### PR TITLE
fix(compaction): preserve row-tombstone local_deletion_time through merge rewrite (#873)

### DIFF
--- a/cqlite-cli/src/output/json.rs
+++ b/cqlite-cli/src/output/json.rs
@@ -688,6 +688,7 @@ mod tests {
         let tombstone = Value::Tombstone(TombstoneInfo {
             deletion_time: 1673778645000000,
             tombstone_type: TombstoneType::CellTombstone,
+            local_deletion_time: 0,
             ttl: None,
             range_start: None,
             range_end: None,
@@ -707,6 +708,7 @@ mod tests {
         let tombstone = Value::Tombstone(TombstoneInfo {
             deletion_time: 1673778645000000,
             tombstone_type: TombstoneType::RowTombstone,
+            local_deletion_time: 0,
             ttl: None,
             range_start: None,
             range_end: None,
@@ -737,6 +739,7 @@ mod tests {
             Value::Tombstone(TombstoneInfo {
                 deletion_time: 0,
                 tombstone_type: TombstoneType::CellTombstone,
+                local_deletion_time: 0,
                 ttl: None,
                 range_start: None,
                 range_end: None,

--- a/cqlite-cli/tests/output_format_tests.rs
+++ b/cqlite-cli/tests/output_format_tests.rs
@@ -330,6 +330,7 @@ fn test_json_serializes_all_value_variants() {
             Value::Tombstone(TombstoneInfo {
                 deletion_time: 1673778645000000,
                 tombstone_type: TombstoneType::RowTombstone,
+                local_deletion_time: 0,
                 ttl: None,
                 range_start: None,
                 range_end: None,
@@ -478,6 +479,7 @@ fn test_csv_serializes_all_value_variants() {
             Value::Tombstone(TombstoneInfo {
                 deletion_time: 1673778645000000,
                 tombstone_type: TombstoneType::RowTombstone,
+                local_deletion_time: 0,
                 ttl: None,
                 range_start: None,
                 range_end: None,

--- a/cqlite-cli/tests/parquet_writer_tests.rs
+++ b/cqlite-cli/tests/parquet_writer_tests.rs
@@ -888,6 +888,7 @@ fn test_parquet_tombstone_value() {
     let tombstone = Value::Tombstone(TombstoneInfo {
         deletion_time: 1673778645,
         tombstone_type: TombstoneType::CellTombstone,
+        local_deletion_time: 0,
         ttl: None,
         range_start: None,
         range_end: None,

--- a/cqlite-core/src/parser/types.rs
+++ b/cqlite-core/src/parser/types.rs
@@ -1261,6 +1261,9 @@ pub fn parse_tombstone(input: &[u8]) -> IResult<&[u8], Value> {
     let tombstone_info = TombstoneInfo {
         deletion_time,
         tombstone_type,
+        // The legacy CQL binary tombstone encoding carries no localDeletionTime
+        // (only deletion_time); default to 0 (#873).
+        local_deletion_time: 0,
         ttl,
         range_start: range_start.map(RowKey::new),
         range_end: range_end.map(RowKey::new),
@@ -2249,6 +2252,7 @@ mod tests {
         let partition_tombstone = Value::Tombstone(TombstoneInfo {
             deletion_time: 9999,
             tombstone_type: TombstoneType::PartitionTombstone,
+            local_deletion_time: 0,
             ttl: None,
             range_start: None,
             range_end: None,

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
@@ -198,6 +198,10 @@ impl RowHeader {
         Value::Tombstone(TombstoneInfo {
             deletion_time,
             tombstone_type: TombstoneType::RowTombstone,
+            // Carry the on-disk `localDeletionTime` (GC clock, seconds) so the
+            // compaction merge→rewrite path can preserve it (#873). Absent for a
+            // non-tombstone header, hence the `0` fallback.
+            local_deletion_time: self.local_deletion_time.unwrap_or(0) as i64,
             ttl: None,
             range_start: None,
             range_end: None,
@@ -4215,6 +4219,9 @@ impl V5CompressedLegacyParser {
                 Value::Tombstone(TombstoneInfo {
                     deletion_time,
                     tombstone_type: TombstoneType::CellTombstone,
+                    // On-disk `localDeletionTime` (GC clock, seconds) for the cell
+                    // tombstone; `0` when not surfaced (#873).
+                    local_deletion_time: cell_local_deletion_time.unwrap_or(0),
                     ttl: None,
                     range_start: None,
                     range_end: None,

--- a/cqlite-core/src/storage/sstable/tombstone_merger.rs
+++ b/cqlite-core/src/storage/sstable/tombstone_merger.rs
@@ -548,6 +548,7 @@ mod tests {
         let tombstone = TombstoneInfo {
             deletion_time: 2000,
             tombstone_type: TombstoneType::RangeTombstone,
+            local_deletion_time: 0,
             ttl: None,
             range_start: Some(start_key),
             range_end: Some(end_key),

--- a/cqlite-core/src/storage/sstable/writer/data_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer.rs
@@ -1489,6 +1489,22 @@ impl DataWriter {
             let ts_delta = (deletion_ts - self.stats.min_timestamp) as u64;
             encode_unsigned(ts_delta, &mut body);
 
+            // Issue #873: reject a row-tombstone LDT that is genuinely below the
+            // baseline, in normal (non-negative i32) time space — a silent
+            // `wrapping_sub` here would zero-extend the underflow into a huge u32,
+            // emit a multi-byte VInt, and corrupt the row body / row-size. A
+            // far-future LDT (negative as i32, value in [2^31, 2^32)) is a
+            // legitimate value, not corruption, so the wrapping arithmetic is
+            // intended there (matches the complex-deletion guard).
+            if local_deletion_time >= 0
+                && self.stats.min_local_deletion_time >= 0
+                && local_deletion_time < self.stats.min_local_deletion_time
+            {
+                return Err(Error::InvalidInput(format!(
+                    "Row tombstone: local deletion time {} is less than min_local_deletion_time {}",
+                    local_deletion_time, self.stats.min_local_deletion_time
+                )));
+            }
             let ldt_delta =
                 local_deletion_time.wrapping_sub(self.stats.min_local_deletion_time) as u32;
             encode_unsigned(ldt_delta as u64, &mut body);
@@ -1779,6 +1795,19 @@ impl DataWriter {
             let ts_delta = (deletion_ts - self.stats.min_timestamp) as u64;
             encode_unsigned(ts_delta, &mut body);
 
+            // Issue #873: same loud guard as the single-row path — reject a
+            // below-baseline row-tombstone LDT in normal time space instead of
+            // silently wrapping the unsigned delta and corrupting the row body.
+            // A far-future LDT (negative as i32) is legitimate and kept.
+            if local_deletion_time >= 0
+                && self.stats.min_local_deletion_time >= 0
+                && local_deletion_time < self.stats.min_local_deletion_time
+            {
+                return Err(Error::InvalidInput(format!(
+                    "Row tombstone: local deletion time {} is less than min_local_deletion_time {}",
+                    local_deletion_time, self.stats.min_local_deletion_time
+                )));
+            }
             let ldt_delta =
                 local_deletion_time.wrapping_sub(self.stats.min_local_deletion_time) as u32;
             encode_unsigned(ldt_delta as u64, &mut body);
@@ -6900,6 +6929,79 @@ mod tests {
             result.is_err(),
             "LDT below baseline must be rejected to avoid VInt wrap corruption"
         );
+    }
+
+    /// Issue #873: a ROW tombstone whose explicit localDeletionTime is below the
+    /// Statistics baseline (in normal, non-negative i32 time space) must be
+    /// rejected loudly rather than silently wrapping the unsigned LDT delta into
+    /// a huge VInt — which would over-count the row body and corrupt Data.db.
+    /// This mirrors the complex-deletion guard above.
+    #[test]
+    fn test_row_tombstone_rejects_ldt_below_baseline() {
+        use crate::storage::write_engine::mutation::{
+            CellOperation, Mutation, PartitionKey, TableId,
+        };
+
+        let schema = create_test_schema();
+        let mut stats = create_test_stats();
+        stats.min_timestamp = 0;
+        stats.min_local_deletion_time = 1_700_000_000; // baseline well above the delete's LDT
+        let mut writer = DataWriter::new(stats);
+
+        // A row tombstone (DeleteRow) whose explicit LDT (50s) is far below the
+        // baseline. `effective_local_deletion_time()` honors the explicit value.
+        let mutation = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(1)),
+            None,
+            vec![CellOperation::DeleteRow],
+            1_000_000, // deletion timestamp (micros)
+            None,
+        )
+        .with_local_deletion_time(50);
+
+        let key = mutation
+            .decorated_key(&schema)
+            .expect("decorated key must build");
+        let result = writer.write_partition(&key, &[mutation], &schema, None, &[]);
+        assert!(
+            result.is_err(),
+            "a below-baseline row-tombstone LDT must be rejected to avoid VInt wrap corruption"
+        );
+    }
+
+    /// Companion to the guard test: a row tombstone with a far-future LDT in
+    /// [2^31, 2^32) (negative i32 bit pattern) is a LEGITIMATE value and must NOT
+    /// be rejected — the wrapping i32 arithmetic is intended there (#853/#873).
+    #[test]
+    fn test_row_tombstone_far_future_ldt_is_accepted() {
+        use crate::storage::write_engine::mutation::{
+            CellOperation, Mutation, PartitionKey, TableId,
+        };
+
+        let schema = create_test_schema();
+        let mut stats = create_test_stats();
+        stats.min_timestamp = 0;
+        stats.min_local_deletion_time = 0; // common DeletionTime.LIVE-derived baseline
+        let mut writer = DataWriter::new(stats);
+
+        let far_future_ldt = (1u32 << 31) as i32; // negative i32, value 2^31
+        let mutation = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(2)),
+            None,
+            vec![CellOperation::DeleteRow],
+            1_000_000,
+            None,
+        )
+        .with_local_deletion_time(far_future_ldt);
+
+        let key = mutation
+            .decorated_key(&schema)
+            .expect("decorated key must build");
+        writer
+            .write_partition(&key, &[mutation], &schema, None, &[])
+            .expect("a far-future row-tombstone LDT must be accepted, not rejected");
     }
 
     /// Issue #853: a complex-deletion marker whose localDeletionTime lands in

--- a/cqlite-core/src/storage/write_engine/merge.rs
+++ b/cqlite-core/src/storage/write_engine/merge.rs
@@ -1022,6 +1022,9 @@ impl SSTableRowIteratorAdapter {
                             Value::Tombstone(crate::types::TombstoneInfo {
                                 deletion_time: elem.timestamp,
                                 tombstone_type: crate::types::TombstoneType::CellTombstone,
+                                // Element's on-disk localDeletionTime (GC clock,
+                                // seconds); `0` when not surfaced (#873).
+                                local_deletion_time: elem.local_deletion_time.unwrap_or(0) as i64,
                                 ttl: None,
                                 range_start: None,
                                 range_end: None,
@@ -1074,7 +1077,15 @@ impl SSTableRowIteratorAdapter {
         match value {
             crate::types::Value::Tombstone(info) => Ok(RowData::Tombstone {
                 deletion_time: info.deletion_time,
-                local_deletion_time: 0, // TombstoneInfo does not carry local_deletion_time
+                // #873: TombstoneInfo now carries the source localDeletionTime
+                // (GC clock, seconds). `RowData::Tombstone` stores it as i32
+                // (the on-disk width); the value fits an i32 in practice
+                // (epoch-seconds, incl. far-future negative-i32 bit patterns).
+                // NOTE: this legacy adapter is `#[cfg(test)]` only — the
+                // production compaction tombstone path is
+                // `compaction_row_data_to_row_data`, which already threads the
+                // LDT from `CompactionRowData::Tombstone`.
+                local_deletion_time: info.local_deletion_time as i32,
             }),
             crate::types::Value::Map(map_entries) => {
                 let mut cells = Vec::with_capacity(map_entries.len());
@@ -1876,7 +1887,12 @@ impl KWayMerger {
         let mut run_index = usize::MAX;
 
         // Step 1: effective row deletion — max deletion_time across row tombstones.
+        // Track the source `local_deletion_time` (GC-clock seconds) PAIRED with the
+        // winning (max) deletion_time so the rebuilt tombstone preserves its
+        // wall-clock LDT instead of re-deriving it from the deletion timestamp
+        // (#873 — gc_grace semantics + unsigned LDT-delta underflow guard).
         let mut row_del: Option<i64> = None;
+        let mut row_del_ldt: i32 = 0;
 
         // Step 2: per-cell reconcile keyed by `(column, cell_path)` so each
         // element of a multi-cell column reconciles independently (epic #899).
@@ -1922,8 +1938,17 @@ impl KWayMerger {
             }
 
             match &entry.row_data {
-                RowData::Tombstone { deletion_time, .. } => {
-                    row_del = Some(row_del.map_or(*deletion_time, |d| d.max(*deletion_time)));
+                RowData::Tombstone {
+                    deletion_time,
+                    local_deletion_time,
+                } => {
+                    // When this tombstone's deletion_time becomes (or sets) the new
+                    // max, capture its paired LDT too so the winning tombstone's
+                    // source `localDeletionTime` survives reconciliation (#873).
+                    if row_del.is_none_or(|d| *deletion_time > d) {
+                        row_del = Some(*deletion_time);
+                        row_del_ldt = *local_deletion_time;
+                    }
                 }
                 RowData::Live { cells } => {
                     for cell in cells {
@@ -2058,7 +2083,10 @@ impl KWayMerger {
                 deletion_time,
                 RowData::Tombstone {
                     deletion_time,
-                    local_deletion_time: 0,
+                    // Preserve the source LDT paired with the winning deletion_time
+                    // (#873) instead of resetting it to 0; the writer encodes it
+                    // verbatim and gc_grace decisions stay faithful.
+                    local_deletion_time: row_del_ldt,
                 },
             ))
         } else if has_carried_metadata {
@@ -2180,6 +2208,29 @@ impl KWayMerger {
         let partition_key = PartitionKey::from_bytes(&entry.key.key, schema)?;
         let table_id = TableId::new(&schema.keyspace, &schema.table);
 
+        // Capture the row tombstone's source LDT (GC-clock seconds) by borrow,
+        // before the `match` below moves `cells` out of `entry.row_data` (#873).
+        //
+        // `0` is the established "LDT not surfaced by the reader" placeholder
+        // (the legacy `CompactionRow::from_legacy_value` fallback and pre-V5 row
+        // tombstones both build `local_deletion_time: 0`), NOT an authoritative
+        // epoch-1970 deletion — a real Cassandra row tombstone always carries a
+        // nonzero wall-clock LDT. Only thread a genuinely-surfaced (nonzero) LDT;
+        // for the placeholder leave it `None` so the writer keeps deriving LDT
+        // from `entry.timestamp` exactly as before this change. Threading `0`
+        // here would both lose that fallback and trip the new below-baseline
+        // writer guard against a nonzero pre-seeded `min_local_deletion_time`,
+        // rejecting previously-valid legacy-path compactions (#873 review #946).
+        // A live row leaves it `None` so any cell tombstones keep their historical
+        // timestamp-derived behavior.
+        let row_tombstone_ldt = match &entry.row_data {
+            RowData::Tombstone {
+                local_deletion_time,
+                ..
+            } if *local_deletion_time != 0 => Some(*local_deletion_time),
+            _ => None,
+        };
+
         let mut operations = match entry.row_data {
             RowData::Live { cells } => Self::cells_to_cell_operations(cells),
             RowData::Tombstone { .. } => vec![CellOperation::DeleteRow],
@@ -2203,22 +2254,24 @@ impl KWayMerger {
             }
         }
 
-        // NOTE (follow-up #873): the rewritten row tombstone's
-        // local_deletion_time is left None here, so the writer derives it from
-        // `entry.timestamp`. The source SSTable's localDeletionTime is not yet
-        // preserved through compaction because it is dropped upstream
-        // (`value_to_row_data` builds `RowData::Tombstone { local_deletion_time: 0 }`
-        // since `TombstoneInfo` carries no LDT). Threading it end-to-end —
-        // including a guard against negative row-tombstone LDT deltas — is
-        // tracked in #873.
-        Ok(Mutation::new(
+        // Thread the row tombstone's preserved source `localDeletionTime` onto the
+        // mutation so the writer emits it verbatim (#873) rather than re-deriving
+        // it from `entry.timestamp` (`timestamp_micros / 1_000_000`). That keeps
+        // gc_grace semantics intact and avoids underflowing the unsigned
+        // row-deletion LDT delta for logical-timestamp deletes. A live row leaves
+        // the mutation LDT unset (`None`).
+        let mutation = Mutation::new(
             table_id,
             partition_key,
             entry.clustering_key,
             operations,
             entry.timestamp,
             None,
-        ))
+        );
+        Ok(match row_tombstone_ldt {
+            Some(ldt) => mutation.with_local_deletion_time(ldt),
+            None => mutation,
+        })
     }
 }
 
@@ -2869,6 +2922,7 @@ mod tests {
                     value: Value::Tombstone(TombstoneInfo {
                         deletion_time: 100,
                         tombstone_type: TombstoneType::CellTombstone,
+                        local_deletion_time: 0,
                         ttl: None,
                         range_start: None,
                         range_end: None,
@@ -5174,6 +5228,7 @@ mod issue_823_complex_column_merge {
                 value: Value::Tombstone(TombstoneInfo {
                     deletion_time: 100,
                     tombstone_type: TombstoneType::CellTombstone,
+                    local_deletion_time: 0,
                     ttl: None,
                     range_start: None,
                     range_end: None,
@@ -6264,6 +6319,7 @@ mod issue_822_merge_ordering_semantics {
                         value: Value::Tombstone(TombstoneInfo {
                             deletion_time: TS,
                             tombstone_type: TombstoneType::CellTombstone,
+                            local_deletion_time: 0,
                             ttl: None,
                             range_start: None,
                             range_end: None,
@@ -6344,6 +6400,7 @@ mod issue_822_merge_ordering_semantics {
                         value: Value::Tombstone(TombstoneInfo {
                             deletion_time: TS,
                             tombstone_type: TombstoneType::CellTombstone,
+                            local_deletion_time: 0,
                             ttl: None,
                             range_start: None,
                             range_end: None,
@@ -6563,6 +6620,7 @@ mod issue_822_merge_ordering_semantics {
             value: Value::Tombstone(TombstoneInfo {
                 deletion_time: 1,
                 tombstone_type: TombstoneType::CellTombstone,
+                local_deletion_time: 0,
                 ttl: None,
                 range_start: None,
                 range_end: None,
@@ -7175,6 +7233,290 @@ mod issue_912_row_tombstone_clustering_identity {
                 .iter()
                 .all(|m| matches!(m.row_data, RowData::Tombstone { .. })),
             "both surviving entries must be row tombstones"
+        );
+    }
+}
+
+/// Issue #873: a row tombstone's source `localDeletionTime` (LDT, the GC clock
+/// instant in seconds) must be preserved through the compaction merge→rewrite
+/// path. Pre-#873 `reconcile_cluster` tracked only the winning `deletion_time`
+/// and rebuilt the surviving tombstone with `local_deletion_time: 0`, and
+/// `merge_entry_to_mutation` passed `None` for the mutation LDT — so the writer
+/// re-derived the LDT from the deletion *timestamp* (`timestamp_micros /
+/// 1_000_000`). That breaks gc_grace semantics and, for a pathological logical
+/// (non-wall-clock) timestamp delete, can underflow the unsigned row-deletion
+/// LDT delta in the writer and corrupt Data.db.
+#[cfg(all(test, feature = "write-support"))]
+mod issue_873_preserve_row_tombstone_ldt {
+    use super::*;
+    use crate::schema::{KeyColumn, TableSchema};
+    use crate::storage::write_engine::mutation::DecoratedKey;
+    use std::collections::HashMap;
+
+    fn unclustered_schema() -> TableSchema {
+        TableSchema {
+            keyspace: "ks873".to_string(),
+            table: "t873".to_string(),
+            partition_keys: vec![KeyColumn {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![],
+            columns: vec![],
+            comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
+        }
+    }
+
+    fn tombstone_entry(run_index: usize, deletion_time: i64, ldt: i32) -> MergeEntry {
+        MergeEntry::new(
+            run_index,
+            DecoratedKey::new(500, 7i32.to_be_bytes().to_vec()),
+            None,
+            deletion_time,
+            RowData::Tombstone {
+                deletion_time,
+                local_deletion_time: ldt,
+            },
+        )
+    }
+
+    /// `reconcile_cluster` must carry the winning tombstone's source LDT through
+    /// to the rebuilt surviving tombstone instead of hardcoding 0, and the LDT it
+    /// keeps must be the one paired with the winning (max) `deletion_time` — NOT
+    /// re-derived from that timestamp.
+    #[test]
+    fn reconcile_cluster_preserves_winning_tombstone_ldt() {
+        // deletion_time chosen so it does NOT equal LDT (which is GC-clock seconds):
+        // a logical-timestamp delete where micros and the wall-clock LDT diverge.
+        let deletion_time = 1_000_000_000_000_000i64; // micros
+        let source_ldt = 1_700_000_000i32; // seconds (wall clock)
+
+        let merged = KWayMerger::reconcile_cluster(
+            None,
+            vec![tombstone_entry(0, deletion_time, source_ldt)],
+            &HashMap::new(),
+        )
+        .expect("a surviving row tombstone must be emitted");
+
+        match merged.row_data {
+            RowData::Tombstone {
+                deletion_time: dt,
+                local_deletion_time,
+            } => {
+                assert_eq!(dt, deletion_time, "deletion_time must survive");
+                assert_eq!(
+                    local_deletion_time, source_ldt,
+                    "the source LDT must be preserved, not reset to 0 nor derived from the timestamp"
+                );
+            }
+            other => panic!("expected Tombstone, got {:?}", other),
+        }
+    }
+
+    /// When several row tombstones reconcile, the LDT kept must pair with the
+    /// winning (max) `deletion_time`, not the max LDT and not the first-seen LDT.
+    #[test]
+    fn reconcile_cluster_keeps_ldt_paired_with_max_deletion_time() {
+        // Older delete (smaller deletion_time) but LARGER LDT; newer delete
+        // (larger deletion_time) with a SMALLER LDT. The winner is the newer
+        // delete, so its (smaller) LDT must be the one carried through.
+        let older = tombstone_entry(0, 100_000_000, 1_900_000_000);
+        let newer = tombstone_entry(1, 200_000_000, 1_500_000_000);
+
+        let merged = KWayMerger::reconcile_cluster(None, vec![older, newer], &HashMap::new())
+            .expect("a surviving row tombstone must be emitted");
+
+        match merged.row_data {
+            RowData::Tombstone {
+                deletion_time,
+                local_deletion_time,
+            } => {
+                assert_eq!(deletion_time, 200_000_000, "the newer delete must win");
+                assert_eq!(
+                    local_deletion_time, 1_500_000_000,
+                    "the LDT carried must be the one paired with the winning deletion_time"
+                );
+            }
+            other => panic!("expected Tombstone, got {:?}", other),
+        }
+    }
+
+    /// `merge_entry_to_mutation` must thread a row tombstone's LDT onto the
+    /// produced mutation so the writer emits it verbatim instead of re-deriving it
+    /// from `timestamp_micros`. A live row keeps `local_deletion_time == None`.
+    #[test]
+    fn merge_entry_to_mutation_threads_row_tombstone_ldt() {
+        let schema = unclustered_schema();
+        let deletion_time = 1_000_000_000_000_000i64;
+        let source_ldt = 1_700_000_000i32;
+
+        let mutation = KWayMerger::merge_entry_to_mutation(
+            tombstone_entry(0, deletion_time, source_ldt),
+            &schema,
+        )
+        .expect("conversion should succeed");
+
+        assert_eq!(
+            mutation.local_deletion_time,
+            Some(source_ldt),
+            "the row tombstone's source LDT must be threaded onto the mutation"
+        );
+        assert_eq!(
+            mutation.effective_local_deletion_time(),
+            source_ldt,
+            "the writer must use the preserved LDT, not the timestamp-derived one"
+        );
+        // The timestamp-derived LDT would be deletion_time / 1_000_000 =
+        // 1_000_000_000, which must NOT be what the writer would stamp.
+        assert_ne!(
+            mutation.effective_local_deletion_time() as i64,
+            deletion_time / 1_000_000,
+            "the LDT must NOT be re-derived from the deletion timestamp"
+        );
+    }
+
+    /// A row tombstone whose LDT is the `0` "not surfaced" placeholder (the legacy
+    /// `from_legacy_value` fallback and pre-V5 row tombstones) must NOT pin an
+    /// explicit LDT — doing so would lose the writer's timestamp-derived fallback
+    /// and could trip the below-baseline guard against a nonzero pre-seeded
+    /// `min_local_deletion_time`, regressing previously-valid compactions (#946).
+    #[test]
+    fn merge_entry_to_mutation_placeholder_ldt_stays_unset() {
+        let schema = unclustered_schema();
+        let deletion_time = 1_000_000_000_000_000i64;
+
+        let mutation = KWayMerger::merge_entry_to_mutation(
+            // ldt = 0 is the reader's "no LDT surfaced" sentinel, not a real delete.
+            tombstone_entry(0, deletion_time, 0),
+            &schema,
+        )
+        .expect("conversion should succeed");
+
+        assert_eq!(
+            mutation.local_deletion_time, None,
+            "a placeholder (0) LDT must leave the mutation LDT unset so the writer \
+             keeps deriving it from the timestamp, exactly as before #873"
+        );
+    }
+
+    /// A live (non-tombstone) row must leave the mutation LDT unset so the writer
+    /// keeps its historical timestamp-derived behavior for cell tombstones.
+    #[test]
+    fn merge_entry_to_mutation_live_row_leaves_ldt_none() {
+        let schema = unclustered_schema();
+        let entry = MergeEntry::new(
+            0,
+            DecoratedKey::new(500, 7i32.to_be_bytes().to_vec()),
+            None,
+            100,
+            RowData::Live {
+                cells: vec![CellData::new(
+                    "value".to_string(),
+                    Value::Text("alive".to_string()),
+                    100,
+                )],
+            },
+        );
+
+        let mutation =
+            KWayMerger::merge_entry_to_mutation(entry, &schema).expect("conversion should succeed");
+        assert_eq!(
+            mutation.local_deletion_time, None,
+            "a live row must not pin an explicit LDT"
+        );
+    }
+
+    /// An in-memory run yielding a fixed list of `MergeEntry`s in order, so the
+    /// readback test can drive the FULL production merge→writer path
+    /// (`merge_entry_to_mutation` + `write_partition`) rather than a hand-rolled
+    /// shortcut.
+    struct VecIterator(std::vec::IntoIter<MergeEntry>);
+    impl SSTableRowIterator for VecIterator {
+        fn next(&mut self) -> Option<Result<MergeEntry>> {
+            self.0.next().map(Ok)
+        }
+    }
+
+    /// Readback regression: a row tombstone whose `deletion_time` (micros) and
+    /// `local_deletion_time` (GC-clock seconds) intentionally DIFFER must survive
+    /// a full compaction rewrite (merge → SSTableWriter → on-disk Data.db →
+    /// reader) with BOTH values intact. The reader re-surfaces the row-tombstone
+    /// `deletion_time` (markedForDeleteAt, micros) on the compaction read path;
+    /// the LDT is the on-disk `localDeletionTime` the writer must have encoded
+    /// without underflowing the unsigned delta.
+    #[tokio::test]
+    async fn row_tombstone_ldt_survives_compaction_rewrite() {
+        use crate::platform::Platform;
+        use crate::storage::sstable::reader::compaction_row::CompactionRowData;
+        use crate::Config;
+        use std::sync::Arc;
+
+        let schema = unclustered_schema();
+        let deletion_time = 1_000_000_000_000_000i64; // micros
+        let source_ldt = 1_700_000_000i32; // seconds, deliberately != deletion_time/1e6
+
+        let merger = KWayMerger {
+            runs: vec![RunReader::new(Box::new(VecIterator(
+                vec![tombstone_entry(0, deletion_time, source_ldt)].into_iter(),
+            )))],
+            heap: std::collections::BinaryHeap::new(),
+            current_partition: None,
+            gc_before_secs: None,
+            now_secs: None,
+            schema: schema.clone(),
+        };
+
+        let temp_dir = tempfile::TempDir::new().expect("temp dir");
+        let mut writer = crate::storage::sstable::writer::SSTableWriter::new(
+            temp_dir.path().to_path_buf(),
+            1,
+            &schema,
+        )
+        .expect("create writer");
+
+        // Drives merge_partition_rows → merge_entry_to_mutation → write_partition
+        // (the production rewrite path). Must not underflow the LDT delta.
+        merger
+            .merge(&mut writer)
+            .expect("merge+write must succeed (no LDT underflow)");
+        let info = writer.finish().await.expect("finish must succeed");
+
+        // Read the row tombstone back from the on-disk SSTable and assert the LDT
+        // round-tripped (the writer encoded the preserved value, not 0 / derived).
+        let config = Config::default();
+        let platform = Arc::new(Platform::new(&config).await.expect("platform"));
+        let reader = crate::storage::sstable::reader::SSTableReader::open(
+            &info.data_path,
+            &config,
+            platform,
+        )
+        .await
+        .expect("open written SSTable");
+        let rows = reader
+            .iterate_all_partitions_for_compaction(Some(&schema))
+            .await
+            .expect("compaction iterator");
+        let mut saw_tombstone = false;
+        for row in rows {
+            if let CompactionRowData::Tombstone {
+                deletion_time: dt,
+                local_deletion_time,
+                ..
+            } = row.row_data
+            {
+                saw_tombstone = true;
+                assert_eq!(dt, deletion_time, "deletion_time must round-trip");
+                assert_eq!(
+                    local_deletion_time, source_ldt,
+                    "local_deletion_time must round-trip the preserved source value"
+                );
+            }
+        }
+        assert!(
+            saw_tombstone,
+            "the rewritten SSTable must contain the row tombstone"
         );
     }
 }

--- a/cqlite-core/src/types.rs
+++ b/cqlite-core/src/types.rs
@@ -144,11 +144,24 @@ pub struct TombstoneInfo {
     pub deletion_time: i64,
     /// Type of tombstone
     pub tombstone_type: TombstoneType,
+    /// Local deletion time in **seconds** since the Unix epoch (the on-disk
+    /// `localDeletionTime`, GC clock), as opposed to `deletion_time` which is the
+    /// reconciliation `markedForDeleteAt` in microseconds.
+    ///
+    /// Carried so the compaction merge→rewrite path can preserve a tombstone's
+    /// source LDT instead of re-deriving it from the deletion timestamp (#873),
+    /// which keeps gc_grace semantics faithful and avoids underflowing the
+    /// unsigned row-deletion LDT delta in the writer. `0` when unknown.
+    ///
+    /// `#[serde(default)]` keeps backward compatibility with serialized values
+    /// written before this field existed.
+    #[serde(default)]
+    pub local_deletion_time: i64,
     /// TTL if applicable (for TTL-based expiration)
     pub ttl: Option<i64>,
     /// Range start key for range tombstones
     pub range_start: Option<RowKey>,
-    /// Range end key for range tombstones  
+    /// Range end key for range tombstones
     pub range_end: Option<RowKey>,
 }
 
@@ -472,6 +485,8 @@ impl Value {
         Value::Tombstone(TombstoneInfo {
             deletion_time,
             tombstone_type,
+            // No GC-clock LDT is supplied by this constructor; default to 0.
+            local_deletion_time: 0,
             ttl,
             range_start,
             range_end,
@@ -1144,6 +1159,7 @@ impl DataType {
             DataType::Tombstone => Value::Tombstone(TombstoneInfo {
                 deletion_time: 0,
                 tombstone_type: TombstoneType::RowTombstone,
+                local_deletion_time: 0,
                 ttl: None,
                 range_start: None,
                 range_end: None,
@@ -1375,6 +1391,7 @@ impl std::hash::Hash for TombstoneInfo {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.deletion_time.hash(state);
         self.tombstone_type.hash(state);
+        self.local_deletion_time.hash(state);
         self.ttl.hash(state);
         self.range_start.hash(state);
         self.range_end.hash(state);
@@ -1517,6 +1534,7 @@ mod tests {
             Value::Tombstone(TombstoneInfo {
                 deletion_time: 1000,
                 tombstone_type: TombstoneType::RowTombstone,
+                local_deletion_time: 0,
                 ttl: None,
                 range_start: None,
                 range_end: None,

--- a/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_tombstone.snap
+++ b/cqlite-core/tests/snapshots/contract_stability_tests__contract_value_tombstone.snap
@@ -7,6 +7,7 @@ expression: "Value::row_tombstone(1704067200000)"
   "Tombstone": {
     "deletion_time": 1704067200000,
     "tombstone_type": "RowTombstone",
+    "local_deletion_time": 0,
     "ttl": null,
     "range_start": null,
     "range_end": null


### PR DESCRIPTION
Closes #873.

## Problem
Compaction's `merge_entry_to_mutation` rewrote merged row tombstones with `local_deletion_time: None`, so the writer re-derived `localDeletionTime` from the deletion timestamp instead of preserving the source SSTable's wall-clock LDT. This breaks gc_grace semantics and — for pathological logical-timestamp deletes whose `markedForDeleteAt` is far from wall clock — can underflow the unsigned row-deletion LDT delta and corrupt `Data.db`.

## Change
- **reconcile_cluster**: track the `localDeletionTime` paired with the winning (max) `deletion_time` and emit it on the rebuilt `RowData::Tombstone` instead of hardcoding `0`.
- **merge_entry_to_mutation**: thread the preserved LDT onto the `Mutation` via `with_local_deletion_time(...)`. `0` is the established "LDT not surfaced" placeholder (legacy `from_legacy_value` fallback + pre-V5 tombstones), so only a genuinely-surfaced (nonzero) LDT is threaded — placeholders keep the prior timestamp-derived behavior and never trip the new writer guard.
- **TombstoneInfo**: add `local_deletion_time: i64` (`#[serde(default)]`, backward-compatible); wire it through the v5 read path and the test-only `value_to_row_data` adapter.
- **Writer guard**: reject below-baseline row-tombstone LDT deltas (loud error instead of silent `Data.db` underflow), mirroring the existing complex-deletion guard. Far-future (#853) LDTs still accepted.

## Tests
- 6 new `issue_873_preserve_row_tombstone_ldt` tests incl. a full merge→writer→on-disk→readback regression with `deletion_time` ≠ `localDeletionTime`, a placeholder-LDT-stays-unset regression, and 2 writer-guard tests.

## Validation
- agent-gate: all green except the **known pre-existing** `python-bindings` py3.9 PEP604 failure (identical on `origin/main`, no `.py` files touched) and the flaky `test_flush_throughput` perf test (passes on isolated retry).
- roborev: Pass (job 948, no issues) after addressing review #946 (placeholder-LDT regression).