### PR TITLE
feat(flight): push integer avg and float min/max (#902, #896)

### DIFF
--- a/cqlite-flight/src/agg.rs
+++ b/cqlite-flight/src/agg.rs
@@ -19,7 +19,11 @@
 //!   Counter), `Float64` for Float/Double; null when the group has no non-null
 //!   inputs. Any other source type is a [`AggError`] (the connector never pushes
 //!   `Sum` on them).
+//! - `SumDouble` → always `Float64`, widening integer inputs so the running sum
+//!   never overflows; the numerator of a pushed `avg(col)` (issue #902). Null
+//!   when the group has no non-null inputs.
 //! - `Min`/`Max` → the source column's Arrow type; null when no non-null inputs.
+//!   Float/double extremes order `NaN` greatest (matches Trino, issue #896).
 //!
 //! # Row semantics
 //!
@@ -45,7 +49,7 @@ pub enum AggError {
     /// A group_by or aggregate referenced a column not in the schema.
     #[error("aggregation references unknown column '{0}'")]
     UnknownColumn(String),
-    /// `Sum`/`Min`/`Max` named no source column (only `Count` may omit it).
+    /// `Sum`/`SumDouble`/`Min`/`Max` named no source column (only `Count` may omit it).
     #[error("aggregate '{output}' ({func:?}) requires a source column")]
     MissingColumn {
         /// The offending output column name.
@@ -53,7 +57,7 @@ pub enum AggError {
         /// The function that needs a column.
         func: AggFunc,
     },
-    /// `Sum` was requested on a non-numeric source column.
+    /// `Sum`/`SumDouble` was requested on a non-numeric source column.
     #[error("sum('{column}') unsupported: source type {cql_type:?} is not numeric")]
     SumNotNumeric {
         /// Source column name.
@@ -66,14 +70,6 @@ pub enum AggError {
     /// instead of silently returning a wrong value.
     #[error("sum('{column}') overflowed i64")]
     SumOverflow {
-        /// Source column name.
-        column: String,
-    },
-    /// `Min`/`Max` on a float/double column is not pushed: NaN ordering must match
-    /// Trino exactly (tracked in a follow-up). The connector already declines this,
-    /// so this guards a hand-crafted ticket and keeps the server consistent.
-    #[error("min/max('{column}') unsupported: float/double NaN ordering is not pushed")]
-    MinMaxFloatUnsupported {
         /// Source column name.
         column: String,
     },
@@ -194,23 +190,18 @@ impl AggPlan {
             }
             (func, Some(column)) => {
                 let ty = column_type(schema, column)?;
-                let kind = if matches!(func, AggFunc::Sum) {
+                // Both Sum and SumDouble need a numeric source. Sum carries the
+                // numeric family (Int64 vs Float64 output); SumDouble always sums
+                // in f64, so it only needs numeric-ness, not the family.
+                let kind = if matches!(func, AggFunc::Sum | AggFunc::SumDouble) {
                     let kind = sum_kind_of(&ty).ok_or_else(|| AggError::SumNotNumeric {
                         column: column.clone(),
                         cql_type: ty.clone(),
                     })?;
-                    Some(kind)
+                    matches!(func, AggFunc::Sum).then_some(kind)
                 } else {
                     None
                 };
-                // Float/double min/max is not pushed (NaN ordering, see #896).
-                if matches!(func, AggFunc::Min | AggFunc::Max)
-                    && matches!(unwrap_frozen(&ty), CqlType::Float | CqlType::Double)
-                {
-                    return Err(AggError::MinMaxFloatUnsupported {
-                        column: column.clone(),
-                    });
-                }
                 (Some(ty), kind)
             }
         };
@@ -273,6 +264,8 @@ impl AggPlan {
                 // Integer family (or, defensively, missing kind) → Int64.
                 _ => CqlType::BigInt,
             },
+            // SumDouble (avg numerator) → always Float64.
+            AggFunc::SumDouble => CqlType::Double,
             // Min/Max keep the source column's type.
             AggFunc::Min | AggFunc::Max => planned.source_type.clone().unwrap_or(CqlType::BigInt),
         }
@@ -466,6 +459,9 @@ enum Accumulator {
     SumInt(Option<i64>),
     /// `sum` over a float family — `None` until a first non-null input.
     SumFloat(Option<f64>),
+    /// `SumDouble` (avg numerator): any numeric input widened to `f64`, never
+    /// overflowing — `None` until a first non-null input.
+    SumDouble(Option<f64>),
     /// `min`/`max` over the source type — holds the current extreme `Value`.
     Extreme(Option<Value>),
 }
@@ -478,6 +474,7 @@ impl Accumulator {
                 Some(SumKind::Float) => Accumulator::SumFloat(None),
                 _ => Accumulator::SumInt(None),
             },
+            AggFunc::SumDouble => Accumulator::SumDouble(None),
             AggFunc::Min | AggFunc::Max => Accumulator::Extreme(None),
         }
     }
@@ -520,6 +517,16 @@ impl Accumulator {
                     }
                 }
             }
+            Accumulator::SumDouble(acc) => {
+                if let Some(value) = non_null(&planned.column, row) {
+                    // Widen any numeric (integer OR float) to f64 — the avg
+                    // numerator never overflows, so an integer total exceeding i64
+                    // is fine here (it would error under a checked-i64 `Sum`).
+                    if let Some(f) = as_f64_widening(value) {
+                        *acc = Some(acc.unwrap_or(0.0) + f);
+                    }
+                }
+            }
             Accumulator::Extreme(current) => {
                 if let Some(value) = non_null(&planned.column, row) {
                     let take = match current {
@@ -551,6 +558,7 @@ impl Accumulator {
             Accumulator::Count(n) => Some(Value::BigInt(n)),
             Accumulator::SumInt(acc) => acc.map(Value::BigInt),
             Accumulator::SumFloat(acc) => acc.map(Value::Float),
+            Accumulator::SumDouble(acc) => acc.map(Value::Float),
             Accumulator::Extreme(v) => v,
         }
     }
@@ -590,14 +598,54 @@ fn as_f64(value: &Value) -> Option<f64> {
     }
 }
 
+/// Widen any numeric `Value` (integer OR float family) to `f64`. Used by the
+/// `SumDouble` accumulator (avg numerator), which must total integer columns in
+/// f64 so the running sum cannot overflow (issue #902).
+fn as_f64_widening(value: &Value) -> Option<f64> {
+    as_i64(value).map(|n| n as f64).or_else(|| as_f64(value))
+}
+
+/// Total order over two `f64`s matching Java's `Double.compare` (and therefore
+/// Trino's `REAL`/`DOUBLE` `min`/`max`): every `NaN` sorts as the LARGEST value
+/// (greater than `+Infinity`), and all `NaN`s are mutually equal. This makes the
+/// Rust accumulator order-independent and identical to the Java
+/// `PartialAggregateMerger`, which compares via `Double.compare` (issue #896).
+///
+/// `max(col)` therefore yields `NaN` when any input is `NaN`; `min(col)` yields
+/// the smallest non-`NaN` (returning `NaN` only when every input is `NaN`).
+fn cmp_f64_trino(a: f64, b: f64) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+    if a < b {
+        Ordering::Less
+    } else if a > b {
+        Ordering::Greater
+    } else {
+        // Equal under `<`/`>` (covers ±0.0 and the all-finite-equal case) or one
+        // side is NaN. Replicate Double.compare's canonical-bits tiebreak: all
+        // NaN canonicalize to one pattern that, as a signed i64, exceeds every
+        // finite/Infinity bit pattern, so NaN sorts greatest.
+        canonical_bits(a).cmp(&canonical_bits(b))
+    }
+}
+
+/// Java `Double.doubleToLongBits` canonicalization viewed as a signed `i64`:
+/// every `NaN` maps to the single quiet-NaN pattern (`0x7ff8…`), which is the
+/// largest positive long, so NaN compares greater than all finite values.
+fn canonical_bits(d: f64) -> i64 {
+    if d.is_nan() {
+        0x7ff8_0000_0000_0000_u64 as i64
+    } else {
+        d.to_bits() as i64
+    }
+}
+
 /// Total order over the `Value` variants that Min/Max can see (the source
 /// column's type). Returns `None` for variants that are not mutually
 /// comparable, in which case the accumulator keeps its current extreme.
 ///
-/// Floats compare via `partial_cmp` falling back to `Equal`, so a `NaN` never
-/// displaces the running extreme (matches "keep current on incomparable").
+/// Floats use [`cmp_f64_trino`] (NaN sorts greatest, matching Trino and the Java
+/// merger), so the result is independent of input row order (issue #896).
 fn compare_values(a: &Value, b: &Value) -> Option<std::cmp::Ordering> {
-    use std::cmp::Ordering;
     match (a, b) {
         (Value::Boolean(x), Value::Boolean(y)) => Some(x.cmp(y)),
         (Value::TinyInt(x), Value::TinyInt(y)) => Some(x.cmp(y)),
@@ -608,8 +656,8 @@ fn compare_values(a: &Value, b: &Value) -> Option<std::cmp::Ordering> {
         | (Value::Timestamp(x), Value::Timestamp(y))
         | (Value::Time(x), Value::Time(y)) => Some(x.cmp(y)),
         (Value::Date(x), Value::Date(y)) => Some(x.cmp(y)),
-        (Value::Float(x), Value::Float(y)) => Some(x.partial_cmp(y).unwrap_or(Ordering::Equal)),
-        (Value::Float32(x), Value::Float32(y)) => Some(x.partial_cmp(y).unwrap_or(Ordering::Equal)),
+        (Value::Float(x), Value::Float(y)) => Some(cmp_f64_trino(*x, *y)),
+        (Value::Float32(x), Value::Float32(y)) => Some(cmp_f64_trino(*x as f64, *y as f64)),
         (Value::Text(x), Value::Text(y)) => Some(x.cmp(y)),
         (Value::Blob(x), Value::Blob(y)) => Some(x.cmp(y)),
         (Value::Uuid(x), Value::Uuid(y)) => Some(x.cmp(y)),
@@ -617,7 +665,7 @@ fn compare_values(a: &Value, b: &Value) -> Option<std::cmp::Ordering> {
         (lhs, rhs) => match (as_i64(lhs), as_i64(rhs)) {
             (Some(x), Some(y)) => Some(x.cmp(&y)),
             _ => match (as_f64(lhs), as_f64(rhs)) {
-                (Some(x), Some(y)) => Some(x.partial_cmp(&y).unwrap_or(Ordering::Equal)),
+                (Some(x), Some(y)) => Some(cmp_f64_trino(x, y)),
                 _ => None,
             },
         },
@@ -695,8 +743,16 @@ mod tests {
     }
 
     #[test]
-    fn float_min_max_is_rejected_at_build() {
-        // The schema's `v` is bigint; add a double column to test float min/max.
+    fn integer_sum_without_overflow_succeeds() {
+        let plan = sum_v_plan();
+        let rows = vec![row_bigint(10), row_bigint(32)];
+        let out = plan.aggregate(&rows).expect("no overflow");
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].values.get("agg0"), Some(&Value::BigInt(42)));
+    }
+
+    /// Schema with a double column `d` for float-aggregate tests.
+    fn double_schema() -> TableSchema {
         let mut schema = bigint_schema();
         schema.columns.push(Column {
             name: "d".into(),
@@ -705,26 +761,91 @@ mod tests {
             default: None,
             is_static: false,
         });
-        for func in [AggFunc::Min, AggFunc::Max] {
-            let agg = Aggregation {
-                group_by: vec![],
-                aggregates: vec![AggregateSpec {
-                    func,
-                    column: Some("d".into()),
-                    output: "agg0".into(),
-                }],
-            };
-            let err = AggPlan::build(&agg, &schema).expect_err("float min/max must be rejected");
-            assert!(matches!(err, AggError::MinMaxFloatUnsupported { column } if column == "d"));
+        schema
+    }
+
+    fn row_double(d: f64) -> QueryRow {
+        let mut values = HashMap::new();
+        values.insert("d".to_string(), Value::Float(d));
+        QueryRow {
+            values,
+            key: RowKey(Vec::new()),
+            metadata: Default::default(),
+            cell_metadata: None,
         }
     }
 
+    fn min_max_d_plan() -> AggPlan {
+        let agg = Aggregation {
+            group_by: vec![],
+            aggregates: vec![
+                AggregateSpec {
+                    func: AggFunc::Min,
+                    column: Some("d".into()),
+                    output: "agg_min".into(),
+                },
+                AggregateSpec {
+                    func: AggFunc::Max,
+                    column: Some("d".into()),
+                    output: "agg_max".into(),
+                },
+            ],
+        };
+        AggPlan::build(&agg, &double_schema()).expect("plan")
+    }
+
+    /// #896: float min/max now pushes; `NaN` orders greatest, so `max` returns
+    /// `NaN` and `min` ignores it — independent of input row order.
     #[test]
-    fn integer_sum_without_overflow_succeeds() {
-        let plan = sum_v_plan();
-        let rows = vec![row_bigint(10), row_bigint(32)];
-        let out = plan.aggregate(&rows).expect("no overflow");
+    fn float_min_max_nan_orders_greatest_and_is_order_independent() {
+        let nan_first = vec![row_double(f64::NAN), row_double(1.0), row_double(3.0)];
+        let nan_last = vec![row_double(1.0), row_double(3.0), row_double(f64::NAN)];
+        for rows in [nan_first, nan_last] {
+            let out = min_max_d_plan()
+                .aggregate(&rows)
+                .expect("float min/max pushes");
+            assert_eq!(out.len(), 1);
+            // min ignores NaN -> 1.0
+            assert_eq!(out[0].values.get("agg_min"), Some(&Value::Float(1.0)));
+            // max -> NaN (NaN is the largest value)
+            match out[0].values.get("agg_max") {
+                Some(Value::Float(v)) => assert!(v.is_nan(), "max over a NaN input must be NaN"),
+                other => panic!("expected NaN max, got {other:?}"),
+            }
+        }
+    }
+
+    /// #896: when every input is `NaN`, both `min` and `max` are `NaN`.
+    #[test]
+    fn float_min_max_all_nan_is_nan() {
+        let rows = vec![row_double(f64::NAN), row_double(f64::NAN)];
+        let out = min_max_d_plan().aggregate(&rows).expect("plan");
+        for col in ["agg_min", "agg_max"] {
+            match out[0].values.get(col) {
+                Some(Value::Float(v)) => assert!(v.is_nan(), "{col} over all-NaN must be NaN"),
+                other => panic!("expected NaN for {col}, got {other:?}"),
+            }
+        }
+    }
+
+    /// #902: `SumDouble` (avg numerator) widens integers to f64 and never
+    /// overflows, where a checked-i64 `Sum` over the same data errors.
+    #[test]
+    fn sum_double_does_not_overflow_on_large_integer_total() {
+        let agg = Aggregation {
+            group_by: vec![],
+            aggregates: vec![AggregateSpec {
+                func: AggFunc::SumDouble,
+                column: Some("v".into()),
+                output: "agg0".into(),
+            }],
+        };
+        let plan = AggPlan::build(&agg, &bigint_schema()).expect("plan");
+        // A total exceeding i64 (i64::MAX + 1 + 1) would error under checked Sum.
+        let rows = vec![row_bigint(i64::MAX), row_bigint(1), row_bigint(1)];
+        let out = plan.aggregate(&rows).expect("SumDouble must not overflow");
         assert_eq!(out.len(), 1);
-        assert_eq!(out[0].values.get("agg0"), Some(&Value::BigInt(42)));
+        let expected = i64::MAX as f64 + 1.0 + 1.0;
+        assert_eq!(out[0].values.get("agg0"), Some(&Value::Float(expected)));
     }
 }

--- a/cqlite-flight/src/producer.rs
+++ b/cqlite-flight/src/producer.rs
@@ -1662,6 +1662,49 @@ mod tests {
         assert_eq!(i32_col(b, "agg4").value(0), 30);
     }
 
+    fn f64_col(batch: &RecordBatch, name: &str) -> arrow::array::Float64Array {
+        batch
+            .column_by_name(name)
+            .unwrap()
+            .as_any()
+            .downcast_ref::<arrow::array::Float64Array>()
+            .unwrap()
+            .clone()
+    }
+
+    /// #902: `SumDouble` (the avg numerator) over an integer column emits a
+    /// Float64 partial and totals in f64, so a running sum past i64::MAX does not
+    /// overflow the way a checked-i64 `Sum` would. Here it just verifies the wire
+    /// type and value through the real merge/Arrow path.
+    #[test]
+    fn sum_double_emits_float64_over_integer_column() {
+        let schema = simple_schema();
+        let (_temp, _data, dir) = build_sstables(
+            &schema,
+            vec![vec![
+                write_row(1, "a", 10, 100),
+                write_row(2, "b", 20, 100),
+                write_row(3, "c", 30, 100),
+            ]],
+        );
+
+        let agg = Aggregation {
+            group_by: vec![],
+            aggregates: vec![
+                agg_on(AggFunc::SumDouble, "score", "agg_sum"),
+                agg_on(AggFunc::Count, "score", "agg_cnt"),
+            ],
+        };
+        let p = agg_producer(schema, ScanSpec::default(), agg);
+        let batches = p.produce(&DirSource::new(&dir)).unwrap();
+        assert_eq!(total_rows(&batches), 1);
+        let b = &batches[0];
+        // SumDouble → Float64 (not Int64), value 60.0; Count → 3. The connector
+        // divides these to 20.0 for avg(score).
+        assert_eq!(f64_col(b, "agg_sum").value(0), 60.0);
+        assert_eq!(i64_col(b, "agg_cnt").value(0), 3);
+    }
+
     /// Global aggregation over EMPTY input → one row: count = 0, sum/min/max null.
     #[test]
     fn global_aggregate_over_empty_input_emits_zero_row() {

--- a/cqlite-flight/src/ticket.rs
+++ b/cqlite-flight/src/ticket.rs
@@ -158,8 +158,16 @@ pub enum PredicateExpr {
 pub enum AggFunc {
     /// `count(*)` (when `column` is `None`) or `count(col)` (non-null count).
     Count,
-    /// `sum(col)`.
+    /// `sum(col)` — integer sources accumulate in checked `i64` (overflow is an
+    /// error, matching Trino's non-pushed `sum(bigint)`); float sources in `f64`.
     Sum,
+    /// A sum coerced to `f64` regardless of source type, used as the numerator of
+    /// a pushed `avg(col)` (issue #902). Unlike [`AggFunc::Sum`] it never overflows
+    /// (integer inputs widen to `f64`), so an integer `avg` whose running total
+    /// exceeds `i64` succeeds where Trino's 128-bit `avg` also would — instead of
+    /// failing the way a checked-`i64` `Sum` would. Always `Float64`, null when the
+    /// group has no non-null inputs.
+    SumDouble,
     /// `min(col)`.
     Min,
     /// `max(col)`.

--- a/trino-connector/docker/e2e-data.cql
+++ b/trino-connector/docker/e2e-data.cql
@@ -5,14 +5,15 @@ CREATE TABLE IF NOT EXISTS analytics.events (
   id int PRIMARY KEY,
   name text,
   score int,
+  ratio double,
   active boolean
 );
 
-INSERT INTO analytics.events (id, name, score, active) VALUES (1, 'alice', 10, true);
-INSERT INTO analytics.events (id, name, score, active) VALUES (2, 'bob',   20, false);
-INSERT INTO analytics.events (id, name, score, active) VALUES (3, 'carol', 30, true);
-INSERT INTO analytics.events (id, name, score, active) VALUES (4, 'dave',  40, false);
-INSERT INTO analytics.events (id, name, score, active) VALUES (5, 'erin',  50, true);
+INSERT INTO analytics.events (id, name, score, ratio, active) VALUES (1, 'alice', 10, 1.5, true);
+INSERT INTO analytics.events (id, name, score, ratio, active) VALUES (2, 'bob',   20, 2.5, false);
+INSERT INTO analytics.events (id, name, score, ratio, active) VALUES (3, 'carol', 30, 3.5, true);
+INSERT INTO analytics.events (id, name, score, ratio, active) VALUES (4, 'dave',  40, 4.5, false);
+INSERT INTO analytics.events (id, name, score, ratio, active) VALUES (5, 'erin',  50, 5.5, true);
 
 -- Diverse-type table to exercise uuid + timestamp conversion end-to-end.
 CREATE TABLE IF NOT EXISTS analytics.typed (

--- a/trino-connector/docker/e2e-test.sh
+++ b/trino-connector/docker/e2e-test.sh
@@ -90,11 +90,17 @@ assert_eq "NOT predicate"           '"2"'                                    "$(
 assert_eq "OR with IS NULL"         '"1"'                                    "$(trino 'SELECT count(*) FROM cqlite.analytics.events WHERE score > 45 OR active IS NULL')"
 
 # Aggregation pushdown (#841): global count/sum already asserted above; add
-# min/max/avg (avg exercises the Sum+Count decomposition) and GROUP BY (the
+# min/max/avg (avg exercises the SumDouble+Count decomposition) and GROUP BY (the
 # single-finalize-split path). Scores: 10,20,30,40,50.
 assert_eq "aggregate min(score)"    '"10"'                                   "$(trino 'SELECT min(score) FROM cqlite.analytics.events')"
 assert_eq "aggregate max(score)"    '"50"'                                   "$(trino 'SELECT max(score) FROM cqlite.analytics.events')"
+# Integer avg now pushes via SumDouble (no i64 overflow, matches Trino) — #902.
 assert_eq "aggregate avg(score)"    '"30.0"'                                 "$(trino 'SELECT avg(score) FROM cqlite.analytics.events')"
+# Float/double min/max/avg push too (#896): NaN ordering matches Trino. ratios:
+# 1.5,2.5,3.5,4.5,5.5 -> min 1.5, max 5.5, avg 3.5.
+assert_eq "aggregate min(ratio)"    '"1.5"'                                  "$(trino 'SELECT min(ratio) FROM cqlite.analytics.events')"
+assert_eq "aggregate max(ratio)"    '"5.5"'                                  "$(trino 'SELECT max(ratio) FROM cqlite.analytics.events')"
+assert_eq "aggregate avg(ratio)"    '"3.5"'                                  "$(trino 'SELECT avg(ratio) FROM cqlite.analytics.events')"
 # GROUP BY active -> two groups; assert the group count is 2 (deterministic scalar).
 assert_eq "group-by group count"    '"2"'                                    "$(trino 'SELECT count(*) FROM (SELECT active FROM cqlite.analytics.events GROUP BY active)')"
 # Aggregation + predicate: sum(score) WHERE score > 25 -> 30+40+50 = 120.

--- a/trino-connector/src/main/java/com/rustyrazorblade/cqlite/flight/AggregationSpec.java
+++ b/trino-connector/src/main/java/com/rustyrazorblade/cqlite/flight/AggregationSpec.java
@@ -12,16 +12,18 @@ import java.util.List;
  *
  * <p>Mirrors the cqlite-flight server's wire contract exactly. The {@code group_by}
  * list names the grouping columns; the {@code aggregates} list names the partial
- * aggregates the server must compute. Server funcs are ONLY
- * {@link Func#Count}/{@link Func#Sum}/{@link Func#Min}/{@link Func#Max} — there is
- * no {@code Avg} on the wire; {@code avg(x)} is decomposed connector-side into
- * {@code Sum(x)} + {@code Count(x)} (see {@link CqliteFlightMetadata#applyAggregation}).
+ * aggregates the server must compute. Server funcs are
+ * {@link Func#Count}/{@link Func#Sum}/{@link Func#SumDouble}/{@link Func#Min}/{@link Func#Max}
+ * — there is no {@code Avg} on the wire; {@code avg(x)} is decomposed connector-side
+ * into {@code SumDouble(x)} + {@code Count(x)} (see
+ * {@link CqliteFlightMetadata#applyAggregation}).
  *
  * <p>The server returns PARTIAL rows whose Arrow columns are, in order:
  * the {@code group_by} columns (their natural types), then one column per aggregate
  * named by its {@code output}. {@code Count} → Int64 (never null);
  * {@code Sum} → Int64 for integer source types or Float64 for float/double (null if
- * no non-null inputs); {@code Min}/{@code Max} → source column type (null if none).
+ * no non-null inputs); {@code SumDouble} → always Float64 (null if none);
+ * {@code Min}/{@code Max} → source column type (null if none).
  * A global (empty {@code group_by}) aggregation returns exactly one row even on
  * empty input.
  */
@@ -31,6 +33,12 @@ public record AggregationSpec(List<String> groupBy, List<Aggregate> aggregates) 
     public enum Func {
         Count,
         Sum,
+        /**
+         * A sum coerced to Float64 regardless of source type, used as the numerator
+         * of a pushed {@code avg(col)}. Unlike {@link #Sum} it never overflows on an
+         * integer column (issue #902), matching Trino's 128-bit {@code avg}.
+         */
+        SumDouble,
         Min,
         Max
     }

--- a/trino-connector/src/main/java/com/rustyrazorblade/cqlite/flight/CqliteFlightMetadata.java
+++ b/trino-connector/src/main/java/com/rustyrazorblade/cqlite/flight/CqliteFlightMetadata.java
@@ -21,7 +21,6 @@ import io.trino.spi.expression.Variable;
 import io.trino.spi.type.BigintType;
 import io.trino.spi.type.BooleanType;
 import io.trino.spi.type.DoubleType;
-import io.trino.spi.type.IntegerType;
 import io.trino.spi.type.Type;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
@@ -312,14 +311,10 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
                     if (arg.isEmpty() || !supportsValueAggregate(arg.get())) {
                         return Optional.empty();
                     }
-                    // Decline float/double min/max: NaN ordering is subtle and must
-                    // match Trino exactly; rather than risk an order-dependent result
-                    // we leave these to Trino. Integer/text/etc. min/max still push.
-                    Type argType = arg.get().type();
-                    if (argType instanceof io.trino.spi.type.RealType
-                            || argType instanceof io.trino.spi.type.DoubleType) {
-                        return Optional.empty();
-                    }
+                    // Float/double min/max push too (issue #896): both the Rust
+                    // accumulator and the Java merger order NaN as the largest value
+                    // (Double.compare semantics), so the result matches Trino's
+                    // non-pushed min/max and is independent of input row order.
                     AggregationSpec.Func f = func.equals("min")
                             ? AggregationSpec.Func.Min : AggregationSpec.Func.Max;
                     String out = nextOutput(outputCounter, groupByNameSet);
@@ -332,24 +327,16 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
                     if (arg.isEmpty() || !supportsValueAggregate(arg.get())) {
                         return Optional.empty();
                     }
-                    // Decline avg() on integer columns: its partial Sum uses checked
-                    // i64 (to match Trino's sum(bigint) overflow), but Trino's avg
-                    // accumulates in 128-bit and never overflows — so a pushed
-                    // integer avg could fail a query Trino would answer. Float/double
-                    // avg sums in f64 (no overflow), so it still pushes. See #902.
-                    Type avgType = arg.get().type();
-                    if (avgType instanceof BigintType || avgType instanceof IntegerType
-                            || avgType instanceof io.trino.spi.type.SmallintType
-                            || avgType instanceof io.trino.spi.type.TinyintType) {
-                        return Optional.empty();
-                    }
-                    // avg(x) -> server Sum(x) + Count(x); combined connector-side as
-                    // ΣSum/ΣCount. The connector emits ONE merged DOUBLE result column
-                    // named by sumOut (the pair's first output); Trino references that.
+                    // avg(x) -> server SumDouble(x) + Count(x); combined connector-side
+                    // as ΣSum/ΣCount. SumDouble totals in f64 even for integer columns,
+                    // so the numerator never overflows — matching Trino's 128-bit avg
+                    // (which never fails), unlike a checked-i64 Sum (issue #902). The
+                    // connector emits ONE merged DOUBLE result column named by sumOut
+                    // (the pair's first output); Trino references that.
                     String sumOut = nextOutput(outputCounter, groupByNameSet);
                     String countOut = nextOutput(outputCounter, groupByNameSet);
                     serverAggregates.add(new AggregationSpec.Aggregate(
-                            AggregationSpec.Func.Sum, arg.get().name(), sumOut));
+                            AggregationSpec.Func.SumDouble, arg.get().name(), sumOut));
                     serverAggregates.add(new AggregationSpec.Aggregate(
                             AggregationSpec.Func.Count, arg.get().name(), countOut));
                     addResult(sumOut, DoubleType.DOUBLE, assignmentList, projections);

--- a/trino-connector/src/main/java/com/rustyrazorblade/cqlite/flight/PartialAggregateMerger.java
+++ b/trino-connector/src/main/java/com/rustyrazorblade/cqlite/flight/PartialAggregateMerger.java
@@ -17,11 +17,12 @@ import java.util.Map;
  * <ul>
  *   <li>{@code Count} → sum (Int64, never null)</li>
  *   <li>{@code Sum} → sum, skipping null partials (null if every partial was null)</li>
+ *   <li>{@code SumDouble} → double sum, skipping null (the avg numerator; never overflows)</li>
  *   <li>{@code Min} → min, skipping null</li>
  *   <li>{@code Max} → max, skipping null</li>
  * </ul>
  * {@code avg} is not a server function — it is computed downstream as ΣSum/ΣCount
- * (null when ΣCount == 0) from a {@code Sum}+{@code Count} pair (see
+ * (null when ΣCount == 0) from a {@code SumDouble}+{@code Count} pair (see
  * {@link FinalizeAggregationPlan}).
  *
  * <p>Grouping: rows are keyed by their group-by values (null keys group together,
@@ -149,6 +150,17 @@ public final class PartialAggregateMerger {
                     // surfaces as a query failure.
                     acc.value = Math.addExact(((Number) acc.value).longValue(), ((Number) partial).longValue());
                 }
+                acc.seen = true;
+            }
+            case SumDouble -> {
+                // The avg numerator: always accumulate in double, so the running
+                // total never overflows (matches Trino's non-overflowing avg).
+                if (partial == null) {
+                    return;
+                }
+                double next = (acc.value == null ? 0.0 : ((Number) acc.value).doubleValue())
+                        + ((Number) partial).doubleValue();
+                acc.value = next;
                 acc.seen = true;
             }
             case Min -> {

--- a/trino-connector/src/test/java/com/rustyrazorblade/cqlite/flight/CqliteFlightMetadataApplyAggregationTest.java
+++ b/trino-connector/src/test/java/com/rustyrazorblade/cqlite/flight/CqliteFlightMetadataApplyAggregationTest.java
@@ -113,19 +113,20 @@ class CqliteFlightMetadataApplyAggregationTest {
     }
 
     @Test
-    void decomposesAvgIntoSumPlusCount() throws Exception {
-        // avg over a DOUBLE column (integer avg is declined — see #902); the
-        // Sum+Count decomposition is identical.
+    void decomposesAvgIntoSumDoublePlusCount() throws Exception {
+        // avg(x) -> SumDouble(x) + Count(x) on the wire. SumDouble totals in f64 so
+        // an integer avg cannot overflow (issue #902); the decomposition is the
+        // same for double columns.
         var result = metadata.applyAggregation(
-                null, TABLE, List.of(agg("avg", DOUBLE, new Variable("d", DOUBLE))),
+                null, TABLE, List.of(agg("avg", DOUBLE, new Variable("x", BIGINT))),
                 ASSIGN, List.of(List.of())).orElseThrow();
 
         JsonNode aggs = aggSpec((CqliteFlightTableHandle) result.getHandle()).get("aggregates");
-        assertEquals(2, aggs.size(), "avg(d) -> Sum(d) + Count(d) on the wire");
-        assertEquals("Sum", aggs.get(0).get("func").asText());
-        assertEquals("d", aggs.get(0).get("column").asText());
+        assertEquals(2, aggs.size(), "avg(x) -> SumDouble(x) + Count(x) on the wire");
+        assertEquals("SumDouble", aggs.get(0).get("func").asText());
+        assertEquals("x", aggs.get(0).get("column").asText());
         assertEquals("Count", aggs.get(1).get("func").asText());
-        assertEquals("d", aggs.get(1).get("column").asText());
+        assertEquals("x", aggs.get(1).get("column").asText());
 
         // But Trino sees ONE projection (the merged DOUBLE avg result).
         assertEquals(1, result.getProjections().size());
@@ -210,15 +211,22 @@ class CqliteFlightMetadataApplyAggregationTest {
     }
 
     @Test
-    void declinesAvgOnIntegerButPushesAvgOnDouble() {
-        // avg(bigint) is declined (its checked-i64 partial sum could overflow where
-        // Trino's 128-bit avg would not). avg(double) sums in f64 — still pushes.
-        assertTrue(metadata.applyAggregation(
+    void pushesAvgOnIntegerAndDouble() throws Exception {
+        // avg(bigint) now pushes via SumDouble (issue #902): the f64 numerator
+        // cannot overflow, matching Trino's 128-bit avg. avg(double) pushes too.
+        var intResult = metadata.applyAggregation(
                 null, TABLE, List.of(agg("avg", DOUBLE, new Variable("x", BIGINT))),
-                ASSIGN, List.of(List.of())).isEmpty(), "avg(bigint) is not pushed");
-        assertTrue(metadata.applyAggregation(
+                ASSIGN, List.of(List.of())).orElseThrow();
+        JsonNode intAggs = aggSpec((CqliteFlightTableHandle) intResult.getHandle()).get("aggregates");
+        assertEquals("SumDouble", intAggs.get(0).get("func").asText(),
+                "integer avg's sum partial must be SumDouble (non-overflowing)");
+        assertEquals("Count", intAggs.get(1).get("func").asText());
+
+        var doubleResult = metadata.applyAggregation(
                 null, TABLE, List.of(agg("avg", DOUBLE, new Variable("d", DOUBLE))),
-                ASSIGN, List.of(List.of())).isPresent(), "avg(double) still pushes");
+                ASSIGN, List.of(List.of())).orElseThrow();
+        JsonNode dblAggs = aggSpec((CqliteFlightTableHandle) doubleResult.getHandle()).get("aggregates");
+        assertEquals("SumDouble", dblAggs.get(0).get("func").asText());
     }
 
     @Test
@@ -230,15 +238,25 @@ class CqliteFlightMetadataApplyAggregationTest {
     }
 
     @Test
-    void declinesMinMaxOnDoubleColumn() {
-        // Float/double min/max is left to Trino (NaN ordering must match exactly).
-        assertTrue(metadata.applyAggregation(
+    void pushesMinMaxOnDoubleColumn() throws Exception {
+        // Float/double min/max now pushes (issue #896): the Rust accumulator and
+        // the Java merger both order NaN as the largest value (Double.compare),
+        // matching Trino and making the result order-independent.
+        var minResult = metadata.applyAggregation(
                 null, TABLE, List.of(agg("min", DOUBLE, new Variable("d", DOUBLE))),
-                ASSIGN, List.of(List.of())).isEmpty(), "min(double) is not pushed");
-        assertTrue(metadata.applyAggregation(
+                ASSIGN, List.of(List.of())).orElseThrow();
+        assertEquals("Min",
+                aggSpec((CqliteFlightTableHandle) minResult.getHandle())
+                        .get("aggregates").get(0).get("func").asText());
+
+        var maxResult = metadata.applyAggregation(
                 null, TABLE, List.of(agg("max", DOUBLE, new Variable("d", DOUBLE))),
-                ASSIGN, List.of(List.of())).isEmpty(), "max(double) is not pushed");
-        // But sum(double) and avg(double) still push (NaN propagates identically).
+                ASSIGN, List.of(List.of())).orElseThrow();
+        assertEquals("Max",
+                aggSpec((CqliteFlightTableHandle) maxResult.getHandle())
+                        .get("aggregates").get(0).get("func").asText());
+
+        // sum(double) still pushes too (NaN propagates identically through f64 sum).
         assertTrue(metadata.applyAggregation(
                 null, TABLE, List.of(agg("sum", DOUBLE, new Variable("d", DOUBLE))),
                 ASSIGN, List.of(List.of())).isPresent(), "sum(double) still pushes");

--- a/trino-connector/src/test/java/com/rustyrazorblade/cqlite/flight/PartialAggregateMergerTest.java
+++ b/trino-connector/src/test/java/com/rustyrazorblade/cqlite/flight/PartialAggregateMergerTest.java
@@ -8,6 +8,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for the partial-merge logic ({@link PartialAggregateMerger}): feed two
@@ -195,5 +196,56 @@ class PartialAggregateMergerTest {
         merger.combine(globalKey, row("agg0", 1.5));
         merger.combine(globalKey, row("agg0", 2.25));
         assertEquals(3.75, (Double) merger.finish().get(0).outputs().get("agg0"), 1e-9);
+    }
+
+    @Test
+    void sumDoubleNumeratorNeverOverflows() {
+        // The avg numerator (SumDouble) totals in double even across ranges whose
+        // combined integer sum exceeds i64 — where a plain integer Sum would throw
+        // (issue #902). Each range ships its partial already widened to double.
+        var aggregates = List.of(
+                new AggregationSpec.Aggregate(AggregationSpec.Func.SumDouble, "x", "agg0"),
+                new AggregationSpec.Aggregate(AggregationSpec.Func.Count, "x", "agg1"));
+        var merger = new PartialAggregateMerger(aggregates);
+        var globalKey = new PartialAggregateMerger.GroupKey(List.of());
+        double big = (double) Long.MAX_VALUE;
+        merger.combine(globalKey, row("agg0", big, "agg1", 1L));
+        merger.combine(globalKey, row("agg0", big, "agg1", 1L)); // sum ≈ 2^64, no overflow
+
+        var out = merger.finish().get(0).outputs();
+        assertEquals(big + big, (Double) out.get("agg0"), 0.0, "SumDouble totals past i64 in f64");
+        assertEquals(2L, out.get("agg1"));
+        // avg = Σsum/Σcount.
+        assertEquals(big, ((Number) out.get("agg0")).doubleValue() / 2.0, 0.0);
+    }
+
+    @Test
+    void sumDoubleNullWhenNoNonNullInputs() {
+        var aggregates = List.of(
+                new AggregationSpec.Aggregate(AggregationSpec.Func.SumDouble, "x", "agg0"));
+        var merger = new PartialAggregateMerger(aggregates);
+        var globalKey = new PartialAggregateMerger.GroupKey(List.of());
+        merger.combine(globalKey, row("agg0", null));
+        merger.combine(globalKey, row("agg0", null));
+        assertNull(merger.finish().get(0).outputs().get("agg0"), "SumDouble null when all-null");
+    }
+
+    @Test
+    void floatMinMaxOrdersNanGreatest() {
+        // Across ranges, max(double) over a NaN partial must return NaN and
+        // min(double) must ignore it — Double.compare orders NaN greatest, matching
+        // Trino and the Rust accumulator (issue #896). Order-independent.
+        var aggregates = List.of(
+                new AggregationSpec.Aggregate(AggregationSpec.Func.Min, "x", "agg0"),
+                new AggregationSpec.Aggregate(AggregationSpec.Func.Max, "x", "agg1"));
+        var merger = new PartialAggregateMerger(aggregates);
+        var globalKey = new PartialAggregateMerger.GroupKey(List.of());
+        // One range's partial is NaN (its only/extreme value), the other finite.
+        merger.combine(globalKey, row("agg0", Double.NaN, "agg1", Double.NaN));
+        merger.combine(globalKey, row("agg0", 2.0, "agg1", 5.0));
+
+        var out = merger.finish().get(0).outputs();
+        assertEquals(2.0, (Double) out.get("agg0"), 0.0, "min ignores NaN");
+        assertTrue(Double.isNaN((Double) out.get("agg1")), "max over a NaN is NaN");
     }
 }


### PR DESCRIPTION
Closes #902. Closes #896. Part of epic #918 (the remaining child #893 — high-cardinality cardinality gate — stays open for a follow-up PR, per scoping decision).

Removes two correctness decline-gates from the Flight/Trino aggregation-pushdown path so previously-local cases now push to the cqlite-flight server while matching Trino's semantics exactly.

## #902 — integer `avg()` pushes without overflow
`avg(x)` was declined on integer columns because its partial `Sum` used checked i64 (to match `sum(bigint)` overflow), but Trino's `avg` accumulates in 128-bit and never overflows — so a pushed integer avg could fail a query Trino would answer.

- New `AggFunc::SumDouble` (Rust) / `Func.SumDouble` (Java): a sum coerced to `f64` regardless of source type, widening integer inputs so the running total can never overflow. Used **only** as the numerator of a pushed `avg(col)`; a plain `Sum` keeps its checked-i64 overflow semantics.
- `applyAggregation` now decomposes `avg(x)` into `SumDouble(x) + Count(x)` for all numeric columns; the integer-avg decline gate is gone.

## #896 — float/double `min`/`max` push with Trino NaN ordering
Float/double `min`/`max` was declined because the Rust accumulator treated a NaN comparison as `Equal` (order-dependent) while the Java merger used `Double.compare` (NaN sorts greatest) — two different conventions.

- Rust `compare_values` now orders NaN as the largest value via `cmp_f64_trino` (Java `Double.compare` semantics): `max` returns NaN when any input is NaN, `min` ignores NaN unless all inputs are NaN. Result is independent of input row order and identical to the Java merger.
- Decline gates removed on both sides (`RealType`/`DoubleType` in `applyAggregation`, `MinMaxFloatUnsupported` in `agg.rs`).

## Tests
- **Rust** (`agg.rs`): NaN order-independence (NaN-first vs NaN-last), all-NaN → NaN, `SumDouble` non-overflow on a total past i64::MAX. (`producer.rs`): `SumDouble` emits a Float64 partial through the real merge path.
- **Java**: merger `SumDouble` non-overflow + null-when-all-null + float min/max NaN ordering; `applyAggregation` now asserts integer `avg` and double `min`/`max` push (and that the avg sum partial is `SumDouble`).
- **E2E** (`docker/e2e-*`): `events` gains a `ratio double` column; asserts `min/max/avg(ratio)` and the now-pushed `avg(score)` (integer) through the connector.

Local: `cargo fmt`/`clippy -D warnings`/`test` green for cqlite-flight; `./gradlew test` green for the connector. The docker E2E runs in CI.