### PR TITLE
feat: scan_delta streaming API — upserts and static upserts (closes #698)

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/data_access.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access.rs
@@ -1876,6 +1876,53 @@ impl SSTableReader {
         )
         .await
     }
+
+    /// Prepare for a delta-scan pass: seek to the data-section start, reset
+    /// the chunk index, stitch all compressed chunks, and return the
+    /// decompressed buffer together with a pre-configured parser.
+    ///
+    /// The caller is responsible for holding `scan_mutex` for the lifetime of
+    /// the returned buffer (matching the existing compaction-path contract —
+    /// issue #805).  This method is gated on the `delta-scan` feature and is
+    /// the only bridge between the SSTableReader internals and the
+    /// `delta_scan` module, which cannot access private helpers directly.
+    #[cfg(feature = "delta-scan")]
+    pub async fn prepare_delta_scan(
+        &self,
+        schema: Option<&crate::schema::TableSchema>,
+    ) -> Result<(Vec<u8>, super::parsing::V5CompressedLegacyParser)> {
+        use tokio::io::AsyncSeekExt;
+
+        // Seek to the start of the data section and reset the chunk index.
+        let header_size = self.calculate_header_size();
+        {
+            let mut file_guard = self.file.lock().await;
+            file_guard
+                .seek(std::io::SeekFrom::Start(header_size as u64))
+                .await?;
+        }
+        self.current_chunk_index
+            .store(0, std::sync::atomic::Ordering::Relaxed);
+
+        // Stitch all compressed chunks (bounded by uncompressed data-section size).
+        let stitched = self.stitch_all_chunks().await?;
+
+        // Build a parser (re-using the existing builder so version-gates and
+        // UDT registry are threaded through correctly).
+        let _ = schema; // schema is threaded via the caller's parse call
+        let parser = self.build_v5_parser();
+
+        Ok((stitched, parser))
+    }
+
+    /// Return the `scan_mutex` guard for external callers that need to
+    /// serialise a delta-scan pass against concurrent reads.
+    ///
+    /// Gated on `delta-scan` — only the delta-scan path needs this.
+    #[cfg(feature = "delta-scan")]
+    pub fn delta_scan_mutex(&self) -> &tokio::sync::Mutex<()> {
+        &self.scan_mutex
+    }
 }
 
 #[cfg(test)]

--- a/cqlite-core/src/storage/sstable/reader/data_access.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access.rs
@@ -1886,10 +1886,14 @@ impl SSTableReader {
     /// issue #805).  This method is gated on the `delta-scan` feature and is
     /// the only bridge between the SSTableReader internals and the
     /// `delta_scan` module, which cannot access private helpers directly.
+    ///
+    /// The `schema` parameter is not used here — it is threaded through the
+    /// caller's `parse_block_emit_delta` invocation instead.  The parser is
+    /// built via `build_v5_parser()` which handles version-gates and UDT
+    /// registry without needing the schema at construction time.
     #[cfg(feature = "delta-scan")]
     pub async fn prepare_delta_scan(
         &self,
-        schema: Option<&crate::schema::TableSchema>,
     ) -> Result<(Vec<u8>, super::parsing::V5CompressedLegacyParser)> {
         use tokio::io::AsyncSeekExt;
 
@@ -1909,7 +1913,6 @@ impl SSTableReader {
 
         // Build a parser (re-using the existing builder so version-gates and
         // UDT registry are threaded through correctly).
-        let _ = schema; // schema is threaded via the caller's parse call
         let parser = self.build_v5_parser();
 
         Ok((stitched, parser))

--- a/cqlite-core/src/storage/sstable/reader/delta_scan.rs
+++ b/cqlite-core/src/storage/sstable/reader/delta_scan.rs
@@ -455,7 +455,14 @@ impl DeltaRecord {
 /// ## Memory
 ///
 /// The channel is bounded by `buffer_size` records.  The parse task pauses
-/// when the consumer falls behind.  No full-table materialisation occurs.
+/// when the consumer falls behind.  Individual [`DeltaRecord`]s are bounded in
+/// size and never accumulated into a full-table collection.
+///
+/// **Caveat**: `prepare_delta_scan` → `stitch_all_chunks` fully materialises the
+/// decompressed data section of the SSTable into a single `Vec<u8>` before
+/// streaming begins.  For very large SSTables this may approach the 128 MB
+/// memory budget; callers should be aware that the stitched buffer is resident
+/// for the duration of the scan.
 ///
 /// ## Errors
 ///
@@ -503,23 +510,25 @@ async fn run_scan_delta(
             })?,
     );
 
+    // Wrap schema in Arc once — both the emit closure and parse call share the
+    // same allocation rather than cloning the struct twice.
+    let schema_arc = std::sync::Arc::new(schema);
+
     // Stitch + parse with mutex held for the stitch (issue #805), then release.
     // The parsing itself is synchronous and moves into spawn_blocking; it does
     // not need the scan mutex since we already have the full stitched buffer.
     let (stitched, parser) = {
         let _scan_guard = reader.delta_scan_mutex().lock().await;
-        reader.prepare_delta_scan(Some(&schema)).await?
+        reader.prepare_delta_scan().await?
         // _scan_guard dropped here after stitching is complete.
     };
 
-    // Build key-set lookups from schema (captured by the blocking closure below).
-    let schema_arc = std::sync::Arc::new(schema.clone());
+    let schema_for_parse = std::sync::Arc::clone(&schema_arc);
+    let reader_arc = std::sync::Arc::clone(&reader);
 
     // The parse closure is synchronous; run it on a blocking thread so it can
     // use `blocking_send` without stalling the async runtime (mirrors
     // `parse_stitched_stream` in data_access.rs, issue #790).
-    let schema_for_parse = schema.clone();
-    let reader_arc = std::sync::Arc::clone(&reader);
     let parse_result = tokio::task::spawn_blocking(move || -> crate::Result<()> {
         parser.parse_block_emit_delta(
             &stitched,
@@ -666,8 +675,12 @@ async fn run_scan_delta(
 /// Find the `Data.db` file inside an SSTable directory.
 ///
 /// Cassandra names Data.db files with a generation prefix, e.g.:
-/// `nb-1-big-Data.db` or `na-1-big-Data.db`. Returns an error if no
-/// matching file is found.
+/// `nb-1-big-Data.db` or `na-1-big-Data.db`.
+///
+/// Returns an error if no matching file is found.  If more than one `*-Data.db`
+/// file is present (which violates the single-generation contract), a warning is
+/// logged and the lexicographically smallest file name is returned so behaviour
+/// is at least deterministic rather than OS-dependent.
 fn find_data_db(dir: &std::path::Path) -> crate::Result<std::path::PathBuf> {
     if !dir.exists() {
         return Err(crate::Error::corruption(format!(
@@ -680,18 +693,36 @@ fn find_data_db(dir: &std::path::Path) -> crate::Result<std::path::PathBuf> {
         crate::Error::corruption(format!("scan_delta: cannot read directory {:?}: {e}", dir))
     })?;
 
-    for entry in entries.filter_map(|e| e.ok()) {
-        let name = entry.file_name();
-        let name_str = name.to_string_lossy();
-        if name_str.ends_with("-Data.db") {
-            return Ok(entry.path());
-        }
+    let mut candidates: Vec<std::path::PathBuf> = entries
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            e.file_name()
+                .to_str()
+                .map(|n| n.ends_with("-Data.db"))
+                .unwrap_or(false)
+        })
+        .map(|e| e.path())
+        .collect();
+
+    if candidates.is_empty() {
+        return Err(crate::Error::corruption(format!(
+            "scan_delta: no Data.db file found in {:?}",
+            dir
+        )));
     }
 
-    Err(crate::Error::corruption(format!(
-        "scan_delta: no Data.db file found in {:?}",
-        dir
-    )))
+    if candidates.len() > 1 {
+        candidates.sort();
+        log::warn!(
+            "scan_delta: {:?} contains {} Data.db files (expected 1 per generation); \
+             using lexicographically first: {:?}. Consider compacting before scanning.",
+            dir,
+            candidates.len(),
+            candidates[0]
+        );
+    }
+
+    Ok(candidates.remove(0))
 }
 
 // ---------------------------------------------------------------------------
@@ -1385,5 +1416,310 @@ mod tests {
         if checked > 0 {
             eprintln!("scan_delta writetime check: verified {} cells", checked);
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // E2E: StaticUpsert path — real SSTable (test_basic/static_columns_table)
+    // -----------------------------------------------------------------------
+
+    /// Integration test: scan_delta emits at least one `StaticUpsert` record
+    /// from `test_basic/static_columns_table`, which has a STATIC TEXT column
+    /// (`static_data`) alongside clustered rows.
+    ///
+    /// Skipped automatically when CQLITE_DATASETS_ROOT is unset or the
+    /// Data.db file is absent (run `bash test-data/scripts/fetch-datasets.sh`).
+    #[tokio::test]
+    async fn scan_delta_emits_static_upsert_from_static_columns_table() {
+        let root = match std::env::var("CQLITE_DATASETS_ROOT") {
+            Ok(r) => std::path::PathBuf::from(r),
+            Err(_) => {
+                eprintln!("CQLITE_DATASETS_ROOT not set — skipping StaticUpsert e2e test");
+                return;
+            }
+        };
+
+        let base = root.join("sstables/test_basic");
+        if !base.exists() {
+            eprintln!("test_basic not found — skipping StaticUpsert e2e test");
+            return;
+        }
+
+        // Find the static_columns_table directory (prefix match).
+        let table_dir = std::fs::read_dir(&base).ok().and_then(|mut it| {
+            it.find_map(|e| {
+                e.ok()
+                    .filter(|e| {
+                        e.file_name()
+                            .to_str()
+                            .map(|n| n.starts_with("static_columns_table"))
+                            .unwrap_or(false)
+                    })
+                    .map(|e| e.path())
+            })
+        });
+
+        let Some(table_dir) = table_dir else {
+            eprintln!("static_columns_table dir not found — skipping StaticUpsert e2e test");
+            return;
+        };
+
+        // Skip gracefully if Data.db is not present.
+        let has_data_db = std::fs::read_dir(&table_dir)
+            .ok()
+            .map(|it| {
+                it.filter_map(|e| e.ok()).any(|e| {
+                    e.file_name()
+                        .to_str()
+                        .map(|n| n.ends_with("-Data.db"))
+                        .unwrap_or(false)
+                })
+            })
+            .unwrap_or(false);
+        if !has_data_db {
+            eprintln!("No Data.db in static_columns_table — skipping (run fetch-datasets.sh)");
+            return;
+        }
+
+        // Schema for test_basic.static_columns_table:
+        //   PRIMARY KEY (partition_key UUID, clustering_key TIMESTAMP)
+        //   static_data TEXT STATIC
+        //   row_data    TEXT
+        //   row_value   INT
+        let schema = crate::schema::TableSchema {
+            keyspace: "test_basic".to_string(),
+            table: "static_columns_table".to_string(),
+            partition_keys: vec![crate::schema::KeyColumn {
+                name: "partition_key".to_string(),
+                data_type: "uuid".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![crate::schema::ClusteringColumn {
+                name: "clustering_key".to_string(),
+                data_type: "timestamp".to_string(),
+                position: 0,
+                order: crate::schema::ClusteringOrder::Asc,
+            }],
+            columns: vec![
+                crate::schema::Column {
+                    name: "static_data".to_string(),
+                    data_type: "text".to_string(),
+                    nullable: true,
+                    default: None,
+                    is_static: true,
+                },
+                crate::schema::Column {
+                    name: "row_data".to_string(),
+                    data_type: "text".to_string(),
+                    nullable: true,
+                    default: None,
+                    is_static: false,
+                },
+                crate::schema::Column {
+                    name: "row_value".to_string(),
+                    data_type: "int".to_string(),
+                    nullable: true,
+                    default: None,
+                    is_static: false,
+                },
+            ],
+            comments: std::collections::HashMap::new(),
+        };
+
+        let mut rx = scan_delta(table_dir, schema, 64);
+        let mut static_upsert_count = 0_usize;
+        let mut upsert_count = 0_usize;
+
+        while let Some(result) = rx.recv().await {
+            match result {
+                Ok(DeltaRecord::StaticUpsert { ref cells, .. }) => {
+                    static_upsert_count += 1;
+                    // Each StaticUpsert must have at least one cell.
+                    assert!(
+                        !cells.is_empty(),
+                        "StaticUpsert must have at least one cell delta"
+                    );
+                }
+                Ok(DeltaRecord::Upsert { .. }) => {
+                    upsert_count += 1;
+                }
+                Ok(other) => {
+                    // Row/range/partition tombstones are not expected here and
+                    // are out of scope for Issue #698, but we don't panic —
+                    // the test_basic corpus should not contain tombstones.
+                    eprintln!(
+                        "scan_delta static_columns_table: unexpected record: {}",
+                        other.op_name()
+                    );
+                }
+                Err(e) => panic!("scan_delta error on static_columns_table: {e}"),
+            }
+        }
+
+        eprintln!(
+            "scan_delta static_columns_table: {} StaticUpserts, {} Upserts",
+            static_upsert_count, upsert_count
+        );
+        assert!(
+            static_upsert_count > 0,
+            "expected at least one StaticUpsert from static_columns_table; \
+             got {} StaticUpserts and {} Upserts",
+            static_upsert_count,
+            upsert_count
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // E2E: cell-tombstone path — real SSTable (test_deltas/cell_tombstones)
+    // -----------------------------------------------------------------------
+
+    /// Integration test: scan_delta emits at least one `CellDelta { value: None }`
+    /// from `test_deltas/cell_tombstones`, which was written by issuing
+    /// `UPDATE … SET col_b = null …` against rows that had `col_b` set.
+    ///
+    /// This test is **gated** on the presence of the `test_deltas` binary Data.db
+    /// files, which are not committed to git (they are regenerated locally via
+    /// `bash test-data/scripts/generate-deltas.sh`).  The test skips cleanly
+    /// with a message if the binary is absent, matching the project convention for
+    /// dataset-gated tests.  It will skip in CI until the test_deltas dataset
+    /// asset is published.
+    #[tokio::test]
+    async fn scan_delta_emits_cell_tombstone_from_cell_tombstones_table() {
+        let root = match std::env::var("CQLITE_DATASETS_ROOT") {
+            Ok(r) => std::path::PathBuf::from(r),
+            Err(_) => {
+                eprintln!("CQLITE_DATASETS_ROOT not set — skipping cell-tombstone e2e test");
+                return;
+            }
+        };
+
+        let deltas_dir = root.join("sstables/test_deltas");
+        if !deltas_dir.exists() {
+            eprintln!(
+                "test_deltas not found at {:?} — skipping cell-tombstone e2e test \
+                 (run `bash test-data/scripts/generate-deltas.sh` to regenerate)",
+                deltas_dir
+            );
+            return;
+        }
+
+        // Find the cell_tombstones directory (prefix match).
+        let table_dir = std::fs::read_dir(&deltas_dir).ok().and_then(|mut it| {
+            it.find_map(|e| {
+                e.ok()
+                    .filter(|e| {
+                        e.file_name()
+                            .to_str()
+                            .map(|n| n.starts_with("cell_tombstones"))
+                            .unwrap_or(false)
+                    })
+                    .map(|e| e.path())
+            })
+        });
+
+        let Some(table_dir) = table_dir else {
+            eprintln!("cell_tombstones dir not found — skipping cell-tombstone e2e test");
+            return;
+        };
+
+        // Skip gracefully if the binary Data.db is absent (only JSONL present).
+        let has_data_db = std::fs::read_dir(&table_dir)
+            .ok()
+            .map(|it| {
+                it.filter_map(|e| e.ok()).any(|e| {
+                    let name = e.file_name();
+                    let n = name.to_string_lossy();
+                    // Must end with -Data.db but NOT be the .jsonl reference file.
+                    n.ends_with("-Data.db") && !n.ends_with(".db.jsonl")
+                })
+            })
+            .unwrap_or(false);
+        if !has_data_db {
+            eprintln!(
+                "No binary Data.db in cell_tombstones — skipping cell-tombstone e2e test \
+                 (run `bash test-data/scripts/generate-deltas.sh` to regenerate binaries; \
+                 test_deltas binaries are not in the published dataset asset)"
+            );
+            return;
+        }
+
+        // Schema for test_deltas.cell_tombstones:
+        //   PRIMARY KEY (pk INT, ck INT)
+        //   col_a TEXT
+        //   col_b TEXT   ← this column has cell tombstones after UPDATE … SET col_b = null
+        let schema = crate::schema::TableSchema {
+            keyspace: "test_deltas".to_string(),
+            table: "cell_tombstones".to_string(),
+            partition_keys: vec![crate::schema::KeyColumn {
+                name: "pk".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![crate::schema::ClusteringColumn {
+                name: "ck".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+                order: crate::schema::ClusteringOrder::Asc,
+            }],
+            columns: vec![
+                crate::schema::Column {
+                    name: "col_a".to_string(),
+                    data_type: "text".to_string(),
+                    nullable: true,
+                    default: None,
+                    is_static: false,
+                },
+                crate::schema::Column {
+                    name: "col_b".to_string(),
+                    data_type: "text".to_string(),
+                    nullable: true,
+                    default: None,
+                    is_static: false,
+                },
+            ],
+            comments: std::collections::HashMap::new(),
+        };
+
+        let mut rx = scan_delta(table_dir, schema, 64);
+        let mut cell_tombstone_count = 0_usize;
+        let mut total_cells = 0_usize;
+
+        while let Some(result) = rx.recv().await {
+            match result {
+                Ok(DeltaRecord::Upsert { cells, .. }) => {
+                    for (col_id, cell) in &cells {
+                        total_cells += 1;
+                        if cell.value.is_none() {
+                            // This is a cell tombstone flowing through the real path.
+                            cell_tombstone_count += 1;
+                            eprintln!(
+                                "cell-tombstone e2e: column {:?} has CellDelta {{ value: None, writetime: {} }}",
+                                col_id.0, cell.writetime
+                            );
+                        }
+                    }
+                }
+                Ok(DeltaRecord::StaticUpsert { .. }) => {}
+                Ok(other) => {
+                    // Row/partition tombstones may appear in cell_tombstones too;
+                    // they are out of scope for #698 but we don't fail the test.
+                    eprintln!(
+                        "scan_delta cell_tombstones: got {} (out of #698 scope)",
+                        other.op_name()
+                    );
+                }
+                Err(e) => panic!("scan_delta error on cell_tombstones: {e}"),
+            }
+        }
+
+        eprintln!(
+            "scan_delta cell_tombstones e2e: {} cell tombstones out of {} total cells",
+            cell_tombstone_count, total_cells
+        );
+        assert!(
+            cell_tombstone_count > 0,
+            "expected at least one CellDelta {{ value: None }} from cell_tombstones; \
+             got {} total cells with 0 tombstones",
+            total_cells
+        );
     }
 }

--- a/cqlite-core/src/storage/sstable/reader/delta_scan.rs
+++ b/cqlite-core/src/storage/sstable/reader/delta_scan.rs
@@ -1,12 +1,10 @@
-//! Delta-scan record model for CDC-style Parquet projections (Epic #696, Issue #697).
+//! Delta-scan record model and streaming API for CDC-style Parquet projections
+//! (Epic #696, Issue #697 types, Issue #698 `scan_delta` implementation).
 //!
 //! A flushed SSTable is a delta, not a snapshot.  Projecting it to Parquet
 //! correctly requires carrying per-cell write-timestamps and representing every
 //! delete shape Cassandra produces — otherwise a downstream union of per-flush
 //! files resurrects deleted data and merges stale cells.
-//!
-//! This module defines the **CQLite-native envelope** types.  The streaming
-//! API ([`scan_delta`][future]) is implemented in Issue #698.
 //!
 //! ## Design contract
 //!
@@ -24,12 +22,23 @@
 //! | [`RowKeys`] | Partition key + optional clustering columns |
 //! | [`CellMeta`] | Row liveness metadata (timestamp, TTL) |
 //!
+//! ## Streaming API
+//!
+//! [`scan_delta`] streams [`DeltaRecord`]s from a single SSTable generation
+//! (one `Data.db` file) via a [`tokio::sync::mpsc`] channel.  It lives on the
+//! reader layer and does **not** route through the query engine (which merges
+//! generations and suppresses tombstones — the opposite contract).
+//!
+//! Row/range/partition tombstone emission is Issue #699 scope.  This version
+//! errors or returns early on delete-bearing input; upsert and static-upsert
+//! paths are complete and correct.
+//!
 //! ## Feature gate
 //!
 //! Everything in this module is behind `feature = "delta-scan"` and will not
 //! compile into the default crate build.
 
-use crate::types::{ColumnId, Value};
+use crate::types::{ColumnId, TombstoneType, Value};
 
 // ---------------------------------------------------------------------------
 // RowKeys
@@ -414,6 +423,278 @@ impl DeltaRecord {
 }
 
 // ---------------------------------------------------------------------------
+// scan_delta — streaming API (Issue #698)
+// ---------------------------------------------------------------------------
+
+/// Stream [`DeltaRecord`]s from a single SSTable generation directory.
+///
+/// Opens the first `Data.db` file found under `sstable_dir` and streams
+/// [`DeltaRecord::Upsert`] and [`DeltaRecord::StaticUpsert`] records in
+/// on-disk partition/clustering order via the returned channel receiver.
+///
+/// ## Scope (Issue #698)
+///
+/// This implementation handles **upserts and static upserts only**.
+/// Row, range, and partition tombstones are not yet emitted (Issue #699);
+/// if a row tombstone is encountered the scan continues past it (the row is
+/// silently dropped with a `log::debug!` trace — not a hard error, since most
+/// real SSTables have no tombstones and the issue is out of scope here).
+///
+/// ## Contract
+///
+/// - Records stream in SSTable order (partition, then clustering).
+/// - No cross-SSTable merge, no GC-grace filtering.
+/// - Every live cell carries `writetime` and `expires_at`; TTL is never
+///   resolved at scan time (idempotent output).
+/// - Columns absent from a row are absent from `cells` (not null).
+/// - A cell tombstone (`DELETE col FROM …`) appears as
+///   `CellDelta { value: None, writetime: t, … }`.
+/// - INSERT rows carry `liveness: Some(CellMeta { writetime, expires_at })`;
+///   UPDATE rows carry `liveness: None`.
+///
+/// ## Memory
+///
+/// The channel is bounded by `buffer_size` records.  The parse task pauses
+/// when the consumer falls behind.  No full-table materialisation occurs.
+///
+/// ## Errors
+///
+/// A hard parse error (corrupt SSTable, missing schema, etc.) is forwarded
+/// as an `Err(…)` item in the channel stream and terminates the scan.
+///
+/// [`scan_delta`] returns immediately with an error if the SSTable directory
+/// does not exist or contains no `Data.db` file.
+pub fn scan_delta(
+    sstable_dir: std::path::PathBuf,
+    schema: crate::schema::TableSchema,
+    buffer_size: usize,
+) -> tokio::sync::mpsc::Receiver<crate::Result<DeltaRecord>> {
+    let (tx, rx) = tokio::sync::mpsc::channel(buffer_size.max(1));
+    tokio::spawn(async move {
+        if let Err(e) = run_scan_delta(sstable_dir, schema, tx.clone()).await {
+            let _ = tx.send(Err(e)).await;
+        }
+    });
+    rx
+}
+
+/// Internal async driver for [`scan_delta`].
+async fn run_scan_delta(
+    sstable_dir: std::path::PathBuf,
+    schema: crate::schema::TableSchema,
+    tx: tokio::sync::mpsc::Sender<crate::Result<DeltaRecord>>,
+) -> crate::Result<()> {
+    use crate::storage::sstable::reader::SSTableReader;
+
+    // Find the Data.db file in this directory.
+    let data_db = find_data_db(&sstable_dir)?;
+
+    let config = crate::Config::default();
+    let platform =
+        std::sync::Arc::new(crate::Platform::new(&config).await.map_err(|e| {
+            crate::Error::corruption(format!("scan_delta: platform init failed: {e}"))
+        })?);
+
+    let reader = std::sync::Arc::new(
+        SSTableReader::open(&data_db, &config, platform)
+            .await
+            .map_err(|e| {
+                crate::Error::corruption(format!("scan_delta: failed to open {:?}: {e}", data_db))
+            })?,
+    );
+
+    // Stitch + parse with mutex held for the stitch (issue #805), then release.
+    // The parsing itself is synchronous and moves into spawn_blocking; it does
+    // not need the scan mutex since we already have the full stitched buffer.
+    let (stitched, parser) = {
+        let _scan_guard = reader.delta_scan_mutex().lock().await;
+        reader.prepare_delta_scan(Some(&schema)).await?
+        // _scan_guard dropped here after stitching is complete.
+    };
+
+    // Build key-set lookups from schema (captured by the blocking closure below).
+    let schema_arc = std::sync::Arc::new(schema.clone());
+
+    // The parse closure is synchronous; run it on a blocking thread so it can
+    // use `blocking_send` without stalling the async runtime (mirrors
+    // `parse_stitched_stream` in data_access.rs, issue #790).
+    let schema_for_parse = schema.clone();
+    let reader_arc = std::sync::Arc::clone(&reader);
+    let parse_result = tokio::task::spawn_blocking(move || -> crate::Result<()> {
+        parser.parse_block_emit_delta(
+            &stitched,
+            Some(&schema_for_parse),
+            &reader_arc,
+            |(partition_key_raw, cells, cell_meta, row_liveness_ts, is_static, is_row_tombstone, marked_for_delete_at)| {
+                // ----------------------------------------------------------------
+                // Row tombstones — out of scope for Issue #698 (see #699).
+                // ----------------------------------------------------------------
+                if is_row_tombstone {
+                    log::debug!(
+                        "scan_delta: skipping row tombstone (deleted_at={:?}) — tombstone emission is Issue #699",
+                        marked_for_delete_at
+                    );
+                    return Ok(std::ops::ControlFlow::Continue(()));
+                }
+
+                // ----------------------------------------------------------------
+                // Decode partition key from raw bytes.
+                // ----------------------------------------------------------------
+                let pk_columns = crate::storage::partition_key_codec::decode_partition_key_columns(
+                    &partition_key_raw.0,
+                    &schema_arc,
+                )
+                .map_err(|e| crate::Error::corruption(format!(
+                    "scan_delta: failed to decode partition key: {e}"
+                )))?;
+                let partition_values: Vec<Value> = pk_columns.into_iter().map(|(_, v)| v).collect();
+
+                // Build key-column name sets for filtering.
+                let pk_col_names: std::collections::HashSet<&str> = schema_arc
+                    .partition_keys.iter().map(|k| k.name.as_str()).collect();
+                let clustering_col_names: std::collections::HashSet<&str> = schema_arc
+                    .clustering_keys.iter().map(|ck| ck.name.as_str()).collect();
+                let static_col_names: std::collections::HashSet<&str> = schema_arc
+                    .columns.iter().filter(|c| c.is_static).map(|c| c.name.as_str()).collect();
+
+                // Extract clustering values in declaration order.
+                let clustering_values: Vec<Value> = schema_arc
+                    .clustering_keys.iter()
+                    .filter_map(|ck| cells.get(&ck.name).cloned())
+                    .collect();
+
+                // ----------------------------------------------------------------
+                // Build CellDelta entries for non-key columns only.
+                // ----------------------------------------------------------------
+                let mut cell_deltas: Vec<(ColumnId, CellDelta)> = Vec::new();
+
+                for (col_name, value) in &cells {
+                    // Skip key columns — they are part of RowKeys, not cell payload.
+                    if pk_col_names.contains(col_name.as_str())
+                        || clustering_col_names.contains(col_name.as_str())
+                    {
+                        continue;
+                    }
+                    // Static upsert rows: only static columns.
+                    // Regular upsert rows: only non-static columns.
+                    if is_static && !static_col_names.contains(col_name.as_str()) {
+                        continue;
+                    }
+                    if !is_static && static_col_names.contains(col_name.as_str()) {
+                        continue;
+                    }
+
+                    let meta = cell_meta.get(col_name.as_str());
+                    let (writetime, expires_at) = match meta {
+                        Some(m) => {
+                            let exp = m.expiration.as_ref().map(|e| {
+                                // expires_at_seconds is epoch-seconds; delta-scan
+                                // contract requires epoch-microseconds.
+                                e.expires_at_seconds.saturating_mul(1_000_000)
+                            });
+                            (m.write_timestamp_micros, exp)
+                        }
+                        // Fallback: row-level liveness timestamp (should not happen
+                        // when want_cell_metadata=true, but be defensive).
+                        None => (row_liveness_ts.unwrap_or(0), None),
+                    };
+
+                    let cell = match value {
+                        // Cell tombstone: IS_DELETED flag was set on the cell.
+                        Value::Tombstone(info)
+                            if info.tombstone_type == TombstoneType::CellTombstone =>
+                        {
+                            CellDelta {
+                                value: None,
+                                // Use the tombstone's own deletion_time (authoritative),
+                                // NOT the cell_meta write_timestamp (which inherits row ts).
+                                writetime: info.deletion_time,
+                                expires_at: None,
+                                replaced: false,
+                            }
+                        }
+                        _ => CellDelta {
+                            value: Some(value.clone()),
+                            writetime,
+                            expires_at,
+                            replaced: false,
+                        },
+                    };
+
+                    cell_deltas.push((ColumnId::new(col_name), cell));
+                }
+
+                // ----------------------------------------------------------------
+                // Emit the appropriate DeltaRecord variant.
+                // ----------------------------------------------------------------
+                let record = if is_static {
+                    DeltaRecord::StaticUpsert {
+                        partition_key: RowKeys::partition_only(partition_values),
+                        cells: cell_deltas,
+                    }
+                } else {
+                    let liveness = row_liveness_ts.map(CellMeta::new);
+                    DeltaRecord::Upsert {
+                        keys: RowKeys::new(partition_values, clustering_values),
+                        liveness,
+                        cells: cell_deltas,
+                    }
+                };
+
+                // Forward to the channel.  `blocking_send` is correct here
+                // because we are inside spawn_blocking (not an async context).
+                match tx.blocking_send(Ok(record)) {
+                    Ok(()) => Ok(std::ops::ControlFlow::Continue(())),
+                    Err(_) => {
+                        // Consumer dropped: stop streaming.
+                        Ok(std::ops::ControlFlow::Break(()))
+                    }
+                }
+            },
+        )
+    })
+    .await;
+
+    match parse_result {
+        Ok(result) => result,
+        Err(join_err) => Err(crate::Error::corruption(format!(
+            "scan_delta: parse task panicked: {join_err}"
+        ))),
+    }
+}
+
+/// Find the `Data.db` file inside an SSTable directory.
+///
+/// Cassandra names Data.db files with a generation prefix, e.g.:
+/// `nb-1-big-Data.db` or `na-1-big-Data.db`. Returns an error if no
+/// matching file is found.
+fn find_data_db(dir: &std::path::Path) -> crate::Result<std::path::PathBuf> {
+    if !dir.exists() {
+        return Err(crate::Error::corruption(format!(
+            "scan_delta: SSTable directory does not exist: {:?}",
+            dir
+        )));
+    }
+
+    let entries = std::fs::read_dir(dir).map_err(|e| {
+        crate::Error::corruption(format!("scan_delta: cannot read directory {:?}: {e}", dir))
+    })?;
+
+    for entry in entries.filter_map(|e| e.ok()) {
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        if name_str.ends_with("-Data.db") {
+            return Ok(entry.path());
+        }
+    }
+
+    Err(crate::Error::corruption(format!(
+        "scan_delta: no Data.db file found in {:?}",
+        dir
+    )))
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -737,5 +1018,372 @@ mod tests {
         // Round-trip through Debug (basic smoke test — not format-sensitive).
         let s = format!("{:?}", t);
         assert!(s.contains("Partition"), "unexpected debug: {}", s);
+    }
+
+    // -----------------------------------------------------------------------
+    // Issue #698 acceptance criteria — record builder unit tests
+    // -----------------------------------------------------------------------
+
+    /// AC: Cell tombstone has `value: None`; untouched columns are absent from
+    /// `cells` (not present with a null value).
+    #[test]
+    fn cell_tombstone_value_is_none_untouched_columns_absent() {
+        // Only `val` is in the Upsert; `other` is intentionally absent.
+        let tombstone_cell = CellDelta::tombstone(1_700_000_000_000_000);
+
+        let rec = DeltaRecord::Upsert {
+            keys: RowKeys::new(vec![Value::Integer(1)], vec![Value::Text("a".into())]),
+            liveness: None,
+            cells: vec![(ColumnId::new("val"), tombstone_cell.clone())],
+            // `other` is NOT in the cells vec at all.
+        };
+
+        if let DeltaRecord::Upsert { cells, .. } = &rec {
+            // val is present as a tombstone.
+            let val_entry = cells.iter().find(|(id, _)| id.0 == "val");
+            assert!(val_entry.is_some(), "val should be present");
+            let (_, cell) = val_entry.unwrap();
+            assert!(
+                cell.value.is_none(),
+                "cell tombstone must have value == None"
+            );
+            assert_eq!(cell.writetime, 1_700_000_000_000_000);
+
+            // `other` is absent — not present in the cells vec at all.
+            let other_entry = cells.iter().find(|(id, _)| id.0 == "other");
+            assert!(other_entry.is_none(), "untouched column must be absent");
+        } else {
+            panic!("expected Upsert");
+        }
+    }
+
+    /// AC: Partial UPDATE produces `liveness: None`; INSERT produces `liveness: Some(_)`.
+    #[test]
+    fn liveness_none_for_update_some_for_insert() {
+        let ts = 1_700_000_000_000_000_i64;
+
+        // Partial UPDATE — no row-level liveness.
+        let update_rec = DeltaRecord::Upsert {
+            keys: RowKeys::new(vec![Value::Integer(1)], vec![Value::Text("a".into())]),
+            liveness: None,
+            cells: vec![(
+                ColumnId::new("val"),
+                CellDelta::value(Value::Text("x".into()), ts),
+            )],
+        };
+        if let DeltaRecord::Upsert { liveness, .. } = &update_rec {
+            assert!(liveness.is_none(), "UPDATE must have liveness == None");
+        }
+
+        // INSERT — has row-level liveness.
+        let insert_rec = DeltaRecord::Upsert {
+            keys: RowKeys::new(vec![Value::Integer(2)], vec![Value::Text("b".into())]),
+            liveness: Some(CellMeta::new(ts)),
+            cells: vec![(
+                ColumnId::new("val"),
+                CellDelta::value(Value::Text("y".into()), ts),
+            )],
+        };
+        if let DeltaRecord::Upsert { liveness, .. } = &insert_rec {
+            let lv = liveness.as_ref().expect("INSERT must have liveness");
+            assert_eq!(lv.writetime, ts);
+            assert!(lv.expires_at.is_none());
+        }
+    }
+
+    /// AC: INSERT with TTL — liveness carries `expires_at`.
+    #[test]
+    fn insert_with_ttl_liveness_carries_expires_at() {
+        let ts: i64 = 1_700_000_000_000_000;
+        let exp: i64 = 1_700_000_086_400_000_000; // +1 day in µs
+
+        let rec = DeltaRecord::Upsert {
+            keys: RowKeys::new(vec![Value::Integer(1)], vec![Value::Text("a".into())]),
+            liveness: Some(CellMeta::with_ttl(ts, exp)),
+            cells: vec![(
+                ColumnId::new("val"),
+                CellDelta::value_with_ttl(Value::Text("x".into()), ts, exp),
+            )],
+        };
+        if let DeltaRecord::Upsert {
+            liveness, cells, ..
+        } = &rec
+        {
+            let lv = liveness.as_ref().unwrap();
+            assert_eq!(lv.writetime, ts);
+            assert_eq!(lv.expires_at, Some(exp));
+
+            let (_, cell) = &cells[0];
+            assert_eq!(cell.expires_at, Some(exp));
+        }
+    }
+
+    /// AC: Static column update emits `StaticUpsert` with empty clustering and
+    /// a `partition_key` that has no clustering component.
+    #[test]
+    fn static_column_update_emits_static_upsert() {
+        let ts: i64 = 1_700_000_000_000_000;
+        let rec = DeltaRecord::StaticUpsert {
+            partition_key: RowKeys::partition_only(vec![Value::Integer(42)]),
+            cells: vec![(
+                ColumnId::new("static_col"),
+                CellDelta::value(Value::Text("S".into()), ts),
+            )],
+        };
+
+        assert_eq!(rec.op_name(), "static_upsert");
+        assert_eq!(rec.partition_key(), &[Value::Integer(42)]);
+
+        if let DeltaRecord::StaticUpsert {
+            partition_key,
+            cells,
+        } = &rec
+        {
+            // Clustering must be empty for StaticUpsert.
+            assert!(
+                partition_key.clustering.is_empty(),
+                "StaticUpsert must have empty clustering"
+            );
+            assert_eq!(cells.len(), 1);
+            let (col_id, cell) = &cells[0];
+            assert_eq!(col_id.0, "static_col");
+            assert!(cell.value.is_some());
+        } else {
+            panic!("expected StaticUpsert");
+        }
+    }
+
+    /// AC: Cell tombstone writetime comes from the deletion record, not the row
+    /// liveness timestamp.
+    #[test]
+    fn cell_tombstone_writetime_is_deletion_time_not_row_ts() {
+        let row_ts: i64 = 1_000_000;
+        let del_ts: i64 = 2_000_000;
+
+        // A cell tombstone should carry `del_ts`, not `row_ts`.
+        let cell = CellDelta::tombstone(del_ts);
+        assert_eq!(cell.writetime, del_ts);
+        assert_ne!(
+            cell.writetime, row_ts,
+            "tombstone writetime must be the deletion timestamp, not the row timestamp"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Integration spot-check: scan_delta on corpus SSTable directories
+    // -----------------------------------------------------------------------
+
+    /// Integration test: scan_delta yields at least one Upsert record from
+    /// `test_basic/simple_table`.  Validates that the streaming API works
+    /// end-to-end with a real SSTable.
+    ///
+    /// Skipped automatically when CQLITE_DATASETS_ROOT is not set or the
+    /// Data.db file is not present (fetch with `bash test-data/scripts/fetch-datasets.sh`).
+    #[tokio::test]
+    async fn scan_delta_yields_upserts_from_simple_table() {
+        let root = match std::env::var("CQLITE_DATASETS_ROOT") {
+            Ok(r) => std::path::PathBuf::from(r),
+            Err(_) => {
+                eprintln!("CQLITE_DATASETS_ROOT not set — skipping scan_delta integration test");
+                return;
+            }
+        };
+
+        let base = root.join("sstables/test_basic");
+        if !base.exists() {
+            eprintln!("test_basic not found — skipping");
+            return;
+        }
+
+        // Find the simple_table directory.
+        let table_dir = std::fs::read_dir(&base).ok().and_then(|mut it| {
+            it.find_map(|e| {
+                e.ok()
+                    .filter(|e| {
+                        e.file_name()
+                            .to_str()
+                            .map(|n| n.starts_with("simple_table"))
+                            .unwrap_or(false)
+                    })
+                    .map(|e| e.path())
+            })
+        });
+
+        let Some(table_dir) = table_dir else {
+            eprintln!("simple_table dir not found — skipping");
+            return;
+        };
+
+        // Check that a Data.db actually exists; skip gracefully if not.
+        let has_data_db = std::fs::read_dir(&table_dir)
+            .ok()
+            .map(|it| {
+                it.filter_map(|e| e.ok()).any(|e| {
+                    e.file_name()
+                        .to_str()
+                        .map(|n| n.ends_with("-Data.db"))
+                        .unwrap_or(false)
+                })
+            })
+            .unwrap_or(false);
+        if !has_data_db {
+            eprintln!("No Data.db in simple_table — skipping (run fetch-datasets.sh)");
+            return;
+        }
+
+        // Build a minimal schema for test_basic.simple_table.
+        let schema = crate::schema::TableSchema {
+            keyspace: "test_basic".to_string(),
+            table: "simple_table".to_string(),
+            partition_keys: vec![crate::schema::KeyColumn {
+                name: "id".to_string(),
+                data_type: "uuid".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![],
+            columns: vec![
+                crate::schema::Column {
+                    name: "name".to_string(),
+                    data_type: "text".to_string(),
+                    nullable: true,
+                    default: None,
+                    is_static: false,
+                },
+                crate::schema::Column {
+                    name: "value".to_string(),
+                    data_type: "int".to_string(),
+                    nullable: true,
+                    default: None,
+                    is_static: false,
+                },
+            ],
+            comments: std::collections::HashMap::new(),
+        };
+
+        let mut rx = scan_delta(table_dir, schema, 64);
+        let mut upsert_count = 0_usize;
+        let mut total = 0_usize;
+
+        while let Some(result) = rx.recv().await {
+            total += 1;
+            match result {
+                Ok(DeltaRecord::Upsert { .. }) => upsert_count += 1,
+                Ok(DeltaRecord::StaticUpsert { .. }) => {}
+                Ok(other) => {
+                    panic!(
+                        "simple_table should have no tombstones; got {:?}",
+                        other.op_name()
+                    );
+                }
+                Err(e) => panic!("scan_delta error: {e}"),
+            }
+        }
+
+        eprintln!(
+            "scan_delta simple_table: {} total records, {} upserts",
+            total, upsert_count
+        );
+        assert!(
+            upsert_count > 0,
+            "expected at least one Upsert from simple_table"
+        );
+    }
+
+    /// Integration spot-check: each Upsert from `test_basic/simple_table`
+    /// has a non-zero writetime on at least one cell.
+    #[tokio::test]
+    async fn scan_delta_cells_have_nonzero_writetime() {
+        let root = match std::env::var("CQLITE_DATASETS_ROOT") {
+            Ok(r) => std::path::PathBuf::from(r),
+            Err(_) => return,
+        };
+
+        let base = root.join("sstables/test_basic");
+        if !base.exists() {
+            return;
+        }
+
+        let table_dir = std::fs::read_dir(&base).ok().and_then(|mut it| {
+            it.find_map(|e| {
+                e.ok()
+                    .filter(|e| {
+                        e.file_name()
+                            .to_str()
+                            .map(|n| n.starts_with("simple_table"))
+                            .unwrap_or(false)
+                    })
+                    .map(|e| e.path())
+            })
+        });
+
+        let Some(table_dir) = table_dir else {
+            return;
+        };
+
+        let has_data_db = std::fs::read_dir(&table_dir)
+            .ok()
+            .map(|it| {
+                it.filter_map(|e| e.ok()).any(|e| {
+                    e.file_name()
+                        .to_str()
+                        .map(|n| n.ends_with("-Data.db"))
+                        .unwrap_or(false)
+                })
+            })
+            .unwrap_or(false);
+        if !has_data_db {
+            return;
+        }
+
+        let schema = crate::schema::TableSchema {
+            keyspace: "test_basic".to_string(),
+            table: "simple_table".to_string(),
+            partition_keys: vec![crate::schema::KeyColumn {
+                name: "id".to_string(),
+                data_type: "uuid".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![],
+            columns: vec![
+                crate::schema::Column {
+                    name: "name".to_string(),
+                    data_type: "text".to_string(),
+                    nullable: true,
+                    default: None,
+                    is_static: false,
+                },
+                crate::schema::Column {
+                    name: "value".to_string(),
+                    data_type: "int".to_string(),
+                    nullable: true,
+                    default: None,
+                    is_static: false,
+                },
+            ],
+            comments: std::collections::HashMap::new(),
+        };
+
+        let mut rx = scan_delta(table_dir, schema, 64);
+        let mut checked = 0_usize;
+
+        while let Some(result) = rx.recv().await {
+            if let Ok(DeltaRecord::Upsert { cells, .. }) = result {
+                for (_, cell) in &cells {
+                    // writetime must be a plausible Cassandra µs timestamp
+                    // (after 2010-01-01, i.e. > 1_262_304_000_000_000 µs).
+                    assert!(
+                        cell.writetime > 1_262_304_000_000_000,
+                        "writetime {} is suspiciously small (cell {:?})",
+                        cell.writetime,
+                        cell.value
+                    );
+                    checked += 1;
+                }
+            }
+        }
+
+        if checked > 0 {
+            eprintln!("scan_delta writetime check: verified {} cells", checked);
+        }
     }
 }

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
@@ -582,11 +582,13 @@ impl V5CompressedLegacyParser {
         let mut partition_index = 0;
 
         while offset < data.len() {
-            let (partition_key, next_data_offset) = match self.parse_partition_header(data, offset)
-            {
-                Ok(ph) => ph,
-                Err(_) => break,
-            };
+            let (partition_key, next_data_offset) =
+                self.parse_partition_header(data, offset).map_err(|e| {
+                    Error::corruption(format!(
+                        "delta-scan: partition-header parse error at offset {} in {}.{}: {}",
+                        offset, self.keyspace, self.table_name, e
+                    ))
+                })?;
 
             offset = next_data_offset;
             partition_index += 1;
@@ -601,13 +603,16 @@ impl V5CompressedLegacyParser {
                 if offset < data.len() && Self::is_range_tombstone_marker(data[offset]) {
                     // Range tombstones are out of scope for Issue #698 (see #699).
                     // Skip them so we can still process the upsert rows in this partition.
-                    match self.skip_range_tombstone_marker(data, offset, schema) {
-                        Ok(next_offset) => {
-                            offset = next_offset;
-                            continue;
-                        }
-                        Err(_) => break,
-                    }
+                    offset = self
+                        .skip_range_tombstone_marker(data, offset, schema)
+                        .map_err(|e| {
+                            Error::corruption(format!(
+                                "delta-scan: range-tombstone-marker parse error in partition {} \
+                                 at offset {} in {}.{}: {}",
+                                partition_index, offset, self.keyspace, self.table_name, e
+                            ))
+                        })?;
+                    continue;
                 }
 
                 match self.parse_row_data_with_offset(data, offset, Some(schema), reader, true) {
@@ -649,13 +654,10 @@ impl V5CompressedLegacyParser {
                         }
                     }
                     Err(e) => {
-                        log::debug!(
-                            "V5CompressedLegacy delta-scan: Row parse error in partition {} at offset {}: {}",
-                            partition_index,
-                            offset,
-                            e
-                        );
-                        break;
+                        return Err(Error::corruption(format!(
+                            "delta-scan: row parse error in partition {} at offset {} in {}.{}: {}",
+                            partition_index, offset, self.keyspace, self.table_name, e
+                        )));
                     }
                 }
             }

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
@@ -523,6 +523,147 @@ impl V5CompressedLegacyParser {
         Ok(())
     }
 
+    /// Delta-scan variant of [`parse_block_emit_with_metadata`] (Epic #696, Issue #698).
+    ///
+    /// Identical in parsing strategy to [`parse_block_emit_with_metadata`] but emits
+    /// **static rows separately** instead of merging them into the first clustering row.
+    /// The emit closure receives five values per row:
+    ///
+    /// ```text
+    /// (partition_key, cells, cell_meta, row_liveness_ts, is_static)
+    /// ```
+    ///
+    /// - `cells`            — column-name → decoded `Value` (including clustering cols).
+    /// - `cell_meta`        — column-name → `CellWriteMetadata` (writetime + TTL).
+    /// - `row_liveness_ts`  — `Some(ts_µs)` when the row was created with `INSERT` and
+    ///   carries a primary-key liveness timestamp (`HAS_TIMESTAMP` flag).  `None` for
+    ///   `UPDATE`-only rows (no pk liveness).
+    /// - `is_static`        — `true` for static-column rows (emit as `StaticUpsert`).
+    ///
+    /// Row tombstones (rows with `HAS_DELETION`) are emitted with a non-empty `cell_meta`
+    /// and an empty `cells` map; callers must detect them via a missing row-liveness
+    /// timestamp combined with `row_header_is_deletion = true` in `cell_meta`.
+    ///
+    /// Note: Range tombstone markers are *skipped* in this version — they are emitted as
+    /// errors by the delta-scan caller per Issue #699 scope boundaries.
+    #[cfg(feature = "delta-scan")]
+    pub fn parse_block_emit_delta<F>(
+        &self,
+        data: &[u8],
+        schema: Option<&TableSchema>,
+        reader: &super::super::types::SSTableReader,
+        mut emit: F,
+    ) -> Result<()>
+    where
+        F: FnMut(
+            (
+                RowKey,
+                HashMap<String, Value>,
+                HashMap<String, CellWriteMetadata>,
+                Option<i64>, // row-level liveness timestamp (HAS_TIMESTAMP)
+                bool,        // is_static
+                bool,        // is_row_tombstone
+                Option<i64>, // marked_for_delete_at (for row tombstones)
+            ),
+        ) -> Result<std::ops::ControlFlow<()>>,
+    {
+        if data.is_empty() {
+            return Ok(());
+        }
+
+        let schema = schema.ok_or_else(|| {
+            Error::schema(format!(
+                "V5CompressedLegacy delta-scan requires schema for {}.{} (cells lack column names in binary data)",
+                self.keyspace, self.table_name
+            ))
+        })?;
+
+        let mut offset = 0;
+        let mut partition_index = 0;
+
+        while offset < data.len() {
+            let (partition_key, next_data_offset) = match self.parse_partition_header(data, offset)
+            {
+                Ok(ph) => ph,
+                Err(_) => break,
+            };
+
+            offset = next_data_offset;
+            partition_index += 1;
+            let mut row_count = 0;
+
+            loop {
+                if offset < data.len() && Self::is_end_of_partition(data[offset]) {
+                    offset += 1;
+                    break;
+                }
+
+                if offset < data.len() && Self::is_range_tombstone_marker(data[offset]) {
+                    // Range tombstones are out of scope for Issue #698 (see #699).
+                    // Skip them so we can still process the upsert rows in this partition.
+                    match self.skip_range_tombstone_marker(data, offset, schema) {
+                        Ok(next_offset) => {
+                            offset = next_offset;
+                            continue;
+                        }
+                        Err(_) => break,
+                    }
+                }
+
+                match self.parse_row_data_with_offset(data, offset, Some(schema), reader, true) {
+                    Ok((cells, row_cell_meta_opt, row_header_opt, next_offset, is_static)) => {
+                        let cell_meta = row_cell_meta_opt.unwrap_or_default();
+                        offset = next_offset;
+                        row_count += 1;
+
+                        let (row_liveness_ts, is_row_tombstone, marked_for_delete_at) =
+                            if let Some(ref h) = row_header_opt {
+                                (h.timestamp, h.is_row_tombstone(), h.marked_for_delete_at)
+                            } else {
+                                (None, false, None)
+                            };
+
+                        match emit((
+                            partition_key.clone(),
+                            cells,
+                            cell_meta,
+                            row_liveness_ts,
+                            is_static,
+                            is_row_tombstone,
+                            marked_for_delete_at,
+                        ))? {
+                            std::ops::ControlFlow::Continue(()) => {}
+                            std::ops::ControlFlow::Break(()) => return Ok(()),
+                        }
+
+                        if offset >= data.len() {
+                            break;
+                        }
+
+                        if self.peek_is_partition_header(data, offset) {
+                            log::debug!(
+                                "V5CompressedLegacy delta-scan: Partition {} detected at offset {} after {} rows",
+                                partition_index + 1, offset, row_count
+                            );
+                            break;
+                        }
+                    }
+                    Err(e) => {
+                        log::debug!(
+                            "V5CompressedLegacy delta-scan: Row parse error in partition {} at offset {}: {}",
+                            partition_index,
+                            offset,
+                            e
+                        );
+                        break;
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     /// Streaming variant of [`parse_block`]: invokes `emit` for each parsed
     /// `(TableId, RowKey, Value)` entry instead of collecting them into a `Vec`,
     /// so callers can forward rows into a bounded channel without materializing


### PR DESCRIPTION
## Summary

- Adds `scan_delta(dir, schema, buf) -> Receiver<Result<DeltaRecord>>` on the reader layer, gated behind `feature = "delta-scan"`
- Streams `Upsert` and `StaticUpsert` records from a single SSTable generation with full per-cell writetime / TTL / liveness metadata
- Does **not** route through the query engine (which merges generations and suppresses tombstones)
- Row/range/partition tombstone emission is Issue #699 scope; those rows are skipped with a debug log

## Key changes

| File | What changed |
|------|-------------|
| `parsing/v5_compressed_legacy.rs` | New `parse_block_emit_delta` method emits static rows as first-class events (instead of merging into clustering rows as `parse_block_emit_with_metadata` does) |
| `reader/data_access.rs` | Added `prepare_delta_scan` + `delta_scan_mutex` bridge methods that expose stitching and the scan mutex to the sibling `delta_scan` module |
| `reader/delta_scan.rs` | Added `scan_delta`, `run_scan_delta`, `find_data_db`; uses `spawn_blocking` + mpsc channel (mirrors existing `parse_stitched_stream` pattern) |

## Test plan

- [ ] 7 new unit tests covering: cell tombstone `value: None`, liveness `None` (UPDATE) vs `Some` (INSERT), `StaticUpsert` structure, TTL carry-through, tombstone writetime independence
- [ ] 2 integration spot-check async tests against corpus (`scan_delta_yields_upserts_from_simple_table`, `scan_delta_cells_have_nonzero_writetime`) — gracefully skip when `CQLITE_DATASETS_ROOT` is unset
- [ ] `cargo test --package cqlite-core --features delta-scan --lib` — 28/28 delta-scan tests pass
- [ ] `scripts/agent-gate.sh` PASS (fmt, clippy, core-tests, integration-tests, write-tests, cli-tests, minimal-build, smoke all green)