### PR TITLE
chore(release): cut v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.9.1] — Reader correctness fixes
+
+Reader correctness and test/CI follow-ups to v0.9.0. No writer changes and no
+public API changes.
+
+### Fixed
+
+- **Set-element tombstones** were surfaced as live values by the V5CompressedLegacy
+  parser because the cell `is_deleted` flag was discarded. `parse_complex_cell_value`
+  now returns the deletion flag, and the set (and list) branch skips tombstoned
+  elements (#493).
+- **Schema-aware tuple decoding** for arbitrary arity: tuples with more than two
+  elements (e.g. `tuple<int, text, uuid>`) previously read back as `Null` or `Blob`.
+  The reader now decodes each element using the element types from the schema's
+  type string, with bounds-checked parsing and no heuristics (#501).
+- **Frozen UDT field decoding**: `frozen<NAME>` columns previously read back as
+  `Frozen(Null)`. The reader now resolves the concrete UDT through the UDT registry
+  and decodes fields by name and type, and returns an actionable error when the
+  referenced UDT is not registered (#502).
+
+### Testing & CI
+
+- Revived the orphan root-package integration tests: hardcoded SSTable directory
+  UUIDs (from the retired dataset version) were replaced with dynamic table
+  discovery, and the suite is now wired into CI so it cannot rot again (#514).
+- Fixed the `aarch64-apple-darwin` CI runner where `cargo` was routed to
+  `rustup-init` (the `cargo metadata` / `cargo +1.88.0` failures). The real cargo
+  is now prepended to `PATH` in the Node and Python build workflows, with a
+  toolchain verification step (#512).
+
+### Known Issues
+
+- Reviving the orphan integration tests surfaced three pre-existing reader bugs,
+  now tracked separately and marked `#[ignore]` in the revived tests:
+  `scan()` result ordering is not guaranteed (#516), `get()` misses partitions that
+  `scan()` returns (#517), and `SSTableReader::stats().block_count` always reports
+  0 (#518).
+- The v0.9.0 known issues for counter writes, the BIG-format BTI writer, and the
+  Python concurrent-query race (#311) are unchanged.
+
 ## [v0.9.0] — M5 Write Support
 
 ### Added
@@ -63,7 +103,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   database handle may see a race in schema metadata access. Run one warm-up query
   before spawning parallel threads.
 - **Open reader follow-ups**: set-element tombstone decoding (#493), schema-aware
-  tuple decoding (#501), frozen<udt> field decoding (#502).
+  tuple decoding (#501), frozen<udt> field decoding (#502). _(Resolved in v0.9.1.)_
 
 ## [0.4.0] - 2026-01-27 (M4 Complete)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [package]
 name = "cqlite"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 
 [dependencies]
@@ -32,7 +32,7 @@ insta = "1.34"
 cqlite-integration-tests = { path = "tests" }
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 authors = ["CQLite Team"]
 license = "MIT OR Apache-2.0"

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cqlite/node",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cqlite/node",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^3.5.1",

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cqlite/node",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Node.js bindings for CQLite - read Apache Cassandra 5.0 SSTables without cluster dependencies",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "cqlite-py"
-version = "0.9.0"
+version = "0.9.1"
 description = "Python bindings for CQLite - read Cassandra 5.0 SSTables locally without a cluster"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## v0.9.1 — Reader correctness fixes

Reader correctness and test/CI follow-ups to v0.9.0. **No writer changes and no public API changes.** Mirrors the v0.9.0 release pattern (#513).

### Fixed
- **#493** — Set-element tombstones surfaced as live values in the V5CompressedLegacy parser. `parse_complex_cell_value` now returns the `is_deleted` flag and the set/list branch skips tombstoned elements.
- **#501** — Schema-aware tuple element decoding for arbitrary arity (`tuple<int, text, uuid>` etc.) — previously read back as `Null`/`Blob`.
- **#502** — Frozen UDT field decoding: `frozen<NAME>` resolved through the UDT registry; actionable error when the UDT is unregistered (previously `Frozen(Null)`).

### Testing & CI
- **#514** — Revived the orphan root-package integration tests (dynamic table discovery replacing hardcoded SSTable UUIDs) and wired them into CI.
- **#512** — Fixed the `aarch64-apple-darwin` runner where `cargo` was routed to `rustup-init`; real cargo prepended to `PATH` in the Node/Python build workflows.

### Version bumps
`cqlite` / `cqlite-core` (Cargo workspace), `cqlite-py` (pyproject), `@cqlite/node` (package.json + package-lock.json) → **0.9.1**.

### New known issues (out of v0.9.1 scope, filed during #514)
Reviving the orphan tests surfaced three pre-existing reader bugs, now tracked and `#[ignore]`d: #516 (scan ordering), #517 (get/scan visibility), #518 (`stats().block_count` always 0).

## Test plan (full pre-push checklist, run on this branch)
| Gate | Result |
|------|--------|
| `cargo fmt --all -- --check` | ✅ |
| `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features` | ✅ 0 warnings |
| `cargo test -p cqlite-core --features cli-helpers` (skip legacy blob) | ✅ 1400 passed, 34 ignored |
| `cargo test -p cqlite-integration-tests` | ✅ 187 passed, 24 ignored |
| Python `pytest bindings/python/tests` | ✅ 229 passed, 167 skipped |
| Node `npm test` | ✅ 351 passed, 2 skipped |
| `smoke-test-all-tables.sh` | ✅ 33/33 |
| **`e2e-cassandra-readback.sh`** (Docker, 5 tables) | ✅ 5/5 (basic-primitives, collections, udt, static-columns, ttl) |

Closes #493, #501, #502, #512, #514.