### PR TITLE
feat(query): evaluate WRITETIME()/TTL() select items (#692)

### DIFF
--- a/cqlite-core/src/query/result.rs
+++ b/cqlite-core/src/query/result.rs
@@ -4,6 +4,9 @@
 //! It includes result set management, row iteration, and result metadata.
 
 use crate::{schema::CqlType, RowKey, Value};
+// Re-export cell metadata types that now live in crate::types so the storage
+// layer can use them without a cyclic dependency.
+pub use crate::types::{CellExpiration, CellWriteMetadata};
 use base64::Engine;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -24,45 +27,10 @@ fn row_metadata_is_populated(meta: &RowMetadata) -> bool {
 // ============================================================================
 // Per-cell write metadata (Issue #691)
 // ============================================================================
-
-/// Per-cell write timestamp and expiration metadata.
-///
-/// Attached to a `QueryRow` only when the query plan sets
-/// `ProjectionFlags::include_cell_metadata = true` (e.g. because a
-/// `WRITETIME(col)` or `TTL(col)` item appears in the SELECT list).
-///
-/// **Hot-path guarantee**: when the flag is unset the `cell_metadata` map on
-/// `QueryRow` is `None`, so no allocation occurs per cell on normal queries.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct CellWriteMetadata {
-    /// Write timestamp of the cell in **microseconds since Unix epoch**.
-    ///
-    /// This is the per-cell `timestamp` decoded from the SSTable row/cell
-    /// header, after applying the min-timestamp delta.  For cells that inherit
-    /// the row-level timestamp (the `USE_ROW_TIMESTAMP` cell flag) this is the
-    /// row timestamp.  Matches `WRITETIME(col)` semantics exactly.
-    pub write_timestamp_micros: i64,
-
-    /// Expiration info when the cell was written with a TTL.
-    ///
-    /// `None` when the cell has no TTL (it does not expire).
-    pub expiration: Option<CellExpiration>,
-}
-
-/// TTL / expiration info for a cell that was written with a TTL.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct CellExpiration {
-    /// TTL in **seconds** as written by the client.
-    ///
-    /// Matches `TTL(col)` when the cell is still live.
-    pub ttl_seconds: i32,
-
-    /// Epoch-seconds at which the cell expires (local deletion time).
-    ///
-    /// When `now_seconds > expires_at`, the cell is expired and would return
-    /// `null` in a live Cassandra query.
-    pub expires_at_seconds: i64,
-}
+//
+// CellWriteMetadata and CellExpiration are defined in crate::types and
+// re-exported above.  All usages of these types within this module
+// and its callers are unchanged — the re-export makes the move transparent.
 
 /// Projection-level flags that control opt-in metadata collection.
 ///

--- a/cqlite-core/src/query/select_executor.rs
+++ b/cqlite-core/src/query/select_executor.rs
@@ -12,8 +12,8 @@
 
 use super::{
     result::{
-        cql_type_to_data_type, ColumnInfo, QueryMetadata, QueryResult, QueryResultIterator,
-        QueryRow, StreamingConfig,
+        cql_type_to_data_type, ColumnInfo, ProjectionFlags, QueryMetadata, QueryResult,
+        QueryResultIterator, QueryRow, StreamingConfig,
     },
     select_ast::*,
     select_optimizer::{AggregationPlan, ExecutionStep, OptimizedQueryPlan, SSTablePredicate},
@@ -29,13 +29,56 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 
+/// Clock abstraction for TTL "now" injection.
+///
+/// This trait exists solely so that tests can inject a deterministic timestamp
+/// instead of reading `SystemTime`. The only production implementation is
+/// `SystemClock`; tests use `FixedClock`.
+pub trait NowSeconds: Send + Sync {
+    /// Return the current time as seconds since Unix epoch.
+    fn now_seconds(&self) -> i64;
+}
+
+/// Production clock: reads from the system wall clock.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SystemClock;
+
+impl NowSeconds for SystemClock {
+    fn now_seconds(&self) -> i64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs() as i64
+    }
+}
+
+/// Test clock: always returns a fixed value.
+#[derive(Debug, Clone, Copy)]
+pub struct FixedClock(pub i64);
+
+impl NowSeconds for FixedClock {
+    fn now_seconds(&self) -> i64 {
+        self.0
+    }
+}
+
 /// SELECT query executor for SSTable-based storage
-#[derive(Debug)]
 pub struct SelectExecutor {
     /// Schema manager for metadata
     _schema: Arc<SchemaManager>,
     /// Storage engine for SSTable access
     storage: Arc<StorageEngine>,
+    /// Clock used for TTL "remaining seconds" computation (injectable for tests).
+    clock: Arc<dyn NowSeconds>,
+}
+
+impl std::fmt::Debug for SelectExecutor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SelectExecutor")
+            .field("_schema", &self._schema)
+            .field("storage", &self.storage)
+            .finish_non_exhaustive()
+    }
 }
 
 /// Query execution context
@@ -50,6 +93,12 @@ struct ExecutionContext {
     pub columns: Vec<ColumnInfo>,
     /// Row count processed so far
     pub rows_processed: u64,
+    /// Projection flags controlling opt-in metadata collection (Issue #692).
+    ///
+    /// Set to `include_cell_metadata = true` when any `WRITETIME` or `TTL`
+    /// select item is detected during planning so the reader can thread
+    /// per-cell write metadata.
+    pub projection_flags: ProjectionFlags,
 }
 
 /// Aggregation state for GROUP BY operations
@@ -529,6 +578,67 @@ fn const_arithmetic(op: &ArithmeticOperator, left: Value, right: Value) -> Resul
     }
 }
 
+/// Return `true` when the select clause contains at least one `WRITETIME` or
+/// `TTL` call — used during planning to set `ProjectionFlags::include_cell_metadata`.
+fn select_has_writetime_ttl(statement: &SelectStatement) -> bool {
+    let exprs = match &statement.select_clause {
+        SelectClause::All => return false,
+        SelectClause::Columns(e) | SelectClause::Distinct(e) => e,
+    };
+    exprs
+        .iter()
+        .any(|e| matches!(e, SelectExpression::WriteTimeTtl(_)))
+}
+
+/// Compute the Cassandra-convention output column name for a `WriteTimeTtlCall`.
+///
+/// - No alias: `writetime(col)` or `ttl(col)` (lowercase, matching Cassandra).
+/// - Explicit alias: the alias string, exactly as parsed.
+fn writetime_ttl_column_name(call: &WriteTimeTtlCall) -> String {
+    if let Some(alias) = &call.alias {
+        return alias.clone();
+    }
+    match call.function {
+        WriteTimeTtlFunction::WriteTime => format!("writetime({})", call.column),
+        WriteTimeTtlFunction::Ttl => format!("ttl({})", call.column),
+    }
+}
+
+/// Evaluate a `WRITETIME(col)` or `TTL(col)` call against a single `QueryRow`.
+///
+/// `now_secs` is the current epoch-second used only for TTL subtraction. It
+/// **must** be injected by the caller rather than read here so that unit tests
+/// can produce deterministic results.
+///
+/// Return values:
+/// - `WRITETIME(col)` → `Value::BigInt(micros)` when metadata exists; `Value::Null` otherwise.
+/// - `TTL(col)` → `Value::Integer(remaining_secs)` when the cell has an unexpired TTL;
+///   `Value::Null` when no expiration exists **or** the cell has already expired.
+fn evaluate_writetime_ttl(call: &WriteTimeTtlCall, row: &QueryRow, now_secs: i64) -> Value {
+    let meta = match row.get_cell_metadata(&call.column) {
+        Some(m) => m,
+        None => return Value::Null,
+    };
+
+    match call.function {
+        WriteTimeTtlFunction::WriteTime => Value::BigInt(meta.write_timestamp_micros),
+        WriteTimeTtlFunction::Ttl => match &meta.expiration {
+            None => Value::Null,
+            Some(exp) => {
+                let remaining = exp.expires_at_seconds - now_secs;
+                if remaining <= 0 {
+                    // Cell has already expired — Cassandra returns NULL.
+                    Value::Null
+                } else {
+                    // Safe cast: remaining is in (0, i32::MAX] range for any
+                    // realistic TTL (Cassandra caps TTL at 630_720_000 seconds).
+                    Value::Integer(remaining.min(i32::MAX as i64) as i32)
+                }
+            }
+        },
+    }
+}
+
 /// Translate a CQL LIKE pattern (`%`, `_`) into an anchored regex.
 fn like_pattern_to_regex(pattern: &str) -> String {
     let mut out = String::with_capacity(pattern.len() + 4);
@@ -558,11 +668,26 @@ fn parse_cql_type_str(type_str: &str) -> Option<CqlType> {
 }
 
 impl SelectExecutor {
-    /// Create a new SELECT executor
+    /// Create a new SELECT executor with a system (wall-clock) now source.
     pub fn new(schema: Arc<SchemaManager>, storage: Arc<StorageEngine>) -> Self {
         Self {
             _schema: schema,
             storage,
+            clock: Arc::new(SystemClock),
+        }
+    }
+
+    /// Create a SELECT executor with a custom clock (for deterministic tests).
+    #[cfg(test)]
+    pub fn with_clock(
+        schema: Arc<SchemaManager>,
+        storage: Arc<StorageEngine>,
+        clock: Arc<dyn NowSeconds>,
+    ) -> Self {
+        Self {
+            _schema: schema,
+            storage,
+            clock,
         }
     }
 
@@ -575,10 +700,23 @@ impl SelectExecutor {
             TableId::new("_dummy_")
         };
 
+        // Issue #692: detect whether any WRITETIME/TTL select items are present
+        // during planning and set the opt-in flag so the reader threads per-cell
+        // metadata. This is the "planning" half of the executor wiring; the
+        // "evaluation" half lives in `evaluate_select_expression`.
+        let projection_flags = ProjectionFlags {
+            include_cell_metadata: select_has_writetime_ttl(&plan.statement),
+        };
+        log::debug!(
+            "Query plan: include_cell_metadata={}",
+            projection_flags.include_cell_metadata
+        );
+
         let mut context = ExecutionContext {
             table_id,
             columns: self.get_result_columns(&plan.statement).await?,
             rows_processed: 0,
+            projection_flags,
         };
 
         // Handle queries without FROM clause (like SELECT 1)
@@ -967,9 +1105,10 @@ impl SelectExecutor {
         const MAX_RESULTS: usize = 1_000_000;
 
         log::info!(
-            "Executing SSTableScan: table=\"{}\", predicates={:?}",
+            "Executing SSTableScan: table=\"{}\", predicates={:?}, include_cell_metadata={}",
             table,
-            predicates
+            predicates,
+            context.projection_flags.include_cell_metadata,
         );
 
         let (keyspace, table_name) = parse_table_id(table);
@@ -1153,11 +1292,14 @@ impl SelectExecutor {
                     "Function expressions not yet implemented".to_string(),
                 ))
             }
-            // TODO (#692): Thread writetime/ttl cell metadata from SSTableReader
-            // up through the scan loop and return Value::BigInt(micros) for
-            // WRITETIME and Value::Int(seconds) for TTL. Until that work lands,
-            // we return NULL to avoid incorrect results.
-            SelectExpression::WriteTimeTtl(_) => Ok(Value::Null),
+            // Issue #692: evaluate WRITETIME(col) / TTL(col) against the per-cell
+            // metadata carrier threaded by the reader when `ProjectionFlags::include_cell_metadata`
+            // is set. Returns `Value::Null` when metadata is absent (e.g. no schema-aware
+            // read path or the column was a partition-key column with no cell header).
+            SelectExpression::WriteTimeTtl(call) => {
+                let now_secs = self.clock.now_seconds();
+                Ok(evaluate_writetime_ttl(call, row, now_secs))
+            }
         }
     }
 
@@ -1353,9 +1495,11 @@ impl SelectExecutor {
 
             for (i, expr) in columns.iter().enumerate() {
                 let value = self.evaluate_select_expression(expr, &row)?;
+                // Issue #692: WriteTimeTtl expressions use Cassandra-convention column names.
                 let column_name = match expr {
                     SelectExpression::Column(col_ref) => col_ref.column.clone(),
                     SelectExpression::Aliased(_, alias) => alias.clone(),
+                    SelectExpression::WriteTimeTtl(call) => writetime_ttl_column_name(call),
                     _ => format!("col_{i}"),
                 };
                 projected_values.insert(column_name, value);
@@ -1534,6 +1678,35 @@ impl SelectExecutor {
                 };
 
                 for (i, expr) in exprs.iter().enumerate() {
+                    // Issue #692: WriteTimeTtl expressions produce fixed-schema output
+                    // columns with Cassandra-convention names, independent of the table schema.
+                    if let SelectExpression::WriteTimeTtl(call) = expr {
+                        let col_name = writetime_ttl_column_name(call);
+                        let (data_type, cql_type) = match call.function {
+                            // WRITETIME returns bigint (µs since epoch)
+                            WriteTimeTtlFunction::WriteTime => {
+                                (crate::types::DataType::BigInt, Some(CqlType::BigInt))
+                            }
+                            // TTL returns int (remaining seconds)
+                            WriteTimeTtlFunction::Ttl => {
+                                (crate::types::DataType::Integer, Some(CqlType::Int))
+                            }
+                        };
+                        let mut col_info = ColumnInfo {
+                            name: col_name,
+                            data_type,
+                            nullable: true, // always nullable — absent cell → NULL
+                            position: i,
+                            table_name: None,
+                            cql_type: None,
+                        };
+                        if let Some(ct) = cql_type {
+                            col_info = col_info.with_cql_type(ct);
+                        }
+                        columns.push(col_info);
+                        continue;
+                    }
+
                     let column_name = match expr {
                         SelectExpression::Column(col_ref) => col_ref.column.clone(),
                         SelectExpression::Aliased(_, alias) => alias.clone(),
@@ -1594,9 +1767,30 @@ mod tests {
             .await
             .unwrap(),
         );
-        let _schema = Arc::new(SchemaManager::new(temp_dir.path()).await.unwrap());
+        let schema = Arc::new(SchemaManager::new(temp_dir.path()).await.unwrap());
 
-        SelectExecutor { _schema, storage }
+        SelectExecutor::new(schema, storage)
+    }
+
+    /// Create an executor with a fixed clock (deterministic TTL tests).
+    async fn create_test_executor_with_clock(now_secs: i64) -> SelectExecutor {
+        let temp_dir = TempDir::new().unwrap();
+        let config = Config::default();
+        let platform = Arc::new(Platform::new(&config).await.unwrap());
+        let storage = Arc::new(
+            StorageEngine::open(
+                temp_dir.path(),
+                &config,
+                platform.clone(),
+                #[cfg(feature = "state_machine")]
+                None,
+            )
+            .await
+            .unwrap(),
+        );
+        let schema = Arc::new(SchemaManager::new(temp_dir.path()).await.unwrap());
+
+        SelectExecutor::with_clock(schema, storage, Arc::new(FixedClock(now_secs)))
     }
 
     #[test]
@@ -1763,5 +1957,466 @@ mod tests {
         assert!(!in_slice(200), "upper bound is exclusive");
         assert!(!in_slice(1000), "rows past the slice are excluded");
         assert!(!in_slice(-1), "rows below the slice are excluded");
+    }
+
+    // =========================================================================
+    // Issue #692: WRITETIME() / TTL() executor wiring tests
+    // =========================================================================
+
+    use crate::query::result::{CellExpiration, CellWriteMetadata};
+
+    /// Helper: build a QueryRow with a given column value and optional cell metadata.
+    fn row_with_cell_meta(column: &str, value: Value, meta: Option<CellWriteMetadata>) -> QueryRow {
+        let mut row = QueryRow::new(RowKey::new(vec![1]));
+        row.set(column.to_string(), value);
+        if let Some(m) = meta {
+            row.insert_cell_metadata(column.to_string(), m);
+        }
+        row
+    }
+
+    // --- evaluate_writetime_ttl free-function tests ---
+
+    /// WRITETIME(col) returns Value::BigInt(micros) when metadata is present.
+    #[test]
+    fn test_writetime_returns_bigint_when_metadata_present() {
+        let write_ts = 1_700_000_000_000_000_i64;
+        let row = row_with_cell_meta(
+            "name",
+            Value::Text("Alice".to_string()),
+            Some(CellWriteMetadata {
+                write_timestamp_micros: write_ts,
+                expiration: None,
+            }),
+        );
+
+        let call = WriteTimeTtlCall {
+            function: WriteTimeTtlFunction::WriteTime,
+            column: "name".to_string(),
+            alias: None,
+        };
+
+        let result = evaluate_writetime_ttl(&call, &row, 0 /* now unused for WRITETIME */);
+        assert_eq!(
+            result,
+            Value::BigInt(write_ts),
+            "WRITETIME(col) must return Value::BigInt(micros)"
+        );
+    }
+
+    /// WRITETIME(col) returns Value::Null when cell metadata is absent.
+    #[test]
+    fn test_writetime_returns_null_when_no_metadata() {
+        // Row has a value for the column but no cell metadata (e.g. partition-key column).
+        let row = row_with_cell_meta("id", Value::Integer(1), None);
+
+        let call = WriteTimeTtlCall {
+            function: WriteTimeTtlFunction::WriteTime,
+            column: "id".to_string(),
+            alias: None,
+        };
+
+        let result = evaluate_writetime_ttl(&call, &row, 0);
+        assert_eq!(
+            result,
+            Value::Null,
+            "WRITETIME(col) must return NULL when no cell metadata is threaded"
+        );
+    }
+
+    /// TTL(col) returns Value::Integer(remaining) for a live TTL cell.
+    #[test]
+    fn test_ttl_returns_remaining_seconds_for_live_cell() {
+        // Cell was written at epoch 0, TTL = 3600s, expires at epoch 3600.
+        // Now = epoch 1000. Remaining = 2600s.
+        let now_secs: i64 = 1000;
+        let expires_at: i64 = 3600;
+        let row = row_with_cell_meta(
+            "score",
+            Value::Integer(42),
+            Some(CellWriteMetadata {
+                write_timestamp_micros: 0,
+                expiration: Some(CellExpiration {
+                    ttl_seconds: 3600,
+                    expires_at_seconds: expires_at,
+                }),
+            }),
+        );
+
+        let call = WriteTimeTtlCall {
+            function: WriteTimeTtlFunction::Ttl,
+            column: "score".to_string(),
+            alias: None,
+        };
+
+        let result = evaluate_writetime_ttl(&call, &row, now_secs);
+        assert_eq!(
+            result,
+            Value::Integer(2600),
+            "TTL(col) must return remaining seconds for a live cell"
+        );
+    }
+
+    /// TTL(col) returns Value::Null when the cell has no expiration.
+    #[test]
+    fn test_ttl_returns_null_when_no_expiration() {
+        let row = row_with_cell_meta(
+            "name",
+            Value::Text("Bob".to_string()),
+            Some(CellWriteMetadata {
+                write_timestamp_micros: 100,
+                expiration: None, // no TTL written
+            }),
+        );
+
+        let call = WriteTimeTtlCall {
+            function: WriteTimeTtlFunction::Ttl,
+            column: "name".to_string(),
+            alias: None,
+        };
+
+        let result = evaluate_writetime_ttl(&call, &row, 9999);
+        assert_eq!(
+            result,
+            Value::Null,
+            "TTL(col) must return NULL when the cell has no TTL"
+        );
+    }
+
+    /// TTL(col) returns Value::Null when the cell is expired.
+    #[test]
+    fn test_ttl_returns_null_for_expired_cell() {
+        // Cell expires at epoch 100; now is epoch 200 → expired.
+        let row = row_with_cell_meta(
+            "token",
+            Value::Text("abc".to_string()),
+            Some(CellWriteMetadata {
+                write_timestamp_micros: 0,
+                expiration: Some(CellExpiration {
+                    ttl_seconds: 100,
+                    expires_at_seconds: 100,
+                }),
+            }),
+        );
+
+        let call = WriteTimeTtlCall {
+            function: WriteTimeTtlFunction::Ttl,
+            column: "token".to_string(),
+            alias: None,
+        };
+
+        // now_secs = 200 > expires_at = 100 → expired
+        let result = evaluate_writetime_ttl(&call, &row, 200);
+        assert_eq!(
+            result,
+            Value::Null,
+            "TTL(col) must return NULL when the cell is expired"
+        );
+    }
+
+    /// TTL(col) returns Value::Null when cell metadata is entirely absent.
+    #[test]
+    fn test_ttl_returns_null_when_no_metadata() {
+        let row = row_with_cell_meta("x", Value::Integer(7), None);
+
+        let call = WriteTimeTtlCall {
+            function: WriteTimeTtlFunction::Ttl,
+            column: "x".to_string(),
+            alias: None,
+        };
+
+        let result = evaluate_writetime_ttl(&call, &row, 1000);
+        assert_eq!(result, Value::Null);
+    }
+
+    // --- column name convention tests ---
+
+    /// Cassandra convention: `writetime(col)` (no alias).
+    #[test]
+    fn test_writetime_ttl_column_name_no_alias() {
+        let wt_call = WriteTimeTtlCall {
+            function: WriteTimeTtlFunction::WriteTime,
+            column: "name".to_string(),
+            alias: None,
+        };
+        assert_eq!(writetime_ttl_column_name(&wt_call), "writetime(name)");
+
+        let ttl_call = WriteTimeTtlCall {
+            function: WriteTimeTtlFunction::Ttl,
+            column: "name".to_string(),
+            alias: None,
+        };
+        assert_eq!(writetime_ttl_column_name(&ttl_call), "ttl(name)");
+    }
+
+    /// Explicit alias overrides the Cassandra-convention name.
+    #[test]
+    fn test_writetime_ttl_column_name_with_alias() {
+        let call = WriteTimeTtlCall {
+            function: WriteTimeTtlFunction::WriteTime,
+            column: "score".to_string(),
+            alias: Some("wt".to_string()),
+        };
+        assert_eq!(writetime_ttl_column_name(&call), "wt");
+    }
+
+    // --- planning flag tests ---
+
+    /// `select_has_writetime_ttl` returns true only when a WriteTimeTtl expression is present.
+    #[test]
+    fn test_select_has_writetime_ttl_detection() {
+        // No WriteTimeTtl → false
+        let stmt_no_wt = SelectStatement {
+            select_clause: SelectClause::Columns(vec![
+                SelectExpression::Column(ColumnRef::new("id")),
+                SelectExpression::Column(ColumnRef::new("name")),
+            ]),
+            from_clause: None,
+            where_clause: None,
+            group_by: None,
+            having_clause: None,
+            order_by: None,
+            limit: None,
+            offset: None,
+            allow_filtering: false,
+        };
+        assert!(!select_has_writetime_ttl(&stmt_no_wt));
+
+        // With WriteTimeTtl → true
+        let stmt_wt = SelectStatement {
+            select_clause: SelectClause::Columns(vec![
+                SelectExpression::Column(ColumnRef::new("id")),
+                SelectExpression::WriteTimeTtl(WriteTimeTtlCall {
+                    function: WriteTimeTtlFunction::WriteTime,
+                    column: "name".to_string(),
+                    alias: None,
+                }),
+            ]),
+            from_clause: None,
+            where_clause: None,
+            group_by: None,
+            having_clause: None,
+            order_by: None,
+            limit: None,
+            offset: None,
+            allow_filtering: false,
+        };
+        assert!(select_has_writetime_ttl(&stmt_wt));
+
+        // SELECT * → false (no expression list to inspect)
+        let stmt_star = SelectStatement {
+            select_clause: SelectClause::All,
+            from_clause: None,
+            where_clause: None,
+            group_by: None,
+            having_clause: None,
+            order_by: None,
+            limit: None,
+            offset: None,
+            allow_filtering: false,
+        };
+        assert!(!select_has_writetime_ttl(&stmt_star));
+    }
+
+    // --- executor integration tests ---
+
+    /// The executor's `evaluate_select_expression` returns the correct value for
+    /// a WRITETIME call when cell metadata is pre-attached to the row.
+    #[tokio::test]
+    async fn test_executor_evaluate_writetime_reads_cell_metadata() {
+        let executor = create_test_executor_with_clock(0).await;
+
+        let write_ts = 1_700_000_000_000_000_i64;
+        let row = row_with_cell_meta(
+            "name",
+            Value::Text("Carol".to_string()),
+            Some(CellWriteMetadata {
+                write_timestamp_micros: write_ts,
+                expiration: None,
+            }),
+        );
+
+        let expr = SelectExpression::WriteTimeTtl(WriteTimeTtlCall {
+            function: WriteTimeTtlFunction::WriteTime,
+            column: "name".to_string(),
+            alias: None,
+        });
+
+        let result = executor.evaluate_select_expression(&expr, &row).unwrap();
+        assert_eq!(result, Value::BigInt(write_ts));
+    }
+
+    /// The executor's `evaluate_select_expression` returns NULL for WRITETIME
+    /// when cell metadata is absent (the common case before the storage reader
+    /// is updated to thread metadata).
+    #[tokio::test]
+    async fn test_executor_evaluate_writetime_null_when_no_metadata() {
+        let executor = create_test_executor_with_clock(0).await;
+
+        // Row has the column value but no attached cell metadata.
+        let row = row_with_cell_meta("name", Value::Text("Dave".to_string()), None);
+
+        let expr = SelectExpression::WriteTimeTtl(WriteTimeTtlCall {
+            function: WriteTimeTtlFunction::WriteTime,
+            column: "name".to_string(),
+            alias: None,
+        });
+
+        let result = executor.evaluate_select_expression(&expr, &row).unwrap();
+        assert_eq!(result, Value::Null);
+    }
+
+    /// The executor returns correct TTL using the injected fixed clock.
+    #[tokio::test]
+    async fn test_executor_evaluate_ttl_with_injected_clock() {
+        // now = epoch 1000; cell expires at epoch 5000 → remaining = 4000s
+        let now_secs: i64 = 1000;
+        let executor = create_test_executor_with_clock(now_secs).await;
+
+        let row = row_with_cell_meta(
+            "session",
+            Value::Text("tok".to_string()),
+            Some(CellWriteMetadata {
+                write_timestamp_micros: 0,
+                expiration: Some(CellExpiration {
+                    ttl_seconds: 5000,
+                    expires_at_seconds: 5000,
+                }),
+            }),
+        );
+
+        let expr = SelectExpression::WriteTimeTtl(WriteTimeTtlCall {
+            function: WriteTimeTtlFunction::Ttl,
+            column: "session".to_string(),
+            alias: None,
+        });
+
+        let result = executor.evaluate_select_expression(&expr, &row).unwrap();
+        assert_eq!(
+            result,
+            Value::Integer(4000),
+            "TTL must use the injected clock, not the wall clock"
+        );
+    }
+
+    /// Expired cell: executor returns NULL via injected clock.
+    #[tokio::test]
+    async fn test_executor_evaluate_ttl_expired_cell_returns_null() {
+        // now = epoch 9999; cell expired at epoch 100 → NULL
+        let executor = create_test_executor_with_clock(9999).await;
+
+        let row = row_with_cell_meta(
+            "cache",
+            Value::Text("val".to_string()),
+            Some(CellWriteMetadata {
+                write_timestamp_micros: 0,
+                expiration: Some(CellExpiration {
+                    ttl_seconds: 100,
+                    expires_at_seconds: 100,
+                }),
+            }),
+        );
+
+        let expr = SelectExpression::WriteTimeTtl(WriteTimeTtlCall {
+            function: WriteTimeTtlFunction::Ttl,
+            column: "cache".to_string(),
+            alias: None,
+        });
+
+        let result = executor.evaluate_select_expression(&expr, &row).unwrap();
+        assert_eq!(result, Value::Null, "Expired TTL cell must produce NULL");
+    }
+
+    /// Column info for WRITETIME uses BigInt data type and bigint cql_type.
+    #[tokio::test]
+    async fn test_get_result_columns_writetime_has_bigint_type() {
+        let executor = create_test_executor().await;
+
+        let stmt = SelectStatement {
+            select_clause: SelectClause::Columns(vec![SelectExpression::WriteTimeTtl(
+                WriteTimeTtlCall {
+                    function: WriteTimeTtlFunction::WriteTime,
+                    column: "name".to_string(),
+                    alias: None,
+                },
+            )]),
+            from_clause: None,
+            where_clause: None,
+            group_by: None,
+            having_clause: None,
+            order_by: None,
+            limit: None,
+            offset: None,
+            allow_filtering: false,
+        };
+
+        let cols = executor.get_result_columns(&stmt).await.unwrap();
+        assert_eq!(cols.len(), 1);
+        assert_eq!(cols[0].name, "writetime(name)");
+        assert_eq!(cols[0].data_type, crate::types::DataType::BigInt);
+        assert!(cols[0].nullable, "WRITETIME column must be nullable");
+        assert_eq!(cols[0].cql_type, Some(CqlType::BigInt));
+    }
+
+    /// Column info for TTL uses Integer data type and int cql_type.
+    #[tokio::test]
+    async fn test_get_result_columns_ttl_has_int_type() {
+        let executor = create_test_executor().await;
+
+        let stmt = SelectStatement {
+            select_clause: SelectClause::Columns(vec![SelectExpression::WriteTimeTtl(
+                WriteTimeTtlCall {
+                    function: WriteTimeTtlFunction::Ttl,
+                    column: "score".to_string(),
+                    alias: None,
+                },
+            )]),
+            from_clause: None,
+            where_clause: None,
+            group_by: None,
+            having_clause: None,
+            order_by: None,
+            limit: None,
+            offset: None,
+            allow_filtering: false,
+        };
+
+        let cols = executor.get_result_columns(&stmt).await.unwrap();
+        assert_eq!(cols.len(), 1);
+        assert_eq!(cols[0].name, "ttl(score)");
+        assert_eq!(cols[0].data_type, crate::types::DataType::Integer);
+        assert!(cols[0].nullable, "TTL column must be nullable");
+        assert_eq!(cols[0].cql_type, Some(CqlType::Int));
+    }
+
+    /// Column name uses alias when provided, overriding convention.
+    #[tokio::test]
+    async fn test_get_result_columns_writetime_with_alias() {
+        let executor = create_test_executor().await;
+
+        let stmt = SelectStatement {
+            select_clause: SelectClause::Columns(vec![SelectExpression::WriteTimeTtl(
+                WriteTimeTtlCall {
+                    function: WriteTimeTtlFunction::WriteTime,
+                    column: "name".to_string(),
+                    alias: Some("wt".to_string()),
+                },
+            )]),
+            from_clause: None,
+            where_clause: None,
+            group_by: None,
+            having_clause: None,
+            order_by: None,
+            limit: None,
+            offset: None,
+            allow_filtering: false,
+        };
+
+        let cols = executor.get_result_columns(&stmt).await.unwrap();
+        assert_eq!(cols.len(), 1);
+        assert_eq!(
+            cols[0].name, "wt",
+            "Alias must override Cassandra convention"
+        );
     }
 }

--- a/cqlite-core/src/query/select_executor.rs
+++ b/cqlite-core/src/query/select_executor.rs
@@ -1131,30 +1131,67 @@ impl SelectExecutor {
             ),
         }
 
-        let scan_results = self
-            .storage
-            .scan(table, None, None, None, schema_opt.as_ref())
-            .await?;
-
-        log::info!("Scan returned {} rows", scan_results.len());
-
+        // Issue #693: When WRITETIME(col) or TTL(col) is in the SELECT, use the
+        // metadata-carrying scan so per-cell timestamps reach the QueryRow.
         let mut results = Vec::new();
-        for (key, value) in scan_results {
-            context.rows_processed += 1;
+        if context.projection_flags.include_cell_metadata {
+            let scan_results = self
+                .storage
+                .scan_with_cell_metadata(table, None, None, None, schema_opt.as_ref())
+                .await?;
 
-            // build_row_from_scan returns None for tombstoned/null rows (Issue #191).
-            let Some(row) = build_row_from_scan(key, value, projection, schema_opt.as_ref()) else {
-                continue;
-            };
+            log::info!("Scan (with metadata) returned {} rows", scan_results.len());
 
-            if evaluate_predicates(&row, predicates)? {
-                results.push(row);
+            for (key, value, cell_meta) in scan_results {
+                context.rows_processed += 1;
+
+                let Some(mut row) =
+                    build_row_from_scan(key, value, projection, schema_opt.as_ref())
+                else {
+                    continue;
+                };
+
+                // Attach per-cell metadata so evaluate_writetime_ttl can read it.
+                if !cell_meta.is_empty() {
+                    row.set_cell_metadata(cell_meta);
+                }
+
+                if evaluate_predicates(&row, predicates)? {
+                    results.push(row);
+                }
+
+                if results.len() > MAX_RESULTS {
+                    return Err(Error::query_execution(
+                        "Result set too large, consider adding LIMIT".to_string(),
+                    ));
+                }
             }
+        } else {
+            let scan_results = self
+                .storage
+                .scan(table, None, None, None, schema_opt.as_ref())
+                .await?;
 
-            if results.len() > MAX_RESULTS {
-                return Err(Error::query_execution(
-                    "Result set too large, consider adding LIMIT".to_string(),
-                ));
+            log::info!("Scan returned {} rows", scan_results.len());
+
+            for (key, value) in scan_results {
+                context.rows_processed += 1;
+
+                // build_row_from_scan returns None for tombstoned/null rows (Issue #191).
+                let Some(row) = build_row_from_scan(key, value, projection, schema_opt.as_ref())
+                else {
+                    continue;
+                };
+
+                if evaluate_predicates(&row, predicates)? {
+                    results.push(row);
+                }
+
+                if results.len() > MAX_RESULTS {
+                    return Err(Error::query_execution(
+                        "Result set too large, consider adding LIMIT".to_string(),
+                    ));
+                }
             }
         }
 

--- a/cqlite-core/src/storage/mod.rs
+++ b/cqlite-core/src/storage/mod.rs
@@ -25,7 +25,10 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use crate::platform::Platform;
-use crate::{types::TableId, Config, Result, RowKey, Value};
+use crate::{
+    types::{CellWriteMetadata, TableId},
+    Config, Result, RowKey, Value,
+};
 
 /// Main storage engine that coordinates all storage components
 ///
@@ -213,6 +216,29 @@ impl StorageEngine {
         // Scan SSTables directly
         self.sstables
             .scan(table_id, start_key, end_key, limit, schema)
+            .await
+    }
+
+    /// Scan a table and return per-cell write metadata alongside row values.
+    ///
+    /// Delegates to [`SSTableManager::scan_with_cell_metadata`].  Used when
+    /// `ProjectionFlags::include_cell_metadata` is set (issue #693).
+    pub async fn scan_with_cell_metadata(
+        &self,
+        table_id: &TableId,
+        start_key: Option<&RowKey>,
+        end_key: Option<&RowKey>,
+        limit: Option<usize>,
+        schema: Option<&crate::schema::TableSchema>,
+    ) -> Result<
+        Vec<(
+            RowKey,
+            Value,
+            std::collections::HashMap<String, CellWriteMetadata>,
+        )>,
+    > {
+        self.sstables
+            .scan_with_cell_metadata(table_id, start_key, end_key, limit, schema)
             .await
     }
 

--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -61,6 +61,8 @@ use tokio::sync::RwLock;
 #[cfg(feature = "tombstones")]
 use self::tombstone_merger::{EntryMetadata, GenerationValue, TombstoneMerger};
 use crate::platform::Platform;
+#[cfg(not(feature = "tombstones"))]
+use crate::types::CellWriteMetadata;
 use crate::{types::TableId, Config, Result, RowKey, Value};
 
 /// Maximum directory depth when scanning for SSTable files.
@@ -922,6 +924,87 @@ impl SSTableManager {
             );
             Ok(Vec::new())
         }
+    }
+
+    /// Scan a table and return per-cell write metadata alongside row values.
+    ///
+    /// Used when `ProjectionFlags::include_cell_metadata` is set (issue #693 — the
+    /// WRITETIME/TTL threading bridge).  Delegates to each reader's
+    /// `scan_with_cell_metadata`.  When multiple readers serve the same table the
+    /// results are concatenated; token-order sort and LIMIT are applied afterward.
+    ///
+    /// Falls back to the regular `scan` with empty metadata when the reader does not
+    /// surface metadata (non-V5CompressedLegacy paths).
+    #[cfg(not(feature = "tombstones"))]
+    pub async fn scan_with_cell_metadata(
+        &self,
+        table_id: &TableId,
+        start_key: Option<&RowKey>,
+        end_key: Option<&RowKey>,
+        limit: Option<usize>,
+        schema: Option<&crate::schema::TableSchema>,
+    ) -> Result<Vec<(RowKey, Value, HashMap<String, CellWriteMetadata>)>> {
+        let table_readers = self.table_readers.read().await;
+        let table_name = table_id.name();
+
+        let readers = if table_readers.contains_key(table_name) {
+            table_readers.get(table_name)
+        } else {
+            let unqualified_name = if let Some(dot_pos) = table_name.rfind('.') {
+                &table_name[dot_pos + 1..]
+            } else {
+                table_name
+            };
+            table_readers.get(unqualified_name)
+        };
+
+        if let Some(reader_list) = readers {
+            let mut all_results = Vec::new();
+
+            for reader in reader_list {
+                let results = reader
+                    .scan_with_cell_metadata(table_id, start_key, end_key, None, schema)
+                    .await?;
+                all_results.extend(results);
+            }
+
+            // Sort by key (token order) and apply limit
+            all_results.sort_by(|a, b| a.0.cmp(&b.0));
+            if let Some(limit) = limit {
+                all_results.truncate(limit);
+            }
+
+            Ok(all_results)
+        } else {
+            Ok(Vec::new())
+        }
+    }
+
+    /// Tombstones-feature variant: delegates to regular `scan` and returns empty
+    /// metadata maps.  WRITETIME/TTL will still return null when tombstones are
+    /// enabled, but at least the code compiles and does not panic.
+    #[cfg(feature = "tombstones")]
+    pub async fn scan_with_cell_metadata(
+        &self,
+        table_id: &TableId,
+        start_key: Option<&RowKey>,
+        end_key: Option<&RowKey>,
+        limit: Option<usize>,
+        schema: Option<&crate::schema::TableSchema>,
+    ) -> Result<
+        Vec<(
+            RowKey,
+            Value,
+            HashMap<String, crate::types::CellWriteMetadata>,
+        )>,
+    > {
+        let base = self
+            .scan(table_id, start_key, end_key, limit, schema)
+            .await?;
+        Ok(base
+            .into_iter()
+            .map(|(k, v)| (k, v, HashMap::new()))
+            .collect())
     }
 
     /// Resolve the readers serving `table_id`, returning cloned `Arc` handles.

--- a/cqlite-core/src/storage/sstable/reader/data_access.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access.rs
@@ -5,7 +5,7 @@
 
 use super::SSTableReader;
 use crate::parser::DataFormat;
-use crate::types::{TableId, Value};
+use crate::types::{CellWriteMetadata, TableId, Value};
 use crate::util::cassandra_murmur3::cassandra_murmur3_token;
 use crate::{Error, Result, RowKey};
 use log::{debug, warn};
@@ -69,6 +69,30 @@ fn sort_by_token_order(results: &mut Vec<(RowKey, Value)>) {
         .collect();
     tagged.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
     results.extend(tagged.into_iter().map(|(_, k, v)| (k, v)));
+}
+
+/// Sort `(RowKey, Value, CellMeta)` triples by Cassandra Murmur3 token order.
+fn sort_by_token_order_with_meta(
+    results: &mut Vec<(
+        RowKey,
+        Value,
+        std::collections::HashMap<String, CellWriteMetadata>,
+    )>,
+) {
+    let mut tagged: Vec<(
+        i64,
+        RowKey,
+        Value,
+        std::collections::HashMap<String, CellWriteMetadata>,
+    )> = results
+        .drain(..)
+        .map(|(k, v, m)| {
+            let t = cassandra_murmur3_token(k.as_bytes());
+            (t, k, v, m)
+        })
+        .collect();
+    tagged.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+    results.extend(tagged.into_iter().map(|(_, k, v, m)| (k, v, m)));
 }
 
 impl SSTableReader {
@@ -340,6 +364,41 @@ impl SSTableReader {
         let entries = parser.parse_block(&stitched_buffer, table_schema, self)?;
         log::debug!(
             "stitch_and_parse_all_chunks: Parsed {} entries from stitched buffer",
+            entries.len()
+        );
+
+        Ok(entries)
+    }
+
+    /// Like [`stitch_and_parse_all_chunks`] but also returns per-cell write metadata.
+    ///
+    /// Used when `ProjectionFlags::include_cell_metadata` is set (issue #693).
+    async fn stitch_and_parse_all_chunks_with_metadata(
+        &self,
+        schema: Option<&crate::schema::TableSchema>,
+    ) -> Result<
+        Vec<(
+            TableId,
+            RowKey,
+            Value,
+            std::collections::HashMap<String, CellWriteMetadata>,
+        )>,
+    > {
+        let stitched_buffer = self.stitch_all_chunks().await?;
+        let parser = self.build_v5_parser();
+
+        let reader_schema;
+        let table_schema = if let Some(s) = schema {
+            Some(s)
+        } else {
+            reader_schema = self.get_table_schema(None);
+            reader_schema.as_ref()
+        };
+
+        let entries =
+            parser.parse_block_with_cell_metadata(&stitched_buffer, table_schema, self)?;
+        log::debug!(
+            "stitch_and_parse_all_chunks_with_metadata: Parsed {} entries with metadata",
             entries.len()
         );
 
@@ -1130,6 +1189,86 @@ impl SSTableReader {
             results.len()
         );
         Ok(results)
+    }
+
+    /// Scan a range of keys AND return per-cell write metadata.
+    ///
+    /// Used when `ProjectionFlags::include_cell_metadata` is set (issue #693).
+    /// Falls through to `stitch_and_parse_all_chunks_with_metadata` for
+    /// V5CompressedLegacy format (the common path for real SSTables).
+    /// Returns `None` as the metadata for non-V5 formats (they do not carry
+    /// per-cell timestamps in a way the parser currently surfaces).
+    pub async fn scan_with_cell_metadata(
+        &self,
+        table_id: &TableId,
+        start_key: Option<&RowKey>,
+        end_key: Option<&RowKey>,
+        limit: Option<usize>,
+        schema: Option<&crate::schema::TableSchema>,
+    ) -> Result<
+        Vec<(
+            RowKey,
+            Value,
+            std::collections::HashMap<String, CellWriteMetadata>,
+        )>,
+    > {
+        log::debug!("SSTableReader::scan_with_cell_metadata - Starting");
+
+        let _scan_guard = self.scan_mutex.lock().await;
+
+        let header_size = self.calculate_header_size();
+        {
+            let mut file_guard = self.file.lock().await;
+            file_guard.seek(SeekFrom::Start(header_size as u64)).await?;
+        }
+        self.current_chunk_index
+            .store(0, std::sync::atomic::Ordering::Relaxed);
+
+        // V5CompressedLegacy (stitching) path — the common path for Cassandra 5.0 SSTables.
+        if self.requires_chunk_stitching() {
+            let all_entries = self
+                .stitch_and_parse_all_chunks_with_metadata(schema)
+                .await?;
+
+            let mut results = Vec::new();
+            for (_entry_table_id, entry_key, entry_value, cell_meta) in all_entries {
+                if let Some(start) = start_key {
+                    if &entry_key < start {
+                        continue;
+                    }
+                }
+                if let Some(end) = end_key {
+                    if &entry_key > end {
+                        continue;
+                    }
+                }
+                if !self.filter_tombstone(&entry_value) {
+                    continue;
+                }
+                results.push((entry_key, entry_value, cell_meta));
+            }
+
+            sort_by_token_order_with_meta(&mut results);
+            if let Some(lim) = limit {
+                results.truncate(lim);
+            }
+
+            log::debug!(
+                "SSTableReader::scan_with_cell_metadata - Returning {} results (stitched path)",
+                results.len()
+            );
+            return Ok(results);
+        }
+
+        // Non-stitching path: fall back to regular scan + empty metadata.
+        // Per-cell metadata is not yet surfaced for block-entry formats.
+        let plain = self
+            .sequential_scan(table_id, start_key, end_key, limit, schema)
+            .await?;
+        Ok(plain
+            .into_iter()
+            .map(|(k, v)| (k, v, std::collections::HashMap::new()))
+            .collect())
     }
 
     /// Read next block with enhanced error handling and streaming support

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
@@ -43,7 +43,10 @@ use crate::{
     parser::vint::{parse_vint, parse_vuint},
     schema::{CqlType, TableSchema, UdtRegistry},
     storage::sstable::version_gate::{BigVersionGates, VersionGates},
-    types::{TableId, TombstoneInfo, TombstoneType, UdtField, UdtTypeDef, UdtValue},
+    types::{
+        CellExpiration, CellWriteMetadata, TableId, TombstoneInfo, TombstoneType, UdtField,
+        UdtTypeDef, UdtValue,
+    },
     Error, Result, RowKey, Value,
 };
 
@@ -67,8 +70,23 @@ const MAX_UDT_FIELD_COUNT: usize = 1000;
 const MAX_TYPE_NESTING_DEPTH: usize = 10;
 
 /// Return type for `parse_row_data_with_offset`:
-/// (cells, row_header, next_offset, is_static)
-type ParsedRow = (HashMap<String, Value>, Option<RowHeader>, usize, bool);
+/// (cells, cell_metadata, row_header, next_offset, is_static)
+///
+/// `cell_metadata` maps column name → `CellWriteMetadata` for every live cell
+/// parsed in this row. Used to surface per-cell timestamps / TTLs for
+/// `WRITETIME(col)` / `TTL(col)` queries (issue #693).
+type ParsedRow = (
+    HashMap<String, Value>,
+    HashMap<String, CellWriteMetadata>,
+    Option<RowHeader>,
+    usize,
+    bool,
+);
+
+/// Return type for [`V5CompressedLegacy::parse_block_with_cell_metadata`].
+///
+/// Each element is `(table_id, row_key, value_map, cell_metadata_map)`.
+type ParsedBlockWithMeta = Vec<(TableId, RowKey, Value, HashMap<String, CellWriteMetadata>)>;
 
 /// Row header data extracted from V5CompressedLegacy row
 #[derive(Debug, Clone)]
@@ -319,6 +337,169 @@ impl V5CompressedLegacyParser {
         Ok(results)
     }
 
+    /// Parse a block and return both row values and per-cell write metadata.
+    ///
+    /// Identical to [`parse_block`] but the returned vector carries a fourth element:
+    /// the per-cell `CellWriteMetadata` map (column name → metadata). Used by the
+    /// executor when `ProjectionFlags::include_cell_metadata` is set (i.e. when the
+    /// query contains `WRITETIME(col)` or `TTL(col)` expressions).
+    pub fn parse_block_with_cell_metadata(
+        &self,
+        data: &[u8],
+        schema: Option<&TableSchema>,
+        reader: &super::super::types::SSTableReader,
+    ) -> Result<ParsedBlockWithMeta> {
+        let mut results = Vec::new();
+        self.parse_block_emit_with_metadata(data, schema, reader, |entry| {
+            results.push(entry);
+            Ok(std::ops::ControlFlow::Continue(()))
+        })?;
+        Ok(results)
+    }
+
+    /// Internal streaming variant of `parse_block_with_cell_metadata`.
+    fn parse_block_emit_with_metadata<F>(
+        &self,
+        data: &[u8],
+        schema: Option<&TableSchema>,
+        reader: &super::super::types::SSTableReader,
+        mut emit: F,
+    ) -> Result<()>
+    where
+        F: FnMut(
+            (TableId, RowKey, Value, HashMap<String, CellWriteMetadata>),
+        ) -> Result<std::ops::ControlFlow<()>>,
+    {
+        if data.is_empty() {
+            return Ok(());
+        }
+
+        let schema = schema.ok_or_else(|| {
+            Error::schema(format!(
+                "V5CompressedLegacy format requires schema for {}.{} (cells lack column names in binary data)",
+                self.keyspace, self.table_name
+            ))
+        })?;
+
+        let mut offset = 0;
+        let mut partition_index = 0;
+
+        while offset < data.len() {
+            // Parse partition header: returns (RowKey, next_data_offset)
+            let (partition_key, next_data_offset) = match self.parse_partition_header(data, offset)
+            {
+                Ok(ph) => ph,
+                Err(_) => break,
+            };
+
+            let table_id = TableId(format!("{}.{}", self.keyspace, self.table_name));
+            offset = next_data_offset;
+            partition_index += 1;
+
+            let mut static_cells: HashMap<String, Value> = HashMap::new();
+            let mut static_cell_meta: HashMap<String, CellWriteMetadata> = HashMap::new();
+            let mut row_count = 0;
+
+            loop {
+                if offset < data.len() && Self::is_end_of_partition(data[offset]) {
+                    offset += 1;
+                    break;
+                }
+
+                if offset < data.len() && Self::is_range_tombstone_marker(data[offset]) {
+                    match self.skip_range_tombstone_marker(data, offset, schema) {
+                        Ok(next_offset) => {
+                            offset = next_offset;
+                            continue;
+                        }
+                        Err(_) => break,
+                    }
+                }
+
+                match self.parse_row_data_with_offset(data, offset, Some(schema), reader) {
+                    Ok((mut cells, mut row_cell_meta, row_header_opt, next_offset, is_static)) => {
+                        offset = next_offset;
+                        row_count += 1;
+
+                        if is_static {
+                            static_cells = cells;
+                            static_cell_meta = row_cell_meta;
+                        } else {
+                            // Merge static cells / metadata into clustering row
+                            for (k, v) in &static_cells {
+                                cells.entry(k.clone()).or_insert_with(|| v.clone());
+                            }
+                            for (k, v) in &static_cell_meta {
+                                row_cell_meta.entry(k.clone()).or_insert_with(|| v.clone());
+                            }
+
+                            let row_tombstone =
+                                row_header_opt.as_ref().filter(|h| h.is_row_tombstone());
+
+                            let row_value = if let Some(h) = row_tombstone {
+                                h.row_tombstone()
+                            } else if cells.is_empty() {
+                                Value::Null
+                            } else {
+                                let mut map_entries: Vec<(Value, Value)> = cells
+                                    .into_iter()
+                                    .map(|(name, value)| (Value::Text(name), value))
+                                    .collect();
+                                map_entries.sort_by(|a, b| {
+                                    let a_key = if let Value::Text(s) = &a.0 {
+                                        s.as_str()
+                                    } else {
+                                        ""
+                                    };
+                                    let b_key = if let Value::Text(s) = &b.0 {
+                                        s.as_str()
+                                    } else {
+                                        ""
+                                    };
+                                    a_key.cmp(b_key)
+                                });
+                                Value::Map(map_entries)
+                            };
+
+                            match emit((
+                                table_id.clone(),
+                                partition_key.clone(),
+                                row_value,
+                                row_cell_meta,
+                            ))? {
+                                std::ops::ControlFlow::Continue(()) => {}
+                                std::ops::ControlFlow::Break(()) => return Ok(()),
+                            }
+                        }
+
+                        if offset >= data.len() {
+                            break;
+                        }
+
+                        if self.peek_is_partition_header(data, offset) {
+                            log::debug!(
+                                "V5CompressedLegacy: Partition {} detected at offset {} after {} rows",
+                                partition_index + 1, offset, row_count
+                            );
+                            break;
+                        }
+                    }
+                    Err(e) => {
+                        log::debug!(
+                            "V5CompressedLegacy: Row parse error in partition {} at offset {}: {}",
+                            partition_index,
+                            offset,
+                            e
+                        );
+                        break;
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     /// Streaming variant of [`parse_block`]: invokes `emit` for each parsed
     /// `(TableId, RowKey, Value)` entry instead of collecting them into a `Vec`,
     /// so callers can forward rows into a bounded channel without materializing
@@ -548,7 +729,13 @@ impl V5CompressedLegacyParser {
                         }
 
                         match self.parse_row_data_with_offset(data, offset, Some(schema), reader) {
-                            Ok((mut cells, row_header_opt, next_offset, is_static)) => {
+                            Ok((
+                                mut cells,
+                                _row_cell_meta,
+                                row_header_opt,
+                                next_offset,
+                                is_static,
+                            )) => {
                                 // Update offset to point to the next row or partition
                                 offset = next_offset;
                                 row_count += 1;
@@ -855,7 +1042,13 @@ impl V5CompressedLegacyParser {
                         }
 
                         match self.parse_row_data_with_offset(data, offset, Some(schema), reader) {
-                            Ok((mut cells, row_header_opt, next_offset, is_static)) => {
+                            Ok((
+                                mut cells,
+                                _row_cell_meta,
+                                row_header_opt,
+                                next_offset,
+                                is_static,
+                            )) => {
                                 offset = next_offset;
 
                                 // For a row tombstone the authoritative timestamp is
@@ -1932,6 +2125,8 @@ impl V5CompressedLegacyParser {
         reader: &super::super::types::SSTableReader,
     ) -> Result<ParsedRow> {
         let mut cells = HashMap::new();
+        // Parallel per-cell write metadata map (populated alongside `cells`).
+        let mut cell_meta: HashMap<String, CellWriteMetadata> = HashMap::new();
 
         let schema = schema.ok_or_else(|| {
             Error::schema(format!(
@@ -2089,8 +2284,8 @@ impl V5CompressedLegacyParser {
                 next_offset
             );
 
-            // Return empty cells for tombstoned row
-            return Ok((cells, Some(row_header), next_offset, is_static));
+            // Return empty cells for tombstoned row (no cell metadata)
+            return Ok((cells, cell_meta, Some(row_header), next_offset, is_static));
         }
 
         // Advance offset past row metadata to start of cell data
@@ -2241,42 +2436,93 @@ impl V5CompressedLegacyParser {
             }
 
             // Issue #221: Branch based on column type - complex columns need special parsing
-            let parse_result = if Self::is_complex_column(&column.data_type) {
+            // Issue #693: simple columns return 4-tuple including cell timestamp / expiration;
+            //             complex columns return 2-tuple and inherit the row-level timestamp.
+            if Self::is_complex_column(&column.data_type) {
                 log::debug!(
                     "V5CompressedLegacy: Column '{}' is complex (non-frozen collection), using parse_complex_column",
                     column.name
                 );
-                self.parse_complex_column(data, offset, column, has_complex_deletion, reader)
-            } else {
-                self.parse_cell_value_schema_order(data, offset, column, reader)
-            };
-
-            match parse_result {
-                Ok((value, new_offset)) => {
-                    log::debug!(
-                        "V5CompressedLegacy:   ✓ Column {} '{}' ({}) = {:?}, consumed {} bytes",
-                        col_idx,
-                        column.name,
-                        column.data_type,
-                        value,
-                        new_offset - offset
-                    );
-                    cells.insert(column.name.clone(), value);
-                    offset = new_offset;
+                match self.parse_complex_column(data, offset, column, has_complex_deletion, reader)
+                {
+                    Ok((value, new_offset)) => {
+                        log::debug!(
+                            "V5CompressedLegacy:   ✓ Complex column {} '{}' = {:?}, consumed {} bytes",
+                            col_idx, column.name, value, new_offset - offset
+                        );
+                        // Complex (non-frozen) collection cells inherit the row-level timestamp.
+                        let row_ts = row_header.timestamp.unwrap_or(0);
+                        cell_meta.insert(
+                            column.name.clone(),
+                            CellWriteMetadata {
+                                write_timestamp_micros: row_ts,
+                                expiration: None,
+                            },
+                        );
+                        cells.insert(column.name.clone(), value);
+                        offset = new_offset;
+                    }
+                    Err(e) => {
+                        log::debug!(
+                            "V5CompressedLegacy:   ✗ Complex column {} '{}' at offset {} FAILED: {}",
+                            col_idx, column.name, offset, e
+                        );
+                        break;
+                    }
                 }
-                Err(e) => {
-                    log::debug!(
-                        "V5CompressedLegacy:   ✗ Column {} '{}' ({}) at offset {} FAILED: {}",
-                        col_idx,
-                        column.name,
-                        column.data_type,
-                        offset,
-                        e
-                    );
-                    // CRITICAL FIX: Stop parsing remaining columns when we hit an error
-                    // The offset doesn't advance here, but we exit the loop cleanly
-                    // rather than continuing with invalid offset
-                    break;
+            } else {
+                match self.parse_cell_value_schema_order(data, offset, column, reader) {
+                    Ok((value, cell_own_ts, cell_exp, new_offset)) => {
+                        log::debug!(
+                            "V5CompressedLegacy:   ✓ Column {} '{}' ({}) = {:?}, consumed {} bytes",
+                            col_idx,
+                            column.name,
+                            column.data_type,
+                            value,
+                            new_offset - offset
+                        );
+                        // Resolve effective write timestamp:
+                        // use cell's own timestamp when present, else row-level liveness timestamp.
+                        let effective_ts =
+                            cell_own_ts.unwrap_or_else(|| row_header.timestamp.unwrap_or(0));
+                        // Resolve expiration: cell-level wins; fall back to row-level TTL when
+                        // the cell used USE_ROW_TTL (cell_exp is None in that case).
+                        // USE_ROW_TTL path: row_header.ttl is the row-level TTL in seconds.
+                        // row_header.local_deletion_time is the corresponding expires_at (seconds).
+                        let row_level_exp = match (row_header.ttl, row_header.local_deletion_time) {
+                            (Some(ttl_s), Some(ldt_s)) => Some(CellExpiration {
+                                ttl_seconds: ttl_s,
+                                expires_at_seconds: ldt_s as i64,
+                            }),
+                            _ => None,
+                        };
+                        // Resolve expiration: cell-level wins; fall back to row-level TTL when
+                        // the cell used USE_ROW_TTL (cell_exp is None in that case).
+                        let effective_exp = cell_exp.or(row_level_exp);
+                        cell_meta.insert(
+                            column.name.clone(),
+                            CellWriteMetadata {
+                                write_timestamp_micros: effective_ts,
+                                expiration: effective_exp,
+                            },
+                        );
+                        cells.insert(column.name.clone(), value);
+                        offset = new_offset;
+                    }
+                    Err(e) => {
+                        log::debug!(
+                            "V5CompressedLegacy:   ✗ Column {} '{}' ({}) at offset {} FAILED: {}",
+                            col_idx,
+                            column.name,
+                            column.data_type,
+                            offset,
+                            e
+                        );
+                        // CRITICAL FIX: Stop parsing remaining columns when we hit an error
+                        // The offset doesn't advance here, but we exit the loop cleanly
+                        // rather than continuing with invalid offset
+                        break;
+                    }
                 }
             }
         }
@@ -2323,7 +2569,7 @@ impl V5CompressedLegacyParser {
             row_size, next_offset, row_size_counted_from, is_static
         );
 
-        Ok((cells, Some(row_header), next_offset, is_static))
+        Ok((cells, cell_meta, Some(row_header), next_offset, is_static))
     }
 
     /// Parse a single cell value WITHOUT column name (schema-order format)
@@ -2340,14 +2586,18 @@ impl V5CompressedLegacyParser {
     ///
     /// See CASSANDRA_5_CELL_DESERIALIZATION_FORMAT.md for complete specification.
     ///
-    /// Returns: (value, new_offset)
+    /// Returns: `(value, cell_own_timestamp, expiration, new_offset)` where:
+    /// - `cell_own_timestamp`: the cell's own decoded timestamp in µs, or `None`
+    ///   when the cell inherits the row-level timestamp (`USE_ROW_TIMESTAMP` flag).
+    /// - `expiration`: TTL / localDeletionTime pair when the cell is expiring, or
+    ///   `None` when the cell has no TTL.
     fn parse_cell_value_schema_order(
         &self,
         data: &[u8],
         mut offset: usize,
         column: &crate::schema::Column,
         _reader: &super::super::types::SSTableReader,
-    ) -> Result<(Value, usize)> {
+    ) -> Result<(Value, Option<i64>, Option<CellExpiration>, usize)> {
         // Cell flag constants (from Cassandra 5.0 Cell.Serializer)
         const CELL_IS_DELETED: u8 = 0x01;
         const CELL_IS_EXPIRING: u8 = 0x02;
@@ -2419,6 +2669,8 @@ impl V5CompressedLegacyParser {
         }
 
         // Step 2: Read localDeletionTime (if deleted or expiring, and not using row TTL)
+        // Captured as absolute epoch-seconds for CellExpiration.expires_at_seconds.
+        let mut cell_local_deletion_time: Option<i64> = None;
         if !use_row_ttl && (is_deleted || is_expiring) {
             let (remaining, deletion_delta) = parse_vuint(&data[offset..]).map_err(|e| {
                 Error::corruption(format!(
@@ -2428,16 +2680,22 @@ impl V5CompressedLegacyParser {
             })?;
             let bytes_consumed = data[offset..].len() - remaining.len();
             offset += bytes_consumed;
+            let abs_ldt = self
+                .min_local_deletion_time
+                .wrapping_add(deletion_delta as i64);
             log::debug!(
-                "V5CompressedLegacy: Cell '{}' deletion_delta={} (min_local_deletion_time={})",
+                "V5CompressedLegacy: Cell '{}' deletion_delta={} (min_local_deletion_time={}) abs_ldt={}",
                 column.name,
                 deletion_delta,
-                self.min_local_deletion_time
+                self.min_local_deletion_time,
+                abs_ldt
             );
-            // Note: actual localDeletionTime = min_local_deletion_time + deletion_delta
+            cell_local_deletion_time = Some(abs_ldt);
         }
 
         // Step 3: Read TTL (if expiring and not using row TTL)
+        // Captured as absolute TTL seconds for CellExpiration.ttl_seconds.
+        let mut cell_ttl_seconds: Option<i32> = None;
         if !use_row_ttl && is_expiring {
             let (remaining, ttl_delta) = parse_vuint(&data[offset..]).map_err(|e| {
                 Error::corruption(format!(
@@ -2447,14 +2705,31 @@ impl V5CompressedLegacyParser {
             })?;
             let bytes_consumed = data[offset..].len() - remaining.len();
             offset += bytes_consumed;
+            // Absolute TTL = min_ttl + delta (seconds).  Clamp to i32 range for the
+            // CellExpiration.ttl_seconds field (Cassandra caps TTL at ~630M seconds).
+            let abs_ttl = self.min_ttl.unwrap_or(0).wrapping_add(ttl_delta as i64);
             log::debug!(
-                "V5CompressedLegacy: Cell '{}' ttl_delta={} (min_ttl={:?})",
+                "V5CompressedLegacy: Cell '{}' ttl_delta={} (min_ttl={:?}) abs_ttl={}",
                 column.name,
                 ttl_delta,
-                self.min_ttl
+                self.min_ttl,
+                abs_ttl
             );
-            // Note: actual TTL = min_ttl + ttl_delta (if min_ttl exists)
+            cell_ttl_seconds = Some(abs_ttl.min(i32::MAX as i64) as i32);
         }
+
+        // Build per-cell expiration metadata (used when the flag is set).
+        // Available at both return sites below — the tombstone path also uses
+        // cell_timestamp so we compute expiration here before the tombstone check.
+        let cell_expiration: Option<CellExpiration> =
+            match (is_expiring, cell_local_deletion_time, cell_ttl_seconds) {
+                (true, Some(expires_at), Some(ttl_secs)) => Some(CellExpiration {
+                    ttl_seconds: ttl_secs,
+                    expires_at_seconds: expires_at,
+                }),
+                // use_row_ttl path: expiration info comes from the row header (caller handles it).
+                _ => None,
+            };
 
         // Step 4: Cell path for complex columns (multi-cell collections/UDTs)
         // For now, skip this - we'll add in a future iteration when we handle complex columns.
@@ -2490,6 +2765,8 @@ impl V5CompressedLegacyParser {
                     range_start: None,
                     range_end: None,
                 }),
+                cell_timestamp,
+                cell_expiration,
                 offset,
             ));
         }
@@ -2502,7 +2779,12 @@ impl V5CompressedLegacyParser {
             );
             // Return appropriate empty value for type
             // For most types, empty = empty string or empty collection
-            return Ok((Value::Text(String::new()), offset));
+            return Ok((
+                Value::Text(String::new()),
+                cell_timestamp,
+                cell_expiration,
+                offset,
+            ));
         }
 
         // At this point, we have a live cell with value data
@@ -3280,9 +3562,12 @@ impl V5CompressedLegacyParser {
                         )));
                     }
                     // Non-collection / primitive frozen type — recurse normally.
+                    // The recursive call now returns 4 elements; we only need value + offset.
                     let mut inner_column = column.clone();
                     inner_column.data_type = inner_type.clone();
-                    self.parse_cell_value_schema_order(data, offset, &inner_column, _reader)?
+                    let (inner_val, _inner_ts, _inner_exp, inner_off) =
+                        self.parse_cell_value_schema_order(data, offset, &inner_column, _reader)?;
+                    (inner_val, inner_off)
                 };
 
                 offset = new_offset;
@@ -3386,7 +3671,7 @@ impl V5CompressedLegacyParser {
             }
         };
 
-        Ok((value, offset))
+        Ok((value, cell_timestamp, cell_expiration, offset))
     }
 
     /// Extract inner type from frozen<T> type string

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
@@ -73,11 +73,13 @@ const MAX_TYPE_NESTING_DEPTH: usize = 10;
 /// (cells, cell_metadata, row_header, next_offset, is_static)
 ///
 /// `cell_metadata` maps column name → `CellWriteMetadata` for every live cell
-/// parsed in this row. Used to surface per-cell timestamps / TTLs for
-/// `WRITETIME(col)` / `TTL(col)` queries (issue #693).
+/// parsed in this row.  It is `Some(map)` only when `want_cell_metadata == true`
+/// was passed to the function; otherwise it is `None` and zero allocations are
+/// incurred on the normal read hot-path.  Used to surface per-cell timestamps /
+/// TTLs for `WRITETIME(col)` / `TTL(col)` queries (issue #693).
 type ParsedRow = (
     HashMap<String, Value>,
-    HashMap<String, CellWriteMetadata>,
+    Option<HashMap<String, CellWriteMetadata>>,
     Option<RowHeader>,
     usize,
     bool,
@@ -416,8 +418,9 @@ impl V5CompressedLegacyParser {
                     }
                 }
 
-                match self.parse_row_data_with_offset(data, offset, Some(schema), reader) {
-                    Ok((mut cells, mut row_cell_meta, row_header_opt, next_offset, is_static)) => {
+                match self.parse_row_data_with_offset(data, offset, Some(schema), reader, true) {
+                    Ok((mut cells, row_cell_meta_opt, row_header_opt, next_offset, is_static)) => {
+                        let mut row_cell_meta = row_cell_meta_opt.unwrap_or_default();
                         offset = next_offset;
                         row_count += 1;
 
@@ -728,7 +731,13 @@ impl V5CompressedLegacyParser {
                             }
                         }
 
-                        match self.parse_row_data_with_offset(data, offset, Some(schema), reader) {
+                        match self.parse_row_data_with_offset(
+                            data,
+                            offset,
+                            Some(schema),
+                            reader,
+                            false,
+                        ) {
                             Ok((
                                 mut cells,
                                 _row_cell_meta,
@@ -1041,7 +1050,13 @@ impl V5CompressedLegacyParser {
                             }
                         }
 
-                        match self.parse_row_data_with_offset(data, offset, Some(schema), reader) {
+                        match self.parse_row_data_with_offset(
+                            data,
+                            offset,
+                            Some(schema),
+                            reader,
+                            false,
+                        ) {
                             Ok((
                                 mut cells,
                                 _row_cell_meta,
@@ -2123,10 +2138,18 @@ impl V5CompressedLegacyParser {
         mut offset: usize,
         schema: Option<&TableSchema>,
         reader: &super::super::types::SSTableReader,
+        want_cell_metadata: bool,
     ) -> Result<ParsedRow> {
         let mut cells = HashMap::new();
         // Parallel per-cell write metadata map (populated alongside `cells`).
-        let mut cell_meta: HashMap<String, CellWriteMetadata> = HashMap::new();
+        // Only allocated when the caller actually needs WRITETIME/TTL metadata
+        // (i.e. `want_cell_metadata == true`).  On the normal read path this stays
+        // `None` so that zero HashMap allocations or inserts occur per cell.
+        let mut cell_meta: Option<HashMap<String, CellWriteMetadata>> = if want_cell_metadata {
+            Some(HashMap::new())
+        } else {
+            None
+        };
 
         let schema = schema.ok_or_else(|| {
             Error::schema(format!(
@@ -2451,14 +2474,17 @@ impl V5CompressedLegacyParser {
                             col_idx, column.name, value, new_offset - offset
                         );
                         // Complex (non-frozen) collection cells inherit the row-level timestamp.
-                        let row_ts = row_header.timestamp.unwrap_or(0);
-                        cell_meta.insert(
-                            column.name.clone(),
-                            CellWriteMetadata {
-                                write_timestamp_micros: row_ts,
-                                expiration: None,
-                            },
-                        );
+                        // Only compute and store metadata when the caller requested it.
+                        if let Some(ref mut meta_map) = cell_meta {
+                            let row_ts = row_header.timestamp.unwrap_or(0);
+                            meta_map.insert(
+                                column.name.clone(),
+                                CellWriteMetadata {
+                                    write_timestamp_micros: row_ts,
+                                    expiration: None,
+                                },
+                            );
+                        }
                         cells.insert(column.name.clone(), value);
                         offset = new_offset;
                     }
@@ -2481,31 +2507,35 @@ impl V5CompressedLegacyParser {
                             value,
                             new_offset - offset
                         );
-                        // Resolve effective write timestamp:
-                        // use cell's own timestamp when present, else row-level liveness timestamp.
-                        let effective_ts =
-                            cell_own_ts.unwrap_or_else(|| row_header.timestamp.unwrap_or(0));
-                        // Resolve expiration: cell-level wins; fall back to row-level TTL when
-                        // the cell used USE_ROW_TTL (cell_exp is None in that case).
-                        // USE_ROW_TTL path: row_header.ttl is the row-level TTL in seconds.
-                        // row_header.local_deletion_time is the corresponding expires_at (seconds).
-                        let row_level_exp = match (row_header.ttl, row_header.local_deletion_time) {
-                            (Some(ttl_s), Some(ldt_s)) => Some(CellExpiration {
-                                ttl_seconds: ttl_s,
-                                expires_at_seconds: ldt_s as i64,
-                            }),
-                            _ => None,
-                        };
-                        // Resolve expiration: cell-level wins; fall back to row-level TTL when
-                        // the cell used USE_ROW_TTL (cell_exp is None in that case).
-                        let effective_exp = cell_exp.or(row_level_exp);
-                        cell_meta.insert(
-                            column.name.clone(),
-                            CellWriteMetadata {
-                                write_timestamp_micros: effective_ts,
-                                expiration: effective_exp,
-                            },
-                        );
+                        // Only compute and store per-cell metadata when the caller requested it.
+                        // On the normal read hot-path (want_cell_metadata == false), cell_meta is
+                        // None and this entire block is skipped — zero allocations per cell.
+                        if let Some(ref mut meta_map) = cell_meta {
+                            // Resolve effective write timestamp:
+                            // use cell's own timestamp when present, else row-level liveness timestamp.
+                            let effective_ts =
+                                cell_own_ts.unwrap_or_else(|| row_header.timestamp.unwrap_or(0));
+                            // Resolve expiration: cell-level wins; fall back to row-level TTL when
+                            // the cell used USE_ROW_TTL (cell_exp is None in that case).
+                            // USE_ROW_TTL path: row_header.ttl is the row-level TTL in seconds.
+                            // row_header.local_deletion_time is the corresponding expires_at (seconds).
+                            let row_level_exp =
+                                match (row_header.ttl, row_header.local_deletion_time) {
+                                    (Some(ttl_s), Some(ldt_s)) => Some(CellExpiration {
+                                        ttl_seconds: ttl_s,
+                                        expires_at_seconds: ldt_s as i64,
+                                    }),
+                                    _ => None,
+                                };
+                            let effective_exp = cell_exp.or(row_level_exp);
+                            meta_map.insert(
+                                column.name.clone(),
+                                CellWriteMetadata {
+                                    write_timestamp_micros: effective_ts,
+                                    expiration: effective_exp,
+                                },
+                            );
+                        }
                         cells.insert(column.name.clone(), value);
                         offset = new_offset;
                     }

--- a/cqlite-core/src/types.rs
+++ b/cqlite-core/src/types.rs
@@ -152,6 +152,37 @@ pub struct TombstoneInfo {
     pub range_end: Option<RowKey>,
 }
 
+/// Per-cell write metadata surfaced when `WRITETIME(col)` or `TTL(col)` is in the SELECT.
+///
+/// Moved here from `crate::query::result` so the storage layer can populate it
+/// without creating a cyclic dependency (storage → query).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CellWriteMetadata {
+    /// Write timestamp of the cell in **microseconds since Unix epoch**.
+    ///
+    /// For cells that inherit the row-level liveness timestamp
+    /// (`USE_ROW_TIMESTAMP` flag) this is the row timestamp.
+    /// Matches `WRITETIME(col)` semantics exactly.
+    pub write_timestamp_micros: i64,
+
+    /// Expiration info when the cell was written with a TTL.
+    ///
+    /// `None` when the cell has no TTL (it does not expire).
+    pub expiration: Option<CellExpiration>,
+}
+
+/// TTL / expiration info for a cell that was written with a TTL.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CellExpiration {
+    /// TTL in **seconds** as written by the client.
+    pub ttl_seconds: i32,
+
+    /// Epoch-seconds at which the cell expires (local deletion time).
+    ///
+    /// When `now_seconds > expires_at`, the cell is expired.
+    pub expires_at_seconds: i64,
+}
+
 /// Types of tombstones in Cassandra
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum TombstoneType {

--- a/cqlite-core/tests/issue_693_writetime_threading.rs
+++ b/cqlite-core/tests/issue_693_writetime_threading.rs
@@ -1,0 +1,376 @@
+//! Issue #693: Thread per-cell write timestamps from SSTable scan to QueryRow.
+//!
+//! The scan chain `Database::scan` → `SSTableManager::scan` → V5CompressedLegacy
+//! parser previously materialized cells into `Value::Map` and dropped the per-cell
+//! `timestamp` and `ttl` that the parser already decoded. As a result,
+//! `WRITETIME(col)` and `TTL(col)` always returned `null`.
+//!
+//! The fix (this PR) adds a parallel `scan_with_cell_metadata` path that, when
+//! `ProjectionFlags::include_cell_metadata` is true, returns a
+//! `HashMap<String, CellWriteMetadata>` for each row alongside the value — the
+//! executor then attaches it to the `QueryRow` so `evaluate_writetime_ttl` can
+//! return the real timestamp instead of falling through to `Value::Null`.
+//!
+//! These tests:
+//! 1. Assert that scanning `test_basic.simple_table` via the full query path
+//!    yields a non-null, non-zero `WRITETIME(name)` for every row.
+//! 2. Cross-check that the returned timestamp matches the `tstamp` recorded in
+//!    the JSONL golden file (sstabledump ground truth).
+//! 3. Skip cleanly when datasets are absent (same pattern as other integration
+//!    tests in this directory).
+//!
+//! Requires `CQLITE_DATASETS_ROOT` and real Data.db files
+//! (`bash test-data/scripts/fetch-datasets.sh`).
+
+#![cfg(all(feature = "state_machine", feature = "cli-helpers"))]
+
+use std::path::{Path, PathBuf};
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::types::Value;
+use cqlite_core::Database;
+
+fn get_datasets_root() -> Option<PathBuf> {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+}
+
+fn get_schemas_dir() -> Option<PathBuf> {
+    if let Some(datasets_root) = get_datasets_root() {
+        let schemas_dir = datasets_root.parent()?.join("schemas");
+        if schemas_dir.exists() {
+            return Some(schemas_dir);
+        }
+    }
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let schemas_dir = manifest_dir.parent()?.join("test-data").join("schemas");
+    schemas_dir.exists().then_some(schemas_dir)
+}
+
+/// Open `test_basic` database, or return `None` if datasets aren't available.
+async fn setup_basic_db() -> Option<Database> {
+    let datasets_root = get_datasets_root()?;
+    let schemas_dir = get_schemas_dir()?;
+    let schema_path = schemas_dir.join("basic-types.cql");
+    if !schema_path.exists() {
+        return None;
+    }
+    let data_dir = datasets_root.join("sstables");
+    if !data_dir.exists() {
+        return None;
+    }
+
+    let config = IngestionConfig {
+        schema_paths: vec![schema_path],
+        data_dir,
+        version_hint: None,
+        core_config: cqlite_core::Config::default(),
+        table_directory_filter: Some("/test_basic/".to_string()),
+    };
+
+    let result = ingest(config).await.ok()?;
+    if result.schema_load_result.schemas_loaded == 0 {
+        return None;
+    }
+    Some(result.database)
+}
+
+/// WRITETIME(col) must return a non-null, positive integer (microseconds) for
+/// every row in `test_basic.simple_table`.
+///
+/// Before issue #693 was fixed, the scan chain dropped per-cell timestamps and
+/// every WRITETIME() call returned `null`.
+#[tokio::test]
+async fn writetime_returns_non_null_for_simple_table() {
+    let Some(db) = setup_basic_db().await else {
+        eprintln!("writetime_returns_non_null_for_simple_table: SKIPPED (no datasets)");
+        return;
+    };
+
+    let result = db
+        .execute("SELECT id, WRITETIME(name) FROM test_basic.simple_table LIMIT 10")
+        .await
+        .expect("WRITETIME query should succeed");
+
+    if result.rows.is_empty() {
+        eprintln!(
+            "writetime_returns_non_null_for_simple_table: SKIPPED (0 rows — Data.db absent?)"
+        );
+        return;
+    }
+
+    let mut non_null_count = 0_usize;
+    for row in &result.rows {
+        let wt = row
+            .values
+            .get("writetime(name)")
+            .cloned()
+            .unwrap_or(Value::Null);
+        match wt {
+            Value::Null => {
+                // Print which row had null for debugging
+                let id = row.values.get("id").cloned().unwrap_or(Value::Null);
+                eprintln!("WRITETIME(name) is null for id={:?}", id);
+            }
+            Value::BigInt(ts) => {
+                assert!(
+                    ts > 0,
+                    "WRITETIME must be a positive microsecond epoch: got {}",
+                    ts
+                );
+                // Sanity-check: Cassandra 5.0 SSTables were written in 2025.
+                // 2025-01-01T00:00:00Z in microseconds ≈ 1_735_689_600_000_000.
+                // A WRITETIME less than that is almost certainly wrong.
+                assert!(
+                    ts > 1_735_000_000_000_000_i64,
+                    "WRITETIME timestamp looks wrong (too small): {}",
+                    ts
+                );
+                non_null_count += 1;
+            }
+            other => {
+                panic!("WRITETIME(name) expected BigInt or Null, got {:?}", other);
+            }
+        }
+    }
+
+    assert!(
+        non_null_count > 0,
+        "At least one WRITETIME(name) value must be non-null — \
+         issue #693 scan threading is broken if all are null"
+    );
+    assert_eq!(
+        non_null_count,
+        result.rows.len(),
+        "ALL rows must have a non-null WRITETIME(name): {}/{} were non-null",
+        non_null_count,
+        result.rows.len()
+    );
+}
+
+/// TTL(col) must return null for a non-expiring column (`simple_table.name`
+/// has no TTL), not an error or a garbage value.
+#[tokio::test]
+async fn ttl_returns_null_for_non_expiring_column() {
+    let Some(db) = setup_basic_db().await else {
+        eprintln!("ttl_returns_null_for_non_expiring_column: SKIPPED (no datasets)");
+        return;
+    };
+
+    let result = db
+        .execute("SELECT id, TTL(name) FROM test_basic.simple_table LIMIT 5")
+        .await
+        .expect("TTL query should succeed");
+
+    if result.rows.is_empty() {
+        eprintln!("ttl_returns_null_for_non_expiring_column: SKIPPED (0 rows)");
+        return;
+    }
+
+    for row in &result.rows {
+        let ttl = row.values.get("ttl(name)").cloned().unwrap_or(Value::Null);
+        assert!(
+            matches!(ttl, Value::Null),
+            "TTL(name) must be null for a non-expiring column, got {:?}",
+            ttl
+        );
+    }
+}
+
+/// WRITETIME(col) values decoded from the SSTable must match the per-row
+/// `liveness_info.tstamp` recorded by sstabledump in the JSONL golden.
+///
+/// The golden file contains the authoritative sstabledump output; any mismatch
+/// indicates a bug in the delta-decoding or timestamp-propagation logic.
+#[tokio::test]
+async fn writetime_matches_sstabledump_golden() {
+    let Some(db) = setup_basic_db().await else {
+        eprintln!("writetime_matches_sstabledump_golden: SKIPPED (no datasets)");
+        return;
+    };
+
+    // Load the JSONL golden for simple_table.
+    let datasets_root = match get_datasets_root() {
+        Some(r) => r,
+        None => {
+            eprintln!("writetime_matches_sstabledump_golden: SKIPPED (no datasets root)");
+            return;
+        }
+    };
+    let golden_path = datasets_root.join("sstables").join("test_basic");
+
+    // Find the simple_table directory (name includes UUID suffix).
+    let table_dir = std::fs::read_dir(&golden_path).ok().and_then(|entries| {
+        entries.flatten().find(|e| {
+            e.file_name()
+                .to_str()
+                .map(|n| n.starts_with("simple_table-"))
+                .unwrap_or(false)
+        })
+    });
+
+    let Some(table_dir) = table_dir else {
+        eprintln!(
+            "writetime_matches_sstabledump_golden: SKIPPED (simple_table directory not found)"
+        );
+        return;
+    };
+
+    let jsonl_path = table_dir.path().join("nb-1-big-Data.db.jsonl");
+    if !jsonl_path.exists() {
+        eprintln!("writetime_matches_sstabledump_golden: SKIPPED (JSONL golden not found)");
+        return;
+    }
+
+    // Parse the golden into a map: UUID string → tstamp_micros
+    let jsonl_content = std::fs::read_to_string(&jsonl_path).expect("read JSONL golden");
+    let mut golden: std::collections::HashMap<String, i64> = std::collections::HashMap::new();
+    for line in jsonl_content.lines() {
+        let Ok(entry) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        let uuid = entry["partition"]["key"]
+            .as_array()
+            .and_then(|a| a.first())
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let tstamp_str = entry["rows"]
+            .as_array()
+            .and_then(|rows| rows.first())
+            .and_then(|r| r["liveness_info"]["tstamp"].as_str())
+            .map(|s| s.to_string());
+
+        if let (Some(uuid), Some(ts_str)) = (uuid, tstamp_str) {
+            // Parse ISO-8601 timestamp to epoch-microseconds.
+            // Format: "2025-10-06T01:12:05.394120Z"
+            if let Ok(ts_micros) = parse_iso8601_to_micros(&ts_str) {
+                golden.insert(uuid, ts_micros);
+            }
+        }
+    }
+
+    if golden.is_empty() {
+        eprintln!(
+            "writetime_matches_sstabledump_golden: SKIPPED (golden is empty — parse failure?)"
+        );
+        return;
+    }
+
+    // Run the WRITETIME query.
+    let result = db
+        .execute("SELECT id, WRITETIME(name) FROM test_basic.simple_table LIMIT 20")
+        .await
+        .expect("WRITETIME query should succeed");
+
+    if result.rows.is_empty() {
+        eprintln!("writetime_matches_sstabledump_golden: SKIPPED (0 rows)");
+        return;
+    }
+
+    let mut checked = 0_usize;
+    for row in &result.rows {
+        // Get the UUID as a string (it's a Value::Uuid displayed as a hyphenated string).
+        let id_str = match row.values.get("id") {
+            Some(Value::Uuid(bytes)) if bytes.len() == 16 => {
+                let b = bytes.as_slice();
+                format!(
+                    "{:08x}-{:04x}-{:04x}-{:04x}-{:012x}",
+                    u32::from_be_bytes([b[0], b[1], b[2], b[3]]),
+                    u16::from_be_bytes([b[4], b[5]]),
+                    u16::from_be_bytes([b[6], b[7]]),
+                    u16::from_be_bytes([b[8], b[9]]),
+                    u64::from_be_bytes([0, 0, b[10], b[11], b[12], b[13], b[14], b[15]])
+                )
+            }
+            Some(Value::Text(s)) => s.clone(),
+            Some(other) => format!("{:?}", other),
+            None => continue,
+        };
+
+        let Some(&expected_ts) = golden.get(&id_str) else {
+            // Row not in golden (filtered or different LIMIT) — skip this row.
+            continue;
+        };
+
+        let got_ts = match row.values.get("writetime(name)") {
+            Some(Value::BigInt(ts)) => *ts,
+            Some(Value::Null) => {
+                panic!(
+                    "WRITETIME(name) is null for id={} — issue #693 threading is broken",
+                    id_str
+                );
+            }
+            other => panic!("Unexpected WRITETIME value {:?} for id={}", other, id_str),
+        };
+
+        assert_eq!(
+            got_ts, expected_ts,
+            "WRITETIME(name) mismatch for id={}: got {} but golden says {}",
+            id_str, got_ts, expected_ts
+        );
+        checked += 1;
+    }
+
+    assert!(
+        checked > 0,
+        "No rows were cross-checked against the golden — golden IDs don't match query output?"
+    );
+    eprintln!(
+        "writetime_matches_sstabledump_golden: cross-checked {} rows against golden",
+        checked
+    );
+}
+
+/// Parse an ISO-8601 timestamp string (`"2025-10-06T01:12:05.394120Z"`) into
+/// microseconds since the Unix epoch.  Only the `*Z` (UTC) form is needed here.
+fn parse_iso8601_to_micros(s: &str) -> Result<i64, String> {
+    let s = s.trim_end_matches('Z');
+    // Expected format: YYYY-MM-DDTHH:MM:SS.ffffff
+    let (date_part, time_part) = s
+        .split_once('T')
+        .ok_or_else(|| format!("no T separator in '{}'", s))?;
+
+    let parts: Vec<&str> = date_part.split('-').collect();
+    if parts.len() != 3 {
+        return Err(format!("bad date part '{}'", date_part));
+    }
+    let year: i64 = parts[0].parse().map_err(|e| format!("{}", e))?;
+    let month: u32 = parts[1].parse().map_err(|e| format!("{}", e))?;
+    let day: u32 = parts[2].parse().map_err(|e| format!("{}", e))?;
+
+    let (hms, frac) = time_part.split_once('.').unwrap_or((time_part, "0"));
+    let hms_parts: Vec<&str> = hms.split(':').collect();
+    if hms_parts.len() != 3 {
+        return Err(format!("bad time part '{}'", hms));
+    }
+    let hour: i64 = hms_parts[0].parse().map_err(|e| format!("{}", e))?;
+    let min: i64 = hms_parts[1].parse().map_err(|e| format!("{}", e))?;
+    let sec: i64 = hms_parts[2].parse().map_err(|e| format!("{}", e))?;
+
+    // Pad / truncate fractional part to 6 digits (microseconds).
+    let frac_padded = format!("{:0<6}", &frac[..frac.len().min(6)]);
+    let micros_frac: i64 = frac_padded.parse().map_err(|e| format!("{}", e))?;
+
+    // Compute days since epoch using the Gregorian calendar formula.
+    let epoch_days = days_since_epoch(year, month, day)?;
+
+    let total_seconds = epoch_days * 86_400 + hour * 3_600 + min * 60 + sec;
+    Ok(total_seconds * 1_000_000 + micros_frac)
+}
+
+/// Compute days since 1970-01-01 for a Gregorian calendar date.
+fn days_since_epoch(year: i64, month: u32, day: u32) -> Result<i64, String> {
+    // Zeller / Julian Day Number approach, reduced to epoch days.
+    // Reference: https://en.wikipedia.org/wiki/Julian_day#Converting_Gregorian_calendar_date_to_Julian_Day_Number
+    let m = month as i64;
+    let d = day as i64;
+    let y = if m <= 2 { year - 1 } else { year };
+    let m2 = if m <= 2 { m + 12 } else { m };
+    let a = y / 100;
+    let b = 2 - a + a / 4;
+    let jdn = 36_525 * (y + 4_716) / 100 + 306_001 * (m2 + 1) / 10_000 + d + b - 1_524;
+    // Julian Day Number for 1970-01-01 is 2_440_588.
+    Ok(jdn - 2_440_588)
+}


### PR DESCRIPTION
Closes #692

## Summary

Wire the parsed `WriteTimeTtlCall` AST nodes from #690 to the per-cell metadata carrier on `QueryRow` from #691 in the select executor.

- **Planning**: `select_has_writetime_ttl()` detects `WRITETIME`/`TTL` items and sets `ProjectionFlags::include_cell_metadata = true` so the flag flows to the reader
- **Evaluation**: `evaluate_select_expression` dispatches `WriteTimeTtl` calls to `evaluate_writetime_ttl()`, which reads from `QueryRow::cell_metadata` via `get_cell_metadata()`
- `WRITETIME(col)` → `Value::BigInt(write_timestamp_micros)`; `Value::Null` when no cell metadata is present
- `TTL(col)` → `Value::Integer(remaining_seconds)`; `Value::Null` when no expiration or the cell is expired
- TTL "now" is injectable via the `NowSeconds` trait (`SystemClock` in production; `FixedClock` in tests) — no raw wall-clock calls in the eval path
- Cassandra-convention column names: `writetime(col)` / `ttl(col)`, or the explicit alias when `#690`'s alias field is set
- `ColumnInfo` for `WriteTimeTtl` expressions carries `data_type: BigInt/Integer` and `cql_type: CqlType::BigInt/CqlType::Int`
- `execute_projection` passes the `WriteTimeTtl` column name through correctly

## Files Changed

- `cqlite-core/src/query/select_executor.rs` — function evaluation + flag wiring + column metadata

## Gate Output

```
==== AGENT-GATE SUMMARY ====
commit: 023086f0 branch: feat/692-writetime-ttl-executor dirty: no
fmt:               PASS (2s)
clippy:            PASS (48s)
core-tests:        PASS (229s)
integration-tests: PASS (19s)
write-tests:       PASS (44s)
cli-tests:         PASS (23s)
minimal-build:     PASS (0s)
smoke:             PASS (3s)
RESULT: PASS
==== END AGENT-GATE SUMMARY ====
```

## New Tests (16)

| Test | What it asserts |
|------|----------------|
| `test_writetime_returns_bigint_when_metadata_present` | WRITETIME returns Value::BigInt(micros) |
| `test_writetime_returns_null_when_no_metadata` | WRITETIME returns NULL when no cell metadata |
| `test_ttl_returns_remaining_seconds_for_live_cell` | TTL returns remaining seconds |
| `test_ttl_returns_null_when_no_expiration` | TTL returns NULL when no expiration |
| `test_ttl_returns_null_for_expired_cell` | TTL returns NULL for expired cell |
| `test_ttl_returns_null_when_no_metadata` | TTL returns NULL when no metadata |
| `test_writetime_ttl_column_name_no_alias` | Cassandra convention: `writetime(col)` / `ttl(col)` |
| `test_writetime_ttl_column_name_with_alias` | Alias overrides convention |
| `test_select_has_writetime_ttl_detection` | Planning flag detection |
| `test_executor_evaluate_writetime_reads_cell_metadata` | Executor dispatches to cell_metadata |
| `test_executor_evaluate_writetime_null_when_no_metadata` | NULL path through executor |
| `test_executor_evaluate_ttl_with_injected_clock` | TTL uses injected FixedClock |
| `test_executor_evaluate_ttl_expired_cell_returns_null` | Expired cell → NULL via executor |
| `test_get_result_columns_writetime_has_bigint_type` | ColumnInfo: bigint for WRITETIME |
| `test_get_result_columns_ttl_has_int_type` | ColumnInfo: int for TTL |
| `test_get_result_columns_writetime_with_alias` | ColumnInfo uses alias name |