### PR TITLE
fix(ci): aarch64-apple-darwin rustup-init PATH confusion

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -61,6 +61,20 @@ jobs:
       - name: Ensure Rust target is installed
         run: rustup target add ${{ matrix.target }}
 
+      - name: Normalize PATH for macOS (prepend ~/.cargo/bin so real cargo wins over rustup-init)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+      - name: Verify Rust toolchain (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          which -a cargo rustup rustup-init || true
+          cargo --version
+          rustup --version
+
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -52,6 +52,20 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Normalize PATH for macOS (prepend ~/.cargo/bin so real cargo wins over rustup-init)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+      - name: Verify Rust toolchain (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          which -a cargo rustup rustup-init || true
+          cargo --version
+          rustup --version
+
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
@@ -116,6 +130,24 @@ jobs:
         run: |
           pip install pytest>=7.0
           pip install dist/*.whl
+
+      - name: Setup Rust (for CLI build)
+        if: runner.os == 'macOS'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Normalize PATH for macOS (prepend ~/.cargo/bin so real cargo wins over rustup-init)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+      - name: Verify Rust toolchain (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          which -a cargo rustup rustup-init || true
+          cargo --version
+          rustup --version
 
       - name: Restore dataset cache
         id: dataset-cache


### PR DESCRIPTION
## Problem

Closes #512.

On the macOS Apple Silicon (`aarch64-apple-darwin`) GitHub-hosted runner,
`cargo` (including `cargo +1.88.0`) was being routed to `rustup-init`
instead of the real binary, producing errors like:

```
error: unexpected argument 'metadata' found
Usage: rustup-init[EXE] [OPTIONS]
```

Root cause: the runner image places `rustup-init` early on PATH.
`dtolnay/rust-toolchain` installs the real cargo shims into
`~/.cargo/bin`, but that directory is not guaranteed to be first on PATH
in the same step or subsequent steps — so `cargo metadata` (called by
napi during the Node build, and by maturin during the Python build)
resolves to `rustup-init`.

The Intel (`x86_64-apple-darwin`) runner is unaffected because its image
has a different PATH ordering.

## What changed

### `.github/workflows/node-ci.yml` — `build` job

After `dtolnay/rust-toolchain@stable` + `rustup target add`, two new
macOS-only steps are inserted **before** `npm ci` / `npm run build`:

1. **Normalize PATH**: `echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"` —
   prepends the cargo bin dir so the real shims win over any pre-installed
   `rustup-init` for all subsequent steps.
2. **Verify toolchain**: runs `which -a cargo rustup rustup-init || true`,
   `cargo --version`, `rustup --version` — surfaces any future regression
   immediately with clear diagnostics.

### `.github/workflows/python-ci.yml` — `build-wheels` job

Same two macOS-only steps inserted after `dtolnay/rust-toolchain@stable`,
before the `maturin-action` (which calls `cargo metadata`).

### `.github/workflows/python-ci.yml` — `test` job

The test job runs `cargo build --package cqlite-cli --release` on macOS
but had **no Rust toolchain install at all**, relying entirely on whatever
Rust the runner image pre-installs. Three new macOS-only steps added:

1. **Setup Rust** via `dtolnay/rust-toolchain@stable` (ensures 1.88.0
   from `rust-toolchain.toml` is active rather than a stale image copy).
2. **Normalize PATH** (same as above).
3. **Verify toolchain** (same as above).

The `if: runner.os == 'macOS'` condition means Linux and Windows jobs
are completely unaffected.

## Test plan

- [ ] PR CI triggers `node-ci.yml` — confirm the `Build (aarch64-apple-darwin)` matrix leg passes (no `rustup-init` errors).
- [ ] PR CI triggers `python-ci.yml` — confirm the `Build wheel (aarch64-apple-darwin)` and `Test (macos-14)` legs pass.
- [ ] `Build (x86_64-apple-darwin)` and all Linux/Windows legs continue to pass (PATH step is a no-op on non-macOS).
- [ ] Verify step output in aarch64 log shows `cargo 1.88.0` and the `which -a` output lists `~/.cargo/bin/cargo` before any other cargo.

**Note**: local validation is not possible (requires GitHub's aarch64-apple-darwin runner). The PR's own CI run on that runner is the definitive validation.