### PR TITLE
fix(compaction): tombstone wins equal-timestamp reconcile per Cassandra Cells#reconcile (closes #498)

### DIFF
--- a/cqlite-core/src/storage/write_engine/merge.rs
+++ b/cqlite-core/src/storage/write_engine/merge.rs
@@ -11,11 +11,17 @@
 //!
 //! ## Ordering
 //!
-//! Entries are ordered by:
+//! The `Ord`/`PartialOrd` impl on `MergeEntry` governs **heap routing only**
+//! (which partition/clustering bucket an entry belongs to) — NOT winner
+//! selection. Winner selection among entries with the same clustering key is
+//! done by `merge_partition_rows` (see "Cell Merge Rule" below), which layers a
+//! timestamp + liveness comparison on top.
+//!
+//! Heap-routing order:
 //! 1. Token (ascending) - Primary partitioning
 //! 2. Key bytes (ascending) - Hash collision resolution
 //! 3. Clustering key (schema-aware) - Within partition ordering
-//! 4. Run index (ascending) - Last-write-wins for equal timestamps
+//! 4. Run index (ascending) - Stable tiebreak for routing (NOT the LWW rule)
 //!
 //! ## Memory Budget
 //!
@@ -88,13 +94,17 @@ impl MergeEntry {
     }
 }
 
-/// Ord implementation for min-heap ordering
+/// Ord implementation for min-heap routing ONLY (not LWW winner selection).
+///
+/// This orders entries so the heap yields them grouped by partition and
+/// clustering key. The actual equal-timestamp Delete-vs-Live winner is chosen
+/// in `merge_partition_rows` (timestamp → liveness → run_index), NOT here.
 ///
 /// Order by:
 /// 1. Token (ascending)
 /// 2. Key bytes (ascending, for hash collisions)
 /// 3. Clustering key (ascending, schema-aware)
-/// 4. Run index (ascending, lower = newer = wins in LWW)
+/// 4. Run index (ascending) - stable routing tiebreak only
 #[cfg(feature = "write-support")]
 impl Ord for MergeEntry {
     fn cmp(&self, other: &Self) -> Ordering {

--- a/cqlite-core/src/storage/write_engine/merge.rs
+++ b/cqlite-core/src/storage/write_engine/merge.rs
@@ -24,9 +24,11 @@
 //!
 //! ## Cell Merge Rule
 //!
-//! Last-write-wins by timestamp:
-//! - Keep cell with highest timestamp
-//! - If timestamps equal, prefer lower run_index (newer file)
+//! Last-write-wins by timestamp, following Cassandra `Cells#reconcile`:
+//! - Keep the entry with the highest timestamp.
+//! - If timestamps are equal, the tombstone (Delete) wins over a live entry,
+//!   independent of which file it came from (Issue #498).
+//! - If timestamp AND liveness are equal, prefer the lower run_index (newer file).
 //!
 //! Implementation for M5.2 (Issue #382)
 
@@ -733,7 +735,25 @@ impl KWayMerger {
         Ok(())
     }
 
-    /// Merge rows within a single partition (last-write-wins by timestamp)
+    /// Liveness priority used as the equal-timestamp tiebreaker.
+    ///
+    /// Cassandra's reconcile rule (`Cells#reconcile`) gives the tombstone (Delete)
+    /// precedence over a live cell/row at the SAME timestamp. We model this with a
+    /// numeric priority where a HIGHER value wins: a row tombstone (Delete) returns
+    /// `1`, a live row returns `0`. The caller sorts so that the higher priority
+    /// sorts first at equal timestamp. (Issue #498)
+    fn tombstone_priority(entry: &MergeEntry) -> u8 {
+        match entry.row_data {
+            RowData::Tombstone { .. } => 1,
+            RowData::Live { .. } => 0,
+        }
+    }
+
+    /// Merge rows within a single partition (last-write-wins by timestamp).
+    ///
+    /// At equal timestamps the tombstone wins (Cassandra `Cells#reconcile`), and
+    /// only when timestamp and liveness are equal does the lower run_index (newer
+    /// file) win. See [`Self::tombstone_priority`].
     fn merge_partition_rows(&self, rows: Vec<MergeEntry>) -> Result<Vec<MergeEntry>> {
         use std::collections::BTreeMap;
 
@@ -747,21 +767,34 @@ impl KWayMerger {
                 .push(row);
         }
 
-        // Merge cells for each clustering key
+        // Merge cells for each clustering key.
+        //
+        // Resolution order (Cassandra `org.apache.cassandra.db.rows.Cells#reconcile`):
+        //   1. timestamp        — higher wins (last-write-wins).
+        //   2. liveness         — at EQUAL timestamp, a Delete (tombstone) beats a
+        //                         Live row. This is independent of which file the
+        //                         entries came from. (Issue #498)
+        //   3. run_index        — only when timestamp AND liveness are equal, the
+        //                         lower run_index (newer file) wins.
+        //
+        // This comparator is total and transitive: each level only acts as a
+        // tiebreak for the previous, and the final `run_index.cmp` is itself total.
         let mut merged = Vec::new();
         for (_ck, mut cluster_rows) in clustered_rows {
-            // Sort by timestamp (descending) then run_index (ascending)
             cluster_rows.sort_by(|a, b| {
-                match b.timestamp.cmp(&a.timestamp) {
-                    Ordering::Equal => {
-                        // Equal timestamps: prefer lower run_index (newer file)
-                        a.run_index.cmp(&b.run_index)
-                    }
-                    other => other,
-                }
+                // Primary: higher timestamp first (descending).
+                b.timestamp
+                    .cmp(&a.timestamp)
+                    // Secondary: at equal timestamp, tombstone (Delete) wins.
+                    // `is_tombstone() == true` must sort BEFORE a live row, so we
+                    // compare `b`'s liveness against `a`'s to keep descending order.
+                    .then_with(|| Self::tombstone_priority(b).cmp(&Self::tombstone_priority(a)))
+                    // Tertiary: lower run_index (newer file) wins.
+                    .then_with(|| a.run_index.cmp(&b.run_index))
             });
 
-            // Take the first entry (highest timestamp, or lowest run_index if tied)
+            // Take the first entry: highest timestamp, then tombstone at equal ts,
+            // then lowest run_index.
             if let Some(winner) = cluster_rows.into_iter().next() {
                 merged.push(winner);
             }
@@ -1141,6 +1174,96 @@ mod tests {
             }
             _ => panic!("Expected Tombstone"),
         }
+    }
+
+    #[test]
+    fn test_real_merger_delete_wins_at_equal_timestamp() {
+        // Issue #498: at EQUAL timestamp, a Delete (tombstone) must beat a Live
+        // row regardless of file recency (Cassandra `Cells#reconcile`).
+        //
+        // We drive the REAL merger entry point (`merge_partition_rows`) with two
+        // entries that share the SAME clustering key and the SAME timestamp:
+        //   - A: Live, run_index 0  (the NEWER file — would win a run_index tiebreak)
+        //   - B: Delete, run_index 1 (the OLDER file)
+        //
+        // The pre-fix merger sorted equal-timestamp ties by run_index only, so the
+        // live row (run_index 0) would win and survive. With the fix the tombstone
+        // wins. This test therefore FAILS if the tiebreak reverts to run_index.
+        use crate::schema::{Column, KeyColumn, TableSchema};
+        use std::collections::HashMap;
+
+        let schema = TableSchema {
+            keyspace: "reconcile_ks".to_string(),
+            table: "reconcile_tbl".to_string(),
+            partition_keys: vec![KeyColumn {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![],
+            columns: vec![Column {
+                name: "value".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            }],
+            comments: HashMap::new(),
+        };
+
+        const EQUAL_TS: i64 = 1_700_000_000_000_000;
+
+        let partition_key = DecoratedKey::new(100, vec![0, 0, 0, 1]);
+
+        // A = Live, in the NEWER file (run_index 0).
+        let live_entry = MergeEntry::new(
+            0,
+            partition_key.clone(),
+            None,
+            EQUAL_TS,
+            RowData::Live {
+                cells: vec![CellData {
+                    column: "value".to_string(),
+                    value: Value::Text("survivor-if-buggy".to_string()),
+                    timestamp: EQUAL_TS,
+                    ttl: None,
+                }],
+            },
+        );
+
+        // B = Delete (row tombstone), in the OLDER file (run_index 1).
+        let tombstone_entry = MergeEntry::new(
+            1,
+            partition_key.clone(),
+            None,
+            EQUAL_TS,
+            RowData::Tombstone {
+                deletion_time: EQUAL_TS,
+                local_deletion_time: 2_000_000,
+            },
+        );
+
+        let merger = KWayMerger {
+            runs: vec![],
+            heap: BinaryHeap::new(),
+            current_partition: None,
+            schema,
+        };
+
+        // Drive the real merger. Order the input so the live (newer-file) entry is
+        // first — pre-fix this is exactly the entry that wins by run_index.
+        let merged = merger
+            .merge_partition_rows(vec![live_entry, tombstone_entry])
+            .expect("merge_partition_rows must not fail");
+
+        assert_eq!(merged.len(), 1, "one clustering key => one merged winner");
+
+        assert!(
+            matches!(merged[0].row_data, RowData::Tombstone { .. }),
+            "At equal timestamp the tombstone must win even though the live row is in \
+             the newer file (run_index 0). Got a live row => the equal-ts tiebreak \
+             reverted to run_index (Issue #498 regression)."
+        );
     }
 
     #[test]
@@ -2093,8 +2216,12 @@ mod merge_property_tests {
                 columns: vec![("ck".to_string(), Value::TinyInt(0))],
             };
 
+            // Deliberately give the LIVE row the NEWER file (run_index 0) and the
+            // tombstone the OLDER file (run_index 1). A run_index-only tiebreak at
+            // equal timestamp would wrongly pick the live row; the Cassandra
+            // liveness rule must pick the tombstone regardless of file recency.
             let live_entry = MergeEntry::new(
-                1, // run_index 1 = older file
+                0, // run_index 0 = newer file
                 partition_key.clone(),
                 Some(ck.clone()),
                 ts_write,
@@ -2108,7 +2235,7 @@ mod merge_property_tests {
                 },
             );
             let tombstone_entry = MergeEntry::new(
-                0, // run_index 0 = newer file
+                1, // run_index 1 = older file
                 partition_key.clone(),
                 Some(ck.clone()),
                 ts_delete,
@@ -2144,8 +2271,17 @@ mod merge_property_tests {
                     "Live(ts={}) must win over Tombstone(ts={})",
                     ts_write, ts_delete
                 );
+            } else {
+                // Equal timestamps: the tombstone (Delete) ALWAYS wins, matching
+                // Cassandra `Cells#reconcile`. This must hold regardless of file
+                // recency — the assertion previously carved this case out, hiding
+                // the run_index-only tiebreak bug (Issue #498).
+                prop_assert!(
+                    matches!(winner.row_data, RowData::Tombstone { .. }),
+                    "At equal ts={}, Tombstone must win over Live (Cassandra reconcile rule)",
+                    ts_delete
+                );
             }
-            // Equal timestamps: run_index 0 (tombstone) wins (newer file) — current merger behaviour.
         }
     }
 }

--- a/cqlite-core/tests/compaction_integration.rs
+++ b/cqlite-core/tests/compaction_integration.rs
@@ -821,11 +821,17 @@ fn test_real_merger_delete_wins_at_equal_timestamp() {
 
     const EQUAL_TS: i64 = 200;
 
-    // SSTable A: live PK=1 at ts=200 (the "newer" live write candidate), plus a
+    // Adversarial setup for #498: the tombstone goes in the OLDER file and the
+    // live write in the NEWER file. The pre-fix tiebreak (equal ts → lower
+    // run_index = newer file wins) would therefore pick the LIVE write and keep
+    // PK=1, so this test fails without the fix. The fix (equal ts → tombstone
+    // wins, independent of file recency) makes PK=1 absent.
+
+    // SSTable A (flushed first = OLDER): row tombstone for PK=1 at ts=200, plus a
     // live PK=2 control that is never deleted.
     engine
-        .write(write_row(1, "live-at-equal-ts", 11, EQUAL_TS))
-        .expect("write live PK=1 A");
+        .write(delete_row(1, EQUAL_TS))
+        .expect("write equal-ts row-tombstone A");
     engine
         .write(write_row(2, "control-live", 22, EQUAL_TS))
         .expect("write live PK=2 A");
@@ -835,10 +841,10 @@ fn test_real_merger_delete_wins_at_equal_timestamp() {
         .expect("info A");
     assert_eq!(info_a.partition_count, 2, "SSTable A: 2 partitions");
 
-    // SSTable B: row tombstone for PK=1 at the SAME timestamp ts=200.
+    // SSTable B (flushed second = NEWER): live PK=1 at the SAME timestamp ts=200.
     engine
-        .write(delete_row(1, EQUAL_TS))
-        .expect("write equal-ts row-tombstone B");
+        .write(write_row(1, "live-at-equal-ts", 11, EQUAL_TS))
+        .expect("write live PK=1 B");
     let info_b = rt
         .block_on(engine.flush())
         .expect("flush B")

--- a/cqlite-core/tests/compaction_integration.rs
+++ b/cqlite-core/tests/compaction_integration.rs
@@ -784,3 +784,137 @@ fn row_tombstone_shadows_live_row_after_compaction() {
 
     drop(temp_dir);
 }
+
+// ── Test 5: Equal-timestamp Delete-vs-Live reconcile (Issue #498) ─────────────
+
+/// Regression test for Issue #498: when a live row and a row tombstone for the
+/// SAME partition key carry the EXACT SAME timestamp, the tombstone must win
+/// after compaction — matching Cassandra `org.apache.cassandra.db.rows.Cells#reconcile`,
+/// independent of which SSTable (file) the entries came from.
+///
+/// Setup (two SSTables, identical timestamp ts=200):
+///   - SSTable A (flushed FIRST): live row PK=1 (ts=200), plus a live PK=2 control.
+///   - SSTable B (flushed SECOND): row tombstone for PK=1 (ts=200).
+///
+/// The pre-fix merger resolved equal-timestamp conflicts by run_index (file
+/// recency) only, so whichever file "won" the tie would decide liveness. With the
+/// fix the tombstone always wins at equal timestamp regardless of file order.
+///
+/// Expected after compaction:
+///   - PK=1 ABSENT  — the equal-ts tombstone shadows the live row.
+///   - PK=2 PRESENT — live, never deleted (proves the merge produced output and
+///     the absence of PK=1 is not a vacuous empty result).
+#[test]
+fn test_real_merger_delete_wins_at_equal_timestamp() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build tokio runtime");
+
+    let temp_dir = TempDir::new().expect("tempdir");
+    let data_dir = temp_dir.path().join("data");
+    let wal_dir = temp_dir.path().join("wal");
+    let schema = make_schema();
+
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir.clone(), schema.clone());
+    let mut engine = WriteEngine::new(config).expect("engine creation");
+
+    const EQUAL_TS: i64 = 200;
+
+    // SSTable A: live PK=1 at ts=200 (the "newer" live write candidate), plus a
+    // live PK=2 control that is never deleted.
+    engine
+        .write(write_row(1, "live-at-equal-ts", 11, EQUAL_TS))
+        .expect("write live PK=1 A");
+    engine
+        .write(write_row(2, "control-live", 22, EQUAL_TS))
+        .expect("write live PK=2 A");
+    let info_a = rt
+        .block_on(engine.flush())
+        .expect("flush A")
+        .expect("info A");
+    assert_eq!(info_a.partition_count, 2, "SSTable A: 2 partitions");
+
+    // SSTable B: row tombstone for PK=1 at the SAME timestamp ts=200.
+    engine
+        .write(delete_row(1, EQUAL_TS))
+        .expect("write equal-ts row-tombstone B");
+    let info_b = rt
+        .block_on(engine.flush())
+        .expect("flush B")
+        .expect("info B");
+    assert!(info_b.partition_count > 0, "SSTable B: non-empty");
+
+    // Permissive STCS so the two tiny SSTables compact together.
+    let policy = STCSPolicy::new(2, 32, 0.01, 100.0, 0).expect("valid STCS params");
+    engine
+        .set_merge_policy(Box::new(policy))
+        .expect("set policy");
+
+    let budget = Duration::from_secs(30);
+    let mut compacted = false;
+    for _ in 0..5 {
+        let report = engine.maintenance_step(budget).expect("maintenance_step");
+        if !report.completed_merges.is_empty() {
+            compacted = true;
+            break;
+        }
+        if !report.pending_compaction {
+            break;
+        }
+    }
+    assert!(compacted, "Compaction must complete");
+
+    rt.block_on(engine.close()).expect("close engine");
+
+    // Re-open and scan the merged SSTable.
+    let cqlite_config = Config::default();
+    let manager = rt.block_on(async {
+        let platform = Arc::new(
+            Platform::new(&cqlite_config)
+                .await
+                .expect("platform creation"),
+        );
+        SSTableManager::new(
+            &data_dir,
+            &cqlite_config,
+            platform,
+            #[cfg(feature = "state_machine")]
+            None,
+        )
+        .await
+        .expect("SSTableManager must open")
+    });
+
+    let table_id = CqlTableId::from("compact_ks.items");
+    let results = rt
+        .block_on(manager.scan(&table_id, None, None, None, Some(&schema)))
+        .expect("post-compaction scan");
+
+    let result_map: HashMap<Vec<u8>, Value> = results.into_iter().map(|(k, v)| (k.0, v)).collect();
+
+    // PK=1 must be ABSENT: equal-timestamp tombstone wins (Cassandra reconcile).
+    let key_1: Vec<u8> = 1_i32.to_be_bytes().into();
+    assert!(
+        !result_map.contains_key(&key_1),
+        "PK=1 was row-deleted at the SAME timestamp (ts={}) as its live write but is \
+         present after compaction — equal-ts tiebreak reverted to file recency \
+         instead of letting the tombstone win (Issue #498)",
+        EQUAL_TS
+    );
+
+    // PK=2 must be PRESENT: proves the compaction produced real output and PK=1's
+    // absence is the tombstone shadowing, not an empty/failed merge.
+    let key_2: Vec<u8> = 2_i32.to_be_bytes().into();
+    assert!(
+        result_map.contains_key(&key_2),
+        "PK=2 (live control, never deleted) must be present after compaction"
+    );
+
+    eprintln!(
+        "test_real_merger_delete_wins_at_equal_timestamp PASSED: \
+         PK=1 absent (equal-ts tombstone wins), PK=2 present (live control)"
+    );
+
+    drop(temp_dir);
+}


### PR DESCRIPTION
## Summary

Fixes #498 — the k-way compaction merger resolved equal-timestamp Delete-vs-Live conflicts by `run_index` (newer input file wins), diverging from Cassandra `org.apache.cassandra.db.rows.Cells#reconcile`, where **the tombstone always wins at equal timestamp** regardless of file recency.

Closes #498.

## Root cause

`KWayMerger::merge_partition_rows()` selected the winning row per clustering key by sorting on `timestamp (desc) → run_index (asc)`. At equal timestamp the lower `run_index` (newer file) won, so a Live cell in the newer file survived over a same-timestamp Delete tombstone in the older file. User-visible whenever conflicting writes from different sources land at exactly the same timestamp (clock skew, batch writes, replicated streams).

## Fix

Insert a **liveness tier** between timestamp and run_index. New `tombstone_priority()` (Tombstone=1, Live=0); the winner-selection sort is now:

1. `timestamp` (desc) — higher wins
2. **liveness** (desc) — Tombstone beats Live at equal ts (Cassandra rule)
3. `run_index` (asc) — newer file, only when timestamp AND liveness are equal

The comparator is a `.then_with` chain of total orders (i64/u8/usize `cmp`) — total and transitive, no sort-panic risk. The decision is at the row-selection level where the merger picks one winning `MergeEntry` per clustering key; the `Ord`/heap-routing impl is unchanged (it only routes entries to buckets, it does not pick winners — doc comments clarified to remove the old "run_index = LWW" wording that originally hid this).

## Tests

- **Proptest** `prop_real_merger_tombstone_vs_live`: removed the `ts_delete == ts_write` carve-out; the equal-ts branch now asserts the tombstone wins. Covers all three timestamp relationships. The live entry sits at `run_index 0` so a revert-to-run_index fails the property.
- **New unit test** `test_real_merger_delete_wins_at_equal_timestamp` (merge.rs): drives the REAL `merge_partition_rows` with `[Live(run_index 0), Delete(run_index 1)]` at equal ts; asserts the tombstone wins. Verified to FAIL under a temporary revert (pre-fix the live row at run_index 0 wins).
- **New e2e test** (compaction_integration.rs): builds real SSTables via the WriteEngine — tombstone PK=1 in the OLDER file, live PK=1 in the NEWER file at the same ts — runs real compaction, reopens via SSTableManager, asserts PK=1 absent (tombstone won despite being the older file) and a live control PK=2 present. Adversarial: the pre-fix run_index tiebreak would keep PK=1.
- `reference_merge` model already encoded "Delete wins at equal ts"; the real merger now matches it.

## Scope

Only the equal-ts Delete-vs-Live tie changes. `ts_delete > ts_write` / `ts_write > ts_delete`, range tombstones, and TTL are unaffected (resolved by the primary timestamp comparison before liveness is consulted).

## Pre-push checklist (all green)

- `cargo fmt --all -- --check` ✅ · `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features` ✅
- core lib 966 passed ✅ · `compaction_integration` 5/5 ✅ · `merge` proptests + unit ✅ · `cqlite-integration-tests` 0 failures ✅
- Python 229 ✅ · Node 351 ✅ · `smoke-test-all-tables.sh` 33/33 ✅

## Review

rust-reviewer: no BLOCKING issues; confirmed comparator direction/totality, adversarial unit test, scope containment. Two NON-BLOCKING items (misleading `Ord` doc; non-adversarial e2e) addressed in the follow-up commit.
