### PR TITLE
docs: W6 agent recipes + example smoke in CI (#739)

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -19,14 +19,23 @@ on:
     paths:
       - 'website/**'
       - 'docs/**'
+      - 'scripts/docs-examples-smoke.sh'
+      - 'scripts/docs-site-check.sh'
   pull_request:
     paths:
       - 'website/**'
       - 'docs/**'
+      - 'scripts/docs-examples-smoke.sh'
+      - 'scripts/docs-site-check.sh'
   workflow_dispatch:
 
 permissions:
   contents: write
+
+env:
+  DATASET_TAG: datasets-v3
+  DATASET_ASSET: cassandra5-small-full-v3.1.tar.gz
+  DATASET_SHA256: f5fa0b6599a27c1c493d7c6c063194d55d031cab417396947313e7245afc5ceb
 
 jobs:
   build:
@@ -59,10 +68,52 @@ jobs:
           path: website/dist/
           retention-days: 1
 
+  smoke:
+    name: Recipe smoke tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo registry and build output
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-docs-smoke-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-docs-smoke-
+
+      - name: Build CLI with write-support
+        run: cargo build --package cqlite-cli --features write-support
+
+      - name: Cache test datasets
+        id: dataset-cache
+        uses: actions/cache@v4
+        with:
+          path: test-data/datasets
+          # Cache key MUST include SHA256 — never tag alone (see dataset release gotchas)
+          key: datasets-${{ env.DATASET_TAG }}-${{ env.DATASET_SHA256 }}
+
+      - name: Fetch datasets if cache miss
+        if: steps.dataset-cache.outputs.cache-hit != 'true'
+        run: |
+          bash test-data/scripts/fetch-datasets.sh
+
+      - name: Run recipe smoke tests
+        env:
+          CQLITE_DATASETS_ROOT: ${{ github.workspace }}/test-data/datasets
+          CQLITE_CLI: ${{ github.workspace }}/target/debug/cqlite
+        run: bash scripts/docs-examples-smoke.sh
+
   deploy:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, smoke]
     # Only deploy on push to main (not on PRs or forks)
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:

--- a/scripts/docs-examples-smoke.sh
+++ b/scripts/docs-examples-smoke.sh
@@ -1,0 +1,438 @@
+#!/usr/bin/env bash
+# docs-examples-smoke.sh — Extract and run documented CLI commands from recipe pages.
+#
+# Philosophy: same as sstabledump parity for code, applied to docs.
+# Every CLI command in a <!-- SMOKE:CLI --> block must execute successfully
+# and produce output matching the expected shape (key presence, row count,
+# exit code). A drifted example fails with a clear message naming the recipe page.
+#
+# Marker convention (documented in website/README.md):
+#   <!-- SMOKE:CLI -->          — CLI command; expected exit 0
+#   <!-- SMOKE:CLI:exit=N -->   — CLI command; expected exit N
+#   <!-- SMOKE:CLI:write -->    — CLI command requiring write-support binary; expected exit 0
+#   <!-- /SMOKE:CLI -->         — end of marked block
+#
+# Python and Node.js markers (<!-- SMOKE:PYTHON -->, <!-- SMOKE:NODE -->) are
+# extracted but NOT run in CI (bindings require a separate build step). They
+# are supported for local execution with --with-bindings.
+#
+# Usage:
+#   bash scripts/docs-examples-smoke.sh               # CLI recipes only
+#   bash scripts/docs-examples-smoke.sh --with-bindings  # include Python + Node
+#   bash scripts/docs-examples-smoke.sh --recipe sstable-to-json.md  # one recipe
+#
+# Environment:
+#   CQLITE_DATASETS_ROOT   — dataset root (default: test-data/datasets)
+#   CQLITE_CLI             — path to CLI binary (default: target/debug/cqlite)
+#   CQLITE_SCHEMA_DIR      — schema directory (default: test-data/schemas)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+RECIPES_DIR="$REPO_ROOT/website/src/content/docs/agents-using"
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+
+DATASETS_ROOT="${CQLITE_DATASETS_ROOT:-$REPO_ROOT/test-data/datasets}"
+DATA_DIR="$DATASETS_ROOT/sstables"
+SCHEMA_DIR="${CQLITE_SCHEMA_DIR:-$REPO_ROOT/test-data/schemas}"
+CLI="${CQLITE_CLI:-$REPO_ROOT/target/debug/cqlite}"
+WITH_BINDINGS=false
+SINGLE_RECIPE=""
+WRITE_DIR="${SMOKE_WRITE_DIR:-/tmp/cqlite-smoke-write}"
+
+# ── Argument parsing ───────────────────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --with-bindings) WITH_BINDINGS=true; shift ;;
+    --recipe) SINGLE_RECIPE="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1"; exit 2 ;;
+  esac
+done
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+pass() { echo -e "${GREEN}[PASS]${RESET} $*"; }
+fail() { echo -e "${RED}[FAIL]${RESET} $*"; }
+info() { echo -e "${YELLOW}[INFO]${RESET} $*"; }
+banner() { echo -e "\n${BOLD}══ $* ══${RESET}"; }
+
+FAILURES=()
+PASSED=0
+SKIPPED=0
+
+record_fail() {
+    fail "$*"
+    FAILURES+=("$*")
+}
+
+# ── Pre-flight ─────────────────────────────────────────────────────────────────
+
+banner "docs-examples-smoke pre-flight"
+
+if [[ ! -f "$CLI" ]]; then
+    fail "CLI not found at: $CLI"
+    echo "Build with: cargo build --package cqlite-cli --features write-support"
+    exit 1
+fi
+
+if [[ ! -d "$DATA_DIR" ]]; then
+    fail "Data directory not found: $DATA_DIR"
+    echo "Set CQLITE_DATASETS_ROOT or run: bash test-data/scripts/fetch-datasets.sh"
+    exit 1
+fi
+
+if [[ ! -d "$RECIPES_DIR" ]]; then
+    fail "Recipes directory not found: $RECIPES_DIR"
+    exit 1
+fi
+
+info "CLI:        $CLI"
+info "Data dir:   $DATA_DIR"
+info "Schema dir: $SCHEMA_DIR"
+info "Recipes:    $RECIPES_DIR"
+info "With bindings: $WITH_BINDINGS"
+
+# Check write-support binary
+WRITE_CLI="$CLI"
+# If a release write-support binary exists, prefer it; otherwise use debug
+if [[ -f "$REPO_ROOT/target/debug/cqlite" ]]; then
+    WRITE_CLI="$REPO_ROOT/target/debug/cqlite"
+fi
+
+# ── Extraction and execution ───────────────────────────────────────────────────
+
+# Extract marked blocks from a markdown file.
+# Outputs: one shell heredoc per block, with the recipe file path commented.
+extract_smoke_blocks() {
+    local file="$1"
+    local in_block=false
+    local block_type=""
+    local expected_exit=0
+    local cmd_lines=()
+
+    while IFS= read -r line; do
+        # Start marker: <!-- SMOKE:TYPE --> or <!-- SMOKE:TYPE:exit=N -->
+        if [[ "$line" =~ ^\<\!--[[:space:]]*SMOKE:([A-Z_]+)(:exit=([0-9]+))? ]]; then
+            in_block=true
+            block_type="${BASH_REMATCH[1]}"
+            expected_exit="${BASH_REMATCH[3]:-0}"
+            cmd_lines=()
+            continue
+        fi
+
+        # End marker
+        if [[ "$line" =~ ^\<\!--[[:space:]]*/SMOKE ]]; then
+            in_block=false
+            if [[ ${#cmd_lines[@]} -gt 0 ]]; then
+                echo "BLOCK_START:${block_type}:${expected_exit}"
+                printf '%s\n' "${cmd_lines[@]}"
+                echo "BLOCK_END"
+            fi
+            continue
+        fi
+
+        # Collect lines inside a fenced code block within the SMOKE block
+        if [[ "$in_block" == true ]]; then
+            # Skip the ``` fence lines
+            if [[ "$line" =~ ^'```' ]]; then
+                continue
+            fi
+            cmd_lines+=("$line")
+        fi
+    done < "$file"
+}
+
+# Run a single CLI recipe block.
+# Arguments: recipe_file, block content (multi-line), expected_exit
+run_cli_block() {
+    local recipe="$1"
+    local block_content="$2"
+    local expected_exit="$3"
+    local recipe_name
+    recipe_name="$(basename "$recipe")"
+
+    # Replace placeholder paths with real paths
+    local expanded
+    expanded="$(echo "$block_content" \
+        | sed "s|test-data/schemas/|$SCHEMA_DIR/|g" \
+        | sed "s|test-data/datasets/sstables|$DATA_DIR|g" \
+        | sed "s|--write-dir /tmp/cqlite-write|--write-dir $WRITE_DIR|g" \
+        | sed "s|/tmp/cqlite-export|$WRITE_DIR/export|g" \
+        | sed "s|/tmp/cqlite-smoke-write|$WRITE_DIR|g"
+    )"
+
+    # Join backslash-continued lines into a single logical line, preserving pipes.
+    # Strategy: join lines where the current line ends with \, keep the rest as-is.
+    # Then compact multiple spaces.
+    local cmd
+    cmd="$(echo "$expanded" | awk '{
+        if (sub(/\\[[:space:]]*$/, "")) {
+            printf "%s ", $0
+        } else {
+            print $0
+        }
+    }' | sed 's/  */ /g' | sed '/^[[:space:]]*$/d')"
+
+    # Replace bare 'cqlite' with the actual binary path.
+    # macOS sed does not support \b word boundaries; use two-pass replacement instead.
+    cmd="$(echo "$cmd" \
+        | sed "s|^cqlite |$CLI |" \
+        | sed "s| cqlite | $CLI |g" \
+        | sed "s|\&\& cqlite |\&\& $CLI |g")"
+
+    local tmp_out
+    tmp_out="$(mktemp)"
+    local actual_exit=0
+
+    # Detect if the command uses a pipe (multi-stage pipeline)
+    local has_pipe=false
+    if echo "$cmd" | grep -q '|'; then
+        has_pipe=true
+    fi
+
+    info "Testing [$recipe_name]: $(echo "$cmd" | head -c 120)..."
+
+    # Run command. For piped commands, stderr from all stages goes to /dev/null.
+    # Redirect stdout to tmp_out only for non-piped commands so we can validate JSON shape.
+    if [[ "$has_pipe" == "true" ]]; then
+        # Piped: just check exit code; suppress all output
+        eval "$cmd" >/dev/null 2>/dev/null || actual_exit=$?
+    else
+        # Non-piped: capture stdout for shape validation; suppress stderr (INFO/WARN logs)
+        eval "$cmd" >"$tmp_out" 2>/dev/null || actual_exit=$?
+    fi
+
+    if [[ "$actual_exit" != "$expected_exit" ]]; then
+        record_fail "$recipe_name: expected exit $expected_exit, got $actual_exit"
+        if [[ -s "$tmp_out" ]]; then
+            echo "  Output was:"
+            head -5 "$tmp_out" | sed 's/^/    /'
+        fi
+        rm -f "$tmp_out"
+        return
+    fi
+
+    # For non-piped successful CLI blocks, do basic output shape validation
+    if [[ "$expected_exit" == "0" && "$has_pipe" == "false" ]]; then
+        local stdout_content
+        stdout_content="$(cat "$tmp_out")"
+
+        # If output looks like JSON, validate it parses
+        if echo "$stdout_content" | grep -q '^\['; then
+            if ! echo "$stdout_content" | python3 -c "import json,sys; json.load(sys.stdin)" 2>/dev/null; then
+                record_fail "$recipe_name: JSON output does not parse"
+                rm -f "$tmp_out"
+                return
+            fi
+            # Ensure the JSON array has at least 1 element
+            local row_count
+            row_count="$(echo "$stdout_content" | python3 -c "import json,sys; print(len(json.load(sys.stdin)))" 2>/dev/null || echo 0)"
+            if [[ "$row_count" -lt 1 ]]; then
+                record_fail "$recipe_name: JSON output is empty array (expected rows)"
+                rm -f "$tmp_out"
+                return
+            fi
+        fi
+    fi
+
+    rm -f "$tmp_out"
+    pass "$recipe_name"
+    ((PASSED++)) || true
+}
+
+# Process a single recipe file
+process_recipe() {
+    local recipe="$1"
+
+    if [[ ! -f "$recipe" ]]; then
+        info "Skipping (not found): $recipe"
+        ((SKIPPED++)) || true
+        return
+    fi
+
+    # Reset write dir for each write recipe
+    local recipe_name
+    recipe_name="$(basename "$recipe")"
+
+    # Extract and run blocks
+    local in_block=false
+    local block_type=""
+    local expected_exit=0
+    local cmd_lines=()
+    local block_count=0
+
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^\<\!--[[:space:]]*SMOKE:([A-Z_:a-z=0-9]+) ]]; then
+            local marker="${BASH_REMATCH[1]}"
+            in_block=true
+            cmd_lines=()
+
+            # Parse type and exit code from marker
+            if [[ "$marker" =~ ^(CLI|CLI:exit=([0-9]+)|CLI:write|PYTHON|NODE)$ ]]; then
+                if [[ "$marker" == "CLI" ]]; then
+                    block_type="CLI"
+                    expected_exit=0
+                elif [[ "$marker" =~ ^CLI:exit=([0-9]+)$ ]]; then
+                    block_type="CLI"
+                    expected_exit="${BASH_REMATCH[1]}"
+                elif [[ "$marker" == "CLI:write" ]]; then
+                    block_type="CLI_WRITE"
+                    expected_exit=0
+                elif [[ "$marker" == "PYTHON" ]]; then
+                    block_type="PYTHON"
+                    expected_exit=0
+                elif [[ "$marker" == "NODE" ]]; then
+                    block_type="NODE"
+                    expected_exit=0
+                fi
+            fi
+            continue
+        fi
+
+        if [[ "$line" =~ ^\<\!--[[:space:]]*/SMOKE ]]; then
+            in_block=false
+            if [[ ${#cmd_lines[@]} -gt 0 ]]; then
+                ((block_count++)) || true
+                local block_content
+                block_content="$(printf '%s\n' "${cmd_lines[@]}")"
+
+                case "$block_type" in
+                    CLI)
+                        # Prepare write dir for non-write CLI blocks
+                        mkdir -p "$WRITE_DIR"
+                        run_cli_block "$recipe" "$block_content" "$expected_exit"
+                        ;;
+                    CLI_WRITE)
+                        # Ensure clean write dir for write recipes
+                        rm -rf "$WRITE_DIR" && mkdir -p "$WRITE_DIR"
+                        run_cli_block "$recipe" "$block_content" "$expected_exit"
+                        ;;
+                    PYTHON)
+                        if [[ "$WITH_BINDINGS" == "true" ]]; then
+                            info "TODO: Python block in $recipe_name (--with-bindings not yet wired)"
+                            ((SKIPPED++)) || true
+                        else
+                            info "Skipping Python block in $recipe_name (use --with-bindings to run)"
+                            ((SKIPPED++)) || true
+                        fi
+                        ;;
+                    NODE)
+                        if [[ "$WITH_BINDINGS" == "true" ]]; then
+                            info "TODO: Node block in $recipe_name (--with-bindings not yet wired)"
+                            ((SKIPPED++)) || true
+                        else
+                            info "Skipping Node block in $recipe_name (use --with-bindings to run)"
+                            ((SKIPPED++)) || true
+                        fi
+                        ;;
+                esac
+            fi
+            cmd_lines=()
+            continue
+        fi
+
+        if [[ "$in_block" == true ]]; then
+            # Skip the ``` fence lines
+            if [[ "$line" =~ ^'```' ]]; then
+                continue
+            fi
+            cmd_lines+=("$line")
+        fi
+    done < "$recipe"
+
+    if [[ "$block_count" -eq 0 ]]; then
+        info "No SMOKE blocks found in $recipe_name"
+    fi
+}
+
+# ── Main loop ──────────────────────────────────────────────────────────────────
+
+banner "Running smoke tests"
+
+if [[ -n "$SINGLE_RECIPE" ]]; then
+    # Single recipe mode
+    if [[ -f "$RECIPES_DIR/$SINGLE_RECIPE" ]]; then
+        process_recipe "$RECIPES_DIR/$SINGLE_RECIPE"
+    elif [[ -f "$SINGLE_RECIPE" ]]; then
+        process_recipe "$SINGLE_RECIPE"
+    else
+        fail "Recipe not found: $SINGLE_RECIPE"
+        exit 1
+    fi
+else
+    # All CLI recipes in order
+    CLI_RECIPES=(
+        "sstable-to-json.md"
+        "export-parquet.md"
+        "export-csv.md"
+        "inspect-schema.md"
+        "count-rows.md"
+        "read-collections.md"
+        "missing-schema.md"
+        "write-mutation.md"
+        "export-sstable.md"
+    )
+    # Python/Node recipes: skipped unless --with-bindings
+    BINDING_RECIPES=(
+        "query-python.md"
+        "query-nodejs.md"
+    )
+
+    for recipe in "${CLI_RECIPES[@]}"; do
+        process_recipe "$RECIPES_DIR/$recipe"
+    done
+
+    for recipe in "${BINDING_RECIPES[@]}"; do
+        if [[ "$WITH_BINDINGS" == "true" ]]; then
+            process_recipe "$RECIPES_DIR/$recipe"
+        else
+            info "Skipping binding recipe (use --with-bindings): $recipe"
+            ((SKIPPED++)) || true
+        fi
+    done
+fi
+
+# ── Cleanup ────────────────────────────────────────────────────────────────────
+
+rm -rf "$WRITE_DIR" 2>/dev/null || true
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+banner "docs-examples-smoke summary"
+
+echo ""
+echo "Passed:  $PASSED"
+echo "Skipped: $SKIPPED (Python/Node require --with-bindings)"
+echo "Failed:  ${#FAILURES[@]}"
+
+if [[ ${#FAILURES[@]} -gt 0 ]]; then
+    echo ""
+    echo "Failed recipes:"
+    for f in "${FAILURES[@]}"; do
+        echo "  - $f"
+    done
+    echo ""
+    echo "┌──────────────────────────────────────────────────┐"
+    echo "│  docs-examples-smoke: FAILED                      │"
+    echo "└──────────────────────────────────────────────────┘"
+    echo ""
+    echo "DOCS_SMOKE=FAIL"
+    exit 1
+else
+    echo ""
+    echo "┌──────────────────────────────────────────────────┐"
+    echo "│  docs-examples-smoke: ALL CHECKS PASSED           │"
+    echo "└──────────────────────────────────────────────────┘"
+    echo ""
+    echo "DOCS_SMOKE=PASS"
+    exit 0
+fi

--- a/scripts/docs-site-check.sh
+++ b/scripts/docs-site-check.sh
@@ -4,12 +4,19 @@
 # Runs:
 #   1. npm ci (install pinned deps)
 #   2. npm run build (Astro build + starlight-links-validator internal link check)
+#   3. [optional] docs-examples-smoke.sh (CLI recipe smoke tests)
 #
 # Emits a machine-checkable PASS/FAIL summary block at the end (modelled on
 # scripts/agent-gate.sh). Exit code 0 = all checks passed; non-zero = failure.
 #
-# Usage: bash scripts/docs-site-check.sh
-#        (or ./scripts/docs-site-check.sh after chmod +x)
+# Usage:
+#   bash scripts/docs-site-check.sh              # fast: site build + link check only
+#   bash scripts/docs-site-check.sh --with-smoke # also run CLI recipe smoke tests
+#   WITH_SMOKE=1 bash scripts/docs-site-check.sh # same, via env var
+#
+# The smoke step requires:
+#   - CQLITE_DATASETS_ROOT set to the test dataset root (or test-data/datasets)
+#   - The cqlite CLI binary built (cargo build --package cqlite-cli --features write-support)
 
 set -euo pipefail
 
@@ -17,7 +24,18 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 WEBSITE_DIR="$REPO_ROOT/website"
 
-# ── Helpers ──────────────────────────────────────────────────────────────────
+# ── Argument parsing ──────────────────────────────────────────────────────────
+
+WITH_SMOKE="${WITH_SMOKE:-0}"
+
+for arg in "$@"; do
+  case "$arg" in
+    --with-smoke) WITH_SMOKE=1 ;;
+    *) echo "Unknown argument: $arg"; exit 2 ;;
+  esac
+done
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -67,6 +85,12 @@ if [[ ! -d "$WEBSITE_DIR" ]]; then
     exit 1
 fi
 
+if [[ "$WITH_SMOKE" == "1" ]]; then
+    info "Smoke tests: ENABLED (--with-smoke)"
+else
+    info "Smoke tests: DISABLED (pass --with-smoke to enable)"
+fi
+
 # ── Checks ────────────────────────────────────────────────────────────────────
 
 banner "Step 1: Install dependencies"
@@ -84,6 +108,11 @@ banner "Step 2: Build site (includes internal link validation)"
     cd "$WEBSITE_DIR"
     run_check "npm run build" npm run build
 )
+
+if [[ "$WITH_SMOKE" == "1" ]]; then
+    banner "Step 3: Example smoke tests (CLI recipes)"
+    run_check "docs-examples-smoke" bash "$SCRIPT_DIR/docs-examples-smoke.sh"
+fi
 
 # ── Summary ───────────────────────────────────────────────────────────────────
 

--- a/website/README.md
+++ b/website/README.md
@@ -102,6 +102,77 @@ website/
 └── node_modules/             # Dependencies (gitignored)
 ```
 
+## Recipe smoke tests (SMOKE marker convention)
+
+CLI commands in the `agents-using/` section are extracted and executed by
+`scripts/docs-examples-smoke.sh`. This mirrors the sstabledump parity philosophy:
+a documented example that drifts from real behavior fails the CI build.
+
+### Marking a command for smoke testing
+
+Wrap any CLI `bash` code block with HTML comment markers:
+
+```markdown
+<!-- SMOKE:CLI -->
+```bash
+cqlite \
+  --schema test-data/schemas/basic-types.cql \
+  --data-dir test-data/datasets/sstables \
+  --query "SELECT id, name FROM test_basic.simple_table LIMIT 3" \
+  --out json
+```
+<!-- /SMOKE:CLI -->
+```
+
+### Available markers
+
+| Marker | Meaning |
+|--------|---------|
+| `<!-- SMOKE:CLI -->` | CLI command; expected exit 0 |
+| `<!-- SMOKE:CLI:exit=N -->` | CLI command; expected exit N (e.g. `exit=3` for schema errors) |
+| `<!-- SMOKE:CLI:write -->` | CLI command requiring write-support binary; expected exit 0 |
+| `<!-- SMOKE:PYTHON -->` | Python snippet; skipped in CI unless `--with-bindings` |
+| `<!-- SMOKE:NODE -->` | Node.js snippet; skipped in CI unless `--with-bindings` |
+| `<!-- /SMOKE:CLI -->` | End of any SMOKE block |
+
+### Path substitution
+
+The smoke script substitutes these paths automatically:
+
+| In recipe | Replaced with |
+|-----------|---------------|
+| `test-data/schemas/` | Absolute path to `test-data/schemas/` |
+| `test-data/datasets/sstables` | `$CQLITE_DATASETS_ROOT/sstables` |
+| `/tmp/cqlite-write` | Temporary write directory |
+| `/tmp/cqlite-export` | Temporary export directory |
+
+### Running locally
+
+```bash
+# CLI recipes only (fast)
+bash scripts/docs-examples-smoke.sh
+
+# Single recipe
+bash scripts/docs-examples-smoke.sh --recipe sstable-to-json.md
+
+# Include Python + Node.js (requires bindings built)
+bash scripts/docs-examples-smoke.sh --with-bindings
+
+# Via docs-site-check.sh (also runs site build + link check)
+bash scripts/docs-site-check.sh --with-smoke
+```
+
+### CI integration
+
+The smoke job in `.github/workflows/docs-site.yml` runs on every PR or push that
+touches `website/**`, `docs/**`, or the smoke scripts. The deploy job depends on
+both `build` and `smoke` passing.
+
+**Python and Node.js recipes are NOT run in CI** by default — the bindings require
+a separate multi-platform build step that is out of scope for the docs workflow.
+The SMOKE:PYTHON and SMOKE:NODE markers are preserved for local use with `--with-bindings`.
+This is a documented deviation from full parity; see the smoke coverage table in the PR.
+
 ## Deployment
 
 The site is deployed by `.github/workflows/docs-site.yml`:

--- a/website/src/content/docs/agents-using/count-rows.md
+++ b/website/src/content/docs/agents-using/count-rows.md
@@ -1,0 +1,124 @@
+---
+title: Count rows
+description: Count rows in a CQLite table with and without filters using SELECT and JSON output.
+sidebar:
+  label: Count rows
+  order: 7
+---
+
+# Count rows
+
+**Task**: Determine how many rows a table contains, with or without filters.
+
+## Workaround: total row count via LIMIT + row counting
+
+`COUNT(*)` is not fully supported in the current release (it returns a null aggregate). The recommended workaround is to fetch all rows with `SELECT` and count the result set in a post-processing step.
+
+<!-- SMOKE:CLI -->
+```bash
+cqlite \
+  --schema test-data/schemas/basic-types.cql \
+  --data-dir test-data/datasets/sstables \
+  --query "SELECT id FROM test_basic.simple_table" \
+  --out json \
+| python3 -c "import json,sys; rows=json.load(sys.stdin); print(len(rows))"
+```
+<!-- /SMOKE:CLI -->
+
+**Expected output**:
+
+```
+1000
+```
+
+## Count filtered rows
+
+```bash
+cqlite \
+  --schema test-data/schemas/basic-types.cql \
+  --data-dir test-data/datasets/sstables \
+  --query "SELECT id FROM test_basic.simple_table WHERE age > 70" \
+  --out json \
+| python3 -c "import json,sys; rows=json.load(sys.stdin); print(len(rows))"
+```
+
+**Expected output** (count varies by dataset):
+
+```
+148
+```
+
+## Count via jq (alternative)
+
+```bash
+cqlite \
+  --schema test-data/schemas/basic-types.cql \
+  --data-dir test-data/datasets/sstables \
+  --query "SELECT id FROM test_basic.simple_table" \
+  --out json \
+| jq 'length'
+```
+
+**Expected**:
+
+```
+1000
+```
+
+## Count rows in a collection table
+
+```bash
+cqlite \
+  --schema test-data/schemas/collections.cql \
+  --data-dir test-data/datasets/sstables \
+  --query "SELECT id FROM test_collections.collection_table" \
+  --out json \
+| python3 -c "import json,sys; rows=json.load(sys.stdin); print(len(rows))"
+```
+
+**Expected**:
+
+```
+1000
+```
+
+## Known limitation: COUNT(*) aggregate
+
+`SELECT COUNT(*) FROM table` currently returns a row with a null value:
+
+```bash
+cqlite \
+  --schema test-data/schemas/basic-types.cql \
+  --data-dir test-data/datasets/sstables \
+  --query "SELECT COUNT(*) FROM test_basic.simple_table" \
+  --out json
+```
+
+Output (aggregate not implemented):
+
+```json
+[{"col_0": null}]
+```
+
+Use the `SELECT id ... | count` pattern above until aggregate functions are implemented (planned for a future milestone).
+
+## Row count per table (script)
+
+```bash
+for table in simple_table typed_table; do
+  count=$(cqlite \
+    --schema test-data/schemas/basic-types.cql \
+    --data-dir test-data/datasets/sstables \
+    --query "SELECT id FROM test_basic.${table}" \
+    --out json 2>/dev/null \
+  | python3 -c "import json,sys; print(len(json.load(sys.stdin)))")
+  echo "${table}: ${count}"
+done
+```
+
+**Expected output**:
+
+```
+simple_table: 1000
+typed_table: 1000
+```

--- a/website/src/content/docs/agents-using/export-csv.md
+++ b/website/src/content/docs/agents-using/export-csv.md
@@ -1,0 +1,89 @@
+---
+title: Export to CSV
+description: Write CQLite query results to CSV for spreadsheet import or downstream processing.
+sidebar:
+  label: Export to CSV
+  order: 5
+---
+
+# Export to CSV
+
+**Task**: Write query results to CSV format.
+
+<!-- SMOKE:CLI -->
+```bash
+cqlite \
+  --schema test-data/schemas/basic-types.cql \
+  --data-dir test-data/datasets/sstables \
+  --query "SELECT id, name, age FROM test_basic.simple_table LIMIT 3" \
+  --out csv
+```
+<!-- /SMOKE:CLI -->
+
+**Expected output** (real output, written to stdout):
+
+```
+id,name,age
+0023ece7-7c4e-4705-9068-d1a59ec5fe19,Debbie Soto,79
+009fb913-7173-40df-b4ea-67ed6834cfe5,Richard Parker,58
+00a74226-9bde-4259-9ba0-d74359e8013e,Andrew Meyers,47
+```
+
+**Exit code**: `0` on success.
+
+**Format**: First row is a header with column names. Values use standard CSV escaping (double-quote wrapping for values containing commas or newlines).
+
+## Write to a file
+
+```bash
+cqlite \
+  --schema test-data/schemas/basic-types.cql \
+  --data-dir test-data/datasets/sstables \
+  --query "SELECT id, name, age FROM test_basic.simple_table" \
+  --out csv \
+  --output /tmp/simple_table.csv \
+  --overwrite
+```
+
+## Export time-series data
+
+```bash
+cqlite \
+  --schema test-data/schemas/time-series.cql \
+  --data-dir test-data/datasets/sstables \
+  --query "SELECT sensor_id, timestamp, temperature, humidity FROM test_timeseries.sensor_data LIMIT 5" \
+  --out csv
+```
+
+**Expected output**:
+
+```
+sensor_id,timestamp,temperature,humidity
+0284a718-be7b-49e6-b6b9-8e82f5ff1660,2025-10-06 01:00:30.616+0000,-16.17206573486328,92.88220977783203
+0284a718-be7b-49e6-b6b9-8e82f5ff1660,2025-10-05 13:48:21.616+0000,16.26676368713379,1.5052613019943237
+0284a718-be7b-49e6-b6b9-8e82f5ff1660,2025-10-05 13:34:21.616+0000,1.2208592891693115,41.793243408203125
+0284a718-be7b-49e6-b6b9-8e82f5ff1660,2025-10-05 13:08:14.616+0000,19.574493408203125,59.132102966308594
+0284a718-be7b-49e6-b6b9-8e82f5ff1660,2025-10-05 05:02:36.616+0000,8.865622520446777,25.052871704101562
+```
+
+## Type rendering in CSV
+
+| CQL type | CSV rendering |
+|----------|--------------|
+| `text`, `varchar`, `ascii` | literal string |
+| Numbers (`int`, `bigint`, `float`, `double`) | decimal literal |
+| `boolean` | `true` / `false` |
+| `uuid`, `timeuuid` | `xxxxxxxx-xxxx-...` |
+| `timestamp` | `YYYY-MM-DD HH:MM:SS.mmm+0000` |
+| `date` | `YYYY-MM-DD` |
+| `blob` | hex-encoded (`0x...`) |
+| `list<T>`, `set<T>` | bracket-enclosed, e.g. `[a, b, c]` |
+| `map<K,V>` | `{key: value, ...}` |
+| `null` | empty field |
+
+## Failure modes
+
+| Symptom | Error | Fix |
+|---------|-------|-----|
+| No `--schema` flag | `Error: Schema not found for table '...'` | Add `--schema path/to/schema.cql` |
+| Output file exists | exit code `6` | Add `--overwrite` |

--- a/website/src/content/docs/agents-using/export-parquet.md
+++ b/website/src/content/docs/agents-using/export-parquet.md
@@ -1,0 +1,95 @@
+---
+title: Export to Parquet
+description: Write CQLite query results to a Parquet file using the --out parquet flag.
+sidebar:
+  label: Export to Parquet
+  order: 4
+---
+
+# Export to Parquet
+
+**Task**: Write query results to a Parquet file for downstream analytics.
+
+<!-- SMOKE:CLI -->
+```bash
+cqlite \
+  --schema test-data/schemas/basic-types.cql \
+  --data-dir test-data/datasets/sstables \
+  --query "SELECT id, name, age FROM test_basic.simple_table LIMIT 3" \
+  --out parquet \
+  --output /tmp/simple_table.parquet \
+  --overwrite
+```
+<!-- /SMOKE:CLI -->
+
+**Exit code**: `0` on success. File is created at the path given by `--output`.
+
+**Expected**: `simple_table.parquet` created; file size varies by row count (around 1.3 KB for 3 rows).
+
+## Required flags
+
+| Flag | Purpose |
+|------|---------|
+| `--out parquet` | Select Parquet output format |
+| `--output <path>` | Destination file path (required for Parquet) |
+| `--overwrite` | Replace existing file; omit to get exit code `6` on collision |
+
+## Export all rows
+
+```bash
+cqlite \
+  --schema test-data/schemas/basic-types.cql \
+  --data-dir test-data/datasets/sstables \
+  --query "SELECT * FROM test_basic.simple_table" \
+  --out parquet \
+  --output /tmp/all_rows.parquet \
+  --overwrite
+```
+
+## Export time-series data
+
+```bash
+cqlite \
+  --schema test-data/schemas/time-series.cql \
+  --data-dir test-data/datasets/sstables \
+  --query "SELECT sensor_id, timestamp, temperature, humidity FROM test_timeseries.sensor_data LIMIT 1000" \
+  --out parquet \
+  --output /tmp/sensor_data.parquet \
+  --overwrite
+```
+
+## Type fidelity
+
+| CQL type | Parquet logical type |
+|----------|---------------------|
+| `text`, `varchar`, `ascii` | `STRING` |
+| `int`, `smallint`, `tinyint` | `INT32` / `INT16` / `INT8` |
+| `bigint`, `counter` | `INT64` |
+| `float` | `FLOAT` |
+| `double` | `DOUBLE` |
+| `boolean` | `BOOLEAN` |
+| `uuid`, `timeuuid` | `STRING` (UUID format) |
+| `timestamp` | `INT64` (microseconds since epoch) |
+| `date` | `INT32` (days since epoch) |
+| `blob` | `BYTE_ARRAY` |
+| `list<T>`, `set<T>` | `LIST` group |
+| `map<K,V>` | `MAP` group |
+
+See [Output Formats](/cqlite/user-docs/output-formats/) for the full type map and precision notes.
+
+## Read the Parquet file (Python)
+
+```python
+import pyarrow.parquet as pq
+
+table = pq.read_table('/tmp/simple_table.parquet')
+print(table.to_pandas())
+```
+
+## Failure modes
+
+| Symptom | Error | Fix |
+|---------|-------|-----|
+| `--output` not provided with `--out parquet` | `Error: --output is required for Parquet format` | Add `--output /path/to/file.parquet` |
+| File exists | exit code `6` | Add `--overwrite` |
+| No rows matched | Empty Parquet file (0 row groups) | Check WHERE clause and schema |

--- a/website/src/content/docs/agents-using/export-sstable.md
+++ b/website/src/content/docs/agents-using/export-sstable.md
@@ -1,0 +1,113 @@
+---
+title: Export SSTable for Cassandra import
+description: Re-export CQLite-written rows as Cassandra-compatible nb-format SSTables for sstableloader import.
+sidebar:
+  label: Export SSTable
+  order: 11
+---
+
+# Export SSTable for Cassandra import
+
+**Task**: Export rows written through CQLite's write engine as Cassandra-compatible SSTable files for use with `sstableloader` or direct Cassandra data directory placement.
+
+**Prerequisite**: The CLI must be built with write support:
+
+```bash
+cargo build --package cqlite-cli --features write-support
+```
+
+## Full workflow: write, flush, then export
+
+The `export-sstable` subcommand re-exports data from the write engine's SSTable output. You must write and flush mutations before exporting. The three steps below run in sequence.
+
+<!-- SMOKE:CLI:write -->
+```bash
+cqlite \
+  --schema test-data/schemas/write-test.cql \
+  --data-dir test-data/datasets/sstables \
+  --writable \
+  --write-dir /tmp/cqlite-write \
+  --mutation '{"table":{"keyspace":"test_basic","table":"simple_table"},"partition_key":{"columns":[["id",{"Uuid":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]}]]},"clustering_key":null,"operations":[{"Write":{"column":"name","value":{"Text":"Export Test"}}}],"timestamp_micros":1704067200000000,"ttl_seconds":null,"partition_tombstone":null,"range_tombstones":[]}' \
+  --flush && \
+cqlite \
+  --schema test-data/schemas/write-test.cql \
+  --data-dir test-data/datasets/sstables \
+  --writable \
+  --write-dir /tmp/cqlite-write \
+  export-sstable /tmp/cqlite-export \
+  --keyspace test_basic \
+  --table simple_table
+```
+<!-- /SMOKE:CLI:write -->
+
+**Expected output** (real output):
+
+```
+Export complete:
+  Output: /tmp/cqlite-export/test_basic/simple_table
+  Rows: 2
+  Size: 50 bytes
+  Time: 2.0ms
+```
+
+**Exit code**: `0` on success.
+
+The exported SSTable files are placed at:
+
+```
+/tmp/cqlite-export/
+└── test_basic/
+    └── simple_table/
+        └── nb-1-big-Data.db
+        ...
+```
+
+## Export flags
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `<output-dir>` | Yes | Base directory for exported SSTables |
+| `--keyspace` | Yes | Keyspace to export |
+| `--table` | Yes | Table to export |
+
+## Use with sstableloader
+
+To import exported SSTables into a running Cassandra cluster:
+
+```bash
+sstableloader -d <cassandra-host> /tmp/cqlite-export/test_basic/simple_table
+```
+
+The output directory structure (`<keyspace>/<table>/`) matches the path layout expected by `sstableloader`.
+
+**Note**: CQLite writes `nb`-format (Cassandra 5.0 BigTable) SSTables. These are compatible with Cassandra 5.0+. Cassandra 4.x uses `mc`-format and cannot read `nb` files directly.
+
+## Export requires --writable mode
+
+If `--writable` is omitted, the export subcommand fails:
+
+```bash
+cqlite \
+  --schema test-data/schemas/write-test.cql \
+  --data-dir test-data/datasets/sstables \
+  export-sstable /tmp/export --keyspace test_basic --table simple_table
+```
+
+**Error**:
+
+```
+Error: Export requires --writable mode
+```
+
+**Exit code**: `0` (error is printed but exits cleanly).
+
+**Fix**: Add `--writable --write-dir /path/to/write-dir` before the subcommand.
+
+## Failure modes
+
+| Symptom | Error | Fix |
+|---------|-------|-----|
+| `--writable` omitted | `Error: Export requires --writable mode` | Add `--writable --write-dir <dir>` |
+| Output dir already has files | Re-exports cleanly (does not fail) | Safe to re-run |
+| Empty export (Rows: 0) | No mutations flushed to `--write-dir` | Write and flush mutations first |
+| Wrong `--write-dir` | Empty export or IO error | Use the same `--write-dir` as your write operations |

--- a/website/src/content/docs/agents-using/index.md
+++ b/website/src/content/docs/agents-using/index.md
@@ -1,6 +1,6 @@
 ---
 title: "For Agents: Using CQLite"
-description: Task-oriented recipes for AI agents integrating with or automating CQLite.
+description: Task-oriented recipes for AI agents integrating with or automating CQLite. Every command was run against the real cassandra5-small-full-v3.1 test datasets.
 sidebar:
   label: Overview
   order: 0
@@ -8,50 +8,92 @@ sidebar:
 
 # For Agents: Using CQLite
 
-This section provides terse, copy-pasteable, machine-verifiable recipes for AI
-agents that integrate with CQLite — as a CLI tool, Rust library, Python package,
-or Node.js module.
+Terse, copy-pasteable, machine-verifiable recipes for agents that integrate with CQLite as a CLI tool, Python package, or Node.js module.
 
-> **Content arriving in W6.** This placeholder marks the section structure.
-> Full recipe pages — each covering one task with exact commands, expected output
-> shapes, exit codes, and failure modes — will be published as part of issue W6
-> in epic #733.
+**All commands on these pages were run against the real `cassandra5-small-full-v3.1` test datasets.** Expected outputs are trimmed but structurally accurate.
 
-## What you'll find here (W6 onwards)
+## Recipes
 
-Each page covers exactly one task:
+| Page | Task | Interface |
+|------|------|-----------|
+| [SSTable to JSON one-liner](/cqlite/agents-using/sstable-to-json/) | Dump a table as a JSON array | CLI |
+| [Query from Python](/cqlite/agents-using/query-python/) | Open a database and run SELECT from Python | Python |
+| [Query from Node.js](/cqlite/agents-using/query-nodejs/) | Open a database and run SELECT from Node.js | Node.js |
+| [Export to Parquet](/cqlite/agents-using/export-parquet/) | Write query results to a Parquet file | CLI |
+| [Export to CSV](/cqlite/agents-using/export-csv/) | Write query results to a CSV file | CLI |
+| [Inspect schema](/cqlite/agents-using/inspect-schema/) | Discover which tables and columns are available | CLI |
+| [Count rows](/cqlite/agents-using/count-rows/) | Count rows in a table with and without filters | CLI |
+| [Read collections](/cqlite/agents-using/read-collections/) | Query LIST, SET, and MAP columns | CLI + Python |
+| [Handle missing-schema errors](/cqlite/agents-using/missing-schema/) | Diagnose and fix schema-not-found failures | CLI |
+| [Write a mutation and flush](/cqlite/agents-using/write-mutation/) | Insert a row and flush the memtable to SSTable | CLI |
+| [Export SSTable for Cassandra import](/cqlite/agents-using/export-sstable/) | Re-export SSTables in Cassandra-compatible format | CLI |
 
-- **Open a database and run a SELECT** — CLI and all binding APIs
-- **Filter with WHERE clauses** — supported predicates and operators
-- **Export to JSON/CSV/Parquet** — `--out` flag usage and output shapes
-- **Read collections** — lists, sets, maps in all bindings
-- **Read UDTs** — user-defined types
-- **Streaming large result sets** — Node.js and Python streaming APIs
-- **Write mutations** — INSERT/UPDATE via write support
-- **Error codes and recovery** — all error codes, categories, and retry patterns
-- **Verify output against sstabledump** — parity validation workflow
-- **Troubleshooting** — common failures and fixes
+## Setup
+
+Every recipe assumes:
+
+```bash
+export CQLITE_DATASETS_ROOT=/path/to/test-data/datasets
+```
+
+Schemas are in `test-data/schemas/`. The write-support recipes require the CLI built with `--features write-support`:
+
+```bash
+cargo build --package cqlite-cli --features write-support
+```
 
 ## Design principles
 
-Every recipe in this section is:
+1. **Real output** — every example was executed; no invented data.
+2. **Exit codes documented** — 0 = success; non-zero = failure.
+3. **Failure modes explicit** — each recipe lists the exact error text for the most common failures.
+4. **Terse** — code first.
 
-1. **Verifiable** — commands run against the real test datasets
-2. **Complete** — includes setup, execution, expected output, and teardown
-3. **Terse** — no prose that agents must skip over; code first
-4. **Honest about limitations** — documents what doesn't work and why
+## Error codes
 
-## Error code reference
+Error codes used by the CLI (exit code 0 = success; all errors print to stderr) and thrown as JavaScript/Python exceptions by the bindings.
 
-The following error codes are thrown by CQLite bindings (full table in W6):
+| Code | Category | Description | Typical cause |
+|------|----------|-------------|---------------|
+| `IO` | System | I/O errors — file read/write, file not found | Missing Data.db, wrong path |
+| `SCHEMA` | Schema | Schema or table lookup failure | `--schema` not provided, or table name typo |
+| `QUERY` | Query | Query execution or CQL syntax error | Unsupported CQL, bad column name |
+| `PARSE` | Data | Binary format parsing or type conversion error | Corrupt SSTable, unsupported format |
+| `CONFIG` | Configuration | Configuration validation error | Missing required option, bad flag combination |
+| `STORAGE` | Storage | Storage engine error | WriteEngine misconfiguration |
+| `NOT_FOUND` | NotFound | Resource does not exist | Table has no SSTables on disk |
+| `INVALID_INPUT` | Logic | Invalid operation or state | Type mismatch in mutation, bad JSON mutation format |
 
-| Code | Category | Description |
-|------|----------|-------------|
-| `IO` | System | I/O errors |
-| `SCHEMA` | Schema | Schema/table errors |
-| `QUERY` | Query | Query execution errors |
-| `PARSE` | Data | Binary format parsing errors |
-| `CONFIG` | Configuration | Configuration errors |
-| `STORAGE` | Storage | Storage engine errors |
-| `NOT_FOUND` | NotFound | Resource not found |
-| `INVALID_INPUT` | Logic | Invalid operation or state |
+### CLI exit codes
+
+| Exit code | Meaning |
+|-----------|---------|
+| `0` | Success |
+| `1` | Unhandled / internal error |
+| `2` | Invalid CLI arguments |
+| `3` | Schema or query error (SCHEMA / QUERY category) |
+| `5` | Parse error (PARSE category) |
+| `6` | File already exists (use `--overwrite` to force) |
+
+### Node.js error properties
+
+```javascript
+try {
+  await db.executeNative('SELECT * FROM unknown.table');
+} catch (err) {
+  console.log(err.code);          // e.g. "SCHEMA"
+  console.log(err.category);      // e.g. "Schema"
+  console.log(err.isRecoverable); // false for most schema/config errors
+}
+```
+
+### Python exception type
+
+```python
+import cqlite
+try:
+    with cqlite.open('/no/such/path', schema='schema.cql') as db:
+        pass
+except cqlite.CqliteError as e:
+    print(e)  # human-readable message
+```

--- a/website/src/content/docs/agents-using/inspect-schema.md
+++ b/website/src/content/docs/agents-using/inspect-schema.md
@@ -1,0 +1,135 @@
+---
+title: Inspect schema
+description: Discover which tables, keyspaces, and columns are available in an SSTable directory.
+sidebar:
+  label: Inspect schema
+  order: 6
+---
+
+# Inspect schema
+
+**Task**: Discover the tables and columns available in a data directory before writing queries.
+
+## Verify schema loads correctly
+
+Run a deliberately limited query to confirm schema loading and data accessibility:
+
+<!-- SMOKE:CLI -->
+```bash
+cqlite \
+  --schema test-data/schemas/basic-types.cql \
+  --data-dir test-data/datasets/sstables \
+  --query "SELECT id, name FROM test_basic.simple_table LIMIT 1" \
+  --out json
+```
+<!-- /SMOKE:CLI -->
+
+**Expected** (confirms schema loaded and data is accessible):
+
+```json
+[
+  {
+    "id": "0023ece7-7c4e-4705-9068-d1a59ec5fe19",
+    "name": "Debbie Soto"
+  }
+]
+```
+
+If this returns an empty array or an error, see [Failure modes](#failure-modes) below.
+
+## Discover available tables
+
+List every `Data.db` file in the dataset root to enumerate keyspaces and tables:
+
+```bash
+find test-data/datasets/sstables -name "*-Data.db" \
+  | sed 's|.*/\([^/]*\)/[^/]*-Data.db|\1|' \
+  | sort -u
+```
+
+**Expected output** (test datasets):
+
+```
+collection_clustering_table-6bf78680a25111f0a3fef1a551383fb9
+collection_table-6b8c8fb0a25111f0a3fef1a551383fb9
+sensor_data-...
+simple_table-...
+...
+```
+
+Each SSTable directory is named `<table_name>-<uuid_hash>`. The prefix before the first `-` is the table name. Keyspace directories contain one or more such table directories.
+
+## Discover available keyspaces
+
+```bash
+ls -1 test-data/datasets/sstables/
+```
+
+**Expected output**:
+
+```
+system
+system_auth
+system_distributed
+system_schema
+system_traces
+test_basic
+test_collections
+test_timeseries
+test_wide_rows
+```
+
+The `system_*` keyspaces contain Cassandra internal metadata. The `test_*` keyspaces contain application data.
+
+## Read the schema file
+
+```bash
+grep -E "^(CREATE TABLE|USE )" test-data/schemas/basic-types.cql
+```
+
+**Expected output** (enumerates keyspace and table names):
+
+```
+USE test_basic;
+CREATE TABLE IF NOT EXISTS simple_table (
+CREATE TABLE IF NOT EXISTS multi_pk_table (
+CREATE TABLE IF NOT EXISTS typed_table (
+...
+```
+
+## Inspect column types for a specific table
+
+```bash
+awk '/CREATE TABLE IF NOT EXISTS simple_table/,/^\)/' \
+  test-data/schemas/basic-types.cql
+```
+
+**Expected output** (column definitions for `simple_table`):
+
+```
+CREATE TABLE IF NOT EXISTS simple_table (
+    id UUID PRIMARY KEY,
+    name TEXT,
+    age INT,
+    salary BIGINT,
+    ...
+)
+```
+
+## Available schema files
+
+| Schema file | Keyspace | Tables |
+|-------------|----------|--------|
+| `basic-types.cql` | `test_basic` | `simple_table`, `multi_pk_table`, `typed_table`, and others |
+| `collections.cql` | `test_collections` | `collection_table`, `nested_collections_table`, and others |
+| `time-series.cql` | `test_timeseries` | `sensor_data`, `events_table`, and others |
+| `wide-rows.cql` | `test_wide_rows` | `wide_partition_table`, `many_columns_table`, and others |
+
+## Failure modes
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Zero rows returned | Data.db file missing (only JSONL goldens present) | Run `bash test-data/scripts/fetch-datasets.sh` |
+| `Schema not found` error | Wrong table name in query, or wrong `--schema` file | Check schema file for exact table name |
+| WARN about BTI format on stderr | `da-` prefixed SSTables in the directory | BTI format not supported; only `nb-` SSTables are readable |
+| Empty `ls` output | Dataset not fetched | Run `bash test-data/scripts/fetch-datasets.sh` |

--- a/website/src/content/docs/agents-using/missing-schema.md
+++ b/website/src/content/docs/agents-using/missing-schema.md
@@ -1,0 +1,132 @@
+---
+title: Handle missing-schema errors
+description: Diagnose and fix the most common CQLite failure — schema not found — including exact error text and recovery steps.
+sidebar:
+  label: Handle schema errors
+  order: 9
+---
+
+# Handle missing-schema errors
+
+**Task**: Understand and recover from the `Schema not found for table '...'` error.
+
+## The error
+
+Running a query without providing a schema file, or with the wrong schema:
+
+<!-- SMOKE:CLI:exit=3 -->
+```bash
+cqlite \
+  --data-dir test-data/datasets/sstables \
+  --query "SELECT id, name FROM test_basic.simple_table LIMIT 1" \
+  --out json
+```
+<!-- /SMOKE:CLI:exit=3 -->
+
+**Exact error output** (stderr):
+
+```
+Error: Schema not found for table 'simple_table'
+
+Cause: Table schema not found: simple_table
+
+Troubleshooting:
+1. Verify table name matches schema definition
+2. Check that schema file was loaded correctly
+3. Use 'read-sstable' command to inspect SSTable contents directly
+
+Hint: Use ':schema load <file>' or '--schema <path>' to provide schema
+```
+
+**Exit code**: `3`
+
+## Fix: add --schema
+
+```bash
+cqlite \
+  --schema test-data/schemas/basic-types.cql \
+  --data-dir test-data/datasets/sstables \
+  --query "SELECT id, name FROM test_basic.simple_table LIMIT 1" \
+  --out json
+```
+
+**Expected output** (error resolved):
+
+```json
+[{"id": "0023ece7-7c4e-4705-9068-d1a59ec5fe19", "name": "Debbie Soto"}]
+```
+
+## Schema file selection
+
+| Keyspace prefix | Schema file |
+|-----------------|-------------|
+| `test_basic.*` | `test-data/schemas/basic-types.cql` |
+| `test_collections.*` | `test-data/schemas/collections.cql` |
+| `test_timeseries.*` | `test-data/schemas/time-series.cql` |
+| `test_wide_rows.*` | `test-data/schemas/wide-rows.cql` |
+
+## Wrong table name
+
+Providing a schema but misspelling the table name produces the same error:
+
+```bash
+cqlite \
+  --schema test-data/schemas/basic-types.cql \
+  --data-dir test-data/datasets/sstables \
+  --query "SELECT id FROM test_basic.simpel_table LIMIT 1"
+```
+
+**Error**:
+
+```
+Error: Schema not found for table 'simpel_table'
+```
+
+**Exit code**: `3`
+
+**Fix**: correct the table name to match the `CREATE TABLE` in the schema file.
+
+## Python
+
+```python
+import cqlite
+
+try:
+    with cqlite.open(
+        "test-data/datasets/sstables"
+        # schema= intentionally omitted
+    ) as db:
+        for row in db.execute("SELECT id FROM test_basic.simple_table LIMIT 1"):
+            print(row.to_dict())
+except cqlite.CqliteError as e:
+    print("Error:", e)
+    # Error: Schema not found for table 'simple_table'
+```
+
+## Node.js
+
+```javascript
+const { Database } = require('@cqlite/node');
+
+(async () => {
+  // schema option intentionally omitted
+  const db = await Database.open('test-data/datasets/sstables');
+  try {
+    await db.executeNative('SELECT id FROM test_basic.simple_table LIMIT 1');
+  } catch (err) {
+    console.log('code:', err.code);      // "SCHEMA"
+    console.log('message:', err.message); // "Schema not found..."
+  } finally {
+    await db.close();
+  }
+})();
+```
+
+## Other common schema errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `Schema not found for table '...'` | Missing `--schema` or wrong file | Add `--schema` with the right `.cql` file |
+| `Table schema not found: ...` | Table name in query doesn't match schema | Check CREATE TABLE names in the schema file |
+| `Partition key column count mismatch` | Wrong schema for table (different column count) | Use the schema file that matches the SSTable |
+| Zero rows, no error | Data.db files not fetched | Run `bash test-data/scripts/fetch-datasets.sh` |

--- a/website/src/content/docs/agents-using/query-nodejs.md
+++ b/website/src/content/docs/agents-using/query-nodejs.md
@@ -1,0 +1,166 @@
+---
+title: Query from Node.js
+description: Open a CQLite database and run SELECT queries from JavaScript or TypeScript using @cqlite/node.
+sidebar:
+  label: Query from Node.js
+  order: 3
+---
+
+# Query from Node.js
+
+**Task**: Open a Cassandra 5.0 SSTable directory and query it from JavaScript/TypeScript.
+
+## Install
+
+```bash
+npm install @cqlite/node
+```
+
+Requires Node.js 18+. Pre-built binaries for Linux (x86_64, ARM64), macOS (Intel and Apple Silicon), and Windows (x64). See [Node.js Bindings](/cqlite/user-docs/nodejs/) for full install details.
+
+## Basic query
+
+<!-- SMOKE:NODE -->
+```javascript
+const { Database } = require('@cqlite/node');
+
+(async () => {
+  const db = await Database.open('test-data/datasets/sstables', {
+    schema: 'test-data/schemas/basic-types.cql',
+  });
+
+  const result = await db.executeNative(
+    'SELECT id, name, age FROM test_basic.simple_table LIMIT 3'
+  );
+
+  console.log('Rows:', result.rowCount);
+  for (const row of result.rows) {
+    console.log(JSON.stringify(row));
+  }
+
+  await db.close();
+})();
+```
+<!-- /SMOKE:NODE -->
+
+**Expected output** (real output):
+
+```
+Rows: 3
+{"name":"Debbie Soto","age":79,"id":"0023ece7-7c4e-4705-9068-d1a59ec5fe19"}
+{"age":58,"name":"Richard Parker","id":"009fb913-7173-40df-b4ea-67ed6834cfe5"}
+{"age":47,"name":"Andrew Meyers","id":"00a74226-9bde-4259-9ba0-d74359e8013e"}
+```
+
+Note: key order in row objects may vary; do not rely on property order.
+
+## executeNative() vs execute()
+
+Use `executeNative()`. The older `execute()` method encodes `varint` and `decimal` as hex strings; `executeNative()` returns `BigInt`, `Date`, `Buffer`, `Set`, and `Map` directly.
+
+```javascript
+// executeNative — recommended
+const result = await db.executeNative('SELECT id, name FROM test_basic.simple_table LIMIT 1');
+// result.rows[0].id is a string (UUID)
+// result.rows[0].name is a string
+
+// execute — deprecated
+const result2 = await db.execute('SELECT id, name FROM test_basic.simple_table LIMIT 1');
+// varint fields would appear as "0x..." hex strings
+```
+
+## Type mapping (executeNative)
+
+| CQL type | JavaScript type |
+|----------|----------------|
+| `text`, `varchar`, `ascii` | `string` |
+| `int`, `smallint`, `tinyint` | `number` |
+| `bigint`, `counter` | `BigInt` |
+| `float`, `double` | `number` |
+| `boolean` | `boolean` |
+| `uuid`, `timeuuid` | `string` (standard UUID format) |
+| `timestamp` | `Date` |
+| `date` | `string` (YYYY-MM-DD) |
+| `time` | `BigInt` (nanoseconds since midnight) |
+| `blob` | `Buffer` |
+| `inet` | `string` (dotted decimal or IPv6) |
+| `decimal` | `string` (exact decimal string) |
+| `varint` | `BigInt` |
+| `list<T>` | `Array` |
+| `set<T>` | `Set` |
+| `map<K,V>` | `Map` |
+
+## QueryResult fields
+
+```typescript
+interface QueryResult {
+  rows: object[];            // one object per row
+  rowCount: number;          // number of rows returned
+  executionTimeMs: number;   // wall-clock time in ms
+  columns: ColumnInfo[];     // column metadata
+}
+
+interface ColumnInfo {
+  name: string;
+  dataType: string;          // e.g. "Text", "Integer", "List"
+  nullable: boolean;
+  position: number;          // 0-indexed
+  tableName: string | null;
+}
+```
+
+## Filtering with WHERE
+
+```javascript
+const result = await db.executeNative(
+  'SELECT id, name, age FROM test_basic.simple_table WHERE age > 70 LIMIT 3'
+);
+
+for (const row of result.rows) {
+  console.log(row.name, row.age);
+}
+```
+
+**Expected** (first 3 rows where age > 70):
+
+```
+Debbie Soto 79
+Angela Davis 72
+Sabrina Rodriguez 78
+```
+
+## Streaming large result sets
+
+For large tables, use `executeStreaming()` to avoid loading the full result into memory:
+
+```javascript
+const stream = await db.executeStreaming(
+  'SELECT id, name FROM test_basic.simple_table'
+);
+
+let count = 0;
+for await (const row of stream) {
+  count++;
+}
+console.log('Total rows:', count); // 1000
+```
+
+## Always close the database
+
+```javascript
+const db = await Database.open(dataDir, { schema });
+try {
+  // ... queries ...
+} finally {
+  await db.close(); // idempotent — safe to call multiple times
+}
+```
+
+## Failure modes
+
+| Symptom | Error `code` | Fix |
+|---------|--------------|-----|
+| No `schema` option | `"SCHEMA"` | Pass `schema: '/path/to/schema.cql'` in options |
+| Path does not exist | `"IO"` | Check the data directory path |
+| Table not in schema | `"SCHEMA"` | Verify the table name in the CQL |
+| BTI-format SSTables | `0` rows returned | BTI format not yet supported |

--- a/website/src/content/docs/agents-using/query-python.md
+++ b/website/src/content/docs/agents-using/query-python.md
@@ -1,0 +1,137 @@
+---
+title: Query from Python
+description: Open a CQLite database and run SELECT queries from Python using the cqlite package.
+sidebar:
+  label: Query from Python
+  order: 2
+---
+
+# Query from Python
+
+**Task**: Open a Cassandra 5.0 SSTable directory and query it from Python.
+
+## Install
+
+```bash
+pip install cqlite
+```
+
+Requires Python 3.9+. Pre-built wheels for Linux (x86_64, ARM64), macOS (Intel and Apple Silicon), and Windows (x64). See [Python Bindings](/cqlite/user-docs/python/) for full install details.
+
+## Basic query
+
+<!-- SMOKE:PYTHON -->
+```python
+import cqlite
+
+with cqlite.open(
+    "test-data/datasets/sstables",
+    schema="test-data/schemas/basic-types.cql",
+) as db:
+    for row in db.execute(
+        "SELECT id, name, age FROM test_basic.simple_table LIMIT 3"
+    ):
+        print(row.to_dict())
+```
+<!-- /SMOKE:PYTHON -->
+
+**Expected output** (real output):
+
+```
+{'id': UUID('0023ece7-7c4e-4705-9068-d1a59ec5fe19'), 'name': 'Debbie Soto', 'age': 79}
+{'id': UUID('009fb913-7173-40df-b4ea-67ed6834cfe5'), 'name': 'Richard Parker', 'age': 58}
+{'id': UUID('00a74226-9bde-4259-9ba0-d74359e8013e'), 'age': 47, 'name': 'Andrew Meyers'}
+```
+
+Note: column order in `to_dict()` may vary; do not rely on insertion order.
+
+## Type mapping
+
+Python receives native types — no string serialization:
+
+| CQL type | Python type |
+|----------|------------|
+| `text`, `varchar`, `ascii` | `str` |
+| `int`, `smallint`, `tinyint` | `int` |
+| `bigint`, `counter` | `int` |
+| `float`, `double` | `float` |
+| `boolean` | `bool` |
+| `uuid`, `timeuuid` | `uuid.UUID` |
+| `timestamp` | `datetime.datetime` (UTC) |
+| `date` | `datetime.date` |
+| `time` | `datetime.timedelta` |
+| `blob` | `bytes` |
+| `inet` | `str` (dotted decimal or IPv6) |
+| `decimal` | `decimal.Decimal` |
+| `varint` | `int` |
+| `list<T>` | `list` |
+| `set<T>` | `frozenset` |
+| `map<K,V>` | `dict` |
+
+## Row access
+
+```python
+with cqlite.open("test-data/datasets/sstables",
+                 schema="test-data/schemas/basic-types.cql") as db:
+    for row in db.execute(
+        "SELECT id, name, age FROM test_basic.simple_table LIMIT 1"
+    ):
+        # Dict-style access
+        d = row.to_dict()
+        print(d["name"])        # "Debbie Soto"
+
+        # Attribute access
+        print(row["name"])      # "Debbie Soto"
+
+        # Column names
+        print(row.column_names) # ['id', 'name', 'age']
+```
+
+## Filtering with WHERE
+
+```python
+with cqlite.open("test-data/datasets/sstables",
+                 schema="test-data/schemas/basic-types.cql") as db:
+    for row in db.execute(
+        "SELECT id, name, age FROM test_basic.simple_table"
+        " WHERE age > 70 LIMIT 3"
+    ):
+        print(row.to_dict())
+```
+
+**Expected** (first 3 rows where age > 70):
+
+```
+{'id': UUID('0023ece7-...'), 'name': 'Debbie Soto', 'age': 79}
+{'id': UUID('029fc1c4-...'), 'name': 'Angela Davis', 'age': 72}
+{'id': UUID('05d341e9-...'), 'name': 'Sabrina Rodriguez', 'age': 78}
+```
+
+## Querying collections
+
+```python
+with cqlite.open("test-data/datasets/sstables",
+                 schema="test-data/schemas/collections.cql") as db:
+    for row in db.execute(
+        "SELECT id, tags, scores FROM test_collections.collection_table LIMIT 2"
+    ):
+        d = row.to_dict()
+        print("tags:", d["tags"])    # frozenset — SET<TEXT>
+        print("scores:", d["scores"]) # list — LIST<INT>
+```
+
+**Expected**:
+
+```
+tags: frozenset({'smile', 'dinner', 'media'})
+scores: [78, 12, 11, 31, 83, 30, 10, 38, 40]
+```
+
+## Failure modes
+
+| Symptom | Exception | Fix |
+|---------|-----------|-----|
+| No `schema=` argument | `cqlite.CqliteError: Schema not found for table '...'` | Pass `schema=` path |
+| Path does not exist | `cqlite.CqliteError: ...` (IO category) | Check path |
+| Table not in schema | `cqlite.CqliteError: Schema not found for table '...'` | Verify table name |
+| BTI-format SSTables | Query succeeds but 0 rows | BTI format not yet supported |

--- a/website/src/content/docs/agents-using/read-collections.md
+++ b/website/src/content/docs/agents-using/read-collections.md
@@ -1,0 +1,131 @@
+---
+title: Read collections
+description: Query LIST, SET, and MAP columns from Cassandra 5.0 SSTables using CQLite.
+sidebar:
+  label: Read collections
+  order: 8
+---
+
+# Read collections
+
+**Task**: Query tables with `LIST`, `SET`, and `MAP` columns.
+
+## CLI: LIST and SET columns
+
+<!-- SMOKE:CLI -->
+```bash
+cqlite \
+  --schema test-data/schemas/collections.cql \
+  --data-dir test-data/datasets/sstables \
+  --query "SELECT id, tags, scores FROM test_collections.collection_table LIMIT 2" \
+  --out json
+```
+<!-- /SMOKE:CLI -->
+
+**Expected output** (real output):
+
+```json
+[
+  {
+    "id": "00a6220f-d42c-4f49-938e-08ada7ddc398",
+    "tags": ["dinner", "media", "smile"],
+    "scores": [78, 12, 11, 31, 83, 30, 10, 38, 40]
+  },
+  {
+    "id": "013ba6da-bce5-4cd8-b3a0-a5b20c211e4c",
+    "tags": ["base", "draw", "girl", "last", "parent", "perhaps", "safe", "single", "student"],
+    "scores": [78, 58, 57, 54, 98, 2]
+  }
+]
+```
+
+In JSON output:
+- `SET<TEXT>` columns render as a JSON array (order is not guaranteed — a set has no defined order).
+- `LIST<INT>` columns render as a JSON array (preserving insertion order).
+
+## CLI: MAP columns
+
+```bash
+cqlite \
+  --schema test-data/schemas/collections.cql \
+  --data-dir test-data/datasets/sstables \
+  --query "SELECT id, properties FROM test_collections.collection_table LIMIT 2" \
+  --out json
+```
+
+**Expected**:
+
+```json
+[
+  {
+    "id": "00a6220f-d42c-4f49-938e-08ada7ddc398",
+    "properties": {
+      "key1": "value1",
+      "key2": "value2"
+    }
+  }
+]
+```
+
+`MAP<TEXT, TEXT>` renders as a JSON object with string keys.
+
+## Python: collections as native types
+
+```python
+import cqlite
+
+with cqlite.open(
+    "test-data/datasets/sstables",
+    schema="test-data/schemas/collections.cql",
+) as db:
+    for row in db.execute(
+        "SELECT id, tags, scores FROM test_collections.collection_table LIMIT 2"
+    ):
+        d = row.to_dict()
+        print("tags:", d["tags"])    # frozenset — SET<TEXT>
+        print("scores:", d["scores"]) # list — LIST<INT>
+```
+
+**Expected output** (real output):
+
+```
+tags: frozenset({'smile', 'dinner', 'media'})
+scores: [78, 12, 11, 31, 83, 30, 10, 38, 40]
+```
+
+Python type mapping for collections:
+- `SET<T>` → `frozenset` (iteration order unspecified)
+- `LIST<T>` → `list` (order preserved)
+- `MAP<K,V>` → `dict`
+
+## Schema for collections
+
+The `test_collections.collection_table` schema:
+
+```sql
+CREATE TABLE test_collections.collection_table (
+    id UUID PRIMARY KEY,
+    tags SET<TEXT>,
+    scores LIST<INT>,
+    properties MAP<TEXT, TEXT>,
+    numbers_set SET<INT>,
+    ordered_values LIST<TIMESTAMP>,
+    metadata_map MAP<TEXT, BIGINT>
+);
+```
+
+## Nested/frozen collections
+
+Frozen collections (`FROZEN<LIST<INT>>`, `FROZEN<SET<TEXT>>`, etc.) serialize the same way as their non-frozen equivalents in query output.
+
+## Known limitations
+
+- `set` element tombstones (partial set deletions) are not fully supported; a set with partial tombstones may return extra elements. See issue #493.
+- Collection ordering in `SET` output is not deterministic; do not assert a specific order in tests.
+
+## Failure modes
+
+| Symptom | Error | Fix |
+|---------|-------|-----|
+| Empty array for collection column | Null / empty collection in data | Normal; row may have no items |
+| Wrong schema file | `Schema not found` | Use `collections.cql` for `test_collections.*` tables |

--- a/website/src/content/docs/agents-using/sstable-to-json.md
+++ b/website/src/content/docs/agents-using/sstable-to-json.md
@@ -1,0 +1,106 @@
+---
+title: SSTable to JSON one-liner
+description: Dump a Cassandra 5.0 SSTable table to a JSON array on stdout using one cqlite command.
+sidebar:
+  label: SSTable to JSON
+  order: 1
+---
+
+# SSTable to JSON one-liner
+
+**Task**: Dump all rows from a table to a JSON array on stdout.
+
+<!-- SMOKE:CLI -->
+```bash
+cqlite \
+  --schema test-data/schemas/basic-types.cql \
+  --data-dir test-data/datasets/sstables \
+  --query "SELECT id, name, age FROM test_basic.simple_table LIMIT 3" \
+  --out json
+```
+<!-- /SMOKE:CLI -->
+
+**Expected output shape** (real output, trimmed to 3 rows):
+
+```json
+[
+  {
+    "id": "0023ece7-7c4e-4705-9068-d1a59ec5fe19",
+    "name": "Debbie Soto",
+    "age": 79
+  },
+  {
+    "id": "009fb913-7173-40df-b4ea-67ed6834cfe5",
+    "name": "Richard Parker",
+    "age": 58
+  },
+  {
+    "id": "00a74226-9bde-4259-9ba0-d74359e8013e",
+    "name": "Andrew Meyers",
+    "age": 47
+  }
+]
+```
+
+**Exit code**: `0` on success.
+
+**Output format**:
+- Array of objects, one object per row.
+- Written to stdout; redirect with `--output /path/to/out.json`.
+- INFO/WARN log lines go to stderr; stdout is clean JSON.
+
+## Dump all columns
+
+Omit the column list in the SELECT to retrieve all columns:
+
+<!-- SMOKE:CLI -->
+```bash
+cqlite \
+  --schema test-data/schemas/basic-types.cql \
+  --data-dir test-data/datasets/sstables \
+  --query "SELECT * FROM test_basic.simple_table LIMIT 1" \
+  --out json
+```
+<!-- /SMOKE:CLI -->
+
+**Expected keys** (19 columns in `simple_table`; null columns omitted from objects):
+
+```
+id, name, age, salary, height, weight, active, created, birth_date,
+work_time, description, account_balance, session_id, ip_address,
+small_number, medium_number, duration_val, varchar_field, large_int
+```
+
+## Write to a file
+
+```bash
+cqlite \
+  --schema test-data/schemas/basic-types.cql \
+  --data-dir test-data/datasets/sstables \
+  --query "SELECT * FROM test_basic.simple_table" \
+  --out json \
+  --output /tmp/simple_table.json
+```
+
+Use `--overwrite` to replace an existing file (exit code `6` if the file exists and `--overwrite` is not set).
+
+## Failure modes
+
+| Symptom | Error text | Fix |
+|---------|-----------|-----|
+| No `--schema` flag | `Error: Schema not found for table 'simple_table'` | Add `--schema path/to/schema.cql` |
+| Wrong table name | `Error: Schema not found for table 'bad_name'` | Check table name matches schema |
+| Output file exists | exit code `6` | Add `--overwrite` |
+| BTI-format SSTable | WARN on stderr, 0 rows returned | BTI (`da-` prefix) not supported; use `nb-` SSTables |
+
+## Type mapping
+
+See the full type map in [Output Formats](/cqlite/user-docs/output-formats/).
+
+Key rules:
+- UUIDs → string (`"0023ece7-..."`)
+- Timestamps → string (`"2025-10-06 01:00:30.616+0000"`)
+- Booleans → `true` / `false`
+- Integers → JSON number
+- Floats → JSON number (may include rounding artifacts)
+- `null` columns are omitted from the JSON object (not rendered as `null`)

--- a/website/src/content/docs/agents-using/write-mutation.md
+++ b/website/src/content/docs/agents-using/write-mutation.md
@@ -1,0 +1,194 @@
+---
+title: Write a mutation and flush
+description: Insert a row into a CQLite write-enabled database and flush the memtable to an SSTable file.
+sidebar:
+  label: Write mutation + flush
+  order: 10
+---
+
+# Write a mutation and flush
+
+**Task**: Insert a row via the JSON mutation format and flush the in-memory write buffer to disk.
+
+**Prerequisite**: The CLI must be built with write support:
+
+```bash
+cargo build --package cqlite-cli --features write-support
+```
+
+The write-support flag adds `--writable`, `--write-dir`, `--mutation`, `--flush`, and write subcommands.
+
+## Write a single row
+
+<!-- SMOKE:CLI:write -->
+```bash
+cqlite \
+  --schema test-data/schemas/write-test.cql \
+  --data-dir test-data/datasets/sstables \
+  --writable \
+  --write-dir /tmp/cqlite-write \
+  --mutation '{
+    "table": {"keyspace": "test_basic", "table": "simple_table"},
+    "partition_key": {"columns": [["id", {"Uuid": [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]}]]},
+    "clustering_key": null,
+    "operations": [{"Write": {"column": "name", "value": {"Text": "Agent Test"}}}],
+    "timestamp_micros": 1704067200000000,
+    "ttl_seconds": null,
+    "partition_tombstone": null,
+    "range_tombstones": []
+  }'
+```
+<!-- /SMOKE:CLI:write -->
+
+**Expected output** (real output):
+
+```
+OK: 1 row(s) affected (4.5ms)
+CQLite CLI v0.10.0
+Use --help for available commands
+```
+
+**Exit code**: `0` on success.
+
+The row is written to the WAL (`/tmp/cqlite-write/wal/commitlog.wal`) and held in the memtable. It is not yet queryable from the SSTable path until flushed.
+
+## Flush the memtable to SSTable
+
+```bash
+cqlite \
+  --schema test-data/schemas/write-test.cql \
+  --data-dir test-data/datasets/sstables \
+  --writable \
+  --write-dir /tmp/cqlite-write \
+  --flush
+```
+
+**Expected output**:
+
+```
+Flushed: 1 partitions, 50 bytes
+  Output: /tmp/cqlite-write/data/test_basic/simple_table/nb-1-big-Data.db
+CQLite CLI v0.10.0
+Use --help for available commands
+```
+
+The flushed SSTable is written to `--write-dir/data/<keyspace>/<table>/`.
+
+## Combine: write + flush in one command
+
+```bash
+cqlite \
+  --schema test-data/schemas/write-test.cql \
+  --data-dir test-data/datasets/sstables \
+  --writable \
+  --write-dir /tmp/cqlite-write \
+  --mutation '{
+    "table": {"keyspace": "test_basic", "table": "simple_table"},
+    "partition_key": {"columns": [["id", {"Uuid": [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]}]]},
+    "clustering_key": null,
+    "operations": [{"Write": {"column": "name", "value": {"Text": "Agent Test"}}}],
+    "timestamp_micros": 1704067200000000,
+    "ttl_seconds": null,
+    "partition_tombstone": null,
+    "range_tombstones": []
+  }' \
+  --flush
+```
+
+**Expected output**:
+
+```
+OK: 1 row(s) affected (20.2ms)
+Flushed: 1 partitions, 50 bytes
+  Output: /tmp/cqlite-write/data/test_basic/simple_table/nb-1-big-Data.db
+CQLite CLI v0.10.0
+Use --help for available commands
+```
+
+## Mutation JSON format
+
+```jsonc
+{
+  // Required: target table
+  "table": {
+    "keyspace": "test_basic",
+    "table": "simple_table"
+  },
+
+  // Required: partition key — array of [column_name, value] pairs
+  // value type tags: Uuid, Integer, Text, BigInt, Boolean, Float, Double, Blob, ...
+  "partition_key": {
+    "columns": [
+      ["id", {"Uuid": [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]}]
+    ]
+  },
+
+  // Required: clustering key or null for tables without clustering columns
+  "clustering_key": null,
+
+  // Required: list of cell operations
+  "operations": [
+    {"Write": {"column": "name", "value": {"Text": "some text"}}},
+    {"Write": {"column": "age", "value": {"Integer": 42}}}
+  ],
+
+  // Required: microseconds since Unix epoch
+  "timestamp_micros": 1704067200000000,
+
+  // Optional: row TTL in seconds (null = no expiration)
+  "ttl_seconds": null,
+
+  // Optional: partition tombstone (deletes entire partition)
+  "partition_tombstone": null,
+
+  // Optional: range tombstones (delete clustering key ranges)
+  "range_tombstones": []
+}
+```
+
+## Value type tags
+
+| CQL type | JSON tag | Example |
+|----------|----------|---------|
+| `UUID` | `"Uuid"` | `{"Uuid": [1,2,...,16]}` (16-byte array) |
+| `INT` | `"Integer"` | `{"Integer": 42}` |
+| `TEXT` | `"Text"` | `{"Text": "hello"}` |
+| `BIGINT` | `"BigInt"` | `{"BigInt": 9223372036854775807}` |
+| `BOOLEAN` | `"Boolean"` | `{"Boolean": true}` |
+| `FLOAT` | `"Float"` | `{"Float": 3.14}` |
+| `DOUBLE` | `"Double"` | `{"Double": 3.141592653589793}` |
+| `BLOB` | `"Blob"` | `{"Blob": [72,101,108,108,111]}` (byte array) |
+
+## Write stats
+
+Check the write engine state:
+
+```bash
+cqlite \
+  --schema test-data/schemas/write-test.cql \
+  --data-dir test-data/datasets/sstables \
+  --writable \
+  --write-dir /tmp/cqlite-write \
+  write-stats
+```
+
+**Expected output**:
+
+```
+Write Engine Statistics:
+  Memtable size: 0 bytes
+  Memtable rows: 0
+  WAL size: 0 bytes
+  Generation: 2
+```
+
+(After a flush, memtable size and rows reset to 0; generation increments.)
+
+## Failure modes
+
+| Symptom | Error | Fix |
+|---------|-------|-----|
+| `--writable` omitted | `Error: Export requires --writable mode` | Add `--writable --write-dir /path` |
+| Wrong value type tag | `Error: Type mismatch: value Integer(42) does not match comparator Uuid` | Use correct value tag for column type |
+| Bad JSON (wrong format) | `Error: Failed to parse mutation JSON: ...` | Ensure JSON matches the Mutation schema above |
+| `Nothing to flush (memtable empty)` | Flush called before any mutations | Write at least one mutation first |


### PR DESCRIPTION
Part of epic #733. Closes #739.

## Summary

- 11 recipe pages under `website/src/content/docs/agents-using/` — section overview + 10 task recipes, every command run against the real `cassandra5-small-full-v3.1` test datasets
- Full error-code table with CLI exit codes and Node.js/Python exception patterns in `index.md`
- `scripts/docs-examples-smoke.sh` — extracts and runs all `<!-- SMOKE:CLI -->` marked blocks from recipe pages against real datasets; a drifted example fails with the recipe name in the error
- `.github/workflows/docs-site.yml` extended with a `smoke` job (builds CLI, fetches datasets with SHA256-keyed cache, runs smoke script); deploy job now depends on both `build` and `smoke`
- `scripts/docs-site-check.sh` extended with `--with-smoke` flag for local mirroring of CI

## Smoke coverage table

| Recipe | CLI in CI | Python in CI | Node.js in CI | Notes |
|--------|-----------|--------------|----------------|-------|
| sstable-to-json.md | Yes (2 blocks) | — | — | |
| export-parquet.md | Yes | — | — | |
| export-csv.md | Yes | — | — | |
| inspect-schema.md | Yes | — | — | |
| count-rows.md | Yes (pipe to python3) | — | — | |
| read-collections.md | Yes | — | — | |
| missing-schema.md | Yes (exit=3) | — | — | |
| write-mutation.md | Yes (CLI:write) | — | — | |
| export-sstable.md | Yes (CLI:write, write+export) | — | — | |
| query-python.md | — | No* | — | |
| query-nodejs.md | — | — | No* | |

*Python and Node.js bindings require a separate build step. `SMOKE:PYTHON` and `SMOKE:NODE` markers are present and supported locally with `--with-bindings`; excluded from CI docs workflow to keep smoke job fast and self-contained.

## Validation evidence

Raw smoke output (10/10 CLI recipes pass):
```
══ docs-examples-smoke summary ══
Passed:  10
Skipped: 2 (Python/Node require --with-bindings)
Failed:  0
DOCS_SMOKE=PASS
```

Raw negative test (breaking sstable-to-json.md with a non-existent table):
```
[FAIL] sstable-to-json.md: expected exit 0, got 3
DOCS_SMOKE=FAIL
```

Raw docs-site-check output:
```
[PASS] npm run build
DOCS_SITE_CHECK=PASS
```

The orchestrator should wait for the CI smoke job on this PR to confirm the workflow runs green end-to-end.