### PR TITLE
Epic #872: BTI canonical-write — emit Cassandra-format da SSTables

### DIFF
--- a/cqlite-core/examples/gen_wide_sstable.rs
+++ b/cqlite-core/examples/gen_wide_sstable.rs
@@ -98,11 +98,14 @@ async fn main() -> cqlite_core::error::Result<()> {
 
     println!("SSTable written to:");
     println!("  Data.db:  {}", info.data_path.display());
-    println!("  Index.db: {}", info.index_path.display());
+    println!(
+        "  Index.db: {}",
+        info.index_path.as_ref().unwrap().display()
+    );
     println!("  Dir:      {}", info.data_path.parent().unwrap().display());
 
     // Verify that promoted index was emitted
-    let index_bytes = std::fs::read(&info.index_path)?;
+    let index_bytes = std::fs::read(info.index_path.as_ref().unwrap())?;
     let key_len = u16::from_be_bytes([index_bytes[0], index_bytes[1]]) as usize;
     let mut pos = 2 + key_len;
     // skip data_offset vint

--- a/cqlite-core/src/storage/sstable/bti/mod.rs
+++ b/cqlite-core/src/storage/sstable/bti/mod.rs
@@ -16,7 +16,7 @@ pub use node::{
     TrieNavigator,
 };
 pub use parser::{
-    decode_bti_partition_payload, encode_partition_key_for_bti_trie,
+    decode_bti_partition_payload, encode_clustering_bound_oss50, encode_partition_key_for_bti_trie,
     iterate_partitions_in_bti_file, iterate_rows_for_partition, iterate_rows_in_bti_file,
     iterate_rows_in_bti_trie, lookup_partition_in_bti_file, lookup_raw_key_in_bti_partitions_db,
     resolve_rows_db_entry, select_row_index_blocks_for_range, BtiHeader, BtiIndexStats,

--- a/cqlite-core/src/storage/sstable/bti/mod.rs
+++ b/cqlite-core/src/storage/sstable/bti/mod.rs
@@ -16,7 +16,8 @@ pub use node::{
     TrieNavigator,
 };
 pub use parser::{
-    decode_bti_partition_payload, encode_clustering_bound_oss50, encode_partition_key_for_bti_trie,
+    decode_bti_partition_payload, encode_clustering_bound_oss50,
+    encode_clustering_bound_oss50_with_order, encode_partition_key_for_bti_trie,
     iterate_partitions_in_bti_file, iterate_rows_for_partition, iterate_rows_in_bti_file,
     iterate_rows_in_bti_trie, lookup_partition_in_bti_file, lookup_raw_key_in_bti_partitions_db,
     resolve_rows_db_entry, select_row_index_blocks_for_range, BtiHeader, BtiIndexStats,

--- a/cqlite-core/src/storage/sstable/bti/parser.rs
+++ b/cqlite-core/src/storage/sstable/bti/parser.rs
@@ -1870,12 +1870,68 @@ fn encode_clustering_component_oss50(value: &Value, out: &mut Vec<u8>) -> BtiRes
 /// per `ClusteringComparator.asByteComparable`), with no leading/trailing frame
 /// so a prefix bound sorts before any longer key sharing it.
 pub fn encode_clustering_bound_oss50(values: &[Value]) -> BtiResult<Vec<u8>> {
+    // All-ascending convenience: every component uses its base byte-comparable
+    // form. Equivalent to `encode_clustering_bound_oss50_with_order` with all
+    // `is_reversed = false`.
     let mut out = Vec::new();
     for (i, v) in values.iter().enumerate() {
         if i > 0 {
             out.push(OSS50_NEXT_COMPONENT);
         }
         encode_clustering_component_oss50(v, &mut out)?;
+    }
+    Ok(out)
+}
+
+/// Encode a multi-component clustering bound applying each column's clustering
+/// **ORDER** (ASC/DESC), producing Cassandra OSS50 byte-comparable separators
+/// that sort in the SAME order the rows are physically written.
+///
+/// ## Why DESC must invert the component bytes
+///
+/// Cassandra wraps a `CLUSTERING ORDER BY (c DESC)` column's type in
+/// `ReversedType`. `ReversedType.asComparableBytes` delegates to the base type's
+/// byte-comparable production and then inverts the resulting [`ByteSource`] via
+/// `ByteSource.invert(...)`, which complements every emitted data byte
+/// (`b -> 0xFF ^ b`). Complementing every byte of a (weakly prefix-free)
+/// byte-comparable encoding reverses its lexicographic order, so a DESCENDING
+/// value order maps to an ASCENDING byte order. This is exactly what a `Rows.db`
+/// row-index trie needs: separators are always stored in ascending *byte* order,
+/// while the underlying clustering values run descending for a DESC column.
+/// (cassandra-5.0.0 `org.apache.cassandra.db.marshal.ReversedType.asComparableBytes`
+/// + `org.apache.cassandra.utils.bytecomparable.ByteSource.invert`.)
+///
+/// The inter-component framing byte ([`OSS50_NEXT_COMPONENT`], `0x40`) is emitted
+/// by the *comparator* (`ClusteringComparator.asByteComparable`), NOT by a
+/// component's type, so it is **not** inverted even when neighbouring components
+/// are DESC — only the per-component byte-comparable bytes are complemented. This
+/// matches Cassandra, where each `subtype(i)` (possibly a `ReversedType`) emits
+/// its own (already inverted) byte source and the comparator separates them with
+/// the un-inverted `NEXT_COMPONENT` byte.
+///
+/// `is_reversed[i]` MUST correspond positionally to `values[i]` (i.e. the schema
+/// clustering-key order). A short `is_reversed` slice treats missing entries as
+/// ascending (`false`).
+pub fn encode_clustering_bound_oss50_with_order(
+    values: &[Value],
+    is_reversed: &[bool],
+) -> BtiResult<Vec<u8>> {
+    let mut out = Vec::new();
+    for (i, v) in values.iter().enumerate() {
+        if i > 0 {
+            out.push(OSS50_NEXT_COMPONENT);
+        }
+        if is_reversed.get(i).copied().unwrap_or(false) {
+            // Encode the base component into a scratch buffer, then complement
+            // every byte (ReversedType / ByteSource.invert).
+            let mut scratch = Vec::new();
+            encode_clustering_component_oss50(v, &mut scratch)?;
+            for b in &scratch {
+                out.push(0xFF ^ *b);
+            }
+        } else {
+            encode_clustering_component_oss50(v, &mut out)?;
+        }
     }
     Ok(out)
 }
@@ -2423,6 +2479,34 @@ impl<R: Read + Seek> RowsParser<R> {
             return Ok(Vec::new());
         }
         let (_, blocks) = self.range_query_encoded(rows_offset, &encoded_start, &encoded_end)?;
+        Ok(blocks)
+    }
+
+    /// Order-aware typed clustering range query: the read-side counterpart to the
+    /// writer's [`encode_clustering_bound_oss50_with_order`]. The trie stores
+    /// DESC columns' separators in REVERSED byte-comparable form (complemented
+    /// bytes), so a lookup MUST encode its bounds with the SAME per-column order
+    /// and then compare in the trie's ascending BYTE order.
+    ///
+    /// `is_reversed[i]` matches `start_key[i]`/`end_key[i]` positionally (schema
+    /// clustering order). For a DESC leading column the value bound `lo` encodes
+    /// to LARGER bytes than `hi`, so after encoding we take the min/max of the
+    /// two encoded byte sequences as the ascending byte range handed to
+    /// [`select_row_index_blocks_for_range`]. This keeps writer↔reader
+    /// consistent: both sides agree the on-disk separators are reversed bytes for
+    /// DESC, and block selection always operates in ascending byte space.
+    pub fn range_query_with_order(
+        &mut self,
+        rows_offset: usize,
+        start_key: &[Value],
+        end_key: &[Value],
+        is_reversed: &[bool],
+    ) -> BtiResult<Vec<BtiRowIndexEntry>> {
+        let a = encode_clustering_bound_oss50_with_order(start_key, is_reversed)?;
+        let b = encode_clustering_bound_oss50_with_order(end_key, is_reversed)?;
+        // Map the value range to the ascending BYTE range the trie is keyed on.
+        let (lo, hi) = if a <= b { (a, b) } else { (b, a) };
+        let (_, blocks) = self.range_query_encoded(rows_offset, &lo, &hi)?;
         Ok(blocks)
     }
 
@@ -4228,6 +4312,73 @@ mod tests {
 
         // Unsupported clustering type errors out explicitly.
         assert!(encode_clustering_bound_oss50(&[Value::Float(1.0)]).is_err());
+    }
+
+    /// Order-aware OSS50 encoder (DESC clustering): a `CLUSTERING ORDER BY DESC`
+    /// column wraps in Cassandra `ReversedType`, whose `asComparableBytes`
+    /// complements every byte of the base byte-comparable form
+    /// (`ByteSource.invert`). The result: DESCENDING value order maps to
+    /// ASCENDING byte order, so a `Rows.db` row-index trie can store the
+    /// separators (which must be strictly ascending bytes).
+    #[test]
+    fn oss50_clustering_encoder_reversed_order() {
+        // DESC int(8): base 80 00 00 08, complemented -> 7F FF FF F7.
+        assert_eq!(
+            encode_clustering_bound_oss50_with_order(&[Value::Integer(8)], &[true]).unwrap(),
+            vec![0x7F, 0xFF, 0xFF, 0xF7]
+        );
+        // ASC path is identical to the plain encoder.
+        assert_eq!(
+            encode_clustering_bound_oss50_with_order(&[Value::Integer(8)], &[false]).unwrap(),
+            encode_clustering_bound_oss50(&[Value::Integer(8)]).unwrap()
+        );
+
+        // The decisive property: for DESC, larger VALUE => smaller BYTES, i.e.
+        // writing rows in descending value order yields ascending separator
+        // bytes. Take values 0,1,..,5 (the physical DESC write order is 5..0).
+        let enc = |v: i32| {
+            encode_clustering_bound_oss50_with_order(&[Value::Integer(v)], &[true]).unwrap()
+        };
+        // Physical write order for DESC: 5,4,3,2,1,0. Their separator bytes must
+        // be strictly ASCENDING in that same sequence.
+        let write_order = [5, 4, 3, 2, 1, 0];
+        for w in write_order.windows(2) {
+            assert!(
+                enc(w[0]) < enc(w[1]),
+                "DESC: value {} written before {} must yield smaller separator bytes",
+                w[0],
+                w[1]
+            );
+        }
+
+        // Mixed ASC/DESC: first column ASC int, second column DESC int. The
+        // NEXT_COMPONENT (0x40) framing byte is NOT inverted; only the DESC
+        // component's bytes are complemented.
+        let mixed = encode_clustering_bound_oss50_with_order(
+            &[Value::Integer(1), Value::Integer(8)],
+            &[false, true],
+        )
+        .unwrap();
+        assert_eq!(
+            mixed,
+            vec![0x80, 0x00, 0x00, 0x01, 0x40, 0x7F, 0xFF, 0xFF, 0xF7],
+            "ASC component bare, 0x40 framing un-inverted, DESC component complemented"
+        );
+
+        // Mixed-order monotonicity: for equal leading ASC component, the trailing
+        // DESC component must reverse the byte order (descending value second
+        // component => ascending bytes).
+        let m = |a: i32, b: i32| {
+            encode_clustering_bound_oss50_with_order(
+                &[Value::Integer(a), Value::Integer(b)],
+                &[false, true],
+            )
+            .unwrap()
+        };
+        // Same first key (1), second key descending 9,8,7 -> ascending bytes.
+        assert!(m(1, 9) < m(1, 8) && m(1, 8) < m(1, 7));
+        // Different first key dominates regardless of second (ASC leading).
+        assert!(m(1, 0) < m(2, 9));
     }
 
     /// Multi-byte unsigned vint decode (count-leading-ones, NOT zigzag).

--- a/cqlite-core/src/storage/sstable/bti/parser.rs
+++ b/cqlite-core/src/storage/sstable/bti/parser.rs
@@ -1652,6 +1652,21 @@ fn read_signed_vint_from_slice(data: &[u8]) -> BtiResult<(i64, usize)> {
     Ok((value, n))
 }
 
+/// Test-only re-export of [`read_unsigned_vint_from_slice`] so the BTI `Rows.db`
+/// writer (`writer::partitions_writer`) can assert its unsigned-VInt encoder is
+/// the exact inverse of this reader decoder.
+#[doc(hidden)]
+pub fn read_unsigned_vint_from_slice_for_test(data: &[u8]) -> BtiResult<(u64, usize)> {
+    read_unsigned_vint_from_slice(data)
+}
+
+/// Test-only re-export of [`read_signed_vint_from_slice`] (see
+/// [`read_unsigned_vint_from_slice_for_test`]).
+#[doc(hidden)]
+pub fn read_signed_vint_from_slice_for_test(data: &[u8]) -> BtiResult<(i64, usize)> {
+    read_signed_vint_from_slice(data)
+}
+
 /// Resolve a partition's row-index entry in `Rows.db`, given the `RowsOffset`
 /// from a `Partitions.db` lookup ([`BtiPartitionLocation::RowsOffset`]).
 ///
@@ -1854,7 +1869,7 @@ fn encode_clustering_component_oss50(value: &Value, out: &mut Vec<u8>) -> BtiRes
 /// encodings separated by [`OSS50_NEXT_COMPONENT`] (`ByteSource.NEXT_COMPONENT`,
 /// per `ClusteringComparator.asByteComparable`), with no leading/trailing frame
 /// so a prefix bound sorts before any longer key sharing it.
-fn encode_clustering_bound_oss50(values: &[Value]) -> BtiResult<Vec<u8>> {
+pub fn encode_clustering_bound_oss50(values: &[Value]) -> BtiResult<Vec<u8>> {
     let mut out = Vec::new();
     for (i, v) in values.iter().enumerate() {
         if i > 0 {

--- a/cqlite-core/src/storage/sstable/bti/parser.rs
+++ b/cqlite-core/src/storage/sstable/bti/parser.rs
@@ -2489,12 +2489,23 @@ impl<R: Read + Seek> RowsParser<R> {
     /// and then compare in the trie's ascending BYTE order.
     ///
     /// `is_reversed[i]` matches `start_key[i]`/`end_key[i]` positionally (schema
-    /// clustering order). For a DESC leading column the value bound `lo` encodes
-    /// to LARGER bytes than `hi`, so after encoding we take the min/max of the
-    /// two encoded byte sequences as the ascending byte range handed to
-    /// [`select_row_index_blocks_for_range`]. This keeps writer↔reader
-    /// consistent: both sides agree the on-disk separators are reversed bytes for
-    /// DESC, and block selection always operates in ascending byte space.
+    /// clustering order). Both bounds are encoded WITH the per-column order, so
+    /// the on-disk-equivalent ascending BYTE encoding is produced directly: for a
+    /// DESC column the reversed (complemented) bytes already sort in the trie's
+    /// ascending byte space. The encoded bounds are then compared in that byte
+    /// space and handed to [`select_row_index_blocks_for_range`] UNCHANGED.
+    ///
+    /// ## Reversed-bounds contract (matches [`range_query`])
+    ///
+    /// Like [`range_query`], a reversed range yields an empty result rather than
+    /// silently re-ordering the bounds. After encoding, if `encoded_start`
+    /// sorts strictly after `encoded_end` in trie byte order, return
+    /// `Ok(Vec::new())`. The bounds are NOT swapped — so with all columns ASC the
+    /// behavior is byte-for-byte identical to [`range_query`], and with DESC
+    /// columns the per-column inversion gives the correct comparator-order
+    /// semantics (a DESC range `[start, end]` where `start` precedes `end` in
+    /// value order encodes to `encoded_start <= encoded_end` in byte space, and a
+    /// genuinely reversed DESC range correctly yields empty).
     pub fn range_query_with_order(
         &mut self,
         rows_offset: usize,
@@ -2502,11 +2513,14 @@ impl<R: Read + Seek> RowsParser<R> {
         end_key: &[Value],
         is_reversed: &[bool],
     ) -> BtiResult<Vec<BtiRowIndexEntry>> {
-        let a = encode_clustering_bound_oss50_with_order(start_key, is_reversed)?;
-        let b = encode_clustering_bound_oss50_with_order(end_key, is_reversed)?;
-        // Map the value range to the ascending BYTE range the trie is keyed on.
-        let (lo, hi) = if a <= b { (a, b) } else { (b, a) };
-        let (_, blocks) = self.range_query_encoded(rows_offset, &lo, &hi)?;
+        let encoded_start = encode_clustering_bound_oss50_with_order(start_key, is_reversed)?;
+        let encoded_end = encode_clustering_bound_oss50_with_order(end_key, is_reversed)?;
+        // Reversed bounds in the trie's ascending byte space yield empty, exactly
+        // like `range_query`. Do NOT swap — pass the encoded bounds through as-is.
+        if encoded_start > encoded_end {
+            return Ok(Vec::new());
+        }
+        let (_, blocks) = self.range_query_encoded(rows_offset, &encoded_start, &encoded_end)?;
         Ok(blocks)
     }
 
@@ -4733,6 +4747,164 @@ mod tests {
             filter(&[0x10, 0x00], &[0x10, 0x10]),
             Vec::<u64>::new(),
             "a range strictly between K and K2 must exclude both"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // range_query_with_order: reversed-bounds contract parity with range_query
+    // -----------------------------------------------------------------------
+
+    /// Wrap a single-byte-keyed 3-leaf Rows.db trie behind a synthetic
+    /// per-partition `TrieIndexEntry`, returning `(buffer, rows_offset)` suitable
+    /// for `RowsParser::range_query` / `range_query_with_order`.
+    ///
+    /// Transition bytes `k1<k2<k3` are the (already byte-comparable) single-byte
+    /// separators — e.g. the OSS50 encodings of `tinyint` clustering values, which
+    /// are exactly one byte each (`v ^ 0x80`, or `0xFF ^ (v ^ 0x80)` for DESC).
+    /// The trie is built first, then the `TrieIndexEntry` is appended; the entry's
+    /// `rootΔ` points back at the trie root, mirroring the real `Rows.db` layout
+    /// and the `resolve_rows_db_entry` tests above.
+    fn make_rows_db_with_three(
+        (k1, p1): (u8, u8),
+        (k2, p2): (u8, u8),
+        (k3, p3): (u8, u8),
+    ) -> (Vec<u8>, usize) {
+        let (trie, root) = make_rows_trie_three((k1, p1), (k2, p2), (k3, p3));
+        let mut buf = trie; // bytes [0, root..] are the trie nodes
+        let rows_offset = buf.len(); // TrieIndexEntry starts right after the trie
+
+        // key: length 4, value 0x00000007 (content is irrelevant to range tests).
+        buf.extend_from_slice(&4u16.to_be_bytes());
+        buf.extend_from_slice(&[0x00, 0x00, 0x00, 0x07]);
+        let base = rows_offset + 4; // RowsOffset + key_length
+
+        // dataPos = 0 (unsigned vint); block offsets are relative to it.
+        buf.push(0);
+        // rootΔ such that trie_root = `root`: Δ = root - base (zigzag + uvint).
+        let root_delta: i64 = root as i64 - base as i64;
+        let zig = ((root_delta << 1) ^ (root_delta >> 63)) as u64;
+        // Emit as a (possibly multi-byte) unsigned vint, MSB-first count-of-ones.
+        write_uvint(&mut buf, zig);
+        // blockCount = 3 (unsigned vint).
+        buf.push(3);
+        // partition DeletionTime: MODERN DA live sentinel (no deletion).
+        buf.push(0x80);
+
+        (buf, rows_offset)
+    }
+
+    /// Minimal unsigned-vint writer (count-leading-ones form, matching
+    /// [`read_unsigned_vint_from_slice`]) for test fixtures. Only the 1- and
+    /// 2-byte forms are needed for the small `rootΔ` magnitudes used here.
+    fn write_uvint(out: &mut Vec<u8>, v: u64) {
+        if v < 0x80 {
+            // 1-byte form: high bit 0, 7 data bits.
+            out.push(v as u8);
+            return;
+        }
+        // 2-byte form: leading byte `10xxxxxx` (1 leading one, 0 separator, 6
+        // data bits) + 1 trailing byte = 14 data bits.
+        assert!(v < 0x4000, "test vint fixture expects <= 14-bit values");
+        out.push(0x80 | (v >> 8) as u8);
+        out.push((v & 0xFF) as u8);
+    }
+
+    /// `range_query_with_order` with all columns ASC must behave byte-for-byte
+    /// like `range_query`: a forward range returns the same blocks, and a
+    /// REVERSED range returns empty (it must NOT swap the bounds).
+    #[test]
+    fn range_query_with_order_all_asc_matches_range_query() {
+        // tinyint clustering values 3,5,9 → OSS50 single-byte separators
+        // 0x83, 0x85, 0x89 (v ^ 0x80). Block offsets 5,17,99.
+        let v = |t: i8| (t as u8) ^ 0x80;
+        let (buf, rows_offset) = make_rows_db_with_three((v(3), 5), (v(5), 17), (v(9), 99));
+
+        let start = [Value::TinyInt(3)];
+        let end = [Value::TinyInt(9)];
+
+        // Forward all-ASC range: both APIs return identical blocks.
+        let mut p1 = RowsParser::new(Cursor::new(buf.clone())).unwrap();
+        let plain = p1.range_query(rows_offset, &start, &end).unwrap();
+        let mut p2 = RowsParser::new(Cursor::new(buf.clone())).unwrap();
+        let ordered = p2
+            .range_query_with_order(rows_offset, &start, &end, &[false])
+            .unwrap();
+        assert_eq!(
+            ordered, plain,
+            "all-ASC range_query_with_order must equal range_query (forward)"
+        );
+        let offs: Vec<u64> = ordered.iter().map(|b| b.data_offset).collect();
+        assert_eq!(
+            offs,
+            vec![5, 17, 99],
+            "forward range returns all three blocks"
+        );
+
+        // Reversed bounds (start=9, end=3): range_query returns empty; the
+        // order-aware variant MUST do the same (NO swap).
+        let mut p3 = RowsParser::new(Cursor::new(buf.clone())).unwrap();
+        let plain_rev = p3.range_query(rows_offset, &end, &start).unwrap();
+        let mut p4 = RowsParser::new(Cursor::new(buf)).unwrap();
+        let ordered_rev = p4
+            .range_query_with_order(rows_offset, &end, &start, &[false])
+            .unwrap();
+        assert!(
+            plain_rev.is_empty(),
+            "sanity: range_query is empty for reversed bounds"
+        );
+        assert_eq!(
+            ordered_rev, plain_rev,
+            "all-ASC reversed range must yield empty, matching range_query (no swap)"
+        );
+    }
+
+    /// DESC clustering: the trie stores reversed (complemented) byte-comparable
+    /// separators. A forward DESC range (value `start` precedes `end` in DESC
+    /// VALUE order, i.e. `start > end` numerically) returns its blocks, while a
+    /// genuinely reversed DESC range yields EMPTY — never swapped.
+    #[test]
+    fn range_query_with_order_desc_reversed_yields_empty() {
+        // DESC tinyint: separator byte = 0xFF ^ (v ^ 0x80). Physical DESC write
+        // order is 9,5,3 → ascending separator bytes. Build the trie in that
+        // ascending-byte order with offsets 5,17,99.
+        let dv = |t: i8| 0xFFu8 ^ ((t as u8) ^ 0x80);
+        // dv(9) < dv(5) < dv(3) (descending value => ascending bytes).
+        assert!(dv(9) < dv(5) && dv(5) < dv(3));
+        let (buf, rows_offset) = make_rows_db_with_three((dv(9), 5), (dv(5), 17), (dv(3), 99));
+
+        // Forward DESC range in VALUE space: from 9 down to 3 (9 precedes 3 in a
+        // DESC clustering order). Encoded start = dv(9) which is < dv(3) = encoded
+        // end, so this is a valid forward byte range and returns all three blocks.
+        let mut pf = RowsParser::new(Cursor::new(buf.clone())).unwrap();
+        let fwd = pf
+            .range_query_with_order(
+                rows_offset,
+                &[Value::TinyInt(9)],
+                &[Value::TinyInt(3)],
+                &[true],
+            )
+            .unwrap();
+        let offs: Vec<u64> = fwd.iter().map(|b| b.data_offset).collect();
+        assert_eq!(
+            offs,
+            vec![5, 17, 99],
+            "forward DESC range (9..3 in DESC value order) returns all blocks"
+        );
+
+        // Reversed DESC range: from 3 up to 9 (3 comes AFTER 9 in DESC order).
+        // Encoded start = dv(3) > dv(9) = encoded end → empty, NOT swapped.
+        let mut pr = RowsParser::new(Cursor::new(buf)).unwrap();
+        let rev = pr
+            .range_query_with_order(
+                rows_offset,
+                &[Value::TinyInt(3)],
+                &[Value::TinyInt(9)],
+                &[true],
+            )
+            .unwrap();
+        assert!(
+            rev.is_empty(),
+            "reversed DESC range must yield empty (encoded_start > encoded_end), no swap"
         );
     }
 }

--- a/cqlite-core/src/storage/sstable/reader/data_access.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access.rs
@@ -189,19 +189,25 @@ impl SSTableReader {
 
     /// Get a value by key from the SSTable
     pub async fn get(&self, table_id: &TableId, key: &RowKey) -> Result<Option<Value>> {
+        // Issue #831 / #909: BTI ("da") readers resolve partitions via the
+        // Partitions.db trie (O(log n)), never via Index.db (absent for BTI) or
+        // the sequential scan. The trie is the AUTHORITATIVE presence oracle for a
+        // BTI SSTable — it answers present/absent definitively — so we branch here
+        // BEFORE the bloom-filter pre-check. Skipping the bloom filter for BTI is
+        // both correct (the trie is authoritative; bloom is only an optimization)
+        // and necessary: a writer-produced Filter.db whose hashing does not match
+        // the reader's would otherwise cause false negatives and drop live
+        // partitions (the writer→reader roundtrip #909 must read back). It also
+        // guarantees a BTI get() can never fall through to scan_for_key.
+        if self.bti_partitions_db.is_some() {
+            return self.bti_point_lookup(table_id, key).await;
+        }
+
         // First check bloom filter if available
         if let Some(bloom_filter) = &self.bloom_filter {
             if !bloom_filter.might_contain(key.as_bytes()) {
                 return Ok(None);
             }
-        }
-
-        // Issue #831: BTI ("da") readers resolve partitions via the Partitions.db
-        // trie (O(log n)), never via Index.db (absent for BTI) or the sequential
-        // scan. Branch BEFORE the Index.db block so a BTI get() can never fall
-        // through to scan_for_key.
-        if self.bti_partitions_db.is_some() {
-            return self.bti_point_lookup(table_id, key).await;
         }
 
         // Use index for efficient lookup if available

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -181,41 +181,65 @@ impl SSTableReader {
             }
         });
 
-        // VG5 / Issue #831: BTI ("da") read support.
+        // VG5 / Issue #831 / #909: BTI ("da") read support.
         //
-        // BTI SSTables use a Partitions.db trie (and optional Rows.db) instead of
-        // Index.db/Summary.db. We load the (tiny) Partitions.db trie fully into
-        // memory here so the point-lookup path (`lookup_partition_via_bti_trie` /
-        // `bti_point_lookup`) can walk it for O(log n) partition resolution.
+        // BTI SSTables use a Partitions.db trie + Rows.db row index instead of
+        // Index.db/Summary.db. We load BOTH (tiny) tries fully into memory here so
+        // the point-lookup path (`lookup_partition_via_bti_trie` /
+        // `bti_point_lookup`) can walk them for O(log n) partition resolution:
+        //   - Partitions.db resolves a partition key to either a direct Data.db
+        //     offset (NARROW partition) or a positive RowsOffset (WIDE partition).
+        //   - Rows.db, indexed by that RowsOffset, recovers the wide partition's
+        //     Data.db position (issue #909/#910).
         //
-        // Loading Partitions.db is the ONLY BTI-specific step in open(): the rest
-        // of the flow (header / compression / Statistics-driven schema) tolerates
-        // the absent Index.db/Summary.db gracefully (those loaders return None).
-        let bti_partitions_db: Option<Arc<Vec<u8>>> =
-            if matches!(*version_gates, VersionGates::Bti(_)) {
-                let base = extract_sstable_base_name(path).ok_or_else(|| {
-                    Error::unsupported_format(format!(
-                        "BTI (da) SSTable '{}' has a non-standard filename; cannot derive the \
+        // Loading Partitions.db + Rows.db is the ONLY BTI-specific step in open():
+        // the rest of the flow (header / compression / Statistics-driven schema)
+        // tolerates the absent Index.db/Summary.db gracefully (those loaders
+        // return None).
+        let (bti_partitions_db, bti_rows_db) = if matches!(*version_gates, VersionGates::Bti(_)) {
+            let base = extract_sstable_base_name(path).ok_or_else(|| {
+                Error::unsupported_format(format!(
+                    "BTI (da) SSTable '{}' has a non-standard filename; cannot derive the \
                          sibling Partitions.db name required for trie point lookup (#831).",
-                        path.display()
-                    ))
-                })?;
-                let parent = path.parent().unwrap_or_else(|| Path::new("."));
-                let partitions_path = parent.join(format!("{}-Partitions.db", base));
-                let bytes = tokio::fs::read(&partitions_path).await.map_err(|e| {
-                    Error::unsupported_format(format!(
-                        "BTI (da) SSTable '{}' is missing its sibling Partitions.db trie \
+                    path.display()
+                ))
+            })?;
+            let parent = path.parent().unwrap_or_else(|| Path::new("."));
+            let partitions_path = parent.join(format!("{}-Partitions.db", base));
+            let partitions_bytes = tokio::fs::read(&partitions_path).await.map_err(|e| {
+                Error::unsupported_format(format!(
+                    "BTI (da) SSTable '{}' is missing its sibling Partitions.db trie \
                          (expected '{}'): {}. BTI read support requires Partitions.db for \
                          partition-key point lookup (#831).",
-                        path.display(),
-                        partitions_path.display(),
-                        e
-                    ))
-                })?;
-                Some(Arc::new(bytes))
-            } else {
-                None
-            };
+                    path.display(),
+                    partitions_path.display(),
+                    e
+                ))
+            })?;
+
+            // Rows.db carries the within-partition row index for WIDE
+            // partitions (issue #909/#910). It is ALWAYS emitted for a BTI
+            // SSTable (possibly 0 bytes for a narrow-only table), so a missing
+            // Rows.db is a structural error. A 0-byte file is valid: no
+            // partition resolved to a positive RowsOffset, so the point-lookup
+            // path never indexes into it.
+            let rows_path = parent.join(format!("{}-Rows.db", base));
+            let rows_bytes = tokio::fs::read(&rows_path).await.map_err(|e| {
+                Error::unsupported_format(format!(
+                    "BTI (da) SSTable '{}' is missing its sibling Rows.db row-index trie \
+                         (expected '{}'): {}. BTI read support requires Rows.db to resolve \
+                         wide-partition point lookups (#909/#910).",
+                    path.display(),
+                    rows_path.display(),
+                    e
+                ))
+            })?;
+
+            (Some(Arc::new(partitions_bytes)), Some(Arc::new(rows_bytes)))
+        } else {
+            let none: Option<Arc<Vec<u8>>> = None;
+            (none.clone(), none)
+        };
 
         let config = crate::cql::config::ParserConfig::default();
         let parser = SSTableParser::new(config)?;
@@ -398,6 +422,7 @@ impl SSTableReader {
             scan_mutex: tokio::sync::Mutex::new(()),
             version_gates,
             bti_partitions_db,
+            bti_rows_db,
         })
     }
 

--- a/cqlite-core/src/storage/sstable/reader/partition_lookup.rs
+++ b/cqlite-core/src/storage/sstable/reader/partition_lookup.rs
@@ -56,21 +56,30 @@ impl SSTableReader {
     /// trie to resolve the partition's location. Returns:
     ///
     /// - `Ok(Some(offset))` — the UNCOMPRESSED Data.db byte offset of the
-    ///   partition (`BtiPartitionLocation::DataOffset`). INVARIANT: this offset
-    ///   indexes into the DECOMPRESSED data section, never raw file bytes.
+    ///   partition. INVARIANT: this offset indexes into the DECOMPRESSED data
+    ///   section, never raw file bytes. The offset is resolved in one of two ways:
+    ///     - **NARROW** partition (`BtiPartitionLocation::DataOffset`) — the trie
+    ///       returns the Data.db offset directly.
+    ///     - **WIDE** partition (`BtiPartitionLocation::RowsOffset`) — the trie
+    ///       returns a positive offset into `Rows.db`; we deserialize that
+    ///       partition's `TrieIndexEntry` via [`resolve_rows_db_entry`] and use its
+    ///       recovered `data_position` (issue #909/#910). Both forms share the same
+    ///       uncompressed Data.db offset domain, so the caller treats them
+    ///       identically.
     /// - `Ok(None)` — the reader is not BTI, or the key has no trie path (the
     ///   partition is definitely absent from this SSTable).
-    /// - `Err(_)` — a structural trie parse error, or a `RowsOffset` result (the
-    ///   Rows.db read path is not yet implemented; narrow tables like
-    ///   `simple_table` always resolve to `DataOffset`).
+    /// - `Err(_)` — a structural trie parse error, or a `RowsOffset` was returned
+    ///   without an accompanying `Rows.db` (a structurally invalid BTI SSTable).
     ///
     /// Because the BTI trie uses path compression, a returned offset may be a
     /// candidate for a *prefix-colliding* key. The caller (`bti_point_lookup`)
     /// MUST verify the partition-key bytes at the resolved offset equal the
     /// queried key before returning rows.
+    ///
+    /// [`resolve_rows_db_entry`]: crate::storage::sstable::bti::resolve_rows_db_entry
     pub fn lookup_partition_via_bti_trie(&self, partition_key: &[u8]) -> Result<Option<u64>> {
         use crate::storage::sstable::bti::{
-            lookup_raw_key_in_bti_partitions_db, BtiPartitionLocation,
+            lookup_raw_key_in_bti_partitions_db, resolve_rows_db_entry, BtiPartitionLocation,
         };
 
         let Some(partitions_db) = &self.bti_partitions_db else {
@@ -88,19 +97,49 @@ impl SSTableReader {
         })? {
             Some(BtiPartitionLocation::DataOffset(off)) => {
                 debug!(
-                    "BTI trie resolved partition (key len={}) to Data.db offset {}",
+                    "BTI trie resolved NARROW partition (key len={}) to Data.db offset {}",
                     partition_key.len(),
                     off
                 );
                 Ok(Some(off))
             }
-            Some(BtiPartitionLocation::RowsOffset(off)) => Err(Error::unsupported_format(format!(
-                "BTI Rows.db read path not yet implemented (trie returned RowsOffset({}) \
-                 for partition key len={}). Wide-partition BTI tables are out of scope for \
-                 issue #831.",
-                off,
-                partition_key.len()
-            ))),
+            Some(BtiPartitionLocation::RowsOffset(rows_offset)) => {
+                // WIDE partition: the trie pointed at this partition's
+                // TrieIndexEntry inside Rows.db. Deserialize it to recover the
+                // partition's Data.db start position (`data_position`), which lives
+                // in the SAME uncompressed-offset domain the narrow path uses, so
+                // the caller can decode the partition identically (#909/#910).
+                let rows_db = self.bti_rows_db.as_ref().ok_or_else(|| {
+                    Error::corruption(format!(
+                        "BTI Partitions.db trie returned RowsOffset({}) for partition key \
+                         (len={}) but this reader has no Rows.db loaded; the SSTable is \
+                         structurally invalid (Rows.db is required for wide partitions).",
+                        rows_offset,
+                        partition_key.len()
+                    ))
+                })?;
+
+                let header = resolve_rows_db_entry(rows_db.as_slice(), rows_offset as usize)
+                    .map_err(|e| {
+                        Error::corruption(format!(
+                            "BTI Rows.db row-index entry at RowsOffset({}) is unreadable for \
+                             partition key (len={}): {}",
+                            rows_offset,
+                            partition_key.len(),
+                            e
+                        ))
+                    })?;
+
+                debug!(
+                    "BTI trie resolved WIDE partition (key len={}) via RowsOffset {} -> Data.db \
+                     position {} ({} row-index blocks)",
+                    partition_key.len(),
+                    rows_offset,
+                    header.data_position,
+                    header.block_count
+                );
+                Ok(Some(header.data_position))
+            }
             None => Ok(None),
         }
     }

--- a/cqlite-core/src/storage/sstable/reader/types.rs
+++ b/cqlite-core/src/storage/sstable/reader/types.rs
@@ -294,4 +294,17 @@ pub struct SSTableReader {
     /// uncompressed Data.db offset for a partition key — an O(log n) point lookup
     /// instead of the sequential scan used when no index is available.
     pub(crate) bti_partitions_db: Option<Arc<Vec<u8>>>,
+    /// Raw bytes of the sibling BTI `*-Rows.db` within-partition row-index trie,
+    /// when this reader was opened on a BTI ("da") SSTable (issue #909, #910).
+    ///
+    /// `Some` for BTI SSTables (always emitted, possibly 0 bytes for a
+    /// narrow-only table), `None` for BIG-format SSTables. The BTI point-lookup
+    /// path uses this to resolve a WIDE partition: the `Partitions.db` trie
+    /// returns a positive `RowsOffset` pointing at the partition's
+    /// `TrieIndexEntry` inside `Rows.db`; [`resolve_rows_db_entry`] then recovers
+    /// the partition's uncompressed `Data.db` position (`data_position`), which is
+    /// the same offset domain a NARROW partition's direct `DataOffset` uses.
+    ///
+    /// [`resolve_rows_db_entry`]: crate::storage::sstable::bti::resolve_rows_db_entry
+    pub(crate) bti_rows_db: Option<Arc<Vec<u8>>>,
 }

--- a/cqlite-core/src/storage/sstable/writer/data_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer.rs
@@ -649,8 +649,24 @@ impl DataWriter {
                         .map(|ck| ck.columns.iter().map(|(_, v)| v.clone()).collect()),
                     PartitionItem::Marker { .. } => None,
                 };
+                // Per-column clustering ORDER (ASC/DESC). For a DESC column the
+                // OSS50 separator bytes must be the REVERSED byte-comparable form
+                // (Cassandra `ReversedType`/`ByteSource.invert`: complement every
+                // byte) so that descending value order maps to ascending byte
+                // order — otherwise the strict-ascending separator check rejects
+                // the trie and the wide partition silently falls back to a direct
+                // Data.db offset (roborev MEDIUM, issue #910 follow-up).
+                let is_reversed: Vec<bool> = schema
+                    .clustering_keys
+                    .iter()
+                    .map(|c| c.order == crate::schema::ClusteringOrder::Desc)
+                    .collect();
                 current_block_oss50 = Some(ck_values.and_then(|vals| {
-                    crate::storage::sstable::bti::encode_clustering_bound_oss50(&vals).ok()
+                    crate::storage::sstable::bti::encode_clustering_bound_oss50_with_order(
+                        &vals,
+                        &is_reversed,
+                    )
+                    .ok()
                 }));
             }
             current_block_last_ck = Some(ck_bytes.clone());

--- a/cqlite-core/src/storage/sstable/writer/data_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer.rs
@@ -611,6 +611,9 @@ impl DataWriter {
         let mut block_start_buf_offset = self.buffer.len() - partition_buf_start;
         let mut current_block_first_ck: Option<Vec<u8>> = None;
         let mut current_block_last_ck: Option<Vec<u8>> = None;
+        // OSS50 byte-comparable separator (first unfiltered's clustering) for the
+        // BTI Rows.db row-index trie (issue #910). `None` until the first item.
+        let mut current_block_oss50: Option<Option<Vec<u8>>> = None;
 
         for item in items {
             // Clustering key bytes for this item (serialized as ClusteringPrefix).
@@ -634,6 +637,21 @@ impl DataWriter {
 
             if current_block_first_ck.is_none() {
                 current_block_first_ck = Some(ck_bytes.clone());
+                // OSS50 byte-comparable separator from the first unfiltered's
+                // clustering values (issue #910). Markers and no-CK rows yield
+                // None (no row-index separator). Encoding errors degrade to None
+                // — the partition then keeps a direct Data.db offset rather than
+                // emitting a separator the reader cannot reconstruct.
+                let ck_values: Option<Vec<Value>> = match &item {
+                    PartitionItem::Row(row) => row
+                        .clustering_key
+                        .filter(|ck| !ck.columns.is_empty())
+                        .map(|ck| ck.columns.iter().map(|(_, v)| v.clone()).collect()),
+                    PartitionItem::Marker { .. } => None,
+                };
+                current_block_oss50 = Some(ck_values.and_then(|vals| {
+                    crate::storage::sstable::bti::encode_clustering_bound_oss50(&vals).ok()
+                }));
             }
             current_block_last_ck = Some(ck_bytes.clone());
 
@@ -668,11 +686,13 @@ impl DataWriter {
                     last_name: current_block_last_ck.take().unwrap_or_else(|| vec![0x00]),
                     offset: block_start_buf_offset as u64,
                     width: block_bytes,
+                    oss50_separator: current_block_oss50.take().flatten(),
                 });
                 block_start_buf_offset = current_buf_offset;
                 // first/last reset for next block
                 current_block_first_ck = None;
                 current_block_last_ck = None;
+                current_block_oss50 = None;
             }
         }
 
@@ -689,6 +709,7 @@ impl DataWriter {
                     last_name: last,
                     offset: block_start_buf_offset as u64,
                     width: block_bytes,
+                    oss50_separator: current_block_oss50.take().flatten(),
                 });
             }
         }

--- a/cqlite-core/src/storage/sstable/writer/index_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/index_writer.rs
@@ -98,7 +98,7 @@ pub const INDEX_INFO_WIDTH_BASE: u64 = 64 * 1024;
 /// Cassandra emits one block per `column_index_size` (64 KiB) boundary crossed.
 /// A promoted index is only written when there are **two or more** blocks
 /// (`RowIndexEntry.create()` lines 227-239).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct PromotedIndexBlock {
     /// Serialized `ClusteringPrefix` for the first unfiltered in this block.
     ///
@@ -116,6 +116,15 @@ pub struct PromotedIndexBlock {
 
     /// Total width (bytes) of this block's data.
     pub width: u64,
+
+    /// OSS50 byte-comparable separator key for this block (the first unfiltered's
+    /// clustering prefix), used by the BTI `Rows.db` row-index trie (issue #910).
+    ///
+    /// `None` for the BIG `Index.db` path (which uses `first_name`/`last_name`
+    /// Data.db `ClusteringPrefix` bytes instead) and for tables without a
+    /// clustering key. This is a separate, byte-comparable encoding that the BTI
+    /// reader reconstructs during DFS; it is NOT the `first_name` form.
+    pub oss50_separator: Option<Vec<u8>>,
 }
 
 /// Index.db component writer
@@ -958,6 +967,7 @@ mod tests {
             last_name: vec![0x00],
             offset: 0,
             width: 70_000,
+            oss50_separator: None,
         };
         let info = writer
             .add_partition_with_promoted(&key, 0, &[block])
@@ -988,12 +998,14 @@ mod tests {
             last_name: ck_prefix.clone(),
             offset: 0,
             width: 65_536, // exactly 64 KiB → delta = 0
+            oss50_separator: None,
         };
         let block2 = PromotedIndexBlock {
             first_name: ck_prefix.clone(),
             last_name: ck_prefix.clone(),
             offset: 65_536,
             width: 65_536,
+            oss50_separator: None,
         };
 
         let info = writer
@@ -1030,6 +1042,7 @@ mod tests {
             last_name: ck_prefix.clone(),
             offset: off,
             width: w,
+            oss50_separator: None,
         };
 
         let blocks = vec![
@@ -1098,12 +1111,14 @@ mod tests {
             last_name: vec![0x00],
             offset: COLUMN_INDEX_SIZE_BYTES,
             width: COLUMN_INDEX_SIZE_BYTES,
+            oss50_separator: None,
         };
         let block_below = PromotedIndexBlock {
             first_name: vec![0x00],
             last_name: vec![0x00],
             offset: 0,
             width: COLUMN_INDEX_SIZE_BYTES,
+            oss50_separator: None,
         };
 
         // Use a 4-byte raw key for a fixed, predictable headerLength = 2 + 4 + 12 = 18.
@@ -1135,12 +1150,14 @@ mod tests {
             last_name: vec![0x00],
             offset: 0,
             width: INDEX_INFO_WIDTH_BASE, // 64 KiB
+            oss50_separator: None,
         };
         let block2 = PromotedIndexBlock {
             first_name: vec![0x00],
             last_name: vec![0x00],
             offset: INDEX_INFO_WIDTH_BASE,
             width: INDEX_INFO_WIDTH_BASE,
+            oss50_separator: None,
         };
 
         let mut info_bytes: Vec<u8> = Vec::new();
@@ -1166,6 +1183,7 @@ mod tests {
             last_name: last_name.clone(),
             offset: 0,
             width: 100_000,
+            oss50_separator: None,
         };
         let mut info_bytes: Vec<u8> = Vec::new();
         serialize_index_info(&mut info_bytes, &block1);
@@ -1258,6 +1276,7 @@ mod tests {
             last_name: ck_prefix.clone(),
             offset: off,
             width: w,
+            oss50_separator: None,
         };
         let blocks = vec![
             make_block(0, 70_000),
@@ -1431,6 +1450,7 @@ mod tests {
             last_name: ck_prefix.clone(),
             offset: off,
             width: w,
+            oss50_separator: None,
         };
         let blocks = vec![
             make_block(0, 70_000),

--- a/cqlite-core/src/storage/sstable/writer/index_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/index_writer.rs
@@ -139,25 +139,40 @@ pub struct PromotedIndexBlock {
 ///   opened lazily on the first `add_partition` call so the parent directory need
 ///   not exist before construction.
 ///
-/// In both modes `index_offset` for a new entry = `position + buffer.len()` measured
-/// before any bytes are written. In streaming mode `buffer` is empty at that point
-/// (cleared after the previous entry's flush) so the offset equals `position`; in
+/// * **Counting mode** (`IndexWriter::counting`): like streaming, but with no sink —
+///   each entry is serialized into the scratch `Vec` only to measure its size, then
+///   the scratch is cleared. No file is created and no entry bytes are retained, so
+///   peak heap is O(one entry). This is the BTI path (Issue #908): BTI has no
+///   `Index.db`, but the write loop still needs the per-entry `index_offset`/size
+///   bookkeeping. The earlier BTI code used in-memory mode, which retained every
+///   serialized entry in `buffer` forever — a full, never-emitted in-memory `Index.db`
+///   that defeated the streaming memory budget on large writes.
+///
+/// In all modes `index_offset` for a new entry = `position + buffer.len()` measured
+/// before any bytes are written. In streaming/counting modes `buffer` is empty at that
+/// point (cleared after the previous entry's flush) so the offset equals `position`; in
 /// in-memory mode `position` is always 0 and `buffer` holds all prior entries, so
 /// the offset equals `buffer.len()`.
 #[derive(Debug)]
 pub struct IndexWriter {
     /// Per-entry scratch buffer.
     ///
-    /// In streaming mode this holds exactly the bytes for one entry (cleared after
-    /// each flush). In in-memory mode it accumulates the entire Index.db output.
+    /// In streaming/counting modes this holds exactly the bytes for one entry (cleared
+    /// after each flush). In in-memory mode it accumulates the entire Index.db output.
     buffer: Vec<u8>,
     /// Streaming sink over the Index.db path (streaming mode only).
     ///
-    /// Lazily opened on the first `add_partition` call. `None` in in-memory mode.
+    /// Lazily opened on the first `add_partition` call. `None` in in-memory and
+    /// counting modes.
     sink: Option<std::io::BufWriter<std::fs::File>>,
     /// Index.db output path (streaming mode only); used for lazy sink open.
+    /// `None` in in-memory and counting modes.
     index_path: Option<PathBuf>,
-    /// Bytes already flushed to `sink`. Always 0 in in-memory mode.
+    /// Whether this writer is in counting mode (no sink, no retention, but the
+    /// per-entry scratch is still cleared so memory stays O(one entry)).
+    counting: bool,
+    /// Bytes that would have been written so far. Advances in streaming and counting
+    /// modes (so `index_offset` tracks correctly); always 0 in in-memory mode.
     position: u64,
     /// Entry count (for validation)
     entry_count: usize,
@@ -193,6 +208,43 @@ impl IndexWriter {
             buffer: Vec::new(),
             sink: None,
             index_path: None,
+            counting: false,
+            position: 0,
+            entry_count: 0,
+        }
+    }
+
+    /// Create a counting-only Index.db writer that retains no entry bytes.
+    ///
+    /// Used by the BTI write path (Issue #908): BTI emits no `Index.db`, but the
+    /// write loop still needs each partition's `index_offset`/`entry_size`
+    /// bookkeeping. Each entry is serialized into a scratch buffer only to measure
+    /// its size and advance `position`, then the scratch is cleared — so peak heap
+    /// is O(one entry) instead of accumulating a full, never-emitted in-memory
+    /// `Index.db`. No file is created.
+    ///
+    /// `index_offset`/`entry_size` values are byte-identical to what the streaming
+    /// and in-memory modes would report for the same partition sequence.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cqlite_core::storage::sstable::writer::IndexWriter;
+    /// use cqlite_core::storage::write_engine::mutation::DecoratedKey;
+    ///
+    /// let mut writer = IndexWriter::counting();
+    /// let key = DecoratedKey::new(12345, vec![0x00, 0x00, 0x00, 0x2A]);
+    /// let info = writer.add_partition(&key, 0).unwrap();
+    /// assert_eq!(info.index_offset, 0);
+    /// // No entry bytes are retained.
+    /// assert_eq!(writer.buffered_len(), 0);
+    /// ```
+    pub fn counting() -> Self {
+        Self {
+            buffer: Vec::new(),
+            sink: None,
+            index_path: None,
+            counting: true,
             position: 0,
             entry_count: 0,
         }
@@ -211,6 +263,7 @@ impl IndexWriter {
             buffer: Vec::new(),
             sink: None,
             index_path: Some(index_path),
+            counting: false,
             position: 0,
             entry_count: 0,
         }
@@ -236,10 +289,21 @@ impl IndexWriter {
         Ok(())
     }
 
-    /// In streaming mode, flush the scratch buffer to the sink, advance `position`,
-    /// and clear the scratch so only one entry is ever resident.
-    /// No-op in in-memory mode (the scratch keeps accumulating).
+    /// Flush the per-entry scratch buffer, advance `position`, and clear the scratch
+    /// so only one entry is ever resident.
+    ///
+    /// - Streaming mode: writes the scratch bytes to the sink.
+    /// - Counting mode: writes nothing (no sink) but still advances `position` and
+    ///   clears the scratch, so memory stays O(one entry) and offset bookkeeping is
+    ///   identical to streaming.
+    /// - In-memory mode: no-op (the scratch keeps accumulating the whole file).
     fn flush_entry(&mut self) -> Result<()> {
+        if self.counting {
+            // Counting mode: retain nothing, but track byte position for offsets.
+            self.position += self.buffer.len() as u64;
+            self.buffer.clear();
+            return Ok(());
+        }
         if self.index_path.is_none() {
             // In-memory mode: keep accumulating in `buffer`.
             return Ok(());
@@ -443,6 +507,16 @@ impl IndexWriter {
     /// ```
     pub fn entry_count(&self) -> usize {
         self.entry_count
+    }
+
+    /// Number of bytes currently held in the per-entry scratch buffer.
+    ///
+    /// In streaming and counting modes this is 0 between entries (the scratch is
+    /// cleared after each `add_partition`). In in-memory mode it grows to the full
+    /// serialized `Index.db` size. Exposed mainly so the BTI path can assert it does
+    /// not accumulate index entry bytes (Issue #908).
+    pub fn buffered_len(&self) -> usize {
+        self.buffer.len()
     }
 }
 
@@ -1280,6 +1354,107 @@ mod tests {
         assert!(
             result.is_err(),
             "finish_streaming() on in-memory writer must fail"
+        );
+    }
+
+    // ── Counting mode tests (Issue #908 — BTI must not retain Index.db bytes) ──
+
+    /// Finding 2 (roborev #908): the BTI path uses counting mode, which must NOT
+    /// accumulate index entry bytes in memory. After writing many partitions the
+    /// scratch buffer must be empty (O(one entry), and 0 between entries), in
+    /// contrast to in-memory mode which retains the whole Index.db.
+    #[test]
+    fn test_counting_mode_does_not_retain_entry_bytes() {
+        let mut counting = IndexWriter::counting();
+        let mut in_memory = IndexWriter::new();
+
+        for i in 0..1000u64 {
+            // UUID-sized keys so each entry is ~20 bytes; in-memory would hold ~20 KB.
+            let key = DecoratedKey::new(i as i64, vec![(i & 0xff) as u8; 16]);
+            counting.add_partition(&key, i * 64).unwrap();
+            in_memory.add_partition(&key, i * 64).unwrap();
+        }
+
+        // Counting mode retains nothing between entries.
+        assert_eq!(
+            counting.buffered_len(),
+            0,
+            "counting mode must not accumulate any Index.db entry bytes"
+        );
+        // In-memory mode, by contrast, holds the entire serialized Index.db.
+        assert!(
+            in_memory.buffered_len() > 1000,
+            "in-memory mode retains all entries (sanity check the contrast)"
+        );
+        assert_eq!(counting.entry_count(), 1000);
+    }
+
+    /// Counting mode reports byte-identical `index_offset`/`entry_size` bookkeeping
+    /// to in-memory mode for the same partition sequence. This is what the BTI write
+    /// path relies on for Summary/offset accounting, so it must not drift.
+    #[test]
+    fn test_counting_mode_offsets_match_in_memory() {
+        let partitions: Vec<(i64, Vec<u8>, u64)> = vec![
+            (100, vec![0x01, 0x02, 0x03, 0x04], 0),
+            (200, vec![0x05, 0x06], 127),
+            (300, vec![0x07], 12381),
+            (400, vec![0xBB; 16], 1_000_000_000),
+        ];
+
+        let mut counting = IndexWriter::counting();
+        let mut in_memory = IndexWriter::new();
+
+        for (token, key_bytes, offset) in &partitions {
+            let key = DecoratedKey::new(*token, key_bytes.clone());
+            let c = counting.add_partition(&key, *offset).unwrap();
+            let m = in_memory.add_partition(&key, *offset).unwrap();
+            assert_eq!(
+                c.index_offset, m.index_offset,
+                "counting index_offset must match in-memory"
+            );
+            assert_eq!(
+                c.entry_size, m.entry_size,
+                "counting entry_size must match in-memory"
+            );
+            // Scratch is cleared after every entry in counting mode.
+            assert_eq!(counting.buffered_len(), 0);
+        }
+    }
+
+    /// Counting mode handles promoted-index (wide partition) bookkeeping the same
+    /// way in-memory mode does, without retaining the promoted payload bytes.
+    #[test]
+    fn test_counting_mode_with_promoted_index_offsets_match() {
+        let ck_prefix = vec![0x00u8, 0x61, 0x62];
+        let make_block = |off: u64, w: u64| PromotedIndexBlock {
+            first_name: ck_prefix.clone(),
+            last_name: ck_prefix.clone(),
+            offset: off,
+            width: w,
+        };
+        let blocks = vec![
+            make_block(0, 70_000),
+            make_block(70_000, 68_000),
+            make_block(138_000, 65_000),
+        ];
+        let key = DecoratedKey::new(42, vec![0xAA, 0xBB]);
+
+        let mut counting = IndexWriter::counting();
+        let c = counting
+            .add_partition_with_promoted(&key, 1234, &blocks)
+            .unwrap();
+
+        let mut in_memory = IndexWriter::new();
+        let m = in_memory
+            .add_partition_with_promoted(&key, 1234, &blocks)
+            .unwrap();
+
+        assert_eq!(c.index_offset, m.index_offset);
+        assert_eq!(c.entry_size, m.entry_size);
+        assert_eq!(
+            counting.buffered_len(),
+            0,
+            "counting mode must not retain the promoted payload"
         );
     }
 

--- a/cqlite-core/src/storage/sstable/writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/mod.rs
@@ -95,24 +95,26 @@ pub enum SSTableFormat {
     /// Legacy BIG format: `Index.db` + `Summary.db`. **Default.**
     #[default]
     Big,
-    /// BTI phase 1: BIG components **plus** a `Partitions.db` partition trie.
+    /// Cassandra-canonical BTI format (`da-<gen>-bti-*`).
     ///
-    /// Phase 1 keeps `Data.db` in BIG layout and continues to emit the BIG
-    /// `Index.db`/`Summary.db` so the existing reader path is unaffected; the
-    /// `Partitions.db` trie is an additional component validated by the BTI
-    /// reader. `Rows.db` (within-partition trie) is out of scope for phase 1.
+    /// Issue #908 (epic #872). Emits a true BTI component set:
+    /// - `Data.db` — the partition/row serialization is **identical** to BIG in
+    ///   Cassandra 5 (the BTI format shares `BigTableWriter`'s row encoding; only
+    ///   the descriptor/version and index components differ — see
+    ///   `docs/sstables-definitive-guide/chapters/17-bti-formats.md`, which lists
+    ///   `Data.db` as a *common component retained*). The bytes are therefore the
+    ///   same as BIG; only the filename descriptor changes.
+    /// - `Partitions.db` — partition trie (replaces `Index.db`/`Summary.db`).
+    /// - `Statistics.db`, `Filter.db`, `Digest.crc32`, `TOC.txt`.
     ///
-    /// **Known phase-1 limitation (follow-up #872):** the output is a hybrid,
-    /// not a Cassandra-canonical BTI SSTable. Components keep the `nb-*-big-*`
-    /// descriptor, and [`crate::storage::sstable::reader::SSTableReader`]
-    /// classifies the directory as BIG from the `Data.db` name — so it does
-    /// **not** auto-discover or use the `Partitions.db` sidecar. The trie is
-    /// verified directly through the BTI reader API
-    /// (`lookup_partition_in_bti_file`). Renaming components to the `da`/`bti`
-    /// prefix here would be unsafe: the reader would then attempt to parse the
-    /// BIG-layout `Data.db` as a BTI `Data.db`. Producing a discoverable,
-    /// Cassandra-readable BTI SSTable (BTI `Data.db`, `da` prefix, dropping
-    /// `Index.db`/`Summary.db`, plus `Rows.db`) is the deferred follow-up.
+    /// **No `Index.db` and no `Summary.db`** — those are BIG-only components; BTI
+    /// resolves partitions through the trie. All components use the `da` version
+    /// letter and `bti` format segment.
+    ///
+    /// **Not yet emitted (follow-up #910):** `Rows.db` (the within-partition
+    /// clustering trie for wide partitions). Until then each partition's trie
+    /// payload is a direct `Data.db` offset, which the BTI reader resolves as a
+    /// point lookup.
     Bti,
 }
 
@@ -124,12 +126,18 @@ pub enum SSTableFormat {
 pub struct SSTableInfo {
     /// Path to the Data.db file
     pub data_path: PathBuf,
-    /// Path to the Index.db file
-    pub index_path: PathBuf,
+    /// Path to the Index.db file.
+    ///
+    /// `Some` for the BIG format; `None` for [`SSTableFormat::Bti`], which has
+    /// no `Index.db` (partition lookups use the `Partitions.db` trie). Issue #908.
+    pub index_path: Option<PathBuf>,
     /// Path to the Filter.db file
     pub filter_path: PathBuf,
-    /// Path to the Summary.db file
-    pub summary_path: PathBuf,
+    /// Path to the Summary.db file.
+    ///
+    /// `Some` for the BIG format; `None` for [`SSTableFormat::Bti`], which has
+    /// no `Summary.db`. Issue #908.
+    pub summary_path: Option<PathBuf>,
     /// Path to the Statistics.db file
     pub stats_path: PathBuf,
     /// Path to the CompressionInfo.db file (None when data is uncompressed)
@@ -316,17 +324,36 @@ impl SSTableWriter {
         // flushed to the Data.db file as it is written, bounding peak memory to a
         // single partition instead of buffering the whole component. The file is
         // opened lazily on the first partition (creating sstable_dir as needed).
-        let data_path = Self::component_path(&sstable_dir, generation, "Data.db");
+        let data_path = Self::component_path_for(&sstable_dir, generation, format, "Data.db");
         let data_writer = DataWriter::with_sink(stats.clone(), data_path);
 
-        // Create Index.db writer in streaming mode (Issue #753): each entry is
-        // serialized and written straight to Index.db as it arrives, keeping only
-        // the current entry's bytes in memory (O(1) in partition count).
-        let index_path = Self::component_path(&sstable_dir, generation, "Index.db");
-        let index_writer = IndexWriter::with_sink(index_path);
+        // Index.db writer.
+        //
+        // BIG (Issue #753): streaming mode flushes each entry straight to
+        // `Index.db` as it arrives, keeping only the current entry's bytes in
+        // memory (O(1) in partition count).
+        //
+        // BTI (Issue #908): the BTI format has no `Index.db` — partition lookups
+        // go through the `Partitions.db` trie instead. We use a *counting-only*
+        // `IndexWriter` (no sink, so no file is created) purely to compute the
+        // per-partition index offsets and promoted-block bookkeeping reused by
+        // the write path. Counting mode serializes each entry into a scratch buffer
+        // only to measure it, then clears the scratch, so peak memory stays
+        // O(one entry). (The prior in-memory mode retained every serialized entry
+        // forever — a full, never-emitted in-memory `Index.db` that defeated the
+        // streaming memory budget on large BTI writes.) Nothing is persisted and no
+        // `Index.db` is emitted.
+        let index_writer = match format {
+            SSTableFormat::Big => {
+                let index_path =
+                    Self::component_path_for(&sstable_dir, generation, format, "Index.db");
+                IndexWriter::with_sink(index_path)
+            }
+            SSTableFormat::Bti => IndexWriter::counting(),
+        };
 
         // Create Filter.db writer (1% false positive rate by default)
-        let filter_path = Self::component_path(&sstable_dir, generation, "Filter.db");
+        let filter_path = Self::component_path_for(&sstable_dir, generation, format, "Filter.db");
         let filter_writer = Some(FilterWriter::new(
             filter_path,
             expected_partitions.max(1),
@@ -690,8 +717,16 @@ impl SSTableWriter {
         // Finalize statistics metadata (normalize sentinel values)
         self.stats.finalize();
 
+        // Capture format/generation up front so component paths can be computed
+        // after `self`'s writers are partially moved out by their `finish()` calls.
+        let format = self.format;
+        let generation = self.generation;
+        let is_bti = matches!(format, SSTableFormat::Bti);
+        let cpath =
+            |component: &str| Self::component_path_for(sstable_dir, generation, format, component);
+
         // 1. Write Statistics.db (FIRST - provides delta baseline)
-        let stats_path = Self::component_path(sstable_dir, self.generation, "Statistics.db");
+        let stats_path = cpath("Statistics.db");
         let stats_writer = StatisticsWriter::new(stats_path.clone());
         stats_writer.write(&self.stats, Some(&self.schema))?;
 
@@ -701,31 +736,49 @@ impl SSTableWriter {
         // flushes and fsyncs the sink and returns the total byte size. If no
         // partitions were written, lazily ensure an (empty) Data.db file exists so
         // the downstream Digest CRC re-read and TOC publication remain valid.
-        let data_path = Self::component_path(sstable_dir, self.generation, "Data.db");
+        //
+        // The BTI `Data.db` row/partition serialization is identical to BIG in
+        // Cassandra 5 (issue #908); only the filename descriptor differs.
+        let data_path = cpath("Data.db");
         let data_size = self.data_writer.finish_streaming()?;
         if data_size == 0 && !data_path.exists() {
             tokio::fs::write(&data_path, b"").await?;
         }
 
-        // 3. Finalize Index.db (Issue #753)
-        // The IndexWriter has been streaming each entry to Index.db as it was
-        // written, so there is no whole-file buffer to write here. `finish_streaming`
-        // flushes and syncs the sink and returns the total byte size.
-        let index_path = Self::component_path(sstable_dir, self.generation, "Index.db");
-        let _index_size = self.index_writer.finish_streaming()?;
+        // 3. Finalize Index.db (Issue #753) — BIG only.
+        // For BIG, the IndexWriter has been streaming each entry to Index.db; we
+        // flush/sync it here. For BTI (issue #908) there is no Index.db: the
+        // IndexWriter ran in counting-only mode (no sink, no retained entry bytes)
+        // purely to compute offsets, so there is nothing to flush and we report no
+        // path. (Calling `finish_streaming` on a non-streaming writer is an error,
+        // so we skip it.)
+        let index_path = if is_bti {
+            None
+        } else {
+            let _index_size = self.index_writer.finish_streaming()?;
+            Some(cpath("Index.db"))
+        };
 
         // 4. Write Filter.db (path already set in constructor using sstable_dir)
-        let filter_path = Self::component_path(sstable_dir, self.generation, "Filter.db");
+        let filter_path = cpath("Filter.db");
         if let Some(filter_writer) = self.filter_writer {
             filter_writer.finish().await?;
         }
 
-        // 5. Write Summary.db
-        let summary_path = Self::component_path(sstable_dir, self.generation, "Summary.db");
+        // 5. Write Summary.db — BIG only.
+        // BTI (issue #908) has no Summary.db; partition sampling is replaced by
+        // the partition trie. We still drive `summary_writer.finish()` to keep its
+        // accounting consistent, but for BTI we discard the bytes and write no file.
         let summary_bytes = self.summary_writer.finish()?;
-        tokio::fs::write(&summary_path, summary_bytes).await?;
+        let summary_path = if is_bti {
+            None
+        } else {
+            let path = cpath("Summary.db");
+            tokio::fs::write(&path, summary_bytes).await?;
+            Some(path)
+        };
 
-        // 5.25. Write Partitions.db (BTI phase 1, issue #766).
+        // 5.25. Write Partitions.db (BTI, issue #766 / #908).
         // Only emitted for SSTableFormat::Bti; for BIG this is None and nothing
         // is written, keeping the default path byte-for-byte unchanged.
         //
@@ -739,7 +792,7 @@ impl SSTableWriter {
             if bytes.is_empty() {
                 None
             } else {
-                let path = Self::component_path(sstable_dir, self.generation, "Partitions.db");
+                let path = cpath("Partitions.db");
                 tokio::fs::write(&path, bytes).await?;
                 Some(path)
             }
@@ -753,36 +806,35 @@ impl SSTableWriter {
         // for future compressed SSTable support.
 
         // 6. Write Digest.crc32 (compute CRC32 of Data.db)
-        let digest_path = Self::component_path(sstable_dir, self.generation, "Digest.crc32");
+        let digest_path = cpath("Digest.crc32");
         let digest_writer = DigestWriter::new(digest_path.clone());
         let crc32_value = Self::compute_crc32(&data_path).await?;
         digest_writer.write(crc32_value)?;
 
-        // 7. Write TOC.txt (LAST - publication barrier)
-        let toc_path = Self::component_path(sstable_dir, self.generation, "TOC.txt");
+        // 7. Write TOC.txt (LAST - publication barrier).
+        //
+        // The TOC lists exactly the component set actually written. BIG lists
+        // Index.db + Summary.db; BTI (issue #908) omits both and lists
+        // Partitions.db instead. `Rows.db` is a follow-up (#910) and is NOT
+        // emitted yet, so it is not listed. TocWriter self-references TOC.txt.
+        use crate::storage::sstable::directory::types::SSTableComponent;
+        let toc_path = cpath("TOC.txt");
         let toc_writer = TocWriter::new(toc_path.clone());
         let mut components = vec![
-            ComponentEntry::new(crate::storage::sstable::directory::types::SSTableComponent::Data),
-            ComponentEntry::new(crate::storage::sstable::directory::types::SSTableComponent::Index),
-            ComponentEntry::new(
-                crate::storage::sstable::directory::types::SSTableComponent::Filter,
-            ),
-            ComponentEntry::new(
-                crate::storage::sstable::directory::types::SSTableComponent::Summary,
-            ),
-            ComponentEntry::new(
-                crate::storage::sstable::directory::types::SSTableComponent::Statistics,
-            ),
-            ComponentEntry::new(
-                crate::storage::sstable::directory::types::SSTableComponent::Digest,
-            ),
+            ComponentEntry::new(SSTableComponent::Data),
+            ComponentEntry::new(SSTableComponent::Filter),
+            ComponentEntry::new(SSTableComponent::Statistics),
+            ComponentEntry::new(SSTableComponent::Digest),
         ];
-        // BTI phase 1 (issue #766): list Partitions.db in the TOC only when the
-        // BTI format was selected. The BIG TOC is unchanged.
+        if index_path.is_some() {
+            components.push(ComponentEntry::new(SSTableComponent::Index));
+        }
+        if summary_path.is_some() {
+            components.push(ComponentEntry::new(SSTableComponent::Summary));
+        }
+        // BTI (issue #766 / #908): list Partitions.db when the trie was emitted.
         if partitions_path.is_some() {
-            components.push(ComponentEntry::new(
-                crate::storage::sstable::directory::types::SSTableComponent::Partitions,
-            ));
+            components.push(ComponentEntry::new(SSTableComponent::Partitions));
         }
         toc_writer.write(&components)?;
 
@@ -801,9 +853,25 @@ impl SSTableWriter {
         })
     }
 
-    /// Build component file path
-    fn component_path(output_dir: &Path, generation: u64, component: &str) -> PathBuf {
-        let filename = format!("nb-{}-big-{}", generation, component);
+    /// Build a component file path for a given on-disk `format`.
+    ///
+    /// The Cassandra filename pattern is `<version>-<id>-<format>-<component>`
+    /// (`SsTableDescriptor::parse`). BIG components use the `nb` version letter
+    /// and the `big` format segment (`nb-<gen>-big-<component>`); BTI components
+    /// use the `da` version letter and the `bti` format segment
+    /// (`da-<gen>-bti-<component>`). This is the single source of truth for
+    /// component naming so the version/format ordering stays consistent.
+    fn component_path_for(
+        output_dir: &Path,
+        generation: u64,
+        format: SSTableFormat,
+        component: &str,
+    ) -> PathBuf {
+        let (version, fmt) = match format {
+            SSTableFormat::Big => ("nb", "big"),
+            SSTableFormat::Bti => ("da", "bti"),
+        };
+        let filename = format!("{}-{}-{}-{}", version, generation, fmt, component);
         output_dir.join(filename)
     }
 
@@ -914,11 +982,15 @@ mod tests {
 
         let info = writer.finish().await.unwrap();
 
-        // Verify all files were created
+        // Verify all files were created (BIG format: Index.db + Summary.db present)
         assert!(info.data_path.exists());
-        assert!(info.index_path.exists());
+        assert!(info.index_path.as_ref().expect("BIG has Index.db").exists());
         assert!(info.filter_path.exists());
-        assert!(info.summary_path.exists());
+        assert!(info
+            .summary_path
+            .as_ref()
+            .expect("BIG has Summary.db")
+            .exists());
         assert!(info.stats_path.exists());
         assert!(info.compression_info_path.is_none());
         assert!(info.toc_path.exists());
@@ -1007,10 +1079,19 @@ mod tests {
         // Verify generation number is used in paths
         // (we don't actually write anything, just test path construction)
 
-        let data_path = SSTableWriter::component_path(temp_dir.path(), 42, "Data.db");
+        let big_path =
+            SSTableWriter::component_path_for(temp_dir.path(), 42, SSTableFormat::Big, "Data.db");
         assert_eq!(
-            data_path.file_name().unwrap().to_str().unwrap(),
+            big_path.file_name().unwrap().to_str().unwrap(),
             "nb-42-big-Data.db"
+        );
+
+        // BTI uses the `da` version letter and `bti` format segment (issue #908).
+        let bti_path =
+            SSTableWriter::component_path_for(temp_dir.path(), 42, SSTableFormat::Bti, "Data.db");
+        assert_eq!(
+            bti_path.file_name().unwrap().to_str().unwrap(),
+            "da-42-bti-Data.db"
         );
     }
 

--- a/cqlite-core/src/storage/sstable/writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/mod.rs
@@ -105,16 +105,21 @@ pub enum SSTableFormat {
     ///   `Data.db` as a *common component retained*). The bytes are therefore the
     ///   same as BIG; only the filename descriptor changes.
     /// - `Partitions.db` — partition trie (replaces `Index.db`/`Summary.db`).
+    /// - `Rows.db` — within-partition row-index trie (issue #910). WIDE
+    ///   partitions (`>= 2` × 64 KiB column-index blocks) get a per-partition
+    ///   row index and a positive `RowsOffset` in their partition-trie leaf;
+    ///   NARROW partitions keep a direct (negative) `Data.db` offset. `Rows.db`
+    ///   is always emitted for a BTI SSTable — possibly 0 bytes when no partition
+    ///   is wide, matching the real `da` fixtures.
     /// - `Statistics.db`, `Filter.db`, `Digest.crc32`, `TOC.txt`.
     ///
     /// **No `Index.db` and no `Summary.db`** — those are BIG-only components; BTI
     /// resolves partitions through the trie. All components use the `da` version
     /// letter and `bti` format segment.
     ///
-    /// **Not yet emitted (follow-up #910):** `Rows.db` (the within-partition
-    /// clustering trie for wide partitions). Until then each partition's trie
-    /// payload is a direct `Data.db` offset, which the BTI reader resolves as a
-    /// point lookup.
+    /// An **empty** BTI SSTable (zero partitions) is refused by `finish()`: a
+    /// `da` SSTable requires a readable `Partitions.db` (8-byte root footer),
+    /// which has no valid zero-partition form.
     Bti,
 }
 
@@ -145,6 +150,10 @@ pub struct SSTableInfo {
     /// Path to the BTI `Partitions.db` trie (Some only for [`SSTableFormat::Bti`];
     /// None for the default BIG format). Issue #766.
     pub partitions_path: Option<PathBuf>,
+    /// Path to the BTI `Rows.db` within-partition row-index trie (Some only for
+    /// [`SSTableFormat::Bti`]; None for BIG). Always present for a non-empty BTI
+    /// SSTable, even when 0 bytes (no wide partitions). Issue #910.
+    pub rows_path: Option<PathBuf>,
     /// Path to the TOC.txt file
     pub toc_path: PathBuf,
     /// Path to the Digest.crc32 file
@@ -248,6 +257,43 @@ pub struct SSTableWriter {
     /// BTI partition trie accumulator. Populated only when `format` is
     /// [`SSTableFormat::Bti`]; `None` otherwise so the BIG path allocates nothing.
     partitions_trie: Option<partitions_writer::PartitionsTrieWriter>,
+    /// BTI per-partition pending payloads (issue #910). Populated only for
+    /// [`SSTableFormat::Bti`]. The partition-trie leaf payload (direct
+    /// `Data.db` offset vs `Rows.db` `RowsOffset`) cannot be finalized until
+    /// `Rows.db` is serialized in [`Self::finish`] (the `RowsOffset` is the
+    /// `TrieIndexEntry` position), so we defer the decision: each entry records
+    /// the partition's raw key, its `Data.db` offset, and — for WIDE partitions
+    /// (>= 2 column-index blocks) — the row-index blocks. `None` for BIG so that
+    /// path allocates nothing.
+    bti_pending: Option<Vec<PendingBtiPartition>>,
+}
+
+/// A deferred BTI partition payload (issue #910).
+///
+/// Narrow partitions (`row_index` is `None`) get a direct `Data.db` offset in
+/// the partition trie; wide partitions get a `Rows.db` `TrieIndexEntry` and a
+/// positive `RowsOffset` once `Rows.db` is serialized.
+#[cfg(feature = "write-support")]
+#[derive(Debug)]
+struct PendingBtiPartition {
+    /// Raw on-disk partition-key bytes.
+    raw_key: Vec<u8>,
+    /// Partition's absolute `Data.db` start offset.
+    data_offset: u64,
+    /// `Some` for a wide partition: its row-index blocks + partition deletion.
+    /// `None` for a narrow partition (direct `Data.db` offset).
+    row_index: Option<PendingRowIndex>,
+}
+
+/// The row-index payload of a wide BTI partition, queued for `Rows.db`.
+#[cfg(feature = "write-support")]
+#[derive(Debug)]
+struct PendingRowIndex {
+    /// Per-block OSS50 separators + within-partition offsets.
+    blocks: Vec<partitions_writer::RowIndexBlock>,
+    /// Partition-level deletion `(local_deletion_time, marked_for_delete_at)`,
+    /// or `None` for LIVE.
+    partition_deletion: Option<(i32, i64)>,
 }
 
 #[cfg(feature = "write-support")]
@@ -370,6 +416,11 @@ impl SSTableWriter {
             SSTableFormat::Big => None,
             SSTableFormat::Bti => Some(partitions_writer::PartitionsTrieWriter::new()),
         };
+        // BTI (issue #910): defer partition-trie payloads until Rows.db is built.
+        let bti_pending = match format {
+            SSTableFormat::Big => None,
+            SSTableFormat::Bti => Some(Vec::new()),
+        };
 
         Ok(Self {
             sstable_dir,
@@ -387,6 +438,7 @@ impl SSTableWriter {
             baselines_locked: false,
             format,
             partitions_trie,
+            bti_pending,
         })
     }
 
@@ -558,11 +610,61 @@ impl SSTableWriter {
             filter.add_key(&key);
         }
 
-        // BTI phase 1 (issue #766): record this partition's raw key bytes and
-        // Data.db offset for the Partitions.db trie. Only active when the BTI
-        // format was selected (the accumulator is None for BIG).
-        if let Some(ref mut trie) = self.partitions_trie {
-            trie.add_partition(&key.key, data_offset);
+        // BTI (issue #766 / #910): defer this partition's Partitions.db trie
+        // payload. The payload is a direct `Data.db` offset for a NARROW
+        // partition (< 2 column-index blocks) or a `Rows.db` `RowsOffset` for a
+        // WIDE partition (>= 2 blocks). The `RowsOffset` is only known after
+        // `Rows.db` is serialized in `finish()`, so we record the raw key, the
+        // Data.db offset, and — for wide partitions — the OSS50 row-index
+        // separators here, and finalize both tries at `finish()`. The wide gate
+        // (>= 2 blocks) mirrors `RowIndexEntry.create()` /
+        // `IndexWriter::add_partition_with_promoted` and guide ch.17.
+        if let Some(ref mut pending) = self.bti_pending {
+            let row_index = if promoted_blocks.len() >= 2 {
+                // Build OSS50-separator row-index blocks. A block lacking an
+                // OSS50 separator (marker-led, or no clustering key) cannot be
+                // placed in the trie; if ANY block lacks one we fall back to a
+                // direct Data.db offset for the whole partition rather than emit
+                // an unreadable separator (no-heuristics: never guess bytes).
+                let mut blocks = Vec::with_capacity(promoted_blocks.len());
+                let mut all_have_sep = true;
+                for b in &promoted_blocks {
+                    match &b.oss50_separator {
+                        Some(sep) if !sep.is_empty() => {
+                            blocks.push(partitions_writer::RowIndexBlock {
+                                separator_key: sep.clone(),
+                                block_offset: b.offset,
+                                open_marker: None,
+                            });
+                        }
+                        _ => {
+                            all_have_sep = false;
+                            break;
+                        }
+                    }
+                }
+                // Separators must be strictly ascending and unique for the trie.
+                let strictly_ascending = blocks
+                    .windows(2)
+                    .all(|w| w[0].separator_key < w[1].separator_key);
+                if all_have_sep && strictly_ascending && !blocks.is_empty() {
+                    let partition_deletion =
+                        partition_tombstone.map(|pt| (pt.local_deletion_time, pt.deletion_time));
+                    Some(PendingRowIndex {
+                        blocks,
+                        partition_deletion,
+                    })
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+            pending.push(PendingBtiPartition {
+                raw_key: key.key.clone(),
+                data_offset,
+                row_index,
+            });
         }
 
         // Track every partition for first_key / last_key / total_partition_count.
@@ -778,26 +880,84 @@ impl SSTableWriter {
             Some(path)
         };
 
-        // 5.25. Write Partitions.db (BTI, issue #766 / #908).
-        // Only emitted for SSTableFormat::Bti; for BIG this is None and nothing
+        // 5.25. Write Rows.db + Partitions.db (BTI, issue #766 / #908 / #910).
+        // Only emitted for SSTableFormat::Bti; for BIG both are None and nothing
         // is written, keeping the default path byte-for-byte unchanged.
         //
-        // An empty BTI SSTable (no partitions) produces a zero-byte trie, which
-        // the BTI reader rejects (it needs at least the 8-byte root footer). For
-        // an empty SSTable we therefore OMIT Partitions.db entirely (file and TOC
-        // entry) rather than write an unreadable component (issue #766 review
-        // finding 2).
-        let partitions_path = if let Some(trie) = self.partitions_trie.take() {
-            let bytes = trie.finish()?;
-            if bytes.is_empty() {
-                None
-            } else {
-                let path = cpath("Partitions.db");
-                tokio::fs::write(&path, bytes).await?;
-                Some(path)
+        // Order matters: `Rows.db` is serialized FIRST so each wide partition's
+        // `TrieIndexEntry` offset (`RowsOffset`) is known, then the partition
+        // trie leaves store either that positive `RowsOffset` (wide) or the
+        // negative direct `Data.db` offset (narrow). Cassandra always emits a
+        // `Rows.db` component for a BTI SSTable, even a 0-byte one when no
+        // partition is wide (verified against the real
+        // `simple_table`/`collection_table`/`ttl_table` `da-2-bti-Rows.db`
+        // fixtures, all 0 bytes yet listed in the TOC).
+        //
+        // Finding 2 (roborev #908): an EMPTY BTI SSTable (no partitions) cannot
+        // produce a readable `Partitions.db` — a zero-byte trie has no 8-byte
+        // root footer, so the BTI reader rejects it, and a `da` SSTable that
+        // omits `Partitions.db` is unreadable. Rather than publish an
+        // unreadable artifact we REFUSE to finish an empty BTI SSTable with a
+        // clear error. (A narrow non-empty table still publishes a valid trie +
+        // a 0-byte `Rows.db`, matching Cassandra.)
+        let (partitions_path, rows_path) = if let Some(pending) = self.bti_pending.take() {
+            if pending.is_empty() {
+                return Err(Error::InvalidInput(
+                    "cannot publish an empty BTI SSTable: a `da` SSTable requires a readable \
+                     Partitions.db trie (with an 8-byte root footer), which has no valid \
+                     zero-partition form. Write at least one partition, or use the BIG format \
+                     for empty SSTables."
+                        .to_string(),
+                ));
             }
+
+            // 1. Serialize Rows.db from the wide partitions, recovering each
+            //    wide partition's RowsOffset (in pending-order of wide entries).
+            let mut rows_writer = partitions_writer::RowsTrieWriter::new();
+            for p in &pending {
+                if let Some(ri) = &p.row_index {
+                    rows_writer.add_partition_row_index(
+                        &p.raw_key,
+                        p.data_offset,
+                        ri.blocks.clone(),
+                        ri.partition_deletion,
+                    );
+                }
+            }
+            let (rows_bytes, rows_offsets) = rows_writer.finish()?;
+
+            // 2. Build the partition trie: wide partitions get their positive
+            //    RowsOffset, narrow partitions keep the negative DataOffset.
+            let mut trie = self.partitions_trie.take().unwrap_or_default();
+            let mut wide_idx = 0usize;
+            for p in &pending {
+                if p.row_index.is_some() {
+                    let rows_offset = rows_offsets[wide_idx];
+                    wide_idx += 1;
+                    trie.add_partition_with_payload(
+                        &p.raw_key,
+                        partitions_writer::PartitionPayload::RowsOffset(rows_offset),
+                    );
+                } else {
+                    trie.add_partition_with_payload(
+                        &p.raw_key,
+                        partitions_writer::PartitionPayload::DataOffset(p.data_offset),
+                    );
+                }
+            }
+            let partitions_bytes = trie.finish()?;
+
+            // Partitions.db must be non-empty here (pending is non-empty).
+            let part_path = cpath("Partitions.db");
+            tokio::fs::write(&part_path, partitions_bytes).await?;
+
+            // Rows.db is ALWAYS emitted for BTI (possibly 0 bytes).
+            let rows_path = cpath("Rows.db");
+            tokio::fs::write(&rows_path, rows_bytes).await?;
+
+            (Some(part_path), Some(rows_path))
         } else {
-            None
+            (None, None)
         };
 
         // 5.5. CompressionInfo.db is omitted for uncompressed data.
@@ -814,9 +974,10 @@ impl SSTableWriter {
         // 7. Write TOC.txt (LAST - publication barrier).
         //
         // The TOC lists exactly the component set actually written. BIG lists
-        // Index.db + Summary.db; BTI (issue #908) omits both and lists
-        // Partitions.db instead. `Rows.db` is a follow-up (#910) and is NOT
-        // emitted yet, so it is not listed. TocWriter self-references TOC.txt.
+        // Index.db + Summary.db; BTI (issue #908 / #910) omits both and lists
+        // Partitions.db AND Rows.db instead (matching the real `da` fixtures,
+        // which list Rows.db even when it is 0 bytes). TocWriter self-references
+        // TOC.txt.
         use crate::storage::sstable::directory::types::SSTableComponent;
         let toc_path = cpath("TOC.txt");
         let toc_writer = TocWriter::new(toc_path.clone());
@@ -836,6 +997,10 @@ impl SSTableWriter {
         if partitions_path.is_some() {
             components.push(ComponentEntry::new(SSTableComponent::Partitions));
         }
+        // BTI (issue #910): list Rows.db when emitted (always for BTI).
+        if rows_path.is_some() {
+            components.push(ComponentEntry::new(SSTableComponent::Rows));
+        }
         toc_writer.write(&components)?;
 
         Ok(SSTableInfo {
@@ -846,6 +1011,7 @@ impl SSTableWriter {
             stats_path,
             compression_info_path: None,
             partitions_path,
+            rows_path,
             toc_path,
             digest_path,
             partition_count: self.partition_count,

--- a/cqlite-core/src/storage/sstable/writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/mod.rs
@@ -487,6 +487,12 @@ impl SSTableWriter {
         }
         self.last_token = Some(key.token);
 
+        // Record the SSTable key range (lowest = first seen, highest = last) for
+        // the `da`-format StatsMetadata `hasKeyRange` fields. Partitions arrive in
+        // ascending token order (validated above), so first/last fall out for
+        // free. Harmless for BIG (the legacy STATS body ignores these fields).
+        self.stats.update_key_range(&key.key);
+
         // Sort mutations by clustering key (Cassandra requires sorted rows within partitions)
         let mut mutations = mutations;
         mutations.sort_by(|a, b| match (&a.clustering_key, &b.clustering_key) {
@@ -827,9 +833,17 @@ impl SSTableWriter {
         let cpath =
             |component: &str| Self::component_path_for(sstable_dir, generation, format, component);
 
-        // 1. Write Statistics.db (FIRST - provides delta baseline)
+        // 1. Write Statistics.db (FIRST - provides delta baseline).
+        // BTI (`da`) requires the BtiFormat `StatsMetadata` layout (covered
+        // clustering Slice, uint deletion times, key range, token-space coverage)
+        // — Cassandra's sstabledump/sstablemetadata reject the legacy `nb` layout
+        // on a `da` descriptor (issue #911). BIG keeps the legacy layout.
         let stats_path = cpath("Statistics.db");
-        let stats_writer = StatisticsWriter::new(stats_path.clone());
+        let stats_writer = if is_bti {
+            StatisticsWriter::new_bti(stats_path.clone())
+        } else {
+            StatisticsWriter::new(stats_path.clone())
+        };
         stats_writer.write(&self.stats, Some(&self.schema))?;
 
         // 2. Finalize Data.db (Issue #492)

--- a/cqlite-core/src/storage/sstable/writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/mod.rs
@@ -552,6 +552,10 @@ impl SSTableWriter {
                 self.stats.update_timestamp(pt.deletion_time);
                 self.stats
                     .update_local_deletion_time(pt.local_deletion_time);
+                // Record the partition-level deletion marker for the `da`-format
+                // StatsMetadata.hasPartitionLevelDeletions field. Authoritative:
+                // the mutation explicitly carries a partition tombstone.
+                self.stats.mark_partition_level_deletion();
             }
 
             // Track stats for range tombstones

--- a/cqlite-core/src/storage/sstable/writer/partitions_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/partitions_writer.rs
@@ -49,21 +49,51 @@
 //!   cannot encode — its child count is a single byte). The reader's
 //!   `parse_bti_node` + `find_child` handle exactly these encodings.
 //!
+//! ## Rows.db (within-partition row-index trie) — issue #910
+//!
+//! [`RowsTrieWriter`] (this module) serializes `Rows.db`: one independent
+//! per-partition row-index trie + `TrieIndexEntry` for each WIDE partition
+//! (`>= 2` column-index blocks). A wide partition's `Partitions.db` leaf then
+//! stores a **positive** `RowsOffset` ([`PartitionPayload::RowsOffset`])
+//! pointing at its `TrieIndexEntry`; narrow partitions keep the **negative**
+//! direct `Data.db` offset ([`PartitionPayload::DataOffset`]). The leaf payloads
+//! and entry layout match the reader exactly
+//! ([`crate::storage::sstable::bti::parser::decode_bti_row_payload`] /
+//! [`resolve_rows_db_entry`](crate::storage::sstable::bti::resolve_rows_db_entry)).
+//!
 //! ## Out of scope (recorded for the epic)
 //!
-//! - `Rows.db` (within-partition clustering trie) is **not** written here. For
-//!   phase 1 every partition payload encodes a direct `Data.db` offset
-//!   (negative `position`), never a `RowsOffset`. Wide-partition row tries are a
-//!   follow-up (see issue #766 / epic #762).
 //! - `Single*` and 12-bit packed node variants are not emitted. They are valid
 //!   and the reader parses them, but `PayloadOnly`/`Sparse`/`Dense` cover every
-//!   trie phase 1 produces.
+//!   trie this writer produces.
+//! - Per-block **open range-tombstone markers** are supported on the wire
+//!   ([`RowIndexBlock::open_marker`]) but the `SSTableWriter` BTI path does not
+//!   yet derive them from Data.db range-tombstone state; it passes `None`
+//!   (the common case). Partition-level deletions ARE wired through.
 
 use crate::error::{Error, Result};
 use crate::storage::sstable::bti::encode_partition_key_for_bti_trie;
 use crate::storage::sstable::bti::parser::FLAG_HAS_HASH_BYTE;
 use crate::util::cassandra_murmur3::cassandra_partition_filter_hash_lower_bits;
 use std::collections::BTreeMap;
+
+/// Where a partition leaf payload points (issue #910).
+///
+/// Mirrors `BtiPartitionLocation` on the read side and Cassandra's
+/// `PartitionIndex` position-sign convention: a **direct** `Data.db` offset is
+/// stored as a *negative* `position = ~data_offset`; a **row-index** offset is
+/// stored as a *non-negative* `position = rows_offset` that points at the
+/// partition's `TrieIndexEntry` in `Rows.db`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PartitionPayload {
+    /// Direct `Data.db` byte offset (narrow partition; `< 2` column-index
+    /// blocks). Encoded as `position = ~data_offset` (negative).
+    DataOffset(u64),
+    /// Offset of this partition's `TrieIndexEntry` in `Rows.db` (wide partition;
+    /// `>= 2` column-index blocks). Encoded as `position = rows_offset`
+    /// (non-negative).
+    RowsOffset(u64),
+}
 
 /// One partition's entry in the partition trie.
 #[derive(Debug, Clone)]
@@ -73,8 +103,8 @@ pub struct PartitionTrieEntry {
     key: [u8; 9],
     /// Filter hash byte (lowest 8 bits of the partition-key filter hash).
     hash_byte: u8,
-    /// `Data.db` byte offset where this partition begins.
-    data_offset: u64,
+    /// Where this partition's leaf payload points (`Data.db` or `Rows.db`).
+    payload: PartitionPayload,
 }
 
 /// Builder that accumulates partition entries and serializes the BTI
@@ -104,16 +134,29 @@ impl PartitionsTrieWriter {
 
     /// Record a partition: its raw on-disk key bytes and its `Data.db` offset.
     ///
+    /// Convenience wrapper for a **narrow** partition whose leaf points directly
+    /// into `Data.db` (the common, `< 2` column-index-block case).
+    ///
     /// The byte-comparable trie key and the filter hash byte are derived here
     /// from the raw partition-key bytes via the same `Murmur3Partitioner`
     /// encoding the reader expects.
     pub fn add_partition(&mut self, raw_key_bytes: &[u8], data_offset: u64) {
+        self.add_partition_with_payload(raw_key_bytes, PartitionPayload::DataOffset(data_offset));
+    }
+
+    /// Record a partition with an explicit payload target (issue #910).
+    ///
+    /// Use [`PartitionPayload::RowsOffset`] for a **wide** partition whose leaf
+    /// must point at its `TrieIndexEntry` in `Rows.db` (positive position), or
+    /// [`PartitionPayload::DataOffset`] for a narrow partition (negative
+    /// position, direct `Data.db` offset).
+    pub fn add_partition_with_payload(&mut self, raw_key_bytes: &[u8], payload: PartitionPayload) {
         let key = encode_partition_key_for_bti_trie(raw_key_bytes);
         let hash_byte = filter_hash_byte(raw_key_bytes);
         self.entries.push(PartitionTrieEntry {
             key,
             hash_byte,
-            data_offset,
+            payload,
         });
     }
 
@@ -174,7 +217,10 @@ fn filter_hash_byte(raw_key_bytes: &[u8]) -> u8 {
 /// An in-memory trie node prior to serialization.
 enum TrieBuildNode {
     /// Leaf: a single partition's payload.
-    Leaf { hash_byte: u8, data_offset: u64 },
+    Leaf {
+        hash_byte: u8,
+        payload: PartitionPayload,
+    },
     /// Internal node keyed by the next byte of each child's key.
     Internal {
         children: BTreeMap<u8, TrieBuildNode>,
@@ -191,12 +237,12 @@ fn build_trie(entries: &[PartitionTrieEntry]) -> TrieBuildNode {
         children: BTreeMap::new(),
     };
     for entry in entries {
-        insert(&mut root, &entry.key, entry.hash_byte, entry.data_offset);
+        insert(&mut root, &entry.key, entry.hash_byte, entry.payload);
     }
     root
 }
 
-fn insert(node: &mut TrieBuildNode, key: &[u8], hash_byte: u8, data_offset: u64) {
+fn insert(node: &mut TrieBuildNode, key: &[u8], hash_byte: u8, payload: PartitionPayload) {
     match node {
         TrieBuildNode::Internal { children } => {
             if key.is_empty() {
@@ -205,29 +251,22 @@ fn insert(node: &mut TrieBuildNode, key: &[u8], hash_byte: u8, data_offset: u64)
                 // an internal node would mean a key was a prefix of another. This
                 // branch is unreachable for valid 9-byte keys, but handle it
                 // defensively by inserting a sentinel leaf under byte 0.
-                children.entry(0).or_insert(TrieBuildNode::Leaf {
-                    hash_byte,
-                    data_offset,
-                });
+                children
+                    .entry(0)
+                    .or_insert(TrieBuildNode::Leaf { hash_byte, payload });
                 return;
             }
             let first = key[0];
             let rest = &key[1..];
             if rest.is_empty() {
-                children.insert(
-                    first,
-                    TrieBuildNode::Leaf {
-                        hash_byte,
-                        data_offset,
-                    },
-                );
+                children.insert(first, TrieBuildNode::Leaf { hash_byte, payload });
             } else {
                 let child = children
                     .entry(first)
                     .or_insert_with(|| TrieBuildNode::Internal {
                         children: BTreeMap::new(),
                     });
-                insert(child, rest, hash_byte, data_offset);
+                insert(child, rest, hash_byte, payload);
             }
         }
         TrieBuildNode::Leaf { .. } => {
@@ -257,10 +296,7 @@ fn serialize_trie(root: &TrieBuildNode) -> Result<Vec<u8>> {
 /// absolute offset at which this node's header byte was written.
 fn write_node(node: &TrieBuildNode, buf: &mut Vec<u8>) -> Result<usize> {
     match node {
-        TrieBuildNode::Leaf {
-            hash_byte,
-            data_offset,
-        } => write_leaf(*hash_byte, *data_offset, buf),
+        TrieBuildNode::Leaf { hash_byte, payload } => write_leaf(*hash_byte, *payload, buf),
         TrieBuildNode::Internal { children } => {
             // Post-order: write every child first so we know its offset.
             let mut child_offsets: Vec<(u8, usize)> = Vec::with_capacity(children.len());
@@ -286,17 +322,33 @@ fn write_node(node: &TrieBuildNode, buf: &mut Vec<u8>) -> Result<usize> {
 /// Write a `PayloadOnly` (ordinal 0) leaf node.
 ///
 /// Layout: `[header=(0<<4)|payloadBits] ++ [hash_byte] ++ SizedInts(position)`
-/// where `position = !data_offset` and
-/// `payloadBits = FLAG_HAS_HASH_BYTE + (position_bytes − 1)`.
-fn write_leaf(hash_byte: u8, data_offset: u64, buf: &mut Vec<u8>) -> Result<usize> {
-    // Negative `position` ⇒ direct Data.db offset (PartitionIndex sign convention).
-    // `~data_offset` as i64. Guard against offsets that would overflow i64.
-    if data_offset > i64::MAX as u64 {
-        return Err(Error::InvalidInput(format!(
-            "Data.db offset {data_offset} too large to encode as a signed BTI position"
-        )));
-    }
-    let position: i64 = !(data_offset as i64);
+/// where `payloadBits = FLAG_HAS_HASH_BYTE + (position_bytes − 1)` and the
+/// signed `position` encodes the payload target per the `PartitionIndex` sign
+/// convention:
+/// - [`PartitionPayload::DataOffset`] ⇒ `position = ~data_offset` (negative).
+/// - [`PartitionPayload::RowsOffset`] ⇒ `position = rows_offset` (non-negative;
+///   a `Rows.db` `TrieIndexEntry` offset, issue #910).
+fn write_leaf(hash_byte: u8, payload: PartitionPayload, buf: &mut Vec<u8>) -> Result<usize> {
+    let position: i64 = match payload {
+        // Negative `position` ⇒ direct Data.db offset.
+        PartitionPayload::DataOffset(data_offset) => {
+            if data_offset > i64::MAX as u64 {
+                return Err(Error::InvalidInput(format!(
+                    "Data.db offset {data_offset} too large to encode as a signed BTI position"
+                )));
+            }
+            !(data_offset as i64)
+        }
+        // Non-negative `position` ⇒ Rows.db TrieIndexEntry offset.
+        PartitionPayload::RowsOffset(rows_offset) => {
+            if rows_offset > i64::MAX as u64 {
+                return Err(Error::InvalidInput(format!(
+                    "Rows.db offset {rows_offset} too large to encode as a signed BTI position"
+                )));
+            }
+            rows_offset as i64
+        }
+    };
     let position_bytes = sized_ints_non_zero_size(position);
     debug_assert!((1..=8).contains(&position_bytes));
 
@@ -486,6 +538,437 @@ fn write_be_unsigned(buf: &mut Vec<u8>, value: u64, bytes: usize) {
     let all = value.to_be_bytes();
     // Take the last `bytes` bytes (the least-significant ones in big-endian).
     buf.extend_from_slice(&all[8 - bytes..]);
+}
+
+// ===========================================================================
+// Rows.db within-partition row-index trie writer (issue #910)
+// ===========================================================================
+//
+// `Rows.db` is a concatenation of independent per-partition structures.  For
+// each WIDE partition (one that spans >= 2 column-index blocks, mirroring
+// `RowIndexEntry.create()` / `IndexWriter::add_partition_with_promoted`) we
+// write, in order:
+//
+//   1. The row-index trie body (children before parents, backward deltas),
+//      whose leaves are `PayloadOnly` nodes carrying a `RowIndexReader.IndexInfo`
+//      payload: `[SizedInts(block_offset)] [optional DeletionTime]`.  The low
+//      nibble (payloadBits) is `offset_bytes | FLAG_OPEN_MARKER`.  This is the
+//      EXACT format `parser::decode_bti_row_payload` consumes.
+//   2. The partition's `TrieIndexEntry` at offset `RowsOffset`:
+//        [u16 key_length][key bytes]
+//        [data position : unsigned vint]
+//        [trieRoot - base : SIGNED vint]   (base = RowsOffset + key_length)
+//        [block count : unsigned vint]
+//        [partition DeletionTime]          (0x80 LIVE sentinel, else 12 bytes)
+//      consumed by `parser::resolve_rows_db_entry`.
+//
+// The returned `RowsOffset` for each partition is the offset of its
+// `TrieIndexEntry` (step 2), which is stored as the POSITIVE position in that
+// partition's `Partitions.db` leaf payload.
+//
+// References: cassandra-5.0.0 `RowIndexWriter.java`, `TrieIndexEntry.java`,
+// `RowIndexReader.java`; docs/sstables-definitive-guide chapter 17.
+
+/// One row-index block separator for a wide partition's `Rows.db` trie.
+///
+/// Mirrors the read-side `BtiRowIndexEntry` plus its byte-comparable separator
+/// key.  `separator_key` is the OSS50 byte-comparable clustering prefix the
+/// reader reconstructs during DFS (e.g. `ck=8 → 80 00 00 08` for an `int`
+/// clustering); `block_offset` is the block's offset RELATIVE to the partition
+/// start in `Data.db`.
+#[derive(Debug, Clone)]
+pub struct RowIndexBlock {
+    /// OSS50 byte-comparable separator key for this block (ascending order).
+    pub separator_key: Vec<u8>,
+    /// Block offset relative to the partition's `Data.db` start.
+    pub block_offset: u64,
+    /// Optional open-deletion `(local_deletion_time, marked_for_delete_at)` for
+    /// a range-tombstone that spans this block boundary; `None` for the common
+    /// no-open-marker case.
+    pub open_marker: Option<(i32, i64)>,
+}
+
+/// One wide partition's row index, queued for serialization into `Rows.db`.
+#[derive(Debug, Clone)]
+struct PartitionRowIndex {
+    /// Raw partition-key bytes (length-prefixed into the `TrieIndexEntry`).
+    partition_key: Vec<u8>,
+    /// Absolute `Data.db` byte position of the partition start.
+    data_position: u64,
+    /// Per-block separators (ascending, de-duplicated).
+    blocks: Vec<RowIndexBlock>,
+    /// Partition-level deletion `(local_deletion_time, marked_for_delete_at)`;
+    /// `None` ⇒ the LIVE `0x80` sentinel is written.
+    partition_deletion: Option<(i32, i64)>,
+}
+
+/// Builder that accumulates wide-partition row indexes and serializes `Rows.db`.
+///
+/// Narrow partitions are NOT added here; they keep a direct
+/// [`PartitionPayload::DataOffset`] in `Partitions.db`.  Call
+/// [`RowsTrieWriter::add_partition_row_index`] for each wide partition (in the
+/// same ascending token order partitions are written), then
+/// [`RowsTrieWriter::finish`] to obtain the `Rows.db` bytes plus each
+/// partition's `RowsOffset` (the `TrieIndexEntry` position to store in the
+/// partition leaf).
+#[derive(Debug, Default)]
+pub struct RowsTrieWriter {
+    partitions: Vec<PartitionRowIndex>,
+}
+
+impl RowsTrieWriter {
+    /// Create an empty `Rows.db` writer.
+    pub fn new() -> Self {
+        Self {
+            partitions: Vec::new(),
+        }
+    }
+
+    /// Number of wide-partition row indexes accumulated.
+    pub fn len(&self) -> usize {
+        self.partitions.len()
+    }
+
+    /// Whether any wide-partition row indexes have been accumulated.
+    pub fn is_empty(&self) -> bool {
+        self.partitions.is_empty()
+    }
+
+    /// Queue a wide partition's row index.
+    ///
+    /// `partition_key` is the raw on-disk partition-key bytes; `data_position`
+    /// is the partition's absolute `Data.db` start offset; `blocks` are the
+    /// per-block separators (ascending); `partition_deletion` is the
+    /// partition-level deletion (or `None` for LIVE).
+    ///
+    /// The caller must supply at least one block (a wide partition always has
+    /// >= 2 column-index blocks); zero blocks is rejected at [`Self::finish`].
+    pub fn add_partition_row_index(
+        &mut self,
+        partition_key: &[u8],
+        data_position: u64,
+        blocks: Vec<RowIndexBlock>,
+        partition_deletion: Option<(i32, i64)>,
+    ) {
+        self.partitions.push(PartitionRowIndex {
+            partition_key: partition_key.to_vec(),
+            data_position,
+            blocks,
+            partition_deletion,
+        });
+    }
+
+    /// Serialize all accumulated row indexes into the `Rows.db` bytes.
+    ///
+    /// Returns `(bytes, rows_offsets)` where `rows_offsets[i]` is the
+    /// `TrieIndexEntry` offset for the i-th partition added (the POSITIVE
+    /// position to store in that partition's `Partitions.db` leaf).
+    ///
+    /// An empty writer returns `(empty bytes, empty offsets)` — Cassandra emits
+    /// a 0-byte `Rows.db` component when no partition is wide (verified against
+    /// the real `simple_table`/`collection_table`/`ttl_table` `da-2-bti-Rows.db`
+    /// fixtures), and the reader's `iterate_rows_in_bti_file` accepts it.
+    pub fn finish(self) -> Result<(Vec<u8>, Vec<u64>)> {
+        let mut buf = Vec::new();
+        let mut rows_offsets = Vec::with_capacity(self.partitions.len());
+
+        for part in &self.partitions {
+            if part.blocks.is_empty() {
+                return Err(Error::InvalidInput(
+                    "Rows.db: wide partition must have at least one row-index block".to_string(),
+                ));
+            }
+            // Validate ascending, unique separator keys (a trie cannot encode a
+            // key that is a prefix of another, and DFS expects strict order).
+            for w in part.blocks.windows(2) {
+                if w[0].separator_key >= w[1].separator_key {
+                    return Err(Error::InvalidInput(
+                        "Rows.db: row-index separators must be strictly ascending".to_string(),
+                    ));
+                }
+            }
+
+            // 1. Serialize the row-index trie body. Its root offset is recorded
+            //    for the SIGNED root delta in the TrieIndexEntry.
+            let root = build_row_trie(&part.blocks);
+            let trie_root = write_row_node(&root, &mut buf)?;
+
+            // 2. Serialize this partition's TrieIndexEntry. `RowsOffset` is the
+            //    offset of the key-length prefix (the entry start).
+            let rows_offset = buf.len();
+            write_trie_index_entry(
+                &mut buf,
+                &part.partition_key,
+                part.data_position,
+                trie_root,
+                part.blocks.len() as u64,
+                part.partition_deletion,
+            )?;
+
+            rows_offsets.push(rows_offset as u64);
+        }
+
+        Ok((buf, rows_offsets))
+    }
+}
+
+/// In-memory row-index trie node prior to serialization.
+enum RowTrieBuildNode {
+    /// Leaf: a single block's `IndexInfo` payload.
+    Leaf {
+        block_offset: u64,
+        open_marker: Option<(i32, i64)>,
+    },
+    /// Internal node keyed by the next byte of each child's separator.
+    Internal {
+        children: BTreeMap<u8, RowTrieBuildNode>,
+    },
+}
+
+/// Build the radix-1 row-index trie from ascending block separators.
+fn build_row_trie(blocks: &[RowIndexBlock]) -> RowTrieBuildNode {
+    let mut root = RowTrieBuildNode::Internal {
+        children: BTreeMap::new(),
+    };
+    for b in blocks {
+        insert_row(&mut root, &b.separator_key, b.block_offset, b.open_marker);
+    }
+    root
+}
+
+fn insert_row(
+    node: &mut RowTrieBuildNode,
+    key: &[u8],
+    block_offset: u64,
+    open_marker: Option<(i32, i64)>,
+) {
+    match node {
+        RowTrieBuildNode::Internal { children } => {
+            if key.is_empty() {
+                // A zero-length separator collides with the trie root; the
+                // shortest real separator is at least one byte. Defensive: place
+                // the leaf under byte 0 (unreachable for valid OSS50 keys, which
+                // are weakly prefix-free and non-empty).
+                children.entry(0).or_insert(RowTrieBuildNode::Leaf {
+                    block_offset,
+                    open_marker,
+                });
+                return;
+            }
+            let first = key[0];
+            let rest = &key[1..];
+            if rest.is_empty() {
+                children.insert(
+                    first,
+                    RowTrieBuildNode::Leaf {
+                        block_offset,
+                        open_marker,
+                    },
+                );
+            } else {
+                let child = children
+                    .entry(first)
+                    .or_insert_with(|| RowTrieBuildNode::Internal {
+                        children: BTreeMap::new(),
+                    });
+                insert_row(child, rest, block_offset, open_marker);
+            }
+        }
+        RowTrieBuildNode::Leaf { .. } => {
+            // Unreachable for unique separators (validated in `finish`).
+        }
+    }
+}
+
+/// Write one row-index trie node (and its subtree), returning the absolute
+/// offset of its header byte. Internal nodes reuse the shared
+/// `write_sparse`/`write_dense` serializers (they are leaf-type agnostic).
+fn write_row_node(node: &RowTrieBuildNode, buf: &mut Vec<u8>) -> Result<usize> {
+    match node {
+        RowTrieBuildNode::Leaf {
+            block_offset,
+            open_marker,
+        } => write_row_leaf(*block_offset, *open_marker, buf),
+        RowTrieBuildNode::Internal { children } => {
+            let mut child_offsets: Vec<(u8, usize)> = Vec::with_capacity(children.len());
+            for (&byte, child) in children.iter() {
+                let off = write_row_node(child, buf)?;
+                child_offsets.push((byte, off));
+            }
+            if child_offsets.len() == 256 {
+                write_dense(&child_offsets, buf)
+            } else {
+                write_sparse(&child_offsets, buf)
+            }
+        }
+    }
+}
+
+/// Write a `PayloadOnly` (ordinal 0) row-index leaf node carrying a
+/// `RowIndexReader.IndexInfo` payload.
+///
+/// Layout: `[header=(0<<4)|payloadBits] ++ SizedInts(block_offset) ++ [DeletionTime?]`
+/// where `payloadBits = SizedInts.nonZeroSize(block_offset) | (FLAG_OPEN_MARKER
+/// if open_marker)`.  This is exactly what `decode_bti_row_payload` reads:
+/// `offset_bytes = payloadBits & !FLAG_OPEN_MARKER` (must be 1..=7), and an open
+/// `DeletionTime` follows when `FLAG_OPEN_MARKER` is set.
+fn write_row_leaf(
+    block_offset: u64,
+    open_marker: Option<(i32, i64)>,
+    buf: &mut Vec<u8>,
+) -> Result<usize> {
+    if block_offset > i64::MAX as u64 {
+        return Err(Error::InvalidInput(format!(
+            "Rows.db block offset {block_offset} too large to encode as SizedInts"
+        )));
+    }
+    // Block offsets are non-negative; size them as an unsigned magnitude so the
+    // high bit (which SizedInts.read sign-extends) is never set for a value that
+    // fits in (bytes*8 - 1) bits. `sized_ints_non_zero_size` already reserves the
+    // sign bit, so a non-negative value never round-trips to a negative.
+    let offset_bytes = sized_ints_non_zero_size(block_offset as i64);
+    // The reader rejects offset_bytes == 0 or > 7 (RowIndexWriter asserts < 8).
+    if !(1..=7).contains(&offset_bytes) {
+        return Err(Error::InvalidInput(format!(
+            "Rows.db block offset {block_offset} needs {offset_bytes} SizedInts bytes; \
+             expected 1..=7"
+        )));
+    }
+
+    let mut payload_bits = offset_bytes as u8;
+    if open_marker.is_some() {
+        payload_bits |= crate::storage::sstable::bti::parser::FLAG_OPEN_MARKER;
+    }
+
+    let offset = buf.len();
+    // PayloadOnly ordinal 0: high nibble 0, low nibble = payloadBits.
+    buf.push(payload_bits & 0x0F);
+    write_sized_int_be(buf, block_offset as i64, offset_bytes);
+    if let Some((ldt, mfda)) = open_marker {
+        write_da_deletion_time(buf, Some((ldt, mfda)));
+    }
+    Ok(offset)
+}
+
+/// Serialize a per-partition `TrieIndexEntry` (Cassandra `TrieIndexEntry.serialize`).
+///
+/// Layout (consumed by `parser::resolve_rows_db_entry`):
+/// ```text
+/// [u16 key_length][partition key bytes]
+/// [data position : unsigned vint]
+/// [trieRoot - base : SIGNED vint]      (base = entry_start + key_length)
+/// [block count : unsigned vint]
+/// [partition DeletionTime]
+/// ```
+/// `entry_start` is the current `buf.len()` (the `RowsOffset` of this entry).
+fn write_trie_index_entry(
+    buf: &mut Vec<u8>,
+    partition_key: &[u8],
+    data_position: u64,
+    trie_root: usize,
+    block_count: u64,
+    partition_deletion: Option<(i32, i64)>,
+) -> Result<()> {
+    let entry_start = buf.len();
+    let key_length = partition_key.len();
+    let key_length_u16 = u16::try_from(key_length).map_err(|_| {
+        Error::InvalidInput(format!(
+            "Rows.db TrieIndexEntry: partition key length {key_length} exceeds u16"
+        ))
+    })?;
+
+    // [u16 key_length][key bytes]
+    buf.extend_from_slice(&key_length_u16.to_be_bytes());
+    buf.extend_from_slice(partition_key);
+
+    // [data position : unsigned vint]
+    write_unsigned_vint(buf, data_position);
+
+    // [trieRoot - base : SIGNED vint]. base = RowsOffset + key_length = the
+    // position immediately after the length-prefixed key (entry_start + 2 +
+    // key_length) MINUS 2; `resolve_rows_db_entry` computes
+    // base = rows_offset + key_length, so root_delta = trie_root - base.
+    let base = entry_start + key_length;
+    let root_delta = trie_root as i64 - base as i64;
+    write_signed_vint(buf, root_delta);
+
+    // [block count : unsigned vint]
+    write_unsigned_vint(buf, block_count);
+
+    // [partition DeletionTime]
+    write_da_deletion_time(buf, partition_deletion);
+
+    Ok(())
+}
+
+/// Write an unsigned VInt in Cassandra's count-leading-ones encoding
+/// (`DataOutputPlus.writeUnsignedVInt`); the inverse of
+/// `parser::read_unsigned_vint_from_slice`.
+fn write_unsigned_vint(buf: &mut Vec<u8>, value: u64) {
+    // extra_bytes = number of bytes after the first; determined by magnitude.
+    // The first byte holds `extra_bytes` leading 1-bits, then a 0 separator,
+    // then the top data bits; remaining bytes are big-endian.
+    let extra_bytes = if value == 0 {
+        0
+    } else {
+        let significant_bits = 64 - value.leading_zeros() as usize;
+        // Each extra byte carries 8 data bits; the first byte carries
+        // (7 - extra_bytes) data bits. Find the smallest extra_bytes such that
+        // (7 - extra_bytes) + 8*extra_bytes >= significant_bits.
+        let mut n = 0usize;
+        while n < 8 && (7 - n) + 8 * n < significant_bits {
+            n += 1;
+        }
+        n
+    };
+
+    if extra_bytes == 0 {
+        buf.push(value as u8);
+        return;
+    }
+    if extra_bytes >= 8 {
+        // 8 extra bytes: first byte is all ones, value spans the full 8 bytes.
+        buf.push(0xFF);
+        buf.extend_from_slice(&value.to_be_bytes());
+        return;
+    }
+
+    let data_bits_first = 7 - extra_bytes;
+    // Leading 1-bits mask (extra_bytes ones) in the high bits of the first byte.
+    let leading_ones: u8 = (!0u8) << (8 - extra_bytes);
+    let total_bytes = extra_bytes + 1;
+    let mut bytes = value.to_be_bytes().to_vec();
+    // Keep only the low `total_bytes` of the big-endian representation.
+    let tail = bytes.split_off(8 - total_bytes);
+    // tail[0] holds the most-significant data byte; its low `data_bits_first`
+    // bits go into the first output byte, OR'd with the leading-ones prefix.
+    let first = leading_ones | (tail[0] & ((1u8 << data_bits_first) - 1));
+    buf.push(first);
+    buf.extend_from_slice(&tail[1..]);
+}
+
+/// Write a signed VInt (Cassandra ZigZag) — the inverse of
+/// `parser::read_signed_vint_from_slice`.
+fn write_signed_vint(buf: &mut Vec<u8>, value: i64) {
+    // ZigZag encode: (n << 1) ^ (n >> 63)
+    let zigzag = ((value << 1) ^ (value >> 63)) as u64;
+    write_unsigned_vint(buf, zigzag);
+}
+
+/// Write a modern (DA/BTI) `DeletionTime` — the inverse of
+/// `parser::decode_da_deletion_time`.
+///
+/// `None` ⇒ the single `0x80` LIVE sentinel. `Some((ldt, mfda))` ⇒ the 12-byte
+/// body `[markedForDeleteAt : i64 BE][localDeletionTime : u32 BE]` (note the
+/// modern field order/width).
+fn write_da_deletion_time(buf: &mut Vec<u8>, deletion: Option<(i32, i64)>) {
+    match deletion {
+        None => buf.push(0x80),
+        Some((local_deletion_time, marked_for_delete_at)) => {
+            buf.extend_from_slice(&marked_for_delete_at.to_be_bytes());
+            buf.extend_from_slice(&(local_deletion_time as u32).to_be_bytes());
+        }
+    }
 }
 
 #[cfg(test)]
@@ -708,7 +1191,7 @@ mod tests {
                 b as u8,
                 TrieBuildNode::Leaf {
                     hash_byte: b as u8,
-                    data_offset: (b as u64) * 17,
+                    payload: PartitionPayload::DataOffset((b as u64) * 17),
                 },
             );
         }
@@ -748,6 +1231,281 @@ mod tests {
         match lookup_partition_in_bti_file(&mut cur, key).ok()?? {
             BtiPartitionLocation::DataOffset(o) => Some(o),
             BtiPartitionLocation::RowsOffset(_) => None,
+        }
+    }
+
+    // ── Rows.db writer (#910) ────────────────────────────────────────────
+
+    /// The unsigned-VInt writer must be the exact inverse of the reader's
+    /// `read_unsigned_vint_from_slice` for a wide spread of values, including
+    /// the 1-/2-/.../9-byte boundaries.
+    #[test]
+    fn unsigned_vint_roundtrips_through_reader() {
+        use crate::storage::sstable::bti::parser::read_unsigned_vint_from_slice_for_test as read_u;
+        let values: [u64; 20] = [
+            0,
+            1,
+            63,
+            64,
+            127,
+            128,
+            255,
+            256,
+            16_383,
+            16_384,
+            65_535,
+            65_536,
+            1_000_000,
+            300_000_000_000,
+            (1u64 << 35) - 1,
+            1u64 << 35,
+            (1u64 << 49) - 1,
+            1u64 << 49,
+            u64::MAX - 1,
+            u64::MAX,
+        ];
+        for v in values {
+            let mut buf = Vec::new();
+            write_unsigned_vint(&mut buf, v);
+            let (got, n) = read_u(&buf).expect("read");
+            assert_eq!(got, v, "unsigned vint roundtrip failed for {v}: {buf:02x?}");
+            assert_eq!(n, buf.len(), "consumed all bytes for {v}");
+        }
+    }
+
+    /// The signed-VInt (ZigZag) writer must be the exact inverse of the reader's
+    /// `read_signed_vint_from_slice` for positive, negative and zero deltas.
+    #[test]
+    fn signed_vint_roundtrips_through_reader() {
+        use crate::storage::sstable::bti::parser::read_signed_vint_from_slice_for_test as read_s;
+        for v in [
+            0i64,
+            1,
+            -1,
+            10,
+            -10,
+            127,
+            -128,
+            1000,
+            -1000,
+            i32::MIN as i64,
+            i64::MAX,
+            i64::MIN,
+        ] {
+            let mut buf = Vec::new();
+            write_signed_vint(&mut buf, v);
+            let (got, _n) = read_s(&buf).expect("read");
+            assert_eq!(got, v, "signed vint roundtrip failed for {v}: {buf:02x?}");
+        }
+    }
+
+    /// A wide partition's Rows.db trie must round-trip through the production
+    /// reader: `resolve_rows_db_entry` recovers the trie root + metadata, and
+    /// `iterate_rows_in_bti_trie` yields the exact separators + block offsets we
+    /// wrote, in ascending order.
+    #[test]
+    fn rows_db_single_wide_partition_roundtrips() {
+        use crate::storage::sstable::bti::{iterate_rows_in_bti_trie, resolve_rows_db_entry};
+
+        // int clustering separators ck = 8,16,24 → OSS50 sign-flipped 4 bytes.
+        let sep = |ck: i32| ((ck as u32) ^ 0x8000_0000).to_be_bytes().to_vec();
+        let blocks = vec![
+            RowIndexBlock {
+                separator_key: sep(8),
+                block_offset: 16_512,
+                open_marker: None,
+            },
+            RowIndexBlock {
+                separator_key: sep(16),
+                block_offset: 33_024,
+                open_marker: None,
+            },
+            RowIndexBlock {
+                separator_key: sep(24),
+                block_offset: 49_536,
+                open_marker: None,
+            },
+        ];
+
+        let raw_pk = 1i32.to_be_bytes().to_vec();
+        let mut w = RowsTrieWriter::new();
+        w.add_partition_row_index(&raw_pk, 0, blocks.clone(), None);
+        let (rows_db, offsets) = w.finish().expect("finish Rows.db");
+        assert_eq!(offsets.len(), 1);
+        let rows_offset = offsets[0] as usize;
+
+        // Feeding RowsOffset directly as a trie root must FAIL (it is the entry).
+        assert!(
+            iterate_rows_in_bti_trie(&rows_db, rows_offset).is_err(),
+            "RowsOffset is a TrieIndexEntry, not a trie root"
+        );
+
+        // resolve_rows_db_entry recovers the header.
+        let header = resolve_rows_db_entry(&rows_db, rows_offset).expect("resolve entry");
+        assert_eq!(header.data_position, 0);
+        assert_eq!(header.block_count, blocks.len() as u32);
+        assert_eq!(header.partition_deletion, None, "LIVE sentinel → None");
+
+        // Traversal from the recovered root yields our separators + offsets.
+        let entries =
+            iterate_rows_in_bti_trie(&rows_db, header.trie_root).expect("traverse from root");
+        assert_eq!(entries.len(), blocks.len());
+        for (got, expected) in entries.iter().zip(blocks.iter()) {
+            assert_eq!(got.0, expected.separator_key, "separator key");
+            assert_eq!(got.1.data_offset, expected.block_offset, "block offset");
+            assert_eq!(got.1.open_marker, None);
+        }
+    }
+
+    /// Multiple wide partitions concatenate in Rows.db; each RowsOffset resolves
+    /// to its OWN trie root and metadata (no cross-talk between partitions).
+    #[test]
+    fn rows_db_multiple_wide_partitions_roundtrip() {
+        use crate::storage::sstable::bti::{iterate_rows_in_bti_trie, resolve_rows_db_entry};
+
+        let sep = |ck: i32| ((ck as u32) ^ 0x8000_0000).to_be_bytes().to_vec();
+        let mk = |base: u64| {
+            vec![
+                RowIndexBlock {
+                    separator_key: sep(8),
+                    block_offset: base + 16_512,
+                    open_marker: None,
+                },
+                RowIndexBlock {
+                    separator_key: sep(16),
+                    block_offset: base + 33_024,
+                    open_marker: None,
+                },
+            ]
+        };
+
+        let mut w = RowsTrieWriter::new();
+        w.add_partition_row_index(&1i32.to_be_bytes(), 0, mk(0), None);
+        w.add_partition_row_index(&2i32.to_be_bytes(), 700_000, mk(0), None);
+        w.add_partition_row_index(&3i32.to_be_bytes(), 1_400_000, mk(0), None);
+        let (rows_db, offsets) = w.finish().expect("finish");
+        assert_eq!(offsets.len(), 3);
+
+        let data_positions = [0u64, 700_000, 1_400_000];
+        for (i, &ro) in offsets.iter().enumerate() {
+            let header = resolve_rows_db_entry(&rows_db, ro as usize).expect("resolve");
+            assert_eq!(
+                header.data_position, data_positions[i],
+                "partition {i} data position"
+            );
+            assert_eq!(header.block_count, 2);
+            let entries = iterate_rows_in_bti_trie(&rows_db, header.trie_root).expect("traverse");
+            assert_eq!(entries.len(), 2, "partition {i} block count");
+            assert_eq!(entries[0].0, sep(8));
+            assert_eq!(entries[1].0, sep(16));
+        }
+    }
+
+    /// An empty RowsTrieWriter yields 0-byte Rows.db with no offsets — exactly
+    /// what Cassandra emits for a narrow-only BTI SSTable (verified against the
+    /// real `simple_table`/`collection_table`/`ttl_table` 0-byte `da-2-bti-Rows.db`
+    /// fixtures), and the reader accepts it.
+    #[test]
+    fn rows_db_empty_writer_is_zero_bytes() {
+        let w = RowsTrieWriter::new();
+        let (bytes, offsets) = w.finish().expect("finish empty");
+        assert!(bytes.is_empty(), "empty Rows.db must be 0 bytes");
+        assert!(offsets.is_empty());
+    }
+
+    /// A wide partition with an open-marker block round-trips the DeletionTime.
+    #[test]
+    fn rows_db_open_marker_roundtrips() {
+        use crate::storage::sstable::bti::{iterate_rows_in_bti_trie, resolve_rows_db_entry};
+        let sep = |ck: i32| ((ck as u32) ^ 0x8000_0000).to_be_bytes().to_vec();
+        let blocks = vec![
+            RowIndexBlock {
+                separator_key: sep(8),
+                block_offset: 16_512,
+                open_marker: Some((1_700_000_000, 1_700_000_000_000_000)),
+            },
+            RowIndexBlock {
+                separator_key: sep(16),
+                block_offset: 33_024,
+                open_marker: None,
+            },
+        ];
+        let mut w = RowsTrieWriter::new();
+        w.add_partition_row_index(&7i32.to_be_bytes(), 0, blocks.clone(), None);
+        let (rows_db, offsets) = w.finish().expect("finish");
+        let header = resolve_rows_db_entry(&rows_db, offsets[0] as usize).expect("resolve");
+        let entries = iterate_rows_in_bti_trie(&rows_db, header.trie_root).expect("traverse");
+        assert_eq!(
+            entries[0].1.open_marker,
+            Some((1_700_000_000, 1_700_000_000_000_000))
+        );
+        assert_eq!(entries[1].1.open_marker, None);
+    }
+
+    /// Partition-level deletion (non-LIVE) round-trips through the TrieIndexEntry.
+    #[test]
+    fn rows_db_partition_deletion_roundtrips() {
+        use crate::storage::sstable::bti::resolve_rows_db_entry;
+        let sep = |ck: i32| ((ck as u32) ^ 0x8000_0000).to_be_bytes().to_vec();
+        let blocks = vec![
+            RowIndexBlock {
+                separator_key: sep(8),
+                block_offset: 16_512,
+                open_marker: None,
+            },
+            RowIndexBlock {
+                separator_key: sep(16),
+                block_offset: 33_024,
+                open_marker: None,
+            },
+        ];
+        let mut w = RowsTrieWriter::new();
+        w.add_partition_row_index(&9i32.to_be_bytes(), 0, blocks, Some((1234, 5678)));
+        let (rows_db, offsets) = w.finish().expect("finish");
+        let header = resolve_rows_db_entry(&rows_db, offsets[0] as usize).expect("resolve");
+        assert_eq!(header.partition_deletion, Some((1234, 5678)));
+    }
+
+    /// A non-ascending separator set is rejected (the trie cannot encode it and
+    /// DFS expects strict order).
+    #[test]
+    fn rows_db_rejects_non_ascending_separators() {
+        let sep = |ck: i32| ((ck as u32) ^ 0x8000_0000).to_be_bytes().to_vec();
+        let blocks = vec![
+            RowIndexBlock {
+                separator_key: sep(16),
+                block_offset: 16_512,
+                open_marker: None,
+            },
+            RowIndexBlock {
+                separator_key: sep(8),
+                block_offset: 33_024,
+                open_marker: None,
+            },
+        ];
+        let mut w = RowsTrieWriter::new();
+        w.add_partition_row_index(&1i32.to_be_bytes(), 0, blocks, None);
+        assert!(w.finish().is_err());
+    }
+
+    /// A partition leaf with a positive RowsOffset payload decodes back to the
+    /// SAME RowsOffset via the reader (`BtiPartitionLocation::RowsOffset`).
+    #[test]
+    fn partition_leaf_rows_offset_roundtrips() {
+        let raw_key = vec![0x11u8; 16];
+        let mut w = PartitionsTrieWriter::new();
+        w.add_partition_with_payload(&raw_key, PartitionPayload::RowsOffset(242));
+        let bytes = w.finish().expect("finish");
+
+        let mut cur = Cursor::new(bytes);
+        let loc = lookup_raw_key_in_bti_partitions_db(&mut cur, &raw_key)
+            .expect("lookup")
+            .expect("found");
+        match loc {
+            BtiPartitionLocation::RowsOffset(o) => assert_eq!(o, 242),
+            BtiPartitionLocation::DataOffset(o) => {
+                panic!("expected RowsOffset(242), got DataOffset({o})")
+            }
         }
     }
 }

--- a/cqlite-core/src/storage/sstable/writer/partitions_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/partitions_writer.rs
@@ -62,7 +62,7 @@
 use crate::error::{Error, Result};
 use crate::storage::sstable::bti::encode_partition_key_for_bti_trie;
 use crate::storage::sstable::bti::parser::FLAG_HAS_HASH_BYTE;
-use crate::util::cassandra_murmur3::cassandra_murmur3_token;
+use crate::util::cassandra_murmur3::cassandra_partition_filter_hash_lower_bits;
 use std::collections::BTreeMap;
 
 /// One partition's entry in the partition trie.
@@ -146,27 +146,25 @@ impl PartitionsTrieWriter {
     }
 }
 
-/// Compute the filter hash byte stored at the front of each partition leaf
-/// payload.
+/// Compute the canonical filter hash byte stored at the front of each partition
+/// leaf payload.
 ///
-/// **Phase-1 placeholder (follow-up #872).** Cassandra's BTI partition index
-/// stores a partition-key *filter* hash byte here for fast mismatch rejection
-/// (see `PartitionIndex` / `DecoratedKey.filterHashLowerBits()`), which is a
-/// distinct quantity from the byte-comparable token. We do not yet emit the
-/// canonical value: the exact derivation must be verified against Cassandra
-/// source/fixtures before we encode it (no-heuristics mandate, issue #28), and
-/// phase-1 output is already a non-canonical hybrid (see [`super::SSTableFormat::Bti`]).
-/// Our BTI reader does **not** verify this byte during lookup (it skips it), so
-/// round-trip correctness is independent of its value; we derive it from the
-/// high byte of the same Murmur3 token the trie key uses, keeping the payload
-/// internally self-consistent. Emitting the canonical filter hash byte (with a
-/// vector test) is tracked in #872.
+/// Cassandra's BTI partition index writes `(byte) decoratedKey.filterHashLowerBits()`
+/// as each leaf's hash byte for fast mismatch rejection (see
+/// `org.apache.cassandra.io.sstable.format.bti.PartitionIndex` and
+/// `org.apache.cassandra.db.DecoratedKey.filterHashLowerBits()`, Cassandra 5.0.8).
+/// `filterHashLowerBits()` returns `hash[1]` — the **second** 64-bit word (`h2`) of
+/// the partition key's 128-bit Murmur3 hash — which is a *distinct* quantity from the
+/// token (`hash[0]` / `h1`) used to build the byte-comparable trie key. The stored
+/// byte is the low 8 bits of that `h2` value.
+///
+/// This is the canonical, authoritative derivation (no heuristics, issue #28), verified
+/// byte-for-byte against the real `da-2-bti-Partitions.db` fixture — see the
+/// `canonical_filter_hash_byte_matches_real_bti_fixture` vector test below. It replaces
+/// the earlier phase-1 placeholder that derived the byte from the trie-key token (`h1`),
+/// which produced values a Cassandra-canonical reader would reject.
 fn filter_hash_byte(raw_key_bytes: &[u8]) -> u8 {
-    let token = cassandra_murmur3_token(raw_key_bytes);
-    let bc = (token as u64) ^ 0x8000_0000_0000_0000u64;
-    // High byte of the byte-comparable token (matches the first discriminating
-    // trie byte, which is the most significant token byte).
-    (bc >> 56) as u8
+    cassandra_partition_filter_hash_lower_bits(raw_key_bytes) as u8
 }
 
 // ---------------------------------------------------------------------------
@@ -571,6 +569,74 @@ mod tests {
                 }
             }
         }
+    }
+
+    /// Finding 1 (roborev #908): the partition leaf hash byte must be the
+    /// **canonical** Cassandra value — `(byte) DecoratedKey.filterHashLowerBits()`,
+    /// i.e. the low 8 bits of `h2` (the second 64-bit Murmur3 word) — NOT the
+    /// byte-comparable token's high byte that the phase-1 placeholder emitted.
+    ///
+    /// These expected bytes are read directly from the real, Cassandra-produced
+    /// `da-2-bti-Partitions.db` fixture at
+    /// `test-data/datasets/sstables/test_da/simple_table-de1be8b064e711f19ad401a8c8227b11`.
+    /// Its three PayloadOnly leaves store:
+    ///   UUID 2222… → hash byte 0x24 (Data.db offset 0)
+    ///   UUID 1111… → hash byte 0x22 (Data.db offset 63)
+    ///   UUID 3333… → hash byte 0xf4 (Data.db offset 125)
+    /// (hexdump: `08 24 ff | 08 22 c0 | 08 f4 82 …`).
+    #[test]
+    fn canonical_filter_hash_byte_matches_real_bti_fixture() {
+        // (raw partition key bytes, expected canonical hash byte from the fixture)
+        let vectors: [(Vec<u8>, u8); 3] = [
+            (vec![0x22u8; 16], 0x24),
+            (vec![0x11u8; 16], 0x22),
+            (vec![0x33u8; 16], 0xf4),
+        ];
+        for (raw_key, expected) in vectors {
+            let got = filter_hash_byte(&raw_key);
+            assert_eq!(
+                got, expected,
+                "canonical hash byte mismatch for key {raw_key:02x?}: \
+                 expected 0x{expected:02x} (from real da-2-bti-Partitions.db), got 0x{got:02x}"
+            );
+        }
+
+        // And confirm the placeholder it replaced (token/h1 high byte) would have
+        // produced *different*, non-canonical values — guarding against a regression
+        // that reintroduces the token-derived byte.
+        for (raw_key, expected) in [(vec![0x22u8; 16], 0x90u8), (vec![0x11u8; 16], 0xbc)] {
+            let token = crate::util::cassandra_murmur3::cassandra_murmur3_token(&raw_key);
+            let placeholder = (((token as u64) ^ 0x8000_0000_0000_0000u64) >> 56) as u8;
+            assert_eq!(placeholder, expected, "placeholder reference value drifted");
+            assert_ne!(
+                placeholder,
+                filter_hash_byte(&raw_key),
+                "canonical hash byte must differ from the old token-derived placeholder"
+            );
+        }
+    }
+
+    /// The canonical hash byte the writer emits round-trips: building a trie that
+    /// includes these partitions yields leaf payloads whose first byte equals the
+    /// canonical hash byte (decoded straight from the serialized bytes).
+    #[test]
+    fn written_leaf_hash_byte_is_canonical() {
+        let raw_key = vec![0x22u8; 16];
+        let mut w = PartitionsTrieWriter::new();
+        w.add_partition(&raw_key, 0);
+        let bytes = w.finish().expect("finish trie");
+        // The first written node is the only leaf (PayloadOnly). Its layout is
+        // [header=0x08][hash_byte][SizedInts position…]; header 0x08 = payloadBits 8.
+        assert_eq!(
+            bytes[0], 0x08,
+            "expected PayloadOnly leaf with payloadBits=8"
+        );
+        assert_eq!(
+            bytes[1],
+            filter_hash_byte(&raw_key),
+            "serialized leaf hash byte must be the canonical value"
+        );
+        assert_eq!(bytes[1], 0x24, "canonical hash byte for UUID 2222… is 0x24");
     }
 
     #[test]

--- a/cqlite-core/src/storage/sstable/writer/partitions_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/partitions_writer.rs
@@ -105,6 +105,11 @@ pub struct PartitionTrieEntry {
     hash_byte: u8,
     /// Where this partition's leaf payload points (`Data.db` or `Rows.db`).
     payload: PartitionPayload,
+    /// Raw on-disk partition-key bytes. Retained so `finish` can write the
+    /// Cassandra `PartitionIndex` first/last-key region (the lowest- and
+    /// highest-token keys after the trie-key sort). Bounded by the partition-key
+    /// size, not the partition data.
+    raw_key: Vec<u8>,
 }
 
 /// Builder that accumulates partition entries and serializes the BTI
@@ -157,11 +162,28 @@ impl PartitionsTrieWriter {
             key,
             hash_byte,
             payload,
+            raw_key: raw_key_bytes.to_vec(),
         });
     }
 
-    /// Serialize the accumulated entries into the on-disk `Partitions.db`
-    /// trie bytes (including the 8-byte big-endian root-offset footer).
+    /// Serialize the accumulated entries into the on-disk `Partitions.db` bytes
+    /// in Cassandra's canonical `PartitionIndex` layout (issue #911):
+    ///
+    /// ```text
+    /// [ trie nodes ............ ]   root node at absolute offset `root`
+    /// [ firstKey  (u16 len + bytes) ]   at absolute offset `firstPos`
+    /// [ lastKey   (u16 len + bytes) ]
+    /// [ footer: i64 firstPos | i64 keyCount | i64 root ]   last 24 bytes
+    /// ```
+    ///
+    /// `PartitionIndex.load` (cassandra-5.0.0) reads the 24-byte footer from
+    /// `dataLength() - 24`, seeks to `firstPos`, then reads the first and last
+    /// decorated keys via `ByteBufferUtil.readWithShortLength`. The trie node
+    /// encoding is unchanged (already Cassandra-`TrieNode`-compatible and verified
+    /// against the real `da` fixtures); only this footer + first/last-key region
+    /// is added so `sstabledump`/`sstablemetadata` and a live node can open the
+    /// index. The final 8 bytes remain `root`, so CQLite's own footer-based reader
+    /// (which reads `root` from the last 8 bytes) is unaffected.
     ///
     /// Returns an empty `Vec` if no partitions were recorded (an empty
     /// `Partitions.db`, mirroring an empty SSTable).
@@ -184,9 +206,51 @@ impl PartitionsTrieWriter {
             }
         }
 
+        // First/last decorated key (lowest/highest token after the trie-key sort).
+        // Bounded copies (partition-key sized); entries is non-empty here.
+        let first_key = entries
+            .first()
+            .map(|e| e.raw_key.clone())
+            .unwrap_or_default();
+        let last_key = entries
+            .last()
+            .map(|e| e.raw_key.clone())
+            .unwrap_or_default();
+        let key_count = entries.len() as i64;
+
+        // 1. Serialize the trie nodes; `root` is the absolute offset of the root
+        //    node within the buffer (post-order write, backward-delta pointers).
         let root = build_trie(&entries);
-        serialize_trie(&root)
+        let mut buf = Vec::new();
+        let root_offset = write_node(&root, &mut buf)?;
+
+        // 2. firstPos marks the start of the first/last-key region.
+        let first_pos = buf.len() as i64;
+        write_with_short_length(&mut buf, &first_key)?;
+        write_with_short_length(&mut buf, &last_key)?;
+
+        // 3. 24-byte footer: firstPos, keyCount, root (each i64 BE). The last 8
+        //    bytes stay `root` so CQLite's existing footer reader is unaffected.
+        buf.extend_from_slice(&first_pos.to_be_bytes());
+        buf.extend_from_slice(&key_count.to_be_bytes());
+        buf.extend_from_slice(&(root_offset as i64).to_be_bytes());
+        Ok(buf)
     }
+}
+
+/// Write a byte slice with a 2-byte big-endian unsigned-short length prefix
+/// (Cassandra `ByteBufferUtil.writeWithShortLength`). Keys longer than
+/// `u16::MAX` are rejected — a partition key cannot exceed 64 KiB in Cassandra.
+fn write_with_short_length(buf: &mut Vec<u8>, bytes: &[u8]) -> Result<()> {
+    if bytes.len() > u16::MAX as usize {
+        return Err(Error::InvalidInput(format!(
+            "partition key too long for Partitions.db short-length prefix: {} bytes",
+            bytes.len()
+        )));
+    }
+    buf.extend_from_slice(&(bytes.len() as u16).to_be_bytes());
+    buf.extend_from_slice(bytes);
+    Ok(())
 }
 
 /// Compute the canonical filter hash byte stored at the front of each partition
@@ -279,12 +343,16 @@ fn insert(node: &mut TrieBuildNode, key: &[u8], hash_byte: u8, payload: Partitio
 // Trie serialization (bottom-up, backward-delta pointers)
 // ---------------------------------------------------------------------------
 
-/// Serialize the trie into `Partitions.db` bytes.
+/// Serialize the trie into bytes with a legacy 8-byte big-endian root-offset
+/// footer (NOT the canonical Cassandra `PartitionIndex` `[firstPos|keyCount|root]`
+/// footer that [`PartitionsTrieWriter::finish`] now emits).
 ///
 /// Performs a post-order traversal so each child is fully written (and its
 /// absolute offset known) before its parent. Child pointers are encoded as
-/// backward deltas `parent_pos − child_pos`, matching the reader. The final 8
-/// bytes are the big-endian absolute offset of the root node.
+/// backward deltas `parent_pos − child_pos`, matching the reader. Retained as a
+/// trie-node-encoding helper for the unit tests that walk a node tree via the
+/// footer-based reader; production `Partitions.db` is written by `finish`.
+#[cfg(test)]
 fn serialize_trie(root: &TrieBuildNode) -> Result<Vec<u8>> {
     let mut buf = Vec::new();
     let root_offset = write_node(root, &mut buf)?;

--- a/cqlite-core/src/storage/sstable/writer/stats_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/stats_writer.rs
@@ -204,6 +204,17 @@ pub struct StatisticsMetadata {
     /// Last (highest-token) decorated partition-key bytes written to this
     /// SSTable. Serialised as the `da`-format `StatsMetadata.lastKey`.
     pub last_key: Option<Vec<u8>>,
+    /// Whether any partition written to this SSTable carries a partition-level
+    /// deletion (partition tombstone).
+    ///
+    /// Serialised as the `da`-format `StatsMetadata.hasPartitionLevelDeletions`
+    /// boolean (`hasPartitionLevelDeletionsPresenceMarker`); written as a single
+    /// `writeBoolean` byte (`0x01` true, `0x00` false) — matching
+    /// cassandra-5.0.0 `StatsMetadata.StatsMetadataSerializer.serialize`
+    /// (line 495). Set by `SSTableWriter::write_partition` whenever a mutation
+    /// contributes a `partition_tombstone`. Ignored by the legacy BIG (nb/oa)
+    /// STATS body, which never serialises this field.
+    pub has_partition_level_deletions: bool,
 }
 
 impl Default for StatisticsMetadata {
@@ -222,6 +233,7 @@ impl Default for StatisticsMetadata {
             tombstone_histogram: TombstoneHistogram::new(),
             first_key: None,
             last_key: None,
+            has_partition_level_deletions: false,
         }
     }
 }
@@ -273,6 +285,16 @@ impl StatisticsMetadata {
             self.first_key = Some(key.to_vec());
         }
         self.last_key = Some(key.to_vec());
+    }
+
+    /// Record that a partition-level deletion (partition tombstone) was written.
+    ///
+    /// Once set, this stays `true` for the lifetime of the SSTable and drives the
+    /// `da`-format `StatsMetadata.hasPartitionLevelDeletions` marker. Called by
+    /// `SSTableWriter::write_partition` for any partition carrying a
+    /// `partition_tombstone`.
+    pub fn mark_partition_level_deletion(&mut self) {
+        self.has_partition_level_deletions = true;
     }
 
     /// Increment row count
@@ -870,8 +892,14 @@ impl StatisticsWriter {
         // 7. compressionRatio (-1.0 = unknown)
         buffer.write_all(&(-1.0f64).to_be_bytes())?;
 
-        // 8. TombstoneHistogram estimatedTombstoneDropTime
-        self.write_tombstone_histogram(&mut buffer, &metadata.tombstone_histogram)?;
+        // 8. TombstoneHistogram estimatedTombstoneDropTime.
+        //
+        // The `da` (BtiFormat) version resolves `TombstoneHistogram.getSerializer`
+        // to the modern `HistogramSerializer` (long point + int value per bin),
+        // NOT the legacy serializer (double + long) used by older versions. Using
+        // the legacy entry encoding here mis-sizes the body and derails the
+        // subsequent `coveredClustering` Slice deserialization in Cassandra.
+        self.write_tombstone_histogram_modern(&mut buffer, &metadata.tombstone_histogram)?;
 
         // 9. sstableLevel, repairedAt
         buffer.write_all(&0i32.to_be_bytes())?;
@@ -928,7 +956,17 @@ impl StatisticsWriter {
         buffer.write_all(&[0x00])?;
 
         // 17. hasPartitionLevelDeletions
-        buffer.write_all(&[0x00])?;
+        //
+        // cassandra-5.0.0 StatsMetadata.StatsMetadataSerializer.serialize line 495:
+        //   out.writeBoolean(component.hasPartitionLevelDeletions)
+        // DataOutput.writeBoolean emits a single byte: 0x01 for true, 0x00 false.
+        // Set when any partition written carries a partition-level tombstone.
+        let has_partition_deletions = if metadata.has_partition_level_deletions {
+            0x01u8
+        } else {
+            0x00u8
+        };
+        buffer.write_all(&[has_partition_deletions])?;
 
         // 18. firstKey, lastKey (ByteBufferUtil.writeWithVIntLength:
         // unsigned-VInt length then the raw key bytes). Empty when no partitions.
@@ -997,6 +1035,49 @@ impl StatisticsWriter {
             for (point, value) in histogram.entries() {
                 buffer.write_all(&point.to_be_bytes())?; // f64 BE point
                 buffer.write_all(&value.to_be_bytes())?; // i64 BE value
+            }
+        }
+        Ok(())
+    }
+
+    /// Serialise a `TombstoneHistogram` using Cassandra's modern (`oa`/`da`)
+    /// `HistogramSerializer` format.
+    ///
+    /// Identical framing to the legacy serializer (`i32 maxBinSize`, `i32 size`)
+    /// but each bin entry is `i64 BE point` + `i32 BE value` (12 bytes), where
+    /// the legacy serializer used `f64 point` + `i64 value` (16 bytes). The
+    /// version split: `StatsMetadata.StatsMetadataSerializer` resolves
+    /// `TombstoneHistogram.getSerializer(version)` to the modern
+    /// `HistogramSerializer` for `oa`+ (incl. `BtiFormat.BtiVersion` `da`) and
+    /// the `LegacyHistogramSerializer` for older versions.
+    ///
+    /// Authority: repo `docs/sstables-definitive-guide/statistics-db-writer-spec.md`
+    /// (TombstoneHistogram legacy vs modern note) and
+    /// cassandra-5.0.0 `TombstoneHistogram.java` (`HistogramSerializer` ->
+    /// `long` point + `int` value).
+    ///
+    /// ```text
+    /// i32 BE  maxBinSize  — capacity: 100 when non-empty, 0 when empty
+    /// i32 BE  size        — actual number of populated bins
+    /// for each of the `size` bins (ascending point order):
+    ///   i64 BE  point  — local-deletion-time bucket centre (as long)
+    ///   i32 BE  value  — tombstone count for this bucket
+    /// ```
+    fn write_tombstone_histogram_modern(
+        &self,
+        buffer: &mut Vec<u8>,
+        histogram: &TombstoneHistogram,
+    ) -> Result<()> {
+        if histogram.is_empty() {
+            buffer.write_all(&0i32.to_be_bytes())?; // maxBinSize
+            buffer.write_all(&0i32.to_be_bytes())?; // size
+        } else {
+            buffer.write_all(&TOMBSTONE_HISTOGRAM_MAX_BIN_SIZE.to_be_bytes())?; // maxBinSize
+            buffer.write_all(&histogram.size().to_be_bytes())?; // size
+            for (point, value) in histogram.entries() {
+                // Modern: long point (truncate the double bucket centre) + int value.
+                buffer.write_all(&(point as i64).to_be_bytes())?; // i64 BE point
+                buffer.write_all(&(value as i32).to_be_bytes())?; // i32 BE value
             }
         }
         Ok(())
@@ -1341,6 +1422,68 @@ mod tests {
         let row_count_bytes = &data[row_count_offset..row_count_offset + 8];
         let row_count = u64::from_be_bytes(row_count_bytes.try_into().unwrap());
         assert_eq!(row_count, 100);
+    }
+
+    /// The `da` STATS body must serialise `hasPartitionLevelDeletions` as a
+    /// single `writeBoolean` byte: `0x01` when the SSTable contains a
+    /// partition-level deletion, `0x00` otherwise. Authority: cassandra-5.0.0
+    /// `StatsMetadata.StatsMetadataSerializer.serialize` line 495
+    /// (`out.writeBoolean(component.hasPartitionLevelDeletions)`), gated by
+    /// `version.hasPartitionLevelDeletionsPresenceMarker()` which is `true` for
+    /// `BtiFormat.BtiVersion`.
+    #[test]
+    fn test_da_stats_has_partition_level_deletions_marker_byte() {
+        let writer = StatisticsWriter::new_bti(PathBuf::from("da-1-bti-Statistics.db"));
+
+        // Identical metadata except for the partition-level-deletion flag, so
+        // the only differing byte is the hasPartitionLevelDeletions marker.
+        let mut base = StatisticsMetadata::new();
+        base.min_timestamp = 1_000_000;
+        base.max_timestamp = 2_000_000;
+        base.min_local_deletion_time = 0;
+        base.max_local_deletion_time = 0;
+        base.partition_count = 1;
+        base.row_count = 1;
+        base.column_count = 1;
+        base.finalize();
+
+        let mut with_del = base.clone();
+        with_del.mark_partition_level_deletion();
+        assert!(with_del.has_partition_level_deletions);
+        assert!(!base.has_partition_level_deletions);
+
+        let no_del_bytes = writer.build_stats_component_da(&base, None).unwrap();
+        let del_bytes = writer.build_stats_component_da(&with_del, None).unwrap();
+
+        // Same length: only the one marker byte changes value.
+        assert_eq!(
+            no_del_bytes.len(),
+            del_bytes.len(),
+            "the flag must not change the serialized length"
+        );
+
+        // Exactly one byte differs, and it flips 0x00 <-> 0x01.
+        let diffs: Vec<usize> = no_del_bytes
+            .iter()
+            .zip(del_bytes.iter())
+            .enumerate()
+            .filter(|(_, (a, b))| a != b)
+            .map(|(i, _)| i)
+            .collect();
+        assert_eq!(
+            diffs.len(),
+            1,
+            "only the hasPartitionLevelDeletions marker byte should differ"
+        );
+        let marker = diffs[0];
+        assert_eq!(
+            no_del_bytes[marker], 0x00,
+            "no partition deletion => marker byte 0x00"
+        );
+        assert_eq!(
+            del_bytes[marker], 0x01,
+            "partition deletion present => marker byte 0x01"
+        );
     }
 
     #[test]

--- a/cqlite-core/src/storage/sstable/writer/stats_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/stats_writer.rs
@@ -196,6 +196,14 @@ pub struct StatisticsMetadata {
     /// tombstone compaction.  Uses the same streaming builder algorithm as
     /// Cassandra's `StreamingTombstoneHistogramBuilder` (max 100 bins).
     pub tombstone_histogram: TombstoneHistogram,
+    /// First (lowest-token) decorated partition-key bytes written to this
+    /// SSTable, or `None` if no partition has been written. Serialised as the
+    /// `da`-format `StatsMetadata.firstKey` (BtiFormat `hasKeyRange`); tracked in
+    /// token order by `SSTableWriter::write_partition`.
+    pub first_key: Option<Vec<u8>>,
+    /// Last (highest-token) decorated partition-key bytes written to this
+    /// SSTable. Serialised as the `da`-format `StatsMetadata.lastKey`.
+    pub last_key: Option<Vec<u8>>,
 }
 
 impl Default for StatisticsMetadata {
@@ -212,6 +220,8 @@ impl Default for StatisticsMetadata {
             column_count: 0,
             total_rows_size: 0,
             tombstone_histogram: TombstoneHistogram::new(),
+            first_key: None,
+            last_key: None,
         }
     }
 }
@@ -249,6 +259,20 @@ impl StatisticsMetadata {
     /// Increment partition count
     pub fn increment_partition_count(&mut self) {
         self.partition_count += 1;
+    }
+
+    /// Record a partition key in the SSTable key range.
+    ///
+    /// Partitions are written in ascending token order (enforced by
+    /// `SSTableWriter::write_partition`), so the FIRST key seen is the lowest and
+    /// the LAST is the highest. Used to populate the `da`-format
+    /// `StatsMetadata.firstKey`/`lastKey` (`hasKeyRange`). The clone is bounded by
+    /// the partition-key size (typically tens of bytes), not the partition data.
+    pub fn update_key_range(&mut self, key: &[u8]) {
+        if self.first_key.is_none() {
+            self.first_key = Some(key.to_vec());
+        }
+        self.last_key = Some(key.to_vec());
     }
 
     /// Increment row count
@@ -417,15 +441,36 @@ fn split_cql_type_args(s: &str) -> Vec<&str> {
 pub struct StatisticsWriter {
     /// Path to the Statistics.db file to write
     path: PathBuf,
+    /// Emit the Cassandra-canonical `da` (BtiFormat) `StatsMetadata` layout
+    /// instead of the legacy `nb` layout.
+    ///
+    /// The `da` STATS component differs from `nb` in the fields gated by the
+    /// BtiFormat version flags (all true for `da` except `hasLegacyMinMax`):
+    /// `hasUIntDeletionTime`, `hasImprovedMinMax` (clusteringTypes + a covered
+    /// `Slice` instead of legacy min/max value lists), `hasIsTransient`,
+    /// `hasOriginatingHostId`, `hasPartitionLevelDeletionsPresenceMarker`,
+    /// `hasKeyRange` (first/last key) and `hasTokenSpaceCoverage`. Cassandra's
+    /// `sstabledump`/`sstablemetadata` deserialize a `da`-descriptor
+    /// Statistics.db with this layout and reject the `nb` layout (a
+    /// `Slice.<init>` assertion fires while reading `coveredClustering`).
+    /// Authority: cassandra-5.0.0 `StatsMetadata.StatsMetadataSerializer` +
+    /// `BtiFormat.BtiVersion` version flags.
+    bti: bool,
 }
 
 impl StatisticsWriter {
-    /// Create a new Statistics.db writer
+    /// Create a new Statistics.db writer for the legacy `nb`/`oa` BIG layout.
     ///
     /// # Arguments
     /// * `path` - Path where Statistics.db will be written
     pub fn new(path: PathBuf) -> Self {
-        Self { path }
+        Self { path, bti: false }
+    }
+
+    /// Create a new Statistics.db writer that emits the Cassandra-canonical `da`
+    /// (BtiFormat) `StatsMetadata` layout.
+    pub fn new_bti(path: PathBuf) -> Self {
+        Self { path, bti: true }
     }
 
     /// Write Statistics.db file with the given metadata
@@ -452,7 +497,15 @@ impl StatisticsWriter {
         // Build component data
         let validation_data = self.build_validation_component()?;
         let compaction_data = self.build_compaction_component()?;
-        let stats_data = self.build_stats_component(&meta)?;
+        // The STATS body is version-gated: BTI (`da`) emits the BtiFormat
+        // `StatsMetadata` layout (covered-clustering Slice, uint deletion times,
+        // key range, token-space coverage); BIG (`nb`/`oa`) emits the legacy
+        // layout. `schema` is needed for the `da` clustering-type list.
+        let stats_data = if self.bti {
+            self.build_stats_component_da(&meta, schema)?
+        } else {
+            self.build_stats_component(&meta)?
+        };
         // Use pre-finalize metadata for the SerializationHeader EncodingStats.
         // The baselines in the header MUST match those used by the DataWriter for
         // delta encoding. The DataWriter uses the raw (pre-finalize) metadata values.
@@ -738,6 +791,157 @@ impl StatisticsWriter {
 
         // 25. byte originatingHostId (0 = null)
         buffer.write_all(&[0x00])?;
+
+        Ok(buffer)
+    }
+
+    /// Build the STATS component for the Cassandra-canonical `da` (BtiFormat)
+    /// layout.
+    ///
+    /// Field order and gating follow cassandra-5.0.0
+    /// `StatsMetadata.StatsMetadataSerializer.serialize` evaluated for
+    /// `BtiFormat.BtiVersion` (all version flags `true` except `hasLegacyMinMax`,
+    /// which is `false`):
+    ///
+    /// 1.  estimatedPartitionSize (EstimatedHistogram)
+    /// 2.  estimatedCellPerPartitionCount (EstimatedHistogram)
+    /// 3.  commitLogUpperBound (CommitLogPosition)
+    /// 4.  minTimestamp, maxTimestamp (long)
+    /// 5.  min/maxLocalDeletionTime as **unsigned int** (`hasUIntDeletionTime`);
+    ///     `NO_DELETION_TIME` (Long.MAX) maps to `0xFFFFFFFF`.
+    /// 6.  minTTL, maxTTL (int)
+    /// 7.  compressionRatio (double)
+    /// 8.  estimatedTombstoneDropTime (TombstoneHistogram)
+    /// 9.  sstableLevel (int), repairedAt (long)
+    /// 10. improvedMinMax (`!hasLegacyMinMax && hasImprovedMinMax`):
+    ///     clusteringTypes list + coveredClustering `Slice`. We emit
+    ///     `Slice.ALL` (BOTTOM..TOP) — a valid, conservative covering slice that
+    ///     Cassandra accepts and that matches the `Covered clusterings: [, ]`
+    ///     shown by `sstablemetadata` on the real `da` fixtures.
+    /// 11. hasLegacyCounterShards (bool)
+    /// 12. totalColumnsSet, totalRows (long)
+    /// 13. commitLogLowerBound (CommitLogPosition), commitLogIntervals (IntervalSet)
+    /// 14. pendingRepair (byte 0 = null)
+    /// 15. isTransient (bool)
+    /// 16. originatingHostId (byte 0 = null)
+    /// 17. hasPartitionLevelDeletions (bool)
+    /// 18. firstKey, lastKey (vint-length ByteBuffer) — `hasKeyRange`
+    /// 19. tokenSpaceCoverage (double) — `hasTokenSpaceCoverage`
+    fn build_stats_component_da(
+        &self,
+        metadata: &StatisticsMetadata,
+        schema: Option<&TableSchema>,
+    ) -> Result<Vec<u8>> {
+        let mut buffer = Vec::new();
+
+        // 1-2. EstimatedHistogram estimatedPartitionSize / estimatedCellPerPartitionCount
+        self.write_estimated_histogram(&mut buffer)?;
+        self.write_estimated_histogram(&mut buffer)?;
+
+        // 3. CommitLogPosition commitLogUpperBound (NONE)
+        buffer.write_all(&(-1i64).to_be_bytes())?; // segmentId
+        buffer.write_all(&0i32.to_be_bytes())?; // position
+
+        // 4. minTimestamp, maxTimestamp
+        buffer.write_all(&metadata.min_timestamp.to_be_bytes())?;
+        buffer.write_all(&metadata.max_timestamp.to_be_bytes())?;
+
+        // 5. min/maxLocalDeletionTime — unsigned int (hasUIntDeletionTime).
+        // No tombstones (sentinel) → NO_DELETION_TIME_UNSIGNED_INTEGER = 0xFFFFFFFF;
+        // otherwise the low 32 bits of the (seconds-since-epoch) deletion time
+        // (Cassandra `CassandraUInt.fromLong` == `(int) value`).
+        let min_ldt_uint: u32 = if metadata.min_local_deletion_time == 0 {
+            0xFFFF_FFFF
+        } else {
+            metadata.min_local_deletion_time as u32
+        };
+        let max_ldt_uint: u32 = if metadata.max_local_deletion_time == 0 {
+            0xFFFF_FFFF
+        } else {
+            metadata.max_local_deletion_time as u32
+        };
+        buffer.write_all(&min_ldt_uint.to_be_bytes())?;
+        buffer.write_all(&max_ldt_uint.to_be_bytes())?;
+
+        // 6. minTTL, maxTTL
+        buffer.write_all(&metadata.min_ttl.to_be_bytes())?;
+        buffer.write_all(&metadata.max_ttl.to_be_bytes())?;
+
+        // 7. compressionRatio (-1.0 = unknown)
+        buffer.write_all(&(-1.0f64).to_be_bytes())?;
+
+        // 8. TombstoneHistogram estimatedTombstoneDropTime
+        self.write_tombstone_histogram(&mut buffer, &metadata.tombstone_histogram)?;
+
+        // 9. sstableLevel, repairedAt
+        buffer.write_all(&0i32.to_be_bytes())?;
+        buffer.write_all(&0i64.to_be_bytes())?;
+
+        // 10. improvedMinMax: clusteringTypes list + coveredClustering Slice.
+        //
+        // AbstractTypeSerializer.serializeList: unsigned-VInt count, then each
+        // type as an unsigned-VInt-length-prefixed UTF-8 marshal-class string —
+        // the exact encoding used for the SERIALIZATION_HEADER clusteringTypes.
+        let clustering_types: Vec<String> = schema
+            .map(|s| {
+                s.clustering_keys
+                    .iter()
+                    .map(|ck| cql_type_to_marshal_type(&ck.data_type))
+                    .collect()
+            })
+            .unwrap_or_default();
+        buffer.write_all(&encode_vuint(clustering_types.len() as u64))?;
+        for ty in &clustering_types {
+            buffer.write_all(&encode_vuint(ty.len() as u64))?;
+            buffer.write_all(ty.as_bytes())?;
+        }
+        // coveredClustering = Slice.ALL = (BOTTOM, TOP). A ClusteringBound
+        // serialises as `[byte kind ordinal][short size][values...]`; BOTTOM and
+        // TOP are empty bounds (size 0). Kind ordinals (ClusteringPrefix.Kind):
+        // INCL_START_BOUND = 1 (BOTTOM), INCL_END_BOUND = 6 (TOP).
+        const KIND_INCL_START_BOUND: u8 = 1;
+        const KIND_INCL_END_BOUND: u8 = 6;
+        buffer.write_all(&[KIND_INCL_START_BOUND])?;
+        buffer.write_all(&0u16.to_be_bytes())?; // start size = 0
+        buffer.write_all(&[KIND_INCL_END_BOUND])?;
+        buffer.write_all(&0u16.to_be_bytes())?; // end size = 0
+
+        // 11. hasLegacyCounterShards
+        buffer.write_all(&[0x00])?;
+
+        // 12. totalColumnsSet, totalRows
+        buffer.write_all(&metadata.column_count.to_be_bytes())?;
+        buffer.write_all(&metadata.row_count.to_be_bytes())?;
+
+        // 13. commitLogLowerBound (NONE) + commitLogIntervals (empty IntervalSet)
+        buffer.write_all(&(-1i64).to_be_bytes())?; // segmentId
+        buffer.write_all(&0i32.to_be_bytes())?; // position
+        buffer.write_all(&0i32.to_be_bytes())?; // interval set size = 0
+
+        // 14. pendingRepair (null)
+        buffer.write_all(&[0x00])?;
+
+        // 15. isTransient
+        buffer.write_all(&[0x00])?;
+
+        // 16. originatingHostId (null)
+        buffer.write_all(&[0x00])?;
+
+        // 17. hasPartitionLevelDeletions
+        buffer.write_all(&[0x00])?;
+
+        // 18. firstKey, lastKey (ByteBufferUtil.writeWithVIntLength:
+        // unsigned-VInt length then the raw key bytes). Empty when no partitions.
+        let first = metadata.first_key.as_deref().unwrap_or(&[]);
+        let last = metadata.last_key.as_deref().unwrap_or(&[]);
+        buffer.write_all(&encode_vuint(first.len() as u64))?;
+        buffer.write_all(first)?;
+        buffer.write_all(&encode_vuint(last.len() as u64))?;
+        buffer.write_all(last)?;
+
+        // 19. tokenSpaceCoverage (double). Cassandra writes NaN when not computed
+        // (sstablemetadata renders this as "Local token space coverage: NaN").
+        buffer.write_all(&f64::NAN.to_be_bytes())?;
 
         Ok(buffer)
     }

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -1524,16 +1524,23 @@ impl WriteEngine {
         // Build list of (src, dst) renames. TOC.txt goes last (publication barrier).
         let mut renames: Vec<(PathBuf, PathBuf)> = Vec::new();
 
-        // Non-TOC components first
-        for src in &[
-            &tmp_info.data_path,
-            &tmp_info.index_path,
-            &tmp_info.filter_path,
-            &tmp_info.summary_path,
-            &tmp_info.stats_path,
-            &tmp_info.digest_path,
-        ] {
+        // Non-TOC components first. Index.db/Summary.db are BIG-only (BTI writers
+        // report them as None — issue #908); only rename them when present.
+        let mut non_toc: Vec<&PathBuf> = vec![&tmp_info.data_path];
+        if let Some(ref p) = tmp_info.index_path {
+            non_toc.push(p);
+        }
+        non_toc.push(&tmp_info.filter_path);
+        if let Some(ref p) = tmp_info.summary_path {
+            non_toc.push(p);
+        }
+        non_toc.push(&tmp_info.stats_path);
+        non_toc.push(&tmp_info.digest_path);
+        for src in non_toc {
             renames.push(make_rename(src)?);
+        }
+        if let Some(ref p) = tmp_info.partitions_path {
+            renames.push(make_rename(p)?);
         }
         if let Some(ref ci_path) = tmp_info.compression_info_path {
             renames.push(make_rename(ci_path)?);
@@ -1619,21 +1626,27 @@ impl WriteEngine {
 
         // Compute total bytes written across ALL output SSTable components (not just Data.db).
         // We stat the final paths (post-rename) so we measure what was actually persisted.
-        let total_bytes_written: u64 = [
-            &tmp_info.data_path,
-            &tmp_info.index_path,
-            &tmp_info.filter_path,
-            &tmp_info.summary_path,
-            &tmp_info.stats_path,
-            &tmp_info.digest_path,
-        ]
-        .iter()
-        .map(|p| {
-            let filename = p.file_name().unwrap_or_default();
-            let final_path = sstable_dir.join(filename);
-            std::fs::metadata(&final_path).map(|m| m.len()).unwrap_or(0)
-        })
-        .sum::<u64>()
+        let mut byte_paths: Vec<&PathBuf> = vec![&tmp_info.data_path];
+        if let Some(ref p) = tmp_info.index_path {
+            byte_paths.push(p);
+        }
+        byte_paths.push(&tmp_info.filter_path);
+        if let Some(ref p) = tmp_info.summary_path {
+            byte_paths.push(p);
+        }
+        byte_paths.push(&tmp_info.stats_path);
+        byte_paths.push(&tmp_info.digest_path);
+        if let Some(ref p) = tmp_info.partitions_path {
+            byte_paths.push(p);
+        }
+        let total_bytes_written: u64 = byte_paths
+            .iter()
+            .map(|p| {
+                let filename = p.file_name().unwrap_or_default();
+                let final_path = sstable_dir.join(filename);
+                std::fs::metadata(&final_path).map(|m| m.len()).unwrap_or(0)
+            })
+            .sum::<u64>()
             + tmp_info
                 .compression_info_path
                 .as_ref()

--- a/cqlite-core/src/util/cassandra_murmur3.rs
+++ b/cqlite-core/src/util/cassandra_murmur3.rs
@@ -116,6 +116,33 @@ pub fn cassandra_murmur3_token(data: &[u8]) -> i64 {
     normalize(h1)
 }
 
+/// Compute `DecoratedKey.filterHashLowerBits()` for a raw partition key, matching
+/// Cassandra 5.0's `org.apache.cassandra.db.DecoratedKey`.
+///
+/// Cassandra computes the full 128-bit Murmur3 hash of the partition-key bytes and
+/// uses the two 64-bit words distinctly:
+/// - `hash[0]` (`h1`, after `normalize`) becomes the `Murmur3Partitioner` token.
+/// - `hash[1]` (`h2`, **un-normalized**) is returned by `filterHashLowerBits()` and
+///   is the value whose **low 8 bits** the BTI `Partitions.db` partition index writes
+///   as each leaf's "hash byte" (fast mismatch pre-filter).
+///
+/// Reference: `DecoratedKey.filterHashLowerBits()` returns `hash[1]`
+/// (`org.apache.cassandra.db.DecoratedKey`, Cassandra 5.0.8); the BTI partition index
+/// stores `(byte) decoratedKey.filterHashLowerBits()`
+/// (`org.apache.cassandra.io.sstable.format.bti.PartitionIndex`).
+///
+/// Verified against the real `da-2-bti-Partitions.db` fixture
+/// (`test-data/datasets/sstables/test_da/simple_table-*`): the three UUID partitions
+/// store hash bytes `0x24`, `0x22`, `0xf4`, which are exactly the low bytes of `h2`
+/// for those keys.
+///
+/// Note this is `h2`, NOT the token's `h1`; the placeholder it replaces incorrectly
+/// derived the byte from the byte-comparable `h1` token.
+pub fn cassandra_partition_filter_hash_lower_bits(data: &[u8]) -> i64 {
+    let (_, h2) = cassandra_murmur3_x64_128(data);
+    h2
+}
+
 /// Cassandra's normalize: `Long.MIN_VALUE` maps to `Long.MAX_VALUE`.
 fn normalize(v: i64) -> i64 {
     if v == i64::MIN {

--- a/cqlite-core/tests/compact_command.rs
+++ b/cqlite-core/tests/compact_command.rs
@@ -180,9 +180,9 @@ fn compact_sstables_merges_explicit_inputs_with_lww() {
     let out = &report.output;
     for (label, path) in [
         ("Data.db", &out.data_path),
-        ("Index.db", &out.index_path),
+        ("Index.db", out.index_path.as_ref().unwrap()),
         ("Filter.db", &out.filter_path),
-        ("Summary.db", &out.summary_path),
+        ("Summary.db", out.summary_path.as_ref().unwrap()),
         ("Statistics.db", &out.stats_path),
         ("Digest.crc32", &out.digest_path),
         ("TOC.txt", &out.toc_path),

--- a/cqlite-core/tests/issue_766_bti_partitions_writer.rs
+++ b/cqlite-core/tests/issue_766_bti_partitions_writer.rs
@@ -144,11 +144,31 @@ async fn bti_format_partitions_db_roundtrips_via_reader() {
         .expect("BTI format must emit Partitions.db");
     assert!(partitions_path.exists());
 
-    // TOC must list Partitions.db for BTI.
+    // Issue #908: canonical BTI naming + no BIG index components.
+    assert_eq!(
+        partitions_path.file_name().unwrap().to_str().unwrap(),
+        "da-1-bti-Partitions.db",
+        "BTI Partitions.db must use the da/bti descriptor"
+    );
+    assert!(
+        info.index_path.is_none(),
+        "BTI must not emit Index.db (#908)"
+    );
+    assert!(
+        info.summary_path.is_none(),
+        "BTI must not emit Summary.db (#908)"
+    );
+
+    // TOC must list Partitions.db for BTI but not Index/Summary.
     let toc = std::fs::read_to_string(&info.toc_path).unwrap();
     assert!(
         toc.contains("Partitions.db"),
         "BTI TOC must list Partitions.db"
+    );
+    assert!(!toc.contains("Index.db"), "BTI TOC must not list Index.db");
+    assert!(
+        !toc.contains("Summary.db"),
+        "BTI TOC must not list Summary.db"
     );
 
     // Read every partition back through the BTI reader and confirm a hit.

--- a/cqlite-core/tests/issue_766_bti_partitions_writer.rs
+++ b/cqlite-core/tests/issue_766_bti_partitions_writer.rs
@@ -252,12 +252,18 @@ async fn bti_resolved_offsets_are_distinct_and_first_is_zero() {
     );
 }
 
-/// Finding 2 (issue #766 review): an empty BTI-format SSTable must NOT emit a
-/// Partitions.db (a zero-byte file is unreadable — the BTI reader rejects files
-/// smaller than the 8-byte root footer). Both the file and the TOC entry are
-/// omitted for an empty SSTable.
+/// Finding 2 (roborev #908, resolved in #910): an empty BTI-format SSTable
+/// cannot be published.
+///
+/// The earlier #766 behavior OMITTED `Partitions.db` for an empty SSTable, but
+/// that still produced a `da-*-bti-*` artifact with no `Partitions.db` — which
+/// the BTI reader requires for every `da` SSTable (it needs the 8-byte trie root
+/// footer), making the artifact unreadable. A zero-partition trie has no valid
+/// canonical form. Rather than emit an unreadable SSTable we now REFUSE to
+/// finish an empty BTI write with a clear error. (Cassandra never flushes an
+/// empty BTI SSTable; every real `da` fixture has >= 1 partition.)
 #[tokio::test]
-async fn empty_bti_sstable_omits_partitions_db_and_toc_entry() {
+async fn empty_bti_sstable_is_refused() {
     let dir = TempDir::new().unwrap();
     let schema = int_pk_schema();
 
@@ -267,30 +273,15 @@ async fn empty_bti_sstable_omits_partitions_db_and_toc_entry() {
             .unwrap();
     assert_eq!(writer.format(), SSTableFormat::Bti);
 
-    let info = writer.finish().await.unwrap();
-
-    // No Partitions.db path is reported for an empty SSTable.
+    let result = writer.finish().await;
     assert!(
-        info.partitions_path.is_none(),
-        "empty BTI SSTable must not report a Partitions.db path"
+        result.is_err(),
+        "an empty BTI SSTable must be refused (no readable Partitions.db form)"
     );
-
-    // No Partitions.db file exists on disk under the table dir.
-    let table_dir = dir.path().join("test_ks").join("t");
-    let has_partitions = std::fs::read_dir(&table_dir)
-        .unwrap()
-        .flatten()
-        .any(|e| e.file_name().to_string_lossy().contains("Partitions.db"));
+    let msg = format!("{}", result.err().unwrap());
     assert!(
-        !has_partitions,
-        "no Partitions.db file expected for an empty BTI SSTable"
-    );
-
-    // TOC must NOT list Partitions.db for the empty SSTable.
-    let toc = std::fs::read_to_string(&info.toc_path).unwrap();
-    assert!(
-        !toc.contains("Partitions.db"),
-        "empty BTI SSTable TOC must not list Partitions.db"
+        msg.contains("empty BTI SSTable"),
+        "error must explain the empty-BTI refusal; got: {msg}"
     );
 }
 

--- a/cqlite-core/tests/issue_819_differential_compaction.rs
+++ b/cqlite-core/tests/issue_819_differential_compaction.rs
@@ -1112,6 +1112,7 @@ fn ref_sstable_info(data_path: &Path) -> cqlite_core::storage::sstable::writer::
         stats_path: comp("Statistics.db"),
         compression_info_path: opt("CompressionInfo.db"),
         partitions_path: opt("Partitions.db"),
+        rows_path: opt("Rows.db"),
         toc_path: comp("TOC.txt"),
         digest_path: comp("Digest.crc32"),
         partition_count: 0,

--- a/cqlite-core/tests/issue_819_differential_compaction.rs
+++ b/cqlite-core/tests/issue_819_differential_compaction.rs
@@ -774,9 +774,9 @@ fn load_path_report(
     // ── Component completeness (the ones the writer publishes) ──
     let mut required: Vec<(&str, &Path)> = vec![
         ("Data.db", &output.data_path),
-        ("Index.db", &output.index_path),
+        ("Index.db", output.index_path.as_ref().unwrap()),
         ("Filter.db", &output.filter_path),
-        ("Summary.db", &output.summary_path),
+        ("Summary.db", output.summary_path.as_ref().unwrap()),
         ("Statistics.db", &output.stats_path),
         ("Digest.crc32", &output.digest_path),
         ("TOC.txt", &output.toc_path),
@@ -1034,7 +1034,11 @@ fn component_byte_diffs(
     let pairs: [(&'static str, &Path, &Path); 3] = [
         ("Data.db", &left.data_path, &right.data_path),
         ("Statistics.db", &left.stats_path, &right.stats_path),
-        ("Index.db", &left.index_path, &right.index_path),
+        (
+            "Index.db",
+            left.index_path.as_ref().unwrap(),
+            right.index_path.as_ref().unwrap(),
+        ),
     ];
     let mut out = Vec::new();
     for (component, lp, rp) in pairs {
@@ -1102,9 +1106,9 @@ fn ref_sstable_info(data_path: &Path) -> cqlite_core::storage::sstable::writer::
     let data_size = std::fs::metadata(data_path).map(|m| m.len()).unwrap_or(0);
     cqlite_core::storage::sstable::writer::SSTableInfo {
         data_path: data_path.to_path_buf(),
-        index_path: comp("Index.db"),
+        index_path: Some(comp("Index.db")),
         filter_path: comp("Filter.db"),
-        summary_path: comp("Summary.db"),
+        summary_path: Some(comp("Summary.db")),
         stats_path: comp("Statistics.db"),
         compression_info_path: opt("CompressionInfo.db"),
         partitions_path: opt("Partitions.db"),

--- a/cqlite-core/tests/issue_908_bti_canonical_write.rs
+++ b/cqlite-core/tests/issue_908_bti_canonical_write.rs
@@ -471,6 +471,244 @@ async fn bti_empty_sstable_is_refused() {
     );
 }
 
+/// Schema: wide(pk int, ck int, payload text, PRIMARY KEY (pk, ck)) with the
+/// clustering column's order set by `order` (ASC or DESC). Used by the reversed
+/// byte-comparable separator regression below.
+fn wide_schema_with_order(order: ClusteringOrder) -> TableSchema {
+    let mut s = wide_schema();
+    s.clustering_keys[0].order = order;
+    s
+}
+
+/// Schema: wide2(pk int, ck1 int ASC, ck2 int DESC, payload text). Exercises a
+/// MIXED-order clustering key (the 0x40 framing byte stays un-inverted while the
+/// DESC component's bytes are complemented).
+fn wide_mixed_schema() -> TableSchema {
+    let mut s = wide_schema();
+    s.table = "wide2".to_string();
+    s.clustering_keys = vec![
+        ClusteringColumn {
+            name: "ck1".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+            order: ClusteringOrder::Asc,
+        },
+        ClusteringColumn {
+            name: "ck2".to_string(),
+            data_type: "int".to_string(),
+            position: 1,
+            order: ClusteringOrder::Desc,
+        },
+    ];
+    s.columns = vec![
+        Column {
+            name: "pk".to_string(),
+            data_type: "int".to_string(),
+            nullable: false,
+            default: None,
+            is_static: false,
+        },
+        Column {
+            name: "ck1".to_string(),
+            data_type: "int".to_string(),
+            nullable: false,
+            default: None,
+            is_static: false,
+        },
+        Column {
+            name: "ck2".to_string(),
+            data_type: "int".to_string(),
+            nullable: false,
+            default: None,
+            is_static: false,
+        },
+        Column {
+            name: "payload".to_string(),
+            data_type: "text".to_string(),
+            nullable: true,
+            default: None,
+            is_static: false,
+        },
+    ];
+    s
+}
+
+/// One wide-partition row carrying a single-component clustering `ck` against an
+/// explicit `table`/schema (mirrors `wide_row` but lets the table name vary).
+fn wide_row_for(table: &str, pk: i32, ck: i32, ts: i64) -> Mutation {
+    let payload = "x".repeat(2048);
+    Mutation::new(
+        TableId::new("test_ks", table),
+        PartitionKey::single("pk", Value::Integer(pk)),
+        Some(
+            cqlite_core::storage::write_engine::mutation::ClusteringKey::single(
+                "ck",
+                Value::Integer(ck),
+            ),
+        ),
+        vec![CellOperation::Write {
+            column: "payload".to_string(),
+            value: Value::Text(payload),
+        }],
+        ts,
+        None,
+    )
+}
+
+/// Regression for the roborev MEDIUM finding: a WIDE partition on a `CLUSTERING
+/// ORDER BY (ck DESC)` table must produce ASCENDING OSS50 separator bytes (via
+/// the reversed byte-comparable transform) so the Rows.db row-index trie is
+/// emitted and the partition resolves through a positive `RowsOffset` — it must
+/// NOT silently fall back to a direct `DataOffset`.
+#[tokio::test]
+async fn bti_wide_desc_partition_resolves_through_rows_db() {
+    let dir = TempDir::new().unwrap();
+    let schema = wide_schema_with_order(ClusteringOrder::Desc);
+    let mut writer =
+        SSTableWriter::with_format(dir.path().to_path_buf(), 1, &schema, 16, SSTableFormat::Bti)
+            .unwrap();
+
+    // Single wide partition pk=1 with 200 rows × ~2 KiB => >= 2 column-index
+    // blocks. The writer sorts rows into clustering (DESC) order internally.
+    let cks: Vec<i32> = (0..200).collect();
+    let muts: Vec<Mutation> = cks
+        .iter()
+        .map(|ck| wide_row_for("wide", 1, *ck, 1_000_000 + *ck as i64))
+        .collect();
+    let key = muts[0].decorated_key(&schema).unwrap();
+    writer.write_partition(key, muts).unwrap();
+
+    let info = writer.finish().await.unwrap();
+
+    let rows_db = std::fs::read(info.rows_path.clone().expect("Rows.db path")).unwrap();
+    assert!(
+        !rows_db.is_empty(),
+        "a wide DESC partition must produce a non-empty Rows.db (no DataOffset fallback)"
+    );
+
+    let partitions_db = std::fs::read(info.partitions_path.clone().unwrap()).unwrap();
+    let raw_pk1 = 1i32.to_be_bytes().to_vec();
+    let mut cur = Cursor::new(partitions_db);
+    let loc = lookup_raw_key_in_bti_partitions_db(&mut cur, &raw_pk1)
+        .unwrap()
+        .expect("pk=1 found");
+    let rows_offset = match loc {
+        BtiPartitionLocation::RowsOffset(o) => o as usize,
+        BtiPartitionLocation::DataOffset(o) => panic!(
+            "wide DESC partition MUST resolve through RowsOffset, not DataOffset({o}) \
+             (reversed byte-comparable separators were rejected -> silent fallback)"
+        ),
+    };
+
+    let header = resolve_rows_db_entry(&rows_db, rows_offset).expect("resolve DESC entry");
+    assert!(
+        header.block_count >= 2,
+        "wide partition must span >= 2 blocks; got {}",
+        header.block_count
+    );
+    let entries =
+        iterate_rows_in_bti_trie(&rows_db, header.trie_root).expect("traverse DESC row index");
+    assert_eq!(entries.len() as u32, header.block_count);
+
+    // Separators ascending (trie requirement) AND block offsets strictly
+    // increasing (physical write order). The DESC encoding makes these agree.
+    for w in entries.windows(2) {
+        assert!(
+            w[0].0 < w[1].0,
+            "DESC separators must be strictly ascending bytes; got {:02x?} then {:02x?}",
+            w[0].0,
+            w[1].0
+        );
+        assert!(
+            w[0].1.data_offset < w[1].1.data_offset,
+            "block offsets must be strictly increasing"
+        );
+    }
+
+    // First block's first row is the LARGEST ck (DESC writes descending). For
+    // ck in 0..200, that is ck=199 => reversed byte-comparable of (sign-flip
+    // int 199) = complement(80 00 00 C7) = 7F FF FF 38.
+    let expected_first = (0x8000_0000u32 ^ 199)
+        .to_be_bytes()
+        .iter()
+        .map(|b| 0xFF ^ *b)
+        .collect::<Vec<u8>>();
+    assert_eq!(
+        entries[0].0, expected_first,
+        "first DESC separator must be reversed byte-comparable of the largest ck (199)"
+    );
+}
+
+/// Mixed ASC/DESC clustering: a wide partition on (ck1 int ASC, ck2 int DESC)
+/// must still resolve through `RowsOffset` with ascending separator bytes.
+#[tokio::test]
+async fn bti_wide_mixed_order_partition_resolves_through_rows_db() {
+    let dir = TempDir::new().unwrap();
+    let schema = wide_mixed_schema();
+    let mut writer =
+        SSTableWriter::with_format(dir.path().to_path_buf(), 1, &schema, 16, SSTableFormat::Bti)
+            .unwrap();
+
+    // Single wide partition pk=1: vary ck1 across a handful of values, ck2 across
+    // many, with ~2 KiB payloads so total >> 2 blocks.
+    let payload = "y".repeat(2048);
+    let mut muts: Vec<Mutation> = Vec::new();
+    for ck1 in 0..4i32 {
+        for ck2 in 0..60i32 {
+            muts.push(Mutation::new(
+                TableId::new("test_ks", "wide2"),
+                PartitionKey::single("pk", Value::Integer(1)),
+                Some(
+                    cqlite_core::storage::write_engine::mutation::ClusteringKey::new(vec![
+                        ("ck1".to_string(), Value::Integer(ck1)),
+                        ("ck2".to_string(), Value::Integer(ck2)),
+                    ]),
+                ),
+                vec![CellOperation::Write {
+                    column: "payload".to_string(),
+                    value: Value::Text(payload.clone()),
+                }],
+                1_000_000,
+                None,
+            ));
+        }
+    }
+    let key = muts[0].decorated_key(&schema).unwrap();
+    writer.write_partition(key, muts).unwrap();
+
+    let info = writer.finish().await.unwrap();
+    let rows_db = std::fs::read(info.rows_path.clone().expect("Rows.db path")).unwrap();
+    assert!(
+        !rows_db.is_empty(),
+        "wide mixed-order partition must produce a non-empty Rows.db"
+    );
+
+    let partitions_db = std::fs::read(info.partitions_path.clone().unwrap()).unwrap();
+    let raw_pk1 = 1i32.to_be_bytes().to_vec();
+    let mut cur = Cursor::new(partitions_db);
+    let loc = lookup_raw_key_in_bti_partitions_db(&mut cur, &raw_pk1)
+        .unwrap()
+        .expect("pk=1 found");
+    let rows_offset = match loc {
+        BtiPartitionLocation::RowsOffset(o) => o as usize,
+        BtiPartitionLocation::DataOffset(o) => {
+            panic!(
+                "mixed-order wide partition MUST resolve through RowsOffset, got DataOffset({o})"
+            )
+        }
+    };
+    let header = resolve_rows_db_entry(&rows_db, rows_offset).expect("resolve mixed entry");
+    assert!(header.block_count >= 2);
+    let entries =
+        iterate_rows_in_bti_trie(&rows_db, header.trie_root).expect("traverse mixed row index");
+    for w in entries.windows(2) {
+        assert!(
+            w[0].0 < w[1].0,
+            "mixed-order separators must be strictly ascending bytes"
+        );
+    }
+}
+
 /// A narrow-only BTI SSTable still publishes (valid Partitions.db) and emits a
 /// 0-byte Rows.db listed in the TOC — exactly matching the real
 /// `simple_table`/`collection_table`/`ttl_table` `da-2-bti-Rows.db` fixtures.

--- a/cqlite-core/tests/issue_908_bti_canonical_write.rs
+++ b/cqlite-core/tests/issue_908_bti_canonical_write.rs
@@ -7,9 +7,10 @@
 //!    (`da-<gen>-bti-<Component>`), parsed back via `SsTableDescriptor`.
 //! 2. A BTI SSTable has `Data.db` + `Partitions.db` and a TOC, but **no**
 //!    `Index.db` and **no** `Summary.db`.
-//! 3. `TOC.txt` lists exactly the BTI component set (Data, Partitions, Filter,
-//!    Statistics, Digest, TOC) — no Index/Summary, no Rows yet (#910) — and
-//!    self-references TOC.txt.
+//! 3. `TOC.txt` lists exactly the BTI component set (Data, Partitions, Rows,
+//!    Filter, Statistics, Digest, TOC) — no Index/Summary — and self-references
+//!    TOC.txt. Rows.db is now emitted (#910), even when 0 bytes for a
+//!    narrow-only table (matching the real `da` fixtures).
 //! 4. The default BIG writer is unchanged (still `nb-*-big-*` with Index/Summary).
 //!
 //! All tests require the `write-support` feature.
@@ -136,12 +137,14 @@ async fn bti_components_use_da_bti_descriptor_and_omit_big_index() {
     // Required BTI components exist with the canonical names.
     assert!(names.iter().any(|n| n == "da-1-bti-Data.db"));
     assert!(names.iter().any(|n| n == "da-1-bti-Partitions.db"));
+    assert!(names.iter().any(|n| n == "da-1-bti-Rows.db"));
     assert!(names.iter().any(|n| n == "da-1-bti-Filter.db"));
     assert!(names.iter().any(|n| n == "da-1-bti-Statistics.db"));
     assert!(names.iter().any(|n| n == "da-1-bti-Digest.crc32"));
     assert!(names.iter().any(|n| n == "da-1-bti-TOC.txt"));
 
-    // No BIG-only components, and no Rows.db (deferred to #910).
+    // No BIG-only components. Rows.db IS now emitted (#910); for this narrow
+    // table it is a 0-byte component, matching the real `da` fixtures.
     assert!(
         !names.iter().any(|n| n.contains("Index.db")),
         "BTI must not emit Index.db, got {names:?}"
@@ -149,10 +152,6 @@ async fn bti_components_use_da_bti_descriptor_and_omit_big_index() {
     assert!(
         !names.iter().any(|n| n.contains("Summary.db")),
         "BTI must not emit Summary.db, got {names:?}"
-    );
-    assert!(
-        !names.iter().any(|n| n.contains("Rows.db")),
-        "Rows.db is deferred to #910, got {names:?}"
     );
 
     // SSTableInfo reflects the omission.
@@ -167,6 +166,10 @@ async fn bti_components_use_da_bti_descriptor_and_omit_big_index() {
     assert!(
         info.partitions_path.is_some(),
         "BTI SSTableInfo.partitions_path must be Some"
+    );
+    assert!(
+        info.rows_path.is_some(),
+        "BTI SSTableInfo.rows_path must be Some (#910)"
     );
     // Reported paths use the canonical descriptor.
     assert_eq!(
@@ -195,6 +198,7 @@ async fn bti_toc_lists_exact_component_set() {
     let expected: std::collections::BTreeSet<&str> = [
         "Data.db",
         "Partitions.db",
+        "Rows.db",
         "Filter.db",
         "Statistics.db",
         "Digest.crc32",
@@ -205,13 +209,14 @@ async fn bti_toc_lists_exact_component_set() {
 
     assert_eq!(
         listed, expected,
-        "BTI TOC must list exactly the canonical component set (no Index/Summary/Rows)"
+        "BTI TOC must list exactly the canonical component set (Data, Partitions, Rows, \
+         Filter, Statistics, Digest, TOC) — no Index/Summary"
     );
-    // Explicit self-reference + explicit exclusions.
+    // Explicit self-reference + explicit exclusions/inclusions.
     assert!(toc.contains("TOC.txt"), "TOC must self-reference");
     assert!(!toc.contains("Index.db"), "TOC must not list Index.db");
     assert!(!toc.contains("Summary.db"), "TOC must not list Summary.db");
-    assert!(!toc.contains("Rows.db"), "TOC must not list Rows.db (#910)");
+    assert!(toc.contains("Rows.db"), "TOC must list Rows.db (#910)");
 }
 
 /// AC#4: the default BIG writer is unchanged — `nb-*-big-*` with Index/Summary,
@@ -256,4 +261,233 @@ async fn big_default_format_unchanged() {
     assert!(toc.contains("Index.db"));
     assert!(toc.contains("Summary.db"));
     assert!(!toc.contains("Partitions.db"));
+    assert!(!toc.contains("Rows.db"), "BIG must not list Rows.db");
+    assert!(info.rows_path.is_none(), "BIG must report no Rows.db path");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #910: Rows.db within-partition row-index roundtrip + empty-table handling
+// ─────────────────────────────────────────────────────────────────────────────
+
+use cqlite_core::schema::{ClusteringColumn, ClusteringOrder};
+use cqlite_core::storage::sstable::bti::{
+    iterate_rows_in_bti_trie, lookup_raw_key_in_bti_partitions_db, resolve_rows_db_entry,
+    BtiPartitionLocation,
+};
+use std::io::Cursor;
+
+/// Schema: wide(pk int, ck int, payload text, PRIMARY KEY (pk, ck)).
+fn wide_schema() -> TableSchema {
+    TableSchema {
+        keyspace: "test_ks".to_string(),
+        table: "wide".to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "pk".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![ClusteringColumn {
+            name: "ck".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+            order: ClusteringOrder::Asc,
+        }],
+        columns: vec![
+            Column {
+                name: "pk".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "ck".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "payload".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+    }
+}
+
+/// One row of a wide partition: pk/ck ints + a ~2 KiB payload so a few hundred
+/// rows comfortably exceed two 64 KiB column-index blocks.
+fn wide_row(pk: i32, ck: i32, ts: i64) -> Mutation {
+    let payload = "x".repeat(2048);
+    Mutation::new(
+        TableId::new("test_ks", "wide"),
+        PartitionKey::single("pk", Value::Integer(pk)),
+        Some(
+            cqlite_core::storage::write_engine::mutation::ClusteringKey::single(
+                "ck",
+                Value::Integer(ck),
+            ),
+        ),
+        vec![CellOperation::Write {
+            column: "payload".to_string(),
+            value: Value::Text(payload),
+        }],
+        ts,
+        None,
+    )
+}
+
+/// AC (#910): a BTI SSTable with a WIDE partition emits a non-empty Rows.db; the
+/// wide partition resolves through Partitions.db → RowsOffset → resolve_rows_db_entry
+/// → iterate_rows_in_bti_trie, while a NARROW partition stays a direct DataOffset.
+#[tokio::test]
+async fn bti_wide_partition_resolves_through_rows_db() {
+    let dir = TempDir::new().unwrap();
+    let schema = wide_schema();
+    let mut writer =
+        SSTableWriter::with_format(dir.path().to_path_buf(), 1, &schema, 16, SSTableFormat::Bti)
+            .unwrap();
+
+    // pk=1: WIDE (200 rows × ~2 KiB ≈ 400 KiB → >= 2 blocks).
+    // pk=2: NARROW (1 small row → 1 block → direct DataOffset).
+    let mut partitions: Vec<(i32, Vec<i32>)> = vec![(1, (0..200).collect()), (2, vec![0])];
+
+    // Determine token order for the two partition keys.
+    partitions.sort_by_key(|(pk, _)| {
+        let m = wide_row(*pk, 0, 1_000_000);
+        m.decorated_key(&schema).unwrap().token
+    });
+
+    for (pk, cks) in &partitions {
+        let mut muts: Vec<Mutation> = cks
+            .iter()
+            .map(|ck| wide_row(*pk, *ck, 1_000_000 + *ck as i64))
+            .collect();
+        // All mutations share the partition key; write_partition takes one key.
+        let key = muts[0].decorated_key(&schema).unwrap();
+        // Sort by ck for clustering order (writer also sorts, but be explicit).
+        muts.sort_by_key(|m| match &m.clustering_key {
+            Some(ck) => match &ck.columns[0].1 {
+                Value::Integer(v) => *v,
+                _ => 0,
+            },
+            None => 0,
+        });
+        writer.write_partition(key, muts).unwrap();
+    }
+
+    let info = writer.finish().await.unwrap();
+
+    // Rows.db must exist and be NON-empty (pk=1 is wide).
+    let rows_path = info.rows_path.clone().expect("Rows.db path");
+    let rows_db = std::fs::read(&rows_path).unwrap();
+    assert!(
+        !rows_db.is_empty(),
+        "a wide partition must produce a non-empty Rows.db"
+    );
+
+    let partitions_db = std::fs::read(info.partitions_path.clone().unwrap()).unwrap();
+
+    // pk=1 (wide) → RowsOffset; resolve + traverse yields >= 2 ascending blocks.
+    let raw_pk1 = 1i32.to_be_bytes().to_vec();
+    let mut cur = Cursor::new(partitions_db.clone());
+    let loc1 = lookup_raw_key_in_bti_partitions_db(&mut cur, &raw_pk1)
+        .unwrap()
+        .expect("pk=1 found");
+    let rows_offset = match loc1 {
+        BtiPartitionLocation::RowsOffset(o) => o as usize,
+        BtiPartitionLocation::DataOffset(o) => {
+            panic!("pk=1 must be wide (RowsOffset); got DataOffset({o})")
+        }
+    };
+    let header = resolve_rows_db_entry(&rows_db, rows_offset).expect("resolve pk=1 entry");
+    assert!(
+        header.block_count >= 2,
+        "wide partition must span >= 2 blocks; got {}",
+        header.block_count
+    );
+    let entries =
+        iterate_rows_in_bti_trie(&rows_db, header.trie_root).expect("traverse pk=1 row index");
+    assert_eq!(
+        entries.len() as u32,
+        header.block_count,
+        "traversal must yield block_count blocks"
+    );
+    // Separators ascending; block offsets strictly increasing.
+    for w in entries.windows(2) {
+        assert!(w[0].0 <= w[1].0, "separators must be ascending");
+        assert!(
+            w[0].1.data_offset < w[1].1.data_offset,
+            "block offsets must be strictly increasing"
+        );
+    }
+    // First block separator is ck=0 (OSS50 sign-flipped int = 0x8000_0000).
+    assert_eq!(
+        entries[0].0,
+        0x8000_0000u32.to_be_bytes().to_vec(),
+        "first separator must be ck=0"
+    );
+
+    // pk=2 (narrow) → DataOffset, NOT a RowsOffset.
+    let raw_pk2 = 2i32.to_be_bytes().to_vec();
+    let mut cur2 = Cursor::new(partitions_db);
+    let loc2 = lookup_raw_key_in_bti_partitions_db(&mut cur2, &raw_pk2)
+        .unwrap()
+        .expect("pk=2 found");
+    assert!(
+        matches!(loc2, BtiPartitionLocation::DataOffset(_)),
+        "narrow partition pk=2 must resolve to a direct DataOffset, got {loc2:?}"
+    );
+
+    // TOC lists Rows.db.
+    let toc = std::fs::read_to_string(&info.toc_path).unwrap();
+    assert!(toc.contains("Rows.db"), "TOC must list Rows.db");
+}
+
+/// Finding 2 (roborev #908): an EMPTY BTI SSTable (no partitions) cannot produce
+/// a readable Partitions.db (no 8-byte root footer) — the writer must REFUSE to
+/// publish it with a clear error rather than emit an unreadable `da` artifact.
+#[tokio::test]
+async fn bti_empty_sstable_is_refused() {
+    let dir = TempDir::new().unwrap();
+    let schema = int_pk_schema();
+    let writer =
+        SSTableWriter::with_format(dir.path().to_path_buf(), 1, &schema, 16, SSTableFormat::Bti)
+            .unwrap();
+    // No partitions written.
+    let result = writer.finish().await;
+    assert!(
+        result.is_err(),
+        "an empty BTI SSTable must be refused (unreadable Partitions.db otherwise)"
+    );
+    let msg = format!("{}", result.err().unwrap());
+    assert!(
+        msg.contains("empty BTI SSTable"),
+        "error must explain the empty-BTI refusal; got: {msg}"
+    );
+}
+
+/// A narrow-only BTI SSTable still publishes (valid Partitions.db) and emits a
+/// 0-byte Rows.db listed in the TOC — exactly matching the real
+/// `simple_table`/`collection_table`/`ttl_table` `da-2-bti-Rows.db` fixtures.
+#[tokio::test]
+async fn bti_narrow_only_emits_zero_byte_rows_db() {
+    let dir = TempDir::new().unwrap();
+    let info = write_bti(dir.path(), 3).await;
+    let rows_path = info.rows_path.clone().expect("Rows.db path");
+    let rows_db = std::fs::read(&rows_path).unwrap();
+    assert!(
+        rows_db.is_empty(),
+        "a narrow-only BTI SSTable must emit a 0-byte Rows.db; got {} bytes",
+        rows_db.len()
+    );
+    let toc = std::fs::read_to_string(&info.toc_path).unwrap();
+    assert!(
+        toc.contains("Rows.db"),
+        "0-byte Rows.db must still be in TOC"
+    );
 }

--- a/cqlite-core/tests/issue_908_bti_canonical_write.rs
+++ b/cqlite-core/tests/issue_908_bti_canonical_write.rs
@@ -1,0 +1,259 @@
+//! Integration tests for issue #908 (epic #872): Cassandra-canonical BTI write.
+//!
+//! These prove the BTI writer emits a true `da`-format BTI component set instead
+//! of the phase-1 `nb-*-big-*` hybrid:
+//!
+//! 1. Component filenames use the `da` version letter and `bti` format segment
+//!    (`da-<gen>-bti-<Component>`), parsed back via `SsTableDescriptor`.
+//! 2. A BTI SSTable has `Data.db` + `Partitions.db` and a TOC, but **no**
+//!    `Index.db` and **no** `Summary.db`.
+//! 3. `TOC.txt` lists exactly the BTI component set (Data, Partitions, Filter,
+//!    Statistics, Digest, TOC) — no Index/Summary, no Rows yet (#910) — and
+//!    self-references TOC.txt.
+//! 4. The default BIG writer is unchanged (still `nb-*-big-*` with Index/Summary).
+//!
+//! All tests require the `write-support` feature.
+
+#![cfg(feature = "write-support")]
+
+use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+use cqlite_core::storage::sstable::version_gate::{SsTableDescriptor, SsTableFormat};
+use cqlite_core::storage::sstable::writer::{SSTableFormat, SSTableWriter};
+use cqlite_core::storage::write_engine::mutation::{
+    CellOperation, Mutation, PartitionKey, TableId,
+};
+use cqlite_core::types::Value;
+use std::collections::HashMap;
+use std::path::Path;
+use tempfile::TempDir;
+
+fn int_pk_schema() -> TableSchema {
+    TableSchema {
+        keyspace: "test_ks".to_string(),
+        table: "t".to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            Column {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "name".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+    }
+}
+
+fn int_mutation(id: i32, name: &str, ts: i64) -> Mutation {
+    Mutation::new(
+        TableId::new("test_ks", "t"),
+        PartitionKey::single("id", Value::Integer(id)),
+        None,
+        vec![CellOperation::Write {
+            column: "name".to_string(),
+            value: Value::Text(name.to_string()),
+        }],
+        ts,
+        None,
+    )
+}
+
+/// List the component filenames present in the table directory.
+fn component_filenames(table_dir: &Path) -> Vec<String> {
+    std::fs::read_dir(table_dir)
+        .unwrap()
+        .flatten()
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .collect()
+}
+
+async fn write_bti(dir: &Path, gen: u64) -> cqlite_core::storage::sstable::writer::SSTableInfo {
+    let schema = int_pk_schema();
+    let mut writer =
+        SSTableWriter::with_format(dir.to_path_buf(), gen, &schema, 16, SSTableFormat::Bti)
+            .unwrap();
+
+    let mut keyed: Vec<_> = (0..6)
+        .map(|i| {
+            let m = int_mutation(i, &format!("name{i}"), 1_000_000 + i as i64);
+            let key = m.decorated_key(&schema).unwrap();
+            (key, m)
+        })
+        .collect();
+    keyed.sort_by_key(|(k, _)| k.token);
+    for (key, m) in keyed {
+        writer.write_partition(key, vec![m]).unwrap();
+    }
+    writer.finish().await.unwrap()
+}
+
+/// AC#1 + AC#2: every emitted BTI component uses the `da-<gen>-bti-<Component>`
+/// descriptor and the directory contains Data.db + Partitions.db but neither
+/// Index.db nor Summary.db.
+#[tokio::test]
+async fn bti_components_use_da_bti_descriptor_and_omit_big_index() {
+    let dir = TempDir::new().unwrap();
+    let info = write_bti(dir.path(), 1).await;
+
+    let table_dir = dir.path().join("test_ks").join("t");
+    let names = component_filenames(&table_dir);
+    assert!(!names.is_empty(), "BTI SSTable should produce components");
+
+    // Every component parses as a `da`/`bti` descriptor (version letter + format
+    // segment in the correct order per SsTableDescriptor::parse).
+    for name in &names {
+        let desc = SsTableDescriptor::parse_filename(name)
+            .unwrap_or_else(|e| panic!("component {name:?} is not a valid descriptor: {e}"));
+        assert_eq!(
+            desc.version, "da",
+            "component {name:?} must use `da` version"
+        );
+        assert_eq!(
+            desc.format,
+            SsTableFormat::Bti,
+            "component {name:?} must use `bti` format segment"
+        );
+        assert_eq!(desc.sstable_id, "1", "generation must be the id segment");
+        assert!(
+            name.starts_with("da-1-bti-"),
+            "component {name:?} must start with da-1-bti-"
+        );
+    }
+
+    // Required BTI components exist with the canonical names.
+    assert!(names.iter().any(|n| n == "da-1-bti-Data.db"));
+    assert!(names.iter().any(|n| n == "da-1-bti-Partitions.db"));
+    assert!(names.iter().any(|n| n == "da-1-bti-Filter.db"));
+    assert!(names.iter().any(|n| n == "da-1-bti-Statistics.db"));
+    assert!(names.iter().any(|n| n == "da-1-bti-Digest.crc32"));
+    assert!(names.iter().any(|n| n == "da-1-bti-TOC.txt"));
+
+    // No BIG-only components, and no Rows.db (deferred to #910).
+    assert!(
+        !names.iter().any(|n| n.contains("Index.db")),
+        "BTI must not emit Index.db, got {names:?}"
+    );
+    assert!(
+        !names.iter().any(|n| n.contains("Summary.db")),
+        "BTI must not emit Summary.db, got {names:?}"
+    );
+    assert!(
+        !names.iter().any(|n| n.contains("Rows.db")),
+        "Rows.db is deferred to #910, got {names:?}"
+    );
+
+    // SSTableInfo reflects the omission.
+    assert!(
+        info.index_path.is_none(),
+        "BTI SSTableInfo.index_path must be None"
+    );
+    assert!(
+        info.summary_path.is_none(),
+        "BTI SSTableInfo.summary_path must be None"
+    );
+    assert!(
+        info.partitions_path.is_some(),
+        "BTI SSTableInfo.partitions_path must be Some"
+    );
+    // Reported paths use the canonical descriptor.
+    assert_eq!(
+        info.data_path.file_name().unwrap().to_str().unwrap(),
+        "da-1-bti-Data.db"
+    );
+    assert_eq!(
+        info.toc_path.file_name().unwrap().to_str().unwrap(),
+        "da-1-bti-TOC.txt"
+    );
+}
+
+/// AC#3: TOC.txt lists exactly the BTI component set and self-references TOC.txt.
+#[tokio::test]
+async fn bti_toc_lists_exact_component_set() {
+    let dir = TempDir::new().unwrap();
+    let info = write_bti(dir.path(), 7).await;
+
+    let toc = std::fs::read_to_string(&info.toc_path).unwrap();
+    let listed: std::collections::BTreeSet<&str> = toc
+        .lines()
+        .map(|l| l.trim())
+        .filter(|l| !l.is_empty())
+        .collect();
+
+    let expected: std::collections::BTreeSet<&str> = [
+        "Data.db",
+        "Partitions.db",
+        "Filter.db",
+        "Statistics.db",
+        "Digest.crc32",
+        "TOC.txt",
+    ]
+    .into_iter()
+    .collect();
+
+    assert_eq!(
+        listed, expected,
+        "BTI TOC must list exactly the canonical component set (no Index/Summary/Rows)"
+    );
+    // Explicit self-reference + explicit exclusions.
+    assert!(toc.contains("TOC.txt"), "TOC must self-reference");
+    assert!(!toc.contains("Index.db"), "TOC must not list Index.db");
+    assert!(!toc.contains("Summary.db"), "TOC must not list Summary.db");
+    assert!(!toc.contains("Rows.db"), "TOC must not list Rows.db (#910)");
+}
+
+/// AC#4: the default BIG writer is unchanged — `nb-*-big-*` with Index/Summary,
+/// no Partitions.db, and the TOC still lists Index/Summary.
+#[tokio::test]
+async fn big_default_format_unchanged() {
+    let dir = TempDir::new().unwrap();
+    let schema = int_pk_schema();
+
+    let mut writer = SSTableWriter::new(dir.path().to_path_buf(), 1, &schema).unwrap();
+    let m = int_mutation(1, "alice", 1_000_000);
+    let key = m.decorated_key(&schema).unwrap();
+    writer.write_partition(key, vec![m]).unwrap();
+    let info = writer.finish().await.unwrap();
+
+    let table_dir = dir.path().join("test_ks").join("t");
+    let names = component_filenames(&table_dir);
+
+    // BIG descriptor on every component.
+    for name in &names {
+        let desc = SsTableDescriptor::parse_filename(name).unwrap();
+        assert_eq!(desc.version, "nb", "BIG component {name:?} must use `nb`");
+        assert_eq!(desc.format, SsTableFormat::Big);
+        assert!(name.starts_with("nb-1-big-"), "got {name:?}");
+    }
+
+    assert!(names.iter().any(|n| n == "nb-1-big-Index.db"));
+    assert!(names.iter().any(|n| n == "nb-1-big-Summary.db"));
+    assert!(
+        !names.iter().any(|n| n.contains("Partitions.db")),
+        "BIG must not emit Partitions.db"
+    );
+
+    assert!(info.index_path.is_some(), "BIG must report Index.db path");
+    assert!(
+        info.summary_path.is_some(),
+        "BIG must report Summary.db path"
+    );
+    assert!(info.partitions_path.is_none());
+
+    let toc = std::fs::read_to_string(&info.toc_path).unwrap();
+    assert!(toc.contains("Index.db"));
+    assert!(toc.contains("Summary.db"));
+    assert!(!toc.contains("Partitions.db"));
+}

--- a/cqlite-core/tests/issue_909_bti_reader_roundtrip.rs
+++ b/cqlite-core/tests/issue_909_bti_reader_roundtrip.rs
@@ -1,0 +1,424 @@
+//! Integration tests for issue #909 (epic #872): SSTableReader discovery for the
+//! canonical `da` BTI format + a full writer -> reader roundtrip.
+//!
+//! These prove that an SSTable produced by [`SSTableWriter`] with
+//! [`SSTableFormat::Bti`] (a real `da-*-bti-*` component set with NO
+//! Index.db/Summary.db) can be:
+//!
+//! 1. DISCOVERED by [`SSTableReader::open`]: the `da` descriptor routes the
+//!    reader onto the BTI partition-trie path (`Partitions.db` + `Rows.db`),
+//!    never the BIG Index.db/Summary.db path.
+//! 2. FULL-SCANNED back: every written row is returned with its values intact —
+//!    for BOTH a NARROW partition (direct `DataOffset`) and a WIDE partition
+//!    (whose payload is a positive `RowsOffset` resolved through `Rows.db`).
+//! 3. POINT-LOOKED-UP back: a `get(partition_key)` resolves through the
+//!    Partitions.db trie (O(log n)) for BOTH the narrow partition (DataOffset)
+//!    and the wide partition (RowsOffset -> `resolve_rows_db_entry` -> Data.db
+//!    position), returning the partition's row.
+//!
+//! The wide partition (200 rows x ~2 KiB) spans >= 2 column-index blocks, so the
+//! writer emits a non-empty `Rows.db` and stores a positive `RowsOffset` in the
+//! partition trie. This is the exact path #909 enables on the read side.
+//!
+//! All tests require the `write-support` feature.
+
+#![cfg(feature = "write-support")]
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+
+use cqlite_core::platform::Platform;
+use cqlite_core::schema::{
+    ClusteringColumn, ClusteringOrder, Column, KeyColumn, SchemaRegistry, SchemaRegistryConfig,
+    TableSchema,
+};
+use cqlite_core::storage::sstable::reader::SSTableReader;
+use cqlite_core::storage::sstable::writer::{SSTableFormat, SSTableWriter};
+use cqlite_core::storage::write_engine::mutation::{
+    CellOperation, ClusteringKey, Mutation, PartitionKey, TableId,
+};
+use cqlite_core::types::{RowKey, TableId as ReaderTableId, Value};
+use cqlite_core::Config;
+use tempfile::TempDir;
+use tokio::sync::RwLock;
+
+/// wide(pk int, ck int, payload text, PRIMARY KEY (pk, ck)).
+fn wide_schema() -> TableSchema {
+    TableSchema {
+        keyspace: "test_ks".to_string(),
+        table: "wide".to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "pk".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![ClusteringColumn {
+            name: "ck".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+            order: ClusteringOrder::Asc,
+        }],
+        columns: vec![
+            Column {
+                name: "pk".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "ck".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "payload".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+    }
+}
+
+/// One row of a partition: pk/ck ints + a payload of the given size. A ~2 KiB
+/// payload over 200 rows comfortably exceeds two 64 KiB column-index blocks,
+/// making the partition WIDE (positive `RowsOffset`).
+fn row(pk: i32, ck: i32, payload_len: usize, ts: i64) -> Mutation {
+    Mutation::new(
+        TableId::new("test_ks", "wide"),
+        PartitionKey::single("pk", Value::Integer(pk)),
+        Some(ClusteringKey::single("ck", Value::Integer(ck))),
+        vec![CellOperation::Write {
+            column: "payload".to_string(),
+            value: Value::Text("x".repeat(payload_len)),
+        }],
+        ts,
+        None,
+    )
+}
+
+/// Number of rows in the WIDE partition. Sized so total bytes >> 2 blocks.
+const WIDE_ROWS: i32 = 200;
+/// Per-row payload size for the wide partition (~2 KiB).
+const WIDE_PAYLOAD: usize = 2048;
+
+/// Partition key that is NARROW (1 small row -> direct DataOffset).
+const NARROW_PK: i32 = 1;
+/// Partition key that is WIDE (>= 2 column-index blocks -> RowsOffset).
+const WIDE_PK: i32 = 2;
+
+/// Write a BTI SSTable containing one NARROW partition (pk=1, 1 small row) and
+/// one WIDE partition (pk=2, 200 x ~2 KiB rows), then relocate the produced
+/// components into a Cassandra-canonical `test_ks/wide-<uuid>/` directory so the
+/// reader extracts the table name (`wide`) from the parent dir exactly as it does
+/// for real `da` fixtures. Returns the relocated `SSTableInfo`.
+async fn write_mixed_bti(dir: &Path) -> cqlite_core::storage::sstable::writer::SSTableInfo {
+    let schema = wide_schema();
+    let mut writer =
+        SSTableWriter::with_format(dir.to_path_buf(), 1, &schema, 16, SSTableFormat::Bti).unwrap();
+
+    // Build per-partition mutation lists.
+    let narrow: Vec<Mutation> = vec![row(NARROW_PK, 0, 8, 1_000_000)];
+    let wide: Vec<Mutation> = (0..WIDE_ROWS)
+        .map(|ck| row(WIDE_PK, ck, WIDE_PAYLOAD, 2_000_000 + ck as i64))
+        .collect();
+
+    // Partitions must be written in token order.
+    let mut partitions: Vec<(i32, Vec<Mutation>)> = vec![(NARROW_PK, narrow), (WIDE_PK, wide)];
+    partitions.sort_by_key(|(pk, _)| row(*pk, 0, 1, 1).decorated_key(&schema).unwrap().token);
+
+    for (_pk, muts) in partitions {
+        let key = muts[0].decorated_key(&schema).unwrap();
+        writer.write_partition(key, muts).unwrap();
+    }
+
+    let info = writer.finish().await.unwrap();
+    relocate_to_canonical_dir(dir, info)
+}
+
+/// Relocate a writer-produced SSTable from `dir/test_ks/wide/` to the
+/// Cassandra-canonical `dir/test_ks/wide-<uuid>/` layout and rewrite the paths in
+/// `info`. The reader derives `table_name` by stripping the `-<uuid>` suffix from
+/// the parent directory, so the canonical layout is required for the table-id
+/// guard in the point-lookup path to resolve to `wide`.
+fn relocate_to_canonical_dir(
+    dir: &Path,
+    info: cqlite_core::storage::sstable::writer::SSTableInfo,
+) -> cqlite_core::storage::sstable::writer::SSTableInfo {
+    let src_table_dir = dir.join("test_ks").join("wide");
+    let dst_table_dir = dir
+        .join("test_ks")
+        .join("wide-00000000000000000000000000000001");
+    std::fs::create_dir_all(&dst_table_dir).unwrap();
+    for entry in std::fs::read_dir(&src_table_dir).unwrap() {
+        let entry = entry.unwrap();
+        let name = entry.file_name();
+        std::fs::rename(entry.path(), dst_table_dir.join(&name)).unwrap();
+    }
+
+    // Rewrite each path in `info` to point at the relocated directory.
+    let remap = |p: std::path::PathBuf| -> std::path::PathBuf {
+        let file = p.file_name().unwrap();
+        dst_table_dir.join(file)
+    };
+    let remap_opt = |p: Option<std::path::PathBuf>| p.map(remap);
+
+    cqlite_core::storage::sstable::writer::SSTableInfo {
+        data_path: remap(info.data_path),
+        index_path: remap_opt(info.index_path),
+        filter_path: remap(info.filter_path),
+        summary_path: remap_opt(info.summary_path),
+        stats_path: remap(info.stats_path),
+        compression_info_path: remap_opt(info.compression_info_path),
+        partitions_path: remap_opt(info.partitions_path),
+        rows_path: remap_opt(info.rows_path),
+        toc_path: remap(info.toc_path),
+        digest_path: remap(info.digest_path),
+        ..info
+    }
+}
+
+/// Open the writer-produced Data.db via `SSTableReader::open` with a schema
+/// registry seeded with `schema` so point lookups can resolve types.
+async fn open_reader(data_path: &Path, schema: &TableSchema) -> SSTableReader {
+    let config = Config::default();
+    let platform = Arc::new(Platform::new(&config).await.unwrap());
+
+    let registry = SchemaRegistry::new(
+        SchemaRegistryConfig::default(),
+        platform.clone(),
+        config.clone(),
+    )
+    .await
+    .unwrap();
+    registry
+        .register_schema(schema.clone(), cqlite_core::schema::SchemaSource::Manual)
+        .await
+        .unwrap();
+
+    let mut reader = SSTableReader::open(data_path, &config, platform)
+        .await
+        .unwrap();
+    reader.set_schema_registry(Arc::new(RwLock::new(registry)));
+    reader
+}
+
+/// Extract the `payload` column text from a row `Value::Map`.
+fn payload_of(value: &Value) -> Option<String> {
+    if let Value::Map(entries) = value {
+        for (k, v) in entries {
+            if let (Value::Text(name), Value::Text(text)) = (k, v) {
+                if name == "payload" {
+                    return Some(text.clone());
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Extract the clustering value (`ck`) from a row `Value::Map`.
+///
+/// The two reader decode paths name the clustering column differently: the
+/// whole-section scan decode (`parse_block_with_cell_metadata`) uses the schema
+/// name `ck`, while the point-lookup decode (`parse_block_emit`) uses the
+/// synthetic `clustering_key`. Both carry the same integer value, so we accept
+/// either name (the column-naming difference is orthogonal to #909's RowsOffset
+/// resolution being exercised here).
+fn ck_of(value: &Value) -> Option<i32> {
+    if let Value::Map(entries) = value {
+        for (k, v) in entries {
+            if let Value::Text(name) = k {
+                if name == "ck" || name == "clustering_key" {
+                    if let Value::Integer(i) = v {
+                        return Some(*i);
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+/// AC#1 + AC#2: discovery routes a `da` SSTable onto the BTI trie path, and a
+/// FULL SCAN reads back every row of BOTH the narrow (DataOffset) and wide
+/// (RowsOffset -> Rows.db) partitions with values intact.
+#[tokio::test]
+async fn bti_writer_reader_full_scan_roundtrip() {
+    let dir = TempDir::new().unwrap();
+    let info = write_mixed_bti(dir.path()).await;
+    let schema = wide_schema();
+
+    // The wide partition must have produced a NON-empty Rows.db (RowsOffset path)
+    // and there must be no Index.db/Summary.db (BTI discovery precondition).
+    let rows_db = std::fs::read(info.rows_path.clone().unwrap()).unwrap();
+    assert!(
+        !rows_db.is_empty(),
+        "the wide partition must produce a non-empty Rows.db (positive RowsOffset path)"
+    );
+    assert!(info.index_path.is_none(), "BTI must have no Index.db");
+    assert!(info.summary_path.is_none(), "BTI must have no Summary.db");
+
+    let reader = open_reader(&info.data_path, &schema).await;
+
+    // Discovery routed to BTI: the reader loaded Partitions.db (proven by the
+    // BTI scan path returning rows below — the BIG index path is absent).
+    let table_id = ReaderTableId::from("test_ks.wide");
+    let rows = reader
+        .scan(&table_id, None, None, None, Some(&schema))
+        .await
+        .unwrap();
+
+    // 1 narrow row + 200 wide rows = 201 rows total.
+    assert_eq!(
+        rows.len(),
+        (WIDE_ROWS as usize) + 1,
+        "full scan must return all rows from BOTH partitions (1 narrow + {} wide)",
+        WIDE_ROWS
+    );
+
+    let narrow_payload = "x".repeat(8);
+    let wide_payload = "x".repeat(WIDE_PAYLOAD);
+
+    // Narrow partition: exactly one row with the small payload.
+    let narrow_rows: Vec<&Value> = rows
+        .iter()
+        .filter(|(_k, v)| payload_of(v).as_ref() == Some(&narrow_payload))
+        .map(|(_k, v)| v)
+        .collect();
+    assert_eq!(
+        narrow_rows.len(),
+        1,
+        "narrow partition must contribute exactly one row"
+    );
+
+    // Wide partition: 200 rows, each with the ~2 KiB payload, covering ck 0..200.
+    let mut wide_cks: Vec<i32> = rows
+        .iter()
+        .filter(|(_k, v)| payload_of(v).as_ref() == Some(&wide_payload))
+        .filter_map(|(_k, v)| ck_of(v))
+        .collect();
+    wide_cks.sort_unstable();
+    assert_eq!(
+        wide_cks.len(),
+        WIDE_ROWS as usize,
+        "wide partition must contribute all {} rows via the Rows.db RowsOffset path",
+        WIDE_ROWS
+    );
+    let expected: Vec<i32> = (0..WIDE_ROWS).collect();
+    assert_eq!(
+        wide_cks, expected,
+        "wide partition rows must cover ck 0..{} exactly",
+        WIDE_ROWS
+    );
+}
+
+/// AC#3: a POINT LOOKUP resolves through the Partitions.db trie for BOTH the
+/// narrow partition (direct DataOffset) and the wide partition (positive
+/// RowsOffset resolved through Rows.db). Neither falls through to a sequential
+/// scan, and both return the partition's row.
+#[tokio::test]
+async fn bti_writer_reader_point_lookup_roundtrip() {
+    let dir = TempDir::new().unwrap();
+    let info = write_mixed_bti(dir.path()).await;
+    let schema = wide_schema();
+    let reader = open_reader(&info.data_path, &schema).await;
+    let table_id = ReaderTableId::from("test_ks.wide");
+
+    let scans_before = SSTableReader::scan_for_key_call_count();
+
+    // --- NARROW partition (pk=1): direct DataOffset ---
+    let narrow_key = RowKey::from(NARROW_PK.to_be_bytes().to_vec());
+    let narrow = reader
+        .get(&table_id, &narrow_key)
+        .await
+        .unwrap()
+        .expect("narrow partition (DataOffset) must be found via the BTI trie");
+    assert_eq!(
+        payload_of(&narrow),
+        Some("x".repeat(8)),
+        "narrow point lookup must return the narrow partition's row"
+    );
+
+    // --- WIDE partition (pk=2): positive RowsOffset -> Rows.db -> data_position ---
+    let wide_key = RowKey::from(WIDE_PK.to_be_bytes().to_vec());
+    let wide = reader
+        .get(&table_id, &wide_key)
+        .await
+        .unwrap()
+        .expect("wide partition (RowsOffset) must be found via the BTI trie + Rows.db");
+    // The point lookup returns the FIRST row of the partition (ck=0).
+    assert_eq!(
+        payload_of(&wide),
+        Some("x".repeat(WIDE_PAYLOAD)),
+        "wide point lookup must return a wide-partition row (resolved through Rows.db)"
+    );
+    assert_eq!(
+        ck_of(&wide),
+        Some(0),
+        "wide point lookup returns the partition's first clustering row (ck=0)"
+    );
+
+    // Neither lookup fell through to a sequential scan: BTI resolves entirely via
+    // the Partitions.db trie (+ Rows.db for the wide partition).
+    let scans_after = SSTableReader::scan_for_key_call_count();
+    assert_eq!(
+        scans_after, scans_before,
+        "BTI point lookups must NOT fall through to scan_for_key (trie + Rows.db only)"
+    );
+
+    // A key that is absent returns None (trie has no path), still no scan.
+    let absent_key = RowKey::from(9999i32.to_be_bytes().to_vec());
+    let absent = reader.get(&table_id, &absent_key).await.unwrap();
+    assert!(absent.is_none(), "an absent partition key must return None");
+    assert_eq!(
+        SSTableReader::scan_for_key_call_count(),
+        scans_before,
+        "an absent BTI lookup must not trigger a sequential scan either"
+    );
+}
+
+/// AC#4: the BTI partition-trie point lookup resolves BOTH the narrow
+/// (DataOffset) and wide (RowsOffset) partition keys to an uncompressed Data.db
+/// offset — proving #909's RowsOffset → Rows.db → `data_position` resolution at
+/// the primitive level (independent of the higher-level `get()` decode). The
+/// narrow partition resolves to the first partition (offset 0); the wide
+/// partition's positive RowsOffset is resolved through `resolve_rows_db_entry` to
+/// its real Data.db position.
+#[tokio::test]
+async fn bti_trie_resolves_both_offset_kinds() {
+    let dir = TempDir::new().unwrap();
+    let info = write_mixed_bti(dir.path()).await;
+    let schema = wide_schema();
+    let reader = open_reader(&info.data_path, &schema).await;
+
+    let narrow_key = NARROW_PK.to_be_bytes().to_vec();
+    let wide_key = WIDE_PK.to_be_bytes().to_vec();
+
+    let narrow_off = reader
+        .lookup_partition_via_bti_trie(&narrow_key)
+        .unwrap()
+        .expect("narrow key must resolve to a direct Data.db offset");
+    let wide_off = reader
+        .lookup_partition_via_bti_trie(&wide_key)
+        .unwrap()
+        .expect("wide key must resolve via RowsOffset -> Rows.db -> Data.db position");
+
+    // The two partitions occupy distinct Data.db positions (different offsets).
+    assert_ne!(
+        narrow_off, wide_off,
+        "narrow and wide partitions must resolve to distinct Data.db offsets"
+    );
+
+    // An absent key has no trie path.
+    let absent = reader
+        .lookup_partition_via_bti_trie(&9999i32.to_be_bytes())
+        .unwrap();
+    assert!(absent.is_none(), "absent key must have no trie path");
+}

--- a/cqlite-core/tests/issue_911_bti_partition_deletion_stats.rs
+++ b/cqlite-core/tests/issue_911_bti_partition_deletion_stats.rs
@@ -1,0 +1,381 @@
+//! Follow-up to #911: the canonical `da` (BtiFormat) `StatsMetadata` must
+//! report `hasPartitionLevelDeletions` truthfully.
+//!
+//! `build_stats_component_da` originally hard-coded the
+//! `hasPartitionLevelDeletions` boolean to `false`, so any `da` SSTable that
+//! contained a partition-level delete lied about its deletion marker in
+//! Statistics.db. This test suite proves the marker is now driven by the actual
+//! mutations written:
+//!
+//! * a BTI SSTable carrying a partition-level tombstone serialises the marker
+//!   byte as `0x01`;
+//! * a BTI SSTable with no partition delete serialises `0x00`.
+//!
+//! ## Encoding authority (cassandra-5.0.0)
+//!
+//! `StatsMetadata.StatsMetadataSerializer.serialize` (StatsMetadata.java line
+//! 495) emits the field as `out.writeBoolean(component.hasPartitionLevelDeletions)`,
+//! gated by `version.hasPartitionLevelDeletionsPresenceMarker()` (true for
+//! `BtiFormat.BtiVersion`). `DataOutput.writeBoolean` writes a single byte:
+//! `0x01` for true, `0x00` for false. The field sits between `originatingHostId`
+//! and the `hasKeyRange` first/last keys in the `da` STATS body.
+//!
+//! ## What runs without Docker
+//!
+//! The marker-byte assertions parse the writer-produced Statistics.db TOC,
+//! extract the STATS component body, and compare the partition-deleted vs
+//! non-deleted bodies. No Cassandra required.
+//!
+//! ## What is Docker-gated
+//!
+//! `partition_deletion_reads_back_under_cassandra5_sstabledump` runs Cassandra
+//! 5's `sstabledump` against the writer-produced SSTable and asserts the
+//! partition deletion is reflected in the dump (`partition.deletion_info`). It
+//! SKIPS CLEANLY when Docker / a `cassandra:5.0` image is absent, exactly like
+//! the #911 / #819 e2e paths.
+
+#![cfg(feature = "write-support")]
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+use cqlite_core::storage::sstable::writer::{SSTableFormat, SSTableInfo, SSTableWriter};
+use cqlite_core::storage::write_engine::mutation::{
+    CellOperation, Mutation, PartitionKey, PartitionTombstone, TableId,
+};
+use cqlite_core::types::Value;
+use tempfile::TempDir;
+
+// ════════════════════════════════════════════════════════════════════════════
+// Docker / Cassandra availability gate (skip cleanly when absent) — mirrors
+// issue_911_bti_sstabledump_parity.rs.
+// ════════════════════════════════════════════════════════════════════════════
+
+const SSTABLEDUMP: &str = "/opt/cassandra/tools/bin/sstabledump";
+
+fn cassandra_5_image() -> Option<String> {
+    let info = Command::new("docker").arg("info").output().ok()?;
+    if !info.status.success() {
+        return None;
+    }
+    let images = Command::new("docker")
+        .args(["images", "--format", "{{.Repository}}:{{.Tag}}"])
+        .output()
+        .ok()?;
+    if !images.status.success() {
+        return None;
+    }
+    let listing = String::from_utf8_lossy(&images.stdout);
+    let mut candidate: Option<String> = None;
+    for line in listing.lines() {
+        let line = line.trim();
+        if line == "cassandra:5.0" {
+            return Some(line.to_string());
+        }
+        if line.starts_with("cassandra:5.0.") && candidate.is_none() {
+            candidate = Some(line.to_string());
+        }
+    }
+    candidate
+}
+
+fn run_sstabledump(image: &str, sstable_dir: &Path, data_file: &str) -> Result<String, String> {
+    let mount = format!("{}:/data:ro", sstable_dir.display());
+    let out = Command::new("docker")
+        .args([
+            "run",
+            "--rm",
+            "--entrypoint",
+            SSTABLEDUMP,
+            "-v",
+            &mount,
+            image,
+            &format!("/data/{data_file}"),
+        ])
+        .output()
+        .map_err(|e| format!("failed to spawn docker: {e}"))?;
+    let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+    if stderr.contains("Exception") || !stdout.trim_start().starts_with('[') {
+        return Err(format!(
+            "sstabledump did not produce a JSON dump.\n--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}"
+        ));
+    }
+    Ok(stdout)
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Schema + mutations: simple(pk int PRIMARY KEY, payload text), no clustering.
+// ════════════════════════════════════════════════════════════════════════════
+
+fn simple_schema() -> TableSchema {
+    TableSchema {
+        keyspace: "test_ks".to_string(),
+        table: "simple".to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "pk".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            Column {
+                name: "pk".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "payload".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+    }
+}
+
+fn live_row(pk: i32, payload: &str, ts: i64) -> Mutation {
+    Mutation::new(
+        TableId::new("test_ks", "simple"),
+        PartitionKey::single("pk", Value::Integer(pk)),
+        None,
+        vec![CellOperation::Write {
+            column: "payload".to_string(),
+            value: Value::Text(payload.to_string()),
+        }],
+        ts,
+        None,
+    )
+}
+
+/// A mutation whose only effect is a partition-level tombstone on `pk`.
+fn partition_delete(pk: i32, deletion_micros: i64, local_secs: i32) -> Mutation {
+    let mut m = Mutation::new(
+        TableId::new("test_ks", "simple"),
+        PartitionKey::single("pk", Value::Integer(pk)),
+        None,
+        vec![],
+        deletion_micros,
+        None,
+    );
+    m.partition_tombstone = Some(PartitionTombstone {
+        deletion_time: deletion_micros,
+        local_deletion_time: local_secs,
+    });
+    m
+}
+
+/// Write a single-partition BTI SSTable. When `with_partition_delete` is set the
+/// partition (pk=1) carries a partition-level tombstone in addition to a live
+/// row; otherwise it is just a live row. The partition key (and hence
+/// first/last key) is identical in both cases so the only Statistics.db
+/// difference is the `hasPartitionLevelDeletions` marker byte.
+async fn write_simple_bti(dir: &Path, with_partition_delete: bool) -> SSTableInfo {
+    let schema = simple_schema();
+    let mut writer =
+        SSTableWriter::with_format(dir.to_path_buf(), 1, &schema, 16, SSTableFormat::Bti).unwrap();
+
+    let pk = 1;
+    let mut muts = vec![live_row(pk, "alive", 1_000_000)];
+    if with_partition_delete {
+        // deletion_time (micros) > the live row ts so the partition is deleted.
+        muts.push(partition_delete(pk, 2_000_000, 2));
+    }
+    let key = muts[0].decorated_key(&schema).unwrap();
+    writer.write_partition(key, muts).unwrap();
+    writer.finish().await.unwrap()
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Statistics.db TOC parsing — extract the STATS component body.
+// ════════════════════════════════════════════════════════════════════════════
+
+const METADATA_TYPE_STATS: u32 = 2;
+const METADATA_TYPE_SERIALIZATION_HEADER: u32 = 3;
+
+/// Parse the Statistics.db TOC and return the STATS component body (without its
+/// trailing 4-byte CRC). The TOC layout is:
+///   u32 count, u32 checksum, count×(u32 type, u32 offset), u32 checksum.
+/// Each component body is `offset_next - offset_this - 4` bytes (the 4 being
+/// this component's trailing CRC). The last component (SERIALIZATION_HEADER)
+/// ends 4 bytes before EOF.
+fn read_stats_component_body(stats_path: &Path) -> Vec<u8> {
+    let bytes = std::fs::read(stats_path).unwrap();
+    let rd_u32 = |b: &[u8], p: usize| u32::from_be_bytes([b[p], b[p + 1], b[p + 2], b[p + 3]]);
+
+    let count = rd_u32(&bytes, 0) as usize;
+    // offsets: count(4) + checksum(4) = 8, then entries.
+    let mut entries: Vec<(u32, u32)> = Vec::with_capacity(count);
+    let mut p = 8;
+    for _ in 0..count {
+        let ty = rd_u32(&bytes, p);
+        let off = rd_u32(&bytes, p + 4);
+        entries.push((ty, off));
+        p += 8;
+    }
+
+    // The STATS body runs from its offset up to the SERIALIZATION_HEADER offset
+    // (the next component) minus the 4-byte STATS CRC.
+    let stats_off = entries
+        .iter()
+        .find(|(t, _)| *t == METADATA_TYPE_STATS)
+        .map(|(_, o)| *o as usize)
+        .expect("STATS component in TOC");
+    let header_off = entries
+        .iter()
+        .find(|(t, _)| *t == METADATA_TYPE_SERIALIZATION_HEADER)
+        .map(|(_, o)| *o as usize)
+        .expect("SERIALIZATION_HEADER component in TOC");
+
+    assert!(header_off > stats_off, "header follows stats");
+    bytes[stats_off..header_off - 4].to_vec()
+}
+
+fn stats_path_for(info: &SSTableInfo) -> PathBuf {
+    info.stats_path.clone()
+}
+
+/// Locate the `hasPartitionLevelDeletions` marker byte within a `da` STATS body.
+///
+/// The `da` STATS body tail (cassandra-5.0.0 `StatsMetadataSerializer.serialize`)
+/// is, in order: `hasPartitionLevelDeletions` (1 byte), then `hasKeyRange`
+/// firstKey + lastKey (each `ByteBufferUtil.writeWithVIntLength`: an unsigned
+/// VInt length followed by the raw key bytes), then `tokenSpaceCoverage`
+/// (8-byte double). We walk in from the tail: drop the 8-byte token coverage,
+/// then parse lastKey and firstKey (VInt length + bytes) backwards is awkward, so
+/// instead we anchor on the marker position computed from the known partition
+/// key length (single 4-byte int => 1-byte VInt length each).
+fn partition_deletion_marker(body: &[u8], key_len: usize) -> u8 {
+    // Each writeWithVIntLength field with a <128-byte payload uses a single-byte
+    // unsigned VInt length, so firstKey/lastKey occupy `1 + key_len` bytes each.
+    let key_field = 1 + key_len;
+    let tail = key_field + key_field + 8; // firstKey + lastKey + tokenSpaceCoverage
+    let marker_idx = body
+        .len()
+        .checked_sub(tail + 1)
+        .expect("STATS body long enough to contain the marker + key range + coverage");
+    body[marker_idx]
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Marker-byte assertions (no Docker required).
+// ════════════════════════════════════════════════════════════════════════════
+
+/// A BTI SSTable that contains a partition-level tombstone must serialise
+/// `hasPartitionLevelDeletions = 0x01`; an otherwise-identical SSTable with no
+/// partition delete must serialise `0x00`. The two STATS bodies are identical
+/// except for that single marker byte.
+#[tokio::test]
+async fn da_stats_marks_partition_level_deletion() {
+    let no_del_dir = TempDir::new().unwrap();
+    let del_dir = TempDir::new().unwrap();
+
+    let no_del = write_simple_bti(no_del_dir.path(), false).await;
+    let with_del = write_simple_bti(del_dir.path(), true).await;
+
+    // Confirm the canonical da component set.
+    assert_eq!(
+        with_del
+            .data_path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap(),
+        "da-1-bti-Data.db",
+        "writer must emit a da-bti Data.db"
+    );
+
+    let no_del_stats = read_stats_component_body(&stats_path_for(&no_del));
+    let with_del_stats = read_stats_component_body(&stats_path_for(&with_del));
+
+    // pk=1 is a single 4-byte int partition key in both SSTables, so the
+    // firstKey/lastKey fields (and hence the marker position relative to the
+    // tail) are identical. The bodies differ in LENGTH because the partition
+    // tombstone also populates the tombstone drop-time histogram — that is
+    // expected and is why we anchor the marker by parsing the tail rather than
+    // diffing the whole body.
+    const PK_LEN: usize = 4; // i32 partition key
+
+    let no_del_marker = partition_deletion_marker(&no_del_stats, PK_LEN);
+    let with_del_marker = partition_deletion_marker(&with_del_stats, PK_LEN);
+
+    assert_eq!(
+        no_del_marker, 0x00,
+        "no partition delete => hasPartitionLevelDeletions = 0x00"
+    );
+    assert_eq!(
+        with_del_marker, 0x01,
+        "partition delete present => hasPartitionLevelDeletions = 0x01"
+    );
+
+    eprintln!(
+        "[#911 partition-deletion] da StatsMetadata hasPartitionLevelDeletions: 0x00 (no delete) \
+         vs 0x01 (partition delete)."
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// LIVE (Docker-gated): Cassandra 5 reads the partition deletion back.
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Cassandra 5's `sstabledump` opens the writer-produced `da` SSTable and
+/// reports the partition-level deletion (`partition.deletion_info` with a
+/// non-`LIVE` `marked_deleted`). This exercises the real `StatsComponent.load`
+/// path that consumes `hasPartitionLevelDeletions`. Skipped cleanly without
+/// Docker / a `cassandra:5.0` image.
+#[tokio::test]
+async fn partition_deletion_reads_back_under_cassandra5_sstabledump() {
+    let Some(image) = cassandra_5_image() else {
+        eprintln!(
+            "[skip] partition_deletion_reads_back_under_cassandra5_sstabledump: Docker or a \
+             cassandra:5.0 image is not available."
+        );
+        return;
+    };
+
+    let dir = TempDir::new().unwrap();
+    let info = write_simple_bti(dir.path(), true).await;
+    let sstable_dir = info
+        .data_path
+        .parent()
+        .expect("Data.db parent dir")
+        .to_path_buf();
+    let data_file = info
+        .data_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .expect("Data.db file name")
+        .to_string();
+
+    let dump = run_sstabledump(&image, &sstable_dir, &data_file).unwrap_or_else(|e| {
+        panic!("Cassandra 5 sstabledump FAILED to read the partition-deleted da-bti SSTable:\n{e}")
+    });
+    let json: serde_json::Value =
+        serde_json::from_str(&dump).expect("sstabledump output must be valid JSON");
+    let partitions = json.as_array().expect("dump is a JSON array of partitions");
+    assert_eq!(partitions.len(), 1, "exactly one partition (pk=1)");
+
+    let p = &partitions[0];
+    let del = &p["partition"]["deletion_info"];
+    assert!(
+        del.is_object(),
+        "partition.deletion_info must be present for a partition-level delete; got: {p}"
+    );
+    let marked = del["marked_deleted"]
+        .as_str()
+        .expect("deletion_info.marked_deleted present");
+    assert!(
+        !marked.is_empty() && marked != "1970-01-01T00:00:00Z",
+        "marked_deleted must be a real (non-LIVE) deletion timestamp; got {marked:?}"
+    );
+
+    eprintln!(
+        "[#911 partition-deletion PASS] Cassandra 5 ({image}) sstabledump reported the partition \
+         deletion (marked_deleted={marked})."
+    );
+}

--- a/cqlite-core/tests/issue_911_bti_sstabledump_parity.rs
+++ b/cqlite-core/tests/issue_911_bti_sstabledump_parity.rs
@@ -1,0 +1,545 @@
+//! Issue #911 (final child of epic #872): validate writer-produced canonical
+//! `da-*-bti-*` BTI SSTables against Cassandra 5's `sstabledump`.
+//!
+//! Epic #872 made CQLite emit Cassandra-canonical BTI SSTables: a `da` descriptor
+//! with `Data.db` + `Partitions.db` + `Rows.db`, no `Index.db`/`Summary.db`
+//! (#908), the within-partition `Rows.db` clustering trie (#910), and
+//! `SSTableReader` discovery + writer->reader roundtrip (#909). #911 closes the
+//! loop by proving the output is also readable by a *real Cassandra 5 reader*:
+//! `sstabledump` (which exercises the same `BtiTableReader` /
+//! `StatsComponent` / `PartitionIndex` load path a live node uses).
+//!
+//! ## What is gated on Docker
+//!
+//! The live `sstabledump` comparison needs Docker + a `cassandra:5.0` (or
+//! `cassandra:5.0.x`) image. Exactly like the other Cassandra e2e paths in this
+//! repo (`issue_819_differential_compaction`'s `CQLITE_DIFFERENTIAL_CASSANDRA`
+//! switch, `test-data/scripts/e2e-cassandra-readback.sh`), the live path is
+//! SKIPPED CLEANLY when Docker or the image is absent — the test prints a skip
+//! note and returns rather than failing. When Docker IS present it actually runs
+//! `sstabledump` against a writer-produced `da` SSTable and asserts the dump is
+//! well-formed and value-equivalent to what CQLite wrote.
+//!
+//! ## What runs WITHOUT Docker
+//!
+//! A structural cross-check that does not need Cassandra at all: the
+//! writer-produced `da` component set + `Partitions.db` canonical footer are
+//! compared against the **real committed Cassandra-produced `da` fixture**
+//! (`test_da/simple_table-…`), so CI without Docker still verifies the on-disk
+//! shape CQLite emits matches what Cassandra writes.
+//!
+//! All tests require the `write-support` feature.
+
+#![cfg(feature = "write-support")]
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use cqlite_core::schema::{ClusteringColumn, ClusteringOrder, Column, KeyColumn, TableSchema};
+use cqlite_core::storage::sstable::writer::{SSTableFormat, SSTableInfo, SSTableWriter};
+use cqlite_core::storage::write_engine::mutation::{
+    CellOperation, ClusteringKey, Mutation, PartitionKey, TableId,
+};
+use cqlite_core::types::Value;
+use tempfile::TempDir;
+
+// ════════════════════════════════════════════════════════════════════════════
+// Docker / Cassandra availability gate (skip cleanly when absent)
+// ════════════════════════════════════════════════════════════════════════════
+
+/// The `sstabledump` binary inside the Cassandra image lives under `tools/bin`
+/// and is NOT on the entrypoint PATH, so we invoke it with an explicit
+/// `--entrypoint`.
+const SSTABLEDUMP: &str = "/opt/cassandra/tools/bin/sstabledump";
+
+/// Pick a usable `cassandra:5.0*` image, or `None` if Docker is unavailable or no
+/// 5.0 image is present. Mirrors the honest gating of the other Cassandra e2e
+/// paths: a missing daemon/image is a SKIP, never a failure.
+fn cassandra_5_image() -> Option<String> {
+    // 1. Docker daemon reachable?
+    let info = Command::new("docker").arg("info").output().ok()?;
+    if !info.status.success() {
+        return None;
+    }
+    // 2. A cassandra:5.0* image present locally? (We do not pull — CI provisions it.)
+    let images = Command::new("docker")
+        .args(["images", "--format", "{{.Repository}}:{{.Tag}}"])
+        .output()
+        .ok()?;
+    if !images.status.success() {
+        return None;
+    }
+    let listing = String::from_utf8_lossy(&images.stdout);
+    // Prefer an exact "cassandra:5.0", else any "cassandra:5.0.*".
+    let mut candidate: Option<String> = None;
+    for line in listing.lines() {
+        let line = line.trim();
+        if line == "cassandra:5.0" {
+            return Some(line.to_string());
+        }
+        if line.starts_with("cassandra:5.0.") && candidate.is_none() {
+            candidate = Some(line.to_string());
+        }
+    }
+    candidate
+}
+
+/// Run `sstabledump <data>` inside the image with the SSTable directory mounted
+/// read-only at `/data`. Returns the captured stdout on success, or an `Err`
+/// carrying stderr (which is where Cassandra prints load-path exceptions).
+fn run_sstabledump(image: &str, sstable_dir: &Path, data_file: &str) -> Result<String, String> {
+    let mount = format!("{}:/data:ro", sstable_dir.display());
+    let out = Command::new("docker")
+        .args([
+            "run",
+            "--rm",
+            "--entrypoint",
+            SSTABLEDUMP,
+            "-v",
+            &mount,
+            image,
+            &format!("/data/{data_file}"),
+        ])
+        .output()
+        .map_err(|e| format!("failed to spawn docker: {e}"))?;
+    let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+    // sstabledump exits 0 and prints JSON to stdout on success. A load-path
+    // failure surfaces as a Java exception on stderr (often still exit 0), so we
+    // treat "no JSON array" or "Exception" on stderr as failure.
+    if stderr.contains("Exception") || !stdout.trim_start().starts_with('[') {
+        return Err(format!(
+            "sstabledump did not produce a JSON dump.\n--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}"
+        ));
+    }
+    Ok(stdout)
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Fixtures: write a canonical da BTI SSTable (narrow + wide partitions)
+// ════════════════════════════════════════════════════════════════════════════
+
+/// wide(pk int, ck int, payload text, PRIMARY KEY (pk, ck)).
+fn wide_schema() -> TableSchema {
+    TableSchema {
+        keyspace: "test_ks".to_string(),
+        table: "wide".to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "pk".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![ClusteringColumn {
+            name: "ck".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+            order: ClusteringOrder::Asc,
+        }],
+        columns: vec![
+            Column {
+                name: "pk".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "ck".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "payload".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+    }
+}
+
+fn row(pk: i32, ck: i32, payload: &str, ts: i64) -> Mutation {
+    Mutation::new(
+        TableId::new("test_ks", "wide"),
+        PartitionKey::single("pk", Value::Integer(pk)),
+        Some(ClusteringKey::single("ck", Value::Integer(ck))),
+        vec![CellOperation::Write {
+            column: "payload".to_string(),
+            value: Value::Text(payload.to_string()),
+        }],
+        ts,
+        None,
+    )
+}
+
+/// Rows in the WIDE partition; ~2 KiB payload each so the partition spans >= 2
+/// column-index blocks and exercises the positive-`RowsOffset` / `Rows.db` path.
+const WIDE_ROWS: i32 = 200;
+const NARROW_PK: i32 = 1;
+const WIDE_PK: i32 = 2;
+
+/// Write a BTI SSTable with one narrow (pk=1, single small row) and one wide
+/// (pk=2, 200 x ~2 KiB rows) partition. Returns the writer `SSTableInfo`.
+async fn write_mixed_bti(dir: &Path) -> SSTableInfo {
+    let schema = wide_schema();
+    let mut writer =
+        SSTableWriter::with_format(dir.to_path_buf(), 1, &schema, 16, SSTableFormat::Bti).unwrap();
+
+    let payload_wide = "x".repeat(2048);
+    let narrow: Vec<Mutation> = vec![row(NARROW_PK, 0, "small", 1_000_000)];
+    let wide: Vec<Mutation> = (0..WIDE_ROWS)
+        .map(|ck| row(WIDE_PK, ck, &payload_wide, 2_000_000 + ck as i64))
+        .collect();
+
+    let mut parts: Vec<(i32, Vec<Mutation>)> = vec![(NARROW_PK, narrow), (WIDE_PK, wide)];
+    parts.sort_by_key(|(pk, _)| row(*pk, 0, "", 1).decorated_key(&schema).unwrap().token);
+    for (_pk, muts) in parts {
+        let key = muts[0].decorated_key(&schema).unwrap();
+        writer.write_partition(key, muts).unwrap();
+    }
+    writer.finish().await.unwrap()
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// AC: a writer-produced BTI SSTable reads back correctly under Cassandra 5's
+//     sstabledump and matches the expected dump.
+// ════════════════════════════════════════════════════════════════════════════
+
+/// LIVE (Docker-gated): `sstabledump` opens a writer-produced `da` SSTable and
+/// dumps every partition/row with the values CQLite wrote.
+///
+/// This exercises the *real* Cassandra 5 BTI load path — `StatsComponent.load`
+/// (Statistics.db `da` `StatsMetadata`, incl. the covered-clustering `Slice`),
+/// `PartitionIndex.load` (the canonical `Partitions.db` `[firstPos|keyCount|root]`
+/// footer + first/last keys), and the BTI `Data.db` reader. Skipped cleanly when
+/// Docker / a `cassandra:5.0` image is absent.
+#[tokio::test]
+async fn bti_writer_output_reads_under_cassandra5_sstabledump() {
+    let Some(image) = cassandra_5_image() else {
+        eprintln!(
+            "[skip] bti_writer_output_reads_under_cassandra5_sstabledump: Docker or a \
+             cassandra:5.0 image is not available. CI runs this via the sstabledump-validator \
+             / e2e harness (see the test module docs)."
+        );
+        return;
+    };
+
+    let dir = TempDir::new().unwrap();
+    let info = write_mixed_bti(dir.path()).await;
+    let sstable_dir = info
+        .data_path
+        .parent()
+        .expect("Data.db parent dir")
+        .to_path_buf();
+    let data_file = info
+        .data_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .expect("Data.db file name")
+        .to_string();
+    assert_eq!(
+        data_file, "da-1-bti-Data.db",
+        "writer must emit a da-bti Data.db"
+    );
+
+    let dump = run_sstabledump(&image, &sstable_dir, &data_file).unwrap_or_else(|e| {
+        panic!(
+            "Cassandra 5 sstabledump FAILED to read the writer-produced da-bti SSTable. \
+             This is the #911 acceptance gate. Detail:\n{e}"
+        )
+    });
+
+    let json: serde_json::Value =
+        serde_json::from_str(&dump).expect("sstabledump output must be valid JSON");
+    let partitions = json.as_array().expect("dump is a JSON array of partitions");
+
+    // Both partitions present.
+    assert_eq!(
+        partitions.len(),
+        2,
+        "sstabledump must report exactly 2 partitions (narrow pk=1 + wide pk=2)"
+    );
+
+    // Collect (partition-key -> row count, and the set of clustering values) so we
+    // assert value parity with what CQLite wrote.
+    let mut narrow_rows = 0usize;
+    let mut wide_cks: Vec<i64> = Vec::new();
+    let mut narrow_payload_ok = false;
+    let wide_payload = "x".repeat(2048);
+    let mut wide_payload_ok = true;
+
+    for p in partitions {
+        let key = p["partition"]["key"][0]
+            .as_str()
+            .expect("partition key rendered as string");
+        let rows = p["rows"].as_array().cloned().unwrap_or_default();
+        match key {
+            "1" => {
+                narrow_rows = rows.len();
+                for r in &rows {
+                    if r["cells"][0]["value"].as_str() == Some("small") {
+                        narrow_payload_ok = true;
+                    }
+                }
+            }
+            "2" => {
+                for r in &rows {
+                    if let Some(ck) = r["clustering"][0].as_i64() {
+                        wide_cks.push(ck);
+                    }
+                    if r["cells"][0]["value"].as_str() != Some(wide_payload.as_str()) {
+                        wide_payload_ok = false;
+                    }
+                }
+            }
+            other => panic!("unexpected partition key {other:?} in dump"),
+        }
+    }
+
+    assert_eq!(narrow_rows, 1, "narrow partition must have exactly one row");
+    assert!(narrow_payload_ok, "narrow row payload must be 'small'");
+
+    wide_cks.sort_unstable();
+    assert_eq!(
+        wide_cks.len(),
+        WIDE_ROWS as usize,
+        "wide partition must dump all {WIDE_ROWS} rows via the Rows.db path"
+    );
+    assert_eq!(
+        wide_cks,
+        (0..WIDE_ROWS as i64).collect::<Vec<_>>(),
+        "wide partition clustering values must cover 0..{WIDE_ROWS}"
+    );
+    assert!(
+        wide_payload_ok,
+        "every wide row payload must match what CQLite wrote"
+    );
+
+    eprintln!(
+        "[#911 PASS] Cassandra 5 ({image}) sstabledump read the writer-produced da-bti SSTable: \
+         2 partitions, 1 narrow + {WIDE_ROWS} wide rows, values intact."
+    );
+}
+
+/// LIVE (Docker-gated): a narrow-only BTI SSTable (no clustering, the
+/// `simple_table` shape) also reads under sstabledump. Covers the
+/// `coveredClustering = Slice.ALL` + empty `clusteringTypes` + 0-byte `Rows.db`
+/// path, matching the real `da` `simple_table` fixture.
+#[tokio::test]
+async fn bti_narrow_only_writer_output_reads_under_cassandra5_sstabledump() {
+    let Some(image) = cassandra_5_image() else {
+        eprintln!(
+            "[skip] bti_narrow_only_writer_output_reads_under_cassandra5_sstabledump: Docker / \
+             cassandra:5.0 image not available."
+        );
+        return;
+    };
+
+    // simple(pk int PRIMARY KEY, name text) — no clustering.
+    let schema = TableSchema {
+        keyspace: "test_ks".to_string(),
+        table: "simple".to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "pk".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            Column {
+                name: "pk".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "name".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+    };
+
+    let dir = TempDir::new().unwrap();
+    let mut writer =
+        SSTableWriter::with_format(dir.path().to_path_buf(), 1, &schema, 16, SSTableFormat::Bti)
+            .unwrap();
+    let mut keyed: Vec<_> = (0..5)
+        .map(|i| {
+            let m = Mutation::new(
+                TableId::new("test_ks", "simple"),
+                PartitionKey::single("pk", Value::Integer(i)),
+                None,
+                vec![CellOperation::Write {
+                    column: "name".to_string(),
+                    value: Value::Text(format!("n{i}")),
+                }],
+                1_000_000 + i as i64,
+                None,
+            );
+            let key = m.decorated_key(&schema).unwrap();
+            (key, m)
+        })
+        .collect();
+    keyed.sort_by_key(|(k, _)| k.token);
+    for (key, m) in keyed {
+        writer.write_partition(key, vec![m]).unwrap();
+    }
+    let info = writer.finish().await.unwrap();
+
+    // Narrow-only: 0-byte Rows.db (matches the simple_table fixture).
+    assert!(
+        std::fs::read(info.rows_path.clone().unwrap())
+            .unwrap()
+            .is_empty(),
+        "narrow-only BTI must emit a 0-byte Rows.db"
+    );
+
+    let sstable_dir = info.data_path.parent().unwrap().to_path_buf();
+    let dump = run_sstabledump(&image, &sstable_dir, "da-1-bti-Data.db")
+        .unwrap_or_else(|e| panic!("sstabledump failed on narrow-only da-bti SSTable:\n{e}"));
+    let json: serde_json::Value = serde_json::from_str(&dump).unwrap();
+    let partitions = json.as_array().unwrap();
+    assert_eq!(partitions.len(), 5, "all 5 narrow partitions must dump");
+
+    let mut names: Vec<String> = partitions
+        .iter()
+        .filter_map(|p| p["rows"][0]["cells"][0]["value"].as_str().map(String::from))
+        .collect();
+    names.sort();
+    assert_eq!(
+        names,
+        vec!["n0", "n1", "n2", "n3", "n4"],
+        "every partition's name cell must match what CQLite wrote"
+    );
+
+    eprintln!(
+        "[#911 PASS] sstabledump read narrow-only da-bti SSTable: 5 partitions, values intact."
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// No-Docker cross-check: writer da component shape vs the real committed fixture
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Locate the committed real-Cassandra `da` `simple_table` fixture under
+/// `CQLITE_DATASETS_ROOT` (or the in-repo default), or `None` if not fetched.
+fn committed_simple_da_fixture_dir() -> Option<PathBuf> {
+    let root = std::env::var("CQLITE_DATASETS_ROOT")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("..")
+                .join("test-data")
+                .join("datasets")
+        });
+    let dir = root
+        .join("sstables")
+        .join("test_da")
+        .join("simple_table-de1be8b064e711f19ad401a8c8227b11");
+    dir.join("da-2-bti-Data.db").exists().then_some(dir)
+}
+
+/// Read the Cassandra `PartitionIndex` footer `[firstPos|keyCount|root]` (last 24
+/// bytes) of a `Partitions.db`, returning `(first_pos, key_count, root)`.
+fn read_partition_index_footer(partitions_db: &Path) -> (i64, i64, i64) {
+    let bytes = std::fs::read(partitions_db).unwrap();
+    assert!(
+        bytes.len() >= 24,
+        "Partitions.db must carry a 24-byte footer"
+    );
+    let f = &bytes[bytes.len() - 24..];
+    let g = |o: usize| i64::from_be_bytes(f[o..o + 8].try_into().unwrap());
+    (g(0), g(8), g(16))
+}
+
+/// NO-DOCKER: the writer-produced `da` `Partitions.db` uses the SAME canonical
+/// Cassandra `PartitionIndex` footer shape as the real committed fixture
+/// (`[firstPos|keyCount|root]` last 24 bytes, first/last keys at `firstPos`), and
+/// the writer emits the same `da` component set. This verifies on-disk shape
+/// parity on CI even when Cassandra/Docker is unavailable.
+#[tokio::test]
+async fn bti_writer_partition_index_footer_matches_cassandra_fixture_shape() {
+    // Writer side.
+    let dir = TempDir::new().unwrap();
+    let info = write_mixed_bti(dir.path()).await;
+    let parts = info.partitions_path.clone().expect("BTI Partitions.db");
+    let (first_pos, key_count, root) = read_partition_index_footer(&parts);
+
+    // Footer self-consistency: firstPos and root point inside the trie region
+    // (before the footer), keyCount matches the partitions written.
+    let total = std::fs::metadata(&parts).unwrap().len() as i64;
+    assert_eq!(key_count, 2, "two partitions were written");
+    assert!(first_pos > 0 && first_pos < total - 24, "firstPos in range");
+    assert!(
+        root >= 0 && root < first_pos,
+        "root precedes first/last-key region"
+    );
+
+    // First/last keys at firstPos must be the pk=1 and pk=2 raw int bytes.
+    let bytes = std::fs::read(&parts).unwrap();
+    let mut p = first_pos as usize;
+    let read_short = |b: &[u8], p: &mut usize| -> Vec<u8> {
+        let len = u16::from_be_bytes([b[*p], b[*p + 1]]) as usize;
+        *p += 2;
+        let v = b[*p..*p + len].to_vec();
+        *p += len;
+        v
+    };
+    let first_key = read_short(&bytes, &mut p);
+    let last_key = read_short(&bytes, &mut p);
+    assert_eq!(
+        first_key,
+        NARROW_PK.to_be_bytes().to_vec(),
+        "firstKey must be pk=1's raw int bytes"
+    );
+    assert_eq!(
+        last_key,
+        WIDE_PK.to_be_bytes().to_vec(),
+        "lastKey must be pk=2's raw int bytes"
+    );
+
+    // Cross-check the SAME footer SHAPE against the real Cassandra fixture (when
+    // fetched). The fixture has its own keys/offsets, but the layout invariants
+    // (footer size, firstPos/root ordering, well-formed short-length keys) must
+    // be identical — that is what makes CQLite output Cassandra-loadable.
+    if let Some(fix_dir) = committed_simple_da_fixture_dir() {
+        let fix_parts = fix_dir.join("da-2-bti-Partitions.db");
+        let (ffp, fkc, fr) = read_partition_index_footer(&fix_parts);
+        let ftotal = std::fs::metadata(&fix_parts).unwrap().len() as i64;
+        assert_eq!(fkc, 3, "fixture simple_table has 3 partitions");
+        assert!(ffp > 0 && ffp < ftotal - 24, "fixture firstPos in range");
+        assert!(fr >= 0 && fr < ffp, "fixture root precedes key region");
+        // Fixture first/last keys are also short-length-framed at firstPos.
+        let fb = std::fs::read(&fix_parts).unwrap();
+        let mut fp = ffp as usize;
+        let fk1 = read_short(&fb, &mut fp);
+        let fk2 = read_short(&fb, &mut fp);
+        assert_eq!(fk1.len(), 16, "fixture keys are 16-byte UUIDs");
+        assert_eq!(fk2.len(), 16);
+        eprintln!(
+            "[#911 shape-parity] writer footer (firstPos={first_pos}, keyCount={key_count}, \
+             root={root}) and fixture footer (firstPos={ffp}, keyCount={fkc}, root={fr}) share \
+             the canonical Cassandra PartitionIndex layout."
+        );
+    } else {
+        eprintln!(
+            "[#911 note] committed da simple_table fixture not present (run \
+             test-data/scripts/fetch-datasets.sh); validated writer footer shape only."
+        );
+    }
+
+    // The writer must emit the canonical da component set, no Index/Summary.
+    assert!(info.index_path.is_none(), "BTI must not emit Index.db");
+    assert!(info.summary_path.is_none(), "BTI must not emit Summary.db");
+    assert!(info.rows_path.is_some(), "BTI must emit Rows.db");
+}

--- a/cqlite-core/tests/sstabledump_parity_summary.rs
+++ b/cqlite-core/tests/sstabledump_parity_summary.rs
@@ -544,11 +544,14 @@ async fn test_summary_via_write_engine() -> CqliteResult<()> {
     let info = engine.flush().await?.expect("Should return SSTableInfo");
 
     // Verify Summary.db exists
-    assert!(info.summary_path.exists(), "Summary.db should exist");
+    assert!(
+        info.summary_path.as_ref().unwrap().exists(),
+        "Summary.db should exist"
+    );
 
     // Read and verify
     let platform = Arc::new(Platform::new(&Config::default()).await?);
-    let reader = SummaryReader::open(&info.summary_path, platform).await?;
+    let reader = SummaryReader::open(info.summary_path.as_ref().unwrap(), platform).await?;
 
     let entries = reader.get_entries();
     assert!(!entries.is_empty(), "Summary.db should have entries");

--- a/cqlite-core/tests/sstableloader_integration.rs
+++ b/cqlite-core/tests/sstableloader_integration.rs
@@ -262,9 +262,9 @@ impl LoaderHarness {
 fn validate_flushed_components(info: &SSTableInfo) -> CqliteResult<()> {
     let required = [
         &info.data_path,
-        &info.index_path,
+        info.index_path.as_ref().unwrap(),
         &info.filter_path,
-        &info.summary_path,
+        info.summary_path.as_ref().unwrap(),
         &info.stats_path,
         &info.toc_path,
         &info.digest_path,

--- a/cqlite-core/tests/write_engine_integration_test.rs
+++ b/cqlite-core/tests/write_engine_integration_test.rs
@@ -100,9 +100,9 @@ async fn test_write_engine_end_to_end() -> Result<()> {
     assert_eq!(info.partition_count, 10);
     assert!(info.data_size > 0);
     assert!(info.data_path.exists());
-    assert!(info.index_path.exists());
+    assert!(info.index_path.as_ref().unwrap().exists());
     assert!(info.filter_path.exists());
-    assert!(info.summary_path.exists());
+    assert!(info.summary_path.as_ref().unwrap().exists());
     assert!(info.stats_path.exists());
     assert!(info.compression_info_path.is_none());
     assert!(info.toc_path.exists());
@@ -583,9 +583,15 @@ async fn test_stage0_write_read_roundtrip_simple_types() -> Result<()> {
 
     // Verify all component files were created
     assert!(info.data_path.exists(), "Data.db exists");
-    assert!(info.index_path.exists(), "Index.db exists");
+    assert!(
+        info.index_path.as_ref().unwrap().exists(),
+        "Index.db exists"
+    );
     assert!(info.filter_path.exists(), "Filter.db exists");
-    assert!(info.summary_path.exists(), "Summary.db exists");
+    assert!(
+        info.summary_path.as_ref().unwrap().exists(),
+        "Summary.db exists"
+    );
     assert!(info.stats_path.exists(), "Statistics.db exists");
     assert!(
         info.compression_info_path.is_none(),
@@ -708,7 +714,7 @@ async fn test_stage0_write_read_roundtrip_multiple_partitions() -> Result<()> {
     // === VALIDATION PHASE ===
     assert!(info.data_path.exists());
     assert!(
-        info.index_path.exists(),
+        info.index_path.as_ref().unwrap().exists(),
         "Index.db required for partition lookup"
     );
 
@@ -776,9 +782,9 @@ async fn test_stage0_sstable_format_validation() -> Result<()> {
     // 1. All required components exist
     let required_components = vec![
         ("Data.db", &info.data_path),
-        ("Index.db", &info.index_path),
+        ("Index.db", info.index_path.as_ref().unwrap()),
         ("Filter.db", &info.filter_path),
-        ("Summary.db", &info.summary_path),
+        ("Summary.db", info.summary_path.as_ref().unwrap()),
         ("Statistics.db", &info.stats_path),
         ("TOC.txt", &info.toc_path),
         ("Digest.crc32", &info.digest_path),
@@ -800,6 +806,8 @@ async fn test_stage0_sstable_format_validation() -> Result<()> {
     );
     assert!(
         info.index_path
+            .as_ref()
+            .unwrap()
             .to_str()
             .unwrap()
             .contains("nb-1-big-Index.db"),
@@ -834,7 +842,7 @@ async fn test_stage0_sstable_format_validation() -> Result<()> {
         "Data.db is non-empty"
     );
     assert!(
-        std::fs::metadata(&info.index_path)?.len() > 0,
+        std::fs::metadata(info.index_path.as_ref().unwrap())?.len() > 0,
         "Index.db is non-empty"
     );
     assert!(
@@ -937,7 +945,7 @@ async fn test_stage0_multi_partition_token_ordering() -> Result<()> {
 
     // === VALIDATION PHASE ===
     // Index.db should have partitions in token order
-    assert!(info.index_path.exists());
+    assert!(info.index_path.as_ref().unwrap().exists());
 
     Ok(())
 }

--- a/cqlite-core/tests/write_read_roundtrip/data_multi.rs
+++ b/cqlite-core/tests/write_read_roundtrip/data_multi.rs
@@ -107,7 +107,7 @@ async fn test_data_partitions_token_order() {
             .await
             .expect("Platform creation should succeed"),
     );
-    let index_reader = IndexReader::open(&info.index_path, platform)
+    let index_reader = IndexReader::open(info.index_path.as_ref().unwrap(), platform)
         .await
         .expect("IndexReader should open");
 
@@ -168,7 +168,7 @@ async fn test_data_index_offset_correctness() {
             .await
             .expect("Platform creation should succeed"),
     );
-    let index_reader = IndexReader::open(&info.index_path, platform)
+    let index_reader = IndexReader::open(info.index_path.as_ref().unwrap(), platform)
         .await
         .expect("IndexReader should open");
 
@@ -241,7 +241,7 @@ async fn test_data_many_partitions() {
             .await
             .expect("Platform creation should succeed"),
     );
-    let index_reader = IndexReader::open(&info.index_path, platform)
+    let index_reader = IndexReader::open(info.index_path.as_ref().unwrap(), platform)
         .await
         .expect("IndexReader should open");
 
@@ -320,7 +320,7 @@ async fn test_data_mixed_partition_sizes() {
             .await
             .expect("Platform creation should succeed"),
     );
-    let index_reader = IndexReader::open(&info.index_path, platform)
+    let index_reader = IndexReader::open(info.index_path.as_ref().unwrap(), platform)
         .await
         .expect("IndexReader should open");
 
@@ -475,7 +475,7 @@ async fn test_data_cross_component_validation() {
             .await
             .expect("Platform creation should succeed"),
     );
-    let index_reader = IndexReader::open(&info.index_path, platform.clone())
+    let index_reader = IndexReader::open(info.index_path.as_ref().unwrap(), platform.clone())
         .await
         .expect("IndexReader should open");
     assert_eq!(
@@ -498,7 +498,7 @@ async fn test_data_cross_component_validation() {
     let _filter = BloomFilter::deserialize(&filter_data).expect("Filter.db should deserialize");
 
     // Cross-validation 4: Summary.db has entries
-    let summary_reader = SummaryReader::open(&info.summary_path, platform)
+    let summary_reader = SummaryReader::open(info.summary_path.as_ref().unwrap(), platform)
         .await
         .expect("SummaryReader should open");
     assert!(

--- a/cqlite-core/tests/write_read_roundtrip/index.rs
+++ b/cqlite-core/tests/write_read_roundtrip/index.rs
@@ -168,7 +168,10 @@ async fn test_index_roundtrip_via_write_engine() {
         .expect("Should return SSTableInfo");
 
     // Verify Index.db exists
-    assert!(info.index_path.exists(), "Index.db should exist");
+    assert!(
+        info.index_path.as_ref().unwrap().exists(),
+        "Index.db should exist"
+    );
 
     // Read using IndexReader
     let config = cqlite_core::Config::default();
@@ -177,7 +180,7 @@ async fn test_index_roundtrip_via_write_engine() {
             .await
             .expect("Platform creation should succeed"),
     );
-    let reader = IndexReader::open(&info.index_path, platform)
+    let reader = IndexReader::open(info.index_path.as_ref().unwrap(), platform)
         .await
         .expect("IndexReader should open Index.db created by WriteEngine");
 

--- a/cqlite-core/tests/write_read_roundtrip/summary.rs
+++ b/cqlite-core/tests/write_read_roundtrip/summary.rs
@@ -182,7 +182,10 @@ async fn test_summary_roundtrip_via_write_engine() {
         .expect("Should return SSTableInfo");
 
     // Verify Summary.db exists
-    assert!(info.summary_path.exists(), "Summary.db should exist");
+    assert!(
+        info.summary_path.as_ref().unwrap().exists(),
+        "Summary.db should exist"
+    );
 
     // Read using SummaryReader
     let config = cqlite_core::Config::default();
@@ -191,7 +194,7 @@ async fn test_summary_roundtrip_via_write_engine() {
             .await
             .expect("Platform creation should succeed"),
     );
-    let reader = SummaryReader::open(&info.summary_path, platform)
+    let reader = SummaryReader::open(info.summary_path.as_ref().unwrap(), platform)
         .await
         .expect("SummaryReader should open Summary.db created by WriteEngine");
 

--- a/cqlite-core/tests/write_read_roundtrip/wide_partition.rs
+++ b/cqlite-core/tests/write_read_roundtrip/wide_partition.rs
@@ -84,7 +84,8 @@ async fn test_small_partition_no_promoted_index() {
         .expect("Flush should succeed")
         .expect("Should return SSTableInfo");
 
-    let index_bytes = std::fs::read(&info.index_path).expect("Should read Index.db");
+    let index_bytes =
+        std::fs::read(info.index_path.as_ref().unwrap()).expect("Should read Index.db");
     let promoted_len = first_entry_promoted_len(&index_bytes);
     assert_eq!(
         promoted_len, 0,
@@ -134,7 +135,8 @@ async fn test_wide_partition_emits_promoted_index() {
         .expect("Should return SSTableInfo");
 
     // ── 1. Index.db must have non-zero promoted_index_len ──────────────────
-    let index_bytes = std::fs::read(&info.index_path).expect("Should read Index.db");
+    let index_bytes =
+        std::fs::read(info.index_path.as_ref().unwrap()).expect("Should read Index.db");
     let promoted_len = first_entry_promoted_len(&index_bytes);
     assert!(
         promoted_len > 0,
@@ -152,10 +154,12 @@ async fn test_wide_partition_emits_promoted_index() {
             .await
             .expect("Platform creation"),
     );
-    let reader =
-        cqlite_core::storage::sstable::index_reader::IndexReader::open(&info.index_path, platform)
-            .await
-            .expect("IndexReader must open wide-partition Index.db without error");
+    let reader = cqlite_core::storage::sstable::index_reader::IndexReader::open(
+        info.index_path.as_ref().unwrap(),
+        platform,
+    )
+    .await
+    .expect("IndexReader must open wide-partition Index.db without error");
 
     let entries = reader.get_partition_entries();
     assert_eq!(

--- a/docs/sstables-definitive-guide/chapters/17-bti-formats.md
+++ b/docs/sstables-definitive-guide/chapters/17-bti-formats.md
@@ -194,12 +194,22 @@ These BTI facts are verified against CQLite's own reader
   from the current node position (children are written before parents / at lower
   offsets), consistent with the node-family table above.
 
-> **Scope note (CQLite-specific).** The items here describe CQLite's BTI **reader**.
-> CQLite's *write* path emits the classic `big`/`nb` format, not BTI; BTI writing is
-> out of scope (epic #762). The byte-invariant test
-> `issue_821_writer_byte_invariants.rs::finding16_bti_partition_leaf_data_offset_roundtrips_over_2gib`
-> only exercises the leaf `SizedInts` offset encoder in isolation to prove 64-bit
-> offset safety — it is not a full BTI writer.
+> **Scope note (CQLite-specific).** CQLite has both a BTI **reader** (the items
+> above) and, as of epic #872 (issues #908/#910), an opt-in BTI **writer**
+> (`SSTableWriter::with_format(.., SSTableFormat::Bti)`). The default write path
+> still emits classic `big`/`nb`. The BTI writer emits the canonical `da-*-bti-*`
+> set — `Data.db`, `Partitions.db`, `Rows.db`, `Statistics.db`, `Filter.db`,
+> `Digest.crc32`, `TOC.txt` — with the round-trip invariant proven against this
+> reader: `Partitions.db` leaves store a negative direct `Data.db` offset for
+> narrow partitions and a positive `RowsOffset` for wide ones; `Rows.db` holds
+> one per-partition `TrieIndexEntry` + row-index trie per wide partition, and is
+> emitted as a 0-byte component when no partition is wide (matching the real
+> `da-2-bti-Rows.db` fixtures). A wide partition is one spanning `>= 2`
+> `column_index_size` (64 KiB) blocks, mirroring `RowIndexEntry.create()`. An
+> empty BTI write (zero partitions) is refused, since a `da` SSTable has no
+> readable zero-partition `Partitions.db` form. See
+> `cqlite-core/src/storage/sstable/writer/partitions_writer.rs` (`RowsTrieWriter`)
+> and `tests/issue_908_bti_canonical_write.rs`.
 
 ### Row index granularity
 

--- a/test-data/validation-matrix.md
+++ b/test-data/validation-matrix.md
@@ -2,7 +2,7 @@
 
 **Comprehensive validation tracking for all test tables across the CQLite test suite**
 
-**Last Updated**: 2026-06-20 (After Issue #699 review — test_deltas adjacent_ranges table added for boundary-marker coverage)
+**Last Updated**: 2026-06-20 (Issue #911 — BTI write-path parity vs Cassandra 5 sstabledump added; see "BTI write-path parity")
 **Issue Reference**: [#200](https://github.com/pmcfadin/cqlite/issues/200) - Validate all 33 test tables can be loaded successfully
 **Current Status**: 39/39 PASS (100% pass rate across nb+oa corpus) — test_deltas (9 tables) skip-pending until dataset asset published (#701)
 
@@ -156,8 +156,11 @@ Example row from `test_basic.ttl_test_table`:
 ### TTL fixture gap (da/BTI format)
 
 The `test_da` keyspace contains a `ttl_table` in da/BTI format that has TTL cells.
-BTI (da) Data.db format is **not yet supported** by the CQLite reader.
-No da-format TTL parity test is included here.
+At the time of issue #694 the BTI (da) Data.db read path was not yet exercised
+here, so no da-format TTL parity test was included. (Reader-side BTI discovery
+landed in #831/#909, and CQLite now also WRITES canonical `da` BTI SSTables
+validated against Cassandra 5 sstabledump — see "BTI write-path parity" below.
+A da-format TTL WRITETIME parity test remains future work.)
 
 Readable TTL fixtures tested above:
 - `test_basic.ttl_test_table` (nb, default_time_to_live=86400) — WRITETIME+TTL both validated
@@ -165,6 +168,66 @@ Readable TTL fixtures tested above:
 - `test_timeseries.log_entries` (nb, default_time_to_live=604800) — not separately tested
 
 No new SSTable fixtures were generated for this issue (Docker/Cassandra required for new data).
+
+---
+
+## BTI write-path parity (Epic #872 / issue #911)
+
+**Added**: 2026-06-20
+
+CQLite now WRITES Cassandra-canonical BTI SSTables (`da-*-bti-*`: `Data.db` +
+`Partitions.db` + `Rows.db`, no `Index.db`/`Summary.db` — #908/#910), reads them
+back through its own `SSTableReader` (#909), AND the output is validated against a
+**real Cassandra 5 reader** (`sstabledump`) — closing epic #872 (#911). This is
+the write-path counterpart to the read-path corpus above, which is exercised only
+by `nb`/`oa` BIG fixtures.
+
+### Write-path parity coverage
+
+| Write path | Format | Reader validated against | Status | Test |
+|-----------|--------|--------------------------|--------|------|
+| BTI narrow + wide partitions | `da` (BTI) | Cassandra 5 `sstabledump` (Docker-gated) | ✅ 2 partitions, 1 narrow + 200 wide rows, values intact | `issue_911_bti_sstabledump_parity::bti_writer_output_reads_under_cassandra5_sstabledump` |
+| BTI narrow-only (no clustering, 0-byte Rows.db) | `da` (BTI) | Cassandra 5 `sstabledump` (Docker-gated) | ✅ 5 partitions, values intact | `issue_911_bti_sstabledump_parity::bti_narrow_only_writer_output_reads_under_cassandra5_sstabledump` |
+| BTI `Partitions.db` canonical footer shape | `da` (BTI) | committed real `da` fixture (no Docker) | ✅ `[firstPos\|keyCount\|root]` + first/last keys shape match | `issue_911_bti_sstabledump_parity::bti_writer_partition_index_footer_matches_cassandra_fixture_shape` |
+| BTI writer→reader roundtrip (CQLite reader) | `da` (BTI) | CQLite `SSTableReader` | ✅ full scan + point lookup | `issue_909_bti_reader_roundtrip` |
+| BTI canonical component set / TOC / descriptor | `da` (BTI) | structural | ✅ | `issue_908_bti_canonical_write` |
+
+### What #911 fixed (surfaced BY the sstabledump gate)
+
+Running a writer-produced `da` SSTable through `sstabledump` exposed two
+canonical-write defects that CQLite's own reader did not catch (it never
+deserialises these structures):
+
+1. **`Statistics.db` STATS layout** — the writer emitted the legacy `nb`
+   `StatsMetadata` body for a `da` descriptor; Cassandra's `da` deserialiser hit a
+   `Slice.<init>` assertion reading `coveredClustering`. Fixed by emitting the
+   BtiFormat `StatsMetadata` layout (uint deletion times, `clusteringTypes` +
+   covered-clustering `Slice`, key range, token-space coverage). `sstablemetadata`
+   now reports `Covered clusterings: [, ]`, correct First/Last token, totalRows.
+2. **`Partitions.db` footer** — the writer wrote an 8-byte root-offset footer;
+   Cassandra's `PartitionIndex.load` requires the 24-byte
+   `[firstPos\|keyCount\|root]` footer with first/last keys at `firstPos`. Fixed in
+   `PartitionsTrieWriter::finish`. The trie node encoding was already
+   Cassandra-compatible; the final 8 bytes stay `root`, so CQLite's own
+   footer-based reader is unaffected.
+
+### How CI validates this (live Cassandra readback)
+
+The `sstabledump` tests are **Docker-gated** (skip cleanly when Docker / a
+`cassandra:5.0` image is absent), mirroring `issue_819_differential_compaction`'s
+`CQLITE_DIFFERENTIAL_CASSANDRA` switch and `e2e-cassandra-readback.sh`. To run the
+live readback (a `cassandra:5.0` or `cassandra:5.0.x` image must be present
+locally; the test does not pull it):
+
+```bash
+env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets \
+  cargo test --package cqlite-core --features write-support \
+  --test issue_911_bti_sstabledump_parity -- --test-threads=1
+```
+
+`sstabledump` lives at `/opt/cassandra/tools/bin/sstabledump` inside the image and
+is invoked via `docker run --entrypoint`. The no-Docker footer-shape test always
+runs and cross-checks the real committed `da` fixture when fetched.
 
 ---
 


### PR DESCRIPTION
Completes epic #872 — the BTI write path now emits **Cassandra-canonical `da`-format BTI SSTables** (not the phase-1 hybrid), validated by live Cassandra 5 readback.

## Children (all complete, each roborev-reviewed clean)
- **#908** — canonical `da-*-bti-*` descriptor, BTI `Data.db`, drop `Index.db`/`Summary.db`, format-aware TOC; canonical partition filter hash byte (`DecoratedKey.filterHashLowerBits` = low byte of murmur3 `h2`), verified against a real Cassandra `da` fixture.
- **#910** — `Rows.db` within-partition clustering trie. Wide partitions (≥2× 64 KiB column-index blocks, per `RowIndexEntry.create`) use a positive `RowsOffset`; narrow partitions keep a direct `DataOffset`. Separators encoded with clustering order (DESC/mixed via `ReversedType` byte inversion). Empty/0-byte `Rows.db` matches real Cassandra fixtures; zero-partition BTI is refused.
- **#909** — `SSTableReader` discovers `da`/BTI descriptors and opens via the partition trie; enabled the previously-gated `RowsOffset` read path. Writer→reader roundtrip test (full scan + point lookup, narrow + wide).
- **#911** — live **Cassandra 5 `sstabledump`** readback of writer-produced `da-*` SSTables (Docker-gated). This surfaced and fixed two real defects: legacy `nb` `Statistics.db` body under a `da` descriptor, and an 8-byte vs canonical 24-byte `PartitionIndex` footer; plus `hasPartitionLevelDeletions` marker + modern tombstone-histogram encoding. Validation matrix updated.

## Validation
- `scripts/agent-gate.sh` on final HEAD: fmt / clippy / core-tests / integration / format-compat / write-tests / cli-tests / minimal-build / smoke all **PASS**.
- Only `python-bindings` FAILs — a **pre-existing, environment-only** PEP 604 (`Path | None`) collection error in `bindings/python/tests/test_parity.py` on Python 3.9.6. That line exists on `main`; this branch changes **no** Python files.
- All commits reviewed by roborev; final per-commit verdicts: **no issues**.

## Scope
- BIG (default) format output is byte-identical; all changes gated behind `SSTableFormat::Bti`.
- `origin/main..HEAD` touches only `cqlite-core/`, the BTI guide chapter, and the validation matrix.

Closes #908, #909, #910, #911. Completes epic #872.
