### PR TITLE
fix(python): hashable representation for SET<FROZEN<UDT>> (#804)

### DIFF
--- a/bindings/python/src/value.rs
+++ b/bindings/python/src/value.rs
@@ -58,8 +58,16 @@ pub fn value_to_py(py: Python<'_>, value: &Value) -> PyResult<PyObject> {
 ///
 /// Python dicts require hashable keys. This converts:
 /// - List → tuple (recursively)
-/// - Set → frozenset (already hashable from set_to_py)
-/// - Other types → as-is
+/// - Map → tuple of (key, value) tuples
+/// - Set → frozenset (elements recursively made hashable)
+/// - Frozen → unwrap and recurse
+/// - UDT → frozenset of (field_name, hashable_value) tuples (sorted by name)
+/// - Other types → as-is (already hashable)
+///
+/// Note: `SET<FROZEN<UDT>>` is handled at the `set_to_py` level by
+/// returning a `list` instead of a `frozenset` (see `set_to_py`). This
+/// function is still called for UDTs that appear as MAP keys, which are
+/// unusual but possible in CQL.
 pub fn value_to_hashable_key(py: Python<'_>, value: &Value) -> PyResult<PyObject> {
     match value {
         Value::List(items) => {
@@ -81,6 +89,55 @@ pub fn value_to_hashable_key(py: Python<'_>, value: &Value) -> PyResult<PyObject
                 })
                 .collect::<PyResult<Vec<_>>>()?;
             Ok(PyTuple::new(py, converted)?.into_any().unbind())
+        }
+        Value::Frozen(inner) => {
+            // Unwrap Frozen and recurse so that FROZEN<UDT> and FROZEN<collection>
+            // are handled by the appropriate arm rather than falling through to
+            // value_to_py (which would return an unhashable dict for UDTs).
+            value_to_hashable_key(py, inner)
+        }
+        Value::Udt(udt) => {
+            // UDT as a map/set key: represent as a frozenset of (name, value) tuples
+            // sorted by field name for deterministic ordering.
+            // Fields: _type, _keyspace, and all named fields (matching udt_to_py).
+            let mut pairs: Vec<PyObject> = Vec::with_capacity(udt.fields.len() + 2);
+
+            // _type and _keyspace metadata fields
+            let type_key = "_type".into_pyobject(py)?.into_any().unbind();
+            let type_val = udt
+                .type_name
+                .as_str()
+                .into_pyobject(py)?
+                .into_any()
+                .unbind();
+            pairs.push(PyTuple::new(py, [type_key, type_val])?.into_any().unbind());
+
+            let ks_key = "_keyspace".into_pyobject(py)?.into_any().unbind();
+            let ks_val = udt.keyspace.as_str().into_pyobject(py)?.into_any().unbind();
+            pairs.push(PyTuple::new(py, [ks_key, ks_val])?.into_any().unbind());
+
+            // Named fields (in schema order; sort by name for a stable hash)
+            let mut field_tuples: Vec<(&str, PyObject)> = udt
+                .fields
+                .iter()
+                .map(|f| {
+                    let v = match &f.value {
+                        Some(v) => value_to_hashable_key(py, v),
+                        None => Ok(py.None()),
+                    }?;
+                    Ok((f.name.as_str(), v))
+                })
+                .collect::<PyResult<Vec<_>>>()?;
+
+            // Sort by field name so the frozenset hash is order-independent
+            field_tuples.sort_by_key(|(name, _)| *name);
+
+            for (name, val) in field_tuples {
+                let k = name.into_pyobject(py)?.into_any().unbind();
+                pairs.push(PyTuple::new(py, [k, val])?.into_any().unbind());
+            }
+
+            Ok(PyFrozenSet::new(py, &pairs)?.into_any().unbind())
         }
         // Other types are already hashable or handled by value_to_py
         _ => value_to_py(py, value),
@@ -334,13 +391,48 @@ fn list_to_py(py: Python<'_>, items: &[Value]) -> PyResult<PyObject> {
     Ok(PyList::new(py, converted)?.into_any().unbind())
 }
 
-/// Convert CQL set to Python frozenset.
+/// Convert CQL set to Python frozenset (or list when elements contain UDTs).
+///
+/// CQL SET semantics require unique, ordered elements. For scalar types, we
+/// return a Python `frozenset` (immutable, hashable, set-semantic). However,
+/// `dict` objects are unhashable in Python, so `SET<FROZEN<UDT>>` columns
+/// cannot use `frozenset`. In that case we fall back to a `list`, which
+/// matches the CLI JSON output and is consistent with how the CLI renders
+/// SET-of-UDT (see epic #795 and issue #804).
 fn set_to_py(py: Python<'_>, items: &[Value]) -> PyResult<PyObject> {
-    let converted: Vec<PyObject> = items
-        .iter()
-        .map(|v| value_to_hashable_key(py, v))
-        .collect::<PyResult<Vec<_>>>()?;
-    Ok(PyFrozenSet::new(py, &converted)?.into_any().unbind())
+    // Check whether any element is (or wraps) a UDT.
+    // UDT values become Python dicts, which are unhashable and cannot be
+    // placed in a frozenset.
+    let has_udt = items.iter().any(contains_udt);
+
+    if has_udt {
+        // Return a list so that each UDT element stays as a plain Python dict.
+        // This aligns with the CLI JSON representation of SET<FROZEN<UDT>>.
+        let converted: Vec<PyObject> = items
+            .iter()
+            .map(|v| value_to_py(py, v))
+            .collect::<PyResult<Vec<_>>>()?;
+        Ok(PyList::new(py, converted)?.into_any().unbind())
+    } else {
+        let converted: Vec<PyObject> = items
+            .iter()
+            .map(|v| value_to_hashable_key(py, v))
+            .collect::<PyResult<Vec<_>>>()?;
+        Ok(PyFrozenSet::new(py, &converted)?.into_any().unbind())
+    }
+}
+
+/// Return `true` if `value` is or wraps a UDT value.
+///
+/// Used by `set_to_py` to decide whether a `SET` should be returned as a
+/// `frozenset` (scalars, always hashable) or a `list` (UDT elements, whose
+/// dict representation is unhashable).
+fn contains_udt(value: &Value) -> bool {
+    match value {
+        Value::Udt(_) => true,
+        Value::Frozen(inner) => contains_udt(inner),
+        _ => false,
+    }
 }
 
 /// Convert CQL map to Python dict.

--- a/bindings/python/tests/test_cli_parity.py
+++ b/bindings/python/tests/test_cli_parity.py
@@ -503,9 +503,6 @@ class TestCLIParityBasic:
 class TestCLIParityCollections:
     """CLI parity tests for test_collections keyspace."""
 
-    # Tables with known product bugs that prevent parity testing
-    _UDT_SET_XFAIL_TABLES = {"collections_with_udts"}
-
     @pytest.mark.parametrize(
         "table",
         [
@@ -521,14 +518,6 @@ class TestCLIParityCollections:
     )
     def test_collection_table_parity(self, db_collections, cli_binary, table: str):
         """Verify Python and CLI produce identical output for collection tables."""
-        if table in self._UDT_SET_XFAIL_TABLES:
-            pytest.xfail(
-                reason=(
-                    "SET<FROZEN<UDT>> deserialization: Python binding wraps UDT values "
-                    "in frozenset but dict is unhashable, causing TypeError. "
-                    "Product bug — see #804 (UDT-in-SET unhashable type)."
-                )
-            )
         db, schema_file = db_collections
         query = f"SELECT * FROM test_collections.{table}"
 

--- a/bindings/python/tests/test_parity.py
+++ b/bindings/python/tests/test_parity.py
@@ -511,14 +511,6 @@ class TestRowCountParity:
     )
     def test_collections_row_count(self, db_collections, table):
         """Verify row count parity for test_collections tables."""
-        if table == "collections_with_udts":
-            pytest.xfail(
-                reason=(
-                    "SET<FROZEN<UDT>> deserialization: Python binding wraps UDT values "
-                    "in frozenset but dict is unhashable, causing TypeError on execute(). "
-                    "Product bug — see #804 (UDT-in-SET unhashable type)."
-                )
-            )
         jsonl_file = find_jsonl_file("test_collections", table)
         if jsonl_file is None:
             pytest.skip(f"JSONL reference not found for test_collections.{table}")
@@ -838,14 +830,7 @@ class TestE2ESummary:
 
     # Tables with known issues that are expected to fail (XFail)
     # Update this list as core issues are resolved
-    KNOWN_ISSUES = {
-        # SET<FROZEN<UDT>>: Python binding wraps UDT values in frozenset but
-        # dict is unhashable, causing TypeError on execute().
-        # Product bug — see #804 (UDT-in-SET unhashable type).
-        ("test_collections", "collections_with_udts"): (
-            "SET<FROZEN<UDT>> unhashable dict: Python binding TypeError on execute()"
-        ),
-    }
+    KNOWN_ISSUES: dict = {}
 
     def test_e2e_all_33_tables(self, datasets_root):
         """E2E validation that all 33 tables are queryable.

--- a/bindings/python/tests/test_types_collections_udt.py
+++ b/bindings/python/tests/test_types_collections_udt.py
@@ -383,6 +383,34 @@ class TestNestedCollections:
         if not found_udt_map:
             pytest.skip("No UDT map found in test data")
 
+    def test_udt_in_set(self, db):
+        """SET<FROZEN<udt>> should return list of dicts (issue #804).
+
+        UDT values are Python dicts which are unhashable and cannot be placed
+        in a frozenset.  The binding therefore returns a list when the set
+        element type is (or wraps) a UDT, matching the CLI JSON output.
+        """
+        result = db.execute(
+            "SELECT contacts FROM test_collections.collections_with_udts LIMIT 10"
+        )
+        found_udt_set = False
+        for row in result.rows:
+            contacts = row.get("contacts")
+            if contacts is not None and len(contacts) > 0:
+                found_udt_set = True
+                # SET<FROZEN<contact_info>> must come back as a list, not frozenset
+                assert isinstance(contacts, list), (
+                    f"Expected list for SET<FROZEN<UDT>>, got {type(contacts).__name__}"
+                )
+                for contact in contacts:
+                    # Each element must be a dict (UDT)
+                    assert isinstance(contact, dict), (
+                        f"Expected dict for FROZEN<UDT> element, got {type(contact).__name__}"
+                    )
+                    assert "_type" in contact, "UDT element should have _type metadata"
+        if not found_udt_set:
+            pytest.skip("No SET<FROZEN<UDT>> values found in test data")
+
 
 class TestFrozenCollections:
     """Test frozen collection handling."""


### PR DESCRIPTION
## Summary

- `SET<FROZEN<UDT>>` columns in `test_collections.collections_with_udts` raised `TypeError: unhashable type: 'dict'` because `set_to_py` tried to build a Python `frozenset` containing UDT values (dicts are unhashable).
- Adds a `contains_udt` helper; when any SET element is or wraps a UDT, `set_to_py` returns a `list` of dicts instead of a `frozenset`. Scalar SETs (SET<INT>, etc.) continue to return `frozenset` unchanged.
- `value_to_hashable_key` gains explicit `Value::Frozen` (unwrap) and `Value::Udt` (frozenset of sorted field-name/value tuples) arms so UDTs used as MAP keys also work.
- Representation choice: `list` matches the CLI JSON renderer (epic #795) and makes both parity normalizers produce identical output without extra logic.

## Test plan

- [ ] Remove 3 xfail markers for `collections_with_udts` (test_parity.py lines 514–521, 833–840; test_cli_parity.py line 524–531)
- [ ] Add `TestNestedCollections::test_udt_in_set` in test_types_collections_udt.py asserting `list` of dicts
- [ ] `test_parity.py::TestRowCountParity::test_collections_row_count[collections_with_udts]` — PASS
- [ ] `test_parity.py::TestE2ESummary::test_e2e_all_33_tables` — PASS (no KNOWN_ISSUES entry)
- [ ] `test_cli_parity.py::TestCLIParityCollections::test_collection_table_parity[collections_with_udts]` — PASS
- [ ] Agent gate: all 8 checks PASS