### PR TITLE
feat(core): fold write-support into default features (#558)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **`write-support` is now a default feature** of `cqlite-core`. The write path
+  (`WriteEngine`, `Mutation`) is available out of the box; downstream consumers no
+  longer need to opt in to enable it. This adds **no new dependencies** —
+  `write-support` gates only first-party code, so the dependency surface for
+  read-only consumers is unchanged. `flush`/`compact` on the high-level `Database`
+  type remain behind the separate `experimental` feature (#558).
+
 ## [v0.9.2] — Correctness fixes
 
 Reader and compaction correctness follow-ups to v0.9.1, plus a compaction memory

--- a/cqlite-core/Cargo.toml
+++ b/cqlite-core/Cargo.toml
@@ -114,8 +114,12 @@ name = "write"
 harness = false
 
 [features]
-# M2+ production defaults: Full query engine enabled
-default = ["all-compression", "state_machine"]
+# M2+ production defaults: Full query engine + write path enabled.
+# write-support is a pure first-party code-gating flag (no extra dependencies),
+# so including it by default makes the write engine available out of the box
+# without changing the dependency surface for read-only consumers (#558).
+# flush/compact remain behind the separate `experimental` flag.
+default = ["all-compression", "state_machine", "write-support"]
 
 # Compression features - properly feature-gated
 lz4 = ["dep:lz4_flex"]


### PR DESCRIPTION
## Summary
Folds `write-support` into `cqlite-core`'s default features, so the write path (`WriteEngine`, `Mutation`) is available out of the box. This removes the #1 documented friction point from the cqlite-perf downstream feedback (epic #556).

## Decision data (posted to #558, maintainer steer: lean yes)
- **Zero new dependencies**: `write-support = []` gates only first-party code. `cargo tree -p cqlite-core -e normal` is byte-identical with/without the feature (123 crates either way).
- **~1s extra compile** for the core crate's own write modules. No dependency recompiles.
- **`experimental` stays separately gated** — `Database::flush`/`compact` are unaffected.

## Clean on current main
This PR was rebased onto current `main` (post-#554, which fixed the multi-partition Index.db reader bug and wired write-support tests into CI). The full `cqlite-core` suite is green under the now-default `write-support`, including `write_read_roundtrip` (125 passing). No `#[ignore]`s or test changes needed. (An earlier revision of this branch, cut from a stale local main, mistakenly re-did work already shipped in #554/#552; that was reverted — tracking issue #564 closed as a duplicate.)

## Gates
- `cargo fmt --all -- --check` ✅
- `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features` ✅ zero warnings
- `CQLITE_DATASETS_ROOT=… cargo test --package cqlite-core` ✅ all targets green

Closes #558