### PR TITLE
CI: wire canonical Cassandra 5 datasets (datasets-v1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+  DATASET_TAG: datasets-v1
+  DATASET_ASSET: cassandra5-small.tar.gz
+  DATASET_SHA256: 313763f28a4de71870c80346818dfa1656f4d9db564b4dce2ddd79f4e00a44dd
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Restore dataset cache
+        id: dataset-cache
+        uses: actions/cache@v4
+        with:
+          path: test-data/datasets
+          key: datasets-${{ env.DATASET_TAG }}
+
+      - name: Fetch datasets if cache miss
+        if: steps.dataset-cache.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          mkdir -p test-data/datasets
+          curl -fsSL -o /tmp/${DATASET_ASSET} \
+            https://github.com/pmcfadin/cqlite/releases/download/${DATASET_TAG}/${DATASET_ASSET}
+          echo "${DATASET_SHA256}  /tmp/${DATASET_ASSET}" | sha256sum -c -
+          tar -xzf /tmp/${DATASET_ASSET} -C test-data
+
+      - name: Sanity check dataset
+        run: |
+          test -f test-data/datasets/metadata.yml
+          find test-data/datasets/sstables -name "*-Data.db" | head -n 1
+
+      - name: Run tests
+        run: cargo test --package cqlite-core --all-features
+
+

--- a/test-data/scripts/fetch-datasets.sh
+++ b/test-data/scripts/fetch-datasets.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fetch canonical Cassandra 5 datasets into test-data/datasets
+# Usage: DATASET_TAG=datasets-v1 DATASET_ASSET=cassandra5-small.tar.gz ./test-data/scripts/fetch-datasets.sh
+
+TAG="${DATASET_TAG:-datasets-v1}"
+ASSET="${DATASET_ASSET:-cassandra5-small.tar.gz}"
+SHA256_EXPECTED="${DATASET_SHA256:-313763f28a4de71870c80346818dfa1656f4d9db564b4dce2ddd79f4e00a44dd}"
+
+echo "Fetching dataset ${ASSET} (tag ${TAG})"
+mkdir -p test-data/datasets
+curl -fsSL -o /tmp/${ASSET} "https://github.com/pmcfadin/cqlite/releases/download/${TAG}/${ASSET}"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  echo "${SHA256_EXPECTED}  /tmp/${ASSET}" | sha256sum -c -
+elif command -v shasum >/dev/null 2>&1; then
+  ACTUAL="$(shasum -a 256 /tmp/${ASSET} | awk '{print $1}')"
+  test "${ACTUAL}" = "${SHA256_EXPECTED}" || { echo "SHA256 mismatch"; exit 1; }
+else
+  echo "Warning: no sha256 checker found; skipping verification" >&2
+fi
+
+tar -xzf /tmp/${ASSET} -C test-data
+echo "Dataset extracted to test-data/datasets"
+
+


### PR DESCRIPTION
This PR wires CI to use the canonical Cassandra 5 datasets for tests.\n\n- Fetch/cache release asset: datasets-v1/cassandra5-small.tar.gz (SHA256 in workflow)\n- Sanity check dataset layout under test-data/datasets\n- Add helper: test-data/scripts/fetch-datasets.sh for local parity\n\nOutcome: CI and dev runs use the same real dataset; no synthetic data.