### PR TITLE
chore(release): cut v0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [package]
 name = "cqlite"
-version = "0.3.0"
+version = "0.9.0"
 edition = "2021"
 
 [dependencies]
@@ -29,7 +29,7 @@ uuid = { version = "1.6", features = ["v4"] }
 insta = "1.34"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.9.0"
 edition = "2021"
 authors = ["CQLite Team"]
 license = "MIT OR Apache-2.0"

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cqlite/node",
-  "version": "0.3.1-rc5",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cqlite/node",
-      "version": "0.3.1-rc5",
+      "version": "0.9.0",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^3.5.1",

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cqlite/node",
-  "version": "0.3.1-rc5",
+  "version": "0.9.0",
   "description": "Node.js bindings for CQLite - read Apache Cassandra 5.0 SSTables without cluster dependencies",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "cqlite-py"
-version = "0.3.0rc4"
+version = "0.9.0"
 description = "Python bindings for CQLite - read Cassandra 5.0 SSTables locally without a cluster"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/cqlite-core/src/storage/sstable/chunked_data_reader.rs
+++ b/cqlite-core/src/storage/sstable/chunked_data_reader.rs
@@ -110,51 +110,61 @@ impl<R: Read + Seek> ChunkedDataReader<R> {
                 ))
             })?;
 
-        let size = self
+        let total_chunk_size = self
             .compression_info
             .compressed_chunk_size(chunk_index, self.file_size)
             .ok_or_else(|| {
                 Error::InvalidFormat(format!(
-                    "Invalid chunk size for chunk index {}",
-                    chunk_index
+                    "Invalid chunk size for chunk index {chunk_index}"
                 ))
             })?;
 
-        // Seek to chunk start and read compressed data
+        // Cassandra chunks are laid out as [compressed_data][4-byte trailing CRC32].
+        // The chunk size from CompressionInfo includes the trailer, so subtract 4
+        // before reading the compressed payload.
+        if total_chunk_size < 4 {
+            return Err(Error::InvalidFormat(format!(
+                "Chunk {chunk_index} size too small: {total_chunk_size} bytes (minimum 4 for CRC)"
+            )));
+        }
+        let compressed_len = (total_chunk_size - 4) as usize;
+
+        // Seek to chunk start and read compressed data (excluding trailing CRC32).
         self.reader.seek(SeekFrom::Start(offset)).map_err(|e| {
             Error::storage(format!(
-                "Failed to seek to chunk {} at offset {}: {}",
-                chunk_index, offset, e
+                "Failed to seek to chunk {chunk_index} at offset {offset}: {e}"
             ))
         })?;
 
-        let mut compressed = vec![0u8; size as usize];
+        let mut compressed = vec![0u8; compressed_len];
         self.reader.read_exact(&mut compressed).map_err(|e| {
             Error::storage(format!(
-                "Failed to read chunk {} ({} bytes at offset {}): {}",
-                chunk_index, size, offset, e
+                "Failed to read chunk {chunk_index} ({compressed_len} bytes at offset {offset}): {e}"
             ))
         })?;
 
-        // Validate CRC if available (modern Cassandra 5.0+ format)
-        if !self.compression_info.chunk_crcs.is_empty() {
-            self.compression_info
-                .validate_chunk_crc(chunk_index, &compressed)
-                .map_err(|e| {
-                    Error::InvalidFormat(format!(
-                        "CRC validation failed for chunk {}: {}",
-                        chunk_index, e
-                    ))
-                })?;
+        // Read the trailing 4-byte CRC32 (big-endian) and validate against the
+        // compressed payload. This matches Cassandra's NB chunk format.
+        let mut crc_bytes = [0u8; 4];
+        self.reader.read_exact(&mut crc_bytes).map_err(|e| {
+            Error::storage(format!(
+                "Failed to read trailing CRC32 for chunk {chunk_index} at offset {}: {e}",
+                offset + compressed_len as u64
+            ))
+        })?;
+        let expected_crc = u32::from_be_bytes(crc_bytes);
+        let computed_crc = crc32fast::hash(&compressed);
+        if computed_crc != expected_crc {
+            return Err(Error::InvalidFormat(format!(
+                "CRC32 mismatch for chunk {chunk_index} at offset 0x{offset:x}: expected=0x{expected_crc:08x}, computed=0x{computed_crc:08x}, compressed_len={compressed_len}"
+            )));
         }
 
         // Decompress chunk
         let decompressed = self.compression.decompress(&compressed).map_err(|e| {
             Error::storage(format!(
-                "Failed to decompress chunk {} ({} compressed bytes): {}",
-                chunk_index,
-                compressed.len(),
-                e
+                "Failed to decompress chunk {chunk_index} ({} compressed bytes): {e}",
+                compressed.len()
             ))
         })?;
 

--- a/cqlite-core/src/storage/sstable/chunked_data_reader.rs
+++ b/cqlite-core/src/storage/sstable/chunked_data_reader.rs
@@ -114,9 +114,7 @@ impl<R: Read + Seek> ChunkedDataReader<R> {
             .compression_info
             .compressed_chunk_size(chunk_index, self.file_size)
             .ok_or_else(|| {
-                Error::InvalidFormat(format!(
-                    "Invalid chunk size for chunk index {chunk_index}"
-                ))
+                Error::InvalidFormat(format!("Invalid chunk size for chunk index {chunk_index}"))
             })?;
 
         // Cassandra chunks are laid out as [compressed_data][4-byte trailing CRC32].

--- a/test-data/scripts/fetch-datasets.sh
+++ b/test-data/scripts/fetch-datasets.sh
@@ -22,5 +22,11 @@ else
 fi
 
 tar -xzf /tmp/${ASSET} -C .
+
+# Remove macOS AppleDouble shadow files (`._*`). The archive may contain them
+# when produced on macOS, and they break test helpers that scan for files by
+# suffix (e.g., `*-Data.db` matches both the real file and `._..-Data.db`).
+find test-data/datasets -name '._*' -delete 2>/dev/null || true
+
 echo "Dataset extracted to test-data/datasets"
 

--- a/tests/src/bin/property_based_test_runner.rs
+++ b/tests/src/bin/property_based_test_runner.rs
@@ -193,7 +193,7 @@ impl PropertyBasedTestRunner {
         self.print_summary();
 
         if total_failures > 0 {
-            return Err(anyhow::anyhow!("{} property tests failed", total_failures));
+            return Err(anyhow::anyhow!("{total_failures} property tests failed"));
         }
 
         Ok(())


### PR DESCRIPTION
Final release branch for v0.9.0. Closes #484 once merged and tagged.

## Version bumps
| File | From | To |
|------|------|-----|
| `Cargo.toml` `[package].version` | 0.3.0 | 0.9.0 |
| `Cargo.toml` `[workspace.package].version` | 0.3.0 | 0.9.0 |
| `bindings/python/pyproject.toml` | 0.3.0rc4 | 0.9.0 |
| `bindings/node/package.json` | 0.3.1-rc5 | 0.9.0 |
| `bindings/node/package-lock.json` | 0.3.1-rc5 | 0.9.0 |

## Fixes required to pass the #484 checklist on macOS

1. **`ChunkedDataReader` CRC32 footer**: `cqlite-core/src/storage/sstable/chunked_data_reader.rs` was reading the full chunk (compressed payload + 4-byte trailing CRC32) and passing it to the LZ4/Snappy decompressor, which then complained about a 4-byte overhang. The sibling `ChunkReader` and the production `read_nb_format_chunk_data` correctly strip the trailer; this PR brings `ChunkedDataReader` in line. Fixes 5 tests in `tests/chunked_data_reader_integration_test.rs` that were silently broken across all platforms (CI never ran them).

2. **macOS AppleDouble shadow files in datasets**: `test-data/scripts/fetch-datasets.sh` now strips `._*` shadow files after extracting the tarball. Without this, macOS `read_dir` returns shadow files whose names also end in `-Data.db`, causing test helpers to read AppleDouble metadata instead of the real SSTable. Linux CI was unaffected, which masked the issue. cqlite-core now passes 1398/0 with the cleanup applied.

3. **Clippy uninlined_format_args**: One callsite in `tests/src/bin/property_based_test_runner.rs` was missed by the workspace-wide sweep in 22fb744.

## #484 checklist — green locally

- [x] `cargo fmt --all -- --check` — clean
- [x] `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features` — clean
- [x] `cargo test --package cqlite-core --features cli-helpers -- --skip test_legacy_format_allows_blob_fallback_with_feature` — **1398 passed, 34 ignored** (CI's exact command)
- [x] `pytest bindings/python/tests` — **229 passed, 167 skipped** (skipped are gated on `RUN_SLOW_TESTS=1`)
- [x] `cd bindings/node && npm test` — **351 passed, 2 skipped, 14 suites**
- [x] `bash test-data/scripts/smoke-test-all-tables.sh` — **33/33 tables pass**
- [x] `bash test-data/scripts/e2e-cassandra-readback.sh` — **5/5 tables pass** (basic-primitives, collections, udt, static-columns, ttl)

## Known orphan tests (not run by CI, deferred to v0.9.1)

`cargo test --workspace` triggers ~18 additional test binaries under the root `cqlite` package's `tests/*.rs` integration suite. These hardcode UUIDs from an older dataset version (e.g., `compression_test_table-6e2f4520934a11f08d448925b7a9e804`) that no longer exist in `datasets-v2` (the current cqlite tag). CI scopes to `cqlite-core` and `cqlite-cli --test unit_tests`, so these have been silently broken across platforms — not introduced by this PR. To be addressed by replacing hardcoded UUIDs with dynamic table discovery (à la `test_basic.counters` test helper) in a follow-up.

## Test plan

- [x] Local cargo / pytest / npm checks listed above
- [ ] CI green on this PR (release.yml, python-ci.yml, node-ci.yml)
- [ ] After merge: tag `v0.9.0` (manual, by @pmcfadin) — confirm PyPI / npm publishing credentials first
- [ ] After tag push: `release.yml`, `python-release.yml`, `node-release.yml` all succeed
- [ ] Publish GitHub release notes from `CHANGELOG.md` `[v0.9.0]` section