### PR TITLE
fix(ci): build duckdb from source via bundled feature (#916)

### DIFF
--- a/.github/workflows/delta-roundtrip.yml
+++ b/.github/workflows/delta-roundtrip.yml
@@ -33,6 +33,8 @@ on:
       - 'test-data/scripts/generate-delta-roundtrip.sh'
       - 'docs/architecture/delta-scan-consumer-reconciliation.md'
       - '.github/workflows/delta-roundtrip.yml'
+      - 'cqlite-cli/Cargo.toml'
+      - 'Cargo.lock'
   pull_request:
     branches: [main]
     paths:
@@ -44,6 +46,8 @@ on:
       - 'test-data/scripts/generate-delta-roundtrip.sh'
       - 'docs/architecture/delta-scan-consumer-reconciliation.md'
       - '.github/workflows/delta-roundtrip.yml'
+      - 'cqlite-cli/Cargo.toml'
+      - 'Cargo.lock'
   workflow_dispatch:
     inputs:
       regenerate:

--- a/.github/workflows/delta-roundtrip.yml
+++ b/.github/workflows/delta-roundtrip.yml
@@ -70,7 +70,11 @@ jobs:
   delta-roundtrip:
     name: DS11 Reconciliation Round-Trip
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # 45 min headroom: the duckdb dev-dependency builds DuckDB (+ parquet
+    # extension) from source via the `bundled`/`parquet` features (issue #916),
+    # which compiles across the build, test, and clippy steps on a cold cargo
+    # cache. Warm-cache runs finish in ~10 min.
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@v4

--- a/cqlite-cli/Cargo.toml
+++ b/cqlite-cli/Cargo.toml
@@ -120,8 +120,11 @@ escargot = "0.5"                # Cargo subprocess management
 cargo-llvm-cov = "0.5"          # LLVM coverage
 trybuild = "1.0"                # Compile-fail testing
 
-# E2E validation: DuckDB reads Parquet exports to validate data integrity
-duckdb = "1.1"
+# E2E validation: DuckDB reads Parquet exports to validate data integrity.
+# `bundled` compiles DuckDB from source via libduckdb-sys so the test binary does
+# not link against a system `-lduckdb`, which is absent on ubuntu-latest CI
+# runners (issue #916). This keeps the delta round-trip suite hermetic.
+duckdb = { version = "1.1", features = ["bundled"] }
 
 [features]
 # M2+ production defaults: Interactive REPL with query engine

--- a/cqlite-cli/Cargo.toml
+++ b/cqlite-cli/Cargo.toml
@@ -123,8 +123,11 @@ trybuild = "1.0"                # Compile-fail testing
 # E2E validation: DuckDB reads Parquet exports to validate data integrity.
 # `bundled` compiles DuckDB from source via libduckdb-sys so the test binary does
 # not link against a system `-lduckdb`, which is absent on ubuntu-latest CI
-# runners (issue #916). This keeps the delta round-trip suite hermetic.
-duckdb = { version = "1.1", features = ["bundled"] }
+# runners (issue #916). `parquet` statically links the parquet extension so
+# read_parquet() never auto-installs it into ~/.duckdb/extensions at runtime —
+# that autoload races across parallel test threads and fails on CI runners. Both
+# features together keep the delta round-trip suite fully hermetic.
+duckdb = { version = "1.1", features = ["bundled", "parquet"] }
 
 [features]
 # M2+ production defaults: Interactive REPL with query engine


### PR DESCRIPTION
## Summary

Fixes #916. The **DS11 Reconciliation Round-Trip** workflow was hard-red on `main` and every PR with a linker error (not a test failure):

```
/usr/bin/ld: cannot find -lduckdb: No such file or directory
```

The `delta_roundtrip_tests` dev-dependency pulls in the `duckdb` crate, whose `libduckdb-sys` compiles but then links against a **system** `libduckdb` that is absent on `ubuntu-latest`.

## Fix

Adopt **Option 1** from the issue (the hermetic one): enable the `duckdb` crate's `bundled` feature so `libduckdb-sys` builds DuckDB from source instead of expecting a system library. No distro-packaging dependency, no `apt-get`/`LD_LIBRARY_PATH` setup step.

Rationale is documented as a comment in `cqlite-cli/Cargo.toml`.

Also added `cqlite-cli/Cargo.toml` and `Cargo.lock` to the workflow's `paths` triggers so future dependency changes re-validate this linker-sensitive suite (and so this PR itself runs it).

## Verification

Built locally with the bundled feature — the test binary links clean (DuckDB compiled from source, no `-lduckdb`):

```
cargo test --package cqlite-cli --features delta-export --test delta_roundtrip_tests --no-run
   Compiling duckdb v1.2.2
    Finished `test` profile ... target(s) in 2m 28s
  Executable tests/delta_roundtrip_tests.rs (...)
```

## Acceptance criteria

- [x] `DS11 Reconciliation Round-Trip` compiles/links without `-lduckdb` error
- [x] Approach documented in a comment near the duckdb dependency
- [ ] Job green on `main` (confirmed post-merge)