### PR TITLE
fix(test-data): UDT-table insertion in regenerate-datasets.sh (#726)

### DIFF
--- a/.claude/skills/test-data-management/dataset-generation.md
+++ b/.claude/skills/test-data-management/dataset-generation.md
@@ -147,13 +147,6 @@ bash test-data/scripts/fetch-datasets.sh
 
 See `.github/workflows/` for the full CI configuration.
 
-## Known limitations
-
-`regenerate-datasets.sh` **skips tables with UDT columns** (e.g.
-`collections_with_udts` in `test_collections`) because the inline Python
-inserter cannot construct UDT values; smoke tests on a freshly regenerated
-corpus will show those tables as missing.
-
 ## Adding new schema types
 
 1. Create `test-data/schemas/my-schema.cql`

--- a/test-data/README.md
+++ b/test-data/README.md
@@ -162,25 +162,6 @@ CI fetches binary SSTables from the `datasets-v3` GitHub Release asset:
 
 See `.github/workflows/` for the full CI configuration.
 
-## Known limitations
-
-### Tables skipped during regeneration
-
-`regenerate-datasets.sh` skips tables that contain **User-Defined Type (UDT)
-columns** because the inline Python inserter cannot yet construct UDT values via
-the Cassandra driver. The main affected table is `collections_with_udts` in the
-`test_collections` keyspace.
-
-As a result, a freshly regenerated corpus will be **missing JSONL golden files
-for UDT-heavy tables**, and `smoke-test-all-tables.sh` will report those tables
-as absent. The datasets-v3 goldens committed to git were produced with a manual
-cqlsh workflow that does include UDT data; regeneration alone does not reproduce
-them.
-
-If you need UDT table coverage, either run the manual compose-stack workflow
-(`start-clean.sh` + `export.sh`) or populate UDT tables manually via `cqlsh`
-before the export step.
-
 ## Troubleshooting
 
 **Port 9042 already in use:**

--- a/test-data/scripts/regenerate-datasets.sh
+++ b/test-data/scripts/regenerate-datasets.sh
@@ -212,8 +212,48 @@ try:
                 return any(has_udt_type(a) for a in inner_args) if inner_args else False
         return True  # Unrecognized type = UDT
 
-    def sample_val(ctype):
-        """Generate a value for any CQL type, including nested collections."""
+    def get_udt_fields(keyspace_name, type_name):
+        """Return a dict of {field_name: field_type} for a UDT in the given keyspace."""
+        rs = session.execute(
+            "SELECT field_names, field_types FROM system_schema.types "
+            "WHERE keyspace_name=%s AND type_name=%s;",
+            (keyspace_name, type_name)
+        )
+        row = rs.one()
+        if row is None:
+            return {}
+        return dict(zip(row.field_names, row.field_types))
+
+    # Discover and register all UDTs in this keyspace so the driver can
+    # serialize UDT values as dicts (the same approach used for test_oa.udt_table).
+    udt_fields_cache = {}
+    try:
+        udts_rs = session.execute(
+            "SELECT type_name, field_names, field_types FROM system_schema.types "
+            "WHERE keyspace_name=%s;",
+            ('$keyspace',)
+        )
+        for udt_row in udts_rs:
+            udt_fields_cache[udt_row.type_name] = dict(
+                zip(udt_row.field_names, udt_row.field_types)
+            )
+            cluster.register_user_type('$keyspace', udt_row.type_name, dict)
+            print(f"  [udt] Registered UDT: $keyspace.{udt_row.type_name}", flush=True)
+    except Exception as udt_exc:
+        print(f"  [udt] Could not discover/register UDTs: {udt_exc}", flush=True)
+
+    def build_udt_value(type_name, depth=0):
+        """Construct a plain dict for a UDT, recursing for nested UDTs."""
+        if depth > 5:
+            return {}
+        fields = udt_fields_cache.get(type_name.lower(), {})
+        result = {}
+        for fname, ftype in fields.items():
+            result[fname] = sample_val(ftype, depth=depth + 1)
+        return result
+
+    def sample_val(ctype, depth=0):
+        """Generate a value for any CQL type, including nested collections and UDTs."""
         ct = ctype.strip().lower()
         # Strip frozen<> wrapper — value generation is the same for frozen and non-frozen
         bare = ct[7:-1].strip() if ct.startswith('frozen<') else ct
@@ -221,26 +261,27 @@ try:
         if bare.startswith('list<'):
             args = parse_type_args(bare)
             elem_type = args[0] if args else 'text'
-            return [sample_val(elem_type) for _ in range(3)]
+            return [sample_val(elem_type, depth=depth) for _ in range(3)]
         if bare.startswith('set<'):
             args = parse_type_args(bare)
             elem_type = args[0] if args else 'text'
-            elems = [sample_val(elem_type) for _ in range(3)]
+            elems = [sample_val(elem_type, depth=depth) for _ in range(3)]
+            # UDT dicts are not hashable; fall back to a list when set() fails
             try:
                 return set(elems)
             except TypeError:
-                return set(str(e) for e in elems)
+                return elems  # driver accepts a list for SET<FROZEN<udt>>
         if bare.startswith('map<'):
             args = parse_type_args(bare)
             k_type = args[0] if len(args) > 0 else 'text'
             v_type = args[1] if len(args) > 1 else 'text'
             result = {}
             for i in range(3):
-                k = sample_val(k_type)
+                k = sample_val(k_type, depth=depth)
                 try:
-                    result[k] = sample_val(v_type)
+                    result[k] = sample_val(v_type, depth=depth)
                 except TypeError:
-                    result[f"k{i}"] = sample_val(v_type)
+                    result[f"k{i}"] = sample_val(v_type, depth=depth)
             return result
         # Scalar primitives
         if bare == 'timeuuid':
@@ -272,6 +313,9 @@ try:
         if bare == 'duration':
             return Duration(months=random.randint(0, 12), days=random.randint(0, 30),
                             nanoseconds=random.randint(0, 10**9))
+        # UDT: if the bare type name is a known UDT in this keyspace, build a dict
+        if bare in udt_fields_cache:
+            return build_udt_value(bare, depth=depth)
         # text, varchar, ascii, and anything unrecognized
         return f"val_{random.randint(1,10000)}"
 
@@ -293,11 +337,12 @@ try:
             print(f"  [skip] {tbl}: no partition key found", flush=True)
             continue
 
-        # Skip tables with UDT columns (require table-specific insertion code)
+        # Detect tables that have UDT columns; they are now handled by the
+        # generic path via build_udt_value() + registered dict UDTs above.
         all_types_list = [t for _, (_, t) in cols.items()]
-        if any(has_udt_type(t) for t in all_types_list):
-            print(f"  [skip] {tbl}: UDT columns require table-specific insertion code", flush=True)
-            continue
+        has_udt = any(has_udt_type(t) for t in all_types_list)
+        if has_udt:
+            print(f"  [udt-table] {tbl}: UDT columns detected — using registered dict path", flush=True)
 
         # Counter tables require UPDATE, not INSERT. Detect by checking if all
         # regular columns are of type 'counter'.


### PR DESCRIPTION
## Summary

- **Add UDT-aware row insertion** to `insert_nb_rows()` in `regenerate-datasets.sh` so tables containing User-Defined Type columns (e.g. `collections_with_udts` in `test_collections`) are no longer skipped during corpus regeneration.
- **Discover and register UDTs** at insert time via `system_schema.types`, then call `cluster.register_user_type(keyspace, type_name, dict)` for each — the same pattern already used for `test_oa.udt_table` in `insert_oa_rows()`.
- **Build nested UDT values recursively**: `build_udt_value()` constructs plain Python `dict`s, recursing for nested UDTs (e.g. `contact_info.address` is itself an `address_type` dict). `sample_val()` gains a UDT branch that delegates to `build_udt_value()` when it recognizes a bare type name as a registered UDT.
- **Fix `SET<FROZEN<udt>>`**: Python `dict`s are not hashable so `set()` raises `TypeError`; the fallback now returns the list directly (the Cassandra driver accepts a list for frozen-element sets).
- **Remove the `[skip]` early-exit** for UDT tables; replaced with an informational `[udt-table]` log line.
- **Remove "Known limitations" caveat** from `test-data/README.md` and `.claude/skills/test-data-management/dataset-generation.md`.

### Schema handled

`test_collections.collections_with_udts` — the main previously-skipped table:
```sql
CREATE TYPE address_type (street TEXT, city TEXT, state TEXT, zip_code TEXT, country TEXT);
CREATE TYPE contact_info (email TEXT, phone TEXT, address FROZEN<address_type>);
CREATE TABLE collections_with_udts (
    user_id UUID PRIMARY KEY,
    addresses LIST<FROZEN<address_type>>,
    contacts SET<FROZEN<contact_info>>,
    locations_visited MAP<DATE, FROZEN<address_type>>,
    emergency_contacts MAP<TEXT, FROZEN<contact_info>>
);
```

## What was validated vs what requires Docker

### Validated locally (no Cassandra needed)

1. **Shell syntax**: `bash -n test-data/scripts/regenerate-datasets.sh` — PASS
2. **shellcheck**: no warnings introduced
3. **UDT value-construction logic** unit-checked in isolation with `python3 -c "..."`:
   - `has_udt_type()` correctly detects all five column types as containing UDTs
   - `build_udt_value('address_type')` produces a 5-field dict
   - `build_udt_value('contact_info')` produces a 3-field dict with a nested `address_type` dict
   - `LIST<FROZEN<address_type>>` produces a `list` of 3 address dicts
   - `SET<FROZEN<contact_info>>` falls back to a list (dict not hashable) — all assertions passed
   - `MAP<DATE, FROZEN<address_type>>` and `MAP<TEXT, FROZEN<contact_info>>` both produce 3-entry dicts
4. **agent-gate.sh** — all 8 checks passed (fmt, clippy, core-tests, integration-tests, write-tests, cli-tests, minimal-build, smoke)

### NOT run locally — requires Docker Cassandra

Full end-to-end regeneration (`bash test-data/scripts/regenerate-datasets.sh`) was NOT run locally because it requires a running Cassandra 5.0.2 container. The UDT value-construction logic was unit-checked in isolation. End-to-end regen should be validated manually or via a Docker-enabled CI run before the regenerated corpus is published as a new datasets release.

## Test plan

- [ ] Run `bash test-data/scripts/regenerate-datasets.sh` against a Cassandra 5.0.2 container and confirm `collections_with_udts` is no longer printed as `[skip]` and instead shows `N rows inserted`
- [ ] Confirm `smoke-test-all-tables.sh` reports `collections_with_udts` as PASS after regen
- [ ] Confirm no regression in other `test_collections` tables

Closes #726