### PR TITLE
fix(release): apply macOS cargo PATH fix to tag-triggered release workflows

### DIFF
--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -52,6 +52,20 @@ jobs:
       - name: Ensure Rust target is installed
         run: rustup target add ${{ matrix.target }}
 
+      - name: Normalize PATH for macOS (prepend ~/.cargo/bin so real cargo wins over rustup-init)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+      - name: Verify Rust toolchain (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          which -a cargo rustup rustup-init || true
+          cargo --version
+          rustup --version
+
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -69,6 +69,20 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Normalize PATH for macOS (prepend ~/.cargo/bin so real cargo wins over rustup-init)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+      - name: Verify Rust toolchain (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          which -a cargo rustup rustup-init || true
+          cargo --version
+          rustup --version
+
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,20 @@ jobs:
     - name: Override Rust toolchain
       run: rm -f rust-toolchain.toml
 
+    - name: Normalize PATH for macOS (prepend ~/.cargo/bin so real cargo wins over rustup-init)
+      if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+    - name: Verify Rust toolchain (macOS)
+      if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        which -a cargo rustup rustup-init || true
+        cargo --version
+        rustup --version
+
     - name: Install cross (Linux only)
       if: matrix.use_cross
       run: cargo install cross

--- a/docs/write-support-limitations.md
+++ b/docs/write-support-limitations.md
@@ -61,26 +61,24 @@ with cqlite.open(data_dir, schema=schema) as db:
 
 ## Set-element tombstone decoding (Issue #493)
 
-**Behaviour**: Tombstones for individual set elements within a cell are silently
-ignored during query. The parent set is returned but tombstoned elements may
-appear as still-present.
+**Behaviour** (resolved in v0.9.1): The V5CompressedLegacy parser now carries the
+per-cell `is_deleted` flag out of complex-cell parsing and skips tombstoned set
+(and list) elements. Data deleted at the element level
+(via `DELETE my_set[element] FROM ...`) no longer appears as still-present in
+query results.
 
-**Impact**: Read-only. Writes are unaffected. Data that was deleted at the
-element level (via `DELETE my_set[element] FROM ...`) may appear in query results.
-
-**Tracking**: Issue #493. Planned for v0.9.1.
+**Tracking**: Issue #493 (fixed in v0.9.1).
 
 ---
 
 ## Schema-aware tuple decoding (Issue #501)
 
-**Behaviour**: Tuple fields are decoded without schema context in some edge cases,
-returning raw byte arrays instead of typed values.
+**Behaviour** (resolved in v0.9.1): The reader decodes tuple element types from the
+schema's type string for arbitrary arity (e.g. `tuple<int, text, uuid>`), with
+bounds-checked per-element parsing. Tuples that previously read back as `Null` or
+`Blob` now decode to typed values.
 
-**Impact**: Read-only. Tuples created by the CQLite writer decode correctly.
-Tuples in pre-existing SSTables written by Cassandra may be affected.
-
-**Tracking**: Issue #501.
+**Tracking**: Issue #501 (fixed in v0.9.1).
 
 ---
 


### PR DESCRIPTION
## Why (pre-tag-push blocker for v0.9.1)

The aarch64-apple-darwin `cargo → rustup-init` PATH fix from **#512** was only applied to the **CI** workflows (`node-ci.yml`, `python-ci.yml`). The **tag-triggered release** workflows build on the same macOS runners and were never patched:

- `node-release.yml` (Build on `macos-14` / aarch64-apple-darwin)
- `python-release.yml` (Build wheel on `macos-14` / aarch64-apple-darwin)
- `release.yml` (Build CLI on `macos-15` for both apple-darwin targets)

These run on `push.tags: v*`, so the held **v0.9.1** tag could still hit the same failure during npm/PyPI/CLI publication. That's **unrecoverable** — PyPI and npm reject re-uploads of a version, so a failed publish means cutting v0.9.2. Better to fix before tagging. (Thanks to the reviewer who caught this.)

## What

- Added the same `GITHUB_PATH` normalization (`echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"`) + a toolchain-verify step to all three release workflows, guarded by `if: runner.os == 'macOS'` — a verbatim copy of the mitigation merged in #521.
- Synced `docs/write-support-limitations.md`: #493 and #501 were still listed as "planned/active"; marked them resolved in v0.9.1 to match the already-updated #502 entry.

## Validation note

⚠️ The release workflows only trigger on `push.tags: v*`, **not on PRs**, so this PR's CI cannot exercise them directly. Validation rests on:
- YAML parses cleanly (verified locally for all three files).
- The added steps are identical to the #512/#521 mitigation, which went green on the `Build (aarch64-apple-darwin)` and `Build wheel (aarch64-apple-darwin)` legs.
- The steps are purely additive and macOS-guarded (PATH prepend + version prints) — they cannot affect Linux/Windows publish jobs.

The definitive test is the v0.9.1 tag push itself.

Refs #512, #525.