### PR TITLE
docs: point README at the documentation site (#733)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@
 
 CQLite provides SQLite-like local access to Apache Cassandra SSTables, enabling developers to read Cassandra 5.0+ data files without cluster dependencies. Built in Rust for performance and safety.
 
+## Documentation
+
+Full documentation is at **[https://pmcfadin.github.io/cqlite/](https://pmcfadin.github.io/cqlite/)**:
+
+| Section | URL |
+|---------|-----|
+| User Docs — install, quick start, CLI, Python, Node.js | [/cqlite/user-docs/](https://pmcfadin.github.io/cqlite/user-docs/) |
+| SSTable Format Guide — binary format deep-dive | [/cqlite/sstable-format/](https://pmcfadin.github.io/cqlite/sstable-format/) |
+| For Agents: Using CQLite — LLM/agent integration | [/cqlite/agents-using/](https://pmcfadin.github.io/cqlite/agents-using/) |
+| For Agents: Developing CQLite — contributor doctrine, gate contract | [/cqlite/agents-developing/](https://pmcfadin.github.io/cqlite/agents-developing/) |
+
 ## Vision
 
 CQLite aims to become the standard tool for Cassandra SSTable manipulation outside of the main Apache Cassandra project, enabling new workflows for data analytics, migration, testing, and edge computing.
@@ -342,9 +353,9 @@ See [docs/development/PRD.md](docs/development/PRD.md) for milestone details.
 
 ## Resources
 
+- **Documentation site**: [https://pmcfadin.github.io/cqlite/](https://pmcfadin.github.io/cqlite/) — user docs, SSTable format guide, agent integration docs
 - **API docs (rustdoc)**: [latest tag](https://pmcfadin.github.io/cqlite/latest/) · published per release tag at `https://pmcfadin.github.io/cqlite/<tag>/`
 - **Changelog**: [CHANGELOG.md](CHANGELOG.md) — what each tagged release contains
-- **Documentation**: [Complete project docs](docs/)
 - **Performance**: [Methodology, local repro, and CI gate policy](docs/performance.md)
 - **CQL Grammar**: [Patrick's Antlr4 CQL Grammar](https://github.com/pmcfadin/cassandra-antlr4-grammar)
 - **Issues**: [GitHub Issues](https://github.com/pmcfadin/cqlite/issues)


### PR DESCRIPTION
Part of epic #733 (success criterion: README points at the site).

## Summary

- Adds a prominent **Documentation** section near the top of README.md (after the intro/badges, before Vision) linking the docs site and all four sections
- Updates the Resources section: replaces the generic `[Complete project docs](docs/)` entry with a direct link to the live docs site
- Adds the docs site as the first entry in Resources for visibility

## Evidence

**diff stat (README.md only):**
```
README.md | 13 ++++++++++++-
1 file changed, 12 insertions(+), 1 deletion(-
```

**URL verification (all 200):**
```
200 https://pmcfadin.github.io/cqlite/
200 https://pmcfadin.github.io/cqlite/user-docs/
200 https://pmcfadin.github.io/cqlite/sstable-format/
200 https://pmcfadin.github.io/cqlite/agents-using/
200 https://pmcfadin.github.io/cqlite/agents-developing/
```

**Note on rustdoc URL**: The task spec references a new `/api/latest/` path, but `https://pmcfadin.github.io/cqlite/api/latest/` currently returns 404 while the existing `/latest/` URL returns 200 with no redirect. The rustdoc link is left pointing at the working `/latest/` URL to avoid breaking it.

**New Documentation block:**
```markdown
## Documentation

Full documentation is at **[https://pmcfadin.github.io/cqlite/](https://pmcfadin.github.io/cqlite/)**:

| Section | URL |
|---------|-----|
| User Docs — install, quick start, CLI, Python, Node.js | [/cqlite/user-docs/](https://pmcfadin.github.io/cqlite/user-docs/) |
| SSTable Format Guide — binary format deep-dive | [/cqlite/sstable-format/](https://pmcfadin.github.io/cqlite/sstable-format/) |
| For Agents: Using CQLite — LLM/agent integration | [/cqlite/agents-using/](https://pmcfadin.github.io/cqlite/agents-using/) |
| For Agents: Developing CQLite — contributor doctrine, gate contract | [/cqlite/agents-developing/](https://pmcfadin.github.io/cqlite/agents-developing/) |
```

## Test plan
- [x] Only README.md changed (diff stat verified)
- [x] All 5 new absolute URLs verified as HTTP 200
- [x] No other files modified