### PR TITLE
ci(release): prebuilt CLI binaries — add musl + checksums + README install (#561)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,11 @@ jobs:
             os: ubuntu-latest
             exe_suffix: ""
             use_cross: false
+          # Static musl build — runs on any Linux without a libc dependency
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            exe_suffix: ""
+            use_cross: true
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
             exe_suffix: ""
@@ -92,10 +97,25 @@ jobs:
           tar czf ../../../cqlite-${{ matrix.target }}.tar.gz cqlite${{ matrix.exe_suffix }}
         fi
 
-    - name: Upload CLI artifact
+    - name: Generate SHA-256 checksum
+      shell: bash
+      run: |
+        ext=$([[ "${{ matrix.target }}" == *"windows"* ]] && echo zip || echo tar.gz)
+        file="cqlite-${{ matrix.target }}.${ext}"
+        # sha256sum on Linux, shasum on macOS — emit "<hash>  <filename>"
+        if command -v sha256sum >/dev/null 2>&1; then
+          sha256sum "$file" > "${file}.sha256"
+        else
+          shasum -a 256 "$file" > "${file}.sha256"
+        fi
+        cat "${file}.sha256"
+
+    - name: Upload CLI artifact + checksum
       uses: softprops/action-gh-release@v2
       with:
-        files: ./cqlite-${{ matrix.target }}.${{ contains(matrix.target, 'windows') && 'zip' || 'tar.gz' }}
+        files: |
+          ./cqlite-${{ matrix.target }}.${{ contains(matrix.target, 'windows') && 'zip' || 'tar.gz' }}
+          ./cqlite-${{ matrix.target }}.${{ contains(matrix.target, 'windows') && 'zip' || 'tar.gz' }}.sha256
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,40 @@ CQLite aims to become the standard tool for Cassandra SSTable manipulation outsi
 
 CQLite is designed by **Patrick McFadin**, Apache Cassandra PMC member with 13 years of Cassandra experience. The project embodies Apache Cassandra community values and will be donated to the Apache Cassandra project upon maturity.
 
+## Install
+
+### CLI (prebuilt binaries — no Rust toolchain required)
+
+Each [GitHub release](https://github.com/pmcfadin/cqlite/releases) attaches a
+prebuilt `cqlite` CLI binary for the common platforms, each with a `.sha256`
+checksum sidecar:
+
+| Platform | Asset |
+|----------|-------|
+| macOS (Apple Silicon) | `cqlite-aarch64-apple-darwin.tar.gz` |
+| macOS (Intel) | `cqlite-x86_64-apple-darwin.tar.gz` |
+| Linux x86_64 (glibc) | `cqlite-x86_64-unknown-linux-gnu.tar.gz` |
+| Linux x86_64 (static musl) | `cqlite-x86_64-unknown-linux-musl.tar.gz` |
+| Linux arm64 (glibc) | `cqlite-aarch64-unknown-linux-gnu.tar.gz` |
+| Windows x86_64 | `cqlite-x86_64-pc-windows-gnu.zip` |
+
+```bash
+# Example: macOS Apple Silicon
+TARGET=aarch64-apple-darwin
+curl -fsSLO https://github.com/pmcfadin/cqlite/releases/latest/download/cqlite-$TARGET.tar.gz
+curl -fsSLO https://github.com/pmcfadin/cqlite/releases/latest/download/cqlite-$TARGET.tar.gz.sha256
+shasum -a 256 -c cqlite-$TARGET.tar.gz.sha256   # verify (use sha256sum -c on Linux)
+tar xzf cqlite-$TARGET.tar.gz
+./cqlite --help
+```
+
+### Language bindings
+
+```bash
+pip install cqlite-py        # Python
+npm install @cqlite/node     # Node.js
+```
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
## Summary
Completes prebuilt `cqlite` CLI coverage on GitHub releases (epic #556, feedback item 3). The existing `release.yml` already builds on tag push for macOS arm64 + x86_64, Linux x86_64 gnu, and Windows x86_64 (plus a bonus aarch64 Linux). This PR:

- **Adds `x86_64-unknown-linux-musl`** (static binary, runs on any Linux without a libc dependency) via `cross`.
- **Adds SHA-256 checksums**: every archive gets a `.sha256` sidecar (`sha256sum`/`shasum`), uploaded alongside it.
- **README Install section**: a table of assets per platform + a download/verify/extract example, so users don't need a Rust toolchain.

Final target matrix: macOS arm64, macOS x86_64, Linux x86_64 gnu, **Linux x86_64 musl (new)**, Linux aarch64 gnu, Windows x86_64.

## Acceptance criteria
- [x] Release workflow builds + attaches the required artifacts on tag push
- [x] Binaries are named consistently and checksummed
- [x] README install instructions point at the release assets

> **Phase-4 note:** this only changes the workflow definition. It fires on `v*` tag push — actually cutting a release is a separate maintainer-gated action.

Closes #561