### PR TITLE
test(write): counter rejection via CQL-text execute() path (#503)

### DIFF
--- a/cqlite-core/tests/write_read_roundtrip/type_coverage.rs
+++ b/cqlite-core/tests/write_read_roundtrip/type_coverage.rs
@@ -736,6 +736,107 @@ fn test_counter_write_sync_returns_typed_error() {
     );
 }
 
+/// Counter rejection via the CQL-text `execute()` entry point (Issue #503).
+///
+/// The Mutation API guard (`reject_counter_cells`) is exercised by
+/// `test_counter_write_returns_typed_error` / `test_counter_write_sync_returns_typed_error`.
+/// This test validates that the **CQL-text path** — `WriteEngine::execute()` →
+/// `convert_cql_to_mutation()` → `update_to_mutation()` → `write()` — also triggers
+/// the same guard, so callers using the string-based execute() interface (e.g. the
+/// CLI's `--mutation` flag) cannot bypass the counter protection.
+///
+/// Route: `execute(cql_str)` → `parse_cql_to_mutation()` → `convert_cql_to_mutation()`
+/// → `update_to_mutation()` (AddAssign path: value `1` is coerced to `Value::Counter(1)`
+/// via `literal_to_value` + `integer_to_value`) → `write()` → `reject_counter_cells()`
+/// → `Error::InvalidOperation`.
+#[test]
+fn test_execute_counter_cql_returns_error() {
+    use cqlite_core::storage::write_engine::{WriteEngine, WriteEngineConfig};
+
+    let temp_dir = TempDir::new().unwrap();
+    let schema = create_type_test_schema("counter_col", "counter");
+
+    let config = WriteEngineConfig::new(
+        temp_dir.path().join("data"),
+        temp_dir.path().join("wal"),
+        schema.clone(),
+    );
+    let mut engine = WriteEngine::new(config).expect("Engine creation should succeed");
+
+    // CQL counter increment via the string execute() path.
+    // The parser recognises `+=` as CqlAssignmentOperator::AddAssign; the integer
+    // literal `1` on the RHS is coerced to Value::Counter(1) using the schema column
+    // type, which then trips the counter guard inside write().
+    let cql = format!(
+        "UPDATE {}.{} SET counter_col += 1 WHERE pk = 1",
+        schema.keyspace, schema.table
+    );
+    let result = engine.execute(&cql);
+
+    assert!(
+        result.is_err(),
+        "Counter write via CQL execute() must return an error, but it succeeded"
+    );
+    let err = result.unwrap_err();
+    assert!(
+        matches!(err, cqlite_core::error::Error::InvalidOperation(_)),
+        "Counter write via CQL execute() must return Error::InvalidOperation, got: {:?}",
+        err
+    );
+    assert!(
+        err.to_string().contains("counter"),
+        "Error message should mention 'counter', got: {}",
+        err
+    );
+}
+
+/// Counter rejection via the CQL INSERT execute() path (Issue #503).
+///
+/// Validates that inserting a counter value via CQL-text `execute()` using an
+/// INSERT statement also reaches `reject_counter_cells()` and returns
+/// `Error::InvalidOperation`.  The INSERT path flows through
+/// `insert_to_mutation()` → `literal_to_value()` → `integer_to_value()` →
+/// `Value::Counter(...)` → `write()` → `reject_counter_cells()`.
+#[test]
+fn test_execute_counter_insert_cql_returns_error() {
+    use cqlite_core::storage::write_engine::{WriteEngine, WriteEngineConfig};
+
+    let temp_dir = TempDir::new().unwrap();
+    let schema = create_type_test_schema("counter_col", "counter");
+
+    let config = WriteEngineConfig::new(
+        temp_dir.path().join("data"),
+        temp_dir.path().join("wal"),
+        schema.clone(),
+    );
+    let mut engine = WriteEngine::new(config).expect("Engine creation should succeed");
+
+    // CQL INSERT that supplies a raw counter value via the string execute() path.
+    // `literal_to_value` coerces the integer literal to Value::Counter(42) based on
+    // the column's counter type, which then trips the counter guard inside write().
+    let cql = format!(
+        "INSERT INTO {}.{} (pk, counter_col) VALUES (1, 42)",
+        schema.keyspace, schema.table
+    );
+    let result = engine.execute(&cql);
+
+    assert!(
+        result.is_err(),
+        "Counter INSERT via CQL execute() must return an error, but it succeeded"
+    );
+    let err = result.unwrap_err();
+    assert!(
+        matches!(err, cqlite_core::error::Error::InvalidOperation(_)),
+        "Counter INSERT via CQL execute() must return Error::InvalidOperation, got: {:?}",
+        err
+    );
+    assert!(
+        err.to_string().contains("counter"),
+        "Error message should mention 'counter', got: {}",
+        err
+    );
+}
+
 /// Test Inet type with IPv4 address
 #[tokio::test]
 async fn test_type_inet_ipv4() {


### PR DESCRIPTION
## Summary

- Adds `test_execute_counter_cql_returns_error` (UPDATE path via `+=`) to `type_coverage.rs`
- Adds `test_execute_counter_insert_cql_returns_error` (INSERT path) to `type_coverage.rs`
- Both tests live adjacent to the existing counter guard tests at ~line 657 in the same file

## Route traced

**UPDATE (`+=`) path:**
`execute(cql)` → `parse_cql_to_mutation()` → `convert_cql_to_mutation()` → `update_to_mutation()` (AddAssign: literal `1` coerced to `Value::Counter(1)` via `integer_to_value(1, CqlType::Counter)`) → `write()` → `reject_counter_cells()` → `Error::InvalidOperation`

**INSERT path:**
`execute(cql)` → `insert_to_mutation()` → `expression_to_value()` → `literal_to_value()` → `integer_to_value(42, CqlType::Counter)` → `Value::Counter(42)` → `write()` → `reject_counter_cells()` → `Error::InvalidOperation`

## Error variant confirmed

Both CQL-text paths return **`Error::InvalidOperation`** — the same variant as the Mutation API tests. The `reject_counter_cells()` guard is the rejection point in all cases. The guard message contains "counter".

## Gate output

```
==== AGENT-GATE SUMMARY ====
commit: 710ab902 branch: test/503-counter-cql-execute-rejection dirty: yes
datasets: 68 Data.db files under /Users/patrickmcfadin/local_projects/cqlite/test-data/datasets
ci-pins: DATASET_TAG: datasets-v3 DATASET_ASSET: cassandra5-small-full-v3.1.tar.gz DATASET_SHA256: f5fa0b6599a27c1c493d7c6c063194d55d031cab417396947313e7245afc5ceb 
fmt:               PASS (2s)
clippy:            PASS (35s)
core-tests:        PASS (180s)
integration-tests: PASS (15s)
write-tests:       PASS (15s)
cli-tests:         PASS (13s)
minimal-build:     PASS (1s)
smoke:             PASS (12s)
logs: /var/folders/2c/tfxwt1g91x729x38m63d81540000gn/T//agent-gate.2qHsWv
RESULT: PASS
==== END AGENT-GATE SUMMARY ====
```

## Focused test output

```
Running tests/write_read_roundtrip.rs (target/debug/deps/write_read_roundtrip-8faad774abe6b79e)

running 2 tests
test type_coverage::test_execute_counter_insert_cql_returns_error ... ok
test type_coverage::test_execute_counter_cql_returns_error ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 125 filtered out; finished in 0.02s
```

Closes #503