### PR TITLE
fix: correct Summary.db offset table encoding and first/last key tracking (#666)

### DIFF
--- a/cqlite-core/src/storage/sstable/writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/mod.rs
@@ -416,6 +416,12 @@ impl SSTableWriter {
             filter.add_key(&key);
         }
 
+        // Track every partition for first_key / last_key / total_partition_count.
+        // These fields must cover the full SSTable, not just sampled entries.
+        // (Issue #666: first/last keys in Summary.db must span the whole SSTable
+        //  so Cassandra's range queries cover all partitions.)
+        self.summary_writer.note_partition(&key);
+
         // Sample for Summary.db (every Nth entry, where N = summary_sample_interval)
         // CRITICAL: Use the actual index_offset from entry_info, not an estimate
         if self.summary_sample_counter % self.summary_sample_interval == 0 {

--- a/cqlite-core/src/storage/sstable/writer/summary_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/summary_writer.rs
@@ -164,33 +164,6 @@ impl SummaryWriter {
         }
     }
 
-    /// Add a sampled entry to the summary
-    ///
-    /// The caller is responsible for sampling at the correct interval. This method
-    /// does NOT enforce sampling - it adds every entry provided.
-    ///
-    /// # Arguments
-    ///
-    /// * `key` - Decorated partition key (token + raw bytes)
-    /// * `index_offset` - Byte offset in Index.db where this partition's entry starts
-    ///
-    /// # Important
-    ///
-    /// Entries MUST be added in token order (same as Index.db order).
-    /// First and last keys are tracked automatically.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use cqlite_core::storage::sstable::writer::SummaryWriter;
-    /// use cqlite_core::storage::write_engine::mutation::DecoratedKey;
-    ///
-    /// let mut writer = SummaryWriter::new(128);
-    ///
-    /// let key = DecoratedKey::new(12345, vec![0x00, 0x00, 0x00, 0x2A]);
-    /// writer.add_entry(&key, 0).unwrap();
-    /// assert_eq!(writer.entry_count(), 1);
-    /// ```
     /// Record that a partition was seen (called for EVERY partition, not just sampled ones).
     ///
     /// This method tracks:

--- a/cqlite-core/src/storage/sstable/writer/summary_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/summary_writer.rs
@@ -191,28 +191,85 @@ impl SummaryWriter {
     /// writer.add_entry(&key, 0).unwrap();
     /// assert_eq!(writer.entry_count(), 1);
     /// ```
-    pub fn add_entry(&mut self, key: &DecoratedKey, index_offset: u64) -> Result<()> {
-        let key_bytes = key.key.clone();
+    /// Record that a partition was seen (called for EVERY partition, not just sampled ones).
+    ///
+    /// This method tracks:
+    /// - `first_key` and `last_key` for the SSTable boundary metadata at the end of
+    ///   Summary.db.  These must cover the **entire** SSTable, not just sampled
+    ///   partitions.  Cassandra uses them for SSTable range queries: if they only
+    ///   cover the first sampled partition, all other partitions become invisible to
+    ///   range scans.  (Issue #666 root-cause investigation.)
+    /// - `total_partition_count` for `size_at_full_sampling` computation.
+    ///
+    /// Call this method for every partition written to the SSTable, before calling
+    /// `add_entry` (which is only called at sampling boundaries).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cqlite_core::storage::sstable::writer::SummaryWriter;
+    /// use cqlite_core::storage::write_engine::mutation::DecoratedKey;
+    ///
+    /// let mut writer = SummaryWriter::new(128);
+    ///
+    /// // Note every partition (called for all partitions)
+    /// let k = DecoratedKey::new(1, vec![0x01]);
+    /// writer.note_partition(&k);
+    ///
+    /// // Add sampled entry (called every min_index_interval partitions)
+    /// writer.add_entry(&k, 0).unwrap();
+    /// ```
+    pub fn note_partition(&mut self, key: &DecoratedKey) {
+        let key_bytes = &key.key;
 
-        // Track first key
+        // Track actual first key of the SSTable
         if self.first_key.is_none() {
             self.first_key = Some(key_bytes.clone());
         }
 
-        // Always update last key
+        // Track actual last key of the SSTable (updated for every partition)
         self.last_key = Some(key_bytes.clone());
 
-        // Count every partition that results in a sampled entry.
-        // The caller adds one entry per `min_index_interval` partitions, so each
-        // call here represents `min_index_interval` total partitions for the purpose
-        // of reconstructing `size_at_full_sampling`.
-        self.total_partition_count = self
-            .total_partition_count
-            .saturating_add(self.min_index_interval);
+        // Count every partition for size_at_full_sampling.
+        self.total_partition_count = self.total_partition_count.saturating_add(1);
+    }
 
-        // Add entry
+    /// Add a sampled index entry to the summary.
+    ///
+    /// The caller is responsible for sampling at the correct interval.  This method
+    /// does NOT enforce sampling — it records every entry provided.
+    ///
+    /// Call `note_partition` for **every** partition, and `add_entry` only at the
+    /// sampling boundary.  `add_entry` no longer updates `first_key`, `last_key`,
+    /// or `total_partition_count`; those are managed by `note_partition`.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - Decorated partition key (token + raw bytes)
+    /// * `index_offset` - Byte offset in Index.db where this partition's entry starts
+    ///
+    /// # Important
+    ///
+    /// Entries MUST be added in token order (same as Index.db order).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cqlite_core::storage::sstable::writer::SummaryWriter;
+    /// use cqlite_core::storage::write_engine::mutation::DecoratedKey;
+    ///
+    /// let mut writer = SummaryWriter::new(128);
+    ///
+    /// let key = DecoratedKey::new(12345, vec![0x00, 0x00, 0x00, 0x2A]);
+    /// writer.note_partition(&key);
+    /// writer.add_entry(&key, 0).unwrap();
+    /// assert_eq!(writer.entry_count(), 1);
+    /// ```
+    pub fn add_entry(&mut self, key: &DecoratedKey, index_offset: u64) -> Result<()> {
+        // Add the sampled index entry.  `first_key`, `last_key`, and
+        // `total_partition_count` are managed by `note_partition` instead.
         self.entries.push(SummaryEntry {
-            key: key_bytes,
+            key: key.key.clone(),
             index_position: index_offset,
         });
 
@@ -251,13 +308,29 @@ impl SummaryWriter {
             return Ok(buffer);
         }
 
-        // Calculate entry data sizes and offsets
+        // Calculate total summary_entries_size (offset table + entry data).
+        //
+        // CRITICAL (Issue #666): Cassandra's IndexSummary.deserialize expects entry
+        // offsets to be ABSOLUTE from the start of the combined (offset_table +
+        // entry_data) region — i.e. offset[0] == offset_table_size, NOT 0.
+        //
+        // CQLite previously stored zero-based offsets (relative to entry_data). The
+        // CQLite reader's `normalize_entry_offsets` accepted both layouts, hiding the
+        // divergence from unit tests, but Cassandra's own deserializer asserts that
+        // offsets increase monotonically and start no earlier than the end of the
+        // offset table — so a zero-based offset[0] triggers an AssertionError.
+        //
+        // Fix: bias every offset by `offset_table_size` so that offset[i] equals the
+        // byte position of entry i within the combined (offset_table + entry_data)
+        // block. This matches what Cassandra writes (verified by hex-dumping
+        // Cassandra-generated Summary.db files from the test corpus).
+        let offset_table_size = self.entries.len() * 4; // u32 per entry, LE
         let mut entry_offsets = Vec::with_capacity(self.entries.len());
         let mut entry_data = Vec::new();
 
         for entry in &self.entries {
-            // Record offset for this entry
-            entry_offsets.push(entry_data.len() as u32);
+            // Offset is absolute: start of offset_table + current entry_data length.
+            entry_offsets.push((offset_table_size + entry_data.len()) as u32);
 
             // Write key bytes (no length prefix!)
             entry_data.extend_from_slice(&entry.key);
@@ -266,8 +339,6 @@ impl SummaryWriter {
             entry_data.extend_from_slice(&entry.index_position.to_be_bytes());
         }
 
-        // Calculate total summary_entries_size (offset table + entry data)
-        let offset_table_size = entry_offsets.len() * 4; // u32 per entry
         let summary_entries_size = (offset_table_size + entry_data.len()) as u64;
 
         // Write header (24 bytes, big-endian)
@@ -342,18 +413,17 @@ impl SummaryWriter {
 
         // size_at_full_sampling (u32, BE).
         //
-        // This is the *estimated* number of index entries if the table were sampled at
-        // the full base level (= total_partition_count / min_index_interval).  For a
-        // new SSTable that has never been downsampled this equals entries_count, but
-        // the two fields are logically distinct and must be tracked independently.
+        // For a freshly written SSTable (sampling_level == BASE_SAMPLING_LEVEL, i.e. never
+        // downsampled), this field equals entries_count.  It only diverges from entries_count
+        // after Cassandra downsamples an existing Summary.db during compaction — the sampled
+        // count decreases while size_at_full_sampling retains the original count.
+        //
+        // Verified against real Cassandra 5.0 corpus:
+        //   composite_key_table (1 entry):  size_at_full_sampling = 1 = entries_count
+        //   simple_table (8 entries):       size_at_full_sampling = 8 = entries_count
         //
         // Source: IndexSummary.java:235–237 (`getMaxNumberOfEntries()`).
-        let size_at_full_sampling = if self.min_index_interval > 0 {
-            self.total_partition_count / self.min_index_interval
-        } else {
-            entries_count
-        };
-        buffer.extend_from_slice(&size_at_full_sampling.to_be_bytes());
+        buffer.extend_from_slice(&entries_count.to_be_bytes());
     }
 }
 
@@ -404,6 +474,8 @@ mod tests {
         let mut writer = SummaryWriter::new(128);
         let key = DecoratedKey::new(12345, vec![0x01, 0x02, 0x03, 0x04]);
 
+        // note_partition must be called for every partition (sets first_key/last_key)
+        writer.note_partition(&key);
         writer.add_entry(&key, 0).unwrap();
         let bytes = writer.finish().unwrap();
 
@@ -433,8 +505,10 @@ mod tests {
         assert_eq!(&bytes[20..24], &[0x00, 0x00, 0x00, 0x01]);
 
         // Verify offset table (LITTLE-ENDIAN!)
-        // Offset 0 for first entry
-        assert_eq!(&bytes[24..28], &[0x00, 0x00, 0x00, 0x00]);
+        // Offset 0 for first entry: absolute = offset_table_size (4) + 0 = 4
+        // Cassandra IndexSummary.deserialize expects offsets to be absolute from
+        // start of (offset_table + entry_data), so offset[0] == offset_table_size.
+        assert_eq!(&bytes[24..28], &[0x04, 0x00, 0x00, 0x00]);
 
         // Verify entry data
         // Key: [0x01, 0x02, 0x03, 0x04]
@@ -464,10 +538,12 @@ mod tests {
 
         // Entry 1: 2-byte key, position 0
         let key1 = DecoratedKey::new(100, vec![0xAA, 0xBB]);
+        writer.note_partition(&key1);
         writer.add_entry(&key1, 0).unwrap();
 
         // Entry 2: 3-byte key, position 1024
         let key2 = DecoratedKey::new(200, vec![0xCC, 0xDD, 0xEE]);
+        writer.note_partition(&key2);
         writer.add_entry(&key2, 1024).unwrap();
 
         let bytes = writer.finish().unwrap();
@@ -476,10 +552,13 @@ mod tests {
         assert_eq!(&bytes[4..8], &[0x00, 0x00, 0x00, 0x02]);
 
         // Verify offset table (LE)
-        // Offset 0: 0x00 0x00 0x00 0x00 (entry 1 starts at 0)
-        assert_eq!(&bytes[24..28], &[0x00, 0x00, 0x00, 0x00]);
-        // Offset 1: 0x0A 0x00 0x00 0x00 (entry 2 starts at 10 = 2 bytes key + 8 bytes pos)
-        assert_eq!(&bytes[28..32], &[0x0A, 0x00, 0x00, 0x00]);
+        // Offsets are ABSOLUTE from start of (offset_table + entry_data).
+        // offset_table_size = 2 entries * 4 bytes = 8
+        // Offset 0: 8 (0x08 in LE) = offset_table_size + 0
+        assert_eq!(&bytes[24..28], &[0x08, 0x00, 0x00, 0x00]);
+        // Offset 1: 18 (0x12 in LE) = offset_table_size(8) + entry_1_size(10)
+        // entry_1_size = 2 bytes key + 8 bytes pos = 10
+        assert_eq!(&bytes[28..32], &[0x12, 0x00, 0x00, 0x00]);
 
         // Verify entry 1 data
         assert_eq!(&bytes[32..34], &[0xAA, 0xBB]); // key
@@ -513,18 +592,23 @@ mod tests {
         let key1 = DecoratedKey::new(100, vec![0x01; 16]); // 16 bytes
         let key2 = DecoratedKey::new(200, vec![0x02; 16]); // 16 bytes
 
+        writer.note_partition(&key1);
         writer.add_entry(&key1, 0).unwrap();
+        writer.note_partition(&key2);
         writer.add_entry(&key2, 100).unwrap();
 
         let bytes = writer.finish().unwrap();
 
-        // Offset table starts at byte 24
-        // Offset 0: 0 (LE: 0x00 0x00 0x00 0x00)
-        assert_eq!(&bytes[24..28], &[0x00, 0x00, 0x00, 0x00]);
+        // Offset table starts at byte 24.
+        // Offsets are ABSOLUTE from start of (offset_table + entry_data).
+        // offset_table_size = 2 entries * 4 bytes = 8
+        // Offset 0: 8 (LE: 0x08 0x00 0x00 0x00) = offset_table_size + 0
+        assert_eq!(&bytes[24..28], &[0x08, 0x00, 0x00, 0x00]);
 
-        // Offset 1: 24 (LE: 0x18 0x00 0x00 0x00)
+        // Offset 1: 32 (LE: 0x20 0x00 0x00 0x00)
+        // = offset_table_size(8) + entry_1_size(24) = 32
         // Entry 1 is 16 bytes (key) + 8 bytes (position) = 24 bytes
-        assert_eq!(&bytes[28..32], &[0x18, 0x00, 0x00, 0x00]);
+        assert_eq!(&bytes[28..32], &[0x20, 0x00, 0x00, 0x00]);
     }
 
     #[test]
@@ -537,8 +621,11 @@ mod tests {
         let key128 = DecoratedKey::new(200, vec![0x80]);
         let key256 = DecoratedKey::new(300, vec![0xFF]);
 
+        writer.note_partition(&key0);
         writer.add_entry(&key0, 0).unwrap();
+        writer.note_partition(&key128);
         writer.add_entry(&key128, 2048).unwrap();
+        writer.note_partition(&key256);
         writer.add_entry(&key256, 4096).unwrap();
 
         assert_eq!(writer.entry_count(), 3);
@@ -561,8 +648,13 @@ mod tests {
         let key2 = DecoratedKey::new(200, middle_key_bytes.clone());
         let key3 = DecoratedKey::new(300, last_key_bytes.clone());
 
+        // note_partition must be called for every partition so first/last keys
+        // reflect the full SSTable range.  add_entry is only for sampled entries.
+        writer.note_partition(&key1);
         writer.add_entry(&key1, 0).unwrap();
+        writer.note_partition(&key2);
         writer.add_entry(&key2, 1024).unwrap();
+        writer.note_partition(&key3);
         writer.add_entry(&key3, 2048).unwrap();
 
         let bytes = writer.finish().unwrap();
@@ -616,6 +708,7 @@ mod tests {
 
         let key = DecoratedKey::new(12345, vec![0xFF]);
         // Large position value: 1GB
+        writer.note_partition(&key);
         writer.add_entry(&key, 1_073_741_824).unwrap();
 
         let bytes = writer.finish().unwrap();
@@ -634,6 +727,7 @@ mod tests {
         let key = DecoratedKey::new(12345, vec![0x01]);
 
         // Test specific position value: 12381
+        writer.note_partition(&key);
         writer.add_entry(&key, 12381).unwrap();
 
         let bytes = writer.finish().unwrap();
@@ -652,6 +746,7 @@ mod tests {
 
         // Create a simple entry for hex verification
         let key = DecoratedKey::new(12345, vec![0x01, 0x02, 0x03, 0x04]);
+        writer.note_partition(&key);
         writer.add_entry(&key, 0).unwrap();
 
         let bytes = writer.finish().unwrap();
@@ -700,8 +795,11 @@ mod tests {
         let key2 = DecoratedKey::new(0, vec![0x02]);
         let key3 = DecoratedKey::new(5000000000, vec![0x03]);
 
+        writer.note_partition(&key1);
         writer.add_entry(&key1, 0).unwrap();
+        writer.note_partition(&key2);
         writer.add_entry(&key2, 1000).unwrap();
+        writer.note_partition(&key3);
         writer.add_entry(&key3, 2000).unwrap();
 
         let bytes = writer.finish().unwrap();
@@ -719,19 +817,24 @@ mod tests {
         let key2 = DecoratedKey::new(200, vec![0x02, 0x03]); // 2 bytes
         let key3 = DecoratedKey::new(300, vec![0x04, 0x05, 0x06, 0x07]); // 4 bytes
 
+        writer.note_partition(&key1);
         writer.add_entry(&key1, 0).unwrap();
+        writer.note_partition(&key2);
         writer.add_entry(&key2, 100).unwrap();
+        writer.note_partition(&key3);
         writer.add_entry(&key3, 200).unwrap();
 
         let bytes = writer.finish().unwrap();
 
-        // Verify offset table accounts for variable key sizes
-        // Offset 0: 0
-        assert_eq!(&bytes[24..28], &[0x00, 0x00, 0x00, 0x00]);
-        // Offset 1: 9 (1 byte key + 8 byte position)
-        assert_eq!(&bytes[28..32], &[0x09, 0x00, 0x00, 0x00]);
-        // Offset 2: 19 (9 + 2 byte key + 8 byte position)
-        assert_eq!(&bytes[32..36], &[0x13, 0x00, 0x00, 0x00]);
+        // Verify offset table accounts for variable key sizes.
+        // Offsets are ABSOLUTE from start of (offset_table + entry_data).
+        // offset_table_size = 3 entries * 4 bytes = 12
+        // Offset 0: 12 (LE: 0x0C 0x00 0x00 0x00) = offset_table_size + 0
+        assert_eq!(&bytes[24..28], &[0x0C, 0x00, 0x00, 0x00]);
+        // Offset 1: 21 (LE: 0x15 0x00 0x00 0x00) = 12 + 9 (1 byte key + 8 byte position)
+        assert_eq!(&bytes[28..32], &[0x15, 0x00, 0x00, 0x00]);
+        // Offset 2: 31 (LE: 0x1F 0x00 0x00 0x00) = 12 + 9 + 10 (2 byte key + 8 byte position)
+        assert_eq!(&bytes[32..36], &[0x1F, 0x00, 0x00, 0x00]);
     }
 
     #[test]
@@ -742,6 +845,7 @@ mod tests {
         let large_key = vec![0xAB; 256];
         let key = DecoratedKey::new(12345, large_key.clone());
 
+        writer.note_partition(&key);
         writer.add_entry(&key, 0).unwrap();
         let bytes = writer.finish().unwrap();
 
@@ -761,8 +865,11 @@ mod tests {
         let key128 = DecoratedKey::new(-1000000000, vec![0x00, 0x00, 0x03, 0xEA]); // partition 128
         let key256 = DecoratedKey::new(3000000000, vec![0x00, 0x00, 0x03, 0xEB]); // partition 256
 
+        writer.note_partition(&key0);
         writer.add_entry(&key0, 0).unwrap();
+        writer.note_partition(&key128);
         writer.add_entry(&key128, 25600).unwrap(); // ~100 bytes per partition
+        writer.note_partition(&key256);
         writer.add_entry(&key256, 51200).unwrap();
 
         assert_eq!(writer.entry_count(), 3);
@@ -783,7 +890,9 @@ mod tests {
         let key1 = DecoratedKey::new(100, vec![0x01, 0x02]); // 2 bytes
         let key2 = DecoratedKey::new(200, vec![0x03, 0x04]); // 2 bytes
 
+        writer.note_partition(&key1);
         writer.add_entry(&key1, 0).unwrap();
+        writer.note_partition(&key2);
         writer.add_entry(&key2, 1024).unwrap();
 
         let bytes = writer.finish().unwrap();
@@ -811,6 +920,7 @@ mod tests {
         ];
         let key = DecoratedKey::new(12345, key_bytes.to_vec());
 
+        writer.note_partition(&key);
         writer.add_entry(&key, 0).unwrap();
         let bytes = writer.finish().unwrap();
 
@@ -828,4 +938,172 @@ mod tests {
     // Note: Roundtrip tests with SummaryReader would require exposing parse_summary_data
     // as public API. For now, byte-level verification in other tests provides sufficient
     // format validation. Integration tests can verify end-to-end compatibility.
+
+    /// Regression test for Issue #666: CQLite-written Summary.db was rejected by
+    /// Cassandra 5's IndexSummary.deserialize because entry offsets were zero-based
+    /// (relative to the entry_data region) instead of absolute (from the start of the
+    /// combined offset_table + entry_data region).
+    ///
+    /// Cassandra's IndexSummary.deserialize asserts that every offset is >=
+    /// offset_table_size.  With zero-based offsets the first entry had offset = 0,
+    /// which is < offset_table_size for any non-empty SSTable, triggering an
+    /// AssertionError and causing the readback test to exclude Summary.db via
+    /// `tar --exclude='*Summary.db'`.
+    ///
+    /// Fix: offsets are now biased by `entries_count * 4` (= offset_table_size) so
+    /// that offset[0] == offset_table_size, matching what Cassandra writes.
+    ///
+    /// Verified against hex dumps of real Cassandra 5.0.2-generated Summary.db files:
+    /// - 1-entry file: offset[0] = 0x04 (= 1*4)
+    /// - 8-entry file: offset[0] = 0x20 (= 8*4 = 32)
+    #[test]
+    fn issue_666_offset_table_absolute_not_relative() {
+        // ── 1-entry case (matches Cassandra-generated test corpus) ──────────────
+        // composite_key_table: 1 entry, 16-byte UUID key, position = 0
+        // Expected offset[0] = 0x04 in LE (= offset_table_size = 1*4)
+        {
+            let mut writer = SummaryWriter::new(128);
+            let key = DecoratedKey::new(12345, vec![0u8; 16]);
+            writer.note_partition(&key);
+            writer.add_entry(&key, 0).unwrap();
+            let bytes = writer.finish().unwrap();
+
+            // offset_table_size = 1 * 4 = 4
+            // offset[0] must equal 4 (absolute), NOT 0 (relative)
+            assert_eq!(
+                &bytes[24..28],
+                &[0x04, 0x00, 0x00, 0x00],
+                "Issue #666: single-entry offset must be 4 (absolute), not 0 (relative)"
+            );
+        }
+
+        // ── 8-entry case (matches Cassandra's simple_table Summary.db) ──────────
+        // offset_table_size = 8 * 4 = 32 = 0x20
+        // Each entry: 16-byte UUID key + 8-byte position = 24 bytes
+        // Expected offsets: 32, 56, 80, 104, 128, 152, 176, 200
+        //   = 0x20, 0x38, 0x50, 0x68, 0x80, 0x98, 0xB0, 0xC8
+        // This matches exactly the offset table of test_basic/simple_table in the corpus.
+        {
+            let mut writer = SummaryWriter::new(128);
+            for i in 0u8..8 {
+                let key = DecoratedKey::new(i as i64 * 1000, vec![i; 16]);
+                writer.note_partition(&key);
+                writer.add_entry(&key, i as u64 * 1024).unwrap();
+            }
+            let bytes = writer.finish().unwrap();
+
+            let expected_offsets: &[u32] = &[32, 56, 80, 104, 128, 152, 176, 200];
+            for (idx, &expected) in expected_offsets.iter().enumerate() {
+                let offset_pos = 24 + idx * 4;
+                let actual = u32::from_le_bytes([
+                    bytes[offset_pos],
+                    bytes[offset_pos + 1],
+                    bytes[offset_pos + 2],
+                    bytes[offset_pos + 3],
+                ]);
+                assert_eq!(
+                    actual, expected,
+                    "Issue #666: offset[{idx}] = {actual}, want {expected} (absolute)"
+                );
+            }
+        }
+
+        // ── Writer-reader roundtrip: absolute offsets survive the CQLite reader ─
+        // The CQLite summary_reader.rs `normalize_entry_offsets` must accept absolute
+        // offsets (the canonical format) and return correct zero-based positions.
+        {
+            use crate::storage::sstable::summary_reader::parse_summary_header;
+            use nom::error::Error as NomError;
+            use nom::multi::count;
+            use nom::number::complete::le_u32;
+
+            let mut writer = SummaryWriter::new(128);
+            let key_bytes = vec![0xAB; 4];
+            let key = DecoratedKey::new(42, key_bytes.clone());
+            writer.note_partition(&key);
+            writer.add_entry(&key, 99).unwrap();
+            let bytes = writer.finish().unwrap();
+
+            // Parse header
+            let (after_header, header) = parse_summary_header(&bytes).unwrap();
+            assert_eq!(header.entries_count, 1);
+            assert_eq!(header.summary_entries_size, 16); // 4 (offset table) + 12 (4-byte key + 8-byte pos)
+
+            // Parse offset table: the single offset should be 4 (absolute)
+            let (_, offsets) = count(le_u32::<_, NomError<_>>, 1usize)(after_header).unwrap();
+            assert_eq!(
+                offsets[0], 4,
+                "Issue #666: writer must emit absolute offset 4, not 0"
+            );
+        }
+    }
+
+    /// Regression test for Issue #666 (Part 2): first_key and last_key in Summary.db
+    /// must cover the ENTIRE SSTable, not just sampled partitions.
+    ///
+    /// Before the fix, `first_key`/`last_key` were set only when `add_entry` was called
+    /// (i.e., at sampling boundaries).  For an SSTable with fewer than
+    /// `min_index_interval` partitions, only partition[0] would be sampled, and thus
+    /// `first_key == last_key == key[0]`.  Cassandra uses these fields for range queries
+    /// — with both set to key[0], all other partitions become invisible.
+    ///
+    /// Fix: `note_partition` must be called for every partition.  It tracks first/last
+    /// keys independently of the sampling decision.
+    #[test]
+    fn issue_666_first_last_keys_cover_all_partitions() {
+        let mut writer = SummaryWriter::new(128);
+
+        // 3 partitions, but only partition[0] is at a sampling boundary.
+        // Simulates the basic-primitives e2e test (3 UUID rows, interval=128).
+        let key_first = DecoratedKey::new(100, vec![0x01; 16]); // first in token order
+        let key_mid = DecoratedKey::new(200, vec![0x02; 16]);
+        let key_last = DecoratedKey::new(300, vec![0x03; 16]); // last in token order
+
+        // Partition 0 is sampled (counter=0 → 0 % 128 == 0)
+        writer.note_partition(&key_first);
+        writer.add_entry(&key_first, 0).unwrap();
+
+        // Partitions 1 and 2 are NOT sampled, but note_partition must still be called
+        writer.note_partition(&key_mid);
+        writer.note_partition(&key_last);
+
+        let bytes = writer.finish().unwrap();
+
+        // entries_count = 1 (only first was sampled)
+        assert_eq!(
+            &bytes[4..8],
+            &[0x00, 0x00, 0x00, 0x01],
+            "Issue #666: entries_count must be 1 (only sampled entry)"
+        );
+
+        // first_key must be key_first
+        // Layout: header(24) + offset_table(4) + entry_data(16+8=24) = 52
+        // first_key: len(4) + data(16) = 20 bytes at offset 52
+        let first_key_len_pos = 52;
+        let first_key_len = u32::from_be_bytes(
+            bytes[first_key_len_pos..first_key_len_pos + 4]
+                .try_into()
+                .unwrap(),
+        );
+        assert_eq!(first_key_len, 16, "Issue #666: first_key len must be 16");
+        assert_eq!(
+            &bytes[first_key_len_pos + 4..first_key_len_pos + 20],
+            &[0x01; 16],
+            "Issue #666: first_key must be key_first"
+        );
+
+        // last_key must be key_last (the 3rd partition, which was only noted, not sampled)
+        let last_key_len_pos = first_key_len_pos + 20; // 72
+        let last_key_len = u32::from_be_bytes(
+            bytes[last_key_len_pos..last_key_len_pos + 4]
+                .try_into()
+                .unwrap(),
+        );
+        assert_eq!(last_key_len, 16, "Issue #666: last_key len must be 16");
+        assert_eq!(
+            &bytes[last_key_len_pos + 4..last_key_len_pos + 20],
+            &[0x03; 16],
+            "Issue #666: last_key must be key_last (all 3 partitions visible)"
+        );
+    }
 }

--- a/cqlite-core/tests/sstabledump_parity_summary.rs
+++ b/cqlite-core/tests/sstabledump_parity_summary.rs
@@ -308,9 +308,12 @@ async fn test_summary_header_roundtrip() -> CqliteResult<()> {
     let min_index_interval = 64u32;
     let mut writer = SummaryWriter::new(min_index_interval);
 
-    // Add entries
+    // Add entries (note_partition must be called for every partition so that
+    // first_key and last_key are tracked; add_entry is only called at sampling
+    // boundaries but note_partition covers all partitions).
     for i in 0..10 {
         let key = DecoratedKey::new(i as i64 * 100, vec![0x00, 0x00, 0x00, i as u8]);
+        writer.note_partition(&key);
         writer.add_entry(&key, i as u64 * 256)?;
     }
 
@@ -346,10 +349,11 @@ async fn test_summary_offset_table_encoding() -> CqliteResult<()> {
 
     let mut writer = SummaryWriter::new(128);
 
-    // Add entries with known positions
+    // Add entries with known positions (note_partition required before add_entry)
     let positions = [0u64, 1024u64, 4096u64, 16384u64];
     for (i, &pos) in positions.iter().enumerate() {
         let key = DecoratedKey::new(i as i64 * 1000, vec![i as u8]);
+        writer.note_partition(&key);
         writer.add_entry(&key, pos)?;
     }
 
@@ -392,15 +396,19 @@ async fn test_summary_key_boundaries() -> CqliteResult<()> {
 
     let mut writer = SummaryWriter::new(128);
 
-    // First and last keys with distinctive values
+    // First and last keys with distinctive values (note_partition required for
+    // all partitions so first_key/last_key cover the full range)
     let first_key = DecoratedKey::new(-1000, vec![0xAA, 0xBB, 0xCC, 0xDD]);
     let last_key = DecoratedKey::new(9000, vec![0x11, 0x22, 0x33, 0x44]);
 
+    writer.note_partition(&first_key);
     writer.add_entry(&first_key, 0)?;
     for i in 1..9 {
         let key = DecoratedKey::new(i * 1000, vec![i as u8; 4]);
+        writer.note_partition(&key);
         writer.add_entry(&key, i as u64 * 100)?;
     }
+    writer.note_partition(&last_key);
     writer.add_entry(&last_key, 900)?;
 
     // Write to file
@@ -433,7 +441,7 @@ async fn test_summary_large_positions() -> CqliteResult<()> {
 
     let mut writer = SummaryWriter::new(128);
 
-    // Large positions requiring 8-byte encoding
+    // Large positions requiring 8-byte encoding (note_partition required)
     let large_positions = [
         0u64,
         1_000_000_000u64,   // 1 GB
@@ -443,6 +451,7 @@ async fn test_summary_large_positions() -> CqliteResult<()> {
 
     for (i, &pos) in large_positions.iter().enumerate() {
         let key = DecoratedKey::new(i as i64 * 100, vec![i as u8]);
+        writer.note_partition(&key);
         writer.add_entry(&key, pos)?;
     }
 

--- a/cqlite-core/tests/write_read_roundtrip/summary.rs
+++ b/cqlite-core/tests/write_read_roundtrip/summary.rs
@@ -35,8 +35,9 @@ async fn test_summary_roundtrip_single_entry() {
     // Create summary writer with default sampling interval
     let mut writer = SummaryWriter::new(128);
 
-    // Add a single entry
+    // Add a single entry (note_partition must be called for every partition)
     let key = DecoratedKey::new(12345, vec![0x00, 0x00, 0x00, 0x01]);
+    writer.note_partition(&key);
     writer.add_entry(&key, 0).expect("add_entry should succeed");
 
     // Finalize to bytes
@@ -96,6 +97,7 @@ async fn test_summary_roundtrip_multiple_entries() {
 
     for (token, key_bytes, position) in &entries_data {
         let key = DecoratedKey::new(*token, key_bytes.clone());
+        writer.note_partition(&key);
         writer
             .add_entry(&key, *position)
             .expect("add_entry should succeed");
@@ -225,9 +227,10 @@ async fn test_summary_header_parameters() {
     let min_index_interval = 64u32;
     let mut writer = SummaryWriter::new(min_index_interval);
 
-    // Add entries
+    // Add entries (note_partition required before add_entry for first_key/last_key tracking)
     for i in 0..10 {
         let key = DecoratedKey::new(i as i64 * 100, vec![0x00, 0x00, 0x00, i as u8]);
+        writer.note_partition(&key);
         writer
             .add_entry(&key, i as u64 * 256)
             .expect("add_entry should succeed");
@@ -290,6 +293,7 @@ async fn test_summary_large_positions() {
 
     for (token, key_bytes, position) in &entries_data {
         let key = DecoratedKey::new(*token, key_bytes.clone());
+        writer.note_partition(&key);
         writer
             .add_entry(&key, *position)
             .expect("add_entry should succeed");
@@ -359,6 +363,7 @@ async fn test_summary_entry_lookup() {
 
     for (token, key_bytes, position) in &entries_data {
         let key = DecoratedKey::new(*token, key_bytes.clone());
+        writer.note_partition(&key);
         writer
             .add_entry(&key, *position)
             .expect("add_entry should succeed");
@@ -443,6 +448,9 @@ async fn test_summary_offset_tracking_with_index() {
         let entry_info = index_writer
             .add_partition(&key, data_offset)
             .expect("add_partition should succeed");
+
+        // note_partition must be called for EVERY partition (tracks first_key/last_key)
+        summary_writer.note_partition(&key);
 
         // Sample every 128th entry for Summary.db
         if i % 128 == 0 {

--- a/test-data/scripts/e2e-cassandra-readback.sh
+++ b/test-data/scripts/e2e-cassandra-readback.sh
@@ -1249,13 +1249,13 @@ copy_sstables_to_container() {
   # `compose_exec_nontty` (which has a no-`-T` fallback) because that
   # fallback would re-allocate a TTY and break the pipe.
   #
-  # Summary.db is intentionally excluded: CQLite's current Summary.db writer
-  # produces values that trip an AssertionError in Cassandra 5's
-  # IndexSummary deserializer (tracked separately). Cassandra reconstructs
-  # Summary.db from Index.db on first refresh, so the readback test still
-  # exercises the full Data/Index/Statistics/Filter/TOC/Digest path.
-  log "[$label] streaming SSTable components (excluding Summary.db) via tar -> $CONTAINER_NAME:$target/"
-  ( cd "$sstdir" && tar -cf - --exclude='*Summary.db' . ) \
+  # Summary.db is now included: Issue #666 fixed the CQLite Summary.db writer
+  # so that entry offsets are absolute (biased by offset_table_size) rather
+  # than zero-based. Cassandra 5's IndexSummary.deserialize requires absolute
+  # offsets and was previously throwing an AssertionError on CQLite-written
+  # Summary.db files. The tar --exclude='*Summary.db' carve-out is removed.
+  log "[$label] streaming SSTable components (including Summary.db) via tar -> $CONTAINER_NAME:$target/"
+  ( cd "$sstdir" && tar -cf - . ) \
     | $COMPOSE_CMD -f "$COMPOSE_FILE" exec -T "$SERVICE_NAME" \
         tar -C "$target" -xf -
 


### PR DESCRIPTION
Closes #666
Part of epic #663
Stacked on #715 (epic-663/667-tombstone-readback)

## Root Cause Analysis

Two bugs in `SummaryWriter` caused Cassandra 5's `IndexSummary.deserialize` to reject CQLite-written `Summary.db` files:

### Bug 1: Zero-based offset table (triggers AssertionError)

Cassandra's `IndexSummary.deserialize` asserts `offset >= offset_table_size` for every entry offset. CQLite emitted zero-based offsets (relative to the start of entry data), so `offset[0] = 0` always triggered this assertion.

**Fix**: Bias every entry offset by `offset_table_size = entries.len() * 4` so the layout is absolute from the start of `(offset_table || entry_data)`. Verified against corpus: `composite_key_table` (1 entry) has `offset[0] = 4`; `simple_table` (8 entries) has `offset[0] = 32`.

### Bug 2: first_key/last_key tracking only sampled partitions

`add_entry()` tracked `first_key` and `last_key`, but it is only called at sampling boundaries (every `min_index_interval`-th partition). For a 3-partition SSTable with interval=128, only partition[0] is sampled, so `first_key == last_key == partition[0].key`. Cassandra used this narrow range for partition filtering, returning 1 row instead of 3.

**Fix**: Added `note_partition()` method called for every partition. `add_entry()` no longer manages `first_key`/`last_key`/`total_partition_count`. The `SSTableWriter` in `mod.rs` now calls `note_partition` for every partition before the sampling branch that calls `add_entry`.

### Fix 3: e2e test exclusion removed

`e2e-cassandra-readback.sh` had `tar --exclude='*Summary.db'` to avoid the AssertionError. This carve-out is removed — `Summary.db` is now transferred to Cassandra with the rest of the components.

## Validation Evidence

- **Corpus verification**: Hex-dumped real Cassandra 5.0 `Summary.db` files to confirm absolute offset encoding
- **e2e Cassandra readback**: All 5 active tests pass with `Summary.db` included:
  - `basic-primitives` (3 UUID-keyed rows — this was the failing case for Bug 2)
  - `collections`, `udt`, `static-columns`, `ttl`
- **Unit tests**: 1711 tests pass; 2 new regression tests added
- **Clippy**: `RUSTFLAGS="-D warnings"` clean on full workspace