### PR TITLE
fix(read): cross-generation LWW merge + tombstone suppression on SELECT* (closes #883)

### DIFF
--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -874,6 +874,41 @@ impl SSTableManager {
                 table_id
             );
 
+            // Issue #883: when a table directory holds more than one SSTable
+            // generation, plain concatenation of each reader's live rows is wrong —
+            // it duplicates rows that exist in several generations and resurrects
+            // rows deleted in a later generation (each reader suppresses only its
+            // OWN tombstones). Reconcile across generations with the same
+            // last-write-wins + tombstone-shadowing rule compaction uses, reusing
+            // the authoritative k-way merger (write-support only; requires schema).
+            #[cfg(feature = "write-support")]
+            if reader_list.len() > 1 {
+                if let Some(schema) = schema {
+                    match self
+                        .merge_generations_for_read(reader_list, schema, limit)
+                        .await
+                    {
+                        Ok(merged) => {
+                            log::debug!(
+                                "SSTableManager::scan - cross-generation merge produced {} rows",
+                                merged.len()
+                            );
+                            return Ok(merged);
+                        }
+                        Err(e) => {
+                            // Never fail a read because the merge path hit an
+                            // unsupported format; fall back to concatenation.
+                            log::warn!(
+                                "SSTableManager::scan - cross-generation merge failed for '{}' ({}); \
+                                 falling back to per-reader concatenation",
+                                table_id,
+                                e
+                            );
+                        }
+                    }
+                }
+            }
+
             let mut all_results = Vec::new();
 
             for reader in reader_list {
@@ -924,6 +959,82 @@ impl SSTableManager {
             );
             Ok(Vec::new())
         }
+    }
+
+    /// Reconcile multiple SSTable generations of one table into the single
+    /// authoritative live-row set, matching Cassandra read semantics (Issue #883).
+    ///
+    /// Plain `scan` concatenates each reader's live rows, which is only correct
+    /// for a single generation. With several generations in a table directory
+    /// (successive flushes), the same `(partition, clustering)` row can appear in
+    /// more than one generation, and a row/cell deleted in a later generation is
+    /// suppressed only inside the generation that holds its tombstone — so the
+    /// older generation's copy leaks back into the result.
+    ///
+    /// This drives the same [`KWayMerger`](crate::storage::write_engine::KWayMerger)
+    /// the compaction path uses, so reconciliation is byte-for-byte the
+    /// last-write-wins + tombstone-shadowing logic (`merge_partition_rows`):
+    /// per-cell LWW by write timestamp, row/cell tombstones shadow older cells,
+    /// and fully-deleted rows are dropped. The merger manages its own reader
+    /// threads/runtimes internally, so it runs on a blocking task.
+    ///
+    /// Requires a schema (cells carry no column names on disk) and the
+    /// `write-support` feature (the merger lives in the write engine). Callers
+    /// fall back to concatenation when either is unavailable.
+    #[cfg(all(not(feature = "tombstones"), feature = "write-support"))]
+    async fn merge_generations_for_read(
+        &self,
+        reader_list: &[Arc<reader::SSTableReader>],
+        schema: &crate::schema::TableSchema,
+        limit: Option<usize>,
+    ) -> Result<Vec<(RowKey, Value)>> {
+        use crate::storage::write_engine::merge::{KWayMerger, MergeStep, RowData};
+
+        // The merger expects inputs ordered newest → oldest (run_index 0 = newest)
+        // for its stable tie-break; the reader Vec order is discovery-dependent, so
+        // sort explicitly by generation descending.
+        let mut ordered: Vec<&Arc<reader::SSTableReader>> = reader_list.iter().collect();
+        ordered.sort_by(|a, b| b.generation.cmp(&a.generation));
+        let paths: Vec<PathBuf> = ordered.iter().map(|r| r.file_path.clone()).collect();
+        let schema = schema.clone();
+
+        let mut merged = tokio::task::spawn_blocking(move || -> Result<Vec<(RowKey, Value)>> {
+            let mut merger = KWayMerger::new(paths, &schema)?;
+            let mut out = Vec::new();
+            while let MergeStep::Partition { key, rows } = merger.step()? {
+                for entry in rows {
+                    match entry.row_data {
+                        RowData::Live { cells } => {
+                            // Drop cell tombstones: a deleted column must be
+                            // absent from the merged row, not surfaced.
+                            let map: Vec<(Value, Value)> = cells
+                                .into_iter()
+                                .filter(|c| !matches!(c.value, Value::Tombstone(_)))
+                                .map(|c| (Value::Text(c.column), c.value))
+                                .collect();
+                            if !map.is_empty() {
+                                out.push((RowKey(key.key.clone()), Value::Map(map)));
+                            }
+                        }
+                        // Row tombstone: the row is deleted across all
+                        // generations — suppress it entirely.
+                        RowData::Tombstone { .. } => {}
+                    }
+                }
+            }
+            Ok(out)
+        })
+        .await
+        .map_err(|e| crate::Error::Storage(format!("cross-generation read merge task: {e}")))??;
+
+        // Match the plain-scan contract: sort by key bytes, then apply LIMIT. The
+        // merger already emits partitions in token order with clustering rows in
+        // order within a partition; a stable sort by key preserves that grouping.
+        merged.sort_by(|a, b| a.0.cmp(&b.0));
+        if let Some(limit) = limit {
+            merged.truncate(limit);
+        }
+        Ok(merged)
     }
 
     /// Scan a table and return per-cell write metadata alongside row values.

--- a/cqlite-core/tests/issue_883_cross_generation_read_merge.rs
+++ b/cqlite-core/tests/issue_883_cross_generation_read_merge.rs
@@ -1,0 +1,267 @@
+//! Issue #883: `SELECT *` over a table directory holding multiple SSTable
+//! generations must reproduce the fully-merged authoritative table state —
+//! cross-generation last-write-wins plus row/cell tombstone suppression —
+//! matching Cassandra read semantics.
+//!
+//! Before the fix, the read path concatenated each generation's live rows: a row
+//! present in several generations was duplicated, and a row/cell deleted in a
+//! LATER generation leaked back in because each reader suppresses only its own
+//! tombstones. This test writes three generations via the public WriteEngine API
+//! (flushing between each, with NO compaction), then scans through
+//! `SSTableManager` and asserts the reconciled live-row set.
+//!
+//! Run with:
+//!   CQLITE_DATASETS_ROOT=$PWD/test-data/datasets \
+//!     cargo test --package cqlite-core --features write-support \
+//!     --test issue_883_cross_generation_read_merge
+
+#![cfg(feature = "write-support")]
+
+use cqlite_core::platform::Platform;
+use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+use cqlite_core::storage::sstable::SSTableManager;
+use cqlite_core::storage::write_engine::{
+    CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::TableId as CqlTableId;
+use cqlite_core::types::Value;
+use cqlite_core::Config;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tempfile::TempDir;
+
+const KS: &str = "gen_ks";
+const TBL: &str = "items";
+
+fn make_schema() -> TableSchema {
+    TableSchema {
+        keyspace: KS.to_string(),
+        table: TBL.to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            Column {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "name".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "score".to_string(),
+                data_type: "int".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+    }
+}
+
+fn write_row(id: i32, name: &str, score: i32, ts: i64) -> Mutation {
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    let ops = vec![
+        CellOperation::Write {
+            column: "name".to_string(),
+            value: Value::Text(name.to_string()),
+        },
+        CellOperation::Write {
+            column: "score".to_string(),
+            value: Value::Integer(score),
+        },
+    ];
+    Mutation::new(TableId::new(KS, TBL), pk, None, ops, ts, None)
+}
+
+/// Write only the `name` column — used to prove disjoint columns survive across
+/// generations (the older generation's `score` must NOT be dropped).
+fn write_name_only(id: i32, name: &str, ts: i64) -> Mutation {
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    let ops = vec![CellOperation::Write {
+        column: "name".to_string(),
+        value: Value::Text(name.to_string()),
+    }];
+    Mutation::new(TableId::new(KS, TBL), pk, None, ops, ts, None)
+}
+
+fn delete_row(id: i32, ts: i64) -> Mutation {
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    Mutation::new(
+        TableId::new(KS, TBL),
+        pk,
+        None,
+        vec![CellOperation::DeleteRow],
+        ts,
+        None,
+    )
+}
+
+fn delete_score_column(id: i32, ts: i64) -> Mutation {
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    let ops = vec![CellOperation::Delete {
+        column: "score".to_string(),
+    }];
+    Mutation::new(TableId::new(KS, TBL), pk, None, ops, ts, None)
+}
+
+fn count_data_files(dir: &std::path::Path) -> usize {
+    std::fs::read_dir(dir)
+        .expect("read sstable dir")
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_name().to_string_lossy().ends_with("-big-Data.db"))
+        .count()
+}
+
+/// Extract a column value from a scan row (`Value::Map` of `(Text(col), value)`).
+fn col<'a>(row: &'a Value, name: &str) -> Option<&'a Value> {
+    match row {
+        Value::Map(pairs) => pairs.iter().find_map(|(k, v)| match k {
+            Value::Text(c) if c == name => Some(v),
+            _ => None,
+        }),
+        _ => None,
+    }
+}
+
+#[test]
+fn select_star_merges_generations_with_lww_and_tombstone_suppression() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build tokio runtime");
+
+    let temp_dir = TempDir::new().unwrap();
+    let data_dir = temp_dir.path().join("data");
+    let wal_dir = temp_dir.path().join("wal");
+    let schema = make_schema();
+
+    // ── Write three generations, flushing between each (no compaction) ─────────
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir.clone(), schema.clone());
+    let mut engine = WriteEngine::new(config).expect("engine creation");
+
+    // Gen 1 (ts=100): PK 1..=4, each name+score.
+    engine.write(write_row(1, "n1-v1", 11, 100)).unwrap();
+    engine.write(write_row(2, "n2-v1", 22, 100)).unwrap();
+    engine.write(write_row(3, "n3-v1", 33, 100)).unwrap();
+    engine.write(write_row(4, "n4-v1", 44, 100)).unwrap();
+    rt.block_on(engine.flush()).expect("flush 1").expect("gen1");
+
+    // Gen 2 (ts=200): PK1 name-only update (disjoint), PK3 full overwrite, PK5 new.
+    engine.write(write_name_only(1, "n1-v2", 200)).unwrap();
+    engine.write(write_row(3, "n3-v2", 333, 200)).unwrap();
+    engine.write(write_row(5, "n5-v2", 55, 200)).unwrap();
+    rt.block_on(engine.flush()).expect("flush 2").expect("gen2");
+
+    // Gen 3 (ts=300): row-delete PK2, cell-delete score@PK4, PK6 new.
+    engine.write(delete_row(2, 300)).unwrap();
+    engine.write(delete_score_column(4, 300)).unwrap();
+    engine.write(write_row(6, "n6-v3", 66, 300)).unwrap();
+    rt.block_on(engine.flush()).expect("flush 3").expect("gen3");
+
+    rt.block_on(engine.close()).expect("close engine");
+
+    // Precondition: three distinct generations are on disk (no compaction ran).
+    let sstable_dir = data_dir.join(KS).join(TBL);
+    assert_eq!(
+        count_data_files(&sstable_dir),
+        3,
+        "test must exercise a multi-generation directory"
+    );
+
+    // ── Reopen and scan ───────────────────────────────────────────────────────
+    let cqlite_config = Config::default();
+    let manager = rt.block_on(async {
+        let platform = Arc::new(Platform::new(&cqlite_config).await.expect("platform"));
+        SSTableManager::new(
+            &data_dir,
+            &cqlite_config,
+            platform,
+            #[cfg(feature = "state_machine")]
+            None,
+        )
+        .await
+        .expect("SSTableManager open")
+    });
+
+    let table_id = CqlTableId::from(format!("{KS}.{TBL}").as_str());
+    let results = rt
+        .block_on(manager.scan(&table_id, None, None, None, Some(&schema)))
+        .expect("scan must not error");
+
+    // ── Reconciled state: live rows are exactly {1, 3, 4, 5, 6} ───────────────
+    // Before the fix this scan returned duplicates (PK1/PK3 from several
+    // generations) and resurrected PK2/score@PK4 from gen1.
+    let by_pk: HashMap<Vec<u8>, Value> = results
+        .iter()
+        .map(|(k, v)| (k.0.clone(), v.clone()))
+        .collect();
+
+    assert_eq!(
+        results.len(),
+        by_pk.len(),
+        "no duplicate partition keys across generations (got {} rows, {} distinct)",
+        results.len(),
+        by_pk.len()
+    );
+    assert_eq!(
+        results.len(),
+        5,
+        "expected exactly 5 live rows after cross-generation merge, got {}",
+        results.len()
+    );
+
+    let pk = |id: i32| -> Vec<u8> { id.to_be_bytes().to_vec() };
+
+    // PK2 row-deleted in gen3 (ts=300) — must NOT resurrect from gen1 (ts=100).
+    assert!(
+        !by_pk.contains_key(&pk(2)),
+        "PK2 was row-deleted in a later generation; it must be suppressed"
+    );
+
+    // PK1: disjoint columns merge across generations — name from gen2, score from gen1.
+    let row1 = by_pk.get(&pk(1)).expect("PK1 present");
+    assert_eq!(
+        col(row1, "name"),
+        Some(&Value::Text("n1-v2".to_string())),
+        "PK1 name must be the gen2 (newer) value"
+    );
+    assert_eq!(
+        col(row1, "score"),
+        Some(&Value::Integer(11)),
+        "PK1 score (written only in gen1) must survive the name-only gen2 update"
+    );
+
+    // PK3: full overwrite — gen2 wins both columns.
+    let row3 = by_pk.get(&pk(3)).expect("PK3 present");
+    assert_eq!(col(row3, "name"), Some(&Value::Text("n3-v2".to_string())));
+    assert_eq!(col(row3, "score"), Some(&Value::Integer(333)));
+
+    // PK4: cell-delete of score in gen3 shadows gen1's score; name survives.
+    let row4 = by_pk.get(&pk(4)).expect("PK4 present");
+    assert_eq!(col(row4, "name"), Some(&Value::Text("n4-v1".to_string())));
+    assert!(
+        col(row4, "score").is_none(),
+        "PK4 score was cell-deleted in a later generation; it must be absent, got {:?}",
+        col(row4, "score")
+    );
+
+    // PK5 / PK6: single-generation rows pass through unchanged.
+    let row5 = by_pk.get(&pk(5)).expect("PK5 present");
+    assert_eq!(col(row5, "score"), Some(&Value::Integer(55)));
+    let row6 = by_pk.get(&pk(6)).expect("PK6 present");
+    assert_eq!(col(row6, "score"), Some(&Value::Integer(66)));
+
+    drop(temp_dir);
+}


### PR DESCRIPTION
## Problem (#883)

When a table directory holds multiple SSTable generations (successive flushes, no compaction), `SELECT *` did not reproduce the fully-merged authoritative table state. The default read path (`SSTableManager::scan`) concatenated each reader's live rows, which:

- **duplicated** rows present in more than one generation, and
- **resurrected** rows/cells deleted in a *later* generation — each reader suppresses only its **own** tombstones, so a delete in gen-N never shadowed the original in gen-(N-1).

## Fix

When more than one generation serves a table, reconcile across generations instead of concatenating, reusing the **same authoritative `KWayMerger`** the compaction path already uses (`merge_partition_rows` → `Cells#reconcile` semantics):

- per-cell **last-write-wins** by write timestamp,
- **row + cell tombstone shadowing** across generations,
- fully-deleted rows dropped, deleted columns absent.

Properties:
- **Single-generation reads are untouched** — no merger is invoked, so there's zero behavior/perf change on the common path.
- Requires a schema (cells carry no column names on disk) and the `write-support` feature (the merger lives in the write engine). If either is absent, it **falls back to the prior concatenation** so reads never fail on an unsupported format.
- The merger manages its own reader threads/runtimes, so it runs on a `spawn_blocking` task.

## Test

`tests/issue_883_cross_generation_read_merge.rs` writes three generations via the public `WriteEngine` API (flush between each, **no compaction**) and asserts the reconciled live set:

| case | covered |
|------|---------|
| disjoint-column survival (name in gen2, score from gen1) | ✅ |
| full overwrite LWW (gen2 wins) | ✅ |
| cross-generation **row tombstone** suppression (PK deleted in gen3) | ✅ |
| cross-generation **cell tombstone** suppression (score deleted in gen3) | ✅ |
| no duplicate partition keys | ✅ |

Verified to **fail on the pre-fix tree** (9 rows / 6 distinct — duplicates + resurrected deletes) and **pass** after.

## Gate

`scripts/agent-gate.sh`: all components PASS except `test_flush_throughput` (4.3 vs 5 MB/sec), the known load-sensitive write-path perf gate — unrelated to this read-path change and **passes in isolation** (5.08 MB/sec). fmt / clippy `-D warnings` / minimal-build / integration / write-tests / cli / smoke all green.