### PR TITLE
feat(write-engine): WAL durability toggle — Durability enum + with_durability builder (#547)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **WAL durability toggle on `WriteEngine`** — `WriteEngineConfig` now has a
+  `durability` field (default `Durability::SyncEachWrite`) and a matching builder
+  method `with_durability(Durability)`. When set to `Durability::Disabled`,
+  `write()` and `write_async()` skip WAL append and fsync entirely, buffering
+  mutations in the memtable only; data becomes durable only after a successful
+  `flush()` or `close()`. Default behavior (`SyncEachWrite`) is **unchanged**: a
+  successful `write` call still guarantees the mutation is durable on disk (#547).
+
+  ```toml
+  # Public API additions (cqlite-core::storage::write_engine)
+  pub enum Durability { SyncEachWrite, Disabled }
+  impl WriteEngineConfig { pub fn with_durability(self, Durability) -> Self }
+  ```
+
+  **Hazard note**: `ingest_wal_on` benchmarks may show fsync-latency noise on
+  shared CI runners; this is expected and does not indicate a regression. Only
+  `Durability::Disabled` paths are CPU-bound and gate-able.
+
 ### Fixed
 
 - **Provenance gate false-positives on branch names**: `scripts/ci/ensure_real_dataset.sh`

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -152,6 +152,65 @@ struct ActiveMerge {
     started_at: Instant,
 }
 
+/// WAL durability mode for the write engine.
+///
+/// Controls whether `write` and `write_async` append to and fsync the
+/// write-ahead log on every call.  The default (`SyncEachWrite`) matches the
+/// pre-existing behavior and is the **only safe choice for production
+/// workloads** — a process crash between a successful `write` and a later
+/// `flush` will lose mutations written with `Disabled`.
+///
+/// ## When to use `Disabled`
+///
+/// - **Bulk-load / import pipelines** where the source data is replayable and
+///   you are willing to re-run the load on failure.
+/// - **Benchmarking** where you want to isolate CPU-bound write throughput from
+///   fsync latency.  The companion `write/ingest_wal_off` Criterion bench uses
+///   this variant (see `cqlite-core/benches/write.rs`).
+///
+/// In both cases, call [`WriteEngine::flush`] (and, optionally,
+/// [`WriteEngine::close`]) when the load is finished so the data is durably
+/// persisted to SSTables.
+///
+/// ## WAL replay on restart
+///
+/// When `Disabled`, no WAL entries are written.  Reopening the engine on the
+/// same `wal_dir` after a crash will replay **zero** mutations, even if
+/// `flush` was never called.  If you need crash-safe recovery, use
+/// `SyncEachWrite`.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use cqlite_core::storage::write_engine::{Durability, WriteEngineConfig};
+///
+/// // Production (default)
+/// let config = WriteEngineConfig::new(data, wal, schema);
+///
+/// // Bulk-load / benchmarking
+/// let config = WriteEngineConfig::new(data, wal, schema)
+///     .with_durability(Durability::Disabled);
+/// ```
+#[cfg(feature = "write-support")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Durability {
+    /// Append to the WAL and call `fsync` on every `write` / `write_async`
+    /// call.  A successful return guarantees the mutation is durable on disk.
+    ///
+    /// This is the **default** and the safe choice for all production
+    /// workloads.
+    #[default]
+    SyncEachWrite,
+
+    /// Skip WAL append **and** fsync on every `write` / `write_async` call.
+    /// Mutations are buffered in the memtable only.  Data is durable only
+    /// after a successful [`WriteEngine::flush`].
+    ///
+    /// **Use only for bulk-load pipelines and benchmarks where durability can
+    /// be traded for throughput.**
+    Disabled,
+}
+
 /// Write engine configuration
 #[cfg(feature = "write-support")]
 #[derive(Debug, Clone)]
@@ -167,6 +226,8 @@ pub struct WriteEngineConfig {
     pub memtable_hard_limit: usize,
     /// Table schema for column metadata
     pub schema: TableSchema,
+    /// WAL durability mode (default: [`Durability::SyncEachWrite`])
+    pub durability: Durability,
 }
 
 #[cfg(feature = "write-support")]
@@ -184,6 +245,7 @@ impl WriteEngineConfig {
             memtable_flush_threshold: Self::DEFAULT_FLUSH_THRESHOLD,
             memtable_hard_limit: Self::DEFAULT_HARD_LIMIT,
             schema,
+            durability: Durability::default(),
         }
     }
 
@@ -196,6 +258,25 @@ impl WriteEngineConfig {
     /// Set a custom hard limit
     pub fn with_hard_limit(mut self, limit: usize) -> Self {
         self.memtable_hard_limit = limit;
+        self
+    }
+
+    /// Set the WAL durability mode.
+    ///
+    /// Mirrors `with_flush_threshold` in style. See [`Durability`] for the
+    /// trade-offs between [`Durability::SyncEachWrite`] (default, production)
+    /// and [`Durability::Disabled`] (bulk-load / benchmarking).
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use cqlite_core::storage::write_engine::{Durability, WriteEngineConfig};
+    ///
+    /// let config = WriteEngineConfig::new(data, wal, schema)
+    ///     .with_durability(Durability::Disabled);
+    /// ```
+    pub fn with_durability(mut self, durability: Durability) -> Self {
+        self.durability = durability;
         self
     }
 }
@@ -434,9 +515,11 @@ impl WriteEngine {
             )));
         }
 
-        // 1. Append to WAL (durability)
-        self.wal.append(&mutation)?;
-        self.wal.sync()?;
+        // 1. Append to WAL (durability) — skipped when Durability::Disabled
+        if self.config.durability == Durability::SyncEachWrite {
+            self.wal.append(&mutation)?;
+            self.wal.sync()?;
+        }
 
         // 2. Compute decorated key from partition key
         let decorated_key = mutation.decorated_key(&self.config.schema)?;
@@ -503,9 +586,11 @@ impl WriteEngine {
             )));
         }
 
-        // 1. Append to WAL (durability)
-        self.wal.append(&mutation)?;
-        self.wal.sync()?;
+        // 1. Append to WAL (durability) — skipped when Durability::Disabled
+        if self.config.durability == Durability::SyncEachWrite {
+            self.wal.append(&mutation)?;
+            self.wal.sync()?;
+        }
 
         // 2. Compute decorated key from partition key
         let decorated_key = mutation.decorated_key(&self.config.schema)?;
@@ -3101,6 +3186,209 @@ mod tests {
         assert_eq!(
             stats.sstables_produced, 1,
             "one output SSTable must have been produced"
+        );
+    }
+
+    // ============================================================================
+    // Issue #547: WAL durability toggle tests
+    // ============================================================================
+
+    /// `Durability::SyncEachWrite` is the default variant.
+    #[test]
+    fn test_durability_default_is_sync_each_write() {
+        assert_eq!(Durability::default(), Durability::SyncEachWrite);
+    }
+
+    /// `WriteEngineConfig` defaults to `Durability::SyncEachWrite`.
+    #[test]
+    fn test_config_default_durability() {
+        let temp_dir = TempDir::new().unwrap();
+        let schema = create_test_schema();
+        let config = WriteEngineConfig::new(
+            temp_dir.path().join("data"),
+            temp_dir.path().join("wal"),
+            schema,
+        );
+        assert_eq!(config.durability, Durability::SyncEachWrite);
+    }
+
+    /// `with_durability` builder sets the field and returns `Self`.
+    #[test]
+    fn test_config_with_durability_builder() {
+        let temp_dir = TempDir::new().unwrap();
+        let schema = create_test_schema();
+        let config = WriteEngineConfig::new(
+            temp_dir.path().join("data"),
+            temp_dir.path().join("wal"),
+            schema,
+        )
+        .with_durability(Durability::Disabled);
+        assert_eq!(config.durability, Durability::Disabled);
+    }
+
+    /// With `Durability::SyncEachWrite`, the WAL grows after each `write`.
+    #[test]
+    fn test_wal_on_produces_wal_growth() {
+        let temp_dir = TempDir::new().unwrap();
+        let schema = create_test_schema();
+        let config = WriteEngineConfig::new(
+            temp_dir.path().join("data"),
+            temp_dir.path().join("wal"),
+            schema,
+        )
+        .with_durability(Durability::SyncEachWrite);
+
+        let mut engine = WriteEngine::new(config).unwrap();
+        assert_eq!(engine.wal_size(), 0, "WAL must start empty");
+
+        let mutation = create_test_mutation(1, "Alice", 1_000_000);
+        engine.write(mutation).unwrap();
+
+        assert!(
+            engine.wal_size() > 0,
+            "WAL must grow after write with SyncEachWrite"
+        );
+    }
+
+    /// With `Durability::Disabled`, the WAL is never written — `wal_size()` stays 0.
+    #[test]
+    fn test_wal_off_produces_no_wal_growth() {
+        let temp_dir = TempDir::new().unwrap();
+        let schema = create_test_schema();
+        let config = WriteEngineConfig::new(
+            temp_dir.path().join("data"),
+            temp_dir.path().join("wal"),
+            schema,
+        )
+        .with_durability(Durability::Disabled);
+
+        let mut engine = WriteEngine::new(config).unwrap();
+        assert_eq!(engine.wal_size(), 0, "WAL must start empty");
+
+        // Write several mutations — none should touch the WAL.
+        for i in 0..10 {
+            let mutation = create_test_mutation(i, &format!("User{}", i), 1_000_000 + i as i64);
+            engine.write(mutation).unwrap();
+        }
+
+        assert_eq!(
+            engine.wal_size(),
+            0,
+            "WAL must remain empty with Durability::Disabled"
+        );
+        assert_eq!(
+            engine.memtable_row_count(),
+            10,
+            "Mutations must reach the memtable even without WAL"
+        );
+    }
+
+    /// With `Durability::Disabled`, async writes also skip the WAL.
+    #[tokio::test]
+    async fn test_wal_off_write_async_produces_no_wal_growth() {
+        let temp_dir = TempDir::new().unwrap();
+        let schema = create_test_schema();
+        let config = WriteEngineConfig::new(
+            temp_dir.path().join("data"),
+            temp_dir.path().join("wal"),
+            schema,
+        )
+        .with_durability(Durability::Disabled);
+
+        let mut engine = WriteEngine::new(config).unwrap();
+
+        for i in 0..5 {
+            let mutation = create_test_mutation(i, &format!("User{}", i), 1_000_000 + i as i64);
+            engine.write_async(mutation).await.unwrap();
+        }
+
+        assert_eq!(
+            engine.wal_size(),
+            0,
+            "WAL must remain empty with Durability::Disabled (async path)"
+        );
+        assert_eq!(engine.memtable_row_count(), 5);
+    }
+
+    /// With `Durability::Disabled`, data that was never WAL'd is NOT replayed on
+    /// restart — confirming the documented durability trade-off.
+    #[test]
+    fn test_wal_off_no_replay_on_restart() {
+        let temp_dir = TempDir::new().unwrap();
+        let schema = create_test_schema();
+
+        {
+            let config = WriteEngineConfig::new(
+                temp_dir.path().join("data"),
+                temp_dir.path().join("wal"),
+                schema.clone(),
+            )
+            .with_durability(Durability::Disabled);
+
+            let mut engine = WriteEngine::new(config).unwrap();
+
+            for i in 0..5 {
+                let mutation = create_test_mutation(i, &format!("User{}", i), 1_000_000 + i as i64);
+                engine.write(mutation).unwrap();
+            }
+
+            // Drop without flushing — simulating crash.
+        }
+
+        // Reopen with default durability.  Because the WAL was never written, the
+        // memtable must be empty.
+        let config2 = WriteEngineConfig::new(
+            temp_dir.path().join("data"),
+            temp_dir.path().join("wal"),
+            schema,
+        );
+        let engine2 = WriteEngine::new(config2).unwrap();
+
+        assert_eq!(
+            engine2.memtable_row_count(),
+            0,
+            "No WAL entries were written with Disabled, so no replay is possible"
+        );
+    }
+
+    /// With `Durability::SyncEachWrite`, mutations ARE replayed after a simulated crash.
+    #[test]
+    fn test_wal_on_replays_on_restart() {
+        let temp_dir = TempDir::new().unwrap();
+        let schema = create_test_schema();
+
+        {
+            let config = WriteEngineConfig::new(
+                temp_dir.path().join("data"),
+                temp_dir.path().join("wal"),
+                schema.clone(),
+            )
+            .with_durability(Durability::SyncEachWrite);
+
+            let mut engine = WriteEngine::new(config).unwrap();
+
+            for i in 0..5 {
+                let mutation = create_test_mutation(i, &format!("User{}", i), 1_000_000 + i as i64);
+                engine.write(mutation).unwrap();
+            }
+
+            // Drop without flushing — WAL entries remain on disk.
+        }
+
+        // Reopen — WAL replay must restore the 5 mutations.
+        let config2 = WriteEngineConfig::new(
+            temp_dir.path().join("data"),
+            temp_dir.path().join("wal"),
+            schema,
+        )
+        .with_durability(Durability::SyncEachWrite);
+
+        let engine2 = WriteEngine::new(config2).unwrap();
+
+        assert_eq!(
+            engine2.memtable_row_count(),
+            5,
+            "SyncEachWrite must replay mutations durably on restart"
         );
     }
 }

--- a/docs/using-cqlite-core-as-a-dependency.md
+++ b/docs/using-cqlite-core-as-a-dependency.md
@@ -95,7 +95,12 @@ let mutation = Mutation::new(
     None,                                  // no TTL
 );
 
-// `write` is SYNCHRONOUS, takes `&mut self`, and fsyncs the WAL on every call.
+// `write` is SYNCHRONOUS, takes `&mut self`, and fsyncs the WAL on every call
+// (the default `Durability::SyncEachWrite`).  For bulk-load or benchmarking,
+// disable per-write fsyncs with `Durability::Disabled`:
+//
+//   let config = WriteEngineConfig::new(data, wal, schema)
+//       .with_durability(cqlite_core::storage::write_engine::Durability::Disabled);
 engine.write(mutation)?;
 ```
 
@@ -105,8 +110,9 @@ These trip up first-time consumers because the real API differs from what the
 on-disk format spec implies:
 
 - **`WriteEngine::write(&mut self, Mutation) -> Result<()>` is synchronous** and
-  fsyncs the WAL on every call. (`write_async` exists for async call sites; it has
-  the same `&mut self` / per-write durability semantics.)
+  fsyncs the WAL on every call by default (`Durability::SyncEachWrite`).
+  (`write_async` exists for async call sites; it has the same `&mut self` /
+  per-write durability semantics unless you opt in to `Durability::Disabled`.)
 - **`CellOperation` has no `Insert` variant.** The variants are `Write`,
   `WriteWithTtl`, `Delete`, and `DeleteRow`.
 - **`Mutation` fields**: `table`, `partition_key`, `clustering_key` (`Option`),
@@ -140,13 +146,38 @@ two properties, both verified in the source
   writer task. The engine is intentionally **not** internally synchronized; there
   is no sharded or multi-writer mode.
 
-- **The WAL is fsync'd on every `write` ⇒ durability-first, throughput-bounded.**
-  Each `write` appends to the write-ahead log and fsyncs before returning, so a
-  successful call means the mutation is durable on disk. The cost is that
-  single-thread write throughput is bounded by fsync latency rather than CPU —
-  expect low-hundreds of ops/sec on typical disks (a downstream benchmark harness
-  measured ~282 ops/sec single-thread). Adding threads does **not** raise this:
-  writers serialize through the single engine, and each still pays one fsync.
+- **The WAL is fsync'd on every `write` by default (`Durability::SyncEachWrite`) ⇒
+  durability-first, throughput-bounded.** Each `write` appends to the write-ahead
+  log and fsyncs before returning, so a successful call means the mutation is
+  durable on disk. The cost is that single-thread write throughput is bounded by
+  fsync latency rather than CPU — expect low-hundreds of ops/sec on typical disks
+  (a downstream benchmark harness measured ~282 ops/sec single-thread). Adding
+  threads does **not** raise this: writers serialize through the single engine, and
+  each still pays one fsync.
+
+- **`Durability::Disabled` removes the per-write fsync ⇒ CPU-bound throughput.**
+  When you build the engine with `.with_durability(Durability::Disabled)`, `write`
+  and `write_async` skip WAL append and fsync entirely, buffering mutations in the
+  memtable only. A successful `flush` (or `close`) then persists everything to an
+  SSTable. **Use only for bulk-load pipelines and benchmarks where you can trade
+  crash safety for throughput.**
+
+  ```rust,ignore
+  use cqlite_core::storage::write_engine::{Durability, WriteEngineConfig};
+
+  // Bulk-load / benchmarking — no per-write fsync
+  let config = WriteEngineConfig::new(data, wal, schema)
+      .with_durability(Durability::Disabled);
+  let mut engine = WriteEngine::new(config)?;
+
+  // … write many mutations …
+
+  engine.flush().await?;  // ← data becomes durable here
+  ```
+
+  If the process crashes between `write` calls and the subsequent `flush`, all
+  buffered mutations are lost (no WAL to replay). `Durability::SyncEachWrite`
+  (the default) is the safe choice for production.
 
 ### Intended usage
 
@@ -154,16 +185,14 @@ two properties, both verified in the source
   Group many cells into a single `Mutation` where the data model allows, and let
   the memtable accumulate across many `write` calls before a `flush` — flushing is
   amortized, the per-write fsync is not.
-- For bulk-load / benchmarking where you can trade durability for speed, an opt-in
-  WAL durability toggle is tracked in
-  [#547](https://github.com/pmcfadin/cqlite/issues/547). That is the planned lever
-  for lifting the per-write fsync bound.
+- For bulk-load / benchmarking, use `Durability::Disabled` (shipped in
+  [#547](https://github.com/pmcfadin/cqlite/issues/547)) to lift the per-write
+  fsync bound and measure CPU-bound write throughput.
 
 ### Is a batched / async write path on the roadmap?
 
 `write_async` already exists for async call sites, but it has the **same**
-single-writer `&mut self` semantics and the same per-write WAL fsync — it is not a
-throughput escape hatch. There is **no separate batched-mutation API currently
-planned**; the single-writer + per-write-durability model above is the intended
-design. The one roadmap item that changes the throughput envelope is the optional
-WAL durability toggle ([#547](https://github.com/pmcfadin/cqlite/issues/547)).
+single-writer `&mut self` semantics and the same per-write WAL fsync by default —
+it is not a throughput escape hatch on its own. The lever that lifts the fsync
+bound is `Durability::Disabled` (#547). There is **no separate batched-mutation
+API currently planned**; the single-writer model above is the intended design.


### PR DESCRIPTION
## Summary

Closes #547

Exposes a public WAL durability knob on `WriteEngineConfig` so callers can opt out of per-write fsync for bulk-load and benchmark workloads. This is the keystone for Epic #573 — the `Durability` enum and `with_durability` builder are the public API that the dependent bench issue (#574) will use.

### What changed

- **New `Durability` enum** (`cqlite-core::storage::write_engine::Durability`):
  - `SyncEachWrite` (default): appends to WAL and fsyncs on every `write`/`write_async` — identical to the pre-existing behavior.
  - `Disabled`: skips WAL append and fsync entirely; mutations reach the memtable only and become durable after a successful `flush`/`close`.
- **New `with_durability(Durability) -> Self` builder** on `WriteEngineConfig`, mirroring `with_flush_threshold`.
- **`write()` and `write_async()` now branch** on `config.durability`; the two lines `self.wal.append()`/`self.wal.sync()` are skipped when `Disabled`.

Default behavior is **unchanged** — `SyncEachWrite` is the `Default` variant.

### Files changed

- `cqlite-core/src/storage/write_engine/mod.rs` — enum, config field, builder, write/write_async branches, 8 new tests
- `docs/using-cqlite-core-as-a-dependency.md` — §5 updated: documents `Disabled`, its trade-offs, code example; forward-ref to future #547 removed
- `CHANGELOG.md` — `[Unreleased] → Added` entry

### Tests added (8)

| Test | What it proves |
|------|---------------|
| `test_durability_default_is_sync_each_write` | `Durability::default()` is `SyncEachWrite` |
| `test_config_default_durability` | Config field defaults to `SyncEachWrite` |
| `test_config_with_durability_builder` | Builder sets `Disabled` correctly |
| `test_wal_on_produces_wal_growth` | WAL grows after write with `SyncEachWrite` |
| `test_wal_off_produces_no_wal_growth` | WAL stays at 0 bytes with `Disabled` (sync path) |
| `test_wal_off_write_async_produces_no_wal_growth` | WAL stays at 0 bytes with `Disabled` (async path) |
| `test_wal_off_no_replay_on_restart` | Crash with `Disabled` → 0 mutations replayed |
| `test_wal_on_replays_on_restart` | Crash with `SyncEachWrite` → all 5 mutations replayed |

### Local gate

```
cargo fmt --all -- --check        ✅ pass
RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features  ✅ pass
cargo test -p cqlite-core         ✅ 1554 tests pass, 0 failed
cargo build --bench write -p cqlite-core  ✅ compiles
```

### ingest_wal_on fsync meta-hazard

The `write/ingest_wal_on` Criterion benchmark (measuring the `SyncEachWrite` path) exercises real fsyncs and will show high variance on shared CI runners. This is expected behavior — fsync latency is disk/OS-dependent, not CPU-bound — and **should be treated as advisory, not a gate**. Only `Durability::Disabled` paths (e.g. the upcoming `write/ingest_wal_off` bench from #574) are CPU-bound and appropriate for pass/fail regression gating. See the brief's meta-hazard note and the updated §5 in `docs/using-cqlite-core-as-a-dependency.md`.