### PR TITLE
ci(release): enable crates.io publish on tag (#782)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,20 +215,57 @@ jobs:
   #     env:
   #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # NOTE: crates.io publishing disabled until CARGO_REGISTRY_TOKEN is configured
-  # Uncomment when ready to publish to crates.io
-  # publish-crate:
-  #   name: Publish to crates.io
-  #   needs: [build-cli]
-  #   runs-on: ubuntu-latest
-  #   if: startsWith(github.ref, 'refs/tags/v')
-  #   steps:
-  #   - uses: actions/checkout@v5
-  #   - name: Install Rust
-  #     uses: dtolnay/rust-toolchain@stable
-  #   - name: Publish cqlite-core
-  #     run: cargo publish --package cqlite-core --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
-  #   - name: Wait for cqlite-core to be available
-  #     run: sleep 30
-  #   - name: Publish cqlite-cli
-  #     run: cargo publish --package cqlite-cli --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+  # Publish cqlite-core then cqlite-cli to crates.io on a version tag.
+  # Idempotent: versions already on crates.io are skipped (so re-running a tag,
+  # or a tag whose version was hand-published, does not hard-fail). cqlite-core
+  # publishes first and we wait for the index to expose it before cqlite-cli,
+  # whose dep is `cqlite-core = { path, version = "X" }` and must resolve.
+  # TODO(#782 follow-up): migrate to crates.io OIDC trusted publishing (no stored
+  # token, matching node-release.yml / python-release.yml).
+  publish-crate:
+    name: Publish to crates.io
+    needs: [build-cli]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+    - uses: actions/checkout@v5
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+    - name: Publish crates (core before cli, idempotent)
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        TAG: ${{ github.ref_name }}
+      run: |
+        set -euo pipefail
+        VER="${TAG#v}"
+        UA="cqlite-release-ci (https://github.com/pmcfadin/cqlite)"
+
+        # Fail fast if the tag and the crate version disagree (avoids publishing
+        # the wrong version from Cargo.toml).
+        PKG_VER="$(cargo metadata --no-deps --format-version 1 \
+          | jq -r '.packages[] | select(.name=="cqlite-core") | .version')"
+        if [ "$PKG_VER" != "$VER" ]; then
+          echo "::error::tag $VER does not match cqlite-core version $PKG_VER"
+          exit 1
+        fi
+
+        on_crates_io() {  # $1=crate -> 0 if version $VER already published
+          [ "$(curl -s -o /dev/null -w '%{http_code}' -A "$UA" \
+            "https://crates.io/api/v1/crates/$1/$VER")" = "200" ]
+        }
+        publish() {  # $1=package
+          if on_crates_io "$1"; then
+            echo "✓ $1 $VER already on crates.io — skipping"
+          else
+            echo "→ publishing $1 $VER"
+            cargo publish --package "$1"
+          fi
+        }
+
+        publish cqlite-core
+        echo "waiting for cqlite-core $VER on the index..."
+        for i in $(seq 1 20); do
+          on_crates_io cqlite-core && break
+          sleep 15
+        done
+        publish cqlite-cli


### PR DESCRIPTION
Enables automatic crates.io publishing on version tags — the last follow-up from #782 (#784). Token-based for now; OIDC migration tracked as the next step.

## What it does
Activates the `publish-crate` job in `release.yml` (runs on `v*` tags, `needs: build-cli`):
- Publishes **cqlite-core**, waits for it to appear on the index, then **cqlite-cli** (its dep is `cqlite-core = { path, version }` and must resolve).
- Uses `CARGO_REGISTRY_TOKEN` (repo/environment secret — already added).

## Safety
- **Idempotent** — checks the crates.io API and skips any version already published, so the already-hand-published `0.11.0` (and any tag re-run) won't hard-fail.
- **Version guard** — fails fast if the tag (`vX.Y.Z`) doesn't match the `cqlite-core` crate version, so it can't publish the wrong version.
- Real publish errors still fail the job (`set -euo pipefail`).

## Testing note
There's nothing to publish at `0.11.0` (already on crates.io), so this job will **no-op on the current tag** and only does real work on the **next version bump** (e.g. `v0.11.1`/`v0.12.0`). That bump is also where the `cqlite-core` dep version literal in `cqlite-cli/Cargo.toml` must be updated in lockstep.

## Next
Migrate this job to **crates.io OIDC trusted publishing** (no stored token), matching `node-release.yml` / `python-release.yml`. A `TODO` marks the spot.