### PR TITLE
fix(sstable): static cell duplication on read (#480)

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/data_access.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access.rs
@@ -1165,4 +1165,111 @@ mod tests {
         let entries = result.unwrap();
         eprintln!("get_all_entries() returned {} entries", entries.len());
     }
+
+    /// Regression test for Issue #480: static cell duplication on read.
+    ///
+    /// static_columns_table has 100 partitions, each containing one static_block
+    /// and one clustering row. CQLite should return exactly 100 result rows — one
+    /// per partition — not 200 (which would occur if static rows were emitted as
+    /// separate result entries).
+    ///
+    /// Two bugs were fixed:
+    /// 1. Snappy varint collision: bytes `0xC0 0x51` at the start of the Snappy
+    ///    stream were misidentified as the V5_0StaticColumns magic number, causing
+    ///    the file pointer to advance past part of the compressed data before
+    ///    decompression, resulting in "corrupt input" errors.
+    /// 2. Static row duplication: static rows were pushed into `results` just like
+    ///    clustering rows. They should be accumulated per-partition and merged into
+    ///    each subsequent clustering row instead.
+    #[tokio::test]
+    async fn test_static_columns_table_row_count_issue480() {
+        use std::path::PathBuf;
+        use std::sync::Arc;
+
+        let datasets_root = match std::env::var("CQLITE_DATASETS_ROOT") {
+            Ok(root) => PathBuf::from(root),
+            Err(_) => {
+                eprintln!("CQLITE_DATASETS_ROOT not set, skipping Issue #480 regression test");
+                return;
+            }
+        };
+
+        let table_base = datasets_root.join("sstables/test_basic");
+        if !table_base.exists() {
+            eprintln!("test_basic dir not found, skipping Issue #480 regression test");
+            return;
+        }
+
+        // Locate the static_columns_table directory
+        let table_dir = std::fs::read_dir(&table_base).ok().and_then(|entries| {
+            entries
+                .filter_map(|e| e.ok())
+                .find(|e| {
+                    e.file_name()
+                        .to_str()
+                        .map(|n| n.starts_with("static_columns_table"))
+                        .unwrap_or(false)
+                })
+                .map(|e| e.path())
+        });
+
+        let Some(table_path) = table_dir else {
+            eprintln!("static_columns_table not found, skipping Issue #480 regression test");
+            return;
+        };
+
+        // Find the Data.db file (must be real binary, not macOS ._resource_fork)
+        let data_file = std::fs::read_dir(&table_path).ok().and_then(|entries| {
+            entries
+                .filter_map(|e| e.ok())
+                .find(|e| {
+                    let name = e.file_name();
+                    let s = name.to_str().unwrap_or("");
+                    s.ends_with("-Data.db") && !s.starts_with("._")
+                })
+                .map(|e| e.path())
+        });
+
+        let Some(data_path) = data_file else {
+            eprintln!("Data.db not found in static_columns_table dir, skipping");
+            return;
+        };
+
+        let config = crate::Config::default();
+        let platform = Arc::new(
+            crate::Platform::new(&config)
+                .await
+                .expect("Failed to create platform"),
+        );
+
+        let reader = SSTableReader::open(&data_path, &config, platform)
+            .await
+            .expect("Failed to open static_columns_table SSTable");
+
+        let table_id = crate::types::TableId::new("test_basic.static_columns_table".to_string());
+        let result = reader.scan(&table_id, None, None, None, None).await;
+        assert!(
+            result.is_ok(),
+            "Scan of static_columns_table should succeed: {:?}",
+            result.err()
+        );
+
+        let entries = result.unwrap();
+        eprintln!(
+            "Issue #480 regression: static_columns_table scan returned {} rows",
+            entries.len()
+        );
+
+        // Expected: 100 rows (one per partition, static data merged into clustering row)
+        // Before fix: 0 rows (Snappy decompression failure)
+        // After fixing only decompression: 200 rows (static rows emitted separately)
+        // After full fix: 100 rows
+        assert_eq!(
+            entries.len(),
+            100,
+            "static_columns_table should return 100 rows (one per partition), \
+             got {}. Regression for Issue #480: static cell duplication on read.",
+            entries.len()
+        );
+    }
 }

--- a/cqlite-core/src/storage/sstable/reader/header.rs
+++ b/cqlite-core/src/storage/sstable/reader/header.rs
@@ -155,23 +155,26 @@ pub(crate) async fn parse_header_with_version_detection(
             // first byte of compressed chunk data has this bit set, it can coincidentally
             // match certain magic number patterns.
             //
-            // Known collision: V5_0WideRows (0xF07C5C00)
-            // - First byte 0xF0 has high bit set (Snappy continuation marker)
-            // - 0xF0 0x7C decodes as Snappy varint for ~15984 bytes (compressed chunk length)
-            // - This occurs when NB format Data.db starts with a ~16KB compressed chunk
+            // Known collisions (Issue #480):
+            //   V5_0WideRows (0xF07C5C00):
+            //   - First byte 0xF0 has high bit set (Snappy continuation marker)
+            //   - 0xF0 0x7C decodes as Snappy varint for ~15984 bytes (compressed chunk length)
+            //   - This occurs when NB format Data.db starts with a ~16KB compressed chunk
             //
-            // We only check V5_0WideRows specifically because:
-            // 1. It's the only collision observed in practice (chat_messages table)
-            // 2. Checking ALL magic numbers with high bit would risk breaking real
-            //    embedded headers (V5_0ComplexTypes, V5_0FormatF, etc. have high bit too)
-            // 3. NB format files are typically headerless, so false positives are rare
+            //   V5_0StaticColumns (0xC0515C00):
+            //   - First byte 0xC0 has high bit set (Snappy continuation marker)
+            //   - 0xC0 0x51 decodes as Snappy varint for 10432 bytes (uncompressed size)
+            //   - This occurs when the static_columns_table Data.db is Snappy-compressed
+            //     and the uncompressed size encodes to bytes matching this magic number
             //
-            // Detection strategy: If bytes match V5_0WideRows AND first byte has high bit,
-            // treat as Snappy collision and parse as headerless.
+            // Detection strategy: if detected version is one of the known headerless
+            // collisions AND the first byte has the Snappy high-bit set, treat as
+            // headerless Snappy-compressed NB format.
             let detected_version = CassandraVersion::from_magic_number(first_4_bytes);
-            let is_snappy_varint_collision = detected_version
-                == Some(CassandraVersion::V5_0WideRows)
-                && (header_buffer[0] & 0x80) != 0;
+            let is_snappy_varint_collision = matches!(
+                detected_version,
+                Some(CassandraVersion::V5_0WideRows) | Some(CassandraVersion::V5_0StaticColumns)
+            ) && (header_buffer[0] & 0x80) != 0;
 
             if detected_version.is_some() && !is_snappy_varint_collision {
                 log::debug!(
@@ -183,7 +186,7 @@ pub(crate) async fn parse_header_with_version_detection(
             } else if is_snappy_varint_collision {
                 // Snappy varint collision detected - treat as headerless
                 log::debug!(
-                    "NB format file '{}' has Snappy varint collision with V5_0WideRows magic (0x{:08x}) - treating as headerless",
+                    "NB format file '{}' has Snappy varint collision with magic 0x{:08x} - treating as headerless",
                     path.display(),
                     first_4_bytes
                 );

--- a/cqlite-core/src/storage/sstable/reader/header.rs
+++ b/cqlite-core/src/storage/sstable/reader/header.rs
@@ -788,13 +788,60 @@ mod tests {
         );
     }
 
-    /// Test other magic numbers with high bit are NOT flagged (only V5_0WideRows check).
+    /// Test Snappy varint collision detection for V5_0StaticColumns magic number.
     ///
-    /// We specifically only check V5_0WideRows to avoid breaking real embedded headers.
+    /// Issue #480: Snappy-compressed Data.db starting with 0xC0 0x51 0x5C 0x00 collides
+    /// with V5_0StaticColumns magic (0xC0515C00) because 0xC0 has the high bit set
+    /// (Snappy continuation marker) and 0xC0 0x51 decodes as the Snappy varint for
+    /// uncompressed size 10432.
+    #[test]
+    fn test_snappy_varint_collision_v5_0_static_columns() {
+        // Bytes that look like V5_0StaticColumns magic but are actually Snappy varint
+        let header_buffer = [0xC0, 0x51, 0x5C, 0x00, 0x10, 0x30, 0xB5, 0x68];
+
+        // First byte 0xC0 has high bit set (Snappy continuation marker)
+        assert_eq!(
+            header_buffer[0] & 0x80,
+            0x80,
+            "First byte should have high bit set"
+        );
+
+        let first_4_bytes = u32::from_be_bytes([
+            header_buffer[0],
+            header_buffer[1],
+            header_buffer[2],
+            header_buffer[3],
+        ]);
+        assert_eq!(
+            first_4_bytes, 0xC051_5C00,
+            "Should match V5_0StaticColumns magic"
+        );
+
+        let detected = CassandraVersion::from_magic_number(first_4_bytes);
+        assert_eq!(
+            detected,
+            Some(CassandraVersion::V5_0StaticColumns),
+            "Should detect V5_0StaticColumns"
+        );
+
+        // Mirrors production: V5_0WideRows OR V5_0StaticColumns is collision when
+        // first byte has the Snappy high bit set.
+        let is_collision = matches!(
+            detected,
+            Some(CassandraVersion::V5_0WideRows) | Some(CassandraVersion::V5_0StaticColumns)
+        ) && (header_buffer[0] & 0x80) != 0;
+        assert!(
+            is_collision,
+            "Should detect Snappy collision for V5_0StaticColumns"
+        );
+    }
+
+    /// Test other magic numbers with high bit are NOT flagged (only V5_0WideRows /
+    /// V5_0StaticColumns are known Snappy-collision allowlist entries).
     #[test]
     fn test_other_high_bit_magic_not_collision() {
         // V5_0ComplexTypes magic: 0x82365C00 - first byte 0x82 HAS high bit
-        // But we don't flag it because we only check V5_0WideRows specifically
+        // But we don't flag it because it's not in the collision allowlist.
         let header_buffer = [0x82, 0x36, 0x5C, 0x00, 0x00, 0x00, 0x00, 0x00];
 
         // First byte DOES have high bit set
@@ -818,9 +865,13 @@ mod tests {
             "Should detect V5_0ComplexTypes"
         );
 
-        // Should NOT be flagged as collision (only V5_0WideRows is checked)
-        let is_collision =
-            detected == Some(CassandraVersion::V5_0WideRows) && (header_buffer[0] & 0x80) != 0;
+        // Mirrors production: only V5_0WideRows / V5_0StaticColumns are in the
+        // Snappy-collision allowlist; V5_0ComplexTypes is a real format and must
+        // not be flagged even though its first byte has the high bit set.
+        let is_collision = matches!(
+            detected,
+            Some(CassandraVersion::V5_0WideRows) | Some(CassandraVersion::V5_0StaticColumns)
+        ) && (header_buffer[0] & 0x80) != 0;
         assert!(
             !is_collision,
             "V5_0ComplexTypes should not be flagged as collision"

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
@@ -1343,7 +1343,9 @@ impl V5CompressedLegacyParser {
     /// V5CompressedLegacy format stores cells WITHOUT column names in schema column order.
     /// Schema is REQUIRED to determine which column each value belongs to.
     ///
-    /// Returns: (cells, row_header, new_offset)
+    /// Returns: `ParsedRow` = `(cells, row_header, new_offset, is_static)` where
+    /// `is_static` is `true` when the row's `EXTENDED_IS_STATIC` flag was set.
+    /// Static rows must be merged into clustering rows by the caller, not emitted directly.
     fn parse_row_data_with_offset(
         &self,
         data: &[u8],

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
@@ -65,6 +65,10 @@ const MAX_UDT_FIELD_COUNT: usize = 1000;
 /// This covers recursive UDTs and deeply nested collections (e.g., list<list<list<...>>>).
 const MAX_TYPE_NESTING_DEPTH: usize = 10;
 
+/// Return type for `parse_row_data_with_offset`:
+/// (cells, row_header, next_offset, is_static)
+type ParsedRow = (HashMap<String, Value>, Option<RowHeader>, usize, bool);
+
 /// Row header data extracted from V5CompressedLegacy row
 #[derive(Debug, Clone)]
 struct RowHeader {
@@ -358,6 +362,15 @@ impl V5CompressedLegacyParser {
                     // - END_OF_PARTITION marker (flags == 0x01, Issue #229 fix)
                     // - Next partition header (detected via peek_is_partition_header)
                     // - Parse error (invalid row data)
+
+                    // Issue #480 FIX: Static cell handling
+                    //
+                    // Cassandra static rows are stored once per partition (before clustering rows).
+                    // They should NOT be emitted as separate result entries — instead their column
+                    // values must be merged into each clustering row that follows in the partition.
+                    //
+                    // We accumulate static cells here and inject them into every clustering row.
+                    let mut static_cells: HashMap<String, Value> = HashMap::new();
                     let mut row_count = 0;
                     loop {
                         // Issue #229 FIX: Check for END_OF_PARTITION marker BEFORE attempting row parse
@@ -402,17 +415,18 @@ impl V5CompressedLegacyParser {
                         }
 
                         match self.parse_row_data_with_offset(data, offset, Some(schema), reader) {
-                            Ok((cells, row_header_opt, next_offset)) => {
+                            Ok((mut cells, row_header_opt, next_offset, is_static)) => {
                                 // Update offset to point to the next row or partition
                                 offset = next_offset;
                                 row_count += 1;
 
                                 log::debug!(
-                                    "V5CompressedLegacy: Partition {} Row {} - Parsed {} cells, now at offset {}",
+                                    "V5CompressedLegacy: Partition {} Row {} - Parsed {} cells, now at offset {} (is_static={})",
                                     partition_index,
                                     row_count,
                                     cells.len(),
-                                    offset
+                                    offset,
+                                    is_static
                                 );
 
                                 if let Some(ref header) = row_header_opt {
@@ -424,32 +438,59 @@ impl V5CompressedLegacyParser {
                                 }
 
                                 debug!(
-                                    "V5CompressedLegacy: Parsed {} cells from row {}",
+                                    "V5CompressedLegacy: Parsed {} cells from row {} (is_static={})",
                                     cells.len(),
-                                    row_count
+                                    row_count,
+                                    is_static
                                 );
 
-                                // Convert cells HashMap to Value::Map (required by SelectExecutor)
-                                let row_value = if cells.is_empty() {
-                                    warn!(
-                                        "V5CompressedLegacy: No cells extracted for {}.{} partition {} row {} (partition key: {} bytes)",
-                                        self.keyspace,
-                                        self.table_name,
+                                // Issue #480 FIX: Static row handling
+                                //
+                                // Static rows are stored once per partition and contain values for
+                                // STATIC columns (e.g. `static_data TEXT STATIC`). They must NOT
+                                // be emitted as standalone result rows. Instead, store the static
+                                // column values and merge them into each subsequent clustering row.
+                                if is_static {
+                                    log::debug!(
+                                        "V5CompressedLegacy: Partition {} - Storing {} static cells for merging into clustering rows",
                                         partition_index,
-                                        row_count,
-                                        partition_key.0.len()
+                                        cells.len()
                                     );
-                                    Value::Null
+                                    static_cells = cells;
+                                    // Do NOT push to results — static rows are not result rows
+                                    // Continue to next row/marker in partition
                                 } else {
-                                    // Convert HashMap<String, Value> to Vec<(Value, Value)> for Value::Map
-                                    let map_entries: Vec<(Value, Value)> = cells
-                                        .into_iter()
-                                        .map(|(name, value)| (Value::Text(name), value))
-                                        .collect();
-                                    Value::Map(map_entries)
-                                };
+                                    // Merge static cells into this clustering row (Issue #480)
+                                    for (k, v) in &static_cells {
+                                        cells.entry(k.clone()).or_insert_with(|| v.clone());
+                                    }
 
-                                results.push((table_id.clone(), partition_key.clone(), row_value));
+                                    // Convert cells HashMap to Value::Map (required by SelectExecutor)
+                                    let row_value = if cells.is_empty() {
+                                        warn!(
+                                            "V5CompressedLegacy: No cells extracted for {}.{} partition {} row {} (partition key: {} bytes)",
+                                            self.keyspace,
+                                            self.table_name,
+                                            partition_index,
+                                            row_count,
+                                            partition_key.0.len()
+                                        );
+                                        Value::Null
+                                    } else {
+                                        // Convert HashMap<String, Value> to Vec<(Value, Value)> for Value::Map
+                                        let map_entries: Vec<(Value, Value)> = cells
+                                            .into_iter()
+                                            .map(|(name, value)| (Value::Text(name), value))
+                                            .collect();
+                                        Value::Map(map_entries)
+                                    };
+
+                                    results.push((
+                                        table_id.clone(),
+                                        partition_key.clone(),
+                                        row_value,
+                                    ));
+                                }
 
                                 // Check if we're at the end of the partition
                                 if offset >= data.len() {
@@ -1309,7 +1350,7 @@ impl V5CompressedLegacyParser {
         mut offset: usize,
         schema: Option<&TableSchema>,
         reader: &super::super::types::SSTableReader,
-    ) -> Result<(HashMap<String, Value>, Option<RowHeader>, usize)> {
+    ) -> Result<ParsedRow> {
         let mut cells = HashMap::new();
 
         let schema = schema.ok_or_else(|| {
@@ -1469,7 +1510,7 @@ impl V5CompressedLegacyParser {
             );
 
             // Return empty cells for tombstoned row
-            return Ok((cells, Some(row_header), next_offset));
+            return Ok((cells, Some(row_header), next_offset, is_static));
         }
 
         // Advance offset past row metadata to start of cell data
@@ -1698,11 +1739,11 @@ impl V5CompressedLegacyParser {
         let next_offset = after_cells_offset;
 
         debug!(
-            "V5CompressedLegacy: Row complete - row_size={} bytes, next offset = {} (counted from {})",
-            row_size, next_offset, row_size_counted_from
+            "V5CompressedLegacy: Row complete - row_size={} bytes, next offset = {} (counted from {}, is_static={})",
+            row_size, next_offset, row_size_counted_from, is_static
         );
 
-        Ok((cells, Some(row_header), next_offset))
+        Ok((cells, Some(row_header), next_offset, is_static))
     }
 
     /// Parse a single cell value WITHOUT column name (schema-order format)


### PR DESCRIPTION
## Summary

- **Bug #1 (Snappy varint collision)**: The first 4 bytes of `static_columns_table`'s Snappy-compressed `Data.db` file (`0xC0 0x51 0x5C 0x00`) were misidentified as the `V5_0StaticColumns` magic number. This caused the file pointer to skip past part of the compressed stream before decompression, producing "expected valid offset" errors. Fixed by adding `V5_0StaticColumns` to the Snappy varint collision detection logic in `parse_header_with_version_detection()`, alongside the existing `V5_0WideRows` check (Issue #219).

- **Bug #2 (static row duplication)**: Static rows (flagged via `EXTENDED_IS_STATIC` in the row's extended flags byte) were emitted as standalone result entries, the same as clustering rows. With 100 partitions × (1 static row + 1 clustering row), CQLite returned 200 results instead of 100. Fixed by accumulating static cell values per-partition in `parse_block()` and merging them into each subsequent clustering row, suppressing standalone static row emission.

**Before fix**: 0 rows (decompression failure); would have been 200 (duplication bug alone)  
**After fix**: 100 rows (one per partition, `static_data` merged into each clustering row)

## Test plan

- [x] New Rust regression test `test_static_columns_table_row_count_issue480` asserts exactly 100 rows
- [x] `cargo test --package cqlite-core --lib` — 954 tests pass, 0 failures
- [x] `RUSTFLAGS="-D warnings" cargo clippy --package cqlite-core --lib --all-features` — clean
- [x] `cargo fmt --package cqlite-core` — applied
- [x] CLI query `SELECT * FROM test_basic.static_columns_table` returns 100 rows with `static_data` correctly populated in each row
- [x] Other tables (`simple_table` 1000 rows, `composite_key_table` 100 rows) not regressed

Closes #480