### PR TITLE
fix(reader): parse real BIG-format Index.db raw keys; wire write-support tests into CI (closes #552)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,18 @@ jobs:
             --test golden_path_scan_operations_tests \
             --test golden_path_summary_index_integration_tests
 
+      - name: Run write-support tests (issue #552)
+        env:
+          CQLITE_DATASETS_ROOT: ${{ github.workspace }}/test-data/datasets
+        run: |
+          echo "Running write-support unit + roundtrip + compaction tests (issue #552)..."
+          # These targets are self-contained: the lib unit tests, the write/read
+          # roundtrip suite, and the compaction integration suite all build their own
+          # SSTables in tempdirs, so they stay green without untracked fixture data.
+          cargo test --package cqlite-core --features write-support --lib
+          cargo test --package cqlite-core --features write-support --test write_read_roundtrip
+          cargo test --package cqlite-core --features write-support --test compaction_integration
+
       - name: Run CLI unit tests
         env:
           CQLITE_DATASETS_ROOT: ${{ github.workspace }}/test-data/datasets

--- a/cqlite-core/Cargo.toml
+++ b/cqlite-core/Cargo.toml
@@ -57,7 +57,6 @@ base64 = "0.21"
 
 # Hashing for Cassandra compatibility
 murmur3 = "0.5"
-md5 = "0.7"
 
 # Features defined at end of file to avoid duplicates
 

--- a/cqlite-core/src/storage/sstable/index_reader.rs
+++ b/cqlite-core/src/storage/sstable/index_reader.rs
@@ -404,7 +404,11 @@ fn parse_big_index_entry(input: &[u8]) -> IResult<&[u8], PartitionIndexEntry> {
     // Read promoted-index length (unsigned VInt) and skip the promoted data.
     // Partition-level lookups work without decoding the promoted index.
     let (input, promoted_len) = parse_vuint(input)?;
-    let (input, _promoted_data) = take(promoted_len as usize)(input)?;
+    // Saturating cast: on a 32-bit target `promoted_len as usize` could truncate and
+    // misalign subsequent entries. `usize::MAX` makes `take` return an Eof error on a
+    // short buffer instead, which is the safe failure mode for a corrupt Index.db.
+    let promoted_len = usize::try_from(promoted_len).unwrap_or(usize::MAX);
+    let (input, _promoted_data) = take(promoted_len)(input)?;
 
     log::trace!(
         "Index.db BIG entry: key_len={}, data_offset={}, promoted_len={}",
@@ -752,11 +756,11 @@ mod tests {
 
     #[test]
     fn test_simple_partition_key_parsing() {
-        // NB format: marker(2) + key_digest(16) + vint_offset(1-9) + vint_promoted_size(1-9)
+        // NB BIG format: key_len(2) + raw_key(key_len) + vint_offset(1-9) + vint_promoted_size(1-9)
         // VInt encoding for 256: 0x81, 0x00 (2 bytes, 10xxxxxx format)
         let data = vec![
-            0x00, 0x10, // marker = 0x0010
-            0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, // key_digest (16 bytes)
+            0x00, 0x10, // key_len = 16 (e.g. a 16-byte UUID partition key)
+            0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, // raw key (16 bytes)
             0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, // key_digest cont.
             0x81, 0x00, // VInt offset = 256
             0x00, // VInt promoted_size = 0 (no promoted index)
@@ -840,20 +844,20 @@ mod tests {
     #[test]
     fn test_multiple_partition_keys_parsing() {
         // Two partition entries with VInt offsets (NB format)
-        // Format: marker(2) + digest(16) + vint_offset + vint_promoted_size
+        // Format: key_len(2) + raw_key(key_len) + vint_offset + vint_promoted_size
         // VInt encoding for 100 (0x64): 0x64 (1 byte, value < 128)
         // VInt encoding for 500 (0x1F4): 0x81, 0xF4 (2 bytes, 10xxxxxx format)
         //   byte0 = 0x80 | ((500 >> 8) & 0x3F) = 0x80 | 1 = 0x81
         //   byte1 = 500 & 0xFF = 0xF4
         let data = vec![
             // Entry 1
-            0x00, 0x10, // marker = 0x0010
+            0x00, 0x10, // key_len = 16 (e.g. a 16-byte UUID partition key)
             0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, // key_digest 1 (16 bytes)
             0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, // key_digest cont.
             0x64, // VInt offset = 100
             0x00, // VInt promoted_size = 0
             // Entry 2
-            0x00, 0x10, // marker = 0x0010
+            0x00, 0x10, // key_len = 16 (e.g. a 16-byte UUID partition key)
             0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, // key_digest 2 (16 bytes)
             0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0x20, // key_digest cont.
             0x81, 0xF4, // VInt offset = 500
@@ -896,18 +900,18 @@ mod tests {
         // to avoid heap allocation on every lookup
 
         // Create index data with two partition entries (NB format with VInt offsets)
-        // Format: marker(2) + digest(16) + vint_offset + vint_promoted_size
+        // Format: key_len(2) + raw_key(key_len) + vint_offset + vint_promoted_size
         // VInt for 100: 0x64 (single byte, value < 128)
         // VInt for 500: 0x81, 0xF4 (2 bytes)
         let data = vec![
             // Entry 1
-            0x00, 0x10, // marker = 0x0010
+            0x00, 0x10, // key_len = 16 (e.g. a 16-byte UUID partition key)
             0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, // key_digest 1
             0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, // key_digest cont.
             0x64, // VInt offset = 100
             0x00, // VInt promoted_size = 0
             // Entry 2
-            0x00, 0x10, // marker = 0x0010
+            0x00, 0x10, // key_len = 16 (e.g. a 16-byte UUID partition key)
             0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, // key_digest 2
             0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0x20, // key_digest cont.
             0x81, 0xF4, // VInt offset = 500

--- a/cqlite-core/src/storage/sstable/index_reader.rs
+++ b/cqlite-core/src/storage/sstable/index_reader.rs
@@ -37,12 +37,18 @@ pub struct IndexHeader {
 /// Partition index entry in Index.db
 #[derive(Debug, Clone)]
 pub struct PartitionIndexEntry {
-    /// Partition key hash/digest - using Arc to enable zero-copy sharing in lookup tables
-    /// This eliminates memory explosion from cloning large numbers of partition digests
+    /// Raw partition key bytes (length-prefixed in the on-disk BIG/NB Index.db format).
+    ///
+    /// NOTE (Issue #552): Despite the historical field name `key_digest`, this holds the
+    /// RAW partition key bytes, not an MD5 digest. The real Cassandra 5.0 NB Index.db entry
+    /// format is `[key_len: u16 BE][raw key bytes][data_offset: vint][promoted_len: vint]`.
+    /// There is no `0x0010` marker and no MD5 digest on disk. The field name is retained to
+    /// avoid churn in the zero-copy lookup table and downstream callers; it is used directly
+    /// as the partition key (e.g. for `RowKey`). The leading u16 is the key length
+    /// (e.g. 0x0010 for a 16-byte UUID, 0x0026 for a 38-byte composite key).
     pub key_digest: Arc<[u8]>,
-    /// Raw partition key bytes for BTI format (Issue #212)
-    /// BTI format stores actual partition keys, not MD5 digests. This field enables
-    /// direct key comparison for sequential scan fallback when offsets are unavailable.
+    /// Raw partition key bytes (mirror of `key_digest`, kept for API compatibility).
+    /// Always `Some` now that all entries carry their raw key.
     pub raw_key: Option<Arc<[u8]>>,
     /// Offset in Data.db file
     pub data_offset: u64,
@@ -320,30 +326,46 @@ fn parse_index_data_with_summary<'a>(
     ))
 }
 
-/// Parse all partition key digests from the Index.db file with Summary.db correlation
+/// Parse all partition entries from the Index.db file.
+///
+/// ## Authoritative format (Issue #552, Cassandra 5.0 NB / BIG Index.db)
+///
+/// Index.db is ALWAYS the BIG-format partition index. Each entry is:
+///
+/// ```text
+/// [key_len: u16 BE]                    ← length of the raw partition key
+/// [raw partition key bytes: key_len]   ← the partition key exactly as in Data.db
+/// [data_offset: unsigned vint]         ← byte offset into the Data.db data section
+/// [promoted_index_len: unsigned vint]  ← byte length of the promoted index (0 = none)
+/// [promoted_index_data: promoted_index_len bytes]
+/// ```
+///
+/// The leading u16 is the partition key LENGTH, not a `0x0010` marker, and there is no
+/// MD5 digest on disk (verified against real Cassandra Index.db files: single-UUID keys
+/// start `0x0010`, the composite-key `multi_partition_table` starts `0x0026` = 38 bytes).
+///
+/// There is no separate "BTI" Index.db format: a BTI-indexed SSTable uses Partitions.db /
+/// Rows.db trie structures and does not produce an Index.db at all (see guide Ch.17). So the
+/// previous `detect_index_format` heuristic was entirely spurious (Issue #28 mandate) and has
+/// been removed in favour of this single, spec-accurate parser that works for ANY key length.
+///
+/// The `summary_reader` argument is retained for API compatibility; offsets are now stored
+/// inline so Summary.db correlation is no longer needed for parsing.
 fn parse_all_partition_keys_with_summary<'a>(
     input: &'a [u8],
-    summary_reader: Option<&SummaryReader>,
+    _summary_reader: Option<&SummaryReader>,
 ) -> IResult<&'a [u8], Vec<PartitionIndexEntry>> {
     let mut entries = Vec::new();
     let mut remaining = input;
 
-    // Detect format by checking first 2 bytes
-    let format = detect_index_format(input);
-    log::debug!("Detected Index.db format: {:?}", format);
-
-    // Parse entries until we consume all input
     let mut entry_index = 0;
     while !remaining.is_empty() {
-        let parse_result = match format {
-            IndexFormat::DigestFormat => {
-                parse_simple_partition_key_with_offset(remaining, entry_index, summary_reader)
-            }
-            IndexFormat::BtiFormat => parse_bti_partition_entry(remaining, entry_index),
-        };
-
-        match parse_result {
+        match parse_big_index_entry(remaining) {
             Ok((rest, entry)) => {
+                debug_assert!(
+                    rest.len() < remaining.len(),
+                    "BIG Index.db parser must make forward progress"
+                );
                 entries.push(entry);
                 remaining = rest;
                 entry_index += 1;
@@ -354,268 +376,51 @@ fn parse_all_partition_keys_with_summary<'a>(
                     entry_index,
                     remaining.len()
                 );
-                // Stop parsing if we can't parse more entries
                 break;
             }
         }
     }
 
-    log::debug!(
-        "Parsed {} partition entries from Index.db ({:?} format)",
-        entries.len(),
-        format
-    );
+    log::debug!("Parsed {} partition entries from Index.db", entries.len());
     Ok((remaining, entries))
 }
 
-/// Parse a single partition key from the Index.db format with variable-length offset
-fn parse_simple_partition_key_with_offset<'a>(
-    input: &'a [u8],
-    #[allow(unused_variables)] entry_index: usize,
-    _summary_reader: Option<&SummaryReader>,
-) -> IResult<&'a [u8], PartitionIndexEntry> {
-    // Some Index.db formats have a 2-byte length prefix before each entry
-    // Try to detect and skip it if present
-    let (input, first_word) = be_u16(input)?;
+/// Parse a single BIG-format Index.db entry.
+///
+/// Layout: `[key_len: u16 BE][raw key][data_offset: vint][promoted_len: vint][promoted...]`.
+/// Works for any key length (int, text, UUID, composite). The raw partition key is stored
+/// directly in `key_digest` / `raw_key` (no MD5, no marker).
+fn parse_big_index_entry(input: &[u8]) -> IResult<&[u8], PartitionIndexEntry> {
+    // Read partition key length (u16 big-endian).
+    let (input, key_len) = be_u16(input)?;
 
-    let (input, marker) = if first_word == 0x0010 {
-        // No length prefix, first_word is the marker
-        (input, first_word)
-    } else {
-        // first_word is likely a length prefix, read the actual marker
-        be_u16(input)?
-    };
+    // Read the raw partition key bytes.
+    let (input, key_bytes) = take(key_len)(input)?;
 
-    if marker != 0x0010 {
-        return Err(nom::Err::Error(nom::error::Error::new(
-            input,
-            nom::error::ErrorKind::Tag,
-        )));
-    }
-
-    // Read partition key digest (16 bytes)
-    let (input, key_digest) = take(16_u8)(input)?;
-
-    // Read unsigned VInt offset (Cassandra 5.0 NB format)
-    // Offset is relative to data section start, not file start
-    // SSTableReader will add actual_header_size when seeking
+    // Read unsigned VInt data offset (relative to the Data.db data section start;
+    // SSTableReader adds the header size when seeking).
     let (input, data_offset) = parse_vuint(input)?;
 
-    // Read promoted index serialized size (VInt)
-    // If size > 0, there's promoted index data following
-    // For now, we skip the promoted index data since partition lookup works without it
-    let (input, promoted_size) = parse_vuint(input)?;
-    let (input, _promoted_data) = take(promoted_size as usize)(input)?;
-
-    // Debug logging to verify parsing
-    log::debug!(
-        "IndexReader Entry {}: marker={:#06x}, data_offset={}, promoted_size={}",
-        entry_index,
-        marker,
-        data_offset,
-        promoted_size
-    );
-
-    // Size not stored in Index.db - will be determined during data read
-    let data_size = 0;
-
-    Ok((
-        input,
-        PartitionIndexEntry {
-            key_digest: Arc::from(key_digest),
-            raw_key: None, // Digest format doesn't have raw keys
-            data_offset,
-            data_size,
-            promoted_index: None,
-        },
-    ))
-}
-
-// REMOVED: try_parse_enhanced_partition_entry
-// The "enhanced format" with inline offsets was causing false positives
-// Issue #92 mandates using Summary.db for offset correlation, not inline heuristics
-
-/// Index.db format variants
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum IndexFormat {
-    /// MD5 digest format: marker(0x0010) + digest(16) + offset_len(1) + offset(variable)
-    DigestFormat,
-    /// BTI/Partition Key format: entry_len(2) + key_len(2) + key(variable) + metadata(variable)
-    BtiFormat,
-}
-
-/// Detect which Index.db format is in use by examining first 2 bytes
-///
-/// ## TEMPORARY HEURISTIC (Issue #28 Follow-up - Technical Debt)
-///
-/// This function uses byte-pattern detection as a temporary workaround until proper
-/// TOC/Statistics integration in M3. The proper fix is to pass format hint from
-/// SSTableReader (which has authoritative version/format metadata).
-///
-/// **Current approach:**
-/// - Check if first 2 bytes are 0x0010 (digest format marker)
-/// - If yes: DigestFormat (MD5 digest + variable-length offset)
-/// - If no: BtiFormat (byte-comparable key + metadata)
-///
-/// **Future improvement (M3):**
-/// - SSTableReader should read TOC/Statistics to determine format authoritatively
-/// - Pass format hint as parameter to this function
-/// - Only fall back to byte-pattern detection if hint unavailable
-fn detect_index_format(input: &[u8]) -> IndexFormat {
-    if input.len() < 2 {
-        // Default to digest format for empty/invalid input
-        log::warn!(
-            "Index.db input too short ({} bytes), defaulting to DigestFormat",
-            input.len()
-        );
-        return IndexFormat::DigestFormat;
-    }
-
-    let first_word = u16::from_be_bytes([input[0], input[1]]);
-
-    // If first word is the digest format marker (0x0010), it's digest format
-    // Otherwise, treat as BTI format (entry length prefix)
-    if first_word == 0x0010 {
-        log::debug!("Detected DigestFormat (marker: {:#06x})", first_word);
-        IndexFormat::DigestFormat
-    } else {
-        // BTI format starts with entry length (typically 0x000e = 14 bytes for simple text keys)
-        log::info!("BTI format detected, using sequential read mode for partition lookups");
-        IndexFormat::BtiFormat
-    }
-}
-
-/// Parse a single partition entry from BTI/Partition Key format
-///
-/// BTI format structure:
-/// - padding: variable (0-3 null bytes between entries)
-/// - entry_length: 2 bytes (big-endian) - total length of entry excluding this field
-/// - key_length: 2 bytes (big-endian) - length of partition key
-/// - key_bytes: variable - actual partition key bytes
-/// - metadata: variable - clustering data, offset, padding
-///
-/// For stock_prices example:
-/// ```text
-/// 00 0e         - entry_length = 14 bytes
-/// 00 04         - key_length = 4 bytes
-/// 41 4d 5a 4e   - key_bytes = "AMZN"
-/// 00 00 04 80   - metadata (clustering/timestamp?)
-/// 00 4f 88      - metadata (offset?)
-/// 00            - end of entry metadata
-/// 00 00 00      - padding before next entry (Issue #212)
-/// ```
-fn parse_bti_partition_entry(
-    input: &[u8],
-    _entry_index: usize,
-) -> IResult<&[u8], PartitionIndexEntry> {
-    // Issue #212: Skip inter-entry padding/trailer bytes in BTI format
-    // Entries can be separated by variable-length data (typically 0-3 bytes).
-    // This padding can be null bytes (0x00) or non-null bytes (like 0x90 0xdb 0x00).
-    // BTI entry_length is typically 0x000e (14) to 0x0100 (256) for reasonable key sizes.
-    //
-    // Strategy: Scan forward looking for a valid entry_length pattern (0x00 0x04-0xff).
-    // Valid entry_length in BTI format has high byte 0x00 and low byte >= 4.
-    let mut input = input;
-    let max_skip = std::cmp::min(10, input.len().saturating_sub(4)); // Don't skip too many bytes
-    let mut skipped = 0;
-
-    while skipped < max_skip && input.len() >= 4 {
-        // Check if current position looks like a valid entry_length (0x00 0x04-0xff)
-        if input[0] == 0x00 && input[1] >= 4 {
-            // This looks like a valid entry_length - verify by checking key_length follows
-            let potential_entry_len = u16::from_be_bytes([input[0], input[1]]);
-            let potential_key_len = u16::from_be_bytes([input[2], input[3]]);
-
-            // Key length should be reasonable (1-255 bytes for partition keys)
-            if (4..1000).contains(&potential_entry_len)
-                && potential_key_len > 0
-                && potential_key_len < 256
-                && (potential_key_len + 2) <= potential_entry_len
-            {
-                break; // Found valid entry start
-            }
-        }
-        // Skip one byte
-        input = &input[1..];
-        skipped += 1;
-    }
-
-    if input.len() < 4 {
-        // Not enough bytes for minimal entry (2 bytes entry_length + 2 bytes key_length)
-        return Err(nom::Err::Error(nom::error::Error::new(
-            input,
-            nom::error::ErrorKind::Eof,
-        )));
-    }
+    // Read promoted-index length (unsigned VInt) and skip the promoted data.
+    // Partition-level lookups work without decoding the promoted index.
+    let (input, promoted_len) = parse_vuint(input)?;
+    let (input, _promoted_data) = take(promoted_len as usize)(input)?;
 
     log::trace!(
-        "BTI padding: skipped {} bytes to find entry start at {:02x?}",
-        skipped,
-        &input[..std::cmp::min(4, input.len())]
+        "Index.db BIG entry: key_len={}, data_offset={}, promoted_len={}",
+        key_len,
+        data_offset,
+        promoted_len
     );
 
-    // Parse entry_length (2 bytes, big-endian)
-    let (input, entry_length) = be_u16(input)?;
-
-    // Parse key_length (2 bytes, big-endian)
-    let (input, key_length) = be_u16(input)?;
-
-    // Read key_bytes
-    let (input, key_bytes) = take(key_length)(input)?;
-
-    // Calculate remaining metadata length
-    // entry_length includes key_length field (2 bytes) + key_bytes + metadata
-    // We've already consumed key_length (2) + key_bytes (key_length)
-    // So metadata_length = entry_length - 2 - key_length
-    let metadata_length = entry_length.saturating_sub(2).saturating_sub(key_length);
-
-    // Read metadata section
-    let (input, metadata) = take(metadata_length)(input)?;
-
-    // TODO (M3 Technical Debt - Issue #208 C3): BTI format offset extraction
-    //
-    // BTI Index.db format does not have a clear specification for inline offset extraction.
-    // The metadata structure is unclear from available documentation and hex analysis.
-    // Setting offset to 0 to indicate sequential read mode is required.
-    //
-    // Proper fix: Research authoritative Cassandra 5.0+ BTI Index.db specification
-    // to determine if and how offsets are encoded in the metadata section.
-    let data_offset = 0;
-
-    log::debug!(
-        "BTI entry parsed: key=\"{}\", key_length={}, metadata_len={}. Offset set to 0 (sequential read mode)",
-        String::from_utf8_lossy(key_bytes),
-        key_length,
-        metadata.len()
-    );
-
-    // Issue #212 Fix: Store raw partition key for BTI format
-    //
-    // BTI format stores actual partition keys (e.g., "AMZN"), not MD5 digests.
-    // We now store the raw key for direct comparison during sequential scan fallback.
-    // The MD5 digest is still computed for compatibility with existing lookup code.
-    let key_digest = md5::compute(key_bytes);
-    let raw_key = Arc::from(key_bytes);
-
-    if data_offset == 0 {
-        log::debug!(
-            "BTI entry has no reliable offset, sequential read mode will be used. \
-             Entry: {:?}, metadata_len: {}",
-            String::from_utf8_lossy(key_bytes),
-            metadata.len()
-        );
-    }
-
-    // Entry structure is: [2-byte length][payload of 'length' bytes]
-    // No padding between entries - the next entry starts immediately with its length field.
-    // Previous code incorrectly skipped 2 bytes thinking it was padding, but hex analysis
-    // shows that was consuming the next entry's length field (Issue #208 C4).
+    let raw_key: Arc<[u8]> = Arc::from(key_bytes);
 
     Ok((
         input,
         PartitionIndexEntry {
-            key_digest: Arc::from(&key_digest[..]),
-            raw_key: Some(raw_key), // Issue #212: Store raw key for BTI matching
+            key_digest: Arc::clone(&raw_key),
+            raw_key: Some(raw_key),
+            // Size is not stored in Index.db; determined during the Data.db read.
             data_offset,
             data_size: 0,
             promoted_index: None,
@@ -643,10 +448,10 @@ fn parse_all_partition_keys(input: &[u8]) -> IResult<&[u8], Vec<PartitionIndexEn
     parse_all_partition_keys_with_summary(input, None)
 }
 
-/// Parse a single partition key from the simple Index.db format - Legacy API
+/// Parse a single BIG-format Index.db partition entry - Legacy API
 #[allow(dead_code)]
 fn parse_simple_partition_key(input: &[u8]) -> IResult<&[u8], PartitionIndexEntry> {
-    parse_simple_partition_key_with_offset(input, 0, None)
+    parse_big_index_entry(input)
 }
 
 // Note: Promoted index parsing removed as it's not present in the simple Index.db format
@@ -863,6 +668,88 @@ mod tests {
         }
     }
 
+    /// Issue #552: Validate the BIG-format parser against REAL Cassandra 5.0 Index.db files.
+    ///
+    /// `simple_table` has a single 16-byte UUID partition key (entries start 0x0010).
+    /// `multi_partition_table` has a 38-byte composite partition key (entries start 0x0026).
+    /// Both must read back ALL entries with monotonically increasing offsets.
+    #[tokio::test]
+    #[ignore = "Requires test data files (CQLITE_DATASETS_ROOT)"]
+    async fn test_real_index_db_big_format() {
+        let datasets_root = env::var("CQLITE_DATASETS_ROOT").unwrap_or_else(|_| {
+            "/Users/patrickmcfadin/local_projects/cqlite/test-data/datasets".to_string()
+        });
+
+        // --- Composite-key table (38-byte keys, entries start 0x0026) ---
+        let multi_dir = format!(
+            "{}/sstables/test_basic/multi_partition_table-6ac52100a25111f0a3fef1a551383fb9",
+            datasets_root
+        );
+        let multi_index = format!("{}/nb-1-big-Index.db", multi_dir);
+        let bytes = std::fs::read(&multi_index).expect("read multi_partition_table Index.db");
+        assert_eq!(
+            u16::from_be_bytes([bytes[0], bytes[1]]),
+            38,
+            "Composite key length should be 38 (0x0026)"
+        );
+        let (rest, entries) = parse_all_partition_keys(&bytes).expect("parse composite Index.db");
+        assert!(rest.is_empty(), "Should consume all Index.db bytes");
+        assert!(
+            entries.len() >= 2,
+            "multi_partition_table should have multiple partitions (got {})",
+            entries.len()
+        );
+        // First key is 38 bytes; first offset must be 0.
+        assert_eq!(
+            entries[0].key_digest.len(),
+            38,
+            "First key should be 38 bytes"
+        );
+        assert_eq!(
+            entries[0].data_offset, 0,
+            "First partition offset should be 0"
+        );
+        // Offsets are strictly increasing in token order.
+        for i in 1..entries.len() {
+            assert!(
+                entries[i].data_offset > entries[i - 1].data_offset,
+                "Offsets must increase: entry {} ({}) <= entry {} ({})",
+                i,
+                entries[i].data_offset,
+                i - 1,
+                entries[i - 1].data_offset
+            );
+        }
+
+        // --- Single-UUID-key table (16-byte keys, entries start 0x0010) ---
+        let simple_index = format!(
+            "{}/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Index.db",
+            datasets_root
+        );
+        let bytes = std::fs::read(&simple_index).expect("read simple_table Index.db");
+        assert_eq!(
+            u16::from_be_bytes([bytes[0], bytes[1]]),
+            16,
+            "UUID key length should be 16 (0x0010)"
+        );
+        let (rest, entries) = parse_all_partition_keys(&bytes).expect("parse simple Index.db");
+        assert!(rest.is_empty(), "Should consume all Index.db bytes");
+        assert!(
+            entries.len() > 3,
+            "simple_table should have many partitions (got {})",
+            entries.len()
+        );
+        assert_eq!(
+            entries[0].key_digest.len(),
+            16,
+            "First key should be 16 bytes"
+        );
+        assert_eq!(
+            entries[0].data_offset, 0,
+            "First partition offset should be 0"
+        );
+    }
+
     #[test]
     fn test_simple_partition_key_parsing() {
         // NB format: marker(2) + key_digest(16) + vint_offset(1-9) + vint_promoted_size(1-9)
@@ -890,36 +777,61 @@ mod tests {
 
     #[test]
     fn test_partition_key_parsing_without_summary() {
-        // NB format: marker(2) + key_digest(16) + vint_offset(1-9) + vint_promoted_size(1-9)
+        // BIG format: key_len(2) + raw key(key_len) + vint_offset + vint_promoted_size
         // VInt encoding for 4096 (0x1000): 0x90, 0x00 (2 bytes, 10xxxxxx format)
         // byte0 = 0x80 | ((4096 >> 8) & 0x3F) = 0x80 | 0x10 = 0x90
         // byte1 = 4096 & 0xFF = 0x00
         let data = vec![
-            0x00, 0x10, // marker = 0x0010
-            0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, // key_digest (16 bytes)
-            0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, // key_digest cont.
+            0x00, 0x10, // key_len = 16
+            0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, // raw key (16 bytes)
+            0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, // raw key cont.
             0x90, 0x00, // VInt offset = 4096
             0x00, // VInt promoted_size = 0
         ];
 
-        // Test with different entry indices - should all parse the same data
-        let (_, entry0) = parse_simple_partition_key_with_offset(&data, 0, None).unwrap();
-        let (_, entry1) = parse_simple_partition_key_with_offset(&data, 1, None).unwrap();
-        let (_, entry5) = parse_simple_partition_key_with_offset(&data, 5, None).unwrap();
+        let (_, entry) = parse_simple_partition_key(&data).unwrap();
 
         assert_eq!(
-            entry0.key_digest.as_ref(),
+            entry.key_digest.as_ref(),
             &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+        );
+        assert_eq!(
+            entry.raw_key.as_deref(),
+            Some(&[1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16][..]),
+            "raw_key should mirror the raw partition key"
         );
 
         // Raw offset from Index.db (relative to data section start)
-        assert_eq!(entry0.data_offset, 4096);
-        assert_eq!(entry1.data_offset, 4096);
-        assert_eq!(entry5.data_offset, 4096);
+        assert_eq!(entry.data_offset, 4096);
+    }
 
-        // All should have the same key digest in this test
-        assert_eq!(entry0.key_digest.as_ref(), entry1.key_digest.as_ref());
-        assert_eq!(entry1.key_digest.as_ref(), entry5.key_digest.as_ref());
+    #[test]
+    fn test_variable_length_keys_parse_all_entries() {
+        // Issue #552: prove the parser handles non-16-byte keys (composite/int/text).
+        // Entry 1: 4-byte int key (0x0000002A), offset 100, no promoted index.
+        // Entry 2: 1-byte key (0x07), offset 500 (2-byte vint 0x81 0xF4), no promoted.
+        let data = vec![
+            // Entry 1
+            0x00, 0x04, // key_len = 4
+            0x00, 0x00, 0x00, 0x2A, // raw key (int 42)
+            0x64, // vint offset = 100
+            0x00, // vint promoted_size = 0
+            // Entry 2
+            0x00, 0x01, // key_len = 1
+            0x07, // raw key
+            0x81, 0xF4, // vint offset = 500
+            0x00, // vint promoted_size = 0
+        ];
+
+        let (rest, entries) = parse_all_partition_keys(&data).unwrap();
+        assert!(rest.is_empty(), "All bytes should be consumed");
+        assert_eq!(entries.len(), 2, "Both variable-length entries must parse");
+
+        assert_eq!(entries[0].key_digest.as_ref(), &[0x00, 0x00, 0x00, 0x2A]);
+        assert_eq!(entries[0].data_offset, 100);
+
+        assert_eq!(entries[1].key_digest.as_ref(), &[0x07]);
+        assert_eq!(entries[1].data_offset, 500);
     }
 
     // REMOVED: test_enhanced_partition_entry_parsing

--- a/cqlite-core/src/storage/sstable/reader/partition_lookup.rs
+++ b/cqlite-core/src/storage/sstable/reader/partition_lookup.rs
@@ -16,7 +16,12 @@ impl SSTableReader {
         partition_key: &[u8],
     ) -> Result<Option<(u64, u32)>> {
         if let Some(index_reader) = &self.index_reader {
-            // Compute the proper key digest for Index.db lookup
+            // KNOWN LIMITATION (tracked in #553): Index.db entries are now
+            // keyed on the RAW partition key (the real Cassandra BIG format, #552),
+            // but this path still computes a hash digest, so the lookup misses and
+            // every caller falls back to a sequential scan (the #517 fallback path).
+            // Reads remain correct; restoring O(1) raw-key point lookup is a separate
+            // optimization, intentionally out of scope for #552.
             let key_digest = match self.compute_partition_key_digest(partition_key).await {
                 Ok(digest) => digest,
                 Err(e) => {

--- a/cqlite-core/src/storage/write_engine/mutation.rs
+++ b/cqlite-core/src/storage/write_engine/mutation.rs
@@ -1222,16 +1222,44 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(
-        expected = "ClusteringKey comparison failed: type mismatch indicates schema validation bug"
-    )]
-    fn test_clustering_key_ord_type_mismatch_panics() {
-        // Test Issue #409: Type mismatch should panic with clear message
+    fn test_clustering_key_ord_type_mismatch_is_total_and_does_not_panic() {
+        // Issue #458/#465: `Ord for ClusteringKey` MUST NOT panic on a type mismatch.
+        // Heterogeneous SSTables can produce mismatched clustering value types, and a
+        // panic in `cmp` would crash the memtable BTreeMap. Instead, the implementation
+        // falls back to a deterministic ordering. This test confirms it is panic-free,
+        // total (antisymmetric), and deterministic.
         let ck1 = ClusteringKey::single("ts", Value::Timestamp(1000));
-        let ck2 = ClusteringKey::single("ts", Value::Integer(2000)); // Wrong type!
+        let ck2 = ClusteringKey::single("ts", Value::Integer(2000)); // Different type
 
-        // This should panic due to type mismatch
-        let _ = ck1.cmp(&ck2);
+        // Must not panic.
+        let ord_12 = ck1.cmp(&ck2);
+        let ord_21 = ck2.cmp(&ck1);
+
+        // Determinism: repeated comparisons return the same result.
+        assert_eq!(ord_12, ck1.cmp(&ck2), "comparison must be deterministic");
+
+        // Antisymmetry / totality: a<b implies b>a (and the mismatch is never reported
+        // as Equal, since the underlying values differ).
+        assert_ne!(
+            ord_12,
+            Ordering::Equal,
+            "mismatched types must not compare Equal"
+        );
+        assert_eq!(
+            ord_12.reverse(),
+            ord_21,
+            "ordering must be antisymmetric (a.cmp(b) == b.cmp(a).reverse())"
+        );
+
+        // Reflexivity: a key compares Equal to itself even across the fallback path.
+        assert_eq!(ck1.cmp(&ck1), Ordering::Equal);
+
+        // It must remain usable as a BTreeMap key without panicking.
+        use std::collections::BTreeMap;
+        let mut map = BTreeMap::new();
+        map.insert(ck1.clone(), "a");
+        map.insert(ck2.clone(), "b");
+        assert_eq!(map.len(), 2, "both distinct keys should be retained");
     }
 
     #[test]

--- a/cqlite-core/tests/write_read_roundtrip/index.rs
+++ b/cqlite-core/tests/write_read_roundtrip/index.rs
@@ -265,7 +265,13 @@ async fn test_index_roundtrip_large_offsets() {
     );
 }
 
-/// Test Index.db partition key digest calculation
+/// Test Index.db stores and reads back the RAW partition key (Issue #552).
+///
+/// The real Cassandra 5.0 NB / BIG Index.db format is
+/// `[key_len: u16 BE][raw key bytes][data_offset: vint][promoted_len: vint]`.
+/// There is NO `0x0010` marker and NO MD5 digest on disk — the leading u16 is the key
+/// length and the bytes that follow are the raw partition key. This test asserts that the
+/// `key_digest` field (historical name) holds the RAW key, not `md5::compute(&pk)`.
 #[tokio::test]
 async fn test_index_partition_key_digest() {
     let temp_dir = TempDir::new().unwrap();
@@ -281,11 +287,20 @@ async fn test_index_partition_key_digest() {
         .add_partition(&key, 0)
         .expect("add_partition should succeed");
 
-    // Calculate expected MD5 digest
-    let expected_digest = md5::compute(&pk_bytes);
-
     // Finalize to bytes
     let index_bytes = writer.finish().expect("IndexWriter finish should succeed");
+
+    // On-disk: [key_len u16 BE = 0x0004][raw key bytes][offset vint][promoted vint].
+    assert_eq!(
+        &index_bytes[0..2],
+        &[0x00, 0x04],
+        "Leading u16 must be the key length (4), not a 0x0010 marker"
+    );
+    assert_eq!(
+        &index_bytes[2..6],
+        pk_bytes.as_slice(),
+        "On-disk bytes after the length prefix must be the RAW key, not an MD5 digest"
+    );
 
     // Write to file
     let mut file = File::create(&index_path)
@@ -312,10 +327,15 @@ async fn test_index_partition_key_digest() {
     let entries = reader.get_partition_entries();
     assert_eq!(entries.len(), 1, "Should have 1 partition entry");
 
-    // Verify key digest matches MD5 of partition key bytes
+    // The stored key is the RAW partition key (NOT md5::compute(&pk_bytes)).
     assert_eq!(
         entries[0].key_digest.as_ref(),
-        expected_digest.as_slice(),
-        "Partition key digest should be MD5 of key bytes"
+        pk_bytes.as_slice(),
+        "Stored key bytes should equal the RAW partition key"
+    );
+    assert_eq!(
+        entries[0].raw_key.as_deref(),
+        Some(pk_bytes.as_slice()),
+        "raw_key should mirror the raw partition key"
     );
 }

--- a/cqlite-core/tests/write_read_roundtrip/summary.rs
+++ b/cqlite-core/tests/write_read_roundtrip/summary.rs
@@ -523,7 +523,10 @@ async fn test_summary_offset_tracking_with_index() {
     for (sample_idx, summary_entry) in summary_entries.iter().enumerate() {
         let expected_partition_idx = sample_idx * 128;
 
-        // Verify the offset points to a valid Index.db entry marker (0x0010)
+        // Verify the offset points to the start of an Index.db entry. In the real
+        // Cassandra BIG/NB format each entry begins with the partition key LENGTH
+        // (u16 BE), not a 0x0010 marker. These keys are 4 bytes, so the entry starts
+        // with the length prefix 0x0004 (Issue #552).
         let offset = summary_entry.position as usize;
         assert!(
             offset + 2 <= index_bytes_vec.len(),
@@ -531,12 +534,12 @@ async fn test_summary_offset_tracking_with_index() {
             offset
         );
 
-        // Check that the offset points to the Index.db entry marker
-        let marker_bytes = &index_bytes_vec[offset..offset + 2];
+        // Check that the offset points to the Index.db entry's key-length prefix.
+        let key_len_bytes = &index_bytes_vec[offset..offset + 2];
         assert_eq!(
-            marker_bytes,
-            &[0x00, 0x10],
-            "Summary entry {} should point to Index.db entry marker at offset {}",
+            key_len_bytes,
+            &[0x00, 0x04],
+            "Summary entry {} should point to Index.db entry key-length prefix at offset {}",
             sample_idx,
             offset
         );
@@ -550,16 +553,16 @@ async fn test_summary_offset_tracking_with_index() {
         );
 
         println!(
-            "✓ Summary entry {} points to Index.db partition {} at offset {} (verified marker 0x0010)",
+            "✓ Summary entry {} points to Index.db partition {} at offset {} (key-length prefix 0x0004)",
             sample_idx, expected_partition_idx, offset
         );
     }
 
-    // Additional verification: compute expected offsets based on entry sizes
-    // Each Index.db entry: 2 (marker) + 16 (digest) + VInt(data_offset) + VInt(0)
-    // For data_offset values 0, 100, 200, ..., most will be 1-byte VInts (< 128)
-    // Entry size = 2 + 16 + 1 + 1 = 20 bytes for data_offset < 128
-    // Entry size = 2 + 16 + 2 + 1 = 21 bytes for data_offset >= 128
+    // Additional verification: compute expected offsets based on entry sizes.
+    // Each BIG-format Index.db entry: 2 (key_len) + 4 (raw key) + VInt(data_offset) + VInt(0).
+    // For data_offset values 0, 100, 200, ..., most will be 1-byte VInts (< 128).
+    // Entry size = 2 + 4 + 1 + 1 = 8 bytes for data_offset < 128.
+    // Entry size = 2 + 4 + 2 + 1 = 9 bytes for data_offset >= 128.
 
     let mut cumulative_offset = 0u64;
     for i in 0..384 {
@@ -575,7 +578,8 @@ async fn test_summary_offset_tracking_with_index() {
         } else {
             4 // Sufficient for this test
         };
-        let entry_size = 2 + 16 + vint_size + 1; // marker + digest + data_offset_vint + promoted_len_vint(0)
+        // key_len(2) + raw key(4) + data_offset_vint + promoted_len_vint(0)
+        let entry_size = 2 + 4 + vint_size + 1;
 
         // If this is a sampled partition, verify the offset matches
         if i % 128 == 0 {

--- a/docs/sstables-definitive-guide/chapters/06-index-and-summary.md
+++ b/docs/sstables-definitive-guide/chapters/06-index-and-summary.md
@@ -10,67 +10,60 @@ This chapter explains the partition index (`Index.db`) and the sampled summary (
 
 ## Partition Index Structure
 
-`Index.db` primarily stores partition key digests and, depending on format, may include offsets and sizes.
-
-Annotated example (BIG, one entry):
-```
-00000000: 0010 6b88 bf20 a251 11f0 a3fe f1a5 5138  |..k.. .Q......Q8|
-00000010: 3fb9 00                                   |?. .             |
-```
-- `0010` → marker (partition key digest follows)
-- `6b88…3fb9` → 16-byte digest
-- `00` → unsigned VInt offset (value 0, single byte for values 0-127)
-
-Annotated example (length-prefixed variant — BIG, one entry):
-```
-00000000: 001a 0010 37ac 9f53 bd8e 4da5 a41a 240f  |....7..S..M...$.
-00000010: 8f5a 6cfd 0000 0480 004f 88               |.Zl......O.     |
-```
-- `001a` → entry length (26 bytes)
-- `0010` → marker (partition key digest follows)
-- `37ac…6cfd` → 16-byte digest
-- `0000 0480 004f 88` → variable-length fields: data offset (and optional size/payload per format)
-
-Tiny side-by-side comparison (first 12–16 bytes):
-```
-// No length prefix (legacy/BIG):
-0010 6b88 bf20 a251 11f0 a3fe f1a5 | 0010 + 16B digest ...
-
-// With 2-byte length prefix (some 5.0 BIG tables):
-001a 0010 37ac 9f53 bd8e 4da5 a41a | 001a + 0010 + 16B digest ...
-```
-
-Variant gating (BIG):
-
-Pseudo-structs per variant (field order, big-endian for fixed-width):
+`Index.db` (the BIG / NB partition index) stores, for every partition, the **raw partition
+key** (length-prefixed) together with its byte offset into `Data.db`. There is **no `0x0010`
+marker and no MD5 digest** — that was a long-standing documentation error (Issue #552). Each
+entry is:
 
 ```
-// No length prefix (legacy/BIG variant)
-u16 marker = 0x0010
-u128 partition_key_digest
-varint data_offset
-[optional promoted-index payload]
-
-// With 2-byte length prefix (some 5.0 BIG tables)
-u16 entry_length
-u16 marker = 0x0010
-u128 partition_key_digest
-varint data_offset
-[optional promoted-index payload]
+[key_len: u16 BE]                    ← length of the raw partition key
+[raw partition key bytes: key_len]   ← the partition key exactly as serialized in Data.db
+[data_offset: unsigned vint]         ← byte offset into the Data.db data section
+[promoted_index_len: unsigned vint]  ← byte length of the promoted index (0 = none)
+[promoted_index_data: promoted_index_len bytes]
 ```
 
-**Critical: VInt Offset Encoding (NB Format)**
+> **The leading `u16` is the partition key LENGTH, not a marker.** It varies with the key:
+> `0x0010` for a 16-byte UUID key, `0x0026` (= 38) for a 38-byte composite partition key,
+> `0x0004` for a 4-byte `int` key, and so on. Earlier revisions of this guide misread the
+> `0x0010` produced by single-UUID tables as a fixed marker; it is simply the length of a
+> 16-byte key.
 
-For NB format SSTables (Cassandra 5.0+), the `data_offset` uses **Cassandra VInt encoding**, NOT a length-prefixed byte array:
+Annotated example — single UUID key (`simple_table`, key length 16):
+```
+00000000: 0010 1529 1a77 d739 4e73 8397 b787 442f  |...).w.9Ns....D/|
+00000010: 3a1f 0000 ...                            |:.. .          |
+```
+- `0010` → key length = 16
+- `1529…3a1f` → 16-byte raw partition key (a UUID)
+- `00` → unsigned VInt data offset (value 0)
+- `00` → unsigned VInt promoted-index length (0, no promoted index)
 
+Annotated example — composite key (`multi_partition_table`, `PRIMARY KEY ((tenant_id, user_id), …)`, key length 38):
 ```
-// NB format (Cassandra 5.0+) - DigestFormat
-u16 marker = 0x0010
-u128 partition_key_digest
-vint data_offset          // VInt encoded, 1-9 bytes based on value magnitude
-vint promoted_size        // VInt encoded size of following promoted index data
-byte promoted_data[promoted_size]  // Promoted index (only if size > 0)
+00000000: 0026 0010 98e0 5820 982d 411c 961f 26d1  |.&....X .-A...&.|
+00000010: 0574 74e4 0000 109d 159a 2b08 da4a d1be  |.tt.......+..J..|
+00000020: 78c9 0f87 83e5 c100 ...                  |x..... .       |
 ```
+- `0026` → key length = 38
+- `0010 98e0…74e4 00 0010 9d15…c1 00` → 38-byte composite key. Cassandra frames each
+  component as `[len: u16 BE][value][0x00 end-of-component]`, so two 16-byte UUIDs become
+  `0010<uuid1>00 0010<uuid2>00` = 19 + 19 = 38 bytes.
+- the data-offset and promoted-index-length vints follow the key.
+
+Pseudo-struct (field order; big-endian for fixed-width):
+```
+u16   key_len
+bytes raw_partition_key[key_len]
+vint  data_offset
+vint  promoted_index_len
+bytes promoted_index[promoted_index_len]   // only when promoted_index_len > 0
+```
+
+**Critical: VInt offset encoding (NB format)**
+
+The `data_offset` and `promoted_index_len` fields use **Cassandra unsigned VInt encoding**,
+not a fixed-width or length-prefixed byte array:
 
 VInt encoding (from `DataInputPlus.java`):
 - First byte's leading 1-bits indicate total byte count
@@ -79,45 +72,42 @@ VInt encoding (from `DataInputPlus.java`):
 - `0xC0-0xDF`: 3 bytes
 - etc.
 
-Example from `sensor_data` Index.db:
+Example offsets:
 ```
 0x00       -> 1 byte  -> value = 0
 0xb0 0x5d  -> 2 bytes -> value = 12381
 0xc0 0x5f 0x11 -> 3 bytes -> value = 24337
 ```
 
-**Important**: NB format offsets are **relative to the Data.db data section** (excluding the compression header, typically 30 bytes). Add the header size when seeking:
+**Important**: NB format offsets are **relative to the Data.db data section** (excluding the
+compression header, typically 30 bytes). Add the header size when seeking:
 ```
 file_offset = index_offset + header_size
 ```
 
-Gate detection is handled by the BIG reader; consult `org.apache.cassandra.io.sstable.format.big.BigTableReader` and `RowIndexEntry` for exact parsing. Implementations must handle both variants by detecting an initial length field that precedes the `0x0010` marker.
-
-Digest and collisions:
-- Partition key digest is 16 bytes; derived from the partition key via Cassandra’s partitioner (e.g., Murmur3Partitioner). Treat digest as an index key; on match, validate by reading the `Data.db` key to guard against extremely rare collisions.
+Keys and collisions:
+- The on-disk key is the raw partition key, so lookups can compare keys directly (no digest /
+  collision handling is required at the index layer). On a hash-based point lookup that misses,
+  readers fall back to a full scan that compares raw keys (see Issue #517).
 
 Promoted index payload (BIG):
-- Emitted for wide partitions. The payload follows the offset field when present; readers identify it by entry payload length (length-prefixed variant) or by probing entry structure (non-prefixed). See `RowIndexEntry` for exact fields.
+- Emitted for wide partitions to accelerate within-partition seeks. Its length is given
+  explicitly by `promoted_index_len`; when it is 0 the entry has no promoted index. See
+  `org.apache.cassandra.io.sstable.format.big` reader/writer for the payload fields.
 
-Mini-parser (variant-tolerant) — conceptual:
+Mini-parser — conceptual:
 ```text
 pos = 0
-prefix = read_u16_be()
-if prefix == 0x0010:
-  // non-length-prefixed variant
-  marker = prefix
-else:
-  entry_len = prefix
-  marker = read_u16_be()
-  assert(marker == 0x0010)
-
-digest = read_16_bytes()
-data_offset = read_vint_u64()
-payload_len = (entry_len - bytes_consumed_so_far) if entry_len else 0
-promoted_index = read_bytes(payload_len) if payload_len > 0
+key_len            = read_u16_be()
+raw_key            = read_bytes(key_len)
+data_offset        = read_vint_u64()
+promoted_index_len = read_vint_u64()
+promoted_index     = read_bytes(promoted_index_len)   // empty when length == 0
 ```
 
-Promoted index (BIG): emitted for wide partitions to accelerate within-partition seeks. Readers detect presence via entry payload structure and fall back to scan when absent. See `org.apache.cassandra.io.sstable.format.big` reader/writer for details.
+> Note: a BTI-indexed SSTable does **not** use `Index.db` at all — it uses the
+> `Partitions.db` / `Rows.db` trie structures (see Ch.17). So `Index.db`, when present, is
+> always this BIG-format partition index; there is no separate "BTI Index.db" variant to detect.
 
 ## Summary.db Format
 
@@ -227,24 +217,29 @@ This section documents the SSTable write workflow for generating Index.db and Su
 
 ### Index.db Entry Format (Write)
 
-When writing Index.db entries in BIG format (NB variant), each entry follows this structure:
+When writing Index.db entries in BIG format (NB variant), each entry follows this structure.
+The entry begins with the partition key **length** and the **raw partition key bytes** — there
+is no `0x0010` marker and no MD5 digest (Issue #552):
 
 ```c
 struct index_entry {
-    be16 marker = 0x0010;          // Partition key digest marker
-    byte digest[16];               // MD5 hash of partition key bytes
+    be16 key_len;                  // Length of the raw partition key
+    byte raw_key[key_len];         // Raw partition key bytes (same as in Data.db)
     vint data_offset;              // Byte offset in Data.db (VInt encoded)
-    vint promoted_index_length;    // Length of promoted index data
+    vint promoted_index_length;    // Length of promoted index data (0 = none)
     byte promoted_index_data[promoted_index_length];  // Only if length > 0
 };
 ```
 
 **Key Requirements:**
 
-1. **Marker**: Always `0x0010` (big-endian), indicating partition key digest follows
-2. **Digest**: MD5 hash of raw partition key bytes (16 bytes)
-3. **Data Offset**: VInt-encoded byte offset in Data.db where partition starts
-4. **Promoted Index**: Length of 0 for simple partitions (M5 Stage 0 implementation)
+1. **Key length**: `be16` length of the raw partition key (e.g. `0x0010` for a 16-byte UUID,
+   `0x0026` for a 38-byte composite key, `0x0004` for a 4-byte `int`). This is a LENGTH, not a
+   marker.
+2. **Raw key**: The raw serialized partition key bytes, byte-for-byte identical to the key in
+   Data.db (no hashing, no digest).
+3. **Data Offset**: VInt-encoded byte offset in Data.db where the partition starts.
+4. **Promoted Index**: Length of 0 for simple partitions (M5 Stage 0 implementation).
 
 ### Index.db Offset Tracking
 
@@ -256,7 +251,7 @@ When adding entries to Index.db, the file offset where each entry starts must be
 // Capture the offset BEFORE writing
 let index_offset = buffer.len() as u64;
 
-// Write entry (marker + digest + position + promoted_index_length)
+// Write entry (key_len + raw key + position + promoted_index_length)
 write_entry(&mut buffer, key, data_offset)?;
 
 // Return IndexEntryInfo for Summary.db sampling
@@ -272,18 +267,14 @@ IndexEntryInfo {
 
 This information is used by Summary.db sampling to record accurate Index.db positions.
 
-### MD5 Digest Calculation
+### Raw Key Storage (no digest)
 
-The partition key digest is computed as:
-
-```rust
-let digest = md5::compute(&partition_key_bytes);
-```
-
-The digest is the MD5 hash of the raw partition key bytes (not the token). This allows readers to:
-1. Binary search Index.db by digest
-2. Validate matches against the actual partition key in Data.db
-3. Guard against rare MD5 collisions
+Index.db stores the **raw partition key bytes** length-prefixed; it does NOT store an MD5
+digest. (A prior version of this guide incorrectly described an MD5 digest — see Issue #552.)
+Because the raw key is on disk, readers can:
+1. Binary search / scan Index.db comparing the raw partition key directly
+2. Use the inline `data_offset` to seek straight into Data.db
+3. Avoid any hash-collision handling at the index layer
 
 ### VInt Encoding for Offsets
 
@@ -559,10 +550,10 @@ Data.db:
   [Partition 2 at offset 250]
   [Partition 3 at offset 500]
 
-Index.db:
-  [Entry 1 at offset 0: digest + data_offset=0]
-  [Entry 2 at offset 20: digest + data_offset=250]
-  [Entry 3 at offset 40: digest + data_offset=500]
+Index.db (16-byte UUID keys → each entry is 2 + 16 + vint + vint bytes):
+  [Entry 1 at offset 0:  key_len + raw_key + data_offset=0]
+  [Entry 2 at offset 20: key_len + raw_key + data_offset=250]
+  [Entry 3 at offset 40: key_len + raw_key + data_offset=500]
 
 Summary.db:
   [Entry 0 sampled: key + index_offset=0]    ← Sample every 128th


### PR DESCRIPTION
## Summary

Fixes #552 — CQLite's Index.db **reader** dropped partitions for any non-16-byte partition key, so multi-partition SSTables read back only 1–3 of N partitions (verified: 100→2, 384→2, 20→3, 10→1). Surfaced by 9 silently-failing `write-support` tests that CI never ran.

Closes #552.

## Root cause (reader, not writer)

The real Cassandra 5.0 NB Index.db entry is `[key_len: u16 BE][raw partition key][data_offset: vint][promoted_index_len: vint][promoted...]` — the leading u16 is the **key length**. The reader's `detect_index_format` mis-read that u16 as a `0x0010` *digest marker*: entries starting `0x0010` (coincidentally, 16-byte UUID keys) went down a "MD5 digest" path; everything else fell into a byte-scanner (`parse_bti_partition_entry`) that mis-parsed and dropped entries.

Ground-truthed against real Cassandra files: `test_basic/simple_table` (UUID key) entries start `0010` (len 16); `test_basic/multi_partition_table` (composite `((tenant_id UUID, user_id UUID))`) entries start `0026` (len 38 — `0010<uuid1>00 0010<uuid2>00`). The leading u16 varies with key length → it is a length, not a marker. The project guide documented this wrong, which is what originally misled the code.

## Fix

- **Reader**: removed `detect_index_format` + `IndexFormat::{DigestFormat,BtiFormat}` + `parse_bti_partition_entry`; replaced with a single `parse_big_index_entry` that parses `[key_len][raw key][offset vint][promoted_len vint]` for **any** key length (no-heuristics, #28). Bounds-safe (saturating `promoted_len` cast; malformed input returns an error, never panics). A BTI-indexed SSTable uses Partitions.db/Rows.db and never produces Index.db, so the format detection was entirely spurious.
- **Writer**: was already correct (raw-key format) — unchanged.
- **Guide**: corrected `docs/sstables-definitive-guide/chapters/06-index-and-summary.md` (read + write sections) to document the raw length-prefixed format, with annotated UUID + composite hex examples.
- **Tests**: rewrote the assertions that wrongly expected MD5 digests (`test_index_partition_key_digest`, `test_summary_offset_tracking_with_index`) to expect raw keys; added a variable-length-key parser test and an ignored real-Cassandra-Index.db validation test; replaced a stale `#[should_panic]` clustering test (the panic was removed in #458/#465) with a panic-free/determinism test. Dropped the now-unused `md5` dep.
- **CI**: added a step running the `write-support` lib + `write_read_roundtrip` + `compaction_integration` targets so these can't rot again (mirrors #514). This whole class of failure was invisible because CI scoped to `--features cli-helpers`.

## Impact

Multi-partition SSTables written by CQLite were already on-disk correct (writer was fine); CQLite's own reader couldn't fully read them back via the index. Reads were partially salvaged by the Data.db scan fallback (#517) and compaction's direct Data.db scan, which is why the ≤2-partition e2e and full-table smoke never caught it. Now the index parses every partition.

## Known limitation (filed as #553)

Point lookups still compute a hash digest that won't match the raw-key index, so `get()` falls back to a sequential scan (pre-existing, correctness-safe — all callers fall back). Restoring O(1) raw-key index lookup (incl. composite-key framing) is tracked in #553.

## Pre-push checklist (all green)

- `cargo fmt --all -- --check` ✅ · `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features` ✅
- `write_read_roundtrip`: **125 passed** (was 9 failing) ✅ · write-support lib 1546 ✅ · cli-helpers lib 967 ✅ · compaction 6/6 ✅
- `cqlite-integration-tests`: 0 failures ✅ · `smoke-test-all-tables.sh` 33/33 ✅
- **`e2e-cassandra-readback.sh` (Docker, Cassandra 5.0): 5/5** ✅

## Review

rust-reviewer: parser is clean/panic-free; confirmed no regression for UUID keys and correct parsing of composite/int/text keys; the one "blocking" item (index point-lookup digest mismatch) was determined to be pre-existing and correctness-safe via scan fallback → documented + filed as #553.
