### PR TITLE
fix(smoke-test): skip macOS AppleDouble sidecars in Data.db glob

### DIFF
--- a/test-data/scripts/smoke-test-all-tables.sh
+++ b/test-data/scripts/smoke-test-all-tables.sh
@@ -217,8 +217,10 @@ test_table() {
     local qualified_name="${keyspace}.${table_name}"
 
     # Find Data.db file
+    # Exclude macOS AppleDouble resource fork sidecar files (._*-Data.db) which are
+    # 4 KB metadata files that look like SSTables to a naive *-Data.db glob (Issue #481).
     local data_db_file
-    data_db_file=$(find "${full_table_path}" -name "*-Data.db" -type f | head -1)
+    data_db_file=$(find "${full_table_path}" -name "*-Data.db" -type f -not -name "._*" | head -1)
 
     if [[ -z "${data_db_file}" ]]; then
         log_error "${qualified_name} ... FAIL (no Data.db file found)"


### PR DESCRIPTION
## Summary

Discovered while validating Issue #481's fix on main: `test-data/scripts/smoke-test-all-tables.sh` reported 0/33 passing on macOS because the bash `find ... -name \"*-Data.db\"` glob matched macOS AppleDouble resource fork files (`._nb-1-big-Data.db`, ~4KB Mac metadata sidecars) before the real `nb-1-big-Data.db`. With `head -1`, the script fed the sidecar to the CLI, producing exit code 5 on every table.

Linux CI is unaffected (no AppleDouble files exist on Linux runners), which is why the smoke test was green in CI even though it's broken on macOS dev machines.

## Fix

Add `-not -name \"._*\"` to the find expression with an explanatory comment. Mirrors the runtime fix in `cqlite-core/src/storage/sstable/mod.rs::is_apple_double_sidecar` introduced by PR #491.

## Test plan

- [x] `bash test-data/scripts/smoke-test-all-tables.sh` on macOS — 33/33 PASS after fix (was 0/33).
- [ ] CI: run smoke-test on Linux (still green) and macOS (now also green).

Follow-up to #481 (#491).