### PR TITLE
feat(bti): extract Data.db offsets from BTI trie payloads for O(log n) seeks (#755)

### DIFF
--- a/cqlite-core/src/storage/sstable/bti/mod.rs
+++ b/cqlite-core/src/storage/sstable/bti/mod.rs
@@ -15,7 +15,10 @@ pub use node::{
     BtiError, BtiNode, BtiNodeData, BtiNodeType, BtiResult, PayloadRef, SizedPointer, Transition,
     TrieNavigator,
 };
-pub use parser::{BtiHeader, BtiIndexStats, PartitionsParser, RowsParser};
+pub use parser::{
+    lookup_partition_in_bti_file, BtiHeader, BtiIndexStats, BtiPartitionLocation, PartitionsParser,
+    RowsParser, FLAG_HAS_HASH_BYTE,
+};
 
 use crate::parser::header::CassandraVersion;
 use std::collections::HashMap;

--- a/cqlite-core/src/storage/sstable/bti/mod.rs
+++ b/cqlite-core/src/storage/sstable/bti/mod.rs
@@ -16,8 +16,9 @@ pub use node::{
     TrieNavigator,
 };
 pub use parser::{
-    lookup_partition_in_bti_file, BtiHeader, BtiIndexStats, BtiPartitionLocation, PartitionsParser,
-    RowsParser, FLAG_HAS_HASH_BYTE,
+    decode_bti_partition_payload, encode_partition_key_for_bti_trie, lookup_partition_in_bti_file,
+    lookup_raw_key_in_bti_partitions_db, BtiHeader, BtiIndexStats, BtiPartitionLocation,
+    PartitionsParser, RowsParser, FLAG_HAS_HASH_BYTE,
 };
 
 use crate::parser::header::CassandraVersion;

--- a/cqlite-core/src/storage/sstable/bti/parser.rs
+++ b/cqlite-core/src/storage/sstable/bti/parser.rs
@@ -811,6 +811,23 @@ fn payload_start_in_node(node: &BtiNode, trie_data: &[u8], node_offset: usize) -
 /// - `Err(_)` on structural parse errors.
 ///
 /// This is the inner engine for [`lookup_partition_in_bti_file`].
+/// Walk the BTI partition trie loaded in `trie_data`, looking for a partition
+/// whose **byte-comparable** encoded key *prefix* routes to a leaf.
+///
+/// Cassandra BTI uses a **path-compressed (Patricia) trie**: once a path leads to
+/// a `PayloadOnly` leaf, the remaining key bytes are stored implicitly (as the
+/// compressed suffix).  Therefore a match is declared as soon as a `PayloadOnly`
+/// leaf is reached — regardless of whether the encoded key has been fully consumed.
+/// The caller is responsible for verifying the actual partition key against the
+/// Data.db bytes at the resolved offset (using the partition's hash byte for a
+/// fast pre-filter and the raw key bytes for definitive confirmation).
+///
+/// Returns:
+/// - `Ok(Some(BtiPartitionLocation))` when a leaf is reached.
+/// - `Ok(None)` when no transition exists for a key byte (key not in trie).
+/// - `Err(_)` on structural parse errors.
+///
+/// This is the inner engine for [`lookup_partition_in_bti_file`].
 fn walk_bti_trie(
     trie_data: &[u8],
     root_offset: usize,
@@ -833,12 +850,15 @@ fn walk_bti_trie(
         let is_leaf = ordinal == 0; // PayloadOnly
 
         if is_leaf {
-            // Leaf node: key must be fully consumed for a match
-            if key_pos >= encoded_key.len() {
-                return read_node_payload(trie_data, current_offset);
-            }
-            // Key not exhausted at leaf → not found
-            return Ok(None);
+            // Path-compressed (Patricia) trie: a PayloadOnly leaf represents the
+            // unique key whose path through the trie led here.  The remaining key
+            // bytes are stored implicitly (compressed suffix) and need not be
+            // compared here — the caller verifies the actual partition key in Data.db.
+            //
+            // Note: the original implementation required the key to be fully consumed
+            // at the leaf (return Ok(None) otherwise), which is incorrect for
+            // path-compressed tries.  Issue #755 corrects this.
+            return read_node_payload(trie_data, current_offset);
         }
 
         // Non-leaf node: if key exhausted, check for an embedded payload
@@ -931,6 +951,91 @@ pub fn lookup_partition_in_bti_file<R: Read + Seek>(
 
     // Step 4: walk the trie
     walk_bti_trie(&trie_data, root_offset as usize, encoded_key)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// BTI partition key encoding for Murmur3Partitioner (issue #755)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Cassandra 5.0 BTI `Partitions.db` trie keys are derived from `DecoratedKey`
+// using `ByteComparable.Version.OSS50`.  For `Murmur3Partitioner` the encoding
+// is a path-compressed representation of:
+//
+//   [type_prefix=0x40] ++ [8 bytes: murmur3_token_bc]
+//
+// where `murmur3_token_bc = (murmur3_token(raw_key_bytes) as u64) XOR 0x8000_0000_0000_0000`
+// (flips the sign bit so signed i64 tokens sort correctly as unsigned big-endian bytes).
+//
+// Because the trie uses path compression (Patricia trie), looking up the first
+// few bytes of this 9-byte key is sufficient to reach the unique leaf for a
+// given partition.  The caller must verify the actual partition key in Data.db
+// to confirm the match (the hash byte in the leaf payload provides a fast pre-filter).
+//
+// This encoding was verified against the real `da-2-bti-Partitions.db` fixture:
+//   UUID 22222222-... → token bc first byte 0x90 → DataOffset(0)   ✓
+//   UUID 11111111-... → token bc first byte 0xBC → DataOffset(63)  ✓
+//   UUID 33333333-... → token bc first byte 0xF9 → DataOffset(125) ✓
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Encode a raw partition key (any CQL type) into the BTI trie lookup key for
+/// `Murmur3Partitioner`.
+///
+/// The encoding is:
+///   `[0x40] ++ [8 bytes big-endian: (murmur3_token(raw_key) as u64) XOR 0x8000_0000_0000_0000]`
+///
+/// This 9-byte prefix uniquely identifies the partition in the trie for typical
+/// Cassandra datasets.  In a path-compressed (Patricia) trie, using only the
+/// first few bytes is correct because each leaf represents exactly one partition:
+/// once the traversal reaches a leaf, no further byte matching is required.
+///
+/// # Arguments
+/// * `raw_key_bytes` – the raw serialized partition key bytes as stored on disk
+///   (e.g. 16 bytes for a UUID, big-endian bytes for int/bigint, UTF-8 for text).
+///
+/// # Verified against
+/// Real `da-2-bti-Partitions.db` fixture — see issue #755 for derivation.
+pub fn encode_partition_key_for_bti_trie(raw_key_bytes: &[u8]) -> [u8; 9] {
+    use crate::util::cassandra_murmur3::cassandra_murmur3_token;
+
+    let token: i64 = cassandra_murmur3_token(raw_key_bytes);
+    let bc: u64 = (token as u64) ^ 0x8000_0000_0000_0000u64;
+    let bc_bytes = bc.to_be_bytes();
+
+    let mut key = [0u8; 9];
+    key[0] = 0x40; // fixed type-discriminator prefix (observed in Partitions.db trie)
+    key[1..9].copy_from_slice(&bc_bytes);
+    key
+}
+
+/// Look up a raw partition key in a Cassandra 5.0 BTI `Partitions.db` trie file
+/// using the `Murmur3Partitioner` byte-comparable encoding.
+///
+/// This is a convenience wrapper over [`lookup_partition_in_bti_file`] that
+/// handles key encoding:
+///
+/// 1. Encodes `raw_key_bytes` → 9-byte BTI trie key via
+///    [`encode_partition_key_for_bti_trie`].
+/// 2. Looks up the key in the trie.
+/// 3. Returns the `BtiPartitionLocation` (Data.db or Rows.db offset).
+///
+/// Because the BTI trie uses path compression the lookup may return a candidate
+/// for a *different* key that shares the same trie prefix.  The caller must
+/// verify the actual partition key at the returned Data.db offset.
+///
+/// # Arguments
+/// * `partitions_db_reader` – seekable reader for the `Partitions.db` file.
+/// * `raw_key_bytes`        – raw on-disk partition key bytes (e.g. 16 bytes for UUID).
+///
+/// # Returns
+/// * `Ok(Some(BtiPartitionLocation::DataOffset(off)))` – candidate Data.db offset.
+/// * `Ok(None)` – definitely not in this SSTable (no trie path for this key prefix).
+/// * `Err(_)` – structural parse error.
+pub fn lookup_raw_key_in_bti_partitions_db<R: Read + Seek>(
+    partitions_db_reader: &mut R,
+    raw_key_bytes: &[u8],
+) -> BtiResult<Option<BtiPartitionLocation>> {
+    let encoded = encode_partition_key_for_bti_trie(raw_key_bytes);
+    lookup_partition_in_bti_file(partitions_db_reader, &encoded)
 }
 
 /// BTI header structure for index files

--- a/cqlite-core/src/storage/sstable/bti/parser.rs
+++ b/cqlite-core/src/storage/sstable/bti/parser.rs
@@ -455,6 +455,484 @@ fn parse_payload_ref(data: &[u8]) -> BtiResult<PayloadRef> {
     Ok(PayloadRef::new(offset, length))
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Real Cassandra BTI Partitions.db trie-payload decoding
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Cassandra 5.0 `Partitions.db` has NO header.  The file is a compact trie
+// whose nodes are written bottom-up (children appear at lower offsets than
+// parents), with the root offset stored as the **last 8 bytes** of the file as
+// a big-endian u64.
+//
+// Every leaf node (ordinal 0 = PayloadOnly) carries a *payload* described by
+// the `payloadBits` value encoded in the **low nibble** of the node's header
+// byte.  In Cassandra 5.0 the hash byte is **always present**
+// (`FLAG_HAS_HASH_BYTE = 8`), so `payloadBits >= 8` for every real partition
+// leaf.  The payload layout is:
+//
+//   byte 0            : partition-key filter hash (lowest 8 bits of Murmur3)
+//   bytes 1 .. N      : SizedInts-encoded signed `position`, where
+//                        N = payloadBits − 8 + 1  (= payloadBits − 7)
+//
+// **Sign convention** (mirrors `PartitionIndex.java`):
+//   - If `position < 0` → `data_offset = ~position` (bitwise NOT; integer NOT)
+//   - If `position >= 0` → `position` points into `Rows.db` (wide partition)
+//
+// Reference: `PartitionIndex.java:131–135`, `BtiFormat.md:946–963`,
+//            `SizedInts.java` (local mirror: `sized_ints.rs`).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The `FLAG_HAS_HASH_BYTE` bit in `payloadBits` (low nibble of a BTI leaf
+/// node's header byte).  When set, the first payload byte is the partition-key
+/// filter hash; the remaining bytes encode the `position` via `SizedInts`.
+///
+/// In Cassandra 5.0 this bit is **always** set for partition index leaves.
+/// Mirrors `PartitionIndex.java:131`.
+pub const FLAG_HAS_HASH_BYTE: u8 = 8;
+
+/// Result of decoding a BTI partition leaf payload.
+///
+/// Mirrors `PartitionIndex.java` payload interpretation: either a direct
+/// `Data.db` offset (for narrow partitions) or a `Rows.db` offset (for wide
+/// partitions that need row-level indexing).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BtiPartitionLocation {
+    /// Direct `Data.db` byte offset.  The partition starts here.
+    ///
+    /// Occurs when the trie leaf's encoded position is **negative**:
+    /// `data_offset = ~position` (bitwise NOT).
+    DataOffset(u64),
+
+    /// Offset into `Rows.db` for this partition's row-level trie index.
+    ///
+    /// Occurs when the trie leaf's encoded position is **non-negative**.
+    RowsOffset(u64),
+}
+
+/// Decode the BTI partition leaf payload at `payload_start` inside `trie_data`.
+///
+/// # Arguments
+/// * `trie_data`      – raw bytes of the trie (i.e. the file **excluding** the
+///   8-byte root-offset footer).
+/// * `payload_start`  – offset within `trie_data` where the payload begins
+///   (immediately after the 1-byte node header).
+/// * `payload_bits`   – the `payloadBits` value from the node header's low nibble.
+///
+/// # Returns
+/// `Ok(BtiPartitionLocation)` on success; a parse error if `payload_bits` is
+/// out of the expected range or the data is too short.
+///
+/// # Reference
+/// Mirrors `PartitionIndex.java` `readPayload` and Cassandra's `SizedInts.read`.
+pub fn decode_bti_partition_payload(
+    trie_data: &[u8],
+    payload_start: usize,
+    payload_bits: u8,
+) -> BtiResult<BtiPartitionLocation> {
+    // Every real Cassandra 5.0 partition leaf must have the hash byte flag set.
+    if payload_bits < FLAG_HAS_HASH_BYTE {
+        return Err(Error::Parse(format!(
+            "BTI payload_bits {payload_bits} < FLAG_HAS_HASH_BYTE (8); \
+             hash-byte-less payloads are not supported in Cassandra 5.0 BTI format"
+        )));
+    }
+    if payload_bits > 16 {
+        // SizedInts stores at most 8 bytes; plus 1 hash byte = 9 bytes max → payloadBits ≤ 16
+        return Err(Error::Parse(format!(
+            "BTI payload_bits {payload_bits} > 16; invalid BTI partition leaf"
+        )));
+    }
+
+    // N = payloadBits − FLAG_HAS_HASH_BYTE + 1
+    // For payloadBits = 8 (most common: 1-byte position): N = 1
+    // For payloadBits = 9: N = 2, etc.
+    let position_bytes = (payload_bits - FLAG_HAS_HASH_BYTE + 1) as usize;
+
+    // Minimum payload = 1 hash byte + position_bytes
+    let needed = 1 + position_bytes;
+    if payload_start + needed > trie_data.len() {
+        return Err(Error::Parse(format!(
+            "BTI partition payload at {payload_start} is too short: \
+             need {needed} bytes, have {}",
+            trie_data.len().saturating_sub(payload_start)
+        )));
+    }
+
+    // Skip hash byte (payload_start + 0), read position starting at payload_start + 1
+    let pos_data = &trie_data[payload_start + 1..payload_start + 1 + position_bytes];
+
+    // Sign-extend the big-endian bytes into a signed i64 (SizedInts semantics)
+    let position: i64 = sized_ints_read_from_slice(pos_data)?;
+
+    // Sign convention: negative → ~position is the Data.db byte offset
+    if position < 0 {
+        let data_offset = !position as u64; // bitwise NOT of the negative value
+        Ok(BtiPartitionLocation::DataOffset(data_offset))
+    } else {
+        Ok(BtiPartitionLocation::RowsOffset(position as u64))
+    }
+}
+
+/// Read a signed big-endian SizedInts value from a byte slice.
+///
+/// Mirrors `SizedInts.read(DataInputPlus, int)` from Cassandra — sign-extends
+/// the most-significant byte.  Accepts 1–8 bytes.
+///
+/// This is the slice-based analogue of `crate::storage::sstable::bti::sized_ints::read`
+/// (which operates on a `std::io::Read` stream).
+fn sized_ints_read_from_slice(data: &[u8]) -> BtiResult<i64> {
+    match data.len() {
+        0 => Ok(0),
+        1 => Ok(data[0] as i8 as i64),
+        2 => Ok(i16::from_be_bytes([data[0], data[1]]) as i64),
+        3 => {
+            let high = data[0] as i8 as i64;
+            let low = u16::from_be_bytes([data[1], data[2]]) as i64;
+            Ok((high << 16) | low)
+        }
+        4 => Ok(i32::from_be_bytes([data[0], data[1], data[2], data[3]]) as i64),
+        5 => {
+            let high = data[0] as i8 as i64;
+            let low = u32::from_be_bytes([data[1], data[2], data[3], data[4]]) as i64;
+            Ok((high << 32) | low)
+        }
+        6 => {
+            let high = i16::from_be_bytes([data[0], data[1]]) as i64;
+            let low = u32::from_be_bytes([data[2], data[3], data[4], data[5]]) as i64;
+            Ok((high << 32) | low)
+        }
+        7 => {
+            let high1 = data[0] as i8 as i64;
+            let high2 = u16::from_be_bytes([data[1], data[2]]) as i64;
+            let low = u32::from_be_bytes([data[3], data[4], data[5], data[6]]) as i64;
+            Ok((high1 << 48) | (high2 << 32) | low)
+        }
+        8 => Ok(i64::from_be_bytes([
+            data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7],
+        ])),
+        n => Err(Error::Parse(format!(
+            "SizedInts: invalid byte count {n} (expected 1–8)"
+        ))),
+    }
+}
+
+/// Parse a BTI trie node from `trie_data` at `node_offset` for **traversal**
+/// purposes (i.e. to follow child pointers).  Unlike [`parse_bti_node`], this
+/// function does NOT require any particular payload format: for PayloadOnly and
+/// for nodes with a non-zero `payloadBits` low nibble the payload bytes are
+/// simply skipped — the caller is responsible for reading the payload via
+/// [`read_node_payload`].
+///
+/// This is important because real Cassandra 5.0 `Partitions.db` uses a
+/// compact SizedInts-based payload (2–10 bytes) that is incompatible with the
+/// legacy 12-byte `PayloadRef` format expected by [`parse_payload_ref`].
+fn parse_bti_node_for_traversal(trie_data: &[u8], node_offset: usize) -> BtiResult<BtiNode> {
+    if node_offset >= trie_data.len() {
+        return Err(Error::Parse(format!(
+            "BTI traversal: node_offset {node_offset} >= trie_data.len {}",
+            trie_data.len()
+        )));
+    }
+
+    let data = &trie_data[node_offset..];
+    let header_byte = data[0];
+    let ordinal = (header_byte >> 4) & 0x0F;
+    let payload_flags = header_byte & 0x0F;
+    let node_type = classify_node_nibble(ordinal)?;
+
+    match node_type {
+        BtiNodeType::PayloadOnly => {
+            // PayloadOnly leaf: no children.  Skip payload (we decode it separately).
+            if payload_flags == 0 {
+                return Err(Error::Parse(
+                    "PayloadOnly node has no payload flags set".to_string(),
+                ));
+            }
+            // Use a stub PayloadRef — the caller uses read_node_payload for the real data
+            let stub = PayloadRef::new(0, 0);
+            Ok(BtiNode {
+                node_type,
+                level: 0,
+                key_prefix: Vec::new(),
+                data: BtiNodeData::PayloadOnly { payload: stub },
+            })
+        }
+        BtiNodeType::Single => {
+            // Reuse the existing full parser — it handles pointers correctly.
+            // Payload (if any) comes after the pointer bytes and is not read here.
+            parse_bti_node(data, node_offset as u64)
+        }
+        BtiNodeType::Sparse => parse_bti_node(data, node_offset as u64),
+        BtiNodeType::Dense => parse_bti_node(data, node_offset as u64),
+    }
+}
+
+/// Walk one BTI trie node at `node_offset` and return the absolute offset of
+/// the child reachable via `search_byte`, or `None` if no such transition
+/// exists.
+///
+/// Returns `Ok(Some(child_offset))` when the byte is found and the child is an
+/// internal node.  Returns `Ok(None)` when there is no matching transition
+/// (key not in trie).
+///
+/// Separately, if the *current* node (at `node_offset`) has an embedded
+/// payload **and** `key_exhausted` is true, the caller should read that
+/// payload; this function does not return it — see [`read_node_payload`].
+fn find_next_child_offset(
+    trie_data: &[u8],
+    node_offset: usize,
+    search_byte: u8,
+) -> BtiResult<Option<usize>> {
+    if node_offset >= trie_data.len() {
+        return Err(Error::Parse(format!(
+            "BTI node offset {node_offset} out of bounds (trie_data.len={})",
+            trie_data.len()
+        )));
+    }
+
+    let bti_node = parse_bti_node_for_traversal(trie_data, node_offset)?;
+
+    match bti_node.find_child(search_byte) {
+        Some(ptr) => {
+            let child = ptr.distance as usize; // distance stores the absolute child offset
+            Ok(Some(child))
+        }
+        None => Ok(None),
+    }
+}
+
+/// Read the `BtiPartitionLocation` from the payload attached to the BTI node
+/// at `node_offset`.  Returns `None` if the node has no payload.
+///
+/// For `PayloadOnly` nodes the payload immediately follows the 1-byte header.
+/// For other node types (Single/Sparse/Dense with a non-zero `payloadBits`
+/// low nibble) the payload appears *after* all the pointer/transition bytes;
+/// this function delegates correctly to [`decode_bti_partition_payload`].
+fn read_node_payload(
+    trie_data: &[u8],
+    node_offset: usize,
+) -> BtiResult<Option<BtiPartitionLocation>> {
+    if node_offset >= trie_data.len() {
+        return Err(Error::Parse(format!(
+            "BTI payload read: node_offset {node_offset} out of bounds"
+        )));
+    }
+
+    let header_byte = trie_data[node_offset];
+    let ordinal = (header_byte >> 4) & 0x0F;
+    let payload_flags = header_byte & 0x0F; // aka payloadBits
+
+    if ordinal == 0 {
+        // PayloadOnly node: the entire node is just [header][payload…]
+        if payload_flags == 0 {
+            return Err(Error::Parse(
+                "PayloadOnly node has zero payload_flags".to_string(),
+            ));
+        }
+        let payload_start = node_offset + 1; // immediately after the 1-byte header
+        Ok(Some(decode_bti_partition_payload(
+            trie_data,
+            payload_start,
+            payload_flags,
+        )?))
+    } else if payload_flags != 0 {
+        // Non-leaf node with an embedded payload (prefix match for short keys).
+        // We need to skip over the node's own pointer/transition data to reach
+        // the payload.  Reuse `parse_bti_node` to find the payload start.
+        let node = parse_bti_node(trie_data, node_offset as u64)?;
+        // Determine where the payload bytes start: after all transition/pointer bytes.
+        // payload_position = node_offset + node_byte_size_without_payload
+        let payload_start = payload_start_in_node(&node, trie_data, node_offset)?;
+        Ok(Some(decode_bti_partition_payload(
+            trie_data,
+            payload_start,
+            payload_flags,
+        )?))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Compute the byte offset of the payload within `trie_data` for a non-leaf
+/// node that carries an embedded payload (`payloadBits != 0`).
+///
+/// This is the byte position immediately after all the node's transition bytes
+/// and pointer bytes, but before any subsequent node data.
+fn payload_start_in_node(node: &BtiNode, trie_data: &[u8], node_offset: usize) -> BtiResult<usize> {
+    use BtiNodeData::*;
+    let header_byte = trie_data[node_offset];
+    let ordinal = (header_byte >> 4) & 0x0F;
+
+    let payload_offset = match &node.data {
+        PayloadOnly { .. } => {
+            // Header(1) + payload: caller handles this case separately
+            node_offset + 1
+        }
+        Single { .. } => {
+            // Singles with payload: header(1) + transition(1) + ptr_bytes
+            let ptr_bytes = pointer_bytes_for_ordinal(ordinal) as usize;
+            // Ordinals 1 and 3 are "NoPayload" variants; they cannot have payloads
+            // (the payload_flags nibble is always 0 for those ordinals, so this
+            // branch is unreachable for them).
+            node_offset + 1 + 1 + ptr_bytes
+        }
+        Sparse { transitions } => {
+            let count = transitions.len();
+            let ptr_bytes = pointer_bytes_for_ordinal(ordinal) as usize;
+            // Ordinal 6 (Sparse12): packed 12-bit pointers, ceil(count*3/2) bytes
+            let ptr_area = if ordinal == 6 {
+                (count * 3).div_ceil(2)
+            } else {
+                count * ptr_bytes
+            };
+            node_offset + 1 + 1 + count + ptr_area // header + count + transitions + deltas
+        }
+        Dense { children, .. } => {
+            let range_len = children.len();
+            let ptr_bytes = pointer_bytes_for_ordinal(ordinal) as usize;
+            let ptr_area = if ordinal == 10 {
+                // Dense12
+                (range_len * 3).div_ceil(2)
+            } else {
+                range_len * ptr_bytes
+            };
+            node_offset + 1 + 1 + 1 + ptr_area // header + start_byte + len-1 + deltas
+        }
+    };
+    Ok(payload_offset)
+}
+
+/// Walk the BTI partition trie loaded in `trie_data`, looking for a partition
+/// whose **byte-comparable** encoding exactly matches `encoded_key`.
+///
+/// Returns:
+/// - `Ok(Some(BtiPartitionLocation))` when the key is found.
+/// - `Ok(None)` when the key is not present in the trie.
+/// - `Err(_)` on structural parse errors.
+///
+/// This is the inner engine for [`lookup_partition_in_bti_file`].
+fn walk_bti_trie(
+    trie_data: &[u8],
+    root_offset: usize,
+    encoded_key: &[u8],
+) -> BtiResult<Option<BtiPartitionLocation>> {
+    let mut current_offset = root_offset;
+    let mut key_pos = 0;
+
+    loop {
+        if current_offset >= trie_data.len() {
+            return Err(Error::Parse(format!(
+                "BTI trie walk: offset {current_offset} out of bounds (trie size {})",
+                trie_data.len()
+            )));
+        }
+
+        let header_byte = trie_data[current_offset];
+        let ordinal = (header_byte >> 4) & 0x0F;
+        let payload_flags = header_byte & 0x0F;
+        let is_leaf = ordinal == 0; // PayloadOnly
+
+        if is_leaf {
+            // Leaf node: key must be fully consumed for a match
+            if key_pos >= encoded_key.len() {
+                return read_node_payload(trie_data, current_offset);
+            }
+            // Key not exhausted at leaf → not found
+            return Ok(None);
+        }
+
+        // Non-leaf node: if key exhausted, check for an embedded payload
+        if key_pos >= encoded_key.len() {
+            if payload_flags != 0 {
+                return read_node_payload(trie_data, current_offset);
+            }
+            return Ok(None);
+        }
+
+        // Advance: look for the next key byte's transition
+        let next_byte = encoded_key[key_pos];
+        match find_next_child_offset(trie_data, current_offset, next_byte)? {
+            Some(child_offset) => {
+                current_offset = child_offset;
+                key_pos += 1;
+            }
+            None => {
+                // No transition for this byte → key not in trie
+                return Ok(None);
+            }
+        }
+    }
+}
+
+/// Look up a partition by its **byte-comparable** encoded key in a real
+/// Cassandra 5.0 `Partitions.db` BTI trie file.
+///
+/// # Format
+/// The file is a compact trie with **no header**:
+/// - Nodes are written bottom-up (children before parents).
+/// - The root node's absolute byte offset is stored as the **last 8 bytes** of
+///   the file (big-endian u64).
+/// - Every partition leaf carries a payload consisting of a 1-byte filter hash
+///   plus a SizedInts-encoded signed `position` (see [`decode_bti_partition_payload`]).
+/// - Negative `position` → `data_offset = ~position` (direct `Data.db` pointer).
+/// - Non-negative `position` → `rows_offset` into `Rows.db` (wide partition).
+///
+/// # Arguments
+/// * `reader`      – positioned at any point; this function seeks as needed.
+/// * `encoded_key` – the byte-comparable encoding of the partition key (e.g.
+///   as produced by [`ByteComparableEncoder`]).
+///
+/// # Returns
+/// * `Ok(Some(BtiPartitionLocation::DataOffset(off)))` – the partition starts
+///   at byte `off` in `Data.db`.  **This is the headline result of issue #755.**
+/// * `Ok(Some(BtiPartitionLocation::RowsOffset(off)))` – the partition has a
+///   row index; consult `Rows.db` at `off` for the row-level trie.
+/// * `Ok(None)` – the key was not found.
+/// * `Err(_)` – structural parse error.
+///
+/// # Reference
+/// Mirrors `PartitionIndex.java` (Cassandra 5.0.8), specifically the
+/// `openBlocking` + `exactCandidate` read path; `SizedInts.read`; and the
+/// payload sign convention at `PartitionIndex.java:131–135`.
+pub fn lookup_partition_in_bti_file<R: Read + Seek>(
+    reader: &mut R,
+    encoded_key: &[u8],
+) -> BtiResult<Option<BtiPartitionLocation>> {
+    // Step 1: determine the file size
+    let file_size = reader.seek(SeekFrom::End(0))?;
+
+    if file_size < 8 {
+        return Err(Error::Parse(format!(
+            "BTI Partitions.db is too small ({file_size} bytes; need at least 8 for footer)"
+        )));
+    }
+
+    // Step 2: read the 8-byte root offset from the end of the file
+    reader.seek(SeekFrom::End(-8))?;
+    let mut footer_buf = [0u8; 8];
+    reader.read_exact(&mut footer_buf)?;
+    let root_offset = u64::from_be_bytes(footer_buf);
+
+    // The trie data is everything before the 8-byte footer
+    let trie_size = file_size - 8;
+
+    if root_offset >= trie_size {
+        return Err(Error::Parse(format!(
+            "BTI Partitions.db: root_offset {root_offset} >= trie_size {trie_size}"
+        )));
+    }
+
+    // Step 3: load the entire trie into memory
+    // For typical Partitions.db files this is small (tens of KB for millions of
+    // partitions because the trie shares prefixes aggressively).
+    reader.seek(SeekFrom::Start(0))?;
+    let mut trie_data = vec![0u8; trie_size as usize];
+    reader.read_exact(&mut trie_data)?;
+
+    // Step 4: walk the trie
+    walk_bti_trie(&trie_data, root_offset as usize, encoded_key)
+}
+
 /// BTI header structure for index files
 #[derive(Debug, Clone)]
 pub struct BtiHeader {
@@ -795,15 +1273,20 @@ impl<R: Read + Seek> RowsParser<R> {
         let _encoded_start = self.encoder.encode_composite_key(start_key)?;
         let _encoded_end = self.encoder.encode_composite_key(end_key)?;
 
-        let results = Vec::new();
-
-        // Navigate to start position
-        let _navigator = TrieNavigator::new(self.header.root_offset);
-
-        // For now, just return empty results - full implementation would traverse range
-        // TODO: Implement proper range traversal
-
-        Ok(results)
+        // Issue #755 scope decision: range_query over the fake-header RowsParser
+        // is not yet implemented.  Returning an empty Vec here would be a *silent*
+        // wrong-result path — callers would see "no rows in range" instead of an
+        // error, making bugs invisible.  Return an explicit error so callers know
+        // this path is unimplemented and must not rely on its output.
+        //
+        // Follow-up issue: implement proper BTI Rows.db range traversal.
+        // Proposed title: "feat(bti): implement RowsParser range_query trie traversal"
+        Err(Error::Parse(
+            "BTI RowsParser::range_query is not yet implemented; \
+             this stub previously returned an empty Vec (silent wrong-result). \
+             See follow-up issue for BTI Rows.db range traversal implementation."
+                .to_string(),
+        ))
     }
 
     /// Iterator over all rows in the index
@@ -844,11 +1327,22 @@ impl<'a, R: Read + Seek> Iterator for PartitionIterator<'a, R> {
         if self.finished {
             return None;
         }
-
-        // TODO: Implement proper trie traversal for iteration
-        // For now, just mark as finished
         self.finished = true;
-        None
+
+        // Issue #755 scope decision: full trie traversal for iteration over the
+        // fake-header PartitionsParser is not yet implemented.  Silently returning
+        // `None` here would make callers believe the index is empty (silent
+        // wrong-result).  Emit an explicit error so callers see an unambiguous
+        // "not implemented" rather than mysteriously empty iteration.
+        //
+        // Follow-up issue: implement BTI PartitionIterator trie traversal
+        // Proposed title: "feat(bti): implement PartitionIterator full trie traversal"
+        Some(Err(Error::Parse(
+            "BTI PartitionIterator::next is not yet implemented; \
+             this stub previously returned None (silent wrong-result). \
+             See follow-up issue for full trie traversal implementation."
+                .to_string(),
+        )))
     }
 }
 
@@ -879,11 +1373,22 @@ impl<'a, R: Read + Seek> Iterator for RowIterator<'a, R> {
         if self.finished {
             return None;
         }
-
-        // TODO: Implement proper trie traversal for iteration
-        // For now, just mark as finished
         self.finished = true;
-        None
+
+        // Issue #755 scope decision: full trie traversal for iteration over the
+        // fake-header RowsParser is not yet implemented.  Silently returning
+        // `None` here would make callers believe the row index is empty (silent
+        // wrong-result).  Emit an explicit error so callers see an unambiguous
+        // "not implemented" rather than mysteriously empty iteration.
+        //
+        // Follow-up issue: implement BTI RowIterator trie traversal
+        // Proposed title: "feat(bti): implement RowIterator full trie traversal"
+        Some(Err(Error::Parse(
+            "BTI RowIterator::next is not yet implemented; \
+             this stub previously returned None (silent wrong-result). \
+             See follow-up issue for full trie traversal implementation."
+                .to_string(),
+        )))
     }
 }
 
@@ -1723,5 +2228,505 @@ mod tests {
         let data: &[u8] = &[0xAB, 0xC1, 0x23];
         assert_eq!(read_12bit_packed(data, 0), 0xABC);
         assert_eq!(read_12bit_packed(data, 1), 0x123);
+    }
+
+    // -----------------------------------------------------------------------
+    // decode_bti_partition_payload unit tests
+    // -----------------------------------------------------------------------
+
+    /// Construct a minimal trie_data slice and verify decode_bti_partition_payload
+    /// returns the correct DataOffset.  Mirrors the simple_table leaf at offset 0
+    /// (hash=0x24, position=−1 → data_offset=0).
+    #[test]
+    fn decode_bti_partition_payload_data_offset_zero() {
+        // PayloadOnly header byte: 0x08 (ordinal=0, payloadBits=8)
+        // payload[0] = 0x24 (hash byte)
+        // payload[1] = 0xFF (position = i8(-1) = -1 → ~(-1) = 0)
+        let header_byte: u8 = 0x08;
+        let hash_byte: u8 = 0x24;
+        let position_byte: u8 = 0xFF; // -1 as i8
+        let trie_data = vec![header_byte, hash_byte, position_byte, 0x00, 0x00];
+        let payload_start = 1; // immediately after header
+        let payload_bits = header_byte & 0x0F; // = 8
+        let result = decode_bti_partition_payload(&trie_data, payload_start, payload_bits)
+            .expect("should decode successfully");
+        assert_eq!(
+            result,
+            BtiPartitionLocation::DataOffset(0),
+            "position=-1 (0xFF as i8) must map to data_offset=0 via ~(-1)=0"
+        );
+    }
+
+    #[test]
+    fn decode_bti_partition_payload_data_offset_63() {
+        // simple_table: leaf at offset 3 (hash=0x22, position=−64 → data_offset=63)
+        // payloadBits = 8 → 1 position byte
+        // position = 0xC0 as i8 = -64; ~(-64) = 63
+        let trie_data = vec![
+            0x08u8, // header: ordinal=0, payloadBits=8
+            0x22,   // hash byte
+            0xC0,   // position = -64 as i8 → data_offset = ~(-64) = 63
+        ];
+        let payload_bits = 8u8;
+        let result = decode_bti_partition_payload(&trie_data, 1, payload_bits).unwrap();
+        assert_eq!(result, BtiPartitionLocation::DataOffset(63));
+    }
+
+    #[test]
+    fn decode_bti_partition_payload_data_offset_125() {
+        // simple_table: leaf at offset 6 (hash=0xF4, position=−126 → data_offset=125)
+        // 0x82 as i8 = -126; ~(-126) = 125
+        let trie_data = vec![
+            0x08u8, // header
+            0xF4,   // hash
+            0x82,   // position = -126 as i8 → data_offset = 125
+        ];
+        let result = decode_bti_partition_payload(&trie_data, 1, 8).unwrap();
+        assert_eq!(result, BtiPartitionLocation::DataOffset(125));
+    }
+
+    #[test]
+    fn decode_bti_partition_payload_rows_offset() {
+        // Positive position → RowsOffset (wide partition).
+        // payloadBits=9 → 2 position bytes; position = 0x0100 = 256 (positive)
+        let trie_data = vec![
+            0x09u8, // header: ordinal=0, payloadBits=9
+            0xAB,   // hash
+            0x01,   // position[0] (MSB)
+            0x00,   // position[1] (LSB) → i16 = 0x0100 = 256
+        ];
+        let result = decode_bti_partition_payload(&trie_data, 1, 9).unwrap();
+        assert_eq!(result, BtiPartitionLocation::RowsOffset(256));
+    }
+
+    #[test]
+    fn decode_bti_partition_payload_no_hash_byte_returns_error() {
+        // payloadBits < FLAG_HAS_HASH_BYTE (8) → not supported in C5.0 BTI
+        let trie_data = vec![0x07u8, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07];
+        let err = decode_bti_partition_payload(&trie_data, 1, 7);
+        assert!(err.is_err(), "payloadBits < 8 must be an error");
+    }
+
+    #[test]
+    fn decode_bti_partition_payload_2byte_position() {
+        // payloadBits=9 → 2 position bytes.
+        // position = 0x00C0 as i16 = 192 (positive) → RowsOffset
+        let trie_data = vec![0x09u8, 0xAB, 0x00, 0xC0];
+        let result = decode_bti_partition_payload(&trie_data, 1, 9).unwrap();
+        assert_eq!(result, BtiPartitionLocation::RowsOffset(192));
+    }
+
+    // -----------------------------------------------------------------------
+    // sized_ints_read_from_slice unit tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn sized_ints_slice_1_byte_positive() {
+        assert_eq!(sized_ints_read_from_slice(&[0x7F]).unwrap(), 127);
+    }
+
+    #[test]
+    fn sized_ints_slice_1_byte_negative() {
+        // 0xFF as i8 = -1
+        assert_eq!(sized_ints_read_from_slice(&[0xFF]).unwrap(), -1);
+        // 0xC0 as i8 = -64
+        assert_eq!(sized_ints_read_from_slice(&[0xC0]).unwrap(), -64);
+        // 0x82 as i8 = -126
+        assert_eq!(sized_ints_read_from_slice(&[0x82]).unwrap(), -126);
+    }
+
+    #[test]
+    fn sized_ints_slice_2_bytes() {
+        // 0x00FF = 255 (positive)
+        assert_eq!(sized_ints_read_from_slice(&[0x00, 0xFF]).unwrap(), 255);
+        // 0xFF00 as i16 = -256
+        assert_eq!(sized_ints_read_from_slice(&[0xFF, 0x00]).unwrap(), -256);
+    }
+
+    // -----------------------------------------------------------------------
+    // walk_bti_trie unit tests — hand-crafted trie bytes
+    // -----------------------------------------------------------------------
+
+    /// Build a minimal 1-partition trie with a single PayloadOnly root node.
+    /// The encoded key must be empty (or rather, the trie matches any non-empty
+    /// key by falling through to a PayloadOnly at depth 0 only if the trie
+    /// immediately has a PayloadOnly root — but that only works for empty keys
+    /// in real BTI).  Here we test the degenerate case where the root IS the
+    /// leaf and the key is already exhausted.
+    #[test]
+    fn walk_bti_trie_payload_only_root_with_empty_key() {
+        // PayloadOnly (ordinal 0, payloadBits=8) at offset 0
+        // payload: hash=0x00, position=0xFF (i8 = -1 → data_offset=0)
+        let trie_data: Vec<u8> = vec![
+            0x08, // header: ordinal=0, payloadBits=8
+            0x00, // hash
+            0xFF, // position = -1 → data_offset = ~(-1) = 0
+        ];
+        let result = walk_bti_trie(&trie_data, 0, &[]).unwrap();
+        assert_eq!(result, Some(BtiPartitionLocation::DataOffset(0)));
+    }
+
+    /// Hand-crafted 2-level trie matching the simple_table Partitions.db layout:
+    ///
+    ///   root (offset 6): SingleNoPayload4  delta=3 transition=0x40
+    ///     child (offset 3): Sparse8        pf=0    count=2
+    ///       trans[0]=0xAA delta=3 → child=0: PayloadOnly hash=0x11 pos=-1  → data_offset=0
+    ///       trans[1]=0xBB delta=0 → ERROR (delta=0 means child at same offset — use a real value)
+    ///
+    /// Simplified: 2-partition trie, key "A" maps to offset 0, key "B" maps to offset 64.
+    #[test]
+    fn walk_bti_trie_two_partitions_via_sparse8_root() {
+        // Build trie manually (bottom-up, children at lower offsets)
+        //
+        // Offset 0: PayloadOnly for "key A" → data_offset=0
+        //   header = 0x08 (ordinal=0, pf=8), hash=0x11, position=0xFF (-1 → ~(-1)=0)
+        // Offset 3: PayloadOnly for "key B" → data_offset=64
+        //   header = 0x08, hash=0x22, position=0xBF (-65 → ~(-65)=64)
+        // Offset 6: Sparse8 (ordinal=5, pf=0) with 2 transitions
+        //   [0x08 | 0x00 = 0x50] [count=2] [trans0=0xAA] [trans1=0xBB]
+        //   [delta0 = 6] [delta1 = 3]
+        //   child0 = 6 - 6 = 0 ✓ ; child1 = 6 - 3 = 3 ✓
+
+        let mut trie_data = vec![0u8; 12];
+        // Leaf at offset 0: PayloadOnly, pf=8, hash=0x11, position=-1 → data_offset=0
+        trie_data[0] = 0x08; // ordinal=0, payloadBits=8
+        trie_data[1] = 0x11; // hash
+        trie_data[2] = 0xFF; // position byte = -1 as i8
+
+        // Leaf at offset 3: PayloadOnly, pf=8, hash=0x22, position=-65 → data_offset=64
+        // -65 as i8 = 0xBF (since 0xBF = 191 unsigned; 191 - 256 = -65)
+        trie_data[3] = 0x08;
+        trie_data[4] = 0x22; // hash
+        trie_data[5] = 0xBF; // -65 as i8 → ~(-65) = 64
+
+        // Sparse8 at offset 6: [0x50][count=2][0xAA][0xBB][delta_AA=6][delta_BB=3]
+        trie_data[6] = 0x50; // ordinal=5, payloadBits=0
+        trie_data[7] = 0x02; // count=2
+        trie_data[8] = 0xAA; // transition[0]
+        trie_data[9] = 0xBB; // transition[1]
+        trie_data[10] = 0x06; // delta[0] → child = 6 - 6 = 0
+        trie_data[11] = 0x03; // delta[1] → child = 6 - 3 = 3
+
+        // Encoded keys: each is a single byte (0xAA for partition A, 0xBB for B)
+        let result_a = walk_bti_trie(&trie_data, 6, &[0xAA]).unwrap();
+        assert_eq!(
+            result_a,
+            Some(BtiPartitionLocation::DataOffset(0)),
+            "key 0xAA should resolve to data_offset=0"
+        );
+
+        let result_b = walk_bti_trie(&trie_data, 6, &[0xBB]).unwrap();
+        assert_eq!(
+            result_b,
+            Some(BtiPartitionLocation::DataOffset(64)),
+            "key 0xBB should resolve to data_offset=64"
+        );
+
+        let result_miss = walk_bti_trie(&trie_data, 6, &[0xCC]).unwrap();
+        assert_eq!(result_miss, None, "key 0xCC should not be found");
+    }
+
+    // -----------------------------------------------------------------------
+    // lookup_partition_in_bti_file — hand-crafted in-memory Partitions.db
+    // -----------------------------------------------------------------------
+
+    /// Build a complete in-memory Partitions.db (trie + 8-byte root footer)
+    /// and assert that `lookup_partition_in_bti_file` returns the correct
+    /// Data.db offsets.  This test does NOT rely on any external test-data
+    /// files, so it always runs and proves the seek-not-scan path.
+    #[test]
+    fn lookup_partition_in_bti_file_synthetic_two_partitions() {
+        use std::io::Cursor;
+
+        // ----------------------------------------------------------------
+        // Trie layout (same as walk_bti_trie_two_partitions_via_sparse8_root):
+        //   offset 0: PayloadOnly (pf=8, hash=0x11, position=-1) → DataOffset(0)
+        //   offset 3: PayloadOnly (pf=8, hash=0x22, position=-65) → DataOffset(64)
+        //   offset 6: Sparse8 count=2 [0xAA→0, 0xBB→3]
+        // Footer (8 bytes): root offset = 6
+        // ----------------------------------------------------------------
+
+        let mut trie_file = vec![0u8; 12 + 8];
+
+        // Leaf A (offset 0)
+        trie_file[0] = 0x08;
+        trie_file[1] = 0x11;
+        trie_file[2] = 0xFF; // -1 as i8 → data_offset=0
+
+        // Leaf B (offset 3)
+        trie_file[3] = 0x08;
+        trie_file[4] = 0x22;
+        trie_file[5] = 0xBF; // -65 as i8 → data_offset=64
+
+        // Sparse8 root (offset 6)
+        trie_file[6] = 0x50;
+        trie_file[7] = 0x02;
+        trie_file[8] = 0xAA;
+        trie_file[9] = 0xBB;
+        trie_file[10] = 0x06;
+        trie_file[11] = 0x03;
+
+        // Footer: root_offset = 6 as big-endian u64
+        trie_file[12..20].copy_from_slice(&6u64.to_be_bytes());
+
+        // ----------------------------------------------------------------
+        // Lookup key 0xAA → should give DataOffset(0)
+        // ----------------------------------------------------------------
+        {
+            let mut cursor = Cursor::new(trie_file.clone());
+            let result =
+                lookup_partition_in_bti_file(&mut cursor, &[0xAA]).expect("lookup must not error");
+            assert_eq!(
+                result,
+                Some(BtiPartitionLocation::DataOffset(0)),
+                "Trie lookup for key 0xAA must return DataOffset(0), NOT a sequential scan"
+            );
+        }
+
+        // ----------------------------------------------------------------
+        // Lookup key 0xBB → should give DataOffset(64)
+        // ----------------------------------------------------------------
+        {
+            let mut cursor = Cursor::new(trie_file.clone());
+            let result =
+                lookup_partition_in_bti_file(&mut cursor, &[0xBB]).expect("lookup must not error");
+            assert_eq!(
+                result,
+                Some(BtiPartitionLocation::DataOffset(64)),
+                "Trie lookup for key 0xBB must return DataOffset(64)"
+            );
+        }
+
+        // ----------------------------------------------------------------
+        // Lookup key 0xCC → must return None (not found)
+        // ----------------------------------------------------------------
+        {
+            let mut cursor = Cursor::new(trie_file.clone());
+            let result =
+                lookup_partition_in_bti_file(&mut cursor, &[0xCC]).expect("lookup must not error");
+            assert_eq!(result, None, "Key 0xCC must not be found");
+        }
+    }
+
+    /// Prove that `lookup_partition_in_bti_file` resolves Data.db offsets via
+    /// the trie (NOT a sequential scan) by asserting the resolved offset
+    /// matches the known partition position from the sstabledump JSONL golden.
+    ///
+    /// This test requires the real BTI fixture files from the test dataset.
+    /// It is guarded by `CQLITE_DATASETS_ROOT` and skips when the dataset is
+    /// absent, so it does not block CI that runs without test data.
+    ///
+    /// **Seek-not-scan proof**: The resolved `data_offset` matches the JSONL
+    /// "position" field exactly.  A sequential scan would never produce a
+    /// file-offset value — it walks Data.db byte-by-byte.  Only the trie lookup
+    /// produces an absolute Data.db offset before any Data.db is read.
+    #[test]
+    fn lookup_partition_in_bti_file_real_simple_table_fixture() {
+        use std::fs::File;
+
+        // Require the real test-data fixtures
+        let datasets_root = match std::env::var("CQLITE_DATASETS_ROOT") {
+            Ok(v) => std::path::PathBuf::from(v),
+            Err(_) => {
+                eprintln!(
+                    "SKIP: CQLITE_DATASETS_ROOT not set; \
+                     test requires real BTI fixture files"
+                );
+                return;
+            }
+        };
+
+        let partitions_db = datasets_root.join(
+            "sstables/test_da/simple_table-de1be8b064e711f19ad401a8c8227b11/da-2-bti-Partitions.db",
+        );
+        if !partitions_db.exists() {
+            eprintln!("SKIP: BTI fixture not found at {:?}", partitions_db);
+            return;
+        }
+
+        // Known encoded keys and expected Data.db offsets from the JSONL golden.
+        //
+        // UUID "22222222-2222-2222-2222-222222222222" → position 0
+        // UUID "11111111-1111-1111-1111-111111111111" → position 63
+        // UUID "33333333-3333-3333-3333-333333333333" → position 125
+        //
+        // The BTI trie is keyed on the byte-comparable encoding of UUIDs as
+        // produced by Cassandra's OSS50 encoder.  Through the trie traversal
+        // analysis we verified that transition bytes 0x90, 0xBC, 0xF9 (after the
+        // 0x40 Single4 prefix hop) map to offsets 0, 63, 125.
+        //
+        // Rather than re-encoding full UUIDs here, we prove the trie resolves the
+        // correct offsets by directly reading the trie and checking that all three
+        // PayloadOnly leaves decode to the known Data.db positions.
+        let mut file = File::open(&partitions_db)
+            .unwrap_or_else(|e| panic!("Cannot open {:?}: {}", partitions_db, e));
+
+        // Read the trie data (file minus 8-byte footer)
+        let file_size = {
+            use std::io::Seek;
+            file.seek(SeekFrom::End(0)).unwrap()
+        };
+        assert_eq!(file_size, 79, "simple_table Partitions.db must be 79 bytes");
+
+        // Read root offset from footer
+        {
+            use std::io::Seek;
+            file.seek(SeekFrom::End(-8)).unwrap();
+        }
+        let mut footer = [0u8; 8];
+        file.read_exact(&mut footer).unwrap();
+        let root_offset = u64::from_be_bytes(footer);
+        assert_eq!(
+            root_offset, 17,
+            "simple_table Partitions.db root must be at offset 17"
+        );
+
+        // Load the full trie
+        {
+            use std::io::Seek;
+            file.seek(SeekFrom::Start(0)).unwrap();
+        }
+        let mut trie_data = vec![0u8; 71]; // 79 - 8 footer
+        file.read_exact(&mut trie_data).unwrap();
+
+        // Verify all three leaves decode to known Data.db offsets.
+        // Leaf at offset 0: hash=0x24, position=0xFF (-1) → data_offset=0
+        let loc0 =
+            decode_bti_partition_payload(&trie_data, 1, 8).expect("leaf at offset 0 must decode");
+        assert_eq!(
+            loc0,
+            BtiPartitionLocation::DataOffset(0),
+            "leaf at trie offset 0 must map to Data.db position 0 (UUID 22222222...)"
+        );
+
+        // Leaf at offset 3: hash=0x22, position=0xC0 (-64) → data_offset=63
+        let loc63 =
+            decode_bti_partition_payload(&trie_data, 4, 8).expect("leaf at offset 3 must decode");
+        assert_eq!(
+            loc63,
+            BtiPartitionLocation::DataOffset(63),
+            "leaf at trie offset 3 must map to Data.db position 63 (UUID 11111111...)"
+        );
+
+        // Leaf at offset 6: hash=0xF4, position=0x82 (-126) → data_offset=125
+        let loc125 =
+            decode_bti_partition_payload(&trie_data, 7, 8).expect("leaf at offset 6 must decode");
+        assert_eq!(
+            loc125,
+            BtiPartitionLocation::DataOffset(125),
+            "leaf at trie offset 6 must map to Data.db position 125 (UUID 33333333...)"
+        );
+
+        // Prove the trie walk itself works end-to-end for the encoded key prefixes
+        // we observe in the file.  Transition chain from hex analysis:
+        //   root(17) -[0x40]→ Sparse8(9) -[0x90]→ leaf(0) → DataOffset(0)
+        //                                 -[0xBC]→ leaf(3) → DataOffset(63)
+        //                                 -[0xF9]→ leaf(6) → DataOffset(125)
+        // We encode the two-byte key [0x40, 0x90] / [0x40, 0xBC] / [0x40, 0xF9]:
+        let result_0 = walk_bti_trie(&trie_data, 17, &[0x40, 0x90]).unwrap();
+        assert_eq!(
+            result_0,
+            Some(BtiPartitionLocation::DataOffset(0)),
+            "[0x40,0x90] must resolve to DataOffset(0)"
+        );
+
+        let result_63 = walk_bti_trie(&trie_data, 17, &[0x40, 0xBC]).unwrap();
+        assert_eq!(
+            result_63,
+            Some(BtiPartitionLocation::DataOffset(63)),
+            "[0x40,0xBC] must resolve to DataOffset(63)"
+        );
+
+        let result_125 = walk_bti_trie(&trie_data, 17, &[0x40, 0xF9]).unwrap();
+        assert_eq!(
+            result_125,
+            Some(BtiPartitionLocation::DataOffset(125)),
+            "[0x40,0xF9] must resolve to DataOffset(125)"
+        );
+
+        // Now use the public API (lookup_partition_in_bti_file) with a fresh Cursor:
+        use std::io::Cursor;
+        let raw = std::fs::read(&partitions_db).unwrap();
+
+        // [0x40, 0x90] → DataOffset(0)  (trie path, NOT sequential scan)
+        let mut cursor = Cursor::new(raw.clone());
+        let r = lookup_partition_in_bti_file(&mut cursor, &[0x40, 0x90]).unwrap();
+        assert_eq!(r, Some(BtiPartitionLocation::DataOffset(0)));
+
+        // [0x40, 0xBC] → DataOffset(63)
+        let mut cursor = Cursor::new(raw.clone());
+        let r = lookup_partition_in_bti_file(&mut cursor, &[0x40, 0xBC]).unwrap();
+        assert_eq!(r, Some(BtiPartitionLocation::DataOffset(63)));
+
+        // [0x40, 0xF9] → DataOffset(125)
+        let mut cursor = Cursor::new(raw.clone());
+        let r = lookup_partition_in_bti_file(&mut cursor, &[0x40, 0xF9]).unwrap();
+        assert_eq!(r, Some(BtiPartitionLocation::DataOffset(125)));
+
+        // Key not in trie → None
+        let mut cursor = Cursor::new(raw.clone());
+        let r = lookup_partition_in_bti_file(&mut cursor, &[0x40, 0x00]).unwrap();
+        assert_eq!(r, None);
+
+        println!(
+            "VERIFIED: lookup_partition_in_bti_file resolved all 3 BTI partition \
+             offsets (0, 63, 125) via trie walk, NOT sequential scan"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Stub-non-silent tests (issue #755 scope decision)
+    // -----------------------------------------------------------------------
+
+    /// Verify that RowsParser::range_query returns an explicit error rather
+    /// than silently returning an empty Vec (which would be a wrong-result path).
+    #[test]
+    fn rows_parser_range_query_returns_explicit_error_not_empty_vec() {
+        let root_node = payload_only_node(1000, 50);
+        let data = make_bti_file(root_node);
+        let cursor = std::io::Cursor::new(data);
+        let mut parser = RowsParser::new(cursor).unwrap();
+
+        let start = vec![Value::Text("start".to_string())];
+        let end = vec![Value::Text("end".to_string())];
+        let result = parser.range_query(&start, &end);
+        assert!(
+            result.is_err(),
+            "range_query must return Err (not Ok(empty Vec)) to prevent silent wrong-result: got {:?}", result
+        );
+    }
+
+    /// Verify that PartitionIterator::next returns Some(Err(_)) on first call
+    /// rather than None (which would look like an empty index).
+    #[test]
+    fn partition_iterator_next_returns_explicit_error_not_none() {
+        let data = make_bti_file(payload_only_node(1000, 50));
+        let cursor = std::io::Cursor::new(data);
+        let mut parser = PartitionsParser::new(cursor).unwrap();
+        let mut iter = parser.iterate_partitions().unwrap();
+        let first = iter.next();
+        assert!(
+            matches!(first, Some(Err(_))),
+            "PartitionIterator must yield Some(Err(_)) on first call (not None); \
+             got: {:?}",
+            first
+        );
+    }
+
+    /// Verify that RowIterator::next returns Some(Err(_)) on first call
+    /// rather than None (which would look like an empty row index).
+    #[test]
+    fn row_iterator_next_returns_explicit_error_not_none() {
+        let data = make_bti_file(payload_only_node(1000, 50));
+        let cursor = std::io::Cursor::new(data);
+        let mut parser = RowsParser::new(cursor).unwrap();
+        let mut iter = parser.iterate_rows().unwrap();
+        let first = iter.next();
+        assert!(
+            matches!(first, Some(Err(_))),
+            "RowIterator must yield Some(Err(_)) on first call (not None); \
+             got: {:?}",
+            first
+        );
     }
 }

--- a/cqlite-core/src/util/cassandra_murmur3.rs
+++ b/cqlite-core/src/util/cassandra_murmur3.rs
@@ -354,4 +354,58 @@ mod tests {
         let (h1, _h2) = cassandra_murmur3_x64_128(b"a");
         assert_eq!(h1, -8839064797231613815_i64);
     }
+
+    /// Validate the byte-comparable token encoding for the three UUID keys
+    /// used in the test_da/simple_table BTI fixture.  These values were verified
+    /// against the real Partitions.db trie structure (issue #755).
+    ///
+    /// The byte-comparable form of a Murmur3 token is:
+    ///   (token as u64) XOR 0x8000_0000_0000_0000  (flips sign bit → unsigned sort order)
+    ///
+    /// The first byte of each bc token matches the Sparse8 transition byte in the
+    /// real Partitions.db trie (see da-2-bti-Partitions.db hex analysis in #755).
+    #[test]
+    fn uuid_murmur3_token_bc_matches_bti_trie_transitions() {
+        // These expected values were verified by parsing the real
+        // da-2-bti-Partitions.db fixture and reading the Sparse8 transition bytes.
+        // Token order determines Data.db write order: 22 < 11 < 33.
+        struct Case {
+            uuid_byte: u8,
+            expected_token: i64,
+            expected_bc_first_byte: u8,
+        }
+        let cases = [
+            Case {
+                uuid_byte: 0x22,
+                expected_token: 1213057064512856170,
+                expected_bc_first_byte: 0x90,
+            },
+            Case {
+                uuid_byte: 0x11,
+                expected_token: 4360155383588533346,
+                expected_bc_first_byte: 0xBC,
+            },
+            Case {
+                uuid_byte: 0x33,
+                expected_token: 8780122315263850168u64 as i64,
+                expected_bc_first_byte: 0xF9,
+            },
+        ];
+        for c in &cases {
+            let uuid = [c.uuid_byte; 16];
+            let token = cassandra_murmur3_token(&uuid);
+            assert_eq!(
+                token, c.expected_token,
+                "token mismatch for UUID {:02X}*16",
+                c.uuid_byte
+            );
+            let bc = (token as u64) ^ 0x8000_0000_0000_0000u64;
+            assert_eq!(
+                (bc >> 56) as u8,
+                c.expected_bc_first_byte,
+                "bc first byte mismatch for UUID {:02X}*16",
+                c.uuid_byte
+            );
+        }
+    }
 }

--- a/cqlite-core/tests/issue_755_bti_trie_point_lookup.rs
+++ b/cqlite-core/tests/issue_755_bti_trie_point_lookup.rs
@@ -1,0 +1,425 @@
+//! End-to-end integration test for Issue #755: BTI trie point lookup
+//!
+//! # What this proves
+//!
+//! The BTI Partitions.db trie lookup (`lookup_raw_key_in_bti_partitions_db`)
+//! resolves the exact Data.db byte offset for each UUID partition **before**
+//! reading any Data.db bytes.  This is point-lookup via trie — not sequential
+//! scan.
+//!
+//! # Validation chain
+//!
+//! 1. Open `da-2-bti-Partitions.db` from the real `test_da/simple_table` fixture.
+//! 2. Call `lookup_raw_key_in_bti_partitions_db` with raw UUID bytes for all
+//!    three partitions.
+//! 3. Assert the returned `BtiPartitionLocation::DataOffset` values match the
+//!    "position" fields in the JSONL sstabledump golden:
+//!    - `[0x22]*16` → offset 0
+//!    - `[0x11]*16` → offset 63
+//!    - `[0x33]*16` → offset 125
+//! 4. Open `da-2-bti-CompressionInfo.db` and `da-2-bti-Data.db`.
+//! 5. Decompress the LZ4 chunk using `ChunkReader` + `Compression::decompress`.
+//! 6. At each resolved offset in the decompressed buffer, parse the partition
+//!    header and read the 16-byte UUID key.
+//! 7. Assert the UUID bytes match the partition key we originally looked up
+//!    (proves trie resolved the right offset, not a lucky scan result).
+//!
+//! # Architecture constraint
+//!
+//! `SSTableReader::open` still returns `Error::UnsupportedFormat` for BTI Data.db
+//! (the `issue_657_da_foundation.rs` test asserts this; that gate is intentional).
+//! This test bypasses the high-level reader and calls the lower-level trie and
+//! compression APIs directly — the same path a future BTI-aware reader would use.
+//!
+//! # Test data requirement
+//!
+//! The `CQLITE_DATASETS_ROOT` environment variable must point to the
+//! `test-data/datasets` directory and the `test_da` binary SSTables must have
+//! been fetched:
+//!
+//! ```bash
+//! bash test-data/scripts/fetch-datasets.sh
+//! ```
+//!
+//! Tests skip gracefully when binary files are absent.
+
+use cqlite_core::storage::sstable::bti::{
+    lookup_raw_key_in_bti_partitions_db, BtiPartitionLocation,
+};
+use cqlite_core::storage::sstable::chunk_reader::ChunkReader;
+use cqlite_core::storage::sstable::compression::{Compression, CompressionAlgorithm};
+use cqlite_core::storage::sstable::compression_info::CompressionInfo;
+use std::fs::File;
+use std::io::BufReader;
+use std::path::PathBuf;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// The three test UUID partitions in the `test_da/simple_table` fixture.
+///
+/// Golden "position" values come from `da-2-bti-Data.db.jsonl` (sstabledump
+/// output).
+struct Partition {
+    /// Raw 16-byte UUID (all bytes identical for these test UUIDs)
+    uuid_byte: u8,
+    /// Expected Data.db uncompressed byte offset (from JSONL golden)
+    expected_offset: u64,
+    /// Canonical display UUID string (for diagnostics)
+    label: &'static str,
+}
+
+const TEST_PARTITIONS: &[Partition] = &[
+    Partition {
+        uuid_byte: 0x22,
+        expected_offset: 0,
+        label: "22222222-2222-2222-2222-222222222222",
+    },
+    Partition {
+        uuid_byte: 0x11,
+        expected_offset: 63,
+        label: "11111111-1111-1111-1111-111111111111",
+    },
+    Partition {
+        uuid_byte: 0x33,
+        expected_offset: 125,
+        label: "33333333-3333-3333-3333-333333333333",
+    },
+];
+
+/// Return the path to the `test_da/simple_table-*` SSTable directory, or `None`
+/// if the binary Partitions.db sentinel is absent.
+fn da_simple_table_dir() -> Option<PathBuf> {
+    let root = std::env::var("CQLITE_DATASETS_ROOT").ok()?;
+    let base = PathBuf::from(root).join("sstables").join("test_da");
+
+    let table_dir = std::fs::read_dir(&base)
+        .ok()?
+        .flatten()
+        .find(|e| e.file_name().to_string_lossy().starts_with("simple_table-"))
+        .map(|e| e.path())?;
+
+    // Guard: binary files must be present (CI may have goldens-only checkout)
+    let has_partitions_db = std::fs::read_dir(&table_dir).ok()?.flatten().any(|e| {
+        let s = e.file_name();
+        let s = s.to_string_lossy();
+        s.starts_with("da-") && s.ends_with("-bti-Partitions.db")
+    });
+
+    if !has_partitions_db {
+        eprintln!(
+            "SKIP: da-*-bti-Partitions.db not present in {:?}. \
+             Run `bash test-data/scripts/fetch-datasets.sh` to download.",
+            table_dir
+        );
+        return None;
+    }
+
+    Some(table_dir)
+}
+
+/// Find the first file in `dir` whose name matches `starts_with` + `ends_with`.
+fn find_file(dir: &PathBuf, starts_with: &str, ends_with: &str) -> Option<PathBuf> {
+    std::fs::read_dir(dir)
+        .ok()?
+        .flatten()
+        .find(|e| {
+            let n = e.file_name();
+            let s = n.to_string_lossy();
+            s.starts_with(starts_with) && s.ends_with(ends_with)
+        })
+        .map(|e| e.path())
+}
+
+// ---------------------------------------------------------------------------
+// Core test: trie resolves correct Data.db offsets
+// ---------------------------------------------------------------------------
+
+/// Phase 1: Verify that the BTI trie lookup returns the golden Data.db offsets.
+///
+/// The resolved offsets come ENTIRELY from Partitions.db — Data.db is NOT
+/// opened yet in this phase.  That is the definition of "trie, not scan".
+#[test]
+fn bti_trie_resolves_data_db_offsets() {
+    let Some(dir) = da_simple_table_dir() else {
+        eprintln!("SKIP: test_da/simple_table binary SSTables not available");
+        return;
+    };
+
+    let partitions_db = match find_file(&dir, "da-", "-bti-Partitions.db") {
+        Some(p) => p,
+        None => {
+            eprintln!("SKIP: da-*-bti-Partitions.db not found in {:?}", dir);
+            return;
+        }
+    };
+
+    let file = File::open(&partitions_db)
+        .unwrap_or_else(|e| panic!("Failed to open {:?}: {}", partitions_db, e));
+    let mut reader = BufReader::new(file);
+
+    for p in TEST_PARTITIONS {
+        let raw_uuid: [u8; 16] = [p.uuid_byte; 16];
+
+        let result = lookup_raw_key_in_bti_partitions_db(&mut reader, &raw_uuid)
+            .unwrap_or_else(|e| panic!("Trie lookup failed for UUID {}: {}", p.label, e));
+
+        match result {
+            Some(BtiPartitionLocation::DataOffset(offset)) => {
+                assert_eq!(
+                    offset, p.expected_offset,
+                    "UUID {} trie lookup: expected DataOffset({}) but got DataOffset({})",
+                    p.label, p.expected_offset, offset
+                );
+            }
+            Some(BtiPartitionLocation::RowsOffset(rows_off)) => {
+                panic!(
+                    "UUID {} trie lookup returned RowsOffset({}) but expected DataOffset({}). \
+                     simple_table is a narrow-partition table so Rows.db offsets are not expected.",
+                    p.label, rows_off, p.expected_offset
+                );
+            }
+            None => {
+                panic!(
+                    "UUID {} not found in Partitions.db trie (lookup returned None). \
+                     Expected DataOffset({}).",
+                    p.label, p.expected_offset
+                );
+            }
+        }
+    }
+
+    eprintln!(
+        "bti_trie_resolves_data_db_offsets PASSED: all three UUID trie lookups \
+         returned the golden Data.db offsets (0, 63, 125)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Core test: decompressed Data.db contains the correct partition key bytes
+//            at the trie-resolved offsets
+// ---------------------------------------------------------------------------
+
+/// Phase 2: Decompress Data.db chunk and verify UUID bytes at each trie-resolved
+/// offset.
+///
+/// This test COMBINES the trie lookup with Data.db decompression to provide full
+/// end-to-end parity proof:
+///  - Trie resolves offset O for UUID key K.
+///  - Decompressed Data.db[O] == partition-header for K.
+///
+/// Partition header format (da / oa format, V5CompressedLegacy with
+/// `hasUIntDeletionTime`):
+///   byte 0:     flags          (0x00 for simple partitions)
+///   byte 1:     key_len (u8)   (0x10 = 16 for UUID)
+///   bytes 2-17: raw UUID bytes
+///   byte 18:    deletion-time byte (0x80 = LIVE)
+#[test]
+fn bti_trie_offset_points_to_correct_uuid_in_data_db() {
+    let Some(dir) = da_simple_table_dir() else {
+        eprintln!("SKIP: test_da/simple_table binary SSTables not available");
+        return;
+    };
+
+    // ---- 1. Locate the three SSTable components ----
+    let partitions_db = match find_file(&dir, "da-", "-bti-Partitions.db") {
+        Some(p) => p,
+        None => {
+            eprintln!("SKIP: da-*-bti-Partitions.db not found");
+            return;
+        }
+    };
+    let compression_info_path = match find_file(&dir, "da-", "-bti-CompressionInfo.db") {
+        Some(p) => p,
+        None => {
+            eprintln!("SKIP: da-*-bti-CompressionInfo.db not found");
+            return;
+        }
+    };
+    let data_db_path = match find_file(&dir, "da-", "-bti-Data.db") {
+        Some(p) => p,
+        None => {
+            eprintln!("SKIP: da-*-bti-Data.db not found");
+            return;
+        }
+    };
+
+    // ---- 2. Phase 1: trie lookups (Data.db not yet opened) ----
+    let mut partitions_file = BufReader::new(
+        File::open(&partitions_db).unwrap_or_else(|e| panic!("open {:?}: {}", partitions_db, e)),
+    );
+
+    let mut resolved_offsets: Vec<(u8, u64)> = Vec::new();
+    for p in TEST_PARTITIONS {
+        let raw_uuid: [u8; 16] = [p.uuid_byte; 16];
+        let loc = lookup_raw_key_in_bti_partitions_db(&mut partitions_file, &raw_uuid)
+            .unwrap_or_else(|e| panic!("trie lookup for UUID {}: {}", p.label, e))
+            .unwrap_or_else(|| panic!("UUID {} not found in trie", p.label));
+
+        let data_offset = match loc {
+            BtiPartitionLocation::DataOffset(off) => off,
+            BtiPartitionLocation::RowsOffset(off) => {
+                panic!(
+                    "UUID {} returned RowsOffset({}); expected DataOffset",
+                    p.label, off
+                )
+            }
+        };
+
+        assert_eq!(
+            data_offset, p.expected_offset,
+            "Phase-1 assertion: UUID {} expected offset {} got {}",
+            p.label, p.expected_offset, data_offset
+        );
+        resolved_offsets.push((p.uuid_byte, data_offset));
+    }
+
+    // ---- 3. Decompress Data.db ----
+    let compression_raw = std::fs::read(&compression_info_path)
+        .unwrap_or_else(|e| panic!("read {:?}: {}", compression_info_path, e));
+    let compression_info = CompressionInfo::parse(&compression_raw)
+        .unwrap_or_else(|e| panic!("parse CompressionInfo: {}", e));
+
+    // Detect compression algorithm from the parsed name
+    let algorithm = CompressionAlgorithm::from(compression_info.algorithm.as_str());
+
+    let data_file =
+        File::open(&data_db_path).unwrap_or_else(|e| panic!("open {:?}: {}", data_db_path, e));
+    let data_file_size = data_file
+        .metadata()
+        .unwrap_or_else(|e| panic!("metadata {:?}: {}", data_db_path, e))
+        .len();
+
+    let mut chunk_reader =
+        ChunkReader::new(BufReader::new(data_file), compression_info, data_file_size);
+
+    // All three partitions are in chunk 0 (data_length = 191, single 16 KiB chunk)
+    let compressed_chunk = chunk_reader
+        .read_chunk(0)
+        .unwrap_or_else(|e| panic!("read_chunk(0): {}", e));
+
+    let compressor =
+        Compression::new(algorithm).unwrap_or_else(|e| panic!("Compression::new: {}", e));
+    let decompressed = compressor
+        .decompress(&compressed_chunk)
+        .unwrap_or_else(|e| panic!("decompress chunk 0: {}", e));
+
+    assert!(
+        !decompressed.is_empty(),
+        "Decompressed Data.db chunk 0 must not be empty"
+    );
+
+    // ---- 4. Phase 2: verify UUID bytes at trie-resolved offsets ----
+    //
+    // Partition header layout (da / oa, V5CompressedLegacy hasUIntDeletionTime):
+    //   [0]      flags     (0x00)
+    //   [1]      key_len   (0x10 = 16)
+    //   [2..18]  UUID bytes (16 bytes)
+    //   [18]     deletion-time byte (0x80 = LIVE)
+    const FLAGS_OFFSET: usize = 0;
+    const KEY_LEN_OFFSET: usize = 1;
+    const KEY_DATA_OFFSET: usize = 2;
+    const UUID_LEN: usize = 16;
+
+    for (uuid_byte, data_offset) in &resolved_offsets {
+        let off = *data_offset as usize;
+
+        // Guard: bounds check before indexing
+        assert!(
+            off + KEY_DATA_OFFSET + UUID_LEN <= decompressed.len(),
+            "Partition at offset {} extends past decompressed buffer len {}",
+            off,
+            decompressed.len()
+        );
+
+        let flags = decompressed[off + FLAGS_OFFSET];
+        let key_len = decompressed[off + KEY_LEN_OFFSET] as usize;
+
+        assert_eq!(
+            key_len, UUID_LEN,
+            "Partition at offset {}: expected key_len=16 for UUID, got {}. flags=0x{:02x}",
+            off, key_len, flags
+        );
+
+        let uuid_bytes = &decompressed[off + KEY_DATA_OFFSET..off + KEY_DATA_OFFSET + UUID_LEN];
+        let expected_uuid: [u8; UUID_LEN] = [*uuid_byte; UUID_LEN];
+
+        assert_eq!(
+            uuid_bytes,
+            &expected_uuid[..],
+            "Partition at offset {} (uuid_byte=0x{:02x}): UUID bytes in Data.db do not match. \
+             Got: {:?}, Expected: {:?}",
+            off,
+            uuid_byte,
+            uuid_bytes,
+            expected_uuid
+        );
+    }
+
+    eprintln!(
+        "bti_trie_offset_points_to_correct_uuid_in_data_db PASSED: \
+         trie-resolved offsets (0, 63, 125) each point to the correct UUID bytes \
+         in the decompressed Data.db"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Regression guard: SSTableReader::open on BTI Data.db still returns
+// UnsupportedFormat (issue_657_da_foundation.rs contract must not break)
+// ---------------------------------------------------------------------------
+
+/// Verify that the BTI gate in SSTableReader::open is still in effect.
+///
+/// This is a redundant guard — `issue_657_da_foundation.rs` is the canonical
+/// home of this assertion — but having it here makes the #755 test file
+/// self-contained and prevents accidental removal of the gate.
+#[tokio::test]
+async fn bti_sstable_reader_open_still_returns_unsupported_format() {
+    let Some(dir) = da_simple_table_dir() else {
+        eprintln!("SKIP: test_da/simple_table binary SSTables not available");
+        return;
+    };
+
+    let data_db = match find_file(&dir, "da-", "-bti-Data.db") {
+        Some(p) => p,
+        None => {
+            eprintln!("SKIP: da-*-bti-Data.db not found");
+            return;
+        }
+    };
+
+    use cqlite_core::{storage::sstable::reader::SSTableReader, Config, Error};
+    use std::sync::Arc;
+
+    let config = Config::default();
+    let platform = Arc::new(
+        cqlite_core::platform::Platform::new(&config)
+            .await
+            .expect("Platform::new"),
+    );
+
+    let result = SSTableReader::open(&data_db, &config, platform).await;
+    assert!(
+        result.is_err(),
+        "SSTableReader::open on BTI Data.db must still return an error"
+    );
+
+    let err = result.unwrap_err();
+    assert!(
+        matches!(err, Error::UnsupportedFormat(_)),
+        "Error must be UnsupportedFormat, got: {:?}",
+        err
+    );
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("BTI (da)"),
+        "Error message must contain 'BTI (da)'. Got: {msg}"
+    );
+
+    eprintln!(
+        "bti_sstable_reader_open_still_returns_unsupported_format PASSED: \
+         SSTableReader::open gate is intact"
+    );
+}


### PR DESCRIPTION
Part of Epic #751. Closes #755. Reader-path integration tracked in #831; traversal iterators in #832.

## What this does
Implements and verifies the **BTI partition-index point-lookup primitive** — the offset extraction the issue title asks for:
- `decode_bti_partition_payload` / `walk_bti_trie`: decode real Cassandra 5.0 BTI `Partitions.db` (headerless trie, 8-byte root-offset footer; leaf payload `[hash byte][position: SizedInts]`, `~position` sign convention → Data.db offset), wiring in the existing `sized_ints.rs` helpers.
- `encode_partition_key_for_bti_trie` + `lookup_raw_key_in_bti_partitions_db`: compute the Murmur3 token, byte-comparable-encode it (`[0x40]` + 8 token bytes), walk the trie, and return the Data.db offset for a partition key.
- Fixed `walk_bti_trie` Patricia-trie handling (a `PayloadOnly` leaf is a valid match regardless of remaining key bytes).
- The three stubbed traversal paths (`range_query`, `PartitionIterator::next`, `RowIterator::next`) are converted from silent empty returns to **explicit errors** (no silent wrong-result paths) — real implementations tracked in #832.

## Verification (real fixtures, not synthetic)
`tests/issue_755_bti_trie_point_lookup.rs` against the real `test_da/simple_table` BTI SSTables:
- `bti_trie_resolves_data_db_offsets` — trie resolves `DataOffset(0/63/125)` matching the sstabledump JSONL golden, **with Data.db never opened** (proves trie seek, not scan).
- `bti_trie_offset_points_to_correct_uuid_in_data_db` — decompresses the LZ4 Data.db chunk and confirms the UUID bytes at each resolved offset match the looked-up key (proves the offsets are correct, not just consistent).
- Murmur3 token→byte-comparable encoding validated against the three fixture UUIDs.

## Honest scope (why reader-path integration is deferred)
This primitive is **not yet reachable through `SSTableReader`'s public API**: `SSTableReader::open` currently rejects BTI ("da") tables (the #657 foundation gate), so a reader point lookup on a BTI table is impossible until BTI reader-open support exists. Wiring the trie lookup into the reader's `sequential_scan` fallback path is therefore tracked as **#831** (depends on BTI reader-open support). `bti_sstable_reader_open_still_returns_unsupported_format` documents that the gate remains intact.

## Gate (scripts/agent-gate.sh)
```
fmt: PASS  clippy: PASS  core-tests: PASS  integration-tests: PASS
write-tests: PASS  cli-tests: PASS  minimal-build: PASS  smoke: PASS
RESULT: PASS
```