### PR TITLE
docs: refresh docs site for v0.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ See [docs/development/PRD.md](docs/development/PRD.md) for milestone details.
 ## Resources
 
 - **Documentation site**: [https://pmcfadin.github.io/cqlite/](https://pmcfadin.github.io/cqlite/) — user docs, SSTable format guide, agent integration docs
-- **API docs (rustdoc)**: [latest tag](https://pmcfadin.github.io/cqlite/latest/) · published per release tag at `https://pmcfadin.github.io/cqlite/<tag>/`
+- **API docs (rustdoc)**: [latest tag](https://pmcfadin.github.io/cqlite/api/latest/) · published per release tag at `https://pmcfadin.github.io/cqlite/api/<tag>/`
 - **Changelog**: [CHANGELOG.md](CHANGELOG.md) — what each tagged release contains
 - **Performance**: [Methodology, local repro, and CI gate policy](docs/performance.md)
 - **CQL Grammar**: [Patrick's Antlr4 CQL Grammar](https://github.com/pmcfadin/cassandra-antlr4-grammar)

--- a/website/README.md
+++ b/website/README.md
@@ -187,7 +187,7 @@ The site is deployed by `.github/workflows/docs-site.yml`:
 
 Rustdoc for `cqlite-core` is published by `.github/workflows/api-docs.yml` to:
 
-- `/api/<version>/` — per-release docs (e.g. `/api/v0.10.0/`)
+- `/api/<version>/` — per-release docs (e.g. `/api/v0.11.0/`)
 - `/api/latest/` — always points to the latest release
 
 The Starlight site links to `/cqlite/api/latest/` from the landing page. These paths

--- a/website/src/content/docs/agents-using/write-mutation.md
+++ b/website/src/content/docs/agents-using/write-mutation.md
@@ -44,7 +44,7 @@ cqlite \
 
 ```
 OK: 1 row(s) affected (4.5ms)
-CQLite CLI v0.10.0
+CQLite CLI v0.11.0
 Use --help for available commands
 ```
 
@@ -68,7 +68,7 @@ cqlite \
 ```
 Flushed: 1 partitions, 50 bytes
   Output: /tmp/cqlite-write/data/test_basic/simple_table/nb-1-big-Data.db
-CQLite CLI v0.10.0
+CQLite CLI v0.11.0
 Use --help for available commands
 ```
 
@@ -101,7 +101,7 @@ cqlite \
 OK: 1 row(s) affected (20.2ms)
 Flushed: 1 partitions, 50 bytes
   Output: /tmp/cqlite-write/data/test_basic/simple_table/nb-1-big-Data.db
-CQLite CLI v0.10.0
+CQLite CLI v0.11.0
 Use --help for available commands
 ```
 

--- a/website/src/content/docs/user-docs/cli-reference.md
+++ b/website/src/content/docs/user-docs/cli-reference.md
@@ -8,7 +8,7 @@ sidebar:
 
 # CLI Reference
 
-This page is built from the actual `cqlite --help` output (binary version 0.10.0, built with `--features write-support`). Every example on this page was run against the real test datasets (`cassandra5-small-full-v3.1`).
+This page is built from the actual `cqlite --help` output (binary version 0.11.0, built with `--features write-support`). Every example on this page was run against the real test datasets (`cassandra5-small-full-v3.1`).
 
 ## Synopsis
 

--- a/website/src/content/docs/user-docs/limitations.md
+++ b/website/src/content/docs/user-docs/limitations.md
@@ -19,10 +19,11 @@ For the exhaustive engineering detail, see [Appendix F: Known Limitations](/cqli
 | SSTable format | Cassandra versions | CQLite support |
 |----------------|-------------------|----------------|
 | `nb-*-big-*` (BIG format) | Cassandra 5.0+ | **Full** — all 33 test tables pass |
+| `oa-*-big-*` (BIG format) | Cassandra 5.0 | **Full** — 6 `oa` fixture tables pass `sstabledump` parity |
 | `md-*` | Cassandra 4.0–4.1 | **Not supported** |
 | `mc-*` | Cassandra 3.11 | **Not supported** |
 | `la-*`, `ma-*` | Cassandra 3.x | **Not supported** |
-| BTI format (Partitions.db / Rows.db) | Cassandra 5.0 opt-in | **Partial** — see below |
+| `da-*-bti-*` / BTI format (Partitions.db / Rows.db) | Cassandra 5.0 opt-in | **Not supported** — detected and rejected with a clear error; see below |
 
 CQLite targets Cassandra 5.0 exclusively. If you need older formats, export your
 data with Cassandra's `sstabledump` tool first.
@@ -35,23 +36,31 @@ The default Cassandra 5.0 index format (`nb-*-big-Index.db` / `nb-*-big-Summary.
 is fully supported. All 33 test tables in the CQLite test corpus use this format and
 pass validation against `sstabledump` output.
 
-### BTI format — partial support
+### BTI format (`da`) — not yet supported, fails cleanly
 
-BTI (trie-based index) is an opt-in, experimental feature in Cassandra 5.0, requiring
-`selected_format: bti` in `cassandra.yaml`. It produces `Partitions.db` and `Rows.db`
-files instead of the standard `Index.db`.
+BTI (trie-based index) is an opt-in feature in Cassandra 5.0, enabled with
+`selected_format: bti` in `cassandra.yaml`. It produces `da-*-bti-*` SSTables with
+`Partitions.db` and `Rows.db` trie indexes instead of the standard
+`Index.db` / `Summary.db`.
 
-Current BTI status:
+As of v0.11.0, CQLite **detects `da`-format SSTables and rejects them with a clear,
+graceful error** instead of misreading them:
 
-- Format detection works (magic number `0x6461`)
-- Byte-comparable encoding (CEP-25) is implemented
-- Trie node structure parsing is partially implemented
-- Range queries and full partition iteration are **not implemented**
-- No BTI test data exists in the test corpus (BTI requires explicit opt-in at the cluster level)
+```
+Unsupported format: BTI (da) read support not yet implemented. da-format SSTables
+use Partitions.db/Rows.db trie indexes instead of Index.db/Summary.db and require a
+dedicated BTI read path.
+```
 
-**In practice**: because BTI requires explicit opt-in, it is rarely used in production.
-If you use BTI, CQLite will fall back to a sequential scan of `Data.db` which is
-functionally correct but O(n) instead of O(log n) for partition lookups.
+The version-gate work (VG5) routes `da` through this graceful-unsupported path today,
+and `da` fixtures plus `sstabledump` goldens ship in the `datasets-v3` test set so a
+real BTI read path can be validated when it lands. That dedicated reader is planned but
+not yet implemented.
+
+**In practice**: because BTI requires explicit cluster opt-in, it is rarely used in
+production. If your SSTables are `da`-format, convert them with Cassandra's
+`sstabledump` first, or use the default BIG format (`nb` / `oa`), which CQLite reads
+fully.
 
 ## Data type support
 


### PR DESCRIPTION
Post-release docs-site refresh for **v0.11.0**. Pure docs/markdown — no code.

## Changes
- **Rustdoc links (deferred item)** — `README.md` now points at `/cqlite/api/latest/` and `/cqlite/api/<tag>/` (was `/cqlite/latest/` + `/<tag>/`). The site homepage already used `/api/`; this closes the README half deferred to the v0.11.0 tag push. `website/README` example bumped `/api/v0.10.0/` → `/api/v0.11.0/`.
- **Version strings** — `cli-reference` documented binary version `0.10.0` → `0.11.0` (matches actual `cqlite --version`); `write-mutation` example CLI banners `v0.10.0` → `v0.11.0` (banner is `CARGO_PKG_VERSION`).
- **Format support (`limitations`)** — brought in line with v0.11.0's version-gate work, **verified against the built binary + datasets-v3 corpus**:
  - Added `oa-*-big-*` as **fully supported** (6 `oa` fixtures pass `sstabledump` parity).
  - `da`/BTI is now **detected and rejected with a graceful unsupported error** (VG5), not a silent sequential-scan fallback. Removed stale claims ("No BTI test data exists" — `test_da` now ships in datasets-v3; the scan-fallback note).

## Validation
`scripts/docs-site-check.sh` → **PASS** (build, all internal links valid, llms.txt + raw `.md` endpoints).

Note: a v0.11.0 rustdoc tree is already live at `/api/v0.11.0/` + `/api/latest/` (api-docs.yml ran on the tag).