### PR TITLE
fix(cli): emit null for tombstoned cells in JSON output (#806)

### DIFF
--- a/bindings/python/tests/test_cli_parity.py
+++ b/bindings/python/tests/test_cli_parity.py
@@ -173,14 +173,6 @@ def normalize_cli_value(value: Any) -> Any:
     - Maps with string keys: regular JSON object {"key1": v1, "key2": v2}
 
     We need to preserve the structure but recurse into nested values.
-
-    Special cases:
-    - CLI tombstone dicts ({"type": "tombstone", ...}) → None
-      Python bindings correctly return None for tombstoned cells; CLI leaks
-      internal tombstone metadata.  Treat them as equivalent so parity tests
-      do not false-fail on tombstoned optional columns.
-      This normalization is a temporary shim until the CLI tombstone-metadata
-      leak is fixed (tracked in #806).
     """
     if value is None:
         return None
@@ -210,11 +202,6 @@ def normalize_cli_value(value: Any) -> Any:
         return [normalize_cli_value(v) for v in value]
 
     if isinstance(value, dict):
-        # CLI tombstone objects leak internal metadata for tombstoned cells.
-        # Python bindings return None for these cells (correct user-facing behaviour).
-        # Normalise tombstone dicts to None so parity comparisons match.
-        if value.get("type") == "tombstone":
-            return None
         # This is either a row dict, UDT, or a map with string keys
         return {k: normalize_cli_value(v) for k, v in value.items()}
 

--- a/cqlite-cli/src/output/json.rs
+++ b/cqlite-cli/src/output/json.rs
@@ -169,14 +169,9 @@ impl JSONWriter {
                 JsonValue::Object(udt_obj)
             }
             Value::Frozen(boxed_value) => Self::value_to_json(boxed_value),
-            Value::Tombstone(info) => {
-                json!({
-                    "type": "tombstone",
-                    "deletion_time": info.deletion_time,
-                    "tombstone_type": format!("{:?}", info.tombstone_type),
-                    "ttl": info.ttl
-                })
-            }
+            // Tombstoned cells represent deleted values. Emit JSON null to match
+            // cqlsh and Python binding behaviour (issue #806).
+            Value::Tombstone(_) => JsonValue::Null,
             Value::Inet(bytes) => {
                 // Format as IP address string if possible
                 if bytes.len() == 4 {
@@ -682,5 +677,86 @@ mod tests {
         let json_val = JSONWriter::value_to_json(&duration);
         // Should be "XmoYdZns" format, not {months, days, nanos} object
         assert_eq!(json_val.as_str().unwrap(), "2mo15d123456789ns");
+    }
+
+    /// Issue #806: tombstoned cells must render as JSON null, not as an internal
+    /// metadata object.  This matches cqlsh and Python binding behaviour.
+    #[test]
+    fn test_cell_tombstone_renders_as_null() {
+        use cqlite_core::types::{TombstoneInfo, TombstoneType};
+
+        let tombstone = Value::Tombstone(TombstoneInfo {
+            deletion_time: 1673778645000000,
+            tombstone_type: TombstoneType::CellTombstone,
+            ttl: None,
+            range_start: None,
+            range_end: None,
+        });
+
+        let json_val = JSONWriter::value_to_json(&tombstone);
+        assert!(
+            json_val.is_null(),
+            "CellTombstone must render as JSON null, got: {json_val}"
+        );
+    }
+
+    #[test]
+    fn test_row_tombstone_renders_as_null() {
+        use cqlite_core::types::{TombstoneInfo, TombstoneType};
+
+        let tombstone = Value::Tombstone(TombstoneInfo {
+            deletion_time: 1673778645000000,
+            tombstone_type: TombstoneType::RowTombstone,
+            ttl: None,
+            range_start: None,
+            range_end: None,
+        });
+
+        let json_val = JSONWriter::value_to_json(&tombstone);
+        assert!(
+            json_val.is_null(),
+            "RowTombstone must render as JSON null, got: {json_val}"
+        );
+    }
+
+    #[test]
+    fn test_tombstone_column_in_result_is_null() {
+        use cqlite_core::types::{TombstoneInfo, TombstoneType};
+
+        let mut result = QueryResult::new();
+        result.metadata.columns = vec![ColumnInfo::new(
+            "deleted_col".to_string(),
+            cqlite_core::types::DataType::Tombstone,
+            true,
+            0,
+        )];
+
+        let mut values = HashMap::new();
+        values.insert(
+            "deleted_col".to_string(),
+            Value::Tombstone(TombstoneInfo {
+                deletion_time: 0,
+                tombstone_type: TombstoneType::CellTombstone,
+                ttl: None,
+                range_start: None,
+                range_end: None,
+            }),
+        );
+        let row = QueryRow::with_values(RowKey::new(vec![1]), values);
+        result.rows.push(row);
+
+        let json_str = JSONWriter::write(&result, &default_config()).unwrap();
+        let parsed: Vec<serde_json::Value> = serde_json::from_str(&json_str).unwrap();
+
+        let col_val = &parsed[0]["deleted_col"];
+        assert!(
+            col_val.is_null(),
+            "Tombstoned column must be JSON null in output, got: {col_val}"
+        );
+        // Ensure NO internal metadata leaked
+        assert!(
+            !json_str.contains("tombstone_type"),
+            "Internal tombstone metadata must not appear in output: {json_str}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- The CLI JSON writer was leaking internal tombstone metadata (`{"type": "tombstone", "deletion_time": ..., "tombstone_type": "CellTombstone", "ttl": null}`) for deleted cells instead of emitting JSON `null`
- Fixed by replacing the tombstone struct arm in `JSONWriter::value_to_json` with `JsonValue::Null` for all tombstone types — a deleted cell's value is `null` from the user's perspective
- Removed the temporary normalization shim in `test_cli_parity.py` (comment referenced #806) so Python/CLI parity tests now compare directly without workarounds

## Test plan

- [ ] `test_cell_tombstone_renders_as_null` — new unit test in `json.rs`
- [ ] `test_row_tombstone_renders_as_null` — new unit test in `json.rs`
- [ ] `test_tombstone_column_in_result_is_null` — full QueryResult round-trip, asserts no `tombstone_type` key in output
- [ ] All 15 existing `output_format_tests` pass unchanged
- [ ] Python CLI parity: 43 passed, 1 xfailed — `log_entries` and `chat_messages` tests now pass without the normalization shim
- [ ] Agent gate: all checks PASS (fmt, clippy -D warnings, core-tests, integration-tests, write-tests, cli-tests, minimal-build, smoke)

## Before / After

**Before** (`test_timeseries.log_entries.stack_trace`):
```json
{"service_name": "Mr", "stack_trace": {"type": "tombstone", "deletion_time": 0, "tombstone_type": "CellTombstone", "ttl": null}}
```

**After**:
```json
{"service_name": "Mr", "stack_trace": null}
```