### PR TITLE
docs(guide): fix Index/Summary and key-lookup flow vs cassandra-5.0.8 (#600)

### DIFF
--- a/docs/sstables-definitive-guide/chapters/06-index-and-summary.md
+++ b/docs/sstables-definitive-guide/chapters/06-index-and-summary.md
@@ -95,6 +95,26 @@ Promoted index payload (BIG):
   explicitly by `promoted_index_len`; when it is 0 the entry has no promoted index. See
   `org.apache.cassandra.io.sstable.format.big` reader/writer for the payload fields.
 
+> **Promoted index trigger (data-size based, not key-count based):** A new
+> `IndexInfo` block is emitted whenever the uncompressed data written for the current
+> partition since the last block boundary reaches `column_index_size` (default 64 KiB).
+> Source: [`BigFormatPartitionWriter.java:49`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigFormatPartitionWriter.java#L49)
+> (`DEFAULT_GRANULARITY = 64 * 1024`) and line 213 (`if (currentPosition() - startPosition >= indexSize)`).
+> A promoted index is only included when **two or more** `IndexInfo` blocks result
+> (`RowIndexEntry.create()` lines 227-239). Partitions smaller than 64 KiB produce a plain
+> `RowIndexEntry` with serialized size = 0 and no promoted index data.
+
+> **DeletionTime field order ("oa" vs legacy, MC-4):** For SSTable version "oa" (5.0+),
+> `DeletionTime` inside a promoted index is serialized as:
+> - LIVE: 1 byte `0x80` (high bit set)
+> - Non-LIVE: 8 bytes `markedForDeleteAt` (sign bit must be 0, high bit used as flags), then
+>   4 bytes `localDeletionTime` as unsigned int
+>
+> For legacy versions (< "oa") the `LegacySerializer` writes `localDeletionTime` (4 bytes,
+> signed int) **first**, then `markedForDeleteAt` (8 bytes). Gate on
+> `version.hasUintDeletionTime` (`BigFormat.java:409`).
+> Source: [`DeletionTime.java#L210-L219`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/DeletionTime.java#L210)
+
 Mini-parser — conceptual:
 ```text
 pos = 0
@@ -204,7 +224,11 @@ First and last keys are serialized at the end of the file for quick boundary loo
 Note: Token-based iteration is not directly supported by Summary.db since tokens are not stored. Token iteration must compute tokens from partition keys.
 
 ### BTI Notes
-- BTI’s indexing can alter how promoted index information is structured; the high-level flow (Summary → Index → Data) remains intact, but entry payloads differ. Ensure readers gate parsing on `Descriptor` format.
+- BTI SSTables do **not** use `Index.db` or `Summary.db` at all. The BIG-format
+  `Summary → Index → Data` flow does not apply to BTI. BTI uses `Partitions.db` (a
+  page-aware trie, `PartitionIndex`) for O(log n) key lookup and `Rows.db` for the
+  row index. See Ch.17 for the complete BTI format.
+  Source: [`BtiFormat.java#L83-L102`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/bti/BtiFormat.java#L83)
 
 ### Key Takeaways
 - `Index.db` maps partition keys to positions; `Summary.db` accelerates binary search.
@@ -305,7 +329,13 @@ For M5 Stage 0 (simple partitions), promoted index is not written:
 encode_unsigned(0, &mut buffer);
 ```
 
-Promoted index is used for wide partitions (many clustering keys) to enable fast within-partition seeks. This can be added in future stages for wide partition support.
+Promoted index is used for wide partitions — those where uncompressed data written for
+the current partition since the last `IndexInfo` block boundary reaches `column_index_size`
+(default 64 KiB, `BigFormatPartitionWriter.DEFAULT_GRANULARITY`). A partition with few but
+large rows can trigger this; one with many tiny rows below 64 KiB will not. A promoted index
+is only included when **two or more** `IndexInfo` blocks result (`RowIndexEntry.create()`
+lines 227-239). This can be added in future stages for wide partition support.
+Source: [`BigFormatPartitionWriter.java#L49,L213`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigFormatPartitionWriter.java#L49)
 
 ### Token Ordering Requirement
 
@@ -424,11 +454,18 @@ fn write_header(&self, buffer: &mut Vec<u8>, entries_count: u32, summary_entries
     // summary_entries_size (u64, BE) = offset_table_size + entry_data_size
     buffer.extend_from_slice(&summary_entries_size.to_be_bytes());
 
-    // sampling_level (u32, BE) - typically same as min_index_interval
-    buffer.extend_from_slice(&self.min_index_interval.to_be_bytes());
+    // sampling_level (u32, BE) - downsampling level: 1..BASE_SAMPLING_LEVEL (128).
+    // For a freshly written SSTable use BASE_SAMPLING_LEVEL (128), NOT min_index_interval.
+    // They share the same default value (128) by coincidence but diverge after downsampling.
+    // Source: Downsampling.java:34 (BASE_SAMPLING_LEVEL=128); IndexSummary.java:88-94,226-229
+    buffer.extend_from_slice(&self.sampling_level.to_be_bytes()); // 128 for new SSTables
 
-    // size_at_full_sampling (u32, BE) - entries count at full sampling
-    buffer.extend_from_slice(&entries_count.to_be_bytes());
+    // size_at_full_sampling (u32, BE) - ESTIMATED entry count at full sampling.
+    // Formula: total_partition_count / min_index_interval  (NOT entries_count).
+    // After downsampling, entries_count < size_at_full_sampling; they are only equal for a
+    // freshly written SSTable when sampling_level == BASE_SAMPLING_LEVEL == 128.
+    // Source: IndexSummary.java:235-237 (getMaxNumberOfEntries() returns sizeAtFullSampling)
+    buffer.extend_from_slice(&self.size_at_full_sampling.to_be_bytes());
 }
 ```
 
@@ -465,7 +502,10 @@ The complete SSTable write workflow coordinates all components:
 
 Components MUST be written in this order:
 
-1. **Statistics.db** - Provides delta encoding baseline (FIRST)
+1. **Statistics.db** - Written first in the CQLite implementation to provide a delta
+   encoding baseline. Note: this ordering is a CQLite implementation decision; Cassandra's
+   `BigTableWriter` streams `Data.db` as the primary output and computes statistics
+   alongside—there is no format constraint requiring Statistics.db before Data.db.
 2. **Data.db** - Main partition/row data
 3. **Index.db** - Partition index (uses Data.db offsets)
 4. **Summary.db** - Sampled index entries (uses Index.db offsets)
@@ -581,10 +621,17 @@ Memory usage is bounded by:
 
 ### References
 - Cassandra 5.0.0:
-  - `IndexSummary`: [org.apache.cassandra.io.sstable.IndexSummary](https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/IndexSummary.java)
-  - `SSTableReader`: [org.apache.cassandra.io.sstable.SSTableReader](https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/SSTableReader.java)
-  - BIG reader: [org/apache/cassandra/io/sstable/format/big/BigTableReader.java](https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java)
-  - BIG writer: [org/apache/cassandra/io/sstable/format/big/BigTableWriter.java](https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java)
+  - `IndexSummary`: [org.apache.cassandra.io.sstable.indexsummary.IndexSummary](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java) (package path changed in 5.0.x)
+  - BIG reader (was SSTableReader): [org.apache.cassandra.io.sstable.format.big.BigTableReader](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java) (`SSTableReader` is now abstract; BIG reading is in `BigTableReader`)
+  - BIG reader: [org/apache/cassandra/io/sstable/format/big/BigTableReader.java](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java)
+  - BIG writer: [org/apache/cassandra/io/sstable/format/big/BigTableWriter.java](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java)
+
+- Cassandra 5.0.8 — additional citations:
+  - IndexSummary offset LE encoding: [`IndexSummary.java#L411-L418`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java#L411)
+  - Promoted index 64 KiB trigger: [`BigFormatPartitionWriter.java#L49,L213`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigFormatPartitionWriter.java#L49)
+  - RowIndexEntry binary format: [`RowIndexEntry.java#L57-L68`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/RowIndexEntry.java#L57)
+  - DeletionTime "oa" serialization (mfda first): [`DeletionTime.java#L210-L219`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/DeletionTime.java#L210)
+  - BASE_SAMPLING_LEVEL=128: [`Downsampling.java#L34`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/Downsampling.java#L34)
 
 - CQLite Implementation:
   - `cqlite-core/src/storage/sstable/writer/index_writer.rs` - Index.db writer

--- a/docs/sstables-definitive-guide/chapters/21-how-to-find-a-row-by-key.md
+++ b/docs/sstables-definitive-guide/chapters/21-how-to-find-a-row-by-key.md
@@ -1,59 +1,139 @@
 ## How to find a row by key (flow card)
 
-This one-pager stitches Bloom → (Summary → Index) → Data for BIG vs BTI, with byte-level seeks and failure paths.
+This one-pager stitches Bloom → (Summary → Index) → Data for BIG vs BTI, with byte-level
+seeks and failure paths.
 
 ### Overview
-- Bloom check (Filter.db) → early negative exit when absent
-- Summary jump (Summary.db) → locate `index_offset`
-- Index scan (Index.db or BTI index) → locate partition digest, get `data_offset`
-- Data read (Data.db) → parse partition + rows via `SerializationHeader`
+- Bloom check (`Filter.db`) → early negative exit when absent
+- BIG: Summary jump (`Summary.db`) → locate `index_offset`; **BTI has no `Summary.db`**
+- Index scan (`Index.db` for BIG, `Partitions.db` trie for BTI) → get `data_offset`
+- Data read (`Data.db`) → parse partition + rows via `SerializationHeader`
 
 ### BIG (legacy/newbig) flow
-1) Bloom
-- Load `Filter.db` if present; `might_contain(partition_digest)`.
+
+**1) Bloom**
+- Load `Filter.db` if present; `might_contain(decorated_key)`.
 - Negative → stop. Positive → continue.
 
-2) Summary
-- Binary search tokens to find nearest `index_offset`.
+**2) Summary**
+- Binary search **partition keys** (decorated-key order, token-first byte comparison) to find
+  the nearest `index_offset` into `Index.db`.
+- Source: `IndexSummary.binarySearch(PartitionPosition key)` —
+  [`IndexSummary.java#L127-L152`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java#L127)
+- Note: the binary search operates on **decorated keys**, not raw token values.
 
-3) Index
-- From `index_offset`, parse entries.
-- Variant gate:
-  - If first u16 == `0x0010`, non-length-prefixed: read marker → digest → varint `data_offset`.
-  - Else treat first u16 as `entry_length`, then assert next u16 == `0x0010`.
-- Promoted index payload may be present for wide partitions; fall back to scan when absent.
+**3) Index**
+- From `index_offset`, parse entries sequentially until the target is found or passed.
+- **Entry format** (always length-prefixed — there is no marker byte, no MD5 digest):
+  ```
+  u16     key_length        <- raw partition-key byte count (e.g. 0x0010 for a 16-byte UUID)
+  bytes   raw_key_bytes     <- partition key, key_length bytes
+  vint    data_offset       <- byte offset into Data.db
+  vint    promoted_index_len<- length of promoted index block (0 = none)
+  bytes   promoted_index    <- present only when promoted_index_len > 0
+  ```
+- Source: `BigTableReader.java:298` uses `ByteBufferUtil.readWithShortLength(in)` — the `u16`
+  is **always** a key length.
+  [`BigTableReader.java#L298-L325`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java#L298)
+- **Compare** raw key bytes to target. On match → deserialize `RowIndexEntry`.
+- On mismatch → call `RowIndexEntry.Serializer.skip(in, descriptor.version)` and advance to
+  next entry.
+  Source: `BigTableReader.java:349`
 
-4) Data
+> **Note on `0x0010`:** The value `0x0010` is the key length for a 16-byte UUID partition key.
+> It is **not** a fixed marker. An earlier version of this guide misidentified it as a format
+> marker followed by an MD5 digest — that was incorrect (Issue #552). Every entry uses a plain
+> `u16` key length prefix regardless of key type.
+
+**4) Data**
 - Seek to `data_offset` in `Data.db`.
-- NB format note: `Data.db` has no header; chunk boundaries come from `CompressionInfo.db`.
+- NB format note: `Data.db` has no standalone header; chunk boundaries come from
+  `CompressionInfo.db`.
 - Parse partition header and rows using `SerializationHeader`.
 
-Failure/negative path
-- If Index digest != target → advance to next entry in Index page/region.
-- If `size == 0` in C5.0 → sequential scan from `data_offset` until next partition.
+**Failure/negative path**
+- If raw key != target → call `Serializer.skip()` and advance to the next Index.db entry.
+- If no entry matches within the scan window → partition absent (false-positive bloom hit).
 
-### BTI (5.0) flow (high level)
-- Bloom: same semantics.
-- Summary: token-sorted summary guides to BTI index structures.
-- Index: BTI-specific reader locates partition; payload layout differs from BIG.
-- Data: seek to `data_offset`; parse via `SerializationHeader`.
+---
+
+### BTI (5.0) exact-key lookup — full detail
+
+BTI uses a trie partition index (`Partitions.db`) instead of the Summary → Index scan chain.
+**There is no `Summary.db` and no `Index.db` in a BTI SSTable.**
+Source: [`BtiFormat.java#L83-L102`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/bti/BtiFormat.java#L83)
+
+**1) Bloom** — `BtiTableReader.isPresentInFilter(dk)`. Negative → stop.
+
+**2) PartitionIndex trie (`Partitions.db`)** —
+`partitionIndex.openReader().exactCandidate(dk)`. Returns `NOT_FOUND` → stop.
+Otherwise returns `indexPos`:
+- `indexPos >= 0` → position in `Rows.db`. Proceed to step 3a.
+- `indexPos < 0` → `~indexPos` is a direct position in `Data.db` (small partition, no row
+  index). Proceed to step 3b.
+
+Source: `BtiTableReader.java:223-276`
+[`BtiTableReader.java#L223`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableReader.java#L223)
+
+**3a) `Rows.db` key verify + TrieIndexEntry** — Read `u16`-prefixed partition key at
+`indexPos`; compare to target. Mismatch → stop. Deserialize `TrieIndexEntry`:
+```
+vint    dataFilePosition   <- offset of partition start in Data.db
+vint    indexTrieRoot      <- delta-encoded relative to current file position
+u32     rowIndexBlockCount
+bytes   DeletionTime       <- 12 bytes (version "oa": mfda 8 B + ldt 4 B)
+```
+Source: [`TrieIndexEntry.java#L90-L118`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/bti/TrieIndexEntry.java#L90)
+
+**3b) `Data.db` direct** — Read `u16`-prefixed key from `~indexPos`; compare to target.
+Mismatch → stop. Use `~indexPos` as `dataFilePosition`.
+
+**4) Data seek** — Seek `dataFilePosition` in `Data.db`; parse with `SerializationHeader`.
+
+> **Key cache absent in BTI:** `TrieIndexEntry.serializeForCache()` throws
+> `AssertionError("BTI SSTables should not use key cache")`. All BTI lookups traverse the
+> trie.
+> Source: [`TrieIndexEntry.java#L68-L76`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/bti/TrieIndexEntry.java#L68)
+
+---
 
 ### Byte-level seek checklist
-- Summary → `index_offset`: verify within file bounds and monotonically increasing tokens.
-- Index → `data_offset`: validate marker `0x0010` (BIG) and digest length = 16 bytes.
-- Data seek: ensure `data_offset` points within a valid chunk boundary (NB: use `CompressionInfo.db`).
 
-### Tiny hex anchors
+- **BIG — Summary → Index:** verify `index_offset` is within file bounds; summary entries are
+  in decorated-key (token-first) order.
+- **BIG — Index → Data:** the leading `u16` is the key byte length; compare raw key bytes to
+  target. No marker, no digest. Call `Serializer.skip()` on mismatch.
+- **BTI — Partitions.db → Data:** sign-bit of `indexPos` routes to `Rows.db` (>= 0) or
+  directly to `Data.db` (< 0, decode as `~indexPos`).
+- **Data seek (both formats):** ensure `data_offset` points within a valid chunk boundary
+  (NB compressed: use `CompressionInfo.db`).
+
+---
+
+### Annotated hex — BIG Index.db entries
+
 ```text
-// BIG, non-length-prefixed (index excerpt)
-00000000: 0010 6b88 bf20 a251 11f0 a3fe f1a5 5138 |..k.. .Q......Q8|
+// BIG Index.db -- 16-byte UUID partition key (key_length = 0x0010 = 16, NOT a marker)
+00000000: 0010 1529 1a77 d739 4e73 8397 b787 442f  |...).w.9Ns....D/|
+00000010: 3a1f 00 00 ...
+//         ^^^^ ^^   ^^
+//         uuid  |    promoted_index_len = 0
+//               data_offset vint
 
-// BIG, length-prefixed (index excerpt)
-00000000: 001a 0010 37ac 9f53 bd8e 4da5 a41a 240f |....7..S..M...$.
+// BIG Index.db -- 26-byte composite key (key_length = 0x001a = 26)
+00000000: 001a 0010 37ac 9f53 bd8e 4da5 a41a 240f  |....7..S..M...$.|
+//         ^^^^
+//         key_length = 26  (not a marker!)
 ```
 
+---
+
 ### References
-- `IndexSummary`: https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/IndexSummary.java
-- BIG reader: https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java
-- `SerializationHeader`: https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/db/SerializationHeader.java
-- BTI format: `org.apache.cassandra.io.sstable.format.bti`
+- `IndexSummary` (5.0.8): [`org.apache.cassandra.io.sstable.indexsummary.IndexSummary`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java)
+- BIG reader: [`BigTableReader.java`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java)
+- BIG raw-key comparison (no digest): [`BigTableReader.java#L298-L325`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java#L298)
+- BTI has no Summary.db: [`BtiFormat.java#L100-L108`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/bti/BtiFormat.java#L83)
+- TrieIndexEntry on-disk format: [`TrieIndexEntry.java#L90-L118`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/bti/TrieIndexEntry.java#L90)
+- Key cache absent in BTI: [`TrieIndexEntry.java#L68-L76`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/bti/TrieIndexEntry.java#L68)
+- `SerializationHeader`: [`SerializationHeader.java`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/SerializationHeader.java)
+- BTI format spec: `org.apache.cassandra.io.sstable.format.bti` (see `BtiFormat.md` in-tree)


### PR DESCRIPTION
## Summary
Audit batch B2 (epic #598). Fixes Ch.06 and Ch.21 against Cassandra 5.0.8 source (incorporates B6's Ch.21 BTI findings).

Key fixes:
- Removed discredited 0x0010 marker + MD5 digest variant from BIG Index.db flow — entry is always u16 key length + raw key (`BigTableReader.java:298`); failure path is key inequality → `Serializer.skip()`
- Summary.db write fields: sampling_level = BASE_SAMPLING_LEVEL (128), size_at_full_sampling = estimated entries at full sampling (not entries_count)
- Promoted index trigger is data-size ≥ 64 KiB (column_index_size), not clustering-key count
- New BTI flow card: no Summary.db/Index.db in BTI — trie walk via Partitions.db with sign-bit position routing
- DeletionTime field-order gate ('oa' unsigned deletion time) documented
- Permalinks re-pinned to cassandra-5.0.8

Closes #600. Part of epic #598.