### PR TITLE
docs: 'Using cqlite-core as a dependency' page + compiling write example (#559)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,10 @@ cargo run --package cqlite-cli --features write-support -- \
 ```
 
 See [docs/write-support.md](docs/write-support.md) for the full write guide,
-including the Cassandra export workflow and known limitations.
+including the Cassandra export workflow and known limitations. To embed
+`cqlite-core` in your own Rust project (dependency line, feature flags, and a
+compiling write example), see
+[docs/using-cqlite-core-as-a-dependency.md](docs/using-cqlite-core-as-a-dependency.md).
 
 ## Feature Flags
 

--- a/cqlite-core/examples/write_a_mutation.rs
+++ b/cqlite-core/examples/write_a_mutation.rs
@@ -1,0 +1,97 @@
+//! Example: construct a `Mutation` and write it via `WriteEngine::write`.
+//!
+//! This is the minimal end-to-end write path a downstream consumer needs. It is
+//! kept as a compiling example (rather than a doc snippet) so it can't drift from
+//! the real API — see `docs/using-cqlite-core-as-a-dependency.md`.
+//!
+//! `write-support` is a default feature as of #558. On a release that predates
+//! that, enable it explicitly:
+//!
+//! ```bash
+//! cargo run -p cqlite-core --example write_a_mutation --features write-support
+//! ```
+
+#[cfg(feature = "write-support")]
+fn main() -> cqlite_core::error::Result<()> {
+    use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+    use cqlite_core::storage::write_engine::{
+        CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+    };
+    use cqlite_core::types::Value;
+    use std::collections::HashMap;
+
+    // 1. Describe the target table. `is_static` is `#[serde(default)]` (false) when
+    //    a schema is deserialized from JSON/CQL; in a Rust literal you set it.
+    let schema = TableSchema {
+        keyspace: "demo".to_string(),
+        table: "users".to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            Column {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "name".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+    };
+
+    // 2. Create the write engine. `data_dir` holds flushed SSTables; `wal_dir`
+    //    holds the write-ahead log.
+    let base = std::env::temp_dir().join("cqlite-write-a-mutation");
+    let config = WriteEngineConfig::new(base.join("data"), base.join("wal"), schema);
+    let mut engine = WriteEngine::new(config)?;
+
+    // 3. Build a mutation equivalent to:
+    //    INSERT INTO demo.users (id, name) VALUES (1, 'Alice')
+    //    Note: the cell op is `Write` — there is no `Insert` variant.
+    let mutation = Mutation::new(
+        TableId::new("demo", "users"),
+        PartitionKey::single("id", Value::Integer(1)),
+        None, // no clustering key on this table
+        vec![CellOperation::Write {
+            column: "name".to_string(),
+            value: Value::Text("Alice".to_string()),
+        }],
+        1_704_067_200_000_000, // write timestamp, microseconds since Unix epoch
+        None,                  // no TTL
+    );
+
+    // 4. Write it. `write` is SYNCHRONOUS, takes `&mut self`, and fsyncs the WAL on
+    //    every call (durability-first). Concurrent writers must serialize — see the
+    //    concurrency model section in the dependency doc.
+    engine.write(mutation)?;
+
+    // 5. `flush` and `close` are async; flush persists the memtable to an SSTable.
+    let rt = tokio::runtime::Runtime::new().expect("create tokio runtime");
+    rt.block_on(async {
+        match engine.flush().await? {
+            Some(_info) => println!("Flushed memtable to a new SSTable in {base:?}"),
+            None => println!("Nothing to flush (memtable was empty)"),
+        }
+        engine.close().await
+    })?;
+
+    Ok(())
+}
+
+#[cfg(not(feature = "write-support"))]
+fn main() {
+    eprintln!("This example requires the `write-support` feature.");
+    eprintln!("Run with: cargo run -p cqlite-core --example write_a_mutation --features write-support");
+    std::process::exit(1);
+}

--- a/cqlite-core/examples/write_a_mutation.rs
+++ b/cqlite-core/examples/write_a_mutation.rs
@@ -92,6 +92,8 @@ fn main() -> cqlite_core::error::Result<()> {
 #[cfg(not(feature = "write-support"))]
 fn main() {
     eprintln!("This example requires the `write-support` feature.");
-    eprintln!("Run with: cargo run -p cqlite-core --example write_a_mutation --features write-support");
+    eprintln!(
+        "Run with: cargo run -p cqlite-core --example write_a_mutation --features write-support"
+    );
     std::process::exit(1);
 }

--- a/docs/using-cqlite-core-as-a-dependency.md
+++ b/docs/using-cqlite-core-as-a-dependency.md
@@ -1,0 +1,127 @@
+# Using `cqlite-core` as a dependency
+
+This page is for developers who want to embed `cqlite-core` (the Rust library) in
+their own project — reading and/or writing Cassandra 5.0 SSTables without a
+cluster. It covers the dependency line, the feature flags you need, and a
+**compiling** end-to-end write example.
+
+`cqlite-core` is not published on crates.io, so downstream projects pin it by git
+tag.
+
+## 1. Add the dependency
+
+Pin a released tag (see the [CHANGELOG](../CHANGELOG.md) for what each tag contains):
+
+```toml
+# Cargo.toml — read + query path (default features)
+[dependencies]
+cqlite-core = { git = "https://github.com/pmcfadin/cqlite.git", tag = "v0.9.2" }
+```
+
+The write path (`WriteEngine`, `Mutation`) is gated behind the `write-support`
+feature. On **v0.9.2** it is opt-in, so enable it explicitly:
+
+```toml
+# Cargo.toml — read + write path on v0.9.2
+[dependencies]
+cqlite-core = { git = "https://github.com/pmcfadin/cqlite.git", tag = "v0.9.2", features = ["write-support"] }
+```
+
+> As of [#558](https://github.com/pmcfadin/cqlite/issues/558) (next release),
+> `write-support` is a **default** feature, so the explicit `features` line is no
+> longer needed for the write path. It gates only first-party code and pulls in no
+> extra dependencies, so keeping it on is free for read-only consumers.
+
+## 2. Feature → API map
+
+Which Cargo feature enables which public API:
+
+| Want… | Enable feature | In defaults? |
+|-------|----------------|--------------|
+| Read / query path (`Database::open`, `execute`, `scan`, `get`) | `state_machine` | ✅ yes |
+| Compression (LZ4 / Snappy / Deflate / Zstd) | `all-compression` | ✅ yes |
+| Write path (`WriteEngine`, `Mutation`, `WriteEngine::write`/`flush`) | `write-support` | ✅ yes (next release; opt-in on v0.9.2) |
+| `Database::flush` / `Database::compact` (high-level convenience) | `experimental` | ❌ opt-in |
+
+This mirrors the table in the [README](../README.md#feature-flags); the README is
+the canonical copy.
+
+## 3. A minimal write example
+
+The snippet below constructs a `Mutation` and persists it with
+`WriteEngine::write`. It is maintained as a compiling example at
+[`cqlite-core/examples/write_a_mutation.rs`](../cqlite-core/examples/write_a_mutation.rs)
+so it cannot drift from the API. Run it with:
+
+```bash
+cargo run -p cqlite-core --example write_a_mutation --features write-support
+```
+
+```rust
+use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+use cqlite_core::storage::write_engine::{
+    CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::Value;
+use std::collections::HashMap;
+
+// Describe the target table. `is_static` is `#[serde(default)]` (false) when a
+// schema is deserialized from JSON/CQL; in a Rust literal you set it explicitly.
+let schema = TableSchema {
+    keyspace: "demo".to_string(),
+    table: "users".to_string(),
+    partition_keys: vec![KeyColumn { name: "id".to_string(), data_type: "int".to_string(), position: 0 }],
+    clustering_keys: vec![],
+    columns: vec![
+        Column { name: "id".to_string(),   data_type: "int".to_string(),  nullable: false, default: None, is_static: false },
+        Column { name: "name".to_string(), data_type: "text".to_string(), nullable: true,  default: None, is_static: false },
+    ],
+    comments: HashMap::new(),
+};
+
+// `data_dir` holds flushed SSTables; `wal_dir` holds the write-ahead log.
+let base = std::env::temp_dir().join("cqlite-write-a-mutation");
+let config = WriteEngineConfig::new(base.join("data"), base.join("wal"), schema);
+let mut engine = WriteEngine::new(config)?;
+
+// INSERT INTO demo.users (id, name) VALUES (1, 'Alice')
+// The cell op is `Write` — there is no `Insert` variant.
+let mutation = Mutation::new(
+    TableId::new("demo", "users"),
+    PartitionKey::single("id", Value::Integer(1)),
+    None,                                  // no clustering key on this table
+    vec![CellOperation::Write { column: "name".to_string(), value: Value::Text("Alice".to_string()) }],
+    1_704_067_200_000_000,                 // write timestamp, microseconds since Unix epoch
+    None,                                  // no TTL
+);
+
+// `write` is SYNCHRONOUS, takes `&mut self`, and fsyncs the WAL on every call.
+engine.write(mutation)?;
+```
+
+### API facts worth knowing up front
+
+These trip up first-time consumers because the real API differs from what the
+on-disk format spec implies:
+
+- **`WriteEngine::write(&mut self, Mutation) -> Result<()>` is synchronous** and
+  fsyncs the WAL on every call. (`write_async` exists for async call sites; it has
+  the same `&mut self` / per-write durability semantics.)
+- **`CellOperation` has no `Insert` variant.** The variants are `Write`,
+  `WriteWithTtl`, `Delete`, and `DeleteRow`.
+- **`Mutation` fields**: `table`, `partition_key`, `clustering_key` (`Option`),
+  `operations`, `timestamp_micros`, `ttl_seconds`, `partition_tombstone`,
+  `range_tombstones`. The `Mutation::new(...)` constructor takes the first six;
+  the two tombstone fields default to empty.
+- **`Column.is_static` is not required** when a schema is deserialized from
+  JSON/CQL — it is `#[serde(default)]` and defaults to `false`. In a Rust struct
+  literal (as above) all fields are set explicitly.
+- **`flush` and `close` are async** (`flush(&mut self) -> Result<Option<SSTableInfo>>`,
+  `close(&mut self) -> Result<()>`); the example wraps them in a Tokio runtime.
+
+## 4. Reading data
+
+For the read/query path, open a `Database` and run CQL — this needs only the
+default features (`state_machine` + `all-compression`). See the [README](../README.md)
+Quick Start and [`docs/write-support.md`](write-support.md) for the writable
+`Database` wrapper that combines reads and writes behind one handle.


### PR DESCRIPTION
## Summary
Adds a single page for consuming `cqlite-core` as a library dependency (epic #556, feedback item 2):
- Minimal `Cargo.toml` git-tag dependency line, with the `write-support` feature note (opt-in on v0.9.2, default from the next release per #558).
- The feature → API map (canonical copy lives in the README #557 table).
- A worked **compiling** example committed at `cqlite-core/examples/write_a_mutation.rs` — verified it builds *and* runs end-to-end (flushes a real SSTable), so it can't rot.
- The API facts that trip up first-time consumers, encoded from verified source: `write` is sync `&mut self` + per-write WAL fsync; `CellOperation` has **no `Insert`**; `Column.is_static` is `#[serde(default)]`; `flush`/`close` are async.

README links to the new page from the Write Support section.

## Acceptance criteria
- [x] New doc page exists and is linked from README
- [x] Write example compiles against the current API (as `examples/write_a_mutation.rs`)
- [x] Page notes `write-support` is required for the write path

> The write-path **concurrency model** section (#560) lands as a follow-up PR on this same page.

Closes #559