### PR TITLE
docs: add validated docs-website design doc

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -29,7 +29,7 @@ jobs:
     name: Build & publish rustdoc
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/cassandra-validation.yml
+++ b/.github/workflows/cassandra-validation.yml
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -74,7 +74,7 @@ jobs:
           toolchain: stable
 
       - name: Cache Rust dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -183,7 +183,7 @@ jobs:
 
       - name: Upload Test Artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: sstableloader-test-results
           path: |
@@ -195,7 +195,7 @@ jobs:
 
       - name: Comment on PR (Success)
         if: success() && github.event_name == 'pull_request'
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           script: |
             const summary = `## ✅ sstableloader Integration Tests PASSED
@@ -216,7 +216,7 @@ jobs:
 
       - name: Comment on PR (Failure)
         if: failure() && github.event_name == 'pull_request'
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           script: |
             const summary = `## ❌ sstableloader Integration Tests FAILED

--- a/.github/workflows/ci-minimal-features.yml
+++ b/.github/workflows/ci-minimal-features.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # This job compiles core+integration+write-support+CLI test deps into one
       # debug target/ and sits at the standard runner's disk ceiling — 2 of the
@@ -33,7 +33,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -43,7 +43,7 @@ jobs:
 
       - name: Restore dataset cache
         id: dataset-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: test-data/datasets
           key: datasets-${{ env.DATASET_TAG }}-${{ env.DATASET_SHA256 }}
@@ -161,7 +161,7 @@ jobs:
 
       - name: Upload smoke test artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: smoke-test-results
           path: test-data/scripts/smoke-test-results/
@@ -174,7 +174,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/coverage-baseline.yml
+++ b/.github/workflows/coverage-baseline.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -34,7 +34,7 @@ jobs:
           CQLITE_DATASETS_ROOT: ${{ github.workspace }}/test-data/datasets
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           files: ./cobertura.xml
           fail_ci_if_error: false

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -36,7 +36,7 @@ jobs:
         coverage-type: [enforced, comprehensive]
         
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     
     - name: Setup Rust
       uses: dtolnay/rust-toolchain@stable
@@ -44,7 +44,7 @@ jobs:
         components: llvm-tools-preview
         
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.cargo/registry
@@ -59,7 +59,7 @@ jobs:
       run: cargo install cargo-llvm-cov
       
     - name: Restore datasets-v3 cache (same as ci.yml)
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: |
           test-data/datasets/
@@ -285,7 +285,7 @@ jobs:
         EOF
         
     - name: Upload Coverage Reports
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: coverage-${{ matrix.coverage-type }}-reports
         path: validation_artifacts/coverage/

--- a/.github/workflows/e2e-readback.yml
+++ b/.github/workflows/e2e-readback.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -57,7 +57,7 @@ jobs:
           toolchain: stable
 
       - name: Cache Rust dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -132,7 +132,7 @@ jobs:
 
       - name: Upload failure artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: e2e-readback-failure-${{ github.run_id }}
           path: /tmp/e2e-artifacts/
@@ -150,7 +150,7 @@ jobs:
       - name: Comment on PR (Success)
         if: success() && github.event_name == 'pull_request'
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             github.rest.issues.createComment({
@@ -167,7 +167,7 @@ jobs:
       - name: Comment on PR (Failure)
         if: failure() && github.event_name == 'pull_request'
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             github.rest.issues.createComment({

--- a/.github/workflows/m1-ci.yml
+++ b/.github/workflows/m1-ci.yml
@@ -34,7 +34,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -53,7 +53,7 @@ jobs:
 
     # Dataset cache and download for integration tests
     - name: Restore datasets-v3 cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: |
           test-data/datasets/
@@ -252,7 +252,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -271,7 +271,7 @@ jobs:
 
     # Dataset cache and download for parity validation
     - name: Restore datasets-v3 cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: |
           test-data/datasets/
@@ -612,7 +612,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -742,7 +742,7 @@ jobs:
 
     - name: 📤 Archive coverage results
       if: steps.coverage.outputs.coverage_failed != 'true'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: m1-coverage-report
         path: |

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -44,10 +44,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'
@@ -98,7 +98,7 @@ jobs:
           fi
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: bindings-${{ matrix.target }}
           path: bindings/node/${{ env.APP_NAME }}.*.node
@@ -127,17 +127,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'
           cache-dependency-path: bindings/node/package-lock.json
 
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: bindings-${{ matrix.target }}
           path: bindings/node
@@ -148,7 +148,7 @@ jobs:
 
       - name: Restore dataset cache
         id: dataset-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: test-data/datasets
           key: datasets-${{ env.DATASET_TAG }}-${{ env.DATASET_SHA256 }}
@@ -191,7 +191,7 @@ jobs:
 
       - name: Upload test results on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-results-${{ matrix.os }}
           path: bindings/node/__test__/
@@ -221,7 +221,7 @@ jobs:
           fi
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: bindings-*
           path: artifacts
@@ -242,7 +242,7 @@ jobs:
           fi
 
       - name: Upload merged artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: cqlite-node-binaries
           path: artifacts/*.node

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -35,10 +35,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'
@@ -89,7 +89,7 @@ jobs:
           fi
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: bindings-${{ matrix.target }}
           path: bindings/node/${{ env.APP_NAME }}.*.node
@@ -108,7 +108,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
@@ -122,7 +122,7 @@ jobs:
           npm --version
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: bindings-*
           path: bindings/node/artifacts
@@ -248,10 +248,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: bindings-*
           path: dist
@@ -266,7 +266,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: dist/*
           generate_release_notes: true

--- a/.github/workflows/perf-regression.yml
+++ b/.github/workflows/perf-regression.yml
@@ -55,7 +55,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout (full history so we can also build main)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -69,7 +69,7 @@ jobs:
       # cached target/ would carry incremental-compilation state across that
       # switch. Rebuilding from clean deps is the robust choice for a gate.
       - name: Cache Cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -80,7 +80,7 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Cache canonical datasets
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: test-data/datasets/
           key: ${{ runner.os }}-datasets-${{ env.DATASET_TAG }}-${{ env.DATASET_SHA256 }}

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -81,7 +81,7 @@ jobs:
           manylinux: ${{ matrix.manylinux || 'auto' }}
 
       - name: Upload wheel artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wheel-${{ matrix.target }}
           path: bindings/python/dist/*.whl
@@ -112,15 +112,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
 
       - name: Download wheel
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: wheel-${{ matrix.target }}
           path: dist
@@ -151,7 +151,7 @@ jobs:
 
       - name: Restore dataset cache
         id: dataset-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: test-data/datasets
           key: datasets-${{ env.DATASET_TAG }}-${{ env.DATASET_SHA256 }}
@@ -202,7 +202,7 @@ jobs:
 
       - name: Upload test results on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: pytest-results-${{ matrix.os }}
           path: |
@@ -233,7 +233,7 @@ jobs:
           fi
 
       - name: Download all wheels
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: wheel-*
           path: wheels
@@ -255,7 +255,7 @@ jobs:
           fi
 
       - name: Upload merged wheel artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: cqlite-wheels
           path: wheels/*.whl

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Build sdist
         uses: PyO3/maturin-action@v1
@@ -31,7 +31,7 @@ jobs:
           working-directory: bindings/python
 
       - name: Upload sdist artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: sdist
           path: bindings/python/dist/*.tar.gz
@@ -62,7 +62,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -98,7 +98,7 @@ jobs:
           manylinux: ${{ matrix.manylinux || 'auto' }}
 
       - name: Upload wheel artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wheel-${{ matrix.target }}
           path: bindings/python/dist/*.whl
@@ -122,10 +122,10 @@ jobs:
 
     steps:
       - name: Checkout (for version validation)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: dist
           merge-multiple: true
@@ -152,7 +152,7 @@ jobs:
           fi
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -197,10 +197,10 @@ jobs:
 
     steps:
       - name: Checkout (for version validation)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: dist
           merge-multiple: true
@@ -227,7 +227,7 @@ jobs:
           fi
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -284,10 +284,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: dist
           merge-multiple: true
@@ -315,7 +315,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: dist/*
           generate_release_notes: true

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -247,7 +247,7 @@ jobs:
         EOF
 
     - name: Upload quality gate report
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: always()
       with:
         name: quality-gate-report-${{ github.sha }}
@@ -263,7 +263,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Store quality gate results
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
@@ -111,7 +111,7 @@ jobs:
         cat "${file}.sha256"
 
     - name: Upload CLI artifact + checksum
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       with:
         files: |
           ./cqlite-${{ matrix.target }}.${{ contains(matrix.target, 'windows') && 'zip' || 'tar.gz' }}
@@ -126,9 +126,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-cli
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Update release body
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       with:
         generate_release_notes: true
         append_body: true
@@ -156,7 +156,7 @@ jobs:
   #         - target: x86_64-apple-darwin
   #           lib_name: libcqlite.dylib
   #   steps:
-  #   - uses: actions/checkout@v4
+  #   - uses: actions/checkout@v5
   #   - name: Install Rust
   #     uses: dtolnay/rust-toolchain@stable
   #     with:
@@ -185,7 +185,7 @@ jobs:
   #         tar czf cqlite-ffi-${{ matrix.target }}.tar.gz ffi-package
   #       fi
   #   - name: Upload FFI artifact
-  #     uses: softprops/action-gh-release@v2
+  #     uses: softprops/action-gh-release@v3
   #     with:
   #       files: ./cqlite-ffi-${{ matrix.target }}.${{ matrix.target == 'x86_64-pc-windows-msvc' && 'zip' || 'tar.gz' }}
   #     env:
@@ -195,7 +195,7 @@ jobs:
   #   name: Build WASM Package
   #   runs-on: ubuntu-latest
   #   steps:
-  #   - uses: actions/checkout@v4
+  #   - uses: actions/checkout@v5
   #   - name: Install Rust
   #     uses: dtolnay/rust-toolchain@stable
   #     with:
@@ -209,7 +209,7 @@ jobs:
   #       cd cqlite-wasm/pkg
   #       tar czf ../../cqlite-wasm.tar.gz .
   #   - name: Upload WASM artifact
-  #     uses: softprops/action-gh-release@v2
+  #     uses: softprops/action-gh-release@v3
   #     with:
   #       files: ./cqlite-wasm.tar.gz
   #     env:
@@ -223,7 +223,7 @@ jobs:
   #   runs-on: ubuntu-latest
   #   if: startsWith(github.ref, 'refs/tags/v')
   #   steps:
-  #   - uses: actions/checkout@v4
+  #   - uses: actions/checkout@v5
   #   - name: Install Rust
   #     uses: dtolnay/rust-toolchain@stable
   #   - name: Publish cqlite-core

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -38,13 +38,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -54,7 +54,7 @@ jobs:
 
       - name: Restore dataset cache
         id: dataset-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: test-data/datasets
           key: datasets-${{ env.DATASET_TAG }}-${{ env.DATASET_SHA256 }}
@@ -138,7 +138,7 @@ jobs:
 
       - name: Upload smoke test results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: smoke-test-results
           path: |
@@ -149,7 +149,7 @@ jobs:
 
       - name: Upload validation matrix
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: validation-matrix
           path: test-data/validation-matrix.md

--- a/.github/workflows/sstabledump-parity-gate.yml
+++ b/.github/workflows/sstabledump-parity-gate.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -34,7 +34,7 @@ jobs:
           toolchain: stable
 
       - name: Cache Rust dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -45,7 +45,7 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Cache canonical full datasets
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: test-data/datasets/
           key: ${{ runner.os }}-datasets-${{ env.DATASET_TAG }}-${{ env.DATASET_SHA256 }}
@@ -81,7 +81,7 @@ jobs:
           test "${statistics_count}" -gt 0
 
       - name: Setup Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "17"
@@ -159,7 +159,7 @@ jobs:
 
       - name: Upload parity artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: parity-test-results
           path: |
@@ -170,7 +170,7 @@ jobs:
 
       - name: Comment on PR (Success)
         if: always() && github.event_name == 'pull_request' && steps.data_parity.outcome == 'success' && steps.index_parity.outcome == 'success' && steps.summary_parity.outcome == 'success' && steps.statistics_parity.outcome == 'success'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const summary = `## ✅ SSTableDump Parity Validation PASSED
@@ -193,7 +193,7 @@ jobs:
 
       - name: Comment on PR (Failure)
         if: always() && github.event_name == 'pull_request' && (steps.data_parity.outcome != 'success' || steps.index_parity.outcome != 'success' || steps.summary_parity.outcome != 'success' || steps.statistics_parity.outcome != 'success')
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const summary = `## ❌ SSTableDump Parity Validation FAILED

--- a/docs/plans/2026-06-11-docs-website-design.md
+++ b/docs/plans/2026-06-11-docs-website-design.md
@@ -1,0 +1,122 @@
+# Documentation Website Design
+
+**Date**: 2026-06-11
+**Status**: Validated (brainstorm with project owner)
+**Target**: Ships with v0.11.0 as a parallel epic lane
+
+## Problem
+
+CQLite's documentation is rich but scattered and repo-bound: a 22-chapter SSTable
+format guide, duplicated quick-starts in `docs/user-guides/`, API references spread
+across loose files in `docs/`, and contributor knowledge living only in `CLAUDE.md`
+and `.claude/skills/`. There is no public website beyond per-tag rustdoc on GitHub
+Pages. Two audiences are unserved:
+
+1. **Users** (humans) who need install/CLI/bindings/troubleshooting docs in a
+   browsable site.
+2. **Agents** (AI), in two distinct tracks:
+   - agents *using* CQLite as a tool or library, who need terse, copy-pasteable,
+     machine-verifiable recipes;
+   - agents *developing* CQLite, who need the contributor doctrine (gate contract,
+     no-heuristics mandate, validation workflow) in public, citable form.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Agent audiences | Both tracks, separate sections | Distinct needs: "use CQLite" vs "develop CQLite" |
+| Format guide | Publish in full | Unique asset; freshly audited to cassandra-5.0.8 (epic #598) |
+| Tooling | Astro Starlight | Multi-section sidebars, built-in search, community plugins for llms.txt and raw-markdown endpoints |
+| Sequencing | Parallel epic, ships with v0.11.0 | Docs work doesn't contend with code-epic files or reviewers |
+| Hosting | GitHub Pages, existing URL | `pmcfadin.github.io/cqlite` already enabled; site takes root, rustdoc moves to `/api/<tag>/` |
+| Versioning | Latest release only, version badge | YAGNI; pinned-version needs covered by rustdoc under `/api/<tag>/` |
+
+## Architecture
+
+One Starlight site in `website/` at the repo root, deployed to
+`pmcfadin.github.io/cqlite/` by a new `docs-site.yml` workflow publishing to the
+`gh-pages` branch root with `keep_files: true` (coexists with rustdoc trees).
+`api-docs.yml` keeps its tag trigger; its publish path changes to `/api/<tag>/`
+(and `/api/latest/`), with redirect stubs at the old per-tag URLs so links in past
+release notes keep working.
+
+Content source of truth stays in `docs/`; the site builds from it (symlinks
+preferred over a sync step to avoid drift — final call in W1 implementation).
+
+### Sections
+
+1. **User Docs** — install, quick start, CLI reference, query guide, output
+   formats (JSON/CSV/Parquet), Python bindings, Node bindings, write support,
+   troubleshooting. Consolidates `docs/user-guides/` and scattered API docs.
+2. **SSTable Format Guide** — the 22 chapters + appendices, near-verbatim;
+   work is frontmatter, link rewriting, and SVG diagram embedding.
+3. **For Agents: Using CQLite** — ~10 recipe pages, one task each: exact
+   command/code, expected output shape, exit codes, failure modes. Written
+   against the real test datasets so every example is verifiable. Error-code
+   table generalized from the Node bindings docs.
+4. **For Agents: Developing CQLite** — ~6 pages distilled from `CLAUDE.md`,
+   `.claude/skills/`, and the orchestration doctrine (#719): gate contract,
+   no-heuristics mandate, test-data fetching, key source paths, sstabledump
+   validation playbook. `CLAUDE.md` then slims to pointers at these pages.
+
+### Agent plumbing
+
+- `llms.txt` at site root: section map with one-line descriptions.
+- `llms-full.txt`: full-content variant.
+- Every page also served as raw markdown at `<page-url>.md`.
+- CI check: every published page appears in `llms.txt`; raw endpoints resolve.
+
+## Content plan
+
+Mostly moves and consolidation; new writing is concentrated in the agent tracks.
+
+- Merge `quick-start.md`, `QUICK_START_GUIDE.md`, `UAT_QUICK_START.md` into one
+  quick start; archive the losers.
+- CLI reference rebuilt from `--help` output + verified command examples (one-shot,
+  REPL, TUI, write subcommands, `--out` precedence) so it documents the actual binary.
+- Bindings pages adapted from existing Python/Node material.
+- User-facing limitations page ("What CQLite can and can't read") twinned from
+  `appendix-f-known-limitations.md` — honest about da/BTI being unsupported and
+  the v1 collection-tombstone gap (#493).
+
+## CI and quality gates
+
+Separate workflow from code gates — a docs break never blocks a code PR and
+vice versa.
+
+1. **Link check**: internal links/anchors fail the build (Starlight native);
+   external links checked weekly via lychee, not per-PR.
+2. **Example verification**: commands in the "Using CQLite" recipe pages are
+   extracted into a smoke script run against the real test datasets in CI; a
+   documented command that stops producing the documented output shape fails
+   the build. Same philosophy as sstabledump parity, applied to docs.
+3. **llms.txt validation** as above.
+
+Local loop: `npm run dev` in `website/`; `scripts/docs-site-check.sh` mirrors the
+CI checks (agent-gate pattern).
+
+## Epic breakdown
+
+| ID | Task | Size | Blocked by |
+|----|------|------|-----------|
+| W1 | Scaffold Starlight site, deploy workflow, rustdoc → `/api/` + redirects | M | — |
+| W2 | Publish Format Guide section | M | W1 |
+| W3 | User docs consolidation | M | W1 |
+| W4 | CLI reference + output formats pages | M | W1 |
+| W5 | Bindings pages (Python, Node) | S | W1 |
+| W6 | Agent track "Using CQLite" recipes + example smoke script | L | W4 |
+| W7 | Agent track "Developing CQLite" + CLAUDE.md slimming | M | W1 |
+| W8 | Agent plumbing: llms.txt, llms-full.txt, raw endpoints, validation | S | W2, W3, W6, W7 |
+
+W2–W5 and W7 are mutually independent; up to five builders can run concurrently
+after W1 lands.
+
+**Ship gate for v0.11.0**: site live with all four sections, CI checks green,
+README pointing at the site.
+
+## Out of scope (v1)
+
+- Versioned docs (rustdoc per tag covers it)
+- PR preview deploys (GitHub Pages legacy mode doesn't support them)
+- Custom domain (can be added later without breaking links)
+- Per-PR external-link checking (weekly lychee instead)


### PR DESCRIPTION
Design doc for the documentation website epic (validated in brainstorm 2026-06-11): Astro Starlight site on existing GitHub Pages, four sections (User Docs, SSTable Format Guide, Agents-Using, Agents-Developing), llms.txt + raw-markdown agent plumbing, example-verification CI. Epic and child issues W1–W8 scaffolded separately.