### PR TITLE
fix(storage): mmap write-while-mapped guard + TOC-first delete policy (#591)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **mmap write-while-mapped guard + delete/publication policy** (Issue #591) —
+  hardens the opt-in memory-mapped read path (#589, default OFF) against the
+  compaction delete path. A memory map aliases a Data.db file's bytes for the
+  reader's lifetime; deleting or truncating a mapped file can fault with `SIGBUS`
+  on Unix or block deletion on Windows. The invariant is now enforced and tested:
+  1. Compaction reads its inputs through **buffered I/O**, never a memory map
+     (pinned explicitly in `KWayMerger`, independent of the global `use_mmap`
+     setting), and drains them into memory before any delete — so the merger
+     never holds a mapping over a file it removes.
+  2. SSTable deletion removes **`TOC.txt` first** (the publication barrier), then
+     the data components best-effort. The compaction candidate scan
+     (`scan_data_files`) now skips any Data.db lacking a sibling TOC.txt, matching
+     the read path. A component still pinned by a mapped reader on Windows
+     therefore becomes an invisible orphan (reclaimed by the startup sweep)
+     rather than a failed delete or a duplicate-row source.
+
+  Regression coverage: an end-to-end test opens the inputs through a mmap-enabled
+  `SSTableManager` and then compacts/deletes them
+  (`issue_591_mmap_compaction_delete.rs`), plus unit tests for TOC-first deletion
+  and the publication-barrier candidate scan. Constraints documented on
+  `StorageConfig::use_mmap` and the write engine.
+
 - **Compaction panicked when triggered from an async context** (Issue #587) —
   a high-severity panic shipped in v0.10.0. `WriteEngine::maintenance_step()` is
   synchronous but bridges to async I/O to read a merge's input SSTables. The

--- a/cqlite-core/src/config.rs
+++ b/cqlite-core/src/config.rs
@@ -74,6 +74,17 @@ pub struct StorageConfig {
     ///   overlays) can fault mid-read after a successful map; prefer buffered
     ///   I/O there.
     ///
+    /// # Interaction with the write engine (Issue #591)
+    ///
+    /// This setting only affects the read path. Compaction always reads its
+    /// input SSTables through buffered I/O regardless of `use_mmap`, and deletes
+    /// each input by removing its `TOC.txt` first (unpublishing it) before the
+    /// data components, best-effort. So enabling mmap for queries is safe
+    /// alongside background compaction: a compaction never holds a mapping over a
+    /// file it then deletes, and on Windows a data file still pinned by a mapped
+    /// reader becomes an invisible orphan (reclaimed on the next startup) rather
+    /// than a failed delete or a source of duplicate rows.
+    ///
     /// Can also be enabled at runtime by setting `CQLITE_USE_MMAP=1`.
     ///
     /// `#[serde(default)]` keeps configs serialized before this field existed

--- a/cqlite-core/src/storage/write_engine/merge.rs
+++ b/cqlite-core/src/storage/write_engine/merge.rs
@@ -466,7 +466,17 @@ impl SSTableRowIteratorAdapter {
         use crate::Config;
         use std::sync::Arc;
 
-        let config = Config::default();
+        let mut config = Config::default();
+        // Issue #591: compaction MUST read its inputs through buffered I/O, never
+        // a memory map. `finalize_merge_async` deletes these input files once the
+        // merged output is published; a live mmap over a file that is then
+        // truncated or removed can fault with SIGBUS on Unix (unrecoverable as an
+        // `io::Error`) and can block deletion on Windows. Reading buffered — and
+        // draining every entry into memory in this constructor, before finalize
+        // deletes the inputs — guarantees no mapping outlives the file. This is
+        // pinned explicitly rather than relying on the (currently `false`) global
+        // default so the invariant cannot silently regress.
+        config.storage.use_mmap = false;
         let path_buf = path.to_path_buf();
 
         // Open SSTable reader and load all partitions with actual row timestamps.

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -1210,7 +1210,25 @@ impl WriteEngine {
 
             // Only consider Data.db files
             if filename.starts_with("nb-") && filename.ends_with("-big-Data.db") {
-                candidates.push(path);
+                // Honor the TOC.txt publication barrier (Issue #591). A Data.db
+                // without a sibling TOC.txt is NOT a published SSTable: it is
+                // either a crash-interrupted partial rename or a deferred-delete
+                // orphan whose TOC was removed first while its data file stayed
+                // pinned by an open/mapped reader (Windows). Feeding such a file
+                // to the merger would re-compact an unpublished input and could
+                // produce garbled output, so it is skipped here just as the
+                // read path discovers SSTables by TOC.txt. The startup orphan
+                // sweep reclaims the leftover components.
+                let base = filename.trim_end_matches("-Data.db");
+                let toc_path = path.with_file_name(format!("{base}-TOC.txt"));
+                if toc_path.exists() {
+                    candidates.push(path);
+                } else {
+                    log::debug!(
+                        "scan_data_files: skipping unpublished SSTable (no TOC.txt): {:?}",
+                        path
+                    );
+                }
             } else if depth > 0 && path.is_dir() {
                 Self::scan_data_files(&path, candidates, depth - 1)?;
             }
@@ -1441,9 +1459,17 @@ impl WriteEngine {
         }
 
         // Step 3: All renames succeeded. The new SSTable is now visible.
-        // Delete input SSTable files. If deletion fails we log a warning but
-        // do NOT return an error — the merge output is correct, and the stale
-        // inputs will simply be re-evaluated by the merge policy on the next call.
+        // Delete input SSTable files. If deletion fails we log a warning but do
+        // NOT return an error — the merge output is correct.
+        //
+        // Issue #591 (write-while-mapped / Windows policy): the inputs were read
+        // through buffered I/O and fully drained into memory by `KWayMerger::new`
+        // before this point, so the merger holds no mapping over them — deleting
+        // them cannot fault with SIGBUS. `delete_sstable_files` removes each
+        // input's TOC.txt first (unpublishing it) and is best-effort on the data
+        // components, so a component still pinned by a concurrent mapped reader on
+        // Windows becomes an invisible orphan reclaimed on the next startup rather
+        // than a hard failure or a source of duplicate rows.
         for input_path in &merge.input_paths {
             if let Err(e) = self.delete_sstable_files(input_path) {
                 log::warn!(
@@ -1532,6 +1558,26 @@ impl WriteEngine {
     /// Static helper that deletes all component files for an SSTable given the
     /// Data.db path.  Called from both `delete_sstable_files` and the startup
     /// orphan sweep, which runs before `self` is fully constructed.
+    ///
+    /// ## Deferred-delete / Windows policy (Issue #591)
+    ///
+    /// `TOC.txt` is removed **first**. TOC.txt is the publication barrier — both
+    /// the read path (`SSTableManager`) and the compaction candidate scan
+    /// (`scan_data_files`, since #591) treat a Data.db without a sibling TOC.txt
+    /// as unpublished. Removing TOC.txt first therefore *unpublishes* the SSTable
+    /// atomically, before any data component is touched, so it can never be
+    /// observed (no duplicate rows, never re-fed to the merger) even if the
+    /// remaining components cannot be removed yet.
+    ///
+    /// The remaining components are then deleted **best-effort**: a failure on
+    /// any one of them (most plausibly a Windows sharing violation when a
+    /// concurrent reader still has the file open or memory-mapped) is logged but
+    /// does NOT abort the rest or fail the operation. Such a leftover is a
+    /// harmless orphan — invisible because its TOC.txt is gone — and is reclaimed
+    /// by [`Self::sweep_orphaned_partial_sstables`] on the next engine startup,
+    /// by which time the reader's handle has been released. This is the
+    /// "deferred delete" half of the policy; Unix removes the inode immediately
+    /// while any mapping keeps the bytes alive until it is dropped.
     fn delete_sstable_files_static(data_path: &Path) -> Result<()> {
         // Extract base path: nb-{gen}-big
         let filename = data_path
@@ -1543,18 +1589,6 @@ impl WriteEngine {
             .strip_suffix("-Data.db")
             .ok_or_else(|| Error::Storage("Invalid Data.db filename".to_string()))?;
 
-        // Component suffixes to delete
-        let components = [
-            "Data.db",
-            "Index.db",
-            "Summary.db",
-            "Statistics.db",
-            "CompressionInfo.db",
-            "Filter.db",
-            "Digest.crc32",
-            "TOC.txt",
-        ];
-
         let parent_dir = data_path.parent().ok_or_else(|| {
             Error::Storage(format!(
                 "Data.db path has no parent directory: {:?}",
@@ -1562,17 +1596,55 @@ impl WriteEngine {
             ))
         })?;
 
+        // TOC.txt FIRST — the publication barrier (Issue #591). Once it is gone
+        // the SSTable is unpublished regardless of whether the data components
+        // can be removed. Remaining components follow, best-effort.
+        let components = [
+            "TOC.txt",
+            "Data.db",
+            "Index.db",
+            "Summary.db",
+            "Statistics.db",
+            "CompressionInfo.db",
+            "Filter.db",
+            "Digest.crc32",
+        ];
+
+        let mut failures: Vec<String> = Vec::new();
         for component in &components {
             let component_path = parent_dir.join(format!("{}-{}", base, component));
             if component_path.exists() {
-                std::fs::remove_file(&component_path).map_err(|e| {
-                    Error::Storage(format!("Failed to delete {:?}: {}", component_path, e))
-                })?;
-                log::debug!("Deleted compaction input: {:?}", component_path);
+                match std::fs::remove_file(&component_path) {
+                    Ok(()) => log::debug!("Deleted compaction input: {:?}", component_path),
+                    Err(e) => {
+                        // Best-effort: do not abort. A leftover data component
+                        // whose TOC.txt is already gone is an invisible orphan
+                        // reclaimed by the startup sweep (Issue #591).
+                        log::warn!(
+                            "Deferred delete of {:?}: {} (component left as orphan; \
+                             unpublished via TOC.txt removal, reclaimed on next startup)",
+                            component_path,
+                            e
+                        );
+                        failures.push(format!("{:?}: {}", component_path, e));
+                    }
+                }
             }
         }
 
-        Ok(())
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            // Surface a non-fatal error so callers can log it. The SSTable is
+            // already unpublished (TOC.txt removed first), so callers treat this
+            // as a deferred reclamation, not a correctness failure.
+            Err(Error::Storage(format!(
+                "Deferred delete left {} orphaned component(s) (unpublished, reclaimed on \
+                 next startup): {}",
+                failures.len(),
+                failures.join("; ")
+            )))
+        }
     }
 
     /// Convert MergeEntry to Mutation (M5.2 helper)
@@ -2479,21 +2551,35 @@ mod tests {
 
         let engine = WriteEngine::new(config).unwrap();
 
-        // Create dummy SSTable files
+        // Create dummy SSTable files. Each Data.db needs a sibling TOC.txt to
+        // count as a *published* SSTable (the publication barrier, Issue #591) —
+        // a Data.db without TOC.txt is an unpublished partial/orphan and must be
+        // skipped by the candidate scan.
         let data_dir = temp_dir.path().join("data");
         std::fs::create_dir_all(&data_dir).unwrap();
         std::fs::write(data_dir.join("nb-1-big-Data.db"), b"").unwrap();
+        std::fs::write(data_dir.join("nb-1-big-TOC.txt"), b"").unwrap();
         std::fs::write(data_dir.join("nb-2-big-Data.db"), b"").unwrap();
+        std::fs::write(data_dir.join("nb-2-big-TOC.txt"), b"").unwrap();
         std::fs::write(data_dir.join("nb-3-big-Index.db"), b"").unwrap(); // Not a Data.db
         std::fs::write(data_dir.join("other-file.txt"), b"").unwrap(); // Not an SSTable
+                                                                       // An unpublished Data.db (no TOC.txt) must NOT be picked up (Issue #591).
+        std::fs::write(data_dir.join("nb-4-big-Data.db"), b"").unwrap();
 
         let candidates = engine.scan_sstable_candidates().unwrap();
 
-        // Should only find Data.db files
+        // Should only find the two PUBLISHED Data.db files (TOC.txt present);
+        // nb-4 is excluded because it has no TOC.txt.
         assert_eq!(candidates.len(), 2);
         assert!(candidates
             .iter()
             .all(|p| p.to_string_lossy().contains("Data.db")));
+        assert!(
+            !candidates
+                .iter()
+                .any(|p| p.to_string_lossy().contains("nb-4-big")),
+            "unpublished Data.db (no TOC.txt) must be excluded (Issue #591)"
+        );
     }
 
     #[test]
@@ -2537,6 +2623,58 @@ mod tests {
         for component in &components {
             assert!(!data_dir.join(component).exists());
         }
+    }
+
+    /// Issue #591: deletion removes TOC.txt FIRST so the SSTable is unpublished
+    /// before any data component is touched. This guarantees the read path and
+    /// the compaction candidate scan stop seeing it immediately, even if a data
+    /// component cannot be removed yet (e.g. pinned by a mapped reader on
+    /// Windows).
+    #[test]
+    fn test_delete_removes_toc_first_unpublishing_atomically() {
+        let temp_dir = TempDir::new().unwrap();
+        let data_dir = temp_dir.path().join("data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+
+        // A full published SSTable component set including TOC.txt.
+        for comp in &[
+            "nb-7-big-Data.db",
+            "nb-7-big-Index.db",
+            "nb-7-big-Statistics.db",
+            "nb-7-big-TOC.txt",
+        ] {
+            std::fs::write(data_dir.join(comp), b"x").unwrap();
+        }
+
+        let data_path = data_dir.join("nb-7-big-Data.db");
+        WriteEngine::delete_sstable_files_static(&data_path).unwrap();
+
+        // Everything gone on the happy path.
+        assert!(!data_dir.join("nb-7-big-TOC.txt").exists());
+        assert!(!data_path.exists());
+
+        // And critically: scan_data_files (the compaction candidate discovery)
+        // never surfaces a Data.db without a TOC.txt, so a deferred-delete orphan
+        // is not re-fed to the merger. Recreate a TOC-less leftover to prove it.
+        std::fs::write(data_dir.join("nb-8-big-Data.db"), b"x").unwrap();
+        let mut candidates = Vec::new();
+        WriteEngine::scan_data_files(&data_dir, &mut candidates, 1).unwrap();
+        assert!(
+            candidates.is_empty(),
+            "a Data.db without a sibling TOC.txt must NOT be a compaction candidate \
+             (publication barrier, Issue #591); got {:?}",
+            candidates
+        );
+
+        // Add the matching TOC.txt and it becomes a valid candidate again.
+        std::fs::write(data_dir.join("nb-8-big-TOC.txt"), b"x").unwrap();
+        let mut candidates = Vec::new();
+        WriteEngine::scan_data_files(&data_dir, &mut candidates, 1).unwrap();
+        assert_eq!(
+            candidates.len(),
+            1,
+            "a published Data.db (TOC.txt present) must be discovered"
+        );
     }
 
     // Mock merge policy that selects specific files for testing

--- a/cqlite-core/tests/issue_591_mmap_compaction_delete.rs
+++ b/cqlite-core/tests/issue_591_mmap_compaction_delete.rs
@@ -1,0 +1,231 @@
+//! Regression test for Issue #591 — mmap write-while-mapped guard + delete policy.
+//!
+//! The mmap read backend (opt-in, #589) aliases a Data.db file's bytes for the
+//! reader's lifetime. The SAFETY contract is that mapped files are immutable for
+//! that lifetime: truncating or deleting a mapped file out from under a live
+//! reader can fault with `SIGBUS` on Unix (unrecoverable as an `io::Error`) and
+//! can block deletion on Windows.
+//!
+//! Compaction deletes its input SSTables once the merged output is published, so
+//! the two paths must not collide. The invariant enforced by the fix:
+//!
+//! 1. Compaction reads its inputs through **buffered I/O**, never a memory map,
+//!    and drains every entry into memory before any delete — so the merger never
+//!    holds a mapping over a file it deletes (no SIGBUS).
+//! 2. Deletion removes `TOC.txt` **first** (the publication barrier), then the
+//!    data components best-effort. The compaction candidate scan skips any
+//!    Data.db lacking a sibling TOC.txt, so a not-yet-removable component (e.g.
+//!    pinned by a mapped reader on Windows) is an invisible orphan, never a
+//!    duplicate-row source and never re-fed to the merger.
+//!
+//! This test exercises the real cross-flow: a separate read-path
+//! [`SSTableManager`] opens the inputs **with mmap enabled** and scans them
+//! (mapping their Data.db files), and *then* the write engine compacts and
+//! deletes those same inputs. It must complete without a panic/SIGBUS and the
+//! merged output must read back correctly.
+
+#![cfg(feature = "write-support")]
+
+use cqlite_core::platform::Platform;
+use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+use cqlite_core::storage::sstable::SSTableManager;
+use cqlite_core::storage::write_engine::{
+    CellOperation, Mutation, PartitionKey, STCSPolicy, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::TableId as CqlTableId;
+use cqlite_core::types::Value;
+use cqlite_core::Config;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+use tempfile::TempDir;
+
+const KEYSPACE: &str = "issue591_ks";
+const TABLE: &str = "items";
+const SSTABLE_COUNT: i32 = 4;
+const ROWS_PER_SSTABLE: i32 = 10;
+const EXPECTED_ROWS: usize = (SSTABLE_COUNT * ROWS_PER_SSTABLE) as usize;
+
+fn make_schema() -> TableSchema {
+    TableSchema {
+        keyspace: KEYSPACE.to_string(),
+        table: TABLE.to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            Column {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "name".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+    }
+}
+
+fn write_row(id: i32, name: &str, timestamp: i64) -> Mutation {
+    let table_id = TableId::new(KEYSPACE, TABLE);
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    let ops = vec![CellOperation::Write {
+        column: "name".to_string(),
+        value: Value::Text(name.to_string()),
+    }];
+    Mutation::new(table_id, pk, None, ops, timestamp, None)
+}
+
+fn make_policy() -> STCSPolicy {
+    STCSPolicy::new(SSTABLE_COUNT as usize, 32, 0.5, 1.5, 0).expect("valid STCS parameters")
+}
+
+/// Config with mmap forced ON for every Data.db (min size 0), so the read path
+/// maps the compaction inputs.
+fn mmap_config() -> Config {
+    let mut cfg = Config::default();
+    cfg.storage.use_mmap = true;
+    cfg.storage.mmap_min_size_bytes = 0;
+    cfg
+}
+
+fn count_data_files(dir: &std::path::Path) -> usize {
+    std::fs::read_dir(dir)
+        .expect("read sstable dir")
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_name().to_string_lossy().ends_with("-big-Data.db"))
+        .count()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn compaction_deletes_inputs_held_by_a_mapped_reader() {
+    let temp_dir = TempDir::new().unwrap();
+    let data_dir = temp_dir.path().join("data");
+    let wal_dir = temp_dir.path().join("wal");
+    let schema = make_schema();
+
+    // ── Phase 1: write N published SSTables (each flush writes a TOC.txt) ──────
+    let cfg = WriteEngineConfig::new(data_dir.clone(), wal_dir.clone(), schema.clone());
+    let mut engine = WriteEngine::new(cfg).expect("engine creation");
+
+    for table_idx in 0..SSTABLE_COUNT {
+        let base = table_idx * ROWS_PER_SSTABLE + 1;
+        for id in base..base + ROWS_PER_SSTABLE {
+            engine
+                .write(write_row(id, &format!("name-{id}"), 100 + id as i64))
+                .expect("write row");
+        }
+        engine
+            .flush()
+            .await
+            .expect("flush")
+            .expect("non-empty sstable");
+    }
+
+    let sstable_dir = data_dir.join(KEYSPACE).join(TABLE);
+    assert_eq!(
+        count_data_files(&sstable_dir),
+        SSTABLE_COUNT as usize,
+        "expected {SSTABLE_COUNT} input Data.db files before compaction"
+    );
+
+    // ── Phase 2: open a read-path manager WITH mmap and scan, mapping the inputs.
+    // The manager is kept alive across the compaction below, so its memory maps
+    // over the input Data.db files are live while the write engine deletes them.
+    let read_cfg = mmap_config();
+    let platform = Arc::new(Platform::new(&read_cfg).await.expect("platform"));
+    let mapped_manager = SSTableManager::new(
+        &data_dir,
+        &read_cfg,
+        platform,
+        #[cfg(feature = "state_machine")]
+        None,
+    )
+    .await
+    .expect("open SSTableManager with mmap");
+
+    let table_id = CqlTableId::from(format!("{KEYSPACE}.{TABLE}").as_str());
+    let pre_rows = mapped_manager
+        .scan(&table_id, None, None, None, Some(&schema))
+        .await
+        .expect("pre-compaction scan (forces the input files to be mapped)");
+    assert_eq!(
+        pre_rows.len(),
+        EXPECTED_ROWS,
+        "the mapped reader should see all {EXPECTED_ROWS} rows across the inputs"
+    );
+
+    // ── Phase 3: compact the same inputs the mapped reader holds. This deletes
+    // files that Phase 2 mapped. With the fix it must NOT panic/SIGBUS and must
+    // collapse N inputs → 1 output.
+    engine
+        .set_merge_policy(Box::new(make_policy()))
+        .expect("set merge policy");
+
+    let budget = Duration::from_secs(30);
+    let mut completed = false;
+    for _ in 0..5 {
+        let report = engine
+            .maintenance_step(budget)
+            .expect("maintenance_step must not error or panic while inputs are mapped");
+        if !report.completed_merges.is_empty() {
+            completed = true;
+            break;
+        }
+        if !report.pending_compaction {
+            break;
+        }
+    }
+    assert!(completed, "compaction must complete");
+
+    let stats = engine.maintenance_stats();
+    assert_eq!(stats.sstables_merged_in, SSTABLE_COUNT as u64);
+    assert_eq!(stats.sstables_produced, 1);
+    assert_eq!(
+        count_data_files(&sstable_dir),
+        1,
+        "after compaction exactly 1 Data.db must exist (N → 1)"
+    );
+
+    // The mapped reader is still alive here; dropping it now releases the maps.
+    // On Unix the deleted inputs' inodes were kept alive by these maps with no
+    // ill effect; on Windows any input pinned by these maps would have been left
+    // as a TOC-less orphan (unpublished, reclaimed on next startup).
+    drop(mapped_manager);
+    engine.close().await.expect("close engine");
+
+    // ── Phase 4: a fresh mmap-enabled manager reads the merged output correctly.
+    let read_cfg2 = mmap_config();
+    let platform2 = Arc::new(Platform::new(&read_cfg2).await.expect("platform"));
+    let manager2 = SSTableManager::new(
+        &data_dir,
+        &read_cfg2,
+        platform2,
+        #[cfg(feature = "state_machine")]
+        None,
+    )
+    .await
+    .expect("reopen SSTableManager");
+
+    let post_rows = manager2
+        .scan(&table_id, None, None, None, Some(&schema))
+        .await
+        .expect("post-compaction scan");
+    assert_eq!(
+        post_rows.len(),
+        EXPECTED_ROWS,
+        "merged output must contain all {EXPECTED_ROWS} rows with no duplicates"
+    );
+
+    drop(temp_dir);
+}


### PR DESCRIPTION
## Summary

Hardens the opt-in memory-mapped read path (#589, default OFF) against the compaction delete path. Fixes the high-priority bug **#591**.

A memory map aliases a Data.db file's bytes for the reader's lifetime. Deleting or truncating a mapped file can fault with **SIGBUS** on Unix (unrecoverable as an `io::Error`, can terminate the process) or **block deletion** on Windows. Compaction deletes its input SSTables once the merged output is published, so the two paths must not collide.

## The invariant (now enforced + tested)

**1. Compaction never memory-maps its inputs.** `KWayMerger`'s reader pins `use_mmap = false` explicitly — independent of the global `StorageConfig::use_mmap` setting, so the invariant cannot silently regress — and drains every entry into memory before `finalize_merge_async` deletes the inputs. The merger therefore never holds a mapping over a file it removes → no SIGBUS.

**2. Deletion is TOC-first + deferred (Windows policy).** `delete_sstable_files_static` removes **`TOC.txt` first** (the publication barrier), then the data components **best-effort**:
- A component still pinned by a concurrent mapped reader on Windows is left as an *invisible orphan* (its TOC is already gone) and reclaimed by the existing startup sweep — instead of aborting the delete or leaving the input published as a duplicate-row source.
- `scan_data_files` (the compaction candidate discovery) now **skips any Data.db lacking a sibling `TOC.txt`**, matching the read path's publication barrier, so a deferred-delete orphan is never re-fed to the merger mid-session.

On Unix, deletion removes the inode immediately while any existing mapping keeps the bytes alive until dropped — harmless.

## Why this is safe for the happy path

`SSTableWriter` always writes a `TOC.txt`, so flushed/compacted SSTables are published and still discovered. The publication-barrier change only excludes genuinely unpublished files (crash-interrupted partial renames or deferred-delete orphans) — which the codebase already treated as garbage (startup orphan sweep).

## Diagnosis notes

The compaction read path already used `Config::default()` (mmap off), so no repo-owned Unix SIGBUS path existed in practice — but it was incidental, not enforced. The latent correctness bug was in deletion: the old loop deleted `Data.db` **first** with `?`, so a locked `Data.db` on Windows aborted before `TOC.txt` was removed, leaving the input fully published → **duplicate rows** on the next scan. TOC-first + best-effort fixes that.

## Tests (fail-meaningfully / pass)

- `cqlite-core/tests/issue_591_mmap_compaction_delete.rs` — opens the inputs through a **mmap-enabled `SSTableManager`**, scans them (mapping their Data.db), then compacts/deletes those same inputs. Asserts no panic/SIGBUS, N→1 compaction, and the merged output reads back with **no duplicates**.
- Unit tests: TOC-first deletion + the publication-barrier candidate scan (a TOC-less Data.db is excluded; adding the TOC makes it a candidate again).
- Updated `test_scan_sstable_candidates_with_sstables` to the new barrier semantics.

## Docs

Invariant + Windows policy documented on `StorageConfig::use_mmap`, `finalize_merge_async`, and `delete_sstable_files_static`. CHANGELOG entry added.

## Local gate (against `main`, version 0.10.0)

- `cargo fmt --all -- --check` ✓
- `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features` ✓
- `cargo test -p cqlite-core --features write-support` ✓ (0 failed)
- `cargo test -p cqlite-integration-tests` ✓ (one pre-existing parallelism flake — `test_golden_path_bloom_summary_index_coordination`, passes 3/3 in isolation and is unreachable from this write-support-gated change — green on re-run)

Closes #591
