### PR TITLE
feat(writer): emit Cassandra-correct promoted index for wide partitions (#752)

### DIFF
--- a/cqlite-core/examples/gen_wide_sstable.rs
+++ b/cqlite-core/examples/gen_wide_sstable.rs
@@ -1,0 +1,131 @@
+/// Generate a wide-partition SSTable at `/tmp/cqlite-sstabledump-test/` for
+/// real Cassandra sstabledump validation of the promoted-index fix (#752).
+///
+/// Run:
+/// ```bash
+/// cargo run -p cqlite-core --example gen_wide_sstable --features write-support
+/// ```
+
+#[cfg(feature = "write-support")]
+#[tokio::main]
+async fn main() -> cqlite_core::error::Result<()> {
+    use cqlite_core::schema::{ClusteringColumn, ClusteringOrder, Column, KeyColumn, TableSchema};
+    use cqlite_core::storage::write_engine::{
+        CellOperation, ClusteringKey, Mutation, PartitionKey, TableId, WriteEngine,
+        WriteEngineConfig,
+    };
+    use cqlite_core::types::Value;
+    use std::collections::HashMap;
+
+    let out = std::path::PathBuf::from("/tmp/cqlite-sstabledump-test");
+    if out.exists() {
+        std::fs::remove_dir_all(&out).ok();
+    }
+
+    let schema = TableSchema {
+        keyspace: "test_roundtrip".to_string(),
+        table: "wide_check".to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "pk".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![ClusteringColumn {
+            name: "ck".to_string(),
+            data_type: "text".to_string(),
+            position: 0,
+            order: ClusteringOrder::Asc,
+        }],
+        columns: vec![
+            Column {
+                name: "pk".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "ck".to_string(),
+                data_type: "text".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "data".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+    };
+
+    let config = WriteEngineConfig::new(out.join("data"), out.join("wal"), schema.clone());
+    let mut engine = WriteEngine::new(config)?;
+
+    // Write 1000 rows under a single partition key (pk=42) to produce a wide partition
+    // (>128 KiB → at least 2 index blocks).
+    let padding: String = "x".repeat(190);
+    for i in 0..1000usize {
+        let ck = format!("ck_{:06}", i);
+        let data = format!("data_{}_{}", i, padding);
+        let mutation = Mutation {
+            table: TableId {
+                keyspace: "test_roundtrip".to_string(),
+                table: "wide_check".to_string(),
+            },
+            partition_key: PartitionKey::single("pk", Value::Integer(42)),
+            clustering_key: Some(ClusteringKey::single("ck", Value::Text(ck))),
+            operations: vec![CellOperation::Write {
+                column: "data".to_string(),
+                value: Value::Text(data),
+            }],
+            timestamp_micros: 1_000_000 + i as i64,
+            ttl_seconds: None,
+            partition_tombstone: None,
+            range_tombstones: vec![],
+        };
+        engine.write_async(mutation).await?;
+    }
+
+    let info = engine
+        .flush()
+        .await?
+        .expect("flush must return SSTableInfo");
+
+    println!("SSTable written to:");
+    println!("  Data.db:  {}", info.data_path.display());
+    println!("  Index.db: {}", info.index_path.display());
+    println!("  Dir:      {}", info.data_path.parent().unwrap().display());
+
+    // Verify that promoted index was emitted
+    let index_bytes = std::fs::read(&info.index_path)?;
+    let key_len = u16::from_be_bytes([index_bytes[0], index_bytes[1]]) as usize;
+    let mut pos = 2 + key_len;
+    // skip data_offset vint
+    while index_bytes[pos] >= 0x80 {
+        pos += 1;
+    }
+    pos += 1;
+    // read promoted_len vint
+    let promoted_len_byte = index_bytes[pos];
+    println!(
+        "  promoted_index_size first byte: 0x{:02X} ({}zero)",
+        promoted_len_byte,
+        if promoted_len_byte > 0 { "non-" } else { "" }
+    );
+
+    if promoted_len_byte == 0 {
+        eprintln!("ERROR: promoted_index_size is 0 — wide partition did not trigger index blocks!");
+        std::process::exit(1);
+    }
+    println!("  promoted index present: YES");
+    Ok(())
+}
+
+#[cfg(not(feature = "write-support"))]
+fn main() {
+    eprintln!("Run with --features write-support");
+}

--- a/cqlite-core/src/storage/sstable/writer/data_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer.rs
@@ -60,6 +60,7 @@ use crate::error::{Error, Result};
 use crate::schema::{Column, CqlType, TableSchema};
 use crate::storage::serialization::types::TypeSerializer;
 use crate::storage::serialization::vint::{encode_signed, encode_unsigned, unsigned_len};
+use crate::storage::sstable::writer::index_writer::{PromotedIndexBlock, COLUMN_INDEX_SIZE_BYTES};
 use crate::storage::sstable::writer::stats_writer::StatisticsMetadata;
 use crate::storage::write_engine::mutation::{
     ClusteringBound, ClusteringKey, DecoratedKey, Mutation, PartitionKey, PartitionTombstone,
@@ -466,6 +467,255 @@ impl DataWriter {
         self.flush_partition()?;
 
         Ok(partition_offset)
+    }
+
+    /// Write a complete partition and collect promoted index blocks for wide partitions.
+    ///
+    /// Same as [`write_partition`] but also tracks `IndexInfo` block boundaries
+    /// for partitions whose uncompressed data exceeds `COLUMN_INDEX_SIZE_BYTES` (64 KiB).
+    /// The returned `Vec<PromotedIndexBlock>` contains **one entry per 64 KiB block**;
+    /// the caller (SSTableWriter) passes this to `IndexWriter::add_partition_with_promoted`.
+    ///
+    /// Block sampling rules (mirrors `BigFormatPartitionWriter`):
+    /// - A new block is opened whenever the bytes written since the last boundary ≥ 64 KiB.
+    /// - The last open block is closed when `END_OF_PARTITION` is reached.
+    /// - Only rows with clustering keys contribute `firstName`/`lastName`; tables without
+    ///   clustering keys produce blocks with empty prefix bytes (`[0x00]` = header-only VInt).
+    /// - A promoted index is only meaningful when 2+ blocks result; the caller checks this.
+    pub fn write_partition_with_index_blocks(
+        &mut self,
+        key: &DecoratedKey,
+        mutations: &[Mutation],
+        schema: &TableSchema,
+        partition_tombstone: Option<&PartitionTombstone>,
+        range_tombstones: &[RangeTombstone],
+    ) -> Result<(u64, Vec<PromotedIndexBlock>)> {
+        // File offset of this partition
+        let partition_offset = self.position + self.buffer.len() as u64;
+
+        // Note the absolute buffer position at the start of partition data.
+        // For streaming mode this is always `self.position` (buffer is empty at start).
+        // For in-memory mode this is `self.buffer.len()` (position == 0).
+        let partition_buf_start = self.buffer.len();
+
+        // Write partition header (with optional tombstone)
+        let header_start = self.buffer.len();
+        self.write_partition_header(key, partition_tombstone)?;
+        let mut prev_unfiltered_size = (self.buffer.len() - header_start) as u64;
+
+        let partition_floor = partition_tombstone.map(|pt| pt.deletion_time);
+        let schema_has_static = schema.columns.iter().any(|c| c.is_static);
+
+        if schema_has_static {
+            let merged = collect_static_operations(mutations, schema, partition_floor);
+            let unshadowed_static = |m: &&Mutation| {
+                partition_floor.is_none_or(|floor| m.timestamp_micros > floor)
+                    && has_static_operation(m, schema)
+            };
+
+            if merged.is_empty() {
+                prev_unfiltered_size =
+                    self.write_empty_static_row(prev_unfiltered_size, schema)? as u64;
+            } else {
+                let latest_ts = mutations
+                    .iter()
+                    .filter(unshadowed_static)
+                    .map(|m| m.timestamp_micros)
+                    .max()
+                    .unwrap_or(mutations.first().map(|m| m.timestamp_micros).unwrap_or(0));
+
+                let ttl = mutations
+                    .iter()
+                    .filter(unshadowed_static)
+                    .max_by_key(|m| m.timestamp_micros)
+                    .and_then(|m| m.ttl_seconds);
+
+                let synthetic = Mutation {
+                    table: mutations
+                        .first()
+                        .map(|m| m.table.clone())
+                        .unwrap_or_else(|| TableId {
+                            keyspace: schema.keyspace.clone(),
+                            table: schema.table.clone(),
+                        }),
+                    partition_key: mutations
+                        .first()
+                        .map(|m| m.partition_key.clone())
+                        .unwrap_or_else(|| PartitionKey {
+                            columns: Vec::new(),
+                        }),
+                    clustering_key: None,
+                    operations: merged,
+                    timestamp_micros: latest_ts,
+                    ttl_seconds: ttl,
+                    partition_tombstone: None,
+                    range_tombstones: Vec::new(),
+                };
+
+                prev_unfiltered_size =
+                    self.write_static_row_with_prev_size(&synthetic, schema, prev_unfiltered_size)?
+                        as u64;
+            }
+        }
+
+        let rows = self.merge_clustering_rows(
+            mutations,
+            schema,
+            schema_has_static,
+            partition_floor,
+            range_tombstones,
+        );
+
+        enum PartitionItem<'a> {
+            Row(RowWrite<'a>),
+            Marker {
+                bound: &'a ClusteringBound,
+                is_open: bool,
+                deletion_time: i64,
+                local_deletion_time: i32,
+            },
+        }
+
+        let mut items: Vec<PartitionItem> = rows.into_iter().map(PartitionItem::Row).collect();
+        for rt in range_tombstones {
+            items.push(PartitionItem::Marker {
+                bound: &rt.start,
+                is_open: true,
+                deletion_time: rt.deletion_time,
+                local_deletion_time: rt.local_deletion_time,
+            });
+            items.push(PartitionItem::Marker {
+                bound: &rt.end,
+                is_open: false,
+                deletion_time: rt.deletion_time,
+                local_deletion_time: rt.local_deletion_time,
+            });
+        }
+
+        fn sort_class<'a, 'b>(item: &'b PartitionItem<'a>) -> (i8, Option<&'b ClusteringKey>, i8) {
+            match item {
+                PartitionItem::Row(row) => (0, row.clustering_key, 0),
+                PartitionItem::Marker { bound, is_open, .. } => match bound {
+                    ClusteringBound::Inclusive(ck) => (0, Some(ck), if *is_open { -1 } else { 1 }),
+                    ClusteringBound::Exclusive(ck) => (0, Some(ck), if *is_open { 1 } else { -1 }),
+                    ClusteringBound::Bottom => (-1, None, 0),
+                    ClusteringBound::Top => (1, None, 0),
+                },
+            }
+        }
+        items.sort_by(|a, b| {
+            let (class_a, ck_a, weight_a) = sort_class(a);
+            let (class_b, ck_b, weight_b) = sort_class(b);
+            class_a
+                .cmp(&class_b)
+                .then_with(|| match (ck_a, ck_b) {
+                    (Some(x), Some(y)) => x.compare(y, schema).unwrap_or_else(|_| x.cmp(y)),
+                    _ => std::cmp::Ordering::Equal,
+                })
+                .then(weight_a.cmp(&weight_b))
+        });
+
+        // ── Promoted index block tracking ────────────────────────────────
+        // Mirrors Cassandra's BigFormatPartitionWriter:
+        // - Start block at position 0 (immediately after partition header).
+        // - Close block + open a new one whenever accumulated bytes ≥ 64 KiB.
+        // - The last block is closed at END_OF_PARTITION.
+        //
+        // `block_start_buf_offset`: absolute position in `self.buffer` where
+        //   the current block began (relative to `partition_buf_start`).
+        // `current_block_first_ck`: serialized ClusteringPrefix of the first item
+        //   in the current block (empty bytes → "header only" VInt 0x00 for no-CK tables).
+        // `current_block_last_ck`: serialized ClusteringPrefix of the most-recent item.
+
+        let mut blocks: Vec<PromotedIndexBlock> = Vec::new();
+        let mut block_start_buf_offset = self.buffer.len() - partition_buf_start;
+        let mut current_block_first_ck: Option<Vec<u8>> = None;
+        let mut current_block_last_ck: Option<Vec<u8>> = None;
+
+        for item in items {
+            // Clustering key bytes for this item (serialized as ClusteringPrefix).
+            let ck_bytes: Vec<u8> = match &item {
+                PartitionItem::Row(row) => {
+                    if let Some(ck) = row.clustering_key {
+                        serialize_clustering_prefix_to_vec(ck, schema)
+                            .unwrap_or_else(|_| vec![0x00])
+                    } else {
+                        vec![0x00] // no clustering key — empty prefix header
+                    }
+                }
+                PartitionItem::Marker { bound, .. } => match bound {
+                    ClusteringBound::Inclusive(ck) | ClusteringBound::Exclusive(ck) => {
+                        serialize_clustering_prefix_to_vec(ck, schema)
+                            .unwrap_or_else(|_| vec![0x00])
+                    }
+                    ClusteringBound::Bottom | ClusteringBound::Top => vec![0x00],
+                },
+            };
+
+            if current_block_first_ck.is_none() {
+                current_block_first_ck = Some(ck_bytes.clone());
+            }
+            current_block_last_ck = Some(ck_bytes.clone());
+
+            // Write the item
+            prev_unfiltered_size = match item {
+                PartitionItem::Row(row) => {
+                    self.write_merged_row_with_prev_size(&row, schema, prev_unfiltered_size)? as u64
+                }
+                PartitionItem::Marker {
+                    bound,
+                    is_open,
+                    deletion_time,
+                    local_deletion_time,
+                } => self.write_range_bound(
+                    bound,
+                    is_open,
+                    deletion_time,
+                    local_deletion_time,
+                    schema,
+                    prev_unfiltered_size,
+                )? as u64,
+            };
+
+            // Bytes written in the current block so far
+            let current_buf_offset = self.buffer.len() - partition_buf_start;
+            let block_bytes = (current_buf_offset - block_start_buf_offset) as u64;
+
+            if block_bytes >= COLUMN_INDEX_SIZE_BYTES {
+                // Close this block and start a new one
+                blocks.push(PromotedIndexBlock {
+                    first_name: current_block_first_ck.take().unwrap_or_else(|| vec![0x00]),
+                    last_name: current_block_last_ck.take().unwrap_or_else(|| vec![0x00]),
+                    offset: block_start_buf_offset as u64,
+                    width: block_bytes,
+                });
+                block_start_buf_offset = current_buf_offset;
+                // first/last reset for next block
+                current_block_first_ck = None;
+                current_block_last_ck = None;
+            }
+        }
+
+        // Write end-of-partition marker
+        self.buffer.push(END_OF_PARTITION);
+
+        // Close the final block (if any items were written)
+        if let (Some(first), Some(last)) = (current_block_first_ck, current_block_last_ck) {
+            let current_buf_offset = self.buffer.len() - partition_buf_start;
+            let block_bytes = (current_buf_offset - block_start_buf_offset) as u64;
+            if block_bytes > 0 {
+                blocks.push(PromotedIndexBlock {
+                    first_name: first,
+                    last_name: last,
+                    offset: block_start_buf_offset as u64,
+                    width: block_bytes,
+                });
+            }
+        }
+
+        self.flush_partition()?;
+
+        Ok((partition_offset, blocks))
     }
 
     /// Write an empty static-row prelude.
@@ -2943,6 +3193,51 @@ fn serialize_value_for_clustering(value: &Value, comparator: &ComparatorType) ->
             value, comparator
         ))),
     }
+}
+
+/// Serialize a `ClusteringKey` as a Cassandra `ClusteringPrefix` byte sequence.
+///
+/// Format (same as the clustering prefix written in Data.db rows):
+/// ```text
+/// [header: unsigned VInt]   ← 2 bits per column: 00=present, 10=null
+/// [value bytes…]            ← type-specific bytes for each PRESENT column
+/// ```
+///
+/// Returns `Err` if a clustering column type is unknown; the caller falls back
+/// to `[0x00]` (empty header VInt, valid for "no columns") in that case.
+pub(super) fn serialize_clustering_prefix_to_vec(
+    clustering_key: &ClusteringKey,
+    schema: &TableSchema,
+) -> Result<Vec<u8>> {
+    let mut header = 0u64;
+    for (i, (_, value)) in clustering_key.columns.iter().enumerate() {
+        let state: u64 = match value {
+            Value::Null => 2, // NULL
+            _ => 0,           // PRESENT
+        };
+        header |= state << (i * 2);
+    }
+
+    let mut buf: Vec<u8> = Vec::new();
+    encode_unsigned(header, &mut buf);
+
+    for (i, (_, value)) in clustering_key.columns.iter().enumerate() {
+        if !matches!(value, Value::Null) {
+            if i >= schema.clustering_keys.len() {
+                return Err(crate::error::Error::Schema(format!(
+                    "Clustering key index {} out of range (schema has {})",
+                    i,
+                    schema.clustering_keys.len()
+                )));
+            }
+            let cluster_col = &schema.clustering_keys[i];
+            let comparator = ComparatorType::from_data_type(&cluster_col.data_type)?;
+            let value_bytes = serialize_value_for_clustering(value, &comparator)?;
+            buf.extend_from_slice(&value_bytes);
+        }
+    }
+
+    Ok(buf)
 }
 
 #[cfg(test)]

--- a/cqlite-core/src/storage/sstable/writer/index_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/index_writer.rs
@@ -14,8 +14,39 @@
 //! [key_len: u16 BE]                ← Length of partition key bytes
 //! [key_bytes: key_len bytes]       ← Raw partition key bytes
 //! [position: unsigned VInt]        ← Byte offset in Data.db
-//! [promoted_index_size: unsigned VInt] ← 0 for simple partitions
+//! [promoted_index_size: unsigned VInt] ← 0 for simple partitions; byte count of promoted index for wide ones
+//! [promoted_index_data: promoted_index_size bytes] ← Only when promoted_index_size > 0
 //! ```
+//!
+//! ## Promoted Index (wide partitions ≥ 64 KiB)
+//!
+//! When a partition's uncompressed data exceeds 64 KiB, a promoted index is written so
+//! Cassandra can seek to a specific clustering-key range without reading the full partition.
+//!
+//! A promoted index is only emitted when **two or more** `IndexInfo` blocks result
+//! (Cassandra `RowIndexEntry.create()` lines 227-239). The promoted index payload is:
+//!
+//! ```text
+//! [headerLength: unsigned VInt]    ← byte count of the DeletionTime blob below
+//! [DeletionTime: headerLength bytes] ← partition header deletion ("oa": 0x80 = LIVE)
+//! [count: unsigned VInt]           ← number of IndexInfo blocks
+//! [IndexInfo[0]..]                 ← IndexInfo blocks (see PromotedIndexBlock)
+//! [offset[0]: i32 BE] ...          ← relative offsets from first IndexInfo, one per block
+//! ```
+//!
+//! Each `IndexInfo` block:
+//! ```text
+//! [firstName: ClusteringPrefix]    ← min clustering key in block (vint header + values)
+//! [lastName: ClusteringPrefix]     ← max clustering key in block
+//! [offset: unsigned VInt]          ← byte offset from partition start
+//! [width: unsigned VInt]           ← (actual_width - WIDTH_BASE) where WIDTH_BASE = 64 KiB
+//! [endOpenMarker: u8]              ← 0 = no open range tombstone marker
+//! ```
+//!
+//! Sources:
+//! - `RowIndexEntry.java` lines 293-296 (BIG "oa" serialization)
+//! - `IndexInfo.Serializer.serialize()` lines 107-117
+//! - `DeletionTime.java` lines 210-219 ("oa" format: mfda first, then ldt unsigned)
 //!
 //! ## Key Requirements
 //!
@@ -32,10 +63,52 @@ use crate::error::Result;
 use crate::storage::serialization::vint::encode_unsigned;
 use crate::storage::write_engine::mutation::DecoratedKey;
 
+/// Threshold at which a new IndexInfo block is emitted (Cassandra default 64 KiB).
+///
+/// A new block is started whenever the uncompressed row data accumulated since the
+/// last block boundary reaches this limit.
+///
+/// Source: `BigFormatPartitionWriter.DEFAULT_GRANULARITY` = 64 * 1024.
+pub const COLUMN_INDEX_SIZE_BYTES: u64 = 64 * 1024;
+
+/// Delta-encoding base for `IndexInfo.width` field.
+///
+/// Each block's actual width is stored as `(actual_width - WIDTH_BASE)` so that
+/// typical blocks near 64 KiB encode to a small or zero VInt value.
+///
+/// Source: `IndexInfo.WIDTH_BASE` = 64 * 1024.
+pub const INDEX_INFO_WIDTH_BASE: u64 = 64 * 1024;
+
+/// One IndexInfo block in the promoted index.
+///
+/// Cassandra emits one block per `column_index_size` (64 KiB) boundary crossed.
+/// A promoted index is only written when there are **two or more** blocks
+/// (`RowIndexEntry.create()` lines 227-239).
+#[derive(Debug, Clone)]
+pub struct PromotedIndexBlock {
+    /// Serialized `ClusteringPrefix` for the first unfiltered in this block.
+    ///
+    /// Format: `[header: unsigned VInt (2 bits per CK col)][value bytes…]`
+    /// Same encoding as the clustering prefix in Data.db rows.
+    /// Empty `Vec` for tables without clustering keys or for empty-clustering rows.
+    pub first_name: Vec<u8>,
+
+    /// Serialized `ClusteringPrefix` for the last unfiltered in this block.
+    pub last_name: Vec<u8>,
+
+    /// Byte offset from the start of the partition's Data.db bytes to the first
+    /// unfiltered in this block.
+    pub offset: u64,
+
+    /// Total width (bytes) of this block's data.
+    pub width: u64,
+}
+
 /// Index.db component writer
 ///
 /// Writes partition index entries in BIG format (NB variant) for Cassandra 5.0 compatibility.
-/// Each entry maps a partition key to a Data.db file offset.
+/// Each entry maps a partition key to a Data.db file offset, optionally with a promoted index
+/// for wide partitions (≥ 64 KiB).
 #[derive(Debug)]
 pub struct IndexWriter {
     /// Serialized index data (written incrementally)
@@ -73,7 +146,7 @@ impl IndexWriter {
         }
     }
 
-    /// Add a partition to the index
+    /// Add a partition to the index (no promoted index — simple/small partition).
     ///
     /// Partitions MUST be added in token order (caller responsibility).
     ///
@@ -104,8 +177,30 @@ impl IndexWriter {
         key: &DecoratedKey,
         data_offset: u64,
     ) -> Result<IndexEntryInfo> {
+        self.add_partition_with_promoted(key, data_offset, &[])
+    }
+
+    /// Add a partition to the index with optional promoted index blocks.
+    ///
+    /// Call this with a non-empty `blocks` slice for wide partitions (≥ 64 KiB).
+    /// When `blocks` contains **fewer than 2 entries**, the promoted index is not
+    /// emitted (matching Cassandra `RowIndexEntry.create()` which gates on
+    /// `columnIndexCount > 1`). When 2 or more blocks are supplied the full
+    /// promoted index payload is written.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - Decorated partition key (token + raw bytes)
+    /// * `data_offset` - Byte offset in Data.db where this partition starts
+    /// * `blocks` - Collected `PromotedIndexBlock`s from the data write pass
+    pub fn add_partition_with_promoted(
+        &mut self,
+        key: &DecoratedKey,
+        data_offset: u64,
+        blocks: &[PromotedIndexBlock],
+    ) -> Result<IndexEntryInfo> {
         let index_offset = self.buffer.len() as u64;
-        let entry_size = self.write_entry(key, data_offset)?;
+        let entry_size = self.write_entry(key, data_offset, blocks)?;
         self.entry_count += 1;
 
         Ok(IndexEntryInfo {
@@ -114,16 +209,22 @@ impl IndexWriter {
         })
     }
 
-    /// Write a single index entry to the buffer
+    /// Write a single index entry to the buffer.
     ///
-    /// Cassandra BIG format Index.db entry (NB variant):
+    /// Cassandra BIG format Index.db entry (NB "oa" variant):
     /// ```text
-    /// [key_len: u16 BE]                   ← Length of raw partition key
-    /// [key_bytes: key_len bytes]          ← Raw partition key bytes
-    /// [position: unsigned VInt]           ← Data.db offset
-    /// [promoted_index_size: unsigned VInt] ← 0 for simple partitions
+    /// [key_len: u16 BE]                    ← Length of raw partition key
+    /// [key_bytes: key_len bytes]           ← Raw partition key bytes
+    /// [position: unsigned VInt]            ← Data.db offset
+    /// [promoted_index_size: unsigned VInt] ← 0 or byte count of promoted payload
+    /// [promoted_index_data: promoted_index_size bytes] ← only when size > 0
     /// ```
-    fn write_entry(&mut self, key: &DecoratedKey, data_offset: u64) -> Result<usize> {
+    fn write_entry(
+        &mut self,
+        key: &DecoratedKey,
+        data_offset: u64,
+        blocks: &[PromotedIndexBlock],
+    ) -> Result<usize> {
         let start_len = self.buffer.len();
 
         // Write key length (u16 big-endian)
@@ -136,8 +237,16 @@ impl IndexWriter {
         // Write position (unsigned VInt encoded)
         encode_unsigned(data_offset, &mut self.buffer);
 
-        // Write promoted index length (0 = no promoted index)
-        encode_unsigned(0, &mut self.buffer);
+        // Only emit a promoted index when there are 2+ blocks
+        // (Cassandra RowIndexEntry.create() gates on columnIndexCount > 1)
+        if blocks.len() >= 2 {
+            let promoted_payload = serialize_promoted_index(blocks);
+            encode_unsigned(promoted_payload.len() as u64, &mut self.buffer);
+            self.buffer.extend_from_slice(&promoted_payload);
+        } else {
+            // Small partition — no promoted index
+            encode_unsigned(0, &mut self.buffer);
+        }
 
         let bytes_written = self.buffer.len() - start_len;
         Ok(bytes_written)
@@ -186,6 +295,93 @@ impl Default for IndexWriter {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Serialize the promoted index payload for a wide partition.
+///
+/// Layout (Cassandra BIG "oa" format, `RowIndexEntry.Serializer.serialize()`):
+/// ```text
+/// [headerLength: unsigned VInt]    ← byte count of DeletionTime below
+/// [DeletionTime: 1 byte = 0x80]   ← LIVE partition header (oa single-byte form)
+/// [count: unsigned VInt]           ← number of IndexInfo blocks
+/// [IndexInfo[0]..]                 ← serialized blocks in order
+/// [offset[0]: i32 BE]             ← relative offsets from first IndexInfo start
+/// ...
+/// [offset[N-1]: i32 BE]
+/// ```
+///
+/// The returned `Vec<u8>` is the content that goes AFTER the `promoted_index_size`
+/// VInt in the Index.db entry.
+fn serialize_promoted_index(blocks: &[PromotedIndexBlock]) -> Vec<u8> {
+    debug_assert!(blocks.len() >= 2, "caller must ensure at least 2 blocks");
+
+    // DeletionTime for a LIVE partition: single byte 0x80 (oa format, high bit = LIVE).
+    // Source: DeletionTime.java lines 210-219.
+    let deletion_time_bytes: &[u8] = &[0x80u8];
+    let header_length = deletion_time_bytes.len() as u64;
+
+    // --- Build IndexInfo bytes and accumulate per-block byte offsets ---
+    let mut index_info_bytes: Vec<u8> = Vec::new();
+    let mut block_start_offsets: Vec<u32> = Vec::with_capacity(blocks.len());
+
+    for block in blocks {
+        let block_offset_in_info = index_info_bytes.len() as u32;
+        block_start_offsets.push(block_offset_in_info);
+        serialize_index_info(&mut index_info_bytes, block);
+    }
+
+    // --- Assemble the full promoted index payload ---
+    let mut payload: Vec<u8> = Vec::new();
+
+    // headerLength (vint)
+    encode_unsigned(header_length, &mut payload);
+
+    // DeletionTime bytes
+    payload.extend_from_slice(deletion_time_bytes);
+
+    // count (vint): number of IndexInfo blocks
+    encode_unsigned(blocks.len() as u64, &mut payload);
+
+    // IndexInfo bytes
+    payload.extend_from_slice(&index_info_bytes);
+
+    // Offsets array: one i32 BE per block (signed, relative to first IndexInfo start)
+    // Source: RowIndexEntry.java line 640: `out.writeInt(offsets[i])`
+    for &offset in &block_start_offsets {
+        payload.extend_from_slice(&(offset as i32).to_be_bytes());
+    }
+
+    payload
+}
+
+/// Serialize one `IndexInfo` block.
+///
+/// Layout (Cassandra `IndexInfo.Serializer.serialize()` lines 107-117):
+/// ```text
+/// [firstName: ClusteringPrefix bytes]  ← min clustering key in block
+/// [lastName: ClusteringPrefix bytes]   ← max clustering key in block
+/// [offset: unsigned VInt]              ← byte offset from partition start
+/// [width: unsigned VInt]               ← actual_width - WIDTH_BASE (64 KiB)
+/// [endOpenMarker: u8]                  ← 0 = no open range tombstone
+/// ```
+fn serialize_index_info(buf: &mut Vec<u8>, block: &PromotedIndexBlock) {
+    // firstName clustering prefix bytes (already serialized by the data writer)
+    buf.extend_from_slice(&block.first_name);
+
+    // lastName clustering prefix bytes
+    buf.extend_from_slice(&block.last_name);
+
+    // offset (unsigned VInt)
+    encode_unsigned(block.offset, buf);
+
+    // width delta-encoded: (actual_width - WIDTH_BASE)
+    // Per Cassandra `IndexInfo.java` line 112: `out.writeUnsignedVInt(lastName.getEnd() - offset - WIDTH_BASE)`
+    // The value CAN underflow if width < WIDTH_BASE (unlikely in practice but safe via wrapping).
+    let width_delta = block.width.saturating_sub(INDEX_INFO_WIDTH_BASE);
+    encode_unsigned(width_delta, buf);
+
+    // endOpenMarker presence flag: 0 = no open marker (simple partitions)
+    buf.push(0u8);
 }
 
 #[cfg(test)]
@@ -477,5 +673,238 @@ mod tests {
         // Entry 2: 2 + 4 + 2 (VInt 250) + 1 = 9
         // Entry 3: 2 + 4 + 2 (VInt 500) + 1 = 9
         assert_eq!(bytes.len(), 26);
+    }
+
+    // ── Promoted index tests ────────────────────────────────────────────────
+
+    /// Small partition (1 block) → promoted_index_size = 0 (no regression).
+    #[test]
+    fn test_single_block_no_promoted_index() {
+        let mut writer = IndexWriter::new();
+        let key = DecoratedKey::new(100, vec![0x01, 0x02, 0x03, 0x04]);
+
+        // Only 1 block → should NOT emit promoted index
+        let block = PromotedIndexBlock {
+            first_name: vec![0x00], // empty CK prefix (just a 0-header VInt)
+            last_name: vec![0x00],
+            offset: 0,
+            width: 70_000,
+        };
+        let info = writer
+            .add_partition_with_promoted(&key, 0, &[block])
+            .unwrap();
+
+        let bytes = writer.finish().unwrap();
+
+        // promoted_index_size must be 0 for a single block
+        // Entry: 2 + 4 + 1(pos) + 1(promoted_len=0) = 8
+        assert_eq!(
+            bytes[info.entry_size - 1],
+            0x00,
+            "promoted size should be 0"
+        );
+        assert_eq!(info.entry_size, 8);
+    }
+
+    /// Two blocks → promoted_index_size > 0 and content is correct.
+    #[test]
+    fn test_two_blocks_emits_promoted_index() {
+        let mut writer = IndexWriter::new();
+        let key = DecoratedKey::new(100, vec![0x01, 0x02, 0x03, 0x04]);
+
+        // Minimal clustering prefix: header VInt 0x00 = no columns all-null/empty
+        let ck_prefix = vec![0x00u8];
+        let block1 = PromotedIndexBlock {
+            first_name: ck_prefix.clone(),
+            last_name: ck_prefix.clone(),
+            offset: 0,
+            width: 65_536, // exactly 64 KiB → delta = 0
+        };
+        let block2 = PromotedIndexBlock {
+            first_name: ck_prefix.clone(),
+            last_name: ck_prefix.clone(),
+            offset: 65_536,
+            width: 65_536,
+        };
+
+        let info = writer
+            .add_partition_with_promoted(&key, 0, &[block1, block2])
+            .unwrap();
+        let bytes = writer.finish().unwrap();
+
+        // The promoted_index_size vint must be > 0
+        let promoted_size_offset = 2 + 4 + 1; // key_len + key + pos vint(0)
+        assert!(
+            bytes[promoted_size_offset] > 0,
+            "promoted_index_size must be > 0 for 2 blocks"
+        );
+
+        // Verify the reader can parse it back (promoted bytes are present)
+        assert!(
+            info.entry_size > 8,
+            "Wide partition entry must be larger than small"
+        );
+    }
+
+    /// Wide partition (3 blocks): verify promoted_index_size matches actual payload.
+    #[test]
+    fn test_three_blocks_promoted_index_size_matches_payload() {
+        let key = DecoratedKey::new(42, vec![0xAA, 0xBB]);
+
+        // Serialize two clustering prefix bytes representing a TEXT value "ab"
+        // Cassandra clustering prefix: header VInt (2 bits per col, 0=PRESENT) then value
+        // For a single TEXT col with 2-byte value: header=0x00, value=[0x61, 0x62]
+        let ck_prefix = vec![0x00u8, 0x61, 0x62]; // header=present, value="ab"
+
+        let make_block = |off: u64, w: u64| PromotedIndexBlock {
+            first_name: ck_prefix.clone(),
+            last_name: ck_prefix.clone(),
+            offset: off,
+            width: w,
+        };
+
+        let blocks = vec![
+            make_block(0, 70_000),
+            make_block(70_000, 68_000),
+            make_block(138_000, 65_000),
+        ];
+
+        let mut writer = IndexWriter::new();
+        let info = writer
+            .add_partition_with_promoted(&key, 1234, &blocks)
+            .unwrap();
+        let bytes = writer.finish().unwrap();
+        assert_eq!(bytes.len(), info.entry_size);
+
+        // Parse promoted_index_size VInt at offset = 2(key_len) + 2(key) + pos_vint
+        // pos = 1234 → 2-byte VInt (0x80 | ...)
+        let pos_vint_len = 2; // 1234 > 127 → 2 bytes
+        let promoted_size_vint_start = 2 + 2 + pos_vint_len;
+        let promoted_size = parse_vint_simple(&bytes[promoted_size_vint_start..]);
+        let (promoted_size_value, promoted_size_vint_bytes) = promoted_size;
+
+        assert!(promoted_size_value > 0, "3 blocks → promoted index present");
+
+        let payload_start = promoted_size_vint_start + promoted_size_vint_bytes;
+        let payload_end = payload_start + promoted_size_value as usize;
+        assert_eq!(
+            payload_end,
+            bytes.len(),
+            "entry size should exactly cover key + vints + promoted payload"
+        );
+
+        // Verify promoted payload structure:
+        // [headerLength VInt][0x80][count VInt][IndexInfo*3][i32*3]
+        let payload = &bytes[payload_start..payload_end];
+        let (header_len, hl_bytes) = parse_vint_simple(payload);
+        assert_eq!(header_len, 1, "LIVE DeletionTime is 1 byte");
+        let deletion_byte = payload[hl_bytes];
+        assert_eq!(deletion_byte, 0x80, "LIVE DeletionTime marker = 0x80");
+
+        let (count, _) = parse_vint_simple(&payload[hl_bytes + header_len as usize..]);
+        assert_eq!(count, 3, "Three IndexInfo blocks");
+    }
+
+    /// Block boundary math: threshold crossing produces exactly one new block.
+    #[test]
+    fn test_block_boundary_math_threshold_crossing() {
+        // At exactly COLUMN_INDEX_SIZE_BYTES we cross the threshold and start a new block.
+        assert_eq!(COLUMN_INDEX_SIZE_BYTES, 64 * 1024);
+
+        // Simulate: data writer would produce a block at exactly the boundary.
+        // Two blocks: one below threshold + one at exactly the threshold.
+        let block_at_threshold = PromotedIndexBlock {
+            first_name: vec![0x00],
+            last_name: vec![0x00],
+            offset: COLUMN_INDEX_SIZE_BYTES,
+            width: COLUMN_INDEX_SIZE_BYTES,
+        };
+        let block_below = PromotedIndexBlock {
+            first_name: vec![0x00],
+            last_name: vec![0x00],
+            offset: 0,
+            width: COLUMN_INDEX_SIZE_BYTES,
+        };
+
+        let blocks = vec![block_below, block_at_threshold];
+        let payload = serialize_promoted_index(&blocks);
+
+        // Payload must be non-empty (promoted index present)
+        assert!(!payload.is_empty());
+        // Count in payload must be 2.
+        // Payload layout: [headerLength vint][DeletionTime bytes][count vint][...]
+        let (header_len, hl_bytes) = parse_vint_simple(&payload);
+        let (count, _) = parse_vint_simple(&payload[hl_bytes + header_len as usize..]);
+        assert_eq!(count, 2);
+    }
+
+    /// Width delta encoding: exact 64KiB block → delta = 0.
+    #[test]
+    fn test_width_delta_encoding_exact_threshold() {
+        // A block that is exactly 64KiB should encode width delta = 0
+        let block = PromotedIndexBlock {
+            first_name: vec![0x00],
+            last_name: vec![0x00],
+            offset: 0,
+            width: INDEX_INFO_WIDTH_BASE, // 64 KiB
+        };
+        let block2 = PromotedIndexBlock {
+            first_name: vec![0x00],
+            last_name: vec![0x00],
+            offset: INDEX_INFO_WIDTH_BASE,
+            width: INDEX_INFO_WIDTH_BASE,
+        };
+
+        let mut info_bytes: Vec<u8> = Vec::new();
+        serialize_index_info(&mut info_bytes, &block);
+
+        // firstName=0x00, lastName=0x00, offset=0x00, width_delta=0x00, endOpenMarker=0x00
+        // All are single-byte VInts/bytes when value = 0.
+        assert_eq!(info_bytes, vec![0x00, 0x00, 0x00, 0x00, 0x00]);
+
+        // Also verify with 2-block payload that the width field is 0
+        let payload = serialize_promoted_index(&[block, block2]);
+        assert!(!payload.is_empty());
+    }
+
+    /// Clustering prefix min/max: bytes are preserved verbatim.
+    #[test]
+    fn test_clustering_prefix_preserved_verbatim() {
+        let first_name = vec![0x00u8, 0x01, 0x02]; // arbitrary bytes
+        let last_name = vec![0x00u8, 0xFF, 0xFE];
+
+        let block1 = PromotedIndexBlock {
+            first_name: first_name.clone(),
+            last_name: last_name.clone(),
+            offset: 0,
+            width: 100_000,
+        };
+        let mut info_bytes: Vec<u8> = Vec::new();
+        serialize_index_info(&mut info_bytes, &block1);
+
+        // firstName bytes appear first
+        assert_eq!(&info_bytes[0..3], &first_name[..]);
+        // lastName bytes appear next
+        assert_eq!(&info_bytes[3..6], &last_name[..]);
+    }
+
+    // Helper: parse a Cassandra unsigned VInt and return (value, bytes_consumed)
+    fn parse_vint_simple(buf: &[u8]) -> (u64, usize) {
+        if buf.is_empty() {
+            return (0, 0);
+        }
+        let first = buf[0];
+        if first <= 0x7F {
+            return (first as u64, 1);
+        }
+        // Count leading 1s to get number of extra bytes
+        let leading = first.leading_ones() as usize;
+        let extra_bits = 8 - leading - 1; // data bits in first byte
+        let mask = (1u8 << extra_bits).wrapping_sub(1);
+        let mut value = (first & mask) as u64;
+        for b in buf.iter().take(leading + 1).skip(1) {
+            value = (value << 8) | *b as u64;
+        }
+        (value, 1 + leading)
     }
 }

--- a/cqlite-core/src/storage/sstable/writer/index_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/index_writer.rs
@@ -27,11 +27,14 @@
 //! (Cassandra `RowIndexEntry.create()` lines 227-239). The promoted index payload is:
 //!
 //! ```text
-//! [headerLength: unsigned VInt]    ← byte count of the DeletionTime blob below
-//! [DeletionTime: headerLength bytes] ← partition header deletion ("oa": 0x80 = LIVE)
+//! [headerLength: unsigned VInt]    ← Data.db byte offset from partition start to first row
+//!                                    (NB format, no static rows: 2 + key_len + 12)
+//! [DeletionTime: 12 bytes]         ← partition-level DeletionTime in NB legacy format:
+//!                                    [localDeletionTime: i32 BE][markedForDeleteAt: i64 BE]
+//!                                    LIVE = Integer.MAX_VALUE + Long.MIN_VALUE
 //! [count: unsigned VInt]           ← number of IndexInfo blocks
 //! [IndexInfo[0]..]                 ← IndexInfo blocks (see PromotedIndexBlock)
-//! [offset[0]: i32 BE] ...          ← relative offsets from first IndexInfo, one per block
+//! [offset[0]: i32 BE] ...          ← relative offsets from first IndexInfo start, one per block
 //! ```
 //!
 //! Each `IndexInfo` block:
@@ -39,14 +42,16 @@
 //! [firstName: ClusteringPrefix]    ← min clustering key in block (vint header + values)
 //! [lastName: ClusteringPrefix]     ← max clustering key in block
 //! [offset: unsigned VInt]          ← byte offset from partition start
-//! [width: unsigned VInt]           ← (actual_width - WIDTH_BASE) where WIDTH_BASE = 64 KiB
-//! [endOpenMarker: u8]              ← 0 = no open range tombstone marker
+//! [width: signed VInt]             ← (actual_width - WIDTH_BASE) where WIDTH_BASE = 64 KiB,
+//!                                    zigzag-encoded (Cassandra writeVInt)
+//! [endOpenMarker: bool byte]       ← 0x00 = no open range tombstone marker
 //! ```
 //!
 //! Sources:
-//! - `RowIndexEntry.java` lines 293-296 (BIG "oa" serialization)
-//! - `IndexInfo.Serializer.serialize()` lines 107-117
-//! - `DeletionTime.java` lines 210-219 ("oa" format: mfda first, then ldt unsigned)
+//! - `RowIndexEntry.IndexedEntry.serialize()` (BIG "nb" serialization)
+//! - `IndexInfo.Serializer.serialize()` lines 119-128
+//! - `DeletionTime.LegacySerializer.serialize()` (NB "nb" format: ldt i32 BE, then mfda i64 BE)
+//! - `SortedTablePartitionWriter.getHeaderLength()` (Data.db header byte count)
 //!
 //! ## Key Requirements
 //!
@@ -60,7 +65,7 @@
 //! - `cqlite-core/src/storage/sstable/index_reader.rs` - BIG format parser
 
 use crate::error::Result;
-use crate::storage::serialization::vint::encode_unsigned;
+use crate::storage::serialization::vint::{encode_signed, encode_unsigned};
 use crate::storage::write_engine::mutation::DecoratedKey;
 
 /// Threshold at which a new IndexInfo block is emitted (Cassandra default 64 KiB).
@@ -211,7 +216,7 @@ impl IndexWriter {
 
     /// Write a single index entry to the buffer.
     ///
-    /// Cassandra BIG format Index.db entry (NB "oa" variant):
+    /// Cassandra BIG format Index.db entry (NB variant):
     /// ```text
     /// [key_len: u16 BE]                    ← Length of raw partition key
     /// [key_bytes: key_len bytes]           ← Raw partition key bytes
@@ -240,7 +245,7 @@ impl IndexWriter {
         // Only emit a promoted index when there are 2+ blocks
         // (Cassandra RowIndexEntry.create() gates on columnIndexCount > 1)
         if blocks.len() >= 2 {
-            let promoted_payload = serialize_promoted_index(blocks);
+            let promoted_payload = serialize_promoted_index(blocks, key.key.len());
             encode_unsigned(promoted_payload.len() as u64, &mut self.buffer);
             self.buffer.extend_from_slice(&promoted_payload);
         } else {
@@ -297,12 +302,23 @@ impl Default for IndexWriter {
     }
 }
 
+/// Byte size of a LIVE `DeletionTime` in the NB (legacy) serializer.
+///
+/// Cassandra NB format uses `DeletionTime.LegacySerializer`:
+///   [localDeletionTime: i32 BE = Integer.MAX_VALUE][markedForDeleteAt: i64 BE = Long.MIN_VALUE]
+/// = 4 + 8 = 12 bytes.
+///
+/// Source: `DeletionTime.LegacySerializer.serialize()` and `serializedSize()`.
+const NB_DELETION_TIME_LIVE_SIZE: usize = 12;
+
 /// Serialize the promoted index payload for a wide partition.
 ///
-/// Layout (Cassandra BIG "oa" format, `RowIndexEntry.Serializer.serialize()`):
+/// Layout (Cassandra BIG "nb" format, `RowIndexEntry.IndexedEntry.serialize()`):
 /// ```text
-/// [headerLength: unsigned VInt]    ← byte count of DeletionTime below
-/// [DeletionTime: 1 byte = 0x80]   ← LIVE partition header (oa single-byte form)
+/// [headerLength: unsigned VInt]    ← Data.db bytes from partition start to first row
+///                                    = 2 (key_len short) + raw_key_len + 12 (NB DeletionTime)
+/// [DeletionTime: 12 bytes]         ← LIVE in NB legacy format:
+///                                    [i32 BE: Integer.MAX_VALUE][i64 BE: Long.MIN_VALUE]
 /// [count: unsigned VInt]           ← number of IndexInfo blocks
 /// [IndexInfo[0]..]                 ← serialized blocks in order
 /// [offset[0]: i32 BE]             ← relative offsets from first IndexInfo start
@@ -310,15 +326,36 @@ impl Default for IndexWriter {
 /// [offset[N-1]: i32 BE]
 /// ```
 ///
+/// `raw_key_len` is the length of the raw partition key bytes (not counting the 2-byte prefix).
+///
 /// The returned `Vec<u8>` is the content that goes AFTER the `promoted_index_size`
 /// VInt in the Index.db entry.
-fn serialize_promoted_index(blocks: &[PromotedIndexBlock]) -> Vec<u8> {
+///
+/// # Correctness notes
+///
+/// - `headerLength` must match `SortedTablePartitionWriter.getHeaderLength()` in Cassandra,
+///   which is the Data.db byte offset to the first non-header unfiltered row.
+///   For CQLite-written "nb" partitions without static rows this is fixed:
+///   `2 + raw_key_len + NB_DELETION_TIME_LIVE_SIZE`.
+/// - DeletionTime must use the "nb" `LegacySerializer` (ldt i32 BE, then mfda i64 BE),
+///   NOT the "oa" single-byte `0x80` form.
+/// - `IndexInfo.width` must be written as a signed VInt (zigzag), not unsigned VInt,
+///   matching Cassandra's `writeVInt(width - WIDTH_BASE)`.
+fn serialize_promoted_index(blocks: &[PromotedIndexBlock], raw_key_len: usize) -> Vec<u8> {
     debug_assert!(blocks.len() >= 2, "caller must ensure at least 2 blocks");
 
-    // DeletionTime for a LIVE partition: single byte 0x80 (oa format, high bit = LIVE).
-    // Source: DeletionTime.java lines 210-219.
-    let deletion_time_bytes: &[u8] = &[0x80u8];
-    let header_length = deletion_time_bytes.len() as u64;
+    // headerLength: Data.db byte count from partition start to the first clustering row.
+    // For "nb" (no static columns): 2-byte key_len prefix + raw key bytes + 12-byte DeletionTime.
+    // Source: SortedTablePartitionWriter.start() + addStaticRow() → getHeaderLength().
+    let header_length: u64 = (2 + raw_key_len + NB_DELETION_TIME_LIVE_SIZE) as u64;
+
+    // LIVE DeletionTime in NB (legacy) format:
+    //   localDeletionTime = Integer.MAX_VALUE = 0x7FFFFFFF (i32 BE)
+    //   markedForDeleteAt = Long.MIN_VALUE    = 0x8000000000000000 (i64 BE)
+    // Source: DeletionTime.LegacySerializer.serialize(), serializedSize() = 12.
+    let mut deletion_time_bytes = [0u8; NB_DELETION_TIME_LIVE_SIZE];
+    deletion_time_bytes[0..4].copy_from_slice(&i32::MAX.to_be_bytes());
+    deletion_time_bytes[4..12].copy_from_slice(&i64::MIN.to_be_bytes());
 
     // --- Build IndexInfo bytes and accumulate per-block byte offsets ---
     let mut index_info_bytes: Vec<u8> = Vec::new();
@@ -333,20 +370,20 @@ fn serialize_promoted_index(blocks: &[PromotedIndexBlock]) -> Vec<u8> {
     // --- Assemble the full promoted index payload ---
     let mut payload: Vec<u8> = Vec::new();
 
-    // headerLength (vint)
+    // headerLength (unsigned VInt)
     encode_unsigned(header_length, &mut payload);
 
-    // DeletionTime bytes
-    payload.extend_from_slice(deletion_time_bytes);
+    // DeletionTime bytes (12-byte NB legacy LIVE form)
+    payload.extend_from_slice(&deletion_time_bytes);
 
-    // count (vint): number of IndexInfo blocks
+    // count (unsigned VInt): number of IndexInfo blocks
     encode_unsigned(blocks.len() as u64, &mut payload);
 
     // IndexInfo bytes
     payload.extend_from_slice(&index_info_bytes);
 
     // Offsets array: one i32 BE per block (signed, relative to first IndexInfo start)
-    // Source: RowIndexEntry.java line 640: `out.writeInt(offsets[i])`
+    // Source: RowIndexEntry.IndexedEntry.serialize() → `out.writeInt(offsets[i])`
     for &offset in &block_start_offsets {
         payload.extend_from_slice(&(offset as i32).to_be_bytes());
     }
@@ -356,14 +393,20 @@ fn serialize_promoted_index(blocks: &[PromotedIndexBlock]) -> Vec<u8> {
 
 /// Serialize one `IndexInfo` block.
 ///
-/// Layout (Cassandra `IndexInfo.Serializer.serialize()` lines 107-117):
+/// Layout (Cassandra `IndexInfo.Serializer.serialize()` lines 119-128):
 /// ```text
 /// [firstName: ClusteringPrefix bytes]  ← min clustering key in block
 /// [lastName: ClusteringPrefix bytes]   ← max clustering key in block
 /// [offset: unsigned VInt]              ← byte offset from partition start
-/// [width: unsigned VInt]               ← actual_width - WIDTH_BASE (64 KiB)
-/// [endOpenMarker: u8]                  ← 0 = no open range tombstone
+/// [width: signed VInt]                 ← (actual_width - WIDTH_BASE), zigzag-encoded
+///                                        Cassandra uses writeVInt (not writeUnsignedVInt)
+/// [endOpenMarker: bool byte]           ← 0x00 = no open range tombstone
 /// ```
+///
+/// IMPORTANT: `width - WIDTH_BASE` is written as a **signed** VInt (zigzag encoding),
+/// not an unsigned VInt.  Cassandra's `IndexInfo.Serializer.serialize()` line 124:
+/// `out.writeVInt(info.width - WIDTH_BASE)`.  For a width exactly equal to WIDTH_BASE,
+/// the delta is 0 and both encodings produce `0x00`, but for any other value they differ.
 fn serialize_index_info(buf: &mut Vec<u8>, block: &PromotedIndexBlock) {
     // firstName clustering prefix bytes (already serialized by the data writer)
     buf.extend_from_slice(&block.first_name);
@@ -374,14 +417,16 @@ fn serialize_index_info(buf: &mut Vec<u8>, block: &PromotedIndexBlock) {
     // offset (unsigned VInt)
     encode_unsigned(block.offset, buf);
 
-    // width delta-encoded: (actual_width - WIDTH_BASE)
-    // Per Cassandra `IndexInfo.java` line 112: `out.writeUnsignedVInt(lastName.getEnd() - offset - WIDTH_BASE)`
-    // The value CAN underflow if width < WIDTH_BASE (unlikely in practice but safe via wrapping).
-    let width_delta = block.width.saturating_sub(INDEX_INFO_WIDTH_BASE);
-    encode_unsigned(width_delta, buf);
+    // width delta: (actual_width - WIDTH_BASE), written as signed VInt (zigzag).
+    // Cassandra: `out.writeVInt(info.width - WIDTH_BASE)` — writeVInt uses zigzag encoding.
+    // We cast to i64 to allow negative delta (width < WIDTH_BASE), which encodes as a small
+    // negative zigzag value; in practice widths are >= WIDTH_BASE but the format supports it.
+    let width_delta = (block.width as i64) - (INDEX_INFO_WIDTH_BASE as i64);
+    encode_signed(width_delta, buf);
 
-    // endOpenMarker presence flag: 0 = no open marker (simple partitions)
-    buf.push(0u8);
+    // endOpenMarker presence: writeBoolean(false) = 0x00 for no open tombstone
+    // Source: IndexInfo.Serializer.serialize() line 126: `out.writeBoolean(info.endOpenMarker != null)`
+    buf.push(0x00u8);
 }
 
 #[cfg(test)]
@@ -793,15 +838,26 @@ mod tests {
             "entry size should exactly cover key + vints + promoted payload"
         );
 
-        // Verify promoted payload structure:
-        // [headerLength VInt][0x80][count VInt][IndexInfo*3][i32*3]
+        // Verify promoted payload structure (NB format):
+        // [headerLength VInt][DeletionTime: 12 bytes][count VInt][IndexInfo*3][i32*3]
+        //
+        // key = [0xAA, 0xBB] (len=2), so headerLength = 2 + 2 + 12 = 16
         let payload = &bytes[payload_start..payload_end];
         let (header_len, hl_bytes) = parse_vint_simple(payload);
-        assert_eq!(header_len, 1, "LIVE DeletionTime is 1 byte");
-        let deletion_byte = payload[hl_bytes];
-        assert_eq!(deletion_byte, 0x80, "LIVE DeletionTime marker = 0x80");
+        assert_eq!(
+            header_len, 16,
+            "headerLength = 2 (key_len_prefix) + 2 (key bytes) + 12 (NB DeletionTime) = 16"
+        );
 
-        let (count, _) = parse_vint_simple(&payload[hl_bytes + header_len as usize..]);
+        // DeletionTime: [i32 BE: i32::MAX][i64 BE: i64::MIN] = 12 bytes
+        let dt_start = hl_bytes;
+        let dt_end = dt_start + NB_DELETION_TIME_LIVE_SIZE;
+        let ldt = i32::from_be_bytes(payload[dt_start..dt_start + 4].try_into().unwrap());
+        let mfda = i64::from_be_bytes(payload[dt_start + 4..dt_end].try_into().unwrap());
+        assert_eq!(ldt, i32::MAX, "NB LIVE DeletionTime: ldt = i32::MAX");
+        assert_eq!(mfda, i64::MIN, "NB LIVE DeletionTime: mfda = i64::MIN");
+
+        let (count, _) = parse_vint_simple(&payload[dt_end..]);
         assert_eq!(count, 3, "Three IndexInfo blocks");
     }
 
@@ -826,15 +882,20 @@ mod tests {
             width: COLUMN_INDEX_SIZE_BYTES,
         };
 
+        // Use a 4-byte raw key for a fixed, predictable headerLength = 2 + 4 + 12 = 18.
+        let raw_key_len = 4usize;
         let blocks = vec![block_below, block_at_threshold];
-        let payload = serialize_promoted_index(&blocks);
+        let payload = serialize_promoted_index(&blocks, raw_key_len);
 
         // Payload must be non-empty (promoted index present)
         assert!(!payload.is_empty());
         // Count in payload must be 2.
-        // Payload layout: [headerLength vint][DeletionTime bytes][count vint][...]
+        // Payload layout: [headerLength vint][DeletionTime 12 bytes][count vint][...]
         let (header_len, hl_bytes) = parse_vint_simple(&payload);
-        let (count, _) = parse_vint_simple(&payload[hl_bytes + header_len as usize..]);
+        // headerLength = 2 + 4 + 12 = 18
+        assert_eq!(header_len, 18, "headerLength for a 4-byte key = 2 + 4 + 12 = 18");
+        let dt_skip = NB_DELETION_TIME_LIVE_SIZE;
+        let (count, _) = parse_vint_simple(&payload[hl_bytes + dt_skip..]);
         assert_eq!(count, 2);
     }
 
@@ -862,8 +923,8 @@ mod tests {
         // All are single-byte VInts/bytes when value = 0.
         assert_eq!(info_bytes, vec![0x00, 0x00, 0x00, 0x00, 0x00]);
 
-        // Also verify with 2-block payload that the width field is 0
-        let payload = serialize_promoted_index(&[block, block2]);
+        // Also verify with 2-block payload that the width field is 0 (use a 4-byte key).
+        let payload = serialize_promoted_index(&[block, block2], 4);
         assert!(!payload.is_empty());
     }
 

--- a/cqlite-core/src/storage/sstable/writer/index_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/index_writer.rs
@@ -893,7 +893,10 @@ mod tests {
         // Payload layout: [headerLength vint][DeletionTime 12 bytes][count vint][...]
         let (header_len, hl_bytes) = parse_vint_simple(&payload);
         // headerLength = 2 + 4 + 12 = 18
-        assert_eq!(header_len, 18, "headerLength for a 4-byte key = 2 + 4 + 12 = 18");
+        assert_eq!(
+            header_len, 18,
+            "headerLength for a 4-byte key = 2 + 4 + 12 = 18"
+        );
         let dt_skip = NB_DELETION_TIME_LIVE_SIZE;
         let (count, _) = parse_vint_simple(&payload[hl_bytes + dt_skip..]);
         assert_eq!(count, 2);

--- a/cqlite-core/src/storage/sstable/writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/mod.rs
@@ -62,7 +62,9 @@ pub use digest_writer::DigestWriter;
 #[cfg(feature = "write-support")]
 pub use filter_writer::FilterWriter;
 #[cfg(feature = "write-support")]
-pub use index_writer::{IndexEntryInfo, IndexWriter};
+pub use index_writer::{
+    IndexEntryInfo, IndexWriter, PromotedIndexBlock, COLUMN_INDEX_SIZE_BYTES, INDEX_INFO_WIDTH_BASE,
+};
 #[cfg(feature = "write-support")]
 pub use stats_writer::{StatisticsMetadata, StatisticsWriter};
 #[cfg(feature = "write-support")]
@@ -416,8 +418,10 @@ impl SSTableWriter {
             .cloned()
             .collect();
 
-        // Write partition to Data.db and get offset
-        let data_offset = self.data_writer.write_partition(
+        // Write partition to Data.db, collecting promoted index blocks for wide partitions.
+        // Wide partitions (≥ 64 KiB of row data) get a non-zero promoted index so Cassandra
+        // can seek directly to a clustering-key range without reading the full partition.
+        let (data_offset, promoted_blocks) = self.data_writer.write_partition_with_index_blocks(
             &key,
             &mutations,
             &self.schema,
@@ -425,9 +429,12 @@ impl SSTableWriter {
             &range_tombstones,
         )?;
 
-        // Add partition to Index.db and get entry info
-        // IMPORTANT: Capture index_offset AFTER the entry is written to Index.db
-        let entry_info = self.index_writer.add_partition(&key, data_offset)?;
+        // Add partition to Index.db and get entry info.
+        // Pass promoted blocks (writer gates on >= 2 blocks before emitting payload).
+        // IMPORTANT: Capture index_offset AFTER the entry is written to Index.db.
+        let entry_info =
+            self.index_writer
+                .add_partition_with_promoted(&key, data_offset, &promoted_blocks)?;
 
         // Add partition key to Filter.db
         if let Some(ref mut filter) = self.filter_writer {

--- a/cqlite-core/tests/write_read_roundtrip.rs
+++ b/cqlite-core/tests/write_read_roundtrip.rs
@@ -49,6 +49,8 @@ mod statistics;
 mod summary;
 #[path = "write_read_roundtrip/type_coverage.rs"]
 mod type_coverage;
+#[path = "write_read_roundtrip/wide_partition.rs"]
+mod wide_partition;
 
 use cqlite_core::platform::Platform;
 use cqlite_core::schema::{

--- a/cqlite-core/tests/write_read_roundtrip/wide_partition.rs
+++ b/cqlite-core/tests/write_read_roundtrip/wide_partition.rs
@@ -1,0 +1,197 @@
+//! Wide Partition Promoted Index E2E Tests (Issue #752)
+//!
+//! Verifies that:
+//! - Wide partitions (data > 64 KiB) produce a non-zero `promoted_index_len` in Index.db.
+//! - Small partitions (data < 64 KiB) still produce `promoted_index_len = 0` (no regression).
+//! - The written SSTable is readable back through SSTableManager.
+
+#![cfg(feature = "write-support")]
+
+use super::{create_clustered_mutation, create_clustering_schema};
+use cqlite_core::platform::Platform;
+use cqlite_core::storage::write_engine::{WriteEngine, WriteEngineConfig};
+use std::sync::Arc;
+use tempfile::TempDir;
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+/// Decode one Cassandra unsigned VInt from the start of `bytes`.
+/// Returns (value, bytes_consumed).
+fn read_vuint(bytes: &[u8]) -> (u64, usize) {
+    assert!(!bytes.is_empty(), "empty slice passed to read_vuint");
+    let first = bytes[0];
+    if first < 0x80 {
+        return (first as u64, 1);
+    }
+    // Count leading ones in the first byte to determine extra bytes.
+    let extra = first.leading_ones() as usize; // 1..=8
+    assert!(extra <= 8, "malformed VUInt: too many leading ones");
+    let mask = 0xFF_u8 >> extra; // bits in first byte that carry value
+    let mut value = (first & mask) as u64;
+    for &b in bytes[1..=extra].iter() {
+        value = (value << 8) | b as u64;
+    }
+    (value, 1 + extra)
+}
+
+/// Read the promoted_index_len field for the **first** entry in a raw Index.db buffer.
+///
+/// Layout per entry: `[key_len: u16 BE][raw key bytes][data_offset: vuint][promoted_len: vuint]`.
+fn first_entry_promoted_len(index_bytes: &[u8]) -> u64 {
+    assert!(
+        index_bytes.len() >= 2,
+        "Index.db too short to contain key_len"
+    );
+
+    // key_len (u16 BE)
+    let key_len = u16::from_be_bytes([index_bytes[0], index_bytes[1]]) as usize;
+    let mut pos = 2 + key_len; // skip key_len + raw key bytes
+
+    // data_offset (vuint)
+    let (_, consumed) = read_vuint(&index_bytes[pos..]);
+    pos += consumed;
+
+    // promoted_len (vuint)
+    let (promoted_len, _) = read_vuint(&index_bytes[pos..]);
+    promoted_len
+}
+
+// ─── tests ───────────────────────────────────────────────────────────────────
+
+/// Small partition (1 row, data << 64 KiB): promoted_index_len must be 0.
+#[tokio::test]
+async fn test_small_partition_no_promoted_index() {
+    let temp_dir = TempDir::new().unwrap();
+    let schema = create_clustering_schema();
+
+    let config = WriteEngineConfig::new(
+        temp_dir.path().join("data"),
+        temp_dir.path().join("wal"),
+        schema.clone(),
+    );
+    let mut engine = WriteEngine::new(config).expect("Engine creation should succeed");
+
+    // Write a single row — nowhere near 64 KiB.
+    let mutation = create_clustered_mutation(1, "ck_only", "a small value", 1_000_000);
+    engine
+        .write_async(mutation)
+        .await
+        .expect("Write should succeed");
+
+    let info = engine
+        .flush()
+        .await
+        .expect("Flush should succeed")
+        .expect("Should return SSTableInfo");
+
+    let index_bytes = std::fs::read(&info.index_path).expect("Should read Index.db");
+    let promoted_len = first_entry_promoted_len(&index_bytes);
+    assert_eq!(
+        promoted_len, 0,
+        "Small partition must have promoted_index_len=0, got {}",
+        promoted_len
+    );
+}
+
+/// Wide partition: write one partition key with enough clustered rows so that
+/// the serialized uncompressed data exceeds 2 × 64 KiB = 128 KiB.  That
+/// triggers at least 2 IndexInfo blocks, which is the gate for emitting the
+/// promoted index in `IndexWriter::add_partition_with_promoted`.
+///
+/// Assertion: the first (and only) Index.db entry has `promoted_index_len > 0`.
+#[tokio::test]
+async fn test_wide_partition_emits_promoted_index() {
+    let temp_dir = TempDir::new().unwrap();
+    let schema = create_clustering_schema();
+
+    let config = WriteEngineConfig::new(
+        temp_dir.path().join("data"),
+        temp_dir.path().join("wal"),
+        schema.clone(),
+    );
+    let mut engine = WriteEngine::new(config).expect("Engine creation should succeed");
+
+    // Each row: ck ~8 bytes + data ~200 bytes → ~210 bytes/row.
+    // 1 000 rows ≈ 210 KB >> 2 × 64 KiB (128 KiB).
+    // All rows share the same partition key (pk=42) → wide single partition.
+    const N_ROWS: usize = 1_000;
+    // 190-byte padding to make each row's data field clearly over 200 bytes total.
+    let padding: String = "x".repeat(190);
+    for i in 0..N_ROWS {
+        let ck = format!("ck_{:06}", i);
+        let data = format!("data_{}_{}", i, padding);
+        let mutation = create_clustered_mutation(42, &ck, &data, 1_000_000 + i as i64);
+        engine
+            .write_async(mutation)
+            .await
+            .expect("Write should succeed");
+    }
+
+    let info = engine
+        .flush()
+        .await
+        .expect("Flush should succeed")
+        .expect("Should return SSTableInfo");
+
+    // ── 1. Index.db must have non-zero promoted_index_len ──────────────────
+    let index_bytes = std::fs::read(&info.index_path).expect("Should read Index.db");
+    let promoted_len = first_entry_promoted_len(&index_bytes);
+    assert!(
+        promoted_len > 0,
+        "Wide partition ({}B data file) must have promoted_index_len > 0, got 0. \
+         Check that DataWriter::write_partition_with_index_blocks is crossing the 64 KiB boundary.",
+        std::fs::metadata(&info.data_path)
+            .map(|m| m.len())
+            .unwrap_or(0)
+    );
+
+    // ── 2. Our own reader must be able to open the Index.db ────────────────
+    let cqlite_config = cqlite_core::Config::default();
+    let platform = Arc::new(
+        Platform::new(&cqlite_config)
+            .await
+            .expect("Platform creation"),
+    );
+    let reader =
+        cqlite_core::storage::sstable::index_reader::IndexReader::open(&info.index_path, platform)
+            .await
+            .expect("IndexReader must open wide-partition Index.db without error");
+
+    let entries = reader.get_partition_entries();
+    assert_eq!(
+        entries.len(),
+        1,
+        "Should have exactly 1 partition entry (pk=42), got {}",
+        entries.len()
+    );
+
+    // ── 3. SSTableManager must scan back all rows ──────────────────────────
+    let platform2 = Arc::new(
+        Platform::new(&cqlite_config)
+            .await
+            .expect("Platform creation"),
+    );
+    let manager = cqlite_core::storage::sstable::SSTableManager::new(
+        &temp_dir.path().join("data"),
+        &cqlite_config,
+        platform2,
+        #[cfg(feature = "state_machine")]
+        None,
+    )
+    .await
+    .expect("SSTableManager must load wide-partition SSTable");
+
+    let table_id = cqlite_core::types::TableId::from("test_roundtrip.clustered");
+    let results = manager
+        .scan(&table_id, None, None, None, Some(&schema))
+        .await
+        .expect("Scan must succeed on wide-partition SSTable");
+
+    assert_eq!(
+        results.len(),
+        N_ROWS,
+        "SSTableManager must read back all {} rows from the wide partition, got {}",
+        N_ROWS,
+        results.len()
+    );
+}


### PR DESCRIPTION
Part of Epic #751. Closes #752.

## What this does
The Index.db writer previously hardcoded `promoted_index_length=0`, so partitions CQLite wrote never got within-partition index blocks. This emits a real promoted index (RowIndexEntry with IndexInfo blocks) when a partition's row data exceeds the 64 KiB column-index threshold (`COLUMN_INDEX_SIZE_BYTES`), with 2+ blocks; small partitions still write `0`.

- `data_writer.rs`: tracks 64 KiB boundaries as rows are written, building `PromotedIndexBlock`s with serialized first/last clustering prefixes + offsets per block.
- `index_writer.rs`: `add_partition_with_promoted()` serializes the **BIG "nb"** RowIndexEntry promoted index and gates on 2+ blocks.
- `mod.rs`: wires the data-write block tracking into the index entry.

## Format correctness (the load-bearing part)
CQLite stamps BIG **"nb"** format. The first cut accidentally used **"oa"** (Cassandra 5.0) encodings for the promoted index, which Cassandra would reject. Verified byte-for-byte against Cassandra's own serializers (`~/local_projects/cassandra`) and fixed three bugs:
1. **DeletionTime**: "nb" uses `DeletionTime.LegacySerializer` = `[i32 BE Integer.MAX_VALUE][i64 BE Long.MIN_VALUE]` (12 bytes), not the "oa" single-byte `0x80`.
2. **headerLength**: must be the Data.db offset from partition start to the first row (`2 + key_len + 12`), not the deletion-byte count.
3. **IndexInfo.width**: Cassandra writes `width - WIDTH_BASE` as a **signed/zigzag** VInt (`writeVInt`), not plain unsigned (identical only at delta=0, which masked the bug).

## Validation
- **Real Cassandra round-trip**: `cassandra:5.0` `sstabledump` on a CQLite-written wide (>192 KiB, 3-block) partition → **exit 0, 1 partition, 1000 rows, zero errors**, `position: 18` confirming `headerLength` read correctly. Reproducible via `cargo run -p cqlite-core --example gen_wide_sstable --features write-support`.
- Unit tests cover block-boundary math (threshold crossing, single/multi-block, prefix min/max, width-delta zigzag, 12-byte DeletionTime).
- `tests/write_read_roundtrip/wide_partition.rs`: small partition stays `promoted_index_len=0`; wide partition emits non-zero and round-trips through CQLite's reader.

## Gate (scripts/agent-gate.sh)
```
fmt: PASS  clippy: PASS  core-tests: PASS  integration-tests: PASS
write-tests: PASS  cli-tests: PASS  minimal-build: PASS  smoke: PASS
RESULT: PASS
```