### PR TITLE
Add profiling infrastructure: pprof flamegraphs, dhat heap profiling, and improvement-loop tooling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,13 @@ cargo fmt
 # Smoke test all tables
 bash test-data/scripts/smoke-test-all-tables.sh
 
+# Profiling loop (see docs/profiling.md)
+./scripts/profile.sh baseline        # save criterion baseline
+./scripts/profile.sh flame           # CPU flamegraphs (pprof, works in containers)
+./scripts/profile.sh heap            # dhat heap profile vs <128MB budget
+./scripts/profile.sh bench && ./scripts/profile.sh compare   # re-measure vs baseline
+./scripts/profile.sh report          # ranked bottleneck report + history.jsonl ledger
+
 # Run CLI
 cargo run --package cqlite-cli -- <command>
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,10 @@ strip = true
 
 [profile.bench]
 debug = true
+# bench inherits from release, which sets `strip = true` — that would discard
+# the symbols that profilers (pprof flamegraphs, dhat backtraces) need even
+# with debug = true above. Keep bench binaries unstripped (docs/profiling.md).
+strip = "none"
 
 [profile.dev]
 # Faster builds for development

--- a/cqlite-core/Cargo.toml
+++ b/cqlite-core/Cargo.toml
@@ -82,6 +82,10 @@ web-sys = { workspace = true, features = ["console"], optional = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
+# Heap profiling harness (examples/heap_profile.rs). The dhat allocator is only
+# installed when the `dhat-heap` feature is enabled; the dependency itself is
+# dev-only and never ships in the library.
+dhat = "0.3"
 proptest = { workspace = true }
 tempfile = "3.8"
 rand = "0.8"
@@ -92,6 +96,13 @@ fastrand = "2.0"
 libc = { workspace = true }
 num-bigint = "0.4"  # For varint/decimal validation in tests
 num-traits = "0.2"  # Required for BigInt conversion methods
+
+# In-process sampling CPU profiler for the criterion benches (signal-based, so
+# it works in containers and on CI runners where `perf` is unavailable).
+# Unix-only: pprof does not build on Windows; benches fall back to the plain
+# criterion config there (see benches/profiling/mod.rs).
+[target.'cfg(unix)'.dev-dependencies]
+pprof = { version = "0.14", features = ["flamegraph", "criterion"] }
 
 [[bench]]
 name = "partition_lookup"
@@ -180,6 +191,11 @@ test-quality-gates = []        # Quality gate enforcement
 
 # M5: Write support - SSTable generation and persistence (Issue #359)
 write-support = []
+
+# Heap profiling: installs the dhat global allocator in examples/heap_profile.rs.
+# Dev/profiling only — never enable for production builds (allocation tracking
+# adds overhead). See docs/profiling.md.
+dhat-heap = []
 
 [lints]
 workspace = true

--- a/cqlite-core/benches/README.md
+++ b/cqlite-core/benches/README.md
@@ -34,6 +34,25 @@ to the workspace-relative `test-data/datasets` path (derived from
 `CARGO_MANIFEST_DIR`), so a checkout with fetched datasets runs with no
 environment setup.
 
+## Profiling
+
+Every bench target has an in-process sampling CPU profiler attached
+(`profiling/mod.rs`, [pprof](https://crates.io/crates/pprof) on unix). It is
+inert during normal measurement runs — including the CI gate — and activates
+only when criterion is invoked with `--profile-time`:
+
+```bash
+# 10 s of sampling per selected bench →
+# target/criterion/<group>/<bench>/profile/flamegraph.svg
+env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets \
+  cargo bench -p cqlite-core --features cli-helpers --bench read -- --profile-time 10
+```
+
+See [docs/profiling.md](../../docs/profiling.md) for the full workflow:
+flamegraphs, dhat heap profiling against the 128 MiB budget
+(`examples/heap_profile.rs`), and the `scripts/profile.sh`
+profile → fix → re-measure loop.
+
 ## Fixtures (Issue #537)
 
 `fixtures/mod.rs` is the shared, deterministic fixture loader every bench draws

--- a/cqlite-core/benches/m1_performance.rs
+++ b/cqlite-core/benches/m1_performance.rs
@@ -20,6 +20,9 @@ use std::sync::Arc;
 #[path = "fixtures/mod.rs"]
 mod fixtures;
 
+#[path = "profiling/mod.rs"]
+mod profiling;
+
 /// Benchmark context holding real SSTable data from multiple datasets
 struct BenchmarkContext {
     /// Index reader for partition lookup benchmarks
@@ -488,7 +491,7 @@ fn bench_m1_comprehensive_validation(c: &mut Criterion) {
 
 criterion_group!(
     name = m1_partition_lookups;
-    config = Criterion::default();
+    config = profiling::configure();
     targets = bench_partition_lookup_cold_cache,
               bench_partition_lookup_warm_cache,
               bench_partition_lookup_throughput
@@ -496,21 +499,21 @@ criterion_group!(
 
 criterion_group!(
     name = m1_read_throughput;
-    config = Criterion::default();
+    config = profiling::configure();
     targets = bench_sstable_read_throughput,
               bench_multi_sstable_read_throughput
 );
 
 criterion_group!(
     name = m1_memory_efficiency;
-    config = Criterion::default();
+    config = profiling::configure();
     targets = bench_memory_usage_large_sstable,
               bench_sequential_memory_efficiency
 );
 
 criterion_group!(
     name = m1_comprehensive;
-    config = Criterion::default();
+    config = profiling::configure();
     targets = bench_m1_comprehensive_validation
 );
 

--- a/cqlite-core/benches/partition_lookup.rs
+++ b/cqlite-core/benches/partition_lookup.rs
@@ -15,6 +15,9 @@ use std::sync::Arc;
 #[path = "fixtures/mod.rs"]
 mod fixtures;
 
+#[path = "profiling/mod.rs"]
+mod profiling;
+
 /// Benchmark context holding real SSTable data
 struct BenchmarkContext {
     index_reader: IndexReader,
@@ -205,11 +208,12 @@ fn bench_cache_operations(c: &mut Criterion) {
 }
 
 criterion_group!(
-    benches,
-    bench_index_lookup_cold,
-    bench_index_lookup_warm,
-    bench_lookup_throughput,
-    bench_lookup_by_key_distribution,
-    bench_cache_operations,
+    name = benches;
+    config = profiling::configure();
+    targets = bench_index_lookup_cold,
+              bench_index_lookup_warm,
+              bench_lookup_throughput,
+              bench_lookup_by_key_distribution,
+              bench_cache_operations,
 );
 criterion_main!(benches);

--- a/cqlite-core/benches/profiling/mod.rs
+++ b/cqlite-core/benches/profiling/mod.rs
@@ -1,0 +1,49 @@
+//! Shared Criterion configuration that attaches an in-process sampling CPU
+//! profiler to every bench target (docs/profiling.md).
+//!
+//! Profiling is **opt-in per run**: a plain `cargo bench` measures exactly as
+//! before (criterion only activates the attached profiler when the binary is
+//! invoked with `--profile-time <seconds>`), so the CI perf-regression gate is
+//! unaffected by this module. When `--profile-time` is passed, each selected
+//! bench runs for the given duration under the [`pprof`] sampler and writes a
+//! flamegraph to:
+//!
+//! ```text
+//! target/criterion/<group>/<bench>/profile/flamegraph.svg
+//! ```
+//!
+//! Typical invocation (or use `scripts/profile.sh flame`):
+//!
+//! ```text
+//! cargo bench --package cqlite-core --features cli-helpers \
+//!     --bench read -- --profile-time 10
+//! ```
+//!
+//! pprof samples via `SIGPROF`/`setitimer`, so it needs neither the `perf`
+//! binary nor `perf_event_open` access — it works inside unprivileged
+//! containers and CI runners. On non-unix targets (where pprof does not
+//! build) this degrades to the plain criterion default config.
+//!
+//! Like `fixtures/mod.rs`, this file is included into each bench target via
+//! `#[path = "profiling/mod.rs"] mod profiling;`.
+
+#![allow(dead_code)]
+
+use criterion::Criterion;
+
+/// Sampling frequency in Hz. A prime (997 ≈ 1 kHz) avoids lockstep with
+/// periodic work in the benched code, which would bias the samples.
+#[cfg(unix)]
+const SAMPLE_HZ: i32 = 997;
+
+/// The standard criterion config for cqlite benches, with the pprof
+/// flamegraph profiler attached on unix.
+pub fn configure() -> Criterion {
+    let criterion = Criterion::default();
+    #[cfg(unix)]
+    let criterion = criterion.with_profiler(pprof::criterion::PProfProfiler::new(
+        SAMPLE_HZ,
+        pprof::criterion::Output::Flamegraph(None),
+    ));
+    criterion
+}

--- a/cqlite-core/benches/read.rs
+++ b/cqlite-core/benches/read.rs
@@ -40,6 +40,9 @@ use criterion::{criterion_group, criterion_main, Criterion};
 #[path = "fixtures/mod.rs"]
 mod fixtures;
 
+#[path = "profiling/mod.rs"]
+mod profiling;
+
 // ---------------------------------------------------------------------------
 // cli-helpers benches
 // ---------------------------------------------------------------------------
@@ -204,11 +207,12 @@ fn bench_type_heavy(c: &mut Criterion) {
 
 #[cfg(feature = "cli-helpers")]
 criterion_group!(
-    benches,
-    bench_point_lookup,
-    bench_clustering_slice,
-    bench_full_scan,
-    bench_type_heavy
+    name = benches;
+    config = profiling::configure();
+    targets = bench_point_lookup,
+              bench_clustering_slice,
+              bench_full_scan,
+              bench_type_heavy
 );
 
 #[cfg(not(feature = "cli-helpers"))]
@@ -218,6 +222,10 @@ fn bench_noop(_c: &mut Criterion) {
 }
 
 #[cfg(not(feature = "cli-helpers"))]
-criterion_group!(benches, bench_noop);
+criterion_group!(
+    name = benches;
+    config = profiling::configure();
+    targets = bench_noop
+);
 
 criterion_main!(benches);

--- a/cqlite-core/benches/write.rs
+++ b/cqlite-core/benches/write.rs
@@ -44,6 +44,9 @@ use criterion::{black_box, Throughput};
 #[path = "fixtures/mod.rs"]
 mod fixtures;
 
+#[path = "profiling/mod.rs"]
+mod profiling;
+
 /// Number of rows inserted per ingest iteration.
 #[cfg(feature = "write-support")]
 const INGEST_ROWS: u64 = 256;
@@ -264,7 +267,11 @@ fn bench_flush(c: &mut Criterion) {
 // every feature combination without dead-code noise.
 
 #[cfg(feature = "write-support")]
-criterion_group!(benches, bench_ingest, bench_ingest_wal_off, bench_flush);
+criterion_group!(
+    name = benches;
+    config = profiling::configure();
+    targets = bench_ingest, bench_ingest_wal_off, bench_flush
+);
 
 #[cfg(not(feature = "write-support"))]
 fn bench_noop(_c: &mut Criterion) {
@@ -273,6 +280,10 @@ fn bench_noop(_c: &mut Criterion) {
 }
 
 #[cfg(not(feature = "write-support"))]
-criterion_group!(benches, bench_noop);
+criterion_group!(
+    name = benches;
+    config = profiling::configure();
+    targets = bench_noop
+);
 
 criterion_main!(benches);

--- a/cqlite-core/examples/heap_profile.rs
+++ b/cqlite-core/examples/heap_profile.rs
@@ -1,0 +1,149 @@
+//! Heap-profiling harness for the read path (docs/profiling.md).
+//!
+//! Runs the same fixture workloads as the `read` criterion bench (full scan of
+//! `test_basic.simple_table`, type-heavy scan of
+//! `test_collections.collection_table`) under the [dhat] heap profiler and
+//! reports allocation totals plus peak heap against the project's <128 MiB
+//! memory budget (CLAUDE.md "Memory target").
+//!
+//! Two artifacts are written to `target/profiling/`:
+//!
+//! - `dhat-heap.json` — full allocation profile. Open it in the dhat viewer:
+//!   <https://nnethercote.github.io/dh_view/dh_view.html> to see allocation
+//!   hot spots by call stack (which code allocates the most / churns the most).
+//! - `heap-summary.json` — compact machine-readable summary consumed by
+//!   `scripts/profile_report.py` for the recursive-improvement report.
+//!
+//! Run via the orchestrator (preferred):
+//!
+//! ```text
+//! ./scripts/profile.sh heap
+//! ```
+//!
+//! or directly:
+//!
+//! ```text
+//! cargo run --package cqlite-core --example heap_profile \
+//!     --features cli-helpers,dhat-heap --profile bench
+//! ```
+//!
+//! Without `dhat-heap` the workload still runs (useful as a smoke test) but no
+//! allocation data is collected. The `bench` profile matters: the workspace
+//! `release` profile strips symbols, which destroys dhat's backtraces.
+
+// The dhat allocator must be the global allocator to observe every allocation.
+// Only installed under the opt-in `dhat-heap` feature so normal builds and
+// other examples are unaffected.
+#[cfg(feature = "dhat-heap")]
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+#[cfg(feature = "cli-helpers")]
+#[path = "../benches/fixtures/mod.rs"]
+mod fixtures;
+
+#[cfg(not(feature = "cli-helpers"))]
+fn main() {
+    eprintln!(
+        "heap_profile requires the cli-helpers feature:\n  \
+         cargo run -p cqlite-core --example heap_profile \
+         --features cli-helpers,dhat-heap --profile bench"
+    );
+    std::process::exit(2);
+}
+
+#[cfg(feature = "cli-helpers")]
+fn main() {
+    use std::path::PathBuf;
+
+    /// Memory budget from CLAUDE.md: <128 MiB for large files.
+    const HEAP_BUDGET_BYTES: u64 = 128 * 1024 * 1024;
+
+    let out_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../target/profiling");
+    std::fs::create_dir_all(&out_dir).expect("create target/profiling");
+
+    // Start the profiler before any workload allocation so setup cost (db
+    // open, schema parse) is attributed too — those paths count against the
+    // memory budget exactly like steady-state reads.
+    #[cfg(feature = "dhat-heap")]
+    let profiler = dhat::Profiler::builder()
+        .file_name(out_dir.join("dhat-heap.json"))
+        .build();
+
+    let workloads = [
+        ("read/full_scan", fixtures::ReadFixture::SIMPLE),
+        ("read/type_heavy", fixtures::ReadFixture::TYPE_HEAVY),
+    ];
+
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    for (name, fx) in &workloads {
+        let loaded = fixtures::open_read_db(fx);
+        let sql = format!("SELECT * FROM {}", fx.qualified());
+        let result = rt
+            .block_on(loaded.db.execute(&sql))
+            .unwrap_or_else(|e| panic!("{name}: query failed: {e}"));
+        assert!(
+            !result.rows.is_empty(),
+            "{name}: zero rows from {} — fixtures not fetched? \
+             Run: bash test-data/scripts/fetch-datasets.sh",
+            fx.qualified()
+        );
+        println!("{name}: scanned {} rows", result.rows.len());
+    }
+
+    #[cfg(feature = "dhat-heap")]
+    {
+        let stats = dhat::HeapStats::get();
+        let within_budget = (stats.max_bytes as u64) <= HEAP_BUDGET_BYTES;
+
+        // Compact summary for scripts/profile_report.py. serde_json is a
+        // regular cqlite-core dependency, so it is available to examples.
+        let summary = serde_json::json!({
+            "workloads": workloads.iter().map(|(n, _)| n).collect::<Vec<_>>(),
+            "total_allocations": stats.total_blocks,
+            "total_bytes_allocated": stats.total_bytes,
+            "peak_blocks": stats.max_blocks,
+            "peak_bytes": stats.max_bytes,
+            "heap_budget_bytes": HEAP_BUDGET_BYTES,
+            "within_budget": within_budget,
+        });
+        let summary_path = out_dir.join("heap-summary.json");
+        std::fs::write(
+            &summary_path,
+            serde_json::to_string_pretty(&summary).expect("serialize heap summary"),
+        )
+        .expect("write heap-summary.json");
+
+        println!();
+        println!("heap profile (dhat):");
+        println!("  total allocations : {}", stats.total_blocks);
+        println!("  total bytes       : {}", stats.total_bytes);
+        println!(
+            "  peak heap         : {} bytes ({:.1} MiB)",
+            stats.max_bytes,
+            stats.max_bytes as f64 / (1024.0 * 1024.0)
+        );
+        println!(
+            "  budget (<128 MiB) : {}",
+            if within_budget { "PASS" } else { "FAIL" }
+        );
+        println!("  summary           : {}", summary_path.display());
+        println!(
+            "  full profile      : {} (view at https://nnethercote.github.io/dh_view/dh_view.html)",
+            out_dir.join("dhat-heap.json").display()
+        );
+
+        // Drop writes dhat-heap.json; do it before the budget verdict exits.
+        drop(profiler);
+
+        if !within_budget {
+            std::process::exit(1);
+        }
+    }
+
+    #[cfg(not(feature = "dhat-heap"))]
+    println!(
+        "\nworkloads completed (no allocation data: rebuild with --features dhat-heap \
+         to collect a heap profile)"
+    );
+}

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -1,0 +1,196 @@
+# Profiling CQLite: tools, workflow, and the recursive-improvement loop
+
+This page is the operational companion to [performance.md](performance.md).
+That page explains *what the CI perf gate enforces*; this one explains *how to
+find and fix the bottlenecks* the gate measures — and how to keep doing it
+iteratively with auditable output.
+
+The entry point for everything below is one script:
+
+```bash
+./scripts/profile.sh help
+```
+
+---
+
+## 1. Profiler selection: what works on this project, and where
+
+CQLite is an async (Tokio) Rust workspace that is exercised through Criterion
+benches over real SSTable fixtures. Profilers were selected against three
+constraints:
+
+1. **Containers/CI without `perf`.** Dev containers and CI runners typically
+   have `perf_event_paranoid=2` and no `perf` binary, so anything built on
+   `perf_event_open` is out for the default loop.
+2. **Symbolized stacks.** The workspace `release` profile sets `strip = true`,
+   so profiling must run under the `bench` profile (`debug = true`), which
+   Criterion uses automatically.
+3. **The 128 MiB memory target.** CPU time alone is not enough; the project
+   has an explicit peak-heap budget (CLAUDE.md), so heap profiling is a
+   first-class concern, not an afterthought.
+
+### Integrated (work everywhere, including this repo's dev containers)
+
+| Tool | Measures | How it's wired in |
+|------|----------|-------------------|
+| **Criterion** (existing) | wall time, throughput, regression deltas | `cqlite-core/benches/{read,write,partition_lookup,m1_performance}.rs`, gated by `benches/perf-gate.json` |
+| **pprof-rs** (`pprof` crate) | CPU call stacks → flamegraph SVG per bench | attached to every bench via `benches/profiling/mod.rs`; activates only with `--profile-time` |
+| **dhat-rs** (`dhat` crate) | allocation counts, churn, peak heap vs 128 MiB budget | `cqlite-core/examples/heap_profile.rs` behind the `dhat-heap` feature |
+
+pprof samples via `SIGPROF`/`setitimer` in-process — no `perf` binary, no
+elevated `perf_event_paranoid`, no container privileges needed. dhat is a
+global-allocator wrapper, so it works on any target.
+
+### Optional (local machines, deeper dives)
+
+| Tool | When to reach for it | Notes |
+|------|----------------------|-------|
+| `cargo flamegraph` / `perf` | local Linux with `perf` installed | kernel + user stacks; needs `perf_event_paranoid ≤ 1` for kernel frames |
+| `samply` | local Linux/macOS | Firefox Profiler UI; great for timeline views of the Tokio runtime |
+| Instruments (Time Profiler / Allocations) | macOS | best-in-class UI; use on Apple-silicon dev machines |
+| Valgrind DHAT / callgrind | available in the dev container (`valgrind` is installed) | deterministic instruction counts; very slow but noise-free — useful when criterion deltas are within noise |
+| `iai-callgrind` | possible future CI addition | instruction-count benchmarking on top of callgrind; immune to shared-runner noise |
+| `tokio-console` | suspected async stalls (tasks blocked, not CPU) | needs `tokio_unstable` + instrumentation; reach for it when flamegraphs show idle time |
+
+Rule of thumb: **flamegraph wide frames** → CPU bottleneck (decode, hashing,
+copies); **fast CPU but slow wall time** → I/O or async scheduling (check
+`write/ingest_wal_on` vs `_off`, consider `tokio-console`); **slow and
+allocation-heavy in dhat** → memory churn (clones, `Vec` growth,
+`String`/`Bytes` copies — see the `rust-patterns` zero-copy guidance).
+
+---
+
+## 2. The workloads being profiled
+
+Profiling reuses the deterministic Criterion benches (Epic #541) — same
+fixtures, same seeded RNG, so two profile runs are comparable:
+
+- `read/point_lookup`, `read/clustering_slice`, `read/full_scan`,
+  `read/type_heavy` — the read path: open → index → decode (collections
+  isolated by `type_heavy`).
+- `write/ingest_wal_off` (CPU-bound, strictly gated), `write/ingest_wal_on`
+  (fsync-bound, advisory), `write/flush` — the write engine.
+- `partition_lookup/*` — Index.db lookup micro-benches.
+
+The heap harness (`examples/heap_profile.rs`) runs the `full_scan` and
+`type_heavy` workloads under dhat and verdicts peak heap against the 128 MiB
+budget.
+
+---
+
+## 3. The recursive-improvement loop
+
+Every iteration produces machine-readable artifacts under `target/profiling/`,
+so each round starts from the previous round's output instead of folklore.
+
+```
+        ┌────────────────────────────────────────────────────────┐
+        ▼                                                        │
+  1. baseline      ./scripts/profile.sh baseline                 │
+  2. profile       ./scripts/profile.sh flame   (CPU)            │
+                   ./scripts/profile.sh heap    (allocations)    │
+  3. diagnose      ./scripts/profile.sh report  → report.md      │
+                   pick the ONE widest frame / worst bench       │
+  4. fix           one targeted change (zero-copy, fewer clones, │
+                   better data structure, skip redundant work)   │
+  5. verify        ./scripts/profile.sh bench                    │
+                   ./scripts/profile.sh compare current base     │
+  6. record        ./scripts/profile.sh report  → history.jsonl ─┘
+                   improvement confirmed? re-run `baseline`, commit,
+                   and let the CI gate (perf-regression.yml) hold the line
+```
+
+### Artifacts per iteration
+
+| File | Purpose |
+|------|---------|
+| `target/criterion/<group>/<bench>/profile/flamegraph.svg` | where CPU time goes, per bench |
+| `target/profiling/dhat-heap.json` | full allocation profile (open in the [dhat viewer](https://nnethercote.github.io/dh_view/dh_view.html)) |
+| `target/profiling/heap-summary.json` | peak heap + budget verdict, machine-readable |
+| `target/profiling/report.json` | ranked bench table with deltas — input for the *next* iteration (or an agent driving it) |
+| `target/profiling/report.md` | the same, human-readable |
+| `target/profiling/history.jsonl` | append-only ledger: one line per iteration with git rev, medians, peak heap |
+
+`history.jsonl` is what makes the loop *recursive* rather than one-shot: it
+survives baseline overwrites, so you can always answer "did the last five
+changes actually compound?" with `git rev` precision.
+
+### Exit criteria for a round of optimization
+
+Stop iterating when any of these hold:
+
+- the top frames in the flamegraph are irreducible work (decompression,
+  checksums, kernel I/O) rather than cqlite code;
+- the strict benches improve by less than their gate threshold (10%) two
+  rounds in a row — you are now tuning noise;
+- peak heap is comfortably inside the 128 MiB budget and allocation churn is
+  dominated by row materialization the API contract requires.
+
+Then lock in the wins: re-save the baseline, update
+`cqlite-core/benches/perf-gate.json` thresholds if a bench got dramatically
+faster (a 10% regression on a 2× faster bench is still a win worth gating),
+and let `perf-regression.yml` enforce it on every PR.
+
+---
+
+## 4. Command reference
+
+```bash
+# one-time setup: binary SSTable fixtures
+bash test-data/scripts/fetch-datasets.sh
+
+# 1. baseline on a clean tree
+./scripts/profile.sh baseline
+
+# 2a. CPU flamegraphs (all benches, 10 s sampling each)
+./scripts/profile.sh flame
+# ... or a single bench, 30 s
+./scripts/profile.sh flame read/full_scan 30
+
+# 2b. heap profile + 128 MiB budget verdict
+./scripts/profile.sh heap
+
+# 3. ranked bottleneck report (+ history ledger)
+./scripts/profile.sh report
+
+# 5. after a change: re-measure and gate-check against the baseline
+./scripts/profile.sh bench
+./scripts/profile.sh compare            # current vs base, same thresholds as CI
+```
+
+Raw equivalents, if you need to bypass the script:
+
+```bash
+# flamegraph for one bench
+cargo bench -p cqlite-core --features cli-helpers --bench read -- --profile-time 10 read/full_scan
+
+# heap profile (bench profile keeps symbols; release strips them)
+cargo run -p cqlite-core --example heap_profile --features cli-helpers,dhat-heap --profile bench
+
+# gate check (same script CI uses)
+python3 scripts/ci/check_perf_regression.py target/criterion current base cqlite-core/benches/perf-gate.json
+```
+
+---
+
+## 5. Practices (and pitfalls) for trustworthy profiles
+
+- **Profile the `bench` profile only.** It is optimized like release but keeps
+  debug info. `--release` builds strip symbols (`strip = true`) and produce
+  unreadable flamegraphs; `dev` builds profile the compiler's laziness, not
+  your code.
+- **Change one thing per iteration.** The report ranks benches by delta; two
+  simultaneous changes make the ledger unattributable.
+- **Trust deltas, not absolute numbers.** Same machine, same session, new vs
+  base — exactly the relative-comparison model the CI gate uses
+  (see performance.md §2).
+- **`write/ingest_wal_on` is advisory for a reason.** Its time is fsync; a
+  flamegraph will correctly show almost no cqlite frames. Optimize
+  `ingest_wal_off` for CPU and treat `_on` as a durability-cost probe.
+- **Watch allocation churn, not just peak.** `total_bytes_allocated` in
+  `heap-summary.json` catches clone-storms that GC-less Rust hides from peak
+  numbers but pays for in allocator time — they show up as `malloc`/`memcpy`
+  frames in the CPU flamegraph too.
+- **Keep the no-heuristics mandate (Issue #28).** An optimization that guesses
+  instead of reading authoritative metadata is a correctness regression, not a
+  performance win.

--- a/scripts/profile.sh
+++ b/scripts/profile.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# CQLite profiling orchestrator (docs/profiling.md).
+#
+# One entry point for the profile → fix → re-measure loop:
+#
+#   ./scripts/profile.sh baseline [name]      # measure + save criterion baseline (default: base)
+#   ./scripts/profile.sh bench [name]         # measure + save baseline (default: current)
+#   ./scripts/profile.sh flame [filter] [sec] # CPU flamegraphs via pprof (default: all, 10s each)
+#   ./scripts/profile.sh heap                 # dhat heap profile vs the <128 MiB budget
+#   ./scripts/profile.sh compare [new] [base] # gate check: new vs base (defaults: current, base)
+#   ./scripts/profile.sh report               # ranked bottleneck report + history ledger
+#
+# Typical loop:
+#   ./scripts/profile.sh baseline   # once, on the clean tree
+#   ./scripts/profile.sh flame      # find the bottleneck, make a change, then:
+#   ./scripts/profile.sh bench && ./scripts/profile.sh compare && ./scripts/profile.sh report
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+export CQLITE_DATASETS_ROOT="${CQLITE_DATASETS_ROOT:-$ROOT/test-data/datasets}"
+
+# cli-helpers gates the read benches; write-support (a default) gates the write
+# benches. Both fixture sets are deterministic (Epic #541).
+FEATURES="cli-helpers,write-support"
+# The bench targets that make up the profiling surface. m1_performance and
+# fixtures_smoke exist but are not part of the gated loop; profile them
+# explicitly with `cargo bench` if needed.
+BENCH_TARGETS=(--bench read --bench write --bench partition_lookup)
+
+require_fixtures() {
+    if ! compgen -G "$CQLITE_DATASETS_ROOT/sstables/test_basic/simple_table-*/nb-1-big-Data.db" > /dev/null; then
+        echo "error: SSTable fixtures missing under $CQLITE_DATASETS_ROOT" >&2
+        echo "fetch them first: bash test-data/scripts/fetch-datasets.sh" >&2
+        exit 1
+    fi
+}
+
+cmd="${1:-help}"
+case "$cmd" in
+    baseline)
+        require_fixtures
+        name="${2:-base}"
+        cargo bench --package cqlite-core --features "$FEATURES" "${BENCH_TARGETS[@]}" \
+            -- --save-baseline "$name"
+        echo
+        echo "baseline '$name' saved under target/criterion/"
+        ;;
+
+    bench)
+        require_fixtures
+        name="${2:-current}"
+        cargo bench --package cqlite-core --features "$FEATURES" "${BENCH_TARGETS[@]}" \
+            -- --save-baseline "$name"
+        echo
+        echo "baseline '$name' saved; next: ./scripts/profile.sh compare $name base"
+        ;;
+
+    flame)
+        require_fixtures
+        filter="${2:-}"
+        seconds="${3:-10}"
+        # --profile-time activates the pprof profiler attached in
+        # benches/profiling/mod.rs; criterion skips its normal analysis and
+        # samples each selected bench for $seconds instead.
+        cargo bench --package cqlite-core --features "$FEATURES" "${BENCH_TARGETS[@]}" \
+            -- --profile-time "$seconds" ${filter:+"$filter"}
+        echo
+        echo "flamegraphs written:"
+        find target/criterion -name flamegraph.svg -newermt '-15 minutes' | sort || true
+        ;;
+
+    heap)
+        require_fixtures
+        # bench profile, not release: release strips symbols, which destroys
+        # dhat's backtraces (Cargo.toml [profile.release] strip = true).
+        cargo run --package cqlite-core --example heap_profile \
+            --features cli-helpers,dhat-heap --profile bench
+        ;;
+
+    compare)
+        new="${2:-current}"
+        base="${3:-base}"
+        python3 scripts/ci/check_perf_regression.py \
+            target/criterion "$new" "$base" cqlite-core/benches/perf-gate.json
+        ;;
+
+    report)
+        python3 scripts/profile_report.py
+        ;;
+
+    *)
+        sed -n '2,16p' "$0" | sed 's/^# \{0,1\}//'
+        [ "$cmd" = "help" ] || exit 2
+        ;;
+esac

--- a/scripts/profile_report.py
+++ b/scripts/profile_report.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Aggregate profiling output into a ranked bottleneck report (docs/profiling.md).
+
+Collects everything the profiling tools left behind and turns it into the
+artifacts that drive the recursive-improvement loop:
+
+  inputs (all optional — the report uses whatever exists):
+    target/criterion/<group>/<bench>/{new,base}/estimates.json   criterion timings
+    target/criterion/<group>/<bench>/new/benchmark.json          throughput config
+    target/criterion/<group>/<bench>/profile/flamegraph.svg      pprof CPU profiles
+    target/profiling/heap-summary.json                           dhat heap summary
+
+  outputs:
+    target/profiling/report.json     machine-readable, for tooling/agents
+    target/profiling/report.md       human-readable ranked bottleneck table
+    target/profiling/history.jsonl   append-only ledger (one line per run, with
+                                     git revision) so improvement across
+                                     iterations is auditable
+
+Usage:
+    scripts/profile_report.py [--criterion-dir target/criterion]
+                              [--out-dir target/profiling]
+"""
+
+import argparse
+import datetime
+import json
+import os
+import subprocess
+import sys
+
+BUDGET_NOTE = "<128 MiB peak heap (CLAUDE.md memory target)"
+
+
+def _load_json(path):
+    if not os.path.isfile(path):
+        return None
+    with open(path) as fh:
+        return json.load(fh)
+
+
+def _git_rev():
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True, text=True, check=True,
+        )
+        return out.stdout.strip()
+    except Exception:
+        return "unknown"
+
+
+def _throughput_elements(benchmark_json):
+    """Criterion stores the group throughput in benchmark.json, e.g.
+    {"throughput": {"Elements": 999}} or {"Bytes": N} or null."""
+    if not benchmark_json:
+        return None, None
+    tp = benchmark_json.get("throughput")
+    if not isinstance(tp, dict):
+        return None, None
+    if "Elements" in tp:
+        return "element", tp["Elements"]
+    if "Bytes" in tp:
+        return "byte", tp["Bytes"]
+    return None, None
+
+
+def collect_benches(criterion_dir):
+    """Walk target/criterion for dirs holding new/estimates.json.
+
+    The bench id is the directory path relative to criterion_dir
+    (e.g. 'read/full_scan'). Criterion's aggregate 'report' dirs are skipped.
+    """
+    benches = []
+    for dirpath, dirnames, _ in os.walk(criterion_dir):
+        dirnames[:] = [d for d in dirnames if d != "report"]
+        new_est = _load_json(os.path.join(dirpath, "new", "estimates.json"))
+        if new_est is None:
+            continue
+        bench_id = os.path.relpath(dirpath, criterion_dir)
+        base_est = _load_json(os.path.join(dirpath, "base", "estimates.json"))
+        bench_json = _load_json(os.path.join(dirpath, "new", "benchmark.json"))
+        tp_unit, tp_count = _throughput_elements(bench_json)
+
+        median_ns = new_est["median"]["point_estimate"]
+        entry = {
+            "id": bench_id.replace(os.sep, "/"),
+            "median_ns": median_ns,
+            "mean_ns": new_est["mean"]["point_estimate"],
+            "std_dev_ns": new_est["std_dev"]["point_estimate"],
+        }
+        if tp_count:
+            entry["throughput_unit"] = tp_unit
+            entry["throughput_count"] = tp_count
+            entry[f"ns_per_{tp_unit}"] = median_ns / tp_count
+        if base_est is not None:
+            base_median = base_est["median"]["point_estimate"]
+            entry["base_median_ns"] = base_median
+            entry["delta_pct"] = (median_ns / base_median - 1.0) * 100.0
+        flame = os.path.join(dirpath, "profile", "flamegraph.svg")
+        if os.path.isfile(flame):
+            entry["flamegraph"] = flame
+        benches.append(entry)
+    # Regressions first (largest positive delta), then by absolute cost.
+    benches.sort(
+        key=lambda b: (-(b.get("delta_pct") or float("-inf")), -b["median_ns"])
+    )
+    return benches
+
+
+def fmt_ns(ns):
+    if ns >= 1e9:
+        return f"{ns / 1e9:.2f} s"
+    if ns >= 1e6:
+        return f"{ns / 1e6:.2f} ms"
+    if ns >= 1e3:
+        return f"{ns / 1e3:.2f} µs"
+    return f"{ns:.0f} ns"
+
+
+def render_markdown(report):
+    lines = [
+        "# CQLite profiling report",
+        "",
+        f"- generated: {report['generated_at']}",
+        f"- git revision: `{report['git_rev']}`",
+        "",
+        "## Benchmarks (regressions first, then by absolute cost)",
+        "",
+        "| bench | median | vs base | per-unit | flamegraph |",
+        "|-------|--------|---------|----------|------------|",
+    ]
+    for b in report["benches"]:
+        delta = (
+            f"{b['delta_pct']:+.1f}%" if "delta_pct" in b else "no base"
+        )
+        unit = b.get("throughput_unit")
+        per_unit = f"{fmt_ns(b['ns_per_' + unit])}/{unit}" if unit else "—"
+        flame = f"`{b['flamegraph']}`" if "flamegraph" in b else "—"
+        lines.append(
+            f"| {b['id']} | {fmt_ns(b['median_ns'])} | {delta} | {per_unit} | {flame} |"
+        )
+
+    heap = report.get("heap")
+    lines += ["", "## Heap (dhat)", ""]
+    if heap:
+        verdict = "PASS" if heap.get("within_budget") else "**FAIL**"
+        lines += [
+            f"- peak heap: {heap['peak_bytes'] / 2**20:.1f} MiB — {verdict} ({BUDGET_NOTE})",
+            f"- total allocations: {heap['total_allocations']:,} "
+            f"({heap['total_bytes_allocated'] / 2**20:.1f} MiB total churn)",
+            "- full profile: `target/profiling/dhat-heap.json` "
+            "(open in <https://nnethercote.github.io/dh_view/dh_view.html>)",
+        ]
+    else:
+        lines.append("- no heap data — run `./scripts/profile.sh heap` first")
+
+    lines += [
+        "",
+        "## Next iteration",
+        "",
+        "1. Open the flamegraph of the worst bench above; the widest frames are the bottleneck.",
+        "2. Make one targeted change; avoid speculative micro-optimizations.",
+        "3. Re-measure: `./scripts/profile.sh bench && ./scripts/profile.sh compare`.",
+        "4. Regenerate this report: `./scripts/profile.sh report` "
+        "(history accumulates in `target/profiling/history.jsonl`).",
+        "5. When the win is confirmed, re-save the baseline: `./scripts/profile.sh baseline`.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--criterion-dir", default="target/criterion")
+    ap.add_argument("--out-dir", default="target/profiling")
+    args = ap.parse_args()
+
+    benches = collect_benches(args.criterion_dir)
+    if not benches:
+        print(
+            f"no criterion data under {args.criterion_dir} — "
+            "run ./scripts/profile.sh bench first",
+            file=sys.stderr,
+        )
+        return 1
+
+    heap = _load_json(os.path.join(args.out_dir, "heap-summary.json"))
+
+    report = {
+        "generated_at": datetime.datetime.now(datetime.timezone.utc).isoformat(
+            timespec="seconds"
+        ),
+        "git_rev": _git_rev(),
+        "benches": benches,
+        "heap": heap,
+    }
+
+    os.makedirs(args.out_dir, exist_ok=True)
+    json_path = os.path.join(args.out_dir, "report.json")
+    md_path = os.path.join(args.out_dir, "report.md")
+    with open(json_path, "w") as fh:
+        json.dump(report, fh, indent=2)
+    with open(md_path, "w") as fh:
+        fh.write(render_markdown(report))
+
+    # Append-only ledger: one compact line per run so successive iterations of
+    # the improvement loop stay comparable even after baselines are overwritten.
+    history_line = {
+        "ts": report["generated_at"],
+        "rev": report["git_rev"],
+        "benches": {
+            b["id"]: round(b["median_ns"]) for b in benches
+        },
+        "peak_heap_bytes": heap.get("peak_bytes") if heap else None,
+    }
+    with open(os.path.join(args.out_dir, "history.jsonl"), "a") as fh:
+        fh.write(json.dumps(history_line) + "\n")
+
+    print(f"wrote {json_path}")
+    print(f"wrote {md_path}")
+    print(f"appended {os.path.join(args.out_dir, 'history.jsonl')}")
+    print()
+    print(render_markdown(report))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds the profiler layer on top of the existing Criterion benches and CI
perf gate (Epic #541), so bottlenecks can be located, not just detected:

- benches/profiling/mod.rs: attach pprof (signal-based sampling, works in
  containers/CI without perf) to all bench targets; activates only with
  --profile-time, so normal measurement runs and the CI gate are unchanged.
  Writes target/criterion/<group>/<bench>/profile/flamegraph.svg.
- examples/heap_profile.rs: dhat heap harness behind the new dhat-heap
  feature; runs the read fixture workloads and verdicts peak heap against
  the <128 MiB budget, emitting heap-summary.json + dhat-heap.json.
- [profile.bench] strip = "none": bench inherits strip = true from
  release, which discarded the symbols profilers need despite debug = true.
- scripts/profile.sh: one entry point for the loop (baseline / flame /
  heap / bench / compare / report); compare reuses the existing CI gate
  script and perf-gate.json thresholds.
- scripts/profile_report.py: aggregates criterion estimates, flamegraphs,
  and the heap summary into target/profiling/report.{json,md} ranked by
  regression-then-cost, and appends one line per run (git rev, medians,
  peak heap) to history.jsonl so successive optimization iterations stay
  auditable.
- docs/profiling.md: tool selection rationale, the recursive-improvement
  workflow, exit criteria, and pitfalls (bench-profile-only, one change
  per iteration, advisory fsync benches).

Validated end-to-end in-container: symbolized flamegraphs for
read/full_scan, dhat run (6.6 MiB peak, PASS), gate compare, and report
generation all working against the fetched SSTable fixtures.

https://claude.ai/code/session_01J8WNVgNNZh7bFrTfeQDoh2