### PR TITLE
feat: prepare crates.io publishing — cqlite-core + cqlite-cli (#782)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,4 +184,32 @@ jobs:
           CQLITE_DATASETS_ROOT: ${{ github.workspace }}/test-data/datasets
         run: ./scripts/ci/validate-cleanup.sh
 
+  # Guards crates.io publish-readiness for cqlite-core: catches missing/invalid
+  # metadata, path-only deps, or a dirty package before a release tag tries to
+  # publish (issue #782). The clean checkout also exercises publish's
+  # "no uncommitted/untracked files" requirement. cqlite-core only — the
+  # cqlite-cli dry-run cannot resolve its versioned cqlite-core dep until core is
+  # on the index, so it is verified at publish time, not here.
+  publish-dry-run:
+    name: crates.io publish dry-run (cqlite-core)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-${{ runner.os }}-publish-dryrun-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: cargo publish --dry-run (cqlite-core)
+        run: cargo publish --package cqlite-core --dry-run
+
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,14 @@ members = [
 resolver = "2"
 
 [package]
+# Workspace-root package: hosts the top-level tests/*.rs integration tests (the
+# issue #514 arrangement). Never published — the `cqlite` name on crates.io
+# belongs to an unrelated project; the CLI publishes as `cqlite-cli` (binary
+# `cqlite`). See issue #782.
 name = "cqlite"
 version = "0.11.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 cqlite-core = { path = "cqlite-core" }

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 <p align="center">
   <a href="https://github.com/pmcfadin/cqlite/actions/workflows/ci.yml"><img src="https://github.com/pmcfadin/cqlite/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://crates.io/crates/cqlite-cli"><img src="https://img.shields.io/crates/v/cqlite-cli.svg?label=crates.io%20cqlite-cli" alt="crates.io"></a>
+  <a href="https://docs.rs/cqlite-core"><img src="https://img.shields.io/docsrs/cqlite-core.svg?label=docs.rs" alt="docs.rs"></a>
   <a href="https://pypi.org/project/cqlite-py/"><img src="https://img.shields.io/pypi/v/cqlite-py.svg?label=pypi%20cqlite-py" alt="PyPI"></a>
   <a href="https://www.npmjs.com/package/@cqlite/node"><img src="https://img.shields.io/npm/v/@cqlite/node.svg?label=npm%20%40cqlite%2Fnode" alt="npm"></a>
   <a href="https://pmcfadin.github.io/cqlite/"><img src="https://img.shields.io/badge/docs-pmcfadin.github.io%2Fcqlite-blue.svg" alt="Docs"></a>
@@ -39,6 +41,13 @@ CQLite is designed by **Patrick McFadin**, Apache Cassandra PMC member with 13 y
 
 ## Install
 
+### CLI (from crates.io — requires Rust 1.85+)
+
+```bash
+cargo install cqlite-cli      # installs the `cqlite` binary
+cqlite --help
+```
+
 ### CLI (prebuilt binaries — no Rust toolchain required)
 
 Each [GitHub release](https://github.com/pmcfadin/cqlite/releases) attaches a
@@ -63,6 +72,14 @@ shasum -a 256 -c cqlite-$TARGET.tar.gz.sha256   # verify (use sha256sum -c on Li
 tar xzf cqlite-$TARGET.tar.gz
 ./cqlite --help
 ```
+
+### Rust library
+
+```bash
+cargo add cqlite-core         # use cqlite-core as a dependency
+```
+
+See [Using cqlite-core as a dependency](docs/using-cqlite-core-as-a-dependency.md) and the [API docs](https://docs.rs/cqlite-core).
 
 ### Language bindings
 

--- a/bindings/node/Cargo.toml
+++ b/bindings/node/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "cqlite-node"
+publish = false  # published to npm via napi-rs, not crates.io
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "cqlite-py"
+publish = false  # published to PyPI via maturin, not crates.io
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/cqlite-cli/Cargo.toml
+++ b/cqlite-cli/Cargo.toml
@@ -8,14 +8,18 @@ repository.workspace = true
 keywords.workspace = true
 categories.workspace = true
 rust-version.workspace = true
-description = "Command-line interface for CQLite database"
+description = "Command-line interface for CQLite — read Apache Cassandra 5.0 SSTables without a cluster"
+readme = "../README.md"
 
 [[bin]]
 name = "cqlite"
 path = "src/main.rs"
 
 [dependencies]
-cqlite-core = { path = "../cqlite-core" }
+# version is required (alongside path) so the dep resolves when published to
+# crates.io. Keep this literal in sync with [workspace.package].version on every
+# release (see release checklist).
+cqlite-core = { path = "../cqlite-core", version = "0.11.0" }
 
 # CLI framework
 clap = { workspace = true }

--- a/cqlite-core/Cargo.toml
+++ b/cqlite-core/Cargo.toml
@@ -8,7 +8,13 @@ repository.workspace = true
 keywords.workspace = true
 categories.workspace = true
 rust-version.workspace = true
-description = "Core database engine for CQLite"
+description = "Core engine for CQLite — read Apache Cassandra 5.0 SSTables locally without a cluster"
+readme = "../README.md"
+
+# docs.rs build: document the commonly used features. Deliberately excludes
+# `wasm` (wasm32-only deps would fail the default x86_64 docs.rs target).
+[package.metadata.docs.rs]
+features = ["all-compression", "state_machine", "write-support", "parquet", "cli-helpers"]
 
 [dependencies]
 # Async runtime

--- a/docs/using-cqlite-core-as-a-dependency.md
+++ b/docs/using-cqlite-core-as-a-dependency.md
@@ -5,32 +5,29 @@ their own project — reading and/or writing Cassandra 5.0 SSTables without a
 cluster. It covers the dependency line, the feature flags you need, and a
 **compiling** end-to-end write example.
 
-`cqlite-core` is not published on crates.io, so downstream projects pin it by git
-tag.
+`cqlite-core` is published on [crates.io](https://crates.io/crates/cqlite-core),
+with API docs on [docs.rs](https://docs.rs/cqlite-core).
 
 ## 1. Add the dependency
 
-Pin a released tag (see the [CHANGELOG](../CHANGELOG.md) for what each tag contains):
-
 ```toml
-# Cargo.toml — read + query path (default features)
+# Cargo.toml — read + query + write path (all default features)
 [dependencies]
-cqlite-core = { git = "https://github.com/pmcfadin/cqlite.git", tag = "v0.9.2" }
+cqlite-core = "0.11"
 ```
 
-The write path (`WriteEngine`, `Mutation`) is gated behind the `write-support`
-feature. On **v0.9.2** it is opt-in, so enable it explicitly:
+Or run `cargo add cqlite-core`. The read/query path, compression, and the write
+path (`WriteEngine`, `Mutation`) are all **on by default** — `write-support` gates
+only first-party code and pulls in no extra dependencies, so it is free for
+read-only consumers.
+
+To track an unreleased commit instead of a published version, you can still pin a
+git tag:
 
 ```toml
-# Cargo.toml — read + write path on v0.9.2
 [dependencies]
-cqlite-core = { git = "https://github.com/pmcfadin/cqlite.git", tag = "v0.9.2", features = ["write-support"] }
+cqlite-core = { git = "https://github.com/pmcfadin/cqlite.git", tag = "v0.11.0" }
 ```
-
-> As of [#558](https://github.com/pmcfadin/cqlite/issues/558) (next release),
-> `write-support` is a **default** feature, so the explicit `features` line is no
-> longer needed for the write path. It gates only first-party code and pulls in no
-> extra dependencies, so keeping it on is free for read-only consumers.
 
 ## 2. Feature → API map
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "cqlite-examples"
+publish = false
 version.workspace = true
 edition.workspace = true
 

--- a/tools/cqlite-validator/Cargo.toml
+++ b/tools/cqlite-validator/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "cqlite-validator"
+publish = false
 version = "0.1.0"
 edition = "2021"
 

--- a/tools/format-validator/Cargo.toml
+++ b/tools/format-validator/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "format-validator"
+publish = false
 version = "0.1.0"
 edition = "2021"
 description = "Cassandra 5+ SSTable format validation toolkit"

--- a/tools/memory-safety-runner/Cargo.toml
+++ b/tools/memory-safety-runner/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "memory-safety-runner"
+publish = false
 version.workspace = true
 edition.workspace = true
 description = "Memory safety testing tools for CQLite (Miri, Valgrind, AddressSanitizer)"

--- a/tools/sstabledump-validator/Cargo.toml
+++ b/tools/sstabledump-validator/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "sstabledump-validator"
+publish = false
 version = "0.1.0"
 edition = "2021"
 description = "Zero-tolerance cell-by-cell validation harness for sstabledump compatibility"


### PR DESCRIPTION
Prepares the workspace for crates.io. Publishes the library as **`cqlite-core`** and the CLI as **`cqlite-cli`** (`cargo install cqlite-cli`; the installed binary is still `cqlite`).

## Why `cqlite-cli`, not `cqlite`
The bare **`cqlite`** crate name on crates.io is already owned by an unrelated project (dyedgreen/cqlite, an embedded graph database). So we publish the CLI under `cqlite-cli` (matches the issue's own task list). No package renames, no `--package` selector churn.

## Changes
- **cqlite-cli**: `cqlite-core` dep gains `version = "0.11.0"` (required + path) so it resolves on crates.io; add `readme`.
- **cqlite-core**: `readme` + `[package.metadata.docs.rs]` (documented features, **excludes `wasm`** so the x86_64 docs.rs build succeeds).
- **`publish = false`** on every non-published member: the empty workspace-root `cqlite` package (test-host), python/node bindings, examples, 4 tools.
- **CI**: new `publish-dry-run` job runs `cargo publish -p cqlite-core --dry-run` on every PR to guard publish-readiness (also exercises the "no uncommitted/untracked files" rule).
- **Docs**: README crates.io (cqlite-cli) + docs.rs (cqlite-core) badges, `cargo install cqlite-cli`, `cargo add cqlite-core`; `docs/using-cqlite-core-as-a-dependency.md` rewritten to crates.io usage.

## Validation
- Local agent-gate: 7/8 components PASS. `core-tests` flagged a **load-induced flake** in the wall-clock `test_flush_throughput` perf assertion (got 4.1 MB/s during a 48-min contended run; **34 / 29 MB/s in isolation** vs the 5 MB/s target). Changes are metadata-only — no source touched — so this is environment, not regression.
- `cargo publish -p cqlite-core --dry-run` → OK (1.3 MB, no fixtures bundled).
- docs.rs feature build simulated clean.

## Follow-ups (not in this PR)
1. **Manual first publish**: `cargo publish -p cqlite-core`, wait for propagation, then `cargo publish -p cqlite-cli`.
2. **Enable CI auto-publish**: uncomment the `publish-crate` job in `release.yml` + add `CARGO_REGISTRY_TOKEN` (recommend OIDC trusted publishing to match npm/PyPI).
3. **Release checklist**: keep the `cqlite-core` dep `version` literal in `cqlite-cli/Cargo.toml` in sync with the workspace version each bump.