### PR TITLE
ci(docs): per-tag rustdoc to GitHub Pages + discoverable changelog (#563)

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -1,0 +1,72 @@
+name: API Docs
+
+# Publishes per-tag rustdoc for cqlite-core to GitHub Pages so downstream
+# consumers (who pin by git tag, since CQLite is not on crates.io) can evaluate a
+# version's API without checking out the repo. Each tag is published under
+# /<tag>/ and the newest also under /latest/; history is preserved (keep_files).
+#
+# Requires GitHub Pages to be enabled for the repo with the "gh-pages branch"
+# source (Settings → Pages). Enabling Pages is a one-time maintainer action.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version subdirectory to publish under (e.g. v0.9.2)"
+        required: true
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  rustdoc:
+    name: Build & publish rustdoc
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      # Use stable for doc builds regardless of the pinned toolchain.
+      - name: Override Rust toolchain
+        run: rm -f rust-toolchain.toml
+
+      - name: Resolve version label
+        id: ver
+        shell: bash
+        run: |
+          if [[ -n "${{ github.event.inputs.version }}" ]]; then
+            echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build rustdoc (cqlite-core, all features)
+        run: cargo doc --no-deps --package cqlite-core --all-features
+
+      - name: Add root redirect to crate index
+        run: |
+          echo '<meta http-equiv="refresh" content="0; url=cqlite_core/index.html">' > target/doc/index.html
+
+      - name: Publish to /<version>/ on gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./target/doc
+          destination_dir: ${{ steps.ver.outputs.version }}
+          keep_files: true
+
+      - name: Publish to /latest/ on gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./target/doc
+          destination_dir: latest
+          keep_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,6 +119,27 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  # Append the changelog + hosted API-docs links to the auto-generated release
+  # notes. Runs once per tag (no matrix) so the body is set a single time (#563).
+  release-notes:
+    name: Add changelog + API-docs links to release notes
+    runs-on: ubuntu-latest
+    needs: build-cli
+    steps:
+    - uses: actions/checkout@v4
+    - name: Update release body
+      uses: softprops/action-gh-release@v2
+      with:
+        generate_release_notes: true
+        append_body: true
+        body: |
+
+          ---
+          📖 **API docs for this release:** https://pmcfadin.github.io/cqlite/${{ github.ref_name }}/
+          📋 **Changelog:** see [CHANGELOG.md](https://github.com/pmcfadin/cqlite/blob/${{ github.ref_name }}/CHANGELOG.md)
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   # NOTE: FFI and WASM builds disabled until M4 (Language Bindings)
   # Uncomment when cqlite-ffi and cqlite-wasm packages exist
   #

--- a/README.md
+++ b/README.md
@@ -342,6 +342,8 @@ See [docs/development/PRD.md](docs/development/PRD.md) for milestone details.
 
 ## Resources
 
+- **API docs (rustdoc)**: [latest tag](https://pmcfadin.github.io/cqlite/latest/) · published per release tag at `https://pmcfadin.github.io/cqlite/<tag>/`
+- **Changelog**: [CHANGELOG.md](CHANGELOG.md) — what each tagged release contains
 - **Documentation**: [Complete project docs](docs/)
 - **CQL Grammar**: [Patrick's Antlr4 CQL Grammar](https://github.com/pmcfadin/cassandra-antlr4-grammar)
 - **Issues**: [GitHub Issues](https://github.com/pmcfadin/cqlite/issues)


### PR DESCRIPTION
## Summary
Gives git-tag consumers a way to evaluate a version's API and changes without checking out the repo (epic #556, feedback item 4).

- **`api-docs.yml`** (new): on `v*` tag push (and `workflow_dispatch`), builds `cqlite-core` rustdoc (`--all-features`) and publishes to the `gh-pages` branch under `/<tag>/` and `/latest/`, preserving prior versions (`keep_files: true`). URLs: `https://pmcfadin.github.io/cqlite/<tag>/` and `/latest/`.
- **`release.yml`**: a single-run `release-notes` job appends hosted API-docs + CHANGELOG links to the auto-generated release notes.
- **README Resources**: links the hosted API docs (latest + per-tag) and `CHANGELOG.md`.

Verified `cargo doc --no-deps -p cqlite-core --all-features` builds (no `-D warnings`, so doc-link warnings don't fail publishing); both workflows are valid YAML.

## Acceptance criteria
- [x] API docs for the latest tag reachable via URL (`/latest/`, plus per-tag)
- [x] CHANGELOG discoverable from the repo landing page (README) and referenced in release notes

> **Depends on #568 (#561):** this branch is cut from `dx/561-cli-release-binaries` because it extends the same `release.yml`. The diff shown will include #561 until that merges; I'll rebase onto main right after, leaving only the 3 #563 files.
>
> **Phase-4 note:** enabling GitHub Pages (gh-pages source) and the first publish are outward-facing — gated on maintainer confirmation. This PR only adds the automation.

Closes #563