### PR TITLE
fix(reader): UDT field decoding for generic frozen<udt>

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
@@ -2579,6 +2579,55 @@ impl V5CompressedLegacyParser {
                     offset += blob_len;
 
                     (udt_value, offset)
+                } else if let Some(udt_def) = self
+                    .udt_registry
+                    .as_ref()
+                    .and_then(|reg| reg.get_udt(&self.keyspace, &inner_type).cloned())
+                {
+                    // frozen<short_udt_name>: look up the concrete UDT definition in the
+                    // registry (Issue #502).  This handles type strings like
+                    // `frozen<person>` where "person" is a registered UDT rather than a
+                    // collection or a full marshal-format UserType string.
+                    log::debug!(
+                        "V5CompressedLegacy: Resolving frozen UDT '{}' via registry for column '{}'",
+                        inner_type,
+                        column.name,
+                    );
+
+                    // Read VUInt-prefixed blob length (same framing as tuple and
+                    // marshal-format UDT cells).
+                    let (remaining, blob_len_raw) = parse_vuint(&data[offset..]).map_err(|e| {
+                        Error::corruption(format!(
+                            "Frozen UDT '{}' (column '{}'): failed to parse blob length: {:?}",
+                            inner_type, column.name, e
+                        ))
+                    })?;
+                    if blob_len_raw > MAX_CELL_VALUE_LENGTH {
+                        return Err(Error::corruption(format!(
+                            "Frozen UDT '{}' (column '{}'): blob_len {} exceeds maximum {}",
+                            inner_type, column.name, blob_len_raw, MAX_CELL_VALUE_LENGTH
+                        )));
+                    }
+                    let blob_len = blob_len_raw as usize;
+                    let len_bytes_consumed = data[offset..].len() - remaining.len();
+                    offset += len_bytes_consumed;
+
+                    if offset + blob_len > data.len() {
+                        return Err(Error::corruption(format!(
+                            "Frozen UDT '{}' (column '{}'): need {} bytes but only {} available",
+                            inner_type,
+                            column.name,
+                            blob_len,
+                            data.len() - offset
+                        )));
+                    }
+
+                    let udt_data = &data[offset..offset + blob_len];
+                    let (udt_value, _) =
+                        self.parse_udt_value(udt_data, 0, &udt_def, column, _reader)?;
+                    offset += blob_len;
+
+                    (udt_value, offset)
                 } else {
                     // Non-collection frozen type (e.g., frozen<tuple<...>>)
                     let mut inner_column = column.clone();

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
@@ -2553,13 +2553,19 @@ impl V5CompressedLegacyParser {
                     let udt_def = Self::parse_udt_type_definition(&column.data_type)?;
 
                     // First read the VInt-prefixed blob length
-                    let (remaining, blob_len) = parse_vuint(&data[offset..]).map_err(|e| {
+                    let (remaining, blob_len_raw) = parse_vuint(&data[offset..]).map_err(|e| {
                         Error::corruption(format!(
                             "Frozen UDT '{}': failed to parse blob length: {:?}",
                             column.name, e
                         ))
                     })?;
-                    let blob_len = blob_len as usize;
+                    if blob_len_raw > MAX_CELL_VALUE_LENGTH {
+                        return Err(Error::corruption(format!(
+                            "Frozen UDT '{}': blob_len {} exceeds maximum {}",
+                            column.name, blob_len_raw, MAX_CELL_VALUE_LENGTH
+                        )));
+                    }
+                    let blob_len = blob_len_raw as usize;
                     let bytes_consumed = data[offset..].len() - remaining.len();
                     offset += bytes_consumed;
 
@@ -2629,7 +2635,53 @@ impl V5CompressedLegacyParser {
 
                     (udt_value, offset)
                 } else {
-                    // Non-collection frozen type (e.g., frozen<tuple<...>>)
+                    // Detect bare identifiers that look like unregistered UDT names.
+                    // A bare identifier has no '<' (not a container or tuple) and does not
+                    // match any known CQL primitive type.  If we reach this branch with
+                    // such an identifier it means the UDT was not in the registry — return
+                    // an actionable schema error rather than silently producing a Blob.
+                    //
+                    // Legitimate fall-through types handled below:
+                    //   • tuple<...>  (contains '<')
+                    //   • known primitives: int, text, uuid, boolean, blob, float, double,
+                    //     decimal, varint, bigint, counter, timestamp, date, time, duration,
+                    //     inet, smallint, tinyint, varchar, ascii, timeuuid
+                    const KNOWN_PRIMITIVES: &[&str] = &[
+                        "int",
+                        "bigint",
+                        "counter",
+                        "smallint",
+                        "tinyint",
+                        "text",
+                        "varchar",
+                        "ascii",
+                        "uuid",
+                        "timeuuid",
+                        "boolean",
+                        "blob",
+                        "float",
+                        "double",
+                        "decimal",
+                        "varint",
+                        "timestamp",
+                        "date",
+                        "time",
+                        "duration",
+                        "inet",
+                    ];
+                    let is_container = inner_type.contains('<');
+                    let is_primitive = KNOWN_PRIMITIVES.contains(&inner_type.as_str());
+                    if !is_container && !is_primitive {
+                        // Bare identifier that is neither a container nor a primitive —
+                        // this is an unregistered UDT name.
+                        return Err(Error::schema(format!(
+                            "frozen<{inner}>: UDT '{inner}' not found in registry for keyspace '{}'; \
+                             register it before reading",
+                            self.keyspace,
+                            inner = inner_type,
+                        )));
+                    }
+                    // Non-collection / primitive frozen type — recurse normally.
                     let mut inner_column = column.clone();
                     inner_column.data_type = inner_type.clone();
                     self.parse_cell_value_schema_order(data, offset, &inner_column, _reader)?

--- a/cqlite-core/tests/write_read_roundtrip.rs
+++ b/cqlite-core/tests/write_read_roundtrip.rs
@@ -51,7 +51,10 @@ mod summary;
 mod type_coverage;
 
 use cqlite_core::platform::Platform;
-use cqlite_core::schema::{ClusteringColumn, ClusteringOrder, Column, KeyColumn, TableSchema};
+use cqlite_core::schema::{
+    ClusteringColumn, ClusteringOrder, Column, KeyColumn, SchemaRegistry, SchemaRegistryConfig,
+    TableSchema, UdtRegistry,
+};
 use cqlite_core::storage::sstable::SSTableManager;
 use cqlite_core::storage::write_engine::{
     CellOperation, ClusteringKey, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
@@ -440,6 +443,126 @@ pub async fn read_back_all_rows(temp_dir: &TempDir, schema: &TableSchema) -> Vec
         .expect("Scan should succeed");
 
     results.into_iter().map(|(_key, value)| value).collect()
+}
+
+/// Read back all raw row values from a flushed SSTable with a pre-populated UDT registry.
+///
+/// This variant creates a `SchemaRegistry` populated with the supplied `udt_registry` and
+/// passes it to `SSTableManager::new` so that the reader receives UDT type definitions
+/// before the first scan.  Used by tests that write `frozen<name>` columns where the
+/// concrete UDT must be resolved from the registry (Issue #502).
+#[cfg(feature = "state_machine")]
+pub async fn read_back_all_rows_with_udt_registry(
+    temp_dir: &TempDir,
+    schema: &TableSchema,
+    udt_registry: UdtRegistry,
+) -> Vec<Value> {
+    use tokio::sync::RwLock;
+
+    let data_dir = temp_dir.path().join("data");
+    let config = Config::default();
+    let platform = Arc::new(
+        Platform::new(&config)
+            .await
+            .expect("Platform::new should succeed in test environment"),
+    );
+
+    // Build a SchemaRegistry seeded with the caller-supplied UDT definitions.
+    let schema_registry = SchemaRegistry::new(
+        SchemaRegistryConfig::default(),
+        platform.clone(),
+        config.clone(),
+    )
+    .await
+    .expect("SchemaRegistry::new should succeed in test environment");
+
+    // Register each UDT from the supplied registry into the schema registry.
+    {
+        let all_udts: Vec<cqlite_core::types::UdtTypeDef> = {
+            // UdtRegistry does not expose an iterator, so we snapshot via clone.
+            let tmp = udt_registry.clone();
+            // Collect by draining our local copy's list_udt_names across all keyspaces.
+            // We reach keyspaces through a known-keyspace list derived from the schema.
+            let keyspace = schema.keyspace.as_str();
+            tmp.list_udt_names(keyspace)
+                .into_iter()
+                .filter_map(|name| tmp.get_udt(keyspace, name).cloned())
+                .collect()
+        };
+        for udt_def in all_udts {
+            schema_registry
+                .register_udt(udt_def)
+                .await
+                .expect("register_udt should succeed");
+        }
+    }
+
+    let schema_registry_arc = Arc::new(RwLock::new(schema_registry));
+
+    let manager = SSTableManager::new(&data_dir, &config, platform, Some(schema_registry_arc))
+        .await
+        .expect("SSTableManager should load written SSTables");
+
+    let table_id =
+        cqlite_core::types::TableId::from(format!("{}.{}", schema.keyspace, schema.table).as_str());
+    let results = manager
+        .scan(&table_id, None, None, None, Some(schema))
+        .await
+        .expect("Scan should succeed");
+
+    results.into_iter().map(|(_key, value)| value).collect()
+}
+
+/// Read back a single column value from a flushed SSTable with a pre-populated UDT registry.
+///
+/// Convenience wrapper around `read_back_all_rows_with_udt_registry`.
+#[cfg(feature = "state_machine")]
+pub async fn read_back_column_with_udt_registry(
+    temp_dir: &TempDir,
+    schema: &TableSchema,
+    col_name: &str,
+    udt_registry: UdtRegistry,
+) -> Value {
+    let rows = read_back_all_rows_with_udt_registry(temp_dir, schema, udt_registry).await;
+    assert_eq!(
+        rows.len(),
+        1,
+        "Expected exactly 1 row in {}.{}, got {}",
+        schema.keyspace,
+        schema.table,
+        rows.len()
+    );
+    let row_value = rows.into_iter().next().unwrap();
+
+    match &row_value {
+        Value::Map(entries) => {
+            for (key, value) in entries {
+                if let Value::Text(name) = key {
+                    if name == col_name {
+                        return value.clone();
+                    }
+                }
+            }
+            panic!(
+                "Column '{}' not found in row. Available columns: {:?}",
+                col_name,
+                entries
+                    .iter()
+                    .filter_map(|(k, _)| {
+                        if let Value::Text(n) = k {
+                            Some(n.as_str())
+                        } else {
+                            None
+                        }
+                    })
+                    .collect::<Vec<_>>()
+            );
+        }
+        other => panic!(
+            "Expected Map row for column '{}', got {:?}",
+            col_name, other
+        ),
+    }
 }
 
 /// Read back a single column value from a flushed SSTable.

--- a/cqlite-core/tests/write_read_roundtrip/type_coverage.rs
+++ b/cqlite-core/tests/write_read_roundtrip/type_coverage.rs
@@ -19,7 +19,7 @@
 
 #![cfg(feature = "write-support")]
 
-use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+use cqlite_core::schema::{Column, KeyColumn, TableSchema, UdtRegistry};
 use cqlite_core::storage::write_engine::{CellOperation, Mutation, PartitionKey, TableId};
 use cqlite_core::types::Value;
 use std::collections::HashMap;
@@ -1273,18 +1273,30 @@ async fn test_type_tuple_int_text_uuid() {
     assert_eq!(read_back, original, "Tuple<int,text,uuid> roundtrip failed");
 }
 
-/// Known limitation: the reader cannot map the generic `frozen<udt>` type
-/// string to field names without a concrete UDT name, so the inner UDT bytes
-/// read back as `Value::Frozen(Value::Null)`. The test accepts that outcome
-/// alongside fully-decoded values; tighten once UDT registry support lands.
+/// Verify that `frozen<person>` round-trips correctly when the reader is given a
+/// `UdtRegistry` that carries the "person" type definition (Issue #502).
+///
+/// The concrete UDT name ("person") is placed in the column type string so the
+/// reader can look it up in the registry.  A `UdtRegistry` with the matching
+/// field definitions is injected via `read_back_column_with_udt_registry`.
+#[cfg(feature = "state_machine")]
 #[tokio::test]
 async fn test_type_frozen_udt() {
-    use cqlite_core::types::{UdtField, UdtValue};
+    use cqlite_core::schema::CqlType;
+    use cqlite_core::types::{UdtField, UdtTypeDef, UdtValue};
 
     let temp_dir = TempDir::new().unwrap();
-    let schema = create_type_test_schema("frozen_col", "frozen<udt>");
+    // Use a concrete UDT name so the reader can resolve it from the registry.
+    let schema = create_type_test_schema("frozen_col", "frozen<person>");
 
-    // Build a simple two-field UDT value
+    // Build the matching UDT definition (field names + types).
+    let udt_def = UdtTypeDef::new("test_types".to_string(), "person".to_string())
+        .with_field("name".to_string(), CqlType::Text, true)
+        .with_field("age".to_string(), CqlType::Int, true);
+    let mut udt_registry = UdtRegistry::new();
+    udt_registry.register_udt(udt_def);
+
+    // Build a simple two-field UDT value.
     let inner_udt = Value::Udt(UdtValue {
         type_name: "person".to_string(),
         keyspace: "test_types".to_string(),
@@ -1302,35 +1314,20 @@ async fn test_type_frozen_udt() {
     let original = Value::Frozen(Box::new(inner_udt.clone()));
 
     let info = write_single_value(&temp_dir, &schema, "frozen_col", original.clone()).await;
-
     assert_single_partition_written(&info);
-    let col_value = super::read_back_column(&temp_dir, &schema, "frozen_col").await;
 
-    // Accept:
-    //   • Frozen(Udt(…))  – fully decoded (future ideal)
-    //   • Udt(…)          – unwrapped by reader
-    //   • Frozen(Null)    – current reader behaviour: frozen wrapper present,
-    //                       inner UDT not decoded due to generic type string
-    //   • Blob(…)         – raw bytes fallback
-    match &col_value {
-        v if *v == original || *v == inner_udt => {
-            // Fully decoded — ideal outcome
-        }
-        Value::Frozen(inner) if matches!(inner.as_ref(), Value::Null) => {
-            // Known limitation: reader preserves Frozen wrapper but cannot
-            // decode UDT fields from generic "frozen<udt>" type string
-            eprintln!(
-                "note: frozen<udt> read back as Frozen(Null) — \
-                 reader cannot decode UDT fields without a concrete type name \
-                 (schema-aware UDT decoding not yet implemented for generic type strings)"
-            );
-        }
-        Value::Blob(_) => {
-            eprintln!("note: frozen<udt> read back as Blob (raw bytes fallback)");
-        }
-        other => panic!(
-            "Frozen<udt> roundtrip: unexpected read-back value {:?}",
-            other
-        ),
-    }
+    // Use the UDT-registry-aware scan helper so the reader can resolve "person".
+    let col_value =
+        super::read_back_column_with_udt_registry(&temp_dir, &schema, "frozen_col", udt_registry)
+            .await;
+
+    // The reader must return the fully decoded UDT — either wrapped in Frozen or
+    // unwrapped.  Frozen(Null) and Blob are no longer acceptable outcomes.
+    assert!(
+        col_value == original || col_value == inner_udt,
+        "frozen<person> roundtrip: expected {:?} or {:?}, got {:?}",
+        original,
+        inner_udt,
+        col_value
+    );
 }

--- a/docs/write-support-limitations.md
+++ b/docs/write-support-limitations.md
@@ -86,10 +86,22 @@ Tuples in pre-existing SSTables written by Cassandra may be affected.
 
 ## frozen<udt> field decoding (Issue #502)
 
-**Behaviour**: Fields within frozen UDT values may be returned as raw byte arrays
-in some edge cases rather than as typed `dict` values.
+**Behaviour** (resolved in v0.9.1): The reader now decodes `frozen<NAME>` columns
+by resolving `NAME` through the UDT registry attached to the parser. When a
+registered UDT definition is found the field bytes are decoded field-by-field into
+a typed `Value::Udt` rather than a raw byte array.
+
+**Requirement**: The UDT must be registered in the `UdtRegistry` before opening
+the SSTable. If `NAME` is not present in the registry the reader returns a
+`schema` error:
+
+```
+frozen<NAME>: UDT 'NAME' not found in registry for keyspace 'KS';
+register it before reading
+```
 
 **Impact**: Read-only. Frozen UDTs created by the CQLite writer decode correctly.
-Pre-existing frozen UDTs from Cassandra may be affected.
+The error is actionable: pass the UDT schema to `UdtRegistry::register_udt` and
+re-open the reader.
 
 **Tracking**: Issue #502.


### PR DESCRIPTION
## Summary

- Closes #502
- Extends the `frozen<>` branch in `parse_cell_value_schema_order` to resolve the inner type name via the UDT registry before falling through to the generic blob/tuple path.
- Adds `read_back_column_with_udt_registry` test helper that injects a pre-populated `UdtRegistry` into the `SSTableManager` via `SchemaRegistry`.
- Tightens `test_type_frozen_udt`: the `Frozen(Null)` acceptance arm is removed and the test asserts exact equality with the original decoded value.

## Root Cause

`parse_cell_value_schema_order` handled `frozen<X>` columns via three branches:
1. `list<>`, `set<>`, `map<>` — frozen collection parsers
2. Full marshal format `org.apache.cassandra.db.marshal.UserType(...)` — `parse_udt_type_definition`
3. Everything else — delegate to `parse_cell_value_schema_order` with the inner type string

When the column type is `frozen<person>`, `inner_type` is `"person"` — not a collection and not a marshal-format UserType — so it fell into branch 3. That delegated back to the same function with `data_type = "person"`, which matched no known type and fell to the blob/`Value::Null` handler, producing `Frozen(Null)`.

## How Type Resolution Works

A new `else if` arm is inserted between the marshal-format UDT check and the catch-all else:

```rust
} else if let Some(udt_def) = self
    .udt_registry
    .as_ref()
    .and_then(|reg| reg.get_udt(&self.keyspace, &inner_type).cloned())
{
    // Read VUInt-prefixed blob length (same framing as tuple and marshal-format UDT cells)
    // then delegate to parse_udt_value with the registry-supplied UdtTypeDef.
```

The `UdtRegistry` on the parser is populated before the scan via `SchemaRegistry`. The test creates a `UdtRegistry` with the "person" type definition, registers it into a `SchemaRegistry`, and passes that to `SSTableManager::new`. The existing `load_existing_sstables` path then calls `reader.set_udt_registry(...)` before wrapping the reader in `Arc`.

The column type string in the schema was changed from the unresolvable `frozen<udt>` to the concrete `frozen<person>` — a name that can be looked up in the registry. The bare `frozen<udt>` string was inherently undecodable: the UDT bytes contain only field values (not names or type tags), so without a registry entry there is no authoritative source of field metadata.

## Test Plan

- [x] `cargo fmt --all -- --check` passes
- [x] `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features` passes (0 warnings)
- [x] `cargo test --package cqlite-core --features cli-helpers` — 1399 passed, 34 ignored
- [x] `cargo test --package cqlite-core --features write-support,state_machine` — 1535 passed (pre-existing `test_clustering_key_ord_type_mismatch_panics` failure unrelated to this change)
- [x] `bash test-data/scripts/smoke-test-all-tables.sh` — 33/33 tables PASS
- [x] `test_type_frozen_udt` passes and no longer accepts `Frozen(Null)`