### PR TITLE
fix(write): file lock on write_dir to prevent concurrent corruption

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,9 @@ predicates = "3.0"
 tokio-test = "0.4"
 rand = "0.9"
 
+# File locking (cross-platform advisory locks for write_dir exclusivity)
+fs2 = "0.4"
+
 # Configuration parsing
 toml = "0.8"
 serde_yaml = "0.9"

--- a/bindings/node/src/error.rs
+++ b/bindings/node/src/error.rs
@@ -430,6 +430,11 @@ mod tests {
                 Error::Internal(_) => {}
                 Error::Parse(_) => {}
 
+                // Write-dir lock conflict — Concurrency category, maps to CONCURRENCY code
+                Error::WriteDirLocked { .. } => {
+                    assert_eq!(err.category(), ErrorCategory::Concurrency);
+                }
+
                 #[cfg(target_arch = "wasm32")]
                 Error::Wasm(_) => {}
             }

--- a/bindings/python/src/error.rs
+++ b/bindings/python/src/error.rs
@@ -97,6 +97,10 @@ pub fn to_py_err(err: cqlite_core::Error) -> PyErr {
         // This covers cases like using a closed database
         cqlite_core::Error::InvalidState(_) => PyRuntimeError::new_err(message),
 
+        // Write-dir lock conflict -> CqliteError with clear message
+        // The formatted message already contains the path and advice
+        cqlite_core::Error::WriteDirLocked { .. } => CqliteError::new_err(message),
+
         // All other errors -> CqliteError (base exception)
         // See test_error_mapping_completeness() for the complete list of unmapped variants
         _ => CqliteError::new_err(message),
@@ -381,6 +385,9 @@ mod tests {
                 Error::Internal(_) => { /* Maps to CqliteError */ }
                 Error::Parse(_) => { /* Maps to CqliteError */ }
 
+                // Write-dir lock conflict — maps to CqliteError with clear message
+                Error::WriteDirLocked { .. } => { /* Maps to CqliteError */ }
+
                 // Conditional variant (only exists on wasm32)
                 #[cfg(target_arch = "wasm32")]
                 Error::Wasm(_) => { /* Maps to CqliteError */ }
@@ -436,6 +443,9 @@ mod tests {
             Error::Compaction("compaction error".to_string()),
             Error::Internal("internal error".to_string()),
             Error::Parse("parse error".to_string()),
+            Error::WriteDirLocked {
+                path: "/tmp/test-write-dir".to_string(),
+            },
         ];
 
         for rust_err in unmapped_cases {

--- a/cqlite-core/Cargo.toml
+++ b/cqlite-core/Cargo.toml
@@ -75,6 +75,9 @@ parquet = { workspace = true, optional = true }
 
 # Features defined at end of file to avoid duplicates
 
+# File locking for write_dir exclusivity (write-support feature only)
+fs2 = { workspace = true, optional = true }
+
 # Additional dependencies
 uuid = { version = "1.10", features = ["v4"] }
 regex = "1.10"
@@ -209,7 +212,8 @@ test-coverage-tracking = []    # Real-time coverage tracking
 test-quality-gates = []        # Quality gate enforcement
 
 # M5: Write support - SSTable generation and persistence (Issue #359)
-write-support = []
+# fs2 provides cross-platform advisory file locking for write_dir exclusivity (Issue #485)
+write-support = ["dep:fs2"]
 
 # Heap profiling: installs the dhat global allocator in examples/heap_profile.rs.
 # Dev/profiling only — never enable for production builds (allocation tracking

--- a/cqlite-core/src/error.rs
+++ b/cqlite-core/src/error.rs
@@ -77,6 +77,21 @@ pub enum Error {
     #[error("Concurrency error: {0}")]
     Concurrency(String),
 
+    /// Write directory already locked by another process or Database instance
+    ///
+    /// Returned by `WriteEngine::new` when the advisory lock on `write_dir`
+    /// cannot be acquired because another `WriteEngine` (in this or another
+    /// process) already holds it.  Only one `Database` instance may hold a
+    /// `write_dir` at a time.
+    #[error(
+        "write_dir '{path}' is already locked by another process. \
+         Only one Database instance may hold a write_dir at a time."
+    )]
+    WriteDirLocked {
+        /// The path that could not be locked
+        path: String,
+    },
+
     /// Resource not found
     #[error("Not found: {0}")]
     NotFound(String),
@@ -266,6 +281,11 @@ impl Error {
         Self::UnsupportedQuery(msg.into())
     }
 
+    /// Create a write-dir locked error
+    pub fn write_dir_locked(path: impl Into<String>) -> Self {
+        Self::WriteDirLocked { path: path.into() }
+    }
+
     /// Create a table not found error
     pub fn table_not_found(msg: impl Into<String>) -> Self {
         Self::NotFound(format!("Table not found: {}", msg.into()))
@@ -304,6 +324,9 @@ impl Error {
 
             // New error types
             Error::Table(_) => false,
+
+            // Write-dir lock conflict — not recoverable without releasing the lock
+            Error::WriteDirLocked { .. } => false,
 
             #[cfg(target_arch = "wasm32")]
             Error::Wasm(_) => false,
@@ -345,6 +368,9 @@ impl Error {
 
             // New error types
             Error::Table(_) => ErrorCategory::Schema,
+
+            // Write-dir lock conflict
+            Error::WriteDirLocked { .. } => ErrorCategory::Concurrency,
 
             #[cfg(target_arch = "wasm32")]
             Error::Wasm(_) => ErrorCategory::Platform,
@@ -566,6 +592,7 @@ mod tests {
         let _ = Error::internal("test");
         let _ = Error::invalid_input("test");
         let _ = Error::parse("test");
+        let _ = Error::write_dir_locked("/tmp/test-dir");
     }
 
     #[test]
@@ -629,6 +656,10 @@ mod tests {
         assert_eq!(Error::internal("test").category(), ErrorCategory::Internal);
         assert_eq!(Error::invalid_input("test").category(), ErrorCategory::Data);
         assert_eq!(Error::parse("test").category(), ErrorCategory::Data);
+        assert_eq!(
+            Error::write_dir_locked("/tmp/test").category(),
+            ErrorCategory::Concurrency
+        );
     }
 
     #[test]
@@ -656,6 +687,7 @@ mod tests {
         assert!(!Error::internal("test").is_recoverable());
         assert!(!Error::invalid_input("test").is_recoverable());
         assert!(!Error::parse("test").is_recoverable());
+        assert!(!Error::write_dir_locked("/tmp/test").is_recoverable());
     }
 
     #[test]

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -339,6 +339,17 @@ pub struct WriteEngine {
     merge_policy: Option<Box<dyn MergePolicy>>,
     /// Cumulative compaction statistics (M5.2, Issue #474)
     cumulative_stats: CompactionStats,
+    /// Advisory exclusive lock on `write_dir` (`.lock` file).
+    ///
+    /// Held for the lifetime of the `WriteEngine`; released on `close()` or
+    /// `Drop`.  The lock is acquired in `new()` via
+    /// `fs2::FileExt::try_lock_exclusive`, which returns an error immediately
+    /// if another process already holds it (fail-fast, no blocking).
+    ///
+    /// The lock prevents two `Database` / `WriteEngine` instances from sharing
+    /// the same `write_dir`, which would corrupt WAL files and SSTables
+    /// (Issue #485).
+    dir_lock: std::fs::File,
 }
 
 /// Reject any mutation that contains a counter cell write.
@@ -401,6 +412,24 @@ impl WriteEngine {
                 config.wal_dir, e
             ))
         })?;
+
+        // Acquire an exclusive advisory lock on the WAL directory to prevent
+        // two WriteEngine / Database instances from sharing the same write_dir
+        // and silently corrupting WAL files or SSTables (Issue #485).
+        //
+        // We use `try_lock_exclusive` (non-blocking) so that callers get an
+        // immediate, actionable error rather than hanging forever.
+        let lock_path = config.wal_dir.join(".lock");
+        let dir_lock = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(&lock_path)
+            .map_err(|e| {
+                Error::Storage(format!("Failed to create lock file {:?}: {}", lock_path, e))
+            })?;
+        fs2::FileExt::try_lock_exclusive(&dir_lock)
+            .map_err(|_| Error::write_dir_locked(config.wal_dir.to_string_lossy().into_owned()))?;
 
         // Startup sweep: remove orphaned compaction artifacts left by a previous crash.
         //
@@ -470,6 +499,7 @@ impl WriteEngine {
             active_merge: None,
             merge_policy: None,
             cumulative_stats: CompactionStats::default(),
+            dir_lock,
         })
     }
 
@@ -807,6 +837,14 @@ impl WriteEngine {
         if let Err(e) = self.wal.sync() {
             log::warn!("Failed to sync WAL during close: {}", e);
             // Don't fail close if sync fails - data is already persisted to SSTable
+        }
+
+        // Release the exclusive advisory lock on write_dir so a subsequent
+        // WriteEngine on the same directory can acquire it immediately.
+        // On Drop the OS would release it anyway, but explicit unlock is more
+        // deterministic in async / multi-phase shutdown sequences.
+        if let Err(e) = fs2::FileExt::unlock(&self.dir_lock) {
+            log::warn!("Failed to release write_dir advisory lock: {}", e);
         }
 
         log::info!("WriteEngine closed");
@@ -1655,6 +1693,30 @@ impl WriteEngine {
         entry: merge::MergeEntry,
     ) -> Result<crate::storage::write_engine::mutation::Mutation> {
         merge::KWayMerger::merge_entry_to_mutation(entry, &self.config.schema)
+    }
+}
+
+/// Safety-net `Drop` implementation for `WriteEngine`.
+///
+/// When a `WriteEngine` is dropped without calling `close()` (e.g. due to an
+/// early return or a panic), the OS would release the advisory lock anyway once
+/// the file descriptor is closed.  This explicit `Drop` makes the release
+/// deterministic and logs a warning so callers can distinguish a normal shutdown
+/// from an ungraceful one.
+#[cfg(feature = "write-support")]
+impl Drop for WriteEngine {
+    fn drop(&mut self) {
+        // If close() was already called the lock was already released; a second
+        // unlock is a no-op on most platforms (Linux returns ENOLCK which we
+        // ignore here).  The important invariant is that the lock is always
+        // released before the file descriptor is closed by the OS on drop.
+        if let Err(e) = fs2::FileExt::unlock(&self.dir_lock) {
+            log::debug!(
+                "WriteEngine drop: advisory lock release returned: {} \
+                 (may have been released by close() already)",
+                e
+            );
+        }
     }
 }
 
@@ -3523,6 +3585,127 @@ mod tests {
             engine2.memtable_row_count(),
             5,
             "SyncEachWrite must replay mutations durably on restart"
+        );
+    }
+
+    // ============================================================================
+    // Issue #485: write_dir file lock tests
+    // ============================================================================
+
+    /// A second WriteEngine on the same write_dir must fail fast with a clear error
+    /// while the first engine is still open.
+    #[test]
+    fn test_write_dir_lock_second_engine_fails_fast() {
+        let temp_dir = TempDir::new().unwrap();
+        let schema = create_test_schema();
+
+        let config1 = WriteEngineConfig::new(
+            temp_dir.path().join("data"),
+            temp_dir.path().join("wal"),
+            schema.clone(),
+        );
+
+        // First engine acquires the lock.
+        let _engine1 = WriteEngine::new(config1).unwrap();
+
+        // Second engine on the same wal_dir must fail immediately.
+        let config2 = WriteEngineConfig::new(
+            temp_dir.path().join("data"),
+            temp_dir.path().join("wal"),
+            schema,
+        );
+
+        let result = WriteEngine::new(config2);
+        assert!(
+            result.is_err(),
+            "A second WriteEngine on the same write_dir must fail"
+        );
+
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, Error::WriteDirLocked { .. }),
+            "Expected WriteDirLocked error, got: {:?}",
+            err
+        );
+
+        // Error message must contain the path and actionable advice.
+        let msg = err.to_string();
+        assert!(
+            msg.contains("already locked"),
+            "Error message must mention the lock: {}",
+            msg
+        );
+        assert!(
+            msg.contains("Only one Database instance"),
+            "Error message must explain the constraint: {}",
+            msg
+        );
+    }
+
+    /// After the first engine is closed, a new engine must successfully acquire the lock.
+    #[tokio::test]
+    async fn test_write_dir_lock_reacquired_after_close() {
+        let temp_dir = TempDir::new().unwrap();
+        let schema = create_test_schema();
+
+        let config1 = WriteEngineConfig::new(
+            temp_dir.path().join("data"),
+            temp_dir.path().join("wal"),
+            schema.clone(),
+        );
+
+        // First engine acquires the lock.
+        let mut engine1 = WriteEngine::new(config1).unwrap();
+
+        // Close releases the lock.
+        engine1.close().await.unwrap();
+
+        // A new engine on the same directory must now succeed.
+        let config2 = WriteEngineConfig::new(
+            temp_dir.path().join("data"),
+            temp_dir.path().join("wal"),
+            schema,
+        );
+
+        let engine2 = WriteEngine::new(config2);
+        assert!(
+            engine2.is_ok(),
+            "WriteEngine must acquire lock after the previous engine closed: {:?}",
+            engine2.err()
+        );
+    }
+
+    /// After the first engine is dropped (without calling close()), a new engine
+    /// must also successfully acquire the lock.
+    #[test]
+    fn test_write_dir_lock_reacquired_after_drop() {
+        let temp_dir = TempDir::new().unwrap();
+        let schema = create_test_schema();
+
+        let config1 = WriteEngineConfig::new(
+            temp_dir.path().join("data"),
+            temp_dir.path().join("wal"),
+            schema.clone(),
+        );
+
+        // First engine acquires the lock; drop releases it.
+        {
+            let _engine1 = WriteEngine::new(config1).unwrap();
+            // engine1 dropped here, lock released
+        }
+
+        // A new engine on the same directory must now succeed.
+        let config2 = WriteEngineConfig::new(
+            temp_dir.path().join("data"),
+            temp_dir.path().join("wal"),
+            schema,
+        );
+
+        let engine2 = WriteEngine::new(config2);
+        assert!(
+            engine2.is_ok(),
+            "WriteEngine must acquire lock after the previous engine was dropped: {:?}",
+            engine2.err()
         );
     }
 }


### PR DESCRIPTION
## Summary

- Acquires an exclusive advisory lock (`.lock` file in `wal_dir`) when a `WriteEngine` is created, preventing two `Database` / `WriteEngine` instances from sharing the same `write_dir` and silently corrupting WAL files or SSTables.
- New `Error::WriteDirLocked { path }` variant with a clear, actionable error message surfaced in Rust, Python (`CqliteError`), and Node.js (`CONCURRENCY` code).
- Uses `fs2::FileExt::try_lock_exclusive` (non-blocking fail-fast; cross-platform: flock on Unix, LockFileEx on Windows).
- Lock is released explicitly in `close()` for deterministic handoff, and via `Drop` as a safety net.

## Test plan

- [x] `test_write_dir_lock_second_engine_fails_fast` — second `WriteEngine` on same dir returns `Error::WriteDirLocked` immediately with clear message
- [x] `test_write_dir_lock_reacquired_after_close` — after explicit `close()`, new engine succeeds
- [x] `test_write_dir_lock_reacquired_after_drop` — after drop (ungraceful exit), new engine succeeds
- [x] Agent gate: `RESULT: PASS` (fmt, clippy -D warnings, core-tests, integration-tests, write-tests, cli-tests, minimal-build, smoke — all green)

Closes #485