### PR TITLE
Docs/CI: Real dataset CI Gate + PR template reminder

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -34,7 +34,7 @@
 ### Test Environment
 - OS: <!-- e.g., Ubuntu 22.04, macOS 14.0, Windows 11 -->
 - Rust version: <!-- e.g., 1.75.0 -->
-- Test data: <!-- If applicable, describe test SSTable files or schemas used -->
+- Test data: <!-- MUST use canonical real data under test-data/datasets; reference metadata.yml and test-data/schemas/ -->
 
 ### Tests Run
 - [ ] Unit tests (`cargo test`)

--- a/test-data/README.md
+++ b/test-data/README.md
@@ -260,6 +260,13 @@ The system includes a comprehensive GitHub Actions workflow (`.github/workflows/
 4. **Tests integration** with CQLite
 5. **Creates releases** for main branch
 
+### CI Gate: Real datasets only
+
+- Tests must use the canonical Cassandra 5 corpus under `test-data/datasets/`.
+- CI fetches a versioned dataset release asset and caches it to `test-data/datasets`.
+- Local parity: fetch with `test-data/scripts/fetch-datasets.sh` (uses `datasets-v1` by default).
+- Do not commit datasets to git; do not use synthetic or alternate fixture paths.
+
 ### Workflow Triggers
 
 - Push to main/develop branches


### PR DESCRIPTION
Adds a short CI Gate section to test-data/README.md and updates PR template to explicitly require using the canonical real datasets under test-data/datasets with metadata.yml and schemas/.