### PR TITLE
VG5: da foundation — routing, graceful unsupported error, BTI scoping (closes #657)

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -177,6 +177,20 @@ impl SSTableReader {
             }
         });
 
+        // VG5: BTI (da) read support is not yet implemented.
+        // Detect the BTI format early — before header parsing — and return a
+        // structured, actionable error rather than a confusing parse failure.
+        // Full BTI reading is tracked in the scoping issue created by issue #657.
+        if matches!(*version_gates, VersionGates::Bti(_)) {
+            return Err(Error::unsupported_format(format!(
+                "BTI (da) read support not yet implemented for '{}'. \
+                 da-format SSTables use Partitions.db/Rows.db trie indexes instead of \
+                 Index.db/Summary.db and require a dedicated BTI read path. \
+                 See docs/reports/bti-read-support-scoping.md for the implementation plan.",
+                path.display()
+            )));
+        }
+
         let config = crate::cql::config::ParserConfig::default();
         let parser = SSTableParser::new(config)?;
         // Parse the header using enhanced version detection - strict error propagation.

--- a/cqlite-core/tests/issue_657_da_foundation.rs
+++ b/cqlite-core/tests/issue_657_da_foundation.rs
@@ -161,6 +161,13 @@ mod da_directory_discovery {
     use cqlite_core::storage::sstable::directory::{SSTableComponent, SSTableDirectory};
 
     /// Helper: return the path to the da simple_table fixture, or None if not available.
+    ///
+    /// Returns `None` when:
+    /// - `CQLITE_DATASETS_ROOT` is not set, or
+    /// - the `test_da/simple_table-*` directory does not exist, or
+    /// - the directory contains only git-tracked JSONL/metadata files (CI with
+    ///   datasets-v2 which has no da binary SSTables).  We detect the binary
+    ///   presence by looking for at least one `da-*-bti-Partitions.db` file.
     fn da_simple_table_path() -> Option<std::path::PathBuf> {
         let datasets_root = std::env::var("CQLITE_DATASETS_ROOT").ok()?;
         let base = std::path::Path::new(&datasets_root)
@@ -168,11 +175,31 @@ mod da_directory_discovery {
             .join("test_da");
 
         // Find the simple_table directory (includes UUID suffix)
-        std::fs::read_dir(&base)
+        let table_dir = std::fs::read_dir(&base)
             .ok()?
             .flatten()
             .find(|e| e.file_name().to_string_lossy().starts_with("simple_table-"))
-            .map(|e| e.path())
+            .map(|e| e.path())?;
+
+        // Guard: require at least one binary Partitions.db sentinel file.
+        // Without it the directory contains only git-tracked JSONL goldens and
+        // SSTableDirectory::scan will fail — causing a spurious test failure on
+        // CI environments that use datasets-v2 (no da binaries).
+        let has_binary_partitions = std::fs::read_dir(&table_dir).ok()?.flatten().any(|e| {
+            let name = e.file_name();
+            let s = name.to_string_lossy();
+            s.starts_with("da-") && s.ends_with("-bti-Partitions.db")
+        });
+
+        if !has_binary_partitions {
+            eprintln!(
+                "SKIP: test_da binaries not present (CI uses datasets-v2; goldens-only checkout). \
+                 Run `bash test-data/scripts/fetch-datasets.sh` to download binary SSTables."
+            );
+            return None;
+        }
+
+        Some(table_dir)
     }
 
     /// Directory scan of the da `simple_table` fixture must succeed — classifying

--- a/cqlite-core/tests/issue_657_da_foundation.rs
+++ b/cqlite-core/tests/issue_657_da_foundation.rs
@@ -1,0 +1,483 @@
+//! VG5: da (BTI) foundation tests (Issue #657)
+//!
+//! These tests verify the foundation work for da/BTI SSTable support:
+//!
+//! 1. Directory scan classifies `Partitions.db`/`Rows.db` correctly without warnings.
+//! 2. `SSTableReader::open` on a da SSTable returns a structured "BTI read support
+//!    not yet implemented" error — not a panic or confusing parse failure.
+//! 3. `FormatDetector` maps `da` to `V5x` (not `Unknown`).
+//! 4. Discovery finds the `test_da` tables from the real fixture.
+//!
+//! # Test data
+//!
+//! Tests that require real SSTable files read the `CQLITE_DATASETS_ROOT` environment
+//! variable (set to `test-data/datasets` when running the local gate).  Tests that
+//! do not require binary SSTable files run unconditionally.
+
+#[cfg(test)]
+mod da_component_routing {
+    use std::str::FromStr;
+
+    use cqlite_core::storage::sstable::directory::SSTableComponent;
+
+    /// Partitions.db must parse to `SSTableComponent::Partitions` without error.
+    #[test]
+    fn partitions_db_parses_to_partitions_component() {
+        let component = SSTableComponent::from_str("Partitions.db")
+            .expect("Partitions.db should parse to SSTableComponent::Partitions");
+        assert_eq!(
+            component,
+            SSTableComponent::Partitions,
+            "Partitions.db must map to SSTableComponent::Partitions"
+        );
+    }
+
+    /// Rows.db must parse to `SSTableComponent::Rows` without error.
+    #[test]
+    fn rows_db_parses_to_rows_component() {
+        let component = SSTableComponent::from_str("Rows.db")
+            .expect("Rows.db should parse to SSTableComponent::Rows");
+        assert_eq!(
+            component,
+            SSTableComponent::Rows,
+            "Rows.db must map to SSTableComponent::Rows"
+        );
+    }
+
+    /// Both Partitions.db and Rows.db must be recognised as BTI-specific.
+    #[test]
+    fn partitions_and_rows_are_bti_specific() {
+        assert!(
+            SSTableComponent::Partitions.is_bti_specific(),
+            "Partitions is a BTI-specific component"
+        );
+        assert!(
+            SSTableComponent::Rows.is_bti_specific(),
+            "Rows is a BTI-specific component"
+        );
+    }
+
+    /// BIG-specific components must NOT be flagged as BTI-specific.
+    #[test]
+    fn big_specific_components_are_not_bti_specific() {
+        assert!(
+            !SSTableComponent::Index.is_bti_specific(),
+            "Index.db is BIG-specific, not BTI-specific"
+        );
+        assert!(
+            !SSTableComponent::Summary.is_bti_specific(),
+            "Summary.db is BIG-specific, not BTI-specific"
+        );
+    }
+
+    /// Partitions.db must NOT be flagged as BIG-specific.
+    #[test]
+    fn partitions_is_not_big_specific() {
+        assert!(
+            !SSTableComponent::Partitions.is_big_specific(),
+            "Partitions.db must not be BIG-specific"
+        );
+    }
+
+    /// Rows.db must NOT be flagged as BIG-specific.
+    #[test]
+    fn rows_is_not_big_specific() {
+        assert!(
+            !SSTableComponent::Rows.is_big_specific(),
+            "Rows.db must not be BIG-specific"
+        );
+    }
+
+    /// File extension round-trips for BTI components.
+    #[test]
+    fn bti_component_extensions_round_trip() {
+        assert_eq!(
+            SSTableComponent::Partitions.file_extension(),
+            "Partitions.db"
+        );
+        assert_eq!(SSTableComponent::Rows.file_extension(), "Rows.db");
+    }
+}
+
+#[cfg(test)]
+mod da_format_detection {
+    use cqlite_core::storage::sstable::format_detector::{FormatDetector, SSTableFormat};
+
+    /// `da` must map to `V5x` in the FormatDetector — not `Unknown`.
+    #[test]
+    fn da_maps_to_v5x_not_unknown() {
+        let detector = FormatDetector::new();
+        let fmt = detector
+            .detect_from_version("da")
+            .expect("FormatDetector must not error for the known 'da' version");
+
+        assert_ne!(
+            fmt,
+            SSTableFormat::Unknown("da".to_string()),
+            "da must NOT map to Unknown"
+        );
+        assert_eq!(
+            fmt,
+            SSTableFormat::V5x("da".to_string()),
+            "da must map to V5x"
+        );
+        assert!(
+            detector.is_supported("da"),
+            "da must appear in supported_versions()"
+        );
+    }
+
+    /// `da` format reports it supports compression (consistent with other V5x).
+    #[test]
+    fn da_format_supports_compression() {
+        let fmt = SSTableFormat::V5x("da".to_string());
+        assert!(
+            fmt.supports_compression(),
+            "da (V5x) format must support compression"
+        );
+    }
+
+    /// `SSTableInfo::from_path` on a da Data.db must return V5x format.
+    #[test]
+    fn sstable_info_from_da_data_db_is_v5x() {
+        use cqlite_core::storage::sstable::format_detector::SSTableInfo;
+        use std::path::PathBuf;
+
+        let path = PathBuf::from("da-2-bti-Data.db");
+        let info = SSTableInfo::from_path(&path).expect("SSTableInfo::from_path must succeed");
+
+        assert_eq!(
+            info.format,
+            SSTableFormat::V5x("da".to_string()),
+            "da-2-bti-Data.db must yield V5x format, not Unknown"
+        );
+        assert_eq!(info.sstable_id, "2");
+        assert_eq!(info.size, "bti");
+    }
+}
+
+#[cfg(test)]
+mod da_directory_discovery {
+    use cqlite_core::storage::sstable::directory::{SSTableComponent, SSTableDirectory};
+
+    /// Helper: return the path to the da simple_table fixture, or None if not available.
+    fn da_simple_table_path() -> Option<std::path::PathBuf> {
+        let datasets_root = std::env::var("CQLITE_DATASETS_ROOT").ok()?;
+        let base = std::path::Path::new(&datasets_root)
+            .join("sstables")
+            .join("test_da");
+
+        // Find the simple_table directory (includes UUID suffix)
+        std::fs::read_dir(&base)
+            .ok()?
+            .flatten()
+            .find(|e| e.file_name().to_string_lossy().starts_with("simple_table-"))
+            .map(|e| e.path())
+    }
+
+    /// Directory scan of the da `simple_table` fixture must succeed — classifying
+    /// Partitions.db and Rows.db without warnings or errors.
+    #[test]
+    fn da_simple_table_scans_without_error() {
+        let Some(table_path) = da_simple_table_path() else {
+            eprintln!(
+                "SKIP: CQLITE_DATASETS_ROOT not set or test_da/simple_table not found; \
+                 run `bash test-data/scripts/fetch-datasets.sh` first"
+            );
+            return;
+        };
+
+        let dir = SSTableDirectory::scan(&table_path).unwrap_or_else(|e| {
+            panic!(
+                "SSTableDirectory::scan failed for da simple_table at {:?}: {}",
+                table_path, e
+            )
+        });
+
+        // Must find at least one generation
+        assert!(
+            !dir.generations.is_empty(),
+            "da simple_table must have at least one generation"
+        );
+
+        let gen = &dir.generations[0];
+        assert_eq!(gen.format, "bti", "da format segment must be 'bti'");
+        assert_eq!(gen.version, "da", "da version must be 'da'");
+
+        // Partitions.db and Rows.db must be classified correctly
+        assert!(
+            gen.components.contains_key(&SSTableComponent::Partitions),
+            "da generation must include SSTableComponent::Partitions; \
+             components present: {:?}",
+            gen.components.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            gen.components.contains_key(&SSTableComponent::Rows),
+            "da generation must include SSTableComponent::Rows; \
+             components present: {:?}",
+            gen.components.keys().collect::<Vec<_>>()
+        );
+
+        // Data.db and Statistics.db must also be present
+        assert!(
+            gen.components.contains_key(&SSTableComponent::Data),
+            "da generation must include SSTableComponent::Data"
+        );
+        assert!(
+            gen.components.contains_key(&SSTableComponent::Statistics),
+            "da generation must include SSTableComponent::Statistics"
+        );
+    }
+
+    /// All three da tables (simple_table, collection_table, ttl_table) must be
+    /// discoverable from the `test_da` keyspace directory.
+    #[test]
+    fn da_keyspace_discovers_three_tables() {
+        let datasets_root = match std::env::var("CQLITE_DATASETS_ROOT") {
+            Ok(v) => v,
+            Err(_) => {
+                eprintln!("SKIP: CQLITE_DATASETS_ROOT not set");
+                return;
+            }
+        };
+
+        let da_ks_path = std::path::Path::new(&datasets_root)
+            .join("sstables")
+            .join("test_da");
+
+        if !da_ks_path.exists() {
+            eprintln!(
+                "SKIP: test_da keyspace directory not found at {:?}",
+                da_ks_path
+            );
+            return;
+        }
+
+        let table_dirs: Vec<_> = std::fs::read_dir(&da_ks_path)
+            .unwrap()
+            .flatten()
+            .filter(|e| e.path().is_dir())
+            .collect();
+
+        assert_eq!(
+            table_dirs.len(),
+            3,
+            "test_da keyspace must have exactly 3 table directories: \
+             simple_table, collection_table, ttl_table. Found: {:?}",
+            table_dirs.iter().map(|e| e.file_name()).collect::<Vec<_>>()
+        );
+
+        // Each expected table must be discoverable
+        let table_names: Vec<String> = table_dirs
+            .iter()
+            .map(|e| {
+                e.file_name()
+                    .to_string_lossy()
+                    .split('-')
+                    .next()
+                    .unwrap_or("")
+                    .to_string()
+            })
+            .collect();
+
+        for expected in &["simple_table", "collection_table", "ttl_table"] {
+            assert!(
+                table_names.iter().any(|n| n == expected),
+                "Expected table '{}' not found in test_da. Found: {:?}",
+                expected,
+                table_names
+            );
+        }
+    }
+
+    /// Scanning the da directory must not produce any component-routing warnings
+    /// for Partitions.db/Rows.db (they must be classified, not silently skipped).
+    ///
+    /// This test verifies the component count includes BTI-specific components.
+    #[test]
+    fn da_scan_includes_bti_specific_components_not_skipped() {
+        let Some(table_path) = da_simple_table_path() else {
+            eprintln!("SKIP: CQLITE_DATASETS_ROOT not set or da fixture not available");
+            return;
+        };
+
+        let dir = SSTableDirectory::scan(&table_path).expect("scan must succeed");
+        let gen = &dir.generations[0];
+
+        // The da fixture has: Data, Statistics, CompressionInfo, Filter,
+        // Partitions, Rows, Digest, TOC — at least 6 components.
+        assert!(
+            gen.components.len() >= 6,
+            "da generation must have >= 6 classified components (including Partitions/Rows). \
+             Got {} components: {:?}",
+            gen.components.len(),
+            gen.components.keys().collect::<Vec<_>>()
+        );
+    }
+}
+
+#[cfg(test)]
+mod da_reader_graceful_rejection {
+    use cqlite_core::{storage::sstable::reader::SSTableReader, Config, Error};
+    use std::sync::Arc;
+
+    /// Helper: return the path to the da simple_table Data.db fixture, or None.
+    fn da_data_db_path() -> Option<std::path::PathBuf> {
+        let datasets_root = std::env::var("CQLITE_DATASETS_ROOT").ok()?;
+        let base = std::path::Path::new(&datasets_root)
+            .join("sstables")
+            .join("test_da");
+
+        let simple_table_dir = std::fs::read_dir(&base)
+            .ok()?
+            .flatten()
+            .find(|e| e.file_name().to_string_lossy().starts_with("simple_table-"))?
+            .path();
+
+        // Find da-N-bti-Data.db within the directory
+        std::fs::read_dir(&simple_table_dir)
+            .ok()?
+            .flatten()
+            .find(|e| {
+                let name = e.file_name();
+                let s = name.to_string_lossy();
+                s.starts_with("da-") && s.ends_with("-bti-Data.db")
+            })
+            .map(|e| e.path())
+    }
+
+    /// Opening a da Data.db with `SSTableReader::open` must return
+    /// `Error::UnsupportedFormat` — not a panic, and not a confusing parse error.
+    ///
+    /// The error message must mention "BTI (da)" so callers can act on it.
+    #[tokio::test]
+    async fn da_reader_open_returns_unsupported_format_error() {
+        let Some(data_db) = da_data_db_path() else {
+            eprintln!(
+                "SKIP: CQLITE_DATASETS_ROOT not set or da Data.db not found; \
+                 run `bash test-data/scripts/fetch-datasets.sh` first"
+            );
+            return;
+        };
+
+        let config = Config::default();
+        let platform = Arc::new(
+            cqlite_core::platform::Platform::new(&config)
+                .await
+                .expect("Platform::new must succeed"),
+        );
+
+        let result = SSTableReader::open(&data_db, &config, platform).await;
+
+        assert!(
+            result.is_err(),
+            "SSTableReader::open on a da Data.db must return an error"
+        );
+
+        let err = result.unwrap_err();
+
+        // Must be UnsupportedFormat — not Corruption or Parse or Internal.
+        assert!(
+            matches!(err, Error::UnsupportedFormat(_)),
+            "Error must be UnsupportedFormat, got: {:?}",
+            err
+        );
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("BTI (da)"),
+            "Error message must contain 'BTI (da)' for actionable diagnosis. Got: {msg}"
+        );
+        assert!(
+            msg.contains("not yet implemented"),
+            "Error message must say 'not yet implemented'. Got: {msg}"
+        );
+
+        // The error must not be recoverable (it's a format limitation, not a transient I/O issue).
+        assert!(
+            !err.is_recoverable(),
+            "UnsupportedFormat error must not be recoverable"
+        );
+    }
+
+    /// Verify the error message includes a pointer to the scoping document.
+    #[tokio::test]
+    async fn da_reader_error_mentions_scoping_doc() {
+        let Some(data_db) = da_data_db_path() else {
+            eprintln!("SKIP: CQLITE_DATASETS_ROOT not set or da Data.db not found");
+            return;
+        };
+
+        let config = Config::default();
+        let platform = Arc::new(
+            cqlite_core::platform::Platform::new(&config)
+                .await
+                .expect("Platform::new must succeed"),
+        );
+
+        let result = SSTableReader::open(&data_db, &config, platform).await;
+        let err = result.expect_err("Must return an error for da Data.db");
+        let msg = err.to_string();
+
+        assert!(
+            msg.contains("bti-read-support-scoping"),
+            "Error message must reference 'bti-read-support-scoping' doc. Got: {msg}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod da_error_category {
+    use cqlite_core::error::ErrorCategory;
+    use cqlite_core::Error;
+
+    /// `Error::UnsupportedFormat` must have category `Data` and be non-recoverable.
+    /// This is the error variant returned when opening a da SSTable.
+    #[test]
+    fn unsupported_format_error_category_and_recoverability() {
+        let err = Error::unsupported_format("BTI (da) read support not yet implemented");
+
+        // Category must be Data (maps to PARSE in Node.js bindings, CqliteError base in Python).
+        assert_eq!(
+            err.category(),
+            ErrorCategory::Data,
+            "UnsupportedFormat must have Data category"
+        );
+
+        // Not recoverable — this is a format limitation, not a transient error.
+        assert!(
+            !err.is_recoverable(),
+            "UnsupportedFormat must not be recoverable"
+        );
+    }
+
+    /// Python binding: `Error::UnsupportedFormat` falls through to `CqliteError`
+    /// base (the `_ =>` arm). This is a compile-time documentation assertion.
+    #[test]
+    fn unsupported_format_maps_to_cqlite_error_in_python_binding() {
+        // The Python binding maps UnsupportedFormat via the `_ => CqliteError` arm.
+        // This test documents the contract: the error IS surfaced (not swallowed),
+        // it just uses the base exception class rather than a specific subclass.
+        let err = Error::UnsupportedFormat("BTI (da) read support not yet implemented".into());
+        let msg = err.to_string();
+        assert!(
+            msg.contains("BTI (da)"),
+            "Error message must contain 'BTI (da)' for Python callers to inspect"
+        );
+    }
+
+    /// Node.js binding: `Error::UnsupportedFormat` category is `Data`, which maps
+    /// to code `PARSE` in the Node error mapping table.
+    #[test]
+    fn unsupported_format_maps_to_parse_code_in_node_binding() {
+        use cqlite_core::error::ErrorCategory;
+
+        let err = Error::UnsupportedFormat("BTI (da) read support not yet implemented".into());
+        // UnsupportedFormat.category() == Data, and Data -> "PARSE" in node error.rs
+        assert_eq!(
+            err.category(),
+            ErrorCategory::Data,
+            "UnsupportedFormat category must be Data (-> PARSE code in Node.js)"
+        );
+    }
+}

--- a/docs/reports/bti-read-support-scoping.md
+++ b/docs/reports/bti-read-support-scoping.md
@@ -1,0 +1,216 @@
+# BTI (da) Read Support — Scoping Document
+
+**Created**: 2026-06-10  
+**Issue**: #657 (VG5 — da foundation)  
+**Epic candidate**: GitHub issue #660  
+**Status**: SCOPING — da read support not yet implemented
+
+---
+
+## Executive Summary
+
+Cassandra 5.0 ships two on-disk SSTable formats:
+
+- **BIG** (`nb`/`oa` version letters) — classic B-tree-style index (Index.db + Summary.db)
+- **BTI** (`da` version letter) — trie-indexed format (Partitions.db + Rows.db)
+
+CQLite currently reads BIG-format SSTables (nb read path is complete; oa BIG read path is in-progress). This document scopes the work needed to add full BTI read support for the `da` format letter, which is the only BTI version letter used by Cassandra 5.0 (`BtiFormat.java:287`).
+
+**VG5 (issue #657)** delivered the foundation:
+- `da` recognised and routed by `FormatDetector` → `V5x("da")` (not `Unknown`)
+- `Partitions.db`/`Rows.db` classified as `SSTableComponent::Partitions`/`::Rows`
+- `SSTableReader::open` returns `Error::UnsupportedFormat` early (not a confusing parse failure)
+- `bti/` module has skeleton types and node-type dispatch (`#647`/`#651`)
+
+This document describes the remaining work for full end-to-end BTI reading.
+
+---
+
+## Authority
+
+All claims below are derived from the Cassandra 5.0.8 source:
+
+| File | Role |
+|------|------|
+| `BtiFormat.java` | Format definition, version gates |
+| `PartitionIndex.java` / `PartitionIndexBuilder.java` | Partitions.db reader/writer |
+| `RowIndexReader.java` / `RowIndexWriter.java` | Rows.db reader/writer |
+| `TrieNode.java` | Node type encoding (nibble dispatch) |
+| `TrieIndexEntry.java` | Per-partition row index entry |
+| `ByteComparable.java` / `ByteSource.java` | ByteComparable key encoding |
+| `SortedTableWriter.java` | Data.db write-time chain |
+| `BtiTableReader.java` | End-to-end read path |
+
+Local copy: `docs/cassandra-5.0-src/` (or `~/local_projects/cassandra`).
+
+---
+
+## Architecture
+
+### Partitions.db — partition trie
+
+`Partitions.db` is a compacted ByteComparable trie where each leaf node references a partition's position in `Data.db`.
+
+Key concepts:
+1. **ByteComparable encoding** (`ByteComparable.java`): partition keys are transformed to a byte-comparable form so trie order equals partition key order. CQLite's `bti/encoder.rs` has a skeleton; it needs to implement all CQL type encodings (int, text, UUID, blob, composite keys, …).
+2. **Trie node types** (`TrieNode.java`): 16 subtypes dispatched by the high nibble of the first byte. `bti/parser.rs` already implements all 16 nibble types (`#647`/`#651`). Remaining work: wire the decoded nodes into a trie-walk that returns a `Data.db` offset for a given partition key.
+3. **Root location**: The trie root is at the end of `Partitions.db`. The last 8 bytes hold the root offset; reading works backwards. (`PartitionIndex.java:82-95`)
+4. **Pointer encoding**: child pointers are backward deltas (child appears earlier in file). `bti/parser.rs` already decodes these correctly.
+
+**Remaining work** (Partitions.db):
+- [ ] Implement `PartitionsParser::find_partition(key: &[u8])` that walks the trie to locate a partition's data offset.
+- [ ] Implement `PartitionsParser::iter_partitions()` for full-scan support (needed for `SELECT *`).
+- [ ] Implement ByteComparable encoding for all CQL primitive and composite key types.
+- [ ] Unit tests: round-trip encoding + trie-walk against real `da-2-bti-Partitions.db`.
+
+### Rows.db — per-partition row index
+
+`Rows.db` holds per-partition row index entries that allow locating rows within a (possibly large) partition in `Data.db` without scanning from the start.
+
+Key concepts from `RowIndexReader.java`:
+1. **Index entry format**: Each entry is a `TrieIndexEntry` (`TrieIndexEntry.java`), containing:
+   - Data file offset (`long`)
+   - Deletion time for the indexed row range (as a `DeletionTime`) — contains `localDeletionTime` (uint32) and `markedForDeleteAt` (int64)
+   - `FLAG_OPEN_MARKER` bit (indicates whether a range tombstone is open at this position)
+2. **Trie structure**: Same nibble-dispatch trie as Partitions.db, but keyed on ByteComparable-encoded clustering keys.
+3. **Optional**: Small partitions (below `column_index_size_in_kb` threshold, default 64 KB) may not have a Rows.db entry at all — the row is read directly from Data.db at the partition offset from Partitions.db.
+
+**Remaining work** (Rows.db):
+- [ ] Implement `RowsParser::find_row(partition_offset, clustering_key)` for point lookups.
+- [ ] Implement `RowsParser::iter_rows(partition_offset)` for scanning a partition.
+- [ ] Parse `TrieIndexEntry` including `DeletionTime` and `FLAG_OPEN_MARKER`.
+- [ ] Handle the "no row index" case for small partitions.
+
+### Data.db — row payload
+
+BTI-format `Data.db` shares the same row-level binary format as BIG `Data.db` (`V5CompressedLegacy` for `nb`/`oa`). The row cell state machine (`row_cell_state_machine.rs`) and the V5 compressed legacy parser should be reusable.
+
+**Remaining work** (Data.db):
+- [ ] Confirm that `row_cell_state_machine.rs` parses `da`-format row payloads correctly (expected: yes, the payload format is shared).
+- [ ] Wire the Data.db reader into the BTI read path: after Partitions.db gives a data offset, seek to that position in Data.db and invoke the existing row parser.
+- [ ] Handle `BtiVersionGates` (all `da` gates are `true`): `hasAccurateMinMax`, etc.
+
+### CompressionInfo.db
+
+Same as BIG format. `CompressionInfo.db` parsing already works; the existing `chunked_data_reader.rs` and `chunk_decompressor.rs` should be reusable without modification.
+
+---
+
+## Read Path Integration Points
+
+The following TODOs exist in the codebase that must be resolved:
+
+### `bti/parser.rs` — open range_query / iter TODO items
+
+The `RowsParser` and `PartitionsParser` structs have placeholder bodies for:
+- `range_query` — range scan over clustering keys
+- partition iteration
+
+These stubs must be replaced with real trie-walk implementations.
+
+### `SSTableReader::open` — early BTI rejection (VG5)
+
+`reader/mod.rs` line ~179 currently returns `Error::UnsupportedFormat` for all BTI files. This guard must be removed (or made conditional on a feature flag) once the BTI read path is wired.
+
+### `BtiVersionGates` consumers
+
+`version_gate.rs` exposes `BtiVersionGates { has_accurate_min_max, has_legacy_min_max }`. These are threaded through `VersionGates::from_path` and available to the reader. When the BTI read path lands, callers should use these gates (e.g., `hasAccurateMinMax == true` means the min/max per Statistics.db column is authoritative for `da`).
+
+### Discovery service (`storage/sstable/mod.rs`)
+
+The `SSTableManager` currently loads `Data.db` via `SSTableReader::open`. For BTI tables this will now return `UnsupportedFormat`. The manager needs to detect BTI format early and route to a `BtiTableReader` (to be created) instead.
+
+---
+
+## Implementation Plan
+
+### Phase 1 — ByteComparable encoding (prerequisite)
+
+Implement `bti/encoder.rs::encode(key_components, types) -> Vec<u8>` for:
+- All CQL primitive types: int, bigint, varint, text, ascii, blob, boolean, timestamp, date, time, UUID, timeuuid, inet, decimal, duration
+- Composite partition keys (concatenate component encodings with separator bytes per `ByteComparable.java:§2.4`)
+- Clustering key encoding (includes ascending/descending ordering flags)
+
+**Estimated size**: M (2–3 days; encoding rules are well-specified in `ByteSource.java`)
+
+### Phase 2 — Partitions.db trie walk
+
+Implement `PartitionsParser::find_partition` and `::iter_partitions` using the existing node-type dispatch from `#647`/`#651`.
+
+**Estimated size**: M (2–3 days)
+
+### Phase 3 — Rows.db row index
+
+Implement `RowsParser::find_row` and `::iter_rows`, including `TrieIndexEntry` parsing with `DeletionTime` and `FLAG_OPEN_MARKER`.
+
+**Estimated size**: M (2–3 days)
+
+### Phase 4 — End-to-end wiring
+
+- Replace the VG5 early-exit guard in `SSTableReader::open` (or create `BtiTableReader`).
+- Wire `Partitions.db → Data.db` offset chain.
+- Wire `Rows.db → Data.db` row-level seeks.
+- Update `SSTableManager` to route BTI tables.
+- Run 33 nb tables smoke test still green; `test_da` tables should flip from SKIP-PENDING to passing.
+
+**Estimated size**: L (3–5 days; integration risk is higher)
+
+### Phase 5 — Parity testing
+
+- Generate JSONL goldens for `test_da` tables (via `sstabledump`; already done in `#654`).
+- Add parity tests matching `test_da.simple_table`, `test_da.collection_table`, `test_da.ttl_table`.
+- Extend smoke test to enforce `test_da` (remove from `SKIP_PENDING_KEYSPACES`).
+
+**Estimated size**: S (1 day)
+
+---
+
+## Total Estimate
+
+| Phase | Size | Risk |
+|-------|------|------|
+| Phase 1 — ByteComparable | M | Low (well-specified) |
+| Phase 2 — Partitions.db trie | M | Medium (trie walk bugs) |
+| Phase 3 — Rows.db row index | M | Medium |
+| Phase 4 — E2E wiring | L | High (integration) |
+| Phase 5 — Parity | S | Low |
+| **Total** | **XL** | **Medium-High** |
+
+Suggested sprint split: Phases 1–3 in one epic, Phase 4–5 in a follow-on.
+
+---
+
+## Known Unknowns / Risks
+
+1. **ByteComparable ordering for exotic types**: `duration`, `decimal`, `inet` have non-trivial byte-comparable encodings. May need reference tests against Cassandra directly.
+2. **Large partition handling**: Partitions with many rows use both Partitions.db (for the partition) AND Rows.db (for rows within). Interaction with the existing chunked decompressor is untested.
+3. **Tombstone semantics**: `FLAG_OPEN_MARKER` in `TrieIndexEntry` affects how range tombstones are applied. The existing `tombstone_merger.rs` may need BTI-aware extension.
+4. **Data.db format identity**: If BTI `da` Data.db uses a different row cell format than BIG `nb`/`oa`, the state machine will need updating. Expected to be the same (both use Cassandra 5.0 row encoding), but must verify with hex comparison.
+
+---
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `cqlite-core/src/storage/sstable/bti/encoder.rs` | Complete ByteComparable encoding |
+| `cqlite-core/src/storage/sstable/bti/parser.rs` | Implement trie-walk, row index |
+| `cqlite-core/src/storage/sstable/reader/mod.rs` | Remove VG5 early-exit guard |
+| `cqlite-core/src/storage/sstable/reader/bti_reader.rs` | New: BtiTableReader |
+| `cqlite-core/src/storage/sstable/mod.rs` | Route BTI tables in SSTableManager |
+| `cqlite-core/tests/issue_NNN_bti_e2e.rs` | Parity tests against test_da fixtures |
+| `test-data/scripts/smoke-test-all-tables.sh` | Move test_da from SKIP_PENDING to enforced |
+
+---
+
+## References
+
+- `BtiFormat.java` — `org.apache.cassandra.io.sstable.format.bti`
+- `PartitionIndex.java` — trie root offset at EOF, `find()` method
+- `RowIndexReader.java` — `TrieIndexEntry`, `FLAG_OPEN_MARKER`, `DeletionTime`
+- `TrieNode.java` — 16 node subtypes, nibble dispatch
+- `ByteComparable.java` / `ByteSource.java` — key encoding rules
+- `bti/parser.rs` — existing node-type dispatch (complete as of #647/#651)
+- `bti/encoder.rs` — ByteComparable encoder skeleton
+- `issue_653_version_gates_plumbing_test.rs` — BtiVersionGates tests
+- `issue_657_da_foundation.rs` — VG5 foundation tests


### PR DESCRIPTION
## Summary

- **Graceful BTI rejection**: `SSTableReader::open` on any `da`-format Data.db returns `Error::UnsupportedFormat` with a clear "BTI (da) read support not yet implemented" message — instead of a confusing parse failure or panic. The early-exit guard uses `VersionGates::from_path` (derived from the filename), so no file I/O is wasted before the check.

- **Component routing confirmed**: `Partitions.db` and `Rows.db` are already classified as `SSTableComponent::Partitions` / `SSTableComponent::Rows` by the directory scanner (VG1 work from #653 is sufficient). No warnings are generated for these BTI-specific components.

- **FormatDetector routing**: `da` → `V5x("da")` (not `Unknown`) confirmed by existing tests from #653; `SSTableInfo::from_path` works for `da-N-bti-Data.db` filenames.

- **18 new integration tests** in `cqlite-core/tests/issue_657_da_foundation.rs` covering: component routing, format detection, real da fixture discovery, graceful reader rejection, and error category/binding mapping.

- **Scoping document** `docs/reports/bti-read-support-scoping.md` covers the full BTI read epic: ByteComparable encoding, Partitions.db trie walk, Rows.db row index (TrieIndexEntry / FLAG_OPEN_MARKER per RowIndexReader.java), Data.db chain, BtiVersionGates consumers. Epic candidate filed as issue #660.

- **Error surfacing**: `Error::UnsupportedFormat` has `ErrorCategory::Data`, which maps to:
  - Node.js: `code=PARSE` (via `category_to_code`)
  - Python: `CqliteError` base exception (via `_ =>` arm in `to_py_err`)
  - CLI: exit code 5 `QueryExecutionError` (via `_ =>` fallthrough)
  No binding files were modified; the existing mapping is correct for this error type.

## Gate Results

| Check | Result |
|-------|--------|
| `cargo fmt --all -- --check` | PASS |
| `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features` | PASS |
| `CQLITE_DATASETS_ROOT cargo test -p cqlite-core` | PASS (18/18 new tests) |
| `CQLITE_DATASETS_ROOT cargo test -p cqlite-integration-tests` | 125 PASS / 4 pre-existing FAIL (CLI binary not compiled for unit test context, confirmed on main) |
| `cargo build --package cqlite-core --no-default-features --features all-compression` | PASS |
| `smoke-test-all-tables.sh` | 33/33 nb PASS, 9 oa/da SKIP-PENDING (unchanged) |

## Scoping Issue

Epic candidate for full BTI read support: #660

## Test Plan

- [ ] Confirm 18 new tests in `issue_657_da_foundation.rs` pass
- [ ] Confirm `SSTableReader::open` on `da-2-bti-Data.db` raises `UnsupportedFormat` (not `Corruption`/panic)
- [ ] Confirm directory scan of `test_da/simple_table-*/` classifies all components including `Partitions` and `Rows`
- [ ] Confirm `smoke-test-all-tables.sh` still shows 33/33 PASS
- [ ] Confirm `docs/reports/bti-read-support-scoping.md` is complete and references issue #660