### PR TITLE
chore(release): cut v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.9.2] — Correctness fixes
+
+Reader and compaction correctness follow-ups to v0.9.1. No new features and no
+public API changes.
+
+### Fixed
+
+- **`scan()` result ordering** is now guaranteed to be ascending Murmur3 token
+  order (with raw key bytes as the equal-token tiebreaker), matching the on-disk
+  SSTable layout and the write engine. Previously rows could come back out of
+  order; `LIMIT` is now applied after ordering (#516).
+- **`get()` / `scan()` partition consistency**: `get()` no longer returns `None`
+  for partition keys that `scan()` returns. An Index.db digest-lookup miss now
+  falls back to a key scan, and the V5CompressedLegacy chunk-stitching parse path
+  is used so partitions spanning chunk boundaries are found (#517).
+- **`SSTableReader::stats().block_count`** is now populated from the authoritative
+  `CompressionInfo.db` chunk count instead of always reporting `0` (#518).
+- **Compaction dropped input tombstones**: the k-way merger now surfaces row and
+  cell tombstones from input SSTables with their authoritative `markedForDeleteAt`
+  timestamps, so a higher-timestamp tombstone in a later SSTable correctly shadows
+  a live row from an earlier one (#505).
+- **Equal-timestamp Delete-vs-Live reconcile** now follows Cassandra
+  `Cells#reconcile`: at equal timestamp the tombstone wins, independent of input
+  file recency (previously the newer file won regardless of liveness) (#498).
+
 ## [v0.9.1] — Reader correctness fixes
 
 Reader correctness and test/CI follow-ups to v0.9.0. No writer changes and no
@@ -37,11 +62,9 @@ public API changes.
 
 ### Known Issues
 
-- Reviving the orphan integration tests surfaced three pre-existing reader bugs,
-  now tracked separately and marked `#[ignore]` in the revived tests:
-  `scan()` result ordering is not guaranteed (#516), `get()` misses partitions that
-  `scan()` returns (#517), and `SSTableReader::stats().block_count` always reports
-  0 (#518).
+- Reviving the orphan integration tests surfaced three pre-existing reader bugs
+  (`scan()` ordering #516, `get()`/`scan()` consistency #517, and
+  `stats().block_count` #518). All three are **resolved in v0.9.2**.
 - The v0.9.0 known issues for counter writes, the BIG-format BTI writer, and the
   Python concurrent-query race (#311) are unchanged.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [package]
 name = "cqlite"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 
 [dependencies]
@@ -32,7 +32,7 @@ insta = "1.34"
 cqlite-integration-tests = { path = "tests" }
 
 [workspace.package]
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 authors = ["CQLite Team"]
 license = "MIT OR Apache-2.0"

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cqlite/node",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cqlite/node",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^3.5.1",

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cqlite/node",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Node.js bindings for CQLite - read Apache Cassandra 5.0 SSTables without cluster dependencies",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "cqlite-py"
-version = "0.9.1"
+version = "0.9.2"
 description = "Python bindings for CQLite - read Cassandra 5.0 SSTables locally without a cluster"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/docs/development/PRD.md
+++ b/docs/development/PRD.md
@@ -163,16 +163,15 @@ cqlsh -e "SELECT * FROM keyspace.table"
 
 The following are tracked follow-ups, not release blockers. All are open GitHub issues.
 The v0.9.0 reader follow-ups (#493 set-element tombstones, #501 tuple decoding,
-#502 frozen<udt> decoding) were **resolved in v0.9.1** and removed from this list.
+#502 frozen<udt> decoding) were **resolved in v0.9.1**. The v0.9.2 reader and
+compaction correctness fixes (#516 `scan()` token ordering, #517 `get()`/`scan()`
+consistency, #518 `stats().block_count`, #505 compaction row tombstones, #498
+equal-timestamp Delete-vs-Live reconcile) were **resolved in v0.9.2** and removed
+from this list.
 
 | Issue | Milestone | Description | Workaround |
 |-------|-----------|-------------|------------|
 | #311 | — | Python concurrent-query race in schema metadata access | Run one warm-up query before spawning parallel threads on the same handle |
-| #516 | v0.9.2 | `scan()` result ordering not guaranteed (rows out of RowKey order) | Sort client-side if order matters |
-| #517 | v0.9.2 | `get()` returns `None` for partition keys that `scan()` returns | Use `scan()` to confirm partition presence |
-| #518 | v0.9.2 | `SSTableReader::stats().block_count` always reports 0 | Do not rely on `block_count` for diagnostics |
-| #505 | v0.9.2 | Compaction merger drops row tombstones from input SSTables | Avoid relying on compaction to preserve row tombstones |
-| #498 | v0.9.2 | Compaction equal-timestamp Delete-vs-Live tiebreaker diverges from Cassandra `Cell.reconcile` | Avoid equal-timestamp delete/live conflicts in compacted input |
 
 See [docs/write-support-limitations.md](../write-support-limitations.md) for the full limitations reference.
 

--- a/docs/write-support-limitations.md
+++ b/docs/write-support-limitations.md
@@ -103,3 +103,32 @@ The error is actionable: pass the UDT schema to `UdtRegistry::register_udt` and
 re-open the reader.
 
 **Tracking**: Issue #502.
+
+---
+
+## Compaction dropped input tombstones (Issue #505)
+
+**Behaviour** (resolved in v0.9.2): The k-way compaction merger now surfaces row
+and cell tombstones from input SSTables (via a dedicated compaction read path that
+does not filter tombstones) and carries their authoritative `markedForDeleteAt`
+timestamps. A higher-timestamp tombstone in a later SSTable now correctly shadows
+a live row from an earlier SSTable after compaction.
+
+**Tracking**: Issue #505 (fixed in v0.9.2).
+
+---
+
+## Compaction equal-timestamp Delete-vs-Live reconcile (Issue #498)
+
+**Behaviour** (resolved in v0.9.2): At equal timestamp, the merger now resolves a
+Delete-vs-Live conflict in favour of the tombstone, independent of which input
+file it came from — matching Cassandra `Cells#reconcile`. Previously the newer
+input file won regardless of liveness.
+
+**Tracking**: Issue #498 (fixed in v0.9.2).
+
+---
+
+> The v0.9.2 reader correctness fixes (#516 `scan()` token ordering, #517
+> `get()`/`scan()` consistency, #518 `stats().block_count`) are read-side; see the
+> CHANGELOG and PRD §4.2 for details.


### PR DESCRIPTION
## v0.9.2 — Correctness fixes

Reader and compaction correctness patch following v0.9.1. **No new features and no public API changes.** Mirrors the v0.9.1 release cut (#525).

### Fixed (milestone v0.9.2, all merged to main)

| Issue | PR | Fix |
|-------|----|-----|
| #516 | #528 | `scan()` now returns ascending Murmur3 token order (byte-lex tiebreak), matching the on-disk layout and write engine; `LIMIT` applied after ordering |
| #517 | #528 | `get()` no longer returns `None` for partitions `scan()` returns (Index.db digest-miss falls back to a key scan; chunk-stitching parse path for partitions spanning chunks) |
| #518 | #529 | `stats().block_count` populated from authoritative `CompressionInfo.db` chunk count (was always 0) |
| #505 | #530 | Compaction merger surfaces input row/cell tombstones with authoritative `markedForDeleteAt` timestamps so later higher-ts tombstones shadow earlier live rows |
| #498 | #531 | Equal-timestamp Delete-vs-Live reconcile now follows Cassandra `Cells#reconcile` (tombstone wins at equal ts, independent of file recency) |

Each fix removed the matching `#[ignore]` (reader bugs) or strengthened the compaction tests, was rust-reviewed, and merged CI-green.

### Release changes in this PR

- Version bump to **0.9.2**: root `Cargo.toml` (`[package]` + `[workspace.package]`), `bindings/python/pyproject.toml`, `bindings/node/package.json`, `bindings/node/package-lock.json`.
- `CHANGELOG.md`: new `## [v0.9.2]` section; #516/#517/#518 marked resolved in the v0.9.1 Known Issues bullet.
- Docs sync: `docs/development/PRD.md` §4.2 and `docs/write-support-limitations.md` mark all five issues resolved.
- Side fix folded into #530: corrected the guide's `HAS_DELETION` VInt-order documentation (markedForDeleteAt first) — the doc bug behind the original #505 mis-implementation.

### Full pre-push checklist (all green, on `release/v0.9.2`)

- `cargo fmt --all -- --check` ✅ · `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features` ✅
- core lib 966 passed ✅ · `cqlite-integration-tests` 0 failures ✅
- Python 229 ✅ · Node 351 ✅ · `smoke-test-all-tables.sh` 33/33 ✅
- **`e2e-cassandra-readback.sh` (Docker, Cassandra 5.0): 5/5** (basic-primitives, collections, udt, static-columns, ttl) — CQLite-written SSTables loaded via `nodetool refresh` and verified with cqlsh ✅

The three tag-triggered release workflows (`release.yml`, `node-release.yml`, `python-release.yml`) all retain the #526 aarch64-apple-darwin cargo PATH fix.
