### PR TITLE
docs(flight): fix integer-avg follow-up issue reference (#897 -> #902)

### DIFF
--- a/trino-connector/src/main/java/com/rustyrazorblade/cqlite/flight/CqliteFlightMetadata.java
+++ b/trino-connector/src/main/java/com/rustyrazorblade/cqlite/flight/CqliteFlightMetadata.java
@@ -336,7 +336,7 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
                     // i64 (to match Trino's sum(bigint) overflow), but Trino's avg
                     // accumulates in 128-bit and never overflows — so a pushed
                     // integer avg could fail a query Trino would answer. Float/double
-                    // avg sums in f64 (no overflow), so it still pushes. See #897.
+                    // avg sums in f64 (no overflow), so it still pushes. See #902.
                     Type avgType = arg.get().type();
                     if (avgType instanceof BigintType || avgType instanceof IntegerType
                             || avgType instanceof io.trino.spi.type.SmallintType

--- a/trino-connector/src/test/java/com/rustyrazorblade/cqlite/flight/CqliteFlightMetadataApplyAggregationTest.java
+++ b/trino-connector/src/test/java/com/rustyrazorblade/cqlite/flight/CqliteFlightMetadataApplyAggregationTest.java
@@ -114,7 +114,7 @@ class CqliteFlightMetadataApplyAggregationTest {
 
     @Test
     void decomposesAvgIntoSumPlusCount() throws Exception {
-        // avg over a DOUBLE column (integer avg is declined — see #897); the
+        // avg over a DOUBLE column (integer avg is declined — see #902); the
         // Sum+Count decomposition is identical.
         var result = metadata.applyAggregation(
                 null, TABLE, List.of(agg("avg", DOUBLE, new Variable("d", DOUBLE))),


### PR DESCRIPTION
Comment-only fix. The integer-avg pushdown decline from #841 referenced `#897`, but that number went to an unrelated PR. The real follow-up is #902. Updates the two stale references in `CqliteFlightMetadata.java` and `CqliteFlightMetadataApplyAggregationTest.java`. No behavior change.

Refs #874, #902