### PR TITLE
ci(release): migrate crates.io publishing to OIDC trusted publishing (closes #786)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,20 +223,27 @@ jobs:
   # or a tag whose version was hand-published, does not hard-fail). cqlite-core
   # publishes first and we wait for the index to expose it before cqlite-cli,
   # whose dep is `cqlite-core = { path, version = "X" }` and must resolve.
-  # TODO(#782 follow-up): migrate to crates.io OIDC trusted publishing (no stored
-  # token, matching node-release.yml / python-release.yml).
+  # Auth is via crates.io OIDC trusted publishing (no stored token), matching
+  # the npm (node-release.yml) and PyPI (python-release.yml) OIDC flows. The
+  # auth action mints a short-lived token from the id-token JWT (#786).
   publish-crate:
     name: Publish to crates.io
     needs: [build-cli]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: read
+      id-token: write
     steps:
     - uses: actions/checkout@v5
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
+    - name: Authenticate to crates.io (OIDC trusted publishing)
+      uses: rust-lang/crates-io-auth-action@v1
+      id: auth
     - name: Publish crates (core before cli, idempotent)
       env:
-        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         TAG: ${{ github.ref_name }}
       run: |
         set -euo pipefail


### PR DESCRIPTION
## Summary

Replaces the long-lived `CARGO_REGISTRY_TOKEN` secret in the `publish-crate` job (`.github/workflows/release.yml`) with **crates.io OIDC trusted publishing**, matching the npm (`node-release.yml`) and PyPI (`python-release.yml`) OIDC flows already in this repo. Removes the `TODO(#782 follow-up)` marker.

Follow-up to #782 / #784 / #785.

## Changes

- Add `permissions: { contents: read, id-token: write }` to the `publish-crate` job.
- Mint a short-lived token via `rust-lang/crates-io-auth-action@v1` and feed it to the existing publish script through `CARGO_REGISTRY_TOKEN`.
- Drop the stored-secret reference (`secrets.CARGO_REGISTRY_TOKEN`).

The idempotency check, tag/version guard, and core-before-cli ordering are unchanged.

## Manual follow-ups (not code — require maintainer action)

These cannot be done in CI and must be completed before the next version tag:

1. **Configure the trusted publisher on crates.io** for both `cqlite-core` and `cqlite-cli` (crate Settings → Trusted Publishing): owner `pmcfadin`, repo `cqlite`, workflow `release.yml`, no environment.
2. **Remove the `CARGO_REGISTRY_TOKEN` repo secret** once OIDC is confirmed working on the next tag.
3. **Verify** on the next version tag that both crates publish without the stored token.

## Validation

- `actionlint` clean for the changed job (only pre-existing shellcheck warnings on unrelated steps remain).
- YAML parses.
- The release workflow only runs on `v*` tags, so this change does not execute on the PR; correctness is verified on the next tag (see follow-up 3).

Closes #786