### PR TITLE
perf(writer): stream Data.db per-partition to bound compaction memory (closes #492)

### DIFF
--- a/cqlite-core/src/storage/sstable/writer/data_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer.rs
@@ -67,6 +67,7 @@ use crate::storage::write_engine::mutation::{
 };
 use crate::types::{ComparatorType, UdtTypeDef, Value};
 use std::io::Write;
+use std::path::PathBuf;
 
 // Row header flag constants (from V5CompressedLegacy parser)
 const ROW_HAS_TIMESTAMP: u8 = 0x04;
@@ -108,28 +109,136 @@ const END_BOUNDARY: u8 = 5; // Top (end of partition)
 // Partition/row markers
 const END_OF_PARTITION: u8 = 0x01;
 
+/// Capacity of the streaming Data.db `BufWriter` (Issue #492).
+///
+/// Large enough that each flushed partition coalesces into a handful of big
+/// `write()` syscalls instead of many small default-8 KB ones, preserving the
+/// throughput of the previous single whole-file write while keeping resident
+/// memory bounded (this buffer plus one partition's scratch).
+const DATA_SINK_BUFFER_BYTES: usize = 1024 * 1024;
+
 /// Data.db component writer
 ///
 /// Writes partitions and rows in V5CompressedLegacy format with delta encoding.
 /// Caller must provide partitions in token order and rows in clustering order.
+///
+/// # Memory model (Issue #492)
+///
+/// The writer supports two modes that produce **byte-identical** Data.db output:
+///
+/// * **In-memory mode** (`DataWriter::new`): every partition is appended to the
+///   `buffer` scratch and never flushed, so `finish()` returns the full Data.db
+///   bytes. Used by unit tests that inspect the produced bytes directly.
+///
+/// * **Streaming mode** (`DataWriter::with_sink`): each partition is built in the
+///   `buffer` scratch, written to a `BufWriter<File>` over the Data.db path, and
+///   the scratch is cleared. Peak heap is therefore `O(largest partition)` rather
+///   than `O(file)`, keeping a multi-GB compaction within the 128 MB target.
+///
+/// In both modes the file offset of a partition is `position + buffer.len()`
+/// measured before any bytes are written. In streaming mode `buffer` is empty at
+/// that point (just cleared) so the offset is `position`; in memory mode
+/// `position` is always 0 and `buffer` holds all prior partitions, so the offset
+/// equals the legacy `buffer.len()`. The within-partition size math uses relative
+/// deltas into `buffer`, which are identical regardless of mode.
 #[derive(Debug)]
 pub struct DataWriter {
-    /// Output buffer for Data.db content
+    /// Per-partition scratch buffer for Data.db content.
+    ///
+    /// In streaming mode this is cleared at the start of every `write_partition`
+    /// and flushed to `sink` at the end, so only one partition is resident.
+    /// In memory mode it accumulates the entire Data.db output.
     buffer: Vec<u8>,
+    /// Streaming sink over the Data.db path (streaming mode only).
+    ///
+    /// Lazily opened on the first `write_partition` so that the keyspace/table
+    /// directory exists before the first byte is written. `None` in in-memory
+    /// mode.
+    sink: Option<std::io::BufWriter<std::fs::File>>,
+    /// Data.db output path (streaming mode only); used for lazy sink open.
+    data_path: Option<PathBuf>,
+    /// Bytes already flushed to `sink`. Always 0 in in-memory mode.
+    position: u64,
     /// Statistics metadata for delta encoding
     stats: StatisticsMetadata,
 }
 
 impl DataWriter {
-    /// Create a new Data.db writer
+    /// Create a new in-memory Data.db writer.
+    ///
+    /// All partitions accumulate in `buffer`; `finish()` returns the full bytes.
+    /// Prefer [`DataWriter::with_sink`] for production writes to bound memory.
     ///
     /// # Arguments
     /// * `stats` - Statistics metadata for delta encoding baselines
     pub fn new(stats: StatisticsMetadata) -> Self {
         Self {
             buffer: Vec::new(),
+            sink: None,
+            data_path: None,
+            position: 0,
             stats,
         }
+    }
+
+    /// Create a streaming Data.db writer that flushes each partition to `data_path`.
+    ///
+    /// The file is opened lazily on the first `write_partition` (creating the
+    /// parent directory if needed) so the keyspace/table layout is established
+    /// before any bytes are written. Memory is bounded to the largest single
+    /// partition.
+    ///
+    /// # Arguments
+    /// * `stats` - Statistics metadata for delta encoding baselines
+    /// * `data_path` - Destination path for the Data.db component
+    pub fn with_sink(stats: StatisticsMetadata, data_path: PathBuf) -> Self {
+        Self {
+            buffer: Vec::new(),
+            sink: None,
+            data_path: Some(data_path),
+            position: 0,
+            stats,
+        }
+    }
+
+    /// Lazily open the streaming sink (and create the parent directory).
+    ///
+    /// No-op in in-memory mode or once the sink is already open.
+    fn ensure_sink(&mut self) -> Result<()> {
+        if self.sink.is_some() {
+            return Ok(());
+        }
+        if let Some(path) = self.data_path.clone() {
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            let file = std::fs::File::create(&path)?;
+            // Use a large BufWriter so a partition's bytes coalesce into a few
+            // big write() syscalls rather than many 8 KB-default ones, matching
+            // the throughput of the old single whole-file write.
+            self.sink = Some(std::io::BufWriter::with_capacity(
+                DATA_SINK_BUFFER_BYTES,
+                file,
+            ));
+        }
+        Ok(())
+    }
+
+    /// In streaming mode, flush the current scratch buffer to the sink, advance
+    /// `position`, and clear the scratch so only one partition is ever resident.
+    /// No-op in in-memory mode (the scratch keeps accumulating).
+    fn flush_partition(&mut self) -> Result<()> {
+        if self.data_path.is_none() {
+            // In-memory mode: keep accumulating in `buffer`.
+            return Ok(());
+        }
+        self.ensure_sink()?;
+        if let Some(sink) = self.sink.as_mut() {
+            sink.write_all(&self.buffer)?;
+        }
+        self.position += self.buffer.len() as u64;
+        self.buffer.clear();
+        Ok(())
     }
 
     /// Update the statistics metadata
@@ -160,7 +269,12 @@ impl DataWriter {
         partition_tombstone: Option<&PartitionTombstone>,
         range_tombstones: &[RangeTombstone],
     ) -> Result<u64> {
-        let partition_offset = self.buffer.len() as u64;
+        // File offset of this partition = bytes already flushed (`position`) plus
+        // whatever is currently buffered. In streaming mode `buffer` is empty at
+        // the start of each partition (flushed + cleared by the previous call),
+        // so this is `position`; in in-memory mode `position` is 0 and `buffer`
+        // holds all prior partitions, matching the legacy `buffer.len()`.
+        let partition_offset = self.position + self.buffer.len() as u64;
 
         // Write partition header (with optional tombstone)
         let header_start = self.buffer.len();
@@ -284,6 +398,10 @@ impl DataWriter {
         // Write end-of-partition marker
         self.buffer.push(END_OF_PARTITION);
 
+        // Streaming mode: flush this partition to disk and clear the scratch so
+        // only one partition is ever resident in memory. No-op in memory mode.
+        self.flush_partition()?;
+
         Ok(partition_offset)
     }
 
@@ -332,9 +450,39 @@ impl DataWriter {
         Ok(self.buffer.len() - start_len)
     }
 
-    /// Finish writing and return the Data.db bytes
+    /// Finish writing and return the Data.db bytes (in-memory mode).
+    ///
+    /// Only valid for writers created via [`DataWriter::new`]. In streaming mode
+    /// the bytes live on disk; use [`DataWriter::finish_streaming`] instead.
     pub fn finish(self) -> Result<Vec<u8>> {
+        debug_assert!(
+            self.data_path.is_none(),
+            "DataWriter::finish() called on a streaming writer; use finish_streaming()"
+        );
         Ok(self.buffer)
+    }
+
+    /// Finish a streaming writer: flush the sink to disk and return the total
+    /// number of Data.db bytes written (i.e. `data_size`).
+    ///
+    /// Any residual scratch (there is none in normal operation, since
+    /// `write_partition` flushes per partition) is flushed first. Returns an
+    /// error if the writer was created in in-memory mode.
+    pub fn finish_streaming(mut self) -> Result<u64> {
+        if self.data_path.is_none() {
+            return Err(Error::InvalidInput(
+                "finish_streaming() called on an in-memory DataWriter".to_string(),
+            ));
+        }
+        // Flush any residual scratch (normally empty), then flush the sink so all
+        // bytes reach the OS file (the subsequent Digest CRC re-read of the same
+        // file sees them via the page cache). This matches the durability of the
+        // previous `tokio::fs::write`, which did not fsync either.
+        self.flush_partition()?;
+        if let Some(mut sink) = self.sink.take() {
+            sink.flush()?;
+        }
+        Ok(self.position)
     }
 
     /// Write partition header
@@ -1746,9 +1894,29 @@ impl DataWriter {
         Ok(self.buffer.len() - start_len)
     }
 
-    /// Get current file position (for Index.db offset tracking)
+    /// Get current file position (for Index.db offset tracking).
+    ///
+    /// This is the total number of Data.db bytes produced so far: bytes already
+    /// flushed to the sink (`position`) plus bytes currently buffered. Identical
+    /// in both streaming and in-memory modes.
     pub fn position(&self) -> u64 {
-        self.buffer.len() as u64
+        self.position + self.buffer.len() as u64
+    }
+
+    /// Length of the per-partition scratch buffer.
+    ///
+    /// In streaming mode this reflects only the most recently written partition
+    /// (the scratch is cleared after each flush), which is the basis of the
+    /// bounded-memory guarantee. Test-only accessor.
+    #[cfg(test)]
+    pub(crate) fn scratch_len(&self) -> usize {
+        self.buffer.len()
+    }
+
+    /// Number of bytes already flushed to the streaming sink. Test-only accessor.
+    #[cfg(test)]
+    pub(crate) fn flushed_position(&self) -> u64 {
+        self.position
     }
 
     fn ordered_columns<'a, F>(&self, schema: &'a TableSchema, predicate: F) -> Vec<&'a Column>
@@ -5203,6 +5371,152 @@ mod tests {
         assert_eq!(
             buf[0], 2,
             "Bitmap should mark 'name' as missing (bit 1) but 'age' as present (bit 0)"
+        );
+    }
+
+    // ========== Issue #492: streaming DataWriter tests ==========
+
+    /// Build a deterministic set of partitions used by the streaming tests.
+    fn streaming_test_partitions() -> Vec<(DecoratedKey, Vec<Mutation>)> {
+        let table_id = TableId::new("test_ks", "test_table");
+        (0..16u32)
+            .map(|i| {
+                let key = DecoratedKey::new(i as i64, i.to_be_bytes().to_vec());
+                let pk = PartitionKey::single("id", Value::Integer(i as i32));
+                let mutation = Mutation::new(
+                    table_id.clone(),
+                    pk,
+                    None,
+                    vec![CellOperation::Write {
+                        column: "name".to_string(),
+                        value: Value::Text(format!("partition-{i}")),
+                    }],
+                    1_001_000 + i as i64,
+                    None,
+                );
+                (key, vec![mutation])
+            })
+            .collect()
+    }
+
+    /// Byte-identical guard (Issue #492): the streaming writer (flushing each
+    /// partition to a file) must produce a Data.db byte sequence that is
+    /// identical to the legacy in-memory writer, and the returned partition
+    /// offsets must match exactly. Anything else breaks Index.db offsets.
+    #[test]
+    fn test_streaming_writer_byte_identical_to_in_memory() {
+        let schema = create_test_schema();
+        let partitions = streaming_test_partitions();
+
+        // In-memory reference: accumulate every partition in `buffer`.
+        let mut mem_writer = DataWriter::new(create_test_stats());
+        let mut mem_offsets = Vec::new();
+        for (key, mutations) in &partitions {
+            mem_offsets.push(
+                mem_writer
+                    .write_partition(key, mutations, &schema, None, &[])
+                    .unwrap(),
+            );
+        }
+        let expected_bytes = mem_writer.finish().unwrap();
+
+        // Streaming: flush each partition to a temp Data.db file.
+        let dir = tempfile::tempdir().unwrap();
+        let data_path = dir.path().join("nb-1-big-Data.db");
+        let mut stream_writer = DataWriter::with_sink(create_test_stats(), data_path.clone());
+        let mut stream_offsets = Vec::new();
+        for (key, mutations) in &partitions {
+            stream_offsets.push(
+                stream_writer
+                    .write_partition(key, mutations, &schema, None, &[])
+                    .unwrap(),
+            );
+        }
+        let data_size = stream_writer.finish_streaming().unwrap();
+
+        // Offsets returned to the caller (fed to Index.db) must be identical.
+        assert_eq!(
+            stream_offsets, mem_offsets,
+            "streaming partition offsets must equal in-memory offsets"
+        );
+
+        // The on-disk Data.db must be byte-for-byte identical to the in-memory
+        // bytes, and the reported data_size must match the file length.
+        let on_disk = std::fs::read(&data_path).unwrap();
+        assert_eq!(
+            on_disk, expected_bytes,
+            "streamed Data.db must be byte-identical to in-memory Data.db"
+        );
+        assert_eq!(
+            data_size as usize,
+            expected_bytes.len(),
+            "finish_streaming() data_size must equal file length"
+        );
+
+        // Every returned offset must point at the actual start byte in the file:
+        // a partition starts with its 2-byte key length, here always 0x0004.
+        for &off in &stream_offsets {
+            assert_eq!(
+                &on_disk[off as usize..off as usize + 2],
+                &[0x00, 0x04],
+                "offset {off} must land on a partition's key-length prefix"
+            );
+        }
+    }
+
+    /// Bounded-memory evidence (Issue #492): after each `write_partition` the
+    /// scratch buffer must hold only the most recent partition, while the
+    /// flushed `position` grows monotonically. This is the proof that peak heap
+    /// is O(largest partition) rather than O(file).
+    #[test]
+    fn test_streaming_writer_bounds_memory_to_one_partition() {
+        let schema = create_test_schema();
+        let partitions = streaming_test_partitions();
+
+        let dir = tempfile::tempdir().unwrap();
+        let data_path = dir.path().join("nb-1-big-Data.db");
+        let mut writer = DataWriter::with_sink(create_test_stats(), data_path);
+
+        let mut prev_flushed = 0u64;
+        let mut max_scratch = 0usize;
+        for (i, (key, mutations)) in partitions.iter().enumerate() {
+            let flushed_before = writer.flushed_position();
+            writer
+                .write_partition(key, mutations, &schema, None, &[])
+                .unwrap();
+
+            // After a partition is written it has been flushed and the scratch
+            // cleared: the scratch must be empty, never accumulating prior
+            // partitions.
+            assert_eq!(
+                writer.scratch_len(),
+                0,
+                "scratch must be cleared after partition {i} (bounded memory)"
+            );
+
+            // Flushed bytes must strictly increase by this partition's size.
+            let flushed_after = writer.flushed_position();
+            assert!(
+                flushed_after > flushed_before,
+                "flushed position must grow after writing partition {i}"
+            );
+            let this_partition_size = (flushed_after - flushed_before) as usize;
+            max_scratch = max_scratch.max(this_partition_size);
+            assert!(flushed_after > prev_flushed);
+            prev_flushed = flushed_after;
+        }
+
+        let total = writer.finish_streaming().unwrap();
+        assert_eq!(
+            total, prev_flushed,
+            "total size must equal last flushed pos"
+        );
+
+        // Peak resident bytes were bounded by the largest single partition,
+        // which is far smaller than the whole file for many partitions.
+        assert!(
+            (max_scratch as u64) < total,
+            "largest single partition ({max_scratch}) must be smaller than the full file ({total})"
         );
     }
 }

--- a/cqlite-core/src/storage/sstable/writer/data_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer.rs
@@ -455,10 +455,15 @@ impl DataWriter {
     /// Only valid for writers created via [`DataWriter::new`]. In streaming mode
     /// the bytes live on disk; use [`DataWriter::finish_streaming`] instead.
     pub fn finish(self) -> Result<Vec<u8>> {
-        debug_assert!(
-            self.data_path.is_none(),
-            "DataWriter::finish() called on a streaming writer; use finish_streaming()"
-        );
+        // Hard guard (not debug_assert!, which compiles out in release): on a
+        // streaming writer the bytes live on disk and `buffer` is empty after each
+        // partition flush, so returning it would silently yield a 0-byte Data.db.
+        if self.data_path.is_some() {
+            return Err(Error::InvalidInput(
+                "DataWriter::finish() called on a streaming writer; use finish_streaming()"
+                    .to_string(),
+            ));
+        }
         Ok(self.buffer)
     }
 
@@ -5478,7 +5483,10 @@ mod tests {
         let mut writer = DataWriter::with_sink(create_test_stats(), data_path);
 
         let mut prev_flushed = 0u64;
-        let mut max_scratch = 0usize;
+        // Tracks the largest single-partition flushed size. Because the scratch is
+        // cleared after every partition (asserted below), peak resident Data.db
+        // bytes are bounded by this value, not the whole file.
+        let mut max_partition_size = 0usize;
         for (i, (key, mutations)) in partitions.iter().enumerate() {
             let flushed_before = writer.flushed_position();
             writer
@@ -5501,7 +5509,7 @@ mod tests {
                 "flushed position must grow after writing partition {i}"
             );
             let this_partition_size = (flushed_after - flushed_before) as usize;
-            max_scratch = max_scratch.max(this_partition_size);
+            max_partition_size = max_partition_size.max(this_partition_size);
             assert!(flushed_after > prev_flushed);
             prev_flushed = flushed_after;
         }
@@ -5515,8 +5523,8 @@ mod tests {
         // Peak resident bytes were bounded by the largest single partition,
         // which is far smaller than the whole file for many partitions.
         assert!(
-            (max_scratch as u64) < total,
-            "largest single partition ({max_scratch}) must be smaller than the full file ({total})"
+            (max_partition_size as u64) < total,
+            "largest single partition ({max_partition_size}) must be smaller than the full file ({total})"
         );
     }
 }

--- a/cqlite-core/src/storage/sstable/writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/mod.rs
@@ -228,15 +228,19 @@ impl SSTableWriter {
         stats.min_ttl = i32::MAX;
         stats.min_local_deletion_time = i32::MAX;
 
-        // Create Data.db writer (needs stats for delta encoding)
-        let data_writer = DataWriter::new(stats.clone());
-
-        // Create Index.db writer
-        let index_writer = IndexWriter::new();
-
         // Compute the SSTable output directory: output_dir/keyspace/table/
         // This ensures the reader's extract_table_name() can map files to table names.
         let sstable_dir = output_dir.join(&schema.keyspace).join(&schema.table);
+
+        // Create Data.db writer in streaming mode (Issue #492): each partition is
+        // flushed to the Data.db file as it is written, bounding peak memory to a
+        // single partition instead of buffering the whole component. The file is
+        // opened lazily on the first partition (creating sstable_dir as needed).
+        let data_path = Self::component_path(&sstable_dir, generation, "Data.db");
+        let data_writer = DataWriter::with_sink(stats.clone(), data_path);
+
+        // Create Index.db writer
+        let index_writer = IndexWriter::new();
 
         // Create Filter.db writer (1% false positive rate by default)
         let filter_path = Self::component_path(&sstable_dir, generation, "Filter.db");
@@ -451,8 +455,10 @@ impl SSTableWriter {
     /// ```
     pub async fn finish(mut self) -> Result<SSTableInfo> {
         // Create keyspace/table subdirectory structure so the reader can
-        // extract the table name from the parent directory path.
-        let sstable_dir = &self.sstable_dir;
+        // extract the table name from the parent directory path. Owned clone so
+        // `finish_streaming()` can move `self.data_writer` out below.
+        let sstable_dir = self.sstable_dir.clone();
+        let sstable_dir = sstable_dir.as_path();
         tokio::fs::create_dir_all(sstable_dir).await?;
 
         // Finalize statistics metadata (normalize sentinel values)
@@ -463,11 +469,17 @@ impl SSTableWriter {
         let stats_writer = StatisticsWriter::new(stats_path.clone());
         stats_writer.write(&self.stats, Some(&self.schema))?;
 
-        // 2. Write Data.db
+        // 2. Finalize Data.db (Issue #492)
+        // The DataWriter has been streaming each partition to disk as it was
+        // written, so there is no whole-file buffer to write here. `finish_streaming`
+        // flushes and fsyncs the sink and returns the total byte size. If no
+        // partitions were written, lazily ensure an (empty) Data.db file exists so
+        // the downstream Digest CRC re-read and TOC publication remain valid.
         let data_path = Self::component_path(sstable_dir, self.generation, "Data.db");
-        let data_bytes = self.data_writer.finish()?;
-        tokio::fs::write(&data_path, &data_bytes).await?;
-        let data_size = data_bytes.len() as u64;
+        let data_size = self.data_writer.finish_streaming()?;
+        if data_size == 0 && !data_path.exists() {
+            tokio::fs::write(&data_path, b"").await?;
+        }
 
         // 3. Write Index.db
         let index_path = Self::component_path(sstable_dir, self.generation, "Index.db");


### PR DESCRIPTION
## Summary

Fixes #492 — `DataWriter` buffered the entire Data.db in an in-memory `Vec<u8>`, so a 4×500 MB compaction held ~2 GB in RAM, violating the 128 MB target. The writer now **streams Data.db per-partition** to disk; peak resident Data.db bytes are O(largest single partition), not O(whole file).

Closes #492.

## Design

`DataWriter` (cqlite-core/src/storage/sstable/writer/data_writer.rs) has two byte-identical modes:

- **Streaming** (`with_sink(stats, data_path)`, used by `SSTableWriter`): each `write_partition` serializes one partition into a reusable scratch `buffer`, flushes it to a `std::io::BufWriter<std::fs::File>` (1 MiB capacity), advances a running `position`, then clears the scratch — so only one partition is resident.
- **In-memory** (`new(stats)`, used by ~40 byte-inspecting unit tests + the static-composite roundtrip integration test): unchanged; `finish()` returns the full `Vec<u8>`.

The partition file offset fed to Index.db is `position + buffer.len()` measured before writing — equal to `position` in streaming mode (scratch empty at capture) and to the legacy `buffer.len()` in in-memory mode (`position` always 0). Data.db is **uncompressed** (no CompressionInfo.db), so offsets are direct byte positions and the math is byte-identical. `SSTableWriter::finish` flushes via `finish_streaming()` (Data.db already on disk); Digest.crc32 still re-reads the file; TOC.txt remains the last publication barrier.

## Byte-identity & memory evidence

- `test_streaming_writer_byte_identical_to_in_memory`: streamed on-disk Data.db == in-memory writer bytes, offsets match, each offset lands on a key-length prefix, `data_size` == file length.
- `test_streaming_writer_bounds_memory_to_one_partition`: scratch length is 0 after every partition while flushed `position` grows; largest partition ≪ whole file.
- **e2e Cassandra 5.0 readback: 5/5** — real Cassandra ingested and read back the streamed SSTables (the definitive byte-correctness gate).

## Pre-push checklist (all green)

- `cargo fmt --all -- --check` ✅ · `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features` ✅
- core lib 966 ✅ · `compaction_integration` 6/6 ✅ · streaming byte-identical + bounds tests ✅ · `cqlite-integration-tests` 0 failures ✅
- Python 229 ✅ · Node 351 ✅ · `smoke-test-all-tables.sh` 33/33 ✅ · **`e2e-cassandra-readback.sh` 5/5 ✅**

## Review

rust-reviewer found 1 BLOCKING issue — `finish()` guarded wrong-mode misuse with `debug_assert!` (compiled out in release → could silently return an empty Vec). Fixed with a hard `Error::InvalidInput` guard mirroring `finish_streaming`. Non-blocking clarity items addressed.

## Note (pre-existing, NOT introduced here)

`write_read_roundtrip` (9 tests) and `test_row_ttl_uses_row_ttl_cell_flags` fail identically on baseline `main` (verified by `git checkout main` + re-run). They are `write-support`-only and invisible to the standard `cli-helpers` checklist/CI. Out of scope for this PR; flagged for a separate follow-up.

## Out of scope (per #492)

On-disk format unchanged; merge pipeline untouched; Index/Filter/Summary/Statistics writers not streamed (they are small relative to Data.db). A single partition >128 MB remains pathological/out of scope.
