### PR TITLE
feat(query): PER PARTITION LIMIT support (#757)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,9 +171,9 @@ property_test_results.json
 ci-validation-results/
 validation_artifacts/
 
-# Binaries in root  
-check_vuint
-test_issue_*
+# Binaries in root (root-scoped so they don't shadow cqlite-core/tests/test_issue_*.rs)
+/check_vuint
+/test_issue_*
 
 # Development directories
 config/
@@ -193,3 +193,5 @@ cassandra5-small.tar.gz.sha256
 # SSTable guide audit working artifacts (not committed)
 docs/cassandra-5.0-src/
 docs/sstable-guide-audit/
+# roborev snapshots
+/.roborev/

--- a/cqlite-core/src/query/select_ast.rs
+++ b/cqlite-core/src/query/select_ast.rs
@@ -22,8 +22,11 @@ pub struct SelectStatement {
     pub having_clause: Option<WhereExpression>,
     /// ORDER BY clause - sorting specification
     pub order_by: Option<OrderByClause>,
-    /// LIMIT clause - result size limitation
+    /// LIMIT clause - query-wide result size limitation
     pub limit: Option<LimitClause>,
+    /// PER PARTITION LIMIT - cap on rows returned per partition, applied
+    /// before the query-wide `limit` (Cassandra semantics, Issue #757)
+    pub per_partition_limit: Option<u64>,
     /// OFFSET clause - result pagination
     pub offset: Option<u64>,
     /// Allow filtering flag (for non-indexed queries)
@@ -286,8 +289,6 @@ pub enum SortDirection {
 pub struct LimitClause {
     /// Maximum number of rows
     pub count: u64,
-    /// Per-partition limit (Cassandra-specific)
-    pub per_partition: bool,
 }
 
 impl SelectStatement {
@@ -301,6 +302,7 @@ impl SelectStatement {
             having_clause: None,
             order_by: None,
             limit: None,
+            per_partition_limit: None,
             offset: None,
             allow_filtering: false,
         }
@@ -503,6 +505,7 @@ mod tests {
             having_clause: None,
             order_by: None,
             limit: None,
+            per_partition_limit: None,
             offset: None,
             allow_filtering: false,
         };

--- a/cqlite-core/src/query/select_executor.rs
+++ b/cqlite-core/src/query/select_executor.rs
@@ -774,6 +774,10 @@ impl SelectExecutor {
                         .execute_aggregation(intermediate_results, agg_plan, &mut context)
                         .await?;
                 }
+                ExecutionStep::PerPartitionLimit { count } => {
+                    intermediate_results =
+                        Self::execute_per_partition_limit(intermediate_results, *count);
+                }
                 ExecutionStep::Limit { count, offset } => {
                     intermediate_results = self
                         .execute_limit(intermediate_results, *count, *offset, &mut context)
@@ -1025,6 +1029,17 @@ impl SelectExecutor {
             return Ok(());
         }
 
+        // Issue #757: PER PARTITION LIMIT caps rows per partition before the
+        // query-wide LIMIT/OFFSET. The scan yields rows grouped by partition
+        // key, so we track the current partition (by its raw key bytes) and
+        // reset the counter at each boundary.
+        let per_partition_limit = execution_steps.iter().find_map(|step| match step {
+            ExecutionStep::PerPartitionLimit { count } => Some(*count),
+            _ => None,
+        });
+        let mut current_partition: Option<Vec<u8>> = None;
+        let mut partition_count: u64 = 0;
+
         let mut sent: u64 = 0;
 
         for step in &execution_steps {
@@ -1050,6 +1065,9 @@ impl SelectExecutor {
 
                     while let Some(item) = scan_stream.recv().await {
                         let (key, value) = item?;
+                        // Capture the partition key bytes before `key` is moved
+                        // into row construction (only when needed).
+                        let part_sig = per_partition_limit.map(|_| key.0.clone());
                         let Some(row) =
                             build_row_from_scan(key, value, projection, schema_opt.as_ref())
                         else {
@@ -1058,6 +1076,19 @@ impl SelectExecutor {
 
                         if !evaluate_predicates(&row, predicates)? {
                             continue;
+                        }
+
+                        // Apply PER PARTITION LIMIT: cap matching rows per
+                        // partition, before OFFSET/LIMIT (Cassandra semantics).
+                        if let (Some(cap), Some(sig)) = (per_partition_limit, part_sig) {
+                            if current_partition.as_deref() != Some(sig.as_slice()) {
+                                current_partition = Some(sig);
+                                partition_count = 0;
+                            }
+                            if partition_count >= cap {
+                                continue;
+                            }
+                            partition_count += 1;
                         }
 
                         // Apply OFFSET: skip the first `offset_remaining` matches.
@@ -1082,8 +1113,8 @@ impl SelectExecutor {
                         }
                     }
                 }
-                ExecutionStep::Limit { .. } => {
-                    // Enforced inline during the scan above (see the limit bound
+                ExecutionStep::Limit { .. } | ExecutionStep::PerPartitionLimit { .. } => {
+                    // Enforced inline during the scan above (see the bounds
                     // extracted before the loop).
                 }
                 // Projection and predicate filtering are pushed into SSTableScan above.
@@ -1507,6 +1538,27 @@ impl SelectExecutor {
             .collect();
 
         Ok(result_rows)
+    }
+
+    /// Execute PER PARTITION LIMIT: keep at most `count` rows per partition,
+    /// preserving order (Issue #757). Rows arrive grouped by partition key from
+    /// the scan, so we track the current partition by its raw key bytes and
+    /// reset the per-partition counter at each boundary.
+    fn execute_per_partition_limit(rows: Vec<QueryRow>, count: u64) -> Vec<QueryRow> {
+        let mut out = Vec::with_capacity(rows.len());
+        let mut current_partition: Option<Vec<u8>> = None;
+        let mut partition_count: u64 = 0;
+        for row in rows {
+            if current_partition.as_deref() != Some(row.key.0.as_slice()) {
+                current_partition = Some(row.key.0.clone());
+                partition_count = 0;
+            }
+            if partition_count < count {
+                partition_count += 1;
+                out.push(row);
+            }
+        }
+        out
     }
 
     /// Execute limit step (apply OFFSET then truncate to LIMIT).
@@ -2222,6 +2274,7 @@ mod tests {
             having_clause: None,
             order_by: None,
             limit: None,
+            per_partition_limit: None,
             offset: None,
             allow_filtering: false,
         };
@@ -2243,6 +2296,7 @@ mod tests {
             having_clause: None,
             order_by: None,
             limit: None,
+            per_partition_limit: None,
             offset: None,
             allow_filtering: false,
         };
@@ -2257,6 +2311,7 @@ mod tests {
             having_clause: None,
             order_by: None,
             limit: None,
+            per_partition_limit: None,
             offset: None,
             allow_filtering: false,
         };
@@ -2391,6 +2446,7 @@ mod tests {
             having_clause: None,
             order_by: None,
             limit: None,
+            per_partition_limit: None,
             offset: None,
             allow_filtering: false,
         };
@@ -2422,6 +2478,7 @@ mod tests {
             having_clause: None,
             order_by: None,
             limit: None,
+            per_partition_limit: None,
             offset: None,
             allow_filtering: false,
         };
@@ -2453,6 +2510,7 @@ mod tests {
             having_clause: None,
             order_by: None,
             limit: None,
+            per_partition_limit: None,
             offset: None,
             allow_filtering: false,
         };

--- a/cqlite-core/src/query/select_executor.rs
+++ b/cqlite-core/src/query/select_executor.rs
@@ -1541,20 +1541,18 @@ impl SelectExecutor {
     }
 
     /// Execute PER PARTITION LIMIT: keep at most `count` rows per partition,
-    /// preserving order (Issue #757). Rows arrive grouped by partition key from
-    /// the scan, so we track the current partition by its raw key bytes and
-    /// reset the per-partition counter at each boundary.
+    /// preserving order (Issue #757). Counts are keyed on the partition (raw key
+    /// bytes) rather than tracking only the most recent partition, so the cap
+    /// holds even when a partition's rows are not contiguous — e.g. when an
+    /// upstream `ORDER BY` interleaves rows from different partitions (roborev
+    /// job 38).
     fn execute_per_partition_limit(rows: Vec<QueryRow>, count: u64) -> Vec<QueryRow> {
         let mut out = Vec::with_capacity(rows.len());
-        let mut current_partition: Option<Vec<u8>> = None;
-        let mut partition_count: u64 = 0;
+        let mut counts: HashMap<Vec<u8>, u64> = HashMap::new();
         for row in rows {
-            if current_partition.as_deref() != Some(row.key.0.as_slice()) {
-                current_partition = Some(row.key.0.clone());
-                partition_count = 0;
-            }
-            if partition_count < count {
-                partition_count += 1;
+            let seen = counts.entry(row.key.0.clone()).or_insert(0);
+            if *seen < count {
+                *seen += 1;
                 out.push(row);
             }
         }
@@ -1997,6 +1995,42 @@ mod tests {
             metadata: Default::default(),
             cell_metadata: None,
         }
+    }
+
+    fn row_with_key(partition: &[u8]) -> QueryRow {
+        QueryRow {
+            values: std::collections::HashMap::new(),
+            key: RowKey::new(partition.to_vec()),
+            metadata: Default::default(),
+            cell_metadata: None,
+        }
+    }
+
+    /// Regression (roborev job 38): in the batch path PER PARTITION LIMIT must
+    /// cap per partition even when a partition's rows are NOT contiguous (e.g.
+    /// after ORDER BY interleaves them). Counting must key on the partition, not
+    /// just track the most recent one.
+    #[test]
+    fn per_partition_limit_caps_interleaved_partitions() {
+        let a = b"A".as_slice();
+        let b = b"B".as_slice();
+        // Partition A appears 3 times but is split by a B row in the middle.
+        let rows = vec![
+            row_with_key(a),
+            row_with_key(b),
+            row_with_key(a),
+            row_with_key(a),
+            row_with_key(b),
+        ];
+        let out = SelectExecutor::execute_per_partition_limit(rows, 2);
+        let count = |p: &[u8]| out.iter().filter(|r| r.key.0 == p).count();
+        assert_eq!(
+            count(a),
+            2,
+            "partition A must be capped at 2 despite interleaving"
+        );
+        assert_eq!(count(b), 2, "partition B has 2 rows, all kept");
+        assert_eq!(out.len(), 4);
     }
 
     /// Issue #788: each clustering-key inequality op must include/exclude rows on

--- a/cqlite-core/src/query/select_optimizer.rs
+++ b/cqlite-core/src/query/select_optimizer.rs
@@ -43,6 +43,11 @@ pub enum ExecutionStep {
         count: u64,
         offset: Option<u64>,
     },
+    /// Cap rows emitted per partition key, applied upstream of `Limit`
+    /// (Cassandra `PER PARTITION LIMIT`, Issue #757).
+    PerPartitionLimit {
+        count: u64,
+    },
     Project {
         columns: Vec<SelectExpression>,
     },
@@ -144,6 +149,13 @@ impl SelectOptimizer {
             plan.execution_steps.push(ExecutionStep::Sort {
                 order_by: order_by.clone(),
             });
+        }
+
+        // PER PARTITION LIMIT caps rows per partition before the query-wide
+        // LIMIT, so it must be emitted ahead of the Limit step.
+        if let Some(count) = statement.per_partition_limit {
+            plan.execution_steps
+                .push(ExecutionStep::PerPartitionLimit { count });
         }
 
         if let Some(limit) = &statement.limit {

--- a/cqlite-core/src/query/select_parser.rs
+++ b/cqlite-core/src/query/select_parser.rs
@@ -1024,14 +1024,19 @@ impl SelectParser {
         Ok(OrderByClause { items })
     }
 
-    /// Parse LIMIT clause
+    /// Parse the query-wide LIMIT clause.
+    ///
+    /// `LIMIT 0` is intentionally accepted and yields an empty result set
+    /// (enforced downstream); this preserves long-standing CQLite behavior
+    /// (`test_limit_zero_returns_empty`). Only `PER PARTITION LIMIT` is required
+    /// to be strictly positive (Issue #757).
     fn parse_limit_clause(&mut self) -> Result<LimitClause> {
-        let count = self.parse_positive_limit("LIMIT")?;
+        let count = self.expect_integer("LIMIT")? as u64;
         Ok(LimitClause { count })
     }
 
-    /// Parse a positive integer limit, rejecting zero/negative values. Cassandra
-    /// requires both `LIMIT` and `PER PARTITION LIMIT` to be strictly positive.
+    /// Parse a strictly-positive integer limit, rejecting zero/negative values.
+    /// Used for `PER PARTITION LIMIT`, which Cassandra requires to be >= 1.
     fn parse_positive_limit(&mut self, clause: &str) -> Result<u64> {
         let value = self.expect_integer(clause)?;
         if value < 1 {
@@ -1338,6 +1343,14 @@ mod tests {
     #[test]
     fn test_per_partition_limit_rejects_zero() {
         assert!(parse_select("SELECT * FROM ks.t PER PARTITION LIMIT 0").is_err());
+    }
+
+    #[test]
+    fn test_global_limit_zero_is_accepted() {
+        // Regression: `LIMIT 0` must parse (yields empty result downstream);
+        // only PER PARTITION LIMIT requires a strictly-positive value.
+        let stmt = parse_select("SELECT * FROM ks.t LIMIT 0").unwrap();
+        assert_eq!(stmt.limit.map(|l| l.count), Some(0));
     }
 
     #[test]

--- a/cqlite-core/src/query/select_parser.rs
+++ b/cqlite-core/src/query/select_parser.rs
@@ -545,14 +545,6 @@ impl SelectParser {
             None
         };
 
-        // PER PARTITION LIMIT after LIMIT is invalid ordering; reject it loudly
-        // instead of silently ignoring the trailing clause (Issue #757).
-        if self.at(&Token::PerPartitionLimit) {
-            return Err(Error::cql_parse(
-                "PER PARTITION LIMIT must appear before LIMIT",
-            ));
-        }
-
         let offset = if self.eat(&Token::Offset)? {
             Some(self.expect_integer("OFFSET")? as u64)
         } else {
@@ -565,6 +557,16 @@ impl SelectParser {
         } else {
             false
         };
+
+        // PER PARTITION LIMIT must precede LIMIT (and any trailing OFFSET/ALLOW
+        // FILTERING). Checking here — after every trailing clause is consumed —
+        // rejects all mis-orderings instead of silently ignoring the clause,
+        // including `LIMIT n OFFSET m PER PARTITION LIMIT k` (roborev job 38).
+        if self.at(&Token::PerPartitionLimit) {
+            return Err(Error::cql_parse(
+                "PER PARTITION LIMIT must appear before LIMIT",
+            ));
+        }
 
         Ok(SelectStatement {
             select_clause,
@@ -1346,6 +1348,14 @@ mod tests {
     #[test]
     fn test_per_partition_limit_rejects_after_global_limit() {
         assert!(parse_select("SELECT * FROM ks.t LIMIT 5 PER PARTITION LIMIT 2").is_err());
+    }
+
+    #[test]
+    fn test_per_partition_limit_rejects_after_limit_offset() {
+        // Regression (roborev job 38): the ordering guard must catch a trailing
+        // PER PARTITION LIMIT even when LIMIT is followed by OFFSET, not just
+        // when it immediately follows LIMIT.
+        assert!(parse_select("SELECT * FROM ks.t LIMIT 5 OFFSET 1 PER PARTITION LIMIT 2").is_err());
     }
 
     #[test]

--- a/cqlite-core/src/query/select_parser.rs
+++ b/cqlite-core/src/query/select_parser.rs
@@ -43,6 +43,7 @@ pub enum Token {
     Having,
     OrderBy,
     Limit,
+    PerPartitionLimit,
     Offset,
     And,
     Or,
@@ -291,12 +292,22 @@ impl Tokenizer {
 
     /// Consume the literal keyword `BY` (case-insensitive) following GROUP/ORDER.
     fn expect_by_keyword(&mut self, after: &str) -> Result<()> {
+        self.expect_keyword_word("BY", after)
+    }
+
+    /// Consume the literal `word` (case-insensitive) as the next identifier,
+    /// erroring if it is absent. Used to resolve multi-word keywords (e.g. the
+    /// `PARTITION`/`LIMIT` words of `PER PARTITION LIMIT`).
+    fn expect_keyword_word(&mut self, word: &str, after: &str) -> Result<()> {
         self.skip_whitespace();
         let next = self.read_identifier();
-        if next.eq_ignore_ascii_case("BY") {
+        if next.eq_ignore_ascii_case(word) {
             Ok(())
         } else {
-            Err(Error::cql_parse(format!("Expected BY after {}", after)))
+            Err(Error::cql_parse(format!(
+                "Expected {} after {}",
+                word, after
+            )))
         }
     }
 
@@ -383,6 +394,13 @@ impl Tokenizer {
                     if identifier.eq_ignore_ascii_case("ORDER") {
                         self.expect_by_keyword("ORDER")?;
                         return Ok(Token::OrderBy);
+                    }
+                    // PER PARTITION LIMIT is a three-word keyword; resolve it
+                    // here so the parser only ever sees a single token.
+                    if identifier.eq_ignore_ascii_case("PER") {
+                        self.expect_keyword_word("PARTITION", "PER")?;
+                        self.expect_keyword_word("LIMIT", "PER PARTITION")?;
+                        return Ok(Token::PerPartitionLimit);
                     }
                     return Ok(keyword_for(&identifier).unwrap_or(Token::Identifier(identifier)));
                 }
@@ -514,11 +532,26 @@ impl SelectParser {
             None
         };
 
+        // PER PARTITION LIMIT precedes the query-wide LIMIT in CQL grammar.
+        let per_partition_limit = if self.eat(&Token::PerPartitionLimit)? {
+            Some(self.parse_positive_limit("PER PARTITION LIMIT")?)
+        } else {
+            None
+        };
+
         let limit = if self.eat(&Token::Limit)? {
             Some(self.parse_limit_clause()?)
         } else {
             None
         };
+
+        // PER PARTITION LIMIT after LIMIT is invalid ordering; reject it loudly
+        // instead of silently ignoring the trailing clause (Issue #757).
+        if self.at(&Token::PerPartitionLimit) {
+            return Err(Error::cql_parse(
+                "PER PARTITION LIMIT must appear before LIMIT",
+            ));
+        }
 
         let offset = if self.eat(&Token::Offset)? {
             Some(self.expect_integer("OFFSET")? as u64)
@@ -541,6 +574,7 @@ impl SelectParser {
             having_clause,
             order_by,
             limit,
+            per_partition_limit,
             offset,
             allow_filtering,
         })
@@ -990,11 +1024,21 @@ impl SelectParser {
 
     /// Parse LIMIT clause
     fn parse_limit_clause(&mut self) -> Result<LimitClause> {
-        let count = self.expect_integer("LIMIT")? as u64;
-        Ok(LimitClause {
-            count,
-            per_partition: false, // TODO: Add PER PARTITION support
-        })
+        let count = self.parse_positive_limit("LIMIT")?;
+        Ok(LimitClause { count })
+    }
+
+    /// Parse a positive integer limit, rejecting zero/negative values. Cassandra
+    /// requires both `LIMIT` and `PER PARTITION LIMIT` to be strictly positive.
+    fn parse_positive_limit(&mut self, clause: &str) -> Result<u64> {
+        let value = self.expect_integer(clause)?;
+        if value < 1 {
+            return Err(Error::cql_parse(format!(
+                "{} must be a positive integer, got {}",
+                clause, value
+            )));
+        }
+        Ok(value as u64)
     }
 }
 
@@ -1262,6 +1306,46 @@ mod tests {
         if let Some(limit) = stmt.limit {
             assert_eq!(limit.count, 10);
         }
+    }
+
+    // --- PER PARTITION LIMIT parser tests (Issue #757) ---
+
+    #[test]
+    fn test_per_partition_limit_basic() {
+        let stmt = parse_select("SELECT * FROM ks.t PER PARTITION LIMIT 2").unwrap();
+        assert_eq!(stmt.per_partition_limit, Some(2));
+        assert!(stmt.limit.is_none());
+    }
+
+    #[test]
+    fn test_per_partition_limit_with_global_limit() {
+        let stmt = parse_select("SELECT * FROM ks.t PER PARTITION LIMIT 2 LIMIT 5").unwrap();
+        assert_eq!(stmt.per_partition_limit, Some(2));
+        assert_eq!(stmt.limit.map(|l| l.count), Some(5));
+    }
+
+    #[test]
+    fn test_per_partition_limit_after_order_by() {
+        let stmt = parse_select("SELECT * FROM ks.t ORDER BY c DESC PER PARTITION LIMIT 3 LIMIT 9")
+            .unwrap();
+        assert!(stmt.order_by.is_some());
+        assert_eq!(stmt.per_partition_limit, Some(3));
+        assert_eq!(stmt.limit.map(|l| l.count), Some(9));
+    }
+
+    #[test]
+    fn test_per_partition_limit_rejects_zero() {
+        assert!(parse_select("SELECT * FROM ks.t PER PARTITION LIMIT 0").is_err());
+    }
+
+    #[test]
+    fn test_per_partition_limit_rejects_negative() {
+        assert!(parse_select("SELECT * FROM ks.t PER PARTITION LIMIT -1").is_err());
+    }
+
+    #[test]
+    fn test_per_partition_limit_rejects_after_global_limit() {
+        assert!(parse_select("SELECT * FROM ks.t LIMIT 5 PER PARTITION LIMIT 2").is_err());
     }
 
     #[test]

--- a/cqlite-core/tests/test_issue_757_per_partition_limit.rs
+++ b/cqlite-core/tests/test_issue_757_per_partition_limit.rs
@@ -1,0 +1,235 @@
+//! Integration test for Issue #757: PER PARTITION LIMIT
+//!
+//! **Feature**: `SELECT ... PER PARTITION LIMIT n` caps the number of rows
+//! returned *per partition key*, applied before the query-wide `LIMIT`
+//! (Cassandra semantics). Before this change the clause was parsed-around
+//! (`per_partition: false` hardcoded) and had no effect.
+//!
+//! **Coverage**:
+//! - per-partition cap on a genuinely wide-partitioned table
+//! - combined `PER PARTITION LIMIT k LIMIT m` (global cap applies after)
+//!
+//! `test_wide_rows` is unusable here — every partition has exactly one row.
+//! `test_timeseries.sensor_data` has ~10 partitions of 170+ rows each, so the
+//! cap is meaningful. Each test asserts a non-vacuous precondition (uncapped
+//! partitions exceed the cap) so a regression that silently drops enforcement
+//! is caught.
+//!
+//! **Requirements**:
+//! - `CQLITE_DATASETS_ROOT` pointing to `test-data/datasets`
+//! - Real SSTable Data.db files (run `bash test-data/scripts/fetch-datasets.sh`)
+
+#![cfg(all(feature = "state_machine", feature = "cli-helpers"))]
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::query::result::StreamingConfig;
+use cqlite_core::Database;
+
+const QUALIFIED_TABLE: &str = "test_timeseries.sensor_data";
+const PARTITION_COLUMN: &str = "sensor_id";
+
+fn get_datasets_root() -> Option<PathBuf> {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+}
+
+fn get_schemas_dir() -> Option<PathBuf> {
+    if let Some(datasets_root) = get_datasets_root() {
+        let schemas_dir = datasets_root.parent()?.join("schemas");
+        if schemas_dir.exists() {
+            return Some(schemas_dir);
+        }
+    }
+    let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let schemas_dir = manifest_dir.parent()?.join("test-data").join("schemas");
+    if schemas_dir.exists() {
+        return Some(schemas_dir);
+    }
+    None
+}
+
+/// Returns true if at least one Data.db file exists for test_timeseries.
+fn data_files_present() -> bool {
+    let Some(root) = get_datasets_root() else {
+        return false;
+    };
+    let dir = root.join("sstables").join("test_timeseries");
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        if let Ok(files) = std::fs::read_dir(entry.path()) {
+            for file in files.flatten() {
+                if file
+                    .file_name()
+                    .to_str()
+                    .is_some_and(|n| n.ends_with("-Data.db"))
+                {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+async fn setup_timeseries_db() -> Result<Database, String> {
+    let datasets_root =
+        get_datasets_root().ok_or_else(|| "CQLITE_DATASETS_ROOT not set".to_string())?;
+    let schemas_dir = get_schemas_dir().ok_or_else(|| "schemas dir not found".to_string())?;
+
+    let schema_path = schemas_dir.join("time-series.cql");
+    if !schema_path.exists() {
+        return Err(format!("schema not found at {:?}", schema_path));
+    }
+
+    let config = IngestionConfig {
+        schema_paths: vec![schema_path],
+        data_dir: datasets_root.join("sstables"),
+        version_hint: None,
+        core_config: cqlite_core::Config::default(),
+        table_directory_filter: Some("/test_timeseries/".to_string()),
+    };
+
+    let result = ingest(config)
+        .await
+        .map_err(|e| format!("ingestion failed: {}", e))?;
+    Ok(result.database)
+}
+
+/// Stream a query and return the per-partition row counts keyed by the
+/// partition column value (rendered as a string).
+async fn counts_by_partition(db: &Database, sql: &str) -> HashMap<String, usize> {
+    let mut iter = db
+        .execute_streaming(sql, StreamingConfig::default())
+        .await
+        .expect("execute_streaming should succeed");
+
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    while let Some(row) = iter.next_async().await {
+        let row = row.expect("streamed row should be Ok");
+        let key = row
+            .get(PARTITION_COLUMN)
+            .map(|v| format!("{:?}", v))
+            .unwrap_or_else(|| "<missing>".to_string());
+        *counts.entry(key).or_insert(0) += 1;
+    }
+    counts
+}
+
+/// Core: `PER PARTITION LIMIT k` must cap each partition at k rows.
+#[tokio::test]
+async fn test_per_partition_limit_caps_each_partition() {
+    if !data_files_present() {
+        eprintln!("Skipping: no Data.db files (run fetch-datasets.sh)");
+        return;
+    }
+    let db = match setup_timeseries_db().await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: setup failed: {}", e);
+            return;
+        }
+    };
+
+    // Precondition: uncapped, at least one partition has more than the cap so
+    // the assertion below is non-vacuous.
+    let cap = 3usize;
+    let uncapped = counts_by_partition(&db, &format!("SELECT * FROM {}", QUALIFIED_TABLE)).await;
+    assert!(
+        !uncapped.is_empty(),
+        "precondition: scan should return partitions"
+    );
+    assert!(
+        uncapped.values().any(|&n| n > cap),
+        "precondition: at least one partition must exceed the cap of {} to make \
+         the test meaningful; got {:?}",
+        cap,
+        uncapped
+    );
+    let partitions_over_cap = uncapped.values().filter(|&&n| n > cap).count();
+
+    let capped = counts_by_partition(
+        &db,
+        &format!(
+            "SELECT * FROM {} PER PARTITION LIMIT {}",
+            QUALIFIED_TABLE, cap
+        ),
+    )
+    .await;
+
+    // Same set of partitions appears (none dropped), each capped at `cap`.
+    assert_eq!(
+        capped.len(),
+        uncapped.len(),
+        "PER PARTITION LIMIT must not drop partitions"
+    );
+    for (partition, &n) in &capped {
+        assert!(
+            n <= cap,
+            "partition {} returned {} rows, exceeds PER PARTITION LIMIT {}",
+            partition,
+            n,
+            cap
+        );
+    }
+    // Partitions that had > cap rows must be capped to exactly `cap`.
+    let exactly_capped = capped.values().filter(|&&n| n == cap).count();
+    assert!(
+        exactly_capped >= partitions_over_cap,
+        "expected at least {} partitions capped to exactly {}, got {} (counts {:?})",
+        partitions_over_cap,
+        cap,
+        exactly_capped,
+        capped
+    );
+}
+
+/// Combined `PER PARTITION LIMIT k LIMIT m`: the global LIMIT applies after the
+/// per-partition cap, so the total is min(m, sum of capped partitions).
+#[tokio::test]
+async fn test_per_partition_limit_with_global_limit() {
+    if !data_files_present() {
+        eprintln!("Skipping: no Data.db files (run fetch-datasets.sh)");
+        return;
+    }
+    let db = match setup_timeseries_db().await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: setup failed: {}", e);
+            return;
+        }
+    };
+
+    let cap = 2usize;
+    let global = 5usize;
+    let counts = counts_by_partition(
+        &db,
+        &format!(
+            "SELECT * FROM {} PER PARTITION LIMIT {} LIMIT {}",
+            QUALIFIED_TABLE, cap, global
+        ),
+    )
+    .await;
+
+    let total: usize = counts.values().sum();
+    assert_eq!(
+        total, global,
+        "PER PARTITION LIMIT {} LIMIT {} should yield exactly {} rows, got {} ({:?})",
+        cap, global, global, total, counts
+    );
+    for (partition, &n) in &counts {
+        assert!(
+            n <= cap,
+            "partition {} returned {} rows under PER PARTITION LIMIT {}",
+            partition,
+            n,
+            cap
+        );
+    }
+}

--- a/docs/plans/2026-06-18-per-partition-limit-design.md
+++ b/docs/plans/2026-06-18-per-partition-limit-design.md
@@ -1,0 +1,118 @@
+# PER PARTITION LIMIT — Design
+
+**Issue:** #757 (child of Epic #756 — Query engine completeness)
+**Date:** 2026-06-18
+**Status:** Approved design, pre-implementation
+
+## Problem
+
+`SELECT ... PER PARTITION LIMIT n` is parsed-around but unsupported.
+`select_parser.rs:992` hardcodes `per_partition: false` with a TODO. The clause
+must work end-to-end: lexer → grammar/AST → query plan → executor enforcement,
+matching Cassandra semantics (cap rows emitted per partition key, applied before
+the global `LIMIT`).
+
+## Findings (verified against the code + corpus, 2026-06-18)
+
+- **Live query path:** `select_parser.rs` → `select_ast.rs` →
+  `select_optimizer.rs` (builds `ExecutionStep`s) → `select_executor.rs`
+  (streaming `execute_streaming` + batch paths). `parser.rs` is the legacy M2
+  path and is out of scope.
+- **Lexer already handles multi-word keywords** (`GROUP BY`, `ORDER BY`) by
+  reading ahead in `next_token` and emitting a single token. The same technique
+  applies to the three-word `PER PARTITION LIMIT`.
+- **Current AST cannot represent the feature.** `LimitClause { count,
+  per_partition: bool }` conflates the two limits, but Cassandra permits both
+  `PER PARTITION LIMIT n` *and* `LIMIT m` in one query. The `per_partition` bool
+  is dead — always `false`, never read meaningfully.
+- **The scan emits one row per clustering row, contiguous by partition.**
+  Verified empirically: `SELECT sensor_id FROM test_timeseries.sensor_data
+  LIMIT 30` returned 30 rows all sharing one `sensor_id`. The K-way merge in
+  `storage/sstable/mod.rs::scan_stream` orders by `RowKey`, so a partition's
+  rows remain contiguous in the merged stream even when split across SSTables.
+- **Fixture reality:** `test_wide_rows` (named in the issue) is entirely
+  1-row-per-partition and cannot exercise this feature. `test_timeseries`
+  has genuine wide partitions: `sensor_data` (10 partitions × 172–220 rows),
+  `stock_prices` (3 × 63–70), `tick_data` (24 × 2–13). Tests use these and
+  document the deviation.
+
+## Design
+
+### 1. AST (`cqlite-core/src/query/select_ast.rs`)
+- Add `per_partition_limit: Option<u64>` to `SelectStatement`.
+- Simplify `LimitClause` to `{ count: u64 }` — remove the dead `per_partition`
+  bool. Update all constructors/tests that set it.
+
+### 2. Lexer (`cqlite-core/src/query/select_parser.rs`)
+- Add `Token::PerPartitionLimit`.
+- In `next_token`, when the identifier is `PER` (case-insensitive), consume the
+  following `PARTITION` then `LIMIT` keywords and emit `Token::PerPartitionLimit`.
+  Mirror the existing `expect_by_keyword` pattern used for `GROUP`/`ORDER`; a
+  malformed sequence (`PER` not followed by `PARTITION LIMIT`) is a clear parse
+  error.
+
+### 3. Parser (`cqlite-core/src/query/select_parser.rs`)
+- Parse the clause in CQL order: after `ORDER BY`, before `LIMIT`.
+- `PER PARTITION LIMIT <n>` reads an integer into
+  `statement.per_partition_limit`.
+- **Validation:**
+  - Reject `n < 1` (zero/negative) with a clear `cql_parse` error.
+  - Reject `PER PARTITION LIMIT` appearing *after* `LIMIT` (token-order check)
+    with a clear error.
+- `parse_limit_clause` returns the simplified `LimitClause { count }`.
+
+### 4. Query plan (`cqlite-core/src/query/select_optimizer.rs`)
+- Add `ExecutionStep::PerPartitionLimit { count: u64 }`.
+- Emit it before the `Limit` step (and before `Project`), so per-partition
+  capping happens upstream of the global limit.
+
+### 5. Executor (`cqlite-core/src/query/select_executor.rs`)
+Enforce in **both** the streaming scan loop (`execute_streaming`) and the batch
+scan path, for parity:
+- Maintain a **partition signature** and a per-partition counter.
+- The signature is the partition-key bytes decoded from the scan `key` via the
+  canonical `storage::partition_key_codec::decode_partition_key_columns`
+  (schema-driven; no heuristics; robust to projection dropping PK columns from
+  the row). Reuse the partition-key prefix so the check is independent of
+  clustering bytes in the key.
+- On signature change → reset the counter. While `counter >= per_partition_count`
+  for the current partition, skip the row (do not send, do not count toward
+  OFFSET/LIMIT).
+- Ordering: per-partition cap → OFFSET → global LIMIT, matching Cassandra
+  (`PER PARTITION LIMIT` applies before `LIMIT`).
+- `LIMIT 0` / per-partition `0` already rejected at parse time; the existing
+  early-return for `limit_count == 0` is retained.
+
+### 6. Tests
+- **Parser unit tests** (`select_parser.rs` test module):
+  - `PER PARTITION LIMIT 2` parses to `per_partition_limit: Some(2)`.
+  - `PER PARTITION LIMIT 2 LIMIT 5` sets both fields.
+  - Rejected: `PER PARTITION LIMIT 0`, negative, and `LIMIT 5 PER PARTITION
+    LIMIT 2` (wrong order).
+- **Executor parity tests** (integration, real SSTable data):
+  - On `test_timeseries.sensor_data`: `PER PARTITION LIMIT k` yields at most `k`
+    rows per `sensor_id`; assert grouped counts.
+  - Combined `PER PARTITION LIMIT k LIMIT m`: global cap applies after the
+    per-partition cap.
+  - Baseline: a `stock_prices` (3 partitions) case for a small, exactly-countable
+    assertion.
+- `scripts/agent-gate.sh` passes; raw summary block pasted in the PR.
+
+## Cassandra semantics reference
+`PER PARTITION LIMIT n` caps the number of rows returned *per partition* before
+the query-wide `LIMIT` is applied. Both clauses may appear together; order in
+CQL is `... [ORDER BY ...] [PER PARTITION LIMIT n] [LIMIT m] [ALLOW FILTERING]`.
+
+## Out of scope / documented limitations
+- **Cross-SSTable duplicate-row reconciliation.** The scan merge does not dedup
+  identical `(partition, clustering)` rows across generations; this is a
+  pre-existing condition affecting all queries, not introduced here.
+- **Legacy `parser.rs` (M2) path** is not modified.
+
+## Affected files
+- `cqlite-core/src/query/select_ast.rs` — AST fields
+- `cqlite-core/src/query/select_parser.rs` — lexer token, grammar, validation,
+  parser tests
+- `cqlite-core/src/query/select_optimizer.rs` — `ExecutionStep::PerPartitionLimit`
+- `cqlite-core/src/query/select_executor.rs` — enforcement (streaming + batch)
+- Integration tests — `test_timeseries` fixtures


### PR DESCRIPTION
Closes #757. Part of Epic #756 (query engine completeness).

## What

Implements `SELECT ... PER PARTITION LIMIT n` end-to-end. Previously the clause was parsed-around (`per_partition: false` hardcoded in `select_parser.rs`) and had no effect.

- **Lexer**: `Token::PerPartitionLimit`, three-word `PER PARTITION LIMIT` recognition (mirrors existing `GROUP BY`/`ORDER BY` handling).
- **Grammar/AST**: `per_partition_limit: Option<u64>` on `SelectStatement`; parsed in CQL clause order (after `ORDER BY`, before `LIMIT`). Removed the dead `per_partition` bool from `LimitClause`.
- **Validation**: rejects `< 1` (zero/negative) and rejects the clause appearing *after* `LIMIT`, both with clear errors.
- **Plan**: `ExecutionStep::PerPartitionLimit { count }`, emitted before `Limit`.
- **Executor**: enforced in **both** the streaming and batch paths — tracks the current partition by raw partition-key bytes, caps rows per partition *before* OFFSET/global LIMIT (Cassandra semantics).

## Semantics

`PER PARTITION LIMIT k` caps each partition at k rows; a combined `LIMIT m` applies across the capped stream. Verified end-to-end:
- `... PER PARTITION LIMIT 2` → 10 partitions × max 2 = 20 rows
- `... PER PARTITION LIMIT 2 LIMIT 5` → exactly 5 rows

## Tests

- 6 parser unit tests (valid forms + rejected: zero, negative, wrong order).
- Integration tests (`test_issue_757_per_partition_limit.rs`) on `test_timeseries.sensor_data` (10 partitions × 172–220 rows) with non-vacuous preconditions so a silent regression is caught.

**Fixture note:** the issue named `test_wide_rows`, but that corpus is entirely 1-row-per-partition (useless for this feature). Used `test_timeseries.sensor_data` instead; documented in the test and the design spec.

## Incidental fix

The root-intended `test_issue_*` gitignore rule was unscoped and silently ignored **all** new `cqlite-core/tests/test_issue_*.rs` files — this PR's test would never have reached CI. Scoped it to `/test_issue_*`.

## Out of scope

Cross-SSTable duplicate-row reconciliation (pre-existing; the scan merge does not dedup). Legacy M2 `parser.rs` path unchanged.

## Gate

`scripts/agent-gate.sh` → **RESULT: PASS** (fmt, clippy, core-tests, integration-tests, write-tests, cli-tests, minimal-build, smoke all green).

Design spec: `docs/plans/2026-06-18-per-partition-limit-design.md`.