### PR TITLE
chore: gitignore SSTable guide audit working dirs (epic #598)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,7 @@ cassandra5-small.tar.gz.sha256
 
 # Runtime locks
 .claude/scheduled_tasks.lock
+
+# SSTable guide audit working artifacts (not committed)
+docs/cassandra-5.0-src/
+docs/sstable-guide-audit/


### PR DESCRIPTION
Ignores the local cassandra-5.0.8 sparse checkout (`docs/cassandra-5.0-src/`) and audit fact-sheets/reports (`docs/sstable-guide-audit/`) used by epic #598. These are local verification artifacts, not committed content.