### PR TITLE
feat(schema): discover clustering order (ASC/DESC) from Statistics.db header (#759)

### DIFF
--- a/cqlite-core/src/parser/benchmarks.rs
+++ b/cqlite-core/src/parser/benchmarks.rs
@@ -474,6 +474,7 @@ impl ParserBenchmarks {
                     key_position: Some(0),
                     is_static: false,
                     is_clustering: false,
+                    clustering_reversed: false,
                 },
                 header::ColumnInfo {
                     name: "timestamp".to_string(),
@@ -482,6 +483,7 @@ impl ParserBenchmarks {
                     key_position: None,
                     is_static: false,
                     is_clustering: true,
+                    clustering_reversed: false,
                 },
                 header::ColumnInfo {
                     name: "data".to_string(),
@@ -490,6 +492,7 @@ impl ParserBenchmarks {
                     key_position: None,
                     is_static: false,
                     is_clustering: false,
+                    clustering_reversed: false,
                 },
             ],
             properties: HashMap::new(),

--- a/cqlite-core/src/parser/enhanced_statistics_parser.rs
+++ b/cqlite-core/src/parser/enhanced_statistics_parser.rs
@@ -1360,7 +1360,12 @@ fn is_reversed_comparator(marshal_type: &str) -> bool {
 fn convert_marshal_type_to_cql(marshal_type: &str) -> String {
     fn strip_wrapping_parens(mut value: &str) -> &str {
         loop {
-            let trimmed = value.trim();
+            // Also strip a leading structural `[` the header may prefix the
+            // comparator list with (e.g. `[org...ReversedType(...)`), so the
+            // wrapper-prefix checks below match the bracketed form too and the
+            // inner CQL type is derived correctly (roborev job 48). This mirrors
+            // the same normalization in `is_reversed_comparator`.
+            let trimmed = value.trim().trim_start_matches('[').trim_start();
             if trimmed.starts_with('(') && trimmed.ends_with(')') && trimmed.len() > 2 {
                 value = &trimmed[1..trimmed.len() - 1];
             } else {
@@ -2462,6 +2467,27 @@ mod tests {
             assert!(!col.column_type.contains("Reversed"));
             assert!(col.is_clustering);
         }
+    }
+
+    /// Regression (roborev job 48): a bracket-prefixed reversed comparator must
+    /// be DESC *and* resolve to the correct inner CQL type (not `timestamptype`).
+    #[test]
+    fn test_build_clustering_key_columns_bracket_prefixed_reversed() {
+        let clustering_types = vec![
+            "[org.apache.cassandra.db.marshal.ReversedType(org.apache.cassandra.db.marshal.TimestampType)"
+                .to_string(),
+        ];
+        let cols = build_clustering_key_columns(&clustering_types);
+        assert_eq!(cols.len(), 1);
+        assert!(
+            cols[0].clustering_reversed,
+            "bracket-prefixed ReversedType is DESC"
+        );
+        assert_eq!(
+            cols[0].column_type, "timestamp",
+            "inner CQL type must resolve through the bracket, got {}",
+            cols[0].column_type
+        );
     }
 
     #[test]

--- a/cqlite-core/src/parser/enhanced_statistics_parser.rs
+++ b/cqlite-core/src/parser/enhanced_statistics_parser.rs
@@ -1347,6 +1347,11 @@ fn is_reversed_comparator(marshal_type: &str) -> bool {
     while value.starts_with('(') && value.ends_with(')') && value.len() > 2 {
         value = value[1..value.len() - 1].trim();
     }
+    // Some accepted header encodings prefix the comparator list with a `[`
+    // (e.g. `[org.apache.cassandra.db.marshal.ReversedType(...)`); strip a
+    // leading bracket so the ReversedType detection matches that form too
+    // (roborev job 43).
+    let value = value.trim_start_matches('[').trim_start();
     value.starts_with("org.apache.cassandra.db.marshal.ReversedType(")
         || value.starts_with("ReversedType(")
 }
@@ -2415,6 +2420,11 @@ mod tests {
         assert!(is_reversed_comparator(
             "(org.apache.cassandra.db.marshal.ReversedType(org.apache.cassandra.db.marshal.SimpleDateType))"
         ));
+        // ...and sometimes with a structural '[' (roborev job 43) — still DESC.
+        assert!(is_reversed_comparator(
+            "[org.apache.cassandra.db.marshal.ReversedType(org.apache.cassandra.db.marshal.TimestampType)"
+        ));
+        assert!(is_reversed_comparator("[ReversedType(Int32Type)"));
         // Non-reversed comparators are ASC.
         assert!(!is_reversed_comparator(
             "org.apache.cassandra.db.marshal.UTF8Type"

--- a/cqlite-core/src/parser/enhanced_statistics_parser.rs
+++ b/cqlite-core/src/parser/enhanced_statistics_parser.rs
@@ -663,6 +663,7 @@ fn parse_serialization_header_at_offset(input: &[u8]) -> IResult<&[u8], Serializ
             key_position: None,
             is_static: true, // Mark as static column!
             is_clustering: false,
+            clustering_reversed: false,
         });
 
         input = remaining;
@@ -747,6 +748,7 @@ fn parse_serialization_header_at_offset(input: &[u8]) -> IResult<&[u8], Serializ
             key_position: None,
             is_static: false,
             is_clustering: false,
+            clustering_reversed: false,
         });
     }
 
@@ -1074,6 +1076,7 @@ fn parse_regular_columns(
                     key_position: None,
                     is_static: false,
                     is_clustering: false,
+                    clustering_reversed: false,
                 });
             }
 
@@ -1242,6 +1245,7 @@ fn fallback_parse_serialization_header_ascii(
                         key_position: None,
                         is_static: false,
                         is_clustering: false,
+                        clustering_reversed: false,
                     });
 
                     // Advance past control bytes to next potential column entry
@@ -1325,6 +1329,26 @@ fn split_type_arguments(input: &str) -> Vec<&str> {
     }
 
     args
+}
+
+/// Detect whether a clustering comparator class denotes descending order.
+///
+/// Issue #759: Cassandra encodes a DESC clustering column by wrapping its
+/// comparator class in `org.apache.cassandra.db.marshal.ReversedType(...)`.
+/// This is the documented, authoritative signal for descending order
+/// (definitive guide Ch.7 / Appendix B) — no heuristics. We mirror the
+/// leading-paren stripping that `convert_marshal_type_to_cql` performs (the
+/// header sometimes prefixes types with `(`), then check for the `ReversedType(`
+/// prefix with or without the marshal package namespace.
+fn is_reversed_comparator(marshal_type: &str) -> bool {
+    let mut value = marshal_type.trim();
+    // Strip the optional leading wrapping paren(s) the header adds to the
+    // top-level type (matches `convert_marshal_type_to_cql`'s normalization).
+    while value.starts_with('(') && value.ends_with(')') && value.len() > 2 {
+        value = value[1..value.len() - 1].trim();
+    }
+    value.starts_with("org.apache.cassandra.db.marshal.ReversedType(")
+        || value.starts_with("ReversedType(")
 }
 
 /// Convert Cassandra internal marshal type to CQL type name
@@ -1467,6 +1491,7 @@ fn build_partition_key_columns(partition_types: &[String]) -> Vec<super::header:
                 key_position: Some(idx as u16),
                 is_static: false,
                 is_clustering: false,
+                clustering_reversed: false,
             }
         })
         .collect()
@@ -1483,6 +1508,13 @@ fn build_clustering_key_columns(clustering_types: &[String]) -> Vec<super::heade
         .iter()
         .enumerate()
         .map(|(idx, marshal_type)| {
+            // Issue #759: a DESC clustering column is encoded by wrapping its
+            // comparator class in `ReversedType(...)`. Detect that authoritative
+            // signal here, BEFORE `convert_marshal_type_to_cql` unwraps it, so
+            // schema discovery can report `ClusteringOrder::Desc`. The CQL type
+            // continues to come from `convert_marshal_type_to_cql`, which strips
+            // `ReversedType` so the inner type's deserialization is undisturbed.
+            let clustering_reversed = is_reversed_comparator(marshal_type);
             let cql_type = convert_marshal_type_to_cql(marshal_type);
             let name = if total == 1 {
                 "clustering_key".to_string()
@@ -1497,6 +1529,7 @@ fn build_clustering_key_columns(clustering_types: &[String]) -> Vec<super::heade
                 key_position: Some(idx as u16),
                 is_static: false,
                 is_clustering: true,
+                clustering_reversed,
             }
         })
         .collect()
@@ -1670,6 +1703,7 @@ fn parse_serialization_header_sequential(
             key_position: None,
             is_static: true,
             is_clustering: false,
+            clustering_reversed: false,
         });
 
         input = remaining;
@@ -1752,6 +1786,7 @@ fn parse_serialization_header_sequential(
             key_position: None,
             is_static: false,
             is_clustering: false,
+            clustering_reversed: false,
         });
 
         input = remaining;
@@ -1851,8 +1886,14 @@ fn parse_serialization_header_schema(input: &[u8]) -> IResult<&[u8], Serializati
         }
 
         let (remaining, ck_type_bytes) = take(ck_type_len as usize)(remaining)?;
+        // Issue #759: preserve the RAW comparator class name (including any
+        // `ReversedType(...)` wrapper) here. `build_clustering_key_columns` is
+        // the single place that converts to a CQL type AND derives clustering
+        // order from the wrapper, so converting eagerly would discard the DESC
+        // signal. Conversion in `build_clustering_key_columns` is idempotent for
+        // already-CQL strings, keeping the other parse paths correct.
         let ck_type = match std::str::from_utf8(ck_type_bytes) {
-            Ok(s) => convert_marshal_type_to_cql(s),
+            Ok(s) => s.to_string(),
             Err(_) => {
                 log::debug!("Invalid UTF-8 in clustering key type {}", i);
                 return Err(nom::Err::Error(nom::error::Error::new(
@@ -1955,6 +1996,7 @@ fn parse_serialization_header_schema(input: &[u8]) -> IResult<&[u8], Serializati
             key_position: None,
             is_static: true,
             is_clustering: false,
+            clustering_reversed: false,
         });
 
         input = remaining;
@@ -2043,6 +2085,7 @@ fn parse_serialization_header_schema(input: &[u8]) -> IResult<&[u8], Serializati
             key_position: None,
             is_static: false,
             is_clustering: false,
+            clustering_reversed: false,
         });
 
         input = remaining;
@@ -2359,6 +2402,57 @@ pub fn parse_statistics_with_fallback<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Issue #759: ReversedType wrapping is the authoritative DESC signal.
+    #[test]
+    fn test_is_reversed_comparator() {
+        // Fully-qualified and short forms both denote DESC.
+        assert!(is_reversed_comparator(
+            "org.apache.cassandra.db.marshal.ReversedType(org.apache.cassandra.db.marshal.TimestampType)"
+        ));
+        assert!(is_reversed_comparator("ReversedType(Int32Type)"));
+        // The header sometimes prefixes the top-level type with '(' — still DESC.
+        assert!(is_reversed_comparator(
+            "(org.apache.cassandra.db.marshal.ReversedType(org.apache.cassandra.db.marshal.SimpleDateType))"
+        ));
+        // Non-reversed comparators are ASC.
+        assert!(!is_reversed_comparator(
+            "org.apache.cassandra.db.marshal.UTF8Type"
+        ));
+        assert!(!is_reversed_comparator("Int32Type"));
+        // ReversedType only counts as the outer wrapper, not nested as an arg.
+        assert!(!is_reversed_comparator(
+            "org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.ReversedType(org.apache.cassandra.db.marshal.Int32Type))"
+        ));
+    }
+
+    // Issue #759: ReversedType drives ClusteringColumn order without disturbing
+    // the inner type's CQL conversion (used for deserialization).
+    #[test]
+    fn test_build_clustering_key_columns_reversed_order() {
+        let clustering_types = vec![
+            "org.apache.cassandra.db.marshal.ReversedType(org.apache.cassandra.db.marshal.TimestampType)".to_string(),
+            "org.apache.cassandra.db.marshal.UTF8Type".to_string(),
+            "org.apache.cassandra.db.marshal.ReversedType(org.apache.cassandra.db.marshal.Int32Type)".to_string(),
+        ];
+
+        let cols = build_clustering_key_columns(&clustering_types);
+        assert_eq!(cols.len(), 3);
+
+        // DESC columns flag clustering_reversed; inner CQL type is preserved.
+        assert!(cols[0].clustering_reversed);
+        assert_eq!(cols[0].column_type, "timestamp");
+        assert!(!cols[1].clustering_reversed);
+        assert_eq!(cols[1].column_type, "text");
+        assert!(cols[2].clustering_reversed);
+        assert_eq!(cols[2].column_type, "int");
+
+        // Never leak the ReversedType wrapper into the resolved CQL type.
+        for col in &cols {
+            assert!(!col.column_type.contains("Reversed"));
+            assert!(col.is_clustering);
+        }
+    }
 
     #[test]
     fn test_serialization_header_with_no_clustering_keys() {

--- a/cqlite-core/src/parser/header.rs
+++ b/cqlite-core/src/parser/header.rs
@@ -422,6 +422,16 @@ pub struct ColumnInfo {
     pub is_static: bool,
     /// Whether the column is clustering
     pub is_clustering: bool,
+    /// Clustering sort order is descending (Issue #759).
+    ///
+    /// Cassandra's serialization header encodes a DESC clustering column by
+    /// wrapping its comparator class in `ReversedType(...)`. This flag captures
+    /// that authoritative signal so schema discovery can report
+    /// `ClusteringOrder::Desc`. Always `false` for non-clustering columns and
+    /// for ASC clustering columns. `#[serde(default)]` keeps previously
+    /// serialized headers (without the field) deserializable.
+    #[serde(default)]
+    pub clustering_reversed: bool,
 }
 
 /// Parse the SSTable magic number and version, supporting multiple Cassandra versions
@@ -608,6 +618,11 @@ pub fn parse_column_info(input: &[u8]) -> IResult<&[u8], ColumnInfo> {
             key_position,
             is_static,
             is_clustering,
+            // The Header.db per-column flags byte does not carry clustering
+            // order; the authoritative DESC signal lives in the Statistics.db
+            // serialization-header comparator (ReversedType). See Issue #759
+            // and `enhanced_statistics_parser::build_clustering_key_columns`.
+            clustering_reversed: false,
         },
     ))
 }
@@ -999,6 +1014,7 @@ mod tests {
             key_position: Some(0),
             is_static: false,
             is_clustering: false,
+            clustering_reversed: false,
         };
 
         let mut serialized = Vec::new();
@@ -1137,6 +1153,7 @@ mod tests {
                 key_position: Some(0),
                 is_static: false,
                 is_clustering: false,
+                clustering_reversed: false,
             }],
             properties,
         };

--- a/cqlite-core/src/schema/mod.rs
+++ b/cqlite-core/src/schema/mod.rs
@@ -612,7 +612,16 @@ impl TableSchema {
                 name: col.name.clone(),
                 data_type: col.column_type.clone(),
                 position: pos, // Contiguous internal position, not header key_position
-                order: ClusteringOrder::Asc, // TODO(Future): Extract clustering order from header properties when format documented
+                // Issue #759: the serialization header wraps a DESC clustering
+                // column's comparator in `ReversedType(...)`. That authoritative
+                // signal is captured in `ColumnInfo::clustering_reversed` during
+                // Statistics.db parsing (no heuristics). `data_type` already holds
+                // the unwrapped inner CQL type, so deserialization is undisturbed.
+                order: if col.clustering_reversed {
+                    ClusteringOrder::Desc
+                } else {
+                    ClusteringOrder::Asc
+                },
             })
             .collect();
 
@@ -1565,6 +1574,7 @@ mod tests {
                 key_position: Some(0),
                 is_static: false,
                 is_clustering: false,
+                clustering_reversed: false,
             },
             ColumnInfo {
                 name: "name".to_string(),
@@ -1573,6 +1583,7 @@ mod tests {
                 key_position: None,
                 is_static: false,
                 is_clustering: false,
+                clustering_reversed: false,
             },
         ];
 

--- a/cqlite-core/tests/issue_759_clustering_order_discovery.rs
+++ b/cqlite-core/tests/issue_759_clustering_order_discovery.rs
@@ -1,0 +1,105 @@
+//! Issue #759 (Epic #756) regression test — clustering order (ASC/DESC)
+//! discovery from the Statistics.db serialization header.
+//!
+//! Cassandra's serialization header encodes clustering-column types as
+//! comparator class names. A DESC clustering column is wrapped in
+//! `org.apache.cassandra.db.marshal.ReversedType(...)`. That wrapping is the
+//! documented, authoritative signal for descending order (definitive guide
+//! Ch.7 / Appendix B). Previously `TableSchema::from_sstable_header` defaulted
+//! every clustering column to ASC.
+//!
+//! Fixture: `test_wide_rows.wide_partition_table` declares
+//!   `CLUSTERING ORDER BY (clustering_col1 DESC, clustering_col2 ASC,
+//!    clustering_col3 DESC, clustering_col4 ASC, clustering_col5 DESC)`
+//! and its Statistics.db header wraps col1/col3/col5 in `ReversedType(...)`.
+//!
+//! Requires `CQLITE_DATASETS_ROOT` and real Data.db files
+//! (`bash test-data/scripts/fetch-datasets.sh`).
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use cqlite_core::platform::Platform;
+use cqlite_core::schema::ClusteringOrder;
+use cqlite_core::storage::sstable::reader::SSTableReader;
+use cqlite_core::Config;
+
+fn datasets_root() -> Option<PathBuf> {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+}
+
+/// Locate the Data.db component for the wide_partition_table fixture.
+fn wide_partition_data_db(root: &Path) -> Option<PathBuf> {
+    let table_dir = root
+        .join("sstables")
+        .join("test_wide_rows")
+        .join("wide_partition_table-6d6d0f80a25111f0a3fef1a551383fb9");
+    let data = table_dir.join("nb-1-big-Data.db");
+    data.exists().then_some(data)
+}
+
+#[tokio::test]
+async fn clustering_order_extracted_from_reversed_type() {
+    let Some(root) = datasets_root() else {
+        eprintln!("Skipping: CQLITE_DATASETS_ROOT not set");
+        return;
+    };
+    let Some(data_db) = wide_partition_data_db(&root) else {
+        eprintln!("Skipping: wide_partition_table Data.db not present (fetch-datasets.sh)");
+        return;
+    };
+
+    let config = Config::default();
+    let platform = Arc::new(Platform::new(&config).await.expect("platform"));
+    let reader = SSTableReader::open(&data_db, &config, platform)
+        .await
+        .expect("open sstable reader");
+
+    let schema = reader
+        .schema()
+        .expect("schema should be discovered from header");
+
+    // Sanity: 5 clustering columns in declared key order.
+    assert_eq!(
+        schema.clustering_keys.len(),
+        5,
+        "expected 5 clustering columns, got {:?}",
+        schema
+            .clustering_keys
+            .iter()
+            .map(|c| (&c.name, &c.order))
+            .collect::<Vec<_>>()
+    );
+
+    // Declared: col1 DESC, col2 ASC, col3 DESC, col4 ASC, col5 DESC.
+    // The header positions are canonical; assert order by position.
+    let expected = [
+        ClusteringOrder::Desc,
+        ClusteringOrder::Asc,
+        ClusteringOrder::Desc,
+        ClusteringOrder::Asc,
+        ClusteringOrder::Desc,
+    ];
+    for (idx, want) in expected.iter().enumerate() {
+        let col = &schema.clustering_keys[idx];
+        assert_eq!(
+            col.order, *want,
+            "clustering column #{} ({}) expected {:?}, got {:?}",
+            idx, col.name, want, col.order
+        );
+    }
+
+    // ReversedType unwrapping must NOT disturb inner-type deserialization:
+    // the discovered data types are the inner CQL types, not "ReversedType".
+    for col in &schema.clustering_keys {
+        assert!(
+            !col.data_type.to_lowercase().contains("reversed"),
+            "clustering column {} leaked ReversedType into data_type: {}",
+            col.name,
+            col.data_type
+        );
+    }
+}

--- a/tests/format-compatibility/tests/oa_format_compliance.rs
+++ b/tests/format-compatibility/tests/oa_format_compliance.rs
@@ -266,7 +266,7 @@ fn test_oa_complete_header_roundtrip() {
                 key_position: Some(0),
                 is_static: false,
                 is_clustering: false,
-            },
+                clustering_reversed: false,            },
             ColumnInfo {
                 name: "data".to_string(),
                 column_type: "text".to_string(),
@@ -274,7 +274,7 @@ fn test_oa_complete_header_roundtrip() {
                 key_position: None,
                 is_static: false,
                 is_clustering: false,
-            }
+                clustering_reversed: false,            }
         ],
         properties: {
             let mut props = HashMap::new();

--- a/tests/format-compatibility/tests/oa_format_compliance.rs
+++ b/tests/format-compatibility/tests/oa_format_compliance.rs
@@ -3,7 +3,7 @@
 //! These tests ensure 100% byte-perfect compatibility with Apache Cassandra 5+
 //! SSTable 'oa' format specification. Zero tolerance for deviations.
 
-use cqlite_core::parser::{header::*, vint::*, types::*};
+use cqlite_core::parser::{header::*, types::*, vint::*};
 use format_validator::{format_constants::*, utils::*, ValidationError};
 use pretty_assertions::assert_eq;
 use std::collections::HashMap;
@@ -13,12 +13,12 @@ fn test_oa_magic_number_compliance() {
     // Test exact magic number format
     let expected_magic = BIG_FORMAT_OA_MAGIC;
     let magic_bytes = expected_magic.to_be_bytes();
-    
+
     assert_eq!(magic_bytes, [0x6F, 0x61, 0x00, 0x00]);
-    
+
     // Verify parsing
     assert!(verify_magic(&magic_bytes, expected_magic).is_ok());
-    
+
     // Test rejection of incorrect magic
     let wrong_magic = [0x6F, 0x62, 0x00, 0x00]; // 'ob' instead of 'oa'
     assert!(verify_magic(&wrong_magic, expected_magic).is_err());
@@ -28,7 +28,7 @@ fn test_oa_magic_number_compliance() {
 fn test_oa_version_compliance() {
     let version = SUPPORTED_VERSION;
     let version_bytes = version.to_be_bytes();
-    
+
     assert_eq!(version_bytes, [0x00, 0x01]);
     assert_eq!(version, 1);
 }
@@ -37,22 +37,22 @@ fn test_oa_version_compliance() {
 fn test_oa_header_structure() {
     // Build a complete 'oa' format header
     let mut header_bytes = Vec::new();
-    
+
     // Magic number (4 bytes)
     header_bytes.extend_from_slice(&BIG_FORMAT_OA_MAGIC.to_be_bytes());
-    
+
     // Version (2 bytes)
     header_bytes.extend_from_slice(&SUPPORTED_VERSION.to_be_bytes());
-    
+
     // Flags (4 bytes) - test various flag combinations
     let flags = 0x0001 | 0x0100 | 0x0200; // has compression + key range + long deletion
     header_bytes.extend_from_slice(&flags.to_be_bytes());
-    
+
     // Reserved (22 bytes) - must be zero
     header_bytes.extend_from_slice(&[0u8; 22]);
-    
+
     assert_eq!(header_bytes.len(), 32); // Standard header size
-    
+
     // Parse header
     let (remaining, version) = parse_magic_and_version(&header_bytes).unwrap();
     assert_eq!(version, SUPPORTED_VERSION);
@@ -78,22 +78,27 @@ fn test_oa_flag_encoding() {
         (0x040000, "deflate_compression"),
         (0x080000, "custom_compression"),
     ];
-    
+
     for (flag_value, flag_name) in test_cases {
         // Test individual flag
         let flag_bytes = flag_value.to_be_bytes();
         let parsed_flags = u32::from_be_bytes(flag_bytes);
         assert_eq!(parsed_flags, flag_value, "Failed for flag: {}", flag_name);
-        
+
         // Test flag detection
-        assert_ne!(parsed_flags & flag_value, 0, "Flag not detected: {}", flag_name);
+        assert_ne!(
+            parsed_flags & flag_value,
+            0,
+            "Flag not detected: {}",
+            flag_name
+        );
     }
-    
+
     // Test combined flags
     let combined = 0x0001 | 0x0100 | 0x010000; // compression + key range + LZ4
     let combined_bytes = combined.to_be_bytes();
     let parsed_combined = u32::from_be_bytes(combined_bytes);
-    
+
     assert_eq!(parsed_combined & 0x0001, 0x0001); // has compression
     assert_eq!(parsed_combined & 0x0100, 0x0100); // key range
     assert_eq!(parsed_combined & 0x010000, 0x010000); // LZ4
@@ -102,54 +107,60 @@ fn test_oa_flag_encoding() {
 #[test]
 fn test_oa_enhanced_metadata() {
     // Test new 'oa' format features
-    
+
     // 1. Long deletion time (64-bit instead of 32-bit)
     let long_deletion_time = 0x1234_5678_9ABC_DEF0i64;
     let deletion_bytes = long_deletion_time.to_be_bytes();
     assert_eq!(deletion_bytes.len(), 8);
-    
+
     let parsed_deletion = i64::from_be_bytes(deletion_bytes);
     assert_eq!(parsed_deletion, long_deletion_time);
-    
+
     // 2. Enhanced timestamps (microsecond precision)
     let timestamp_micros = 1_640_995_200_000_000i64; // 2022-01-01 00:00:00 UTC in microseconds
     let timestamp_bytes = timestamp_micros.to_be_bytes();
-    
+
     let parsed_timestamp = i64::from_be_bytes(timestamp_bytes);
     assert_eq!(parsed_timestamp, timestamp_micros);
-    
+
     // 3. Token space coverage
     let token_ranges = vec![
         (-9223372036854775808i64, -4611686018427387904i64), // First quarter
-        (-4611686018427387904i64, 0i64),                     // Second quarter
-        (0i64, 4611686018427387904i64),                      // Third quarter
-        (4611686018427387904i64, 9223372036854775807i64),    // Fourth quarter
+        (-4611686018427387904i64, 0i64),                    // Second quarter
+        (0i64, 4611686018427387904i64),                     // Third quarter
+        (4611686018427387904i64, 9223372036854775807i64),   // Fourth quarter
     ];
-    
+
     // Encode token ranges
     let mut token_bytes = Vec::new();
     token_bytes.extend_from_slice(&encode_vint(token_ranges.len() as i64));
-    
+
     for (start, end) in token_ranges {
         token_bytes.extend_from_slice(&encode_vint(start));
         token_bytes.extend_from_slice(&encode_vint(end));
     }
-    
+
     // Parse token ranges
     let mut offset = 0;
     let (remaining, range_count) = parse_vint(&token_bytes[offset..]).unwrap();
     offset = token_bytes.len() - remaining.len();
     assert_eq!(range_count, 4);
-    
+
     for i in 0..range_count {
         let (remaining, start) = parse_vint(&token_bytes[offset..]).unwrap();
         offset = token_bytes.len() - remaining.len();
-        
+
         let (remaining, end) = parse_vint(&token_bytes[offset..]).unwrap();
         offset = token_bytes.len() - remaining.len();
-        
+
         // Verify ranges are properly ordered
-        assert!(start < end, "Invalid token range {}: {} >= {}", i, start, end);
+        assert!(
+            start < end,
+            "Invalid token range {}: {} >= {}",
+            i,
+            start,
+            end
+        );
     }
 }
 
@@ -166,19 +177,22 @@ fn test_oa_compression_info_structure() {
             params
         },
     };
-    
+
     // Serialize compression info
     let mut serialized = Vec::new();
     serialize_compression_info(&mut serialized, &compression_info).unwrap();
-    
+
     // Parse it back
     let (remaining, parsed_info) = parse_compression_info(&serialized).unwrap();
     assert!(remaining.is_empty());
-    
+
     assert_eq!(parsed_info.algorithm, "LZ4");
     assert_eq!(parsed_info.chunk_size, 4096);
     assert_eq!(parsed_info.parameters.get("level"), Some(&"6".to_string()));
-    assert_eq!(parsed_info.parameters.get("checksum"), Some(&"CRC32".to_string()));
+    assert_eq!(
+        parsed_info.parameters.get("checksum"),
+        Some(&"CRC32".to_string())
+    );
 }
 
 #[test]
@@ -192,21 +206,24 @@ fn test_oa_statistics_structure() {
         compression_ratio: 0.65,
         row_size_histogram: vec![100, 500, 1000, 2000, 5000],
     };
-    
+
     // Serialize statistics
     let mut serialized = Vec::new();
     serialize_sstable_stats(&mut serialized, &stats).unwrap();
-    
+
     // Parse it back
     let (remaining, parsed_stats) = parse_sstable_stats(&serialized).unwrap();
     assert!(remaining.is_empty());
-    
+
     assert_eq!(parsed_stats.row_count, 100_000);
     assert_eq!(parsed_stats.min_timestamp, 1_640_995_200_000_000i64);
     assert_eq!(parsed_stats.max_timestamp, 1_672_531_199_999_999i64);
     assert_eq!(parsed_stats.max_deletion_time, 1_672_531_199_999_999i64);
     assert!((parsed_stats.compression_ratio - 0.65).abs() < 1e-10);
-    assert_eq!(parsed_stats.row_size_histogram, vec![100, 500, 1000, 2000, 5000]);
+    assert_eq!(
+        parsed_stats.row_size_histogram,
+        vec![100, 500, 1000, 2000, 5000]
+    );
 }
 
 #[test]
@@ -215,22 +232,21 @@ fn test_oa_footer_structure() {
     let index_offset = 0x1234_5678_9ABC_DEF0u64;
     let crc32_checksum = 0xDEAD_BEEFu32;
     let magic_verification = BIG_FORMAT_OA_MAGIC;
-    
+
     let mut footer = Vec::new();
     footer.extend_from_slice(&index_offset.to_be_bytes());
     footer.extend_from_slice(&crc32_checksum.to_be_bytes());
     footer.extend_from_slice(&magic_verification.to_be_bytes());
-    
+
     assert_eq!(footer.len(), 16); // 8 + 4 + 4 = 16 bytes
-    
+
     // Parse footer
     let parsed_offset = u64::from_be_bytes([
-        footer[0], footer[1], footer[2], footer[3],
-        footer[4], footer[5], footer[6], footer[7]
+        footer[0], footer[1], footer[2], footer[3], footer[4], footer[5], footer[6], footer[7],
     ]);
     let parsed_checksum = u32::from_be_bytes([footer[8], footer[9], footer[10], footer[11]]);
     let parsed_magic = u32::from_be_bytes([footer[12], footer[13], footer[14], footer[15]]);
-    
+
     assert_eq!(parsed_offset, index_offset);
     assert_eq!(parsed_checksum, crc32_checksum);
     assert_eq!(parsed_magic, magic_verification);
@@ -266,7 +282,8 @@ fn test_oa_complete_header_roundtrip() {
                 key_position: Some(0),
                 is_static: false,
                 is_clustering: false,
-                clustering_reversed: false,            },
+                clustering_reversed: false,
+            },
             ColumnInfo {
                 name: "data".to_string(),
                 column_type: "text".to_string(),
@@ -274,7 +291,8 @@ fn test_oa_complete_header_roundtrip() {
                 key_position: None,
                 is_static: false,
                 is_clustering: false,
-                clustering_reversed: false,            }
+                clustering_reversed: false,
+            },
         ],
         properties: {
             let mut props = HashMap::new();
@@ -282,25 +300,28 @@ fn test_oa_complete_header_roundtrip() {
             props
         },
     };
-    
+
     // Serialize header
     let serialized = serialize_sstable_header(&header).unwrap();
-    
+
     // Verify starts with correct magic and version
     assert_eq!(&serialized[0..4], &BIG_FORMAT_OA_MAGIC.to_be_bytes());
     assert_eq!(&serialized[4..6], &SUPPORTED_VERSION.to_be_bytes());
-    
+
     // Parse header back
     let (remaining, parsed_header) = parse_sstable_header(&serialized).unwrap();
     assert!(remaining.is_empty());
-    
+
     // Verify all fields match
     assert_eq!(parsed_header.version, header.version);
     assert_eq!(parsed_header.table_id, header.table_id);
     assert_eq!(parsed_header.keyspace, header.keyspace);
     assert_eq!(parsed_header.table_name, header.table_name);
     assert_eq!(parsed_header.generation, header.generation);
-    assert_eq!(parsed_header.compression.algorithm, header.compression.algorithm);
+    assert_eq!(
+        parsed_header.compression.algorithm,
+        header.compression.algorithm
+    );
     assert_eq!(parsed_header.stats.row_count, header.stats.row_count);
     assert_eq!(parsed_header.columns.len(), header.columns.len());
     assert_eq!(parsed_header.properties, header.properties);
@@ -309,25 +330,25 @@ fn test_oa_complete_header_roundtrip() {
 #[test]
 fn test_oa_endianness_compliance() {
     // Test that all multi-byte values use big-endian encoding
-    
+
     // 16-bit values
     let test_u16 = 0x1234u16;
     let bytes_u16 = test_u16.to_be_bytes();
     assert_eq!(bytes_u16, [0x12, 0x34]);
     assert_eq!(u16::from_be_bytes(bytes_u16), test_u16);
-    
+
     // 32-bit values
     let test_u32 = 0x12345678u32;
     let bytes_u32 = test_u32.to_be_bytes();
     assert_eq!(bytes_u32, [0x12, 0x34, 0x56, 0x78]);
     assert_eq!(u32::from_be_bytes(bytes_u32), test_u32);
-    
+
     // 64-bit values
     let test_u64 = 0x123456789ABCDEFu64;
     let bytes_u64 = test_u64.to_be_bytes();
     assert_eq!(bytes_u64, [0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF]);
     assert_eq!(u64::from_be_bytes(bytes_u64), test_u64);
-    
+
     // Signed values
     let test_i64 = -1i64;
     let bytes_i64 = test_i64.to_be_bytes();
@@ -340,14 +361,14 @@ fn test_oa_checksum_compliance() {
     // Test CRC32 checksum calculation compliance
     let test_data = b"Hello, Cassandra 5.0 'oa' format!";
     let checksum = calculate_crc32(test_data);
-    
+
     // Verify checksum is deterministic
     assert_eq!(checksum, calculate_crc32(test_data));
-    
+
     // Verify different data produces different checksum
     let other_data = b"Different data";
     assert_ne!(checksum, calculate_crc32(other_data));
-    
+
     // Test empty data
     let empty_checksum = calculate_crc32(&[]);
     assert_eq!(empty_checksum, 0); // CRC32 of empty data is 0
@@ -357,16 +378,16 @@ fn test_oa_checksum_compliance() {
 fn test_oa_reserved_fields_compliance() {
     // All reserved fields must be zero
     let reserved_22_bytes = [0u8; 22];
-    
+
     // Verify all bytes are zero
     for (i, &byte) in reserved_22_bytes.iter().enumerate() {
         assert_eq!(byte, 0, "Reserved byte {} is not zero", i);
     }
-    
+
     // Test that non-zero reserved fields are rejected
     let mut bad_reserved = [0u8; 22];
     bad_reserved[10] = 1; // Set one byte to non-zero
-    
+
     // This should be detected in a proper validation
     assert_ne!(bad_reserved, reserved_22_bytes);
 }

--- a/tests/src/compatibility_framework.rs
+++ b/tests/src/compatibility_framework.rs
@@ -646,6 +646,7 @@ impl CompatibilityTestFramework {
                     key_position: Some(0),
                     is_static: false,
                     is_clustering: false,
+                    clustering_reversed: false,
                 },
                 ColumnInfo {
                     name: "name".to_string(),
@@ -654,6 +655,7 @@ impl CompatibilityTestFramework {
                     key_position: None,
                     is_static: false,
                     is_clustering: false,
+                    clustering_reversed: false,
                 },
             ],
             properties: HashMap::new(),

--- a/tests/src/comprehensive_parser_integration_tests.rs
+++ b/tests/src/comprehensive_parser_integration_tests.rs
@@ -1109,6 +1109,7 @@ impl ParserIntegrationTestSuite {
                     key_position: Some(0),
                     is_static: false,
                     is_clustering: false,
+                    clustering_reversed: false,
                 },
                 ColumnInfo {
                     name: "data".to_string(),
@@ -1117,6 +1118,7 @@ impl ParserIntegrationTestSuite {
                     key_position: None,
                     is_static: false,
                     is_clustering: false,
+                    clustering_reversed: false,
                 },
             ],
             properties: HashMap::new(),
@@ -1162,6 +1164,7 @@ impl ParserIntegrationTestSuite {
                     key_position: Some(0),
                     is_static: false,
                     is_clustering: false,
+                    clustering_reversed: false,
                 },
                 ColumnInfo {
                     name: "clustering_key".to_string(),
@@ -1170,6 +1173,7 @@ impl ParserIntegrationTestSuite {
                     key_position: Some(1),
                     is_static: false,
                     is_clustering: true,
+                    clustering_reversed: false,
                 },
                 ColumnInfo {
                     name: "static_column".to_string(),
@@ -1178,6 +1182,7 @@ impl ParserIntegrationTestSuite {
                     key_position: None,
                     is_static: true,
                     is_clustering: false,
+                    clustering_reversed: false,
                 },
                 ColumnInfo {
                     name: "regular_column".to_string(),
@@ -1186,6 +1191,7 @@ impl ParserIntegrationTestSuite {
                     key_position: None,
                     is_static: false,
                     is_clustering: false,
+                    clustering_reversed: false,
                 },
             ],
             properties,

--- a/tests/src/integration_e2e.rs
+++ b/tests/src/integration_e2e.rs
@@ -950,6 +950,7 @@ fn create_mock_cassandra5_header() -> SSTableHeader {
                 key_position: Some(0),
                 is_static: false,
                 is_clustering: false,
+                clustering_reversed: false,
             },
             ColumnInfo {
                 name: "data".to_string(),
@@ -958,6 +959,7 @@ fn create_mock_cassandra5_header() -> SSTableHeader {
                 key_position: None,
                 is_static: false,
                 is_clustering: false,
+                clustering_reversed: false,
             },
         ],
         properties: HashMap::new(),

--- a/tests/src/parser_validation.rs
+++ b/tests/src/parser_validation.rs
@@ -212,6 +212,7 @@ impl ParserValidationSuite {
                     key_position: Some(0),
                     is_static: false,
                     is_clustering: false,
+                    clustering_reversed: false,
                 },
                 ColumnInfo {
                     name: "data".to_string(),
@@ -220,6 +221,7 @@ impl ParserValidationSuite {
                     key_position: None,
                     is_static: false,
                     is_clustering: false,
+                    clustering_reversed: false,
                 },
             ],
             properties: {

--- a/tests/src/performance_benchmarks.rs
+++ b/tests/src/performance_benchmarks.rs
@@ -779,6 +779,7 @@ impl PerformanceBenchmarks {
                 key_position: if i < 3 { Some(i as u16) } else { None },
                 is_static: i % 10 == 0,
                 is_clustering: i < 3 && i > 0,
+                clustering_reversed: false,
             })
             .collect();
 

--- a/tests/src/real_sstable_test_fixtures.rs
+++ b/tests/src/real_sstable_test_fixtures.rs
@@ -125,6 +125,7 @@ impl SSTableTestFixtureGenerator {
                 key_position: Some(0),
                 is_static: false,
                 is_clustering: false,
+                clustering_reversed: false,
             },
             ColumnInfo {
                 name: "boolean_col".to_string(),
@@ -133,6 +134,7 @@ impl SSTableTestFixtureGenerator {
                 key_position: None,
                 is_static: false,
                 is_clustering: false,
+                clustering_reversed: false,
             },
             ColumnInfo {
                 name: "int_col".to_string(),
@@ -141,6 +143,7 @@ impl SSTableTestFixtureGenerator {
                 key_position: None,
                 is_static: false,
                 is_clustering: false,
+                clustering_reversed: false,
             },
             ColumnInfo {
                 name: "bigint_col".to_string(),
@@ -149,6 +152,7 @@ impl SSTableTestFixtureGenerator {
                 key_position: None,
                 is_static: false,
                 is_clustering: false,
+                clustering_reversed: false,
             },
             ColumnInfo {
                 name: "float_col".to_string(),
@@ -157,6 +161,7 @@ impl SSTableTestFixtureGenerator {
                 key_position: None,
                 is_static: false,
                 is_clustering: false,
+                clustering_reversed: false,
             },
             ColumnInfo {
                 name: "double_col".to_string(),
@@ -165,6 +170,7 @@ impl SSTableTestFixtureGenerator {
                 key_position: None,
                 is_static: false,
                 is_clustering: false,
+                clustering_reversed: false,
             },
             ColumnInfo {
                 name: "text_col".to_string(),
@@ -173,6 +179,7 @@ impl SSTableTestFixtureGenerator {
                 key_position: None,
                 is_static: false,
                 is_clustering: false,
+                clustering_reversed: false,
             },
             ColumnInfo {
                 name: "varchar_col".to_string(),
@@ -181,6 +188,7 @@ impl SSTableTestFixtureGenerator {
                 key_position: None,
                 is_static: false,
                 is_clustering: false,
+                clustering_reversed: false,
             },
             ColumnInfo {
                 name: "blob_col".to_string(),
@@ -189,6 +197,7 @@ impl SSTableTestFixtureGenerator {
                 key_position: None,
                 is_static: false,
                 is_clustering: false,
+                clustering_reversed: false,
             },
             ColumnInfo {
                 name: "timestamp_col".to_string(),
@@ -197,6 +206,7 @@ impl SSTableTestFixtureGenerator {
                 key_position: None,
                 is_static: false,
                 is_clustering: false,
+                clustering_reversed: false,
             },
             ColumnInfo {
                 name: "uuid_col".to_string(),
@@ -205,6 +215,7 @@ impl SSTableTestFixtureGenerator {
                 key_position: None,
                 is_static: false,
                 is_clustering: false,
+                clustering_reversed: false,
             },
         ];
 
@@ -307,6 +318,7 @@ impl SSTableTestFixtureGenerator {
                 key_position: Some(0),
                 is_static: false,
                 is_clustering: false,
+                clustering_reversed: false,
             },
             ColumnInfo {
                 name: "text_list".to_string(),
@@ -315,6 +327,7 @@ impl SSTableTestFixtureGenerator {
                 key_position: None,
                 is_static: false,
                 is_clustering: false,
+                clustering_reversed: false,
             },
             ColumnInfo {
                 name: "int_set".to_string(),
@@ -323,6 +336,7 @@ impl SSTableTestFixtureGenerator {
                 key_position: None,
                 is_static: false,
                 is_clustering: false,
+                clustering_reversed: false,
             },
             ColumnInfo {
                 name: "text_to_int_map".to_string(),
@@ -331,6 +345,7 @@ impl SSTableTestFixtureGenerator {
                 key_position: None,
                 is_static: false,
                 is_clustering: false,
+                clustering_reversed: false,
             },
             ColumnInfo {
                 name: "nested_list".to_string(),
@@ -339,6 +354,7 @@ impl SSTableTestFixtureGenerator {
                 key_position: None,
                 is_static: false,
                 is_clustering: false,
+                clustering_reversed: false,
             },
         ];
 
@@ -438,6 +454,7 @@ impl SSTableTestFixtureGenerator {
                 key_position: Some(0),
                 is_static: false,
                 is_clustering: false,
+                clustering_reversed: false,
             },
             ColumnInfo {
                 name: "large_text".to_string(),
@@ -446,6 +463,7 @@ impl SSTableTestFixtureGenerator {
                 key_position: None,
                 is_static: false,
                 is_clustering: false,
+                clustering_reversed: false,
             },
             ColumnInfo {
                 name: "large_blob".to_string(),
@@ -454,6 +472,7 @@ impl SSTableTestFixtureGenerator {
                 key_position: None,
                 is_static: false,
                 is_clustering: false,
+                clustering_reversed: false,
             },
             ColumnInfo {
                 name: "json_data".to_string(),
@@ -462,6 +481,7 @@ impl SSTableTestFixtureGenerator {
                 key_position: None,
                 is_static: false,
                 is_clustering: false,
+                clustering_reversed: false,
             },
         ];
 
@@ -559,6 +579,7 @@ impl SSTableTestFixtureGenerator {
                 key_position: Some(0),
                 is_static: false,
                 is_clustering: false,
+                clustering_reversed: false,
             }];
 
             // Create empty file as placeholder

--- a/tests/src/sstable_format_tests.rs
+++ b/tests/src/sstable_format_tests.rs
@@ -232,6 +232,7 @@ impl SSTableFormatTests {
                 key_position: Some(0),
                 is_static: false,
                 is_clustering: false,
+                clustering_reversed: false,
             },
             ColumnInfo {
                 name: "timestamp".to_string(),
@@ -240,6 +241,7 @@ impl SSTableFormatTests {
                 key_position: Some(1),
                 is_static: false,
                 is_clustering: true,
+                clustering_reversed: false,
             },
             ColumnInfo {
                 name: "data".to_string(),
@@ -248,6 +250,7 @@ impl SSTableFormatTests {
                 key_position: None,
                 is_static: false,
                 is_clustering: false,
+                clustering_reversed: false,
             },
             ColumnInfo {
                 name: "metadata".to_string(),
@@ -256,6 +259,7 @@ impl SSTableFormatTests {
                 key_position: None,
                 is_static: true,
                 is_clustering: false,
+                clustering_reversed: false,
             },
         ];
 
@@ -433,6 +437,7 @@ impl SSTableFormatTests {
                 key_position: if i == 0 { Some(0) } else { None },
                 is_static: false,
                 is_clustering: false,
+                clustering_reversed: false,
             });
         }
 
@@ -512,6 +517,7 @@ impl SSTableFormatTests {
                     key_position: Some(0),
                     is_static: false,
                     is_clustering: false,
+                    clustering_reversed: false,
                 },
                 ColumnInfo {
                     name: "name".to_string(),
@@ -520,6 +526,7 @@ impl SSTableFormatTests {
                     key_position: None,
                     is_static: false,
                     is_clustering: false,
+                    clustering_reversed: false,
                 },
             ],
             properties,

--- a/tests/sstable_reading/header_parsing_comprehensive_tests.rs
+++ b/tests/sstable_reading/header_parsing_comprehensive_tests.rs
@@ -1103,7 +1103,7 @@ fn create_test_header() -> SSTableHeader {
                 key_position: Some(0),
                 is_static: false,
                 is_clustering: false,
-            },
+                clustering_reversed: false,            },
             ColumnInfo {
                 name: "data".to_string(),
                 column_type: "text".to_string(),
@@ -1111,7 +1111,7 @@ fn create_test_header() -> SSTableHeader {
                 key_position: None,
                 is_static: false,
                 is_clustering: false,
-            },
+                clustering_reversed: false,            },
         ],
         properties: {
             let mut props = HashMap::new();
@@ -1133,7 +1133,7 @@ fn create_large_test_header() -> SSTableHeader {
             key_position: if i < 5 { Some(i as u16) } else { None },
             is_static: i % 10 == 0,
             is_clustering: i % 7 == 0,
-        });
+            clustering_reversed: false,        });
     }
 
     // Add many properties

--- a/tests/sstable_reading/header_parsing_error_handling_tests.rs
+++ b/tests/sstable_reading/header_parsing_error_handling_tests.rs
@@ -678,7 +678,7 @@ fn create_test_header() -> SSTableHeader {
                 key_position: Some(0),
                 is_static: false,
                 is_clustering: false,
-            }
+                clustering_reversed: false,            }
         ],
         properties: HashMap::new(),
     }
@@ -696,7 +696,7 @@ fn create_complex_header() -> SSTableHeader {
             key_position: None,
             is_static: i % 3 == 0,
             is_clustering: i % 2 == 0,
-        });
+            clustering_reversed: false,        });
     }
 
     for i in 0..20 {
@@ -721,7 +721,7 @@ fn create_extremely_large_header() -> SSTableHeader {
             key_position: if i < 5 { Some(i as u16) } else { None },
             is_static: i % 10 == 0,
             is_clustering: i % 7 == 0,
-        });
+            clustering_reversed: false,        });
     }
 
     // Large number of properties

--- a/tests/sstable_reading/header_parsing_performance_tests.rs
+++ b/tests/sstable_reading/header_parsing_performance_tests.rs
@@ -653,7 +653,7 @@ fn create_simple_header() -> SSTableHeader {
                 key_position: Some(0),
                 is_static: false,
                 is_clustering: false,
-            }
+                clustering_reversed: false,            }
         ],
         properties: HashMap::new(),
     }
@@ -673,7 +673,7 @@ fn create_typical_header() -> SSTableHeader {
             key_position: Some(0),
             is_static: false,
             is_clustering: false,
-        },
+            clustering_reversed: false,        },
         ColumnInfo {
             name: "created_at".to_string(),
             column_type: "timestamp".to_string(),
@@ -681,7 +681,7 @@ fn create_typical_header() -> SSTableHeader {
             key_position: None,
             is_static: false,
             is_clustering: true,
-        },
+            clustering_reversed: false,        },
         ColumnInfo {
             name: "data".to_string(),
             column_type: "text".to_string(),
@@ -689,7 +689,7 @@ fn create_typical_header() -> SSTableHeader {
             key_position: None,
             is_static: false,
             is_clustering: false,
-        },
+            clustering_reversed: false,        },
     ];
 
     // Add typical properties
@@ -727,7 +727,7 @@ fn create_complex_header() -> SSTableHeader {
             key_position: if i < 3 { Some(i as u16) } else { None },
             is_static: i % 7 == 0,
             is_clustering: i % 3 == 0,
-        });
+            clustering_reversed: false,        });
     }
 
     // Add more properties
@@ -754,7 +754,7 @@ fn create_large_header() -> SSTableHeader {
             key_position: if i < 10 { Some(i as u16) } else { None },
             is_static: i % 13 == 0,
             is_clustering: i % 17 == 0,
-        });
+            clustering_reversed: false,        });
     }
 
     // Large property set
@@ -794,7 +794,7 @@ fn create_header_with_columns(column_count: usize) -> SSTableHeader {
             key_position: if i < 5 { Some(i as u16) } else { None },
             is_static: i % 10 == 0,
             is_clustering: i % 7 == 0,
-        });
+            clustering_reversed: false,        });
     }
 
     header

--- a/tests/sstable_reading/header_parsing_unit_tests.rs
+++ b/tests/sstable_reading/header_parsing_unit_tests.rs
@@ -583,7 +583,7 @@ mod full_header_unit_tests {
                 key_position: if i < 3 { Some(i as u16) } else { None },
                 is_static: i % 5 == 0,
                 is_clustering: i % 3 == 0,
-            });
+                clustering_reversed: false,            });
         }
 
         let header = SSTableHeader {
@@ -798,7 +798,7 @@ mod property_unit_tests {
                     key_position: Some(0),
                     is_static: false,
                     is_clustering: false,
-                }
+                    clustering_reversed: false,                }
             ],
             properties: {
                 let mut props = HashMap::new();


### PR DESCRIPTION
## What changed

`TableSchema::from_sstable_header` previously defaulted every clustering column to `ClusteringOrder::Asc` (the long-standing `TODO(Future): Extract clustering order from header properties`). Cassandra's serialization header encodes a DESC clustering column by wrapping its comparator class in `ReversedType(...)` — the documented, authoritative signal (definitive guide Ch.7 / Appendix B; cross-checked against `~/local_projects/cassandra`).

- `ColumnInfo` (parser header) gains a `clustering_reversed: bool` field (`#[serde(default)]` for backward-compatible header deserialization).
- `build_clustering_key_columns` detects `ReversedType(...)` on the **raw** comparator class name via the new `is_reversed_comparator` helper. The eager CQL conversion in `parse_serialization_header_schema` was discarding the wrapper before this point, so the raw comparator string is now preserved through to the single conversion site (idempotent for already-CQL strings, so the other parse paths stay correct).
- `from_sstable_header` sets `ClusteringOrder::Desc` when `clustering_reversed` is true.

**No heuristics:** order is driven purely off the comparator class name. **ReversedType unwrapping does not disturb inner-type deserialization** — `convert_marshal_type_to_cql` still strips the wrapper, so `data_type` is the inner CQL type (verified by tests).

## Evidence

Integration test against the real `test_wide_rows.wide_partition_table` fixture, whose Statistics.db header wraps clustering_col1 (timestamp), clustering_col3 (int), clustering_col5 (date) in `ReversedType` and matches the declared `CLUSTERING ORDER BY (clustering_col1 DESC, clustering_col2 ASC, clustering_col3 DESC, clustering_col4 ASC, clustering_col5 DESC)`.

New integration test (TDD — failed first with `expected Desc, got Asc`, now passes):
```
test clustering_order_extracted_from_reversed_type ... ok
test result: ok. 1 passed; 0 failed
```

Unit tests:
```
test parser::enhanced_statistics_parser::tests::test_is_reversed_comparator ... ok
test parser::enhanced_statistics_parser::tests::test_build_clustering_key_columns_reversed_order ... ok
```

`cargo fmt --all`: clean. `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features`: PASS.

Agent gate: fmt PASS, clippy PASS, integration-tests PASS, write-tests PASS, cli-tests PASS, minimal-build PASS, smoke PASS. The only red was `test_flush_throughput` (4.2 vs 5 MB/sec) — a timing-sensitive write-throughput perf test unrelated to this change; it passes in isolation (`test_flush_throughput ... ok`).

> Note: sibling PRs #758 and #761 also edit `schema/mod.rs`; a rebase may be needed at merge.

Closes #759. Part of Epic #756.