### PR TITLE
docs(guide): fix type-mapping and version matrix vs cassandra-5.0.8 (#608)

### DIFF
--- a/docs/sstables-definitive-guide/chapters/22-versioning-matrix.md
+++ b/docs/sstables-definitive-guide/chapters/22-versioning-matrix.md
@@ -4,17 +4,27 @@ A one-page map of Cassandra releases to SSTable version tags and on-disk deltas.
 
 | Release | SSTable tag(s) | Notable on-disk deltas | Gates/notes | Anchors |
 |---|---|---|---|---|
-| 3.x | `mc` (and earlier series) | Legacy BIG layouts; size-prefixed Snappy in places; no NB | BIG family only | `Descriptor`, `BigTableReader` |
-| 4.x | `md`/`me` (varies by minor) | BIG refinements; summary/token changes; no NB | Gate by tag; consult per-release notes | `Descriptor`, `IndexSummary` |
-| 5.0 | `V5_0NewBig` (NB coexists with BIG) | NB: header-less `Data.db`, trailing per-chunk CRCs, CompressionInfo-driven chunk map; Index entry variant with optional 2-byte length prefix in BIG | Gate by `Descriptor` format (`nb` vs `big`); detect BIG index entry variant by prefix | `SSTableReader`, `RowIndexEntry`, `CompressionMetadata` |
+| 3.x | `ma`--`me` (BIG only) | Legacy BIG layouts; `ma`=3.0.0 baseline; `mb`=commit-log lower bound; `mc`=commit-log intervals; `md`=accurate min/max (3.0.18); `me`=originating host ID (3.0.25) | BIG family only; `earliest_supported_version = "ma"` | `BigFormat.java:344`, `BigTableReader` |
+| 4.x | `na`/`nb` (BIG only) | `na` (4.0-rc1): max-compressed-length, pending-repair, is-transient, metadata checksum, new Bloom filter format; `nb` (4.0-rc2): no new major features | Gate by version letter `na`/`nb`; `hasOriginatingHostId` fires for `nb`+ **or** `me`+ (straddles series -- see note below) | `BigFormat.java:400-405`, `Descriptor` |
+| 5.0 | `oa` (BIG) / `da` (BTI) | `oa` feature gates: `hasImprovedMinMax`, `hasPartitionLevelDeletionPresenceMarker`, `hasKeyRange`, `hasUIntDeletionTime` (year-2106 safe), `hasTokenSpaceCoverage`; `hasAccurateMinMax`=FALSE (deprecated in `oa`); BTI `da` enables all modern gates | **Default write version is `nb` (BIG).** `BigFormat.java:343`: `current_version = storageCompatibilityMode.isBefore(5) ? "nb" : "oa"`. Stock 5.0 clusters default to `storage_compatibility_mode=CASSANDRA_4` (NEWS.txt), which satisfies `isBefore(5)`, so they write `nb`-versioned BIG SSTables until the operator raises the mode. BTI format always writes `da`. Gate by format **name** (`big` vs `bti`) then version letter (`oa` for 5.0+ BIG; `da` for all BTI). | `BigFormat.java:343,406-410`, `BtiFormat.java:289-290`, `Descriptor.java:85,189` |
+
+### `hasOriginatingHostId` gate note
+
+`BigFormat.java:400`: `hasOriginatingHostId = version.compareTo("nb") >= 0 || version.matches("(m[e-z])")`. This gate straddles two major-letter series: it fires for `me`--`mz` (late 3.x) **and** independently for all `na`+ (4.x and above). Parsers must check both conditions.
+
+### `hasAccurateMinMax` deprecation note
+
+`BigFormat.java:397` comment: `hasAccurateMinMax` applies to versions `md`--`mz` and `na`--`nz`. It is deprecated in `oa` and to be removed after `oa`. The `oa` row uses `hasImprovedMinMax` instead. Set `hasAccurateMinMax=FALSE` for any `oa`+ file.
 
 ### How to use this matrix
-- Read `Descriptor` to determine format/tag; gate parsing paths accordingly.
+- Read `Descriptor` to determine format name and version letter; gate parsing paths accordingly.
+- Filename format: `<version>-<id>-<formatName>-<component>.db` (e.g., `oa-1-big-Data.db`, `da-3-bti-Partitions.db`).
+- Detection is by format **name** (`big` or `bti`), not by version letter alone.
 - For BIG Index entries, handle both variants (non-prefixed and length-prefixed); see Chapter 06.
-- For NB `Data.db`, ignore header/magic and validate trailing per-chunk CRCs using `CompressionInfo.db`.
 
-References (pinned to 5.0.0 where relevant):
-- `Descriptor`: https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/Descriptor.java
-- `SSTableReader`: https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/SSTableReader.java
-- `RowIndexEntry` (BIG): https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/format/big/RowIndexEntry.java
-- `CompressionMetadata`: https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/compress/CompressionMetadata.java
+References (pinned to cassandra-5.0.8):
+- `Descriptor`: https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/Descriptor.java
+- `BigFormat` (versions & gates): https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigFormat.java
+- `BtiFormat` (version & gates): https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/bti/BtiFormat.java
+- `SSTableReader`: https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/SSTableReader.java
+- `CompressionMetadata`: https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/compress/CompressionMetadata.java

--- a/docs/sstables-definitive-guide/chapters/appendix-a-type-mapping.md
+++ b/docs/sstables-definitive-guide/chapters/appendix-a-type-mapping.md
@@ -1,4 +1,4 @@
-# Appendix A — CQL→SSTable Type Mapping
+# Appendix A -- CQL->SSTable Type Mapping
 
 In this appendix you will learn:
 - How CQL primitive, collection, UDT, and vector types map to on-disk encodings
@@ -16,49 +16,53 @@ This appendix consolidates the type mapping tables for Cassandra 5.0 SSTables an
 ## Worked Examples
 
 - Nested collection (map<text, list<int>>), 2 entries:
-  - Encoding: count (VInt) → for each entry: key (VInt len + UTF-8), value list (VInt elem count → each int as 4 bytes)
-  - Size rule of thumb: total_size ≈ size(VInt(count)) + Σ[ size(VInt(|key|)) + |key| + size(VInt(list_len)) + 4*list_len ]
+  - Encoding: count (VInt) -> for each entry: key (VInt len + UTF-8), value list (VInt elem count -> each int as 4 bytes)
+  - Size rule of thumb: total_size ~= size(VInt(count)) + sum[ size(VInt(|key|)) + |key| + size(VInt(list_len)) + 4*list_len ]
 
 - UDT with optional fields (frozen):
-  - Encoding: for each field in definition order: VInt length + value bytes; null field uses length = -1 (VInt)
-  - Size rule of thumb: total_size ≈ Σ size(VInt(len_i)) + Σ max(len_i, 0)
+  - Encoding: for each field in definition order: **4-byte BE signed int** length + value bytes; null field uses length = 0xFFFFFFFF (-1 as signed int)
+  - Size rule of thumb: total_size ~= sum (4 + max(len_i, 0))
 
-## Upstream anchors (Cassandra 5.0.0)
+## Upstream anchors (cassandra-5.0.8)
 
 - Serialization header and schema-driven encodings
   - `org.apache.cassandra.db.SerializationHeader`
-    - `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/db/SerializationHeader.java`
+    - `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/SerializationHeader.java`
 - Type marshallers (`org.apache.cassandra.db.marshal.*`)
-  - Directory: `https://github.com/apache/cassandra/tree/cassandra-5.0.0/src/java/org/apache/cassandra/db/marshal`
-  - Representative primitives: 
-    - `LongType` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/db/marshal/LongType.java`
-    - `Int32Type` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/db/marshal/Int32Type.java`
-    - `UTF8Type` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/db/marshal/UTF8Type.java`
-    - `AsciiType` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/db/marshal/AsciiType.java`
-    - `UUIDType` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/db/marshal/UUIDType.java`
-    - `TimeUUIDType` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/db/marshal/TimeUUIDType.java`
-    - `TimestampType` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/db/marshal/TimestampType.java`
-    - `InetAddressType` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/db/marshal/InetAddressType.java`
-    - `DecimalType` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/db/marshal/DecimalType.java`
-    - `DurationType` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/db/marshal/DurationType.java`
+  - Directory: `https://github.com/apache/cassandra/tree/cassandra-5.0.8/src/java/org/apache/cassandra/db/marshal`
+  - Representative primitives:
+    - `LongType` -- `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/marshal/LongType.java`
+    - `Int32Type` -- `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/marshal/Int32Type.java`
+    - `UTF8Type` -- `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/marshal/UTF8Type.java`
+    - `AsciiType` -- `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/marshal/AsciiType.java`
+    - `UUIDType` -- `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/marshal/UUIDType.java`
+    - `TimeUUIDType` -- `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/marshal/TimeUUIDType.java`
+    - `TimestampType` -- `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/marshal/TimestampType.java`
+    - `InetAddressType` -- `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/marshal/InetAddressType.java`
+    - `DecimalType` -- `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/marshal/DecimalType.java`
+    - `DurationType` -- `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/marshal/DurationType.java`
+    - `IntegerType` (varint) -- `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/marshal/IntegerType.java`
+    - `CounterColumnType` -- `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/marshal/CounterColumnType.java`
   - Collections and complex:
-    - `ListType` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/db/marshal/ListType.java`
-    - `SetType` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/db/marshal/SetType.java`
-    - `MapType` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/db/marshal/MapType.java`
-    - `TupleType` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/db/marshal/TupleType.java`
-    - `UserType` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/db/marshal/UserType.java`
-    - `VectorType` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/db/marshal/VectorType.java`
+    - `ListType` -- `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/marshal/ListType.java`
+    - `SetType` -- `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/marshal/SetType.java`
+    - `MapType` -- `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/marshal/MapType.java`
+    - `TupleType` -- `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/marshal/TupleType.java`
+    - `UserType` -- `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/marshal/UserType.java`
+    - `VectorType` -- `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/marshal/VectorType.java`
 
 ## Notes
 
-- Variable-length fields use VInt-encoded lengths. See Appendix B for VInt details.
-- Collections and UDTs encode each element/field as length-prefixed value; `-1` denotes null.
+- **Collection element lengths** (list, set, map) use unsigned VInt encoding (`CollectionSerializer.java:43,51`). See Appendix B for VInt details.
+- **Tuple and UDT field lengths** use **4-byte BE signed int** (not VInt). Null fields are encoded as 0xFFFFFFFF (-1). Source: `TupleType.java:345-359`.
+- **Vector types**: fixed-element vectors (`vector<float,n>`) write no length prefix -- layout is exactly `n x elementSize` bytes concatenated. Source: `VectorType.java:477-493`, `FixedLengthSerializer`.
 
 ## Key Takeaways
 - Primitive numeric and time types are fixed-width big-endian values.
-- Strings and blobs are length-prefixed with VInt; collections and UDTs repeat that pattern for members/fields.
+- Strings and blobs are length-prefixed with VInt; collection counts and element lengths also use unsigned VInt.
+- Tuple and UDT field lengths use 4-byte BE signed int; -1 (0xFFFFFFFF) = null.
+- Fixed-element vectors (e.g., `vector<float,n>`) are raw concatenated elements with no length prefix.
 - Serialization is schema-driven; `SerializationHeader` and the `db.marshal` types define exact encodings.
 
 ## References
-- Cassandra 5.0: see Upstream anchors above for pinned links
-
+- Cassandra 5.0.8: see Upstream anchors above for pinned links

--- a/docs/sstables-definitive-guide/tables/type-mapping-collections.md
+++ b/docs/sstables-definitive-guide/tables/type-mapping-collections.md
@@ -1,14 +1,14 @@
-## CQL → SSTable Type Mapping — Collections and Tuples (Cassandra 5.0)
+## CQL -> SSTable Type Mapping -- Collections and Tuples (Cassandra 5.0)
 
 | CQL type | On-disk representation | Notes |
 |---|---|---|
-| `list<T>` | VInt element count; for each element: [VInt length + value bytes or fixed-size value] | Elements serialized using `T`'s encoding |
+| `list<T>` | Unsigned VInt element count; for each element: [unsigned VInt length + value bytes or fixed-size value] | Elements serialized using `T`'s encoding. Count and element lengths use `writeUnsignedVInt32`. Source: `CollectionSerializer.java:43,51`. |
 | `set<T>` | Same as `list<T>` with set semantics | Elements sorted by comparator on read paths |
-| `map<K,V>` | VInt entry count; for each entry: key then value serialized as per types | Keys must be unique; order by key comparator |
-| `tuple<T1,...,Tn>` | For each field: [VInt length + value bytes or fixed-size value]; null fields encoded as -1 length | Field order fixed |
+| `map<K,V>` | Unsigned VInt entry count; for each entry: key then value serialized as per types | Keys must be unique; order by key comparator. Source: `CollectionSerializer.java:58`. |
+| `tuple<T1,...,Tn>` | For each field: [**4-byte BE signed int** length + value bytes]; null fields encoded as 0xFFFFFFFF (-1) | Field lengths are 4-byte BE int, **not** VInt. Source: `TupleType.java:345-359`. |
 | `frozen<...>` | Payload serialized as a single value using inner type encoding | Prevents updates by sub-component |
 
-Length fields above are VInt-encoded. See the Encodings cheat sheet for VInt details.
+**Collection element lengths** (list, set, map) use unsigned VInt encoding (`CollectionSerializer.java`).
+**Tuple field lengths** use 4-byte BE signed int: -1 (0xFFFFFFFF) = null, 0 = empty, >0 = byte count. See Appendix B for VInt details.
 
-- Cassandra 5.0: `org.apache.cassandra.db.SerializationHeader` (`https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/db/SerializationHeader.java`)
-
+- Cassandra 5.0.8: `org.apache.cassandra.db.SerializationHeader` (`https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/SerializationHeader.java`)

--- a/docs/sstables-definitive-guide/tables/type-mapping-complex.md
+++ b/docs/sstables-definitive-guide/tables/type-mapping-complex.md
@@ -1,16 +1,16 @@
-## CQL → SSTable Type Mapping — Complex Types (Cassandra 5.0)
+## CQL -> SSTable Type Mapping -- Complex Types (Cassandra 5.0)
 
 | CQL type | On-disk representation | Notes |
 |---|---|---|
-| `udt<name>` | For each field (in definition order): [4-byte BE i32 length][value bytes] | -1=null, 0=empty, >0=data length |
+| `udt<name>` | For each field (in definition order): [4-byte BE i32 length][value bytes] | -1=null, 0=empty, >0=data length. Source: `TupleType.java:345-359` (UserType delegates to `TupleType.buildValue`). |
 | `frozen<udt<...>>` | Same as UDT, serialized as single blob | Treated atomically, single-cell storage |
 | `list<frozen<udt>>` | Multi-cell: each element is separate cell with frozen UDT blob | Outer list not frozen = multi-cell |
 | `frozen<list<udt>>` | Single-cell: entire list serialized as one blob | Outer frozen = single-cell |
-| `vector<float,n>` | VInt length (n) + `n` 32-bit floats (big-endian) | Vector CQL type introduced in 5.x |
+| `vector<float,n>` | Exactly `n x 4` bytes -- **no length prefix** | Fixed-element vector: `FixedLengthSerializer` concatenates elements with zero framing overhead. Layout = n x elementSize bytes. For variable-element vectors, each element is prefixed with unsigned VInt length. Source: `VectorType.java:477-493,565-576`. |
 
 ### UDT Binary Format Details
 
-**Frozen UDT field encoding** (confirmed via Issue #220):
+**Frozen UDT field encoding** (confirmed via `TupleType.java:345-359`):
 ```
 [field_1_length: 4-byte BE i32][field_1_data: variable bytes]
 [field_2_length: 4-byte BE i32][field_2_data: variable bytes]
@@ -43,6 +43,6 @@ The **outer** type determines storage format. Inner frozen types affect element 
 
 References:
 
-- Cassandra 5.0: `org.apache.cassandra.db.marshal.VectorType` (`https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/db/marshal/VectorType.java`)
-- Cassandra 5.0: `org.apache.cassandra.db.SerializationHeader` (`https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/db/SerializationHeader.java`)
-
+- Cassandra 5.0.8: `org.apache.cassandra.db.marshal.VectorType` (`https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/marshal/VectorType.java`)
+- Cassandra 5.0.8: `org.apache.cassandra.db.marshal.TupleType` (`https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/marshal/TupleType.java`)
+- Cassandra 5.0.8: `org.apache.cassandra.db.SerializationHeader` (`https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/SerializationHeader.java`)

--- a/docs/sstables-definitive-guide/tables/type-mapping-primitives.md
+++ b/docs/sstables-definitive-guide/tables/type-mapping-primitives.md
@@ -1,4 +1,4 @@
-## CQL → SSTable Type Mapping — Primitives (Cassandra 5.0)
+## CQL -> SSTable Type Mapping -- Primitives (Cassandra 5.0)
 
 This table summarizes how common primitive CQL types map to on-disk encodings in `Data.db`. Sizes indicate fixed-length payloads, excluding length prefixes for variable types.
 
@@ -11,19 +11,20 @@ This table summarizes how common primitive CQL types map to on-disk encodings in
 | `bigint` | 64-bit signed integer (big-endian) | 8 | |
 | `float` | IEEE-754 single (big-endian) | 4 | |
 | `double` | IEEE-754 double (big-endian) | 8 | |
-| `decimal` | variable (scale:int32 + unscaled BigInteger bytes) | — | BigInteger two's-complement bytes preceded by scale |
-| `text`/`varchar` | VInt length + UTF-8 bytes | — | Length is VInt-encoded |
-| `ascii` | VInt length + ASCII bytes | — | No multibyte chars |
-| `blob` | VInt length + raw bytes | — | |
+| `decimal` | variable (scale:int32 + unscaled BigInteger bytes) | -- | 4-byte BE signed scale followed by BigInteger two's-complement bytes. Source: `DecimalType.java:275-278`. |
+| `varint` | variable (custom byte-ordered encoding) | -- | **Not** standard VInt. Two cases (source: `IntegerType.java:48-53,207-210`): (1) length < 7 bytes: 0x80-based positive-varint header; (2) length >= 7 bytes: sign byte (0xFF=positive, 0x00=negative) + variable-length unsigned magnitude. `FULL_FORM_THRESHOLD=7`. |
+| `counter` | 8-byte signed integer (big-endian) | 8 | On-disk value is 8-byte BE long (the counter value). Distributed counter context/clock shards are in the cell context header, not the value payload. Source: `CounterColumnType.java`. |
+| `text`/`varchar` | VInt length + UTF-8 bytes | -- | Length is unsigned VInt-encoded |
+| `ascii` | VInt length + ASCII bytes | -- | No multibyte chars |
+| `blob` | VInt length + raw bytes | -- | |
 | `timestamp` | 64-bit millis since epoch (big-endian) | 8 | |
-| `date` | 32-bit unsigned days offset (big-endian) | 4 | Epoch at 1970-01-01 bias per Cassandra |
+| `date` | 32-bit unsigned days, epoch-biased (big-endian) | 4 | Stored as epoch-days + 2^31 (0x80000000); on-disk value 0x80000000 = 1970-01-01. `SimpleDateSerializer.timeInMillisToDay()` adds `Integer.MIN_VALUE` bias. Source: `SimpleDateType.java:42`. |
 | `time` | 64-bit nanoseconds since midnight (big-endian) | 8 | |
 | `uuid` | 128-bit UUID | 16 | Network byte order |
 | `timeuuid` | 128-bit time-based UUID | 16 | Includes timestamp fields |
-| `inet` | 4 or 16 bytes | — | IPv4 = 4 bytes, IPv6 = 16 bytes |
-| `duration` | variable (months VInt, days VInt, nanos VInt) | — | Triplet of VInts |
+| `inet` | 4 or 16 bytes | -- | IPv4 = 4 bytes, IPv6 = 16 bytes |
+| `duration` | variable (months VInt, days VInt, nanos VInt) | -- | Triplet of signed (zigzag) VInts. All three components use zigzag-signed VInt encoding even though months and days are non-negative by CQL contract. Source: `DurationType.java:33-34`. |
 
 Reference: `SerializationHeader` defines type info carried in partition/row serialization.
 
-- Cassandra 5.0: `org.apache.cassandra.db.SerializationHeader` (`https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/db/SerializationHeader.java`)
-
+- Cassandra 5.0.8: `org.apache.cassandra.db.SerializationHeader` (`https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/SerializationHeader.java`)


### PR DESCRIPTION
## Summary
Audit batch B10 (epic #598). Fixes Appendix A, type-mapping tables, and Ch.22.

Key fixes:
- Ch.22: nonexistent `V5_0NewBig` tag eliminated — real 5.0 versions are `oa` (BIG, `BigFormat.java:343`) and `da` (BTI, `BtiFormat.java:289`); `md`/`me` are 3.x, `na`/`nb` are 4.0
- Documents that stock 5.0 writes `nb` by default (storage_compatibility_mode=CASSANDRA_4 satisfies isBefore(5)) until the operator raises the mode
- All `oa` feature gates added (hasImprovedMinMax, hasPartitionLevelDeletionPresenceMarker, hasKeyRange, hasUIntDeletionTime, hasTokenSpaceCoverage) + hasOriginatingHostId straddle-gate note
- Appendix A: tuple/UDT field lengths are 4-byte BE signed int (-1=null), NOT VInt — parsers treating these as VInt corrupt fields ≥ 128 bytes
- vector<float,n> has NO length prefix (exactly n×4 bytes, `VectorType.java:477-493`)
- Missing varint/counter rows added; date epoch bias fixed; permalinks re-pinned to cassandra-5.0.8

Closes #608. Part of epic #598.