### PR TITLE
perf(storage): restore parallel reads on a single SSTableReader (#815)

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/data_access.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access.rs
@@ -3,6 +3,7 @@
 //! This module contains all methods related to reading data from SSTables,
 //! including point lookups, range scans, and sequential access.
 
+use super::source::ScanCursor;
 use super::SSTableReader;
 use crate::parser::DataFormat;
 use crate::types::{CellWriteMetadata, TableId, Value};
@@ -325,7 +326,7 @@ impl SSTableReader {
     /// Chunk targeting (the fast path): when `CompressionInfo` with a non-zero
     /// `chunk_length` is present, the chunk containing `offset` is
     /// `target_chunk = offset / chunk_length`; we seek that chunk via its
-    /// `chunk_offsets` entry, set `current_chunk_index = target_chunk`, then
+    /// `chunk_offsets` entry, set the cursor's chunk index to `target_chunk`, then
     /// decompress forward chunk-by-chunk, appending each into `window`. After each
     /// appended chunk we attempt to parse the FIRST partition at `window[within..]`
     /// (`within = offset % chunk_length`). The stop condition (correctness-critical
@@ -342,8 +343,9 @@ impl SSTableReader {
     /// decompresses the WHOLE section via [`stitch_all_chunks`] (`window_base = 0`)
     /// and runs the same single-partition parse.
     ///
-    /// Serialises against other scans (shared file position + chunk index) by
-    /// holding `scan_mutex` for the whole operation (issue #805).
+    /// Uses its own per-scan [`ScanCursor`] (private file position + chunk
+    /// index), so concurrent lookups run in parallel without serialization
+    /// (issue #815).
     async fn bti_decompress_and_parse_target(
         &self,
         offset: usize,
@@ -354,7 +356,9 @@ impl SSTableReader {
     ) -> Result<Option<Value>> {
         use crate::storage::sstable::compression::Compression;
 
-        let _scan_guard = self.scan_mutex.lock().await;
+        // Issue #815: each lookup uses its own cursor so concurrent lookups on
+        // this reader never share a mutable file position / chunk index.
+        let cursor = self.new_scan_cursor().await?;
 
         // Determine the chunk-targeting parameters. `chunk_length == 0` (or no
         // CompressionInfo) means we cannot chunk-target -> whole-section fallback.
@@ -382,10 +386,11 @@ impl SSTableReader {
                         ))
                     })?;
                 {
-                    let mut file_guard = self.file.lock().await;
+                    let mut file_guard = cursor.file.lock().await;
                     file_guard.seek(SeekFrom::Start(chunk_start)).await?;
                 }
-                self.current_chunk_index
+                cursor
+                    .chunk_index
                     .store(target_chunk, std::sync::atomic::Ordering::Relaxed);
                 (target_chunk, window_base, Vec::<u8>::new())
             }
@@ -393,12 +398,10 @@ impl SSTableReader {
                 // Whole-section fallback (uncompressed BTI, or chunk_length absent/0).
                 let header_size = self.calculate_header_size();
                 {
-                    let mut file_guard = self.file.lock().await;
+                    let mut file_guard = cursor.file.lock().await;
                     file_guard.seek(SeekFrom::Start(header_size as u64)).await?;
                 }
-                self.current_chunk_index
-                    .store(0, std::sync::atomic::Ordering::Relaxed);
-                let whole = self.stitch_all_chunks().await?;
+                let whole = self.stitch_all_chunks(&cursor).await?;
                 (0usize, 0usize, whole)
             }
         };
@@ -420,7 +423,7 @@ impl SSTableReader {
             // If chunk-targeted, append the next chunk before each parse attempt
             // (the whole-section fallback already has all bytes in `window`).
             if chunk_targeted {
-                match self.read_next_block().await? {
+                match self.read_next_block(&cursor).await? {
                     Some(compressed_chunk) => {
                         let decompressed_chunk = if let Some(compression_reader) =
                             &self.compression_reader
@@ -594,8 +597,8 @@ impl SSTableReader {
     /// Murmur3 token order and truncated to `limit` — identical post-processing
     /// to the V5CompressedLegacy stitched path.
     ///
-    /// Holds `scan_mutex` for the whole operation because it advances the shared
-    /// file position and `current_chunk_index` (issue #805).
+    /// Uses its own per-scan [`ScanCursor`], so it runs in parallel with other
+    /// scans on this reader without serialization (issue #815).
     ///
     /// [`parse_block_with_cell_metadata`]: crate::storage::sstable::reader::parsing::V5CompressedLegacyParser::parse_block_with_cell_metadata
     async fn bti_scan_with_metadata(
@@ -611,18 +614,16 @@ impl SSTableReader {
             std::collections::HashMap<String, CellWriteMetadata>,
         )>,
     > {
-        let _scan_guard = self.scan_mutex.lock().await;
+        let cursor = self.new_scan_cursor().await?;
 
         // Decompress the entire data section. Precondition for stitch_all_chunks:
-        // file seeked to data-section start, current_chunk_index reset to 0.
+        // cursor's file seeked to data-section start (fresh cursor is at chunk 0).
         let header_size = self.calculate_header_size();
         {
-            let mut file_guard = self.file.lock().await;
+            let mut file_guard = cursor.file.lock().await;
             file_guard.seek(SeekFrom::Start(header_size as u64)).await?;
         }
-        self.current_chunk_index
-            .store(0, std::sync::atomic::Ordering::Relaxed);
-        let whole = self.stitch_all_chunks().await?;
+        let whole = self.stitch_all_chunks(&cursor).await?;
 
         // Resolve schema via the four-tier strategy (provided > header > registry).
         // V5CompressedLegacy partition decode requires a schema (cells lack names).
@@ -814,9 +815,8 @@ impl SSTableReader {
     pub async fn get_all_entries(&self) -> Result<Vec<(TableId, RowKey, Value)>> {
         // Issue #660: BTI ("da") tables have no Index.db; route through the
         // whole-Data.db BTI scan, which resolves schema via get_table_schema
-        // (header/registry) and decodes every partition. `bti_scan_with_metadata`
-        // takes `scan_mutex` itself, so this branch runs BEFORE the lock below to
-        // avoid re-entrant deadlock.
+        // (header/registry) and decodes every partition. It mints its own
+        // per-scan cursor, as does the non-BTI path below (issue #815).
         if self.bti_partitions_db.is_some() {
             let table_id = TableId::new(format!(
                 "{}.{}",
@@ -829,20 +829,17 @@ impl SSTableReader {
                 .collect());
         }
 
-        // Issue #805: serialise concurrent scans (shared file position + chunk index).
-        let _scan_guard = self.scan_mutex.lock().await;
+        // Issue #815: independent per-scan cursor — no cross-scan serialization.
+        let cursor = self.new_scan_cursor().await?;
 
         let mut results = Vec::new();
 
         // Reset to beginning of data section
         let header_size = self.calculate_header_size();
         {
-            let mut file_guard = self.file.lock().await;
+            let mut file_guard = cursor.file.lock().await;
             file_guard.seek(SeekFrom::Start(header_size as u64)).await?;
         }
-        // Reset chunk index when seeking to start
-        self.current_chunk_index
-            .store(0, std::sync::atomic::Ordering::Relaxed);
 
         if self.requires_chunk_stitching() {
             // V5CompressedLegacy: Row payloads can span multiple compressed chunks
@@ -852,11 +849,11 @@ impl SSTableReader {
             );
 
             // Use shared stitching helper method
-            let entries = self.stitch_and_parse_all_chunks(None).await?;
+            let entries = self.stitch_and_parse_all_chunks(&cursor, None).await?;
             results.extend(entries);
         } else {
             // Other formats: Read and parse blocks individually
-            while let Some(block) = self.read_next_block().await? {
+            while let Some(block) = self.read_next_block(&cursor).await? {
                 let entries = self.parse_block_entries(&block, None)?;
                 results.extend(entries);
             }
@@ -876,9 +873,10 @@ impl SSTableReader {
     /// format where partitions can span chunk boundaries.
     async fn stitch_and_parse_all_chunks(
         &self,
+        cursor: &ScanCursor,
         schema: Option<&crate::schema::TableSchema>,
     ) -> Result<Vec<(TableId, RowKey, Value)>> {
-        let stitched_buffer = self.stitch_all_chunks().await?;
+        let stitched_buffer = self.stitch_all_chunks(cursor).await?;
         let parser = self.build_v5_parser();
 
         // Get schema (use provided schema or reader's schema)
@@ -905,6 +903,7 @@ impl SSTableReader {
     /// Used when `ProjectionFlags::include_cell_metadata` is set (issue #693).
     async fn stitch_and_parse_all_chunks_with_metadata(
         &self,
+        cursor: &ScanCursor,
         schema: Option<&crate::schema::TableSchema>,
     ) -> Result<
         Vec<(
@@ -914,7 +913,7 @@ impl SSTableReader {
             std::collections::HashMap<String, CellWriteMetadata>,
         )>,
     > {
-        let stitched_buffer = self.stitch_all_chunks().await?;
+        let stitched_buffer = self.stitch_all_chunks(cursor).await?;
         let parser = self.build_v5_parser();
 
         let reader_schema;
@@ -943,16 +942,16 @@ impl SSTableReader {
     /// bounded by the *uncompressed data-section size* — it scales with on-disk
     /// bytes, not row count (issue #790).
     ///
-    /// Precondition: the caller has seeked the file to the start of the data
-    /// section and reset `current_chunk_index` to 0.
-    async fn stitch_all_chunks(&self) -> Result<Vec<u8>> {
+    /// Precondition: the caller has seeked `cursor`'s file to the start of the
+    /// data section (the cursor's chunk index starts at 0 when freshly minted).
+    async fn stitch_all_chunks(&self, cursor: &ScanCursor) -> Result<Vec<u8>> {
         use crate::storage::sstable::compression::Compression;
 
         // Pre-allocate buffer for ~2.5MB (estimated max size for test data)
         let mut stitched_buffer = Vec::with_capacity(2_500_000);
 
         let mut chunk_count = 0;
-        while let Some(compressed_chunk) = self.read_next_block().await? {
+        while let Some(compressed_chunk) = self.read_next_block(cursor).await? {
             let decompressed_chunk = if let Some(compression_reader) = &self.compression_reader {
                 let compression = Compression::new(*compression_reader.algorithm())?;
                 match compression.decompress(&compressed_chunk) {
@@ -1062,23 +1061,21 @@ impl SSTableReader {
         schema: Option<crate::schema::TableSchema>,
         tx: mpsc::Sender<Result<(RowKey, Value)>>,
     ) -> Result<()> {
-        // Issue #805: serialise concurrent scans (shared file position + chunk index).
-        let _scan_guard = self.scan_mutex.lock().await;
+        // Issue #815: independent per-scan cursor — no cross-scan serialization.
+        let cursor = self.new_scan_cursor().await?;
 
         // Position at the start of the data section (mirrors sequential_scan).
         let header_size = self.calculate_header_size();
         {
-            let mut file_guard = self.file.lock().await;
+            let mut file_guard = cursor.file.lock().await;
             file_guard.seek(SeekFrom::Start(header_size as u64)).await?;
         }
-        self.current_chunk_index
-            .store(0, std::sync::atomic::Ordering::Relaxed);
 
         if self.requires_chunk_stitching() {
             // Stitch the (bounded) data section, then parse on a blocking thread,
             // emitting one entry at a time. `blocking_send` provides backpressure
             // so parsed Values are never all live at once.
-            let stitched = self.stitch_all_chunks().await?;
+            let stitched = self.stitch_all_chunks(&cursor).await?;
             let reader = std::sync::Arc::clone(&self);
             let parse = tokio::task::spawn_blocking(move || {
                 reader.parse_stitched_stream(&stitched, schema.as_ref(), start_key, end_key, &tx)
@@ -1093,7 +1090,7 @@ impl SSTableReader {
         } else {
             // Non-stitching formats already read block-by-block; emit per block so
             // only one block's entries are live at a time.
-            while let Some(block) = self.read_next_block().await? {
+            while let Some(block) = self.read_next_block(&cursor).await? {
                 let entries = self.parse_block_entries_with_schema(&block, schema.as_ref())?;
                 for (entry_table_id, entry_key, entry_value) in entries {
                     if !table_ids_match(&entry_table_id, &table_id) {
@@ -1177,6 +1174,7 @@ impl SSTableReader {
     /// Used exclusively by the compaction k-way merger path (Issue #505).
     async fn stitch_and_parse_all_chunks_for_compaction(
         &self,
+        cursor: &ScanCursor,
         schema: Option<&crate::schema::TableSchema>,
     ) -> Result<Vec<(TableId, RowKey, Value, i64)>> {
         log::debug!("stitch_and_parse_all_chunks_for_compaction: stitching chunks");
@@ -1184,7 +1182,7 @@ impl SSTableReader {
         let mut stitched_buffer = Vec::with_capacity(2_500_000);
         let mut chunk_count = 0;
 
-        while let Some(compressed_chunk) = self.read_next_block().await? {
+        while let Some(compressed_chunk) = self.read_next_block(cursor).await? {
             use crate::storage::sstable::compression::Compression;
             let decompressed_chunk = if let Some(compression_reader) = &self.compression_reader {
                 let compression = Compression::new(*compression_reader.algorithm())?;
@@ -1284,20 +1282,19 @@ impl SSTableReader {
             // can pass it to the async helper without borrow-checker issues.
             let owned_schema = schema.cloned().or_else(|| self.get_table_schema(None));
 
-            // Reset chunk reader to start of data section.
+            // Reset chunk reader to start of data section (own per-scan cursor).
+            let cursor = self.new_scan_cursor().await?;
             let header_size = self.calculate_header_size();
             {
-                let mut file_guard = self.file.lock().await;
+                let mut file_guard = cursor.file.lock().await;
                 use tokio::io::AsyncSeekExt;
                 file_guard
                     .seek(std::io::SeekFrom::Start(header_size as u64))
                     .await?;
             }
-            self.current_chunk_index
-                .store(0, std::sync::atomic::Ordering::Relaxed);
 
             let entries = self
-                .stitch_and_parse_all_chunks_for_compaction(owned_schema.as_ref())
+                .stitch_and_parse_all_chunks_for_compaction(&cursor, owned_schema.as_ref())
                 .await?;
 
             return Ok(entries
@@ -1348,14 +1345,13 @@ impl SSTableReader {
         F: FnMut(RowKey, Value, i64) -> Result<std::ops::ControlFlow<()>>,
     {
         // Reset chunk reader to the start of the data section (mirrors
-        // iterate_all_partitions_for_compaction).
+        // iterate_all_partitions_for_compaction) using an own per-scan cursor.
+        let cursor = self.new_scan_cursor().await?;
         let header_size = self.calculate_header_size();
         {
-            let mut file_guard = self.file.lock().await;
+            let mut file_guard = cursor.file.lock().await;
             file_guard.seek(SeekFrom::Start(header_size as u64)).await?;
         }
-        self.current_chunk_index
-            .store(0, std::sync::atomic::Ordering::Relaxed);
 
         // Non-stitching formats are single-block / small: emit via the
         // materialising iterator with ts=0 (matches the Vec-variant fallback).
@@ -1379,7 +1375,7 @@ impl SSTableReader {
 
         use crate::storage::sstable::compression::Compression;
         let mut chunk_count = 0;
-        while let Some(compressed_chunk) = self.read_next_block().await? {
+        while let Some(compressed_chunk) = self.read_next_block(&cursor).await? {
             let decompressed_chunk = if let Some(compression_reader) = &self.compression_reader {
                 let compression = Compression::new(*compression_reader.algorithm())?;
                 compression.decompress(&compressed_chunk).map_err(|e| {
@@ -1609,8 +1605,8 @@ impl SSTableReader {
         // path never reaches the sequential scan.
         SCAN_FOR_KEY_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
-        // Issue #805: serialise concurrent scans (shared file position + chunk index).
-        let _scan_guard = self.scan_mutex.lock().await;
+        // Issue #815: independent per-scan cursor — no cross-scan serialization.
+        let cursor = self.new_scan_cursor().await?;
 
         let header_size = self.calculate_header_size();
 
@@ -1623,28 +1619,24 @@ impl SSTableReader {
             log::debug!(
                 "scan_for_key: V5CompressedLegacy NB detected, using stitched buffer for key lookup"
             );
-            // `stitch_all_chunks` reads from the CURRENT file position forward, so
-            // its precondition is "seeked to the data-section start, chunk index 0"
-            // (mirrors sequential_scan / scan_stream). A prior scan on this reader
-            // leaves the shared file position at end-of-data and the chunk index
-            // advanced; without resetting BOTH, the stitch reads zero chunks and
-            // every key falsely misses — making a get() after a scan() return None
-            // even though the partition exists (e.g. AlwaysPresentFilter tables
-            // where the bloom gate no longer short-circuits the lookup). Reset the
-            // file position too, not just the chunk index.
+            // `stitch_all_chunks` reads from the CURRENT cursor position forward,
+            // so its precondition is "seeked to the data-section start" (the fresh
+            // cursor's chunk index already starts at 0). Each call uses its own
+            // cursor (issue #815), so there is no cross-call position to reset.
             {
-                let mut file_guard = self.file.lock().await;
+                let mut file_guard = cursor.file.lock().await;
                 file_guard.seek(SeekFrom::Start(header_size as u64)).await?;
             }
-            self.current_chunk_index
-                .store(0, std::sync::atomic::Ordering::Relaxed);
 
             // Pass the reader's own schema so that V5CompressedLegacy rows can be fully
             // parsed and their partition RowKeys emitted.  Without a schema, parse_row_v5
             // fails for all rows in a partition, causing no entries to be pushed and making
             // the key comparison always miss even when the key exists.
             let schema_opt = self.get_table_schema(None);
-            let all_entries = match self.stitch_and_parse_all_chunks(schema_opt.as_ref()).await {
+            let all_entries = match self
+                .stitch_and_parse_all_chunks(&cursor, schema_opt.as_ref())
+                .await
+            {
                 Ok(entries) => entries,
                 Err(e) => {
                     // Schema may not be available for this reader (e.g., wrong table type).
@@ -1683,15 +1675,12 @@ impl SSTableReader {
         }
 
         {
-            let mut file_guard = self.file.lock().await;
+            let mut file_guard = cursor.file.lock().await;
             file_guard.seek(SeekFrom::Start(header_size as u64)).await?;
         }
-        // Reset chunk index when seeking to start
-        self.current_chunk_index
-            .store(0, std::sync::atomic::Ordering::Relaxed);
 
         // Sequential scan through blocks
-        while let Some(block) = self.read_next_block().await? {
+        while let Some(block) = self.read_next_block(&cursor).await? {
             let entries = self.parse_block_entries(&block, None)?;
 
             for (entry_table_id, entry_key, entry_value) in entries {
@@ -1727,11 +1716,10 @@ impl SSTableReader {
             schema.is_some()
         );
 
-        // Issue #805: Serialise concurrent sequential scans on this reader.
-        // The file seek-position and current_chunk_index are shared state;
-        // two concurrent callers advancing them simultaneously corrupt each
-        // other's reads. Hold the scan_mutex for the full scan lifetime.
-        let _scan_guard = self.scan_mutex.lock().await;
+        // Issue #815: each scan uses its own cursor (private file position and
+        // chunk index), so concurrent scans on this reader run in parallel
+        // without the per-scan serialization #805 introduced for correctness.
+        let cursor = self.new_scan_cursor().await?;
 
         let mut results = Vec::new();
 
@@ -1742,16 +1730,13 @@ impl SSTableReader {
         );
 
         {
-            let mut file_guard = self.file.lock().await;
+            let mut file_guard = cursor.file.lock().await;
             file_guard.seek(SeekFrom::Start(header_size as u64)).await?;
             log::debug!(
                 "SSTableReader::sequential_scan - Seeked to start of data section at offset {}",
                 header_size
             );
         }
-        // Reset chunk index when seeking to start
-        self.current_chunk_index
-            .store(0, std::sync::atomic::Ordering::Relaxed);
 
         // CRITICAL FIX: V5CompressedLegacy partitions can span chunk boundaries.
         // We must stitch all chunks together before parsing to avoid dropping partitions.
@@ -1767,7 +1752,7 @@ impl SSTableReader {
             );
 
             // Stitch all chunks together (reuse logic from get_all_entries)
-            let all_entries = self.stitch_and_parse_all_chunks(schema).await?;
+            let all_entries = self.stitch_and_parse_all_chunks(&cursor, schema).await?;
             log::debug!(
                 "SSTableReader::sequential_scan - Stitched parsing returned {} total entries",
                 all_entries.len()
@@ -1818,7 +1803,7 @@ impl SSTableReader {
 
         // Non-stitching path for other formats
         let mut block_count = 0;
-        while let Some(block) = self.read_next_block().await? {
+        while let Some(block) = self.read_next_block(&cursor).await? {
             block_count += 1;
             log::debug!(
                 "SSTableReader::sequential_scan - Read block {}, size {} bytes",
@@ -1938,20 +1923,19 @@ impl SSTableReader {
                 .await;
         }
 
-        let _scan_guard = self.scan_mutex.lock().await;
+        // Issue #815: independent per-scan cursor — no cross-scan serialization.
+        let cursor = self.new_scan_cursor().await?;
 
         let header_size = self.calculate_header_size();
         {
-            let mut file_guard = self.file.lock().await;
+            let mut file_guard = cursor.file.lock().await;
             file_guard.seek(SeekFrom::Start(header_size as u64)).await?;
         }
-        self.current_chunk_index
-            .store(0, std::sync::atomic::Ordering::Relaxed);
 
         // V5CompressedLegacy (stitching) path — the common path for Cassandra 5.0 SSTables.
         if self.requires_chunk_stitching() {
             let all_entries = self
-                .stitch_and_parse_all_chunks_with_metadata(schema)
+                .stitch_and_parse_all_chunks_with_metadata(&cursor, schema)
                 .await?;
 
             let mut results = Vec::new();
@@ -1995,29 +1979,41 @@ impl SSTableReader {
             .collect())
     }
 
-    /// Read next block with enhanced error handling and streaming support
-    pub(super) async fn read_next_block(&self) -> Result<Option<Vec<u8>>> {
+    /// Mint a fresh, independent cursor for one scan (issue #815).
+    ///
+    /// Each cursor owns a private file handle (or mmap cursor) and chunk index,
+    /// so concurrent scans on this reader never share a mutable file position —
+    /// they run in parallel without the per-scan serialization #805 required.
+    pub(super) async fn new_scan_cursor(&self) -> Result<ScanCursor> {
+        Ok(ScanCursor::new(
+            self.scan_source.open(&self.file_path).await?,
+        ))
+    }
+
+    /// Read the next block from a scan-local `cursor` (its own file position and
+    /// chunk index). See [`Self::new_scan_cursor`].
+    pub(super) async fn read_next_block(&self, cursor: &ScanCursor) -> Result<Option<Vec<u8>>> {
         use super::block_io;
         block_io::read_next_block(
-            &self.file,
+            &cursor.file,
             &self.header.cassandra_version,
             &self.config,
             &self.compression_info,
-            &self.current_chunk_index,
+            &cursor.chunk_index,
             self.actual_header_size as u64,
         )
         .await
     }
 
-    /// Prepare for a delta-scan pass: seek to the data-section start, reset
-    /// the chunk index, stitch all compressed chunks, and return the
-    /// decompressed buffer together with a pre-configured parser.
+    /// Prepare for a delta-scan pass: stitch all compressed chunks of the data
+    /// section and return the decompressed buffer together with a pre-configured
+    /// parser.
     ///
-    /// The caller is responsible for holding `scan_mutex` for the lifetime of
-    /// the returned buffer (matching the existing compaction-path contract —
-    /// issue #805).  This method is gated on the `delta-scan` feature and is
-    /// the only bridge between the SSTableReader internals and the
-    /// `delta_scan` module, which cannot access private helpers directly.
+    /// Uses its own per-scan cursor (issue #815), so it no longer needs the
+    /// caller to serialize against concurrent reads. This method is gated on the
+    /// `delta-scan` feature and is the only bridge between the SSTableReader
+    /// internals and the `delta_scan` module, which cannot access private
+    /// helpers directly.
     ///
     /// The `schema` parameter is not used here — it is threaded through the
     /// caller's `parse_block_emit_delta` invocation instead.  The parser is
@@ -2029,34 +2025,24 @@ impl SSTableReader {
     ) -> Result<(Vec<u8>, super::parsing::V5CompressedLegacyParser)> {
         use tokio::io::AsyncSeekExt;
 
-        // Seek to the start of the data section and reset the chunk index.
+        // Seek the per-scan cursor to the start of the data section.
+        let cursor = self.new_scan_cursor().await?;
         let header_size = self.calculate_header_size();
         {
-            let mut file_guard = self.file.lock().await;
+            let mut file_guard = cursor.file.lock().await;
             file_guard
                 .seek(std::io::SeekFrom::Start(header_size as u64))
                 .await?;
         }
-        self.current_chunk_index
-            .store(0, std::sync::atomic::Ordering::Relaxed);
 
         // Stitch all compressed chunks (bounded by uncompressed data-section size).
-        let stitched = self.stitch_all_chunks().await?;
+        let stitched = self.stitch_all_chunks(&cursor).await?;
 
         // Build a parser (re-using the existing builder so version-gates and
         // UDT registry are threaded through correctly).
         let parser = self.build_v5_parser();
 
         Ok((stitched, parser))
-    }
-
-    /// Return the `scan_mutex` guard for external callers that need to
-    /// serialise a delta-scan pass against concurrent reads.
-    ///
-    /// Gated on `delta-scan` — only the delta-scan path needs this.
-    #[cfg(feature = "delta-scan")]
-    pub fn delta_scan_mutex(&self) -> &tokio::sync::Mutex<()> {
-        &self.scan_mutex
     }
 }
 

--- a/cqlite-core/src/storage/sstable/reader/delta_scan.rs
+++ b/cqlite-core/src/storage/sstable/reader/delta_scan.rs
@@ -590,14 +590,10 @@ async fn run_scan_delta(
     // same allocation rather than cloning the struct twice.
     let schema_arc = std::sync::Arc::new(schema);
 
-    // Stitch + parse with mutex held for the stitch (issue #805), then release.
-    // The parsing itself is synchronous and moves into spawn_blocking; it does
-    // not need the scan mutex since we already have the full stitched buffer.
-    let (stitched, parser) = {
-        let _scan_guard = reader.delta_scan_mutex().lock().await;
-        reader.prepare_delta_scan().await?
-        // _scan_guard dropped here after stitching is complete.
-    };
+    // Stitch + parse using a private per-scan cursor (issue #815): no scan-wide
+    // mutex needed because the cursor owns its own file position / chunk index.
+    // The parsing itself is synchronous and moves into spawn_blocking.
+    let (stitched, parser) = reader.prepare_delta_scan().await?;
 
     let schema_for_parse = std::sync::Arc::clone(&schema_arc);
     let reader_arc = std::sync::Arc::clone(&reader);

--- a/cqlite-core/src/storage/sstable/reader/integrity.rs
+++ b/cqlite-core/src/storage/sstable/reader/integrity.rs
@@ -62,21 +62,18 @@ impl SSTableReader {
             overall_status: IntegrityStatus::Healthy,
         };
 
-        // Save current position
-        let original_position = {
-            let mut file_guard = self.file.lock().await;
-            file_guard.stream_position().await.unwrap_or(0)
-        };
-
-        // Reset to data section
+        // Read through a private per-scan cursor (issue #815) so the integrity
+        // check never mutates the shared point-read cursor and can run alongside
+        // concurrent reads.
+        let cursor = self.new_scan_cursor().await?;
         let header_size = self.calculate_header_size();
         {
-            let mut file_guard = self.file.lock().await;
+            let mut file_guard = cursor.file.lock().await;
             file_guard.seek(SeekFrom::Start(header_size as u64)).await?;
         }
 
         // Check each block
-        while let Some(block_data) = self.read_next_block().await.ok().flatten() {
+        while let Some(block_data) = self.read_next_block(&cursor).await.ok().flatten() {
             result.total_blocks_checked += 1;
 
             // Try to parse block entries
@@ -96,12 +93,6 @@ impl SSTableReader {
             if result.total_blocks_checked % 100 == 0 {
                 tokio::task::yield_now().await;
             }
-        }
-
-        // Restore original position
-        {
-            let mut file_guard = self.file.lock().await;
-            file_guard.seek(SeekFrom::Start(original_position)).await?;
         }
 
         // Determine overall status

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -51,13 +51,13 @@ use header::{
 
 use std::collections::HashMap;
 use std::path::Path;
-use std::sync::atomic::{AtomicU64, AtomicUsize};
+use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use tokio::fs::File;
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
 use tokio::sync::Mutex;
 
-use source::BlockSource;
+use source::{BlockSource, ScanSource};
 
 use crate::{
     parser::{header::CassandraVersion, SSTableHeader, SSTableParser},
@@ -121,7 +121,11 @@ impl SSTableReader {
         let use_mmap = reader_config.use_mmap
             && file_size > 0
             && file_size >= reader_config.mmap_min_size_bytes as u64;
-        let source = if use_mmap {
+        // Build both the shared point-read source and the per-scan factory from
+        // the same backend decision so concurrent scans get independent cursors
+        // (issue #815). `ScanSource::Mapped` shares the same `Arc<Mmap>` so no
+        // extra mapping is created per scan.
+        let (source, scan_source) = if use_mmap {
             match Self::map_file(path) {
                 Ok(mmap) => {
                     log::debug!(
@@ -129,7 +133,8 @@ impl SSTableReader {
                         path.display(),
                         file_size
                     );
-                    BlockSource::mapped(Arc::new(mmap))
+                    let mmap = Arc::new(mmap);
+                    (BlockSource::mapped(mmap.clone()), ScanSource::Mapped(mmap))
                 }
                 Err(e) => {
                     // Memory mapping can fail on some filesystems (e.g. certain
@@ -140,11 +145,17 @@ impl SSTableReader {
                         path.display(),
                         e
                     );
-                    BlockSource::buffered(File::open(path).await?)
+                    (
+                        BlockSource::buffered(File::open(path).await?),
+                        ScanSource::Buffered,
+                    )
                 }
             }
         } else {
-            BlockSource::buffered(File::open(path).await?)
+            (
+                BlockSource::buffered(File::open(path).await?),
+                ScanSource::Buffered,
+            )
         };
         let file = Arc::new(Mutex::new(source));
 
@@ -371,6 +382,7 @@ impl SSTableReader {
         Ok(Self {
             file_path: path.to_path_buf(),
             file,
+            scan_source,
             header,
             parser,
             index,
@@ -394,8 +406,6 @@ impl SSTableReader {
             schema,
             udt_registry: None, // Will be set when available for UDT-aware parsing
             compression_info: compression_info.map(Arc::new),
-            current_chunk_index: AtomicUsize::new(0),
-            scan_mutex: tokio::sync::Mutex::new(()),
             version_gates,
             bti_partitions_db,
         })

--- a/cqlite-core/src/storage/sstable/reader/source.rs
+++ b/cqlite-core/src/storage/sstable/reader/source.rs
@@ -23,13 +23,18 @@
 //! poll methods always complete synchronously (`Poll::Ready`).
 
 use std::io::{self, SeekFrom};
+use std::path::Path;
 use std::pin::Pin;
+use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use memmap2::Mmap;
 use tokio::fs::File;
 use tokio::io::{AsyncRead, AsyncSeek, BufReader, ReadBuf};
+use tokio::sync::Mutex;
+
+use crate::Result;
 
 /// A seekable byte source backing an [`SSTableReader`](super::types::SSTableReader).
 ///
@@ -56,6 +61,55 @@ impl BlockSource {
     #[cfg(test)]
     pub(crate) fn is_mmap(&self) -> bool {
         matches!(self, BlockSource::Mapped(_))
+    }
+}
+
+/// Template for minting fresh, independent [`BlockSource`]s — one per scan.
+///
+/// Issue #815: concurrent scans on a single `SSTableReader` must not share a
+/// mutable file position or chunk index, otherwise their seeks interleave and
+/// corrupt each other's reads (the bug #805 fixed by serializing with a mutex).
+/// Instead of serializing, each scan now opens its own [`ScanCursor`] from this
+/// template, so they run in parallel while staying correct. SSTable files are
+/// immutable, so minting extra views is always safe.
+pub(crate) enum ScanSource {
+    /// Reopen the file for each scan, giving it its own OS file handle and seek
+    /// position. The per-handle cost is a small buffered reader.
+    Buffered,
+    /// Share the underlying read-only memory map; each scan gets its own cursor
+    /// position over the same mapped bytes (just an `Arc` clone, no new mapping).
+    Mapped(Arc<Mmap>),
+}
+
+impl ScanSource {
+    /// Mint a fresh, independent [`BlockSource`] for one scan.
+    pub(crate) async fn open(&self, path: &Path) -> Result<BlockSource> {
+        Ok(match self {
+            ScanSource::Buffered => BlockSource::buffered(File::open(path).await?),
+            ScanSource::Mapped(mmap) => BlockSource::mapped(mmap.clone()),
+        })
+    }
+}
+
+/// An independent read cursor for a single scan.
+///
+/// Bundles a private file handle (uncontended `Arc<Mutex<BlockSource>>`) with a
+/// private `chunk_index`, so concurrent scans on the same `SSTableReader` never
+/// touch shared mutable I/O state (issue #815). The mutex is per-scan and so is
+/// effectively uncontended — it only exists because the block-I/O helpers need
+/// `&mut` access to seek/read the source.
+pub(crate) struct ScanCursor {
+    pub(crate) file: Arc<Mutex<BlockSource>>,
+    pub(crate) chunk_index: AtomicUsize,
+}
+
+impl ScanCursor {
+    /// Wrap a freshly-minted source as a scan cursor positioned at chunk 0.
+    pub(crate) fn new(source: BlockSource) -> Self {
+        Self {
+            file: Arc::new(Mutex::new(source)),
+            chunk_index: AtomicUsize::new(0),
+        }
     }
 }
 

--- a/cqlite-core/src/storage/sstable/reader/tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/tests.rs
@@ -614,4 +614,76 @@ mod tests {
 
         Ok(())
     }
+
+    /// Issue #815: concurrent full scans on a *single* `SSTableReader` must
+    /// return identical, correct results. Before #815 each scan held
+    /// `scan_mutex` for its whole lifetime (correct but fully serialized); the
+    /// per-scan cursor lets them run in parallel. This stress test would surface
+    /// the #805 corruption (interleaved seeks / chunk-index advances producing
+    /// `Column not found` errors or short/garbled results) if the scans shared a
+    /// mutable cursor again. Run against both the buffered and mmap backends.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_concurrent_scans_single_reader_are_consistent() -> crate::Result<()> {
+        use super::super::SSTableReader;
+        use crate::{Config, Platform};
+        use std::path::Path;
+        use std::sync::Arc;
+
+        let test_dir = match std::env::var("CQLITE_DATASETS_ROOT") {
+            Ok(root) => Path::new(&root)
+                .join("sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9"),
+            Err(_) => {
+                eprintln!("CQLITE_DATASETS_ROOT not set, skipping test");
+                return Ok(());
+            }
+        };
+        let data_file = test_dir.join("nb-1-big-Data.db");
+        if !data_file.exists() {
+            eprintln!("Test data file not found at {:?}, skipping test", data_file);
+            return Ok(());
+        }
+
+        for use_mmap in [false, true] {
+            let mut config = Config::default();
+            config.storage.use_mmap = use_mmap;
+            let platform = Arc::new(Platform::new(&config).await?);
+            let reader = Arc::new(SSTableReader::open(&data_file, &config, platform).await?);
+
+            // Reference result from an uncontended scan.
+            let reference = reader.get_all_entries().await?;
+            assert!(
+                !reference.is_empty(),
+                "expected non-empty reference scan (mmap={use_mmap})"
+            );
+            let mut reference_keys: Vec<_> = reference.iter().map(|(_, k, _)| k.clone()).collect();
+            reference_keys.sort();
+
+            // Fan out many concurrent scans on the SAME reader and confirm each
+            // returns exactly the reference set of partition keys.
+            let mut handles = Vec::new();
+            for _ in 0..16 {
+                let reader = Arc::clone(&reader);
+                handles.push(tokio::spawn(async move { reader.get_all_entries().await }));
+            }
+            for handle in handles {
+                let entries = handle
+                    .await
+                    .expect("scan task panicked")
+                    .expect("concurrent scan failed");
+                assert_eq!(
+                    entries.len(),
+                    reference.len(),
+                    "concurrent scan returned a different row count (mmap={use_mmap})"
+                );
+                let mut keys: Vec<_> = entries.iter().map(|(_, k, _)| k.clone()).collect();
+                keys.sort();
+                assert_eq!(
+                    keys, reference_keys,
+                    "concurrent scan returned different keys (mmap={use_mmap})"
+                );
+            }
+        }
+
+        Ok(())
+    }
 }

--- a/cqlite-core/src/storage/sstable/reader/types.rs
+++ b/cqlite-core/src/storage/sstable/reader/types.rs
@@ -2,11 +2,11 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, AtomicUsize};
+use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-use super::source::BlockSource;
+use super::source::{BlockSource, ScanSource};
 
 use crate::{
     parser::SSTableHeader,
@@ -207,8 +207,17 @@ pub struct CachedBlock {
 pub struct SSTableReader {
     /// Path to the SSTable file
     pub(crate) file_path: PathBuf,
-    /// Backing byte source for reading (buffered file I/O or memory map)
+    /// Backing byte source for point reads (buffered file I/O or memory map).
+    ///
+    /// Used only by positioned point-read helpers (`get_cached_data`,
+    /// integrity checks) that lock, seek, read, and unlock atomically. Full
+    /// scans no longer use this shared cursor — they mint their own
+    /// [`ScanCursor`](super::source::ScanCursor) via [`Self::scan_source`] so
+    /// they run in parallel (issue #815).
     pub(crate) file: Arc<Mutex<BlockSource>>,
+    /// Template for minting fresh per-scan [`BlockSource`]s so concurrent scans
+    /// never share a mutable file position or chunk index (issue #815).
+    pub(crate) scan_source: ScanSource,
     /// SSTable header information
     pub(crate) header: SSTableHeader,
     /// Parser for SSTable format
@@ -259,21 +268,6 @@ pub struct SSTableReader {
     pub(crate) udt_registry: Option<UdtRegistry>,
     /// CompressionInfo metadata for chunked decompression (if compressed)
     pub compression_info: Option<Arc<CompressionInfo>>,
-    /// Current chunk index for sequential chunk reading.
-    ///
-    /// IMPORTANT: This field is shared across all callers of `read_next_block`.
-    /// Concurrent callers MUST hold `scan_mutex` for the full lifetime of their
-    /// scan to prevent interleaving of file-position advances and chunk-index
-    /// increments (issue #805).
-    pub(super) current_chunk_index: AtomicUsize,
-    /// Serialises concurrent sequential scans on this reader.
-    ///
-    /// SSTable files are immutable, but `sequential_scan`, `scan_for_key`, and
-    /// `stitch_all_chunks` share both the underlying file's seek-position and the
-    /// `current_chunk_index` counter. Two concurrent callers advancing those
-    /// fields simultaneously corrupt each other's reads (issue #805). Acquiring
-    /// this mutex for the full duration of a scan prevents interleaving.
-    pub(super) scan_mutex: tokio::sync::Mutex<()>,
     /// Version-feature gates derived from the SSTable filename.
     ///
     /// Computed once in `SSTableReader::open` via `VersionGates::from_path` and


### PR DESCRIPTION
## Summary

Part of epic #906 (Read-path performance & I/O backend). Closes #815.

Post-#805/#814, every scan held `scan_mutex` for its full lifetime because `sequential_scan`, `scan_for_key`, `stitch_all_chunks`, etc. all shared **one** file seek-position plus a `current_chunk_index` counter on the reader. Correct, but it serialized concurrent scans to one-at-a-time per reader.

This replaces the shared cursor + mutex with an **independent per-scan cursor**, so scans run in parallel while staying correct. SSTable files are immutable, so minting extra views is always safe.

## What changed

- **`source.rs`**: new `ScanSource` factory (mints a fresh `BlockSource` per scan — reopen the file for buffered, clone the `Arc<Mmap>` for mapped, no new mapping) and `ScanCursor` (private, uncontended `Arc<Mutex<BlockSource>>` + its own chunk index).
- **`data_access.rs`**: every scan/lookup mints its own cursor; `read_next_block` / `stitch_*` take the cursor explicitly. `bti_decompress_and_parse_target`, `bti_scan_with_metadata`, `get_all_entries`, `scan_for_key`, `run_scan_stream`, `scan_with_cell_metadata`, `iterate_all_partitions_for_compaction`, `stream_all_partitions_for_compaction`, `prepare_delta_scan` all converted.
- **`integrity.rs` / `delta_scan.rs`**: converted to per-scan cursors; removed the now-defunct `delta_scan_mutex`.
- **`types.rs` / `mod.rs`**: removed shared `current_chunk_index` and `scan_mutex`; added the `scan_source` factory.
- **`block_io.rs` is unchanged** — it already took the file + chunk index by reference, so the byte-level decode path carries **no** correctness risk.
- The shared `file` handle is kept only for atomic positioned point reads (`get_cached_data`).

## Acceptance criteria

- [x] Concurrent scans on one `SSTableReader` run in parallel (no full-scan serialization) while remaining correct.
- [x] No shared mutable file-position or chunk-index state across concurrent callers (audited + stress test).
- [x] Memory stays within target — buffered scans reopen a small file handle; mmap scans just clone an `Arc` (no extra mapping).
- [x] New stress test `test_concurrent_scans_single_reader_are_consistent`: 16 concurrent full scans on one reader return identical, correct results on **both** buffered and mmap backends — the workload that triggered the #805 corruption.

## Validation

`scripts/agent-gate.sh` (RUN_SLOW_TESTS=1) — **RESULT: PASS**

```
fmt: PASS  clippy: PASS  core-tests: PASS  integration-tests: PASS
format-compat: PASS  write-tests: PASS  cli-tests: PASS
python-bindings: PASS  minimal-build: PASS  smoke: PASS
```