### PR TITLE
docs(guide): fix Statistics.db spec field encodings vs cassandra-5.0.8 (#602)

### DIFF
--- a/docs/sstables-definitive-guide/chapters/08-statistics-db.md
+++ b/docs/sstables-definitive-guide/chapters/08-statistics-db.md
@@ -47,7 +47,7 @@ These fields drive compaction policies (e.g., tombstone purging thresholds), rea
 
 Statistics are collected during flush and serialized alongside component files. Readers parse `Statistics.db` to provide summaries and drive decisions (e.g., compaction tuning, bloom FPR reporting).
 
-Pinpoints in Cassandra 5.0.0:
+Pinpoints in Cassandra 5.0.8:
 - `MetadataCollector` gathers live stats during flush (row counts, histograms)
 - `MetadataSerializer` writes and reads the metadata blocks
 - `StatsMetadata` exposes typed accessors for the above
@@ -87,14 +87,18 @@ Statistics.db in Cassandra 5.0 (nb-format) also contains an embedded **Serializa
 The SerializationHeader follows this structure (from `SerializationHeader.java`):
 
 ```
-[VInt pk_type_len] [pk_type_string]           -- partition key type
-[VInt ck_count]                                -- clustering key count
+[UnsignedVInt minTimestamp_delta]              -- 64-bit delta from TIMESTAMP_EPOCH (µs)
+[UnsignedVInt32 minLocalDeletionTime_delta]    -- 32-bit delta from DELETION_TIME_EPOCH (s)
+[UnsignedVInt32 minTTL_delta]                  -- 32-bit delta from TTL_EPOCH (0)
+                                               -- (EncodingStats block: 3–14 bytes total)
+[VInt pk_type_len] [pk_type_string]            -- partition key type
+[UnsignedVInt32 ck_count]                      -- clustering key count
   for each clustering key:
-    [VInt ck_len] [ck_type_string]            -- clustering key type
-[VInt static_count]                            -- static column count (0 if none)
+    [VInt ck_len] [ck_type_string]             -- clustering key type
+[UnsignedVInt32 static_count]                  -- static column count (0 if none)
   for each static column:
     [VInt name_len] [name] [VInt type_len] [type]
-[VInt reg_count]                               -- regular column count
+[UnsignedVInt32 reg_count]                     -- regular column count
   for each regular column:
     [VInt name_len] [name] [VInt type_len] [type]
 ```
@@ -121,11 +125,12 @@ regular_columns: [{name: "row_data", type: "UTF8Type"}, {name: "row_value", type
 ```
 
 ### References
-- Cassandra 5.0.0:
-  - `StatsMetadata`: [org.apache.cassandra.io.sstable.metadata.StatsMetadata](https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/metadata/StatsMetadata.java)
-  - `MetadataCollector`: [org.apache.cassandra.io.sstable.metadata.MetadataCollector](https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/metadata/MetadataCollector.java)
-  - `MetadataSerializer`: [org.apache.cassandra.io.sstable.metadata.MetadataSerializer](https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/metadata/MetadataSerializer.java)
-  - `SerializationHeader`: [org.apache.cassandra.db.SerializationHeader](https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/db/SerializationHeader.java)
+- Cassandra 5.0.8:
+  - [`StatsMetadata`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/metadata/StatsMetadata.java)
+  - [`MetadataCollector`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/metadata/MetadataCollector.java)
+  - [`MetadataSerializer`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/metadata/MetadataSerializer.java)
+  - [`SerializationHeader`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/SerializationHeader.java)
+  - [`EncodingStats`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/rows/EncodingStats.java)
 
 For implementation details, see Appendix C.
 
@@ -151,9 +156,9 @@ Bytes 32+: EncodingStats data
   [VUInt]  43                   - Partitioner string length
   [bytes]  Murmur3Partitioner   - Partitioner class name
   [VUInt]  0, 0                 - Metadata placeholders
-  [VInt]   min_timestamp        - ZigZag encoded microseconds
-  [VInt]   min_deletion_time    - ZigZag encoded seconds
-  [VInt]   min_ttl              - ZigZag encoded seconds
+  [UnsignedVInt]   min_timestamp_delta     - Unsigned VInt 64-bit (delta from TIMESTAMP_EPOCH)
+  [UnsignedVInt32] min_deletion_time_delta - Unsigned VInt32 (delta from DELETION_TIME_EPOCH)
+  [UnsignedVInt32] min_ttl_delta            - Unsigned VInt32 (delta from TTL_EPOCH=0)
 ```
 
 **Magic Number**: The constant `0x26291b05` appears at bytes 4-7 and serves dual purposes:
@@ -173,19 +178,22 @@ The primary purpose of Statistics.db is to provide **baseline values for delta e
 #### min_timestamp
 - **Purpose**: Baseline for timestamp delta encoding
 - **Unit**: Microseconds since Unix epoch
-- **Encoding**: Signed VInt (ZigZag)
+- **Encoding**: `writeUnsignedVInt` (64-bit unsigned VInt, up to 8 bytes; delta from
+  `TIMESTAMP_EPOCH` = Sept 22 2015 in µs). **Not** ZigZag/signed.
 - **Usage**: Data.db encodes cell timestamps as deltas from this value
 
 #### min_local_deletion_time
 - **Purpose**: Baseline for tombstone deletion time encoding
 - **Unit**: Seconds since Unix epoch
-- **Encoding**: Signed VInt (ZigZag, cast from i32)
+- **Encoding**: `writeUnsignedVInt32` (32-bit unsigned VInt, up to 5 bytes; delta from
+  `DELETION_TIME_EPOCH` = Sept 22 2015 in seconds). **Not** ZigZag/signed.
 - **Usage**: Tombstone deletion times in Data.db are encoded as deltas from this value
 
 #### min_ttl
 - **Purpose**: Baseline for TTL delta encoding
 - **Unit**: Seconds
-- **Encoding**: Signed VInt (ZigZag, cast from i32)
+- **Encoding**: `writeUnsignedVInt32` (32-bit unsigned VInt, up to 5 bytes; delta from
+  `TTL_EPOCH` = 0). **Not** ZigZag/signed.
 - **Usage**: Cell TTL values in Data.db are encoded as deltas from this value
 - **Special case**: If no TTL is used in the SSTable, this value is set to 0
 
@@ -201,12 +209,15 @@ The EncodingStats section (starting at byte 32) uses a specific VInt encoding se
    - Length as `VUInt` (43 bytes for Murmur3Partitioner)
    - Full class name: `org.apache.cassandra.dht.Murmur3Partitioner`
 4. **Metadata placeholders** (2x `VUInt` = 0): Purpose unclear, observed in real files
-5. **Delta encoding baselines** (3x `VInt`):
-   - `min_timestamp` (i64)
-   - `min_local_deletion_time` (i32 cast to i64)
-   - `min_ttl` (i32 cast to i64)
+5. **Delta encoding baselines** (3× unsigned VInt):
+   - `min_timestamp` (i64 delta): `writeUnsignedVInt` (64-bit, up to 8 bytes)
+   - `min_local_deletion_time` (i32 delta): `writeUnsignedVInt32` (32-bit, up to 5 bytes)
+   - `min_ttl` (i32 delta): `writeUnsignedVInt32` (32-bit, up to 5 bytes)
 
-**VInt encoding**: All baseline values use signed VInt encoding (ZigZag) to support negative values. See Appendix B for VInt encoding details.
+**VInt encoding**: All baseline values use **unsigned** VInt encoding. Deltas are always
+non-negative (subtracted from their respective epochs). ZigZag (signed) encoding is NOT
+used. Using a 32-bit VInt for `minTimestamp` will corrupt timestamps after 2037. See
+[`EncodingStats.java:272–276`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/rows/EncodingStats.java#L272) and Appendix B for VInt encoding details.
 
 ### Statistics Metadata Collection
 

--- a/docs/sstables-definitive-guide/statistics-db-annotated-dump.txt
+++ b/docs/sstables-definitive-guide/statistics-db-annotated-dump.txt
@@ -31,15 +31,16 @@ TOC Entry 3 (HEADER):
 0x0020: 00 00 00 03  ← component_type (u32 BE) = 3
 0x0024: 00 00 1d 2b  ← component_offset (u32 BE) = 0x1d2b (7467 bytes)
 
-[Padding/unused: 0x0028-0x002b = 4 bytes]
-0x0028: 09 66 82 16  ← (appears to be start of next section or padding)
+0x0028: 09 66 82 16  ← toc_block_checksum (CRC32 over all TOC entries, 4 bytes)
+                       MetadataSerializer.java:96 — second maybeWriteChecksum() call
 
 ================================================================================
 VALIDATION COMPONENT - Offset 0x002c to 0x0060 (53 bytes)
 ================================================================================
 
-0x002c: 00           ← reserved (u8) = 0x00
-0x002d: 2b           ← partitioner_len (VInt) = 43 bytes
+0x002c: 00 2b        ← partitioner_len (u16 BE) = 43 — Java writeUTF 2-byte length prefix
+                       ValidationMetadata.java:81: out.writeUTF(component.partitioner)
+                       (high byte 0x00 at 0x002c, low byte 0x2b at 0x002d)
 
 Partitioner string (43 bytes UTF-8):
 0x002e: 6f 72 67 2e 61 70 61 63 68 65 2e 63 61 73 73  "org.apache.cass"
@@ -91,11 +92,14 @@ For brevity, showing only first 128 bytes:
 HEADER COMPONENT (SerializationHeader) - Offset 0x1d2b to 0x2122 (1016 bytes)
 ================================================================================
 
-Unknown VInt field (7 bytes):
-0x1d2b: fd 20 28 75 dc 45 19  ← Multi-byte VInt (purpose unclear)
-
-Marker (start of partition key descriptor):
-0x1d32: 00 00  ← 0x00 0x00 marker
+EncodingStats block (SerializationHeader.java:453, EncodingStats.java:272–276):
+0x1d2b: fd 20 28 75 dc 45 19  ← minTimestamp_delta (UnsignedVInt 64-bit, 7 bytes)
+                                 ≈316 trillion µs from TIMESTAMP_EPOCH (~10 years)
+0x1d32: 00                    ← minLocalDeletionTime_delta (UnsignedVInt32, 1 byte) = 0
+                                 delta from DELETION_TIME_EPOCH (Sept 22 2015 in seconds)
+0x1d33: 00                    ← minTTL_delta (UnsignedVInt32, 1 byte) = 0
+                                 delta from TTL_EPOCH = 0 (no TTL in this SSTable)
+                              ── EncodingStats ends (9 bytes total); keyType follows ──
 
 Partition Key Type:
 0x1d34: 28     ← pk_type_len (VInt) = 40 bytes
@@ -106,8 +110,10 @@ Partition Key Type:
 Clustering Key Count:
 0x1d5d: 00     ← ck_count (VInt) = 0 (no clustering keys)
 
-Regular Column Marker:
-0x1d5e: 00 12  ← reg_col_marker = 0x0012 (possibly column count: 18 decimal)
+Static and Regular Column Counts:
+0x1d5e: 00     ← static_count (UnsignedVInt32) = 0 (no static columns)
+0x1d5f: 12     ← reg_count (UnsignedVInt32) = 18 regular columns
+               SerializationHeader.java:458-459
 
 --------------------------------------------------------------------------------
 Regular Column 1: account_balance
@@ -171,9 +177,9 @@ CRITICAL NOTES FOR WRITER IMPLEMENTATION:
 2. TOC checksum MUST match Cassandra's CRC32 algorithm
 3. All strings are UTF-8 with VInt length prefix
 4. All integers are BIG ENDIAN
-5. VALIDATION component has a mysterious 0x00 reserved byte before partitioner
-6. HEADER component has a mysterious 7-byte VInt before the 0x00 0x00 marker
-7. Regular column marker (0x00 0x12) may indicate column count (18 decimal)
+5. VALIDATION `partitioner_len` is a 2-byte big-endian prefix (Java writeUTF); no reserved byte
+6. HEADER component STARTS with EncodingStats (3 unsigned VInt deltas) before pk_type
+7. `static_count` (0x00) and `reg_count` (0x12 = 18) are separate UnsignedVInt32 fields
 
 For MVP writer implementation (Issue #328):
 - Focus on VALIDATION and HEADER components (fully documented above)

--- a/docs/sstables-definitive-guide/statistics-db-writer-spec.md
+++ b/docs/sstables-definitive-guide/statistics-db-writer-spec.md
@@ -12,7 +12,9 @@ This specification documents the EXACT binary format needed to write valid Stati
 ## 1. File Structure Overview
 
 Statistics.db consists of:
-1. **TOC (Table of Contents)** - 8 + (8 × num_components) bytes
+1. **TOC (Table of Contents)** - `4 + (2 × 4) + (8 × num_components)` bytes for checksummed
+   versions (`nb`/`oa`), or `4 + (8 × num_components)` bytes without checksums. For 4
+   components with checksums: `4 + 8 + 32 = 44` bytes (VALIDATION starts at `0x002c`).
 2. **Component data sections** - VALIDATION, COMPACTION, STATS, HEADER
 
 **Key Encoding Rules**:
@@ -42,17 +44,18 @@ Statistics.db consists of:
 | `0x0020` | 4    | u32 BE  | `component_type`  | 3 (HEADER)                       |
 | `0x0024` | 4    | u32 BE  | `component_offset`| `0x1d2b` (7467 bytes)           |
 
-**TOC ends at**: `0x0028` (40 bytes)
+**TOC ends at**: `0x002b` (44 bytes for checksummed nb/oa). The 4 bytes at `0x0028`–`0x002b` are
+the `toc_block_checksum` (CRC32 over all TOC entries, `MetadataSerializer.java:96`), not padding.
 
 ### MetadataType Enum
 
-From `org.apache.cassandra.db.commitlog.CommitLogSegment.MetadataType`:
+From [`org.apache.cassandra.io.sstable.metadata.MetadataType`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/metadata/MetadataType.java):
 
 | Value | Name        | Description                              |
 |-------|-------------|------------------------------------------|
 | 0     | VALIDATION  | Partitioner, bloom filter settings       |
 | 1     | COMPACTION  | Ancestor histograms, cardinality         |
-| 2     | STATS       | EncodingStats, distribution histograms   |
+| 2     | STATS       | Full `StatsMetadata` (26 version-gated fields; histograms, timestamps, repair info) |
 | 3     | HEADER      | SerializationHeader (column schema)      |
 
 ---
@@ -68,8 +71,7 @@ From `org.apache.cassandra.db.commitlog.CommitLogSegment.MetadataType`:
 
 | Offset   | Size | Type    | Field Name         | Value                                              |
 |----------|------|---------|--------------------|---------------------------------------------------|
-| `0x002c` | 1    | u8      | `reserved`         | `0x00` (always 0x00, purpose unclear)             |
-| `0x002d` | 1    | VInt    | `partitioner_len`  | `0x2b` (43 bytes)                                 |
+| `0x002c` | 2    | u16 BE  | `partitioner_len`  | `0x00 0x2b` = 43 (Java `writeUTF` 2-byte length prefix) |
 | `0x002e` | 43   | UTF-8   | `partitioner`      | `org.apache.cassandra.dht.Murmur3Partitioner`     |
 | `0x0059` | 8    | f64 BE  | `bloom_fp_chance`  | `0.01` (1% false positive rate)                   |
 
@@ -77,8 +79,8 @@ From `org.apache.cassandra.db.commitlog.CommitLogSegment.MetadataType`:
 
 ### Writer Notes
 
-- `reserved` byte is always `0x00` (possibly version/flags for future use)
-- `partitioner_len` is a single-byte VInt for strings < 128 bytes
+- `partitioner_len` is a **2-byte big-endian** length prefix written by Java `DataOutput.writeUTF`
+  (e.g., `0x00 0x2b` = 43 for Murmur3Partitioner). No reserved byte precedes it.
 - Standard Murmur3 partitioner string is 43 bytes
 - `bloom_fp_chance`: Typical value is `0.01` (1%) or `0.001` (0.1%)
 
@@ -107,7 +109,7 @@ Contains complex `EstimatedHistogram` structures for:
 
 - For MVP writer: Use minimal stub (empty/zero histogram data)
 - Future: Implement full `MetadataCollector` serialization
-- Cassandra source: `org.apache.cassandra.db.compaction.CompactionMetadata`
+- Cassandra source: [`org.apache.cassandra.io.sstable.metadata.CompactionMetadata`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/metadata/CompactionMetadata.java)
 
 ---
 
@@ -120,10 +122,13 @@ Contains complex `EstimatedHistogram` structures for:
 
 ### Structure
 
-Contains:
-- `EstimatedHistogram` for partition sizes
-- `EstimatedHistogram` for cell counts per row
-- `EncodingStats` (min_timestamp, min_deletion_time, min_ttl)
+Contains the full `StatsMetadata` serialization (26 version-gated fields including
+`EstimatedHistogram` for partition sizes and cell counts per row, commit-log positions,
+min/max timestamps, deletion times, TTL, compression ratio, `TombstoneHistogram`,
+level, repair metadata, clustering bounds, and more). See `StatsMetadata.java:402–513`.
+
+> **Note**: `EncodingStats` is NOT a sub-block inside the STATS component. It is the
+> leading field of the HEADER component only (`SerializationHeader.java:453`).
 
 **First 64 bytes** (observed):
 ```
@@ -135,10 +140,18 @@ Contains:
 
 ### Writer Notes (DEFERRED TO FUTURE MILESTONE)
 
-- EncodingStats fields are embedded within larger `MetadataCollector` structure
+- `StatsMetadata` is the full serialization (26 fields); `EncodingStats` is the leading
+  field of the HEADER component, not an embedded sub-block here.
 - For MVP writer: Use minimal stub with zero/empty histograms
-- Future: Implement full `MetadataCollector` with real statistics
+- Future: Implement full `StatsMetadata` serializer with version gates
 - **Note**: Current `enhanced_statistics_parser.rs` ONLY extracts EncodingStats
+
+> **TombstoneHistogram legacy format (pre-`oa`)**: The `LegacyHistogramSerializer`
+> writes deletion time as `double` (8 bytes) and tombstone count as `long` (8 bytes)
+> per entry — NOT `int` (4 bytes). Total per entry = 16 bytes (`TombstoneHistogram.java:155–156`).
+> The modern serializer (`oa`+) writes `long` (8) + `int` (4) = 12 bytes per entry.
+> Also: `HistogramSerializer.serializedSize` over-allocates by `4 × histSize` bytes
+> (stale comment assumes 16 bytes/entry); do not use it as a wire-byte guarantee.
 
 ---
 
@@ -151,15 +164,16 @@ Contains:
 
 ### Binary Format
 
-| Offset   | Size | Type    | Field Name         | Value                                              |
-|----------|------|---------|--------------------|---------------------------------------------------|
-| `0x1d2b` | 7    | VInt    | `unknown_field`    | Multi-byte VInt (purpose unclear)                 |
-|          |      |         |                    | Raw: `fd 20 28 75 dc 45 19`                       |
-| `0x1d32` | 2    | u8[2]   | `marker`           | `0x00 0x00` (start of pk descriptor)              |
-| `0x1d34` | 1    | VInt    | `pk_type_len`      | `0x28` (40 bytes)                                 |
-| `0x1d35` | 40   | UTF-8   | `pk_type`          | `org.apache.cassandra.db.marshal.UUIDType`        |
-| `0x1d5d` | 1    | VInt    | `ck_count`         | `0x00` (0 clustering keys)                        |
-| `0x1d5e` | 2    | u8[2]   | `reg_col_marker`   | `0x00 0x12` (possibly column count: 0x12 = 18)   |
+| Offset   | Size   | Type                  | Field Name                   | Value                                                   |
+|----------|--------|-----------------------|------------------------------|---------------------------------------------------------|
+| `0x1d2b` | 7      | UnsignedVInt (64-bit) | `minTimestamp_delta`         | `fd 20 28 75 dc 45 19` (~316 T µs from TIMESTAMP_EPOCH) |
+| `0x1d32` | 1      | UnsignedVInt32        | `minLocalDeletionTime_delta` | `0x00` (no deletions; delta from DELETION_TIME_EPOCH)   |
+| `0x1d33` | 1      | UnsignedVInt32        | `minTTL_delta`               | `0x00` (no TTL; delta from TTL_EPOCH = 0)               |
+| `0x1d34` | 1      | VInt                  | `pk_type_len`                | `0x28` (40 bytes)                                       |
+| `0x1d35` | 40     | UTF-8                 | `pk_type`                    | `org.apache.cassandra.db.marshal.UUIDType`              |
+| `0x1d5d` | 1      | UnsignedVInt32        | `ck_count`                   | `0x00` (0 clustering keys)                              |
+| `0x1d5e` | 1      | UnsignedVInt32        | `static_count`               | `0x00` (0 static columns)                               |
+| `0x1d5f` | 1      | UnsignedVInt32        | `reg_count`                  | `0x12` = 18 regular columns                             |
 
 ### Regular Column Format (repeats for each column)
 
@@ -172,20 +186,29 @@ Contains:
 | `0x1d70` | 1    | VInt    | `col_type_len`     | `0x2b` (43 bytes)                                 |
 | `0x1d71` | 43   | UTF-8   | `col_type`         | `org.apache.cassandra.db.marshal.DecimalType`     |
 
-This pattern repeats for all 19 regular columns.
+This pattern repeats for all 18 regular columns.
 
 ### Complete SerializationHeader Structure
 
-1. **unknown_vint** (7 bytes in this file): Purpose unclear, varies per file
-2. **marker** (2 bytes): `0x00 0x00` - Start of partition key type descriptor
-3. **pk_type_len** (VInt): Length of partition key type string
-4. **pk_type** (UTF-8): CQL type descriptor
-5. **ck_count** (VInt): Number of clustering keys (0 for simple tables)
-6. **(If ck_count > 0)**: For each clustering key:
+The HEADER component MUST begin with `EncodingStats` before any key-type data
+(`SerializationHeader.java:453`). A writer that omits EncodingStats shifts every
+subsequent field and produces a file Cassandra cannot parse.
+
+1. **EncodingStats** (3–14 bytes, variable): Three unsigned VInt delta fields:
+   - `minTimestamp_delta`: `writeUnsignedVInt` (64-bit, up to 8 bytes)
+   - `minLocalDeletionTime_delta`: `writeUnsignedVInt32` (32-bit, up to 5 bytes)
+   - `minTTL_delta`: `writeUnsignedVInt32` (32-bit, up to 5 bytes)
+2. **pk_type_len** (VInt): Length of partition key type string
+3. **pk_type** (UTF-8): CQL type descriptor
+4. **ck_count** (UnsignedVInt32): Number of clustering keys (0 for simple tables)
+5. **(If ck_count > 0)**: For each clustering key:
    - `ck_type_len` (VInt)
    - `ck_type` (UTF-8)
-7. **reg_col_marker** (2 bytes): `0x00 0x12` in this file
-8. **For each regular column** (19 in this file):
+6. **static_count** (UnsignedVInt32): Number of static columns (0 if none)
+7. **(If static_count > 0)**: For each static column:
+   - `col_name_len` (VInt), `col_name` (UTF-8), `col_type_len` (VInt), `col_type` (UTF-8)
+8. **reg_count** (UnsignedVInt32): Number of regular columns (18 in this file)
+9. **For each regular column** (18 in this file):
    - `col_name_len` (VInt)
    - `col_name` (UTF-8)
    - `col_type_len` (VInt)
@@ -296,9 +319,17 @@ fn encode_vint(value: i64) -> Vec<u8> {
 
 ## 11. References
 
-- **Cassandra Source**: `org.apache.cassandra.io.sstable.metadata.MetadataSerializer`
-- **CQLite Parser**: `/Users/patrick/local_projects/cqlite/cqlite-core/src/parser/enhanced_statistics_parser.rs`
-- **Reference File**: `/Users/patrick/local_projects/cqlite/test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Statistics.db`
+- [`MetadataSerializer.java`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/metadata/MetadataSerializer.java)
+- [`MetadataType.java`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/metadata/MetadataType.java)
+- [`ValidationMetadata.java`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/metadata/ValidationMetadata.java)
+- [`CompactionMetadata.java`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/metadata/CompactionMetadata.java)
+- [`StatsMetadata.java`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/metadata/StatsMetadata.java)
+- [`SerializationHeader.java`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/SerializationHeader.java)
+- [`EncodingStats.java`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/rows/EncodingStats.java)
+- [`EstimatedHistogram.java`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/utils/EstimatedHistogram.java)
+- [`TombstoneHistogram.java`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/utils/streamhist/TombstoneHistogram.java)
+- **CQLite Parser**: `cqlite-core/src/parser/enhanced_statistics_parser.rs`
+- **Reference File**: `test-data/datasets/sstables/test_basic/simple_table-.../nb-1-big-Statistics.db`
 
 ---
 


### PR DESCRIPTION
## Summary
Audit batch B4 (epic #598). Fixes Ch.08 + statistics-db-writer-spec.md (writer-critical; drives CQLite's Statistics.db writer).

Data-corruption-class corrections:
- EncodingStats fields are **unsigned VInt**, not 'Signed VInt (ZigZag)' (`EncodingStats.java:272-276`)
- HEADER component begins with EncodingStats (up to 9 bytes) BEFORE pk_type — the spec's 'unknown 7-byte VInt + 0x00 0x00 marker' was EncodingStats all along
- VALIDATION 'reserved byte' is the high byte of Java writeUTF's 2-byte BE length prefix
- TOC size formula, MetadataType FQCN, legacy TombstoneHistogram writeLong, static/regular column counts also fixed

Note: CQLite's Rust `stats_writer.rs` was checked — already encodes EncodingStats correctly; no code change needed.

Closes #602. Part of epic #598.