### PR TITLE
feat: S2 type system verification — fix decimal, duration, tuple/UDT field lengths (#624)

### DIFF
--- a/cqlite-core/src/parser/types.rs
+++ b/cqlite-core/src/parser/types.rs
@@ -312,28 +312,48 @@ pub fn parse_varint(input: &[u8]) -> IResult<&[u8], Value> {
     Ok((input, Value::Varint(bytes.to_vec())))
 }
 
-/// Parse decimal (scale + unscaled value)
+/// Parse decimal (scale + unscaled BigInteger bytes)
+///
+/// Cassandra SSTable format (DecimalType.java:275-278):
+///   - 4 bytes: scale as big-endian signed int32
+///   - remaining bytes: unscaled value as raw BigInteger two's-complement big-endian bytes
+///
+/// The unscaled bytes are NOT VInt-encoded; they are the raw Java BigInteger
+/// byte array written by `ByteBuffer.putInt(scale)` then `unscaledValue.toByteArray()`.
 pub fn parse_decimal(input: &[u8]) -> IResult<&[u8], Value> {
     let (input, scale) = be_i32(input)?;
-    let (input, unscaled) = parse_vint(input)?;
-
-    // For now, convert to float (losing precision)
-    let value = (unscaled as f64) / (10.0_f64.powi(scale));
-    Ok((input, Value::Float(value)))
+    // All remaining bytes in this cell's data are the BigInteger unscaled bytes.
+    // In the SSTable cell framing, each cell value is already length-delimited by
+    // the surrounding cell header, so we consume all of `input` here.
+    let unscaled = input.to_vec();
+    Ok((
+        &input[input.len()..], // empty remaining slice
+        Value::Decimal { scale, unscaled },
+    ))
 }
 
 /// Parse duration (months, days, nanoseconds)
+///
+/// Cassandra SSTable format (DurationType.java / DurationSerializer):
+///   - months:  signed VInt (zigzag-encoded)
+///   - days:    signed VInt (zigzag-encoded)
+///   - nanos:   signed VInt (zigzag-encoded)
+///
+/// All three components are returned as-is in `Value::Duration` to preserve
+/// calendar semantics (months ≠ 30 days; days ≠ 24 hours in all time zones).
 pub fn parse_duration(input: &[u8]) -> IResult<&[u8], Value> {
     let (input, months) = parse_vint(input)?;
     let (input, days) = parse_vint(input)?;
     let (input, nanos) = parse_vint(input)?;
 
-    // Convert to total microseconds (approximate)
-    let total_micros = (months * 30 * 24 * 60 * 60 * 1_000_000)
-        + (days * 24 * 60 * 60 * 1_000_000)
-        + (nanos / 1000);
-
-    Ok((input, Value::BigInt(total_micros)))
+    Ok((
+        input,
+        Value::Duration {
+            months: months as i32,
+            days: days as i32,
+            nanos,
+        },
+    ))
 }
 
 /// Parse inet address (4 or 16 bytes)
@@ -2284,35 +2304,65 @@ mod tests {
 
     #[test]
     fn test_parse_decimal() {
-        // Decimal is: scale (i32) + unscaled value (vint)
-        // e.g., 123.45 = scale 2, unscaled 12345
-        use super::super::vint::encode_vint;
+        // Cassandra decimal: 4-byte BE i32 scale + raw BigInteger bytes (NOT VInt).
+        // e.g., 1.23 = scale 2, unscaled raw bytes = [0x7B] (= 123)
         let mut data = Vec::new();
         data.extend_from_slice(&2i32.to_be_bytes()); // scale = 2
-        data.extend_from_slice(&encode_vint(12345)); // unscaled = 12345
+        data.push(0x7B); // unscaled BigInteger bytes = 123
         let (remaining, value) = parse_decimal(&data).unwrap();
         assert!(remaining.is_empty());
-        if let Value::Float(f) = value {
-            assert!((f - 123.45).abs() < 0.001, "Expected ~123.45, got {}", f);
-        } else {
-            panic!("Expected Float value, got {:?}", value);
+        match value {
+            Value::Decimal {
+                scale,
+                ref unscaled,
+            } => {
+                assert_eq!(scale, 2, "scale should be 2");
+                assert_eq!(unscaled, &[0x7B], "unscaled should be [0x7B]=123 (= 1.23)");
+            }
+            other => panic!("Expected Decimal value, got {:?}", other),
         }
     }
 
     #[test]
     fn test_parse_decimal_negative_scale() {
-        // Negative scale means multiply by 10^|scale|
-        // e.g., scale -2, unscaled 5 = 500
-        use super::super::vint::encode_vint;
+        // scale = -2, unscaled = [0x05] = 5 → value is 500 (5 × 10^2)
         let mut data = Vec::new();
         data.extend_from_slice(&(-2i32).to_be_bytes()); // scale = -2
-        data.extend_from_slice(&encode_vint(5)); // unscaled = 5
+        data.push(0x05); // unscaled = 5
         let (remaining, value) = parse_decimal(&data).unwrap();
         assert!(remaining.is_empty());
-        if let Value::Float(f) = value {
-            assert!((f - 500.0).abs() < 0.001, "Expected ~500, got {}", f);
-        } else {
-            panic!("Expected Float value, got {:?}", value);
+        match value {
+            Value::Decimal {
+                scale,
+                ref unscaled,
+            } => {
+                assert_eq!(scale, -2, "scale should be -2");
+                assert_eq!(unscaled, &[0x05], "unscaled should be [0x05]=5");
+            }
+            other => panic!("Expected Decimal value, got {:?}", other),
+        }
+    }
+
+    /// S2 regression: decimal unscaled bytes > 127 must NOT be VInt-decoded.
+    /// If decoded as VInt, byte 0x80 would be misread (high bit set = multi-byte VInt).
+    #[test]
+    fn test_parse_decimal_large_unscaled_no_vint_misread() {
+        // scale = 0, unscaled = [0x01, 0x00] = 256 (big-endian BigInteger)
+        let mut data = Vec::new();
+        data.extend_from_slice(&0i32.to_be_bytes()); // scale = 0
+        data.push(0x01); // MSB of 256
+        data.push(0x00); // LSB of 256
+        let (remaining, value) = parse_decimal(&data).unwrap();
+        assert!(remaining.is_empty());
+        match value {
+            Value::Decimal {
+                scale,
+                ref unscaled,
+            } => {
+                assert_eq!(scale, 0);
+                assert_eq!(unscaled, &[0x01, 0x00], "unscaled [0x01,0x00] = 256");
+            }
+            other => panic!("Expected Decimal value, got {:?}", other),
         }
     }
 
@@ -2346,7 +2396,8 @@ mod tests {
 
     #[test]
     fn test_parse_duration() {
-        // Duration: months (vint) + days (vint) + nanos (vint)
+        // Duration: months (signed VInt) + days (signed VInt) + nanos (signed VInt)
+        // Returns Value::Duration { months, days, nanos } preserving calendar semantics.
         use super::super::vint::encode_vint;
         let mut data = Vec::new();
         data.extend_from_slice(&encode_vint(1)); // 1 month
@@ -2354,17 +2405,63 @@ mod tests {
         data.extend_from_slice(&encode_vint(3_600_000_000_000_i64)); // 1 hour in nanos
         let (remaining, value) = parse_duration(&data).unwrap();
         assert!(remaining.is_empty());
-        // Result is total microseconds
-        if let Value::BigInt(micros) = value {
-            // 1 month ≈ 30 days, 15 days, 1 hour
-            // = (30*24*60*60 + 15*24*60*60 + 3600) * 1_000_000 μs
-            let expected = (30 * 24 * 60 * 60 * 1_000_000_i64)
-                + (15 * 24 * 60 * 60 * 1_000_000_i64)
-                + (3_600_000_000_000_i64 / 1000);
-            assert_eq!(micros, expected);
-        } else {
-            panic!("Expected BigInt value, got {:?}", value);
+        match value {
+            Value::Duration {
+                months,
+                days,
+                nanos,
+            } => {
+                assert_eq!(months, 1, "months should be 1");
+                assert_eq!(days, 15, "days should be 15");
+                assert_eq!(
+                    nanos, 3_600_000_000_000,
+                    "nanos should be 1 hour in nanoseconds"
+                );
+            }
+            other => panic!("Expected Duration value, got {:?}", other),
         }
+    }
+
+    /// S2 regression: duration with all-zero components should produce Duration{{0,0,0}}.
+    #[test]
+    fn test_parse_duration_zero() {
+        use super::super::vint::encode_vint;
+        let mut data = Vec::new();
+        data.extend_from_slice(&encode_vint(0));
+        data.extend_from_slice(&encode_vint(0));
+        data.extend_from_slice(&encode_vint(0));
+        let (remaining, value) = parse_duration(&data).unwrap();
+        assert!(remaining.is_empty());
+        assert_eq!(
+            value,
+            Value::Duration {
+                months: 0,
+                days: 0,
+                nanos: 0
+            },
+            "zero duration should be Duration{{0,0,0}}"
+        );
+    }
+
+    /// S2 regression: duration with negative nanos (nanoseconds can be negative).
+    #[test]
+    fn test_parse_duration_negative_nanos() {
+        use super::super::vint::encode_vint;
+        let mut data = Vec::new();
+        data.extend_from_slice(&encode_vint(0));
+        data.extend_from_slice(&encode_vint(0));
+        data.extend_from_slice(&encode_vint(-1_i64));
+        let (remaining, value) = parse_duration(&data).unwrap();
+        assert!(remaining.is_empty());
+        assert_eq!(
+            value,
+            Value::Duration {
+                months: 0,
+                days: 0,
+                nanos: -1
+            },
+            "duration with -1 nanos should be Duration{{0,0,-1}}"
+        );
     }
 
     #[test]

--- a/cqlite-core/src/storage/sstable/reader/parsing/value_parsing.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/value_parsing.rs
@@ -240,6 +240,10 @@ where
 }
 
 /// Parse tuple value with recursive field parsing via closure
+///
+/// Cassandra tuple field lengths are encoded as 4-byte big-endian signed int32
+/// (TupleType.java uses `accessor.putInt`), with -1 meaning null.
+/// This is NOT VInt encoding.
 pub(crate) fn parse_tuple_value_with<F>(
     data: &[u8],
     field_comparators: &[ComparatorType],
@@ -248,8 +252,6 @@ pub(crate) fn parse_tuple_value_with<F>(
 where
     F: Fn(&[u8], &ComparatorType) -> Result<Value>,
 {
-    use crate::parser::vint::parse_vint_length;
-
     let mut offset = 0;
     let mut fields = Vec::new();
 
@@ -259,20 +261,42 @@ where
             break;
         }
 
-        // Parse field length
-        let (remaining, field_len) = parse_vint_length(&data[offset..])
-            .map_err(|_| Error::corruption(format!("Failed to parse tuple field {} length", i)))?;
-        offset = data.len() - remaining.len();
-
-        if field_len > remaining.len() {
+        // Parse field length as 4-byte big-endian signed int32 (Cassandra specification)
+        // -1 = null field, 0 = empty field, >0 = byte count
+        if offset + 4 > data.len() {
             return Err(Error::corruption(format!(
-                "Tuple field {} length exceeds available data",
+                "Tuple field {} length prefix truncated",
                 i
+            )));
+        }
+        let field_len_i32 =
+            i32::from_be_bytes(data[offset..offset + 4].try_into().map_err(|_| {
+                Error::corruption(format!("Tuple field {} length bytes invalid", i))
+            })?);
+        offset += 4;
+
+        if field_len_i32 == -1 {
+            // Null field
+            fields.push(Value::Null);
+            continue;
+        }
+        if field_len_i32 < 0 {
+            return Err(Error::corruption(format!(
+                "Tuple field {} has invalid negative length {}",
+                i, field_len_i32
+            )));
+        }
+        let field_len = field_len_i32 as usize;
+
+        if offset + field_len > data.len() {
+            return Err(Error::corruption(format!(
+                "Tuple field {} length {} exceeds available data",
+                i, field_len
             )));
         }
 
         // Parse field value using provided closure
-        let field_data = &remaining[..field_len];
+        let field_data = &data[offset..offset + field_len];
         let field_value = parse_element(field_data, field_comparator)?;
         fields.push(field_value);
         offset += field_len;
@@ -282,6 +306,10 @@ where
 }
 
 /// Parse UDT value with recursive field parsing via closure
+///
+/// Cassandra UDT field lengths are encoded as 4-byte big-endian signed int32
+/// (TupleType.java / UserType.java use `accessor.putInt`), with -1 meaning null.
+/// This is NOT VInt encoding.
 #[allow(dead_code)] // Used in tests; may be used by future refactoring
 pub(crate) fn parse_udt_value_with<F>(
     data: &[u8],
@@ -291,8 +319,6 @@ pub(crate) fn parse_udt_value_with<F>(
 where
     F: Fn(&[u8], &ComparatorType) -> Result<Value>,
 {
-    use crate::parser::vint::parse_vint_length;
-
     let mut offset = 0;
     let mut fields = Vec::new();
 
@@ -302,21 +328,45 @@ where
             break;
         }
 
-        // Parse field length
-        let (remaining, field_len) = parse_vint_length(&data[offset..]).map_err(|_| {
-            Error::corruption(format!("Failed to parse UDT field {} length", field_name))
-        })?;
-        offset = data.len() - remaining.len();
-
-        if field_len > remaining.len() {
+        // Parse field length as 4-byte big-endian signed int32 (Cassandra specification)
+        // -1 = null field, 0 = empty field, >0 = byte count
+        if offset + 4 > data.len() {
             return Err(Error::corruption(format!(
-                "UDT field {} length exceeds available data",
+                "UDT field {} length prefix truncated",
                 field_name
+            )));
+        }
+        let field_len_i32 =
+            i32::from_be_bytes(data[offset..offset + 4].try_into().map_err(|_| {
+                Error::corruption(format!("UDT field {} length bytes invalid", field_name))
+            })?);
+        offset += 4;
+
+        if field_len_i32 == -1 {
+            // Null field
+            fields.push(UdtField {
+                name: field_name.clone(),
+                value: None,
+            });
+            continue;
+        }
+        if field_len_i32 < 0 {
+            return Err(Error::corruption(format!(
+                "UDT field {} has invalid negative length {}",
+                field_name, field_len_i32
+            )));
+        }
+        let field_len = field_len_i32 as usize;
+
+        if offset + field_len > data.len() {
+            return Err(Error::corruption(format!(
+                "UDT field {} length {} exceeds available data",
+                field_name, field_len
             )));
         }
 
         // Parse field value using provided closure
-        let field_data = &remaining[..field_len];
+        let field_data = &data[offset..offset + field_len];
         let field_value = parse_element(field_data, field_comparator)?;
 
         fields.push(UdtField {
@@ -443,8 +493,6 @@ impl SSTableReader {
         value_data: &[u8],
         comparator: &ComparatorType,
     ) -> Result<Value> {
-        use crate::parser::vint::parse_vint_length;
-
         match comparator {
             ComparatorType::Boolean => parse_boolean_value(value_data),
             ComparatorType::TinyInt => parse_tinyint_value(value_data),
@@ -476,6 +524,7 @@ impl SSTableReader {
                 // Parse UDT fields inline with full type info (Issue #238 fix)
                 // This avoids the V5 format check in parse_udt_value() which incorrectly
                 // returns an error even when we have complete schema information.
+                // Field lengths are 4-byte big-endian signed int32 per Cassandra specification.
                 let mut offset = 0;
                 let mut fields = Vec::new();
 
@@ -483,23 +532,43 @@ impl SSTableReader {
                     if offset >= value_data.len() {
                         break;
                     }
-                    let (remaining, field_len) =
-                        parse_vint_length(&value_data[offset..]).map_err(|_| {
-                            Error::corruption(format!(
-                                "Failed to parse UDT field {} length",
-                                field_name
-                            ))
-                        })?;
-                    offset = value_data.len() - remaining.len();
-
-                    if field_len > remaining.len() {
+                    // Parse field length as 4-byte big-endian signed int32 (Cassandra spec)
+                    if offset + 4 > value_data.len() {
                         return Err(Error::corruption(format!(
-                            "UDT field {} length exceeds available data",
+                            "UDT field {} length prefix truncated",
                             field_name
                         )));
                     }
+                    let field_len_i32 = i32::from_be_bytes(
+                        value_data[offset..offset + 4].try_into().map_err(|_| {
+                            Error::corruption(format!("UDT field {} length invalid", field_name))
+                        })?,
+                    );
+                    offset += 4;
 
-                    let field_data = &remaining[..field_len];
+                    if field_len_i32 == -1 {
+                        fields.push(UdtField {
+                            name: field_name.clone(),
+                            value: None,
+                        });
+                        continue;
+                    }
+                    if field_len_i32 < 0 {
+                        return Err(Error::corruption(format!(
+                            "UDT field {} has invalid negative length {}",
+                            field_name, field_len_i32
+                        )));
+                    }
+                    let field_len = field_len_i32 as usize;
+
+                    if offset + field_len > value_data.len() {
+                        return Err(Error::corruption(format!(
+                            "UDT field {} length {} exceeds available data",
+                            field_name, field_len
+                        )));
+                    }
+
+                    let field_data = &value_data[offset..offset + field_len];
                     let field_value =
                         self.parse_value_with_comparator(field_data, field_comparator)?;
 
@@ -578,13 +647,13 @@ impl SSTableReader {
     }
 
     /// Parse UDT value using field comparators
+    ///
+    /// Cassandra UDT field lengths are 4-byte big-endian signed int32 (not VInt).
     pub(in crate::storage::sstable::reader) fn parse_udt_value(
         &self,
         value_data: &[u8],
         field_comparators: &[(String, ComparatorType)],
     ) -> Result<Value> {
-        use crate::parser::vint::parse_vint_length;
-
         let mut offset = 0;
         let mut fields = Vec::new();
 
@@ -594,29 +663,50 @@ impl SSTableReader {
                 break;
             }
 
-            // Parse field length
-            let (remaining, field_len) =
-                parse_vint_length(&value_data[offset..]).map_err(|_| {
-                    Error::corruption(format!("Failed to parse UDT field {} length", field_name))
-                })?;
-            offset = value_data.len() - remaining.len();
-
-            if field_len > remaining.len() {
+            // Parse field length as 4-byte big-endian signed int32 (Cassandra specification)
+            if offset + 4 > value_data.len() {
                 return Err(Error::corruption(format!(
-                    "UDT field {} length exceeds available data",
+                    "UDT field {} length prefix truncated",
                     field_name
+                )));
+            }
+            let field_len_i32 =
+                i32::from_be_bytes(value_data[offset..offset + 4].try_into().map_err(|_| {
+                    Error::corruption(format!("UDT field {} length invalid", field_name))
+                })?);
+            offset += 4;
+
+            if field_len_i32 == -1 {
+                fields.push(UdtField {
+                    name: field_name.clone(),
+                    value: None,
+                });
+                continue;
+            }
+            if field_len_i32 < 0 {
+                return Err(Error::corruption(format!(
+                    "UDT field {} has invalid negative length {}",
+                    field_name, field_len_i32
+                )));
+            }
+            let field_len = field_len_i32 as usize;
+
+            if offset + field_len > value_data.len() {
+                return Err(Error::corruption(format!(
+                    "UDT field {} length {} exceeds available data",
+                    field_name, field_len
                 )));
             }
 
             // Parse field value using field comparator
-            let field_data = &remaining[..field_len];
+            let field_data = &value_data[offset..offset + field_len];
             let field_value = self.parse_value_with_comparator(field_data, field_comparator)?;
+            offset += field_len;
 
             fields.push(UdtField {
                 name: field_name.clone(),
                 value: Some(field_value),
             });
-            offset += field_len;
         }
 
         // Modern formats should never use generic UDT fabrication without schema
@@ -1074,15 +1164,16 @@ mod tests {
 
     #[test]
     fn test_parse_tuple_int_text() {
+        // Cassandra tuple field lengths use 4-byte big-endian signed int32 (not VInt).
         let mut data = Vec::new();
 
-        // Field 0: int = 42
-        data.extend_from_slice(&encode_vint(4));
+        // Field 0: int = 42 (4 bytes)
+        data.extend_from_slice(&4i32.to_be_bytes()); // 4-byte length prefix
         data.extend_from_slice(&42i32.to_be_bytes());
 
-        // Field 1: text = "hello"
+        // Field 1: text = "hello" (5 bytes)
         let text = "hello";
-        data.extend_from_slice(&encode_vint(text.len() as i64));
+        data.extend_from_slice(&(text.len() as i32).to_be_bytes()); // 4-byte length prefix
         data.extend_from_slice(text.as_bytes());
 
         let field_comparators = vec![ComparatorType::Int, ComparatorType::Text];
@@ -1105,29 +1196,22 @@ mod tests {
 
     #[test]
     fn test_parse_tuple_with_null() {
-        // Note: In Cassandra tuples, null fields are represented by negative length
-        // However, parse_vint_length will reject negative values
-        // For this test, we'll test a tuple with a field that has 0-length data
+        // Cassandra uses 4-byte big-endian signed int32 for field lengths.
+        // -1 means null field.
         let mut data = Vec::new();
 
-        // Field 0: int = 42
-        data.extend_from_slice(&encode_vint(4));
+        // Field 0: int = 42 (4 bytes)
+        data.extend_from_slice(&4i32.to_be_bytes()); // length = 4
         data.extend_from_slice(&42i32.to_be_bytes());
 
-        // Field 1: empty text (0 bytes)
-        data.extend_from_slice(&encode_vint(0));
+        // Field 1: null text (-1 sentinel)
+        data.extend_from_slice(&(-1i32).to_be_bytes()); // -1 = null
 
         let field_comparators = vec![ComparatorType::Int, ComparatorType::Text];
 
         let result = parse_tuple_value_with(&data, &field_comparators, |d, comp| match comp {
             ComparatorType::Int => parse_int_value(d),
-            ComparatorType::Text => {
-                if d.is_empty() {
-                    Ok(Value::Text(String::new()))
-                } else {
-                    parse_text_value(d)
-                }
-            }
+            ComparatorType::Text => parse_text_value(d),
             _ => panic!("Unexpected comparator"),
         })
         .unwrap();
@@ -1135,7 +1219,11 @@ mod tests {
         if let Value::Tuple(fields) = result {
             assert_eq!(fields.len(), 2);
             assert_eq!(fields[0], Value::Integer(42));
-            assert_eq!(fields[1], Value::Text(String::new()));
+            assert_eq!(
+                fields[1],
+                Value::Null,
+                "null field should decode to Value::Null"
+            );
         } else {
             panic!("Expected Tuple value");
         }
@@ -1143,15 +1231,16 @@ mod tests {
 
     #[test]
     fn test_parse_udt_simple() {
+        // Cassandra UDT field lengths use 4-byte big-endian signed int32 (not VInt).
         let mut data = Vec::new();
 
-        // Field "id": int = 123
-        data.extend_from_slice(&encode_vint(4));
+        // Field "id": int = 123 (4 bytes)
+        data.extend_from_slice(&4i32.to_be_bytes()); // 4-byte length prefix
         data.extend_from_slice(&123i32.to_be_bytes());
 
-        // Field "name": text = "Alice"
+        // Field "name": text = "Alice" (5 bytes)
         let name = "Alice";
-        data.extend_from_slice(&encode_vint(name.len() as i64));
+        data.extend_from_slice(&(name.len() as i32).to_be_bytes()); // 4-byte length prefix
         data.extend_from_slice(name.as_bytes());
 
         let field_comparators = vec![
@@ -1178,20 +1267,23 @@ mod tests {
 
     #[test]
     fn test_parse_udt_with_collection() {
+        // Cassandra UDT field lengths use 4-byte big-endian signed int32 (not VInt).
+        // Note: the list *elements* still use VInt lengths (CollectionSerializer format).
         let mut data = Vec::new();
 
-        // Field "id": int = 456
-        data.extend_from_slice(&encode_vint(4));
+        // Field "id": int = 456 (4 bytes)
+        data.extend_from_slice(&4i32.to_be_bytes()); // 4-byte UDT field length prefix
         data.extend_from_slice(&456i32.to_be_bytes());
 
         // Field "tags": list<text> = ["tag1", "tag2"]
         let mut list_data = Vec::new();
-        list_data.extend_from_slice(&encode_vint(2)); // 2 elements
+        list_data.extend_from_slice(&encode_vint(2)); // 2 elements (VInt count per CollectionSerializer)
         for tag in ["tag1", "tag2"] {
-            list_data.extend_from_slice(&encode_vint(tag.len() as i64));
+            list_data.extend_from_slice(&encode_vint(tag.len() as i64)); // VInt element length
             list_data.extend_from_slice(tag.as_bytes());
         }
-        data.extend_from_slice(&encode_vint(list_data.len() as i64));
+        // UDT field length prefix = 4-byte BE i32
+        data.extend_from_slice(&(list_data.len() as i32).to_be_bytes());
         data.extend_from_slice(&list_data);
 
         let field_comparators = vec![
@@ -1286,6 +1378,135 @@ mod tests {
         let data = [0x00, 0x00, 0x00]; // Only 3 bytes instead of 4
         let result = parse_date_value(&data);
         assert!(result.is_err());
+    }
+
+    // ============================================================================
+    // S2 Type System Verification Tests (Issue #624, Epic #622)
+    // ============================================================================
+
+    /// A-07: Tuple field with length >= 128 bytes uses 4-byte BE i32, not VInt.
+    /// Before this fix, parse_vint_length would read 0x00 as length=0 for a
+    /// 4-byte field-length header like [0x00, 0x00, 0x00, 0x80], corrupting data.
+    #[test]
+    fn s2_a07_tuple_field_128_bytes_cassandra_format() {
+        // 128-byte blob field followed by int field = 99
+        let blob_data: Vec<u8> = (0u8..=127u8).collect(); // 128 bytes
+        let mut data = Vec::new();
+        // 4-byte BE i32 length = 128 = [0x00, 0x00, 0x00, 0x80]
+        data.extend_from_slice(&128i32.to_be_bytes());
+        data.extend_from_slice(&blob_data);
+        // Second field: int = 99
+        data.extend_from_slice(&4i32.to_be_bytes());
+        data.extend_from_slice(&99i32.to_be_bytes());
+
+        let field_comparators = vec![ComparatorType::Blob, ComparatorType::Int];
+        let result = parse_tuple_value_with(&data, &field_comparators, |d, comp| match comp {
+            ComparatorType::Blob => parse_blob_value(d),
+            ComparatorType::Int => parse_int_value(d),
+            _ => panic!("Unexpected comparator"),
+        })
+        .unwrap();
+
+        if let Value::Tuple(fields) = result {
+            assert_eq!(fields.len(), 2);
+            assert_eq!(
+                fields[0],
+                Value::Blob(blob_data),
+                "128-byte blob should be intact"
+            );
+            assert_eq!(
+                fields[1],
+                Value::Integer(99),
+                "int after 128-byte blob should be 99"
+            );
+        } else {
+            panic!("Expected Tuple value");
+        }
+    }
+
+    /// A-07/A-08: Tuple null field uses -1 sentinel (4-byte BE i32).
+    #[test]
+    fn s2_a08_tuple_null_field_minus_one_sentinel() {
+        let mut data = Vec::new();
+        data.extend_from_slice(&(-1i32).to_be_bytes()); // null
+        data.extend_from_slice(&4i32.to_be_bytes()); // int length
+        data.extend_from_slice(&7i32.to_be_bytes()); // int = 7
+
+        let field_comparators = vec![ComparatorType::Int, ComparatorType::Int];
+        let result =
+            parse_tuple_value_with(&data, &field_comparators, |d, _| parse_int_value(d)).unwrap();
+
+        if let Value::Tuple(fields) = result {
+            assert_eq!(fields[0], Value::Null, "first field should be null");
+            assert_eq!(fields[1], Value::Integer(7), "second field should be 7");
+        } else {
+            panic!("Expected Tuple value");
+        }
+    }
+
+    /// A-08: UDT field with length >= 128 bytes uses 4-byte BE i32, not VInt.
+    #[test]
+    fn s2_a08_udt_field_128_bytes_cassandra_format() {
+        let text_data: Vec<u8> = b"A".repeat(128);
+        let mut data = Vec::new();
+        data.extend_from_slice(&128i32.to_be_bytes()); // 4-byte BE i32 length
+        data.extend_from_slice(&text_data);
+
+        let field_comparators = vec![("data".to_string(), ComparatorType::Text)];
+        let result =
+            parse_udt_value_with(&data, &field_comparators, |d, _| parse_text_value(d)).unwrap();
+
+        assert_eq!(result.fields.len(), 1);
+        assert_eq!(
+            result.fields[0].value,
+            Some(Value::Text("A".repeat(128))),
+            "128-char text field should be intact"
+        );
+    }
+
+    /// A-08: UDT null field uses -1 sentinel (4-byte BE i32).
+    #[test]
+    fn s2_a08_udt_null_field_minus_one_sentinel() {
+        let mut data = Vec::new();
+        data.extend_from_slice(&(-1i32).to_be_bytes()); // null field
+
+        let field_comparators = vec![("x".to_string(), ComparatorType::Int)];
+        let result =
+            parse_udt_value_with(&data, &field_comparators, |d, _| parse_int_value(d)).unwrap();
+
+        assert_eq!(result.fields.len(), 1);
+        assert_eq!(
+            result.fields[0].value, None,
+            "null field should have value=None"
+        );
+    }
+
+    /// A-02: Date epoch bias - 0x80000000 on disk decodes to day 0 (1970-01-01).
+    #[test]
+    fn s2_a02_date_epoch_bias_0x80000000() {
+        let data = 0x80000000u32.to_be_bytes();
+        let result = parse_date_value(&data).unwrap();
+        assert_eq!(
+            result,
+            Value::Date(0),
+            "0x80000000 should decode to epoch day 0"
+        );
+    }
+
+    /// A-02: Date 1 day after epoch = 0x80000001 on disk.
+    #[test]
+    fn s2_a02_date_one_day_after_epoch() {
+        let data = 0x80000001u32.to_be_bytes();
+        let result = parse_date_value(&data).unwrap();
+        assert_eq!(result, Value::Date(1));
+    }
+
+    /// A-02: Date 1 day before epoch = 0x7FFFFFFF on disk.
+    #[test]
+    fn s2_a02_date_one_day_before_epoch() {
+        let data = 0x7FFFFFFFu32.to_be_bytes();
+        let result = parse_date_value(&data).unwrap();
+        assert_eq!(result, Value::Date(-1));
     }
 
     // Issue #264: Blob fallback disabled test - type-specific parsers enforce strict validation


### PR DESCRIPTION
## Summary

Stage S2 of Epic #622 — behavioral verification of CQLite's CQL type deserialization against Cassandra 5.0.8 source and audit report-B10.md.

Closes #624. References epic #622.

## Verdict Table

| Claim | Description | Verdict | Issue |
|-------|-------------|---------|-------|
| A-02 | DATE = 4-byte unsigned + 2^31 bias | CORRECT & TESTED | — |
| A-03 | decimal = 4-byte BE scale + raw BigInteger bytes (NOT VInt) | **BUG → FIXED** | #632 |
| A-04 | duration = 3 signed zigzag VInts → `Duration{months,days,nanos}` | **BUG → FIXED** | #633 |
| A-06 | varint = raw two's-complement big-endian bytes | CORRECT & TESTED | — |
| A-07 | tuple field lengths = 4-byte BE i32 (NOT VInt), -1 = null | **BUG → FIXED** | #634 |
| A-08 | UDT field lengths = 4-byte BE i32 (NOT VInt), -1 = null | **BUG → FIXED** | #634 |
| A-09 | UDT stored same as tuple | CORRECT (types.rs path already used be_i32) | — |
| A-12 | frozen collections use vint count + vint element lengths | CORRECT & TESTED | — |

## Bugs Fixed

**Bug A-03** (`parse_decimal` in `types.rs`):
- Was: `parse_vint()` for unscaled field → `Value::Float` (loses precision for any non-trivial value; zigzag-decodes the raw BigInteger bytes, completely wrong)
- Now: reads all remaining bytes as raw BigInteger → `Value::Decimal { scale, unscaled }`
- Root cause: `DecimalType.java:275-278` uses `ByteBuffer.putInt(scale)` then `unscaledValue.toByteArray()` — no VInt encoding

**Bug A-04** (`parse_duration` in `types.rs`):
- Was: read 3 VInts correctly, then collapsed to `Value::BigInt(total_micros)` — approximate and loses calendar semantics
- Now: returns `Value::Duration { months: months as i32, days: days as i32, nanos }` preserving exact components
- Python `duration_to_timedelta` and Node.js `duration_to_object` both expected the struct form

**Bug A-07/A-08** (tuple/UDT field lengths in `value_parsing.rs`):
- Was: `parse_vint_length` — silently corrupts any field ≥ 128 bytes (VInt reads `0x00` as length=0 when Cassandra wrote `[0x00,0x00,0x00,0x80]`); also cannot handle -1 null sentinel
- Now: `i32::from_be_bytes(&data[offset..offset+4])` with -1 = null, 0 = empty, >0 = byte count
- Affected 4 code paths: `parse_tuple_value_with`, `parse_udt_value_with`, `SSTableReader::parse_udt_value`, and the inline UDT branch in `parse_value_with_comparator`
- Note: `parse_tuple` and `parse_udt` in `parser/types.rs` already used `be_i32` correctly — the bug was only in the schema-aware `value_parsing.rs` path

## Tests Added / Updated

**New behavioral tests** (S2-prefixed) in `value_parsing.rs`:
- `s2_a07_tuple_field_128_bytes_cassandra_format` — proves 128-byte field parses correctly
- `s2_a08_tuple_null_field_minus_one_sentinel` — proves -1 null sentinel works
- `s2_a08_udt_field_128_bytes_cassandra_format` — same for UDT
- `s2_a08_udt_null_field_minus_one_sentinel` — same for UDT null
- `s2_a02_date_epoch_bias_0x80000000` — verifies DATE epoch bias
- `s2_a02_date_one_day_after_epoch` / `s2_a02_date_one_day_before_epoch`

**Updated tests in `types.rs`**:
- `test_parse_decimal` — now expects `Value::Decimal { scale: 2, unscaled: [0x7B] }` for bytes `[0x00,0x00,0x00,0x02,0x7B]`
- `test_parse_decimal_negative_scale` — updated to match fixed behavior
- `test_parse_decimal_large_unscaled_no_vint_misread` — new regression test
- `test_parse_duration` — now expects `Value::Duration { months: 1, days: 15, nanos: ... }`
- `test_parse_duration_zero` — new zero duration test
- `test_parse_duration_negative_nanos` — new negative nanos test

**Updated existing tuple/UDT tests** to use correct 4-byte BE i32 field lengths:
- `test_parse_tuple_int_text`
- `test_parse_tuple_with_null` (now tests true null with -1 sentinel)
- `test_parse_udt_simple`
- `test_parse_udt_with_collection`

## CI

- All 1598 lib tests pass with default features
- All 872 lib tests pass with `--no-default-features --features all-compression`
- `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features` passes clean

## Out of Scope

- Ch.22 version-gate claims belong to S5 per task instructions
- Partition key Duration codec (`partition_key_codec.rs`) uses fixed 16-byte format — separate correctness concern, not in S2 scope