### PR TITLE
ci: skip PR-comment steps on fork PRs to avoid 403 failures

### DIFF
--- a/.github/workflows/cassandra-validation.yml
+++ b/.github/workflows/cassandra-validation.yml
@@ -208,7 +208,7 @@ jobs:
           retention-days: 14
 
       - name: Comment on PR (Success)
-        if: success() && github.event_name == 'pull_request'
+        if: success() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v8
         with:
           script: |
@@ -229,7 +229,7 @@ jobs:
             });
 
       - name: Comment on PR (Failure)
-        if: failure() && github.event_name == 'pull_request'
+        if: failure() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v8
         with:
           script: |

--- a/.github/workflows/sstabledump-parity-gate.yml
+++ b/.github/workflows/sstabledump-parity-gate.yml
@@ -169,7 +169,7 @@ jobs:
           retention-days: 30
 
       - name: Comment on PR (Success)
-        if: always() && github.event_name == 'pull_request' && steps.data_parity.outcome == 'success' && steps.index_parity.outcome == 'success' && steps.summary_parity.outcome == 'success' && steps.statistics_parity.outcome == 'success'
+        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && steps.data_parity.outcome == 'success' && steps.index_parity.outcome == 'success' && steps.summary_parity.outcome == 'success' && steps.statistics_parity.outcome == 'success'
         uses: actions/github-script@v8
         with:
           script: |
@@ -192,7 +192,7 @@ jobs:
             });
 
       - name: Comment on PR (Failure)
-        if: always() && github.event_name == 'pull_request' && (steps.data_parity.outcome != 'success' || steps.index_parity.outcome != 'success' || steps.summary_parity.outcome != 'success' || steps.statistics_parity.outcome != 'success')
+        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && (steps.data_parity.outcome != 'success' || steps.index_parity.outcome != 'success' || steps.summary_parity.outcome != 'success' || steps.statistics_parity.outcome != 'success')
         uses: actions/github-script@v8
         with:
           script: |


### PR DESCRIPTION
Fork-triggered pull_request runs receive a read-only GITHUB_TOKEN
regardless of the workflow `permissions:` block, so the
actions/github-script steps that post status comments fail with
"403 Resource not accessible by integration" and mark the whole
job as failed even when the underlying validation passed.

Guard the comment steps with
`github.event.pull_request.head.repo.full_name == github.repository`
so they only run for same-repo PRs and are skipped on forks. This
matches the existing continue-on-error precedent in e2e-readback.yml.

Affects sstabledump-parity-gate.yml and cassandra-validation.yml.

Claude-Session: https://claude.ai/code/session_01DfAbudWK1sku4JoHv1Ai6t