### PR TITLE
chore(release): v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [v0.10.1] - 2026-06-13
+## [v0.11.0] - 2026-06-15
 
-Patch release bundling everything merged since v0.10.0. Correctness:
+Minor release bundling everything merged since v0.10.0. New capability: a
+first-class Parquet writer lifted into `cqlite-core` behind a `parquet` feature,
+with `export_parquet` methods on the Python and Node bindings (Epic #682).
+New read coverage: version-gated read behavior for the Cassandra 5.0 `oa` format
+and graceful handling of the `da` (BTI) format (VG1/VG3/VG5/VG6/VG7), real BTI
+node-type dispatch (#651), schema-typed query result columns (#770), and
+higher-fidelity Parquet/Arrow type mapping (#771). Plus opt-in memory-mapped
+reads (#589, **off by default**) with their follow-up hardening (#591) and a
+bounded uncompressed-read allocation (#592). Correctness:
 TEXT/composite partition-key reconstruction on the scan path (#586), a safe
 compaction async-to-sync bridge (#587), writer temporal-delta and tombstone
 serialization fixes (#645, #723), Summary.db offset-table encoding (#718), and
-removal of the last parser heuristic (#650). New read coverage: version-gated
-read behavior for the Cassandra 5.0 `oa` format and graceful handling of the
-`da` (BTI) format (VG1/VG3/VG5/VG6/VG7), real BTI node-type dispatch (#651),
-schema-typed query result columns (#770), and higher-fidelity Parquet/Arrow
-type mapping (#771). Plus opt-in memory-mapped reads (#589, **off by default**)
-with their follow-up hardening (#591), a bounded uncompressed-read allocation
-(#592), removal of three dead mmap readers (#590), and a new documentation site.
+removal of the last parser heuristic (#650). Plus removal of three dead mmap
+readers (#590) and a new documentation site.
+
+(The `0.10.1` version that briefly appeared in the manifests was never tagged or
+published; its prepared notes are folded into this release.)
 
 ### Added
+
+- **Parquet writer lifted into `cqlite-core` behind a `parquet` feature**
+  (Epic #682) — the Parquet/Arrow export engine now lives in
+  `cqlite-core/src/export/parquet.rs` behind an optional `parquet` cargo feature,
+  with the CLI's `cqlite-cli/src/output/parquet.rs` reduced to a thin wrapper over
+  it (#685). The Python and Node bindings gain `export_parquet` /
+  `exportParquet(query, path, { rowGroupSize, compression })` methods so callers
+  can stream query results straight to a Parquet file. Golden-file coverage lives
+  in `cqlite-cli/tests/parquet_golden_tests.rs`.
 
 - **Version-gated read support for the Cassandra 5.0 `oa` format** (Issues
   #653, #655, #672) — `VersionGate`s are threaded through the read path (VG1)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [package]
 name = "cqlite"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 
 [dependencies]
@@ -33,7 +33,7 @@ crc32fast = { workspace = true }
 cqlite-integration-tests = { path = "tests" }
 
 [workspace.package]
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 authors = ["CQLite Team"]
 license = "MIT OR Apache-2.0"

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cqlite/node",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cqlite/node",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^3.5.1",

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cqlite/node",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Node.js bindings for CQLite - read Apache Cassandra 5.0 SSTables without cluster dependencies",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "cqlite-py"
-version = "0.10.1"
+version = "0.11.0"
 description = "Python bindings for CQLite - read Cassandra 5.0 SSTables locally without a cluster"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Release v0.11.0

Bumps workspace + Python/Node binding versions `0.10.1` → `0.11.0` and renames the never-tagged `v0.10.1` CHANGELOG section to a dated `v0.11.0`.

### Why minor, not the prepared 0.10.1
The `v0.10.1` manifest bump (#594) landed on main but was **never tagged or published**. After it, **Epic #682 / #772** lifted the Parquet writer into `cqlite-core` behind a `parquet` feature and added `export_parquet` binding APIs — substantial new public API. Shipping that under a patch number would be semver-wrong, so the 0.10.1 prep is folded into **v0.11.0**.

This also brings `bindings/node/package-lock.json` (left at `0.10.0` in the 0.10.1 prep) up to `0.11.0`.

### Highlights since v0.10.0
- **Parquet writer in `cqlite-core`** behind a `parquet` feature + `export_parquet` Python/Node APIs (Epic #682, #772, #685)
- **Version-gated `oa`/`da` read path** (VG1–VG7) + BTI node-type dispatch (#651)
- **Schema `CqlType` in query result `ColumnInfo`** (#674/#770), higher-fidelity Parquet/Arrow type mapping (#771)
- **Opt-in memory-mapped reads** (#589, off by default) + hardening (#591), bounded uncompressed read (#592)
- **Fixes**: TEXT/composite PK reconstruction (#586), async compaction bridge (#587), temporal-delta/tombstone serialization (#645/#723), Summary.db offsets (#718), last parser heuristic removed (#650); three dead mmap readers removed (#590)
- New documentation site

### Validation
`scripts/agent-gate.sh` (on this branch, commit 8ee82232) → **RESULT: PASS** — fmt, clippy `--all-features`, core, integration, write, cli, minimal-build, smoke.

### Post-merge
Tagging `v0.11.0` triggers `release.yml`, `node-release.yml`, `python-release.yml`, and `api-docs.yml` (deferred `/api/<tag>/` + `/api/latest/` rustdoc deploy).