### PR TITLE
chore(gitignore): ignore performance.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ hive-mind-prompt-*.txt
 # dataset archives
 cassandra5-small-*.tar.gz
 cassandra5-small-*.tar.gz.sha256
+
+# Performance metrics
+performance.json


### PR DESCRIPTION
Adds performance.json to .gitignore to avoid committing local metrics artifacts.