### PR TITLE
docs(guide): fix SAI chapters + add vector on-disk format vs cassandra-5.0.8 (#605)

### DIFF
--- a/docs/sstables-definitive-guide/chapters/13-secondary-indexes.md
+++ b/docs/sstables-definitive-guide/chapters/13-secondary-indexes.md
@@ -10,10 +10,12 @@ One-paragraph summary: Introduce per-table local indexes, their storage interact
 
 ## Storage and Lifecycle
 
-Secondary indexes (2i) are local, per-table indexes that map a non-primary-key column value to the base table’s primary key. In Cassandra 5.0, built-in 2i implementations attach to the table via the `org.apache.cassandra.index.Index` API and maintain their own index memtables and SSTables. They flush and compact independently of the base table, but reads ultimately retrieve rows from the base table’s `Data.db`.
+Secondary indexes (2i) are local, per-table indexes that map a non-primary-key column value to the base table's primary key. In Cassandra 5.0, built-in 2i implementations attach to the table via the `org.apache.cassandra.index.Index` API and maintain their own index memtables and SSTables. They flush and compact independently of the base table, but reads ultimately retrieve rows from the base table's `Data.db`.
 
-- Index data model: value → set of row identifiers (partition key plus clustering key as needed).
-- Storage: hidden, per-index SSTables managed by the index implementation. These files follow the table’s lifecycle (flush/compaction) but are separate artifacts.
+The built-in implementation is `CassandraIndex` (internal name `legacy_local_table`), which is considered legacy in Cassandra 5.0; SAI is the recommended replacement for new indexes.
+
+- Index data model: value -> set of row identifiers (partition key plus clustering key as needed).
+- Storage: hidden, per-index SSTables managed by the index implementation. These files follow the table's lifecycle (flush/compaction) but are separate artifacts.
 - Local scope: indexes do not span multiple nodes; coordinator nodes query relevant replicas and merge results.
 - Consistency: index updates are part of the base table mutation path; the base row remains the source of truth during reads.
 
@@ -31,7 +33,7 @@ Tiny example (conceptual):
 2. Query: `SELECT id FROM users WHERE email = 'a@example.com' AND age >= 30;`
 3. Execution:
    - 2i lookup yields candidate keys: `{id1, id2, id3}` for `email='a@example.com'`.
-   - Fetch rows from `Data.db` using the normal read path (Bloom → Index → Summary → Data).
+   - Fetch rows from `Data.db` using the normal read path (Bloom -> Index -> Summary -> Data).
    - Apply `age >= 30` as a post-filter to the fetched rows.
 
 Notes:
@@ -56,22 +58,20 @@ Notes:
 ### Complexity Notes
 
 - Equality lookup in 2i: O(log S + K) per segment (binary search/lookup plus iterating K candidates), where S is index segment size.
-- Fetch/validation from base SSTables follows normal read-path complexity (see Ch. 10–12). Overall cost scales with candidate set size.
+- Fetch/validation from base SSTables follows normal read-path complexity (see Ch. 10-12). Overall cost scales with candidate set size.
 
 ### Key Takeaways
 - 2i are local, per-index SSTables that map values to primary keys; base table remains authoritative.
 - Reads consult the index to produce candidate keys, then fetch and filter base rows.
 - Works well for selective equality (and small IN) predicates; avoid low-cardinality columns.
-- 2i lifecycle (flush/compact) is independent but coordinated with the table’s write path.
+- 2i lifecycle (flush/compact) is independent but coordinated with the table's write path.
 - Prefer SAI for range, LIKE, and vector searches in Cassandra 5.0.
 
 ### References
-- Cassandra 5.0.0
-  - Index API: `org.apache.cassandra.index.Index` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/index/Index.java`
-  - Built-in 2i base: `org.apache.cassandra.index.internal.CassandraIndex` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/index/internal/CassandraIndex.java`
-  - Keys index: `org.apache.cassandra.index.internal.KeysIndex` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/index/internal/KeysIndex.java`
-  - Composite index: `org.apache.cassandra.index.internal.CompositesIndex` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/index/internal/CompositesIndex.java`
-  
+- Cassandra 5.0.8
+  - Index API: `org.apache.cassandra.index.Index` -- `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/index/Index.java`
+  - Built-in 2i base (legacy): `org.apache.cassandra.index.internal.CassandraIndex` -- `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/index/internal/CassandraIndex.java`
+  - Keys searcher: `org.apache.cassandra.index.internal.keys.KeysSearcher` -- `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/index/internal/keys/KeysSearcher.java`
+  - Composites searcher: `org.apache.cassandra.index.internal.composites.CompositesSearcher` -- `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/index/internal/composites/CompositesSearcher.java`
+
 For implementation details, see Appendix C.
-
-

--- a/docs/sstables-definitive-guide/chapters/14-storage-attached-indexes-sai.md
+++ b/docs/sstables-definitive-guide/chapters/14-storage-attached-indexes-sai.md
@@ -5,20 +5,176 @@ One-paragraph summary: Cover SAI data structures and files, lifecycle with SSTab
 ### In this chapter you will learn
 - SAI on-disk structures and segments
 - How SAI integrates with SSTable lifecycle
+- Vector index component files, HNSW graph layout, and ANN query path
 - Query paths for range/LIKE and vector similarity
 - Practical examples and limitations
 
 ## File Layout and Segments
 
-SAI builds per-column indexes that are persisted alongside the base table’s SSTables. Each indexed column produces one or more immutable on-disk segments. During flush and compaction, new SAI segments are created and old ones are merged according to index policy, independently of the base table’s SSTables.
+SAI builds per-column indexes that are persisted alongside the base table's SSTables. Each indexed column produces one or more immutable on-disk segments. During flush and compaction, new SAI segments are created and old ones are merged according to index policy, independently of the base table's SSTables.
 
 - Per-column indexing: each indexed column (numeric, text, vector) has its own writer/reader and set of segment files.
 - Segments are immutable: new segments are added on flush; compactions merge segments and drop obsolete postings.
 - Base-table authority: SAI returns candidate primary keys; rows are materialized via the normal read path against `Data.db`.
 
+SAI 5.0 uses a single on-disk version identifier `aa` (lowercase two characters). All component filenames embed this version, following the pattern:
+
+```
+<sstable_descriptor>-SAI+aa+[<index_name>]+<ComponentDisplayName>.db
+```
+
+The display name in the filename is the string value passed to the `IndexComponent` enum constructor -- not the Java enum name. For example, enum `TERMS_DATA` maps to display name `TermsData`, `POSTING_LISTS` to `PostingLists`, `COLUMN_COMPLETION_MARKER` to `ColumnComplete`, and `GROUP_COMPLETION_MARKER` to `GroupComplete`. Assembly logic is in
+[`Version.java:142-155`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/index/sai/disk/format/Version.java).
+
 ![SAI file layout](diagrams/sai-file-layout)
   - Alt-text: SAI per-column segments (numeric/text/vector) and their on-disk components.
   - Caption: SAI segments are written per indexed column; vector segments sit alongside numeric/text segments.
+
+## Vector indexes on disk
+
+When a column is indexed with `CREATE CUSTOM INDEX ... USING 'StorageAttachedIndex'` on a
+`vector<float, N>` column, SAI writes five component files per SSTable segment:
+
+```
+<descriptor>-SAI+aa+[<index_name>]+TermsData.db
+<descriptor>-SAI+aa+[<index_name>]+CompressedVectors.db
+<descriptor>-SAI+aa+[<index_name>]+PostingLists.db
+<descriptor>-SAI+aa+[<index_name>]+Meta.db
+<descriptor>-SAI+aa+[<index_name>]+ColumnComplete.db
+```
+
+The `VECTOR_COMPONENTS` set is defined in
+[`V1OnDiskFormat.java:92-96`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/index/sai/disk/v1/V1OnDiskFormat.java):
+
+```java
+VECTOR_COMPONENTS = EnumSet.of(
+    COLUMN_COMPLETION_MARKER, META, COMPRESSED_VECTORS, TERMS_DATA, POSTING_LISTS)
+```
+
+### TermsData.db -- jvector HNSW graph
+
+`TermsData.db` stores a jvector `OnDiskGraphIndex` -- an HNSW (Hierarchical Navigable Small
+World) graph. On open, `DiskAnn` reads the graph at the byte offset stored in
+`ComponentMetadata.offset` for the `TERMS_DATA` component
+([`DiskAnn.java:58-60`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/index/sai/disk/v1/vector/DiskAnn.java)):
+
+```java
+SegmentMetadata.ComponentMetadata termsMetadata = componentMetadatas.get(IndexComponent.TERMS_DATA);
+graphHandle = indexFiles.termsData();
+graph = new CachingGraphIndex(
+    new OnDiskGraphIndex<>(RandomAccessReaderAdapter.createSupplier(graphHandle),
+                           termsMetadata.offset));
+```
+
+`CachingGraphIndex` wraps `OnDiskGraphIndex` and keeps recently traversed nodes in heap to reduce disk
+seeks on repeated graph queries.
+
+### CompressedVectors.db -- Product Quantization store
+
+`CompressedVectors.db` holds optional PQ-compressed vectors produced by the jvector library. At the
+offset for `COMPRESSED_VECTORS` in `ComponentMetadataMap` a single boolean byte signals whether PQ
+data follows
+([`DiskAnn.java:62-70`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/index/sai/disk/v1/vector/DiskAnn.java)):
+
+```java
+long pqSegmentOffset = componentMetadatas.get(IndexComponent.COMPRESSED_VECTORS).offset;
+reader.seek(pqSegmentOffset);
+boolean containsCompressedVectors = reader.readBoolean();
+if (containsCompressedVectors)
+    compressedVectors = CompressedVectors.load(reader, reader.getFilePointer());
+```
+
+When present, PQ vectors enable two-pass scoring: a fast approximate pass via
+`CompressedVectors.approximateScoreFunctionFor()`, followed by full-precision exact scoring of the
+top-K candidates. See
+[`VectorIndexSegmentSearcher.java:267-281`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/index/sai/disk/v1/segment/VectorIndexSegmentSearcher.java).
+
+### PostingLists.db -- ordinals map
+
+For vector indexes, `PostingLists.db` is an `OnDiskOrdinalsMap` -- a bidirectional mapping between
+HNSW graph node ordinals and SSTable segment row IDs
+([`DiskAnn.java:73-74`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/index/sai/disk/v1/vector/DiskAnn.java)):
+
+```java
+SegmentMetadata.ComponentMetadata postingListsMetadata =
+    componentMetadatas.get(IndexComponent.POSTING_LISTS);
+ordinalsMap = new OnDiskOrdinalsMap(
+    indexFiles.postingLists(), postingListsMetadata.offset, postingListsMetadata.length);
+```
+
+The on-disk layout written by
+[`VectorPostingsWriter.java:34-111`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/index/sai/disk/v1/vector/VectorPostingsWriter.java)
+is (within the segment's byte range):
+
+1. `int` -- count of deleted ordinals
+2. N x `int` -- deleted ordinal values
+3. Ordinal to row ID section:
+   - `int` -- total vector count
+   - count x `long` -- per-ordinal offsets (8 bytes each) pointing to postings lists
+   - count postings lists, each: `int` (size) + size x `int` (row IDs)
+4. Row ID to ordinal reverse section:
+   - K x (`int` rowId, `int` ordinal) pairs sorted by rowId
+   - `long` at the very end: file offset of the start of the reverse-lookup section
+
+Source: [`OnDiskOrdinalsMap.java:41-66`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/index/sai/disk/v1/vector/OnDiskOrdinalsMap.java).
+
+### SegmentMetadata fields
+
+All segment types (numeric, literal, vector) share the same `META` file structure. The file contains a
+VInt segment count followed by N records. Each record is serialized in this order
+([`SegmentMetadata.java:118-176`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/index/sai/disk/v1/segment/SegmentMetadata.java)):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `rowIdOffset` | `long` | Add to segment row ID to get SSTable row ID |
+| `numRows` | `long` | Number of indexed rows in this segment |
+| `minSSTableRowId` | `long` | Lowest SSTable row ID in segment |
+| `maxSSTableRowId` | `long` | Highest SSTable row ID in segment |
+| `minKey` | `int`-length-prefixed bytes | Min primary key as OSS50 comparable bytes |
+| `maxKey` | `int`-length-prefixed bytes | Max primary key as OSS50 comparable bytes |
+| `minTerm` | `int`-length-prefixed bytes | Min indexed column value |
+| `maxTerm` | `int`-length-prefixed bytes | Max indexed column value |
+| `ComponentMetadataMap` | nested | Per-component `{root, offset, length, attributes}` map |
+
+`ComponentMetadata` stores three `long` values (`root`, `offset`, `length`) plus a `Map<String,String>`
+for additional attributes, serialized as `int` count followed by UTF-8 key-value pairs.
+
+### PrimaryKeyMap -- row ID to primary key resolution
+
+After graph search returns `(rowId, score)` pairs, SAI resolves them to full primary keys via
+`PrimaryKeyMap`
+([`PrimaryKeyMap.java:71-97`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/index/sai/disk/PrimaryKeyMap.java)):
+
+- `primaryKeyFromRowId(long sstableRowId)` returns `PrimaryKey`
+- `rowIdFromPrimaryKey(PrimaryKey key)` returns `long`
+- `ceiling(Token)` / `floor(Token)` return token boundary row IDs
+
+Two concrete implementations exist
+([`V1OnDiskFormat.java:133-137`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/index/sai/disk/v1/V1OnDiskFormat.java)):
+
+- `SkinnyPrimaryKeyMap.Factory` -- tables without clustering: reads `PARTITION_KEY_BLOCKS*` only
+- `WidePrimaryKeyMap.Factory` -- tables with clustering: adds `CLUSTERING_KEY_BLOCKS*`
+
+### ANN query path
+
+[`VectorIndexSegmentSearcher.orderBy()`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/index/sai/disk/v1/segment/VectorIndexSegmentSearcher.java)
+orchestrates the full ANN path:
+
+1. Decompose the query vector from the CQL `Expression` lower bound.
+2. Compute `topK = optimizeFor.topKFor(limit)` (oversampling for recall).
+3. **Key-range restriction** (when a WHERE clause limits partitions):
+   - Resolve `minSSTableRowId` / `maxSSTableRowId` via `PrimaryKeyMap.ceiling()` / `floor()`.
+   - If the candidate row count is at most `maxBruteForceRows`, skip graph traversal and run
+     exact brute-force scoring over `OnDiskOrdinalsMap.OrdinalsView` directly.
+   - Otherwise, build a `SparseFixedBitSet` of allowed ordinals and pass it to the graph
+     searcher as an acceptance filter.
+4. **Graph search** -- `DiskAnn.search()` calls jvector `GraphSearcher` on the cached HNSW
+   graph. With PQ present, a fast approximate pass precedes full-precision reranking.
+5. **Ordinal to row ID** -- `OnDiskOrdinalsMap.RowIdsView.getSegmentRowIdsMatching()`.
+6. **Row ID to PrimaryKey** -- `RowIdToPrimaryKeyWithScoreIterator` calls
+   `PrimaryKeyMap.primaryKeyFromRowId()`.
+7. Scored primary keys from all segments are merged by the caller, then rows are fetched from
+   `Data.db` via the standard read path.
 
 ## Query Flow
 
@@ -26,9 +182,11 @@ At query time, SAI chooses a path based on predicate type:
 
 - Numeric: range predicates probe numeric trees/structures to produce candidate primary keys.
 - Text: equality/prefix-like predicates probe term dictionaries and posting lists.
-- Vector: a vector similarity search over vector segments returns approximate nearest-neighbor candidates.
+- Vector: a vector similarity search over vector segments returns approximate nearest-neighbor
+  candidates via the HNSW graph search described above.
 
-Candidates are then deduplicated/merged, and fetched from the base table using the standard read path (Bloom → Index → Summary → Data). Non-indexed predicates are applied as filters on the fetched rows.
+Candidates are then deduplicated/merged and fetched from the base table using the standard read path
+(Bloom -> Index -> Summary -> Data). Non-indexed predicates are applied as filters on the fetched rows.
 
 ![SAI query flow](diagrams/sai-query-flow)
   - Alt-text: Dispatcher routes numeric/text/vector queries; candidates merged and passed to base read path.
@@ -36,46 +194,75 @@ Candidates are then deduplicated/merged, and fetched from the base table using t
 
 Illustrative examples (trimmed):
 
-- Numeric range: “Find orders with `amount` in [100, 200).” The `amount` SAI probes its numeric segment(s) to produce candidate row keys, then the base table fetch validates and returns rows in-range.
-- Text prefix: “Find pages with `title` starting with `foo`.” The `title` SAI looks up the term/prefix to retrieve posting lists, yielding candidates that are fetched and post-filtered.
-- Vector similarity: “Return top-10 nearest neighbors to query vector q in `embedding`.” The `embedding` SAI performs a vector similarity search over vector segments to return candidates ranked by distance, then base rows are fetched and returned (respecting LIMIT).
+- Numeric range: "Find orders with `amount` in [100, 200)." The `amount` SAI probes its numeric
+  segment(s) to produce candidate row keys, then the base table fetch validates and returns rows
+  in-range.
+- Text prefix: "Find pages with `title` starting with `foo`." The `title` SAI looks up the
+  term/prefix to retrieve posting lists, yielding candidates that are fetched and post-filtered.
+- Vector similarity: "Return top-10 nearest neighbors to query vector q in `embedding`." The
+  `embedding` SAI performs HNSW graph search over vector segments to return candidates ranked by
+  distance, then base rows are fetched and returned (respecting LIMIT).
 
 ### Caching and Memory Behavior
 
-- Segment-level structures (term dictionaries, numeric trees, vector blocks) are memory-mapped or buffered; hot paths benefit from the OS page cache. Implementations may keep small per-segment metadata and open-file handles.
-- For vectors, blocks and auxiliary structures (e.g., centroids/quantization metadata when present) are accessed on demand; memory usage scales with number of active segments and query concurrency.
+- Segment-level structures (term dictionaries, numeric trees, vector graph nodes) are memory-mapped or
+  buffered; hot paths benefit from the OS page cache. Implementations keep small per-segment metadata
+  and open file handles.
+- For vectors, `CachingGraphIndex` keeps recently traversed HNSW nodes in heap to reduce disk seeks
+  on repeated queries. PQ metadata is loaded once per segment open.
 
 ### Compaction of Index Segments
 
-- SAI compaction merges per-column segments, drops obsolete postings/entries, and rewrites compacted segments. Compaction policy is independent of base-table compaction but aligned at lifecycle boundaries (flush/cleanup).
-- Merging reduces candidate duplication and improves locality; during compaction, readers see a stable view via segment switching.
+- SAI compaction merges per-column segments, drops obsolete postings/entries, and rewrites compacted
+  segments. Compaction policy is independent of base-table compaction but aligned at lifecycle
+  boundaries (flush/cleanup).
+- Merging reduces candidate duplication and improves locality; during compaction, readers see a stable
+  view via segment switching.
 
 ### Corruption and Error Handling
 
-- Segment checksum and metadata validation occur on open and sometimes at read boundaries; failures typically isolate to specific segments. The index can be rebuilt for affected columns while the base table remains intact.
-- On validation failure, queries may skip a bad segment (degraded results) or surface errors based on configuration; operators should run validation tools and rebuild.
+- Segment checksum and metadata validation occur on open and sometimes at read boundaries; failures
+  typically isolate to specific segments. The index can be rebuilt for affected columns while the base
+  table remains intact.
+- On validation failure, queries may skip a bad segment (degraded results) or surface errors based on
+  configuration; operators should run validation tools and rebuild.
 
 ### Complexity Notes
 
 - Numeric range: O(log S + R) per segment, where S is segment size and R is number of results in-range.
 - Text term/prefix: O(log S + P) for term lookup plus posting traversal P.
-- Vector KNN: roughly O(C · B · log S) depending on the segment algorithm, where C is candidate beams/centroids, B blocks probed; exact complexity varies by implementation.
+- Vector ANN (HNSW): O(log N * ef) per segment, where N is graph node count and ef is the exploration
+  beam width. When PQ compression is present, a two-pass strategy applies: fast approximate scoring via
+  `CompressedVectors`, then exact rerank of top-ef candidates. Brute-force fallback is O(N) and triggers
+  when the key-restricted candidate count falls below `maxBruteForceRows` (computed as
+  `maximumNodeConnections * expectedNodesVisited`).
 
 ### Key Takeaways
 - SAI is per-column and segment-based; segments are immutable and merged by compaction.
+- All SAI 5.0 files use the single on-disk version `aa`; filenames follow the pattern
+  `<descriptor>-SAI+aa+[<index_name>]+<ComponentDisplayName>.db`.
+- Vector indexes write five component files per segment: `TermsData.db` (HNSW graph),
+  `CompressedVectors.db` (optional PQ), `PostingLists.db` (ordinals map), `Meta.db`,
+  and `ColumnComplete.db`.
 - Numeric/text/vector predicates are routed to specialized segment readers to produce candidates.
 - Base-table SSTables remain authoritative; SAI candidates are validated via the normal read path.
 - Prefer SAI over 2i for range, LIKE, and vector searches in Cassandra 5.0.
-- Vector indexing integrates with SAI; queries return approximate nearest neighbors efficiently.
 
 ### References
-- Cassandra 5.0.0 (pinned)
-  - SAI root: `https://github.com/apache/cassandra/tree/cassandra-5.0.0/src/java/org/apache/cassandra/index/sai`
-  - SAI on-disk formats: `https://github.com/apache/cassandra/tree/cassandra-5.0.0/src/java/org/apache/cassandra/index/sai/disk`
-  - SAI query path: `https://github.com/apache/cassandra/tree/cassandra-5.0.0/src/java/org/apache/cassandra/index/sai/query`
-  - SAI v1 disk (includes vector indexing classes): `https://github.com/apache/cassandra/tree/cassandra-5.0.0/src/java/org/apache/cassandra/index/sai/disk/v1`
-  - Vector CQL type (`VectorType`): `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/db/marshal/VectorType.java`
-  
+- Cassandra 5.0.8
+  - SAI root: `https://github.com/apache/cassandra/tree/cassandra-5.0.8/src/java/org/apache/cassandra/index/sai`
+  - SAI on-disk formats: `https://github.com/apache/cassandra/tree/cassandra-5.0.8/src/java/org/apache/cassandra/index/sai/disk`
+  - SAI query path: `https://github.com/apache/cassandra/tree/cassandra-5.0.8/src/java/org/apache/cassandra/index/sai/query`
+  - SAI v1 disk (includes vector indexing classes): `https://github.com/apache/cassandra/tree/cassandra-5.0.8/src/java/org/apache/cassandra/index/sai/disk/v1`
+  - Vector CQL type (`VectorType`): `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/marshal/VectorType.java`
+  - SAI version identifier: [`Version.java`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/index/sai/disk/format/Version.java)
+  - Index component enum: [`IndexComponent.java`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/index/sai/disk/format/IndexComponent.java)
+  - On-disk format registry: [`V1OnDiskFormat.java`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/index/sai/disk/v1/V1OnDiskFormat.java)
+  - Segment metadata: [`SegmentMetadata.java`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/index/sai/disk/v1/segment/SegmentMetadata.java)
+  - Vector disk index: [`DiskAnn.java`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/index/sai/disk/v1/vector/DiskAnn.java)
+  - Vector postings writer: [`VectorPostingsWriter.java`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/index/sai/disk/v1/vector/VectorPostingsWriter.java)
+  - Ordinals map: [`OnDiskOrdinalsMap.java`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/index/sai/disk/v1/vector/OnDiskOrdinalsMap.java)
+  - Vector segment searcher: [`VectorIndexSegmentSearcher.java`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/index/sai/disk/v1/segment/VectorIndexSegmentSearcher.java)
+  - Primary key map: [`PrimaryKeyMap.java`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/index/sai/disk/PrimaryKeyMap.java)
+
 For implementation details, see Appendix C.
-
-


### PR DESCRIPTION
## Summary
Audit batch B7 (epic #598). Fixes Ch.13/Ch.14 and adds the user-mandated vector on-disk coverage.

Key fixes:
- Vector ANN complexity corrected: jvector HNSW O(log N · ef), not IVF-style O(C·B·log S) — `DiskAnn.java:95-127`
- Dead Ch.13 links replaced (KeysIndex/CompositesIndex → keys/KeysSearcher, composites/CompositesSearcher)
- New ~130-line 'Vector indexes on disk' section: TermsData.db (HNSW graph), CompressedVectors.db (PQ + leading boolean flag), PostingLists.db (ordinals map), SegmentMetadata 8-field record, PrimaryKeyMap skinny/wide, adaptive HNSW-vs-brute-force query path
- SAI 'aa' version + canonical file naming pattern documented
- Permalinks re-pinned to cassandra-5.0.8 + 9 new vector-class citations

Closes #605. Part of epic #598.