### PR TITLE
perf(sstable): /simplify follow-ups for is_udt_type and UDT debug log

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
@@ -2710,10 +2710,16 @@ impl V5CompressedLegacyParser {
     /// Check if a type string represents a UDT (User-Defined Type).
     /// Detects Cassandra's internal format: org.apache.cassandra.db.marshal.UserType(...)
     fn is_udt_type(type_str: &str) -> bool {
-        // Case-insensitive check for UDT type marker
-        type_str
-            .to_lowercase()
-            .contains("org.apache.cassandra.db.marshal.usertype")
+        // ASCII case-insensitive substring match without allocating a lowercased
+        // copy. The marshal name is pure ASCII so byte-window comparison is safe.
+        const TARGET: &[u8] = b"org.apache.cassandra.db.marshal.usertype";
+        let bytes = type_str.as_bytes();
+        if bytes.len() < TARGET.len() {
+            return false;
+        }
+        bytes
+            .windows(TARGET.len())
+            .any(|w| w.iter().zip(TARGET).all(|(a, b)| a.eq_ignore_ascii_case(b)))
     }
 
     /// Parse a UDT type string to extract the UDT definition.
@@ -5370,18 +5376,20 @@ impl V5CompressedLegacyParser {
                 // The data slice passed to parse_raw_type_value is already the raw UDT bytes.
                 let udt_data = &data[offset..];
 
-                // Debug: Log the UDT data hex dump
-                log::debug!(
-                    "Frozen UDT '{}': data_len={}, hex dump: {}",
-                    column_name,
-                    udt_data.len(),
-                    udt_data
+                if log::log_enabled!(log::Level::Debug) {
+                    let hex: String = udt_data
                         .iter()
                         .take(64)
                         .map(|b| format!("{:02x}", b))
                         .collect::<Vec<_>>()
-                        .join(" ")
-                );
+                        .join(" ");
+                    log::debug!(
+                        "Frozen UDT '{}': data_len={}, hex dump: {}",
+                        column_name,
+                        udt_data.len(),
+                        hex
+                    );
+                }
 
                 // TODO(Issue #220): Full UDT parsing requires SSTableReader for nested types.
                 // parse_raw_type_value is called in frozen collection contexts where we don't


### PR DESCRIPTION
## Summary

Two efficiency follow-ups discovered by \`/simplify\` review of the PR #491 (Issue #481) merged work.

1. **\`is_udt_type\` allocation on hot path** — \`cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs:2712\`

   The function called \`type_str.to_lowercase()\` on every cell-value parse with a non-primitive type, heap-allocating a copy of the type string just to do a substring match. The new UDT-registry-delegation arm added in PR #491 (\`parse_value_from_raw_bytes::other\`) put this on the read hot path. Switched to an ASCII byte-window case-insensitive scan: same semantics, no allocation.

2. **UDT hex-dump format!() runs even when debug log disabled** — same file, around line 5373

   \`parse_raw_type_value\`'s UDT branch built a 64-byte hex string via \`map(format!) → Vec<String> → join()\` and passed it to \`log::debug!\`. The \`log\` macro short-circuits when the level is disabled, but argument evaluation still happens — the \`Vec<String>\` is allocated and joined regardless. Wrap in \`log::log_enabled!(log::Level::Debug)\` so the formatting only runs when a debug logger is attached.

## Skipped findings (false positives or out-of-scope)

- **\`is_apple_double_sidecar\` vs \`testing::should_ignore_file\`**: technically duplicates a one-line predicate, but pulling \`testing/\` into production storage code crosses an architectural boundary. The duplication cost is one line; the boundary cost is higher. Keeping both.
- **\`ParsedRow\` tuple alias → named struct**: agent flagged the tuple-positional fragility, but the type alias is module-private with three call sites that destructure it inline. Promotion adds churn for marginal safety.
- **UDT field-loop duplication in \`parse_raw_type_value\` two arms** (~120 lines): pre-existing pattern, not introduced this session, larger refactor.
- **\`static_cells = cells\` replace vs extend**: edge case for partitions with multiple static rows. Cassandra rarely produces these and the test corpus has none.
- **O(N×S) static-cell clones**: bounded by typical static column count (<10) and clustering rows per partition. Defer pending profiles.
- **\`path_bytes.to_vec()\` allocation**: pre-existing.

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`RUSTFLAGS="-D warnings" cargo clippy --package cqlite-core --all-features --lib\` — clean
- [x] \`cargo test --package cqlite-core --lib reader::parsing::v5_compressed_legacy\` — 38/38 pass
- [ ] CI matrix on PR