### PR TITLE
fix(compaction/read): preserve row deletion alongside surviving newer cells (#932)

### DIFF
--- a/cqlite-core/examples/gen_wide_sstable.rs
+++ b/cqlite-core/examples/gen_wide_sstable.rs
@@ -88,6 +88,7 @@ async fn main() -> cqlite_core::error::Result<()> {
             partition_tombstone: None,
             range_tombstones: vec![],
             local_deletion_time: None,
+            row_tombstone: None,
         };
         engine.write_async(mutation).await?;
     }

--- a/cqlite-core/src/storage/sstable/reader/compaction_row.rs
+++ b/cqlite-core/src/storage/sstable/reader/compaction_row.rs
@@ -92,6 +92,10 @@ impl CompactionRow {
                 CompactionRowData::Live {
                     simple,
                     complex: Vec::new(),
+                    // The legacy collapsed-value fallback never carries a
+                    // coexisting row deletion (a `Value::Tombstone` row maps to
+                    // `Tombstone` above; a `Value::Map` row is purely live).
+                    row_deletion: None,
                 }
             }
             other => CompactionRowData::Live {
@@ -103,6 +107,7 @@ impl CompactionRow {
                     local_deletion_time: None,
                 }],
                 complex: Vec::new(),
+                row_deletion: None,
             },
         };
         CompactionRow {
@@ -140,6 +145,16 @@ pub enum CompactionRowData {
         /// Complex (non-frozen collection / UDT) columns, each with its
         /// per-element cells and optional complex deletion.
         complex: Vec<ComplexColumn>,
+        /// Row-level deletion that COEXISTS with the surviving live cells
+        /// (issue #932). `Some((markedForDeleteAt µs, localDeletionTime s))`
+        /// when this row carried `HAS_DELETION` AND still has surviving cells
+        /// (the cells the merge kept are strictly newer than the deletion). The
+        /// deletion is preserved so it keeps shadowing older cells of OTHER
+        /// columns in SSTables not part of a partial compaction. `None` for a
+        /// plain live row with no row deletion. A row whose ONLY payload is the
+        /// deletion (no surviving cells) is a [`Self::Tombstone`], not a `Live`
+        /// with this field set.
+        row_deletion: Option<(i64, i32)>,
     },
 }
 

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
@@ -300,6 +300,20 @@ const ROW_HAS_ALL_COLUMNS: u8 = 0x20;
 const ROW_HAS_COMPLEX_DELETION: u8 = 0x40; // Issue #221: Row contains complex column with deletion info
 const ROW_HAS_EXTENDED_FLAGS: u8 = 0x80;
 
+/// Issue #932: does the decoded cell map hold any NON-primary-key data cell?
+///
+/// Primary-key (partition + clustering) columns are surfaced into the cell map
+/// as pseudo-cells (#229) so the read-back path can recover the clustering
+/// identity; they are NOT row data. A row carrying `HAS_DELETION` is a PURE row
+/// tombstone only when no such data cell survives — otherwise the row deletion
+/// COEXISTS with surviving (strictly-newer) cells and the row displays as live.
+fn row_has_non_key_cell(cells: &HashMap<String, Value>, schema: &TableSchema) -> bool {
+    cells.keys().any(|name| {
+        !schema.partition_keys.iter().any(|k| &k.name == name)
+            && !schema.clustering_keys.iter().any(|c| &c.name == name)
+    })
+}
+
 // Unfiltered marker constants (from Cassandra UnfilteredSerializer.java lines 102-109)
 // Issue #229: These markers were being misinterpreted as row data, causing parsing failures
 const END_OF_PARTITION: u8 = 0x01; // Signal end of partition - nothing follows this flag byte
@@ -557,8 +571,18 @@ impl V5CompressedLegacyParser {
                             let row_tombstone =
                                 row_header_opt.as_ref().filter(|h| h.is_row_tombstone());
 
-                            let row_value = if let Some(h) = row_tombstone {
-                                h.row_tombstone()
+                            // Issue #932: a HAS_DELETION row may ALSO carry surviving
+                            // cells (written strictly after the row deletion). For the
+                            // user-facing scan those cells — all newer than the
+                            // deletion — display as a live row; the deletion shadows
+                            // only already-absent older cells, so it has no display
+                            // effect here. Emit a pure `Tombstone` ONLY when no
+                            // non-primary-key cell survives.
+                            let has_data_cell = row_has_non_key_cell(&cells, schema);
+                            let row_value = if row_tombstone.is_some() && !has_data_cell {
+                                row_tombstone
+                                    .map(|h| h.row_tombstone())
+                                    .unwrap_or(Value::Null)
                             } else if cells.is_empty() {
                                 Value::Null
                             } else {
@@ -1310,12 +1334,23 @@ impl V5CompressedLegacyParser {
                                     let row_tombstone =
                                         row_header_opt.as_ref().filter(|h| h.is_row_tombstone());
 
-                                    let row_value = if let Some(h) = row_tombstone {
-                                        log::debug!(
-                                            "V5CompressedLegacy: Partition {} Row {} - emitting Tombstone(deletion_time={})",
-                                            partition_index, row_count, h.row_tombstone_deletion_time()
-                                        );
-                                        h.row_tombstone()
+                                    // Issue #932: a HAS_DELETION row carrying
+                                    // surviving (strictly-newer) cells displays as a
+                                    // live row for the user-facing scan — the
+                                    // deletion shadows only already-absent older
+                                    // cells. Emit a pure Tombstone only when no
+                                    // non-primary-key cell survives.
+                                    let has_data_cell = row_has_non_key_cell(&cells, schema);
+                                    let row_value = if row_tombstone.is_some() && !has_data_cell {
+                                        if let Some(h) = row_tombstone {
+                                            log::debug!(
+                                                "V5CompressedLegacy: Partition {} Row {} - emitting Tombstone(deletion_time={})",
+                                                partition_index, row_count, h.row_tombstone_deletion_time()
+                                            );
+                                            h.row_tombstone()
+                                        } else {
+                                            Value::Null
+                                        }
                                     } else if cells.is_empty() {
                                         warn!(
                                             "V5CompressedLegacy: No cells extracted for {}.{} partition {} row {} (partition key: {} bytes)",
@@ -1764,13 +1799,18 @@ impl V5CompressedLegacyParser {
                     // Both the merger tuple `row_ts` and the emitted
                     // Value::Tombstone must agree, so resolve once here (#505).
                     let row_tombstone = row_header_opt.as_ref().filter(|h| h.is_row_tombstone());
-                    let row_ts = match row_tombstone {
-                        Some(h) => h.row_tombstone_deletion_time(),
-                        None => row_header_opt
-                            .as_ref()
-                            .and_then(|h| h.timestamp)
-                            .unwrap_or(0),
-                    };
+                    // Issue #932: a HAS_DELETION row may ALSO carry a liveness
+                    // timestamp (surviving cells written strictly after the
+                    // deletion). Prefer the liveness timestamp as the row
+                    // timestamp so those cells inherit it and are NOT shadowed by
+                    // the older row deletion during reconcile; fall back to
+                    // markedForDeleteAt only for a PURE row tombstone (which has no
+                    // HAS_TIMESTAMP).
+                    let row_ts = row_header_opt
+                        .as_ref()
+                        .and_then(|h| h.timestamp)
+                        .or_else(|| row_tombstone.map(|h| h.row_tombstone_deletion_time()))
+                        .unwrap_or(0);
 
                     if is_static {
                         static_cells = cells;
@@ -1779,9 +1819,16 @@ impl V5CompressedLegacyParser {
                             cells.entry(k.clone()).or_insert_with(|| v.clone());
                         }
 
-                        // Row tombstone → Value::Tombstone(markedForDeleteAt)
-                        let row_value = if let Some(h) = row_tombstone {
-                            h.row_tombstone()
+                        // Row tombstone → Value::Tombstone(markedForDeleteAt).
+                        // Issue #932: unless the row ALSO carries surviving cells
+                        // (newer than the deletion), in which case it displays as a
+                        // live row — the deletion shadows only already-absent older
+                        // cells.
+                        let has_data_cell = row_has_non_key_cell(&cells, schema);
+                        let row_value = if row_tombstone.is_some() && !has_data_cell {
+                            row_tombstone
+                                .map(|h| h.row_tombstone())
+                                .unwrap_or(Value::Null)
                         } else if cells.is_empty() {
                             Value::Null
                         } else {
@@ -1863,34 +1910,23 @@ impl V5CompressedLegacyParser {
             CompactionRowData, ComplexColumn, SimpleCell,
         };
 
-        if let Some(h) = row_header_opt.as_ref().filter(|h| h.is_row_tombstone()) {
-            // #912: capture the clustering prefix that the parser surfaced into
-            // `cells` (see `parse_row_data_with_offset_impl`, Issue #229). Without
-            // it every clustering-row tombstone — and the partition's static row —
-            // would collapse into the single `None` clustering bucket during merge,
-            // mis-reconciling against each other. Build the columns in schema
-            // order; a clustering column missing from `cells` (partial/range
-            // boundary) yields an empty vec → the `None` bucket, the previous
-            // behavior.
-            let mut clustering: Vec<(String, Value)> =
-                Vec::with_capacity(schema.clustering_keys.len());
-            for ck in &schema.clustering_keys {
-                match cells.get(&ck.name) {
-                    Some(v) => clustering.push((ck.name.clone(), v.clone())),
-                    None => {
-                        clustering.clear();
-                        break;
-                    }
-                }
-            }
-            return CompactionRowData::Tombstone {
-                deletion_time: h.row_tombstone_deletion_time(),
-                // localDeletionTime in SECONDS (GC-grace clock). Preserve the
-                // far-future [2^31, 2^32) encoding via wrapping `as u32 as i32`.
-                local_deletion_time: h.local_deletion_time.unwrap_or(0),
-                clustering,
-            };
-        }
+        // Issue #932: a row with `HAS_DELETION` may ALSO carry surviving cells
+        // (cells written strictly after the row deletion). The row deletion is
+        // captured here either as the coexisting `row_deletion` on a `Live` row
+        // (when data cells survive) or as a pure `Tombstone` (when only the
+        // deletion remains). The decision is made AFTER building the cell sets so
+        // we can tell whether any NON-clustering data cell survived.
+        let row_deletion: Option<(i64, i32)> = row_header_opt
+            .as_ref()
+            .filter(|h| h.is_row_tombstone())
+            .map(|h| {
+                (
+                    h.row_tombstone_deletion_time(),
+                    // localDeletionTime in SECONDS (GC-grace clock). Preserve the
+                    // far-future [2^31, 2^32) encoding via wrapping `as u32 as i32`.
+                    h.local_deletion_time.unwrap_or(0),
+                )
+            });
 
         // Build complex columns (sorted by name for deterministic output, mirroring
         // the collapsed-value path's column ordering).
@@ -1940,9 +1976,53 @@ impl V5CompressedLegacyParser {
             .collect();
         simple_cells.sort_by(|a, b| a.column.cmp(&b.column));
 
+        // Issue #932: a row deletion either COEXISTS with surviving data cells
+        // (kept as `Live { row_deletion: Some(..) }`) or — when no NON-primary-key
+        // cell and no complex element survives — is a pure row tombstone (kept as
+        // `Tombstone`, preserving the #912 clustering-prefix capture). The earlier
+        // code always took the `Tombstone` branch, DROPPING surviving cells and
+        // letting older cells of other columns resurrect in a partial compaction.
+        if let Some((deletion_time, local_deletion_time)) = row_deletion {
+            let primary_key: std::collections::HashSet<&str> = schema
+                .partition_keys
+                .iter()
+                .map(|k| k.name.as_str())
+                .chain(schema.clustering_keys.iter().map(|c| c.name.as_str()))
+                .collect();
+            let has_simple_data = simple_cells
+                .iter()
+                .any(|c| !primary_key.contains(c.column.as_str()));
+            let has_complex_data = complex_cols
+                .iter()
+                .any(|c| !c.elements.is_empty() || c.complex_deletion.is_some());
+
+            if !has_simple_data && !has_complex_data {
+                // Pure row tombstone: rebuild the clustering prefix in schema
+                // order from the surfaced clustering pseudo-cells (#912). A
+                // missing clustering column falls back to the `None` bucket.
+                let mut clustering: Vec<(String, Value)> =
+                    Vec::with_capacity(schema.clustering_keys.len());
+                for ck in &schema.clustering_keys {
+                    match simple_cells.iter().find(|c| c.column == ck.name) {
+                        Some(c) => clustering.push((ck.name.clone(), c.value.clone())),
+                        None => {
+                            clustering.clear();
+                            break;
+                        }
+                    }
+                }
+                return CompactionRowData::Tombstone {
+                    deletion_time,
+                    local_deletion_time,
+                    clustering,
+                };
+            }
+        }
+
         CompactionRowData::Live {
             simple: simple_cells,
             complex: complex_cols,
+            row_deletion,
         }
     }
 
@@ -2164,13 +2244,18 @@ impl V5CompressedLegacyParser {
                     offset = next_offset;
 
                     let row_tombstone = row_header_opt.as_ref().filter(|h| h.is_row_tombstone());
-                    let row_ts = match row_tombstone {
-                        Some(h) => h.row_tombstone_deletion_time(),
-                        None => row_header_opt
-                            .as_ref()
-                            .and_then(|h| h.timestamp)
-                            .unwrap_or(0),
-                    };
+                    // Issue #932: a HAS_DELETION row may ALSO carry a liveness
+                    // timestamp (surviving cells written strictly after the
+                    // deletion). Prefer the liveness timestamp as the row
+                    // timestamp so those cells inherit it and are NOT shadowed by
+                    // the older row deletion during reconcile; fall back to
+                    // markedForDeleteAt only for a PURE row tombstone (which has no
+                    // HAS_TIMESTAMP).
+                    let row_ts = row_header_opt
+                        .as_ref()
+                        .and_then(|h| h.timestamp)
+                        .or_else(|| row_tombstone.map(|h| h.row_tombstone_deletion_time()))
+                        .unwrap_or(0);
 
                     if is_static {
                         static_cells = cells;
@@ -3623,32 +3708,34 @@ impl V5CompressedLegacyParser {
             offset, row_header.header_size, row_size, row_header.timestamp, row_header.ttl, row_header.local_deletion_time
         );
 
-        // CRITICAL FIX (Issue #191, Phase 2): Row tombstone detection
-        // If the row has deletion metadata (local_deletion_time is set), the entire row is deleted.
-        // In this case, there are NO cell values to parse - the row_size includes ONLY the header.
-        // Attempting to parse cells from a tombstoned row will read garbage data and fail.
+        // Row tombstone detection (Issue #191, Phase 2) + coexistence (Issue #932).
         //
-        // According to Cassandra 5.0 format:
-        // - Deleted rows have ROW_HAS_DELETION flag (0x10) set
-        // - Row header contains deletion time and deletion timestamp
-        // - row_size = header_size (no cell data follows)
-        // - Cell parsing must be skipped entirely
-        if row_header.local_deletion_time.is_some() {
+        // A row with ROW_HAS_DELETION (0x10) carries a row-level deletion. HISTORICALLY
+        // such a row had NO cells, so the parser skipped cell parsing entirely. But a
+        // row deletion can COEXIST with surviving cells (cells written strictly after
+        // the deletion — issue #932): the writer emits HAS_DELETION + HAS_TIMESTAMP +
+        // the surviving cells. We must therefore skip cell parsing ONLY when there are
+        // no cell bytes after the row header; otherwise fall through to the normal cell
+        // loop so the surviving cells are read (the row header still carries the
+        // deletion via `local_deletion_time` / `marked_for_delete_at`).
+        //
+        // Calculate offset after row data (based on row_size from header).
+        //
+        // CRITICAL FIX (Issue #237): row_size is measured from AFTER the row_size VInt,
+        // not from where it starts. This matches Cassandra's getFilePointer() semantics:
+        //   next_position = row_size_value + position_after_reading_row_size_vint
+        let after_row_offset =
+            (row_metadata_offset + row_header.row_size_vint_len) + row_size as usize;
+        // Cell data (if any) begins right after the row header. When that start
+        // reaches the row boundary there are no cells — a pure row tombstone.
+        let cell_data_start = row_metadata_offset + row_header.header_size;
+        let has_cell_bytes = cell_data_start < after_row_offset;
+
+        if row_header.local_deletion_time.is_some() && !has_cell_bytes {
             log::debug!(
-                "V5CompressedLegacy: Row is tombstoned (deletion_time={:?}), skipping cell parsing",
+                "V5CompressedLegacy: Pure row tombstone (deletion_time={:?}), skipping cell parsing",
                 row_header.local_deletion_time
             );
-
-            // Calculate offset after row data (based on row_size from header)
-            //
-            // CRITICAL FIX (Issue #237): row_size is measured from AFTER the row_size VInt,
-            // not from where it starts. This matches Cassandra's getFilePointer() semantics:
-            //   next_position = row_size_value + position_after_reading_row_size_vint
-            //
-            // There is NO trailing field in V5CompressedLegacy format - the next partition/row
-            // starts immediately after row_size bytes from this position.
-            let after_row_offset =
-                (row_metadata_offset + row_header.row_size_vint_len) + row_size as usize;
 
             // Validate we have enough data
             if after_row_offset > data.len() {

--- a/cqlite-core/src/storage/sstable/writer/data_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer.rs
@@ -1010,6 +1010,20 @@ impl DataWriter {
                 // Issue #764: honor the mutation's explicit local_deletion_time.
                 row_deletion = Some((m.timestamp_micros, m.effective_local_deletion_time()));
             }
+            // Issue #932: an explicit coexisting row tombstone carries a deletion
+            // time DECOUPLED from `m.timestamp_micros` (the row's liveness
+            // writetime). Select it by its OWN `deletion_time`, not the mutation
+            // timestamp. The mutation's surviving cells were written strictly
+            // after this deletion, so they are NOT shadowed by it (the shadow
+            // boundary below uses `deletion_ts`, which equals the deletion's own
+            // time) — the row keeps both the deletion AND the newer cells.
+            if let Some((del_ts, del_ldt)) = m.row_tombstone {
+                if shadow_floor.is_none_or(|floor| del_ts > floor)
+                    && row_deletion.is_none_or(|(ts, _)| del_ts >= ts)
+                {
+                    row_deletion = Some((del_ts, del_ldt));
+                }
+            }
         }
         // Cells and liveness are shadowed by the strongest covering deletion:
         // the row deletion or the partition/range tombstone floor.

--- a/cqlite-core/src/storage/write_engine/merge.rs
+++ b/cqlite-core/src/storage/write_engine/merge.rs
@@ -107,6 +107,21 @@ pub struct MergeEntry {
     /// or the writer, so output is byte-unchanged. `None` when this entry
     /// carries no range deletion.
     pub range_deletion: Option<RangeTombstone>,
+    /// Row-level deletion that COEXISTS with this entry's surviving live cells
+    /// (issue #932).
+    ///
+    /// `Some((deletion_time_micros, local_deletion_time_secs))` when a row
+    /// tombstone whose timestamp is OLDER than the surviving cells must be kept
+    /// alongside `RowData::Live`. `RowData::Live` has no row-deletion slot, so —
+    /// mirroring the carry-only `complex_deletions` / `range_deletion` fields —
+    /// the coexisting deletion rides here instead of forcing a `RowData` change
+    /// across ~100 `RowData::Live` sites. `reconcile_cluster` folds it into the
+    /// winning row deletion and re-attaches it to the emitted live entry;
+    /// `merge_entry_to_mutation` emits it as `Mutation::row_tombstone`. Without
+    /// this, a partial compaction that keeps newer cells would DROP the row
+    /// deletion and let older cells of other columns (in SSTables not part of the
+    /// compaction) resurrect. `None` for a row with no coexisting deletion.
+    pub row_deletion: Option<(i64, i32)>,
 }
 
 impl MergeEntry {
@@ -132,6 +147,7 @@ impl MergeEntry {
             row_data,
             complex_deletions: Vec::new(),
             range_deletion: None,
+            row_deletion: None,
         }
     }
 
@@ -139,6 +155,18 @@ impl MergeEntry {
     #[must_use]
     pub fn with_complex_deletions(mut self, complex_deletions: Vec<ComplexDeletion>) -> Self {
         self.complex_deletions = complex_deletions;
+        self
+    }
+
+    /// Attach a coexisting row-level deletion (issue #932).
+    ///
+    /// `deletion_time` is `markedForDeleteAt` (microseconds); `ldt` is the
+    /// `localDeletionTime` (GC-clock seconds, `0` = not surfaced). Used when a
+    /// row's surviving cells are newer than a row tombstone that must still be
+    /// preserved so it keeps shadowing older cells in non-compacted SSTables.
+    #[must_use]
+    pub fn with_row_deletion(mut self, deletion_time: i64, ldt: i32) -> Self {
+        self.row_deletion = Some((deletion_time, ldt));
         self
     }
 
@@ -845,7 +873,7 @@ impl SSTableRowIteratorAdapter {
         // the partition's `None` bucket and mis-reconcile against the static row
         // and against other clustering-row tombstones.
         let clustering_key = Self::extract_clustering_key_from_compaction(&row_data, schema);
-        let (row_data, complex_deletions) =
+        let (row_data, complex_deletions, row_deletion) =
             Self::compaction_row_data_to_row_data(row_data, row_timestamp);
         let entry = MergeEntry::new(
             run_index,
@@ -858,6 +886,13 @@ impl SSTableRowIteratorAdapter {
             entry
         } else {
             entry.with_complex_deletions(complex_deletions)
+        };
+        // Issue #932: carry the coexisting row deletion so reconciliation keeps it
+        // alongside the surviving live cells (preventing resurrection of older
+        // cells in non-compacted SSTables).
+        let entry = match row_deletion {
+            Some((deletion_time, ldt)) => entry.with_row_deletion(deletion_time, ldt),
+            None => entry,
         };
         Ok(entry)
     }
@@ -961,7 +996,7 @@ impl SSTableRowIteratorAdapter {
     fn compaction_row_data_to_row_data(
         row_data: crate::storage::sstable::reader::compaction_row::CompactionRowData,
         _row_timestamp: i64,
-    ) -> (RowData, Vec<ComplexDeletion>) {
+    ) -> (RowData, Vec<ComplexDeletion>, Option<(i64, i32)>) {
         use crate::storage::sstable::reader::compaction_row::CompactionRowData;
 
         match row_data {
@@ -978,8 +1013,15 @@ impl SSTableRowIteratorAdapter {
                     local_deletion_time,
                 },
                 Vec::new(),
+                None,
             ),
-            CompactionRowData::Live { simple, complex } => {
+            CompactionRowData::Live {
+                simple,
+                complex,
+                // Issue #932: a coexisting row deletion surfaces here so the
+                // merge entry carries it alongside the live cells.
+                row_deletion,
+            } => {
                 let element_count: usize = complex.iter().map(|c| c.elements.len()).sum();
                 let mut cells = Vec::with_capacity(simple.len() + element_count);
                 let mut complex_deletions = Vec::new();
@@ -1047,7 +1089,7 @@ impl SSTableRowIteratorAdapter {
                     }
                 }
 
-                (RowData::Live { cells }, complex_deletions)
+                (RowData::Live { cells }, complex_deletions, row_deletion)
             }
         }
     }
@@ -2130,6 +2172,19 @@ impl KWayMerger {
                 }
             }
 
+            // Issue #932: a coexisting row deletion carried on a LIVE entry (a
+            // read-back row that held BOTH a row tombstone and surviving newer
+            // cells) contributes to the winning row deletion exactly as a
+            // standalone `RowData::Tombstone` does — capture its paired LDT when
+            // it sets the new max so the rebuilt deletion preserves its wall-clock
+            // `localDeletionTime` (#873).
+            if let Some((del_ts, del_ldt)) = entry.row_deletion {
+                if row_del.is_none_or(|d| del_ts > d) {
+                    row_del = Some(del_ts);
+                    row_del_ldt = del_ldt;
+                }
+            }
+
             match &entry.row_data {
                 RowData::Tombstone {
                     deletion_time,
@@ -2422,13 +2477,24 @@ impl KWayMerger {
             // `surviving` is non-empty, so `max()` is `Some`; `unwrap_or(0)` only
             // guards the type and never triggers.
             let row_ts = surviving.iter().map(|c| c.timestamp).max().unwrap_or(0);
-            Some(MergeEntry::new(
+            let live = MergeEntry::new(
                 run_index,
                 key,
                 clustering_key,
                 row_ts,
                 RowData::Live { cells: surviving },
-            ))
+            );
+            // Issue #932: a row deletion that survived purging COEXISTS with the
+            // surviving (strictly-newer) cells. Carry it on the live entry so the
+            // merge→mutation step emits a `HAS_DELETION` row holding both — the row
+            // deletion keeps shadowing older cells of OTHER columns living in
+            // SSTables not part of a partial compaction, preventing resurrection.
+            // Step 3 already dropped the cells this deletion covers (ts <= row_del),
+            // so the deletion shadows nothing within `surviving`.
+            Some(match row_del {
+                Some(deletion_time) => live.with_row_deletion(deletion_time, row_del_ldt),
+                None => live,
+            })
         } else if let Some(deletion_time) = row_del {
             // No surviving data. If a row tombstone exists, keep the row shadowed
             // so downstream still emits the deletion (preserves #505/#498 absence).
@@ -2604,6 +2670,18 @@ impl KWayMerger {
             _ => None,
         };
 
+        // Issue #932: a coexisting row deletion carried on a LIVE entry must be
+        // emitted as the mutation's `row_tombstone` (deletion time decoupled from
+        // the row's liveness `timestamp_micros`), so the writer re-emits a
+        // `HAS_DELETION` row holding both the deletion and the surviving cells. A
+        // pure `RowData::Tombstone` entry carries its deletion via `DeleteRow`
+        // (below) and leaves `row_deletion` unset, so this only fires for the
+        // coexistence case.
+        let coexisting_row_tombstone = match &entry.row_data {
+            RowData::Live { .. } => entry.row_deletion,
+            RowData::Tombstone { .. } => None,
+        };
+
         // Capture the row tombstone's deletion time (`row_del`) BEFORE moving
         // `row_data` into `operations`. A row tombstone shadows only cells/markers
         // whose timestamp is `<= row_del`; a complex-deletion marker whose
@@ -2665,8 +2743,14 @@ impl KWayMerger {
             entry.timestamp,
             None,
         );
-        Ok(match row_tombstone_ldt {
+        let mutation = match row_tombstone_ldt {
             Some(ldt) => mutation.with_local_deletion_time(ldt),
+            None => mutation,
+        };
+        // Issue #932: attach the coexisting row deletion (deletion time + LDT) so
+        // the writer keeps both the row tombstone and the surviving newer cells.
+        Ok(match coexisting_row_tombstone {
+            Some((deletion_time, ldt)) => mutation.with_row_tombstone(deletion_time, ldt),
             None => mutation,
         })
     }
@@ -6445,9 +6529,10 @@ mod issue_899_per_element_merge {
                     Value::Text("c".to_string()),
                 ]),
             }],
+            row_deletion: None,
         };
 
-        let (row, complex_deletions) =
+        let (row, complex_deletions, _row_deletion) =
             SSTableRowIteratorAdapter::compaction_row_data_to_row_data(row_data, 999);
         assert!(complex_deletions.is_empty(), "no complex deletion present");
 
@@ -6487,9 +6572,10 @@ mod issue_899_per_element_merge {
                 elements: vec![element(&[0xAB], "x", 20_000)],
                 collapsed_value: Value::Set(vec![Value::Text("x".to_string())]),
             }],
+            row_deletion: None,
         };
 
-        let (_row, complex_deletions) =
+        let (_row, complex_deletions, _row_deletion) =
             SSTableRowIteratorAdapter::compaction_row_data_to_row_data(row_data, 20_000);
         assert_eq!(complex_deletions.len(), 1);
         assert_eq!(complex_deletions[0].column, "tags");
@@ -8354,6 +8440,7 @@ mod issue_912_row_tombstone_clustering_identity {
                 local_deletion_time: None,
             }],
             complex: Vec::new(),
+            row_deletion: None,
         };
         let live_ck =
             SSTableRowIteratorAdapter::extract_clustering_key_from_compaction(&live, &schema);
@@ -8619,6 +8706,147 @@ mod issue_873_preserve_row_tombstone_ldt {
         assert_eq!(
             mutation.local_deletion_time, None,
             "a live row must not pin an explicit LDT"
+        );
+    }
+
+    /// Issue #932: when a row tombstone (older) reconciles with a surviving cell
+    /// (newer) for the same `(pk, ck)`, `reconcile_cluster` must emit a LIVE entry
+    /// carrying the surviving cell AND the coexisting `row_deletion` (so the
+    /// deletion keeps shadowing older cells of other columns in SSTables not part
+    /// of a partial compaction). Pre-#932 the row deletion was DROPPED.
+    #[test]
+    fn reconcile_cluster_attaches_row_deletion_when_cells_survive() {
+        let deletion_time = 100i64;
+        let source_ldt = 1_700_000_000i32;
+        // A row tombstone at ts=100 and a live `name` cell at ts=300 (> 100).
+        let tomb = tombstone_entry(1, deletion_time, source_ldt);
+        let live = MergeEntry::new(
+            0,
+            DecoratedKey::new(500, 7i32.to_be_bytes().to_vec()),
+            None,
+            300,
+            RowData::Live {
+                cells: vec![CellData::new(
+                    "name".to_string(),
+                    Value::Text("new".to_string()),
+                    300,
+                )],
+            },
+        );
+
+        let merged = KWayMerger::reconcile_cluster(None, vec![tomb, live], &HashMap::new(), None)
+            .expect("a live coexistence row must be emitted");
+
+        match &merged.row_data {
+            RowData::Live { cells } => {
+                assert_eq!(cells.len(), 1, "the surviving name cell must remain");
+                assert_eq!(cells[0].column, "name");
+                assert_eq!(cells[0].timestamp, 300);
+            }
+            other => panic!("expected a Live coexistence row, got {:?}", other),
+        }
+        assert_eq!(
+            merged.row_deletion,
+            Some((deletion_time, source_ldt)),
+            "the coexisting row deletion (and its source LDT) must be preserved on the live entry"
+        );
+    }
+
+    /// Issue #932: an older cell shadowed by the coexisting row deletion must be
+    /// dropped from the surviving set (a cell at ts <= row_del is shadowed) while
+    /// the deletion is still carried for the newer survivor.
+    #[test]
+    fn reconcile_cluster_shadows_older_cell_under_coexisting_deletion() {
+        let deletion_time = 100i64;
+        let tomb = tombstone_entry(1, deletion_time, 1_700_000_000);
+        // Older `score` cell at ts=50 (<= 100, must be shadowed) and a newer
+        // `name` cell at ts=300 (> 100, must survive), in two runs.
+        let older = MergeEntry::new(
+            2,
+            DecoratedKey::new(500, 7i32.to_be_bytes().to_vec()),
+            None,
+            50,
+            RowData::Live {
+                cells: vec![CellData::new("score".to_string(), Value::Integer(999), 50)],
+            },
+        );
+        let newer = MergeEntry::new(
+            0,
+            DecoratedKey::new(500, 7i32.to_be_bytes().to_vec()),
+            None,
+            300,
+            RowData::Live {
+                cells: vec![CellData::new(
+                    "name".to_string(),
+                    Value::Text("new".to_string()),
+                    300,
+                )],
+            },
+        );
+
+        let merged =
+            KWayMerger::reconcile_cluster(None, vec![tomb, older, newer], &HashMap::new(), None)
+                .expect("a live coexistence row must be emitted");
+
+        match &merged.row_data {
+            RowData::Live { cells } => {
+                assert_eq!(cells.len(), 1, "only the newer cell survives");
+                assert_eq!(
+                    cells[0].column, "name",
+                    "the older `score` cell is shadowed"
+                );
+            }
+            other => panic!("expected a Live coexistence row, got {:?}", other),
+        }
+        assert_eq!(
+            merged.row_deletion.map(|(dt, _)| dt),
+            Some(deletion_time),
+            "the row deletion must be preserved to keep shadowing across SSTables"
+        );
+    }
+
+    /// Issue #932: `merge_entry_to_mutation` must emit the coexisting row deletion
+    /// as `Mutation::row_tombstone` (decoupled from the row's liveness
+    /// `timestamp_micros`) so the writer re-emits a `HAS_DELETION` row holding both
+    /// the deletion and the surviving cells.
+    #[test]
+    fn merge_entry_to_mutation_emits_coexisting_row_tombstone() {
+        let schema = unclustered_schema();
+        let deletion_time = 100i64;
+        let source_ldt = 1_700_000_000i32;
+        let entry = MergeEntry::new(
+            0,
+            DecoratedKey::new(500, 7i32.to_be_bytes().to_vec()),
+            None,
+            300,
+            RowData::Live {
+                cells: vec![CellData::new(
+                    "name".to_string(),
+                    Value::Text("new".to_string()),
+                    300,
+                )],
+            },
+        )
+        .with_row_deletion(deletion_time, source_ldt);
+
+        let mutation =
+            KWayMerger::merge_entry_to_mutation(entry, &schema).expect("conversion should succeed");
+
+        assert_eq!(
+            mutation.row_tombstone,
+            Some((deletion_time, source_ldt)),
+            "the coexisting row deletion must be emitted as Mutation::row_tombstone"
+        );
+        assert_eq!(
+            mutation.timestamp_micros, 300,
+            "the mutation's liveness timestamp stays the row write time, NOT the deletion time"
+        );
+        assert!(
+            mutation
+                .operations
+                .iter()
+                .any(|op| matches!(op, crate::storage::write_engine::mutation::CellOperation::Write { column, .. } if column == "name")),
+            "the surviving cell must still be emitted alongside the row tombstone"
         );
     }
 

--- a/cqlite-core/src/storage/write_engine/mutation.rs
+++ b/cqlite-core/src/storage/write_engine/mutation.rs
@@ -95,6 +95,23 @@ pub struct Mutation {
     /// this field. (Issue #764)
     #[serde(default)]
     pub local_deletion_time: Option<i32>,
+    /// Row-level deletion that COEXISTS with the live cells produced by this
+    /// mutation's `operations` (issue #932).
+    ///
+    /// `Some((deletion_time_micros, local_deletion_time_secs))` carries a row
+    /// tombstone whose `deletion_time` is DECOUPLED from `timestamp_micros` — it
+    /// is older than the row's surviving cells (whose own writetimes drive
+    /// `timestamp_micros`). The writer emits a `HAS_DELETION` row carrying BOTH
+    /// the deletion AND the surviving cells, so older cells of OTHER columns in
+    /// SSTables not part of a partial compaction stay shadowed (they cannot
+    /// resurrect). This is distinct from a `CellOperation::DeleteRow`, whose
+    /// deletion time IS the mutation timestamp; `row_tombstone` is used only on
+    /// the compaction merge→mutation path where the two diverge.
+    ///
+    /// `None` (the default) preserves historical behavior: a row deletion, when
+    /// present, rides as `CellOperation::DeleteRow` at `timestamp_micros`.
+    #[serde(default)]
+    pub row_tombstone: Option<(i64, i32)>,
 }
 
 impl Mutation {
@@ -117,7 +134,21 @@ impl Mutation {
             partition_tombstone: None,
             range_tombstones: Vec::new(),
             local_deletion_time: None,
+            row_tombstone: None,
         }
+    }
+
+    /// Attach a row-level deletion that coexists with this mutation's live cells
+    /// (issue #932).
+    ///
+    /// `deletion_time` is in microseconds (`markedForDeleteAt`); `ldt` is the
+    /// `localDeletionTime` in GC-clock seconds. The writer emits a `HAS_DELETION`
+    /// row carrying both the deletion and the surviving cells, decoupling the
+    /// deletion time from `timestamp_micros` (the row's liveness writetime).
+    #[must_use]
+    pub fn with_row_tombstone(mut self, deletion_time: i64, ldt: i32) -> Self {
+        self.row_tombstone = Some((deletion_time, ldt));
+        self
     }
 
     /// Set an explicit local deletion time (seconds since Unix epoch) for the

--- a/cqlite-core/src/storage/write_engine/wal.rs
+++ b/cqlite-core/src/storage/write_engine/wal.rs
@@ -280,6 +280,8 @@ impl From<LegacyMutation> for Mutation {
             // Pre-#764 records had no explicit local deletion time; preserving
             // None means the writer derives it from the timestamp as before.
             local_deletion_time: None,
+            // Pre-#932 records had no coexisting row tombstone field.
+            row_tombstone: None,
         }
     }
 }
@@ -332,6 +334,53 @@ impl From<LegacyMutationWithLdt> for Mutation {
             // Preserve the mutation-level LDT that layout (B) carries; only the
             // pre-#921 cell `Delete` ops lose their (never-present) LDT to None.
             local_deletion_time: m.local_deletion_time,
+            // Layout (B) predates #932; no coexisting row tombstone field.
+            row_tombstone: None,
+        }
+    }
+}
+
+/// On-disk `Mutation` layout post-Issue #921, pre-Issue #932 (layout (C)).
+///
+/// Issue #932 appended a trailing `row_tombstone: Option<(i64, i32)>` field to
+/// [`Mutation`]. Because the WAL has no per-record version field and bincode is
+/// positional, a record written by a #921-era binary (layout (C): current
+/// `CellOperation` shapes and mutation-level LDT, but NO trailing
+/// `row_tombstone`) has no bytes for the new field. Decoding it as the current
+/// [`Mutation`] runs out of bytes when reading the trailing `Option`. This
+/// mirror reproduces the EXACT layout-(C) field order — identical to the current
+/// `Mutation` minus the new trailing field — so such records still replay,
+/// upgrading `row_tombstone` to `None` (historical behavior).
+///
+/// The field order MUST stay in lockstep with [`Mutation`] (current
+/// [`CellOperation`]), with only the trailing `row_tombstone` omitted.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct PreRowTombstoneMutation {
+    table: TableId,
+    partition_key: PartitionKey,
+    clustering_key: Option<ClusteringKey>,
+    operations: Vec<CellOperation>,
+    timestamp_micros: i64,
+    ttl_seconds: Option<u32>,
+    partition_tombstone: Option<PartitionTombstone>,
+    range_tombstones: Vec<RangeTombstone>,
+    local_deletion_time: Option<i32>,
+}
+
+impl From<PreRowTombstoneMutation> for Mutation {
+    fn from(m: PreRowTombstoneMutation) -> Self {
+        Mutation {
+            table: m.table,
+            partition_key: m.partition_key,
+            clustering_key: m.clustering_key,
+            operations: m.operations,
+            timestamp_micros: m.timestamp_micros,
+            ttl_seconds: m.ttl_seconds,
+            partition_tombstone: m.partition_tombstone,
+            range_tombstones: m.range_tombstones,
+            local_deletion_time: m.local_deletion_time,
+            // Pre-#932 records carry no coexisting row tombstone.
+            row_tombstone: None,
         }
     }
 }
@@ -350,6 +399,13 @@ fn decode_mutation(bytes: &[u8]) -> std::result::Result<Mutation, bincode::Error
     match bincode::deserialize::<Mutation>(bytes) {
         Ok(mutation) => Ok(mutation),
         Err(current_err) => {
+            // Layout (C): post-#921, pre-#932 — current op shapes + mutation LDT
+            // but no trailing `row_tombstone`. Tried first so a #921-era record
+            // with current `Delete { column, local_deletion_time }` ops decodes
+            // correctly rather than misaligning under the pre-#921 mirrors below.
+            if let Ok(m) = bincode::deserialize::<PreRowTombstoneMutation>(bytes) {
+                return Ok(Mutation::from(m));
+            }
             // Layout (B): mutation-level LDT present, pre-#921 Delete ops.
             if let Ok(m) = bincode::deserialize::<LegacyMutationWithLdt>(bytes) {
                 return Ok(Mutation::from(m));

--- a/cqlite-core/tests/compaction_integration.rs
+++ b/cqlite-core/tests/compaction_integration.rs
@@ -816,6 +816,158 @@ fn row_tombstone_shadows_live_row_after_compaction() {
     drop(temp_dir);
 }
 
+// ── Test 4b: Row deletion coexists with a surviving newer cell (Issue #932) ───
+
+/// Regression test for Issue #932: a row-level deletion that COEXISTS with cells
+/// written strictly AFTER it must (a) be read back with its surviving cells (not
+/// collapsed to a pure tombstone), and (b) keep shadowing an OLDER cell of a
+/// different column so that cell cannot resurrect across a compaction.
+///
+/// Setup (two SSTables):
+///   - SSTable A (ts=50):  `score=999` for PK=7   (an OLDER cell, must be shadowed)
+///   - SSTable B: a row tombstone for PK=7 at ts=100 AND `name="new"` at ts=300.
+///     The intra-memtable flush already produces a COEXISTENCE row on disk —
+///     `HAS_DELETION`(100) + the surviving `name`(300) cell.
+///
+/// Expected after compacting A+B:
+///   - PK=7 is PRESENT and live, carrying `name="new"` (300 > 100 survives).
+///   - PK=7 has NO `score`: the older `score`(50) is shadowed by the row
+///     deletion (100). Before the fix, B's coexistence row read back as a PURE
+///     tombstone (dropping `name`), so the merged row was either absent or had
+///     `name` lost — and the preserved deletion is exactly what stops `score`
+///     from resurrecting.
+#[test]
+fn row_deletion_coexists_with_newer_cell_after_compaction() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build tokio runtime");
+
+    let temp_dir = TempDir::new().expect("tempdir");
+    let data_dir = temp_dir.path().join("data");
+    let wal_dir = temp_dir.path().join("wal");
+    let schema = make_schema();
+
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir.clone(), schema.clone());
+    let mut engine = WriteEngine::new(config).expect("engine creation");
+
+    // SSTable A: an OLDER `score` cell (ts=50) for PK=7. This must end up shadowed
+    // by the row deletion that lives in SSTable B.
+    engine
+        .write(write_score_only(7, 999, 50))
+        .expect("write score A");
+    let info_a = rt
+        .block_on(engine.flush())
+        .expect("flush A")
+        .expect("info A");
+    assert_eq!(info_a.partition_count, 1, "SSTable A: 1 partition");
+
+    // SSTable B: a row tombstone at ts=100 PLUS a newer `name` write at ts=300 in
+    // the same memtable. On flush these merge into ONE on-disk row carrying BOTH
+    // the row deletion (100) and the surviving `name` cell (300) — the coexistence
+    // row at the heart of #932.
+    engine
+        .write(delete_row(7, 100))
+        .expect("write row-tombstone B");
+    engine
+        .write(write_name_only(7, "new", 300))
+        .expect("write name B");
+    let info_b = rt
+        .block_on(engine.flush())
+        .expect("flush B")
+        .expect("info B");
+    assert!(info_b.partition_count > 0, "SSTable B: non-empty");
+
+    // Compact A+B (min_threshold=2, permissive buckets).
+    let policy = STCSPolicy::new(2, 32, 0.01, 100.0, 0).expect("valid STCS params");
+    engine
+        .set_merge_policy(Box::new(policy))
+        .expect("set policy");
+
+    let budget = Duration::from_secs(30);
+    let mut compacted = false;
+    for _ in 0..5 {
+        let report = engine.maintenance_step(budget).expect("maintenance_step");
+        if !report.completed_merges.is_empty() {
+            compacted = true;
+            break;
+        }
+        if !report.pending_compaction {
+            break;
+        }
+    }
+    assert!(compacted, "Compaction must complete");
+
+    rt.block_on(engine.close()).expect("close engine");
+
+    // Re-open and scan the merged SSTable.
+    let cqlite_config = Config::default();
+    let manager = rt.block_on(async {
+        let platform = Arc::new(
+            Platform::new(&cqlite_config)
+                .await
+                .expect("platform creation"),
+        );
+        SSTableManager::new(
+            &data_dir,
+            &cqlite_config,
+            platform,
+            #[cfg(feature = "state_machine")]
+            None,
+        )
+        .await
+        .expect("SSTableManager must open")
+    });
+
+    let table_id = CqlTableId::from("compact_ks.items");
+    let results = rt
+        .block_on(manager.scan(&table_id, None, None, None, Some(&schema)))
+        .expect("post-compaction scan");
+
+    let result_map: HashMap<Vec<u8>, Value> = results.into_iter().map(|(k, v)| (k.0, v)).collect();
+
+    let key_7: Vec<u8> = 7_i32.to_be_bytes().into();
+    let pk7 = result_map.get(&key_7).unwrap_or_else(|| {
+        panic!(
+            "PK=7 must be PRESENT after compaction: the row deletion (ts=100) coexists with the \
+             newer name='new' cell (ts=300) — Issue #932 (reader dropped the surviving cell)"
+        )
+    });
+
+    match pk7 {
+        Value::Map(pairs) => {
+            let name = pairs.iter().find_map(|(k, v)| match (k, v) {
+                (Value::Text(col), Value::Text(val)) if col == "name" => Some(val.clone()),
+                _ => None,
+            });
+            assert_eq!(
+                name.as_deref(),
+                Some("new"),
+                "PK=7 must carry the surviving name='new' (ts=300 > deletion ts=100) — Issue #932"
+            );
+            // The older score (ts=50 <= deletion ts=100) must be shadowed by the
+            // preserved row deletion and must NOT resurrect.
+            let score = pairs.iter().find_map(|(k, v)| match (k, v) {
+                (Value::Text(col), Value::Integer(val)) if col == "score" => Some(*val),
+                _ => None,
+            });
+            assert!(
+                score.is_none(),
+                "PK=7 score (ts=50) must be shadowed by the row deletion (ts=100) and NOT \
+                 resurrect, got score={:?} — Issue #932 resurrection regression",
+                score
+            );
+        }
+        other => panic!(
+            "PK=7 must read back as a live row (Value::Map) carrying name='new', got {:?} — \
+             Issue #932 (coexistence row collapsed to a pure tombstone)",
+            other
+        ),
+    }
+
+    drop(temp_dir);
+}
+
 // ── Test 5: Equal-timestamp Delete-vs-Live reconcile (Issue #498) ─────────────
 
 /// Regression test for Issue #498: when a live row and a row tombstone for the


### PR DESCRIPTION
Closes #932.

## Problem
When a row has BOTH a row-level deletion AND surviving cells whose timestamp is newer than the row deletion, CQLite lost the row deletion: `reconcile_cluster` emitted `RowData::Live { cells: surviving }` and used `row_del` only to filter cells, never propagating it to the output. In a **partial compaction**, older cells of other columns living in SSTables not part of the compaction were no longer shadowed by the (dropped) row deletion, so they could **resurrect**. The reader also collapsed any `HAS_DELETION` row to a pure `Value::Tombstone`, dropping its surviving cells.

Cassandra keeps the row's `deletion()` (shadowing cells with `ts <= row_del`) AND the newer live cells; the output row carries both. This PR matches that.

## Changes

**Merge model** (carry-only, mirrors `complex_deletions` / `range_deletion` — avoids touching ~100 `RowData::Live` sites):
- `MergeEntry.row_deletion: Option<(i64,i32)>` + `with_row_deletion`.
- `reconcile_cluster` folds `entry.row_deletion` into the winning row deletion and re-attaches it to the emitted `Live` entry when a deletion coexists with surviving (strictly-newer) cells.
- `Mutation.row_tombstone: Option<(i64,i32)>` (+`with_row_tombstone`, `#[serde(default)]`, WAL `PreRowTombstoneMutation` bincode fallback) decouples the deletion time from the row's liveness timestamp. `merge_entry_to_mutation` emits it; the writer's `merge_row_group` honors it (deletion shadows only `ts <= row_del`, surviving cells stay live).

**Reader / query:**
- `CompactionRowData::Live` gains `row_deletion`; `build_compaction_row_data` emits a `Live` coexistence row (deletion + surviving cells) instead of a pure `Tombstone` when non-key data survives, and prefers the liveness timestamp for the row ts.
- The V5CompressedLegacy row parser no longer blanket-skips cell parsing when `HAS_DELETION` is set — it skips only when there are genuinely no cell bytes after the header (a pure tombstone). The scan emit paths display a coexistence row as live.

## Tests
- New writer→reader round-trip integration test `row_deletion_coexists_with_newer_cell_after_compaction`: older cell (ts=50) shadowed, newer cell (ts=300) survives, deletion (ts=100) preserved.
- Merge-model unit tests for `reconcile_cluster` / `merge_entry_to_mutation`.
- Updated `row_tombstone_shadows_live_row_after_compaction` (which previously passed only because the resurrection bug dropped the deletion) to read the coexistence row back live.

## Validation
`scripts/agent-gate.sh`: **RESULT: PASS** (fmt, clippy, core-tests, integration-tests, format-compat, write-tests, cli-tests, python-bindings, minimal-build, smoke).