### PR TITLE
docs: W3 user docs consolidation (#736)

### DIFF
--- a/docs/archive/user-guides-superseded/QUICK_START_GUIDE.md
+++ b/docs/archive/user-guides-superseded/QUICK_START_GUIDE.md
@@ -1,3 +1,5 @@
+> **ARCHIVED** — superseded by `website/src/content/docs/user-docs/quick-start.md` (issue #736).
+
 # 🚀 CQLite Issue #17 - Quick Start Guide
 
 ## How to Run and Test the Cassandra 5+ SSTable Reader

--- a/docs/archive/user-guides-superseded/UAT_QUICK_START.md
+++ b/docs/archive/user-guides-superseded/UAT_QUICK_START.md
@@ -1,3 +1,5 @@
+> **ARCHIVED** — superseded by `website/src/content/docs/user-docs/quick-start.md` (issue #736).
+
 # CQLite UAT Quick Start Guide
 
 ## 🚀 5-Minute Validation Test

--- a/docs/archive/user-guides-superseded/cli.md
+++ b/docs/archive/user-guides-superseded/cli.md
@@ -1,3 +1,5 @@
+> **ARCHIVED** — CLI reference content will be migrated to `website/src/content/docs/user-docs/cli-reference.md` in W4 (issue #736). Current source archived here to avoid orphaning.
+
 # CQLite CLI User Guide
 
 ## Quick Start with Cassandra 5+ SSTable Files

--- a/docs/archive/user-guides-superseded/demo_real_data.md
+++ b/docs/archive/user-guides-superseded/demo_real_data.md
@@ -1,3 +1,5 @@
+> **ARCHIVED** — internal development notes from early demo work; not migrated to the documentation site (issue #736).
+
 # 🚀 CQLite Real Data Demo - WORKING!
 
 ## 🎯 What We Have Successfully Built

--- a/docs/archive/user-guides-superseded/installation.md
+++ b/docs/archive/user-guides-superseded/installation.md
@@ -1,3 +1,5 @@
+> **ARCHIVED** — superseded by `website/src/content/docs/user-docs/installation.md` (issue #736). Note: this file described aspirational features (Docker Hub images, Kubernetes Helm, OAuth2, etc.) not yet shipped; the site page documents what is actually available.
+
 # CQLite Installation and Setup Guide
 
 ## 🎯 **Complete Installation Solution**

--- a/docs/archive/user-guides-superseded/quick-start.md
+++ b/docs/archive/user-guides-superseded/quick-start.md
@@ -1,3 +1,5 @@
+> **ARCHIVED** — superseded by `website/src/content/docs/user-docs/quick-start.md` (issue #736).
+
 # CQLite Quick Start Guide
 
 ## 🎯 Fast Track to Implementation

--- a/docs/archive/user-guides-superseded/troubleshooting.md
+++ b/docs/archive/user-guides-superseded/troubleshooting.md
@@ -1,3 +1,5 @@
+> **ARCHIVED** — superseded by `website/src/content/docs/user-docs/troubleshooting.md` (issue #736). Note: this file described aspirational features (server mode, Kubernetes, enterprise support) not yet shipped; the site page documents real, tested scenarios only.
+
 # CQLite Troubleshooting Guide
 
 ## 🎯 **Complete Problem Resolution Guide**

--- a/website/src/content/docs/user-docs/index.md
+++ b/website/src/content/docs/user-docs/index.md
@@ -8,27 +8,43 @@ sidebar:
 
 # User Docs
 
-This section covers everything you need to install and use CQLite.
+Everything you need to install, configure, and use CQLite.
 
-> **Content arriving in W2–W3.** This placeholder marks the section structure.
-> Full content — installation guides, CLI reference, query guide, output formats,
-> Python bindings, Node.js bindings, write support, troubleshooting, and use cases —
-> will be published as part of issues #W3, #W4, #W5, and #W9 in epic #733.
+CQLite reads Cassandra 5.0 SSTables directly from disk — no cluster, no JVM, no
+daemon required.
 
-## What you'll find here (W3 onwards)
+## In this section
 
-- **Installation** — Rust library, Python package, Node.js module
-- **Quick Start** — get a query running in under 5 minutes
-- **CLI Reference** — all flags, subcommands, and output format options
-- **Query Guide** — supported CQL syntax, filtering, and ordering
-- **Output Formats** — JSON, CSV, Parquet
-- **Python Bindings** — `cqlite` Python package usage and API
-- **Node.js Bindings** — `@cqlite/node` usage and API
-- **Write Support** — mutations, flush, compaction
-- **Use Cases** — Cassandra sidecar/lakehouse, data science, services, operational scenarios
-- **Troubleshooting** — common issues and solutions
+### Getting started
 
-## Links
+- [Quick Start](/cqlite/user-docs/quick-start/) — run your first query in under five minutes
+- [Installation](/cqlite/user-docs/installation/) — prebuilt binaries, cargo, pip, npm paths for all platforms
+
+### Reference
+
+<!-- TODO(W8): link CLI Reference when merged (W4 issue) -->
+**CLI Reference** — all flags, subcommands, and one-shot / REPL / TUI modes *(arriving in W4)*
+
+<!-- TODO(W8): link Output Formats when merged (W4 issue) -->
+**Output Formats** — JSON, CSV, Parquet *(arriving in W4)*
+
+<!-- TODO(W8): link Python Bindings when merged (W5 issue) -->
+**Python Bindings** — `cqlite-py` API reference *(arriving in W5)*
+
+<!-- TODO(W8): link Node.js Bindings when merged (W5 issue) -->
+**Node.js Bindings** — `@cqlite/node` API reference *(arriving in W5)*
+
+### Topics
+
+- [Write Support](/cqlite/user-docs/write-support/) — offline SSTable writing, flush, compaction (M5)
+- [Limitations](/cqlite/user-docs/limitations/) — what CQLite can and cannot read (format matrix, known gaps)
+- [Troubleshooting](/cqlite/user-docs/troubleshooting/) — common problems and fixes
+
+<!-- TODO(W8): link Use Cases when merged (W9 issue) -->
+**Use Cases** — Cassandra sidecar, data science, services, operational scenarios *(arriving in W9)*
+
+## Quick links
 
 - [GitHub Repository](https://github.com/pmcfadin/cqlite)
 - [API Reference](/cqlite/api/latest/)
+- [SSTable Format Guide](/cqlite/sstable-format/) — 22-chapter deep dive into the on-disk format

--- a/website/src/content/docs/user-docs/installation.md
+++ b/website/src/content/docs/user-docs/installation.md
@@ -1,0 +1,193 @@
+---
+title: Installation
+description: Install the CQLite CLI, Rust library, Python package, or Node.js module.
+sidebar:
+  label: Installation
+  order: 2
+---
+
+# Installation
+
+CQLite ships in four forms: a prebuilt CLI binary (the fastest way to start), a
+Rust library crate, a Python package, and a Node.js package.
+
+## Prebuilt CLI binaries
+
+Each [GitHub release](https://github.com/pmcfadin/cqlite/releases) attaches a
+prebuilt `cqlite` binary and a `.sha256` checksum sidecar for six platforms:
+
+| Platform | Asset |
+|----------|-------|
+| macOS Apple Silicon | `cqlite-aarch64-apple-darwin.tar.gz` |
+| macOS Intel | `cqlite-x86_64-apple-darwin.tar.gz` |
+| Linux x86_64 (glibc) | `cqlite-x86_64-unknown-linux-gnu.tar.gz` |
+| Linux x86_64 (musl/static) | `cqlite-x86_64-unknown-linux-musl.tar.gz` |
+| Linux arm64 (glibc) | `cqlite-aarch64-unknown-linux-gnu.tar.gz` |
+| Windows x86_64 | `cqlite-x86_64-pc-windows-gnu.zip` |
+
+### macOS
+
+```bash
+# Apple Silicon
+TARGET=aarch64-apple-darwin
+
+# Intel Mac — uncomment this line instead:
+# TARGET=x86_64-apple-darwin
+
+curl -fsSLO https://github.com/pmcfadin/cqlite/releases/latest/download/cqlite-$TARGET.tar.gz
+curl -fsSLO https://github.com/pmcfadin/cqlite/releases/latest/download/cqlite-$TARGET.tar.gz.sha256
+shasum -a 256 -c cqlite-$TARGET.tar.gz.sha256
+tar xzf cqlite-$TARGET.tar.gz
+./cqlite --version
+```
+
+### Linux
+
+```bash
+# x86_64 glibc (most common, requires glibc >= 2.17)
+TARGET=x86_64-unknown-linux-gnu
+
+# x86_64 musl (fully static, runs everywhere including Alpine containers)
+# TARGET=x86_64-unknown-linux-musl
+
+# ARM64 (glibc)
+# TARGET=aarch64-unknown-linux-gnu
+
+curl -fsSLO https://github.com/pmcfadin/cqlite/releases/latest/download/cqlite-$TARGET.tar.gz
+curl -fsSLO https://github.com/pmcfadin/cqlite/releases/latest/download/cqlite-$TARGET.tar.gz.sha256
+sha256sum -c cqlite-$TARGET.tar.gz.sha256
+tar xzf cqlite-$TARGET.tar.gz
+sudo mv cqlite /usr/local/bin/
+cqlite --version
+```
+
+### Windows
+
+Download `cqlite-x86_64-pc-windows-gnu.zip` from the
+[releases page](https://github.com/pmcfadin/cqlite/releases/latest), extract it,
+and add the folder to your `PATH`. Then verify:
+
+```powershell
+cqlite --version
+```
+
+## Build from source (Rust)
+
+Requires Rust 1.85+. Install Rust via [rustup.rs](https://rustup.rs) if needed.
+
+```bash
+git clone https://github.com/pmcfadin/cqlite.git
+cd cqlite
+cargo build --release
+
+# The binary is at ./target/release/cqlite
+./target/release/cqlite --version
+```
+
+To build with write support (M5 feature):
+
+```bash
+cargo build --package cqlite-cli --features write-support --release
+```
+
+## Python package
+
+Requires Python 3.9+ and a supported platform (Linux x86_64/arm64, macOS x86_64/arm64,
+Windows x86_64).
+
+```bash
+pip install cqlite-py
+```
+
+Verify the install:
+
+```python
+import cqlite
+print(cqlite.__version__)
+```
+
+If the import fails after install, see [Troubleshooting](/cqlite/user-docs/troubleshooting/#python-import-errors-after-install).
+
+### Build the Python package from source
+
+Requires Rust 1.85+ and [maturin](https://www.maturin.rs/).
+
+```bash
+pip install maturin
+cd bindings/python
+maturin develop          # development build (editable)
+# maturin build --release  # release wheel
+```
+
+## Node.js package
+
+Requires Node.js 18+ and npm.
+
+```bash
+npm install @cqlite/node
+```
+
+Verify:
+
+```javascript
+const { Database } = require('@cqlite/node');
+console.log('CQLite Node.js bindings loaded');
+```
+
+If the native module fails to load, check that your platform is in the supported
+list (Linux x86_64/arm64, macOS x86_64/arm64, Windows x86_64) and file a
+[bug report](https://github.com/pmcfadin/cqlite/issues) if it is.
+
+### Build the Node.js package from source
+
+```bash
+cd bindings/node
+npm install
+npm run build
+npm test
+```
+
+## Using CQLite as a Rust library
+
+Add `cqlite-core` to your `Cargo.toml`:
+
+```toml
+[dependencies]
+cqlite-core = { git = "https://github.com/pmcfadin/cqlite.git" }
+```
+
+Default features include `all-compression` (LZ4, Snappy, Deflate, Zstd) and
+`state_machine` (query engine). For a minimal build without the query engine:
+
+```toml
+cqlite-core = { git = "…", default-features = false, features = ["all-compression"] }
+```
+
+## Feature flags (cqlite-core)
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `all-compression` | yes | LZ4, Snappy, Deflate, Zstd support |
+| `state_machine` | yes | Query engine and schema-based discovery |
+| `cli-helpers` | no | CLI-specific ingestion and REPL API |
+| `metrics` | no | Performance metrics collection |
+| `experimental` | no | Experimental / unstable features |
+
+## Verify your installation
+
+Regardless of how you installed CQLite, verify it can parse real data:
+
+```bash
+# Fetch the test datasets (requires git clone)
+bash test-data/scripts/fetch-datasets.sh
+
+# Run a query against them
+cqlite \
+  --schema test-data/schemas/basic-types.cql \
+  --data-dir test-data/datasets/sstables \
+  --query "SELECT * FROM test_basic.simple_table LIMIT 3" \
+  --out json
+```
+
+If you see three JSON rows, you are ready to go.
+If you see errors, check [Troubleshooting](/cqlite/user-docs/troubleshooting/).

--- a/website/src/content/docs/user-docs/limitations.md
+++ b/website/src/content/docs/user-docs/limitations.md
@@ -1,0 +1,171 @@
+---
+title: Limitations
+description: What CQLite can and cannot read — honest about unsupported formats, index types, and known gaps.
+sidebar:
+  label: Limitations
+  order: 6
+---
+
+# Limitations — What CQLite Can and Cannot Read
+
+CQLite is production-ready for the common case: reading Cassandra 5.0 BIG-format
+SSTables with standard data types. This page is honest about what it cannot do yet,
+so you know before you depend on it.
+
+For the exhaustive engineering detail, see the source document in the repository:
+`docs/sstables-definitive-guide/chapters/appendix-f-known-limitations.md`
+<!-- TODO(W8): replace with site link when the SSTable Format Guide section is merged -->
+
+## Format support
+
+| SSTable format | Cassandra versions | CQLite support |
+|----------------|-------------------|----------------|
+| `nb-*-big-*` (BIG format) | Cassandra 5.0+ | **Full** — all 33 test tables pass |
+| `md-*` | Cassandra 4.0–4.1 | **Not supported** |
+| `mc-*` | Cassandra 3.11 | **Not supported** |
+| `la-*`, `ma-*` | Cassandra 3.x | **Not supported** |
+| BTI format (Partitions.db / Rows.db) | Cassandra 5.0 opt-in | **Partial** — see below |
+
+CQLite targets Cassandra 5.0 exclusively. If you need older formats, export your
+data with Cassandra's `sstabledump` tool first.
+
+## Index types
+
+### BIG format — full support
+
+The default Cassandra 5.0 index format (`nb-*-big-Index.db` / `nb-*-big-Summary.db`)
+is fully supported. All 33 test tables in the CQLite test corpus use this format and
+pass validation against `sstabledump` output.
+
+### BTI format — partial support
+
+BTI (trie-based index) is an opt-in, experimental feature in Cassandra 5.0, requiring
+`selected_format: bti` in `cassandra.yaml`. It produces `Partitions.db` and `Rows.db`
+files instead of the standard `Index.db`.
+
+Current BTI status:
+
+- Format detection works (magic number `0x6461`)
+- Byte-comparable encoding (CEP-25) is implemented
+- Trie node structure parsing is partially implemented
+- Range queries and full partition iteration are **not implemented**
+- No BTI test data exists in the test corpus (BTI requires explicit opt-in at the cluster level)
+
+**In practice**: because BTI requires explicit opt-in, it is rarely used in production.
+If you use BTI, CQLite will fall back to a sequential scan of `Data.db` which is
+functionally correct but O(n) instead of O(log n) for partition lookups.
+
+## Data type support
+
+All CQL primitive types are supported. Collections and complex types are fully
+supported in read mode (all 33 test tables, including UDTs, frozen collections, and
+nested collections, pass 100% of validation tests).
+
+| Type category | Examples | Read support | Write support |
+|---------------|---------|-------------|--------------|
+| Primitives | `text`, `int`, `uuid`, `timestamp`, `boolean`, `blob`, `inet` | Full | Full |
+| Large numerics | `varint`, `decimal`, `counter` | Full | Full |
+| Collections | `list<T>`, `set<T>`, `map<K,V>` | Full | Full |
+| Frozen collections | `frozen<list<T>>`, `frozen<map<K,V>>` | Full | Full |
+| User-defined types (UDTs) | `CREATE TYPE …` | Full | Full |
+| Tuples | `tuple<T1, T2>` | Full | Full |
+| Nested collections | `map<text, frozen<list<int>>>` | Full | Full |
+
+## Write support limitations
+
+CQLite M5.1 introduces SSTable write support. The implementation is correct and
+produces Cassandra-compatible SSTables, but includes some known trade-offs:
+
+### Promoted index deferred
+
+`Index.db` entries always write `promoted_index_length = 0`.
+
+**Impact**: wide partitions with 10 000+ rows per partition cannot use fast
+within-partition seeks. CQLite must scan rows linearly within the partition.
+
+- Narrow partitions (less than 100 rows): no impact
+- Wide partitions (10 000+ rows): O(n) linear scan within the partition
+
+### BTI format writing not implemented
+
+The write engine produces BIG-format SSTables only. BTI-format writing
+(`Partitions.db`, `Rows.db`) is not implemented.
+
+**Rationale**: BTI is opt-in in Cassandra 5.0 and covers less than 5% of production
+deployments. BIG format covers all current use cases.
+
+### IndexWriter memory buffering
+
+The `IndexWriter` buffers all index entries in memory until `finish()` is called.
+
+**Impact**: approximately 20 MB per 1 million partitions. For extremely large SSTables
+(hundreds of millions of partitions), split writes into multiple generation files.
+
+### Compaction not yet executable
+
+The k-way merge compaction API is defined (STCS policy, `maintenance_step()`, etc.)
+but execution requires M5.3 SSTable reader integration to convert entries back to
+mutations. `set_merge_policy()` currently returns an error.
+
+**Impact**: `maintenance_step()` currently performs flush operations only. Full
+compaction is deferred to M5.3.
+
+## Query engine limitations
+
+| Feature | Status |
+|---------|--------|
+| `SELECT` with `LIMIT` | Full |
+| `SELECT` with partition-key `WHERE` | Full |
+| `SELECT` with clustering-key `WHERE` | Partial (point-lookup path works; range filtering via residual scan) |
+| `ORDER BY` | Not implemented |
+| `INSERT` / `UPDATE` / `DELETE` via CQL | Requires write-support feature flag; write mutations via API |
+| Aggregate functions (`COUNT`, `SUM`, etc.) | Not implemented |
+| `GROUP BY` | Not implemented |
+
+## Collection tombstone gap (issue #493)
+
+Set element tombstones — individual element deletions inside a `set<T>` — are not
+fully surfaced. Rows containing only element tombstones may appear empty rather
+than absent. This affects a narrow edge case and is tracked in
+[issue #493](https://github.com/pmcfadin/cqlite/issues/493) for v0.9.1.
+
+## Operational constraints
+
+- **Local files only**: CQLite reads SSTable files from the local filesystem.
+  There is no network protocol, no cluster connection, and no Cassandra driver.
+- **No live cluster writes**: You can write SSTables offline and load them into
+  Cassandra with `nodetool refresh`, but CQLite does not connect to a running cluster.
+- **Single-node perspective**: CQLite reads one SSTable at a time. It has no
+  knowledge of replication, consistency levels, or coordinator routing.
+- **Memory target**: CQLite targets less than 128 MB for files up to 1 GB.
+  Files larger than 1 GB may require the streaming API or a partition-key filter.
+
+## Workarounds for unsupported scenarios
+
+### Cassandra 3.x / 4.x SSTables
+
+Upgrade your cluster to Cassandra 5.0 and run:
+
+```bash
+nodetool upgradesstables
+```
+
+or use Cassandra's `sstabledump` to export to JSON and reimport.
+
+### BTI format (trie index)
+
+If your Cassandra cluster is configured with `selected_format: bti`, CQLite will
+still return correct results via sequential scan fallback. For large tables the
+scan may be slow; partition-key `WHERE` filters help bound the scan.
+
+### Wide partitions
+
+For partitions with thousands of rows and a specific clustering-key range,
+a `WHERE` clause that includes the partition key will let CQLite locate the
+partition quickly via the index and then scan within it:
+
+```cql
+SELECT * FROM my_ks.my_table
+WHERE user_id = 42 AND timestamp > '2025-01-01'
+LIMIT 1000;
+```

--- a/website/src/content/docs/user-docs/quick-start.md
+++ b/website/src/content/docs/user-docs/quick-start.md
@@ -1,0 +1,169 @@
+---
+title: Quick Start
+description: Get CQLite running and query a Cassandra 5.0 SSTable in under five minutes.
+sidebar:
+  label: Quick Start
+  order: 1
+---
+
+# Quick Start
+
+This guide gets you from nothing to a working CQLite query in under five minutes.
+CQLite reads Cassandra 5.0 SSTables directly from disk — no cluster, no JVM, no daemon.
+
+## What you need
+
+- A CQLite binary (see [Installation](/cqlite/user-docs/installation/))
+- A Cassandra 5.0 SSTable directory (`nb-1-big-Data.db` and siblings), **or** the
+  bundled test data (option A below)
+
+## Option A — Use the bundled test data (fastest)
+
+If you cloned the repository you can fetch the real Cassandra 5.0 test datasets and
+run the one-shot CLI immediately.
+
+```bash
+# Fetch test datasets (~50 MB tarball, real Cassandra 5.0 SSTables)
+bash test-data/scripts/fetch-datasets.sh
+
+# Run a query — JSON output to stdout
+cargo run --package cqlite-cli -- \
+  --schema test-data/schemas/basic-types.cql \
+  --data-dir test-data/datasets/sstables \
+  --query "SELECT * FROM test_basic.simple_table LIMIT 5" \
+  --out json
+```
+
+Expected output (abbreviated):
+
+```json
+[
+  {"id":"…","name":"Alice","age":30},
+  {"id":"…","name":"Bob","age":25}
+]
+```
+
+## Option B — Use your own Cassandra 5.0 data
+
+### 1. Locate your SSTables
+
+Cassandra 5.0 stores SSTables under the data directory, one subdirectory per table:
+
+```
+/var/lib/cassandra/data/
+└── my_keyspace/
+    └── my_table-{uuid}/
+        ├── nb-1-big-Data.db
+        ├── nb-1-big-Index.db
+        ├── nb-1-big-Summary.db
+        ├── nb-1-big-Statistics.db
+        ├── nb-1-big-CompressionInfo.db
+        ├── nb-1-big-Filter.db
+        └── nb-1-big-TOC.txt
+```
+
+### 2. Provide a schema file
+
+CQLite needs a `.cql` schema file describing the table structure.
+Create one from your existing Cassandra keyspace:
+
+```cql
+-- my_keyspace.cql
+CREATE KEYSPACE my_keyspace
+  WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};
+
+USE my_keyspace;
+
+CREATE TABLE my_table (
+    id   UUID    PRIMARY KEY,
+    name TEXT,
+    age  INT
+);
+```
+
+You can export the schema directly from `cqlsh`:
+
+```bash
+cqlsh -e "DESCRIBE KEYSPACE my_keyspace" > my_keyspace.cql
+```
+
+### 3. Run a query
+
+```bash
+cqlite \
+  --schema my_keyspace.cql \
+  --data-dir /var/lib/cassandra/data/my_keyspace \
+  --query "SELECT * FROM my_keyspace.my_table LIMIT 10" \
+  --out json
+```
+
+## Python
+
+Install the Python binding, then open a dataset and run a query:
+
+```bash
+pip install cqlite-py
+```
+
+```python
+import cqlite
+
+with cqlite.open('test-data/datasets/sstables',
+                 schema='test-data/schemas/basic-types.cql') as db:
+    for row in db.execute('SELECT * FROM test_basic.simple_table LIMIT 5'):
+        print(row.to_dict())
+```
+
+## Node.js
+
+```bash
+npm install @cqlite/node
+```
+
+```javascript
+import { Database } from '@cqlite/node';
+
+const db = await Database.open('test-data/datasets/sstables', {
+  schema: 'test-data/schemas/basic-types.cql',
+});
+const result = await db.executeNative(
+  'SELECT * FROM test_basic.simple_table LIMIT 5'
+);
+for (const row of result.rows) {
+  console.log(row.name);
+}
+await db.close();
+```
+
+## CLI modes
+
+Beyond one-shot mode shown above, the CLI offers an interactive REPL and a TUI:
+
+```bash
+# Interactive REPL
+cqlite --schema my_keyspace.cql --data-dir /path/to/sstables repl
+
+# Full terminal UI
+cqlite --schema my_keyspace.cql --data-dir /path/to/sstables tui
+```
+
+In REPL mode:
+
+```
+[OK] Mem: 24.5 MB | Data: 1.2 GB
+cqlite> SELECT * FROM my_keyspace.my_table LIMIT 5;
+```
+
+## What CQLite cannot do (yet)
+
+- Query Cassandra 3.x or 4.x SSTables (Cassandra 5.0 `nb-*-big-*` format only)
+- Read BTI-format SSTables (the opt-in `bti` index format; see [Limitations](/cqlite/user-docs/limitations/))
+- Run against a live Cassandra cluster — CQLite works on local files only
+
+For a full list, see [Limitations](/cqlite/user-docs/limitations/).
+
+## Next steps
+
+- [Installation](/cqlite/user-docs/installation/) — prebuilt binaries, cargo, pip, npm
+- [Troubleshooting](/cqlite/user-docs/troubleshooting/) — common issues and fixes
+<!-- TODO(W8): link CLI reference, Output Formats, Python, Node.js when merged -->

--- a/website/src/content/docs/user-docs/troubleshooting.md
+++ b/website/src/content/docs/user-docs/troubleshooting.md
@@ -1,0 +1,228 @@
+---
+title: Troubleshooting
+description: Common problems and solutions when installing and using CQLite.
+sidebar:
+  label: Troubleshooting
+  order: 5
+---
+
+# Troubleshooting
+
+This page covers the most common problems users encounter with CQLite. If you
+do not find your answer here, check the
+[GitHub issues](https://github.com/pmcfadin/cqlite/issues) or open a new one.
+
+## Installation
+
+### `command not found: cqlite`
+
+The binary is not on your `PATH`.
+
+```bash
+# Verify the binary exists
+ls -la $(which cqlite 2>/dev/null || echo "NOT FOUND")
+
+# Add the directory to PATH permanently (bash/zsh)
+echo 'export PATH="/usr/local/bin:$PATH"' >> ~/.bashrc  # or ~/.zshrc
+source ~/.bashrc
+
+# Verify
+cqlite --version
+```
+
+On macOS with Homebrew-style installations, the binary might be in
+`/usr/local/bin` or `~/.local/bin`. Check both.
+
+### Binary not compatible with my OS/architecture
+
+Download the correct asset for your platform from the
+[releases page](https://github.com/pmcfadin/cqlite/releases):
+
+- macOS Apple Silicon: `cqlite-aarch64-apple-darwin.tar.gz`
+- macOS Intel: `cqlite-x86_64-apple-darwin.tar.gz`
+- Linux x86_64 (any distro): use the `musl` variant for maximum compatibility
+- Linux ARM64: `cqlite-aarch64-unknown-linux-gnu.tar.gz`
+
+See [Installation](/cqlite/user-docs/installation/) for the full platform table.
+
+### Missing shared libraries on Linux
+
+```
+./cqlite: error while loading shared libraries: libssl.so.1.1: cannot open shared object file
+```
+
+Use the musl (static) build, which has no shared library dependencies:
+
+```bash
+TARGET=x86_64-unknown-linux-musl
+curl -fsSLO https://github.com/pmcfadin/cqlite/releases/latest/download/cqlite-$TARGET.tar.gz
+tar xzf cqlite-$TARGET.tar.gz
+./cqlite --version
+```
+
+## Test data
+
+### Query tests return 0 rows
+
+The test datasets contain only the JSONL reference files by default.
+The actual SSTable binary files (`.db`) must be fetched separately:
+
+```bash
+export CQLITE_DATASETS_ROOT=$PWD/test-data/datasets
+bash test-data/scripts/fetch-datasets.sh
+```
+
+After fetching, retry your query. You should see results.
+
+### Missing test data environment variable
+
+Many integration tests look for `CQLITE_DATASETS_ROOT`. Set it before running:
+
+```bash
+export CQLITE_DATASETS_ROOT=$PWD/test-data/datasets
+cargo test --package cqlite-core
+```
+
+## CLI
+
+### Query returns no rows on your own SSTable data
+
+1. **Wrong `--data-dir` path**: `--data-dir` should point to the directory that
+   contains the keyspace subdirectories, not to a single SSTable directory.
+
+   ```bash
+   # Correct: the parent directory
+   cqlite --data-dir /var/lib/cassandra/data ...
+
+   # Incorrect: the table-specific directory
+   cqlite --data-dir /var/lib/cassandra/data/my_ks/my_table-abc123 ...
+   ```
+
+2. **Schema mismatch**: ensure the keyspace and table names in the schema file
+   exactly match the directory names on disk.
+
+3. **Unsupported format**: CQLite only supports Cassandra 5.0 `nb-*-big-*` files.
+   Check that your SSTable directory contains files named `nb-1-big-Data.db` (not
+   `mc-*`, `md-*`, or `la-*`).
+
+### `Unsupported SSTable format`
+
+CQLite reads **Cassandra 5.0 BIG format** SSTables only. Files from Cassandra 3.x
+(`mc-*`, `la-*`) and 4.x (`md-*`) are not supported. Upgrade your cluster to
+Cassandra 5.0 and run `nodetool upgradesstables` to convert, or use
+Cassandra's `sstabledump` tool to export to JSON first.
+
+See [Limitations](/cqlite/user-docs/limitations/) for the full format-support matrix.
+
+### `Parsing issues` or garbled values
+
+Check `docs/sstables-definitive-guide/chapters/appendix-f-known-limitations.md`
+for known parsing gaps. Some edge cases (for example, very wide partitions with
+10 000+ rows, or BTI-format index files) may not produce correct results.
+
+Enable debug logging to get more detail:
+
+```bash
+RUST_LOG=debug cqlite \
+  --schema my.cql \
+  --data-dir /path/to/data \
+  --query "SELECT * FROM ks.tbl LIMIT 5"
+```
+
+### `--out` vs `--format` precedence
+
+`--out` takes precedence over `--format` when both are provided. Use `--out` for
+reliable behavior. You can also set a default via the environment variable:
+
+```bash
+export CQLITE_OUT=json
+```
+
+## Python bindings
+
+### Python import errors after install
+
+```bash
+python3 --version  # Must be 3.9+
+pip install --upgrade cqlite-py
+```
+
+If the binary wheel is missing for your platform, build from source:
+
+```bash
+pip install maturin
+rustup update    # Requires Rust 1.85+
+cd bindings/python && maturin develop
+```
+
+### Python tests skip or fail
+
+Ensure the dataset is available:
+
+```bash
+export CQLITE_DATASETS_ROOT=$PWD/test-data/datasets
+bash test-data/scripts/fetch-datasets.sh
+pytest bindings/python/tests -v
+```
+
+### Concurrent query race condition
+
+A known issue: concurrent queries on the **same** `Database` handle may race on
+schema metadata access. Work around it by running a warm-up query before spawning
+parallel threads:
+
+```python
+# Warm up — triggers schema metadata load
+list(db.execute('SELECT * FROM ks.tbl LIMIT 1'))
+
+# Now safe to use from multiple threads
+```
+
+## Node.js bindings
+
+### Native module fails to load
+
+Check that you are on a supported platform (Linux x86_64/arm64, macOS
+x86_64/arm64, Windows x86_64). If you are on a supported platform and still see
+an error like `Error: Cannot find module './cqlite.node'`, try rebuilding:
+
+```bash
+cd bindings/node
+npm run build
+npm test
+```
+
+### TypeScript types not found
+
+The types are in `lib/index.d.ts`. Ensure `"types": "lib/index.d.ts"` is
+referenced in your `tsconfig.json` or that `@cqlite/node` resolves correctly.
+The package ships with complete TypeScript definitions — no `@types/` package is
+needed.
+
+## Clippy and CI failures
+
+Run Clippy in CI mode to catch issues early:
+
+```bash
+env RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features
+```
+
+## Common error quick reference
+
+| Symptom | Likely cause | Quick fix |
+|---------|-------------|-----------|
+| `command not found: cqlite` | Binary not on PATH | Add install dir to PATH |
+| Query returns 0 rows | Missing test data | Run `fetch-datasets.sh` |
+| `Unsupported SSTable format` | Not Cassandra 5.0 format | Upgrade cluster, convert SSTables |
+| `IO` error opening file | Wrong `--data-dir` path | Check path points to data root |
+| Python `ImportError` | Old Python or missing wheel | Upgrade Python, rebuild bindings |
+| `SCHEMA` error | Keyspace/table name mismatch | Check schema file vs directory names |
+| `PARSE` error | Parsing limitation or corrupt file | Check limitations page; report bug |
+
+For anything not listed here, open an issue at
+https://github.com/pmcfadin/cqlite/issues with the output of:
+
+```bash
+cqlite --version
+RUST_LOG=debug cqlite --schema <your.cql> --data-dir <dir> --query "<query>" 2>&1 | head -50
+```

--- a/website/src/content/docs/user-docs/write-support.md
+++ b/website/src/content/docs/user-docs/write-support.md
@@ -1,0 +1,167 @@
+---
+title: Write Support
+description: Write Cassandra 5.0 SSTables offline with CQLite's write engine (M5).
+sidebar:
+  label: Write Support
+  order: 7
+---
+
+# Write Support
+
+CQLite v0.9.0 (M5) ships offline SSTable write support across all interfaces:
+Rust core, Python, Node.js, and CLI. Written data flushes to portable Cassandra 5.0
+BIG-format SSTables that Cassandra can load with `nodetool refresh`.
+
+For known limitations (promoted index, compaction deferral, etc.) see
+[Limitations](/cqlite/user-docs/limitations/#write-support-limitations).
+
+## CLI
+
+Build with write support enabled:
+
+```bash
+cargo build --package cqlite-cli --features write-support --release
+```
+
+### Write a mutation
+
+```bash
+cqlite \
+  --writable \
+  --write-dir /tmp/cqlite-write \
+  --schema test-data/schemas/basic-types.cql \
+  --mutation '{
+    "table":{"keyspace":"test_basic","table":"simple_table"},
+    "partition_key":[{"Uuid":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]}],
+    "clustering_key":[],
+    "operations":[{"Write":{"column":"name","value":{"Text":"Alice"}}}],
+    "timestamp_micros":1704067200000000
+  }'
+```
+
+### Flush memtable to an SSTable file
+
+```bash
+cqlite \
+  --writable \
+  --write-dir /tmp/cqlite-write \
+  --schema test-data/schemas/basic-types.cql \
+  --flush
+```
+
+### Write subcommands
+
+```bash
+# Run incremental maintenance (flush + partial compaction)
+cqlite maintenance --budget-ms 100 \
+  --writable --write-dir /tmp/cqlite-write \
+  --schema test-data/schemas/basic-types.cql
+
+# Show write-engine statistics
+cqlite write-stats \
+  --writable --write-dir /tmp/cqlite-write \
+  --schema test-data/schemas/basic-types.cql
+
+# Export flushed SSTables to a distribution directory
+cqlite export-sstable /tmp/export --keyspace my_ks --table my_tbl \
+  --writable --write-dir /tmp/cqlite-write \
+  --schema test-data/schemas/basic-types.cql
+```
+
+## Python
+
+```python
+import cqlite
+
+# Open in writable mode — write_dir stores the WAL and flushed SSTables
+with cqlite.open(
+    'test-data/datasets/sstables',
+    schema='test-data/schemas/write-test.cql',
+    writable=True,
+    write_dir='/tmp/my-writes',
+) as db:
+    db.execute(
+        "INSERT INTO test_basic.simple_table (id, name, age) "
+        "VALUES (11111111-1111-1111-1111-111111111111, 'Alice', 30)"
+    )
+    path = db.flush_run()
+    print(f'Flushed SSTable: {path}')
+```
+
+## Node.js
+
+```javascript
+const { Database } = require('@cqlite/node');
+
+const db = await Database.open('test-data/datasets/sstables', {
+  schema: 'test-data/schemas/write-test.cql',
+  writable: true,
+  writeDir: '/tmp/my-writes',
+});
+
+await db.execute(
+  "INSERT INTO test_basic.simple_table (id, name, age) " +
+  "VALUES (11111111-1111-1111-1111-111111111111, 'Bob', 25)"
+);
+const path = await db.flushRun();
+console.log('Flushed SSTable:', path);
+await db.close();
+```
+
+## Load into Cassandra
+
+Once you have flushed SSTable files, load them into a running Cassandra 5.0 cluster
+by copying the files to the appropriate data directory and running:
+
+```bash
+# Copy SSTable files to Cassandra data directory
+cp /tmp/my-writes/*.db \
+   /var/lib/cassandra/data/test_basic/simple_table-<uuid>/
+
+# Tell Cassandra to pick them up
+nodetool refresh test_basic simple_table
+```
+
+## Schema file format
+
+CQLite write operations require a `.cql` schema file that defines the keyspace and
+table structure:
+
+```cql
+CREATE KEYSPACE test_basic
+  WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};
+
+USE test_basic;
+
+CREATE TABLE simple_table (
+    id   UUID    PRIMARY KEY,
+    name TEXT,
+    age  INT
+);
+```
+
+A sample schema is included in the repository at
+`test-data/schemas/write-test.cql`.
+
+## Supported write operations
+
+| Operation | Status |
+|-----------|--------|
+| INSERT / upsert | Full |
+| UPDATE (column write) | Full |
+| DELETE (partition or row) | Full |
+| DELETE (column) | Full |
+| TTL (expiring cells) | Full |
+| Frozen collections | Full |
+| Non-frozen collections (list, set, map) | Full |
+| Static columns | Full |
+| Composite partition keys | Full |
+| Counter columns | Not yet supported |
+| Lightweight transactions (CAS) | Not applicable (offline) |
+
+## Compaction status
+
+The k-way merge compaction API (`STCSPolicy`, `maintenance_step()`) is defined and
+tested, but execution requires M5.3 reader integration. `maintenance_step()`
+currently performs flush operations only; `set_merge_policy()` returns an error.
+Full compaction support is planned for M5.3.


### PR DESCRIPTION
Part of epic #733. Closes #736.

## Summary

- Merges three quick starts (`quick-start.md`, `QUICK_START_GUIDE.md`, `UAT_QUICK_START.md`) into one canonical site page at `website/src/content/docs/user-docs/quick-start.md`
- Publishes **Installation** page covering all 6 prebuilt platforms + cargo/pip/npm paths from README
- Publishes **Troubleshooting** page (real issues only, sourced from CLAUDE.md and existing guides; aspirational content stripped)
- Publishes **Limitations** page ("What CQLite can and cannot read") with format matrix, BTI partial-support status, write-support trade-offs, and collection tombstone gap (#493) — cross-links appendix F source with a TODO(W8) note for the site link
- Publishes **Write Support** page with CLI/Python/Node.js examples from README/CLAUDE.md
- Upgrades **user-docs/index.md** to a real section landing page
- Archives all 7 `docs/user-guides/` source files under `docs/archive/user-guides-superseded/` with tombstone headers (git mv, not delete)

## Validation

`bash scripts/docs-site-check.sh` → **DOCS_SITE_CHECK=PASS**

All internal links validated by `starlight-links-validator` (0 broken links).

## File disposition table

| File | Disposition | Reason |
|------|------------|--------|
| `docs/user-guides/quick-start.md` | Archived | Superseded by site page |
| `docs/user-guides/QUICK_START_GUIDE.md` | Archived | Superseded by site page |
| `docs/user-guides/UAT_QUICK_START.md` | Archived | Superseded by site page |
| `docs/user-guides/installation.md` | Archived | Superseded by site page; contained aspirational content |
| `docs/user-guides/troubleshooting.md` | Archived | Superseded by site page; contained aspirational content |
| `docs/user-guides/cli.md` | Archived | CLI reference content deferred to W4 |
| `docs/user-guides/demo_real_data.md` | Archived | Internal dev notes, not user-facing |