### PR TITLE
docs(guide): fix compaction/lifecycle/streaming chapters + zero-copy & UCS coverage (#606)

### DIFF
--- a/docs/sstables-definitive-guide/chapters/15-compaction-strategies.md
+++ b/docs/sstables-definitive-guide/chapters/15-compaction-strategies.md
@@ -21,7 +21,7 @@ LCS organizes SSTables into size-constrained levels where each SSTable at L1+ co
 Key parameters include `sstable_size_in_mb` and `fanout_size` (how many SSTables per next level target size).
 
 ### Time-Window Compaction Strategy (TWCS)
-TWCS places SSTables into time windows (e.g., 1 hour or 1 day) and compacts only within each window. This isolates older immutable data from newer hot data and is well-suited to time-series and TTL-heavy workloads. It eases tombstone purging when windows close, while accepting overlap across windows for large time-range scans.
+TWCS places SSTables into time windows (defaults to 1 day; configurable to hours or other units) and compacts only within each window. This isolates older immutable data from newer hot data and is well-suited to time-series and TTL-heavy workloads. It eases tombstone purging when windows close, while accepting overlap across windows for large time-range scans.
 
 Key parameters include `compaction_window_unit` and `compaction_window_size` (and optional split during flush).
 
@@ -57,11 +57,47 @@ Small comparison of strategy behaviors (indicative, not absolute):
 Concurrency and throttling:
 - Compaction is typically multi-threaded and rate-limited; per-strategy concurrency interacts with disk bandwidth and page cache. LCS often benefits from stricter throttling to avoid foreground read jitter; STCS benefits from batching/merging larger tiers.
 
-Implementation touchpoints (Cassandra 5.0.0): `CompactionManager`, `CompactionController`, strategy classes listed below.
+Implementation touchpoints (Cassandra 5.0.8): `CompactionManager`, `CompactionController`, strategy classes listed below.
 
-### Sidebar: UCS (Unified Compaction Strategy)
+### Sidebar: Unified Compaction Strategy (UCS)
 
-UCS generalizes compaction with scaling presets to emulate tiered (Tn) or leveled (Ln) behavior while adding shard-based concurrency and configurable target sizes. For migration, you can set scaling parameters to approximate STCS (`T4`) or LCS (`L10`) while maintaining a single strategy across tables. See also the Cassandra 5.0 code for `UnifiedCompactionStrategy` and the operating guide for typical presets.
+UCS ([`UnifiedCompactionStrategy`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java))
+unifies tiered and leveled compaction. It groups SSTables into exponential density levels, compacts when a
+configurable number of SSTables accumulate on a level, and splits output across token-range shards for concurrent
+compaction without cross-node coordination.
+
+#### Scaling Parameter W
+
+The `scaling_parameters` option is a comma-separated list of integers W, one per level
+(the last value extends to all higher levels). The W value encodes both fanout and threshold
+([`UnifiedCompactionStrategy.java:106–113`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java#L106-L113)):
+
+- **W > 0 → tiered (T-style)**: fanout `f = 2 + W`, threshold `t = f`. Written as `T(f)` — e.g. `T4` for W=2 gives
+  f=4, t=4. Compaction fires once four SSTables accumulate; low write amplification, higher read amplification.
+- **W < 0 → leveled (L-style)**: fanout `f = 2 − W`, threshold `t = 2`. Written as `L(f)` — e.g. `L10` for W=−8
+  gives f=10, t=2. Compact aggressively at every two SSTables; low read amplification, higher write amplification.
+- **W = 0 → N**: `f = t = 2`. Midpoint; equivalent to T2 or L2.
+
+**Default `scaling_parameters`**: `T4`, matching STCS default threshold=4. To emulate LCS with fanout 10, use `L10`.
+
+#### Key Options and Defaults
+
+Loaded via `Controller.fromOptions()`
+([`Controller.java:408–461`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/compaction/unified/Controller.java#L408-L461));
+documented in [`UnifiedCompactionStrategy.md`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.md):
+
+| Option | Default | Notes |
+|--------|---------|-------|
+| `scaling_parameters` | `T4` | Per-level W list; last value repeats |
+| `target_sstable_size` | 1 GiB | Minimum enforced at 1 MiB (`Controller.java:83`) |
+| `base_shard_count` | 4 | Min shards for lowest density levels; 1 for system tables |
+| `sstable_growth` (λ) | 0.333 | 0=fixed target size; 1=fixed shard count; 0.333=sstable size grows as cube-root of density |
+| `min_sstable_size` | 100 MiB | Below this, shards drop below `base_shard_count` |
+| `max_sstables_to_compact` | no limit | Option value ≤ 0 means `Integer.MAX_VALUE` (`Controller.java:202–203`) |
+| `expired_sstable_check_frequency_seconds` | 600 | Same as TWCS default |
+
+Maximum shard splitting is bounded at `base_shard_count × 2^20`
+(`MAX_SHARD_SHIFT = 20`, `Controller.java:139`).
 
 ### Key Takeaways
 - STCS favors write throughput; expect higher read amplification due to overlap.
@@ -84,12 +120,12 @@ For implementation details, see Appendix C.
 
 ### References
 
-- Cassandra 5.0.0 (code):
-  - `SizeTieredCompactionStrategy` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/db/compaction/SizeTieredCompactionStrategy.java`
-  - `LeveledCompactionStrategy` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/db/compaction/LeveledCompactionStrategy.java`
-  - `TimeWindowCompactionStrategy` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/db/compaction/TimeWindowCompactionStrategy.java`
-  - `UnifiedCompactionStrategy` (sidebar) — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java`
-  - `CompactionController` (tombstone purging) — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/db/compaction/CompactionController.java`
+- Cassandra 5.0.8 (code):
+  - `SizeTieredCompactionStrategy` — `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/compaction/SizeTieredCompactionStrategy.java`
+  - `LeveledCompactionStrategy` — `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/compaction/LeveledCompactionStrategy.java`
+  - `TimeWindowCompactionStrategy` — `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/compaction/TimeWindowCompactionStrategy.java`
+  - `UnifiedCompactionStrategy` (sidebar) — `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java`
+  - `CompactionController` (tombstone purging) — `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/compaction/CompactionController.java`
   
 For implementation details, see Appendix C.
 

--- a/docs/sstables-definitive-guide/chapters/16-sstable-lifecycle-and-maintenance.md
+++ b/docs/sstables-definitive-guide/chapters/16-sstable-lifecycle-and-maintenance.md
@@ -83,8 +83,8 @@ Repair/streaming move SSTables between nodes and reconcile divergent histories; 
 - Streaming integrity: digests are verified per stream; on failure, SSTables are discarded and retried.
 
 Related Cassandra 5.0.0 code (pinned) for further study:
-- Streaming session — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/streaming/StreamSession.java`
-- Active repair service — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/service/ActiveRepairService.java`
+- Streaming session — `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/streaming/StreamSession.java`
+- Active repair service — `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/service/ActiveRepairService.java`
 
 ### Key Takeaways
 - `TOC.txt` is authoritative; validate both presence and cross-listing of components.
@@ -94,11 +94,11 @@ Related Cassandra 5.0.0 code (pinned) for further study:
 - Repair/streaming rely on the same invariants; broken invariants propagate.
 
 ### References
-**Cassandra 5.0.0 (pinned):**
-- `SSTableMetadata` (tool) — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/tools/SSTableMetadata.java`
-- `SSTableDump` (tool) — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/tools/SSTableDump.java`
-- `Descriptor` (component paths/TOC context) — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/Descriptor.java`
-- `SSTableWriter` (emits `TOC.txt`) — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/SSTableWriter.java`
+**Cassandra 5.0.8 (pinned):**
+- `SSTableMetadataViewer` (tool) — `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/tools/SSTableMetadataViewer.java`
+- `SSTableExport` (tool, CLI alias: `sstabledump`) — `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/tools/SSTableExport.java`
+- `Descriptor` (component paths/TOC context) — `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/Descriptor.java`
+- `SSTableWriter` (emits `TOC.txt`) — `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/SSTableWriter.java`
 
 For implementation details, see Appendix C.
 

--- a/docs/sstables-definitive-guide/chapters/18-repair-streaming-bootstrap.md
+++ b/docs/sstables-definitive-guide/chapters/18-repair-streaming-bootstrap.md
@@ -27,6 +27,78 @@ High-level sequences (trimmed):
   2) Stream relevant SSTable sections from existing replicas
   3) Build local indexes/stats; participate fully after completion
 
+
+## Zero-Copy (Entire-SSTable) Streaming
+
+When certain eligibility conditions are met, Cassandra 5.0 streams an entire SSTable as raw bytes over the wire
+instead of rebuilding it section by section. This is the default fast path for repair, bootstrap, and range movement
+when the requested token range covers the full SSTable extent.
+
+### Eligibility Conditions
+
+A sender qualifies for zero-copy streaming only if **all four** of the following hold
+([`CassandraOutgoingFile.computeShouldStreamEntireSSTables()`, lines 181–201](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/streaming/CassandraOutgoingFile.java#L181-L201)):
+
+1. **`stream_entire_sstables` is enabled** — `DatabaseDescriptor.streamEntireSSTables()` returns `true`.
+   This is set via `cassandra.yaml` and is the default for Cassandra 5.0.
+2. **No legacy counter shards** — `SSTableMetadata.hasLegacyCounterShards == false`. Pre-3.0 counter SSTables
+   carry legacy shard metadata incompatible with the zero-copy wire format.
+3. **No old bloom-filter format** — `sstable.descriptor.version.hasOldBfFormat() == false`. The pre-4.0 bloom
+   filter encoding is incompatible; affected SSTables fall back to section-based streaming.
+4. **Sections fully cover the SSTable** — the sum of all requested `PartitionPositionBounds` lengths equals
+   `sstable.uncompressedLength()`. A partial range request disqualifies zero-copy.
+
+If any condition fails the code falls through to `CassandraStreamWriter` (legacy, lines 173–176), which reads
+only the requested sections and reconstructs the SSTable on the receiver.
+
+### ComponentManifest
+
+When an SSTable qualifies, the sender creates a
+[`ComponentManifest`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/streaming/ComponentManifest.java):
+an ordered `LinkedHashMap<Component, Long>` recording each streaming component and its exact on-disk size in bytes.
+The manifest is embedded in the `CassandraStreamHeader` transmitted before the data so the receiver knows the
+byte length of every component before reading it.
+
+Mutable components (`Statistics.db` and Index Summary) can be written concurrently by Cassandra internals. The sender
+therefore re-creates the manifest **inside `sstable.runWithLock()`** at the moment bytes are about to be sent
+(`CassandraOutgoingFile.java:157–165`). A `ComponentContext` retains the manifest and any required hard-linked
+copies for the duration of the transfer.
+
+### CassandraEntireSSTableStreamWriter Flow
+
+[`CassandraEntireSSTableStreamWriter.write()`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/streaming/CassandraEntireSSTableStreamWriter.java)
+iterates `manifest.components()` in order. For each component it:
+
+1. Opens a `FileChannel` via `ComponentContext.channel(descriptor, component, length)`.
+2. Calls `out.writeFileToChannel(channel, limiter)` — a rate-limited OS-level transfer backed by
+   `FileChannel.transferTo` or equivalent; no row parsing occurs.
+3. Records per-component progress to the `StreamSession` via `session.progress()`.
+
+Total bytes transferred equals `manifest.totalSize()` — the sum of all component file sizes.
+
+### CassandraEntireSSTableStreamReader Flow
+
+On the receiver,
+[`CassandraEntireSSTableStreamReader.read()`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/streaming/CassandraEntireSSTableStreamReader.java)
+reads the `ComponentManifest` from the incoming header, constructs a new `SSTableZeroCopyWriter` at a fresh
+descriptor, then calls `writer.writeComponent(component, in, length)` for each component in manifest order.
+After all components land, it mutates `StatsMetadata` in-place to reflect the receiver's SSTable level and
+repair metadata — the only processing step beyond raw I/O.
+
+### Contrast with Section-Based (Legacy) Streaming
+
+The legacy `CassandraStreamWriter` path reads only the partition sections requested
+(`PartitionPositionBounds`), passing compressed chunks through `CassandraCompressedStreamWriter` when needed.
+The receiver reconstructs a full SSTable through normal writer infrastructure.
+
+| Dimension | Zero-copy path | Section-based path |
+|-----------|---------------|-------------------|
+| Granularity | Entire file components | Requested partition sections only |
+| CPU (sender) | Near-zero (no parsing) | Moderate (section reads, decompress if needed) |
+| CPU (receiver) | Near-zero (write raw bytes) | Full SSTable construction |
+| Eligibility gate | Full range + no legacy features | Always available as fallback |
+| Key classes | `CassandraEntireSSTableStream{Writer,Reader}`, `ComponentManifest` | `CassandraStream{Writer,Reader}`, `CassandraCompressedStreamWriter` |
+
 ## Intersections with Read/Write Paths
 These flows reuse the same on-disk artifacts and parsers:
 - Readers: open `Data.db` through `CompressionInfo.db`, consult Bloom (`Filter.db`) and, depending on format, `Index.db`/`Summary.db` or BTI tries
@@ -40,7 +112,7 @@ For a streaming reader implementation walkthrough, see Appendix C.
   - Multiple token ranges can stream concurrently; coordination ensures backpressure and ordering per range
   - Retry and resumption logic operates at section granularity, not whole-file
 - Integrity and Idempotency:
-  - Receivers validate chunks and components atomically; partially received files remain isolated until complete
+  - Receivers validate chunks and components atomically using `ComponentManifest` (which enumerates each component and its exact byte length); partially received files remain isolated until complete
   - Duplicate section arrivals are ignored or cause idempotent overwrites gated by `TOC` and digest checks
 - Resource Management:
   - Concurrency limits cap open files and in-flight buffers; memory pressure triggers throttling
@@ -57,8 +129,8 @@ For a streaming reader implementation walkthrough, see Appendix C.
 
 ### References
 - Cassandra 5.0.0:
-  - Streaming package: `https://github.com/apache/cassandra/tree/cassandra-5.0.0/src/java/org/apache/cassandra/streaming`
-  - Repair package: `https://github.com/apache/cassandra/tree/cassandra-5.0.0/src/java/org/apache/cassandra/repair`
+  - Streaming package: `https://github.com/apache/cassandra/tree/cassandra-5.0.8/src/java/org/apache/cassandra/streaming`
+  - Repair package: `https://github.com/apache/cassandra/tree/cassandra-5.0.8/src/java/org/apache/cassandra/repair`
 - Cross-links: see `10-point-reads-and-slices.md`, `04-from-cql-to-disk.md`, and `16-sstable-lifecycle-and-maintenance.md`
 
 

--- a/docs/sstables-definitive-guide/chapters/19-incremental-backups-and-snapshots.md
+++ b/docs/sstables-definitive-guide/chapters/19-incremental-backups-and-snapshots.md
@@ -20,19 +20,35 @@ Tiny example (trimmed) of a snapshot directory structure:
 # │  ├─ nb-1-big-Summary.db
 # │  ├─ nb-1-big-Statistics.db
 # │  ├─ nb-1-big-CompressionInfo.db
-# │  └─ nb-1-big-TOC.txt
+# │  ├─ nb-1-big-TOC.txt
+# │  └─ manifest.json          ← snapshot manifest (see below)
 # └─ backups/
 #    ├─ nb-2-big-Data.db
 #    └─ ...
 ```
 
 Notes:
-- Snapshots are usually hardlinks to immutable SSTable components at a moment in time.
-- Incremental backups collect subsequently flushed SSTables under `backups/`.
+- Snapshots are usually hardlinks to immutable SSTable components at a moment in time
+  ([`TableSnapshot.java:300`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/service/snapshot/TableSnapshot.java#L300)).
+- Incremental backups collect subsequently flushed SSTables under `backups/`
+  ([`Directories.java:119`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/Directories.java#L119-L120)).
+- `manifest.json` is written alongside every snapshot by `SnapshotManifest`
+  ([source](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/service/snapshot/SnapshotManifest.java)).
+  It carries four fields:
+  - `files` — list of component filenames included in the snapshot.
+  - `created_at` — ISO-8601 timestamp of snapshot creation.
+  - `expires_at` — optional expiry timestamp; when set, `SnapshotManager` schedules automatic
+    deletion via a `PriorityQueue` ordered by expiration time
+    ([`SnapshotManager.java:143–162`](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/service/snapshot/SnapshotManager.java#L143-L162)).
+  - `ephemeral` — if `true`, the snapshot is transient (used during repair/streaming) and will
+    be deleted automatically when no longer needed.
 
 ## Restore Considerations
 Brief guidance:
 - Restores must respect component sets listed in `TOC.txt`; partial copies are unsafe.
+- Cross-check `TOC.txt` against `manifest.json` `files` list to confirm no components are missing.
+- `manifest.json` `expires_at` and `ephemeral` fields should be verified before relying on a snapshot
+  for long-term restore; ephemeral snapshots may already have been removed.
 - Hardlinks preserve inode identity; copying should avoid breaking reference integrity.
 - Verify `Digest.crc32` and per-chunk CRCs where present before placing files live.
 - After restore, run validation tools and allow compaction to normalize overlap.
@@ -73,8 +89,8 @@ For component identification tips during restore (BIG vs BTI specifics), see App
 
 ### References
 - Cassandra 5.0.0 tools and storage:
-  - Tools root: `https://github.com/apache/cassandra/tree/cassandra-5.0.0/src/java/org/apache/cassandra/tools`
-  - Descriptor (component naming): `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/Descriptor.java`
+  - Tools root: `https://github.com/apache/cassandra/tree/cassandra-5.0.8/src/java/org/apache/cassandra/tools`
+  - Descriptor (component naming): `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/Descriptor.java`
   
 For implementation details, see Appendix C.
 


### PR DESCRIPTION
## Summary
Audit batch B8 (epic #598). Fixes Ch.15/16/18/19 and adds two user-mandated coverage expansions.

Key changes:
- Ch.16: renamed/moved tool sources fixed (SSTableDump→SSTableExport, SSTableMetadata→SSTableMetadataViewer, SSTableWriter→format/)
- Ch.18: new 'Zero-Copy (Entire-SSTable) Streaming' section — 4 eligibility conditions from `CassandraOutgoingFile.computeShouldStreamEntireSSTables` (lines 181-201), ComponentManifest, writer/reader flow, comparison vs section-based streaming
- Ch.15: full UCS sidebar (W semantics, scaling presets, base_shard_count, target_sstable_size, Controller defaults); TWCS window default fixed
- Ch.19: manifest.json documented (files/created_at/expires_at/ephemeral) + restore guidance
- All permalinks re-pinned to cassandra-5.0.8

Closes #606. Part of epic #598.