### PR TITLE
docs: W5 Python and Node bindings pages (#738)

### DIFF
--- a/website/src/content/docs/user-docs/nodejs.md
+++ b/website/src/content/docs/user-docs/nodejs.md
@@ -1,0 +1,343 @@
+---
+title: Node.js Bindings
+description: Install and use the @cqlite/node package to query Cassandra 5.0 SSTables from JavaScript and TypeScript.
+sidebar:
+  label: Node.js Bindings
+  order: 6
+---
+
+The `@cqlite/node` package provides direct access to Cassandra 5.0 SSTable files
+from JavaScript and TypeScript, without requiring a running Cassandra cluster.
+It ships pre-built native binaries for all major platforms.
+
+## Installation
+
+```bash
+npm install @cqlite/node
+```
+
+Requires Node.js 18+. Pre-built binaries are available for Linux (x86_64,
+ARM64), macOS (Intel and Apple Silicon), and Windows (x64).
+
+## Quick start
+
+```javascript
+const { Database } = require('@cqlite/node');
+
+(async () => {
+  const db = await Database.open('path/to/sstables', {
+    schema: 'path/to/schema.cql',
+  });
+
+  const result = await db.executeNative(
+    'SELECT id, name, age FROM test_basic.simple_table LIMIT 5'
+  );
+  console.log(`Rows: ${result.rowCount}`);
+  console.log(`Time: ${result.executionTimeMs}ms`);
+
+  for (const row of result.rows) {
+    console.log(`${row.name}: age ${row.age}`);
+  }
+
+  await db.close();
+})();
+```
+
+Running against the test datasets produces:
+
+```
+Rows: 5
+Time: 8ms
+Debbie Soto: age 79
+Richard Parker: age 58
+Andrew Meyers: age 47
+Jacqueline Davis: age 27
+Aaron Moore: age 68
+```
+
+## Opening a database
+
+`Database.open()` is the async factory method. Always call `close()` when done
+to release file handles.
+
+```javascript
+// With schema
+const db = await Database.open('/path/to/sstables', {
+  schema: '/path/to/schema.cql',
+});
+
+// With memory limit (bytes)
+const db = await Database.open('/path/to/sstables', {
+  schema: '/path/to/schema.cql',
+  memoryLimit: 256 * 1024 * 1024, // 256 MB
+});
+
+// Always close when done — close() is idempotent
+await db.close();
+await db.close(); // safe to call again
+```
+
+**`DatabaseOptions` fields**
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `schema` | `string` (optional) | — | Path to a `.cql` schema file |
+| `memoryLimit` | `number` (optional) | 1 GB | Maximum memory budget in bytes |
+| `cacheEnabled` | `boolean` (optional) | `true` | Enable block, row, and query caches |
+| `writable` | `boolean` (optional) | `false` | Enable INSERT/UPDATE/DELETE |
+| `writeDir` | `string` (optional) | — | Directory for WAL and flushed SSTables; required when `writable: true` |
+
+## executeNative() — recommended
+
+Use `executeNative()` to get native JavaScript types. It maps CQL types to
+`bigint`, `Date`, `Buffer`, `Set`, and `Map` instead of JSON-serializable values.
+
+```javascript
+const result = await db.executeNative(
+  'SELECT id, name, age, account_balance FROM test_basic.simple_table LIMIT 5'
+);
+
+for (const row of result.rows) {
+  // row.id          — string (UUID)
+  // row.name        — string
+  // row.age         — number
+  // row.account_balance — string (decimal, precision preserved)
+  console.log(row);
+}
+```
+
+## execute() and the hex-encoding caveat
+
+The older `execute()` method returns JSON-serializable values. It works well for
+most types, but encodes `varint` and `decimal` using a hex format to preserve
+arbitrary precision — output that is not human-readable:
+
+```javascript
+// Using execute() — hex encoding for varint/decimal
+const result = await db.execute('SELECT amount FROM transactions');
+console.log(result.rows[0].amount);
+// varint:  "0x7f"            (127 in two's-complement big-endian hex)
+// decimal: "decimal:2:0x7b"  (1.23 — scale 2, unscaled value 123)
+
+// Using executeNative() — human-readable (recommended)
+const native = await db.executeNative('SELECT amount FROM transactions');
+console.log(native.rows[0].amount);
+// varint:  127n    (BigInt)
+// decimal: "1.23"  (string preserving precision)
+```
+
+**Use `executeNative()` for all new code.** The `execute()` method is kept for
+backwards compatibility and JSON-serialization scenarios where you need raw,
+reversible encoding. See [issue #343](https://github.com/pmcfadin/cqlite/issues/343)
+for full details.
+
+## Type conversions
+
+| CQL Type | JavaScript Type (`executeNative`) | Notes |
+|----------|----------------------------------|-------|
+| `text`, `varchar`, `ascii` | `string` | |
+| `int`, `smallint`, `tinyint` | `number` | |
+| `float`, `double` | `number` | |
+| `bigint`, `counter` | `bigint` | Full 64-bit precision |
+| `varint` | `bigint` | Arbitrary precision |
+| `decimal` | `string` | Precision-preserving string |
+| `boolean` | `boolean` | |
+| `blob` | `Buffer` | |
+| `timestamp` | `Date` | |
+| `date` | `Date` | |
+| `time` | `bigint` | Nanoseconds since midnight |
+| `duration` | `{ months, days, nanos }` | `nanos` is `bigint` |
+| `uuid`, `timeuuid` | `string` | Lowercase formatted UUID |
+| `inet` | `string` | IP address string |
+| `list<T>` | `T[]` | |
+| `set<T>` | `Set<T>` | |
+| `map<K,V>` | `Map<K,V>` | |
+| `tuple<...>` | `[...]` | Array |
+| `frozen<T>` | Inner type | Unwrapped |
+| UDT | `object` | Includes `_type` and `_keyspace` fields |
+| `null` | `null` | |
+
+## Streaming large result sets
+
+`executeStreaming()` returns an `AsyncIterable<Row>` for memory-bounded
+iteration. Use it with `for await...of`.
+
+```javascript
+// Basic streaming
+for await (const row of db.executeStreaming('SELECT * FROM large_table')) {
+  console.log(row.name);
+}
+
+// With custom buffer sizes
+const config = { bufferSize: 256, chunkSize: 2500 };
+for await (const row of db.executeStreaming('SELECT * FROM large_table', config)) {
+  process(row);
+}
+
+// Early termination — resources cleaned up automatically
+for await (const row of db.executeStreaming('SELECT * FROM huge_table')) {
+  if (row.id === targetId) {
+    break;
+  }
+}
+```
+
+**Default memory budget (~11 MB peak):**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `bufferSize` | `1024` | Rows to hold in-flight |
+| `chunkSize` | `10000` | Rows fetched per storage read |
+
+The `StreamingResult` object also exposes `rowsReceived` and `columns` for
+progress tracking after the first row is yielded.
+
+## Error handling
+
+All CQLite errors include structured metadata for programmatic handling:
+
+```javascript
+const { Database } = require('@cqlite/node');
+
+try {
+  const db = await Database.open('/path/to/data', {
+    schema: '/path/to/schema.cql',
+  });
+  const result = await db.executeNative('SELECT * FROM keyspace.table');
+  await db.close();
+} catch (e) {
+  console.log(`Code: ${e.code}`);          // 'IO', 'SCHEMA', 'QUERY', etc.
+  console.log(`Category: ${e.category}`);  // 'System', 'Schema', 'Query', etc.
+  console.log(`Recoverable: ${e.isRecoverable}`);
+  console.log(`Message: ${e.message}`);
+}
+```
+
+**Error code reference**
+
+| Code | Category | Description | Recoverable |
+|------|----------|-------------|-------------|
+| `IO` | `System` | File system errors (access, memory, timeout) | Yes |
+| `SCHEMA` | `Schema` | Schema parsing or validation failures | No |
+| `QUERY` | `Query` | Query execution failures | No |
+| `PARSE` | `Data` | CQL syntax errors, type conversion failures | No |
+| `CONFIG` | `Configuration` | Invalid configuration | No |
+| `STORAGE` | `Storage` | Storage engine errors | No |
+| `NOT_FOUND` | `NotFound` | Table or resource not found | No |
+| `INVALID_INPUT` | `Logic` | Invalid operation (e.g. closed database) | No |
+
+## Column metadata
+
+Each query result includes `columns: ColumnInfo[]`:
+
+```javascript
+const result = await db.executeNative('SELECT * FROM test_basic.simple_table LIMIT 1');
+
+for (const col of result.columns) {
+  console.log(`${col.name}: ${col.dataType} (nullable: ${col.nullable}, pos: ${col.position})`);
+}
+// id: Text (nullable: false, pos: 0)
+// name: Text (nullable: true, pos: 1)
+// ...
+```
+
+**`ColumnInfo` fields**: `name`, `dataType`, `nullable`, `position`, `tableName`.
+
+## Database statistics
+
+```javascript
+const stats = await db.getStats();
+console.log(`SSTables: ${stats.totalSstables}`);
+console.log(`Total rows: ${stats.totalRows}`);      // bigint
+console.log(`Memory: ${stats.memoryUsedBytes}`);    // bigint
+```
+
+## Write support
+
+Open the database with `writable: true` to enable INSERT, UPDATE, and DELETE.
+
+```javascript
+const db = await Database.open('path/to/sstables', {
+  schema: 'schema.cql',
+  writable: true,
+  writeDir: '/tmp/my-writes',
+});
+
+await db.execute(
+  "INSERT INTO test_basic.simple_table (id, name, age) " +
+  "VALUES (22222222-2222-2222-2222-222222222222, 'Bob', 25)"
+);
+
+// Flush the memtable to an SSTable on disk
+const path = await db.flushRun();
+console.log('Flushed to:', path);
+
+// Incremental compaction
+let report;
+do {
+  report = await db.maintenanceStep({ budgetMs: 100 });
+  console.log(`Merged ${report.rowsMerged} rows`);
+} while (report.pendingCompaction);
+
+// Synchronous write stats getter
+const stats = db.writeStats;
+console.log(`Memtable: ${stats.memtableSize} bytes, ${stats.memtableRows} rows`);
+
+await db.close();
+```
+
+**Known write limitations**
+
+- Counter columns cannot be written; `execute()` throws `CqliteError` for counter mutations.
+- The writer produces BIG-format index files, not BTI format.
+
+## TypeScript support
+
+Complete TypeScript definitions are included in `lib/index.d.ts`:
+
+```typescript
+import { Database, DatabaseOptions, NativeQueryResult, CqliteError } from '@cqlite/node';
+
+async function query(): Promise<void> {
+  const db = await Database.open('/path/to/sstables', {
+    schema: '/path/to/schema.cql',
+  } satisfies DatabaseOptions);
+
+  const result: NativeQueryResult = await db.executeNative(
+    'SELECT * FROM test_basic.simple_table LIMIT 10'
+  );
+
+  for (const row of result.rows) {
+    const name = row.name as string;
+    console.log(name);
+  }
+
+  await db.close();
+}
+```
+
+## API reference summary
+
+| Method / property | Returns | Description |
+|-------------------|---------|-------------|
+| `Database.open(dir, options?)` | `Promise<Database>` | Open a database |
+| `db.execute(query)` | `Promise<QueryResult>` | Execute query; hex-encoded varint/decimal |
+| `db.executeNative(query)` | `Promise<NativeQueryResult>` | Execute query with native JS types (recommended) |
+| `db.executeStreaming(query, config?)` | `StreamingResult` | Memory-bounded async iteration |
+| `db.getStats()` | `Promise<DatabaseStats>` | Storage and memory metrics |
+| `db.prepare(query)` | `Promise<PreparedStatement>` | Parse and plan a query |
+| `db.flushRun()` | `Promise<string>` | Flush memtable; returns Data.db path |
+| `db.maintenanceStep(options?)` | `Promise<MaintenanceReport>` | Incremental compaction |
+| `db.writeStats` | `WriteStats` | Synchronous write engine snapshot |
+| `db.close()` | `Promise<void>` | Release resources (idempotent) |
+| `db.isClosed` | `boolean` | True if the connection is closed |
+
+Full TypeScript definitions are in
+[`bindings/node/lib/index.d.ts`](https://github.com/pmcfadin/cqlite/blob/main/bindings/node/lib/index.d.ts).
+
+## Resources
+
+- [GitHub Repository](https://github.com/pmcfadin/cqlite)
+- [npm Package](https://www.npmjs.com/package/@cqlite/node)
+- [TypeScript Definitions](https://github.com/pmcfadin/cqlite/blob/main/bindings/node/lib/index.d.ts)
+<!-- TODO(W8): link when merged -->

--- a/website/src/content/docs/user-docs/python.md
+++ b/website/src/content/docs/user-docs/python.md
@@ -1,0 +1,289 @@
+---
+title: Python Bindings
+description: Install and use the cqlite Python package to query Cassandra 5.0 SSTables without a cluster.
+sidebar:
+  label: Python Bindings
+  order: 5
+---
+
+The `cqlite` Python package provides direct access to Cassandra 5.0 SSTable files
+from Python, without requiring a running Cassandra cluster. It exposes a simple
+open/execute/stream API built on native Python types.
+
+## Installation
+
+### From PyPI (recommended)
+
+```bash
+pip install cqlite-py
+```
+
+Requires Python 3.9+. Pre-built wheels are available for Linux (x86_64, ARM64),
+macOS (Intel and Apple Silicon), and Windows (x64).
+
+### From source (development)
+
+```bash
+# Install Rust 1.85+ and maturin first
+pip install maturin
+git clone https://github.com/pmcfadin/cqlite
+cd cqlite/bindings/python
+maturin develop
+```
+
+## Quick start
+
+```python
+import cqlite
+
+# Open an SSTable directory with a CQL schema
+with cqlite.open("path/to/sstables", schema="path/to/schema.cql") as db:
+    result = db.execute("SELECT * FROM test_basic.simple_table LIMIT 5")
+    print(f"Rows returned: {len(result)}")
+    print(f"Execution time: {result.execution_time_ms}ms")
+    for row in result:
+        print(row.to_dict())
+```
+
+Running against the test datasets produces output like:
+
+```
+Rows returned: 5
+Execution time: 74ms
+{'id': UUID('0023ece7-7c4e-4705-9068-d1a59ec5fe19'), 'name': 'Debbie Soto',
+ 'age': 79, 'account_balance': Decimal('69799.73'), 'active': True,
+ 'created': datetime.datetime(2025, 10, 6, 1, 12, 5, 926000, tzinfo=datetime.timezone.utc),
+ ...}
+```
+
+## Opening a database
+
+`cqlite.open()` is the main entry point. It returns a `Database` that supports
+the context manager protocol.
+
+```python
+import cqlite
+
+# Context manager — close() called automatically on exit
+with cqlite.open("data/sstables", schema="schema.cql") as db:
+    ...
+
+# Manual lifecycle
+db = cqlite.open("data/sstables", schema="schema.cql")
+try:
+    ...
+finally:
+    db.close()  # idempotent; safe to call more than once
+```
+
+**Parameters**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `path` | `str` or `Path` | Directory containing SSTable files |
+| `schema` | `str` or `Path` (optional) | Path to a `.cql` schema file |
+| `config` | `dict` or `str` (optional) | Configuration dict or preset name |
+| `writable` | `bool` (default `False`) | Enable write support (INSERT/UPDATE/DELETE) |
+| `write_dir` | `str` or `Path` | Directory for WAL and flushed SSTables; required when `writable=True` |
+
+## Executing queries
+
+`db.execute()` runs a CQL SELECT (or DML when `writable=True`) and returns a
+`QueryResult` containing all rows.
+
+```python
+# Iterate directly over the result
+for row in db.execute("SELECT id, name, age FROM test_basic.simple_table LIMIT 10"):
+    print(f"{row['name']}: age {row['age']}")
+
+# Access metadata
+result = db.execute("SELECT * FROM test_basic.simple_table LIMIT 100")
+print(f"Rows: {len(result)}")
+print(f"Time: {result.execution_time_ms}ms")
+print(f"Columns: {[col.name for col in result.columns]}")
+```
+
+## Type conversions
+
+CQL types are mapped to native Python types automatically:
+
+| CQL Type | Python Type |
+|----------|-------------|
+| `text`, `varchar`, `ascii` | `str` |
+| `int`, `smallint`, `tinyint` | `int` |
+| `bigint`, `varint` | `int` (arbitrary precision) |
+| `float` | `float` |
+| `double` | `float` |
+| `boolean` | `bool` |
+| `blob` | `bytes` |
+| `timestamp` | `datetime.datetime` (UTC-aware) |
+| `date` | `datetime.date` |
+| `time` | `datetime.time` |
+| `duration` | `datetime.timedelta` |
+| `uuid`, `timeuuid` | `uuid.UUID` |
+| `inet` | `ipaddress.IPv4Address` or `IPv6Address` |
+| `decimal` | `decimal.Decimal` |
+| `counter` | `int` |
+| `list<T>` | `list` |
+| `set<T>` | `frozenset` |
+| `map<K,V>` | `dict` |
+| `tuple<...>` | `tuple` |
+| `frozen<T>` | Unwrapped inner type |
+| UDT | `dict` with `_type` and `_keyspace` keys |
+| `null` | `None` |
+
+## Streaming large result sets
+
+For tables with many rows, use `db.execute_streaming()` instead of
+`db.execute()`. It yields rows one at a time, keeping memory usage bounded
+regardless of result size.
+
+```python
+import cqlite
+from cqlite import StreamingConfig
+
+# Default streaming (buffers up to 1024 rows, ~11 MB peak)
+with cqlite.open("data/sstables", schema="schema.cql") as db:
+    for row in db.execute_streaming("SELECT * FROM test_basic.simple_table"):
+        process(row)
+
+# Custom config for memory-constrained environments
+config = StreamingConfig(buffer_size=256, chunk_size=2000)
+with cqlite.open("data/sstables", schema="schema.cql") as db:
+    iterator = db.execute_streaming(
+        "SELECT * FROM test_basic.simple_table", config=config
+    )
+    for row in iterator:
+        if iterator.rows_received % 1000 == 0:
+            print(f"Processed {iterator.rows_received} rows")
+```
+
+### StreamingConfig presets
+
+`StreamingConfig` takes two parameters controlling memory usage:
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `buffer_size` | `1024` | Rows to hold in-flight (~1 MB with typical rows) |
+| `chunk_size` | `10000` | Rows fetched per storage read (~10 MB per chunk) |
+
+For rows with large blobs, reduce both values proportionally.
+
+You can also open a database with a built-in memory preset:
+
+```python
+# 256 MB memory limit
+db = cqlite.open("data/sstables", schema="schema.cql", config="memory_optimized")
+
+# 4 GB memory limit
+db = cqlite.open("data/sstables", schema="schema.cql", config="performance_optimized")
+```
+
+## Error handling
+
+```python
+import cqlite
+
+try:
+    with cqlite.open("data/sstables", schema="schema.cql") as db:
+        for row in db.execute("SELECT * FROM test_basic.simple_table"):
+            print(row.to_dict())
+except cqlite.ParseError as e:
+    print(f"CQL syntax error: {e}")
+except cqlite.QueryError as e:
+    print(f"Query execution failed: {e}")
+except cqlite.SchemaError as e:
+    print(f"Schema validation failed: {e}")
+except IOError as e:
+    print(f"File not found: {e}")
+except RuntimeError as e:
+    print(f"Database already closed: {e}")
+```
+
+**Exception hierarchy**
+
+```
+CqliteError              # base exception for all CQLite errors
+├── SchemaError          # schema parsing or validation failures
+├── QueryError           # query execution failures
+└── ParseError           # CQL syntax errors
+
+Built-in exceptions also used:
+├── IOError              # file system errors
+├── ValueError           # invalid configuration
+├── RuntimeError         # invalid state (e.g. database closed)
+└── MemoryError          # memory allocation failures
+```
+
+## Write support
+
+Open the database with `writable=True` and a `write_dir` to enable INSERT,
+UPDATE, and DELETE statements.
+
+```python
+import cqlite
+
+with cqlite.open(
+    "path/to/sstables",
+    schema="schema.cql",
+    writable=True,
+    write_dir="/tmp/my-writes",
+) as db:
+    db.execute(
+        "INSERT INTO test_basic.simple_table (id, name, age) "
+        "VALUES (11111111-1111-1111-1111-111111111111, 'Alice', 30)"
+    )
+
+    # Flush in-memory writes to an SSTable on disk
+    path = db.flush_run()
+    print(f"Flushed to: {path}")
+
+    # Run incremental compaction within a time budget
+    report = db.maintenance_step(budget_ms=100)
+    print(f"Merged {report.rows_merged} rows in {report.time_spent_ms:.1f} ms")
+    if report.pending_compaction:
+        print("More compaction work available")
+
+    # Inspect write engine state
+    stats = db.write_stats
+    print(f"Memtable: {stats.memtable_size} bytes, {stats.memtable_rows} rows")
+```
+
+**Known write limitations**
+
+- Counter columns cannot be written; `execute()` raises `CqliteError` for counter mutations.
+- Concurrent queries on the same handle require a warm-up query first (see issue #311).
+
+## Thread safety
+
+`Database` handles are thread-safe via `Arc<Database>`. All blocking operations
+(`open`, `execute`, `execute_streaming`, `close`) release the Python GIL so
+other threads can run during I/O.
+
+Each thread should create its own `StreamingIterator` via `execute_streaming()`.
+Do not share a single iterator across threads.
+
+## API reference summary
+
+| Method / property | Description |
+|-------------------|-------------|
+| `cqlite.open(path, ...)` | Open a database; returns `Database` |
+| `db.execute(query)` | Run a CQL query; returns `QueryResult` |
+| `db.execute_streaming(query, config?)` | Memory-bounded row iteration; returns `StreamingIterator` |
+| `db.prepare(query)` | Parse and plan a query; returns `PreparedStatement` |
+| `db.stats()` | Storage and memory metrics; returns `DatabaseStats` |
+| `db.flush_run()` | Flush memtable to SSTable; returns Data.db path |
+| `db.maintenance_step(budget_ms)` | Incremental compaction; returns `MaintenanceReport` |
+| `db.write_stats` | Write engine snapshot; returns `WriteStats` |
+| `db.close()` | Release resources (idempotent) |
+| `db.is_closed` | `True` if the connection is closed |
+
+Full type stubs are in
+[`bindings/python/python/cqlite/__init__.pyi`](https://github.com/pmcfadin/cqlite/blob/main/bindings/python/python/cqlite/__init__.pyi).
+
+## Resources
+
+- [GitHub Repository](https://github.com/pmcfadin/cqlite)
+- [PyPI Package](https://pypi.org/project/cqlite-py/)
+- [Type Stubs](https://github.com/pmcfadin/cqlite/blob/main/bindings/python/python/cqlite/__init__.pyi)
+<!-- TODO(W8): link when merged -->


### PR DESCRIPTION
Part of epic #733. Closes #738.

## Summary

- Adds `website/src/content/docs/user-docs/python.md`: install (pip/maturin), open/execute usage, CQL→Python type table, streaming with `StreamingConfig` presets, error hierarchy, write support, thread-safety notes
- Adds `website/src/content/docs/user-docs/nodejs.md`: install, `executeNative()` recommendation with the `execute()` hex-encoding caveat (#343), error-code table, streaming with `for await`, CQL→JS type table, TypeScript definitions

## Validation

All code examples were run against real Cassandra 5.0 test data (datasets-v3 / `cassandra5-small-full-v3.1.tar.gz`).

**Python example run output (verified):**
```
cqlite version: 0.10.0
Rows returned: 5
Execution time: 74ms
Columns: ['account_balance', 'active', 'age', ...]
{'id': UUID('0023ece7-7c4e-4705-9068-d1a59ec5fe19'), 'name': 'Debbie Soto', 'age': 79, ...}
```

**Node.js executeNative() example run output (verified):**
```
Rows: 5
Execution time: 8ms
{ id: '0023ece7-7c4e-4705-9068-d1a59ec5fe19', name: 'Debbie Soto', age: 79, balance: '69799.73' }
```

**docs-site-check result:**
```
DOCS_SITE_CHECK=PASS
```

**Changed files (only):**
```
website/src/content/docs/user-docs/nodejs.md
website/src/content/docs/user-docs/python.md
```