### PR TITLE
perf(ci): baseline capture + regression gate (closes #540)

### DIFF
--- a/.github/workflows/perf-regression.yml
+++ b/.github/workflows/perf-regression.yml
@@ -1,0 +1,120 @@
+name: "CI: Performance Regression Gate"
+
+# Phase 1 of the performance plan (Epic #541): an in-repo regression wall.
+# Runs the cqlite-core read + write micro-benchmarks on BOTH the PR and `main`
+# on the SAME runner, then fails if any tracked bench's Criterion median is more
+# than the configured threshold slower on the PR than on main. The baseline is
+# main itself (re-measured every run), so no machine-specific absolute timings
+# are committed and the gate is immune to cross-machine variance.
+#
+# Policy (tracked benches + threshold) lives in cqlite-core/benches/perf-gate.json.
+# See cqlite-core/benches/README.md ("Performance regression gate") for details
+# and the baseline-refresh procedure.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "cqlite-core/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/perf-regression.yml"
+      - "scripts/ci/check_perf_regression.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: perf-regression-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  DATASET_TAG: datasets-v2
+  DATASET_ASSET: cassandra5-small-full.tar.gz
+  DATASET_SHA256: 5be43811bbee320a412aaf79aa63134ec1e2ec5434c03815a082b4a31bd86c55
+  CQLITE_DATASETS_ROOT: ${{ github.workspace }}/test-data/datasets
+  # Features needed by the benches: cli-helpers for the read suite (queryable
+  # Database), write-support for the write suite (WriteEngine).
+  BENCH_FEATURES: "cli-helpers,write-support"
+  # Criterion run config — kept small for CI. Tune here if the gate is too noisy
+  # (more samples → stabler medians, slower job).
+  BENCH_ARGS: "--sample-size 20 --warm-up-time 1 --measurement-time 3"
+
+jobs:
+  perf-gate:
+    name: Bench regression vs main
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout (full history so we can also build main)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      # Cache only the registry/git, NOT target/. This job checks out two
+      # different source trees (PR ref, then main) into the same workspace; a
+      # cached target/ would carry incremental-compilation state across that
+      # switch. Rebuilding from clean deps is the robust choice for a gate.
+      - name: Cache Cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-perfgate-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-perfgate-cargo-
+            ${{ runner.os }}-cargo-
+
+      - name: Cache canonical datasets
+        uses: actions/cache@v4
+        with:
+          path: test-data/datasets/
+          key: ${{ runner.os }}-datasets-${{ env.DATASET_TAG }}-${{ env.DATASET_SHA256 }}
+
+      - name: Fetch canonical datasets
+        run: bash ./test-data/scripts/fetch-datasets.sh
+
+      - name: Dataset provenance gate
+        run: |
+          scripts/ci/ensure_real_dataset.sh \
+            "${CQLITE_DATASETS_ROOT}" \
+            "${DATASET_ASSET}" \
+            "performance regression gate"
+
+      - name: Record refs
+        id: refs
+        run: |
+          set -euo pipefail
+          # In a pull_request run the workspace is the PR↔main merge commit; that
+          # is exactly what we want to measure (what main becomes if merged).
+          echo "pr_ref=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "PR (merge) ref: $(git rev-parse HEAD)"
+          echo "main baseline ref: $(git rev-parse origin/main)"
+
+      - name: Benchmark PR (merge ref) → baseline 'pr'
+        run: |
+          cargo bench -p cqlite-core --features "$BENCH_FEATURES" \
+            --bench read --bench write -- --save-baseline pr $BENCH_ARGS
+
+      - name: Benchmark main → baseline 'base'
+        run: |
+          set -euo pipefail
+          git checkout --force --detach origin/main
+          git submodule update --init --recursive || true
+          cargo bench -p cqlite-core --features "$BENCH_FEATURES" \
+            --bench read --bench write -- --save-baseline base $BENCH_ARGS
+
+      - name: Restore PR ref (for the gate script + policy)
+        run: git checkout --force --detach ${{ steps.refs.outputs.pr_ref }}
+
+      - name: Compare PR vs main (fail on regression past threshold)
+        run: |
+          python3 scripts/ci/check_perf_regression.py \
+            target/criterion pr base cqlite-core/benches/perf-gate.json

--- a/cqlite-core/benches/README.md
+++ b/cqlite-core/benches/README.md
@@ -70,6 +70,43 @@ env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets \
 | `partition_lookup` | kept | Index.db partition-key lookup (`IndexReader::lookup_partition`) — cold/warm cache, throughput, access-pattern distribution. The latency-sensitive read path. |
 | `m1_performance` | kept | M1 baseline targets: partition-lookup latency plus multi-SSTable read throughput (MB/s). |
 | `fixtures_smoke` | added (#537) | Smoke/acceptance bench proving the fixture loaders are deterministic (seeded RNG + stable scan row count). Read/write portions activate under `cli-helpers` / `write-support`. |
+| `read` | added (#538) | Read suite (needs `--features cli-helpers`): `point_lookup`, `clustering_slice`, `full_scan`, `type_heavy` over the fixtures via the public query API. |
+| `write` | added (#539) | Write suite (needs `--features write-support`): `ingest_wal_on` (sustained ingest) and `flush` (memtable→SSTable flush latency) over the M5 `WriteEngine`. |
+
+## Performance regression gate (Issue #540)
+
+CI runs the `read` + `write` benches on **both the PR and `main`, on the same
+runner**, and fails the PR if any tracked bench's Criterion **median** is more
+than the threshold slower than on main. Comparing PR-vs-main on one runner means
+the gate measures *relative* change only, so it is immune to the cross-machine
+(and cross-OS) variance that makes committed absolute-time baselines unreliable.
+
+- **Workflow:** `.github/workflows/perf-regression.yml` (runs on PRs touching
+  `cqlite-core/**` and on manual `workflow_dispatch`).
+- **Policy / baseline:** `cqlite-core/benches/perf-gate.json` — the tracked bench
+  IDs and `threshold_pct` (default **10%**). This file *is* the committed,
+  version-controlled baseline policy; the measured baseline is `main` itself,
+  re-measured on every run.
+- **Comparison:** `scripts/ci/check_perf_regression.py` reads the Criterion
+  median (`estimates.json`) for each tracked bench from the `pr` and `base`
+  baselines and exits non-zero on any regression past the threshold. Benches
+  absent from `main` (e.g. a brand-new bench) are reported `SKIP`, never failed.
+
+### Adjusting / refreshing the gate
+
+There is no committed absolute-time baseline to refresh — **`main` is the living
+baseline**, so merging a legitimate change automatically updates what future PRs
+are compared against. To change *what* the gate enforces, edit
+`cqlite-core/benches/perf-gate.json`:
+
+- raise/lower `threshold_pct` (micro-benchmarks on shared CI runners are noisy;
+  if the gate flaps, raise the threshold or increase `--sample-size` in the
+  workflow's `BENCH_ARGS`);
+- add/remove bench IDs from `benches`.
+
+If a PR intentionally trades performance for another goal, justify the regression
+in the PR description; a reviewer can raise the threshold or merge with the
+explanation on record.
 
 ## Audit (Issue #536)
 

--- a/cqlite-core/benches/perf-gate.json
+++ b/cqlite-core/benches/perf-gate.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "Performance regression gate policy for Epic #541 Phase 1. The CI workflow .github/workflows/perf-regression.yml runs these benches on both the PR and main on the SAME runner and fails if any tracked bench's Criterion median regresses by more than threshold_pct. The baseline is main itself (re-measured each run), so absolute timings are never committed and the gate is immune to cross-machine variance. To adjust the gate, edit this file (threshold or tracked set); see cqlite-core/benches/README.md.",
+  "threshold_pct": 10,
+  "benches": [
+    "read/point_lookup",
+    "read/clustering_slice",
+    "read/full_scan",
+    "read/type_heavy",
+    "write/ingest_wal_on",
+    "write/flush"
+  ]
+}

--- a/scripts/ci/check_perf_regression.py
+++ b/scripts/ci/check_perf_regression.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Fail CI when a tracked Criterion bench regresses past the configured threshold.
+
+Compares the Criterion *median* point estimate of each tracked benchmark between
+two saved baselines (typically the PR's `pr` baseline and `main`'s `base`
+baseline, both measured on the same CI runner — see
+`.github/workflows/perf-regression.yml`). Exits non-zero if any tracked bench is
+more than `threshold_pct` slower in `new` than in `base`.
+
+Usage:
+    check_perf_regression.py <criterion_dir> <new_baseline> <base_baseline> <perf_gate_json>
+
+Example:
+    check_perf_regression.py target/criterion pr base cqlite-core/benches/perf-gate.json
+
+Benches missing from either baseline are reported as SKIP (e.g. a bench added in
+the PR that main does not have yet) and never fail the gate.
+"""
+
+import json
+import os
+import sys
+
+
+def _median_ns(criterion_dir, bench_id, baseline):
+    """Return the median point estimate (ns) for a bench baseline, or None."""
+    path = os.path.join(criterion_dir, bench_id, baseline, "estimates.json")
+    if not os.path.isfile(path):
+        return None
+    with open(path) as fh:
+        data = json.load(fh)
+    return data["median"]["point_estimate"]
+
+
+def main(argv):
+    if len(argv) != 5:
+        print(__doc__)
+        return 2
+
+    criterion_dir, new_baseline, base_baseline, cfg_path = argv[1:5]
+
+    with open(cfg_path) as fh:
+        cfg = json.load(fh)
+    threshold_pct = float(cfg["threshold_pct"])
+    threshold = threshold_pct / 100.0
+    benches = cfg["benches"]
+
+    print(
+        f"Performance regression gate: '{new_baseline}' vs '{base_baseline}' "
+        f"(fail if any bench > {threshold_pct:g}% slower)\n"
+    )
+    header = f"{'bench':<32} {'base (ns)':>16} {'new (ns)':>16} {'delta':>9}  status"
+    print(header)
+    print("-" * len(header))
+
+    failures = []
+    compared = 0
+    for bench in benches:
+        base = _median_ns(criterion_dir, bench, base_baseline)
+        new = _median_ns(criterion_dir, bench, new_baseline)
+        if base is None or new is None:
+            missing = []
+            if base is None:
+                missing.append(f"{base_baseline}")
+            if new is None:
+                missing.append(f"{new_baseline}")
+            print(
+                f"{bench:<32} {'-':>16} {'-':>16} {'-':>9}  "
+                f"SKIP (no data in: {', '.join(missing)})"
+            )
+            continue
+
+        compared += 1
+        ratio = (new / base) - 1.0
+        if ratio > threshold:
+            status = f"REGRESSION (> {threshold_pct:g}%)"
+            failures.append((bench, ratio))
+        else:
+            status = "ok"
+        print(f"{bench:<32} {base:>16.0f} {new:>16.0f} {ratio * 100:>+8.1f}%  {status}")
+
+    print()
+    if compared == 0:
+        # No bench could be compared (e.g. baselines never produced) — surface
+        # loudly rather than passing silently.
+        print("❌ No tracked benches could be compared (no baseline data found).")
+        return 1
+    if failures:
+        print(f"❌ {len(failures)} bench(es) regressed past {threshold_pct:g}%:")
+        for bench, ratio in failures:
+            print(f"   - {bench}: {ratio * 100:+.1f}%")
+        print(
+            "\nIf this slowdown is expected/intended, justify it in the PR. To change "
+            "the threshold or tracked set, edit cqlite-core/benches/perf-gate.json."
+        )
+        return 1
+
+    print(f"✅ All {compared} tracked bench(es) within {threshold_pct:g}% of main.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
## Summary

Final piece of Epic #541 Phase 1: gate PRs on performance regressions in the `cqlite-core` read + write benches.

**Design — compare-vs-main on the same runner (no committed absolute timings):** `.github/workflows/perf-regression.yml` runs the `read` + `write` benches on both the PR (merge ref) and `main`, on the *same* runner, saving Criterion baselines `pr` and `base`. `scripts/ci/check_perf_regression.py` then fails the PR if any tracked bench's Criterion **median** is more than the threshold slower on `pr` than `base`. Measuring relative change on one runner makes the gate immune to cross-machine/OS variance that plagues committed absolute-time baselines.

- **`cqlite-core/benches/perf-gate.json`** — committed gate policy: tracked bench IDs + `threshold_pct` (**10%**). This *is* the version-controlled baseline policy; the measured baseline is `main` itself, re-measured every run.
- **`scripts/ci/check_perf_regression.py`** — median extraction from `estimates.json`, ratio test, `SKIP` for benches missing in either baseline (e.g. a brand-new bench), and a fail-loudly guard if *nothing* could be compared.
- **`cqlite-core/benches/README.md`** — documents the gate, the 10% threshold, the shared-runner noise tradeoff, and how to adjust/refresh.

## Acceptance criteria (#540)

- [x] Baseline stored and documented — committed policy (`perf-gate.json`) + `main` as the living measured baseline; documented in README.
- [x] Workflow runs benches and compares on PR.
- [x] Regression past threshold fails CI; refresh procedure documented (it's automatic vs main; tune threshold/tracked-set in `perf-gate.json`).

## Validation

- End-to-end local dry-run: ran all six benches into `pr` and `base` baselines → script passed (exit 0, all within 10%, only *speedups* on the noisy ones); synthetic +25% → exit 1; +5% → exit 0.
- `python3 -m py_compile` clean; `perf-gate.json` parses.
- `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features` ✓ (no Rust changed; confirmed clean).

Reviewed by `rust-reviewer` agent: PASS (applied its robustness fixes — dropped `target/` from the cache given the double-checkout, added `timeout-minutes: 30`, made ref-logging visible).

> Note: the new workflow only runs once this PR's branch exists; this PR adds no bench code, so the gate's first comparison is PR-benches ≡ main-benches → ~0% diff → pass, demonstrating the gate green-path.

Closes #540. Part of #541.