### PR TITLE
fix(compaction): make async-to-sync bridge safe inside a runtime (#587)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Compaction panicked when triggered from an async context** (Issue #587) —
+  a high-severity panic shipped in v0.10.0. `WriteEngine::maintenance_step()` is
+  synchronous but bridges to async I/O to read a merge's input SSTables. The
+  bridge used `tokio::runtime::Handle::current().block_on(future)` whenever a
+  runtime was already running on the calling thread, which panics with *"Cannot
+  start a runtime from within a runtime"*. Because the bridge is only reached once
+  a merge has input SSTables to read, STCS compaction worked in isolation but was
+  **unreachable from any `#[tokio::main]`/async caller** — including the CLI's
+  `maintenance` and `export-sstable --compact` subcommands (both run under
+  `#[tokio::main]`).
+
+  Fix: the shared async-to-sync bridge (`merge::block_on_async`, now also used by
+  `flush_internal` and `finalize_merge_blocking`) detects an already-running
+  runtime and offloads the future to a dedicated scoped thread with its own
+  runtime, joining before returning. This is runtime-flavor-agnostic (works for
+  both multi-thread and current-thread runtimes, unlike `block_in_place`) and
+  preserves the synchronous public signature of `maintenance_step` that the CLI
+  and Python bindings depend on. The Node binding already wrapped the call in
+  `spawn_blocking` and was unaffected; the Python binding calls from outside any
+  runtime and was likewise unaffected. Regression coverage drives
+  `maintenance_step()` from inside both runtime flavors
+  (`cqlite-core/tests/issue_587_compaction_async_bridge.rs`).
+
 - **Partition-key column dropped / `WHERE` on TEXT PK returned 0 rows** (Issue #586) —
   a correctness regression shipped in v0.10.0. On the scan + residual-filter path
   (used for `WHERE` on a TEXT partition key, unlike the Index.db point-lookup path

--- a/cqlite-core/src/storage/write_engine/merge.rs
+++ b/cqlite-core/src/storage/write_engine/merge.rs
@@ -377,19 +377,61 @@ pub trait SSTableRowIterator: Send {
     fn next(&mut self) -> Option<Result<MergeEntry>>;
 }
 
-/// Adapter that wraps async SSTableReader into sync SSTableRowIterator
+/// Run an async future to completion from a synchronous context, safely whether
+/// or not a Tokio runtime is already running on the current thread.
 ///
-/// Run an async future synchronously, reusing the current tokio runtime if available.
+/// This is the shared async-to-sync bridge for the write engine's blocking
+/// helpers: [`SSTableRowIteratorAdapter`] (the k-way merge readers),
+/// `WriteEngine::flush_internal`, and `WriteEngine::finalize_merge_blocking`.
 ///
-/// This is the standard async-to-sync bridge pattern used throughout the write engine
-/// (flush_internal, finalize_merge_blocking, SSTableRowIteratorAdapter).
+/// ## Why not `Handle::block_on`?
+///
+/// When this bridge is reached from a thread that is already driving a Tokio
+/// runtime — anything under `#[tokio::main]` or `#[tokio::test]`, which is how
+/// the CLI (`maintenance`, `export-sstable --compact`) and any async caller
+/// reach compaction — `Handle::current().block_on()` panics with *"Cannot start
+/// a runtime from within a runtime"* (Issue #587). Compaction only reaches the
+/// bridge once a merge has input SSTables to read, which is why STCS worked in
+/// isolation but blew up from async callers.
+///
+/// `tokio::task::block_in_place` is not a general fix either: it panics on a
+/// current-thread runtime (e.g. the default `#[tokio::test]` flavor).
+///
+/// ## Strategy
+///
+/// - **No runtime on the current thread** (`Handle::try_current()` is `Err`):
+///   create a temporary runtime and block on it directly.
+/// - **Already inside a runtime** (`Ok`): hand the future to a dedicated scoped
+///   thread that owns a fresh runtime, then join it. That thread is free to
+///   block because it is not driving the caller's runtime, so this works for
+///   both the multi-thread and current-thread runtime flavors.
+///   [`std::thread::scope`] (rather than [`std::thread::spawn`]) lets the future
+///   borrow from the caller's stack — `flush_internal`/`finalize_merge_blocking`
+///   pass futures that borrow `&mut self` — so it need not be `'static`.
+///
+/// The future and its output must be `Send` because they cross a thread boundary
+/// in the in-runtime case.
 #[cfg(feature = "write-support")]
-fn block_on_async<F, T>(future: F) -> Result<T>
+pub(crate) fn block_on_async<F, T>(future: F) -> Result<T>
 where
-    F: std::future::Future<Output = Result<T>>,
+    F: std::future::Future<Output = Result<T>> + Send,
+    T: Send,
 {
     match tokio::runtime::Handle::try_current() {
-        Ok(handle) => handle.block_on(future),
+        // Already inside a runtime: a nested `block_on` on this thread would
+        // panic. Run the future on a scoped thread with its own runtime instead.
+        Ok(_) => std::thread::scope(|scope| {
+            scope
+                .spawn(|| {
+                    let rt = tokio::runtime::Runtime::new().map_err(|e| {
+                        Error::Storage(format!("Failed to create tokio runtime: {}", e))
+                    })?;
+                    rt.block_on(future)
+                })
+                .join()
+                .map_err(|_| Error::Storage("async-to-sync bridge thread panicked".to_string()))?
+        }),
+        // No runtime on this thread: safe to create one and block directly.
         Err(_) => {
             let rt = tokio::runtime::Runtime::new()
                 .map_err(|e| Error::Storage(format!("Failed to create tokio runtime: {}", e)))?;

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -691,22 +691,13 @@ impl WriteEngine {
         self.flush_internal_async().await
     }
 
-    /// Internal synchronous flush helper
+    /// Internal synchronous flush helper.
+    ///
+    /// Bridges to the async flush via [`merge::block_on_async`], which is safe to
+    /// call whether or not a Tokio runtime is already running on this thread
+    /// (Issue #587).
     fn flush_internal(&mut self) -> Result<()> {
-        // Try to use existing runtime, or create a new one if none exists
-        match tokio::runtime::Handle::try_current() {
-            Ok(handle) => {
-                // We're inside a runtime, use it
-                handle.block_on(self.flush_internal_async())?;
-            }
-            Err(_) => {
-                // No runtime, create one
-                let rt = tokio::runtime::Runtime::new().map_err(|e| {
-                    Error::Storage(format!("Failed to create tokio runtime: {}", e))
-                })?;
-                rt.block_on(self.flush_internal_async())?;
-            }
-        }
+        merge::block_on_async(self.flush_internal_async())?;
         Ok(())
     }
 
@@ -939,6 +930,18 @@ impl WriteEngine {
     /// This method performs background compaction work within a time budget.
     /// It can be called repeatedly from a background thread or task scheduler
     /// to make incremental progress on compaction.
+    ///
+    /// ## Runtime contexts
+    ///
+    /// This is a synchronous method, but its internal async-to-sync bridge is
+    /// runtime-aware (see [`merge::block_on_async`]), so it is safe to call from
+    /// **either** a plain synchronous context **or** from within an active Tokio
+    /// runtime — including `#[tokio::main]`/`#[tokio::test]` worker threads and
+    /// `async fn` callers. Prior to Issue #587 calling it from inside a runtime
+    /// panicked with "Cannot start a runtime from within a runtime" once a merge
+    /// had input SSTables to read. The sync signature is preserved so the CLI and
+    /// Python bindings can keep calling it directly. (The Node binding wraps it in
+    /// `spawn_blocking`, which remains correct.)
     ///
     /// ## Behavior
     ///
@@ -1299,22 +1302,15 @@ impl WriteEngine {
         Ok(())
     }
 
-    /// Finalize the active merge - blocking version (M5.2 helper)
+    /// Finalize the active merge - blocking version (M5.2 helper).
+    ///
+    /// Bridges to the async finalizer via [`merge::block_on_async`], which is
+    /// safe to call from within an active Tokio runtime (e.g. the CLI's
+    /// `#[tokio::main]` worker threads). A nested `Handle::block_on` here would
+    /// otherwise panic with "Cannot start a runtime from within a runtime"
+    /// (Issue #587).
     fn finalize_merge_blocking(&mut self, report: &mut MaintenanceReport) -> Result<()> {
-        // Use existing runtime or create new one
-        match tokio::runtime::Handle::try_current() {
-            Ok(handle) => {
-                // We're inside a runtime, use it
-                handle.block_on(self.finalize_merge_async(report))
-            }
-            Err(_) => {
-                // No runtime, create one
-                let rt = tokio::runtime::Runtime::new().map_err(|e| {
-                    Error::Storage(format!("Failed to create tokio runtime: {}", e))
-                })?;
-                rt.block_on(self.finalize_merge_async(report))
-            }
-        }
+        merge::block_on_async(self.finalize_merge_async(report))
     }
 
     /// Finalize the active merge - async version (M5.2 helper, Issue #474)

--- a/cqlite-core/tests/compaction_integration.rs
+++ b/cqlite-core/tests/compaction_integration.rs
@@ -36,11 +36,16 @@
 //!
 //! ## Runtime design
 //!
-//! `maintenance_step()` uses an internal `block_on` call (synchronous compaction),
-//! which cannot be invoked from within an active tokio runtime.  The tests are
-//! therefore plain `#[test]` functions that drive all async operations through an
-//! explicit single-threaded `Runtime::block_on` call — the same pattern used by the
-//! existing unit tests in `storage/write_engine/mod.rs`.
+//! `maintenance_step()` uses an internal `block_on` call (synchronous compaction).
+//! These tests are plain `#[test]` functions that drive all async operations
+//! through an explicit single-threaded `Runtime::block_on` call — the same
+//! pattern used by the existing unit tests in `storage/write_engine/mod.rs`.
+//!
+//! NOTE (Issue #587): `maintenance_step()` is now also safe to call from *within*
+//! an active tokio runtime — the async-to-sync bridge offloads to a scoped thread
+//! when a runtime is already running. The async-context regression coverage lives
+//! in `issue_587_compaction_async_bridge.rs`; these tests intentionally keep the
+//! plain-`#[test]` form to also exercise the no-runtime bridge path.
 
 #![cfg(feature = "write-support")]
 
@@ -346,11 +351,12 @@ fn write_three_sstables_and_compact(
 ///   - `maintenance_stats` shows compactions_completed >= 1, sstables_merged_in == 3,
 ///     sstables_produced == 1
 ///
-/// This is a synchronous `#[test]` because `maintenance_step()` calls
-/// `block_on()` internally and cannot be invoked from within an active tokio
-/// runtime.  Async operations are driven via an explicit `Runtime::block_on`
-/// call — the same approach used by the existing compaction unit tests in
-/// `storage/write_engine/mod.rs`.
+/// This is a synchronous `#[test]` that drives `maintenance_step()` with no
+/// surrounding runtime, exercising the bridge's no-runtime path. (Since Issue
+/// #587 it is also safe to call from within an active runtime — see
+/// `issue_587_compaction_async_bridge.rs`.) Async operations are driven via an
+/// explicit `Runtime::block_on` call — the same approach used by the existing
+/// compaction unit tests in `storage/write_engine/mod.rs`.
 #[test]
 fn compaction_3_sstables_mechanics() {
     let rt = tokio::runtime::Builder::new_current_thread()

--- a/cqlite-core/tests/issue_587_compaction_async_bridge.rs
+++ b/cqlite-core/tests/issue_587_compaction_async_bridge.rs
@@ -1,0 +1,274 @@
+//! Regression test for Issue #587 — compaction async-to-sync bridge panic.
+//!
+//! `WriteEngine::maintenance_step()` is synchronous but bridges to async I/O to
+//! read the input SSTables of a merge (`merge::block_on_async`, reached via
+//! `KWayMerger::new` → `SSTableRowIteratorAdapter::open`, and again in
+//! `finalize_merge_blocking`). The pre-fix bridge called
+//! `tokio::runtime::Handle::current().block_on(future)` whenever a runtime was
+//! already running on the thread, which panics with
+//! *"Cannot start a runtime from within a runtime"*.
+//!
+//! Because the bridge is only reached once a merge has input SSTables to read,
+//! STCS compaction worked in isolation (plain `#[test]`) but was **unreachable
+//! from any `#[tokio::main]`/async caller** — exactly how the CLI (`maintenance`,
+//! `export-sstable --compact`, both under `#[tokio::main]`) invokes it.
+//!
+//! These tests drive `maintenance_step()` **from inside a Tokio runtime** (the
+//! real entry-point condition the CLI hits). They reproduce the panic before the
+//! fix and assert correct compaction (N SSTables → 1, correct row count) after.
+//!
+//! - [`maintenance_step_from_multi_thread_runtime`] mirrors the CLI's default
+//!   `#[tokio::main]` multi-thread runtime.
+//! - [`maintenance_step_from_current_thread_runtime`] covers the current-thread
+//!   flavor (the default `#[tokio::test]` flavor), which `block_in_place` cannot
+//!   support — proving the scoped-thread bridge is runtime-flavor-agnostic.
+
+#![cfg(feature = "write-support")]
+
+use cqlite_core::platform::Platform;
+use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+use cqlite_core::storage::sstable::SSTableManager;
+use cqlite_core::storage::write_engine::{
+    CellOperation, Mutation, PartitionKey, STCSPolicy, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::TableId as CqlTableId;
+use cqlite_core::types::Value;
+use cqlite_core::Config;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+use tempfile::TempDir;
+
+const KEYSPACE: &str = "issue587_ks";
+const TABLE: &str = "items";
+
+/// 4 SSTables × 10 disjoint partition keys each = 40 rows total.
+const SSTABLE_COUNT: i32 = 4;
+const ROWS_PER_SSTABLE: i32 = 10;
+const EXPECTED_ROWS: usize = (SSTABLE_COUNT * ROWS_PER_SSTABLE) as usize;
+
+fn make_schema() -> TableSchema {
+    TableSchema {
+        keyspace: KEYSPACE.to_string(),
+        table: TABLE.to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            Column {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "name".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "score".to_string(),
+                data_type: "int".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+    }
+}
+
+fn write_row(id: i32, name: &str, score: i32, timestamp: i64) -> Mutation {
+    let table_id = TableId::new(KEYSPACE, TABLE);
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    let ops = vec![
+        CellOperation::Write {
+            column: "name".to_string(),
+            value: Value::Text(name.to_string()),
+        },
+        CellOperation::Write {
+            column: "score".to_string(),
+            value: Value::Integer(score),
+        },
+    ];
+    Mutation::new(table_id, pk, None, ops, timestamp, None)
+}
+
+/// STCS policy that compacts groups of >= `SSTABLE_COUNT` SSTables.
+/// `min_sstable_size = 0` buckets the tiny test files together.
+fn make_policy() -> STCSPolicy {
+    STCSPolicy::new(
+        SSTABLE_COUNT as usize, // min_threshold — compact once all N exist
+        32,                     // max_threshold
+        0.5,                    // bucket_low
+        1.5,                    // bucket_high
+        0,                      // min_sstable_size — zero so small files group together
+    )
+    .expect("valid STCS parameters")
+}
+
+fn count_data_files(dir: &std::path::Path) -> usize {
+    std::fs::read_dir(dir)
+        .expect("read sstable dir")
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_name().to_string_lossy().ends_with("-big-Data.db"))
+        .count()
+}
+
+/// The shared scenario, executed from within an active Tokio runtime.
+///
+/// Writes `SSTABLE_COUNT` SSTables with disjoint partition keys, then runs
+/// `maintenance_step()` (the **synchronous** API) directly from this async
+/// context. Pre-fix this panics; post-fix it compacts N SSTables → 1 and the
+/// merged output reads back all `EXPECTED_ROWS` rows.
+async fn run_compaction_from_async_context() {
+    let temp_dir = TempDir::new().unwrap();
+    let data_dir = temp_dir.path().join("data");
+    let wal_dir = temp_dir.path().join("wal");
+    let schema = make_schema();
+
+    // ── Phase 1: write N SSTables, each with disjoint partition keys ──────────
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir.clone(), schema.clone());
+    let mut engine = WriteEngine::new(config).expect("engine creation");
+
+    for table_idx in 0..SSTABLE_COUNT {
+        let base = table_idx * ROWS_PER_SSTABLE + 1;
+        for id in base..base + ROWS_PER_SSTABLE {
+            let ts = 100 + (id as i64);
+            engine
+                .write(write_row(id, &format!("name-{id}"), id * 10, ts))
+                .expect("write row");
+        }
+        // flush() is async — awaiting it here is fine; the bug is in the *sync*
+        // maintenance_step bridge, not flush from an async context.
+        let info = engine
+            .flush()
+            .await
+            .expect("flush sstable")
+            .expect("non-empty sstable");
+        assert_eq!(
+            info.partition_count, ROWS_PER_SSTABLE as usize,
+            "each SSTable has {ROWS_PER_SSTABLE} partitions"
+        );
+    }
+
+    let sstable_dir = data_dir.join(KEYSPACE).join(TABLE);
+    assert_eq!(
+        count_data_files(&sstable_dir),
+        SSTABLE_COUNT as usize,
+        "expected {SSTABLE_COUNT} Data.db files before compaction"
+    );
+
+    // ── Phase 2: compaction via the SYNC maintenance_step from async context ──
+    engine
+        .set_merge_policy(Box::new(make_policy()))
+        .expect("set merge policy");
+
+    // This is the Issue #587 reproduction: a synchronous method whose internal
+    // async-to-sync bridge runs while a Tokio runtime is already active on this
+    // thread. Pre-fix, the first call that starts a real merge panics here with
+    // "Cannot start a runtime from within a runtime".
+    let budget = Duration::from_secs(30);
+    let mut compaction_completed = false;
+    for _ in 0..5 {
+        let report = engine
+            .maintenance_step(budget)
+            .expect("maintenance_step must not error");
+        if !report.completed_merges.is_empty() {
+            compaction_completed = true;
+            break;
+        }
+        if !report.pending_compaction {
+            break;
+        }
+    }
+    assert!(
+        compaction_completed,
+        "compaction must complete within 5 maintenance_step calls"
+    );
+
+    let stats = engine.maintenance_stats();
+    assert_eq!(
+        stats.compactions_completed, 1,
+        "exactly 1 compaction must have completed"
+    );
+    assert_eq!(
+        stats.sstables_merged_in, SSTABLE_COUNT as u64,
+        "all {SSTABLE_COUNT} input SSTables must have been consumed"
+    );
+    assert_eq!(
+        stats.sstables_produced, 1,
+        "exactly 1 output SSTable must have been produced"
+    );
+    assert_eq!(
+        count_data_files(&sstable_dir),
+        1,
+        "after compaction exactly 1 Data.db must exist (N → 1)"
+    );
+
+    engine.close().await.expect("close engine");
+
+    // ── Phase 3: read back the merged SSTable and assert the row count ────────
+    let cqlite_config = Config::default();
+    let platform = Arc::new(
+        Platform::new(&cqlite_config)
+            .await
+            .expect("platform creation"),
+    );
+    let manager = SSTableManager::new(
+        &data_dir,
+        &cqlite_config,
+        platform,
+        #[cfg(feature = "state_machine")]
+        None,
+    )
+    .await
+    .expect("SSTableManager must open the merged output");
+
+    let table_id = CqlTableId::from(format!("{KEYSPACE}.{TABLE}").as_str());
+    let results = manager
+        .scan(&table_id, None, None, None, Some(&schema))
+        .await
+        .expect("post-compaction scan must not error");
+
+    assert_eq!(
+        results.len(),
+        EXPECTED_ROWS,
+        "compacted output must contain all {EXPECTED_ROWS} disjoint rows (got {})",
+        results.len()
+    );
+
+    // Spot-check that every original partition key survived the merge.
+    let keys: std::collections::HashSet<Vec<u8>> = results.into_iter().map(|(k, _)| k.0).collect();
+    for id in 1..=(SSTABLE_COUNT * ROWS_PER_SSTABLE) {
+        let key: Vec<u8> = id.to_be_bytes().into();
+        assert!(
+            keys.contains(&key),
+            "partition key id={id} must survive compaction"
+        );
+    }
+
+    // temp_dir kept alive until here.
+    drop(temp_dir);
+}
+
+/// Multi-thread runtime — mirrors the CLI's default `#[tokio::main]`, which is
+/// how `maintenance` / `export-sstable --compact` reach `maintenance_step`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn maintenance_step_from_multi_thread_runtime() {
+    run_compaction_from_async_context().await;
+}
+
+/// Current-thread runtime — the default `#[tokio::test]` flavor. `block_in_place`
+/// would panic here; the scoped-thread bridge handles it, proving the fix is
+/// runtime-flavor-agnostic.
+#[tokio::test(flavor = "current_thread")]
+async fn maintenance_step_from_current_thread_runtime() {
+    run_compaction_from_async_context().await;
+}


### PR DESCRIPTION
## Summary

Fixes the high-severity panic in `WriteEngine::maintenance_step()` shipped in v0.10.0 (Issue #587).

`maintenance_step()` is **synchronous** but bridges to async I/O to read a merge's input SSTables. The shared bridge called `tokio::runtime::Handle::current().block_on(future)` whenever a runtime was already running on the calling thread, which panics with **"Cannot start a runtime from within a runtime"**. Because the bridge is only reached once a merge has input SSTables to read, STCS compaction worked in isolation but was **unreachable from any `#[tokio::main]`/async caller**.

## Diagnosis — which call sites actually panic (with evidence)

Establishing the real blast radius before fixing, so the test covers the real entry points:

| Call site | Verdict | Why |
|-----------|---------|-----|
| Core `maintenance_step` from any runtime thread | **PANICS** | `start_merge` → `KWayMerger::new` → `SSTableRowIteratorAdapter::open` → `block_on_async` → `handle.block_on()`. `finalize_merge_blocking` has the same bug in the same call. |
| CLI `maintenance` (`main.rs:890`) | **PANICS** | Runs under `#[tokio::main]` (multi-thread) on a worker thread. |
| CLI `export-sstable --compact` (`main.rs:931`) | **PANICS** | `async fn handle_export` awaited on the runtime; calls `maintenance_step` directly. |
| Node `maintenanceStep` (`database.rs:963`) | **SAFE** | Already wrapped in `tokio::task::spawn_blocking`; blocking-pool threads aren't driving the runtime, so `block_on` is permitted. |
| Python `maintenance_step` (`database.rs:456`) | **SAFE** | Called on the Python thread with no active runtime → `Handle::try_current()` is `Err` → takes the `Runtime::new()` branch. |

**Proof:** stashing the fix and running the new test against the original code panics in **both** runtime flavors at exactly `merge.rs:392` ("Cannot start a runtime from within a runtime"); with the fix both pass.

## Fix

One change in the shared bridge `merge::block_on_async`, now also used by `flush_internal` and `finalize_merge_blocking` (all three bridges fixed in one place):

- **No runtime on the thread** (`Err`): create a temporary runtime and block directly (unchanged behavior).
- **Already inside a runtime** (`Ok`): hand the future to a dedicated `std::thread::scope` thread that owns a fresh runtime, then join. That thread is free to block because it is not driving the caller's runtime.

`std::thread::scope` (not `std::thread::spawn`) lets the future borrow `&mut self` (needed by `flush_internal`/`finalize_merge_blocking`), so it need not be `'static`. The approach is **runtime-flavor-agnostic** — it works for both multi-thread and current-thread runtimes, unlike `tokio::task::block_in_place` which panics on a current-thread runtime. The synchronous public signature of `maintenance_step` is preserved (CLI/Python depend on it).

## Tests

`cqlite-core/tests/issue_587_compaction_async_bridge.rs`:
- Builds 4 SSTables with disjoint partition keys + an STCS policy, then calls `maintenance_step()` **from inside a Tokio runtime**.
- Asserts: no panic, compaction completes (4 SSTables → 1), correct stats, and 40 rows read back.
- Two flavors: `multi_thread` (mirrors the CLI's `#[tokio::main]`) and `current_thread` (proves flavor-agnosticism).
- Fails-before (panic) / passes-after, verified by stashing the fix.

## Docs

- `maintenance_step` rustdoc: now documents it is safe from async contexts.
- `block_on_async` rustdoc: documents the strategy and why not `block_in_place`.
- `compaction_integration.rs`: corrected stale comments that claimed the restriction.
- `CHANGELOG.md`: entry under Unreleased.

## Local gate

- `cargo fmt --all -- --check` ✓
- `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features` ✓
- `cargo test -p cqlite-core --features write-support` ✓
- `cargo test -p cqlite-integration-tests` ✓ (129 + others, 0 failed)

Closes #587
