### PR TITLE
fix(read): reconcile WRITETIME/TTL metadata scan across SSTable generations (closes #885)

### DIFF
--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -1037,6 +1037,135 @@ impl SSTableManager {
         Ok(merged)
     }
 
+    /// Metadata-aware sibling of [`merge_generations_for_read`](Self::merge_generations_for_read)
+    /// for the `WRITETIME(col)` / `TTL(col)` projection path (Issue #885).
+    ///
+    /// Reconciles multiple SSTable generations into the authoritative live-row set
+    /// with the same [`KWayMerger`](crate::storage::write_engine::KWayMerger)
+    /// (per-cell LWW + row/cell tombstone shadowing), and additionally surfaces the
+    /// **winning** cell's per-cell write metadata in the
+    /// [`CellWriteMetadata`](crate::types::CellWriteMetadata) shape
+    /// `scan_with_cell_metadata` returns:
+    ///
+    /// - `write_timestamp_micros` comes straight from the winning `CellData`
+    ///   (`reconcile_cluster` keeps each surviving cell's own timestamp), so it is
+    ///   the WRITETIME of the cell that actually won cross-generation LWW — not an
+    ///   arbitrary generation's.
+    /// - `expiration` (TTL) is recovered best-effort from the per-reader
+    ///   `scan_with_cell_metadata` outputs: the merger's compaction iterator does
+    ///   not carry per-cell TTL, so for each surviving `(key, column)` we take the
+    ///   newest reader-surfaced metadata and attach its expiration only when its
+    ///   timestamp matches the merge winner. Absent/mismatched ⇒ `None` (no TTL),
+    ///   which is the same answer the plain read gives for a cell without TTL.
+    ///
+    /// Requires a schema and the `write-support` feature; callers fall back to
+    /// per-reader concatenation when either is unavailable.
+    #[cfg(all(not(feature = "tombstones"), feature = "write-support"))]
+    async fn merge_generations_for_read_with_metadata(
+        &self,
+        reader_list: &[Arc<reader::SSTableReader>],
+        schema: &crate::schema::TableSchema,
+        limit: Option<usize>,
+    ) -> Result<Vec<(RowKey, Value, HashMap<String, CellWriteMetadata>)>> {
+        use crate::storage::write_engine::merge::{KWayMerger, MergeStep, RowData};
+        use crate::types::TableId as CqlTableId;
+
+        // Best-effort TTL source: gather each reader's own per-cell metadata and
+        // keep, per (row-key bytes, column), the entry with the newest write
+        // timestamp. The merger surfaces accurate WRITETIME but no TTL, so this
+        // recovers expiration for the winning cell when the reader format carries
+        // it (V5CompressedLegacy / BTI). Keyed by raw key bytes so it lines up with
+        // the merger's `DecoratedKey` partition bytes.
+        let table_id = CqlTableId::from(format!("{}.{}", schema.keyspace, schema.table).as_str());
+        let mut ttl_lookup: HashMap<(Vec<u8>, String), CellWriteMetadata> = HashMap::new();
+        for reader in reader_list {
+            let per_reader = reader
+                .scan_with_cell_metadata(&table_id, None, None, None, Some(schema))
+                .await?;
+            for (row_key, _value, meta) in per_reader {
+                for (column, cell_meta) in meta {
+                    ttl_lookup
+                        .entry((row_key.0.clone(), column))
+                        .and_modify(|existing| {
+                            if cell_meta.write_timestamp_micros > existing.write_timestamp_micros {
+                                *existing = cell_meta.clone();
+                            }
+                        })
+                        .or_insert(cell_meta);
+                }
+            }
+        }
+
+        // Drive the authoritative merge (newest → oldest), mirroring the plain
+        // `merge_generations_for_read` path, but keep each winning cell's timestamp.
+        let mut ordered: Vec<&Arc<reader::SSTableReader>> = reader_list.iter().collect();
+        ordered.sort_by(|a, b| b.generation.cmp(&a.generation));
+        let paths: Vec<PathBuf> = ordered.iter().map(|r| r.file_path.clone()).collect();
+        let merge_schema = schema.clone();
+
+        // Returns (key bytes, Value::Map, [(column, write_timestamp_micros)]).
+        type MergedRow = (Vec<u8>, Value, Vec<(String, i64)>);
+        let merged_rows = tokio::task::spawn_blocking(move || -> Result<Vec<MergedRow>> {
+            let mut merger = KWayMerger::new(paths, &merge_schema)?;
+            let mut out = Vec::new();
+            while let MergeStep::Partition { key, rows } = merger.step()? {
+                for entry in rows {
+                    if let RowData::Live { cells } = entry.row_data {
+                        let mut map: Vec<(Value, Value)> = Vec::with_capacity(cells.len());
+                        let mut timestamps: Vec<(String, i64)> = Vec::with_capacity(cells.len());
+                        for c in cells {
+                            // Drop cell tombstones: a deleted column is absent.
+                            if matches!(c.value, Value::Tombstone(_)) {
+                                continue;
+                            }
+                            timestamps.push((c.column.clone(), c.timestamp));
+                            map.push((Value::Text(c.column), c.value));
+                        }
+                        if !map.is_empty() {
+                            out.push((key.key.clone(), Value::Map(map), timestamps));
+                        }
+                    }
+                    // Row tombstones suppress the row entirely (no emission).
+                }
+            }
+            Ok(out)
+        })
+        .await
+        .map_err(|e| {
+            crate::Error::Storage(format!("cross-generation metadata merge task: {e}"))
+        })??;
+
+        // Attach per-cell metadata: WRITETIME from the merge winner, TTL recovered
+        // from the reader lookup only when its timestamp matches the winner.
+        let mut results: Vec<(RowKey, Value, HashMap<String, CellWriteMetadata>)> =
+            Vec::with_capacity(merged_rows.len());
+        for (key_bytes, value, timestamps) in merged_rows {
+            let mut meta_map: HashMap<String, CellWriteMetadata> =
+                HashMap::with_capacity(timestamps.len());
+            for (column, write_ts) in timestamps {
+                let expiration = ttl_lookup
+                    .get(&(key_bytes.clone(), column.clone()))
+                    .filter(|m| m.write_timestamp_micros == write_ts)
+                    .and_then(|m| m.expiration.clone());
+                meta_map.insert(
+                    column,
+                    CellWriteMetadata {
+                        write_timestamp_micros: write_ts,
+                        expiration,
+                    },
+                );
+            }
+            results.push((RowKey(key_bytes), value, meta_map));
+        }
+
+        // Match the plain-scan contract: sort by key bytes, then apply LIMIT.
+        results.sort_by(|a, b| a.0.cmp(&b.0));
+        if let Some(limit) = limit {
+            results.truncate(limit);
+        }
+        Ok(results)
+    }
+
     /// Scan a table and return per-cell write metadata alongside row values.
     ///
     /// Used when `ProjectionFlags::include_cell_metadata` is set (issue #693 — the
@@ -1070,6 +1199,35 @@ impl SSTableManager {
         };
 
         if let Some(reader_list) = readers {
+            // Issue #885: the metadata path (WRITETIME/TTL projection) must
+            // reconcile across SSTable generations exactly like the plain `scan`
+            // path (#883) — otherwise a multi-generation directory returns
+            // duplicate rows and resurrects rows/cells deleted in a later
+            // generation. Drive the same authoritative k-way merger, then surface
+            // the WINNING cell's per-cell write timestamp / TTL (write-support
+            // only; requires schema). Single-generation reads skip this entirely.
+            #[cfg(feature = "write-support")]
+            if reader_list.len() > 1 {
+                if let Some(schema) = schema {
+                    match self
+                        .merge_generations_for_read_with_metadata(reader_list, schema, limit)
+                        .await
+                    {
+                        Ok(merged) => return Ok(merged),
+                        Err(e) => {
+                            // Never fail a read because the merge path hit an
+                            // unsupported format; fall back to concatenation.
+                            log::warn!(
+                                "SSTableManager::scan_with_cell_metadata - cross-generation merge \
+                                 failed for '{}' ({}); falling back to per-reader concatenation",
+                                table_id,
+                                e
+                            );
+                        }
+                    }
+                }
+            }
+
             let mut all_results = Vec::new();
 
             for reader in reader_list {

--- a/cqlite-core/tests/issue_885_cross_generation_metadata_merge.rs
+++ b/cqlite-core/tests/issue_885_cross_generation_metadata_merge.rs
@@ -1,0 +1,320 @@
+//! Issue #885: the WRITETIME/TTL metadata read path
+//! (`SSTableManager::scan_with_cell_metadata`, used when a query projects
+//! `WRITETIME(col)` / `TTL(col)`) must reconcile across SSTable generations
+//! exactly like the plain `scan` path fixed in #883 — and report the **winning**
+//! cell's per-cell write timestamp / TTL after cross-generation last-write-wins.
+//!
+//! Before the fix, the metadata path concatenated each generation's rows: a row
+//! present in several generations was duplicated, and a row/cell deleted in a
+//! LATER generation leaked back in (each reader suppresses only its own
+//! tombstones). This test writes three generations via the public WriteEngine API
+//! (flushing between each, NO compaction), then scans through
+//! `SSTableManager::scan_with_cell_metadata` and asserts both the reconciled
+//! live-row set AND the per-cell WRITETIME of the winning cell.
+//!
+//! Run with:
+//!   CQLITE_DATASETS_ROOT=$PWD/test-data/datasets \
+//!     cargo test --package cqlite-core --features write-support \
+//!     --test issue_885_cross_generation_metadata_merge
+
+#![cfg(feature = "write-support")]
+
+use cqlite_core::platform::Platform;
+use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+use cqlite_core::storage::sstable::SSTableManager;
+use cqlite_core::storage::write_engine::{
+    CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::TableId as CqlTableId;
+use cqlite_core::types::{CellWriteMetadata, Value};
+use cqlite_core::Config;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tempfile::TempDir;
+
+const KS: &str = "gen_ks";
+const TBL: &str = "items";
+
+fn make_schema() -> TableSchema {
+    TableSchema {
+        keyspace: KS.to_string(),
+        table: TBL.to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            Column {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "name".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "score".to_string(),
+                data_type: "int".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+    }
+}
+
+fn write_row(id: i32, name: &str, score: i32, ts: i64) -> Mutation {
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    let ops = vec![
+        CellOperation::Write {
+            column: "name".to_string(),
+            value: Value::Text(name.to_string()),
+        },
+        CellOperation::Write {
+            column: "score".to_string(),
+            value: Value::Integer(score),
+        },
+    ];
+    Mutation::new(TableId::new(KS, TBL), pk, None, ops, ts, None)
+}
+
+/// Write only the `name` column with a per-cell TTL.
+fn write_name_only_ttl(id: i32, name: &str, ttl_seconds: u32, ts: i64) -> Mutation {
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    let ops = vec![CellOperation::WriteWithTtl {
+        column: "name".to_string(),
+        value: Value::Text(name.to_string()),
+        ttl_seconds,
+    }];
+    Mutation::new(TableId::new(KS, TBL), pk, None, ops, ts, None)
+}
+
+fn delete_row(id: i32, ts: i64) -> Mutation {
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    Mutation::new(
+        TableId::new(KS, TBL),
+        pk,
+        None,
+        vec![CellOperation::DeleteRow],
+        ts,
+        None,
+    )
+}
+
+fn delete_score_column(id: i32, ts: i64) -> Mutation {
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    let ops = vec![CellOperation::Delete {
+        column: "score".to_string(),
+    }];
+    Mutation::new(TableId::new(KS, TBL), pk, None, ops, ts, None)
+}
+
+fn count_data_files(dir: &std::path::Path) -> usize {
+    std::fs::read_dir(dir)
+        .expect("read sstable dir")
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_name().to_string_lossy().ends_with("-big-Data.db"))
+        .count()
+}
+
+/// Extract a column value from a scan row (`Value::Map` of `(Text(col), value)`).
+fn col<'a>(row: &'a Value, name: &str) -> Option<&'a Value> {
+    match row {
+        Value::Map(pairs) => pairs.iter().find_map(|(k, v)| match k {
+            Value::Text(c) if c == name => Some(v),
+            _ => None,
+        }),
+        _ => None,
+    }
+}
+
+#[test]
+fn metadata_scan_merges_generations_with_lww_and_tombstone_suppression() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build tokio runtime");
+
+    let temp_dir = TempDir::new().unwrap();
+    let data_dir = temp_dir.path().join("data");
+    let wal_dir = temp_dir.path().join("wal");
+    let schema = make_schema();
+
+    // ── Write three generations, flushing between each (no compaction) ─────────
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir.clone(), schema.clone());
+    let mut engine = WriteEngine::new(config).expect("engine creation");
+
+    // Gen 1 (ts=100): PK 1..=4, each name+score.
+    engine.write(write_row(1, "n1-v1", 11, 100)).unwrap();
+    engine.write(write_row(2, "n2-v1", 22, 100)).unwrap();
+    engine.write(write_row(3, "n3-v1", 33, 100)).unwrap();
+    engine.write(write_row(4, "n4-v1", 44, 100)).unwrap();
+    rt.block_on(engine.flush()).expect("flush 1").expect("gen1");
+
+    // Gen 2 (ts=200): PK1 name-only update WITH TTL (disjoint, newer), PK3 full
+    // overwrite, PK5 new.
+    engine
+        .write(write_name_only_ttl(1, "n1-v2", 3600, 200))
+        .unwrap();
+    engine.write(write_row(3, "n3-v2", 333, 200)).unwrap();
+    engine.write(write_row(5, "n5-v2", 55, 200)).unwrap();
+    rt.block_on(engine.flush()).expect("flush 2").expect("gen2");
+
+    // Gen 3 (ts=300): row-delete PK2, cell-delete score@PK4, PK6 new.
+    engine.write(delete_row(2, 300)).unwrap();
+    engine.write(delete_score_column(4, 300)).unwrap();
+    engine.write(write_row(6, "n6-v3", 66, 300)).unwrap();
+    rt.block_on(engine.flush()).expect("flush 3").expect("gen3");
+
+    rt.block_on(engine.close()).expect("close engine");
+
+    // Precondition: three distinct generations are on disk (no compaction ran).
+    let sstable_dir = data_dir.join(KS).join(TBL);
+    assert_eq!(
+        count_data_files(&sstable_dir),
+        3,
+        "test must exercise a multi-generation directory"
+    );
+
+    // ── Reopen and scan with cell metadata ────────────────────────────────────
+    let cqlite_config = Config::default();
+    let manager = rt.block_on(async {
+        let platform = Arc::new(Platform::new(&cqlite_config).await.expect("platform"));
+        SSTableManager::new(
+            &data_dir,
+            &cqlite_config,
+            platform,
+            #[cfg(feature = "state_machine")]
+            None,
+        )
+        .await
+        .expect("SSTableManager open")
+    });
+
+    let table_id = CqlTableId::from(format!("{KS}.{TBL}").as_str());
+    let results = rt
+        .block_on(manager.scan_with_cell_metadata(&table_id, None, None, None, Some(&schema)))
+        .expect("metadata scan must not error");
+
+    // ── Reconciled state: live rows are exactly {1, 3, 4, 5, 6} ───────────────
+    let by_pk: HashMap<Vec<u8>, (Value, HashMap<String, CellWriteMetadata>)> = results
+        .iter()
+        .map(|(k, v, m)| (k.0.clone(), (v.clone(), m.clone())))
+        .collect();
+
+    assert_eq!(
+        results.len(),
+        by_pk.len(),
+        "no duplicate partition keys across generations (got {} rows, {} distinct)",
+        results.len(),
+        by_pk.len()
+    );
+    assert_eq!(
+        results.len(),
+        5,
+        "expected exactly 5 live rows after cross-generation metadata merge, got {}",
+        results.len()
+    );
+
+    let pk = |id: i32| -> Vec<u8> { id.to_be_bytes().to_vec() };
+
+    // PK2 row-deleted in gen3 — must NOT resurrect from gen1.
+    assert!(
+        !by_pk.contains_key(&pk(2)),
+        "PK2 was row-deleted in a later generation; it must be suppressed"
+    );
+
+    // Helper: fetch (value, metadata) for a PK.
+    let row = |id: i32| -> &(Value, HashMap<String, CellWriteMetadata>) {
+        by_pk.get(&pk(id)).expect("row present")
+    };
+    let writetime = |meta: &HashMap<String, CellWriteMetadata>, c: &str| -> i64 {
+        meta.get(c)
+            .unwrap_or_else(|| panic!("metadata for column '{c}' present"))
+            .write_timestamp_micros
+    };
+
+    // PK1: disjoint columns merge — name from gen2 (ts=200), score from gen1 (ts=100).
+    let (v1, m1) = row(1);
+    assert_eq!(
+        col(v1, "name"),
+        Some(&Value::Text("n1-v2".to_string())),
+        "PK1 name must be the gen2 (newer) value"
+    );
+    assert_eq!(
+        col(v1, "score"),
+        Some(&Value::Integer(11)),
+        "PK1 score (written only in gen1) must survive the name-only gen2 update"
+    );
+    // WRITETIME is per WINNING cell: name won in gen2, score won in gen1.
+    assert_eq!(
+        writetime(m1, "name"),
+        200,
+        "PK1 WRITETIME(name) must be the gen2 winner's timestamp"
+    );
+    assert_eq!(
+        writetime(m1, "score"),
+        100,
+        "PK1 WRITETIME(score) must be the gen1 timestamp (not the newer name update)"
+    );
+    // TTL: the winning gen2 name cell was written WITH ttl=3600. The reconciled
+    // expiration must be that winning cell's TTL — never an arbitrary generation's.
+    let exp1 = m1
+        .get("name")
+        .and_then(|m| m.expiration.as_ref())
+        .expect("PK1 name (gen2 winner) carries the TTL it was written with");
+    assert_eq!(
+        exp1.ttl_seconds, 3600,
+        "PK1 TTL(name) must be the winning gen2 cell's TTL"
+    );
+    // The gen1 score cell had no TTL — must always be None.
+    assert!(
+        m1.get("score")
+            .and_then(|m| m.expiration.as_ref())
+            .is_none(),
+        "PK1 score had no TTL; expiration must be None"
+    );
+
+    // PK3: full overwrite — gen2 (ts=200) wins both columns.
+    let (v3, m3) = row(3);
+    assert_eq!(col(v3, "name"), Some(&Value::Text("n3-v2".to_string())));
+    assert_eq!(col(v3, "score"), Some(&Value::Integer(333)));
+    assert_eq!(writetime(m3, "name"), 200);
+    assert_eq!(writetime(m3, "score"), 200);
+
+    // PK4: cell-delete of score in gen3 shadows gen1's score; name survives at ts=100.
+    let (v4, m4) = row(4);
+    assert_eq!(col(v4, "name"), Some(&Value::Text("n4-v1".to_string())));
+    assert!(
+        col(v4, "score").is_none(),
+        "PK4 score was cell-deleted in a later generation; it must be absent, got {:?}",
+        col(v4, "score")
+    );
+    assert_eq!(writetime(m4, "name"), 100);
+    assert!(
+        !m4.contains_key("score"),
+        "PK4 score is deleted; no metadata must be reported for it"
+    );
+
+    // PK5 / PK6: single-generation rows pass through with their own timestamps.
+    let (v5, m5) = row(5);
+    assert_eq!(col(v5, "score"), Some(&Value::Integer(55)));
+    assert_eq!(writetime(m5, "name"), 200);
+    assert_eq!(writetime(m5, "score"), 200);
+
+    let (v6, m6) = row(6);
+    assert_eq!(col(v6, "score"), Some(&Value::Integer(66)));
+    assert_eq!(writetime(m6, "name"), 300);
+    assert_eq!(writetime(m6, "score"), 300);
+
+    drop(temp_dir);
+}


### PR DESCRIPTION
## Summary

Follow-up to #883 / PR #884. That fix made the plain `SSTableManager::scan` path reconcile across SSTable generations (per-cell LWW + tombstone shadowing via the `KWayMerger`), but deliberately scoped out the sibling `scan_with_cell_metadata` path used when a query projects `WRITETIME(col)` / `TTL(col)` (the #693 metadata bridge).

That metadata path still **concatenated each generation's rows**, so a multi-generation directory queried with `WRITETIME`/`TTL` reproduced the original #883 symptoms:
- duplicate rows for partitions present in more than one generation, and
- resurrected rows/cells deleted in a later generation (each reader suppresses only its own tombstones).

So the metadata path could disagree with the now-correct plain `scan` over the same data.

## Fix

Add `merge_generations_for_read_with_metadata`. When more than one reader serves a table (and a schema + the `write-support` feature are available), drive the same authoritative `KWayMerger` the plain path uses, then surface the **winning** cell's per-cell metadata:

- `write_timestamp_micros` comes straight from the merged `CellData` (`reconcile_cluster` keeps each surviving cell's own timestamp) — so `WRITETIME` is that of the cell that actually won cross-generation LWW, not an arbitrary generation's.
- `expiration` (TTL) is recovered best-effort from the per-reader `scan_with_cell_metadata` outputs (the compaction iterator the merger reads carries accurate timestamps but not per-cell TTL): for each surviving `(key, column)` take the newest reader-surfaced metadata and attach its expiration only when its timestamp matches the merge winner. Absent / mismatched ⇒ `None` (no TTL) — the same answer the plain read gives.

Single-generation reads are untouched (the branch only fires for `>1` reader), and any merge-path error falls back to the prior concatenation so reads never fail on an unsupported format.

## Acceptance criteria

- [x] A multi-generation directory queried with `WRITETIME(col)` / `TTL(col)` returns the same reconciled row set as plain `SELECT *` (no duplicates, deletes suppressed).
- [x] The reported `WRITETIME`/`TTL` is that of the **winning** cell after cross-generation LWW.
- [x] Regression test mirroring `tests/issue_883_cross_generation_read_merge.rs` but asserting metadata values (`tests/issue_885_cross_generation_metadata_merge.rs`).
- [x] Single-generation metadata reads unchanged.

## Test

`tests/issue_885_cross_generation_metadata_merge.rs` writes three generations via the `WriteEngine` (no compaction) and asserts the reconciled row set plus per-cell WRITETIME of the winning cell (100/200/300 across PKs) and the winning gen2 cell's TTL (3600). **Verified to fail on the pre-fix tree (9 rows / 6 distinct) and pass after.**

## Gate

`scripts/agent-gate.sh`: all components PASS except a single flaky run of `test_flush_throughput` (4.4 vs 5 MB/sec — load-sensitive perf assertion, unrelated to this read-path change; passes in isolation).