### PR TITLE
feat(udt): bare-CQL-name non-frozen UDT detection via UdtRegistry (#929)

### DIFF
--- a/cqlite-cli/src/commands/write.rs
+++ b/cqlite-cli/src/commands/write.rs
@@ -376,7 +376,15 @@ fn compact_purge_safe(args: &crate::cli_types::CompactArgs) -> bool {
 pub async fn handle_compact(args: &crate::cli_types::CompactArgs) -> Result<CompactResult> {
     let start = Instant::now();
 
-    let schema = crate::commands::load_schema_file(&args.schema, false, None)?;
+    // Parse the table schema robustly: a real CQL file commonly has CREATE TYPE
+    // (and CREATE KEYSPACE / USE) statements BEFORE the CREATE TABLE, which the
+    // single-statement `load_schema_file` cannot handle (roborev #1031).
+    let schema = load_compaction_table_schema(&args.schema)?;
+    // #929: a bare-name UDT column added after the input SSTables were written is
+    // absent from every input header; supply a registry built from the schema
+    // file's CREATE TYPE statements so the compaction output normalizes it to a
+    // UserType(...) header instead of a bare/BytesType column (roborev #1027).
+    let udt_registry = udt_registry_from_schema_file(&args.schema, &schema.keyspace);
 
     let inputs = discover_input_sstables(&args.input_dir)?;
     if inputs.is_empty() {
@@ -390,7 +398,7 @@ pub async fn handle_compact(args: &crate::cli_types::CompactArgs) -> Result<Comp
     // explicit `--major` opt-in to `purge_safe`. Default (flag absent) is
     // conservative — see `compact_purge_safe`.
     let purge_safe = compact_purge_safe(args);
-    let report = cqlite_core::storage::write_engine::merge::compact_sstables(
+    let report = cqlite_core::storage::write_engine::merge::compact_sstables_with_registry(
         inputs,
         &args.output,
         &schema,
@@ -398,6 +406,7 @@ pub async fn handle_compact(args: &crate::cli_types::CompactArgs) -> Result<Comp
         args.gc_before,
         args.now_sec,
         purge_safe,
+        Some(&udt_registry),
     )
     .await
     .with_context(|| "compaction failed")?;
@@ -410,6 +419,131 @@ pub async fn handle_compact(args: &crate::cli_types::CompactArgs) -> Result<Comp
         data_file_size: report.output.data_size,
         execution_time_ms: start.elapsed().as_secs_f64() * 1000.0,
     })
+}
+
+/// Load the table schema for compaction from a CQL or JSON schema file.
+///
+/// Unlike the single-statement `load_schema_file`, a `.cql` file is split into
+/// statements and the FIRST `CREATE TABLE` is selected, applying any file-level
+/// keyspace from `CREATE KEYSPACE` / `USE` — so a realistic file with
+/// `CREATE TYPE` (and keyspace) statements before the table parses correctly
+/// (roborev #1031). JSON files fall back to `load_schema_file`.
+#[cfg(feature = "write-support")]
+fn load_compaction_table_schema(schema_path: &Path) -> Result<cqlite_core::schema::TableSchema> {
+    use cqlite_core::schema::cql_parser::{
+        classify_statement, parse_create_table, split_cql_statements, StatementType,
+    };
+
+    let is_cql = matches!(
+        schema_path
+            .extension()
+            .and_then(|s| s.to_str())
+            .unwrap_or("")
+            .to_lowercase()
+            .as_str(),
+        "cql" | "sql" | ""
+    );
+    if !is_cql {
+        // JSON (or other) — the single-statement loader handles it.
+        return crate::commands::load_schema_file(schema_path, false, None);
+    }
+
+    let content = std::fs::read_to_string(schema_path)
+        .with_context(|| format!("Failed to read schema file: {}", schema_path.display()))?;
+
+    let mut file_keyspace: Option<String> = None;
+    for stmt in split_cql_statements(&content) {
+        match classify_statement(&stmt) {
+            StatementType::Other(ref kind) if kind == "use" => {
+                let name = stmt
+                    .trim()
+                    .strip_prefix("USE")
+                    .or_else(|| stmt.trim().strip_prefix("use"))
+                    .unwrap_or("")
+                    .trim()
+                    .trim_end_matches(';')
+                    .trim()
+                    .to_string();
+                if !name.is_empty() {
+                    file_keyspace = Some(name);
+                }
+            }
+            StatementType::Other(ref kind) if kind == "create" => {
+                let lower = stmt.to_lowercase();
+                if lower.contains("create keyspace") {
+                    let after = if let Some(pos) = lower.find("exists") {
+                        &stmt[pos + 6..]
+                    } else if let Some(pos) = lower.find("keyspace") {
+                        &stmt[pos + 8..]
+                    } else {
+                        ""
+                    };
+                    let name = after
+                        .trim()
+                        .split(|c: char| c.is_whitespace() || c == '{' || c == ';')
+                        .next()
+                        .unwrap_or("")
+                        .trim()
+                        .to_string();
+                    if !name.is_empty() {
+                        file_keyspace = Some(name);
+                    }
+                }
+            }
+            StatementType::CreateTable => {
+                if let Ok((_, mut ts)) = parse_create_table(&stmt) {
+                    if ts.keyspace.is_empty()
+                        || ts.keyspace == "unknown"
+                        || ts.keyspace == "default"
+                    {
+                        if let Some(ref ks) = file_keyspace {
+                            ts.keyspace = ks.clone();
+                        }
+                    }
+                    return Ok(ts);
+                }
+            }
+            _ => {}
+        }
+    }
+    Err(anyhow::anyhow!(
+        "No CREATE TABLE statement found in {}",
+        schema_path.display()
+    ))
+}
+
+/// Build a [`UdtRegistry`] from the `CREATE TYPE` statements in a CQL schema
+/// file (#929). Used so compaction can normalize a bare-name UDT column that was
+/// added after the input SSTables were written. Best-effort: a file with no
+/// `CREATE TYPE` statements (or a non-CQL file) yields an empty registry, which
+/// makes compaction header-only — identical to the prior behavior.
+#[cfg(feature = "write-support")]
+pub(crate) fn udt_registry_from_schema_file(
+    schema_path: &Path,
+    default_keyspace: &str,
+) -> cqlite_core::schema::UdtRegistry {
+    use cqlite_core::schema::cql_parser::{parse_create_type, split_cql_statements};
+    use cqlite_core::schema::{CqlType, UdtRegistry};
+    use cqlite_core::types::UdtTypeDef;
+
+    let mut registry = UdtRegistry::new();
+    let Ok(content) = std::fs::read_to_string(schema_path) else {
+        return registry;
+    };
+    for stmt in split_cql_statements(&content) {
+        if let Ok((_, (name, keyspace, fields))) = parse_create_type(&stmt) {
+            let keyspace = keyspace.unwrap_or_else(|| default_keyspace.to_string());
+            let mut def = UdtTypeDef::new(keyspace, name);
+            for (field_name, field_type) in fields {
+                // Unparseable field types fall back to Blob (rendered BytesType),
+                // matching the writer's unknown-type handling.
+                let cql = CqlType::parse(&field_type).unwrap_or(CqlType::Blob);
+                def = def.with_field(field_name, cql, true);
+            }
+            registry.register_udt(def);
+        }
+    }
+    registry
 }
 
 /// Recursively discover published input SSTables under `dir`, ordered
@@ -613,5 +747,81 @@ mod compact_purge_safe_tests {
             compact_purge_safe(&args),
             "--purge-tombstones alias must map to purge_safe = true"
         );
+    }
+}
+
+#[cfg(all(test, feature = "write-support"))]
+mod issue_929_tests {
+    use super::*;
+    use cqlite_core::schema::CqlType;
+    use std::io::Write as _;
+
+    /// The CLI builds a UDT registry from a schema file's CREATE TYPE statements
+    /// so a bare-name UDT column flushes/compacts as complex (#929).
+    #[test]
+    fn builds_udt_registry_from_create_type_statements() {
+        let mut f = tempfile::Builder::new()
+            .suffix(".cql")
+            .tempfile()
+            .expect("temp file");
+        write!(
+            f,
+            "CREATE KEYSPACE test_ks WITH replication = {{'class':'SimpleStrategy'}};\n\
+             CREATE TYPE test_ks.person (name text, age int);\n\
+             CREATE TABLE test_ks.t (id int PRIMARY KEY, addr person);\n"
+        )
+        .expect("write schema");
+
+        let registry = udt_registry_from_schema_file(f.path(), "test_ks");
+        let person = registry
+            .get_udt("test_ks", "person")
+            .expect("person UDT registered");
+        let fields: Vec<(&str, &CqlType)> = person
+            .fields
+            .iter()
+            .map(|fd| (fd.name.as_str(), &fd.field_type))
+            .collect();
+        assert_eq!(fields.len(), 2, "person has two fields");
+        assert_eq!(fields[0].0, "name");
+        assert!(matches!(fields[0].1, CqlType::Text));
+        assert_eq!(fields[1].0, "age");
+        assert!(matches!(fields[1].1, CqlType::Int));
+    }
+
+    /// The compaction schema loader handles a realistic multi-statement CQL file
+    /// where CREATE KEYSPACE / CREATE TYPE precede the CREATE TABLE (roborev #1031).
+    #[test]
+    fn loads_table_schema_after_create_type_statements() {
+        let mut f = tempfile::Builder::new()
+            .suffix(".cql")
+            .tempfile()
+            .expect("temp file");
+        write!(
+            f,
+            "CREATE KEYSPACE test_ks WITH replication = {{'class':'SimpleStrategy'}};\n\
+             CREATE TYPE test_ks.person (name text, age int);\n\
+             CREATE TABLE test_ks.t (id int PRIMARY KEY, addr person);\n"
+        )
+        .expect("write schema");
+
+        let schema = load_compaction_table_schema(f.path()).expect("schema parses");
+        assert_eq!(schema.keyspace, "test_ks");
+        assert_eq!(schema.table, "t");
+        assert!(
+            schema.columns.iter().any(|c| c.name == "addr"),
+            "the addr UDT column must be present"
+        );
+    }
+
+    /// A schema file with no CREATE TYPE yields an empty registry (no-op path).
+    #[test]
+    fn no_create_type_yields_empty_registry() {
+        let mut f = tempfile::Builder::new()
+            .suffix(".cql")
+            .tempfile()
+            .expect("temp file");
+        write!(f, "CREATE TABLE test_ks.t (id int PRIMARY KEY, n text);\n").expect("write");
+        let registry = udt_registry_from_schema_file(f.path(), "test_ks");
+        assert_eq!(registry.total_udts(), 0);
     }
 }

--- a/cqlite-cli/src/main.rs
+++ b/cqlite-cli/src/main.rs
@@ -452,7 +452,21 @@ async fn run_main() -> Result<()> {
             ));
         };
 
-        let config = WriteEngineConfig::new(write_dir.join("data"), write_dir.join("wal"), schema);
+        let mut config = WriteEngineConfig::new(
+            write_dir.join("data"),
+            write_dir.join("wal"),
+            schema.clone(),
+        );
+        // #929: supply a UDT registry built from the schema file's CREATE TYPE
+        // statements so a bare-name non-frozen UDT column flushes as complex
+        // per-field cells instead of the single-cell fallback (roborev #1029).
+        if let Some(ref schema_path) = cli.schema {
+            config =
+                config.with_udt_registry(crate::commands::write::udt_registry_from_schema_file(
+                    schema_path,
+                    &schema.keyspace,
+                ));
+        }
         Some(
             WriteEngine::new(config)
                 .map_err(|e| anyhow::anyhow!("Failed to initialize WriteEngine: {}", e))?,

--- a/cqlite-core/src/storage/sstable/writer/data_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer.rs
@@ -57,7 +57,7 @@
 //! - Format docs: `docs/sstables-definitive-guide/chapters/05-data-db-format.md`
 
 use crate::error::{Error, Result};
-use crate::schema::{Column, CqlType, TableSchema};
+use crate::schema::{Column, CqlType, TableSchema, UdtRegistry};
 use crate::storage::serialization::types::TypeSerializer;
 use crate::storage::serialization::vint::{encode_signed, encode_unsigned, unsigned_len};
 use crate::storage::sstable::writer::index_writer::{PromotedIndexBlock, COLUMN_INDEX_SIZE_BYTES};
@@ -3915,6 +3915,271 @@ fn udt_declared_field_names(data_type: &str) -> Result<Vec<String>> {
         names.push(name);
     }
     Ok(names)
+}
+
+/// Render a [`CqlType`] back to a CQL type string that
+/// [`cql_type_to_marshal_type`] can convert to a Cassandra marshal type.
+///
+/// Used by [`render_udt_marshal`] to emit each UDT field's marshal type. Only
+/// the shapes that the string-based converter understands are produced
+/// (primitives, `list/set/map/frozen/tuple` wrappers). A nested bare UDT
+/// reference (`CqlType::Udt`) has no marshal expansion here — it is rendered as
+/// its bare name and will fall through `cql_type_to_marshal_type` to
+/// `BytesType`, matching the documented "top-level bare UDT only" scope of
+/// issue #929.
+fn cql_type_to_cql_string(ty: &CqlType) -> String {
+    match ty {
+        CqlType::Boolean => "boolean".to_string(),
+        CqlType::TinyInt => "tinyint".to_string(),
+        CqlType::SmallInt => "smallint".to_string(),
+        CqlType::Int => "int".to_string(),
+        CqlType::BigInt => "bigint".to_string(),
+        CqlType::Counter => "counter".to_string(),
+        CqlType::Float => "float".to_string(),
+        CqlType::Double => "double".to_string(),
+        CqlType::Decimal => "decimal".to_string(),
+        CqlType::Text => "text".to_string(),
+        CqlType::Ascii => "ascii".to_string(),
+        CqlType::Varchar => "varchar".to_string(),
+        CqlType::Blob => "blob".to_string(),
+        CqlType::Timestamp => "timestamp".to_string(),
+        CqlType::Date => "date".to_string(),
+        CqlType::Time => "time".to_string(),
+        CqlType::Uuid => "uuid".to_string(),
+        CqlType::TimeUuid => "timeuuid".to_string(),
+        CqlType::Inet => "inet".to_string(),
+        CqlType::Duration => "duration".to_string(),
+        CqlType::Varint => "varint".to_string(),
+        CqlType::List(inner) => format!("list<{}>", cql_type_to_cql_string(inner)),
+        CqlType::Set(inner) => format!("set<{}>", cql_type_to_cql_string(inner)),
+        CqlType::Map(k, v) => format!(
+            "map<{},{}>",
+            cql_type_to_cql_string(k),
+            cql_type_to_cql_string(v)
+        ),
+        CqlType::Tuple(fields) => {
+            let inner: Vec<String> = fields.iter().map(cql_type_to_cql_string).collect();
+            format!("tuple<{}>", inner.join(","))
+        }
+        CqlType::Frozen(inner) => format!("frozen<{}>", cql_type_to_cql_string(inner)),
+        // Bare UDT reference — emit the name; out of scope for marshal expansion
+        // (issue #929 covers top-level bare UDTs only).
+        CqlType::Udt(name, _) => name.clone(),
+        CqlType::Custom(name) => name.clone(),
+    }
+}
+
+/// True if `name` (already lowercased) is a native CQL primitive type keyword.
+/// Used to keep [`resolve_bare_udt_marshal`] from rewriting a real primitive
+/// column even if a same-named UDT is registered (an illegal collision in
+/// Cassandra, guarded against defensively). Mirrors the primitive arms of
+/// `cql_type_to_marshal_type`.
+fn is_cql_primitive_name(lower: &str) -> bool {
+    matches!(
+        lower,
+        "text"
+            | "varchar"
+            | "int"
+            | "bigint"
+            | "smallint"
+            | "tinyint"
+            | "float"
+            | "double"
+            | "boolean"
+            | "blob"
+            | "uuid"
+            | "timeuuid"
+            | "timestamp"
+            | "date"
+            | "time"
+            | "duration"
+            | "inet"
+            | "ascii"
+            | "decimal"
+            | "varint"
+            | "counter"
+    )
+}
+
+/// Render a [`UdtTypeDef`] as a TOP-LEVEL non-frozen `UserType(...)` marshal
+/// string (issue #929) in exactly the shape [`udt_declared_field_names`] parses
+/// and [`is_udt_marshal`] recognizes:
+///
+/// ```text
+/// org.apache.cassandra.db.marshal.UserType(<keyspace>,<hex-name>,<hex-fieldname>:<field-marshal-type>,...)
+/// ```
+///
+/// The keyspace appears as plain text; the UDT name and each field name are
+/// lowercase-hex of their UTF-8 bytes. Each field's marshal type comes from the
+/// canonical CQL→marshal string converter ([`cql_type_to_marshal_type`]).
+///
+/// SCOPE / KNOWN LIMITATION: a field that is itself a UDT (or a
+/// collection/tuple/frozen *containing* a UDT) renders to `BytesType`, NOT the
+/// nested `UserType(...)`. This is deliberate: the direct-write value path
+/// ([`serialize_value`] for `Value::Udt`) infers a nested UDT's schema from the
+/// literal's own field order and does not pad missing fields, so it cannot yet
+/// guarantee declared-order serialization of a sparse / out-of-order nested
+/// literal. Advertising the expanded nested `UserType` in the header while the
+/// value bytes follow literal order would make the SSTable inconsistent (a
+/// reader decoding in declared order would mis-read the fields). Keeping nested
+/// UDT fields as `BytesType` leaves the header and the (blob) value bytes
+/// self-consistent. Schema-aware nested-UDT value serialization is tracked as a
+/// follow-up. Issue #929 targets TOP-LEVEL bare-name non-frozen UDT columns
+/// (whose own fields are primitives / collections of primitives).
+fn render_udt_marshal(udt: &UdtTypeDef) -> String {
+    let prefix = "org.apache.cassandra.db.marshal.UserType(";
+    let mut out = String::from(prefix);
+    out.push_str(&udt.keyspace);
+    out.push(',');
+    out.push_str(&hex::encode(udt.name.as_bytes()));
+    for field in &udt.fields {
+        out.push(',');
+        out.push_str(&hex::encode(field.name.as_bytes()));
+        out.push(':');
+        let field_cql = cql_type_to_cql_string(&field.field_type);
+        out.push_str(
+            &crate::storage::sstable::writer::stats_writer::cql_type_to_marshal_type(&field_cql),
+        );
+    }
+    out.push(')');
+    out
+}
+
+/// Normalize a schema's column `data_type`s by resolving TOP-LEVEL bare CQL UDT
+/// names (e.g. `person`) to their full `UserType(...)` marshal string via the
+/// registry (issue #929).
+///
+/// A direct user write may give a column a bare UDT name as its `data_type`.
+/// The writer holds only a `&TableSchema` and cannot otherwise resolve such a
+/// name to its fields, so it would incorrectly write the column as a single
+/// simple cell. Rewriting the `data_type` to the marshal form lets the existing
+/// [`is_complex_column`] / `write_udt_complex_cells` path decompose it into
+/// per-field cells unchanged.
+///
+/// Scope is strictly TOP-LEVEL bare names: a column whose `data_type` already
+/// looks like a CQL type the converter understands (primitive, `frozen<...>`,
+/// `list<...>`, `set<...>`, `map<...>`, `tuple<...>`) or an
+/// `org.apache.cassandra.db.marshal.*` string is left untouched. With no
+/// registry, or for an unregistered name, the column is left as-is (documented
+/// fallback: single simple cell, no error).
+pub(crate) fn normalize_schema_udts(schema: &mut TableSchema, registry: &UdtRegistry) {
+    let keyspace = schema.keyspace.clone();
+    for column in &mut schema.columns {
+        if let Some(marshal) = resolve_bare_udt_marshal(&column.data_type, &keyspace, registry) {
+            column.data_type = marshal;
+        }
+    }
+}
+
+/// If `data_type` is a TOP-LEVEL bare CQL UDT name that resolves in `registry`,
+/// return its rendered `UserType(...)` marshal string; otherwise `None`.
+pub(crate) fn resolve_bare_udt_marshal(
+    data_type: &str,
+    keyspace: &str,
+    registry: &UdtRegistry,
+) -> Option<String> {
+    let trimmed = data_type.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let lower = trimmed.to_lowercase();
+
+    // Already a marshal string (incl. UserType / frozen marshal) — leave as-is.
+    if lower.starts_with("org.apache.cassandra.db.marshal.") {
+        return None;
+    }
+    // Parameterized CQL types are not bare names — leave to the existing path.
+    if lower.contains('<') {
+        return None;
+    }
+    // A bare name must be a single identifier (no commas / parens).
+    if trimmed.contains(',') || trimmed.contains('(') || trimmed.contains(')') {
+        return None;
+    }
+    // A native CQL type name never denotes a UDT. Cassandra forbids creating a
+    // UDT whose name shadows a primitive, but guard defensively: a registered
+    // UDT colliding with a primitive keyword must not rewrite a real primitive
+    // column into a UserType marshal (which would corrupt it).
+    if is_cql_primitive_name(&lower) {
+        return None;
+    }
+
+    // Resolve the bare name in the registry. Try an exact match first, then
+    // fall back to a case-insensitive match within the keyspace: unquoted CQL
+    // identifiers are case-insensitive, so a `CREATE TYPE Person` registered as
+    // `Person` must still resolve a column declared `person` (roborev #1005).
+    // The exact match wins when present, so a quoted (case-preserving) name is
+    // never shadowed by a differently-cased sibling. The case-insensitive
+    // fallback resolves ONLY when it is unambiguous (exactly one match), so two
+    // differently-cased quoted names never resolve nondeterministically
+    // (roborev #1011).
+    let udt = match registry.get_udt(keyspace, trimmed) {
+        Some(udt) => udt,
+        None => {
+            let ks_udts = registry.get_keyspace_udts(keyspace)?;
+            let mut matches = ks_udts
+                .iter()
+                .filter(|(name, _)| name.eq_ignore_ascii_case(trimmed));
+            let first = matches.next()?;
+            if matches.next().is_some() {
+                return None; // ambiguous — refuse rather than guess.
+            }
+            first.1
+        }
+    };
+
+    // Only normalize UDTs we can FULLY represent: every field is a primitive or
+    // a collection/tuple/frozen OF primitives. A field that is itself a UDT is
+    // NOT yet supported on the direct-write value path (serialize_value infers a
+    // nested UDT's schema from the literal's own order and cannot guarantee
+    // declared-order serialization of a sparse/out-of-order nested literal). If
+    // we normalized such a UDT, its nested field would be advertised as
+    // `BytesType` while the value bytes follow literal order — losing the nested
+    // type semantics. Leaving the column unnormalized keeps it a single,
+    // self-consistent simple cell (documented fallback) until schema-aware
+    // nested-UDT value serialization exists (roborev #1011).
+    if udt
+        .fields
+        .iter()
+        .any(|f| cql_type_references_udt(&f.field_type, keyspace, registry))
+    {
+        return None;
+    }
+
+    Some(render_udt_marshal(udt))
+}
+
+/// True if `ty` is, or transitively contains, a UDT reference (a nested
+/// `UserType`). Used by [`resolve_bare_udt_marshal`] to skip normalizing a
+/// top-level UDT whose fields include another UDT — see the note there.
+///
+/// A `CqlType::Custom` is a UDT reference when its name carries the parser's
+/// `udt:` prefix OR resolves to a registered UDT in `keyspace` (the CQL parser
+/// also emits unprefixed lowercase names like `address` for UDT references, so
+/// the registry lookup is required — roborev #1013).
+fn cql_type_references_udt(ty: &CqlType, keyspace: &str, registry: &UdtRegistry) -> bool {
+    match ty {
+        CqlType::Udt(..) => true,
+        CqlType::Custom(name) => {
+            let clean = name.strip_prefix("udt:").unwrap_or(name);
+            name.starts_with("udt:")
+                || registry.get_udt(keyspace, clean).is_some()
+                || registry
+                    .get_keyspace_udts(keyspace)
+                    .is_some_and(|m| m.keys().any(|k| k.eq_ignore_ascii_case(clean)))
+        }
+        CqlType::List(inner) | CqlType::Set(inner) | CqlType::Frozen(inner) => {
+            cql_type_references_udt(inner, keyspace, registry)
+        }
+        CqlType::Map(k, v) => {
+            cql_type_references_udt(k, keyspace, registry)
+                || cql_type_references_udt(v, keyspace, registry)
+        }
+        CqlType::Tuple(fields) => fields
+            .iter()
+            .any(|f| cql_type_references_udt(f, keyspace, registry)),
+        _ => false,
+    }
 }
 
 /// A surviving cell operation in a merged row, tagged with the timestamp and
@@ -11319,5 +11584,317 @@ mod tests {
             "a row-tombstone row whose complex elements are all shadowed must NOT carry \
              a LIVE row timestamp"
         );
+    }
+
+    // ===================================================================
+    // Issue #929 — bare-name non-frozen UDT resolution at write time.
+    //
+    // A direct user write may give a column a BARE CQL UDT name (e.g. `person`)
+    // as its `data_type`. With a populated `UdtRegistry` the writer's schema is
+    // normalized to the full `UserType(...)` marshal string so the existing
+    // complex-cell path decomposes it into per-field cells. With no registry it
+    // falls back to a single simple cell (documented behavior).
+    // ===================================================================
+
+    /// Build the `person { name text, age int, email text }` registry def used
+    /// by the bare-name tests, in declared field order.
+    fn person_udt_def() -> UdtTypeDef {
+        UdtTypeDef::new("test_ks".to_string(), "person".to_string())
+            .with_field("name".to_string(), CqlType::Text, true)
+            .with_field("age".to_string(), CqlType::Int, true)
+            .with_field("email".to_string(), CqlType::Text, true)
+    }
+
+    /// A registry containing only the `person` UDT.
+    fn person_registry() -> UdtRegistry {
+        let mut reg = UdtRegistry::new();
+        reg.register_udt(person_udt_def());
+        reg
+    }
+
+    /// The rendered marshal string for a `UdtTypeDef` must match the hand-written
+    /// `person_udt_marshal()` byte-for-byte AND round-trip through
+    /// `udt_declared_field_names` to the declared field order (issue #929).
+    #[test]
+    fn render_udt_marshal_matches_and_roundtrips() {
+        let rendered = render_udt_marshal(&person_udt_def());
+        assert_eq!(
+            rendered,
+            person_udt_marshal(),
+            "rendered marshal must match the canonical hand-written form"
+        );
+
+        let names = udt_declared_field_names(&rendered)
+            .expect("rendered marshal must parse via udt_declared_field_names");
+        assert_eq!(
+            names,
+            vec!["name".to_string(), "age".to_string(), "email".to_string()],
+            "field names must round-trip in declared order"
+        );
+
+        // And the renderer's output is recognized as a top-level UDT marshal.
+        assert!(
+            is_udt_marshal(&rendered.to_lowercase()),
+            "rendered marshal must be recognized by is_udt_marshal"
+        );
+        assert!(
+            is_complex_column(&rendered),
+            "rendered marshal must be treated as a complex column"
+        );
+    }
+
+    /// A bare UDT name resolves to its marshal string only when the registry
+    /// knows it; parameterized / marshal / unknown types are left untouched
+    /// (issue #929 top-level-bare-only scope).
+    #[test]
+    fn resolve_bare_udt_marshal_scope() {
+        let reg = person_registry();
+
+        // Bare known name -> rendered marshal.
+        assert_eq!(
+            resolve_bare_udt_marshal("person", "test_ks", &reg).as_deref(),
+            Some(person_udt_marshal().as_str())
+        );
+        // Whitespace tolerated.
+        assert_eq!(
+            resolve_bare_udt_marshal("  person  ", "test_ks", &reg).as_deref(),
+            Some(person_udt_marshal().as_str())
+        );
+        // Unquoted CQL identifiers are case-insensitive: a column declared with a
+        // different case than the registered name still resolves (roborev #1005).
+        assert_eq!(
+            resolve_bare_udt_marshal("Person", "test_ks", &reg).as_deref(),
+            Some(person_udt_marshal().as_str())
+        );
+        assert_eq!(
+            resolve_bare_udt_marshal("PERSON", "test_ks", &reg).as_deref(),
+            Some(person_udt_marshal().as_str())
+        );
+
+        // Unknown name / wrong keyspace -> no rewrite.
+        assert!(resolve_bare_udt_marshal("unknown", "test_ks", &reg).is_none());
+        assert!(resolve_bare_udt_marshal("person", "other_ks", &reg).is_none());
+
+        // Primitives and parameterized types are not bare UDT names.
+        assert!(resolve_bare_udt_marshal("text", "test_ks", &reg).is_none());
+        assert!(resolve_bare_udt_marshal("list<person>", "test_ks", &reg).is_none());
+        assert!(resolve_bare_udt_marshal("frozen<person>", "test_ks", &reg).is_none());
+
+        // An already-marshalled type is left untouched.
+        assert!(resolve_bare_udt_marshal(&person_udt_marshal(), "test_ks", &reg).is_none());
+
+        // SCOPE (roborev #1011): a UDT whose fields include a nested UDT (directly,
+        // or inside a collection/tuple/frozen) is NOT normalized at all — it stays
+        // a single, self-consistent simple cell rather than a partially-degraded
+        // complex column. A UDT with only primitive / collection-of-primitive
+        // fields IS normalized.
+        let mut nested_reg = UdtRegistry::new();
+        nested_reg.register_udt(
+            UdtTypeDef::new("test_ks".to_string(), "inner".to_string()).with_field(
+                "x".to_string(),
+                CqlType::Int,
+                true,
+            ),
+        );
+        // `with_nested` has a direct nested-UDT field -> skipped.
+        nested_reg.register_udt(
+            UdtTypeDef::new("test_ks".to_string(), "with_nested".to_string()).with_field(
+                "i".to_string(),
+                CqlType::Udt("inner".to_string(), vec![]),
+                true,
+            ),
+        );
+        // `with_nested_list` hides the nested UDT inside a list -> skipped.
+        nested_reg.register_udt(
+            UdtTypeDef::new("test_ks".to_string(), "with_nested_list".to_string()).with_field(
+                "xs".to_string(),
+                CqlType::List(Box::new(CqlType::Udt("inner".to_string(), vec![]))),
+                true,
+            ),
+        );
+        // `prim_coll` has only primitive / collection-of-primitive fields ->
+        // normalized, with the collection field rendered fully.
+        nested_reg.register_udt(
+            UdtTypeDef::new("test_ks".to_string(), "prim_coll".to_string())
+                .with_field("n".to_string(), CqlType::Text, true)
+                .with_field(
+                    "xs".to_string(),
+                    CqlType::List(Box::new(CqlType::Int)),
+                    true,
+                ),
+        );
+        assert!(
+            resolve_bare_udt_marshal("with_nested", "test_ks", &nested_reg).is_none(),
+            "UDT with a nested-UDT field must be skipped (single-cell fallback)"
+        );
+        assert!(
+            resolve_bare_udt_marshal("with_nested_list", "test_ks", &nested_reg).is_none(),
+            "UDT with a collection-of-UDT field must be skipped (single-cell fallback)"
+        );
+        let prim_coll = resolve_bare_udt_marshal("prim_coll", "test_ks", &nested_reg)
+            .expect("primitive-only UDT resolves");
+        assert!(
+            prim_coll.contains(&format!(
+                "{}:org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.Int32Type)",
+                hex::encode(b"xs")
+            )),
+            "list<int> field must render as ListType(Int32Type), got: {prim_coll}"
+        );
+        assert!(
+            !prim_coll.contains("BytesType"),
+            "a primitive-only UDT must not contain BytesType, got: {prim_coll}"
+        );
+
+        // Defensive: even if a UDT named after a primitive is registered, a real
+        // primitive column must NOT be rewritten into a UserType marshal.
+        let mut shadow = UdtRegistry::new();
+        shadow.register_udt(
+            UdtTypeDef::new("test_ks".to_string(), "text".to_string()).with_field(
+                "x".to_string(),
+                CqlType::Int,
+                true,
+            ),
+        );
+        assert!(
+            resolve_bare_udt_marshal("text", "test_ks", &shadow).is_none(),
+            "primitive keyword must never resolve to a UDT marshal"
+        );
+    }
+
+    /// A direct write of a BARE-name non-frozen UDT column WITH a populated
+    /// registry must, after schema normalization, decompose into per-field
+    /// complex cells at declared indices and round-trip through the reader,
+    /// even for a sparse / out-of-order literal (issue #929, mirroring the #927
+    /// sparse test but starting from a bare `person` name).
+    #[test]
+    fn bare_udt_with_registry_roundtrips_sparse_out_of_order() {
+        // A schema whose UDT column is declared with the BARE name `person`.
+        let mut schema = TableSchema {
+            keyspace: "test_ks".to_string(),
+            table: "test_table".to_string(),
+            partition_keys: vec![KeyColumn {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![],
+            columns: vec![udt_column("addr", "person")],
+            comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
+        };
+
+        // Before normalization the bare name is NOT complex.
+        assert!(
+            !is_complex_column(&schema.columns[0].data_type),
+            "bare name is not complex before normalization"
+        );
+
+        normalize_schema_udts(&mut schema, &person_registry());
+
+        // After normalization the column carries the full marshal string and is
+        // recognized as a complex column.
+        assert_eq!(schema.columns[0].data_type, person_udt_marshal());
+        assert!(is_complex_column(&schema.columns[0].data_type));
+
+        let col = schema.columns[0].clone();
+        let writer = DataWriter::new(create_test_stats());
+        // Literal lists email THEN name (out of order) and OMITS age (sparse).
+        let udt = Value::Udt(crate::types::UdtValue {
+            type_name: "person".to_string(),
+            keyspace: "test_ks".to_string(),
+            fields: vec![
+                udt_field("email", Some(Value::Text("a@b.com".to_string()))),
+                udt_field("name", Some(Value::Text("Alice".to_string()))),
+            ],
+        });
+
+        let row_ts = 1_005_000i64;
+        let mut buf = Vec::new();
+        writer
+            .write_complex_column(&mut buf, &col, &udt, row_ts, None)
+            .expect("normalized bare UDT must write as a complex column");
+
+        let (_del_ts, _del_ldt, cells) = decode_complex_column(&buf);
+        assert_eq!(cells.len(), 2, "two non-null fields => two cells");
+        assert_eq!(
+            cells[0].cell_path,
+            0u16.to_be_bytes().to_vec(),
+            "name idx 0"
+        );
+        assert_eq!(
+            cells[1].cell_path,
+            2u16.to_be_bytes().to_vec(),
+            "email idx 2"
+        );
+
+        let parser = person_reader();
+        let (value, _off, _meta) = parser
+            .parse_complex_column_inner(&buf, 0, &col, true, row_ts, None)
+            .expect("reader must parse the UDT complex column");
+
+        match value {
+            Value::Udt(out) => {
+                assert_eq!(out.type_name, "person");
+                assert_eq!(out.keyspace, "test_ks");
+                assert_eq!(out.fields.len(), 3, "all DECLARED fields present");
+                assert_eq!(out.fields[0].name, "name");
+                assert_eq!(out.fields[0].value, Some(Value::Text("Alice".to_string())));
+                assert_eq!(out.fields[1].name, "age");
+                assert_eq!(out.fields[1].value, None, "omitted field stays null");
+                assert_eq!(out.fields[2].name, "email");
+                assert_eq!(
+                    out.fields[2].value,
+                    Some(Value::Text("a@b.com".to_string()))
+                );
+            }
+            other => panic!("expected Value::Udt, got {:?}", other),
+        }
+    }
+
+    /// With NO registry a bare-name UDT column stays bare, is NOT detected as
+    /// complex, and a whole-`Value::Udt` write goes through the simple-cell path
+    /// without panicking (issue #929 documented fallback).
+    #[test]
+    fn bare_udt_without_registry_is_single_simple_cell() {
+        let mut schema = TableSchema {
+            keyspace: "test_ks".to_string(),
+            table: "test_table".to_string(),
+            partition_keys: vec![KeyColumn {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![],
+            columns: vec![udt_column("addr", "person")],
+            comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
+        };
+
+        // No registry => no normalization (empty registry resolves nothing).
+        normalize_schema_udts(&mut schema, &UdtRegistry::new());
+        assert_eq!(
+            schema.columns[0].data_type, "person",
+            "with no matching registry entry the bare name is unchanged"
+        );
+        assert!(
+            !is_complex_column(&schema.columns[0].data_type),
+            "bare name without resolution is not a complex column"
+        );
+
+        // A whole-UDT write must not panic on the simple-cell path.
+        let col = schema.columns[0].clone();
+        let writer = DataWriter::new(create_test_stats());
+        let udt = Value::Udt(crate::types::UdtValue {
+            type_name: "person".to_string(),
+            keyspace: "test_ks".to_string(),
+            fields: vec![udt_field("name", Some(Value::Text("Alice".to_string())))],
+        });
+        let mut buf = Vec::new();
+        let res = writer.write_cell(&mut buf, &col.name, &udt, 1_005_000);
+        assert!(
+            res.is_ok(),
+            "bare-name fallback write must succeed as a simple cell: {res:?}"
+        );
+        assert!(!buf.is_empty(), "a simple cell must have been written");
     }
 }

--- a/cqlite-core/src/storage/sstable/writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/mod.rs
@@ -76,6 +76,8 @@ pub use toc_writer::{ComponentEntry, TocWriter};
 
 use crate::error::{Error, Result};
 use crate::schema::TableSchema;
+#[cfg(feature = "write-support")]
+use crate::schema::UdtRegistry;
 use crate::storage::write_engine::mutation::{DecoratedKey, Mutation};
 use std::path::{Path, PathBuf};
 
@@ -359,6 +361,63 @@ impl SSTableWriter {
         expected_partitions: usize,
         format: SSTableFormat,
     ) -> Result<Self> {
+        Self::with_format_and_registry(
+            output_dir,
+            generation,
+            schema,
+            expected_partitions,
+            format,
+            None,
+        )
+    }
+
+    /// Create a new SSTable writer with an expected partition count hint and an
+    /// optional [`UdtRegistry`] for resolving bare UDT column types (issue #929).
+    ///
+    /// When `registry` is `Some`, any column whose `data_type` is a TOP-LEVEL
+    /// bare CQL UDT name (e.g. `person`) that resolves in the registry is
+    /// rewritten to its full `UserType(...)` marshal string so the existing
+    /// complex-cell decomposition path writes per-field cells. With `None`, or
+    /// for an unregistered name, behavior is unchanged (single simple cell).
+    pub fn with_expected_partitions_and_registry(
+        output_dir: PathBuf,
+        generation: u64,
+        schema: &TableSchema,
+        expected_partitions: usize,
+        registry: Option<&UdtRegistry>,
+    ) -> Result<Self> {
+        Self::with_format_and_registry(
+            output_dir,
+            generation,
+            schema,
+            expected_partitions,
+            SSTableFormat::default(),
+            registry,
+        )
+    }
+
+    /// Create a new SSTable writer selecting the on-disk index `format` and an
+    /// optional [`UdtRegistry`] for bare-UDT resolution (issue #766 + #929).
+    pub fn with_format_and_registry(
+        output_dir: PathBuf,
+        generation: u64,
+        schema: &TableSchema,
+        expected_partitions: usize,
+        format: SSTableFormat,
+        registry: Option<&UdtRegistry>,
+    ) -> Result<Self> {
+        // Issue #929: resolve TOP-LEVEL bare UDT column names to their marshal
+        // form on the schema copy the writer holds, so the existing complex-cell
+        // path treats them as multi-cell UDTs. No registry => no rewrite.
+        let mut schema = schema.clone();
+        if let Some(registry) = registry {
+            crate::storage::sstable::writer::data_writer::normalize_schema_udts(
+                &mut schema,
+                registry,
+            );
+        }
+        let schema = &schema;
+
         // Initialize statistics metadata with sentinel values
         let mut stats = StatisticsMetadata::new();
         // Pre-set min values to reasonable defaults (will be updated during writes)
@@ -1304,6 +1363,105 @@ mod tests {
             comments: HashMap::new(),
             dropped_columns: HashMap::new(),
         }
+    }
+
+    /// Issue #929: a bare-name non-frozen UDT column, after registry-backed
+    /// normalization, must be advertised in the Statistics.db SERIALIZATION_HEADER
+    /// as the full `UserType(...)` marshal — NOT `BytesType`. Otherwise Data.db
+    /// would carry complex UDT cells while the header claims a blob, producing an
+    /// inconsistent SSTable (roborev #999).
+    #[tokio::test]
+    async fn bare_udt_column_emits_usertype_in_serialization_header() {
+        use crate::schema::{CqlType, UdtRegistry};
+        use crate::types::{UdtField, UdtTypeDef, UdtValue};
+
+        let schema = TableSchema {
+            keyspace: "test_ks".to_string(),
+            table: "test_table".to_string(),
+            partition_keys: vec![KeyColumn {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![],
+            columns: vec![
+                Column {
+                    name: "id".to_string(),
+                    data_type: "int".to_string(),
+                    nullable: false,
+                    default: None,
+                    is_static: false,
+                },
+                // Declared with the BARE UDT name `person`.
+                Column {
+                    name: "addr".to_string(),
+                    data_type: "person".to_string(),
+                    nullable: true,
+                    default: None,
+                    is_static: false,
+                },
+            ],
+            comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
+        };
+
+        let mut registry = UdtRegistry::new();
+        registry.register_udt(
+            UdtTypeDef::new("test_ks".to_string(), "person".to_string())
+                .with_field("name".to_string(), CqlType::Text, true)
+                .with_field("age".to_string(), CqlType::Int, true),
+        );
+
+        let temp_dir = TempDir::new().unwrap();
+        let mut writer = SSTableWriter::with_expected_partitions_and_registry(
+            temp_dir.path().to_path_buf(),
+            1,
+            &schema,
+            1,
+            Some(&registry),
+        )
+        .unwrap();
+
+        let table_id = TableId::new("test_ks", "test_table");
+        let pk = PartitionKey::single("id", Value::Integer(1));
+        let udt = Value::Udt(UdtValue {
+            type_name: "person".to_string(),
+            keyspace: "test_ks".to_string(),
+            fields: vec![
+                UdtField {
+                    name: "name".to_string(),
+                    value: Some(Value::Text("Alice".to_string())),
+                },
+                UdtField {
+                    name: "age".to_string(),
+                    value: Some(Value::Integer(30)),
+                },
+            ],
+        });
+        let mutation = Mutation::new(
+            table_id,
+            pk,
+            None,
+            vec![CellOperation::Write {
+                column: "addr".to_string(),
+                value: udt,
+            }],
+            1_000_000,
+            None,
+        );
+        let key = mutation.decorated_key(&schema).unwrap();
+        writer.write_partition(key, vec![mutation]).unwrap();
+        let info = writer.finish().await.unwrap();
+
+        let stats_bytes = std::fs::read(&info.stats_path).unwrap();
+        let expected = "org.apache.cassandra.db.marshal.UserType(test_ks,706572736f6e,6e616d65:org.apache.cassandra.db.marshal.UTF8Type,616765:org.apache.cassandra.db.marshal.Int32Type)";
+        let contains = stats_bytes
+            .windows(expected.len())
+            .any(|w| w == expected.as_bytes());
+        assert!(
+            contains,
+            "serialization header must advertise the bare UDT column as UserType(...)"
+        );
     }
 
     /// A schema with a single static column (and a clustering key, so static

--- a/cqlite-core/src/storage/sstable/writer/stats_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/stats_writer.rs
@@ -380,7 +380,22 @@ impl StatisticsMetadata {
 /// - Collections: list<T>, set<T>, map<K,V>
 /// - Frozen wrappers: frozen<list<T>>, frozen<map<K,V>>
 /// - Tuples: tuple<T1, T2, ...>
-fn cql_type_to_marshal_type(cql_type: &str) -> String {
+pub(crate) fn cql_type_to_marshal_type(cql_type: &str) -> String {
+    // Already a marshal string (e.g. a UDT column normalized to UserType(...),
+    // or a column type read back from an input SSTable's SerializationHeader):
+    // return it verbatim. The marshal grammar is case-sensitive (UserType,
+    // Int32Type, ...), so this MUST happen before the lowercasing below, and the
+    // original-case string MUST be preserved. Without this, an already-marshaled
+    // type would fall through to BytesType, advertising the wrong type in the
+    // header while Data.db carries the real (e.g. complex UDT) cells (#929).
+    let raw = cql_type.trim();
+    if raw
+        .to_lowercase()
+        .starts_with("org.apache.cassandra.db.marshal.")
+    {
+        return raw.to_string();
+    }
+
     // Normalize to lowercase for case-insensitive matching.
     // CQL type names are case-insensitive, and the parser may preserve
     // original case from CQL files (e.g., "SET<TEXT>" instead of "set<text>").
@@ -1882,6 +1897,20 @@ mod tests {
         assert_eq!(
             cql_type_to_marshal_type("unknown_type"),
             "org.apache.cassandra.db.marshal.BytesType"
+        );
+
+        // Already-marshaled strings pass through verbatim, case preserved (#929).
+        // This is what a normalized bare-UDT column carries, and what columns
+        // read back from an input SSTable's SerializationHeader look like.
+        let user_type =
+            "org.apache.cassandra.db.marshal.UserType(ks,706572736f6e,6e616d65:org.apache.cassandra.db.marshal.UTF8Type)";
+        assert_eq!(cql_type_to_marshal_type(user_type), user_type);
+        let int_type = "org.apache.cassandra.db.marshal.Int32Type";
+        assert_eq!(cql_type_to_marshal_type(int_type), int_type);
+        // Whitespace around a marshal string is trimmed but case is preserved.
+        assert_eq!(
+            cql_type_to_marshal_type("  org.apache.cassandra.db.marshal.UTF8Type  "),
+            "org.apache.cassandra.db.marshal.UTF8Type"
         );
 
         // Collection types

--- a/cqlite-core/src/storage/write_engine/merge.rs
+++ b/cqlite-core/src/storage/write_engine/merge.rs
@@ -1383,6 +1383,160 @@ pub fn compute_baseline_min(input_paths: &[PathBuf]) -> (i64, i32, i32) {
 /// from `schema` (the overwhelmingly common case), so output stays byte-identical
 /// for every table whose schema still matches its on-disk data.
 #[cfg(feature = "write-support")]
+/// How the input SSTable headers constrain bare-name UDT normalization for a
+/// compaction (#929). The compaction reader decides complex-vs-simple from the
+/// single decode schema, so each column's encoding must be consistent across
+/// inputs.
+#[derive(Debug, Default, Clone)]
+pub struct UdtNormalizationPlan {
+    /// Columns SAFE to decode/write as complex, mapped to the EXACT
+    /// `UserType(...)` marshal string taken from the input headers. The header
+    /// marshal is used verbatim (rather than re-rendered from the registry) so
+    /// the decode schema is byte-exact and handles nested-UDT field types the
+    /// flush-time renderer intentionally skips (roborev #1019).
+    pub eligible_marshals: std::collections::HashMap<String, String>,
+    /// Columns with an incompatible encoding across inputs — declared BOTH as a
+    /// `UserType(...)` (complex) and as a simple form, OR as two DIFFERENT
+    /// `UserType(...)` marshals (a UDT definition mismatch). No single decode
+    /// schema is correct, so the caller must fail rather than corrupt
+    /// (roborev #1017 / #1019).
+    pub conflicts: std::collections::HashSet<String>,
+    /// Every column name that appears in ANY input header (complex or simple).
+    /// A schema column ABSENT from this set is in no input, so there are no cells
+    /// to misdecode and it may be safely registry-normalized for the output
+    /// (schema evolution: a UDT column added after the inputs were written —
+    /// roborev #1023). Trust this set ONLY when `headers_verified` is true.
+    pub observed: std::collections::HashSet<String>,
+    /// True only when EVERY input header was successfully read and parsed. When
+    /// false, header state is unknown: `observed`/`eligible_marshals` are empty
+    /// and the caller MUST NOT treat a column's absence from `observed` as proof
+    /// it is absent from the inputs (it could be an unreadable simple-cell input
+    /// that registry-normalization would misdecode — roborev #1025).
+    pub headers_verified: bool,
+}
+
+/// Inspect the input SSTable headers to plan bare-name UDT normalization.
+///
+/// - An input written without registry support stores the column as a simple
+///   `BytesType` cell; that VETOES normalization, or the reader would misdecode
+///   that input (roborev #1013).
+/// - An older input that simply LACKS the column (schema evolution) must NOT
+///   veto: absence is not a simple-cell declaration (roborev #1015).
+/// - A column with incompatible encodings across inputs (complex vs simple, or
+///   two different `UserType` marshals) is a `conflict`: no single decode schema
+///   is correct, so the caller must fail rather than silently drop/corrupt the
+///   complex values (roborev #1017 / #1019).
+///
+/// Conservative: if any input's header is missing or unparseable, returns an
+/// empty plan (normalize nothing), since the inputs' forms cannot be confirmed.
+pub fn udt_columns_eligible_for_normalization(input_paths: &[PathBuf]) -> UdtNormalizationPlan {
+    use std::collections::{HashMap, HashSet};
+    const USERTYPE_PREFIX: &str = "org.apache.cassandra.db.marshal.usertype(";
+    // column -> distinct UserType marshal strings observed (exact, original case)
+    let mut usertype_marshals: HashMap<String, HashSet<String>> = HashMap::new();
+    // columns declared as a non-UserType (simple) form by some input
+    let mut vetoed: HashSet<String> = HashSet::new();
+    for data_path in input_paths {
+        let stats_path = {
+            let filename = data_path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            let stats_filename = filename.replace("Data.db", "Statistics.db");
+            data_path
+                .parent()
+                .unwrap_or(data_path.as_path())
+                .join(stats_filename)
+        };
+        let Ok(stats_bytes) = std::fs::read(&stats_path) else {
+            return UdtNormalizationPlan::default();
+        };
+        match crate::parser::enhanced_statistics_parser::parse_statistics_with_fallback(
+            &stats_bytes,
+            None,
+        ) {
+            Ok((_, sstable_stats)) => {
+                for c in &sstable_stats.serialization_header_columns {
+                    if c.column_type.to_lowercase().starts_with(USERTYPE_PREFIX) {
+                        usertype_marshals
+                            .entry(c.name.clone())
+                            .or_default()
+                            .insert(c.column_type.clone());
+                    } else {
+                        // Declared, but not a complex UserType -> a simple cell.
+                        vetoed.insert(c.name.clone());
+                    }
+                }
+            }
+            Err(_) => return UdtNormalizationPlan::default(),
+        }
+    }
+
+    let mut plan = UdtNormalizationPlan {
+        headers_verified: true,
+        ..UdtNormalizationPlan::default()
+    };
+    plan.observed.extend(vetoed.iter().cloned());
+    plan.observed.extend(usertype_marshals.keys().cloned());
+    for (column, marshals) in usertype_marshals {
+        if vetoed.contains(&column) || marshals.len() != 1 {
+            // Mixed complex/simple, or disagreeing UDT definitions -> conflict.
+            plan.conflicts.insert(column);
+        } else if let Some(marshal) = marshals.into_iter().next() {
+            plan.eligible_marshals.insert(column, marshal);
+        }
+    }
+    plan
+}
+
+/// Apply the #929 compaction normalization to `schema` (the EFFECTIVE decode
+/// schema): copy each eligible column's exact `UserType(...)` marshal from the
+/// input headers so the compaction reader treats it as complex
+/// (`is_complex_column`) and round-trips the per-field UDT cells. Errors when an
+/// input set has an incompatible mixed encoding for a column (see
+/// [`UdtNormalizationPlan::conflicts`]) rather than silently corrupting data.
+pub(crate) fn apply_udt_marshals_from_inputs(
+    schema: &mut TableSchema,
+    input_paths: &[PathBuf],
+    registry: Option<&crate::schema::UdtRegistry>,
+) -> Result<()> {
+    let plan = udt_columns_eligible_for_normalization(input_paths);
+    if !plan.conflicts.is_empty() {
+        let mut cols: Vec<&String> = plan.conflicts.iter().collect();
+        cols.sort();
+        return Err(Error::InvalidInput(format!(
+            "compaction inputs disagree on the encoding of UDT column(s) {cols:?}: some store \
+             complex UserType cells and others a simple cell (or a different UDT definition). \
+             Refusing to compact to avoid data loss; rewrite the divergent SSTable(s) first."
+        )));
+    }
+    let keyspace = schema.keyspace.clone();
+    for column in &mut schema.columns {
+        if let Some(marshal) = plan.eligible_marshals.get(&column.name) {
+            // Observed as complex in the inputs: use the exact header marshal.
+            column.data_type = marshal.clone();
+        } else if plan.headers_verified && !plan.observed.contains(&column.name) {
+            // Absent from ALL input headers (schema evolution: a UDT column added
+            // after the inputs were written). No input cells to misdecode, so a
+            // registry render is safe and keeps the output header consistent with
+            // future flushes (roborev #1023). Columns OBSERVED as simple are left
+            // bare on purpose (normalizing them would misdecode those inputs).
+            // Requires `headers_verified`: if a header was unreadable we cannot
+            // prove the column is truly absent, so we must not normalize it
+            // (roborev #1025).
+            if let Some(reg) = registry {
+                if let Some(marshal) =
+                    crate::storage::sstable::writer::data_writer::resolve_bare_udt_marshal(
+                        &column.data_type,
+                        &keyspace,
+                        reg,
+                    )
+                {
+                    column.data_type = marshal;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 pub fn effective_compaction_schema(schema: &TableSchema, input_paths: &[PathBuf]) -> TableSchema {
     use std::collections::HashSet;
 
@@ -1609,6 +1763,35 @@ pub async fn compact_sstables(
     now_secs: Option<i64>,
     purge_safe: bool,
 ) -> Result<CompactReport> {
+    compact_sstables_with_registry(
+        input_paths,
+        output_dir,
+        schema,
+        generation,
+        gc_before_secs,
+        now_secs,
+        purge_safe,
+        None,
+    )
+    .await
+}
+
+/// Like [`compact_sstables`], but accepts an optional [`UdtRegistry`] so a UDT
+/// column ADDED after the inputs were written (absent from every input header)
+/// is normalized to its `UserType(...)` marshal in the output instead of being
+/// emitted as a bare `BytesType` column (roborev #1027). Pass `None` to keep the
+/// header-only behavior of [`compact_sstables`].
+#[allow(clippy::too_many_arguments)]
+pub async fn compact_sstables_with_registry(
+    input_paths: Vec<PathBuf>,
+    output_dir: &std::path::Path,
+    schema: &TableSchema,
+    generation: u64,
+    gc_before_secs: Option<i64>,
+    now_secs: Option<i64>,
+    purge_safe: bool,
+    udt_registry: Option<&crate::schema::UdtRegistry>,
+) -> Result<CompactReport> {
     if input_paths.is_empty() {
         return Err(Error::InvalidInput(
             "compaction requires at least one input SSTable".to_string(),
@@ -1624,7 +1807,18 @@ pub async fn compact_sstables(
     // #847/#904 dropped-column flow below: the effective schema keeps `schema`'s
     // `dropped_columns` map, so the retained-dropped pre-pass and write-schema
     // derivation operate on it unchanged.
-    let effective_schema = effective_compaction_schema(schema, &input_paths);
+    let mut effective_schema = effective_compaction_schema(schema, &input_paths);
+    // #929: copy each UDT column's exact UserType(...) marshal from the input
+    // headers onto the EFFECTIVE (decode) schema so the compaction reader treats
+    // it as complex (is_complex_column) and round-trips the per-field UDT cells
+    // (roborev #1009/#1013/#1015/#1017/#1019). This derives ENTIRELY from the
+    // input headers, so it runs unconditionally — a registry is needed only at
+    // flush time. No-op when no input advertises a UserType column; errors on a
+    // mixed encoding rather than corrupting. `write_schema` inherits it via
+    // `for_compaction_output` (clones columns). When `udt_registry` is supplied,
+    // a UDT column absent from every input (schema evolution) is registry-
+    // normalized so the output header is not a bare/BytesType column.
+    apply_udt_marshals_from_inputs(&mut effective_schema, &input_paths, udt_registry)?;
 
     // Decode with `effective_schema` (retains dropped columns so their input cells
     // parse and can be purged), but WRITE with a post-drop schema: fully-purged
@@ -1649,6 +1843,8 @@ pub async fn compact_sstables(
             purge_safe,
         )?
     };
+    // `write_schema` inherits the #929 UDT normalization from the already-
+    // normalized `effective_schema` (for_compaction_output clones columns).
     let write_schema = effective_schema.for_compaction_output(&retained_dropped);
 
     let merger = KWayMerger::new_with_gc(
@@ -9716,6 +9912,778 @@ mod issue_845_gc_grace_purge {
             !purged.contains("tags"),
             "a PURGED complex-deletion marker must NOT count as a survivor (the \
              dropped column is stripped from the output schema); got {purged:?}"
+        );
+    }
+}
+
+// ── Issue #929: bare-name UDT normalization survives compaction ──────────────
+//
+// A flush normalizes a bare-name non-frozen UDT column (e.g. `addr person`) to
+// its `UserType(...)` marshal via the registry and writes complex per-field
+// cells with a matching SERIALIZATION_HEADER. Compaction must apply the SAME
+// normalization to its output write-schema, or it would rewrite the column as a
+// single simple cell and degrade the header to `BytesType` (roborev #1007).
+#[cfg(all(test, feature = "write-support"))]
+mod issue_929_bare_udt_compaction {
+    use super::*;
+    use crate::schema::{Column, CqlType, KeyColumn, UdtRegistry};
+    use crate::storage::write_engine::mutation::{CellOperation, Mutation, PartitionKey, TableId};
+    use crate::types::{UdtField, UdtTypeDef, UdtValue, Value};
+
+    fn person_registry() -> UdtRegistry {
+        let mut reg = UdtRegistry::new();
+        reg.register_udt(
+            UdtTypeDef::new("test_ks".to_string(), "person".to_string())
+                .with_field("name".to_string(), CqlType::Text, true)
+                .with_field("age".to_string(), CqlType::Int, true),
+        );
+        reg
+    }
+
+    // Schema whose UDT column is declared with the BARE name `person`.
+    fn bare_udt_schema() -> TableSchema {
+        TableSchema {
+            keyspace: "test_ks".to_string(),
+            table: "test_table".to_string(),
+            partition_keys: vec![KeyColumn {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![],
+            columns: vec![
+                Column {
+                    name: "id".to_string(),
+                    data_type: "int".to_string(),
+                    nullable: false,
+                    default: None,
+                    is_static: false,
+                },
+                Column {
+                    name: "addr".to_string(),
+                    data_type: "person".to_string(),
+                    nullable: true,
+                    default: None,
+                    is_static: false,
+                },
+            ],
+            comments: std::collections::HashMap::new(),
+            dropped_columns: std::collections::HashMap::new(),
+        }
+    }
+
+    const PERSON_USERTYPE: &str = "org.apache.cassandra.db.marshal.UserType(test_ks,706572736f6e,6e616d65:org.apache.cassandra.db.marshal.UTF8Type,616765:org.apache.cassandra.db.marshal.Int32Type)";
+
+    fn header_has(stats_path: &std::path::Path, needle: &str) -> bool {
+        let bytes = std::fs::read(stats_path).expect("read Statistics.db");
+        bytes.windows(needle.len()).any(|w| w == needle.as_bytes())
+    }
+
+    #[tokio::test]
+    async fn bare_udt_column_survives_compaction_with_registry() {
+        let schema = bare_udt_schema();
+        let registry = person_registry();
+
+        // 1. Flush an input SSTable WITH the registry: the column is normalized to
+        //    UserType(...) and written as complex per-field cells.
+        let in_dir = tempfile::TempDir::new().expect("in dir");
+        let mut writer =
+            crate::storage::sstable::writer::SSTableWriter::with_expected_partitions_and_registry(
+                in_dir.path().to_path_buf(),
+                1,
+                &schema,
+                1,
+                Some(&registry),
+            )
+            .expect("input writer");
+        let udt = Value::Udt(UdtValue {
+            type_name: "person".to_string(),
+            keyspace: "test_ks".to_string(),
+            fields: vec![
+                UdtField {
+                    name: "name".to_string(),
+                    value: Some(Value::Text("Alice".to_string())),
+                },
+                UdtField {
+                    name: "age".to_string(),
+                    value: Some(Value::Integer(30)),
+                },
+            ],
+        });
+        let mutation = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(1)),
+            None,
+            vec![CellOperation::Write {
+                column: "addr".to_string(),
+                value: udt,
+            }],
+            1_000_000,
+            None,
+        );
+        let key = mutation.decorated_key(&schema).expect("decorated key");
+        writer
+            .write_partition(key, vec![mutation])
+            .expect("write partition");
+        let input = writer.finish().await.expect("finish input");
+        assert!(
+            header_has(&input.stats_path, PERSON_USERTYPE),
+            "input header must advertise the UDT column as UserType"
+        );
+
+        // 2. Compact WITH the registry, passing the BARE-name schema (as the engine
+        //    does). The output must re-apply normalization, not degrade to BytesType.
+        let out_dir = tempfile::TempDir::new().expect("out dir");
+        let report = compact_sstables(
+            vec![input.data_path.clone()],
+            out_dir.path(),
+            &schema,
+            2,
+            None,
+            None,
+            true,
+        )
+        .await
+        .expect("compaction");
+
+        assert!(
+            header_has(&report.output.stats_path, PERSON_USERTYPE),
+            "compaction output header must keep the UDT column as UserType (not degrade to BytesType)"
+        );
+
+        // 3. Read the compacted output back through the compaction path and assert
+        //    the per-field UDT cells SURVIVED as a complex column with the original
+        //    field values (not collapsed/dropped). The reader keys complex-vs-simple
+        //    off the schema's data_type, so read with the normalized (UserType) form.
+        let mut read_schema = schema.clone();
+        crate::storage::sstable::writer::data_writer::normalize_schema_udts(
+            &mut read_schema,
+            &registry,
+        );
+        let config = crate::Config::default();
+        let platform = std::sync::Arc::new(
+            crate::platform::Platform::new(&config)
+                .await
+                .expect("platform"),
+        );
+        let reader = crate::storage::sstable::reader::SSTableReader::open(
+            &report.output.data_path,
+            &config,
+            platform,
+        )
+        .await
+        .expect("open compacted output");
+        let rows = reader
+            .iterate_all_partitions_for_compaction(Some(&read_schema))
+            .await
+            .expect("compaction iterator");
+
+        let mut saw_addr = false;
+        for row in &rows {
+            if let crate::storage::sstable::reader::compaction_row::CompactionRowData::Live {
+                complex,
+                ..
+            } = &row.row_data
+            {
+                if let Some(addr) = complex.iter().find(|c| c.column == "addr") {
+                    saw_addr = true;
+                    // Two per-field cells survived: name (idx 0) and age (idx 1).
+                    // The compaction read path surfaces per-element UDT values
+                    // byte-faithfully, so `age` may arrive typed (Integer) or as
+                    // its raw 4-byte big-endian form — both mean the value
+                    // survived rather than being dropped/collapsed.
+                    assert_eq!(
+                        addr.elements.len(),
+                        2,
+                        "both UDT field cells must survive, got: {:?}",
+                        addr.elements
+                    );
+                    let values: Vec<Option<Value>> =
+                        addr.elements.iter().map(|e| e.value.clone()).collect();
+                    let name_ok = values.iter().any(|v| {
+                        matches!(v, Some(Value::Text(s)) if s == "Alice")
+                            || matches!(v, Some(Value::Blob(b)) if b == b"Alice")
+                    });
+                    assert!(
+                        name_ok,
+                        "UDT field `name` value must survive compaction, got: {values:?}"
+                    );
+                    let age_ok = values.iter().any(|v| {
+                        matches!(v, Some(Value::Integer(30)))
+                            || matches!(v, Some(Value::Blob(b)) if b.as_slice() == 30i32.to_be_bytes())
+                    });
+                    assert!(
+                        age_ok,
+                        "UDT field `age` value must survive compaction, got: {values:?}"
+                    );
+                }
+            }
+        }
+        assert!(
+            saw_addr,
+            "compacted output must contain the `addr` UDT as a COMPLEX column (per-field cells \
+             survived rather than being dropped/collapsed)"
+        );
+    }
+
+    /// #1013 safety: an input written WITHOUT a registry stores the bare UDT
+    /// column as a single simple `BytesType` cell. Compacting it WITH a registry
+    /// must NOT normalize/upgrade that column (the header gate sees it is not a
+    /// UserType in the input), so the reader does not misdecode the simple cell.
+    /// The output keeps the column simple (header has no UserType for it).
+    #[tokio::test]
+    async fn simple_cell_input_not_upgraded_on_compaction() {
+        let schema = bare_udt_schema();
+
+        // Input written WITHOUT a registry: `addr` is a single simple cell whose
+        // header type is NOT a UserType marshal.
+        let in_dir = tempfile::TempDir::new().expect("in dir");
+        let mut writer = crate::storage::sstable::writer::SSTableWriter::with_expected_partitions(
+            in_dir.path().to_path_buf(),
+            1,
+            &schema,
+            1,
+        )
+        .expect("input writer");
+        let udt = Value::Udt(UdtValue {
+            type_name: "person".to_string(),
+            keyspace: "test_ks".to_string(),
+            fields: vec![UdtField {
+                name: "name".to_string(),
+                value: Some(Value::Text("Bob".to_string())),
+            }],
+        });
+        let mutation = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(2)),
+            None,
+            vec![CellOperation::Write {
+                column: "addr".to_string(),
+                value: udt,
+            }],
+            1_000_000,
+            None,
+        );
+        let key = mutation.decorated_key(&schema).expect("decorated key");
+        writer
+            .write_partition(key, vec![mutation])
+            .expect("write partition");
+        let input = writer.finish().await.expect("finish input");
+        assert!(
+            !header_has(&input.stats_path, "UserType("),
+            "input written without registry must store the column as a simple (non-UserType) cell"
+        );
+
+        // The header gate must report NO complex UDT columns for this input.
+        let plan = udt_columns_eligible_for_normalization(&[input.data_path.clone()]);
+        assert!(
+            plan.eligible_marshals.is_empty() && plan.conflicts.is_empty(),
+            "a simple-cell input must not be reported as eligible or conflicting"
+        );
+
+        // Compact WITH the registry: the gate prevents normalization, so the
+        // output keeps the column simple (no spurious UserType upgrade, no
+        // misdecode panic).
+        let out_dir = tempfile::TempDir::new().expect("out dir");
+        let report = compact_sstables(
+            vec![input.data_path.clone()],
+            out_dir.path(),
+            &schema,
+            2,
+            None,
+            None,
+            true,
+        )
+        .await
+        .expect("compaction must not panic on a simple-cell input");
+        assert!(
+            !header_has(&report.output.stats_path, "UserType("),
+            "compaction must not upgrade a simple-cell input's column to UserType"
+        );
+    }
+
+    /// #1015 schema evolution: an older input that simply LACKS the UDT column
+    /// (absent from its header) must NOT veto normalization. Compacting it with a
+    /// newer input that DOES carry the complex UDT must still normalize the
+    /// column so the newer input's complex cells survive.
+    #[tokio::test]
+    async fn absent_column_in_older_input_does_not_veto_normalization() {
+        let registry = person_registry();
+        let full_schema = bare_udt_schema();
+
+        // Input A (newer): complex `addr` written WITH the registry.
+        let a_dir = tempfile::TempDir::new().expect("a dir");
+        let mut wa =
+            crate::storage::sstable::writer::SSTableWriter::with_expected_partitions_and_registry(
+                a_dir.path().to_path_buf(),
+                1,
+                &full_schema,
+                1,
+                Some(&registry),
+            )
+            .expect("writer a");
+        let udt = Value::Udt(UdtValue {
+            type_name: "person".to_string(),
+            keyspace: "test_ks".to_string(),
+            fields: vec![UdtField {
+                name: "name".to_string(),
+                value: Some(Value::Text("Carol".to_string())),
+            }],
+        });
+        let ma = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(1)),
+            None,
+            vec![CellOperation::Write {
+                column: "addr".to_string(),
+                value: udt,
+            }],
+            1_000_000,
+            None,
+        );
+        let ka = ma.decorated_key(&full_schema).expect("key a");
+        wa.write_partition(ka, vec![ma]).expect("write a");
+        let input_a = wa.finish().await.expect("finish a");
+
+        // Input B (older): a schema that LACKS `addr` entirely (has a `note`
+        // column instead). Its header never declares `addr`.
+        let older_schema = TableSchema {
+            keyspace: "test_ks".to_string(),
+            table: "test_table".to_string(),
+            partition_keys: vec![KeyColumn {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![],
+            columns: vec![
+                Column {
+                    name: "id".to_string(),
+                    data_type: "int".to_string(),
+                    nullable: false,
+                    default: None,
+                    is_static: false,
+                },
+                Column {
+                    name: "note".to_string(),
+                    data_type: "text".to_string(),
+                    nullable: true,
+                    default: None,
+                    is_static: false,
+                },
+            ],
+            comments: std::collections::HashMap::new(),
+            dropped_columns: std::collections::HashMap::new(),
+        };
+        let b_dir = tempfile::TempDir::new().expect("b dir");
+        let mut wb = crate::storage::sstable::writer::SSTableWriter::with_expected_partitions(
+            b_dir.path().to_path_buf(),
+            1,
+            &older_schema,
+            1,
+        )
+        .expect("writer b");
+        let mb = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(2)),
+            None,
+            vec![CellOperation::Write {
+                column: "note".to_string(),
+                value: Value::Text("x".to_string()),
+            }],
+            1_000_000,
+            None,
+        );
+        let kb = mb.decorated_key(&older_schema).expect("key b");
+        wb.write_partition(kb, vec![mb]).expect("write b");
+        let input_b = wb.finish().await.expect("finish b");
+
+        // `addr` is eligible: declared UserType in A, absent (not simple) in B.
+        let plan = udt_columns_eligible_for_normalization(&[
+            input_a.data_path.clone(),
+            input_b.data_path.clone(),
+        ]);
+        assert!(
+            plan.eligible_marshals.contains_key("addr") && plan.conflicts.is_empty(),
+            "a column absent from an older input must remain eligible, got: {plan:?}"
+        );
+
+        // Compact both with the registry: `addr` must be normalized so A's complex
+        // cells survive into the output (header advertises UserType).
+        let out_dir = tempfile::TempDir::new().expect("out dir");
+        let report = compact_sstables(
+            vec![input_a.data_path.clone(), input_b.data_path.clone()],
+            out_dir.path(),
+            &full_schema,
+            2,
+            None,
+            None,
+            true,
+        )
+        .await
+        .expect("compaction");
+        assert!(
+            header_has(&report.output.stats_path, PERSON_USERTYPE),
+            "newer input's complex UDT column must survive compaction with an older input \
+             that lacks the column"
+        );
+    }
+
+    /// #1017 mixed encoding: the SAME column stored as complex `UserType` in one
+    /// input and a simple cell in another cannot be represented by a single
+    /// decode schema. Compaction must FAIL (not silently drop/corrupt the complex
+    /// values) so the operator can rewrite the simple-cell SSTable first.
+    #[tokio::test]
+    async fn mixed_encoding_inputs_fail_compaction() {
+        let registry = person_registry();
+        let schema = bare_udt_schema();
+
+        // Input A: complex `addr` (written WITH the registry).
+        let a_dir = tempfile::TempDir::new().expect("a dir");
+        let mut wa =
+            crate::storage::sstable::writer::SSTableWriter::with_expected_partitions_and_registry(
+                a_dir.path().to_path_buf(),
+                1,
+                &schema,
+                1,
+                Some(&registry),
+            )
+            .expect("writer a");
+        let udt = Value::Udt(UdtValue {
+            type_name: "person".to_string(),
+            keyspace: "test_ks".to_string(),
+            fields: vec![UdtField {
+                name: "name".to_string(),
+                value: Some(Value::Text("Dave".to_string())),
+            }],
+        });
+        let ma = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(1)),
+            None,
+            vec![CellOperation::Write {
+                column: "addr".to_string(),
+                value: udt,
+            }],
+            1_000_000,
+            None,
+        );
+        let ka = ma.decorated_key(&schema).expect("key a");
+        wa.write_partition(ka, vec![ma]).expect("write a");
+        let input_a = wa.finish().await.expect("finish a");
+
+        // Input B: same `addr` column as a SIMPLE cell (written WITHOUT registry).
+        let b_dir = tempfile::TempDir::new().expect("b dir");
+        let mut wb = crate::storage::sstable::writer::SSTableWriter::with_expected_partitions(
+            b_dir.path().to_path_buf(),
+            1,
+            &schema,
+            1,
+        )
+        .expect("writer b");
+        let udt_b = Value::Udt(UdtValue {
+            type_name: "person".to_string(),
+            keyspace: "test_ks".to_string(),
+            fields: vec![UdtField {
+                name: "name".to_string(),
+                value: Some(Value::Text("Eve".to_string())),
+            }],
+        });
+        let mb = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(2)),
+            None,
+            vec![CellOperation::Write {
+                column: "addr".to_string(),
+                value: udt_b,
+            }],
+            1_000_000,
+            None,
+        );
+        let kb = mb.decorated_key(&schema).expect("key b");
+        wb.write_partition(kb, vec![mb]).expect("write b");
+        let input_b = wb.finish().await.expect("finish b");
+
+        // The plan flags `addr` as a conflict (UserType in A, simple in B).
+        let plan = udt_columns_eligible_for_normalization(&[
+            input_a.data_path.clone(),
+            input_b.data_path.clone(),
+        ]);
+        assert!(
+            plan.conflicts.contains("addr"),
+            "mixed-encoding column must be reported as a conflict, got: {plan:?}"
+        );
+
+        // Compaction must refuse rather than corrupt.
+        let out_dir = tempfile::TempDir::new().expect("out dir");
+        let err = compact_sstables(
+            vec![input_a.data_path.clone(), input_b.data_path.clone()],
+            out_dir.path(),
+            &schema,
+            2,
+            None,
+            None,
+            true,
+        )
+        .await
+        .expect_err("mixed-encoding compaction must fail");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("disagree on the encoding") && msg.contains("addr"),
+            "error must explain the mixed-encoding conflict, got: {msg}"
+        );
+    }
+
+    /// #1019 nested UDT: compaction copies the EXACT `UserType(...)` marshal from
+    /// the input header (which may contain a nested `UserType` the flush-time
+    /// renderer intentionally skips). A column whose on-disk marshal nests
+    /// another UserType must survive compaction byte-exact (header preserved) and
+    /// be decoded as complex, never dropped.
+    #[tokio::test]
+    async fn nested_usertype_column_survives_compaction() {
+        // outer { i: inner { x: int } } — a UDT whose field is itself a UDT.
+        const INNER_MARSHAL: &str =
+            "org.apache.cassandra.db.marshal.UserType(test_ks,696e6e6572,78:org.apache.cassandra.db.marshal.Int32Type)";
+        // outer(test_ks, hex "outer", hex "i" : <inner marshal>)
+        let outer_marshal = format!(
+            "org.apache.cassandra.db.marshal.UserType(test_ks,6f75746572,69:{INNER_MARSHAL})"
+        );
+
+        // Schema whose `addr` column already carries the full nested marshal, so
+        // the writer treats it as complex without needing the registry to render
+        // it (which it could not — nested UDTs are skipped at flush).
+        let schema = TableSchema {
+            keyspace: "test_ks".to_string(),
+            table: "test_table".to_string(),
+            partition_keys: vec![KeyColumn {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![],
+            columns: vec![
+                Column {
+                    name: "id".to_string(),
+                    data_type: "int".to_string(),
+                    nullable: false,
+                    default: None,
+                    is_static: false,
+                },
+                Column {
+                    name: "addr".to_string(),
+                    data_type: outer_marshal.clone(),
+                    nullable: true,
+                    default: None,
+                    is_static: false,
+                },
+            ],
+            comments: std::collections::HashMap::new(),
+            dropped_columns: std::collections::HashMap::new(),
+        };
+
+        let in_dir = tempfile::TempDir::new().expect("in dir");
+        let mut writer = crate::storage::sstable::writer::SSTableWriter::new(
+            in_dir.path().to_path_buf(),
+            1,
+            &schema,
+        )
+        .expect("input writer");
+        // `addr` = outer{ i: inner{ x: 5 } }.
+        let addr = Value::Udt(UdtValue {
+            type_name: "outer".to_string(),
+            keyspace: "test_ks".to_string(),
+            fields: vec![UdtField {
+                name: "i".to_string(),
+                value: Some(Value::Udt(UdtValue {
+                    type_name: "inner".to_string(),
+                    keyspace: "test_ks".to_string(),
+                    fields: vec![UdtField {
+                        name: "x".to_string(),
+                        value: Some(Value::Integer(5)),
+                    }],
+                })),
+            }],
+        });
+        let mutation = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(1)),
+            None,
+            vec![CellOperation::Write {
+                column: "addr".to_string(),
+                value: addr,
+            }],
+            1_000_000,
+            None,
+        );
+        let key = mutation.decorated_key(&schema).expect("decorated key");
+        writer.write_partition(key, vec![mutation]).expect("write");
+        let input = writer.finish().await.expect("finish");
+        assert!(
+            header_has(&input.stats_path, &outer_marshal),
+            "input header must carry the exact nested UserType marshal"
+        );
+
+        // The plan copies the nested marshal verbatim (NOT a registry re-render).
+        let plan = udt_columns_eligible_for_normalization(&[input.data_path.clone()]);
+        assert_eq!(
+            plan.eligible_marshals.get("addr").map(String::as_str),
+            Some(outer_marshal.as_str()),
+            "compaction must copy the exact nested marshal from the input header"
+        );
+
+        // Compaction (header-driven, no registry needed) must preserve the nested
+        // marshal byte-exact in the output header (not degraded to BytesType).
+        let out_dir = tempfile::TempDir::new().expect("out dir");
+        let report = compact_sstables(
+            vec![input.data_path.clone()],
+            out_dir.path(),
+            &schema,
+            2,
+            None,
+            None,
+            true,
+        )
+        .await
+        .expect("compaction");
+        assert!(
+            header_has(&report.output.stats_path, &outer_marshal),
+            "nested UserType column must survive compaction byte-exact"
+        );
+    }
+
+    /// #1023 schema evolution: a bare UDT column ADDED after the inputs were
+    /// written is absent from every input header, so the header gate leaves it
+    /// bare. The engine's configured registry must normalize it (it has no input
+    /// cells to misdecode) so compaction output is not emitted as BytesType.
+    #[tokio::test]
+    async fn newly_added_bare_udt_column_normalized_via_registry() {
+        let registry = person_registry();
+
+        // Input written with an OLDER schema lacking `addr` (only id + note).
+        let older_schema = TableSchema {
+            keyspace: "test_ks".to_string(),
+            table: "test_table".to_string(),
+            partition_keys: vec![KeyColumn {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![],
+            columns: vec![
+                Column {
+                    name: "id".to_string(),
+                    data_type: "int".to_string(),
+                    nullable: false,
+                    default: None,
+                    is_static: false,
+                },
+                Column {
+                    name: "note".to_string(),
+                    data_type: "text".to_string(),
+                    nullable: true,
+                    default: None,
+                    is_static: false,
+                },
+            ],
+            comments: std::collections::HashMap::new(),
+            dropped_columns: std::collections::HashMap::new(),
+        };
+        let in_dir = tempfile::TempDir::new().expect("in dir");
+        let mut writer = crate::storage::sstable::writer::SSTableWriter::with_expected_partitions(
+            in_dir.path().to_path_buf(),
+            1,
+            &older_schema,
+            1,
+        )
+        .expect("writer");
+        let m = Mutation::new(
+            TableId::new("test_ks", "test_table"),
+            PartitionKey::single("id", Value::Integer(1)),
+            None,
+            vec![CellOperation::Write {
+                column: "note".to_string(),
+                value: Value::Text("x".to_string()),
+            }],
+            1_000_000,
+            None,
+        );
+        let k = m.decorated_key(&older_schema).expect("key");
+        writer.write_partition(k, vec![m]).expect("write");
+        let input = writer.finish().await.expect("finish");
+
+        // The NEW schema adds the bare UDT column `addr` (absent from the input).
+        let mut new_schema = bare_udt_schema();
+        // `addr` is absent from the input header, so it is registry-normalized.
+        crate::storage::write_engine::merge::apply_udt_marshals_from_inputs(
+            &mut new_schema,
+            &[input.data_path.clone()],
+            Some(&registry),
+        )
+        .expect("apply");
+        let addr = new_schema
+            .columns
+            .iter()
+            .find(|c| c.name == "addr")
+            .expect("addr column");
+        assert_eq!(
+            addr.data_type, PERSON_USERTYPE,
+            "a UDT column absent from all inputs must be registry-normalized, not left bare"
+        );
+
+        // Without a registry the column stays bare (free-fn / no-registry path).
+        let mut bare_again = bare_udt_schema();
+        crate::storage::write_engine::merge::apply_udt_marshals_from_inputs(
+            &mut bare_again,
+            &[input.data_path.clone()],
+            None,
+        )
+        .expect("apply no-registry");
+        assert_eq!(
+            bare_again
+                .columns
+                .iter()
+                .find(|c| c.name == "addr")
+                .unwrap()
+                .data_type,
+            "person",
+            "without a registry an absent column stays bare"
+        );
+    }
+
+    /// #1025 unknown header state: if an input header cannot be read/parsed, the
+    /// column's true encoding is unknown. The absent-column registry fallback
+    /// MUST NOT fire (it could misdecode an unreadable simple-cell input), so the
+    /// bare column is left bare.
+    #[tokio::test]
+    async fn unreadable_header_does_not_trigger_registry_normalization() {
+        let registry = person_registry();
+
+        // A path whose sibling Statistics.db does not exist -> header unverified.
+        let dir = tempfile::TempDir::new().expect("dir");
+        let bogus = dir.path().join("nb-1-big-Data.db");
+
+        let plan = udt_columns_eligible_for_normalization(&[bogus.clone()]);
+        assert!(
+            !plan.headers_verified,
+            "an unreadable header must leave the plan unverified"
+        );
+
+        let mut schema = bare_udt_schema();
+        crate::storage::write_engine::merge::apply_udt_marshals_from_inputs(
+            &mut schema,
+            &[bogus],
+            Some(&registry),
+        )
+        .expect("apply");
+        assert_eq!(
+            schema
+                .columns
+                .iter()
+                .find(|c| c.name == "addr")
+                .unwrap()
+                .data_type,
+            "person",
+            "with unverified headers, a bare UDT column must NOT be registry-normalized"
         );
     }
 }

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -54,7 +54,7 @@ pub use mutation::{
 pub use wal::WriteAheadLog;
 
 use crate::error::{Error, Result};
-use crate::schema::TableSchema;
+use crate::schema::{TableSchema, UdtRegistry};
 use crate::storage::sstable::writer::SSTableInfo;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -234,6 +234,11 @@ pub struct WriteEngineConfig {
     pub schema: TableSchema,
     /// WAL durability mode (default: [`Durability::SyncEachWrite`])
     pub durability: Durability,
+    /// Optional UDT registry for resolving bare CQL UDT column types to their
+    /// `UserType(...)` marshal form at flush time (issue #929). When `None`
+    /// (the default), a column whose `data_type` is a bare UDT name is written
+    /// as a single simple cell (documented fallback).
+    pub udt_registry: Option<UdtRegistry>,
 }
 
 #[cfg(feature = "write-support")]
@@ -252,7 +257,15 @@ impl WriteEngineConfig {
             memtable_hard_limit: Self::DEFAULT_HARD_LIMIT,
             schema,
             durability: Durability::default(),
+            udt_registry: None,
         }
+    }
+
+    /// Attach a [`UdtRegistry`] used to resolve bare CQL UDT column types at
+    /// flush time (issue #929). See [`WriteEngineConfig::udt_registry`].
+    pub fn with_udt_registry(mut self, registry: UdtRegistry) -> Self {
+        self.udt_registry = Some(registry);
+        self
     }
 
     /// Set a custom flush threshold
@@ -779,12 +792,14 @@ impl WriteEngine {
 
         // Create SSTable writer with hint for Bloom filter sizing
         let partition_count_hint = self.memtable.iter().count();
-        let mut writer = crate::storage::sstable::writer::SSTableWriter::with_expected_partitions(
-            self.config.data_dir.clone(),
-            self.generation,
-            &self.config.schema,
-            partition_count_hint,
-        )?;
+        let mut writer =
+            crate::storage::sstable::writer::SSTableWriter::with_expected_partitions_and_registry(
+                self.config.data_dir.clone(),
+                self.generation,
+                &self.config.schema,
+                partition_count_hint,
+                self.config.udt_registry.as_ref(),
+            )?;
 
         // Two-pass flush (issue #729): compute FINAL encoding baselines from all
         // partitions before writing any data.  Delta encoding in Data.db must use
@@ -1465,8 +1480,25 @@ impl WriteEngine {
         // merger decodes the static cells and the writer emits the static prelude
         // (header-driven static presence). Byte-identical to `config.schema` when
         // no such column exists.
-        let effective_schema =
+        let mut effective_schema =
             merge::effective_compaction_schema(&self.config.schema, &input_paths);
+        // #929: normalize bare-name UDT columns to their UserType(...) marshal on
+        // the EFFECTIVE (decode) schema by copying each column's exact UserType
+        // marshal from the input headers. The compaction reader decides complex-
+        // vs-simple from this schema's `data_type` (is_complex_column), so a bare
+        // name would make it misdecode/drop pre-existing per-field UDT cells
+        // (roborev #1009/#1013/#1015/#1017/#1019/#1021). Derived ENTIRELY from the
+        // input headers, so it runs unconditionally (a registry is needed only at
+        // flush time); errors on a mixed encoding rather than corrupting.
+        // `write_schema` derives from this via `for_compaction_output`. The
+        // configured registry handles a UDT column added after the inputs were
+        // written (absent from every input header) so the output is not emitted
+        // as a bare/BytesType column (roborev #1023).
+        merge::apply_udt_marshals_from_inputs(
+            &mut effective_schema,
+            &input_paths,
+            self.config.udt_registry.as_ref(),
+        )?;
 
         // Create K-way merger.
         //
@@ -1509,6 +1541,8 @@ impl WriteEngine {
                 purge_safe,
             )?
         };
+        // `write_schema` inherits the #929 UDT normalization from the already-
+        // normalized `effective_schema` (for_compaction_output clones columns).
         let write_schema = effective_schema.for_compaction_output(&retained_dropped);
 
         let merger = KWayMerger::new_with_gc(


### PR DESCRIPTION
Closes #929. Follow-up from #927 / PR #928.

## Problem
A **direct user write** to a column whose `data_type` is a *bare* CQL UDT name (e.g. `addr person`) was not detected as complex and was incorrectly written as a single simple cell — the writer holds only a `&TableSchema` and could not resolve a bare name to its fields. (PR #928 covered the marshal-string path used by compaction.)

## Approach
- Plumb an optional `UdtRegistry` from `WriteEngineConfig` through `SSTableWriter`. At **flush** time, `normalize_schema_udts` resolves a top-level bare UDT name to its full `UserType(...)` marshal so the existing #927/#928 complex-cell path decomposes it into per-field cells unchanged.
- `cql_type_to_marshal_type` now passes through already-marshaled strings verbatim, so the Statistics.db serialization header advertises `UserType(...)` (not `BytesType`) for a normalized column.
- **Compaction**: copies each column's exact `UserType(...)` marshal from the input SSTable headers onto the decode schema (handles nested UDTs byte-exact), with header-state gating:
  - simple-cell inputs are not misdecoded;
  - a column absent from all inputs (schema evolution) is registry-normalized;
  - mixed/divergent encodings across inputs **fail** the compaction rather than corrupt;
  - unverified (unreadable) headers never trigger registry normalization.
- CLI write & compact paths build a `UdtRegistry` from the schema file's `CREATE TYPE` statements; the compact path now parses multi-statement CQL files robustly.

## Scope / known limitation
Top-level bare names whose fields are primitives / collections-of-primitives are normalized at flush. A UDT with a **nested UDT field** is intentionally NOT normalized at flush (the direct-write value path cannot yet serialize a sparse/out-of-order nested literal in declared order); compaction still preserves such columns byte-exact from the input header.

## Tests
- Marshal renderer round-trip; resolution scope (primitive-collision guard, case-insensitive, nested-skip).
- Direct-write bare-name UDT round-trip (sparse/out-of-order); registry-absent fallback.
- Serialization-header `UserType` assertion.
- Compaction: survival, simple-cell safety, schema-evolution (absent column), mixed-encoding failure, nested-UserType byte-exact survival, unreadable-header safety.
- CLI: registry-from-schema-file, multi-statement CQL loader.

## Validation
- `roborev`: **Pass — no issues found**.
- `rust-reviewer`: no blockers.
- agent-gate: all substantive stages PASS; only pre-existing knowns fail (python-bindings PEP604/py3.9, `test_flush_throughput` timing flake — passes isolated).