### PR TITLE
fix(reader): populate stats().block_count from CompressionInfo.db (closes #518)

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -214,11 +214,19 @@ impl SSTableReader {
             None
         };
 
+        // Derive block_count from CompressionInfo.db when available — this is the
+        // authoritative source for compressed SSTables (no-heuristics mandate #28).
+        // Each entry in chunk_offsets corresponds to one compressed block in Data.db.
+        let block_count = compression_info
+            .as_ref()
+            .map(|ci| ci.chunk_offsets.len() as u64)
+            .unwrap_or(0);
+
         let stats = SSTableReaderStats {
             file_size,
             entry_count: header.stats.row_count,
-            table_count: 1,       // Will be updated as we discover tables
-            block_count: 0,       // Will be updated as we scan
+            table_count: 1, // Will be updated as we discover tables
+            block_count,
             index_size: 0,        // Will be updated if index is loaded
             bloom_filter_size: 0, // Will be updated if bloom filter is loaded
             compression_ratio: header.stats.compression_ratio,

--- a/tests/golden_path_get_operations_tests.rs
+++ b/tests/golden_path_get_operations_tests.rs
@@ -288,11 +288,7 @@ async fn test_golden_path_get_edge_cases() -> Result<()> {
     Ok(())
 }
 
-// Ignored: pre-existing reader issue where stats().block_count returns 0
-// even when the file is valid and readable.  Discovered while reviving
-// this test in issue #514.  Tracked separately for investigation.
 #[tokio::test]
-#[ignore = "pre-existing reader issue: stats().block_count is always 0 (issue #514)"]
 async fn test_golden_path_get_integration_validation() -> Result<()> {
     let fixture = GoldenPathGetTestFixture::new().await?;
     let reader = fixture.setup_test_basic_reader().await?;


### PR DESCRIPTION
## Summary

Fixes #518 — `SSTableReader::stats().block_count` always reported `0`. Surfaced by reviving the orphan integration tests in #514.

Closes #518.

## Root cause

`SSTableReader::open()` initialized `stats.block_count = 0` with a "will be updated as we scan" comment, but the update never happened — `sequential_scan` computes a local count that is never written back, and `stats()` just returns the cached struct. So `block_count` was always 0 regardless of file contents, and `stats()` is supposed to be correct without requiring a prior `scan()`.

## Fix

Derive `block_count` during `open()` from the authoritative `CompressionInfo.db` metadata (`chunk_offsets.len()` — one entry per compressed chunk; verified 1:1 with the file's `chunk_count` field, no end-sentinel). This satisfies the no-heuristics mandate (#28): the live `Statistics.db` path stubs `block_count = 0` (enhanced parser is minimal), so CompressionInfo.db is the correct authoritative source. Uncompressed SSTables (no CompressionInfo.db) correctly report 0.

## Tests

Re-enabled `tests/golden_path_get_operations_tests.rs::test_golden_path_get_integration_validation` (was `#[ignore]` citing #514; asserts `block_count > 0` against the LZ4-compressed `compression_test_table`).

- `test_golden_path_get_integration_validation ... ok`

## Out of scope (noted, not fixed)

`optimized_reader.rs`, `streaming_reader.rs`, and `enhanced_statistics_parser.rs` also hardcode `block_count: 0`; they are separate reader paths not exercised by this test. Candidates for a follow-up issue (not filed to avoid expanding v0.9.2 scope).

## Pre-push checklist (all green)

- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features` ✅
- `cargo test --package cqlite-core --features cli-helpers` ✅ (1400 passed)
- `cargo test --package cqlite-integration-tests` ✅ (192 passed)
- Python 229 ✅ · Node 351 ✅ · `smoke-test-all-tables.sh` 33/33 ✅

## Review

rust-reviewer pass: no BLOCKING issues; confirmed `chunk_offsets.len()` is one-per-chunk (no off-by-one), no unwrap/panic, stats() correct without prior scan().
