### PR TITLE
feat(trino): operator gate for GROUP BY aggregation pushdown (#893)

### DIFF
--- a/trino-connector/README.md
+++ b/trino-connector/README.md
@@ -55,6 +55,29 @@ docker compose exec trino trino
 trino> SELECT * FROM cqlite.<keyspace>.<table> LIMIT 10;
 ```
 
+## Catalog configuration
+
+Catalog properties (`etc/catalog/cqlite.properties`):
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `cqlite.sidecar-uri` | *(required)* | Cassandra Sidecar base URI for DDL/ring discovery. |
+| `cqlite.flight-port` | `8815` | Arrow Flight port on each Cassandra node. |
+| `cqlite.local-datacenter` | *(none)* | Preferred datacenter for split placement. |
+| `cqlite.aggregation-pushdown-group-by` | `automatic` | GROUP BY aggregation-pushdown policy: `automatic`, `always`, or `never`. Global aggregates (no GROUP BY) are an unconditional win and always push regardless of this setting. |
+| `cqlite.aggregation-pushdown-max-group-ratio` | `0.5` | `automatic` only: decline GROUP BY pushdown once the estimated distinct-groups / rows ratio exceeds this. Must be in `(0.0, 1.0]`. |
+
+**Aggregation-pushdown gate (issue #893).** The single-finalize-split design wins
+big for global aggregates and low/mid-cardinality `GROUP BY`, but degrades to
+break-even (and slightly negative on bytes) once the number of distinct groups
+approaches the row count. `automatic` declines pushdown in that high-cardinality
+case so Trino aggregates locally — but only when a cardinality estimate is
+available. No authoritative per-grouping-column NDV is surfaced through the
+Flight/Sidecar path yet (Cassandra's `Statistics.db` does not store it), so today
+`automatic` always pushes. Operators who hit the high-cardinality loss can force
+the gate with `cqlite.aggregation-pushdown-group-by=never`; `always` restores the
+unconditional pre-gate behavior.
+
 ## Load testing (optional `loadtest` profile)
 
 `cassandra-easy-stress` is wired in behind a separate `loadtest` profile, so a

--- a/trino-connector/docker/trino/catalog/cqlite.properties
+++ b/trino-connector/docker/trino/catalog/cqlite.properties
@@ -2,3 +2,6 @@ connector.name=cqlite_flight
 cqlite.sidecar-uri=http://172.42.0.2:9043
 cqlite.flight-port=8815
 cqlite.local-datacenter=dc1
+# Aggregation-pushdown gate (issue #893); GROUP BY only — global aggregates always push.
+# cqlite.aggregation-pushdown-group-by=automatic
+# cqlite.aggregation-pushdown-max-group-ratio=0.5

--- a/trino-connector/src/main/java/com/rustyrazorblade/cqlite/flight/CqliteFlightConfig.java
+++ b/trino-connector/src/main/java/com/rustyrazorblade/cqlite/flight/CqliteFlightConfig.java
@@ -11,11 +11,34 @@ import java.util.Map;
  * cqlite.sidecar-uri=http://cassandra:9043
  * cqlite.flight-port=8815
  * cqlite.local-datacenter=dc1
+ * # Aggregation-pushdown gate (issue #893); GROUP BY only — globals always push.
+ * cqlite.aggregation-pushdown-group-by=automatic   # automatic | always | never
+ * cqlite.aggregation-pushdown-max-group-ratio=0.5   # decline above this groups/rows ratio
  * </pre>
  */
-public record CqliteFlightConfig(URI sidecarUri, int flightPort, String localDatacenter) {
+public record CqliteFlightConfig(
+        URI sidecarUri,
+        int flightPort,
+        String localDatacenter,
+        GroupByPushdownPolicy groupByPushdown,
+        double maxGroupRatio) {
 
     public static final int DEFAULT_FLIGHT_PORT = 8815;
+
+    /**
+     * Default groups/rows crossover for {@link GroupByPushdownPolicy#AUTOMATIC}. The
+     * benefit eval (#841) shows GROUP BY pushdown wins materially while distinct groups
+     * stay well under the row count and degrades to break-even-to-loss as they converge;
+     * decline once the estimated group count exceeds half the rows.
+     */
+    public static final double DEFAULT_MAX_GROUP_RATIO = 0.5;
+
+    public CqliteFlightConfig {
+        if (maxGroupRatio <= 0.0 || maxGroupRatio > 1.0) {
+            throw new IllegalArgumentException(
+                    "cqlite.aggregation-pushdown-max-group-ratio must be in (0.0, 1.0], got " + maxGroupRatio);
+        }
+    }
 
     public static CqliteFlightConfig fromMap(Map<String, String> config) {
         String sidecar = require(config, "cqlite.sidecar-uri");
@@ -23,7 +46,12 @@ public record CqliteFlightConfig(URI sidecarUri, int flightPort, String localDat
                 ? Integer.parseInt(config.get("cqlite.flight-port"))
                 : DEFAULT_FLIGHT_PORT;
         String dc = config.get("cqlite.local-datacenter");
-        return new CqliteFlightConfig(URI.create(sidecar), port, dc);
+        GroupByPushdownPolicy policy =
+                GroupByPushdownPolicy.fromConfig(config.get("cqlite.aggregation-pushdown-group-by"));
+        double ratio = config.containsKey("cqlite.aggregation-pushdown-max-group-ratio")
+                ? Double.parseDouble(config.get("cqlite.aggregation-pushdown-max-group-ratio"))
+                : DEFAULT_MAX_GROUP_RATIO;
+        return new CqliteFlightConfig(URI.create(sidecar), port, dc, policy, ratio);
     }
 
     private static String require(Map<String, String> config, String key) {

--- a/trino-connector/src/main/java/com/rustyrazorblade/cqlite/flight/CqliteFlightMetadata.java
+++ b/trino-connector/src/main/java/com/rustyrazorblade/cqlite/flight/CqliteFlightMetadata.java
@@ -236,6 +236,7 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
             return Optional.empty();
         }
         List<ColumnHandle> groupingSet = groupingSets.get(0);
+        boolean hasGroupBy = !groupingSet.isEmpty();
 
         // Grouping columns must be plain column handles (projectable).
         List<CqliteFlightColumnHandle> groupingColumns = new ArrayList<>();
@@ -253,6 +254,16 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
             }
             groupingColumns.add(col);
             groupByNameSet.add(col.name());
+        }
+
+        // Cardinality / operator gate (issue #893). Global aggregates (no GROUP BY)
+        // are an unconditional data-reduction win and are NEVER gated — they bypass
+        // this check. For a GROUP BY, the single-finalize-split design degrades to
+        // break-even-to-loss as distinct groups approach the row count, so honor the
+        // operator policy and decline when the estimated group ratio is too high.
+        if (hasGroupBy && declineGroupByPushdown(
+                groupByPolicy(), estimateGroupRatio(table, groupingColumns), maxGroupRatio())) {
+            return Optional.empty();
         }
 
         // Translate each Trino aggregate into one or more server partial aggregates,
@@ -381,6 +392,53 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
                 assignmentList,
                 groupingColumnMapping,
                 false));
+    }
+
+    /** Effective GROUP BY pushdown policy (defaults to AUTOMATIC when no config is set). */
+    private GroupByPushdownPolicy groupByPolicy() {
+        return config != null ? config.groupByPushdown() : GroupByPushdownPolicy.AUTOMATIC;
+    }
+
+    /** Effective groups/rows crossover for the AUTOMATIC gate. */
+    private double maxGroupRatio() {
+        return config != null ? config.maxGroupRatio() : CqliteFlightConfig.DEFAULT_MAX_GROUP_RATIO;
+    }
+
+    /**
+     * Decide whether to DECLINE GROUP BY aggregation pushdown (issue #893). Pure
+     * decision over the operator policy and an optional estimated groups/rows ratio:
+     *
+     * <ul>
+     *   <li>{@link GroupByPushdownPolicy#NEVER} — always decline.</li>
+     *   <li>{@link GroupByPushdownPolicy#ALWAYS} — never decline (push).</li>
+     *   <li>{@link GroupByPushdownPolicy#AUTOMATIC} — decline only when an estimate is
+     *       present AND it exceeds {@code maxGroupRatio}; with no estimate, push (always
+     *       correct, only a possible perf loss in the rare high-cardinality case).</li>
+     * </ul>
+     */
+    static boolean declineGroupByPushdown(
+            GroupByPushdownPolicy policy, java.util.OptionalDouble estimatedGroupRatio, double maxGroupRatio) {
+        return switch (policy) {
+            case NEVER -> true;
+            case ALWAYS -> false;
+            case AUTOMATIC -> estimatedGroupRatio.isPresent()
+                    && estimatedGroupRatio.getAsDouble() > maxGroupRatio;
+        };
+    }
+
+    /**
+     * Estimate distinct-groups / rows for a GROUP BY, used by the AUTOMATIC gate.
+     *
+     * <p>Returns empty today: an authoritative per-column NDV is not surfaced through
+     * the Flight/Sidecar path (Cassandra's Statistics.db does not store it), so there is
+     * no estimate to gate on. The hook is in place — once a row-count + per-grouping-column
+     * cardinality source exists, populate it here and AUTOMATIC starts gating without any
+     * other change. Until then AUTOMATIC pushes, and operators who hit the rare
+     * high-cardinality loss set {@code cqlite.aggregation-pushdown-group-by=never}.
+     */
+    private java.util.OptionalDouble estimateGroupRatio(
+            CqliteFlightTableHandle table, List<CqliteFlightColumnHandle> groupingColumns) {
+        return java.util.OptionalDouble.empty();
     }
 
     /**

--- a/trino-connector/src/main/java/com/rustyrazorblade/cqlite/flight/GroupByPushdownPolicy.java
+++ b/trino-connector/src/main/java/com/rustyrazorblade/cqlite/flight/GroupByPushdownPolicy.java
@@ -1,0 +1,41 @@
+package com.rustyrazorblade.cqlite.flight;
+
+import java.util.Locale;
+
+/**
+ * Operator control over GROUP BY aggregation pushdown (issue #893).
+ *
+ * <p>Global aggregates (no GROUP BY) are an unconditional win and are ALWAYS pushed,
+ * independent of this policy. This setting governs only aggregates that carry a
+ * {@code GROUP BY}, where the single-finalize-split design degrades to break-even (and
+ * slightly negative on bytes) once the number of distinct groups approaches the row
+ * count — see {@code docs/plans/2026-06-20-issue-841-aggregation-pushdown-benefit-eval.md}.
+ *
+ * <ul>
+ *   <li>{@link #AUTOMATIC} — push when a cardinality estimate says the group count is
+ *       comfortably below the row count; decline (let Trino aggregate locally) above the
+ *       configured ratio. When no estimate is available the connector pushes, which is
+ *       always correct and only risks the rare high-cardinality perf loss.</li>
+ *   <li>{@link #ALWAYS} — always push supported GROUP BY shapes (the pre-#893 behavior).</li>
+ *   <li>{@link #NEVER} — never push GROUP BY; Trino always aggregates locally.</li>
+ * </ul>
+ */
+public enum GroupByPushdownPolicy {
+    AUTOMATIC,
+    ALWAYS,
+    NEVER;
+
+    /** Parse a catalog property value (case-insensitive); blank/null → {@link #AUTOMATIC}. */
+    public static GroupByPushdownPolicy fromConfig(String value) {
+        if (value == null || value.isBlank()) {
+            return AUTOMATIC;
+        }
+        try {
+            return valueOf(value.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "Invalid value for cqlite.aggregation-pushdown-group-by: '" + value
+                            + "' (expected automatic, always, or never)");
+        }
+    }
+}

--- a/trino-connector/src/test/java/com/rustyrazorblade/cqlite/flight/CqliteFlightConfigTest.java
+++ b/trino-connector/src/test/java/com/rustyrazorblade/cqlite/flight/CqliteFlightConfigTest.java
@@ -1,0 +1,62 @@
+package com.rustyrazorblade.cqlite.flight;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Parsing of the aggregation-pushdown gate properties (issue #893) and existing
+ * connector config keys.
+ */
+class CqliteFlightConfigTest {
+
+    private static Map<String, String> base() {
+        Map<String, String> m = new HashMap<>();
+        m.put("cqlite.sidecar-uri", "http://cassandra:9043");
+        return m;
+    }
+
+    @Test
+    void defaultsWhenGateUnset() {
+        CqliteFlightConfig config = CqliteFlightConfig.fromMap(base());
+        assertEquals(GroupByPushdownPolicy.AUTOMATIC, config.groupByPushdown());
+        assertEquals(CqliteFlightConfig.DEFAULT_MAX_GROUP_RATIO, config.maxGroupRatio());
+        assertEquals(CqliteFlightConfig.DEFAULT_FLIGHT_PORT, config.flightPort());
+    }
+
+    @Test
+    void parsesPolicyCaseInsensitively() {
+        Map<String, String> m = base();
+        m.put("cqlite.aggregation-pushdown-group-by", "NeVeR");
+        assertEquals(GroupByPushdownPolicy.NEVER, CqliteFlightConfig.fromMap(m).groupByPushdown());
+    }
+
+    @Test
+    void parsesMaxGroupRatio() {
+        Map<String, String> m = base();
+        m.put("cqlite.aggregation-pushdown-max-group-ratio", "0.25");
+        assertEquals(0.25, CqliteFlightConfig.fromMap(m).maxGroupRatio());
+    }
+
+    @Test
+    void rejectsInvalidPolicy() {
+        Map<String, String> m = base();
+        m.put("cqlite.aggregation-pushdown-group-by", "sometimes");
+        assertThrows(IllegalArgumentException.class, () -> CqliteFlightConfig.fromMap(m));
+    }
+
+    @Test
+    void rejectsOutOfRangeRatio() {
+        Map<String, String> m = base();
+        m.put("cqlite.aggregation-pushdown-max-group-ratio", "1.5");
+        assertThrows(IllegalArgumentException.class, () -> CqliteFlightConfig.fromMap(m));
+
+        Map<String, String> z = base();
+        z.put("cqlite.aggregation-pushdown-max-group-ratio", "0");
+        assertThrows(IllegalArgumentException.class, () -> CqliteFlightConfig.fromMap(z));
+    }
+}

--- a/trino-connector/src/test/java/com/rustyrazorblade/cqlite/flight/CqliteFlightMetadataApplyAggregationTest.java
+++ b/trino-connector/src/test/java/com/rustyrazorblade/cqlite/flight/CqliteFlightMetadataApplyAggregationTest.java
@@ -278,6 +278,69 @@ class CqliteFlightMetadataApplyAggregationTest {
                 .isEmpty());
     }
 
+    // --- Cardinality / operator gate (issue #893) ---
+
+    private static CqliteFlightMetadata metadataWithPolicy(String policy) {
+        var config = CqliteFlightConfig.fromMap(Map.of(
+                "cqlite.sidecar-uri", "http://localhost:9043",
+                "cqlite.aggregation-pushdown-group-by", policy));
+        return new CqliteFlightMetadata(config, null, null);
+    }
+
+    @Test
+    void neverPolicyDeclinesGroupByPushdown() {
+        // GROUP BY is left to Trino entirely when the operator forces it off.
+        assertTrue(metadataWithPolicy("never").applyAggregation(
+                null, TABLE, List.of(agg("count", BIGINT)), ASSIGN, List.of(List.of(C1))).isEmpty(),
+                "GROUP BY must not push under aggregation-pushdown-group-by=never");
+    }
+
+    @Test
+    void neverPolicyStillPushesGlobalAggregate() {
+        // Global aggregates are an unconditional win — the gate never blocks them.
+        assertTrue(metadataWithPolicy("never").applyAggregation(
+                null, TABLE, List.of(agg("count", BIGINT)), ASSIGN, List.of(List.of())).isPresent(),
+                "global aggregate must push even when GROUP BY pushdown is disabled");
+    }
+
+    @Test
+    void alwaysPolicyPushesGroupBy() {
+        assertTrue(metadataWithPolicy("always").applyAggregation(
+                null, TABLE, List.of(agg("count", BIGINT)), ASSIGN, List.of(List.of(C1))).isPresent(),
+                "GROUP BY must push under aggregation-pushdown-group-by=always");
+    }
+
+    @Test
+    void automaticPolicyPushesGroupByWhenNoEstimate() {
+        // No NDV stats are surfaced yet, so AUTOMATIC has no estimate and pushes
+        // (always correct; only risks the rare high-cardinality perf loss).
+        assertTrue(metadataWithPolicy("automatic").applyAggregation(
+                null, TABLE, List.of(agg("count", BIGINT)), ASSIGN, List.of(List.of(C1))).isPresent(),
+                "AUTOMATIC pushes GROUP BY when no cardinality estimate is available");
+    }
+
+    @Test
+    void declineGroupByPushdownDecisionTable() {
+        var none = java.util.OptionalDouble.empty();
+        var low = java.util.OptionalDouble.of(0.1);   // groups well under rows -> push
+        var high = java.util.OptionalDouble.of(0.9);  // groups ~= rows -> decline
+        double maxRatio = 0.5;
+
+        // NEVER always declines; ALWAYS never declines — regardless of estimate.
+        assertTrue(CqliteFlightMetadata.declineGroupByPushdown(GroupByPushdownPolicy.NEVER, low, maxRatio));
+        assertTrue(CqliteFlightMetadata.declineGroupByPushdown(GroupByPushdownPolicy.NEVER, none, maxRatio));
+        assertTrue(!CqliteFlightMetadata.declineGroupByPushdown(GroupByPushdownPolicy.ALWAYS, high, maxRatio));
+        assertTrue(!CqliteFlightMetadata.declineGroupByPushdown(GroupByPushdownPolicy.ALWAYS, none, maxRatio));
+
+        // AUTOMATIC: no estimate -> push; below threshold -> push; above -> decline.
+        assertTrue(!CqliteFlightMetadata.declineGroupByPushdown(GroupByPushdownPolicy.AUTOMATIC, none, maxRatio));
+        assertTrue(!CqliteFlightMetadata.declineGroupByPushdown(GroupByPushdownPolicy.AUTOMATIC, low, maxRatio));
+        assertTrue(CqliteFlightMetadata.declineGroupByPushdown(GroupByPushdownPolicy.AUTOMATIC, high, maxRatio));
+        // Exactly at the threshold is NOT declined (strict >).
+        assertTrue(!CqliteFlightMetadata.declineGroupByPushdown(
+                GroupByPushdownPolicy.AUTOMATIC, java.util.OptionalDouble.of(0.5), maxRatio));
+    }
+
     @Test
     void applyFilterDeclinesOnAggregatedHandle() {
         // After aggregation pushdown, a later filter must NOT be pushed: it would


### PR DESCRIPTION
Closes #893.

## What
Adds a connector-side **policy gate** over GROUP BY aggregation pushdown in the Trino/Flight connector. Global aggregates (no GROUP BY) stay an unconditional win and always push; the gate governs only `GROUP BY`, where the single-finalize-split design degrades to break-even-to-loss as distinct groups approach the row count (per the #841 benefit eval).

## New catalog properties
| Property | Default | Description |
|----------|---------|-------------|
| `cqlite.aggregation-pushdown-group-by` | `automatic` | `automatic` \| `always` \| `never` |
| `cqlite.aggregation-pushdown-max-group-ratio` | `0.5` | `automatic` only: decline above this groups/rows ratio; must be in `(0.0, 1.0]` |

## How
`applyAggregation` consults a pure `declineGroupByPushdown(policy, estimate, ratio)`:
- **NEVER** → decline GROUP BY (Trino aggregates locally)
- **ALWAYS** → push (pre-#893 behavior)
- **AUTOMATIC** → decline only when a cardinality estimate exceeds the ratio

Global aggregates bypass the gate entirely.

### On the cardinality estimate (the deferred dependency)
The issue was parked because no authoritative per-grouping-column NDV is surfaced through the Flight/Sidecar path — Cassandra's `Statistics.db` does not store it. So `estimateGroupRatio()` returns empty today and **AUTOMATIC pushes** (always correct; only risks the rare high-cardinality perf loss). The hook is in place: once a row-count + per-column cardinality source is surfaced, populating that one method activates AUTOMATIC gating with no other change. Until then, operators who hit the high-cardinality loss set `aggregation-pushdown-group-by=never`. This fully delivers the operator-control item (#4) and the gate framework (#2, #3); the stats-surfacing item (#1) is left as a follow-up.

## Tests
- `CqliteFlightConfigTest` — property parsing, case-insensitivity, range validation (5 tests)
- `CqliteFlightMetadataApplyAggregationTest` — gate behavior through `applyAggregation` (never declines GROUP BY but still pushes globals; always/automatic push) + a pure decision-table unit test

Clean `./gradlew test installPlugin` is green locally (21 + 5 tests). Behavior-preserving by default, so the Flight/Trino e2e path is unaffected.