### PR TITLE
fix(compaction): read static-row presence from input SSTable headers (#850)

### DIFF
--- a/cqlite-core/src/storage/write_engine/merge.rs
+++ b/cqlite-core/src/storage/write_engine/merge.rs
@@ -1296,6 +1296,113 @@ pub fn compute_baseline_min(input_paths: &[PathBuf]) -> (i64, i32, i32) {
     (baseline_min_ts, baseline_min_ldt, baseline_min_ttl)
 }
 
+/// Build the effective compaction schema (#850): `schema` augmented with any
+/// static columns that the input SSTables' SerializationHeaders declare but the
+/// current schema no longer does (e.g. a static column dropped from the table).
+///
+/// Cassandra reads static-row PRESENCE from each input SSTable's
+/// SerializationHeader, not from the current table metadata. After the last
+/// static column is dropped, an older SSTable that still carries static rows must
+/// keep its static-row prelude through compaction — otherwise the prelude (and
+/// any surviving static data) is dropped, diverging from Cassandra. Re-adding the
+/// dropped static column to the schema handed to the merger and writer restores
+/// that: the reader decodes the static cells and the writer emits the static
+/// prelude, exactly as a header-driven compaction would.
+///
+/// Returns `schema` unchanged when the inputs declare no static column absent
+/// from `schema` (the overwhelmingly common case), so output stays byte-identical
+/// for every table whose schema still matches its on-disk data.
+#[cfg(feature = "write-support")]
+pub fn effective_compaction_schema(schema: &TableSchema, input_paths: &[PathBuf]) -> TableSchema {
+    use std::collections::HashSet;
+
+    // Names already known to the current schema (regular + static columns and
+    // both key kinds) must not be re-added.
+    let mut known: HashSet<String> = schema.columns.iter().map(|c| c.name.clone()).collect();
+    for k in &schema.partition_keys {
+        known.insert(k.name.clone());
+    }
+    for k in &schema.clustering_keys {
+        known.insert(k.name.clone());
+    }
+
+    // (name, cql_type) for static columns present in the inputs but missing from
+    // the current schema. Sorted by name for deterministic output.
+    let mut added: Vec<(String, String)> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+
+    for data_path in input_paths {
+        let stats_path = {
+            let filename = data_path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            let stats_filename = filename.replace("Data.db", "Statistics.db");
+            data_path
+                .parent()
+                .unwrap_or(data_path.as_path())
+                .join(stats_filename)
+        };
+        if !stats_path.exists() {
+            continue;
+        }
+        let stats_bytes = match std::fs::read(&stats_path) {
+            Ok(b) => b,
+            Err(e) => {
+                log::warn!(
+                    "effective_compaction_schema: cannot read Statistics.db {:?}: {}",
+                    stats_path,
+                    e
+                );
+                continue;
+            }
+        };
+        match crate::parser::enhanced_statistics_parser::parse_statistics_with_fallback(
+            &stats_bytes,
+            None,
+        ) {
+            Ok((_, sstable_stats)) => {
+                for col in &sstable_stats.serialization_header_columns {
+                    if col.is_static && !known.contains(&col.name) && seen.insert(col.name.clone())
+                    {
+                        added.push((col.name.clone(), col.column_type.clone()));
+                    }
+                }
+            }
+            Err(e) => {
+                log::warn!(
+                    "effective_compaction_schema: cannot parse Statistics.db {:?}: {:?}",
+                    stats_path,
+                    e
+                );
+            }
+        }
+    }
+
+    if added.is_empty() {
+        return schema.clone();
+    }
+
+    added.sort_by(|a, b| a.0.cmp(&b.0));
+    log::info!(
+        "effective_compaction_schema: re-adding {} static column(s) dropped from schema \
+         {}.{} but still present in input SSTable headers: {:?}",
+        added.len(),
+        schema.keyspace,
+        schema.table,
+        added.iter().map(|(n, _)| n.as_str()).collect::<Vec<_>>()
+    );
+
+    let mut effective = schema.clone();
+    for (name, data_type) in added {
+        effective.columns.push(crate::schema::Column {
+            name,
+            data_type,
+            nullable: true,
+            default: None,
+            is_static: true,
+        });
+    }
+    effective
+}
+
 /// Compact an explicit set of input SSTables into a single output SSTable.
 ///
 /// Unlike [`WriteEngine::maintenance_step`](super::WriteEngine::maintenance_step),
@@ -1367,23 +1474,44 @@ pub async fn compact_sstables(
         ));
     }
 
-    // Decode with `schema` (retains dropped columns so their input cells parse and
-    // can be purged), but WRITE with a post-drop schema: fully-purged dropped
-    // columns are stripped from the output serialization header (a natural
+    // #850: read static-row presence from the input SSTable headers. If a static
+    // column is absent from the current schema but an input SSTable still declares
+    // it (e.g. it was dropped from the catalog entirely, not retained via
+    // `dropped_columns`), the effective schema re-adds it so the merger decodes the
+    // static cells and the writer emits the static prelude. Byte-identical to
+    // `schema` when no such column exists (the common case). This composes with the
+    // #847/#904 dropped-column flow below: the effective schema keeps `schema`'s
+    // `dropped_columns` map, so the retained-dropped pre-pass and write-schema
+    // derivation operate on it unchanged.
+    let effective_schema = effective_compaction_schema(schema, &input_paths);
+
+    // Decode with `effective_schema` (retains dropped columns so their input cells
+    // parse and can be purged), but WRITE with a post-drop schema: fully-purged
+    // dropped columns are stripped from the output serialization header (a natural
     // post-drop reader is not misaligned) while dropped columns with surviving
     // re-added cells are retained (those cells keep a matching header column).
     // Which dropped columns survive is data-dependent and the writer fixes its
     // header before the first row, so determine the surviving set with a merge
     // pre-pass (only when any column is dropped). The pre-pass uses the SAME merge
     // logic as the write pass, so the two agree. See #847 review.
-    let retained_dropped = if schema.dropped_columns.is_empty() {
+    let retained_dropped = if effective_schema.dropped_columns.is_empty() {
         std::collections::HashSet::new()
     } else {
-        compute_surviving_dropped_columns(input_paths.clone(), schema, gc_before_secs, now_secs)?
+        compute_surviving_dropped_columns(
+            input_paths.clone(),
+            &effective_schema,
+            gc_before_secs,
+            now_secs,
+        )?
     };
-    let write_schema = schema.for_compaction_output(&retained_dropped);
+    let write_schema = effective_schema.for_compaction_output(&retained_dropped);
 
-    let merger = KWayMerger::new_with_gc(input_paths.clone(), schema, gc_before_secs, now_secs)?;
+    let merger = KWayMerger::new_with_gc(
+        input_paths.clone(),
+        &effective_schema,
+        gc_before_secs,
+        now_secs,
+    )?;
 
     let mut writer = crate::storage::sstable::writer::SSTableWriter::new(
         output_dir.to_path_buf(),
@@ -6904,6 +7032,7 @@ mod issue_912_row_tombstone_clustering_identity {
                 is_static: false,
             }],
             comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
         }
     }
 

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -150,6 +150,12 @@ struct ActiveMerge {
     bytes_read: u64,
     /// When this merge started
     started_at: Instant,
+    /// Effective compaction schema (#850): the configured schema augmented with
+    /// any static columns that appear in the input SSTables' SerializationHeaders
+    /// but were dropped from the current schema. Used to convert merged entries to
+    /// mutations so the writer still emits the static-row prelude (static-column
+    /// presence is read from the input headers, not the current schema only).
+    effective_schema: TableSchema,
 }
 
 /// WAL durability mode for the write engine.
@@ -1175,10 +1181,22 @@ impl WriteEngine {
                     // stream but have no writer-emittable content yet, so writing
                     // them would produce a phantom live empty (pure-PK) row at
                     // timestamp 0. See `MergeEntry::is_metadata_only_no_op`.
+                    // #850: convert with the effective compaction schema so any
+                    // static column re-added from the input headers is preserved
+                    // (partition-key decoding is identical; only static columns
+                    // differ). Falls back to the config schema if (impossibly) no
+                    // active merge is present.
+                    let conversion_schema = self
+                        .active_merge
+                        .as_ref()
+                        .map(|m| m.effective_schema.clone())
+                        .unwrap_or_else(|| self.config.schema.clone());
                     let mutations = entries_vec
                         .into_iter()
                         .filter(|entry| !entry.is_metadata_only_no_op())
-                        .map(|entry| self.merge_entry_to_mutation(entry))
+                        .map(|entry| {
+                            merge::KWayMerger::merge_entry_to_mutation(entry, &conversion_schema)
+                        })
                         .collect::<Result<Vec<_>>>()?;
 
                     // If every merged row was metadata-only, the partition has no
@@ -1422,15 +1440,24 @@ impl WriteEngine {
             ))
         })?;
 
+        // #850: derive the effective compaction schema by reading static-row
+        // presence from the input SSTable headers. If a static column was dropped
+        // from the current schema but an input still carries it, re-add it so the
+        // merger decodes the static cells and the writer emits the static prelude
+        // (header-driven static presence). Byte-identical to `config.schema` when
+        // no such column exists.
+        let effective_schema =
+            merge::effective_compaction_schema(&self.config.schema, &input_paths);
+
         // Create K-way merger
-        let merger = KWayMerger::new(input_paths.clone(), &self.config.schema)?;
+        let merger = KWayMerger::new(input_paths.clone(), &effective_schema)?;
 
         // Point the SSTableWriter at the tmp root; it will write to
         // tmp_dir/keyspace/table/nb-{gen}-big-*.db
         let mut writer = crate::storage::sstable::writer::SSTableWriter::new(
             tmp_dir.clone(),
             output_generation,
-            &self.config.schema,
+            &effective_schema,
         )?;
 
         // Two-pass compaction (issue #729): compute output FINAL encoding baselines
@@ -1452,6 +1479,7 @@ impl WriteEngine {
             rows_merged: 0,
             bytes_read,
             started_at: Instant::now(),
+            effective_schema,
         });
 
         Ok(())
@@ -1801,16 +1829,6 @@ impl WriteEngine {
                 failures.join("; ")
             )))
         }
-    }
-
-    /// Convert MergeEntry to Mutation (M5.2 helper)
-    ///
-    /// Delegates to `KWayMerger::merge_entry_to_mutation` to avoid duplication.
-    fn merge_entry_to_mutation(
-        &self,
-        entry: merge::MergeEntry,
-    ) -> Result<crate::storage::write_engine::mutation::Mutation> {
-        merge::KWayMerger::merge_entry_to_mutation(entry, &self.config.schema)
     }
 }
 

--- a/cqlite-core/tests/issue_850_static_presence.rs
+++ b/cqlite-core/tests/issue_850_static_presence.rs
@@ -1,0 +1,253 @@
+//! Integration test: static-row presence is read from the input SSTable headers,
+//! not the current schema only (Issue #850, Cassandra ref cb34ad47).
+//!
+//! Scenario (the #850 data-loss bug):
+//!   1. Two SSTables are written while the table still HAS a static column `s`.
+//!      Their Statistics.db SerializationHeaders record `s` as static.
+//!   2. The static column is later DROPPED from the schema.
+//!   3. Compaction runs under the dropped schema.
+//!
+//! Pre-#850 the writer derived static-column presence from the current schema
+//! only (`data_writer.rs`: `schema_has_static`), so the compacted output dropped
+//! the static-row prelude entirely — divergence / data loss versus Cassandra,
+//! which reads static presence from the input headers.
+//!
+//! The fix builds an *effective compaction schema* by unioning the input
+//! SSTable headers' static columns back onto the current schema, so the merger
+//! decodes the static cells and the writer emits the static prelude. This test
+//! drives the full WriteEngine compaction path and asserts that the compacted
+//! output's SerializationHeader still declares `s` as static (header-driven
+//! presence) and that the partitions read back without corruption.
+
+#![cfg(feature = "write-support")]
+
+use std::sync::Arc;
+
+use cqlite_core::config::Config;
+use cqlite_core::platform::Platform;
+use cqlite_core::schema::{ClusteringColumn, Column, KeyColumn, TableSchema};
+use cqlite_core::storage::sstable::SSTableManager;
+use cqlite_core::storage::write_engine::{
+    CellOperation, ClusteringKey, Mutation, PartitionKey, STCSPolicy, TableId, WriteEngine,
+    WriteEngineConfig,
+};
+use cqlite_core::types::{TableId as CqlTableId, Value};
+use std::collections::HashMap;
+use tempfile::TempDir;
+
+const KS: &str = "static850";
+const TBL: &str = "t";
+
+fn schema_with_static() -> TableSchema {
+    TableSchema {
+        keyspace: KS.to_string(),
+        table: TBL.to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "pk".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![ClusteringColumn {
+            name: "ck".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+            order: Default::default(),
+        }],
+        columns: vec![
+            Column {
+                name: "s".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: true,
+            },
+            Column {
+                name: "v".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+fn schema_dropped_static() -> TableSchema {
+    let mut s = schema_with_static();
+    s.columns.retain(|c| c.name != "s");
+    s
+}
+
+/// A mutation that writes the static column `s` and a clustering row cell `v`.
+fn write_static_and_row(pk: i32, s_val: &str, v_val: &str, ts: i64) -> Mutation {
+    Mutation::new(
+        TableId::new(KS, TBL),
+        PartitionKey::single("pk", Value::Integer(pk)),
+        Some(ClusteringKey::single("ck", Value::Integer(1))),
+        vec![
+            CellOperation::Write {
+                column: "s".to_string(),
+                value: Value::Text(s_val.to_string()),
+            },
+            CellOperation::Write {
+                column: "v".to_string(),
+                value: Value::Text(v_val.to_string()),
+            },
+        ],
+        ts,
+        None,
+    )
+}
+
+#[test]
+fn static_prelude_survives_compaction_after_static_column_dropped() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build tokio runtime");
+
+    let temp_dir = TempDir::new().expect("tempdir");
+    let data_dir = temp_dir.path().join("data");
+    let wal_dir = temp_dir.path().join("wal");
+
+    // ── Phase 1: write two SSTables WHILE the table still has the static column.
+    {
+        let config =
+            WriteEngineConfig::new(data_dir.clone(), wal_dir.clone(), schema_with_static());
+        let mut engine = WriteEngine::new(config).expect("engine (with static)");
+
+        engine
+            .write(write_static_and_row(1, "static-1", "row-1", 100))
+            .expect("write pk=1");
+        let info1 = rt
+            .block_on(engine.flush())
+            .expect("flush 1")
+            .expect("info 1");
+        assert!(info1.partition_count > 0, "SSTable 1 must be non-empty");
+
+        engine
+            .write(write_static_and_row(2, "static-2", "row-2", 200))
+            .expect("write pk=2");
+        let info2 = rt
+            .block_on(engine.flush())
+            .expect("flush 2")
+            .expect("info 2");
+        assert!(info2.partition_count > 0, "SSTable 2 must be non-empty");
+
+        rt.block_on(engine.close()).expect("close engine 1");
+    }
+
+    // Sanity: the input SSTables' headers must declare `s` as static, otherwise
+    // the rest of the test would be vacuous.
+    let input_static_cols = collect_header_static_columns(&data_dir);
+    assert!(
+        input_static_cols.contains(&"s".to_string()),
+        "input SSTable headers must record `s` as a static column (got {:?})",
+        input_static_cols
+    );
+
+    // ── Phase 2: compact under the schema with the static column DROPPED.
+    {
+        let config =
+            WriteEngineConfig::new(data_dir.clone(), wal_dir.clone(), schema_dropped_static());
+        let mut engine = WriteEngine::new(config).expect("engine (dropped static)");
+
+        // Permissive STCS so the two tiny SSTables group into one bucket.
+        let policy = STCSPolicy::new(2, 32, 0.01, 100.0, 0).expect("valid STCS params");
+        engine
+            .set_merge_policy(Box::new(policy))
+            .expect("set policy");
+
+        let budget = std::time::Duration::from_secs(30);
+        let mut compacted = false;
+        for _ in 0..6 {
+            let report = engine.maintenance_step(budget).expect("maintenance_step");
+            if !report.completed_merges.is_empty() {
+                compacted = true;
+                break;
+            }
+            if !report.pending_compaction {
+                break;
+            }
+        }
+        assert!(compacted, "compaction must complete");
+        rt.block_on(engine.close()).expect("close engine 2");
+    }
+
+    // ── Assert: the compacted output's header still declares `s` as static.
+    // This is the header-driven static presence the fix restores: the effective
+    // compaction schema re-added `s` from the input headers and threaded it to
+    // the output writer.
+    let output_static_cols = collect_header_static_columns(&data_dir);
+    assert!(
+        output_static_cols.contains(&"s".to_string()),
+        "#850 regression: after compacting under the dropped-static schema, the \
+         output SSTable header dropped the static column `s` (got {:?}). Static-row \
+         presence must be read from the input headers, not the current schema only.",
+        output_static_cols
+    );
+
+    // ── Assert: the compacted partitions read back without corruption.
+    let cqlite_config = Config::default();
+    let manager = rt.block_on(async {
+        let platform = Arc::new(Platform::new(&cqlite_config).await.expect("platform"));
+        SSTableManager::new(
+            &data_dir,
+            &cqlite_config,
+            platform,
+            #[cfg(feature = "state_machine")]
+            None,
+        )
+        .await
+        .expect("SSTableManager open")
+    });
+
+    let table_id = CqlTableId::from(format!("{}.{}", KS, TBL).as_str());
+    let results = rt
+        .block_on(manager.scan(&table_id, None, None, None, Some(&schema_with_static())))
+        .expect("post-compaction scan");
+    assert!(
+        !results.is_empty(),
+        "compacted output must still return rows after a scan"
+    );
+}
+
+/// Collect the names of static columns declared in every `*-Statistics.db`
+/// SerializationHeader under `data_dir/<ks>/<tbl>/`.
+fn collect_header_static_columns(data_dir: &std::path::Path) -> Vec<String> {
+    let table_dir = data_dir.join(KS).join(TBL);
+    let mut names: Vec<String> = Vec::new();
+    let read_dir = match std::fs::read_dir(&table_dir) {
+        Ok(rd) => rd,
+        Err(_) => return names,
+    };
+    for entry in read_dir.flatten() {
+        let path = entry.path();
+        let is_stats = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(|n| n.ends_with("Statistics.db"))
+            .unwrap_or(false);
+        if !is_stats {
+            continue;
+        }
+        let bytes = match std::fs::read(&path) {
+            Ok(b) => b,
+            Err(_) => continue,
+        };
+        if let Ok((_, stats)) =
+            cqlite_core::parser::enhanced_statistics_parser::parse_statistics_with_fallback(
+                &bytes, None,
+            )
+        {
+            for col in &stats.serialization_header_columns {
+                if col.is_static && !names.contains(&col.name) {
+                    names.push(col.name.clone());
+                }
+            }
+        }
+    }
+    names
+}


### PR DESCRIPTION
## Summary

Closes #850. Builds on #912 (row-tombstone clustering identity) and composes with #923 (#847/#904 dropped-column filtering).

Static-column presence was derived from the current schema only (`data_writer.rs`: `schema_has_static`), not the union of the input SSTable headers. After the last static column is dropped from the schema, compacting an older SSTable that still carries static rows dropped the static-row prelude entirely — divergence / data loss versus Cassandra, which reads static presence from the input headers (Cassandra ref `cb34ad47`).

## Fix

New `merge::effective_compaction_schema(schema, input_paths)` unions the static columns declared in the input SSTables' Statistics.db `SerializationHeader`s back onto the current schema. The compaction merger and writer use this effective schema, so a static column absent from the current schema but present in the inputs is re-decoded by the reader and re-emitted as a static prelude by the writer (header-driven presence).

- **Behavior-neutral in the common case.** When no input header declares a static column absent from the schema, the effective schema *equals* the current schema and output is byte-identical — so all existing compaction parity is unaffected.
- **Composes with #923.** The effective schema preserves `schema.dropped_columns`, so the `compact_sstables` retained-dropped pre-pass and `for_compaction_output` write-schema derivation run on it unchanged. (This is the complementary case to #923: #923 covers a dropped column *retained* in `columns` + `dropped_columns`; #850 covers a static column *fully absent* from the schema but still in the on-disk headers.)
- **`DataWriter` stays schema-driven** — only the schema the compaction layer hands it changes. The existing `issue_22_static_emission_is_schema_driven...` invariant is untouched.

Wired into both compaction entry points: `compact_sstables` (CLI / parity harness) and `WriteEngine::start_merge` + `maintenance_step`.

## Also fixes a broken-main compile

`#912`'s test helper `clustered_schema()` (merged in #924) predates #923 making `TableSchema.dropped_columns` a required field, so test builds on `main` currently fail to compile. This PR adds the missing field, un-breaking `main`.

## Tests

New integration test `issue_850_static_presence`: writes two SSTables under a static schema, compacts under the dropped-static schema, asserts the output header still declares the static column and the partitions read back intact. **Verified to fail without the fix** (output header drops `s`).

## Validation

`scripts/agent-gate.sh`: fmt / clippy / integration / format-compat / write / cli / python / minimal-build / smoke PASS. core-tests: the only failure is `test_flush_throughput`, the pre-existing flaky throughput timer (documented as a known flake in #923; passes in isolation here).