### PR TITLE
docs: W8 llms.txt, raw markdown endpoints, validation (#741)

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -57,8 +57,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build site (includes internal link validation)
+      - name: Build site (includes internal link validation + raw markdown emit)
         run: npm run build
+
+      - name: Validate agent plumbing (llms.txt coverage + raw .md endpoints)
+        run: node scripts/validate-agent-plumbing.mjs
 
       - name: Upload build artifact
         if: github.event_name != 'pull_request'

--- a/scripts/docs-site-check.sh
+++ b/scripts/docs-site-check.sh
@@ -3,8 +3,10 @@
 #
 # Runs:
 #   1. npm ci (install pinned deps)
-#   2. npm run build (Astro build + starlight-links-validator internal link check)
-#   3. [optional] docs-examples-smoke.sh (CLI recipe smoke tests)
+#   2. npm run build (Astro build + starlight-links-validator internal link check
+#                    + emit-raw-markdown.mjs postbuild)
+#   3. Agent-plumbing validation (llms.txt coverage + raw .md endpoint coverage)
+#   4. [optional] docs-examples-smoke.sh (CLI recipe smoke tests)
 #
 # Emits a machine-checkable PASS/FAIL summary block at the end (modelled on
 # scripts/agent-gate.sh). Exit code 0 = all checks passed; non-zero = failure.
@@ -103,14 +105,20 @@ banner "Step 1: Install dependencies"
     fi
 )
 
-banner "Step 2: Build site (includes internal link validation)"
+banner "Step 2: Build site (includes internal link validation + raw markdown emit)"
 (
     cd "$WEBSITE_DIR"
     run_check "npm run build" npm run build
 )
 
+banner "Step 3: Agent-plumbing validation (llms.txt + raw .md endpoints)"
+(
+    cd "$WEBSITE_DIR"
+    run_check "validate-agent-plumbing" node scripts/validate-agent-plumbing.mjs
+)
+
 if [[ "$WITH_SMOKE" == "1" ]]; then
-    banner "Step 3: Example smoke tests (CLI recipes)"
+    banner "Step 4: Example smoke tests (CLI recipes)"
     run_check "docs-examples-smoke" bash "$SCRIPT_DIR/docs-examples-smoke.sh"
 fi
 

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -2,6 +2,7 @@
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
 import starlightLinksValidator from 'starlight-links-validator';
+import starlightLlmsTxt from 'starlight-llms-txt';
 
 // https://astro.build/config
 export default defineConfig({
@@ -30,6 +31,14 @@ export default defineConfig({
           // api-docs.yml to a separate subtree of gh-pages and are not part of
           // the Starlight site build.
           exclude: ['/cqlite/api/**'],
+        }),
+        starlightLlmsTxt({
+          // Generate llms.txt (section map + one-line descriptions) and
+          // llms-full.txt (full content of every page) at the site root.
+          // Plugin version: 0.6.1 (pinned in package.json).
+          // URLs in the generated files use the site + base from astro.config.mjs,
+          // so absolute URLs are: https://pmcfadin.github.io/cqlite/<page-slug>/
+          description: 'Local Apache Cassandra SSTable access without cluster dependencies. Reads Cassandra 5.0 SSTables directly from disk — no cluster, no JVM required.',
         }),
       ],
       sidebar: [

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@astrojs/starlight": "0.34.3",
         "astro": "5.18.2",
-        "starlight-links-validator": "0.15.1"
+        "starlight-links-validator": "0.15.1",
+        "starlight-llms-txt": "^0.6.1"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -1826,6 +1827,12 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
+    "node_modules/@types/braces": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/braces/-/braces-3.0.5.tgz",
+      "integrity": "sha512-SQFof9H+LXeWNz8wDe7oN5zu7ket0qwMu5vZubW4GCJ8Kkeh6nBWUz87+KTz/G3Kqsrp0j/W253XJb3KMEeg3w==",
+      "license": "MIT"
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -1879,6 +1886,15 @@
       "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.14.tgz",
       "integrity": "sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==",
       "license": "MIT"
+    },
+    "node_modules/@types/micromatch": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@types/micromatch/-/micromatch-4.0.10.tgz",
+      "integrity": "sha512-5jOhFDElqr4DKTrTEbnW8DZ4Hz5LRUEmyrGpCMrD/NphYv3nUnaF08xmSLx1rGGnyEs/kFnhiw6dCgcDqMr5PQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/braces": "*"
+      }
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -2742,6 +2758,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/camelcase": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
@@ -3469,6 +3497,18 @@
         }
       }
     },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/flattie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flattie/-/flattie-1.1.1.tgz",
@@ -3835,6 +3875,32 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-mdast": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-mdast/-/hast-util-to-mdast-10.1.2.tgz",
+      "integrity": "sha512-FiCRI7NmOvM4y+f5w32jPRzcxDIz+PUqDwEqn1A+1q2cdp3B8Gx7aVrXORdOKjMNDQsD1ogOr896+0jJHW1EFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-phrasing": "^3.0.0",
+        "hast-util-to-html": "^9.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "rehype-minify-whitespace": "^6.0.0",
+        "trim-trailing-lines": "^2.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-parse5": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
@@ -4089,6 +4155,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/is-plain-obj": {
@@ -5284,6 +5359,31 @@
       ],
       "license": "MIT"
     },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -5808,6 +5908,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/rehype-minify-whitespace": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-minify-whitespace/-/rehype-minify-whitespace-6.0.2.tgz",
+      "integrity": "sha512-Zk0pyQ06A3Lyxhe9vGtOtzz3Z0+qZ5+7icZ/PL/2x1SHPbKao5oB/g/rlc6BCTajqBb33JcOe71Ye1oFsuYbnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-minify-whitespace": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/rehype-parse": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
@@ -5847,6 +5961,23 @@
         "@types/estree": "^1.0.0",
         "@types/hast": "^3.0.0",
         "hast-util-to-estree": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-remark": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-remark/-/rehype-remark-10.0.1.tgz",
+      "integrity": "sha512-EmDndlb5NVwXGfUa4c9GPK+lXeItTilLhE6ADSaQuHr4JUlKw9MidzGzx4HpqZrNCt6vnHmEifXQiiA+CEnjYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "hast-util-to-mdast": "^10.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -6270,6 +6401,33 @@
         "@astrojs/starlight": ">=0.32.0"
       }
     },
+    "node_modules/starlight-llms-txt": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/starlight-llms-txt/-/starlight-llms-txt-0.6.1.tgz",
+      "integrity": "sha512-V0XEj92hrWHCDOu2SiDbgPviKnlB/O4Fqh9yeDxjV+udw9y+mSQ+4Obhlj6UUhjn6gfoj0V7dPLM0Dhbd6j1NA==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/mdx": "^4.0.5",
+        "@types/hast": "^3.0.4",
+        "@types/micromatch": "^4.0.9",
+        "github-slugger": "^2.0.0",
+        "hast-util-select": "^6.0.3",
+        "micromatch": "^4.0.8",
+        "rehype-parse": "^9.0.1",
+        "rehype-remark": "^10.0.0",
+        "remark-gfm": "^4.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.5",
+        "unist-util-remove": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.17.1 || ^20.3.0 || >=21.0.0"
+      },
+      "peerDependencies": {
+        "@astrojs/starlight": ">=0.31",
+        "astro": "^5.15.9"
+      }
+    },
     "node_modules/stream-replace-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
@@ -6396,10 +6554,32 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
       "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trim-trailing-lines": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-2.1.0.tgz",
+      "integrity": "sha512-5UR5Biq4VlVOtzqkm2AZlgvSlDJtME46uV0br0gENbwN4l5+mMKT4b9gJKqWtuL2zAIqajGJGuvbCbcAJUZqBg==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -6584,6 +6764,21 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-remove/-/unist-util-remove-4.0.0.tgz",
+      "integrity": "sha512-b4gokeGId57UVRX/eVKej5gXqGlc9+trkORhFJpu9raqZkZhU0zm8Doi05+HaiBsMEIJowL+2WtQ5ItjsngPXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/website/package.json
+++ b/website/package.json
@@ -10,12 +10,14 @@
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",
+    "postbuild": "node scripts/emit-raw-markdown.mjs",
     "preview": "astro preview",
     "astro": "astro"
   },
   "dependencies": {
     "@astrojs/starlight": "0.34.3",
     "astro": "5.18.2",
-    "starlight-links-validator": "0.15.1"
+    "starlight-links-validator": "0.15.1",
+    "starlight-llms-txt": "0.6.1"
   }
 }

--- a/website/scripts/emit-raw-markdown.mjs
+++ b/website/scripts/emit-raw-markdown.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/**
+ * emit-raw-markdown.mjs
+ *
+ * Post-build step: copies the source Markdown (and MDX) files for every
+ * published page into the Astro dist/ directory so that each page is also
+ * reachable as raw Markdown at <page-url>.md.
+ *
+ * Mapping rule:
+ *   src/content/docs/<slug>.md   →  dist/<slug>.md
+ *   src/content/docs/<slug>.mdx  →  dist/<slug>.md   (extension normalised)
+ *
+ * Index files follow the same rule:
+ *   src/content/docs/user-docs/index.md  →  dist/user-docs/index.md
+ *   (served at /cqlite/user-docs/index.md — matches the page URL + ".md")
+ *
+ * For the site root:
+ *   src/content/docs/index.mdx  →  dist/index.md
+ *
+ * The format-guide pages are generated at build time by sync-format-guide.mjs
+ * and written to src/content/docs/sstable-format/<prefix>.md (gitignored).
+ * They exist on disk when this script runs (postbuild), so they are picked up
+ * by the glob scan automatically — no special handling needed.
+ *
+ * Usage:
+ *   node website/scripts/emit-raw-markdown.mjs
+ *   (called automatically by the "postbuild" npm hook)
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const WEBSITE_DIR = path.resolve(__dirname, '..');
+const CONTENT_DIR = path.join(WEBSITE_DIR, 'src', 'content', 'docs');
+const DIST_DIR = path.join(WEBSITE_DIR, 'dist');
+
+/**
+ * Recursively collect all .md and .mdx files under a directory.
+ * Returns an array of absolute file paths.
+ */
+function collectMarkdownFiles(dir) {
+  const results = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...collectMarkdownFiles(fullPath));
+    } else if (entry.isFile() && (entry.name.endsWith('.md') || entry.name.endsWith('.mdx'))) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+console.log('[emit-raw-markdown] Starting...');
+
+if (!fs.existsSync(DIST_DIR)) {
+  console.error(`[emit-raw-markdown] ERROR: dist/ not found at ${DIST_DIR}`);
+  console.error('[emit-raw-markdown] Run npm run build before this script.');
+  process.exit(1);
+}
+
+const sourceFiles = collectMarkdownFiles(CONTENT_DIR);
+let copied = 0;
+let skipped = 0;
+
+for (const srcPath of sourceFiles) {
+  // Compute the relative path from the content root
+  const relFromContent = path.relative(CONTENT_DIR, srcPath);
+
+  // Normalise extension: .mdx → .md
+  const relNormalized = relFromContent.replace(/\.mdx$/, '.md');
+
+  // The dist path mirrors the content path but lives under dist/
+  const destPath = path.join(DIST_DIR, relNormalized);
+
+  // Only copy if the corresponding HTML page exists in dist
+  // (confirms the page was actually built, not a draft or excluded page).
+  // The HTML is either at dist/<slug>/index.html (directory pages)
+  // or dist/<slug>.html (flat pages, rare in Starlight).
+  // For index.md files: dist/<parent>/index.html or dist/index.html at root.
+
+  const relDir = path.dirname(relNormalized);          // e.g. "user-docs"
+  const relBase = path.basename(relNormalized, '.md'); // e.g. "cli-reference"
+
+  let htmlPath;
+  if (relBase === 'index') {
+    // index pages → dist/<parent>/index.html
+    htmlPath = path.join(DIST_DIR, relDir, 'index.html');
+  } else {
+    // regular pages → dist/<parent>/<slug>/index.html
+    htmlPath = path.join(DIST_DIR, relDir, relBase, 'index.html');
+  }
+
+  if (!fs.existsSync(htmlPath)) {
+    // Page was not built (draft, excluded, or no matching route). Skip.
+    skipped++;
+    continue;
+  }
+
+  // Ensure destination directory exists
+  fs.mkdirSync(path.dirname(destPath), { recursive: true });
+
+  // Copy the source markdown to dist
+  fs.copyFileSync(srcPath, destPath);
+  copied++;
+}
+
+console.log(
+  `[emit-raw-markdown] Done: ${copied} raw .md endpoints written, ${skipped} source files skipped (no matching built page).`
+);

--- a/website/scripts/validate-agent-plumbing.mjs
+++ b/website/scripts/validate-agent-plumbing.mjs
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+/**
+ * validate-agent-plumbing.mjs
+ *
+ * Post-build validation: checks that every published HTML page:
+ *   1. Appears in dist/llms.txt (or dist/llms-full.txt as fallback)
+ *   2. Has a corresponding raw .md endpoint in dist/
+ *
+ * This script inspects dist/ only — no live HTTP requests.
+ * Exit code 0 = all checks pass; 1 = one or more missing pages.
+ *
+ * Usage:
+ *   node website/scripts/validate-agent-plumbing.mjs
+ *   (called by scripts/docs-site-check.sh and docs-site.yml)
+ *
+ * What counts as a "published page":
+ *   Any dist/**\/index.html that is not:
+ *   - 404.html
+ *   - Inside _astro/ or pagefind/ (build artifacts)
+ *
+ * llms.txt coverage:
+ *   The starlight-llms-txt plugin writes page URLs into llms-full.txt
+ *   (one per section, full content). We check that the relative URL path
+ *   of each HTML page appears somewhere in llms-full.txt.
+ *   The top-level llms.txt is a section map; checking llms-full.txt gives
+ *   stronger per-page coverage.
+ *
+ * Raw .md endpoint:
+ *   dist/user-docs/cli-reference/index.html  →  dist/user-docs/cli-reference.md
+ *   dist/user-docs/index.html               →  dist/user-docs/index.md
+ *   dist/index.html                         →  dist/index.md
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const WEBSITE_DIR = path.resolve(__dirname, '..');
+const DIST_DIR = path.join(WEBSITE_DIR, 'dist');
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function abort(msg) {
+  console.error(`[validate-agent-plumbing] ERROR: ${msg}`);
+  process.exit(1);
+}
+
+function collectHtmlPages(dir, baseDir) {
+  baseDir = baseDir ?? dir;
+  const pages = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    // Skip build artefact directories
+    if (entry.isDirectory()) {
+      if (entry.name === '_astro' || entry.name === 'pagefind') continue;
+      pages.push(...collectHtmlPages(fullPath, baseDir));
+    } else if (entry.isFile() && entry.name === 'index.html') {
+      const rel = path.relative(baseDir, dir); // e.g. "user-docs/cli-reference"
+      pages.push(rel === '' ? '/' : '/' + rel + '/');
+    }
+  }
+  return pages;
+}
+
+// ── Pre-flight ─────────────────────────────────────────────────────────────────
+
+if (!fs.existsSync(DIST_DIR)) {
+  abort(`dist/ not found at ${DIST_DIR}. Run npm run build first.`);
+}
+
+const llmsFullPath = path.join(DIST_DIR, 'llms-full.txt');
+const llmsTxtPath  = path.join(DIST_DIR, 'llms.txt');
+
+if (!fs.existsSync(llmsFullPath)) {
+  abort('dist/llms-full.txt not found. The starlight-llms-txt plugin may not be installed or the build failed.');
+}
+if (!fs.existsSync(llmsTxtPath)) {
+  abort('dist/llms.txt not found. The starlight-llms-txt plugin may not be installed or the build failed.');
+}
+
+// ── Collect published pages ────────────────────────────────────────────────────
+
+// Collect all index.html paths, excluding 404
+const rawPages = collectHtmlPages(DIST_DIR);
+// Filter out the 404 page (it lives at dist/404.html, not dist/*/index.html, so
+// it never appears in rawPages; guard anyway)
+const pages = rawPages.filter(p => !p.includes('404'));
+
+console.log(`[validate-agent-plumbing] Found ${pages.length} published pages.`);
+
+// ── Check 1: llms.txt coverage ────────────────────────────────────────────────
+
+const llmsFullContent = fs.readFileSync(llmsFullPath, 'utf-8');
+
+const missingFromLlms = [];
+for (const page of pages) {
+  // The plugin writes URLs like /cqlite/user-docs/cli-reference/ — strip the
+  // trailing slash to match both forms, and match the path segment.
+  // We look for the page path (without leading slash) anywhere in the file.
+  const searchPath = page.replace(/^\//, '').replace(/\/$/, '');
+  // Accept both /cqlite/<path>/ and /cqlite/<path> (with or without trailing slash)
+  const pattern = `/${searchPath}`;
+  if (!llmsFullContent.includes(pattern)) {
+    missingFromLlms.push(page);
+  }
+}
+
+// ── Check 2: Raw .md endpoint coverage ────────────────────────────────────────
+
+const missingRawMd = [];
+for (const page of pages) {
+  // Map page URL to expected .md file in dist/
+  // /  →  dist/index.md
+  // /user-docs/  →  dist/user-docs/index.md
+  // /user-docs/cli-reference/  →  dist/user-docs/cli-reference.md
+
+  let relPath;
+  if (page === '/') {
+    relPath = 'index.md';
+  } else {
+    // Remove leading and trailing slashes → "user-docs/cli-reference"
+    const stripped = page.replace(/^\//, '').replace(/\/$/, '');
+    const parts = stripped.split('/');
+    // If the last segment is "index" (shouldn't happen with Starlight), treat as dir
+    const last = parts[parts.length - 1];
+    if (last === '') {
+      // Trailing slash after join — shouldn't happen but guard
+      relPath = stripped + 'index.md';
+    } else {
+      // The page at /a/b/ has its HTML at dist/a/b/index.html
+      // The raw endpoint is dist/a/b.md  (NOT dist/a/b/index.md)
+      // However index pages (/a/) → dist/a/index.md
+      // Detect index pages: the directory itself has an index.html AND the
+      // parent directory also has an index.html (i.e. page is a section overview)
+      // In Starlight, every directory gets an index page, so we use:
+      //   /user-docs/        →  dist/user-docs/index.md       (section index)
+      //   /user-docs/python/ →  dist/user-docs/python.md      (leaf page)
+      // The index pages have their parent as the content dir (e.g. user-docs/index.md)
+      // Leaf pages have a matching filename (e.g. user-docs/python.md)
+      // We detect index pages by checking if the path ends with a known section root.
+      // Simpler: check if a dist/<stripped>/index.md exists; if so it's an index page.
+      // Actually we just check both paths and use whichever exists.
+
+      // The emit-raw-markdown.mjs script writes:
+      //   for index.md source files  → dist/<parent>/index.md
+      //   for other source files     → dist/<parent>/<slug>.md
+      //
+      // So the raw endpoint for:
+      //   page /user-docs/cli-reference/  →  dist/user-docs/cli-reference.md
+      //   page /user-docs/               →  dist/user-docs/index.md
+      //
+      // We detect the index case by checking if the LAST segment in the URL
+      // path (before trailing slash) is the same as the parent. But actually
+      // the simplest signal is: does dist/<stripped>/index.md exist?
+
+      const indexMdPath = path.join(DIST_DIR, stripped, 'index.md');
+      const leafMdPath  = path.join(DIST_DIR, stripped + '.md');
+      // Leaf path is used for non-index pages
+      if (fs.existsSync(indexMdPath)) {
+        relPath = stripped + '/index.md';
+      } else {
+        relPath = stripped + '.md';
+      }
+    }
+  }
+
+  const mdPath = path.join(DIST_DIR, relPath);
+  if (!fs.existsSync(mdPath)) {
+    missingRawMd.push({ page, expected: relPath });
+  }
+}
+
+// ── Report ─────────────────────────────────────────────────────────────────────
+
+let failed = false;
+
+if (missingFromLlms.length > 0) {
+  failed = true;
+  console.error('\n[validate-agent-plumbing] FAIL: The following pages are missing from llms-full.txt:');
+  for (const p of missingFromLlms) {
+    console.error(`  MISSING FROM llms-full.txt: ${p}`);
+  }
+}
+
+if (missingRawMd.length > 0) {
+  failed = true;
+  console.error('\n[validate-agent-plumbing] FAIL: The following pages have no raw .md endpoint in dist/:');
+  for (const { page, expected } of missingRawMd) {
+    console.error(`  MISSING RAW ENDPOINT: ${page}  (expected dist/${expected})`);
+  }
+}
+
+if (failed) {
+  console.error('\n[validate-agent-plumbing] FAILED — see errors above.');
+  process.exit(1);
+} else {
+  console.log(`[validate-agent-plumbing] PASS: all ${pages.length} pages are covered by llms-full.txt and have raw .md endpoints.`);
+  process.exit(0);
+}

--- a/website/src/content/docs/agents-developing/no-heuristics.md
+++ b/website/src/content/docs/agents-developing/no-heuristics.md
@@ -91,5 +91,4 @@ the library must not invent values.
 | `experimental` | Yes — explicitly opt-in |
 
 See [Key source paths](/cqlite/agents-developing/source-map/) for where type decoding lives in the codebase.
-The full feature-flags table is in `CLAUDE.md` (repo root).
-<!-- TODO(W8): add site link to feature-flags page once it exists -->
+The full feature-flags table and feature-gated test notes are in [Gate Contract](/cqlite/agents-developing/gate-contract/).

--- a/website/src/content/docs/agents-developing/test-data.md
+++ b/website/src/content/docs/agents-developing/test-data.md
@@ -146,6 +146,5 @@ bash test-data/scripts/package_datasets.sh
 bash test-data/scripts/publish_datasets.sh
 ```
 
-<!-- TODO(W8): link to full dataset-generation reference once site page exists -->
 See `.claude/skills/test-data-management/dataset-generation.md` in the repo for the
 full workflow including the compose-stack interactive path.

--- a/website/src/content/docs/user-docs/cli-reference.md
+++ b/website/src/content/docs/user-docs/cli-reference.md
@@ -597,6 +597,4 @@ cqlite --quiet \
   --out json
 ```
 
-<!-- TODO(W8): link output-formats page when merged -->
-
 **See also**: [Output Formats](/cqlite/user-docs/output-formats/) for JSON, CSV, and Parquet format details.

--- a/website/src/content/docs/user-docs/index.md
+++ b/website/src/content/docs/user-docs/index.md
@@ -22,26 +22,17 @@ daemon required.
 
 ### Reference
 
-<!-- TODO(W8): link CLI Reference when merged (W4 issue) -->
-**CLI Reference** — all flags, subcommands, and one-shot / REPL / TUI modes *(arriving in W4)*
-
-<!-- TODO(W8): link Output Formats when merged (W4 issue) -->
-**Output Formats** — JSON, CSV, Parquet *(arriving in W4)*
-
-<!-- TODO(W8): link Python Bindings when merged (W5 issue) -->
-**Python Bindings** — `cqlite-py` API reference *(arriving in W5)*
-
-<!-- TODO(W8): link Node.js Bindings when merged (W5 issue) -->
-**Node.js Bindings** — `@cqlite/node` API reference *(arriving in W5)*
+- [CLI Reference](/cqlite/user-docs/cli-reference/) — all flags, subcommands, and one-shot / REPL / TUI modes
+- [Output Formats](/cqlite/user-docs/output-formats/) — JSON, CSV, Parquet
+- [Python Bindings](/cqlite/user-docs/python/) — `cqlite-py` API reference
+- [Node.js Bindings](/cqlite/user-docs/nodejs/) — `@cqlite/node` API reference
 
 ### Topics
 
 - [Write Support](/cqlite/user-docs/write-support/) — offline SSTable writing, flush, compaction (M5)
 - [Limitations](/cqlite/user-docs/limitations/) — what CQLite can and cannot read (format matrix, known gaps)
 - [Troubleshooting](/cqlite/user-docs/troubleshooting/) — common problems and fixes
-
-<!-- TODO(W8): link Use Cases when merged (W9 issue) -->
-**Use Cases** — Cassandra sidecar, data science, services, operational scenarios *(arriving in W9)*
+- [Use Cases](/cqlite/user-docs/use-cases/) — Cassandra sidecar, data science, services, operational scenarios
 
 ## Quick links
 

--- a/website/src/content/docs/user-docs/limitations.md
+++ b/website/src/content/docs/user-docs/limitations.md
@@ -12,9 +12,7 @@ CQLite is production-ready for the common case: reading Cassandra 5.0 BIG-format
 SSTables with standard data types. This page is honest about what it cannot do yet,
 so you know before you depend on it.
 
-For the exhaustive engineering detail, see the source document in the repository:
-`docs/sstables-definitive-guide/chapters/appendix-f-known-limitations.md`
-<!-- TODO(W8): replace with site link when the SSTable Format Guide section is merged -->
+For the exhaustive engineering detail, see [Appendix F: Known Limitations](/cqlite/sstable-format/appendix-f/) in the SSTable Format Guide.
 
 ## Format support
 

--- a/website/src/content/docs/user-docs/nodejs.md
+++ b/website/src/content/docs/user-docs/nodejs.md
@@ -340,4 +340,4 @@ Full TypeScript definitions are in
 - [GitHub Repository](https://github.com/pmcfadin/cqlite)
 - [npm Package](https://www.npmjs.com/package/@cqlite/node)
 - [TypeScript Definitions](https://github.com/pmcfadin/cqlite/blob/main/bindings/node/lib/index.d.ts)
-<!-- TODO(W8): link when merged -->
+- [Query from Node.js recipe](/cqlite/agents-using/query-nodejs/) — copy-pasteable agent recipe with expected output shapes

--- a/website/src/content/docs/user-docs/output-formats.md
+++ b/website/src/content/docs/user-docs/output-formats.md
@@ -246,6 +246,5 @@ parquet-tools show results.parquet
 | Analytics / Spark / DuckDB | `parquet` (with awareness of caveats above) |
 | Lakehouse / columnar predicates on complex types | Wait for epic #673 or cast in the consumer |
 
-<!-- TODO(W8): link to agent recipes when merged -->
-
 **See also**: [CLI Reference](/cqlite/user-docs/cli-reference/) for `--out`, `--format`, and `CQLITE_OUT` flag details.
+For agent recipes that use these formats, see [For Agents: Using CQLite](/cqlite/agents-using/).

--- a/website/src/content/docs/user-docs/python.md
+++ b/website/src/content/docs/user-docs/python.md
@@ -286,4 +286,4 @@ Full type stubs are in
 - [GitHub Repository](https://github.com/pmcfadin/cqlite)
 - [PyPI Package](https://pypi.org/project/cqlite-py/)
 - [Type Stubs](https://github.com/pmcfadin/cqlite/blob/main/bindings/python/python/cqlite/__init__.pyi)
-<!-- TODO(W8): link when merged -->
+- [Query from Python recipe](/cqlite/agents-using/query-python/) — copy-pasteable agent recipe with expected output shapes

--- a/website/src/content/docs/user-docs/quick-start.md
+++ b/website/src/content/docs/user-docs/quick-start.md
@@ -165,5 +165,8 @@ For a full list, see [Limitations](/cqlite/user-docs/limitations/).
 ## Next steps
 
 - [Installation](/cqlite/user-docs/installation/) — prebuilt binaries, cargo, pip, npm
+- [CLI Reference](/cqlite/user-docs/cli-reference/) — all flags, subcommands, and modes
+- [Output Formats](/cqlite/user-docs/output-formats/) — JSON, CSV, Parquet
+- [Python Bindings](/cqlite/user-docs/python/) — `cqlite-py` API
+- [Node.js Bindings](/cqlite/user-docs/nodejs/) — `@cqlite/node` API
 - [Troubleshooting](/cqlite/user-docs/troubleshooting/) — common issues and fixes
-<!-- TODO(W8): link CLI reference, Output Formats, Python, Node.js when merged -->


### PR DESCRIPTION
Part of epic #733. Closes #741.

## Summary

- **`llms.txt` + `llms-full.txt`**: Added `starlight-llms-txt@0.6.1` (pinned exact version) to `astro.config.mjs`. Generates `/llms.txt` (section map linking to full/small variants) and `/llms-full.txt` (complete content of every page) at the site root. URLs use the correct absolute base (`https://pmcfadin.github.io/cqlite/...`).
- **Raw markdown endpoints**: Added `website/scripts/emit-raw-markdown.mjs` (runs as `postbuild`). Copies every built page's source `.md` file to `dist/<page-path>.md` — 65 endpoints covering all sections including generated format-guide chapters (e.g. `dist/sstable-format/appendix-f.md`, `dist/sstable-format/ch01.md`).
- **CI validation**: Added `website/scripts/validate-agent-plumbing.mjs`. Inspects `dist/` only (no live HTTP). Fails loudly naming missing pages. Integrated into `scripts/docs-site-check.sh` (Step 3) and `.github/workflows/docs-site.yml` (new `Validate agent plumbing` step after build).
- **TODO(W8) marker resolution**: Replaced all 13 `<!-- TODO(W8): ... -->` markers in 9 files with proper site links. `rg 'TODO(W8)' website/src/content/docs` returns empty.

## Validation evidence

**docs-site-check.sh summary** (raw):
```
══ docs-site-check summary ══

┌─────────────────────────────────────────┐
│  docs-site-check: ALL CHECKS PASSED      │
└─────────────────────────────────────────┘

DOCS_SITE_CHECK=PASS
```

**Deliberate failure — missing raw endpoint**:
```
[validate-agent-plumbing] Found 65 published pages.

[validate-agent-plumbing] FAIL: The following pages have no raw .md endpoint in dist/:
  MISSING RAW ENDPOINT: /user-docs/cli-reference/  (expected dist/user-docs/cli-reference.md)

[validate-agent-plumbing] FAILED — see errors above.
```

**Deliberate failure — page missing from llms-full.txt**:
```
[validate-agent-plumbing] Found 65 published pages.

[validate-agent-plumbing] FAIL: The following pages are missing from llms-full.txt:
  MISSING FROM llms-full.txt: /user-docs/cli-reference/

[validate-agent-plumbing] FAILED — see errors above.
```

**Head of generated `dist/llms.txt`**:
```
# CQLite

> Local Apache Cassandra SSTable access without cluster dependencies. Reads Cassandra 5.0 SSTables directly from disk — no cluster, no JVM required.

## Documentation Sets

- [Abridged documentation](https://pmcfadin.github.io/cqlite/llms-small.txt): ...
- [Complete documentation](https://pmcfadin.github.io/cqlite/llms-full.txt): ...
```

**Raw .md endpoints in dist** (sample including a generated format-guide page):
```
dist/index.md
dist/sstable-format/appendix-f.md
dist/sstable-format/ch01.md
dist/user-docs/cli-reference.md
dist/user-docs/index.md
dist/user-docs/limitations.md
... (65 total)
```

**TODO(W8) markers**:
```
$ rg 'TODO(W8)' website/src/content/docs
(no output — exit 1 means no matches)
```

## Plugin choices

| Plugin | Version | Source |
|--------|---------|--------|
| `starlight-llms-txt` | `0.6.1` (pinned) | npm — requires `@astrojs/starlight >=0.31`; site uses 0.34.3 |

No plugin found for raw markdown endpoints; implemented as `website/scripts/emit-raw-markdown.mjs` (plain Node.js, no new deps).

## Changed files

```
.github/workflows/docs-site.yml
scripts/docs-site-check.sh
website/astro.config.mjs
website/package.json
website/package-lock.json
website/scripts/emit-raw-markdown.mjs (new)
website/scripts/validate-agent-plumbing.mjs (new)
website/src/content/docs/agents-developing/no-heuristics.md
website/src/content/docs/agents-developing/test-data.md
website/src/content/docs/user-docs/cli-reference.md
website/src/content/docs/user-docs/index.md
website/src/content/docs/user-docs/limitations.md
website/src/content/docs/user-docs/nodejs.md
website/src/content/docs/user-docs/output-formats.md
website/src/content/docs/user-docs/python.md
website/src/content/docs/user-docs/quick-start.md
```