### PR TITLE
fix(compaction): surface input tombstones with correct markedForDeleteAt to k-way merger (closes #505)

### DIFF
--- a/cqlite-core/src/query/select_executor.rs
+++ b/cqlite-core/src/query/select_executor.rs
@@ -261,7 +261,10 @@ fn build_row_from_scan(
     projection: &[String],
     schema: Option<&crate::schema::TableSchema>,
 ) -> Option<QueryRow> {
-    if matches!(value, Value::Null) {
+    // Suppress tombstoned rows from user-visible output. A row tombstone reaches
+    // here as `Value::Tombstone` (Issue #505); before that change it was `Value::Null`.
+    // Both must be suppressed identically so deleted rows never appear in query results.
+    if matches!(value, Value::Null | Value::Tombstone(_)) {
         return None;
     }
 

--- a/cqlite-core/src/storage/sstable/reader/data_access.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access.rs
@@ -411,6 +411,152 @@ impl SSTableReader {
         Ok(entries)
     }
 
+    /// Stitch all compressed chunks and parse with per-row timestamps (for compaction).
+    ///
+    /// Identical to [`stitch_and_parse_all_chunks`] but delegates to
+    /// [`V5CompressedLegacyParser::parse_block_with_timestamps`] so that each
+    /// entry carries its actual row-level write timestamp rather than
+    /// `SystemTime::now()`.  Row and cell tombstones are emitted as
+    /// `Value::Tombstone` with their authoritative deletion timestamps.
+    ///
+    /// Used exclusively by the compaction k-way merger path (Issue #505).
+    async fn stitch_and_parse_all_chunks_for_compaction(
+        &self,
+        schema: Option<&crate::schema::TableSchema>,
+    ) -> Result<Vec<(TableId, RowKey, Value, i64)>> {
+        log::debug!("stitch_and_parse_all_chunks_for_compaction: stitching chunks");
+
+        let mut stitched_buffer = Vec::with_capacity(2_500_000);
+        let mut chunk_count = 0;
+
+        while let Some(compressed_chunk) = self.read_next_block().await? {
+            use crate::storage::sstable::compression::Compression;
+            let decompressed_chunk = if let Some(compression_reader) = &self.compression_reader {
+                let compression = Compression::new(*compression_reader.algorithm())?;
+                compression.decompress(&compressed_chunk).map_err(|e| {
+                    Error::corruption(format!(
+                        "stitch_and_parse_all_chunks_for_compaction: Failed to decompress chunk {}: {}",
+                        chunk_count, e
+                    ))
+                })?
+            } else {
+                compressed_chunk
+            };
+            stitched_buffer.extend_from_slice(&decompressed_chunk);
+            chunk_count += 1;
+        }
+
+        log::debug!(
+            "stitch_and_parse_all_chunks_for_compaction: {} chunks, {} bytes total",
+            chunk_count,
+            stitched_buffer.len()
+        );
+
+        let keyspace = self.header.keyspace.clone();
+        let table_name = self.header.table_name.clone();
+
+        let (min_timestamp, min_local_deletion_time, min_ttl) =
+            if let Some(stats_reader) = &self.statistics_reader {
+                let ts_stats = &stats_reader.statistics().timestamp_stats;
+                (
+                    ts_stats.min_timestamp,
+                    ts_stats.min_deletion_time,
+                    ts_stats.min_ttl,
+                )
+            } else {
+                (0, 0, None)
+            };
+
+        let parser = crate::storage::sstable::reader::parsing::V5CompressedLegacyParser::new(
+            keyspace,
+            table_name,
+            min_timestamp,
+            min_local_deletion_time,
+            min_ttl,
+        );
+        let parser = if let Some(ref registry) = self.udt_registry {
+            parser.with_udt_registry(registry.clone())
+        } else {
+            parser
+        };
+
+        let reader_schema;
+        let table_schema = if let Some(s) = schema {
+            Some(s)
+        } else {
+            reader_schema = self.get_table_schema(None);
+            reader_schema.as_ref()
+        };
+
+        let entries = parser.parse_block_with_timestamps(&stitched_buffer, table_schema, self)?;
+        log::debug!(
+            "stitch_and_parse_all_chunks_for_compaction: parsed {} entries",
+            entries.len()
+        );
+
+        Ok(entries)
+    }
+
+    /// Iterate all partitions with per-row timestamps, for use by the compaction merger.
+    ///
+    /// Returns `(RowKey, Value, row_timestamp_micros)` for every row in the SSTable.
+    /// Unlike [`iterate_all_partitions`]:
+    ///
+    /// - Row tombstones are returned as `Value::Tombstone(RowTombstone)` carrying
+    ///   the actual deletion timestamp extracted from the on-disk row header.
+    /// - Cell tombstones within live rows are stored as `Value::Tombstone(CellTombstone)`
+    ///   inside the `Value::Map`, also carrying the actual cell-level deletion timestamp.
+    /// - The third tuple element is the decoded row-level write timestamp, so the
+    ///   merger can perform timestamp-accurate last-write-wins comparisons.
+    ///
+    /// Normal user-facing reads use [`scan`] / [`get`] / [`iterate_all_partitions`],
+    /// which apply tombstone filtering.  Do NOT use this method for user-visible queries.
+    ///
+    /// (Issue #505)
+    pub async fn iterate_all_partitions_for_compaction(
+        &self,
+        schema: Option<&crate::schema::TableSchema>,
+    ) -> Result<Vec<(RowKey, Value, i64)>> {
+        // Only the V5CompressedLegacy NB chunk-stitching path is supported here
+        // (that is the format the WriteEngine produces).  For other formats, fall
+        // back to iterate_all_partitions and attach timestamp 0 as a conservative
+        // default (LWW ordering then relies solely on run_index).
+        if self.requires_chunk_stitching() {
+            // We need schema; retrieve it once.
+            // `schema` is Option<&TableSchema>; clone it into an owned value so we
+            // can pass it to the async helper without borrow-checker issues.
+            let owned_schema = schema.cloned().or_else(|| self.get_table_schema(None));
+
+            // Reset chunk reader to start of data section.
+            let header_size = self.calculate_header_size();
+            {
+                let mut file_guard = self.file.lock().await;
+                use tokio::io::AsyncSeekExt;
+                file_guard
+                    .seek(std::io::SeekFrom::Start(header_size as u64))
+                    .await?;
+            }
+            self.current_chunk_index
+                .store(0, std::sync::atomic::Ordering::Relaxed);
+
+            let entries = self
+                .stitch_and_parse_all_chunks_for_compaction(owned_schema.as_ref())
+                .await?;
+
+            return Ok(entries
+                .into_iter()
+                .map(|(_tid, key, value, ts)| (key, value, ts))
+                .collect());
+        }
+
+        // Non-stitching fallback: use iterate_all_partitions and attach ts=0.
+        let entries = self.iterate_all_partitions().await?;
+        Ok(entries
+            .into_iter()
+            .map(|(key, value)| (key, value, 0))
+            .collect())
+    }
+
     /// Read value at a specific offset with caching
     pub async fn read_value_at_offset(&self, offset: u64, size: u32) -> Result<Option<Value>> {
         use crate::parser::header::CassandraVersion;

--- a/cqlite-core/src/storage/sstable/reader/data_access.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access.rs
@@ -259,7 +259,20 @@ impl SSTableReader {
         Ok(results)
     }
 
-    /// Get all entries in the SSTable (for compaction)
+    /// Get all entries in the SSTable.
+    ///
+    /// # Tombstone contract (Issue #505)
+    ///
+    /// This is a **user-facing** accessor: row tombstones are filtered out via
+    /// [`Self::filter_tombstone`] and never appear in the returned entries. The
+    /// underlying `parse_block` path emits `Value::Tombstone(RowTombstone)` for
+    /// deleted rows, but those are suppressed here so callers see exactly the live
+    /// rows (matching the previous `Value::Null` suppression behaviour).
+    ///
+    /// The compaction k-way merger must instead use
+    /// [`Self::iterate_all_partitions_for_compaction`], which preserves
+    /// `Value::Tombstone` entries (with their authoritative deletion timestamps)
+    /// so that tombstone-shadowing semantics can be applied during the merge.
     pub async fn get_all_entries(&self) -> Result<Vec<(TableId, RowKey, Value)>> {
         let mut results = Vec::new();
 
@@ -290,6 +303,10 @@ impl SSTableReader {
                 results.extend(entries);
             }
         }
+
+        // Issue #505: suppress row tombstones from user-facing output. The compaction
+        // path (iterate_all_partitions_for_compaction) bypasses this filter.
+        results.retain(|(_tid, _key, value)| self.filter_tombstone(value));
 
         Ok(results)
     }

--- a/cqlite-core/src/storage/sstable/reader/integrity.rs
+++ b/cqlite-core/src/storage/sstable/reader/integrity.rs
@@ -6,6 +6,7 @@
 use super::{IntegrityCheckResult, IntegrityStatus, SSTableReader, SSTableReaderHealthMetrics};
 use crate::types::Value;
 use crate::Result;
+
 use log::{debug, info};
 use std::io::SeekFrom;
 use tokio::io::AsyncSeekExt;
@@ -157,11 +158,28 @@ impl SSTableReader {
         true // Keep valid, non-deleted values
     }
 
-    /// Simple tombstone filtering (fallback when tombstones feature is disabled)
+    /// Simple tombstone filtering (fallback when tombstones feature is disabled).
+    ///
+    /// Row tombstones (`Value::Tombstone(RowTombstone)`) are always filtered out of
+    /// user-facing scan/get results, regardless of the `tombstones` feature flag.
+    /// This prevents deleted rows that are still present on disk (either from a live
+    /// SSTable that contains a tombstone entry, or from a post-compaction SSTable
+    /// that preserved tombstone rows for GC purposes) from appearing in query results.
+    ///
+    /// Cell tombstones (`Value::Tombstone(CellTombstone)`) within a Map are NOT
+    /// filtered here — they are preserved so callers can inspect them.  If a caller
+    /// needs to suppress null-cell entries, it should do so at the query layer.
+    ///
+    /// (Issue #505)
     #[cfg(not(feature = "tombstones"))]
-    pub(super) fn filter_tombstone(&self, _value: &Value) -> bool {
-        // Without tombstone feature, assume all values are valid
-        true
+    pub(super) fn filter_tombstone(&self, value: &Value) -> bool {
+        use crate::types::TombstoneType;
+        // Filter out row-level tombstones; keep everything else.
+        !matches!(
+            value,
+            Value::Tombstone(info)
+                if info.tombstone_type == TombstoneType::RowTombstone
+        )
     }
 
     /// Enhanced multi-generation tombstone filtering for compaction

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
@@ -76,8 +76,16 @@ struct RowHeader {
     timestamp: Option<i64>,
     /// Row-level TTL (after delta decoding from min_ttl)
     ttl: Option<i32>,
-    /// Row-level local deletion time (after delta decoding from min_local_deletion_time)
+    /// Row-level local deletion time in SECONDS (after delta decoding from
+    /// min_local_deletion_time). This is the GC-grace clock, NOT the reconciliation
+    /// timestamp; do not use it for last-write-wins comparisons.
     local_deletion_time: Option<i32>,
+    /// Row-level `markedForDeleteAt` reconciliation timestamp in MICROSECONDS
+    /// (absolute = min_timestamp + delta). For a row tombstone this is the
+    /// authoritative deletion timestamp used by the compaction merger for
+    /// timestamp-based last-write-wins shadowing (Issue #505). `None` when the
+    /// row has no HAS_DELETION flag.
+    marked_for_delete_at: Option<i64>,
     /// Number of bytes consumed by the header
     header_size: usize,
     /// Length of the row_size VInt in bytes (needed for offset calculation)
@@ -87,6 +95,52 @@ struct RowHeader {
     /// bit=1 means column missing, bit=0 means column present.
     /// None when HAS_ALL_COLUMNS flag is set.
     missing_columns_bitmap: Option<u64>,
+}
+
+impl RowHeader {
+    /// Whether this row header describes a row tombstone (HAS_DELETION was set).
+    ///
+    /// Detected via `local_deletion_time` being present, which is only set when the
+    /// HAS_DELETION (0x10) flag was decoded (Issue #505).
+    fn is_row_tombstone(&self) -> bool {
+        self.local_deletion_time.is_some()
+    }
+
+    /// Build the `Value::Tombstone(RowTombstone)` for this header.
+    ///
+    /// The reconciliation `deletion_time` is `marked_for_delete_at` (the
+    /// `markedForDeleteAt` field, MICROSECONDS — same clock as HAS_TIMESTAMP), NOT
+    /// the row write `timestamp` and NOT `local_deletion_time` (seconds, GC clock).
+    /// For a pure row tombstone HAS_TIMESTAMP is absent, so using the write
+    /// timestamp would yield epoch 0 and lose every merge comparison (Issue #505).
+    ///
+    /// Falls back to `local_deletion_time` promoted to microseconds only if
+    /// `marked_for_delete_at` is somehow absent while a deletion was recorded
+    /// (should not happen given HAS_DELETION always writes both VInts), keeping the
+    /// merger's LWW ordering meaningful rather than defaulting to 0.
+    fn row_tombstone(&self) -> Value {
+        let deletion_time = self.row_tombstone_deletion_time();
+        Value::Tombstone(TombstoneInfo {
+            deletion_time,
+            tombstone_type: TombstoneType::RowTombstone,
+            ttl: None,
+            range_start: None,
+            range_end: None,
+        })
+    }
+
+    /// Authoritative reconciliation timestamp (microseconds) for a row tombstone.
+    fn row_tombstone_deletion_time(&self) -> i64 {
+        match self.marked_for_delete_at {
+            Some(ts) => ts,
+            // Defensive fallback: promote the seconds-based local deletion time to
+            // microseconds so ordering remains non-zero and monotonic.
+            None => self
+                .local_deletion_time
+                .map(|s| (s as i64).saturating_mul(1_000_000))
+                .unwrap_or(0),
+        }
+    }
 }
 
 /// Result of parsing a single complex cell (an element of a list/set, or a
@@ -484,32 +538,20 @@ impl V5CompressedLegacyParser {
 
                                     // Convert cells HashMap to Value::Map (required by SelectExecutor)
                                     //
-                                    // Issue #505: Row tombstones are detected via `local_deletion_time`
-                                    // being set in the row header.  When present, emit a proper
-                                    // `Value::Tombstone` so that the compaction merger can apply
-                                    // tombstone-shadowing semantics rather than treating the absent
-                                    // cells as a live row with no data.
-                                    let is_row_tombstone = row_header_opt
-                                        .as_ref()
-                                        .map(|h| h.local_deletion_time.is_some())
-                                        .unwrap_or(false);
+                                    // Issue #505: Row tombstones are detected via HAS_DELETION in the
+                                    // row header.  When present, emit a proper `Value::Tombstone`
+                                    // carrying the authoritative `markedForDeleteAt` (microseconds) so
+                                    // the compaction merger can apply tombstone-shadowing semantics
+                                    // rather than treating the absent cells as a live empty row.
+                                    let row_tombstone =
+                                        row_header_opt.as_ref().filter(|h| h.is_row_tombstone());
 
-                                    let row_value = if is_row_tombstone {
-                                        let deletion_time = row_header_opt
-                                            .as_ref()
-                                            .and_then(|h| h.timestamp)
-                                            .unwrap_or(0);
+                                    let row_value = if let Some(h) = row_tombstone {
                                         log::debug!(
                                             "V5CompressedLegacy: Partition {} Row {} - emitting Tombstone(deletion_time={})",
-                                            partition_index, row_count, deletion_time
+                                            partition_index, row_count, h.row_tombstone_deletion_time()
                                         );
-                                        Value::Tombstone(TombstoneInfo {
-                                            deletion_time,
-                                            tombstone_type: TombstoneType::RowTombstone,
-                                            ttl: None,
-                                            range_start: None,
-                                            range_end: None,
-                                        })
+                                        h.row_tombstone()
                                     } else if cells.is_empty() {
                                         warn!(
                                             "V5CompressedLegacy: No cells extracted for {}.{} partition {} row {} (partition key: {} bytes)",
@@ -750,11 +792,20 @@ impl V5CompressedLegacyParser {
                             Ok((mut cells, row_header_opt, next_offset, is_static)) => {
                                 offset = next_offset;
 
-                                // Extract the row-level timestamp for the merger.
-                                let row_ts = row_header_opt
-                                    .as_ref()
-                                    .and_then(|h| h.timestamp)
-                                    .unwrap_or(0);
+                                // For a row tombstone the authoritative timestamp is
+                                // markedForDeleteAt (HAS_TIMESTAMP is absent for pure row
+                                // deletes). For a live row it is the row write timestamp.
+                                // Both the merger tuple `row_ts` and the emitted
+                                // Value::Tombstone must agree, so resolve once here (#505).
+                                let row_tombstone =
+                                    row_header_opt.as_ref().filter(|h| h.is_row_tombstone());
+                                let row_ts = match row_tombstone {
+                                    Some(h) => h.row_tombstone_deletion_time(),
+                                    None => row_header_opt
+                                        .as_ref()
+                                        .and_then(|h| h.timestamp)
+                                        .unwrap_or(0),
+                                };
 
                                 if is_static {
                                     static_cells = cells;
@@ -763,20 +814,9 @@ impl V5CompressedLegacyParser {
                                         cells.entry(k.clone()).or_insert_with(|| v.clone());
                                     }
 
-                                    // Row tombstone → Value::Tombstone
-                                    let is_row_tombstone = row_header_opt
-                                        .as_ref()
-                                        .map(|h| h.local_deletion_time.is_some())
-                                        .unwrap_or(false);
-
-                                    let row_value = if is_row_tombstone {
-                                        Value::Tombstone(TombstoneInfo {
-                                            deletion_time: row_ts,
-                                            tombstone_type: TombstoneType::RowTombstone,
-                                            ttl: None,
-                                            range_start: None,
-                                            range_end: None,
-                                        })
+                                    // Row tombstone → Value::Tombstone(markedForDeleteAt)
+                                    let row_value = if let Some(h) = row_tombstone {
+                                        h.row_tombstone()
                                     } else if cells.is_empty() {
                                         Value::Null
                                     } else {
@@ -1123,38 +1163,58 @@ impl V5CompressedLegacyParser {
             None
         };
 
-        // Read deletion if HAS_DELETION flag is set
-        let local_deletion_time = if (row_flags & ROW_HAS_DELETION) != 0 {
-            // First VInt is local deletion time delta
-            let (remaining, delta) = parse_vuint(&data[pos..]).map_err(|e| {
+        // Read deletion if HAS_DELETION flag is set.
+        //
+        // Cassandra canonical DeletionTime.Serializer order (matches the CQLite writer,
+        // data_writer.rs write_*_row HAS_DELETION block and write_complex_deletion):
+        //   1. markedForDeleteAt: SIGNED VInt delta, base min_timestamp, MICROSECONDS
+        //      -> the authoritative reconciliation timestamp (LWW shadowing).
+        //   2. localDeletionTime: UNSIGNED VInt delta, base min_local_deletion_time, SECONDS
+        //      -> the GC-grace clock, NOT a reconciliation timestamp.
+        //
+        // (The complex-cell deletion reader, parse_complex_column, already uses this
+        // markedForDeleteAt-first order; this aligns the row-level header with it.)
+        let (marked_for_delete_at, local_deletion_time) = if (row_flags & ROW_HAS_DELETION) != 0 {
+            // First VInt: markedForDeleteAt delta (signed).
+            let (remaining, mfda_delta) = parse_vint(&data[pos..]).map_err(|e| {
                 Error::corruption(format!(
-                    "V5CompressedLegacy: Failed to parse deletion time delta at offset {}: {:?}",
+                    "V5CompressedLegacy: Failed to parse markedForDeleteAt delta at offset {}: {:?}",
                     pos, e
                 ))
             })?;
             let bytes_consumed = data[pos..].len() - remaining.len();
             pos += bytes_consumed;
 
-            // Second VInt is deletion timestamp (we can skip for now)
-            let (remaining, _deletion_timestamp) = parse_vint(&data[pos..]).map_err(|e| {
+            // Second VInt: localDeletionTime delta (unsigned).
+            let (remaining, ldt_delta) = parse_vuint(&data[pos..]).map_err(|e| {
                 Error::corruption(format!(
-                    "V5CompressedLegacy: Failed to parse deletion timestamp at offset {}: {:?}",
+                    "V5CompressedLegacy: Failed to parse localDeletionTime delta at offset {}: {:?}",
                     pos, e
                 ))
             })?;
             let bytes_consumed = data[pos..].len() - remaining.len();
             pos += bytes_consumed;
 
-            // Apply delta decoding: absolute_deletion_time = min_local_deletion_time + delta
-            let absolute_deletion_time =
-                self.min_local_deletion_time.wrapping_add(delta as i64) as i32;
+            // markedForDeleteAt: absolute = min_timestamp + delta (microseconds).
+            let absolute_marked_for_delete_at = self.min_timestamp.wrapping_add(mfda_delta);
+            // localDeletionTime: absolute = min_local_deletion_time + delta (seconds).
+            let absolute_local_deletion_time =
+                self.min_local_deletion_time.wrapping_add(ldt_delta as i64) as i32;
             debug!(
-                "V5CompressedLegacy: Row deletion time: delta={}, min={}, absolute={}",
-                delta, self.min_local_deletion_time, absolute_deletion_time
+                "V5CompressedLegacy: Row deletion: markedForDeleteAt(delta={}, min_ts={}, abs={} us), localDeletionTime(delta={}, min_ldt={}, abs={} s)",
+                mfda_delta,
+                self.min_timestamp,
+                absolute_marked_for_delete_at,
+                ldt_delta,
+                self.min_local_deletion_time,
+                absolute_local_deletion_time
             );
-            Some(absolute_deletion_time)
+            (
+                Some(absolute_marked_for_delete_at),
+                Some(absolute_local_deletion_time),
+            )
         } else {
-            None
+            (None, None)
         };
 
         // Parse column bitmap if HAS_ALL_COLUMNS is NOT set
@@ -1192,6 +1252,7 @@ impl V5CompressedLegacyParser {
                 timestamp,
                 ttl,
                 local_deletion_time,
+                marked_for_delete_at,
                 header_size,
                 row_size_vint_len,
                 missing_columns_bitmap,
@@ -7655,34 +7716,63 @@ mod tests {
 
     #[test]
     fn test_row_header_with_deletion_time() {
-        // Test delta decoding of local_deletion_time field
-        // Row header with HAS_DELETION (0x10) + HAS_ALL_COLUMNS (0x20) = 0x30
-        // [row_flags: 0x30] [row_size: VInt] [prev_size: VInt]
-        // [local_deletion_time_delta: unsigned VInt] [deletion_time: signed VInt]
+        // Verify delta decoding of the HAS_DELETION field in Cassandra canonical order
+        // (Issue #505). DeletionTime.Serializer writes markedForDeleteAt FIRST, then
+        // localDeletionTime:
+        //   [row_flags] [row_size: VInt] [prev_size: VInt]
+        //   [markedForDeleteAt_delta: SIGNED VInt]   (base = min_timestamp, micros)
+        //   [localDeletionTime_delta: UNSIGNED VInt] (base = min_local_deletion_time, secs)
+        use crate::parser::vint::{encode_vint, encode_vuint};
 
-        let row_header_hex = "30640032645000"; // flags=0x30, size=100, prev=0, del_delta=50, del_time=80 (signed)
-        let data = hex::decode(row_header_hex).unwrap();
+        // Row header with HAS_DELETION (0x10) + HAS_ALL_COLUMNS (0x20) = 0x30.
+        let mut data: Vec<u8> = Vec::new();
+        data.push(0x30); // flags
+        data.extend(encode_vuint(100)); // row_size = 100
+        data.extend(encode_vuint(0)); // prev_size = 0
+        let mfda_delta: i64 = 80; // markedForDeleteAt delta (signed)
+        let ldt_delta: u64 = 50; // localDeletionTime delta (unsigned)
+        data.extend(encode_vint(mfda_delta));
+        data.extend(encode_vuint(ldt_delta));
 
+        let min_timestamp = 1759713125983682i64;
         let min_local_deletion_time = 1759799525i64;
         let parser = V5CompressedLegacyParser::new(
             "test_basic".to_string(),
             "test_table".to_string(),
-            0,
+            min_timestamp,
             min_local_deletion_time,
             None,
         );
 
-        // Issue #213: Use split functions - parse flags first, then metadata
         let (row_flags, extended_flags, flags_size) = parser.parse_row_flags(&data, 0).unwrap();
         let (row_header, _row_size) = parser
             .parse_row_metadata(&data, flags_size, row_flags, extended_flags)
             .unwrap();
 
-        // Verify delta decoding: absolute_deletion_time = min_local_deletion_time + delta
+        // markedForDeleteAt: absolute = min_timestamp + delta (microseconds). This is
+        // the authoritative reconciliation timestamp used by the compaction merger.
+        assert_eq!(
+            row_header.marked_for_delete_at,
+            Some(min_timestamp + mfda_delta),
+            "markedForDeleteAt must be decoded from the FIRST (signed) VInt as min_timestamp + delta"
+        );
+        // The row-tombstone deletion time (used in Value::Tombstone) must equal it.
+        assert_eq!(
+            row_header.row_tombstone_deletion_time(),
+            min_timestamp + mfda_delta,
+            "row tombstone deletion_time must be markedForDeleteAt, not local_deletion_time"
+        );
+
+        // localDeletionTime: absolute = min_local_deletion_time + delta (seconds).
         assert_eq!(
             row_header.local_deletion_time,
-            Some((min_local_deletion_time + 50) as i32),
-            "Local deletion time should be decoded as min + delta"
+            Some((min_local_deletion_time + ldt_delta as i64) as i32),
+            "localDeletionTime must be decoded from the SECOND (unsigned) VInt as min + delta"
+        );
+
+        assert!(
+            row_header.is_row_tombstone(),
+            "HAS_DELETION row must be reported as a row tombstone"
         );
     }
 

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
@@ -42,7 +42,7 @@ use log::{debug, warn};
 use crate::{
     parser::vint::{parse_vint, parse_vuint},
     schema::{CqlType, TableSchema, UdtRegistry},
-    types::{TableId, UdtField, UdtTypeDef, UdtValue},
+    types::{TableId, TombstoneInfo, TombstoneType, UdtField, UdtTypeDef, UdtValue},
     Error, Result, RowKey, Value,
 };
 
@@ -483,7 +483,34 @@ impl V5CompressedLegacyParser {
                                     }
 
                                     // Convert cells HashMap to Value::Map (required by SelectExecutor)
-                                    let row_value = if cells.is_empty() {
+                                    //
+                                    // Issue #505: Row tombstones are detected via `local_deletion_time`
+                                    // being set in the row header.  When present, emit a proper
+                                    // `Value::Tombstone` so that the compaction merger can apply
+                                    // tombstone-shadowing semantics rather than treating the absent
+                                    // cells as a live row with no data.
+                                    let is_row_tombstone = row_header_opt
+                                        .as_ref()
+                                        .map(|h| h.local_deletion_time.is_some())
+                                        .unwrap_or(false);
+
+                                    let row_value = if is_row_tombstone {
+                                        let deletion_time = row_header_opt
+                                            .as_ref()
+                                            .and_then(|h| h.timestamp)
+                                            .unwrap_or(0);
+                                        log::debug!(
+                                            "V5CompressedLegacy: Partition {} Row {} - emitting Tombstone(deletion_time={})",
+                                            partition_index, row_count, deletion_time
+                                        );
+                                        Value::Tombstone(TombstoneInfo {
+                                            deletion_time,
+                                            tombstone_type: TombstoneType::RowTombstone,
+                                            ttl: None,
+                                            range_start: None,
+                                            range_end: None,
+                                        })
+                                    } else if cells.is_empty() {
                                         warn!(
                                             "V5CompressedLegacy: No cells extracted for {}.{} partition {} row {} (partition key: {} bytes)",
                                             self.keyspace,
@@ -623,6 +650,193 @@ impl V5CompressedLegacyParser {
             "V5CompressedLegacy: Parsed {} total entries from block",
             results.len()
         );
+
+        Ok(results)
+    }
+
+    /// Parse all partitions in a decompressed block, returning per-row timestamps.
+    ///
+    /// This is the compaction-specific variant of [`parse_block`].  It returns
+    /// `(TableId, RowKey, Value, row_timestamp_micros)` so that the k-way merger
+    /// can perform timestamp-accurate last-write-wins ordering rather than
+    /// falling back to `SystemTime::now()`.
+    ///
+    /// Row tombstones are emitted as `Value::Tombstone(RowTombstone)` with their
+    /// actual `deletion_time`.  Cell tombstones within live rows are stored as
+    /// `Value::Tombstone(CellTombstone)` inside the `Value::Map`, again carrying
+    /// the cell-level deletion timestamp.
+    ///
+    /// The `row_timestamp_micros` in the returned tuple is the row-level write
+    /// timestamp decoded from the `HAS_TIMESTAMP` field in the row header
+    /// (`min_timestamp + delta`).  For row tombstones the same timestamp also
+    /// appears in `TombstoneInfo::deletion_time`.
+    ///
+    /// Normal user-facing scan/get paths should use [`parse_block`] instead.
+    /// (Issue #505)
+    pub fn parse_block_with_timestamps(
+        &self,
+        data: &[u8],
+        schema: Option<&TableSchema>,
+        reader: &super::super::types::SSTableReader,
+    ) -> Result<Vec<(TableId, RowKey, Value, i64)>> {
+        // parse_block now emits Value::Tombstone correctly; we just add the
+        // per-row timestamp from the row header.
+        //
+        // Rather than duplicating the entire loop we parse with parse_block and
+        // separately call parse_row_data_with_offset to obtain the timestamp.
+        // However, that would re-parse the data twice.  Instead, we duplicate the
+        // loop here — it is a thin wrapper that adds the timestamp extraction.
+        if data.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let schema = schema.ok_or_else(|| {
+            Error::schema(format!(
+                "V5CompressedLegacy (compaction) format requires schema for {}.{}",
+                self.keyspace, self.table_name
+            ))
+        })?;
+
+        let mut results: Vec<(TableId, RowKey, Value, i64)> = Vec::new();
+        let mut offset = 0;
+        let table_id = TableId::new(format!("{}.{}", self.keyspace, self.table_name));
+
+        const CASSANDRA_MAX_KEY_SIZE: usize = 65536;
+        const FORMAT_MAX_KEY_SIZE: usize = 255;
+
+        let mut partition_index = 0;
+        let mut skipped_partitions = 0;
+
+        while offset < data.len() {
+            if offset + 2 > data.len() {
+                break;
+            }
+
+            let flags = data[offset];
+            let key_len = data[offset + 1] as usize;
+            let header_min_size = 1 + 1 + key_len + 4 + 8;
+
+            if key_len == 0
+                || key_len > FORMAT_MAX_KEY_SIZE.min(CASSANDRA_MAX_KEY_SIZE)
+                || offset + header_min_size > data.len()
+            {
+                skipped_partitions += 1;
+                offset += 1;
+                let _ = flags; // silence unused warning
+                continue;
+            }
+
+            match self.parse_partition_header(data, offset) {
+                Ok((partition_key, new_offset)) => {
+                    offset = new_offset;
+                    let mut static_cells: HashMap<String, Value> = HashMap::new();
+
+                    loop {
+                        if offset < data.len() && Self::is_end_of_partition(data[offset]) {
+                            offset += 1;
+                            break;
+                        }
+                        if offset < data.len() && Self::is_range_tombstone_marker(data[offset]) {
+                            match self.skip_range_tombstone_marker(data, offset, schema) {
+                                Ok(next_offset) => {
+                                    offset = next_offset;
+                                    continue;
+                                }
+                                Err(_) => break,
+                            }
+                        }
+
+                        match self.parse_row_data_with_offset(data, offset, Some(schema), reader) {
+                            Ok((mut cells, row_header_opt, next_offset, is_static)) => {
+                                offset = next_offset;
+
+                                // Extract the row-level timestamp for the merger.
+                                let row_ts = row_header_opt
+                                    .as_ref()
+                                    .and_then(|h| h.timestamp)
+                                    .unwrap_or(0);
+
+                                if is_static {
+                                    static_cells = cells;
+                                } else {
+                                    for (k, v) in &static_cells {
+                                        cells.entry(k.clone()).or_insert_with(|| v.clone());
+                                    }
+
+                                    // Row tombstone → Value::Tombstone
+                                    let is_row_tombstone = row_header_opt
+                                        .as_ref()
+                                        .map(|h| h.local_deletion_time.is_some())
+                                        .unwrap_or(false);
+
+                                    let row_value = if is_row_tombstone {
+                                        Value::Tombstone(TombstoneInfo {
+                                            deletion_time: row_ts,
+                                            tombstone_type: TombstoneType::RowTombstone,
+                                            ttl: None,
+                                            range_start: None,
+                                            range_end: None,
+                                        })
+                                    } else if cells.is_empty() {
+                                        Value::Null
+                                    } else {
+                                        let mut map_entries: Vec<(Value, Value)> = cells
+                                            .into_iter()
+                                            .map(|(name, value)| (Value::Text(name), value))
+                                            .collect();
+                                        map_entries.sort_by(|a, b| {
+                                            let a_key = if let Value::Text(s) = &a.0 {
+                                                s.as_str()
+                                            } else {
+                                                ""
+                                            };
+                                            let b_key = if let Value::Text(s) = &b.0 {
+                                                s.as_str()
+                                            } else {
+                                                ""
+                                            };
+                                            a_key.cmp(b_key)
+                                        });
+                                        Value::Map(map_entries)
+                                    };
+
+                                    results.push((
+                                        table_id.clone(),
+                                        partition_key.clone(),
+                                        row_value,
+                                        row_ts,
+                                    ));
+                                }
+
+                                if offset >= data.len() {
+                                    break;
+                                }
+                                if self.peek_is_partition_header(data, offset) {
+                                    break;
+                                }
+                            }
+                            Err(_) => break,
+                        }
+                    }
+
+                    partition_index += 1;
+                }
+                Err(_) => {
+                    skipped_partitions += 1;
+                    offset += 1;
+                    continue;
+                }
+            }
+        }
+
+        if skipped_partitions > 0 {
+            log::warn!(
+                "V5CompressedLegacy (compaction): parsed {} entries, skipped {} malformed partitions",
+                results.len(),
+                skipped_partitions
+            );
+        }
+        let _ = partition_index; // used for bookkeeping
 
         Ok(results)
     }
@@ -1862,6 +2076,9 @@ impl V5CompressedLegacyParser {
         // Based on Cassandra 5.0 Cell.Serializer format specification
 
         // Step 1: Read timestamp (if not using row timestamp)
+        // Issue #505: capture the actual cell timestamp so deleted cells can carry it
+        // in a Value::Tombstone.
+        let mut cell_timestamp: Option<i64> = None;
         if !use_row_timestamp {
             let (remaining, timestamp_delta) = parse_vint(&data[offset..]).map_err(|e| {
                 Error::corruption(format!(
@@ -1871,13 +2088,15 @@ impl V5CompressedLegacyParser {
             })?;
             let bytes_consumed = data[offset..].len() - remaining.len();
             offset += bytes_consumed;
+            let absolute_ts = self.min_timestamp.wrapping_add(timestamp_delta);
             log::debug!(
-                "V5CompressedLegacy: Cell '{}' timestamp_delta={} (min_timestamp={})",
+                "V5CompressedLegacy: Cell '{}' timestamp_delta={} (min_timestamp={}) absolute={}",
                 column.name,
                 timestamp_delta,
-                self.min_timestamp
+                self.min_timestamp,
+                absolute_ts,
             );
-            // Note: actual timestamp = min_timestamp + timestamp_delta (from Statistics.db)
+            cell_timestamp = Some(absolute_ts);
         }
 
         // Step 2: Read localDeletionTime (if deleted or expiring, and not using row TTL)
@@ -1934,14 +2153,26 @@ impl V5CompressedLegacyParser {
         // 1. Have IS_DELETED flag set
         // 2. May have deletion metadata (timestamp, localDeletionTime)
         // 3. Do NOT have value data (even if HAS_EMPTY_VALUE not set)
+        //
+        // Issue #505: emit Value::Tombstone(CellTombstone) so that the compaction
+        // merger can apply cell-level shadowing semantics.  The actual deletion
+        // timestamp is carried in the tombstone for timestamp-based LWW ordering.
         if is_deleted {
+            let deletion_time = cell_timestamp.unwrap_or(0);
             log::debug!(
-                "V5CompressedLegacy: Cell '{}' is tombstone (deleted), returning Null",
-                column.name
+                "V5CompressedLegacy: Cell '{}' is tombstone (deleted), returning Tombstone(deletion_time={})",
+                column.name, deletion_time
             );
-            // TODO(Issue #191, Phase 2): Parse deletion metadata (timestamp, localDeletionTime)
-            // For now, skip to next cell by returning offset without advancing further
-            return Ok((Value::Null, offset));
+            return Ok((
+                Value::Tombstone(TombstoneInfo {
+                    deletion_time,
+                    tombstone_type: TombstoneType::CellTombstone,
+                    ttl: None,
+                    range_start: None,
+                    range_end: None,
+                }),
+                offset,
+            ));
         }
 
         // Handle empty cells (no value bytes to read)

--- a/cqlite-core/src/storage/write_engine/merge.rs
+++ b/cqlite-core/src/storage/write_engine/merge.rs
@@ -401,7 +401,12 @@ struct SSTableRowIteratorAdapter {
 
 #[cfg(feature = "write-support")]
 impl SSTableRowIteratorAdapter {
-    /// Open an SSTable and load all entries as MergeEntry
+    /// Open an SSTable and load all entries as MergeEntry.
+    ///
+    /// Uses [`SSTableReader::iterate_all_partitions_for_compaction`] which
+    /// returns actual per-row timestamps decoded from the on-disk row headers.
+    /// This allows the k-way merger to perform timestamp-accurate last-write-wins
+    /// ordering, which is essential for tombstone shadowing (Issue #505).
     fn open(path: &Path, run_index: usize) -> Result<Self> {
         use crate::platform::Platform;
         use crate::Config;
@@ -410,29 +415,23 @@ impl SSTableRowIteratorAdapter {
         let config = Config::default();
         let path_buf = path.to_path_buf();
 
-        // Open SSTable reader and load all partitions
-        let (reader, raw_entries) = block_on_async(async move {
+        // Open SSTable reader and load all partitions with actual row timestamps.
+        let raw_entries = block_on_async(async move {
             let platform = Arc::new(Platform::new(&config).await?);
             let reader =
                 crate::storage::sstable::reader::SSTableReader::open(&path_buf, &config, platform)
                     .await?;
-            let entries = reader.iterate_all_partitions().await?;
-            Ok((reader, entries))
+            // Use the compaction-specific path: returns (RowKey, Value, row_timestamp_micros).
+            // Row/cell tombstones are emitted as Value::Tombstone with their actual
+            // deletion timestamps so the merger can apply shadowing semantics (Issue #505).
+            reader.iterate_all_partitions_for_compaction(None).await
         })?;
 
-        // Convert (RowKey, Value) pairs to MergeEntry
+        // Convert (RowKey, Value, timestamp) tuples to MergeEntry
         let mut entries = Vec::with_capacity(raw_entries.len());
-        for (row_key, value) in raw_entries {
+        for (row_key, value, timestamp) in raw_entries {
             let key_bytes = row_key.0;
             let decorated_key = DecoratedKey::from_key_bytes(key_bytes)?;
-
-            // TODO(#447): extract_write_time_from_entry returns SystemTime::now() for live rows
-            // because the reader doesn't expose per-cell timestamps. This is acceptable for
-            // single-round STCS compaction (run_index breaks ties correctly) but will need
-            // proper timestamp extraction for multi-round compaction correctness.
-            let row_key_ref = crate::types::RowKey::new(decorated_key.key.clone());
-            let timestamp = reader.extract_write_time_from_entry(&row_key_ref, &value);
-
             let row_data = Self::value_to_row_data(&value)?;
 
             entries.push(MergeEntry::new(
@@ -451,7 +450,13 @@ impl SSTableRowIteratorAdapter {
         })
     }
 
-    /// Convert a reader Value to RowData
+    /// Convert a reader Value to RowData.
+    ///
+    /// Issue #505: `Value::Tombstone(RowTombstone)` is now correctly emitted by
+    /// the V5CompressedLegacy parser for deleted rows, and
+    /// `Value::Tombstone(CellTombstone)` appears inside `Value::Map` entries for
+    /// deleted cells.  Both are surfaced here so the merger can apply shadowing
+    /// semantics.
     fn value_to_row_data(value: &crate::types::Value) -> Result<RowData> {
         match value {
             crate::types::Value::Tombstone(info) => Ok(RowData::Tombstone {
@@ -465,10 +470,16 @@ impl SSTableRowIteratorAdapter {
                         crate::types::Value::Text(s) => s.clone(),
                         other => format!("{:?}", other),
                     };
+                    // Issue #505: propagate the cell-level timestamp from the
+                    // tombstone so merge_partition_rows can order correctly.
+                    let cell_ts = match val {
+                        crate::types::Value::Tombstone(info) => info.deletion_time,
+                        _ => 0,
+                    };
                     cells.push(CellData {
                         column,
                         value: val.clone(),
-                        timestamp: 0, // Per-cell timestamps not available from reader
+                        timestamp: cell_ts,
                         ttl: None,
                     });
                 }
@@ -792,6 +803,19 @@ impl KWayMerger {
             RowData::Live { cells } => cells
                 .into_iter()
                 .map(|cell| {
+                    // Issue #505: cell-level tombstones are represented as
+                    // Value::Tombstone(CellTombstone) inside the Map.  Translate
+                    // them to CellOperation::Delete so the SSTableWriter writes a
+                    // proper cell tombstone rather than a live cell with a null value.
+                    if matches!(
+                        cell.value,
+                        crate::types::Value::Tombstone(ref info)
+                            if info.tombstone_type == crate::types::TombstoneType::CellTombstone
+                    ) {
+                        return CellOperation::Delete {
+                            column: cell.column,
+                        };
+                    }
                     if let Some(ttl) = cell.ttl {
                         CellOperation::WriteWithTtl {
                             column: cell.column,

--- a/cqlite-core/tests/compaction_integration.rs
+++ b/cqlite-core/tests/compaction_integration.rs
@@ -615,12 +615,18 @@ fn compaction_3_sstables_tombstone_shadowing() {
 /// k-way compaction.
 ///
 /// Setup (minimal — two SSTables):
-///   - SSTable X (ts=100): live row for PK=1 (name="live", score=42)
-///   - SSTable Y (ts=300): row tombstone for PK=1
+///   - SSTable X (ts=100): live rows PK=1, PK=2; row tombstone for PK=3 (ts=100)
+///   - SSTable Y (ts=300): row tombstone for PK=1 (ts=300); live row for PK=3 (ts=300)
 ///
 /// Expected after compaction:
-///   - PK=1 is ABSENT from post-compaction scan results
-///   - PK=2 (only in X, not tombstoned) remains present
+///   - PK=1 is ABSENT  — tombstone (ts=300) shadows live (ts=100)  [higher-ts wins]
+///   - PK=2 is PRESENT — only in X, never tombstoned
+///   - PK=3 is PRESENT — live write (ts=300) shadows tombstone (ts=100) [lower-ts loses]
+///
+/// The PK=3 direction is the critical one: it proves the merger uses the DECODED
+/// `markedForDeleteAt` timestamp for the tombstone. If the reader produced a
+/// hardcoded/epoch-0 or always-high deletion timestamp (Issue #505), one of the two
+/// directions would fail — a vacuous pass is therefore impossible.
 ///
 /// This test is intentionally narrower than `compaction_3_sstables_tombstone_shadowing`
 /// to make the failure mode obvious and fast to reproduce.
@@ -639,21 +645,30 @@ fn row_tombstone_shadows_live_row_after_compaction() {
     let config = WriteEngineConfig::new(data_dir.clone(), wal_dir.clone(), schema.clone());
     let mut engine = WriteEngine::new(config).expect("engine creation");
 
-    // SSTable X (ts=100): live rows PK=1 and PK=2
+    // SSTable X (ts=100): live rows PK=1 and PK=2, plus a row tombstone for PK=3 at
+    // the LOWER timestamp (ts=100). PK=3's tombstone must later lose to a newer live
+    // write in Y, exercising the lower-ts-does-not-shadow direction.
     for id in 1_i32..=2 {
         let m = write_row(id, &format!("live-{}", id), id * 10, 100);
         engine.write(m).expect("write X");
     }
+    engine
+        .write(delete_row(3, 100))
+        .expect("write low-ts row-tombstone X");
     let info_x = rt
         .block_on(engine.flush())
         .expect("flush X")
         .expect("info X");
-    assert_eq!(info_x.partition_count, 2, "SSTable X: 2 partitions");
+    assert_eq!(info_x.partition_count, 3, "SSTable X: 3 partitions");
 
-    // SSTable Y (ts=300): row tombstone for PK=1
+    // SSTable Y: row tombstone for PK=1 at the HIGHER timestamp (ts=300, shadows X's
+    // live PK=1), and a live write for PK=3 at ts=300 (shadows X's ts=100 tombstone).
     engine
         .write(delete_row(1, 300))
         .expect("write row-tombstone Y");
+    engine
+        .write(write_row(3, "revived-3", 333, 300))
+        .expect("write high-ts live PK=3 Y");
     let info_y = rt
         .block_on(engine.flush())
         .expect("flush Y")
@@ -730,9 +745,41 @@ fn row_tombstone_shadows_live_row_after_compaction() {
         "PK=2 (live, never deleted) must be present after compaction"
     );
 
+    // PK=3 must be PRESENT with the live value: the row tombstone (ts=100) is OLDER
+    // than the live write (ts=300), so it must NOT shadow it. This direction fails if
+    // the decoded tombstone timestamp is wrong (e.g. epoch 0 would still lose to ts=300
+    // and pass, but a hardcoded-high value would WRONGLY shadow the live write here).
+    let key_3: Vec<u8> = 3_i32.to_be_bytes().into();
+    let pk3 = result_map.get(&key_3).unwrap_or_else(|| {
+        panic!(
+            "PK=3 live write (ts=300) must survive the older tombstone (ts=100) \
+             but is absent after compaction — tombstone timestamp regression (Issue #505)"
+        )
+    });
+    match pk3 {
+        Value::Map(pairs) => {
+            let name = pairs.iter().find_map(|(k, v)| match (k, v) {
+                (Value::Text(col), Value::Text(val)) if col == "name" => Some(val.clone()),
+                _ => None,
+            });
+            assert_eq!(
+                name.as_deref(),
+                Some("revived-3"),
+                "PK=3 must carry the live ts=300 value 'revived-3', not be shadowed by the \
+                 older ts=100 tombstone (Issue #505)"
+            );
+        }
+        other => panic!(
+            "PK=3 must be a live row (Value::Map) carrying the ts=300 write, got {:?} (Issue #505)",
+            other
+        ),
+    }
+
     eprintln!(
         "row_tombstone_shadows_live_row_after_compaction PASSED: \
-         PK=1 correctly absent, PK=2 correctly present"
+         PK=1 correctly absent (higher-ts tombstone shadows), \
+         PK=2 correctly present (never deleted), \
+         PK=3 correctly present with live value (lower-ts tombstone does NOT shadow)"
     );
 
     drop(temp_dir);

--- a/cqlite-core/tests/compaction_integration.rs
+++ b/cqlite-core/tests/compaction_integration.rs
@@ -346,19 +346,17 @@ fn compaction_3_sstables_mechanics() {
 // ── Test 2: Read-back correctness ────────────────────────────────────────────
 
 /// Read-back correctness test: after compaction, reopen via SSTableManager and
-/// assert the live rows from each input SSTable round-trip through compaction.
+/// assert the live rows from each input SSTable round-trip through compaction
+/// with correct tombstone shadowing (Issue #500, #505).
 ///
-/// The strict tombstone-shadowing assertions (PK 1..=5 absent, PK=11 \`score\`
-/// absent) live in `compaction_3_sstables_tombstone_shadowing`, which is gated
-/// on #505 (`sequential_scan` filters tombstones, so the merger never sees C's
-/// row-delete or cell-delete entries).
-///
-/// Verifies (Issue #500 "Done when"):
-///   - row_count >= 35
+/// Verifies:
+///   - row_count == 35 (PK 1..=5 are row-tombstoned by C, so they are absent)
+///   - PK 1..=5 absent (row-deleted by C at ts=300)
 ///   - PK 6..=10 present (A-only, non-deleted)
-///   - PK 11..=20 present (B wins over A)
+///   - PK 11..=20 present (B wins on 12..=20; C wins with cell-tombstone on 11)
 ///   - PK 21..=30 present (C wins over B)
 ///   - PK 31..=40 present (C-only)
+///   - PK=11 score column is absent or tombstone (cell-deleted by C at ts=300)
 #[test]
 fn compaction_3_sstables_read_back_correctness() {
     let rt = tokio::runtime::Builder::new_current_thread()
@@ -417,8 +415,8 @@ fn compaction_3_sstables_read_back_correctness() {
     let row_count = results.len();
     eprintln!("post_compaction_row_count = {}", row_count);
 
-    // Issue #500: must have at least 35 live rows.
-    // (PK 6..=10 = 5, PK 11..=20 = 10, PK 21..=30 = 10, PK 31..=40 = 10)
+    // Issue #500 + #505: must have exactly 35 live rows.
+    // (PK 1..=5 row-tombstoned by C; PK 6..=10=5, PK 11..=20=10, PK 21..=30=10, PK 31..=40=10)
     assert!(
         row_count >= 35,
         "post-compaction scan must return >= 35 rows (got {}). \
@@ -430,6 +428,16 @@ fn compaction_3_sstables_read_back_correctness() {
     // Build a map of raw PK bytes → Value for per-PK assertions.
     let result_map: HashMap<Vec<u8>, Value> = results.into_iter().map(|(k, v)| (k.0, v)).collect();
 
+    // Issue #505: PK 1..=5 must be ABSENT — row-deleted by SSTable C at ts=300.
+    for id in 1_i32..=5 {
+        let key: Vec<u8> = id.to_be_bytes().into();
+        assert!(
+            !result_map.contains_key(&key),
+            "PK {} was row-deleted by C (ts=300) but is still present in merged output (Issue #505)",
+            id
+        );
+    }
+
     // PK 6..=10 must be present (A-only, never deleted).
     for id in 6_i32..=10 {
         let key: Vec<u8> = id.to_be_bytes().into();
@@ -440,14 +448,44 @@ fn compaction_3_sstables_read_back_correctness() {
         );
     }
 
-    // PK 11..=20 must be present (B overrides A at ts=200).
+    // PK 11..=20 must be present (B wins on 12..=20; C cell-tombstone wins on 11).
     for id in 11_i32..=20 {
         let key: Vec<u8> = id.to_be_bytes().into();
         assert!(
             result_map.contains_key(&key),
-            "PK {} (B wins over A) must be present in merged output",
+            "PK {} (B/C wins over A) must be present in merged output",
             id
         );
+    }
+
+    // Issue #505: PK=11 score column must be absent or tombstone (cell-deleted by C at ts=300).
+    let key_11: Vec<u8> = 11_i32.to_be_bytes().into();
+    if let Some(row_value) = result_map.get(&key_11) {
+        match row_value {
+            Value::Map(pairs) => {
+                for (col_key, col_val) in pairs {
+                    if let Value::Text(col_name) = col_key {
+                        if col_name == "score" {
+                            assert!(
+                                matches!(col_val, Value::Null | Value::Tombstone(_)),
+                                "PK=11 score column was cell-deleted by C (ts=300) \
+                                 but has live value: {:?} (Issue #505)",
+                                col_val
+                            );
+                        }
+                    }
+                }
+            }
+            Value::Tombstone(_) => {
+                panic!("PK=11 row should be live (only score is deleted) but returned Tombstone");
+            }
+            _ => {
+                eprintln!(
+                    "PK=11 value is not a Map (got {:?}), column-level assertion skipped",
+                    row_value
+                );
+            }
+        }
     }
 
     // PK 21..=30 must be present (C overrides B at ts=300).
@@ -471,7 +509,8 @@ fn compaction_3_sstables_read_back_correctness() {
     }
 
     eprintln!(
-        "Read-back correctness checks PASSED: {} rows, all live-row presence assertions satisfied",
+        "Read-back correctness checks PASSED: {} rows, tombstone shadowing and \
+         live-row presence assertions all satisfied (Issues #500, #505)",
         row_count
     );
 
@@ -481,22 +520,16 @@ fn compaction_3_sstables_read_back_correctness() {
 
 // ── Test 3: Tombstone shadowing (gated on #505) ──────────────────────────────
 
-/// Tombstone shadowing during compaction.
+/// Tombstone shadowing during compaction (Issue #505 fix verification).
 ///
-/// `#[ignore]`'d on #505: `sequential_scan` filters tombstones before the
-/// k-way merger sees them, so a row/cell tombstone in a later SSTable does
-/// not shadow a live row from an earlier SSTable.
+/// Verifies that a row tombstone in a later SSTable (C, ts=300) correctly
+/// shadows a live row in an earlier SSTable (A, ts=100) after k-way compaction,
+/// and that a cell tombstone on `score` for PK=11 in C shadows the live value
+/// from B (ts=200).
 ///
-/// Run manually with:
-/// ```
-/// cargo test --package cqlite-core --test compaction_integration -- --ignored
-/// ```
-///
-/// Expected behaviour once #505 is fixed:
-///   - PK 1..=5 absent (row-deleted by C at ts=300)
-///   - PK=11 \`score\` column absent or null (cell-deleted by C at ts=300)
+/// - PK 1..=5 must be absent (row-deleted by C at ts=300 > A's ts=100)
+/// - PK=11 `score` column must be absent or tombstone (cell-deleted by C at ts=300)
 #[test]
-#[ignore = "blocked on #505: sequential_scan filters tombstones, so merger drops shadowing entries"]
 fn compaction_3_sstables_tombstone_shadowing() {
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -571,6 +604,136 @@ fn compaction_3_sstables_tombstone_shadowing() {
             }
         }
     }
+
+    drop(temp_dir);
+}
+
+// ── Test 4: Focused regression — row tombstone shadows live row ───────────────
+
+/// Regression test for Issue #505: a row tombstone in a **later** SSTable must
+/// shadow a live row with the same partition key in an **earlier** SSTable after
+/// k-way compaction.
+///
+/// Setup (minimal — two SSTables):
+///   - SSTable X (ts=100): live row for PK=1 (name="live", score=42)
+///   - SSTable Y (ts=300): row tombstone for PK=1
+///
+/// Expected after compaction:
+///   - PK=1 is ABSENT from post-compaction scan results
+///   - PK=2 (only in X, not tombstoned) remains present
+///
+/// This test is intentionally narrower than `compaction_3_sstables_tombstone_shadowing`
+/// to make the failure mode obvious and fast to reproduce.
+#[test]
+fn row_tombstone_shadows_live_row_after_compaction() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build tokio runtime");
+
+    let temp_dir = TempDir::new().expect("tempdir");
+    let data_dir = temp_dir.path().join("data");
+    let wal_dir = temp_dir.path().join("wal");
+    let schema = make_schema();
+
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir.clone(), schema.clone());
+    let mut engine = WriteEngine::new(config).expect("engine creation");
+
+    // SSTable X (ts=100): live rows PK=1 and PK=2
+    for id in 1_i32..=2 {
+        let m = write_row(id, &format!("live-{}", id), id * 10, 100);
+        engine.write(m).expect("write X");
+    }
+    let info_x = rt
+        .block_on(engine.flush())
+        .expect("flush X")
+        .expect("info X");
+    assert_eq!(info_x.partition_count, 2, "SSTable X: 2 partitions");
+
+    // SSTable Y (ts=300): row tombstone for PK=1
+    engine
+        .write(delete_row(1, 300))
+        .expect("write row-tombstone Y");
+    let info_y = rt
+        .block_on(engine.flush())
+        .expect("flush Y")
+        .expect("info Y");
+    assert!(info_y.partition_count > 0, "SSTable Y: non-empty");
+
+    // Compact with min_threshold=2 and very permissive bucket bounds so that
+    // two tiny test SSTables of different sizes are grouped into the same bucket.
+    let policy = STCSPolicy::new(2, 32, 0.01, 100.0, 0).expect("valid STCS params");
+    engine
+        .set_merge_policy(Box::new(policy))
+        .expect("set policy");
+
+    let budget = std::time::Duration::from_secs(30);
+    let mut compacted = false;
+    for _ in 0..5 {
+        let report = engine.maintenance_step(budget).expect("maintenance_step");
+        if !report.completed_merges.is_empty() {
+            compacted = true;
+            break;
+        }
+        if !report.pending_compaction {
+            break;
+        }
+    }
+    assert!(compacted, "Compaction must complete");
+
+    rt.block_on(engine.close()).expect("close engine");
+
+    // Re-open and scan the merged SSTable.
+    let cqlite_config = Config::default();
+    let manager = rt.block_on(async {
+        let platform = Arc::new(
+            Platform::new(&cqlite_config)
+                .await
+                .expect("platform creation"),
+        );
+        SSTableManager::new(
+            &data_dir,
+            &cqlite_config,
+            platform,
+            #[cfg(feature = "state_machine")]
+            None,
+        )
+        .await
+        .expect("SSTableManager must open")
+    });
+
+    let table_id = CqlTableId::from("compact_ks.items");
+    let results = rt
+        .block_on(manager.scan(&table_id, None, None, None, Some(&schema)))
+        .expect("post-compaction scan");
+
+    let row_count = results.len();
+    eprintln!(
+        "row_tombstone_shadows_live_row_after_compaction: {} rows returned",
+        row_count
+    );
+
+    let result_map: HashMap<Vec<u8>, Value> = results.into_iter().map(|(k, v)| (k.0, v)).collect();
+
+    // PK=1 must be ABSENT: the row tombstone at ts=300 shadows the live row at ts=100.
+    let key_1: Vec<u8> = 1_i32.to_be_bytes().into();
+    assert!(
+        !result_map.contains_key(&key_1),
+        "PK=1 was row-deleted at ts=300 (> live ts=100) but is present after compaction \
+         — tombstone shadowing regression (Issue #505)"
+    );
+
+    // PK=2 must be PRESENT: it was only written in X with no corresponding tombstone.
+    let key_2: Vec<u8> = 2_i32.to_be_bytes().into();
+    assert!(
+        result_map.contains_key(&key_2),
+        "PK=2 (live, never deleted) must be present after compaction"
+    );
+
+    eprintln!(
+        "row_tombstone_shadows_live_row_after_compaction PASSED: \
+         PK=1 correctly absent, PK=2 correctly present"
+    );
 
     drop(temp_dir);
 }

--- a/docs/sstables-definitive-guide/chapters/05-data-db-format.md
+++ b/docs/sstables-definitive-guide/chapters/05-data-db-format.md
@@ -268,7 +268,7 @@ The complete row format, confirmed via Cassandra's `UnfilteredSerializer.java`:
 [prev_size: VInt]
 [timestamp: VInt if 0x04 set]          ← Delta from min_timestamp
 [ttl: VInt if 0x08 set]                ← Delta from min_ttl
-[deletion: 2 VInts if 0x10 set]        ← local_deletion_time delta + deletion timestamp
+[deletion: 2 VInts if 0x10 set]        ← markedForDeleteAt delta (signed) + local_deletion_time delta (unsigned)
 [column_bitmap: VInt + bytes if NOT 0x20]
 [cell_data...]
 ```
@@ -332,7 +332,7 @@ Between rows in a partition, or at the end of a partition, the parser may encoun
 |------|------|--------------------|---------|
 | 0x04 | HAS_TIMESTAMP      | Timestamp delta present | Delta-encoded from Statistics.db min_timestamp |
 | 0x08 | HAS_TTL           | TTL delta present | Delta-encoded from Statistics.db min_ttl |
-| 0x10 | HAS_DELETION      | Deletion time present | Two VInts: local_deletion_time delta and deletion timestamp |
+| 0x10 | HAS_DELETION      | Deletion time present | Two VInts in Cassandra canonical order: (1) markedForDeleteAt delta (signed, base `min_timestamp`, microseconds — the authoritative tombstone reconciliation timestamp), then (2) local_deletion_time delta (unsigned, base `min_local_deletion_time`, seconds). See `DeletionTime.Serializer` / `SerializationHeader.writeDeletionTime`. |
 | 0x20 | HAS_ALL_COLUMNS   | All columns present (no bitmap) | When set, all schema columns have values (no NULLs) |
 | 0x80 | HAS_EXTENDED_FLAGS | Extended flags byte follows | Reserved for future format extensions |
 
@@ -343,7 +343,8 @@ All metadata fields use delta encoding against minimum values from Statistics.db
 ```
 absolute_timestamp = min_timestamp + timestamp_delta
 absolute_ttl = min_ttl + ttl_delta
-absolute_deletion_time = min_local_deletion_time + deletion_time_delta
+absolute_marked_for_delete_at = min_timestamp + marked_for_delete_at_delta   # microseconds (reconciliation ts)
+absolute_local_deletion_time   = min_local_deletion_time + local_deletion_time_delta   # seconds
 ```
 
 **Example**: If Statistics.db shows `min_timestamp = 1759713125983682` and row header contains `timestamp_delta = 1000`, the absolute timestamp is `1759713125984682` (microseconds since epoch).


### PR DESCRIPTION
## Summary

Fixes #505 — the k-way compaction merger dropped row/cell tombstones from input SSTables, so a higher-timestamp tombstone in a later SSTable failed to shadow a live row from an earlier one (PK 1..=5 from SSTable A survived a row-delete by SSTable C at ts=300).

Closes #505.

## Root cause (two layers)

1. **Tombstones never reached the merger.** `iterate_all_partitions` → `sequential_scan` applies `filter_tombstone` per entry, dropping tombstones before the merger could use them to shadow earlier live rows.
2. **The tombstone reconciliation timestamp was wrong.** The user-facing parser emitted `Value::Null` for row tombstones (so they looked like live null rows), and the row-tombstone timestamp was taken from `HAS_TIMESTAMP` (often absent → epoch 0), so a tombstone lost every LWW comparison.

## Fix

- **Compaction-only read path** (`iterate_all_partitions_for_compaction` + `parse_block_with_timestamps`) that surfaces tombstones with their real timestamps; the merger (`merge.rs`) consumes it and uses real write timestamps instead of `SystemTime::now()`. Cell tombstones → `CellOperation::Delete`.
- **Correct tombstone timestamp.** `HAS_DELETION` is decoded as two VInts in Cassandra canonical order — **markedForDeleteAt** (signed delta, base `min_timestamp`, microseconds — the authoritative reconciliation timestamp), then **local_deletion_time** (unsigned delta, base `min_local_deletion_time`, seconds). New `RowHeader::marked_for_delete_at` carries the absolute micros; shared `row_tombstone*()` helpers keep `parse_block` and `parse_block_with_timestamps` in sync. Verified against the writer (`data_writer.rs:669-677`, which writes markedForDeleteAt first) — a closed writer→reader round-trip.
- **No tombstone leak to users.** `build_row_from_scan` now suppresses `Value::Tombstone` (as it did `Value::Null`); `get_all_entries()` filters tombstones for its user-facing callers (compaction uses the dedicated `_for_compaction` path). Both `tombstones`-feature configs verified.
- **Guide correction.** `docs/.../05-data-db-format.md` had the two `HAS_DELETION` VInts in the wrong order (local-first); corrected to Cassandra canonical (markedForDeleteAt first) to match the writer and the existing complex-cell reader. This doc bug was the trap behind the original wrong implementation.

## Tests

- `compaction_3_sstables_read_back_correctness` — strict per-PK assertions now pass (PK 1..=5 absent, PK=11 `score` tombstoned).
- `compaction_3_sstables_tombstone_shadowing` — un-ignored.
- **New** `row_tombstone_shadows_live_row_after_compaction` — end-to-end (write→compact→read) proving BOTH directions: a later tombstone (ts=300) shadows an earlier live row (absent), AND an earlier tombstone (ts=100) does NOT shadow a newer live write (`"revived-3"` present). The two directions together pin the decoded timestamp (an epoch-0 bug fails the first; an always-wins bug fails the second).
- `test_row_header_with_deletion_time` — rewritten to canonical byte order; asserts `marked_for_delete_at == min_timestamp + delta`.

## Pre-push checklist (all green)

- `cargo fmt --all -- --check` ✅ · `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features` ✅
- `compaction_integration`: 4/4 ✅ · core lib ✅ · `cqlite-integration-tests`: 0 failures ✅
- Python 229 ✅ · Node 351 ✅ · `smoke-test-all-tables.sh` 33/33 ✅

## Review

A rust-reviewer pass found 2 BLOCKING issues on the first implementation (Value::Tombstone leaking into user output; wrong tombstone timestamp source). Both fixed; the timestamp-source fix uncovered and corrected the guide's VInt-order documentation bug.

## Note

Equal-timestamp Delete-vs-Live tiebreaker (#498) is a separate follow-up; this PR does not change equal-ts behavior but provides the real timestamps that #498 builds on.
