### PR TITLE
fix(write-stats): wire real l0_count and total_written from WriteEngine

### DIFF
--- a/bindings/python/python/cqlite/__init__.pyi
+++ b/bindings/python/python/cqlite/__init__.pyi
@@ -633,18 +633,19 @@ class WriteStats:
         memtable_size: Current memtable size in bytes.
         memtable_rows: Number of rows currently buffered in the memtable.
         wal_size: Write-ahead log file size in bytes.
-        l0_count: Number of Level-0 (unflushed) SSTables on disk.
-        total_written: Cumulative rows written since the engine was opened.
-
-    Note:
-        ``l0_count`` and ``total_written`` are placeholder fields that will be
-        populated when ``WriteEngine`` exposes runtime stats (planned, see
-        issue #486).  For now they default to ``0`` and may not reflect actual
-        storage state.
+        l0_count: Number of L0 SSTables successfully flushed since the engine
+            was opened.  Incremented once per ``flush_run()`` call that produces
+            a non-empty SSTable.  Resets to zero when the engine is re-opened
+            (in-process counter, issue #486).
+        total_written: Cumulative number of rows written since the engine was
+            opened.  Incremented for every row that enters the memtable and is
+            NOT reset on flush.  Resets to zero when the engine is re-opened
+            (in-process counter, issue #486).
 
     Example:
         >>> stats = db.write_stats
         >>> print(f"Memtable: {stats.memtable_size} bytes, {stats.memtable_rows} rows")
+        >>> print(f"L0 SSTables: {stats.l0_count}, total rows written: {stats.total_written}")
     """
 
     @property

--- a/bindings/python/src/write.rs
+++ b/bindings/python/src/write.rs
@@ -214,8 +214,8 @@ impl PyWriteEngine {
             memtable_size: self.inner.memtable_size(),
             memtable_rows: self.inner.memtable_row_count(),
             wal_size: self.inner.wal_size(),
-            l0_count: 0,
-            total_written: self.inner.memtable_row_count(),
+            l0_count: self.inner.l0_count() as usize,
+            total_written: self.inner.total_written() as usize,
         }
     }
 }

--- a/bindings/python/tests/test_write_api.py
+++ b/bindings/python/tests/test_write_api.py
@@ -410,3 +410,89 @@ def test_close_flushes_memtable(tmp_path, write_schema):
         f"Expected at least one flushed SSTable (*-Data.db) under {wd_data}, "
         f"but found: {list(wd_data.rglob('*'))}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Issue #486 — l0_count and total_written non-placeholder behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_l0_count_increments_after_flush(writable_db):
+    """l0_count increases after flush_run(), proving it is not a hardcoded zero."""
+    stats_before = writable_db.write_stats
+    assert stats_before.l0_count == 0, "l0_count should start at 0"
+
+    writable_db.execute(
+        "INSERT INTO write_test.items (id, name, value) VALUES (600, 'l0_test', 1)"
+    )
+    writable_db.flush_run()
+
+    stats_after = writable_db.write_stats
+    assert stats_after.l0_count == 1, (
+        f"l0_count must be 1 after one flush, got {stats_after.l0_count}"
+    )
+
+    # A second insert + flush must push l0_count to 2
+    writable_db.execute(
+        "INSERT INTO write_test.items (id, name, value) VALUES (601, 'l0_test2', 2)"
+    )
+    writable_db.flush_run()
+
+    stats_final = writable_db.write_stats
+    assert stats_final.l0_count == 2, (
+        f"l0_count must be 2 after two flushes, got {stats_final.l0_count}"
+    )
+
+
+def test_total_written_survives_flush(writable_db):
+    """total_written > memtable_rows after a flush — proves it is not a proxy."""
+    # Write 3 rows
+    for i in range(3):
+        writable_db.execute(
+            f"INSERT INTO write_test.items (id, name, value) VALUES ({700 + i}, 'tw{i}', {i})"
+        )
+
+    stats_before_flush = writable_db.write_stats
+    assert stats_before_flush.total_written >= 3, (
+        f"total_written should be >= 3 before flush, got {stats_before_flush.total_written}"
+    )
+
+    # Flush — memtable_rows drops to 0 but total_written must remain >= 3
+    writable_db.flush_run()
+
+    stats_after_flush = writable_db.write_stats
+    assert stats_after_flush.memtable_rows == 0, "memtable_rows should be 0 after flush"
+    assert stats_after_flush.total_written >= 3, (
+        f"total_written must survive flush, got {stats_after_flush.total_written}"
+    )
+    assert stats_after_flush.total_written > stats_after_flush.memtable_rows, (
+        "total_written must exceed memtable_rows after flush — "
+        f"total_written={stats_after_flush.total_written}, "
+        f"memtable_rows={stats_after_flush.memtable_rows}"
+    )
+
+
+def test_total_written_accumulates_across_flushes(writable_db):
+    """total_written accumulates across multiple flush cycles."""
+    # First batch: 2 rows + flush
+    for i in range(2):
+        writable_db.execute(
+            f"INSERT INTO write_test.items (id, name, value) VALUES ({800 + i}, 'acc{i}', {i})"
+        )
+    writable_db.flush_run()
+    stats_mid = writable_db.write_stats
+    assert stats_mid.total_written >= 2
+
+    # Second batch: 3 more rows + flush
+    for i in range(3):
+        writable_db.execute(
+            f"INSERT INTO write_test.items (id, name, value) VALUES ({810 + i}, 'acc2_{i}', {i})"
+        )
+    writable_db.flush_run()
+    stats_final = writable_db.write_stats
+    assert stats_final.total_written >= 5, (
+        f"total_written must accumulate across flushes, got {stats_final.total_written}"
+    )
+    assert stats_final.l0_count >= 2, (
+        f"l0_count must be >= 2 after two flushes, got {stats_final.l0_count}"
+    )

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -339,6 +339,22 @@ pub struct WriteEngine {
     merge_policy: Option<Box<dyn MergePolicy>>,
     /// Cumulative compaction statistics (M5.2, Issue #474)
     cumulative_stats: CompactionStats,
+    /// Cumulative count of rows written since the engine was opened (Issue #486).
+    ///
+    /// Incremented for each row that enters the memtable via `write()` or
+    /// `write_async()`.  Unlike `memtable.row_count()`, this counter is NOT
+    /// reset when the memtable is flushed, so it reflects the total number of
+    /// rows written across the lifetime of the session.
+    rows_written: u64,
+    /// Number of L0 SSTable files successfully flushed since the engine was
+    /// opened (Issue #486).
+    ///
+    /// Incremented once per successful `flush_internal_async()` call that
+    /// produces a non-empty SSTable.  This is an in-process counter; it is
+    /// reset to zero when the engine is re-opened (a directory scan could
+    /// also be used for persistence, but the counter is more robust and avoids
+    /// scanning the filesystem on every stats query).
+    l0_count: u64,
     /// Advisory exclusive lock on `write_dir` (`.lock` file).
     ///
     /// Held for the lifetime of the `WriteEngine`; released on `close()` or
@@ -499,6 +515,8 @@ impl WriteEngine {
             active_merge: None,
             merge_policy: None,
             cumulative_stats: CompactionStats::default(),
+            rows_written: 0,
+            l0_count: 0,
             dir_lock,
         })
     }
@@ -557,7 +575,11 @@ impl WriteEngine {
         // 3. Insert into memtable
         self.memtable.insert_with_key(decorated_key, mutation)?;
 
-        // 4. Check if memtable should be flushed (only in non-async context)
+        // 4. Increment the cumulative rows-written counter (Issue #486).
+        //    Done after a successful insert so that failed writes are not counted.
+        self.rows_written += 1;
+
+        // 5. Check if memtable should be flushed (only in non-async context)
         if self
             .memtable
             .should_flush(self.config.memtable_flush_threshold)
@@ -628,7 +650,11 @@ impl WriteEngine {
         // 3. Insert into memtable
         self.memtable.insert_with_key(decorated_key, mutation)?;
 
-        // 4. Check if memtable should be flushed
+        // 4. Increment the cumulative rows-written counter (Issue #486).
+        //    Done after a successful insert so that failed writes are not counted.
+        self.rows_written += 1;
+
+        // 5. Check if memtable should be flushed
         if self
             .memtable
             .should_flush(self.config.memtable_flush_threshold)
@@ -802,6 +828,9 @@ impl WriteEngine {
         // Clear memtable
         self.memtable.clear();
 
+        // Increment the L0 SSTable counter (Issue #486).
+        self.l0_count += 1;
+
         // Increment generation for next flush
         self.generation += 1;
 
@@ -889,6 +918,31 @@ impl WriteEngine {
     /// Get the current generation number
     pub fn generation(&self) -> u64 {
         self.generation
+    }
+
+    /// Return the cumulative number of rows written since the engine was opened
+    /// (Issue #486).
+    ///
+    /// This counter is incremented for every row that is successfully inserted
+    /// into the memtable and is NOT reset on flush.  It therefore represents
+    /// the total write throughput for the current session.
+    ///
+    /// Note: This counter is in-process only and resets to zero when the engine
+    /// is re-opened.  WAL replay rows (recovered from a previous crash) are NOT
+    /// counted; only rows written through `write()` / `write_async()` during
+    /// the current session are counted.
+    pub fn total_written(&self) -> u64 {
+        self.rows_written
+    }
+
+    /// Return the number of L0 SSTables successfully flushed since the engine
+    /// was opened (Issue #486).
+    ///
+    /// Incremented once per successful `flush()` call that produces a non-empty
+    /// SSTable.  This is an in-process counter and resets to zero when the
+    /// engine is re-opened.
+    pub fn l0_count(&self) -> u64 {
+        self.l0_count
     }
 
     /// Parse a CQL statement to a Mutation
@@ -3787,6 +3841,157 @@ mod tests {
             engine2.is_ok(),
             "WriteEngine must acquire lock after the previous engine was dropped: {:?}",
             engine2.err()
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Issue #486 — total_written and l0_count non-placeholder behaviour
+    // -----------------------------------------------------------------------
+
+    /// After writing N rows and flushing, `total_written()` == N even though
+    /// `memtable_row_count()` has been reset to 0.
+    #[tokio::test]
+    async fn test_total_written_survives_flush() {
+        let temp_dir = TempDir::new().unwrap();
+        let schema = create_test_schema();
+        let config = WriteEngineConfig::new(
+            temp_dir.path().join("data"),
+            temp_dir.path().join("wal"),
+            schema,
+        );
+        let mut engine = WriteEngine::new(config).unwrap();
+
+        // Write 5 rows to the first "batch"
+        for i in 0..5 {
+            engine
+                .write(create_test_mutation(
+                    i,
+                    &format!("User{i}"),
+                    1_000_000 + i as i64,
+                ))
+                .unwrap();
+        }
+        assert_eq!(engine.total_written(), 5);
+        assert_eq!(engine.memtable_row_count(), 5);
+
+        // Flush — memtable resets but total_written must NOT
+        engine.flush().await.unwrap();
+        assert_eq!(
+            engine.memtable_row_count(),
+            0,
+            "memtable should be empty after flush"
+        );
+        assert_eq!(
+            engine.total_written(),
+            5,
+            "total_written must NOT reset after flush"
+        );
+
+        // Write 3 more rows in a second batch
+        for i in 10..13 {
+            engine
+                .write(create_test_mutation(
+                    i,
+                    &format!("User{i}"),
+                    2_000_000 + i as i64,
+                ))
+                .unwrap();
+        }
+        assert_eq!(
+            engine.total_written(),
+            8,
+            "total_written must accumulate across flushes"
+        );
+        assert_eq!(engine.memtable_row_count(), 3);
+
+        // Flush again
+        engine.flush().await.unwrap();
+        assert_eq!(engine.memtable_row_count(), 0);
+        assert_eq!(
+            engine.total_written(),
+            8,
+            "total_written must still be 8 after second flush"
+        );
+    }
+
+    /// `l0_count()` reflects the number of successful flush operations (not zero).
+    #[tokio::test]
+    async fn test_l0_count_increments_on_flush() {
+        let temp_dir = TempDir::new().unwrap();
+        let schema = create_test_schema();
+        let config = WriteEngineConfig::new(
+            temp_dir.path().join("data"),
+            temp_dir.path().join("wal"),
+            schema,
+        );
+        let mut engine = WriteEngine::new(config).unwrap();
+
+        assert_eq!(engine.l0_count(), 0, "l0_count should start at 0");
+
+        // Flushing an empty memtable produces no SSTable — count stays 0
+        engine.flush().await.unwrap();
+        assert_eq!(
+            engine.l0_count(),
+            0,
+            "empty flush must not increment l0_count"
+        );
+
+        // Write one row and flush — count must become 1
+        engine
+            .write(create_test_mutation(1, "Alice", 1_000_000))
+            .unwrap();
+        engine.flush().await.unwrap();
+        assert_eq!(
+            engine.l0_count(),
+            1,
+            "l0_count must be 1 after first non-empty flush"
+        );
+
+        // Write and flush again — count must become 2
+        engine
+            .write(create_test_mutation(2, "Bob", 2_000_000))
+            .unwrap();
+        engine.flush().await.unwrap();
+        assert_eq!(
+            engine.l0_count(),
+            2,
+            "l0_count must be 2 after second non-empty flush"
+        );
+    }
+
+    /// Verify that `total_written` != `memtable_row_count` after a flush —
+    /// the scenario that proves the placeholder is replaced.
+    #[tokio::test]
+    async fn test_total_written_differs_from_memtable_after_flush() {
+        let temp_dir = TempDir::new().unwrap();
+        let schema = create_test_schema();
+        let config = WriteEngineConfig::new(
+            temp_dir.path().join("data"),
+            temp_dir.path().join("wal"),
+            schema,
+        );
+        let mut engine = WriteEngine::new(config).unwrap();
+
+        // Write 7 rows and flush
+        for i in 0..7 {
+            engine
+                .write(create_test_mutation(
+                    i,
+                    &format!("User{i}"),
+                    1_000_000 + i as i64,
+                ))
+                .unwrap();
+        }
+        engine.flush().await.unwrap();
+
+        // Post-flush: memtable_row_count is 0 but total_written is 7
+        assert_eq!(engine.memtable_row_count(), 0);
+        assert_eq!(engine.total_written(), 7);
+        assert_ne!(
+            engine.total_written() as usize,
+            engine.memtable_row_count(),
+            "total_written must differ from memtable_row_count after flush — \
+             proves neither is a placeholder"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Adds `rows_written: u64` field to `WriteEngine` (in `cqlite-core/src/storage/write_engine/mod.rs`) incremented in `write()` and `write_async()` after each successful memtable insert; survives flushes (cumulative session total)
- Adds `l0_count: u64` field incremented in `flush_internal_async()` after each successful non-empty SSTable flush
- Exposes `total_written()` and `l0_count()` public methods on `WriteEngine`
- Wires real values in `bindings/python/src/write.rs` (replaces `l0_count: 0` and `total_written: memtable_row_count()`)
- Updates Python type stub doc-comments in `__init__.pyi` to remove "placeholder" language
- Both counters are in-process only (reset to zero on engine re-open); WAL replay rows are not counted

## Test plan

- [ ] 3 new Rust unit tests in `cqlite-core/src/storage/write_engine/mod.rs`:
  - `test_total_written_survives_flush` — total_written == N after flush (memtable_row_count == 0)
  - `test_l0_count_increments_on_flush` — l0_count goes 0 → 1 → 2 across flushes; empty flush does not increment
  - `test_total_written_differs_from_memtable_after_flush` — total_written != memtable_row_count after flush
- [ ] 3 new Python tests in `bindings/python/tests/test_write_api.py`:
  - `test_l0_count_increments_after_flush`
  - `test_total_written_survives_flush`
  - `test_total_written_accumulates_across_flushes`
- [ ] Node.js bindings: already tracking `l0_count` and `total_written` at the binding level (per flush callback) — no changes needed
- [ ] `scripts/agent-gate.sh` — RESULT: PASS

Closes #486