### PR TITLE
feat(cql): parse WRITETIME()/TTL() select functions with validation (#690)

### DIFF
--- a/cqlite-core/src/query/mod.rs
+++ b/cqlite-core/src/query/mod.rs
@@ -23,6 +23,7 @@ pub mod parser;
 pub mod planner;
 pub mod prepared;
 pub mod result;
+pub mod writetime_ttl_validator;
 
 // Advanced SELECT query components
 #[cfg(feature = "state_machine")]
@@ -52,6 +53,10 @@ pub use prepared::{
 pub use result::{
     cql_type_to_data_type, ColumnInfo, PerformanceMetrics, QueryMetadata, QueryResult,
     QueryResultIterator, QueryRow, RowMetadata, StreamingConfig,
+};
+pub use writetime_ttl_validator::{
+    descriptors_from_table_schema, validate_all_writetime_ttl_calls, validate_writetime_ttl_call,
+    ColumnDescriptor as WriteTimeTtlColumnDescriptor, WriteTimeTtlKind,
 };
 
 // Re-export advanced SELECT components.

--- a/cqlite-core/src/query/select_ast.rs
+++ b/cqlite-core/src/query/select_ast.rs
@@ -50,6 +50,11 @@ pub enum SelectExpression {
     Aggregate(AggregateFunction),
     /// Scalar function
     Function(FunctionCall),
+    /// `WRITETIME(col)` or `TTL(col)` — first-class metadata-retrieval functions.
+    ///
+    /// Using a dedicated variant avoids downstream string-matching on the function
+    /// name and keeps the executor dispatch explicit and exhaustive.
+    WriteTimeTtl(WriteTimeTtlCall),
     /// Literal value
     Literal(Value),
     /// Collection access (list[0], map['key'])
@@ -97,6 +102,35 @@ pub struct FunctionCall {
     pub name: String,
     /// Arguments
     pub args: Vec<SelectExpression>,
+}
+
+/// The two metadata-retrieval functions Cassandra exposes in SELECT.
+///
+/// These are first-class variants rather than being folded into `FunctionCall`
+/// so the executor can dispatch on them without string-matching function names.
+///
+/// # Executor TODO (#692)
+/// Evaluation is not yet wired: the executor must thread `writetime` / `ttl`
+/// cell-level metadata from `SSTableReader` up through the row-scanning loop
+/// and then return `Value::BigInt(micros)` / `Value::Int(seconds)` respectively.
+/// Until that work lands, selecting these columns returns `Value::Null`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum WriteTimeTtlFunction {
+    /// `WRITETIME(col)` — returns the write timestamp in microseconds (bigint)
+    WriteTime,
+    /// `TTL(col)` — returns the remaining TTL in seconds (int), or NULL if no TTL
+    Ttl,
+}
+
+/// A parsed `WRITETIME(col)` or `TTL(col)` select item.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct WriteTimeTtlCall {
+    /// Which function was written
+    pub function: WriteTimeTtlFunction,
+    /// The single column argument (case-preserved from the source text)
+    pub column: String,
+    /// Optional alias (`WRITETIME(col) AS wt`)
+    pub alias: Option<String>,
 }
 
 /// Collection access operations
@@ -334,6 +368,9 @@ impl SelectExpression {
             SelectExpression::Column(col_ref) => vec![col_ref.clone()],
             SelectExpression::Aggregate(agg) => collect_refs(&agg.args),
             SelectExpression::Function(func) => collect_refs(&func.args),
+            SelectExpression::WriteTimeTtl(call) => {
+                vec![ColumnRef::new(call.column.clone())]
+            }
             SelectExpression::CollectionAccess(access) => {
                 let (col_ref, sub_expr) = match access {
                     CollectionAccessExpression::ListIndex(c, e)

--- a/cqlite-core/src/query/select_executor.rs
+++ b/cqlite-core/src/query/select_executor.rs
@@ -1151,6 +1151,11 @@ impl SelectExecutor {
                     "Function expressions not yet implemented".to_string(),
                 ))
             }
+            // TODO (#692): Thread writetime/ttl cell metadata from SSTableReader
+            // up through the scan loop and return Value::BigInt(micros) for
+            // WRITETIME and Value::Int(seconds) for TTL. Until that work lands,
+            // we return NULL to avoid incorrect results.
+            SelectExpression::WriteTimeTtl(_) => Ok(Value::Null),
         }
     }
 

--- a/cqlite-core/src/query/select_parser.rs
+++ b/cqlite-core/src/query/select_parser.rs
@@ -17,6 +17,11 @@
 use super::select_ast::*;
 use crate::{Error, Result, TableId, Value};
 
+// WRITETIME and TTL are reserved words in CQL that introduce a special
+// single-argument metadata-retrieval form. They are handled as dedicated tokens
+// so the parser can produce a first-class `SelectExpression::WriteTimeTtl`
+// rather than falling through to the generic `FunctionCall` path.
+
 /// Advanced CQL SELECT parser
 #[derive(Debug)]
 pub struct SelectParser {
@@ -60,6 +65,9 @@ pub enum Token {
     Null,
     Contains,
     Key,
+    // Metadata-retrieval functions (CQL reserved words)
+    Writetime,
+    Ttl,
 
     // Operators
     Equal,            // =
@@ -135,6 +143,8 @@ fn keyword_for(ident: &str) -> Option<Token> {
         ("NULL", Token::Null),
         ("CONTAINS", Token::Contains),
         ("KEY", Token::Key),
+        ("WRITETIME", Token::Writetime),
+        ("TTL", Token::Ttl),
         ("TRUE", Token::Boolean(true)),
         ("FALSE", Token::Boolean(false)),
     ];
@@ -582,6 +592,19 @@ impl SelectParser {
             return self.parse_aggregate_function(agg);
         }
 
+        // WRITETIME(col) and TTL(col) — first-class metadata-retrieval functions.
+        // They tokenize as dedicated keywords so they are caught here before the
+        // generic identifier path.
+        if matches!(self.peek(), Token::Writetime | Token::Ttl) {
+            let function = match self.current_token.clone() {
+                Some(Token::Writetime) => WriteTimeTtlFunction::WriteTime,
+                Some(Token::Ttl) => WriteTimeTtlFunction::Ttl,
+                _ => unreachable!("peek guard ensures only Writetime or Ttl here"),
+            };
+            self.advance()?;
+            return self.parse_writetime_ttl_call(function);
+        }
+
         // Take ownership/copy of literal payloads up front so we can call &mut self.
         match self.current_token.clone() {
             Some(Token::Identifier(name)) => {
@@ -637,6 +660,66 @@ impl SelectParser {
                 other
             ))),
         }
+    }
+
+    /// Parse `WRITETIME(col)` or `TTL(col)`.
+    ///
+    /// The function keyword has already been consumed by the caller.
+    /// Grammar: `'(' identifier ')'` optionally followed by `AS alias`.
+    fn parse_writetime_ttl_call(
+        &mut self,
+        function: WriteTimeTtlFunction,
+    ) -> Result<SelectExpression> {
+        self.expect(Token::LeftParen)?;
+
+        // Argument must be a single bare identifier (the column name).
+        let column = match self.current_token.clone() {
+            Some(Token::Identifier(name)) => {
+                self.advance()?;
+                name
+            }
+            other => {
+                return Err(Error::cql_parse(format!(
+                    "{} requires a single column name argument, found: {:?}",
+                    match function {
+                        WriteTimeTtlFunction::WriteTime => "WRITETIME",
+                        WriteTimeTtlFunction::Ttl => "TTL",
+                    },
+                    other
+                )));
+            }
+        };
+
+        self.expect(Token::RightParen)?;
+
+        // Optional alias: `WRITETIME(col) AS wt`
+        // Aliases in SELECT are supported by the grammar (the surrounding
+        // `parse_select_expression` already handles `AS`), but we handle it here
+        // too so we can attach it directly to the `WriteTimeTtlCall` for clarity.
+        // The outer `parse_select_expression` wraps us in `Aliased` when it sees
+        // `AS`; that path is the canonical one and this variant stores it inline.
+        let alias = if self.eat(&Token::As)? {
+            match self.current_token.clone() {
+                Some(Token::Identifier(alias_name)) => {
+                    self.advance()?;
+                    Some(alias_name)
+                }
+                other => {
+                    return Err(Error::cql_parse(format!(
+                        "Expected alias identifier after AS, found: {:?}",
+                        other
+                    )));
+                }
+            }
+        } else {
+            None
+        };
+
+        Ok(SelectExpression::WriteTimeTtl(WriteTimeTtlCall {
+            function,
+            column,
+            alias,
+        }))
     }
 
     /// Parse aggregate function
@@ -937,7 +1020,179 @@ pub fn parse_select(cql: &str) -> Result<SelectStatement> {
 
 #[cfg(all(test, feature = "state_machine"))]
 mod tests {
+    use super::super::select_ast::{SelectExpression, WriteTimeTtlFunction};
     use super::*;
+
+    // --- WRITETIME / TTL parser tests (Issue #690) ---
+
+    #[test]
+    fn test_writetime_basic() {
+        let stmt = parse_select("SELECT WRITETIME(name) FROM ks.tbl").unwrap();
+        if let SelectClause::Columns(exprs) = stmt.select_clause {
+            assert_eq!(exprs.len(), 1);
+            match &exprs[0] {
+                SelectExpression::WriteTimeTtl(call) => {
+                    assert_eq!(call.function, WriteTimeTtlFunction::WriteTime);
+                    assert_eq!(call.column, "name");
+                    assert!(call.alias.is_none());
+                }
+                other => panic!("Expected WriteTimeTtl, got: {:?}", other),
+            }
+        } else {
+            panic!("Expected Columns select clause");
+        }
+    }
+
+    #[test]
+    fn test_ttl_basic() {
+        let stmt = parse_select("SELECT TTL(name) FROM ks.tbl").unwrap();
+        if let SelectClause::Columns(exprs) = stmt.select_clause {
+            assert_eq!(exprs.len(), 1);
+            match &exprs[0] {
+                SelectExpression::WriteTimeTtl(call) => {
+                    assert_eq!(call.function, WriteTimeTtlFunction::Ttl);
+                    assert_eq!(call.column, "name");
+                    assert!(call.alias.is_none());
+                }
+                other => panic!("Expected WriteTimeTtl, got: {:?}", other),
+            }
+        } else {
+            panic!("Expected Columns select clause");
+        }
+    }
+
+    #[test]
+    fn test_writetime_lowercase() {
+        // CQL is case-insensitive; the keyword should parse regardless of case.
+        let stmt = parse_select("SELECT writetime(name) FROM tbl").unwrap();
+        if let SelectClause::Columns(exprs) = stmt.select_clause {
+            match &exprs[0] {
+                SelectExpression::WriteTimeTtl(call) => {
+                    assert_eq!(call.function, WriteTimeTtlFunction::WriteTime);
+                }
+                other => panic!("Expected WriteTimeTtl, got: {:?}", other),
+            }
+        } else {
+            panic!("Expected Columns");
+        }
+    }
+
+    #[test]
+    fn test_ttl_lowercase() {
+        let stmt = parse_select("SELECT ttl(name) FROM tbl").unwrap();
+        if let SelectClause::Columns(exprs) = stmt.select_clause {
+            match &exprs[0] {
+                SelectExpression::WriteTimeTtl(call) => {
+                    assert_eq!(call.function, WriteTimeTtlFunction::Ttl);
+                }
+                other => panic!("Expected WriteTimeTtl, got: {:?}", other),
+            }
+        } else {
+            panic!("Expected Columns");
+        }
+    }
+
+    #[test]
+    fn test_writetime_mixed_case() {
+        let stmt = parse_select("SELECT WriteTime(name) FROM tbl").unwrap();
+        if let SelectClause::Columns(exprs) = stmt.select_clause {
+            match &exprs[0] {
+                SelectExpression::WriteTimeTtl(call) => {
+                    assert_eq!(call.function, WriteTimeTtlFunction::WriteTime);
+                }
+                other => panic!("Expected WriteTimeTtl, got: {:?}", other),
+            }
+        } else {
+            panic!("Expected Columns");
+        }
+    }
+
+    #[test]
+    fn test_writetime_and_ttl_together() {
+        let stmt = parse_select("SELECT WRITETIME(name), TTL(name) FROM ks.tbl").unwrap();
+        if let SelectClause::Columns(exprs) = stmt.select_clause {
+            assert_eq!(exprs.len(), 2);
+            match &exprs[0] {
+                SelectExpression::WriteTimeTtl(c) => {
+                    assert_eq!(c.function, WriteTimeTtlFunction::WriteTime);
+                }
+                other => panic!("Expected WriteTimeTtl for first expr, got: {:?}", other),
+            }
+            match &exprs[1] {
+                SelectExpression::WriteTimeTtl(c) => {
+                    assert_eq!(c.function, WriteTimeTtlFunction::Ttl);
+                }
+                other => panic!("Expected WriteTimeTtl for second expr, got: {:?}", other),
+            }
+        } else {
+            panic!("Expected Columns");
+        }
+    }
+
+    #[test]
+    fn test_writetime_with_alias() {
+        // Aliases on WRITETIME/TTL are supported; the parser captures them inline.
+        let stmt = parse_select("SELECT WRITETIME(name) AS wt FROM tbl").unwrap();
+        if let SelectClause::Columns(exprs) = stmt.select_clause {
+            assert_eq!(exprs.len(), 1);
+            match &exprs[0] {
+                SelectExpression::WriteTimeTtl(call) => {
+                    assert_eq!(call.function, WriteTimeTtlFunction::WriteTime);
+                    assert_eq!(call.alias.as_deref(), Some("wt"));
+                }
+                other => panic!("Expected WriteTimeTtl with alias, got: {:?}", other),
+            }
+        } else {
+            panic!("Expected Columns");
+        }
+    }
+
+    #[test]
+    fn test_ttl_with_alias() {
+        let stmt = parse_select("SELECT ttl(name) AS remaining FROM tbl").unwrap();
+        if let SelectClause::Columns(exprs) = stmt.select_clause {
+            match &exprs[0] {
+                SelectExpression::WriteTimeTtl(call) => {
+                    assert_eq!(call.function, WriteTimeTtlFunction::Ttl);
+                    assert_eq!(call.alias.as_deref(), Some("remaining"));
+                }
+                other => panic!("Expected WriteTimeTtl, got: {:?}", other),
+            }
+        } else {
+            panic!("Expected Columns");
+        }
+    }
+
+    #[test]
+    fn test_writetime_alongside_plain_columns() {
+        let stmt = parse_select("SELECT id, WRITETIME(name), name FROM tbl").unwrap();
+        if let SelectClause::Columns(exprs) = stmt.select_clause {
+            assert_eq!(exprs.len(), 3);
+            assert!(matches!(&exprs[0], SelectExpression::Column(_)));
+            assert!(matches!(&exprs[1], SelectExpression::WriteTimeTtl(_)));
+            assert!(matches!(&exprs[2], SelectExpression::Column(_)));
+        } else {
+            panic!("Expected Columns");
+        }
+    }
+
+    #[test]
+    fn test_column_name_is_preserved() {
+        let stmt = parse_select("SELECT WRITETIME(myColumn) FROM tbl").unwrap();
+        if let SelectClause::Columns(exprs) = stmt.select_clause {
+            match &exprs[0] {
+                SelectExpression::WriteTimeTtl(call) => {
+                    // The column name is preserved as parsed (not lowercased).
+                    assert_eq!(call.column, "myColumn");
+                }
+                other => panic!("Unexpected: {:?}", other),
+            }
+        } else {
+            panic!("Expected Columns");
+        }
+    }
+
+    // --- existing tests (preserved) ---
 
     #[test]
     fn test_simple_select() {

--- a/cqlite-core/src/query/writetime_ttl_validator.rs
+++ b/cqlite-core/src/query/writetime_ttl_validator.rs
@@ -1,0 +1,419 @@
+//! Schema-aware validation for `WRITETIME()` and `TTL()` select functions.
+//!
+//! Cassandra imposes the following restrictions on these metadata-retrieval functions:
+//!
+//! - **Partition-key columns**: not allowed — the error message mirrors Cassandra's:
+//!   `"Cannot use selection function writeTime on PRIMARY KEY part <col>"`
+//! - **Clustering columns**: same restriction as partition keys.
+//! - **Non-frozen collection columns** (`list<T>`, `set<T>`, `map<K,V>` that are *not*
+//!   `frozen<...>`): not allowed — multi-cell semantics mean there is no single
+//!   writetime/TTL for the whole column.  Frozen collections (single-cell) are OK.
+//!   The error mirrors Cassandra's:
+//!   `"Cannot use selection function writeTime on non-frozen <type>"`
+//! - **Unknown columns**: any column not found in the schema is an error.
+//!
+//! # Executor TODO (#692)
+//! This module is the **parser/planning layer only**.  Evaluation (actually reading
+//! `writetime` / `ttl` from SSTable cell metadata) is deferred to issue #692.
+
+use crate::{Error, Result};
+
+/// A parsed `WRITETIME()` or `TTL()` call, as seen during planning.
+///
+/// The caller supplies a slice of these (one per such item in the SELECT list)
+/// together with the schema columns.  Validation is stateless and re-entrant.
+#[derive(Debug, Clone, PartialEq)]
+pub enum WriteTimeTtlKind {
+    WriteTime,
+    Ttl,
+}
+
+impl WriteTimeTtlKind {
+    /// Cassandra spells the function name in lower-case in its error messages.
+    fn cassandra_fn_name(&self) -> &'static str {
+        match self {
+            WriteTimeTtlKind::WriteTime => "writeTime",
+            WriteTimeTtlKind::Ttl => "ttl",
+        }
+    }
+}
+
+/// Minimal column descriptor needed for validation.
+///
+/// The validator works with this lightweight struct so it is not tightly
+/// coupled to any particular schema representation.
+#[derive(Debug, Clone)]
+pub struct ColumnDescriptor {
+    /// Column name (case-insensitive matching is applied by the validator)
+    pub name: String,
+    /// CQL type string (e.g. `"text"`, `"list<int>"`, `"frozen<set<text>>"`)
+    pub type_str: String,
+    /// True when this column is part of the partition key
+    pub is_partition_key: bool,
+    /// True when this column is part of the clustering key
+    pub is_clustering_key: bool,
+}
+
+/// Validate a single `WRITETIME(col)` or `TTL(col)` call against the supplied
+/// schema columns.
+///
+/// Returns `Ok(())` when the call is valid, `Err(...)` with a Cassandra-shaped
+/// error message otherwise.
+///
+/// # Errors
+///
+/// - Unknown column: `Error::CqlParse` with column name.
+/// - Partition-key column: `Error::CqlParse` mirroring Cassandra's message.
+/// - Clustering column: `Error::CqlParse` mirroring Cassandra's message.
+/// - Non-frozen collection column: `Error::CqlParse` mirroring Cassandra's message.
+pub fn validate_writetime_ttl_call(
+    kind: &WriteTimeTtlKind,
+    column_name: &str,
+    columns: &[ColumnDescriptor],
+) -> Result<()> {
+    // Case-insensitive lookup (CQL identifiers are case-insensitive when unquoted).
+    let col = columns
+        .iter()
+        .find(|c| c.name.eq_ignore_ascii_case(column_name))
+        .ok_or_else(|| {
+            Error::cql_parse(format!(
+                "Undefined column name {} in selection clause",
+                column_name
+            ))
+        })?;
+
+    if col.is_partition_key || col.is_clustering_key {
+        return Err(Error::cql_parse(format!(
+            "Cannot use selection function {} on PRIMARY KEY part {}",
+            kind.cassandra_fn_name(),
+            col.name,
+        )));
+    }
+
+    if is_non_frozen_collection(&col.type_str) {
+        return Err(Error::cql_parse(format!(
+            "Cannot use selection function {} on non-frozen {}",
+            kind.cassandra_fn_name(),
+            col.type_str,
+        )));
+    }
+
+    Ok(())
+}
+
+/// Validate all `WRITETIME()`/`TTL()` calls in a SELECT list at once.
+///
+/// Returns the first error encountered, or `Ok(())` if all are valid.
+pub fn validate_all_writetime_ttl_calls(
+    calls: &[(WriteTimeTtlKind, String)],
+    columns: &[ColumnDescriptor],
+) -> Result<()> {
+    for (kind, column_name) in calls {
+        validate_writetime_ttl_call(kind, column_name, columns)?;
+    }
+    Ok(())
+}
+
+/// Build a `ColumnDescriptor` list from a `crate::schema::TableSchema`.
+///
+/// This bridge function keeps the validator decoupled from the schema crate.
+pub fn descriptors_from_table_schema(schema: &crate::schema::TableSchema) -> Vec<ColumnDescriptor> {
+    let pk_names: std::collections::HashSet<&str> = schema
+        .partition_keys
+        .iter()
+        .map(|k| k.name.as_str())
+        .collect();
+    let ck_names: std::collections::HashSet<&str> = schema
+        .clustering_keys
+        .iter()
+        .map(|k| k.name.as_str())
+        .collect();
+
+    schema
+        .columns
+        .iter()
+        .map(|col| ColumnDescriptor {
+            name: col.name.clone(),
+            type_str: col.data_type.clone(),
+            is_partition_key: pk_names.contains(col.name.as_str()),
+            is_clustering_key: ck_names.contains(col.name.as_str()),
+        })
+        .collect()
+}
+
+/// Returns `true` when `type_str` describes a non-frozen collection.
+///
+/// `frozen<list<...>>` / `frozen<set<...>>` / `frozen<map<...>>` are single-cell
+/// and are **allowed** with WRITETIME/TTL.  Plain `list<...>`, `set<...>`,
+/// `map<...>` are multi-cell and are **not** allowed.
+fn is_non_frozen_collection(type_str: &str) -> bool {
+    let t = type_str.trim().to_lowercase();
+    // A frozen wrapper at the top level means it is single-cell.
+    if t.starts_with("frozen<") {
+        return false;
+    }
+    t.starts_with("list<") || t.starts_with("set<") || t.starts_with("map<")
+}
+
+/// Convenience: extract `(WriteTimeTtlKind, column_name)` pairs from a parsed
+/// `SelectStatement`'s select clause.  Returns an empty vec for `SELECT *`.
+#[cfg(feature = "state_machine")]
+pub fn extract_writetime_ttl_calls(
+    stmt: &super::select_ast::SelectStatement,
+) -> Vec<(WriteTimeTtlKind, String)> {
+    use super::select_ast::{SelectClause, SelectExpression, WriteTimeTtlFunction};
+
+    let exprs = match &stmt.select_clause {
+        SelectClause::Columns(v) | SelectClause::Distinct(v) => v,
+        SelectClause::All => return vec![],
+    };
+
+    exprs
+        .iter()
+        .filter_map(|expr| {
+            let call = match expr {
+                SelectExpression::WriteTimeTtl(c) => c,
+                SelectExpression::Aliased(inner, _) => {
+                    if let SelectExpression::WriteTimeTtl(c) = inner.as_ref() {
+                        c
+                    } else {
+                        return None;
+                    }
+                }
+                _ => return None,
+            };
+            let kind = match call.function {
+                WriteTimeTtlFunction::WriteTime => WriteTimeTtlKind::WriteTime,
+                WriteTimeTtlFunction::Ttl => WriteTimeTtlKind::Ttl,
+            };
+            Some((kind, call.column.clone()))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn col(name: &str, type_str: &str, is_pk: bool, is_ck: bool) -> ColumnDescriptor {
+        ColumnDescriptor {
+            name: name.to_string(),
+            type_str: type_str.to_string(),
+            is_partition_key: is_pk,
+            is_clustering_key: is_ck,
+        }
+    }
+
+    fn basic_columns() -> Vec<ColumnDescriptor> {
+        vec![
+            col("user_id", "uuid", true, false),
+            col("bucket", "int", false, true),
+            col("name", "text", false, false),
+            col("scores", "list<int>", false, false),
+            col("tags", "set<text>", false, false),
+            col("meta", "map<text,text>", false, false),
+            col("frozen_scores", "frozen<list<int>>", false, false),
+            col("data", "blob", false, false),
+        ]
+    }
+
+    // --- Happy-path tests ---
+
+    #[test]
+    fn test_writetime_on_regular_column_is_valid() {
+        let cols = basic_columns();
+        let result = validate_writetime_ttl_call(&WriteTimeTtlKind::WriteTime, "name", &cols);
+        assert!(
+            result.is_ok(),
+            "WRITETIME on a plain text column should be valid"
+        );
+    }
+
+    #[test]
+    fn test_ttl_on_regular_column_is_valid() {
+        let cols = basic_columns();
+        let result = validate_writetime_ttl_call(&WriteTimeTtlKind::Ttl, "name", &cols);
+        assert!(result.is_ok(), "TTL on a plain text column should be valid");
+    }
+
+    #[test]
+    fn test_writetime_on_frozen_collection_is_valid() {
+        let cols = basic_columns();
+        let result =
+            validate_writetime_ttl_call(&WriteTimeTtlKind::WriteTime, "frozen_scores", &cols);
+        assert!(
+            result.is_ok(),
+            "WRITETIME on a frozen<list<int>> should be valid"
+        );
+    }
+
+    #[test]
+    fn test_writetime_on_blob_is_valid() {
+        let cols = basic_columns();
+        let result = validate_writetime_ttl_call(&WriteTimeTtlKind::WriteTime, "data", &cols);
+        assert!(result.is_ok());
+    }
+
+    // --- Partition-key rejection ---
+
+    #[test]
+    fn test_writetime_on_partition_key_is_rejected() {
+        let cols = basic_columns();
+        let err = validate_writetime_ttl_call(&WriteTimeTtlKind::WriteTime, "user_id", &cols)
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("writeTime"),
+            "Error should name the function: {msg}"
+        );
+        assert!(
+            msg.contains("PRIMARY KEY"),
+            "Error should mention PRIMARY KEY: {msg}"
+        );
+        assert!(
+            msg.contains("user_id"),
+            "Error should name the column: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_ttl_on_partition_key_is_rejected() {
+        let cols = basic_columns();
+        let err =
+            validate_writetime_ttl_call(&WriteTimeTtlKind::Ttl, "user_id", &cols).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("ttl"), "Error should name the function: {msg}");
+        assert!(
+            msg.contains("PRIMARY KEY"),
+            "Error should mention PRIMARY KEY: {msg}"
+        );
+    }
+
+    // --- Clustering-key rejection ---
+
+    #[test]
+    fn test_writetime_on_clustering_key_is_rejected() {
+        let cols = basic_columns();
+        let err =
+            validate_writetime_ttl_call(&WriteTimeTtlKind::WriteTime, "bucket", &cols).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("PRIMARY KEY"),
+            "Clustering-key error should cite PRIMARY KEY: {msg}"
+        );
+        assert!(msg.contains("bucket"));
+    }
+
+    // --- Non-frozen collection rejection ---
+
+    #[test]
+    fn test_writetime_on_list_is_rejected() {
+        let cols = basic_columns();
+        let err =
+            validate_writetime_ttl_call(&WriteTimeTtlKind::WriteTime, "scores", &cols).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("non-frozen"),
+            "Error should cite non-frozen: {msg}"
+        );
+        assert!(
+            msg.contains("list<int>"),
+            "Error should include the type: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_writetime_on_set_is_rejected() {
+        let cols = basic_columns();
+        let err =
+            validate_writetime_ttl_call(&WriteTimeTtlKind::WriteTime, "tags", &cols).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("non-frozen"));
+    }
+
+    #[test]
+    fn test_writetime_on_map_is_rejected() {
+        let cols = basic_columns();
+        let err =
+            validate_writetime_ttl_call(&WriteTimeTtlKind::WriteTime, "meta", &cols).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("non-frozen"));
+    }
+
+    #[test]
+    fn test_ttl_on_set_is_rejected() {
+        let cols = basic_columns();
+        let err = validate_writetime_ttl_call(&WriteTimeTtlKind::Ttl, "tags", &cols).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("non-frozen"));
+        assert!(msg.contains("ttl"));
+    }
+
+    // --- Unknown-column rejection ---
+
+    #[test]
+    fn test_writetime_on_unknown_column_is_rejected() {
+        let cols = basic_columns();
+        let err =
+            validate_writetime_ttl_call(&WriteTimeTtlKind::WriteTime, "nonexistent_col", &cols)
+                .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("nonexistent_col"),
+            "Error should name the unknown column: {msg}"
+        );
+    }
+
+    // --- Case-insensitive column lookup ---
+
+    #[test]
+    fn test_column_lookup_is_case_insensitive() {
+        let cols = basic_columns();
+        // Schema stores "name" in lower-case; query uses "NAME".
+        let result = validate_writetime_ttl_call(&WriteTimeTtlKind::WriteTime, "NAME", &cols);
+        assert!(result.is_ok(), "Column lookup should be case-insensitive");
+    }
+
+    // --- Batch validation ---
+
+    #[test]
+    fn test_validate_all_calls_stops_at_first_error() {
+        let cols = basic_columns();
+        let calls = vec![
+            (WriteTimeTtlKind::WriteTime, "name".to_string()),
+            (WriteTimeTtlKind::Ttl, "user_id".to_string()), // PK — should error
+            (WriteTimeTtlKind::WriteTime, "data".to_string()),
+        ];
+        let result = validate_all_writetime_ttl_calls(&calls, &cols);
+        assert!(
+            result.is_err(),
+            "Batch validation should fail on the PK column"
+        );
+    }
+
+    #[test]
+    fn test_validate_all_calls_succeeds_when_all_valid() {
+        let cols = basic_columns();
+        let calls = vec![
+            (WriteTimeTtlKind::WriteTime, "name".to_string()),
+            (WriteTimeTtlKind::Ttl, "data".to_string()),
+        ];
+        assert!(validate_all_writetime_ttl_calls(&calls, &cols).is_ok());
+    }
+
+    // --- is_non_frozen_collection helper ---
+
+    #[test]
+    fn test_non_frozen_collection_detection() {
+        assert!(is_non_frozen_collection("list<int>"));
+        assert!(is_non_frozen_collection("set<text>"));
+        assert!(is_non_frozen_collection("map<text,int>"));
+        assert!(is_non_frozen_collection("LIST<INT>")); // case-insensitive
+        assert!(!is_non_frozen_collection("frozen<list<int>>"));
+        assert!(!is_non_frozen_collection("frozen<set<text>>"));
+        assert!(!is_non_frozen_collection("frozen<map<text,int>>"));
+        assert!(!is_non_frozen_collection("text"));
+        assert!(!is_non_frozen_collection("bigint"));
+        assert!(!is_non_frozen_collection("uuid"));
+    }
+}


### PR DESCRIPTION
Closes #690

## Summary

- Adds `Token::Writetime` / `Token::Ttl` in the select tokenizer so these CQL reserved words are recognized case-insensitively.
- Adds `WriteTimeTtlFunction`, `WriteTimeTtlCall`, and `SelectExpression::WriteTimeTtl` to `select_ast.rs` — a first-class typed variant rather than falling through to the generic `FunctionCall` path, enabling exhaustive downstream dispatch.
- Parses `WRITETIME(col)` / `TTL(col)` (all cases) with optional `AS alias` directly in the parser.
- New `writetime_ttl_validator.rs`: schema-aware planning-layer validation with Cassandra-shaped error messages for partition-key, clustering-key, non-frozen-collection, and unknown-column arguments. Frozen collections (single-cell) are allowed.
- Executor stub in `select_executor.rs` returns `Value::Null` with a `TODO(#692)` comment; actual cell-level metadata threading is deferred to #692.

## Gate summary block

```
==== AGENT-GATE SUMMARY ====
commit: 2fc9a846 branch: feat/690-writetime-ttl-parser dirty: no
datasets: 68 Data.db files under /Users/patrickmcfadin/local_projects/cqlite/test-data/datasets
ci-pins: DATASET_TAG: datasets-v3 DATASET_ASSET: cassandra5-small-full-v3.1.tar.gz DATASET_SHA256: f5fa0b6599a27c1c493d7c6c063194d55d031cab417396947313e7245afc5ceb 
fmt:               PASS (2s)
clippy:            PASS (22s)
core-tests:        PASS (197s)
integration-tests: PASS (16s)
write-tests:       PASS (47s)
cli-tests:         PASS (25s)
minimal-build:     PASS (0s)
smoke:             PASS (4s)
logs: /var/folders/2c/tfxwt1g91x729x38m63d81540000gn/T//agent-gate.PvbxB7
RESULT: PASS
==== END AGENT-GATE SUMMARY ====
```