### PR TITLE
docs: add Known Issues + Roadmap, sharpen contribution path

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@
 
 CQLite provides SQLite-like local access to Apache Cassandra SSTables, enabling developers to read Cassandra 5.0+ data files without cluster dependencies. Built in Rust for performance and safety.
 
+> ⭐ **Find CQLite useful?** [**Star the repo**](https://github.com/pmcfadin/cqlite) — it is the clearest signal that this work matters and directly drives how much time goes into it.
+> 🐛 **Hit a bug or need a feature?** [**Open an issue**](https://github.com/pmcfadin/cqlite/issues/new/choose). For questions and ideas, use [Discussions](https://github.com/pmcfadin/cqlite/discussions). See [Known Issues](#known-issues) and the [Roadmap](#roadmap) before filing.
+
 ## Documentation
 
 Full documentation is at **[https://pmcfadin.github.io/cqlite/](https://pmcfadin.github.io/cqlite/)**:
@@ -296,8 +299,46 @@ cargo build -p cqlite-core --no-default-features
 - See [CHANGELOG.md](CHANGELOG.md) for the full per-release detail
 
 ### 📋 Roadmap
-- [ ] M6: WASM bindings for browser deployment
-- [ ] M7: Performance validation + v1.0 release
+
+See the [**Roadmap**](#roadmap) section below for in-flight epics and milestones.
+
+## Roadmap
+
+CQLite is at **v0.11.0** and production-ready for the use cases above. The path to
+**v1.0** is tracked in the open. Full detail, with milestones, lives at
+[pmcfadin.github.io/cqlite → Roadmap](https://pmcfadin.github.io/cqlite/user-docs/roadmap/).
+
+| Workstream | Epic |
+|------------|------|
+| Query engine completeness — `PER PARTITION LIMIT`, static columns, clustering order, plan metadata | [#756](https://github.com/pmcfadin/cqlite/issues/756) |
+| `WRITETIME()` / `TTL()` in `SELECT` | [#689](https://github.com/pmcfadin/cqlite/issues/689) |
+| Writer format fidelity — `>64`-col headers, deletion-time, `DURATION`, BTI index writing | [#762](https://github.com/pmcfadin/cqlite/issues/762) |
+| Wide-partition & memory performance — promoted index, streamed writers, O(log n) seeks | [#751](https://github.com/pmcfadin/cqlite/issues/751) |
+| BTI (`da`) end-to-end **read** support | [#660](https://github.com/pmcfadin/cqlite/issues/660) |
+| Delta-scan envelope for CDC-style Parquet projections | [#696](https://github.com/pmcfadin/cqlite/issues/696) |
+| M6 — WASM bindings · M7 — performance validation + **v1.0** | _planned_ |
+
+The roadmap follows real-world use. Want something prioritized?
+[Open or 👍 an issue](https://github.com/pmcfadin/cqlite/issues) — and
+[⭐ star the repo](https://github.com/pmcfadin/cqlite).
+
+## Known Issues
+
+CQLite is honest about its sharp edges. The current release (`v0.11.0`) has a few
+known gaps — none of which block the core read/export workflows. Full, dated list:
+[pmcfadin.github.io/cqlite → Known Issues](https://pmcfadin.github.io/cqlite/user-docs/known-issues/).
+
+| Issue | Impact | Tracking |
+|-------|--------|----------|
+| Set element tombstones may hide a row | Narrow correctness edge case | [#493](https://github.com/pmcfadin/cqlite/issues/493) |
+| Wide partitions written by CQLite scan linearly (`promoted_index_length = 0`) | Perf on 10k+ rows/partition | [#751](https://github.com/pmcfadin/cqlite/issues/751), [#752](https://github.com/pmcfadin/cqlite/issues/752) |
+| BTI (`da`) SSTables are rejected, not read | Use BIG format or convert first | [#660](https://github.com/pmcfadin/cqlite/issues/660) |
+| Pre-5.0 formats (`md`/`mc`/`la`/`ma`) unsupported | By design — Cassandra 5.0 only | [Limitations](https://pmcfadin.github.io/cqlite/user-docs/limitations/) |
+
+For what CQLite does **not** do by design (older formats, network access, query
+features), see [Limitations](https://pmcfadin.github.io/cqlite/user-docs/limitations/).
+
+**Found something not listed?** [Open an issue](https://github.com/pmcfadin/cqlite/issues/new/choose) — a good report (Cassandra version, schema, command, output) is the most valuable contribution you can make.
 
 ## Architecture Highlights
 
@@ -405,9 +446,10 @@ See [docs/development/PRD.md](docs/development/PRD.md) for milestone details.
 
 ## Community
 
-- **Questions & ideas**: [GitHub Discussions](https://github.com/pmcfadin/cqlite/discussions)
-- **Bugs & feature requests**: [GitHub Issues](https://github.com/pmcfadin/cqlite/issues)
-- **Contributing**: see [CONTRIBUTING.md](CONTRIBUTING.md) and our [Code of Conduct](CODE_OF_CONDUCT.md)
+- **⭐ Star the project**: [github.com/pmcfadin/cqlite](https://github.com/pmcfadin/cqlite) — the single best way to support it and shape where the time goes
+- **🐛 Bugs & feature requests**: [GitHub Issues](https://github.com/pmcfadin/cqlite/issues/new/choose)
+- **💬 Questions & ideas**: [GitHub Discussions](https://github.com/pmcfadin/cqlite/discussions)
+- **🛠 Contributing**: see [CONTRIBUTING.md](CONTRIBUTING.md), the [Roadmap](#roadmap), and our [Code of Conduct](CODE_OF_CONDUCT.md) — look for `good-first-issue` labels
 
 CQLite is an independent open-source project, not an Apache Software Foundation
 project. It is built in the spirit of the Apache Cassandra community, with the

--- a/website/src/content/docs/user-docs/known-issues.md
+++ b/website/src/content/docs/user-docs/known-issues.md
@@ -1,0 +1,96 @@
+---
+title: Known Issues
+description: Active bugs and sharp edges in the current CQLite release, with issue links — what to watch out for today.
+sidebar:
+  label: Known Issues
+  order: 8
+---
+
+# Known Issues
+
+This page tracks **active bugs and sharp edges** in the current release (`v0.11.0`).
+It is deliberately short and honest: if something here bites you, you are not doing
+it wrong.
+
+- For things CQLite **does not do by design or yet**, see
+  [Limitations](/cqlite/user-docs/limitations/).
+- For **planned work and milestones**, see [Roadmap](/cqlite/user-docs/roadmap/).
+- Hit something not listed here?
+  [**Open an issue**](https://github.com/pmcfadin/cqlite/issues/new/choose) — that is
+  the single most useful thing you can do for the project.
+
+_Last reviewed: 2026-06-16 (v0.11.0)._
+
+## Correctness
+
+### Set element tombstones may hide a row ([#493](https://github.com/pmcfadin/cqlite/issues/493))
+
+Individual element deletions inside a `set<T>` are not fully surfaced. A row that
+contains **only** set-element tombstones may read as empty rather than as present.
+This is a narrow edge case — full sets, set replacement, and partition/row/range
+tombstones all work correctly. Tracked in
+[#493](https://github.com/pmcfadin/cqlite/issues/493).
+
+## Performance
+
+### Wide partitions scan linearly ([#751](https://github.com/pmcfadin/cqlite/issues/751), [#752](https://github.com/pmcfadin/cqlite/issues/752))
+
+SSTables **written** by CQLite emit `promoted_index_length = 0`, so within-partition
+seeks fall back to a linear scan.
+
+- Narrow partitions (< 100 rows): no measurable impact.
+- Wide partitions (10 000+ rows): O(n) scan within the partition.
+
+Reading SSTables written by Cassandra is unaffected — this only concerns the CQLite
+write path. The promoted-index writer and BTI-based O(log n) seeks are on the
+[roadmap](/cqlite/user-docs/roadmap/) (epic
+[#751](https://github.com/pmcfadin/cqlite/issues/751)).
+
+## Format coverage
+
+### BTI (`da`) SSTables are rejected, not read
+
+BTI/trie-index SSTables (`da-*-bti-*`, opt-in in Cassandra 5.0) are detected and
+rejected with a clear error rather than misread. This is by design until the
+dedicated BTI read path lands — see
+[Limitations](/cqlite/user-docs/limitations/) and roadmap item
+[#660](https://github.com/pmcfadin/cqlite/issues/660).
+
+## Contributor / CI
+
+These do not affect users of the published packages, but matter if you build and test
+from source.
+
+### Python test suite silently skips tests ([#773](https://github.com/pmcfadin/cqlite/issues/773))
+
+A path-resolution bug in the Python test harness (`CQLITE_DATASETS_ROOT`) can cause
+~120 tests to skip silently and mask real failures. If you run `pytest` against the
+Python bindings, set the dataset root explicitly:
+
+```bash
+export CQLITE_DATASETS_ROOT=$PWD/test-data/datasets
+bash test-data/scripts/fetch-datasets.sh
+```
+
+Tracked in [#773](https://github.com/pmcfadin/cqlite/issues/773).
+
+### Intermittent CI flake ([#774](https://github.com/pmcfadin/cqlite/issues/774))
+
+`test_row_ttl_uses_row_ttl_cell_flags` byte-scans flag bytes and fails
+intermittently in CI. A re-run clears it; it does not indicate a real regression.
+Tracked in [#774](https://github.com/pmcfadin/cqlite/issues/774).
+
+## Reporting something new
+
+If you hit a bug — wrong output, a panic, a parsing error, a performance cliff —
+please report it. Good reports include:
+
+1. The **Cassandra version** that wrote the SSTable and the file names (e.g.
+   `nb-1-big-Data.db`).
+2. The **CQL schema** for the table.
+3. The exact **command or code** you ran and the output (or a hex dump for parsing
+   issues).
+
+[**→ Open an issue**](https://github.com/pmcfadin/cqlite/issues/new/choose)
+</content>
+</invoke>

--- a/website/src/content/docs/user-docs/limitations.md
+++ b/website/src/content/docs/user-docs/limitations.md
@@ -12,6 +12,10 @@ CQLite is production-ready for the common case: reading Cassandra 5.0 BIG-format
 SSTables with standard data types. This page is honest about what it cannot do yet,
 so you know before you depend on it.
 
+This page covers what CQLite **cannot do by design or yet**. For active bugs and
+sharp edges in the current release, see [Known Issues](/cqlite/user-docs/known-issues/);
+for what is coming next, see the [Roadmap](/cqlite/user-docs/roadmap/).
+
 For the exhaustive engineering detail, see [Appendix F: Known Limitations](/cqlite/sstable-format/appendix-f/) in the SSTable Format Guide.
 
 ## Format support
@@ -108,14 +112,15 @@ The `IndexWriter` buffers all index entries in memory until `finish()` is called
 **Impact**: approximately 20 MB per 1 million partitions. For extremely large SSTables
 (hundreds of millions of partitions), split writes into multiple generation files.
 
-### Compaction not yet executable
+### Compaction is STCS-only
 
-The k-way merge compaction API is defined (STCS policy, `maintenance_step()`, etc.)
-but execution requires M5.3 SSTable reader integration to convert entries back to
-mutations. `set_merge_policy()` currently returns an error.
+STCS (size-tiered) compaction executes via `set_merge_policy()` and
+`maintenance_step()`. Other strategies (LCS, TWCS, UCS) are not implemented — a
+non-STCS policy is not selectable.
 
-**Impact**: `maintenance_step()` currently performs flush operations only. Full
-compaction is deferred to M5.3.
+**Impact**: SSTables written and compacted by CQLite follow size-tiered behavior.
+This matches the most common Cassandra default and is sufficient for offline
+write/flush/compact workflows.
 
 ## Query engine limitations
 
@@ -134,7 +139,7 @@ compaction is deferred to M5.3.
 Set element tombstones — individual element deletions inside a `set<T>` — are not
 fully surfaced. Rows containing only element tombstones may appear empty rather
 than absent. This affects a narrow edge case and is tracked in
-[issue #493](https://github.com/pmcfadin/cqlite/issues/493) for v0.9.1.
+[issue #493](https://github.com/pmcfadin/cqlite/issues/493).
 
 ## Operational constraints
 
@@ -161,9 +166,12 @@ or use Cassandra's `sstabledump` to export to JSON and reimport.
 
 ### BTI format (trie index)
 
-If your Cassandra cluster is configured with `selected_format: bti`, CQLite will
-still return correct results via sequential scan fallback. For large tables the
-scan may be slow; partition-key `WHERE` filters help bound the scan.
+If your Cassandra cluster is configured with `selected_format: bti`, CQLite detects
+the `da-*-bti-*` SSTables and rejects them with a clear error rather than misreading
+them. Convert them to the default BIG format first — run `nodetool upgradesstables`
+after switching `selected_format` back to `big`, or export with `sstabledump`.
+End-to-end BTI read support is on the [roadmap](/cqlite/user-docs/roadmap/)
+([#660](https://github.com/pmcfadin/cqlite/issues/660)).
 
 ### Wide partitions
 

--- a/website/src/content/docs/user-docs/roadmap.md
+++ b/website/src/content/docs/user-docs/roadmap.md
@@ -1,0 +1,86 @@
+---
+title: Roadmap
+description: Where CQLite is headed — milestones, in-flight epics, and how to influence priorities.
+sidebar:
+  label: Roadmap
+  order: 9
+---
+
+# Roadmap
+
+CQLite is at **v0.11.0**. The read path, CLI, output writers (including Parquet),
+Python and Node.js bindings, and write support with STCS compaction are
+production-ready. This page is what comes next.
+
+The roadmap is community-driven. The fastest way to move something up the list is to
+[**open or +1 an issue**](https://github.com/pmcfadin/cqlite/issues) describing your
+use case — and to [**star the repo**](https://github.com/pmcfadin/cqlite) so the
+project's reach is visible.
+
+_Last reviewed: 2026-06-16 (v0.11.0)._
+
+## Milestones
+
+| Milestone | Status |
+|-----------|--------|
+| M1 — Core SSTable reading | ✅ Complete |
+| M2 — CLI (one-shot + REPL) | ✅ Complete |
+| M3 — Output writers (CSV, JSON, Parquet, CQL) | ✅ Complete |
+| M4 — Python + Node.js bindings | ✅ Complete |
+| M5 — Write support + STCS compaction | ✅ Complete (v0.9.0) |
+| M6 — WASM bindings for the browser | 📋 Planned |
+| M7 — Performance validation + **v1.0** | 📋 Planned |
+
+## In-flight epics
+
+These are the active workstreams between v0.11.0 and v1.0. Each links to its GitHub
+epic with the child tasks.
+
+### Query engine completeness ([#756](https://github.com/pmcfadin/cqlite/issues/756))
+
+`PER PARTITION LIMIT`, static-column tracking, clustering-order (`ASC`/`DESC`)
+extraction, and query-plan metadata (`indexes_used`). Closes the gap between CQLite's
+`SELECT` support and CQL semantics.
+
+### `WRITETIME()` and `TTL()` in `SELECT` ([#689](https://github.com/pmcfadin/cqlite/issues/689))
+
+Surface per-cell write timestamps and TTLs through the parser, executor, output
+formats, and bindings — a common need for debugging and migration workflows.
+
+### Writer format fidelity ([#762](https://github.com/pmcfadin/cqlite/issues/762))
+
+`> 64`-column serialization headers, explicit deletion-time semantics, `DURATION`
+comparator parsing, and phase 1 of BTI **index writing** for SSTables CQLite produces.
+
+### Wide-partition & memory performance ([#751](https://github.com/pmcfadin/cqlite/issues/751))
+
+Promoted-index writing for wide partitions, streamed index/merge writers to drop the
+in-memory buffer, and BTI-payload Data.db offsets for O(log n) partition seeks. This
+also closes the wide-partition scan listed in
+[Known Issues](/cqlite/user-docs/known-issues/).
+
+### BTI (`da`) end-to-end read support ([#660](https://github.com/pmcfadin/cqlite/issues/660))
+
+A dedicated read path for trie-indexed SSTables — full trie walk, `ByteComparable`
+decode, and Data.db chaining — so `da`-format files are read instead of rejected.
+Fixtures and `sstabledump` goldens already ship in the test corpus.
+
+### Delta-scan envelope for CDC-style Parquet ([#696](https://github.com/pmcfadin/cqlite/issues/696))
+
+A streaming `scan_delta` API and `cqlite delta-export` subcommand that emit
+upserts, tombstones, and per-cell metadata as Parquet for change-data-capture and
+reconciliation pipelines.
+
+## Influencing the roadmap
+
+Priorities follow real-world use. If you need something:
+
+1. **Search** [existing issues](https://github.com/pmcfadin/cqlite/issues) and add a
+   👍 or a comment with your use case.
+2. **File** a [new issue](https://github.com/pmcfadin/cqlite/issues/new/choose) if it
+   is not tracked.
+3. **Star** [the repo](https://github.com/pmcfadin/cqlite) — visibility directly
+   affects how much time goes into the project.
+4. **Contribute** — see [CONTRIBUTING](https://github.com/pmcfadin/cqlite/blob/main/CONTRIBUTING.md)
+   and look for `good-first-issue` labels.
+</content>


### PR DESCRIPTION
Pre-launch docs pass.

## What
- **New docs pages**: `user-docs/known-issues.md` (active sharp edges, dated, with issue links + a good-bug-report guide) and `user-docs/roadmap.md` (milestones + in-flight epics).
- **README**: ⭐/🐛 CTA banner under the intro, new `## Roadmap` and `## Known Issues` sections, stronger Community section with a clear star + issue path.
- **`limitations.md` fixes** found while in there:
  - STCS compaction now executes — corrected the stale "not executable / set_merge_policy returns an error" section (verified in code).
  - BTI workaround corrected: `da` SSTables are rejected with a clear error, not read via scan fallback (was self-contradictory).
  - Dropped stale `#493 … for v0.9.1` reference.
  - Added cross-links between Limitations / Known Issues / Roadmap.

## Verification
- `npm run build` passes: `✓ All internal links are valid`, 68 pages built.
- New pages confirmed present in generated `llms-full.txt` (auto-regenerated; no manual llms.txt edits needed).

Docs-only; no code changes.