### PR TITLE
fix(e2e): preserve workdir (spec/JSONL) for failure artifacts (#725)

### DIFF
--- a/.github/workflows/e2e-readback.yml
+++ b/.github/workflows/e2e-readback.yml
@@ -75,14 +75,21 @@ jobs:
 
       # The script manages the compose stack itself (start-clean.sh + trap cleanup).
       # We pass --no-build so it uses the binary we just compiled, and --bin to
-      # point at the exact path.  On failure we preserve workdir artifacts via
-      # the upload step below.
+      # point at the exact path.
+      #
+      # E2E_ARTIFACT_DIR is set to /tmp/e2e-artifacts so the script's EXIT trap
+      # copies the per-table mutation JSONL and spec.txt files into that stable
+      # location before deleting the random /tmp/cqlite-e2e-readback.* workdir.
+      # The "Collect failure artifacts" step below then picks them up.  (Issue #725)
       - name: Run e2e Cassandra readback
         id: readback
         shell: bash
         env:
           # Force docker compose (available on ubuntu-latest GitHub runners)
           COMPOSE_CMD: "docker compose"
+          # Stable artifact destination — populated by the script's EXIT trap on
+          # failure so the per-table JSONL/spec files survive artifact collection.
+          E2E_ARTIFACT_DIR: /tmp/e2e-artifacts
         run: |
           EXTRA_ARGS=""
           if [[ -n "${{ github.event.inputs.tables }}" ]]; then
@@ -100,11 +107,12 @@ jobs:
           # tee swallows the exit code; use PIPESTATUS to propagate it
           exit "${PIPESTATUS[0]}"
 
-      # Collect logs and Cassandra container logs as artifacts on failure.
-      # Note: the script's EXIT trap calls rm -rf on its workdir ($WORKDIR under
-      # /tmp/cqlite-e2e-readback.*) so per-table mutation/spec files are gone by
-      # the time this step runs.  The full script stdout+stderr is captured in
-      # /tmp/e2e-readback.log (from the tee above) and is always present.
+      # Collect logs and workdir contents as artifacts on failure.
+      # On a failing exit the script's EXIT trap copies the per-table mutation
+      # JSONL and spec.txt files from $WORKDIR into /tmp/e2e-artifacts/workdir/
+      # (via E2E_ARTIFACT_DIR) before deleting the random workdir path, so
+      # those files are available here.  The full script stdout+stderr is also
+      # in /tmp/e2e-readback.log (captured by tee above).  (Issue #725)
       - name: Collect failure artifacts
         if: failure()
         run: |
@@ -115,8 +123,12 @@ jobs:
             cp /tmp/e2e-readback.log /tmp/e2e-artifacts/
           fi
 
+          # Per-table mutation JSONL and spec.txt files are in
+          # /tmp/e2e-artifacts/workdir/ (copied there by the script's EXIT trap
+          # via E2E_ARTIFACT_DIR before the random workdir was deleted).
           # If the script was abruptly killed (SIGTERM from timeout) the workdir
-          # cleanup trap may not have run yet; capture any remaining files.
+          # cleanup trap may not have run; capture any remaining random-path dirs
+          # as a fallback.
           for d in /tmp/cqlite-e2e-readback.*; do
             [[ -d "$d" ]] && cp -r "$d" /tmp/e2e-artifacts/ || true
           done

--- a/test-data/scripts/e2e-cassandra-readback.sh
+++ b/test-data/scripts/e2e-cassandra-readback.sh
@@ -60,6 +60,14 @@ SUBSET=""
 CQLITE_BIN_OVERRIDE=""
 SELF_TEST=0
 
+# E2E_ARTIFACT_DIR: when set (non-empty), the cleanup() EXIT trap copies the
+# workdir into this stable location on a FAILING exit before deleting it.
+# This lets CI artifact-collection steps find the per-table mutation JSONL
+# and spec.txt files even though the random /tmp/cqlite-e2e-readback.* path
+# is gone.  On a SUCCESS exit the workdir is still deleted without copying.
+# (Issue #725)
+E2E_ARTIFACT_DIR="${E2E_ARTIFACT_DIR:-}"
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --keep-running) KEEP_RUNNING=1; shift ;;
@@ -340,6 +348,17 @@ declare -a FAILED_LIST=()
 cleanup() {
   local rc=$?
   if [[ "$KEEP_RUNNING" -eq 0 ]]; then
+    # On a failing exit, copy the workdir into E2E_ARTIFACT_DIR (if set) so
+    # per-table mutation JSONL and spec.txt files survive for CI artifact
+    # collection.  The copy happens here, inside the EXIT trap, before the
+    # rm -rf — which means the stable location is populated before the
+    # workflow's "Collect failure artifacts" step runs.  (Issue #725)
+    if [[ "$rc" -ne 0 && -n "$E2E_ARTIFACT_DIR" && -d "$WORKDIR" ]]; then
+      log "Copying workdir to $E2E_ARTIFACT_DIR/workdir for failure artifact collection"
+      mkdir -p "$E2E_ARTIFACT_DIR/workdir"
+      cp -r "$WORKDIR/." "$E2E_ARTIFACT_DIR/workdir/" || true
+      log "Workdir contents preserved at $E2E_ARTIFACT_DIR/workdir"
+    fi
     log "Tearing down Cassandra stack"
     bash "$SCRIPTS/shutdown-clean.sh" >/dev/null 2>&1 || true
     rm -rf "$WORKDIR" || true


### PR DESCRIPTION
## Problem

The script's EXIT trap called `rm -rf $WORKDIR` (a random `/tmp/cqlite-e2e-readback.*` path) before the workflow's **Collect failure artifacts** / **Upload failure artifacts** steps ran. On a Cassandra-side verification failure the per-table mutation JSONL and `spec.txt` files were already deleted by the time CI collected artifacts. The workflow itself had a comment on lines 104-107 acknowledging this gap: _"per-table mutation/spec files are gone by the time this step runs."_

## Approach: copy-on-failure inside the EXIT trap

Added `E2E_ARTIFACT_DIR` env var support to `cleanup()`. When `E2E_ARTIFACT_DIR` is set (non-empty) and the exit code is non-zero, the trap copies `$WORKDIR` into `$E2E_ARTIFACT_DIR/workdir/` **before** the `rm -rf`. The copy fires inside the EXIT trap — which runs inside the script before any workflow step fires — so the stable location is populated in time for the "Collect failure artifacts" step.

- **Failure path**: workdir copied to `$E2E_ARTIFACT_DIR/workdir/`, then deleted
- **Success path**: workdir deleted without copying (no /tmp bloat)
- **`--keep-running` path**: unchanged (entire stack and workdir left intact)
- **`E2E_ARTIFACT_DIR` unset**: cleanup behaves exactly as before

The workflow sets `E2E_ARTIFACT_DIR=/tmp/e2e-artifacts` (the same dir the "Collect failure artifacts" step creates and uploads), so per-table JSONL/spec files are now included in the uploaded failure artifact. The stale comment is updated to reflect the new behaviour. The SIGTERM fallback glob is kept.

## Local simulation output

```
=== Issue #725 cleanup() preserve-on-failure simulation ===

--- Test 1: FAILURE exit (rc=1), E2E_ARTIFACT_DIR set ---
[cleanup] Copying workdir to /tmp/.../workdir for failure artifact collection
[cleanup] Workdir contents preserved at /tmp/.../workdir
[cleanup] Tearing down Cassandra stack (simulated: no-op)
  OK: workdir deleted
  OK: mutations.jsonl and spec.txt found in /tmp/.../workdir/

--- Test 2: SUCCESS exit (rc=0), E2E_ARTIFACT_DIR set ---
[cleanup] Tearing down Cassandra stack (simulated: no-op)
  OK: workdir deleted
  OK: artifact dir not populated on success (correct — no bloat)

--- Test 3: FAILURE exit (rc=1), E2E_ARTIFACT_DIR empty (not set) ---
[cleanup] Tearing down Cassandra stack (simulated: no-op)
  OK: workdir deleted even when E2E_ARTIFACT_DIR is unset

--- Test 4: FAILURE with nested workdir structure (per-table subdirs) ---
[cleanup] Copying workdir to /tmp/.../workdir for failure artifact collection
[cleanup] Workdir contents preserved at /tmp/.../workdir
[cleanup] Tearing down Cassandra stack (simulated: no-op)
  OK: workdir deleted
  OK: nested per-table files preserved correctly

=== Results: 4 passed, 0 failed ===
ALL TESTS PASSED
```

## `--self-test` exit 0 confirmation

```
[e2e-readback] Self-test: all 9 cases passed using production verifier (e2e_verify.py)
Exit code: 0
```

## Gate output

```
==== AGENT-GATE SUMMARY ====
commit: 1d7105c3 branch: fix/725-e2e-keep-workdir-artifacts dirty: yes
fmt:               PASS (2s)
clippy:            PASS (2s)
core-tests:        PASS (127s)
integration-tests: PASS (3s)
write-tests:       PASS (16s)
cli-tests:         PASS (1s)
minimal-build:     PASS (1s)
smoke:             PASS (4s)
RESULT: PASS
==== END AGENT-GATE SUMMARY ====
```

## Docker CI note

The full failure-artifact upload (verifying that `spec.txt`/JSONL appear in the uploaded artifact when a Cassandra readback fails) only exercises in a real Docker CI run. The local cleanup simulation and gate cover the logic.

Closes #725