### PR TITLE
ci: document dual-path Cassandra validation decision + add concurrency guard (#728)

### DIFF
--- a/.github/workflows/cassandra-validation.yml
+++ b/.github/workflows/cassandra-validation.yml
@@ -1,5 +1,14 @@
 name: "CI: Cassandra sstableloader Validation"
 
+# DUAL-WORKFLOW DECISION (issue #728):
+# This workflow and e2e-readback.yml are BOTH intentionally kept.
+# They cover two distinct production ingest paths:
+#   - cassandra-validation.yml (this file): validates the `sstableloader` ingest path
+#   - e2e-readback.yml:                     validates the `nodetool refresh` ingest path
+# On writer-path PRs, both workflows run (~30 min each). This overlap is accepted
+# deliberately — merging them would obscure ingest-path-specific regressions.
+# See issue #728 for the full decision record.
+
 on:
   pull_request:
     branches: [main, develop]
@@ -11,9 +20,9 @@ on:
       - 'cqlite-core/tests/sstableloader_integration.rs'
       - '.github/workflows/cassandra-validation.yml'
       # Note: cqlite-core/src/parser/** and schema/** are included here to gate
-      # serialization-adjacent code changes. Issue #664 adds e2e-readback.yml which
-      # also triggers on these paths; both workflows serve different validation roles
-      # (sstableloader vs readback), so some overlap is intentional.
+      # serialization-adjacent code changes. e2e-readback.yml also triggers on these
+      # paths; both workflows serve different validation roles (sstableloader vs
+      # nodetool refresh), so some overlap is intentional — see issue #728.
   push:
     branches: [main]
   workflow_dispatch:
@@ -37,6 +46,11 @@ env:
 permissions:
   contents: read
   pull-requests: write
+
+# Cancel any in-progress PR run when a new push arrives; let push/scheduled runs complete.
+concurrency:
+  group: cassandra-validation-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # This workflow validates that SSTables written by CQLite can be imported
 # into a real Cassandra 5.0 cluster using the current loader-based harness

--- a/.github/workflows/e2e-readback.yml
+++ b/.github/workflows/e2e-readback.yml
@@ -7,6 +7,15 @@ name: "CI: E2E Cassandra Readback Gate"
 # Runs:
 #   - Nightly (schedule) to catch regressions on main
 #   - On PRs touching writer/serialization/schema paths or the script/compose file itself
+#
+# DUAL-WORKFLOW DECISION (issue #728):
+# This workflow and cassandra-validation.yml are BOTH intentionally kept.
+# They cover two distinct production ingest paths:
+#   - e2e-readback.yml (this file): validates the `nodetool refresh` ingest path
+#   - cassandra-validation.yml:     validates the `sstableloader` ingest path
+# On writer-path PRs, both workflows run (~30 min each). This overlap is accepted
+# deliberately — merging them would obscure ingest-path-specific regressions.
+# See issue #728 for the full decision record.
 
 on:
   schedule:


### PR DESCRIPTION
## Summary

- Both Cassandra validation workflows are intentionally kept — `e2e-readback.yml` validates the `nodetool refresh` ingest path; `cassandra-validation.yml` validates the `sstableloader` ingest path.
- On writer-path PRs, both workflows run (~30 min each). This overlap is **accepted deliberately** as the cost of covering two distinct production ingest mechanisms — merging them would obscure ingest-path-specific regressions.
- The decision is documented in a `DUAL-WORKFLOW DECISION` comment block at the top of **both** workflow files (issue #728 cited as the decision record).

## Changes

- `.github/workflows/e2e-readback.yml` — added `DUAL-WORKFLOW DECISION` comment block explaining the intentional dual-path coverage
- `.github/workflows/cassandra-validation.yml` — added `DUAL-WORKFLOW DECISION` comment block; expanded inline note to reference #728; added `concurrency` block matching the one in `e2e-readback.yml` (cancels superseded in-progress PR runs, lets push/scheduled runs complete)

**No path filters or job steps changed — coverage is unchanged.**

## Concurrency guard

The one concrete cost reduction: `cassandra-validation.yml` previously had **no** `concurrency` block, so rapid pushes stacked multiple 30-minute runs. Added:

```yaml
concurrency:
  group: cassandra-validation-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

This mirrors the block already in `e2e-readback.yml`.

## Validation

```
YAML OK
```
(`ruby -ryaml` parse of both files passed.)

`actionlint` output (both warnings are pre-existing in unchanged job steps):
```
.github/workflows/cassandra-validation.yml:186:9: shellcheck reported issue in this script: SC2129:style ... [shellcheck]
.github/workflows/e2e-readback.yml:102:9: shellcheck reported issue in this script: SC2086:info ... [shellcheck]
```

`grep -n "concurrency" .github/workflows/cassandra-validation.yml` → `51:concurrency:`

This is a YAML/docs-only change; no Rust gate is needed.

Closes #728