### PR TITLE
docs(guide): fix BTI format chapter vs cassandra-5.0.8 (#604)

### DIFF
--- a/docs/sstables-definitive-guide/chapters/17-bti-formats.md
+++ b/docs/sstables-definitive-guide/chapters/17-bti-formats.md
@@ -1,4 +1,4 @@
-## BTI (B-Tree/Trie Indexed) Formats
+## BTI (Big Trie-Indexed) Formats
 
 BTI is the modern SSTable index format introduced to improve lookup efficiency, cache locality, and on-disk structure over the classic `big` family. Instead of a single `Index.db` plus sampled `Summary.db`, BTI splits indexing into trie-structured files that directly encode byte-comparable keys, reducing indirection and making prefix and range navigation more predictable. This chapter contrasts BTI with big/mc/mm and calls out practical impacts on read amplification.
 
@@ -9,19 +9,19 @@ BTI is the modern SSTable index format introduced to improve lookup efficiency, 
 - Practical implications for latency
 
 ## Motivation and Structure
-BTI (B-Tree/Trie Indexed) replaces the classic `big` index structure with trie-based indexes that favor prefix navigation and reduce binary-search hops across large sampled summaries. In Cassandra 5.0, BTI artifacts live alongside the data file and statistics:
+BTI (Big Trie-Indexed) replaces the classic `big` index structure with trie-based indexes that traverse keys byte-by-byte instead of binary-searching a sampled summary—reading less data and requiring less processing per lookup, with equivalent seek counts on a match ([`BtiFormat.md` lines 581–589](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/bti/BtiFormat.md#L581)). In Cassandra 5.0, BTI artifacts live alongside the data file and statistics:
 
 ### Connection to In-Memory Tries: The Efficiency Foundation
 
 > **Cross-reference**: This section connects to [Chapter 4: From CQL to Disk](./04-from-cql-to-disk.md), which covers the flush pipeline from memtable to SSTable.
 
-BTI's efficiency is not just an on-disk optimization—it is architecturally aligned with Cassandra 5.0's in-memory `TrieMemtable`. The on-disk BTI structure is essentially a **direct persistence of the efficient in-memory trie concepts**, which dramatically reduces flush complexity and overhead.
+BTI's efficiency is not just an on-disk optimization—it is architecturally aligned with Cassandra 5.0's in-memory `TrieMemtable`. Both use byte-comparable keys and trie organisation, but the flush path constructs a new on-disk trie incrementally from the memtable iterator; it is **not** a raw serialisation of the in-memory trie.
 
 **Key alignment points:**
 
 1. **Identical byte-comparable representation**: Both `TrieMemtable` and BTI use `ByteComparable.Version.OSS50` for partition key encoding. This means keys in memory are already in the exact format needed for the on-disk trie—no transformation required during flush.
 
-2. **No sorting pass required**: Traditional memtables (like the older `SkipListMemtable`) stored data in a structure that required iteration to produce sorted output. The `TrieMemtable` stores partition keys in a trie that is inherently sorted by byte-comparable order. The `entryIterator()` method walks the trie and emits partitions in exactly the order BTI expects.
+2. **No sorting pass required**: `SkipListMemtable` (the compiled-in default factory in Cassandra 5.0 unless overridden in `cassandra.yaml`; see [`MemtableParams.java:99`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/schema/MemtableParams.java#L99)) stored data in a structure that required iteration to produce sorted output. `TrieMemtable` is an opt-in alternative: it stores partition keys in a trie that is inherently sorted by byte-comparable order. The `entryIterator()` method walks the trie and emits partitions in exactly the order BTI expects.
 
 3. **Prefix sharing preserved**: The in-memory trie shares prefixes between partition keys (e.g., keys `user:alice` and `user:bob` share the `user:` prefix). During flush, the `IncrementalTrieWriter` constructs the on-disk trie incrementally and naturally preserves this prefix structure.
 
@@ -44,11 +44,19 @@ for entry in memtableTrie.entryIterator():    // Already sorted!
 //   - Uses IncrementalTrieWriter for page-aware output
 ```
 
-**Position encoding trick:** The partition index uses position sign to distinguish pointer types:
+**Position encoding trick:** The partition index uses position sign to distinguish pointer types ([`BtiFormat.md` lines 965–971](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/bti/BtiFormat.md#L965)):
 - **Positive position** → points to row index file (`Rows.db`) for wide partitions
 - **Negative position (`~dataPosition`)** → bitwise NOT of direct `Data.db` offset (e.g., position 0 → -1, position 1 → -2)
 
 This encoding eliminates the need for a separate flag field and allows the reader to immediately know whether to consult the row index.
+
+**Hash byte (Cassandra 5.0 always present):** Every leaf node in the partition trie carries a hash
+byte before the position value. This byte holds the lowest 8 bits of the partition key's filter
+hash and allows fast mismatch rejection without reading the full key from disk. When
+`payloadBits >= 8` (`FLAG_HAS_HASH_BYTE = 8`), byte 0 at the payload position is the hash byte
+and bytes 1–(`payloadBits`−8+1) encode the position. In Cassandra 5.0 the hash byte is
+**always written** ([`PartitionIndex.java:131–135`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/bti/PartitionIndex.java#L131);
+[`BtiFormat.md` lines 946–963](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/bti/BtiFormat.md#L946)).
 
 **Why this matters for performance:**
 
@@ -59,25 +67,31 @@ This encoding eliminates the need for a separate flag field and allows the reade
 | Prefix sharing | None (full keys in Index.db) | Preserved memory→disk |
 | Construction passes | Multiple (data, index, summary) | Single incremental pass |
 
-This alignment was intentionally designed as described in the [VLDB 2022 paper](https://www.vldb.org/pvldb/vol15/p3359-lambov.pdf) that introduced `TrieMemtable` to Cassandra.
+This alignment was intentionally designed as described in the [VLDB 2022 paper](https://www.vldb.org/pvldb/vol15/p3359-lambov.pdf) that introduced `TrieMemtable` to Cassandra [external citation — not verified against 5.0.8 source].
 
 **Where to look in source:**
-- `TrieMemtable`: `org.apache.cassandra.db.memtable.TrieMemtable` — see `getFlushSet()` method (lines 360-493)
-  - [https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/db/memtable/TrieMemtable.java](https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/db/memtable/TrieMemtable.java)
+- `TrieMemtable`: `org.apache.cassandra.db.memtable.TrieMemtable` — see `getFlushSet()` method (lines 350–403)
+  - [https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/memtable/TrieMemtable.java](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/memtable/TrieMemtable.java)
 - `PartitionIndexBuilder`: `org.apache.cassandra.io.sstable.format.bti.PartitionIndexBuilder` — builds `Partitions.db` from sorted byte-comparable keys
-  - [https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/format/bti/PartitionIndexBuilder.java](https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/format/bti/PartitionIndexBuilder.java)
+  - [https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/bti/PartitionIndexBuilder.java](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/bti/PartitionIndexBuilder.java)
 - `IncrementalTrieWriter`: `org.apache.cassandra.io.tries.IncrementalTrieWriter` — incremental trie construction from sorted input
-  - [https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/tries/IncrementalTrieWriter.java](https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/tries/IncrementalTrieWriter.java)
+  - [https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/tries/IncrementalTrieWriter.java](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/tries/IncrementalTrieWriter.java)
 
 - BTI-specific components: `Partitions.db` (partition trie), `Rows.db` (per-partition clustering trie)
 - Common components retained: `Data.db`, `Statistics.db`, `TOC.txt`, `Digest.crc32`, `CompressionInfo.db` (when compressed)
 
+> **Note**: BTI format SSTables do **not** include `Index.db` or `Summary.db`. These are
+> components of the classic `big` format only. The complete required BTI component set is:
+> `Data.db`, `Partitions.db`, `Rows.db`, `Statistics.db`, `TOC.txt`, `Digest.crc32`, and
+> optionally `CompressionInfo.db`
+> ([`BtiFormat.java:83–102`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/bti/BtiFormat.java#L83)).
+
 Where to look in source:
-- Cassandra 5.0.0 (pinned): `org.apache.cassandra.io.sstable.format.bti` — see package directory
-  - `https://github.com/apache/cassandra/tree/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/format/bti`
+- Cassandra 5.0.8 (pinned): `org.apache.cassandra.io.sstable.format.bti` — see package directory
+  - `https://github.com/apache/cassandra/tree/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/bti`
 - Classic big format for comparison:
   - Reader: `BigTableReader`
-    `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java`
+    `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java`
 
 Sidebar: Version Differences
 BTI is a Cassandra 5.x format family. Older releases rely on `big` plus `Index.db`/`Summary.db`. Readers should expect co-existence during upgrades; mixed-format directories are normal during transitions.
@@ -89,7 +103,7 @@ Conceptual contrast (trimmed):
 - BTI: `Partitions.db` trie → partition payload; then `Rows.db` trie (within-partition) → row payload in `Data.db`
 
 Illustrative bullets:
-- Fewer binary-search steps against sampled summaries; trie traversal uses byte-wise transitions
+- Trie traversal reads less data and requires less processing per lookup than binary-searching sampled summaries; seek counts on a match are equivalent to the `big` format
 - Better prefix navigation for wide-partition clustering keys
 - Similar Bloom filter role for negative lookups; statistics unchanged
 - Mixed deployments are supported; compaction/upgrade can rewrite formats
@@ -114,6 +128,46 @@ advance(trie, prefix_bytes):
 
 Effectively, prefix seek walks byte-by-byte until divergence, then takes the first branch ≥ the requested byte; this contrasts with BIG’s binary search over sampled entries in `Summary.db` followed by scans in `Index.db`.
 
+### Trie node type families
+
+Every trie node starts with one byte: high nibble (bits 7–4) = 4-bit node-type ordinal (0–15);
+low nibble (bits 3–0) = 4 payload flag bits (_pb_). Four families
+([`BtiFormat.md` lines 806–877](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/bti/BtiFormat.md#L806);
+[`TrieNode.java:947–969`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/tries/TrieNode.java#L947)):
+
+| Family | Ordinals | Description |
+|--------|----------|-------------|
+| `PAYLOAD_ONLY` | 0 | Leaf; no transitions |
+| `SINGLE` | 1–4 | One child; 4-/8-/12-/16-bit distance |
+| `SPARSE` | 5–9 | Binary-searched byte list; 8- to 40-bit distances |
+| `DENSE` | 10–15 | Consecutive byte range; 12- to 64-bit distances (`LONG_DENSE` catch-all) |
+
+All distances are unsigned and subtracted from the current node position (children are earlier
+in the file). See Appendix C for complete per-type byte layouts.
+
+### `Rows.db` per-partition footer
+
+Each partition's row index in `Rows.db` is padded to a 4096-byte page boundary. After the trie
+pages the footer contains, in order
+([`BtiFormat.md` lines 977–1010](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/bti/BtiFormat.md#L977);
+[`TrieIndexEntry.java:92–116`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/bti/TrieIndexEntry.java#L92)):
+
+1. Partition key (short-length-prefixed bytes)
+2. Data file position of the partition start (unsigned vint)
+3. Root node position: signed vint delta relative to the data file position
+4. Row count in the partition (unsigned vint)
+5. Partition deletion time (12 bytes: local deletion time int + marked-for-delete-at long)
+
+The partition index (`Partitions.db`) points to the position of the partition key bytes (step 1).
+
+### Row index granularity
+
+The row index does not index every row—it indexes blocks. The default block size is **at least
+16 KB** of serialised row data, controlled by the `column_index_size` parameter in
+`cassandra.yaml`. Separator keys (the shortest prefix greater than the last key of the prior
+block) are stored, not exact start keys, keeping the index compact
+([`BtiFormat.md` lines 646–653](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/bti/BtiFormat.md#L646)).
+
 ## Performance Considerations and Benchmark Methodology
 
 Note: Provide methodology and harness only; do not claim specific results here.
@@ -134,17 +188,26 @@ Note: Provide methodology and harness only; do not claim specific results here.
   - Report confidence intervals; avoid extrapolating beyond tested sizes
 
 ### Key Takeaways
-- BTI uses trie indexes (`Partitions.db`/`Rows.db`) instead of `Index.db`/`Summary.db`.
-- Trie traversal replaces some binary searches, improving predictability for wide partitions.
+- BTI stands for **Big Trie-Indexed**; it uses trie indexes (`Partitions.db`/`Rows.db`) and does not include `Index.db` or `Summary.db`.
+- Trie traversal reads less data and requires less CPU per lookup than binary-searching sampled summaries; seek counts on a match are equivalent.
+- Every partition-index leaf node carries a hash byte (`FLAG_HAS_HASH_BYTE = 8`) for fast mismatch rejection—always present in Cassandra 5.0.
+- `SkipListMemtable` remains the compiled-in default in Cassandra 5.0; `TrieMemtable` is opt-in via `cassandra.yaml`.
+- The row index operates on 16 KB blocks (configurable via `column_index_size`), not individual rows.
 - Bloom filters and statistics continue to guide/guard the read path.
 - Mixed-format directories occur during upgrades; readers must detect format.
 For implementation details, see Appendix C.
 
 ### References
-- Cassandra 5.0.0:
-  - BTI package: `https://github.com/apache/cassandra/tree/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/format/bti`
-  - Big format reader (contrast): `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java`
-  
+- Cassandra 5.0.8 (pinned):
+  - BTI package: `https://github.com/apache/cassandra/tree/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/bti`
+  - Authoritative in-tree spec: `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/bti/BtiFormat.md`
+  - `BtiFormat.java` (component sets): `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/bti/BtiFormat.java#L83`
+  - `PartitionIndex.java` (hash byte, position encoding): `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/bti/PartitionIndex.java`
+  - `TrieNode.java` (node types): `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/tries/TrieNode.java#L947`
+  - `PageAware.java` (4096-byte page constant): `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/util/PageAware.java#L24`
+  - `MemtableParams.java` (default factory): `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/schema/MemtableParams.java#L99`
+  - Big format reader (contrast): `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java`
+
 For implementation details, see Appendix C.
 
 


### PR DESCRIPTION
## Summary
Audit batch B6 (epic #598). Fixes Ch.17 against Cassandra 5.0.8 source and the in-tree BtiFormat.md/Trie.md specs.

Key fixes:
- BTI = 'Big Trie-Indexed' (BtiFormat.md:24), not 'B-Tree/Trie Indexed'
- Added partition-index hash byte (FLAG_HAS_HASH_BYTE = 8, always written in 5.0) to position-encoding description
- SkipListMemtable reframed as the still-current compiled-in default; TrieMemtable opt-in
- New subsections: trie node-type families, Rows.db per-partition footer, row-index granularity (16 KB blocks), explicit Index.db/Summary.db absence
- Permalinks re-pinned to cassandra-5.0.8 + 6 new BtiFormat.md citations

Ch.21/Ch.22 BTI findings handled in #600/#608 PRs. Closes #604. Part of epic #598.