### PR TITLE
docs: remove internal epic/issue-planning refs from user-facing pages

### DIFF
--- a/website/src/content/docs/user-docs/nodejs.md
+++ b/website/src/content/docs/user-docs/nodejs.md
@@ -195,7 +195,7 @@ progress tracking after the first row is yielded.
 ## Exporting to Parquet
 
 `db.exportParquet()` writes query results straight to a Parquet file using
-the embeddable core writer ([epic #682](https://github.com/pmcfadin/cqlite/issues/682)).
+the embeddable core writer.
 The query streams, so arbitrarily large result sets export within bounded
 memory, and the export runs as an async task off the JavaScript main thread.
 

--- a/website/src/content/docs/user-docs/output-formats.md
+++ b/website/src/content/docs/user-docs/output-formats.md
@@ -173,7 +173,7 @@ id,name,age
 
 Parquet is a columnar binary format for analytics workloads. CQLite writes valid Parquet files (magic bytes `PAR1`) compatible with Apache Arrow, DuckDB, Spark, and other readers.
 
-The writer is embeddable ([epic #682](https://github.com/pmcfadin/cqlite/issues/682)): it lives in `cqlite-core` behind the off-by-default `parquet` cargo feature, and is exposed without the CLI via `db.export_parquet(...)` in the [Python bindings](/cqlite/user-docs/python/) and `db.exportParquet(...)` in the [Node.js bindings](/cqlite/user-docs/nodejs/).
+The writer is embeddable: it lives in `cqlite-core` behind the off-by-default `parquet` cargo feature, and is exposed without the CLI via `db.export_parquet(...)` in the [Python bindings](/cqlite/user-docs/python/) and `db.exportParquet(...)` in the [Node.js bindings](/cqlite/user-docs/nodejs/).
 
 **Parquet requires a file destination** — it cannot be written to stdout:
 
@@ -190,7 +190,7 @@ If you specify `--out parquet` without `--output`, CQLite exits with an error.
 
 ### Type mapping
 
-**CQLite's Parquet output preserves nested and high-precision CQL types** ([epic #673](https://github.com/pmcfadin/cqlite/issues/673)). When a schema is provided (the normal case — CQLite requires one to decode SSTables), query results carry the authoritative schema `CqlType` and the writer builds a faithful Arrow schema, recursively:
+**CQLite's Parquet output preserves nested and high-precision CQL types.** When a schema is provided (the normal case — CQLite requires one to decode SSTables), query results carry the authoritative schema `CqlType` and the writer builds a faithful Arrow schema, recursively:
 
 | CQL type | Arrow/Parquet type | Notes |
 |----------|--------------------|-------|

--- a/website/src/content/docs/user-docs/python.md
+++ b/website/src/content/docs/user-docs/python.md
@@ -182,7 +182,7 @@ db = cqlite.open("data/sstables", schema="schema.cql", config="performance_optim
 ## Exporting to Parquet
 
 `db.export_parquet()` writes query results straight to a Parquet file using
-the embeddable core writer ([epic #682](https://github.com/pmcfadin/cqlite/issues/682)).
+the embeddable core writer.
 The query streams, so arbitrarily large result sets export within bounded
 memory, and the GIL is released for the duration of the export.
 

--- a/website/src/content/docs/user-docs/use-cases/index.md
+++ b/website/src/content/docs/user-docs/use-cases/index.md
@@ -16,7 +16,7 @@ about what is still in progress.
 
 | Page | What it covers |
 |------|----------------|
-| [Lakehouse projections with the Cassandra Sidecar](/cqlite/user-docs/use-cases/sidecar-lakehouse/) | SSTable-to-Parquet pipeline architecture, the delta-semantics caveat, the high-fidelity type mapping, and what epics #682/#696 unlock |
+| [Lakehouse projections with the Cassandra Sidecar](/cqlite/user-docs/use-cases/sidecar-lakehouse/) | SSTable-to-Parquet pipeline architecture, the delta-semantics caveat, the high-fidelity type mapping, and embedding the Parquet writer |
 | [Python: data science and ETL](/cqlite/user-docs/use-cases/python-data-science/) | Offline analytics on snapshots and backups without a cluster; pandas and notebook workflows |
 | [Node.js: services and tooling](/cqlite/user-docs/use-cases/nodejs-services/) | Data inspection services, ops dashboards, `executeNative` + streaming patterns |
 | [Operational scenarios](/cqlite/user-docs/use-cases/operational/) | Migration validation, test fixtures from production data, backup and snapshot inspection |

--- a/website/src/content/docs/user-docs/use-cases/nodejs-services.md
+++ b/website/src/content/docs/user-docs/use-cases/nodejs-services.md
@@ -266,8 +266,7 @@ for (const col of result.columns as ColumnInfo[]) {
 
 ## Export Parquet directly from Node.js
 
-The bindings expose the core Parquet writer
-([epic #682](https://github.com/pmcfadin/cqlite/issues/682)) — no CLI
+The bindings expose the core Parquet writer — no CLI
 subprocess needed. The query streams, so large tables export within bounded
 memory, and the export runs off the JavaScript main thread:
 

--- a/website/src/content/docs/user-docs/use-cases/operational.md
+++ b/website/src/content/docs/user-docs/use-cases/operational.md
@@ -252,8 +252,8 @@ schema can produce incorrect values or errors.
 - **Schema-free inspection.** CQLite always requires a schema file. If you have lost
   the schema, use `DESCRIBE TABLE` from `cqlsh` on a running cluster, or extract it
   from `system_schema.tables` in an older backup.
-- **Real-time CDC / streaming from commitlog.** [Epic #696](https://github.com/pmcfadin/cqlite/issues/696)
-  tracks delta-scan and CDC-style projections *(in progress)*.
+- **Real-time CDC / streaming from commitlog.** Delta-scan and CDC-style projections
+  are not yet available; CQLite reads per-SSTable snapshots, not a change stream.
 
 ## Further reading
 

--- a/website/src/content/docs/user-docs/use-cases/python-data-science.md
+++ b/website/src/content/docs/user-docs/use-cases/python-data-science.md
@@ -198,8 +198,7 @@ with cqlite.open(DATASETS, schema=SCHEMA) as db:
 print(f"Exported {len(result.rows)} rows to {OUTPUT}")
 ```
 
-For Parquet, export directly from the bindings
-([epic #682](https://github.com/pmcfadin/cqlite/issues/682)) — the query
+For Parquet, export directly from the bindings — the query
 streams, so large tables export within bounded memory:
 
 ```python

--- a/website/src/content/docs/user-docs/use-cases/sidecar-lakehouse.md
+++ b/website/src/content/docs/user-docs/use-cases/sidecar-lakehouse.md
@@ -27,7 +27,7 @@ The read-to-Parquet pipeline is largely in place:
 3. **Parquet output** is available via `--out parquet` in the CLI, via
    `db.export_parquet(...)` / `db.exportParquet(...)` in the Python and Node
    bindings, and as an embeddable writer in `cqlite-core` behind the `parquet`
-   cargo feature (epic #682, delivered).
+   cargo feature.
 
 A minimal per-SSTable projection is already expressible as a one-shot CLI call:
 
@@ -124,9 +124,8 @@ path performs the LWW merge, then export. Correct, but re-reads everything on ea
 
 ## Type mapping fidelity
 
-The type mapping is **analytics-grade for schema-aware queries**
-([epic #673](https://github.com/pmcfadin/cqlite/issues/673)): query results carry the
-authoritative schema `CqlType`, and the Parquet writer maps it recursively to a
+The type mapping is **analytics-grade for schema-aware queries**: query results carry
+the authoritative schema `CqlType`, and the Parquet writer maps it recursively to a
 faithful Arrow schema.
 
 | CQL type | Arrow/Parquet | Fidelity |
@@ -152,30 +151,28 @@ in downstream consumers (Trino, Spark, DuckDB). The batch and streaming writers 
 identical schemas and values. See
 [Output Formats](/cqlite/user-docs/output-formats/) for the full table and notes.
 
-## What epics #682 and #696 unlock
+## Embedding the Parquet writer
 
-**[Epic #682: Lift Parquet writer into cqlite-core](https://github.com/pmcfadin/cqlite/issues/682)**
-*(delivered)*
-
-The Parquet writer now lives in `cqlite-core/src/export/parquet.rs` behind an
+The Parquet writer lives in `cqlite-core/src/export/parquet.rs` behind an
 off-by-default `parquet` feature flag. A projection service can call the writer
 directly as a library without a subprocess, and the Python
 (`db.export_parquet(...)`) and Node (`db.exportParquet(...)`) bindings export
 Parquet natively. CQLite produces Parquet files only; committing them to
 Iceberg/Delta remains the external committer's job.
 
-**[Epic #696: Delta-scan envelope for CDC-style projections](https://github.com/pmcfadin/cqlite/issues/696)**
-*(in progress)*
+## Roadmap: delta-aware projections
 
-Implements a `scan_delta` streaming API that emits `DeltaRecord`s with per-cell
-`writetime`, `expires_at`, and an `__op` discriminator covering all five Cassandra
-delete shapes (`upsert`, `static_upsert`, `row_delete`, `range_delete`,
-`partition_delete`). Paired with a `DeltaParquetWriter` and a `cqlite delta-export`
-CLI subcommand. This is what makes CDC-mode projections reconcilable downstream.
+Fully reconcilable CDC-mode projections need a delta-scan API that streams per-cell
+`writetime`, TTL/expiry, and an operation discriminator covering all five Cassandra
+delete shapes (upsert, static upsert, row delete, range delete, partition delete),
+paired with a delta-aware Parquet writer and an export subcommand. **This is not yet
+available.** Until it lands, preserve `writetime` and represent tombstones yourself
+(see [Recommendations](#recommendations)) so a union of per-flush Parquet is
+reconcilable rather than silently wrong.
 
 ## Schema sourcing
 
-CQLite requires the CQL schema to decode an SSTable (no-heuristics mandate, issue #28).
+CQLite requires the CQL schema to decode an SSTable — it does not guess types.
 The projection service must source and cache the schema — flush events do not carry it.
 The practical approach is to pull it from `DESCRIBE TABLE` output and keep it in sync
 with schema changes.
@@ -191,9 +188,9 @@ events and commit timestamps.
 Our approach's distinct value is **open, lake-native columnar output from Cassandra with
 no cluster dependency in the read path**. The trade-off is that Cassandra has no ordered
 committed log — its source of truth is independently-flushed, LWW-merged SSTables — so
-any columnar projection is inherently a delta-reconciliation problem. Epics #673
-and #682 (delivered) addressed type fidelity and embeddability; epic #696
-addresses the remaining part of that problem.
+any columnar projection is inherently a delta-reconciliation problem. CQLite already
+provides the type fidelity and the embeddable writer that projection needs; full
+delta-aware scanning (above) is the remaining piece.
 
 ## Recommendations
 
@@ -206,7 +203,7 @@ addresses the remaining part of that problem.
    is silently wrong.
 4. **Prefer commitlog CDC over raw flush events** when correctness matters.
 5. **Embed the writer rather than shelling out** — the Parquet writer lives in
-   `cqlite-core` behind the `parquet` feature (epic #682, delivered), and the
+   `cqlite-core` behind the `parquet` feature, and the
    Python/Node bindings expose it directly.
 
 <!-- TODO(W4): link to CLI reference when merged -->


### PR DESCRIPTION
Per feedback that the use-case pages "show more of the sausage making than I wanted" — they referenced GitHub **epics by number** and labeled features *delivered*/*in progress*, which is internal development framing that doesn't belong in user docs.

## Changes
Rewrote to state capabilities and limitations plainly, no epic/issue-planning references:

- **Dropped** `(epic #682, delivered)`, `[epic #673]`, `[epic #696]` links across use-cases (`sidecar-lakehouse`, `python-data-science`, `nodejs-services`, `operational`, `index`) and bindings pages (`python`, `nodejs`, `output-formats`).
- **`sidecar-lakehouse`**: renamed *"What epics #682 and #696 unlock"* → *"Embedding the Parquet writer"* + *"Roadmap: delta-aware projections"*; the unshipped delta-scan/CDC work is now described as **"not yet available"** rather than naming internal APIs (`scan_delta`, `DeltaParquetWriter`, `cqlite delta-export`) as if they exist.
- **`operational`**: CDC item reframed as a plain not-yet-available limitation.

## Deliberately kept
- *"Known limitation tracked at issue #N"* links (collection-tombstone gap, concurrency caveat) — these help users, unlike feature-planning refs.
- Contributor docs under `agents-developing/` — issue refs are appropriate for that audience.

## Validation
`scripts/docs-site-check.sh` → **PASS** (build, internal links, llms.txt + raw endpoints).