### PR TITLE
fix(query): apply clustering-key inequality bounds (>=, >, <, <=) (#788)

### DIFF
--- a/cqlite-core/src/query/select_executor.rs
+++ b/cqlite-core/src/query/select_executor.rs
@@ -179,6 +179,24 @@ fn evaluate_predicates(row: &QueryRow, predicates: &[SSTablePredicate]) -> Resul
                         && compare_values_ordering(column_value, hi).is_le()
                 }
             }
+            // Single-bound clustering inequalities (Issue #788). A missing bound
+            // rejects the row, mirroring the `Range` len-guard above.
+            SSTableFilterOp::Gt => predicate
+                .values
+                .first()
+                .is_some_and(|b| compare_values_ordering(column_value, b).is_gt()),
+            SSTableFilterOp::Gte => predicate
+                .values
+                .first()
+                .is_some_and(|b| compare_values_ordering(column_value, b).is_ge()),
+            SSTableFilterOp::Lt => predicate
+                .values
+                .first()
+                .is_some_and(|b| compare_values_ordering(column_value, b).is_lt()),
+            SSTableFilterOp::Lte => predicate
+                .values
+                .first()
+                .is_some_and(|b| compare_values_ordering(column_value, b).is_le()),
             SSTableFilterOp::Prefix => matches!(
                 (column_value, predicate.values.first()),
                 (Value::Text(s), Some(Value::Text(p))) if s.starts_with(p)
@@ -1658,5 +1676,73 @@ mod tests {
             evaluate_predicates(&row, std::slice::from_ref(&predicate)).unwrap(),
             "Issue #586: WHERE id = '<literal>' must match the reconstructed PK column"
         );
+    }
+
+    /// Build a one-column `QueryRow` for predicate-evaluation tests.
+    fn row_with_int(column: &str, value: i64) -> QueryRow {
+        let mut values = std::collections::HashMap::new();
+        values.insert(column.to_string(), Value::Integer(value as i32));
+        QueryRow {
+            values,
+            key: RowKey::new(Vec::new()),
+            metadata: Default::default(),
+        }
+    }
+
+    /// Issue #788: each clustering-key inequality op must include/exclude rows on
+    /// the correct side of its bound when evaluated post-scan.
+    #[test]
+    fn inequality_predicates_apply_single_bound() {
+        use super::super::select_optimizer::{SSTableFilterOp, SSTablePredicate};
+
+        let bound = |op: SSTableFilterOp| SSTablePredicate {
+            column: "ck".to_string(),
+            operation: op,
+            values: vec![Value::Integer(200)],
+        };
+        let eval = |op: SSTableFilterOp, ck: i64| {
+            evaluate_predicates(&row_with_int("ck", ck), std::slice::from_ref(&bound(op))).unwrap()
+        };
+
+        // ck > 200
+        assert!(!eval(SSTableFilterOp::Gt, 200));
+        assert!(eval(SSTableFilterOp::Gt, 201));
+        // ck >= 200
+        assert!(eval(SSTableFilterOp::Gte, 200));
+        assert!(!eval(SSTableFilterOp::Gte, 199));
+        // ck < 200
+        assert!(eval(SSTableFilterOp::Lt, 199));
+        assert!(!eval(SSTableFilterOp::Lt, 200));
+        // ck <= 200
+        assert!(eval(SSTableFilterOp::Lte, 200));
+        assert!(!eval(SSTableFilterOp::Lte, 201));
+    }
+
+    /// Issue #788: the `pk = ? AND ck >= 0 AND ck < 200` shape — a two-bound AND
+    /// set — must include `[0, 199]` and exclude `200`/`1000`, reproducing the
+    /// 200-row slice the issue expects (previously the whole partition leaked).
+    #[test]
+    fn two_bound_inequality_slice_selects_half_open_range() {
+        use super::super::select_optimizer::{SSTableFilterOp, SSTablePredicate};
+
+        let predicates = vec![
+            SSTablePredicate {
+                column: "ck".to_string(),
+                operation: SSTableFilterOp::Gte,
+                values: vec![Value::Integer(0)],
+            },
+            SSTablePredicate {
+                column: "ck".to_string(),
+                operation: SSTableFilterOp::Lt,
+                values: vec![Value::Integer(200)],
+            },
+        ];
+        let in_slice = |ck: i64| evaluate_predicates(&row_with_int("ck", ck), &predicates).unwrap();
+
+        assert!(in_slice(0), "lower bound is inclusive");
+        assert!(in_slice(199), "last row in [0, 200) is included");
+        assert!(!in_slice(200), "upper bound is exclusive");
+        assert!(!in_slice(1000), "rows past the slice are excluded");
+        assert!(!in_slice(-1), "rows below the slice are excluded");
     }
 }

--- a/cqlite-core/src/query/select_optimizer.rs
+++ b/cqlite-core/src/query/select_optimizer.rs
@@ -61,6 +61,12 @@ pub struct SSTablePredicate {
 pub enum SSTableFilterOp {
     Equal,
     Range,
+    /// Single-bound clustering inequalities (`>`, `>=`, `<`, `<=`). Each carries
+    /// one bound value in `SSTablePredicate::values`. Issue #788.
+    Gt,
+    Gte,
+    Lt,
+    Lte,
     In,
     Prefix,
     BloomFilter,
@@ -220,6 +226,37 @@ fn comparison_to_sstable_predicate(comp: &ComparisonExpression) -> Option<SSTabl
                 values: vec![start, end],
             })
         }
+        // Single-bound clustering inequalities. Without these arms the operators
+        // fall through to `None` and the restriction is silently dropped, so the
+        // whole partition is returned instead of the requested slice (Issue #788).
+        (ComparisonOperator::GreaterThan, ComparisonRightSide::Value(value_expr)) => {
+            Some(SSTablePredicate {
+                column,
+                operation: SSTableFilterOp::Gt,
+                values: vec![literal_value(value_expr)?],
+            })
+        }
+        (ComparisonOperator::GreaterThanOrEqual, ComparisonRightSide::Value(value_expr)) => {
+            Some(SSTablePredicate {
+                column,
+                operation: SSTableFilterOp::Gte,
+                values: vec![literal_value(value_expr)?],
+            })
+        }
+        (ComparisonOperator::LessThan, ComparisonRightSide::Value(value_expr)) => {
+            Some(SSTablePredicate {
+                column,
+                operation: SSTableFilterOp::Lt,
+                values: vec![literal_value(value_expr)?],
+            })
+        }
+        (ComparisonOperator::LessThanOrEqual, ComparisonRightSide::Value(value_expr)) => {
+            Some(SSTablePredicate {
+                column,
+                operation: SSTableFilterOp::Lte,
+                values: vec![literal_value(value_expr)?],
+            })
+        }
         _ => None,
     }
 }
@@ -324,5 +361,86 @@ mod tests {
         let schema = Arc::new(SchemaManager::new(temp_dir.path()).await.unwrap());
         let optimizer = SelectOptimizer { schema, storage };
         assert!(std::mem::size_of_val(&optimizer) > 0);
+    }
+
+    /// Build `<column> <op> <literal>` for predicate-conversion tests.
+    fn cmp(op: ComparisonOperator, column: &str, value: Value) -> ComparisonExpression {
+        ComparisonExpression {
+            left: SelectExpression::Column(ColumnRef {
+                table: None,
+                column: column.to_string(),
+            }),
+            operator: op,
+            right: ComparisonRightSide::Value(SelectExpression::Literal(value)),
+        }
+    }
+
+    /// Issue #788: clustering-key inequalities must convert to single-bound
+    /// SSTable predicates so they are evaluated post-scan instead of dropped.
+    #[test]
+    fn inequality_operators_convert_to_single_bound_predicates() {
+        let cases = [
+            (ComparisonOperator::GreaterThan, SSTableFilterOp::Gt),
+            (ComparisonOperator::GreaterThanOrEqual, SSTableFilterOp::Gte),
+            (ComparisonOperator::LessThan, SSTableFilterOp::Lt),
+            (ComparisonOperator::LessThanOrEqual, SSTableFilterOp::Lte),
+        ];
+        for (op, expected_op) in cases {
+            let comp = cmp(op.clone(), "ck", Value::Integer(200));
+            let predicate = comparison_to_sstable_predicate(&comp)
+                .unwrap_or_else(|| panic!("operator {op:?} must convert to a predicate"));
+            assert_eq!(predicate.column, "ck");
+            assert!(
+                std::mem::discriminant(&predicate.operation)
+                    == std::mem::discriminant(&expected_op),
+                "operator {op:?} produced {:?}, expected {expected_op:?}",
+                predicate.operation
+            );
+            assert_eq!(predicate.values, vec![Value::Integer(200)]);
+        }
+    }
+
+    /// Issue #788, end-to-end through the real parser: the exact query from the
+    /// bug report must produce a plan that carries BOTH clustering inequalities
+    /// alongside the partition equality. Before the fix only the `pk` equality
+    /// survived `collect_sstable_predicates`, so the whole partition leaked.
+    #[test]
+    fn query_plan_carries_clustering_inequality_bounds() {
+        use crate::query::select_parser::parse_select;
+
+        let statement = parse_select(
+            "SELECT * FROM perf.wide_rows WHERE pk = 'p0000' AND ck >= 0 AND ck < 200",
+        )
+        .expect("issue #788 query must parse");
+        let where_clause = statement
+            .where_clause
+            .expect("WHERE clause must be present");
+
+        let predicates = collect_sstable_predicates(&where_clause);
+
+        let has = |col: &str, want: &SSTableFilterOp| {
+            predicates.iter().any(|p| {
+                p.column == col
+                    && std::mem::discriminant(&p.operation) == std::mem::discriminant(want)
+            })
+        };
+
+        assert!(
+            has("pk", &SSTableFilterOp::Equal),
+            "partition equality must be pushed; got {predicates:?}"
+        );
+        assert!(
+            has("ck", &SSTableFilterOp::Gte),
+            "Issue #788: `ck >= 0` must be pushed as Gte (was dropped); got {predicates:?}"
+        );
+        assert!(
+            has("ck", &SSTableFilterOp::Lt),
+            "Issue #788: `ck < 200` must be pushed as Lt (was dropped); got {predicates:?}"
+        );
+        assert_eq!(
+            predicates.len(),
+            3,
+            "all three restrictions must be captured; got {predicates:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #788. On a composite-PK table, clustering-key **inequality** restrictions (`>=`, `>`, `<`, `<=`) were silently dropped on the read path — a query returned the **whole partition** instead of the requested slice, while `BETWEEN` on the same column worked.

## Root cause

`comparison_to_sstable_predicate()` (`cqlite-core/src/query/select_optimizer.rs`) only converted `Equal`, `In`, and `Between`. The four inequality operators fell through to `_ => None`, so they were never turned into a pushdown predicate. With the `pk =` equality already pushed, the optimizer also skipped its post-scan `Filter` fallback (which only fires when *no* predicate could be pushed), so the bounds vanished entirely. `BETWEEN` worked because it became a `Range` predicate evaluated per row via `compare_values_ordering`.

## Fix

Mirror the existing `BETWEEN`/`Range` path:
- add `Gt`/`Gte`/`Lt`/`Lte` to `SSTableFilterOp`
- convert each inequality to a single-bound predicate in the optimizer
- evaluate them in `evaluate_predicates` using `compare_values_ordering`

## Tests (deterministic, no fetched data)

- **optimizer**: each operator converts to the correct single-bound predicate
- **optimizer**: the issue's exact query string, parsed through `parse_select`, yields a plan carrying **both** clustering inequalities alongside the `pk` equality (regression guard for the dropped bounds)
- **executor**: per-operator include/exclude around the bound, plus the half-open `>= lo AND < hi` two-bound slice from the bug report

The shipped corpus has no table with a multi-row integer-clustering partition (the issue's `perf.wide_rows` is synthetic), so the end-to-end slice is covered at the parse→plan and per-row evaluation layers.

## Validation

`scripts/agent-gate.sh` — RESULT: PASS (fmt, clippy `-D warnings`, core/integration/write/cli tests, minimal-build, smoke).