### PR TITLE
docs(release): add #552 to v0.9.2 changelog/docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v0.9.2] — Correctness fixes
 
 Reader and compaction correctness follow-ups to v0.9.1, plus a compaction memory
-fix. No new features and no public API changes.
+fix and a multi-partition Index.db reader fix. No new features and no public API
+changes.
 
 ### Fixed
 
@@ -37,6 +38,13 @@ fix. No new features and no public API changes.
   partition instead of buffering the entire component in memory, bounding peak heap
   to roughly the largest single partition (was O(whole file), exceeding the 128 MB
   target on large compactions). Output is byte-identical (#492).
+- **Multi-partition Index.db reader**: the reader mis-parsed Index.db entries whose
+  leading `u16` key length was not `0x0010`, treating it as a digest marker and
+  dropping most partitions (e.g. 100 partitions read back as 2). It now parses the
+  real Cassandra BIG format `[key_len][raw key][offset][promoted]` for any key
+  length; the project guide's Index.db documentation was corrected to match, and
+  the `write-support` test targets are now wired into CI so this class of failure
+  can't rot again (#552). Restoring O(1) raw-key point lookup is tracked in #553.
 
 ## [v0.9.1] — Reader correctness fixes
 

--- a/docs/development/PRD.md
+++ b/docs/development/PRD.md
@@ -166,13 +166,14 @@ The v0.9.0 reader follow-ups (#493 set-element tombstones, #501 tuple decoding,
 #502 frozen<udt> decoding) were **resolved in v0.9.1**. The v0.9.2 reader and
 compaction correctness fixes (#516 `scan()` token ordering, #517 `get()`/`scan()`
 consistency, #518 `stats().block_count`, #505 compaction row tombstones, #498
-equal-timestamp Delete-vs-Live reconcile, #533 per-cell compaction reconcile, and
-#492 streaming `Data.db` writer) were **resolved in v0.9.2** and removed from this
-list.
+equal-timestamp Delete-vs-Live reconcile, #533 per-cell compaction reconcile,
+#492 streaming `Data.db` writer, and #552 multi-partition Index.db reader) were
+**resolved in v0.9.2** and removed from this list.
 
 | Issue | Milestone | Description | Workaround |
 |-------|-----------|-------------|------------|
 | #311 | — | Python concurrent-query race in schema metadata access | Run one warm-up query before spawning parallel threads on the same handle |
+| #553 | — | Index.db point lookup falls back to a full scan (hash digest vs raw-key mismatch); reads correct, not O(1) | None needed; correctness unaffected |
 
 See [docs/write-support-limitations.md](../write-support-limitations.md) for the full limitations reference.
 

--- a/docs/write-support-limitations.md
+++ b/docs/write-support-limitations.md
@@ -152,6 +152,21 @@ within the 128 MB memory target. Output bytes are unchanged.
 
 ---
 
+## Multi-partition Index.db read back fewer partitions than written (Issue #552)
+
+**Behaviour** (resolved in v0.9.2): CQLite-written multi-partition SSTables had a
+correct Index.db, but CQLite's *reader* mis-parsed entries whose leading `u16` key
+length was not `0x0010`, dropping most partitions on read-back. The reader now parses
+the real Cassandra BIG format `[key_len][raw key][offset][promoted]` for any key
+length. Reads were previously salvaged by the Data.db scan fallback (#517), so this
+was not user-visible for full-table scans. The `write-support` test targets are now
+run in CI.
+
+**Tracking**: Issue #552 (fixed in v0.9.2). Follow-up #553: restore O(1) raw-key
+Index.db point lookup (reads currently fall back to scan; correctness unaffected).
+
+---
+
 > The v0.9.2 reader correctness fixes (#516 `scan()` token ordering, #517
 > `get()`/`scan()` consistency, #518 `stats().block_count`) are read-side; see the
 > CHANGELOG and PRD §4.2 for details.


### PR DESCRIPTION
## v0.9.2 changelog/docs — add #552

Records #552 (multi-partition Index.db reader fix, merged via #554) in the v0.9.2 release notes/docs. **Docs-only — no code, no version change** (main is already `0.9.2`).

This is the third and final addition to the v0.9.2 notes after Patrick expanded scope twice during the release:
1. Original 5 reader/compaction fixes (#516 #517 #518 #505 #498).
2. + #533 (per-cell reconcile / data loss) and #492 (streaming writer / memory).
3. + #552 (multi-partition Index.db reader — found while fixing the silently-rotting write-support tests).

### Full v0.9.2 issue set (8, all merged to main)

#516 #517 (#528) · #518 (#529) · #505 (#530) · #498 (#531) · #533 (#534) · #492 (#535) · #552 (#554)

Follow-ups filed (not in v0.9.2): #533-adjacent cell work done; **#553** (restore O(1) raw-key Index.db point lookup — reads currently fall back to scan, correctness unaffected).

### Final gate (on the merged tree)

- `cargo fmt --all -- --check` ✅ · clippy ✅ · core-lib (cli-helpers) 967 ✅ · write-support lib 1546 ✅
- `write_read_roundtrip` 125 ✅ · compaction 6/6 ✅ · `cqlite-integration-tests` 0 failures ✅ · smoke 33/33 ✅
- **`e2e-cassandra-readback.sh` (Docker, Cassandra 5.0): 5/5** ✅
- The `write-support` test targets are now in CI (added in #554) so the #552 class of failure can't recur silently.
