### PR TITLE
docs(guide): fix bloom filter and checksum format claims vs cassandra-5.0.8 (#601)

### DIFF
--- a/docs/sstables-definitive-guide/HEADER_CRC32_DOCUMENTATION.md
+++ b/docs/sstables-definitive-guide/HEADER_CRC32_DOCUMENTATION.md
@@ -16,6 +16,11 @@
 
 **See:** ISSUE_149_LEARNINGS.md - Issue #153 section for authoritative NB format documentation.
 
+**Ch.20 update (audit B3, 2026-06-09):** The “Header CRC32 Prefixes” section in
+`chapters/20-checksums-and-integrity.md` has been removed and replaced with a correction
+notice consistent with this retraction. NB format `Data.db` has no header; the section
+described a non-existent feature.
+
 ---
 
 ## Original Documentation (Now Obsolete)

--- a/docs/sstables-definitive-guide/chapters/07-bloom-filter.md
+++ b/docs/sstables-definitive-guide/chapters/07-bloom-filter.md
@@ -23,31 +23,44 @@ Small numeric example (intuition): for n=1,000 and p=1%, the optimal bits-per-ke
 
 ## Hash Algorithm
 
-Cassandra bloom filters use **Murmur3 128-bit hash** with seed 0 for partition key hashing. The 128-bit output is split into two 64-bit values for double hashing:
+Cassandra bloom filters use **Murmur3 128-bit hash** for partition key hashing. The 128-bit output
+is split into two 64-bit values used for double hashing. The seed is caller-provided; seed=0 is a
+common default for the standard `FilterKey` implementation but is not a format constant.
 
 ```
-hash128 = murmur3_x64_128(key, seed=0)
-hash1 = (hash128 >> 64) & 0xFFFFFFFFFFFFFFFF  // high 64 bits
-hash2 = hash128 & 0xFFFFFFFFFFFFFFFF         // low 64 bits
+[hash[0], hash[1]] = murmur3_x64_128(key, seed)   // result[0]=h1, result[1]=h2
 ```
 
 For each of the k hash functions, bit positions are derived using the **double hashing formula**:
 
 ```
-hash_i = hash1 + (i * hash2)  for i = 0, 1, 2, ..., k-1
-bit_position = (hash_i mod bit_count)
+index_i = abs((hash[1] + i * hash[0]) % bitset_capacity)   for i = 0, 1, ..., k-1
 ```
 
-This scheme avoids computing k independent hashes by deriving all positions from two base hashes. The wrapping arithmetic ensures consistent behavior across hash implementations.
+Here `hash[0]` is MurmurHash result[0] (h1) and `hash[1]` is result[1] (h2). Note that
+`hash[1]` (h2) is the base and `hash[0]` (h1) is the increment --- matching
+[`BloomFilter.java:84`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/utils/BloomFilter.java):
+`setIndexes(hash[1], hash[0], ...)`.
+
+`bitset_capacity` is the allocated bit capacity of the `OffHeapBitSet`:
+`capacity = ceil((n * bucketsPerElement + BITSET_EXCESS) / 64) * 64` bits,
+where `BITSET_EXCESS = 20`
+([`FilterFactory.java:35`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/utils/FilterFactory.java)).
+Modulo is over the full allocated capacity, which includes the 20-bit excess.
+
+This scheme avoids computing k independent hashes by deriving all positions from two base hashes.
+The wrapping arithmetic ensures consistent behavior across hash implementations.
 
 **Special cases:**
-- Empty key produces `hash1 = 0, hash2 = 0` (Murmur3 seed 0 behavior)
-- Hash values are deterministic for a given key
+- Hash values are deterministic for a given key and seed
 - Different keys produce different hash pairs with high probability
 
 Hashing and bit array notes:
 - Double-hashing scheme derives k positions from two base hashes to avoid k separate hashes.
-- Bit array is addressed modulo bit_count; serialized as big-endian u64 words with bits packed LSB-first within each byte.
+- Bit array is stored as raw bytes (no endianness transformation); bit addressing uses
+  `index >> 3` for byte offset and `index & 0x7` for bit mask (LSB-first within each byte).
+- Old format (`serializeOldBfFormat`) explicitly writes little-endian 8-byte longs; the new
+  format is a raw memory dump with no byte-swapping.
 
 ## Read Flow Interaction
 
@@ -62,9 +75,19 @@ During a point lookup, Bloom is checked before any index/summary seeks. A negati
 - Missing or unreadable Bloom falls back to index/summary without correctness loss.
 
 ### References
-- Cassandra 5.0.0:
-  - `BloomFilter`: [org.apache.cassandra.utils.bloom.BloomFilter](https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/utils/bloom/BloomFilter.java)
-  - `BloomCalculations`: [org.apache.cassandra.utils.bloom.BloomCalculations](https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/utils/bloom/BloomCalculations.java)
+- Cassandra 5.0.8:
+  - `BloomFilter`:
+    [`org.apache.cassandra.utils.BloomFilter`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/utils/BloomFilter.java)
+  - `BloomCalculations`:
+    [`org.apache.cassandra.utils.BloomCalculations`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/utils/BloomCalculations.java)
+  - `BloomFilterSerializer`:
+    [`org.apache.cassandra.utils.BloomFilterSerializer`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/utils/BloomFilterSerializer.java)
+  - `OffHeapBitSet`:
+    [`org.apache.cassandra.utils.obs.OffHeapBitSet`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/utils/obs/OffHeapBitSet.java)
+  - `FilterFactory`:
+    [`org.apache.cassandra.utils.FilterFactory`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/utils/FilterFactory.java)
+  - `FilterComponent`:
+    [`org.apache.cassandra.io.sstable.format.FilterComponent`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/FilterComponent.java)
   
 For implementation details, see Appendix C.
 
@@ -75,38 +98,53 @@ The Filter.db file contains a complete bloom filter serialized in Cassandra-comp
 ### Binary Structure
 
 ```
-[Hash Count: 4 bytes, big-endian u32]
-[Bit Count:  8 bytes, big-endian u64]
-[Bit Array:  variable length, big-endian u64 words]
+[Hash Count:  4 bytes, signed int]
+[Word Count:  4 bytes, signed int]
+[Bit Array:   word_count * 8 bytes, raw bytes]
 ```
 
 **Field details:**
-- `hash_count` (u32 BE): Number of hash functions (k) used for insertion/lookup
-- `bit_count` (u64 BE): Total number of bits in the filter (m)
-- `bit_array`: Sequence of u64 words in big-endian format, with bits packed within each word
+- `hash_count` (4-byte signed int): Number of hash functions (k) used for insertion/lookup
+  ([`BloomFilterSerializer.java:53`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/utils/BloomFilterSerializer.java)).
+- `word_count` (4-byte signed int): Number of 64-bit words in the bit array
+  ([`OffHeapBitSet.java:117`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/utils/obs/OffHeapBitSet.java):
+  `out.writeInt((int)(bytes.size() / 8))`).
+- `bit_array`: `word_count * 8` bytes of raw bit data, copied directly from off-heap memory
+  with no endianness transformation
+  ([`OffHeapBitSet.java:118`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/utils/obs/OffHeapBitSet.java):
+  `out.write(bytes, 0, bytes.size())`).
 
 The bit array length is calculated as:
 ```
-word_count = ceil(bit_count / 64)
 bit_array_bytes = word_count * 8
-total_file_size = 12 + bit_array_bytes
+total_file_size = 8 + bit_array_bytes
 ```
+
+Deserialization reads the word count as a 4-byte int and multiplies by 8 to get byte count
+([`OffHeapBitSet.java:146`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/utils/obs/OffHeapBitSet.java):
+`long byteCount = in.readInt() * 8L`).
+
+> **Note on format versions:** The description above covers the current (new) format.
+> An older format (`serializeOldBfFormat`) exists for backward compatibility; it writes each
+> 64-bit word as an explicit little-endian long (8 bytes per word). The version-selection
+> logic is in `FilterComponent.java` via `descriptor.version.hasOldBfFormat()`.
 
 ### Hex Example
 
-Tiny hex excerpt (real file, start):
+Tiny hex excerpt (illustrative, new format):
 ```
-00000000: 0000 0007 0000 0000 0000 0258 a4c0 e2a8 ...
+00000000: 0000 0007 0000 000A <80 bytes of raw bit data> ...
 ```
 Interpretation:
-- `0000 0007` → hash_count = 7
-- `0000 0000 0000 0258` → bit_count = 600 bits
-- next bytes → bit array (75 bytes = ceil(600/64) * 8 = 10 words * 8 bytes)
+- `0000 0007` -> hash_count = 7
+- `0000 000A` -> word_count = 10
+- next 80 bytes -> bit array (10 words x 8 bytes each)
 
-**Endianness and bit packing:**
-- Fixed-width fields are big-endian
-- Each u64 word in the bit array is stored in big-endian byte order
-- Within each u64 word, bit 0 is the least significant bit
+**Bit addressing:**
+- Each byte in the bit array is addressed as `byte_index = bit_index >> 3`
+- Within each byte, the bit mask is `1 << (bit_index & 0x7)` (LSB-first)
+- There is no endianness transformation in the new format; bytes are stored as-is from
+  off-heap memory
 
 ## Write-Time Sizing Guidance
 
@@ -126,6 +164,10 @@ m = ceil(-(n * ln(p)) / (ln(2))^2)
 k = ceil((m / n) * ln(2))
 k = max(k, 1)  // ensure at least one hash function
 ```
+
+> **Note:** Cassandra's implementation uses a pre-computed lookup table
+> (`BloomCalculations.optKPerBuckets[]`) rather than the continuous formula, so actual k values
+> for small bucket counts may differ slightly from the formula above.
 
 ### Concrete Examples
 
@@ -169,6 +211,8 @@ actual_fpr = (1 - prob_bit_zero)^k
 
 If `inserted_count` significantly exceeds `n`, the filter becomes saturated and `actual_fpr` rises above the target `p`. In production, rebuild the SSTable with a larger `expected_elements` value.
 
-See `org.apache.cassandra.utils.bloom.BloomFilter` and `BloomCalculations` for writer/reader details.
+See [`BloomFilter`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/utils/BloomFilter.java)
+and [`BloomCalculations`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/utils/BloomCalculations.java)
+for writer/reader details.
 
 

--- a/docs/sstables-definitive-guide/chapters/20-checksums-and-integrity.md
+++ b/docs/sstables-definitive-guide/chapters/20-checksums-and-integrity.md
@@ -1,10 +1,21 @@
 ## Checksums and Integrity
 
-SSTables carry integrity metadata at three levels: optional header CRC32 prefixes in legacy/BIG formats, per-chunk checksums for compressed `Data.db` blocks, and the `Digest.crc32` file for component-level verification. Readers validate checksums at each level to ensure data integrity throughout the read path.
+SSTables carry integrity metadata at two levels: per-chunk checksums for compressed `Data.db`
+blocks, and the `Digest.crc32` file for component-level verification. Readers validate checksums
+at each level to ensure data integrity throughout the read path.
+
+> **Correction notice:** An earlier version of this chapter contained a section titled
+> "Header CRC32 Prefixes" describing a CRC32 prefix that was believed to appear before certain
+> NB-format SSTable headers. That section has been removed. Per
+> `HEADER_CRC32_DOCUMENTATION.md` and verification against Cassandra 5.0.8 source, **NB format
+> `Data.db` has NO magic number or global header** -- the file starts directly with compressed
+> chunk data. The bytes previously mistaken for a header CRC32 (e.g., `0x71160000`,
+> `0xf1185c00`) are the first bytes of compressed chunk data. NB format is identified by
+> filename pattern, not file content. See `CompressedSequentialWriter` constructor and
+> `flushData()` for confirmation.
 
 ### In this chapter you will learn
-- How header CRC32 prefixes (Legacy/BIG only) protect SSTable metadata
-- How per-chunk checksums are stored and validated
+- How per-chunk checksums are stored and validated for NB compressed `Data.db`
 - What `Digest.crc32` covers and how it differs from other checksums
 - How readers/writers interact with integrity metadata
 - How to demonstrate a minimal verification example
@@ -20,151 +31,12 @@ SSTables carry integrity metadata at three levels: optional header CRC32 prefixe
 | Filter.db (BIG/NB) | no | n/a | n/a | n/a | `Digest.crc32` |
 | Statistics.db (BIG/NB) | no | n/a | n/a | n/a | `Digest.crc32` |
 | CompressionInfo.db (NB) | no | n/a | n/a | n/a | `Digest.crc32` |
-| Legacy headers (select BIG sub-variants) | yes (where present) | n/a | big-endian u32 | header bytes only (after prefix) | reader on open |
-
 Notes:
-- “Legacy headers” are format-specific BIG-family artifacts, not used by NB `Data.db`.
-- `Digest.crc32` validates whole components over full-file contents per `TOC.txt`.
+- NB format `Data.db` has no magic number or header; the file starts directly with compressed data.
+- `Digest.crc32` is an independent per-component file; each component written by
+  `ChecksummedSequentialWriter` or `CompressedSequentialWriter` generates its own
+  `Digest.crc32`. There is no single digest enumerating all TOC components.
 - Full matrix with details appears later in this chapter.
-
-## Header CRC32 Prefixes (Legacy Formats Only)
-
-> **Note:** This section describes CRC32 prefixes in **legacy formats only**.
-> NB format (Cassandra 4.x/5.x) does NOT use header CRC32 prefixes.
-> See "NB Format: Trailing Chunk CRCs" section below for NB format CRC32 handling (trailing chunk CRCs).
-
-Starting with certain Cassandra versions, some SSTable components in **legacy formats** (not NB) may include a **4-byte CRC32 checksum prefix** prepended to the file header. This provides early detection of header corruption before attempting to parse metadata.
-
-### Format Structure
-
-**Checksummed Header Format:**
-```
-[4 bytes: CRC32 checksum] [remaining bytes: actual header data]
-│                          │
-│                          └─ Starts with magic number (e.g., 0x6F610000 for 'oa' format)
-└─ CRC32 of all subsequent header bytes
-```
-
-**Example from legacy Cassandra data (OA format):**
-```
-Offset  Bytes                 Interpretation
-------  --------------------  ---------------------------
-0x00    XX XX XX XX          CRC32 checksum
-0x04    6F 61 00 00          Magic = 0x6F610000 ('oa' legacy format)
-0x08    00 01                Version
-0x0a    ...                  Remaining header data
-```
-
-> **IMPORTANT: NB Format is Headerless (Issue #211)**
->
-> NB format Data.db files (`nb-*-big-Data.db`) have **NO magic number or header**.
-> The file starts directly with compressed chunk data. The value `0x00400000` that
-> sometimes appears at offset 0 is the **LZ4 chunk length prefix** (16384 in
-> little-endian = `0x00004000`), NOT a magic number. NB format is identified solely
-> by filename pattern, not by file content. See Chapter 9 for NB format details.
-
-### Detection Algorithm
-
-Readers should detect checksummed headers using this two-step process:
-
-1. **Read first 4 bytes** as potential magic number
-2. **Check against known formats**: If the value doesn't match any known magic number, treat it as a CRC32 checksum
-
-**Implementation pattern:**
-```rust
-let first_4_bytes = read_be_u32()?;
-
-if CassandraVersion::from_magic_number(first_4_bytes).is_none() {
-    // First 4 bytes are likely a CRC32 checksum
-    let expected_checksum = first_4_bytes;
-    let header_data = read_remaining_header()?;
-
-    // Validate checksum
-    let computed_checksum = crc32fast::hash(&header_data);
-    if computed_checksum != expected_checksum {
-        return Err(HeaderChecksumMismatch {
-            expected: expected_checksum,
-            computed: computed_checksum,
-        });
-    }
-
-    // Parse actual header starting after checksum
-    parse_header(&header_data)
-} else {
-    // First 4 bytes are the magic number (no checksum)
-    parse_header_from_offset_0()
-}
-```
-
-### When Headers Have Checksums
-
-**Observed in:**
-- Collection tables with complex types
-- Tables with User-Defined Types (UDTs)
-- Some V5_0NewBig format SSTables (format-specific, not universal)
-
-**Not observed in:**
-- Simple tables with basic types
-- Many V5_0NewBig tables (checksums are optional)
-- Legacy formats (pre-5.0)
-
-This is an **optional integrity feature**, not a format requirement. Readers must handle both checksummed and non-checksummed headers.
-
-### Validation Strategy
-
-**Fail-fast approach (recommended):**
-```
-1. Detect checksum presence (first 4 bytes don't match magic numbers)
-2. Compute CRC32 of header data
-3. Compare with prefix value
-4. On mismatch: reject file immediately (corruption detected)
-5. On match: proceed with header parsing
-```
-
-**Why fail-fast?** Header corruption indicates severe problems:
-- File system corruption
-- Failed writes during SSTable flush/compaction
-- Data transfer errors
-- Storage media failures
-
-Attempting to parse corrupt headers leads to undefined behavior, crashes, or silent data corruption. Modern formats (Cassandra 5.0+) mandate strict validation.
-
-### Error Handling
-
-**Checksum mismatch errors should:**
-- Report both expected and computed checksums (hex format)
-- Include file path for forensics
-- Not attempt fallback parsing or recovery
-- Trigger component quarantine in production systems
-
-**Example error message:**
-```
-Header checksum mismatch for /var/lib/cassandra/data/ks/table-uuid/nb-1-big-Data.db
-Expected: 0xf1185c00
-Computed: 0xa3b4c5d6
-Action:  Quarantine component and trigger repair
-```
-
-### Integration with Other Checksums
-
-The three-level checksum hierarchy:
-
-1. **Header CRC32** (this section) - Protects metadata before parsing
-2. **Per-chunk CRCs** (next section) - Protects compressed data blocks
-3. **Digest.crc32** (later section) - Validates whole components
-
-Each level serves a distinct purpose:
-- Header CRC32: Early validation, prevents parsing corrupt metadata
-- Chunk CRCs: Runtime validation during reads, per-block granularity
-- Digest.crc32: Offline verification, post-transfer validation
-
-### Key Takeaways
-
-- Header CRC32 prefixes are **optional** in Cassandra 5.0 (format-specific)
-- Detect by checking if first 4 bytes match known magic numbers
-- Validate using `crc32fast::hash()` over remaining header bytes
-- Fail immediately on mismatch (never attempt recovery)
-- Handle both checksummed and non-checksummed headers in readers
 
 ## NB Format: Trailing Chunk CRCs
 
@@ -180,6 +52,12 @@ NB format uses a different CRC strategy than legacy formats - CRCs are placed **
 ...
 ```
 
+Source:
+[`CompressedSequentialWriter.java:187-192`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/compress/CompressedSequentialWriter.java)
+-- `channel.write(toWrite)` then `crcMetadata.appendDirect(toWrite, true)`.
+Each chunk offset advances by `compressedLength + 4` (for the trailing CRC)
+([`CompressedSequentialWriter.java:203`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/compress/CompressedSequentialWriter.java)).
+
 ### Validation Process
 
 1. Read chunk bytes from Data.db (length from CompressionInfo.db)
@@ -189,7 +67,9 @@ NB format uses a different CRC strategy than legacy formats - CRCs are placed **
 5. On match: decompress and continue
 6. On mismatch: corruption detected (fail or warn based on `crc_check_chance` config)
 
-Explicit note: CRC32 is computed over the compressed chunk only and excludes the trailing 4-byte CRC itself.
+Explicit note: CRC32 is computed over the compressed chunk only and excludes the trailing
+4-byte CRC itself
+([`ChecksumWriter.java:68-69`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/util/ChecksumWriter.java)).
 
 Minimal illustration (excerpt from a real `Data.db`, first 32 bytes):
 ```
@@ -201,6 +81,7 @@ When aligned to a chunk boundary, the 4 bytes immediately following the compress
 ### CRC Algorithm Details
 
 - **Standard:** Java `java.util.zip.CRC32`
+  ([`ChecksumType.java`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/utils/ChecksumType.java))
 - **Polynomial:** 0x04C11DB7 (IEEE standard)
 - **Initial value:** 0
 - **Reflected:** Yes (reversed polynomial: 0xEDB88320)
@@ -216,15 +97,65 @@ When aligned to a chunk boundary, the 4 bytes immediately following the compress
 
 The `crc32fast` Rust crate implements the same algorithm. Ensure big-endian byte order when comparing.
 
+## CRC.db Component (Separate Per-Chunk CRCs for Uncompressed Data)
+
+For uncompressed (non-compressed) `Data.db`, a separate `CRC.db` file holds per-chunk CRC32
+values.
+
+Source:
+[`ChecksummedSequentialWriter.java:33-40`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/util/ChecksummedSequentialWriter.java),
+[`ChecksumWriter.java:43-53`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/util/ChecksumWriter.java).
+
+**CRC.db layout:**
+```
+[Chunk Size: 4 bytes, signed int]   <- uncompressed buffer capacity (header)
+[CRC32 chunk 0: 4 bytes]
+[CRC32 chunk 1: 4 bytes]
+...
+```
+
+**Seek formula** -- to locate the CRC for a given byte offset in `Data.db`:
+```
+chunk_index   = byte_offset / chunkSize
+crc_file_pos  = (chunk_index * 4) + 4
+```
+where `chunkSize` is the 4-byte int at the start of `CRC.db`
+([`DataIntegrityMetadata.java:52-53`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/util/DataIntegrityMetadata.java):
+`reader.seek(((start / chunkSize) * 4L) + 4)` where `start = chunkStart(offset)`).
+
+Note: per-chunk CRC values written to `CRC.db` are **not** included in the full checksum
+for `ChecksummedSequentialWriter` (`checksumIncrementalResult=false`,
+[`ChecksummedSequentialWriter.java:49`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/util/ChecksummedSequentialWriter.java)).
+For `CompressedSequentialWriter`, per-chunk CRC bytes **are** included in the full checksum
+(`checksumIncrementalResult=true`,
+[`CompressedSequentialWriter.java:192`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/compress/CompressedSequentialWriter.java)).
+
 ## Per-Chunk Checksums (Legacy Formats)
 When compression is enabled, `CompressionInfo.db` may include a CRC for each compressed chunk. Readers should compute CRC over the compressed bytes and compare with metadata prior to decompression. This catches corruption early and avoids propagating errors downstream.
 
 Readers should validate chunk CRCs where present before decompression; modern formats expect strict CRC adherence. For validation walkthroughs, see Appendix C.
 
 ## Digest Files
-`Digest.crc32` provides a fast verification for the main components of an SSTable generation. It is complementary to per-chunk CRCs: the digest validates whole-file contents, while per-chunk CRCs validate compressed block integrity during reads.
+`Digest.crc32` is written by `ChecksumWriter.writeFullChecksum()` on SSTable finalization
+([`ChecksumWriter.java:91-103`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/util/ChecksumWriter.java)).
+It contains a **single line**: the CRC32 checksum value as a UTF-8 decimal string, flushed
+and synced to disk.
 
-Minimal example (conceptual): During directory validation, ensure that for each generation listed in `TOC.txt`, all required components exist and optionally check `Digest.crc32` against recomputed CRCs when available.
+Each component written by `ChecksummedSequentialWriter` or `CompressedSequentialWriter`
+generates its own independent `Digest.crc32`. Each digest covers exactly one component file
+([`DataIntegrityMetadata.FileDigestValidator`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/util/DataIntegrityMetadata.java):
+reads `Long.parseLong(digestReader.readLine())` -- decimal string -- and validates a single
+`dataFile` against a single `digestFile`). There is no single `Digest.crc32` that enumerates
+all components listed in `TOC.txt`.
+
+`Digest.crc32` is complementary to per-chunk CRCs: the digest validates whole-file contents,
+while per-chunk CRCs validate compressed block integrity during reads.
+
+Minimal verification example:
+1. For each component file, locate the corresponding `Digest.crc32`.
+2. Compute CRC32 over the entire component file contents.
+3. Compare against the decimal value in `Digest.crc32`; on mismatch, quarantine and
+   rehydrate via repair/streaming.
 
 ## Recovery Strategies (Beyond Detection)
 
@@ -247,21 +178,36 @@ Scope note: focus on SSTable-level recovery patterns; node-level operations are 
   - Monitor error counters; re-scan directories after compaction
 
 ### Key Takeaways
-- **Header CRC32 prefixes** (legacy formats only) protect SSTable metadata; **NB format does NOT use header CRC32 prefixes**.
-- **NB format uses trailing chunk CRCs** - placed after each compressed chunk, not before.
-- **Per-chunk CRCs** protect compressed `Data.db` blocks before decompression (legacy) or after reading (NB format).
-- **`Digest.crc32`** validates whole-file content at the component level.
+- **NB format `Data.db` has NO magic number or header** -- the file starts directly with
+  compressed chunk data. There are no “Header CRC32 Prefixes” in NB format.
+- **NB format uses trailing chunk CRCs** -- placed after each compressed chunk, big-endian u32,
+  covering compressed chunk bytes only.
+- **CRC.db** (uncompressed path) holds a 4-byte int header (chunk size) + 4-byte CRC32 per chunk.
+  Seek to chunk N's CRC with: `crc_file_pos = (chunk_index * 4) + 4`.
+- **`Digest.crc32`** is an independent per-component file containing a single UTF-8 decimal
+  CRC32 value; each component has its own digest. It does not enumerate all TOC components.
 - Readers should validate all checksums on-the-fly; tools may verify digests offline.
-- Fail-fast on any CRC mismatch—corruption detected; do not attempt heuristic recovery in modern formats.
-- The three-level hierarchy provides defense in depth: header validation (legacy) or chunk validation (NB) → component validation.
+- Fail-fast on any CRC mismatch -- do not attempt heuristic recovery in modern formats.
 
 ### References
-- Cassandra 5.0.0:
-  - `DataIntegrityMetadata`: `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/util/DataIntegrityMetadata.java`
-  - `PureJavaCrc32`: `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/utils/PureJavaCrc32.java`
+- Cassandra 5.0.8:
+  - `DataIntegrityMetadata`:
+    [`org.apache.cassandra.io.util.DataIntegrityMetadata`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/util/DataIntegrityMetadata.java)
+  - `PureJavaCrc32`:
+    [`org.apache.cassandra.utils.PureJavaCrc32`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/utils/PureJavaCrc32.java)
+  - `ChecksumWriter`:
+    [`org.apache.cassandra.io.util.ChecksumWriter`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/util/ChecksumWriter.java)
+    (chunk size header L43-48; appendDirect L62-89; writeFullChecksum L91-103)
+  - `ChecksummedSequentialWriter`:
+    [`org.apache.cassandra.io.util.ChecksummedSequentialWriter`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/util/ChecksummedSequentialWriter.java)
+    (constructor L33-40; flushData L43-50 calling appendDirect with false)
+  - `CompressedSequentialWriter`:
+    [`org.apache.cassandra.io.compress.CompressedSequentialWriter`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/compress/CompressedSequentialWriter.java)
+    (flushData L140-206: inline CRC after compressed chunk; digest on finalize L392-393)
+  - `ChecksumType`:
+    [`org.apache.cassandra.utils.ChecksumType`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/utils/ChecksumType.java)
 
 - CQLite implementation:
-  - Header CRC32 detection: `cqlite-core/src/storage/sstable/reader/header.rs` (see Issue #153)
   - CRC32 computation: `crc32fast` crate (Rust standard library compatible)
 
 For implementation details and walkthroughs, see Appendix C.
@@ -270,22 +216,31 @@ For implementation details and walkthroughs, see Appendix C.
 
 | Component (format)     | Header CRC32 prefix | Trailing chunk CRCs | Byte order (stored) | CRC scope | `Digest.crc32` present |
 |------------------------|---------------------|---------------------|---------------------|-----------|------------------------|
-| Data.db (BIG)          | format-dependent    | no                  | n/a                 | n/a       | yes                    |
-| Index.db (BIG)         | format-dependent    | n/a                 | n/a                 | n/a       | yes                    |
-| Summary.db (BIG)       | format-dependent    | n/a                 | n/a                 | n/a       | yes                    |
-| Filter.db (BIG)        | format-dependent    | n/a                 | n/a                 | n/a       | yes                    |
-| Statistics.db (BIG)    | format-dependent    | n/a                 | n/a                 | n/a       | yes                    |
+| Data.db (BIG)          | no                  | no                  | n/a                 | n/a       | yes                    |
+| Index.db (BIG)         | no                  | n/a                 | n/a                 | n/a       | yes                    |
+| Summary.db (BIG)       | no                  | n/a                 | n/a                 | n/a       | yes                    |
+| Filter.db (BIG)        | no                  | n/a                 | n/a                 | n/a       | yes                    |
+| Statistics.db (BIG)    | no                  | n/a                 | n/a                 | n/a       | yes                    |
 | CompressionInfo.db     | no                  | n/a                 | n/a                 | n/a       | yes                    |
 | Data.db (NB)           | no                  | yes (per chunk)     | big-endian u32      | compressed chunk bytes only | yes |
 
 Notes:
-- “format-dependent” indicates presence varies by sub-version/feature flags in BIG/mc/mm families. NB does not use header CRCs.
+- NB `Data.db` starts directly with compressed data; no magic number, no header.
 - Trailing CRCs apply only to NB `Data.db` and are big-endian u32 immediately following each compressed chunk.
-- `Digest.crc32` is emitted per generation and covers the component set listed in `TOC.txt` (see below).
+- Each `Digest.crc32` covers exactly one component file (independent per-component, not a set digest).
 
 ## `Digest.crc32` Coverage
 
-`Digest.crc32` is a per-generation file that stores CRC32 values for listed components. Coverage includes each component file named in `TOC.txt` for that generation (e.g., `Data.db`, `Index.db`, `Summary.db`, `Filter.db`, `Statistics.db`, `CompressionInfo.db` when present). Each entry records the CRC32 over the full file contents (entire byte range) of the corresponding component, computed independently per file.
+`Digest.crc32` is a per-component file written by `ChecksumWriter.writeFullChecksum()`. It holds
+a single UTF-8 decimal line: the CRC32 over the full byte range of the associated component file.
+Each component written by `ChecksummedSequentialWriter` or `CompressedSequentialWriter` produces
+its own independent `Digest.crc32`.
+
+For compressed components (`CompressedSequentialWriter`), the full checksum includes all
+compressed data bytes **plus** all per-chunk CRC values
+([`ChecksumWriter.java:74-81`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/util/ChecksumWriter.java)).
+For uncompressed components (`ChecksummedSequentialWriter`), only data bytes are included
+(per-chunk CRCs are not fed into the full checksum).
 
 Minimal verification example:
 1. Read `TOC.txt` to enumerate components.


### PR DESCRIPTION
## Summary
Audit batch B3 (epic #598). Fixes Ch.07, Ch.20, HEADER_CRC32_DOCUMENTATION.md against Cassandra 5.0.8 source.

Key fixes:
- Filter.db layout: [hashCount 4B int][wordCount 4B int][bit array raw bytes] — the documented 8-byte bit_count field does not exist (`OffHeapBitSet.java:117`, `BloomFilterSerializer.java:53-54`)
- Double-hashing operand order: index_i = abs((hash[1] + i*hash[0]) % capacity) — base and increment were swapped
- Removed retracted 'Header CRC32 Prefixes' section from Ch.20 (NB Data.db has no global header/magic)
- Digest.crc32 is per-component and independent; CRC.db seek formula corrected
- Permalinks re-pinned to cassandra-5.0.8; 10 new citations

Closes #601. Part of epic #598.