### PR TITLE
fix(compaction): filter dropped-column cells during compaction (#847)

### DIFF
--- a/cqlite-cli/src/commands/info.rs
+++ b/cqlite-cli/src/commands/info.rs
@@ -436,6 +436,7 @@ fn parse_json_schema(schema_content: &str) -> Result<TableSchema> {
         partition_keys: Vec::new(),
         clustering_keys: Vec::new(),
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     })
 }
 

--- a/cqlite-cli/src/commands/mod.rs
+++ b/cqlite-cli/src/commands/mod.rs
@@ -1751,17 +1751,28 @@ fn parse_json_schema(json: &serde_json::Value) -> Result<TableSchema> {
     }
 
     // Optional dropped-column drop times (column → drop_time_micros) used for
-    // dropped-column filtering during compaction (#904/#847). Absent → empty.
+    // dropped-column filtering during compaction (#904/#847). Absent → empty; a
+    // present-but-malformed field is a hard error (not silently ignored) so a
+    // typo can't leave stale cells unpurged.
     let mut dropped_columns = HashMap::new();
-    if let Some(dropped) = json.get("dropped_columns").and_then(|v| v.as_object()) {
-        for (name, ts) in dropped {
-            let drop_time = ts.as_i64().ok_or_else(|| {
-                anyhow::anyhow!(
-                    "dropped_columns['{}'] must be an integer drop time in microseconds",
-                    name
-                )
-            })?;
-            dropped_columns.insert(name.clone(), drop_time);
+    match json.get("dropped_columns") {
+        None | Some(serde_json::Value::Null) => {}
+        Some(serde_json::Value::Object(dropped)) => {
+            for (name, ts) in dropped {
+                let drop_time = ts.as_i64().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "dropped_columns['{}'] must be an integer drop time in microseconds",
+                        name
+                    )
+                })?;
+                dropped_columns.insert(name.clone(), drop_time);
+            }
+        }
+        Some(_) => {
+            return Err(anyhow::anyhow!(
+                "schema field `dropped_columns` must be an object mapping column \
+                 name → drop time in microseconds"
+            ));
         }
     }
 
@@ -2940,6 +2951,27 @@ mod dropped_column_json_tests {
             schema.dropped_columns.get("legacy"),
             Some(&1_700_000_000_000_000_i64),
             "CLI JSON loader must preserve dropped_columns drop time"
+        );
+    }
+
+    /// A `dropped_columns` field of the wrong shape (not an object) is a clear
+    /// error, not silently ignored — a typo must not leave stale cells unpurged.
+    #[test]
+    fn parse_json_schema_rejects_non_object_dropped_columns() {
+        let json: serde_json::Value = serde_json::from_str(
+            r#"{
+                "keyspace": "ks",
+                "table": "t",
+                "columns": {"id": {"type": "uuid", "kind": "PartitionKey"}},
+                "dropped_columns": ["legacy"]
+            }"#,
+        )
+        .expect("json parses");
+
+        let err = parse_json_schema(&json).expect_err("non-object dropped_columns must error");
+        assert!(
+            err.to_string().contains("dropped_columns"),
+            "error must name the offending field, got: {err}"
         );
     }
 

--- a/cqlite-cli/src/commands/mod.rs
+++ b/cqlite-cli/src/commands/mod.rs
@@ -1757,6 +1757,7 @@ fn parse_json_schema(json: &serde_json::Value) -> Result<TableSchema> {
         partition_keys,
         clustering_keys: clustering_columns,
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     })
 }
 

--- a/cqlite-cli/src/commands/mod.rs
+++ b/cqlite-cli/src/commands/mod.rs
@@ -1750,6 +1750,21 @@ fn parse_json_schema(json: &serde_json::Value) -> Result<TableSchema> {
         schema_columns.push(column);
     }
 
+    // Optional dropped-column drop times (column → drop_time_micros) used for
+    // dropped-column filtering during compaction (#904/#847). Absent → empty.
+    let mut dropped_columns = HashMap::new();
+    if let Some(dropped) = json.get("dropped_columns").and_then(|v| v.as_object()) {
+        for (name, ts) in dropped {
+            let drop_time = ts.as_i64().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "dropped_columns['{}'] must be an integer drop time in microseconds",
+                    name
+                )
+            })?;
+            dropped_columns.insert(name.clone(), drop_time);
+        }
+    }
+
     Ok(TableSchema {
         keyspace: keyspace.to_string(),
         table: table.to_string(),
@@ -1757,7 +1772,7 @@ fn parse_json_schema(json: &serde_json::Value) -> Result<TableSchema> {
         partition_keys,
         clustering_keys: clustering_columns,
         comments: HashMap::new(),
-        dropped_columns: HashMap::new(),
+        dropped_columns,
     })
 }
 
@@ -2894,5 +2909,56 @@ async fn benchmark_query_operation(
             }
         }
         Err(_) => Ok(0),
+    }
+}
+
+#[cfg(test)]
+mod dropped_column_json_tests {
+    use super::*;
+
+    /// The CLI JSON schema loader must carry `dropped_columns` into the
+    /// `TableSchema` so `cqlite compact --schema x.json` can supply drop times
+    /// for dropped-column filtering (#904/#847). The dropped column stays in
+    /// `columns` (decode contract).
+    #[test]
+    fn parse_json_schema_preserves_dropped_columns() {
+        let json: serde_json::Value = serde_json::from_str(
+            r#"{
+                "keyspace": "ks",
+                "table": "t",
+                "columns": {
+                    "id": {"type": "uuid", "kind": "PartitionKey"},
+                    "legacy": {"type": "int", "kind": "Regular"}
+                },
+                "dropped_columns": {"legacy": 1700000000000000}
+            }"#,
+        )
+        .expect("json parses");
+
+        let schema = parse_json_schema(&json).expect("schema parses");
+        assert_eq!(
+            schema.dropped_columns.get("legacy"),
+            Some(&1_700_000_000_000_000_i64),
+            "CLI JSON loader must preserve dropped_columns drop time"
+        );
+    }
+
+    /// A non-integer drop time is a clear error rather than a silent drop.
+    #[test]
+    fn parse_json_schema_rejects_non_integer_drop_time() {
+        let json: serde_json::Value = serde_json::from_str(
+            r#"{
+                "keyspace": "ks",
+                "table": "t",
+                "columns": {"id": {"type": "uuid", "kind": "PartitionKey"}},
+                "dropped_columns": {"legacy": "not-a-number"}
+            }"#,
+        )
+        .expect("json parses");
+
+        assert!(
+            parse_json_schema(&json).is_err(),
+            "a non-integer drop time must be rejected"
+        );
     }
 }

--- a/cqlite-cli/src/commands/schema.rs
+++ b/cqlite-cli/src/commands/schema.rs
@@ -448,6 +448,7 @@ fn parse_cql_ddl(cql_content: &str) -> Result<TableSchema> {
         clustering_keys,
         columns,
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     };
 
     // Validate the parsed schema

--- a/cqlite-cli/tests/unit_tests.rs
+++ b/cqlite-cli/tests/unit_tests.rs
@@ -607,6 +607,7 @@ mod test_helpers {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 

--- a/cqlite-core/examples/gen_wide_sstable.rs
+++ b/cqlite-core/examples/gen_wide_sstable.rs
@@ -60,6 +60,7 @@ async fn main() -> cqlite_core::error::Result<()> {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     };
 
     let config = WriteEngineConfig::new(out.join("data"), out.join("wal"), schema.clone());

--- a/cqlite-core/examples/write_a_mutation.rs
+++ b/cqlite-core/examples/write_a_mutation.rs
@@ -48,6 +48,7 @@ fn main() -> cqlite_core::error::Result<()> {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     };
 
     // 2. Create the write engine. `data_dir` holds flushed SSTables; `wal_dir`

--- a/cqlite-core/src/cql/nom_backend.rs
+++ b/cqlite-core/src/cql/nom_backend.rs
@@ -305,6 +305,7 @@ impl NomParser {
                 .iter()
                 .map(|(k, v)| (k.clone(), format!("{:?}", v)))
                 .collect(),
+            dropped_columns: std::collections::HashMap::new(),
         }
     }
 

--- a/cqlite-core/src/cql/schema_integration.rs
+++ b/cqlite-core/src/cql/schema_integration.rs
@@ -299,6 +299,7 @@ mod tests {
             clustering_keys: vec![],
             columns: vec![],
             comments: std::collections::HashMap::new(),
+            dropped_columns: std::collections::HashMap::new(),
         };
 
         assert!(table_name_matches_enhanced(&schema, "test_table"));

--- a/cqlite-core/src/cql/visitor.rs
+++ b/cqlite-core/src/cql/visitor.rs
@@ -1039,6 +1039,7 @@ impl CqlVisitor<TableSchema> for SchemaBuilderVisitor {
             clustering_keys,
             columns,
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         })
     }
 

--- a/cqlite-core/src/export/delta_parquet.rs
+++ b/cqlite-core/src/export/delta_parquet.rs
@@ -860,6 +860,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 

--- a/cqlite-core/src/export/delta_schema.rs
+++ b/cqlite-core/src/export/delta_schema.rs
@@ -509,6 +509,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 
@@ -678,6 +679,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let schema =
@@ -748,6 +750,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let schema =
@@ -804,6 +807,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let err = derive_delta_schema(&table, &DeltaSchemaOpts::default())
@@ -846,6 +850,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let err = derive_delta_schema(&table, &DeltaSchemaOpts::default())
@@ -890,6 +895,7 @@ mod tests {
                 is_static: false,
             }],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let err = derive_delta_schema(&table, &DeltaSchemaOpts::default())
@@ -939,6 +945,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let err = derive_delta_schema(&table, &DeltaSchemaOpts::default())
@@ -987,6 +994,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         // Default prefix → collision.
@@ -1046,6 +1054,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let opts = DeltaSchemaOpts::with_prefix("_cqlite_");
@@ -1091,6 +1100,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let err = derive_delta_schema(&table, &DeltaSchemaOpts::default())
@@ -1176,6 +1186,7 @@ mod tests {
                     },
                 ],
                 comments: HashMap::new(),
+                dropped_columns: HashMap::new(),
             };
 
             let schema = derive_delta_schema(&table, &DeltaSchemaOpts::default())
@@ -1224,6 +1235,7 @@ mod tests {
                 is_static: false,
             }],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let schema =
@@ -1296,6 +1308,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let schema =
@@ -1353,6 +1366,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let schema =
@@ -1402,6 +1416,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let schema =

--- a/cqlite-core/src/query/select_executor.rs
+++ b/cqlite-core/src/query/select_executor.rs
@@ -1994,6 +1994,7 @@ mod tests {
             clustering_keys: vec![],
             columns: vec![],
             comments: std::collections::HashMap::new(),
+            dropped_columns: std::collections::HashMap::new(),
         }
     }
 

--- a/cqlite-core/src/schema/aggregator.rs
+++ b/cqlite-core/src/schema/aggregator.rs
@@ -136,6 +136,10 @@ struct MinimalTableSchema {
     primary_key: Vec<String>, // Synonym for partition_keys when no clustering
     #[serde(default)]
     clustering_keys: Vec<JsonClusteringKey>,
+    /// Dropped-column drop times (column → drop_time_micros), used for
+    /// dropped-column filtering during compaction (#904/#847).
+    #[serde(default)]
+    dropped_columns: HashMap<String, i64>,
 }
 
 /// Full JSON schema format (multiple tables + UDTs)
@@ -160,6 +164,10 @@ struct JsonTable {
     primary_key: Vec<String>,
     #[serde(default)]
     clustering_keys: Vec<JsonClusteringKey>,
+    /// Dropped-column drop times (column → drop_time_micros), used for
+    /// dropped-column filtering during compaction (#904/#847).
+    #[serde(default)]
+    dropped_columns: HashMap<String, i64>,
 }
 
 /// JSON column definition
@@ -731,7 +739,7 @@ impl SchemaAggregator {
             clustering_keys,
             columns,
             comments: HashMap::new(),
-            dropped_columns: HashMap::new(),
+            dropped_columns: minimal.dropped_columns,
         };
 
         schema.validate()?;
@@ -809,7 +817,7 @@ impl SchemaAggregator {
             clustering_keys,
             columns,
             comments: HashMap::new(),
-            dropped_columns: HashMap::new(),
+            dropped_columns: table_json.dropped_columns,
         };
 
         schema.validate()?;
@@ -1010,6 +1018,40 @@ mod tests {
         assert_eq!(result.schemas_loaded, 1);
         assert_eq!(result.udts_loaded, 0);
         assert!(result.errors.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_minimal_json_preserves_dropped_columns() {
+        // A JSON schema may carry dropped-column drop times (#904/#847). The
+        // dropped column stays declared in `columns` (decode contract) and is
+        // listed in `dropped_columns` with its drop time in micros.
+        let (aggregator, _temp_dir) = setup_test_aggregator().await;
+
+        let json_content = r#"
+        {
+            "keyspace": "test_ks",
+            "table": "events",
+            "columns": [
+                {"name": "id", "type": "uuid"},
+                {"name": "legacy", "type": "int"}
+            ],
+            "partition_keys": ["id"],
+            "clustering_keys": [],
+            "dropped_columns": {"legacy": 1700000000000000}
+        }
+        "#;
+
+        let minimal: MinimalTableSchema =
+            serde_json::from_str(json_content).expect("minimal schema parses");
+        let schema = aggregator
+            .convert_minimal_to_table_schema(minimal)
+            .expect("conversion succeeds");
+
+        assert_eq!(
+            schema.dropped_columns.get("legacy"),
+            Some(&1_700_000_000_000_000_i64),
+            "dropped_columns drop time must survive JSON loading"
+        );
     }
 
     #[tokio::test]

--- a/cqlite-core/src/schema/aggregator.rs
+++ b/cqlite-core/src/schema/aggregator.rs
@@ -731,6 +731,7 @@ impl SchemaAggregator {
             clustering_keys,
             columns,
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         schema.validate()?;
@@ -808,6 +809,7 @@ impl SchemaAggregator {
             clustering_keys,
             columns,
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         schema.validate()?;

--- a/cqlite-core/src/schema/cql_generator.rs
+++ b/cqlite-core/src/schema/cql_generator.rs
@@ -752,6 +752,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let result = generator.generate_from_table_schema(&schema).unwrap();
@@ -806,6 +807,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let result = generator.generate_from_table_schema(&schema).unwrap();
@@ -844,6 +846,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let result = generator.generate_from_table_schema(&schema).unwrap();

--- a/cqlite-core/src/schema/cql_parser.rs
+++ b/cqlite-core/src/schema/cql_parser.rs
@@ -894,6 +894,7 @@ pub fn parse_create_table(input: &str) -> IResult<&str, TableSchema> {
             .into_iter()
             .map(|(k, v)| (k.to_lowercase(), v))
             .collect(),
+        dropped_columns: std::collections::HashMap::new(),
     };
 
     Ok((input, schema))

--- a/cqlite-core/src/schema/mod.rs
+++ b/cqlite-core/src/schema/mod.rs
@@ -83,6 +83,18 @@ pub struct TableSchema {
     /// Optional metadata
     #[serde(default)]
     pub comments: HashMap<String, String>,
+
+    /// Dropped-column drop times in microseconds (column name → drop_time_micros).
+    ///
+    /// Populated from the schema-loading surface (JSON `dropped_columns`, or set
+    /// programmatically) since drop times are assigned at DDL-execution by the
+    /// cluster catalog (`system_schema.dropped_columns`) and are not recorded in
+    /// local SSTable files or the CQL `DROP COLUMN` text. Used during compaction
+    /// to discard cells of a dropped column whose timestamp ≤ the drop time
+    /// (Cassandra `cb34ad47`). See issues #904 (this plumbing) and #847 (the
+    /// merge-side filter).
+    #[serde(default)]
+    pub dropped_columns: HashMap<String, i64>,
 }
 
 /// Partition key column definition
@@ -668,6 +680,7 @@ impl TableSchema {
             clustering_keys,
             columns,
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         schema.validate()?;
@@ -1053,6 +1066,7 @@ impl TableSchema {
                 is_static: false,
             }],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 }
@@ -1471,6 +1485,7 @@ impl SchemaManager {
                 is_static: false,
             }],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 
@@ -1660,6 +1675,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 

--- a/cqlite-core/src/schema/mod.rs
+++ b/cqlite-core/src/schema/mod.rs
@@ -103,6 +103,10 @@ pub struct TableSchema {
     /// misparse. Supporting per-version types requires carrying type metadata
     /// here (or decoding from the SSTable serialization-header type) and is
     /// follow-up work alongside the element-level representation in #899.
+    ///
+    /// Filtering is also at row-timestamp granularity (the merge stream surfaces
+    /// only the row write-time per cell); exact per-cell purging is tracked as
+    /// follow-up #922.
     #[serde(default)]
     pub dropped_columns: HashMap<String, i64>,
 }

--- a/cqlite-core/src/schema/mod.rs
+++ b/cqlite-core/src/schema/mod.rs
@@ -93,6 +93,16 @@ pub struct TableSchema {
     /// to discard cells of a dropped column whose timestamp ≤ the drop time
     /// (Cassandra `cb34ad47`). See issues #904 (this plumbing) and #847 (the
     /// merge-side filter).
+    ///
+    /// Scope (#847): this map carries only the drop time, so the dropped column's
+    /// pre-drop cells are decoded using its CURRENT type in [`Self::columns`] (the
+    /// decode contract enforced by [`Self::validate_dropped_columns`]). That is
+    /// byte-correct when the column's type is unchanged — the common case. A
+    /// column dropped and later RE-ADDED with a DIFFERENT type is out of scope:
+    /// the historical cells would be decoded with the new type and could
+    /// misparse. Supporting per-version types requires carrying type metadata
+    /// here (or decoding from the SSTable serialization-header type) and is
+    /// follow-up work alongside the element-level representation in #899.
     #[serde(default)]
     pub dropped_columns: HashMap<String, i64>,
 }

--- a/cqlite-core/src/schema/mod.rs
+++ b/cqlite-core/src/schema/mod.rs
@@ -797,6 +797,45 @@ impl TableSchema {
         Ok(())
     }
 
+    /// The **post-drop** schema that compaction uses to *write* its output.
+    ///
+    /// The decode schema retains dropped columns (carrying their type) so input
+    /// cells can be parsed and then purged by the merge filter (see
+    /// [`Self::validate_dropped_columns`]). The compaction *output*, however,
+    /// must NOT encode dropped columns in its serialization header / row column
+    /// bitmap: a reader using a natural post-drop schema (one that omits the
+    /// dropped column) intersects the on-disk header with its `columns` and would
+    /// drop that header column *before* applying bitmap indices, misaligning the
+    /// surviving columns that sort after it (roborev #847 review).
+    ///
+    /// Because the merge filter has already purged the dropped columns' cells,
+    /// this returns a schema with those columns removed from `columns` and an
+    /// empty `dropped_columns` map — so the output header reflects the live,
+    /// post-drop column set and is readable by any matching schema.
+    ///
+    /// Scope note: a column re-added after its drop (cells with `ts > drop_time`)
+    /// is treated as dropped here and is not retained in the output, consistent
+    /// with the scalar / row-timestamp granularity of dropped-column filtering
+    /// (#847); element-level retention is follow-up work (#899).
+    pub fn for_compaction_output(&self) -> TableSchema {
+        let dropped: std::collections::HashSet<&str> =
+            self.dropped_columns.keys().map(String::as_str).collect();
+        TableSchema {
+            keyspace: self.keyspace.clone(),
+            table: self.table.clone(),
+            partition_keys: self.partition_keys.clone(),
+            clustering_keys: self.clustering_keys.clone(),
+            columns: self
+                .columns
+                .iter()
+                .filter(|c| !dropped.contains(c.name.as_str()))
+                .cloned()
+                .collect(),
+            comments: self.comments.clone(),
+            dropped_columns: HashMap::new(),
+        }
+    }
+
     /// Validate the dropped-column decode contract (#904/#847).
     ///
     /// Dropped-column filtering during compaction discards a dropped column's

--- a/cqlite-core/src/schema/mod.rs
+++ b/cqlite-core/src/schema/mod.rs
@@ -792,6 +792,37 @@ impl TableSchema {
             }
         }
 
+        self.validate_dropped_columns()?;
+
+        Ok(())
+    }
+
+    /// Validate the dropped-column decode contract (#904/#847).
+    ///
+    /// Dropped-column filtering during compaction discards a dropped column's
+    /// cells *after they are decoded*. The schema-driven reader only decodes a
+    /// column whose name is present in [`Self::columns`] (it intersects the
+    /// on-disk serialization-header columns with the schema); a column absent
+    /// from `columns` is skipped without consuming its bytes, so its cells would
+    /// never reach the filter and surrounding columns could misalign.
+    ///
+    /// Therefore every column named in `dropped_columns` MUST remain declared in
+    /// `columns` (carrying its type) so its cells decode and can be purged. This
+    /// mirrors Cassandra retaining a dropped column's type in
+    /// `system_schema.dropped_columns`. Decoding a dropped column that is absent
+    /// from `columns` (purely from header type metadata) is follow-up work
+    /// related to #899 and intentionally out of scope here.
+    pub fn validate_dropped_columns(&self) -> Result<()> {
+        for name in self.dropped_columns.keys() {
+            if !self.columns.iter().any(|c| &c.name == name) {
+                return Err(Error::schema(format!(
+                    "dropped column '{}' must remain declared in `columns` (with its type) so \
+                     its cells can be decoded and purged during compaction; a dropped column \
+                     present only in `dropped_columns` cannot be decoded (see #904/#847)",
+                    name
+                )));
+            }
+        }
         Ok(())
     }
 

--- a/cqlite-core/src/schema/mod.rs
+++ b/cqlite-core/src/schema/mod.rs
@@ -801,25 +801,29 @@ impl TableSchema {
     ///
     /// The decode schema retains dropped columns (carrying their type) so input
     /// cells can be parsed and then purged by the merge filter (see
-    /// [`Self::validate_dropped_columns`]). The compaction *output*, however,
-    /// must NOT encode dropped columns in its serialization header / row column
-    /// bitmap: a reader using a natural post-drop schema (one that omits the
-    /// dropped column) intersects the on-disk header with its `columns` and would
-    /// drop that header column *before* applying bitmap indices, misaligning the
-    /// surviving columns that sort after it (roborev #847 review).
+    /// [`Self::validate_dropped_columns`]). The compaction *output* must keep its
+    /// serialization header / row column bitmap consistent with the cells that
+    /// actually survive the merge:
     ///
-    /// Because the merge filter has already purged the dropped columns' cells,
-    /// this returns a schema with those columns removed from `columns` and an
-    /// empty `dropped_columns` map — so the output header reflects the live,
-    /// post-drop column set and is readable by any matching schema.
+    /// - A dropped column with **no surviving cells** (all cells were at or
+    ///   before its drop time) is removed from `columns` so it does not appear in
+    ///   the output header. This lets a natural post-drop reader schema (which
+    ///   omits the column) read the output without the header-column /
+    ///   bitmap-index misalignment that retaining it would cause (roborev #847).
+    /// - A dropped column with **surviving cells** (re-added: cells written after
+    ///   `drop_time`) is RETAINED in `columns`, because the merge still emits
+    ///   those cells and the writer needs a matching header column — otherwise
+    ///   the cell would be serialized with no header entry and corrupt the row.
     ///
-    /// Scope note: a column re-added after its drop (cells with `ts > drop_time`)
-    /// is treated as dropped here and is not retained in the output, consistent
-    /// with the scalar / row-timestamp granularity of dropped-column filtering
-    /// (#847); element-level retention is follow-up work (#899).
-    pub fn for_compaction_output(&self) -> TableSchema {
-        let dropped: std::collections::HashSet<&str> =
-            self.dropped_columns.keys().map(String::as_str).collect();
+    /// `retained` is the set of dropped-column names that had surviving cells
+    /// (computed by `compact_sstables` from a merge pre-pass). The returned
+    /// schema carries an empty `dropped_columns` map: the purge has already
+    /// happened, so the output must not re-purge the surviving cells on a later
+    /// compaction.
+    pub fn for_compaction_output(
+        &self,
+        retained: &std::collections::HashSet<String>,
+    ) -> TableSchema {
         TableSchema {
             keyspace: self.keyspace.clone(),
             table: self.table.clone(),
@@ -828,7 +832,11 @@ impl TableSchema {
             columns: self
                 .columns
                 .iter()
-                .filter(|c| !dropped.contains(c.name.as_str()))
+                .filter(|c| {
+                    // Keep a column unless it is a dropped column with no
+                    // surviving cells.
+                    !self.dropped_columns.contains_key(&c.name) || retained.contains(&c.name)
+                })
                 .cloned()
                 .collect(),
             comments: self.comments.clone(),

--- a/cqlite-core/src/schema/parser_tests.rs
+++ b/cqlite-core/src/schema/parser_tests.rs
@@ -65,6 +65,7 @@ mod parser_tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 
@@ -376,6 +377,7 @@ mod parser_tests {
                 clustering_keys: vec![],
                 columns: vec![],
                 comments: HashMap::new(),
+                dropped_columns: HashMap::new(),
             },
             partition_comparators: vec![],
             clustering_comparators: vec![],
@@ -460,6 +462,7 @@ mod parser_tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let mut column_comparators = HashMap::new();

--- a/cqlite-core/src/schema/registry.rs
+++ b/cqlite-core/src/schema/registry.rs
@@ -1017,6 +1017,7 @@ impl SchemaRegistry {
             clustering_keys,
             columns,
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         })
     }
 
@@ -1486,6 +1487,7 @@ mod tests {
                 is_static: false,
             }],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 

--- a/cqlite-core/src/storage/partition_key_codec.rs
+++ b/cqlite-core/src/storage/partition_key_codec.rs
@@ -242,6 +242,7 @@ mod tests {
             clustering_keys: vec![],
             columns: vec![],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 

--- a/cqlite-core/src/storage/schema_discovery.rs
+++ b/cqlite-core/src/storage/schema_discovery.rs
@@ -373,6 +373,7 @@ impl SchemaDiscovery {
             clustering_keys: vec![],
             columns,
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         })
     }
 

--- a/cqlite-core/src/storage/sstable/key_digest.rs
+++ b/cqlite-core/src/storage/sstable/key_digest.rs
@@ -299,6 +299,7 @@ mod tests {
             clustering_keys: vec![],
             columns: vec![],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         ParsingContext {

--- a/cqlite-core/src/storage/sstable/key_digest_integration_test.rs
+++ b/cqlite-core/src/storage/sstable/key_digest_integration_test.rs
@@ -67,6 +67,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 
@@ -213,6 +214,7 @@ mod tests {
                 clustering_keys: vec![],
                 columns: vec![],
                 comments: HashMap::new(),
+                dropped_columns: HashMap::new(),
             };
 
             registry
@@ -324,6 +326,7 @@ mod tests {
             clustering_keys: vec![],
             columns: vec![],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         registry

--- a/cqlite-core/src/storage/sstable/key_digest_test.rs
+++ b/cqlite-core/src/storage/sstable/key_digest_test.rs
@@ -29,6 +29,7 @@ mod tests {
             clustering_keys: vec![],
             columns: vec![],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         ParsingContext {

--- a/cqlite-core/src/storage/sstable/reader/delta_scan.rs
+++ b/cqlite-core/src/storage/sstable/reader/delta_scan.rs
@@ -1602,6 +1602,7 @@ mod tests {
                 },
             ],
             comments: std::collections::HashMap::new(),
+            dropped_columns: std::collections::HashMap::new(),
         };
 
         let (mut rx, _scan_summary) = scan_delta(table_dir, schema, 64);
@@ -1705,6 +1706,7 @@ mod tests {
                 },
             ],
             comments: std::collections::HashMap::new(),
+            dropped_columns: std::collections::HashMap::new(),
         };
 
         let (mut rx, _scan_summary) = scan_delta(table_dir, schema, 64);
@@ -1836,6 +1838,7 @@ mod tests {
                 },
             ],
             comments: std::collections::HashMap::new(),
+            dropped_columns: std::collections::HashMap::new(),
         };
 
         let (mut rx, _scan_summary) = scan_delta(table_dir, schema, 64);
@@ -1990,6 +1993,7 @@ mod tests {
                 },
             ],
             comments: std::collections::HashMap::new(),
+            dropped_columns: std::collections::HashMap::new(),
         };
 
         let (mut rx, _scan_summary) = scan_delta(table_dir, schema, 64);
@@ -2208,6 +2212,7 @@ mod tests {
             clustering_keys: vec![],
             columns: vec![],
             comments: std::collections::HashMap::new(),
+            dropped_columns: std::collections::HashMap::new(),
         };
 
         // Crafted range tombstone marker with bound_kind = 99 (unrecognised).
@@ -2453,6 +2458,7 @@ mod tests {
                 is_static: false,
             }],
             comments: std::collections::HashMap::new(),
+            dropped_columns: std::collections::HashMap::new(),
         };
 
         let (mut rx, _scan_summary) = scan_delta(table_dir, schema, 64);
@@ -2561,6 +2567,7 @@ mod tests {
                 is_static: false,
             }],
             comments: std::collections::HashMap::new(),
+            dropped_columns: std::collections::HashMap::new(),
         };
 
         let (mut rx, _scan_summary) = scan_delta(table_dir, schema, 64);
@@ -2670,6 +2677,7 @@ mod tests {
                 is_static: false,
             }],
             comments: std::collections::HashMap::new(),
+            dropped_columns: std::collections::HashMap::new(),
         };
 
         let (mut rx, _scan_summary) = scan_delta(table_dir, schema, 64);
@@ -2802,6 +2810,7 @@ mod tests {
                 is_static: false,
             }],
             comments: std::collections::HashMap::new(),
+            dropped_columns: std::collections::HashMap::new(),
         };
 
         let (mut rx, _scan_summary) = scan_delta(table_dir, schema, 128);
@@ -3025,6 +3034,7 @@ mod tests {
                 },
             ],
             comments: std::collections::HashMap::new(),
+            dropped_columns: std::collections::HashMap::new(),
         };
 
         let (mut rx, summary_handle) = scan_delta(table_dir, schema, 64);

--- a/cqlite-core/src/storage/sstable/reader/parsing/key_parsing.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/key_parsing.rs
@@ -465,6 +465,7 @@ mod tests {
             clustering_keys: vec![],
             columns: vec![],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 
@@ -485,6 +486,7 @@ mod tests {
             clustering_keys: vec![],
             columns: vec![],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 

--- a/cqlite-core/src/storage/sstable/reader/parsing/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/mod.rs
@@ -265,6 +265,7 @@ impl SSTableReader {
             clustering_keys,
             columns,
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         })
     }
 

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
@@ -2705,6 +2705,7 @@ impl V5CompressedLegacyParser {
                 clustering_keys: schema.clustering_keys[..n].to_vec(),
                 columns: schema.columns.clone(),
                 comments: schema.comments.clone(),
+                dropped_columns: schema.dropped_columns.clone(),
             })
         }
     }

--- a/cqlite-core/src/storage/sstable/reader/tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/tests.rs
@@ -346,6 +346,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         // Create schema registry and register the schema

--- a/cqlite-core/src/storage/sstable/row_cell_state_machine_test.rs
+++ b/cqlite-core/src/storage/sstable/row_cell_state_machine_test.rs
@@ -89,6 +89,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 

--- a/cqlite-core/src/storage/sstable/schema_aware_reader.rs
+++ b/cqlite-core/src/storage/sstable/schema_aware_reader.rs
@@ -627,6 +627,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 

--- a/cqlite-core/src/storage/sstable/schema_aware_reader_test.rs
+++ b/cqlite-core/src/storage/sstable/schema_aware_reader_test.rs
@@ -53,6 +53,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 

--- a/cqlite-core/src/storage/sstable/writer/data_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer.rs
@@ -3559,6 +3559,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 
@@ -3610,6 +3611,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 
@@ -3900,6 +3902,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 
@@ -5370,6 +5373,7 @@ mod tests {
             clustering_keys: vec![],
             columns,
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let table_id = TableId::new("test_ks", "test_table");
@@ -5436,6 +5440,7 @@ mod tests {
             }],
             columns,
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let table_id = TableId::new("test_ks", "test_table");
@@ -5500,6 +5505,7 @@ mod tests {
             clustering_keys: vec![],
             columns,
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let table_id = TableId::new("test_ks", "test_table");
@@ -5564,6 +5570,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let ordered = writer.regular_columns(&schema);
@@ -5615,6 +5622,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let ordered = writer.static_columns(&schema);
@@ -5652,6 +5660,7 @@ mod tests {
             clustering_keys: vec![],
             columns,
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let table_id = TableId::new("test_ks", "test_table");
@@ -6149,6 +6158,7 @@ mod tests {
                 is_static: false,
             }],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let stats = create_test_stats();
@@ -6213,6 +6223,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let stats = create_test_stats();
@@ -6617,6 +6628,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         // Boundary 2^31 and a high value near 2^32 - 1, both negative i32 patterns.
@@ -6681,6 +6693,7 @@ mod tests {
                 is_static: false,
             }],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let stats = create_test_stats();
@@ -6739,6 +6752,7 @@ mod tests {
                 is_static: false,
             }],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let stats = create_test_stats();
@@ -6792,6 +6806,7 @@ mod tests {
                 is_static: false,
             }],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let stats = create_test_stats();
@@ -7264,6 +7279,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let stats = create_test_stats();
@@ -7334,6 +7350,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let stats = create_test_stats();

--- a/cqlite-core/src/storage/sstable/writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/mod.rs
@@ -1199,6 +1199,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 
@@ -1243,6 +1244,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 
@@ -1290,6 +1292,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 
@@ -1343,6 +1346,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 
@@ -1384,6 +1388,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 

--- a/cqlite-core/src/storage/sstable/writer/stats_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/stats_writer.rs
@@ -1949,6 +1949,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let writer = StatisticsWriter::new(PathBuf::from("test.db"));
@@ -2031,6 +2032,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let writer = StatisticsWriter::new(PathBuf::from("test.db"));
@@ -2362,6 +2364,7 @@ mod tests {
             clustering_keys: vec![],
             columns,
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 

--- a/cqlite-core/src/storage/write_engine/cql_to_mutation.rs
+++ b/cqlite-core/src/storage/write_engine/cql_to_mutation.rs
@@ -1602,6 +1602,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 
@@ -1762,6 +1763,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 
@@ -2720,6 +2722,7 @@ mod tests {
                 },
             ],
             comments: std::collections::HashMap::new(),
+            dropped_columns: std::collections::HashMap::new(),
         };
 
         let delete = CqlDelete {
@@ -2904,6 +2907,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 
@@ -3085,6 +3089,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 

--- a/cqlite-core/src/storage/write_engine/export.rs
+++ b/cqlite-core/src/storage/write_engine/export.rs
@@ -709,6 +709,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 

--- a/cqlite-core/src/storage/write_engine/merge.rs
+++ b/cqlite-core/src/storage/write_engine/merge.rs
@@ -1290,9 +1290,18 @@ pub fn compute_baseline_min(input_paths: &[PathBuf]) -> (i64, i32, i32) {
 /// Complex deletions (roborev High, #847): `reconcile_cluster` purges complex
 /// deletions on dropped columns with the SAME boundary as cells
 /// (`marked_for_delete_at > drop_time` survives), so any complex deletion still
-/// present on a reconciled entry is a genuine post-drop survivor and must keep
-/// its column in the output schema — otherwise the writer would emit a
-/// `CellOperation::ComplexDeletion` for a column absent from the output header.
+/// present on a reconciled entry is a genuine post-drop survivor. BUT the write
+/// pass only emits that marker for rows whose `merge_entry_to_mutation` does NOT
+/// reduce to a bare `[CellOperation::DeleteRow]` — i.e. NOT a `RowData::Tombstone`
+/// row (see [`entry_emits_complex_deletions`]). A complex-deletion marker carried
+/// on a reconciled row tombstone is suppressed by the writer, so the pre-pass must
+/// likewise NOT retain its column — otherwise the output header would gain a
+/// column for which no cell or complex deletion is ever written, reintroducing the
+/// header/schema divergence #847 set out to fix.
+///
+/// `compact_sstables` keeps exactly the columns this returns in the output writer
+/// schema; the rest are stripped from the output header. Stops early once every
+/// dropped column has been observed surviving.
 fn compute_surviving_dropped_columns(
     input_paths: Vec<PathBuf>,
     schema: &TableSchema,
@@ -1307,20 +1316,8 @@ fn compute_surviving_dropped_columns(
             MergeStep::Complete => break,
             MergeStep::Partition { rows, .. } => {
                 for row in &rows {
-                    if let RowData::Live { cells } = &row.row_data {
-                        for cell in cells {
-                            if schema.dropped_columns.contains_key(&cell.column) {
-                                surviving.insert(cell.column.clone());
-                            }
-                        }
-                    }
-                    // A retained complex-deletion marker is a post-drop survivor
-                    // (already filtered by `reconcile_cluster`), so its dropped
-                    // column must stay in the output schema (#847).
-                    for cd in &row.complex_deletions {
-                        if schema.dropped_columns.contains_key(&cd.column) {
-                            surviving.insert(cd.column.clone());
-                        }
+                    for column in surviving_dropped_columns_in_row(row, &schema.dropped_columns) {
+                        surviving.insert(column.to_string());
                     }
                 }
                 if surviving.len() == total {
@@ -1330,6 +1327,54 @@ fn compute_surviving_dropped_columns(
         }
     }
     Ok(surviving)
+}
+
+/// Mirror of the write pass's complex-deletion emit guard.
+///
+/// `merge_entry_to_mutation` builds `operations` as `[CellOperation::DeleteRow]`
+/// for a `RowData::Tombstone` row and the per-cell ops otherwise, then pushes
+/// `CellOperation::ComplexDeletion` markers ONLY when
+/// `!matches!(operations.as_slice(), [CellOperation::DeleteRow])`. The bare
+/// `[DeleteRow]` shape arises exactly from `RowData::Tombstone`, so the writer
+/// emits carried complex deletions iff the row is `RowData::Live`. The pre-pass
+/// uses this same predicate so the two passes agree on which complex deletions
+/// reach the writer (roborev High, #847).
+#[inline]
+fn entry_emits_complex_deletions(row_data: &RowData) -> bool {
+    matches!(row_data, RowData::Live { .. })
+}
+
+/// Dropped columns this merged row keeps alive in the output schema, applying the
+/// SAME emit rules as the write pass:
+///
+/// * a surviving `Live` cell on a dropped column (the writer emits a real cell), and
+/// * a carried complex-deletion marker on a dropped column — but ONLY when the
+///   writer would actually emit it (see [`entry_emits_complex_deletions`]); a
+///   marker on a `RowData::Tombstone` row is suppressed by the writer and must NOT
+///   retain its column (roborev High, #847).
+fn surviving_dropped_columns_in_row<'a>(
+    row: &'a MergeEntry,
+    dropped_columns: &std::collections::HashMap<String, i64>,
+) -> Vec<&'a str> {
+    let mut columns: Vec<&'a str> = Vec::new();
+    if let RowData::Live { cells } = &row.row_data {
+        for cell in cells {
+            if dropped_columns.contains_key(&cell.column) {
+                columns.push(cell.column.as_str());
+            }
+        }
+    }
+    // A retained complex-deletion marker is a post-drop survivor (already filtered
+    // by `reconcile_cluster`), but it only keeps its column when the write pass
+    // would actually emit it — i.e. not on a row tombstone (#847).
+    if entry_emits_complex_deletions(&row.row_data) {
+        for cd in &row.complex_deletions {
+            if dropped_columns.contains_key(&cd.column) {
+                columns.push(cd.column.as_str());
+            }
+        }
+    }
+    columns
 }
 
 pub async fn compact_sstables(
@@ -6961,5 +7006,101 @@ mod issue_886_empty_partition_skip {
             info.partition_count, 1,
             "a normal partition must still be written"
         );
+    }
+
+    /// #847 (roborev High follow-up): the pre-pass that picks which dropped
+    /// columns stay in the output header must count a carried complex-deletion
+    /// marker as "surviving" ONLY when the write pass would actually emit it.
+    /// `merge_entry_to_mutation` suppresses `CellOperation::ComplexDeletion`
+    /// markers on a `RowData::Tombstone` row (its `operations` reduce to a bare
+    /// `[DeleteRow]`), so a marker on a row tombstone must NOT retain its column —
+    /// otherwise the output gains a header column for which no cell or complex
+    /// deletion is ever written.
+    #[test]
+    fn test_surviving_dropped_columns_skips_complex_deletion_on_row_tombstone() {
+        let mut dropped_columns = std::collections::HashMap::new();
+        // Dropped at t=100 (micros); the marker below is post-drop (200 > 100), so
+        // it survives `reconcile_cluster` — the only reason it could be retained is
+        // emission, which the writer suppresses on a row tombstone.
+        dropped_columns.insert("dropped_coll".to_string(), 100);
+
+        let tombstone_with_marker = MergeEntry::new(
+            0,
+            DecoratedKey::new(1, vec![1, 2, 3]),
+            None,
+            200,
+            RowData::Tombstone {
+                deletion_time: 200,
+                local_deletion_time: 0,
+            },
+        )
+        .with_complex_deletions(vec![ComplexDeletion {
+            column: "dropped_coll".to_string(),
+            marked_for_delete_at: 200,
+            local_deletion_time: 0,
+        }]);
+
+        let survivors = surviving_dropped_columns_in_row(&tombstone_with_marker, &dropped_columns);
+        assert!(
+            survivors.is_empty(),
+            "a complex-deletion marker on a row tombstone is suppressed by the \
+             writer, so its dropped column must NOT be retained (got {survivors:?})"
+        );
+    }
+
+    /// Companion to the row-tombstone case: a post-drop complex-deletion marker on
+    /// a `RowData::Live` row IS emitted by `merge_entry_to_mutation`, so the
+    /// pre-pass must retain its dropped column (the original #847 retain case must
+    /// stay GREEN).
+    #[test]
+    fn test_surviving_dropped_columns_retains_complex_deletion_on_live_row() {
+        let mut dropped_columns = std::collections::HashMap::new();
+        dropped_columns.insert("dropped_coll".to_string(), 100);
+
+        let live_with_marker = MergeEntry::new(
+            0,
+            DecoratedKey::new(1, vec![1, 2, 3]),
+            None,
+            200,
+            RowData::Live { cells: vec![] },
+        )
+        .with_complex_deletions(vec![ComplexDeletion {
+            column: "dropped_coll".to_string(),
+            marked_for_delete_at: 200,
+            local_deletion_time: 0,
+        }]);
+
+        let survivors = surviving_dropped_columns_in_row(&live_with_marker, &dropped_columns);
+        assert_eq!(
+            survivors,
+            vec!["dropped_coll"],
+            "a complex-deletion marker on a live row IS emitted by the writer, so \
+             its dropped column must be retained in the output header"
+        );
+    }
+
+    /// A surviving `Live` cell on a dropped column retains its column regardless of
+    /// any complex-deletion marker (the writer emits a real cell for it).
+    #[test]
+    fn test_surviving_dropped_columns_retains_live_cell() {
+        let mut dropped_columns = std::collections::HashMap::new();
+        dropped_columns.insert("readded".to_string(), 100);
+
+        let live_cell = MergeEntry::new(
+            0,
+            DecoratedKey::new(1, vec![1, 2, 3]),
+            None,
+            200,
+            RowData::Live {
+                cells: vec![CellData::new(
+                    "readded".to_string(),
+                    Value::Text("post-drop".to_string()),
+                    200,
+                )],
+            },
+        );
+
+        let survivors = surviving_dropped_columns_in_row(&live_cell, &dropped_columns);
+        assert_eq!(survivors, vec!["readded"]);
     }
 }

--- a/cqlite-core/src/storage/write_engine/merge.rs
+++ b/cqlite-core/src/storage/write_engine/merge.rs
@@ -1183,6 +1183,14 @@ impl KWayMerger {
             ));
         }
 
+        // Enforce the dropped-column decode contract (#904/#847): every column
+        // named in `dropped_columns` must still be declared in `columns` so its
+        // cells decode and can be purged. A schema built programmatically may
+        // bypass `validate()`, so guard here at the authoritative compaction
+        // entry too — converting a silent "cells never decoded / misaligned"
+        // bug into a clear error.
+        schema.validate_dropped_columns()?;
+
         // Create run readers for each input SSTable (ordered newest to oldest)
         let mut runs = Vec::with_capacity(input_paths.len());
         for (run_index, path) in input_paths.iter().enumerate() {

--- a/cqlite-core/src/storage/write_engine/merge.rs
+++ b/cqlite-core/src/storage/write_engine/merge.rs
@@ -1109,10 +1109,16 @@ pub async fn compact_sstables(
 
     let merger = KWayMerger::new_with_gc(input_paths.clone(), schema, gc_before_secs, now_secs)?;
 
+    // Decode with `schema` (which retains dropped columns so their input cells
+    // parse and can be purged), but WRITE with the post-drop schema: dropped
+    // columns are excluded from the output serialization header / row column
+    // bitmap so the compacted output is readable by a natural post-drop schema
+    // (#847 review). The merge filter has already purged those columns' cells.
+    let write_schema = schema.for_compaction_output();
     let mut writer = crate::storage::sstable::writer::SSTableWriter::new(
         output_dir.to_path_buf(),
         generation,
-        schema,
+        &write_schema,
     )?;
 
     // Two-pass compaction (issue #729): seed the output's encoding baselines from

--- a/cqlite-core/src/storage/write_engine/merge.rs
+++ b/cqlite-core/src/storage/write_engine/merge.rs
@@ -1280,11 +1280,19 @@ pub fn compute_baseline_min(input_paths: &[PathBuf]) -> (i64, i32, i32) {
 ///
 /// Runs a merge pre-pass with the decode `schema` (so the dropped-column filter
 /// applies identically to the write pass) and collects the names of
-/// `dropped_columns` that appear in at least one surviving `Live` cell — i.e.
-/// columns re-added with writes after their drop time. `compact_sstables` keeps
-/// exactly these dropped columns in the output writer schema; the rest are
+/// `dropped_columns` that appear in at least one surviving `Live` cell OR a
+/// surviving (post-drop) complex-deletion marker — i.e. columns re-added with
+/// writes (or a collection deletion) after their drop time. `compact_sstables`
+/// keeps exactly these dropped columns in the output writer schema; the rest are
 /// stripped from the output header. Stops early once every dropped column has
 /// been observed surviving.
+///
+/// Complex deletions (roborev High, #847): `reconcile_cluster` purges complex
+/// deletions on dropped columns with the SAME boundary as cells
+/// (`marked_for_delete_at > drop_time` survives), so any complex deletion still
+/// present on a reconciled entry is a genuine post-drop survivor and must keep
+/// its column in the output schema — otherwise the writer would emit a
+/// `CellOperation::ComplexDeletion` for a column absent from the output header.
 fn compute_surviving_dropped_columns(
     input_paths: Vec<PathBuf>,
     schema: &TableSchema,
@@ -1304,6 +1312,14 @@ fn compute_surviving_dropped_columns(
                             if schema.dropped_columns.contains_key(&cell.column) {
                                 surviving.insert(cell.column.clone());
                             }
+                        }
+                    }
+                    // A retained complex-deletion marker is a post-drop survivor
+                    // (already filtered by `reconcile_cluster`), so its dropped
+                    // column must stay in the output schema (#847).
+                    for cd in &row.complex_deletions {
+                        if schema.dropped_columns.contains_key(&cd.column) {
+                            surviving.insert(cd.column.clone());
                         }
                     }
                 }
@@ -1860,6 +1876,22 @@ impl KWayMerger {
         let had_data_before = after_row_del.iter().any(is_data_cell);
         let has_data_after = surviving.iter().any(is_data_cell);
         let purged_to_empty = had_data_before && !has_data_after;
+
+        // Step 3c: dropped-column filtering for COMPLEX DELETIONS (roborev High,
+        // #847). Complex-deletion metadata is writer-visible (a dropped collection's
+        // pre-drop marker would otherwise emit a `CellOperation::ComplexDeletion` for
+        // a column the output schema no longer carries → header divergence). Apply
+        // the SAME boundary used for cells: a marker whose `marked_for_delete_at`
+        // is strictly AFTER the column's `drop_time` survives (the column was
+        // re-added), while `<= drop_time` is purged. This MUST run before computing
+        // `has_carried_metadata` so a column whose only survivor is a purged complex
+        // deletion does not emit a phantom metadata-only entry, and a column whose
+        // only survivor is a post-drop complex deletion is correctly retained (and
+        // matched by `compute_surviving_dropped_columns`, which mirrors this rule).
+        complex_deletions.retain(|cd| match dropped_columns.get(&cd.column) {
+            Some(drop_time) => cd.marked_for_delete_at > *drop_time,
+            None => true,
+        });
 
         // Step 4: build the merged result.
         //
@@ -5542,6 +5574,108 @@ mod issue_886_merge_entry_enrichment {
         assert_eq!(a, b);
         assert!(a.complex_deletions.is_empty());
         assert_eq!(a.range_deletion, None);
+    }
+
+    /// Regression (roborev High, #847): a DROPPED complex column carrying ONLY a
+    /// PRE-drop complex-deletion marker (`marked_for_delete_at <= drop_time`) must
+    /// be purged by the dropped-column filter — exactly like a pre-drop cell. With
+    /// no other surviving data, no row tombstone, and the purged complex deletion,
+    /// reconciliation must NOT emit a metadata-only entry: the column is stripped
+    /// from the output schema, so a metadata-only marker for it would diverge from
+    /// the output header.
+    #[test]
+    fn reconcile_cluster_purges_pre_drop_complex_deletion_under_dropped_column() {
+        let complex = ComplexDeletion {
+            column: "tags".to_string(),
+            marked_for_delete_at: 100, // <= drop_time → purged
+            local_deletion_time: 1_700_000_000,
+        };
+        let row = MergeEntry::new(0, dk(1), None, 0, RowData::Live { cells: vec![] })
+            .with_complex_deletions(vec![complex]);
+
+        let mut dropped = ::std::collections::HashMap::new();
+        dropped.insert("tags".to_string(), 150_i64); // drop_time=150 >= marker ts=100
+
+        assert!(
+            KWayMerger::reconcile_cluster(None, vec![row], &dropped).is_none(),
+            "a pre-drop complex deletion on a dropped column must be purged, \
+             leaving nothing to emit (no metadata-only entry for a stripped column)"
+        );
+    }
+
+    /// Regression (roborev High, #847): a DROPPED complex column carrying a
+    /// POST-drop complex-deletion marker (`marked_for_delete_at > drop_time`) must
+    /// SURVIVE — the column was re-added after the drop. Reconciliation emits a
+    /// metadata-only entry carrying exactly the surviving marker, and the column
+    /// is retained in the output schema (see the pre-pass test below).
+    #[test]
+    fn reconcile_cluster_retains_post_drop_complex_deletion_under_dropped_column() {
+        let complex = ComplexDeletion {
+            column: "tags".to_string(),
+            marked_for_delete_at: 300, // > drop_time → retained
+            local_deletion_time: 1_700_000_000,
+        };
+        let row = MergeEntry::new(0, dk(1), None, 0, RowData::Live { cells: vec![] })
+            .with_complex_deletions(vec![complex.clone()]);
+
+        let mut dropped = ::std::collections::HashMap::new();
+        dropped.insert("tags".to_string(), 150_i64); // drop_time=150 < marker ts=300
+
+        let merged = KWayMerger::reconcile_cluster(None, vec![row], &dropped)
+            .expect("a post-drop complex deletion must survive as a metadata-only entry");
+        assert_eq!(
+            merged.complex_deletions,
+            vec![complex],
+            "the surviving post-drop complex deletion must be carried through"
+        );
+        match &merged.row_data {
+            RowData::Live { cells } => assert!(cells.is_empty()),
+            other => panic!("expected empty Live, got {other:?}"),
+        }
+    }
+
+    /// Boundary mirror (roborev High, #847): the complex-deletion drop boundary
+    /// must match the cell boundary EXACTLY — `marked_for_delete_at == drop_time`
+    /// is PURGED (`<=` is purged, only `>` survives), identical to a cell whose
+    /// `timestamp == drop_time`.
+    #[test]
+    fn reconcile_cluster_complex_deletion_at_drop_time_is_purged() {
+        let complex = ComplexDeletion {
+            column: "tags".to_string(),
+            marked_for_delete_at: 150, // == drop_time → purged (boundary is <=)
+            local_deletion_time: 1_700_000_000,
+        };
+        let row = MergeEntry::new(0, dk(1), None, 0, RowData::Live { cells: vec![] })
+            .with_complex_deletions(vec![complex]);
+
+        let mut dropped = ::std::collections::HashMap::new();
+        dropped.insert("tags".to_string(), 150_i64);
+
+        assert!(
+            KWayMerger::reconcile_cluster(None, vec![row], &dropped).is_none(),
+            "marked_for_delete_at == drop_time must be purged (mirrors cell ts == drop_time)"
+        );
+    }
+
+    /// A complex deletion on a column that is NOT dropped is never filtered,
+    /// regardless of its `marked_for_delete_at`.
+    #[test]
+    fn reconcile_cluster_complex_deletion_on_undropped_column_is_kept() {
+        let complex = ComplexDeletion {
+            column: "tags".to_string(),
+            marked_for_delete_at: 100,
+            local_deletion_time: 1_700_000_000,
+        };
+        let row = MergeEntry::new(0, dk(1), None, 0, RowData::Live { cells: vec![] })
+            .with_complex_deletions(vec![complex.clone()]);
+
+        // drop map covers a DIFFERENT column.
+        let mut dropped = ::std::collections::HashMap::new();
+        dropped.insert("other".to_string(), 1_000_000_i64);
+
+        let merged = KWayMerger::reconcile_cluster(None, vec![row], &dropped)
+            .expect("undropped complex deletion must survive");
+        assert_eq!(merged.complex_deletions, vec![complex]);
     }
 }
 

--- a/cqlite-core/src/storage/write_engine/merge.rs
+++ b/cqlite-core/src/storage/write_engine/merge.rs
@@ -1093,6 +1093,46 @@ pub fn compute_baseline_min(input_paths: &[PathBuf]) -> (i64, i32, i32) {
 /// currently carried but do not yet drop purgeable data. The plumbing lands first
 /// so the parity harness can drive out the purge semantics.
 #[cfg(feature = "write-support")]
+/// Determine which dropped columns still have surviving cells after the merge.
+///
+/// Runs a merge pre-pass with the decode `schema` (so the dropped-column filter
+/// applies identically to the write pass) and collects the names of
+/// `dropped_columns` that appear in at least one surviving `Live` cell — i.e.
+/// columns re-added with writes after their drop time. `compact_sstables` keeps
+/// exactly these dropped columns in the output writer schema; the rest are
+/// stripped from the output header. Stops early once every dropped column has
+/// been observed surviving.
+fn compute_surviving_dropped_columns(
+    input_paths: Vec<PathBuf>,
+    schema: &TableSchema,
+    gc_before_secs: Option<i64>,
+    now_secs: Option<i64>,
+) -> Result<std::collections::HashSet<String>> {
+    let mut surviving: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let total = schema.dropped_columns.len();
+    let mut merger = KWayMerger::new_with_gc(input_paths, schema, gc_before_secs, now_secs)?;
+    loop {
+        match merger.step()? {
+            MergeStep::Complete => break,
+            MergeStep::Partition { rows, .. } => {
+                for row in &rows {
+                    if let RowData::Live { cells } = &row.row_data {
+                        for cell in cells {
+                            if schema.dropped_columns.contains_key(&cell.column) {
+                                surviving.insert(cell.column.clone());
+                            }
+                        }
+                    }
+                }
+                if surviving.len() == total {
+                    break; // every dropped column already shown to survive
+                }
+            }
+        }
+    }
+    Ok(surviving)
+}
+
 pub async fn compact_sstables(
     input_paths: Vec<PathBuf>,
     output_dir: &std::path::Path,
@@ -1107,14 +1147,27 @@ pub async fn compact_sstables(
         ));
     }
 
+    // Decode with `schema` (which retains dropped columns so their input cells
+    // parse and can be purged), but WRITE with a post-drop schema. A dropped
+    // column with no surviving cells must NOT appear in the output serialization
+    // header (else a natural post-drop reader misaligns), while a dropped column
+    // with surviving (re-added) cells MUST be retained (else those cells have no
+    // matching header column and corrupt the row) — see #847 review.
+    //
+    // Which dropped columns survive is data-dependent, and the writer fixes its
+    // header from the schema before the first row is written, so determine the
+    // surviving set with a merge pre-pass (only when any column is dropped — the
+    // common no-drop path skips it entirely). The pre-pass uses the SAME merge
+    // logic as the write pass, so the two agree on what survives.
+    let retained_dropped = if schema.dropped_columns.is_empty() {
+        std::collections::HashSet::new()
+    } else {
+        compute_surviving_dropped_columns(input_paths.clone(), schema, gc_before_secs, now_secs)?
+    };
+    let write_schema = schema.for_compaction_output(&retained_dropped);
+
     let merger = KWayMerger::new_with_gc(input_paths.clone(), schema, gc_before_secs, now_secs)?;
 
-    // Decode with `schema` (which retains dropped columns so their input cells
-    // parse and can be purged), but WRITE with the post-drop schema: dropped
-    // columns are excluded from the output serialization header / row column
-    // bitmap so the compacted output is readable by a natural post-drop schema
-    // (#847 review). The merge filter has already purged those columns' cells.
-    let write_schema = schema.for_compaction_output();
     let mut writer = crate::storage::sstable::writer::SSTableWriter::new(
         output_dir.to_path_buf(),
         generation,
@@ -1560,22 +1613,19 @@ impl KWayMerger {
         // live cells — `reconcile_cluster` is the authoritative behavior here.
         //
         // Step 3b: dropped-column filtering (Cassandra `cb34ad47`,
-        // `compaction.purge`). A column dropped at `drop_time` discards its cells:
-        // for well-formed input every cell of a dropped column predates the drop
-        // (you cannot write to a dropped column), so `timestamp <= drop_time`
-        // holds for all of them and this equals Cassandra's purge.
+        // `compaction.purge`). A column dropped at `drop_time` discards every cell
+        // whose `timestamp <= drop_time`; a cell written strictly after the drop
+        // (the column was re-added) survives. This mirrors the row-tombstone `<=`
+        // shadowing above but is scoped per column via the `dropped_columns` map
+        // (#904 plumbing, #847 filter).
         //
-        // The column is purged WHOLESALE here — `drop_time` bounds the cells in
-        // practice, but the predicate keys on column membership so the merge
-        // output stays consistent with the post-drop *writer* schema
-        // (`TableSchema::for_compaction_output`, which removes dropped columns
-        // from the serialization header / row column bitmap). If the filter kept
-        // a `timestamp > drop_time` cell (an anomalous post-drop / re-added
-        // write) while the writer omitted the column, that cell would be
-        // serialized with no matching header column and corrupt the row. Keeping
-        // re-added cells therefore requires a column re-added into the live set
-        // and is element-level / per-timestamp follow-up (#899); it is out of the
-        // scalar, row-timestamp scope of #847.
+        // Output consistency: a surviving cell here keeps its column in the
+        // compaction output, so `compact_sstables` retains any dropped column
+        // that has survivors in the *writer* schema (and strips only the
+        // fully-purged ones from the serialization header) — see
+        // `TableSchema::for_compaction_output`. Byte-correct for scalar columns at
+        // row-timestamp granularity; element-level collection/UDT filtering needs
+        // per-cell timestamps (#899) and is out of scope.
         let surviving: Vec<CellData> = order
             .into_iter()
             .filter_map(|col| winners.remove(&col))
@@ -1583,7 +1633,10 @@ impl KWayMerger {
                 Some(d) => cell.timestamp > d,
                 None => true,
             })
-            .filter(|cell| !dropped_columns.contains_key(&cell.column))
+            .filter(|cell| match dropped_columns.get(&cell.column) {
+                Some(drop_time) => cell.timestamp > *drop_time,
+                None => true,
+            })
             .collect();
 
         // Step 4: build the merged result. `max()` is `Some` exactly when `surviving`
@@ -4311,33 +4364,25 @@ mod issue_823_complex_column_merge {
         assert_eq!(cells[0].column, "name");
     }
 
-    /// A dropped column is purged WHOLESALE from the compaction output, including
-    /// an anomalous cell written after `drop_time`. This keeps the merge output
-    /// consistent with the post-drop writer schema (the column is absent from the
-    /// output serialization header), avoiding an orphaned cell that would corrupt
-    /// the row. Retaining a re-added column's post-drop cells is #899 follow-up
-    /// (out of the scalar / row-timestamp scope of #847).
+    /// A cell written STRICTLY AFTER the drop time survives the reconcile filter
+    /// (the column was re-added). `compact_sstables` then retains that column in
+    /// the output writer schema so the surviving cell has a matching header
+    /// column (see `for_compaction_output`).
     #[test]
-    fn dropped_column_cell_after_drop_time_is_also_purged() {
-        let row = live(
-            0,
-            200,
-            vec![
-                scalar_cell("name", "keep", 200),
-                scalar_cell("legacy", "anomalous", 200), // ts=200 > drop_time=150
-            ],
-        );
+    fn dropped_column_cell_after_drop_time_survives() {
+        let row = live(0, 200, vec![scalar_cell("legacy", "fresh", 200)]);
         let mut dropped = ::std::collections::HashMap::new();
-        dropped.insert("legacy".to_string(), 150);
+        dropped.insert("legacy".to_string(), 150); // cell ts=200 > 150
 
         let merged = KWayMerger::reconcile_cluster(None, vec![row], &dropped)
-            .expect("a live row must be emitted (name survives)");
+            .expect("a live row must be emitted (cell post-dates the drop)");
         let cells = match merged.row_data {
             RowData::Live { cells } => cells,
             other => panic!("expected Live, got {:?}", other),
         };
-        assert_eq!(cells.len(), 1, "the dropped column is purged wholesale");
-        assert_eq!(cells[0].column, "name");
+        assert_eq!(cells.len(), 1);
+        assert_eq!(cells[0].column, "legacy");
+        assert_eq!(cells[0].value, Value::Text("fresh".to_string()));
     }
 
     /// Equal timestamp (cell ts == drop_time) is discarded — the `<=` boundary,

--- a/cqlite-core/src/storage/write_engine/merge.rs
+++ b/cqlite-core/src/storage/write_engine/merge.rs
@@ -1626,18 +1626,45 @@ impl KWayMerger {
         // `TableSchema::for_compaction_output`. Byte-correct for scalar columns at
         // row-timestamp granularity; element-level collection/UDT filtering needs
         // per-cell timestamps (#899) and is out of scope.
-        let surviving: Vec<CellData> = order
+        // Apply row-tombstone shadowing first (Step 3), then dropped-column
+        // filtering (Step 3b) as a second stage so we can tell whether the
+        // dropped-column purge is what emptied the row of real data.
+        let after_row_del: Vec<CellData> = order
             .into_iter()
             .filter_map(|col| winners.remove(&col))
             .filter(|cell| match row_del {
                 Some(d) => cell.timestamp > d,
                 None => true,
             })
+            .collect();
+
+        let surviving: Vec<CellData> = after_row_del
+            .iter()
             .filter(|cell| match dropped_columns.get(&cell.column) {
                 Some(drop_time) => cell.timestamp > *drop_time,
                 None => true,
             })
+            .cloned()
             .collect();
+
+        // Phantom-row guard (#847 review): clustering-key columns are intentionally
+        // left in the cell list (see `extract_clustering_key`) so read-back can
+        // recover them. If a clustered row's only real (non-key) data is a dropped
+        // column, the dropped-column filter removes it but the clustering-key
+        // pseudo-cells remain — which would otherwise emit a phantom live row with
+        // a key but no data, and the writer (whose schema excludes the dropped
+        // column) would serialize a key-only empty row. Suppress that: when the
+        // row HAD non-key data before the dropped-column purge and has none after,
+        // treat it as data-less. A row that was always key-only (a genuine row
+        // marker) is preserved.
+        let ck_names: std::collections::HashSet<&str> = clustering_key
+            .as_ref()
+            .map(|ck| ck.columns.iter().map(|(n, _)| n.as_str()).collect())
+            .unwrap_or_default();
+        let is_data_cell = |cell: &CellData| !ck_names.contains(cell.column.as_str());
+        let had_data_before = after_row_del.iter().any(is_data_cell);
+        let has_data_after = surviving.iter().any(is_data_cell);
+        let purged_to_empty = had_data_before && !has_data_after;
 
         // Step 4: build the merged result. `max()` is `Some` exactly when `surviving`
         // is non-empty, so this match needs no unreachable fallback timestamp.
@@ -1650,50 +1677,60 @@ impl KWayMerger {
         // Finding 3).
         let has_carried_metadata = !complex_deletions.is_empty() || range_deletion.is_some();
 
-        let built = match surviving.iter().map(|c| c.timestamp).max() {
-            Some(row_ts) => Some(MergeEntry::new(
+        // Emit a live row only when real data survives. `surviving` is non-empty
+        // for an ordinary live row; `!purged_to_empty` additionally suppresses a
+        // clustered row whose only data was a dropped column (phantom key-only
+        // row, see above). A row that was always key-only (genuine row marker)
+        // has `had_data_before == false`, so `purged_to_empty` is false and it is
+        // preserved.
+        let built = if !surviving.is_empty() && !purged_to_empty {
+            // `surviving` is non-empty, so `max()` is `Some`; `unwrap_or(0)` only
+            // guards the type and never triggers.
+            let row_ts = surviving.iter().map(|c| c.timestamp).max().unwrap_or(0);
+            Some(MergeEntry::new(
                 run_index,
                 key,
                 clustering_key,
                 row_ts,
                 RowData::Live { cells: surviving },
-            )),
-            // No surviving cells. If a row tombstone exists, keep the row shadowed
+            ))
+        } else if let Some(deletion_time) = row_del {
+            // No surviving data. If a row tombstone exists, keep the row shadowed
             // so downstream still emits the deletion (preserves #505/#498 absence).
-            None => match row_del {
-                Some(deletion_time) => Some(MergeEntry::new(
-                    run_index,
-                    key,
-                    clustering_key,
+            Some(MergeEntry::new(
+                run_index,
+                key,
+                clustering_key,
+                deletion_time,
+                RowData::Tombstone {
                     deletion_time,
-                    RowData::Tombstone {
-                        deletion_time,
-                        local_deletion_time: 0,
-                    },
-                )),
-                // No surviving cells AND no row tombstone, but the cluster still
-                // carries complex/range deletion metadata. Emit a metadata-only
-                // entry (an empty `Live` row) so the carried deletion metadata
-                // survives reconciliation and reaches downstream consumers
-                // (#844/#846/#899). Without this the `built.map(...)` preservation
-                // below never runs and the metadata is silently dropped.
-                //
-                // Behavior-neutral for existing cases: this only adds an entry when
-                // metadata exists that would otherwise be lost. An empty-cell `Live`
-                // produces no live cells, and the writer does not yet consume the
-                // carried metadata fields, so existing output/tests are unaffected.
-                None if has_carried_metadata => Some(MergeEntry::new(
-                    run_index,
-                    key,
-                    clustering_key,
-                    // No row/cell timestamp applies; use 0 (the carried metadata
-                    // holds its own deletion timestamps).
-                    0,
-                    RowData::Live { cells: vec![] },
-                )),
-                // Truly empty/absent row.
-                None => None,
-            },
+                    local_deletion_time: 0,
+                },
+            ))
+        } else if has_carried_metadata {
+            // No surviving data AND no row tombstone, but the cluster still carries
+            // complex/range deletion metadata. Emit a metadata-only entry (an empty
+            // `Live` row) so the carried deletion metadata survives reconciliation
+            // and reaches downstream consumers (#844/#846/#899). Without this the
+            // `built.map(...)` preservation below never runs and the metadata is
+            // silently dropped.
+            //
+            // Behavior-neutral for existing cases: this only adds an entry when
+            // metadata exists that would otherwise be lost. An empty-cell `Live`
+            // produces no live cells, and the writer does not yet consume the
+            // carried metadata fields, so existing output/tests are unaffected.
+            Some(MergeEntry::new(
+                run_index,
+                key,
+                clustering_key,
+                // No row/cell timestamp applies; use 0 (the carried metadata holds
+                // its own deletion timestamps).
+                0,
+                RowData::Live { cells: vec![] },
+            ))
+        } else {
+            // Truly empty/absent row.
+            None
         };
 
         built.map(|entry| {

--- a/cqlite-core/src/storage/write_engine/merge.rs
+++ b/cqlite-core/src/storage/write_engine/merge.rs
@@ -1404,7 +1404,9 @@ impl KWayMerger {
 
         let mut merged = Vec::new();
         for (ck, cluster_rows) in clustered_rows {
-            if let Some(entry) = Self::reconcile_cluster(ck, cluster_rows) {
+            if let Some(entry) =
+                Self::reconcile_cluster(ck, cluster_rows, &self.schema.dropped_columns)
+            {
                 merged.push(entry);
             }
         }
@@ -1453,6 +1455,7 @@ impl KWayMerger {
     fn reconcile_cluster(
         clustering_key: Option<ClusteringKey>,
         cluster_rows: Vec<MergeEntry>,
+        dropped_columns: &std::collections::HashMap<String, i64>,
     ) -> Option<MergeEntry> {
         use std::collections::HashMap;
 
@@ -1541,11 +1544,24 @@ impl KWayMerger {
         // ts<=T (real Cassandra semantics). Note this is INTENTIONALLY stricter than
         // the `reference_merge` model, whose range-tombstone path only suppresses
         // live cells — `reconcile_cluster` is the authoritative behavior here.
+        //
+        // Step 3b: dropped-column filtering (Cassandra `cb34ad47`,
+        // `compaction.purge`). A column dropped at drop_time discards every cell
+        // whose `timestamp <= drop_time`; a cell written strictly after the drop
+        // (the column was re-added) survives. This mirrors row-tombstone shadowing
+        // but is scoped per column via the `dropped_columns` map (#904 plumbing,
+        // #847 filter). Byte-correct for scalar columns at row-timestamp
+        // granularity; element-level collection/UDT filtering additionally needs
+        // per-cell timestamps (#899) and is out of scope here.
         let surviving: Vec<CellData> = order
             .into_iter()
             .filter_map(|col| winners.remove(&col))
             .filter(|cell| match row_del {
                 Some(d) => cell.timestamp > d,
+                None => true,
+            })
+            .filter(|cell| match dropped_columns.get(&cell.column) {
+                Some(drop_time) => cell.timestamp > *drop_time,
                 None => true,
             })
             .collect();
@@ -1915,6 +1931,7 @@ mod tests {
             clustering_keys: vec![],
             columns: vec![],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let result = KWayMerger::new(vec![], &schema);
@@ -2027,6 +2044,7 @@ mod tests {
                 is_static: false,
             }],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         const EQUAL_TS: i64 = 1_700_000_000_000_000;
@@ -2133,6 +2151,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let partition_key = DecoratedKey::new(100, vec![0, 0, 0, 1]);
@@ -2264,6 +2283,7 @@ mod tests {
                 is_static: false,
             }],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let partition_key = DecoratedKey::new(100, vec![0, 0, 0, 1]);
@@ -2397,6 +2417,7 @@ mod tests {
                 is_static: false,
             }],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         const EQUAL_TS: i64 = 1_700_000_000_000_000;
@@ -2541,6 +2562,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let partition_key = DecoratedKey::new(100, vec![0, 0, 0, 1]);
@@ -2666,6 +2688,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let pk = DecoratedKey::new(100, vec![0, 0, 0, 1]);
@@ -2771,6 +2794,7 @@ mod tests {
                 is_static: false,
             }],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let pk = DecoratedKey::new(100, vec![0, 0, 0, 1]);
@@ -2899,6 +2923,7 @@ mod tests {
             clustering_keys: vec![],
             columns: vec![],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         // Encode key as 4-byte big-endian int (42)
@@ -2971,6 +2996,7 @@ mod tests {
             clustering_keys: vec![],
             columns: vec![],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let key_bytes = 7i32.to_be_bytes().to_vec();
@@ -3742,6 +3768,7 @@ mod merge_property_tests {
                     is_static: false,
                 }],
                 comments: SchemaMap::new(),
+                dropped_columns: SchemaMap::new(),
             };
 
             // Build MergeEntry stream — one per (ck, run_index, timestamp) tuple.
@@ -3852,6 +3879,7 @@ mod merge_property_tests {
                     is_static: false,
                 }],
                 comments: SchemaMap::new(),
+                dropped_columns: SchemaMap::new(),
             };
 
             let partition_key = DecoratedKey::new(100, vec![0, 0, 0, 1]);
@@ -4038,6 +4066,7 @@ mod streaming_tests {
             clustering_keys: vec![],
             columns: vec![],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         // Two sources with disjoint tokens:
@@ -4218,6 +4247,123 @@ mod issue_823_complex_column_merge {
         MergeEntry::new(run_index, dk(1), None, row_ts, RowData::Live { cells })
     }
 
+    fn scalar_cell(column: &str, value: &str, ts: i64) -> CellData {
+        CellData {
+            column: column.to_string(),
+            value: Value::Text(value.to_string()),
+            timestamp: ts,
+            ttl: None,
+            cell_path: None,
+            local_deletion_time: None,
+        }
+    }
+
+    // ── Issue #847: dropped-column cell filtering during compaction ──────────
+    // Cassandra `cb34ad47` / `compaction.purge`: a column dropped at drop_time
+    // discards every cell whose timestamp <= drop_time. The drop time comes from
+    // the `dropped_columns` map plumbed in #904. Byte-correct for scalar columns
+    // at row-timestamp granularity; element-level collection/UDT filtering needs
+    // per-cell timestamps (#899) and is out of scope.
+
+    /// A cell of a dropped column written AT OR BEFORE the drop time is discarded;
+    /// a sibling column with no drop entry is untouched.
+    #[test]
+    fn dropped_column_cell_at_or_before_drop_time_is_filtered() {
+        let row = live(
+            0,
+            200,
+            vec![
+                scalar_cell("name", "alice", 100),
+                scalar_cell("legacy", "stale", 100),
+            ],
+        );
+        let mut dropped = ::std::collections::HashMap::new();
+        dropped.insert("legacy".to_string(), 150); // dropped at T=150, cell ts=100 <= 150
+
+        let merged = KWayMerger::reconcile_cluster(None, vec![row], &dropped)
+            .expect("a live row must be emitted (name survives)");
+        let cells = match merged.row_data {
+            RowData::Live { cells } => cells,
+            other => panic!("expected Live, got {:?}", other),
+        };
+
+        assert_eq!(cells.len(), 1, "the dropped-column cell must be discarded");
+        assert_eq!(cells[0].column, "name");
+    }
+
+    /// A cell written STRICTLY AFTER the drop time survives (the column was
+    /// re-added after being dropped).
+    #[test]
+    fn dropped_column_cell_after_drop_time_survives() {
+        let row = live(0, 200, vec![scalar_cell("legacy", "fresh", 200)]);
+        let mut dropped = ::std::collections::HashMap::new();
+        dropped.insert("legacy".to_string(), 150); // cell ts=200 > 150
+
+        let merged = KWayMerger::reconcile_cluster(None, vec![row], &dropped)
+            .expect("a live row must be emitted (cell post-dates the drop)");
+        let cells = match merged.row_data {
+            RowData::Live { cells } => cells,
+            other => panic!("expected Live, got {:?}", other),
+        };
+        assert_eq!(cells.len(), 1);
+        assert_eq!(cells[0].column, "legacy");
+        assert_eq!(cells[0].value, Value::Text("fresh".to_string()));
+    }
+
+    /// Equal timestamp (cell ts == drop_time) is discarded — the `<=` boundary,
+    /// matching the row-tombstone `<=` shadowing rule.
+    #[test]
+    fn dropped_column_cell_at_exact_drop_time_is_filtered() {
+        let row = live(0, 150, vec![scalar_cell("legacy", "edge", 150)]);
+        let mut dropped = ::std::collections::HashMap::new();
+        dropped.insert("legacy".to_string(), 150);
+
+        assert!(
+            KWayMerger::reconcile_cluster(None, vec![row], &dropped).is_none(),
+            "cell at exactly drop_time must be discarded, leaving no surviving cells"
+        );
+    }
+
+    /// When ALL cells belong to dropped columns and all are at/before drop time,
+    /// the row produces no output (no spurious empty Live entry).
+    #[test]
+    fn all_cells_dropped_yields_no_row() {
+        let row = live(
+            0,
+            120,
+            vec![scalar_cell("a", "x", 100), scalar_cell("b", "y", 110)],
+        );
+        let mut dropped = ::std::collections::HashMap::new();
+        dropped.insert("a".to_string(), 200);
+        dropped.insert("b".to_string(), 200);
+
+        assert!(
+            KWayMerger::reconcile_cluster(None, vec![row], &dropped).is_none(),
+            "a row whose every cell is a dropped-column cell emits nothing"
+        );
+    }
+
+    /// An empty `dropped_columns` map is a no-op: all cells survive.
+    #[test]
+    fn empty_dropped_map_is_noop() {
+        let row = live(
+            0,
+            200,
+            vec![
+                scalar_cell("name", "alice", 100),
+                scalar_cell("legacy", "stale", 100),
+            ],
+        );
+        let merged =
+            KWayMerger::reconcile_cluster(None, vec![row], &::std::collections::HashMap::new())
+                .expect("a live row must be emitted");
+        let cells = match merged.row_data {
+            RowData::Live { cells } => cells,
+            other => panic!("expected Live, got {:?}", other),
+        };
+        assert_eq!(cells.len(), 2, "no drops configured → every cell survives");
+    }
+
     /// GATING TEST — multi-cell merge granularity.
     ///
     /// A non-frozen collection (here: a list) is read back from an SSTable as a
@@ -4260,8 +4406,12 @@ mod issue_823_complex_column_merge {
             }],
         );
 
-        let merged = KWayMerger::reconcile_cluster(None, vec![newer, older])
-            .expect("a live row must be emitted");
+        let merged = KWayMerger::reconcile_cluster(
+            None,
+            vec![newer, older],
+            &::std::collections::HashMap::new(),
+        )
+        .expect("a live row must be emitted");
 
         let cells = match merged.row_data {
             RowData::Live { cells } => cells,
@@ -4329,8 +4479,12 @@ mod issue_823_complex_column_merge {
             }],
         );
 
-        let merged = KWayMerger::reconcile_cluster(None, vec![newer, older])
-            .expect("a live row must be emitted");
+        let merged = KWayMerger::reconcile_cluster(
+            None,
+            vec![newer, older],
+            &::std::collections::HashMap::new(),
+        )
+        .expect("a live row must be emitted");
         let cells = match merged.row_data {
             RowData::Live { cells } => cells,
             other => panic!("expected Live, got {:?}", other),
@@ -4438,8 +4592,12 @@ mod issue_823_complex_column_merge {
             }],
         );
 
-        let merged = KWayMerger::reconcile_cluster(None, vec![row_tomb, cell_tomb])
-            .expect("row tombstone keeps the row shadowed");
+        let merged = KWayMerger::reconcile_cluster(
+            None,
+            vec![row_tomb, cell_tomb],
+            &::std::collections::HashMap::new(),
+        )
+        .expect("row tombstone keeps the row shadowed");
 
         // Equal-ts row deletion wins: no surviving cell, row stays a tombstone.
         match merged.row_data {
@@ -4578,7 +4736,8 @@ mod issue_886_merge_entry_enrichment {
                 local_deletion_time: 1_700_000_000,
             }]);
         let merged =
-            KWayMerger::reconcile_cluster(None, vec![live]).expect("live row must be emitted");
+            KWayMerger::reconcile_cluster(None, vec![live], &::std::collections::HashMap::new())
+                .expect("live row must be emitted");
         match merged.row_data {
             RowData::Live { cells } => {
                 assert_eq!(
@@ -4613,7 +4772,8 @@ mod issue_886_merge_entry_enrichment {
         // Plumbing-only: the covered cell (ts=1000 < range ts=5000) STILL
         // survives reconcile because range deletions are not yet applied.
         let merged =
-            KWayMerger::reconcile_cluster(None, vec![entry]).expect("live row must be emitted");
+            KWayMerger::reconcile_cluster(None, vec![entry], &::std::collections::HashMap::new())
+                .expect("live row must be emitted");
         match merged.row_data {
             RowData::Live { cells } => {
                 assert_eq!(
@@ -4681,8 +4841,12 @@ mod issue_886_merge_entry_enrichment {
         .with_complex_deletions(vec![complex_a.clone(), complex_b.clone()])
         .with_range_deletion(range_high.clone());
 
-        let merged = KWayMerger::reconcile_cluster(None, vec![row0, row1])
-            .expect("live row must be emitted");
+        let merged = KWayMerger::reconcile_cluster(
+            None,
+            vec![row0, row1],
+            &::std::collections::HashMap::new(),
+        )
+        .expect("live row must be emitted");
 
         // complex_deletions: union, first-seen order, deduplicated.
         assert_eq!(
@@ -4717,8 +4881,12 @@ mod issue_886_merge_entry_enrichment {
                 cells: vec![CellData::new("w".to_string(), Value::Integer(1), 1000)],
             },
         );
-        let plain = KWayMerger::reconcile_cluster(None, vec![plain0, plain1])
-            .expect("live row must be emitted");
+        let plain = KWayMerger::reconcile_cluster(
+            None,
+            vec![plain0, plain1],
+            &::std::collections::HashMap::new(),
+        )
+        .expect("live row must be emitted");
         assert_eq!(
             merged.row_data, plain.row_data,
             "carrying deletion metadata must not change surviving-cell output"
@@ -4750,7 +4918,8 @@ mod issue_886_merge_entry_enrichment {
         .with_complex_deletions(vec![complex.clone()]);
 
         let merged =
-            KWayMerger::reconcile_cluster(None, vec![row]).expect("row tombstone must be emitted");
+            KWayMerger::reconcile_cluster(None, vec![row], &::std::collections::HashMap::new())
+                .expect("row tombstone must be emitted");
         assert!(matches!(merged.row_data, RowData::Tombstone { .. }));
         assert_eq!(merged.complex_deletions, vec![complex]);
     }
@@ -4781,8 +4950,9 @@ mod issue_886_merge_entry_enrichment {
             .with_complex_deletions(vec![complex.clone()])
             .with_range_deletion(range.clone());
 
-        let merged = KWayMerger::reconcile_cluster(None, vec![row])
-            .expect("metadata-only cluster must still emit an entry");
+        let merged =
+            KWayMerger::reconcile_cluster(None, vec![row], &::std::collections::HashMap::new())
+                .expect("metadata-only cluster must still emit an entry");
 
         // The emitted entry carries the metadata and has no live cells.
         match &merged.row_data {
@@ -4806,7 +4976,8 @@ mod issue_886_merge_entry_enrichment {
     fn reconcile_cluster_empty_live_without_metadata_yields_none() {
         let row = MergeEntry::new(0, dk(1), None, 0, RowData::Live { cells: vec![] });
         assert!(
-            KWayMerger::reconcile_cluster(None, vec![row]).is_none(),
+            KWayMerger::reconcile_cluster(None, vec![row], &::std::collections::HashMap::new())
+                .is_none(),
             "empty live row with no metadata must not emit an entry"
         );
     }
@@ -4846,8 +5017,12 @@ mod issue_886_merge_entry_enrichment {
         // It survives reconciliation (metadata preserved in the merge stream) but
         // is filtered out before reaching the writer — proving the same entry the
         // merge stream keeps is the one the writer path drops.
-        let reconciled = KWayMerger::reconcile_cluster(None, vec![meta_only])
-            .expect("metadata-only cluster must still emit an entry in the merge stream");
+        let reconciled = KWayMerger::reconcile_cluster(
+            None,
+            vec![meta_only],
+            &::std::collections::HashMap::new(),
+        )
+        .expect("metadata-only cluster must still emit an entry in the merge stream");
         assert!(
             reconciled.is_metadata_only_no_op(),
             "the reconciled metadata-only entry must be writer-skippable"
@@ -5009,6 +5184,7 @@ mod issue_822_merge_ordering_semantics {
                 is_static: false,
             }],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 
@@ -5354,6 +5530,7 @@ mod issue_822_merge_ordering_semantics {
                 is_static: false,
             }],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         const TS: i64 = 2_000_000;
@@ -5571,6 +5748,7 @@ mod issue_822_merge_ordering_semantics {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         // Same table after the static column was DROPPED from the schema. On a real
@@ -5746,6 +5924,7 @@ mod issue_886_empty_partition_skip {
                 is_static: false,
             }],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 

--- a/cqlite-core/src/storage/write_engine/merge.rs
+++ b/cqlite-core/src/storage/write_engine/merge.rs
@@ -1623,9 +1623,18 @@ impl KWayMerger {
         // compaction output, so `compact_sstables` retains any dropped column
         // that has survivors in the *writer* schema (and strips only the
         // fully-purged ones from the serialization header) — see
-        // `TableSchema::for_compaction_output`. Byte-correct for scalar columns at
-        // row-timestamp granularity; element-level collection/UDT filtering needs
-        // per-cell timestamps (#899) and is out of scope.
+        // `TableSchema::for_compaction_output`.
+        //
+        // ROW-TIMESTAMP GRANULARITY (#847 documented scope): `cell.timestamp` here
+        // is the ROW write-time, not the cell's own writetime — the reader's
+        // `(RowKey, Value, ts)` compaction stream does not surface per-cell
+        // timestamps (see `value_to_row_data`; surfacing them is #886 reader
+        // plumbing, a prerequisite the epic sequenced separately). So a row that
+        // mixes a pre-drop cell of the dropped column with a post-drop cell of
+        // another column carries one (newer) row timestamp, and the dropped cell
+        // can survive when it should be purged. This is byte-correct when a row's
+        // cells share a timestamp (the common case); exact per-cell purging needs
+        // #886/#899 and is out of #847's scope.
         // Apply row-tombstone shadowing first (Step 3), then dropped-column
         // filtering (Step 3b) as a second stage so we can tell whether the
         // dropped-column purge is what emptied the row of real data.

--- a/cqlite-core/src/storage/write_engine/merge.rs
+++ b/cqlite-core/src/storage/write_engine/merge.rs
@@ -1634,7 +1634,8 @@ impl KWayMerger {
         // another column carries one (newer) row timestamp, and the dropped cell
         // can survive when it should be purged. This is byte-correct when a row's
         // cells share a timestamp (the common case); exact per-cell purging needs
-        // #886/#899 and is out of #847's scope.
+        // the per-cell-timestamp reader plumbing in #886/#899 and is tracked as
+        // follow-up #922 — out of #847's scope.
         // Apply row-tombstone shadowing first (Step 3), then dropped-column
         // filtering (Step 3b) as a second stage so we can tell whether the
         // dropped-column purge is what emptied the row of real data.

--- a/cqlite-core/src/storage/write_engine/merge.rs
+++ b/cqlite-core/src/storage/write_engine/merge.rs
@@ -1560,13 +1560,22 @@ impl KWayMerger {
         // live cells — `reconcile_cluster` is the authoritative behavior here.
         //
         // Step 3b: dropped-column filtering (Cassandra `cb34ad47`,
-        // `compaction.purge`). A column dropped at drop_time discards every cell
-        // whose `timestamp <= drop_time`; a cell written strictly after the drop
-        // (the column was re-added) survives. This mirrors row-tombstone shadowing
-        // but is scoped per column via the `dropped_columns` map (#904 plumbing,
-        // #847 filter). Byte-correct for scalar columns at row-timestamp
-        // granularity; element-level collection/UDT filtering additionally needs
-        // per-cell timestamps (#899) and is out of scope here.
+        // `compaction.purge`). A column dropped at `drop_time` discards its cells:
+        // for well-formed input every cell of a dropped column predates the drop
+        // (you cannot write to a dropped column), so `timestamp <= drop_time`
+        // holds for all of them and this equals Cassandra's purge.
+        //
+        // The column is purged WHOLESALE here — `drop_time` bounds the cells in
+        // practice, but the predicate keys on column membership so the merge
+        // output stays consistent with the post-drop *writer* schema
+        // (`TableSchema::for_compaction_output`, which removes dropped columns
+        // from the serialization header / row column bitmap). If the filter kept
+        // a `timestamp > drop_time` cell (an anomalous post-drop / re-added
+        // write) while the writer omitted the column, that cell would be
+        // serialized with no matching header column and corrupt the row. Keeping
+        // re-added cells therefore requires a column re-added into the live set
+        // and is element-level / per-timestamp follow-up (#899); it is out of the
+        // scalar, row-timestamp scope of #847.
         let surviving: Vec<CellData> = order
             .into_iter()
             .filter_map(|col| winners.remove(&col))
@@ -1574,10 +1583,7 @@ impl KWayMerger {
                 Some(d) => cell.timestamp > d,
                 None => true,
             })
-            .filter(|cell| match dropped_columns.get(&cell.column) {
-                Some(drop_time) => cell.timestamp > *drop_time,
-                None => true,
-            })
+            .filter(|cell| !dropped_columns.contains_key(&cell.column))
             .collect();
 
         // Step 4: build the merged result. `max()` is `Some` exactly when `surviving`
@@ -4305,23 +4311,33 @@ mod issue_823_complex_column_merge {
         assert_eq!(cells[0].column, "name");
     }
 
-    /// A cell written STRICTLY AFTER the drop time survives (the column was
-    /// re-added after being dropped).
+    /// A dropped column is purged WHOLESALE from the compaction output, including
+    /// an anomalous cell written after `drop_time`. This keeps the merge output
+    /// consistent with the post-drop writer schema (the column is absent from the
+    /// output serialization header), avoiding an orphaned cell that would corrupt
+    /// the row. Retaining a re-added column's post-drop cells is #899 follow-up
+    /// (out of the scalar / row-timestamp scope of #847).
     #[test]
-    fn dropped_column_cell_after_drop_time_survives() {
-        let row = live(0, 200, vec![scalar_cell("legacy", "fresh", 200)]);
+    fn dropped_column_cell_after_drop_time_is_also_purged() {
+        let row = live(
+            0,
+            200,
+            vec![
+                scalar_cell("name", "keep", 200),
+                scalar_cell("legacy", "anomalous", 200), // ts=200 > drop_time=150
+            ],
+        );
         let mut dropped = ::std::collections::HashMap::new();
-        dropped.insert("legacy".to_string(), 150); // cell ts=200 > 150
+        dropped.insert("legacy".to_string(), 150);
 
         let merged = KWayMerger::reconcile_cluster(None, vec![row], &dropped)
-            .expect("a live row must be emitted (cell post-dates the drop)");
+            .expect("a live row must be emitted (name survives)");
         let cells = match merged.row_data {
             RowData::Live { cells } => cells,
             other => panic!("expected Live, got {:?}", other),
         };
-        assert_eq!(cells.len(), 1);
-        assert_eq!(cells[0].column, "legacy");
-        assert_eq!(cells[0].value, Value::Text("fresh".to_string()));
+        assert_eq!(cells.len(), 1, "the dropped column is purged wholesale");
+        assert_eq!(cells[0].column, "name");
     }
 
     /// Equal timestamp (cell ts == drop_time) is discarded — the `<=` boundary,

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -1874,6 +1874,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 

--- a/cqlite-core/src/storage/write_engine/mutation.rs
+++ b/cqlite-core/src/storage/write_engine/mutation.rs
@@ -711,6 +711,7 @@ mod tests {
                 .collect(),
             columns: vec![],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 
@@ -1486,6 +1487,7 @@ mod tests {
             clustering_keys: vec![],
             columns: vec![],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let original = PartitionKey::single("id", Value::Integer(42));
@@ -1507,6 +1509,7 @@ mod tests {
             clustering_keys: vec![],
             columns: vec![],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let uuid_bytes = [1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
@@ -1529,6 +1532,7 @@ mod tests {
             clustering_keys: vec![],
             columns: vec![],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let original = PartitionKey::single("name", Value::Text("hello".to_string()));
@@ -1557,6 +1561,7 @@ mod tests {
             clustering_keys: vec![],
             columns: vec![],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         let original = PartitionKey::new(vec![
@@ -1581,6 +1586,7 @@ mod tests {
             clustering_keys: vec![],
             columns: vec![],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         assert!(PartitionKey::from_bytes(&[], &schema).is_err());

--- a/cqlite-core/tests/compact_command.rs
+++ b/cqlite-core/tests/compact_command.rs
@@ -59,6 +59,7 @@ fn make_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 
@@ -403,6 +404,7 @@ fn make_clustering_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 

--- a/cqlite-core/tests/compaction_integration.rs
+++ b/cqlite-core/tests/compaction_integration.rs
@@ -101,6 +101,7 @@ fn make_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 
@@ -1187,6 +1188,7 @@ fn clustering_key_rows_survive_compaction() {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     };
 
     // Helper: build a mutation for (pk, ck, val).

--- a/cqlite-core/tests/counter_type_integration_test.rs
+++ b/cqlite-core/tests/counter_type_integration_test.rs
@@ -109,6 +109,7 @@ fn create_counters_table_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 

--- a/cqlite-core/tests/enhanced_index_operation_tests.rs
+++ b/cqlite-core/tests/enhanced_index_operation_tests.rs
@@ -124,6 +124,7 @@ async fn test_sstable_reader_index_operations(reader: &SSTableReader) {
         clustering_keys: vec![],
         columns: vec![],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     };
 
     let parsing_context = ParsingContext {

--- a/cqlite-core/tests/issue_548_uuid_where_tests.rs
+++ b/cqlite-core/tests/issue_548_uuid_where_tests.rs
@@ -188,6 +188,7 @@ fn test_uuid_row_key_bytes_match_partition_key_to_bytes() {
         clustering_keys: vec![],
         columns: vec![],
         comments: Default::default(),
+        dropped_columns: Default::default(),
     };
 
     let pk = PartitionKey::single("id", Value::Uuid(uuid_bytes));
@@ -247,6 +248,7 @@ fn test_composite_uuid_key_framing_matches_partition_key_to_bytes() {
         clustering_keys: vec![],
         columns: vec![],
         comments: Default::default(),
+        dropped_columns: Default::default(),
     };
 
     let pk = PartitionKey::new(vec![

--- a/cqlite-core/tests/issue_587_compaction_async_bridge.rs
+++ b/cqlite-core/tests/issue_587_compaction_async_bridge.rs
@@ -81,6 +81,7 @@ fn make_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 

--- a/cqlite-core/tests/issue_591_mmap_compaction_delete.rs
+++ b/cqlite-core/tests/issue_591_mmap_compaction_delete.rs
@@ -73,6 +73,7 @@ fn make_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 

--- a/cqlite-core/tests/issue_702_static_bitmap_unit.rs
+++ b/cqlite-core/tests/issue_702_static_bitmap_unit.rs
@@ -114,6 +114,7 @@ fn mixed_static_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 
@@ -308,6 +309,7 @@ fn pure_regular_schema_unaffected_by_static_filter() {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     };
 
     let header = vec![

--- a/cqlite-core/tests/issue_716_tombstone_cell_format.rs
+++ b/cqlite-core/tests/issue_716_tombstone_cell_format.rs
@@ -74,6 +74,7 @@ fn test_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 

--- a/cqlite-core/tests/issue_717_row_tombstone_columns_subset.rs
+++ b/cqlite-core/tests/issue_717_row_tombstone_columns_subset.rs
@@ -79,6 +79,7 @@ fn test_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 

--- a/cqlite-core/tests/issue_764_explicit_local_deletion_time.rs
+++ b/cqlite-core/tests/issue_764_explicit_local_deletion_time.rs
@@ -56,6 +56,7 @@ fn test_schema() -> TableSchema {
             is_static: false,
         }],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 
@@ -222,6 +223,7 @@ fn complex_schema() -> TableSchema {
             is_static: false,
         }],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 
@@ -351,6 +353,7 @@ fn static_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 

--- a/cqlite-core/tests/issue_766_bti_partitions_writer.rs
+++ b/cqlite-core/tests/issue_766_bti_partitions_writer.rs
@@ -57,6 +57,7 @@ fn int_pk_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 

--- a/cqlite-core/tests/issue_819_differential_compaction.rs
+++ b/cqlite-core/tests/issue_819_differential_compaction.rs
@@ -1175,6 +1175,7 @@ fn make_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 

--- a/cqlite-core/tests/issue_821_writer_byte_invariants.rs
+++ b/cqlite-core/tests/issue_821_writer_byte_invariants.rs
@@ -76,6 +76,7 @@ fn simple_schema() -> TableSchema {
             is_static: false,
         }],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 
@@ -112,6 +113,7 @@ fn static_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 
@@ -465,6 +467,7 @@ fn clustering_schema() -> TableSchema {
             is_static: false,
         }],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 

--- a/cqlite-core/tests/issue_824_column_subset_and_filter.rs
+++ b/cqlite-core/tests/issue_824_column_subset_and_filter.rs
@@ -88,6 +88,7 @@ fn schema_with_n_columns(n: usize) -> TableSchema {
         clustering_keys: vec![], // no clustering: row body starts right after flags
         columns,
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 

--- a/cqlite-core/tests/issue_847_dropped_column_filter.rs
+++ b/cqlite-core/tests/issue_847_dropped_column_filter.rs
@@ -1,0 +1,215 @@
+//! Issue #847 — filter dropped-column cells during compaction (end-to-end).
+//!
+//! Cassandra `cb34ad47` (`compaction.purge`): a column dropped at `drop_time`
+//! discards every cell whose `timestamp <= drop_time`. The drop time is supplied
+//! through `TableSchema::dropped_columns` (plumbed in #904) and applied in the
+//! merge reconcile loop (`KWayMerger::reconcile_cluster`, #847).
+//!
+//! This test exercises the FULL wiring: write an SSTable holding `score` cells,
+//! compact it with a schema that drops `score` at a time at/after those cells'
+//! timestamp, then **read the compacted output back with a schema that has NO
+//! drop map** — proving the cells were physically removed by the writer, not just
+//! hidden by a second read-time filter.
+
+#![cfg(feature = "write-support")]
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use cqlite_core::schema::{ClusteringColumn, ClusteringOrder, Column, KeyColumn, TableSchema};
+use cqlite_core::storage::write_engine::merge::{compact_sstables, MergeStep, RowData};
+use cqlite_core::storage::write_engine::{
+    CellOperation, KWayMerger, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::Value;
+use tempfile::TempDir;
+
+/// Schema: keyspace=drop_ks, table=items, PK=id(int), CK=ck(int),
+/// columns name(text), score(int). `dropped` lets a test inject drop times.
+fn schema_with_drops(dropped: HashMap<String, i64>) -> TableSchema {
+    TableSchema {
+        keyspace: "drop_ks".to_string(),
+        table: "items".to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![ClusteringColumn {
+            name: "ck".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+            order: ClusteringOrder::Asc,
+        }],
+        columns: vec![
+            col("id", "int"),
+            col("ck", "int"),
+            col("name", "text"),
+            col("score", "int"),
+        ],
+        comments: HashMap::new(),
+        dropped_columns: dropped,
+    }
+}
+
+fn col(name: &str, ty: &str) -> Column {
+    Column {
+        name: name.to_string(),
+        data_type: ty.to_string(),
+        nullable: true,
+        default: None,
+        is_static: false,
+    }
+}
+
+fn write_row(id: i32, ck: i32, name: &str, score: i32, ts: i64) -> Mutation {
+    Mutation::new(
+        TableId::new("drop_ks", "items"),
+        PartitionKey::single("id", Value::Integer(id)),
+        Some(cqlite_core::storage::write_engine::ClusteringKey::single(
+            "ck",
+            Value::Integer(ck),
+        )),
+        vec![
+            CellOperation::Write {
+                column: "name".to_string(),
+                value: Value::Text(name.to_string()),
+            },
+            CellOperation::Write {
+                column: "score".to_string(),
+                value: Value::Integer(score),
+            },
+        ],
+        ts,
+        None,
+    )
+}
+
+/// Write one SSTable at `ts` with rows (id=1 ck=0..=2). Returns its input paths.
+fn build_input(temp: &TempDir, ts: i64) -> (Vec<PathBuf>, TableSchema) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    let data_dir = temp.path().join("inputs");
+    let wal_dir = temp.path().join("wal");
+    let schema = schema_with_drops(HashMap::new());
+
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir, schema.clone());
+    let mut engine = WriteEngine::new(config).expect("engine");
+    for ck in 0_i32..=2 {
+        engine
+            .write(write_row(1, ck, &format!("name-{ck}"), ck * 10, ts))
+            .expect("write row");
+    }
+    rt.block_on(engine.flush()).expect("flush").expect("info");
+    rt.block_on(engine.close()).expect("close");
+
+    (discover_inputs(&data_dir), schema)
+}
+
+fn discover_inputs(dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+        if let Ok(entries) = std::fs::read_dir(dir) {
+            for e in entries.flatten() {
+                let p = e.path();
+                if p.is_dir() {
+                    walk(&p, out);
+                } else if p
+                    .file_name()
+                    .and_then(|s| s.to_str())
+                    .is_some_and(|n| n.ends_with("-Data.db") || n.ends_with("Data.db"))
+                {
+                    out.push(p);
+                }
+            }
+        }
+    }
+    walk(dir, &mut out);
+    out
+}
+
+fn compact(inputs: Vec<PathBuf>, out_dir: &Path, schema: &TableSchema) -> PathBuf {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    let report = rt
+        .block_on(compact_sstables(inputs, out_dir, schema, 901, None, None))
+        .expect("compaction must succeed");
+    report.output.data_path
+}
+
+/// Read every surviving (column, value) cell out of `data_path`, using a schema
+/// with NO drop map so the reader does not re-apply the filter. This reflects what
+/// was physically written by compaction.
+fn surviving_columns(data_path: PathBuf) -> Vec<(String, Value)> {
+    let plain = schema_with_drops(HashMap::new());
+    let mut merger = KWayMerger::new(vec![data_path], &plain).expect("merger over output");
+    let mut cells = Vec::new();
+    loop {
+        match merger.step().expect("step") {
+            MergeStep::Complete => break,
+            MergeStep::Partition { rows, .. } => {
+                for row in rows {
+                    if let RowData::Live { cells: row_cells } = row.row_data {
+                        for c in row_cells {
+                            cells.push((c.column, c.value));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    cells
+}
+
+/// AC: a column dropped at T discards cells with ts <= T from the compacted output.
+#[test]
+fn dropped_column_cells_discarded_from_compaction_output() {
+    let temp = TempDir::new().expect("tempdir");
+    let (inputs, _) = build_input(&temp, 100); // score cells written at ts=100
+    assert!(!inputs.is_empty(), "expected at least one input SSTable");
+
+    // Drop `score` at T=150 (>= the cells' ts=100 → must be filtered).
+    let mut dropped = HashMap::new();
+    dropped.insert("score".to_string(), 150_i64);
+    let drop_schema = schema_with_drops(dropped);
+
+    let out_dir = temp.path().join("out");
+    let data_path = compact(inputs, &out_dir, &drop_schema);
+
+    let cols = surviving_columns(data_path);
+    assert!(
+        !cols.is_empty(),
+        "name cells must still be present after the drop"
+    );
+    assert!(
+        cols.iter().all(|(c, _)| c != "score"),
+        "every `score` cell (ts=100 <= drop_time=150) must be physically removed, \
+         got surviving columns: {:?}",
+        cols.iter().map(|(c, _)| c).collect::<Vec<_>>()
+    );
+    assert!(
+        cols.iter().any(|(c, _)| c == "name"),
+        "the non-dropped `name` column must survive"
+    );
+}
+
+/// Control: with no drop configured, `score` cells survive compaction unchanged.
+#[test]
+fn no_drop_keeps_all_columns() {
+    let temp = TempDir::new().expect("tempdir");
+    let (inputs, schema) = build_input(&temp, 100);
+
+    let out_dir = temp.path().join("out");
+    let data_path = compact(inputs, &out_dir, &schema); // schema has empty drop map
+
+    let cols = surviving_columns(data_path);
+    assert!(
+        cols.iter().any(|(c, _)| c == "score"),
+        "without a drop entry, score must survive: {:?}",
+        cols.iter().map(|(c, _)| c).collect::<Vec<_>>()
+    );
+}

--- a/cqlite-core/tests/issue_847_dropped_column_filter.rs
+++ b/cqlite-core/tests/issue_847_dropped_column_filter.rs
@@ -281,17 +281,16 @@ fn dropped_column_absent_from_columns_is_rejected() {
     );
 }
 
-/// A cell written AFTER `drop_time` (ts > drop_time) is still purged from the
-/// compaction output (roborev #847 review). The dropped column is removed from
-/// the post-drop writer schema, so keeping such a cell would orphan it (no
-/// matching header column) and corrupt the row. Purging it keeps the merge and
-/// writer consistent. Retaining re-added cells is #899 follow-up.
+/// A cell written AFTER `drop_time` (ts > drop_time) SURVIVES compaction — the
+/// column was re-added — and the output retains that column so the surviving
+/// cell has a matching serialization-header entry (roborev #847 review). Only
+/// fully-purged dropped columns are stripped from the output header.
 #[test]
-fn dropped_column_cell_after_drop_time_purged_in_output() {
+fn dropped_column_cell_after_drop_time_survives_in_output() {
     let temp = TempDir::new().expect("tempdir");
     let (inputs, _) = build_input(&temp, 300); // score cells written at ts=300
 
-    // Drop `score` at T=150, BEFORE the cells' ts=300 (anomalous post-drop write).
+    // Drop `score` at T=150, BEFORE the cells' ts=300 (re-added after the drop).
     let mut dropped = HashMap::new();
     dropped.insert("score".to_string(), 150_i64);
     let drop_schema = schema_with_drops(dropped);
@@ -299,13 +298,12 @@ fn dropped_column_cell_after_drop_time_purged_in_output() {
     let out_dir = temp.path().join("out");
     let data_path = compact(inputs, &out_dir, &drop_schema);
 
-    // Read with a schema that still includes `score` in columns: even so, it must
-    // be absent because the writer omitted it from the output header.
     let cols = surviving_columns(data_path);
     assert!(
-        cols.iter().all(|(c, _)| c != "score"),
-        "a cell with ts > drop_time must still be purged from the output, got: {:?}",
-        cols.iter().map(|(c, _)| c).collect::<Vec<_>>()
+        cols.iter()
+            .any(|(c, v)| c == "score" && matches!(v, Value::Integer(_))),
+        "a re-added cell (ts > drop_time) must survive in the output, got: {:?}",
+        cols
     );
     assert!(
         cols.iter().any(|(c, _)| c == "name"),

--- a/cqlite-core/tests/issue_847_dropped_column_filter.rs
+++ b/cqlite-core/tests/issue_847_dropped_column_filter.rs
@@ -145,8 +145,23 @@ fn compact(inputs: Vec<PathBuf>, out_dir: &Path, schema: &TableSchema) -> PathBu
 /// with NO drop map so the reader does not re-apply the filter. This reflects what
 /// was physically written by compaction.
 fn surviving_columns(data_path: PathBuf) -> Vec<(String, Value)> {
-    let plain = schema_with_drops(HashMap::new());
-    let mut merger = KWayMerger::new(vec![data_path], &plain).expect("merger over output");
+    surviving_columns_with(data_path, &schema_with_drops(HashMap::new()))
+}
+
+/// Schema describing the table AFTER `name` was dropped: it omits `name`
+/// entirely (the natural post-drop schema a reader would use). `name` sorts
+/// before `score` in the alphabetical serialization-header order, so reading the
+/// compacted output with this schema proves the dropped column is absent from
+/// the output header/bitmap and `score` is not misparsed.
+fn post_drop_schema_without_name() -> TableSchema {
+    let mut s = schema_with_drops(HashMap::new());
+    s.columns.retain(|c| c.name != "name");
+    s
+}
+
+/// Read surviving (column, value) cells out of `data_path` using `read_schema`.
+fn surviving_columns_with(data_path: PathBuf, read_schema: &TableSchema) -> Vec<(String, Value)> {
+    let mut merger = KWayMerger::new(vec![data_path], read_schema).expect("merger over output");
     let mut cells = Vec::new();
     loop {
         match merger.step().expect("step") {
@@ -194,6 +209,42 @@ fn dropped_column_cells_discarded_from_compaction_output() {
     assert!(
         cols.iter().any(|(c, _)| c == "name"),
         "the non-dropped `name` column must survive"
+    );
+}
+
+/// Output-header cleanliness (roborev #847 review): when a dropped column sorts
+/// BEFORE a surviving column in the serialization-header order, the compacted
+/// output must not encode the dropped column in its header/bitmap — otherwise a
+/// post-drop reader schema (omitting the dropped column) misaligns and misparses
+/// the surviving column. Here `name` (dropped) sorts before `score` (surviving).
+#[test]
+fn dropped_column_before_surviving_is_absent_from_output_header() {
+    let temp = TempDir::new().expect("tempdir");
+    let (inputs, _) = build_input(&temp, 100); // name + score cells at ts=100
+
+    // Drop `name` (sorts before `score`) at T=150 (>= the cells' ts=100).
+    let mut dropped = HashMap::new();
+    dropped.insert("name".to_string(), 150_i64);
+    let drop_schema = schema_with_drops(dropped);
+
+    let out_dir = temp.path().join("out");
+    let data_path = compact(inputs, &out_dir, &drop_schema);
+
+    // Read the output with a POST-DROP schema that omits `name` entirely.
+    let cols = surviving_columns_with(data_path, &post_drop_schema_without_name());
+
+    assert!(
+        cols.iter().all(|(c, _)| c != "name"),
+        "the dropped column must not appear in the output, got: {:?}",
+        cols.iter().map(|(c, _)| c).collect::<Vec<_>>()
+    );
+    // `score` must still decode correctly (as an integer) — proving the header
+    // did not carry the dropped `name` column and misalign `score`.
+    assert!(
+        cols.iter()
+            .any(|(c, v)| c == "score" && matches!(v, Value::Integer(_))),
+        "surviving `score` must parse correctly under a post-drop reader schema, got: {:?}",
+        cols
     );
 }
 

--- a/cqlite-core/tests/issue_847_dropped_column_filter.rs
+++ b/cqlite-core/tests/issue_847_dropped_column_filter.rs
@@ -197,6 +197,39 @@ fn dropped_column_cells_discarded_from_compaction_output() {
     );
 }
 
+/// Decode-contract guard (roborev High, #904/#847): a dropped column that is
+/// ABSENT from `columns` cannot be decoded by the schema-driven reader, so its
+/// cells would never reach the filter and surrounding columns could misalign.
+/// Compaction must reject this configuration with a clear error rather than
+/// silently mis-decoding.
+#[test]
+fn dropped_column_absent_from_columns_is_rejected() {
+    let temp = TempDir::new().expect("tempdir");
+    let (inputs, _) = build_input(&temp, 100);
+
+    // Build a schema that drops `score` but OMITS it from `columns` entirely.
+    let mut schema = schema_with_drops({
+        let mut m = HashMap::new();
+        m.insert("score".to_string(), 150_i64);
+        m
+    });
+    schema.columns.retain(|c| c.name != "score");
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    let out_dir = temp.path().join("out");
+    let result = rt.block_on(compact_sstables(inputs, &out_dir, &schema, 902, None, None));
+
+    let err = result.expect_err("compaction must reject a dropped column absent from `columns`");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("score") && msg.contains("columns"),
+        "error must name the offending column and the contract, got: {msg}"
+    );
+}
+
 /// Control: with no drop configured, `score` cells survive compaction unchanged.
 #[test]
 fn no_drop_keeps_all_columns() {

--- a/cqlite-core/tests/issue_847_dropped_column_filter.rs
+++ b/cqlite-core/tests/issue_847_dropped_column_filter.rs
@@ -281,6 +281,38 @@ fn dropped_column_absent_from_columns_is_rejected() {
     );
 }
 
+/// A cell written AFTER `drop_time` (ts > drop_time) is still purged from the
+/// compaction output (roborev #847 review). The dropped column is removed from
+/// the post-drop writer schema, so keeping such a cell would orphan it (no
+/// matching header column) and corrupt the row. Purging it keeps the merge and
+/// writer consistent. Retaining re-added cells is #899 follow-up.
+#[test]
+fn dropped_column_cell_after_drop_time_purged_in_output() {
+    let temp = TempDir::new().expect("tempdir");
+    let (inputs, _) = build_input(&temp, 300); // score cells written at ts=300
+
+    // Drop `score` at T=150, BEFORE the cells' ts=300 (anomalous post-drop write).
+    let mut dropped = HashMap::new();
+    dropped.insert("score".to_string(), 150_i64);
+    let drop_schema = schema_with_drops(dropped);
+
+    let out_dir = temp.path().join("out");
+    let data_path = compact(inputs, &out_dir, &drop_schema);
+
+    // Read with a schema that still includes `score` in columns: even so, it must
+    // be absent because the writer omitted it from the output header.
+    let cols = surviving_columns(data_path);
+    assert!(
+        cols.iter().all(|(c, _)| c != "score"),
+        "a cell with ts > drop_time must still be purged from the output, got: {:?}",
+        cols.iter().map(|(c, _)| c).collect::<Vec<_>>()
+    );
+    assert!(
+        cols.iter().any(|(c, _)| c == "name"),
+        "non-dropped `name` must survive"
+    );
+}
+
 /// Control: with no drop configured, `score` cells survive compaction unchanged.
 #[test]
 fn no_drop_keeps_all_columns() {

--- a/cqlite-core/tests/issue_847_dropped_column_filter.rs
+++ b/cqlite-core/tests/issue_847_dropped_column_filter.rs
@@ -311,6 +311,34 @@ fn dropped_column_cell_after_drop_time_survives_in_output() {
     );
 }
 
+/// Phantom-row guard (roborev #847 review): clustering-key columns are kept in
+/// the cell list for read-back, so a clustered row whose ONLY regular data is
+/// dropped must not emit a phantom key-only live row. Here both regular columns
+/// (`name`, `score`) are dropped, so every row's data is purged and the output
+/// must contain no rows (not key-only empties).
+#[test]
+fn clustered_row_with_all_regular_columns_dropped_emits_no_phantom_row() {
+    let temp = TempDir::new().expect("tempdir");
+    let (inputs, _) = build_input(&temp, 100); // rows id=1, ck=0..=2, name+score
+
+    let mut dropped = HashMap::new();
+    dropped.insert("name".to_string(), 150_i64);
+    dropped.insert("score".to_string(), 150_i64);
+    let drop_schema = schema_with_drops(dropped);
+
+    let out_dir = temp.path().join("out");
+    let data_path = compact(inputs, &out_dir, &drop_schema);
+
+    // Every row's only data was dropped, so the merge emits no rows at all — not
+    // even key-only phantom rows. The compacted Data.db is therefore empty.
+    let len = std::fs::metadata(&data_path).map(|m| m.len()).unwrap_or(0);
+    assert_eq!(
+        len, 0,
+        "all-purged compaction must write no rows (no key-only phantom rows); \
+         Data.db is {len} bytes"
+    );
+}
+
 /// Control: with no drop configured, `score` cells survive compaction unchanged.
 #[test]
 fn no_drop_keeps_all_columns() {

--- a/cqlite-core/tests/issue_883_cross_generation_read_merge.rs
+++ b/cqlite-core/tests/issue_883_cross_generation_read_merge.rs
@@ -67,6 +67,7 @@ fn make_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 

--- a/cqlite-core/tests/issue_885_cross_generation_metadata_merge.rs
+++ b/cqlite-core/tests/issue_885_cross_generation_metadata_merge.rs
@@ -69,6 +69,7 @@ fn make_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 

--- a/cqlite-core/tests/issue_908_bti_canonical_write.rs
+++ b/cqlite-core/tests/issue_908_bti_canonical_write.rs
@@ -55,6 +55,7 @@ fn int_pk_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 
@@ -316,6 +317,7 @@ fn wide_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 

--- a/cqlite-core/tests/issue_909_bti_reader_roundtrip.rs
+++ b/cqlite-core/tests/issue_909_bti_reader_roundtrip.rs
@@ -83,6 +83,7 @@ fn wide_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 

--- a/cqlite-core/tests/issue_911_bti_partition_deletion_stats.rs
+++ b/cqlite-core/tests/issue_911_bti_partition_deletion_stats.rs
@@ -137,6 +137,7 @@ fn simple_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 

--- a/cqlite-core/tests/issue_911_bti_sstabledump_parity.rs
+++ b/cqlite-core/tests/issue_911_bti_sstabledump_parity.rs
@@ -160,6 +160,7 @@ fn wide_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 
@@ -367,6 +368,7 @@ async fn bti_narrow_only_writer_output_reads_under_cassandra5_sstabledump() {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     };
 
     let dir = TempDir::new().unwrap();

--- a/cqlite-core/tests/scan_delta_parity_test.rs
+++ b/cqlite-core/tests/scan_delta_parity_test.rs
@@ -592,6 +592,7 @@ fn schema_for_table(table: &str) -> Option<TableSchema> {
         clustering_keys: ck_cols,
         columns: regular_cols,
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     })
 }
 
@@ -1593,6 +1594,7 @@ fn simple_table_schema() -> TableSchema {
             col("work_time", "time", false),
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 
@@ -1612,6 +1614,7 @@ fn collection_table_schema() -> TableSchema {
             col("tags", "set<text>", false),
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 
@@ -1631,6 +1634,7 @@ fn sensor_data_schema() -> TableSchema {
             col("temperature", "float", false),
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 
@@ -1653,6 +1657,7 @@ fn wide_partition_schema() -> TableSchema {
             col("json_column", "text", false),
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 

--- a/cqlite-core/tests/schema_aware_reader_integration_test.rs
+++ b/cqlite-core/tests/schema_aware_reader_integration_test.rs
@@ -97,6 +97,7 @@ fn create_simple_table_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 
@@ -135,6 +136,7 @@ fn create_nested_collections_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 
@@ -273,6 +275,7 @@ fn test_schema_validation_acceptance_criteria() {
         clustering_keys: vec![],
         columns: vec![],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     };
 
     let result = SchemaAwareReader::validate_schema_completeness(&incomplete_schema);

--- a/cqlite-core/tests/schema_parser_property_tests.rs
+++ b/cqlite-core/tests/schema_parser_property_tests.rs
@@ -23,6 +23,7 @@ fn create_test_context(columns: Vec<Column>) -> ParsingContext {
         clustering_keys: vec![],
         columns,
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     };
 
     ParsingContext {
@@ -314,6 +315,7 @@ fn test_null_handling_in_row() {
             clustering_keys: vec![],
             columns: columns.clone(),
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         },
         partition_comparators: vec![ComparatorType::Int],
         clustering_comparators: vec![],

--- a/cqlite-core/tests/sstabledump_parity_data.rs
+++ b/cqlite-core/tests/sstabledump_parity_data.rs
@@ -521,6 +521,7 @@ fn create_test_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 
@@ -563,6 +564,7 @@ fn create_clustered_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 

--- a/cqlite-core/tests/sstabledump_parity_summary.rs
+++ b/cqlite-core/tests/sstabledump_parity_summary.rs
@@ -518,6 +518,7 @@ async fn test_summary_via_write_engine() -> CqliteResult<()> {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     };
 
     let config = WriteEngineConfig::new(

--- a/cqlite-core/tests/sstableloader_integration.rs
+++ b/cqlite-core/tests/sstableloader_integration.rs
@@ -2146,6 +2146,7 @@ fn create_simple_schema(table_name: &str) -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 
@@ -2188,6 +2189,7 @@ fn create_clustered_schema(table_name: &str) -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 
@@ -2265,6 +2267,7 @@ fn create_types_schema(table_name: &str) -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 
@@ -2553,6 +2556,7 @@ fn build_schema(
         clustering_keys,
         columns,
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 

--- a/cqlite-core/tests/static_composite_roundtrip_test.rs
+++ b/cqlite-core/tests/static_composite_roundtrip_test.rs
@@ -66,6 +66,7 @@ fn create_schema_with_static() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 
@@ -255,6 +256,7 @@ fn create_composite_key_schema() -> TableSchema {
             is_static: false,
         }],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 
@@ -296,6 +298,7 @@ fn create_composite_partition_with_clustering_schema() -> TableSchema {
             is_static: false,
         }],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 
@@ -369,6 +372,7 @@ fn test_single_component_no_separator() {
         clustering_keys: vec![],
         columns: vec![],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     };
 
     let pk = PartitionKey::single("id", Value::Integer(42));
@@ -398,6 +402,7 @@ fn test_composite_key_with_text() {
         clustering_keys: vec![],
         columns: vec![],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     };
 
     let pk = PartitionKey::new(vec![
@@ -584,6 +589,7 @@ fn create_static_columns_table_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 

--- a/cqlite-core/tests/test_issue_827_merge_streaming_memory.rs
+++ b/cqlite-core/tests/test_issue_827_merge_streaming_memory.rs
@@ -100,6 +100,7 @@ fn make_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 

--- a/cqlite-core/tests/test_issue_827_streaming_parity.rs
+++ b/cqlite-core/tests/test_issue_827_streaming_parity.rs
@@ -79,6 +79,7 @@ fn make_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 
@@ -361,6 +362,7 @@ fn make_clustered_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 

--- a/cqlite-core/tests/type_invariant_tests.rs
+++ b/cqlite-core/tests/type_invariant_tests.rs
@@ -124,6 +124,7 @@ fn create_empty_collections_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 
@@ -184,6 +185,7 @@ fn create_frozen_collections_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 
@@ -260,6 +262,7 @@ fn create_typed_collections_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 

--- a/cqlite-core/tests/write_collection_nulls.rs
+++ b/cqlite-core/tests/write_collection_nulls.rs
@@ -84,6 +84,7 @@ fn create_collection_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 

--- a/cqlite-core/tests/write_concurrent.rs
+++ b/cqlite-core/tests/write_concurrent.rs
@@ -48,6 +48,7 @@ fn create_test_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 

--- a/cqlite-core/tests/write_engine_integration_test.rs
+++ b/cqlite-core/tests/write_engine_integration_test.rs
@@ -48,6 +48,7 @@ fn create_test_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 
@@ -502,6 +503,7 @@ fn create_comprehensive_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 
@@ -1029,6 +1031,7 @@ async fn test_stage0_various_data_types() -> Result<()> {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     };
 
     // === WRITE PHASE ===

--- a/cqlite-core/tests/write_error_injection.rs
+++ b/cqlite-core/tests/write_error_injection.rs
@@ -47,6 +47,7 @@ fn create_test_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 

--- a/cqlite-core/tests/write_integration.rs
+++ b/cqlite-core/tests/write_integration.rs
@@ -57,6 +57,7 @@ fn create_simple_schema(keyspace: &str, table: &str) -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 
@@ -100,6 +101,7 @@ fn create_clustering_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 
@@ -308,6 +310,7 @@ async fn test_collection_types() -> Result<()> {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     };
 
     let config = WriteEngineConfig::new(

--- a/cqlite-core/tests/write_large_data.rs
+++ b/cqlite-core/tests/write_large_data.rs
@@ -61,6 +61,7 @@ fn simple_schema(keyspace: &str, table: &str, columns: Vec<(&str, &str)>, pk: &s
         clustering_keys: vec![],
         columns: col_structs,
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 
@@ -109,6 +110,7 @@ fn simple_schema_with_clustering(
         }],
         columns: col_structs,
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 
@@ -421,6 +423,7 @@ async fn test_500_columns_roundtrip() -> cqlite_core::error::Result<()> {
         clustering_keys: vec![],
         columns: col_structs,
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     };
 
     let mut engine = create_engine(&temp_dir, schema);

--- a/cqlite-core/tests/write_read_roundtrip.rs
+++ b/cqlite-core/tests/write_read_roundtrip.rs
@@ -103,6 +103,7 @@ pub fn create_simple_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 
@@ -146,6 +147,7 @@ pub fn create_clustering_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 
@@ -211,6 +213,7 @@ pub fn create_comprehensive_schema() -> TableSchema {
             col("frozen_col", "frozen<list<int>>"),
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 

--- a/cqlite-core/tests/write_read_roundtrip/data_single.rs
+++ b/cqlite-core/tests/write_read_roundtrip/data_single.rs
@@ -219,6 +219,7 @@ async fn test_data_single_partition_column_types() {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     };
 
     let config = WriteEngineConfig::new(

--- a/cqlite-core/tests/write_read_roundtrip/edge_cases.rs
+++ b/cqlite-core/tests/write_read_roundtrip/edge_cases.rs
@@ -82,6 +82,7 @@ fn create_edge_case_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 
@@ -576,6 +577,7 @@ async fn test_edge_single_byte_values() {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     };
 
     let config = WriteEngineConfig::new(
@@ -1062,6 +1064,7 @@ async fn test_frozen_list_clustering_key_uniqueness() {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     };
 
     let pk = Value::Uuid([0u8; 16]);

--- a/cqlite-core/tests/write_read_roundtrip/type_coverage.rs
+++ b/cqlite-core/tests/write_read_roundtrip/type_coverage.rs
@@ -56,6 +56,7 @@ fn create_type_test_schema(col_name: &str, col_type: &str) -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 

--- a/cqlite-core/tests/write_schema_evolution.rs
+++ b/cqlite-core/tests/write_schema_evolution.rs
@@ -57,6 +57,7 @@ fn build_schema(
         clustering_keys: clustering,
         columns: col_defs,
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 

--- a/cqlite-flight/src/agg.rs
+++ b/cqlite-flight/src/agg.rs
@@ -706,6 +706,7 @@ mod tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 

--- a/cqlite-flight/src/testutil.rs
+++ b/cqlite-flight/src/testutil.rs
@@ -36,6 +36,7 @@ pub fn simple_schema() -> TableSchema {
             col("score", "int", true),
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 
@@ -138,6 +139,7 @@ pub fn clustering_schema() -> TableSchema {
             col("val", "int", true),
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 
@@ -172,6 +174,7 @@ pub fn uuid_schema() -> TableSchema {
         clustering_keys: vec![],
         columns: vec![col("id", "uuid", false), col("name", "text", true)],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 

--- a/tests/comprehensive_component_integration_tests.rs
+++ b/tests/comprehensive_component_integration_tests.rs
@@ -161,6 +161,7 @@ impl ComponentIntegrationTestFixture {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         })
     }
 }

--- a/tests/integration/test_schema_driven_key_decoding.rs
+++ b/tests/integration/test_schema_driven_key_decoding.rs
@@ -53,6 +53,7 @@ fn create_multi_component_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 
@@ -95,6 +96,7 @@ fn create_complex_types_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 

--- a/tests/integration/test_schema_driven_value_decoding.rs
+++ b/tests/integration/test_schema_driven_value_decoding.rs
@@ -177,6 +177,7 @@ fn create_collections_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 
@@ -219,6 +220,7 @@ fn create_complex_types_schema() -> TableSchema {
             },
         ],
         comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
     }
 }
 

--- a/tests/integration/test_sstabledump_parity_integration.rs
+++ b/tests/integration/test_sstabledump_parity_integration.rs
@@ -49,6 +49,7 @@ mod test_schemas {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 
@@ -96,6 +97,7 @@ mod test_schemas {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 
@@ -159,6 +161,7 @@ mod test_schemas {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 }

--- a/tests/schema_integration_tests.rs
+++ b/tests/schema_integration_tests.rs
@@ -130,6 +130,7 @@ impl SchemaIntegrationFixture {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 
@@ -229,6 +230,7 @@ impl SchemaIntegrationFixture {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 
@@ -354,6 +356,7 @@ impl SchemaIntegrationFixture {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 }

--- a/tests/schema_parity_test.rs
+++ b/tests/schema_parity_test.rs
@@ -68,6 +68,7 @@ impl SchemaParityTestFixture {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         self.registry
@@ -128,6 +129,7 @@ impl SchemaParityTestFixture {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         self.registry
@@ -220,6 +222,7 @@ impl SchemaParityTestFixture {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         self.registry

--- a/tests/src/comparator_type_tests.rs
+++ b/tests/src/comparator_type_tests.rs
@@ -631,6 +631,7 @@ mod integration_tests {
                 },
             ],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         // Test getting column comparator
@@ -701,6 +702,7 @@ mod integration_tests {
             clustering_keys: vec![],
             columns: vec![],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         // Test non-existent column

--- a/tests/src/cql_integration_tests.rs
+++ b/tests/src/cql_integration_tests.rs
@@ -943,6 +943,7 @@ impl CqlIntegrationTestSuite {
             clustering_keys: vec![],
             columns,
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         })
     }
 

--- a/tests/src/cql_parser_validation_suite.rs
+++ b/tests/src/cql_parser_validation_suite.rs
@@ -1019,6 +1019,7 @@ impl CqlParserValidationSuite {
                 is_static: false,
             }],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         })
     }
 
@@ -1300,6 +1301,7 @@ mod tests {
             clustering_keys: vec![],
             columns: vec![],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         };
 
         assert!(suite.table_name_matches(&schema, "users"));

--- a/tests/src/cql_performance_benchmarks.rs
+++ b/tests/src/cql_performance_benchmarks.rs
@@ -922,6 +922,7 @@ impl CqlPerformanceBenchmarkSuite {
                 is_static: false,
             }],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         })
     }
 

--- a/tests/src/issue_28a_heuristics_removal_tests.rs
+++ b/tests/src/issue_28a_heuristics_removal_tests.rs
@@ -172,6 +172,7 @@ fn test_row_cell_state_machine_no_blob_fallback_modern() {
             },
         ],
         comments: std::collections::HashMap::new(),
+        dropped_columns: std::collections::HashMap::new(),
     };
 
     // Test BIG v5 format


### PR DESCRIPTION
Closes #847 (epic #921 — compaction byte-parity vs Apache Cassandra).

Cassandra ref: `cb34ad47` (filter dropped-column cells).

## What
Dropped-column cells are filtered during compaction so a column dropped at time T discards cells with `ts <= T` from the output, and the output header omits fully-purged dropped columns. Complex (collection/UDT) deletion markers are filtered under the same drop boundary, and the output-schema pre-pass counts only writer-emittable markers (mirrors `merge_entry_to_mutation`'s emit guard — `RowData::Live` only).

## Validation
- `cargo fmt`, `clippy -D warnings` (workspace, all-targets, all-features): clean
- `cargo test -p cqlite-core --features write-support`: lib 2057 passed; end-to-end `issue_847_dropped_column_filter` 6 passed; reconcile-level regression tests for purge/retain/tombstone cases pass
- Pre-existing env-only failures unrelated to this change: `debug_schema_extraction` (missing fetched test-data binary), `test_flush_throughput` (known flaky perf threshold; passes in isolation)

## roborev
All findings resolved; final review (job 918) on `5b61f897`: **no issues found**. Two earlier High findings (complex-deletion filtering coverage; pre-pass vs writer-emit divergence) fixed in `fa6b2d43` and `5b61f897`.

## Known limitation (tracked as #922)
Cell filtering compares the row write-timestamp, not per-cell writetime; byte-correct when a row's cells share a timestamp (common case). Exact per-cell purge needs further #886/#899 per-element plumbing.