### PR TITLE
feat(schema): validate UDT references against registry at load (#761)

### DIFF
--- a/cqlite-core/src/schema/aggregator.rs
+++ b/cqlite-core/src/schema/aggregator.rs
@@ -888,6 +888,28 @@ impl SchemaAggregator {
         {
             let registry = self.registry.write().await;
             for (_key, table_schema) in table_map {
+                // Fail fast on undefined UDT references (issue #761): a column
+                // referencing a UDT not in the registry surfaces here with the
+                // missing type named, rather than later as a confusing
+                // parse/deserialization error. Gated by the same flag that
+                // controls UDT dependency validation.
+                if self.config.validate_udt_dependencies {
+                    let udt_registry = self.udt_registry.read().await;
+                    if let Err(e) = table_schema.validate_udt_references(&udt_registry) {
+                        self.errors.push(SchemaLoadError {
+                            file_path: None,
+                            error_type: LoadErrorType::ValidationFailed,
+                            message: format!(
+                                "Failed to register table '{}.{}': {}",
+                                table_schema.keyspace, table_schema.table, e
+                            ),
+                        });
+                        if !self.config.graceful_degradation {
+                            return (udts_loaded, tables_loaded);
+                        }
+                        continue;
+                    }
+                }
                 match registry
                     .register_schema(
                         table_schema.clone(),
@@ -1528,6 +1550,96 @@ mod tests {
         let schema = registry.get_schema("test_ks", "users").await.unwrap();
         assert_eq!(schema.table, "users");
         assert_eq!(schema.columns.len(), 3);
+    }
+
+    /// Issue #761: a table column referencing an undefined UDT must fail to load
+    /// with an error naming the missing UDT (top-level reference).
+    #[tokio::test]
+    async fn test_table_referencing_undefined_udt_top_level_fails() {
+        let (mut aggregator, temp_dir) = setup_test_aggregator().await;
+
+        let cql_content = r#"
+        CREATE TABLE test_ks.users (
+            id uuid PRIMARY KEY,
+            name text,
+            contact ContactInfo
+        );
+        "#;
+
+        let cql_path = write_file(temp_dir.path(), "schema.cql", cql_content);
+        let result = aggregator.load_from_paths(&[cql_path]).await.unwrap();
+
+        assert_eq!(
+            result.schemas_loaded, 0,
+            "table referencing undefined UDT must not load"
+        );
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|e| e.message.contains("ContactInfo")),
+            "an error must name the missing UDT, got: {:?}",
+            result.errors
+        );
+    }
+
+    /// Issue #761: nested UDT references (UDT inside a collection/frozen) must be
+    /// validated, not just top-level columns.
+    #[tokio::test]
+    async fn test_table_referencing_undefined_udt_nested_fails() {
+        let (mut aggregator, temp_dir) = setup_test_aggregator().await;
+
+        let cql_content = r#"
+        CREATE TABLE test_ks.users (
+            id uuid PRIMARY KEY,
+            contacts list<frozen<ContactInfo>>
+        );
+        "#;
+
+        let cql_path = write_file(temp_dir.path(), "schema.cql", cql_content);
+        let result = aggregator.load_from_paths(&[cql_path]).await.unwrap();
+
+        assert_eq!(
+            result.schemas_loaded, 0,
+            "table referencing undefined nested UDT must not load"
+        );
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|e| e.message.contains("ContactInfo")),
+            "an error must name the missing nested UDT, got: {:?}",
+            result.errors
+        );
+    }
+
+    /// Issue #761: a table whose UDT reference IS defined still loads cleanly.
+    #[tokio::test]
+    async fn test_table_referencing_defined_udt_loads() {
+        let (mut aggregator, temp_dir) = setup_test_aggregator().await;
+
+        let cql_content = r#"
+        CREATE TYPE test_ks.contact_info (
+            email text,
+            phone text
+        );
+
+        CREATE TABLE test_ks.users (
+            id uuid PRIMARY KEY,
+            contact contact_info
+        );
+        "#;
+
+        let cql_path = write_file(temp_dir.path(), "schema.cql", cql_content);
+        let result = aggregator.load_from_paths(&[cql_path]).await.unwrap();
+
+        assert!(
+            result.errors.is_empty(),
+            "defined UDT reference should load without errors, got: {:?}",
+            result.errors
+        );
+        assert_eq!(result.udts_loaded, 1);
+        assert_eq!(result.schemas_loaded, 1);
     }
 
     #[tokio::test]

--- a/cqlite-core/src/schema/mod.rs
+++ b/cqlite-core/src/schema/mod.rs
@@ -730,7 +730,9 @@ impl TableSchema {
             })?;
         }
 
-        // TODO: Add UDT type validation - check that referenced UDTs exist in registry
+        // NOTE: UDT-reference validation requires a registry and is not done here
+        // (a TableSchema is self-contained). At schema-load time, call
+        // `validate_udt_references(&registry)` to fail fast on undefined UDTs.
 
         // Validate all key columns exist in columns list
         for key in &self.partition_keys {
@@ -752,6 +754,91 @@ impl TableSchema {
         }
 
         Ok(())
+    }
+
+    /// Validate that every UDT referenced by a column exists in the registry.
+    ///
+    /// This is a schema-load-time pass that fails fast with a schema-category
+    /// error naming the missing UDT, instead of surfacing the problem later as a
+    /// confusing parse/deserialization error (issue #761). Nested references are
+    /// validated recursively: a UDT inside a collection, `frozen<>`, a tuple, or
+    /// another UDT is checked just like a top-level reference.
+    ///
+    /// UDTs are looked up in the schema's own keyspace; the `system` keyspace is
+    /// also consulted so built-in/system UDTs resolve regardless of the table's
+    /// keyspace.
+    pub fn validate_udt_references(&self, registry: &UdtRegistry) -> Result<()> {
+        for column in &self.columns {
+            // Reuse the same parse the rest of validation uses; parse errors are
+            // reported by `validate()`, so ignore them here.
+            if let Ok(cql_type) = CqlType::parse(&column.data_type) {
+                self.check_type_udt_references(&cql_type, &column.name, registry)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Recursively check a single CQL type for UDT references that are not
+    /// present in the registry.
+    fn check_type_udt_references(
+        &self,
+        cql_type: &CqlType,
+        column_name: &str,
+        registry: &UdtRegistry,
+    ) -> Result<()> {
+        match cql_type {
+            CqlType::Udt(name, _) => {
+                self.ensure_udt_exists(name, column_name, registry)?;
+            }
+            // `CqlType::parse` represents UDT references encountered in a column's
+            // declared type string as `Custom("udt:<name>")`.
+            CqlType::Custom(name) => {
+                if let Some(udt_name) = name.strip_prefix("udt:") {
+                    self.ensure_udt_exists(udt_name, column_name, registry)?;
+                }
+            }
+            CqlType::List(inner) | CqlType::Set(inner) | CqlType::Frozen(inner) => {
+                self.check_type_udt_references(inner, column_name, registry)?;
+            }
+            CqlType::Map(key_type, value_type) => {
+                self.check_type_udt_references(key_type, column_name, registry)?;
+                self.check_type_udt_references(value_type, column_name, registry)?;
+            }
+            CqlType::Tuple(field_types) => {
+                for field_type in field_types {
+                    self.check_type_udt_references(field_type, column_name, registry)?;
+                }
+            }
+            _ => {} // Primitive types reference no UDTs.
+        }
+        Ok(())
+    }
+
+    /// Confirm a referenced UDT exists in the table's keyspace (or the `system`
+    /// keyspace), returning a schema-category error naming the missing UDT.
+    fn ensure_udt_exists(
+        &self,
+        udt_name: &str,
+        column_name: &str,
+        registry: &UdtRegistry,
+    ) -> Result<()> {
+        // A reference may be qualified as `keyspace.udt`; honor an explicit
+        // keyspace, otherwise resolve against the table's keyspace.
+        let (lookup_keyspace, bare_name) = match udt_name.split_once('.') {
+            Some((ks, name)) => (ks, name),
+            None => (self.keyspace.as_str(), udt_name),
+        };
+
+        if registry.contains_udt(lookup_keyspace, bare_name)
+            || registry.contains_udt("system", bare_name)
+        {
+            return Ok(());
+        }
+
+        Err(Error::schema(format!(
+            "Column '{}' references undefined UDT '{}' in keyspace '{}'",
+            column_name, udt_name, lookup_keyspace
+        )))
     }
 
     /// Get column by name
@@ -1500,6 +1587,125 @@ mod tests {
 
         // This should succeed as we allow custom types
         assert!(TableSchema::from_json(invalid_type).is_ok());
+    }
+
+    fn udt_schema(column_type: &str) -> TableSchema {
+        TableSchema {
+            keyspace: "test_ks".to_string(),
+            table: "t".to_string(),
+            partition_keys: vec![KeyColumn {
+                name: "id".to_string(),
+                data_type: "uuid".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![],
+            columns: vec![
+                Column {
+                    name: "id".to_string(),
+                    data_type: "uuid".to_string(),
+                    nullable: false,
+                    default: None,
+                    is_static: false,
+                },
+                Column {
+                    name: "value".to_string(),
+                    data_type: column_type.to_string(),
+                    nullable: true,
+                    default: None,
+                    is_static: false,
+                },
+            ],
+            comments: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn test_udt_reference_undefined_top_level_errors() {
+        let registry = UdtRegistry::new();
+        let schema = udt_schema("MyMissingType");
+
+        let err = schema
+            .validate_udt_references(&registry)
+            .expect_err("undefined UDT reference must fail validation");
+        let msg = err.to_string();
+        assert!(
+            matches!(err, Error::Schema(_)),
+            "expected schema-category error, got {err:?}"
+        );
+        assert!(
+            msg.contains("MyMissingType"),
+            "error must name the missing UDT, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_udt_reference_undefined_nested_in_collection_errors() {
+        let registry = UdtRegistry::new();
+        let schema = udt_schema("list<frozen<NestedMissing>>");
+
+        let err = schema
+            .validate_udt_references(&registry)
+            .expect_err("nested undefined UDT reference must fail validation");
+        let msg = err.to_string();
+        assert!(matches!(err, Error::Schema(_)));
+        assert!(
+            msg.contains("NestedMissing"),
+            "error must name the nested missing UDT, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_udt_reference_undefined_nested_in_map_errors() {
+        let registry = UdtRegistry::new();
+        let schema = udt_schema("map<text, MapValueMissing>");
+
+        let err = schema
+            .validate_udt_references(&registry)
+            .expect_err("undefined UDT in map value must fail validation");
+        assert!(matches!(err, Error::Schema(_)));
+        assert!(err.to_string().contains("MapValueMissing"));
+    }
+
+    #[test]
+    fn test_udt_reference_defined_top_level_ok() {
+        let mut registry = UdtRegistry::new();
+        registry.register_udt(
+            UdtTypeDef::new("test_ks".to_string(), "MyType".to_string()).with_field(
+                "a".to_string(),
+                CqlType::Text,
+                true,
+            ),
+        );
+        let schema = udt_schema("MyType");
+        schema
+            .validate_udt_references(&registry)
+            .expect("defined UDT should validate");
+    }
+
+    #[test]
+    fn test_udt_reference_defined_nested_ok() {
+        let mut registry = UdtRegistry::new();
+        registry.register_udt(
+            UdtTypeDef::new("test_ks".to_string(), "MyType".to_string()).with_field(
+                "a".to_string(),
+                CqlType::Text,
+                true,
+            ),
+        );
+        let schema = udt_schema("list<frozen<MyType>>");
+        schema
+            .validate_udt_references(&registry)
+            .expect("defined nested UDT should validate");
+    }
+
+    #[test]
+    fn test_validate_udt_references_no_udts_ok() {
+        // Schemas without any UDT columns must validate against an empty registry.
+        let registry = UdtRegistry::new();
+        let schema = udt_schema("map<text, list<int>>");
+        schema
+            .validate_udt_references(&registry)
+            .expect("primitive/collection-only schema should validate");
     }
 
     #[tokio::test]

--- a/cqlite-core/src/schema/mod.rs
+++ b/cqlite-core/src/schema/mod.rs
@@ -545,6 +545,20 @@ impl UdtRegistry {
     }
 }
 
+/// Whether a de-prefixed `Custom` type name is a plausible UDT reference.
+///
+/// `CqlType::parse` returns `Custom(..)` both for real UDT names and for type
+/// strings it cannot structurally parse (e.g. an uppercase `SET<TEXT>` whose
+/// collection prefix it doesn't recognize). Only simple identifiers
+/// (alphanumeric / `_` / `.`) can name a UDT, so structural fragments
+/// containing `<`, `>`, `,` or whitespace are excluded from UDT validation.
+pub(crate) fn is_udt_identifier(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '_' || c == '.')
+}
+
 impl TableSchema {
     /// Extract schema from SSTable header column metadata
     ///
@@ -793,12 +807,16 @@ impl TableSchema {
             // `CqlType::parse` represents UDT references as `Custom("udt:<name>")`
             // for names with mixed case / underscores / digits, but as a bare
             // `Custom("<name>")` for purely-lowercase names (e.g. `address`).
-            // Either way, `parse` only yields `Custom` for non-primitive,
-            // non-collection type strings — i.e. UDT references — so validate the
-            // de-prefixed name against the registry (roborev job 39).
+            // Validate the de-prefixed name *only* when it is a simple type
+            // identifier: `parse` also yields a bare `Custom` for type strings it
+            // can't structurally parse (e.g. an uppercase `SET<TEXT>` collection),
+            // which must NOT be mistaken for a UDT (roborev job 39 + the
+            // collections-fixture regression).
             CqlType::Custom(name) => {
                 let udt_name = name.strip_prefix("udt:").unwrap_or(name);
-                self.ensure_udt_exists(udt_name, column_name, registry)?;
+                if is_udt_identifier(udt_name) {
+                    self.ensure_udt_exists(udt_name, column_name, registry)?;
+                }
             }
             CqlType::List(inner) | CqlType::Set(inner) | CqlType::Frozen(inner) => {
                 self.check_type_udt_references(inner, column_name, registry)?;
@@ -1658,6 +1676,20 @@ mod tests {
                 err.to_string().contains("address"),
                 "error must name the missing UDT, got: {err}"
             );
+        }
+    }
+
+    #[test]
+    fn test_unparsed_uppercase_collection_is_not_treated_as_udt() {
+        // Regression: `CqlType::parse` returns a bare `Custom("SET<TEXT>")` for an
+        // uppercase collection it doesn't structurally parse. That is NOT a UDT
+        // reference and must not fail validation (collections fixture regression).
+        let registry = UdtRegistry::new();
+        for col_type in ["SET<TEXT>", "LIST<INT>", "MAP<TEXT, TEXT>"] {
+            let schema = udt_schema(col_type);
+            schema
+                .validate_udt_references(&registry)
+                .unwrap_or_else(|e| panic!("'{col_type}' must not be flagged as a UDT: {e}"));
         }
     }
 

--- a/cqlite-core/src/schema/mod.rs
+++ b/cqlite-core/src/schema/mod.rs
@@ -1086,27 +1086,38 @@ impl CqlType {
     pub fn parse(type_str: &str) -> Result<Self> {
         let type_str = type_str.trim();
 
+        // CQL type keywords are case-insensitive (`SET<TEXT>` == `set<text>`),
+        // so match collection/frozen/tuple prefixes case-insensitively. Matching
+        // only lowercase here previously left uppercase collections to fall
+        // through to a bare `Custom("SET<TEXT>")`, which both broke type-aware
+        // handling and confused UDT-reference validation (roborev job 51).
+        fn strip_prefix_ci<'a>(s: &'a str, prefix: &str) -> Option<&'a str> {
+            s.get(..prefix.len())
+                .filter(|head| head.eq_ignore_ascii_case(prefix))
+                .map(|_| &s[prefix.len()..])
+        }
+
         // Handle frozen types
-        if let Some(inner) = type_str.strip_prefix("frozen<") {
+        if let Some(inner) = strip_prefix_ci(type_str, "frozen<") {
             if let Some(inner) = inner.strip_suffix('>') {
                 return Ok(CqlType::Frozen(Box::new(Self::parse(inner)?)));
             }
         }
 
         // Handle collection types
-        if let Some(inner) = type_str.strip_prefix("list<") {
+        if let Some(inner) = strip_prefix_ci(type_str, "list<") {
             if let Some(inner) = inner.strip_suffix('>') {
                 return Ok(CqlType::List(Box::new(Self::parse(inner)?)));
             }
         }
 
-        if let Some(inner) = type_str.strip_prefix("set<") {
+        if let Some(inner) = strip_prefix_ci(type_str, "set<") {
             if let Some(inner) = inner.strip_suffix('>') {
                 return Ok(CqlType::Set(Box::new(Self::parse(inner)?)));
             }
         }
 
-        if let Some(inner) = type_str.strip_prefix("map<") {
+        if let Some(inner) = strip_prefix_ci(type_str, "map<") {
             if let Some(inner) = inner.strip_suffix('>') {
                 let parts = Self::split_top_level_types(inner)?;
                 if parts.len() != 2 {
@@ -1120,7 +1131,7 @@ impl CqlType {
         }
 
         // Handle tuple types
-        if let Some(inner) = type_str.strip_prefix("tuple<") {
+        if let Some(inner) = strip_prefix_ci(type_str, "tuple<") {
             if let Some(inner) = inner.strip_suffix('>') {
                 let parts = Self::split_top_level_types(inner)?;
                 let mut types = Vec::new();
@@ -1680,16 +1691,43 @@ mod tests {
     }
 
     #[test]
-    fn test_unparsed_uppercase_collection_is_not_treated_as_udt() {
-        // Regression: `CqlType::parse` returns a bare `Custom("SET<TEXT>")` for an
-        // uppercase collection it doesn't structurally parse. That is NOT a UDT
-        // reference and must not fail validation (collections fixture regression).
+    fn test_uppercase_collection_of_primitives_is_not_a_udt() {
+        // Regression (collections fixture): uppercase collections of primitives
+        // must parse and not be mistaken for a UDT reference.
         let registry = UdtRegistry::new();
-        for col_type in ["SET<TEXT>", "LIST<INT>", "MAP<TEXT, TEXT>"] {
+        for col_type in [
+            "SET<TEXT>",
+            "LIST<INT>",
+            "MAP<TEXT, TEXT>",
+            "FROZEN<LIST<INT>>",
+        ] {
             let schema = udt_schema(col_type);
             schema
                 .validate_udt_references(&registry)
                 .unwrap_or_else(|e| panic!("'{col_type}' must not be flagged as a UDT: {e}"));
+        }
+    }
+
+    #[test]
+    fn test_uppercase_collection_with_undefined_udt_errors() {
+        // Regression (roborev job 51): an undefined UDT nested inside an
+        // UPPERCASE collection must still be detected — case-insensitive parsing
+        // means the nested reference is validated, not skipped.
+        let registry = UdtRegistry::new();
+        for col_type in [
+            "LIST<MissingType>",
+            "MAP<TEXT, MissingType>",
+            "FROZEN<SET<MissingType>>",
+        ] {
+            let schema = udt_schema(col_type);
+            let err = schema
+                .validate_udt_references(&registry)
+                .expect_err("undefined UDT in uppercase collection must fail");
+            assert!(matches!(err, Error::Schema(_)), "got {err:?}");
+            assert!(
+                err.to_string().contains("MissingType"),
+                "error must name the missing UDT, got: {err}"
+            );
         }
     }
 

--- a/cqlite-core/src/schema/mod.rs
+++ b/cqlite-core/src/schema/mod.rs
@@ -790,12 +790,15 @@ impl TableSchema {
             CqlType::Udt(name, _) => {
                 self.ensure_udt_exists(name, column_name, registry)?;
             }
-            // `CqlType::parse` represents UDT references encountered in a column's
-            // declared type string as `Custom("udt:<name>")`.
+            // `CqlType::parse` represents UDT references as `Custom("udt:<name>")`
+            // for names with mixed case / underscores / digits, but as a bare
+            // `Custom("<name>")` for purely-lowercase names (e.g. `address`).
+            // Either way, `parse` only yields `Custom` for non-primitive,
+            // non-collection type strings — i.e. UDT references — so validate the
+            // de-prefixed name against the registry (roborev job 39).
             CqlType::Custom(name) => {
-                if let Some(udt_name) = name.strip_prefix("udt:") {
-                    self.ensure_udt_exists(udt_name, column_name, registry)?;
-                }
+                let udt_name = name.strip_prefix("udt:").unwrap_or(name);
+                self.ensure_udt_exists(udt_name, column_name, registry)?;
             }
             CqlType::List(inner) | CqlType::Set(inner) | CqlType::Frozen(inner) => {
                 self.check_type_udt_references(inner, column_name, registry)?;
@@ -1636,6 +1639,26 @@ mod tests {
             msg.contains("MyMissingType"),
             "error must name the missing UDT, got: {msg}"
         );
+    }
+
+    #[test]
+    fn test_udt_reference_undefined_lowercase_errors() {
+        // Regression (roborev job 39): a UDT name that is purely lowercase
+        // letters (no underscore/digit) parses to a bare `Custom("<name>")`
+        // with no `udt:` prefix, so validation must still catch it —
+        // top-level and nested.
+        let registry = UdtRegistry::new();
+        for col_type in ["address", "list<frozen<address>>"] {
+            let schema = udt_schema(col_type);
+            let err = schema
+                .validate_udt_references(&registry)
+                .expect_err("undefined lowercase UDT must fail validation");
+            assert!(matches!(err, Error::Schema(_)), "got {err:?}");
+            assert!(
+                err.to_string().contains("address"),
+                "error must name the missing UDT, got: {err}"
+            );
+        }
     }
 
     #[test]

--- a/cqlite-core/src/schema/registry.rs
+++ b/cqlite-core/src/schema/registry.rs
@@ -1229,27 +1229,30 @@ impl SchemaRegistry {
                     });
                 }
             }
-            // `CqlType::parse` represents UDT references in declared column type
-            // strings as `Custom("udt:<name>")` (issue #761).
+            // `CqlType::parse` represents UDT references as `Custom("udt:<name>")`
+            // for mixed-case/underscore/digit names but as a bare `Custom("<name>")`
+            // for purely-lowercase names (e.g. `address`). Either way `parse` only
+            // yields `Custom` for non-primitive, non-collection type strings — i.e.
+            // UDT references — so validate the de-prefixed name (issue #761,
+            // roborev job 44).
             CqlType::Custom(name) => {
-                if let Some(udt_name) = name.strip_prefix("udt:") {
-                    let (lookup_keyspace, bare_name) = match udt_name.split_once('.') {
-                        Some((ks, n)) => (ks, n),
-                        None => (keyspace, udt_name),
-                    };
-                    if !udt_registry.contains_udt(lookup_keyspace, bare_name)
-                        && !udt_registry.contains_udt("system", bare_name)
-                    {
-                        errors.push(ValidationError {
-                            code: "UDT_NOT_FOUND".to_string(),
-                            message: format!(
-                                "UDT '{}' not found in keyspace '{}'",
-                                udt_name, lookup_keyspace
-                            ),
-                            component: Some(udt_name.to_string()),
-                            severity: ErrorSeverity::High,
-                        });
-                    }
+                let udt_name = name.strip_prefix("udt:").unwrap_or(name);
+                let (lookup_keyspace, bare_name) = match udt_name.split_once('.') {
+                    Some((ks, n)) => (ks, n),
+                    None => (keyspace, udt_name),
+                };
+                if !udt_registry.contains_udt(lookup_keyspace, bare_name)
+                    && !udt_registry.contains_udt("system", bare_name)
+                {
+                    errors.push(ValidationError {
+                        code: "UDT_NOT_FOUND".to_string(),
+                        message: format!(
+                            "UDT '{}' not found in keyspace '{}'",
+                            udt_name, lookup_keyspace
+                        ),
+                        component: Some(udt_name.to_string()),
+                        severity: ErrorSeverity::High,
+                    });
                 }
             }
             CqlType::List(inner) | CqlType::Set(inner) | CqlType::Frozen(inner) => {
@@ -1488,6 +1491,33 @@ mod tests {
         let registry = make_registry(SchemaRegistryConfig::default()).await;
         let stats = registry.get_statistics().await.unwrap();
         assert_eq!(stats.total_schemas, 0);
+    }
+
+    /// Regression (roborev job 44): the registry's `validate_cql_type_udts` must
+    /// flag an undefined purely-lowercase UDT (bare `Custom("address")`, no
+    /// `udt:` prefix), matching `TableSchema::check_type_udt_references`.
+    #[tokio::test]
+    async fn test_registry_validate_lowercase_udt_not_found() {
+        let registry = make_registry(SchemaRegistryConfig::default()).await;
+        let udt_registry = UdtRegistry::new();
+        let mut errors = Vec::new();
+        let mut warnings = Vec::new();
+
+        let cql_type = CqlType::parse("address").expect("parse");
+        registry.validate_cql_type_udts(
+            &cql_type,
+            "test_ks",
+            &udt_registry,
+            &mut errors,
+            &mut warnings,
+        );
+
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.code == "UDT_NOT_FOUND" && e.message.contains("address")),
+            "undefined lowercase UDT must be reported, got: {errors:?}"
+        );
     }
 
     #[test]

--- a/cqlite-core/src/schema/registry.rs
+++ b/cqlite-core/src/schema/registry.rs
@@ -1241,7 +1241,10 @@ impl SchemaRegistry {
                     Some((ks, n)) => (ks, n),
                     None => (keyspace, udt_name),
                 };
-                if !udt_registry.contains_udt(lookup_keyspace, bare_name)
+                // Skip structural fragments parse couldn't resolve (e.g. an
+                // uppercase `SET<TEXT>`); only simple identifiers name a UDT.
+                if crate::schema::is_udt_identifier(udt_name)
+                    && !udt_registry.contains_udt(lookup_keyspace, bare_name)
                     && !udt_registry.contains_udt("system", bare_name)
                 {
                     errors.push(ValidationError {

--- a/cqlite-core/src/schema/registry.rs
+++ b/cqlite-core/src/schema/registry.rs
@@ -1523,6 +1523,34 @@ mod tests {
         );
     }
 
+    /// Regression (roborev job 55): the registry validation path must also catch
+    /// an undefined UDT nested inside an UPPERCASE collection, mirroring
+    /// `TableSchema::validate_udt_references`.
+    #[tokio::test]
+    async fn test_registry_validate_uppercase_collection_udt_not_found() {
+        let registry = make_registry(SchemaRegistryConfig::default()).await;
+        let udt_registry = UdtRegistry::new();
+
+        for ty in ["LIST<MissingType>", "MAP<TEXT, MissingType>"] {
+            let mut errors = Vec::new();
+            let mut warnings = Vec::new();
+            let cql_type = CqlType::parse(ty).expect("parse");
+            registry.validate_cql_type_udts(
+                &cql_type,
+                "test_ks",
+                &udt_registry,
+                &mut errors,
+                &mut warnings,
+            );
+            assert!(
+                errors
+                    .iter()
+                    .any(|e| e.code == "UDT_NOT_FOUND" && e.message.contains("MissingType")),
+                "undefined UDT in '{ty}' must be reported, got: {errors:?}"
+            );
+        }
+    }
+
     #[test]
     fn test_schema_query_creation() {
         let query = SchemaQuery {

--- a/cqlite-core/src/schema/registry.rs
+++ b/cqlite-core/src/schema/registry.rs
@@ -1218,13 +1218,38 @@ impl SchemaRegistry {
     ) {
         match cql_type {
             CqlType::Udt(udt_name, _) => {
-                if !udt_registry.contains_udt(keyspace, udt_name) {
+                if !udt_registry.contains_udt(keyspace, udt_name)
+                    && !udt_registry.contains_udt("system", udt_name)
+                {
                     errors.push(ValidationError {
                         code: "UDT_NOT_FOUND".to_string(),
                         message: format!("UDT '{}' not found in keyspace '{}'", udt_name, keyspace),
                         component: Some(udt_name.clone()),
                         severity: ErrorSeverity::High,
                     });
+                }
+            }
+            // `CqlType::parse` represents UDT references in declared column type
+            // strings as `Custom("udt:<name>")` (issue #761).
+            CqlType::Custom(name) => {
+                if let Some(udt_name) = name.strip_prefix("udt:") {
+                    let (lookup_keyspace, bare_name) = match udt_name.split_once('.') {
+                        Some((ks, n)) => (ks, n),
+                        None => (keyspace, udt_name),
+                    };
+                    if !udt_registry.contains_udt(lookup_keyspace, bare_name)
+                        && !udt_registry.contains_udt("system", bare_name)
+                    {
+                        errors.push(ValidationError {
+                            code: "UDT_NOT_FOUND".to_string(),
+                            message: format!(
+                                "UDT '{}' not found in keyspace '{}'",
+                                udt_name, lookup_keyspace
+                            ),
+                            component: Some(udt_name.to_string()),
+                            severity: ErrorSeverity::High,
+                        });
+                    }
                 }
             }
             CqlType::List(inner) | CqlType::Set(inner) | CqlType::Frozen(inner) => {


### PR DESCRIPTION
## What changed

Implements **#761** (child of Epic #756): validate UDT references against the registry at schema load so an undefined UDT fails fast with a clear, named error instead of surfacing later as a confusing parse/deserialization failure.

Previously `cqlite-core/src/schema/mod.rs` had a `TODO` at the data-type validation step and never checked that referenced UDTs exist.

## Validation approach (incl. nested handling)

- New `TableSchema::validate_udt_references(&UdtRegistry) -> Result<()>`: for each column, parse its declared type to a `CqlType` and recursively walk it. UDT references are caught in both representations:
  - `CqlType::Udt(name, _)`, and
  - `CqlType::Custom("udt:<name>")` — the form `CqlType::parse` produces for a UDT named in a declared column type string.
- **Nested references** are validated by recursing through `List`/`Set`/`Frozen` (inner), `Map` (key + value), and `Tuple` (all elements) — so a UDT inside a collection, `frozen<>`, a tuple, or another UDT is checked exactly like a top-level reference.
- Lookups honor qualified `keyspace.udt` names and also consult the `system` keyspace for built-in UDTs.
- On a miss, returns `Error::Schema(...)` naming the missing UDT and the column.

**Wiring at load:** the fail-fast check runs in `SchemaAggregator`'s table-registration loop, gated by the existing `validate_udt_dependencies` config flag, validating against the aggregator's already-populated UDT registry (the two-pass loader registers UDTs first, then tables). A table referencing an undefined UDT is rejected with the error recorded; under `graceful_degradation` it is skipped, otherwise loading stops.

**Bonus fix:** the registry's validation-report path (`validate_cql_type_udts`) previously only matched `CqlType::Udt`, so it never caught declared-type UDT references (which parse to `Custom("udt:...")`). Added that case there too, and made both paths consult the `system` keyspace.

No `unwrap()`/`expect()` in library code; errors use `thiserror` via `Error::schema`.

## Tests (TDD — written first, watched fail, then implemented)

Unit (`schema::tests`): undefined UDT top-level / nested-in-collection / nested-in-map all error naming the missing type; defined UDT (top-level and nested) loads; primitive/collection-only schema loads.

Integration (`schema::aggregator::tests`): table referencing an undefined UDT (top-level and `list<frozen<...>>`) fails to load with the missing name in the error; a table whose UDT is defined loads cleanly.

## Evidence

```
$ cargo test -p cqlite-core --lib schema::
test result: ok. 79 passed; 0 failed; 3 ignored; 0 measured; 1791 filtered out

$ cargo test -p cqlite-core --lib
test result: ok. 1859 passed; 0 failed; 14 ignored; 0 measured; 0 filtered out

$ cargo fmt --all            # clean
$ RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features
    Finished `dev` profile ... (no warnings)
```

> Note: sibling PRs #758 and #759 also edit `schema/mod.rs`; a rebase may be needed at merge.

Closes #761. Part of Epic #756.
