### PR TITLE
feat(merge): carry-only per-cell + complex/range-deletion substrate on the merge entry (#886)

### DIFF
--- a/cqlite-core/src/storage/write_engine/merge.rs
+++ b/cqlite-core/src/storage/write_engine/merge.rs
@@ -57,7 +57,7 @@ use crate::error::{Error, Result};
 #[cfg(feature = "write-support")]
 use crate::schema::TableSchema;
 #[cfg(feature = "write-support")]
-use crate::storage::write_engine::mutation::{ClusteringKey, DecoratedKey};
+use crate::storage::write_engine::mutation::{ClusteringKey, DecoratedKey, RangeTombstone};
 #[cfg(feature = "write-support")]
 use crate::types::Value;
 
@@ -87,10 +87,33 @@ pub struct MergeEntry {
     pub timestamp: i64,
     /// Row data (live cells or tombstone)
     pub row_data: RowData,
+    /// Complex-deletion markers for the multi-cell columns of this row
+    /// (issue #886 substrate).
+    ///
+    /// **Carry-only.** Threaded so per-path merge (#844) and
+    /// shadow-before-purge (#887) can preserve collection/UDT deletion
+    /// timestamps, but nothing populates or applies it yet — the reader still
+    /// reduces complex deletions to a boolean upstream. Population lands in
+    /// #899. Empty for rows with no complex deletions.
+    pub complex_deletions: Vec<ComplexDeletion>,
+    /// Range-deletion marker covering a span of clustering keys (issue #886
+    /// substrate).
+    ///
+    /// **Carry-only.** A first-class slot so range tombstones can flow through
+    /// the merge stream instead of being skipped by the parser; applying them
+    /// to shadow covered cells is the follow-up #846. `None` when this entry
+    /// carries no range deletion.
+    pub range_deletion: Option<RangeTombstone>,
 }
 
 impl MergeEntry {
-    /// Create a new merge entry
+    /// Create a new merge entry.
+    ///
+    /// The carry-only #886 substrate fields (`complex_deletions`,
+    /// `range_deletion`) default to empty/`None`; populate them with
+    /// [`with_complex_deletions`](Self::with_complex_deletions) /
+    /// [`with_range_deletion`](Self::with_range_deletion) once the reader emit
+    /// surfaces them (#899).
     pub fn new(
         run_index: usize,
         key: DecoratedKey,
@@ -104,7 +127,21 @@ impl MergeEntry {
             clustering_key,
             timestamp,
             row_data,
+            complex_deletions: Vec::new(),
+            range_deletion: None,
         }
+    }
+
+    /// Attach complex-deletion markers (issue #886 substrate; carry-only).
+    pub fn with_complex_deletions(mut self, complex_deletions: Vec<ComplexDeletion>) -> Self {
+        self.complex_deletions = complex_deletions;
+        self
+    }
+
+    /// Attach a range-deletion marker (issue #886 substrate; carry-only).
+    pub fn with_range_deletion(mut self, range_deletion: RangeTombstone) -> Self {
+        self.range_deletion = Some(range_deletion);
+        self
     }
 }
 
@@ -194,6 +231,46 @@ pub struct CellData {
     pub timestamp: i64,
     /// TTL in seconds (None = no expiration)
     pub ttl: Option<u32>,
+    /// Cell path for a complex (collection / non-frozen UDT) element — the
+    /// serialized element key/index that distinguishes one element of a
+    /// multi-cell column from another (issue #886 substrate).
+    ///
+    /// **Carry-only.** This field is threaded through the merge entry so that
+    /// per-element reconciliation can become byte-faithful, but nothing
+    /// populates or consumes it yet: the reader still collapses collections to
+    /// a single whole-column [`CellData`] and the writer does not read this
+    /// field. Population (per-element reader emit) and consumption (per-path
+    /// merge) land in the follow-up #899. `None` for simple cells.
+    pub cell_path: Option<Vec<u8>>,
+    /// Local deletion time in **seconds** since the Unix epoch for this cell
+    /// (the on-disk `localDeletionTime`), used by gc_grace purging and
+    /// expiring-cell tie-breaks (issue #886 substrate).
+    ///
+    /// **Carry-only.** Threaded for #845/#848 but not yet populated by the
+    /// reader or consumed by the merge/writer. `None` when unknown.
+    pub local_deletion_time: Option<i32>,
+}
+
+/// Complex (collection / non-frozen UDT) deletion marker for one column
+/// (issue #886 substrate).
+///
+/// Cassandra writes a complex-deletion marker ahead of a multi-cell column's
+/// elements to delete every element written at or before `marked_for_delete_at`.
+/// CQLite currently reduces this to a boolean and discards the timestamps; this
+/// first-class entity preserves them so per-path merge (#844) and
+/// shadow-before-purge (#887) can be byte-faithful.
+///
+/// **Carry-only.** Carried on [`MergeEntry`] but not yet populated by the reader
+/// or applied during the merge — that is the follow-up #899/#887.
+#[cfg(feature = "write-support")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ComplexDeletion {
+    /// Name of the complex column this deletion covers.
+    pub column: String,
+    /// Deletion timestamp (`markedForDeleteAt`) in microseconds since the epoch.
+    pub marked_for_delete_at: i64,
+    /// Local deletion time in seconds since the epoch.
+    pub local_deletion_time: i32,
 }
 
 /// Result of a merge step (incremental merge)
@@ -742,6 +819,8 @@ impl SSTableRowIteratorAdapter {
                         value: val.clone(),
                         timestamp: cell_ts,
                         ttl: None,
+                        cell_path: None,
+                        local_deletion_time: None,
                     });
                 }
                 Ok(RowData::Live { cells })
@@ -753,6 +832,8 @@ impl SSTableRowIteratorAdapter {
                     value: other.clone(),
                     timestamp: row_timestamp,
                     ttl: None,
+                    cell_path: None,
+                    local_deletion_time: None,
                 }],
             }),
         }
@@ -1557,6 +1638,8 @@ mod tests {
                 value: Value::Text("Alice".to_string()),
                 timestamp: 1000,
                 ttl: None,
+                cell_path: None,
+                local_deletion_time: None,
             }],
         };
 
@@ -1592,6 +1675,8 @@ mod tests {
             value: Value::Integer(30),
             timestamp: 1234567890,
             ttl: Some(3600),
+            cell_path: None,
+            local_deletion_time: None,
         };
 
         assert_eq!(cell.column, "age");
@@ -1630,6 +1715,8 @@ mod tests {
                     value: Value::Text("Alice".to_string()),
                     timestamp: 1000,
                     ttl: None,
+                    cell_path: None,
+                    local_deletion_time: None,
                 }],
             },
         );
@@ -1684,6 +1771,8 @@ mod tests {
                     value: Value::Text("Newer".to_string()),
                     timestamp: 1000,
                     ttl: None,
+                    cell_path: None,
+                    local_deletion_time: None,
                 }],
             },
         );
@@ -1699,6 +1788,8 @@ mod tests {
                     value: Value::Text("Older".to_string()),
                     timestamp: 1000,
                     ttl: None,
+                    cell_path: None,
+                    local_deletion_time: None,
                 }],
             },
         );
@@ -1783,6 +1874,8 @@ mod tests {
                     value: Value::Text("survivor-if-buggy".to_string()),
                     timestamp: EQUAL_TS,
                     ttl: None,
+                    cell_path: None,
+                    local_deletion_time: None,
                 }],
             },
         );
@@ -1888,6 +1981,8 @@ mod tests {
                     value: Value::Text("alice".to_string()),
                     timestamp: 100,
                     ttl: None,
+                    cell_path: None,
+                    local_deletion_time: None,
                 }],
             },
         );
@@ -1904,6 +1999,8 @@ mod tests {
                     value: Value::Integer(42),
                     timestamp: 200,
                     ttl: None,
+                    cell_path: None,
+                    local_deletion_time: None,
                 }],
             },
         );
@@ -2015,6 +2112,8 @@ mod tests {
                     value: Value::Integer(42),
                     timestamp: 100,
                     ttl: None,
+                    cell_path: None,
+                    local_deletion_time: None,
                 }],
             },
         );
@@ -2037,6 +2136,8 @@ mod tests {
                     }),
                     timestamp: 100,
                     ttl: None,
+                    cell_path: None,
+                    local_deletion_time: None,
                 }],
             },
         );
@@ -2158,6 +2259,8 @@ mod tests {
                     value: Value::Text(newer_file_value.to_string()),
                     timestamp: EQUAL_TS,
                     ttl: None,
+                    cell_path: None,
+                    local_deletion_time: None,
                 }],
             },
         );
@@ -2173,6 +2276,8 @@ mod tests {
                     value: Value::Text(older_file_value.to_string()),
                     timestamp: EQUAL_TS,
                     ttl: None,
+                    cell_path: None,
+                    local_deletion_time: None,
                 }],
             },
         );
@@ -2281,12 +2386,16 @@ mod tests {
                         value: Value::Text("old".to_string()),
                         timestamp: 100,
                         ttl: None,
+                        cell_path: None,
+                        local_deletion_time: None,
                     },
                     CellData {
                         column: "extra".to_string(),
                         value: Value::Text("a-only".to_string()),
                         timestamp: 100,
                         ttl: None,
+                        cell_path: None,
+                        local_deletion_time: None,
                     },
                 ],
             },
@@ -2303,6 +2412,8 @@ mod tests {
                     value: Value::Text("new".to_string()),
                     timestamp: 200,
                     ttl: None,
+                    cell_path: None,
+                    local_deletion_time: None,
                 }],
             },
         );
@@ -2399,6 +2510,8 @@ mod tests {
                     value: Value::Text("old".to_string()),
                     timestamp: 100,
                     ttl: None,
+                    cell_path: None,
+                    local_deletion_time: None,
                 }],
             },
         );
@@ -2423,6 +2536,8 @@ mod tests {
                     value: Value::Integer(7),
                     timestamp: 300,
                     ttl: None,
+                    cell_path: None,
+                    local_deletion_time: None,
                 }],
             },
         );
@@ -2500,6 +2615,8 @@ mod tests {
                     value: Value::Text("doomed".to_string()),
                     timestamp: 100,
                     ttl: None,
+                    cell_path: None,
+                    local_deletion_time: None,
                 }],
             },
         );
@@ -2566,6 +2683,8 @@ mod tests {
             value: Value::Text("Old".to_string()),
             timestamp: 1000,
             ttl: None,
+            cell_path: None,
+            local_deletion_time: None,
         };
 
         let cell2 = CellData {
@@ -2573,6 +2692,8 @@ mod tests {
             value: Value::Text("New".to_string()),
             timestamp: 2000, // Higher timestamp wins
             ttl: None,
+            cell_path: None,
+            local_deletion_time: None,
         };
 
         // Cell2 should win in last-write-wins merge
@@ -2624,12 +2745,16 @@ mod tests {
                         value: Value::Text("Alice".to_string()),
                         timestamp: 999_000_000,
                         ttl: None,
+                        cell_path: None,
+                        local_deletion_time: None,
                     },
                     CellData {
                         column: "age".to_string(),
                         value: Value::Integer(30),
                         timestamp: 999_000_000,
                         ttl: Some(3600),
+                        cell_path: None,
+                        local_deletion_time: None,
                     },
                 ],
             },
@@ -3393,6 +3518,8 @@ mod merge_property_tests {
                             value: Value::Integer(ts as i32),
                             timestamp: ts,
                             ttl: None,
+                            cell_path: None,
+                            local_deletion_time: None,
                         }],
                     },
                 )
@@ -3503,6 +3630,8 @@ mod merge_property_tests {
                         value: Value::Integer(42),
                         timestamp: ts_write,
                         ttl: None,
+                        cell_path: None,
+                        local_deletion_time: None,
                     }],
                 },
             );
@@ -3870,6 +3999,8 @@ mod issue_823_complex_column_merge {
                 value: Value::List(vec![Value::Text("b".to_string())]),
                 timestamp: 200,
                 ttl: None,
+                cell_path: None,
+                local_deletion_time: None,
             }],
         );
         let older = live(
@@ -3880,6 +4011,8 @@ mod issue_823_complex_column_merge {
                 value: Value::List(vec![Value::Text("a".to_string())]),
                 timestamp: 100,
                 ttl: None,
+                cell_path: None,
+                local_deletion_time: None,
             }],
         );
 
@@ -3935,6 +4068,8 @@ mod issue_823_complex_column_merge {
                 value: mk_udt("city", "SF"),
                 timestamp: 200,
                 ttl: None,
+                cell_path: None,
+                local_deletion_time: None,
             }],
         );
         let older = live(
@@ -3945,6 +4080,8 @@ mod issue_823_complex_column_merge {
                 value: mk_udt("zip", "94105"),
                 timestamp: 100,
                 ttl: None,
+                cell_path: None,
+                local_deletion_time: None,
             }],
         );
 
@@ -4052,6 +4189,8 @@ mod issue_823_complex_column_merge {
                 }),
                 timestamp: 100,
                 ttl: None,
+                cell_path: None,
+                local_deletion_time: None,
             }],
         );
 
@@ -4251,6 +4390,8 @@ mod issue_822_merge_ordering_semantics {
                         value: Value::Text(format!("row-{ck}")),
                         timestamp: TS,
                         ttl: None,
+                        cell_path: None,
+                        local_deletion_time: None,
                     }],
                 },
             )
@@ -4303,6 +4444,8 @@ mod issue_822_merge_ordering_semantics {
             value: Value::Text("c".to_string()),
             timestamp: TS,
             ttl: None,
+            cell_path: None,
+            local_deletion_time: None,
         };
 
         // Expiring (TTL) live cell for column "v", in the NEWER file (run 0).
@@ -4321,6 +4464,8 @@ mod issue_822_merge_ordering_semantics {
                         value: Value::Text("expiring-if-buggy".to_string()),
                         timestamp: TS,
                         ttl: Some(3600),
+                        cell_path: None,
+                        local_deletion_time: None,
                     },
                 ],
             },
@@ -4346,6 +4491,8 @@ mod issue_822_merge_ordering_semantics {
                         }),
                         timestamp: TS,
                         ttl: None,
+                        cell_path: None,
+                        local_deletion_time: None,
                     },
                 ],
             },
@@ -4395,6 +4542,8 @@ mod issue_822_merge_ordering_semantics {
             value: Value::Text("c".to_string()),
             timestamp: TS,
             ttl: None,
+            cell_path: None,
+            local_deletion_time: None,
         };
 
         let tombstone = MergeEntry::new(
@@ -4416,6 +4565,8 @@ mod issue_822_merge_ordering_semantics {
                         }),
                         timestamp: TS,
                         ttl: None,
+                        cell_path: None,
+                        local_deletion_time: None,
                     },
                 ],
             },
@@ -4434,6 +4585,8 @@ mod issue_822_merge_ordering_semantics {
                         value: Value::Text("expiring-if-buggy".to_string()),
                         timestamp: TS,
                         ttl: Some(3600),
+                        cell_path: None,
+                        local_deletion_time: None,
                     },
                 ],
             },
@@ -4624,6 +4777,8 @@ mod issue_822_merge_ordering_semantics {
             }),
             timestamp: 1,
             ttl: None,
+            cell_path: None,
+            local_deletion_time: None,
         };
         assert!(KWayMerger::is_cell_tombstone(&tomb));
         assert!(
@@ -4636,6 +4791,8 @@ mod issue_822_merge_ordering_semantics {
             value: Value::Text("x".to_string()),
             timestamp: 1,
             ttl: Some(60),
+            cell_path: None,
+            local_deletion_time: None,
         };
         assert!(
             !KWayMerger::is_cell_tombstone(&expiring),

--- a/cqlite-core/src/storage/write_engine/mutation.rs
+++ b/cqlite-core/src/storage/write_engine/mutation.rs
@@ -160,7 +160,7 @@ pub struct PartitionTombstone {
 ///
 /// Stored as markers within the partition data and shadows all rows
 /// in the specified clustering key range.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct RangeTombstone {
     /// Start bound (inclusive or exclusive)
     pub start: ClusteringBound,
@@ -176,7 +176,7 @@ pub struct RangeTombstone {
 ///
 /// Defines the boundary of a range deletion. Can be inclusive or exclusive,
 /// or represent the minimum/maximum possible clustering key.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum ClusteringBound {
     /// Inclusive bound (clustering key is part of the deletion range)
     Inclusive(ClusteringKey),

--- a/cqlite-core/tests/issue_823_complex_column_merge.rs
+++ b/cqlite-core/tests/issue_823_complex_column_merge.rs
@@ -23,32 +23,44 @@
 use cqlite_core::storage::write_engine::merge::{CellData, RowData};
 use cqlite_core::types::{UdtField, UdtValue, Value};
 
-/// `CellData` carries only `column`/`value`/`timestamp`/`ttl`. There is no
-/// `cell_path`, `collection_key`, or per-element discriminator. This is the
-/// structural reason multi-cell merge cannot be per-path: two writes to different
-/// paths of the same column are indistinguishable once they share a `column`.
+/// Issue #886 added the carry-only `cell_path` / `local_deletion_time` substrate
+/// fields to `CellData` (defaulting to `None`), but per-path merge is still NOT
+/// wired: the reader does not yet populate `cell_path` and the merge does not yet
+/// consume it (that reader-emit + per-path reconcile work is #899). So two writes
+/// to different paths of the same column remain indistinguishable in practice —
+/// the field exists but nothing fills it in.
 #[test]
-fn celldata_has_no_path_dimension() {
+fn celldata_path_dimension_is_carry_only() {
     let cell = CellData {
         column: "tags".to_string(),
         value: Value::List(vec![Value::Text("a".to_string())]),
         timestamp: 1,
         ttl: None,
+        cell_path: None,
+        local_deletion_time: None,
     };
 
-    // The public fields are exactly these four. If a path/collection-key field is
-    // ever added, this destructuring will fail to compile and this test must be
-    // revisited (it would mean per-path merge became representable).
+    // The path dimension now exists structurally (#886) but is carry-only: when
+    // built from the reader it is `None`. If a later change starts POPULATING
+    // `cell_path` from the reader emit, this test should be revisited alongside
+    // the #899 per-path merge work.
     let CellData {
         column,
         value,
         timestamp,
         ttl,
+        cell_path,
+        local_deletion_time,
     } = cell;
     assert_eq!(column, "tags");
     assert!(matches!(value, Value::List(_)));
     assert_eq!(timestamp, 1);
     assert_eq!(ttl, None);
+    assert_eq!(cell_path, None, "carry-only: unpopulated until #899");
+    assert_eq!(
+        local_deletion_time, None,
+        "carry-only: unpopulated until #899"
+    );
 }
 
 /// A multi-cell collection is surfaced as a single nested `Value` under one
@@ -66,6 +78,8 @@ fn multicell_collection_is_one_nested_cell_value() {
             ]),
             timestamp: 10,
             ttl: None,
+            cell_path: None,
+            local_deletion_time: None,
         }],
     };
 
@@ -106,6 +120,8 @@ fn nonfrozen_udt_is_one_nested_cell_value() {
             }),
             timestamp: 10,
             ttl: None,
+            cell_path: None,
+            local_deletion_time: None,
         }],
     };
 
@@ -121,11 +137,11 @@ fn nonfrozen_udt_is_one_nested_cell_value() {
     }
 }
 
-/// Complex (collection-level) deletion (#14/#17) has no dedicated public
-/// representation: `RowData::Tombstone` is whole-row only (deletion_time +
-/// local_deletion_time, no column scope). A per-column complex deletion can only
-/// be smuggled as a `Value::Tombstone` inside a cell, which then collapses with
-/// any sibling cell on the same column name.
+/// `RowData::Tombstone` is still whole-row only (deletion_time +
+/// local_deletion_time, no column scope). Issue #886 added a dedicated,
+/// column-scoped complex-deletion entity (`MergeEntry.complex_deletions` /
+/// `ComplexDeletion`) as carry-only substrate, but `RowData` itself is unchanged —
+/// a per-column complex deletion is NOT smuggled into `RowData::Tombstone`.
 #[test]
 fn row_tombstone_has_no_column_scope() {
     let t = RowData::Tombstone {

--- a/cqlite-core/tests/issue_886_merge_entry_substrate.rs
+++ b/cqlite-core/tests/issue_886_merge_entry_substrate.rs
@@ -1,0 +1,149 @@
+//! Issue #886 (foundation for epic #842): enrich the reader→merge entry with the
+//! substrate needed for byte-faithful per-cell / per-element reconciliation —
+//! `CellData.cell_path` / `CellData.local_deletion_time`, and first-class
+//! `MergeEntry.complex_deletions` / `MergeEntry.range_deletion` entities.
+//!
+//! Scope is **plumbing only**: these fields/entities are added and threaded so the
+//! follow-ups can populate and consume them, but #886 itself neither populates nor
+//! consumes them (the reader-emit + per-path reconcile work is #899). This test
+//! therefore asserts the new substrate exists and round-trips through
+//! construction, and that it is **carry-only** — `MergeEntry::new` defaults the new
+//! entities to empty/`None`, and the merge data model is byte-neutral because
+//! nothing reads them yet.
+//!
+//! Run with:
+//!   CQLITE_DATASETS_ROOT=$PWD/test-data/datasets \
+//!     cargo test --package cqlite-core --features write-support \
+//!     --test issue_886_merge_entry_substrate
+
+#![cfg(feature = "write-support")]
+
+use cqlite_core::storage::write_engine::merge::{CellData, ComplexDeletion, MergeEntry, RowData};
+use cqlite_core::storage::write_engine::mutation::{
+    ClusteringBound, ClusteringKey, DecoratedKey, RangeTombstone,
+};
+use cqlite_core::types::Value;
+
+/// `CellData` now carries the per-element substrate fields. They default to
+/// `None` (the value the reader produces today) but can hold a real cell path and
+/// local deletion time so #899 can populate them.
+#[test]
+fn celldata_carries_cell_path_and_local_deletion_time() {
+    // Simple cell as built today: both new fields absent.
+    let simple = CellData {
+        column: "name".to_string(),
+        value: Value::Text("v".to_string()),
+        timestamp: 100,
+        ttl: None,
+        cell_path: None,
+        local_deletion_time: None,
+    };
+    assert_eq!(simple.cell_path, None);
+    assert_eq!(simple.local_deletion_time, None);
+
+    // A per-element cell as #899 will eventually build it: round-trip the path and
+    // local deletion time through the struct.
+    let element = CellData {
+        column: "tags".to_string(),
+        value: Value::Text("element".to_string()),
+        timestamp: 200,
+        ttl: Some(3600),
+        cell_path: Some(vec![0x00, 0x01, 0xAB]),
+        local_deletion_time: Some(1_700_000_000),
+    };
+    assert_eq!(element.cell_path.as_deref(), Some(&[0x00, 0x01, 0xAB][..]));
+    assert_eq!(element.local_deletion_time, Some(1_700_000_000));
+
+    // Equality is structural over the new fields too: same column/value but a
+    // different cell path is a distinct cell (the point of the substrate).
+    let other_path = CellData {
+        cell_path: Some(vec![0x00, 0x02]),
+        ..element.clone()
+    };
+    assert_ne!(
+        element, other_path,
+        "cell_path participates in CellData identity"
+    );
+}
+
+/// `MergeEntry::new` leaves the carry-only deletion entities empty/`None`, so
+/// existing call sites and merge output are unchanged by #886.
+#[test]
+fn merge_entry_new_defaults_deletion_entities_empty() {
+    let entry = MergeEntry::new(
+        0,
+        DecoratedKey::new(42, vec![1, 2, 3]),
+        None,
+        100,
+        RowData::Live { cells: Vec::new() },
+    );
+    assert!(
+        entry.complex_deletions.is_empty(),
+        "complex_deletions default empty (carry-only)"
+    );
+    assert!(
+        entry.range_deletion.is_none(),
+        "range_deletion defaults None (carry-only)"
+    );
+}
+
+/// The complex-deletion marker entity round-trips its column scope and timestamps,
+/// and attaches to a `MergeEntry` via the builder without disturbing the row data.
+#[test]
+fn complex_deletion_entity_round_trips_on_merge_entry() {
+    let cd = ComplexDeletion {
+        column: "tags".to_string(),
+        marked_for_delete_at: 12_345,
+        local_deletion_time: 1_700_000_000,
+    };
+
+    let entry = MergeEntry::new(
+        0,
+        DecoratedKey::new(7, vec![9]),
+        None,
+        12_345,
+        RowData::Live { cells: Vec::new() },
+    )
+    .with_complex_deletions(vec![cd.clone()]);
+
+    assert_eq!(entry.complex_deletions, vec![cd]);
+    assert_eq!(entry.complex_deletions[0].column, "tags");
+    assert_eq!(entry.complex_deletions[0].marked_for_delete_at, 12_345);
+    assert_eq!(
+        entry.complex_deletions[0].local_deletion_time,
+        1_700_000_000
+    );
+    // The row payload is untouched by the carry-only marker.
+    assert!(matches!(entry.row_data, RowData::Live { .. }));
+}
+
+/// A first-class range-deletion entity (reusing the open-ended `RangeTombstone`
+/// representation with `ClusteringBound`) flows onto the `MergeEntry` as a
+/// carry-only slot, including the open-ended `Bottom`/`Top` bounds.
+#[test]
+fn range_deletion_entity_attaches_to_merge_entry() {
+    let rt = RangeTombstone {
+        start: ClusteringBound::Inclusive(ClusteringKey::new(vec![(
+            "ck".to_string(),
+            Value::Integer(1),
+        )])),
+        end: ClusteringBound::Top,
+        deletion_time: 999,
+        local_deletion_time: 1_700_000_001,
+    };
+
+    let entry = MergeEntry::new(
+        0,
+        DecoratedKey::new(7, vec![9]),
+        None,
+        999,
+        RowData::Live { cells: Vec::new() },
+    )
+    .with_range_deletion(rt.clone());
+
+    let got = entry.range_deletion.expect("range_deletion present");
+    assert_eq!(got, rt);
+    assert!(matches!(got.end, ClusteringBound::Top));
+    assert_eq!(got.deletion_time, 999);
+    assert_eq!(got.local_deletion_time, 1_700_000_001);
+}


### PR DESCRIPTION
## Summary

Foundation issue for epic **#842** (write/compaction byte-parity). The reader→merge→writer path is whole-cell / row-timestamp granular, so per-element and per-cell reconciliation cannot be byte-faithful regardless of tie-break logic. This PR lands the shared **merge-entry substrate** once, on its own, behavior-neutral, so the dependent behaviors (#844/#846/#848/#887/#888) stay thin instead of each silently rebuilding it.

**Scope is plumbing only** — confirmed against **#899**, which owns the reader-emit rewrite that *populates* these fields. This PR adds the fields/entities; nothing populates or consumes them yet.

## Changes

- `CellData` gains `cell_path: Option<Vec<u8>>` and `local_deletion_time: Option<i32>` (carry-only, default `None`) — the serialized element key/index and on-disk `localDeletionTime` needed for per-path merge (#844) and gc_grace / expiring-cell tie-breaks (#845/#848).
- New first-class `ComplexDeletion { column, marked_for_delete_at, local_deletion_time }` entity, carried on `MergeEntry.complex_deletions`, so a collection/UDT complex-deletion marker survives as a column-scoped entity instead of being reduced to a boolean.
- New `MergeEntry.range_deletion: Option<RangeTombstone>` slot so range tombstones can flow through the merge stream (reusing the existing open-ended `RangeTombstone` / `ClusteringBound` representation) instead of being skipped by the parser.

## Carry-only / byte-neutral

Nothing populates or consumes the new fields:
- `MergeEntry::new` defaults the entities to empty/`None` (no call-site churn; new `with_complex_deletions` / `with_range_deletion` builders for #899).
- The reader still emits whole-column cells with the fields `None`.
- `merge_entry_to_mutation` does not read them.

`RangeTombstone`/`ClusteringBound` now derive `PartialEq + Eq` so `MergeEntry`'s derived `Eq` (required by the heap's `Ord`) still holds with the new `Option<RangeTombstone>` field.

## Acceptance criteria

- [x] New fields (`cell_path`, `local_deletion_time`) added to `CellData`; complex-deletion + range-deletion entities added to `MergeEntry`.
- [x] Unit-tested for presence/round-trip — `tests/issue_886_merge_entry_substrate.rs` (incl. open-ended `Bottom`/`Top` bounds; `cell_path` participating in `CellData` identity; `MergeEntry::new` defaults empty/`None`).
- [x] Reconciliation behavior **byte-for-byte unchanged** — full compaction + sstabledump parity suite green (see gate below).
- [x] Updates `tests/issue_823_complex_column_merge.rs`, the structural-evidence test that explicitly required revisiting if a path field was added (carry-only `cell_path` now exists but stays `None`; per-path merge deferred to #899).

## Gate

```
==== AGENT-GATE SUMMARY ====
fmt:               PASS (2s)
clippy:            PASS (48s)
core-tests:        PASS (281s)
integration-tests: PASS (40s)
format-compat:     PASS (21s)
write-tests:       PASS (27s)
cli-tests:         PASS (40s)
python-bindings:   PASS (55s)
minimal-build:     PASS (2s)
smoke:             PASS (24s)
RESULT: PASS
==== END AGENT-GATE SUMMARY ====
```

Closes #886.