### PR TITLE
ci: migrate GitHub Actions to Node 24-compatible majors (#724)

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -29,7 +29,7 @@ jobs:
     name: Build & publish rustdoc
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/cassandra-validation.yml
+++ b/.github/workflows/cassandra-validation.yml
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -74,7 +74,7 @@ jobs:
           toolchain: stable
 
       - name: Cache Rust dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -183,7 +183,7 @@ jobs:
 
       - name: Upload Test Artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: sstableloader-test-results
           path: |
@@ -195,7 +195,7 @@ jobs:
 
       - name: Comment on PR (Success)
         if: success() && github.event_name == 'pull_request'
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           script: |
             const summary = `## ✅ sstableloader Integration Tests PASSED
@@ -216,7 +216,7 @@ jobs:
 
       - name: Comment on PR (Failure)
         if: failure() && github.event_name == 'pull_request'
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           script: |
             const summary = `## ❌ sstableloader Integration Tests FAILED

--- a/.github/workflows/ci-minimal-features.yml
+++ b/.github/workflows/ci-minimal-features.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # This job compiles core+integration+write-support+CLI test deps into one
       # debug target/ and sits at the standard runner's disk ceiling — 2 of the
@@ -33,7 +33,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -43,7 +43,7 @@ jobs:
 
       - name: Restore dataset cache
         id: dataset-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: test-data/datasets
           key: datasets-${{ env.DATASET_TAG }}-${{ env.DATASET_SHA256 }}
@@ -161,7 +161,7 @@ jobs:
 
       - name: Upload smoke test artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: smoke-test-results
           path: test-data/scripts/smoke-test-results/
@@ -174,7 +174,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/coverage-baseline.yml
+++ b/.github/workflows/coverage-baseline.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -34,7 +34,7 @@ jobs:
           CQLITE_DATASETS_ROOT: ${{ github.workspace }}/test-data/datasets
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           files: ./cobertura.xml
           fail_ci_if_error: false

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -36,7 +36,7 @@ jobs:
         coverage-type: [enforced, comprehensive]
         
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     
     - name: Setup Rust
       uses: dtolnay/rust-toolchain@stable
@@ -44,7 +44,7 @@ jobs:
         components: llvm-tools-preview
         
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.cargo/registry
@@ -59,7 +59,7 @@ jobs:
       run: cargo install cargo-llvm-cov
       
     - name: Restore datasets-v3 cache (same as ci.yml)
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: |
           test-data/datasets/
@@ -285,7 +285,7 @@ jobs:
         EOF
         
     - name: Upload Coverage Reports
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: coverage-${{ matrix.coverage-type }}-reports
         path: validation_artifacts/coverage/

--- a/.github/workflows/e2e-readback.yml
+++ b/.github/workflows/e2e-readback.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -57,7 +57,7 @@ jobs:
           toolchain: stable
 
       - name: Cache Rust dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -132,7 +132,7 @@ jobs:
 
       - name: Upload failure artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: e2e-readback-failure-${{ github.run_id }}
           path: /tmp/e2e-artifacts/
@@ -150,7 +150,7 @@ jobs:
       - name: Comment on PR (Success)
         if: success() && github.event_name == 'pull_request'
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             github.rest.issues.createComment({
@@ -167,7 +167,7 @@ jobs:
       - name: Comment on PR (Failure)
         if: failure() && github.event_name == 'pull_request'
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             github.rest.issues.createComment({

--- a/.github/workflows/m1-ci.yml
+++ b/.github/workflows/m1-ci.yml
@@ -34,7 +34,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -53,7 +53,7 @@ jobs:
 
     # Dataset cache and download for integration tests
     - name: Restore datasets-v3 cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: |
           test-data/datasets/
@@ -252,7 +252,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -271,7 +271,7 @@ jobs:
 
     # Dataset cache and download for parity validation
     - name: Restore datasets-v3 cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: |
           test-data/datasets/
@@ -612,7 +612,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -742,7 +742,7 @@ jobs:
 
     - name: 📤 Archive coverage results
       if: steps.coverage.outputs.coverage_failed != 'true'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: m1-coverage-report
         path: |

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -44,10 +44,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'
@@ -98,7 +98,7 @@ jobs:
           fi
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: bindings-${{ matrix.target }}
           path: bindings/node/${{ env.APP_NAME }}.*.node
@@ -127,17 +127,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'
           cache-dependency-path: bindings/node/package-lock.json
 
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: bindings-${{ matrix.target }}
           path: bindings/node
@@ -148,7 +148,7 @@ jobs:
 
       - name: Restore dataset cache
         id: dataset-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: test-data/datasets
           key: datasets-${{ env.DATASET_TAG }}-${{ env.DATASET_SHA256 }}
@@ -191,7 +191,7 @@ jobs:
 
       - name: Upload test results on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-results-${{ matrix.os }}
           path: bindings/node/__test__/
@@ -221,7 +221,7 @@ jobs:
           fi
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: bindings-*
           path: artifacts
@@ -242,7 +242,7 @@ jobs:
           fi
 
       - name: Upload merged artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: cqlite-node-binaries
           path: artifacts/*.node

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -35,10 +35,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'
@@ -89,7 +89,7 @@ jobs:
           fi
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: bindings-${{ matrix.target }}
           path: bindings/node/${{ env.APP_NAME }}.*.node
@@ -108,7 +108,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
@@ -122,7 +122,7 @@ jobs:
           npm --version
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: bindings-*
           path: bindings/node/artifacts
@@ -248,10 +248,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: bindings-*
           path: dist
@@ -266,7 +266,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: dist/*
           generate_release_notes: true

--- a/.github/workflows/perf-regression.yml
+++ b/.github/workflows/perf-regression.yml
@@ -55,7 +55,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout (full history so we can also build main)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -69,7 +69,7 @@ jobs:
       # cached target/ would carry incremental-compilation state across that
       # switch. Rebuilding from clean deps is the robust choice for a gate.
       - name: Cache Cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -80,7 +80,7 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Cache canonical datasets
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: test-data/datasets/
           key: ${{ runner.os }}-datasets-${{ env.DATASET_TAG }}-${{ env.DATASET_SHA256 }}

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -81,7 +81,7 @@ jobs:
           manylinux: ${{ matrix.manylinux || 'auto' }}
 
       - name: Upload wheel artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wheel-${{ matrix.target }}
           path: bindings/python/dist/*.whl
@@ -112,15 +112,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
 
       - name: Download wheel
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: wheel-${{ matrix.target }}
           path: dist
@@ -151,7 +151,7 @@ jobs:
 
       - name: Restore dataset cache
         id: dataset-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: test-data/datasets
           key: datasets-${{ env.DATASET_TAG }}-${{ env.DATASET_SHA256 }}
@@ -202,7 +202,7 @@ jobs:
 
       - name: Upload test results on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: pytest-results-${{ matrix.os }}
           path: |
@@ -233,7 +233,7 @@ jobs:
           fi
 
       - name: Download all wheels
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: wheel-*
           path: wheels
@@ -255,7 +255,7 @@ jobs:
           fi
 
       - name: Upload merged wheel artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: cqlite-wheels
           path: wheels/*.whl

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Build sdist
         uses: PyO3/maturin-action@v1
@@ -31,7 +31,7 @@ jobs:
           working-directory: bindings/python
 
       - name: Upload sdist artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: sdist
           path: bindings/python/dist/*.tar.gz
@@ -62,7 +62,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -98,7 +98,7 @@ jobs:
           manylinux: ${{ matrix.manylinux || 'auto' }}
 
       - name: Upload wheel artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wheel-${{ matrix.target }}
           path: bindings/python/dist/*.whl
@@ -122,10 +122,10 @@ jobs:
 
     steps:
       - name: Checkout (for version validation)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: dist
           merge-multiple: true
@@ -152,7 +152,7 @@ jobs:
           fi
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -197,10 +197,10 @@ jobs:
 
     steps:
       - name: Checkout (for version validation)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: dist
           merge-multiple: true
@@ -227,7 +227,7 @@ jobs:
           fi
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -284,10 +284,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: dist
           merge-multiple: true
@@ -315,7 +315,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: dist/*
           generate_release_notes: true

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -247,7 +247,7 @@ jobs:
         EOF
 
     - name: Upload quality gate report
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: always()
       with:
         name: quality-gate-report-${{ github.sha }}
@@ -263,7 +263,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Store quality gate results
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
@@ -111,7 +111,7 @@ jobs:
         cat "${file}.sha256"
 
     - name: Upload CLI artifact + checksum
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       with:
         files: |
           ./cqlite-${{ matrix.target }}.${{ contains(matrix.target, 'windows') && 'zip' || 'tar.gz' }}
@@ -126,9 +126,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-cli
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Update release body
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       with:
         generate_release_notes: true
         append_body: true
@@ -156,7 +156,7 @@ jobs:
   #         - target: x86_64-apple-darwin
   #           lib_name: libcqlite.dylib
   #   steps:
-  #   - uses: actions/checkout@v4
+  #   - uses: actions/checkout@v5
   #   - name: Install Rust
   #     uses: dtolnay/rust-toolchain@stable
   #     with:
@@ -185,7 +185,7 @@ jobs:
   #         tar czf cqlite-ffi-${{ matrix.target }}.tar.gz ffi-package
   #       fi
   #   - name: Upload FFI artifact
-  #     uses: softprops/action-gh-release@v2
+  #     uses: softprops/action-gh-release@v3
   #     with:
   #       files: ./cqlite-ffi-${{ matrix.target }}.${{ matrix.target == 'x86_64-pc-windows-msvc' && 'zip' || 'tar.gz' }}
   #     env:
@@ -195,7 +195,7 @@ jobs:
   #   name: Build WASM Package
   #   runs-on: ubuntu-latest
   #   steps:
-  #   - uses: actions/checkout@v4
+  #   - uses: actions/checkout@v5
   #   - name: Install Rust
   #     uses: dtolnay/rust-toolchain@stable
   #     with:
@@ -209,7 +209,7 @@ jobs:
   #       cd cqlite-wasm/pkg
   #       tar czf ../../cqlite-wasm.tar.gz .
   #   - name: Upload WASM artifact
-  #     uses: softprops/action-gh-release@v2
+  #     uses: softprops/action-gh-release@v3
   #     with:
   #       files: ./cqlite-wasm.tar.gz
   #     env:
@@ -223,7 +223,7 @@ jobs:
   #   runs-on: ubuntu-latest
   #   if: startsWith(github.ref, 'refs/tags/v')
   #   steps:
-  #   - uses: actions/checkout@v4
+  #   - uses: actions/checkout@v5
   #   - name: Install Rust
   #     uses: dtolnay/rust-toolchain@stable
   #   - name: Publish cqlite-core

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -38,13 +38,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -54,7 +54,7 @@ jobs:
 
       - name: Restore dataset cache
         id: dataset-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: test-data/datasets
           key: datasets-${{ env.DATASET_TAG }}-${{ env.DATASET_SHA256 }}
@@ -138,7 +138,7 @@ jobs:
 
       - name: Upload smoke test results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: smoke-test-results
           path: |
@@ -149,7 +149,7 @@ jobs:
 
       - name: Upload validation matrix
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: validation-matrix
           path: test-data/validation-matrix.md

--- a/.github/workflows/sstabledump-parity-gate.yml
+++ b/.github/workflows/sstabledump-parity-gate.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -34,7 +34,7 @@ jobs:
           toolchain: stable
 
       - name: Cache Rust dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -45,7 +45,7 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Cache canonical full datasets
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: test-data/datasets/
           key: ${{ runner.os }}-datasets-${{ env.DATASET_TAG }}-${{ env.DATASET_SHA256 }}
@@ -81,7 +81,7 @@ jobs:
           test "${statistics_count}" -gt 0
 
       - name: Setup Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "17"
@@ -159,7 +159,7 @@ jobs:
 
       - name: Upload parity artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: parity-test-results
           path: |
@@ -170,7 +170,7 @@ jobs:
 
       - name: Comment on PR (Success)
         if: always() && github.event_name == 'pull_request' && steps.data_parity.outcome == 'success' && steps.index_parity.outcome == 'success' && steps.summary_parity.outcome == 'success' && steps.statistics_parity.outcome == 'success'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const summary = `## ✅ SSTableDump Parity Validation PASSED
@@ -193,7 +193,7 @@ jobs:
 
       - name: Comment on PR (Failure)
         if: always() && github.event_name == 'pull_request' && (steps.data_parity.outcome != 'success' || steps.index_parity.outcome != 'success' || steps.summary_parity.outcome != 'success' || steps.statistics_parity.outcome != 'success')
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const summary = `## ❌ SSTableDump Parity Validation FAILED


### PR DESCRIPTION
Closes #724.

GitHub forces Node 20 actions onto Node 24 runners on **2026-06-16**. This bumps every action pinned to a Node 20 runtime across all 17 workflow files to its **lowest Node 24-native major** (minimizing behavioral drift vs. jumping to latest):

| Action | From | To | Notes |
|---|---|---|---|
| actions/checkout | v4 | v5 | node24 only |
| actions/cache (+ /restore) | v4 | v5 | node24 only |
| actions/github-script | v6, v7 | v8 | node24 only; API unchanged since v6's `github.rest` |
| actions/upload-artifact | v4 | **v6** | v5 still defaulted to node20 |
| actions/download-artifact | v4 | **v7** | v5/v6 still node20 |
| actions/setup-python | v5 | v6 | node24 only |
| actions/setup-node | v4 | v5 | see audit below |
| actions/setup-java | v4 | v5 | node24 only |
| codecov/codecov-action | v4 | v5 | now composite/CLI wrapper |
| softprops/action-gh-release | v2 | v3 | node24 only per release notes |

**Unchanged (already Node 24 or non-Node runtimes):** Swatinem/rust-cache@v2, peaceiris/actions-gh-pages@v4, PyO3/maturin-action@v1, dtolnay/rust-toolchain, actions-rust-lang/setup-rust-toolchain@v1, taiki-e/install-action@v2, pypa/gh-action-pypi-publish (docker). Runtimes verified by reading `runs.using` from each action's `action.yml` at the pinned tag.

**Breaking-change audit across the version jumps:**
- `download-artifact` v5 changed extraction paths **only for `artifact-ids:` downloads** — all 9 usages here use `name:`/`pattern:`, unaffected.
- `setup-node` v5 auto-caches when `package.json` has a `packageManager` field — `bindings/node/package.json` has none, and all usages set `cache: npm` explicitly.
- `codecov-action` v5 keeps the `files`/`fail_ci_if_error`/`verbose` inputs used in coverage-baseline.yml.
- Node 24 actions need runner ≥ 2.327.1 — all jobs run on GitHub-hosted runners.

**Verification:** workflow-only change (no Rust code), so the gate here is this PR's CI itself — all workflows that trigger on PR exercise the bumped checkout/cache/artifact/setup actions directly. Release-only workflows (node-release, python-release, release) use the same bumped action set.