### PR TITLE
Compaction byte-parity: complex-deletion, tombstone-vs-TTL, gc_grace purge (#921: #887/#848/#845)

### DIFF
--- a/cqlite-cli/src/cli_types.rs
+++ b/cqlite-cli/src/cli_types.rs
@@ -432,6 +432,16 @@ pub struct CompactArgs {
     /// Output SSTable generation number (filename nb-<gen>-big-*.db)
     #[arg(long, default_value = "1")]
     pub generation: u64,
+    /// Treat this as a MAJOR (full) compaction and PURGE gc-expired tombstones
+    /// from the output. SAFETY CONTRACT: tombstone purging is only safe when the
+    /// `<input-dir>` contains ALL overlapping SSTables for the table; otherwise a
+    /// purged tombstone could resurrect data still shadowed in a non-included
+    /// SSTable. `cqlite compact` compacts only the SSTables found under
+    /// `<input-dir>`, so this flag is the operator's assertion that that set is
+    /// complete. Default (flag absent): conservative — tombstones are RETAINED
+    /// and nothing is purged.
+    #[arg(long = "major", alias = "purge-tombstones", default_value_t = false)]
+    pub major: bool,
 }
 
 // Arguments for the export-sstable subcommand (Issue #392)

--- a/cqlite-cli/src/commands/write.rs
+++ b/cqlite-cli/src/commands/write.rs
@@ -358,6 +358,20 @@ impl CompactResult {
 ///
 /// `args.gc_before` / `args.now_sec` are threaded into the merge for
 /// deterministic purge decisions but are not yet applied (issues #845/#848).
+/// Map the `compact` subcommand args to the `purge_safe` flag threaded into
+/// the merge (#921 finding 1).
+///
+/// `cqlite compact` compacts only the SSTables found under `<input-dir>`, which
+/// is NOT necessarily every overlapping SSTable for the table. Tombstone
+/// purging is only overlap-safe when that input set is complete, so the default
+/// is CONSERVATIVE (`false`, no purge) and purging is enabled only when the
+/// operator explicitly asserts a complete/major compaction via `--major`
+/// (alias `--purge-tombstones`).
+#[cfg(feature = "write-support")]
+fn compact_purge_safe(args: &crate::cli_types::CompactArgs) -> bool {
+    args.major
+}
+
 #[cfg(feature = "write-support")]
 pub async fn handle_compact(args: &crate::cli_types::CompactArgs) -> Result<CompactResult> {
     let start = Instant::now();
@@ -372,6 +386,10 @@ pub async fn handle_compact(args: &crate::cli_types::CompactArgs) -> Result<Comp
         ));
     }
 
+    // Overlap-safety gate for tombstone purging (#921 finding 1): map the
+    // explicit `--major` opt-in to `purge_safe`. Default (flag absent) is
+    // conservative — see `compact_purge_safe`.
+    let purge_safe = compact_purge_safe(args);
     let report = cqlite_core::storage::write_engine::merge::compact_sstables(
         inputs,
         &args.output,
@@ -379,6 +397,7 @@ pub async fn handle_compact(args: &crate::cli_types::CompactArgs) -> Result<Comp
         args.generation,
         args.gc_before,
         args.now_sec,
+        purge_safe,
     )
     .await
     .with_context(|| "compaction failed")?;
@@ -535,4 +554,64 @@ pub async fn handle_flush(_write_engine: &mut ()) -> Result<Option<()>> {
     Err(anyhow::anyhow!(
         "Write support is not enabled. Build with --features write-support to enable write operations."
     ))
+}
+
+#[cfg(all(test, feature = "write-support"))]
+mod compact_purge_safe_tests {
+    use super::compact_purge_safe;
+    use crate::cli_types::{Cli, Commands};
+    use clap::Parser;
+
+    /// Parse a `cqlite compact ...` invocation and return its `CompactArgs`.
+    fn parse_compact(extra: &[&str]) -> crate::cli_types::CompactArgs {
+        let mut argv = vec![
+            "cqlite",
+            "compact",
+            "/tmp/in",
+            "--output",
+            "/tmp/out",
+            "--schema",
+            "/tmp/s.cql",
+        ];
+        argv.extend_from_slice(extra);
+        match Cli::parse_from(argv).command {
+            Some(Commands::Compact(args)) => args,
+            _ => panic!("expected the Compact subcommand to parse"),
+        }
+    }
+
+    /// #921 finding 1: with NO flag the CLI defaults to `purge_safe = false` —
+    /// a purgeable tombstone is RETAINED (conservative; subset compaction must
+    /// never resurrect shadowed data).
+    #[test]
+    fn issue_921_compact_defaults_to_no_purge() {
+        let args = parse_compact(&[]);
+        assert!(!args.major, "--major must default to false");
+        assert!(
+            !compact_purge_safe(&args),
+            "default (no flag) must map to purge_safe = false (tombstones retained)"
+        );
+    }
+
+    /// #921 finding 1: the explicit `--major` opt-in maps to `purge_safe = true`
+    /// (the operator asserts the input set is the complete SSTable set).
+    #[test]
+    fn issue_921_compact_major_flag_enables_purge() {
+        let args = parse_compact(&["--major"]);
+        assert!(args.major, "--major must set major = true");
+        assert!(
+            compact_purge_safe(&args),
+            "--major must map to purge_safe = true (purging enabled)"
+        );
+    }
+
+    /// The `--purge-tombstones` alias is equivalent to `--major`.
+    #[test]
+    fn issue_921_compact_purge_tombstones_alias_enables_purge() {
+        let args = parse_compact(&["--purge-tombstones"]);
+        assert!(
+            compact_purge_safe(&args),
+            "--purge-tombstones alias must map to purge_safe = true"
+        );
+    }
 }

--- a/cqlite-core/src/storage/sstable/writer/data_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer.rs
@@ -1025,16 +1025,110 @@ impl DataWriter {
         // (a column has many elements). Kept verbatim and emitted via
         // `write_complex_column_per_element`. Empty for every existing scenario.
         let mut complex_element_ops: Vec<MergedOp<'a>> = Vec::new();
-        // Liveness: (timestamp, row-level TTL) of the newest contributing mutation
+        // Liveness: (timestamp, row-level TTL) of the newest contributing mutation.
+        // Cell-less liveness sources (pure-PK inserts, clustering-only writes) are
+        // recorded here directly (they are never shadowed by complex-deletion markers).
         let mut liveness: Option<(i64, Option<u32>)> = None;
+        // Issue #921 (roborev High): WHOLE-COLUMN write liveness candidates, keyed by
+        // regular-column name → (newest write ts, that write's row TTL). A
+        // `Write`/`WriteWithTtl` of a regular column sets the ROW MARKER (row
+        // liveness) even when its CELL loses last-write-wins to a same-column
+        // `Delete` tombstone at an equal timestamp (issue #822) — the row marker is
+        // independent of cell-level reconciliation. So these candidates are collected
+        // here REGARDLESS of the per-column `cells` LWW outcome. They are folded into
+        // `liveness` only AFTER the #927 mixed-stream reconcile, with candidates for
+        // any column whose COMPLEX stream wins removed first: a whole-column write
+        // entirely superseded by a newer complex marker/element stream leaves no live
+        // cell and must NOT leak a phantom row marker.
+        let mut whole_col_liveness: std::collections::HashMap<&'a str, (i64, Option<u32>)> =
+            std::collections::HashMap::new();
+        // Issue #887 / #921: a live `WriteComplexElement` contributes row liveness too,
+        // but ONLY if it actually survives every reconcile/retain below. Rather than
+        // tracking pre-retain candidates with an exclusion set (fragile — roborev
+        // #921 High), complex-element liveness is DERIVED at the very end directly
+        // from the FINAL surviving `complex_element_ops`: after the #927 mixed-stream
+        // reconcile AND the #887 strict-supersede/shadow-before-purge retain have run,
+        // each surviving LIVE element (a `WriteComplexElement` with a value, not an
+        // element tombstone) folds its OWN `(elem_ts, ttl)` into `liveness`. This way
+        // liveness reflects exactly the live per-element cells that remain in the
+        // output — no candidate can resurrect liveness for an element that was dropped
+        // (by a winning whole-column op, LIVE or Delete) or shadowed (by a same-column
+        // complex deletion). Simple-cell and pure-PK liveness in `liveness` is folded
+        // directly below and is never shadowed by complex-deletion markers.
 
         for m in group {
-            // Shadowed entirely by the row deletion
-            if deletion_ts.is_some_and(|dts| m.timestamp_micros <= dts) {
+            // Shadowed by the row deletion (or partition/range floor): cells,
+            // liveness, and row-level writes of this mutation written at
+            // `timestamp <= deletion_ts` are dead.
+            //
+            // Issue #887: a `ComplexDeletion` marker is itself a deletion with its OWN
+            // `marked_for_delete_at`, NOT the mutation's row timestamp. A marker whose
+            // mfda STRICTLY exceeds `deletion_ts` covers a range the row/partition
+            // tombstone does not (e.g. elements in OTHER SSTables not part of this
+            // compaction), so it must survive even when the carrying mutation's row
+            // timestamp is shadowed. The SAME independence applies to
+            // `WriteComplexElement`: each per-element complex write carries its OWN
+            // `timestamp_micros` (an explicit delta, NOT the mutation's row timestamp);
+            // an element whose own timestamp STRICTLY exceeds `deletion_ts` is live and
+            // must survive.
+            //
+            // Skip the rest of a shadowed mutation, but still scan it for such
+            // surviving complex-deletion markers AND surviving per-element writes so
+            // they are emitted alongside the row tombstone.
+            let mutation_shadowed = deletion_ts.is_some_and(|dts| m.timestamp_micros <= dts);
+            if mutation_shadowed {
+                // The mutation's row timestamp is covered, so its simple cells,
+                // liveness, and row-level writes are dead. Per-element/per-marker
+                // complex ops carry INDEPENDENT timestamps, however, so still scan for
+                // them and push verbatim — carrying each op's OWN timestamp in the
+                // `MergedOp` (see the per-op rationale on the normal path below). The
+                // `deletion_ts` shadow boundary is applied UNIFORMLY for both paths by
+                // the single retain pass after this loop (Issue #921 roborev), so no
+                // per-op boundary check is done here; that keeps the normal and
+                // shadowed paths from drifting apart.
+                for op in &m.operations {
+                    match op {
+                        CellOperation::ComplexDeletion {
+                            marked_for_delete_at,
+                            ..
+                        } => {
+                            if skip_static_ops && is_static_operation(op, schema) {
+                                continue;
+                            }
+                            complex_element_ops.push(MergedOp {
+                                op,
+                                timestamp_micros: *marked_for_delete_at,
+                                row_ttl_seconds: m.ttl_seconds,
+                                cell_local_deletion_time: m.effective_local_deletion_time(),
+                            });
+                        }
+                        CellOperation::WriteComplexElement {
+                            timestamp_micros: elem_ts,
+                            ..
+                        } => {
+                            if skip_static_ops && is_static_operation(op, schema) {
+                                continue;
+                            }
+                            complex_element_ops.push(MergedOp {
+                                op,
+                                timestamp_micros: *elem_ts,
+                                row_ttl_seconds: m.ttl_seconds,
+                                cell_local_deletion_time: m.effective_local_deletion_time(),
+                            });
+                        }
+                        _ => {}
+                    }
+                }
                 continue;
             }
 
-            let mut contributes_liveness = false;
+            // Issue #921: a `Write`/`WriteWithTtl` of a PRIMARY-KEY column (the
+            // compaction path can surface a clustering column as a Write, #857) is
+            // dropped from `cells` below — it leaves NO survivor to derive liveness
+            // from. Such a clustering-only write must still keep the row live, so
+            // record its contribution inline (it can never be shadowed by a complex
+            // marker — primary-key columns are never complex).
+            let mut pk_write_liveness = false;
             for op in &m.operations {
                 let column = match op {
                     CellOperation::Write { column, .. }
@@ -1045,28 +1139,71 @@ impl DataWriter {
                     // contributes row liveness; a `ComplexDeletion` marker does
                     // not. Primary-key columns can never be complex, so no
                     // key-column skip is needed.
-                    CellOperation::WriteComplexElement { value, .. } => {
+                    //
+                    // Issue #887: the liveness contribution is DEFERRED. If this
+                    // element is later shadowed by a same-column `ComplexDeletion`
+                    // (shadow-before-purge retain below), it must NOT keep the row
+                    // live. Record a candidate carrying the column + the element's OWN
+                    // timestamp; fold it into `liveness` only if it survives the retain.
+                    CellOperation::WriteComplexElement {
+                        timestamp_micros: elem_ts,
+                        ..
+                    } => {
                         if skip_static_ops && is_static_operation(op, schema) {
                             continue;
                         }
-                        if value.is_some() {
-                            contributes_liveness = true;
-                        }
+                        // Issue #887 / #921: row liveness from a live per-element write
+                        // is NOT recorded here. It is derived from the FINAL surviving
+                        // `complex_element_ops` after all reconciles/retains (see the
+                        // end of this function), so an element later dropped or
+                        // shadowed cannot leak liveness.
+                        //
+                        // Issue #921 (roborev Finding 1): carry the element's OWN
+                        // `*elem_ts` in the `MergedOp`, NOT the mutation row timestamp.
+                        // #927's mixed-stream reconcile below derives `elem_max_ts`
+                        // from `MergedOp.timestamp_micros`; using the mutation row
+                        // timestamp would understate it and let an older whole-column
+                        // write wrongly shadow a newer per-element edit whose enclosing
+                        // mutation happens to carry an older row timestamp. This also
+                        // matches the shadowed/rescue path above (which already stores
+                        // `*elem_ts`) and the #887 shadow-before-purge retain. The
+                        // per-element writer reads the element's own timestamp from the
+                        // `WriteComplexElement` payload, so the emitted cell timestamp
+                        // is unaffected.
                         complex_element_ops.push(MergedOp {
                             op,
-                            timestamp_micros: m.timestamp_micros,
+                            timestamp_micros: *elem_ts,
                             row_ttl_seconds: m.ttl_seconds,
                             cell_local_deletion_time: m.effective_local_deletion_time(),
                         });
                         continue;
                     }
-                    CellOperation::ComplexDeletion { .. } => {
+                    CellOperation::ComplexDeletion {
+                        marked_for_delete_at,
+                        ..
+                    } => {
                         if skip_static_ops && is_static_operation(op, schema) {
                             continue;
                         }
+                        // Issue #921 (roborev Finding): a `ComplexDeletion` marker is a
+                        // deletion with its OWN `marked_for_delete_at` (mfda), which is
+                        // INDEPENDENT of the enclosing mutation's row timestamp (the
+                        // marker can be carried by an OLDER metadata/tombstone mutation).
+                        // #927's mixed-stream reconcile below derives `elem_max_ts` from
+                        // `MergedOp.timestamp_micros` and uses `mop.timestamp_micros >=
+                        // emax` to decide whether a whole-column op shadows the
+                        // per-element/marker stream. Carrying the row timestamp here
+                        // would let a whole-column write/delete at `row_ts > mfda` but
+                        // `whole_ts < mfda` wrongly drop a NEWER collection tombstone —
+                        // losing the marker and resurrecting covered elements. Carry the
+                        // mfda so the comparison reflects the marker's true deletion time.
+                        // The emitted marker bytes read mfda/ldt from the
+                        // `ComplexDeletion` payload (see
+                        // `write_complex_element_columns`), so this only affects the
+                        // RECONCILE COMPARISON, never the serialized marker.
                         complex_element_ops.push(MergedOp {
                             op,
-                            timestamp_micros: m.timestamp_micros,
+                            timestamp_micros: *marked_for_delete_at,
                             row_ttl_seconds: m.ttl_seconds,
                             cell_local_deletion_time: m.effective_local_deletion_time(),
                         });
@@ -1077,23 +1214,49 @@ impl DataWriter {
                 if skip_static_ops && is_static_operation(op, schema) {
                     continue;
                 }
-                if matches!(
-                    op,
-                    CellOperation::Write { .. } | CellOperation::WriteWithTtl { .. }
-                ) {
-                    // A write — even of a primary-key column — means the row is
-                    // live. This must be recorded BEFORE the key-column skip below,
-                    // so a row whose only cells are clustering values (a pure
-                    // primary-key row) keeps its liveness instead of vanishing.
-                    contributes_liveness = true;
-                }
+                // Issue #921 (roborev High): whole-column `Write`/`WriteWithTtl`
+                // liveness is NOT folded into `liveness` here anymore. It is recorded
+                // as a per-column candidate in `whole_col_liveness` (below the
+                // cells-dedup block) and folded only AFTER the #927 mixed-stream
+                // reconcile, with candidates for columns whose complex stream wins
+                // removed. Folding inline before reconcile let a whole-column write
+                // entirely superseded by a newer complex marker/element stream leak a
+                // phantom row marker.
                 // Primary-key columns are encoded positionally (partition key +
                 // clustering prefix), never as cells. The compaction path can
                 // surface a clustering column as a Write op (#857) — drop it so the
                 // writer doesn't emit a phantom cell that corrupts the row body for
                 // strict readers.
                 if is_primary_key_column(column, schema) {
+                    if matches!(
+                        op,
+                        CellOperation::Write { .. } | CellOperation::WriteWithTtl { .. }
+                    ) {
+                        // A clustering-only write keeps the row live even though it
+                        // produces no cell survivor (see note above).
+                        pk_write_liveness = true;
+                    }
                     continue;
+                }
+
+                // Issue #921: record the ROW-MARKER liveness candidate for this
+                // regular-column write. Done BEFORE the cells LWW dedup so that a
+                // same-column `Delete` cell tombstone winning an equal-ts tie does not
+                // erase the row marker (issue #822). Keep the newest write's ts/ttl.
+                if matches!(
+                    op,
+                    CellOperation::Write { .. } | CellOperation::WriteWithTtl { .. }
+                ) {
+                    match whole_col_liveness.entry(column) {
+                        std::collections::hash_map::Entry::Vacant(entry) => {
+                            entry.insert((m.timestamp_micros, m.ttl_seconds));
+                        }
+                        std::collections::hash_map::Entry::Occupied(mut entry) => {
+                            if m.timestamp_micros >= entry.get().0 {
+                                entry.insert((m.timestamp_micros, m.ttl_seconds));
+                            }
+                        }
+                    }
                 }
 
                 let candidate = MergedOp {
@@ -1126,11 +1289,33 @@ impl DataWriter {
             let pure_pk_insert = m.operations.is_empty()
                 && m.partition_tombstone.is_none()
                 && m.range_tombstones.is_empty();
-            if (contributes_liveness || pure_pk_insert)
+            // Issue #921: only the cell-less liveness sources are folded inline here
+            // — a pure-PK insert and a clustering-only write. Whole-column writes
+            // that DO produce a `cells` survivor are derived after reconcile.
+            if (pk_write_liveness || pure_pk_insert)
                 && liveness.is_none_or(|(ts, _)| m.timestamp_micros >= ts)
             {
                 liveness = Some((m.timestamp_micros, m.ttl_seconds));
             }
+        }
+
+        // Issue #921 (roborev HIGH/MEDIUM): apply the row/range `deletion_ts` shadow
+        // boundary UNIFORMLY to per-element/per-marker complex ops, regardless of
+        // whether the enclosing mutation was classified shadowed. Each such op carries
+        // its OWN timestamp (a `WriteComplexElement`'s explicit delta, a
+        // `ComplexDeletion`'s `marked_for_delete_at`), already stored in
+        // `MergedOp.timestamp_micros` at every push point above. Previously this
+        // boundary was applied ONLY on the shadowed/rescue path; the normal path
+        // (mutation row ts > deletion_ts) pushed complex ops unconditionally, so a
+        // covered element (`elem_ts <= deletion_ts`) resurrected after the tombstone
+        // was purged, and a fully-covered marker (`mfda <= deletion_ts`) emitted a dead
+        // redundant tombstone. One retain here gives both paths the SAME boundary:
+        // `> deletion_ts` survives, `<= deletion_ts` is shadowed (equal-ts tombstone
+        // wins, #498). This is the ONLY complex-op family with an independent timestamp;
+        // simple `Write`/`Delete` and pure-PK liveness keep their mutation-level shadow
+        // behavior (handled by `mutation_shadowed` above).
+        if let Some(dts) = deletion_ts {
+            complex_element_ops.retain(|mop| mop.timestamp_micros > dts);
         }
 
         let mut ops: Vec<MergedOp<'a>> = cells.into_values().collect();
@@ -1142,6 +1327,13 @@ impl DataWriter {
         // column and desync the reader. Reconcile by timestamp shadowing: keep the
         // stream with the newer max timestamp and drop the other, rather than
         // silently losing one.
+        //
+        // Issue #921 (roborev High): liveness is no longer tracked via a candidate
+        // list + exclusion set here. Because complex-element liveness is DERIVED at
+        // the end from the FINAL surviving `complex_element_ops`, a per-element
+        // stream dropped by a winning whole-column op (LIVE write OR Delete) simply
+        // leaves no survivor to fold — so it cannot leak liveness, and this
+        // reconcile only has to drop the losing stream.
         if !complex_element_ops.is_empty() {
             let mut elem_max_ts: std::collections::HashMap<&str, i64> =
                 std::collections::HashMap::new();
@@ -1173,6 +1365,125 @@ impl DataWriter {
                     Some(col) => !whole_wins.contains(col),
                     None => true,
                 });
+            }
+            // Issue #921 (roborev High): a column whose COMPLEX stream won (present in
+            // `elem_max_ts` but NOT in `whole_wins`) had its whole-column op dropped
+            // from `ops`. That whole-column write is entirely superseded — it leaves
+            // no live cell — so it must NOT contribute the row marker. Drop its
+            // liveness candidate so a phantom live row is not emitted.
+            if !whole_col_liveness.is_empty() {
+                whole_col_liveness
+                    .retain(|col, _| !elem_max_ts.contains_key(col) || whole_wins.contains(col));
+            }
+        }
+
+        // Issue #887: SHADOW-BEFORE-PURGE for the direct writer merge path — the
+        // writer-side analogue of reconcile_cluster Step 2b (merge.rs). Above, a
+        // `WriteComplexElement` is kept based only on its timestamp vs the ROW/RANGE
+        // `deletion_ts`; it is NOT yet shadowed against a surviving `ComplexDeletion`
+        // marker for the SAME column. A mutation set carrying e.g.
+        // `ComplexDeletion(tags, mfda=300)` and an element `tags[path]@200` would
+        // otherwise emit BOTH the marker and the covered element@200 — violating
+        // shadow-before-purge (a later purge of the marker resurrects the element).
+        //
+        // Mirror Step 2b exactly: (1) reduce to the ACTIVE complex deletion PER COLUMN
+        // NAME (strict-supersede: greatest `marked_for_delete_at` wins; EQUAL does NOT
+        // supersede), then (2) drop every `WriteComplexElement` of that column whose
+        // own `timestamp_micros <= marked_for_delete_at` (shadowed). Boundary: element
+        // ts STRICTLY GREATER than mfda survives; `<=` is shadowed. Matched BY COLUMN
+        // NAME. This runs unconditionally so the normal mutation path and the
+        // shadowed-mutation rescue path are consistent.
+        if !complex_element_ops.is_empty() {
+            // Strict-supersede: active mfda per column name from surviving markers.
+            let mut active_mfda: std::collections::HashMap<&'a str, i64> =
+                std::collections::HashMap::new();
+            for mop in &complex_element_ops {
+                if let CellOperation::ComplexDeletion {
+                    column,
+                    marked_for_delete_at,
+                    ..
+                } = mop.op
+                {
+                    let col = column.as_str();
+                    match active_mfda.get(col) {
+                        // STRICTLY GREATER supersedes; equal/lesser does NOT.
+                        Some(existing) if marked_for_delete_at <= existing => {}
+                        _ => {
+                            active_mfda.insert(col, *marked_for_delete_at);
+                        }
+                    }
+                }
+            }
+            // Shadow-before-purge: drop any WriteComplexElement whose own timestamp is
+            // `<= mfda` of the active marker on its column.
+            if !active_mfda.is_empty() {
+                complex_element_ops.retain(|mop| match mop.op {
+                    CellOperation::WriteComplexElement {
+                        column,
+                        timestamp_micros: elem_ts,
+                        ..
+                    } => active_mfda
+                        .get(column.as_str())
+                        .is_none_or(|mfda| *elem_ts > *mfda),
+                    _ => true,
+                });
+            }
+        }
+
+        // Issue #921 (roborev High): FOLD the surviving WHOLE-COLUMN write liveness
+        // candidates — i.e. AFTER the #927 mixed-stream reconcile, which removed
+        // candidates for any column whose complex stream won (the whole-column write
+        // was entirely superseded by a newer complex marker/element stream). The
+        // remaining candidates are regular-column `Write`/`WriteWithTtl` ops that set
+        // the ROW MARKER: each contributes even when its CELL lost a same-column
+        // equal-ts `Delete` tie (issue #822) — the row marker is independent of
+        // cell-level reconciliation. This is the symmetric counterpart to the
+        // per-element liveness derivation below: a whole-column write dropped by a
+        // winning complex stream (e.g. `Write(tags)@500` + `ComplexDeletion(tags,
+        // mfda=900)`) is no longer in `whole_col_liveness`, so it cannot leak a
+        // phantom live row. Cell-less liveness sources (pure-PK insert,
+        // clustering-only write) were already folded inline above.
+        for &(ts, ttl) in whole_col_liveness.values() {
+            if liveness.is_none_or(|(cur, _)| ts >= cur) {
+                liveness = Some((ts, ttl));
+            }
+        }
+
+        // Issue #921 (roborev High): DERIVE complex-element liveness from the FINAL
+        // surviving `complex_element_ops` — i.e. AFTER the #927 mixed-stream
+        // reconcile AND the #887 strict-supersede / shadow-before-purge retain. Each
+        // surviving LIVE element (a `WriteComplexElement` carrying a value, not an
+        // element tombstone and not a `ComplexDeletion` marker) folds its OWN
+        // `(elem_ts, ttl)` into row liveness. Because we read only the survivors, an
+        // element dropped by a winning whole-column op (LIVE write OR Delete) or
+        // shadowed by a same-column complex deletion contributes nothing — it is no
+        // longer in `complex_element_ops`. A row whose only live complex elements
+        // were all dropped/shadowed therefore carries NO complex-element liveness.
+        // Simple-cell `Write`/`WriteWithTtl` and pure-PK liveness already folded into
+        // `liveness` above are independent and untouched here.
+        //
+        // The element's OWN `timestamp_micros` and `ttl_seconds` are read straight
+        // from its `WriteComplexElement` payload (the same values the writer stamps
+        // on the surviving element cell), so row liveness reflects exactly that live
+        // element.
+        for mop in &complex_element_ops {
+            if let CellOperation::WriteComplexElement {
+                value,
+                timestamp_micros: elem_ts,
+                ttl_seconds,
+                is_deleted,
+                ..
+            } = mop.op
+            {
+                // A live element has a value and is not a tombstone. Element-level
+                // tombstones (`value == None` / `is_deleted`) and empty-value
+                // members carry no liveness.
+                if *is_deleted || value.is_none() {
+                    continue;
+                }
+                if liveness.is_none_or(|(ts, _)| *elem_ts >= ts) {
+                    liveness = Some((*elem_ts, *ttl_seconds));
+                }
             }
         }
 
@@ -9568,6 +9879,1205 @@ mod tests {
             row.complex_element_ops.len(),
             1,
             "newer per-element edit survives"
+        );
+    }
+
+    /// Schema with a non-frozen complex column `tags` (`list<text>`).
+    fn complex_column_schema() -> TableSchema {
+        TableSchema {
+            keyspace: "test_ks".to_string(),
+            table: "test_table".to_string(),
+            partition_keys: vec![KeyColumn {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![],
+            columns: vec![Column {
+                name: "tags".to_string(),
+                data_type: "list<text>".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            }],
+            comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
+        }
+    }
+
+    /// Issue #887: a row-tombstone mutation that ALSO carries a complex-deletion
+    /// marker whose `marked_for_delete_at` STRICTLY exceeds the row-tombstone time
+    /// must NOT have that marker shadowed out of `merge_row_group`. The row tombstone
+    /// covers only `timestamp <= row_del`; the marker covers `(row_del, mfda]` — so
+    /// it must survive into the written row alongside the row deletion.
+    #[test]
+    fn merge_row_group_keeps_strictly_newer_complex_deletion_on_row_tombstone() {
+        let schema = complex_column_schema();
+        const ROW_DEL: i64 = 100;
+        const MFDA: i64 = 300; // strictly greater than ROW_DEL
+
+        let mutation = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(1)),
+            None,
+            vec![
+                CellOperation::DeleteRow,
+                CellOperation::ComplexDeletion {
+                    column: "tags".to_string(),
+                    marked_for_delete_at: MFDA,
+                    local_deletion_time: 1_700_000_000,
+                },
+            ],
+            ROW_DEL,
+            None,
+        );
+
+        let row = DataWriter::merge_row_group(&[&mutation], &schema, false, None)
+            .expect("a row tombstone + surviving complex deletion must produce a row");
+
+        assert!(
+            row.row_deletion.is_some(),
+            "the row tombstone must be preserved"
+        );
+        assert_eq!(row.row_deletion.map(|(ts, _)| ts), Some(ROW_DEL));
+
+        let kept_marker = row.complex_element_ops.iter().any(|mop| {
+            matches!(
+                mop.op,
+                CellOperation::ComplexDeletion {
+                    column,
+                    marked_for_delete_at,
+                    ..
+                } if column == "tags" && *marked_for_delete_at == MFDA
+            )
+        });
+        assert!(
+            kept_marker,
+            "the strictly-newer (mfda > row_del) complex deletion marker must survive \
+             into the written row (else (row_del, mfda] elements resurrect)"
+        );
+    }
+
+    /// Issue #887: a row-tombstone mutation that ALSO carries a per-element
+    /// `WriteComplexElement` whose OWN `timestamp_micros` STRICTLY exceeds the
+    /// row-tombstone time must NOT have that element shadowed out. Per-element writes
+    /// carry INDEPENDENT timestamps; the row tombstone covers only `timestamp <=
+    /// row_del`, so a live element with `elem_ts > row_del` survives.
+    #[test]
+    fn merge_row_group_keeps_strictly_newer_complex_element_on_row_tombstone() {
+        let schema = complex_column_schema();
+        const ROW_DEL: i64 = 100;
+        const SHADOWED_ELEM_TS: i64 = 100; // <= ROW_DEL: fully shadowed, dropped
+        const LIVE_ELEM_TS: i64 = 300; // > ROW_DEL: must survive
+
+        let mutation = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(1)),
+            None,
+            vec![
+                CellOperation::DeleteRow,
+                CellOperation::WriteComplexElement {
+                    column: "tags".to_string(),
+                    cell_path: vec![0u8; 16],
+                    value: Some(Value::Text("shadowed".to_string())),
+                    timestamp_micros: SHADOWED_ELEM_TS,
+                    ttl_seconds: None,
+                    local_deletion_time: None,
+                    is_deleted: false,
+                },
+                CellOperation::WriteComplexElement {
+                    column: "tags".to_string(),
+                    cell_path: vec![1u8; 16],
+                    value: Some(Value::Text("live".to_string())),
+                    timestamp_micros: LIVE_ELEM_TS,
+                    ttl_seconds: None,
+                    local_deletion_time: None,
+                    is_deleted: false,
+                },
+            ],
+            ROW_DEL,
+            None,
+        );
+
+        let row = DataWriter::merge_row_group(&[&mutation], &schema, false, None)
+            .expect("a row tombstone + surviving complex element must produce a row");
+
+        assert!(
+            row.row_deletion.is_some(),
+            "the row tombstone must be preserved"
+        );
+        assert_eq!(row.row_deletion.map(|(ts, _)| ts), Some(ROW_DEL));
+
+        let kept: Vec<i64> = row
+            .complex_element_ops
+            .iter()
+            .filter_map(|mop| match mop.op {
+                CellOperation::WriteComplexElement {
+                    timestamp_micros, ..
+                } => Some(*timestamp_micros),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            kept,
+            vec![LIVE_ELEM_TS],
+            "the element whose OWN timestamp ({LIVE_ELEM_TS}) strictly exceeds row_del \
+             ({ROW_DEL}) must survive while the boundary element ({SHADOWED_ELEM_TS}) \
+             stays shadowed"
+        );
+    }
+
+    /// Issue #887, complement: a complex-deletion marker FULLY COVERED by the row
+    /// tombstone (`mfda <= row_del`) is shadowed out — redundant with the row
+    /// tombstone. Mirrors the strict boundary (`equal` does NOT survive).
+    #[test]
+    fn merge_row_group_drops_fully_covered_complex_deletion_on_row_tombstone() {
+        let schema = complex_column_schema();
+        const ROW_DEL: i64 = 300;
+
+        for covered_mfda in [ROW_DEL - 100, ROW_DEL] {
+            let mutation = Mutation::new(
+                TableId::new("test_ks", "test_table"),
+                PartitionKey::single("id", Value::Integer(1)),
+                None,
+                vec![
+                    CellOperation::DeleteRow,
+                    CellOperation::ComplexDeletion {
+                        column: "tags".to_string(),
+                        marked_for_delete_at: covered_mfda,
+                        local_deletion_time: 1_700_000_000,
+                    },
+                ],
+                ROW_DEL,
+                None,
+            );
+
+            let row = DataWriter::merge_row_group(&[&mutation], &schema, false, None)
+                .expect("the row tombstone alone still produces a row");
+            assert!(row.row_deletion.is_some());
+            assert!(
+                row.complex_element_ops.is_empty(),
+                "a marker with mfda ({covered_mfda}) <= row_del ({ROW_DEL}) is fully \
+                 covered by the row tombstone and must be dropped"
+            );
+        }
+    }
+
+    /// Issue #921 (roborev HIGH): the `deletion_ts` shadow boundary for per-element
+    /// complex writes must apply on the NORMAL (non-shadowed) merge path too, not only
+    /// the row-tombstone rescue path. Here a partition/range tombstone supplies
+    /// `deletion_ts` via `shadow_floor`, but the carrying mutation's row timestamp is
+    /// ABOVE the floor, so it is NOT classified shadowed (takes the normal path). A
+    /// `WriteComplexElement` whose OWN `timestamp_micros <= deletion_ts` must still be
+    /// DROPPED (it is covered by the partition/range tombstone and would otherwise
+    /// resurrect once that tombstone is purged); an element with `ts > deletion_ts` in
+    /// the SAME mutation must survive. Boundary: `> deletion_ts` survives, `<=` shadowed
+    /// (equal-ts tombstone wins, #498) — identical to the rescue path.
+    #[test]
+    fn merge_row_group_shadows_complex_element_on_normal_path_by_floor() {
+        let schema = complex_column_schema();
+        const FLOOR: i64 = 200; // partition/range tombstone deletion_ts
+        const MUTATION_ROW_TS: i64 = 500; // > FLOOR => NORMAL path (not shadowed)
+        const COVERED_ELEM_TS: i64 = 200; // == FLOOR: covered, must drop (equal-ts loses)
+        const BELOW_ELEM_TS: i64 = 150; // < FLOOR: covered, must drop
+        const LIVE_ELEM_TS: i64 = 350; // > FLOOR: survives
+
+        let mutation = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(1)),
+            None,
+            vec![
+                CellOperation::WriteComplexElement {
+                    column: "tags".to_string(),
+                    cell_path: vec![0u8; 16],
+                    value: Some(Value::Text("covered-eq".to_string())),
+                    timestamp_micros: COVERED_ELEM_TS,
+                    ttl_seconds: None,
+                    local_deletion_time: None,
+                    is_deleted: false,
+                },
+                CellOperation::WriteComplexElement {
+                    column: "tags".to_string(),
+                    cell_path: vec![1u8; 16],
+                    value: Some(Value::Text("covered-below".to_string())),
+                    timestamp_micros: BELOW_ELEM_TS,
+                    ttl_seconds: None,
+                    local_deletion_time: None,
+                    is_deleted: false,
+                },
+                CellOperation::WriteComplexElement {
+                    column: "tags".to_string(),
+                    cell_path: vec![2u8; 16],
+                    value: Some(Value::Text("live".to_string())),
+                    timestamp_micros: LIVE_ELEM_TS,
+                    ttl_seconds: None,
+                    local_deletion_time: None,
+                    is_deleted: false,
+                },
+            ],
+            MUTATION_ROW_TS,
+            None,
+        );
+
+        let row = DataWriter::merge_row_group(&[&mutation], &schema, false, Some(FLOOR))
+            .expect("a surviving live element must still produce a row");
+
+        let kept: Vec<i64> = row
+            .complex_element_ops
+            .iter()
+            .filter_map(|mop| match mop.op {
+                CellOperation::WriteComplexElement {
+                    timestamp_micros, ..
+                } => Some(*timestamp_micros),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            kept,
+            vec![LIVE_ELEM_TS],
+            "on the NORMAL path (mutation row ts {MUTATION_ROW_TS} > floor {FLOOR}), \
+             elements at ts <= floor ({COVERED_ELEM_TS}, {BELOW_ELEM_TS}) must be \
+             shadowed by the partition/range tombstone; only ts > floor \
+             ({LIVE_ELEM_TS}) survives"
+        );
+        assert_eq!(
+            row.liveness_ts,
+            Some(LIVE_ELEM_TS),
+            "row liveness comes only from the surviving live element"
+        );
+    }
+
+    /// Issue #921 (roborev MEDIUM): the `deletion_ts` shadow boundary for complex
+    /// DELETION markers must apply on the NORMAL merge path too. A partition/range
+    /// tombstone supplies `deletion_ts` via `shadow_floor`; the carrying mutation's row
+    /// timestamp is ABOVE the floor (normal path). A `ComplexDeletion` whose own
+    /// `marked_for_delete_at <= deletion_ts` is FULLY COVERED and must be DROPPED
+    /// (redundant dead marker); one with `mfda > deletion_ts` must be retained.
+    /// Boundary matches the rescue path exactly (`equal` is shadowed).
+    #[test]
+    fn merge_row_group_drops_covered_complex_deletion_on_normal_path_by_floor() {
+        let schema = complex_column_schema();
+        const FLOOR: i64 = 300; // partition/range tombstone deletion_ts
+        const MUTATION_ROW_TS: i64 = 700; // > FLOOR => NORMAL path
+
+        // Covered markers (mfda <= floor) must be dropped on the normal path.
+        for covered_mfda in [FLOOR - 100, FLOOR] {
+            let mutation = Mutation::new(
+                TableId::new("test_ks", "test_table"),
+                PartitionKey::single("id", Value::Integer(1)),
+                None,
+                vec![CellOperation::ComplexDeletion {
+                    column: "tags".to_string(),
+                    marked_for_delete_at: covered_mfda,
+                    local_deletion_time: 1_700_000_000,
+                }],
+                MUTATION_ROW_TS,
+                None,
+            );
+            let row = DataWriter::merge_row_group(&[&mutation], &schema, false, Some(FLOOR));
+            assert!(
+                row.is_none_or(|r| r.complex_element_ops.is_empty()),
+                "on the NORMAL path (row ts {MUTATION_ROW_TS} > floor {FLOOR}), a marker \
+                 with mfda ({covered_mfda}) <= floor is fully covered and must be dropped"
+            );
+        }
+
+        // A marker strictly above the floor must be retained on the normal path.
+        const LIVE_MFDA: i64 = 500; // > FLOOR
+        let mutation = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(1)),
+            None,
+            vec![CellOperation::ComplexDeletion {
+                column: "tags".to_string(),
+                marked_for_delete_at: LIVE_MFDA,
+                local_deletion_time: 1_700_000_000,
+            }],
+            MUTATION_ROW_TS,
+            None,
+        );
+        let row = DataWriter::merge_row_group(&[&mutation], &schema, false, Some(FLOOR))
+            .expect("a strictly-newer marker must produce a row");
+        assert!(
+            row.complex_element_ops.iter().any(|mop| matches!(
+                mop.op,
+                CellOperation::ComplexDeletion { column, marked_for_delete_at, .. }
+                    if column == "tags" && *marked_for_delete_at == LIVE_MFDA
+            )),
+            "a marker with mfda ({LIVE_MFDA}) > floor ({FLOOR}) must survive on the \
+             normal path"
+        );
+    }
+
+    /// Issue #887: SHADOW-BEFORE-PURGE in the direct writer merge path — the analogue
+    /// of `reconcile_cluster` Step 2b. A surviving `ComplexDeletion(col, mfda)` marker
+    /// must shadow every `WriteComplexElement` of THE SAME COLUMN whose own
+    /// `timestamp_micros <= mfda`, while elements with `ts > mfda` survive. This MUST
+    /// hold on BOTH the NORMAL path and the SHADOWED (row-tombstone) rescue path.
+    #[test]
+    fn merge_row_group_shadows_complex_element_against_surviving_marker() {
+        let schema = complex_column_schema();
+        const MFDA: i64 = 300;
+        const COVERED_ELEM_TS: i64 = 200; // <= MFDA: shadowed by the marker
+        const LIVE_ELEM_TS: i64 = 500; // > MFDA: survives
+
+        let covered_elem = || CellOperation::WriteComplexElement {
+            column: "tags".to_string(),
+            cell_path: vec![0u8; 16],
+            value: Some(Value::Text("covered".to_string())),
+            timestamp_micros: COVERED_ELEM_TS,
+            ttl_seconds: None,
+            local_deletion_time: None,
+            is_deleted: false,
+        };
+        let live_elem = || CellOperation::WriteComplexElement {
+            column: "tags".to_string(),
+            cell_path: vec![1u8; 16],
+            value: Some(Value::Text("live".to_string())),
+            timestamp_micros: LIVE_ELEM_TS,
+            ttl_seconds: None,
+            local_deletion_time: None,
+            is_deleted: false,
+        };
+        let marker = || CellOperation::ComplexDeletion {
+            column: "tags".to_string(),
+            marked_for_delete_at: MFDA,
+            local_deletion_time: 1_700_000_000,
+        };
+
+        let assert_shadowed = |row: &RowWrite<'_>, scenario: &str| {
+            let kept_marker = row.complex_element_ops.iter().any(|mop| {
+                matches!(
+                    mop.op,
+                    CellOperation::ComplexDeletion {
+                        marked_for_delete_at,
+                        ..
+                    } if *marked_for_delete_at == MFDA
+                )
+            });
+            assert!(
+                kept_marker,
+                "{scenario}: the surviving complex-deletion marker (mfda={MFDA}) must be emitted"
+            );
+            let kept_elems: Vec<i64> = row
+                .complex_element_ops
+                .iter()
+                .filter_map(|mop| match mop.op {
+                    CellOperation::WriteComplexElement {
+                        timestamp_micros, ..
+                    } => Some(*timestamp_micros),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(
+                kept_elems,
+                vec![LIVE_ELEM_TS],
+                "{scenario}: the covered element@{COVERED_ELEM_TS} (<= mfda={MFDA}) must be \
+                 shadowed; only the live element@{LIVE_ELEM_TS} (> mfda) survives"
+            );
+        };
+
+        // --- Normal path: no row tombstone. mfda alone shadows the element. ---
+        let normal = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(1)),
+            None,
+            vec![marker(), covered_elem(), live_elem()],
+            COVERED_ELEM_TS,
+            None,
+        );
+        let row = DataWriter::merge_row_group(&[&normal], &schema, false, None)
+            .expect("normal path must produce a row");
+        assert!(
+            row.row_deletion.is_none(),
+            "normal path carries no row tombstone"
+        );
+        assert_shadowed(&row, "normal path");
+
+        // --- Shadowed (row-tombstone) rescue path: DeleteRow@100, mfda=300>100. ---
+        const ROW_DEL: i64 = 100;
+        let shadowed = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(1)),
+            None,
+            vec![
+                CellOperation::DeleteRow,
+                marker(),
+                covered_elem(),
+                live_elem(),
+            ],
+            ROW_DEL,
+            None,
+        );
+        let row = DataWriter::merge_row_group(&[&shadowed], &schema, false, None)
+            .expect("shadowed path must produce a row");
+        assert_eq!(
+            row.row_deletion.map(|(ts, _)| ts),
+            Some(ROW_DEL),
+            "shadowed path preserves the row tombstone"
+        );
+        assert_shadowed(&row, "shadowed (row-tombstone) path");
+    }
+
+    /// Issue #887: when EVERY live complex element of a mutation is shadowed by a
+    /// same-column `ComplexDeletion` (every element `timestamp_micros <= mfda`), and
+    /// there is NO other live contributor, the row must NOT carry a LIVE row timestamp
+    /// — it is a marker-only / deletion row. Liveness from OTHER sources (a surviving
+    /// element or a simple-cell `Write`) must still keep the row live.
+    #[test]
+    fn merge_row_group_drops_liveness_when_all_complex_elements_shadowed() {
+        let schema = complex_column_schema();
+        const MFDA: i64 = 300;
+        const SHADOWED_ELEM_TS: i64 = 200; // <= MFDA: shadowed by the marker
+        const LIVE_ELEM_TS: i64 = 500; // > MFDA: survives
+
+        let marker = || CellOperation::ComplexDeletion {
+            column: "tags".to_string(),
+            marked_for_delete_at: MFDA,
+            local_deletion_time: 1_700_000_000,
+        };
+        let shadowed_elem = || CellOperation::WriteComplexElement {
+            column: "tags".to_string(),
+            cell_path: vec![0u8; 16],
+            value: Some(Value::Text("shadowed".to_string())),
+            timestamp_micros: SHADOWED_ELEM_TS,
+            ttl_seconds: None,
+            local_deletion_time: None,
+            is_deleted: false,
+        };
+        let live_elem = || CellOperation::WriteComplexElement {
+            column: "tags".to_string(),
+            cell_path: vec![1u8; 16],
+            value: Some(Value::Text("live".to_string())),
+            timestamp_micros: LIVE_ELEM_TS,
+            ttl_seconds: None,
+            local_deletion_time: None,
+            is_deleted: false,
+        };
+
+        // --- Case 1: marker + ONLY shadowed element, no other live contributor. ---
+        let all_shadowed = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(1)),
+            None,
+            vec![marker(), shadowed_elem()],
+            SHADOWED_ELEM_TS,
+            None,
+        );
+        let row = DataWriter::merge_row_group(&[&all_shadowed], &schema, false, None)
+            .expect("the surviving marker alone still produces a row");
+        assert!(
+            row.complex_element_ops
+                .iter()
+                .all(|mop| !matches!(mop.op, CellOperation::WriteComplexElement { .. })),
+            "the shadowed element must be purged; only the marker survives"
+        );
+        assert_eq!(
+            row.liveness_ts, None,
+            "a marker-only row carries NO liveness (shadowed element must not leak one)"
+        );
+
+        // --- Case 2: a SURVIVING element (ts > mfda) keeps the row live. ---
+        let one_survives = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(1)),
+            None,
+            vec![marker(), shadowed_elem(), live_elem()],
+            LIVE_ELEM_TS,
+            None,
+        );
+        let row = DataWriter::merge_row_group(&[&one_survives], &schema, false, None)
+            .expect("a surviving element must produce a row");
+        assert_eq!(
+            row.liveness_ts,
+            Some(LIVE_ELEM_TS),
+            "a surviving element (ts {LIVE_ELEM_TS} > mfda {MFDA}) must keep the row live"
+        );
+
+        // --- Case 3: an explicit simple-cell Write is an independent live source. ---
+        let mut simple_schema = complex_column_schema();
+        simple_schema.columns.push(Column {
+            name: "v".to_string(),
+            data_type: "text".to_string(),
+            nullable: true,
+            default: None,
+            is_static: false,
+        });
+        let with_simple_write = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(1)),
+            None,
+            vec![
+                CellOperation::ComplexDeletion {
+                    column: "tags".to_string(),
+                    marked_for_delete_at: MFDA,
+                    local_deletion_time: 1_700_000_000,
+                },
+                CellOperation::WriteComplexElement {
+                    column: "tags".to_string(),
+                    cell_path: vec![0u8; 16],
+                    value: Some(Value::Text("shadowed".to_string())),
+                    timestamp_micros: SHADOWED_ELEM_TS,
+                    ttl_seconds: None,
+                    local_deletion_time: None,
+                    is_deleted: false,
+                },
+                CellOperation::Write {
+                    column: "v".to_string(),
+                    value: Value::Text("alive".to_string()),
+                },
+            ],
+            SHADOWED_ELEM_TS,
+            None,
+        );
+        let row = DataWriter::merge_row_group(&[&with_simple_write], &simple_schema, false, None)
+            .expect("a simple write must produce a row");
+        assert_eq!(
+            row.liveness_ts,
+            Some(SHADOWED_ELEM_TS),
+            "a simple-cell Write is an independent live source and must keep the row live \
+             even when every complex element is shadowed"
+        );
+    }
+
+    /// Schema with TWO non-frozen complex columns (`tags` and `notes`, both
+    /// `list<text>`) for mixed-stream / multi-column reconcile tests (issue #921).
+    fn two_complex_column_schema() -> TableSchema {
+        let mut schema = complex_column_schema();
+        schema.columns.push(Column {
+            name: "notes".to_string(),
+            data_type: "list<text>".to_string(),
+            nullable: true,
+            default: None,
+            is_static: false,
+        });
+        schema
+    }
+
+    /// Issue #921 (roborev Finding 1): in the #927 mixed-stream reconcile a column
+    /// may carry BOTH a whole-column write and a per-element edit. The reconcile
+    /// compares the whole op's timestamp to the per-element stream's MAX timestamp.
+    /// That max must be the element's OWN `timestamp_micros`, NOT the enclosing
+    /// mutation's row timestamp. Here a per-element edit's own timestamp is NEWER
+    /// than a whole-column write, but its enclosing mutation's row timestamp is
+    /// OLDER. The element must still WIN (be retained, whole op dropped).
+    #[test]
+    fn merge_row_group_element_own_ts_wins_mixed_stream_over_older_row_ts() {
+        let schema = complex_column_schema();
+        // Whole-column write at ts 500.
+        const WHOLE_TS: i64 = 500;
+        // Per-element edit: OWN element ts 900 (newer than the whole op) but its
+        // enclosing mutation carries an OLDER row timestamp of 100.
+        const ELEM_OWN_TS: i64 = 900;
+        const MUTATION_ROW_TS: i64 = 100;
+
+        let whole = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(1)),
+            None,
+            vec![CellOperation::Write {
+                column: "tags".to_string(),
+                value: Value::Text("whole".to_string()),
+            }],
+            WHOLE_TS,
+            None,
+        );
+        let per_elem = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(1)),
+            None,
+            vec![CellOperation::WriteComplexElement {
+                column: "tags".to_string(),
+                cell_path: vec![0u8; 16],
+                value: Some(Value::Text("new-elem".to_string())),
+                timestamp_micros: ELEM_OWN_TS,
+                ttl_seconds: None,
+                local_deletion_time: None,
+                is_deleted: false,
+            }],
+            MUTATION_ROW_TS,
+            None,
+        );
+
+        let row = DataWriter::merge_row_group(&[&whole, &per_elem], &schema, false, None)
+            .expect("mixed stream must produce a row");
+
+        // The element's OWN ts (900) exceeds the whole-column write (500), so the
+        // per-element stream wins regardless of the older enclosing row ts (100).
+        assert!(
+            !row.ops
+                .iter()
+                .any(|m| merged_op_column(m.op) == Some("tags")),
+            "the whole-column write must lose: the per-element edit's OWN timestamp \
+             ({ELEM_OWN_TS}) exceeds it ({WHOLE_TS}), even though its mutation row \
+             timestamp ({MUTATION_ROW_TS}) is older"
+        );
+        assert_eq!(
+            row.complex_element_ops.len(),
+            1,
+            "the newer per-element edit (own ts {ELEM_OWN_TS}) must be retained"
+        );
+        assert!(
+            row.complex_element_ops.iter().any(|mop| matches!(
+                mop.op,
+                CellOperation::WriteComplexElement { column, timestamp_micros, .. }
+                    if column == "tags" && *timestamp_micros == ELEM_OWN_TS
+            )),
+            "the surviving element must be the newer per-element edit"
+        );
+    }
+
+    /// Issue #921 (roborev, ComplexDeletion analogue of element-own-ts-wins): a
+    /// `ComplexDeletion(col, mfda)` carried by an OLDER metadata/tombstone mutation
+    /// (row ts 100) must NOT be shadowed by a whole-column write/delete (ts 500)
+    /// whose timestamp is below the marker's `marked_for_delete_at` (900). The #927
+    /// mixed-stream reconcile compares `MergedOp.timestamp_micros`; the marker must
+    /// carry its OWN mfda there so the per-element/marker stream WINS, retaining the
+    /// collection tombstone (otherwise covered elements survive/resurrect). Covers
+    /// the NORMAL (non-shadowed) merge path.
+    #[test]
+    fn merge_row_group_complex_deletion_mfda_wins_mixed_stream_over_older_row_ts() {
+        let schema = complex_column_schema();
+        // Whole-column write to `tags` at ts 500.
+        const WHOLE_TS: i64 = 500;
+        // ComplexDeletion marker: OWN mfda 900 (newer than the whole op) but carried
+        // by a mutation whose row timestamp is an OLDER 100.
+        const MARKER_MFDA: i64 = 900;
+        const MUTATION_ROW_TS: i64 = 100;
+        const MARKER_LDT: i32 = 1_700_000_000;
+
+        let whole = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(1)),
+            None,
+            vec![CellOperation::Write {
+                column: "tags".to_string(),
+                value: Value::Text("whole".to_string()),
+            }],
+            WHOLE_TS,
+            None,
+        );
+        let marker = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(1)),
+            None,
+            vec![CellOperation::ComplexDeletion {
+                column: "tags".to_string(),
+                marked_for_delete_at: MARKER_MFDA,
+                local_deletion_time: MARKER_LDT,
+            }],
+            MUTATION_ROW_TS,
+            None,
+        );
+
+        let row = DataWriter::merge_row_group(&[&whole, &marker], &schema, false, None)
+            .expect("mixed stream must produce a row");
+
+        // The marker's OWN mfda (900) exceeds the whole-column write (500), so the
+        // marker stream wins regardless of the older enclosing row ts (100).
+        assert!(
+            !row.ops
+                .iter()
+                .any(|m| merged_op_column(m.op) == Some("tags")),
+            "the whole-column write must lose: the ComplexDeletion's OWN mfda \
+             ({MARKER_MFDA}) exceeds it ({WHOLE_TS}), even though its mutation row \
+             timestamp ({MUTATION_ROW_TS}) is older"
+        );
+        // The collection tombstone must be retained with its UNCHANGED mfda/ldt bytes.
+        assert!(
+            row.complex_element_ops.iter().any(|mop| matches!(
+                mop.op,
+                CellOperation::ComplexDeletion {
+                    column,
+                    marked_for_delete_at,
+                    local_deletion_time,
+                } if column == "tags"
+                    && *marked_for_delete_at == MARKER_MFDA
+                    && *local_deletion_time == MARKER_LDT
+            )),
+            "the ComplexDeletion marker must survive with its emitted mfda/ldt unchanged"
+        );
+    }
+
+    /// Issue #921 (roborev, ComplexDeletion analogue, SHADOWED rescue path): the same
+    /// independence on the row-tombstone rescue path. A row tombstone at ts 100 carries
+    /// a `ComplexDeletion(col, mfda=900)`; a separate whole-column write to `col` at
+    /// ts 500 must NOT shadow the marker via the #927 reconcile, because the marker
+    /// carries its OWN mfda (900) as the comparison timestamp. The marker survives the
+    /// row tombstone (mfda > row_del) AND wins the mixed-stream reconcile.
+    #[test]
+    fn merge_row_group_complex_deletion_mfda_wins_mixed_stream_shadowed_path() {
+        let schema = complex_column_schema();
+        const ROW_DEL: i64 = 100;
+        const WHOLE_TS: i64 = 500;
+        const MARKER_MFDA: i64 = 900;
+        const MARKER_LDT: i32 = 1_700_000_000;
+
+        // Row-tombstone mutation (ts == ROW_DEL) that ALSO carries the marker. Its row
+        // timestamp is shadowed by its own deletion, exercising the rescue path.
+        let mut tombstone = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(1)),
+            None,
+            vec![CellOperation::ComplexDeletion {
+                column: "tags".to_string(),
+                marked_for_delete_at: MARKER_MFDA,
+                local_deletion_time: MARKER_LDT,
+            }],
+            ROW_DEL,
+            None,
+        );
+        tombstone.operations.push(CellOperation::DeleteRow);
+
+        // A separate whole-column write at ts 500 (> row_del, < mfda).
+        let whole = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(1)),
+            None,
+            vec![CellOperation::Write {
+                column: "tags".to_string(),
+                value: Value::Text("whole".to_string()),
+            }],
+            WHOLE_TS,
+            None,
+        );
+
+        let row = DataWriter::merge_row_group(&[&tombstone, &whole], &schema, false, None)
+            .expect("row tombstone + surviving marker must produce a row");
+
+        assert!(
+            !row.ops
+                .iter()
+                .any(|m| merged_op_column(m.op) == Some("tags")),
+            "the whole-column write must lose on the shadowed path too: the marker's \
+             OWN mfda ({MARKER_MFDA}) exceeds the whole op ts ({WHOLE_TS})"
+        );
+        assert!(
+            row.complex_element_ops.iter().any(|mop| matches!(
+                mop.op,
+                CellOperation::ComplexDeletion {
+                    column,
+                    marked_for_delete_at,
+                    local_deletion_time,
+                } if column == "tags"
+                    && *marked_for_delete_at == MARKER_MFDA
+                    && *local_deletion_time == MARKER_LDT
+            )),
+            "the rescued ComplexDeletion marker must survive the #927 reconcile with \
+             its emitted mfda/ldt unchanged"
+        );
+    }
+
+    /// Issue #921 (roborev Finding 2): a winning whole-column `Delete` for column A
+    /// drops A's per-element ops via the #927 mixed-stream reconcile. The deferred
+    /// complex-element liveness fold must NOT then let A's dropped (live) element
+    /// keep the row alive — even though another complex column B keeps
+    /// `complex_element_ops` non-empty (so the fold runs). The result is a
+    /// deletion-only column A: no liveness leaks from it.
+    #[test]
+    fn merge_row_group_no_liveness_from_element_dropped_by_whole_column_delete() {
+        let schema = two_complex_column_schema();
+        // Column A (`tags`): a live per-element write at ts 300, shadowed by a NEWER
+        // whole-column Delete at ts 500 (delete wins the #927 reconcile, drops A's
+        // element). A contributes NO liveness.
+        const A_ELEM_TS: i64 = 300;
+        const A_DELETE_TS: i64 = 500;
+        // Column B (`notes`): an unrelated whole-column Delete keeps the row a
+        // deletion (B's per-element stream is empty; B does not contribute either).
+        // Crucially, column B keeps a per-element op so `complex_element_ops` is
+        // non-empty and the liveness fold executes.
+        const B_ELEM_TS: i64 = 200; // shadowed by B's own marker below
+        const B_MFDA: i64 = 400; // > B_ELEM_TS: B's element is fully shadowed too
+
+        let a_elem = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(1)),
+            None,
+            vec![CellOperation::WriteComplexElement {
+                column: "tags".to_string(),
+                cell_path: vec![0u8; 16],
+                value: Some(Value::Text("a-live".to_string())),
+                timestamp_micros: A_ELEM_TS,
+                ttl_seconds: None,
+                local_deletion_time: None,
+                is_deleted: false,
+            }],
+            A_ELEM_TS,
+            None,
+        );
+        let a_delete = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(1)),
+            None,
+            vec![CellOperation::Delete {
+                column: "tags".to_string(),
+            }],
+            A_DELETE_TS,
+            None,
+        );
+        // Column B: a marker + a fully-shadowed element so B keeps a per-element op
+        // (the surviving marker) without contributing any liveness of its own.
+        let b_marker_and_elem = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(1)),
+            None,
+            vec![
+                CellOperation::ComplexDeletion {
+                    column: "notes".to_string(),
+                    marked_for_delete_at: B_MFDA,
+                    local_deletion_time: 1_700_000_000,
+                },
+                CellOperation::WriteComplexElement {
+                    column: "notes".to_string(),
+                    cell_path: vec![1u8; 16],
+                    value: Some(Value::Text("b-shadowed".to_string())),
+                    timestamp_micros: B_ELEM_TS,
+                    ttl_seconds: None,
+                    local_deletion_time: None,
+                    is_deleted: false,
+                },
+            ],
+            B_ELEM_TS,
+            None,
+        );
+
+        let row = DataWriter::merge_row_group(
+            &[&a_elem, &a_delete, &b_marker_and_elem],
+            &schema,
+            false,
+            None,
+        )
+        .expect("the surviving deletes/marker still produce a row");
+
+        // Column A's element was dropped by the winning whole-column Delete; no
+        // liveness must leak from it. Column B contributes none either. The row is a
+        // deletion-only row.
+        assert_eq!(
+            row.liveness_ts, None,
+            "a live element of column A dropped by a winning whole-column Delete must \
+             NOT keep the row live (Finding 2)"
+        );
+        // Sanity: A's element op did not survive; the whole-column Delete did.
+        assert!(
+            !row.complex_element_ops.iter().any(|mop| matches!(
+                mop.op,
+                CellOperation::WriteComplexElement { column, .. } if column == "tags"
+            )),
+            "column A's per-element write must be dropped by the winning whole-column Delete"
+        );
+        assert!(
+            row.ops.iter().any(|mop| matches!(
+                mop.op,
+                CellOperation::Delete { column } if column == "tags"
+            )),
+            "column A's whole-column Delete must survive"
+        );
+    }
+
+    /// Issue #921 (roborev High): a winning whole-column LIVE `Write` for column A
+    /// drops A's per-element ops via the #927 mixed-stream reconcile. The OLD
+    /// candidate-list + exclusion-set fold only excluded columns whose stream was
+    /// dropped by a NON-live (Delete) winner, so a dropped LIVE element could still
+    /// fold liveness — and it folded the ENCLOSING MUTATION's row timestamp, which
+    /// can be NEWER than the surviving write even though the dropped element's OWN
+    /// timestamp is OLDER. The row would then carry a liveness timestamp from an
+    /// element that no longer exists. After the fix, complex-element liveness is
+    /// derived from the FINAL surviving `complex_element_ops`, so a dropped element
+    /// contributes nothing and the row's liveness comes only from the surviving LIVE
+    /// whole-column write.
+    #[test]
+    fn merge_row_group_no_liveness_from_element_dropped_by_whole_column_live_write() {
+        let schema = two_complex_column_schema();
+        // Column A (`tags`): a live per-element write whose OWN timestamp (300) is
+        // OLDER than the winning whole-column Write (500), but whose ENCLOSING
+        // mutation carries a NEWER row timestamp (1000). The whole-column Write wins
+        // the #927 reconcile (500 >= elem_max 300) and drops A's element.
+        const A_ELEM_TS: i64 = 300;
+        const A_WRITE_TS: i64 = 500;
+        const A_ELEM_MUTATION_ROW_TS: i64 = 1000; // > A_WRITE_TS: the trap for the old fold
+                                                  // Column B (`notes`): a marker + fully-shadowed element so B keeps a
+                                                  // per-element op (the surviving marker) and `complex_element_ops` is
+                                                  // non-empty, exercising the liveness derivation. B contributes no liveness.
+        const B_ELEM_TS: i64 = 200;
+        const B_MFDA: i64 = 400; // > B_ELEM_TS: B's element is fully shadowed
+
+        let a_elem = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(1)),
+            None,
+            vec![CellOperation::WriteComplexElement {
+                column: "tags".to_string(),
+                cell_path: vec![0u8; 16],
+                value: Some(Value::Text("a-live".to_string())),
+                timestamp_micros: A_ELEM_TS,
+                ttl_seconds: None,
+                local_deletion_time: None,
+                is_deleted: false,
+            }],
+            A_ELEM_MUTATION_ROW_TS,
+            None,
+        );
+        let a_write = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(1)),
+            None,
+            vec![CellOperation::Write {
+                column: "tags".to_string(),
+                value: Value::Text("a-whole".to_string()),
+            }],
+            A_WRITE_TS,
+            None,
+        );
+        let b_marker_and_elem = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(1)),
+            None,
+            vec![
+                CellOperation::ComplexDeletion {
+                    column: "notes".to_string(),
+                    marked_for_delete_at: B_MFDA,
+                    local_deletion_time: 1_700_000_000,
+                },
+                CellOperation::WriteComplexElement {
+                    column: "notes".to_string(),
+                    cell_path: vec![1u8; 16],
+                    value: Some(Value::Text("b-shadowed".to_string())),
+                    timestamp_micros: B_ELEM_TS,
+                    ttl_seconds: None,
+                    local_deletion_time: None,
+                    is_deleted: false,
+                },
+            ],
+            B_ELEM_TS,
+            None,
+        );
+
+        let row = DataWriter::merge_row_group(
+            &[&a_elem, &a_write, &b_marker_and_elem],
+            &schema,
+            false,
+            None,
+        )
+        .expect("the surviving write/marker still produce a row");
+
+        // A's per-element write was dropped by the winning whole-column LIVE Write;
+        // its OWN timestamp (300) no longer exists in the output, so the only live
+        // source is the surviving whole-column Write at 500. Liveness must be 500 —
+        // NOT the dropped element's enclosing mutation row ts (1000), which the OLD
+        // fold would have leaked.
+        assert_eq!(
+            row.liveness_ts,
+            Some(A_WRITE_TS),
+            "liveness must come from the surviving whole-column Write ({A_WRITE_TS}), \
+             not the dropped per-element write's enclosing mutation row ts \
+             ({A_ELEM_MUTATION_ROW_TS})"
+        );
+        // Sanity: A's element op did not survive; the whole-column Write did.
+        assert!(
+            !row.complex_element_ops.iter().any(|mop| matches!(
+                mop.op,
+                CellOperation::WriteComplexElement { column, .. } if column == "tags"
+            )),
+            "column A's per-element write must be dropped by the winning whole-column Write"
+        );
+        assert!(
+            row.ops.iter().any(|mop| matches!(
+                mop.op,
+                CellOperation::Write { column, .. } if column == "tags"
+            )),
+            "column A's whole-column Write must survive"
+        );
+    }
+
+    /// Issue #921 (roborev HIGH — symmetric counterpart to the per-element liveness
+    /// fix): a live WHOLE-COLUMN `Write` that LOSES the #927 mixed-stream reconcile to
+    /// a newer same-column complex stream must NOT leak row liveness. Here
+    /// `Write(tags)@500` competes with `ComplexDeletion(tags, mfda=900)`. The complex
+    /// marker stream wins (900 >= whole-column 500), so the whole-column Write is
+    /// DROPPED from `ops`, and the marker is a deletion (no live element) — there is
+    /// NO surviving live cell for `tags`. The row therefore carries NO liveness.
+    ///
+    /// RED before the fix: whole-column liveness was folded INLINE at 500 during the
+    /// per-mutation loop, before reconcile decided the write loses, so the row emitted
+    /// a phantom live timestamp@500. GREEN after: liveness is derived from the FINAL
+    /// surviving `ops`, which no longer contain the dropped write.
+    #[test]
+    fn merge_row_group_no_liveness_when_whole_column_write_loses_to_complex_marker() {
+        let schema = complex_column_schema();
+        const WRITE_TS: i64 = 500;
+        const MFDA: i64 = 900; // > WRITE_TS: the complex marker stream wins
+
+        let write = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(1)),
+            None,
+            vec![CellOperation::Write {
+                column: "tags".to_string(),
+                value: Value::Text("whole".to_string()),
+            }],
+            WRITE_TS,
+            None,
+        );
+        let marker = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(1)),
+            None,
+            vec![CellOperation::ComplexDeletion {
+                column: "tags".to_string(),
+                marked_for_delete_at: MFDA,
+                local_deletion_time: 1_700_000_000,
+            }],
+            MFDA,
+            None,
+        );
+
+        let row = DataWriter::merge_row_group(&[&write, &marker], &schema, false, None)
+            .expect("the surviving complex-deletion marker still produces a row");
+
+        // The whole-column Write lost the reconcile and was dropped; the only
+        // surviving op is the deletion marker (no live cell). No phantom liveness.
+        assert_eq!(
+            row.liveness_ts, None,
+            "a whole-column Write dropped by a winning complex marker must NOT leak \
+             row liveness (no surviving live cell)"
+        );
+        assert!(
+            !row.ops.iter().any(|mop| matches!(
+                mop.op,
+                CellOperation::Write { column, .. } if column == "tags"
+            )),
+            "the whole-column Write must be dropped by the winning complex stream"
+        );
+        assert!(
+            row.complex_element_ops.iter().any(|mop| matches!(
+                mop.op,
+                CellOperation::ComplexDeletion { column, .. } if column == "tags"
+            )),
+            "the complex-deletion marker must survive"
+        );
+    }
+
+    /// Issue #921: a surviving whole-column `Write` with NO competing complex winner
+    /// still sets row liveness at its own timestamp — the common case must be
+    /// unaffected by deriving liveness from final survivors.
+    #[test]
+    fn merge_row_group_surviving_whole_column_write_sets_liveness() {
+        let schema = create_test_schema();
+        const WRITE_TS: i64 = 700;
+
+        let write = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(1)),
+            None,
+            vec![CellOperation::Write {
+                column: "name".to_string(),
+                value: Value::Text("alive".to_string()),
+            }],
+            WRITE_TS,
+            None,
+        );
+
+        let row = DataWriter::merge_row_group(&[&write], &schema, false, None)
+            .expect("a live whole-column write produces a row");
+
+        assert_eq!(
+            row.liveness_ts,
+            Some(WRITE_TS),
+            "a surviving whole-column write must set row liveness at its own timestamp"
+        );
+        assert!(
+            row.ops.iter().any(|mop| matches!(
+                mop.op,
+                CellOperation::Write { column, .. } if column == "name"
+            )),
+            "the whole-column write must survive into ops"
+        );
+    }
+
+    /// Issue #921: a pure primary-key insert (no ops, no tombstone payload) still
+    /// sets row liveness — the cell-less liveness source must be preserved when
+    /// whole-column liveness moves to a post-reconcile derivation.
+    #[test]
+    fn merge_row_group_pure_pk_insert_still_sets_liveness() {
+        let schema = create_test_schema();
+        const INSERT_TS: i64 = 1234;
+
+        let insert = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(1)),
+            None,
+            vec![],
+            INSERT_TS,
+            None,
+        );
+
+        let row = DataWriter::merge_row_group(&[&insert], &schema, false, None)
+            .expect("a pure primary-key insert produces a live row with no cells");
+
+        assert_eq!(
+            row.liveness_ts,
+            Some(INSERT_TS),
+            "a pure primary-key insert must keep its liveness timestamp"
+        );
+        assert!(
+            row.ops.is_empty(),
+            "a pure primary-key insert produces no cells"
+        );
+    }
+
+    /// Issue #887: the all-shadowed case on the SHADOWED (row-tombstone) rescue path.
+    /// A row tombstone produces a row, but its surviving complex elements (rescue
+    /// path) deliberately contribute no liveness — so an all-shadowed complex column
+    /// must leave the row a pure tombstone (no LIVE timestamp).
+    #[test]
+    fn merge_row_group_row_tombstone_all_complex_shadowed_carries_no_liveness() {
+        let schema = complex_column_schema();
+        const ROW_DEL: i64 = 100;
+        const MFDA: i64 = 300; // > ROW_DEL so the marker survives the row tombstone
+        const COVERED_ELEM_TS: i64 = 250; // > ROW_DEL but <= MFDA: rescued then shadowed
+
+        let mutation = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(1)),
+            None,
+            vec![
+                CellOperation::DeleteRow,
+                CellOperation::ComplexDeletion {
+                    column: "tags".to_string(),
+                    marked_for_delete_at: MFDA,
+                    local_deletion_time: 1_700_000_000,
+                },
+                CellOperation::WriteComplexElement {
+                    column: "tags".to_string(),
+                    cell_path: vec![0u8; 16],
+                    value: Some(Value::Text("covered".to_string())),
+                    timestamp_micros: COVERED_ELEM_TS,
+                    ttl_seconds: None,
+                    local_deletion_time: None,
+                    is_deleted: false,
+                },
+            ],
+            ROW_DEL,
+            None,
+        );
+
+        let row = DataWriter::merge_row_group(&[&mutation], &schema, false, None)
+            .expect("a row tombstone + surviving marker must produce a row");
+        assert_eq!(
+            row.row_deletion.map(|(ts, _)| ts),
+            Some(ROW_DEL),
+            "the row tombstone is preserved"
+        );
+        assert!(
+            row.complex_element_ops
+                .iter()
+                .all(|mop| !matches!(mop.op, CellOperation::WriteComplexElement { .. })),
+            "the element@{COVERED_ELEM_TS} (<= mfda {MFDA}) is shadowed out; only the marker survives"
+        );
+        assert_eq!(
+            row.liveness_ts, None,
+            "a row-tombstone row whose complex elements are all shadowed must NOT carry \
+             a LIVE row timestamp"
         );
     }
 }

--- a/cqlite-core/src/storage/sstable/writer/data_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer.rs
@@ -1271,12 +1271,28 @@ impl DataWriter {
                     }
                     std::collections::hash_map::Entry::Occupied(mut entry) => {
                         let existing = entry.get();
+                        // Per-cell winner resolution mirroring Cassandra
+                        // `Cells#reconcile` (parity `a62c749`; issue #848 / #498),
+                        // kept CONSISTENT with `KWayMerger::cell_reconcile_replace`:
+                        //   1. higher timestamp always wins;
+                        //   2. at EQUAL timestamp a cell DELETION (a `Delete`
+                        //      tombstone) beats a LIVE/EXPIRING write — decided
+                        //      BEFORE any localDeletionTime compare, so an expiring
+                        //      (TTL) write at equal ts can never resurrect data over
+                        //      a same-ts cell tombstone (`WriteWithTtl` is LIVE here,
+                        //      NOT a tombstone). `local_deletion_time` is never used
+                        //      as a tie-break.
+                        // The writer keeps its existing convention for equal-ts
+                        // live-vs-live (later mutation wins) via `!existing_is_tomb`;
+                        // only the tombstone-vs-live/expiring axis is load-bearing
+                        // for #848 and matches reconcile.
                         let candidate_is_tombstone =
                             matches!(candidate.op, CellOperation::Delete { .. });
+                        let existing_is_tombstone =
+                            matches!(existing.op, CellOperation::Delete { .. });
                         let wins = candidate.timestamp_micros > existing.timestamp_micros
                             || (candidate.timestamp_micros == existing.timestamp_micros
-                                && (candidate_is_tombstone
-                                    || !matches!(existing.op, CellOperation::Delete { .. })));
+                                && (candidate_is_tombstone || !existing_is_tombstone));
                         if wins {
                             entry.insert(candidate);
                         }

--- a/cqlite-core/src/storage/sstable/writer/data_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer.rs
@@ -1133,7 +1133,7 @@ impl DataWriter {
                 let column = match op {
                     CellOperation::Write { column, .. }
                     | CellOperation::WriteWithTtl { column, .. }
-                    | CellOperation::Delete { column } => column.as_str(),
+                    | CellOperation::Delete { column, .. } => column.as_str(),
                     // Epic #899 (Phase B): per-element complex ops keep all
                     // elements (no per-column dedup). A live element write
                     // contributes row liveness; a `ComplexDeletion` marker does
@@ -1263,7 +1263,9 @@ impl DataWriter {
                     op,
                     timestamp_micros: m.timestamp_micros,
                     row_ttl_seconds: m.ttl_seconds,
-                    cell_local_deletion_time: m.effective_local_deletion_time(),
+                    // #921 finding 2: a surviving `Delete` cell tombstone keeps its
+                    // OWN surfaced LDT; other ops fall back to the mutation's LDT.
+                    cell_local_deletion_time: op_cell_local_deletion_time(op, m),
                 };
                 match cells.entry(column) {
                     std::collections::hash_map::Entry::Vacant(entry) => {
@@ -1591,7 +1593,7 @@ impl DataWriter {
             let col_name = match mop.op {
                 CellOperation::Write { column, .. }
                 | CellOperation::WriteWithTtl { column, .. }
-                | CellOperation::Delete { column } => Some(column.as_str()),
+                | CellOperation::Delete { column, .. } => Some(column.as_str()),
                 _ => None,
             };
             col_name.is_some_and(op_targets_complex)
@@ -1664,9 +1666,11 @@ impl DataWriter {
             .operations
             .iter()
             .map(|op| StaticMergedOp {
+                // #921 finding 2: a `Delete` cell tombstone keeps its own surfaced
+                // LDT; every other op falls back to the mutation's effective LDT.
+                cell_local_deletion_time: op_cell_local_deletion_time(op, mutation),
                 op: op.clone(),
                 timestamp_micros: mutation.timestamp_micros,
-                cell_local_deletion_time: mutation.effective_local_deletion_time(),
             })
             .collect();
         self.write_static_row_with_prev_size(
@@ -1926,9 +1930,9 @@ impl DataWriter {
                     value,
                     ..
                 } if !matches!(value, Value::Null) => Some(column.as_str()),
-                crate::storage::write_engine::mutation::CellOperation::Delete { column } => {
-                    Some(column.as_str())
-                }
+                crate::storage::write_engine::mutation::CellOperation::Delete {
+                    column, ..
+                } => Some(column.as_str()),
                 _ => None,
             })
             .collect();
@@ -1998,7 +2002,9 @@ impl DataWriter {
                         )?;
                     }
                 }
-                crate::storage::write_engine::mutation::CellOperation::Delete { column } => {
+                crate::storage::write_engine::mutation::CellOperation::Delete {
+                    column, ..
+                } => {
                     // Only process if it's a static column
                     if static_column_names.contains(column) {
                         cells_written += 1;
@@ -2049,7 +2055,7 @@ impl DataWriter {
             | crate::storage::write_engine::mutation::CellOperation::WriteWithTtl {
                 column, ..
             }
-            | crate::storage::write_engine::mutation::CellOperation::Delete { column }
+            | crate::storage::write_engine::mutation::CellOperation::Delete { column, .. }
             | crate::storage::write_engine::mutation::CellOperation::WriteComplexElement {
                 column,
                 ..
@@ -2279,9 +2285,9 @@ impl DataWriter {
                     value,
                     ..
                 } if !matches!(value, Value::Null) => Some(column.as_str()),
-                crate::storage::write_engine::mutation::CellOperation::Delete { column } => {
-                    Some(column.as_str())
-                }
+                crate::storage::write_engine::mutation::CellOperation::Delete {
+                    column, ..
+                } => Some(column.as_str()),
                 _ => None,
             })
             .collect();
@@ -2312,7 +2318,7 @@ impl DataWriter {
                 {
                     Some(column.as_str())
                 }
-                CellOperation::Delete { column } => Some(column.as_str()),
+                CellOperation::Delete { column, .. } => Some(column.as_str()),
                 _ => None,
             })
             .collect();
@@ -2483,7 +2489,7 @@ impl DataWriter {
                         )?;
                     }
                 }
-                CellOperation::Delete { column } => {
+                CellOperation::Delete { column, .. } => {
                     cells_written += 1;
                     let is_complex = schema
                         .columns
@@ -3736,7 +3742,7 @@ impl DataWriter {
             | crate::storage::write_engine::mutation::CellOperation::WriteWithTtl {
                 column, ..
             }
-            | crate::storage::write_engine::mutation::CellOperation::Delete { column }
+            | crate::storage::write_engine::mutation::CellOperation::Delete { column, .. }
             | crate::storage::write_engine::mutation::CellOperation::WriteComplexElement {
                 column,
                 ..
@@ -4065,10 +4071,46 @@ fn merged_op_column(op: &crate::storage::write_engine::mutation::CellOperation) 
     match op {
         CellOperation::Write { column, .. }
         | CellOperation::WriteWithTtl { column, .. }
-        | CellOperation::Delete { column }
+        | CellOperation::Delete { column, .. }
         | CellOperation::WriteComplexElement { column, .. }
         | CellOperation::ComplexDeletion { column, .. } => Some(column.as_str()),
         CellOperation::DeleteRow => None,
+    }
+}
+
+/// The `localDeletionTime` (seconds, GC clock) to stamp a cell tombstone with for
+/// an op carried by `mutation` (#921 finding 2).
+///
+/// A `CellOperation::Delete` that carries its OWN `local_deletion_time` (set by
+/// the compaction merge→rewrite path from the SOURCE cell tombstone's surfaced
+/// LDT) is honored VERBATIM so a surviving within-grace cell tombstone keeps its
+/// original GC clock across compactions. For every other op — and for a `Delete`
+/// with no surfaced LDT (`None`) — fall back to the mutation's
+/// [`effective_local_deletion_time`](crate::storage::write_engine::mutation::Mutation::effective_local_deletion_time),
+/// preserving the historical behavior (WAL / CQL-DELETE paths, row-derived LDT).
+/// Choose the `localDeletionTime` the cell/row tombstone of `op` is actually
+/// emitted with.
+///
+/// A `CellOperation::Delete { local_deletion_time: Some(ldt), .. }` carries an
+/// explicit per-cell LDT (#921 finding 2) that the DataWriter stamps VERBATIM;
+/// every other op (a `Delete` without a per-cell LDT, or a `DeleteRow`) derives
+/// the LDT from the enclosing mutation. The SSTable writer's STATS/baseline
+/// collection MUST record this exact value (not just
+/// `mutation.effective_local_deletion_time()`), otherwise a per-cell LDT below
+/// the mutation-derived value underflows the Data.db delta encoding, and one
+/// above it leaves Statistics.db min/max/histogram describing a tombstone that
+/// was never written (#921 finding 2 — roborev Medium).
+pub(crate) fn op_cell_local_deletion_time(
+    op: &crate::storage::write_engine::mutation::CellOperation,
+    mutation: &Mutation,
+) -> i32 {
+    use crate::storage::write_engine::mutation::CellOperation;
+    match op {
+        CellOperation::Delete {
+            local_deletion_time: Some(ldt),
+            ..
+        } => *ldt,
+        _ => mutation.effective_local_deletion_time(),
     }
 }
 
@@ -4335,7 +4377,7 @@ fn is_static_row_mutation(mutation: &Mutation, schema: &TableSchema) -> bool {
     mutation.operations.iter().all(|operation| match operation {
         crate::storage::write_engine::mutation::CellOperation::Write { column, .. }
         | crate::storage::write_engine::mutation::CellOperation::WriteWithTtl { column, .. }
-        | crate::storage::write_engine::mutation::CellOperation::Delete { column }
+        | crate::storage::write_engine::mutation::CellOperation::Delete { column, .. }
         | crate::storage::write_engine::mutation::CellOperation::WriteComplexElement {
             column,
             ..
@@ -4360,7 +4402,7 @@ fn is_static_operation(
     match op {
         crate::storage::write_engine::mutation::CellOperation::Write { column, .. }
         | crate::storage::write_engine::mutation::CellOperation::WriteWithTtl { column, .. }
-        | crate::storage::write_engine::mutation::CellOperation::Delete { column }
+        | crate::storage::write_engine::mutation::CellOperation::Delete { column, .. }
         | crate::storage::write_engine::mutation::CellOperation::WriteComplexElement {
             column,
             ..
@@ -4438,9 +4480,9 @@ fn collect_static_operations(
                     column,
                     ..
                 }
-                | crate::storage::write_engine::mutation::CellOperation::Delete { column } => {
-                    column.clone()
-                }
+                | crate::storage::write_engine::mutation::CellOperation::Delete {
+                    column, ..
+                } => column.clone(),
                 // Per-element complex ops (epic #899) are not produced for STATIC
                 // complex columns by the (Phase B) capability — they flow through
                 // the regular-row per-element path. Skip them here defensively.
@@ -4453,9 +4495,11 @@ fn collect_static_operations(
                 crate::storage::write_engine::mutation::CellOperation::DeleteRow => continue,
             };
             let candidate = StaticMergedOp {
+                // #921 finding 2: preserve a `Delete` cell tombstone's own surfaced
+                // LDT; other ops fall back to the mutation's effective LDT.
+                cell_local_deletion_time: op_cell_local_deletion_time(op, mutation),
                 op: op.clone(),
                 timestamp_micros: mutation.timestamp_micros,
-                cell_local_deletion_time: mutation.effective_local_deletion_time(),
             };
             match best.entry(col_name) {
                 std::collections::hash_map::Entry::Vacant(entry) => {
@@ -4704,7 +4748,7 @@ mod tests {
             .filter_map(|m| match m.op {
                 CellOperation::Write { column, .. }
                 | CellOperation::WriteWithTtl { column, .. }
-                | CellOperation::Delete { column }
+                | CellOperation::Delete { column, .. }
                 | CellOperation::WriteComplexElement { column, .. }
                 | CellOperation::ComplexDeletion { column, .. } => Some(column.clone()),
                 CellOperation::DeleteRow => None,
@@ -7815,6 +7859,7 @@ mod tests {
                 None,
                 vec![CellOperation::Delete {
                     column: "tags".to_string(),
+                    local_deletion_time: None,
                 }],
                 2_000_000,
                 None,
@@ -7937,6 +7982,7 @@ mod tests {
             None,
             vec![CellOperation::Delete {
                 column: "tags".to_string(),
+                local_deletion_time: None,
             }],
             1001000,
             None,
@@ -8466,6 +8512,7 @@ mod tests {
             vec![
                 CellOperation::Delete {
                     column: "age".to_string(),
+                    local_deletion_time: None,
                 },
                 CellOperation::Write {
                     column: "name".to_string(),
@@ -8536,6 +8583,7 @@ mod tests {
             None,
             vec![CellOperation::Delete {
                 column: "age".to_string(),
+                local_deletion_time: None,
             }],
             1001000,
             None,
@@ -10727,6 +10775,7 @@ mod tests {
             None,
             vec![CellOperation::Delete {
                 column: "tags".to_string(),
+                local_deletion_time: None,
             }],
             A_DELETE_TS,
             None,
@@ -10784,7 +10833,7 @@ mod tests {
         assert!(
             row.ops.iter().any(|mop| matches!(
                 mop.op,
-                CellOperation::Delete { column } if column == "tags"
+                CellOperation::Delete { column, .. } if column == "tags"
             )),
             "column A's whole-column Delete must survive"
         );

--- a/cqlite-core/src/storage/sstable/writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/mod.rs
@@ -547,11 +547,21 @@ impl SSTableWriter {
                         let local_deletion_time = now_seconds.saturating_add(*ttl_seconds as i32);
                         self.stats.update_local_deletion_time(local_deletion_time);
                     }
-                    crate::storage::write_engine::mutation::CellOperation::Delete { .. }
-                    | crate::storage::write_engine::mutation::CellOperation::DeleteRow => {
-                        // Issue #764: honor the explicit local_deletion_time if
-                        // the mutation supplied one, else derive from timestamp.
-                        let local_deletion_time = mutation.effective_local_deletion_time();
+                    op @ (crate::storage::write_engine::mutation::CellOperation::Delete { .. }
+                    | crate::storage::write_engine::mutation::CellOperation::DeleteRow) => {
+                        // Issue #764 / #921 finding 2: record the EXACT LDT the
+                        // tombstone is emitted with. A `Delete` carrying a per-cell
+                        // `local_deletion_time: Some(L)` is stamped with `L`
+                        // verbatim by DataWriter; everything else derives the LDT
+                        // from the mutation. Reuse `op_cell_local_deletion_time`
+                        // (the emit path's helper) so stats and the bytes written
+                        // to Data.db agree exactly — a per-cell `L` below the
+                        // mutation-derived value would otherwise underflow the
+                        // delta, and one above it would leave min/max wrong.
+                        let local_deletion_time =
+                            crate::storage::sstable::writer::data_writer::op_cell_local_deletion_time(
+                                op, mutation,
+                            );
                         self.stats.update_local_deletion_time(local_deletion_time);
                     }
                     // Issue #887: a `ComplexDeletion` marker is physically written
@@ -821,12 +831,19 @@ impl SSTableWriter {
                             min_ldt = min_ldt.min(ldt);
                         }
                     }
-                    crate::storage::write_engine::mutation::CellOperation::Delete { .. }
-                    | crate::storage::write_engine::mutation::CellOperation::DeleteRow => {
-                        // Issue #764: the encoding baseline must match the LDT the
-                        // row/cell tombstone will actually be written with, else the
-                        // delta underflows for an explicit LDT below the timestamp.
-                        let ldt = mutation.effective_local_deletion_time();
+                    op @ (crate::storage::write_engine::mutation::CellOperation::Delete { .. }
+                    | crate::storage::write_engine::mutation::CellOperation::DeleteRow) => {
+                        // Issue #764 / #921 finding 2: the encoding baseline must
+                        // match the LDT the row/cell tombstone will ACTUALLY be
+                        // written with, else the delta underflows. A `Delete` with
+                        // a per-cell `local_deletion_time: Some(L)` is emitted with
+                        // `L` verbatim; reuse the emit path's
+                        // `op_cell_local_deletion_time` helper so the pre-seeded
+                        // baseline always covers the smallest LDT actually written.
+                        let ldt =
+                            crate::storage::sstable::writer::data_writer::op_cell_local_deletion_time(
+                                op, mutation,
+                            );
                         min_ldt = min_ldt.min(ldt);
                     }
                     // Issue #887: the pre-seeded baseline path must fold the SAME
@@ -2005,6 +2022,103 @@ mod tests {
         assert_eq!(
             min_ttl, 600,
             "baseline min_ttl must reflect the per-element TTL"
+        );
+    }
+
+    /// #921 finding 2 (roborev Medium): a `CellOperation::Delete` carrying an
+    /// explicit per-cell `local_deletion_time: Some(L)` is stamped with `L`
+    /// VERBATIM by `DataWriter` (via `op_cell_local_deletion_time`). The writer's
+    /// STATS collection must record that SAME `L`, not just
+    /// `mutation.effective_local_deletion_time()`:
+    ///   * an `L` BELOW the mutation-derived value must (a) let the Data.db write
+    ///     SUCCEED (no LDT-below-baseline delta underflow) and (b) lower
+    ///     `min_local_deletion_time` to `L`;
+    ///   * an `L` ABOVE the mutation-derived value must lift
+    ///     `max_local_deletion_time` to `L`.
+    /// RED before the fix: stats used the mutation LDT only, so the lower-`L`
+    /// tombstone underflowed the baseline (write fails) and min/max were wrong.
+    #[tokio::test]
+    async fn test_per_cell_delete_ldt_drives_stats_and_write() {
+        let temp_dir = TempDir::new().unwrap();
+        let schema = create_test_schema();
+        let mut writer = SSTableWriter::new(temp_dir.path().to_path_buf(), 1, &schema).unwrap();
+
+        // Mutation timestamp 5_000_000 micros => effective LDT = 5 seconds.
+        // Per-cell LDTs straddle that: 2 (below) and 9_000 (above).
+        const ROW_TS_MICROS: i64 = 5_000_000;
+        const LOWER_LDT: i32 = 2;
+        const HIGHER_LDT: i32 = 9_000;
+
+        let table_id = TableId::new("test_ks", "test_table");
+        let pk = PartitionKey::single("id", Value::Integer(7));
+        let mutation = Mutation::new(
+            table_id,
+            pk,
+            None,
+            vec![
+                CellOperation::Delete {
+                    column: "name".to_string(),
+                    local_deletion_time: Some(LOWER_LDT),
+                },
+                CellOperation::Delete {
+                    column: "name".to_string(),
+                    local_deletion_time: Some(HIGHER_LDT),
+                },
+            ],
+            ROW_TS_MICROS,
+            None,
+        );
+        let key = mutation.decorated_key(&schema).unwrap();
+
+        // (a) The write must SUCCEED: the per-cell LDT of 2 is below the
+        // mutation-derived baseline of 5, so if stats recorded 5 the Data.db
+        // delta (cell LDT 2 - baseline 5) underflows and the write errors.
+        writer
+            .write_partition(key, vec![mutation])
+            .expect("per-cell Delete LDT below the mutation LDT must not underflow the baseline");
+
+        // (b) Stats must describe the tombstones actually written.
+        assert_eq!(
+            writer.stats.min_local_deletion_time, LOWER_LDT,
+            "min_local_deletion_time must reflect the lower per-cell Delete LDT"
+        );
+        assert_eq!(
+            writer.stats.max_local_deletion_time, HIGHER_LDT,
+            "max_local_deletion_time must reflect the higher per-cell Delete LDT"
+        );
+
+        let _info = writer.finish().await.unwrap();
+    }
+
+    /// #921 finding 2: the PRE-SEEDED baseline path
+    /// (`compute_mutations_baseline_stats`, issue #729 two-pass flush) must lock
+    /// `min_local_deletion_time` to the EXACT LDT the tombstone is written with.
+    /// A per-cell `Delete` LDT below the mutation-derived value must drag the
+    /// baseline down to it, else the locked delta underflows at write time.
+    #[test]
+    fn test_compute_baseline_uses_per_cell_delete_ldt() {
+        let table_id = TableId::new("test_ks", "test_table");
+        let pk = PartitionKey::single("id", Value::Integer(7));
+
+        // Mutation LDT = 5 (5_000_000 micros). Per-cell LDT of 2 is lower.
+        let mutation = Mutation::new(
+            table_id,
+            pk,
+            None,
+            vec![CellOperation::Delete {
+                column: "name".to_string(),
+                local_deletion_time: Some(2),
+            }],
+            5_000_000,
+            None,
+        );
+
+        let (_min_ts, min_ldt, _min_ttl) =
+            SSTableWriter::compute_mutations_baseline_stats(std::slice::from_ref(&mutation));
+
+        assert_eq!(
+            min_ldt, 2,
+            "baseline min_ldt must reflect the per-cell Delete LDT (2), not the mutation LDT (5)"
         );
     }
 

--- a/cqlite-core/src/storage/sstable/writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/mod.rs
@@ -554,7 +554,47 @@ impl SSTableWriter {
                         let local_deletion_time = mutation.effective_local_deletion_time();
                         self.stats.update_local_deletion_time(local_deletion_time);
                     }
-                    _ => {}
+                    // Issue #887: a `ComplexDeletion` marker is physically written
+                    // with its OWN `marked_for_delete_at` / `local_deletion_time`
+                    // (DataWriter delta-encodes both against `min_timestamp` /
+                    // `min_local_deletion_time`). The mutation's row timestamp does
+                    // NOT cover the marker — for a tombstone-only row whose marker
+                    // strictly supersedes the row tombstone, `marked_for_delete_at`
+                    // can lie ABOVE the row timestamp and the marker LDT below the
+                    // row's LDT. Fold both into the stats so `max_timestamp` /
+                    // `min_local_deletion_time` reflect what was actually emitted to
+                    // Data.db (LIVE sentinels are filtered inside the `update_*`
+                    // chokepoints, issue #851).
+                    crate::storage::write_engine::mutation::CellOperation::ComplexDeletion {
+                        marked_for_delete_at,
+                        local_deletion_time,
+                        ..
+                    } => {
+                        self.stats.update_timestamp(*marked_for_delete_at);
+                        self.stats.update_local_deletion_time(*local_deletion_time);
+                    }
+                    // Issue #887: a per-element complex cell carries its OWN explicit
+                    // timestamp/ttl/local_deletion_time (DataWriter delta-encodes each
+                    // against the SSTable baselines). The element timestamp can differ
+                    // from the row liveness timestamp, and a deleted/expiring element
+                    // supplies an LDT/TTL the row-level accumulation never sees. Fold
+                    // them all in so the baselines cover every byte emitted by
+                    // `write_complex_element_cell`.
+                    crate::storage::write_engine::mutation::CellOperation::WriteComplexElement {
+                        timestamp_micros,
+                        ttl_seconds,
+                        local_deletion_time,
+                        ..
+                    } => {
+                        self.stats.update_timestamp(*timestamp_micros);
+                        if let Some(ttl) = ttl_seconds {
+                            self.stats.update_ttl(*ttl as i32);
+                        }
+                        if let Some(ldt) = local_deletion_time {
+                            self.stats.update_local_deletion_time(*ldt);
+                        }
+                    }
+                    crate::storage::write_engine::mutation::CellOperation::Write { .. } => {}
                 }
             }
             // Track stats for partition tombstones
@@ -789,7 +829,53 @@ impl SSTableWriter {
                         let ldt = mutation.effective_local_deletion_time();
                         min_ldt = min_ldt.min(ldt);
                     }
-                    _ => {}
+                    // Issue #887: the pre-seeded baseline path must fold the SAME
+                    // marker timestamps/LDTs the DataWriter delta-encodes (it
+                    // subtracts `min_timestamp` / `min_local_deletion_time` from
+                    // `marked_for_delete_at` and the element LDT). A
+                    // `ComplexDeletion`/`WriteComplexElement` carrying a timestamp or
+                    // LDT BELOW the mutation's own values would make the delta
+                    // underflow when baselines are locked — exactly what #729's
+                    // two-pass flush is meant to prevent. Mirror the non-pre-seeded
+                    // accumulation in `write_partition`.
+                    crate::storage::write_engine::mutation::CellOperation::ComplexDeletion {
+                        marked_for_delete_at,
+                        local_deletion_time,
+                        ..
+                    } => {
+                        // Exclude LIVE / NO_DELETION sentinels exactly as the
+                        // `update_*` chokepoints do (issue #851), so a sentinel
+                        // marker cannot drag the min baselines to `i64::MIN` /
+                        // `i32::MAX`.
+                        if *marked_for_delete_at != i64::MIN && *marked_for_delete_at != i64::MAX {
+                            min_timestamp = min_timestamp.min(*marked_for_delete_at);
+                        }
+                        if *local_deletion_time != i32::MAX {
+                            min_ldt = min_ldt.min(*local_deletion_time);
+                        }
+                    }
+                    crate::storage::write_engine::mutation::CellOperation::WriteComplexElement {
+                        timestamp_micros,
+                        ttl_seconds,
+                        local_deletion_time,
+                        ..
+                    } => {
+                        if *timestamp_micros != i64::MIN && *timestamp_micros != i64::MAX {
+                            min_timestamp = min_timestamp.min(*timestamp_micros);
+                        }
+                        if let Some(ttl) = ttl_seconds {
+                            let ttl = *ttl as i32;
+                            if ttl > 0 {
+                                min_ttl = min_ttl.min(ttl);
+                            }
+                        }
+                        if let Some(ldt) = local_deletion_time {
+                            if *ldt != i32::MAX {
+                                min_ldt = min_ldt.min(*ldt);
+                            }
+                        }
+                    }
+                    crate::storage::write_engine::mutation::CellOperation::Write { .. } => {}
                 }
             }
 
@@ -1721,6 +1807,205 @@ mod tests {
         assert_eq!(writer.stats.partition_count, 3);
 
         let _info = writer.finish().await.unwrap();
+    }
+
+    /// A schema with one partition key, one clustering key, and a non-frozen
+    /// `set<text>` regular column `tags` (a complex/multi-cell column). Used by the
+    /// issue #887 complex-deletion / per-element stats regressions.
+    fn create_complex_schema() -> TableSchema {
+        TableSchema {
+            keyspace: "test_ks".to_string(),
+            table: "test_complex".to_string(),
+            partition_keys: vec![KeyColumn {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![ClusteringColumn {
+                name: "ck".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+                order: Default::default(),
+            }],
+            columns: vec![
+                Column {
+                    name: "id".to_string(),
+                    data_type: "int".to_string(),
+                    nullable: false,
+                    default: None,
+                    is_static: false,
+                },
+                Column {
+                    name: "ck".to_string(),
+                    data_type: "int".to_string(),
+                    nullable: false,
+                    default: None,
+                    is_static: false,
+                },
+                Column {
+                    name: "tags".to_string(),
+                    data_type: "set<text>".to_string(),
+                    nullable: true,
+                    default: None,
+                    is_static: false,
+                },
+            ],
+            comments: std::collections::HashMap::new(),
+            dropped_columns: std::collections::HashMap::new(),
+        }
+    }
+
+    /// Issue #887: a tombstone-only row that ALSO carries a surviving complex-deletion
+    /// marker (its `marked_for_delete_at` strictly supersedes the row tombstone) must
+    /// fold the marker's OWN `marked_for_delete_at` / `local_deletion_time` into the
+    /// SSTable stats. The DataWriter delta-encodes the marker against `min_timestamp`
+    /// / `min_local_deletion_time`, so if the stats only saw the row tombstone's
+    /// timestamp/LDT the marker's bytes would be encoded against a baseline that
+    /// Statistics.db never advertises.
+    #[tokio::test]
+    async fn test_complex_deletion_marker_folds_into_stats() {
+        let temp_dir = TempDir::new().unwrap();
+        let schema = create_complex_schema();
+        let mut writer = SSTableWriter::new(temp_dir.path().to_path_buf(), 1, &schema).unwrap();
+
+        let table_id = TableId::new("test_ks", "test_complex");
+        let pk = PartitionKey::single("id", Value::Integer(1));
+        let ck = ClusteringKey::single("ck", Value::Integer(1));
+        let mutation = Mutation::new(
+            table_id,
+            pk,
+            Some(ck),
+            vec![
+                CellOperation::DeleteRow,
+                CellOperation::ComplexDeletion {
+                    column: "tags".to_string(),
+                    marked_for_delete_at: 9_000_000,
+                    local_deletion_time: 1_500,
+                },
+            ],
+            5_000_000,
+            None,
+        )
+        .with_local_deletion_time(1_700);
+        let key = mutation.decorated_key(&schema).unwrap();
+
+        writer.write_partition(key, vec![mutation]).unwrap();
+
+        assert_eq!(
+            writer.stats.max_timestamp, 9_000_000,
+            "complex-deletion marked_for_delete_at must lift max_timestamp above the row timestamp"
+        );
+        assert_eq!(
+            writer.stats.min_local_deletion_time, 1_500,
+            "complex-deletion local_deletion_time must lower min_local_deletion_time below the row LDT"
+        );
+
+        let _info = writer.finish().await.unwrap();
+    }
+
+    /// Issue #887: a per-element complex cell carries its OWN timestamp/ttl/
+    /// local_deletion_time, which the DataWriter delta-encodes against the SSTable
+    /// baselines. A `WriteComplexElement`-only row must fold all three into the stats.
+    #[tokio::test]
+    async fn test_write_complex_element_folds_into_stats() {
+        let temp_dir = TempDir::new().unwrap();
+        let schema = create_complex_schema();
+        let mut writer = SSTableWriter::new(temp_dir.path().to_path_buf(), 1, &schema).unwrap();
+
+        let table_id = TableId::new("test_ks", "test_complex");
+        let pk = PartitionKey::single("id", Value::Integer(2));
+        let ck = ClusteringKey::single("ck", Value::Integer(1));
+        let mutation = Mutation::new(
+            table_id,
+            pk,
+            Some(ck),
+            vec![CellOperation::WriteComplexElement {
+                column: "tags".to_string(),
+                cell_path: b"hot".to_vec(),
+                value: None,
+                timestamp_micros: 9_500_000,
+                ttl_seconds: Some(4_200),
+                local_deletion_time: Some(1_400),
+                is_deleted: false,
+            }],
+            3_000_000,
+            None,
+        );
+        let key = mutation.decorated_key(&schema).unwrap();
+
+        writer.write_partition(key, vec![mutation]).unwrap();
+
+        assert_eq!(
+            writer.stats.max_timestamp, 9_500_000,
+            "per-element timestamp must lift max_timestamp above the row timestamp"
+        );
+        assert_eq!(
+            writer.stats.min_ttl, 4_200,
+            "per-element TTL must populate min_ttl"
+        );
+        assert_eq!(
+            writer.stats.max_ttl, 4_200,
+            "per-element TTL must populate max_ttl"
+        );
+        assert_eq!(
+            writer.stats.min_local_deletion_time, 1_400,
+            "per-element local_deletion_time must populate min_local_deletion_time"
+        );
+
+        let _info = writer.finish().await.unwrap();
+    }
+
+    /// Issue #887: the PRE-SEEDED baseline path (`compute_mutations_baseline_stats`,
+    /// issue #729 two-pass flush) must fold the same marker/element timestamps the
+    /// DataWriter delta-encodes. A marker LDT or element ts/ttl BELOW the mutation's
+    /// own values would otherwise underflow the locked delta baseline.
+    #[test]
+    fn test_compute_baseline_folds_complex_ops() {
+        let table_id = TableId::new("test_ks", "test_complex");
+        let pk = PartitionKey::single("id", Value::Integer(1));
+        let ck = ClusteringKey::single("ck", Value::Integer(1));
+
+        let mutation = Mutation::new(
+            table_id,
+            pk,
+            Some(ck),
+            vec![
+                CellOperation::DeleteRow,
+                CellOperation::ComplexDeletion {
+                    column: "tags".to_string(),
+                    marked_for_delete_at: 9_000_000,
+                    local_deletion_time: 1_500,
+                },
+                CellOperation::WriteComplexElement {
+                    column: "tags".to_string(),
+                    cell_path: b"warm".to_vec(),
+                    value: None,
+                    timestamp_micros: 2_000_000,
+                    ttl_seconds: Some(600),
+                    local_deletion_time: Some(1_300),
+                    is_deleted: false,
+                },
+            ],
+            5_000_000,
+            None,
+        )
+        .with_local_deletion_time(1_700);
+
+        let (min_ts, min_ldt, min_ttl) =
+            SSTableWriter::compute_mutations_baseline_stats(std::slice::from_ref(&mutation));
+
+        assert_eq!(
+            min_ts, 2_000_000,
+            "baseline min_timestamp must reflect the per-element timestamp below the row ts"
+        );
+        assert_eq!(
+            min_ldt, 1_300,
+            "baseline min_ldt must reflect the lowest complex LDT (the element's 1_300)"
+        );
+        assert_eq!(
+            min_ttl, 600,
+            "baseline min_ttl must reflect the per-element TTL"
+        );
     }
 
     #[tokio::test]

--- a/cqlite-core/src/storage/write_engine/cql_to_mutation.rs
+++ b/cqlite-core/src/storage/write_engine/cql_to_mutation.rs
@@ -654,6 +654,9 @@ pub(crate) fn delete_to_mutation(
             .iter()
             .map(|col_id| CellOperation::Delete {
                 column: col_id.name.clone(),
+                // CQL DELETE has no per-cell surfaced LDT; the writer derives it
+                // from the mutation timestamp (historical behavior, #921 finding 2).
+                local_deletion_time: None,
             })
             .collect()
     };
@@ -2658,10 +2661,10 @@ mod tests {
         let mutation = delete_to_mutation(&delete, &schema).unwrap();
         assert_eq!(mutation.operations.len(), 2);
         assert!(
-            matches!(&mutation.operations[0], CellOperation::Delete { column } if column == "name")
+            matches!(&mutation.operations[0], CellOperation::Delete { column, .. } if column == "name")
         );
         assert!(
-            matches!(&mutation.operations[1], CellOperation::Delete { column } if column == "age")
+            matches!(&mutation.operations[1], CellOperation::Delete { column, .. } if column == "age")
         );
     }
 

--- a/cqlite-core/src/storage/write_engine/memtable.rs
+++ b/cqlite-core/src/storage/write_engine/memtable.rs
@@ -264,7 +264,7 @@ impl Memtable {
                 // TTL cells: same as Write + 4 bytes for TTL + 4 bytes for local_deletion_time
                 column.len() + Self::estimate_value_size(value) + 16
             }
-            CellOperation::Delete { column } => column.len() + 8,
+            CellOperation::Delete { column, .. } => column.len() + 8,
             CellOperation::DeleteRow => 8,
             // Epic #899: per-element complex ops. Each carries a column name,
             // the preserved cell path, an optional value, and temporal metadata.

--- a/cqlite-core/src/storage/write_engine/merge.rs
+++ b/cqlite-core/src/storage/write_engine/merge.rs
@@ -1865,6 +1865,42 @@ impl KWayMerger {
             crate::types::Value::Tombstone(ref info)
                 if info.tombstone_type == crate::types::TombstoneType::CellTombstone
         )
+            // Complex-element tombstones carry their delete via the IS_DELETED
+            // (0x01) flag (epic #899); their value is wrapped as a CellTombstone in
+            // `compaction_row_data_to_row_data`, so the `matches!` above already
+            // covers them. Keep `is_deleted` as a belt-and-braces signal so a
+            // future element representation that sets the flag without the wrapped
+            // value still counts as a deletion for the tie-break.
+            || cell.is_deleted
+    }
+
+    /// Per-cell winner resolution mirroring Cassandra `Cells#reconcile`
+    /// (parity commit `a62c749`): returns `true` when `candidate` should replace
+    /// the current `existing` winner.
+    ///
+    /// Ordering (decided IN THIS ORDER, short-circuiting):
+    /// 1. **timestamp** — a strictly higher write timestamp always wins.
+    /// 2. **deletion vs live/expiring at EQUAL timestamp** — a cell DELETION
+    ///    (tombstone) beats a LIVE or EXPIRING (TTL) cell. This is decided
+    ///    *before* any `localDeletionTime` comparison, so an expiring cell can
+    ///    never resurrect data over a same-timestamp tombstone just because its
+    ///    TTL expiry instant is later (issue #848 / #498). `is_cell_tombstone`
+    ///    treats an expiring cell as LIVE (it carries a real value + a TTL, not a
+    ///    `CellTombstone`), so this single rule subsumes both
+    ///    tombstone-beats-live and tombstone-beats-expiring.
+    /// 3. **equal timestamp + equal liveness** — keep the first-seen (newer file)
+    ///    winner. `reconcile_cluster` only calls this for a later-seen candidate,
+    ///    so returning `false` preserves first-seen order deterministically.
+    ///    `localDeletionTime` is intentionally NOT a discriminator here: at equal
+    ///    ts + equal deletion-status the cells are equivalent and first-seen order
+    ///    is the stable choice.
+    fn cell_reconcile_replace(candidate: &CellData, existing: &CellData) -> bool {
+        if candidate.timestamp != existing.timestamp {
+            return candidate.timestamp > existing.timestamp;
+        }
+        // Equal timestamp: deletion wins over a live/expiring cell, BEFORE any
+        // localDeletionTime compare (parity `a62c749`).
+        Self::is_cell_tombstone(candidate) && !Self::is_cell_tombstone(existing)
     }
 
     /// Reconcile all entries for a single clustering-key group into at most one
@@ -1957,15 +1993,13 @@ impl KWayMerger {
                             }
                             Some(existing) => {
                                 // Higher timestamp wins. At EQUAL timestamp a cell
-                                // tombstone beats a live value (Issue #498 per
-                                // cell). At EQUAL timestamp + liveness, break ties
-                                // by value bytes for determinism, else keep the
-                                // first-seen (newer file) winner.
-                                let replace = cell.timestamp > existing.timestamp
-                                    || (cell.timestamp == existing.timestamp
-                                        && Self::is_cell_tombstone(cell)
-                                        && !Self::is_cell_tombstone(existing));
-                                if replace {
+                                // DELETION (tombstone) beats a LIVE or EXPIRING
+                                // (TTL) cell, decided BEFORE any localDeletionTime
+                                // compare (parity Cassandra `a62c749`,
+                                // `Cells#reconcile`; issue #848 / #498). At equal ts
+                                // + equal deletion-status, keep the first-seen
+                                // (newer file) winner. See `cell_reconcile_replace`.
+                                if Self::cell_reconcile_replace(cell, existing) {
                                     winners.insert(cell_key, cell.clone());
                                 }
                             }
@@ -5352,6 +5386,152 @@ mod issue_823_complex_column_merge {
             }
         }
     }
+
+    // ── Issue #848 (Epic #921): tombstone-vs-expiring(TTL) tie-break ──────────
+    //
+    // Parity Cassandra `a62c749` (`Cells#reconcile`): at EQUAL timestamp a cell
+    // DELETION wins over a LIVE/expiring cell, decided BEFORE any
+    // `localDeletionTime` compare. `main` carries `ttl`/`local_deletion_time` on
+    // `CellData` (now populated for simple cells via SimpleCell), so an expiring
+    // cell at equal ts must NOT resurrect data over a same-ts cell tombstone.
+
+    /// Build a single-cell expiring (TTL) `CellData` for column `v`.
+    fn expiring_cell(value: &str, ts: i64, ttl: u32, ldt: i32) -> CellData {
+        CellData {
+            column: "v".to_string(),
+            value: Value::Text(value.to_string()),
+            timestamp: ts,
+            ttl: Some(ttl),
+            cell_path: None,
+            local_deletion_time: Some(ldt),
+            is_complex_element: false,
+            is_deleted: false,
+            has_empty_value: false,
+        }
+    }
+
+    /// Build a single-cell tombstone `CellData` for column `v`.
+    fn cell_tombstone(ts: i64, ldt: i32) -> CellData {
+        CellData {
+            column: "v".to_string(),
+            value: Value::Tombstone(TombstoneInfo {
+                deletion_time: ts,
+                tombstone_type: TombstoneType::CellTombstone,
+                local_deletion_time: ldt as i64,
+                ttl: None,
+                range_start: None,
+                range_end: None,
+            }),
+            timestamp: ts,
+            ttl: None,
+            cell_path: None,
+            local_deletion_time: Some(ldt),
+            is_complex_element: false,
+            is_deleted: false,
+            has_empty_value: false,
+        }
+    }
+
+    /// At equal timestamp the cell tombstone beats an expiring cell — EXPIRING
+    /// arrives FIRST (newer run_index) so a naive recency/first-seen pick would
+    /// resurrect it. The tombstone must still win (parity `a62c749`).
+    #[test]
+    fn issue_848_tombstone_beats_expiring_at_equal_ts_expiring_first() {
+        const TS: i64 = 200;
+        // EXPIRING cell carries a LARGER localDeletionTime than the tombstone, so
+        // a (wrong) localDeletionTime-first tie-break would pick the expiring
+        // cell. The deletion must be decided BEFORE that compare.
+        let expiring = live(
+            0,
+            TS,
+            vec![expiring_cell("resurrected-if-buggy", TS, 3600, 9_999)],
+        );
+        let tombstone = live(1, TS, vec![cell_tombstone(TS, 1_000)]);
+
+        let merged = KWayMerger::reconcile_cluster(
+            None,
+            vec![expiring, tombstone],
+            &::std::collections::HashMap::new(),
+        )
+        .expect("a row must be emitted");
+
+        let cells = match merged.row_data {
+            RowData::Live { cells } => cells,
+            other => panic!("expected Live, got {:?}", other),
+        };
+        assert_eq!(cells.len(), 1, "single column `v`");
+        assert!(
+            KWayMerger::is_cell_tombstone(&cells[0]),
+            "at equal ts the cell TOMBSTONE must win over the expiring cell \
+             (before any localDeletionTime compare); got {:?}",
+            cells[0].value
+        );
+        assert!(
+            cells[0].ttl.is_none(),
+            "the surviving winner is the tombstone, which carries no TTL"
+        );
+    }
+
+    /// Same equal-ts tie-break with the source order REVERSED — tombstone arrives
+    /// FIRST. The tombstone must still win (order-independence; the existing
+    /// `tombstone beats live` rule already covered this, pinned here too).
+    #[test]
+    fn issue_848_tombstone_beats_expiring_at_equal_ts_tombstone_first() {
+        const TS: i64 = 200;
+        let tombstone = live(0, TS, vec![cell_tombstone(TS, 1_000)]);
+        let expiring = live(
+            1,
+            TS,
+            vec![expiring_cell("resurrected-if-buggy", TS, 3600, 9_999)],
+        );
+
+        let merged = KWayMerger::reconcile_cluster(
+            None,
+            vec![tombstone, expiring],
+            &::std::collections::HashMap::new(),
+        )
+        .expect("a row must be emitted");
+
+        let cells = match merged.row_data {
+            RowData::Live { cells } => cells,
+            other => panic!("expected Live, got {:?}", other),
+        };
+        assert_eq!(cells.len(), 1, "single column `v`");
+        assert!(
+            KWayMerger::is_cell_tombstone(&cells[0]),
+            "at equal ts the cell TOMBSTONE must win regardless of source order; \
+             got {:?}",
+            cells[0].value
+        );
+    }
+
+    /// A STRICTLY NEWER expiring cell still beats an older tombstone — the
+    /// tie-break only fires at EQUAL timestamp, so timestamp recency is honored
+    /// first (parity `a62c749`: timestamp compared before deletion-status).
+    #[test]
+    fn issue_848_newer_expiring_beats_older_tombstone() {
+        let tombstone = live(0, 100, vec![cell_tombstone(100, 1_000)]);
+        let expiring = live(1, 200, vec![expiring_cell("survives", 200, 3600, 9_999)]);
+
+        let merged = KWayMerger::reconcile_cluster(
+            None,
+            vec![tombstone, expiring],
+            &::std::collections::HashMap::new(),
+        )
+        .expect("a row must be emitted");
+
+        let cells = match merged.row_data {
+            RowData::Live { cells } => cells,
+            other => panic!("expected Live, got {:?}", other),
+        };
+        assert_eq!(cells.len(), 1, "single column `v`");
+        assert!(
+            !KWayMerger::is_cell_tombstone(&cells[0]),
+            "a strictly NEWER expiring cell (ts=200) beats the older tombstone \
+             (ts=100); the deletion tie-break only fires at equal ts"
+        );
+        assert_eq!(cells[0].value, Value::Text("survives".to_string()));
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -7156,6 +7336,111 @@ mod issue_822_merge_ordering_semantics {
         assert_eq!(
             cell_flags, 0x05,
             "surviving cell tombstone must serialize as CELL_IS_DELETED|HAS_EMPTY \
+             (0x05); got {cell_flags:#04x}"
+        );
+    }
+
+    /// Issue #848: writer-path equal-ts tie-break, REVERSED source order. The
+    /// cell tombstone arrives FIRST, the expiring write SECOND (newer in
+    /// recency). The writer's `cells` LWW must still keep the tombstone — an
+    /// equal-ts expiring write does NOT supersede an existing cell tombstone
+    /// (parity `a62c749`). Pins the writer path agrees with `reconcile_cluster`
+    /// in BOTH source orders.
+    #[test]
+    fn issue_848_writer_tombstone_beats_expiring_tombstone_first() {
+        let schema = TableSchema {
+            keyspace: "issue_822".to_string(),
+            table: "tbl".to_string(),
+            partition_keys: vec![KeyColumn {
+                name: "pk".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![ClusteringColumn {
+                name: "ck".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+                order: ClusteringOrder::Asc,
+            }],
+            columns: vec![Column {
+                name: "v".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            }],
+            comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
+        };
+
+        const TS: i64 = 2_000_000;
+        let key = DecoratedKey::new(1, int_key_bytes(1));
+
+        let tombstone = Mutation::new(
+            TableId::new("issue_822", "tbl"),
+            PartitionKey::single("pk", Value::Integer(1)),
+            Some(ClusteringKey::single("ck", Value::Integer(7))),
+            vec![CellOperation::Delete {
+                column: "v".to_string(),
+            }],
+            TS,
+            None,
+        );
+        let expiring = Mutation::new(
+            TableId::new("issue_822", "tbl"),
+            PartitionKey::single("pk", Value::Integer(1)),
+            Some(ClusteringKey::single("ck", Value::Integer(7))),
+            vec![CellOperation::WriteWithTtl {
+                column: "v".to_string(),
+                value: Value::Text("expiring-if-buggy".to_string()),
+                ttl_seconds: 3600,
+            }],
+            TS,
+            None,
+        );
+
+        // Tombstone FIRST so a recency bug favoring the later expiring write
+        // would surface (the reverse of issue_3_tombstone_beats_expiring).
+        let mut w = DataWriter::new(writer_stats());
+        w.write_partition(&key, &[tombstone, expiring], &schema, None, &[])
+            .expect("write_partition must succeed");
+        let bytes = w.finish().expect("finish must succeed");
+
+        let mut p = INT_PK_HEADER_SIZE;
+        let row_flags = bytes[p];
+        p += 1;
+        assert_eq!(
+            row_flags & ROW_HAS_ALL_COLUMNS,
+            0,
+            "a surviving cell tombstone forces a column subset/bitmap"
+        );
+        // Clustering prefix: 1 header byte + 4 int value bytes.
+        p += 1 + 4;
+        let (_row_size, rs_len) = read_vuint(&bytes, p);
+        p += rs_len;
+        let (_prev_size, ps_len) = read_vuint(&bytes, p);
+        p += ps_len;
+        let (_ts_delta, ts_len) = read_vuint(&bytes, p);
+        p += ts_len;
+        let (_bitmap, bm_len) = read_vuint(&bytes, p);
+        p += bm_len;
+
+        let cell_flags = bytes[p];
+        assert_ne!(
+            cell_flags & CELL_IS_DELETED,
+            0,
+            "tombstone-first: at equal ts the cell tombstone must still win \
+             (CELL_IS_DELETED set). Flags byte = {cell_flags:#04x}"
+        );
+        assert_eq!(
+            cell_flags & CELL_IS_EXPIRING,
+            0,
+            "the surviving tombstone must NOT carry CELL_IS_EXPIRING. \
+             Flags byte = {cell_flags:#04x}"
+        );
+        assert_eq!(
+            cell_flags, 0x05,
+            "surviving cell tombstone serializes as CELL_IS_DELETED|HAS_EMPTY \
              (0x05); got {cell_flags:#04x}"
         );
     }

--- a/cqlite-core/src/storage/write_engine/merge.rs
+++ b/cqlite-core/src/storage/write_engine/merge.rs
@@ -951,9 +951,10 @@ impl SSTableRowIteratorAdapter {
     ///
     /// The real per-column complex deletion (`markedForDeleteAt` +
     /// `localDeletionTime`) is surfaced on `complex_deletions` so the writer
-    /// emits a REAL deletion marker (replacing the LIVE sentinel). Applying that
-    /// marker to SHADOW covered elements (strict-supersede, gc) is deferred to
-    /// #887/#845 — Phase C carries and emits the marker but does not shadow.
+    /// emits a REAL deletion marker (replacing the LIVE sentinel). `reconcile_cluster`
+    /// reduces these to the strict-superseding (max-mfda) deletion per column NAME
+    /// and SHADOWS covered elements (ts <= mfda) before purge (issue #887). gc_grace
+    /// purging of the surviving marker remains future work (#845).
     ///
     /// [`ComplexElement`]: crate::storage::sstable::reader::compaction_row::ComplexElement
     /// [`CellOperation::WriteComplexElement`]: crate::storage::write_engine::mutation::CellOperation::WriteComplexElement
@@ -1903,16 +1904,12 @@ impl KWayMerger {
         let mut order: Vec<CellKey> = Vec::new();
         let mut winners: HashMap<CellKey, CellData> = HashMap::new();
 
-        // Carried complex deletions (epic #899 substrate). PHASE A IS
-        // BEHAVIOR-NEUTRAL: we POPULATE `complex_deletions` (the foundation the
-        // writer will consume in Phase C) but reconcile MUST NOT act on them —
-        // no element shadowing, no strict-supersede filtering. Acting on them now
-        // would drop collection tombstones / element survivors and change the
-        // emitted bytes vs pre-Phase-A (roborev #863, Finding 2). The shadowing
-        // rule + writing the complex-deletion marker is deferred to Phase C
-        // (where the writer consumes it and differential parity verifies it).
-        // Accumulate as the pre-Phase-A simple union: first-seen order,
-        // de-duplicated.
+        // Carried complex deletions (epic #899 substrate). Accumulate the inputs'
+        // markers as a first-seen, de-duplicated union here; the strict-supersede
+        // reduction (one max-mfda deletion per column NAME) and shadow-before-purge
+        // (dropping covered elements) run in Step 2b AFTER per-cell winner resolution
+        // and BEFORE the row-tombstone / dropped-column filters (issue #887, parity
+        // Cassandra `bd244649` + `f66fa14f`).
         let mut complex_deletions: Vec<ComplexDeletion> = Vec::new();
         let mut range_deletion: Option<RangeTombstone> = None;
 
@@ -1980,6 +1977,80 @@ impl KWayMerger {
 
         let key = key?; // empty group => nothing to emit
 
+        // Step 2b: COMPLEX-DELETION reconcile — strict-supersede + shadow-before-purge
+        // (issue #887). This runs AFTER per-cell winner resolution and BEFORE the
+        // row-tombstone / dropped-column filters, so an element shadowed by a
+        // surviving complex deletion cannot be resurrected by a later purge of the
+        // deletion marker.
+        //
+        // 1. STRICT SUPERSEDE (parity Cassandra `bd244649`): per complex column the
+        //    ACTIVE deletion is the one with the greatest `marked_for_delete_at`. A
+        //    merged deletion supersedes the active one only when its mfda is STRICTLY
+        //    GREATER — EQUAL timestamps do NOT supersede. Reduce the carried
+        //    first-seen union to ONE deletion per column NAME (the strict max),
+        //    preserving first-seen column order for deterministic output. Matched BY
+        //    NAME (`ComplexDeletion.column`), never by header identity (consistent
+        //    with #888's match-by-name substrate).
+        //
+        // 2. SHADOW BEFORE PURGE (parity Cassandra `f66fa14f`): for the surviving
+        //    deletion on a column, drop every per-element winner of THAT column
+        //    (matched by NAME, only complex ELEMENTS carrying a `cell_path`) whose own
+        //    timestamp is `<= marked_for_delete_at`. The boundary mirrors the
+        //    cell-vs-deletion rule (#498): an element with ts STRICTLY GREATER than
+        //    mfda survives; `<=` is shadowed. A simple cell sharing the name is never
+        //    collapsed by a complex marker.
+        if !complex_deletions.is_empty() {
+            // Strict-supersede: collapse to the max-mfda deletion per column name.
+            let mut active: HashMap<String, ComplexDeletion> = HashMap::new();
+            let mut active_order: Vec<String> = Vec::new();
+            for cd in complex_deletions.drain(..) {
+                match active.get_mut(&cd.column) {
+                    None => {
+                        active_order.push(cd.column.clone());
+                        active.insert(cd.column.clone(), cd);
+                    }
+                    // STRICTLY GREATER supersedes; equal/lesser does NOT (bd244649).
+                    Some(existing) if cd.marked_for_delete_at > existing.marked_for_delete_at => {
+                        *existing = cd;
+                    }
+                    Some(_) => {}
+                }
+            }
+
+            // Shadow-before-purge: drop covered per-element winners of each column
+            // whose ts <= mfda (matched by NAME), so purging the marker later cannot
+            // resurrect them (f66fa14f). Elements strictly newer than mfda survive.
+            for column in &active_order {
+                if let Some(cd) = active.get(column) {
+                    let mfda = cd.marked_for_delete_at;
+                    order.retain(|cell_key| {
+                        let (cell_column, cell_path) = cell_key;
+                        // Only complex elements (those with a cell_path) of THIS
+                        // column are candidates for shadowing.
+                        if cell_column != column || cell_path.is_none() {
+                            return true;
+                        }
+                        match winners.get(cell_key) {
+                            // ts > mfda survives; ts <= mfda is shadowed (purged).
+                            Some(cell) if cell.timestamp > mfda => true,
+                            Some(_) => {
+                                winners.remove(cell_key);
+                                false
+                            }
+                            None => false,
+                        }
+                    });
+                }
+            }
+
+            // Rebuild the carried union as the surviving per-column deletions in
+            // first-seen column order.
+            complex_deletions = active_order
+                .into_iter()
+                .filter_map(|column| active.remove(&column))
+                .collect();
+        }
+
         // Step 3: apply row-tombstone shadowing per cell. A cell whose timestamp is
         // <= row_del is shadowed (`<=` lets the tombstone win at equal ts, #498).
         // Cells written strictly after row_del survive. This shadowing applies to
@@ -1988,13 +2059,10 @@ impl KWayMerger {
         // the `reference_merge` model, whose range-tombstone path only suppresses
         // live cells — `reconcile_cluster` is the authoritative behavior here.
         //
-        // PHASE A NEUTRALITY (roborev #863, Finding 2): row-tombstone shadowing is
-        // pre-existing and unchanged. COMPLEX-DELETION shadowing (dropping elements
-        // covered by a collection `markedForDeleteAt`) is INTENTIONALLY NOT applied
-        // here — it is deferred to Phase C alongside writing the complex-deletion
-        // marker. Applying it now would filter shadowed/metadata-only elements out
-        // before the writer runs, dropping collection tombstones and risking data
-        // resurrection, and would diverge from pre-Phase-A output bytes.
+        // COMPLEX-DELETION shadowing (dropping elements covered by a collection
+        // `markedForDeleteAt`) has already been applied in Step 2b above, BEFORE this
+        // row-tombstone filter, so a surviving complex deletion cannot resurrect a
+        // covered element on a later purge (issue #887, parity `f66fa14f`).
         //
         // Step 3b: dropped-column filtering (Cassandra `cb34ad47`,
         // `compaction.purge`). A column dropped at `drop_time` discards every cell
@@ -2231,6 +2299,16 @@ impl KWayMerger {
             _ => None,
         };
 
+        // Capture the row tombstone's deletion time (`row_del`) BEFORE moving
+        // `row_data` into `operations`. A row tombstone shadows only cells/markers
+        // whose timestamp is `<= row_del`; a complex-deletion marker whose
+        // `marked_for_delete_at` is STRICTLY GREATER than `row_del` covers a range
+        // the row tombstone does NOT, and must still be emitted (see below).
+        let row_del = match &entry.row_data {
+            RowData::Tombstone { deletion_time, .. } => Some(*deletion_time),
+            RowData::Live { .. } => None,
+        };
+
         let mut operations = match entry.row_data {
             RowData::Live { cells } => Self::cells_to_cell_operations(cells),
             RowData::Tombstone { .. } => vec![CellOperation::DeleteRow],
@@ -2239,13 +2317,27 @@ impl KWayMerger {
         // Epic #899 Phase C: emit a REAL per-column complex deletion marker for
         // each carried `ComplexDeletion`, replacing the writer's hardcoded LIVE
         // sentinel. The writer pairs this with the column's surviving per-element
-        // cells (WriteComplexElement ops above). Only meaningful for a live row;
-        // a row tombstone already covers the whole row. Applying the marker to
-        // SHADOW covered elements (strict-supersede / gc purge) is deferred to
-        // #887 / #845 — Phase C carries and emits the marker faithfully but does
-        // not shadow (see merge module / reconcile_cluster docs).
-        if !matches!(operations.as_slice(), [CellOperation::DeleteRow]) {
-            for cd in entry.complex_deletions {
+        // cells (WriteComplexElement ops above). `reconcile_cluster` has already
+        // applied strict-supersede + shadow-before-purge to this carried deletion
+        // (issue #887), so the marker emitted here is the surviving (max-mfda)
+        // deletion and the paired elements are only the survivors. gc_grace purging
+        // of the surviving marker remains future work (#845).
+        //
+        // Issue #887: for a row that reduces to a ROW TOMBSTONE we must NOT
+        // unconditionally drop carried complex-deletion markers. A row tombstone at
+        // `row_del` shadows only `timestamp <= row_del`. A carried marker whose
+        // `marked_for_delete_at` is STRICTLY GREATER than `row_del` covers elements
+        // in `(row_del, mfda]` — including elements living in OTHER SSTables not part
+        // of this compaction. Dropping such a marker would let those elements be
+        // RESURRECTED. So we emit any marker that strictly supersedes the row
+        // tombstone (`mfda > row_del`) alongside the `DeleteRow`, mirroring #887's
+        // strict boundary. A marker with `mfda <= row_del` is fully covered by the
+        // row tombstone and is dropped. For a live row (`row_del == None`) every
+        // carried marker is emitted as before.
+        for cd in entry.complex_deletions {
+            let strictly_supersedes_row_tombstone =
+                row_del.is_none_or(|rd| cd.marked_for_delete_at > rd);
+            if strictly_supersedes_row_tombstone {
                 operations.push(CellOperation::ComplexDeletion {
                     column: cd.column,
                     marked_for_delete_at: cd.marked_for_delete_at,
@@ -5944,14 +6036,13 @@ mod issue_899_per_element_merge {
         assert_eq!(paths, vec![vec![0xAA], vec![0xBB]]);
     }
 
-    /// PHASE A NEUTRALITY (roborev #863, Finding 2): a complex deletion is
-    /// CARRIED on the MergeEntry but reconcile does NOT act on it — it does NOT
-    /// shadow elements written at or before its `markedForDeleteAt`. Both
-    /// elements survive in Phase A; the complex-deletion marker rides along on
-    /// `MergeEntry.complex_deletions` for Phase C, where the writer consumes it
-    /// (shadowing + marker emit) under differential parity.
+    /// ISSUE #887 (parity f66fa14f): a surviving complex deletion SHADOWS the
+    /// elements it covers BEFORE the marker is purged. An element whose timestamp
+    /// is `<= markedForDeleteAt` is shadowed; an element strictly newer survives.
+    /// The marker still rides along on `MergeEntry.complex_deletions` so the writer
+    /// can emit it (and the per-element survivors) faithfully.
     #[test]
-    fn complex_deletion_is_carried_but_does_not_shadow_in_phase_a() {
+    fn complex_deletion_shadows_covered_elements_before_purge() {
         let old_el = MergeEntry::new(
             1,
             dk(1),
@@ -5965,7 +6056,7 @@ mod issue_899_per_element_merge {
                     ttl: None,
                     cell_path: Some(vec![0x01]),
                     local_deletion_time: None,
-                    is_complex_element: false,
+                    is_complex_element: true,
                     is_deleted: false,
                     has_empty_value: false,
                 }],
@@ -5984,7 +6075,7 @@ mod issue_899_per_element_merge {
                     ttl: None,
                     cell_path: Some(vec![0x02]),
                     local_deletion_time: None,
-                    is_complex_element: false,
+                    is_complex_element: true,
                     is_deleted: false,
                     has_empty_value: false,
                 }],
@@ -6003,7 +6094,7 @@ mod issue_899_per_element_merge {
         )
         .expect("a live row must be emitted");
 
-        // The complex deletion is carried (foundation for Phase C)...
+        // The complex deletion is carried so the writer can emit the marker...
         assert_eq!(
             merged.complex_deletions,
             vec![ComplexDeletion {
@@ -6014,22 +6105,483 @@ mod issue_899_per_element_merge {
             "complex deletion is carried on the MergeEntry"
         );
 
-        // ...but reconcile does NOT shadow on it: both elements survive in Phase A.
+        // ...and reconcile shadows the covered element (ts 100 <= mfda 200) BEFORE
+        // purge: only the strictly-newer element (ts 300 > mfda 200) survives.
         let cells = match merged.row_data {
             RowData::Live { cells } => cells,
             other => panic!("expected Live, got {other:?}"),
         };
         assert_eq!(
             cells.len(),
-            2,
-            "Phase A does NOT apply complex-deletion shadowing (deferred to Phase C)"
+            1,
+            "the covered element (ts<=mfda) is shadowed before purge (#887 f66fa14f)"
         );
-        let mut paths: Vec<Vec<u8>> = cells
+        assert_eq!(
+            cells[0].cell_path.as_deref(),
+            Some([0x02].as_slice()),
+            "the strictly-newer element (ts>mfda) survives"
+        );
+    }
+
+    /// ACCEPTANCE #887 (1) — parity bd244649: when two SSTables carry complex
+    /// deletions on the SAME column at EQUAL `markedForDeleteAt`, the merged
+    /// deletion does NOT supersede the active one (only STRICTLY-greater
+    /// supersedes). At equal mfda the boundary is still `<=`, so an element at
+    /// exactly `mfda` is shadowed, but an element strictly newer survives — proving
+    /// the equal-ts deletions did not collapse into a stronger one.
+    #[test]
+    fn complex_deletion_equal_timestamps_do_not_supersede() {
+        let covered = MergeEntry::new(
+            1,
+            dk(1),
+            None,
+            200,
+            RowData::Live {
+                cells: vec![CellData {
+                    column: "tags".to_string(),
+                    value: Value::Text("at-mfda".to_string()),
+                    timestamp: 200,
+                    ttl: None,
+                    cell_path: Some(vec![0x01]),
+                    local_deletion_time: None,
+                    is_complex_element: true,
+                    is_deleted: false,
+                    has_empty_value: false,
+                }],
+            },
+        )
+        .with_complex_deletions(vec![ComplexDeletion {
+            column: "tags".to_string(),
+            marked_for_delete_at: 200,
+            local_deletion_time: 1_700_000_100,
+        }]);
+        let survivor = MergeEntry::new(
+            0,
+            dk(1),
+            None,
+            300,
+            RowData::Live {
+                cells: vec![CellData {
+                    column: "tags".to_string(),
+                    value: Value::Text("after".to_string()),
+                    timestamp: 300,
+                    ttl: None,
+                    cell_path: Some(vec![0x02]),
+                    local_deletion_time: None,
+                    is_complex_element: true,
+                    is_deleted: false,
+                    has_empty_value: false,
+                }],
+            },
+        )
+        // SAME column, EQUAL marked_for_delete_at — must NOT supersede the active.
+        .with_complex_deletions(vec![ComplexDeletion {
+            column: "tags".to_string(),
+            marked_for_delete_at: 200,
+            local_deletion_time: 1_700_000_000,
+        }]);
+
+        let merged = KWayMerger::reconcile_cluster(
+            None,
+            vec![survivor, covered],
+            &::std::collections::HashMap::new(),
+        )
+        .expect("a live row must be emitted");
+
+        // The deletion at mfda=200 survives (one carried marker for `tags`)...
+        let tags_dels: Vec<&ComplexDeletion> = merged
+            .complex_deletions
             .iter()
-            .map(|c| c.cell_path.clone().expect("cell_path"))
+            .filter(|d| d.column == "tags")
             .collect();
-        paths.sort();
-        assert_eq!(paths, vec![vec![0x01], vec![0x02]]);
+        assert_eq!(
+            tags_dels.len(),
+            1,
+            "the union keeps one complex deletion for the column"
+        );
+        assert_eq!(
+            tags_dels[0].marked_for_delete_at, 200,
+            "equal-ts deletions do not produce a stronger mfda (bd244649)"
+        );
+
+        // ...the strictly-newer element (ts 300 > 200) survives; the at-mfda element
+        // (ts 200 <= 200) is shadowed.
+        let cells = match merged.row_data {
+            RowData::Live { cells } => cells,
+            other => panic!("expected Live, got {other:?}"),
+        };
+        assert_eq!(
+            cells.len(),
+            1,
+            "only the strictly-newer element survives the active deletion"
+        );
+        assert_eq!(
+            cells[0].cell_path.as_deref(),
+            Some([0x02].as_slice()),
+            "ts>mfda element survives; equal-ts deletions did not shadow it"
+        );
+    }
+
+    /// ACCEPTANCE #887 (2) — parity bd244649 + f66fa14f: a STRICTLY-superseding
+    /// complex deletion shadows every covered element (ts <= mfda) BEFORE the marker
+    /// is purged, so a later purge cannot resurrect them. An element with ts STRICTLY
+    /// GREATER than the surviving mfda MUST survive.
+    #[test]
+    fn complex_deletion_strict_supersede_shadows_before_purge() {
+        // Older source: weaker deletion (mfda 100) + element at ts 50 (covered by
+        // the strong deletion below) + element at ts 500 (survives everything).
+        let weak = MergeEntry::new(
+            1,
+            dk(1),
+            None,
+            500,
+            RowData::Live {
+                cells: vec![
+                    CellData {
+                        column: "tags".to_string(),
+                        value: Value::Text("ancient".to_string()),
+                        timestamp: 50,
+                        ttl: None,
+                        cell_path: Some(vec![0x01]),
+                        local_deletion_time: None,
+                        is_complex_element: true,
+                        is_deleted: false,
+                        has_empty_value: false,
+                    },
+                    CellData {
+                        column: "tags".to_string(),
+                        value: Value::Text("survivor".to_string()),
+                        timestamp: 500,
+                        ttl: None,
+                        cell_path: Some(vec![0x03]),
+                        local_deletion_time: None,
+                        is_complex_element: true,
+                        is_deleted: false,
+                        has_empty_value: false,
+                    },
+                ],
+            },
+        )
+        .with_complex_deletions(vec![ComplexDeletion {
+            column: "tags".to_string(),
+            marked_for_delete_at: 100,
+            local_deletion_time: 1_700_000_000,
+        }]);
+        // Newer source: STRONG deletion (mfda 300, strictly > 100) + element at ts
+        // 300 (== strong mfda → covered).
+        let strong = MergeEntry::new(
+            0,
+            dk(1),
+            None,
+            300,
+            RowData::Live {
+                cells: vec![CellData {
+                    column: "tags".to_string(),
+                    value: Value::Text("covered".to_string()),
+                    timestamp: 300,
+                    ttl: None,
+                    cell_path: Some(vec![0x02]),
+                    local_deletion_time: None,
+                    is_complex_element: true,
+                    is_deleted: false,
+                    has_empty_value: false,
+                }],
+            },
+        )
+        .with_complex_deletions(vec![ComplexDeletion {
+            column: "tags".to_string(),
+            marked_for_delete_at: 300,
+            local_deletion_time: 1_700_000_200,
+        }]);
+
+        let merged = KWayMerger::reconcile_cluster(
+            None,
+            vec![strong, weak],
+            &::std::collections::HashMap::new(),
+        )
+        .expect("a live row must be emitted");
+
+        // The strong deletion (mfda 300) strictly supersedes the weak one (100).
+        let tags_dels: Vec<&ComplexDeletion> = merged
+            .complex_deletions
+            .iter()
+            .filter(|d| d.column == "tags")
+            .collect();
+        assert_eq!(
+            tags_dels.len(),
+            1,
+            "one surviving complex deletion for tags"
+        );
+        assert_eq!(
+            tags_dels[0].marked_for_delete_at, 300,
+            "the strictly-greater mfda supersedes (bd244649)"
+        );
+
+        // Covered elements (ts 50 and ts 300, both <= 300) are shadowed BEFORE purge;
+        // only the ts 500 element (strictly > 300) survives (f66fa14f).
+        let cells = match merged.row_data {
+            RowData::Live { cells } => cells,
+            other => panic!("expected Live, got {other:?}"),
+        };
+        assert_eq!(
+            cells.len(),
+            1,
+            "all elements with ts<=mfda are shadowed before purge (no resurrection)"
+        );
+        assert_eq!(
+            cells[0].cell_path.as_deref(),
+            Some([0x03].as_slice()),
+            "the strictly-newer element (ts>mfda) survives"
+        );
+        assert_eq!(cells[0].timestamp, 500);
+    }
+
+    /// ISSUE #887: a row that reduces to a ROW TOMBSTONE at `row_del = T_low` must
+    /// STILL emit any carried complex-deletion marker whose `marked_for_delete_at =
+    /// T_high` is STRICTLY GREATER than `row_del`.
+    ///
+    /// A row tombstone shadows only `timestamp <= row_del`. A complex deletion at
+    /// `mfda = T_high > T_low` covers elements in `(T_low, T_high]` — including
+    /// elements that live in OTHER SSTables NOT part of this compaction. If the
+    /// marker is dropped, those elements would be RESURRECTED. So the emitted
+    /// mutation must carry BOTH the `DeleteRow` AND the `ComplexDeletion{T_high}`.
+    #[test]
+    fn row_tombstone_keeps_strictly_newer_complex_deletion_marker() {
+        use crate::schema::{Column, KeyColumn, TableSchema};
+        use crate::storage::write_engine::mutation::CellOperation;
+        use std::collections::HashMap;
+
+        const T_LOW: i64 = 100; // row tombstone (row_del)
+        const T_HIGH: i64 = 300; // complex deletion mfda (strictly > row_del)
+
+        // Source A (newest, run 0): a ROW TOMBSTONE at T_low.
+        let row_tomb = MergeEntry::new(
+            0,
+            dk(1),
+            None,
+            T_LOW,
+            RowData::Tombstone {
+                deletion_time: T_LOW,
+                local_deletion_time: 0,
+            },
+        );
+
+        // Source B (older, run 1): carries the STRONGER complex deletion (mfda
+        // T_high > row_del) plus three elements (shadowed-by-row, shadowed-by-complex,
+        // survivor).
+        let carrier = MergeEntry::new(
+            1,
+            dk(1),
+            None,
+            T_HIGH + 200,
+            RowData::Live {
+                cells: vec![
+                    CellData {
+                        column: "tags".to_string(),
+                        value: Value::Text("shadowed_by_row".to_string()),
+                        timestamp: T_LOW,
+                        ttl: None,
+                        cell_path: Some(vec![0x01]),
+                        local_deletion_time: None,
+                        is_complex_element: true,
+                        is_deleted: false,
+                        has_empty_value: false,
+                    },
+                    CellData {
+                        column: "tags".to_string(),
+                        value: Value::Text("shadowed_by_complex".to_string()),
+                        timestamp: T_HIGH,
+                        ttl: None,
+                        cell_path: Some(vec![0x02]),
+                        local_deletion_time: None,
+                        is_complex_element: true,
+                        is_deleted: false,
+                        has_empty_value: false,
+                    },
+                    CellData {
+                        column: "tags".to_string(),
+                        value: Value::Text("survivor".to_string()),
+                        timestamp: T_HIGH + 200,
+                        ttl: None,
+                        cell_path: Some(vec![0x03]),
+                        local_deletion_time: None,
+                        is_complex_element: true,
+                        is_deleted: false,
+                        has_empty_value: false,
+                    },
+                ],
+            },
+        )
+        .with_complex_deletions(vec![ComplexDeletion {
+            column: "tags".to_string(),
+            marked_for_delete_at: T_HIGH,
+            local_deletion_time: 1_700_000_000,
+        }]);
+
+        let merged = KWayMerger::reconcile_cluster(
+            None,
+            vec![row_tomb, carrier],
+            &::std::collections::HashMap::new(),
+        )
+        .expect("a row must be emitted (it carries a row tombstone + survivor)");
+
+        // The strictly-newer element (ts T_high+200) survives both deletions; the
+        // ts<=T_low and T_low<ts<=T_high elements are shadowed BEFORE purge.
+        let cells = match &merged.row_data {
+            RowData::Live { cells } => cells.clone(),
+            other => panic!("expected Live (survivor present), got {other:?}"),
+        };
+        assert_eq!(
+            cells.len(),
+            1,
+            "only the element with ts > T_high survives the complex deletion"
+        );
+        assert_eq!(cells[0].cell_path.as_deref(), Some([0x03].as_slice()));
+        assert_eq!(cells[0].timestamp, T_HIGH + 200);
+
+        // The strictly-newer complex deletion marker is preserved on the merge entry.
+        let tags_dels: Vec<&ComplexDeletion> = merged
+            .complex_deletions
+            .iter()
+            .filter(|d| d.column == "tags")
+            .collect();
+        assert_eq!(tags_dels.len(), 1, "the T_high complex deletion is carried");
+        assert_eq!(tags_dels[0].marked_for_delete_at, T_HIGH);
+
+        // Schema with a non-frozen complex column `tags`.
+        let schema = TableSchema {
+            keyspace: "ks".to_string(),
+            table: "t".to_string(),
+            partition_keys: vec![KeyColumn {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![],
+            columns: vec![Column {
+                name: "tags".to_string(),
+                data_type: "list<text>".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            }],
+            comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
+        };
+
+        // The crux: `merge_entry_to_mutation` MUST emit BOTH a `DeleteRow` AND the
+        // strictly-newer `ComplexDeletion` (mfda = T_high). `merge_entry_to_mutation`
+        // decodes the partition key against the schema's `int` PK, so the key must be
+        // a 4-byte big-endian int.
+        let int_pk = DecoratedKey::new(1, 1i32.to_be_bytes().to_vec());
+        let tomb_entry = MergeEntry::new(
+            0,
+            int_pk,
+            None,
+            T_LOW,
+            RowData::Tombstone {
+                deletion_time: T_LOW,
+                local_deletion_time: 0,
+            },
+        )
+        .with_complex_deletions(vec![ComplexDeletion {
+            column: "tags".to_string(),
+            marked_for_delete_at: T_HIGH,
+            local_deletion_time: 1_700_000_000,
+        }]);
+
+        let mutation = KWayMerger::merge_entry_to_mutation(tomb_entry, &schema)
+            .expect("conversion should succeed");
+
+        let has_delete_row = mutation
+            .operations
+            .iter()
+            .any(|op| matches!(op, CellOperation::DeleteRow));
+        assert!(has_delete_row, "the row tombstone must still be emitted");
+
+        let strictly_newer_marker = mutation.operations.iter().any(|op| {
+            matches!(
+                op,
+                CellOperation::ComplexDeletion {
+                    column,
+                    marked_for_delete_at,
+                    ..
+                } if column == "tags" && *marked_for_delete_at == T_HIGH
+            )
+        });
+        assert!(
+            strictly_newer_marker,
+            "the strictly-newer (mfda > row_del) complex deletion marker must be \
+             emitted alongside the row tombstone (else (row_del, mfda] resurrects)"
+        );
+    }
+
+    /// ISSUE #887, complement: a carried complex-deletion marker that is FULLY
+    /// COVERED by the row tombstone (`mfda <= row_del`) IS dropped — the row
+    /// tombstone already shadows its entire range. Mirrors #887's strict boundary
+    /// (equal does not supersede).
+    #[test]
+    fn row_tombstone_drops_fully_covered_complex_deletion_marker() {
+        use crate::schema::{Column, KeyColumn, TableSchema};
+        use crate::storage::write_engine::mutation::CellOperation;
+        use std::collections::HashMap;
+
+        const ROW_DEL: i64 = 300;
+
+        let schema = TableSchema {
+            keyspace: "ks".to_string(),
+            table: "t".to_string(),
+            partition_keys: vec![KeyColumn {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![],
+            columns: vec![Column {
+                name: "tags".to_string(),
+                data_type: "list<text>".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            }],
+            comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
+        };
+
+        let int_pk = DecoratedKey::new(1, 1i32.to_be_bytes().to_vec());
+        for covered_mfda in [ROW_DEL - 100, ROW_DEL] {
+            let entry = MergeEntry::new(
+                0,
+                int_pk.clone(),
+                None,
+                ROW_DEL,
+                RowData::Tombstone {
+                    deletion_time: ROW_DEL,
+                    local_deletion_time: 0,
+                },
+            )
+            .with_complex_deletions(vec![ComplexDeletion {
+                column: "tags".to_string(),
+                marked_for_delete_at: covered_mfda,
+                local_deletion_time: 1_700_000_000,
+            }]);
+
+            let mutation = KWayMerger::merge_entry_to_mutation(entry, &schema)
+                .expect("conversion should succeed");
+
+            assert!(
+                mutation
+                    .operations
+                    .iter()
+                    .all(|op| !matches!(op, CellOperation::ComplexDeletion { .. })),
+                "a marker with mfda ({covered_mfda}) <= row_del ({ROW_DEL}) is fully \
+                 covered by the row tombstone and must be dropped (strict boundary)"
+            );
+            assert!(
+                matches!(mutation.operations.as_slice(), [CellOperation::DeleteRow]),
+                "the fully-covered case reduces to exactly [DeleteRow]"
+            );
+        }
     }
 }
 

--- a/cqlite-core/src/storage/write_engine/merge.rs
+++ b/cqlite-core/src/storage/write_engine/merge.rs
@@ -1209,6 +1209,22 @@ pub struct KWayMerger {
     /// Carried but not yet consulted — see the note on `gc_before_secs`.
     #[allow(dead_code)]
     now_secs: Option<i64>,
+    /// Overlap-safety gate for tombstone purging (#921 finding 1).
+    ///
+    /// A compaction that merges only a SUBSET of a table's SSTables may leave
+    /// data shadowed by a tombstone living in a NON-included overlapping
+    /// SSTable. Purging the tombstone in that case resurrects the shadowed data
+    /// once both files are later read together. Cassandra gates the purge on the
+    /// `CompactionController`'s `maxPurgeableTimestamp` / fully-expired-overlap
+    /// check; CQLite has no such controller, so it gates conservatively: a
+    /// tombstone is purged ONLY when this flag proves the compaction is safe
+    /// (i.e. it spans ALL of the table's SSTables — a major/full compaction — so
+    /// no non-included overlapping SSTable can hold shadowed data).
+    ///
+    /// DEFAULT is `false`: the background/partial path does NOT purge, so it can
+    /// never resurrect data. The policy-driven path sets it to `true` only when
+    /// the selected inputs cover every candidate SSTable for the table.
+    purge_safe: bool,
 }
 
 /// Report returned by [`compact_sstables`].
@@ -1427,10 +1443,44 @@ pub fn effective_compaction_schema(schema: &TableSchema, input_paths: &[PathBuf]
 /// wins last-write-wins ties at equal timestamp/liveness.
 ///
 /// `gc_before_secs` / `now_secs` are threaded into the merger for deterministic,
-/// Cassandra-matching purge decisions. NOTE: tombstone purging and TTL expiry are
-/// NOT yet applied during the merge (issues #845, #848); these parameters are
-/// currently carried but do not yet drop purgeable data. The plumbing lands first
-/// so the parity harness can drive out the purge semantics.
+/// Cassandra-matching purge decisions. gc_grace tombstone purging IS applied
+/// (issue #845), but ONLY when the compaction is overlap-safe — see
+/// `KWayMerger::with_purge_safe` (#921 finding 1). TTL expiry (#848) remains
+/// carried-but-not-yet-applied.
+/// Compute the gc_grace `gcBefore` cutoff (GC-clock seconds) for a compaction.
+///
+/// Cassandra purges a tombstone during compaction when its on-disk
+/// `localDeletionTime` is strictly less than `gcBefore = now - gc_grace_seconds`
+/// (parity `8d47ebb2`). CQLite reads `gc_grace_seconds` from the table schema
+/// (the `comments` option map — the same surface `cql_parser` / `cql_generator`
+/// use), since it is a table parameter not recorded inside SSTable files.
+///
+/// When the table declares NO `gc_grace_seconds` (#921 finding 3), CQLite falls
+/// back to Cassandra's table DEFAULT of `864000` seconds (10 days) — CQL tables
+/// commonly omit the option and rely on that default, so disabling purging on
+/// absence diverged from Cassandra. A value of exactly `0` is valid (immediate
+/// grace, `TableParams` allows it) and yields `gcBefore == now`.
+///
+/// Returns `None` ONLY when the declared value is INVALID — unparseable or
+/// NEGATIVE — which DISABLES purging (a strict no-op): garbage metadata must
+/// never cause data to be dropped.
+#[cfg(feature = "write-support")]
+pub(crate) fn compute_gc_before(schema: &TableSchema, now_secs: i64) -> Option<i64> {
+    /// Cassandra's `TableParams.DEFAULT_GC_GRACE_SECONDS` (10 days).
+    const DEFAULT_GC_GRACE_SECONDS: i64 = 864_000;
+
+    match schema.comments.get("gc_grace_seconds") {
+        // Absent → Cassandra default (10 days).
+        None => Some(now_secs - DEFAULT_GC_GRACE_SECONDS),
+        // Present → parse. Reject unparseable or negative values conservatively
+        // (return None = no purge); 0 is valid (immediate grace).
+        Some(s) => match s.trim().parse::<i64>() {
+            Ok(gc_grace_seconds) if gc_grace_seconds >= 0 => Some(now_secs - gc_grace_seconds),
+            _ => None,
+        },
+    }
+}
+
 #[cfg(feature = "write-support")]
 /// Determine which dropped columns still have surviving cells after the merge.
 ///
@@ -1441,15 +1491,35 @@ pub fn effective_compaction_schema(schema: &TableSchema, input_paths: &[PathBuf]
 /// exactly these dropped columns in the output writer schema; the rest are
 /// stripped from the output header. Stops early once every dropped column has
 /// been observed surviving.
-fn compute_surviving_dropped_columns(
+///
+/// A dropped column also counts as surviving when its only surviving state is a
+/// retained `ComplexDeletion` marker. A complex (collection / UDT) tombstone for
+/// a dropped COMPLEX column lives in `row.complex_deletions`, NOT in `cells`, so
+/// counting only live `cells` would strip such a column from the output schema —
+/// and the writer only emits complex-element columns present in the schema,
+/// silently dropping a complex tombstone the merge decided to RETAIN. Because the
+/// merge pre-pass runs reconcile with the SAME `gc_before`/`purge_safe` as the
+/// write pass, a marker purged by gc never reaches the yielded `rows`, so a
+/// retained marker IS counted while a purged one is NOT (#921 finding 2 / #847).
+///
+/// `purge_safe` (#921 finding 1) MUST match the value the write pass uses
+/// (`compact_sstables`'s `purge_safe`). The pre-pass builds its merger with the
+/// SAME gc cutoff (`gc_before_secs`/`now_secs`) AND the SAME `purge_safe` flag
+/// so its purge decisions are byte-identical to the write pass. Without this, a
+/// purgeable tombstone in a dropped column would count as a survivor here (no
+/// purging) yet be purged in the real merge (purging on) — leaving an empty
+/// dropped column in the output header that this pre-pass exists to strip.
+pub(crate) fn compute_surviving_dropped_columns(
     input_paths: Vec<PathBuf>,
     schema: &TableSchema,
     gc_before_secs: Option<i64>,
     now_secs: Option<i64>,
+    purge_safe: bool,
 ) -> Result<std::collections::HashSet<String>> {
     let mut surviving: std::collections::HashSet<String> = std::collections::HashSet::new();
     let total = schema.dropped_columns.len();
-    let mut merger = KWayMerger::new_with_gc(input_paths, schema, gc_before_secs, now_secs)?;
+    let mut merger = KWayMerger::new_with_gc(input_paths, schema, gc_before_secs, now_secs)?
+        .with_purge_safe(purge_safe);
     loop {
         match merger.step()? {
             MergeStep::Complete => break,
@@ -1462,6 +1532,15 @@ fn compute_surviving_dropped_columns(
                             }
                         }
                     }
+                    // A surviving (within-grace / purge-unsafe) complex-deletion
+                    // marker for a dropped COMPLEX column is a survivor too: the
+                    // marker lives here, not in `cells`, and the writer must keep
+                    // the column to emit it.
+                    for cd in &row.complex_deletions {
+                        if schema.dropped_columns.contains_key(&cd.column) {
+                            surviving.insert(cd.column.clone());
+                        }
+                    }
                 }
                 if surviving.len() == total {
                     break; // every dropped column already shown to survive
@@ -1472,6 +1551,13 @@ fn compute_surviving_dropped_columns(
     Ok(surviving)
 }
 
+/// One-shot compaction entry point (behind the `cqlite compact` CLI command).
+///
+/// `purge_safe` (#921 finding 1) gates gc_grace tombstone purging on overlap
+/// safety: pass `true` ONLY when `input_paths` spans EVERY SSTable for the table
+/// (so no non-included overlapping SSTable can hold data shadowed by a purged
+/// tombstone). When `false`, tombstones are retained even if older than
+/// `gcBefore`, so a partial compaction cannot resurrect deleted data.
 pub async fn compact_sstables(
     input_paths: Vec<PathBuf>,
     output_dir: &std::path::Path,
@@ -1479,6 +1565,7 @@ pub async fn compact_sstables(
     generation: u64,
     gc_before_secs: Option<i64>,
     now_secs: Option<i64>,
+    purge_safe: bool,
 ) -> Result<CompactReport> {
     if input_paths.is_empty() {
         return Err(Error::InvalidInput(
@@ -1505,7 +1592,10 @@ pub async fn compact_sstables(
     // Which dropped columns survive is data-dependent and the writer fixes its
     // header before the first row, so determine the surviving set with a merge
     // pre-pass (only when any column is dropped). The pre-pass uses the SAME merge
-    // logic as the write pass, so the two agree. See #847 review.
+    // logic as the write pass — including the same `purge_safe` flag (#921 finding
+    // 1) and gc cutoff — so the two make IDENTICAL purge decisions and a tombstone
+    // purged in the write pass is also purged in the pre-pass (never counted as a
+    // surviving cell). See #847 review.
     let retained_dropped = if effective_schema.dropped_columns.is_empty() {
         std::collections::HashSet::new()
     } else {
@@ -1514,6 +1604,7 @@ pub async fn compact_sstables(
             &effective_schema,
             gc_before_secs,
             now_secs,
+            purge_safe,
         )?
     };
     let write_schema = effective_schema.for_compaction_output(&retained_dropped);
@@ -1523,7 +1614,8 @@ pub async fn compact_sstables(
         &effective_schema,
         gc_before_secs,
         now_secs,
-    )?;
+    )?
+    .with_purge_safe(purge_safe);
 
     let mut writer = crate::storage::sstable::writer::SSTableWriter::new(
         output_dir.to_path_buf(),
@@ -1622,7 +1714,23 @@ impl KWayMerger {
             schema: schema.clone(),
             gc_before_secs,
             now_secs,
+            // Conservatively unsafe by default (#921 finding 1): purging is
+            // dormant until a caller proves the compaction spans all of the
+            // table's SSTables via `with_purge_safe`.
+            purge_safe: false,
         })
+    }
+
+    /// Mark this merge as overlap-safe for tombstone purging (#921 finding 1).
+    ///
+    /// Set `true` ONLY when the compaction inputs provably span EVERY SSTable
+    /// for the table (a major/full compaction), so no non-included overlapping
+    /// SSTable can hold data shadowed by a purged tombstone. When `false` (the
+    /// default) the gc_grace purge stage is a strict no-op — tombstones are
+    /// retained — which can never resurrect data in a partial compaction.
+    pub fn with_purge_safe(mut self, purge_safe: bool) -> Self {
+        self.purge_safe = purge_safe;
+        self
     }
 
     /// Perform a full merge to the output writer
@@ -1824,11 +1932,25 @@ impl KWayMerger {
                 .push(row);
         }
 
+        // Overlap-safety gate for tombstone purging (#921 finding 1): collapse
+        // the gc_grace cutoff to `None` (purge no-op) unless this compaction is
+        // provably overlap-safe (a major/full compaction over every SSTable for
+        // the table). A partial compaction must retain tombstones so it can
+        // never resurrect data shadowed in a non-included overlapping SSTable.
+        let effective_gc_before = if self.purge_safe {
+            self.gc_before_secs
+        } else {
+            None
+        };
+
         let mut merged = Vec::new();
         for (ck, cluster_rows) in clustered_rows {
-            if let Some(entry) =
-                Self::reconcile_cluster(ck, cluster_rows, &self.schema.dropped_columns)
-            {
+            if let Some(entry) = Self::reconcile_cluster(
+                ck,
+                cluster_rows,
+                &self.schema.dropped_columns,
+                effective_gc_before,
+            ) {
                 merged.push(entry);
             }
         }
@@ -1851,6 +1973,34 @@ impl KWayMerger {
         });
 
         Ok(merged)
+    }
+
+    /// The cell's effective `localDeletionTime` (GC-clock seconds, on-disk
+    /// width) for gc_grace purge decisions (#921 finding 1/2).
+    ///
+    /// The reader surfaces an EXPIRING simple cell's LDT in
+    /// [`CellData::local_deletion_time`], but a simple cell TOMBSTONE carries its
+    /// LDT inside its `Value::Tombstone(CellTombstone)` payload
+    /// (`TombstoneInfo::local_deletion_time`, seconds) — `CellData::local_deletion_time`
+    /// stays `None` for it (`v5_compressed_legacy` only fills that field from
+    /// `cell_meta` expiration). Without consulting the tombstone payload, the
+    /// purge stage would always see `None` for a cell tombstone and conservatively
+    /// retain it, so a purgeable dropped-column tombstone would be (wrongly)
+    /// counted as a survivor. Prefer the explicit `CellData` field, then fall back
+    /// to a non-zero tombstone-payload LDT; `0` is the "not surfaced" placeholder
+    /// and yields `None` (retain on unknown LDT — no-heuristics mandate).
+    fn cell_effective_ldt(cell: &CellData) -> Option<i32> {
+        if let Some(ldt) = cell.local_deletion_time {
+            return Some(ldt);
+        }
+        if let crate::types::Value::Tombstone(ref info) = cell.value {
+            if info.tombstone_type == crate::types::TombstoneType::CellTombstone
+                && info.local_deletion_time != 0
+            {
+                return Some(info.local_deletion_time as i32);
+            }
+        }
+        None
     }
 
     /// Returns true when a cell carries a cell-level tombstone
@@ -1914,6 +2064,16 @@ impl KWayMerger {
         clustering_key: Option<ClusteringKey>,
         cluster_rows: Vec<MergeEntry>,
         dropped_columns: &std::collections::HashMap<String, i64>,
+        // EFFECTIVE gc_grace cutoff (`gcBefore`, GC-clock seconds), threaded from
+        // the merger. A tombstone whose `localDeletionTime < gc_before_secs` is
+        // PURGEABLE; `None` disables purging (issue #845).
+        //
+        // OVERLAP SAFETY (#921 finding 1): the caller (`merge_partition_rows`)
+        // collapses this to `None` whenever the compaction is NOT overlap-safe
+        // (a partial compaction), so the purge stage stays a strict no-op there.
+        // Purging therefore runs ONLY for a major/full compaction that spans
+        // every SSTable for the table — see `KWayMerger::with_purge_safe`.
+        gc_before_secs: Option<i64>,
     ) -> Option<MergeEntry> {
         use std::collections::HashMap;
 
@@ -2126,7 +2286,7 @@ impl KWayMerger {
             })
             .collect();
 
-        let surviving: Vec<CellData> = after_row_del
+        let mut surviving: Vec<CellData> = after_row_del
             .iter()
             .filter(|cell| match dropped_columns.get(&cell.column) {
                 Some(drop_time) => cell.timestamp > *drop_time,
@@ -2137,19 +2297,107 @@ impl KWayMerger {
 
         // Phantom-row guard (#847 review): clustering-key columns are intentionally
         // left in the cell list (see `extract_clustering_key`) for read-back. If a
-        // clustered row's only real (non-key) data is a dropped column, the filter
-        // removes it but the clustering-key pseudo-cells remain — which would emit
-        // a phantom live row with a key but no data (the writer, whose schema
-        // excludes the dropped column, would serialize a key-only empty row).
-        // Suppress that: when the row HAD non-key data before the purge and has
-        // none after, treat it as data-less. A row that was always key-only (a
-        // genuine row marker) is preserved.
+        // clustered row's only real (non-key) data is a dropped column (or, per
+        // #921 finding 3 below, a purgeable cell tombstone), the filters remove it
+        // but the clustering-key pseudo-cells remain — which would emit a phantom
+        // live row with a key but no data (the writer, whose schema excludes the
+        // dropped column, would serialize a key-only empty row). Suppress that:
+        // when the row HAD non-key data before the purges and has none after,
+        // treat it as data-less. A row that was always key-only (a genuine row
+        // marker) is preserved.
+        //
+        // We capture `had_data_before` here, but DEFER the
+        // `has_data_after` / `purged_to_empty` determination until AFTER the
+        // gc-grace tombstone purge (Step 3c) — see #921 finding 3 below. Computing
+        // it now (before Step 3c) would miss a clustered row whose only non-key
+        // data is a purgeable cell tombstone: that tombstone is still present in
+        // `surviving` at this point, so a pre-purge check would (wrongly) report
+        // surviving data and emit a phantom key-only live row after the purge.
         let ck_names: std::collections::HashSet<&str> = clustering_key
             .as_ref()
             .map(|ck| ck.columns.iter().map(|(n, _)| n.as_str()).collect())
             .unwrap_or_default();
         let is_data_cell = |cell: &CellData| !ck_names.contains(cell.column.as_str());
         let had_data_before = after_row_del.iter().any(is_data_cell);
+
+        // Step 3c: gc_grace / gcBefore tombstone PURGING (issue #845, parity
+        // Cassandra `8d47ebb2`). A tombstone whose on-disk `localDeletionTime`
+        // (GC-clock seconds) is STRICTLY LESS THAN `gcBefore` is purgeable and
+        // dropped from the output; one within grace (`>= gcBefore`) is retained.
+        // The boundary mirrors Cassandra exactly: `localDeletionTime < gcBefore`
+        // purges, `==` is retained.
+        //
+        // This is a SEPARATE stage that runs AFTER complex-deletion
+        // shadow-before-purge (Step 2b) and the row-tombstone / dropped-column
+        // filters above. Those stages have already removed every cell/element
+        // COVERED by a tombstone WITHIN this compaction, so purging the
+        // now-redundant marker here cannot resurrect data within this set.
+        //
+        // OVERLAP SAFETY (#921 finding 1): `gc_before_secs` here is the EFFECTIVE
+        // cutoff — `merge_partition_rows` already collapsed it to `None` for a
+        // partial (non-overlap-safe) compaction, so this stage runs only for a
+        // major/full compaction that spans every SSTable for the table. A partial
+        // compaction therefore retains every tombstone and cannot resurrect data
+        // shadowed in a non-included overlapping SSTable.
+        //
+        // LDT NORMALIZATION (#921 finding 2): on-disk `localDeletionTime` is an
+        // UNSIGNED 32-bit GC-clock second count (OA/DA). It is carried here as a
+        // wrapped `i32`, so a far-future LDT with bit 31 set reads as a NEGATIVE
+        // `i32`. Comparing that via `as i64` would make it look older than any
+        // `gcBefore` and purge a far-future tombstone immediately. Reinterpret
+        // the bits as unsigned (`i64::from(ldt as u32)`) before every compare.
+        if let Some(gc_before) = gc_before_secs {
+            // (a) Cell tombstones: drop any purgeable simple cell tombstone (and
+            // purgeable complex-element tombstone) from the surviving set. A cell
+            // whose `local_deletion_time` is not surfaced (`None`) is conservative-
+            // ly RETAINED — we never purge on unknown LDT (no-heuristics mandate).
+            surviving.retain(|cell| {
+                if Self::is_cell_tombstone(cell) || cell.is_deleted {
+                    // #921 finding 1: a simple cell tombstone surfaces its LDT in
+                    // its `Value::Tombstone` payload, not `CellData.local_deletion_time`
+                    // (which the reader fills only for expiring cells). Consult both
+                    // via `cell_effective_ldt` so a purgeable cell tombstone is
+                    // actually purged here — matching the survivor pre-pass.
+                    match Self::cell_effective_ldt(cell) {
+                        Some(ldt) => i64::from(ldt as u32) >= gc_before,
+                        None => true,
+                    }
+                } else {
+                    true
+                }
+            });
+
+            // (b) Row tombstone: a purgeable row deletion is dropped so no
+            // tombstone entry is emitted for it. Row-tombstone shadowing already
+            // ran above (`after_row_del`), so cells it covered are gone.
+            //
+            // UNKNOWN-LDT RETENTION (#921 finding 2): `row_del_ldt == 0` is the
+            // "LDT not surfaced" placeholder used by legacy/pre-V5 paths (the
+            // field is initialized to 0 and only overwritten when a real
+            // `local_deletion_time` is carried). Treat 0 as UNKNOWN and RETAIN
+            // the row tombstone — never purge on unknown LDT, matching the
+            // conservative rule already used for cell tombstones (case (a),
+            // `None => true`). Only a real, non-zero, surfaced LDT strictly
+            // below `gcBefore` purges.
+            if row_del.is_some() && row_del_ldt != 0 && i64::from(row_del_ldt as u32) < gc_before {
+                row_del = None;
+            }
+
+            // (c) Complex-deletion markers: drop each purgeable marker. The
+            // strict-supersede reduction + shadow-before-purge already ran in
+            // Step 2b, so a covered element is gone before its marker is purged.
+            complex_deletions.retain(|cd| i64::from(cd.local_deletion_time as u32) >= gc_before);
+        }
+
+        // Phantom key-only-row determination (#921 finding 3): recompute
+        // `purged_to_empty` AFTER the gc-grace cell-tombstone purge above, so a
+        // CLUSTERED row whose only non-key data was a purgeable cell tombstone —
+        // now removed from `surviving` — is recognized as data-less and emits
+        // NOTHING instead of a phantom key-only live row. `had_data_before` was
+        // captured pre-purge above; if the row HAD non-key data before the purges
+        // and has none after, it has been `purged_to_empty`. A row that was always
+        // key-only (a genuine row marker) keeps `had_data_before == false` and is
+        // preserved by Step 4 below.
         let has_data_after = surviving.iter().any(is_data_cell);
         let purged_to_empty = had_data_before && !has_data_after;
 
@@ -2274,15 +2522,32 @@ impl KWayMerger {
                 // Value::Tombstone(CellTombstone); translate to
                 // CellOperation::Delete so the writer emits a proper cell tombstone
                 // rather than a live cell with a null value.
-                if matches!(
-                    cell.value,
-                    Value::Tombstone(ref info)
-                        if info.tombstone_type == TombstoneType::CellTombstone
-                ) {
-                    CellOperation::Delete {
-                        column: cell.column,
+                if let Value::Tombstone(ref info) = cell.value {
+                    if info.tombstone_type == TombstoneType::CellTombstone {
+                        // #921 finding 2: preserve the SOURCE cell tombstone's own
+                        // `localDeletionTime` (GC clock, seconds) so the writer
+                        // emits it verbatim instead of deriving one from the
+                        // enclosing mutation's timestamp. A within-grace cell
+                        // tombstone that survives THIS compaction keeps its
+                        // original GC clock — no drift that would purge it too
+                        // early / keep it too long in a LATER compaction. `0` is
+                        // the "not surfaced" placeholder (the reader writes it
+                        // when the on-disk LDT is absent), in which case we leave
+                        // the op LDT `None` so the writer keeps its historical
+                        // timestamp-derived behavior. The width conversion mirrors
+                        // the row-tombstone path (`info.local_deletion_time as
+                        // i32`, #873).
+                        let preserved_ldt = match info.local_deletion_time {
+                            0 => None,
+                            ldt => Some(ldt as i32),
+                        };
+                        return CellOperation::Delete {
+                            column: cell.column,
+                            local_deletion_time: preserved_ldt,
+                        };
                     }
-                } else if let Some(ttl) = cell.ttl {
+                }
+                if let Some(ttl) = cell.ttl {
                     CellOperation::WriteWithTtl {
                         column: cell.column,
                         value: cell.value,
@@ -2805,6 +3070,7 @@ mod tests {
             current_partition: None,
             gc_before_secs: None,
             now_secs: None,
+            purge_safe: false,
             schema,
         };
 
@@ -2925,6 +3191,7 @@ mod tests {
             current_partition: None,
             gc_before_secs: None,
             now_secs: None,
+            purge_safe: false,
             schema,
         };
 
@@ -3070,6 +3337,7 @@ mod tests {
             current_partition: None,
             gc_before_secs: None,
             now_secs: None,
+            purge_safe: false,
             schema,
         };
 
@@ -3217,6 +3485,7 @@ mod tests {
             current_partition: None,
             gc_before_secs: None,
             now_secs: None,
+            purge_safe: false,
             schema,
         };
 
@@ -3363,6 +3632,7 @@ mod tests {
             current_partition: None,
             gc_before_secs: None,
             now_secs: None,
+            purge_safe: false,
             schema,
         };
 
@@ -3494,6 +3764,7 @@ mod tests {
             current_partition: None,
             gc_before_secs: None,
             now_secs: None,
+            purge_safe: false,
             schema,
         };
 
@@ -3587,6 +3858,7 @@ mod tests {
             current_partition: None,
             gc_before_secs: None,
             now_secs: None,
+            purge_safe: false,
             schema,
         };
 
@@ -4573,6 +4845,7 @@ mod merge_property_tests {
                     current_partition: None,
                     gc_before_secs: None,
                     now_secs: None,
+                    purge_safe: false,
                     schema: schema.clone(),
                 };
                 let real_merged = merger.merge_partition_rows(merge_entries.clone())
@@ -4697,6 +4970,7 @@ mod merge_property_tests {
                     current_partition: None,
                     gc_before_secs: None,
                     now_secs: None,
+                    purge_safe: false,
                     schema: schema.clone(),
                 };
                 let merged = merger.merge_partition_rows(vec![live_entry, tombstone_entry])
@@ -4906,6 +5180,7 @@ mod streaming_tests {
             current_partition: None,
             gc_before_secs: None,
             now_secs: None,
+            purge_safe: false,
             schema,
         };
 
@@ -5045,7 +5320,7 @@ mod issue_823_complex_column_merge {
         let mut dropped = ::std::collections::HashMap::new();
         dropped.insert("legacy".to_string(), 150); // cell ts=100 <= 150
 
-        let merged = KWayMerger::reconcile_cluster(None, vec![row], &dropped)
+        let merged = KWayMerger::reconcile_cluster(None, vec![row], &dropped, None)
             .expect("a live row must be emitted (name survives)");
         let cells = match merged.row_data {
             RowData::Live { cells } => cells,
@@ -5062,7 +5337,7 @@ mod issue_823_complex_column_merge {
         let mut dropped = ::std::collections::HashMap::new();
         dropped.insert("legacy".to_string(), 150); // cell ts=200 > 150
 
-        let merged = KWayMerger::reconcile_cluster(None, vec![row], &dropped)
+        let merged = KWayMerger::reconcile_cluster(None, vec![row], &dropped, None)
             .expect("a live row must be emitted (cell post-dates the drop)");
         let cells = match merged.row_data {
             RowData::Live { cells } => cells,
@@ -5081,7 +5356,7 @@ mod issue_823_complex_column_merge {
         dropped.insert("legacy".to_string(), 150);
 
         assert!(
-            KWayMerger::reconcile_cluster(None, vec![row], &dropped).is_none(),
+            KWayMerger::reconcile_cluster(None, vec![row], &dropped, None).is_none(),
             "cell at exactly drop_time must be discarded, leaving no surviving cells"
         );
     }
@@ -5099,7 +5374,7 @@ mod issue_823_complex_column_merge {
         dropped.insert("b".to_string(), 200);
 
         assert!(
-            KWayMerger::reconcile_cluster(None, vec![row], &dropped).is_none(),
+            KWayMerger::reconcile_cluster(None, vec![row], &dropped, None).is_none(),
             "a row whose every cell is a dropped-column cell emits nothing"
         );
     }
@@ -5115,9 +5390,13 @@ mod issue_823_complex_column_merge {
                 scalar_cell("legacy", "stale", 100),
             ],
         );
-        let merged =
-            KWayMerger::reconcile_cluster(None, vec![row], &::std::collections::HashMap::new())
-                .expect("a live row must be emitted");
+        let merged = KWayMerger::reconcile_cluster(
+            None,
+            vec![row],
+            &::std::collections::HashMap::new(),
+            None,
+        )
+        .expect("a live row must be emitted");
         let cells = match merged.row_data {
             RowData::Live { cells } => cells,
             other => panic!("expected Live, got {:?}", other),
@@ -5177,6 +5456,7 @@ mod issue_823_complex_column_merge {
             None,
             vec![newer, older],
             &::std::collections::HashMap::new(),
+            None,
         )
         .expect("a live row must be emitted");
 
@@ -5256,6 +5536,7 @@ mod issue_823_complex_column_merge {
             None,
             vec![newer, older],
             &::std::collections::HashMap::new(),
+            None,
         )
         .expect("a live row must be emitted");
         let cells = match merged.row_data {
@@ -5373,6 +5654,7 @@ mod issue_823_complex_column_merge {
             None,
             vec![row_tomb, cell_tomb],
             &::std::collections::HashMap::new(),
+            None,
         )
         .expect("row tombstone keeps the row shadowed");
 
@@ -5452,6 +5734,7 @@ mod issue_823_complex_column_merge {
             None,
             vec![expiring, tombstone],
             &::std::collections::HashMap::new(),
+            None,
         )
         .expect("a row must be emitted");
 
@@ -5489,6 +5772,7 @@ mod issue_823_complex_column_merge {
             None,
             vec![tombstone, expiring],
             &::std::collections::HashMap::new(),
+            None,
         )
         .expect("a row must be emitted");
 
@@ -5517,6 +5801,7 @@ mod issue_823_complex_column_merge {
             None,
             vec![tombstone, expiring],
             &::std::collections::HashMap::new(),
+            None,
         )
         .expect("a row must be emitted");
 
@@ -5661,9 +5946,13 @@ mod issue_886_merge_entry_enrichment {
                 marked_for_delete_at: 1234,
                 local_deletion_time: 1_700_000_000,
             }]);
-        let merged =
-            KWayMerger::reconcile_cluster(None, vec![live], &::std::collections::HashMap::new())
-                .expect("live row must be emitted");
+        let merged = KWayMerger::reconcile_cluster(
+            None,
+            vec![live],
+            &::std::collections::HashMap::new(),
+            None,
+        )
+        .expect("live row must be emitted");
         match merged.row_data {
             RowData::Live { cells } => {
                 assert_eq!(
@@ -5697,9 +5986,13 @@ mod issue_886_merge_entry_enrichment {
 
         // Plumbing-only: the covered cell (ts=1000 < range ts=5000) STILL
         // survives reconcile because range deletions are not yet applied.
-        let merged =
-            KWayMerger::reconcile_cluster(None, vec![entry], &::std::collections::HashMap::new())
-                .expect("live row must be emitted");
+        let merged = KWayMerger::reconcile_cluster(
+            None,
+            vec![entry],
+            &::std::collections::HashMap::new(),
+            None,
+        )
+        .expect("live row must be emitted");
         match merged.row_data {
             RowData::Live { cells } => {
                 assert_eq!(
@@ -5771,6 +6064,7 @@ mod issue_886_merge_entry_enrichment {
             None,
             vec![row0, row1],
             &::std::collections::HashMap::new(),
+            None,
         )
         .expect("live row must be emitted");
 
@@ -5814,6 +6108,7 @@ mod issue_886_merge_entry_enrichment {
             None,
             vec![plain0, plain1],
             &::std::collections::HashMap::new(),
+            None,
         )
         .expect("live row must be emitted");
         assert_eq!(
@@ -5846,9 +6141,13 @@ mod issue_886_merge_entry_enrichment {
         )
         .with_complex_deletions(vec![complex.clone()]);
 
-        let merged =
-            KWayMerger::reconcile_cluster(None, vec![row], &::std::collections::HashMap::new())
-                .expect("row tombstone must be emitted");
+        let merged = KWayMerger::reconcile_cluster(
+            None,
+            vec![row],
+            &::std::collections::HashMap::new(),
+            None,
+        )
+        .expect("row tombstone must be emitted");
         assert!(matches!(merged.row_data, RowData::Tombstone { .. }));
         assert_eq!(merged.complex_deletions, vec![complex]);
     }
@@ -5879,9 +6178,13 @@ mod issue_886_merge_entry_enrichment {
             .with_complex_deletions(vec![complex.clone()])
             .with_range_deletion(range.clone());
 
-        let merged =
-            KWayMerger::reconcile_cluster(None, vec![row], &::std::collections::HashMap::new())
-                .expect("metadata-only cluster must still emit an entry");
+        let merged = KWayMerger::reconcile_cluster(
+            None,
+            vec![row],
+            &::std::collections::HashMap::new(),
+            None,
+        )
+        .expect("metadata-only cluster must still emit an entry");
 
         // The emitted entry carries the metadata and has no live cells.
         match &merged.row_data {
@@ -5905,8 +6208,13 @@ mod issue_886_merge_entry_enrichment {
     fn reconcile_cluster_empty_live_without_metadata_yields_none() {
         let row = MergeEntry::new(0, dk(1), None, 0, RowData::Live { cells: vec![] });
         assert!(
-            KWayMerger::reconcile_cluster(None, vec![row], &::std::collections::HashMap::new())
-                .is_none(),
+            KWayMerger::reconcile_cluster(
+                None,
+                vec![row],
+                &::std::collections::HashMap::new(),
+                None
+            )
+            .is_none(),
             "empty live row with no metadata must not emit an entry"
         );
     }
@@ -5967,6 +6275,7 @@ mod issue_886_merge_entry_enrichment {
             None,
             vec![complex_only],
             &::std::collections::HashMap::new(),
+            None,
         )
         .expect("complex-deletion-only cluster must still emit an entry");
         assert!(
@@ -6199,6 +6508,7 @@ mod issue_899_per_element_merge {
             None,
             vec![newer, older],
             &::std::collections::HashMap::new(),
+            None,
         )
         .expect("a live row must be emitted");
         let cells = match merged.row_data {
@@ -6271,6 +6581,7 @@ mod issue_899_per_element_merge {
             None,
             vec![new_el, old_el],
             &::std::collections::HashMap::new(),
+            None,
         )
         .expect("a live row must be emitted");
 
@@ -6365,6 +6676,7 @@ mod issue_899_per_element_merge {
             None,
             vec![survivor, covered],
             &::std::collections::HashMap::new(),
+            None,
         )
         .expect("a live row must be emitted");
 
@@ -6478,6 +6790,7 @@ mod issue_899_per_element_merge {
             None,
             vec![strong, weak],
             &::std::collections::HashMap::new(),
+            None,
         )
         .expect("a live row must be emitted");
 
@@ -6602,6 +6915,7 @@ mod issue_899_per_element_merge {
             None,
             vec![row_tomb, carrier],
             &::std::collections::HashMap::new(),
+            None,
         )
         .expect("a row must be emitted (it carries a row tombstone + survivor)");
 
@@ -6869,6 +7183,7 @@ mod issue_822_merge_ordering_semantics {
             current_partition: None,
             gc_before_secs: None,
             now_secs: None,
+            purge_safe: false,
             schema,
         }
     }
@@ -7254,6 +7569,7 @@ mod issue_822_merge_ordering_semantics {
             Some(ClusteringKey::single("ck", Value::Integer(7))),
             vec![CellOperation::Delete {
                 column: "v".to_string(),
+                local_deletion_time: None,
             }],
             TS,
             None,
@@ -7382,6 +7698,7 @@ mod issue_822_merge_ordering_semantics {
             Some(ClusteringKey::single("ck", Value::Integer(7))),
             vec![CellOperation::Delete {
                 column: "v".to_string(),
+                local_deletion_time: None,
             }],
             TS,
             None,
@@ -7770,6 +8087,7 @@ mod issue_886_empty_partition_skip {
             current_partition: None,
             gc_before_secs: None,
             now_secs: None,
+            purge_safe: false,
             schema,
         }
     }
@@ -8054,6 +8372,7 @@ mod issue_912_row_tombstone_clustering_identity {
             current_partition: None,
             gc_before_secs: None,
             now_secs: None,
+            purge_safe: false,
             schema: schema.clone(),
         };
         let merged = merger
@@ -8134,6 +8453,7 @@ mod issue_873_preserve_row_tombstone_ldt {
             None,
             vec![tombstone_entry(0, deletion_time, source_ldt)],
             &HashMap::new(),
+            None,
         )
         .expect("a surviving row tombstone must be emitted");
 
@@ -8162,7 +8482,7 @@ mod issue_873_preserve_row_tombstone_ldt {
         let older = tombstone_entry(0, 100_000_000, 1_900_000_000);
         let newer = tombstone_entry(1, 200_000_000, 1_500_000_000);
 
-        let merged = KWayMerger::reconcile_cluster(None, vec![older, newer], &HashMap::new())
+        let merged = KWayMerger::reconcile_cluster(None, vec![older, newer], &HashMap::new(), None)
             .expect("a surviving row tombstone must be emitted");
 
         match merged.row_data {
@@ -8302,6 +8622,7 @@ mod issue_873_preserve_row_tombstone_ldt {
             current_partition: None,
             gc_before_secs: None,
             now_secs: None,
+            purge_safe: false,
             schema: schema.clone(),
         };
 
@@ -8354,6 +8675,782 @@ mod issue_873_preserve_row_tombstone_ldt {
         assert!(
             saw_tombstone,
             "the rewritten SSTable must contain the row tombstone"
+        );
+    }
+}
+
+// ── Issue #845 (Epic #921): gc_grace / gcBefore tombstone purging ────────────
+//
+// Parity Cassandra `8d47ebb2` (`cursor-compaction-completion`): a tombstone
+// whose `localDeletionTime < gcBefore` is PURGEABLE and dropped from the
+// compaction output; one within grace (`localDeletionTime >= gcBefore`) is
+// RETAINED. The purge runs as a SEPARATE stage AFTER shadow-before-purge
+// (#887) and the row-tombstone / dropped-column filters, so covered cells
+// are already removed before any marker is purged (no resurrection). When
+// `gc_before_secs` is `None`, the stage is a strict no-op.
+#[cfg(all(test, feature = "write-support"))]
+mod issue_845_gc_grace_purge {
+    use super::*;
+    use crate::schema::{KeyColumn, TableSchema};
+    use crate::storage::write_engine::mutation::DecoratedKey;
+    use crate::types::{TombstoneInfo, TombstoneType};
+    use std::collections::HashMap;
+
+    fn dk(byte: u8) -> DecoratedKey {
+        DecoratedKey::from_key_bytes(vec![byte]).expect("token")
+    }
+
+    fn live(run_index: usize, row_ts: i64, cells: Vec<CellData>) -> MergeEntry {
+        MergeEntry::new(run_index, dk(1), None, row_ts, RowData::Live { cells })
+    }
+
+    fn unclustered_schema() -> TableSchema {
+        TableSchema {
+            keyspace: "ks845".to_string(),
+            table: "t845".to_string(),
+            partition_keys: vec![KeyColumn {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![],
+            columns: vec![],
+            comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
+        }
+    }
+
+    fn tombstone_entry(run_index: usize, deletion_time: i64, ldt: i32) -> MergeEntry {
+        MergeEntry::new(
+            run_index,
+            DecoratedKey::new(500, 7i32.to_be_bytes().to_vec()),
+            None,
+            deletion_time,
+            RowData::Tombstone {
+                deletion_time,
+                local_deletion_time: ldt,
+            },
+        )
+    }
+
+    /// A single-cell tombstone `CellData` for column `v` carrying its LDT.
+    fn cell_tombstone(ts: i64, ldt: i32) -> CellData {
+        CellData {
+            column: "v".to_string(),
+            value: Value::Tombstone(TombstoneInfo {
+                deletion_time: ts,
+                tombstone_type: TombstoneType::CellTombstone,
+                local_deletion_time: ldt as i64,
+                ttl: None,
+                range_start: None,
+                range_end: None,
+            }),
+            timestamp: ts,
+            ttl: None,
+            cell_path: None,
+            local_deletion_time: Some(ldt),
+            is_complex_element: false,
+            is_deleted: false,
+            has_empty_value: false,
+        }
+    }
+
+    /// A complex-deletion marker whose LDT is older than gcBefore is purged; an
+    /// equivalent marker within grace is retained. Boundary: `== gcBefore` is
+    /// RETAINED (only strictly-less purges).
+    #[test]
+    fn issue_845_complex_deletion_purged_when_older_than_gc_before() {
+        const GC_BEFORE: i64 = 1_700_000_000;
+        // Marker covers NOTHING (no live elements), so purging cannot resurrect.
+        let make = |ldt: i32| {
+            MergeEntry::new(0, dk(1), None, 0, RowData::Live { cells: vec![] })
+                .with_complex_deletions(vec![ComplexDeletion {
+                    column: "tags".to_string(),
+                    marked_for_delete_at: 50,
+                    local_deletion_time: ldt,
+                }])
+        };
+
+        // Older than gcBefore → purgeable → the marker is dropped, and with no
+        // surviving data + no row tombstone the whole entry vanishes.
+        let purged = KWayMerger::reconcile_cluster(
+            None,
+            vec![make((GC_BEFORE - 1) as i32)],
+            &::std::collections::HashMap::new(),
+            Some(GC_BEFORE),
+        );
+        assert!(
+            purged.is_none(),
+            "a complex-deletion marker older than gcBefore must be purged, \
+             leaving nothing to emit"
+        );
+
+        // Within grace (strictly newer) → retained.
+        let retained = KWayMerger::reconcile_cluster(
+            None,
+            vec![make((GC_BEFORE + 1) as i32)],
+            &::std::collections::HashMap::new(),
+            Some(GC_BEFORE),
+        )
+        .expect("a within-grace marker must keep a metadata-only entry");
+        assert_eq!(
+            retained.complex_deletions.len(),
+            1,
+            "a complex-deletion marker within grace must be retained"
+        );
+
+        // Boundary: LDT == gcBefore is RETAINED (only `< gcBefore` purges).
+        let boundary = KWayMerger::reconcile_cluster(
+            None,
+            vec![make(GC_BEFORE as i32)],
+            &::std::collections::HashMap::new(),
+            Some(GC_BEFORE),
+        )
+        .expect("a marker at exactly gcBefore must be retained");
+        assert_eq!(
+            boundary.complex_deletions.len(),
+            1,
+            "localDeletionTime == gcBefore is within grace (only `<` purges)"
+        );
+    }
+
+    /// A row tombstone whose LDT is older than gcBefore is purged; an equivalent
+    /// one within grace is retained. Boundary `== gcBefore` is RETAINED.
+    #[test]
+    fn issue_845_row_tombstone_purged_when_older_than_gc_before() {
+        const GC_BEFORE: i64 = 1_700_000_000;
+        // deletion_time (micros) chosen so it does not equal LDT (seconds).
+        let dt = 1_000_000_000_000_000i64;
+
+        let older = KWayMerger::reconcile_cluster(
+            None,
+            vec![tombstone_entry(0, dt, (GC_BEFORE - 1) as i32)],
+            &::std::collections::HashMap::new(),
+            Some(GC_BEFORE),
+        );
+        assert!(
+            older.is_none(),
+            "a row tombstone older than gcBefore must be purged (nothing emitted)"
+        );
+
+        let within = KWayMerger::reconcile_cluster(
+            None,
+            vec![tombstone_entry(0, dt, (GC_BEFORE + 1) as i32)],
+            &::std::collections::HashMap::new(),
+            Some(GC_BEFORE),
+        )
+        .expect("a within-grace row tombstone must be retained");
+        assert!(
+            matches!(within.row_data, RowData::Tombstone { .. }),
+            "a within-grace row tombstone must survive"
+        );
+
+        let boundary = KWayMerger::reconcile_cluster(
+            None,
+            vec![tombstone_entry(0, dt, GC_BEFORE as i32)],
+            &::std::collections::HashMap::new(),
+            Some(GC_BEFORE),
+        )
+        .expect("a row tombstone at exactly gcBefore must be retained");
+        assert!(
+            matches!(boundary.row_data, RowData::Tombstone { .. }),
+            "localDeletionTime == gcBefore is within grace (only `<` purges)"
+        );
+    }
+
+    /// A simple cell tombstone whose LDT is older than gcBefore is purged; one
+    /// within grace is retained. Boundary `== gcBefore` is RETAINED.
+    #[test]
+    fn issue_845_cell_tombstone_purged_when_older_than_gc_before() {
+        const GC_BEFORE: i64 = 1_700_000_000;
+        // A live cell on a SEPARATE column keeps the row alive so we observe the
+        // tombstone cell being dropped (not the row collapsing). Its ts is well
+        // above any tombstone ts so row-tombstone shadowing is irrelevant here.
+        let keep = CellData::new("name".to_string(), Value::Text("alive".to_string()), 500);
+
+        let count_tombstone_cells = |ldt: i32| -> usize {
+            let merged = KWayMerger::reconcile_cluster(
+                None,
+                vec![live(0, 500, vec![keep.clone(), cell_tombstone(100, ldt)])],
+                &::std::collections::HashMap::new(),
+                Some(GC_BEFORE),
+            )
+            .expect("a live row must be emitted");
+            match merged.row_data {
+                RowData::Live { cells } => cells
+                    .iter()
+                    .filter(|c| KWayMerger::is_cell_tombstone(c))
+                    .count(),
+                other => panic!("expected Live, got {other:?}"),
+            }
+        };
+
+        assert_eq!(
+            count_tombstone_cells((GC_BEFORE - 1) as i32),
+            0,
+            "a cell tombstone older than gcBefore must be purged from the row"
+        );
+        assert_eq!(
+            count_tombstone_cells((GC_BEFORE + 1) as i32),
+            1,
+            "a cell tombstone within grace must be retained"
+        );
+        assert_eq!(
+            count_tombstone_cells(GC_BEFORE as i32),
+            1,
+            "localDeletionTime == gcBefore is within grace (only `<` purges)"
+        );
+    }
+
+    /// When `gc_before_secs` is `None` the purge stage is a strict no-op: an
+    /// ancient tombstone (LDT far in the past) is RETAINED, preserving the
+    /// pre-#845 behavior.
+    #[test]
+    fn issue_845_no_gc_before_retains_everything() {
+        let dt = 1_000_000_000_000_000i64;
+        let merged = KWayMerger::reconcile_cluster(
+            None,
+            vec![tombstone_entry(0, dt, 1)],
+            &::std::collections::HashMap::new(),
+            None,
+        )
+        .expect("without gcBefore the tombstone must be retained");
+        assert!(
+            matches!(merged.row_data, RowData::Tombstone { .. }),
+            "with gc_before_secs = None nothing is purged"
+        );
+    }
+
+    /// CRITICAL no-resurrection guard: a complex-deletion marker that SHADOWS a
+    /// covered element (ts <= mfda) must remove that element in Step 2b BEFORE
+    /// the marker is purged in the gc stage. After purging the marker, the
+    /// covered element must NOT reappear.
+    #[test]
+    fn issue_845_purge_does_not_resurrect_shadowed_element() {
+        const GC_BEFORE: i64 = 1_700_000_000;
+        const MFDA: i64 = 200;
+        // A complex ELEMENT (carries a cell_path) of column `tags` written at
+        // ts == MFDA, so it is shadowed (`ts <= mfda`) by the marker.
+        let covered = CellData {
+            column: "tags".to_string(),
+            value: Value::Text("ghost".to_string()),
+            timestamp: MFDA,
+            ttl: None,
+            cell_path: Some(vec![1, 2, 3]),
+            local_deletion_time: None,
+            is_complex_element: true,
+            is_deleted: false,
+            has_empty_value: false,
+        };
+        let entry = MergeEntry::new(
+            0,
+            dk(1),
+            None,
+            MFDA,
+            RowData::Live {
+                cells: vec![covered],
+            },
+        )
+        .with_complex_deletions(vec![ComplexDeletion {
+            column: "tags".to_string(),
+            marked_for_delete_at: MFDA,
+            // Marker is older than gcBefore → purgeable.
+            local_deletion_time: (GC_BEFORE - 1) as i32,
+        }]);
+
+        let merged = KWayMerger::reconcile_cluster(
+            None,
+            vec![entry],
+            &::std::collections::HashMap::new(),
+            Some(GC_BEFORE),
+        );
+        // The covered element was shadowed (removed) in Step 2b, then the marker
+        // was purged: nothing survives, so no entry is emitted — and crucially
+        // the shadowed element is NOT resurrected as a live cell.
+        assert!(
+            merged.is_none(),
+            "purging the marker must not resurrect the element it shadowed"
+        );
+    }
+
+    /// `compute_gc_before` derives `now - gc_grace_seconds` from the schema's
+    /// `gc_grace_seconds` comment. When ABSENT it falls back to Cassandra's
+    /// table DEFAULT of 864000s (#921 finding 3); INVALID values return `None`.
+    #[test]
+    fn issue_845_compute_gc_before_from_schema() {
+        let mut schema = unclustered_schema();
+        let now = 2_000_000_000i64;
+
+        // gc_grace_seconds = 0 → gcBefore == now (immediate purge eligibility).
+        schema
+            .comments
+            .insert("gc_grace_seconds".to_string(), "0".to_string());
+        assert_eq!(compute_gc_before(&schema, now), Some(now));
+
+        // gc_grace_seconds = 864000 (10 days) → gcBefore == now - 864000.
+        schema
+            .comments
+            .insert("gc_grace_seconds".to_string(), "864000".to_string());
+        assert_eq!(compute_gc_before(&schema, now), Some(now - 864_000));
+
+        // Unparseable → None (never purge on bad metadata).
+        schema
+            .comments
+            .insert("gc_grace_seconds".to_string(), "not-a-number".to_string());
+        assert_eq!(compute_gc_before(&schema, now), None);
+    }
+
+    /// #921 finding 3: a table that OMITS `gc_grace_seconds` must use
+    /// Cassandra's DEFAULT of 864000s (10 days), not disable purging. A NEGATIVE
+    /// or unparseable value is rejected conservatively (`None`, no purge); 0 is
+    /// valid (immediate grace).
+    #[test]
+    fn issue_921_compute_gc_before_defaults_to_864000_when_absent() {
+        let mut schema = unclustered_schema();
+        let now = 2_000_000_000i64;
+
+        // ABSENT → Cassandra default 864000s (NOT None / disabled).
+        assert_eq!(
+            compute_gc_before(&schema, now),
+            Some(now - 864_000),
+            "missing gc_grace_seconds must use the Cassandra default of 864000s"
+        );
+
+        // 0 is a VALID value (immediate grace) per Cassandra → gcBefore == now.
+        schema
+            .comments
+            .insert("gc_grace_seconds".to_string(), "0".to_string());
+        assert_eq!(
+            compute_gc_before(&schema, now),
+            Some(now),
+            "gc_grace_seconds = 0 is valid (immediate grace)"
+        );
+
+        // NEGATIVE → None (never purge on out-of-range metadata).
+        schema
+            .comments
+            .insert("gc_grace_seconds".to_string(), "-1".to_string());
+        assert_eq!(
+            compute_gc_before(&schema, now),
+            None,
+            "a negative gc_grace_seconds must disable purging (no-op)"
+        );
+
+        // Unparseable → None.
+        schema
+            .comments
+            .insert("gc_grace_seconds".to_string(), "garbage".to_string());
+        assert_eq!(
+            compute_gc_before(&schema, now),
+            None,
+            "an unparseable gc_grace_seconds must disable purging (no-op)"
+        );
+    }
+
+    /// #921 finding 2: on-disk `localDeletionTime` is an UNSIGNED 32-bit count.
+    /// A far-future LDT with bit 31 set (e.g. `0x8000_0000` ≈ year 2038) is
+    /// carried as a NEGATIVE `i32`. The purge compare must normalize it as
+    /// unsigned (`i64::from(ldt as u32)`) so it reads as a LARGE future second
+    /// and is NOT purged by a normal `gcBefore`. The pre-fix `as i64` path made
+    /// it look ancient and purged the tombstone immediately (resurrection bug).
+    #[test]
+    fn issue_921_unsigned_local_deletion_time_not_purged() {
+        // bit 31 set: as i32 this is negative (-2147483648); as u32 it is
+        // 2_147_483_648 seconds ≈ 2038-01-19 — far in the future.
+        let future_ldt_bits = 0x8000_0000u32 as i32;
+        assert!(future_ldt_bits < 0, "the wrapped LDT is a negative i32");
+        // A normal gcBefore well below the unsigned value: nothing should purge.
+        const GC_BEFORE: i64 = 1_700_000_000;
+        assert!(
+            i64::from(future_ldt_bits as u32) > GC_BEFORE,
+            "the unsigned LDT is in the future relative to gcBefore"
+        );
+
+        // (a) Row tombstone with the far-future LDT must be RETAINED.
+        let dt = 1_000_000_000_000_000i64;
+        let row = KWayMerger::reconcile_cluster(
+            None,
+            vec![tombstone_entry(0, dt, future_ldt_bits)],
+            &::std::collections::HashMap::new(),
+            Some(GC_BEFORE),
+        )
+        .expect("a far-future row tombstone must NOT be purged");
+        assert!(
+            matches!(row.row_data, RowData::Tombstone { .. }),
+            "an unsigned far-future row tombstone must survive a normal gcBefore"
+        );
+
+        // (b) Complex-deletion marker with the far-future LDT must be RETAINED.
+        let complex = KWayMerger::reconcile_cluster(
+            None,
+            vec![
+                MergeEntry::new(0, dk(1), None, 0, RowData::Live { cells: vec![] })
+                    .with_complex_deletions(vec![ComplexDeletion {
+                        column: "tags".to_string(),
+                        marked_for_delete_at: 50,
+                        local_deletion_time: future_ldt_bits,
+                    }]),
+            ],
+            &::std::collections::HashMap::new(),
+            Some(GC_BEFORE),
+        )
+        .expect("a far-future complex-deletion marker must NOT be purged");
+        assert_eq!(
+            complex.complex_deletions.len(),
+            1,
+            "an unsigned far-future complex marker must survive a normal gcBefore"
+        );
+
+        // (c) Cell tombstone with the far-future LDT must be RETAINED.
+        let keep = CellData::new("name".to_string(), Value::Text("alive".to_string()), 500);
+        let cell = KWayMerger::reconcile_cluster(
+            None,
+            vec![live(
+                0,
+                500,
+                vec![keep, cell_tombstone(100, future_ldt_bits)],
+            )],
+            &::std::collections::HashMap::new(),
+            Some(GC_BEFORE),
+        )
+        .expect("a live row must be emitted");
+        let tombstone_cells = match cell.row_data {
+            RowData::Live { cells } => cells
+                .iter()
+                .filter(|c| KWayMerger::is_cell_tombstone(c))
+                .count(),
+            other => panic!("expected Live, got {other:?}"),
+        };
+        assert_eq!(
+            tombstone_cells, 1,
+            "an unsigned far-future cell tombstone must survive a normal gcBefore"
+        );
+
+        // Control: a genuinely ancient LDT (bit 31 clear, < gcBefore) IS purged,
+        // proving the normalization did not disable purging wholesale.
+        let ancient = KWayMerger::reconcile_cluster(
+            None,
+            vec![tombstone_entry(0, dt, (GC_BEFORE - 1) as i32)],
+            &::std::collections::HashMap::new(),
+            Some(GC_BEFORE),
+        );
+        assert!(
+            ancient.is_none(),
+            "a genuinely ancient row tombstone must still be purged"
+        );
+    }
+
+    /// #921 finding 1 (SAFETY-CRITICAL): a PARTIAL compaction (not overlap-safe)
+    /// must NOT purge tombstones — purging one could resurrect data shadowed in a
+    /// non-included overlapping SSTable. A MAJOR/full compaction (overlap-safe)
+    /// purges. Drives the gate through `merge_partition_rows`, which collapses
+    /// the gc_grace cutoff to `None` unless `purge_safe` is set.
+    #[test]
+    fn issue_921_partial_compaction_does_not_purge_but_major_does() {
+        const GC_BEFORE: i64 = 1_700_000_000;
+        let dt = 1_000_000_000_000_000i64;
+        // A row tombstone old enough to be purgeable (LDT < gcBefore).
+        let ancient_ldt = (GC_BEFORE - 1) as i32;
+
+        // Build a merger with NO runs (merge_partition_rows ignores `runs`),
+        // gc_before set, and toggle only `purge_safe`.
+        let merger = |purge_safe: bool| KWayMerger {
+            runs: vec![],
+            heap: BinaryHeap::new(),
+            current_partition: None,
+            schema: unclustered_schema(),
+            gc_before_secs: Some(GC_BEFORE),
+            now_secs: None,
+            purge_safe,
+        };
+
+        // PARTIAL compaction (purge_safe = false): the purgeable row tombstone is
+        // RETAINED — the partial path must never drop a tombstone.
+        let partial = merger(false)
+            .merge_partition_rows(vec![tombstone_entry(0, dt, ancient_ldt)])
+            .expect("merge must succeed");
+        assert_eq!(
+            partial.len(),
+            1,
+            "a partial (non-overlap-safe) compaction must RETAIN the tombstone"
+        );
+        assert!(
+            matches!(partial[0].row_data, RowData::Tombstone { .. }),
+            "the retained entry must still be a row tombstone (no resurrection risk)"
+        );
+
+        // MAJOR compaction (purge_safe = true): the same purgeable tombstone IS
+        // dropped — overlap-safe, so purging cannot resurrect anything.
+        let major = merger(true)
+            .merge_partition_rows(vec![tombstone_entry(0, dt, ancient_ldt)])
+            .expect("merge must succeed");
+        assert!(
+            major.is_empty(),
+            "a major (overlap-safe) compaction must PURGE the ancient tombstone"
+        );
+    }
+
+    /// #921 finding 2: a row tombstone with `local_deletion_time == 0` is the
+    /// "LDT not surfaced" placeholder used by legacy/pre-V5 paths. It must be
+    /// treated as UNKNOWN and RETAINED under purge-safe compaction (never purge
+    /// on unknown LDT). Only a real, non-zero LDT strictly below `gcBefore`
+    /// purges; a within-grace LDT is retained.
+    #[test]
+    fn issue_921_row_tombstone_ldt_zero_is_unknown_and_retained() {
+        const GC_BEFORE: i64 = 1_700_000_000;
+        let dt = 1_000_000_000_000_000i64;
+
+        // LDT == 0 (unknown placeholder): RETAINED even though `0 < gcBefore`.
+        let unknown = KWayMerger::reconcile_cluster(
+            None,
+            vec![tombstone_entry(0, dt, 0)],
+            &::std::collections::HashMap::new(),
+            Some(GC_BEFORE),
+        )
+        .expect("a row tombstone with unknown (0) LDT must be RETAINED, not purged");
+        assert!(
+            matches!(unknown.row_data, RowData::Tombstone { .. }),
+            "LDT==0 is the unknown placeholder and must be retained (never purge \
+             on unknown LDT)"
+        );
+
+        // A REAL, non-zero ancient LDT (< gcBefore) still purges.
+        let ancient = KWayMerger::reconcile_cluster(
+            None,
+            vec![tombstone_entry(0, dt, (GC_BEFORE - 1) as i32)],
+            &::std::collections::HashMap::new(),
+            Some(GC_BEFORE),
+        );
+        assert!(
+            ancient.is_none(),
+            "a real non-zero ancient row tombstone (LDT < gcBefore) must still purge"
+        );
+
+        // Within-grace LDT (>= gcBefore) is retained.
+        let within = KWayMerger::reconcile_cluster(
+            None,
+            vec![tombstone_entry(0, dt, (GC_BEFORE + 1) as i32)],
+            &::std::collections::HashMap::new(),
+            Some(GC_BEFORE),
+        )
+        .expect("a within-grace row tombstone must be retained");
+        assert!(
+            matches!(within.row_data, RowData::Tombstone { .. }),
+            "a within-grace row tombstone (LDT >= gcBefore) must survive"
+        );
+    }
+
+    /// #921 finding 3: a CLUSTERED row whose only non-key data is a PURGEABLE
+    /// cell tombstone must emit NOTHING after the gc purge — no phantom key-only
+    /// live row. The `purged_to_empty` determination must run AFTER the cell
+    /// tombstone purge. A clustered row with REAL surviving (non-key) data still
+    /// emits a live row.
+    #[test]
+    fn issue_921_clustered_row_with_only_purgeable_cell_tombstone_emits_nothing() {
+        const GC_BEFORE: i64 = 1_700_000_000;
+        // Clustering key column `ck` (a pseudo-cell that stays in the cell list).
+        let ck = ClusteringKey {
+            columns: vec![("ck".to_string(), Value::Text("c1".to_string()))],
+        };
+        // The clustering-key pseudo-cell carried alongside the data cells (mirrors
+        // `extract_clustering_key` keeping CK columns in the cell list for
+        // read-back). It is NOT a data cell (its column name is in `ck_names`).
+        let ck_cell = CellData::new("ck".to_string(), Value::Text("c1".to_string()), 100);
+
+        let make = |extra: Vec<CellData>| {
+            let mut cells = vec![ck_cell.clone()];
+            cells.extend(extra);
+            MergeEntry::new(0, dk(1), Some(ck.clone()), 100, RowData::Live { cells })
+        };
+
+        // Only non-key data is a purgeable (ancient LDT) cell tombstone on `v`.
+        // After the gc purge the row has only the CK pseudo-cell left → it must
+        // be recognized as purged-to-empty and emit NOTHING (no phantom live row).
+        let purged = KWayMerger::reconcile_cluster(
+            Some(ck.clone()),
+            vec![make(vec![cell_tombstone(50, (GC_BEFORE - 1) as i32)])],
+            &::std::collections::HashMap::new(),
+            Some(GC_BEFORE),
+        );
+        assert!(
+            purged.is_none(),
+            "a clustered row whose only non-key data is a purgeable cell tombstone \
+             must emit NOTHING (no phantom key-only live row) after the gc purge"
+        );
+
+        // Control: a clustered row with REAL surviving non-key data still emits a
+        // live row (the purge of the tombstone does not collapse a real row).
+        let kept = KWayMerger::reconcile_cluster(
+            Some(ck.clone()),
+            vec![make(vec![
+                CellData::new("v".to_string(), Value::Text("real".to_string()), 60),
+                cell_tombstone(50, (GC_BEFORE - 1) as i32),
+            ])],
+            &::std::collections::HashMap::new(),
+            Some(GC_BEFORE),
+        )
+        .expect("a clustered row with real surviving data must emit a live row");
+        match kept.row_data {
+            RowData::Live { cells } => {
+                assert!(
+                    cells
+                        .iter()
+                        .any(|c| c.column == "v" && !KWayMerger::is_cell_tombstone(c)),
+                    "the real surviving `v` cell must remain in the emitted live row"
+                );
+                assert!(
+                    !cells.iter().any(KWayMerger::is_cell_tombstone),
+                    "the purgeable cell tombstone must still be purged from the live row"
+                );
+            }
+            other => panic!("expected Live row, got {other:?}"),
+        }
+    }
+
+    /// #921 finding 2: the dropped-column survivor pre-pass
+    /// (`compute_surviving_dropped_columns`) must count a RETAINED
+    /// `ComplexDeletion` marker for a dropped COMPLEX column as a survivor.
+    ///
+    /// A complex (collection) tombstone lives in `row.complex_deletions`, NOT in
+    /// `cells`. The pre-fix pre-pass counted only live `cells`, so a dropped
+    /// complex column whose only survivor is a within-grace / purge-unsafe
+    /// complex-deletion marker was stripped from the output schema — and since the
+    /// writer only emits complex-element columns present in the schema, the marker
+    /// was silently dropped despite the merge deciding to RETAIN it.
+    ///
+    /// This drives the FULL merge→writer→on-disk path: it writes a `tags`
+    /// complex-deletion marker (no live elements) to a real SSTable, then runs the
+    /// survivor pre-pass over that file with `tags` dropped. With no gc (`None`),
+    /// the marker is RETAINED so `tags` MUST be counted as a survivor; with a gc
+    /// cutoff strictly above the marker's LDT (and `purge_safe`), the marker is
+    /// PURGED so `tags` MUST NOT be counted. Mirrors the cell-vs-marker asymmetry
+    /// the writer sees.
+    #[tokio::test]
+    async fn issue_921_complex_deletion_marker_counts_as_dropped_column_survivor() {
+        use crate::schema::Column;
+
+        // An in-memory run yielding a fixed `MergeEntry` so we drive the FULL
+        // production merge→writer path onto a real on-disk SSTable.
+        struct VecIterator(std::vec::IntoIter<MergeEntry>);
+        impl SSTableRowIterator for VecIterator {
+            fn next(&mut self) -> Option<Result<MergeEntry>> {
+                self.0.next().map(Ok)
+            }
+        }
+
+        // Schema with a non-frozen complex column `tags set<text>`. Drop map is
+        // applied per-call below.
+        fn schema_with_tags(dropped: HashMap<String, i64>) -> TableSchema {
+            TableSchema {
+                keyspace: "ks921".to_string(),
+                table: "t921".to_string(),
+                partition_keys: vec![KeyColumn {
+                    name: "id".to_string(),
+                    data_type: "int".to_string(),
+                    position: 0,
+                }],
+                clustering_keys: vec![],
+                columns: vec![
+                    Column {
+                        name: "id".to_string(),
+                        data_type: "int".to_string(),
+                        nullable: false,
+                        default: None,
+                        is_static: false,
+                    },
+                    Column {
+                        name: "tags".to_string(),
+                        data_type: "set<text>".to_string(),
+                        nullable: true,
+                        default: None,
+                        is_static: false,
+                    },
+                ],
+                comments: HashMap::new(),
+                dropped_columns: dropped,
+            }
+        }
+
+        const MARKER_LDT: i32 = 1_700_000_000;
+        const MARKER_MFDA: i64 = 1_600_000_000_000_000; // micros
+
+        // Write an SSTable whose single partition carries ONLY a `tags`
+        // complex-deletion marker (no surviving live elements, no other cells), so
+        // the column's sole survivor is the marker — exactly the case the pre-fix
+        // pre-pass missed.
+        let write_schema = schema_with_tags(HashMap::new());
+        let entry = MergeEntry::new(
+            0,
+            DecoratedKey::new(7, 7i32.to_be_bytes().to_vec()),
+            None,
+            0,
+            RowData::Live { cells: vec![] },
+        )
+        .with_complex_deletions(vec![ComplexDeletion {
+            column: "tags".to_string(),
+            marked_for_delete_at: MARKER_MFDA,
+            local_deletion_time: MARKER_LDT,
+        }]);
+
+        let merger = KWayMerger {
+            runs: vec![RunReader::new(Box::new(VecIterator(
+                vec![entry].into_iter(),
+            )))],
+            heap: std::collections::BinaryHeap::new(),
+            current_partition: None,
+            gc_before_secs: None,
+            now_secs: None,
+            purge_safe: false,
+            schema: write_schema.clone(),
+        };
+
+        let temp_dir = tempfile::TempDir::new().expect("temp dir");
+        let mut writer = crate::storage::sstable::writer::SSTableWriter::new(
+            temp_dir.path().to_path_buf(),
+            1,
+            &write_schema,
+        )
+        .expect("create writer");
+        merger.merge(&mut writer).expect("merge+write must succeed");
+        let info = writer.finish().await.expect("finish must succeed");
+        let data_path = info.data_path;
+
+        // Drop `tags`; the column stays in `columns` (decode contract) with a drop
+        // time well before the marker so a re-add filter does not interfere.
+        let mut dropped = HashMap::new();
+        dropped.insert("tags".to_string(), 1_i64);
+        let drop_schema = schema_with_tags(dropped);
+
+        // (a) No gc → the marker is RETAINED → `tags` MUST be a survivor.
+        let retained = compute_surviving_dropped_columns(
+            vec![data_path.clone()],
+            &drop_schema,
+            None,
+            None,
+            false,
+        )
+        .expect("survivor pre-pass (no gc) must succeed");
+        assert!(
+            retained.contains("tags"),
+            "a RETAINED complex-deletion marker for a dropped complex column must \
+             count as a survivor so the writer keeps the column to emit it; got {retained:?}"
+        );
+
+        // (b) gc strictly above the marker's LDT + purge_safe → the marker is
+        // PURGED → `tags` MUST NOT be a survivor (stripped from the output schema).
+        let gc_before = i64::from(MARKER_LDT) + 1;
+        let purged = compute_surviving_dropped_columns(
+            vec![data_path],
+            &drop_schema,
+            Some(gc_before),
+            Some(gc_before),
+            true,
+        )
+        .expect("survivor pre-pass (purging) must succeed");
+        assert!(
+            !purged.contains("tags"),
+            "a PURGED complex-deletion marker must NOT count as a survivor (the \
+             dropped column is stripped from the output schema); got {purged:?}"
         );
     }
 }

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -1144,8 +1144,22 @@ impl WriteEngine {
             let selected = merge_policy.select_merge(&candidates)?;
 
             if !selected.is_empty() {
+                // Overlap-safety gate for tombstone purging (#921 finding 1): a
+                // compaction may purge tombstones ONLY when it spans EVERY
+                // candidate SSTable for the table (a major/full compaction).
+                // Otherwise a tombstone could be purged while a non-included
+                // overlapping SSTable still holds data it shadows, resurrecting
+                // that data on the next read. A partial selection (the common
+                // background-compaction case) is therefore purge-UNSAFE: it
+                // retains tombstones. Compare as sets so input ordering does not
+                // affect the decision.
+                let selected_set: std::collections::HashSet<&PathBuf> = selected.iter().collect();
+                let candidate_set: std::collections::HashSet<&PathBuf> =
+                    candidates.iter().collect();
+                let purge_safe = !candidate_set.is_empty() && selected_set == candidate_set;
+
                 // Start a new merge
-                self.start_merge(selected)?;
+                self.start_merge(selected, purge_safe)?;
             } else {
                 // No work selected by policy
                 report.time_spent = start.elapsed();
@@ -1400,7 +1414,12 @@ impl WriteEngine {
     ///   by readers scanning for `TOC.txt`.
     /// - A crash after all renames but before input deletion: a harmless duplicate
     ///   exists until next compaction.
-    fn start_merge(&mut self, input_paths: Vec<PathBuf>) -> Result<()> {
+    ///
+    /// `purge_safe` (#921 finding 1): `true` only when `input_paths` spans every
+    /// SSTable for the table (a major/full compaction), allowing gc_grace
+    /// tombstone purging without risking resurrection of data shadowed in a
+    /// non-included overlapping SSTable. `false` keeps every tombstone.
+    fn start_merge(&mut self, input_paths: Vec<PathBuf>, purge_safe: bool) -> Result<()> {
         log::info!(
             "Starting compaction merge of {} SSTables",
             input_paths.len()
@@ -1449,15 +1468,65 @@ impl WriteEngine {
         let effective_schema =
             merge::effective_compaction_schema(&self.config.schema, &input_paths);
 
-        // Create K-way merger
-        let merger = KWayMerger::new(input_paths.clone(), &effective_schema)?;
+        // Create K-way merger.
+        //
+        // gc_grace / gcBefore purging (issue #845): compute `gcBefore = now -
+        // gc_grace_seconds` from the table's `gc_grace_seconds` (read from the
+        // AUTHORITATIVE table schema's options, not the dropped-column-augmented
+        // `effective_schema`). When the table declares no `gc_grace_seconds`,
+        // `compute_gc_before` returns `None` and purging is a strict no-op,
+        // preserving the pre-#845 behavior. `now_secs` is the wall-clock used for
+        // both the purge boundary and TTL evaluation.
+        let now_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+        let gc_before_secs = merge::compute_gc_before(&self.config.schema, now_secs);
+        // Overlap-safety gate (#921 finding 1): only a major/full compaction
+        // (one that spans every candidate SSTable for the table) may purge
+        // tombstones. A partial compaction sets `purge_safe = false`, which
+        // makes the gc_grace purge stage a strict no-op and cannot resurrect
+        // data shadowed in a non-included overlapping SSTable.
+
+        // #921 finding 2: mirror `compact_sstables`' dropped-column survivor
+        // pre-pass. Decode with `effective_schema` (retains dropped columns so
+        // their cells parse and can be purged), but WRITE with a post-drop
+        // schema: a background compaction that purges the LAST cell/tombstone of
+        // a dropped column must NOT emit that column in the output
+        // SerializationHeader (stale header columns misalign a post-drop reader).
+        // The pre-pass uses the SAME gc cutoff AND `purge_safe` as the write
+        // merger below so the two make IDENTICAL purge decisions — a tombstone
+        // purged in the write pass is also purged here and never counted as a
+        // surviving cell. Reuses the exact helper `compact_sstables` uses.
+        let retained_dropped = if effective_schema.dropped_columns.is_empty() {
+            std::collections::HashSet::new()
+        } else {
+            merge::compute_surviving_dropped_columns(
+                input_paths.clone(),
+                &effective_schema,
+                gc_before_secs,
+                Some(now_secs),
+                purge_safe,
+            )?
+        };
+        let write_schema = effective_schema.for_compaction_output(&retained_dropped);
+
+        let merger = KWayMerger::new_with_gc(
+            input_paths.clone(),
+            &effective_schema,
+            gc_before_secs,
+            Some(now_secs),
+        )?
+        .with_purge_safe(purge_safe);
 
         // Point the SSTableWriter at the tmp root; it will write to
-        // tmp_dir/keyspace/table/nb-{gen}-big-*.db
+        // tmp_dir/keyspace/table/nb-{gen}-big-*.db. Use the post-drop
+        // `write_schema` (NOT `effective_schema`) so fully-purged dropped
+        // columns are stripped from the output header (#921 finding 2).
         let mut writer = crate::storage::sstable::writer::SSTableWriter::new(
             tmp_dir.clone(),
             output_generation,
-            &effective_schema,
+            &write_schema,
         )?;
 
         // Two-pass compaction (issue #729): compute output FINAL encoding baselines

--- a/cqlite-core/src/storage/write_engine/mutation.rs
+++ b/cqlite-core/src/storage/write_engine/mutation.rs
@@ -227,6 +227,27 @@ pub enum CellOperation {
     Delete {
         /// Column name
         column: String,
+        /// Optional per-cell `localDeletionTime` (seconds since the Unix epoch,
+        /// the on-disk GC clock) for this cell tombstone (#921 finding 2).
+        ///
+        /// When `Some`, the writer stamps the emitted cell tombstone with this
+        /// LDT VERBATIM rather than deriving one from the enclosing mutation's
+        /// timestamp / [`Mutation::local_deletion_time`]. The compaction
+        /// merge→rewrite path sets it from the SOURCE cell tombstone's own LDT
+        /// (`TombstoneInfo::local_deletion_time`) so a within-grace cell
+        /// tombstone that survives a compaction keeps its original GC clock and
+        /// is not purged too early / kept too long in a LATER compaction.
+        ///
+        /// `None` preserves the historical behavior (the writer derives the LDT
+        /// from the mutation), so the WAL / CQL-DELETE paths that build a
+        /// `Delete` without a surfaced source LDT are unchanged.
+        ///
+        /// `#[serde(default)]` keeps backward compatibility with `Delete`
+        /// values serialized before this field existed (e.g. older WAL records).
+        ///
+        /// [`Mutation::local_deletion_time`]: Mutation::local_deletion_time
+        #[serde(default)]
+        local_deletion_time: Option<i32>,
     },
     /// Delete entire row (row tombstone)
     DeleteRow,
@@ -1214,10 +1235,11 @@ mod tests {
     fn test_cell_operation_delete() {
         let op = CellOperation::Delete {
             column: "name".to_string(),
+            local_deletion_time: None,
         };
 
         match op {
-            CellOperation::Delete { column } => {
+            CellOperation::Delete { column, .. } => {
                 assert_eq!(column, "name");
             }
             _ => panic!("Expected Delete operation"),

--- a/cqlite-core/src/storage/write_engine/wal.rs
+++ b/cqlite-core/src/storage/write_engine/wal.rs
@@ -143,21 +143,123 @@ fn set_secure_permissions(_file: &File) -> Result<()> {
     Ok(())
 }
 
-/// Legacy on-disk `Mutation` layout (pre-Issue #764).
+/// Legacy `CellOperation` layout (pre-Issue #921).
+///
+/// bincode is positional and NOT self-describing: it encodes an enum as a `u32`
+/// variant index followed by that variant's fields, with no field names and no
+/// length/version prefix. Issue #921 added a `local_deletion_time: Option<i32>`
+/// field to [`CellOperation::Delete`], turning the on-disk shape of that variant
+/// from `{ column }` into `{ column, local_deletion_time }`. A `#[serde(default)]`
+/// attribute does NOT help bincode here — there are simply no bytes for the new
+/// field in an older record, so decoding the new `Delete` reads the bytes of the
+/// following operation as the missing `Option<i32>` and the whole record
+/// misaligns.
+///
+/// This mirror enum reproduces the EXACT pre-#921 variant order and shapes so a
+/// record written by an older binary round-trips. Only `Delete` differs (no
+/// `local_deletion_time`). It MUST stay in lockstep with [`CellOperation`]:
+/// variant order is the bincode discriminant, so any reordering / insertion in
+/// the live enum must be reflected here or legacy decoding breaks.
+#[derive(serde::Serialize, serde::Deserialize)]
+enum LegacyCellOperation {
+    Write {
+        column: String,
+        value: crate::types::Value,
+    },
+    WriteWithTtl {
+        column: String,
+        value: crate::types::Value,
+        ttl_seconds: u32,
+    },
+    /// Pre-#921 `Delete` had no `local_deletion_time` field.
+    Delete {
+        column: String,
+    },
+    DeleteRow,
+    WriteComplexElement {
+        column: String,
+        cell_path: Vec<u8>,
+        value: Option<crate::types::Value>,
+        timestamp_micros: i64,
+        ttl_seconds: Option<u32>,
+        local_deletion_time: Option<i32>,
+        is_deleted: bool,
+    },
+    ComplexDeletion {
+        column: String,
+        marked_for_delete_at: i64,
+        local_deletion_time: i32,
+    },
+}
+
+impl From<LegacyCellOperation> for CellOperation {
+    fn from(op: LegacyCellOperation) -> Self {
+        match op {
+            LegacyCellOperation::Write { column, value } => CellOperation::Write { column, value },
+            LegacyCellOperation::WriteWithTtl {
+                column,
+                value,
+                ttl_seconds,
+            } => CellOperation::WriteWithTtl {
+                column,
+                value,
+                ttl_seconds,
+            },
+            // Pre-#921 cell tombstone: no surfaced source LDT, so the writer
+            // derives it from the enclosing mutation (historical behavior).
+            LegacyCellOperation::Delete { column } => CellOperation::Delete {
+                column,
+                local_deletion_time: None,
+            },
+            LegacyCellOperation::DeleteRow => CellOperation::DeleteRow,
+            LegacyCellOperation::WriteComplexElement {
+                column,
+                cell_path,
+                value,
+                timestamp_micros,
+                ttl_seconds,
+                local_deletion_time,
+                is_deleted,
+            } => CellOperation::WriteComplexElement {
+                column,
+                cell_path,
+                value,
+                timestamp_micros,
+                ttl_seconds,
+                local_deletion_time,
+                is_deleted,
+            },
+            LegacyCellOperation::ComplexDeletion {
+                column,
+                marked_for_delete_at,
+                local_deletion_time,
+            } => CellOperation::ComplexDeletion {
+                column,
+                marked_for_delete_at,
+                local_deletion_time,
+            },
+        }
+    }
+}
+
+/// Legacy on-disk `Mutation` layout (pre-Issue #764 / pre-Issue #921).
 ///
 /// The WAL has no per-record version field; mutations are bincode-serialized
 /// directly and bincode is positional, so the `local_deletion_time` field added
-/// in #764 changes the byte layout. To keep recovering WAL records written by an
-/// older binary, `decode_mutation` first tries the current layout and, on
-/// failure, falls back to this legacy layout (which lacks `local_deletion_time`)
-/// and upgrades it to `local_deletion_time: None` — exactly the pre-#764
-/// behavior. The field order here MUST mirror the historical `Mutation` struct.
+/// to [`Mutation`] in #764 — and the `local_deletion_time` field added to
+/// [`CellOperation::Delete`] in #921 — both change the byte layout. To keep
+/// recovering WAL records written by an older binary, `decode_mutation` first
+/// tries the current layout and, on failure, falls back to this legacy layout
+/// (which lacks the `Mutation`-level `local_deletion_time` AND uses the pre-#921
+/// [`LegacyCellOperation`] for `operations`), upgrading both to the historical
+/// `None` behavior. The field order here MUST mirror the historical `Mutation`
+/// struct.
 #[derive(serde::Serialize, serde::Deserialize)]
 struct LegacyMutation {
     table: TableId,
     partition_key: PartitionKey,
     clustering_key: Option<ClusteringKey>,
-    operations: Vec<CellOperation>,
+    operations: Vec<LegacyCellOperation>,
     timestamp_micros: i64,
     ttl_seconds: Option<u32>,
     partition_tombstone: Option<PartitionTombstone>,
@@ -170,7 +272,7 @@ impl From<LegacyMutation> for Mutation {
             table: m.table,
             partition_key: m.partition_key,
             clustering_key: m.clustering_key,
-            operations: m.operations,
+            operations: m.operations.into_iter().map(CellOperation::from).collect(),
             timestamp_micros: m.timestamp_micros,
             ttl_seconds: m.ttl_seconds,
             partition_tombstone: m.partition_tombstone,
@@ -182,14 +284,79 @@ impl From<LegacyMutation> for Mutation {
     }
 }
 
+/// Intermediate on-disk `Mutation` layout (post-Issue #764, pre-Issue #921).
+///
+/// There are three historical WAL record layouts because the WAL has no
+/// per-record version field and bincode is positional:
+///
+/// - **(A)** pre-#764: no `Mutation`-level `local_deletion_time`, old
+///   `Delete { column }` operations — see [`LegacyMutation`].
+/// - **(B)** post-#764 / pre-#921 (THIS struct): the `Mutation`-level
+///   `local_deletion_time: Option<i32>` trailing field is PRESENT, but the
+///   operations still use the pre-#921 `Delete { column }` shape.
+/// - **(C)** current: `Mutation`-level LDT present AND
+///   `Delete { column, local_deletion_time }`.
+///
+/// Layout (B) records are NOT covered by [`LegacyMutation`] (which lacks the
+/// mutation-level LDT) nor by the current [`Mutation`] (whose `Delete` carries
+/// an extra `Option<i32>`), so without this struct a (B) record would fail to
+/// replay and silently lose its mutation-level local deletion time.
+///
+/// The field order MUST mirror the current [`Mutation`] struct exactly, with
+/// only `operations` swapped to [`LegacyCellOperation`].
+#[derive(serde::Serialize, serde::Deserialize)]
+struct LegacyMutationWithLdt {
+    table: TableId,
+    partition_key: PartitionKey,
+    clustering_key: Option<ClusteringKey>,
+    operations: Vec<LegacyCellOperation>,
+    timestamp_micros: i64,
+    ttl_seconds: Option<u32>,
+    partition_tombstone: Option<PartitionTombstone>,
+    range_tombstones: Vec<RangeTombstone>,
+    /// Mutation-level local deletion time added in #764; preserved on upgrade.
+    local_deletion_time: Option<i32>,
+}
+
+impl From<LegacyMutationWithLdt> for Mutation {
+    fn from(m: LegacyMutationWithLdt) -> Self {
+        Mutation {
+            table: m.table,
+            partition_key: m.partition_key,
+            clustering_key: m.clustering_key,
+            operations: m.operations.into_iter().map(CellOperation::from).collect(),
+            timestamp_micros: m.timestamp_micros,
+            ttl_seconds: m.ttl_seconds,
+            partition_tombstone: m.partition_tombstone,
+            range_tombstones: m.range_tombstones,
+            // Preserve the mutation-level LDT that layout (B) carries; only the
+            // pre-#921 cell `Delete` ops lose their (never-present) LDT to None.
+            local_deletion_time: m.local_deletion_time,
+        }
+    }
+}
+
 /// Deserialize a `Mutation` from WAL bytes, tolerating records written by an
-/// older binary that predates the `local_deletion_time` field (Issue #764).
+/// older binary that predates the `Mutation::local_deletion_time` field
+/// (Issue #764) or the `CellOperation::Delete::local_deletion_time` field
+/// (Issue #921).
+///
+/// Attempts the layouts most-recent-first: current (C), then layout (B)
+/// (post-#764/pre-#921: mutation LDT present, old `Delete` op shape), then
+/// layout (A) (pre-#764: no mutation LDT, old `Delete` op shape). Each maps to
+/// the current [`Mutation`]/[`CellOperation`] with `Delete.local_deletion_time
+/// = None`, while layout (B) additionally preserves the mutation-level LDT.
 fn decode_mutation(bytes: &[u8]) -> std::result::Result<Mutation, bincode::Error> {
     match bincode::deserialize::<Mutation>(bytes) {
         Ok(mutation) => Ok(mutation),
         Err(current_err) => {
-            // Fall back to the legacy layout. If that also fails, surface the
-            // original (current-layout) error which is the more informative one.
+            // Layout (B): mutation-level LDT present, pre-#921 Delete ops.
+            if let Ok(m) = bincode::deserialize::<LegacyMutationWithLdt>(bytes) {
+                return Ok(Mutation::from(m));
+            }
+            // Layout (A): pre-#764 (no mutation LDT), pre-#921 Delete ops. If
+            // this also fails, surface the original (current-layout) error,
+            // which is the more informative one.
             bincode::deserialize::<LegacyMutation>(bytes)
                 .map(Mutation::from)
                 .map_err(|_| current_err)
@@ -912,6 +1079,7 @@ mod tests {
         let pk = PartitionKey::single("id", Value::Integer(1));
         let ops = vec![CellOperation::Delete {
             column: "name".to_string(),
+            local_deletion_time: None,
         }];
 
         let mutation = Mutation::new(table_id, pk, None, ops, 1234567890, None);
@@ -990,15 +1158,15 @@ mod tests {
     }
 
     #[test]
-    fn test_wal_decodes_legacy_record_without_local_deletion_time() {
+    fn test_wal_decodes_legacy_record_without_mutation_local_deletion_time() {
         // Issue #764: the WAL has no per-record version field. A record written
-        // by an older binary (legacy layout, no local_deletion_time) must still
-        // decode, upgrading to local_deletion_time: None.
+        // by an older binary (legacy Mutation layout, no Mutation-level
+        // local_deletion_time) must still decode, upgrading to None.
         let legacy = LegacyMutation {
             table: TableId::new("ks", "tbl"),
             partition_key: PartitionKey::single("id", Value::Integer(3)),
             clustering_key: None,
-            operations: vec![CellOperation::Delete {
+            operations: vec![LegacyCellOperation::Delete {
                 column: "name".to_string(),
             }],
             timestamp_micros: 1_234_567_890,
@@ -1007,27 +1175,8 @@ mod tests {
             range_tombstones: Vec::new(),
         };
 
-        // Serialize using the LEGACY layout (no local_deletion_time field).
+        // Serialize using the LEGACY layout.
         let legacy_bytes = bincode::serialize(&legacy).unwrap();
-
-        // Sanity: the new layout has a different length (extra Option byte) so
-        // this genuinely exercises the legacy fallback path.
-        let mutation = Mutation::new(
-            TableId::new("ks", "tbl"),
-            PartitionKey::single("id", Value::Integer(3)),
-            None,
-            vec![CellOperation::Delete {
-                column: "name".to_string(),
-            }],
-            1_234_567_890,
-            None,
-        );
-        let current_bytes = bincode::serialize(&mutation).unwrap();
-        assert_eq!(
-            current_bytes.len(),
-            legacy_bytes.len() + 1,
-            "Current layout should add exactly one byte (Option<i32> discriminant) for None"
-        );
 
         // The fallback must decode the legacy bytes into None.
         let decoded = decode_mutation(&legacy_bytes).expect("legacy record must decode");
@@ -1035,8 +1184,214 @@ mod tests {
         assert_eq!(decoded.timestamp_micros, 1_234_567_890);
         assert!(matches!(
             &decoded.operations[0],
-            CellOperation::Delete { .. }
+            CellOperation::Delete {
+                local_deletion_time: None,
+                ..
+            }
         ));
+    }
+
+    #[test]
+    fn test_wal_decodes_legacy_delete_op_without_local_deletion_time() {
+        // Issue #921: `CellOperation::Delete` gained a `local_deletion_time:
+        // Option<i32>` field. bincode is positional and NOT self-describing, so a
+        // pre-#921 record encoding `Delete { column }` (no LDT) has no bytes for
+        // the new field. Decoding it with the NEW enum reads the following
+        // operation's bytes as the missing Option and misaligns the record;
+        // `#[serde(default)]` does NOT save bincode. The legacy fallback must
+        // recover such a record as `Delete { column, local_deletion_time: None }`.
+        //
+        // The Delete is placed FIRST (followed by a Write) so that a naive new
+        // decode genuinely misreads the trailing operation — this is the case
+        // `#[serde(default)]` cannot handle and that the prior test (which used
+        // only the new enum) failed to exercise.
+        let legacy = LegacyMutation {
+            table: TableId::new("ks", "tbl"),
+            partition_key: PartitionKey::single("id", Value::Integer(7)),
+            clustering_key: None,
+            operations: vec![
+                LegacyCellOperation::Delete {
+                    column: "dropped_col".to_string(),
+                },
+                LegacyCellOperation::Write {
+                    column: "name".to_string(),
+                    value: Value::Text("Bob".to_string()),
+                },
+            ],
+            timestamp_micros: 999_000,
+            ttl_seconds: None,
+            partition_tombstone: None,
+            range_tombstones: Vec::new(),
+        };
+
+        // Bytes as written by a pre-#921 binary.
+        let legacy_bytes = bincode::serialize(&legacy).unwrap();
+
+        // Sanity: the NEW layout adds exactly one byte for the Delete's
+        // Option<i32> discriminant (None), so the legacy bytes are genuinely a
+        // different, shorter shape that the current decode cannot consume cleanly.
+        let current = Mutation::new(
+            TableId::new("ks", "tbl"),
+            PartitionKey::single("id", Value::Integer(7)),
+            None,
+            vec![
+                CellOperation::Delete {
+                    column: "dropped_col".to_string(),
+                    local_deletion_time: None,
+                },
+                CellOperation::Write {
+                    column: "name".to_string(),
+                    value: Value::Text("Bob".to_string()),
+                },
+            ],
+            999_000,
+            None,
+        );
+        let current_bytes = bincode::serialize(&current).unwrap();
+        assert!(
+            current_bytes.len() > legacy_bytes.len(),
+            "Current Delete layout is strictly longer (adds the Option<i32> \
+             discriminant for local_deletion_time): current={}, legacy={}",
+            current_bytes.len(),
+            legacy_bytes.len()
+        );
+
+        // The legacy fallback must recover the record with both ops intact and
+        // the Delete upgraded to local_deletion_time: None.
+        let decoded = decode_mutation(&legacy_bytes).expect("legacy #921 record must decode");
+        assert_eq!(decoded.timestamp_micros, 999_000);
+        assert_eq!(decoded.operations.len(), 2);
+        match &decoded.operations[0] {
+            CellOperation::Delete {
+                column,
+                local_deletion_time,
+            } => {
+                assert_eq!(column, "dropped_col");
+                assert_eq!(*local_deletion_time, None);
+            }
+            other => panic!("expected Delete, got {other:?}"),
+        }
+        match &decoded.operations[1] {
+            CellOperation::Write { column, value } => {
+                assert_eq!(column, "name");
+                assert_eq!(value, &Value::Text("Bob".to_string()));
+            }
+            other => panic!("expected Write, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_wal_roundtrips_delete_with_explicit_local_deletion_time() {
+        // The current layout must round-trip a Delete carrying an explicit
+        // per-cell local_deletion_time (the #921 compaction path).
+        let temp_dir = TempDir::new().unwrap();
+        let mut wal = WriteAheadLog::create(temp_dir.path()).unwrap();
+
+        let mutation = Mutation::new(
+            TableId::new("ks", "tbl"),
+            PartitionKey::single("id", Value::Integer(11)),
+            None,
+            vec![CellOperation::Delete {
+                column: "name".to_string(),
+                local_deletion_time: Some(1_700_000_000),
+            }],
+            1_700_000_000_000_000,
+            None,
+        );
+        wal.append(&mutation).unwrap();
+        wal.sync().unwrap();
+
+        let mutations = wal.replay().unwrap();
+        assert_eq!(mutations.len(), 1);
+        match &mutations[0].operations[0] {
+            CellOperation::Delete {
+                column,
+                local_deletion_time,
+            } => {
+                assert_eq!(column, "name");
+                assert_eq!(*local_deletion_time, Some(1_700_000_000));
+            }
+            other => panic!("expected Delete, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_wal_decodes_layout_b_record_preserving_mutation_local_deletion_time() {
+        // Layout (B): post-#764 / pre-#921. The mutation-level
+        // local_deletion_time trailing field is PRESENT (Some(x)), but the
+        // operations still use the pre-#921 `Delete { column }` shape, with the
+        // Delete placed FIRST so a naive current decode misreads the trailing
+        // op. Neither the current `Mutation` layout (whose Delete carries an
+        // extra Option<i32>) nor `LegacyMutation` (which lacks the mutation-level
+        // LDT) can decode these bytes, so the (B) compat layout is required. The
+        // decoded mutation must preserve the mutation-level LDT AND recover both
+        // ops with `Delete.local_deletion_time = None`.
+        let legacy = LegacyMutationWithLdt {
+            table: TableId::new("ks", "tbl"),
+            partition_key: PartitionKey::single("id", Value::Integer(13)),
+            clustering_key: None,
+            operations: vec![
+                LegacyCellOperation::Delete {
+                    column: "dropped_col".to_string(),
+                },
+                LegacyCellOperation::Write {
+                    column: "name".to_string(),
+                    value: Value::Text("Carol".to_string()),
+                },
+            ],
+            timestamp_micros: 1_650_000_000_000_000,
+            ttl_seconds: None,
+            partition_tombstone: None,
+            range_tombstones: Vec::new(),
+            local_deletion_time: Some(1_650_000_000),
+        };
+
+        // Bytes as written by a post-#764/pre-#921 binary.
+        let legacy_bytes = bincode::serialize(&legacy).unwrap();
+
+        // Sanity: the current `Mutation` layout cannot decode (B) bytes
+        // correctly. The pre-#921 `Delete { column }` op (first in the list) has
+        // no `local_deletion_time` byte, so a current decode either errors or
+        // misaligns and reads a wrong number of operations — it can never
+        // recover the two-op mutation faithfully. This is what forces the (B)
+        // compat layout to run.
+        let current_attempt = bincode::deserialize::<Mutation>(&legacy_bytes);
+        let current_recovers_faithfully = matches!(
+            &current_attempt,
+            Ok(m) if m.operations.len() == 2
+                && matches!(&m.operations[0], CellOperation::Delete { column, .. } if column == "dropped_col")
+                && matches!(&m.operations[1], CellOperation::Write { column, value }
+                    if column == "name" && value == &Value::Text("Carol".to_string()))
+        );
+        assert!(
+            !current_recovers_faithfully,
+            "current layout must NOT faithfully decode a layout (B) record; \
+             otherwise the (B) compat path is never exercised"
+        );
+
+        // The (B) compat layout must recover the record: mutation-level LDT
+        // preserved, both ops intact, Delete upgraded to local_deletion_time: None.
+        let decoded = decode_mutation(&legacy_bytes).expect("layout (B) record must decode");
+        assert_eq!(decoded.local_deletion_time, Some(1_650_000_000));
+        assert_eq!(decoded.timestamp_micros, 1_650_000_000_000_000);
+        assert_eq!(decoded.operations.len(), 2);
+        match &decoded.operations[0] {
+            CellOperation::Delete {
+                column,
+                local_deletion_time,
+            } => {
+                assert_eq!(column, "dropped_col");
+                assert_eq!(*local_deletion_time, None);
+            }
+            other => panic!("expected Delete, got {other:?}"),
+        }
+        match &decoded.operations[1] {
+            CellOperation::Write { column, value } => {
+                assert_eq!(column, "name");
+                assert_eq!(value, &Value::Text("Carol".to_string()));
+            }
+            other => panic!("expected Write, got {other:?}"),
+        }
     }
 
     #[test]

--- a/cqlite-core/tests/compact_command.rs
+++ b/cqlite-core/tests/compact_command.rs
@@ -166,8 +166,9 @@ fn compact_sstables_merges_explicit_inputs_with_lww() {
             &output_dir,
             &schema,
             9,                   // output generation
-            Some(1_700_000_000), // gc_before (threaded but not yet applied)
+            Some(1_700_000_000), // gc_before
             None,                // now_sec
+            true,                // purge_safe: full compaction (#921 finding 1)
         ))
         .expect("compaction must succeed");
 
@@ -314,6 +315,7 @@ fn compact_disabled_filter_table_succeeds_without_filter_db() {
             9,
             Some(1_700_000_000),
             None,
+            true, // purge_safe: full compaction (#921 finding 1)
         ))
         .expect("compaction of a disabled-filter table must succeed");
 
@@ -473,6 +475,7 @@ fn compact_clustering_table_preserves_rows_and_lww() {
             9,
             None,
             None,
+            true, // purge_safe: full compaction (#921 finding 1)
         ))
         .expect("compaction must succeed");
     assert_eq!(report.stats.output_partitions, 1, "single partition id=1");

--- a/cqlite-core/tests/compaction_integration.rs
+++ b/cqlite-core/tests/compaction_integration.rs
@@ -165,6 +165,7 @@ fn delete_score_column(id: i32, timestamp: i64) -> Mutation {
     let pk = PartitionKey::single("id", Value::Integer(id));
     let ops = vec![CellOperation::Delete {
         column: "score".to_string(),
+        local_deletion_time: None,
     }];
     Mutation::new(table_id, pk, None, ops, timestamp, None)
 }

--- a/cqlite-core/tests/issue_716_tombstone_cell_format.rs
+++ b/cqlite-core/tests/issue_716_tombstone_cell_format.rs
@@ -144,6 +144,7 @@ async fn tombstone_cell_sets_has_empty_value_flag() {
         None,
         vec![CellOperation::Delete {
             column: "age".to_string(),
+            local_deletion_time: None,
         }],
         T1,
         None,

--- a/cqlite-core/tests/issue_764_explicit_local_deletion_time.rs
+++ b/cqlite-core/tests/issue_764_explicit_local_deletion_time.rs
@@ -300,6 +300,7 @@ async fn explicit_local_deletion_time_flows_to_complex_column_deletion() {
         None,
         vec![CellOperation::Delete {
             column: "tags".to_string(),
+            local_deletion_time: None,
         }],
         T0,
         None,
@@ -453,6 +454,7 @@ async fn explicit_local_deletion_time_preserved_for_older_static_delete() {
         None,
         vec![CellOperation::Delete {
             column: "s_old".to_string(),
+            local_deletion_time: None,
         }],
         T0,
         None,
@@ -468,6 +470,7 @@ async fn explicit_local_deletion_time_preserved_for_older_static_delete() {
         None,
         vec![CellOperation::Delete {
             column: "s_new".to_string(),
+            local_deletion_time: None,
         }],
         T0 + 2_000_000, // 2 seconds later
         None,

--- a/cqlite-core/tests/issue_819_differential_compaction.rs
+++ b/cqlite-core/tests/issue_819_differential_compaction.rs
@@ -1120,6 +1120,7 @@ fn delete_score_cell(id: i32, ck: i32, ts: i64) -> Mutation {
         Some(ClusteringKey::single("ck", Value::Integer(ck))),
         vec![CellOperation::Delete {
             column: "score".to_string(),
+            local_deletion_time: None,
         }],
         ts,
         None,
@@ -1295,6 +1296,8 @@ fn cqlite_compact(
     let report = rt
         .block_on(compact_sstables(
             inputs, out_dir, schema, generation, None, None,
+            // Full compaction over all inputs → overlap-safe purge (#921 finding 1).
+            true,
         ))
         .expect("compaction must succeed");
     report.output

--- a/cqlite-core/tests/issue_847_dropped_column_filter.rs
+++ b/cqlite-core/tests/issue_847_dropped_column_filter.rs
@@ -136,7 +136,9 @@ fn compact(inputs: Vec<PathBuf>, out_dir: &Path, schema: &TableSchema) -> PathBu
         .build()
         .expect("runtime");
     let report = rt
-        .block_on(compact_sstables(inputs, out_dir, schema, 901, None, None))
+        .block_on(compact_sstables(
+            inputs, out_dir, schema, 901, None, None, true,
+        ))
         .expect("compaction must succeed");
     report.output.data_path
 }
@@ -271,7 +273,9 @@ fn dropped_column_absent_from_columns_is_rejected() {
         .build()
         .expect("runtime");
     let out_dir = temp.path().join("out");
-    let result = rt.block_on(compact_sstables(inputs, &out_dir, &schema, 902, None, None));
+    let result = rt.block_on(compact_sstables(
+        inputs, &out_dir, &schema, 902, None, None, true,
+    ));
 
     let err = result.expect_err("compaction must reject a dropped column absent from `columns`");
     let msg = err.to_string();

--- a/cqlite-core/tests/issue_848_tombstone_beats_expiring_roundtrip.rs
+++ b/cqlite-core/tests/issue_848_tombstone_beats_expiring_roundtrip.rs
@@ -1,0 +1,209 @@
+//! Issue #848 (Epic #921): at EQUAL timestamp a cell TOMBSTONE must beat an
+//! EXPIRING (TTL) cell — decided before any `localDeletionTime` compare (parity
+//! Cassandra `a62c749`, `Cells#reconcile`). Without the fix an expiring cell
+//! written at the same timestamp as a cell delete could resurrect the value
+//! until its TTL lapsed.
+//!
+//! This is the NON-DORMANT, round-trip proof: the V5 reader surfaces per-cell
+//! `ttl` / `localDeletionTime` for SIMPLE cells (see
+//! `v5_compressed_legacy.rs::parse_block_for_compaction_emit`), which the merge
+//! threads onto `CellData`. Here we drive the REAL write→flush→read path: an
+//! expiring write in one generation and a same-timestamp cell delete in another,
+//! scanned back through `SSTableManager` after the cross-generation merge. The
+//! deleted column must be ABSENT in both source orders.
+//!
+//! Run with:
+//!   CQLITE_DATASETS_ROOT=$PWD/test-data/datasets \
+//!     cargo test --package cqlite-core --features write-support \
+//!     --test issue_848_tombstone_beats_expiring_roundtrip
+//!
+//! Gated `not(feature = "tombstones")`: with `tombstones` enabled,
+//! `SSTableManager::scan` resolves to the tombstones-specific implementation
+//! that does NOT route through the `KWayMerger` compaction merge path this test
+//! is asserting (roborev #974). The #848 tie-break itself is feature-independent
+//! and is pinned by the `reconcile_cluster` and writer-bytes unit tests; this
+//! round-trip only exercises the merge scan path, so we skip it under
+//! `tombstones`. (The `tombstones` read-path reconciliation is out of #848's
+//! compaction scope.)
+
+#![cfg(all(feature = "write-support", not(feature = "tombstones")))]
+
+use cqlite_core::platform::Platform;
+use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+use cqlite_core::storage::sstable::SSTableManager;
+use cqlite_core::storage::write_engine::{
+    CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::TableId as CqlTableId;
+use cqlite_core::types::Value;
+use cqlite_core::Config;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tempfile::TempDir;
+
+const KS: &str = "ttl_tomb_ks";
+const TBL: &str = "items";
+/// Identical write timestamp for the expiring write and the cell delete.
+const TS: i64 = 1_700_000_000_000_000;
+
+fn make_schema() -> TableSchema {
+    TableSchema {
+        keyspace: KS.to_string(),
+        table: TBL.to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            Column {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "name".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "v".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+fn expiring_write(id: i32, ttl: u32, ts: i64) -> Mutation {
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    let ops = vec![
+        // A plain `name` so the row stays live and is emitted even after `v` is
+        // deleted (a row of only a cell tombstone would otherwise be a pure
+        // tombstone-carrier).
+        CellOperation::Write {
+            column: "name".to_string(),
+            value: Value::Text(format!("row-{id}")),
+        },
+        CellOperation::WriteWithTtl {
+            column: "v".to_string(),
+            value: Value::Text("expiring-if-buggy".to_string()),
+            ttl_seconds: ttl,
+        },
+    ];
+    Mutation::new(TableId::new(KS, TBL), pk, None, ops, ts, None)
+}
+
+fn delete_v(id: i32, ts: i64) -> Mutation {
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    let ops = vec![CellOperation::Delete {
+        column: "v".to_string(),
+    }];
+    Mutation::new(TableId::new(KS, TBL), pk, None, ops, ts, None)
+}
+
+fn col<'a>(row: &'a Value, name: &str) -> Option<&'a Value> {
+    match row {
+        Value::Map(pairs) => pairs.iter().find_map(|(k, v)| match k {
+            Value::Text(c) if c == name => Some(v),
+            _ => None,
+        }),
+        _ => None,
+    }
+}
+
+/// Write the expiring `v` for PK `id` in gen1 and the cell delete in gen2 (or
+/// the reverse when `tombstone_first`), flush each generation separately, then
+/// scan the merged directory and assert `v` is ABSENT (the tombstone wins at
+/// equal ts).
+fn run_case(tombstone_first: bool) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build tokio runtime");
+
+    let temp_dir = TempDir::new().expect("tempdir");
+    let data_dir = temp_dir.path().join("data");
+    let wal_dir = temp_dir.path().join("wal");
+    let schema = make_schema();
+
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir.clone(), schema.clone());
+    let mut engine = WriteEngine::new(config).expect("engine creation");
+
+    let id = 1;
+    if tombstone_first {
+        engine.write(delete_v(id, TS)).expect("write delete");
+        rt.block_on(engine.flush()).expect("flush g1").expect("g1");
+        engine
+            .write(expiring_write(id, 3600, TS))
+            .expect("write expiring");
+        rt.block_on(engine.flush()).expect("flush g2").expect("g2");
+    } else {
+        engine
+            .write(expiring_write(id, 3600, TS))
+            .expect("write expiring");
+        rt.block_on(engine.flush()).expect("flush g1").expect("g1");
+        engine.write(delete_v(id, TS)).expect("write delete");
+        rt.block_on(engine.flush()).expect("flush g2").expect("g2");
+    }
+    rt.block_on(engine.close()).expect("close engine");
+
+    let cqlite_config = Config::default();
+    let manager = rt.block_on(async {
+        let platform = Arc::new(Platform::new(&cqlite_config).await.expect("platform"));
+        SSTableManager::new(
+            &data_dir,
+            &cqlite_config,
+            platform,
+            #[cfg(feature = "state_machine")]
+            None,
+        )
+        .await
+        .expect("SSTableManager open")
+    });
+
+    let table_id = CqlTableId::from(format!("{KS}.{TBL}").as_str());
+    let results = rt
+        .block_on(manager.scan(&table_id, None, None, None, Some(&schema)))
+        .expect("scan must not error");
+
+    // The row is still live (it carries `name`), but `v` must be absent: at equal
+    // ts the cell tombstone beats the expiring cell, so `v` is NOT resurrected.
+    let pk_bytes = id.to_be_bytes().to_vec();
+    let row = results
+        .iter()
+        .find(|(k, _)| k.0 == pk_bytes)
+        .map(|(_, v)| v.clone())
+        .expect("row must be present (kept live by the `name` cell)");
+
+    assert_eq!(
+        col(&row, "name"),
+        Some(&Value::Text(format!("row-{id}"))),
+        "the live `name` cell keeps the row present"
+    );
+    assert!(
+        col(&row, "v").is_none(),
+        "tombstone_first={tombstone_first}: at equal ts the cell tombstone must \
+         beat the expiring cell — `v` must NOT be resurrected, got {:?}",
+        col(&row, "v")
+    );
+}
+
+#[test]
+fn tombstone_beats_expiring_at_equal_ts_expiring_first_roundtrip() {
+    run_case(false);
+}
+
+#[test]
+fn tombstone_beats_expiring_at_equal_ts_tombstone_first_roundtrip() {
+    run_case(true);
+}

--- a/cqlite-core/tests/issue_848_tombstone_beats_expiring_roundtrip.rs
+++ b/cqlite-core/tests/issue_848_tombstone_beats_expiring_roundtrip.rs
@@ -107,6 +107,7 @@ fn delete_v(id: i32, ts: i64) -> Mutation {
     let pk = PartitionKey::single("id", Value::Integer(id));
     let ops = vec![CellOperation::Delete {
         column: "v".to_string(),
+        local_deletion_time: None,
     }];
     Mutation::new(TableId::new(KS, TBL), pk, None, ops, ts, None)
 }

--- a/cqlite-core/tests/issue_883_cross_generation_read_merge.rs
+++ b/cqlite-core/tests/issue_883_cross_generation_read_merge.rs
@@ -113,6 +113,7 @@ fn delete_score_column(id: i32, ts: i64) -> Mutation {
     let pk = PartitionKey::single("id", Value::Integer(id));
     let ops = vec![CellOperation::Delete {
         column: "score".to_string(),
+        local_deletion_time: None,
     }];
     Mutation::new(TableId::new(KS, TBL), pk, None, ops, ts, None)
 }

--- a/cqlite-core/tests/issue_885_cross_generation_metadata_merge.rs
+++ b/cqlite-core/tests/issue_885_cross_generation_metadata_merge.rs
@@ -115,6 +115,7 @@ fn delete_score_column(id: i32, ts: i64) -> Mutation {
     let pk = PartitionKey::single("id", Value::Integer(id));
     let ops = vec![CellOperation::Delete {
         column: "score".to_string(),
+        local_deletion_time: None,
     }];
     Mutation::new(TableId::new(KS, TBL), pk, None, ops, ts, None)
 }

--- a/cqlite-core/tests/issue_899_per_element_survives_compaction.rs
+++ b/cqlite-core/tests/issue_899_per_element_survives_compaction.rs
@@ -196,6 +196,8 @@ fn per_element_metadata_survives_compaction_of_real_cassandra_sstable() {
             900,
             None,
             None,
+            // Full compaction over all inputs → overlap-safe purge (#921 finding 1).
+            true,
         ))
         .expect("compaction must succeed");
 

--- a/cqlite-core/tests/issue_921_background_compaction_dropped_column_header.rs
+++ b/cqlite-core/tests/issue_921_background_compaction_dropped_column_header.rs
@@ -1,0 +1,254 @@
+//! Issue #921 finding 2 — background compaction must strip a fully-purged
+//! dropped column from the output SerializationHeader.
+//!
+//! `WriteEngine::compact_sstables` already runs a dropped-column survivor
+//! pre-pass (`compute_surviving_dropped_columns`) and writes with
+//! `effective_schema.for_compaction_output(&retained_dropped)`, so a dropped
+//! column whose last cell is purged is removed from the output header. The
+//! BACKGROUND compaction path (`maintenance_step` → `start_merge`) previously
+//! initialized the `SSTableWriter` with `effective_schema` DIRECTLY, so it could
+//! purge the last cell of a dropped column while still emitting that column in
+//! the output header — misaligning a post-drop reader.
+//!
+//! This test drives a FULL background compaction (the merge policy selects every
+//! candidate SSTable, so `purge_safe == true`) over an input whose only cells for
+//! the dropped column `name` are all older than the drop time. After compaction,
+//! reading the output with a POST-DROP schema (which omits `name`) must NOT see
+//! `name`, and the surviving `score` column — which sorts AFTER `name` in the
+//! serialization-header order — must still decode as an integer (proving the
+//! header did not carry the dropped column and misalign `score`).
+
+#![cfg(feature = "write-support")]
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use cqlite_core::error::Result;
+use cqlite_core::schema::{ClusteringColumn, ClusteringOrder, Column, KeyColumn, TableSchema};
+use cqlite_core::storage::write_engine::merge::{MergeStep, RowData};
+use cqlite_core::storage::write_engine::{
+    CellOperation, ClusteringKey, KWayMerger, MergePolicy, Mutation, PartitionKey, TableId,
+    WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::Value;
+use tempfile::TempDir;
+
+/// Merge policy that selects EVERY candidate (a full/major compaction). With the
+/// selected set equal to the candidate set, `maintenance_step` marks the merge
+/// `purge_safe == true` — the precondition for gc/drop purging.
+#[derive(Debug)]
+struct SelectAllPolicy;
+
+impl MergePolicy for SelectAllPolicy {
+    fn select_merge(&self, candidates: &[PathBuf]) -> Result<Vec<PathBuf>> {
+        Ok(candidates.to_vec())
+    }
+}
+
+fn col(name: &str, ty: &str) -> Column {
+    Column {
+        name: name.to_string(),
+        data_type: ty.to_string(),
+        nullable: true,
+        default: None,
+        is_static: false,
+    }
+}
+
+/// Schema: keyspace=drop_ks, table=items, PK=id(int), CK=ck(int),
+/// columns name(text), score(int). `dropped` injects per-column drop times.
+fn schema_with_drops(dropped: HashMap<String, i64>) -> TableSchema {
+    TableSchema {
+        keyspace: "drop_ks".to_string(),
+        table: "items".to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![ClusteringColumn {
+            name: "ck".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+            order: ClusteringOrder::Asc,
+        }],
+        columns: vec![
+            col("id", "int"),
+            col("ck", "int"),
+            col("name", "text"),
+            col("score", "int"),
+        ],
+        comments: HashMap::new(),
+        dropped_columns: dropped,
+    }
+}
+
+/// Schema describing the table AFTER `name` was dropped: it omits `name`
+/// entirely (the natural post-drop schema a reader would use). `name` sorts
+/// before `score` in the alphabetical serialization-header order, so reading the
+/// compacted output with this schema proves the dropped column is absent from
+/// the output header and `score` is not misparsed.
+fn post_drop_schema_without_name() -> TableSchema {
+    let mut s = schema_with_drops(HashMap::new());
+    s.columns.retain(|c| c.name != "name");
+    s
+}
+
+fn write_row(id: i32, ck: i32, name: &str, score: i32, ts: i64) -> Mutation {
+    Mutation::new(
+        TableId::new("drop_ks", "items"),
+        PartitionKey::single("id", Value::Integer(id)),
+        Some(ClusteringKey::single("ck", Value::Integer(ck))),
+        vec![
+            CellOperation::Write {
+                column: "name".to_string(),
+                value: Value::Text(name.to_string()),
+            },
+            CellOperation::Write {
+                column: "score".to_string(),
+                value: Value::Integer(score),
+            },
+        ],
+        ts,
+        None,
+    )
+}
+
+fn discover_inputs(dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+        if let Ok(entries) = std::fs::read_dir(dir) {
+            for e in entries.flatten() {
+                let p = e.path();
+                if p.is_dir() {
+                    walk(&p, out);
+                } else if p
+                    .file_name()
+                    .and_then(|s| s.to_str())
+                    .is_some_and(|n| n.ends_with("Data.db"))
+                {
+                    out.push(p);
+                }
+            }
+        }
+    }
+    walk(dir, &mut out);
+    out
+}
+
+/// Read surviving (column, value) cells out of `data_path` using `read_schema`.
+fn surviving_columns_with(data_path: PathBuf, read_schema: &TableSchema) -> Vec<(String, Value)> {
+    let mut merger = KWayMerger::new(vec![data_path], read_schema).expect("merger over output");
+    let mut cells = Vec::new();
+    loop {
+        match merger.step().expect("step") {
+            MergeStep::Complete => break,
+            MergeStep::Partition { rows, .. } => {
+                for row in rows {
+                    if let RowData::Live { cells: row_cells } = row.row_data {
+                        for c in row_cells {
+                            cells.push((c.column, c.value));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    cells
+}
+
+/// A FULL background compaction (`maintenance_step` → `start_merge`, purge_safe)
+/// that purges the last cell of a dropped column must NOT emit that column in the
+/// output header.
+#[test]
+fn background_compaction_strips_fully_purged_dropped_column_from_header() {
+    let temp = TempDir::new().expect("tempdir");
+    let data_dir = temp.path().join("data");
+    let wal_dir = temp.path().join("wal");
+
+    // Drop `name` at T=150; all cells are written at ts=100 (<= drop time) so
+    // every `name` cell is purged by the drop-time filter during compaction.
+    let mut dropped = HashMap::new();
+    dropped.insert("name".to_string(), 150_i64);
+    let drop_schema = schema_with_drops(dropped);
+
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir, drop_schema);
+    let mut engine = WriteEngine::new(config).expect("engine");
+
+    // Write two flushed SSTables so the compaction has multiple inputs; the
+    // SelectAllPolicy then makes the merge a full (purge_safe) compaction.
+    for ck in 0_i32..=1 {
+        engine
+            .write(write_row(1, ck, &format!("name-{ck}"), ck * 10, 100))
+            .expect("write row");
+    }
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    rt.block_on(engine.flush()).expect("flush").expect("info");
+
+    for ck in 2_i32..=3 {
+        engine
+            .write(write_row(1, ck, &format!("name-{ck}"), ck * 10, 100))
+            .expect("write row");
+    }
+    rt.block_on(engine.flush()).expect("flush").expect("info");
+
+    // Sanity: more than one input SSTable so the merge is a real compaction.
+    let inputs_before = discover_inputs(&data_dir);
+    assert!(
+        inputs_before.len() >= 2,
+        "expected >= 2 input SSTables, got {}",
+        inputs_before.len()
+    );
+
+    // Drive a FULL background compaction: SelectAllPolicy selects every candidate
+    // so maintenance_step computes purge_safe == true.
+    engine
+        .set_merge_policy(Box::new(SelectAllPolicy))
+        .expect("set policy");
+
+    // Run maintenance to completion (the merge may span several budgeted steps).
+    let mut guard = 0;
+    loop {
+        let report = engine
+            .maintenance_step(Duration::from_millis(500))
+            .expect("maintenance step");
+        if !report.pending_compaction {
+            break;
+        }
+        guard += 1;
+        assert!(guard < 1000, "maintenance did not converge");
+    }
+    rt.block_on(engine.close()).expect("close");
+
+    // Find the compacted output (the newest generation Data.db). After a full
+    // compaction the inputs are deleted, so any remaining Data.db is the output.
+    let outputs = discover_inputs(&data_dir);
+    assert_eq!(
+        outputs.len(),
+        1,
+        "full compaction should leave exactly one output SSTable, got {:?}",
+        outputs
+    );
+    let data_path = outputs.into_iter().next().expect("one output");
+
+    // Read the output with a POST-DROP schema that omits `name` entirely.
+    let cols = surviving_columns_with(data_path, &post_drop_schema_without_name());
+
+    assert!(
+        cols.iter().all(|(c, _)| c != "name"),
+        "the dropped column must not appear in the background-compaction output, got: {:?}",
+        cols.iter().map(|(c, _)| c).collect::<Vec<_>>()
+    );
+    // `score` must still decode correctly (as an integer) — proving the output
+    // header did not carry the purged `name` column and misalign `score`.
+    assert!(
+        cols.iter()
+            .any(|(c, v)| c == "score" && matches!(v, Value::Integer(_))),
+        "surviving `score` must parse correctly under a post-drop reader schema, got: {:?}",
+        cols
+    );
+}

--- a/cqlite-core/tests/issue_921_purge_decision_consistency.rs
+++ b/cqlite-core/tests/issue_921_purge_decision_consistency.rs
@@ -1,0 +1,470 @@
+//! Issue #921 (epic) — purge-decision consistency between the dropped-column
+//! survivor PRE-PASS and the real merge WRITE PASS, and per-cell tombstone LDT
+//! preservation through the writer.
+//!
+//! FINDING 1 (pre-pass vs write-pass purge mismatch): `compact_sstables` runs a
+//! merge PRE-PASS (`compute_surviving_dropped_columns`) to decide which dropped
+//! columns still have surviving cells (so the output serialization header retains
+//! them) before the real WRITE PASS. Before the fix the pre-pass built its merger
+//! with the DEFAULT `purge_safe = false`, while a major compaction's write pass
+//! used `purge_safe = true`. A purgeable cell tombstone in a dropped column was
+//! therefore counted as a SURVIVOR by the pre-pass (column retained in the
+//! header) yet PURGED by the write pass — leaving an empty dropped column in the
+//! output header that defeats the post-drop header stripping. The fix threads the
+//! SAME `purge_safe` (and gc cutoff) into the pre-pass so the two agree.
+//!
+//! FINDING 2 (retained cell-tombstone LDT lost through writer): a retained simple
+//! cell tombstone's SOURCE `localDeletionTime` was dropped when converting to
+//! `CellOperation::Delete`; the writer then re-stamped it with a mutation-derived
+//! LDT. A within-grace cell tombstone that SURVIVES this compaction could thus
+//! get a DIFFERENT GC clock in the output → purged too early / kept too long in a
+//! LATER compaction. The fix preserves the per-cell tombstone's own LDT through
+//! the mutation→writer path.
+
+#![cfg(all(feature = "write-support", feature = "cli-helpers"))]
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use cqlite_core::platform::Platform;
+use cqlite_core::schema::{ClusteringColumn, ClusteringOrder, Column, KeyColumn, TableSchema};
+use cqlite_core::storage::sstable::reader::{CompactionRowData, SSTableReader};
+use cqlite_core::storage::write_engine::merge::{compact_sstables, MergeStep, RowData};
+use cqlite_core::storage::write_engine::{
+    CellOperation, ClusteringKey, KWayMerger, Mutation, PartitionKey, TableId, WriteEngine,
+    WriteEngineConfig,
+};
+use cqlite_core::types::Value;
+use cqlite_core::Config;
+use tempfile::TempDir;
+
+const KEYSPACE: &str = "purge_ks";
+const TABLE: &str = "items";
+
+/// Schema: PK=id(int), CK=ck(int), columns name(text), score(int). `name` sorts
+/// before `score` in the serialization header, so a stale (empty) `name` entry
+/// in the output header would misalign `score` for a post-drop reader.
+fn schema_with_drops(dropped: HashMap<String, i64>) -> TableSchema {
+    TableSchema {
+        keyspace: KEYSPACE.to_string(),
+        table: TABLE.to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![ClusteringColumn {
+            name: "ck".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+            order: ClusteringOrder::Asc,
+        }],
+        columns: vec![
+            col("id", "int"),
+            col("ck", "int"),
+            col("name", "text"),
+            col("score", "int"),
+        ],
+        comments: HashMap::new(),
+        dropped_columns: dropped,
+    }
+}
+
+fn col(name: &str, ty: &str) -> Column {
+    Column {
+        name: name.to_string(),
+        data_type: ty.to_string(),
+        nullable: true,
+        default: None,
+        is_static: false,
+    }
+}
+
+/// A row whose `name` column carries ONLY a simple cell tombstone (with an
+/// explicit, far-in-the-past `localDeletionTime`) and whose `score` column is a
+/// live integer. The tombstone is written at `ts` (microseconds) and stamped with
+/// `ldt_secs` (the GC clock the purge stage compares against `gcBefore`).
+fn write_name_tombstone_score_live(
+    id: i32,
+    ck: i32,
+    score: i32,
+    ts: i64,
+    name_ldt_secs: i32,
+) -> Mutation {
+    Mutation::new(
+        TableId::new(KEYSPACE, TABLE),
+        PartitionKey::single("id", Value::Integer(id)),
+        Some(ClusteringKey::single("ck", Value::Integer(ck))),
+        vec![
+            CellOperation::Delete {
+                column: "name".to_string(),
+                // The mutation-level LDT below would otherwise stamp this; the
+                // writer honors the per-op LDT (#921 finding 2) — here it equals
+                // the mutation LDT, so this test isolates Finding 1.
+                local_deletion_time: None,
+            },
+            CellOperation::Write {
+                column: "score".to_string(),
+                value: Value::Integer(score),
+            },
+        ],
+        ts,
+        None,
+    )
+    .with_local_deletion_time(name_ldt_secs)
+}
+
+/// Flush `mutations` into one SSTable and return its Data.db input paths.
+fn build_input(temp: &TempDir, mutations: Vec<Mutation>) -> Vec<PathBuf> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    let data_dir = temp.path().join("inputs");
+    let wal_dir = temp.path().join("wal");
+    let schema = schema_with_drops(HashMap::new());
+
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir, schema);
+    let mut engine = WriteEngine::new(config).expect("engine");
+    for m in mutations {
+        engine.write(m).expect("write row");
+    }
+    rt.block_on(engine.flush()).expect("flush").expect("info");
+    rt.block_on(engine.close()).expect("close");
+
+    discover_inputs(&data_dir)
+}
+
+fn discover_inputs(dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+        if let Ok(entries) = std::fs::read_dir(dir) {
+            for e in entries.flatten() {
+                let p = e.path();
+                if p.is_dir() {
+                    walk(&p, out);
+                } else if p
+                    .file_name()
+                    .and_then(|s| s.to_str())
+                    .is_some_and(|n| n.ends_with("-Data.db"))
+                {
+                    out.push(p);
+                }
+            }
+        }
+    }
+    walk(dir, &mut out);
+    out
+}
+
+/// Run a MAJOR compaction (`purge_safe = true`) with explicit gc settings.
+fn compact_major(
+    inputs: Vec<PathBuf>,
+    out_dir: &Path,
+    schema: &TableSchema,
+    gc_before_secs: i64,
+    now_secs: i64,
+) -> PathBuf {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    let report = rt
+        .block_on(compact_sstables(
+            inputs,
+            out_dir,
+            schema,
+            921,
+            Some(gc_before_secs),
+            Some(now_secs),
+            true, // purge_safe: major compaction spanning every SSTable
+        ))
+        .expect("compaction must succeed");
+    report.output.data_path
+}
+
+/// Schema describing the table AFTER `name` was dropped: it omits `name`
+/// entirely (the natural post-drop reader schema). Reading the compacted output
+/// with this schema proves the dropped column is ABSENT from the output header
+/// and `score` is not misaligned.
+fn post_drop_schema_without_name() -> TableSchema {
+    let mut s = schema_with_drops(HashMap::new());
+    s.columns.retain(|c| c.name != "name");
+    s
+}
+
+/// Read surviving (column, value) cells out of `data_path` using `read_schema`.
+fn surviving_columns_with(data_path: PathBuf, read_schema: &TableSchema) -> Vec<(String, Value)> {
+    let mut merger = KWayMerger::new(vec![data_path], read_schema).expect("merger over output");
+    let mut cells = Vec::new();
+    loop {
+        match merger.step().expect("step") {
+            MergeStep::Complete => break,
+            MergeStep::Partition { rows, .. } => {
+                for row in rows {
+                    if let RowData::Live { cells: row_cells } = row.row_data {
+                        for c in row_cells {
+                            cells.push((c.column, c.value));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    cells
+}
+
+// ---------------------------------------------------------------------------
+// FINDING 1
+// ---------------------------------------------------------------------------
+
+/// FINDING 1 AC: in a MAJOR compaction (`purge_safe = true`), a DROPPED column
+/// whose only data is a PURGEABLE cell tombstone must NOT be retained in the
+/// output serialization header — the survivor pre-pass must make the SAME purge
+/// decision as the write pass.
+///
+/// `name` (dropped, sorts before `score`) carries only a cell tombstone whose
+/// `ts > drop_time` (survives the dropped-column filter) but whose
+/// `localDeletionTime < gcBefore` (purgeable). Before the fix the pre-pass (with
+/// `purge_safe = false`) counts the tombstone as surviving and retains `name` in
+/// the header; the write pass (with `purge_safe = true`) then purges it, leaving
+/// a STALE empty `name` header entry that misaligns `score` for a post-drop
+/// reader. After the fix the pre-pass purges it too, strips `name`, and `score`
+/// decodes correctly.
+#[test]
+fn dropped_column_purgeable_tombstone_not_retained_in_header() {
+    let temp = TempDir::new().expect("tempdir");
+
+    // Cell tombstone for `name` at ts=300 (microseconds), stamped with an OLD
+    // localDeletionTime of 1000 seconds. `score` is a live cell.
+    let name_ldt_secs = 1_000_i32;
+    let mutations = vec![write_name_tombstone_score_live(
+        1,
+        0,
+        42,
+        300,
+        name_ldt_secs,
+    )];
+    let inputs = build_input(&temp, mutations);
+    assert!(!inputs.is_empty(), "expected at least one input SSTable");
+
+    // Drop `name` at drop_time=150 (BEFORE the tombstone's ts=300, so the
+    // dropped-column filter alone does NOT remove it — only the gc_grace purge
+    // does). `name` sorts before `score`.
+    let mut dropped = HashMap::new();
+    dropped.insert("name".to_string(), 150_i64);
+    let drop_schema = schema_with_drops(dropped);
+
+    // gcBefore = 2000s > name_ldt(1000s) → the tombstone is PURGEABLE. now is in
+    // the far future so the live `score` cell is never TTL-expired.
+    let gc_before_secs = 2_000_i64;
+    let now_secs = 10_000_i64;
+
+    let out_dir = temp.path().join("out");
+    let data_path = compact_major(inputs, &out_dir, &drop_schema, gc_before_secs, now_secs);
+
+    // Read the output with a POST-DROP schema that omits `name` entirely.
+    let cols = surviving_columns_with(data_path, &post_drop_schema_without_name());
+
+    assert!(
+        cols.iter().all(|(c, _)| c != "name"),
+        "dropped+purged `name` must not appear in the output, got: {:?}",
+        cols.iter().map(|(c, _)| c).collect::<Vec<_>>()
+    );
+    // `score` must decode as an integer. If the pre-pass had wrongly retained the
+    // purged `name` column in the header, a post-drop reader (no `name`) would
+    // misalign and fail to surface `score` as a clean integer.
+    assert!(
+        cols.iter()
+            .any(|(c, v)| c == "score" && matches!(v, Value::Integer(42))),
+        "surviving `score`=42 must parse correctly under a post-drop reader schema, got: {:?}",
+        cols
+    );
+}
+
+// ---------------------------------------------------------------------------
+// FINDING 2
+// ---------------------------------------------------------------------------
+
+const F2_KEYSPACE: &str = "ldt_ks";
+const F2_TABLE: &str = "items";
+
+/// Schema with no clustering: PK=id(int), columns name(text), data(text).
+fn f2_schema() -> TableSchema {
+    TableSchema {
+        keyspace: F2_KEYSPACE.to_string(),
+        table: F2_TABLE.to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            col_in("id", "int", F2_KEYSPACE),
+            col_in("name", "text", F2_KEYSPACE),
+            col_in("data", "text", F2_KEYSPACE),
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+fn col_in(name: &str, ty: &str, _ks: &str) -> Column {
+    Column {
+        name: name.to_string(),
+        data_type: ty.to_string(),
+        nullable: true,
+        default: None,
+        is_static: false,
+    }
+}
+
+/// Write one SSTable for the Finding-2 schema and return its Data.db paths.
+fn f2_build_input(temp: &TempDir, mutations: Vec<Mutation>) -> Vec<PathBuf> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    let data_dir = temp.path().join("inputs");
+    let wal_dir = temp.path().join("wal");
+
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir, f2_schema());
+    let mut engine = WriteEngine::new(config).expect("engine");
+    for m in mutations {
+        engine.write(m).expect("write row");
+    }
+    rt.block_on(engine.flush()).expect("flush").expect("info");
+    rt.block_on(engine.close()).expect("close");
+
+    discover_inputs(&data_dir)
+}
+
+fn f2_compact(inputs: Vec<PathBuf>, out_dir: &Path, gc_before_secs: i64, now_secs: i64) -> PathBuf {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    let report = rt
+        .block_on(compact_sstables(
+            inputs,
+            out_dir,
+            &f2_schema(),
+            922,
+            Some(gc_before_secs),
+            Some(now_secs),
+            true,
+        ))
+        .expect("compaction must succeed");
+    report.output.data_path
+}
+
+/// Read the `name`-column cell tombstone's `localDeletionTime` (seconds) out of
+/// the compacted output via the compaction reader's `SimpleCell` surface.
+fn read_name_tombstone_ldt(data_path: &Path) -> Option<i32> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    rt.block_on(async {
+        let mut config = Config::default();
+        config.storage.use_mmap = false;
+        let platform = Arc::new(Platform::new(&config).await.expect("platform"));
+        let reader = SSTableReader::open(data_path, &config, platform)
+            .await
+            .expect("open reader");
+        let schema = f2_schema();
+        let rows = reader
+            .iterate_all_partitions_for_compaction(Some(&schema))
+            .await
+            .expect("iterate compaction rows");
+        for row in rows {
+            if let CompactionRowData::Live { simple, .. } = &row.row_data {
+                for cell in simple {
+                    if cell.column == "name" {
+                        // A simple cell tombstone carries its localDeletionTime in
+                        // its `Value::Tombstone` payload (seconds), NOT in
+                        // `SimpleCell.local_deletion_time` (the reader fills that
+                        // only for expiring cells). Read the authoritative LDT off
+                        // the tombstone value.
+                        if let Value::Tombstone(info) = &cell.value {
+                            if info.tombstone_type
+                                == cqlite_core::types::TombstoneType::CellTombstone
+                            {
+                                return Some(info.local_deletion_time as i32);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        None
+    })
+}
+
+/// FINDING 2 AC: a WITHIN-GRACE simple cell tombstone with an explicit, non-zero
+/// `localDeletionTime` that SURVIVES compaction must carry the SAME LDT in the
+/// output — not a mutation-derived one.
+///
+/// The `name` cell tombstone is stamped with an explicit `EXPLICIT_LDT` that is
+/// DELIBERATELY DIFFERENT from the timestamp-derived value
+/// (`timestamp_micros / 1_000_000`). It is within grace (`LDT >= gcBefore`), so
+/// it survives the purge. Before the fix the writer re-derived the LDT from the
+/// mutation timestamp (a different number); after the fix it preserves the
+/// source cell tombstone's own LDT.
+#[test]
+fn surviving_cell_tombstone_preserves_source_ldt() {
+    let temp = TempDir::new().expect("tempdir");
+
+    // ts = 8_000_000_000 µs → timestamp-derived LDT would be 8_000 seconds.
+    // EXPLICIT_LDT = 9_000 seconds is BOTH != 8_000 (so a regression that
+    // re-derives the LDT from the timestamp is detectable as a DIFFERENT LDT, not
+    // merely an early purge) AND, like the derived value, WITHIN grace relative to
+    // gcBefore=1_000 (both >= 1_000 → both would be retained). Isolating the
+    // LDT-VALUE check this way means the RED is "wrong LDT in the output", exactly
+    // the drift Finding 2 fixes.
+    const TS_MICROS: i64 = 8_000_000_000;
+    const EXPLICIT_LDT: i32 = 9_000;
+    const TIMESTAMP_DERIVED_LDT: i32 = (TS_MICROS / 1_000_000) as i32; // = 8_000
+
+    let mutation = Mutation::new(
+        TableId::new(F2_KEYSPACE, F2_TABLE),
+        PartitionKey::single("id", Value::Integer(7)),
+        None,
+        vec![
+            // `data` stays live so the row is not reduced to an empty/absent row.
+            CellOperation::Write {
+                column: "data".to_string(),
+                value: Value::Text("keep".to_string()),
+            },
+            CellOperation::Delete {
+                column: "name".to_string(),
+                local_deletion_time: Some(EXPLICIT_LDT),
+            },
+        ],
+        TS_MICROS,
+        None,
+    );
+
+    let inputs = f2_build_input(&temp, vec![mutation]);
+    assert!(!inputs.is_empty(), "expected at least one input SSTable");
+
+    // gcBefore = 1_000s: EXPLICIT_LDT (9_000) >= gcBefore → the tombstone is
+    // WITHIN grace and SURVIVES. now far in the future (no TTL involved).
+    let out_dir = temp.path().join("out");
+    let data_path = f2_compact(inputs, &out_dir, 1_000, 1_000_000);
+
+    let ldt = read_name_tombstone_ldt(&data_path)
+        .expect("a surviving `name` cell tombstone must be present in the output");
+
+    assert_ne!(
+        TIMESTAMP_DERIVED_LDT, EXPLICIT_LDT,
+        "test precondition: explicit LDT must differ from the timestamp-derived one"
+    );
+    assert_eq!(
+        ldt, EXPLICIT_LDT,
+        "surviving cell tombstone must keep its SOURCE localDeletionTime ({EXPLICIT_LDT}), \
+         not a mutation-derived one ({TIMESTAMP_DERIVED_LDT}); got {ldt}"
+    );
+}

--- a/cqlite-core/tests/sstabledump_parity_data.rs
+++ b/cqlite-core/tests/sstabledump_parity_data.rs
@@ -265,6 +265,7 @@ async fn test_data_db_tombstone_parity() -> CqliteResult<()> {
     // Column tombstone
     let delete_ops = vec![CellOperation::Delete {
         column: "data".to_string(),
+        local_deletion_time: None,
     }];
     let delete_mutation = Mutation::new(
         table_id.clone(),

--- a/cqlite-core/tests/write_engine_integration_test.rs
+++ b/cqlite-core/tests/write_engine_integration_test.rs
@@ -304,6 +304,7 @@ async fn test_write_engine_delete_operations() -> Result<()> {
     let pk = PartitionKey::single("id", Value::Integer(2));
     let ops = vec![CellOperation::Delete {
         column: "name".to_string(),
+        local_deletion_time: None,
     }];
     let mutation2 = Mutation::new(table_id.clone(), pk.clone(), None, ops, 1001000, None);
     engine.write_async(mutation2).await?;

--- a/cqlite-core/tests/write_integration.rs
+++ b/cqlite-core/tests/write_integration.rs
@@ -518,6 +518,7 @@ async fn test_cell_tombstones() -> Result<()> {
         let pk = PartitionKey::single("id", Value::Integer(1));
         let ops = vec![CellOperation::Delete {
             column: "value".to_string(),
+            local_deletion_time: None,
         }];
         Mutation::new(table_id, pk, None, ops, 1000001, None)
     };
@@ -584,6 +585,7 @@ async fn test_tombstone_overwrite() -> Result<()> {
         let pk = PartitionKey::single("id", Value::Integer(1));
         let ops = vec![CellOperation::Delete {
             column: "value".to_string(),
+            local_deletion_time: None,
         }];
         Mutation::new(table_id, pk, None, ops, 1000001, None)
     };
@@ -996,6 +998,7 @@ async fn test_mixed_operations_in_partition() -> Result<()> {
         None,
         vec![CellOperation::Delete {
             column: "value".to_string(),
+            local_deletion_time: None,
         }],
         1000002,
         None,

--- a/cqlite-core/tests/write_read_roundtrip/edge_cases.rs
+++ b/cqlite-core/tests/write_read_roundtrip/edge_cases.rs
@@ -509,6 +509,7 @@ async fn test_edge_delete_operations() {
     // Delete the column
     let delete_ops = vec![CellOperation::Delete {
         column: "data".to_string(),
+        local_deletion_time: None,
     }];
     let delete_mutation = Mutation::new(
         table_id.clone(),
@@ -1195,6 +1196,7 @@ fn test_edge_cell_tombstone_compaction_merge() {
         let ck = ClusteringKey::single("ck", Value::Text(suffix.to_string()));
         let ops = vec![CellOperation::Delete {
             column: "data".to_string(),
+            local_deletion_time: None,
         }];
         let mutation = Mutation::new(table_id.clone(), pk.clone(), Some(ck), ops, ts, None);
         rt.block_on(engine.write_async(mutation))

--- a/docs/sstables-definitive-guide/chapters/11-merging-tombstones-and-shadowing.md
+++ b/docs/sstables-definitive-guide/chapters/11-merging-tombstones-and-shadowing.md
@@ -39,14 +39,18 @@ What it actually compares, per column, is narrow — and the divergences below a
 **not** an exhaustive enumeration of every place it differs from Cassandra. These
 are documented honestly here and tracked in Appendix F.
 
-- **What `reconcile_cluster` actually compares.** Per column, the winner is chosen
-  by: (1) **strictly higher `timestamp`** wins; (2) at **equal** `timestamp`, a
-  **cell tombstone beats a live cell** (`is_cell_tombstone(cell) &&
-  !is_cell_tombstone(existing)`); (3) otherwise the **first-seen** cell is kept —
-  and because inputs arrive in heap-routing order (`run_index` ascending = newest
-  file first), first-seen means the newer file. Row-tombstone shadowing then drops
-  any surviving cell whose `timestamp <= row_del` (the `<=` lets the row tombstone
-  win at equal timestamp). That is the whole of the equal-timestamp logic.
+- **What `reconcile_cluster` actually compares.** Per **`(column, cell_path)`**
+  (epic #921; multi-cell collection/UDT elements reconcile independently — see
+  "Compaction merge semantics" below), the winner is chosen by
+  `cell_reconcile_replace`: (1) **strictly higher `timestamp`** wins; (2) at
+  **equal** `timestamp`, a **cell tombstone beats a live OR expiring cell**
+  (`is_cell_tombstone(candidate) && !is_cell_tombstone(existing)`), decided
+  **before** any `localDeletionTime` compare (issue #848, parity Cassandra
+  `a62c749`); (3) otherwise the **first-seen** cell is kept — and because inputs
+  arrive in heap-routing order (`run_index` ascending = newest file first),
+  first-seen means the newer file. Row-tombstone shadowing then drops any surviving
+  cell whose `timestamp <= row_del` (the `<=` lets the row tombstone win at equal
+  timestamp). That is the whole of the equal-timestamp logic.
 
 - **What matches Cassandra at equal timestamp.** Because `is_cell_tombstone`
   distinguishes a cell tombstone from *any* non-tombstone (whether live or
@@ -80,13 +84,146 @@ are documented honestly here and tracked in Appendix F.
   divergence (ruled a FIX in issue #818; the fix is a follow-up). Authority:
   `org.apache.cassandra.db.rows.Cells.resolveRegular`.
 
-- **Complex (collection/UDT) column merge — CQLite limitation (#14/#17/#18).**
+- **Complex (collection/UDT) column merge — per-cell-path (RESOLVED in epic #921).**
   Cassandra merges complex columns **per cell-path** using the column's path
   comparator — signed `ShortType` for a UDT field index, `TimeUUIDType` for a list
   element, and the map key type for a map — applying shadow-before-purge per path.
-  CQLite's reconcile collapses the **whole column** (its `CellData` carries no
-  cell-path), so per-path merge of multi-cell collections/UDTs is not yet
-  representable. See Appendix F.
+  CQLite now reconciles complex columns per `(column, cell_path)`: `CellData`
+  carries a `cell_path`, so disjoint elements of the same column survive and a
+  same-key collision resolves by the higher per-cell timestamp (#844). UDT field
+  paths are compared as **signed** `ShortType` and complex columns are matched
+  **by name** across differing source headers (#888/#927). Complex deletion markers
+  reconcile with strict-supersede + shadow-before-purge (#887). See "Compaction
+  merge semantics" below.
+
+## Compaction merge semantics
+
+Epic #921 brought CQLite's compaction merge path
+(`cqlite-core/src/storage/write_engine/merge.rs`, `reconcile_cluster`, and the
+`merge_entry_to_mutation` rewrite) substantially closer to Cassandra's
+`CompactionIterator` / `Cells#reconcile`. This section documents what the merge
+**actually** does, verified against the code on this branch; each rule names the
+function that implements it and (where given) the Cassandra parity commit.
+
+### Per-(column, cell_path) reconciliation (#844)
+
+`reconcile_cluster` keys per-cell winners by `(column, cell_path)`, not by whole
+column. A simple cell has `cell_path == None` and behaves as before; each element
+of a multi-cell collection or UDT carries its authoritative `cell_path` and
+reconciles independently. **Disjoint elements** of the same column written in
+different SSTables both survive; the **same `(column, cell_path)` key** resolves to
+the cell with the **higher per-cell timestamp** (`cell_reconcile_replace`). On the
+write-out side, `cells_to_cell_operations` emits one
+`CellOperation::WriteComplexElement` per surviving element (preserving its
+`cell_path`, `timestamp`, `ttl`, `local_deletion_time`, and authoritative
+`is_deleted`), so the elements round-trip rather than collapsing to a whole-column
+value.
+
+### UDT cell-path ordering and match-by-name (#888 / #927)
+
+A UDT field-index cell path is a 2-byte **signed** `ShortType` value, so a field
+index in `[32768, 65535]` is negative as `i16` and must sort **before** the
+positive indices. `compare_cell_paths(a, b, is_udt=true)` decodes both paths with
+`i16::from_be_bytes` and compares as signed; collection (non-UDT) paths keep
+plain lexicographic byte ordering (parity Cassandra `d14c96b8` / `5e636f9`).
+Complex columns are matched **by name** (`ComplexDeletion.column`,
+`udt_declared_field_names` resolving a `Value::Udt` literal's fields to their
+declared index by name) rather than by header identity, so two sources whose
+serialization headers differ still merge the same logical column. Non-frozen UDT
+multi-cell data is now read and written end-to-end (#927).
+
+### Complex-deletion reconciliation (#887)
+
+Complex (collection/UDT) deletion markers reconcile in a dedicated stage (Step 2b
+of `reconcile_cluster`) that runs **after** per-cell winner resolution and
+**before** the row-tombstone and gc_grace filters (parity Cassandra `bd244649` +
+`f66fa14f`):
+
+- **Strict supersede.** Per complex column (matched by name) the active deletion
+  is the one with the greatest `marked_for_delete_at`; a candidate supersedes only
+  when its `marked_for_delete_at` is **strictly greater** — **equal** timestamps do
+  **not** supersede.
+- **Shadow before purge.** For the surviving deletion on a column, every per-element
+  winner of that column whose timestamp is `<= marked_for_delete_at` is **shadowed
+  (dropped) before** the marker itself is purged, so a later purge of the marker can
+  never resurrect a covered element. An element strictly newer than
+  `marked_for_delete_at` survives.
+
+**Row-tombstone interaction.** A row tombstone at `row_del` shadows only timestamps
+`<= row_del`. In `merge_entry_to_mutation`, a carried complex-deletion marker whose
+`marked_for_delete_at` is **strictly greater** than `row_del` covers a range the row
+tombstone does not (including elements in SSTables outside this compaction), so it is
+**preserved and emitted** as a `CellOperation::ComplexDeletion` alongside the
+`DeleteRow`. A marker with `marked_for_delete_at <= row_del` is fully covered and is
+dropped.
+
+### Tombstone-vs-expiring (TTL) tie-break (#848)
+
+At **equal timestamp** a cell **tombstone beats an expiring (TTL) cell**, and this is
+decided **before** the `localDeletionTime` compare. `cell_reconcile_replace` compares
+timestamps first, then returns `is_cell_tombstone(candidate) &&
+!is_cell_tombstone(existing)`; because `is_cell_tombstone` treats an expiring cell as
+non-tombstone (it carries a real value plus a TTL, not a `CellTombstone`), the single
+rule subsumes both tombstone-beats-live and tombstone-beats-expiring (parity Cassandra
+`a62c749`). The further equal-timestamp ranking among non-tombstone cells
+(expiring-beats-live, higher-`localDeletionTime`, lower-TTL) is still **not**
+implemented — see the divergence note above and Appendix F.
+
+### gc_grace / gcBefore purging during compaction (#845)
+
+A tombstone whose on-disk `localDeletionTime` is **strictly less than** `gcBefore` is
+purged from the output (Step 3c of `reconcile_cluster`, parity Cassandra `8d47ebb2`).
+Key invariants, verified in `compute_gc_before` and `reconcile_cluster`:
+
+- **Clock and cutoff.** `localDeletionTime` is the GC clock in **seconds**;
+  `gcBefore = now_secs - gc_grace_seconds`. When the table declares no
+  `gc_grace_seconds`, CQLite falls back to Cassandra's table **default of 864000
+  seconds** (10 days). An invalid (unparseable or negative) declared value returns
+  `None`, disabling purging (a strict no-op — garbage metadata never drops data).
+- **Unsigned LDT.** `localDeletionTime` is read **unsigned** (`i64::from(ldt as u32)`)
+  so a far-future LDT with bit 31 set is not mistaken for an ancient negative `i32`.
+- **`LDT == 0` is unknown.** A zero LDT is the "not surfaced" placeholder and the
+  tombstone is **retained** (never purge on unknown LDT — the no-heuristics mandate).
+- **No resurrection.** Purge runs **after** the complex-deletion shadow stage and the
+  row-tombstone / dropped-column filters, so a now-redundant marker is dropped only
+  once everything it covered within the compaction is already gone.
+- **Overlap safety.** Purging happens **only** on an overlap-safe (full/major)
+  compaction that spans every SSTable for the table. `merge_partition_rows` collapses
+  the effective `gc_before_secs` to `None` for a partial/background compaction
+  (`KWayMerger::with_purge_safe` / the `purge_safe` flag), so partial compactions
+  **retain** tombstones and cannot resurrect data shadowed in a non-included
+  overlapping SSTable. In the CLI this is opt-in via `--major` / `--purge-tombstones`.
+
+### Writer invariants surfaced by the merge path
+
+The compaction rewrite exposed several writer invariants that must hold or the
+delta-encoded SSTable would be corrupt:
+
+- **Stats/baseline must fold every emitted field.** The Statistics.db baselines
+  (`min_timestamp`, `min_local_deletion_time`, `min_ttl`) are folded over
+  `ComplexDeletion` (`marked_for_delete_at` + `local_deletion_time`),
+  `WriteComplexElement` (per-element `timestamp` / `ttl` / `local_deletion_time`), and
+  per-cell `Delete` (`op_cell_local_deletion_time`) in
+  `SSTableWriter::write_partition` (`writer/mod.rs`). A marker or element whose
+  timestamp/LDT lies below an un-folded baseline would underflow the unsigned delta.
+- **Per-op deletion timestamp shadowing is uniform** across the normal and shadowed
+  writer paths.
+- **Per-cell `Delete` localDeletionTime is preserved** through the merge→writer path
+  (`cells_to_cell_operations` threads the source cell tombstone's own LDT into
+  `CellOperation::Delete { local_deletion_time }`), avoiding GC-clock drift that would
+  purge a surviving tombstone too early — or keep it too long — in a later compaction.
+- **The WAL has three backward-compatible record layouts** (the WAL has no per-record
+  version field and bincode is positional): (A) pre-#764 (no mutation-level
+  `local_deletion_time`, old `Delete` op shape), (B) post-#764 / pre-#921
+  (mutation-level LDT present, old `Delete` op shape), and (C) current
+  (`CellOperation::Delete` carries `local_deletion_time`). `deserialize_mutation`
+  attempts most-recent-first and falls back, mapping older layouts to `None` LDTs.
+
+> **Reference: Cassandra parity.** Per-cell reconcile and the tombstone-vs-expiring
+> tie-break mirror `org.apache.cassandra.db.rows.Cells#reconcile` (commit `a62c749`);
+> complex-deletion strict-supersede + shadow-before-purge mirror commits `bd244649`
+> and `f66fa14f`; UDT signed-short paths + match-by-name mirror `d14c96b8` / `5e636f9`;
+> gc_grace purging mirrors `8d47ebb2`.
 
 ### Clustering order: empty vs valued under DESC
 
@@ -103,6 +240,13 @@ comparison.
 ## Range Tombstones
 
 Range tombstones delete clustering intervals; readers must compare timestamps against range bounds during reconciliation.
+
+> **Warning: range tombstones during compaction.** As of epic #921, range
+> tombstones are **not** applied or emitted end-to-end in the compaction merge path.
+> The V5CompressedLegacy reader only **skips** range markers (it does not surface
+> them to the merger, except on the dedicated delta-scan path), and the writer does
+> not persist a surviving range marker through `merge_entry_to_mutation`. Tracked in
+> #933 — see Appendix F.
 
 ## Tombstone Timeline Diagram
 

--- a/docs/sstables-definitive-guide/chapters/appendix-f-known-limitations.md
+++ b/docs/sstables-definitive-guide/chapters/appendix-f-known-limitations.md
@@ -738,17 +738,29 @@ index VInts as cell data, corrupting the row stream. The reader also treats any 
 `cqlite-core/tests/issue_824_column_subset_and_filter.rs`. **Workaround**: tables with fewer
 than 64 regular columns are unaffected (the common case).
 
-### Complex-column merge is whole-column, not per-cell-path (#14/#17/#18)
+### Complex-column merge is whole-column, not per-cell-path (#14/#17/#18) — RESOLVED in epic #921
 
-**Status**: 🐛 **OPEN** (limitation)
+**Status**: ✅ **RESOLVED** (#844 / #888 / #927 / #887, epic #921)
 
-Cassandra merges complex (multi-cell collection/UDT) columns **per cell-path** using the
-column's path comparator — signed `ShortType` for a UDT field index, `TimeUUIDType` for a list
-element, the map key type for a map — applying shadow-before-purge per path. CQLite's merge
-(`storage/write_engine/merge.rs::reconcile_cluster`) reconciles by **whole column**: its
-`CellData` carries no cell-path, so per-path merge of multi-cell collections/UDTs is not yet
-representable. Authority: `org.apache.cassandra.db.rows.Cells` (per-column complex merge) and
-the column's `CellPath` comparator.
+**Was** (Epic #817): Cassandra merges complex (multi-cell collection/UDT) columns **per
+cell-path** using the column's path comparator — signed `ShortType` for a UDT field index,
+`TimeUUIDType` for a list element, the map key type for a map — applying shadow-before-purge per
+path. CQLite's merge (`storage/write_engine/merge.rs::reconcile_cluster`) reconciled by **whole
+column**: its `CellData` carried no cell-path, so per-path merge of multi-cell collections/UDTs
+was not representable.
+
+**Now** (epic #921): `reconcile_cluster` keys per-cell winners by `(column, cell_path)` and the
+`merge_entry_to_mutation` rewrite emits one `WriteComplexElement` per surviving element. Disjoint
+elements survive; a same-key collision resolves by the higher per-cell timestamp (#844). UDT field
+paths compare as **signed** `ShortType` (`compare_cell_paths`, field index `>= 32768` sorts
+negative) and complex columns match **by name** across differing source headers
+(#888 / #927; parity Cassandra `d14c96b8` / `5e636f9`). Complex deletion markers reconcile with
+strict-supersede (equal `markedForDeleteAt` does NOT supersede) and shadow-before-purge (elements
+with ts `<= markedForDeleteAt` are shadowed BEFORE the marker is purged) (#887; parity `bd244649`
++ `f66fa14f`). Non-frozen UDT multi-cell data now reads and writes end-to-end (#927). See
+Chapter 11 — "Compaction merge semantics". Authority:
+`org.apache.cassandra.db.rows.Cells` (per-column complex merge) and the column's `CellPath`
+comparator.
 
 ### Equal-timestamp live-cell value tie-break diverges from Cassandra (#4/#21)
 
@@ -789,6 +801,72 @@ filter ("always maybe") never short-circuits a point lookup to `None`; `get` the
 the same stitched-chunk scan that `scan` uses. Verified by
 `cqlite-core/tests/issue_824_column_subset_and_filter.rs` (absent-`Filter.db` scan + get tests,
 which also strip the `Filter.db` TOC entry to faithfully reproduce the always-present case).
+
+---
+
+## Epic #921 — Compaction merge semantics (landed) and residual gaps
+
+Epic #921 made CQLite's compaction merge path act on metadata that earlier epics
+only carried. The merge behaviors are documented in full in Chapter 11 — "Compaction
+merge semantics"; this section records what is now **supported** and the limitations
+that **remain** after the epic, each verified against the code on the epic branch.
+
+### Non-frozen UDT multi-cell read+write — SUPPORTED (#927)
+
+**Status**: ✅ **SUPPORTED** end-to-end (was previously called out as unsupported)
+
+A non-frozen UDT is stored as a complex column with one cell per field, keyed by a
+2-byte **signed** `ShortType` declared field index. CQLite now reads such columns and
+writes them back through compaction: per-element winners reconcile by `(column,
+cell_path)`, field paths sort by signed `ShortType` (`compare_cell_paths`), and
+complex columns are matched **by name** so two sources with differing serialization
+headers merge the same logical column (#888 / #927; parity Cassandra `d14c96b8` /
+`5e636f9`). Any stale "non-frozen UDT unsupported" claim elsewhere is superseded by
+this entry.
+
+### Row-deletion + live-cells coexistence — NOT represented (#932)
+
+**Status**: 🐛 **OPEN** (limitation)
+
+A Cassandra row can carry a **row deletion** (`HAS_DELETION`) **and** surviving cells
+written strictly after the deletion timestamp at the same time. CQLite does not
+represent this: the V5CompressedLegacy reader collapses a `HAS_DELETION` row to a
+**pure tombstone** (it emits the row tombstone with an empty cell map and detects it
+via `RowHeader::is_row_tombstone`), and the merge `RowData` is an enum — `Tombstone`
+**xor** `Live`, never both. So a row tombstone that should coexist with newer
+surviving cells **loses the row deletion** (the surviving cells win and the deletion
+is dropped). Authority: `org.apache.cassandra.db.rows.Row` (a `Row` carries both a
+`Row.Deletion` and live cells). Tracked in **#932**.
+
+### Range tombstones during compaction — NOT applied/emitted (#933)
+
+**Status**: 🐛 **OPEN** (limitation)
+
+Range tombstones are not applied or emitted end-to-end in the compaction merge path.
+The V5CompressedLegacy reader **skips** range tombstone markers
+(`skip_range_tombstone_marker`) on the normal scan/compaction path — it does not
+surface a surviving marker to the merger (only the dedicated `delta-scan` path decodes
+them via `parse_range_tombstone_marker_full`), and `merge_entry_to_mutation` does not
+persist a surviving range marker into the rewritten output. Consequently a range
+tombstone is neither used to shadow covered rows during compaction nor re-emitted into
+the compacted SSTable. Authority:
+`org.apache.cassandra.db.rows.RangeTombstoneMarker` / `UnfilteredSerializer`. Tracked
+in **#933**.
+
+### gc_grace purging only on full/major compaction (#935)
+
+**Status**: 🐛 **OPEN** (limitation / by design for safety)
+
+gc_grace / `gcBefore` tombstone purging (#845, parity Cassandra `8d47ebb2`) runs
+**only** on an overlap-safe **full/major** compaction that spans every SSTable for the
+table. A **partial / background** compaction collapses the effective `gc_before_secs`
+to `None` (`merge_partition_rows`, gated by `KWayMerger::with_purge_safe` /
+`purge_safe`) and therefore **retains** every tombstone — there is no per-key
+`maxPurgeableTimestamp` overlap check yet, so the conservative choice avoids
+resurrecting data shadowed in a non-included overlapping SSTable. In the CLI, purging
+is opt-in via `--major` / `--purge-tombstones`. Authority:
+`org.apache.cassandra.db.compaction.CompactionController#maxPurgeableTimestamp`.
+Tracked in **#935**.
 
 ---
 


### PR DESCRIPTION
Epic #921 (compaction byte-parity vs Apache Cassandra) — the remaining merge-acting-logic issues, re-founded on current `main` (after #844/#888/#850/#847/#927/#873/#912 landed via other PRs). Each commit is roborev-reviewed clean (final review jobs 972/976/990).

## Commits
- **#887** `76fdd34f` — complex-deletion entity: strict-supersede (equal mfda does NOT supersede) + shadow-before-purge (elements ts≤mfda shadowed before marker purge), matched by column NAME; row-tombstone interaction (marker with mfda>row_del preserved+emitted alongside DeleteRow); writer-path shadow + per-element rescue; liveness derived from final survivors; ComplexDeletion/WriteComplexElement folded into writer stats. Parity: `bd244649`, `f66fa14f`.
- **#848** `74245c69` — tombstone-vs-expiring(TTL) tie-break: at equal timestamp a cell tombstone beats an expiring cell, decided before the localDeletionTime compare (`cell_reconcile_replace`), consistent across reconcile + writer LWW. Parity: `a62c749`.
- **#845** `a2af0868` — gc_grace/gcBefore tombstone purging during compaction: `localDeletionTime < gcBefore` purges (unsigned-normalized, seconds); default gc_grace 864000; LDT==0 treated unknown/retained; runs after shadow/row-tombstone filters (no resurrection); **overlap-safe gate** — purges only on a full/major compaction (`purge_safe`; CLI opt-in `--major`/`--purge-tombstones`), partial compactions retain; per-cell Delete LDT preserved through writer+stats; WAL 3-way backward-compat. Parity: `8d47ebb2`.
- **docs** `86b91909` — definitive guide: Ch.11 "Compaction merge semantics" + Appendix F (resolved entries + residual gaps #932/#933/#935).

## Validation
`scripts/agent-gate.sh`: fmt/clippy/integration/format-compat/write/cli/minimal-build/smoke all PASS. Two FAILs are pre-existing/environmental, not from this branch:
- `core-tests`: only `test_flush_throughput` (timing perf threshold under parallel load) — passes in isolation.
- `python-bindings`: `test_parity.py` PEP604 `Path | None` collection error on Python 3.9 (file unchanged by this branch).

## Deferred follow-ups (filed, with implementation briefs)
- **#932** — row-deletion + live-cells coexistence (reader collapses HAS_DELETION rows; needs reader/query refactor).
- **#933** — range tombstones end-to-end in compaction (reader skips markers / writer doesn't persist; #846 closed in favor of this).
- **#935** — overlap-aware partial-compaction purging (per-key maxPurgeableTimestamp).

Closes #887, #848, #845.