### PR TITLE
docs(guide): fix appendix C/D walkthroughs + re-pin all references to cassandra-5.0.8 (#619)

### DIFF
--- a/docs/sstables-definitive-guide/OPEN_QUESTIONS.md
+++ b/docs/sstables-definitive-guide/OPEN_QUESTIONS.md
@@ -43,7 +43,7 @@ A: Yes, make sure there are clean, permanent links.
 
 ## Further Clarifying Questions
 - Pinning target: do you prefer `cassandra-5.0.0` tag specifically, or `cassandra-5.0` branch for permalinks?
-A: cassandra-5.0.0 branch since it pins a version. 
+A: cassandra-5.0.0 branch since it pins a version. Updated to cassandra-5.0.8 (2026-06-09) after source-verification audit confirmed several class paths changed between 5.0.0 and 5.0.8 (SSTableReader → format/, IndexSummary → indexsummary/, SSTableDump → SSTableExport, SSTableMetadata → SSTableMetadataViewer). All guide permalinks now target cassandra-5.0.8.
 
 - SAI scope: include numeric and text index internals only, or also cover spatial/vector if present in 5.0?
 A: Include vector since it is a part of 5.0 

--- a/docs/sstables-definitive-guide/PUBLISHING.md
+++ b/docs/sstables-definitive-guide/PUBLISHING.md
@@ -89,7 +89,7 @@ Files are numbered (`01-..`, `02-..`, …, `appendix-..`) so globbing `chapters/
 ## Validation Checklist
 - Run diagram render; confirm `.svg` exists for each `.mmd` in `diagrams/`.
 - Build HTML and PDF; open both and spot-check diagrams, tables, and code blocks.
-- Verify citations are pinned to `cassandra-5.0.0` (see `REFERENCES.md`).
+- Verify citations are pinned to `cassandra-5.0.8` (see `REFERENCES.md`).
 - Ensure Cassandra-first terminology per `STYLE_GUIDE.md`.
 
 ## Distribution

--- a/docs/sstables-definitive-guide/REFERENCES.md
+++ b/docs/sstables-definitive-guide/REFERENCES.md
@@ -2,12 +2,12 @@
 
 ## Version Baseline and Pinning Policy
 - Baseline: Apache Cassandra 5.0 (not 5.1). Older versions (3.x/4.x) are cited only for historical deltas and in sidebars.
-- Pinning: Prefer permalinks to the `cassandra-5.0.0` tag. When stability matters beyond tags, use commit-SHA permalinks.
+- Pinning: Prefer permalinks to the `cassandra-5.0.8` tag. When stability matters beyond tags, use commit-SHA permalinks.
 - Callouts: When behavior differs from 3.x/4.x, add an O’Reilly-style sidebar in the chapter and link the older code/doc.
 
 ## Apache Cassandra (Core) — 5.0 Namespace Map
 - Format and components: `org.apache.cassandra.io.sstable.format.*`, `...format.big.*`, `...format.bti.*`
-- Index summary: `org.apache.cassandra.io.sstable.IndexSummary`
+- Index summary: `org.apache.cassandra.io.sstable.indexsummary.IndexSummary`
 - Read path: `org.apache.cassandra.db.SinglePartitionReadCommand`, `org.apache.cassandra.db.partitions.UnfilteredPartitionIterator`
 - Write/flush path: `org.apache.cassandra.db.memtable.*`, `org.apache.cassandra.io.sstable.SSTableWriter`
 - Bloom filter: `org.apache.cassandra.utils.bloom.*`
@@ -42,27 +42,27 @@
 - ScyllaDB engineering posts for comparative context
 
 ## Referencing Guidance
-- Prefer linking to `cassandra-5.0.0` tag; include class and package names in the text.
+- Prefer linking to `cassandra-5.0.8` tag; include class and package names in the text.
 - Use short code excerpts only when necessary; otherwise point to permalinks.
 - Keep a per-chapter mini bibliography at the end of each file.
 
-## Pinned Upstream Links (Cassandra 5.0.0)
+## Pinned Upstream Links (Cassandra 5.0.8)
 
 - SSTable core:
-  - `SSTableReader` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/SSTableReader.java`
-  - `SSTableWriter` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/SSTableWriter.java`
-  - `BigTableReader` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java`
-  - `BigTableWriter` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java`
+  - `SSTableReader` — `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java`
+  - `SSTableWriter` — `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/SSTableWriter.java`
+  - `BigTableReader` — `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java`
+  - `BigTableWriter` — `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java`
 - Components:
-  - `IndexSummary` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/IndexSummary.java`
-  - `StatsMetadata` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/metadata/StatsMetadata.java`
-  - `CompressionMetadata` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/compress/CompressionMetadata.java`
-  - `BloomFilter` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/utils/bloom/BloomFilter.java`
-  - `Descriptor` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/Descriptor.java`
+  - `IndexSummary` — `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java`
+  - `StatsMetadata` — `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/metadata/StatsMetadata.java`
+  - `CompressionMetadata` — `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/compress/CompressionMetadata.java`
+  - `BloomFilter` — `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/utils/bloom/BloomFilter.java`
+  - `Descriptor` — `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/Descriptor.java`
 - SAI (Storage-Attached Indexes):
-  - Root: `https://github.com/apache/cassandra/tree/cassandra-5.0.0/src/java/org/apache/cassandra/index/sai`
-  - Disk formats: `https://github.com/apache/cassandra/tree/cassandra-5.0.0/src/java/org/apache/cassandra/index/sai/disk`
-  - Query: `https://github.com/apache/cassandra/tree/cassandra-5.0.0/src/java/org/apache/cassandra/index/sai/query`
+  - Root: `https://github.com/apache/cassandra/tree/cassandra-5.0.8/src/java/org/apache/cassandra/index/sai`
+  - Disk formats: `https://github.com/apache/cassandra/tree/cassandra-5.0.8/src/java/org/apache/cassandra/index/sai/disk`
+  - Query: `https://github.com/apache/cassandra/tree/cassandra-5.0.8/src/java/org/apache/cassandra/index/sai/query`
 
 ## Source Map
 

--- a/docs/sstables-definitive-guide/RELEASE_NOTES.md
+++ b/docs/sstables-definitive-guide/RELEASE_NOTES.md
@@ -2,6 +2,42 @@
 
 This document captures distribution notes for the Cassandra-focused guide. Keep CQLite mentions minimal; prioritize Cassandra correctness and pinned upstream references.
 
+## 2026-06-09 — Source-verification audit vs Apache Cassandra 5.0.8
+
+Full claim-by-claim audit of all guide chapters against a cassandra-5.0.8 source checkout
+(epic #598, PRs #609–#618 + this PR #619).
+
+### Summary of changes
+
+- All permalinks re-pinned from cassandra-5.0.0 to cassandra-5.0.8 across REFERENCES.md,
+  STYLE_GUIDE.md, source-map.md, context-brief.md, and both appendixes.
+- Major corrections applied (via individual audit PRs):
+  - Cell flag bits 3/4 corrected to USE_ROW_TIMESTAMP / USE_ROW_TTL
+  - Unsigned VInt encoding confirmed for temporal deltas
+  - Filter.db layout verified: `hashCount` (4B) then `wordCount` (4B) then raw bitset bytes;
+    field labels were previously swapped
+  - Inline per-chunk CRC32 clarified: 4-byte big-endian u32 appended in Data.db after each
+    compressed chunk; CompressionInfo.db holds only chunk start offsets
+  - Default chunk length confirmed as 16 KiB (not a different value)
+  - Version letter identifiers: `oa`/`da` replace the former `V5_0NewBig` placeholder names
+  - BIG Index.db entry format corrected: u16 BE key length + raw key bytes + vint position;
+    no 0x0010 marker, no MD5 digest — the bytes `0010` are the key length itself
+  - BTI clarified as "Big Trie-Indexed" format family
+- New coverage added: SAI vector on-disk format, zero-copy streaming, UCS compaction strategy,
+  manifest.json component.
+- Retracted: "Header CRC32 Validation (Legacy/BIG only)" section removed from Appendix C
+  (no BIG-family component prepends a 4-byte CRC32 header prefix; the per-chunk CRC lives
+  inline in NB Data.db only).
+- Moved class paths corrected:
+  - `SSTableReader` → `io/sstable/format/SSTableReader.java`
+  - `SSTableWriter` → `io/sstable/format/SSTableWriter.java`
+  - `IndexSummary` → `io/sstable/indexsummary/IndexSummary.java`
+  - `IndexSummaryBuilder` → `io/sstable/indexsummary/IndexSummaryBuilder.java`
+  - `SSTableDump` (nonexistent) → `tools/SSTableExport.java`
+  - `SSTableMetadata` (nonexistent) → `tools/SSTableMetadataViewer.java`
+
+---
+
 ## v0.1 (Draft for Review)
 
 ### Highlights

--- a/docs/sstables-definitive-guide/STYLE_GUIDE.md
+++ b/docs/sstables-definitive-guide/STYLE_GUIDE.md
@@ -39,7 +39,7 @@ This guide ensures consistency across chapters and contributors.
 
 ## Citations and Sources
 - Always include at least one Cassandra source link per major claim
-- Pin links to specific git tags/commits; default to `cassandra-5.0.0` tag
+- Pin links to specific git tags/commits; default to `cassandra-5.0.8` tag
 - Cassandra-first policy: keep CQLite references to a minimum. Avoid embedding CQLite code in core chapters; when useful, add a brief cross-link to Appendix C instead of in-body excerpts.
 
 ## Examples and Datasets

--- a/docs/sstables-definitive-guide/chapters/appendix-c-walkthroughs.md
+++ b/docs/sstables-definitive-guide/chapters/appendix-c-walkthroughs.md
@@ -9,23 +9,23 @@ In this appendix you will learn:
 
 Conceptually, a point read follows: Bloom → Index → Summary → Data. Cassandra defines serialization via `SerializationHeader` and marshaller types, while `IndexSummary` and `RowIndexEntry` guide seeks.
 
-Pinned upstream anchors (5.0.0):
-- `SSTableReader` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/SSTableReader.java`
-- `IndexSummary` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/IndexSummary.java`
-- `RowIndexEntry` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/format/big/RowIndexEntry.java`
-- `SerializationHeader` — `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/db/SerializationHeader.java`
+Pinned upstream anchors (cassandra-5.0.8):
+- `SSTableReader` — `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java`
+- `IndexSummary` — `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java`
+- `RowIndexEntry` — `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/RowIndexEntry.java`
+- `SerializationHeader` — `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/SerializationHeader.java`
 
 Step-by-step (using `test-data/datasets/test_basic` as mental model):
-1) Bloom filter: check partition key digest in `Filter.db` (negative → stop).
+1) Bloom filter: check partition key in `Filter.db` (negative → stop).
 2) Summary: binary search in `Summary.db` over tokens to find nearest `index_offset`.
-3) Index: scan `Index.db` from `index_offset` to find matching partition digest; read `RowIndexEntry`.
+3) Index: scan `Index.db` from `index_offset` to find matching partition key (u16-prefixed raw bytes); read `RowIndexEntry`.
 4) Data: seek to `Data.db` position from `RowIndexEntry`; read partition header, then row/cell payloads using `SerializationHeader`.
 
 Tiny trimmed example (conceptual):
 ```
 Summary entry: token=12345 index_offset=0x0000_2A10
-Index entry: key_digest=ab..cd data_offset=0x0001_0030
-Data read @0x0001_0030: partition header + row [len=0x12] ...
+Index entry: key=[u16 len][raw key bytes] data_position=vint
+Data read @data_position: partition header + row [len=0x12] ...
 ```
 
 Row and cell serialization are defined by `rows.*` and the marshaller types (`db.marshal.*`).
@@ -34,69 +34,33 @@ Index and Summary provide navigation primitives: `IndexSummary` samples `RowInde
 
 ## Walkthrough: NB chunk CRC verification (unit-testable)
 
-NB `Data.db` has no global header. Validation is per compressed chunk using `CompressionInfo.db`:
+NB `Data.db` has no global header. CRC32 is appended inline to each compressed chunk in `Data.db`. `CompressionInfo.db` provides chunk start offsets only — no CRCs.
 
 Example (real test file `event_store`):
 ```
 chunk 0: start=0x0000 comp_len=7729 expected=0x001daf10 computed=0x001daf10 match=true
 chunk 1: start=0x1e35 comp_len=2666 expected=0x657f7155 computed=0x657f7155 match=true
 ```
-Compute CRC32 over compressed bytes only; compare to trailing 4-byte big-endian u32 after each chunk.
+Compute CRC32 over compressed bytes only; compare to trailing 4-byte big-endian u32 appended inline after each chunk in `Data.db`.
 
-## Walkthrough: Header CRC32 Validation (Legacy/BIG only)
+## Walkthrough: BIG Index.db entry parse
 
-Some legacy/BIG family components may prepend a 4-byte CRC32 checksum to protect header integrity. NB format does not use header CRCs. This walkthrough demonstrates detection and validation for BIG artifacts only. Do not apply this logic to NB `Data.db`.
-
-### Schematic Example (legacy/BIG component with header CRC)
-
-```
-[4 bytes: CRC32 prefix] [header bytes starting with magic number]
-```
-
-High-level validation sketch:
-
-```rust
-let first4 = read_be_u32()?; // potential magic or CRC
-if CassandraVersion::from_magic_number(first4).is_none() {
-    let expected_crc = first4;
-    let header = read_header_bytes()?; // from offset 4
-    let computed = crc32fast::hash(&header);
-    if computed != expected_crc { return Err(Error::HeaderCorruption); }
-    parse_header(&header)?;
-} else {
-    // No prefix; parse header from offset 0
-    parse_header_from_offset_0()?;
-}
-```
-
-Scope note: NB `Data.db` begins with compressed chunk bytes and uses trailing per‑chunk CRCs; see the NB chunk CRC walkthrough above for the canonical NB integrity path.
-
-## Walkthrough: BIG Index.db entry parse (both variants)
+`BigTableWriter` writes each BIG `Index.db` entry as: a u16 big-endian key length, the raw key bytes, then a vint data position (followed by optional promoted index). There is no marker byte and no MD5 digest — the 2-byte field is the key length.
 
 Tiny hex → parsed struct → assertion.
 
-Input A (non-length-prefixed):
+Input (non-promoted):
 ```
 0010 6b88 bf20 a251 11f0 a3fe f1a5 5138 3fb9 00
 ```
 Parse:
-- marker = 0x0010
-- digest = 16 bytes (0x6b88…0x3fb9)
-- data_offset = vint (next bytes)
+- key_length = 0x0010 (= 16 bytes)
+- key_bytes = `6b88 bf20 a251 11f0 a3fe f1a5 5138 3fb9` (16 raw bytes)
+- data_position = vint (byte `00`, = position 0)
 
-Assertion: marker == 0x0010; digest.len == 16; offset >= 0.
+Assertion: `key_length == key_bytes.len; data_position >= 0`.
 
-Input B (length-prefixed):
-```
-001a 0010 37ac 9f53 bd8e 4da5 a41a 240f 8f5a 6cfd 00 00 04 80 00 4f 88
-```
-Parse:
-- entry_len = 0x001a
-- marker = 0x0010
-- digest = 16 bytes (0x37ac…0x6cfd)
-- data_offset = vint (subsequent bytes)
-
-Assertion: entry_len == bytes_consumed; marker == 0x0010; digest.len == 16.
+Source: `BigTableWriter.java:277` — `ByteBufferUtil.writeWithShortLength(key.getKey(), writer)` writes u16 length then raw bytes; `RowIndexEntry.serialize` writes the vint position.
 
 ## Walkthrough: Bloom on-disk decode (Filter.db)
 
@@ -105,22 +69,24 @@ Given bytes:
 0000 0005 0000 0002 a4c0 e2a8 02a2 a1b3 77
 ```
 Decode:
-- bitset_length_bytes = 5
-- k = 2
-- payload = 5 bytes
+- `hashCount = 5` (4 bytes: `00 00 00 05`) — number of hash functions (k)
+- `wordCount = 2` (4 bytes: `00 00 00 02`) — 64-bit word count of bitset (= 16 raw bytes follow)
+- bitset payload = next `wordCount × 8` bytes
 
-Bit packing: bits are LSB-first within each byte; consult `BloomFilter` writer/reader for word ordering (big-endian u64 words when serialized as words).
+Bit packing: new format (NB) copies raw memory bytes in native byte order. Old format writes each 64-bit word little-endian (LSB first). Neither format uses big-endian words. Consult `BloomFilterSerializer` and `OffHeapBitSet` for serialization details.
+
+Source: `BloomFilterSerializer.java:53-54` (hashCount then bitset.serialize); `OffHeapBitSet.java:117` (wordCount = bytes/8, then raw copy).
 
 ## Key Takeaways
 - Schema-aware decoding eliminates guesswork; comparators come from the schema.
 - Index and Summary readers narrow reads before hitting `Data.db` bytes.
-- **Header CRC32 validation** (Legacy/BIG only) detects corruption before parsing where present.
+- BIG `Index.db` entries use u16 BE key length + raw key bytes + vint position; no digest field exists.
+- Per-chunk CRC32 (NB `Data.db`) validates each compressed chunk via 4-byte big-endian u32 appended inline after the compressed bytes.
 - Use `crc32fast::hash()` for efficient checksum computation.
 - Validate with small, trimmed output from real SSTables (e.g., `sstabledump | head -n 10`).
 
 ## References
-- Cassandra 5.0: `SSTableReader`, `IndexSummary`, `RowIndexEntry`, `SerializationHeader` (see Source Map)
-- CQLite: Header CRC32 validation in `cqlite-core/src/storage/sstable/reader/header.rs`
+- Cassandra 5.0.8: `SSTableReader`, `IndexSummary`, `RowIndexEntry`, `SerializationHeader` (see Source Map)
 - CRC32 library: `crc32fast` crate (https://docs.rs/crc32fast/)
 
 ## CLI examples
@@ -134,9 +100,8 @@ sstablemetadata nb-1-big-Statistics.db
 # Dump index/summary entries (trimmed)
 sstabledump nb-1-big-Index.db | head -n 50
 
-# Verify digest over components (use Cassandra’s verifier or equivalent)
+# Verify digest over components (use Cassandra's verifier or equivalent)
 sstableverify /var/lib/cassandra/data/ks/table-uuid/
 ```
 
 Align outputs with the toy `test_basic/simple_table` used in examples elsewhere in this guide.
-

--- a/docs/sstables-definitive-guide/chapters/appendix-d-tools-and-workflows.md
+++ b/docs/sstables-definitive-guide/chapters/appendix-d-tools-and-workflows.md
@@ -7,16 +7,16 @@ In this appendix you will learn:
 
 ## Cassandra Tools (CLI)
 
-Examples use tiny, trimmed outputs for clarity.
+Examples use tiny, trimmed outputs for clarity. Cassandra 5.0 NB-format files use the `nb-1-big-` prefix.
 
 ```bash
-sstabledump /var/lib/cassandra/data/ks/tbl-.../mb-1-big-Data.db | head -n 10
+sstabledump /var/lib/cassandra/data/ks/tbl-.../nb-1-big-Data.db | head -n 10
 # Example trimmed output (illustrative):
 # {"partition": {"key": "..."}, "row": {"cells": [ ... ]}}
 ```
 
 ```bash
-sstablemetadata /var/lib/cassandra/data/ks/tbl-.../mb-1-big-Data.db
+sstablemetadata /var/lib/cassandra/data/ks/tbl-.../nb-1-big-Data.db
 # Example trimmed output:
 # SSTable Metadata: minTimestamp=..., maxTimestamp=..., partitionCount=...
 ```
@@ -26,9 +26,9 @@ Other tools:
 - `sstablelevelreset` — reset LCS levels
 - `sstableverify` — verify data checksums and components
 
-Pin source classes:
-- `org.apache.cassandra.tools.SSTableDump`
-- `org.apache.cassandra.tools.SSTableMetadata`
+Pin source classes (Cassandra 5.0.8):
+- `org.apache.cassandra.tools.SSTableExport` — implements the `sstabledump` CLI
+- `org.apache.cassandra.tools.SSTableMetadataViewer` — implements the `sstablemetadata` CLI
 
 ## Operational Notes (Cassandra)
 
@@ -40,6 +40,5 @@ Pin source classes:
 - Cross-check TOC and component presence before analysis.
 
 ## References
-- Cassandra 5.0 tools: `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/tools/SSTableDump.java`
-- Cassandra 5.0 tools: `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/tools/SSTableMetadata.java`
-
+- `SSTableExport` (sstabledump): `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/tools/SSTableExport.java`
+- `SSTableMetadataViewer` (sstablemetadata): `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/tools/SSTableMetadataViewer.java`

--- a/docs/sstables-definitive-guide/references/context-brief.md
+++ b/docs/sstables-definitive-guide/references/context-brief.md
@@ -9,7 +9,7 @@ This brief captures shared context, assumptions, and open deltas to align all co
 - Out of scope: encryption at rest, key management, operations-tuning guidance.
 
 ## Key Policies
-- Pin upstream citations to GitHub permalinks under the `cassandra-5.0.0` tag (or a commit SHA when necessary).
+- Pin upstream citations to GitHub permalinks under the `cassandra-5.0.8` tag (or a commit SHA when necessary).
 - Embed only short upstream code excerpts (<30 lines) and include a permalink to the full source.
 - Diagrams authored in Mermaid (`.mmd`) and committed; SVG export is optional for now.
 - Canonical examples must use `test-data/datasets/test_basic`.
@@ -32,7 +32,7 @@ This brief captures shared context, assumptions, and open deltas to align all co
 - Keep chapters ≤ ~500 lines; split where warranted.
 
 ## Open Deltas (to resolve early)
-- Confirm exact permalink scheme for Cassandra 5.0: prefer `cassandra-5.0.0` tag (naming verification) vs branch/tag variants.
+- Confirm exact permalink scheme for Cassandra 5.0: prefer `cassandra-5.0.8` tag (naming verification) vs branch/tag variants.
 - BTI exemplar dataset: choose/build a small canonical workload to illustrate BTI differences (wide partition and clustering variety?).
 - SAI vector coverage: enumerate concrete classes/files to cite (segment writers/readers, query ops) for 5.0.
 - Chapter file layout: confirm `chapters/` directory and naming convention (e.g., `01-what-are-sstables.md`).

--- a/docs/sstables-definitive-guide/references/source-map.md
+++ b/docs/sstables-definitive-guide/references/source-map.md
@@ -1,6 +1,6 @@
-# Source Map — Cassandra 5.0.0 (Pinned)
+# Source Map — Cassandra 5.0.8 (Pinned)
 
-This source map pins key classes and packages in Apache Cassandra 5.0.0 to the SSTable components and related topics covered in this guide. Links are permalinks to the `cassandra-5.0.0` tag. Prefer these when citing upstream code. When multiple files participate, we link the package directory and call out representative classes.
+This source map pins key classes and packages in Apache Cassandra 5.0.8 to the SSTable components and related topics covered in this guide. Links are permalinks to the `cassandra-5.0.8` tag. Prefer these when citing upstream code. When multiple files participate, we link the package directory and call out representative classes.
 
 Notes:
 - Component names follow Cassandra’s multi-file layout: `Data.db`, `Index.db`, `Summary.db`, `Filter.db`, `Statistics.db`, `CompressionInfo.db`, `TOC.txt`, `Digest.crc32`.
@@ -13,68 +13,68 @@ Notes:
 
 ### Data.db (read/write path)
 
-| Component/Topic | Cassandra class/package | Permalink (5.0.0) | Notes |
+| Component/Topic | Cassandra class/package | Permalink (5.0.8) | Notes |
 |---|---|---|---|
-| Reader (big format) | `org.apache.cassandra.io.sstable.format.big.BigTableReader` | `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java` | Reads Data.db and related components |
-| Writer (big format) | `org.apache.cassandra.io.sstable.format.big.BigTableWriter` | `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java` | Builds Data/Index/Summary/Stats/Filter/CompressionInfo |
-| Generic reader base | `org.apache.cassandra.io.sstable.SSTableReader` | `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/SSTableReader.java` | Format-agnostic reader orchestration |
-| Generic writer base | `org.apache.cassandra.io.sstable.SSTableWriter` | `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/SSTableWriter.java` | Format-agnostic writer orchestration |
-| Serialization header | `org.apache.cassandra.db.SerializationHeader` | `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/db/SerializationHeader.java` | Schema-driven on-disk encodings |
-| Row/partition structures | `org.apache.cassandra.db.rows.*` | `https://github.com/apache/cassandra/tree/cassandra-5.0.0/src/java/org/apache/cassandra/db/rows` | Unfiltered rows, deletions, tombstones |
+| Reader (big format) | `org.apache.cassandra.io.sstable.format.big.BigTableReader` | `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java` | Reads Data.db and related components |
+| Writer (big format) | `org.apache.cassandra.io.sstable.format.big.BigTableWriter` | `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java` | Builds Data/Index/Summary/Stats/Filter/CompressionInfo |
+| Generic reader base | `org.apache.cassandra.io.sstable.format.SSTableReader` | `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java` | Format-agnostic reader orchestration |
+| Generic writer base | `org.apache.cassandra.io.sstable.format.SSTableWriter` | `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/SSTableWriter.java` | Format-agnostic writer orchestration |
+| Serialization header | `org.apache.cassandra.db.SerializationHeader` | `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/SerializationHeader.java` | Schema-driven on-disk encodings |
+| Row/partition structures | `org.apache.cassandra.db.rows.*` | `https://github.com/apache/cassandra/tree/cassandra-5.0.8/src/java/org/apache/cassandra/db/rows` | Unfiltered rows, deletions, tombstones |
 
 ### Index.db (partition index)
 
-| Component/Topic | Cassandra class/package | Permalink (5.0.0) | Notes |
+| Component/Topic | Cassandra class/package | Permalink (5.0.8) | Notes |
 |---|---|---|---|
-| Index entry (big) | `org.apache.cassandra.io.sstable.format.big.RowIndexEntry` | `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/format/big/RowIndexEntry.java` | Per-partition index metadata/positions |
-| Index file writer (big) | `org.apache.cassandra.io.sstable.format.big.BigTableWriter` | `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java` | Creates `Index.db` during flush |
-| Reader integration | `org.apache.cassandra.io.sstable.SSTableReader` | `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/SSTableReader.java` | Seeks via index to Data.db |
+| Index entry (big) | `org.apache.cassandra.io.sstable.format.big.RowIndexEntry` | `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/RowIndexEntry.java` | Per-partition index metadata/positions |
+| Index file writer (big) | `org.apache.cassandra.io.sstable.format.big.BigTableWriter` | `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java` | Creates `Index.db` during flush |
+| Reader integration | `org.apache.cassandra.io.sstable.format.SSTableReader` | `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java` | Seeks via index to Data.db |
 
 ### Summary.db (promoted index / sampling)
 
-| Component/Topic | Cassandra class/package | Permalink (5.0.0) | Notes |
+| Component/Topic | Cassandra class/package | Permalink (5.0.8) | Notes |
 |---|---|---|---|
-| Summary | `org.apache.cassandra.io.sstable.IndexSummary` | `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/IndexSummary.java` | Sampled entries enabling faster navigation |
-| Summary builder | `org.apache.cassandra.io.sstable.IndexSummaryBuilder` | `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/IndexSummaryBuilder.java` | Builds `Summary.db` during flush |
+| Summary | `org.apache.cassandra.io.sstable.indexsummary.IndexSummary` | `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java` | Sampled entries enabling faster navigation |
+| Summary builder | `org.apache.cassandra.io.sstable.indexsummary.IndexSummaryBuilder` | `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummaryBuilder.java` | Builds `Summary.db` during flush |
 
 ### Filter.db (Bloom filter)
 
-| Component/Topic | Cassandra class/package | Permalink (5.0.0) | Notes |
+| Component/Topic | Cassandra class/package | Permalink (5.0.8) | Notes |
 |---|---|---|---|
-| Bloom filter (API) | `org.apache.cassandra.utils.bloom.BloomFilter` | `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/utils/bloom/BloomFilter.java` | In-memory Bloom filter structure |
-| Bloom calculations | `org.apache.cassandra.utils.bloom.BloomCalculations` | `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/utils/bloom/BloomCalculations.java` | FPR/bitset sizing |
-| Bloom factory | `org.apache.cassandra.utils.bloom.FilterFactory` | `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/utils/bloom/FilterFactory.java` | Creates Bloom instances |
-| Bitset impl | `org.apache.cassandra.utils.obs.OffHeapBitSet` | `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/utils/obs/OffHeapBitSet.java` | Off-heap bit set used by filters |
+| Bloom filter (API) | `org.apache.cassandra.utils.bloom.BloomFilter` | `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/utils/bloom/BloomFilter.java` | In-memory Bloom filter structure |
+| Bloom calculations | `org.apache.cassandra.utils.bloom.BloomCalculations` | `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/utils/bloom/BloomCalculations.java` | FPR/bitset sizing |
+| Bloom factory | `org.apache.cassandra.utils.bloom.FilterFactory` | `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/utils/bloom/FilterFactory.java` | Creates Bloom instances |
+| Bitset impl | `org.apache.cassandra.utils.obs.OffHeapBitSet` | `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/utils/obs/OffHeapBitSet.java` | Off-heap bit set used by filters |
 
 ### Statistics.db (table-level statistics)
 
-| Component/Topic | Cassandra class/package | Permalink (5.0.0) | Notes |
+| Component/Topic | Cassandra class/package | Permalink (5.0.8) | Notes |
 |---|---|---|---|
-| Stats metadata | `org.apache.cassandra.io.sstable.metadata.StatsMetadata` | `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/metadata/StatsMetadata.java` | Histograms, timestamps, repair/level info |
-| Collector | `org.apache.cassandra.io.sstable.metadata.MetadataCollector` | `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/metadata/MetadataCollector.java` | Gathers stats during flush |
-| Serializer | `org.apache.cassandra.io.sstable.metadata.MetadataSerializer` | `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/metadata/MetadataSerializer.java` | Writes/reads `Statistics.db` |
+| Stats metadata | `org.apache.cassandra.io.sstable.metadata.StatsMetadata` | `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/metadata/StatsMetadata.java` | Histograms, timestamps, repair/level info |
+| Collector | `org.apache.cassandra.io.sstable.metadata.MetadataCollector` | `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/metadata/MetadataCollector.java` | Gathers stats during flush |
+| Serializer | `org.apache.cassandra.io.sstable.metadata.MetadataSerializer` | `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/metadata/MetadataSerializer.java` | Writes/reads `Statistics.db` |
 
 ### CompressionInfo.db (chunk metadata)
 
-| Component/Topic | Cassandra class/package | Permalink (5.0.0) | Notes |
+| Component/Topic | Cassandra class/package | Permalink (5.0.8) | Notes |
 |---|---|---|---|
-| Compression metadata | `org.apache.cassandra.io.compress.CompressionMetadata` | `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/compress/CompressionMetadata.java` | Offsets map, chunk sizes, checksums |
-| Chunk reader | `org.apache.cassandra.io.compress.CompressedChunkReader` | `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/compress/CompressedChunkReader.java` | Reads compressed chunks |
-| Parameters | `org.apache.cassandra.io.compress.CompressionParameters` | `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/compress/CompressionParameters.java` | Algorithm/option configuration |
+| Compression metadata | `org.apache.cassandra.io.compress.CompressionMetadata` | `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/compress/CompressionMetadata.java` | Offsets map, chunk sizes, checksums |
+| Chunk reader | `org.apache.cassandra.io.compress.CompressedChunkReader` | `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/compress/CompressedChunkReader.java` | Reads compressed chunks |
+| Parameters | `org.apache.cassandra.io.compress.CompressionParameters` | `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/compress/CompressionParameters.java` | Algorithm/option configuration |
 
 ### Digest.crc32 and Data Integrity
 
-| Component/Topic | Cassandra class/package | Permalink (5.0.0) | Notes |
+| Component/Topic | Cassandra class/package | Permalink (5.0.8) | Notes |
 |---|---|---|---|
-| Data integrity (per-chunk) | `org.apache.cassandra.io.util.DataIntegrityMetadata` | `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/util/DataIntegrityMetadata.java` | CRC handling for chunks |
-| CRC implementation (pure Java) | `org.apache.cassandra.utils.PureJavaCrc32` | `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/utils/PureJavaCrc32.java` | CRC32 implementation used in IO |
+| Data integrity (per-chunk) | `org.apache.cassandra.io.util.DataIntegrityMetadata` | `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/util/DataIntegrityMetadata.java` | CRC handling for chunks |
+| CRC implementation (pure Java) | `org.apache.cassandra.utils.PureJavaCrc32` | `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/utils/PureJavaCrc32.java` | CRC32 implementation used in IO |
 
 ### TOC.txt and Component Enumeration
 
-| Component/Topic | Cassandra class/package | Permalink (5.0.0) | Notes |
+| Component/Topic | Cassandra class/package | Permalink (5.0.8) | Notes |
 |---|---|---|---|
-| Descriptor and components | `org.apache.cassandra.io.sstable.Descriptor` | `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/Descriptor.java` | Naming, component paths |
-| Writer (TOC emission) | `org.apache.cassandra.io.sstable.SSTableWriter` | `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/SSTableWriter.java` | Writes `TOC.txt` listing components |
+| Descriptor and components | `org.apache.cassandra.io.sstable.Descriptor` | `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/Descriptor.java` | Naming, component paths |
+| Writer (TOC emission) | `org.apache.cassandra.io.sstable.format.SSTableWriter` | `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/SSTableWriter.java` | Writes `TOC.txt` listing components |
 
 ---
 
@@ -83,13 +83,13 @@ Notes:
 ### `big` format
 
 - Package: `org.apache.cassandra.io.sstable.format.big`
-  - Directory permalink: `https://github.com/apache/cassandra/tree/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/format/big`
+  - Directory permalink: `https://github.com/apache/cassandra/tree/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/big`
   - Representative classes: `BigTableReader`, `BigTableWriter`, `RowIndexEntry`
 
 ### BTI format (B-Tree/Trie Indexed)
 
 - Package: `org.apache.cassandra.io.sstable.format.bti`
-  - Directory permalink: `https://github.com/apache/cassandra/tree/cassandra-5.0.0/src/java/org/apache/cassandra/io/sstable/format/bti`
+  - Directory permalink: `https://github.com/apache/cassandra/tree/cassandra-5.0.8/src/java/org/apache/cassandra/io/sstable/format/bti`
   - Notes: BTI format family classes and readers/writers live here (Cassandra 5.0)
 
 ---
@@ -97,30 +97,30 @@ Notes:
 ## Storage-Attached Indexes (SAI)
 
 - Root package: `org.apache.cassandra.index.sai`
-  - Directory permalink: `https://github.com/apache/cassandra/tree/cassandra-5.0.0/src/java/org/apache/cassandra/index/sai`
+  - Directory permalink: `https://github.com/apache/cassandra/tree/cassandra-5.0.8/src/java/org/apache/cassandra/index/sai`
 - Disk formats and segments: `org.apache.cassandra.index.sai.disk`
-  - Directory permalink: `https://github.com/apache/cassandra/tree/cassandra-5.0.0/src/java/org/apache/cassandra/index/sai/disk`
+  - Directory permalink: `https://github.com/apache/cassandra/tree/cassandra-5.0.8/src/java/org/apache/cassandra/index/sai/disk`
 - Query path: `org.apache.cassandra.index.sai.query`
-  - Directory permalink: `https://github.com/apache/cassandra/tree/cassandra-5.0.0/src/java/org/apache/cassandra/index/sai/query`
+  - Directory permalink: `https://github.com/apache/cassandra/tree/cassandra-5.0.8/src/java/org/apache/cassandra/index/sai/query`
 - Vector indexing (5.0): `org.apache.cassandra.index.sai.disk.v1` (vector classes live under this hierarchy)
-  - Directory permalink: `https://github.com/apache/cassandra/tree/cassandra-5.0.0/src/java/org/apache/cassandra/index/sai/disk/v1`
+  - Directory permalink: `https://github.com/apache/cassandra/tree/cassandra-5.0.8/src/java/org/apache/cassandra/index/sai/disk/v1`
 
 ### SAI Vector — Key Classes
 
-| Topic | Cassandra class | Permalink (5.0.0) | Notes |
+| Topic | Cassandra class | Permalink (5.0.8) | Notes |
 |---|---|---|---|
-| Vector CQL type | `org.apache.cassandra.db.marshal.VectorType` | `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/db/marshal/VectorType.java` | Type definition for `vector<elem, n>` |
-| SAI index (entry point) | `org.apache.cassandra.index.sai.StorageAttachedIndex` | `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java` | Index implementation used for SAI (incl. vector) |
-| SAI searcher | `org.apache.cassandra.index.sai.StorageAttachedIndexSearcher` | `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexSearcher.java` | Query/search integration |
+| Vector CQL type | `org.apache.cassandra.db.marshal.VectorType` | `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/db/marshal/VectorType.java` | Type definition for `vector<elem, n>` |
+| SAI index (entry point) | `org.apache.cassandra.index.sai.StorageAttachedIndex` | `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java` | Index implementation used for SAI (incl. vector) |
+| SAI searcher | `org.apache.cassandra.index.sai.StorageAttachedIndexSearcher` | `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexSearcher.java` | Query/search integration |
 
 ---
 
 ## Tools (for examples and verification)
 
-| Tool | Cassandra class | Permalink (5.0.0) | Notes |
+| Tool | Cassandra class | Permalink (5.0.8) | Notes |
 |---|---|---|---|
-| sstabledump | `org.apache.cassandra.tools.SSTableDump` | `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/tools/SSTableDump.java` | Dump rows and metadata |
-| sstablemetadata | `org.apache.cassandra.tools.SSTableMetadata` | `https://github.com/apache/cassandra/blob/cassandra-5.0.0/src/java/org/apache/cassandra/tools/SSTableMetadata.java` | Show `Statistics.db` contents |
+| sstabledump | `org.apache.cassandra.tools.SSTableExport` | `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/tools/SSTableExport.java` | Dump rows and metadata |
+| sstablemetadata | `org.apache.cassandra.tools.SSTableMetadataViewer` | `https://github.com/apache/cassandra/blob/cassandra-5.0.8/src/java/org/apache/cassandra/tools/SSTableMetadataViewer.java` | Show `Statistics.db` contents |
 
 ---
 
@@ -138,6 +138,6 @@ These modules are used in chapter code references to illustrate how CQLite consu
 
 ---
 
-Key policy: All upstream citations should target the permalinks above (5.0.0 tag) unless a deeper file/class link is explicitly needed.
+Key policy: All upstream citations should target the permalinks above (cassandra-5.0.8 tag) unless a deeper file/class link is explicitly needed.
 
 


### PR DESCRIPTION
## Summary
Audit batch B11 (epic #598) — final-consistency batch covering files missed by B1–B10 ownership.

Key fixes:
- Appendix C: BIG Index.db walkthrough rewritten — u16 BE key_length + raw key + vint position; fabricated 0x0010 'marker' and MD5 'key_digest' removed
- Appendix C: retracted 'Header CRC32 Validation (Legacy/BIG only)' section removed (NB Data.db has no global header; per-chunk CRCs are inline in Data.db)
- Appendix C: bloom filter walkthrough labels corrected (hashCount=5, wordCount=2; native-order raw copy, never big-endian u64)
- Appendix D: dead tool classes fixed (SSTableDump → SSTableExport, SSTableMetadata → SSTableMetadataViewer); file prefix examples mb- → nb-
- Meta files (REFERENCES.md, STYLE_GUIDE.md, PUBLISHING.md, references/*): every cassandra-5.0.0 permalink re-pinned to cassandra-5.0.8; moved paths fixed (SSTableReader → format/, IndexSummary → indexsummary/)
- RELEASE_NOTES.md: dated audit entry; OPEN_QUESTIONS.md: permalink-pin answer updated

Closes #619. Part of epic #598.