### PR TITLE
fix(python): thread-safe schema init for concurrent queries (#805)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,8 +297,9 @@ details, see `bindings/node/lib/index.d.ts` and the issue backlog (#290, #296–
 
 ### Python/Node.js Thread Safety and Output Parity
 
-**Python thread safety** (Issue #311): `Arc<Database>` + `AtomicBool`; GIL released
-during async ops; concurrent queries on same database require a warm-up query first.
+**Python thread safety** (Issue #311, #805): `Arc<Database>` + `AtomicBool`; GIL released
+during async ops; concurrent queries on the same database are safe without a warm-up
+(`SSTableReader.scan_mutex` serialises concurrent sequential scans — fix #805).
 
 **Python/CLI parity** (Issue #319): Python uses native types (datetime, UUID, bytes);
 CLI uses JSON strings. Normalization required for comparison — see

--- a/bindings/python/tests/test_edge_cases.py
+++ b/bindings/python/tests/test_edge_cases.py
@@ -221,18 +221,13 @@ class TestDatabaseLifecycle:
 class TestConcurrentAccess:
     """Test thread safety with concurrent access."""
 
-    @pytest.mark.xfail(
-        reason=(
-            "Concurrent query thread safety: multiple threads issuing queries "
-            "simultaneously against the same Database object intermittently fail "
-            "with 'Column not found: id', even after a warm-up sequence. "
-            "Documented limitation in CLAUDE.md: 'concurrent queries on same "
-            "database require a warm-up query first'. The warm-up does not fully "
-            "resolve the race. Product bug — see #805 (concurrent-query column-not-found)."
-        )
-    )
     def test_concurrent_queries_from_threads(self):
-        """Multiple threads should be able to query simultaneously."""
+        """Multiple threads should be able to query simultaneously without a warm-up.
+
+        Fixed in #805: SSTableReader.scan_mutex now serialises concurrent sequential
+        scans on the same reader, preventing interleaving of the shared file-position
+        and current_chunk_index state that previously caused 'Column not found: id'.
+        """
         if not DATASETS.exists():
             pytest.skip("Test data not found")
         schema_file = SCHEMAS / "basic-types.cql"
@@ -256,18 +251,14 @@ class TestConcurrentAccess:
                 with lock:
                     errors.append((thread_id, e))
 
+        # No warm-up required — fix #805 makes concurrent first-access safe.
         with cqlite.open(DATASETS, schema=schema_file) as db:
-            # Warm up: execute multiple queries to ensure schema is fully loaded
-            # and all internal caches are populated before concurrent access
-            for _ in range(3):
-                _ = db.execute("SELECT id, active, age, salary FROM test_basic.simple_table LIMIT 1")
-
             threads = []
             for i in range(10):
                 t = threading.Thread(target=query_thread, args=(db, i))
                 threads.append(t)
 
-            # Start all threads
+            # Start all threads simultaneously to maximise race pressure
             for t in threads:
                 t.start()
 

--- a/cqlite-core/src/storage/sstable/reader/data_access.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access.rs
@@ -275,6 +275,9 @@ impl SSTableReader {
     /// `Value::Tombstone` entries (with their authoritative deletion timestamps)
     /// so that tombstone-shadowing semantics can be applied during the merge.
     pub async fn get_all_entries(&self) -> Result<Vec<(TableId, RowKey, Value)>> {
+        // Issue #805: serialise concurrent scans (shared file position + chunk index).
+        let _scan_guard = self.scan_mutex.lock().await;
+
         let mut results = Vec::new();
 
         // Reset to beginning of data section
@@ -470,6 +473,9 @@ impl SSTableReader {
         schema: Option<crate::schema::TableSchema>,
         tx: mpsc::Sender<Result<(RowKey, Value)>>,
     ) -> Result<()> {
+        // Issue #805: serialise concurrent scans (shared file position + chunk index).
+        let _scan_guard = self.scan_mutex.lock().await;
+
         // Position at the start of the data section (mirrors sequential_scan).
         let header_size = self.calculate_header_size();
         {
@@ -841,6 +847,9 @@ impl SSTableReader {
     }
 
     async fn scan_for_key(&self, table_id: &TableId, key: &RowKey) -> Result<Option<Value>> {
+        // Issue #805: serialise concurrent scans (shared file position + chunk index).
+        let _scan_guard = self.scan_mutex.lock().await;
+
         // For V5CompressedLegacy NB format, partitions can span chunk boundaries.
         // The block-by-block parser will miss any partition whose bytes cross a
         // chunk boundary.  Use the same stitched-buffer path that sequential_scan()
@@ -942,6 +951,12 @@ impl SSTableReader {
             "SSTableReader::sequential_scan - Has schema: {}",
             schema.is_some()
         );
+
+        // Issue #805: Serialise concurrent sequential scans on this reader.
+        // The file seek-position and current_chunk_index are shared state;
+        // two concurrent callers advancing them simultaneously corrupt each
+        // other's reads. Hold the scan_mutex for the full scan lifetime.
+        let _scan_guard = self.scan_mutex.lock().await;
 
         let mut results = Vec::new();
 

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -369,6 +369,7 @@ impl SSTableReader {
             udt_registry: None, // Will be set when available for UDT-aware parsing
             compression_info: compression_info.map(Arc::new),
             current_chunk_index: AtomicUsize::new(0),
+            scan_mutex: tokio::sync::Mutex::new(()),
             version_gates,
         })
     }

--- a/cqlite-core/src/storage/sstable/reader/types.rs
+++ b/cqlite-core/src/storage/sstable/reader/types.rs
@@ -259,8 +259,21 @@ pub struct SSTableReader {
     pub(crate) udt_registry: Option<UdtRegistry>,
     /// CompressionInfo metadata for chunked decompression (if compressed)
     pub compression_info: Option<Arc<CompressionInfo>>,
-    /// Current chunk index for sequential chunk reading
+    /// Current chunk index for sequential chunk reading.
+    ///
+    /// IMPORTANT: This field is shared across all callers of `read_next_block`.
+    /// Concurrent callers MUST hold `scan_mutex` for the full lifetime of their
+    /// scan to prevent interleaving of file-position advances and chunk-index
+    /// increments (issue #805).
     pub(super) current_chunk_index: AtomicUsize,
+    /// Serialises concurrent sequential scans on this reader.
+    ///
+    /// SSTable files are immutable, but `sequential_scan`, `scan_for_key`, and
+    /// `stitch_all_chunks` share both the underlying file's seek-position and the
+    /// `current_chunk_index` counter. Two concurrent callers advancing those
+    /// fields simultaneously corrupt each other's reads (issue #805). Acquiring
+    /// this mutex for the full duration of a scan prevents interleaving.
+    pub(super) scan_mutex: tokio::sync::Mutex<()>,
     /// Version-feature gates derived from the SSTable filename.
     ///
     /// Computed once in `SSTableReader::open` via `VersionGates::from_path` and


### PR DESCRIPTION
## Summary

- **Root cause**: `SSTableReader` shared two pieces of mutable scan state — the file seek-position (inside `Arc<Mutex<BlockSource>>`) and `current_chunk_index: AtomicUsize` — without atomically coordinating them. The `file` Mutex serialised individual I/O operations but not full scans: between a seek and subsequent block reads, a concurrent thread could seek to a different position, corrupting both reads and producing `Column not found: id` errors.

- **Fix**: Added `scan_mutex: tokio::sync::Mutex<()>` to `SSTableReader` and acquire it for the full lifetime of each scan (`sequential_scan`, `get_all_entries`, `scan_for_key`, `run_scan_stream`). This serialises concurrent callers' file-position advances and `current_chunk_index` increments.

- **Test**: Removed `@pytest.mark.xfail` from `test_concurrent_queries_from_threads` and removed the warm-up loop (no longer needed). Verified 20/20 runs pass without flakiness.

- **Docs**: Updated `CLAUDE.md` to remove the outdated "concurrent queries on same database require a warm-up query first" caveat.

## Test plan

- [ ] `scripts/agent-gate.sh` — all gates PASS (fmt, clippy, core-tests, integration-tests, write-tests, cli-tests, minimal-build, smoke)
- [ ] `test_concurrent_queries_from_threads` runs 20/20 without errors
- [ ] No `unwrap()`/`expect()` added to library code
- [ ] `RUSTFLAGS="-D warnings"` (clippy) passes