### PR TITLE
Epic #835: Read-path completion for wide-partition & BTI performance (#827, #831, #832)

### DIFF
--- a/cqlite-core/src/storage/sstable/bti/mod.rs
+++ b/cqlite-core/src/storage/sstable/bti/mod.rs
@@ -17,10 +17,11 @@ pub use node::{
 };
 pub use parser::{
     decode_bti_partition_payload, encode_partition_key_for_bti_trie,
-    iterate_partitions_in_bti_file, iterate_rows_in_bti_file, iterate_rows_in_bti_trie,
-    lookup_partition_in_bti_file, lookup_raw_key_in_bti_partitions_db, BtiHeader, BtiIndexStats,
-    BtiPartitionLocation, BtiRowIndexEntry, PartitionsParser, RowsParser, FLAG_HAS_HASH_BYTE,
-    FLAG_OPEN_MARKER,
+    iterate_partitions_in_bti_file, iterate_rows_for_partition, iterate_rows_in_bti_file,
+    iterate_rows_in_bti_trie, lookup_partition_in_bti_file, lookup_raw_key_in_bti_partitions_db,
+    resolve_rows_db_entry, select_row_index_blocks_for_range, BtiHeader, BtiIndexStats,
+    BtiPartitionLocation, BtiRowIndexEntry, BtiRowIndexEntryWithKey, BtiRowIndexHeader,
+    PartitionsParser, RowsParser, FLAG_HAS_HASH_BYTE, FLAG_OPEN_MARKER,
 };
 
 use crate::parser::header::CassandraVersion;

--- a/cqlite-core/src/storage/sstable/bti/mod.rs
+++ b/cqlite-core/src/storage/sstable/bti/mod.rs
@@ -17,9 +17,10 @@ pub use node::{
 };
 pub use parser::{
     decode_bti_partition_payload, encode_partition_key_for_bti_trie,
-    iterate_partitions_in_bti_file, iterate_rows_in_bti_file, lookup_partition_in_bti_file,
-    lookup_raw_key_in_bti_partitions_db, BtiHeader, BtiIndexStats, BtiPartitionLocation,
-    BtiRowIndexEntry, PartitionsParser, RowsParser, FLAG_HAS_HASH_BYTE, FLAG_OPEN_MARKER,
+    iterate_partitions_in_bti_file, iterate_rows_in_bti_file, iterate_rows_in_bti_trie,
+    lookup_partition_in_bti_file, lookup_raw_key_in_bti_partitions_db, BtiHeader, BtiIndexStats,
+    BtiPartitionLocation, BtiRowIndexEntry, PartitionsParser, RowsParser, FLAG_HAS_HASH_BYTE,
+    FLAG_OPEN_MARKER,
 };
 
 use crate::parser::header::CassandraVersion;

--- a/cqlite-core/src/storage/sstable/bti/mod.rs
+++ b/cqlite-core/src/storage/sstable/bti/mod.rs
@@ -16,9 +16,10 @@ pub use node::{
     TrieNavigator,
 };
 pub use parser::{
-    decode_bti_partition_payload, encode_partition_key_for_bti_trie, lookup_partition_in_bti_file,
+    decode_bti_partition_payload, encode_partition_key_for_bti_trie,
+    iterate_partitions_in_bti_file, iterate_rows_in_bti_file, lookup_partition_in_bti_file,
     lookup_raw_key_in_bti_partitions_db, BtiHeader, BtiIndexStats, BtiPartitionLocation,
-    PartitionsParser, RowsParser, FLAG_HAS_HASH_BYTE,
+    BtiRowIndexEntry, PartitionsParser, RowsParser, FLAG_HAS_HASH_BYTE, FLAG_OPEN_MARKER,
 };
 
 use crate::parser::header::CassandraVersion;

--- a/cqlite-core/src/storage/sstable/bti/node.rs
+++ b/cqlite-core/src/storage/sstable/bti/node.rs
@@ -227,8 +227,16 @@ pub enum BtiNodeData {
     Dense {
         /// Starting byte value for the consecutive range
         start_byte: u8,
-        /// Child pointers for the consecutive range
-        children: Vec<SizedPointer>,
+        /// Child pointers for the consecutive range.
+        ///
+        /// Each slot represents the transition `start_byte + index`.  `None`
+        /// means "no transition" (the raw Dense delta was `0`, the sentinel);
+        /// `Some(ptr)` is a real child.  Presence is tracked explicitly because
+        /// a REAL child can legitimately live at absolute trie offset `0` (the
+        /// first-written leaf in BTI's bottom-up layout): an offset of `0` is a
+        /// valid child and must NOT be confused with the absent-transition
+        /// sentinel.
+        children: Vec<Option<SizedPointer>>,
     },
 }
 
@@ -267,11 +275,15 @@ impl BtiNode {
     }
 
     /// Create a dense node
+    ///
+    /// `children[i]` is the transition for byte `start_byte + i`: `None` for a
+    /// missing transition (raw delta `0`), `Some(ptr)` for a real child (which
+    /// may point at absolute offset `0`).
     pub fn dense(
         level: u16,
         key_prefix: Vec<u8>,
         start_byte: u8,
-        children: Vec<SizedPointer>,
+        children: Vec<Option<SizedPointer>>,
     ) -> Self {
         Self {
             node_type: BtiNodeType::Dense,
@@ -312,7 +324,9 @@ impl BtiNode {
                 if byte >= *start_byte && (byte as usize) < (*start_byte as usize + children.len())
                 {
                     let index = byte as usize - *start_byte as usize;
-                    children.get(index)
+                    // `None` means "no transition" for this byte; `Some(ptr)` is
+                    // a real child (possibly at absolute offset 0).
+                    children.get(index).and_then(|slot| slot.as_ref())
                 } else {
                     None
                 }
@@ -520,9 +534,9 @@ mod tests {
     #[test]
     fn test_dense_node_lookup() {
         let children = vec![
-            SizedPointer::new(100),
-            SizedPointer::new(200),
-            SizedPointer::new(300),
+            Some(SizedPointer::new(100)),
+            Some(SizedPointer::new(200)),
+            Some(SizedPointer::new(300)),
         ];
 
         let node = BtiNode::dense(1, Vec::new(), b'a', children);
@@ -532,6 +546,41 @@ mod tests {
         assert!(node.find_child(b'c').is_some());
         assert!(node.find_child(b'd').is_none());
         assert!(node.find_child(b'@').is_none()); // Before range
+    }
+
+    /// Finding 1 (issue #832): a Dense node where the FIRST real child points at
+    /// absolute trie offset 0 (a legitimate position — the first-written leaf in
+    /// BTI's bottom-up layout) and a later slot is the "no transition" sentinel
+    /// (`None`).  `find_child` must return the offset-0 child for the real byte
+    /// and `None` for the gap byte — the offset-0 pointer must NOT be treated as
+    /// "no transition".
+    #[test]
+    fn test_dense_node_offset_zero_child_distinct_from_no_transition() {
+        // start_byte = b'a':
+        //   b'a' → real child at offset 0 (SizedPointer distance 0)
+        //   b'b' → no transition (None)
+        //   b'c' → real child at offset 300
+        let children = vec![
+            Some(SizedPointer::new(0)), // real child at absolute offset 0
+            None,                       // no transition
+            Some(SizedPointer::new(300)),
+        ];
+        let node = BtiNode::dense(1, Vec::new(), b'a', children);
+
+        let a = node.find_child(b'a');
+        assert!(a.is_some(), "offset-0 child must be found, not dropped");
+        assert_eq!(
+            a.unwrap().distance,
+            0,
+            "the real child at absolute offset 0 must be returned"
+        );
+        assert!(
+            node.find_child(b'b').is_none(),
+            "no-transition slot must return None"
+        );
+        assert!(node.find_child(b'c').is_some());
+        // child_count is the dense RANGE length (slots), independent of gaps.
+        assert_eq!(node.child_count(), 3);
     }
 
     #[test]

--- a/cqlite-core/src/storage/sstable/bti/parser.rs
+++ b/cqlite-core/src/storage/sstable/bti/parser.rs
@@ -1367,6 +1367,68 @@ fn read_unsigned_vint_from_slice(data: &[u8]) -> BtiResult<(u64, usize)> {
     Ok((value, total))
 }
 
+/// The modern (DA/BTI) `DeletionTime` "live" sentinel byte.
+///
+/// In the `da`-family on-disk serializer, a `DeletionTime` written by the BTI
+/// row-index / trie-index path is encoded as a single `0x80` byte when it is
+/// `DeletionTime.LIVE` (no deletion), and otherwise as the full value (see
+/// [`decode_da_deletion_time`]).  Mirrors the live/no-deletion fast-path of
+/// `org.apache.cassandra.db.DeletionTime.Serializer` in the trie-index
+/// (`cassandra-5.0.0`) format, where the live sentinel avoids writing the
+/// 12-byte body.
+const DA_DELETION_TIME_LIVE_SENTINEL: u8 = 0x80;
+
+/// Width of a non-live modern (DA) `DeletionTime` body: `i64 markedForDeleteAt`
+/// followed by `u32 localDeletionTime`.
+const DA_DELETION_TIME_BODY_LEN: usize = 12;
+
+/// Decode a modern (DA/BTI) `DeletionTime` at `data[start..]`, returning
+/// `(deletion, bytes_consumed)` where `deletion` is `None` for the LIVE
+/// sentinel (issue #832 Finding 2).
+///
+/// Layout (mirrors `org.apache.cassandra.db.DeletionTime.Serializer` in the
+/// `da`/trie-index format, cassandra-5.0.0):
+///
+///   - a single `0x80` byte → `DeletionTime.LIVE` (no deletion); consumes 1 byte.
+///   - otherwise the body is `[markedForDeleteAt : i64 BE][localDeletionTime :
+///     u32 BE]` — `markedForDeleteAt` FIRST, then `localDeletionTime`; consumes
+///     12 bytes.  This differs from the LEGACY layout
+///     (`[localDeletionTime i32][markedForDeleteAt i64]`) in BOTH field order
+///     and the width/signedness of `localDeletionTime` (modern: `u32`).
+///
+/// Returns the deletion as `(local_deletion_time, marked_for_delete_at)` to
+/// match [`BtiRowIndexEntry::open_marker`]'s existing tuple ordering, even
+/// though the modern wire order is the reverse.
+///
+/// # Errors
+/// Returns a parse error if `start` is out of bounds or a non-live value is
+/// truncated.
+fn decode_da_deletion_time(data: &[u8], start: usize) -> BtiResult<(Option<(i32, i64)>, usize)> {
+    if start >= data.len() {
+        return Err(Error::Parse(format!(
+            "DA DeletionTime: start {start} beyond buffer size {}",
+            data.len()
+        )));
+    }
+    if data[start] == DA_DELETION_TIME_LIVE_SENTINEL {
+        return Ok((None, 1));
+    }
+    if start + DA_DELETION_TIME_BODY_LEN > data.len() {
+        return Err(Error::Parse(format!(
+            "DA DeletionTime: non-live value needs {DA_DELETION_TIME_BODY_LEN} bytes, have {}",
+            data.len().saturating_sub(start)
+        )));
+    }
+    let b = &data[start..start + DA_DELETION_TIME_BODY_LEN];
+    // markedForDeleteAt FIRST (i64), then localDeletionTime (u32).
+    let marked_for_delete_at = i64::from_be_bytes([b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]]);
+    let local_deletion_time = u32::from_be_bytes([b[8], b[9], b[10], b[11]]) as i32;
+    Ok((
+        Some((local_deletion_time, marked_for_delete_at)),
+        DA_DELETION_TIME_BODY_LEN,
+    ))
+}
+
 /// Decode a `Rows.db` in-trie payload (`RowIndexReader.IndexInfo`) at
 /// `payload_start` inside `trie_data`, given the node's `payload_bits` (low
 /// nibble of the header byte).
@@ -1377,7 +1439,8 @@ fn read_unsigned_vint_from_slice(data: &[u8]) -> BtiResult<(u64, usize)> {
 ///     `SizedInts` value of `bytes` bytes (the offset is relative to the
 ///     partition's data position).
 ///   - if `payload_bits & FLAG_OPEN_MARKER`, an open-deletion `DeletionTime`
-///     follows (legacy fixed 12-byte form when present in `trie_data`).
+///     follows in the MODERN DA form ([`decode_da_deletion_time`]): a `0x80`
+///     LIVE sentinel, else `[i64 markedForDeleteAt][u32 localDeletionTime]`.
 ///
 /// A `payload_bits` of `0` is not a valid leaf payload here (the caller filters
 /// such nodes out) and yields an error.
@@ -1417,18 +1480,12 @@ fn decode_bti_row_payload(
     let data_offset = raw as u64;
 
     let open_marker = if payload_bits & FLAG_OPEN_MARKER != 0 {
+        // DA/BTI modern DeletionTime (issue #832 Finding 2): a 0x80 sentinel
+        // means LIVE (no open deletion); otherwise [i64 markedForDeleteAt][u32
+        // localDeletionTime].  This is NOT the legacy [i32 ldt][i64 mfda] form.
         let dt_start = payload_start + offset_bytes;
-        if dt_start + 12 > trie_data.len() {
-            return Err(Error::Parse(format!(
-                "Rows.db payload: open-marker DeletionTime needs 12 bytes, have {}",
-                trie_data.len().saturating_sub(dt_start)
-            )));
-        }
-        let dt = &trie_data[dt_start..dt_start + 12];
-        let local_deletion_time = i32::from_be_bytes([dt[0], dt[1], dt[2], dt[3]]);
-        let marked_for_delete_at =
-            i64::from_be_bytes([dt[4], dt[5], dt[6], dt[7], dt[8], dt[9], dt[10], dt[11]]);
-        Some((local_deletion_time, marked_for_delete_at))
+        let (deletion, _consumed) = decode_da_deletion_time(trie_data, dt_start)?;
+        deletion
     } else {
         None
     };
@@ -1580,8 +1637,9 @@ pub struct BtiRowIndexHeader {
     /// Number of row-index blocks indexed by this partition's trie.
     pub block_count: u32,
     /// Partition-level deletion `(local_deletion_time, marked_for_delete_at)`,
-    /// when it could be decoded as the legacy fixed 12-byte form; `None` for the
-    /// compact "live" sentinel or when too few trailing bytes remain.
+    /// decoded via the MODERN DA `DeletionTime` form
+    /// ([`decode_da_deletion_time`], issue #832 Finding 2); `None` for the `0x80`
+    /// LIVE sentinel or when too few trailing bytes remain.
     pub partition_deletion: Option<(i32, i64)>,
 }
 
@@ -1657,16 +1715,15 @@ pub fn resolve_rows_db_entry(rows_db: &[u8], rows_offset: usize) -> BtiResult<Bt
         ))
     })?;
 
-    // Partition DeletionTime: the `da`-family form is delta/compact and not
-    // required for traversal correctness, so decode the legacy fixed 12-byte
-    // form best-effort and otherwise leave it `None` rather than failing.
-    let partition_deletion = if cur + 12 <= rows_db.len() {
-        let dt = &rows_db[cur..cur + 12];
-        let ldt = i32::from_be_bytes([dt[0], dt[1], dt[2], dt[3]]);
-        let mfda = i64::from_be_bytes([dt[4], dt[5], dt[6], dt[7], dt[8], dt[9], dt[10], dt[11]]);
-        Some((ldt, mfda))
-    } else {
-        None
+    // Partition DeletionTime: decode the MODERN DA/BTI form (issue #832
+    // Finding 2) — a 0x80 byte means LIVE (no deletion, the common case when no
+    // deletes were issued); otherwise [i64 markedForDeleteAt][u32
+    // localDeletionTime].  Decoded best-effort: if too few trailing bytes
+    // remain, leave it `None` rather than failing (it is not required for
+    // traversal correctness).
+    let partition_deletion = match decode_da_deletion_time(rows_db, cur) {
+        Ok((deletion, _consumed)) => deletion,
+        Err(_) => None,
     };
 
     Ok(BtiRowIndexHeader {
@@ -1675,6 +1732,121 @@ pub fn resolve_rows_db_entry(rows_db: &[u8], rows_offset: usize) -> BtiResult<Bt
         block_count,
         partition_deletion,
     })
+}
+
+/// Cassandra component separator used between clustering components in the
+/// OSS50 byte-comparable form.  Mirrors `ByteSource.NEXT_COMPONENT` (value
+/// `0x40`) emitted by `ClusteringComparator.asByteComparable` /
+/// `ByteSource.withTerminator`/`ByteSource.of(...)` in
+/// `org.apache.cassandra.utils.bytecomparable.ByteSource` (cassandra-5.0.0).
+const OSS50_NEXT_COMPONENT: u8 = 0x40;
+
+/// Encode a single clustering-component [`Value`] in Cassandra OSS50
+/// **byte-comparable** form (the SAME encoding the `Rows.db` row-index trie
+/// stores its separators in), appending to `out`.
+///
+/// This is NOT CQLite's custom [`ByteComparableEncoder`] (which prepends a
+/// 1-byte type discriminator and so is byte-incompatible with the on-disk
+/// trie).  It reproduces the per-type `AbstractType.asComparableBytes(...)`
+/// production used by Cassandra to build the byte-comparable keys:
+///
+/// - `Int32Type` → `(v as u32 ^ 0x8000_0000)` big-endian (sign-flip, 4B), per
+///   `Int32Type.asComparableBytes` / `ByteSource.optionalSignedFixedLengthNumber`.
+/// - `LongType` → `(v as u64 ^ 0x8000_0000_0000_0000)` big-endian (8B), per
+///   `LongType.asComparableBytes`.
+/// - `ShortType`/`ByteType` (`smallint`/`tinyint`) → sign-flip big-endian (2B /
+///   1B), per `ShortType`/`ByteType.asComparableBytes`.
+/// - `BooleanType` → single byte `0x00`/`0x01`, per `BooleanType.asComparableBytes`.
+/// - `TimestampType` (`timestamp`) → `LongType`-style sign-flip 8B (`TimestampType`
+///   extends `LongType`'s comparable form).
+/// - `UUIDType`/`TimeUUIDType` → the 16 raw bytes (network order is already
+///   byte-comparable for the on-disk separator form here).
+/// - `UTF8Type`/`AsciiType` (`text`/`ascii`) and `BytesType` (`blob`) → the raw
+///   value bytes, terminated by the OSS50 variable-length component terminator
+///   (`0x00`) so a shorter value sorts before a longer one sharing its prefix
+///   (`ByteSource.of(ByteBuffer)` + the terminator convention in
+///   `ByteComparable.Version.OSS50`).
+///
+/// Any clustering type not enumerated here returns an explicit parse error
+/// (NO silent wrong results — issue #28 no-heuristics mandate).
+fn encode_clustering_component_oss50(value: &Value, out: &mut Vec<u8>) -> BtiResult<()> {
+    match value {
+        // int — Int32Type: sign-flip, big-endian (matches `wide_table` separators,
+        // e.g. ck=8 → 80 00 00 08).
+        Value::Integer(v) => {
+            out.extend_from_slice(&((*v as u32) ^ 0x8000_0000).to_be_bytes());
+            Ok(())
+        }
+        // bigint — LongType: sign-flip, big-endian, 8 bytes.
+        Value::BigInt(v) | Value::Counter(v) => {
+            out.extend_from_slice(&((*v as u64) ^ 0x8000_0000_0000_0000).to_be_bytes());
+            Ok(())
+        }
+        // smallint — ShortType: sign-flip, big-endian, 2 bytes.
+        Value::SmallInt(v) => {
+            out.extend_from_slice(&((*v as u16) ^ 0x8000).to_be_bytes());
+            Ok(())
+        }
+        // tinyint — ByteType: sign-flip, 1 byte.
+        Value::TinyInt(v) => {
+            out.push((*v as u8) ^ 0x80);
+            Ok(())
+        }
+        // boolean — BooleanType: single 0x00/0x01 byte.
+        Value::Boolean(b) => {
+            out.push(if *b { 0x01 } else { 0x00 });
+            Ok(())
+        }
+        // timestamp — TimestampType shares LongType's comparable form (8-byte
+        // sign-flip big-endian of the millisecond value).
+        Value::Timestamp(v) => {
+            out.extend_from_slice(&((*v as u64) ^ 0x8000_0000_0000_0000).to_be_bytes());
+            Ok(())
+        }
+        // uuid / timeuuid — raw 16 bytes (already byte-comparable in the on-disk
+        // separator form for this fixed-length type).
+        Value::Uuid(bytes) => {
+            out.extend_from_slice(bytes);
+            Ok(())
+        }
+        // text / ascii — raw UTF-8/ASCII bytes + variable-length component
+        // terminator (0x00) so prefixes sort first.
+        Value::Text(s) => {
+            out.extend_from_slice(s.as_bytes());
+            out.push(0x00);
+            Ok(())
+        }
+        // blob — raw bytes + variable-length component terminator (0x00).
+        Value::Blob(b) | Value::Inet(b) => {
+            out.extend_from_slice(b);
+            out.push(0x00);
+            Ok(())
+        }
+        other => Err(Error::Parse(format!(
+            "BTI range_query: byte-comparable encoding not implemented for {:?}",
+            other.data_type()
+        ))),
+    }
+}
+
+/// Encode a multi-component clustering bound (`&[Value]`) in Cassandra OSS50
+/// byte-comparable form — the SAME encoding the `Rows.db` trie stores.
+///
+/// A single-component clustering encodes to the bare component bytes (matching
+/// the `wide_table` fixture separators, e.g. ck=8 → `80 00 00 08`, NO framing).
+/// Multi-component clusterings concatenate per-component byte-comparable
+/// encodings separated by [`OSS50_NEXT_COMPONENT`] (`ByteSource.NEXT_COMPONENT`,
+/// per `ClusteringComparator.asByteComparable`), with no leading/trailing frame
+/// so a prefix bound sorts before any longer key sharing it.
+fn encode_clustering_bound_oss50(values: &[Value]) -> BtiResult<Vec<u8>> {
+    let mut out = Vec::new();
+    for (i, v) in values.iter().enumerate() {
+        if i > 0 {
+            out.push(OSS50_NEXT_COMPONENT);
+        }
+        encode_clustering_component_oss50(v, &mut out)?;
+    }
+    Ok(out)
 }
 
 /// Select the row-index blocks that may contain clustering keys in the
@@ -1800,6 +1972,22 @@ impl BtiHeader {
 
     /// Current BTI version
     pub const VERSION: u16 = 0x0001;
+
+    /// A benign placeholder header for files that carry no fictional
+    /// [`BtiHeader`] (i.e. every real Cassandra `Rows.db`/`Partitions.db`, which
+    /// are footer-rooted).  Used by [`RowsParser::new`] so the trie-based,
+    /// whole-file entry points work on real files that legitimately lack the
+    /// header; the fields are never consulted by those entry points.
+    pub fn placeholder() -> Self {
+        BtiHeader {
+            magic: Self::MAGIC,
+            version: Self::VERSION,
+            flags: 0,
+            root_offset: 0,
+            entry_count: 0,
+            metadata_size: 0,
+        }
+    }
 
     /// Parse BTI header from bytes
     pub fn parse(data: &[u8]) -> BtiResult<(Self, usize)> {
@@ -2013,14 +2201,35 @@ pub struct RowsParser<R: Read + Seek> {
 }
 
 impl<R: Read + Seek> RowsParser<R> {
-    /// Create new rows parser
+    /// Create new rows parser.
+    ///
+    /// A real Cassandra 5.0 `Rows.db` has **no** whole-file [`BtiHeader`] (that
+    /// fictional 28-byte header is only emitted by CQLite's own test/index
+    /// writers); its leading bytes are trie node data and its layout is described
+    /// per-partition via the `RowsOffset` from `Partitions.db`.  The trie-based
+    /// entry points used here ([`range_query`](Self::range_query),
+    /// [`range_query_encoded`](Self::range_query_encoded),
+    /// [`iterate_rows`](Self::iterate_rows)) read the whole file and root from a
+    /// resolved per-partition entry, so they do not consult `self.header`.
+    ///
+    /// We therefore *attempt* to parse the fictional header (for files that do
+    /// carry it) but fall back to a benign default when it is absent — rather
+    /// than rejecting every real `Rows.db` with an "invalid BTI magic" error.
     pub fn new(mut reader: R) -> BtiResult<Self> {
-        // Read and parse header
+        // Attempt to read the (optional, CQLite-only) fictional header.  Real
+        // Rows.db files have no such header; a parse failure there is expected
+        // and must not block construction.
         reader.seek(SeekFrom::Start(0))?;
         let mut header_data = vec![0u8; 28];
-        reader.read_exact(&mut header_data)?;
-
-        let (header, _) = BtiHeader::parse(&header_data)?;
+        let header = match reader.read_exact(&mut header_data) {
+            Ok(()) => BtiHeader::parse(&header_data)
+                .map(|(h, _)| h)
+                .unwrap_or_else(|_| BtiHeader::placeholder()),
+            // File shorter than 28 bytes (e.g. tiny/empty Rows.db): also fine.
+            Err(_) => BtiHeader::placeholder(),
+        };
+        // Leave the reader positioned at the start for whole-file reads.
+        reader.seek(SeekFrom::Start(0))?;
 
         Ok(Self {
             reader,
@@ -2149,28 +2358,36 @@ impl<R: Read + Seek> RowsParser<R> {
         Ok((header, blocks))
     }
 
-    /// Clustering-key range/slice traversal using the **custom CQLite**
-    /// byte-comparable encoder ([`ByteComparableEncoder`]).
+    /// Typed clustering-key range/slice traversal (issue #832 Finding 1).
     ///
-    /// NOTE: the CQLite encoder is NOT byte-identical to Cassandra's on-disk
-    /// OSS50 clustering encoding (it prefixes a type discriminator), so for
-    /// fixture-faithful filtering against real `Rows.db` separators callers
-    /// should encode bounds in the Cassandra form and use
-    /// [`range_query_encoded`](Self::range_query_encoded).  This method is kept
-    /// for in-process round-trips where both the writer and the bounds use the
-    /// CQLite encoder.
+    /// Encodes the `Value` clustering bounds in Cassandra **OSS50
+    /// byte-comparable** form — the SAME encoding the `Rows.db` row-index trie
+    /// stores its separators in — via [`encode_clustering_bound_oss50`], then
+    /// delegates to the separator-aware [`range_query_encoded`].  This is the
+    /// fix for the prior bug where bounds were encoded with CQLite's custom
+    /// [`ByteComparableEncoder`] (which prepends a type discriminator and so is
+    /// byte-incompatible with the on-disk trie), causing the typed API to
+    /// compare incompatible byte formats and return empty/wrong block sets for
+    /// real callers.
+    ///
+    /// Supported clustering types: `int`, `bigint`/`counter`, `smallint`,
+    /// `tinyint`, `boolean`, `timestamp`, `uuid`/`timeuuid`, `text`/`ascii`,
+    /// `blob`/`inet`.  Any other clustering type returns an explicit
+    /// `Error::Parse("BTI range_query: byte-comparable encoding not implemented
+    /// for <type>")` (no silent wrong results — issue #28).
     ///
     /// `rows_offset` is the partition's `RowsOffset` (resolved to the real trie
     /// root via [`resolve_rows_db_entry`], Finding A).  Separator semantics
     /// (Finding B) are applied via [`select_row_index_blocks_for_range`].
+    /// Reversed bounds yield an empty result.
     pub fn range_query(
         &mut self,
         rows_offset: usize,
         start_key: &[Value],
         end_key: &[Value],
     ) -> BtiResult<Vec<BtiRowIndexEntry>> {
-        let encoded_start = self.encoder.encode_composite_key(start_key)?;
-        let encoded_end = self.encoder.encode_composite_key(end_key)?;
+        let encoded_start = encode_clustering_bound_oss50(start_key)?;
+        let encoded_end = encode_clustering_bound_oss50(end_key)?;
         if encoded_start > encoded_end {
             return Ok(Vec::new());
         }
@@ -3855,23 +4072,115 @@ mod tests {
         assert!(node.find_child(0x12).is_some());
     }
 
-    /// Rows.db payload with FLAG_OPEN_MARKER decodes a trailing 12-byte
-    /// DeletionTime.
+    /// Rows.db payload with FLAG_OPEN_MARKER decodes a trailing MODERN DA
+    /// DeletionTime (issue #832 Finding 2): `[i64 markedForDeleteAt][u32
+    /// localDeletionTime]` — markedForDeleteAt FIRST.
     #[test]
-    fn decode_row_payload_open_marker() {
+    fn decode_row_payload_open_marker_modern() {
         // payloadBits = 0x9 → FLAG_OPEN_MARKER (0x8) set.
-        // payload: [pos vint = 7][localDeletionTime i32][markedForDeleteAt i64]
+        // payload: [pos vint = 7][i64 markedForDeleteAt=567890][u32 localDeletionTime=1234]
         let mut data = vec![0x07u8]; // pos = 7
-        data.extend_from_slice(&1234i32.to_be_bytes());
         data.extend_from_slice(&567890i64.to_be_bytes());
+        data.extend_from_slice(&1234u32.to_be_bytes());
         let entry = decode_bti_row_payload(&data, 0, 0x9).unwrap();
         assert_eq!(
             entry,
             BtiRowIndexEntry {
                 data_offset: 7,
+                // open_marker tuple is (local_deletion_time, marked_for_delete_at).
                 open_marker: Some((1234, 567890)),
             }
         );
+    }
+
+    /// Rows.db payload with FLAG_OPEN_MARKER but a `0x80` LIVE sentinel decodes
+    /// to NO open deletion (issue #832 Finding 2): the live fast-path consumes
+    /// only 1 byte and yields `open_marker == None`.
+    #[test]
+    fn decode_row_payload_open_marker_live_sentinel() {
+        // payloadBits = 0x9 → FLAG_OPEN_MARKER set; payload: [pos=7][0x80 live].
+        let data = vec![0x07u8, 0x80u8];
+        let entry = decode_bti_row_payload(&data, 0, 0x9).unwrap();
+        assert_eq!(
+            entry,
+            BtiRowIndexEntry {
+                data_offset: 7,
+                open_marker: None,
+            }
+        );
+    }
+
+    /// Direct coverage of the modern DA `DeletionTime` decoder (issue #832
+    /// Finding 2): the `0x80` sentinel → live (None, 1 byte); a non-live value
+    /// → `[i64 markedForDeleteAt][u32 localDeletionTime]` in the CORRECT order
+    /// and widths (12 bytes); a truncated non-live value errors; an
+    /// out-of-bounds start errors.
+    #[test]
+    fn da_deletion_time_decoder() {
+        // Live sentinel.
+        assert_eq!(decode_da_deletion_time(&[0x80], 0).unwrap(), (None, 1));
+        // Live sentinel mid-buffer (trailing bytes ignored, consumes 1).
+        assert_eq!(
+            decode_da_deletion_time(&[0x00, 0x80, 0xFF], 1).unwrap(),
+            (None, 1)
+        );
+
+        // Non-live: markedForDeleteAt FIRST (i64), then localDeletionTime (u32).
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&987_654_321_000i64.to_be_bytes()); // mfda
+        buf.extend_from_slice(&1_700_000_000u32.to_be_bytes()); // ldt
+        let (del, n) = decode_da_deletion_time(&buf, 0).unwrap();
+        assert_eq!(n, 12);
+        assert_eq!(del, Some((1_700_000_000i32, 987_654_321_000i64)));
+
+        // The leading byte of mfda here is 0x00 (not 0x80), so this is correctly
+        // treated as non-live rather than the live sentinel.
+        assert_ne!(buf[0], 0x80);
+
+        // Truncated non-live value (leading byte != 0x80 but < 12 bytes) errors.
+        assert!(decode_da_deletion_time(&[0x00, 0x01, 0x02], 0).is_err());
+        // Out-of-bounds start errors.
+        assert!(decode_da_deletion_time(&[0x00], 5).is_err());
+    }
+
+    /// The OSS50 byte-comparable clustering encoder (issue #832 Finding 1)
+    /// reproduces the on-disk trie separator bytes: `int` is sign-flip BE
+    /// (ck=8 → 80 00 00 08), and a multi-component clustering joins components
+    /// with the `0x40` NEXT_COMPONENT separator.  Unsupported clustering types
+    /// error out explicitly (no silent wrong results).
+    #[test]
+    fn oss50_clustering_encoder() {
+        // Single int component — bare, sign-flip big-endian (matches fixture).
+        assert_eq!(
+            encode_clustering_bound_oss50(&[Value::Integer(8)]).unwrap(),
+            vec![0x80, 0x00, 0x00, 0x08]
+        );
+        assert_eq!(
+            encode_clustering_bound_oss50(&[Value::Integer(-1)]).unwrap(),
+            vec![0x7F, 0xFF, 0xFF, 0xFF]
+        );
+        // Ordering is preserved: -1 < 0 < 100 byte-comparably.
+        let neg = encode_clustering_bound_oss50(&[Value::Integer(-1)]).unwrap();
+        let zero = encode_clustering_bound_oss50(&[Value::Integer(0)]).unwrap();
+        let pos = encode_clustering_bound_oss50(&[Value::Integer(100)]).unwrap();
+        assert!(neg < zero && zero < pos);
+
+        // bigint — 8-byte sign-flip BE.
+        assert_eq!(
+            encode_clustering_bound_oss50(&[Value::BigInt(1)]).unwrap(),
+            vec![0x80, 0, 0, 0, 0, 0, 0, 0x01]
+        );
+
+        // Multi-component: int(1) + text("ab") joined with 0x40 NEXT_COMPONENT,
+        // text terminated by 0x00.
+        assert_eq!(
+            encode_clustering_bound_oss50(&[Value::Integer(1), Value::Text("ab".to_string())])
+                .unwrap(),
+            vec![0x80, 0x00, 0x00, 0x01, 0x40, b'a', b'b', 0x00]
+        );
+
+        // Unsupported clustering type errors out explicitly.
+        assert!(encode_clustering_bound_oss50(&[Value::Float(1.0)]).is_err());
     }
 
     /// Multi-byte unsigned vint decode (count-leading-ones, NOT zigzag).
@@ -3992,7 +4301,8 @@ mod tests {
     /// per-partition `TrieIndexEntry` and recovers the trie root via
     /// `indexTrieRoot = readVInt() + (RowsOffset + key_length)`.  Mirrors the
     /// real `wide_table` layout: `[u16 keylen][key][dataPos uvint][rootΔ svint]
-    /// [blockCount uvint][deletion 12B]`.
+    /// [blockCount uvint][modern DA deletion]`.  The deletion here is a non-live
+    /// MODERN value `[i64 markedForDeleteAt][u32 localDeletionTime]` (Finding 2).
     #[test]
     fn resolve_rows_db_entry_recovers_root_and_metadata() {
         // Place a 1-byte pad so the trie "root" lives at a non-zero offset.
@@ -4014,9 +4324,10 @@ mod tests {
         buf.push(zig as u8);
         // blockCount = 38 (unsigned vint)
         buf.push(38);
-        // partition DeletionTime (legacy fixed 12 bytes): ldt=0x09, mfda=0x11
-        buf.extend_from_slice(&9i32.to_be_bytes());
+        // partition DeletionTime (MODERN DA non-live): [i64 mfda=17][u32 ldt=9].
+        // (Leading byte 0x00 != 0x80 live sentinel.)
         buf.extend_from_slice(&17i64.to_be_bytes());
+        buf.extend_from_slice(&9u32.to_be_bytes());
 
         let header = resolve_rows_db_entry(&buf, rows_offset).unwrap();
         assert_eq!(header.data_position, 123);
@@ -4025,10 +4336,35 @@ mod tests {
             "trie root = rootΔ + (RowsOffset + keylen)"
         );
         assert_eq!(header.block_count, 38);
+        // (local_deletion_time, marked_for_delete_at) = (9, 17).
         assert_eq!(header.partition_deletion, Some((9, 17)));
 
         // Out-of-bounds RowsOffset → clean error, no panic.
         assert!(resolve_rows_db_entry(&buf, buf.len() + 10).is_err());
+    }
+
+    /// Finding 2 (issue #832): a `TrieIndexEntry` whose partition DeletionTime is
+    /// the MODERN `0x80` LIVE sentinel decodes to `partition_deletion == None`.
+    #[test]
+    fn resolve_rows_db_entry_live_partition_deletion() {
+        let mut buf = vec![0xEEu8; 4];
+        let rows_offset = buf.len();
+        buf.extend_from_slice(&4u16.to_be_bytes());
+        buf.extend_from_slice(&[0x00, 0x00, 0x00, 0x07]);
+        let base = rows_offset + 4;
+        buf.push(123); // dataPos
+        let root_delta: i64 = 2 - base as i64;
+        let zig = ((root_delta << 1) ^ (root_delta >> 63)) as u64;
+        buf.push(zig as u8); // rootΔ
+        buf.push(38); // blockCount
+        buf.push(0x80); // MODERN DA live sentinel → no deletion
+
+        let header = resolve_rows_db_entry(&buf, rows_offset).unwrap();
+        assert_eq!(header.block_count, 38);
+        assert_eq!(
+            header.partition_deletion, None,
+            "0x80 live sentinel must decode to no partition deletion"
+        );
     }
 
     /// Signed vint (zig-zag) decode round-trips small +/- values.

--- a/cqlite-core/src/storage/sstable/bti/parser.rs
+++ b/cqlite-core/src/storage/sstable/bti/parser.rs
@@ -722,6 +722,16 @@ fn read_node_payload(
     let ordinal = (header_byte >> 4) & 0x0F;
     let payload_flags = header_byte & 0x0F; // aka payloadBits
 
+    // Ordinals 1 (SingleNoPayload4) and 3 (SingleNoPayload12) encode their
+    // backward delta in the low nibble / low 12 bits — that nibble is NOT a
+    // payload flag, and these node types can NEVER carry a payload.  Treating
+    // their low nibble as `payloadBits` was a latent bug exposed by full DFS
+    // (issue #832): e.g. a `0x18` SingleNoPayload4 was misread as having a
+    // payload, producing a spurious entry.
+    if ordinal == 1 || ordinal == 3 {
+        return Ok(None);
+    }
+
     if ordinal == 0 {
         // PayloadOnly node: the entire node is just [header][payload…]
         if payload_flags == 0 {
@@ -739,7 +749,14 @@ fn read_node_payload(
         // Non-leaf node with an embedded payload (prefix match for short keys).
         // We need to skip over the node's own pointer/transition data to reach
         // the payload.  Reuse `parse_bti_node` to find the payload start.
-        let node = parse_bti_node(trie_data, node_offset as u64)?;
+        //
+        // NOTE: `parse_bti_node` reads its header from `data[0]`, so it must be
+        // passed the slice STARTING at the node (`&trie_data[node_offset..]`),
+        // while the absolute `node_offset` drives child-position arithmetic.
+        // Passing the whole `trie_data` here was a latent bug (it parsed the
+        // node at offset 0 instead) — only exposed once a non-leaf node carries
+        // an embedded payload at a non-zero offset (issue #832).
+        let node = parse_bti_node(&trie_data[node_offset..], node_offset as u64)?;
         // Determine where the payload bytes start: after all transition/pointer bytes.
         // payload_position = node_offset + node_byte_size_without_payload
         let payload_start = payload_start_in_node(&node, trie_data, node_offset)?;
@@ -1036,6 +1053,410 @@ pub fn lookup_raw_key_in_bti_partitions_db<R: Read + Seek>(
 ) -> BtiResult<Option<BtiPartitionLocation>> {
     let encoded = encode_partition_key_for_bti_trie(raw_key_bytes);
     lookup_partition_in_bti_file(partitions_db_reader, &encoded)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Full trie traversal (DFS) primitives — issue #832
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// These free functions operate purely on in-memory trie bytes plus a root
+// offset (mirroring `walk_bti_trie`).  They enumerate *every* leaf/payload in
+// **byte-comparable order** by performing an explicit, depth-capped, stack-based
+// depth-first search.
+//
+// In-order semantics (matches Cassandra `Walker`/`ReverseValueIterator`):
+//   - A node that carries its own payload sorts BEFORE all of its children
+//     (the key that terminates here is a prefix of every continuation).
+//   - Children are visited in ascending transition-byte order.
+//
+// The reconstructed key for each emitted entry is the concatenation of the
+// transition bytes from the root down to (and including) the node that carries
+// the payload.  This is a *byte-comparable / token* encoding, NOT the original
+// partition/clustering key — callers that need the original key must resolve it
+// from Data.db.  The payload OFFSETS, however, are definitive.
+
+/// Maximum DFS stack depth, mirroring [`crate::storage::sstable::bti::MAX_TRIE_DEPTH`].
+const DFS_MAX_DEPTH: usize = 128;
+
+/// Read the root offset from the 8-byte big-endian footer of a BTI file and
+/// load the entire trie (everything before the footer) into memory.
+///
+/// Real Cassandra 5.0 BTI files (`Partitions.db` / `Rows.db`) have **no
+/// header** — the root node's absolute offset is the last 8 bytes of the file.
+/// This is the footer-based loader used by the traversal iterators; it does NOT
+/// rely on the fictional [`BtiHeader`] (whose `parse` would misread byte 0 of a
+/// real BTI file).
+///
+/// Returns `(trie_data, root_offset)`.
+fn load_bti_trie_via_footer<R: Read + Seek>(reader: &mut R) -> BtiResult<(Vec<u8>, usize)> {
+    let file_size = reader.seek(SeekFrom::End(0))?;
+    if file_size < 8 {
+        return Err(Error::Parse(format!(
+            "BTI file too small ({file_size} bytes; need at least 8 for footer)"
+        )));
+    }
+
+    reader.seek(SeekFrom::End(-8))?;
+    let mut footer = [0u8; 8];
+    reader.read_exact(&mut footer)?;
+    let root_offset = u64::from_be_bytes(footer);
+
+    let trie_size = file_size - 8;
+    if root_offset >= trie_size {
+        return Err(Error::Parse(format!(
+            "BTI file: root_offset {root_offset} >= trie_size {trie_size}"
+        )));
+    }
+
+    reader.seek(SeekFrom::Start(0))?;
+    let mut trie_data = vec![0u8; trie_size as usize];
+    reader.read_exact(&mut trie_data)?;
+    Ok((trie_data, root_offset as usize))
+}
+
+/// Collect the ascending-transition-byte child list `(transition_byte, child_offset)`
+/// for a parsed BTI node, ready for in-order DFS.
+///
+/// Crucially this iterates `Dense` children directly by index (transition byte =
+/// `start_byte + i`) and **skips** any child whose absolute offset is `0`, which
+/// is the Dense "no transition" sentinel.  ([`BtiNode::get_transitions`] returns
+/// an empty Vec for Dense nodes and must NOT be used for traversal.)
+///
+/// `Sparse` transitions are returned in their stored order; the parser preserves
+/// the on-disk ascending order, and we sort defensively.
+fn ordered_children(node: &BtiNode) -> Vec<(u8, usize)> {
+    match &node.data {
+        BtiNodeData::PayloadOnly { .. } => Vec::new(),
+        BtiNodeData::Single { transition } => {
+            vec![(transition.byte, transition.child.distance as usize)]
+        }
+        BtiNodeData::Sparse { transitions } => {
+            let mut out: Vec<(u8, usize)> = transitions
+                .iter()
+                .map(|t| (t.byte, t.child.distance as usize))
+                .collect();
+            // Defensive: BTI Sparse transitions are stored ascending; enforce it.
+            out.sort_by_key(|&(b, _)| b);
+            out
+        }
+        BtiNodeData::Dense {
+            start_byte,
+            children,
+        } => {
+            let mut out = Vec::new();
+            for (i, child) in children.iter().enumerate() {
+                let off = child.distance as usize;
+                // distance == 0 is the Dense "no transition" sentinel.  For a
+                // Dense node a real child can never live at absolute offset 0:
+                // the parent is at a higher offset and Cassandra never emits a
+                // Dense delta equal to the node offset for a real transition.
+                if off == 0 {
+                    continue;
+                }
+                let transition_byte = start_byte.wrapping_add(i as u8);
+                out.push((transition_byte, off));
+            }
+            out
+        }
+    }
+}
+
+/// Generic in-order DFS over a BTI trie, decoding each node payload with
+/// `decode_payload` and pushing `(reconstructed_key, decoded_payload)` onto the
+/// result Vec in byte-comparable order.
+///
+/// The traversal is iterative (explicit stack), depth-capped at
+/// [`DFS_MAX_DEPTH`], and bounds-checks every offset — corrupt or cyclic tries
+/// produce an error rather than an infinite loop or panic.
+fn dfs_collect_in_order<T, F>(
+    trie_data: &[u8],
+    root_offset: usize,
+    mut decode_payload: F,
+) -> BtiResult<Vec<(Vec<u8>, T)>>
+where
+    F: FnMut(&[u8], usize) -> BtiResult<Option<T>>,
+{
+    let mut results: Vec<(Vec<u8>, T)> = Vec::new();
+
+    // Stack frame: (node_offset, accumulated_key_bytes).
+    // We use an explicit stack and push children in *reverse* order so the
+    // smallest transition byte is processed first (LIFO).
+    let mut stack: Vec<(usize, Vec<u8>)> = vec![(root_offset, Vec::new())];
+
+    while let Some((node_offset, key_bytes)) = stack.pop() {
+        if key_bytes.len() > DFS_MAX_DEPTH {
+            return Err(Error::Parse(format!(
+                "BTI DFS exceeded max depth {DFS_MAX_DEPTH} (corrupt or cyclic trie)"
+            )));
+        }
+        if node_offset >= trie_data.len() {
+            return Err(Error::Parse(format!(
+                "BTI DFS: node_offset {node_offset} out of bounds (trie size {})",
+                trie_data.len()
+            )));
+        }
+
+        // 1) Emit this node's own payload (if any) BEFORE descending — the key
+        //    terminating here sorts before any continuation.
+        if let Some(payload) = decode_payload(trie_data, node_offset)? {
+            results.push((key_bytes.clone(), payload));
+        }
+
+        // 2) Descend children in ASCENDING transition-byte order.  Because the
+        //    stack is LIFO, push them in DESCENDING order.
+        let node = parse_bti_node_for_traversal(trie_data, node_offset)?;
+        let children = ordered_children(&node);
+        for &(transition_byte, child_offset) in children.iter().rev() {
+            let mut child_key = key_bytes.clone();
+            child_key.push(transition_byte);
+            stack.push((child_offset, child_key));
+        }
+    }
+
+    Ok(results)
+}
+
+/// Enumerate every partition entry in a `Partitions.db` trie in byte-comparable
+/// order: `(reconstructed_token_key, BtiPartitionLocation)`.
+fn dfs_collect_partition_entries(
+    trie_data: &[u8],
+    root_offset: usize,
+) -> BtiResult<Vec<(Vec<u8>, BtiPartitionLocation)>> {
+    dfs_collect_in_order(trie_data, root_offset, |data, off| {
+        read_node_payload(data, off)
+    })
+}
+
+/// Enumerate **all** partitions in a real Cassandra 5.0 `Partitions.db` BTI file
+/// (issue #832), in byte-comparable order.
+///
+/// This is the headerless public entry point: the trie is loaded via the 8-byte
+/// footer (NOT the fictional [`BtiHeader`]).  Each returned tuple is
+/// `(reconstructed_token_key, BtiPartitionLocation)`; the offset is definitive,
+/// the key is a byte-comparable token prefix (see the DFS module note).
+///
+/// Returns an empty Vec for a `< 8`-byte (e.g. empty) file.
+pub fn iterate_partitions_in_bti_file<R: Read + Seek>(
+    reader: &mut R,
+) -> BtiResult<Vec<(Vec<u8>, BtiPartitionLocation)>> {
+    let file_size = reader.seek(SeekFrom::End(0))?;
+    if file_size < 8 {
+        return Ok(Vec::new());
+    }
+    let (trie_data, root_offset) = load_bti_trie_via_footer(reader)?;
+    dfs_collect_partition_entries(&trie_data, root_offset)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Rows.db in-trie payload decoding (RowIndexReader / TrieIndexEntry)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// IMPORTANT: `Rows.db` in-trie payloads are NOT the `Partitions.db` payload
+// format (which is a hash byte + SizedInts position).  A `Rows.db` trie leaf
+// carries a *row index block* entry as described by Cassandra's
+// `RowIndexReader.java` / `TrieIndexEntry.java`:
+//
+//   - Data.db position of the block start (unsigned vint)
+//   - if the payload's flag bits include `FLAG_OPEN_MARKER`, a 12-byte
+//     `DeletionTime` (4-byte localDeletionTime + 8-byte markedForDeleteAt)
+//     follows the position vint.
+//
+// The low nibble of the node header byte is the BTI `payloadBits`.  For Rows.db
+// the convention used by Cassandra's RowIndexReader is:
+//   bit 0x8 (FLAG_OPEN_MARKER) → an open-marker DeletionTime follows.
+// We decode the Data.db block position (the definitive field) and, when the
+// open-marker flag is set, the trailing DeletionTime.  Length is not recoverable
+// from a single payload and is reported as 0.
+//
+// Reference: docs/sstables-definitive-guide chapter 17 (lines ~148-162),
+//            Cassandra `RowIndexReader.java` / `TrieIndexEntry.java`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The `FLAG_OPEN_MARKER` bit in a `Rows.db` trie node's `payloadBits`
+/// (low nibble of the header byte).  When set, a 12-byte open-marker
+/// `DeletionTime` follows the Data.db position vint.
+pub const FLAG_OPEN_MARKER: u8 = 0x8;
+
+/// A decoded `Rows.db` in-trie row-index block entry.
+///
+/// Mirrors the fields a `RowIndexReader` produces per block.  The headline
+/// field is [`data_offset`](Self::data_offset): the Data.db byte position of the
+/// indexed block (as Cassandra stores it in the row index).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BtiRowIndexEntry {
+    /// Data.db block position decoded from the payload's leading unsigned vint.
+    pub data_offset: u64,
+    /// Open-marker deletion time `(local_deletion_time, marked_for_delete_at)`,
+    /// present only when the `FLAG_OPEN_MARKER` payload bit is set.
+    pub open_marker: Option<(i32, i64)>,
+}
+
+/// Read an unsigned VInt (Cassandra count-leading-ones encoding, **not** ZigZag)
+/// from `data`, returning `(value, bytes_consumed)`.
+///
+/// This is the encoding Cassandra uses for Data.db positions in the row index
+/// (`DataOutputPlus.writeUnsignedVInt`).  The number of extra bytes equals the
+/// number of leading 1-bits in the first byte; the value is big-endian across
+/// the remaining bits.
+fn read_unsigned_vint_from_slice(data: &[u8]) -> BtiResult<(u64, usize)> {
+    if data.is_empty() {
+        return Err(Error::Parse(
+            "Rows.db payload: unexpected end of data reading unsigned vint".to_string(),
+        ));
+    }
+    let first = data[0];
+    let extra_bytes = first.leading_ones() as usize;
+    if extra_bytes > 8 {
+        return Err(Error::Parse(format!(
+            "Rows.db payload: invalid unsigned vint first byte 0x{first:02x}"
+        )));
+    }
+    let total = extra_bytes + 1;
+    if data.len() < total {
+        return Err(Error::Parse(format!(
+            "Rows.db payload: unsigned vint needs {total} bytes, have {}",
+            data.len()
+        )));
+    }
+
+    // Data bits in the first byte: 8 - extra_bytes - 1 (the separator 0 bit),
+    // except when extra_bytes == 8 (first byte is all ones, no data bits).
+    let mut value: u64 = if extra_bytes >= 8 {
+        0
+    } else {
+        let data_bits = 8 - extra_bytes - 1;
+        let mask = if data_bits == 0 {
+            0
+        } else {
+            (1u16 << data_bits) - 1
+        };
+        (first as u16 & mask) as u64
+    };
+    for &b in &data[1..total] {
+        value = (value << 8) | (b as u64);
+    }
+    Ok((value, total))
+}
+
+/// Decode a `Rows.db` in-trie payload at `payload_start` inside `trie_data`,
+/// given the node's `payload_bits` (low nibble of the header byte).
+///
+/// See the module-level note above for the format.  Returns the decoded
+/// [`BtiRowIndexEntry`].
+fn decode_bti_row_payload(
+    trie_data: &[u8],
+    payload_start: usize,
+    payload_bits: u8,
+) -> BtiResult<BtiRowIndexEntry> {
+    if payload_start > trie_data.len() {
+        return Err(Error::Parse(format!(
+            "Rows.db payload start {payload_start} beyond trie size {}",
+            trie_data.len()
+        )));
+    }
+    let slice = &trie_data[payload_start..];
+    let (data_offset, consumed) = read_unsigned_vint_from_slice(slice)?;
+
+    let open_marker = if payload_bits & FLAG_OPEN_MARKER != 0 {
+        let dt_start = consumed;
+        if dt_start + 12 > slice.len() {
+            return Err(Error::Parse(format!(
+                "Rows.db payload: open-marker DeletionTime needs 12 bytes, have {}",
+                slice.len().saturating_sub(dt_start)
+            )));
+        }
+        let dt = &slice[dt_start..dt_start + 12];
+        let local_deletion_time = i32::from_be_bytes([dt[0], dt[1], dt[2], dt[3]]);
+        let marked_for_delete_at =
+            i64::from_be_bytes([dt[4], dt[5], dt[6], dt[7], dt[8], dt[9], dt[10], dt[11]]);
+        Some((local_deletion_time, marked_for_delete_at))
+    } else {
+        None
+    };
+
+    Ok(BtiRowIndexEntry {
+        data_offset,
+        open_marker,
+    })
+}
+
+/// Read the `BtiRowIndexEntry` from the payload attached to a `Rows.db` node at
+/// `node_offset`, or `None` if the node carries no payload.
+///
+/// Structurally parallels [`read_node_payload`] but decodes the Rows.db payload
+/// format via [`decode_bti_row_payload`].
+fn read_row_node_payload(
+    trie_data: &[u8],
+    node_offset: usize,
+) -> BtiResult<Option<BtiRowIndexEntry>> {
+    if node_offset >= trie_data.len() {
+        return Err(Error::Parse(format!(
+            "Rows.db payload read: node_offset {node_offset} out of bounds"
+        )));
+    }
+
+    let header_byte = trie_data[node_offset];
+    let ordinal = (header_byte >> 4) & 0x0F;
+    let payload_flags = header_byte & 0x0F;
+
+    // SingleNoPayload variants (ordinals 1, 3) carry their delta in the low
+    // nibble and never have a payload.  See `read_node_payload`.
+    if ordinal == 1 || ordinal == 3 {
+        return Ok(None);
+    }
+
+    if ordinal == 0 {
+        if payload_flags == 0 {
+            return Err(Error::Parse(
+                "Rows.db PayloadOnly node has zero payload_flags".to_string(),
+            ));
+        }
+        let payload_start = node_offset + 1;
+        Ok(Some(decode_bti_row_payload(
+            trie_data,
+            payload_start,
+            payload_flags,
+        )?))
+    } else if payload_flags != 0 {
+        // Slice must start at the node (see note in `read_node_payload`).
+        let node = parse_bti_node(&trie_data[node_offset..], node_offset as u64)?;
+        let payload_start = payload_start_in_node(&node, trie_data, node_offset)?;
+        Ok(Some(decode_bti_row_payload(
+            trie_data,
+            payload_start,
+            payload_flags,
+        )?))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Enumerate every row-index entry in a `Rows.db` trie (rooted at `root_offset`)
+/// in byte-comparable order: `(reconstructed_clustering_key, BtiRowIndexEntry)`.
+fn dfs_collect_row_entries(
+    trie_data: &[u8],
+    root_offset: usize,
+) -> BtiResult<Vec<(Vec<u8>, BtiRowIndexEntry)>> {
+    dfs_collect_in_order(trie_data, root_offset, |data, off| {
+        read_row_node_payload(data, off)
+    })
+}
+
+/// Enumerate **all** row-index entries in a real Cassandra 5.0 `Rows.db` BTI
+/// file (issue #832), in byte-comparable order.
+///
+/// Headerless public entry point (footer-based, NOT [`BtiHeader`]).  A
+/// `< 8`-byte (e.g. 0-byte) `Rows.db` — common for partitions with no row index
+/// — yields an empty Vec without erroring.
+pub fn iterate_rows_in_bti_file<R: Read + Seek>(
+    reader: &mut R,
+) -> BtiResult<Vec<(Vec<u8>, BtiRowIndexEntry)>> {
+    let file_size = reader.seek(SeekFrom::End(0))?;
+    if file_size < 8 {
+        return Ok(Vec::new());
+    }
+    let (trie_data, root_offset) = load_bti_trie_via_footer(reader)?;
+    dfs_collect_row_entries(&trie_data, root_offset)
 }
 
 /// BTI header structure for index files
@@ -1369,29 +1790,42 @@ impl<R: Read + Seek> RowsParser<R> {
         parse_bti_node(data, offset)
     }
 
-    /// Range query for clustering keys
+    /// Clustering-key range/slice traversal of a `Rows.db` trie (issue #832).
+    ///
+    /// Encodes `start_key` and `end_key` via the byte-comparable encoder, then
+    /// returns every row-index entry whose reconstructed byte-comparable key
+    /// falls within `[encoded_start, encoded_end]` (inclusive both ends, matching
+    /// Cassandra clustering-slice semantics).  Comparison is lexicographic over
+    /// the reconstructed transition-byte keys.
+    ///
+    /// First-cut correctness implementation: runs the full in-order DFS and
+    /// filters by the byte-comparable bounds.  Reversed bounds (start > end)
+    /// yield an empty result.  The trie is loaded via the footer (NOT the
+    /// fictional [`BtiHeader`]).
     pub fn range_query(
         &mut self,
         start_key: &[Value],
         end_key: &[Value],
-    ) -> BtiResult<Vec<PayloadRef>> {
-        let _encoded_start = self.encoder.encode_composite_key(start_key)?;
-        let _encoded_end = self.encoder.encode_composite_key(end_key)?;
+    ) -> BtiResult<Vec<BtiRowIndexEntry>> {
+        let encoded_start = self.encoder.encode_composite_key(start_key)?;
+        let encoded_end = self.encoder.encode_composite_key(end_key)?;
 
-        // Issue #755 scope decision: range_query over the fake-header RowsParser
-        // is not yet implemented.  Returning an empty Vec here would be a *silent*
-        // wrong-result path — callers would see "no rows in range" instead of an
-        // error, making bugs invisible.  Return an explicit error so callers know
-        // this path is unimplemented and must not rely on its output.
-        //
-        // Follow-up issue: implement proper BTI Rows.db range traversal.
-        // Proposed title: "feat(bti): implement RowsParser range_query trie traversal"
-        Err(Error::Parse(
-            "BTI RowsParser::range_query is not yet implemented; \
-             this stub previously returned an empty Vec (silent wrong-result). \
-             See follow-up issue for BTI Rows.db range traversal implementation."
-                .to_string(),
-        ))
+        // Reversed bounds → empty range.
+        if encoded_start > encoded_end {
+            return Ok(Vec::new());
+        }
+
+        let (trie_data, root_offset) = load_bti_trie_via_footer(&mut self.reader)?;
+        let all = dfs_collect_row_entries(&trie_data, root_offset)?;
+
+        Ok(all
+            .into_iter()
+            .filter(|(key, _)| {
+                key.as_slice() >= encoded_start.as_slice()
+                    && key.as_slice() <= encoded_end.as_slice()
+            })
+            .map(|(_, entry)| entry)
+            .collect())
     }
 
     /// Iterator over all rows in the index
@@ -1405,95 +1839,110 @@ impl<R: Read + Seek> RowsParser<R> {
     }
 }
 
-/// Iterator over partitions in BTI index
+/// Iterator over **all** partitions in a `Partitions.db` BTI index, in
+/// byte-comparable order (issue #832).
+///
+/// The full trie is loaded via the footer-based loader (NOT the fictional
+/// [`BtiHeader`]) and traversed in-order during [`PartitionIterator::new`]; the
+/// materialized entries are then yielded one at a time.  BTI partition indexes
+/// are tiny (tens of KB even for millions of partitions, thanks to prefix
+/// sharing), so eager materialization is acceptable.
+///
+/// The yielded `Vec<u8>` key is the reconstructed *byte-comparable token* key
+/// (concatenated transition bytes), NOT the original partition key.  The
+/// [`BtiPartitionLocation`] offset is definitive.
 pub struct PartitionIterator<'a, R: Read + Seek> {
     #[allow(dead_code)]
     parser: &'a mut PartitionsParser<R>,
-    #[allow(dead_code)]
-    current_position: u64,
-    finished: bool,
+    /// Materialized entries in byte-comparable order.
+    entries: std::vec::IntoIter<(Vec<u8>, BtiPartitionLocation)>,
+    /// A deferred error to surface on the first `next()` call.
+    pending_error: Option<Error>,
 }
 
 impl<'a, R: Read + Seek> PartitionIterator<'a, R> {
     fn new(parser: &'a mut PartitionsParser<R>) -> BtiResult<Self> {
-        let root_offset = parser.header.root_offset;
+        // Load and traverse via the footer-based loader; surface any error on
+        // the first `next()` call rather than failing construction (so callers
+        // that ignore errors still see a non-silent failure).
+        let (entries, pending_error) = match load_bti_trie_via_footer(&mut parser.reader)
+            .and_then(|(trie, root)| dfs_collect_partition_entries(&trie, root))
+        {
+            Ok(v) => (v, None),
+            Err(e) => (Vec::new(), Some(e)),
+        };
         Ok(Self {
             parser,
-            current_position: root_offset,
-            finished: false,
+            entries: entries.into_iter(),
+            pending_error,
         })
     }
 }
 
 impl<'a, R: Read + Seek> Iterator for PartitionIterator<'a, R> {
-    type Item = BtiResult<(Vec<u8>, PayloadRef)>;
+    type Item = BtiResult<(Vec<u8>, BtiPartitionLocation)>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.finished {
-            return None;
+        if let Some(err) = self.pending_error.take() {
+            return Some(Err(err));
         }
-        self.finished = true;
-
-        // Issue #755 scope decision: full trie traversal for iteration over the
-        // fake-header PartitionsParser is not yet implemented.  Silently returning
-        // `None` here would make callers believe the index is empty (silent
-        // wrong-result).  Emit an explicit error so callers see an unambiguous
-        // "not implemented" rather than mysteriously empty iteration.
-        //
-        // Follow-up issue: implement BTI PartitionIterator trie traversal
-        // Proposed title: "feat(bti): implement PartitionIterator full trie traversal"
-        Some(Err(Error::Parse(
-            "BTI PartitionIterator::next is not yet implemented; \
-             this stub previously returned None (silent wrong-result). \
-             See follow-up issue for full trie traversal implementation."
-                .to_string(),
-        )))
+        self.entries.next().map(Ok)
     }
 }
 
-/// Iterator over rows in BTI index
+/// Iterator over **all** row-index entries in a `Rows.db` BTI index (for a
+/// single partition's trie), in byte-comparable order (issue #832).
+///
+/// Like [`PartitionIterator`], the trie is loaded via the footer-based loader
+/// and traversed in-order during construction.  Each yielded `Vec<u8>` is the
+/// reconstructed byte-comparable clustering key; the [`BtiRowIndexEntry`]
+/// carries the Data.db block position (definitive) and an optional open-marker
+/// `DeletionTime`.
+///
+/// An empty (< 8-byte, e.g. 0-byte) `Rows.db` trie yields nothing without
+/// panicking.
 pub struct RowIterator<'a, R: Read + Seek> {
     #[allow(dead_code)]
     parser: &'a mut RowsParser<R>,
-    #[allow(dead_code)]
-    current_position: u64,
-    finished: bool,
+    entries: std::vec::IntoIter<(Vec<u8>, BtiRowIndexEntry)>,
+    pending_error: Option<Error>,
 }
 
 impl<'a, R: Read + Seek> RowIterator<'a, R> {
     fn new(parser: &'a mut RowsParser<R>) -> BtiResult<Self> {
-        let root_offset = parser.header.root_offset;
+        // An empty Rows.db (< 8 bytes, e.g. a 0-byte file for partitions with no
+        // row index) yields nothing rather than erroring.
+        let file_size = parser.reader.seek(SeekFrom::End(0))?;
+        if file_size < 8 {
+            return Ok(Self {
+                parser,
+                entries: Vec::new().into_iter(),
+                pending_error: None,
+            });
+        }
+
+        let (entries, pending_error) = match load_bti_trie_via_footer(&mut parser.reader)
+            .and_then(|(trie, root)| dfs_collect_row_entries(&trie, root))
+        {
+            Ok(v) => (v, None),
+            Err(e) => (Vec::new(), Some(e)),
+        };
         Ok(Self {
             parser,
-            current_position: root_offset,
-            finished: false,
+            entries: entries.into_iter(),
+            pending_error,
         })
     }
 }
 
 impl<'a, R: Read + Seek> Iterator for RowIterator<'a, R> {
-    type Item = BtiResult<(Vec<u8>, PayloadRef)>;
+    type Item = BtiResult<(Vec<u8>, BtiRowIndexEntry)>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.finished {
-            return None;
+        if let Some(err) = self.pending_error.take() {
+            return Some(Err(err));
         }
-        self.finished = true;
-
-        // Issue #755 scope decision: full trie traversal for iteration over the
-        // fake-header RowsParser is not yet implemented.  Silently returning
-        // `None` here would make callers believe the row index is empty (silent
-        // wrong-result).  Emit an explicit error so callers see an unambiguous
-        // "not implemented" rather than mysteriously empty iteration.
-        //
-        // Follow-up issue: implement BTI RowIterator trie traversal
-        // Proposed title: "feat(bti): implement RowIterator full trie traversal"
-        Some(Err(Error::Parse(
-            "BTI RowIterator::next is not yet implemented; \
-             this stub previously returned None (silent wrong-result). \
-             See follow-up issue for full trie traversal implementation."
-                .to_string(),
-        )))
+        self.entries.next().map(Ok)
     }
 }
 
@@ -2780,58 +3229,290 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Stub-non-silent tests (issue #755 scope decision)
+    // issue #832 — full trie traversal (DFS) unit tests
     // -----------------------------------------------------------------------
+    //
+    // These hand-craft in-memory tries (no external files) and exercise the new
+    // free-function DFS/range primitives directly.  They always run in CI.
 
-    /// Verify that RowsParser::range_query returns an explicit error rather
-    /// than silently returning an empty Vec (which would be a wrong-result path).
+    /// Build a complete in-memory Partitions.db-style file (trie + 8-byte
+    /// big-endian root-offset footer).
+    fn make_partitions_db(trie_bytes: Vec<u8>, root_offset: u64) -> Vec<u8> {
+        let mut v = trie_bytes;
+        v.extend_from_slice(&root_offset.to_be_bytes());
+        v
+    }
+
+    /// A `Partitions.db` PayloadOnly leaf with payloadBits=8 (hash + 1-byte
+    /// SizedInts position).  `position` is the *signed* byte; negative →
+    /// DataOffset(~position).
+    fn partition_leaf(hash: u8, position: i8) -> Vec<u8> {
+        vec![0x08, hash, position as u8]
+    }
+
+    /// (1) partition DFS over a synthetic Sparse trie yields entries in
+    /// ascending transition-byte order with correct payloads/offsets, and the
+    /// reconstructed keys are the transition bytes.
     #[test]
-    fn rows_parser_range_query_returns_explicit_error_not_empty_vec() {
-        let root_node = payload_only_node(1000, 50);
-        let data = make_bti_file(root_node);
-        let cursor = std::io::Cursor::new(data);
-        let mut parser = RowsParser::new(cursor).unwrap();
+    fn dfs_partition_sparse_ascending_order_with_offsets() {
+        // Leaves (bottom-up):
+        //   offset 0: leaf hash=0x11 pos=-1  → DataOffset(0)
+        //   offset 3: leaf hash=0x22 pos=-65 → DataOffset(64)
+        //   offset 6: Sparse8 count=2  trans 0xAA→0 (delta6), 0xBB→3 (delta3)
+        let mut trie = vec![0u8; 12];
+        trie[0..3].copy_from_slice(&partition_leaf(0x11, -1));
+        trie[3..6].copy_from_slice(&partition_leaf(0x22, -65));
+        trie[6] = 0x50; // Sparse8
+        trie[7] = 0x02; // count
+        trie[8] = 0xAA;
+        trie[9] = 0xBB;
+        trie[10] = 0x06; // child = 6-6 = 0
+        trie[11] = 0x03; // child = 6-3 = 3
 
-        let start = vec![Value::Text("start".to_string())];
-        let end = vec![Value::Text("end".to_string())];
-        let result = parser.range_query(&start, &end);
-        assert!(
-            result.is_err(),
-            "range_query must return Err (not Ok(empty Vec)) to prevent silent wrong-result: got {:?}", result
+        let entries = dfs_collect_partition_entries(&trie, 6).unwrap();
+        assert_eq!(
+            entries,
+            vec![
+                (vec![0xAA], BtiPartitionLocation::DataOffset(0)),
+                (vec![0xBB], BtiPartitionLocation::DataOffset(64)),
+            ],
+            "Sparse DFS must emit ascending transition bytes with correct offsets"
         );
     }
 
-    /// Verify that PartitionIterator::next returns Some(Err(_)) on first call
-    /// rather than None (which would look like an empty index).
+    /// (2) partition DFS over a Dense node skips distance==0 gaps and emits in
+    /// start_byte+i order.
     #[test]
-    fn partition_iterator_next_returns_explicit_error_not_none() {
-        let data = make_bti_file(payload_only_node(1000, 50));
-        let cursor = std::io::Cursor::new(data);
-        let mut parser = PartitionsParser::new(cursor).unwrap();
-        let mut iter = parser.iterate_partitions().unwrap();
-        let first = iter.next();
-        assert!(
-            matches!(first, Some(Err(_))),
-            "PartitionIterator must yield Some(Err(_)) on first call (not None); \
-             got: {:?}",
-            first
+    fn dfs_partition_dense_skips_gaps() {
+        // A leading pad byte ensures the real children never resolve to absolute
+        // offset 0 (which would collide with the Dense "no transition" sentinel).
+        //   offset 0: pad
+        //   offset 1: leaf → DataOffset(0)
+        //   offset 4: leaf → DataOffset(64)
+        //   Dense16 root: start_byte=0x10, range_len=3
+        //     index 0 (byte 0x10): → child at offset 1
+        //     index 1 (byte 0x11): delta=0 → NO TRANSITION (skip)
+        //     index 2 (byte 0x12): → child at offset 4
+        let mut trie = vec![0x00u8]; // pad at offset 0
+        let l1 = trie.len() as u64; // 1
+        trie.extend_from_slice(&partition_leaf(0x11, -1)); // DataOffset(0)
+        let l2 = trie.len() as u64; // 4
+        trie.extend_from_slice(&partition_leaf(0x22, -65)); // DataOffset(64)
+        let dense_off = trie.len() as u64; // 7
+        trie.push(0xB0); // Dense16 (ordinal 11)
+        trie.push(0x10); // start_byte
+        trie.push(0x02); // range_len - 1 = 2 → 3 entries
+        trie.extend_from_slice(&((dense_off - l1) as u16).to_be_bytes()); // 0x10 → leaf 1
+        trie.extend_from_slice(&0u16.to_be_bytes()); // 0x11 → gap (sentinel)
+        trie.extend_from_slice(&((dense_off - l2) as u16).to_be_bytes()); // 0x12 → leaf 4
+
+        let entries = dfs_collect_partition_entries(&trie, dense_off as usize).unwrap();
+        assert_eq!(
+            entries,
+            vec![
+                (vec![0x10], BtiPartitionLocation::DataOffset(0)),
+                (vec![0x12], BtiPartitionLocation::DataOffset(64)),
+            ],
+            "Dense DFS must skip distance==0 gaps and emit start_byte+i order"
         );
     }
 
-    /// Verify that RowIterator::next returns Some(Err(_)) on first call
-    /// rather than None (which would look like an empty row index).
+    /// (3) partition DFS emits an internal node's own payload BEFORE its children.
     #[test]
-    fn row_iterator_next_returns_explicit_error_not_none() {
-        let data = make_bti_file(payload_only_node(1000, 50));
-        let cursor = std::io::Cursor::new(data);
-        let mut parser = RowsParser::new(cursor).unwrap();
-        let mut iter = parser.iterate_rows().unwrap();
-        let first = iter.next();
-        assert!(
-            matches!(first, Some(Err(_))),
-            "RowIterator must yield Some(Err(_)) on first call (not None); \
-             got: {:?}",
-            first
+    fn dfs_partition_internal_payload_before_children() {
+        // Layout (bottom-up):
+        //   offset 0: child leaf → DataOffset(0)
+        //   offset 3: Single8 WITH its own payload (payloadBits=8):
+        //             [0x28][transition=0xCC][delta=3][hash][pos]
+        //             pos=-65 → the node's own payload = DataOffset(64)
+        //             child via 0xCC = offset 3-3 = 0 → DataOffset(0)
+        let mut trie = Vec::new();
+        trie.extend_from_slice(&partition_leaf(0x11, -1)); // offset 0 → DataOffset(0)
+        let node_off = trie.len() as u64; // 3
+        trie.push(0x28); // Single8 (ordinal 2), payloadBits=8
+        trie.push(0xCC); // transition byte
+        trie.push(node_off as u8); // delta=3 → child at offset 0
+        trie.push(0x99); // payload hash
+        trie.push((-65i8) as u8); // payload position → DataOffset(64)
+
+        let entries = dfs_collect_partition_entries(&trie, node_off as usize).unwrap();
+        assert_eq!(
+            entries,
+            vec![
+                // The node's OWN payload (empty key prefix) sorts first.
+                (vec![], BtiPartitionLocation::DataOffset(64)),
+                // Then its child via transition 0xCC.
+                (vec![0xCC], BtiPartitionLocation::DataOffset(0)),
+            ],
+            "An internal node's payload must be emitted before its children"
         );
+    }
+
+    // ----- Rows.db-style synthetic tries (issue #832) -----
+
+    /// A `Rows.db` PayloadOnly leaf with no open marker (payloadBits=1): a
+    /// single-byte unsigned-vint Data.db position (value 0..=127).
+    fn row_leaf_no_marker(pos: u8) -> Vec<u8> {
+        assert!(pos <= 127, "use a 1-byte unsigned vint position");
+        vec![0x01, pos] // ordinal=0, payloadBits=1 (no FLAG_OPEN_MARKER)
+    }
+
+    /// Build a 3-leaf Rows.db-style trie via a Sparse8 root.  Returns
+    /// `(trie_bytes, root_offset)`.  Transition bytes k1<k2<k3 map to Data.db
+    /// positions p1,p2,p3.
+    fn make_rows_trie_three(
+        (k1, p1): (u8, u8),
+        (k2, p2): (u8, u8),
+        (k3, p3): (u8, u8),
+    ) -> (Vec<u8>, usize) {
+        let mut trie = Vec::new();
+        let o1 = trie.len() as u64; // 0
+        trie.extend_from_slice(&row_leaf_no_marker(p1));
+        let o2 = trie.len() as u64; // 2
+        trie.extend_from_slice(&row_leaf_no_marker(p2));
+        let o3 = trie.len() as u64; // 4
+        trie.extend_from_slice(&row_leaf_no_marker(p3));
+        let root = trie.len() as u64; // 6
+        trie.push(0x50); // Sparse8
+        trie.push(0x03); // count=3
+        trie.push(k1);
+        trie.push(k2);
+        trie.push(k3);
+        trie.push((root - o1) as u8);
+        trie.push((root - o2) as u8);
+        trie.push((root - o3) as u8);
+        (trie, root as usize)
+    }
+
+    /// (5) RowIterator over a synthetic Rows.db-style trie yields clustering
+    /// keys in byte order with correct Rows.db-decoded payloads.  We exercise
+    /// the underlying DFS row collector directly.
+    #[test]
+    fn dfs_rows_yields_byte_order_with_row_payloads() {
+        let (trie, root) = make_rows_trie_three((0x10, 5), (0x20, 17), (0x30, 99));
+        let entries = dfs_collect_row_entries(&trie, root).unwrap();
+        assert_eq!(
+            entries,
+            vec![
+                (
+                    vec![0x10],
+                    BtiRowIndexEntry {
+                        data_offset: 5,
+                        open_marker: None
+                    }
+                ),
+                (
+                    vec![0x20],
+                    BtiRowIndexEntry {
+                        data_offset: 17,
+                        open_marker: None
+                    }
+                ),
+                (
+                    vec![0x30],
+                    BtiRowIndexEntry {
+                        data_offset: 99,
+                        open_marker: None
+                    }
+                ),
+            ],
+            "Rows.db DFS must yield byte-ordered keys with decoded Data.db positions"
+        );
+    }
+
+    /// Rows.db payload with FLAG_OPEN_MARKER decodes a trailing 12-byte
+    /// DeletionTime.
+    #[test]
+    fn decode_row_payload_open_marker() {
+        // payloadBits = 0x9 → FLAG_OPEN_MARKER (0x8) set.
+        // payload: [pos vint = 7][localDeletionTime i32][markedForDeleteAt i64]
+        let mut data = vec![0x07u8]; // pos = 7
+        data.extend_from_slice(&1234i32.to_be_bytes());
+        data.extend_from_slice(&567890i64.to_be_bytes());
+        let entry = decode_bti_row_payload(&data, 0, 0x9).unwrap();
+        assert_eq!(
+            entry,
+            BtiRowIndexEntry {
+                data_offset: 7,
+                open_marker: Some((1234, 567890)),
+            }
+        );
+    }
+
+    /// Multi-byte unsigned vint decode (count-leading-ones, NOT zigzag).
+    #[test]
+    fn read_unsigned_vint_multibyte() {
+        // 300 = 0x12C → two-byte vint: 0b1000_0001 0b0010_1100 = [0x81, 0x2C]
+        let (v, n) = read_unsigned_vint_from_slice(&[0x81, 0x2C]).unwrap();
+        assert_eq!((v, n), (300, 2));
+        // 127 fits in one byte: [0x7F]
+        let (v, n) = read_unsigned_vint_from_slice(&[0x7F]).unwrap();
+        assert_eq!((v, n), (127, 1));
+    }
+
+    /// (4) range filter over a synthetic 3-leaf rows-style trie returns the
+    /// correct subset (k1..=k2 excludes k3), empty for below/above range, and
+    /// empty for reversed bounds.  This exercises the byte-level filter that
+    /// `range_query` applies on top of `dfs_collect_row_entries`.
+    #[test]
+    fn range_filter_subset_and_empty_and_reversed() {
+        let (trie, root) = make_rows_trie_three((0x10, 5), (0x20, 17), (0x30, 99));
+        let all = dfs_collect_row_entries(&trie, root).unwrap();
+
+        // Inclusive filter helper mirroring range_query's filter.
+        let filter = |lo: &[u8], hi: &[u8]| -> Vec<u64> {
+            if lo > hi {
+                return Vec::new();
+            }
+            all.iter()
+                .filter(|(k, _)| k.as_slice() >= lo && k.as_slice() <= hi)
+                .map(|(_, e)| e.data_offset)
+                .collect()
+        };
+
+        assert_eq!(filter(&[0x10], &[0x20]), vec![5, 17]); // k1..=k2 excludes k3
+        assert_eq!(filter(&[0x20], &[0x30]), vec![17, 99]); // k2..=k3 excludes k1
+        assert_eq!(filter(&[0x00], &[0x0F]), Vec::<u64>::new()); // below range
+        assert_eq!(filter(&[0x31], &[0xFF]), Vec::<u64>::new()); // above range
+        assert_eq!(filter(&[0x30], &[0x10]), Vec::<u64>::new()); // reversed bounds
+        assert_eq!(filter(&[0x10], &[0x30]), vec![5, 17, 99]); // full inclusive
+    }
+
+    /// PartitionIterator footer-based loading: build a complete in-memory
+    /// Partitions.db (trie + footer) and prove the footer loader + DFS produce
+    /// the correct entries (re-platformed off BtiHeader).
+    #[test]
+    fn partition_iterator_full_traversal_synthetic() {
+        let mut trie = vec![0u8; 12];
+        trie[0..3].copy_from_slice(&partition_leaf(0x11, -1));
+        trie[3..6].copy_from_slice(&partition_leaf(0x22, -65));
+        trie[6] = 0x50;
+        trie[7] = 0x02;
+        trie[8] = 0xAA;
+        trie[9] = 0xBB;
+        trie[10] = 0x06;
+        trie[11] = 0x03;
+        let file = make_partitions_db(trie, 6);
+
+        let (trie_data, root) = load_bti_trie_via_footer(&mut Cursor::new(file)).unwrap();
+        assert_eq!(root, 6);
+        let entries = dfs_collect_partition_entries(&trie_data, root).unwrap();
+        assert_eq!(
+            entries,
+            vec![
+                (vec![0xAA], BtiPartitionLocation::DataOffset(0)),
+                (vec![0xBB], BtiPartitionLocation::DataOffset(64)),
+            ]
+        );
+    }
+
+    /// A < 8-byte (e.g. 0-byte) Rows.db file must not load a trie (the public
+    /// `RowIterator` treats this as "no rows" and yields nothing without
+    /// panicking; the real 0-byte fixture is covered by the integration test).
+    #[test]
+    fn row_iterator_empty_file_yields_nothing() {
+        let mut cursor = Cursor::new(Vec::<u8>::new());
+        let res = load_bti_trie_via_footer(&mut cursor);
+        assert!(res.is_err(), "0-byte file must not load a trie");
     }
 }

--- a/cqlite-core/src/storage/sstable/bti/parser.rs
+++ b/cqlite-core/src/storage/sstable/bti/parser.rs
@@ -1259,41 +1259,63 @@ pub fn iterate_partitions_in_bti_file<R: Read + Seek>(
 // ─────────────────────────────────────────────────────────────────────────────
 //
 // IMPORTANT: `Rows.db` in-trie payloads are NOT the `Partitions.db` payload
-// format (which is a hash byte + SizedInts position).  A `Rows.db` trie leaf
-// carries a *row index block* entry as described by Cassandra's
-// `RowIndexReader.java` / `TrieIndexEntry.java`:
+// format (which is a hash byte + SizedInts *signed* position).  A `Rows.db`
+// trie leaf carries a `RowIndexReader.IndexInfo` whose byte layout is defined
+// authoritatively by `RowIndexReader.readPayload`
+// (cassandra-5.0.0 `RowIndexReader.java:111-125`):
 //
-//   - Data.db position of the block start (unsigned vint)
-//   - if the payload's flag bits include `FLAG_OPEN_MARKER`, a 12-byte
-//     `DeletionTime` (4-byte localDeletionTime + 8-byte markedForDeleteAt)
-//     follows the position vint.
+//   static IndexInfo readPayload(ByteBuffer buf, int ppos, int bits, Version v) {
+//       if (bits == 0) return null;
+//       int bytes = bits & ~FLAG_OPEN_MARKER;            // FLAG_OPEN_MARKER = 8
+//       long offset = SizedInts.read(buf, ppos, bytes);  // SizedInts, NOT a vint
+//       ppos += bytes;
+//       DeletionTime del = (bits & FLAG_OPEN_MARKER) != 0
+//                          ? DeletionTime.deserialize(buf, ppos) : null;
+//       return new IndexInfo(offset, del);
+//   }
 //
-// The low nibble of the node header byte is the BTI `payloadBits`.  For Rows.db
-// the convention used by Cassandra's RowIndexReader is:
-//   bit 0x8 (FLAG_OPEN_MARKER) → an open-marker DeletionTime follows.
-// We decode the Data.db block position (the definitive field) and, when the
-// open-marker flag is set, the trailing DeletionTime.  Length is not recoverable
-// from a single payload and is reported as 0.
+// So the low nibble of the node header byte (`payloadBits`) splits as:
+//   - low 3 bits  → the number of `SizedInts` bytes encoding the block offset
+//   - bit 0x8     → FLAG_OPEN_MARKER: an open-deletion `DeletionTime` follows
 //
-// Reference: docs/sstables-definitive-guide chapter 17 (lines ~148-162),
-//            Cassandra `RowIndexReader.java` / `TrieIndexEntry.java`.
+// The `offset` field is the block's offset **relative to the partition start**
+// in `Data.db` (the IndexInfo doc: "where in the data file to start looking for
+// a given key"), so absolute Data.db position = `entry.data_position + offset`.
+//
+// The writer side (`RowIndexWriter.getSerializer.write`,
+// `RowIndexWriter.java:160-180`) confirms this exactly:
+//   bytes = SizedInts.nonZeroSize(payload.offset);
+//   type.serialize(dest, node, bytes | hasOpenMarker, nodePosition);
+//   SizedInts.write(dest, payload.offset, bytes);
+//   if (hasOpenMarker) DeletionTime.serialize(payload.openDeletion, dest);
+//
+// Earlier this decoder read the offset as an *unsigned vint* and treated the
+// whole low nibble as a flag — that misparsed every real wide-partition block
+// (issue #832, Finding A's sibling bug: payloads came out as 64/0/1/… garbage).
+//
+// Reference: docs/sstables-definitive-guide chapter 17 (Rows.db footer);
+//            cassandra-5.0.0 `RowIndexReader.java`, `RowIndexWriter.java`,
+//            `TrieIndexEntry.java`, `SizedInts.java`.
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// The `FLAG_OPEN_MARKER` bit in a `Rows.db` trie node's `payloadBits`
-/// (low nibble of the header byte).  When set, a 12-byte open-marker
-/// `DeletionTime` follows the Data.db position vint.
+/// (low nibble of the header byte).  When set, an open-deletion `DeletionTime`
+/// follows the `SizedInts` block offset.  Mirrors
+/// `RowIndexReader.FLAG_OPEN_MARKER`.
 pub const FLAG_OPEN_MARKER: u8 = 0x8;
 
-/// A decoded `Rows.db` in-trie row-index block entry.
+/// A decoded `Rows.db` in-trie row-index block entry (`RowIndexReader.IndexInfo`).
 ///
-/// Mirrors the fields a `RowIndexReader` produces per block.  The headline
-/// field is [`data_offset`](Self::data_offset): the Data.db byte position of the
-/// indexed block (as Cassandra stores it in the row index).
+/// The headline field is [`data_offset`](Self::data_offset): the block's offset
+/// **relative to the partition start** in `Data.db`.  To obtain the absolute
+/// `Data.db` byte position, add the partition's data position (see
+/// [`BtiRowIndexHeader::data_position`]).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BtiRowIndexEntry {
-    /// Data.db block position decoded from the payload's leading unsigned vint.
+    /// Block offset **relative to the partition start**, decoded via
+    /// `SizedInts.read(buf, ppos, payloadBits & ~FLAG_OPEN_MARKER)`.
     pub data_offset: u64,
-    /// Open-marker deletion time `(local_deletion_time, marked_for_delete_at)`,
+    /// Open-deletion time `(local_deletion_time, marked_for_delete_at)`,
     /// present only when the `FLAG_OPEN_MARKER` payload bit is set.
     pub open_marker: Option<(i32, i64)>,
 }
@@ -1345,11 +1367,20 @@ fn read_unsigned_vint_from_slice(data: &[u8]) -> BtiResult<(u64, usize)> {
     Ok((value, total))
 }
 
-/// Decode a `Rows.db` in-trie payload at `payload_start` inside `trie_data`,
-/// given the node's `payload_bits` (low nibble of the header byte).
+/// Decode a `Rows.db` in-trie payload (`RowIndexReader.IndexInfo`) at
+/// `payload_start` inside `trie_data`, given the node's `payload_bits` (low
+/// nibble of the header byte).
 ///
-/// See the module-level note above for the format.  Returns the decoded
-/// [`BtiRowIndexEntry`].
+/// Layout (mirrors `RowIndexReader.readPayload`, cassandra-5.0.0
+/// `RowIndexReader.java:111-125`):
+///   - `bytes = payload_bits & !FLAG_OPEN_MARKER` → block offset is a
+///     `SizedInts` value of `bytes` bytes (the offset is relative to the
+///     partition's data position).
+///   - if `payload_bits & FLAG_OPEN_MARKER`, an open-deletion `DeletionTime`
+///     follows (legacy fixed 12-byte form when present in `trie_data`).
+///
+/// A `payload_bits` of `0` is not a valid leaf payload here (the caller filters
+/// such nodes out) and yields an error.
 fn decode_bti_row_payload(
     trie_data: &[u8],
     payload_start: usize,
@@ -1361,18 +1392,39 @@ fn decode_bti_row_payload(
             trie_data.len()
         )));
     }
-    let slice = &trie_data[payload_start..];
-    let (data_offset, consumed) = read_unsigned_vint_from_slice(slice)?;
+
+    // Low 3 bits = number of SizedInts bytes; bit 0x8 = open-marker flag.
+    let offset_bytes = (payload_bits & !FLAG_OPEN_MARKER) as usize;
+    if offset_bytes == 0 || offset_bytes > 7 {
+        // RowIndexWriter asserts `bytes < 8` ("rows larger than 32 PiB"); a
+        // 0-byte offset would mean an empty payload, which the trie does not
+        // emit for a real row-index block.
+        return Err(Error::Parse(format!(
+            "Rows.db payload: invalid SizedInts byte count {offset_bytes} \
+             (payload_bits=0x{payload_bits:02x}); expected 1..=7"
+        )));
+    }
+    if payload_start + offset_bytes > trie_data.len() {
+        return Err(Error::Parse(format!(
+            "Rows.db payload: SizedInts offset needs {offset_bytes} bytes, have {}",
+            trie_data.len().saturating_sub(payload_start)
+        )));
+    }
+
+    // SizedInts is a signed sign-extended big-endian read (SizedInts.read).
+    // Block offsets are non-negative in practice, but we decode faithfully.
+    let raw = sized_ints_read_from_slice(&trie_data[payload_start..payload_start + offset_bytes])?;
+    let data_offset = raw as u64;
 
     let open_marker = if payload_bits & FLAG_OPEN_MARKER != 0 {
-        let dt_start = consumed;
-        if dt_start + 12 > slice.len() {
+        let dt_start = payload_start + offset_bytes;
+        if dt_start + 12 > trie_data.len() {
             return Err(Error::Parse(format!(
                 "Rows.db payload: open-marker DeletionTime needs 12 bytes, have {}",
-                slice.len().saturating_sub(dt_start)
+                trie_data.len().saturating_sub(dt_start)
             )));
         }
-        let dt = &slice[dt_start..dt_start + 12];
+        let dt = &trie_data[dt_start..dt_start + 12];
         let local_deletion_time = i32::from_be_bytes([dt[0], dt[1], dt[2], dt[3]]);
         let marked_for_delete_at =
             i64::from_be_bytes([dt[4], dt[5], dt[6], dt[7], dt[8], dt[9], dt[10], dt[11]]);
@@ -1473,6 +1525,231 @@ pub fn iterate_rows_in_bti_trie(
     root_offset: usize,
 ) -> BtiResult<Vec<(Vec<u8>, BtiRowIndexEntry)>> {
     dfs_collect_row_entries(trie_data, root_offset)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Per-partition Rows.db entry resolution — TrieIndexEntry (issue #832 Finding A)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// The positive `position` stored in a `Partitions.db` leaf payload
+// (`BtiPartitionLocation::RowsOffset`) does NOT point at a row-index trie root.
+// It points at this partition's **row-index entry** in `Rows.db`, which must be
+// deserialized to recover the actual trie root (plus the partition's Data.db
+// position, block count and partition-level deletion).  Feeding `RowsOffset`
+// straight to `iterate_rows_in_bti_trie` parses entry metadata as a trie node
+// and fails (or, worse, returns garbage) on real wide partitions.
+//
+// On-disk layout at `RowsOffset` (validated against the `wide_table` fixture —
+// see `tests/issue_832_bti_traversal.rs`; cassandra-5.0.0 `TrieIndexEntry.java`
+// `serialize`/`deserialize`, lines 89-120, and `RowIndexWriter.complete`):
+//
+//   [u16 key_length][partition key bytes]      ← short-length-prefixed key
+//   [data file position : unsigned vint]       ← partition start in Data.db
+//   [trie_root - base    : SIGNED vint]         ← base = RowsOffset + key_length
+//   [row index block count : unsigned vint32]
+//   [partition DeletionTime]                    ← delta/compact form; best-effort
+//
+// `TrieIndexEntry.deserialize` computes `indexTrieRoot = readVInt() + base`.
+// Cassandra passes `base` as the file position from which the entry is read;
+// for this fixture that base is `RowsOffset + key_length` (the partition key
+// is length-prefixed and precedes the vint fields).  Concretely, the three
+// `wide_table` partitions decode as:
+//
+//   RowsOffset 242 → key=pk1, dataPos=0,       rootΔ=-10 → trieRoot=236, blocks=38
+//   RowsOffset 494 → key=pk2, dataPos=619201,  rootΔ=-10 → trieRoot=488, blocks=38
+//   RowsOffset 748 → key=pk3, dataPos=1238408, rootΔ=-10 → trieRoot=742, blocks=38
+//
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A single `Rows.db` row-index entry paired with its reconstructed
+/// byte-comparable clustering separator key, as yielded by the in-order DFS.
+pub type BtiRowIndexEntryWithKey = (Vec<u8>, BtiRowIndexEntry);
+
+/// A deserialized per-partition `Rows.db` row-index entry (Cassandra
+/// `TrieIndexEntry`).  Produced by [`resolve_rows_db_entry`] from the
+/// `RowsOffset` returned by a `Partitions.db` lookup.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BtiRowIndexHeader {
+    /// Absolute byte position of the partition's start in `Data.db`.  Block
+    /// offsets in [`BtiRowIndexEntry::data_offset`] are relative to this.
+    pub data_position: u64,
+    /// Byte offset, within the `Rows.db` file, of this partition's row-index
+    /// trie root node.  Feed this to [`iterate_rows_in_bti_trie`] /
+    /// [`RowsParser::range_query`] / [`RowsParser::iterate_rows`].
+    pub trie_root: usize,
+    /// Number of row-index blocks indexed by this partition's trie.
+    pub block_count: u32,
+    /// Partition-level deletion `(local_deletion_time, marked_for_delete_at)`,
+    /// when it could be decoded as the legacy fixed 12-byte form; `None` for the
+    /// compact "live" sentinel or when too few trailing bytes remain.
+    pub partition_deletion: Option<(i32, i64)>,
+}
+
+/// Read a signed VInt (Cassandra zig-zag, `DataInputPlus.readVInt`) from `data`,
+/// returning `(value, bytes_consumed)`.
+fn read_signed_vint_from_slice(data: &[u8]) -> BtiResult<(i64, usize)> {
+    let (u, n) = read_unsigned_vint_from_slice(data)?;
+    // ZigZag decode: (u >>> 1) ^ -(u & 1)
+    let value = ((u >> 1) as i64) ^ -((u & 1) as i64);
+    Ok((value, n))
+}
+
+/// Resolve a partition's row-index entry in `Rows.db`, given the `RowsOffset`
+/// from a `Partitions.db` lookup ([`BtiPartitionLocation::RowsOffset`]).
+///
+/// This is the fix for issue #832 Finding A: `RowsOffset` is the offset of the
+/// per-partition `TrieIndexEntry`, NOT a trie root.  This deserializes that
+/// entry — recovering the partition's Data.db position, the actual row-index
+/// trie root, the block count and the partition deletion — so traversal can be
+/// rooted correctly.
+///
+/// `rows_db` is the full `Rows.db` file contents; `rows_offset` is the
+/// `RowsOffset` value.  All reads are bounds-checked.
+///
+/// # Errors
+/// Returns a parse error if `rows_offset` is out of bounds, the key length is
+/// implausible, the vint fields are truncated, or the recovered trie root falls
+/// outside `rows_db`.
+pub fn resolve_rows_db_entry(rows_db: &[u8], rows_offset: usize) -> BtiResult<BtiRowIndexHeader> {
+    if rows_offset + 2 > rows_db.len() {
+        return Err(Error::Parse(format!(
+            "Rows.db entry: rows_offset {rows_offset} + 2 (key length) exceeds file size {}",
+            rows_db.len()
+        )));
+    }
+
+    // [u16 key_length][key bytes]
+    let key_length = u16::from_be_bytes([rows_db[rows_offset], rows_db[rows_offset + 1]]) as usize;
+    let entry_start = rows_offset + 2 + key_length;
+    if entry_start > rows_db.len() {
+        return Err(Error::Parse(format!(
+            "Rows.db entry: key length {key_length} at offset {rows_offset} overruns file size {}",
+            rows_db.len()
+        )));
+    }
+
+    // base for the SIGNED root delta = RowsOffset + key_length (see module note).
+    let base = rows_offset + key_length;
+
+    let mut cur = entry_start;
+    let (data_position, n) = read_unsigned_vint_from_slice(&rows_db[cur..])?;
+    cur += n;
+
+    let (root_delta, n) = read_signed_vint_from_slice(&rows_db[cur..])?;
+    cur += n;
+
+    // indexTrieRoot = readVInt() + base   (TrieIndexEntry.deserialize)
+    let trie_root_signed = root_delta + base as i64;
+    if trie_root_signed < 0 || (trie_root_signed as usize) >= rows_db.len() {
+        return Err(Error::Parse(format!(
+            "Rows.db entry: recovered trie root {trie_root_signed} out of bounds \
+             (base={base}, delta={root_delta}, file size={})",
+            rows_db.len()
+        )));
+    }
+    let trie_root = trie_root_signed as usize;
+
+    let (block_count_u64, n) = read_unsigned_vint_from_slice(&rows_db[cur..])?;
+    cur += n;
+    let block_count = u32::try_from(block_count_u64).map_err(|_| {
+        Error::Parse(format!(
+            "Rows.db entry: implausible block count {block_count_u64}"
+        ))
+    })?;
+
+    // Partition DeletionTime: the `da`-family form is delta/compact and not
+    // required for traversal correctness, so decode the legacy fixed 12-byte
+    // form best-effort and otherwise leave it `None` rather than failing.
+    let partition_deletion = if cur + 12 <= rows_db.len() {
+        let dt = &rows_db[cur..cur + 12];
+        let ldt = i32::from_be_bytes([dt[0], dt[1], dt[2], dt[3]]);
+        let mfda = i64::from_be_bytes([dt[4], dt[5], dt[6], dt[7], dt[8], dt[9], dt[10], dt[11]]);
+        Some((ldt, mfda))
+    } else {
+        None
+    };
+
+    Ok(BtiRowIndexHeader {
+        data_position,
+        trie_root,
+        block_count,
+        partition_deletion,
+    })
+}
+
+/// Select the row-index blocks that may contain clustering keys in the
+/// inclusive byte-comparable range `[start, end]`, applying row-index
+/// **separator** semantics (issue #832 Finding B).
+///
+/// ## Why naive `[start, end]` filtering is wrong
+///
+/// A `Rows.db` row-index trie stores **separators**, not block start keys.  For
+/// consecutive blocks the writer (`RowIndexWriter.add`) stores the shortest
+/// `sep` with `prevMax < sep <= nextBlockFirstKey`, and `complete()` appends a
+/// trailing separator after the last block.  Consequently the separator `s_i`
+/// labels the boundary at the START of block `i`'s key range, and block `i`
+/// covers the half-open key interval `[s_i, s_{i+1})` (the final block runs to
+/// the trailing separator).  A reader locates the block for a key `K` via the
+/// trie *floor* of `K` (`RowIndexReader.separatorFloor`), i.e. the block whose
+/// separator is the greatest `<= K`.
+///
+/// Therefore a block `i` overlaps the requested clustering range `[start, end]`
+/// iff its key interval `[s_i, s_{i+1})` intersects `[start, end]`:
+///
+///   `s_i <= end`  AND  `s_{i+1} > start`
+///
+/// (For the last block, `s_{i+1}` is treated as +∞.)  Filtering separators by
+/// `start <= s_i <= end` — as the original implementation did — drops the
+/// *floor* block whose separator is below `start` but whose interval still
+/// contains `start`, and mishandles the block straddling `end`.
+///
+/// `entries` MUST be the full ascending-order `(separator, block)` list for one
+/// partition (as produced by [`iterate_rows_in_bti_trie`]).  `start`/`end` are
+/// byte-comparable clustering bounds in the **same encoding as the trie keys**
+/// (Cassandra OSS50 clustering byte-comparable order).  Reversed bounds
+/// (`start > end`) yield an empty result.
+pub fn select_row_index_blocks_for_range(
+    entries: &[(Vec<u8>, BtiRowIndexEntry)],
+    start: &[u8],
+    end: &[u8],
+) -> Vec<BtiRowIndexEntry> {
+    if start > end || entries.is_empty() {
+        return Vec::new();
+    }
+
+    let mut out = Vec::new();
+    for (i, (sep_i, block)) in entries.iter().enumerate() {
+        // s_{i+1}: the next separator, or +∞ for the last block.
+        let next_is_greater_than_start = match entries.get(i + 1) {
+            Some((sep_next, _)) => sep_next.as_slice() > start,
+            None => true, // +∞ > start
+        };
+        let overlaps = sep_i.as_slice() <= end && next_is_greater_than_start;
+        if overlaps {
+            out.push(block.clone());
+        }
+    }
+    out
+}
+
+/// Enumerate every row-index block entry for the partition whose `Rows.db`
+/// row-index entry is at `rows_offset` (the `RowsOffset` from `Partitions.db`),
+/// in ascending byte-comparable (clustering) order.
+///
+/// This is the convenience entry point that combines [`resolve_rows_db_entry`]
+/// (Finding A) with [`iterate_rows_in_bti_trie`]: it resolves the real trie root
+/// from the per-partition entry and then traverses from that root.  Each
+/// returned [`BtiRowIndexEntry::data_offset`] is **relative to the partition
+/// start**; add `header.data_position` for an absolute `Data.db` position.
+///
+/// Returns `(header, entries)`.
+pub fn iterate_rows_for_partition(
+    rows_db: &[u8],
+    rows_offset: usize,
+) -> BtiResult<(BtiRowIndexHeader, Vec<BtiRowIndexEntryWithKey>)> {
+    let header = resolve_rows_db_entry(rows_db, rows_offset)?;
+    let entries = iterate_rows_in_bti_trie(rows_db, header.trie_root)?;
+    Ok((header, entries))
 }
 
 /// Enumerate row-index entries in a `Rows.db` file that is a **single-partition**
@@ -1832,61 +2109,73 @@ impl<R: Read + Seek> RowsParser<R> {
     }
 
     /// Clustering-key range/slice traversal of a single partition's `Rows.db`
-    /// row-index trie (issue #832).
+    /// row-index trie (issue #832), taking **pre-encoded byte-comparable
+    /// clustering bounds** and applying row-index **separator** semantics.
     ///
-    /// ## Rooting (Finding 2)
+    /// ## Rooting (Finding A)
     ///
-    /// `rows_root` is the byte offset, within the `Rows.db` file, of THIS
-    /// partition's row-index trie root — i.e. the `RowsOffset` returned from the
-    /// `Partitions.db` lookup ([`BtiPartitionLocation::RowsOffset`]).  A real
-    /// `Rows.db` concatenates one such trie per wide partition, so the traversal
-    /// must be rooted at the partition's offset, NOT at a whole-file footer.
+    /// `rows_offset` is the partition's `RowsOffset` from the `Partitions.db`
+    /// lookup ([`BtiPartitionLocation::RowsOffset`]).  It points at the
+    /// per-partition `TrieIndexEntry`, NOT the trie root, so this resolves the
+    /// real trie root via [`resolve_rows_db_entry`] before traversing.
     ///
-    /// Encodes `start_key` and `end_key` via the byte-comparable encoder, then
-    /// returns every row-index entry whose reconstructed byte-comparable key
-    /// falls within `[encoded_start, encoded_end]` (inclusive both ends, matching
-    /// Cassandra clustering-slice semantics).  Reversed bounds (start > end)
-    /// yield an empty result.
+    /// ## Separator semantics (Finding B)
     ///
-    /// ## Soundness of the byte-comparable filter (Finding 3)
+    /// `encoded_start`/`encoded_end` are inclusive byte-comparable clustering
+    /// bounds in the **same encoding as the trie keys** (Cassandra OSS50
+    /// clustering byte-comparable form — e.g. an `int` clustering `ck` encodes
+    /// as `(ck as u32 ^ 0x8000_0000).to_be_bytes()`).  Because the trie stores
+    /// separators (block boundaries), block selection uses
+    /// [`select_row_index_blocks_for_range`]: a block is returned iff its
+    /// half-open key interval `[s_i, s_{i+1})` intersects `[start, end]`.  This
+    /// correctly includes the *floor* block that contains `start` even when its
+    /// separator is below `start`, and excludes blocks that only abut the range.
     ///
-    /// The filter compares the *full* encoded bounds against the keys
-    /// reconstructed by the DFS, and that comparison is sound because every BTI
-    /// trie edge in this representation carries **exactly one transition byte**
-    /// (the only node kinds are `Single`, `Sparse`, and `Dense` — there is no
-    /// multi-byte "chain" node).  Concatenating the transition bytes from the
-    /// root to any node therefore reconstructs the COMPLETE byte-comparable key
-    /// terminating at that node.  An internal node may itself carry a payload
-    /// whose key `K` is a strict prefix of a deeper leaf's key `K2`; because the
-    /// keys are complete (not truncated), ordinary lexicographic comparison
-    /// handles the prefix relationship correctly — `K` is included iff it lies
-    /// in `[start, end]`, independently of `K2`. No key is spuriously dropped or
-    /// included.
+    /// Reversed bounds yield an empty result.
+    ///
+    /// Returns the resolved [`BtiRowIndexHeader`] (for the partition's Data.db
+    /// position and block count) together with the selected blocks; each block's
+    /// `data_offset` is relative to `header.data_position`.
+    pub fn range_query_encoded(
+        &mut self,
+        rows_offset: usize,
+        encoded_start: &[u8],
+        encoded_end: &[u8],
+    ) -> BtiResult<(BtiRowIndexHeader, Vec<BtiRowIndexEntry>)> {
+        let trie_data = self.read_full_rows_db()?;
+        let header = resolve_rows_db_entry(&trie_data, rows_offset)?;
+        let all = iterate_rows_in_bti_trie(&trie_data, header.trie_root)?;
+        let blocks = select_row_index_blocks_for_range(&all, encoded_start, encoded_end);
+        Ok((header, blocks))
+    }
+
+    /// Clustering-key range/slice traversal using the **custom CQLite**
+    /// byte-comparable encoder ([`ByteComparableEncoder`]).
+    ///
+    /// NOTE: the CQLite encoder is NOT byte-identical to Cassandra's on-disk
+    /// OSS50 clustering encoding (it prefixes a type discriminator), so for
+    /// fixture-faithful filtering against real `Rows.db` separators callers
+    /// should encode bounds in the Cassandra form and use
+    /// [`range_query_encoded`](Self::range_query_encoded).  This method is kept
+    /// for in-process round-trips where both the writer and the bounds use the
+    /// CQLite encoder.
+    ///
+    /// `rows_offset` is the partition's `RowsOffset` (resolved to the real trie
+    /// root via [`resolve_rows_db_entry`], Finding A).  Separator semantics
+    /// (Finding B) are applied via [`select_row_index_blocks_for_range`].
     pub fn range_query(
         &mut self,
-        rows_root: usize,
+        rows_offset: usize,
         start_key: &[Value],
         end_key: &[Value],
     ) -> BtiResult<Vec<BtiRowIndexEntry>> {
         let encoded_start = self.encoder.encode_composite_key(start_key)?;
         let encoded_end = self.encoder.encode_composite_key(end_key)?;
-
-        // Reversed bounds → empty range.
         if encoded_start > encoded_end {
             return Ok(Vec::new());
         }
-
-        let trie_data = self.read_full_rows_db()?;
-        let all = iterate_rows_in_bti_trie(&trie_data, rows_root)?;
-
-        Ok(all
-            .into_iter()
-            .filter(|(key, _)| {
-                key.as_slice() >= encoded_start.as_slice()
-                    && key.as_slice() <= encoded_end.as_slice()
-            })
-            .map(|(_, entry)| entry)
-            .collect())
+        let (_, blocks) = self.range_query_encoded(rows_offset, &encoded_start, &encoded_end)?;
+        Ok(blocks)
     }
 
     /// Read the entire `Rows.db` file into a buffer for in-trie traversal.
@@ -1902,13 +2191,17 @@ impl<R: Read + Seek> RowsParser<R> {
         Ok(buf)
     }
 
-    /// Iterator over all rows in a single partition's row-index trie, rooted at
-    /// `rows_root` (the partition's `RowsOffset` from `Partitions.db`).
+    /// Iterator over all row-index blocks of a single partition, given the
+    /// partition's `RowsOffset` from `Partitions.db`
+    /// ([`BtiPartitionLocation::RowsOffset`]).
     ///
-    /// See [`range_query`](Self::range_query) for why an explicit root is
-    /// required: a `Rows.db` holds one row-index trie per partition.
-    pub fn iterate_rows(&mut self, rows_root: usize) -> BtiResult<RowIterator<'_, R>> {
-        RowIterator::new(self, rows_root)
+    /// `rows_offset` points at the per-partition `TrieIndexEntry` (NOT the trie
+    /// root); this resolves the real root via [`resolve_rows_db_entry`]
+    /// (Finding A) before traversing.  Blocks are yielded in ascending
+    /// byte-comparable clustering order; each [`BtiRowIndexEntry::data_offset`]
+    /// is relative to the partition's Data.db position.
+    pub fn iterate_rows(&mut self, rows_offset: usize) -> BtiResult<RowIterator<'_, R>> {
+        RowIterator::new(self, rows_offset)
     }
 
     /// Get header information
@@ -1968,17 +2261,18 @@ impl<'a, R: Read + Seek> Iterator for PartitionIterator<'a, R> {
     }
 }
 
-/// Iterator over the row-index entries of **one partition's** `Rows.db`
-/// row-index trie, rooted at an explicit `rows_root`, in byte-comparable order
-/// (issue #832).
+/// Iterator over the row-index block entries of **one partition's** `Rows.db`
+/// row-index trie (issue #832), in ascending byte-comparable clustering order.
 ///
-/// A real `Rows.db` concatenates one row-index trie per wide partition, so the
-/// iterator is rooted at the partition's `RowsOffset` (from `Partitions.db`),
-/// NOT at a whole-file footer (Finding 2).  The full file is read into memory
-/// and traversed in-order during construction.  Each yielded `Vec<u8>` is the
-/// reconstructed byte-comparable clustering key; the [`BtiRowIndexEntry`]
-/// carries the Data.db block position (definitive) and an optional open-marker
-/// `DeletionTime`.
+/// A real `Rows.db` concatenates one per-partition `TrieIndexEntry` + row-index
+/// trie per wide partition.  The iterator is created from the partition's
+/// `RowsOffset` (from `Partitions.db`); that offset points at the per-partition
+/// entry, so the real trie root is resolved via [`resolve_rows_db_entry`]
+/// (Finding A) before traversal — it is NOT a whole-file footer root.  The full
+/// file is read into memory and traversed in-order during construction.  Each
+/// yielded `Vec<u8>` is the reconstructed byte-comparable clustering separator
+/// key; the [`BtiRowIndexEntry`] carries the block offset (relative to the
+/// partition's Data.db position) and an optional open-deletion `DeletionTime`.
 ///
 /// An empty (e.g. 0-byte) `Rows.db` yields nothing without panicking.
 pub struct RowIterator<'a, R: Read + Seek> {
@@ -1989,7 +2283,7 @@ pub struct RowIterator<'a, R: Read + Seek> {
 }
 
 impl<'a, R: Read + Seek> RowIterator<'a, R> {
-    fn new(parser: &'a mut RowsParser<R>, rows_root: usize) -> BtiResult<Self> {
+    fn new(parser: &'a mut RowsParser<R>, rows_offset: usize) -> BtiResult<Self> {
         // An empty Rows.db (e.g. a 0-byte file for SSTables with no row index)
         // yields nothing rather than erroring.
         let file_size = parser.reader.seek(SeekFrom::End(0))?;
@@ -2001,10 +2295,12 @@ impl<'a, R: Read + Seek> RowIterator<'a, R> {
             });
         }
 
-        let (entries, pending_error) = match parser
-            .read_full_rows_db()
-            .and_then(|trie| iterate_rows_in_bti_trie(&trie, rows_root))
-        {
+        // Finding A: resolve the per-partition TrieIndexEntry at `rows_offset`
+        // to recover the actual trie root, then traverse from THAT root.
+        let (entries, pending_error) = match parser.read_full_rows_db().and_then(|trie| {
+            let header = resolve_rows_db_entry(&trie, rows_offset)?;
+            iterate_rows_in_bti_trie(&trie, header.trie_root)
+        }) {
             Ok(v) => (v, None),
             Err(e) => (Vec::new(), Some(e)),
         };
@@ -3615,6 +3911,153 @@ mod tests {
         assert_eq!(filter(&[0x31], &[0xFF]), Vec::<u64>::new()); // above range
         assert_eq!(filter(&[0x30], &[0x10]), Vec::<u64>::new()); // reversed bounds
         assert_eq!(filter(&[0x10], &[0x30]), vec![5, 17, 99]); // full inclusive
+    }
+
+    /// Finding B (issue #832): `select_row_index_blocks_for_range` applies
+    /// row-index SEPARATOR semantics — a block whose half-open key interval
+    /// `[s_i, s_{i+1})` overlaps `[start, end]` is included, including the FLOOR
+    /// block whose separator is below `start`.  This is the property naive
+    /// `[start, end]` membership filtering gets wrong.
+    #[test]
+    fn select_blocks_separator_semantics() {
+        // Three separators (block boundaries) at byte-comparable keys 0x10, 0x20,
+        // 0x30 with offsets 5, 17, 99.  Block intervals:
+        //   block@5  : [0x10, 0x20)
+        //   block@17 : [0x20, 0x30)
+        //   block@99 : [0x30, +inf)
+        let entries = vec![
+            (
+                vec![0x10u8],
+                BtiRowIndexEntry {
+                    data_offset: 5,
+                    open_marker: None,
+                },
+            ),
+            (
+                vec![0x20u8],
+                BtiRowIndexEntry {
+                    data_offset: 17,
+                    open_marker: None,
+                },
+            ),
+            (
+                vec![0x30u8],
+                BtiRowIndexEntry {
+                    data_offset: 99,
+                    open_marker: None,
+                },
+            ),
+        ];
+        let offs = |start: &[u8], end: &[u8]| -> Vec<u64> {
+            select_row_index_blocks_for_range(&entries, start, end)
+                .into_iter()
+                .map(|b| b.data_offset)
+                .collect()
+        };
+
+        // A key strictly inside the FIRST block's interval ([0x10,0x20)): the
+        // floor block @5 must be selected even though its separator (0x10) is
+        // <= start (0x18) — naive `start<=sep<=end` would WRONGLY drop it.
+        assert_eq!(
+            offs(&[0x18], &[0x18]),
+            vec![5],
+            "floor block must be selected"
+        );
+
+        // A range spanning block 1 into block 2 selects both.
+        assert_eq!(offs(&[0x18], &[0x28]), vec![5, 17]);
+
+        // A range starting exactly at a separator includes that block (and the
+        // straddling next is excluded because its s_{i} > end).
+        assert_eq!(offs(&[0x20], &[0x2F]), vec![17]);
+
+        // A range above the last separator selects only the open-ended last block.
+        assert_eq!(offs(&[0x40], &[0x50]), vec![99]);
+
+        // Below the first separator: block@5's interval [0x10,0x20) does not
+        // overlap [0x00,0x0F], so nothing is selected.
+        assert_eq!(offs(&[0x00], &[0x0F]), Vec::<u64>::new());
+
+        // Full range selects all blocks.
+        assert_eq!(offs(&[0x00], &[0xFF]), vec![5, 17, 99]);
+
+        // Reversed bounds → empty.
+        assert_eq!(offs(&[0x30], &[0x10]), Vec::<u64>::new());
+
+        // Empty entries → empty.
+        assert!(select_row_index_blocks_for_range(&[], &[0x00], &[0xFF]).is_empty());
+    }
+
+    /// Finding A (issue #832): `resolve_rows_db_entry` deserializes a synthetic
+    /// per-partition `TrieIndexEntry` and recovers the trie root via
+    /// `indexTrieRoot = readVInt() + (RowsOffset + key_length)`.  Mirrors the
+    /// real `wide_table` layout: `[u16 keylen][key][dataPos uvint][rootΔ svint]
+    /// [blockCount uvint][deletion 12B]`.
+    #[test]
+    fn resolve_rows_db_entry_recovers_root_and_metadata() {
+        // Place a 1-byte pad so the trie "root" lives at a non-zero offset.
+        let mut buf = vec![0xEEu8; 4]; // bytes 0..4: pretend trie nodes
+        let rows_offset = buf.len(); // entry starts here, e.g. 4
+
+        // key: length 4, value 0x00000007
+        buf.extend_from_slice(&4u16.to_be_bytes());
+        buf.extend_from_slice(&[0x00, 0x00, 0x00, 0x07]);
+        let base = rows_offset + 4; // RowsOffset + key_length
+
+        // dataPos = 123 (unsigned vint, 1 byte since < 128)
+        buf.push(123);
+        // rootΔ such that trie_root = 2 (a node inside the pad region): Δ = 2 - base
+        let root_delta: i64 = 2 - base as i64;
+        // zigzag-encode then unsigned-vint (1 byte for small magnitudes)
+        let zig = ((root_delta << 1) ^ (root_delta >> 63)) as u64;
+        assert!(zig < 128, "test setup expects a 1-byte vint");
+        buf.push(zig as u8);
+        // blockCount = 38 (unsigned vint)
+        buf.push(38);
+        // partition DeletionTime (legacy fixed 12 bytes): ldt=0x09, mfda=0x11
+        buf.extend_from_slice(&9i32.to_be_bytes());
+        buf.extend_from_slice(&17i64.to_be_bytes());
+
+        let header = resolve_rows_db_entry(&buf, rows_offset).unwrap();
+        assert_eq!(header.data_position, 123);
+        assert_eq!(
+            header.trie_root, 2,
+            "trie root = rootΔ + (RowsOffset + keylen)"
+        );
+        assert_eq!(header.block_count, 38);
+        assert_eq!(header.partition_deletion, Some((9, 17)));
+
+        // Out-of-bounds RowsOffset → clean error, no panic.
+        assert!(resolve_rows_db_entry(&buf, buf.len() + 10).is_err());
+    }
+
+    /// Signed vint (zig-zag) decode round-trips small +/- values.
+    #[test]
+    fn read_signed_vint_zigzag() {
+        // -10 → zigzag 19 → 1-byte vint 0x13 (the real wide_table rootΔ).
+        let (v, n) = read_signed_vint_from_slice(&[0x13]).unwrap();
+        assert_eq!((v, n), (-10, 1));
+        // 0 → 0x00
+        assert_eq!(read_signed_vint_from_slice(&[0x00]).unwrap(), (0, 1));
+        // 63 → zigzag 126 → 0x7E
+        assert_eq!(read_signed_vint_from_slice(&[0x7E]).unwrap(), (63, 1));
+    }
+
+    /// The Rows.db payload offset is a SizedInts value (NOT an unsigned vint):
+    /// `bytes = payloadBits & ~FLAG_OPEN_MARKER`.  A 2-byte SizedInts offset of
+    /// 0x4080 (=16512, the real first block offset) must decode correctly.
+    #[test]
+    fn decode_row_payload_sizedints_two_bytes() {
+        // payloadBits = 2 → 2 SizedInts bytes, no open marker.
+        let data = vec![0x40u8, 0x80];
+        let entry = decode_bti_row_payload(&data, 0, 0x2).unwrap();
+        assert_eq!(
+            entry,
+            BtiRowIndexEntry {
+                data_offset: 16512,
+                open_marker: None,
+            }
+        );
     }
 
     /// PartitionIterator footer-based loading: build a complete in-memory

--- a/cqlite-core/src/storage/sstable/bti/parser.rs
+++ b/cqlite-core/src/storage/sstable/bti/parser.rs
@@ -348,13 +348,16 @@ fn parse_bti_node(data: &[u8], offset: u64) -> BtiResult<BtiNode> {
                 let mut children = Vec::with_capacity(range_len);
                 for i in 0..range_len {
                     let delta = read_12bit_packed(&data[3..], i);
-                    // delta == 0 means "no transition" for Dense nodes
-                    let child_offset = if delta == 0 {
-                        0
+                    // delta == 0 is the "no transition" sentinel → None.  Any
+                    // other delta is a real child at `offset - delta` (which may
+                    // be absolute offset 0 — a legitimate child, distinct from
+                    // the sentinel).
+                    let child = if delta == 0 {
+                        None
                     } else {
-                        offset.saturating_sub(delta)
+                        Some(SizedPointer::new(offset.saturating_sub(delta)))
                     };
-                    children.push(SizedPointer::new(child_offset));
+                    children.push(child);
                 }
                 Ok(BtiNode {
                     node_type,
@@ -380,13 +383,16 @@ fn parse_bti_node(data: &[u8], offset: u64) -> BtiResult<BtiNode> {
                 for i in 0..range_len {
                     let ptr_off = 3 + i * ptr_bytes;
                     let delta = read_be_unsigned(&data[ptr_off..ptr_off + ptr_bytes]);
-                    // delta == 0 means "no transition" for Dense nodes
-                    let child_offset = if delta == 0 {
-                        0
+                    // delta == 0 is the "no transition" sentinel → None.  Any
+                    // other delta is a real child at `offset - delta` (which may
+                    // be absolute offset 0 — a legitimate child, distinct from
+                    // the sentinel).
+                    let child = if delta == 0 {
+                        None
                     } else {
-                        offset.saturating_sub(delta)
+                        Some(SizedPointer::new(offset.saturating_sub(delta)))
                     };
-                    children.push(SizedPointer::new(child_offset));
+                    children.push(child);
                 }
                 Ok(BtiNode {
                     node_type,
@@ -1118,9 +1124,12 @@ fn load_bti_trie_via_footer<R: Read + Seek>(reader: &mut R) -> BtiResult<(Vec<u8
 /// for a parsed BTI node, ready for in-order DFS.
 ///
 /// Crucially this iterates `Dense` children directly by index (transition byte =
-/// `start_byte + i`) and **skips** any child whose absolute offset is `0`, which
-/// is the Dense "no transition" sentinel.  ([`BtiNode::get_transitions`] returns
-/// an empty Vec for Dense nodes and must NOT be used for traversal.)
+/// `start_byte + i`) and **skips** the `None` slots, which are the Dense "no
+/// transition" sentinels (raw delta `0`).  A `Some(ptr)` slot is a real child
+/// and is always emitted — *including* one whose absolute offset is `0` (the
+/// first-written leaf in BTI's bottom-up layout legitimately lives at offset 0).
+/// ([`BtiNode::get_transitions`] returns an empty Vec for Dense nodes and must
+/// NOT be used for traversal.)
 ///
 /// `Sparse` transitions are returned in their stored order; the parser preserves
 /// the on-disk ascending order, and we sort defensively.
@@ -1145,16 +1154,14 @@ fn ordered_children(node: &BtiNode) -> Vec<(u8, usize)> {
         } => {
             let mut out = Vec::new();
             for (i, child) in children.iter().enumerate() {
-                let off = child.distance as usize;
-                // distance == 0 is the Dense "no transition" sentinel.  For a
-                // Dense node a real child can never live at absolute offset 0:
-                // the parent is at a higher offset and Cassandra never emits a
-                // Dense delta equal to the node offset for a real transition.
-                if off == 0 {
-                    continue;
+                // `None` is the Dense "no transition" sentinel (raw delta 0):
+                // skip it.  `Some(ptr)` is a real child and is always emitted,
+                // even when `ptr.distance == 0` — a real child can live at
+                // absolute trie offset 0 (the first-written leaf).
+                if let Some(ptr) = child {
+                    let transition_byte = start_byte.wrapping_add(i as u8);
+                    out.push((transition_byte, ptr.distance as usize));
                 }
-                let transition_byte = start_byte.wrapping_add(i as u8);
-                out.push((transition_byte, off));
             }
             out
         }
@@ -1442,12 +1449,46 @@ fn dfs_collect_row_entries(
     })
 }
 
-/// Enumerate **all** row-index entries in a real Cassandra 5.0 `Rows.db` BTI
-/// file (issue #832), in byte-comparable order.
+/// Enumerate every row-index entry in a `Rows.db` row-index trie **rooted at an
+/// explicit `root_offset`**, in byte-comparable order
+/// (`(reconstructed_clustering_key, BtiRowIndexEntry)`).
 ///
-/// Headerless public entry point (footer-based, NOT [`BtiHeader`]).  A
-/// `< 8`-byte (e.g. 0-byte) `Rows.db` — common for partitions with no row index
-/// — yields an empty Vec without erroring.
+/// ## Why the root must be supplied by the caller
+///
+/// A real Cassandra 5.0 `Rows.db` is NOT a single whole-file trie: it holds
+/// **many independent per-partition row-index tries** concatenated together.
+/// There is one row-index trie per (wide) partition, and the root of a given
+/// partition's trie is the `RowsOffset` returned from the corresponding
+/// `Partitions.db` lookup ([`BtiPartitionLocation::RowsOffset`]) — it is NOT the
+/// 8-byte file footer, which spans the whole file and would misparse any
+/// multi-partition `Rows.db`.
+///
+/// This is therefore the correct general entry point: pass the full `Rows.db`
+/// bytes as `trie_data` and the partition's `RowsOffset` as `root_offset`.
+///
+/// An out-of-bounds `root_offset` (e.g. on empty `trie_data`) yields a clean
+/// parse error rather than a panic.
+pub fn iterate_rows_in_bti_trie(
+    trie_data: &[u8],
+    root_offset: usize,
+) -> BtiResult<Vec<(Vec<u8>, BtiRowIndexEntry)>> {
+    dfs_collect_row_entries(trie_data, root_offset)
+}
+
+/// Enumerate row-index entries in a `Rows.db` file that is a **single-partition**
+/// trie rooted at its 8-byte footer, in byte-comparable order.
+///
+/// ## Precondition
+///
+/// This treats the WHOLE file as one trie whose root is named by the trailing
+/// 8-byte footer.  That is only correct when the `Rows.db` contains exactly one
+/// partition's row-index trie (or is empty).  For a real multi-partition
+/// `Rows.db` you MUST instead use [`iterate_rows_in_bti_trie`] with the
+/// per-partition `RowsOffset` obtained from `Partitions.db`; the file footer
+/// does not describe a single whole-file root in that case.
+///
+/// A `< 8`-byte (e.g. 0-byte) `Rows.db` — common for SSTables where no partition
+/// has a row index — yields an empty Vec without erroring.
 pub fn iterate_rows_in_bti_file<R: Read + Seek>(
     reader: &mut R,
 ) -> BtiResult<Vec<(Vec<u8>, BtiRowIndexEntry)>> {
@@ -1456,7 +1497,7 @@ pub fn iterate_rows_in_bti_file<R: Read + Seek>(
         return Ok(Vec::new());
     }
     let (trie_data, root_offset) = load_bti_trie_via_footer(reader)?;
-    dfs_collect_row_entries(&trie_data, root_offset)
+    iterate_rows_in_bti_trie(&trie_data, root_offset)
 }
 
 /// BTI header structure for index files
@@ -1790,20 +1831,40 @@ impl<R: Read + Seek> RowsParser<R> {
         parse_bti_node(data, offset)
     }
 
-    /// Clustering-key range/slice traversal of a `Rows.db` trie (issue #832).
+    /// Clustering-key range/slice traversal of a single partition's `Rows.db`
+    /// row-index trie (issue #832).
+    ///
+    /// ## Rooting (Finding 2)
+    ///
+    /// `rows_root` is the byte offset, within the `Rows.db` file, of THIS
+    /// partition's row-index trie root — i.e. the `RowsOffset` returned from the
+    /// `Partitions.db` lookup ([`BtiPartitionLocation::RowsOffset`]).  A real
+    /// `Rows.db` concatenates one such trie per wide partition, so the traversal
+    /// must be rooted at the partition's offset, NOT at a whole-file footer.
     ///
     /// Encodes `start_key` and `end_key` via the byte-comparable encoder, then
     /// returns every row-index entry whose reconstructed byte-comparable key
     /// falls within `[encoded_start, encoded_end]` (inclusive both ends, matching
-    /// Cassandra clustering-slice semantics).  Comparison is lexicographic over
-    /// the reconstructed transition-byte keys.
+    /// Cassandra clustering-slice semantics).  Reversed bounds (start > end)
+    /// yield an empty result.
     ///
-    /// First-cut correctness implementation: runs the full in-order DFS and
-    /// filters by the byte-comparable bounds.  Reversed bounds (start > end)
-    /// yield an empty result.  The trie is loaded via the footer (NOT the
-    /// fictional [`BtiHeader`]).
+    /// ## Soundness of the byte-comparable filter (Finding 3)
+    ///
+    /// The filter compares the *full* encoded bounds against the keys
+    /// reconstructed by the DFS, and that comparison is sound because every BTI
+    /// trie edge in this representation carries **exactly one transition byte**
+    /// (the only node kinds are `Single`, `Sparse`, and `Dense` — there is no
+    /// multi-byte "chain" node).  Concatenating the transition bytes from the
+    /// root to any node therefore reconstructs the COMPLETE byte-comparable key
+    /// terminating at that node.  An internal node may itself carry a payload
+    /// whose key `K` is a strict prefix of a deeper leaf's key `K2`; because the
+    /// keys are complete (not truncated), ordinary lexicographic comparison
+    /// handles the prefix relationship correctly — `K` is included iff it lies
+    /// in `[start, end]`, independently of `K2`. No key is spuriously dropped or
+    /// included.
     pub fn range_query(
         &mut self,
+        rows_root: usize,
         start_key: &[Value],
         end_key: &[Value],
     ) -> BtiResult<Vec<BtiRowIndexEntry>> {
@@ -1815,8 +1876,8 @@ impl<R: Read + Seek> RowsParser<R> {
             return Ok(Vec::new());
         }
 
-        let (trie_data, root_offset) = load_bti_trie_via_footer(&mut self.reader)?;
-        let all = dfs_collect_row_entries(&trie_data, root_offset)?;
+        let trie_data = self.read_full_rows_db()?;
+        let all = iterate_rows_in_bti_trie(&trie_data, rows_root)?;
 
         Ok(all
             .into_iter()
@@ -1828,9 +1889,26 @@ impl<R: Read + Seek> RowsParser<R> {
             .collect())
     }
 
-    /// Iterator over all rows in the index
-    pub fn iterate_rows(&mut self) -> BtiResult<RowIterator<'_, R>> {
-        RowIterator::new(self)
+    /// Read the entire `Rows.db` file into a buffer for in-trie traversal.
+    ///
+    /// Unlike `Partitions.db`, a `Rows.db` has no whole-file footer describing a
+    /// single root (see [`iterate_rows_in_bti_trie`]); callers supply the
+    /// per-partition `RowsOffset` separately.
+    fn read_full_rows_db(&mut self) -> BtiResult<Vec<u8>> {
+        let file_size = self.reader.seek(SeekFrom::End(0))?;
+        self.reader.seek(SeekFrom::Start(0))?;
+        let mut buf = vec![0u8; file_size as usize];
+        self.reader.read_exact(&mut buf)?;
+        Ok(buf)
+    }
+
+    /// Iterator over all rows in a single partition's row-index trie, rooted at
+    /// `rows_root` (the partition's `RowsOffset` from `Partitions.db`).
+    ///
+    /// See [`range_query`](Self::range_query) for why an explicit root is
+    /// required: a `Rows.db` holds one row-index trie per partition.
+    pub fn iterate_rows(&mut self, rows_root: usize) -> BtiResult<RowIterator<'_, R>> {
+        RowIterator::new(self, rows_root)
     }
 
     /// Get header information
@@ -1890,17 +1968,19 @@ impl<'a, R: Read + Seek> Iterator for PartitionIterator<'a, R> {
     }
 }
 
-/// Iterator over **all** row-index entries in a `Rows.db` BTI index (for a
-/// single partition's trie), in byte-comparable order (issue #832).
+/// Iterator over the row-index entries of **one partition's** `Rows.db`
+/// row-index trie, rooted at an explicit `rows_root`, in byte-comparable order
+/// (issue #832).
 ///
-/// Like [`PartitionIterator`], the trie is loaded via the footer-based loader
+/// A real `Rows.db` concatenates one row-index trie per wide partition, so the
+/// iterator is rooted at the partition's `RowsOffset` (from `Partitions.db`),
+/// NOT at a whole-file footer (Finding 2).  The full file is read into memory
 /// and traversed in-order during construction.  Each yielded `Vec<u8>` is the
 /// reconstructed byte-comparable clustering key; the [`BtiRowIndexEntry`]
 /// carries the Data.db block position (definitive) and an optional open-marker
 /// `DeletionTime`.
 ///
-/// An empty (< 8-byte, e.g. 0-byte) `Rows.db` trie yields nothing without
-/// panicking.
+/// An empty (e.g. 0-byte) `Rows.db` yields nothing without panicking.
 pub struct RowIterator<'a, R: Read + Seek> {
     #[allow(dead_code)]
     parser: &'a mut RowsParser<R>,
@@ -1909,11 +1989,11 @@ pub struct RowIterator<'a, R: Read + Seek> {
 }
 
 impl<'a, R: Read + Seek> RowIterator<'a, R> {
-    fn new(parser: &'a mut RowsParser<R>) -> BtiResult<Self> {
-        // An empty Rows.db (< 8 bytes, e.g. a 0-byte file for partitions with no
-        // row index) yields nothing rather than erroring.
+    fn new(parser: &'a mut RowsParser<R>, rows_root: usize) -> BtiResult<Self> {
+        // An empty Rows.db (e.g. a 0-byte file for SSTables with no row index)
+        // yields nothing rather than erroring.
         let file_size = parser.reader.seek(SeekFrom::End(0))?;
-        if file_size < 8 {
+        if file_size == 0 {
             return Ok(Self {
                 parser,
                 entries: Vec::new().into_iter(),
@@ -1921,8 +2001,9 @@ impl<'a, R: Read + Seek> RowIterator<'a, R> {
             });
         }
 
-        let (entries, pending_error) = match load_bti_trie_via_footer(&mut parser.reader)
-            .and_then(|(trie, root)| dfs_collect_row_entries(&trie, root))
+        let (entries, pending_error) = match parser
+            .read_full_rows_db()
+            .and_then(|trie| iterate_rows_in_bti_trie(&trie, rows_root))
         {
             Ok(v) => (v, None),
             Err(e) => (Vec::new(), Some(e)),
@@ -2500,7 +2581,7 @@ mod tests {
             } => {
                 assert_eq!(*start_byte, b'A');
                 assert_eq!(children.len(), 1);
-                assert_eq!(children[0].distance, offset - 0x123);
+                assert_eq!(children[0].as_ref().unwrap().distance, offset - 0x123);
             }
             other => panic!("Expected BtiNodeData::Dense, got {:?}", other),
         }
@@ -2527,8 +2608,8 @@ mod tests {
             } => {
                 assert_eq!(*start_byte, b'A');
                 assert_eq!(children.len(), 2);
-                assert_eq!(children[0].distance, offset - 0x100);
-                assert_eq!(children[1].distance, offset - 0x200);
+                assert_eq!(children[0].as_ref().unwrap().distance, offset - 0x100);
+                assert_eq!(children[1].as_ref().unwrap().distance, offset - 0x200);
             }
             other => panic!("Expected BtiNodeData::Dense, got {:?}", other),
         }
@@ -2553,11 +2634,11 @@ mod tests {
                 assert_eq!(*start_byte, b'a');
                 assert_eq!(children.len(), 3);
                 // child 0 (b'a'): offset = 0x200 - 0x0010 = 0x1F0
-                assert_eq!(children[0].distance, 0x200 - 0x0010);
-                // child 1 (b'b'): delta=0 → no child, offset=0
-                assert_eq!(children[1].distance, 0);
+                assert_eq!(children[0].as_ref().unwrap().distance, 0x200 - 0x0010);
+                // child 1 (b'b'): delta=0 → no transition → None
+                assert!(children[1].is_none());
                 // child 2 (b'c'): offset = 0x200 - 0x0030 = 0x1D0
-                assert_eq!(children[2].distance, 0x200 - 0x0030);
+                assert_eq!(children[2].as_ref().unwrap().distance, 0x200 - 0x0030);
             }
             other => panic!("Expected Dense, got {:?}", other),
         }
@@ -2576,8 +2657,8 @@ mod tests {
             } => {
                 assert_eq!(*start_byte, b'A');
                 assert_eq!(children.len(), 2);
-                assert_eq!(children[0].distance, 0x10000 - 0x100);
-                assert_eq!(children[1].distance, 0x10000 - 0x200);
+                assert_eq!(children[0].as_ref().unwrap().distance, 0x10000 - 0x100);
+                assert_eq!(children[1].as_ref().unwrap().distance, 0x10000 - 0x200);
             }
             other => panic!("Expected Dense, got {:?}", other),
         }
@@ -3420,6 +3501,64 @@ mod tests {
         );
     }
 
+    /// Finding 1 (issue #832): a Dense node whose FIRST real child is at
+    /// absolute trie offset 0 (the first-written leaf in BTI's bottom-up layout)
+    /// AND that has a "no transition" gap elsewhere.  DFS must:
+    ///   - emit the offset-0 child (NOT silently drop it), and
+    ///   - skip the gap byte.
+    ///
+    /// Layout (bottom-up; children at lower offsets):
+    ///   offset 0: Rows leaf  pos=5   (the offset-0 child)
+    ///   offset 2: Rows leaf  pos=9
+    ///   offset 4: Dense16 root, start=0x10, range 3:
+    ///       0x10 → delta 4 → child offset 0  (real, absolute offset 0)
+    ///       0x11 → delta 0 → no transition   (sentinel)
+    ///       0x12 → delta 2 → child offset 2  (real)
+    #[test]
+    fn dfs_dense_emits_offset_zero_child_and_skips_gap() {
+        let mut trie = Vec::new();
+        trie.extend_from_slice(&row_leaf_no_marker(5)); // offset 0
+        trie.extend_from_slice(&row_leaf_no_marker(9)); // offset 2
+        let root = trie.len() as u64; // 4
+
+        // Dense16 root: delta 0 is the "no transition" sentinel.
+        let deltas = [root as u16, 0x0000, (root - 2) as u16];
+        trie.extend(dense16_node(0, 0x10, &deltas));
+
+        let entries = dfs_collect_row_entries(&trie, root as usize).unwrap();
+        assert_eq!(
+            entries,
+            vec![
+                (
+                    vec![0x10],
+                    BtiRowIndexEntry {
+                        data_offset: 5,
+                        open_marker: None
+                    }
+                ),
+                (
+                    vec![0x12],
+                    BtiRowIndexEntry {
+                        data_offset: 9,
+                        open_marker: None
+                    }
+                ),
+            ],
+            "DFS must emit the real child at absolute offset 0 and skip the \
+             no-transition gap (0x11)"
+        );
+
+        // And find_child on the parsed Dense root must agree.
+        let node = parse_bti_node_for_traversal(&trie, root as usize).unwrap();
+        let c10 = node.find_child(0x10).expect("0x10 child must be found");
+        assert_eq!(c10.distance, 0, "0x10 must route to absolute offset 0");
+        assert!(
+            node.find_child(0x11).is_none(),
+            "0x11 is the no-transition gap"
+        );
+        assert!(node.find_child(0x12).is_some());
+    }
+
     /// Rows.db payload with FLAG_OPEN_MARKER decodes a trailing 12-byte
     /// DeletionTime.
     #[test]
@@ -3506,13 +3645,117 @@ mod tests {
         );
     }
 
-    /// A < 8-byte (e.g. 0-byte) Rows.db file must not load a trie (the public
-    /// `RowIterator` treats this as "no rows" and yields nothing without
-    /// panicking; the real 0-byte fixture is covered by the integration test).
+    /// Finding 2 (issue #832): the rooted Rows.db API must handle the empty /
+    /// out-of-bounds cases cleanly (no panic).  Empty `trie_data` or a root
+    /// beyond the buffer yields a clean parse error; a real partition root is
+    /// what callers pass in production (from `Partitions.db` `RowsOffset`).
     #[test]
-    fn row_iterator_empty_file_yields_nothing() {
-        let mut cursor = Cursor::new(Vec::<u8>::new());
-        let res = load_bti_trie_via_footer(&mut cursor);
-        assert!(res.is_err(), "0-byte file must not load a trie");
+    fn iterate_rows_in_bti_trie_empty_and_oob_root() {
+        // Empty trie_data with root 0 → out-of-bounds → clean error, no panic.
+        let err = iterate_rows_in_bti_trie(&[], 0);
+        assert!(err.is_err(), "empty Rows.db trie must error, not panic");
+
+        // Non-empty trie but root beyond bounds → clean error.
+        let (trie, _root) = make_rows_trie_three((0x10, 5), (0x20, 17), (0x30, 99));
+        let err = iterate_rows_in_bti_trie(&trie, trie.len() + 100);
+        assert!(err.is_err(), "out-of-bounds root must error, not panic");
+
+        // A valid per-partition root traverses correctly.
+        let (trie, root) = make_rows_trie_three((0x10, 5), (0x20, 17), (0x30, 99));
+        let entries = iterate_rows_in_bti_trie(&trie, root).unwrap();
+        assert_eq!(entries.len(), 3);
+    }
+
+    /// Finding 3 (issue #832): range_query soundness over reconstructed keys
+    /// when an internal-node payload's key is a STRICT PREFIX of a deeper leaf
+    /// key.  This exercises the byte-comparable inclusive filter applied on top
+    /// of the DFS — the same filter `RowsParser::range_query` uses — and proves
+    /// that prefixes are neither spuriously dropped nor included.
+    ///
+    /// Trie layout (bottom-up):
+    ///   K  = [0x10]        (internal node, carries a payload: pos=1)
+    ///   K2 = [0x10, 0x20]  (deeper leaf: pos=2)
+    ///
+    ///   offset 0: Rows leaf pos=2                         → K2 payload
+    ///   offset 2: Single8 trans=0x20 delta=2, payload pos=1 (the K node)
+    ///   offset 5: Single8 root trans=0x10 delta=3, no payload
+    ///
+    /// So root --0x10--> K(internal, payload) --0x20--> K2(leaf).
+    #[test]
+    fn range_filter_prefix_relationship_is_sound() {
+        let mut trie = Vec::new();
+        // offset 0: leaf for K2 = [0x10,0x20], pos=2
+        trie.extend_from_slice(&row_leaf_no_marker(2));
+        // offset 2: Single8 with payload — the K = [0x10] node.
+        //   header 0x21 (ordinal=2 Single8, payloadBits=1), transition=0x20,
+        //   delta=2 (child = 2 - 2 = 0 → the K2 leaf), then payload pos=1.
+        let k_off = trie.len() as u64; // 2
+        trie.push(0x21); // Single8 + payloadBits=1
+        trie.push(0x20); // transition byte
+        trie.push(k_off as u8); // delta=2 → child at offset 0
+        trie.push(0x01); // payload: unsigned vint pos=1
+
+        // offset 6: Single8 root, no payload, transition=0x10 → child = k_off (2).
+        let root = trie.len() as u64; // 6
+        trie.push(0x20); // Single8, payloadBits=0 (no payload)
+        trie.push(0x10); // transition byte
+        trie.push((root - k_off) as u8); // delta=4 → child at k_off=2
+
+        let all = iterate_rows_in_bti_trie(&trie, root as usize).unwrap();
+        // DFS emits K's own payload before descending to K2.
+        assert_eq!(
+            all,
+            vec![
+                (
+                    vec![0x10],
+                    BtiRowIndexEntry {
+                        data_offset: 1,
+                        open_marker: None
+                    }
+                ),
+                (
+                    vec![0x10, 0x20],
+                    BtiRowIndexEntry {
+                        data_offset: 2,
+                        open_marker: None
+                    }
+                ),
+            ],
+            "K (internal payload) must sort before its descendant K2"
+        );
+
+        // Inclusive byte-comparable filter mirroring range_query's filter.
+        let filter = |lo: &[u8], hi: &[u8]| -> Vec<u64> {
+            if lo > hi {
+                return Vec::new();
+            }
+            all.iter()
+                .filter(|(k, _)| k.as_slice() >= lo && k.as_slice() <= hi)
+                .map(|(_, e)| e.data_offset)
+                .collect()
+        };
+
+        let k = [0x10u8];
+        let k2 = [0x10u8, 0x20u8];
+
+        // [K..=K] returns K but NOT K2 (K2 = [0x10,0x20] > [0x10]).
+        assert_eq!(
+            filter(&k, &k),
+            vec![1],
+            "[K..=K] must include K and exclude the longer K2"
+        );
+        // [K..=K2] returns both.
+        assert_eq!(
+            filter(&k, &k2),
+            vec![1, 2],
+            "[K..=K2] must include both K and K2"
+        );
+        // A bound strictly between K and K2 excludes both:
+        //   [0x10,0x00] ..= [0x10,0x10]; K=[0x10] < [0x10,0x00], K2=[0x10,0x20] > [0x10,0x10].
+        assert_eq!(
+            filter(&[0x10, 0x00], &[0x10, 0x10]),
+            Vec::<u64>::new(),
+            "a range strictly between K and K2 must exclude both"
+        );
     }
 }

--- a/cqlite-core/src/storage/sstable/bti/parser.rs
+++ b/cqlite-core/src/storage/sstable/bti/parser.rs
@@ -1769,6 +1769,25 @@ const OSS50_NEXT_COMPONENT: u8 = 0x40;
 ///
 /// Any clustering type not enumerated here returns an explicit parse error
 /// (NO silent wrong results — issue #28 no-heuristics mandate).
+/// OSS50 variable-length byte-comparable encoding for `BytesType`/`UTF8Type`
+/// (Cassandra `ByteSource`): every literal `0x00` byte is escaped as
+/// `0x00 0xFE` (`ESCAPE` + `ESCAPED_0_CONT`) and the component is terminated
+/// with `0x00 0xFF` (`ESCAPE` + `ESCAPED_0_DONE`).  This makes the encoding
+/// weakly prefix-free, so a shorter value sorts before a longer value that
+/// shares its prefix — matching the separators stored in a real `Rows.db`
+/// trie.  (The project's `ByteComparableEncoder` uses a different,
+/// non-Cassandra escape scheme and must NOT be used for trie-compatible bounds.)
+fn encode_varlen_oss50(bytes: &[u8], out: &mut Vec<u8>) {
+    for &b in bytes {
+        out.push(b);
+        if b == 0x00 {
+            out.push(0xFE);
+        }
+    }
+    out.push(0x00);
+    out.push(0xFF);
+}
+
 fn encode_clustering_component_oss50(value: &Value, out: &mut Vec<u8>) -> BtiResult<()> {
     match value {
         // int — Int32Type: sign-flip, big-endian (matches `wide_table` separators,
@@ -1809,17 +1828,14 @@ fn encode_clustering_component_oss50(value: &Value, out: &mut Vec<u8>) -> BtiRes
             out.extend_from_slice(bytes);
             Ok(())
         }
-        // text / ascii — raw UTF-8/ASCII bytes + variable-length component
-        // terminator (0x00) so prefixes sort first.
+        // text / ascii — OSS50 variable-length byte-comparable encoding.
         Value::Text(s) => {
-            out.extend_from_slice(s.as_bytes());
-            out.push(0x00);
+            encode_varlen_oss50(s.as_bytes(), out);
             Ok(())
         }
-        // blob — raw bytes + variable-length component terminator (0x00).
+        // blob / inet — OSS50 variable-length byte-comparable encoding.
         Value::Blob(b) | Value::Inet(b) => {
-            out.extend_from_slice(b);
-            out.push(0x00);
+            encode_varlen_oss50(b, out);
             Ok(())
         }
         other => Err(Error::Parse(format!(
@@ -4172,12 +4188,28 @@ mod tests {
         );
 
         // Multi-component: int(1) + text("ab") joined with 0x40 NEXT_COMPONENT,
-        // text terminated by 0x00.
+        // text terminated by the OSS50 end marker 0x00 0xFF.
         assert_eq!(
             encode_clustering_bound_oss50(&[Value::Integer(1), Value::Text("ab".to_string())])
                 .unwrap(),
-            vec![0x80, 0x00, 0x00, 0x01, 0x40, b'a', b'b', 0x00]
+            vec![0x80, 0x00, 0x00, 0x01, 0x40, b'a', b'b', 0x00, 0xFF]
         );
+
+        // Variable-length OSS50: text terminates with 0x00 0xFF; a literal 0x00
+        // byte is escaped as 0x00 0xFE so it never collides with the terminator.
+        assert_eq!(
+            encode_clustering_bound_oss50(&[Value::Text("a".to_string())]).unwrap(),
+            vec![b'a', 0x00, 0xFF]
+        );
+        assert_eq!(
+            encode_clustering_bound_oss50(&[Value::Blob(vec![0x01, 0x00, 0x02])]).unwrap(),
+            vec![0x01, 0x00, 0xFE, 0x02, 0x00, 0xFF]
+        );
+        // Prefix-free ordering: "a" sorts before "ab" (00 0xFE/0xFF < any byte
+        // after the shared prefix means the shorter value compares first).
+        let a = encode_clustering_bound_oss50(&[Value::Text("a".to_string())]).unwrap();
+        let ab = encode_clustering_bound_oss50(&[Value::Text("ab".to_string())]).unwrap();
+        assert!(a < ab);
 
         // Unsupported clustering type errors out explicitly.
         assert!(encode_clustering_bound_oss50(&[Value::Float(1.0)]).is_err());

--- a/cqlite-core/src/storage/sstable/reader/block_io.rs
+++ b/cqlite-core/src/storage/sstable/reader/block_io.rs
@@ -14,6 +14,23 @@ use super::source::BlockSource;
 use super::types::SSTableReaderConfig;
 use crate::{Error, Result};
 
+/// Maximum bytes returned by a single `read_uncompressed_data_block` call.
+///
+/// An uncompressed NB SSTable (CQLite's own write output has no CompressionInfo.db)
+/// has no chunk boundaries to read against. Returning the WHOLE data section in
+/// one `Vec` makes every stitching consumer's working set scale with the file
+/// size — defeating the bounded sliding-window compaction read (issue #827).
+///
+/// Instead this path yields the data section in fixed-size pieces across
+/// successive `read_next_block` calls (advancing the file's stream position).
+/// Stitching consumers (`stitch_all_chunks`,
+/// `stream_all_partitions_for_compaction`) concatenate pieces and drain whole
+/// partitions out of the front, so a partition straddling a piece boundary is
+/// handled by the same NeedMore refill logic as a real compression chunk. The
+/// value mirrors Cassandra's default 64 KiB compression chunk so behaviour is
+/// uniform across compressed and uncompressed inputs.
+const UNCOMPRESSED_READ_PIECE_BYTES: usize = 64 * 1024;
+
 /// Read next block with enhanced error handling and streaming support
 pub(crate) async fn read_next_block(
     file: &Arc<Mutex<BlockSource>>,
@@ -616,22 +633,29 @@ async fn read_uncompressed_data_block(
         return Ok(None);
     }
 
+    // Yield at most one fixed-size piece per call so the caller's working set
+    // (and any sliding-window stitch buffer) stays bounded regardless of file
+    // size (issue #827). The file's stream position advances by the bytes read,
+    // so the next call returns the next piece and EOF is reached naturally.
+    let to_read = remaining.min(UNCOMPRESSED_READ_PIECE_BYTES);
+
     log::debug!(
-        "read_uncompressed_data_block: Reading {} bytes from position {}",
+        "read_uncompressed_data_block: Reading {} of {} remaining bytes from position {}",
+        to_read,
         remaining,
         current_pos
     );
 
-    // Read remaining data through a capped scratch buffer so the transient
-    // working set does not scale with the file size (Issue #592).
+    // Read the piece through a capped scratch buffer so the transient working
+    // set does not scale with the file size (Issue #592).
     let data = {
         let mut file_guard = file.lock().await;
-        read_into_vec_capped(&mut *file_guard, remaining, config.read_buffer_size)
+        read_into_vec_capped(&mut *file_guard, to_read, config.read_buffer_size)
             .await
             .map_err(|e| {
                 Error::Io(std::io::Error::other(format!(
                     "Failed to read uncompressed data block ({} bytes): {}",
-                    remaining, e
+                    to_read, e
                 )))
             })?
     };
@@ -1067,15 +1091,18 @@ mod tests {
         );
     }
 
-    /// Issue #592: end-to-end, `read_uncompressed_data_block` must stream a block
-    /// far larger than `read_buffer_size` through the capped path and return
-    /// byte-identical data.
+    /// Issue #592 + #827: `read_uncompressed_data_block` must stream a data
+    /// section far larger than both `read_buffer_size` and the per-call piece
+    /// cap, returning byte-identical data when the pieces are concatenated, and
+    /// bounding each returned piece to `UNCOMPRESSED_READ_PIECE_BYTES` so the
+    /// sliding-window compaction read stays memory-bounded.
     #[tokio::test]
     async fn uncompressed_data_block_streams_large_block_byte_identical() {
         let temp_dir = std::env::temp_dir();
         let temp_file = temp_dir.join("issue_592_uncompressed_large.bin");
 
-        let size = 256 * 1024; // 256 KiB, well above the 8 KiB buffer below
+        // 3.5 piece-caps so several pieces plus a short tail are returned.
+        let size = UNCOMPRESSED_READ_PIECE_BYTES * 3 + UNCOMPRESSED_READ_PIECE_BYTES / 2;
         let test_data: Vec<u8> = (0..size).map(|i| (i % 256) as u8).collect();
         tokio::fs::write(&temp_file, &test_data).await.unwrap();
 
@@ -1083,16 +1110,33 @@ mod tests {
         let file = Arc::new(Mutex::new(BlockSource::buffered(file)));
 
         let config = SSTableReaderConfig {
-            read_buffer_size: 8 * 1024, // small buffer forces ~32 streamed chunks
+            read_buffer_size: 8 * 1024, // small buffer forces capped scratch reads
             ..Default::default()
         };
 
-        let data = read_uncompressed_data_block(&file, &config)
+        // Each call returns at most one piece; concatenating all pieces must
+        // reproduce the section byte-for-byte. EOF is signalled by Ok(None).
+        let mut assembled = Vec::new();
+        let mut pieces = 0;
+        while let Some(piece) = read_uncompressed_data_block(&file, &config)
             .await
             .expect("read should succeed")
-            .expect("non-empty block");
-        assert_eq!(data.len(), size);
-        assert_eq!(data, test_data);
+        {
+            assert!(
+                piece.len() <= UNCOMPRESSED_READ_PIECE_BYTES,
+                "piece {} bytes exceeds the {} byte cap — read is not bounded",
+                piece.len(),
+                UNCOMPRESSED_READ_PIECE_BYTES
+            );
+            assembled.extend_from_slice(&piece);
+            pieces += 1;
+        }
+        assert_eq!(assembled.len(), size);
+        assert_eq!(assembled, test_data);
+        assert!(
+            pieces >= 4,
+            "expected the section to be split into multiple bounded pieces, got {pieces}"
+        );
 
         tokio::fs::remove_file(&temp_file).await.ok();
     }

--- a/cqlite-core/src/storage/sstable/reader/block_io.rs
+++ b/cqlite-core/src/storage/sstable/reader/block_io.rs
@@ -14,21 +14,30 @@ use super::source::BlockSource;
 use super::types::SSTableReaderConfig;
 use crate::{Error, Result};
 
-/// Maximum bytes returned by a single `read_uncompressed_data_block` call.
+/// Maximum bytes returned by a single *piecewise* `read_uncompressed_data_block`
+/// call.
 ///
 /// An uncompressed NB SSTable (CQLite's own write output has no CompressionInfo.db)
 /// has no chunk boundaries to read against. Returning the WHOLE data section in
 /// one `Vec` makes every stitching consumer's working set scale with the file
 /// size — defeating the bounded sliding-window compaction read (issue #827).
 ///
-/// Instead this path yields the data section in fixed-size pieces across
-/// successive `read_next_block` calls (advancing the file's stream position).
-/// Stitching consumers (`stitch_all_chunks`,
-/// `stream_all_partitions_for_compaction`) concatenate pieces and drain whole
-/// partitions out of the front, so a partition straddling a piece boundary is
-/// handled by the same NeedMore refill logic as a real compression chunk. The
-/// value mirrors Cassandra's default 64 KiB compression chunk so behaviour is
-/// uniform across compressed and uncompressed inputs.
+/// So for the **stitching** consumers (NB-without-CompressionInfo:
+/// `stitch_all_chunks`, `stream_all_partitions_for_compaction`) this path yields
+/// the data section in fixed-size pieces across successive `read_next_block`
+/// calls (advancing the file's stream position). Those consumers concatenate
+/// pieces and drain whole partitions out of the front, so a partition straddling
+/// a piece boundary is handled by the same NeedMore refill logic as a real
+/// compression chunk. The value mirrors Cassandra's default 64 KiB compression
+/// chunk so behaviour is uniform across compressed and uncompressed inputs.
+///
+/// CRITICAL (issue #827 Finding 2): the piecewise split is applied ONLY to those
+/// stitching consumers. The `V5_0Uncompressed` format is NOT stitched — its
+/// callers (`iterate_all_partitions`, `sequential_scan`) parse each returned
+/// block as a SELF-CONTAINED unit. Handing them a 64 KiB piece would truncate any
+/// partition/row crossing a piece boundary (silent drop/corruption). Those
+/// callers therefore receive the ENTIRE data section as one CONTIGUOUS buffer
+/// (`piecewise = false`), exactly as before the #827 change.
 const UNCOMPRESSED_READ_PIECE_BYTES: usize = 64 * 1024;
 
 /// Read next block with enhanced error handling and streaming support
@@ -120,7 +129,11 @@ async fn read_next_block_impl(
         crate::parser::header::CassandraVersion::V5_0Uncompressed
     ) {
         log::debug!("block_io::read_next_block_impl: Using uncompressed direct read");
-        return read_uncompressed_data_block(file, config).await;
+        // V5_0Uncompressed is NOT stitched: its callers parse each returned block
+        // as a self-contained unit, so return the whole data section contiguously
+        // (issue #827 Finding 2). Piecewise here would silently truncate any
+        // partition/row crossing a 64 KiB boundary.
+        return read_uncompressed_data_block(file, config, false).await;
     }
 
     if cassandra_version.is_nb_format() {
@@ -260,7 +273,11 @@ async fn read_nb_format_chunk_data(
         log::debug!(
             "read_nb_format_chunk_data: No CompressionInfo.db, falling back to raw data read"
         );
-        return read_uncompressed_data_block(file, config).await;
+        // NB-without-CompressionInfo IS stitched (requires_chunk_stitching() is
+        // true for NB format): the sliding-window stitchers reassemble pieces and
+        // handle NeedMore across boundaries, so piecewise reads keep their working
+        // set bounded (issue #827) without truncating partitions.
+        return read_uncompressed_data_block(file, config, true).await;
     };
 
     let chunk_idx = current_chunk_index.load(std::sync::atomic::Ordering::Relaxed);
@@ -568,19 +585,30 @@ async fn read_large_block_streaming(
         })
 }
 
-/// Read uncompressed data block for V5_0Uncompressed format
+/// Read uncompressed data block (no compression, no block headers): the data
+/// section after the file header is raw partition data.
 ///
-/// This format has no compression and no block headers - the entire data section
-/// after the 4096-byte file header is raw partition data. We read remaining data
-/// from current position to EOF, returning it as a single block.
+/// `piecewise` selects the return contract (issue #827 Finding 2):
 ///
-/// The returned block is inherently sized to the data section (the parser needs
-/// it contiguous), but the *read itself* streams through a capped scratch buffer
+/// - `false` (DEFAULT for `V5_0Uncompressed`): return the ENTIRE remaining data
+///   section as one CONTIGUOUS buffer. Non-stitching callers
+///   (`iterate_all_partitions`, `sequential_scan`) parse each returned block as a
+///   self-contained unit, so they MUST receive a complete unit — a partition or
+///   row crossing a 64 KiB boundary would otherwise be parsed as truncated and
+///   silently dropped/corrupted.
+/// - `true` (for NB-without-CompressionInfo stitching callers): return at most
+///   one [`UNCOMPRESSED_READ_PIECE_BYTES`] piece per call, advancing the file's
+///   stream position so successive calls walk the section. Only the sliding-
+///   window stitchers (which reassemble across pieces and handle `NeedMore`) use
+///   this, keeping their working set bounded regardless of file size.
+///
+/// In BOTH modes the *read itself* streams through a capped scratch buffer
 /// (`config.read_buffer_size`) rather than allocating and zeroing a second
 /// file-sized buffer up front. See [`read_into_vec_capped`] and Issue #592.
 async fn read_uncompressed_data_block(
     file: &Arc<Mutex<BlockSource>>,
     config: &SSTableReaderConfig,
+    piecewise: bool,
 ) -> Result<Option<Vec<u8>>> {
     let (current_pos, file_size) = {
         let mut file_guard = file.lock().await;
@@ -633,11 +661,19 @@ async fn read_uncompressed_data_block(
         return Ok(None);
     }
 
-    // Yield at most one fixed-size piece per call so the caller's working set
-    // (and any sliding-window stitch buffer) stays bounded regardless of file
-    // size (issue #827). The file's stream position advances by the bytes read,
-    // so the next call returns the next piece and EOF is reached naturally.
-    let to_read = remaining.min(UNCOMPRESSED_READ_PIECE_BYTES);
+    // Piecewise (stitching callers): yield at most one fixed-size piece per call
+    // so the sliding-window stitch buffer stays bounded regardless of file size
+    // (issue #827). The file's stream position advances by the bytes read, so the
+    // next call returns the next piece and EOF is reached naturally.
+    //
+    // Contiguous (V5_0Uncompressed non-stitching callers, Finding 2): return the
+    // WHOLE remaining section so the block is a complete, self-contained parse
+    // unit and no partition/row is truncated at a piece boundary.
+    let to_read = if piecewise {
+        remaining.min(UNCOMPRESSED_READ_PIECE_BYTES)
+    } else {
+        remaining
+    };
 
     log::debug!(
         "read_uncompressed_data_block: Reading {} of {} remaining bytes from position {}",
@@ -891,7 +927,8 @@ mod tests {
         let file = Arc::new(Mutex::new(BlockSource::buffered(file)));
 
         let config = SSTableReaderConfig::default();
-        let result = read_uncompressed_data_block(&file, &config).await;
+        // Contiguous (V5_0Uncompressed non-stitching) read.
+        let result = read_uncompressed_data_block(&file, &config, false).await;
         assert!(result.is_ok());
 
         let data = result.unwrap();
@@ -915,7 +952,7 @@ mod tests {
 
         // Should return None for EOF
         let config = SSTableReaderConfig::default();
-        let result = read_uncompressed_data_block(&file, &config).await;
+        let result = read_uncompressed_data_block(&file, &config, false).await;
         assert!(result.is_ok());
         assert!(result.unwrap().is_none());
 
@@ -1091,11 +1128,12 @@ mod tests {
         );
     }
 
-    /// Issue #592 + #827: `read_uncompressed_data_block` must stream a data
-    /// section far larger than both `read_buffer_size` and the per-call piece
-    /// cap, returning byte-identical data when the pieces are concatenated, and
-    /// bounding each returned piece to `UNCOMPRESSED_READ_PIECE_BYTES` so the
-    /// sliding-window compaction read stays memory-bounded.
+    /// Issue #592 + #827: the PIECEWISE `read_uncompressed_data_block` (stitching
+    /// callers: NB-without-CompressionInfo) must stream a data section far larger
+    /// than both `read_buffer_size` and the per-call piece cap, returning
+    /// byte-identical data when the pieces are concatenated, and bounding each
+    /// returned piece to `UNCOMPRESSED_READ_PIECE_BYTES` so the sliding-window
+    /// compaction read stays memory-bounded.
     #[tokio::test]
     async fn uncompressed_data_block_streams_large_block_byte_identical() {
         let temp_dir = std::env::temp_dir();
@@ -1114,11 +1152,11 @@ mod tests {
             ..Default::default()
         };
 
-        // Each call returns at most one piece; concatenating all pieces must
-        // reproduce the section byte-for-byte. EOF is signalled by Ok(None).
+        // piecewise = true: each call returns at most one piece; concatenating all
+        // pieces must reproduce the section byte-for-byte. EOF is Ok(None).
         let mut assembled = Vec::new();
         let mut pieces = 0;
-        while let Some(piece) = read_uncompressed_data_block(&file, &config)
+        while let Some(piece) = read_uncompressed_data_block(&file, &config, true)
             .await
             .expect("read should succeed")
         {
@@ -1136,6 +1174,131 @@ mod tests {
         assert!(
             pieces >= 4,
             "expected the section to be split into multiple bounded pieces, got {pieces}"
+        );
+
+        tokio::fs::remove_file(&temp_file).await.ok();
+    }
+
+    /// Issue #827 Finding 2: the CONTIGUOUS `read_uncompressed_data_block`
+    /// (`piecewise = false`, the `V5_0Uncompressed` non-stitching path) must
+    /// return the ENTIRE data section in ONE call even when it far exceeds
+    /// `UNCOMPRESSED_READ_PIECE_BYTES`. Non-stitching callers parse each returned
+    /// block as a self-contained unit, so a piecewise split here would truncate
+    /// any partition/row crossing a 64 KiB boundary (silent drop/corruption).
+    /// A regression to unconditional piecewise reads trips the single-call
+    /// assertion below.
+    #[tokio::test]
+    async fn uncompressed_data_block_contiguous_returns_whole_section_in_one_call() {
+        let temp_dir = std::env::temp_dir();
+        let temp_file = temp_dir.join("issue_827_uncompressed_contiguous.bin");
+
+        // Larger than several piece-caps — a single partition this size would be
+        // shredded if the read split it.
+        let size = UNCOMPRESSED_READ_PIECE_BYTES * 3 + 7;
+        let test_data: Vec<u8> = (0..size).map(|i| (i % 251) as u8).collect();
+        tokio::fs::write(&temp_file, &test_data).await.unwrap();
+
+        let file = tokio::fs::File::open(&temp_file).await.unwrap();
+        let file = Arc::new(Mutex::new(BlockSource::buffered(file)));
+
+        let config = SSTableReaderConfig {
+            read_buffer_size: 8 * 1024, // small scratch buffer (#592) must NOT cause splitting
+            ..Default::default()
+        };
+
+        // piecewise = false: the FIRST call must return the whole section.
+        let first = read_uncompressed_data_block(&file, &config, false)
+            .await
+            .expect("read should succeed")
+            .expect("a non-empty section");
+        assert_eq!(
+            first.len(),
+            size,
+            "Finding 2: contiguous read must return the whole {size}-byte section \
+             in one call, got {} bytes (it was split into pieces)",
+            first.len()
+        );
+        assert_eq!(first, test_data, "contiguous read must be byte-identical");
+
+        // And the next call is EOF (the section was fully consumed).
+        let next = read_uncompressed_data_block(&file, &config, false)
+            .await
+            .expect("read should succeed");
+        assert!(
+            next.is_none(),
+            "Finding 2: after a contiguous full-section read the next call must be EOF"
+        );
+
+        tokio::fs::remove_file(&temp_file).await.ok();
+    }
+
+    /// Issue #827 Finding 2 (dispatch-level): `read_next_block` for the
+    /// `V5_0Uncompressed` format must return the whole data section as ONE
+    /// contiguous block (no chunk stitching is applied to this format, so each
+    /// returned block is a complete parse unit). This exercises the exact
+    /// `read_next_block_impl` dispatch a NORMAL (non-compaction) scan takes for a
+    /// V5_0Uncompressed SSTable whose data section exceeds 64 KiB.
+    #[tokio::test]
+    async fn read_next_block_v5_0_uncompressed_returns_contiguous_section() {
+        use crate::parser::header::CassandraVersion;
+
+        let temp_dir = std::env::temp_dir();
+        let temp_file = temp_dir.join("issue_827_v5_uncompressed_block.bin");
+
+        // A >64 KiB "partition" body. We position the reader at offset 0 (the
+        // dispatch reads from the current stream position to EOF).
+        let size = UNCOMPRESSED_READ_PIECE_BYTES * 2 + 123;
+        let test_data: Vec<u8> = (0..size).map(|i| (i % 199) as u8).collect();
+        tokio::fs::write(&temp_file, &test_data).await.unwrap();
+
+        let file = tokio::fs::File::open(&temp_file).await.unwrap();
+        let file = Arc::new(Mutex::new(BlockSource::buffered(file)));
+
+        let config = SSTableReaderConfig {
+            read_buffer_size: 8 * 1024,
+            ..Default::default()
+        };
+        let chunk_index = AtomicUsize::new(0);
+
+        // V5_0Uncompressed dispatch: contiguous whole-section read.
+        let block = read_next_block(
+            &file,
+            &CassandraVersion::V5_0Uncompressed,
+            &config,
+            &None, // no CompressionInfo
+            &chunk_index,
+            0,
+        )
+        .await
+        .expect("read_next_block should succeed")
+        .expect("a non-empty block");
+
+        assert_eq!(
+            block.len(),
+            size,
+            "Finding 2: a normal V5_0Uncompressed read must return the whole \
+             {size}-byte section as one block, got {} (truncated to a piece)",
+            block.len()
+        );
+        assert_eq!(
+            block, test_data,
+            "block must be byte-identical to the section"
+        );
+
+        // Next dispatch is EOF.
+        let next = read_next_block(
+            &file,
+            &CassandraVersion::V5_0Uncompressed,
+            &config,
+            &None,
+            &chunk_index,
+            0,
+        )
+        .await
+        .expect("read_next_block should succeed");
+        assert!(
+            next.is_none(),
+            "Finding 2: second V5_0Uncompressed read is EOF"
         );
 
         tokio::fs::remove_file(&temp_file).await.ok();

--- a/cqlite-core/src/storage/sstable/reader/block_io.rs
+++ b/cqlite-core/src/storage/sstable/reader/block_io.rs
@@ -106,8 +106,24 @@ async fn read_next_block_impl(
         return read_uncompressed_data_block(file, config).await;
     }
 
-    if cassandra_version.is_nb_format() {
-        log::debug!("block_io::read_next_block_impl: Using NB format chunk reader");
+    // Issue #831: BTI ("da") Data.db is chunk-compressed exactly like NB — the
+    // chunk offsets live in CompressionInfo.db and the file is a stream of
+    // LZ4-compressed chunks (each followed by a 4-byte CRC32), NOT a sequence of
+    // self-describing 12-byte block headers. When CompressionInfo is present,
+    // route BTI through the same CompressionInfo-driven chunk reader as NB rather
+    // than the (incorrect) block-header reader below. Without CompressionInfo, an
+    // uncompressed BTI Data.db is read directly.
+    let is_bti = matches!(
+        cassandra_version,
+        crate::parser::header::CassandraVersion::V5_0Bti
+    );
+    if is_bti && compression_info.is_none() {
+        log::debug!("block_io::read_next_block_impl: BTI without CompressionInfo, direct read");
+        return read_uncompressed_data_block(file, config).await;
+    }
+
+    if cassandra_version.is_nb_format() || is_bti {
+        log::debug!("block_io::read_next_block_impl: Using NB/BTI format chunk reader");
 
         // Get file size for chunk size calculation
         let file_size = {

--- a/cqlite-core/src/storage/sstable/reader/block_io.rs
+++ b/cqlite-core/src/storage/sstable/reader/block_io.rs
@@ -149,7 +149,10 @@ async fn read_next_block_impl(
     );
     if is_bti && compression_info.is_none() {
         log::debug!("block_io::read_next_block_impl: BTI without CompressionInfo, direct read");
-        return read_uncompressed_data_block(file, config).await;
+        // BTI direct read is parsed as a self-contained unit (like V5_0Uncompressed
+        // above), so return the whole data section contiguously (issue #827 Finding 2):
+        // piecewise here would truncate any partition/row crossing a 64 KiB boundary.
+        return read_uncompressed_data_block(file, config, false).await;
     }
 
     if cassandra_version.is_nb_format() || is_bti {

--- a/cqlite-core/src/storage/sstable/reader/data_access.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access.rs
@@ -424,9 +424,6 @@ impl SSTableReader {
 
             // INVARIANT 3: verify the on-disk partition-key bytes match the queried
             // key before decoding (guard against prefix-collision trie candidates).
-            // Only meaningful once the key prefix is present in `window`; if the key
-            // bytes are not yet fully buffered, fall through to a parse attempt which
-            // will report truncation (Err) and pull another chunk.
             if Self::bti_partition_key_bytes_available(&window, within, key.as_bytes()) {
                 if !self.bti_partition_key_matches(&window, within, key.as_bytes()) {
                     debug!(
@@ -436,7 +433,15 @@ impl SSTableReader {
                     );
                     return Ok(None);
                 }
-            } else if !chunk_targeted {
+                // Full key prefix is buffered and matches — safe to parse below.
+            } else if chunk_targeted {
+                // The partition header/key straddles a chunk boundary and is not
+                // yet fully buffered. Do NOT invoke the parser on a truncated
+                // header: `parse_block_emit` may skip bytes and emit a later
+                // false-positive entry, returning Ok and stopping the lookup
+                // prematurely (issue #831 review). Pull the next chunk first.
+                continue;
+            } else {
                 // Whole-section fallback but the key prefix is structurally short.
                 return Ok(None);
             }

--- a/cqlite-core/src/storage/sstable/reader/data_access.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access.rs
@@ -62,6 +62,25 @@ fn table_ids_match(entry_table_id: &TableId, query_table_id: &TableId) -> bool {
     entry_unqualified == query_unqualified
 }
 
+/// Stricter table-id match used by the BTI point-lookup guard (issue #831 review).
+///
+/// [`table_ids_match`] matches on the unqualified table name, so it treats
+/// `ks_a.users` and `ks_b.users` as equal — fine for index lookups that are
+/// already scoped to one table, but too permissive as a defensive guard against
+/// a fully-qualified wrong-keyspace query. When BOTH ids are qualified
+/// (`keyspace.table`), this requires exact `keyspace.table` equality; it only
+/// falls back to the permissive unqualified match when one side lacks a
+/// keyspace (preserving qualified-vs-unqualified flexibility).
+fn table_ids_match_strict(entry_table_id: &TableId, query_table_id: &TableId) -> bool {
+    let entry_qualified = entry_table_id.name().contains('.');
+    let query_qualified = query_table_id.name().contains('.');
+    if entry_qualified && query_qualified {
+        entry_table_id.name() == query_table_id.name()
+    } else {
+        table_ids_match(entry_table_id, query_table_id)
+    }
+}
+
 /// Sort a result slice in ascending Cassandra token order.
 ///
 /// The authoritative ordering for SSTable partitions is ascending Murmur3 token, with
@@ -437,7 +456,9 @@ impl SSTableReader {
                     // Verify BOTH the emitted table id matches the queried table
                     // (a wrong-table query never returns a row, issue #831 review)
                     // AND the parser-decoded partition key equals the queried key.
-                    if table_ids_match(&tid, table_id) && entry_key.as_bytes() == key.as_bytes() {
+                    if table_ids_match_strict(&tid, table_id)
+                        && entry_key.as_bytes() == key.as_bytes()
+                    {
                         found = Some(entry_value);
                     }
                     Ok(std::ops::ControlFlow::Break(()))

--- a/cqlite-core/src/storage/sstable/reader/data_access.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access.rs
@@ -784,6 +784,175 @@ impl SSTableReader {
             .collect())
     }
 
+    /// Streaming compaction read (issue #827): yield `(RowKey, Value, ts)`
+    /// entries via `emit` one partition at a time, so peak memory is bounded by
+    /// `max_partition_size + one_chunk` rather than by the total input size.
+    ///
+    /// This is the incremental counterpart of
+    /// [`iterate_all_partitions_for_compaction`], which fully materialises the
+    /// decompressed data section and parses every entry into a `Vec` before
+    /// returning. The k-way merge producer (`merge::producer_thread`) uses this
+    /// to forward entries into its bounded channel directly, so a source's
+    /// decompressed content is never fully resident.
+    ///
+    /// ## Sliding-window driver
+    ///
+    /// The V5CompressedLegacy chunk-stitching path keeps a `window: Vec<u8>` of
+    /// decompressed bytes. After appending each decompressed chunk it drains
+    /// confirmed partitions via `parse_one_partition_with_timestamps`,
+    /// `drain(0..consumed)`-ing the front of the window after every `Emitted`,
+    /// and stopping at `NeedMore` to await the next chunk (a partition can
+    /// straddle a chunk boundary). At EOF a final drain pass runs with
+    /// `at_final_chunk = true` so the trailing (possibly truncated) partition is
+    /// terminal rather than requesting a refill that will never come.
+    ///
+    /// Returning `ControlFlow::Break` from `emit` stops the scan early
+    /// (consumer dropped). Tombstone / timestamp semantics are byte-identical to
+    /// the Vec variant (Issue #505/#533).
+    pub async fn stream_all_partitions_for_compaction<F>(
+        &self,
+        schema: Option<&crate::schema::TableSchema>,
+        mut emit: F,
+    ) -> Result<()>
+    where
+        F: FnMut(RowKey, Value, i64) -> Result<std::ops::ControlFlow<()>>,
+    {
+        // Reset chunk reader to the start of the data section (mirrors
+        // iterate_all_partitions_for_compaction).
+        let header_size = self.calculate_header_size();
+        {
+            let mut file_guard = self.file.lock().await;
+            file_guard.seek(SeekFrom::Start(header_size as u64)).await?;
+        }
+        self.current_chunk_index
+            .store(0, std::sync::atomic::Ordering::Relaxed);
+
+        // Non-stitching formats are single-block / small: emit via the
+        // materialising iterator with ts=0 (matches the Vec-variant fallback).
+        if !self.requires_chunk_stitching() {
+            let entries = self.iterate_all_partitions().await?;
+            for (key, value) in entries {
+                match emit(key, value, 0)? {
+                    std::ops::ControlFlow::Continue(()) => {}
+                    std::ops::ControlFlow::Break(()) => return Ok(()),
+                }
+            }
+            return Ok(());
+        }
+
+        // Resolve the schema the parser needs (cells lack column names on disk).
+        let owned_schema = schema.cloned().or_else(|| self.get_table_schema(None));
+        let parser = self.build_v5_parser();
+
+        let mut window: Vec<u8> = Vec::new();
+        let mut broke = false;
+
+        use crate::storage::sstable::compression::Compression;
+        let mut chunk_count = 0;
+        while let Some(compressed_chunk) = self.read_next_block().await? {
+            let decompressed_chunk = if let Some(compression_reader) = &self.compression_reader {
+                let compression = Compression::new(*compression_reader.algorithm())?;
+                compression.decompress(&compressed_chunk).map_err(|e| {
+                    Error::corruption(format!(
+                        "stream_all_partitions_for_compaction: Failed to decompress chunk {}: {}",
+                        chunk_count, e
+                    ))
+                })?
+            } else {
+                compressed_chunk
+            };
+            window.extend_from_slice(&decompressed_chunk);
+            chunk_count += 1;
+
+            // Not the final chunk yet: NeedMore means "await more bytes". Drain
+            // every confirmed partition from the front of the window.
+            self.drain_compaction_window(
+                &parser,
+                owned_schema.as_ref(),
+                &mut window,
+                false,
+                &mut emit,
+                &mut broke,
+            )?;
+            if broke {
+                return Ok(());
+            }
+        }
+
+        // EOF: final drain — a truncated/unterminated trailing partition is now
+        // terminal (Done), not a refill request.
+        if !broke {
+            self.drain_compaction_window(
+                &parser,
+                owned_schema.as_ref(),
+                &mut window,
+                true,
+                &mut emit,
+                &mut broke,
+            )?;
+        }
+
+        log::debug!(
+            "stream_all_partitions_for_compaction: drained {} chunks (final window {} bytes)",
+            chunk_count,
+            window.len()
+        );
+
+        Ok(())
+    }
+
+    /// Drain every confirmed partition from the front of the sliding `window`,
+    /// emitting each row via `emit` (issue #827). After each `Emitted` the
+    /// consumed prefix is removed so the window's peak size stays bounded by
+    /// `max_partition_size + one_chunk`. Stops at `NeedMore` / `Done` (await the
+    /// next chunk / genuine end) or when `emit` returns `Break` (sets `*broke`).
+    fn drain_compaction_window<F>(
+        &self,
+        parser: &crate::storage::sstable::reader::parsing::V5CompressedLegacyParser,
+        schema: Option<&crate::schema::TableSchema>,
+        window: &mut Vec<u8>,
+        at_final_chunk: bool,
+        emit: &mut F,
+        broke: &mut bool,
+    ) -> Result<()>
+    where
+        F: FnMut(RowKey, Value, i64) -> Result<std::ops::ControlFlow<()>>,
+    {
+        use crate::storage::sstable::reader::parsing::ParseStep;
+        loop {
+            if *broke || window.is_empty() {
+                return Ok(());
+            }
+            let mut local_break = false;
+            let step = parser.parse_one_partition_with_timestamps(
+                window.as_slice(),
+                schema,
+                self,
+                at_final_chunk,
+                &mut |(_tid, key, value, ts): (TableId, RowKey, Value, i64)| match emit(
+                    key, value, ts,
+                )? {
+                    std::ops::ControlFlow::Continue(()) => Ok(std::ops::ControlFlow::Continue(())),
+                    std::ops::ControlFlow::Break(()) => {
+                        local_break = true;
+                        Ok(std::ops::ControlFlow::Break(()))
+                    }
+                },
+            )?;
+            match step {
+                ParseStep::Emitted(consumed) => {
+                    let take = if consumed == 0 { 1 } else { consumed };
+                    window.drain(0..take.min(window.len()));
+                    if local_break {
+                        *broke = true;
+                        return Ok(());
+                    }
+                }
+                ParseStep::NeedMore | ParseStep::Done => return Ok(()),
+            }
+        }
+    }
+
     /// Read value at a specific offset with caching
     pub async fn read_value_at_offset(&self, offset: u64, size: u32) -> Result<Option<Value>> {
         use crate::parser::header::CassandraVersion;

--- a/cqlite-core/src/storage/sstable/reader/data_access.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access.rs
@@ -198,7 +198,13 @@ impl SSTableReader {
     ///   `read_value_at_offset`/`get_cached_data` (which seek raw file bytes).
     /// - **Own decompression**: `requires_chunk_stitching()` is `false` for BTI,
     ///   so this path decompresses the chunk-compressed Data.db itself via the
-    ///   reader's CompressionInfo + compression_reader (`stitch_all_chunks`).
+    ///   reader's CompressionInfo + compression_reader. Because the trie already
+    ///   resolved the EXACT uncompressed offset of the target partition, this only
+    ///   decompresses the chunk that contains that offset and continues forward
+    ///   chunk-by-chunk ONLY until the target partition is fully parsed — it never
+    ///   decompresses earlier chunks or the rest of the file (issue #831 perf
+    ///   finding). The whole-section [`stitch_all_chunks`] fallback is used only
+    ///   when chunk targeting is impossible (no/zero `chunk_length`).
     /// - **Prefix-collision guard**: the trie may return a candidate for a
     ///   prefix-colliding key, so the decoded partition key is verified to equal
     ///   the queried key before any row is returned.
@@ -209,74 +215,24 @@ impl SSTableReader {
             None => return Ok(None), // not in this SSTable
         };
 
-        // 2. Decompress the data section into a single buffer. The trie offset
-        //    indexes into THIS decompressed buffer (INVARIANT 1).
+        // 2. Obtain a DECOMPRESSED window that contains the target partition.
         //
-        //    Reuse the shared chunk-stitch helper, which decompresses every chunk
-        //    via the reader's compression_reader. Serialise against other scans
-        //    (shared file position + chunk index) per issue #805.
-        let decompressed = {
-            let _scan_guard = self.scan_mutex.lock().await;
-            let header_size = self.calculate_header_size();
-            {
-                let mut file_guard = self.file.lock().await;
-                file_guard.seek(SeekFrom::Start(header_size as u64)).await?;
-            }
-            self.current_chunk_index
-                .store(0, std::sync::atomic::Ordering::Relaxed);
-            self.stitch_all_chunks().await?
-        };
-
-        if offset >= decompressed.len() {
-            return Err(Error::corruption(format!(
-                "BTI trie resolved Data.db offset {} beyond decompressed data section ({} bytes)",
-                offset,
-                decompressed.len()
-            )));
-        }
-
-        // 3. Verify the partition-key bytes at the resolved offset match the
-        //    queried key (INVARIANT 3: guard against prefix-collision candidates).
+        //    `window_base` is the uncompressed offset of the window's first byte
+        //    and `window` holds the decompressed bytes from there onward. The
+        //    target partition starts at `offset - window_base` inside `window`
+        //    (INVARIANT 1: the trie offset indexes the uncompressed data section).
         //
-        //    Partition on-disk header (oa/da, hasUIntDeletionTime):
-        //      [0]      flags (0x00)
-        //      [1]      key_len (u8)
-        //      [2..2+L] raw partition-key bytes
-        //      [..]     partition deletion time
-        if !self.bti_partition_key_matches(&decompressed, offset, key.as_bytes()) {
-            debug!(
-                "BTI trie candidate at offset {} did not match queried key (prefix collision); \
-                 treating as absent",
-                offset
-            );
-            return Ok(None);
-        }
-
-        // 4. Decode the partition. Feed the decompressed buffer FROM the resolved
-        //    offset to the schema-aware V5 parser, which parses the partition-key
-        //    header itself and stops at the next partition boundary / end-of-buffer
-        //    (it detects the next partition header structurally and honours the
-        //    0x01 end-of-partition marker). Stop after the first emitted entry so
-        //    only the target partition is decoded.
+        //    For the chunk-targeted path the window starts at the chunk that
+        //    contains `offset` (so `window_base = target_chunk * chunk_length`);
+        //    for the whole-section fallback the window starts at offset 0
+        //    (`window_base = 0`). Either way the parse below uses the same
+        //    `within = offset - window_base` index.
         let schema_opt = self.get_table_schema(None);
         let parser = self.build_v5_parser();
 
-        let mut found: Option<Value> = None;
-        parser.parse_block_emit(
-            &decompressed[offset..],
-            schema_opt.as_ref(),
-            self,
-            |(tid, entry_key, entry_value)| {
-                // The first partition in the slice is the one the trie resolved.
-                // Verify BOTH that the emitted table id matches the queried table
-                // (so a wrong-table query never returns a row, issue #831 review)
-                // AND that the parser-decoded partition key equals the queried key.
-                if table_ids_match(&tid, table_id) && entry_key.as_bytes() == key.as_bytes() {
-                    found = Some(entry_value);
-                }
-                Ok(std::ops::ControlFlow::Break(()))
-            },
-        )?;
+        let found = self
+            .bti_decompress_and_parse_target(offset, key, table_id, schema_opt.as_ref(), &parser)
+            .await?;
 
         match found {
             Some(value) => {
@@ -287,6 +243,247 @@ impl SSTableReader {
             }
             None => Ok(None),
         }
+    }
+
+    /// Compute the chunk that contains uncompressed `offset`, the uncompressed
+    /// offset of that chunk's start, and the within-chunk index — given the
+    /// CompressionInfo `chunk_length` (issue #831).
+    ///
+    /// Returns `(target_chunk, window_base, within)` where
+    /// `window_base = target_chunk * chunk_length` and `within = offset - window_base`.
+    /// Pure arithmetic so it can be unit-tested independently of any I/O.
+    #[inline]
+    fn bti_chunk_target(offset: usize, chunk_length: usize) -> (usize, usize, usize) {
+        let target_chunk = offset / chunk_length;
+        let window_base = target_chunk * chunk_length;
+        let within = offset - window_base;
+        (target_chunk, window_base, within)
+    }
+
+    /// Decompress only the chunk(s) needed to fully parse the target partition at
+    /// uncompressed `offset`, then parse and return its row value (issue #831).
+    ///
+    /// Chunk targeting (the fast path): when `CompressionInfo` with a non-zero
+    /// `chunk_length` is present, the chunk containing `offset` is
+    /// `target_chunk = offset / chunk_length`; we seek that chunk via its
+    /// `chunk_offsets` entry, set `current_chunk_index = target_chunk`, then
+    /// decompress forward chunk-by-chunk, appending each into `window`. After each
+    /// appended chunk we attempt to parse the FIRST partition at `window[within..]`
+    /// (`within = offset % chunk_length`). The stop condition (correctness-critical
+    /// — never return a truncated parse):
+    ///   - parse returns `Ok` AND the emit closure fired (a COMPLETE partition was
+    ///     decoded) -> stop and return what the closure captured;
+    ///   - parse returns `Err` (buffer truncated mid-partition) OR the closure
+    ///     never fired -> append the next chunk and retry;
+    ///   - `read_next_block()` returns `None` (EOF) and still not parsed -> stop
+    ///     (the caller treats `None` as "absent", matching prior behaviour).
+    ///
+    /// Fallbacks (preserve prior behaviour exactly): when `compression_info` is
+    /// `None` (uncompressed BTI Data.db) or `chunk_length` is 0/absent, this
+    /// decompresses the WHOLE section via [`stitch_all_chunks`] (`window_base = 0`)
+    /// and runs the same single-partition parse.
+    ///
+    /// Serialises against other scans (shared file position + chunk index) by
+    /// holding `scan_mutex` for the whole operation (issue #805).
+    async fn bti_decompress_and_parse_target(
+        &self,
+        offset: usize,
+        key: &RowKey,
+        table_id: &TableId,
+        schema_opt: Option<&crate::schema::TableSchema>,
+        parser: &crate::storage::sstable::reader::parsing::V5CompressedLegacyParser,
+    ) -> Result<Option<Value>> {
+        use crate::storage::sstable::compression::Compression;
+
+        let _scan_guard = self.scan_mutex.lock().await;
+
+        // Determine the chunk-targeting parameters. `chunk_length == 0` (or no
+        // CompressionInfo) means we cannot chunk-target -> whole-section fallback.
+        let chunk_length = self
+            .compression_info
+            .as_ref()
+            .map(|ci| ci.chunk_length as usize)
+            .filter(|&len| len > 0);
+
+        let (target_chunk, window_base, mut window) = match chunk_length {
+            Some(len) => {
+                let (target_chunk, window_base, _within) = Self::bti_chunk_target(offset, len);
+                // Seek to the START of target_chunk so read_next_block() reads it
+                // first, and set the shared chunk index accordingly. Chunk offsets
+                // are relative to file start for NB/BTI (header_offset = 0).
+                let chunk_start = self
+                    .compression_info
+                    .as_ref()
+                    .and_then(|ci| ci.compressed_chunk_offset(target_chunk))
+                    .ok_or_else(|| {
+                        Error::corruption(format!(
+                            "BTI point lookup: no compressed offset for target chunk {} \
+                             (offset {}, chunk_length {})",
+                            target_chunk, offset, len
+                        ))
+                    })?;
+                {
+                    let mut file_guard = self.file.lock().await;
+                    file_guard.seek(SeekFrom::Start(chunk_start)).await?;
+                }
+                self.current_chunk_index
+                    .store(target_chunk, std::sync::atomic::Ordering::Relaxed);
+                (target_chunk, window_base, Vec::<u8>::new())
+            }
+            None => {
+                // Whole-section fallback (uncompressed BTI, or chunk_length absent/0).
+                let header_size = self.calculate_header_size();
+                {
+                    let mut file_guard = self.file.lock().await;
+                    file_guard.seek(SeekFrom::Start(header_size as u64)).await?;
+                }
+                self.current_chunk_index
+                    .store(0, std::sync::atomic::Ordering::Relaxed);
+                let whole = self.stitch_all_chunks().await?;
+                (0usize, 0usize, whole)
+            }
+        };
+
+        // `within` is the start of the target partition inside `window`.
+        if offset < window_base {
+            return Err(Error::corruption(format!(
+                "BTI point lookup: resolved offset {} precedes window base {} (chunk {})",
+                offset, window_base, target_chunk
+            )));
+        }
+        let within = offset - window_base;
+
+        // For the chunk-targeted path we still need to populate `window`. For the
+        // whole-section fallback `window` is already complete.
+        let chunk_targeted = chunk_length.is_some();
+
+        loop {
+            // If chunk-targeted, append the next chunk before each parse attempt
+            // (the whole-section fallback already has all bytes in `window`).
+            if chunk_targeted {
+                match self.read_next_block().await? {
+                    Some(compressed_chunk) => {
+                        let decompressed_chunk = if let Some(compression_reader) =
+                            &self.compression_reader
+                        {
+                            let compression = Compression::new(*compression_reader.algorithm())?;
+                            compression.decompress(&compressed_chunk).map_err(|e| {
+                                Error::corruption(format!(
+                                    "BTI point lookup: failed to decompress chunk: {}",
+                                    e
+                                ))
+                            })?
+                        } else {
+                            // No compression reader despite CompressionInfo:
+                            // treat raw chunk bytes as the decompressed data.
+                            compressed_chunk
+                        };
+                        window.extend_from_slice(&decompressed_chunk);
+                    }
+                    None => {
+                        // EOF: no more chunks. If we never parsed a complete
+                        // partition, the partition is treated as absent (matching
+                        // the prior whole-section behaviour for an unparseable tail).
+                        return Ok(None);
+                    }
+                }
+            }
+
+            // Need at least the partition header to attempt a match.
+            if within >= window.len() {
+                if chunk_targeted {
+                    // Not enough bytes yet; pull the next chunk.
+                    continue;
+                }
+                // Whole-section window can't grow: offset is past the data.
+                return Err(Error::corruption(format!(
+                    "BTI trie resolved Data.db offset {} beyond decompressed data section ({} bytes)",
+                    offset,
+                    window.len()
+                )));
+            }
+
+            // INVARIANT 3: verify the on-disk partition-key bytes match the queried
+            // key before decoding (guard against prefix-collision trie candidates).
+            // Only meaningful once the key prefix is present in `window`; if the key
+            // bytes are not yet fully buffered, fall through to a parse attempt which
+            // will report truncation (Err) and pull another chunk.
+            if Self::bti_partition_key_bytes_available(&window, within, key.as_bytes()) {
+                if !self.bti_partition_key_matches(&window, within, key.as_bytes()) {
+                    debug!(
+                        "BTI trie candidate at offset {} did not match queried key (prefix \
+                         collision); treating as absent",
+                        offset
+                    );
+                    return Ok(None);
+                }
+            } else if !chunk_targeted {
+                // Whole-section fallback but the key prefix is structurally short.
+                return Ok(None);
+            }
+
+            // Attempt to parse the FIRST partition at window[within..]. The parser
+            // detects the next partition boundary / 0x01 end-of-partition marker and
+            // stops; we break after the first emitted entry. A complete partition
+            // means: parse returned Ok AND the closure fired.
+            let mut found: Option<Value> = None;
+            let mut emitted = false;
+            let parse_result = parser.parse_block_emit(
+                &window[within..],
+                schema_opt,
+                self,
+                |(tid, entry_key, entry_value)| {
+                    emitted = true;
+                    // Verify BOTH the emitted table id matches the queried table
+                    // (a wrong-table query never returns a row, issue #831 review)
+                    // AND the parser-decoded partition key equals the queried key.
+                    if table_ids_match(&tid, table_id) && entry_key.as_bytes() == key.as_bytes() {
+                        found = Some(entry_value);
+                    }
+                    Ok(std::ops::ControlFlow::Break(()))
+                },
+            );
+
+            match parse_result {
+                Ok(()) if emitted => {
+                    // A COMPLETE partition was decoded — accept it and stop.
+                    return Ok(found);
+                }
+                _ => {
+                    // Either Err (truncated mid-partition) or the closure never
+                    // fired (no complete partition yet). For the chunk-targeted
+                    // path, pull the next chunk and retry; never accept a partial.
+                    if chunk_targeted {
+                        continue;
+                    }
+                    // Whole-section fallback already has every byte: a failure here
+                    // means the partition genuinely could not be parsed -> absent.
+                    return Ok(None);
+                }
+            }
+        }
+    }
+
+    /// Returns true when the `[flags][key_len: u8][key bytes]` prefix at `within`
+    /// is fully present in `window` AND `key_len` equals `expected_key.len()`.
+    ///
+    /// Used by the chunk-targeted BTI lookup to decide whether the INVARIANT-3
+    /// key match can be evaluated yet, or whether more chunk bytes must be pulled
+    /// first (issue #831).
+    fn bti_partition_key_bytes_available(
+        window: &[u8],
+        within: usize,
+        _expected_key: &[u8],
+    ) -> bool {
+        // Need flags + key_len byte first.
+        if within + 2 > window.len() {
+            return false;
+        }
+        let key_len = window[within + 1] as usize;
+        // The declared key bytes must all be buffered. (Whether `key_len` equals
+        // the expected length is decided by the subsequent match check, which
+        // fails fast on a mismatch — here we only require the bytes be present.)
+        within + 2 + key_len <= window.len()
     }
 
     /// Verify the on-disk partition-key bytes at `offset` in the decompressed
@@ -1668,6 +1865,103 @@ mod tests {
         let id4 = TableId::new("test.orders".to_string());
 
         assert!(!table_ids_match(&id3, &id4));
+    }
+
+    // =========================================================================
+    // Issue #831: BTI chunk-targeting math + window stop-condition logic
+    // =========================================================================
+
+    /// The chunk-index arithmetic must match `CompressionInfo`'s definitions:
+    /// `target_chunk = off / chunk_length`, `window_base = target_chunk *
+    /// chunk_length`, `within = off - window_base` (== `off % chunk_length`).
+    #[test]
+    fn bti_chunk_target_arithmetic() {
+        // Single-chunk case (simple_table fixture shape): chunk_length 16384,
+        // offset 0/63/125 all land in chunk 0 with within == offset.
+        let chunk_length = 16384;
+        for off in [0usize, 63, 125] {
+            let (chunk, base, within) = SSTableReader::bti_chunk_target(off, chunk_length);
+            assert_eq!(chunk, 0, "off {off} must be in chunk 0");
+            assert_eq!(base, 0, "chunk 0 window base must be 0");
+            assert_eq!(within, off, "within must equal offset in chunk 0");
+        }
+
+        // Multi-chunk arithmetic with a small chunk_length to exercise the math.
+        let cl = 100usize;
+        // Exactly on a chunk boundary.
+        assert_eq!(SSTableReader::bti_chunk_target(100, cl), (1, 100, 0));
+        assert_eq!(SSTableReader::bti_chunk_target(200, cl), (2, 200, 0));
+        // Inside chunk 1.
+        assert_eq!(SSTableReader::bti_chunk_target(150, cl), (1, 100, 50));
+        // Just before a boundary.
+        assert_eq!(SSTableReader::bti_chunk_target(99, cl), (0, 0, 99));
+        // Within always equals off % chunk_length, base = chunk * chunk_length.
+        for off in [0usize, 1, 99, 100, 101, 250, 999] {
+            let (chunk, base, within) = SSTableReader::bti_chunk_target(off, cl);
+            assert_eq!(within, off % cl);
+            assert_eq!(base, chunk * cl);
+            assert_eq!(base + within, off);
+        }
+    }
+
+    /// `bti_partition_key_bytes_available` drives the growing-window stop
+    /// condition: while the `[flags][key_len][key bytes]` prefix is NOT yet fully
+    /// buffered it returns false (the chunk-targeted loop pulls another chunk);
+    /// once the declared key bytes have all arrived it returns true (the
+    /// INVARIANT-3 key match can be evaluated). This is the SYNTHETIC spanning
+    /// test: the key prefix straddles a simulated chunk boundary and the window
+    /// grows one byte at a time across it.
+    ///
+    /// NOTE: a full multi-chunk-spanning parse against a real
+    /// `V5CompressedLegacyParser` has NO real BTI DataOffset fixture — these are
+    /// narrow partitions that fit within a single chunk — so the spanning *parse*
+    /// path is only exercised structurally here via the byte-availability gate
+    /// that decides when a parse may even be attempted. This calls the real
+    /// associated function (no I/O), so a regression in its boundary math is
+    /// caught.
+    #[test]
+    fn bti_partition_key_bytes_available_growing_window() {
+        // Header at within=0: [flags=0x00][key_len=4][k0 k1 k2 k3]. Simulate a
+        // window that grows from 0 bytes up to the full prefix; availability must
+        // flip to true exactly when all 4 declared key bytes are buffered.
+        let expected_key = [0xAA, 0xBB, 0xCC, 0xDD];
+        let within = 0usize;
+        let full = {
+            let mut v = vec![0x00u8, expected_key.len() as u8];
+            v.extend_from_slice(&expected_key);
+            v
+        };
+
+        let avail = |len: usize| {
+            SSTableReader::bti_partition_key_bytes_available(&full[..len], within, &expected_key)
+        };
+
+        // Not enough for flags+key_len yet.
+        assert!(!avail(0));
+        assert!(!avail(1));
+        // flags+key_len present but key bytes not fully buffered.
+        assert!(!avail(2));
+        assert!(!avail(3)); // 1 key byte
+        assert!(!avail(4)); // 2 key bytes
+        assert!(!avail(5)); // 3 key bytes
+                            // All 4 key bytes buffered -> available (boundary fully crossed).
+        assert!(avail(6));
+        assert!(avail(full.len()));
+
+        // A non-zero `within` (target partition not at window start) must use the
+        // same relative math.
+        let mut padded = vec![0x77u8, 0x88];
+        padded.extend_from_slice(&full);
+        assert!(!SSTableReader::bti_partition_key_bytes_available(
+            &padded[..2 + 5],
+            2,
+            &expected_key
+        ));
+        assert!(SSTableReader::bti_partition_key_bytes_available(
+            &padded,
+            2,
+            &expected_key
+        ));
     }
 
     #[test]

--- a/cqlite-core/src/storage/sstable/reader/data_access.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access.rs
@@ -81,6 +81,46 @@ fn table_ids_match_strict(entry_table_id: &TableId, query_table_id: &TableId) ->
     }
 }
 
+/// Per-iteration decision for the BTI chunk-targeted point-lookup loop.
+#[derive(Debug, PartialEq, Eq)]
+enum BtiLookupStep {
+    /// The full partition-key prefix is buffered and matches the queried key —
+    /// parse the partition.
+    Parse,
+    /// The header/key prefix straddles a chunk boundary and is not yet fully
+    /// buffered — read the next chunk before parsing (chunk-targeted path only).
+    PullNextChunk,
+    /// Treat the partition as absent: either the buffered key prefix does not
+    /// match, or a whole-section window is structurally too short to grow.
+    Absent,
+}
+
+/// Decide what the BTI point-lookup loop should do for the current window state.
+///
+/// Pure so the chunk-straddle control flow is unit-testable without a real
+/// multi-chunk BTI fixture (DataOffset partitions are narrow and fit in one
+/// chunk, so a boundary-straddling header cannot be produced by the available
+/// fixtures). Crucially, when the key prefix is not yet buffered on the
+/// chunk-targeted path this returns [`BtiLookupStep::PullNextChunk`] — it must
+/// NOT lead to parsing a truncated header (issue #831 review).
+fn bti_lookup_step(
+    key_prefix_available: bool,
+    key_matches: bool,
+    chunk_targeted: bool,
+) -> BtiLookupStep {
+    if key_prefix_available {
+        if key_matches {
+            BtiLookupStep::Parse
+        } else {
+            BtiLookupStep::Absent
+        }
+    } else if chunk_targeted {
+        BtiLookupStep::PullNextChunk
+    } else {
+        BtiLookupStep::Absent
+    }
+}
+
 /// Sort a result slice in ascending Cassandra token order.
 ///
 /// The authoritative ordering for SSTable partitions is ascending Murmur3 token, with
@@ -422,28 +462,29 @@ impl SSTableReader {
                 )));
             }
 
-            // INVARIANT 3: verify the on-disk partition-key bytes match the queried
-            // key before decoding (guard against prefix-collision trie candidates).
-            if Self::bti_partition_key_bytes_available(&window, within, key.as_bytes()) {
-                if !self.bti_partition_key_matches(&window, within, key.as_bytes()) {
-                    debug!(
-                        "BTI trie candidate at offset {} did not match queried key (prefix \
-                         collision); treating as absent",
-                        offset
-                    );
+            // INVARIANT 3 + chunk-straddle gate. The parse/pull/absent decision is
+            // factored into the pure `bti_lookup_step` so the chunk-straddle control
+            // flow is unit-testable without a multi-chunk fixture (issue #831 review):
+            // when the header/key prefix is not yet fully buffered we must NOT invoke
+            // the parser on a truncated header (it can skip bytes and emit a later
+            // false-positive entry), and must read the next chunk first.
+            let key_available =
+                Self::bti_partition_key_bytes_available(&window, within, key.as_bytes());
+            let key_matches =
+                key_available && self.bti_partition_key_matches(&window, within, key.as_bytes());
+            match bti_lookup_step(key_available, key_matches, chunk_targeted) {
+                BtiLookupStep::Parse => { /* full key prefix buffered and matches */ }
+                BtiLookupStep::PullNextChunk => continue,
+                BtiLookupStep::Absent => {
+                    if key_available {
+                        debug!(
+                            "BTI trie candidate at offset {} did not match queried key \
+                             (prefix collision); treating as absent",
+                            offset
+                        );
+                    }
                     return Ok(None);
                 }
-                // Full key prefix is buffered and matches — safe to parse below.
-            } else if chunk_targeted {
-                // The partition header/key straddles a chunk boundary and is not
-                // yet fully buffered. Do NOT invoke the parser on a truncated
-                // header: `parse_block_emit` may skip bytes and emit a later
-                // false-positive entry, returning Ok and stopping the lookup
-                // prematurely (issue #831 review). Pull the next chunk first.
-                continue;
-            } else {
-                // Whole-section fallback but the key prefix is structurally short.
-                return Ok(None);
             }
 
             // Attempt to parse the FIRST partition at window[within..]. The parser
@@ -1844,6 +1885,45 @@ mod tests {
     // =========================================================================
     // table_ids_match tests
     // =========================================================================
+
+    #[test]
+    fn test_table_ids_match_strict_keyspace_aware() {
+        let a = TableId::new("ks_a.users".to_string());
+        let b = TableId::new("ks_b.users".to_string());
+        // Both qualified, different keyspace, same table name → must NOT match
+        // (the permissive helper would match these).
+        assert!(table_ids_match(&a, &b), "permissive helper matches on name");
+        assert!(
+            !table_ids_match_strict(&a, &b),
+            "strict guard must reject a wrong-keyspace same-name query"
+        );
+        // Both qualified, identical → match.
+        let a2 = TableId::new("ks_a.users".to_string());
+        assert!(table_ids_match_strict(&a, &a2));
+        // One side unqualified → fall back to permissive name match.
+        let unq = TableId::new("users".to_string());
+        assert!(table_ids_match_strict(&a, &unq));
+        assert!(table_ids_match_strict(&unq, &a));
+    }
+
+    #[test]
+    fn test_bti_lookup_step_decision() {
+        // Key prefix buffered and matches → parse.
+        assert_eq!(bti_lookup_step(true, true, true), BtiLookupStep::Parse);
+        assert_eq!(bti_lookup_step(true, true, false), BtiLookupStep::Parse);
+        // Key prefix buffered but does NOT match → absent (prefix collision).
+        assert_eq!(bti_lookup_step(true, false, true), BtiLookupStep::Absent);
+        assert_eq!(bti_lookup_step(true, false, false), BtiLookupStep::Absent);
+        // Key prefix NOT yet buffered (header straddles a chunk boundary):
+        //  - chunk-targeted path MUST pull the next chunk, never parse a
+        //    truncated header (issue #831 review regression);
+        assert_eq!(
+            bti_lookup_step(false, false, true),
+            BtiLookupStep::PullNextChunk
+        );
+        //  - whole-section fallback cannot grow → absent.
+        assert_eq!(bti_lookup_step(false, false, false), BtiLookupStep::Absent);
+    }
 
     #[test]
     fn test_table_ids_match_exact() {

--- a/cqlite-core/src/storage/sstable/reader/data_access.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access.rs
@@ -13,6 +13,17 @@ use std::io::SeekFrom;
 use tokio::io::AsyncSeekExt;
 use tokio::sync::mpsc;
 
+/// Counter of `scan_for_key` invocations, used by tests to prove the BTI
+/// point-lookup path never falls through to a sequential scan (issue #831).
+///
+/// Incremented at the top of [`SSTableReader::scan_for_key`] and read via
+/// [`SSTableReader::scan_for_key_call_count`]. The increment is a single
+/// `Relaxed` atomic add on a cold path, so the runtime cost is negligible; it is
+/// not gated behind `cfg(test)` because integration tests in the `tests/`
+/// directory compile against the library crate without its `test` cfg.
+pub(crate) static SCAN_FOR_KEY_CALLS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
 /// Compare two table IDs, handling both qualified (keyspace.table) and unqualified (table) formats.
 ///
 /// This function allows flexible matching:
@@ -126,6 +137,14 @@ impl SSTableReader {
             }
         }
 
+        // Issue #831: BTI ("da") readers resolve partitions via the Partitions.db
+        // trie (O(log n)), never via Index.db (absent for BTI) or the sequential
+        // scan. Branch BEFORE the Index.db block so a BTI get() can never fall
+        // through to scan_for_key.
+        if self.bti_partitions_db.is_some() {
+            return self.bti_point_lookup(table_id, key).await;
+        }
+
         // Use index for efficient lookup if available
         if let Some(index) = &self.index {
             if let Some(entry) = index.find_entry(table_id, key).await? {
@@ -157,6 +176,141 @@ impl SSTableReader {
             // No index at all — fall back to sequential scan
             return self.scan_for_key(table_id, key).await;
         }
+    }
+
+    /// Current value of the test-only `scan_for_key` invocation counter.
+    ///
+    /// Issue #831: tests use this to assert that a BTI `get()` resolves entirely
+    /// through the Partitions.db trie and never falls through to the sequential
+    /// scan. See [`SCAN_FOR_KEY_CALLS`].
+    pub fn scan_for_key_call_count() -> u64 {
+        SCAN_FOR_KEY_CALLS.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// BTI ("da") point lookup: resolve a partition key via the Partitions.db
+    /// trie, decode the partition at the resolved offset, and return its row
+    /// `Value` (issue #831).
+    ///
+    /// Correctness invariants (see issue #831 / #755):
+    ///
+    /// - **Offset domain**: the trie returns an *uncompressed* Data.db offset, so
+    ///   we decode the partition out of the DECOMPRESSED data section, never via
+    ///   `read_value_at_offset`/`get_cached_data` (which seek raw file bytes).
+    /// - **Own decompression**: `requires_chunk_stitching()` is `false` for BTI,
+    ///   so this path decompresses the chunk-compressed Data.db itself via the
+    ///   reader's CompressionInfo + compression_reader (`stitch_all_chunks`).
+    /// - **Prefix-collision guard**: the trie may return a candidate for a
+    ///   prefix-colliding key, so the decoded partition key is verified to equal
+    ///   the queried key before any row is returned.
+    async fn bti_point_lookup(&self, _table_id: &TableId, key: &RowKey) -> Result<Option<Value>> {
+        // 1. Resolve the uncompressed Data.db offset via the trie.
+        let offset = match self.lookup_partition_via_bti_trie(key.as_bytes())? {
+            Some(off) => off as usize,
+            None => return Ok(None), // not in this SSTable
+        };
+
+        // 2. Decompress the data section into a single buffer. The trie offset
+        //    indexes into THIS decompressed buffer (INVARIANT 1).
+        //
+        //    Reuse the shared chunk-stitch helper, which decompresses every chunk
+        //    via the reader's compression_reader. Serialise against other scans
+        //    (shared file position + chunk index) per issue #805.
+        let decompressed = {
+            let _scan_guard = self.scan_mutex.lock().await;
+            let header_size = self.calculate_header_size();
+            {
+                let mut file_guard = self.file.lock().await;
+                file_guard.seek(SeekFrom::Start(header_size as u64)).await?;
+            }
+            self.current_chunk_index
+                .store(0, std::sync::atomic::Ordering::Relaxed);
+            self.stitch_all_chunks().await?
+        };
+
+        if offset >= decompressed.len() {
+            return Err(Error::corruption(format!(
+                "BTI trie resolved Data.db offset {} beyond decompressed data section ({} bytes)",
+                offset,
+                decompressed.len()
+            )));
+        }
+
+        // 3. Verify the partition-key bytes at the resolved offset match the
+        //    queried key (INVARIANT 3: guard against prefix-collision candidates).
+        //
+        //    Partition on-disk header (oa/da, hasUIntDeletionTime):
+        //      [0]      flags (0x00)
+        //      [1]      key_len (u8)
+        //      [2..2+L] raw partition-key bytes
+        //      [..]     partition deletion time
+        if !self.bti_partition_key_matches(&decompressed, offset, key.as_bytes()) {
+            debug!(
+                "BTI trie candidate at offset {} did not match queried key (prefix collision); \
+                 treating as absent",
+                offset
+            );
+            return Ok(None);
+        }
+
+        // 4. Decode the partition. Feed the decompressed buffer FROM the resolved
+        //    offset to the schema-aware V5 parser, which parses the partition-key
+        //    header itself and stops at the next partition boundary / end-of-buffer
+        //    (it detects the next partition header structurally and honours the
+        //    0x01 end-of-partition marker). Stop after the first emitted entry so
+        //    only the target partition is decoded.
+        let schema_opt = self.get_table_schema(None);
+        let parser = self.build_v5_parser();
+
+        let mut found: Option<Value> = None;
+        parser.parse_block_emit(
+            &decompressed[offset..],
+            schema_opt.as_ref(),
+            self,
+            |(_tid, entry_key, entry_value)| {
+                // The first partition in the slice is the one the trie resolved.
+                // Defensively re-check the key (the parser-decoded partition key
+                // must equal the queried key).
+                if entry_key.as_bytes() == key.as_bytes() {
+                    found = Some(entry_value);
+                }
+                Ok(std::ops::ControlFlow::Break(()))
+            },
+        )?;
+
+        match found {
+            Some(value) => {
+                if !self.filter_tombstone(&value) {
+                    return Ok(None);
+                }
+                Ok(Some(value))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Verify the on-disk partition-key bytes at `offset` in the decompressed
+    /// data section equal `expected_key` (issue #831, INVARIANT 3).
+    ///
+    /// Reads the `[flags][key_len: u8][key bytes]` prefix. Returns `false` (rather
+    /// than erroring) on any structural mismatch so the caller can treat the trie
+    /// candidate as absent.
+    fn bti_partition_key_matches(
+        &self,
+        decompressed: &[u8],
+        offset: usize,
+        expected_key: &[u8],
+    ) -> bool {
+        // Need at least flags + key_len.
+        if offset + 2 > decompressed.len() {
+            return false;
+        }
+        let key_len = decompressed[offset + 1] as usize;
+        let key_start = offset + 2;
+        let key_end = key_start + key_len;
+        if key_end > decompressed.len() {
+            return false;
+        }
+        &decompressed[key_start..key_end] == expected_key
     }
 
     /// Scan a range of keys
@@ -906,6 +1060,10 @@ impl SSTableReader {
     }
 
     async fn scan_for_key(&self, table_id: &TableId, key: &RowKey) -> Result<Option<Value>> {
+        // Issue #831: record the call so tests can assert the BTI point-lookup
+        // path never reaches the sequential scan.
+        SCAN_FOR_KEY_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
         // Issue #805: serialise concurrent scans (shared file position + chunk index).
         let _scan_guard = self.scan_mutex.lock().await;
 

--- a/cqlite-core/src/storage/sstable/reader/data_access.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access.rs
@@ -202,7 +202,7 @@ impl SSTableReader {
     /// - **Prefix-collision guard**: the trie may return a candidate for a
     ///   prefix-colliding key, so the decoded partition key is verified to equal
     ///   the queried key before any row is returned.
-    async fn bti_point_lookup(&self, _table_id: &TableId, key: &RowKey) -> Result<Option<Value>> {
+    async fn bti_point_lookup(&self, table_id: &TableId, key: &RowKey) -> Result<Option<Value>> {
         // 1. Resolve the uncompressed Data.db offset via the trie.
         let offset = match self.lookup_partition_via_bti_trie(key.as_bytes())? {
             Some(off) => off as usize,
@@ -266,11 +266,12 @@ impl SSTableReader {
             &decompressed[offset..],
             schema_opt.as_ref(),
             self,
-            |(_tid, entry_key, entry_value)| {
+            |(tid, entry_key, entry_value)| {
                 // The first partition in the slice is the one the trie resolved.
-                // Defensively re-check the key (the parser-decoded partition key
-                // must equal the queried key).
-                if entry_key.as_bytes() == key.as_bytes() {
+                // Verify BOTH that the emitted table id matches the queried table
+                // (so a wrong-table query never returns a row, issue #831 review)
+                // AND that the parser-decoded partition key equals the queried key.
+                if table_ids_match(&tid, table_id) && entry_key.as_bytes() == key.as_bytes() {
                     found = Some(entry_value);
                 }
                 Ok(std::ops::ControlFlow::Break(()))

--- a/cqlite-core/src/storage/sstable/reader/header.rs
+++ b/cqlite-core/src/storage/sstable/reader/header.rs
@@ -266,6 +266,20 @@ pub(crate) async fn parse_header_with_version_detection(
         }
     }
 
+    // Issue #831: BTI ("da") format Data.db is headerless, exactly like nb/oa
+    // BIG format — the file begins directly with compressed-chunk data and all
+    // metadata lives in the companion Statistics.db / CompressionInfo.db. There is
+    // never an embedded magic number, so we go straight to a minimal header
+    // (versioned V5_0Bti so schema extraction and the V5 row parser engage).
+    if matches!(gates, VersionGates::Bti(_)) {
+        log::debug!(
+            "Detected BTI (da) format from filename '{}' — headerless Data.db, \
+             building minimal header from CompressionInfo.db",
+            path.display()
+        );
+        return create_minimal_bti_header(path).await;
+    }
+
     // Read first 4 bytes as potential magic number or CRC32 checksum
     let first_4_bytes = u32::from_be_bytes([
         header_buffer[0],
@@ -637,6 +651,60 @@ async fn create_minimal_nb_header(path: &Path) -> Result<SSTableHeader> {
         cassandra_version: CassandraVersion::V5_0NewBig, // NB format maps to NewBig
         version: 0,        // NB format doesn't have version in Data.db
         table_id: [0; 16], // Table ID is in other components
+        keyspace: extract_keyspace_from_path(path),
+        table_name: extract_table_name_from_path(path),
+        generation: extract_generation_from_path(path),
+        compression: CompressionInfo {
+            algorithm: compression_algorithm,
+            chunk_size: 16384, // Default chunk size
+            parameters: std::collections::HashMap::new(),
+        },
+        stats: SSTableStats {
+            row_count: 0,
+            min_timestamp: 0,
+            max_timestamp: 0,
+            max_deletion_time: 0,
+            compression_ratio: 1.0,
+            row_size_histogram: vec![],
+        },
+        columns: vec![],
+        properties: std::collections::HashMap::new(),
+    })
+}
+
+/// Build a minimal headerless header for BTI ("da") format Data.db (issue #831).
+///
+/// BTI Data.db is headerless and chunk-compressed, just like nb/oa BIG format,
+/// so this mirrors [`create_minimal_nb_header`] but sets `cassandra_version` to
+/// [`CassandraVersion::V5_0Bti`] — which is what makes the reader engage schema
+/// extraction (mod.rs schema-eligible match) and schema-aware V5 row parsing for
+/// the BTI partition decode path. Compression metadata is loaded from the sibling
+/// CompressionInfo.db (BTI Data.db is LZ4-chunk-compressed).
+async fn create_minimal_bti_header(path: &Path) -> Result<SSTableHeader> {
+    let compression_algorithm = match load_nb_compression_info(path).await {
+        Ok(info) => {
+            log::info!(
+                "Loaded CompressionInfo.db for BTI format: algorithm={}, chunk_length={}, chunks={}",
+                info.algorithm,
+                info.chunk_length,
+                info.chunk_offsets.len()
+            );
+            info.algorithm
+        }
+        Err(e) => {
+            log::warn!(
+                "Could not load CompressionInfo.db for BTI format file '{}': {}. Assuming no compression.",
+                path.display(),
+                e
+            );
+            "NONE".to_string()
+        }
+    };
+
+    Ok(SSTableHeader {
+        cassandra_version: CassandraVersion::V5_0Bti, // da format maps to BTI
+        version: 0,                                   // headerless: no version in Data.db
+        table_id: [0; 16],                            // Table ID is in other components
         keyspace: extract_keyspace_from_path(path),
         table_name: extract_table_name_from_path(path),
         generation: extract_generation_from_path(path),

--- a/cqlite-core/src/storage/sstable/reader/header_helpers.rs
+++ b/cqlite-core/src/storage/sstable/reader/header_helpers.rs
@@ -92,6 +92,14 @@ pub(crate) fn calculate_actual_header_size(
         return Ok(0);
     }
 
+    // Issue #831: BTI ("da") Data.db is headerless — create_minimal_bti_header()
+    // sets version=0 as the headerless sentinel. The Data.db buffer is compressed
+    // chunk data starting at offset 0, not an embedded header.
+    if header.cassandra_version == CassandraVersion::V5_0Bti && header.version == 0 {
+        debug!("Headerless BTI (da) format detected (version=0) - Data.db starts at offset 0");
+        return Ok(0);
+    }
+
     // Use proper structured parsing to find the end of the header
     match header.cassandra_version {
         CassandraVersion::V5_0NewBig => {

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -177,19 +177,41 @@ impl SSTableReader {
             }
         });
 
-        // VG5: BTI (da) read support is not yet implemented.
-        // Detect the BTI format early — before header parsing — and return a
-        // structured, actionable error rather than a confusing parse failure.
-        // Full BTI reading is tracked in the scoping issue created by issue #657.
-        if matches!(*version_gates, VersionGates::Bti(_)) {
-            return Err(Error::unsupported_format(format!(
-                "BTI (da) read support not yet implemented for '{}'. \
-                 da-format SSTables use Partitions.db/Rows.db trie indexes instead of \
-                 Index.db/Summary.db and require a dedicated BTI read path. \
-                 See docs/reports/bti-read-support-scoping.md for the implementation plan.",
-                path.display()
-            )));
-        }
+        // VG5 / Issue #831: BTI ("da") read support.
+        //
+        // BTI SSTables use a Partitions.db trie (and optional Rows.db) instead of
+        // Index.db/Summary.db. We load the (tiny) Partitions.db trie fully into
+        // memory here so the point-lookup path (`lookup_partition_via_bti_trie` /
+        // `bti_point_lookup`) can walk it for O(log n) partition resolution.
+        //
+        // Loading Partitions.db is the ONLY BTI-specific step in open(): the rest
+        // of the flow (header / compression / Statistics-driven schema) tolerates
+        // the absent Index.db/Summary.db gracefully (those loaders return None).
+        let bti_partitions_db: Option<Arc<Vec<u8>>> =
+            if matches!(*version_gates, VersionGates::Bti(_)) {
+                let base = extract_sstable_base_name(path).ok_or_else(|| {
+                    Error::unsupported_format(format!(
+                        "BTI (da) SSTable '{}' has a non-standard filename; cannot derive the \
+                         sibling Partitions.db name required for trie point lookup (#831).",
+                        path.display()
+                    ))
+                })?;
+                let parent = path.parent().unwrap_or_else(|| Path::new("."));
+                let partitions_path = parent.join(format!("{}-Partitions.db", base));
+                let bytes = tokio::fs::read(&partitions_path).await.map_err(|e| {
+                    Error::unsupported_format(format!(
+                        "BTI (da) SSTable '{}' is missing its sibling Partitions.db trie \
+                         (expected '{}'): {}. BTI read support requires Partitions.db for \
+                         partition-key point lookup (#831).",
+                        path.display(),
+                        partitions_path.display(),
+                        e
+                    ))
+                })?;
+                Some(Arc::new(bytes))
+            } else {
+                None
+            };
 
         let config = crate::cql::config::ParserConfig::default();
         let parser = SSTableParser::new(config)?;
@@ -371,6 +393,7 @@ impl SSTableReader {
             current_chunk_index: AtomicUsize::new(0),
             scan_mutex: tokio::sync::Mutex::new(()),
             version_gates,
+            bti_partitions_db,
         })
     }
 

--- a/cqlite-core/src/storage/sstable/reader/parsing/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/mod.rs
@@ -21,6 +21,10 @@ mod value_parsing;
 // Re-export V5CompressedLegacy parser for internal use
 pub(in crate::storage::sstable::reader) use v5_compressed_legacy::V5CompressedLegacyParser;
 
+// Re-export the sliding-window parse outcome enum (issue #827) so the
+// compaction-read streaming driver in data_access.rs can match on it.
+pub(in crate::storage::sstable::reader) use v5_compressed_legacy::ParseStep;
+
 // Re-export publicly for integration tests (Issue #166 regression tests)
 // Using doc(hidden) to keep it out of public documentation but available for testing
 #[doc(hidden)]

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
@@ -90,6 +90,26 @@ type ParsedRow = (
 /// Each element is `(table_id, row_key, value_map, cell_metadata_map)`.
 type ParsedBlockWithMeta = Vec<(TableId, RowKey, Value, HashMap<String, CellWriteMetadata>)>;
 
+/// Outcome of [`V5CompressedLegacyParser::parse_one_partition_with_timestamps`].
+///
+/// The sliding-window compaction-read driver (issue #827) feeds the parser a
+/// `data` slice that grows as decompressed chunks are appended and shrinks as
+/// confirmed partitions are drained. Because a single partition can straddle a
+/// compression-chunk boundary, the bounded parser must distinguish "I parsed a
+/// complete partition" from "I ran out of buffer mid-partition and need more
+/// bytes" — conflating the two would silently drop trailing partitions.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ParseStep {
+    /// A full partition was parsed; `usize` bytes of `data` were consumed and
+    /// can be drained from the front of the sliding window.
+    Emitted(usize),
+    /// `data` appears truncated mid-partition. The caller should append the
+    /// next decompressed chunk and retry. Only returned when `!at_final_chunk`.
+    NeedMore,
+    /// Genuine end of partitions in `data` (no more bytes to consume).
+    Done,
+}
+
 /// Row header data extracted from V5CompressedLegacy row
 #[derive(Debug, Clone)]
 struct RowHeader {
@@ -983,15 +1003,39 @@ impl V5CompressedLegacyParser {
         schema: Option<&TableSchema>,
         reader: &super::super::types::SSTableReader,
     ) -> Result<Vec<(TableId, RowKey, Value, i64)>> {
-        // parse_block now emits Value::Tombstone correctly; we just add the
-        // per-row timestamp from the row header.
-        //
-        // Rather than duplicating the entire loop we parse with parse_block and
-        // separately call parse_row_data_with_offset to obtain the timestamp.
-        // However, that would re-parse the data twice.  Instead, we duplicate the
-        // loop here — it is a thin wrapper that adds the timestamp extraction.
+        // Thin wrapper that collects the streaming emit variant into a Vec, so
+        // every existing caller/test is byte-for-byte unchanged (issue #827).
+        let mut results: Vec<(TableId, RowKey, Value, i64)> = Vec::new();
+        self.parse_block_with_timestamps_emit(data, schema, reader, |entry| {
+            results.push(entry);
+            Ok(std::ops::ControlFlow::Continue(()))
+        })?;
+        Ok(results)
+    }
+
+    /// Streaming variant of [`parse_block_with_timestamps`]: invokes `emit` for
+    /// each parsed `(TableId, RowKey, Value, row_timestamp_micros)` entry rather
+    /// than collecting into a `Vec`, so the compaction read path can forward
+    /// rows into a bounded channel without materialising the whole block at once
+    /// (issue #827). Returning `ControlFlow::Break` from `emit` stops parsing
+    /// early — used when the streaming consumer is dropped.
+    ///
+    /// The tombstone/timestamp semantics are byte-identical to
+    /// [`parse_block_with_timestamps`] (Issue #505/#533): a row tombstone is
+    /// emitted as `Value::Tombstone` carrying its `markedForDeleteAt`, and the
+    /// fourth tuple element is the row write timestamp for live rows.
+    pub fn parse_block_with_timestamps_emit<F>(
+        &self,
+        data: &[u8],
+        schema: Option<&TableSchema>,
+        reader: &super::super::types::SSTableReader,
+        mut emit: F,
+    ) -> Result<()>
+    where
+        F: FnMut((TableId, RowKey, Value, i64)) -> Result<std::ops::ControlFlow<()>>,
+    {
         if data.is_empty() {
-            return Ok(Vec::new());
+            return Ok(());
         }
 
         let schema = schema.ok_or_else(|| {
@@ -1001,158 +1045,280 @@ impl V5CompressedLegacyParser {
             ))
         })?;
 
-        let mut results: Vec<(TableId, RowKey, Value, i64)> = Vec::new();
         let mut offset = 0;
-        let table_id = TableId::new(format!("{}.{}", self.keyspace, self.table_name));
-
-        const CASSANDRA_MAX_KEY_SIZE: usize = 65536;
-        const FORMAT_MAX_KEY_SIZE: usize = 255;
-
-        let mut partition_index = 0;
         let mut skipped_partitions = 0;
 
+        // Wrap `emit` so a Break is observable here as well as inside the
+        // one-partition parser (which stops its inner row loop on Break). This
+        // lets the outer loop terminate promptly when the consumer is dropped.
+        // `Cell` so the wrapping closure can borrow it shared while the outer
+        // loop also reads it between calls.
+        let broke = std::cell::Cell::new(false);
+        let mut tracking_emit = |entry| -> Result<std::ops::ControlFlow<()>> {
+            let flow = emit(entry)?;
+            if matches!(flow, std::ops::ControlFlow::Break(())) {
+                broke.set(true);
+            }
+            Ok(flow)
+        };
+
         while offset < data.len() {
-            if offset + 2 > data.len() {
-                break;
-            }
-
-            let flags = data[offset];
-            let key_len = data[offset + 1] as usize;
-            let header_min_size = 1 + 1 + key_len + 4 + 8;
-
-            if key_len == 0
-                || key_len > FORMAT_MAX_KEY_SIZE.min(CASSANDRA_MAX_KEY_SIZE)
-                || offset + header_min_size > data.len()
-            {
-                skipped_partitions += 1;
-                offset += 1;
-                let _ = flags; // silence unused warning
-                continue;
-            }
-
-            match self.parse_partition_header(data, offset) {
-                Ok((partition_key, new_offset)) => {
-                    offset = new_offset;
-                    let mut static_cells: HashMap<String, Value> = HashMap::new();
-
-                    loop {
-                        if offset < data.len() && Self::is_end_of_partition(data[offset]) {
-                            offset += 1;
-                            break;
-                        }
-                        if offset < data.len() && Self::is_range_tombstone_marker(data[offset]) {
-                            match self.skip_range_tombstone_marker(data, offset, schema) {
-                                Ok(next_offset) => {
-                                    offset = next_offset;
-                                    continue;
-                                }
-                                Err(_) => break,
-                            }
-                        }
-
-                        match self.parse_row_data_with_offset(
-                            data,
-                            offset,
-                            Some(schema),
-                            reader,
-                            false,
-                        ) {
-                            Ok((
-                                mut cells,
-                                _row_cell_meta,
-                                row_header_opt,
-                                next_offset,
-                                is_static,
-                            )) => {
-                                offset = next_offset;
-
-                                // For a row tombstone the authoritative timestamp is
-                                // markedForDeleteAt (HAS_TIMESTAMP is absent for pure row
-                                // deletes). For a live row it is the row write timestamp.
-                                // Both the merger tuple `row_ts` and the emitted
-                                // Value::Tombstone must agree, so resolve once here (#505).
-                                let row_tombstone =
-                                    row_header_opt.as_ref().filter(|h| h.is_row_tombstone());
-                                let row_ts = match row_tombstone {
-                                    Some(h) => h.row_tombstone_deletion_time(),
-                                    None => row_header_opt
-                                        .as_ref()
-                                        .and_then(|h| h.timestamp)
-                                        .unwrap_or(0),
-                                };
-
-                                if is_static {
-                                    static_cells = cells;
-                                } else {
-                                    for (k, v) in &static_cells {
-                                        cells.entry(k.clone()).or_insert_with(|| v.clone());
-                                    }
-
-                                    // Row tombstone → Value::Tombstone(markedForDeleteAt)
-                                    let row_value = if let Some(h) = row_tombstone {
-                                        h.row_tombstone()
-                                    } else if cells.is_empty() {
-                                        Value::Null
-                                    } else {
-                                        let mut map_entries: Vec<(Value, Value)> = cells
-                                            .into_iter()
-                                            .map(|(name, value)| (Value::Text(name), value))
-                                            .collect();
-                                        map_entries.sort_by(|a, b| {
-                                            let a_key = if let Value::Text(s) = &a.0 {
-                                                s.as_str()
-                                            } else {
-                                                ""
-                                            };
-                                            let b_key = if let Value::Text(s) = &b.0 {
-                                                s.as_str()
-                                            } else {
-                                                ""
-                                            };
-                                            a_key.cmp(b_key)
-                                        });
-                                        Value::Map(map_entries)
-                                    };
-
-                                    results.push((
-                                        table_id.clone(),
-                                        partition_key.clone(),
-                                        row_value,
-                                        row_ts,
-                                    ));
-                                }
-
-                                if offset >= data.len() {
-                                    break;
-                                }
-                                if self.peek_is_partition_header(data, offset) {
-                                    break;
-                                }
-                            }
-                            Err(_) => break,
-                        }
+            match self.parse_one_partition_with_timestamps(
+                &data[offset..],
+                Some(schema),
+                reader,
+                // The whole block is present; never request a refill. A trailing
+                // parse failure is terminal here (matches the legacy
+                // `Err(_) => break` behaviour of the original loop).
+                true,
+                &mut tracking_emit,
+            )? {
+                ParseStep::Emitted(consumed) => {
+                    if consumed == 0 {
+                        // Defensive: avoid an infinite loop on a zero-byte
+                        // partition (should not happen — a header is >= 2 bytes).
+                        skipped_partitions += 1;
+                        offset += 1;
+                    } else {
+                        offset += consumed;
                     }
-
-                    partition_index += 1;
                 }
-                Err(_) => {
-                    skipped_partitions += 1;
-                    offset += 1;
-                    continue;
-                }
+                // `at_final_chunk = true` collapses NeedMore into Done: there is
+                // no further chunk to append, so a truncated tail is end-of-data.
+                ParseStep::NeedMore | ParseStep::Done => break,
+            }
+            // Propagate an early Break from `emit` (consumer dropped).
+            if broke.get() {
+                break;
             }
         }
 
         if skipped_partitions > 0 {
             log::warn!(
-                "V5CompressedLegacy (compaction): parsed {} entries, skipped {} malformed partitions",
-                results.len(),
+                "V5CompressedLegacy (compaction): skipped {} malformed partitions",
                 skipped_partitions
             );
         }
-        let _ = partition_index; // used for bookkeeping
 
-        Ok(results)
+        Ok(())
+    }
+
+    /// Parse exactly ONE partition from the front of `data`, emitting each row
+    /// via `emit`, and report how the parse terminated (issue #827).
+    ///
+    /// This isolates the body of the outer partition loop so the sliding-window
+    /// compaction driver can drain one partition at a time and `drain(0..consumed)`
+    /// from its window between calls. The crucial distinction over the legacy
+    /// monolithic loop is `NeedMore` vs `Done`:
+    ///
+    /// - [`ParseStep::Emitted(consumed)`] — a full partition was parsed and
+    ///   terminated by an END_OF_PARTITION marker or a confirmed next-partition
+    ///   header. `consumed` bytes may be drained from the window.
+    /// - [`ParseStep::NeedMore`] — `data` is (possibly) truncated mid-partition
+    ///   and `!at_final_chunk`, so the caller must append the next chunk and
+    ///   retry. NEVER returned when `at_final_chunk` is true.
+    /// - [`ParseStep::Done`] — genuine end of partitions, or (when
+    ///   `at_final_chunk`) a trailing truncation that cannot be resolved by more
+    ///   data. Terminal.
+    ///
+    /// `at_final_chunk` flips a mid-partition parse failure between a refill
+    /// request (`NeedMore`) and a terminal stop. The legacy code conflated
+    /// parse-error with end-of-partitions (`Err(_) => break`); doing that
+    /// mid-stream would silently drop every partition after a chunk boundary, so
+    /// we return `NeedMore` whenever the buffer may simply be truncated and we
+    /// are not yet at the final chunk.
+    pub fn parse_one_partition_with_timestamps<F>(
+        &self,
+        data: &[u8],
+        schema: Option<&TableSchema>,
+        reader: &super::super::types::SSTableReader,
+        at_final_chunk: bool,
+        emit: &mut F,
+    ) -> Result<ParseStep>
+    where
+        F: FnMut((TableId, RowKey, Value, i64)) -> Result<std::ops::ControlFlow<()>>,
+    {
+        if data.is_empty() {
+            return Ok(ParseStep::Done);
+        }
+
+        let schema = schema.ok_or_else(|| {
+            Error::schema(format!(
+                "V5CompressedLegacy (compaction) format requires schema for {}.{}",
+                self.keyspace, self.table_name
+            ))
+        })?;
+
+        let table_id = TableId::new(format!("{}.{}", self.keyspace, self.table_name));
+
+        const CASSANDRA_MAX_KEY_SIZE: usize = 65536;
+        const FORMAT_MAX_KEY_SIZE: usize = 255;
+
+        // A partition header is at least flags(1) + key_len(1). If we cannot even
+        // read those two bytes, we are truncated: request more unless final.
+        if data.len() < 2 {
+            return Ok(if at_final_chunk {
+                ParseStep::Done
+            } else {
+                ParseStep::NeedMore
+            });
+        }
+
+        let key_len = data[1] as usize;
+        let header_min_size = 1 + 1 + key_len + 4 + 8;
+
+        // Invalid header shape (zero/over-long key) → malformed; advance by one
+        // byte so the outer loop can resynchronise. Returning Emitted(1) here
+        // mirrors the legacy `offset += 1; continue` skip-a-byte recovery.
+        if key_len == 0 || key_len > FORMAT_MAX_KEY_SIZE.min(CASSANDRA_MAX_KEY_SIZE) {
+            return Ok(ParseStep::Emitted(1));
+        }
+
+        // Header declared but not fully present in `data` → truncated mid-header.
+        if header_min_size > data.len() {
+            return Ok(if at_final_chunk {
+                // No more bytes will ever arrive; the legacy loop treated this
+                // as the end of parseable partitions.
+                ParseStep::Done
+            } else {
+                ParseStep::NeedMore
+            });
+        }
+
+        let (partition_key, mut offset) = match self.parse_partition_header(data, 0) {
+            Ok(v) => v,
+            Err(_) => {
+                // Fixed header bytes are present but did not parse: skip a byte
+                // to resynchronise — matching the legacy
+                // `Err(_) => { offset += 1; continue }` recovery.
+                return Ok(ParseStep::Emitted(1));
+            }
+        };
+
+        let mut static_cells: HashMap<String, Value> = HashMap::new();
+
+        loop {
+            // END_OF_PARTITION (0x01): partition complete, consume the marker.
+            if offset < data.len() && Self::is_end_of_partition(data[offset]) {
+                offset += 1;
+                return Ok(ParseStep::Emitted(offset));
+            }
+
+            // Consumed everything but never saw END_OF_PARTITION: the partition
+            // may continue in the next chunk.
+            if offset >= data.len() {
+                return Ok(if at_final_chunk {
+                    ParseStep::Emitted(offset)
+                } else {
+                    ParseStep::NeedMore
+                });
+            }
+
+            if Self::is_range_tombstone_marker(data[offset]) {
+                match self.skip_range_tombstone_marker(data, offset, schema) {
+                    Ok(next_offset) => {
+                        offset = next_offset;
+                        continue;
+                    }
+                    Err(_) => {
+                        // Marker body truncated? request more unless final.
+                        return Ok(if at_final_chunk {
+                            ParseStep::Emitted(offset)
+                        } else {
+                            ParseStep::NeedMore
+                        });
+                    }
+                }
+            }
+
+            match self.parse_row_data_with_offset(data, offset, Some(schema), reader, false) {
+                Ok((mut cells, _row_cell_meta, row_header_opt, next_offset, is_static)) => {
+                    offset = next_offset;
+
+                    // For a row tombstone the authoritative timestamp is
+                    // markedForDeleteAt (HAS_TIMESTAMP is absent for pure row
+                    // deletes). For a live row it is the row write timestamp.
+                    // Both the merger tuple `row_ts` and the emitted
+                    // Value::Tombstone must agree, so resolve once here (#505).
+                    let row_tombstone = row_header_opt.as_ref().filter(|h| h.is_row_tombstone());
+                    let row_ts = match row_tombstone {
+                        Some(h) => h.row_tombstone_deletion_time(),
+                        None => row_header_opt
+                            .as_ref()
+                            .and_then(|h| h.timestamp)
+                            .unwrap_or(0),
+                    };
+
+                    if is_static {
+                        static_cells = cells;
+                    } else {
+                        for (k, v) in &static_cells {
+                            cells.entry(k.clone()).or_insert_with(|| v.clone());
+                        }
+
+                        // Row tombstone → Value::Tombstone(markedForDeleteAt)
+                        let row_value = if let Some(h) = row_tombstone {
+                            h.row_tombstone()
+                        } else if cells.is_empty() {
+                            Value::Null
+                        } else {
+                            let mut map_entries: Vec<(Value, Value)> = cells
+                                .into_iter()
+                                .map(|(name, value)| (Value::Text(name), value))
+                                .collect();
+                            map_entries.sort_by(|a, b| {
+                                let a_key = if let Value::Text(s) = &a.0 {
+                                    s.as_str()
+                                } else {
+                                    ""
+                                };
+                                let b_key = if let Value::Text(s) = &b.0 {
+                                    s.as_str()
+                                } else {
+                                    ""
+                                };
+                                a_key.cmp(b_key)
+                            });
+                            Value::Map(map_entries)
+                        };
+
+                        match emit((table_id.clone(), partition_key.clone(), row_value, row_ts))? {
+                            std::ops::ControlFlow::Continue(()) => {}
+                            std::ops::ControlFlow::Break(()) => {
+                                // Consumer dropped: stop emitting. Report bytes
+                                // consumed so far so the caller can drain.
+                                return Ok(ParseStep::Emitted(offset));
+                            }
+                        }
+                    }
+
+                    if offset >= data.len() {
+                        // End of the buffer without an explicit END_OF_PARTITION:
+                        // the partition may continue in the next chunk.
+                        return Ok(if at_final_chunk {
+                            ParseStep::Emitted(offset)
+                        } else {
+                            ParseStep::NeedMore
+                        });
+                    }
+                    if self.peek_is_partition_header(data, offset) {
+                        // Next partition starts here — current one is complete.
+                        return Ok(ParseStep::Emitted(offset));
+                    }
+                }
+                Err(_) => {
+                    // A row failed to parse. The legacy loop unconditionally
+                    // `break`s here (end-of-partition). Mid-stream that may
+                    // instead be a row straddling the chunk boundary, so request
+                    // more bytes unless this is the final chunk.
+                    return Ok(if at_final_chunk {
+                        ParseStep::Emitted(offset)
+                    } else {
+                        ParseStep::NeedMore
+                    });
+                }
+            }
+        }
     }
 
     /// Parse row flags only (Issue #213 fix: split from parse_row_header)

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
@@ -1197,21 +1197,52 @@ impl V5CompressedLegacyParser {
 
         let mut static_cells: HashMap<String, Value> = HashMap::new();
 
+        // Finding 1 (#827): buffer this partition's emitted rows locally and only
+        // forward them to the external `emit` once the partition is CONFIRMED
+        // complete (a `ParseStep::Emitted` return). If the buffer is truncated
+        // mid-partition (`NeedMore`) after one or more rows were parsed, we must
+        // emit NOTHING and let the caller refill and re-parse this partition from
+        // its start — otherwise the already-forwarded rows would be re-emitted on
+        // the retry, duplicating them in the streaming compaction output.
+        //
+        // The buffer is bounded by ONE partition's rows (the documented
+        // `max_partition_size` bound), not the whole file, so memory stays
+        // bounded as required by the #827 deliverable.
+        let mut pending: Vec<(TableId, RowKey, Value, i64)> = Vec::new();
+
+        // Flush the buffered rows to the external `emit`, honouring an early
+        // `Break`. Returns the `ParseStep` to surface to the caller: on `Break`
+        // we still report the bytes consumed for this (complete) partition so the
+        // caller drains correctly, but stop forwarding the remaining buffered
+        // rows. `flushed_break` becomes true so the driver can stop promptly.
+        macro_rules! flush_and_emitted {
+            ($consumed:expr, $pending:expr, $emit:expr) => {{
+                for entry in $pending.drain(..) {
+                    match $emit(entry)? {
+                        std::ops::ControlFlow::Continue(()) => {}
+                        std::ops::ControlFlow::Break(()) => break,
+                    }
+                }
+                Ok(ParseStep::Emitted($consumed))
+            }};
+        }
+
         loop {
             // END_OF_PARTITION (0x01): partition complete, consume the marker.
             if offset < data.len() && Self::is_end_of_partition(data[offset]) {
                 offset += 1;
-                return Ok(ParseStep::Emitted(offset));
+                return flush_and_emitted!(offset, pending, emit);
             }
 
             // Consumed everything but never saw END_OF_PARTITION: the partition
-            // may continue in the next chunk.
+            // may continue in the next chunk. On NeedMore emit NOTHING (drop the
+            // buffered rows) so the caller can refill and re-parse from the start
+            // without duplicating already-buffered rows (Finding 1).
             if offset >= data.len() {
-                return Ok(if at_final_chunk {
-                    ParseStep::Emitted(offset)
-                } else {
-                    ParseStep::NeedMore
-                });
+                if at_final_chunk {
+                    return flush_and_emitted!(offset, pending, emit);
+                }
+                return Ok(ParseStep::NeedMore);
             }
 
             if Self::is_range_tombstone_marker(data[offset]) {
@@ -1222,11 +1253,10 @@ impl V5CompressedLegacyParser {
                     }
                     Err(_) => {
                         // Marker body truncated? request more unless final.
-                        return Ok(if at_final_chunk {
-                            ParseStep::Emitted(offset)
-                        } else {
-                            ParseStep::NeedMore
-                        });
+                        if at_final_chunk {
+                            return flush_and_emitted!(offset, pending, emit);
+                        }
+                        return Ok(ParseStep::NeedMore);
                     }
                 }
             }
@@ -1282,28 +1312,25 @@ impl V5CompressedLegacyParser {
                             Value::Map(map_entries)
                         };
 
-                        match emit((table_id.clone(), partition_key.clone(), row_value, row_ts))? {
-                            std::ops::ControlFlow::Continue(()) => {}
-                            std::ops::ControlFlow::Break(()) => {
-                                // Consumer dropped: stop emitting. Report bytes
-                                // consumed so far so the caller can drain.
-                                return Ok(ParseStep::Emitted(offset));
-                            }
-                        }
+                        // Finding 1: buffer the row instead of forwarding it now.
+                        // It is flushed to `emit` only when the partition is
+                        // confirmed complete (a `flush_and_emitted!` return). A
+                        // mid-partition `NeedMore` discards `pending` and the
+                        // caller re-parses from the partition start.
+                        pending.push((table_id.clone(), partition_key.clone(), row_value, row_ts));
                     }
 
                     if offset >= data.len() {
                         // End of the buffer without an explicit END_OF_PARTITION:
                         // the partition may continue in the next chunk.
-                        return Ok(if at_final_chunk {
-                            ParseStep::Emitted(offset)
-                        } else {
-                            ParseStep::NeedMore
-                        });
+                        if at_final_chunk {
+                            return flush_and_emitted!(offset, pending, emit);
+                        }
+                        return Ok(ParseStep::NeedMore);
                     }
                     if self.peek_is_partition_header(data, offset) {
                         // Next partition starts here — current one is complete.
-                        return Ok(ParseStep::Emitted(offset));
+                        return flush_and_emitted!(offset, pending, emit);
                     }
                 }
                 Err(_) => {
@@ -1311,11 +1338,10 @@ impl V5CompressedLegacyParser {
                     // `break`s here (end-of-partition). Mid-stream that may
                     // instead be a row straddling the chunk boundary, so request
                     // more bytes unless this is the final chunk.
-                    return Ok(if at_final_chunk {
-                        ParseStep::Emitted(offset)
-                    } else {
-                        ParseStep::NeedMore
-                    });
+                    if at_final_chunk {
+                        return flush_and_emitted!(offset, pending, emit);
+                    }
+                    return Ok(ParseStep::NeedMore);
                 }
             }
         }

--- a/cqlite-core/src/storage/sstable/reader/partition_lookup.rs
+++ b/cqlite-core/src/storage/sstable/reader/partition_lookup.rs
@@ -49,6 +49,62 @@ impl SSTableReader {
         Ok(None)
     }
 
+    /// BTI ("da") partition point lookup via the in-memory Partitions.db trie
+    /// (issue #831, building on the verified #755 primitive).
+    ///
+    /// Encodes `partition_key` into the BTI byte-comparable trie key and walks the
+    /// trie to resolve the partition's location. Returns:
+    ///
+    /// - `Ok(Some(offset))` — the UNCOMPRESSED Data.db byte offset of the
+    ///   partition (`BtiPartitionLocation::DataOffset`). INVARIANT: this offset
+    ///   indexes into the DECOMPRESSED data section, never raw file bytes.
+    /// - `Ok(None)` — the reader is not BTI, or the key has no trie path (the
+    ///   partition is definitely absent from this SSTable).
+    /// - `Err(_)` — a structural trie parse error, or a `RowsOffset` result (the
+    ///   Rows.db read path is not yet implemented; narrow tables like
+    ///   `simple_table` always resolve to `DataOffset`).
+    ///
+    /// Because the BTI trie uses path compression, a returned offset may be a
+    /// candidate for a *prefix-colliding* key. The caller (`bti_point_lookup`)
+    /// MUST verify the partition-key bytes at the resolved offset equal the
+    /// queried key before returning rows.
+    pub fn lookup_partition_via_bti_trie(&self, partition_key: &[u8]) -> Result<Option<u64>> {
+        use crate::storage::sstable::bti::{
+            lookup_raw_key_in_bti_partitions_db, BtiPartitionLocation,
+        };
+
+        let Some(partitions_db) = &self.bti_partitions_db else {
+            // Not a BTI reader — no trie to consult.
+            return Ok(None);
+        };
+
+        let mut cursor = std::io::Cursor::new(partitions_db.as_slice());
+        match lookup_raw_key_in_bti_partitions_db(&mut cursor, partition_key).map_err(|e| {
+            Error::corruption(format!(
+                "BTI Partitions.db trie lookup failed for partition key (len={}): {}",
+                partition_key.len(),
+                e
+            ))
+        })? {
+            Some(BtiPartitionLocation::DataOffset(off)) => {
+                debug!(
+                    "BTI trie resolved partition (key len={}) to Data.db offset {}",
+                    partition_key.len(),
+                    off
+                );
+                Ok(Some(off))
+            }
+            Some(BtiPartitionLocation::RowsOffset(off)) => Err(Error::unsupported_format(format!(
+                "BTI Rows.db read path not yet implemented (trie returned RowsOffset({}) \
+                 for partition key len={}). Wide-partition BTI tables are out of scope for \
+                 issue #831.",
+                off,
+                partition_key.len()
+            ))),
+            None => Ok(None),
+        }
+    }
+
     /// Enhanced partition lookup using schema-driven key digest computation
     pub async fn lookup_partition_with_schema_context(
         &self,

--- a/cqlite-core/src/storage/sstable/reader/types.rs
+++ b/cqlite-core/src/storage/sstable/reader/types.rs
@@ -284,4 +284,14 @@ pub struct SSTableReader {
     /// Decision points that WILL be gated in VG3 are annotated with
     /// `// VG3: use self.version_gates.has_XXX()` comments at each call site.
     pub(crate) version_gates: Arc<VersionGates>,
+    /// Raw bytes of the sibling BTI `*-Partitions.db` trie, when this reader was
+    /// opened on a BTI ("da") SSTable (issue #831).
+    ///
+    /// `Some` for BTI SSTables (Partitions.db is tiny — a single small trie),
+    /// `None` for BIG-format SSTables. The BTI point-lookup path
+    /// (`lookup_partition_via_bti_trie` / `bti_point_lookup`) wraps these bytes in
+    /// a `std::io::Cursor` per lookup and walks the trie to resolve the
+    /// uncompressed Data.db offset for a partition key — an O(log n) point lookup
+    /// instead of the sequential scan used when no index is available.
+    pub(crate) bti_partitions_db: Option<Arc<Vec<u8>>>,
 }

--- a/cqlite-core/src/storage/sstable/writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/mod.rs
@@ -681,10 +681,31 @@ impl SSTableWriter {
     }
 
     /// Compute CRC32 checksum of a file
+    /// Compute the CRC32 digest of a finished component by streaming it through
+    /// a fixed-size buffer.
+    ///
+    /// Reads the file in 64 KiB pieces rather than slurping the whole component
+    /// into one `Vec` (`tokio::fs::read`). For a multi-GB merge output the
+    /// digest pass would otherwise allocate a buffer the size of the entire
+    /// Data.db, making end-to-end compaction peak memory scale with the output
+    /// size — defeating the bounded compaction-read work of issue #827. The
+    /// CRC32 is order-sensitive but chunk-size-agnostic, so streaming yields the
+    /// identical digest.
     async fn compute_crc32(file_path: &PathBuf) -> Result<u32> {
-        let data = tokio::fs::read(file_path).await?;
+        use tokio::io::AsyncReadExt;
+
+        const DIGEST_READ_BUFFER_BYTES: usize = 64 * 1024;
+
+        let mut file = tokio::fs::File::open(file_path).await?;
         let mut hasher = crc32fast::Hasher::new();
-        hasher.update(&data);
+        let mut buffer = vec![0u8; DIGEST_READ_BUFFER_BYTES];
+        loop {
+            let n = file.read(&mut buffer).await?;
+            if n == 0 {
+                break;
+            }
+            hasher.update(&buffer[..n]);
+        }
         Ok(hasher.finalize())
     }
 }

--- a/cqlite-core/src/storage/write_engine/merge.rs
+++ b/cqlite-core/src/storage/write_engine/merge.rs
@@ -23,24 +23,24 @@
 //! 3. Clustering key (schema-aware) - Within partition ordering
 //! 4. Run index (ascending) - Stable tiebreak for routing (NOT the LWW rule)
 //!
-//! ## Memory Budget (Groundwork — Issue #754)
+//! ## Memory Budget (Issue #754 groundwork, Issue #827 streaming read)
 //!
 //! The bounded `sync_channel` (capacity [`STREAMING_CHANNEL_CAPACITY`]) limits
 //! how many converted `MergeEntry` values from each source live in memory
 //! simultaneously between producer and consumer. The consumer/heap pulls
 //! lazily via cursors, so the channel acts as a backpressure valve.
 //!
-//! **Current limitation**: the producer thread still calls
-//! `iterate_all_partitions_for_compaction(None)`, which returns a `Vec`
-//! containing the entire parsed source SSTable (the reader's
-//! `stitch_and_parse_all_chunks_for_compaction` materialises the whole
-//! decompressed file before returning). As a result, end-to-end peak memory
-//! is NOT yet bounded independent of total input size — the decompressed
-//! content of each source is fully resident before any entries enter the
-//! channel.
-//!
-//! True end-to-end streaming (incremental stitch+parse so the producer pulls
-//! one partition at a time) is tracked in issue #827.
+//! The producer thread streams its source via
+//! [`stream_all_partitions_for_compaction`](crate::storage::sstable::reader::SSTableReader::stream_all_partitions_for_compaction),
+//! which uses a sliding-window incremental stitch+parse: it decompresses one
+//! chunk at a time, drains every fully-decoded partition out of the window, and
+//! forwards each entry through the bounded channel before pulling the next
+//! chunk. The blocking `SyncSender::send` backpressure plus the bounded window
+//! mean a source's decompressed content is NEVER fully resident — peak memory
+//! is bounded by roughly `max_partition_size + one_chunk + channel_capacity`
+//! per source, independent of total input size (issue #827). The dhat test
+//! `tests/test_issue_827_merge_streaming_memory.rs` asserts the 128 MiB bound
+//! against inputs whose total decompressed size exceeds it.
 //!
 //! ## Cell Merge Rule
 //!
@@ -459,28 +459,25 @@ where
 ///
 /// ## Design (Issue #754 — remove 128MB buffer cap residue of #447)
 ///
-/// The V5CompressedLegacy format requires full chunk stitching: ALL compressed
-/// chunks in the file must be decompressed and concatenated before the row
-/// parser can run. That is a format constraint we cannot sidestep. What we CAN
-/// do is limit how many **converted `MergeEntry` objects** from each source live
-/// in memory simultaneously between producer and consumer.
+/// The V5CompressedLegacy format requires chunk stitching: a partition may
+/// straddle compression-chunk boundaries, so the decoder needs a contiguous
+/// view spanning at least one whole partition. The reader's streaming path
+/// keeps only a **sliding window** of that view — one chunk plus the partition
+/// currently being decoded — rather than the whole decompressed file.
 ///
 /// A background thread (the producer) opens the SSTable with its own Tokio
-/// runtime, reads and parses ALL entries (the stitching phase — currently
-/// unavoidable; see issue #827), then feeds them one at a time into a bounded
+/// runtime and calls
+/// [`stream_all_partitions_for_compaction`](crate::storage::sstable::reader::SSTableReader::stream_all_partitions_for_compaction),
+/// which decompresses one chunk at a time, drains every fully-decoded partition
+/// out of the window, and forwards each entry one at a time into a bounded
 /// `sync_channel`. The channel capacity is [`STREAMING_CHANNEL_CAPACITY`]
 /// entries; once the channel is full the producer blocks until the consumer
 /// (the main merge thread) pulls the next entry.
 ///
-/// The channel therefore bounds how many *converted `MergeEntry` values* sit
-/// in-flight between producer and consumer at once. However, because the
-/// producer calls `iterate_all_partitions_for_compaction(None)` — which
-/// materialises the whole source as a `Vec` — end-to-end peak memory is NOT
-/// yet independent of total input size. The decompressed file content is fully
-/// resident before any entries enter the channel.
-///
-/// True end-to-end streaming (incremental read so the producer pulls one
-/// partition at a time) is tracked in issue #827.
+/// The bounded window plus the bounded channel together make end-to-end peak
+/// memory independent of total input size: a source's decompressed content is
+/// never fully resident. Peak is roughly `max_partition_size + one_chunk +
+/// channel_capacity` per source (issue #827).
 ///
 /// ## Issue #591 safety (mmap vs file deletion)
 ///
@@ -552,90 +549,113 @@ impl SSTableRowIteratorAdapter {
 
     /// Body of the producer thread.
     ///
-    /// Opens the SSTable with buffered I/O (Issue #591), reads all entries via
-    /// chunk stitching (materialising the full source into a `Vec` — see issue
-    /// #827 for the planned incremental-read upgrade), converts them to
-    /// [`MergeEntry`] (populating the clustering key from the decoded cells when
-    /// the schema has clustering columns), then streams them through the bounded
-    /// channel one at a time. Errors are forwarded as `Err(String)`.
+    /// Opens the SSTable with buffered I/O (Issue #591), then **streams** the
+    /// source one partition at a time via
+    /// [`stream_all_partitions_for_compaction`](crate::storage::sstable::reader::SSTableReader::stream_all_partitions_for_compaction),
+    /// converting each entry to a [`MergeEntry`] (populating the clustering key
+    /// from the decoded cells when the schema has clustering columns) and
+    /// sending it through the bounded channel immediately (issue #827). The
+    /// blocking `SyncSender::send` provides the backpressure that — together
+    /// with the reader's sliding-window stitch+parse — keeps peak memory bounded
+    /// by `max_partition_size + one_chunk + channel_capacity`, independent of
+    /// the total source size. Errors are forwarded as `Err(String)`.
     fn producer_thread(
         path_buf: PathBuf,
         run_index: usize,
         schema: TableSchema,
         sender: std::sync::mpsc::SyncSender<std::result::Result<MergeEntry, String>>,
     ) {
-        // Build the raw entries using an owned Tokio runtime (Issue #587).
+        // Drive the streaming read on an owned Tokio runtime (Issue #587): the
+        // producer owns its single-purpose runtime, so the blocking
+        // `SyncSender::send` inside the emit callback never stalls a shared
+        // runtime, and there is no nested `block_on` / `Handle::current`.
         // use_mmap = false (Issue #591): the file must not be memory-mapped
         // because finalize_merge_async may delete it after the merge completes.
-        let raw_entries_result =
-            (|| -> Result<Vec<(crate::types::RowKey, crate::types::Value, i64)>> {
-                use crate::platform::Platform;
-                use crate::Config;
-                use std::sync::Arc;
+        // Clone the sender for the error path: the streaming closure moves one
+        // clone for per-entry sends, leaving this one to report a fatal error.
+        let error_sender = sender.clone();
+        let stream_result = (|| -> Result<()> {
+            use crate::platform::Platform;
+            use crate::Config;
+            use std::sync::Arc;
 
-                let mut config = Config::default();
-                config.storage.use_mmap = false;
-                // Cloned so the async block can take it by move while the outer
-                // `schema` stays available for extract_clustering_key below.
-                let schema_for_reader = schema.clone();
+            let mut config = Config::default();
+            config.storage.use_mmap = false;
+            // Cloned so the async block can take it by move while the outer
+            // `schema` stays available for build_merge_entry below.
+            let schema_for_reader = schema.clone();
 
-                let rt = tokio::runtime::Runtime::new().map_err(|e| {
-                    Error::Storage(format!(
-                        "streaming producer: failed to create runtime: {}",
-                        e
-                    ))
-                })?;
-
-                rt.block_on(async move {
-                    let platform = Arc::new(Platform::new(&config).await?);
-                    let reader = crate::storage::sstable::reader::SSTableReader::open(
-                        &path_buf, &config, platform,
-                    )
-                    .await?;
-                    // Pass the schema so the parser uses the real clustering column
-                    // names; the header-inferred fallback uses generic names like
-                    // "clustering_key", which would defeat extract_clustering_key.
-                    reader
-                        .iterate_all_partitions_for_compaction(Some(&schema_for_reader))
-                        .await
-                })
-            })();
-
-        let raw_entries = match raw_entries_result {
-            Ok(entries) => entries,
-            Err(e) => {
-                // Forward the error; ignore send failure (consumer may have dropped).
-                let _ = sender.send(Err(e.to_string()));
-                return;
-            }
-        };
-
-        // Stream entries through the bounded channel one at a time.
-        for (row_key, value, timestamp) in raw_entries {
-            let entry_result = (|| -> Result<MergeEntry> {
-                let key_bytes = row_key.0;
-                let decorated_key = DecoratedKey::from_key_bytes(key_bytes)?;
-                let row_data = Self::value_to_row_data(&value, timestamp)?;
-                // Populate the clustering key from the decoded cells so wide-row
-                // (clustering) partitions reconcile per (pk, ck) instead of
-                // collapsing into one row.
-                let clustering_key = Self::extract_clustering_key(&row_data, &schema);
-                Ok(MergeEntry::new(
-                    run_index,
-                    decorated_key,
-                    clustering_key,
-                    timestamp,
-                    row_data,
+            let rt = tokio::runtime::Runtime::new().map_err(|e| {
+                Error::Storage(format!(
+                    "streaming producer: failed to create runtime: {}",
+                    e
                 ))
-            })();
+            })?;
 
-            let msg = entry_result.map_err(|e| e.to_string());
-            // If the receiver has been dropped (e.g. merge aborted), stop.
-            if sender.send(msg).is_err() {
-                return;
-            }
+            rt.block_on(async move {
+                let platform = Arc::new(Platform::new(&config).await?);
+                let reader = crate::storage::sstable::reader::SSTableReader::open(
+                    &path_buf, &config, platform,
+                )
+                .await?;
+
+                // Pass the schema so the parser uses the real clustering column
+                // names; the header-inferred fallback uses generic names like
+                // "clustering_key", which would defeat extract_clustering_key.
+                //
+                // The emit callback converts and forwards one entry at a time.
+                // A blocking `send` applies backpressure; an `Err` from `send`
+                // means the consumer was dropped → stop the scan (Break).
+                reader
+                    .stream_all_partitions_for_compaction(
+                        Some(&schema_for_reader),
+                        |row_key, value, timestamp| {
+                            let msg = Self::build_merge_entry(
+                                run_index, row_key, value, timestamp, &schema,
+                            )
+                            .map_err(|e| e.to_string());
+                            match sender.send(msg) {
+                                Ok(()) => Ok(std::ops::ControlFlow::Continue(())),
+                                Err(_) => Ok(std::ops::ControlFlow::Break(())),
+                            }
+                        },
+                    )
+                    .await
+            })
+        })();
+
+        if let Err(e) = stream_result {
+            // Forward the error; ignore send failure (consumer may have dropped).
+            let _ = error_sender.send(Err(e.to_string()));
         }
         // Channel closed naturally when sender is dropped here.
+    }
+
+    /// Convert one streamed `(RowKey, Value, timestamp)` source entry into a
+    /// [`MergeEntry`] for run `run_index` (issue #827).
+    ///
+    /// Factored out of the producer loop so the streaming emit callback can call
+    /// it inline. Populates the clustering key from the decoded cells so wide-row
+    /// (clustering) partitions reconcile per `(pk, ck)` instead of collapsing
+    /// into one row.
+    fn build_merge_entry(
+        run_index: usize,
+        row_key: crate::types::RowKey,
+        value: crate::types::Value,
+        timestamp: i64,
+        schema: &TableSchema,
+    ) -> Result<MergeEntry> {
+        let key_bytes = row_key.0;
+        let decorated_key = DecoratedKey::from_key_bytes(key_bytes)?;
+        let row_data = Self::value_to_row_data(&value, timestamp)?;
+        let clustering_key = Self::extract_clustering_key(&row_data, schema);
+        Ok(MergeEntry::new(
+            run_index,
+            decorated_key,
+            clustering_key,
+            timestamp,
+            row_data,
+        ))
     }
 
     /// Extract a `ClusteringKey` from the row's live cells using the schema.
@@ -3541,11 +3561,11 @@ mod merge_property_tests {
 // is preserved, and the channel provides backpressure between producer and
 // consumer.
 //
-// NOTE: these tests do NOT prove an end-to-end memory bound independent of
-// total input size. The real SSTableRowIteratorAdapter producer still
-// materialises each source as a full Vec (via
-// iterate_all_partitions_for_compaction). True incremental streaming is
-// tracked in issue #827.
+// NOTE: these tests verify the channel/cursor mechanism in isolation; they do
+// NOT themselves prove the end-to-end memory bound. The end-to-end bound — the
+// real producer streaming its source via stream_all_partitions_for_compaction
+// (issue #827) — is asserted by the dhat test
+// tests/test_issue_827_merge_streaming_memory.rs.
 
 #[cfg(all(test, feature = "write-support"))]
 mod streaming_tests {
@@ -3554,11 +3574,11 @@ mod streaming_tests {
     /// Channel capacity constant is accessible and matches documented value.
     ///
     /// This test checks only the constant's value — it does NOT prove an
-    /// end-to-end memory bound. The real producer still materialises each
-    /// source as a full Vec; the bound on in-flight MergeEntry objects between
-    /// producer and consumer is STREAMING_CHANNEL_CAPACITY, but the backing
-    /// file data is fully resident before any entries enter the channel.
-    /// See issue #827 for the planned fix.
+    /// end-to-end memory bound. The bound on in-flight MergeEntry objects
+    /// between producer and consumer is STREAMING_CHANNEL_CAPACITY; the
+    /// end-to-end memory bound (the producer streaming its source one partition
+    /// at a time, issue #827) is asserted by the dhat test
+    /// tests/test_issue_827_merge_streaming_memory.rs.
     #[test]
     fn test_streaming_channel_capacity_constant() {
         // The constant must be large enough to amortise scheduling overhead but
@@ -3617,10 +3637,10 @@ mod streaming_tests {
     /// per source (≤ 8 total) while the test runs, demonstrating correct
     /// ordering and completeness through a small-capacity channel.
     ///
-    /// NOTE: this test does NOT prove an end-to-end memory bound for the real
-    /// SSTableRowIteratorAdapter, whose producer still materialises the full
-    /// source Vec before sending entries. End-to-end streaming is tracked in
-    /// issue #827.
+    /// NOTE: this test exercises the synthetic streaming-iterator path only; the
+    /// end-to-end memory bound for the real SSTableRowIteratorAdapter (whose
+    /// producer streams its source one partition at a time, issue #827) is
+    /// asserted by the dhat test tests/test_issue_827_merge_streaming_memory.rs.
     #[test]
     fn test_kway_merge_with_streaming_sources_preserves_order() {
         use crate::schema::{KeyColumn, TableSchema};

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -1581,9 +1581,10 @@ impl WriteEngine {
         // NOT return an error — the merge output is correct.
         //
         // Issue #591 (write-while-mapped / Windows policy): the inputs were read
-        // through buffered I/O and fully drained into memory by `KWayMerger::new`
-        // before this point, so the merger holds no mapping over them — deleting
-        // them cannot fault with SIGBUS. `delete_sstable_files` removes each
+        // through buffered I/O (never memory-mapped) and the merge has fully
+        // drained every source through its streaming producer by this point
+        // (issue #827), so the merger holds no mapping over them — deleting them
+        // cannot fault with SIGBUS. `delete_sstable_files` removes each
         // input's TOC.txt first (unpublishing it) and is best-effort on the data
         // components, so a component still pinned by a concurrent mapped reader on
         // Windows becomes an invisible orphan reclaimed on the next startup rather

--- a/cqlite-core/tests/issue_657_da_foundation.rs
+++ b/cqlite-core/tests/issue_657_da_foundation.rs
@@ -256,8 +256,13 @@ mod da_directory_discovery {
         );
     }
 
-    /// All three da tables (simple_table, collection_table, ttl_table) must be
-    /// discoverable from the `test_da` keyspace directory.
+    /// The three foundational da tables (simple_table, collection_table,
+    /// ttl_table) must be discoverable from the `test_da` keyspace directory.
+    ///
+    /// NOTE (issue #832): the `test_da` keyspace also carries a `wide_table`
+    /// fixture used by the BTI row-index traversal tests, so the directory count
+    /// is now >= 3 rather than exactly 3.  This test pins the *required* tables'
+    /// presence, not an exact directory count.
     #[test]
     fn da_keyspace_discovers_three_tables() {
         let datasets_root = match std::env::var("CQLITE_DATASETS_ROOT") {
@@ -286,11 +291,10 @@ mod da_directory_discovery {
             .filter(|e| e.path().is_dir())
             .collect();
 
-        assert_eq!(
-            table_dirs.len(),
-            3,
-            "test_da keyspace must have exactly 3 table directories: \
-             simple_table, collection_table, ttl_table. Found: {:?}",
+        assert!(
+            table_dirs.len() >= 3,
+            "test_da keyspace must have at least the 3 foundational table \
+             directories (simple_table, collection_table, ttl_table). Found: {:?}",
             table_dirs.iter().map(|e| e.file_name()).collect::<Vec<_>>()
         );
 

--- a/cqlite-core/tests/issue_657_da_foundation.rs
+++ b/cqlite-core/tests/issue_657_da_foundation.rs
@@ -344,7 +344,7 @@ mod da_directory_discovery {
 }
 
 #[cfg(test)]
-mod da_reader_graceful_rejection {
+mod da_reader_open {
     use cqlite_core::{storage::sstable::reader::SSTableReader, Config, Error};
     use std::sync::Arc;
 
@@ -373,12 +373,12 @@ mod da_reader_graceful_rejection {
             .map(|e| e.path())
     }
 
-    /// Opening a da Data.db with `SSTableReader::open` must return
-    /// `Error::UnsupportedFormat` — not a panic, and not a confusing parse error.
-    ///
-    /// The error message must mention "BTI (da)" so callers can act on it.
+    /// Issue #831: opening a da Data.db with `SSTableReader::open` now SUCCEEDS
+    /// when the sibling `*-Partitions.db` trie is present. The reader wires the
+    /// BTI trie point-lookup primitive (#755) into its open + get path, so the
+    /// pre-#831 `Error::UnsupportedFormat` gate is gone.
     #[tokio::test]
-    async fn da_reader_open_returns_unsupported_format_error() {
+    async fn da_reader_open_succeeds_with_partitions_db() {
         let Some(data_db) = da_data_db_path() else {
             eprintln!(
                 "SKIP: CQLITE_DATASETS_ROOT not set or da Data.db not found; \
@@ -397,44 +397,51 @@ mod da_reader_graceful_rejection {
         let result = SSTableReader::open(&data_db, &config, platform).await;
 
         assert!(
-            result.is_err(),
-            "SSTableReader::open on a da Data.db must return an error"
-        );
-
-        let err = result.unwrap_err();
-
-        // Must be UnsupportedFormat — not Corruption or Parse or Internal.
-        assert!(
-            matches!(err, Error::UnsupportedFormat(_)),
-            "Error must be UnsupportedFormat, got: {:?}",
-            err
-        );
-
-        let msg = err.to_string();
-        assert!(
-            msg.contains("BTI (da)"),
-            "Error message must contain 'BTI (da)' for actionable diagnosis. Got: {msg}"
-        );
-        assert!(
-            msg.contains("not yet implemented"),
-            "Error message must say 'not yet implemented'. Got: {msg}"
-        );
-
-        // The error must not be recoverable (it's a format limitation, not a transient I/O issue).
-        assert!(
-            !err.is_recoverable(),
-            "UnsupportedFormat error must not be recoverable"
+            result.is_ok(),
+            "SSTableReader::open on a da Data.db (with Partitions.db present) must \
+             now succeed (#831), got error: {:?}",
+            result.err()
         );
     }
 
-    /// Verify the error message includes a pointer to the scoping document.
+    /// Issue #831 negative variant: opening a BTI Data.db whose sibling
+    /// `*-Partitions.db` trie is ABSENT must still fail with a clear, actionable
+    /// `UnsupportedFormat` error (the trie is required for partition lookup).
+    ///
+    /// We copy just the Data.db (and the CompressionInfo/Statistics it needs to
+    /// parse a header) into a temp dir WITHOUT Partitions.db, then assert open
+    /// errors.
     #[tokio::test]
-    async fn da_reader_error_mentions_scoping_doc() {
+    async fn da_reader_open_errors_when_partitions_db_absent() {
         let Some(data_db) = da_data_db_path() else {
             eprintln!("SKIP: CQLITE_DATASETS_ROOT not set or da Data.db not found");
             return;
         };
+        let src_dir = data_db.parent().expect("Data.db has a parent dir");
+        let data_name = data_db
+            .file_name()
+            .and_then(|n| n.to_str())
+            .expect("Data.db file name");
 
+        // Stage a copy of the SSTable WITHOUT Partitions.db.
+        let tmp = std::env::temp_dir().join(format!(
+            "cqlite-issue831-no-partitions-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+
+        for entry in std::fs::read_dir(src_dir).expect("read src dir").flatten() {
+            let name = entry.file_name();
+            let s = name.to_string_lossy();
+            // Skip Partitions.db (the file under test) and the JSONL/txt sidecars.
+            if s.ends_with("-Partitions.db") || s.ends_with(".jsonl") || s.ends_with(".txt") {
+                continue;
+            }
+            std::fs::copy(entry.path(), tmp.join(&name)).expect("copy component");
+        }
+
+        let staged_data = tmp.join(data_name);
         let config = Config::default();
         let platform = Arc::new(
             cqlite_core::platform::Platform::new(&config)
@@ -442,13 +449,19 @@ mod da_reader_graceful_rejection {
                 .expect("Platform::new must succeed"),
         );
 
-        let result = SSTableReader::open(&data_db, &config, platform).await;
-        let err = result.expect_err("Must return an error for da Data.db");
-        let msg = err.to_string();
+        let result = SSTableReader::open(&staged_data, &config, platform).await;
+        let _ = std::fs::remove_dir_all(&tmp);
 
+        let err = result.expect_err("open must error when Partitions.db is absent");
         assert!(
-            msg.contains("bti-read-support-scoping"),
-            "Error message must reference 'bti-read-support-scoping' doc. Got: {msg}"
+            matches!(err, Error::UnsupportedFormat(_)),
+            "Error must be UnsupportedFormat, got: {:?}",
+            err
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Partitions.db"),
+            "Error message must mention the missing Partitions.db. Got: {msg}"
         );
     }
 }

--- a/cqlite-core/tests/issue_755_bti_trie_point_lookup.rs
+++ b/cqlite-core/tests/issue_755_bti_trie_point_lookup.rs
@@ -24,12 +24,12 @@
 //! 7. Assert the UUID bytes match the partition key we originally looked up
 //!    (proves trie resolved the right offset, not a lucky scan result).
 //!
-//! # Architecture constraint
+//! # Architecture note
 //!
-//! `SSTableReader::open` still returns `Error::UnsupportedFormat` for BTI Data.db
-//! (the `issue_657_da_foundation.rs` test asserts this; that gate is intentional).
-//! This test bypasses the high-level reader and calls the lower-level trie and
-//! compression APIs directly — the same path a future BTI-aware reader would use.
+//! This test exercises the low-level trie + compression primitives directly.
+//! As of issue #831, `SSTableReader::open` now SUCCEEDS for BTI Data.db and wires
+//! these same primitives into the public open + get path (see
+//! `issue_831_bti_reader_point_lookup.rs` for the end-to-end reader test).
 //!
 //! # Test data requirement
 //!
@@ -365,17 +365,14 @@ fn bti_trie_offset_points_to_correct_uuid_in_data_db() {
 }
 
 // ---------------------------------------------------------------------------
-// Regression guard: SSTableReader::open on BTI Data.db still returns
-// UnsupportedFormat (issue_657_da_foundation.rs contract must not break)
+// Issue #831: SSTableReader::open now SUCCEEDS for BTI Data.db (the pre-#831
+// UnsupportedFormat gate has been lifted). The end-to-end reader assertions
+// live in issue_831_bti_reader_point_lookup.rs; this is a light guard that the
+// gate is gone.
 // ---------------------------------------------------------------------------
 
-/// Verify that the BTI gate in SSTableReader::open is still in effect.
-///
-/// This is a redundant guard — `issue_657_da_foundation.rs` is the canonical
-/// home of this assertion — but having it here makes the #755 test file
-/// self-contained and prevents accidental removal of the gate.
 #[tokio::test]
-async fn bti_sstable_reader_open_still_returns_unsupported_format() {
+async fn bti_sstable_reader_open_now_succeeds() {
     let Some(dir) = da_simple_table_dir() else {
         eprintln!("SKIP: test_da/simple_table binary SSTables not available");
         return;
@@ -389,7 +386,7 @@ async fn bti_sstable_reader_open_still_returns_unsupported_format() {
         }
     };
 
-    use cqlite_core::{storage::sstable::reader::SSTableReader, Config, Error};
+    use cqlite_core::{storage::sstable::reader::SSTableReader, Config};
     use std::sync::Arc;
 
     let config = Config::default();
@@ -401,25 +398,10 @@ async fn bti_sstable_reader_open_still_returns_unsupported_format() {
 
     let result = SSTableReader::open(&data_db, &config, platform).await;
     assert!(
-        result.is_err(),
-        "SSTableReader::open on BTI Data.db must still return an error"
+        result.is_ok(),
+        "SSTableReader::open on BTI Data.db must now succeed (#831), got: {:?}",
+        result.err()
     );
 
-    let err = result.unwrap_err();
-    assert!(
-        matches!(err, Error::UnsupportedFormat(_)),
-        "Error must be UnsupportedFormat, got: {:?}",
-        err
-    );
-
-    let msg = err.to_string();
-    assert!(
-        msg.contains("BTI (da)"),
-        "Error message must contain 'BTI (da)'. Got: {msg}"
-    );
-
-    eprintln!(
-        "bti_sstable_reader_open_still_returns_unsupported_format PASSED: \
-         SSTableReader::open gate is intact"
-    );
+    eprintln!("bti_sstable_reader_open_now_succeeds PASSED: BTI open gate lifted");
 }

--- a/cqlite-core/tests/issue_831_bti_reader_point_lookup.rs
+++ b/cqlite-core/tests/issue_831_bti_reader_point_lookup.rs
@@ -240,6 +240,60 @@ async fn bti_reader_get_returns_row_for_known_key() {
 }
 
 // ---------------------------------------------------------------------------
+// Test 3b: chunk-targeted decompress lands on the correct chunk (issue #831
+// perf finding) — the lookup decompresses only the chunk containing the trie
+// offset, not the whole section. For this single-chunk fixture every golden
+// offset (0/63/125) maps to target_chunk 0, and get() must still return the
+// identical golden rows (proving the chunk-targeted branch produced correct
+// output rather than falling back to the whole-section stitch).
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn bti_reader_get_uses_chunk_targeted_decompress() {
+    let Some(data_db) = da_data_db_path() else {
+        eprintln!("SKIP: test_da/simple_table BTI fixture not available");
+        return;
+    };
+    let reader = open_reader(&data_db).await;
+    let table_id = TableId::from(TABLE_ID);
+
+    // The fixture is chunk-compressed: CompressionInfo must be present, and the
+    // chunk-targeting math must place every golden offset in chunk 0.
+    let comp = reader
+        .compression_info
+        .as_ref()
+        .expect("BTI fixture is chunk-compressed (CompressionInfo.db present)");
+    let chunk_length = comp.chunk_length as u64;
+    assert!(chunk_length > 0, "chunk_length must be non-zero");
+
+    for p in TEST_PARTITIONS {
+        let target_chunk = (p.expected_offset / chunk_length) as usize;
+        assert_eq!(
+            target_chunk, 0,
+            "offset {} (chunk_length {}) must target chunk 0 for this fixture",
+            p.expected_offset, chunk_length
+        );
+
+        // And get() through the chunk-targeted path still returns the golden row.
+        let raw: [u8; 16] = [p.uuid_byte; 16];
+        let key = RowKey::new(raw.to_vec());
+        let value = reader
+            .get(&table_id, &key)
+            .await
+            .unwrap_or_else(|e| panic!("get() for UUID {} errored: {}", p.label, e))
+            .unwrap_or_else(|| panic!("get() for UUID {} returned None", p.label));
+        match cell(&value, "name") {
+            Some(Value::Text(s)) => assert_eq!(s, p.name, "UUID {} name mismatch", p.label),
+            other => panic!("UUID {} missing/!text name cell: {:?}", p.label, other),
+        }
+    }
+    eprintln!(
+        "bti_reader_get_uses_chunk_targeted_decompress PASSED: target_chunk=0 for all golden \
+         offsets and rows match"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Test 4: missing key returns None
 // ---------------------------------------------------------------------------
 

--- a/cqlite-core/tests/issue_831_bti_reader_point_lookup.rs
+++ b/cqlite-core/tests/issue_831_bti_reader_point_lookup.rs
@@ -1,0 +1,293 @@
+//! End-to-end integration test for Issue #831: wire the BTI trie point-lookup
+//! primitive (verified in #755) into `SSTableReader`'s public open + get path.
+//!
+//! # What this proves
+//!
+//! 1. `SSTableReader::open` now SUCCEEDS for a BTI ("da") Data.db when the
+//!    sibling `*-Partitions.db` trie is present (the #657 gate is lifted).
+//! 2. A partition-key lookup resolves via the BTI trie (O(log n)) — returning
+//!    the exact golden Data.db offsets (0/63/125) — instead of a sequential
+//!    scan.
+//! 3. `reader.get(table_id, raw_uuid)` returns the decoded row for each known
+//!    key, with column values matching the `da-2-bti-Data.db.jsonl` golden.
+//! 4. A missing key returns `Ok(None)` without consulting the sequential scan.
+//!
+//! # Test data requirement
+//!
+//! `CQLITE_DATASETS_ROOT` must point to `test-data/datasets` and the `test_da`
+//! binary SSTables must be present. Tests skip gracefully when absent:
+//!
+//! ```bash
+//! CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test --test issue_831_bti_reader_point_lookup
+//! ```
+
+use cqlite_core::{storage::sstable::reader::SSTableReader, types::TableId, Config, RowKey, Value};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+// ---------------------------------------------------------------------------
+// Golden constants (same fixture / offsets as issue_755_bti_trie_point_lookup.rs)
+// ---------------------------------------------------------------------------
+
+struct Partition {
+    /// Raw 16-byte UUID (all bytes identical for these test UUIDs)
+    uuid_byte: u8,
+    /// Expected Data.db uncompressed byte offset (from JSONL golden "position")
+    expected_offset: u64,
+    /// Canonical display UUID string (diagnostics)
+    label: &'static str,
+    /// Golden cell values (from da-2-bti-Data.db.jsonl).
+    /// `age` is CQL INT (Value::Integer), `salary` is CQL BIGINT (Value::BigInt).
+    name: &'static str,
+    age: i32,
+    salary: i64,
+    active: bool,
+}
+
+const TEST_PARTITIONS: &[Partition] = &[
+    Partition {
+        uuid_byte: 0x22,
+        expected_offset: 0,
+        label: "22222222-2222-2222-2222-222222222222",
+        name: "Bob Johnson",
+        age: 45,
+        salary: 95000,
+        active: false,
+    },
+    Partition {
+        uuid_byte: 0x11,
+        expected_offset: 63,
+        label: "11111111-1111-1111-1111-111111111111",
+        name: "Alice Smith",
+        age: 30,
+        salary: 75000,
+        active: true,
+    },
+    Partition {
+        uuid_byte: 0x33,
+        expected_offset: 125,
+        label: "33333333-3333-3333-3333-333333333333",
+        name: "Carol Williams",
+        age: 28,
+        salary: 65000,
+        active: true,
+    },
+];
+
+const TABLE_ID: &str = "test_da.simple_table";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Locate the `da-*-bti-Data.db` for `test_da/simple_table`, or `None` if the
+/// binary fixture (with the Partitions.db trie) is absent.
+fn da_data_db_path() -> Option<PathBuf> {
+    let root = std::env::var("CQLITE_DATASETS_ROOT").ok()?;
+    let base = PathBuf::from(root).join("sstables").join("test_da");
+
+    let table_dir = std::fs::read_dir(&base)
+        .ok()?
+        .flatten()
+        .find(|e| e.file_name().to_string_lossy().starts_with("simple_table-"))
+        .map(|e| e.path())?;
+
+    // Both Data.db AND Partitions.db must be present for the lookup path.
+    let has_partitions = std::fs::read_dir(&table_dir).ok()?.flatten().any(|e| {
+        let n = e.file_name();
+        let s = n.to_string_lossy();
+        s.starts_with("da-") && s.ends_with("-bti-Partitions.db")
+    });
+    if !has_partitions {
+        eprintln!("SKIP: da-*-bti-Partitions.db not present; run fetch-datasets.sh");
+        return None;
+    }
+
+    std::fs::read_dir(&table_dir).ok()?.flatten().find_map(|e| {
+        let n = e.file_name();
+        let s = n.to_string_lossy();
+        if s.starts_with("da-") && s.ends_with("-bti-Data.db") {
+            Some(e.path())
+        } else {
+            None
+        }
+    })
+}
+
+async fn open_reader(data_db: &Path) -> SSTableReader {
+    let config = Config::default();
+    let platform = Arc::new(
+        cqlite_core::platform::Platform::new(&config)
+            .await
+            .expect("Platform::new"),
+    );
+    SSTableReader::open(data_db, &config, platform)
+        .await
+        .expect("SSTableReader::open must succeed for BTI Data.db with Partitions.db present")
+}
+
+/// Extract a named cell value from the `Value::Map` a BTI partition row decodes to.
+fn cell<'a>(value: &'a Value, name: &str) -> Option<&'a Value> {
+    if let Value::Map(entries) = value {
+        for (k, v) in entries {
+            if let Value::Text(s) = k {
+                if s == name {
+                    return Some(v);
+                }
+            }
+        }
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: open succeeds for BTI when Partitions.db present
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn bti_reader_open_succeeds() {
+    let Some(data_db) = da_data_db_path() else {
+        eprintln!("SKIP: test_da/simple_table BTI fixture not available");
+        return;
+    };
+    let _reader = open_reader(&data_db).await;
+    eprintln!("bti_reader_open_succeeds PASSED: SSTableReader::open returned Ok for BTI Data.db");
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: trie resolves the golden offsets (proves trie use, not scan)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn bti_reader_point_lookup_resolves_golden_offset() {
+    let Some(data_db) = da_data_db_path() else {
+        eprintln!("SKIP: test_da/simple_table BTI fixture not available");
+        return;
+    };
+    let reader = open_reader(&data_db).await;
+
+    for p in TEST_PARTITIONS {
+        let raw: [u8; 16] = [p.uuid_byte; 16];
+        let resolved = reader
+            .lookup_partition_via_bti_trie(&raw)
+            .expect("trie lookup must not error");
+        assert_eq!(
+            resolved,
+            Some(p.expected_offset),
+            "UUID {} expected trie-resolved DataOffset {}",
+            p.label,
+            p.expected_offset
+        );
+    }
+    eprintln!(
+        "bti_reader_point_lookup_resolves_golden_offset PASSED: trie returned offsets 0/63/125"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: get() returns the decoded row for each known key
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn bti_reader_get_returns_row_for_known_key() {
+    let Some(data_db) = da_data_db_path() else {
+        eprintln!("SKIP: test_da/simple_table BTI fixture not available");
+        return;
+    };
+    let reader = open_reader(&data_db).await;
+    let table_id = TableId::from(TABLE_ID);
+
+    for p in TEST_PARTITIONS {
+        let raw: [u8; 16] = [p.uuid_byte; 16];
+        let key = RowKey::new(raw.to_vec());
+
+        let result = reader
+            .get(&table_id, &key)
+            .await
+            .unwrap_or_else(|e| panic!("get() for UUID {} errored: {}", p.label, e));
+
+        let value = result
+            .unwrap_or_else(|| panic!("get() for UUID {} returned None (expected a row)", p.label));
+
+        // name (Text)
+        match cell(&value, "name") {
+            Some(Value::Text(s)) => assert_eq!(s, p.name, "UUID {} name mismatch", p.label),
+            other => panic!("UUID {} missing/!text name cell: {:?}", p.label, other),
+        }
+        // age (Int)
+        match cell(&value, "age") {
+            Some(Value::Integer(n)) => assert_eq!(*n, p.age, "UUID {} age mismatch", p.label),
+            other => panic!("UUID {} missing/!int age cell: {:?}", p.label, other),
+        }
+        // salary (BigInt)
+        match cell(&value, "salary") {
+            Some(Value::BigInt(n)) => {
+                assert_eq!(*n, p.salary, "UUID {} salary mismatch", p.label)
+            }
+            other => panic!("UUID {} missing/!bigint salary cell: {:?}", p.label, other),
+        }
+        // active (Boolean)
+        match cell(&value, "active") {
+            Some(Value::Boolean(b)) => {
+                assert_eq!(*b, p.active, "UUID {} active mismatch", p.label)
+            }
+            other => panic!("UUID {} missing/!bool active cell: {:?}", p.label, other),
+        }
+    }
+    eprintln!(
+        "bti_reader_get_returns_row_for_known_key PASSED: decoded rows match the JSONL golden"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: missing key returns None
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn bti_reader_get_missing_key_returns_none() {
+    let Some(data_db) = da_data_db_path() else {
+        eprintln!("SKIP: test_da/simple_table BTI fixture not available");
+        return;
+    };
+    let reader = open_reader(&data_db).await;
+    let table_id = TableId::from(TABLE_ID);
+
+    let missing = RowKey::new(vec![0x00u8; 16]);
+    let result = reader
+        .get(&table_id, &missing)
+        .await
+        .expect("get() for missing key must not error");
+    assert!(
+        result.is_none(),
+        "get() for a UUID not in the fixture must return None, got {:?}",
+        result
+    );
+    eprintln!("bti_reader_get_missing_key_returns_none PASSED");
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: no sequential scan is consulted on a BTI get()
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn bti_reader_get_does_not_sequential_scan() {
+    let Some(data_db) = da_data_db_path() else {
+        eprintln!("SKIP: test_da/simple_table BTI fixture not available");
+        return;
+    };
+    let reader = open_reader(&data_db).await;
+    let table_id = TableId::from(TABLE_ID);
+
+    let before = SSTableReader::scan_for_key_call_count();
+    let raw: [u8; 16] = [0x22; 16];
+    let key = RowKey::new(raw.to_vec());
+    let _ = reader.get(&table_id, &key).await.expect("get() ok");
+    let after = SSTableReader::scan_for_key_call_count();
+
+    assert_eq!(
+        before, after,
+        "BTI get() must not invoke scan_for_key (sequential scan), count went {} -> {}",
+        before, after
+    );
+    eprintln!("bti_reader_get_does_not_sequential_scan PASSED: scan_for_key never called");
+}

--- a/cqlite-core/tests/issue_831_bti_reader_point_lookup.rs
+++ b/cqlite-core/tests/issue_831_bti_reader_point_lookup.rs
@@ -240,6 +240,48 @@ async fn bti_reader_get_returns_row_for_known_key() {
 }
 
 // ---------------------------------------------------------------------------
+// Test 3a: a fully-qualified WRONG-KEYSPACE query must NOT return a row, even
+// though the table name matches (issue #831 review: the BTI guard must compare
+// keyspace.table exactly, not just the unqualified table name).
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn bti_reader_get_wrong_keyspace_returns_none() {
+    let Some(data_db) = da_data_db_path() else {
+        eprintln!("SKIP: test_da/simple_table BTI fixture not available");
+        return;
+    };
+    let reader = open_reader(&data_db).await;
+
+    // Same table name, different keyspace — both fully qualified.
+    let wrong_ks = TableId::from("other_keyspace.simple_table");
+    // A key that DOES exist in this SSTable under the correct keyspace.
+    let existing_key = RowKey::new([TEST_PARTITIONS[0].uuid_byte; 16].to_vec());
+
+    let result = reader
+        .get(&wrong_ks, &existing_key)
+        .await
+        .expect("get() with a wrong-keyspace table id must not error");
+    assert!(
+        result.is_none(),
+        "BTI point lookup returned a row for a wrong-keyspace query \
+         (other_keyspace.simple_table); the keyspace-aware guard must reject it"
+    );
+
+    // Sanity: the same key under the CORRECT qualified id still resolves.
+    let right_ks = TableId::from(TABLE_ID);
+    let ok = reader
+        .get(&right_ks, &existing_key)
+        .await
+        .expect("get() with the correct table id must not error");
+    assert!(
+        ok.is_some(),
+        "control: correct keyspace.table must still return the row"
+    );
+    eprintln!("bti_reader_get_wrong_keyspace_returns_none PASSED");
+}
+
+// ---------------------------------------------------------------------------
 // Test 3b: chunk-targeted decompress lands on the correct chunk (issue #831
 // perf finding) — the lookup decompresses only the chunk containing the trie
 // offset, not the whole section. For this single-chunk fixture every golden

--- a/cqlite-core/tests/issue_832_bti_traversal.rs
+++ b/cqlite-core/tests/issue_832_bti_traversal.rs
@@ -1,0 +1,158 @@
+//! Fixture-backed integration tests for Issue #832: BTI full trie traversal.
+//!
+//! These exercise the new headerless, footer-based traversal entry points
+//! against the real `test_da` BTI fixtures:
+//!
+//!   - `iterate_partitions_in_bti_file` — full Partitions.db DFS.
+//!   - `iterate_rows_in_bti_file`       — full Rows.db DFS.
+//!
+//! The reconstructed keys are byte-comparable token prefixes (not original
+//! partition keys), so assertions target the definitive payload OFFSETS, which
+//! match the `position` fields in the sstabledump JSONL goldens.
+//!
+//! All tests are guarded by `CQLITE_DATASETS_ROOT` and skip (return early) when
+//! the binary fixtures are absent, so they never block CI that runs without
+//! test data.
+
+use cqlite_core::storage::sstable::bti::{
+    iterate_partitions_in_bti_file, iterate_rows_in_bti_file, BtiPartitionLocation,
+};
+use std::io::Cursor;
+use std::path::{Path, PathBuf};
+
+/// Resolve the datasets root, skipping the test if it is not configured.
+fn datasets_root() -> Option<PathBuf> {
+    match std::env::var("CQLITE_DATASETS_ROOT") {
+        Ok(v) => Some(PathBuf::from(v)),
+        Err(_) => {
+            eprintln!("SKIP: CQLITE_DATASETS_ROOT not set; needs real BTI fixtures");
+            None
+        }
+    }
+}
+
+/// Load a BTI component file into a Cursor, skipping the test if absent.
+fn load_component(root: &Path, rel: &str) -> Option<Cursor<Vec<u8>>> {
+    let path = root.join(rel);
+    if !path.exists() {
+        eprintln!("SKIP: BTI fixture not found at {:?}", path);
+        return None;
+    }
+    match std::fs::read(&path) {
+        Ok(bytes) => Some(Cursor::new(bytes)),
+        Err(e) => {
+            eprintln!("SKIP: cannot read {:?}: {}", path, e);
+            None
+        }
+    }
+}
+
+/// (6) PartitionIterator over real `test_da/simple_table` Partitions.db
+/// (79 bytes, root offset 17) yields exactly 3 entries with DataOffset
+/// [0, 63, 125] in byte-comparable order — matching the JSONL goldens via the
+/// transition chain root(17)→Sparse8→{0x90,0xBC,0xF9}→{0,63,125}.
+#[test]
+fn partition_iterator_real_simple_table_three_entries() {
+    let Some(root) = datasets_root() else {
+        return;
+    };
+    let Some(mut cursor) = load_component(
+        &root,
+        "sstables/test_da/simple_table-de1be8b064e711f19ad401a8c8227b11/da-2-bti-Partitions.db",
+    ) else {
+        return;
+    };
+
+    let entries = iterate_partitions_in_bti_file(&mut cursor)
+        .expect("full Partitions.db traversal must succeed");
+
+    let offsets: Vec<u64> = entries
+        .iter()
+        .map(|(_, loc)| match loc {
+            BtiPartitionLocation::DataOffset(o) => *o,
+            BtiPartitionLocation::RowsOffset(o) => *o,
+        })
+        .collect();
+
+    assert_eq!(
+        entries.len(),
+        3,
+        "simple_table has exactly 3 partitions; got {}: {:?}",
+        entries.len(),
+        entries
+    );
+    assert_eq!(
+        offsets,
+        vec![0, 63, 125],
+        "DFS must yield DataOffsets in byte-comparable order [0, 63, 125]"
+    );
+    for (_, loc) in &entries {
+        assert!(
+            matches!(loc, BtiPartitionLocation::DataOffset(_)),
+            "narrow partitions must resolve to DataOffset, got {:?}",
+            loc
+        );
+    }
+}
+
+/// (7) PartitionIterator over real `test_da/collection_table` Partitions.db
+/// (74 bytes, root 12) yields exactly 2 entries with DataOffset [0, 107].
+#[test]
+fn partition_iterator_real_collection_table_two_entries() {
+    let Some(root) = datasets_root() else {
+        return;
+    };
+    let Some(mut cursor) = load_component(
+        &root,
+        "sstables/test_da/collection_table-de2c155064e711f19ad401a8c8227b11/da-2-bti-Partitions.db",
+    ) else {
+        return;
+    };
+
+    let entries = iterate_partitions_in_bti_file(&mut cursor)
+        .expect("full Partitions.db traversal must succeed");
+
+    let offsets: Vec<u64> = entries
+        .iter()
+        .map(|(_, loc)| match loc {
+            BtiPartitionLocation::DataOffset(o) => *o,
+            BtiPartitionLocation::RowsOffset(o) => *o,
+        })
+        .collect();
+
+    assert_eq!(
+        entries.len(),
+        2,
+        "collection_table has exactly 2 partitions; got {}: {:?}",
+        entries.len(),
+        entries
+    );
+    assert_eq!(
+        offsets,
+        vec![0, 107],
+        "DFS must yield DataOffsets [0, 107] in byte-comparable order"
+    );
+}
+
+/// (8) RowIterator over the empty (0-byte) simple_table Rows.db yields nothing
+/// without panicking.
+#[test]
+fn row_iterator_real_empty_rows_db_yields_nothing() {
+    let Some(root) = datasets_root() else {
+        return;
+    };
+    let Some(mut cursor) = load_component(
+        &root,
+        "sstables/test_da/simple_table-de1be8b064e711f19ad401a8c8227b11/da-2-bti-Rows.db",
+    ) else {
+        return;
+    };
+
+    let entries =
+        iterate_rows_in_bti_file(&mut cursor).expect("empty Rows.db must yield Ok(empty), not Err");
+    assert!(
+        entries.is_empty(),
+        "0-byte Rows.db must yield no entries; got {:?}",
+        entries
+    );
+}

--- a/cqlite-core/tests/issue_832_bti_traversal.rs
+++ b/cqlite-core/tests/issue_832_bti_traversal.rs
@@ -17,8 +17,9 @@
 use cqlite_core::storage::sstable::bti::{
     iterate_partitions_in_bti_file, iterate_rows_for_partition, iterate_rows_in_bti_file,
     iterate_rows_in_bti_trie, lookup_raw_key_in_bti_partitions_db, resolve_rows_db_entry,
-    select_row_index_blocks_for_range, BtiPartitionLocation,
+    select_row_index_blocks_for_range, BtiPartitionLocation, RowsParser,
 };
+use cqlite_core::types::Value;
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
 
@@ -261,7 +262,7 @@ fn rows_offset_resolves_real_trie_root() {
     let Some(root) = datasets_root() else {
         return;
     };
-    let Some([ro1, _ro2, _ro3]) = wide_rows_offsets(&root) else {
+    let Some([ro1, _ro2, ro3]) = wide_rows_offsets(&root) else {
         return;
     };
     let Some(rdb) = read_component(&root, "da-2-bti-Rows.db") else {
@@ -287,6 +288,22 @@ fn rows_offset_resolves_real_trie_root() {
     );
     assert_eq!(header.data_position, 0, "pk=1 Data.db position must be 0");
     assert_eq!(header.block_count, 38, "pk=1 must have 38 row-index blocks");
+
+    // Finding 2 (issue #832): the fixture issued no deletes, so the MODERN DA
+    // partition DeletionTime is the `0x80` LIVE sentinel and must decode to
+    // `None`.  The OLD legacy decoder would have mis-read the 12 following bytes
+    // (the next partition's entry data) as a bogus deletion.
+    assert_eq!(
+        header.partition_deletion, None,
+        "pk=1 partition deletion must be LIVE (0x80 sentinel → None)"
+    );
+    // pk=3 is the LAST entry; its 0x80 live sentinel is the final byte of the
+    // file, so the modern decoder must not over-read.
+    let header3 = resolve_rows_db_entry(&rdb, ro3).expect("pk=3 entry must deserialize");
+    assert_eq!(
+        header3.partition_deletion, None,
+        "pk=3 partition deletion must be LIVE (0x80 sentinel → None)"
+    );
 
     // Traversal from the recovered root yields exactly blockCount valid blocks.
     let entries = iterate_rows_in_bti_trie(&rdb, header.trie_root)
@@ -510,4 +527,97 @@ fn range_query_wide_partition_returns_correct_clustering_subset() {
     let reversed =
         select_row_index_blocks_for_range(&all, &encode_ck_int(150), &encode_ck_int(100));
     assert!(reversed.is_empty(), "reversed bounds must select no blocks");
+}
+
+/// Finding 1 (issue #832): the TYPED public `RowsParser::range_query` must encode
+/// `Value` clustering bounds in the SAME Cassandra OSS50 byte-comparable form the
+/// `Rows.db` trie stores (NOT CQLite's custom prefixed encoder).  This proves the
+/// typed API selects the correct block subset against the REAL trie separators,
+/// rather than the test hand-encoding the bytes (which hid the encoding bug).
+///
+/// We pass `&[Value::Integer(100)]..=&[Value::Integer(150)]` directly and assert
+/// the result is byte-for-byte identical to the pre-encoded
+/// `select_row_index_blocks_for_range` path (Finding B golden), including the
+/// floor block for ck=100, and that below-/above-range typed queries match too.
+#[test]
+fn typed_range_query_encodes_compatibly_with_real_trie() {
+    let Some(root) = datasets_root() else {
+        return;
+    };
+    let Some([ro1, _, _]) = wide_rows_offsets(&root) else {
+        return;
+    };
+    let Some(mut cursor) = load_component(
+        &root,
+        "sstables/test_da/wide_table-9099a7c06c1811f19864870fb8444786/da-2-bti-Rows.db",
+    ) else {
+        return;
+    };
+    let Some(rdb) = read_component(&root, "da-2-bti-Rows.db") else {
+        return;
+    };
+
+    // Pre-encoded golden (Finding B path) for ck in [100, 150].
+    let (_, all) = iterate_rows_for_partition(&rdb, ro1).expect("partition row index");
+    let golden_in: Vec<u64> =
+        select_row_index_blocks_for_range(&all, &encode_ck_int(100), &encode_ck_int(150))
+            .into_iter()
+            .map(|b| b.data_offset)
+            .collect();
+    assert!(
+        !golden_in.is_empty(),
+        "golden in-range set must be non-empty"
+    );
+
+    let mut parser = RowsParser::new(&mut cursor).expect("RowsParser::new on real Rows.db");
+
+    // TYPED call — Value bounds, NOT hand-encoded bytes.
+    let typed_in: Vec<u64> = parser
+        .range_query(ro1, &[Value::Integer(100)], &[Value::Integer(150)])
+        .expect("typed range_query must succeed")
+        .into_iter()
+        .map(|b| b.data_offset)
+        .collect();
+    assert_eq!(
+        typed_in, golden_in,
+        "typed range_query(Value::Integer 100..=150) must select the SAME blocks \
+         as the pre-encoded OSS50 byte-comparable path (proves compatible encoding)"
+    );
+
+    // Floor block for ck=100 (separator floor 96, interval [96,104)) must be present.
+    let sep_to_ck = |k: &[u8]| -> i64 {
+        let mut buf = [0u8; 4];
+        for (i, b) in k.iter().take(4).enumerate() {
+            buf[i] = *b;
+        }
+        (u32::from_be_bytes(buf) ^ 0x8000_0000) as i32 as i64
+    };
+    let floor_off = all
+        .iter()
+        .filter(|(k, _)| sep_to_ck(k) <= 100)
+        .max_by_key(|(k, _)| sep_to_ck(k))
+        .map(|(_, e)| e.data_offset)
+        .expect("a floor separator for ck=100 must exist");
+    assert!(
+        typed_in.contains(&floor_off),
+        "typed range_query must include the floor block (off={floor_off}) for ck=100"
+    );
+
+    // Below-range typed query (ck < 0): no blocks.
+    let typed_below = parser
+        .range_query(ro1, &[Value::Integer(-50)], &[Value::Integer(-10)])
+        .expect("typed range_query below range");
+    assert!(
+        typed_below.is_empty(),
+        "typed below-range query must select no blocks"
+    );
+
+    // Reversed typed bounds → empty.
+    let typed_rev = parser
+        .range_query(ro1, &[Value::Integer(150)], &[Value::Integer(100)])
+        .expect("typed reversed range_query");
+    assert!(
+        typed_rev.is_empty(),
+        "typed reversed bounds must select no blocks"
+    );
 }

--- a/cqlite-core/tests/issue_832_bti_traversal.rs
+++ b/cqlite-core/tests/issue_832_bti_traversal.rs
@@ -15,10 +15,89 @@
 //! test data.
 
 use cqlite_core::storage::sstable::bti::{
-    iterate_partitions_in_bti_file, iterate_rows_in_bti_file, BtiPartitionLocation,
+    iterate_partitions_in_bti_file, iterate_rows_for_partition, iterate_rows_in_bti_file,
+    iterate_rows_in_bti_trie, lookup_raw_key_in_bti_partitions_db, resolve_rows_db_entry,
+    select_row_index_blocks_for_range, BtiPartitionLocation,
 };
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
+
+/// Relative path of the wide-partition BTI fixture directory (issue #832).
+const WIDE_DIR: &str = "sstables/test_da/wide_table-9099a7c06c1811f19864870fb8444786";
+
+/// Cassandra OSS50 byte-comparable encoding of an `int` clustering value `ck`
+/// (single-component clustering): flip the sign bit, big-endian.  This matches
+/// the separator keys stored in the `wide_table` Rows.db tries (e.g. ck=8 →
+/// `80 00 00 08`).
+fn encode_ck_int(ck: i32) -> Vec<u8> {
+    ((ck as u32) ^ 0x8000_0000).to_be_bytes().to_vec()
+}
+
+/// Cassandra `Int32Type` raw partition-key bytes for `pk` (4-byte big-endian).
+fn raw_pk_int(pk: i32) -> Vec<u8> {
+    pk.to_be_bytes().to_vec()
+}
+
+/// Read a whole BTI component file as raw bytes (Rows.db / Partitions.db are NOT
+/// chunk-compressed), skipping the test when the binary fixture is absent.
+fn read_component(root: &Path, rel: &str) -> Option<Vec<u8>> {
+    let path = root.join(WIDE_DIR).join(rel);
+    if !path.exists() {
+        eprintln!("SKIP: wide BTI fixture not found at {:?}", path);
+        return None;
+    }
+    match std::fs::read(&path) {
+        Ok(b) => Some(b),
+        Err(e) => {
+            eprintln!("SKIP: cannot read {:?}: {}", path, e);
+            None
+        }
+    }
+}
+
+/// Resolve the three wide_table partition `RowsOffset`s by looking up the int
+/// partition keys 1/2/3 in Partitions.db.  Returns `[ro_pk1, ro_pk2, ro_pk3]`.
+fn wide_rows_offsets(root: &Path) -> Option<[usize; 3]> {
+    let pdb = read_component(root, "da-2-bti-Partitions.db")?;
+    let mut offs = [0usize; 3];
+    for (i, pk) in [1i32, 2, 3].into_iter().enumerate() {
+        let mut cur = Cursor::new(pdb.clone());
+        let loc = lookup_raw_key_in_bti_partitions_db(&mut cur, &raw_pk_int(pk))
+            .expect("Partitions.db lookup must succeed");
+        match loc {
+            Some(BtiPartitionLocation::RowsOffset(o)) => offs[i] = o as usize,
+            other => panic!("pk={pk} must be a wide partition (RowsOffset); got {other:?}"),
+        }
+    }
+    Some(offs)
+}
+
+/// Build `ck -> within-partition data position` from the JSONL golden for a
+/// partition (by index 0/1/2).
+fn jsonl_positions(
+    root: &Path,
+    partition_index: usize,
+) -> Option<std::collections::BTreeMap<i64, u64>> {
+    let path = root.join(WIDE_DIR).join("da-2-bti-Data.db.jsonl");
+    if !path.exists() {
+        eprintln!("SKIP: JSONL golden not found at {:?}", path);
+        return None;
+    }
+    let text = std::fs::read_to_string(&path).ok()?;
+    let line = text.lines().nth(partition_index)?;
+    let obj: serde_json::Value = serde_json::from_str(line).ok()?;
+    let rows = obj.get("rows")?.as_array()?;
+    let mut map = std::collections::BTreeMap::new();
+    for r in rows {
+        if r.get("type").and_then(|t| t.as_str()) != Some("row") {
+            continue;
+        }
+        let ck = r.get("clustering")?.as_array()?.first()?.as_i64()?;
+        let pos = r.get("position")?.as_u64()?;
+        map.insert(ck, pos);
+    }
+    Some(map)
+}
 
 /// Resolve the datasets root, skipping the test if it is not configured.
 fn datasets_root() -> Option<PathBuf> {
@@ -155,4 +234,280 @@ fn row_iterator_real_empty_rows_db_yields_nothing() {
         "0-byte Rows.db must yield no entries; got {:?}",
         entries
     );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Wide-partition fixture tests (issue #832, Findings A & B)
+//
+// Fixture: test_da/wide_table — wide_table(pk int, ck int, payload text,
+// PRIMARY KEY (pk, ck)), LZ4. 3 partitions pk=1/2/3, each 300 rows ck=0..299,
+// each ~600 KiB → each has a Rows.db row-index entry.
+//
+// Concrete, deterministic fixture facts (decoded from the real bytes):
+//   pk=1 → RowsOffset 242 → trieRoot 236, dataPos 0,       blockCount 38
+//   pk=2 → RowsOffset 494 → trieRoot 488, dataPos 619201,  blockCount 38
+//   pk=3 → RowsOffset 748 → trieRoot 742, dataPos 1238408, blockCount 38
+// Each partition's 38 separators are ck = 8,16,24,…,296,300 with within-partition
+// block offsets 16512, 33024, … (~16 KiB granularity), ending at the partition
+// data size (~619200). Separator key for ck=N is (N ^ 0x8000_0000) big-endian.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// (1) Finding A: pk=1's RowsOffset must resolve to a per-partition
+/// `TrieIndexEntry`, NOT a trie root.  Asserts the recovered trie root differs
+/// from RowsOffset, parses as a valid trie node, and that traversal from THAT
+/// root yields blockCount (38) row-index blocks — not an error or garbage.
+#[test]
+fn rows_offset_resolves_real_trie_root() {
+    let Some(root) = datasets_root() else {
+        return;
+    };
+    let Some([ro1, _ro2, _ro3]) = wide_rows_offsets(&root) else {
+        return;
+    };
+    let Some(rdb) = read_component(&root, "da-2-bti-Rows.db") else {
+        return;
+    };
+
+    // RowsOffset for pk=1 must be the known value 242.
+    assert_eq!(ro1, 242, "pk=1 RowsOffset must be 242 in this fixture");
+
+    // Feeding RowsOffset directly as a trie root must FAIL (it is entry metadata,
+    // not a node) — this is the bug Finding A fixes.
+    assert!(
+        iterate_rows_in_bti_trie(&rdb, ro1).is_err(),
+        "RowsOffset must NOT parse as a trie root directly (it is the entry)"
+    );
+
+    // Resolving the entry recovers the real trie root + partition metadata.
+    let header = resolve_rows_db_entry(&rdb, ro1).expect("entry must deserialize");
+    assert_eq!(header.trie_root, 236, "pk=1 trie root must resolve to 236");
+    assert_ne!(
+        header.trie_root, ro1,
+        "trie root must differ from RowsOffset (entry vs node)"
+    );
+    assert_eq!(header.data_position, 0, "pk=1 Data.db position must be 0");
+    assert_eq!(header.block_count, 38, "pk=1 must have 38 row-index blocks");
+
+    // Traversal from the recovered root yields exactly blockCount valid blocks.
+    let entries = iterate_rows_in_bti_trie(&rdb, header.trie_root)
+        .expect("traversal from the recovered root must succeed");
+    assert_eq!(
+        entries.len() as u32,
+        header.block_count,
+        "traversal must yield blockCount (38) row-index blocks, got {}",
+        entries.len()
+    );
+}
+
+/// (2) RowIterator-style traversal over pk=1's row index yields blocks in
+/// ascending clustering order; block count >= 2; within-partition offsets are
+/// strictly increasing and stay within Data.db bounds (absolute pos =
+/// data_position + offset < Data.db size).
+#[test]
+fn row_iterator_wide_partition_yields_blocks_in_order() {
+    let Some(root) = datasets_root() else {
+        return;
+    };
+    let Some([ro1, _, _]) = wide_rows_offsets(&root) else {
+        return;
+    };
+    let Some(rdb) = read_component(&root, "da-2-bti-Rows.db") else {
+        return;
+    };
+    // Data.db is LZ4-chunk-compressed, so its on-disk size is NOT the bound for
+    // these UNCOMPRESSED within-partition offsets.  Bound against the partition's
+    // uncompressed span derived from the JSONL golden (max row position + one
+    // 2 KiB payload row, generously rounded up).
+    let Some(positions) = jsonl_positions(&root, 0) else {
+        return;
+    };
+    let uncompressed_span = positions.values().copied().max().unwrap_or(0) + 4096;
+
+    let (header, entries) =
+        iterate_rows_for_partition(&rdb, ro1).expect("partition row index must traverse");
+
+    assert!(
+        entries.len() >= 2,
+        "a ~600 KiB partition must span multiple index blocks; got {}",
+        entries.len()
+    );
+    assert_eq!(entries.len(), 38, "pk=1 must yield 38 blocks");
+
+    // Separator keys ascending (DFS guarantees byte-comparable order).
+    for w in entries.windows(2) {
+        assert!(
+            w[0].0 <= w[1].0,
+            "row-index separator keys must be ascending: {:?} then {:?}",
+            w[0].0,
+            w[1].0
+        );
+    }
+
+    // Within-partition offsets strictly increasing, absolute position in bounds.
+    let offsets: Vec<u64> = entries.iter().map(|(_, e)| e.data_offset).collect();
+    for w in offsets.windows(2) {
+        assert!(
+            w[0] < w[1],
+            "block offsets must be strictly increasing: {} then {}",
+            w[0],
+            w[1]
+        );
+    }
+    for &off in &offsets {
+        assert!(
+            off <= uncompressed_span,
+            "within-partition block offset {off} must be within the partition's \
+             uncompressed span ({uncompressed_span})"
+        );
+    }
+    // pk=1 starts at Data.db position 0.
+    assert_eq!(header.data_position, 0);
+
+    // First separator is ck=8, last is ck=300 (the complete() trailing sep).
+    assert_eq!(entries.first().unwrap().0, encode_ck_int(8));
+    assert_eq!(entries.last().unwrap().0, encode_ck_int(300));
+    assert_eq!(offsets.first().copied(), Some(16512));
+}
+
+/// (3) Finding B: range_query over ck in [100..=150] returns exactly the blocks
+/// whose separator interval overlaps that clustering interval, using row-index
+/// separator semantics.  Cross-checked against the JSONL golden's per-ck data
+/// positions: every returned block covers some requested ck, the block whose
+/// interval contains ck=100 (the floor block) is present, and below-/above-range
+/// queries return non-overlapping disjoint sets.
+#[test]
+fn range_query_wide_partition_returns_correct_clustering_subset() {
+    let Some(root) = datasets_root() else {
+        return;
+    };
+    let Some([ro1, _, _]) = wide_rows_offsets(&root) else {
+        return;
+    };
+    let Some(rdb) = read_component(&root, "da-2-bti-Rows.db") else {
+        return;
+    };
+    let Some(positions) = jsonl_positions(&root, 0) else {
+        return;
+    };
+
+    let (header, all) =
+        iterate_rows_for_partition(&rdb, ro1).expect("partition row index must traverse");
+
+    // ---- in-range: ck in [100, 150] ----
+    let in_blocks =
+        select_row_index_blocks_for_range(&all, &encode_ck_int(100), &encode_ck_int(150));
+    assert!(
+        !in_blocks.is_empty(),
+        "ck in [100,150] must select at least one block"
+    );
+
+    // Separators are ck = 8,16,…; blocks hold 8 rows each. ck=100 lives in the
+    // block whose separator floor is 96 (interval [96,104)); ck=150 in [144,152).
+    // The selected separators must therefore range from <=100 up to <=150, with
+    // the next-after included to cover ck=150.
+    // Build the parallel list of (separator_ck, offset) for cross-checking.
+    // decode separator ck from the byte-comparable key.  Separators are the
+    // shortest prefix > prevMax; for this single int-clustering fixture they are
+    // the full 4-byte form (e.g. ck=8 → 80 00 00 08), but guard for any shorter
+    // path-compressed key by zero-padding on the right (byte-comparable order).
+    let sep_to_ck = |k: &[u8]| -> i64 {
+        let mut buf = [0u8; 4];
+        for (i, b) in k.iter().take(4).enumerate() {
+            buf[i] = *b;
+        }
+        (u32::from_be_bytes(buf) ^ 0x8000_0000) as i32 as i64
+    };
+    let sep_offsets: Vec<(i64, u64)> = all
+        .iter()
+        .map(|(k, e)| (sep_to_ck(k), e.data_offset))
+        .collect();
+
+    // The floor block for ck=100: largest separator <= 100. Its offset must be
+    // present in the selected set and must correspond (via JSONL) to a ck <= 100.
+    let floor = sep_offsets
+        .iter()
+        .filter(|(sep, _)| *sep <= 100)
+        .max_by_key(|(sep, _)| *sep)
+        .expect("a floor separator for ck=100 must exist");
+    let in_offsets: Vec<u64> = in_blocks.iter().map(|b| b.data_offset).collect();
+    assert!(
+        in_offsets.contains(&floor.1),
+        "the floor block (sep_ck={}, off={}) containing ck=100 must be selected; got {:?}",
+        floor.0,
+        floor.1,
+        in_offsets
+    );
+
+    // Every selected block's within-partition offset must equal some ck's
+    // position from the JSONL golden, and that ck must be reachable from the
+    // requested interval (i.e. the block's separator interval overlaps [100,150]).
+    let pos_to_ck: std::collections::BTreeMap<u64, i64> =
+        positions.iter().map(|(&ck, &p)| (p, ck)).collect();
+    for &off in &in_offsets {
+        let abs = header.data_position + off;
+        // off is within-partition; JSONL positions are within-partition too.
+        let ck_at_block = pos_to_ck.get(&off);
+        assert!(
+            ck_at_block.is_some(),
+            "selected block offset {off} (abs {abs}) must match a JSONL row position"
+        );
+    }
+
+    // The union of the selected blocks' separator intervals [s_i, s_{i+1}) must
+    // COVER the requested clustering range [100, 150].  (A block's separator is
+    // the floor of the first ck it covers; the block holding ck=150 has separator
+    // 144 with interval [144, 152), so the largest selected separator is < 150 by
+    // design — that is correct separator semantics, not a miss.)
+    let all_seps: Vec<i64> = sep_offsets.iter().map(|(s, _)| *s).collect();
+    let selected_seps: Vec<i64> = sep_offsets
+        .iter()
+        .filter(|(_, off)| in_offsets.contains(off))
+        .map(|(sep, _)| *sep)
+        .collect();
+    let min_sep = *selected_seps.iter().min().unwrap();
+    assert!(
+        min_sep <= 100,
+        "selected blocks must start at or below ck=100 (floor block); min_sep={min_sep}"
+    );
+    // For each requested ck in 100..=150, the block whose interval contains it
+    // (separator = greatest sep <= ck) must be among the selected blocks.
+    for ck in 100i64..=150 {
+        let floor_sep = *all_seps
+            .iter()
+            .filter(|&&s| s <= ck)
+            .max()
+            .expect("a floor separator must exist for ck in [100,150]");
+        assert!(
+            selected_seps.contains(&floor_sep),
+            "ck={ck} maps to floor separator {floor_sep}, which must be selected; \
+             selected={selected_seps:?}"
+        );
+    }
+
+    // ---- below-range: ck in [-50, -10] (no rows; all cks are 0..299) ----
+    let below = select_row_index_blocks_for_range(&all, &encode_ck_int(-50), &encode_ck_int(-10));
+    assert!(
+        below.is_empty(),
+        "a below-range query (ck < 0) must select no blocks; got {:?}",
+        below.iter().map(|b| b.data_offset).collect::<Vec<_>>()
+    );
+
+    // ---- above-range: ck in [400, 500] (beyond ck=299) ----
+    let above = select_row_index_blocks_for_range(&all, &encode_ck_int(400), &encode_ck_int(500));
+    // The only block that can possibly match is the trailing complete() sentinel
+    // (separator ck=300) if its interval is treated as [300, +inf). Assert it
+    // selects at most that one boundary block and never the data blocks of the
+    // requested in-range query.
+    let above_offsets: Vec<u64> = above.iter().map(|b| b.data_offset).collect();
+    for off in &above_offsets {
+        assert!(
+            !in_offsets.contains(off) || sep_offsets.iter().any(|(s, o)| *o == *off && *s >= 300),
+            "above-range must not select in-range data blocks (off {off})"
+        );
+    }
+
+    // ---- reversed bounds → empty ----
+    let reversed =
+        select_row_index_blocks_for_range(&all, &encode_ck_int(150), &encode_ck_int(100));
+    assert!(reversed.is_empty(), "reversed bounds must select no blocks");
 }

--- a/cqlite-core/tests/test_issue_827_merge_streaming_memory.rs
+++ b/cqlite-core/tests/test_issue_827_merge_streaming_memory.rs
@@ -1,0 +1,265 @@
+//! Memory-bound regression test for Issue #827 (dhat-gated) — THE deliverable.
+//!
+//! **Problem**: the k-way merge producer (`merge::producer_thread`) read each
+//! source via `iterate_all_partitions_for_compaction`, which fully materialised
+//! the decompressed data section and parsed EVERY entry into a `Vec` before any
+//! entry entered the bounded channel. End-to-end peak live heap therefore
+//! scaled with total input size (≈O(sum of source sizes)), not with a bounded
+//! read-ahead window — so a compaction whose inputs collectively exceed the
+//! 128 MiB budget would blow past it.
+//!
+//! **Fix**: a sliding-window incremental stitch+parse
+//! (`SSTableReader::stream_all_partitions_for_compaction`) feeding a streaming
+//! producer. A source's decompressed content is never fully resident; peak per
+//! source is bounded by roughly `max_partition_size + one_chunk +
+//! channel_capacity`.
+//!
+//! **This test** writes several SSTables whose combined decompressed size
+//! exceeds 128 MiB, runs an actual STCS compaction (k-way merge) under the dhat
+//! heap profiler, and asserts the peak live heap stays within the 128 MiB
+//! budget. On the pre-fix code the producer materialised each full source, so
+//! the peak exceeded the budget; with the streaming read it stays bounded.
+//!
+//! The profiler is started immediately before the compaction so only the merge
+//! workload is attributed (the write/flush setup that builds the large inputs
+//! is intentionally outside the measured window).
+//!
+//! Gated on the `dhat-heap` feature; runs in the profiling job, not normal
+//! `cargo test`. Run via:
+//!
+//! ```text
+//! cargo test --package cqlite-core \
+//!   --features write-support,cli-helpers,dhat-heap \
+//!   --test test_issue_827_merge_streaming_memory --profile bench -- --nocapture
+//! ```
+
+#![cfg(all(
+    feature = "write-support",
+    feature = "cli-helpers",
+    feature = "dhat-heap"
+))]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use cqlite_core::platform::Platform;
+use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+use cqlite_core::storage::sstable::SSTableManager;
+use cqlite_core::storage::write_engine::{
+    CellOperation, Mutation, PartitionKey, STCSPolicy, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::TableId as CqlTableId;
+use cqlite_core::types::Value;
+use cqlite_core::Config;
+use tempfile::TempDir;
+
+// The dhat allocator must be the global allocator to observe every allocation.
+// This test binary is separate from all others, so installing it here does not
+// affect normal builds or other test binaries.
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+const HEAP_BUDGET_BYTES: usize = 128 * 1024 * 1024;
+const KEYSPACE: &str = "issue827_mem_ks";
+const TABLE: &str = "blobs";
+
+// Workload sizing: payload bytes per row, rows per SSTable, number of SSTables.
+// 4 SSTables × 800 rows × 48 KiB ≈ 150 MiB of decompressed source content —
+// comfortably over the 128 MiB budget. The pre-fix producer held one whole
+// source (~38 MiB parsed) plus the consumer's per-source channels; with several
+// large sources the materialising path exceeded the budget. The streaming read
+// keeps only one partition + one chunk per source resident.
+const PAYLOAD_BYTES: usize = 48 * 1024;
+const ROWS_PER_SSTABLE: i32 = 800;
+const SSTABLE_COUNT: i32 = 4;
+
+fn make_schema() -> TableSchema {
+    TableSchema {
+        keyspace: KEYSPACE.to_string(),
+        table: TABLE.to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            Column {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "payload".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+    }
+}
+
+use std::collections::HashMap;
+
+/// A distinct-enough payload per row so the data does not trivially compress to
+/// nothing (we want a real decompressed window). The leading unique prefix
+/// defeats run-length collapse while the bulk stays cheap to generate.
+fn payload_for(id: i32) -> String {
+    let mut s = format!("row-{id:08}-");
+    s.push_str(&"abcdefghij".repeat((PAYLOAD_BYTES.saturating_sub(s.len())) / 10 + 1));
+    s.truncate(PAYLOAD_BYTES);
+    s
+}
+
+fn write_row(id: i32, timestamp: i64) -> Mutation {
+    let table_id = TableId::new(KEYSPACE, TABLE);
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    let ops = vec![CellOperation::Write {
+        column: "payload".to_string(),
+        value: Value::Text(payload_for(id)),
+    }];
+    Mutation::new(table_id, pk, None, ops, timestamp, None)
+}
+
+fn make_policy() -> STCSPolicy {
+    STCSPolicy::new(
+        SSTABLE_COUNT as usize, // min_threshold — compact once all N exist
+        32,                     // max_threshold
+        0.5,                    // bucket_low
+        1.5,                    // bucket_high
+        0,                      // min_sstable_size — zero so files group together
+    )
+    .expect("valid STCS parameters")
+}
+
+fn count_data_files(dir: &std::path::Path) -> usize {
+    std::fs::read_dir(dir)
+        .map(|rd| {
+            rd.filter_map(|e| e.ok())
+                .filter(|e| e.file_name().to_string_lossy().ends_with("-big-Data.db"))
+                .count()
+        })
+        .unwrap_or(0)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_merge_streaming_stays_within_heap_budget() {
+    let temp_dir = TempDir::new().unwrap();
+    let data_dir = temp_dir.path().join("data");
+    let wal_dir = temp_dir.path().join("wal");
+    let schema = make_schema();
+
+    // ── Phase 1 (UNMEASURED): write SSTABLE_COUNT large SSTables ──────────────
+    // Disjoint partition-key ranges per SSTable so the merge does real work.
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir, schema.clone());
+    let mut engine = WriteEngine::new(config).expect("engine creation");
+    for table_idx in 0..SSTABLE_COUNT {
+        let base = table_idx * ROWS_PER_SSTABLE;
+        for id in base..base + ROWS_PER_SSTABLE {
+            engine
+                .write(write_row(id, 100 + id as i64))
+                .expect("write row");
+        }
+        engine
+            .flush()
+            .await
+            .expect("flush sstable")
+            .expect("non-empty sstable");
+    }
+
+    let sstable_dir = data_dir.join(KEYSPACE).join(TABLE);
+    assert_eq!(
+        count_data_files(&sstable_dir),
+        SSTABLE_COUNT as usize,
+        "expected {SSTABLE_COUNT} Data.db files before compaction"
+    );
+
+    engine
+        .set_merge_policy(Box::new(make_policy()))
+        .expect("set merge policy");
+
+    // ── Phase 2 (MEASURED): run the k-way-merge compaction under dhat ─────────
+    // Start the profiler here so only the merge read/merge/write is attributed.
+    let _profiler = dhat::Profiler::builder().testing().build();
+
+    let budget = Duration::from_secs(120);
+    let mut compaction_completed = false;
+    for _ in 0..8 {
+        let report = engine
+            .maintenance_step(budget)
+            .expect("maintenance_step must not error");
+        if !report.completed_merges.is_empty() {
+            compaction_completed = true;
+            break;
+        }
+        if !report.pending_compaction {
+            break;
+        }
+    }
+    assert!(
+        compaction_completed,
+        "Issue #827: compaction must complete so the merge memory bound is exercised"
+    );
+
+    let stats = dhat::HeapStats::get();
+    eprintln!(
+        "Issue #827 merge streaming: {SSTABLE_COUNT} sources × {ROWS_PER_SSTABLE} rows × {} KiB \
+         payload, peak heap {} bytes ({:.2} MiB) vs budget {} MiB",
+        PAYLOAD_BYTES / 1024,
+        stats.max_bytes,
+        stats.max_bytes as f64 / (1024.0 * 1024.0),
+        HEAP_BUDGET_BYTES / (1024 * 1024),
+    );
+
+    // ── Phase 3 (post-measurement sanity): N → 1 and rows preserved ───────────
+    let merged_count = count_data_files(&sstable_dir);
+    assert_eq!(
+        merged_count, 1,
+        "Issue #827: compaction must produce exactly 1 output SSTable (N → 1)"
+    );
+
+    assert!(
+        stats.max_bytes <= HEAP_BUDGET_BYTES,
+        "Issue #827: k-way-merge peak heap {} bytes ({:.2} MiB) exceeds the {} MiB budget — \
+         the compaction read path regressed to materialising the whole source",
+        stats.max_bytes,
+        stats.max_bytes as f64 / (1024.0 * 1024.0),
+        HEAP_BUDGET_BYTES / (1024 * 1024),
+    );
+
+    engine.close().await.expect("close engine");
+
+    // Read back to confirm the merge preserved all partitions (correctness guard
+    // alongside the memory assertion).
+    let cqlite_config = Config::default();
+    let platform = Arc::new(
+        Platform::new(&cqlite_config)
+            .await
+            .expect("platform creation"),
+    );
+    let manager = SSTableManager::new(
+        &data_dir,
+        &cqlite_config,
+        platform,
+        #[cfg(feature = "state_machine")]
+        None,
+    )
+    .await
+    .expect("SSTableManager must open the merged output");
+    let table_id = CqlTableId::from(format!("{KEYSPACE}.{TABLE}").as_str());
+    let results = manager
+        .scan(&table_id, None, None, None, Some(&schema))
+        .await
+        .expect("post-compaction scan must not error");
+    assert_eq!(
+        results.len(),
+        (SSTABLE_COUNT * ROWS_PER_SSTABLE) as usize,
+        "Issue #827: merged output must contain all rows"
+    );
+
+    drop(temp_dir);
+}

--- a/cqlite-core/tests/test_issue_827_streaming_parity.rs
+++ b/cqlite-core/tests/test_issue_827_streaming_parity.rs
@@ -32,10 +32,10 @@
 use std::sync::Arc;
 
 use cqlite_core::platform::Platform;
-use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+use cqlite_core::schema::{ClusteringColumn, ClusteringOrder, Column, KeyColumn, TableSchema};
 use cqlite_core::storage::sstable::reader::SSTableReader;
 use cqlite_core::storage::write_engine::{
-    CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+    CellOperation, ClusteringKey, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
 };
 use cqlite_core::types::Value;
 use cqlite_core::{Config, RowKey};
@@ -305,6 +305,182 @@ async fn test_streaming_parity_with_row_tombstone() {
     );
 
     assert_parity(&vec_entries, &stream_entries, "row_tombstone");
+}
+
+// ===========================================================================
+// Finding 1 (#827): multi-row partition straddling a chunk boundary.
+//
+// The bounded one-partition parser must NOT re-emit rows it already emitted
+// when a partition is truncated mid-parse (NeedMore) after several rows. The
+// fixtures above only use single-row partitions, so they cannot catch the
+// duplicate-row regression. This uses a CLUSTERED schema: one partition with
+// many clustering rows whose serialised size exceeds one 16 KiB compression
+// chunk, forcing a mid-partition straddle AFTER several rows were parsed.
+// ===========================================================================
+
+const CLUSTERED_TABLE: &str = "events";
+
+/// A partition-key + clustering-key schema, so a single partition can hold many
+/// rows (one per clustering value).
+fn make_clustered_schema() -> TableSchema {
+    TableSchema {
+        keyspace: KEYSPACE.to_string(),
+        table: CLUSTERED_TABLE.to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "pk".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![ClusteringColumn {
+            name: "ck".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+            order: ClusteringOrder::Asc,
+        }],
+        columns: vec![
+            Column {
+                name: "pk".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "ck".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "payload".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+    }
+}
+
+fn write_clustered_row(pk: i32, ck: i32, payload: &str, timestamp: i64) -> Mutation {
+    let table_id = TableId::new(KEYSPACE, CLUSTERED_TABLE);
+    let partition = PartitionKey::single("pk", Value::Integer(pk));
+    let clustering = ClusteringKey::single("ck", Value::Integer(ck));
+    let ops = vec![CellOperation::Write {
+        column: "payload".to_string(),
+        value: Value::Text(payload.to_string()),
+    }];
+    Mutation::new(table_id, partition, Some(clustering), ops, timestamp, None)
+}
+
+/// Write `mutations` into one SSTable under `CLUSTERED_TABLE` and return its
+/// Data.db path (kept alive by the returned `TempDir`).
+async fn write_clustered_sstable(mutations: Vec<Mutation>) -> (TempDir, std::path::PathBuf) {
+    let temp_dir = TempDir::new().unwrap();
+    let data_dir = temp_dir.path().join("data");
+    let wal_dir = temp_dir.path().join("wal");
+    let schema = make_clustered_schema();
+
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir, schema);
+    let mut engine = WriteEngine::new(config).expect("engine creation");
+    for m in mutations {
+        engine.write(m).expect("write row");
+    }
+    engine
+        .flush()
+        .await
+        .expect("flush sstable")
+        .expect("non-empty sstable");
+    engine.close().await.expect("close engine");
+
+    let table_dir = data_dir.join(KEYSPACE).join(CLUSTERED_TABLE);
+    let path = std::fs::read_dir(&table_dir)
+        .expect("read sstable dir")
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .find(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.ends_with("-Data.db"))
+        })
+        .expect("a Data.db file should exist after flush");
+    (temp_dir, path)
+}
+
+/// Finding 1 regression: a SINGLE partition with MANY clustering rows whose
+/// total serialised size exceeds one 16 KiB compression chunk. The window will
+/// be truncated mid-partition AFTER several rows have already been parsed,
+/// returning `NeedMore`. The streaming read MUST yield exactly the same entries
+/// as the materialising Vec read — no row duplicated (the bug) and none dropped.
+#[tokio::test]
+async fn test_streaming_parity_multi_row_partition_chunk_straddle() {
+    let schema = make_clustered_schema();
+
+    // One partition, 200 clustering rows. Each row carries a ~512-byte payload,
+    // so the partition serialises to well over 16 KiB (multiple chunks) and the
+    // straddle happens after many rows were already emitted by the parser.
+    const ROWS: i32 = 200;
+    let payload = "Q".repeat(512);
+    let mut mutations = Vec::new();
+    for ck in 0..ROWS {
+        mutations.push(write_clustered_row(7, ck, &payload, 5_000 + ck as i64));
+    }
+    let (_tmp, data_path) = write_clustered_sstable(mutations).await;
+
+    let reader = open_reader(&data_path).await;
+    let vec_entries = collect_vec(&reader, &schema).await;
+    // Precondition: every clustering row is a distinct compaction entry, so the
+    // single partition produced many entries.
+    assert!(
+        vec_entries.len() >= ROWS as usize,
+        "Finding 1 precondition: expected >= {ROWS} entries from a multi-row \
+         partition, got {} (did clustering rows collapse?)",
+        vec_entries.len()
+    );
+
+    let stream_entries = collect_stream(&reader, &schema).await;
+
+    // The core assertion: no duplicates and none dropped — exact parity.
+    assert_eq!(
+        stream_entries.len(),
+        vec_entries.len(),
+        "Finding 1: streaming read returned {} entries, materialising read \
+         returned {} — a multi-row partition straddling a chunk boundary \
+         re-emitted (duplicated) or dropped rows",
+        stream_entries.len(),
+        vec_entries.len()
+    );
+
+    // Stronger guard: the multiset of (key,value,ts) must match exactly. Sort
+    // both so any duplicate/drop shows up as a mismatch regardless of ordering.
+    let mut vec_sorted = vec_entries.clone();
+    let mut stream_sorted = stream_entries.clone();
+    let sort_key = |e: &EntrySnapshot| (e.0.clone(), e.2);
+    vec_sorted.sort_by_key(sort_key);
+    stream_sorted.sort_by_key(sort_key);
+    assert_eq!(
+        stream_sorted, vec_sorted,
+        "Finding 1: streaming entries differ from materialising entries for a \
+         multi-row partition straddling a chunk boundary (duplicate/dropped rows)"
+    );
+
+    // Belt-and-suspenders: assert no exact-duplicate entry appears in the stream
+    // that is not also duplicated in the Vec read (catches re-emission directly).
+    let mut seen: HashMap<(Vec<u8>, i64), usize> = HashMap::new();
+    for e in &stream_entries {
+        *seen.entry((e.0.clone(), e.2)).or_insert(0) += 1;
+    }
+    let mut want: HashMap<(Vec<u8>, i64), usize> = HashMap::new();
+    for e in &vec_entries {
+        *want.entry((e.0.clone(), e.2)).or_insert(0) += 1;
+    }
+    assert_eq!(
+        seen, want,
+        "Finding 1: per-(key,ts) entry counts differ — duplicate rows emitted \
+         across a chunk-straddling multi-row partition"
+    );
 }
 
 /// Early-Break: returning `ControlFlow::Break` from the emit callback must stop

--- a/cqlite-core/tests/test_issue_827_streaming_parity.rs
+++ b/cqlite-core/tests/test_issue_827_streaming_parity.rs
@@ -1,0 +1,342 @@
+//! Parity + regression tests for Issue #827 (streaming compaction read path).
+//!
+//! **Problem**: the k-way merge producer (`merge::producer_thread`) read each
+//! source via `iterate_all_partitions_for_compaction`, which fully materialised
+//! the decompressed data section and parsed every entry into a `Vec` before any
+//! entry entered the bounded channel. End-to-end peak memory therefore scaled
+//! with total input size, not with a bounded read-ahead window.
+//!
+//! **Fix**: a sliding-window incremental stitch+parse
+//! (`SSTableReader::stream_all_partitions_for_compaction`) driven by the bounded
+//! one-partition parser
+//! (`V5CompressedLegacyParser::parse_one_partition_with_timestamps`), plus a
+//! streaming producer that forwards one entry at a time.
+//!
+//! **These tests** guard *correctness* of that refactor:
+//!
+//! 1. `parse_block_with_timestamps_emit` (always-on, via the streaming reader
+//!    which uses the one-partition parser) returns exactly the same entries as
+//!    the materialising `parse_block_with_timestamps` (via the Vec reader API),
+//!    byte-for-byte (keys, values, timestamps, tombstones), across a
+//!    multi-partition / multi-chunk SSTable.
+//! 2. **chunk-straddle**: a partition larger than one 16 KiB compression chunk
+//!    still parses identically through the sliding window (proves the window
+//!    refills across chunk boundaries / the NeedMore logic).
+//!
+//! The fixtures are written in-test via the `WriteEngine` (V5CompressedLegacy
+//! "nb" format — exactly what compaction reads), so the tests need no external
+//! dataset corpus.
+
+#![cfg(all(feature = "write-support", feature = "cli-helpers"))]
+
+use std::sync::Arc;
+
+use cqlite_core::platform::Platform;
+use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+use cqlite_core::storage::sstable::reader::SSTableReader;
+use cqlite_core::storage::write_engine::{
+    CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::Value;
+use cqlite_core::{Config, RowKey};
+use std::collections::HashMap;
+use tempfile::TempDir;
+
+const KEYSPACE: &str = "issue827_ks";
+const TABLE: &str = "items";
+
+fn make_schema() -> TableSchema {
+    TableSchema {
+        keyspace: KEYSPACE.to_string(),
+        table: TABLE.to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            Column {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "name".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "payload".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+    }
+}
+
+fn write_row(id: i32, name: &str, payload: &str, timestamp: i64) -> Mutation {
+    let table_id = TableId::new(KEYSPACE, TABLE);
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    let ops = vec![
+        CellOperation::Write {
+            column: "name".to_string(),
+            value: Value::Text(name.to_string()),
+        },
+        CellOperation::Write {
+            column: "payload".to_string(),
+            value: Value::Text(payload.to_string()),
+        },
+    ];
+    Mutation::new(table_id, pk, None, ops, timestamp, None)
+}
+
+/// Find the single `-Data.db` file produced by a flush under `dir`.
+fn find_data_db(dir: &std::path::Path) -> std::path::PathBuf {
+    let table_dir = dir.join(KEYSPACE).join(TABLE);
+    std::fs::read_dir(&table_dir)
+        .expect("read sstable dir")
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .find(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.ends_with("-Data.db"))
+        })
+        .expect("a Data.db file should exist after flush")
+}
+
+/// Write `mutations` into one SSTable and return its Data.db path (kept alive by
+/// the returned `TempDir`).
+async fn write_sstable(mutations: Vec<Mutation>) -> (TempDir, std::path::PathBuf) {
+    let temp_dir = TempDir::new().unwrap();
+    let data_dir = temp_dir.path().join("data");
+    let wal_dir = temp_dir.path().join("wal");
+    let schema = make_schema();
+
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir, schema);
+    let mut engine = WriteEngine::new(config).expect("engine creation");
+    for m in mutations {
+        engine.write(m).expect("write row");
+    }
+    engine
+        .flush()
+        .await
+        .expect("flush sstable")
+        .expect("non-empty sstable");
+    engine.close().await.expect("close engine");
+
+    let path = find_data_db(&data_dir);
+    (temp_dir, path)
+}
+
+/// A comparable snapshot of a compaction entry: (key bytes, value, timestamp).
+type EntrySnapshot = (Vec<u8>, Value, i64);
+
+async fn collect_vec(reader: &SSTableReader, schema: &TableSchema) -> Vec<EntrySnapshot> {
+    reader
+        .iterate_all_partitions_for_compaction(Some(schema))
+        .await
+        .expect("iterate_all_partitions_for_compaction")
+        .into_iter()
+        .map(|(k, v, ts)| (k.0, v, ts))
+        .collect()
+}
+
+async fn collect_stream(reader: &SSTableReader, schema: &TableSchema) -> Vec<EntrySnapshot> {
+    let mut out: Vec<EntrySnapshot> = Vec::new();
+    reader
+        .stream_all_partitions_for_compaction(Some(schema), |key: RowKey, value, ts| {
+            out.push((key.0, value, ts));
+            Ok(std::ops::ControlFlow::Continue(()))
+        })
+        .await
+        .expect("stream_all_partitions_for_compaction");
+    out
+}
+
+async fn open_reader(path: &std::path::Path) -> SSTableReader {
+    let mut config = Config::default();
+    // #591: never mmap (mirrors the producer thread).
+    config.storage.use_mmap = false;
+    let platform = Arc::new(Platform::new(&config).await.expect("platform"));
+    SSTableReader::open(path, &config, platform)
+        .await
+        .expect("open reader")
+}
+
+/// Assert the streaming compaction read returns byte-for-byte the same entries
+/// (order, keys, values, timestamps) as the materialising Vec read.
+fn assert_parity(vec_entries: &[EntrySnapshot], stream_entries: &[EntrySnapshot], ctx: &str) {
+    assert_eq!(
+        stream_entries.len(),
+        vec_entries.len(),
+        "Issue #827 [{ctx}]: streaming read returned {} entries, materialising read returned {}",
+        stream_entries.len(),
+        vec_entries.len()
+    );
+    for (i, (got, want)) in stream_entries.iter().zip(vec_entries.iter()).enumerate() {
+        assert_eq!(got.0, want.0, "Issue #827 [{ctx}]: entry {i} key mismatch");
+        assert_eq!(
+            got.1, want.1,
+            "Issue #827 [{ctx}]: entry {i} value mismatch"
+        );
+        assert_eq!(
+            got.2, want.2,
+            "Issue #827 [{ctx}]: entry {i} timestamp mismatch"
+        );
+    }
+}
+
+/// Many small partitions spanning MULTIPLE 16 KiB compression chunks: the
+/// streaming sliding-window read must equal the materialising Vec read exactly.
+#[tokio::test]
+async fn test_streaming_parity_multi_chunk() {
+    let schema = make_schema();
+    // ~600 partitions × (a ~64-byte payload) comfortably exceeds several 16 KiB
+    // chunks once serialised, forcing the window to refill across chunk
+    // boundaries.
+    let mut mutations = Vec::new();
+    for id in 0..600i32 {
+        let payload = format!("payload-{id:08}-{}", "x".repeat(48));
+        mutations.push(write_row(
+            id,
+            &format!("name-{id}"),
+            &payload,
+            1_000 + id as i64,
+        ));
+    }
+    let (_tmp, data_path) = write_sstable(mutations).await;
+
+    let reader = open_reader(&data_path).await;
+    let vec_entries = collect_vec(&reader, &schema).await;
+    assert!(
+        vec_entries.len() >= 500,
+        "Issue #827 precondition: expected many partitions, got {}",
+        vec_entries.len()
+    );
+    let stream_entries = collect_stream(&reader, &schema).await;
+    assert_parity(&vec_entries, &stream_entries, "multi_chunk");
+}
+
+/// A SINGLE partition whose serialised size exceeds one 16 KiB chunk: parity
+/// must still hold, proving the bounded one-partition parser returns NeedMore
+/// (not a premature end) until the whole partition has been stitched together.
+#[tokio::test]
+async fn test_streaming_parity_chunk_straddle_wide_partition() {
+    let schema = make_schema();
+    // One ~48 KiB text value (> 2 chunks) plus a few normal partitions around it.
+    let big_payload = "Z".repeat(48 * 1024);
+    let mutations = vec![
+        write_row(1, "small-before", "p1", 2_001),
+        write_row(2, "the-big-one", &big_payload, 2_002),
+        write_row(3, "small-after", "p3", 2_003),
+    ];
+    let (_tmp, data_path) = write_sstable(mutations).await;
+
+    let reader = open_reader(&data_path).await;
+    let vec_entries = collect_vec(&reader, &schema).await;
+    assert!(
+        !vec_entries.is_empty(),
+        "Issue #827 precondition: wide-partition fixture should yield rows"
+    );
+    // Sanity: the big partition's value really is large (so it straddles chunks).
+    let has_big = vec_entries.iter().any(|(_, v, _)| {
+        if let Value::Map(entries) = v {
+            entries
+                .iter()
+                .any(|(_, val)| matches!(val, Value::Text(s) if s.len() >= 48 * 1024))
+        } else {
+            false
+        }
+    });
+    assert!(
+        has_big,
+        "Issue #827 precondition: expected a partition with a >=48 KiB text value"
+    );
+
+    let stream_entries = collect_stream(&reader, &schema).await;
+    assert_parity(&vec_entries, &stream_entries, "chunk_straddle");
+}
+
+/// Tombstone parity (#505/#533 invariant): a partition carrying a row tombstone
+/// must stream byte-identically to the materialising read — same
+/// `Value::Tombstone` and same deletion timestamp. This guards the tombstone-
+/// shadowing semantics the merger relies on.
+#[tokio::test]
+async fn test_streaming_parity_with_row_tombstone() {
+    let schema = make_schema();
+
+    // A live partition, a row tombstone, and another live partition.
+    let mutations = vec![
+        write_row(10, "alive-1", "p", 4_001),
+        // Row tombstone for id=11.
+        Mutation::new(
+            TableId::new(KEYSPACE, TABLE),
+            PartitionKey::single("id", Value::Integer(11)),
+            None,
+            vec![CellOperation::DeleteRow],
+            4_002,
+            None,
+        ),
+        write_row(12, "alive-2", "p", 4_003),
+    ];
+    let (_tmp, data_path) = write_sstable(mutations).await;
+
+    let reader = open_reader(&data_path).await;
+    let vec_entries = collect_vec(&reader, &schema).await;
+    let stream_entries = collect_stream(&reader, &schema).await;
+
+    // At least one tombstone must be present, so the parity is non-trivial.
+    let tombstone_count = vec_entries
+        .iter()
+        .filter(|(_, v, _)| matches!(v, Value::Tombstone(_)))
+        .count();
+    assert!(
+        tombstone_count >= 1,
+        "Issue #827 precondition: expected a row tombstone in the fixture"
+    );
+
+    assert_parity(&vec_entries, &stream_entries, "row_tombstone");
+}
+
+/// Early-Break: returning `ControlFlow::Break` from the emit callback must stop
+/// the streaming read promptly and yield exactly the prefix produced so far.
+#[tokio::test]
+async fn test_streaming_break_stops_early() {
+    let schema = make_schema();
+    let mut mutations = Vec::new();
+    for id in 0..200i32 {
+        mutations.push(write_row(id, &format!("n-{id}"), "p", 3_000 + id as i64));
+    }
+    let (_tmp, data_path) = write_sstable(mutations).await;
+
+    let reader = open_reader(&data_path).await;
+
+    let mut collected: Vec<Vec<u8>> = Vec::new();
+    reader
+        .stream_all_partitions_for_compaction(Some(&schema), |key: RowKey, _v, _ts| {
+            collected.push(key.0);
+            if collected.len() >= 5 {
+                Ok(std::ops::ControlFlow::Break(()))
+            } else {
+                Ok(std::ops::ControlFlow::Continue(()))
+            }
+        })
+        .await
+        .expect("stream with early break");
+
+    assert_eq!(
+        collected.len(),
+        5,
+        "Issue #827: Break must stop the stream at exactly 5 entries, got {}",
+        collected.len()
+    );
+}

--- a/test-data/scripts/gen-wide-bti.sh
+++ b/test-data/scripts/gen-wide-bti.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# gen-wide-bti.sh — Generate a WIDE-PARTITION BTI (da) fixture with a populated
+# Rows.db row-index, for issue #832 (BTI RowIterator / range_query validation).
+#
+# The existing test_da tables are all narrow (no clustering) and produce 0-byte
+# Rows.db files. This creates test_da.wide_table: a clustered table with a few
+# partitions each far larger than column_index_size (64KiB), forcing Cassandra
+# to write per-partition row indexes into Rows.db (reached via Partitions.db
+# RowsOffset -> TrieIndexEntry).
+#
+# Output (binaries are gitignored; the .jsonl golden is committed):
+#   $OUT/sstables/test_da/wide_table-<hash>/da-*-{Data,Partitions,Rows,...}.db
+#   $OUT/sstables/test_da/wide_table-<hash>/da-*-Data.db.jsonl   (sstabledump -l)
+set -euo pipefail
+
+IMAGE="${IMAGE:-cassandra:5.0.2}"
+CONTAINER="${CONTAINER:-cqlite-widebti}"
+OUT="${OUT:-/Users/pmcfadin/projects/cqlite/test-data/datasets}"
+KS="test_da"
+TBL="wide_table"
+ROWS_PER_PART="${ROWS_PER_PART:-300}"   # 300 rows * ~2KiB payload ~= 600KiB/partition
+PARTS="${PARTS:-3}"
+PAYLOAD_BYTES="${PAYLOAD_BYTES:-2048}"
+
+log() { echo "[gen-wide-bti] $*"; }
+
+# Keep the container on failure for diagnosis; remove only on clean success.
+KEEP_ON_FAIL=1
+cleanup() {
+  local code=$?
+  if [[ $code -ne 0 && "${KEEP_ON_FAIL}" == "1" ]]; then
+    log "FAILED (exit $code). Dumping last container logs; leaving container '$CONTAINER' for inspection."
+    docker logs --tail 60 "$CONTAINER" 2>&1 || true
+  else
+    docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+wait_ready() {
+  local label="$1" max="${2:-90}" delay=5
+  log "Waiting for Cassandra to be ready ($label, max ${max}x${delay}s)..."
+  for i in $(seq 1 "$max"); do
+    if docker exec "$CONTAINER" cqlsh -e "SELECT cluster_name FROM system.local;" >/dev/null 2>&1; then
+      log "Cassandra ready ($label, attempt $i)."
+      return 0
+    fi
+    sleep "$delay"
+  done
+  log "FATAL: Cassandra not ready ($label) after $((max*delay))s"
+  return 1
+}
+
+log "Removing any stale container..."
+docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+
+log "Starting $IMAGE as $CONTAINER (pulls image if absent)..."
+docker run -d --name "$CONTAINER" "$IMAGE" >/dev/null
+
+# Let the FIRST boot complete fully before reconfiguring — restarting mid-boot
+# stalls Cassandra (the bug in the prior run).
+wait_ready "initial boot" 90
+
+log "Setting storage_compatibility_mode: NONE (required for BTI) + sstable.selected_format: bti..."
+docker exec "$CONTAINER" bash -lc \
+  "sed -i 's/storage_compatibility_mode: CASSANDRA_4/storage_compatibility_mode: NONE/g; s|#sstable:|sstable:|; s|#  selected_format: big|  selected_format: bti|' /etc/cassandra/cassandra.yaml"
+docker exec "$CONTAINER" bash -lc "grep -E '^storage_compatibility_mode|^sstable:|selected_format' /etc/cassandra/cassandra.yaml || true"
+
+log "Restarting container to apply BTI mode..."
+docker restart "$CONTAINER" >/dev/null
+wait_ready "BTI mode" 90
+
+log "Building schema + ${PARTS}x${ROWS_PER_PART} inserts (~${PAYLOAD_BYTES}B payload each) into one CQL file..."
+CQL_FILE="$(mktemp /tmp/wide-bti.XXXXXX.cql)"
+python3 - "$CQL_FILE" "$KS" "$TBL" "$PARTS" "$ROWS_PER_PART" "$PAYLOAD_BYTES" <<'PYEOF'
+import sys
+out, ks, tbl, parts, rows, pbytes = sys.argv[1], sys.argv[2], sys.argv[3], int(sys.argv[4]), int(sys.argv[5]), int(sys.argv[6])
+with open(out, "w") as f:
+    f.write(f"CREATE KEYSPACE IF NOT EXISTS {ks} WITH replication = {{'class':'SimpleStrategy','replication_factor':1}};\n")
+    f.write(f"USE {ks};\n")
+    f.write(f"CREATE TABLE IF NOT EXISTS {tbl} (pk int, ck int, payload text, PRIMARY KEY (pk, ck)) WITH compression = {{'class':'LZ4Compressor'}};\n")
+    for pk in range(1, parts + 1):
+        for ck in range(rows):
+            seed = f"p{pk}c{ck}-"
+            reps = (pbytes // len(seed)) + 1
+            payload = (seed * reps)[:pbytes]
+            f.write(f"INSERT INTO {tbl} (pk, ck, payload) VALUES ({pk}, {ck}, '{payload}');\n")
+print("[gen-wide-bti] wrote", out)
+PYEOF
+
+docker cp "$CQL_FILE" "$CONTAINER:/tmp/wide.cql"
+log "Applying schema + inserts via cqlsh -f (this can take a moment)..."
+docker exec "$CONTAINER" cqlsh -f /tmp/wide.cql
+rm -f "$CQL_FILE"
+
+log "Flushing + compacting ${KS}..."
+docker exec "$CONTAINER" nodetool flush "$KS"
+docker exec "$CONTAINER" nodetool compact "$KS"
+
+log "Locating wide_table SSTable dir in container..."
+SSTABLE_DIR="$(docker exec "$CONTAINER" bash -lc "ls -d /var/lib/cassandra/data/${KS}/${TBL}-* | head -1")"
+log "Container SSTable dir: $SSTABLE_DIR"
+docker exec "$CONTAINER" bash -lc "ls -la '$SSTABLE_DIR'"
+
+ROWS_DB_SIZE="$(docker exec "$CONTAINER" bash -lc "stat -c %s '$SSTABLE_DIR'/da-*-Rows.db 2>/dev/null | head -1 || echo 0")"
+log "Rows.db size: ${ROWS_DB_SIZE} bytes"
+if [[ "${ROWS_DB_SIZE:-0}" -lt 1 ]]; then
+  log "FATAL: Rows.db is empty — partitions did not exceed column_index_size. Increase ROWS_PER_PART/PAYLOAD_BYTES."
+  exit 1
+fi
+log "SUCCESS: Rows.db is populated (${ROWS_DB_SIZE} bytes)."
+
+DEST_PARENT="$OUT/sstables/${KS}"
+DEST_NAME="$(basename "$SSTABLE_DIR")"
+DEST="$DEST_PARENT/$DEST_NAME"
+log "Copying SSTable to $DEST ..."
+mkdir -p "$DEST_PARENT"
+rm -rf "$DEST"
+docker cp "$CONTAINER:$SSTABLE_DIR" "$DEST_PARENT/"
+ls -la "$DEST"
+
+log "Generating sstabledump JSONL golden..."
+DATA_DB="$(ls "$DEST"/da-*-Data.db | head -1)"
+BASE="$(basename "$DATA_DB")"
+REL="${KS}/${DEST_NAME}/${BASE}"
+docker exec "$CONTAINER" bash -lc "ls -la '$SSTABLE_DIR'/$BASE"
+# sstabledump runs inside the container against the container path.
+docker exec "$CONTAINER" bash -lc \
+  "/opt/cassandra/tools/bin/sstabledump '$SSTABLE_DIR/$BASE' -l" > "$DEST/${BASE}.jsonl" || {
+    log "WARN: sstabledump -l failed; trying without -l"
+    docker exec "$CONTAINER" bash -lc "/opt/cassandra/tools/bin/sstabledump '$SSTABLE_DIR/$BASE'" > "$DEST/${BASE}.json" || true
+  }
+log "JSONL golden lines: $(wc -l < "$DEST/${BASE}.jsonl" 2>/dev/null || echo '?')"
+
+log "DONE. Fixture at: $DEST"
+log "Files:"; ls -la "$DEST"


### PR DESCRIPTION
## Epic #835 — read-path completion (follow-ups from #751)

Completes the three end-to-end read-path pieces re-scoped out of #751. Each child was implemented with TDD, validated against real Cassandra 5.0 fixtures, passed `scripts/agent-gate.sh`, and was reviewed via roborev (all findings resolved — final reviews clean).

### #827 — streaming compaction-read path (bounded K-way merge memory)
- Sliding-window incremental stitch+parse (`parse_block_with_timestamps_emit`, `parse_one_partition_with_timestamps`) so the merge producer streams one partition at a time into the `sync_channel` instead of materializing each whole source.
- Also made `read_uncompressed_data_block` piecewise only for the streaming consumer (V5_0Uncompressed normal reads stay contiguous) and streamed the output CRC.
- **dhat: peak heap 52.9 MiB ≤ 128 MiB** on ~150 MiB of inputs (TDD red→green: 352→150→52.9 MiB). No duplicate rows on multi-row chunk-straddle (regression test).

### #831 — wire BTI trie point-lookup into `SSTableReader`
- BTI (`da`) reader-open (loads Partitions.db), trie-resolved point lookup (no sequential scan), chunk-targeted decompress (not whole-section), keyspace-aware table guard, prefix-collision guard.
- Full decoded-row parity vs sstabledump JSONL goldens on `test_da/simple_table`.

### #832 — BTI trie traversal iterators
- `PartitionIterator` (validated vs real fixtures: offsets [0,63,125] / [0,107]), Dense offset-0 child fix.
- `RowIterator` / `range_query`: `TrieIndexEntry` per-partition root resolution, row-index **separator** range semantics, Cassandra OSS50 byte-comparable clustering encoding (incl. variable-length zero-escape), DA `DeletionTime` decoding — validated against a newly generated **wide-partition BTI fixture** (`test_da.wide_table`, 3×300 rows, populated 760B Rows.db; reproducible via `test-data/scripts/gen-wide-bti.sh`).

### Validation
- Full `scripts/agent-gate.sh` PASS on the integrated branch (fmt, clippy -D warnings, core/integration/write/cli tests, minimal build, smoke).
- roborev reviewed every commit; all findings (incl. Dense sentinel, Rows.db rooting, encoder mismatch, table-guard keyspace, chunk-straddle) fixed and re-reviewed clean.
- Note: the new `wide_table` BTI fixture binaries are local (gitignored, like other datasets); its `#832` Rows.db tests skip on CI until the fixture is added to the dataset release package. PartitionIterator + point-lookup goldens are exercised by existing committed fixtures.

Closes #827
Closes #831
Closes #832
Closes #835