### PR TITLE
fix(release): build linux-gnu CLI under cross to lower glibc floor (#864)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,14 @@ jobs:
     strategy:
       matrix:
         include:
-          # Linux builds use cross-compilation on Ubuntu
+          # Linux gnu build runs under cross so the binary links against an
+          # older glibc (cross's image floor is ~2.31) rather than the
+          # ubuntu-latest host's glibc (2.39 on 24.04). This keeps the binary
+          # runnable on enterprise distros like Rocky/RHEL 9 (glibc 2.34). (#864)
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             exe_suffix: ""
-            use_cross: false
+            use_cross: true
           # Static musl build — runs on any Linux without a libc dependency
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest


### PR DESCRIPTION
Closes #864.

## Problem

The prebuilt `cqlite-x86_64-unknown-linux-gnu` binary fails to start on Rocky Linux 9.7 (and RHEL/Alma 9, Debian 12, Amazon Linux 2023):

```
cqlite: /lib64/libc.so.6: version 'GLIBC_2.39' not found (required by cqlite)
```

**Root cause:** the gnu target was built *natively* on `ubuntu-latest`, which GitHub has moved to Ubuntu 24.04 (glibc 2.39). A dynamically-linked binary records the highest glibc symbol version it touches, so it then refuses to run on any host with older glibc. Rocky 9.x ships glibc 2.34.

## Fix

Flip `x86_64-unknown-linux-gnu` to `use_cross: true`, matching the `aarch64-unknown-linux-gnu` entry that already builds under `cross`. The cross image's glibc floor (~2.31) is **below** Rocky 9.7's 2.34, so the binary stays forward-compatible across modern enterprise distros.

One-line matrix change in `.github/workflows/release.yml` — no source changes.

## Verification

This only takes effect on a release tag, so it can't run in normal PR CI. To verify after merge + a test tag:

```bash
objdump -T target/x86_64-unknown-linux-gnu/release/cqlite | grep GLIBC_ | sort -u
# highest GLIBC_ version should be <= 2.31
```

## Notes

- The static `cqlite-x86_64-unknown-linux-musl.tar.gz` remains the universal-Linux option (no libc dependency at all) for users on even older glibc — RHEL 8 (2.28), Amazon Linux 2 (2.26) — below the cross gnu floor.
- Rejected alternative: pinning to `ubuntu-22.04` (glibc 2.35) — still > 2.34, so it wouldn't fix Rocky 9.7, and `ubuntu-20.04` runners are retired.

See triage discussion in #864.