### PR TITLE
docs: W9 use-case pages (#743)

### DIFF
--- a/website/src/content/docs/user-docs/use-cases/index.md
+++ b/website/src/content/docs/user-docs/use-cases/index.md
@@ -1,0 +1,38 @@
+---
+title: Use Cases
+description: When and why to use CQLite — narrative architecture guides for common patterns.
+sidebar:
+  label: Overview
+  order: 0
+---
+
+# Use Cases
+
+These pages explain *when* and *why* to reach for CQLite, not just *how* to use its
+APIs. Each page covers a concrete pattern, shows what is working today, and is honest
+about what is still in progress.
+
+## Pages in this section
+
+| Page | What it covers |
+|------|----------------|
+| [Lakehouse projections with the Cassandra Sidecar](/cqlite/user-docs/use-cases/sidecar-lakehouse/) | SSTable-to-Parquet pipeline architecture, the delta-semantics caveat, and what epics #673/#682/#696 unlock |
+| [Python: data science and ETL](/cqlite/user-docs/use-cases/python-data-science/) | Offline analytics on snapshots and backups without a cluster; pandas and notebook workflows |
+| [Node.js: services and tooling](/cqlite/user-docs/use-cases/nodejs-services/) | Data inspection services, ops dashboards, `executeNative` + streaming patterns |
+| [Operational scenarios](/cqlite/user-docs/use-cases/operational/) | Migration validation, test fixtures from production data, backup and snapshot inspection |
+
+## Common thread
+
+All four use cases share the same core property: **no cluster dependency in the read
+path.** CQLite reads Cassandra 5.0 SSTables directly from the filesystem. That opens
+up workflows that would otherwise require a live Cassandra cluster — offline analytics,
+CI fixtures, DR validation, lakehouse projection — while keeping the toolchain simple.
+
+## What CQLite is not (yet)
+
+- Not a real-time replication solution. Reads are per-SSTable batch operations.
+- Not a query engine for the data lake. It produces files and rows; Spark, Trino,
+  DuckDB, or pandas consume them.
+- Not a replacement for the Cassandra query path for production traffic.
+
+See [GitHub Issues](https://github.com/pmcfadin/cqlite/issues) for the roadmap.

--- a/website/src/content/docs/user-docs/use-cases/nodejs-services.md
+++ b/website/src/content/docs/user-docs/use-cases/nodejs-services.md
@@ -1,0 +1,280 @@
+---
+title: "Node.js: Services and Tooling"
+description: How to use the CQLite Node.js bindings to build data inspection services, ops dashboards, and CLI tools that read Cassandra SSTables without a live cluster.
+sidebar:
+  label: Node.js / Services
+  order: 3
+---
+
+# Node.js: Services and Tooling
+
+The CQLite Node.js bindings (`@cqlite/node`, built with napi-rs) let you read
+Cassandra 5.0 SSTables from Node.js — no cluster, no JVM, no Cassandra driver.
+
+This page covers the services and tooling use case: data inspection APIs, operational
+dashboards, async streaming for large result sets, and native JavaScript type handling.
+
+<!-- TODO(W5): link to full Node.js bindings API reference when merged -->
+
+## Installation
+
+```bash
+npm install @cqlite/node
+```
+
+Or build from source:
+
+```bash
+git clone https://github.com/pmcfadin/cqlite
+cd cqlite/bindings/node
+npm install
+npm run build      # requires Rust 1.85+
+```
+
+## The core pattern
+
+```javascript
+const { Database } = require("@cqlite/node");
+
+const db = await Database.open("/path/to/sstables", {
+  schema: "/path/to/schema.cql",
+});
+
+const result = await db.executeNative(
+  "SELECT * FROM my_keyspace.my_table LIMIT 100"
+);
+console.log(`${result.rowCount} rows in ${result.executionTimeMs}ms`);
+
+for (const row of result.rows) {
+  console.log(row);
+}
+
+await db.close();
+```
+
+Use `executeNative()` rather than the deprecated `execute()`. It returns native
+JavaScript types: `BigInt` for 64-bit integers, `Date` for timestamps, `Buffer` for
+blobs, `Set` and `Map` for collection types. `execute()` uses hex-encoded strings for
+`varint` and `decimal`, which is harder to work with.
+
+## Complete example: data inspection service
+
+This example was run against the real CQLite test datasets and its output is shown below.
+
+```javascript
+const { Database } = require("@cqlite/node");
+const path = require("path");
+
+const DATASETS = path.resolve("test-data/datasets/sstables");
+const SCHEMA   = path.resolve("test-data/schemas/basic-types.cql");
+
+async function inspectTable() {
+  const db = await Database.open(DATASETS, { schema: SCHEMA });
+
+  try {
+    const result = await db.executeNative(
+      "SELECT id, name, age, active, account_balance " +
+      "FROM test_basic.simple_table LIMIT 3"
+    );
+
+    console.log(`rowCount: ${result.rowCount}`);
+    console.log(`executionTimeMs: ${result.executionTimeMs}`);
+    console.log("columns:", result.columns.map(c => `${c.name}:${c.dataType}`));
+    console.log();
+
+    for (const row of result.rows) {
+      // account_balance is returned as a string for decimal types
+      console.log(JSON.stringify(row));
+    }
+  } finally {
+    await db.close();
+  }
+}
+
+inspectTable().catch(console.error);
+```
+
+**Actual output** (run against `test_basic.simple_table`):
+
+```
+rowCount: 3
+executionTimeMs: 9
+columns: [ 'name:Text', 'age:Integer', 'account_balance:Decimal', 'id:Uuid', 'active:Boolean' ]
+
+{"name":"Debbie Soto","age":79,"account_balance":"69799.73","id":"0023ece7-7c4e-4705-9068-d1a59ec5fe19","active":true}
+{"active":false,"name":"Richard Parker","id":"009fb913-7173-40df-b4ea-67ed6834cfe5","age":58,"account_balance":"74196.78"}
+{"active":false,"name":"Andrew Meyers","age":47,"account_balance":"47110.15","id":"00a74226-9bde-4259-9ba0-d74359e8013e"}
+```
+
+## CQL → JavaScript type mapping (`executeNative`)
+
+| CQL type | JavaScript type |
+|----------|----------------|
+| boolean | `boolean` |
+| tinyint, smallint, int | `number` |
+| bigint, counter | `BigInt` |
+| float, double | `number` |
+| decimal, varint | `string` (decimal string representation) |
+| text, varchar, ascii | `string` |
+| blob | `Buffer` |
+| timestamp | `Date` |
+| date | `string` (`"YYYY-MM-DD"`) |
+| time | `string` (`"HH:MM:SS.nnnnnnnnn"`) |
+| uuid, timeuuid | `string` (standard hyphenated UUID format) |
+| duration | `object` `{ months, days, nanoseconds: BigInt }` |
+| inet | `string` |
+| list, set | `Array` |
+| map | `Map` |
+| tuple | `Array` |
+| UDT | `object` (field name → value) |
+
+## Streaming for memory-bounded iteration
+
+For large tables, `executeStreaming()` returns an async iterable. Rows are streamed
+from the SSTable rather than loaded all at once:
+
+```javascript
+const { Database } = require("@cqlite/node");
+const path = require("path");
+
+const DATASETS = path.resolve("test-data/datasets/sstables");
+const SCHEMA   = path.resolve("test-data/schemas/basic-types.cql");
+
+async function streamRows() {
+  const db = await Database.open(DATASETS, { schema: SCHEMA });
+
+  try {
+    let count = 0;
+    const stream = await db.executeStreaming(
+      "SELECT name, age, salary FROM test_basic.simple_table"
+    );
+
+    for await (const row of stream) {
+      count++;
+      // process each row without accumulating all in memory
+    }
+
+    console.log(`Streamed ${count} rows`);
+  } finally {
+    await db.close();
+  }
+}
+
+streamRows().catch(console.error);
+```
+
+**Actual output** (run against `test_basic.simple_table`, 100 rows):
+
+```
+Streamed 100 rows
+```
+
+Default buffer size is 1,024 rows (~11 MB peak). Pass a `StreamingConfig` to tune:
+
+```javascript
+const stream = await db.executeStreaming(query, {
+  chunkSize: 500,   // rows per internal chunk
+  bufferSize: 2048, // max buffered rows
+});
+```
+
+## Error handling
+
+All errors thrown by `@cqlite/node` include `code`, `category`, and `isRecoverable`
+properties:
+
+```javascript
+try {
+  const result = await db.executeNative("SELECT * FROM nonexistent.table");
+} catch (err) {
+  console.error(err.message);      // human-readable message
+  console.error(err.code);         // e.g. "NOT_FOUND", "SCHEMA", "IO"
+  console.error(err.category);     // e.g. "NotFound", "Schema"
+  console.error(err.isRecoverable); // boolean: retry vs. fix the input
+}
+```
+
+| Code | Category | When it fires |
+|------|----------|---------------|
+| `IO` | System | File access, memory, timeout |
+| `SCHEMA` | Schema | Table not found, schema mismatch |
+| `QUERY` | Query | CQL syntax error |
+| `PARSE` | Data | Binary format parsing error |
+| `NOT_FOUND` | NotFound | SSTable or keyspace not found |
+| `INVALID_INPUT` | Logic | Invalid operation or state |
+
+## Building an Express inspection API
+
+```javascript
+const express = require("express");
+const { Database } = require("@cqlite/node");
+const path = require("path");
+
+const app = express();
+let db;
+
+async function start() {
+  db = await Database.open(process.env.SSTABLE_DIR, {
+    schema: process.env.SCHEMA_FILE,
+  });
+
+  app.get("/tables/:keyspace/:table", async (req, res) => {
+    const { keyspace, table } = req.params;
+    const limit = Math.min(parseInt(req.query.limit ?? "100"), 1000);
+
+    try {
+      const result = await db.executeNative(
+        `SELECT * FROM ${keyspace}.${table} LIMIT ${limit}`
+      );
+      res.json({
+        rowCount: result.rowCount,
+        executionTimeMs: result.executionTimeMs,
+        columns: result.columns,
+        rows: result.rows,
+      });
+    } catch (err) {
+      const status = err.code === "NOT_FOUND" ? 404 : 500;
+      res.status(status).json({ error: err.message, code: err.code });
+    }
+  });
+
+  app.listen(3000, () => console.log("Listening on :3000"));
+}
+
+start().catch(err => { console.error(err); process.exit(1); });
+```
+
+## TypeScript support
+
+`@cqlite/node` ships complete TypeScript definitions in `lib/index.d.ts`:
+
+```typescript
+import { Database, QueryResult, ColumnInfo, StreamingConfig } from "@cqlite/node";
+
+const db: Database = await Database.open("/path/to/sstables", {
+  schema: "/path/to/schema.cql",
+});
+
+const result: QueryResult = await db.executeNative(
+  "SELECT * FROM my_ks.my_table LIMIT 10"
+);
+
+for (const col of result.columns as ColumnInfo[]) {
+  console.log(`${col.name}: ${col.dataType} (nullable: ${col.nullable})`);
+}
+```
+
+## What you cannot do (yet)
+
+- **Write back to SSTables from Node.js.** The write API is in the core library but not
+  yet exposed in the Node.js bindings.
+- **Export Parquet directly from Node.js.** Use the CLI `--out parquet` flag for now.
+  [Epic #682](https://github.com/pmcfadin/cqlite/issues/682) tracks this *(in progress)*.
+- **Collection type fidelity in Parquet export.** Lists and maps are stringified.
+  [Epic #673](https://github.com/pmcfadin/cqlite/issues/673) tracks this *(in progress)*.
+
+## Further reading
+
+- [GitHub repository](https://github.com/pmcfadin/cqlite)
+- [API reference](/cqlite/api/latest/)
+<!-- TODO(W5): link to Node.js bindings reference page when merged -->

--- a/website/src/content/docs/user-docs/use-cases/operational.md
+++ b/website/src/content/docs/user-docs/use-cases/operational.md
@@ -1,0 +1,263 @@
+---
+title: "Operational Scenarios"
+description: Using CQLite for migration validation, generating test fixtures from production data, and inspecting Cassandra backups and snapshots without a live cluster.
+sidebar:
+  label: Operational
+  order: 4
+---
+
+# Operational Scenarios
+
+CQLite's no-cluster-dependency model makes it useful for several operational
+tasks that normally require a running Cassandra instance. This page covers three
+patterns: migration validation, test fixture generation from production data, and
+backup/snapshot inspection.
+
+## Migration validation
+
+When migrating between Cassandra clusters, versions, or schemas, you need to verify
+that the data in the new cluster matches the source. CQLite lets you read the source
+SSTables directly from a backup or snapshot — no source cluster required.
+
+### Row count and schema smoke test
+
+```bash
+# Count rows in the source SSTable
+cqlite --schema source-schema.cql \
+       --data-dir /mnt/cassandra-backup/data/my_ks/my_table-<uuid>/ \
+       --query "SELECT COUNT(*) FROM my_ks.my_table" \
+       --out json
+
+# Sample rows from the source for spot-checking
+cqlite --schema source-schema.cql \
+       --data-dir /mnt/cassandra-backup/data/my_ks/my_table-<uuid>/ \
+       --query "SELECT * FROM my_ks.my_table LIMIT 1000" \
+       --out csv > source-sample.csv
+```
+
+Then compare against the target cluster's output to validate row counts and
+spot-check values.
+
+### Python validation script
+
+```python
+import cqlite
+import json
+
+SOURCE_SSTABLES = "/mnt/cassandra-backup/data"
+SOURCE_SCHEMA   = "/etc/cassandra-schemas/my_keyspace.cql"
+
+# Read source SSTables
+with cqlite.open(SOURCE_SSTABLES, schema=SOURCE_SCHEMA) as db:
+    result = db.execute("SELECT id, checksum_field FROM my_ks.my_table")
+    source_rows = {row.get("id"): row.get("checksum_field") for row in result.rows}
+
+print(f"Source: {len(source_rows)} rows")
+
+# Compare against target (using your Cassandra driver of choice)
+# target_rows = query_target_cluster(...)
+# mismatches = {k for k in source_rows if source_rows[k] != target_rows.get(k)}
+# print(f"Mismatches: {len(mismatches)}")
+```
+
+### What CQLite validates and what it does not
+
+CQLite reads each SSTable's own view of the data. It does **not**:
+
+- Merge multiple SSTables the way a live Cassandra node does (compaction merges cells
+  via last-write-wins). For a fully merged view, point `--data-dir` at the full table
+  directory, not a single SSTable generation.
+- Validate against compaction state or repair history.
+- Resolve TTL expirations at query time relative to a wall clock (TTL behaviour
+  may differ between source and target if substantial time has passed).
+
+For high-confidence migration validation, use both CQLite for a quick structural
+check and a secondary validation against a restored cluster.
+
+## Test fixtures from production data
+
+Running integration tests against a live production cluster is risky and slow.
+CQLite lets you export a sanitized slice of production SSTables as test fixtures:
+
+### Extract a fixture slice
+
+```bash
+# Export a deterministic slice to JSON for use as test fixtures
+cqlite --schema prod-schema.cql \
+       --data-dir /mnt/prod-backup/data/app_ks/users-<uuid>/ \
+       --query "SELECT id, name, email, role FROM app_ks.users LIMIT 200" \
+       --out json > tests/fixtures/users-sample.json
+```
+
+### Sanitize PII before committing fixtures
+
+```python
+import cqlite
+import json
+import hashlib
+
+SOURCE_SSTABLES = "/mnt/prod-backup/data"
+SCHEMA          = "/etc/cassandra-schemas/app.cql"
+OUTPUT          = "tests/fixtures/users-anonymised.json"
+
+def anonymise(row: dict) -> dict:
+    """Replace PII fields with deterministic hashes."""
+    out = dict(row)
+    if "email" in out and out["email"]:
+        out["email"] = hashlib.sha256(str(out["email"]).encode()).hexdigest()[:12] + "@test.example"
+    if "name" in out and out["name"]:
+        out["name"] = "User-" + hashlib.sha256(str(out["id"]).encode()).hexdigest()[:8]
+    return out
+
+with cqlite.open(SOURCE_SSTABLES, schema=SCHEMA) as db:
+    result = db.execute(
+        "SELECT id, name, email, role, created FROM app_ks.users LIMIT 500"
+    )
+    rows = [anonymise(row.to_dict()) for row in result.rows]
+
+with open(OUTPUT, "w") as f:
+    json.dump(rows, f, indent=2, default=str)
+
+print(f"Written {len(rows)} anonymised rows to {OUTPUT}")
+```
+
+### Use fixtures in CI
+
+Once exported, fixtures are plain JSON files that work with any test framework —
+no Cassandra connection needed in CI:
+
+```python
+import json
+import pytest
+
+@pytest.fixture
+def sample_users():
+    with open("tests/fixtures/users-anonymised.json") as f:
+        return json.load(f)
+
+def test_user_roles(sample_users):
+    roles = {row["role"] for row in sample_users}
+    assert "admin" in roles or "user" in roles
+```
+
+## Backup and snapshot inspection
+
+Cassandra's `nodetool snapshot` and cloud backup tools (Medusa, Priam) produce
+directories of SSTable files. CQLite can read them directly without restoring to
+a cluster first.
+
+### Quick health check on a backup
+
+```bash
+# Verify a backup is readable and contains expected data
+cqlite --schema schema.cql \
+       --data-dir /mnt/backup/2025-01-15/my_ks/events-<uuid>/ \
+       --query "SELECT COUNT(*) FROM my_ks.events" \
+       --out json
+```
+
+### List all tables in a backup directory
+
+```bash
+# Inspect what's in a backup (shell, not CQL)
+find /mnt/backup/data -name "TOC.txt" \
+  | sed 's|.*/\([^/]*/[^/]*\)/.*|\1|' \
+  | sort -u
+```
+
+### Spot-check specific rows
+
+```bash
+# Check if a specific partition exists in a backup
+cqlite --schema schema.cql \
+       --data-dir /mnt/backup/data/my_ks/orders-<uuid>/ \
+       --query "SELECT order_id, status, total FROM my_ks.orders WHERE order_id = 12345" \
+       --out json
+```
+
+### Python: audit backup completeness
+
+```python
+import cqlite
+import os
+from pathlib import Path
+
+BACKUP_ROOT = Path("/mnt/cassandra-backup/data")
+SCHEMA      = "/etc/cassandra-schemas/my_keyspace.cql"
+
+# Find all SSTable directories for a keyspace
+ks_path = BACKUP_ROOT / "my_ks"
+table_dirs = [d for d in ks_path.iterdir() if d.is_dir()]
+
+print(f"Found {len(table_dirs)} table directories")
+
+with cqlite.open(str(BACKUP_ROOT), schema=SCHEMA) as db:
+    result = db.execute("SELECT COUNT(*) FROM my_ks.orders")
+    rows = result.rows
+    if rows:
+        print("Order count:", rows[0].to_dict())
+```
+
+### Disaster recovery validation
+
+CQLite is useful in DR drills: given a set of SSTables extracted from a backup,
+verify that critical data is present and readable before committing to a full
+cluster restore:
+
+```bash
+#!/usr/bin/env bash
+# dr-validate.sh — quick sanity check on a restored backup
+
+SCHEMA="/etc/cassandra-schemas/critical.cql"
+DATA_DIR="/mnt/dr-restore/data"
+
+for table in critical_ks.accounts critical_ks.transactions; do
+    count=$(cqlite --schema "$SCHEMA" \
+                   --data-dir "$DATA_DIR" \
+                   --query "SELECT COUNT(*) FROM $table" \
+                   --out json 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print(d[0].get('count(*)', 0))" 2>/dev/null || echo "ERROR")
+    echo "$table: $count rows"
+done
+```
+
+## Schema evolution inspection
+
+When you need to understand what columns existed at a particular point in time
+(from a backup), or when a live schema change has made old SSTables ambiguous:
+
+```bash
+# Inspect the Statistics.db.txt file (no CQLite needed — plain text)
+cat /mnt/backup/data/my_ks/my_table-<uuid>/nb-1-big-Statistics.db.txt
+
+# Read using the old schema to see what columns were populated
+cqlite --schema old-schema.cql \
+       --data-dir /mnt/backup/data/my_ks/my_table-<uuid>/ \
+       --query "SELECT * FROM my_ks.my_table LIMIT 5" \
+       --out json
+```
+
+:::caution
+CQLite requires a schema file to decode SSTables (no-heuristics mandate). If the
+schema has evolved since the backup was taken, use the schema that was in effect
+when the backup was created, not the current schema. Decoding with a mismatched
+schema can produce incorrect values or errors.
+:::
+
+## What you cannot do (yet)
+
+- **Full compaction merge across all SSTables in a keyspace.** CQLite reads the
+  SSTables you point it at. If those span multiple non-merged generations, duplicate
+  partition keys appear as separate rows. For a fully merged view, point at the full
+  table directory or run `nodetool compact` before exporting.
+- **Schema-free inspection.** CQLite always requires a schema file. If you have lost
+  the schema, use `DESCRIBE TABLE` from `cqlsh` on a running cluster, or extract it
+  from `system_schema.tables` in an older backup.
+- **Real-time CDC / streaming from commitlog.** [Epic #696](https://github.com/pmcfadin/cqlite/issues/696)
+  tracks delta-scan and CDC-style projections *(in progress)*.
+
+## Further reading
+
+- [GitHub repository](https://github.com/pmcfadin/cqlite)
+- [API reference](/cqlite/api/latest/)
+<!-- TODO(W4): link to CLI reference when merged -->
+<!-- TODO(W5): link to Python and Node bindings pages when merged -->

--- a/website/src/content/docs/user-docs/use-cases/python-data-science.md
+++ b/website/src/content/docs/user-docs/use-cases/python-data-science.md
@@ -1,0 +1,243 @@
+---
+title: "Python: Data Science and ETL"
+description: How to use the CQLite Python bindings for offline analytics on Cassandra snapshots and backups — pandas workflows, streaming for large tables, and ETL patterns without a live cluster.
+sidebar:
+  label: Python / Data Science
+  order: 2
+---
+
+# Python: Data Science and ETL
+
+The CQLite Python bindings (`cqlite` package, built with PyO3) let you read
+Cassandra 5.0 SSTables directly in Python — no cluster, no JVM, no Cassandra driver.
+
+This page covers the data-science and ETL use case: offline analytics on snapshots
+and backups, pandas integration, and memory-bounded streaming for large tables.
+
+<!-- TODO(W5): link to full Python bindings API reference when merged -->
+
+## Installation
+
+```bash
+pip install cqlite
+```
+
+Or build from source for the latest development version:
+
+```bash
+git clone https://github.com/pmcfadin/cqlite
+cd cqlite/bindings/python
+pip install maturin
+maturin develop        # development build, editable install
+```
+
+Requires Python 3.9+ and Rust 1.85+ (for source builds only).
+
+## The core pattern
+
+```python
+import cqlite
+
+with cqlite.open("/path/to/sstables", schema="/path/to/schema.cql") as db:
+    result = db.execute("SELECT * FROM my_keyspace.my_table LIMIT 100")
+    for row in result.rows:
+        print(row.to_dict())
+```
+
+The `schema` parameter is a CQL file containing `CREATE TABLE` statements.
+CQLite requires it to decode binary SSTable data — there is no guessing from bytes.
+
+`cqlite.open()` works as a context manager; `db.close()` is idempotent and safe to
+call from any thread.
+
+## Complete example: pandas analytics on a Cassandra backup
+
+This example was run against the real CQLite test datasets and its output is shown
+below.
+
+```python
+import cqlite
+import pandas as pd
+from decimal import Decimal
+
+DATASETS = "test-data/datasets/sstables"
+SCHEMA   = "test-data/schemas/basic-types.cql"
+
+with cqlite.open(DATASETS, schema=SCHEMA) as db:
+    result = db.execute(
+        "SELECT name, age, salary, account_balance, active "
+        "FROM test_basic.simple_table LIMIT 10"
+    )
+
+    # Build a DataFrame from the result rows
+    rows = [row.to_dict() for row in result.rows]
+    df = pd.DataFrame(rows)
+
+    # CQLite returns Decimal for decimal columns — convert to float for pandas math
+    df["account_balance"] = df["account_balance"].apply(float)
+
+    print("DataFrame shape:", df.shape)
+    print()
+    print("Column dtypes:")
+    print(df.dtypes)
+    print()
+    print("Summary statistics:")
+    print(df[["age", "salary", "account_balance"]].describe().round(2))
+    print()
+    active = df[df["active"] == True]
+    print(f"Active users: {len(active)} of {len(df)}")
+    if len(active) > 0:
+        print(f"  Average salary: {active['salary'].mean():.2f}")
+```
+
+**Actual output** (run against `test_basic.simple_table`, 10 rows):
+
+```
+DataFrame shape: (10, 5)
+
+Column dtypes:
+salary               int64
+age                  int64
+name                   str
+active                bool
+account_balance    float64
+dtype: object
+
+Summary statistics:
+         age     salary  account_balance
+count  10.00      10.00            10.00
+mean   49.20  123326.50         54020.85
+std    20.43   45608.41         24617.66
+min    18.00   44179.00          2656.69
+25%    31.00   89334.50         44476.72
+50%    52.50  132994.50         62270.92
+75%    64.00  161093.50         71958.12
+max    79.00  175802.00         80199.79
+
+Active users: 4 of 10
+  Average salary: 127350.50
+```
+
+## CQL → Python type mapping
+
+| CQL type | Python type |
+|----------|-------------|
+| boolean | `bool` |
+| tinyint, smallint, int, bigint, counter | `int` |
+| float, double | `float` |
+| decimal, varint | `decimal.Decimal` |
+| text, varchar, ascii | `str` |
+| blob | `bytes` |
+| timestamp | `datetime.datetime` (timezone-aware, UTC) |
+| date | `datetime.date` |
+| time | `datetime.time` |
+| uuid, timeuuid | `uuid.UUID` |
+| duration | `datetime.timedelta` |
+| inet | `ipaddress.IPv4Address` or `ipaddress.IPv6Address` |
+| list, set | `list` |
+| map | `dict` |
+| tuple | `tuple` |
+| UDT | `dict` (field name → value) |
+
+## Streaming for large tables
+
+For large tables where loading all rows into memory is impractical, use
+`db.execute_streaming()`. It returns a lazy iterator; rows are decoded one at a
+time and never buffered in bulk:
+
+```python
+import cqlite
+
+DATASETS = "test-data/datasets/sstables"
+SCHEMA   = "test-data/schemas/basic-types.cql"
+
+with cqlite.open(DATASETS, schema=SCHEMA) as db:
+    count = 0
+    total_balance = 0.0
+
+    for row in db.execute_streaming(
+        "SELECT name, age, account_balance FROM test_basic.simple_table"
+    ):
+        d = row.to_dict()
+        total_balance += float(d["account_balance"])
+        count += 1
+
+    print(f"Processed {count} rows, total balance: {total_balance:.2f}")
+```
+
+**Actual output** (run against `test_basic.simple_table`):
+
+```
+Processed 100 rows, total balance: 5482530.44
+```
+
+The streaming iterator releases the Python GIL during I/O, so it is safe to use
+from multiple threads (each with its own iterator).
+
+## ETL pattern: snapshot to CSV / Parquet
+
+```python
+import cqlite
+import csv
+import io
+
+DATASETS = "/mnt/cassandra-backup/data"
+SCHEMA   = "/etc/cassandra-schemas/my_keyspace.cql"
+OUTPUT   = "/tmp/my_table_export.csv"
+
+with cqlite.open(DATASETS, schema=SCHEMA) as db:
+    result = db.execute("SELECT * FROM my_keyspace.my_table")
+    columns = [c.name for c in result.columns]
+
+    with open(OUTPUT, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=columns)
+        writer.writeheader()
+        for row in result.rows:
+            writer.writerow(row.to_dict())
+
+print(f"Exported {len(result.rows)} rows to {OUTPUT}")
+```
+
+For Parquet output, use the CLI with `--out parquet`
+<!-- TODO(W4): link to output formats page when merged -->.
+Native Parquet export from the Python bindings is planned in
+[epic #682](https://github.com/pmcfadin/cqlite/issues/682) *(in progress)*.
+
+## Notebook workflow
+
+In a Jupyter or Colab notebook:
+
+```python
+# Cell 1: imports and setup
+import cqlite
+import pandas as pd
+
+DATASETS = "/path/to/cassandra-snapshot"
+SCHEMA   = "/path/to/schema.cql"
+
+# Cell 2: load data
+with cqlite.open(DATASETS, schema=SCHEMA) as db:
+    result = db.execute("SELECT * FROM my_ks.events WHERE date = '2025-01-01'")
+    df = pd.DataFrame([row.to_dict() for row in result.rows])
+
+# Cell 3: explore
+df.head()
+df.describe()
+df["event_type"].value_counts().plot(kind="bar")
+```
+
+## What you cannot do (yet)
+
+- **Write back to SSTables from Python.** The write API is in the core library but not
+  yet exposed in the Python bindings. Tracked in the write support roadmap.
+- **Export Parquet directly from Python.** Use the CLI `--out parquet` flag for now.
+  [Epic #682](https://github.com/pmcfadin/cqlite/issues/682) tracks this *(in progress)*.
+- **Collection type fidelity in Parquet export.** Lists and maps are currently stringified
+  in Parquet output. [Epic #673](https://github.com/pmcfadin/cqlite/issues/673) tracks
+  this *(in progress)*.
+
+## Further reading
+
+- [GitHub repository](https://github.com/pmcfadin/cqlite)
+- [API reference](/cqlite/api/latest/)
+<!-- TODO(W5): link to Python bindings reference page when merged -->

--- a/website/src/content/docs/user-docs/use-cases/sidecar-lakehouse.md
+++ b/website/src/content/docs/user-docs/use-cases/sidecar-lakehouse.md
@@ -1,0 +1,213 @@
+---
+title: "Lakehouse Projections with the Cassandra Sidecar"
+description: How to use CQLite alongside the Cassandra Sidecar to materialize Parquet projections from SSTable flush events — architecture, delta semantics, and what is still in progress.
+sidebar:
+  label: Sidecar / Lakehouse
+  order: 1
+---
+
+# Lakehouse Projections with the Cassandra Sidecar
+
+This page explains how CQLite fits into a **Parquet projection pipeline** that is
+triggered by Cassandra SSTable flush events, co-located with the
+[Apache Cassandra Sidecar](https://github.com/apache/cassandra-sidecar).
+
+The internal position document (`docs/architecture/cassandra-sidecar-parquet-projections.md`)
+is the authoritative source of truth for CQLite maintainers. This page is the
+user-facing distillation.
+
+## What is already built
+
+The read-to-Parquet pipeline is largely in place:
+
+1. **CQLite reads externally-discovered SSTables** via `open_with_discovered_sstables()` —
+   the integration hook for "the Sidecar told me where a new SSTable is, read it."
+2. **Memory-bounded streaming reads** via `execute_streaming()` keep peak memory
+   predictable on large tables.
+3. **Parquet output** is available via `--out parquet` in the CLI.
+
+A minimal per-SSTable projection is already expressible as a one-shot CLI call:
+
+```bash
+cqlite --schema users.cql \
+       --data-dir /var/lib/cassandra/data/my_ks/users-<uuid>/ \
+       --query "SELECT * FROM my_ks.users" \
+       --out parquet -o /projections/users/nb-<gen>.parquet
+```
+
+## Architecture
+
+```
+┌─────────────────┐   flush     ┌──────────────────────┐
+│  Cassandra node │────────────▶│  data dir (SSTables) │
+└─────────────────┘  new SSTable└──────────┬───────────┘
+                                            │ TOC.txt appears (file complete)
+                                ┌───────────▼───────────┐
+                                │  Projection service   │  (co-located w/ Sidecar)
+                                │  - detect new SSTable  │
+                                │  - debounce + dedupe   │
+                                └───────────┬───────────┘
+                                            │ path + keyspace/table + schema
+                                ┌───────────▼───────────┐
+                                │  CQLite                │
+                                │  open_with_discovered_ │
+                                │    sstables()          │
+                                │  execute_streaming()   │
+                                │  StreamingParquetWriter│
+                                └───────────┬───────────┘
+                                            │
+                                ┌───────────▼───────────┐
+                                │  /projections/<ks>/    │
+                                │    <table>/nb-<gen>.parquet
+                                │  (ideally Iceberg/Delta)
+                                └────────────────────────┘
+```
+
+### Trigger options
+
+The Sidecar does not expose a push stream of "memtable flushed" events. Options:
+
+| Trigger | Mechanism | Trade-off |
+|---------|-----------|-----------|
+| Filesystem watch | `inotify` on the table data dir; key on `TOC.txt` (written last ⇒ SSTable complete) | Simplest, reliable; per-host |
+| Commitlog CDC | Cassandra CDC on the commitlog | Ordered + carries timestamps; closest to correct CDC; more setup |
+| Sidecar API polling | Diff SSTable component listings per table | Easy; latency = poll interval |
+| Diagnostic events / JMX | SSTable lifecycle notifications | JVM-side; reintroduces a cluster dependency |
+
+For a simple bulk projection, **filesystem watch keyed on `TOC.txt`** is the pragmatic
+default. For correctness-sensitive pipelines, commitlog CDC is the better source — see
+the delta semantics section below for why.
+
+:::note
+A `*-Data.db` file appearing is not always a memtable flush — it can also be a
+**compaction** output. For downstream lake purposes this is usually fine (and often
+desirable), but if "flush only" semantics matter, the source must distinguish them.
+:::
+
+## ⚠ Delta semantics — this caveat is load-bearing
+
+**A flushed SSTable is a *delta*, not a table snapshot.**
+
+This is inherent to Cassandra's storage model — not a CQLite defect. Four properties
+combine to make a naive Parquet-union of per-flush files silently wrong:
+
+1. **Rows are partial / superseded.** The same primary key can appear across many
+   SSTables; the live value is the per-cell last-write-wins (LWW) merge of all of them.
+   One flush's Parquet reflects only that flush's writes.
+
+2. **Tombstones carry deletes.** A flush can contain row, range, or cell tombstones and
+   TTL expirations. The current projection has no representation of these, so a naive
+   union of insert rows will **resurrect deleted data**.
+
+3. **Reconciliation requires write-timestamps.** LWW merge is driven by each cell's
+   `writetime`. A plain `SELECT *` drops it, so two flushes cannot be correctly merged
+   downstream without it.
+
+4. **Absent-vs-null is collapsed.** CQLite's `SELECT *` flattens Cassandra's sparse
+   cell-sets into a rectangular result; a cell not written in a particular flush is
+   indistinguishable from a null.
+
+### Two coherent approaches — pick deliberately
+
+**CDC / append-log projection (recommended).** Treat each flushed SSTable as an
+immutable event batch → one Parquet file per generation. Embrace that it is a delta.
+For correctness, **carry `writetime` and represent tombstones** (e.g. `__writetime` /
+`__deleted` columns, Debezium-style). Downstream (Spark/Trino/Iceberg) performs the
+merge. Idempotent; matches the immutable-SSTable grain.
+
+**Current-snapshot projection.** To reflect current table state, point
+`open_with_discovered_sstables()` at *all* live SSTables for the table so CQLite's read
+path performs the LWW merge, then export. Correct, but re-reads everything on each flush.
+
+## Type mapping fidelity (current state)
+
+Scalars map cleanly to Parquet. Collection and complex types are **currently lossy**:
+
+| CQL type | Arrow/Parquet | Fidelity |
+|----------|---------------|----------|
+| boolean, tinyint … bigint, float, double | Boolean, Int8/16/32/64, Float32/64 | Clean |
+| text / varchar / ascii | Utf8 | Clean |
+| blob | Binary | Clean |
+| timestamp | Timestamp(ms, UTC) | Clean |
+| uuid / timeuuid | FixedSizeBinary(16) | Raw bytes (no logical UUID annotation) |
+| date | Int32 | Days-since-epoch as plain int, not Arrow `Date32` |
+| time | Int64 | Nanos as plain int, not Arrow `Time64` |
+| list / set | `List<Utf8>` | **Elements stringified** |
+| map | `Map<Utf8, Utf8>` | **Keys and values stringified** |
+| tuple / UDT / frozen | Utf8 | **Whole value serialized to one string** |
+| varint, decimal, inet, duration | string fallback | Lossy |
+
+Tables of scalars (IDs, metrics, timestamps, text) project faithfully. The moment
+collections, UDTs, or `decimal`/`varint` appear, nested structure and element typing
+collapse to strings, which defeats columnar predicate pushdown in downstream consumers.
+
+This is the single highest-value engineering investment for the lakehouse use case.
+
+## What epics #673, #682, and #696 unlock
+
+These three in-progress epics complete the lakehouse story:
+
+**[Epic #673: Parquet/Arrow type-mapping fidelity](https://github.com/pmcfadin/cqlite/issues/673)**
+*(in progress)*
+
+Upgrades `ColumnInfo` to carry the authoritative schema `CqlType`, maps `list<T>` /
+`set<T>` as `List<T>` with typed elements, `map<K,V>` as Arrow `Map<K,V>`, and UDTs /
+tuples as Arrow `Struct`. Scalar types gain `Date32`, `Time64(ns)`, `Decimal128`, and
+UUID annotations. Without this epic, collection columns cannot support predicate
+pushdown in Trino, Spark, or DuckDB.
+
+**[Epic #682: Lift Parquet writer into cqlite-core](https://github.com/pmcfadin/cqlite/issues/682)**
+*(in progress)*
+
+Moves the Parquet writer from `cqlite-cli` into `cqlite-core` behind a `parquet`
+feature flag. Today, embedding projection in a long-running service requires shelling
+out to the CLI. After this epic, a projection service can call the writer directly as a
+library without a subprocess, and the Python and Node bindings can export Parquet.
+
+**[Epic #696: Delta-scan envelope for CDC-style projections](https://github.com/pmcfadin/cqlite/issues/696)**
+*(in progress)*
+
+Implements a `scan_delta` streaming API that emits `DeltaRecord`s with per-cell
+`writetime`, `expires_at`, and an `__op` discriminator covering all five Cassandra
+delete shapes (`upsert`, `static_upsert`, `row_delete`, `range_delete`,
+`partition_delete`). Paired with a `DeltaParquetWriter` and a `cqlite delta-export`
+CLI subcommand. This is what makes CDC-mode projections reconcilable downstream.
+
+## Schema sourcing
+
+CQLite requires the CQL schema to decode an SSTable (no-heuristics mandate, issue #28).
+The projection service must source and cache the schema — flush events do not carry it.
+The practical approach is to pull it from `DESCRIBE TABLE` output and keep it in sync
+with schema changes.
+
+## Comparison with TiDB's approach
+
+TiDB's TiFlash is instructive: it is a Raft learner that receives every committed write
+in real-time, providing a strongly consistent, transactionally-consistent columnar
+replica. TiCDC (the structural analog to this pipeline) tails the ordered row-change
+log and emits Kafka or cloud-storage changefeeds with explicit insert/update/delete
+events and commit timestamps.
+
+Our approach's distinct value is **open, lake-native columnar output from Cassandra with
+no cluster dependency in the read path**. The trade-off is that Cassandra has no ordered
+committed log — its source of truth is independently-flushed, LWW-merged SSTables — so
+any columnar projection is inherently a delta-reconciliation problem. Epics #673, #682,
+and #696 each address one part of that problem.
+
+## Recommendations
+
+1. **Model it as CDC/append-log, not snapshot.** It matches the immutable-SSTable grain
+   and is idempotent per generation.
+2. **Land in a table format (Iceberg or Delta), not bare Parquet files.** Those provide
+   snapshot isolation, compaction, and merge-on-read that otherwise you must build by hand.
+3. **Preserve `writetime` and represent tombstones** (`__writetime` / `__deleted`
+   columns) so projections are reconcilable. Without this, a union of per-flush Parquet
+   is silently wrong.
+4. **Prefer commitlog CDC over raw flush events** when correctness matters.
+5. **Upgrade the Arrow type mapping** (epic #673) before calling the pipeline
+   analytics-grade.
+6. **Lift the Parquet writer into `cqlite-core`** (epic #682) if you want embeddable
+   non-CLI projection.
+
+<!-- TODO(W4): link to CLI reference when merged -->
+<!-- TODO(W5): link to Python and Node bindings pages when merged -->


### PR DESCRIPTION
Part of epic #733. Closes #743.

## Summary

- Adds `website/src/content/docs/user-docs/use-cases/` as a new Starlight sidebar group
- Five pages: group overview + four use-case narratives

### Pages added

| File | Description |
|------|-------------|
| `use-cases/index.md` | Group overview with links to all four pages |
| `use-cases/sidecar-lakehouse.md` | Distills the position doc: sidecar pattern, `open_with_discovered_sstables` + `execute_streaming` hooks, **delta-not-snapshot caveat** (load-bearing, not softened), epics #673/#682/#696 linked and marked in-progress |
| `use-cases/python-data-science.md` | Offline analytics, pandas workflow, streaming; includes a complete example actually executed against real test datasets |
| `use-cases/nodejs-services.md` | `executeNative` + streaming patterns, TypeScript definitions, error codes; includes a complete example actually executed |
| `use-cases/operational.md` | Migration validation, test fixture generation from production data, backup/snapshot inspection, DR validation |

### No capability overclaiming

Every in-progress feature is explicitly marked with its tracking issue:
- Epic #673 (type-mapping fidelity) — Parquet collection types
- Epic #682 (embeddable writer) — Parquet from Python/Node
- Epic #696 (delta-scan) — CDC-mode projections

### Validation evidence

`bash scripts/docs-site-check.sh` output:
```
DOCS_SITE_CHECK=PASS
✓ All internal links are valid.
14 page(s) built successfully
```

`git diff --name-only origin/main...HEAD` — only files under the owned directory:
```
website/src/content/docs/user-docs/use-cases/index.md
website/src/content/docs/user-docs/use-cases/nodejs-services.md
website/src/content/docs/user-docs/use-cases/operational.md
website/src/content/docs/user-docs/use-cases/python-data-science.md
website/src/content/docs/user-docs/use-cases/sidecar-lakehouse.md
```

Python example executed output (from `test_basic.simple_table`, 10 rows):
```
DataFrame shape: (10, 5)
mean age: 49.20, mean salary: 123326.50, mean balance: 54020.85
Active users: 4 of 10
```

Node.js example executed output (3 rows):
```
rowCount: 3
executionTimeMs: 9
{"name":"Debbie Soto","age":79,"account_balance":"69799.73","id":"0023ece7-7c4e-4705-9068-d1a59ec5fe19","active":true}
```

## Test plan

- [x] `bash scripts/docs-site-check.sh` passes with `DOCS_SITE_CHECK=PASS`
- [x] All internal links validate (no relative `./` links — all absolute `/cqlite/` paths)
- [x] Python example executed against real test datasets (bindings built with maturin)
- [x] Node.js example executed against real test datasets (bindings built with npm run build)
- [x] Only files under `website/src/content/docs/user-docs/use-cases/` touched
- [x] No edits to `astro.config.mjs` or any other existing file