### PR TITLE
docs(v0.9): Phase 6.1 — M5 write support documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,65 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v0.9.0] — M5 Write Support
 
 ### Added
+
+- **WriteEngine** in `cqlite-core/src/storage/write_engine/`: WAL-backed memtable,
+  STCS compaction, and flush to portable Cassandra 5.0 SSTables. Public methods:
+  `write(mutation)`, `write_async(mutation)`, `flush()`, `maintenance_step(budget)`,
+  `maintenance_stats()`, and `export_sstable(path)`.
+- **Mutation API** (parser-independent): `Mutation { table, partition_key,
+  clustering_key, operations, timestamp_micros, ttl_seconds }` with
+  `CellOperation::Write | WriteWithTtl | Delete | DeleteRow`.
+- **CQL text write path**: `db.execute("INSERT/UPDATE/DELETE …")` as a convenience
+  layer on top of the mutation API (PR #487).
+- **Type coverage** for write roundtrips: Inet, Varint, Duration, Tuple, and
+  Frozen all roundtrip through write→flush→read (Issue #477, #478).
+- **Counter guard**: `WriteEngine::write()` and `write_async()` return
+  `Error::InvalidOperation` immediately when a mutation targets a counter column,
+  preventing silent data corruption (Issue #479, PR #489).
+- **Python bindings write support** (PR #488): `db.execute(INSERT/UPDATE/DELETE)`,
+  `db.flush_run()`, `db.maintenance_step(budget_ms)`, and `db.write_stats` property.
+  Open database with `writable=True, write_dir=path` to enable writes.
+- **Node.js bindings write support** (PR #494): `await db.execute(INSERT/UPDATE/DELETE)`,
+  `await db.flushRun()`, `await db.maintenanceStep({ budgetMs })`, and
+  `db.writeStats` getter. Open with `{ writable: true, writeDir: path }`.
+- **CLI write flags**: `--writable`, `--write-dir`, `--mutation`, `--mutations-file`,
+  `--flush`. Subcommands: `maintenance --budget-ms`, `write-stats`, `export-sstable`.
+- **E2E readback gate** (`test-data/scripts/e2e-cassandra-readback.sh`, PR #508):
+  exercises 5 tables (basic-primitives, collections, udt, static-columns, ttl)
+  through write → flush → Docker copy → `nodetool refresh` → `cqlsh` verify.
 - Write→flush→read roundtrip tests for `Inet`, `Varint`, and `Duration` types
-  (Issue #477)
+  (Issue #477).
 - Write→flush→read roundtrip tests for `Tuple<int, text, uuid>` and
-  `Frozen<udt>` types (Issue #478)
-- `WriteEngine::write()` and `WriteEngine::write_async()` now return
-  `Error::InvalidOperation` immediately when a mutation contains a
-  `Value::Counter` cell, preventing silent data corruption — counter columns
-  require server-side distributed increment semantics (Issue #479)
+  `Frozen<udt>` types (Issue #478).
+
+### Changed
+
+- M5 milestone closed; v0.9.0 marks the first release with full write support.
+- CHANGELOG promoted from `[Unreleased]` to `[v0.9.0]`.
+
+### Fixed
+
+- Static columns could be duplicated in query results; fixed in PR #490
+  (Issue #480, `static_columns_table` xfail removed).
+- `typed_collections_table` V5CompressedLegacy cell extraction returned 1 row
+  instead of 50; reader fallback added in PR #506 (Issue #481).
+- Static-row write path emitted incorrect flags; fixed in PR #509.
+
+### Known Issues
+
+- **Counter writes**: Counter columns cannot be written via CQLite. The `write()`
+  call returns `Error::InvalidOperation` with a descriptive message. Cassandra
+  requires distributed CAS semantics for counter increments.
+- **BTI writer**: The SSTable writer emits BIG format index files. BTI (trie)
+  format indexes are read-only for now.
+- **Python concurrent-query race** (Issue #311): Concurrent queries on the same
+  database handle may see a race in schema metadata access. Run one warm-up query
+  before spawning parallel threads.
+- **Open reader follow-ups**: set-element tombstone decoding (#493), schema-aware
+  tuple decoding (#501), frozen<udt> field decoding (#502).
 
 ## [0.4.0] - 2026-01-27 (M4 Complete)
 
@@ -104,7 +152,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - No external cluster dependencies required
 - Real Cassandra SSTable test data validation
 
-[Unreleased]: https://github.com/pmcfadin/cqlite/compare/v0.4.0...HEAD
+[v0.9.0]: https://github.com/pmcfadin/cqlite/compare/v0.4.0...v0.9.0
 [0.4.0]: https://github.com/pmcfadin/cqlite/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/pmcfadin/cqlite/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/pmcfadin/cqlite/compare/v0.1.0...v0.2.0

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Rust](https://img.shields.io/badge/rust-1.85+-red.svg)](https://www.rust-lang.org)
 [![Cassandra](https://img.shields.io/badge/cassandra-5.0+-green.svg)](https://cassandra.apache.org)
 
-> **Status**: M4 Complete - Core reading, CLI, Output Writers, Python and Node.js Bindings are production-ready
+> **Status**: M5 Complete (v0.9.0) - Core reading, CLI, Output Writers, Python and Node.js Bindings, and Write Support are production-ready
 
 CQLite provides SQLite-like local access to Apache Cassandra SSTables, enabling developers to read Cassandra 5.0+ data files without cluster dependencies. Built in Rust for performance and safety.
 
@@ -67,6 +67,77 @@ for (const row of result.rows) {
 await db.close();
 ```
 
+## Write Support
+
+CQLite v0.9.0 (M5) ships write support across all interfaces: Rust core, Python,
+Node.js, and CLI. Written data flushes to portable Cassandra 5.0 SSTables that
+Cassandra can read directly via `nodetool refresh`.
+
+The schema file below is included in the repository at
+`test-data/schemas/write-test.cql`.
+
+### Python
+
+```python
+import cqlite
+
+# Open in writable mode — write_dir stores the WAL and flushed SSTables
+with cqlite.open(
+    'test-data/datasets/sstables',
+    schema='test-data/schemas/write-test.cql',
+    writable=True,
+    write_dir='/tmp/my-writes',
+) as db:
+    db.execute(
+        "INSERT INTO test_basic.simple_table (id, name, age) "
+        "VALUES (11111111-1111-1111-1111-111111111111, 'Alice', 30)"
+    )
+    path = db.flush_run()
+    print(f'Flushed SSTable: {path}')
+```
+
+### Node.js
+
+```javascript
+const { Database } = require('@cqlite/node');
+
+const db = await Database.open('test-data/datasets/sstables', {
+  schema: 'test-data/schemas/write-test.cql',
+  writable: true,
+  writeDir: '/tmp/my-writes',
+});
+await db.execute(
+  "INSERT INTO test_basic.simple_table (id, name, age) " +
+  "VALUES (22222222-2222-2222-2222-222222222222, 'Bob', 25)"
+);
+const path = await db.flushRun();
+console.log('Flushed SSTable:', path);
+await db.close();
+```
+
+### CLI
+
+```bash
+# Build with write support
+cargo build --package cqlite-cli --features write-support
+
+# Write via CQL INSERT
+cargo run --package cqlite-cli --features write-support -- \
+  --writable --write-dir /tmp/my-writes \
+  --schema test-data/schemas/write-test.cql \
+  --execute "INSERT INTO test_basic.simple_table (id, name, age) \
+             VALUES (33333333-3333-3333-3333-333333333333, 'Carol', 28)"
+
+# Flush memtable to SSTable
+cargo run --package cqlite-cli --features write-support -- \
+  --writable --write-dir /tmp/my-writes \
+  --schema test-data/schemas/write-test.cql \
+  --flush
+```
+
+See [docs/write-support.md](docs/write-support.md) for the full write guide,
+including the Cassandra export workflow and known limitations.
+
 ## Feature Flags
 
 CQLite uses Cargo feature flags to control optional functionality:
@@ -116,10 +187,16 @@ cargo build --no-default-features
 - [x] pip/npm installable packages (5 platform builds each)
 - [x] Type stubs for IDE support (Python mypy, TypeScript)
 
-### 📋 Roadmap (M5+)
-- [ ] Write support (SSTable creation)
-- [ ] WASM support for browser deployment
-- [ ] Advanced query capabilities
+### ✅ M5 Complete — v0.9.0 (May 2026)
+- [x] Write support: WAL + memtable + flush to Cassandra SSTables
+- [x] STCS compaction via `maintenance_step()`
+- [x] Write API in Python, Node.js, and CLI
+- [x] Full type coverage: Inet, Varint, Duration, Tuple, Frozen
+- [x] E2E readback gate: write → flush → Cassandra `nodetool refresh` → verify
+
+### 📋 Roadmap
+- [ ] M6: WASM bindings for browser deployment
+- [ ] M7: Performance validation + v1.0 release
 
 ## Architecture Highlights
 
@@ -187,6 +264,15 @@ env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test --package cqlite-cor
 - Thread-safe database handles
 - 500+ tests with 98%+ pass rate across both bindings
 
+### ✅ M5 Complete — v0.9.0 (May 2026)
+- Write support: WAL-backed memtable + flush to portable Cassandra 5.0 SSTables
+- STCS compaction (`maintenance_step()`)
+- Write API exposed in Python (`flush_run`, `maintenance_step`, `write_stats`),
+  Node.js (`flushRun`, `maintenanceStep`, `writeStats`), and CLI (`--writable`,
+  `--write-dir`, `--flush`, `maintenance`, `write-stats`, `export-sstable`)
+- Type roundtrips verified for all major types including Inet, Varint, Duration, Tuple, Frozen
+- E2E validation against live Cassandra 5.0 (write → flush → `nodetool refresh` → `cqlsh`)
+
 See [docs/development/PRD.md](docs/development/PRD.md) for milestone details.
 
 ## Technical Details
@@ -229,4 +315,4 @@ Special thanks to the Apache Cassandra community and the many contributors who m
 
 ---
 
-**Note**: M1 through M4 milestones are complete. Core SSTable reading, CLI, output writers, Python bindings, and Node.js bindings are production-ready. Next: M5 (Write Support).
+**Note**: M1 through M5 milestones are complete (v0.9.0). Core SSTable reading, CLI, output writers, Python bindings, Node.js bindings, and write support are production-ready. Next: M6 (WASM bindings) and M7 (performance validation + v1.0).

--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -225,6 +225,68 @@ CQL types are automatically converted to JavaScript types:
 \* **Note:** With `execute()`, `varint` returns `"0x{hex}"` and `decimal` returns `"decimal:{scale}:0x{hex}"`.
 Use `executeNative()` for human-readable formats.
 
+## Write Operations
+
+CQLite v0.9.0 adds write support to the Node.js bindings. Open the database with
+`writable: true` and a `writeDir` to enable write operations.
+
+```javascript
+const { Database } = require('@cqlite/node');
+
+const db = await Database.open('path/to/sstables', {
+  schema: 'schema.cql',
+  writable: true,
+  writeDir: '/tmp/my-writes',
+});
+
+// Write rows via CQL INSERT, UPDATE, or DELETE
+await db.execute(
+  "INSERT INTO test_basic.simple_table (id, name, age) " +
+  "VALUES (22222222-2222-2222-2222-222222222222, 'Bob', 25)"
+);
+await db.execute(
+  "UPDATE test_basic.simple_table SET age = 26 " +
+  "WHERE id = 22222222-2222-2222-2222-222222222222"
+);
+
+// Flush the in-memory write buffer (memtable) to an SSTable on disk.
+// Returns the path to the flushed Data.db file, or "" if memtable was empty.
+const path = await db.flushRun();
+console.log('Flushed to:', path);
+
+// Run background compaction within a time budget
+const report = await db.maintenanceStep({ budgetMs: 100 });
+console.log(`Merged ${report.rowsMerged} rows in ${report.timeSpentMs}ms`);
+if (report.pendingCompaction) {
+  console.log('More compaction work available');
+}
+
+// Inspect write statistics (synchronous getter)
+const stats = db.writeStats;
+console.log('Memtable size:', stats.memtableSizeBytes, 'bytes');
+console.log('Total flushed:', stats.totalWrittenBytes, 'bytes');
+
+await db.close();
+```
+
+### Write API
+
+| Method / Property | Description |
+|-------------------|-------------|
+| `db.execute(cql)` | Execute a CQL INSERT, UPDATE, or DELETE statement |
+| `db.flushRun()` | Flush memtable to SSTable; returns the Data.db path or `""` if memtable was empty |
+| `db.maintenanceStep(options?)` | Run STCS compaction for up to `options.budgetMs` ms (default: 100); returns `MaintenanceReport` |
+| `db.writeStats` | Synchronous getter: `memtableSizeBytes`, `memtableRowCount`, `totalWrittenBytes`, `l0SstableCount` |
+
+### Known Limitations
+
+- Counter columns cannot be written — `execute()` throws `CqliteError` for
+  counter mutations.
+- BTI-format index files are not produced; the writer emits BIG format.
+
+See [docs/write-support-limitations.md](../../docs/write-support-limitations.md)
+for the full limitations reference.
+
 ## Examples
 
 See the [examples/](examples/) directory for complete working examples:
@@ -239,6 +301,7 @@ See the [examples/](examples/) directory for complete working examples:
 
 - [TypeScript Definitions](lib/index.d.ts) - Complete API type hints
 - [Main Project README](../../README.md) - CQLite project overview
+- [Write Support Guide](../../docs/write-support.md) - Detailed write documentation
 - [Issue Tracker](https://github.com/pmcfadin/cqlite/issues) - Report bugs or request features
 
 ## License

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -177,11 +177,72 @@ CQL types are automatically converted to Python native types:
 | `frozen<T>` | Unwrapped inner type |
 | UDT | `dict` with `_type` and `_keyspace` keys |
 
+## Write Operations
+
+CQLite v0.9.0 adds write support to the Python bindings. Open the database with
+`writable=True` and a `write_dir` to enable write operations.
+
+```python
+import cqlite
+
+with cqlite.open(
+    'path/to/sstables',
+    schema='schema.cql',
+    writable=True,
+    write_dir='/tmp/my-writes',
+) as db:
+    # Write rows via CQL INSERT, UPDATE, or DELETE
+    db.execute(
+        "INSERT INTO test_basic.simple_table (id, name, age) "
+        "VALUES (11111111-1111-1111-1111-111111111111, 'Alice', 30)"
+    )
+    db.execute(
+        "UPDATE test_basic.simple_table SET age = 31 "
+        "WHERE id = 11111111-1111-1111-1111-111111111111"
+    )
+
+    # Flush the in-memory write buffer (memtable) to an SSTable on disk.
+    # Returns the path to the flushed Data.db file.
+    path = db.flush_run()
+    print(f'Flushed to: {path}')
+
+    # Run background compaction within a time budget
+    report = db.maintenance_step(budget_ms=100)
+    print(f'Merged {report.rows_merged} rows in {report.time_spent_ms:.1f} ms')
+    if report.pending_compaction:
+        print('More compaction work available')
+
+    # Inspect write statistics
+    stats = db.write_stats
+    print(f'Memtable size: {stats.memtable_size_bytes} bytes')
+    print(f'Total flushed: {stats.total_written_bytes} bytes')
+```
+
+### Write API
+
+| Method / Property | Description |
+|-------------------|-------------|
+| `db.execute(cql)` | Execute a CQL INSERT, UPDATE, or DELETE statement |
+| `db.flush_run()` | Flush memtable to SSTable; returns the Data.db path or `""` if memtable was empty |
+| `db.maintenance_step(budget_ms)` | Run STCS compaction for up to `budget_ms` milliseconds; returns `MaintenanceReport` |
+| `db.write_stats` | `WriteStats` property: `memtable_size_bytes`, `memtable_row_count`, `total_written_bytes`, `l0_sstable_count` |
+
+### Known Limitations
+
+- Counter columns cannot be written — `execute()` raises `CqliteError` for
+  counter mutations.
+- Concurrent queries on the same handle may need a warm-up query first (Issue
+  #311).
+
+See [docs/write-support-limitations.md](../../docs/write-support-limitations.md)
+for the full limitations reference.
+
 ## Resources
 
 - [Acceptance Testing Notebook](notebooks/acceptance-testing.ipynb) - Interactive examples and validation
 - [Type Stubs](python/cqlite/__init__.pyi) - Complete API type hints for IDE support
 - [Main Project README](../../README.md) - CQLite project overview and documentation
+- [Write Support Guide](../../docs/write-support.md) - Detailed write documentation
 - [Issue Tracker](https://github.com/pmcfadin/cqlite/issues) - Report bugs or request features
 
 ## License

--- a/docs/development/PRD.md
+++ b/docs/development/PRD.md
@@ -49,11 +49,13 @@ tests/              # shared fixtures (Cassandra 5 SSTables)
 | **M2** | **CLI (REPL + one‑shot)**  | Human can query & verify data from disk; basic `SELECT … WHERE …`                         |
 | **M3** | **Output Writers**         | JSON, CSV, Parquet export work end‑to‑end via CLI                                         |
 | **M4** | **Python & Node.js Bindings** | `pip install cqlite-py`, `npm i @cqlite/node`; CI wheels & native modules                 |
-| **M5** | **Write Support**          | Generate valid Cassandra 5 SSTables; write API in core and bindings                       |
-| **M6** | **WASM Bindings**          | `npm i @cqlite/wasm`; IndexedDB support; browser compatibility                            |
-| **M7** | **Perf & Size Validation** | Benchmarks > native bulk tools; WASM < 2 MB; publish v1.0 release                         |
+| **M5** | **Write Support** ✅ **(v0.9.0)** | Generate valid Cassandra 5 SSTables; write API in core and bindings                       |
+| **M6** | **WASM Bindings** *(deferred)*   | `npm i @cqlite/wasm`; IndexedDB support; browser compatibility                            |
+| **M7** | **Perf & Size Validation** *(deferred)* | Benchmarks > native bulk tools; WASM < 2 MB; publish v1.0 release                |
 
 > **Revision Note (Jan 2026)**: M1 coverage revised to tiered targets per Issue #204. M4 now Python & Node.js only (sync Python first). Write Support restored as M5. WASM moved to M6. v1.0 release moved to M7.
+
+> **Revision Note (May 2026)**: M5 complete, v0.9.0 cut. WAL + memtable + STCS compaction + write APIs in Python, Node.js, and CLI ship in this release. M6 (WASM) and M7 (perf + v1.0) are the remaining milestones. See CHANGELOG.md for the full M5 change list.
 
 ### 4.1 · M5 Write Support Architecture
 
@@ -152,6 +154,21 @@ cqlsh -e "SELECT * FROM keyspace.table"
 - `sstableloader` compatibility is a useful secondary workflow, but passing `sstableloader` alone does not satisfy M5.
 
 > **Revision Note (March 2026)**: M5 write support treats flushed SSTables as the primary portable artifact. The milestone acceptance path is now explicitly direct Cassandra readability after copy plus native refresh/import; loader workflows remain secondary convenience tooling. See Issues #392, #393, #396, #397.
+
+---
+
+## 4.2 · Known Issues (post-v0.9.0)
+
+The following are tracked follow-ups, not release blockers. All are open GitHub issues.
+
+| Issue | Description | Workaround |
+|-------|-------------|------------|
+| #311 | Python concurrent-query race in schema metadata access | Run one warm-up query before spawning parallel threads on the same handle |
+| #493 | Set-element tombstone decoding | Read-only; tombstones are silently ignored in query results |
+| #501 | Schema-aware tuple decoding | Tuples return as raw byte arrays in some edge cases |
+| #502 | frozen<udt> field decoding | Frozen UDT values may be returned as raw bytes in some edge cases |
+
+See [docs/write-support-limitations.md](../write-support-limitations.md) for the full limitations reference.
 
 ---
 

--- a/docs/write-support-limitations.md
+++ b/docs/write-support-limitations.md
@@ -1,0 +1,95 @@
+# Write Support Limitations (v0.9.0)
+
+This document lists the known constraints and open issues for CQLite write support
+as of v0.9.0. Issues not listed here are expected to work correctly.
+
+---
+
+## Counter columns are not writable
+
+**Behaviour**: `WriteEngine::write()` and `write_async()` return
+`Error::InvalidOperation` immediately when a mutation contains a `Value::Counter`
+cell. No data is written to the WAL or memtable.
+
+**Reason**: Cassandra counter increments require distributed CAS semantics.
+CQLite runs outside the cluster and cannot safely implement the read-before-write
+protocol that Cassandra uses to increment counter values atomically.
+
+**Workaround**: Write counter data directly via a live Cassandra cluster using
+`cqlsh` or a Cassandra driver.
+
+---
+
+## BTI index writer not implemented
+
+**Behaviour**: The SSTable writer always emits BIG-format index files
+(`nb-{gen}-big-Index.db`, `nb-{gen}-big-Summary.db`). Trie-based BTI format
+index files are not produced.
+
+**Impact**: Flushed SSTables are readable by Cassandra 5.0 because Cassandra
+supports both formats. The read path in CQLite supports BTI indexes for reading;
+only the writer is BIG-format only.
+
+**Tracking**: No separate issue; this is a planned enhancement for M6/M7.
+
+---
+
+## Python concurrent-query race (Issue #311)
+
+**Behaviour**: Concurrent queries on the same `Database` handle from multiple
+threads may encounter a race in schema metadata access. The symptom is an
+occasional `QueryError` on one of the concurrent queries.
+
+**Workaround**: Run one warm-up query (any SELECT) before spawning parallel
+threads. This materialises the schema cache and makes subsequent concurrent
+accesses safe.
+
+```python
+with cqlite.open(data_dir, schema=schema) as db:
+    # Warm up schema cache before threading
+    list(db.execute('SELECT * FROM ks.tbl LIMIT 1'))
+
+    import concurrent.futures
+    with concurrent.futures.ThreadPoolExecutor() as pool:
+        futures = [pool.submit(db.execute, 'SELECT * FROM ks.tbl') for _ in range(4)]
+        results = [f.result() for f in futures]
+```
+
+**Tracking**: Issue #311.
+
+---
+
+## Set-element tombstone decoding (Issue #493)
+
+**Behaviour**: Tombstones for individual set elements within a cell are silently
+ignored during query. The parent set is returned but tombstoned elements may
+appear as still-present.
+
+**Impact**: Read-only. Writes are unaffected. Data that was deleted at the
+element level (via `DELETE my_set[element] FROM ...`) may appear in query results.
+
+**Tracking**: Issue #493. Planned for v0.9.1.
+
+---
+
+## Schema-aware tuple decoding (Issue #501)
+
+**Behaviour**: Tuple fields are decoded without schema context in some edge cases,
+returning raw byte arrays instead of typed values.
+
+**Impact**: Read-only. Tuples created by the CQLite writer decode correctly.
+Tuples in pre-existing SSTables written by Cassandra may be affected.
+
+**Tracking**: Issue #501.
+
+---
+
+## frozen<udt> field decoding (Issue #502)
+
+**Behaviour**: Fields within frozen UDT values may be returned as raw byte arrays
+in some edge cases rather than as typed `dict` values.
+
+**Impact**: Read-only. Frozen UDTs created by the CQLite writer decode correctly.
+Pre-existing frozen UDTs from Cassandra may be affected.
+
+**Tracking**: Issue #502.

--- a/docs/write-support.md
+++ b/docs/write-support.md
@@ -1,0 +1,271 @@
+# Write Support (M5)
+
+CQLite v0.9.0 ships write support across the Rust core, Python bindings, Node.js
+bindings, and CLI. Written data lands in portable Cassandra 5.0 BIG-format SSTables
+that Cassandra can read directly via `nodetool refresh`.
+
+For a concise list of current limitations see
+[docs/write-support-limitations.md](write-support-limitations.md).
+
+---
+
+## Architecture
+
+```
+User call (CQL text or Mutation struct)
+        |
+        v
+   WriteEngine
+  /     |      \
+WAL  Memtable  (auto-flush trigger)
+               |
+               v
+         SSTableWriter  ──>  nb-{gen}-big-*.{ext}  (BIG format)
+               |
+               v
+       STCS Compaction (maintenance_step)
+```
+
+1. Every write is appended to the WAL for durability.
+2. The WAL entry is inserted into the memtable.
+3. When the memtable exceeds the flush threshold (default 64 MB) or when you call
+   `flush()` / `flush_run()` / `--flush`, the memtable is serialised to a new
+   SSTable generation.
+4. `maintenance_step()` runs Size-Tiered Compaction (STCS) within a time budget,
+   merging small SSTables into larger ones and dropping overwritten cells.
+
+---
+
+## Rust API
+
+```rust
+use cqlite_core::storage::write_engine::{
+    CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::Value;
+
+// 1. Build configuration
+let config = WriteEngineConfig::new(
+    PathBuf::from("data"),          // SSTable output directory
+    PathBuf::from("data/wal"),      // WAL directory
+    schema,                         // TableSchema loaded from .cql file
+);
+
+// 2. Open engine (replays WAL on startup)
+let mut engine = WriteEngine::new(config)?;
+
+// 3a. Write via the mutation API (no parser dependency)
+let mutation = Mutation::new(
+    TableId::new("my_keyspace", "my_table"),
+    PartitionKey::single("id", Value::Integer(1)),
+    None,   // clustering key
+    vec![CellOperation::Write {
+        column: "name".into(),
+        value: Value::Text("Alice".into()),
+    }],
+    chrono::Utc::now().timestamp_micros(),
+    None,   // TTL
+);
+engine.write(mutation)?;
+
+// 3b. Write via CQL (convenience; requires CQL parser feature)
+engine.execute("INSERT INTO my_keyspace.my_table (id, name) VALUES (2, 'Bob')")?;
+
+// 4. Flush to SSTable
+let info = engine.flush().await?;
+println!("Flushed to {:?}", info.map(|i| i.data_path));
+
+// 5. Background compaction
+let budget = std::time::Duration::from_millis(100);
+let report = engine.maintenance_step(budget)?;
+if report.pending_compaction {
+    println!("More compaction work available");
+}
+```
+
+---
+
+## Python Quickstart
+
+```python
+import cqlite
+
+# Open in writable mode
+with cqlite.open(
+    'test-data/datasets/sstables',
+    schema='test-data/schemas/write-test.cql',
+    writable=True,
+    write_dir='/tmp/my-writes',
+) as db:
+    # Write via CQL
+    db.execute(
+        "INSERT INTO test_basic.simple_table (id, name, age) "
+        "VALUES (11111111-1111-1111-1111-111111111111, 'Alice', 30)"
+    )
+
+    # Flush memtable to SSTable
+    path = db.flush_run()
+    print(f'Flushed to: {path}')
+
+    # Optional: run background compaction
+    report = db.maintenance_step(budget_ms=100)
+    print(f'Merged {report.rows_merged} rows in {report.time_spent_ms:.1f} ms')
+
+    # Write statistics
+    stats = db.write_stats
+    print(f'Total flushed: {stats.total_written_bytes} bytes')
+```
+
+See the full Python API in [bindings/python/README.md](../bindings/python/README.md).
+
+---
+
+## Node.js Quickstart
+
+```javascript
+const { Database } = require('@cqlite/node');
+
+const db = await Database.open('test-data/datasets/sstables', {
+  schema: 'test-data/schemas/write-test.cql',
+  writable: true,
+  writeDir: '/tmp/my-writes',
+});
+
+// Write via CQL
+await db.execute(
+  "INSERT INTO test_basic.simple_table (id, name, age) " +
+  "VALUES (22222222-2222-2222-2222-222222222222, 'Bob', 25)"
+);
+
+// Flush to SSTable
+const path = await db.flushRun();
+console.log('Flushed to:', path);
+
+// Optional: background compaction
+const report = await db.maintenanceStep({ budgetMs: 100 });
+console.log(`Merged ${report.rowsMerged} rows in ${report.timeSpentMs}ms`);
+
+// Write statistics
+const stats = db.writeStats;
+console.log('Total bytes flushed:', stats.totalWrittenBytes);
+
+await db.close();
+```
+
+See the full Node.js API in [bindings/node/README.md](../bindings/node/README.md).
+
+---
+
+## CLI Quickstart
+
+```bash
+# Build with write support enabled
+cargo build --package cqlite-cli --features write-support
+
+# Write via CQL INSERT
+cargo run --package cqlite-cli --features write-support -- \
+  --writable --write-dir /tmp/my-writes \
+  --schema test-data/schemas/write-test.cql \
+  --execute "INSERT INTO test_basic.simple_table (id, name, age) \
+             VALUES (33333333-3333-3333-3333-333333333333, 'Carol', 28)"
+
+# Flush memtable to SSTable
+cargo run --package cqlite-cli --features write-support -- \
+  --writable --write-dir /tmp/my-writes \
+  --schema test-data/schemas/write-test.cql \
+  --flush
+
+# Run compaction (100 ms budget)
+cargo run --package cqlite-cli --features write-support -- \
+  maintenance --budget-ms 100 \
+  --writable --write-dir /tmp/my-writes \
+  --schema test-data/schemas/write-test.cql
+
+# Print write statistics
+cargo run --package cqlite-cli --features write-support -- \
+  write-stats \
+  --writable --write-dir /tmp/my-writes \
+  --schema test-data/schemas/write-test.cql
+```
+
+### JSON mutation format (CLI --mutation flag)
+
+You can bypass the CQL parser and write mutations directly in JSON. This is the
+lowest-overhead path and has no parser dependency:
+
+```bash
+cargo run --package cqlite-cli --features write-support -- \
+  --writable --write-dir /tmp/my-writes \
+  --schema test-data/schemas/write-test.cql \
+  --mutation '{
+    "table":{"keyspace":"test_basic","table":"simple_table"},
+    "partition_key":{"columns":[["id",{"Uuid":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]}]]},
+    "clustering_key":null,
+    "operations":[{"Write":{"column":"name","value":{"Text":"Alice"}}}],
+    "timestamp_micros":1704067200000000,
+    "ttl_seconds":null,
+    "partition_tombstone":null,
+    "range_tombstones":[]
+  }'
+```
+
+For bulk imports, put one JSON object per line in a `.jsonl` file and pass it with
+`--mutations-file path/to/mutations.jsonl`.
+
+---
+
+## Cassandra Export Workflow
+
+After flush, CQLite produces files named `nb-{gen}-big-*.{ext}` directly inside
+`write_dir/data/{keyspace}/{table}/`. These are standard Cassandra BIG-format
+SSTable components. Copy them into the Cassandra data directory and refresh:
+
+```bash
+# 1. Flush to portable SSTables
+cargo run --package cqlite-cli --features write-support -- \
+  --writable --write-dir /tmp/my-writes \
+  --schema schema.cql --flush
+
+# 2. Copy into Cassandra table directory
+# (Replace the UUID with the actual table directory name from Cassandra)
+cp /tmp/my-writes/data/my_ks/my_tbl/nb-*-big-* \
+   /var/lib/cassandra/data/my_ks/my_tbl-<uuid>/
+
+# 3. Tell Cassandra to discover the new SSTables
+nodetool refresh my_ks my_tbl
+
+# 4. Verify
+cqlsh -e "SELECT COUNT(*) FROM my_ks.my_tbl"
+```
+
+The `export-sstable` subcommand packages the current write directory SSTables into
+a separate export path:
+
+```bash
+cargo run --package cqlite-cli --features write-support -- \
+  export-sstable /tmp/export --keyspace my_ks --table my_tbl \
+  --writable --write-dir /tmp/my-writes \
+  --schema schema.cql
+```
+
+---
+
+## Type Support
+
+All CQL types roundtrip through write→flush→read:
+
+| Category | Types |
+|----------|-------|
+| Primitive | `boolean`, `tinyint`, `smallint`, `int`, `bigint`, `float`, `double` |
+| Text | `text`, `varchar`, `ascii` |
+| Binary | `blob` |
+| Temporal | `timestamp`, `date`, `time`, `duration` |
+| Identity | `uuid`, `timeuuid` |
+| Network | `inet` |
+| Numeric | `varint`, `decimal` |
+| Collections | `list<T>`, `set<T>`, `map<K,V>` |
+| Structured | `tuple<...>`, `frozen<T>`, UDT |
+
+Counter columns are **not writable** — the write engine returns
+`Error::InvalidOperation` when a counter cell is submitted. See
+[docs/write-support-limitations.md](write-support-limitations.md) for details.


### PR DESCRIPTION
## Summary

- CHANGELOG.md: promotes `[Unreleased]` to `[v0.9.0]` with a full M5 entry grouping PRs #487–#509 under Added / Changed / Fixed / Known Issues
- README.md: updates status line to M5 complete, adds a "Write Support" quickstart section (Python, Node.js, CLI), and refreshes the roadmap table
- `docs/write-support.md` (new): single reference document covering architecture, WAL→memtable→SSTable flow, Rust API, Python/Node.js/CLI quickstarts, the JSON mutation format, and the Cassandra export workflow
- `docs/write-support-limitations.md` (new): concise limitations reference for counter writes, BTI writer gaps, Python concurrency race (#311), and reader follow-ups (#493, #501, #502)
- `docs/development/PRD.md`: marks M5 complete, notes v0.9 cut, adds a Known Issues table, and marks M6/M7 as deferred
- `bindings/python/README.md`: adds a "Write Operations" section with a working quickstart and API table
- `bindings/node/README.md`: adds a "Write Operations" section with a working quickstart and API table

Closes #483
Closes #393

## Test plan

- [x] CLI write example ran end-to-end (`--execute INSERT + --flush`, confirmed `nb-1-big-Data.db` created)
- [x] Python write example ran end-to-end (`db.execute INSERT + db.flush_run()`, confirmed file exists)
- [x] Node.js write example ran end-to-end (`db.execute INSERT + db.flushRun()`, confirmed file exists)
- [x] Smoke test skipped — binary Data.db files not present in this worktree (pre-existing condition; CI runs against fetched datasets)
- [x] No Rust source files changed (docs only); no clippy/fmt run needed