### PR TITLE
Wire memory-mapped I/O into the live SSTable read path

### DIFF
--- a/cqlite-core/src/config.rs
+++ b/cqlite-core/src/config.rs
@@ -52,6 +52,37 @@ pub struct StorageConfig {
 
     /// Sync mode for durability
     pub sync_mode: SyncMode,
+
+    /// Memory-map SSTable Data.db files instead of using buffered file I/O.
+    ///
+    /// **Opt-in.** Defaults to `false` (buffered I/O), which is portable and
+    /// safe on every filesystem. When enabled, the reader maps Data.db files at
+    /// or above [`Self::mmap_min_size_bytes`] into the process address space and
+    /// serves reads from the OS page cache with no per-block `read` syscall,
+    /// mirroring Cassandra's `disk_access_mode: mmap`. This speeds up repeated
+    /// local scans of the same files.
+    ///
+    /// # Safety / platform constraints
+    ///
+    /// A memory map aliases the file's bytes for the reader's lifetime. Only
+    /// enable this when the SSTables are **immutable local files**:
+    /// - Mutating, truncating, or deleting a mapped file out from under a live
+    ///   reader is undefined behaviour and can raise `SIGBUS`, terminating the
+    ///   process. CQLite never rewrites its own mapped inputs, but external
+    ///   tools must not either.
+    /// - Network and overlay filesystems (NFS, SMB, FUSE, some container
+    ///   overlays) can fault mid-read after a successful map; prefer buffered
+    ///   I/O there.
+    ///
+    /// Can also be enabled at runtime by setting `CQLITE_USE_MMAP=1`.
+    pub use_mmap: bool,
+
+    /// Minimum Data.db file size (bytes) before [`Self::use_mmap`] takes effect.
+    ///
+    /// Files smaller than this use buffered I/O even when `use_mmap` is set,
+    /// since the per-file mapping overhead is not worthwhile for tiny files and
+    /// mapping a zero-length file is invalid. Defaults to one page (4096).
+    pub mmap_min_size_bytes: usize,
 }
 
 impl Default for StorageConfig {
@@ -66,6 +97,8 @@ impl Default for StorageConfig {
             bloom_filter_fp_rate: 0.01,
             io_threads: num_cpus::get().min(4),
             sync_mode: SyncMode::Normal,
+            use_mmap: false, // Opt-in; buffered I/O is the portable, safe default
+            mmap_min_size_bytes: 4096, // One page
         }
     }
 }

--- a/cqlite-core/src/config.rs
+++ b/cqlite-core/src/config.rs
@@ -75,6 +75,10 @@ pub struct StorageConfig {
     ///   I/O there.
     ///
     /// Can also be enabled at runtime by setting `CQLITE_USE_MMAP=1`.
+    ///
+    /// `#[serde(default)]` keeps configs serialized before this field existed
+    /// (which omit it) deserializing successfully, defaulting to buffered I/O.
+    #[serde(default = "default_use_mmap")]
     pub use_mmap: bool,
 
     /// Minimum Data.db file size (bytes) before [`Self::use_mmap`] takes effect.
@@ -82,7 +86,20 @@ pub struct StorageConfig {
     /// Files smaller than this use buffered I/O even when `use_mmap` is set,
     /// since the per-file mapping overhead is not worthwhile for tiny files and
     /// mapping a zero-length file is invalid. Defaults to one page (4096).
+    ///
+    /// `#[serde(default)]` for backward compatibility with older payloads.
+    #[serde(default = "default_mmap_min_size_bytes")]
     pub mmap_min_size_bytes: usize,
+}
+
+/// Default for [`StorageConfig::use_mmap`]: mmap is opt-in, so buffered I/O.
+fn default_use_mmap() -> bool {
+    false
+}
+
+/// Default for [`StorageConfig::mmap_min_size_bytes`]: one page.
+fn default_mmap_min_size_bytes() -> usize {
+    4096
 }
 
 impl Default for StorageConfig {
@@ -97,8 +114,10 @@ impl Default for StorageConfig {
             bloom_filter_fp_rate: 0.01,
             io_threads: num_cpus::get().min(4),
             sync_mode: SyncMode::Normal,
-            use_mmap: false, // Opt-in; buffered I/O is the portable, safe default
-            mmap_min_size_bytes: 4096, // One page
+            // Opt-in; buffered I/O is the portable, safe default. Shared with
+            // the serde defaults so the two can never drift.
+            use_mmap: default_use_mmap(),
+            mmap_min_size_bytes: default_mmap_min_size_bytes(),
         }
     }
 }
@@ -692,6 +711,57 @@ mod tests {
 
         config.storage.bloom_filter_fp_rate = 0.99; // Valid rate
         assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_storage_config_deserializes_without_mmap_fields() {
+        // Backward compatibility: a config payload serialized before the mmap
+        // fields existed omits `use_mmap` / `mmap_min_size_bytes`. It must still
+        // deserialize, defaulting to the safe buffered backend.
+        let mut value = serde_json::to_value(StorageConfig::default()).unwrap();
+        let obj = value.as_object_mut().unwrap();
+        obj.remove("use_mmap");
+        obj.remove("mmap_min_size_bytes");
+        assert!(!obj.contains_key("use_mmap"));
+
+        let restored: StorageConfig =
+            serde_json::from_value(value).expect("old payload must still deserialize");
+        assert!(!restored.use_mmap, "missing use_mmap must default to false");
+        assert_eq!(
+            restored.mmap_min_size_bytes, 4096,
+            "missing mmap_min_size_bytes must default to one page"
+        );
+    }
+
+    #[test]
+    fn test_full_config_deserializes_without_mmap_fields() {
+        // Same guarantee through the top-level Config, mirroring how the Python
+        // bindings parse a JSON/dict payload into `cqlite_core::Config`.
+        let mut value = serde_json::to_value(Config::default()).unwrap();
+        let storage = value
+            .get_mut("storage")
+            .and_then(|s| s.as_object_mut())
+            .unwrap();
+        storage.remove("use_mmap");
+        storage.remove("mmap_min_size_bytes");
+
+        let restored: Config =
+            serde_json::from_value(value).expect("old Config payload must still deserialize");
+        assert!(!restored.storage.use_mmap);
+        assert_eq!(restored.storage.mmap_min_size_bytes, 4096);
+        restored.validate().expect("restored config must validate");
+    }
+
+    #[test]
+    fn test_mmap_fields_roundtrip_when_present() {
+        // When the fields ARE present (e.g. a user opting in), they round-trip.
+        let mut config = StorageConfig::default();
+        config.use_mmap = true;
+        config.mmap_min_size_bytes = 8192;
+        let json = serde_json::to_string(&config).unwrap();
+        let restored: StorageConfig = serde_json::from_str(&json).unwrap();
+        assert!(restored.use_mmap);
+        assert_eq!(restored.mmap_min_size_bytes, 8192);
     }
 
     #[test]

--- a/cqlite-core/src/storage/sstable/reader/block_io.rs
+++ b/cqlite-core/src/storage/sstable/reader/block_io.rs
@@ -6,17 +6,17 @@
 //! - Retry logic for transient I/O errors
 
 use std::sync::Arc;
-use tokio::fs::File;
-use tokio::io::{AsyncReadExt, AsyncSeekExt, BufReader};
+use tokio::io::{AsyncReadExt, AsyncSeekExt};
 use tokio::sync::Mutex;
 
 use super::header::{detect_ascii_header_corruption, is_ascii_corruption_value};
+use super::source::BlockSource;
 use super::types::SSTableReaderConfig;
 use crate::{Error, Result};
 
 /// Read next block with enhanced error handling and streaming support
 pub(crate) async fn read_next_block(
-    file: &Arc<Mutex<BufReader<File>>>,
+    file: &Arc<Mutex<BlockSource>>,
     cassandra_version: &crate::parser::header::CassandraVersion,
     config: &SSTableReaderConfig,
     compression_info: &Option<Arc<crate::storage::sstable::compression_info::CompressionInfo>>,
@@ -37,7 +37,7 @@ pub(crate) async fn read_next_block(
 
 /// Read block with retry logic for handling transient I/O errors
 async fn read_next_block_with_retry(
-    file: &Arc<Mutex<BufReader<File>>>,
+    file: &Arc<Mutex<BlockSource>>,
     cassandra_version: &crate::parser::header::CassandraVersion,
     config: &SSTableReaderConfig,
     compression_info: &Option<Arc<crate::storage::sstable::compression_info::CompressionInfo>>,
@@ -83,7 +83,7 @@ async fn read_next_block_with_retry(
 
 /// Internal block reading implementation
 async fn read_next_block_impl(
-    file: &Arc<Mutex<BufReader<File>>>,
+    file: &Arc<Mutex<BlockSource>>,
     cassandra_version: &crate::parser::header::CassandraVersion,
     config: &SSTableReaderConfig,
     compression_info: &Option<Arc<crate::storage::sstable::compression_info::CompressionInfo>>,
@@ -227,7 +227,7 @@ async fn read_next_block_impl(
 /// support where chunk offsets may be relative to compressed data start, but for
 /// NB format it should always be 0.
 async fn read_nb_format_chunk_data(
-    file: &Arc<Mutex<BufReader<File>>>,
+    file: &Arc<Mutex<BlockSource>>,
     compression_info: &Option<Arc<crate::storage::sstable::compression_info::CompressionInfo>>,
     current_chunk_index: &std::sync::atomic::AtomicUsize,
     file_size: u64,
@@ -383,7 +383,7 @@ async fn read_nb_format_chunk_data(
 
 /// Read block header for BTI format
 async fn read_bti_format_block_header(
-    file: &Arc<Mutex<BufReader<File>>>,
+    file: &Arc<Mutex<BlockSource>>,
 ) -> Result<Option<(u32, u32, u64)>> {
     // BTI format has a slightly different header structure
     let mut header_buffer = [0u8; 12]; // 12-byte header for BTI
@@ -431,7 +431,7 @@ async fn read_bti_format_block_header(
 
 /// Read block header for legacy format
 async fn read_legacy_format_block_header(
-    file: &Arc<Mutex<BufReader<File>>>,
+    file: &Arc<Mutex<BlockSource>>,
 ) -> Result<Option<(u32, u32, u64)>> {
     let mut header_buffer = [0u8; 8]; // Minimal 8-byte header
     let current_pos = {
@@ -468,7 +468,7 @@ async fn read_legacy_format_block_header(
 }
 
 /// Read block data directly for small blocks
-async fn read_block_direct(file: &Arc<Mutex<BufReader<File>>>, size: usize) -> Result<Vec<u8>> {
+async fn read_block_direct(file: &Arc<Mutex<BlockSource>>, size: usize) -> Result<Vec<u8>> {
     let mut block_data = vec![0u8; size];
     {
         let mut file_guard = file.lock().await;
@@ -484,7 +484,7 @@ async fn read_block_direct(file: &Arc<Mutex<BufReader<File>>>, size: usize) -> R
 
 /// Read large block using streaming I/O to reduce memory pressure
 async fn read_large_block_streaming(
-    file: &Arc<Mutex<BufReader<File>>>,
+    file: &Arc<Mutex<BlockSource>>,
     size: usize,
     config: &SSTableReaderConfig,
 ) -> Result<Vec<u8>> {
@@ -531,9 +531,7 @@ async fn read_large_block_streaming(
 /// This format has no compression and no block headers - the entire data section
 /// after the 4096-byte file header is raw partition data. We read remaining data
 /// from current position to EOF, returning it as a single block.
-async fn read_uncompressed_data_block(
-    file: &Arc<Mutex<BufReader<File>>>,
-) -> Result<Option<Vec<u8>>> {
+async fn read_uncompressed_data_block(file: &Arc<Mutex<BlockSource>>) -> Result<Option<Vec<u8>>> {
     let (current_pos, file_size) = {
         let mut file_guard = file.lock().await;
         let current = file_guard.stream_position().await.map_err(|e| {
@@ -791,7 +789,7 @@ mod tests {
         tokio::fs::write(&temp_file, b"").await.unwrap();
 
         let file = tokio::fs::File::open(&temp_file).await.unwrap();
-        let file = Arc::new(Mutex::new(BufReader::new(file)));
+        let file = Arc::new(Mutex::new(BlockSource::buffered(file)));
 
         let result = read_block_direct(&file, 0).await;
         assert!(result.is_ok());
@@ -811,7 +809,7 @@ mod tests {
         tokio::fs::write(&temp_file, test_data).await.unwrap();
 
         let file = tokio::fs::File::open(&temp_file).await.unwrap();
-        let file = Arc::new(Mutex::new(BufReader::new(file)));
+        let file = Arc::new(Mutex::new(BlockSource::buffered(file)));
 
         let result = read_block_direct(&file, test_data.len()).await;
         assert!(result.is_ok());
@@ -831,7 +829,7 @@ mod tests {
         tokio::fs::write(&temp_file, test_data).await.unwrap();
 
         let file = tokio::fs::File::open(&temp_file).await.unwrap();
-        let file = Arc::new(Mutex::new(BufReader::new(file)));
+        let file = Arc::new(Mutex::new(BlockSource::buffered(file)));
 
         let result = read_uncompressed_data_block(&file).await;
         assert!(result.is_ok());
@@ -853,7 +851,7 @@ mod tests {
         tokio::fs::write(&temp_file, b"").await.unwrap();
 
         let file = tokio::fs::File::open(&temp_file).await.unwrap();
-        let file = Arc::new(Mutex::new(BufReader::new(file)));
+        let file = Arc::new(Mutex::new(BlockSource::buffered(file)));
 
         // Should return None for EOF
         let result = read_uncompressed_data_block(&file).await;
@@ -875,7 +873,7 @@ mod tests {
             .unwrap();
 
         let file = tokio::fs::File::open(&temp_file).await.unwrap();
-        let file = Arc::new(Mutex::new(BufReader::new(file)));
+        let file = Arc::new(Mutex::new(BlockSource::buffered(file)));
 
         // Should return None for incomplete header (EOF)
         let result = read_legacy_format_block_header(&file).await;
@@ -896,7 +894,7 @@ mod tests {
         tokio::fs::write(&temp_file, &header).await.unwrap();
 
         let file = tokio::fs::File::open(&temp_file).await.unwrap();
-        let file = Arc::new(Mutex::new(BufReader::new(file)));
+        let file = Arc::new(Mutex::new(BlockSource::buffered(file)));
 
         let result = read_legacy_format_block_header(&file).await;
         assert!(result.is_ok());
@@ -924,7 +922,7 @@ mod tests {
         tokio::fs::write(&temp_file, &header).await.unwrap();
 
         let file = tokio::fs::File::open(&temp_file).await.unwrap();
-        let file = Arc::new(Mutex::new(BufReader::new(file)));
+        let file = Arc::new(Mutex::new(BlockSource::buffered(file)));
 
         let result = read_bti_format_block_header(&file).await;
         assert!(result.is_ok());
@@ -949,7 +947,7 @@ mod tests {
         tokio::fs::write(&temp_file, &test_data).await.unwrap();
 
         let file = tokio::fs::File::open(&temp_file).await.unwrap();
-        let file = Arc::new(Mutex::new(BufReader::new(file)));
+        let file = Arc::new(Mutex::new(BlockSource::buffered(file)));
 
         let config = SSTableReaderConfig {
             read_buffer_size: 4096, // Small buffer to test streaming
@@ -1032,7 +1030,7 @@ mod tests {
             metadata.len()
         );
 
-        let file = Arc::new(Mutex::new(BufReader::new(file)));
+        let file = Arc::new(Mutex::new(BlockSource::buffered(file)));
 
         // Try reading a small block
         if metadata.len() > 100 {

--- a/cqlite-core/src/storage/sstable/reader/component_loading.rs
+++ b/cqlite-core/src/storage/sstable/reader/component_loading.rs
@@ -13,13 +13,14 @@ use crate::{Error, Result, RowKey};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use tokio::fs::File;
 use tokio::io::{AsyncSeekExt, BufReader};
+
+use super::source::BlockSource;
 
 impl SSTableReader {
     /// Load index from integrated or component-based format
     pub(super) async fn load_index(
-        file: &Arc<tokio::sync::Mutex<BufReader<File>>>,
+        file: &Arc<tokio::sync::Mutex<BlockSource>>,
         header: &crate::parser::SSTableHeader,
         platform: &Arc<Platform>,
         data_file_path: &Path,
@@ -101,7 +102,7 @@ impl SSTableReader {
 
     /// Load bloom filter from integrated or component-based format
     pub(super) async fn load_bloom_filter(
-        file: &Arc<tokio::sync::Mutex<BufReader<File>>>,
+        file: &Arc<tokio::sync::Mutex<BlockSource>>,
         header: &crate::parser::SSTableHeader,
         _platform: &Arc<Platform>,
         data_file_path: &Path,

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -69,10 +69,42 @@ use log::debug;
 #[cfg(feature = "tombstones")]
 use super::tombstone_merger::TombstoneMerger;
 
+/// Returns `true` when memory-mapped reads are force-enabled via the
+/// `CQLITE_USE_MMAP` environment variable.
+///
+/// Accepts `1`, `true`, `yes`, `on` (case-insensitive). Any other value — or
+/// an unset variable — leaves the decision to [`Config`]. This is an opt-in
+/// escape hatch for ad-hoc local use without threading a custom config.
+fn mmap_enabled_via_env() -> bool {
+    std::env::var("CQLITE_USE_MMAP")
+        .ok()
+        .as_deref()
+        .map(parse_truthy_env)
+        .unwrap_or(false)
+}
+
+/// Parse a truthy environment-variable value (`1`/`true`/`yes`/`on`,
+/// case-insensitive). Split out so it can be unit-tested without mutating the
+/// process-global environment (which would race other `open()` tests).
+fn parse_truthy_env(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
 impl SSTableReader {
     /// Open an SSTable file for reading
-    pub async fn open(path: &Path, _config: &Config, platform: Arc<Platform>) -> Result<Self> {
-        let reader_config = SSTableReaderConfig::default();
+    pub async fn open(path: &Path, config: &Config, platform: Arc<Platform>) -> Result<Self> {
+        // Honor the caller's storage config for the mmap decision. Memory
+        // mapping is opt-in (buffered I/O is the portable default); it can be
+        // turned on via `config.storage.use_mmap` or the `CQLITE_USE_MMAP`
+        // environment variable. See `Config::storage.use_mmap` for the
+        // platform/filesystem safety constraints.
+        let mut reader_config = SSTableReaderConfig::default();
+        reader_config.use_mmap = config.storage.use_mmap || mmap_enabled_via_env();
+        reader_config.mmap_min_size_bytes = config.storage.mmap_min_size_bytes;
+
         let file_size = tokio::fs::metadata(path).await?.len();
 
         // Select the backing store for block I/O. Memory-map the file when mmap
@@ -300,6 +332,15 @@ impl SSTableReader {
         })
     }
 
+    /// Whether this reader's block source is backed by a memory map.
+    ///
+    /// Test-only hook used to verify that the `use_mmap` config / env wiring
+    /// actually selects the intended backend end-to-end.
+    #[cfg(test)]
+    pub(crate) async fn is_mmap_backed(&self) -> bool {
+        self.file.lock().await.is_mmap()
+    }
+
     /// Memory-map an SSTable file read-only.
     ///
     /// # Safety / correctness
@@ -309,6 +350,12 @@ impl SSTableReader {
     /// them as read-only inputs, so this matches Cassandra's own mmap read
     /// strategy. Mutating the underlying file while a reader is open is
     /// undefined behaviour — callers must not do so.
+    ///
+    /// Note that only the initial mapping is fallible here. Once mapped, a later
+    /// page fault — caused by truncation, deletion, or a network/overlay
+    /// filesystem hiccup — raises `SIGBUS` and **cannot** be recovered as an
+    /// `io::Error`. This is why mmap is opt-in and gated on immutable local
+    /// files; see [`Config`]'s `storage.use_mmap` for the full constraints.
     fn map_file(path: &Path) -> Result<memmap2::Mmap> {
         let std_file = std::fs::File::open(path)?;
         // SAFETY: read-only mapping of a file assumed immutable for the

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -20,6 +20,7 @@ mod integrity;
 mod key_digest;
 pub(crate) mod parsing; // Needs to be accessible from row_cell_state_machine
 mod partition_lookup;
+mod source;
 #[cfg(test)]
 mod tests;
 mod types;
@@ -49,8 +50,10 @@ use std::path::Path;
 use std::sync::atomic::{AtomicU64, AtomicUsize};
 use std::sync::Arc;
 use tokio::fs::File;
-use tokio::io::{AsyncReadExt, AsyncSeekExt, BufReader};
+use tokio::io::{AsyncReadExt, AsyncSeekExt};
 use tokio::sync::Mutex;
+
+use source::BlockSource;
 
 use crate::{
     parser::{header::CassandraVersion, SSTableHeader, SSTableParser},
@@ -69,9 +72,42 @@ use super::tombstone_merger::TombstoneMerger;
 impl SSTableReader {
     /// Open an SSTable file for reading
     pub async fn open(path: &Path, _config: &Config, platform: Arc<Platform>) -> Result<Self> {
-        let file = File::open(path).await?;
-        let file_size = file.metadata().await?.len();
-        let file = Arc::new(Mutex::new(BufReader::new(file)));
+        let reader_config = SSTableReaderConfig::default();
+        let file_size = tokio::fs::metadata(path).await?.len();
+
+        // Select the backing store for block I/O. Memory-map the file when mmap
+        // is enabled and the file is large enough to be worth it; otherwise use
+        // buffered file I/O. Mapping a zero-length file is invalid, so empty
+        // files always fall back to buffered reads.
+        let use_mmap = reader_config.use_mmap
+            && file_size > 0
+            && file_size >= reader_config.mmap_min_size_bytes as u64;
+        let source = if use_mmap {
+            match Self::map_file(path) {
+                Ok(mmap) => {
+                    log::debug!(
+                        "Opened {} via memory map ({} bytes)",
+                        path.display(),
+                        file_size
+                    );
+                    BlockSource::mapped(Arc::new(mmap))
+                }
+                Err(e) => {
+                    // Memory mapping can fail on some filesystems (e.g. certain
+                    // network mounts). Degrade gracefully to buffered I/O rather
+                    // than failing the open outright.
+                    log::warn!(
+                        "Memory-mapping {} failed ({}); falling back to buffered I/O",
+                        path.display(),
+                        e
+                    );
+                    BlockSource::buffered(File::open(path).await?)
+                }
+            }
+        } else {
+            BlockSource::buffered(File::open(path).await?)
+        };
+        let file = Arc::new(Mutex::new(source));
 
         // Parse header - read available bytes, not a fixed size
         // NOTE: For NB format files (Cassandra 4.x+), Data.db often contains compressed row data
@@ -137,8 +173,6 @@ impl SSTableReader {
 
         // Load bloom filter if available (supports both integrated and component-based)
         let bloom_filter = Self::load_bloom_filter(&file, &header, &platform, path).await?;
-
-        let reader_config = SSTableReaderConfig::default();
 
         // Load spec readers for enhanced metadata and lookups
         let index_reader = Self::load_index_reader(path, &platform).await;
@@ -264,6 +298,23 @@ impl SSTableReader {
             compression_info: compression_info.map(Arc::new),
             current_chunk_index: AtomicUsize::new(0),
         })
+    }
+
+    /// Memory-map an SSTable file read-only.
+    ///
+    /// # Safety / correctness
+    ///
+    /// The returned [`Mmap`](memmap2::Mmap) aliases the file's bytes for its
+    /// entire lifetime. SSTables are immutable once written, and CQLite treats
+    /// them as read-only inputs, so this matches Cassandra's own mmap read
+    /// strategy. Mutating the underlying file while a reader is open is
+    /// undefined behaviour — callers must not do so.
+    fn map_file(path: &Path) -> Result<memmap2::Mmap> {
+        let std_file = std::fs::File::open(path)?;
+        // SAFETY: read-only mapping of a file assumed immutable for the
+        // reader's lifetime; see the function-level note above.
+        let mmap = unsafe { memmap2::MmapOptions::new().map(&std_file)? };
+        Ok(mmap)
     }
 
     /// Load CompressionInfo.db metadata for chunked reading

--- a/cqlite-core/src/storage/sstable/reader/source.rs
+++ b/cqlite-core/src/storage/sstable/reader/source.rs
@@ -114,14 +114,21 @@ impl AsyncRead for MmapCursor {
     ) -> Poll<io::Result<()>> {
         let this = self.get_mut();
         let data: &[u8] = &this.mmap;
-        // Clamp the position to the length; a position past EOF reads nothing,
-        // which drives `read_exact` to return `UnexpectedEof` just like a real
-        // file would. The block-header readers rely on this to detect EOF.
-        let pos = this.pos.min(data.len() as u64) as usize;
+        let len = data.len() as u64;
+        // At or past EOF: read nothing and leave the position untouched. A real
+        // `File` preserves a seeked-past-EOF position across a zero-byte read,
+        // so we must not clamp `pos` back to `len` here (that divergence was the
+        // source-level parity bug). Returning zero bytes still drives
+        // `read_exact` to `UnexpectedEof`, which the block-header readers use to
+        // detect EOF.
+        if this.pos >= len {
+            return Poll::Ready(Ok(()));
+        }
+        let pos = this.pos as usize;
         let remaining = &data[pos..];
         let n = remaining.len().min(buf.remaining());
         buf.put_slice(&remaining[..n]);
-        this.pos = pos as u64 + n as u64;
+        this.pos += n as u64;
         Poll::Ready(Ok(()))
     }
 }
@@ -232,6 +239,87 @@ mod tests {
         let file = tokio::fs::File::open(&path).await.unwrap();
         assert!(!BlockSource::buffered(file).is_mmap());
         tokio::fs::remove_file(&path).await.ok();
+    }
+
+    #[tokio::test]
+    async fn seek_past_eof_preserves_position_like_file() {
+        // Parity with std/tokio `File`: seeking past EOF and issuing a read
+        // returns zero bytes WITHOUT collapsing the cursor back to EOF.
+        let mut c = cursor(b"abc"); // len 3
+        let landed = c.seek(SeekFrom::Start(10)).await.unwrap();
+        assert_eq!(landed, 10);
+
+        let mut b = [0u8; 4];
+        let n = c.read(&mut b).await.unwrap();
+        assert_eq!(n, 0, "read past EOF yields no bytes");
+
+        // The position must still be 10, exactly as a real File would report,
+        // not clamped down to the file length (3).
+        assert_eq!(c.stream_position().await.unwrap(), 10);
+
+        // Seeking back to a valid offset still reads correctly afterwards.
+        c.seek(SeekFrom::Start(1)).await.unwrap();
+        let mut one = [0u8; 1];
+        c.read_exact(&mut one).await.unwrap();
+        assert_eq!(&one, b"b");
+    }
+
+    #[tokio::test]
+    async fn seek_past_eof_position_matches_real_file() {
+        // Cross-check the cursor's behaviour against an actual tokio File so the
+        // parity claim is verified against the reference implementation, not
+        // just asserted in isolation.
+        let bytes = b"abc";
+        let dir = std::env::temp_dir();
+        let path = dir.join("cqlite_mmapcursor_eof_parity.bin");
+        tokio::fs::write(&path, bytes).await.unwrap();
+
+        let mut file = tokio::fs::File::open(&path).await.unwrap();
+        file.seek(SeekFrom::Start(10)).await.unwrap();
+        let mut fb = [0u8; 4];
+        let file_n = file.read(&mut fb).await.unwrap();
+        let file_pos = file.stream_position().await.unwrap();
+        tokio::fs::remove_file(&path).await.ok();
+
+        let mut c = cursor(bytes);
+        c.seek(SeekFrom::Start(10)).await.unwrap();
+        let mut cb = [0u8; 4];
+        let cur_n = c.read(&mut cb).await.unwrap();
+        let cur_pos = c.stream_position().await.unwrap();
+
+        assert_eq!(cur_n, file_n, "byte count parity");
+        assert_eq!(cur_pos, file_pos, "post-read position parity");
+    }
+
+    #[tokio::test]
+    async fn multipage_read_across_page_boundary() {
+        // Exercise a map larger than a single OS page and read straddling the
+        // 4096-byte boundary, ensuring slicing/position math holds beyond one
+        // page.
+        let len = 10_000usize;
+        let mut data = vec![0u8; len];
+        for (i, b) in data.iter_mut().enumerate() {
+            *b = (i % 251) as u8; // deterministic, spans the page boundary
+        }
+        let mut c = cursor(&data);
+
+        // Read a window that starts before page 1 and ends after it.
+        c.seek(SeekFrom::Start(4090)).await.unwrap();
+        let mut window = [0u8; 16]; // covers 4090..4106, crossing 4096
+        c.read_exact(&mut window).await.unwrap();
+        for (k, b) in window.iter().enumerate() {
+            assert_eq!(*b, ((4090 + k) % 251) as u8);
+        }
+        assert_eq!(c.stream_position().await.unwrap(), 4106);
+
+        // Read the final bytes right up to EOF.
+        c.seek(SeekFrom::Start((len - 4) as u64)).await.unwrap();
+        let mut tail = [0u8; 4];
+        c.read_exact(&mut tail).await.unwrap();
+        for (k, b) in tail.iter().enumerate() {
+            assert_eq!(*b, ((len - 4 + k) % 251) as u8);
+        }
+        assert_eq!(c.stream_position().await.unwrap(), len as u64);
     }
 
     #[tokio::test]

--- a/cqlite-core/src/storage/sstable/reader/source.rs
+++ b/cqlite-core/src/storage/sstable/reader/source.rs
@@ -157,7 +157,14 @@ impl AsyncSeek for MmapCursor {
 /// subsequent reads simply return zero bytes.
 fn offset_from(base: u64, offset: i64) -> io::Result<u64> {
     let result = if offset >= 0 {
-        base.saturating_add(offset as u64)
+        // Overflowing the u64 address space is rejected rather than clamped, to
+        // mirror `std::fs::File`, which errors on a seek that overflows.
+        base.checked_add(offset as u64).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "invalid seek to an overflowing position",
+            )
+        })?
     } else {
         base.checked_sub(offset.unsigned_abs()).ok_or_else(|| {
             io::Error::new(
@@ -239,6 +246,24 @@ mod tests {
         let file = tokio::fs::File::open(&path).await.unwrap();
         assert!(!BlockSource::buffered(file).is_mmap());
         tokio::fs::remove_file(&path).await.ok();
+    }
+
+    #[tokio::test]
+    async fn positive_seek_overflow_errors() {
+        // A positive offset that overflows the u64 address space is rejected
+        // with InvalidInput (matching `File`), not saturated to u64::MAX.
+        let mut c = cursor(b"abc");
+        // Park the cursor at the very top of the address space (seeking past EOF
+        // is legal), then a positive Current offset overflows.
+        c.seek(SeekFrom::Start(u64::MAX)).await.unwrap();
+        let err = c.seek(SeekFrom::Current(1)).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+
+        // A large-but-non-overflowing positive offset still succeeds (parity:
+        // seeking past EOF is permitted, only overflow is an error).
+        let mut c2 = cursor(b"abc"); // len 3
+        let landed = c2.seek(SeekFrom::End(i64::MAX)).await.unwrap();
+        assert_eq!(landed, 3u64 + i64::MAX as u64);
     }
 
     #[tokio::test]

--- a/cqlite-core/src/storage/sstable/reader/source.rs
+++ b/cqlite-core/src/storage/sstable/reader/source.rs
@@ -1,0 +1,247 @@
+//! Backing store abstraction for SSTable block I/O.
+//!
+//! The SSTable reader accesses Data.db through a single seekable byte source.
+//! Historically this was always a buffered file handle (`BufReader<File>`).
+//! [`BlockSource`] generalizes that to two interchangeable backends:
+//!
+//! - [`BlockSource::Buffered`]: standard buffered async file I/O. Reads go
+//!   through the OS page cache with kernel read-ahead. This is the safe,
+//!   universally-portable default and is used for small files (where mmap
+//!   setup overhead is not worth it) or when mmap is disabled.
+//! - [`BlockSource::Mapped`]: a memory-mapped view of the file. The OS maps
+//!   the file into the process address space and serves reads straight from
+//!   the page cache with no per-block `read` syscall and no extra copy into a
+//!   buffered reader. This is well-suited to local SSTable analysis where the
+//!   same files are scanned repeatedly across queries (the page cache is
+//!   shared and reused), which is also the strategy Cassandra itself uses for
+//!   its read path (`disk_access_mode: mmap`).
+//!
+//! Both variants implement [`tokio::io::AsyncRead`] and
+//! [`tokio::io::AsyncSeek`], so every existing call site
+//! (`seek` / `stream_position` / `read` / `read_exact`) works against either
+//! backend without modification. The mmap backend is purely in-memory, so its
+//! poll methods always complete synchronously (`Poll::Ready`).
+
+use std::io::{self, SeekFrom};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use memmap2::Mmap;
+use tokio::fs::File;
+use tokio::io::{AsyncRead, AsyncSeek, BufReader, ReadBuf};
+
+/// A seekable byte source backing an [`SSTableReader`](super::types::SSTableReader).
+///
+/// See the module documentation for the trade-offs between the two backends.
+pub(crate) enum BlockSource {
+    /// Buffered file I/O through the OS page cache.
+    Buffered(BufReader<File>),
+    /// Memory-mapped file view served directly from the page cache.
+    Mapped(MmapCursor),
+}
+
+impl BlockSource {
+    /// Create a buffered (non-mmap) source from an open tokio file.
+    pub(crate) fn buffered(file: File) -> Self {
+        BlockSource::Buffered(BufReader::new(file))
+    }
+
+    /// Create a memory-mapped source from a previously mapped file.
+    pub(crate) fn mapped(mmap: Arc<Mmap>) -> Self {
+        BlockSource::Mapped(MmapCursor::new(mmap))
+    }
+
+    /// Returns `true` when this source is backed by a memory map.
+    #[cfg(test)]
+    pub(crate) fn is_mmap(&self) -> bool {
+        matches!(self, BlockSource::Mapped(_))
+    }
+}
+
+impl AsyncRead for BlockSource {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        match self.get_mut() {
+            BlockSource::Buffered(r) => Pin::new(r).poll_read(cx, buf),
+            BlockSource::Mapped(c) => Pin::new(c).poll_read(cx, buf),
+        }
+    }
+}
+
+impl AsyncSeek for BlockSource {
+    fn start_seek(self: Pin<&mut Self>, position: SeekFrom) -> io::Result<()> {
+        match self.get_mut() {
+            BlockSource::Buffered(r) => Pin::new(r).start_seek(position),
+            BlockSource::Mapped(c) => Pin::new(c).start_seek(position),
+        }
+    }
+
+    fn poll_complete(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<u64>> {
+        match self.get_mut() {
+            BlockSource::Buffered(r) => Pin::new(r).poll_complete(cx),
+            BlockSource::Mapped(c) => Pin::new(c).poll_complete(cx),
+        }
+    }
+}
+
+/// An in-memory read cursor over a memory-mapped file.
+///
+/// Implements the same `AsyncRead`/`AsyncSeek` contract as a buffered file
+/// reader, but every operation completes immediately since the data is already
+/// resident (modulo lazy page faults handled transparently by the OS).
+pub(crate) struct MmapCursor {
+    mmap: Arc<Mmap>,
+    /// Current read position. May legally point past the end of the map, in
+    /// which case reads yield zero bytes (matching `File` EOF semantics).
+    pos: u64,
+}
+
+impl MmapCursor {
+    fn new(mmap: Arc<Mmap>) -> Self {
+        Self { mmap, pos: 0 }
+    }
+}
+
+impl AsyncRead for MmapCursor {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        let data: &[u8] = &this.mmap;
+        // Clamp the position to the length; a position past EOF reads nothing,
+        // which drives `read_exact` to return `UnexpectedEof` just like a real
+        // file would. The block-header readers rely on this to detect EOF.
+        let pos = this.pos.min(data.len() as u64) as usize;
+        let remaining = &data[pos..];
+        let n = remaining.len().min(buf.remaining());
+        buf.put_slice(&remaining[..n]);
+        this.pos = pos as u64 + n as u64;
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl AsyncSeek for MmapCursor {
+    fn start_seek(self: Pin<&mut Self>, position: SeekFrom) -> io::Result<()> {
+        let this = self.get_mut();
+        let len = this.mmap.len() as u64;
+        let new_pos = match position {
+            SeekFrom::Start(offset) => offset,
+            SeekFrom::End(offset) => offset_from(len, offset)?,
+            SeekFrom::Current(offset) => offset_from(this.pos, offset)?,
+        };
+        this.pos = new_pos;
+        Ok(())
+    }
+
+    fn poll_complete(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<u64>> {
+        Poll::Ready(Ok(self.get_mut().pos))
+    }
+}
+
+/// Apply a signed offset to a base position, rejecting seeks before byte 0.
+///
+/// Seeking past the end is permitted (matching `std`/`tokio` `File` behaviour);
+/// subsequent reads simply return zero bytes.
+fn offset_from(base: u64, offset: i64) -> io::Result<u64> {
+    let result = if offset >= 0 {
+        base.saturating_add(offset as u64)
+    } else {
+        base.checked_sub(offset.unsigned_abs()).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "invalid seek to a negative position",
+            )
+        })?
+    };
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncSeekExt};
+
+    fn cursor(bytes: &[u8]) -> MmapCursor {
+        // Build an anonymous memory map and copy bytes into it so tests do not
+        // depend on touching the filesystem.
+        let mut mmap = memmap2::MmapMut::map_anon(bytes.len().max(1)).unwrap();
+        mmap[..bytes.len()].copy_from_slice(bytes);
+        let mmap = mmap.make_read_only().unwrap();
+        MmapCursor::new(Arc::new(mmap))
+    }
+
+    #[tokio::test]
+    async fn reads_sequentially() {
+        let mut c = cursor(b"hello world");
+        let mut buf = [0u8; 5];
+        c.read_exact(&mut buf).await.unwrap();
+        assert_eq!(&buf, b"hello");
+        assert_eq!(c.stream_position().await.unwrap(), 5);
+    }
+
+    #[tokio::test]
+    async fn seek_start_current_end() {
+        let mut c = cursor(b"0123456789");
+        c.seek(SeekFrom::Start(3)).await.unwrap();
+        let mut b = [0u8; 2];
+        c.read_exact(&mut b).await.unwrap();
+        assert_eq!(&b, b"34");
+
+        c.seek(SeekFrom::Current(2)).await.unwrap();
+        c.read_exact(&mut b).await.unwrap();
+        assert_eq!(&b, b"78");
+
+        // SeekFrom::End(0) should land at EOF and report total length.
+        let end = c.seek(SeekFrom::End(0)).await.unwrap();
+        assert_eq!(end, 10);
+    }
+
+    #[tokio::test]
+    async fn read_past_eof_is_unexpected_eof() {
+        let mut c = cursor(b"abc");
+        c.seek(SeekFrom::Start(2)).await.unwrap();
+        let mut b = [0u8; 8];
+        let err = c.read_exact(&mut b).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+    }
+
+    #[tokio::test]
+    async fn negative_seek_before_start_errors() {
+        let mut c = cursor(b"abc");
+        let err = c.seek(SeekFrom::Current(-5)).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[tokio::test]
+    async fn block_source_reports_backend() {
+        // Mapped variant reports as mmap-backed.
+        let mmap = memmap2::MmapMut::map_anon(8).unwrap();
+        let mmap = mmap.make_read_only().unwrap();
+        assert!(BlockSource::mapped(Arc::new(mmap)).is_mmap());
+
+        // Buffered variant does not.
+        let dir = std::env::temp_dir();
+        let path = dir.join("cqlite_blocksource_backend_test.bin");
+        tokio::fs::write(&path, b"buffered").await.unwrap();
+        let file = tokio::fs::File::open(&path).await.unwrap();
+        assert!(!BlockSource::buffered(file).is_mmap());
+        tokio::fs::remove_file(&path).await.ok();
+    }
+
+    #[tokio::test]
+    async fn partial_read_returns_available_bytes() {
+        let mut c = cursor(b"abcd");
+        c.seek(SeekFrom::Start(2)).await.unwrap();
+        let mut b = [0u8; 8];
+        // A single read() yields only the available bytes, not an error.
+        let n = c.read(&mut b).await.unwrap();
+        assert_eq!(n, 2);
+        assert_eq!(&b[..2], b"cd");
+    }
+}

--- a/cqlite-core/src/storage/sstable/reader/tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/tests.rs
@@ -551,4 +551,67 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_mmap_env_parsing() {
+        use super::super::parse_truthy_env;
+        for truthy in ["1", "true", "TRUE", "Yes", " on ", "On"] {
+            assert!(parse_truthy_env(truthy), "{truthy:?} should enable mmap");
+        }
+        for falsy in ["0", "false", "no", "off", "", "maybe", "2"] {
+            assert!(!parse_truthy_env(falsy), "{falsy:?} should not enable mmap");
+        }
+    }
+
+    /// End-to-end: the `use_mmap` storage config flag drives backend selection.
+    /// Defaults to buffered (opt-in); flipping the flag maps the file.
+    #[tokio::test]
+    async fn test_config_drives_mmap_backend() -> crate::Result<()> {
+        use super::super::SSTableReader;
+        use crate::{Config, Platform};
+        use std::path::Path;
+        use std::sync::Arc;
+
+        let test_dir = match std::env::var("CQLITE_DATASETS_ROOT") {
+            Ok(root) => Path::new(&root)
+                .join("sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9"),
+            Err(_) => {
+                eprintln!("CQLITE_DATASETS_ROOT not set, skipping test");
+                return Ok(());
+            }
+        };
+        let data_file = test_dir.join("nb-1-big-Data.db");
+        if !data_file.exists() {
+            eprintln!("Test data file not found at {:?}, skipping test", data_file);
+            return Ok(());
+        }
+
+        let mut config = Config::default();
+        let platform = Arc::new(Platform::new(&config).await?);
+
+        // Default config: buffered backend (mmap is opt-in).
+        let reader = SSTableReader::open(&data_file, &config, platform.clone()).await?;
+        assert!(
+            !reader.is_mmap_backed().await,
+            "default config must use buffered I/O, not mmap"
+        );
+
+        // Opt in via config: file (>4096 bytes) is now mapped.
+        config.storage.use_mmap = true;
+        let mapped = SSTableReader::open(&data_file, &config, platform.clone()).await?;
+        assert!(
+            mapped.is_mmap_backed().await,
+            "use_mmap=true must select the mmap backend for a >4KiB file"
+        );
+
+        // A min-size threshold above the file size forces buffered even when on.
+        config.storage.mmap_min_size_bytes = usize::MAX;
+        let buffered = SSTableReader::open(&data_file, &config, platform.clone()).await?;
+        assert!(
+            !buffered.is_mmap_backed().await,
+            "files below mmap_min_size_bytes must stay buffered"
+        );
+
+        Ok(())
+    }
 }

--- a/cqlite-core/src/storage/sstable/reader/types.rs
+++ b/cqlite-core/src/storage/sstable/reader/types.rs
@@ -4,9 +4,9 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, AtomicUsize};
 use std::sync::Arc;
-use tokio::fs::File;
-use tokio::io::BufReader;
 use tokio::sync::Mutex;
+
+use super::source::BlockSource;
 
 use crate::{
     parser::SSTableHeader,
@@ -130,8 +130,19 @@ impl Default for SSTableReaderStats {
 pub struct SSTableReaderConfig {
     /// Size of the read buffer in bytes
     pub read_buffer_size: usize,
-    /// Whether to use memory-mapped files
+    /// Whether to memory-map SSTable files instead of using buffered file I/O.
+    ///
+    /// When enabled, files at or above [`Self::mmap_min_size_bytes`] are mapped
+    /// into the address space and served from the OS page cache with no
+    /// per-block read syscall. This mirrors Cassandra's default read path and
+    /// benefits repeated local scans of the same files.
     pub use_mmap: bool,
+    /// Minimum file size (bytes) for memory mapping to kick in.
+    ///
+    /// Files smaller than this use buffered I/O even when [`Self::use_mmap`] is
+    /// set, since the per-file mapping overhead is not worthwhile for tiny
+    /// files and mapping a zero-length file is invalid.
+    pub mmap_min_size_bytes: usize,
     /// Maximum number of blocks to cache
     pub block_cache_size: usize,
     /// Whether to validate checksums
@@ -146,7 +157,8 @@ impl Default for SSTableReaderConfig {
     fn default() -> Self {
         Self {
             read_buffer_size: 64 * 1024, // 64KB
-            use_mmap: false,             // Safer default for cross-platform
+            use_mmap: true,              // Memory-map by default (Cassandra-style read path)
+            mmap_min_size_bytes: 4096,   // Skip mmap for files smaller than a page
             block_cache_size: 1000,      // Cache 1000 blocks
             validate_checksums: true,
             use_bloom_filter: true,
@@ -192,8 +204,8 @@ pub struct CachedBlock {
 pub struct SSTableReader {
     /// Path to the SSTable file
     pub(crate) file_path: PathBuf,
-    /// File handle for reading
-    pub(crate) file: Arc<Mutex<BufReader<File>>>,
+    /// Backing byte source for reading (buffered file I/O or memory map)
+    pub(crate) file: Arc<Mutex<BlockSource>>,
     /// SSTable header information
     pub(crate) header: SSTableHeader,
     /// Parser for SSTable format

--- a/cqlite-core/src/storage/sstable/reader/types.rs
+++ b/cqlite-core/src/storage/sstable/reader/types.rs
@@ -132,10 +132,13 @@ pub struct SSTableReaderConfig {
     pub read_buffer_size: usize,
     /// Whether to memory-map SSTable files instead of using buffered file I/O.
     ///
-    /// When enabled, files at or above [`Self::mmap_min_size_bytes`] are mapped
-    /// into the address space and served from the OS page cache with no
-    /// per-block read syscall. This mirrors Cassandra's default read path and
-    /// benefits repeated local scans of the same files.
+    /// **Opt-in; defaults to `false`.** When enabled, files at or above
+    /// [`Self::mmap_min_size_bytes`] are mapped into the address space and
+    /// served from the OS page cache with no per-block read syscall. This
+    /// mirrors Cassandra's `disk_access_mode: mmap` and benefits repeated local
+    /// scans of the same files. Enable only for immutable local SSTables — see
+    /// [`crate::Config`]'s `storage.use_mmap` for the platform/filesystem
+    /// constraints (network FS and external mutation can `SIGBUS`).
     pub use_mmap: bool,
     /// Minimum file size (bytes) for memory mapping to kick in.
     ///
@@ -157,7 +160,7 @@ impl Default for SSTableReaderConfig {
     fn default() -> Self {
         Self {
             read_buffer_size: 64 * 1024, // 64KB
-            use_mmap: true,              // Memory-map by default (Cassandra-style read path)
+            use_mmap: false,             // Opt-in; buffered I/O is the portable, safe default
             mmap_min_size_bytes: 4096,   // Skip mmap for files smaller than a page
             block_cache_size: 1000,      // Cache 1000 blocks
             validate_checksums: true,


### PR DESCRIPTION
## Summary

Makes memory-mapped I/O **real** on the live SSTable read path, but ships it **opt-in with buffered I/O as the default** in response to an I/O-strategy eval (see "Eval response" below). Previously the `use_mmap` flag existed but did nothing on the path every query takes.

## Eval response (what changed since the first revision)

An independent review flagged two merge blockers in the original "mmap by default" revision. This revision addresses them:

| Eval finding | Sev | Resolution |
|---|---|---|
| `open()` ignored its `&Config` and forced `SSTableReaderConfig::default()` (mmap on), with no public opt-out | **High / Blocker** | `open()` now honors `config.storage.use_mmap` (new public field, **default `false`**) plus a `CQLITE_USE_MMAP` env override. Buffered is the default everywhere. |
| Fallback only caught initial `map_file()` failure; a later in-page fault (truncation, network/overlay FS) raises `SIGBUS` and can terminate the process | **High / Blocker** | mmap is now opt-in and off by default, so default users have zero SIGBUS exposure. The residual risk for opt-in users is documented as an explicit platform/FS constraint on `Config.storage.use_mmap` and `map_file()`. Enforcement tracked in #591. |
| `MmapCursor::poll_read` clamped a seek-past-EOF cursor back to EOF; a real `File` preserves the past-EOF position | **Medium** | Fixed: a zero-byte read past EOF now leaves the cursor untouched, byte-for-byte matching `tokio::File`. Verified by a direct File cross-check test. |
| Tests didn't cover fallback, multipage maps, seek-past-EOF parity, config wiring | **Low** | Added: seek-past-EOF parity (+ real-File cross-check), multipage read across the page boundary, env-string parsing, and an end-to-end `test_config_drives_mmap_backend` (default→buffered, opt-in→mapped, threshold→buffered). |

**Release posture:** buffered stays the default (safe for a patch / v0.10.1). mmap is available as opt-in and can become a documented minor-release feature once the #591 write-while-mapped/Windows policy lands.

## Why mmap at all (and why not direct I/O)

`O_DIRECT` was the original ask but is the wrong fit: it bypasses the page cache (this is a read-mostly, re-read-the-same-files workload), needs a deep async queue we don't have, requires block-aligned arbitrary-offset reads, and is Linux-only across a 5-platform wheel matrix. Cassandra itself reads via mmap (`disk_access_mode: mmap`), not `O_DIRECT`. mmap's win: zero per-block `read` syscalls, no extra copy through a buffered reader, shared page cache across queries — but only when the files are immutable local files, hence opt-in.

## Architecture

A `BlockSource` abstraction (`reader/source.rs`) backs the reader, with two interchangeable backends, both `tokio::io::AsyncRead + AsyncSeek`:

| Variant | Backing | Use |
|---------|---------|-----|
| `BlockSource::Buffered` | `BufReader<File>` | **Default.** Portable; small/empty files; map failures |
| `BlockSource::Mapped` | read-only `memmap2::Mmap` cursor | Opt-in, for files ≥ `mmap_min_size_bytes` |

Because `BlockSource` exposes the same async read/seek surface as the old `BufReader<File>`, every call site (`block_io`, `component_loading`, `data_access`, `parsing`, `integrity`) works unchanged.

Backend selection in `open()`:

```rust
let mut reader_config = SSTableReaderConfig::default();        // use_mmap: false
reader_config.use_mmap = config.storage.use_mmap || mmap_enabled_via_env();
reader_config.mmap_min_size_bytes = config.storage.mmap_min_size_bytes;
let use_mmap = reader_config.use_mmap
    && file_size > 0
    && file_size >= reader_config.mmap_min_size_bytes as u64;
```

Zero-length files always use buffered I/O. Map failure degrades gracefully to buffered with a warning.

### Opt-in surface

- `Config.storage.use_mmap: bool` (default `false`) + `Config.storage.mmap_min_size_bytes` (default 4096) — public, documented with safety constraints
- `CQLITE_USE_MMAP=1` env override (honored by CLI and bindings, since all go through `open()`)

### Files

- **new** `reader/source.rs` — `BlockSource`, `MmapCursor`, `AsyncRead`/`AsyncSeek` impls, seek-past-EOF parity fix, tests
- `reader/mod.rs` — config/env-driven backend selection in `open()`, `mmap_enabled_via_env()`/`parse_truthy_env()`, `map_file()` with SIGBUS/FS safety notes, `cfg(test)` backend accessor
- `reader/types.rs` — `use_mmap` default flipped `true → false`, doc updated
- `reader/tests.rs` — env-parse + end-to-end backend-selection tests
- `config.rs` — public `StorageConfig.use_mmap` / `mmap_min_size_bytes` with constraint docs

## Safety note for reviewers

`MmapOptions::map()` is `unsafe`: the mapping aliases the file's bytes for the reader's lifetime, and external mutation while mapped is UB. Only the initial map is fallible — a later page fault raises `SIGBUS` and cannot be turned into an `io::Error`. This is why mmap is opt-in and gated on immutable local files, documented at both `Config.storage.use_mmap` and `map_file()`. Enforcing the invariant against the write path / compaction / Windows delete is tracked in #591.

## Validation

- ✅ Build clean; `clippy -D warnings --all-targets --all-features` clean; `cargo fmt --check` clean
- ✅ 235 reader + 13 config + 9 `source` unit tests pass
- ✅ `smoke-test-all-tables.sh`: **33/33** on the default buffered path **and** 33/33 with `CQLITE_USE_MMAP=1` (byte-identical results both ways)

## Follow-up issues

- #590 — delete the 3 dead mmap readers (cleanup, Low)
- #591 — write-while-mapped guard + Windows delete/replace policy (High/P1)
- #592 — `block_io` position-to-EOF single-`Vec` allocation vs <128MB target (Medium, pre-existing)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EfxyApccnj8t5in2DSAo9G)_
