### PR TITLE
feat(tests): Add contract stability tests for M3/M4 protection (Issue #265)

### DIFF
--- a/cqlite-core/Cargo.toml
+++ b/cqlite-core/Cargo.toml
@@ -87,7 +87,7 @@ proptest = { workspace = true }
 tempfile = "3.8"
 rand = "0.8"
 tokio-test = "0.4"
-insta = "1.34"
+insta = { version = "1.34", features = ["json"] }
 # cqlite-validation = { path = "../cqlite-validation" }
 fastrand = "2.0"
 libc = { workspace = true }

--- a/cqlite-core/src/query/result.rs
+++ b/cqlite-core/src/query/result.rs
@@ -4,11 +4,12 @@
 //! It includes result set management, row iteration, and result metadata.
 
 use crate::{RowKey, Value};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt;
 
 /// Query result containing rows and metadata
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QueryResult {
     /// Result rows
     pub rows: Vec<QueryRow>,
@@ -21,7 +22,7 @@ pub struct QueryResult {
 }
 
 /// Individual row in query result
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QueryRow {
     /// Column values mapped by column name
     pub values: HashMap<String, Value>,
@@ -32,7 +33,7 @@ pub struct QueryRow {
 }
 
 /// Metadata for query results
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct QueryMetadata {
     /// Column information
     pub columns: Vec<ColumnInfo>,
@@ -47,7 +48,7 @@ pub struct QueryMetadata {
 }
 
 /// Information about a column in the result set
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ColumnInfo {
     /// Column name
     pub name: String,
@@ -62,7 +63,7 @@ pub struct ColumnInfo {
 }
 
 /// Row metadata
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct RowMetadata {
     /// Row version/timestamp
     pub version: Option<u64>,
@@ -73,7 +74,7 @@ pub struct RowMetadata {
 }
 
 /// Query execution plan information
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PlanInfo {
     /// Plan type used
     pub plan_type: String,
@@ -90,7 +91,7 @@ pub struct PlanInfo {
 }
 
 /// Parallelization information for query execution
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ParallelizationInfo {
     /// Number of threads used
     pub threads_used: usize,
@@ -101,7 +102,7 @@ pub struct ParallelizationInfo {
 }
 
 /// Information about a partition processed in parallel
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PartitionInfo {
     /// Partition ID
     pub id: usize,
@@ -112,7 +113,7 @@ pub struct PartitionInfo {
 }
 
 /// Performance metrics for query execution
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct PerformanceMetrics {
     /// Parse time in microseconds
     pub parse_time_us: u64,

--- a/cqlite-core/tests/contract_stability_tests.rs
+++ b/cqlite-core/tests/contract_stability_tests.rs
@@ -1,0 +1,475 @@
+//! Contract Stability Tests (Issue #265)
+//!
+//! These tests validate the stability of CQLite's public query result API contracts.
+//! Any modification to the structure of these types will cause snapshot test failures,
+//! ensuring breaking changes are caught during development.
+//!
+//! **Why These Tests Matter:**
+//! - M3 (Output Writers) depends on these contract types for JSON/CSV/Parquet output
+//! - M4 (Language Bindings) depends on these contracts for FFI and WASM interfaces
+//! - Breaking changes here silently break ALL downstream consumers
+//!
+//! **Contract Types Protected:**
+//! - `QueryResult` - Contains rows and metadata for query results
+//! - `QueryRow` - Individual row with values HashMap and key
+//! - `QueryMetadata` - Column info, performance metrics, warnings
+//! - `ColumnInfo` - Column name, type, position, nullability
+//! - `Value` enum - All 27 CQL type variants
+//! - `PerformanceMetrics` - Timing and cache statistics
+//!
+//! The tests use insta for JSON snapshot testing. Snapshots are stored in:
+//! `cqlite-core/tests/snapshots/`
+
+use cqlite_core::query::result::{
+    ColumnInfo, PerformanceMetrics, PlanInfo, QueryMetadata, QueryResult, QueryRow, RowMetadata,
+};
+use cqlite_core::types::{DataType, UdtValue};
+use cqlite_core::{RowKey, Value};
+
+// =============================================================================
+// QueryResult Contract Tests
+// =============================================================================
+
+/// Tests that an empty QueryResult serializes to a stable JSON format.
+/// This is the base case for query results.
+#[test]
+fn contract_query_result_empty() {
+    let result = QueryResult::new();
+    // Use sort_maps to ensure deterministic HashMap serialization order
+    insta::with_settings!({sort_maps => true}, {
+        insta::assert_json_snapshot!(result);
+    });
+}
+
+/// Tests QueryResult with actual row data.
+/// Verifies the structure of rows, values, and metadata.
+#[test]
+fn contract_query_result_with_rows() {
+    let mut row = QueryRow::new(RowKey::new(vec![1, 2, 3]));
+    row.set("id".to_string(), Value::Integer(42));
+    row.set("name".to_string(), Value::Text("test".to_string()));
+
+    let mut result = QueryResult::with_rows(vec![row]);
+    result.metadata.columns = vec![
+        ColumnInfo::new("id".to_string(), DataType::Integer, false, 0),
+        ColumnInfo::new("name".to_string(), DataType::Text, true, 1),
+    ];
+
+    // Use sort_maps to ensure deterministic HashMap serialization order
+    insta::with_settings!({sort_maps => true}, {
+        insta::assert_json_snapshot!(result);
+    });
+}
+
+/// Tests QueryResult for DML operations that return affected row count.
+#[test]
+fn contract_query_result_with_affected_rows() {
+    let result = QueryResult::with_affected_rows(5);
+    insta::with_settings!({sort_maps => true}, {
+        insta::assert_json_snapshot!(result);
+    });
+}
+
+// =============================================================================
+// QueryRow Contract Tests
+// =============================================================================
+
+/// Tests a minimal QueryRow with just a key.
+#[test]
+fn contract_query_row_minimal() {
+    let row = QueryRow::new(RowKey::new(vec![0xFF, 0x00]));
+    insta::with_settings!({sort_maps => true}, {
+        insta::assert_json_snapshot!(row);
+    });
+}
+
+/// Tests QueryRow with metadata (version, TTL, tags).
+#[test]
+fn contract_query_row_with_metadata() {
+    let mut row = QueryRow::new(RowKey::new(vec![1]));
+    row.set("col1".to_string(), Value::Integer(1));
+    row.set_metadata(
+        RowMetadata::new()
+            .with_version(12345)
+            .with_ttl(3600)
+            .with_tag("source".to_string(), "import".to_string()),
+    );
+    insta::with_settings!({sort_maps => true}, {
+        insta::assert_json_snapshot!(row);
+    });
+}
+
+// =============================================================================
+// QueryMetadata Contract Tests
+// =============================================================================
+
+/// Tests the default QueryMetadata structure.
+#[test]
+fn contract_query_metadata_default() {
+    let metadata = QueryMetadata::default();
+    insta::assert_json_snapshot!(metadata);
+}
+
+/// Tests QueryMetadata with all fields populated.
+#[test]
+fn contract_query_metadata_full() {
+    let metadata = QueryMetadata {
+        columns: vec![ColumnInfo::new(
+            "id".to_string(),
+            DataType::Integer,
+            false,
+            0,
+        )],
+        total_rows: Some(100),
+        plan_info: Some(PlanInfo {
+            plan_type: "IndexScan".to_string(),
+            estimated_cost: 1.5,
+            actual_cost: 1.2,
+            indexes_used: vec!["idx_id".to_string()],
+            steps: vec!["scan".to_string(), "filter".to_string()],
+            parallelization: None,
+        }),
+        performance: PerformanceMetrics::default(),
+        warnings: vec!["test warning".to_string()],
+    };
+    insta::assert_json_snapshot!(metadata);
+}
+
+// =============================================================================
+// ColumnInfo Contract Tests
+// =============================================================================
+
+/// Tests basic ColumnInfo structure.
+#[test]
+fn contract_column_info_basic() {
+    let col = ColumnInfo::new("user_id".to_string(), DataType::Integer, false, 0);
+    insta::assert_json_snapshot!(col);
+}
+
+/// Tests ColumnInfo with optional table name.
+#[test]
+fn contract_column_info_with_table() {
+    let col = ColumnInfo::new("user_id".to_string(), DataType::Uuid, true, 0)
+        .with_table_name("users".to_string());
+    insta::assert_json_snapshot!(col);
+}
+
+// =============================================================================
+// Value Enum Contract Tests (All 27 Variants)
+//
+// These tests verify that each Value variant serializes to a stable format.
+// M3 Output Writers and M4 Language Bindings depend on this serialization.
+// =============================================================================
+
+#[test]
+fn contract_value_null() {
+    insta::assert_json_snapshot!(Value::Null);
+}
+
+#[test]
+fn contract_value_boolean() {
+    insta::assert_json_snapshot!(Value::Boolean(true));
+}
+
+#[test]
+fn contract_value_integer() {
+    insta::assert_json_snapshot!(Value::Integer(42));
+}
+
+#[test]
+fn contract_value_bigint() {
+    insta::assert_json_snapshot!(Value::BigInt(9223372036854775807i64));
+}
+
+#[test]
+fn contract_value_counter() {
+    insta::assert_json_snapshot!(Value::Counter(1000));
+}
+
+#[test]
+fn contract_value_float() {
+    // Use an arbitrary float value (not a mathematical constant to avoid clippy::approx_constant)
+    insta::assert_json_snapshot!(Value::Float(1.23456));
+}
+
+#[test]
+fn contract_value_text() {
+    insta::assert_json_snapshot!(Value::Text("hello world".to_string()));
+}
+
+#[test]
+fn contract_value_blob() {
+    insta::assert_json_snapshot!(Value::Blob(vec![0xDE, 0xAD, 0xBE, 0xEF]));
+}
+
+#[test]
+fn contract_value_timestamp() {
+    // Fixed timestamp: 2024-01-01 00:00:00 UTC
+    insta::assert_json_snapshot!(Value::Timestamp(1704067200000));
+}
+
+#[test]
+fn contract_value_date() {
+    // Days since Unix epoch for 2024-01-01
+    insta::assert_json_snapshot!(Value::Date(19724));
+}
+
+#[test]
+fn contract_value_time() {
+    // Noon in nanoseconds since midnight
+    insta::assert_json_snapshot!(Value::Time(43200000000000i64));
+}
+
+#[test]
+fn contract_value_uuid() {
+    // A fixed UUID for reproducibility
+    insta::assert_json_snapshot!(Value::Uuid([
+        0x55, 0x0e, 0x84, 0x00, 0xe2, 0x9b, 0x41, 0xd4, 0xa7, 0x16, 0x44, 0x66, 0x55, 0x44, 0x00,
+        0x00
+    ]));
+}
+
+#[test]
+fn contract_value_varint() {
+    insta::assert_json_snapshot!(Value::Varint(vec![0x01, 0x00]));
+}
+
+#[test]
+fn contract_value_decimal() {
+    insta::assert_json_snapshot!(Value::Decimal {
+        scale: 2,
+        unscaled: vec![0x30, 0x39],
+    });
+}
+
+#[test]
+fn contract_value_duration() {
+    insta::assert_json_snapshot!(Value::Duration {
+        months: 1,
+        days: 15,
+        nanos: 3600000000000i64,
+    });
+}
+
+#[test]
+fn contract_value_json() {
+    insta::assert_json_snapshot!(Value::Json(serde_json::json!({
+        "key": "value",
+        "number": 42
+    })));
+}
+
+#[test]
+fn contract_value_tinyint() {
+    insta::assert_json_snapshot!(Value::TinyInt(127));
+}
+
+#[test]
+fn contract_value_smallint() {
+    insta::assert_json_snapshot!(Value::SmallInt(32767));
+}
+
+#[test]
+fn contract_value_float32() {
+    insta::assert_json_snapshot!(Value::Float32(2.5));
+}
+
+#[test]
+fn contract_value_list() {
+    insta::assert_json_snapshot!(Value::List(vec![
+        Value::Integer(1),
+        Value::Integer(2),
+        Value::Integer(3),
+    ]));
+}
+
+#[test]
+fn contract_value_set() {
+    insta::assert_json_snapshot!(Value::Set(vec![
+        Value::Text("a".to_string()),
+        Value::Text("b".to_string()),
+    ]));
+}
+
+#[test]
+fn contract_value_map() {
+    insta::assert_json_snapshot!(Value::Map(vec![
+        (Value::Text("key1".to_string()), Value::Integer(1)),
+        (Value::Text("key2".to_string()), Value::Integer(2)),
+    ]));
+}
+
+#[test]
+fn contract_value_tuple() {
+    insta::assert_json_snapshot!(Value::Tuple(vec![
+        Value::Integer(1),
+        Value::Text("test".to_string()),
+        Value::Boolean(true),
+    ]));
+}
+
+#[test]
+fn contract_value_udt() {
+    let udt = UdtValue::new("Person".to_string(), "test_keyspace".to_string())
+        .with_field("name".to_string(), Some(Value::Text("John".to_string())))
+        .with_field("age".to_string(), Some(Value::Integer(30)));
+    insta::assert_json_snapshot!(Value::Udt(udt));
+}
+
+#[test]
+fn contract_value_frozen() {
+    insta::assert_json_snapshot!(Value::Frozen(Box::new(Value::List(vec![
+        Value::Integer(1),
+        Value::Integer(2),
+    ]))));
+}
+
+#[test]
+fn contract_value_tombstone() {
+    insta::assert_json_snapshot!(Value::row_tombstone(1704067200000));
+}
+
+#[test]
+fn contract_value_inet_ipv4() {
+    insta::assert_json_snapshot!(Value::Inet(vec![192, 168, 1, 1]));
+}
+
+#[test]
+fn contract_value_inet_ipv6() {
+    insta::assert_json_snapshot!(Value::Inet(vec![
+        0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x01,
+    ]));
+}
+
+// =============================================================================
+// Column Order Validation (Issue #129)
+//
+// This test verifies that QueryResult respects column order from metadata,
+// NOT HashMap iteration order (which is non-deterministic).
+// =============================================================================
+
+#[test]
+fn contract_column_order_from_metadata() {
+    let mut row1 = QueryRow::new(RowKey::new(vec![1]));
+    // Insert in non-alphabetical order to verify ordering
+    row1.set("z_col".to_string(), Value::Integer(1));
+    row1.set("a_col".to_string(), Value::Integer(2));
+    row1.set("m_col".to_string(), Value::Integer(3));
+
+    let mut result = QueryResult::with_rows(vec![row1]);
+    // Define explicit column order: a, m, z (custom order)
+    result.metadata.columns = vec![
+        ColumnInfo::new("a_col".to_string(), DataType::Integer, false, 0),
+        ColumnInfo::new("m_col".to_string(), DataType::Integer, false, 1),
+        ColumnInfo::new("z_col".to_string(), DataType::Integer, false, 2),
+    ];
+
+    // Snapshot the serialized form - to_json() respects metadata column order
+    let json = result.to_json();
+    insta::with_settings!({sort_maps => true}, {
+        insta::assert_json_snapshot!(json);
+    });
+}
+
+// =============================================================================
+// PlanInfo Contract Tests
+// =============================================================================
+
+#[test]
+fn contract_plan_info() {
+    let plan = PlanInfo {
+        plan_type: "IndexScan".to_string(),
+        estimated_cost: 1.5,
+        actual_cost: 1.2,
+        indexes_used: vec!["idx_primary".to_string()],
+        steps: vec!["scan".to_string(), "filter".to_string()],
+        parallelization: None,
+    };
+    insta::assert_json_snapshot!(plan);
+}
+
+// =============================================================================
+// ParallelizationInfo and PartitionInfo Contract Tests
+// =============================================================================
+
+#[test]
+fn contract_partition_info() {
+    use cqlite_core::query::result::PartitionInfo;
+    let info = PartitionInfo {
+        id: 0,
+        rows_processed: 5000,
+        processing_time_ms: 250,
+    };
+    insta::assert_json_snapshot!(info);
+}
+
+#[test]
+fn contract_parallelization_info() {
+    use cqlite_core::query::result::{ParallelizationInfo, PartitionInfo};
+    let info = ParallelizationInfo {
+        threads_used: 4,
+        effective: true,
+        partitions: vec![
+            PartitionInfo {
+                id: 0,
+                rows_processed: 1000,
+                processing_time_ms: 50,
+            },
+            PartitionInfo {
+                id: 1,
+                rows_processed: 1200,
+                processing_time_ms: 60,
+            },
+        ],
+    };
+    insta::assert_json_snapshot!(info);
+}
+
+// =============================================================================
+// Performance Metrics Contract Tests
+// =============================================================================
+
+#[test]
+fn contract_performance_metrics_default() {
+    let metrics = PerformanceMetrics::default();
+    insta::assert_json_snapshot!(metrics);
+}
+
+#[test]
+fn contract_performance_metrics_populated() {
+    let mut metrics = PerformanceMetrics::new();
+    metrics.parse_time_us = 100;
+    metrics.planning_time_us = 200;
+    metrics.execution_time_us = 1000;
+    metrics.total_time_us = 1300;
+    metrics.memory_usage_bytes = 1048576;
+    metrics.io_operations = 5;
+    metrics.cache_hits = 8;
+    metrics.cache_misses = 2;
+    insta::assert_json_snapshot!(metrics);
+}
+
+// =============================================================================
+// RowMetadata Contract Tests
+// =============================================================================
+
+#[test]
+fn contract_row_metadata_empty() {
+    let metadata = RowMetadata::new();
+    insta::with_settings!({sort_maps => true}, {
+        insta::assert_json_snapshot!(metadata);
+    });
+}
+
+#[test]
+fn contract_row_metadata_full() {
+    let metadata = RowMetadata::new()
+        .with_version(123456789)
+        .with_ttl(86400)
+        .with_tag("source".to_string(), "migration".to_string())
+        .with_tag("batch".to_string(), "001".to_string());
+    insta::with_settings!({sort_maps => true}, {
+        insta::assert_json_snapshot!(metadata);
+    });
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_column_info_basic.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_column_info_basic.snap
@@ -1,0 +1,12 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 134
+expression: col
+---
+{
+  "name": "user_id",
+  "data_type": "Integer",
+  "nullable": false,
+  "position": 0,
+  "table_name": null
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_column_info_with_table.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_column_info_with_table.snap
@@ -1,0 +1,12 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 142
+expression: col
+---
+{
+  "name": "user_id",
+  "data_type": "Uuid",
+  "nullable": true,
+  "position": 0,
+  "table_name": "users"
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_column_order_from_metadata.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_column_order_from_metadata.snap
@@ -1,0 +1,49 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 370
+expression: json
+---
+{
+  "columns": [
+    {
+      "data_type": "Integer",
+      "name": "a_col",
+      "nullable": false,
+      "position": 0
+    },
+    {
+      "data_type": "Integer",
+      "name": "m_col",
+      "nullable": false,
+      "position": 1
+    },
+    {
+      "data_type": "Integer",
+      "name": "z_col",
+      "nullable": false,
+      "position": 2
+    }
+  ],
+  "performance": {
+    "cache_hit_ratio": 0.0,
+    "cache_hits": 0,
+    "cache_misses": 0,
+    "execution_time_us": 0,
+    "io_operations": 0,
+    "memory_usage_bytes": 0,
+    "parse_time_us": 0,
+    "planning_time_us": 0,
+    "total_time_us": 0
+  },
+  "row_count": 1,
+  "rows": [
+    {
+      "_key": "RowKey([1])",
+      "a_col": 2,
+      "m_col": 3,
+      "z_col": 1
+    }
+  ],
+  "rows_affected": 0,
+  "warnings": []
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_parallelization_info.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_parallelization_info.snap
@@ -1,0 +1,21 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 426
+expression: info
+---
+{
+  "threads_used": 4,
+  "effective": true,
+  "partitions": [
+    {
+      "id": 0,
+      "rows_processed": 1000,
+      "processing_time_ms": 50
+    },
+    {
+      "id": 1,
+      "rows_processed": 1200,
+      "processing_time_ms": 60
+    }
+  ]
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_partition_info.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_partition_info.snap
@@ -1,0 +1,10 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 404
+expression: info
+---
+{
+  "id": 0,
+  "rows_processed": 5000,
+  "processing_time_ms": 250
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_performance_metrics_default.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_performance_metrics_default.snap
@@ -1,0 +1,15 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 367
+expression: metrics
+---
+{
+  "parse_time_us": 0,
+  "planning_time_us": 0,
+  "execution_time_us": 0,
+  "total_time_us": 0,
+  "memory_usage_bytes": 0,
+  "io_operations": 0,
+  "cache_hits": 0,
+  "cache_misses": 0
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_performance_metrics_populated.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_performance_metrics_populated.snap
@@ -1,0 +1,15 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 381
+expression: metrics
+---
+{
+  "parse_time_us": 100,
+  "planning_time_us": 200,
+  "execution_time_us": 1000,
+  "total_time_us": 1300,
+  "memory_usage_bytes": 1048576,
+  "io_operations": 5,
+  "cache_hits": 8,
+  "cache_misses": 2
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_plan_info.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_plan_info.snap
@@ -1,0 +1,18 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 389
+expression: plan
+---
+{
+  "plan_type": "IndexScan",
+  "estimated_cost": 1.5,
+  "actual_cost": 1.2,
+  "indexes_used": [
+    "idx_primary"
+  ],
+  "steps": [
+    "scan",
+    "filter"
+  ],
+  "parallelization": null
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_query_metadata_default.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_query_metadata_default.snap
@@ -1,0 +1,21 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 98
+expression: metadata
+---
+{
+  "columns": [],
+  "total_rows": null,
+  "plan_info": null,
+  "performance": {
+    "parse_time_us": 0,
+    "planning_time_us": 0,
+    "execution_time_us": 0,
+    "total_time_us": 0,
+    "memory_usage_bytes": 0,
+    "io_operations": 0,
+    "cache_hits": 0,
+    "cache_misses": 0
+  },
+  "warnings": []
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_query_metadata_full.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_query_metadata_full.snap
@@ -1,0 +1,43 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 123
+expression: metadata
+---
+{
+  "columns": [
+    {
+      "name": "id",
+      "data_type": "Integer",
+      "nullable": false,
+      "position": 0,
+      "table_name": null
+    }
+  ],
+  "total_rows": 100,
+  "plan_info": {
+    "plan_type": "IndexScan",
+    "estimated_cost": 1.5,
+    "actual_cost": 1.2,
+    "indexes_used": [
+      "idx_id"
+    ],
+    "steps": [
+      "scan",
+      "filter"
+    ],
+    "parallelization": null
+  },
+  "performance": {
+    "parse_time_us": 0,
+    "planning_time_us": 0,
+    "execution_time_us": 0,
+    "total_time_us": 0,
+    "memory_usage_bytes": 0,
+    "io_operations": 0,
+    "cache_hits": 0,
+    "cache_misses": 0
+  },
+  "warnings": [
+    "test warning"
+  ]
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_query_result_empty.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_query_result_empty.snap
@@ -1,0 +1,26 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 38
+expression: result
+---
+{
+  "rows": [],
+  "rows_affected": 0,
+  "execution_time_ms": 0,
+  "metadata": {
+    "columns": [],
+    "total_rows": null,
+    "plan_info": null,
+    "performance": {
+      "parse_time_us": 0,
+      "planning_time_us": 0,
+      "execution_time_us": 0,
+      "total_time_us": 0,
+      "memory_usage_bytes": 0,
+      "io_operations": 0,
+      "cache_hits": 0,
+      "cache_misses": 0
+    },
+    "warnings": []
+  }
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_query_result_with_affected_rows.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_query_result_with_affected_rows.snap
@@ -1,0 +1,26 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 62
+expression: result
+---
+{
+  "rows": [],
+  "rows_affected": 5,
+  "execution_time_ms": 0,
+  "metadata": {
+    "columns": [],
+    "total_rows": null,
+    "plan_info": null,
+    "performance": {
+      "parse_time_us": 0,
+      "planning_time_us": 0,
+      "execution_time_us": 0,
+      "total_time_us": 0,
+      "memory_usage_bytes": 0,
+      "io_operations": 0,
+      "cache_hits": 0,
+      "cache_misses": 0
+    },
+    "warnings": []
+  }
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_query_result_with_rows.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_query_result_with_rows.snap
@@ -1,0 +1,62 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 55
+expression: result
+---
+{
+  "rows": [
+    {
+      "values": {
+        "id": {
+          "Integer": 42
+        },
+        "name": {
+          "Text": "test"
+        }
+      },
+      "key": [
+        1,
+        2,
+        3
+      ],
+      "metadata": {
+        "version": null,
+        "ttl": null,
+        "tags": {}
+      }
+    }
+  ],
+  "rows_affected": 0,
+  "execution_time_ms": 0,
+  "metadata": {
+    "columns": [
+      {
+        "name": "id",
+        "data_type": "Integer",
+        "nullable": false,
+        "position": 0,
+        "table_name": null
+      },
+      {
+        "name": "name",
+        "data_type": "Text",
+        "nullable": true,
+        "position": 1,
+        "table_name": null
+      }
+    ],
+    "total_rows": null,
+    "plan_info": null,
+    "performance": {
+      "parse_time_us": 0,
+      "planning_time_us": 0,
+      "execution_time_us": 0,
+      "total_time_us": 0,
+      "memory_usage_bytes": 0,
+      "io_operations": 0,
+      "cache_hits": 0,
+      "cache_misses": 0
+    },
+    "warnings": []
+  }
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_query_row_minimal.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_query_row_minimal.snap
@@ -1,0 +1,17 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 73
+expression: row
+---
+{
+  "values": {},
+  "key": [
+    255,
+    0
+  ],
+  "metadata": {
+    "version": null,
+    "ttl": null,
+    "tags": {}
+  }
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_query_row_with_metadata.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_query_row_with_metadata.snap
@@ -1,0 +1,22 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 87
+expression: row
+---
+{
+  "values": {
+    "col1": {
+      "Integer": 1
+    }
+  },
+  "key": [
+    1
+  ],
+  "metadata": {
+    "version": 12345,
+    "ttl": 3600,
+    "tags": {
+      "source": "import"
+    }
+  }
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_row_metadata_empty.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_row_metadata_empty.snap
@@ -1,0 +1,10 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 391
+expression: metadata
+---
+{
+  "version": null,
+  "ttl": null,
+  "tags": {}
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_row_metadata_full.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_row_metadata_full.snap
@@ -1,0 +1,13 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 418
+expression: metadata
+---
+{
+  "version": 123456789,
+  "ttl": 86400,
+  "tags": {
+    "batch": "001",
+    "source": "migration"
+  }
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_bigint.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_bigint.snap
@@ -1,0 +1,8 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 169
+expression: "Value::BigInt(9223372036854775807i64)"
+---
+{
+  "BigInt": 9223372036854775807
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_blob.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_blob.snap
@@ -1,0 +1,13 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 189
+expression: "Value::Blob(vec![0xDE, 0xAD, 0xBE, 0xEF])"
+---
+{
+  "Blob": [
+    222,
+    173,
+    190,
+    239
+  ]
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_boolean.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_boolean.snap
@@ -1,0 +1,8 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 159
+expression: "Value::Boolean(true)"
+---
+{
+  "Boolean": true
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_counter.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_counter.snap
@@ -1,0 +1,8 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 174
+expression: "Value::Counter(1000)"
+---
+{
+  "Counter": 1000
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_date.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_date.snap
@@ -1,0 +1,8 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 201
+expression: "Value::Date(19724)"
+---
+{
+  "Date": 19724
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_decimal.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_decimal.snap
@@ -1,0 +1,14 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 226
+expression: "Value::Decimal { scale: 2, unscaled: vec![0x30, 0x39], }"
+---
+{
+  "Decimal": {
+    "scale": 2,
+    "unscaled": [
+      48,
+      57
+    ]
+  }
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_duration.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_duration.snap
@@ -1,0 +1,12 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 234
+expression: "Value::Duration { months: 1, days: 15, nanos: 3600000000000i64, }"
+---
+{
+  "Duration": {
+    "months": 1,
+    "days": 15,
+    "nanos": 3600000000000
+  }
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_float.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_float.snap
@@ -1,0 +1,8 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 192
+expression: "Value::Float(1.23456)"
+---
+{
+  "Float": 1.23456
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_float32.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_float32.snap
@@ -1,0 +1,8 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 261
+expression: "Value::Float32(2.5)"
+---
+{
+  "Float32": 2.5
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_frozen.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_frozen.snap
@@ -1,0 +1,17 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 308
+expression: "Value::Frozen(Box::new(Value::List(vec![Value::Integer(1),\nValue::Integer(2),])))"
+---
+{
+  "Frozen": {
+    "List": [
+      {
+        "Integer": 1
+      },
+      {
+        "Integer": 2
+      }
+    ]
+  }
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_inet_ipv4.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_inet_ipv4.snap
@@ -1,0 +1,13 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 321
+expression: "Value::Inet(vec![192, 168, 1, 1])"
+---
+{
+  "Inet": [
+    192,
+    168,
+    1,
+    1
+  ]
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_inet_ipv6.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_inet_ipv6.snap
@@ -1,0 +1,25 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 326
+expression: "Value::Inet(vec![0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,\n0x00, 0x00, 0x00, 0x00, 0x00, 0x01,])"
+---
+{
+  "Inet": [
+    32,
+    1,
+    13,
+    184,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    1
+  ]
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_integer.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_integer.snap
@@ -1,0 +1,8 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 164
+expression: "Value::Integer(42)"
+---
+{
+  "Integer": 42
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_json.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_json.snap
@@ -1,0 +1,11 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 243
+expression: "Value::Json(serde_json::json!({ \"key\": \"value\", \"number\": 42 }))"
+---
+{
+  "Json": {
+    "key": "value",
+    "number": 42
+  }
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_list.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_list.snap
@@ -1,0 +1,18 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 266
+expression: "Value::List(vec![Value::Integer(1), Value::Integer(2), Value::Integer(3),])"
+---
+{
+  "List": [
+    {
+      "Integer": 1
+    },
+    {
+      "Integer": 2
+    },
+    {
+      "Integer": 3
+    }
+  ]
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_map.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_map.snap
@@ -1,0 +1,25 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 283
+expression: "Value::Map(vec![(Value::Text(\"key1\".to_string()), Value::Integer(1)),\n(Value::Text(\"key2\".to_string()), Value::Integer(2)),])"
+---
+{
+  "Map": [
+    [
+      {
+        "Text": "key1"
+      },
+      {
+        "Integer": 1
+      }
+    ],
+    [
+      {
+        "Text": "key2"
+      },
+      {
+        "Integer": 2
+      }
+    ]
+  ]
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_null.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_null.snap
@@ -1,0 +1,6 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 154
+expression: "Value::Null"
+---
+"Null"

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_set.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_set.snap
@@ -1,0 +1,15 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 275
+expression: "Value::Set(vec![Value::Text(\"a\".to_string()), Value::Text(\"b\".to_string()),])"
+---
+{
+  "Set": [
+    {
+      "Text": "a"
+    },
+    {
+      "Text": "b"
+    }
+  ]
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_smallint.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_smallint.snap
@@ -1,0 +1,8 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 256
+expression: "Value::SmallInt(32767)"
+---
+{
+  "SmallInt": 32767
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_text.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_text.snap
@@ -1,0 +1,8 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 184
+expression: "Value::Text(\"hello world\".to_string())"
+---
+{
+  "Text": "hello world"
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_time.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_time.snap
@@ -1,0 +1,8 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 207
+expression: "Value::Time(43200000000000i64)"
+---
+{
+  "Time": 43200000000000
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_timestamp.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_timestamp.snap
@@ -1,0 +1,8 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 195
+expression: "Value::Timestamp(1704067200000)"
+---
+{
+  "Timestamp": 1704067200000
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_tinyint.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_tinyint.snap
@@ -1,0 +1,8 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 251
+expression: "Value::TinyInt(127)"
+---
+{
+  "TinyInt": 127
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_tombstone.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_tombstone.snap
@@ -1,0 +1,14 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 316
+expression: "Value::row_tombstone(1704067200000)"
+---
+{
+  "Tombstone": {
+    "deletion_time": 1704067200000,
+    "tombstone_type": "RowTombstone",
+    "ttl": null,
+    "range_start": null,
+    "range_end": null
+  }
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_tuple.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_tuple.snap
@@ -1,0 +1,18 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 291
+expression: "Value::Tuple(vec![Value::Integer(1), Value::Text(\"test\".to_string()),\nValue::Boolean(true),])"
+---
+{
+  "Tuple": [
+    {
+      "Integer": 1
+    },
+    {
+      "Text": "test"
+    },
+    {
+      "Boolean": true
+    }
+  ]
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_udt.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_udt.snap
@@ -1,0 +1,25 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 303
+expression: "Value::Udt(udt)"
+---
+{
+  "Udt": {
+    "type_name": "Person",
+    "keyspace": "test_keyspace",
+    "fields": [
+      {
+        "name": "name",
+        "value": {
+          "Text": "John"
+        }
+      },
+      {
+        "name": "age",
+        "value": {
+          "Integer": 30
+        }
+      }
+    ]
+  }
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_uuid.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_uuid.snap
@@ -1,0 +1,25 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 213
+expression: "Value::Uuid([0x55, 0x0e, 0x84, 0x00, 0xe2, 0x9b, 0x41, 0xd4, 0xa7, 0x16, 0x44,\n0x66, 0x55, 0x44, 0x00, 0x00])"
+---
+{
+  "Uuid": [
+    85,
+    14,
+    132,
+    0,
+    226,
+    155,
+    65,
+    212,
+    167,
+    22,
+    68,
+    102,
+    85,
+    68,
+    0,
+    0
+  ]
+}

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_varint.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_varint.snap
@@ -1,0 +1,11 @@
+---
+source: cqlite-core/tests/contract_stability_tests.rs
+assertion_line: 221
+expression: "Value::Varint(vec![0x01, 0x00])"
+---
+{
+  "Varint": [
+    1,
+    0
+  ]
+}


### PR DESCRIPTION
## Summary

- Add snapshot tests using `insta` to prevent breaking changes to public API contracts
- Protect M3 (Output Writers) and M4 (Language Bindings) from silent breaking changes
- Add `Serialize`/`Deserialize` derives to 9 structs in `query/result.rs`

Closes #265

## Changes

### Contract Types Protected

| Type | Tests | Notes |
|------|-------|-------|
| `QueryResult` | 3 | Empty, with rows, affected rows |
| `QueryRow` | 2 | Minimal, with metadata |
| `QueryMetadata` | 2 | Default, full |
| `ColumnInfo` | 2 | Basic, with table |
| `RowMetadata` | 2 | Empty, full |
| `PlanInfo` | 1 | Direct test |
| `ParallelizationInfo` | 1 | Direct test |
| `PartitionInfo` | 1 | Direct test |
| `PerformanceMetrics` | 2 | Default, populated |
| `Value` enum | 28 | All 27 variants + IPv4/IPv6 |
| Column ordering | 1 | Issue #129 validation |

**Total: 45 snapshot tests**

### Files Changed

- `cqlite-core/Cargo.toml` - Add `json` feature to insta
- `cqlite-core/src/query/result.rs` - Add serde derives to 9 structs
- `cqlite-core/tests/contract_stability_tests.rs` - New test file
- `cqlite-core/tests/snapshots/` - 45 golden files

## Test plan

- [x] All 45 contract stability tests pass
- [x] `cargo clippy` passes with `-D warnings`
- [x] `cargo fmt` applied
- [x] Change detection verified (renaming fields causes test failures)
- [ ] CI pipeline passes

```bash
# Run contract tests
cargo test --package cqlite-core --test contract_stability_tests

# Verify snapshots
ls cqlite-core/tests/snapshots/ | wc -l  # Should be 45
```

## Why This Matters

Without these tests, a refactor could change field names or add required fields, silently breaking:
- JSON/CSV/Parquet output formatters (M3)
- FFI and WASM language bindings (M4)
- Any downstream consumers of the query result API