### PR TITLE
Compaction parity: `cqlite compact`, differential harness vs Apache Cassandra, + clustering-table writer fix (#857)

### DIFF
--- a/compaction-parity/.gitignore
+++ b/compaction-parity/.gitignore
@@ -1,0 +1,2 @@
+build/
+.gradle/

--- a/compaction-parity/README.md
+++ b/compaction-parity/README.md
@@ -46,16 +46,26 @@ cd compaction-parity && gradle test
 The Cassandra checkout location can be overridden with `-PcassandraSrc=<dir>` or
 `$CQLITE_CASSANDRA_SRC`.
 
-## Known divergences
+## Scenarios
+
+Both current scenarios PASS — the harness confirms cqlite's compaction matches
+Apache Cassandra's for these cases:
+
+- `liveRowsLastWriteWinsNoClustering` — partition-key-only table, LWW overlap.
+- `liveRowsLastWriteWinsAcrossTwoSSTables` — clustering table, LWW overlap.
+
+## Resolved divergences
 
 The harness is wired to catch writer/compaction divergences; each is tracked as a
-sub-issue of #842 and the corresponding scenario is `@Ignore`d until fixed.
+sub-issue of #842 and its scenario is `@Ignore`d only while open.
 
-- **`liveRowsLastWriteWinsAcrossTwoSSTables`** — `@Ignore`d, tracked as **#857**.
-  cqlite's compacted
-  `Data.db` for a table **with clustering columns** is not Cassandra-readable:
-  `sstabledump` decodes the first partition then fails with
-  `CorruptSSTableException` / `EOFException` at `Columns$Serializer.deserializeSubset`
-  (row-body / column-subset / index-offset encoding). cqlite also reads its own
-  such output as 0 rows via the CLI query path. (No-clustering tables round-trip;
-  see `cqlite-core/tests/compact_command.rs`.) Un-ignore once the writer is fixed.
+- **#857 (fixed)** — cqlite's compacted `Data.db` for a table **with clustering
+  columns** was not Cassandra-readable: `sstabledump` decoded the first partition
+  then failed at `Columns$Serializer.deserializeSubset`. Root cause: the merge left
+  clustering columns inside the row's cells, so the writer emitted each clustering
+  value a second time as a phantom regular cell. Fixed by dropping primary-key
+  columns from a merged row's cell ops in `merge_row_group` (the clustering value is
+  still written positionally in the clustering prefix). Regression tests:
+  `data_writer::tests::merge_row_group_excludes_*` and
+  `cqlite-core/tests/compact_command.rs::compact_clustering_table_preserves_rows_and_lww`,
+  plus this harness's `liveRowsLastWriteWinsAcrossTwoSSTables`.

--- a/compaction-parity/README.md
+++ b/compaction-parity/README.md
@@ -1,0 +1,60 @@
+# compaction-parity
+
+Differential compaction-parity harness for CQLite (issue #842).
+
+Runs the **same input SSTables** through two compaction engines and asserts the
+outputs are equivalent:
+
+1. **Reference** — Apache Cassandra's compaction, in-JVM via `CQLTester`.
+2. **Candidate** — the external `cqlite compact` binary.
+
+See the design doc: `docs/plans/2026-06-18-compaction-parity-harness-design.md`.
+
+## Status
+
+- **Logical tier** (this module): a canonical `sstabledump` of every output must
+  match, run with the same tool over both engines' output.
+- **Byte tier** (#842 north star): per-component `cmp` — not yet implemented.
+
+## Layout
+
+```
+scripts/bootstrap-cassandra.sh   # clone apache/cassandra @ cassandra-5.0.2; ant jar build-test
+build.gradle.kts                 # builds against that checkout; JDK 17 test JVM
+src/test/java/org/cqlite/parity/
+  CqliteCompactionRunner.java    # shells out to `cqlite compact`
+  DifferentialParityTester.java  # build inputs → reference + candidate → logical diff
+  BasicDifferentialTest.java     # scenario: live rows, last-write-wins
+```
+
+## Running
+
+Prerequisites: JDK 11 or 17 (for the Cassandra build), Ant, a `cqlite` binary
+built with `--features write-support`, and Gradle.
+
+```bash
+# 1. Build the pinned Cassandra source once (cached under ~/.cache/cqlite).
+compaction-parity/scripts/bootstrap-cassandra.sh
+
+# 2. Build the cqlite binary under test.
+cargo build --features write-support
+
+# 3. Run the harness (uses target/debug/cqlite by default; override with -Dcqlite.bin).
+cd compaction-parity && gradle test
+```
+
+The Cassandra checkout location can be overridden with `-PcassandraSrc=<dir>` or
+`$CQLITE_CASSANDRA_SRC`.
+
+## Known divergences
+
+The harness is wired to catch writer/compaction divergences; each is tracked as a
+sub-issue of #842 and the corresponding scenario is `@Ignore`d until fixed.
+
+- **`liveRowsLastWriteWinsAcrossTwoSSTables`** — `@Ignore`d. cqlite's compacted
+  `Data.db` for a table **with clustering columns** is not Cassandra-readable:
+  `sstabledump` decodes the first partition then fails with
+  `CorruptSSTableException` / `EOFException` at `Columns$Serializer.deserializeSubset`
+  (row-body / column-subset / index-offset encoding). cqlite also reads its own
+  such output as 0 rows via the CLI query path. (No-clustering tables round-trip;
+  see `cqlite-core/tests/compact_command.rs`.) Un-ignore once the writer is fixed.

--- a/compaction-parity/README.md
+++ b/compaction-parity/README.md
@@ -51,7 +51,8 @@ The Cassandra checkout location can be overridden with `-PcassandraSrc=<dir>` or
 The harness is wired to catch writer/compaction divergences; each is tracked as a
 sub-issue of #842 and the corresponding scenario is `@Ignore`d until fixed.
 
-- **`liveRowsLastWriteWinsAcrossTwoSSTables`** — `@Ignore`d. cqlite's compacted
+- **`liveRowsLastWriteWinsAcrossTwoSSTables`** — `@Ignore`d, tracked as **#857**.
+  cqlite's compacted
   `Data.db` for a table **with clustering columns** is not Cassandra-readable:
   `sstabledump` decodes the first partition then fails with
   `CorruptSSTableException` / `EOFException` at `Columns$Serializer.deserializeSubset`

--- a/compaction-parity/build.gradle.kts
+++ b/compaction-parity/build.gradle.kts
@@ -1,0 +1,117 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
+
+/*
+ * Compaction-parity harness (issue #842).
+ *
+ * Builds against a pinned Apache Cassandra 5.0.2 source checkout produced by
+ * scripts/bootstrap-cassandra.sh. The harness runs Cassandra's compaction in-JVM
+ * (the reference) and shells out to the `cqlite compact` binary (the candidate),
+ * then compares the outputs (logical tier now; byte tier in a follow-up).
+ */
+
+plugins {
+    java
+}
+
+// ── Locate the Cassandra source checkout ────────────────────────────────────
+val defaultCassandraSrc =
+    "${System.getProperty("user.home")}/.cache/cqlite/cassandra-src/cassandra-5.0.2"
+val cassandraSrc: String =
+    (findProperty("cassandraSrc") as String?)
+        ?: System.getenv("CQLITE_CASSANDRA_SRC")
+        ?: defaultCassandraSrc
+
+val cassandraMainClasses = file("$cassandraSrc/build/classes/main")
+val cassandraTestClasses = file("$cassandraSrc/build/test/classes")
+val jammAgent = file("$cassandraSrc/lib/jamm-0.4.0.jar")
+val cassandraYaml = file("$cassandraSrc/test/conf/cassandra.yaml")
+val sstabledump = file("$cassandraSrc/tools/bin/sstabledump")
+
+fun cassandraJars() = files(
+    fileTree("$cassandraSrc/lib") { include("*.jar") },
+    fileTree("$cassandraSrc/build/lib/jars") { include("*.jar") },
+    fileTree("$cassandraSrc/build/test/lib/jars") { include("*.jar") },
+)
+
+java {
+    // Cassandra 5.0 runs on JDK 11 or 17 (NOT 21). Pin the test JVM to 17.
+    toolchain { languageVersion.set(JavaLanguageVersion.of(17)) }
+}
+
+dependencies {
+    // Cassandra main + test-tree classes, plus all of Cassandra's dependency jars.
+    testImplementation(files(cassandraMainClasses, cassandraTestClasses))
+    testImplementation(cassandraJars())
+}
+
+// ── cqlite binary under test ────────────────────────────────────────────────
+// Default to the workspace debug build; override with -Dcqlite.bin or $CQLITE_BIN.
+val cqliteBin: String =
+    System.getProperty("cqlite.bin")
+        ?: System.getenv("CQLITE_BIN")
+        ?: file("${rootDir.parent}/target/debug/cqlite").absolutePath
+
+// JDK 17 module access required by Cassandra's internals (mirrors build.xml).
+val jvm17Args = listOf(
+    "-Djdk.attach.allowAttachSelf=true",
+    "-XX:+UseG1GC",
+    "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
+    "--add-exports", "java.base/jdk.internal.ref=ALL-UNNAMED",
+    "--add-exports", "java.base/sun.nio.ch=ALL-UNNAMED",
+    "--add-exports", "java.management.rmi/com.sun.jmx.remote.internal.rmi=ALL-UNNAMED",
+    "--add-exports", "java.rmi/sun.rmi.registry=ALL-UNNAMED",
+    "--add-exports", "java.rmi/sun.rmi.server=ALL-UNNAMED",
+    "--add-exports", "java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED",
+    "--add-exports", "java.sql/java.sql=ALL-UNNAMED",
+    "--add-exports", "java.base/java.lang.ref=ALL-UNNAMED",
+    "--add-exports", "jdk.unsupported/sun.misc=ALL-UNNAMED",
+    "--add-opens", "java.base/java.lang.module=ALL-UNNAMED",
+    "--add-opens", "java.base/jdk.internal.loader=ALL-UNNAMED",
+    "--add-opens", "java.base/jdk.internal.ref=ALL-UNNAMED",
+    "--add-opens", "java.base/jdk.internal.reflect=ALL-UNNAMED",
+    "--add-opens", "java.base/jdk.internal.math=ALL-UNNAMED",
+    "--add-opens", "java.base/jdk.internal.module=ALL-UNNAMED",
+    "--add-opens", "java.base/jdk.internal.util.jar=ALL-UNNAMED",
+    "--add-opens", "jdk.management/com.sun.management.internal=ALL-UNNAMED",
+    "--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED",
+    "--add-opens", "java.base/java.io=ALL-UNNAMED",
+    "--add-opens", "java.base/java.lang.reflect=ALL-UNNAMED",
+    "--add-opens", "java.base/java.lang=ALL-UNNAMED",
+    "--add-opens", "java.base/java.util=ALL-UNNAMED",
+    "--add-opens", "java.base/java.nio=ALL-UNNAMED",
+    "--add-opens", "java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED",
+    "-Dio.netty.tryReflectionSetAccessible=true",
+)
+
+tasks.test {
+    useJUnit() // Cassandra's test tree is JUnit 4
+
+    // Fail fast and loudly if the harness isn't wired up, rather than silently passing.
+    doFirst {
+        require(cassandraMainClasses.isDirectory && cassandraTestClasses.isDirectory) {
+            "Cassandra classes not found under $cassandraSrc. Run scripts/bootstrap-cassandra.sh first."
+        }
+        require(file(cqliteBin).exists()) {
+            "cqlite binary not found at $cqliteBin. Build it with " +
+                "`cargo build --features write-support` or set -Dcqlite.bin."
+        }
+    }
+
+    jvmArgs(jvm17Args)
+    jvmArgs("-javaagent:${jammAgent.absolutePath}")
+
+    systemProperty("cassandra.config", cassandraYaml.toURI().toString())
+    systemProperty("cassandra.storagedir", "${layout.buildDirectory.get()}/cassandra-storage")
+    systemProperty("cqlite.bin", cqliteBin)
+    systemProperty("cassandra.src", cassandraSrc)
+    systemProperty("cassandra.sstabledump", sstabledump.absolutePath)
+
+    maxParallelForks = 1
+
+    testLogging {
+        events(TestLogEvent.PASSED, TestLogEvent.FAILED, TestLogEvent.SKIPPED)
+        exceptionFormat = TestExceptionFormat.FULL
+        showStandardStreams = true
+    }
+}

--- a/compaction-parity/scripts/bootstrap-cassandra.sh
+++ b/compaction-parity/scripts/bootstrap-cassandra.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# bootstrap-cassandra.sh — fetch and build the pinned Apache Cassandra source so
+# the compaction-parity harness can compile against its test-tree classes
+# (CQLTester, CompactionTask, JsonTransformer) which are NOT published to Maven.
+#
+# The version is pinned to the SAME release as the cassandra:5.0.2 Docker image
+# used to generate test data (single source of truth, issue #669). Build it once;
+# subsequent runs are a no-op unless --force is passed.
+#
+# Cassandra 5.0 builds with JDK 11 or 17 (NOT 21). This script picks a JDK 11
+# from $CASSANDRA_BUILD_JAVA_HOME, else an sdkman-installed JDK 11, else errors
+# with guidance. The harness itself (Gradle) runs on the default JDK.
+#
+# Output: prints the built source directory on the last line (stdout) so callers
+# (Gradle) can locate build/classes/main, build/test/classes and the dep jars.
+
+set -euo pipefail
+
+CASSANDRA_REF="${CASSANDRA_REF:-cassandra-5.0.2}"
+CACHE_ROOT="${CQLITE_CASSANDRA_CACHE:-$HOME/.cache/cqlite/cassandra-src}"
+SRC_DIR="$CACHE_ROOT/$CASSANDRA_REF"
+MARKER="$SRC_DIR/.cqlite-build-complete"
+FORCE=0
+
+for arg in "$@"; do
+    case "$arg" in
+        --force) FORCE=1 ;;
+        *) echo "unknown argument: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[bootstrap-cassandra] $*" >&2; }
+
+if [[ "$FORCE" -eq 0 && -f "$MARKER" ]]; then
+    log "already built at $SRC_DIR (pass --force to rebuild)"
+    echo "$SRC_DIR"
+    exit 0
+fi
+
+# ── Select a JDK 11/17 for the Cassandra build ──────────────────────────────
+pick_build_jdk() {
+    if [[ -n "${CASSANDRA_BUILD_JAVA_HOME:-}" ]]; then
+        echo "$CASSANDRA_BUILD_JAVA_HOME"
+        return
+    fi
+    # Prefer an sdkman-installed JDK 11, then 17 (newest patch of each).
+    local candidates_dir="$HOME/.sdkman/candidates/java"
+    local major chosen="" path
+    for major in 11 17; do
+        chosen=""
+        for path in "$candidates_dir/$major."*; do
+            [[ -x "$path/bin/javac" ]] && chosen="$path"
+        done
+        if [[ -n "$chosen" ]]; then
+            echo "$chosen"
+            return
+        fi
+    done
+    echo ""
+}
+
+BUILD_JAVA_HOME="$(pick_build_jdk)"
+if [[ -z "$BUILD_JAVA_HOME" || ! -x "$BUILD_JAVA_HOME/bin/javac" ]]; then
+    log "ERROR: no JDK 11/17 found for the Cassandra build."
+    log "Set CASSANDRA_BUILD_JAVA_HOME to a JDK 11 (or 17) home, e.g.:"
+    log "  sdk install java 11.0.25-amzn && CASSANDRA_BUILD_JAVA_HOME=\$HOME/.sdkman/candidates/java/11.0.25-amzn $0"
+    exit 1
+fi
+log "using build JDK: $BUILD_JAVA_HOME"
+
+command -v ant >/dev/null 2>&1 || { log "ERROR: ant not found on PATH"; exit 1; }
+
+# ── Fetch the pinned source (shallow, single tag) ───────────────────────────
+mkdir -p "$CACHE_ROOT"
+if [[ ! -d "$SRC_DIR/.git" ]]; then
+    log "cloning apache/cassandra @ $CASSANDRA_REF (shallow) → $SRC_DIR"
+    rm -rf "$SRC_DIR"
+    git clone --depth 1 --branch "$CASSANDRA_REF" \
+        https://github.com/apache/cassandra.git "$SRC_DIR"
+else
+    log "reusing existing checkout at $SRC_DIR"
+fi
+
+# ── Build main + test classes + resolve dependency jars ─────────────────────
+log "building Cassandra (ant jar build-test) — this takes several minutes"
+(
+    cd "$SRC_DIR"
+    export JAVA_HOME="$BUILD_JAVA_HOME"
+    export PATH="$BUILD_JAVA_HOME/bin:$PATH"
+    # `jar` compiles main + resolves runtime deps into build/lib/jars and lib/.
+    # `build-test` compiles the test tree (CQLTester et al.) into build/test/classes.
+    ant -quiet jar
+    ant -quiet build-test
+)
+
+touch "$MARKER"
+log "build complete"
+echo "$SRC_DIR"

--- a/compaction-parity/settings.gradle.kts
+++ b/compaction-parity/settings.gradle.kts
@@ -1,0 +1,7 @@
+// Standalone Gradle build for the compaction-parity harness (issue #842).
+//
+// This is intentionally NOT part of the Cargo workspace: it is a JVM project that
+// builds against a pinned Apache Cassandra 5.0.2 source checkout (see
+// scripts/bootstrap-cassandra.sh) to reach test-tree classes (CQLTester,
+// CompactionTask, JsonTransformer) that Cassandra does not publish to Maven.
+rootProject.name = "compaction-parity"

--- a/compaction-parity/src/test/java/org/cqlite/parity/BasicDifferentialTest.java
+++ b/compaction-parity/src/test/java/org/cqlite/parity/BasicDifferentialTest.java
@@ -20,7 +20,6 @@ package org.cqlite.parity;
 
 import java.util.List;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -34,13 +33,6 @@ import org.junit.Test;
  */
 public class BasicDifferentialTest extends DifferentialParityTester
 {
-    // KNOWN DIVERGENCE (tracked as a #842 sub-issue): cqlite's compacted Data.db for
-    // a table WITH clustering columns is not Cassandra-readable — sstabledump decodes
-    // partition 1 then fails with CorruptSSTableException/EOFException at
-    // Columns$Serializer.deserializeSubset. cqlite also reads its own such output as
-    // 0 rows via the CLI. No-clustering tables round-trip (compact_command.rs). Remove
-    // @Ignore once the writer is fixed; the harness itself is correct and ready.
-    @Ignore("reveals cqlite writer divergence on clustering tables (#857); un-ignore when fixed")
     @Test
     public void liveRowsLastWriteWinsAcrossTwoSSTables() throws Exception
     {

--- a/compaction-parity/src/test/java/org/cqlite/parity/BasicDifferentialTest.java
+++ b/compaction-parity/src/test/java/org/cqlite/parity/BasicDifferentialTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cqlite.parity;
+
+import java.util.List;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * First differential scenario: live rows across two overlapping SSTables.
+ *
+ * <p>The simplest meaningful merge — two SSTables that overlap on some primary
+ * keys, where the newer write must win (last-write-wins). No tombstones, so no
+ * purging is involved; this is the harness's green smoke and proves the whole
+ * pipeline (build inputs → reference compaction → cqlite compaction → logical
+ * diff) end-to-end. Tombstone / TTL / collection scenarios follow (#844–#853).
+ */
+public class BasicDifferentialTest extends DifferentialParityTester
+{
+    // KNOWN DIVERGENCE (tracked as a #842 sub-issue): cqlite's compacted Data.db for
+    // a table WITH clustering columns is not Cassandra-readable — sstabledump decodes
+    // partition 1 then fails with CorruptSSTableException/EOFException at
+    // Columns$Serializer.deserializeSubset. cqlite also reads its own such output as
+    // 0 rows via the CLI. No-clustering tables round-trip (compact_command.rs). Remove
+    // @Ignore once the writer is fixed; the harness itself is correct and ready.
+    @Ignore("reveals cqlite writer divergence on clustering tables; un-ignore when fixed (#842)")
+    @Test
+    public void liveRowsLastWriteWinsAcrossTwoSSTables() throws Exception
+    {
+        String ddl = "CREATE TABLE %s (id int, ck int, v text, PRIMARY KEY (id, ck))";
+
+        // SSTable A (ts=1000): ids 1..3, each one clustering row.
+        List<String> a = List.of(
+            "INSERT INTO %s (id, ck, v) VALUES (1, 0, 'a-1') USING TIMESTAMP 1000",
+            "INSERT INTO %s (id, ck, v) VALUES (2, 0, 'a-2') USING TIMESTAMP 1000",
+            "INSERT INTO %s (id, ck, v) VALUES (3, 0, 'a-3') USING TIMESTAMP 1000");
+
+        // SSTable B (ts=2000): overrides id 2 and 3, adds id 4.
+        List<String> b = List.of(
+            "INSERT INTO %s (id, ck, v) VALUES (2, 0, 'b-2') USING TIMESTAMP 2000",
+            "INSERT INTO %s (id, ck, v) VALUES (3, 0, 'b-3') USING TIMESTAMP 2000",
+            "INSERT INTO %s (id, ck, v) VALUES (4, 0, 'b-4') USING TIMESTAMP 2000");
+
+        assertCqliteMatchesCassandra(ddl, List.of(a, b));
+    }
+}

--- a/compaction-parity/src/test/java/org/cqlite/parity/BasicDifferentialTest.java
+++ b/compaction-parity/src/test/java/org/cqlite/parity/BasicDifferentialTest.java
@@ -40,7 +40,7 @@ public class BasicDifferentialTest extends DifferentialParityTester
     // Columns$Serializer.deserializeSubset. cqlite also reads its own such output as
     // 0 rows via the CLI. No-clustering tables round-trip (compact_command.rs). Remove
     // @Ignore once the writer is fixed; the harness itself is correct and ready.
-    @Ignore("reveals cqlite writer divergence on clustering tables; un-ignore when fixed (#842)")
+    @Ignore("reveals cqlite writer divergence on clustering tables (#857); un-ignore when fixed")
     @Test
     public void liveRowsLastWriteWinsAcrossTwoSSTables() throws Exception
     {
@@ -57,6 +57,29 @@ public class BasicDifferentialTest extends DifferentialParityTester
             "INSERT INTO %s (id, ck, v) VALUES (2, 0, 'b-2') USING TIMESTAMP 2000",
             "INSERT INTO %s (id, ck, v) VALUES (3, 0, 'b-3') USING TIMESTAMP 2000",
             "INSERT INTO %s (id, ck, v) VALUES (4, 0, 'b-4') USING TIMESTAMP 2000");
+
+        assertCqliteMatchesCassandra(ddl, List.of(a, b));
+    }
+
+    /**
+     * No-clustering variant: a partition-key-only table (one row per partition).
+     * cqlite round-trips these (see compact_command.rs); this asserts Cassandra
+     * agrees, i.e. the harness confirms a genuine MATCH, not just catches mismatches.
+     */
+    @Test
+    public void liveRowsLastWriteWinsNoClustering() throws Exception
+    {
+        String ddl = "CREATE TABLE %s (id int PRIMARY KEY, v text)";
+
+        List<String> a = List.of(
+            "INSERT INTO %s (id, v) VALUES (1, 'a-1') USING TIMESTAMP 1000",
+            "INSERT INTO %s (id, v) VALUES (2, 'a-2') USING TIMESTAMP 1000",
+            "INSERT INTO %s (id, v) VALUES (3, 'a-3') USING TIMESTAMP 1000");
+
+        List<String> b = List.of(
+            "INSERT INTO %s (id, v) VALUES (2, 'b-2') USING TIMESTAMP 2000",
+            "INSERT INTO %s (id, v) VALUES (3, 'b-3') USING TIMESTAMP 2000",
+            "INSERT INTO %s (id, v) VALUES (4, 'b-4') USING TIMESTAMP 2000");
 
         assertCqliteMatchesCassandra(ddl, List.of(a, b));
     }

--- a/compaction-parity/src/test/java/org/cqlite/parity/CqliteCompactionRunner.java
+++ b/compaction-parity/src/test/java/org/cqlite/parity/CqliteCompactionRunner.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cqlite.parity;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Drives the external {@code cqlite compact} CLI command — the candidate side of
+ * the differential compaction-parity comparison (issue #842).
+ *
+ * <p>This class has no Cassandra dependencies on purpose: it is the seam between
+ * the JVM harness (which builds inputs + runs the reference compaction) and the
+ * Rust binary under test. The binary must be built with {@code --features
+ * write-support}; its path is supplied via {@code -Dcqlite.bin} or
+ * {@code $CQLITE_BIN} (the Gradle build sets this from a {@code cargo build}).
+ */
+public final class CqliteCompactionRunner
+{
+    private static final long TIMEOUT_MINUTES = 10;
+
+    private final Path binary;
+
+    public CqliteCompactionRunner(Path binary)
+    {
+        this.binary = binary;
+    }
+
+    /**
+     * Resolve the cqlite binary from {@code -Dcqlite.bin} or {@code $CQLITE_BIN}.
+     *
+     * @throws IllegalStateException if unset or not executable — a parity run with
+     *         no binary under test is a configuration error, not a silent skip.
+     */
+    public static CqliteCompactionRunner fromConfig()
+    {
+        String configured = System.getProperty("cqlite.bin");
+        if (configured == null || configured.isBlank())
+            configured = System.getenv("CQLITE_BIN");
+        if (configured == null || configured.isBlank())
+            throw new IllegalStateException(
+                "cqlite binary not configured: set -Dcqlite.bin or $CQLITE_BIN to a `cqlite` " +
+                "binary built with `cargo build --features write-support`.");
+        Path bin = Path.of(configured);
+        if (!Files.isExecutable(bin))
+            throw new IllegalStateException("cqlite binary is not executable: " + bin);
+        return new CqliteCompactionRunner(bin);
+    }
+
+    /** Outcome of one {@code cqlite compact} invocation. */
+    public static final class Result
+    {
+        public final int exitCode;
+        public final String stdout;
+        public final String stderr;
+
+        Result(int exitCode, String stdout, String stderr)
+        {
+            this.exitCode = exitCode;
+            this.stdout = stdout;
+            this.stderr = stderr;
+        }
+
+        public boolean succeeded()
+        {
+            return exitCode == 0;
+        }
+    }
+
+    /**
+     * Run {@code cqlite compact <inputDir> -o <outputDir> --schema <schemaFile>
+     * [--gc-before N] [--now-sec N] --generation G}.
+     *
+     * @param gcBefore gc_grace cutoff (seconds since epoch), or {@code null} to omit
+     * @param nowSec   TTL "now" (seconds since epoch), or {@code null} to omit
+     */
+    public Result compact(Path inputDir,
+                          Path outputDir,
+                          Path schemaFile,
+                          Long gcBefore,
+                          Long nowSec,
+                          long generation) throws IOException, InterruptedException
+    {
+        List<String> cmd = new ArrayList<>();
+        cmd.add(binary.toString());
+        cmd.add("compact");
+        cmd.add(inputDir.toString());
+        cmd.add("--output");
+        cmd.add(outputDir.toString());
+        cmd.add("--schema");
+        cmd.add(schemaFile.toString());
+        if (gcBefore != null)
+        {
+            cmd.add("--gc-before");
+            cmd.add(Long.toString(gcBefore));
+        }
+        if (nowSec != null)
+        {
+            cmd.add("--now-sec");
+            cmd.add(Long.toString(nowSec));
+        }
+        cmd.add("--generation");
+        cmd.add(Long.toString(generation));
+
+        // Redirect to files rather than reading the pipes inline: a child that fills
+        // either pipe buffer while we block reading the other would deadlock.
+        Path outFile = Files.createTempFile("cqlite-compact-out", ".log");
+        Path errFile = Files.createTempFile("cqlite-compact-err", ".log");
+        try
+        {
+            Process proc = new ProcessBuilder(cmd)
+                           .redirectOutput(outFile.toFile())
+                           .redirectError(errFile.toFile())
+                           .start();
+            if (!proc.waitFor(TIMEOUT_MINUTES, TimeUnit.MINUTES))
+            {
+                proc.destroyForcibly();
+                throw new IOException("cqlite compact timed out after " + TIMEOUT_MINUTES + "m: " + cmd);
+            }
+            return new Result(proc.exitValue(),
+                              Files.readString(outFile),
+                              Files.readString(errFile));
+        }
+        finally
+        {
+            Files.deleteIfExists(outFile);
+            Files.deleteIfExists(errFile);
+        }
+    }
+}

--- a/compaction-parity/src/test/java/org/cqlite/parity/DifferentialParityTester.java
+++ b/compaction-parity/src/test/java/org/cqlite/parity/DifferentialParityTester.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cqlite.parity;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.compaction.CompactionManager;
+import org.apache.cassandra.io.sstable.Descriptor;
+import org.apache.cassandra.io.sstable.format.SSTableFormat.Components;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.utils.FBUtilities;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Differential compaction-parity harness (issue #842).
+ *
+ * <p>Runs the SAME input SSTables through two compaction engines and asserts the
+ * outputs are equivalent:
+ *
+ * <ol>
+ *   <li>REFERENCE — Apache Cassandra's compaction, in-JVM via {@link CQLTester}.</li>
+ *   <li>CANDIDATE — the external {@code cqlite compact} binary
+ *       ({@link CqliteCompactionRunner}).</li>
+ * </ol>
+ *
+ * <p>This step implements the LOGICAL tier only: a canonical {@code sstabledump}
+ * of every output must match. The same {@code sstabledump} tool is run over both
+ * engines' output so the comparison is apples-to-apples. The BYTE tier (#842's
+ * north star) lands in a follow-up.
+ *
+ * <p>Determinism: inputs are written with explicit {@code USING TIMESTAMP}; the
+ * same {@code gcBefore} is passed to both engines. NOTE: cqlite does not yet purge
+ * (issues #845/#848), so scenarios here must not place purgeable tombstones — live
+ * data and retained (non-purgeable) tombstones only.
+ */
+public abstract class DifferentialParityTester extends CQLTester
+{
+    private static final Pattern EXPIRED_FLAG =
+        Pattern.compile("\"expired\"\\s*:\\s*(true|false)");
+
+    private final CqliteCompactionRunner cqlite = CqliteCompactionRunner.fromConfig();
+
+    /**
+     * Build inputs, compact with both engines over the same files, and assert the
+     * logical dumps match.
+     *
+     * @param createTableDdl a {@code CREATE TABLE %s (...)} statement (CQLTester
+     *                       substitutes the generated table name for {@code %s})
+     * @param insertGroups   each inner list is the inserts for one input SSTable,
+     *                       flushed independently; provide >= 2 groups so a real
+     *                       merge happens
+     */
+    protected void assertCqliteMatchesCassandra(String createTableDdl,
+                                                List<List<String>> insertGroups) throws Exception
+    {
+        assertTrue("need >= 2 input SSTables for a meaningful merge", insertGroups.size() >= 2);
+
+        String table = createTable(createTableDdl);
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        for (List<String> group : insertGroups)
+        {
+            for (String insert : group)
+                execute(insert);
+            flush();
+        }
+
+        List<SSTableReader> inputs = new ArrayList<>(cfs.getLiveSSTables());
+        assertEquals("each insert group should flush to its own SSTable",
+                     insertGroups.size(), inputs.size());
+
+        // ── Snapshot the input SSTables for cqlite BEFORE compaction obsoletes them ──
+        Path inputDir = Files.createTempDirectory("parity-inputs");
+        for (SSTableReader r : inputs)
+            copyAllComponents(r.descriptor, inputDir);
+
+        // cqlite schema file: the same DDL, but fully qualified and standalone.
+        Path schemaFile = Files.createTempFile("parity-schema", ".cql");
+        String standaloneDdl = createTableDdl.replace("%s", keyspace() + "." + table) + ";";
+        Files.writeString(schemaFile, standaloneDdl);
+
+        // No purging for these scenarios: gcBefore well before any deletion time.
+        long gcBefore = FBUtilities.nowInSeconds();
+
+        // ── REFERENCE: Cassandra major compaction → a single SSTable ──
+        CompactionManager.instance.performMaximal(cfs, false);
+        List<SSTableReader> outputs = new ArrayList<>(cfs.getLiveSSTables());
+        assertEquals("expected exactly one reference output SSTable", 1, outputs.size());
+        Path referenceData = outputs.get(0).descriptor.fileFor(Components.DATA).toPath();
+
+        // ── CANDIDATE: cqlite compaction over the SAME inputs ──
+        Path outputDir = Files.createTempDirectory("parity-cqlite-out");
+        CqliteCompactionRunner.Result res =
+            cqlite.compact(inputDir, outputDir, schemaFile, gcBefore, null, 1);
+        assertTrue("cqlite compact failed (exit " + res.exitCode + "):\n" + res.stderr + res.stdout,
+                   res.succeeded());
+        Path candidateData = findSingleData(outputDir);
+
+        // ── LOGICAL comparison: same sstabledump over both outputs ──
+        String referenceJson = normalize(sstabledump(referenceData));
+        String candidateJson = normalize(sstabledump(candidateData));
+        assertEquals("logical dump mismatch (cassandra reference vs cqlite candidate)",
+                     referenceJson, candidateJson);
+    }
+
+    /** Copy every on-disk file of an SSTable (all components incl. TOC.txt) into {@code dest}. */
+    private static void copyAllComponents(Descriptor descriptor, Path dest) throws IOException
+    {
+        Path dataFile = descriptor.fileFor(Components.DATA).toPath();
+        String dataName = dataFile.getFileName().toString();
+        String prefix = dataName.substring(0, dataName.length() - "Data.db".length());
+        Path dir = dataFile.getParent();
+        try (var stream = Files.list(dir))
+        {
+            for (Path p : (Iterable<Path>) stream::iterator)
+            {
+                if (p.getFileName().toString().startsWith(prefix))
+                    Files.copy(p, dest.resolve(p.getFileName().toString()));
+            }
+        }
+    }
+
+    private static Path findSingleData(Path outputDir) throws IOException
+    {
+        List<Path> data = new ArrayList<>();
+        try (var stream = Files.walk(outputDir))
+        {
+            stream.filter(p -> p.getFileName().toString().endsWith("-Data.db")).forEach(data::add);
+        }
+        assertEquals("expected exactly one cqlite output Data.db under " + outputDir, 1, data.size());
+        return data.get(0);
+    }
+
+    /** Run Cassandra's {@code sstabledump -l} over a Data.db and return the JSONL. */
+    private static String sstabledump(Path dataFile) throws IOException, InterruptedException
+    {
+        String tool = System.getProperty("cassandra.sstabledump");
+        if (tool == null)
+            throw new IllegalStateException("-Dcassandra.sstabledump not set");
+
+        Path out = Files.createTempFile("sstabledump", ".jsonl");
+        Path err = Files.createTempFile("sstabledump", ".err");
+        try
+        {
+            ProcessBuilder pb = new ProcessBuilder(tool, "-l", dataFile.toString())
+                                .redirectOutput(out.toFile())
+                                .redirectError(err.toFile());
+            // Run the tool on the SAME JDK as this test (Cassandra 5.0 needs 11/17, not 21).
+            pb.environment().put("JAVA_HOME", System.getProperty("java.home"));
+            Process proc = pb.start();
+            if (!proc.waitFor(5, TimeUnit.MINUTES))
+            {
+                proc.destroyForcibly();
+                throw new IOException("sstabledump timed out for " + dataFile);
+            }
+            if (proc.exitValue() != 0)
+                fail("sstabledump failed (exit " + proc.exitValue() + ") for " + dataFile + ":\n"
+                     + Files.readString(err));
+            return Files.readString(out, StandardCharsets.UTF_8);
+        }
+        finally
+        {
+            Files.deleteIfExists(out);
+            Files.deleteIfExists(err);
+        }
+    }
+
+    /**
+     * Strip wall-clock-derived noise so byte-equal data renders equal. The
+     * {@code expired} flag is computed from the current time at dump (not the data),
+     * so two dumps taken seconds apart can differ; {@code expires_at} is still
+     * compared. (Only relevant once TTL scenarios are added.)
+     */
+    private static String normalize(String json)
+    {
+        return EXPIRED_FLAG.matcher(json).replaceAll("\"expired\" : <normalized>");
+    }
+}

--- a/compaction-parity/src/test/resources/logback-test.xml
+++ b/compaction-parity/src/test/resources/logback-test.xml
@@ -1,0 +1,17 @@
+<!--
+  Quiet Cassandra's logging during parity runs. CQLTester pulls in Cassandra's
+  full logging; without this the harness output is dominated by INFO/DEBUG flush
+  and compaction chatter. Only WARN+ and the harness's own output are shown.
+-->
+<configuration>
+  <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+    <target>System.err</target>
+    <encoder>
+      <pattern>%-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="WARN">
+    <appender-ref ref="STDERR" />
+  </root>
+</configuration>

--- a/cqlite-cli/src/cli_types.rs
+++ b/cqlite-cli/src/cli_types.rs
@@ -288,6 +288,11 @@ pub enum Commands {
         long_about = "Export data from the write engine as Cassandra-compatible SSTables. Use --compact to run compaction before export to merge multiple SSTables into one. Example: cqlite export-sstable /tmp/export --compact --writable --write-dir /path/to/data"
     )]
     ExportSstable(ExportSstableArgs),
+    /// Compact an explicit set of input SSTables into one output SSTable
+    #[command(
+        long_about = "One-shot, policy-free compaction over exactly the SSTables in <input-dir>, writing the merged result to --output. Unlike maintenance/export-sstable this does not use a managed write-dir and takes an explicit --gc-before for deterministic, Cassandra-matching purge decisions (used by the compaction-parity harness, issue #842). Example: cqlite compact ./inputs -o ./out --schema ks.tbl.cql --gc-before 1700000000"
+    )]
+    Compact(CompactArgs),
 }
 
 #[derive(Subcommand)]
@@ -394,6 +399,33 @@ pub struct MaintenanceArgs {
     /// Time budget in milliseconds for this maintenance step
     #[arg(long, default_value = "100")]
     pub budget_ms: u64,
+}
+
+// Arguments for the compact subcommand (Issue #842 — compaction parity harness)
+#[derive(Args, Debug, Clone)]
+pub struct CompactArgs {
+    /// Directory containing the input SSTables to compact (scanned for nb-*-big-Data.db)
+    pub input_dir: PathBuf,
+    /// Output directory for the compacted SSTable (keyspace/table/ is appended)
+    #[arg(short, long)]
+    pub output: PathBuf,
+    /// CQL (.cql) or JSON (.json) schema file for the table being compacted
+    #[arg(long, value_name = "PATH")]
+    pub schema: PathBuf,
+    /// gc_grace cutoff in seconds since epoch. Tombstones/cells whose
+    /// localDeletionTime < this value are purgeable. Omit to disable purging.
+    /// NOTE: purging is not yet applied during the merge (issues #845/#848);
+    /// the value is currently accepted and threaded through but does not yet
+    /// drop purgeable data.
+    #[arg(long, value_name = "SECS")]
+    pub gc_before: Option<i64>,
+    /// "now" in seconds since epoch for TTL expiry evaluation. Omit for engine
+    /// default. (Carried but not yet consulted — see --gc-before note.)
+    #[arg(long, value_name = "SECS")]
+    pub now_sec: Option<i64>,
+    /// Output SSTable generation number (filename nb-<gen>-big-*.db)
+    #[arg(long, default_value = "1")]
+    pub generation: u64,
 }
 
 // Arguments for the export-sstable subcommand (Issue #392)

--- a/cqlite-cli/src/commands/mod.rs
+++ b/cqlite-cli/src/commands/mod.rs
@@ -1649,7 +1649,7 @@ fn resolve_sstable_path(sstable_path: &Path) -> Result<PathBuf> {
 }
 
 /// Load schema from JSON or CQL file
-fn load_schema_file(
+pub(crate) fn load_schema_file(
     schema_path: &Path,
     _auto_detect: bool,
     _cassandra_version: Option<&str>,

--- a/cqlite-cli/src/commands/write.rs
+++ b/cqlite-cli/src/commands/write.rs
@@ -315,6 +315,136 @@ pub async fn handle_export(
     })
 }
 
+/// Result of a one-shot `compact` operation
+#[cfg(feature = "write-support")]
+#[derive(Debug)]
+pub struct CompactResult {
+    /// Path to the written output Data.db
+    pub output_path: std::path::PathBuf,
+    /// Number of input SSTables merged
+    pub input_files: usize,
+    /// Partitions written to the output
+    pub output_partitions: u64,
+    /// Rows written to the output
+    pub output_rows: u64,
+    /// Size of the output Data.db in bytes
+    pub data_file_size: u64,
+    /// Wall-clock execution time in milliseconds
+    pub execution_time_ms: f64,
+}
+
+#[cfg(feature = "write-support")]
+impl CompactResult {
+    /// Display the result to stdout
+    pub fn display(&self) {
+        println!(
+            "OK: compacted {} SSTable(s) → {}",
+            self.input_files,
+            self.output_path.display()
+        );
+        println!(
+            "  partitions: {}, rows: {}, Data.db: {} bytes ({:.1}ms)",
+            self.output_partitions, self.output_rows, self.data_file_size, self.execution_time_ms
+        );
+    }
+}
+
+/// Handle the `compact` subcommand: one-shot, policy-free compaction of an
+/// explicit set of input SSTables into a single output SSTable (Issue #842).
+///
+/// Reads the published `nb-*-big-Data.db` files under `args.input_dir`
+/// (newest-generation first, so the newest run wins last-write-wins ties),
+/// merges them, and writes the result under `args.output`.
+///
+/// `args.gc_before` / `args.now_sec` are threaded into the merge for
+/// deterministic purge decisions but are not yet applied (issues #845/#848).
+#[cfg(feature = "write-support")]
+pub async fn handle_compact(args: &crate::cli_types::CompactArgs) -> Result<CompactResult> {
+    let start = Instant::now();
+
+    let schema = crate::commands::load_schema_file(&args.schema, false, None)?;
+
+    let inputs = discover_input_sstables(&args.input_dir)?;
+    if inputs.is_empty() {
+        return Err(anyhow::anyhow!(
+            "No published SSTables (nb-*-big-Data.db with a sibling TOC.txt) found under {}",
+            args.input_dir.display()
+        ));
+    }
+
+    let report = cqlite_core::storage::write_engine::merge::compact_sstables(
+        inputs,
+        &args.output,
+        &schema,
+        args.generation,
+        args.gc_before,
+        args.now_sec,
+    )
+    .await
+    .with_context(|| "compaction failed")?;
+
+    Ok(CompactResult {
+        output_path: report.output.data_path,
+        input_files: report.stats.input_files,
+        output_partitions: report.stats.output_partitions,
+        output_rows: report.stats.output_rows,
+        data_file_size: report.output.data_size,
+        execution_time_ms: start.elapsed().as_secs_f64() * 1000.0,
+    })
+}
+
+/// Recursively discover published input SSTables under `dir`, ordered
+/// newest-to-oldest by generation (the order `compact_sstables` expects).
+#[cfg(feature = "write-support")]
+fn discover_input_sstables(dir: &Path) -> Result<Vec<std::path::PathBuf>> {
+    let mut found: Vec<(u64, std::path::PathBuf)> = Vec::new();
+    collect_data_files(dir, &mut found, 8)?;
+    // Highest generation first: run_index 0 must be the newest run.
+    found.sort_by(|a, b| b.0.cmp(&a.0));
+    Ok(found.into_iter().map(|(_, p)| p).collect())
+}
+
+/// Recursively collect `nb-<gen>-big-Data.db` files that have a sibling
+/// `TOC.txt` (the publication barrier), pairing each with its generation.
+#[cfg(feature = "write-support")]
+fn collect_data_files(
+    dir: &Path,
+    out: &mut Vec<(u64, std::path::PathBuf)>,
+    depth: usize,
+) -> Result<()> {
+    for entry in std::fs::read_dir(dir)
+        .with_context(|| format!("Failed to read input directory: {}", dir.display()))?
+    {
+        let entry = entry?;
+        let path = entry.path();
+        let name = path
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string();
+
+        if name.starts_with("nb-") && name.ends_with("-big-Data.db") {
+            // Honor the TOC.txt publication barrier: a Data.db without a sibling
+            // TOC.txt is an unpublished/partial SSTable and must not be compacted.
+            let base = name.trim_end_matches("-Data.db");
+            let toc = path.with_file_name(format!("{base}-TOC.txt"));
+            if !toc.exists() {
+                continue;
+            }
+            // Parse generation from nb-<gen>-big-Data.db
+            let generation = name
+                .strip_prefix("nb-")
+                .and_then(|s| s.split("-big-").next())
+                .and_then(|g| g.parse::<u64>().ok())
+                .unwrap_or(0);
+            out.push((generation, path));
+        } else if depth > 0 && path.is_dir() {
+            collect_data_files(&path, out, depth - 1)?;
+        }
+    }
+    Ok(())
+}
+
 /// Handle the flush operation
 ///
 /// # Arguments

--- a/cqlite-cli/src/main.rs
+++ b/cqlite-cli/src/main.rs
@@ -948,6 +948,21 @@ async fn run_main() -> Result<()> {
                 ))
             }
         }
+        Some(Commands::Compact(args)) => {
+            #[cfg(feature = "write-support")]
+            {
+                let result = commands::write::handle_compact(&args).await?;
+                result.display();
+                Ok(())
+            }
+            #[cfg(not(feature = "write-support"))]
+            {
+                let _ = args;
+                Err(anyhow::anyhow!(
+                    "Write support is not enabled. Build with --features write-support to enable write operations."
+                ))
+            }
+        }
         None => {
             // Default to help message for now
             println!("CQLite CLI v{}", env!("CARGO_PKG_VERSION"));

--- a/cqlite-core/src/storage/sstable/writer/data_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer.rs
@@ -1002,7 +1002,19 @@ impl DataWriter {
                     op,
                     CellOperation::Write { .. } | CellOperation::WriteWithTtl { .. }
                 ) {
+                    // A write — even of a primary-key column — means the row is
+                    // live. This must be recorded BEFORE the key-column skip below,
+                    // so a row whose only cells are clustering values (a pure
+                    // primary-key row) keeps its liveness instead of vanishing.
                     contributes_liveness = true;
+                }
+                // Primary-key columns are encoded positionally (partition key +
+                // clustering prefix), never as cells. The compaction path can
+                // surface a clustering column as a Write op (#857) — drop it so the
+                // writer doesn't emit a phantom cell that corrupts the row body for
+                // strict readers.
+                if is_primary_key_column(column, schema) {
+                    continue;
                 }
 
                 let candidate = MergedOp {
@@ -3051,6 +3063,20 @@ fn is_static_operation(
     }
 }
 
+/// Returns true if `column` is part of the primary key — a partition-key or
+/// clustering-key column.
+///
+/// Primary-key columns are encoded positionally (the partition key and the row's
+/// clustering prefix); they must NEVER be written as regular cells. The compaction
+/// path can surface a clustering column as a `Write` op (the merger keeps the
+/// clustering cell for its own read-back, and `merge_entry_to_mutation` turns it
+/// into a `Write`); emitting it as a cell writes the value a second time and
+/// corrupts the row body for strict readers (#857). The writer drops such ops.
+fn is_primary_key_column(column: &str, schema: &TableSchema) -> bool {
+    schema.partition_keys.iter().any(|k| k.name == column)
+        || schema.clustering_keys.iter().any(|k| k.name == column)
+}
+
 /// Returns true if this mutation contributes at least one static-column operation.
 fn has_static_operation(mutation: &Mutation, schema: &TableSchema) -> bool {
     mutation
@@ -3289,6 +3315,203 @@ mod tests {
         stats.min_ttl = 0;
         stats.min_local_deletion_time = 0;
         stats
+    }
+
+    /// Schema with a clustering column: id (pk) / ck (clustering) / v (regular).
+    fn clustering_test_schema() -> TableSchema {
+        TableSchema {
+            keyspace: "test_ks".to_string(),
+            table: "test_table".to_string(),
+            partition_keys: vec![KeyColumn {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![ClusteringColumn {
+                name: "ck".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+                order: ClusteringOrder::Asc,
+            }],
+            columns: vec![
+                Column {
+                    name: "id".to_string(),
+                    data_type: "int".to_string(),
+                    nullable: false,
+                    default: None,
+                    is_static: false,
+                },
+                Column {
+                    name: "ck".to_string(),
+                    data_type: "int".to_string(),
+                    nullable: false,
+                    default: None,
+                    is_static: false,
+                },
+                Column {
+                    name: "v".to_string(),
+                    data_type: "text".to_string(),
+                    nullable: true,
+                    default: None,
+                    is_static: false,
+                },
+            ],
+            comments: HashMap::new(),
+        }
+    }
+
+    fn op_columns(row: &RowWrite<'_>) -> Vec<String> {
+        row.ops
+            .iter()
+            .filter_map(|m| match m.op {
+                CellOperation::Write { column, .. }
+                | CellOperation::WriteWithTtl { column, .. }
+                | CellOperation::Delete { column } => Some(column.clone()),
+                CellOperation::DeleteRow => None,
+            })
+            .collect()
+    }
+
+    /// Regression for #857. In the compaction path, `merge_entry_to_mutation`
+    /// turns the retained clustering cell into a `Write` op, so the merged mutation
+    /// carries the clustering column in BOTH `clustering_key` AND `operations`.
+    /// `merge_row_group` must drop primary-key (partition + clustering) columns from
+    /// `RowWrite.ops`; otherwise the writer emits the clustering value a second time
+    /// as a phantom regular cell, which:
+    ///   - corrupts the row body for Cassandra's reader (CorruptSSTableException at
+    ///     Columns$Serializer.deserializeSubset), and
+    ///   - desyncs HAS_ALL_COLUMNS (ops.len() != regular_column_count).
+    #[test]
+    fn merge_row_group_excludes_primary_key_columns_from_ops() {
+        let schema = clustering_test_schema();
+
+        // Exactly the shape merge_entry_to_mutation produces for a compacted row.
+        let mutation = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(1)),
+            Some(ClusteringKey::single("ck", Value::Integer(7))),
+            vec![
+                CellOperation::Write {
+                    column: "ck".to_string(),
+                    value: Value::Integer(7),
+                },
+                CellOperation::Write {
+                    column: "v".to_string(),
+                    value: Value::Text("hello".to_string()),
+                },
+            ],
+            2000,
+            None,
+        );
+
+        let row = DataWriter::merge_row_group(&[&mutation], &schema, false, None)
+            .expect("row group must produce a row");
+
+        let cols = op_columns(&row);
+        assert!(
+            !cols.iter().any(|c| c == "ck"),
+            "clustering column 'ck' must not appear as a cell op (#857); got {cols:?}"
+        );
+        assert!(
+            cols.iter().any(|c| c == "v"),
+            "regular column 'v' must be present; got {cols:?}"
+        );
+        assert_eq!(
+            cols.len(),
+            1,
+            "only the single regular column should remain as a cell op; got {cols:?}"
+        );
+    }
+
+    /// A partition-key column accidentally present in `operations` must also be
+    /// dropped from the row ops (defends the same invariant for the pk).
+    #[test]
+    fn merge_row_group_excludes_partition_key_column_from_ops() {
+        let schema = clustering_test_schema();
+        let mutation = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(1)),
+            Some(ClusteringKey::single("ck", Value::Integer(7))),
+            vec![
+                CellOperation::Write {
+                    column: "id".to_string(),
+                    value: Value::Integer(1),
+                },
+                CellOperation::Write {
+                    column: "v".to_string(),
+                    value: Value::Text("hello".to_string()),
+                },
+            ],
+            2000,
+            None,
+        );
+
+        let row = DataWriter::merge_row_group(&[&mutation], &schema, false, None)
+            .expect("row group must produce a row");
+        let cols = op_columns(&row);
+        assert_eq!(
+            cols,
+            vec!["v".to_string()],
+            "partition-key column 'id' must not appear as a cell op; got {cols:?}"
+        );
+    }
+
+    /// Direct (non-compaction) mutations never put key columns in `operations`, so
+    /// the filter must be a no-op for them — guards against over-filtering.
+    #[test]
+    fn merge_row_group_keeps_all_regular_ops_for_direct_mutation() {
+        let schema = clustering_test_schema();
+        let mutation = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(1)),
+            Some(ClusteringKey::single("ck", Value::Integer(7))),
+            vec![CellOperation::Write {
+                column: "v".to_string(),
+                value: Value::Text("hello".to_string()),
+            }],
+            2000,
+            None,
+        );
+
+        let row = DataWriter::merge_row_group(&[&mutation], &schema, false, None)
+            .expect("row group must produce a row");
+        assert_eq!(op_columns(&row), vec!["v".to_string()]);
+    }
+
+    /// A row whose only cells are primary-key columns (a pure primary-key row,
+    /// e.g. `INSERT INTO t (id, ck) VALUES (...)`) must SURVIVE compaction with its
+    /// liveness intact even though the key columns are dropped from the cells. The
+    /// key-column write still signals liveness, so the row is emitted (no cells).
+    /// Without that, filtering would silently drop such rows.
+    #[test]
+    fn merge_row_group_keeps_pure_primary_key_row_alive() {
+        let schema = clustering_test_schema();
+        let mutation = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(1)),
+            Some(ClusteringKey::single("ck", Value::Integer(7))),
+            // Only the clustering column is present as an op (as the compaction path
+            // produces for a row that has no regular columns set).
+            vec![CellOperation::Write {
+                column: "ck".to_string(),
+                value: Value::Integer(7),
+            }],
+            2000,
+            None,
+        );
+
+        let row = DataWriter::merge_row_group(&[&mutation], &schema, false, None)
+            .expect("a pure primary-key row must not be dropped");
+        assert!(
+            op_columns(&row).is_empty(),
+            "no regular cells for a pure primary-key row; got {:?}",
+            op_columns(&row)
+        );
+        assert_eq!(
+            row.liveness_ts,
+            Some(2000),
+            "pure primary-key row must keep its liveness timestamp"
+        );
     }
 
     fn phase3_address_schema() -> UdtTypeDef {

--- a/cqlite-core/src/storage/write_engine/merge.rs
+++ b/cqlite-core/src/storage/write_engine/merge.rs
@@ -789,6 +789,153 @@ pub struct KWayMerger {
     current_partition: Option<DecoratedKey>,
     /// Table schema for schema-aware merging
     schema: TableSchema,
+    /// gc_grace cutoff (seconds since epoch): tombstones/cells whose
+    /// `local_deletion_time < gc_before_secs` are purgeable.
+    ///
+    /// Threaded in for deterministic, Cassandra-matching purge decisions
+    /// (issue #842 parity harness). NOTE: purging is NOT yet applied during the
+    /// merge — see `reconcile_cluster` (issues #845 gc_grace purging, #848
+    /// TTL/expiring tie-break). The value is currently carried but unused so the
+    /// `cqlite compact --gc-before` plumbing and parity harness can land ahead of
+    /// the purge semantics.
+    #[allow(dead_code)]
+    gc_before_secs: Option<i64>,
+    /// "now" (seconds since epoch) used to evaluate TTL expiry during merge.
+    /// Carried but not yet consulted — see the note on `gc_before_secs`.
+    #[allow(dead_code)]
+    now_secs: Option<i64>,
+}
+
+/// Report returned by [`compact_sstables`].
+#[cfg(feature = "write-support")]
+#[derive(Debug)]
+pub struct CompactReport {
+    /// Metadata for the SSTable written by the compaction.
+    pub output: crate::storage::sstable::writer::SSTableInfo,
+    /// Statistics about the merge that produced it.
+    pub stats: MergeStats,
+}
+
+/// Compute output encoding baselines (min timestamp / local-deletion-time / TTL)
+/// from the input SSTables' `Statistics.db` files (two-pass compaction, issue #729).
+///
+/// The output's delta-encoding baseline must be `<=` every per-partition value in
+/// every input, so this returns the minimum across all inputs. Each component is
+/// left at its `MAX` sentinel when no input contributes a value — matching the
+/// value `SSTableWriter::pre_seed_encoding_baselines` then receives.
+///
+/// Shared by [`compact_sstables`] and `WriteEngine::start_merge` so the one-shot
+/// and policy-driven compaction paths seed baselines identically.
+#[cfg(feature = "write-support")]
+pub(crate) fn compute_baseline_min(input_paths: &[PathBuf]) -> (i64, i32, i32) {
+    let mut baseline_min_ts = i64::MAX;
+    let mut baseline_min_ldt = i32::MAX;
+    let mut baseline_min_ttl = i32::MAX;
+    for data_path in input_paths {
+        // Derive Statistics.db path from Data.db path
+        let stats_path = {
+            let filename = data_path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            let stats_filename = filename.replace("Data.db", "Statistics.db");
+            data_path
+                .parent()
+                .unwrap_or(data_path.as_path())
+                .join(stats_filename)
+        };
+        if !stats_path.exists() {
+            continue;
+        }
+        let stats_bytes = match std::fs::read(&stats_path) {
+            Ok(b) => b,
+            Err(e) => {
+                log::warn!(
+                    "Could not read Statistics.db {:?} for baseline pre-seeding: {}",
+                    stats_path,
+                    e
+                );
+                continue;
+            }
+        };
+        match crate::parser::enhanced_statistics_parser::parse_statistics_with_fallback(
+            &stats_bytes,
+            None,
+        ) {
+            Ok((_, sstable_stats)) => {
+                let ts_stats = &sstable_stats.timestamp_stats;
+                baseline_min_ts = baseline_min_ts.min(ts_stats.min_timestamp);
+                // min_deletion_time of 0 is the normalized "no tombstones" sentinel
+                // (StatisticsMetadata::finalize() maps i32::MAX→0). We include 0 so the
+                // baseline stays safe for merger tombstones that also use
+                // local_deletion_time=0. Exclude negatives and the raw i32::MAX sentinel.
+                let ldt = ts_stats.min_deletion_time;
+                if ldt >= 0 && ldt < i32::MAX as i64 {
+                    baseline_min_ldt = baseline_min_ldt.min(ldt as i32);
+                }
+                if let Some(min_ttl) = ts_stats.min_ttl {
+                    if min_ttl > 0 && min_ttl < i32::MAX as i64 {
+                        baseline_min_ttl = baseline_min_ttl.min(min_ttl as i32);
+                    }
+                }
+            }
+            Err(e) => {
+                log::warn!(
+                    "Could not parse Statistics.db {:?} for baseline pre-seeding: {:?}",
+                    stats_path,
+                    e
+                );
+            }
+        }
+    }
+    (baseline_min_ts, baseline_min_ldt, baseline_min_ttl)
+}
+
+/// Compact an explicit set of input SSTables into a single output SSTable.
+///
+/// Unlike [`WriteEngine::maintenance_step`](super::WriteEngine::maintenance_step),
+/// this is a one-shot, policy-free compaction over exactly `input_paths`, writing
+/// the merged result to `output_dir` (the writer appends `keyspace/table/`). It is
+/// the engine entry point behind the `cqlite compact` CLI command and the
+/// compaction-parity harness (issue #842).
+///
+/// `input_paths` must be ordered newest-to-oldest: index 0 is the newest run, which
+/// wins last-write-wins ties at equal timestamp/liveness.
+///
+/// `gc_before_secs` / `now_secs` are threaded into the merger for deterministic,
+/// Cassandra-matching purge decisions. NOTE: tombstone purging and TTL expiry are
+/// NOT yet applied during the merge (issues #845, #848); these parameters are
+/// currently carried but do not yet drop purgeable data. The plumbing lands first
+/// so the parity harness can drive out the purge semantics.
+#[cfg(feature = "write-support")]
+pub async fn compact_sstables(
+    input_paths: Vec<PathBuf>,
+    output_dir: &std::path::Path,
+    schema: &TableSchema,
+    generation: u64,
+    gc_before_secs: Option<i64>,
+    now_secs: Option<i64>,
+) -> Result<CompactReport> {
+    if input_paths.is_empty() {
+        return Err(Error::InvalidInput(
+            "compaction requires at least one input SSTable".to_string(),
+        ));
+    }
+
+    let merger = KWayMerger::new_with_gc(input_paths.clone(), schema, gc_before_secs, now_secs)?;
+
+    let mut writer = crate::storage::sstable::writer::SSTableWriter::new(
+        output_dir.to_path_buf(),
+        generation,
+        schema,
+    )?;
+
+    // Two-pass compaction (issue #729): seed the output's encoding baselines from
+    // the inputs' Statistics.db before writing any partition.
+    let (baseline_min_ts, baseline_min_ldt, baseline_min_ttl) = compute_baseline_min(&input_paths);
+    writer.pre_seed_encoding_baselines(baseline_min_ts, baseline_min_ldt, baseline_min_ttl);
+
+    let stats = merger.merge(&mut writer)?;
+    let output = writer.finish().await?;
+
+    Ok(CompactReport { output, stats })
 }
 
 #[cfg(feature = "write-support")]
@@ -818,6 +965,30 @@ impl KWayMerger {
     /// let merger = KWayMerger::new(input_paths, &schema)?;
     /// ```
     pub fn new(input_paths: Vec<PathBuf>, schema: &TableSchema) -> Result<Self> {
+        Self::new_with_gc(input_paths, schema, None, None)
+    }
+
+    /// Create a new k-way merger with explicit purge parameters.
+    ///
+    /// Identical to [`KWayMerger::new`] but threads an explicit gc_grace cutoff
+    /// (`gc_before_secs`) and TTL evaluation time (`now_secs`) into the merge.
+    /// This is the deterministic entry point used by `compact_sstables` (the
+    /// `cqlite compact` CLI command) and the compaction-parity harness (issue
+    /// #842): Cassandra's compaction takes the same `gcBefore`, so purge
+    /// decisions cannot diverge between the two engines.
+    ///
+    /// # Arguments
+    ///
+    /// * `input_paths` - Paths to input SSTable Data.db files (ordered newest to oldest)
+    /// * `schema` - Table schema for schema-aware merging
+    /// * `gc_before_secs` - gc_grace cutoff (seconds since epoch), or `None` to not purge
+    /// * `now_secs` - "now" (seconds since epoch) for TTL expiry, or `None` for engine default
+    pub fn new_with_gc(
+        input_paths: Vec<PathBuf>,
+        schema: &TableSchema,
+        gc_before_secs: Option<i64>,
+        now_secs: Option<i64>,
+    ) -> Result<Self> {
         if input_paths.is_empty() {
             return Err(Error::InvalidInput(
                 "K-way merge requires at least one input file".to_string(),
@@ -839,6 +1010,8 @@ impl KWayMerger {
             heap,
             current_partition: None,
             schema: schema.clone(),
+            gc_before_secs,
+            now_secs,
         })
     }
 
@@ -1602,6 +1775,8 @@ mod tests {
             runs: vec![],
             heap: BinaryHeap::new(),
             current_partition: None,
+            gc_before_secs: None,
+            now_secs: None,
             schema,
         };
 
@@ -1709,6 +1884,8 @@ mod tests {
             runs: vec![],
             heap: BinaryHeap::new(),
             current_partition: None,
+            gc_before_secs: None,
+            now_secs: None,
             schema,
         };
 
@@ -1840,6 +2017,8 @@ mod tests {
             runs: vec![],
             heap: BinaryHeap::new(),
             current_partition: None,
+            gc_before_secs: None,
+            now_secs: None,
             schema,
         };
 
@@ -1974,6 +2153,8 @@ mod tests {
             runs: vec![],
             heap: BinaryHeap::new(),
             current_partition: None,
+            gc_before_secs: None,
+            now_secs: None,
             schema,
         };
 
@@ -2102,6 +2283,8 @@ mod tests {
             runs: vec![],
             heap: BinaryHeap::new(),
             current_partition: None,
+            gc_before_secs: None,
+            now_secs: None,
             schema,
         };
 
@@ -2220,6 +2403,8 @@ mod tests {
             runs: vec![],
             heap: BinaryHeap::new(),
             current_partition: None,
+            gc_before_secs: None,
+            now_secs: None,
             schema,
         };
 
@@ -2305,6 +2490,8 @@ mod tests {
             runs: vec![],
             heap: BinaryHeap::new(),
             current_partition: None,
+            gc_before_secs: None,
+            now_secs: None,
             schema,
         };
 
@@ -3188,6 +3375,8 @@ mod merge_property_tests {
                 runs: vec![],
                 heap: std::collections::BinaryHeap::new(),
                 current_partition: None,
+                gc_before_secs: None,
+                now_secs: None,
                 schema: schema.clone(),
             };
             let real_merged = merger.merge_partition_rows(merge_entries.clone())
@@ -3304,6 +3493,8 @@ mod merge_property_tests {
                 runs: vec![],
                 heap: std::collections::BinaryHeap::new(),
                 current_partition: None,
+                gc_before_secs: None,
+                now_secs: None,
                 schema: schema.clone(),
             };
             let merged = merger.merge_partition_rows(vec![live_entry, tombstone_entry])
@@ -3510,6 +3701,8 @@ mod streaming_tests {
             runs,
             heap: BinaryHeap::new(),
             current_partition: None,
+            gc_before_secs: None,
+            now_secs: None,
             schema,
         };
 

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -1417,63 +1417,8 @@ impl WriteEngine {
         // Two-pass compaction (issue #729): compute output FINAL encoding baselines
         // by reading the minimum values from each input SSTable's Statistics.db.
         // The output baseline must be ≤ all per-partition values from all inputs.
-        let mut baseline_min_ts = i64::MAX;
-        let mut baseline_min_ldt = i32::MAX;
-        let mut baseline_min_ttl = i32::MAX;
-        for data_path in &input_paths {
-            // Derive Statistics.db path from Data.db path
-            let stats_path = {
-                let filename = data_path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-                let stats_filename = filename.replace("Data.db", "Statistics.db");
-                data_path
-                    .parent()
-                    .unwrap_or(data_path.as_path())
-                    .join(stats_filename)
-            };
-            if stats_path.exists() {
-                match std::fs::read(&stats_path) {
-                    Ok(stats_bytes) => {
-                        match crate::parser::enhanced_statistics_parser::parse_statistics_with_fallback(
-                            &stats_bytes,
-                            None,
-                        ) {
-                            Ok((_, sstable_stats)) => {
-                                let ts_stats = &sstable_stats.timestamp_stats;
-                                baseline_min_ts = baseline_min_ts.min(ts_stats.min_timestamp);
-                                // min_deletion_time of 0 is the normalized "no tombstones"
-                                // sentinel (StatisticsMetadata::finalize() sets i32::MAX→0).
-                                // We include 0 so the baseline remains safe for merger
-                                // tombstones that also use local_deletion_time=0.
-                                // Exclude negative values and the raw i32::MAX sentinel.
-                                let ldt = ts_stats.min_deletion_time;
-                                if ldt >= 0 && ldt < i32::MAX as i64 {
-                                    baseline_min_ldt = baseline_min_ldt.min(ldt as i32);
-                                }
-                                if let Some(min_ttl) = ts_stats.min_ttl {
-                                    if min_ttl > 0 && min_ttl < i32::MAX as i64 {
-                                        baseline_min_ttl = baseline_min_ttl.min(min_ttl as i32);
-                                    }
-                                }
-                            }
-                            Err(e) => {
-                                log::warn!(
-                                    "Could not parse Statistics.db {:?} for baseline pre-seeding: {:?}",
-                                    stats_path,
-                                    e
-                                );
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        log::warn!(
-                            "Could not read Statistics.db {:?} for baseline pre-seeding: {}",
-                            stats_path,
-                            e
-                        );
-                    }
-                }
-            }
-        }
+        let (baseline_min_ts, baseline_min_ldt, baseline_min_ttl) =
+            merge::compute_baseline_min(&input_paths);
         writer.pre_seed_encoding_baselines(baseline_min_ts, baseline_min_ldt, baseline_min_ttl);
 
         // Increment generation for next operation

--- a/cqlite-core/tests/compact_command.rs
+++ b/cqlite-core/tests/compact_command.rs
@@ -17,11 +17,12 @@
 #![cfg(feature = "write-support")]
 
 use cqlite_core::platform::Platform;
+use cqlite_core::schema::{ClusteringColumn, ClusteringOrder};
 use cqlite_core::schema::{Column, KeyColumn, TableSchema};
 use cqlite_core::storage::sstable::SSTableManager;
 use cqlite_core::storage::write_engine::merge::compact_sstables;
 use cqlite_core::storage::write_engine::{
-    CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+    CellOperation, ClusteringKey, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
 };
 use cqlite_core::types::TableId as CqlTableId;
 use cqlite_core::types::Value;
@@ -234,6 +235,162 @@ fn compact_sstables_merges_explicit_inputs_with_lww() {
         assert!(
             rendered.contains(&format!("b-name-{id}")),
             "PK {id}: newest write (b-name-{id}) must win LWW, got {rendered}"
+        );
+    }
+}
+
+// ── Clustering-key regression (#857) ────────────────────────────────────────
+
+fn make_clustering_schema() -> TableSchema {
+    TableSchema {
+        keyspace: "compact_ks".to_string(),
+        table: "items".to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![ClusteringColumn {
+            name: "ck".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+            order: ClusteringOrder::Asc,
+        }],
+        columns: vec![
+            Column {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "ck".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "v".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+    }
+}
+
+fn write_clustered_row(id: i32, ck: i32, v: &str, timestamp: i64) -> Mutation {
+    Mutation::new(
+        TableId::new("compact_ks", "items"),
+        PartitionKey::single("id", Value::Integer(id)),
+        Some(ClusteringKey::single("ck", Value::Integer(ck))),
+        vec![CellOperation::Write {
+            column: "v".to_string(),
+            value: Value::Text(v.to_string()),
+        }],
+        timestamp,
+        None,
+    )
+}
+
+/// Regression for #857: compacting a table WITH clustering columns must produce a
+/// valid SSTable. cqlite previously left the clustering column inside the row's
+/// cells, so the writer emitted it a second time as a phantom regular cell — which
+/// corrupted the row body (Cassandra's sstabledump and cqlite's own reader both
+/// failed; the read-back returned 0 rows). Multiple clustering rows in one
+/// partition exercise the wide-row path.
+#[test]
+fn compact_clustering_table_preserves_rows_and_lww() {
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let temp = TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    let wal_dir = temp.path().join("wal");
+    let output_dir = temp.path().join("out");
+    let schema = make_clustering_schema();
+
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir.clone(), schema.clone());
+    let mut engine = WriteEngine::new(config).expect("engine creation");
+
+    // SSTable A (ts=1000): partition id=1, clustering rows ck=0,1,2.
+    for ck in 0_i32..=2 {
+        engine
+            .write(write_clustered_row(1, ck, &format!("a{ck}"), 1000))
+            .expect("write A");
+    }
+    rt.block_on(engine.flush())
+        .expect("flush A")
+        .expect("info A");
+
+    // SSTable B (ts=2000): overrides ck=1,2 and adds ck=3.
+    for ck in 1_i32..=3 {
+        engine
+            .write(write_clustered_row(1, ck, &format!("b{ck}"), 2000))
+            .expect("write B");
+    }
+    rt.block_on(engine.flush())
+        .expect("flush B")
+        .expect("info B");
+
+    drop(engine);
+
+    let inputs = discover_inputs(&data_dir);
+    assert_eq!(inputs.len(), 2, "expected 2 input SSTables, got {inputs:?}");
+
+    let report = rt
+        .block_on(compact_sstables(
+            inputs,
+            &output_dir,
+            &schema,
+            9,
+            None,
+            None,
+        ))
+        .expect("compaction must succeed");
+    assert_eq!(report.stats.output_partitions, 1, "single partition id=1");
+
+    // Re-open and scan: the merged partition must have 4 clustering rows with LWW.
+    let cqlite_config = Config::default();
+    let manager = rt.block_on(async {
+        let platform = Arc::new(Platform::new(&cqlite_config).await.expect("platform"));
+        SSTableManager::new(
+            &output_dir,
+            &cqlite_config,
+            platform,
+            #[cfg(feature = "state_machine")]
+            None,
+        )
+        .await
+        .expect("SSTableManager opens the compacted clustering output")
+    });
+
+    let table_id = CqlTableId::from("compact_ks.items");
+    let results = rt
+        .block_on(manager.scan(&table_id, None, None, None, Some(&schema)))
+        .expect("post-compaction scan");
+
+    assert_eq!(
+        results.len(),
+        4,
+        "merged partition must have 4 clustering rows (ck=0..=3), got {}",
+        results.len()
+    );
+
+    // Newest write wins per clustering row: ck0=a0, ck1=b1, ck2=b2, ck3=b3.
+    let rendered = format!("{:?}", results.iter().map(|(_, v)| v).collect::<Vec<_>>());
+    for expected in ["a0", "b1", "b2", "b3"] {
+        assert!(
+            rendered.contains(expected),
+            "merged output must contain {expected}; shadowed a1/a2 must not win. got {rendered}"
+        );
+    }
+    for shadowed in ["a1", "a2"] {
+        assert!(
+            !rendered.contains(shadowed),
+            "{shadowed} was overwritten at ts=2000 and must not appear; got {rendered}"
         );
     }
 }

--- a/cqlite-core/tests/compact_command.rs
+++ b/cqlite-core/tests/compact_command.rs
@@ -1,0 +1,239 @@
+//! Integration test for the one-shot `compact_sstables` entry point (Issue #842).
+//!
+//! `compact_sstables` is the engine entry point behind the `cqlite compact` CLI
+//! command and the compaction-parity harness. Unlike `WriteEngine::maintenance_step`,
+//! it compacts an *explicit* set of input SSTables into an *explicit* output
+//! directory, with an explicit `gc_before` / `now_sec`.
+//!
+//! This test builds two overlapping SSTables via the public WriteEngine API, then
+//! drives `compact_sstables` over exactly those files (newest-generation first) and
+//! asserts the merged output is a valid, readable SSTable with last-write-wins
+//! semantics applied.
+//!
+//! NOTE: `gc_before` is passed but purging is not yet applied during the merge
+//! (issues #845/#848); this test therefore asserts merge/LWW correctness, not
+//! tombstone purging.
+
+#![cfg(feature = "write-support")]
+
+use cqlite_core::platform::Platform;
+use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+use cqlite_core::storage::sstable::SSTableManager;
+use cqlite_core::storage::write_engine::merge::compact_sstables;
+use cqlite_core::storage::write_engine::{
+    CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::TableId as CqlTableId;
+use cqlite_core::types::Value;
+use cqlite_core::Config;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tempfile::TempDir;
+
+fn make_schema() -> TableSchema {
+    TableSchema {
+        keyspace: "compact_ks".to_string(),
+        table: "items".to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            Column {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "name".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+    }
+}
+
+fn write_row(id: i32, name: &str, timestamp: i64) -> Mutation {
+    let table_id = TableId::new("compact_ks", "items");
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    let ops = vec![CellOperation::Write {
+        column: "name".to_string(),
+        value: Value::Text(name.to_string()),
+    }];
+    Mutation::new(table_id, pk, None, ops, timestamp, None)
+}
+
+/// Discover published `nb-*-big-Data.db` files under `dir`, newest-generation first.
+///
+/// Mirrors the CLI's `discover_input_sstables` so this test exercises the same
+/// input-ordering contract `compact_sstables` relies on (run index 0 = newest).
+fn discover_inputs(dir: &std::path::Path) -> Vec<PathBuf> {
+    let mut found: Vec<(u64, PathBuf)> = Vec::new();
+    collect(dir, &mut found, 8);
+    found.sort_by(|a, b| b.0.cmp(&a.0));
+    found.into_iter().map(|(_, p)| p).collect()
+}
+
+fn collect(dir: &std::path::Path, out: &mut Vec<(u64, PathBuf)>, depth: usize) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = path
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string();
+        if name.starts_with("nb-") && name.ends_with("-big-Data.db") {
+            let base = name.trim_end_matches("-Data.db");
+            if !path.with_file_name(format!("{base}-TOC.txt")).exists() {
+                continue;
+            }
+            let generation = name
+                .strip_prefix("nb-")
+                .and_then(|s| s.split("-big-").next())
+                .and_then(|g| g.parse::<u64>().ok())
+                .unwrap_or(0);
+            out.push((generation, path));
+        } else if depth > 0 && path.is_dir() {
+            collect(&path, out, depth - 1);
+        }
+    }
+}
+
+/// Build two overlapping SSTables and compact them via `compact_sstables`.
+///
+/// - SSTable A (ts=100): ids 1..=10, names `a-name-{id}`
+/// - SSTable B (ts=200): ids 6..=15, names `b-name-{id}` — overrides A on 6..=10
+///
+/// Expected merged output: 15 partitions; ids 6..=10 carry B's `b-name-*` value
+/// (newest timestamp wins).
+#[test]
+fn compact_sstables_merges_explicit_inputs_with_lww() {
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let temp = TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    let wal_dir = temp.path().join("wal");
+    let output_dir = temp.path().join("out");
+    let schema = make_schema();
+
+    // ── Build two input SSTables via the public WriteEngine API ──
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir.clone(), schema.clone());
+    let mut engine = WriteEngine::new(config).expect("engine creation");
+
+    for id in 1_i32..=10 {
+        engine
+            .write(write_row(id, &format!("a-name-{id}"), 100))
+            .expect("write A");
+    }
+    let info_a = rt
+        .block_on(engine.flush())
+        .expect("flush A")
+        .expect("info A");
+    assert_eq!(info_a.partition_count, 10, "SSTable A: 10 partitions");
+
+    for id in 6_i32..=15 {
+        engine
+            .write(write_row(id, &format!("b-name-{id}"), 200))
+            .expect("write B");
+    }
+    let info_b = rt
+        .block_on(engine.flush())
+        .expect("flush B")
+        .expect("info B");
+    assert_eq!(info_b.partition_count, 10, "SSTable B: 10 partitions");
+
+    drop(engine); // release the write-dir before re-reading inputs
+
+    // ── Compact exactly those inputs into an explicit output dir ──
+    let inputs = discover_inputs(&data_dir);
+    assert_eq!(inputs.len(), 2, "expected 2 input SSTables, got {inputs:?}");
+
+    let report = rt
+        .block_on(compact_sstables(
+            inputs,
+            &output_dir,
+            &schema,
+            9,                   // output generation
+            Some(1_700_000_000), // gc_before (threaded but not yet applied)
+            None,                // now_sec
+        ))
+        .expect("compaction must succeed");
+
+    assert_eq!(report.stats.input_files, 2, "merged 2 inputs");
+    assert_eq!(
+        report.stats.output_partitions, 15,
+        "union of ids 1..=15 = 15 partitions"
+    );
+
+    // ── Every output component is published (TOC.txt is the barrier) ──
+    let out = &report.output;
+    for (label, path) in [
+        ("Data.db", &out.data_path),
+        ("Index.db", &out.index_path),
+        ("Filter.db", &out.filter_path),
+        ("Summary.db", &out.summary_path),
+        ("Statistics.db", &out.stats_path),
+        ("Digest.crc32", &out.digest_path),
+        ("TOC.txt", &out.toc_path),
+    ] {
+        assert!(
+            path.exists(),
+            "output component {label} must exist at {path:?}"
+        );
+    }
+    assert!(
+        out.data_path.to_string_lossy().contains("nb-9-big-"),
+        "output should use the requested generation 9: {:?}",
+        out.data_path
+    );
+
+    // ── Re-open the output and assert read-back + last-write-wins ──
+    let cqlite_config = Config::default();
+    let manager = rt.block_on(async {
+        let platform = Arc::new(Platform::new(&cqlite_config).await.expect("platform"));
+        SSTableManager::new(
+            &output_dir,
+            &cqlite_config,
+            platform,
+            #[cfg(feature = "state_machine")]
+            None,
+        )
+        .await
+        .expect("SSTableManager opens the compacted output")
+    });
+
+    let table_id = CqlTableId::from("compact_ks.items");
+    let results = rt
+        .block_on(manager.scan(&table_id, None, None, None, Some(&schema)))
+        .expect("post-compaction scan");
+
+    assert_eq!(
+        results.len(),
+        15,
+        "merged output must contain the union of both inputs (15 rows)"
+    );
+
+    // ids 6..=10 overlap; SSTable B (ts=200) wins over A (ts=100).
+    let by_pk: HashMap<Vec<u8>, Value> = results.into_iter().map(|(k, v)| (k.0, v)).collect();
+    for id in 6_i32..=10 {
+        let key: Vec<u8> = id.to_be_bytes().into();
+        let row = by_pk
+            .get(&key)
+            .unwrap_or_else(|| panic!("PK {id} must be present in merged output"));
+        let rendered = format!("{row:?}");
+        assert!(
+            rendered.contains(&format!("b-name-{id}")),
+            "PK {id}: newest write (b-name-{id}) must win LWW, got {rendered}"
+        );
+    }
+}

--- a/docs/compaction/byte-parity-rules.md
+++ b/docs/compaction/byte-parity-rules.md
@@ -16,6 +16,11 @@ fixed. The guiding principle, from that branch:
 **How this is used.**
 - The byte-for-byte parity CI (umbrella issue #842) asserts these rules by diffing
   CQLite output against Cassandra output.
+- The **differential parity harness** (`compaction-parity/`, designed in
+  [`docs/plans/2026-06-18-compaction-parity-harness-design.md`](../plans/2026-06-18-compaction-parity-harness-design.md))
+  is the runtime mechanism: it runs Cassandra's compaction in-JVM and `cqlite compact`
+  over the same input SSTables, then compares the outputs. Each scenario below maps to
+  one or more of these rules.
 - The `compaction-parity-auditor` agent (`.claude/agents/`) audits the code against
   this list and the branch history.
 - `Status` / `Tracking` columns reflect the current CQLite gap analysis. Update them
@@ -86,6 +91,7 @@ test), **Gap** (not handled), **N/A** (out of scope, e.g. intentionally rejected
 |------|------------------|--------|----------|
 | A complex-deletion marker's **encoded size equals the bytes written** for far-future `localDeletionTime` in `[2^31, 2^32)` (same i32 cast on both paths). | `c81fbae1` | Partial — verify size path | #853 |
 | **Disabled bloom filter** (`bloom_filter_fp_chance = 1.0`) is tolerated (always-present/empty filter). | `6ab1d9c0` | Gap — fp_chance validated to (0,1) | #852 |
+| **Primary-key columns are never written as cells** — clustering (and partition-key) values are encoded positionally (clustering prefix), not duplicated in the row body. | (baseline) | **Covered** | #857 — `merge_row_group` drops key columns from ops; tests in data_writer.rs + compaction-parity harness |
 | Index block **start offset is 64-bit** (partitions past 2 GiB). | `e1c6aed4` | **Covered** | index_writer.rs (u64) |
 | **Fail loudly** on unknown writer formats. | `673b694f` | Partial — verify | — |
 | Output format: CQLite writes **BIG** (BTI output is a separate format; `e6822e93` adds BTI in Cassandra). | `e6822e93` | N/A — BIG only | — |

--- a/docs/plans/2026-06-18-compaction-parity-harness-design.md
+++ b/docs/plans/2026-06-18-compaction-parity-harness-design.md
@@ -1,0 +1,174 @@
+# Compaction Parity Harness Design
+
+**Date**: 2026-06-18
+**Status**: Validated (brainstorm with project owner)
+**Tracks**: #842 (byte-for-byte write+compaction parity) and its sub-issues #844–#853
+**Inspiration**: the Cassandra `cursor-compaction-completion` branch's
+`DifferentialCompactionTester` and `differential/` scenario tree
+(rustyrazorblade/cassandra)
+
+## Problem
+
+CQLite already has a compaction engine — k-way merge with LWW cell reconciliation,
+row/cell/range tombstones, TTL handling (`cqlite-core/src/storage/write_engine/merge.rs`),
+STCS selection (`merge_policy.rs`), two-pass Statistics baselines, and atomic
+publication. What it lacks is **proof of correctness against Apache Cassandra**.
+
+The goal (issue #842): prove that CQLite's write and compaction paths produce output
+**identical to Apache Cassandra** for the same inputs — not just logically equivalent,
+but byte-for-byte across every output component (`Data.db`, `Statistics.db`, `Index.db`,
+`Summary.db`, `Filter.db`, `CompressionInfo.db`, `Digest.crc32`).
+
+The recently-filed sub-issues #844–#853 are concrete divergences mined from the
+Cassandra branch's commit history by the `compaction-parity-auditor` agent. They are
+the catalog of edge cases this harness must exercise. Today there is no test that
+feeds CQLite the *exact* SSTables Cassandra compacted and diffs the output.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Success bar | Two-tier: logical (blocking) + byte-for-byte (#842 north star, non-blocking until clean) | Logical parity is achievable now and catches the #844–#853 semantic bugs; byte parity is the real goal but red until the writer is perfect. Both run; only the logical tier gates PRs initially. |
+| Reference driver | Java harness (in-JVM `CompactionTask`) | Needs an **explicit `gcBefore`** for deterministic purge decisions — `nodetool` in a container can't pin it. Mirrors the reference's `DifferentialCompactionTester`. |
+| Harness home | Self-contained Gradle module in the cqlite repo (`compaction-parity/`), built against a pinned Cassandra 5.0.2 **source checkout** fetched in CI | Test logic lives next to the code under test; the source checkout exposes test-tree classes (`CQLTester`, `CompactionTask`, `JsonTransformer`) not in the published `cassandra-all` jar. |
+| Cassandra version | `cassandra-5.0.2` source tag, pinned to the same version as the `cassandra:5.0.2` Docker image | Single source of truth (issue #669); the offline source build and the live Docker corpus stay on the same format. |
+| No allowlist | Byte tier has no exception list | The reference branch's final commit was "remove the byte-comparison allowlist; nothing is allowed to diverge." Every divergence is a tracked bug. |
+
+## Architecture
+
+### The differential loop (per scenario)
+
+1. **Build inputs deterministically** (JVM, via `CQLTester`): write rows with explicit
+   `USING TIMESTAMP`, flushing at controlled boundaries to produce N input SSTables
+   (A, B, …). No value or timestamp may come from the wall clock.
+2. **Reference compaction** (Cassandra): run `CompactionTask` with `keepOriginals=true`
+   and an **explicit `gcBefore`** → reference output. `keepOriginals=true` is what keeps
+   the harness sound: the input bytes survive the compaction, so CQLite compacts the
+   *identical* files and any divergence is attributable to CQLite alone.
+3. **Candidate compaction** (CQLite): `CqliteCompactionRunner` shells out to the cqlite
+   binary on the same input files with the same `gcBefore` → candidate output.
+4. **Capture** both outputs as `{component files (copied), normalized sstabledump JSON,
+   stats summary}`. CQLite's output JSON is produced by running Cassandra's own
+   `sstabledump` over it, so the logical comparison is apples-to-apples.
+5. **Assert equivalence at two tiers** (below).
+
+### Two tiers
+
+- **Logical (blocking gate):** the normalized `sstabledump` JSON of every output SSTable
+  matches exactly, plus key `Statistics.db` fields (min/max timestamp, min/max clustering,
+  tombstone/row/column counts). Reuses the existing JSONL / `sstabledump-validator`
+  pipeline. Goes green achievable-now; is the gate that catches #844–#853.
+- **Byte-for-byte (#842 north star, non-blocking initially):** `cmp` each output
+  component. On mismatch, report per-component, per-offset diffs. Expected red until the
+  writer is byte-perfect; flips to blocking once clean. No allowlist.
+
+### Determinism rules
+
+- **Timestamps:** every write uses a fixed `USING TIMESTAMP`; never wall-clock.
+- **Purge boundary (#845):** read the actual `localDeletionTime` from the flushed input's
+  stats, then run both engines twice — `gcBefore == ldt` (tombstone retained) and
+  `gcBefore == ldt + 1` (purged). Exercises the exact boundary without controlling any
+  clock.
+- **TTL/expiring (#848):** `JsonTransformer`'s `expired` flag is wall-clock-derived, so
+  normalize it out of the JSON and compare `expires_at` instead. Keep TTL expiry
+  boundaries far from run time.
+- **Scale mode:** for the >2 GiB-partition / millions-of-rows scenarios, stream the JSON
+  dump into a SHA-256 digest (the reference's `scaleCapture`) so capture memory stays flat.
+- **No silent fallback:** if a scenario isn't actually exercised (e.g. cqlite reads zero
+  input rows, or no merge occurs), fail loudly rather than pass vacuously.
+
+### What CQLite must add (a real gap)
+
+The existing `export-sstable --compact` operates on a managed write-dir and reads the
+clock — unusable for deterministic parity. We add a dedicated entry point:
+
+```
+cqlite compact <input-sstable-dir> --output <dir> \
+    --schema <ks.tbl.cql> --gc-before <unix-secs> [--now-sec <unix-secs>]
+```
+
+- Reads exactly the input SSTables in `<input-sstable-dir>`.
+- Threads explicit `--gc-before` / `--now-sec` through the existing merge engine
+  (`merge.rs`, two-pass stats) so purge and TTL decisions are deterministic and match
+  Cassandra's run.
+- Writes the compacted output to `<output-dir>`.
+
+This is the linchpin: without an explicit `gcBefore`, byte parity on any
+tombstone-bearing scenario is impossible.
+
+### Module layout
+
+```
+compaction-parity/
+  build.gradle.kts                     # depends on the Cassandra checkout's built artifacts
+  scripts/bootstrap-cassandra.sh       # clone apache/cassandra @ cassandra-5.0.2; `ant jar build-test`
+  src/test/java/org/cqlite/parity/differential/
+    DifferentialParityTester.java      # base: build inputs, run both engines, capture, compare 2 tiers
+    CqliteCompactionRunner.java        # shells out to the cqlite `compact` binary, captures output
+    BasicDifferentialTest.java         # scenario #1: rows + range tombstone
+    ...                                # one class per scenario family (see catalog)
+```
+
+`bootstrap-cassandra.sh` clones `apache/cassandra` at the `cassandra-5.0.2` tag into a
+cache dir and runs `ant jar build-test` to produce `build/classes/main`,
+`build/test/classes`, and lib jars. The Gradle module puts those on the compile +
+runtime classpath; scenarios `extend CQLTester`. The checkout is cached in CI keyed on
+the version pin.
+
+## Scenario catalog → issues
+
+One scenario class per family, mirroring the reference's `differential/` tree:
+
+| Scenario | Issue(s) |
+|---|---|
+| rows + range tombstone (shadow covered cells) | #846 |
+| row / cell / partition / **complex** deletion merge (per cell-path) | #844, #853 |
+| gc_grace purge boundary (gcBefore == ldt vs ldt+1) | #845 |
+| TTL/expiring vs tombstone tie-break | #848 |
+| dropped-column cell filtering | #847 |
+| static-row presence read from input headers; empty-static stat over-count | #850, #851 |
+| clustering reversal / null & empty component ordering | #849 |
+| disabled bloom filter (`bloom_filter_fp_chance = 1.0`) | #852 |
+| counters (timestamp tie-break by raw value bytes) | catalog |
+| wide / pathological schema (64+ columns), large partition (>2 GiB) | catalog |
+| cross-generation (recompact CQLite's own output) | catches write-side corruption that desyncs the *next* merge |
+| randomized differential soak | broad coverage |
+
+## CI shape
+
+A new workflow:
+
+1. Build the cqlite `compact` binary (release).
+2. `bootstrap-cassandra.sh` (cached) → Cassandra 5.0.2 artifacts.
+3. Run the `compaction-parity` scenario matrix.
+4. On failure, surface per-scenario, per-component diffs (and the captured component
+   dirs as artifacts for offline byte-level decoding).
+
+The **logical tier blocks** the PR; the **byte tier reports** (non-blocking) until it is
+clean across the matrix, then flips to blocking.
+
+## Build order
+
+1. **(Rust)** Add the `cqlite compact` command with explicit `--gc-before` / `--now-sec`
+   and an output dir, reading exact input SSTables.
+2. **(Java)** Stand up `compaction-parity/` + `bootstrap-cassandra.sh` +
+   `DifferentialParityTester` + one scenario (rows + range tombstone), **logical tier
+   only**, green end-to-end.
+3. Add the **byte tier** (non-blocking) with per-component / per-offset diff reporting.
+4. Grow the scenario matrix issue-by-issue (#844–#853); fix divergences as they surface.
+5. Add cross-generation + randomized soak; **flip the byte tier to blocking** when clean.
+6. Wire the CI workflow over the full matrix.
+
+## Risks / open questions
+
+- **Cassandra source build cost in CI:** `ant jar build-test` is slow; mitigated by
+  caching the built artifacts keyed on the version pin. If too slow, fall back to a
+  prebuilt artifact published once per pin.
+- **`CQLTester` API stability:** tied to the 5.0.2 source tag; revisit on any version bump.
+- **Output SSTable identity / multi-output compactions:** a single compaction can emit
+  multiple SSTables; the harness must match outputs by token range (the reference sorts by
+  first key), not by filename or instance identity.
+- **CQLite multi-output behavior:** if CQLite always emits a single output where Cassandra
+  may split, those scenarios need either a size threshold matched to Cassandra or to be
+  scoped to single-output cases first.
+```

--- a/docs/plans/2026-06-18-compaction-parity-harness-design.md
+++ b/docs/plans/2026-06-18-compaction-parity-harness-design.md
@@ -6,6 +6,12 @@
 **Inspiration**: the Cassandra `cursor-compaction-completion` branch's
 `DifferentialCompactionTester` and `differential/` scenario tree
 (rustyrazorblade/cassandra)
+**Rule set**: this harness is the runtime enforcement mechanism for the codified
+rules in [`docs/compaction/byte-parity-rules.md`](../compaction/byte-parity-rules.md)
+(#854). That file says *what* must match Cassandra byte-for-byte and tracks each
+rule's status; this harness and the `compaction-parity/` module are *how* those
+rules are asserted (the differential CI of #842). The scenario catalog below maps
+onto that rule set, and the `compaction-parity-auditor` agent audits code against it.
 
 ## Problem
 


### PR DESCRIPTION
Establishes the foundation for proving CQLite's compaction matches Apache Cassandra (umbrella #842), and fixes the first real divergence the new harness uncovered. All changes are additive plus one correctness fix; rebased on current `main` with no regressions.

## 🐛 Fixes

### #857 — clustering-table compacted SSTables were not Cassandra-readable
Compacting a table **with clustering columns** produced a `Data.db` that Apache Cassandra's `sstabledump` rejected with `CorruptSSTableException` / `EOFException` at `Columns$Serializer.deserializeSubset` (it decoded the first partition, then misaligned and ran off the end).

**Root cause:** the k-way merger keeps clustering columns inside a row's `cells` for its own read-back, and `merge_entry_to_mutation` turns each retained clustering cell into a `Write` op. The writer then emitted that clustering value **a second time as a phantom regular cell** — even though the value is already encoded positionally in the row's clustering prefix. The extra cell desynced `HAS_ALL_COLUMNS` (`ops.len() != regular_column_count`) and left trailing bytes that a strict reader parsed as a bogus next row. CQLite's own lenient reader tolerated it, so the corruption only surfaced against Cassandra.

**Fix:** enforce the invariant *"primary-key columns are never written as cells"* at its single point of responsibility — `merge_row_group` (the row-model builder) now drops partition- and clustering-key columns from a row's cell ops. A key-column write still records row **liveness before** the drop, so a pure primary-key row (no regular columns) is preserved rather than silently lost. Direct (non-compaction) mutations never carry key columns in `operations`, so they're unaffected.

## ✨ Features

### `cqlite compact` — deterministic one-shot compaction
A new CLI command and engine entry point (`compact_sstables`) that compacts an **explicit** set of input SSTables into an **explicit** output directory:

```
cqlite compact <input-dir> --output <dir> --schema <cql> [--gc-before <secs>] [--now-sec <secs>] [--generation <n>]
```

Unlike `maintenance`/`export-sstable`, it doesn't use a managed write-dir and threads an explicit `gc_before`/`now_sec` for deterministic, Cassandra-matching purge decisions. (Plumbing only: purge/TTL semantics are carried but not yet applied — tracked by #845/#848.) Refactors `start_merge`'s two-pass baseline computation into a shared `compute_baseline_min` helper (behavior-preserving, DRY).

### Differential compaction-parity harness (`compaction-parity/`)
A standalone Gradle/JUnit module that runs Apache Cassandra's compaction **in-JVM** (via `CQLTester`, reference) and the external `cqlite compact` binary (candidate) over the **same** input SSTables, then compares both outputs with the same `sstabledump` (logical tier; byte tier is the #842 north star, to follow).

- `scripts/bootstrap-cassandra.sh` — clones + builds Apache Cassandra at the pinned `cassandra-5.0.2` tag (matching the `cassandra:5.0.2` test-data image, #669) so the harness can use test-tree classes not published to Maven.
- `DifferentialParityTester` builds inputs with explicit timestamps, runs both engines with a shared `gcBefore`, and diffs canonical dumps.
- Scenarios: live-rows last-write-wins with and without clustering — **both pass against real Cassandra 5.0.2**.
- Cross-linked with #854's `docs/compaction/byte-parity-rules.md` (the codified rule set this harness enforces) and the design doc `docs/plans/2026-06-18-compaction-parity-harness-design.md`.

## ✅ Tests
- **Unit** (`data_writer`): key-column exclusion (clustering + partition), pure-primary-key-row liveness preservation, no-op for direct mutations — written TDD-first (red→green).
- **Integration** (`compact_command.rs`): explicit-input compaction round-trip + LWW, and a clustering-table multi-row-partition regression.
- **Cross-engine**: the harness scenario `liveRowsLastWriteWinsAcrossTwoSSTables` confirms cqlite's clustering output is byte-readable by and logically matches Cassandra.
- Regression suites green: `compaction_integration`, `sstabledump_parity_data`, `issue_717`, `static_composite_roundtrip`, `write_integration`. `fmt` + `clippy -D warnings` clean.

## 📈 Unblocks
Clustering tables were the ceiling for the #844–#853 parity matrix (range/cell/complex tombstones, collections, wide rows, statics — all require clustering). With #857 fixed and the harness in place, those scenarios can now be driven against Cassandra.

**Related:** #842 (umbrella), #854 (byte-parity rules), #857 (fixed here); future work: #845/#848 (purge/TTL during merge).
