### PR TITLE
docs(guide): fix foundations/read-path/caching chapters vs cassandra-5.0.8 (#607)

### DIFF
--- a/docs/sstables-definitive-guide/chapters/01-what-are-sstables.md
+++ b/docs/sstables-definitive-guide/chapters/01-what-are-sstables.md
@@ -15,13 +15,15 @@ At a high level, Cassandra batches updates in a memtable and appends them to a W
 ## Role in Cassandra Read/Write Path
 
 - Write path (implementation view):
-  - Client mutation → append to WAL → update memtable (TrieMemtable: byte-ordered prefix trie with shared prefixes)
+  - Client mutation → append to WAL → update memtable (default: `SkipListMemtable`; `TrieMemtable`
+    is an opt-in alternative — byte-ordered prefix trie with shared prefixes and CPU-core sharding)
   - Flush triggers `SSTableWriter` to build components:
     - Serialize rows into `Data.db` (optionally compressed in fixed-size chunks)
     - Emit partition digests and offsets to `Index.db`; build `Summary.db` samples
     - Construct `Filter.db` (Bloom) and accumulate `Statistics.db`
     - Write `CompressionInfo.db`, `Digest.crc32`, and `TOC.txt`
 - Read path (point read, implementation view):
+  - Check min/max key bounds of the SSTable; outside range → skip entirely (no Bloom check needed)
   - Compute partition key digest and check Bloom (`Filter.db`); negative → stop
   - Use `Summary.db` to narrow a region of `Index.db`; seek to exact index entry
   - Translate to `Data.db` position; read aligned to compression chunk boundaries and decompress just the needed bytes
@@ -59,16 +61,18 @@ Summary.db
 
 ### Key Takeaways
 - SSTables are immutable, sorted disk artifacts produced by memtable flushes
-- Reads follow Bloom → Index → Summary → Data; writes never mutate existing SSTables
+- Reads follow Bloom → Summary → Index → Data (min/max key bounds checked before Bloom for range exclusion); writes never mutate existing SSTables
 - The component set is consistent across versions; 5.0 advances internal layout with BTI
 - `TOC.txt` is the single source of truth for which component files exist
 
 ### References
 
-- Cassandra 5.0.0 (pinned):
-  - `SSTableReader` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/SSTableReader.java`
-  - `SSTableWriter` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/SSTableWriter.java`
-  - `Descriptor` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/Descriptor.java`
+- Cassandra 5.0.8 (pinned):
+  - `SSTableReader` — https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/SSTableReader.java
+  - `SSTableWriter` — https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/SSTableWriter.java
+  - `Descriptor` — https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/Descriptor.java
+  - `MemtableParams` (default factory L99) — https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/schema/MemtableParams.java#L99-L100
+  - `BigTableReader` (min/max bounds + Bloom order L220–L278) — https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java#L220-L278
 - See also: Chapter 2 (components), Chapter 10 (read flow). For an implementation walkthrough, see Appendix C.
 
 

--- a/docs/sstables-definitive-guide/chapters/02-anatomy-of-an-sstable.md
+++ b/docs/sstables-definitive-guide/chapters/02-anatomy-of-an-sstable.md
@@ -58,6 +58,10 @@ nb-1-big-Summary.db
 nb-1-big-TOC.txt
 ```
 
+> **Note**: Cassandra 5.0 nodes write `oa-…-big-*` for new SSTables (version `oa` is current
+> for the BIG format in 5.0; `BigFormat.java:343`). The `nb-…` prefix above is valid for
+> SSTables written by pre-5.0 nodes or during a rolling upgrade.
+
 The `TOC.txt` inside the same directory confirms the components present:
 
 ```1:9:/Users/patrick/local_projects/cqlite/test-data/datasets/sstables/test_basic/simple_table-6de93b70934a11f08d448925b7a9e804/nb-1-big-TOC.txt
@@ -76,15 +80,19 @@ Summary.db
 When BTI is enabled, a generation includes BTI-specific components alongside common ones. During upgrades, directories may contain both BIG and BTI generations. Real filenames (trimmed):
 
 ```text
-na-3-bti-Data.db
-na-3-bti-Partitions.db
-na-3-bti-Rows.db
-na-3-bti-Statistics.db
-na-3-bti-TOC.txt
-na-3-bti-Digest.crc32
+da-3-bti-Data.db
+da-3-bti-Partitions.db
+da-3-bti-Rows.db
+da-3-bti-Statistics.db
+da-3-bti-TOC.txt
+da-3-bti-Digest.crc32
 ```
 
 See the BTI package for details: `org.apache.cassandra.io.sstable.format.bti`.
+
+> **Correction**: BTI only ever uses version `da` (`BtiFormat.java:289`:
+> `current_version = "da"`). Version `na` is a BIG-format version letter and is incompatible
+> with BTI filenames.
 
 ## TOC Invariants and Integrity Checks
 
@@ -107,7 +115,7 @@ While component order in `TOC.txt` does not affect functionality, Cassandra writ
 7. **Index.db** - Partition index
 8. **Summary.db** - Sampled index for acceleration
 
-This ordering matches the implementation in CQLite's `TocWriter` and reflects Cassandra's write patterns.
+This ordering matches the implementation in CQLite's `TocWriter`. Cassandra's source does not enforce a canonical TOC line ordering; the order above is CQLite's own convention.
 
 ### TOC.txt Self-Inclusion
 
@@ -134,9 +142,13 @@ Implementation note: Writers use `fsync()` on each component before writing `TOC
 
 SSTable components have internal dependencies that dictate write ordering beyond the final TOC barrier:
 
-1. **Statistics.db FIRST**: Contains timestamp/tombstone metadata and delta encoding baselines. Must be written before Data.db to establish encoding parameters.
+1. **Data.db first via flush**: Partition rows are streamed to disk first. Statistics accumulate during the write.
 
-2. **Data.db + Index.db**: Written in parallel or sequentially. Index.db entries reference Data.db byte offsets, so Data.db chunks must be flushed before corresponding Index entries.
+2. **Data.db + Index.db**: Written together during the flush pass. Index.db entries reference Data.db byte offsets, so Data.db chunks must be flushed before corresponding Index entries.
+
+   > **Note**: `Statistics.db` is written in `doPrepare()` *after* Data.db is complete
+   > ([SSTableWriter.java:384–392](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/SSTableWriter.java#L384-L394)),
+   > using finalized metadata. It is serialized just before `TOC.txt`, not before Data.db.
 
 3. **Summary.db**: Samples Index.db entries, so Index.db must be complete before Summary generation.
 
@@ -153,7 +165,7 @@ Violating these dependencies results in corrupted SSTables with invalid offsets,
 ### Sidebar: Version Differences (3.x/4.x)
 
 - File family remains multi-component; feature flags and index internals differ
-- `Descriptor` format tags (`big`, `mc/mm`, `bti`) encode capabilities; 5.0 introduces BTI
+- `Descriptor` format **names** are `big` and `bti` only (`BigFormat.java:75`, `BtiFormat.java:64`). `mc`, `mm`, `nb`, and `oa` are version letters within `big`, not format names. 5.0 pairs `big` (version `oa`) with BTI (version `da`).
 - Statistics fields expanded over time; tooling output formatting changed subtly
 
 ### Key Takeaways
@@ -164,10 +176,13 @@ Violating these dependencies results in corrupted SSTables with invalid offsets,
 
 ### References
 
-- Cassandra 5.0.0 (pinned):
-  - `Descriptor` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/Descriptor.java`
-  - `StatsMetadata` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/metadata/StatsMetadata.java`
-  - `IndexSummary` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/IndexSummary.java`
+- Cassandra 5.0.8 (pinned):
+  - `Descriptor` — https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/Descriptor.java
+  - `StatsMetadata` — https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/metadata/StatsMetadata.java
+  - `IndexSummary` — https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/IndexSummary.java
+  - `SSTableWriter.doPrepare()` (Statistics.db write timing) — https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/SSTableWriter.java#L384-L394
+  - `BigFormat` (current_version = "oa") — https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigFormat.java#L343
+  - `BtiFormat` (current_version = "da") — https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/bti/BtiFormat.java#L289-L290
 Reference (diagram source):
 ```1:10:/Users/patrick/local_projects/cqlite/docs/sstables-definitive-guide/diagrams/sstable-components.mmd
 %% SSTable component relationship diagram (stub)

--- a/docs/sstables-definitive-guide/chapters/03-disk-and-io-model.md
+++ b/docs/sstables-definitive-guide/chapters/03-disk-and-io-model.md
@@ -42,9 +42,32 @@ Two common strategies exist for SSTable IO:
 
 In practice, chunked compression dominates the read cost model: aligning reads to chunk boundaries reduces amplification for random lookups; sequential scans amortize decompression overhead. Cassandra’s `CompressionMetadata` and related classes define the chunk map used by the readers.
 
+### Cassandra 5.0 Default: `mmap_index_only`
+
+Cassandra 5.0 changed the default `disk_access_mode` from `auto` to `mmap_index_only`
+(CASSANDRA-19021; `NEWS.txt:288`, `CHANGES.txt:349`). Under `mmap_index_only`:
+
+- **Index files** (`Index.db`, `Summary.db`, BTI trie files) are memory-mapped via
+  `ioOptions.indexDiskAccessMode` (mapped to `Config.DiskAccessMode.mmap`).
+- **Data.db** uses buffered I/O via `ioOptions.defaultDiskAccessMode` — not mmap.
+
+This hybrid retains mmap’s lookup speed for index navigation while keeping `Data.db` reads
+buffered, reducing address-space pressure and JVM GC interaction. Source: `IOOptions.java` and
+`SortedTableReaderLoadingBuilder.java:65`. To revert to pre-5.0 behavior, set
+`disk_access_mode: auto` in `cassandra.yaml`.
+
+### ChunkCache and `file_cache_size`
+
+Cassandra optionally wraps buffered readers in a `ChunkCache` (configured via `file_cache_size`
+in `cassandra.yaml`). The cache stores decompressed chunks so repeated random reads into the
+same compressed region avoid re-decompression. Integration point: `FileHandle.java:444–448`
+(`maybeCached()` wraps `SimpleChunkReader` with `CachingRebufferer`). The `BufferPool` backing
+individual read allocations has a hard maximum of **64 KiB**
+(`DiskOptimizationStrategy.java:32`: `MAX_BUFFER_SIZE = 1 << 16`).
+
 ## Practical guidance on chunk sizes
 
-- Server default for `chunk_length` in 5.0: see `CompressionParams` (defaults vary by compressor and release; many deployments use 64 KiB with LZ4 by default)
+- Server default for `chunk_length_in_kb` in 5.0: **16 KiB** with LZ4 compressor (`CompressionParams.java:47`: `DEFAULT_CHUNK_LENGTH = 1024 * 16`). 64 KiB is a common tuning choice, not the default.
 - 32–64 KiB can reduce metadata overhead and improve scan throughput at the cost of higher random-read amplification
 - ≤16 KiB may help highly random access patterns when storage latency is high, but increases metadata and CPU overhead
 
@@ -70,10 +93,12 @@ False positive rate (FPR) refresher:
 - Checksums and digests provide integrity at chunk and file levels
 
 ### References
-- Cassandra 5.0.0 (pinned):
-  - `CompressionMetadata` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/compress/CompressionMetadata.java`
-  - `CompressionParams` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/compress/CompressionParams.java`
-  - `BloomFilter` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/utils/bloom/BloomFilter.java`
+- Cassandra 5.0.8 (pinned):
+  - `CompressionMetadata` — https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/compress/CompressionMetadata.java
+  - `CompressionParams` (DEFAULT_CHUNK_LENGTH=16384, L47) — https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/schema/CompressionParams.java#L47
+  - `BloomFilter` — https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/utils/bloom/BloomFilter.java
+  - `IOOptions` (mmap_index_only wiring) — https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/IOOptions.java
+  - `DiskOptimizationStrategy` (MAX_BUFFER_SIZE L32) — https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/util/DiskOptimizationStrategy.java#L32
   
 For implementation walkthroughs, see Appendix C.
 

--- a/docs/sstables-definitive-guide/chapters/10-point-reads-and-slices.md
+++ b/docs/sstables-definitive-guide/chapters/10-point-reads-and-slices.md
@@ -51,9 +51,10 @@ From `test_basic/simple_table`:
 - Range scans mix summary jumps with sequential index advances.
 
 ### References
-- Cassandra 5.0.0:
-  - `IndexSummary`: https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/IndexSummary.java
-  - Read commands: `org.apache.cassandra.db.SinglePartitionReadCommand`
+- Cassandra 5.0.8 (pinned):
+  - `IndexSummary` — https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/IndexSummary.java
+  - `SinglePartitionReadCommand` (read decision tree L701–L807) — https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/SinglePartitionReadCommand.java#L701-L807
+  - `BigTableReader` (per-SSTable read order L220–L278) — https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java#L220-L278
   
 For implementation details, see Appendix C.
 

--- a/docs/sstables-definitive-guide/chapters/11-merging-tombstones-and-shadowing.md
+++ b/docs/sstables-definitive-guide/chapters/11-merging-tombstones-and-shadowing.md
@@ -19,6 +19,18 @@ Reconciliation applies Cassandra 5.0 semantics to select visible values.
 
 Row-level handling ensures newer data can supersede older row tombstones when timestamps allow.
 
+### Tombstone Tie-Breaking Hierarchy
+
+When two cells share **equal timestamps**, `Cells.resolveRegular()` applies this precedence
+(`Cells.java:79–128`, CASSANDRA-14592):
+
+1. **Tombstone/expiring beats live cell** — any cell with a `localDeletionTime` wins over a live
+   cell at the same timestamp.
+2. **Pure tombstone beats expiring cell** — a hard delete wins over a TTL-expiring write.
+3. **Higher `localDeletionTime` wins** — between two expiring cells or two tombstones.
+4. **Lower TTL wins** — between two expiring cells with equal `localDeletionTime`.
+5. **Value bytes** — final tiebreaker for live cells with identical timestamps.
+
 ## Range Tombstones
 
 Range tombstones delete clustering intervals; readers must compare timestamps against range bounds during reconciliation.
@@ -30,7 +42,9 @@ Range tombstones delete clustering intervals; readers must compare timestamps ag
 - Caption: Newer values can shadow older tombstones; TTLs create time-bound deletions
 
 ## Key Takeaways
-- Newest wins unless tombstones at or after write remove visibility.
+- Newest wins by timestamp; at **equal timestamp**, tombstones (and expiring cells) always beat
+  live cells (`Cells.java:94`, CASSANDRA-14592). Within equal-timestamp tombstones: pure
+  tombstone beats expiring cell; then higher `localDeletionTime`; then lower TTL.
 - Range tombstones apply only within their intervals and while active.
 - TTL expiry can surface as synthetic tombstones.
 
@@ -39,8 +53,10 @@ Range tombstones delete clustering intervals; readers must compare timestamps ag
 - Range tombstone filtering: O(n × t) worst-case (n entries, t tombstones) but typically reduced by time-sorted early exits.
 
 ### References
-- Cassandra 5.0.0:
-  - Rows/tombstones: [org.apache.cassandra.db.rows](https://github.com/apache/cassandra/tree/cassandra-5.0.0/src/java/org/apache/cassandra/db/rows)
+- Cassandra 5.0.8 (pinned):
+  - `Cells.java` (tombstone reconciliation L79–L128) — https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/rows/Cells.java#L79-L128
+  - `DeletionTime.supersedes()` (partition/row tombstone precedence L158–L161) — https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/DeletionTime.java#L158-L161
+  - Rows/tombstones package — https://github.com/apache/cassandra/tree/cassandra-5.0.8/src/java/org/apache/cassandra/db/rows
   
 For implementation details, see Appendix C.
 

--- a/docs/sstables-definitive-guide/chapters/12-caching-and-os-interaction.md
+++ b/docs/sstables-definitive-guide/chapters/12-caching-and-os-interaction.md
@@ -17,7 +17,11 @@ For a concrete cache/IO implementation walkthrough, see Appendix C.
 
 ## Practical Defaults
 
-- Use mmap for large sequential scans; buffered async for mixed/random workloads
+- Cassandra 5.0 defaults to `mmap_index_only`: index files are mmap'd; `Data.db` uses buffered
+  I/O. This is the recommended baseline — see Ch. 3 for `IOOptions.java` wiring details.
+- For workloads saturating `Data.db` sequentially, `disk_access_mode: mmap` re-enables full mmap;
+  be aware of JVM address-space pressure on large datasets.
+- Buffered async I/O suits mixed/random workloads and bounded-memory `Data.db` reads.
 - Keep Bloom enabled; summary sampling reduces seeks
 - Tune prefetch window to match chunk sizes (see Ch. 9)
 
@@ -31,7 +35,10 @@ For a concrete cache/IO implementation walkthrough, see Appendix C.
 - Fall back to buffered IO when decompression or random access breaks large request alignment.
 
 ### Buffer Pool Sizing
-- Start with pool size ≈ (concurrency × average request size × 2). Bound by memory budget and adjust to keep allocator overhead <5% CPU.
+- The `BufferPool` backing `RandomAccessReader` allocations has a hard ceiling of **64 KiB** per
+  buffer (`DiskOptimizationStrategy.java:32`: `MAX_BUFFER_SIZE = 1 << 16`).
+- Start with pool size ≈ (concurrency × average request size × 2). Bound by memory budget and
+  adjust to keep allocator overhead <5% CPU.
 - Align buffers to chunk size boundaries to minimize partial-chunk decompression and copies.
 
 ### Key Takeaways
@@ -40,7 +47,9 @@ For a concrete cache/IO implementation walkthrough, see Appendix C.
 - Prefetch and block caches mitigate random-read penalties
 
 ### References
-- Cassandra 5.0.0:
+- Cassandra 5.0.8 (pinned):
+  - `IOOptions` (mmap_index_only wiring) — https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/IOOptions.java
+  - `DiskOptimizationStrategy` (MAX_BUFFER_SIZE L32) — https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/util/DiskOptimizationStrategy.java#L32
   - Reader abstractions and IO options in `org.apache.cassandra.io.*`
   
 For implementation details, see Appendix C.

--- a/docs/sstables-definitive-guide/chapters/appendix-e-glossary.md
+++ b/docs/sstables-definitive-guide/chapters/appendix-e-glossary.md
@@ -18,10 +18,13 @@ Concise definitions; cross-link to first use in the chapters.
 - BTI: B-Tree/Trie indexed SSTable format family in Cassandra 5.x.
   See `17-bti-formats.md`.
 
-- TrieMemtable: Cassandra 5.0's default memtable implementation using a byte-ordered prefix trie
+- TrieMemtable: An **opt-in** memtable in Cassandra 5.0, using a byte-ordered prefix trie
   (`InMemoryTrie`) for efficient memory usage and reduced GC pressure. Stores partitions using
-  `ByteComparable` keys with prefix sharing. Sharded across CPU cores for write concurrency.
-  See `04-from-cql-to-disk.md` and [TrieMemtable.java](https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/db/memtable/TrieMemtable.java).
+  `ByteComparable` keys with prefix sharing; sharded across CPU cores for write concurrency.
+  The **default** memtable in 5.0 is `SkipListMemtable` (`MemtableParams.java:99`); opt in via
+  `memtable: { class: TrieMemtable }` in the table schema or `cassandra.yaml`.
+  See `04-from-cql-to-disk.md` and
+  [TrieMemtable.java](https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/memtable/TrieMemtable.java).
 
 - big format: Legacy SSTable format family (pre-BTI) with classic `BigTableReader`/`Writer`.
   See `02-anatomy-of-an-sstable.md` and `17-bti-formats.md` for contrasts.


### PR DESCRIPTION
## Summary
Audit batch B9 (epic #598). Fixes Ch.01-03, Ch.10-12, Appendix E (plus B10's Ch.02-scoped findings).

Key fixes:
- TrieMemtable is NOT the 5.0 default — SkipListMemtable is (`MemtableParams.java:99`); Ch.01 + App E corrected
- Lookup order is Bloom → **Summary → Index** → Data (was reversed); min/max key bounds checked before Bloom
- Statistics.db is written AFTER Data.db in doPrepare(), not before (`SSTableWriter.java:384-392`)
- Default chunk_length is 16 KiB; new coverage: 5.0 default disk_access_mode=mmap_index_only (CASSANDRA-19021), ChunkCache/file_cache_size, BufferPool 64 KiB cap
- Ch.11: tombstone beats live cell at equal timestamp (`Cells.java:94`, CASSANDRA-14592) + full tie-breaking hierarchy
- Ch.02: 5.0 writes oa-/da- versioned filenames (examples fixed); format names are big/bti only
- Permalinks re-pinned to cassandra-5.0.8 + 6 new citations

Closes #607. Part of epic #598.