### PR TITLE
perf(bench): write micro-benchmarks (ingest/flush) (closes #539)

### DIFF
--- a/cqlite-core/Cargo.toml
+++ b/cqlite-core/Cargo.toml
@@ -110,6 +110,10 @@ harness = false
 name = "read"
 harness = false
 
+[[bench]]
+name = "write"
+harness = false
+
 [features]
 # M2+ production defaults: Full query engine enabled
 default = ["all-compression", "state_machine"]

--- a/cqlite-core/benches/write.rs
+++ b/cqlite-core/benches/write.rs
@@ -1,0 +1,212 @@
+//! Write micro-benchmarks for cqlite-core (Issue #539, Epic #541 Phase 1).
+//!
+//! These benches measure the two hot paths in the write engine:
+//!
+//! - `write/ingest_wal_on` — sustained mutation ingest through the public
+//!   `WriteEngine::execute` API with WAL enabled. A WAL-off variant awaits the
+//!   public durability toggle tracked in issue #547.
+//!
+//! - `write/flush` — memtable → SSTable flush latency.  A pre-filled memtable
+//!   is flushed once per iteration; throughput is reported in MB/s relative to
+//!   the pre-flush memtable byte size.
+//!
+//! Both benches are deterministic: all input is generated from [`fixtures::seeded_rng`]
+//! so key/value selection is byte-for-byte identical across runs and machines.
+//! Each iteration uses a fresh [`tempfile::TempDir`] so iterations are
+//! independent and cannot share state through the WAL or data files.
+//!
+//! ## WAL-off variant (deferred)
+//!
+//! The issue spec asks for both `ingest_wal_on` and `ingest_wal_off` variants.
+//! `WriteEngine::write` unconditionally calls `wal.append()` + `wal.sync()` and
+//! [`WriteEngineConfig`](cqlite_core::storage::write_engine::WriteEngineConfig)
+//! has no durability toggle.  Implementing that toggle is tracked in issue #547.
+//! When #547 lands, add `ingest_wal_off` next to `ingest_wal_on` here.
+//!
+//! ## Running
+//!
+//! ```text
+//! # default features (compiles as no-op group):
+//! cargo bench -p cqlite-core --bench write -- --test
+//!
+//! # with write-support:
+//! cargo bench -p cqlite-core --features write-support --bench write -- --test
+//! cargo bench -p cqlite-core --features write-support --bench write
+//! ```
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+#[cfg(feature = "write-support")]
+use criterion::{black_box, Throughput};
+
+#[path = "fixtures/mod.rs"]
+mod fixtures;
+
+/// Number of rows inserted per ingest iteration.
+#[cfg(feature = "write-support")]
+const INGEST_ROWS: u64 = 256;
+
+/// Number of rows inserted into the memtable before each flush iteration.
+#[cfg(feature = "write-support")]
+const FLUSH_ROWS: u64 = 1_000;
+
+/// `write/ingest_wal_on` — sustained mutation ingest (WAL enabled).
+///
+/// Each iteration creates a fresh engine in a temp dir (setup, untimed) and
+/// then inserts [`INGEST_ROWS`] seeded rows via `engine.execute` (routine,
+/// timed).  The flush threshold is `usize::MAX` so no mid-batch auto-flush
+/// perturbs the timing.
+///
+/// Throughput is reported as writes/second (`Throughput::Elements`).
+///
+/// NOTE: A WAL-off variant is deferred until issue #547 adds a public
+/// durability toggle to `WriteEngineConfig`.
+#[cfg(feature = "write-support")]
+fn bench_ingest(c: &mut Criterion) {
+    use rand::Rng;
+
+    let mut group = c.benchmark_group("write");
+    group.throughput(Throughput::Elements(INGEST_ROWS));
+
+    group.bench_function("ingest_wal_on", |b| {
+        b.iter_batched(
+            // SETUP (untimed): fresh temp dir + engine with huge flush threshold
+            // so no auto-flush fires mid-batch, plus the seeded RNG (its ChaCha
+            // key schedule is kept out of the timed path).
+            || {
+                let tmp = tempfile::TempDir::new().expect("create temp dir for ingest bench");
+                let engine = fixtures::open_write_engine(tmp.path(), usize::MAX);
+                let rng = fixtures::seeded_rng();
+                (tmp, engine, rng)
+            },
+            // ROUTINE (timed): insert INGEST_ROWS seeded rows.
+            |(_tmp, mut engine, mut rng)| {
+                for _ in 0..INGEST_ROWS {
+                    let id = uuid::Uuid::from_u128(rng.gen());
+                    let age: i32 = rng.gen_range(0..100);
+                    let stmt = format!(
+                        "INSERT INTO test_basic.simple_table \
+                         (id, name, age, active) \
+                         VALUES ({id}, 'bench-row', {age}, true)"
+                    );
+                    engine.execute(&stmt).expect("ingest seeded row");
+                }
+                // Assert that rows actually landed so a broken engine fails
+                // loudly rather than measuring nothing.
+                let n = engine.memtable_row_count();
+                assert!(
+                    n > 0,
+                    "ingest_wal_on: memtable is empty after {INGEST_ROWS} inserts"
+                );
+                black_box(n)
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+/// `write/flush` — memtable → SSTable flush latency.
+///
+/// Each iteration pre-fills a fresh engine with [`FLUSH_ROWS`] seeded rows
+/// (setup, untimed), then flushes once via `rt.block_on(engine.flush())`
+/// (routine, timed).  The flush must return `Ok(Some(_))` (i.e. actually
+/// produce an SSTable); if it returns `None` the bench panics so a regression
+/// is immediately visible.
+///
+/// Throughput is reported as bytes/second (`Throughput::Bytes`) using the
+/// memtable byte size captured after setup so the report shows MB/s.
+#[cfg(feature = "write-support")]
+fn bench_flush(c: &mut Criterion) {
+    use rand::Rng;
+
+    // Helper: fill `engine` with FLUSH_ROWS seeded rows and return the
+    // memtable byte size.
+    fn fill_engine(engine: &mut cqlite_core::storage::write_engine::WriteEngine) -> usize {
+        let mut rng = fixtures::seeded_rng();
+        for _ in 0..FLUSH_ROWS {
+            let id = uuid::Uuid::from_u128(rng.gen());
+            let age: i32 = rng.gen_range(0..100);
+            let salary: i64 = rng.gen_range(30_000..200_000);
+            let stmt = format!(
+                "INSERT INTO test_basic.simple_table \
+                 (id, name, age, salary, active) \
+                 VALUES ({id}, 'flush-row', {age}, {salary}, true)"
+            );
+            engine.execute(&stmt).expect("fill engine row");
+        }
+        engine.memtable_size()
+    }
+
+    // Measure the representative memtable byte size once so Criterion can use
+    // it as a static throughput label.  (Criterion's throughput is set on the
+    // group before the loop and doesn't change per-iteration.)
+    let size_probe = {
+        let tmp = tempfile::TempDir::new().expect("probe temp dir");
+        let mut engine = fixtures::open_write_engine(tmp.path(), usize::MAX);
+        let sz = fill_engine(&mut engine);
+        assert!(
+            sz > 0,
+            "flush bench: memtable_size() returned 0 after {FLUSH_ROWS} inserts"
+        );
+        sz
+    };
+
+    // Shared Tokio runtime for `block_on(engine.flush())`.
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime for flush bench");
+
+    let mut group = c.benchmark_group("write");
+    group.throughput(Throughput::Bytes(size_probe as u64));
+
+    group.bench_function("flush", |b| {
+        b.iter_batched(
+            // SETUP (untimed): fresh engine pre-filled with FLUSH_ROWS rows.
+            || {
+                let tmp = tempfile::TempDir::new().expect("create temp dir for flush bench");
+                // Use usize::MAX flush threshold so the engine will not
+                // auto-flush during setup; we trigger the flush manually in
+                // the routine.
+                let mut engine = fixtures::open_write_engine(tmp.path(), usize::MAX);
+                let sz = fill_engine(&mut engine);
+                assert!(
+                    sz > 0,
+                    "flush bench setup: memtable empty after {FLUSH_ROWS} rows"
+                );
+                (tmp, engine)
+            },
+            // ROUTINE (timed): flush once and assert an SSTable was produced.
+            |(_tmp, mut engine)| {
+                let result = rt.block_on(engine.flush()).expect("flush must not error");
+                assert!(
+                    result.is_some(),
+                    "flush returned None — nothing was written to disk; \
+                     check that FLUSH_ROWS rows are above the flush threshold"
+                );
+                black_box(result)
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+// ── criterion_group! / criterion_main! ──────────────────────────────────────
+//
+// Four variants mirror fixtures_smoke.rs so the bench file compiles under
+// every feature combination without dead-code noise.
+
+#[cfg(feature = "write-support")]
+criterion_group!(benches, bench_ingest, bench_flush);
+
+#[cfg(not(feature = "write-support"))]
+fn bench_noop(_c: &mut Criterion) {
+    // write-support is disabled; these benches are no-ops.
+    // Enable with: --features write-support
+}
+
+#[cfg(not(feature = "write-support"))]
+criterion_group!(benches, bench_noop);
+
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

Phase 1 of Epic #541. Adds single-threaded Criterion **write** micro-benchmarks over the M5 `WriteEngine`, using the #537 temp-isolated fixture loader. New `cqlite-core/benches/write.rs` (`harness = false`), gated on `write-support`:

- **`write/ingest_wal_on`** — sustained mutation ingest via `WriteEngine::execute`. `iter_batched` with a fresh temp-dir engine per batch (flush threshold `usize::MAX` so no mid-batch auto-flush), 256 seeded rows/iter; RNG seeding kept in untimed setup. `Throughput::Elements` → writes/sec.
- **`write/flush`** — memtable→SSTable flush latency. Pre-fills 1000 seeded rows (untimed setup), times `engine.flush()`, asserts it produced an SSTable (`Some`). `Throughput::Bytes` from the pre-flush memtable size → MB/s.

Deterministic seeded input (`fixtures::seeded_rng`), temp dirs cleaned via `TempDir` RAII, single-threaded. Under default features (no `write-support`) compiles to a no-op group.

### WAL on/off (tracked in #547)

Only the **WAL-on** ingest variant is implemented. `WriteEngine::write()` unconditionally appends+syncs the WAL and `WriteEngineConfig` exposes no durability toggle, so the WAL-off variant can't be expressed through the public API — adding the toggle is core work, out of scope for "benches drive the public API". Filed #547; the bench is named `ingest_wal_on` so `ingest_wal_off` slots in cleanly once #547 lands.

## Acceptance criteria (#539)

- [x] Two benches wired under `cqlite-core/benches/` (`harness = false`).
- [~] WAL on/off reported separately — **WAL-on** shipped; WAL-off deferred to #547 (no public toggle exists; see above).
- [x] Deterministic input (fixed seed); temp dirs cleaned.
- [x] `RUSTFLAGS="-D warnings" cargo clippy` clean.

## Validation

- `cargo bench -p cqlite-core --features write-support --bench write -- --test` ✓ (both Success)
- Default-features compile (`--bench write -- --test`) ✓ (no-op group)
- `cargo fmt --check` ✓
- `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features` ✓ (0 warnings)

Reviewed by `rust-reviewer` agent: PASS (moved RNG seeding out of the timed ingest path per review).

Part of #541. WAL-off follow-up: #547.