### PR TITLE
Remove heuristic Ascii/Varchar fallback from parse_cql_value (#648)

### DIFF
--- a/cqlite-core/src/parser/types.rs
+++ b/cqlite-core/src/parser/types.rs
@@ -108,28 +108,47 @@ pub fn parse_cql_value(input: &[u8], type_id: CqlTypeId) -> IResult<&[u8], Value
         CqlTypeId::Float => parse_float(input),
         CqlTypeId::Double => parse_double(input),
         CqlTypeId::Ascii | CqlTypeId::Varchar => {
-            // Try 4-byte big-endian length prefix first (for test compatibility)
-            if input.len() >= 4 {
-                let length = u32::from_be_bytes([input[0], input[1], input[2], input[3]]) as usize;
-                if input.len() >= 4 + length {
-                    let text_bytes = &input[4..4 + length];
-                    if let Ok(text) = String::from_utf8(text_bytes.to_vec()) {
-                        return Ok((&input[4 + length..], Value::Text(text)));
+            // In the SSTable cell format the caller has already extracted exactly
+            // the bytes belonging to this cell (length-framing is done at the cell
+            // level before parse_cql_value is invoked).  The entire `input` slice
+            // IS the text value — no additional length prefix to strip.
+            //
+            // For Ascii, Cassandra's AsciiSerializer requires every byte to be in
+            // the 0x00-0x7F range.  For Varchar/Text any valid UTF-8 is accepted.
+            // We accept both under the same validation path here; a stricter
+            // Ascii-only byte check can be added when needed.
+            #[cfg(feature = "legacy-heuristics")]
+            {
+                // Legacy path: try 4-byte big-endian length prefix, then null-terminated,
+                // then raw UTF-8 (kept for pre-5.0 compatibility only).
+                if input.len() >= 4 {
+                    let length =
+                        u32::from_be_bytes([input[0], input[1], input[2], input[3]]) as usize;
+                    if input.len() >= 4 + length {
+                        let text_bytes = &input[4..4 + length];
+                        if let Ok(text) = String::from_utf8(text_bytes.to_vec()) {
+                            return Ok((&input[4 + length..], Value::Text(text)));
+                        }
                     }
                 }
-            }
-            // Try null-terminated string (for test compatibility)
-            if let Some(null_pos) = input.iter().position(|&b| b == 0) {
-                if let Ok(text) = String::from_utf8(input[..null_pos].to_vec()) {
-                    return Ok((&input[null_pos + 1..], Value::Text(text)));
+                if let Some(null_pos) = input.iter().position(|&b| b == 0) {
+                    if let Ok(text) = String::from_utf8(input[..null_pos].to_vec()) {
+                        return Ok((&input[null_pos + 1..], Value::Text(text)));
+                    }
                 }
+                if let Ok(text) = String::from_utf8(input.to_vec()) {
+                    return Ok((&[], Value::Text(text)));
+                }
+                parse_text(input)
             }
-            // Try raw UTF-8 without prefix (for test compatibility)
-            if let Ok(text) = String::from_utf8(input.to_vec()) {
-                return Ok((&[], Value::Text(text)));
+            #[cfg(not(feature = "legacy-heuristics"))]
+            {
+                // Deterministic path: treat the entire input as the UTF-8 text value.
+                let text = String::from_utf8(input.to_vec()).map_err(|_| {
+                    nom::Err::Error(nom::error::Error::new(input, nom::error::ErrorKind::Verify))
+                })?;
+                Ok((&[], Value::Text(text)))
             }
-            // Fallback to VInt parsing
-            parse_text(input)
         }
         CqlTypeId::Blob => {
             // For test compatibility, if input is exactly the expected size without length prefix, return it as-is

--- a/cqlite-core/tests/parsing_improvements_test.rs
+++ b/cqlite-core/tests/parsing_improvements_test.rs
@@ -49,39 +49,82 @@ mod parsing_improvements_tests {
     }
 
     #[test]
-    fn test_text_field_extraction_improvements() {
-        // Test case 1: Length-prefixed text (4-byte length)
-        let mut length_prefixed = Vec::new();
+    fn test_text_field_extraction_deterministic() {
+        // SSTable cell framing: the caller strips the cell length prefix before
+        // invoking parse_cql_value.  The entire `input` slice IS the text value.
+
+        // Test case 1: Plain ASCII text (cell already framed — no extra length prefix)
         let text = "Hello, CQLite!";
+        let (remaining, value) = parse_cql_value(text.as_bytes(), CqlTypeId::Varchar).unwrap();
+        match value {
+            Value::Text(parsed_text) => assert_eq!(parsed_text, text),
+            _ => panic!("Expected text value"),
+        }
+        assert!(remaining.is_empty(), "should consume all input");
+
+        // Test case 2: Ascii type — same raw bytes, no prefix
+        let ascii_text = "Hello from Ascii";
+        let (remaining, value) = parse_cql_value(ascii_text.as_bytes(), CqlTypeId::Ascii).unwrap();
+        match value {
+            Value::Text(parsed_text) => assert_eq!(parsed_text, ascii_text),
+            _ => panic!("Expected text value for Ascii type"),
+        }
+        assert!(remaining.is_empty(), "should consume all input");
+
+        // Test case 3: UTF-8 with multi-byte characters
+        let valid_utf8 = "🚀 CQLite with emojis! 🎉";
+        let (remaining, value) =
+            parse_cql_value(valid_utf8.as_bytes(), CqlTypeId::Varchar).unwrap();
+        match value {
+            Value::Text(parsed_text) => {
+                assert!(parsed_text.contains("🚀"));
+                assert_eq!(parsed_text, valid_utf8);
+            }
+            _ => panic!("Expected text value"),
+        }
+        assert!(remaining.is_empty(), "should consume all input");
+
+        // Test case 4: Empty string (cell with 0 bytes; caller handles null vs empty at cell level)
+        let (remaining, value) = parse_cql_value(&[], CqlTypeId::Varchar).unwrap();
+        match value {
+            Value::Text(text) => assert!(text.is_empty()),
+            _ => panic!("Expected empty text value"),
+        }
+        assert!(remaining.is_empty());
+
+        // Test case 5: Invalid UTF-8 must be rejected (not silently accepted)
+        let invalid_utf8 = &[0xFF, 0xFE, 0xFD, 0xFC];
+        assert!(
+            parse_cql_value(invalid_utf8, CqlTypeId::Varchar).is_err(),
+            "invalid UTF-8 must be a parse error, not silently accepted"
+        );
+    }
+
+    #[cfg(feature = "legacy-heuristics")]
+    #[test]
+    fn test_text_field_extraction_legacy_heuristics() {
+        // These tests only run when the legacy-heuristics feature is enabled.
+        // They document the old behavior that is now opt-in only.
+
+        // Legacy path 1: 4-byte big-endian length prefix
+        let text = "Hello, CQLite!";
+        let mut length_prefixed = Vec::new();
         length_prefixed.extend_from_slice(&(text.len() as u32).to_be_bytes());
         length_prefixed.extend_from_slice(text.as_bytes());
 
-        // Should correctly parse the length-prefixed text
         let (_, value) = parse_cql_value(&length_prefixed, CqlTypeId::Varchar).unwrap();
         match value {
             Value::Text(parsed_text) => assert_eq!(parsed_text, text),
             _ => panic!("Expected text value"),
         }
 
-        // Test case 2: Null-terminated text
+        // Legacy path 2: Null-terminated string
         let null_terminated = b"Hello\0";
         let (_, value) = parse_cql_value(null_terminated, CqlTypeId::Varchar).unwrap();
         match value {
             Value::Text(parsed_text) => assert_eq!(parsed_text, "Hello"),
             _ => panic!("Expected text value"),
         }
-
-        // Test case 3: UTF-8 validation
-        let valid_utf8 = "🚀 CQLite with emojis! 🎉".as_bytes();
-        let (_, value) = parse_cql_value(valid_utf8, CqlTypeId::Varchar).unwrap();
-        match value {
-            Value::Text(parsed_text) => assert!(parsed_text.contains("🚀")),
-            _ => panic!("Expected text value"),
-        }
-
-        // Test case 4: Invalid UTF-8 should fallback to blob
-        let _invalid_utf8 = &[0xFF, 0xFE, 0xFD, 0xFC];
-        // Should not panic and should handle gracefully
     }
 
     #[test]
@@ -131,12 +174,13 @@ mod parsing_improvements_tests {
         // Should handle empty data gracefully
 
         // Test case 2: Zero-length string
-        let zero_length_string = &[0u8, 0u8, 0u8, 0u8]; // 4-byte length prefix = 0
-        let (_, value) = parse_cql_value(zero_length_string, CqlTypeId::Varchar).unwrap();
+        // In SSTable cell framing a zero-length cell is handled at the cell level
+        // (typically encoded as null/absent).  When parse_cql_value IS called with
+        // an empty slice the deterministic path returns an empty Text value.
+        let (_, value) = parse_cql_value(&[], CqlTypeId::Varchar).unwrap();
         match value {
             Value::Text(text) => assert!(text.is_empty()),
-            Value::Null => {} // Also acceptable
-            _ => panic!("Expected empty text or null value"),
+            _ => panic!("Expected empty text value"),
         }
 
         // Test case 3: Null value handling


### PR DESCRIPTION
## Summary

- The `Ascii`/`Varchar` arm of `parse_cql_value` carried three heuristic fallback paths (4-byte big-endian length prefix, null-terminated string, raw UTF-8) that were kept "for test compatibility." These violate the no-heuristics mandate (Issue #28).
- **New behavior (default):** the entire `input` slice is treated as the UTF-8 text value. This is correct because SSTable cell framing already supplies the value length at the cell level before `parse_cql_value` is invoked.
- **Legacy path:** the three old guessing paths are preserved behind the existing opt-in `legacy-heuristics` feature flag for any pre-5.0 compatibility needs. No new feature flag was needed.

## What changed

- `cqlite-core/src/parser/types.rs`: `Ascii|Varchar` arm rewritten; old heuristics moved inside `#[cfg(feature = "legacy-heuristics")]` block; new deterministic path under `#[cfg(not(feature = "legacy-heuristics"))]`.
- `cqlite-core/tests/parsing_improvements_test.rs`: `test_text_field_extraction_improvements` replaced by `test_text_field_extraction_deterministic` (5 deterministic cases including empty slice and invalid-UTF-8 rejection); heuristic-specific cases moved to `test_text_field_extraction_legacy_heuristics` gated on the feature flag.

## Call sites whose behavior changed

`parse_cql_value` is the only function affected. The primary SSTable read path (`row_cell_state_machine.rs`) calls `parse_cql_value_raw` (not `parse_cql_value`), which was already deterministic. The comparator value parsing path also uses its own direct UTF-8 decode. No production call sites are affected by this change.

## Gates

- `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features` — clean
- `cargo test --package cqlite-core` — 1674 passed, 0 failed
- `cargo test --package cqlite-core --no-default-features --features all-compression --lib` — 940 passed, 0 failed
- `bash test-data/scripts/smoke-test-all-tables.sh` — 33/33 tables PASS

Closes #648