### PR TITLE
feat(udt): non-frozen UDT multi-cell support (reader + writer) (#927)

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
@@ -268,7 +268,7 @@ struct ComplexCellParse {
 /// without that feature the struct is built but not consumed, hence the allow.
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
-pub(in crate::storage::sstable::reader) struct ComplexColumnMeta {
+pub(crate) struct ComplexColumnMeta {
     /// `true` when the collection generation carries a collection-level tombstone
     /// (`s = {...}` overwrite), meaning the consumer must **replace** rather than
     /// merge the prior collection state.
@@ -6231,7 +6231,93 @@ impl V5CompressedLegacyParser {
             return true;
         }
 
+        // Issue #927: a TOP-LEVEL non-frozen UDT is a first-class multi-cell
+        // complex column — each field is stored as its own cell whose cell_path
+        // is the 2-byte (signed ShortType) field index. Frozen UDTs were already
+        // excluded above (frozen<...> / FrozenType(...)), and a UDT nested inside
+        // a collection (e.g. ListType(UserType(...))) is matched by its outer
+        // list/set/map branch, so a bare `usertype(` prefix here is unambiguous.
+        if dt.starts_with("org.apache.cassandra.db.marshal.usertype(") {
+            return true;
+        }
+
         false
+    }
+
+    /// Parse the OUTERMOST `UserType(ks,hexname,hexfield:type,...)` marshal string
+    /// into its DECLARED field order, returning `(field_name, field_marshal_type)`
+    /// pairs (issue #927). The field type is kept as its raw marshal string so the
+    /// per-field value bytes can be decoded with [`parse_value_from_raw_bytes`].
+    ///
+    /// Reuses the same paren-matching / hex-name decoding as
+    /// [`parse_udt_type_definition`]; the two differ only in that this preserves
+    /// the raw type string instead of converting it to a `CqlType`.
+    fn udt_field_marshal_types(type_str: &str) -> Result<Vec<(String, String)>> {
+        let start_marker = "org.apache.cassandra.db.marshal.UserType(";
+        let type_lower = type_str.to_lowercase();
+        let start_marker_lower = start_marker.to_lowercase();
+        let start_idx = type_lower
+            .find(&start_marker_lower)
+            .ok_or_else(|| Error::schema(format!("Not a UserType: {}", type_str)))?;
+
+        let inner_start = start_idx + start_marker.len();
+        let mut paren_depth = 1;
+        let mut end_idx = inner_start;
+        let chars: Vec<char> = type_str[inner_start..].chars().collect();
+        for (i, c) in chars.iter().enumerate() {
+            match c {
+                '(' => paren_depth += 1,
+                ')' => {
+                    paren_depth -= 1;
+                    if paren_depth == 0 {
+                        end_idx = inner_start + i;
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        if paren_depth != 0 {
+            return Err(Error::schema(format!(
+                "Unbalanced parentheses in UserType: {}",
+                type_str
+            )));
+        }
+
+        let inner = &type_str[inner_start..end_idx];
+        let parts = Self::split_type_args(inner)?;
+        if parts.len() < 2 {
+            return Err(Error::schema(format!(
+                "UserType requires at least keyspace and name: {}",
+                inner
+            )));
+        }
+
+        let mut fields = Vec::with_capacity(parts.len().saturating_sub(2));
+        for field_def in parts.iter().skip(2) {
+            let field_def = field_def.trim();
+            if field_def.is_empty() {
+                continue;
+            }
+            let colon_idx = field_def.find(':').ok_or_else(|| {
+                Error::schema(format!(
+                    "Invalid UDT field definition (missing colon): {}",
+                    field_def
+                ))
+            })?;
+            let field_name = Self::decode_hex_name(&field_def[..colon_idx])?;
+            let field_type = field_def[colon_idx + 1..].trim().to_string();
+            fields.push((field_name, field_type));
+        }
+        Ok(fields)
+    }
+
+    /// Extract `(keyspace, type_name)` from the outermost `UserType(...)` marshal
+    /// string (issue #927). The keyspace is the first arg; the name is the
+    /// hex-decoded second arg.
+    fn udt_keyspace_and_name(type_str: &str) -> Result<(String, String)> {
+        let udt_def = Self::parse_udt_type_definition(type_str)?;
+        Ok((udt_def.keyspace, udt_def.name))
     }
 
     /// Parse a complex column (non-frozen collection).
@@ -6277,7 +6363,7 @@ impl V5CompressedLegacyParser {
     /// by elements that carry the `USE_ROW_TIMESTAMP` (0x08) flag — only read
     /// when collecting elements. On the user-facing read path `elements_out` is
     /// `None`, `row_timestamp` is `0`, and no per-element collection occurs.
-    fn parse_complex_column_inner(
+    pub(crate) fn parse_complex_column_inner(
         &self,
         data: &[u8],
         mut offset: usize,
@@ -6660,6 +6746,101 @@ impl V5CompressedLegacyParser {
             }
 
             Value::Map(entries)
+        } else if dt.starts_with("org.apache.cassandra.db.marshal.usertype(") {
+            // Issue #927: TOP-LEVEL non-frozen UDT — each field is a cell whose
+            // cell_path is the 2-byte (signed ShortType) declared field index and
+            // whose value bytes are the field datum. Decode each cell's value with
+            // the DECLARED field type resolved from the marshal string.
+            let field_defs = Self::udt_field_marshal_types(&column.data_type)?;
+            // Field values keyed by declared index; absent / null fields stay None.
+            let mut field_values: Vec<Option<Value>> = vec![None; field_defs.len()];
+
+            for i in 0..cell_count_usize {
+                // Capture the value bytes raw (BytesType is identity) so they can
+                // be re-decoded with the per-field type AFTER the cell_path (which
+                // carries the field index) is known.
+                let cell = self.parse_complex_cell_value(
+                    data,
+                    offset,
+                    "org.apache.cassandra.db.marshal.BytesType",
+                    column,
+                    i as u64,
+                )?;
+                offset = cell.next_offset;
+
+                // Resolve the declared field index from the 2-byte signed-short
+                // cell_path. A path that is not exactly 2 bytes, or that names a
+                // field index outside the declared range, is authoritative
+                // corruption — surface it rather than guessing (no-heuristics).
+                let field_index = if cell.path_bytes.len() == 2 {
+                    i16::from_be_bytes([cell.path_bytes[0], cell.path_bytes[1]]) as i32
+                } else {
+                    return Err(Error::corruption(format!(
+                        "UDT column '{}' cell {}: field-index cell_path must be 2 bytes, got {}",
+                        column.name,
+                        i,
+                        cell.path_bytes.len()
+                    )));
+                };
+
+                if cell.is_deleted {
+                    element_tombstone_count += 1;
+                    record_element(&mut elements_out, &cell, None, None, row_timestamp);
+                    continue;
+                }
+                update_max_writetime(&mut max_element_writetime, &cell);
+
+                // Decode the field value with its DECLARED type. `cell.value` is the
+                // raw bytes wrapped as Blob (BytesType) above; an empty-value cell
+                // yields None.
+                let decoded = match &cell.value {
+                    Some(Value::Blob(raw)) => {
+                        let (_name, field_type) = field_defs
+                            .get(field_index as usize)
+                            .filter(|_| field_index >= 0)
+                            .ok_or_else(|| {
+                                Error::corruption(format!(
+                                    "UDT column '{}' cell {}: field index {} out of range (0..{})",
+                                    column.name,
+                                    i,
+                                    field_index,
+                                    field_defs.len()
+                                ))
+                            })?;
+                        Some(self.parse_value_from_raw_bytes(raw, field_type, &column.name, 0)?)
+                    }
+                    other => other.clone(),
+                };
+
+                record_element(
+                    &mut elements_out,
+                    &cell,
+                    decoded.clone(),
+                    None,
+                    row_timestamp,
+                );
+
+                if field_index >= 0 && (field_index as usize) < field_values.len() {
+                    field_values[field_index as usize] = decoded;
+                }
+            }
+
+            // Build the collapsed UDT in DECLARED field order for the user-facing
+            // read path. The keyspace/type-name come from the marshal string.
+            let (udt_keyspace, udt_name) = Self::udt_keyspace_and_name(&column.data_type)?;
+            let fields = field_defs
+                .iter()
+                .zip(field_values)
+                .map(|((name, _ty), value)| crate::types::UdtField {
+                    name: name.clone(),
+                    value,
+                })
+                .collect();
+            Value::Udt(UdtValue {
+                type_name: udt_name,
+                keyspace: udt_keyspace,
+                fields,
+            })
         } else {
             // Unknown complex column type, skip cells
             for i in 0..cell_count_usize {
@@ -11780,5 +11961,37 @@ mod tests {
             min_timestamp + 500,
             min_local_deletion_time + 617
         );
+    }
+
+    // Issue #927: reader-side classification + declared-field parsing for
+    // top-level non-frozen UDT complex columns.
+    #[test]
+    fn test_is_complex_column_udt() {
+        // Top-level non-frozen UDT IS complex.
+        assert!(V5CompressedLegacyParser::is_complex_column(
+            "org.apache.cassandra.db.marshal.UserType(ks,61,62:org.apache.cassandra.db.marshal.UTF8Type)"
+        ));
+        // Frozen UDT is NOT complex.
+        assert!(!V5CompressedLegacyParser::is_complex_column(
+            "org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.UserType(ks,61,62:org.apache.cassandra.db.marshal.UTF8Type))"
+        ));
+    }
+
+    #[test]
+    fn test_udt_field_marshal_types_declared_order() {
+        let marshal = "org.apache.cassandra.db.marshal.UserType(\
+            test_ks,706572736f6e,\
+            6e616d65:org.apache.cassandra.db.marshal.UTF8Type,\
+            616765:org.apache.cassandra.db.marshal.Int32Type)";
+        let fields = V5CompressedLegacyParser::udt_field_marshal_types(marshal).unwrap();
+        assert_eq!(fields.len(), 2);
+        assert_eq!(fields[0].0, "name");
+        assert_eq!(fields[0].1, "org.apache.cassandra.db.marshal.UTF8Type");
+        assert_eq!(fields[1].0, "age");
+        assert_eq!(fields[1].1, "org.apache.cassandra.db.marshal.Int32Type");
+
+        let (ks, name) = V5CompressedLegacyParser::udt_keyspace_and_name(marshal).unwrap();
+        assert_eq!(ks, "test_ks");
+        assert_eq!(name, "person");
     }
 }

--- a/cqlite-core/src/storage/sstable/writer/data_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer.rs
@@ -1133,7 +1133,49 @@ impl DataWriter {
             }
         }
 
-        let ops: Vec<MergedOp<'a>> = cells.into_values().collect();
+        let mut ops: Vec<MergedOp<'a>> = cells.into_values().collect();
+
+        // Issue #927 (item 6): mixed-stream reconciliation. A single column may
+        // carry BOTH a whole-column op (in `ops`) and per-element complex ops (in
+        // `complex_element_ops`) — e.g. a UDT overwritten wholesale by one mutation
+        // and edited per-field by another. Emitting both would double-write the
+        // column and desync the reader. Reconcile by timestamp shadowing: keep the
+        // stream with the newer max timestamp and drop the other, rather than
+        // silently losing one.
+        if !complex_element_ops.is_empty() {
+            let mut elem_max_ts: std::collections::HashMap<&str, i64> =
+                std::collections::HashMap::new();
+            for mop in &complex_element_ops {
+                if let Some(col) = merged_op_column(mop.op) {
+                    let entry = elem_max_ts.entry(col).or_insert(i64::MIN);
+                    if mop.timestamp_micros > *entry {
+                        *entry = mop.timestamp_micros;
+                    }
+                }
+            }
+            // Columns whose whole-column op wins (>= element max ts) keep their
+            // whole op; their per-element ops are dropped. Columns where elements
+            // win drop the whole-column op.
+            let mut whole_wins: std::collections::HashSet<&str> = std::collections::HashSet::new();
+            ops.retain(|mop| match merged_op_column(mop.op) {
+                Some(col) => match elem_max_ts.get(col) {
+                    Some(&emax) if mop.timestamp_micros >= emax => {
+                        whole_wins.insert(col);
+                        true
+                    }
+                    Some(_) => false,
+                    None => true,
+                },
+                None => true,
+            });
+            if !whole_wins.is_empty() {
+                complex_element_ops.retain(|mop| match merged_op_column(mop.op) {
+                    Some(col) => !whole_wins.contains(col),
+                    None => true,
+                });
+            }
+        }
+
         if ops.is_empty()
             && complex_element_ops.is_empty()
             && row_deletion.is_none()
@@ -2268,6 +2310,13 @@ impl DataWriter {
             || dt.starts_with("org.apache.cassandra.db.marshal.listtype(")
         {
             self.write_list_complex_cells(buf, value, timestamp_micros, ttl_seconds)?;
+        } else if is_udt_marshal(&dt) {
+            // Issue #927: decompose a whole-`Value::Udt` literal into per-field
+            // cells (cell_path = 2-byte signed-short DECLARED field index, value =
+            // field datum). Field index comes from the column's declared order, NOT
+            // the literal's position — a sparse / reordered literal lands each field
+            // at its correct index.
+            self.write_udt_complex_cells(buf, column, value, timestamp_micros, ttl_seconds)?;
         } else {
             return Err(Error::InvalidInput(format!(
                 "Column '{}' has type '{}' which is not a recognized complex column type",
@@ -2275,6 +2324,87 @@ impl DataWriter {
             )));
         }
 
+        Ok(())
+    }
+
+    /// Write the per-field cells of a whole-`Value::Udt` write, following the
+    /// column header already emitted by [`write_complex_column`] (issue #927).
+    ///
+    /// Each non-null field becomes one complex cell whose cell_path is the 2-byte
+    /// big-endian DECLARED field index (resolved by NAME from the `UserType(...)`
+    /// marshal string) and whose value is the serialized field datum. Null fields
+    /// are absent (no cell), matching Cassandra. Cells are emitted in ascending
+    /// field-index order. Row TTL, when present, propagates to every field cell as
+    /// an expiring cell.
+    fn write_udt_complex_cells(
+        &self,
+        buf: &mut Vec<u8>,
+        column: &Column,
+        value: &Value,
+        timestamp_micros: i64,
+        ttl_seconds: Option<u32>,
+    ) -> Result<()> {
+        let udt = match value {
+            Value::Udt(udt) => udt,
+            Value::Frozen(inner) => {
+                if let Value::Udt(udt) = inner.as_ref() {
+                    udt
+                } else {
+                    return Err(Error::InvalidInput(format!(
+                        "Column '{}' is a UDT complex column but value is {:?}",
+                        column.name, value
+                    )));
+                }
+            }
+            other => {
+                return Err(Error::InvalidInput(format!(
+                    "Column '{}' is a UDT complex column but value is {:?}",
+                    column.name, other
+                )));
+            }
+        };
+
+        let declared = udt_declared_field_names(&column.data_type)?;
+
+        // Resolve each literal field to its DECLARED index by name; reject unknown
+        // field names (no-heuristics). Build elements in declared-index order.
+        let mut elements: Vec<ComplexElementWrite> = Vec::new();
+        for field in &udt.fields {
+            let Some(field_value) = &field.value else {
+                // Null field: absent cell.
+                continue;
+            };
+            let idx = declared
+                .iter()
+                .position(|n| n == &field.name)
+                .ok_or_else(|| {
+                    Error::InvalidInput(format!(
+                        "UDT column '{}': literal field '{}' is not a declared field of {}",
+                        column.name, field.name, column.data_type
+                    ))
+                })?;
+            let cell_path = (idx as u16).to_be_bytes().to_vec();
+            let local_deletion_time = match ttl_seconds {
+                Some(ttl) => Some(self.expiring_local_deletion_time(ttl)?),
+                None => None,
+            };
+            elements.push(ComplexElementWrite {
+                cell_path,
+                value: Some(field_value.clone()),
+                timestamp_micros,
+                ttl_seconds,
+                local_deletion_time,
+                is_deleted: false,
+            });
+        }
+
+        // Ascending field-index (signed-short) order.
+        elements.sort_by(|a, b| compare_cell_paths(&a.cell_path, &b.cell_path, true));
+
+        encode_unsigned(elements.len() as u64, buf);
+        for elem in &elements {
+            self.write_complex_element_cell(buf, elem, timestamp_micros)?;
+        }
         Ok(())
     }
 
@@ -2622,14 +2752,15 @@ impl DataWriter {
             }
         }
 
-        // ---- Element order: SET/MAP by cell_path bytes; LIST insertion order.
-        let is_list = {
-            let dt = column.data_type.to_lowercase();
-            dt.starts_with("list<") || dt.starts_with("org.apache.cassandra.db.marshal.listtype(")
-        };
+        // ---- Element order: SET/MAP by cell_path bytes; UDT by SIGNED-short field
+        // index (issue #927); LIST insertion order.
+        let dt = column.data_type.to_lowercase();
+        let is_list =
+            dt.starts_with("list<") || dt.starts_with("org.apache.cassandra.db.marshal.listtype(");
+        let is_udt = is_udt_marshal(&dt);
         let mut ordered: Vec<&ComplexElementWrite> = elements.iter().collect();
         if !is_list {
-            ordered.sort_by(|a, b| a.cell_path.cmp(&b.cell_path));
+            ordered.sort_by(|a, b| compare_cell_paths(&a.cell_path, &b.cell_path, is_udt));
         }
 
         // ---- Cell count.
@@ -3339,7 +3470,123 @@ fn is_complex_column(data_type: &str) -> bool {
         return true;
     }
 
+    // Issue #927: a TOP-LEVEL non-frozen UDT is a first-class multi-cell complex
+    // column (each field is a cell keyed by its 2-byte signed-short field index).
+    // Frozen UDTs were excluded above; a UDT nested in a collection is matched by
+    // its outer list/set/map branch. Bare CQL UDT names (e.g. `address`) are NOT
+    // detected here — the writer holds only a `&TableSchema` and cannot resolve a
+    // bare name to a UDT without a `UdtRegistry` (issue #927 item 4, follow-up).
+    // Compaction inputs always carry the full `UserType(...)` marshal string, so
+    // this covers the compaction path.
+    if is_udt_marshal(&dt) {
+        return true;
+    }
+
     false
+}
+
+/// True iff `data_type` is a TOP-LEVEL non-frozen `UserType(...)` marshal string
+/// (issue #927). `dt_lower` is expected already lowercased by the caller.
+fn is_udt_marshal(dt_lower: &str) -> bool {
+    dt_lower.starts_with("org.apache.cassandra.db.marshal.usertype(")
+}
+
+/// Total-order comparator for two complex-column cell paths (issue #927, parity
+/// Cassandra `d14c96b8`). UDT field-index paths are 2-byte **signed** `ShortType`
+/// values, so a field index in `[32768, 65535]` (negative as `i16`) must sort
+/// BEFORE the positive indices — a plain lexicographic byte compare would order
+/// it last. Non-UDT paths (collections) keep lexicographic byte ordering.
+fn compare_cell_paths(a: &[u8], b: &[u8], is_udt: bool) -> std::cmp::Ordering {
+    if is_udt && a.len() == 2 && b.len() == 2 {
+        let ai = i16::from_be_bytes([a[0], a[1]]);
+        let bi = i16::from_be_bytes([b[0], b[1]]);
+        return ai.cmp(&bi);
+    }
+    a.cmp(b)
+}
+
+/// Parse the DECLARED field order (names only) from a top-level `UserType(...)`
+/// marshal string (issue #927). Used to map a whole-`Value::Udt` literal's fields
+/// to their 2-byte signed-short cell-path index by NAME, never by literal
+/// position (the literal may be sparse / out of order).
+fn udt_declared_field_names(data_type: &str) -> Result<Vec<String>> {
+    let start_marker = "org.apache.cassandra.db.marshal.UserType(";
+    let type_lower = data_type.to_lowercase();
+    let start_idx = type_lower
+        .find(&start_marker.to_lowercase())
+        .ok_or_else(|| Error::InvalidInput(format!("Not a UserType: {}", data_type)))?;
+    let inner_start = start_idx + start_marker.len();
+    let mut paren_depth = 1;
+    let mut end_idx = inner_start;
+    let chars: Vec<char> = data_type[inner_start..].chars().collect();
+    for (i, c) in chars.iter().enumerate() {
+        match c {
+            '(' => paren_depth += 1,
+            ')' => {
+                paren_depth -= 1;
+                if paren_depth == 0 {
+                    end_idx = inner_start + i;
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+    if paren_depth != 0 {
+        return Err(Error::InvalidInput(format!(
+            "Unbalanced parentheses in UserType: {}",
+            data_type
+        )));
+    }
+    let inner = &data_type[inner_start..end_idx];
+    // Split top-level args respecting nested parens.
+    let mut parts: Vec<String> = Vec::new();
+    let mut current = String::new();
+    let mut depth = 0;
+    for c in inner.chars() {
+        match c {
+            '(' => {
+                depth += 1;
+                current.push(c);
+            }
+            ')' => {
+                depth -= 1;
+                current.push(c);
+            }
+            ',' if depth == 0 => {
+                parts.push(std::mem::take(&mut current));
+            }
+            _ => current.push(c),
+        }
+    }
+    if !current.is_empty() {
+        parts.push(current);
+    }
+    // First two args are keyspace + hex name; the rest are `hexname:type`.
+    let mut names = Vec::with_capacity(parts.len().saturating_sub(2));
+    for field_def in parts.iter().skip(2) {
+        let field_def = field_def.trim();
+        if field_def.is_empty() {
+            continue;
+        }
+        let colon_idx = field_def.find(':').ok_or_else(|| {
+            Error::InvalidInput(format!(
+                "Invalid UDT field definition (missing colon): {}",
+                field_def
+            ))
+        })?;
+        let name_bytes = hex::decode(&field_def[..colon_idx]).map_err(|e| {
+            Error::InvalidInput(format!(
+                "Invalid hex-encoded UDT field name '{}': {}",
+                &field_def[..colon_idx],
+                e
+            ))
+        })?;
+        let name = String::from_utf8(name_bytes)
+            .map_err(|e| Error::InvalidInput(format!("Invalid UTF-8 in UDT field name: {}", e)))?;
+        names.push(name);
+    }
+    Ok(names)
 }
 
 /// A surviving cell operation in a merged row, tagged with the timestamp and
@@ -3453,6 +3700,20 @@ struct RowWrite<'a> {
 
 fn column_order_key(column: &Column) -> (bool, &str) {
     (is_complex_column(&column.data_type), column.name.as_str())
+}
+
+/// The column name targeted by a cell operation, if any (issue #927: used by
+/// mixed-stream reconciliation). `DeleteRow` targets no specific column.
+fn merged_op_column(op: &crate::storage::write_engine::mutation::CellOperation) -> Option<&str> {
+    use crate::storage::write_engine::mutation::CellOperation;
+    match op {
+        CellOperation::Write { column, .. }
+        | CellOperation::WriteWithTtl { column, .. }
+        | CellOperation::Delete { column }
+        | CellOperation::WriteComplexElement { column, .. }
+        | CellOperation::ComplexDeletion { column, .. } => Some(column.as_str()),
+        CellOperation::DeleteRow => None,
+    }
 }
 
 /// Generate a version-1 TimeUUID for use as a list cell path.
@@ -6474,6 +6735,19 @@ mod tests {
         assert!(!is_complex_column("text"));
         assert!(!is_complex_column("uuid"));
         assert!(!is_complex_column("timestamp"));
+
+        // Issue #927: a TOP-LEVEL non-frozen UDT IS complex.
+        assert!(is_complex_column(
+            "org.apache.cassandra.db.marshal.UserType(ks,61,62:org.apache.cassandra.db.marshal.UTF8Type)"
+        ));
+        // A frozen UDT is NOT complex (single-cell).
+        assert!(!is_complex_column(
+            "org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.UserType(ks,61,62:org.apache.cassandra.db.marshal.UTF8Type))"
+        ));
+        // A bare CQL UDT name is NOT detected here (needs a UdtRegistry — issue
+        // #927 item 4); `frozen<addr>` is likewise not complex.
+        assert!(!is_complex_column("address_type"));
+        assert!(!is_complex_column("frozen<address_type>"));
     }
 
     #[test]
@@ -8926,5 +9200,272 @@ mod tests {
         );
         assert!(dead.value.is_none(), "tombstone writes no value bytes");
         assert_eq!(dead.ldt_delta, Some((1_700_000_009 - 1_700_000_000) as u64));
+    }
+
+    // ===================================================================
+    // Issue #927 — non-frozen UDT multi-cell support (writer + reader).
+    //
+    // A non-frozen UDT column stores each non-null field as its own complex
+    // cell, keyed by the 2-byte signed-short DECLARED field index. These tests
+    // exercise the writer decomposition AND a true writer->reader round-trip.
+    // ===================================================================
+
+    /// `person { name text, age int, email text }` as a top-level non-frozen UDT
+    /// marshal string.
+    fn person_udt_marshal() -> String {
+        "org.apache.cassandra.db.marshal.UserType(\
+         test_ks,706572736f6e,\
+         6e616d65:org.apache.cassandra.db.marshal.UTF8Type,\
+         616765:org.apache.cassandra.db.marshal.Int32Type,\
+         656d61696c:org.apache.cassandra.db.marshal.UTF8Type)"
+            .to_string()
+    }
+
+    fn udt_column(name: &str, data_type: &str) -> Column {
+        Column {
+            name: name.to_string(),
+            data_type: data_type.to_string(),
+            nullable: true,
+            default: None,
+            is_static: false,
+        }
+    }
+
+    fn udt_field(name: &str, value: Option<Value>) -> crate::types::UdtField {
+        crate::types::UdtField {
+            name: name.to_string(),
+            value,
+        }
+    }
+
+    fn person_reader() -> crate::storage::sstable::reader::V5CompressedLegacyParser {
+        crate::storage::sstable::reader::V5CompressedLegacyParser::new(
+            "test_ks".to_string(),
+            "test_table".to_string(),
+            1_000_000, // min_timestamp (matches create_test_stats)
+            0,         // min_local_deletion_time
+            Some(0),   // min_ttl
+        )
+    }
+
+    /// A sparse, out-of-order whole-`Value::Udt` write must round-trip through
+    /// the reader with each field landing at its DECLARED index (issue #927 item
+    /// 3: field index comes from declared order, never the literal's position).
+    #[test]
+    fn udt_whole_write_roundtrips_sparse_out_of_order() {
+        let writer = DataWriter::new(create_test_stats());
+        let col = udt_column("addr", &person_udt_marshal());
+        // Literal lists email THEN name (out of order) and OMITS age (sparse).
+        let udt = Value::Udt(crate::types::UdtValue {
+            type_name: "person".to_string(),
+            keyspace: "test_ks".to_string(),
+            fields: vec![
+                udt_field("email", Some(Value::Text("a@b.com".to_string()))),
+                udt_field("name", Some(Value::Text("Alice".to_string()))),
+            ],
+        });
+
+        let row_ts = 1_005_000i64;
+        let mut buf = Vec::new();
+        writer
+            .write_complex_column(&mut buf, &col, &udt, row_ts, None)
+            .unwrap();
+
+        // Decode the raw bytes: two cells (name idx 0, email idx 2), ascending
+        // signed-short field index, age (idx 1) absent.
+        let (_del_ts, _del_ldt, cells) = decode_complex_column(&buf);
+        assert_eq!(cells.len(), 2, "two non-null fields => two cells");
+        assert_eq!(
+            cells[0].cell_path,
+            0u16.to_be_bytes().to_vec(),
+            "name idx 0 first"
+        );
+        assert_eq!(
+            cells[1].cell_path,
+            2u16.to_be_bytes().to_vec(),
+            "email idx 2 next"
+        );
+
+        // True round-trip through the reader.
+        let parser = person_reader();
+        let (value, _off, _meta) = parser
+            .parse_complex_column_inner(&buf, 0, &col, true, row_ts, None)
+            .expect("reader must parse the UDT complex column");
+
+        match value {
+            Value::Udt(out) => {
+                assert_eq!(out.type_name, "person");
+                assert_eq!(out.keyspace, "test_ks");
+                assert_eq!(out.fields.len(), 3, "all DECLARED fields present");
+                assert_eq!(out.fields[0].name, "name");
+                assert_eq!(out.fields[0].value, Some(Value::Text("Alice".to_string())));
+                assert_eq!(out.fields[1].name, "age");
+                assert_eq!(out.fields[1].value, None, "omitted field stays null");
+                assert_eq!(out.fields[2].name, "email");
+                assert_eq!(
+                    out.fields[2].value,
+                    Some(Value::Text("a@b.com".to_string()))
+                );
+            }
+            other => panic!("expected Value::Udt, got {:?}", other),
+        }
+    }
+
+    /// Row TTL on a whole-UDT write must propagate to every emitted field cell as
+    /// an expiring cell (issue #927 item 4 / roborev job 929).
+    #[test]
+    fn udt_whole_write_propagates_row_ttl() {
+        let writer = DataWriter::new(create_test_stats());
+        let col = udt_column("addr", &person_udt_marshal());
+        let udt = Value::Udt(crate::types::UdtValue {
+            type_name: "person".to_string(),
+            keyspace: "test_ks".to_string(),
+            fields: vec![
+                udt_field("name", Some(Value::Text("Bob".to_string()))),
+                udt_field("age", Some(Value::Integer(42))),
+            ],
+        });
+
+        let mut buf = Vec::new();
+        writer
+            .write_complex_column(&mut buf, &col, &udt, 1_005_000, Some(3_600))
+            .unwrap();
+
+        let (_d, _l, cells) = decode_complex_column(&buf);
+        assert_eq!(cells.len(), 2);
+        for c in &cells {
+            assert_ne!(
+                c.flags & CELL_IS_EXPIRING,
+                0,
+                "TTL must make every field cell expiring, flags=0x{:02x}",
+                c.flags
+            );
+            assert!(c.ttl_delta.is_some(), "expiring cell carries a TTL delta");
+            assert!(c.ldt_delta.is_some(), "expiring cell carries an LDT delta");
+        }
+    }
+
+    /// A whole-UDT literal naming a field that is not declared is authoritative
+    /// corruption — reject it (no-heuristics mandate, issue #927 item 3).
+    #[test]
+    fn udt_whole_write_rejects_unknown_field() {
+        let writer = DataWriter::new(create_test_stats());
+        let col = udt_column("addr", &person_udt_marshal());
+        let udt = Value::Udt(crate::types::UdtValue {
+            type_name: "person".to_string(),
+            keyspace: "test_ks".to_string(),
+            fields: vec![udt_field("nope", Some(Value::Text("x".to_string())))],
+        });
+        let mut buf = Vec::new();
+        let err = writer
+            .write_complex_column(&mut buf, &col, &udt, 1_005_000, None)
+            .unwrap_err();
+        assert!(
+            matches!(err, Error::InvalidInput(_)),
+            "unknown UDT field must be InvalidInput, got {:?}",
+            err
+        );
+    }
+
+    /// UDT per-element cell paths must sort by SIGNED ShortType, so a field index
+    /// in `[32768, 65535]` (negative as i16) sorts BEFORE the positive indices
+    /// (issue #927, parity Cassandra `d14c96b8`). A plain byte-lexicographic sort
+    /// would put 0x8000 last.
+    #[test]
+    fn udt_per_element_signed_short_ordering() {
+        let writer = DataWriter::new(create_test_stats());
+        let col = udt_column("addr", &person_udt_marshal());
+        let mk = |idx: u16| ComplexElementWrite {
+            cell_path: idx.to_be_bytes().to_vec(),
+            value: Some(Value::Integer(idx as i32)),
+            timestamp_micros: 1_000_000,
+            ttl_seconds: None,
+            local_deletion_time: None,
+            is_deleted: false,
+        };
+        // Supplied out of order; 0x8000 == -32768 (signed), 0x7FFF == 32767.
+        let elements = vec![mk(0x7FFF), mk(0x8000), mk(0x0001)];
+        let mut buf = Vec::new();
+        writer
+            .write_complex_column_per_element(&mut buf, &col, None, &elements, 1_000_000)
+            .unwrap();
+
+        let (_d, _l, cells) = decode_complex_column(&buf);
+        let paths: Vec<u16> = cells
+            .iter()
+            .map(|c| u16::from_be_bytes([c.cell_path[0], c.cell_path[1]]))
+            .collect();
+        assert_eq!(
+            paths,
+            vec![0x8000, 0x0001, 0x7FFF],
+            "signed-short order: -32768, 1, 32767"
+        );
+    }
+
+    /// Mixed-stream reconciliation (issue #927 item 6): a column carrying BOTH a
+    /// whole-column op and per-element ops keeps the newer stream by timestamp,
+    /// rather than emitting both (which would double-write and desync the reader).
+    #[test]
+    fn udt_mixed_stream_reconciliation_newer_wins() {
+        let writer = DataWriter::new(create_test_stats());
+        let mut schema = create_test_schema();
+        schema
+            .columns
+            .push(udt_column("addr", &person_udt_marshal()));
+
+        let table_id = TableId::new("test_ks", "test_table");
+        let pk = PartitionKey::single("id", Value::Integer(7));
+
+        // Older whole-column UDT write (ts 1_000_000) ...
+        let whole = Mutation::new(
+            table_id.clone(),
+            pk.clone(),
+            None,
+            vec![CellOperation::Write {
+                column: "addr".to_string(),
+                value: Value::Udt(crate::types::UdtValue {
+                    type_name: "person".to_string(),
+                    keyspace: "test_ks".to_string(),
+                    fields: vec![udt_field("name", Some(Value::Text("Old".to_string())))],
+                }),
+            }],
+            1_000_000,
+            None,
+        );
+        // ... shadowed by a NEWER per-element edit (ts 2_000_000).
+        let per_elem = Mutation::new(
+            table_id,
+            pk,
+            None,
+            vec![CellOperation::WriteComplexElement {
+                column: "addr".to_string(),
+                cell_path: 0u16.to_be_bytes().to_vec(),
+                value: Some(Value::Text("New".to_string())),
+                timestamp_micros: 2_000_000,
+                ttl_seconds: None,
+                local_deletion_time: None,
+                is_deleted: false,
+            }],
+            2_000_000,
+            None,
+        );
+
+        let _ = &writer; // writer not needed: merge_row_group is associated
+        let row = DataWriter::merge_row_group(&[&whole, &per_elem], &schema, false, None)
+            .expect("merge must produce a row");
+
+        // The per-element stream is newer, so the whole-column op is dropped and
+        // the per-element op survives — no double-write.
+        assert!(
+            !row.ops
+                .iter()
+                .any(|m| merged_op_column(m.op) == Some("addr")),
+            "older whole-column UDT op must be shadowed by newer per-element edit"
+        );
+        assert_eq!(
+            row.complex_element_ops.len(),
+            1,
+            "newer per-element edit survives"
+        );
     }
 }


### PR DESCRIPTION
Closes #927 (core delivered; two narrow follow-ups tracked separately — see below).

## What

Treats a **top-level non-frozen UDT** as a first-class multi-cell complex column end to end. Each field is stored as its own cell keyed by the 2-byte **signed-short** DECLARED field index, matching Cassandra (parity `d14c96b8`).

### Reader (`v5_compressed_legacy.rs`)
- `is_complex_column` classifies top-level non-frozen `UserType(...)` marshal as complex. Frozen UDTs (`FrozenType(UserType(...))`) and collection-nested UDTs are unaffected.
- New UDT arm in `parse_complex_column_inner`: decodes each field cell by its signed-short field index, resolves the per-field type from the marshal string, collapses to `Value::Udt` in declared order, and surfaces per-element cells for the compaction read path.
- Helpers `udt_field_marshal_types` / `udt_keyspace_and_name`.

### Writer (`data_writer.rs`)
- `is_complex_column` + `is_udt_marshal` classify non-frozen UDT marshal as complex, so the row header sets `ROW_HAS_COMPLEX_DELETION` and orders the column among complex columns.
- `write_udt_complex_cells` decomposes a whole `Value::Udt` into per-field cells indexed by **declared** order (resolved by name, not literal position) — a sparse / reordered literal lands each field at its correct index. Unknown literal fields are rejected (`InvalidInput`, no-heuristics). Row TTL propagates to every field cell.
- `compare_cell_paths` signed-short comparator wired into per-element ordering, so a field index in `[32768, 65535]` (negative as `i16`) sorts before the positive indices.
- Mixed-stream reconciliation in `merge_row_group`: a column carrying BOTH a whole-column op and per-element ops keeps the newer stream by timestamp rather than double-writing.

## Tests
7 new tests including a true **writer→reader round-trip** (sparse / out-of-order literal), TTL propagation, signed-short ordering across field index 32768, unknown-field rejection, and mixed-stream reconciliation.

## Validation (`scripts/agent-gate.sh`)
fmt ✅ · clippy ✅ · integration ✅ · format-compat ✅ · write-tests ✅ · cli-tests ✅ · python-bindings ✅ · minimal-build ✅ · smoke ✅. Core-tests' only failure is the known-flaky `test_flush_throughput` perf gate (4.0 vs 5 MB/sec under concurrent machine load); passes in isolation and is unrelated to this change.

## Follow-ups (out of scope here)
1. **Bare-CQL-name UDT detection** — the writer holds only `&TableSchema` and cannot resolve a bare name (e.g. `address`) to a UDT without a `UdtRegistry`. Compaction always carries full `UserType(...)` marshal strings, so the compaction path is fully covered; only direct user writes with bare names need the registry plumbing.
2. **Single schema-ordered complex emission pass** — a row mixing whole-column complex writes and per-element ops for *different* columns can misorder them across the two emit passes. Real pipelines don't mix modes per row; not exercised today.