### PR TITLE
perf(bench): add write/ingest_wal_off benchmark (#574)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   shared CI runners; this is expected and does not indicate a regression. Only
   `Durability::Disabled` paths are CPU-bound and gate-able.
 
+- **`write/ingest_wal_off` benchmark** — new Criterion bench in
+  `cqlite-core/benches/write.rs` that runs the same 256-row ingest loop as
+  `ingest_wal_on` but with `Durability::Disabled` (#574). The measured path
+  performs no `wal.append()` or `wal.sync()`, isolating pure CPU + memtable
+  cost. This bench is strictly gated in the CI perf regression gate;
+  `ingest_wal_on` is now classified as advisory (reported, never fails CI on
+  its own). A new `open_write_engine_wal_off` fixture helper in
+  `benches/fixtures/mod.rs` constructs the WAL-disabled engine.
+
 ### Fixed
 
 - **Provenance gate false-positives on branch names**: `scripts/ci/ensure_real_dataset.sh`

--- a/cqlite-core/benches/README.md
+++ b/cqlite-core/benches/README.md
@@ -71,7 +71,15 @@ env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets \
 | `m1_performance` | kept | M1 baseline targets: partition-lookup latency plus multi-SSTable read throughput (MB/s). |
 | `fixtures_smoke` | added (#537) | Smoke/acceptance bench proving the fixture loaders are deterministic (seeded RNG + stable scan row count). Read/write portions activate under `cli-helpers` / `write-support`. |
 | `read` | added (#538) | Read suite (needs `--features cli-helpers`): `point_lookup`, `clustering_slice`, `full_scan`, `type_heavy` over the fixtures via the public query API. |
-| `write` | added (#539) | Write suite (needs `--features write-support`): `ingest_wal_on` (sustained ingest) and `flush` (memtable→SSTable flush latency) over the M5 `WriteEngine`. |
+| `write` | added (#539, #574) | Write suite (needs `--features write-support`): `ingest_wal_on`, `ingest_wal_off`, and `flush` — see below. |
+
+### `write` bench breakdown
+
+| Bench name | Gate policy | What it measures |
+|------------|-------------|------------------|
+| `write/ingest_wal_off` | **Strictly gated** — strict pass/fail | 256-row ingest with `Durability::Disabled`: WAL append and fsync are skipped. Pure CPU + memtable cost. Stable enough for reliable regression detection. |
+| `write/ingest_wal_on` | **Advisory** — reported, never fails CI | Identical 256-row ingest with `Durability::SyncEachWrite` (default): every row calls `wal.append()` + `wal.sync()` (fsync). I/O-dominated; fsync latency on shared CI runners makes this too noisy for strict gating, but it documents durability cost. |
+| `write/flush` | **Strictly gated** — strict pass/fail | Pre-filled memtable flushed once per iteration. Throughput reported in MB/s. |
 
 ## Performance regression gate (Issue #540)
 

--- a/cqlite-core/benches/fixtures/mod.rs
+++ b/cqlite-core/benches/fixtures/mod.rs
@@ -207,6 +207,10 @@ CREATE TABLE test_basic.simple_table (
 /// [`tempfile::TempDir`]). `flush_threshold` bytes controls when the memtable is
 /// eligible to flush; pass a large value to bench pure ingest, a small value to
 /// force flushes.
+///
+/// The engine is built with the default [`Durability::SyncEachWrite`] policy —
+/// every `write()` call performs `wal.append()` + `wal.sync()` (fsync).  Use
+/// [`open_write_engine_wal_off`] to benchmark the WAL-disabled path.
 #[cfg(feature = "write-support")]
 pub fn open_write_engine(
     dir: &std::path::Path,
@@ -219,6 +223,28 @@ pub fn open_write_engine(
     let cfg = WriteEngineConfig::new(dir.join("data"), dir.join("wal"), schema)
         .with_flush_threshold(flush_threshold);
     WriteEngine::new(cfg).expect("build write engine")
+}
+
+/// Build a [`WriteEngine`](cqlite_core::storage::write_engine::WriteEngine) with
+/// [`Durability::Disabled`] — WAL append and fsync are skipped on every
+/// `write()` call.  Mutations land only in the memtable; data is durable only
+/// after an explicit [`WriteEngine::flush`].
+///
+/// Use this for the `write/ingest_wal_off` bench (Issue #574) to measure the
+/// pure CPU/memtable ingest cost without I/O noise from fsync.
+#[cfg(feature = "write-support")]
+pub fn open_write_engine_wal_off(
+    dir: &std::path::Path,
+    flush_threshold: usize,
+) -> cqlite_core::storage::write_engine::WriteEngine {
+    use cqlite_core::schema::parse_cql_schema;
+    use cqlite_core::storage::write_engine::{Durability, WriteEngine, WriteEngineConfig};
+
+    let schema = parse_cql_schema(WRITE_TABLE_CQL).expect("parse write-bench schema");
+    let cfg = WriteEngineConfig::new(dir.join("data"), dir.join("wal"), schema)
+        .with_flush_threshold(flush_threshold)
+        .with_durability(Durability::Disabled);
+    WriteEngine::new(cfg).expect("build write engine (WAL off)")
 }
 
 /// Recursively copy a directory tree (files only; SSTable dirs are flat).

--- a/cqlite-core/benches/write.rs
+++ b/cqlite-core/benches/write.rs
@@ -1,27 +1,29 @@
-//! Write micro-benchmarks for cqlite-core (Issue #539, Epic #541 Phase 1).
+//! Write micro-benchmarks for cqlite-core (Issue #539, #574, Epic #541 Phase 1).
 //!
-//! These benches measure the two hot paths in the write engine:
+//! These benches measure the three hot paths in the write engine:
 //!
 //! - `write/ingest_wal_on` — sustained mutation ingest through the public
-//!   `WriteEngine::execute` API with WAL enabled. A WAL-off variant awaits the
-//!   public durability toggle tracked in issue #547.
+//!   `WriteEngine::execute` API with WAL enabled (`Durability::SyncEachWrite`).
+//!   Every row triggers `wal.append()` + `wal.sync()` (fsync), so this bench
+//!   is dominated by I/O latency on real disks.  It is tracked as **advisory**
+//!   in the perf gate — fsync variance on CI runners makes it unsuitable for
+//!   strict pass/fail.
+//!
+//! - `write/ingest_wal_off` — identical 256-row ingest loop but built with
+//!   [`Durability::Disabled`] (Issue #547/#574).  The measured path performs no
+//!   `wal.append()` or `wal.sync()` — it is pure CPU + memtable cost.  This
+//!   bench is tracked as **strictly gated** in the perf gate; because there is
+//!   no fsync it is stable enough to catch genuine throughput regressions.
 //!
 //! - `write/flush` — memtable → SSTable flush latency.  A pre-filled memtable
 //!   is flushed once per iteration; throughput is reported in MB/s relative to
 //!   the pre-flush memtable byte size.
 //!
-//! Both benches are deterministic: all input is generated from [`fixtures::seeded_rng`]
-//! so key/value selection is byte-for-byte identical across runs and machines.
-//! Each iteration uses a fresh [`tempfile::TempDir`] so iterations are
-//! independent and cannot share state through the WAL or data files.
-//!
-//! ## WAL-off variant (deferred)
-//!
-//! The issue spec asks for both `ingest_wal_on` and `ingest_wal_off` variants.
-//! `WriteEngine::write` unconditionally calls `wal.append()` + `wal.sync()` and
-//! [`WriteEngineConfig`](cqlite_core::storage::write_engine::WriteEngineConfig)
-//! has no durability toggle.  Implementing that toggle is tracked in issue #547.
-//! When #547 lands, add `ingest_wal_off` next to `ingest_wal_on` here.
+//! All benches are deterministic: all input is generated from
+//! [`fixtures::seeded_rng`] so key/value selection is byte-for-byte identical
+//! across runs and machines.  Each iteration uses a fresh [`tempfile::TempDir`]
+//! so iterations are independent and cannot share state through the WAL or data
+//! files.
 //!
 //! ## Running
 //!
@@ -59,8 +61,11 @@ const FLUSH_ROWS: u64 = 1_000;
 ///
 /// Throughput is reported as writes/second (`Throughput::Elements`).
 ///
-/// NOTE: A WAL-off variant is deferred until issue #547 adds a public
-/// durability toggle to `WriteEngineConfig`.
+/// This bench uses `Durability::SyncEachWrite` (the default): every row causes
+/// `wal.append()` + `wal.sync()` (fsync), so the result is dominated by
+/// disk-I/O latency.  It is tracked as **advisory** in the perf gate — fsync
+/// variance on shared CI runners makes it unsuitable for strict pass/fail.
+/// Use `write/ingest_wal_off` for the CPU-bound, strictly-gated measurement.
 #[cfg(feature = "write-support")]
 fn bench_ingest(c: &mut Criterion) {
     use rand::Rng;
@@ -97,6 +102,67 @@ fn bench_ingest(c: &mut Criterion) {
                 assert!(
                     n > 0,
                     "ingest_wal_on: memtable is empty after {INGEST_ROWS} inserts"
+                );
+                black_box(n)
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+/// `write/ingest_wal_off` — sustained mutation ingest (WAL disabled, Issue #574).
+///
+/// Identical to [`bench_ingest`] in every respect except the engine is built
+/// with [`Durability::Disabled`]: `wal.append()` and `wal.sync()` are skipped
+/// for every row.  The measured loop is pure CPU + memtable cost with no fsync
+/// I/O on the critical path.
+///
+/// **This bench is strictly gated** in the CI perf regression gate: because
+/// there is no fsync the measurement is stable across runs and a genuine
+/// throughput regression will be caught reliably.  `write/ingest_wal_on`
+/// complements it as the durability/disk probe (advisory, never fails CI on
+/// its own).
+///
+/// Throughput is reported as writes/second (`Throughput::Elements`).
+#[cfg(feature = "write-support")]
+fn bench_ingest_wal_off(c: &mut Criterion) {
+    use rand::Rng;
+
+    let mut group = c.benchmark_group("write");
+    group.throughput(Throughput::Elements(INGEST_ROWS));
+
+    group.bench_function("ingest_wal_off", |b| {
+        b.iter_batched(
+            // SETUP (untimed): fresh temp dir + engine with Durability::Disabled
+            // and huge flush threshold so no auto-flush fires mid-batch.
+            || {
+                let tmp =
+                    tempfile::TempDir::new().expect("create temp dir for ingest_wal_off bench");
+                let engine = fixtures::open_write_engine_wal_off(tmp.path(), usize::MAX);
+                let rng = fixtures::seeded_rng();
+                (tmp, engine, rng)
+            },
+            // ROUTINE (timed): insert INGEST_ROWS seeded rows — no wal.append()
+            // or wal.sync() on this path; pure memtable cost.
+            |(_tmp, mut engine, mut rng)| {
+                for _ in 0..INGEST_ROWS {
+                    let id = uuid::Uuid::from_u128(rng.gen());
+                    let age: i32 = rng.gen_range(0..100);
+                    let stmt = format!(
+                        "INSERT INTO test_basic.simple_table \
+                         (id, name, age, active) \
+                         VALUES ({id}, 'bench-row', {age}, true)"
+                    );
+                    engine.execute(&stmt).expect("ingest seeded row (wal off)");
+                }
+                // Assert that rows actually landed so a broken engine fails
+                // loudly rather than measuring nothing.
+                let n = engine.memtable_row_count();
+                assert!(
+                    n > 0,
+                    "ingest_wal_off: memtable is empty after {INGEST_ROWS} inserts"
                 );
                 black_box(n)
             },
@@ -198,7 +264,7 @@ fn bench_flush(c: &mut Criterion) {
 // every feature combination without dead-code noise.
 
 #[cfg(feature = "write-support")]
-criterion_group!(benches, bench_ingest, bench_flush);
+criterion_group!(benches, bench_ingest, bench_ingest_wal_off, bench_flush);
 
 #[cfg(not(feature = "write-support"))]
 fn bench_noop(_c: &mut Criterion) {


### PR DESCRIPTION
## Summary

- Adds `write/ingest_wal_off` Criterion bench to `cqlite-core/benches/write.rs` — identical 256-row ingest loop to the existing `write/ingest_wal_on` but built with `Durability::Disabled` (no `wal.append()` / `wal.sync()` on the measured path).
- Adds `open_write_engine_wal_off` fixture helper in `benches/fixtures/mod.rs` that wires `WriteEngineConfig::with_durability(Durability::Disabled)`.
- Documents the two-tier gate policy in `benches/README.md`: `ingest_wal_off` = strictly gated (code-bound, stable); `ingest_wal_on` = advisory (fsync-noise, never fails CI on its own).
- Updates `CHANGELOG.md`.

## WAL-off path confirmation

`write/ingest_wal_off` ran at ~97K writes/sec vs ~225 writes/sec for `write/ingest_wal_on` (~430x faster), which is the expected signature of skipping fsync. The code path branches at `if self.config.durability == Durability::SyncEachWrite` (write_engine/mod.rs lines 518-522) — confirmed no `wal.append()` or `wal.sync()` call for `Durability::Disabled`.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features` — clean
- [x] `cargo test -p cqlite-core` — 28 passed, 0 failed
- [x] `cargo bench -p cqlite-core --features write-support --bench write -- --warm-up-time 1 --measurement-time 2` — both `write/ingest_wal_on` and `write/ingest_wal_off` ran and produced output

## Stack

This PR is **stacked on #577** (issue #547 — WAL durability toggle). The `Durability` enum and `WriteEngineConfig::with_durability` used here live on `perf/547-wal-durability-toggle`. **Merge #577 first, then this PR.**

Closes #574