### PR TITLE
docs: refresh doc hub and index — fix link rot, current status, profiling cross-links

### DIFF
--- a/docs/DOCUMENTATION_INDEX.md
+++ b/docs/DOCUMENTATION_INDEX.md
@@ -8,14 +8,25 @@ This document provides a comprehensive index of all documentation in the CQLite 
 docs/
 ├── DOCUMENTATION_INDEX.md          # This file - comprehensive documentation catalog
 ├── README.md                       # Main documentation entry point
-├── TESTING_PRD.md                  # Testing Product Requirements Document
-├── development/                    # Development guides and architecture
-├── testing/                        # Testing strategies and guides
+├── sstables-definitive-guide/      # PRIMARY REFERENCE: Cassandra 5.0 SSTable format
+├── architecture/                   # Design notes and architecture decisions
+├── development/                    # Development guides and specs
+├── read-path/                      # Read path walkthrough series
 ├── technical/                      # Technical specifications and formats
+├── testing/                        # Testing strategies and guides
 ├── user-guides/                    # End-user documentation
+├── m5/                             # M5 write-support implementation notes
 ├── reports/                        # Project reports and analysis
-└── archive/                        # Historical documents and reports
+├── plans/                          # Design plans and proposals
+├── ci/                             # CI policy documentation
+└── archive/                        # Historical documents (issue investigations)
 ```
+
+## 📖 Primary Reference
+
+| Document | Description | Status |
+|----------|-------------|--------|
+| [sstables-definitive-guide/README.md](sstables-definitive-guide/README.md) | The SSTable Definitive Guide — single source of truth for the Cassandra 5.0 format (Data.db, Index.db, BTI, encoding, known limitations) | Active |
 
 ## 🚀 Quick Start Documentation
 
@@ -25,66 +36,98 @@ docs/
 | [user-guides/quick-start.md](user-guides/quick-start.md) | Getting started guide | New users |
 | [user-guides/installation.md](user-guides/installation.md) | Installation instructions | Users |
 | [user-guides/cli.md](user-guides/cli.md) | CLI usage guide | CLI users |
+| [using-cqlite-core-as-a-dependency.md](using-cqlite-core-as-a-dependency.md) | Embedding the library in Rust projects | Rust developers |
 
 ## 🔧 Development Documentation
 
 ### Architecture & Design
-| Document | Description | Last Updated |
-|----------|-------------|--------------|
+| Document | Description | Status |
+|----------|-------------|--------|
 | [development/PRD.md](development/PRD.md) | Product Requirements Document | Active |
 | [development/DEVELOPMENT.md](development/DEVELOPMENT.md) | Development setup and workflows | Active |
-| [development/REPL_ARCHITECTURE_DESIGN.md](development/REPL_ARCHITECTURE_DESIGN.md) | REPL system architecture | Moved from root |
-| [development/REPL_CORE_ENGINE_IMPLEMENTATION.md](development/REPL_CORE_ENGINE_IMPLEMENTATION.md) | REPL implementation details | Moved from root |
-| [development/TECHNICAL_DEBT_REDUCTION_PLAN.md](development/TECHNICAL_DEBT_REDUCTION_PLAN.md) | Technical debt strategy | Moved from root |
-| [development/QUALITY_GATES_ENFORCEMENT.md](development/QUALITY_GATES_ENFORCEMENT.md) | Quality assurance processes | Moved from root |
 | [development/contributing.md](development/contributing.md) | Contribution guidelines | Active |
+| [development/rust_developer_guide.md](development/rust_developer_guide.md) | Project Rust conventions and patterns | Active |
+| [development/RELEASING.md](development/RELEASING.md) | Release process and checklist | Active |
+| [development/ISSUE_EXECUTION_PLAYBOOK.md](development/ISSUE_EXECUTION_PLAYBOOK.md) | Issue workflow playbook | Active |
+| [architecture/parser-overview.md](architecture/parser-overview.md) | How the SSTable parsers fit together | Active |
+| [architecture/SCHEMA_PROPAGATION_DECISION.md](architecture/SCHEMA_PROPAGATION_DECISION.md) | Schema propagation design decision | Active |
+| [architecture/sstabledump_parity_test_architecture.md](architecture/sstabledump_parity_test_architecture.md) | Parity test architecture | Active |
+
+### Milestone Specs
+| Document | Description | Status |
+|----------|-------------|--------|
+| [development/M2_CLI_SPEC.md](development/M2_CLI_SPEC.md) | M2 CLI specification | Complete |
+| [development/M4_spec.md](development/M4_spec.md) | M4 Python bindings specification | Complete |
+| [write-support.md](write-support.md) | M5 write support overview | Active |
+| [write-engine-api.md](write-engine-api.md) | Write engine API reference | Active |
+| [write-support-limitations.md](write-support-limitations.md) | Write support limitations | Active |
 
 ### Migration & Upgrades
 | Document | Description | Status |
-|----------|-------------|---------|
+|----------|-------------|--------|
 | [development/MIGRATION_GUIDE.md](development/MIGRATION_GUIDE.md) | Migration procedures | Active |
-| [development/RUST_2024_UPGRADE_REPORT.md](development/RUST_2024_UPGRADE_REPORT.md) | Rust 2024 edition upgrade | Moved from root |
+
+## 📚 Read Path Walkthrough
+
+| Document | Description |
+|----------|-------------|
+| [read-path/00-overview.md](read-path/00-overview.md) | Read path overview |
+| [read-path/01-query-engine.md](read-path/01-query-engine.md) | Query engine |
+| [read-path/02-storage-engine.md](read-path/02-storage-engine.md) | Storage engine |
+| [read-path/03-sstable-index-lookup.md](read-path/03-sstable-index-lookup.md) | Index lookup |
+| [read-path/04-sstable-sequential-scan.md](read-path/04-sstable-sequential-scan.md) | Sequential scan |
 
 ## 🧪 Testing Documentation
 
 ### Core Testing Strategy
 | Document | Description | Status |
-|----------|-------------|---------|
+|----------|-------------|--------|
 | [TESTING_PRD.md](TESTING_PRD.md) | Testing Product Requirements | Active |
 | [testing/comprehensive-testing-framework.md](testing/comprehensive-testing-framework.md) | Complete testing framework | Active |
-| [testing/TESTING_ARCHITECTURE_SPECIFICATION.md](testing/TESTING_ARCHITECTURE_SPECIFICATION.md) | Testing architecture design | Moved from root |
-| [testing/TESTING_IMPLEMENTATION_GUIDE.md](testing/TESTING_IMPLEMENTATION_GUIDE.md) | Implementation guidelines | Moved from root |
-| [testing/TESTING_ARCHITECTURE.md](testing/TESTING_ARCHITECTURE.md) | Testing system architecture | Moved from root |
+| [testing/TESTING_ARCHITECTURE_SPECIFICATION.md](testing/TESTING_ARCHITECTURE_SPECIFICATION.md) | Testing architecture design | Active |
+| [testing/TESTING_IMPLEMENTATION_GUIDE.md](testing/TESTING_IMPLEMENTATION_GUIDE.md) | Implementation guidelines | Active |
+| [testing/TESTING_ARCHITECTURE.md](testing/TESTING_ARCHITECTURE.md) | Testing system architecture | Active |
+| [test-infrastructure-architecture.md](test-infrastructure-architecture.md) | Test infrastructure architecture | Active |
+| [test_data_pipeline_guide.md](test_data_pipeline_guide.md) | Test data pipeline guide | Active |
 
 ### Testing Guides & Best Practices
 | Document | Description | Status |
-|----------|-------------|---------|
-| [testing/RUST_CLI_TESTING_BEST_PRACTICES.md](testing/RUST_CLI_TESTING_BEST_PRACTICES.md) | Rust CLI testing patterns | Moved from root |
-| [testing/REPL_TESTING_GUIDE.md](testing/REPL_TESTING_GUIDE.md) | REPL testing strategies | Moved from root |
-| [testing/TESTING_MIGRATION_PLAN.md](testing/TESTING_MIGRATION_PLAN.md) | Testing migration strategy | Moved from root |
-| [testing/TEST_DATA_CONSOLIDATION_PLAN.md](testing/TEST_DATA_CONSOLIDATION_PLAN.md) | Test data management | Moved from root |
-| [testing/TESTING_IMPLEMENTATION_ISSUES.md](testing/TESTING_IMPLEMENTATION_ISSUES.md) | Known testing issues | Moved from root |
+|----------|-------------|--------|
+| [testing/RUST_CLI_TESTING_BEST_PRACTICES.md](testing/RUST_CLI_TESTING_BEST_PRACTICES.md) | Rust CLI testing patterns | Active |
+| [testing/REPL_TESTING_GUIDE.md](testing/REPL_TESTING_GUIDE.md) | REPL testing strategies | Active |
+| [testing/E2E_WRITE_TESTING_GUIDE.md](testing/E2E_WRITE_TESTING_GUIDE.md) | End-to-end write testing | Active |
+| [testing/MOCK_USAGE_POLICY.md](testing/MOCK_USAGE_POLICY.md) | Mock usage policy (real data preferred) | Active |
 
 ## 📊 Technical Documentation
 
 ### Format Specifications
 | Document | Description | Status |
-|----------|-------------|---------|
-| [technical/cassandra-5-format-spec.md](cassandra-5-format-spec.md) | Cassandra 5.0 format specification | Active |
+|----------|-------------|--------|
 | [technical/BTI_FORMAT_SPECIFICATION.md](technical/BTI_FORMAT_SPECIFICATION.md) | BTI format details | Active |
-| [technical/CASSANDRA_COMPLEX_TYPES_FORMAT_SPEC.md](technical/CASSANDRA_COMPLEX_TYPES_FORMAT_SPEC.md) | Complex types format | Active |
+| [technical/BTI_COMPLETE_ARCHITECTURE.md](technical/BTI_COMPLETE_ARCHITECTURE.md) | BTI architecture | Active |
 | [technical/UDT_FORMAT_SPEC.md](technical/UDT_FORMAT_SPEC.md) | User Defined Types format | Active |
+| [technical/CEP25_BYTE_COMPARABLE_ENCODER.md](technical/CEP25_BYTE_COMPARABLE_ENCODER.md) | CEP-25 byte-comparable encoding | Active |
+| [comparator-type-api.md](comparator-type-api.md) | Comparator type API | Active |
 
 ### API & Architecture
 | Document | Description | Status |
-|----------|-------------|---------|
+|----------|-------------|--------|
 | [technical/api-specification.md](technical/api-specification.md) | API specification | Active |
 | [technical/architecture.md](technical/architecture.md) | System architecture | Active |
-| [technical/cassandra-compatibility.md](technical/cassandra-compatibility.md) | Compatibility matrix | Active |
+| [technical/CASSANDRA_5_0_COMPATIBILITY_MATRIX.md](technical/CASSANDRA_5_0_COMPATIBILITY_MATRIX.md) | Compatibility matrix | Active |
+| [technical/CASSANDRA_COMPATIBILITY_GUIDE.md](technical/CASSANDRA_COMPATIBILITY_GUIDE.md) | Compatibility guide | Active |
+| [technical/CQL_PARSER_IMPLEMENTATION.md](technical/CQL_PARSER_IMPLEMENTATION.md) | CQL parser implementation | Active |
+| [technical/ERROR_HANDLING_RECOVERY.md](technical/ERROR_HANDLING_RECOVERY.md) | Error handling and recovery | Active |
+
+### Performance & Profiling
+| Document | Description | Status |
+|----------|-------------|--------|
+| [performance.md](performance.md) | Benchmark methodology, reproducibility, CI perf gate | Active |
+| [profiling.md](profiling.md) | pprof flamegraphs, dhat heap profiling, `scripts/profile.sh` loop | Active |
 
 ### Complex Types Documentation
 | Document | Description | Status |
-|----------|-------------|---------|
+|----------|-------------|--------|
 | [complex_types_documentation_index.md](complex_types_documentation_index.md) | Complex types overview | Active |
 | [complex_types_api_reference.md](complex_types_api_reference.md) | API reference | Active |
 | [complex_types_examples.md](complex_types_examples.md) | Usage examples | Active |
@@ -104,49 +147,38 @@ docs/
 
 ## 📈 Reports & Analysis
 
-### Active Reports
-| Report Category | Location | Description |
-|----------------|----------|-------------|
-| Milestone Reports | [reports/milestone-reports/](reports/milestone-reports/) | Project milestone tracking |
-| Validation Reports | [reports/validation-reports/](reports/validation-reports/) | Testing and validation results |
-| Archived Reports | [reports/archived/](reports/archived/) | Historical project reports |
-
-### Key Reports
-- [reports/milestone-reports/EXECUTIVE_SUMMARY.md](reports/milestone-reports/EXECUTIVE_SUMMARY.md) - Project executive summary
-- [reports/validation-reports/INTEGRATION_VALIDATION_FINAL_REPORT.md](reports/validation-reports/INTEGRATION_VALIDATION_FINAL_REPORT.md) - Final integration validation
-- [reports/milestone-reports/MILESTONE_TRACKER.md](reports/milestone-reports/MILESTONE_TRACKER.md) - Current milestone status
+| Document | Description |
+|----------|-------------|
+| [reports/README.md](reports/README.md) | Reports index |
+| [reports/milestone-reports/EXECUTIVE_SUMMARY.md](reports/milestone-reports/EXECUTIVE_SUMMARY.md) | Project executive summary |
+| [reports/milestone-reports/M2_COMPLETION_REPORT.md](reports/milestone-reports/M2_COMPLETION_REPORT.md) | M2 completion report |
+| [reports/bti-read-support-scoping.md](reports/bti-read-support-scoping.md) | BTI read support scoping |
+| [reports/fixture-version-matrix.md](reports/fixture-version-matrix.md) | Fixture version matrix |
+| [report/M5_FINAL_AUDIT_REPORT.md](report/M5_FINAL_AUDIT_REPORT.md) | M5 final audit |
+| [coverage-analysis-jan-2026.md](coverage-analysis-jan-2026.md) | Coverage analysis (Jan 2026) |
 
 ## 🗂️ Archived Documentation
 
 The `archive/` directory contains historical documents that are no longer actively maintained but kept for reference:
 
-### Coordination Archives
-- `archive/coordination/` - Team coordination and planning documents from development phases
-- `archive/issues/` - Completed issue tracking and implementation summaries
-- `archive/reports/` - Temporary analysis and status reports
-
-### What's Archived
-- Project coordination status reports
-- Team assignment strategies
-- Development coordination plans
-- Issue completion summaries
-- Temporary analysis reports
-- Compilation and performance analysis
+- [archive/issues/INDEX.md](archive/issues/INDEX.md) - Historical issue investigations and format-debugging deep dives
 
 ## 🔍 Finding Documentation
 
 ### By Purpose
 - **Getting Started**: Start with [user-guides/quick-start.md](user-guides/quick-start.md)
+- **SSTable Format**: Read [the definitive guide](sstables-definitive-guide/README.md)
 - **Development Setup**: See [development/DEVELOPMENT.md](development/DEVELOPMENT.md)
 - **Testing**: Begin with [TESTING_PRD.md](TESTING_PRD.md)
+- **Performance**: See [performance.md](performance.md) and [profiling.md](profiling.md)
 - **API Reference**: Check [technical/api-specification.md](technical/api-specification.md)
 - **Troubleshooting**: Visit [user-guides/troubleshooting.md](user-guides/troubleshooting.md)
 
 ### By Audience
 - **End Users**: Browse `user-guides/`
-- **Developers**: Focus on `development/` and `technical/`
-- **QA Engineers**: Check `testing/` and `reports/validation-reports/`
-- **Project Managers**: Review `reports/milestone-reports/`
+- **Developers**: Focus on `development/`, `technical/`, and `sstables-definitive-guide/`
+- **QA Engineers**: Check `testing/` and `test-data/validation-matrix.md` (repo root)
+- **Project Managers**: Review `reports/`
 
 ## 📋 Documentation Standards
 
@@ -160,12 +192,11 @@ All documentation in this project follows these standards:
 
 ## 🔄 Maintenance
 
-This documentation index is maintained by the documentation-librarian agent and updated whenever:
+This documentation index is updated whenever:
 - New documentation is added
 - Documents are moved or restructured
 - Archive policies are applied
 - Major project milestones are reached
 
-**Last Updated**: July 30, 2025 (Documentation Cleanup Phase)
-**Maintained By**: Documentation Librarian Agent
+**Last Updated**: June 10, 2026 (link audit + profiling docs added; removed entries for deleted reports and renamed specs)
 **Status**: Active and Comprehensive

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,12 +8,25 @@ Welcome to the CQLite documentation hub. This directory contains all technical d
 
 ---
 
+## 📖 Primary Reference
+
+- **[The SSTable Definitive Guide](sstables-definitive-guide/README.md)** - Single source of truth for the Cassandra 5.0 SSTable format: Data.db row layout, Index.db/Summary.db lookups, BTI trie indexes, encoding cheat sheets, and known limitations.
+
+---
+
 ## 🗂️ Documentation Structure
 
 ### 👥 User Documentation
 - **[Installation Guide](user-guides/installation.md)** - Complete setup instructions for all platforms
-- **[Quick Start Guide](user-guides/quick-start.md)** - Get started with CQLite in minutes  
+- **[Quick Start Guide](user-guides/quick-start.md)** - Get started with CQLite in minutes
+- **[CLI Guide](user-guides/cli.md)** - Command-line interface usage
 - **[Troubleshooting Guide](user-guides/troubleshooting.md)** - Comprehensive problem resolution
+- **[Using cqlite-core as a Dependency](using-cqlite-core-as-a-dependency.md)** - Embedding the library in your own Rust project
+
+### ✍️ Write Support (M5)
+- **[Write Support Overview](write-support.md)** - Mutations, memtable, WAL, and flush
+- **[Write Engine API](write-engine-api.md)** - Programmatic write API reference
+- **[Write Support Limitations](write-support-limitations.md)** - What write support does not cover yet
 
 ### 🎯 Complex Types Documentation
 - **[Complex Types API Reference](complex_types_api_reference.md)** - Complete API for complex types
@@ -21,52 +34,29 @@ Welcome to the CQLite documentation hub. This directory contains all technical d
 - **[Complex Types Examples](complex_types_examples.md)** - Implementation examples and patterns
 - **[Complex Types Performance Guide](complex_types_performance_guide.md)** - Performance optimization strategies
 - **[Complex Types Troubleshooting](complex_types_troubleshooting.md)** - Common issues and solutions
-- **[Cassandra 5 Format Specification](cassandra-5-format-spec.md)** - Cassandra 5.0 format compatibility
 
 ### 🔧 Technical Documentation
 - **[Architecture Overview](technical/architecture.md)** - System design and architecture
 - **[API Specification](technical/api-specification.md)** - Complete API reference
-- **[Cassandra Compatibility](technical/cassandra-compatibility.md)** - Format compatibility matrix
-- **[Binary Format Analysis](technical/BINARY_FORMAT_ANALYSIS.md)** - SSTable binary format specifications
+- **[Cassandra 5.0 Compatibility Matrix](technical/CASSANDRA_5_0_COMPATIBILITY_MATRIX.md)** - Format compatibility matrix
+- **[Cassandra Compatibility Guide](technical/CASSANDRA_COMPATIBILITY_GUIDE.md)** - Compatibility details and caveats
 - **[BTI Format Specification](technical/BTI_FORMAT_SPECIFICATION.md)** - BTI index format details
-- **[Cassandra Complex Types Format](technical/CASSANDRA_COMPLEX_TYPES_FORMAT_SPEC.md)** - Complex type format specifications
-- **[CQLSH Format Specification](technical/CQLSH_FORMAT_SPECIFICATION.md)** - CQLSH compatibility formats
 - **[UDT Format Specification](technical/UDT_FORMAT_SPEC.md)** - User-defined type format details
+- **[Parser Overview](architecture/parser-overview.md)** - How the SSTable parsers fit together
+
+### ⚡ Performance & Profiling
+- **[Performance Methodology](performance.md)** - Benchmark reproducibility and the CI perf gate
+- **[Profiling Guide](profiling.md)** - Flamegraphs, heap profiling, and the `scripts/profile.sh` improvement loop
 
 ### 💻 Development Documentation
 - **[Contributing Guide](development/contributing.md)** - How to contribute to CQLite
-- **[Testing Guide](development/testing-guide.md)** - Testing framework and procedures
-- **[Development Roadmap](development/roadmap.md)** - Project milestones and future plans
+- **[Development Guide](development/DEVELOPMENT.md)** - Local development workflow
+- **[Rust Developer Guide](development/rust_developer_guide.md)** - Project Rust conventions and patterns
+- **[Releasing](development/RELEASING.md)** - Release process and checklist
 
 ### 📊 Project Reports
-
-#### Milestone Reports
-- **[M2 Completion Report](reports/milestone-reports/M2_COMPLETION_REPORT.md)** - Phase 2 completion status
-- **[M3 Cassandra SSTable Acquisition](reports/milestone-reports/M3_CASSANDRA_SSTABLE_ACQUISITION.md)** - SSTable acquisition milestone
-- **[M3 Completion Update](reports/milestone-reports/M3_COMPLETION_UPDATE.md)** - Phase 3 completion status
-- **[M3 Complex Types Coordination](reports/milestone-reports/M3_COMPLEX_TYPES_COORDINATION.md)** - Complex types implementation
-- **[M3 Complex Type Validation Report](reports/milestone-reports/M3_COMPLEX_TYPE_VALIDATION_REPORT.md)** - Validation results
-- **[M3 Coordination Plan](reports/milestone-reports/M3_COORDINATION_PLAN.md)** - Project coordination strategy
-- **[M3 Performance Optimization Summary](reports/milestone-reports/M3_PERFORMANCE_OPTIMIZATION_SUMMARY.md)** - Performance improvements
-- **[M3 Validation Report](reports/milestone-reports/M3_VALIDATION_REPORT.md)** - Overall validation results
-
-#### Validation Reports
-- **[Integration Test Results](reports/validation-reports/INTEGRATION_TEST_RESULTS.md)** - Integration testing outcomes
-- **[Integration Test Summary](reports/validation-reports/INTEGRATION_TEST_SUMMARY.md)** - Test summary overview
-- **[Integration Validation Final Report](reports/validation-reports/INTEGRATION_VALIDATION_FINAL_REPORT.md)** - Final validation results
-- **[Performance Analysis Report](reports/validation-reports/PERFORMANCE_ANALYSIS_REPORT.md)** - Performance testing analysis
-- **[QA Validation Report](reports/validation-reports/QA_VALIDATION_REPORT.md)** - Quality assurance results
-- **[Real Data Validation Report](reports/validation-reports/REAL_DATA_VALIDATION_REPORT.md)** - Real-world data testing
-- **[Real SSTable Compatibility Report](reports/validation-reports/REAL_SSTABLE_COMPATIBILITY_REPORT.md)** - SSTable compatibility testing
-
-#### Archived Reports
-- **[Achievement Summary](reports/archived/ACHIEVEMENT_SUMMARY.md)** - Project achievements overview
-- **[Breakthrough Success](reports/archived/BREAKTHROUGH_SUCCESS.md)** - Major breakthrough documentation
-- **[Integration Complete](reports/archived/INTEGRATION_COMPLETE.md)** - Integration completion status
-- **[Pagination Features](reports/archived/PAGINATION_FEATURES.md)** - Pagination implementation details
-- **[Parser Abstraction Test Report](reports/archived/PARSER_ABSTRACTION_TEST_REPORT.md)** - Parser testing results
-- **[Real Data Demo](reports/archived/REAL_DATA_DEMO.md)** - Real data demonstration
-- **[Testing Framework Complete](reports/archived/TESTING_FRAMEWORK_COMPLETE.md)** - Testing framework status
+- **[Reports Index](reports/README.md)** - Project reports organized by category
+- **[Historical Issue Investigations](archive/issues/INDEX.md)** - Archived deep-dives from past format debugging
 
 ---
 
@@ -80,32 +70,33 @@ Welcome to the CQLite documentation hub. This directory contains all technical d
 ### For Developers
 1. Read [Architecture Overview](technical/architecture.md)
 2. Check [Contributing Guide](development/contributing.md)
-3. Review [Testing Guide](development/testing-guide.md)
+3. Study [The SSTable Definitive Guide](sstables-definitive-guide/README.md) before touching format code
 
-### For Operations
-1. Study [Performance Analysis](technical/performance-analysis.md)
-2. Keep [Troubleshooting Guide](user-guides/troubleshooting.md) handy
-3. Monitor [Compatibility Matrix](technical/cassandra-compatibility.md)
+### For Performance Work
+1. Read [Performance Methodology](performance.md) for what the CI gate enforces
+2. Use the [Profiling Guide](profiling.md) to find and fix bottlenecks
+3. Keep the [Troubleshooting Guide](user-guides/troubleshooting.md) handy
 
 ---
 
 ## 📈 Project Status
 
-- **Current Version**: 0.3.0 (M4 Complete - Production Ready)
+- **Current Version**: 0.10.0
 - **Cassandra Compatibility**: 5.0+ with BTI format support
-- **Milestones Complete**: M1 (Core), M2 (CLI), M3 (Output Writers), M4 (Language Bindings)
-- **Next**: M5 (Write Support)
+- **Milestones Complete**: M1 (Core Reading), M2 (CLI), M3 (Output Writers), M4 (Python Bindings), M5.1 (Write Support); Node.js bindings shipped
+- **In Progress**: M5.2 (Compaction & Export)
+- **Next**: M6 (WebAssembly Bindings)
+- **Test Pass Rate**: 100% (33/33 tables vs sstabledump, see `test-data/validation-matrix.md`)
 
 ---
 
 ## 🔄 Document Maintenance
 
 ### Last Updated
+- Documentation hub: 2026-06-10
+- Performance & profiling docs: 2026-06-10
 - Architecture docs: 2026-01-27
 - User guides: 2026-01-27
-- Technical specs: 2026-01-27
-- Project reports: 2026-01-27
-- Documentation organization: 2026-01-27
 
 ### Contributing to Documentation
 - Follow the [Documentation Standards](development/contributing.md#documentation-standards)

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -4,6 +4,11 @@ This page explains what the in-repo performance gate enforces, why CI absolute
 numbers are not authoritative, how to reproduce benchmark results locally, and
 why ~282 ops/sec is the expected single-writer throughput when durability is on.
 
+For the operational side — *finding and fixing* the bottlenecks the gate
+measures (pprof flamegraphs, dhat heap profiling against the 128 MiB budget,
+and the `scripts/profile.sh` improvement loop) — see
+[profiling.md](profiling.md).
+
 ---
 
 ## 1. What the gate enforces vs. what it tracks

--- a/docs/plans/2026-06-10-delta-scan-envelope-design.md
+++ b/docs/plans/2026-06-10-delta-scan-envelope-design.md
@@ -1,0 +1,234 @@
+# Design: Delta-Scan Envelope for CDC-Style Parquet Projections
+
+**Status:** Validated design (brainstormed 2026-06-10, pending review)
+**Audience:** CQLite maintainers
+**Related:**
+- `docs/architecture/cassandra-sidecar-parquet-projections.md` (decisions this design implements)
+- Epic #673 (Arrow type fidelity), Epic #682 (Parquet writer in core), Epic #689 (WRITETIME/TTL in SELECT)
+- Issue #493 (set element tombstones), Issue #667 (tombstone readback coverage)
+
+## Purpose
+
+A flushed SSTable is a delta, not a snapshot. Projecting it to Parquet correctly
+requires carrying cell write-timestamps and representing every delete shape
+Cassandra produces — otherwise a downstream union of per-flush files resurrects
+deleted data and merges stale cells. This document defines the **CQLite-native
+envelope** (per the recorded decision: not Debezium-compatible) and the core API
+that produces it.
+
+**Contract in one sentence:** one SSTable generation in, faithful change events
+out; reconciliation (LWW merge, tombstone application, TTL filtering) is
+deliberately the downstream consumer's job.
+
+## Decisions
+
+| Question | Decision |
+|---|---|
+| Record grain | Row-grain records; each non-key column is a `Struct{value, writetime, expires_at}` |
+| Per-cell vs per-row writetime | Per-cell, via the struct; record-level `__ts` carries row liveness / deletion time |
+| Absent vs null | Null struct = "cell not in this delta"; `{value: null, writetime: t}` = cell tombstone |
+| Non-cell deletes | Single stream with `__op` discriminator; typed range-bound structs |
+| TTL | `expires_at` (µs epoch) on the cell struct; never resolved at scan time (idempotent output) |
+| Static columns | Dedicated `static_upsert` record per partition (clustering keys null) |
+| API surface | New feature-gated core scan API on the reader layer; not a SELECT extension; not CLI-only |
+
+## Envelope schema
+
+Each table's delta schema is derived from its CQL schema plus fixed envelope
+columns. All Arrow types follow the epic #673 fidelity mapping.
+
+### Columns
+
+1. **Key columns** — partition key and clustering columns as plain Arrow types.
+   Populated per record type:
+
+   | `__op` | partition key | clustering |
+   |---|---|---|
+   | `upsert` | yes | yes |
+   | `static_upsert` | yes | null |
+   | `row_delete` | yes | yes |
+   | `range_delete` | yes | null (bounds carry clustering) |
+   | `partition_delete` | yes | null |
+
+2. **Cell columns** — every non-key column becomes:
+
+   ```
+   Struct {
+     value:      <Arrow type per #673>,  // null = cell tombstone
+     writetime:  i64,                    // µs since epoch, required
+     expires_at: i64 | null,             // µs since epoch; null = no TTL
+   }
+   ```
+
+   The struct itself is nullable: a null struct means the cell is not present
+   in this generation (e.g. a partial UPDATE touched other columns).
+
+3. **`__op: Utf8`** (dictionary-encoded) — `upsert | static_upsert |
+   row_delete | range_delete | partition_delete`.
+
+4. **`__ts: i64 | null`** — for upserts, the row's primary-key liveness
+   timestamp (null when the row was created by UPDATE and has no liveness
+   info); for all delete ops, the deletion timestamp (`markedForDeleteAt`).
+
+5. **`__range_start` / `__range_end`** —
+   `Struct{<clustering columns>, inclusive: bool}`, null except on
+   `range_delete`. Bounds are typed in the table's own clustering types and
+   may be prefixes: trailing clustering components are null.
+
+### Examples
+
+Table `t (pk int, ck text, val text, st text STATIC, PRIMARY KEY (pk, ck))`:
+
+```
+-- UPDATE t SET val='x' WHERE pk=1 AND ck='a'   (partial update)
+{ pk:1, ck:'a', __op:'upsert', __ts:null,
+  val:{value:'x', writetime:t1, expires_at:null}, st:null }
+
+-- DELETE val FROM t WHERE pk=1 AND ck='a'      (cell tombstone)
+{ pk:1, ck:'a', __op:'upsert', __ts:null,
+  val:{value:null, writetime:t2, expires_at:null}, st:null }
+
+-- UPDATE t SET st='S' WHERE pk=1               (static write)
+{ pk:1, ck:null, __op:'static_upsert',
+  st:{value:'S', writetime:t3, expires_at:null}, val:null }
+
+-- DELETE FROM t WHERE pk=1 AND ck='a'          (row tombstone)
+{ pk:1, ck:'a', __op:'row_delete', __ts:t4, val:null, st:null }
+
+-- DELETE FROM t WHERE pk=1 AND ck >= 'a' AND ck < 'm'
+{ pk:1, __op:'range_delete', __ts:t5,
+  __range_start:{ck:'a', inclusive:true},
+  __range_end:{ck:'m', inclusive:false} }
+
+-- DELETE FROM t WHERE pk=1                     (partition tombstone)
+{ pk:1, __op:'partition_delete', __ts:t6 }
+```
+
+### Downstream merge keys
+
+Consumers reconcile with: `upsert`/`row_delete` on `(pk, ck)`;
+`static_upsert` on `pk`; `partition_delete` and `range_delete` applied as
+predicates over `(pk)` / `(pk, ck range)` with `__ts` deciding
+last-write-wins per cell.
+
+### Name collisions
+
+A user column named `__op` (legal in CQL) collides with the envelope. The
+writer **errors at schema-derivation time** — no silent renaming — with an
+`--envelope-prefix` option to choose a different reserved prefix.
+
+### Non-frozen collections (v1 limitation)
+
+Multi-cell collections carry per-element writetimes and element tombstones
+(issue #493 territory). V1 emits the collection cell as:
+
+- `value`: the elements present in this generation (for an append
+  `s = s + {...}`, that is only the appended elements — correct delta
+  semantics)
+- `writetime`: max element writetime
+- `replaced: bool` added to the struct for collection columns only — `true`
+  when the generation carries a collection tombstone (i.e. `s = {...}`
+  overwrite), so consumers know whether to merge or replace
+
+Element-level removals are detected and counted (scan summary warning) but not
+represented in v1; full element fidelity is a tracked follow-up.
+
+## API and architecture
+
+### Core API
+
+Feature `delta-scan`, off by default. Lives on the SSTable reader layer
+(`row_cell_state_machine`, the V5 parsers, `TombstoneInfo`/`TombstoneType`
+from `types.rs`) — **not** the query engine, whose contract (merge
+generations, suppress tombstones) is the opposite of this one.
+
+```rust
+pub enum DeltaRecord {
+    Upsert      { keys: RowKeys, liveness: Option<CellMeta>, cells: Vec<(ColumnId, CellDelta)> },
+    StaticUpsert{ partition_key: RowKeys, cells: Vec<(ColumnId, CellDelta)> },
+    RowDelete   { keys: RowKeys, deleted_at: i64 },
+    RangeDelete { partition_key: RowKeys, start: RangeBound, end: RangeBound, deleted_at: i64 },
+    PartitionDelete { partition_key: RowKeys, deleted_at: i64 },
+}
+
+pub struct CellDelta {
+    pub value: Option<Value>,      // None = cell tombstone
+    pub writetime: i64,
+    pub expires_at: Option<i64>,
+    pub replaced: bool,            // collections only; see v1 limitation
+}
+
+pub fn scan_delta(sstable_dir: &Path, table: &TableSchema)
+    -> impl Stream<Item = Result<DeltaRecord>>
+```
+
+Records stream in SSTable order (partition, then clustering). No
+cross-SSTable merge, no GC-grace filtering.
+
+### Envelope writer
+
+`DeltaParquetWriter` in core behind `delta-scan` + `parquet` (composes with
+the epic #682 lifted writer). Derives the schema above from `TableSchema`,
+consumes the record stream, writes one file per generation.
+
+Parquet footer key-value metadata (enough for an external committer to dedupe
+and order generations):
+
+| Key | Value |
+|---|---|
+| `cqlite.delta.version` | `1` |
+| `cqlite.delta.source` | SSTable identity/generation |
+| `cqlite.delta.schema_hash` | hash of the CQL schema used |
+| `cqlite.version` | crate version |
+
+### CLI
+
+```bash
+cqlite delta-export <sstable-dir> --schema <file.cql> --out parquet -o <file>
+```
+
+Bindings exposure is deferred until there is a consumer.
+
+## Error handling
+
+1. **No silent skips.** Any structure the scanner cannot faithfully represent
+   is a hard error naming the partition/position — never a dropped record
+   (no-heuristics mandate, issue #28).
+2. **Fail before writing.** Collision and unsupported-feature errors (e.g.
+   counter tables) are raised at schema-derivation time, before any output
+   bytes exist.
+3. **Loud limitations.** Collection element tombstones are detected and
+   surfaced as a warning counter in the scan summary, not merged away
+   silently.
+
+## Testing
+
+1. **Unit** — synthetic cells/tombstones through the record builder: every
+   `__op` shape, null-vs-absent struct semantics, TTL, liveness-less upserts,
+   prefix range bounds, collision errors.
+2. **Fixture parity** — for each corpus table, `scan_delta` output must agree
+   with `sstabledump` JSONL (which natively shows tombstones, `tstamp`, and
+   expiration — effectively a reference delta scan). Requires fixtures with
+   deletes; coordinate with #667 (tombstone readback coverage) rather than
+   duplicating fixture work.
+3. **Reconciliation round-trip** (the proof of sufficiency) — write N flush
+   generations from a real Cassandra container, delta-export each, run the
+   documented consumer merge in DuckDB/Spark SQL, and assert the result equals
+   CQLite's own merged `SELECT *` over all generations.
+
+## Sequencing
+
+- **Depends on:** epic #673 (type fidelity — the cell struct `value` field
+  reuses its mapping) and epic #682 (Parquet writer in core).
+- **Independent of:** epic #689 (WRITETIME/TTL in SELECT) — different layer,
+  shared fixture interests only.
+- **Next step:** after this design is reviewed, scaffold the implementation
+  epic (scanner, schema derivation, writer, CLI, three test tiers).
+
+## Explicitly out of scope
+
+- Cross-SSTable merge or snapshot semantics (use the existing read path)
+- GC-grace handling, compaction awareness, commitlog/CDC reading
+- Iceberg/Delta commit logic (external committer's job, per recorded decision)
+- Collection element tombstone fidelity (v1 limitation above)
+- Counter tables (rejected at schema derivation)


### PR DESCRIPTION
Follow-up to the profiling infrastructure work (#695): while verifying it was properly documented, the doc hub and index turned out to be badly rotted.

## Changes

- **docs/performance.md**: add a forward link to its operational companion `profiling.md` (the profiling guide linked back, but nothing pointed forward).
- **docs/README.md**:
  - Project status updated to 0.10.0 with M5.2 in progress (previously said 0.3.0, M4 complete).
  - SSTable Definitive Guide surfaced as the primary reference (CLAUDE.md designates it the single source of truth; the hub never mentioned it).
  - New sections: Write Support (M5), Performance & Profiling, current development docs.
  - Removed 29 dead links (deleted `reports/` subtrees, renamed technical specs).
- **docs/DOCUMENTATION_INDEX.md**:
  - Removed 15 dead links; indexed previously missing docs (definitive guide, `read-path/` series, M5 write docs, `architecture/` notes, current testing/development guides).
  - Structure-overview tree now matches the actual `docs/` layout.

## Validation

Every relative link in both rewritten files verified to resolve against the filesystem.

Docs-only change — no code touched.