### PR TITLE
docs(release): add #533 + #492 to v0.9.2 changelog/docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.9.2] — Correctness fixes
 
-Reader and compaction correctness follow-ups to v0.9.1. No new features and no
-public API changes.
+Reader and compaction correctness follow-ups to v0.9.1, plus a compaction memory
+fix. No new features and no public API changes.
 
 ### Fixed
 
@@ -29,6 +29,14 @@ public API changes.
 - **Equal-timestamp Delete-vs-Live reconcile** now follows Cassandra
   `Cells#reconcile`: at equal timestamp the tombstone wins, independent of input
   file recency (previously the newer file won regardless of liveness) (#498).
+- **Compaction dropped disjoint columns**: the k-way merger now reconciles cells
+  per column (Cassandra `Cells#reconcile`) instead of selecting one whole winning
+  row per clustering key, so rows updated across SSTables on different columns keep
+  all their cells after compaction (#533).
+- **Compaction memory**: the SSTable writer now streams `Data.db` to disk per
+  partition instead of buffering the entire component in memory, bounding peak heap
+  to roughly the largest single partition (was O(whole file), exceeding the 128 MB
+  target on large compactions). Output is byte-identical (#492).
 
 ## [v0.9.1] — Reader correctness fixes
 

--- a/docs/development/PRD.md
+++ b/docs/development/PRD.md
@@ -166,8 +166,9 @@ The v0.9.0 reader follow-ups (#493 set-element tombstones, #501 tuple decoding,
 #502 frozen<udt> decoding) were **resolved in v0.9.1**. The v0.9.2 reader and
 compaction correctness fixes (#516 `scan()` token ordering, #517 `get()`/`scan()`
 consistency, #518 `stats().block_count`, #505 compaction row tombstones, #498
-equal-timestamp Delete-vs-Live reconcile) were **resolved in v0.9.2** and removed
-from this list.
+equal-timestamp Delete-vs-Live reconcile, #533 per-cell compaction reconcile, and
+#492 streaming `Data.db` writer) were **resolved in v0.9.2** and removed from this
+list.
 
 | Issue | Milestone | Description | Workaround |
 |-------|-----------|-------------|------------|

--- a/docs/write-support-limitations.md
+++ b/docs/write-support-limitations.md
@@ -129,6 +129,29 @@ input file won regardless of liveness.
 
 ---
 
+## Compaction dropped disjoint columns (Issue #533)
+
+**Behaviour** (resolved in v0.9.2): The merger now reconciles cells per column
+(Cassandra `Cells#reconcile`) instead of selecting one whole winning row per
+clustering key. Rows updated across different SSTables on different columns keep
+all their cells after compaction; previously the losing row's columns were dropped.
+
+**Tracking**: Issue #533 (fixed in v0.9.2).
+
+---
+
+## DataWriter buffered the whole SSTable in memory (Issue #492)
+
+**Behaviour** (resolved in v0.9.2): The SSTable writer streams `Data.db` to disk one
+partition at a time via a buffered file sink, instead of accumulating the entire
+component in a `Vec<u8>`. Peak heap during a write/compaction is now bounded by the
+largest single partition rather than the full output size, keeping large compactions
+within the 128 MB memory target. Output bytes are unchanged.
+
+**Tracking**: Issue #492 (fixed in v0.9.2).
+
+---
+
 > The v0.9.2 reader correctness fixes (#516 `scan()` token ordering, #517
 > `get()`/`scan()` consistency, #518 `stats().block_count`) are read-side; see the
 > CHANGELOG and PRD §4.2 for details.


### PR DESCRIPTION
## v0.9.2 changelog/docs — add #533 + #492

Follow-up to the v0.9.2 release cut (#532). After Patrick expanded scope to include the two correctness-class issues found during review, #533 and #492 were fixed and merged to `main` (PRs #534, #535). This PR records them in the release notes/docs. **Docs-only — no code, no version change** (main is already `0.9.2`).

### Added to the v0.9.2 CHANGELOG "Fixed" section

- **#533** — compaction merger now reconciles cells **per column** (Cassandra `Cells#reconcile`) instead of selecting one whole winning row per clustering key, so rows updated across SSTables on disjoint columns keep all their cells (was data loss).
- **#492** — SSTable writer now **streams `Data.db` per partition** instead of buffering the whole component in `Vec<u8>`; peak heap is bounded by the largest single partition (was O(whole file), exceeding the 128 MB target). Output is byte-identical.

Also updated `docs/development/PRD.md` §4.2 and `docs/write-support-limitations.md` to mark both resolved.

### Full v0.9.2 issue set (7, all merged to main)

#516 #517 (#528) · #518 (#529) · #505 (#530) · #498 (#531) · #533 (#534) · #492 (#535)

### Full pre-push checklist (all green, on the final tree)

- `cargo fmt --all -- --check` ✅ · `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features` ✅
- core lib 966 ✅ · `cqlite-integration-tests` 0 failures ✅ · smoke 33/33 ✅
- Python 229 ✅ · Node 351 ✅
- **`e2e-cassandra-readback.sh` (Docker, Cassandra 5.0): 5/5** ✅ — streamed SSTables load + read back correctly

### Note (pre-existing, out of scope)

The `write-support`-only test targets `write_read_roundtrip` (9 tests) and `test_row_ttl_uses_row_ttl_cell_flags` fail identically on baseline `main` (verified) and are invisible to the standard `cli-helpers` CI/checklist. Flagged for a separate follow-up issue; not a v0.9.2 regression.
