### PR TITLE
feat(compaction): apply range tombstones end-to-end (#933)

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/compaction_row.rs
+++ b/cqlite-core/src/storage/sstable/reader/compaction_row.rs
@@ -118,9 +118,49 @@ impl CompactionRow {
     }
 }
 
+/// A clustering bound of a range-tombstone marker surfaced on the compaction
+/// read path (issue #933).
+///
+/// Reader-native counterpart of
+/// [`crate::storage::write_engine::mutation::ClusteringBound`]; kept here so the
+/// compaction read contract does not depend on the write-engine types. Each
+/// bound carries its clustering-prefix `(name, value)` pairs (possibly a PREFIX
+/// shorter than the full clustering arity). An open bound (the writer emits these
+/// as an inclusive bound with zero clustering values) is [`Self::Bottom`] /
+/// [`Self::Top`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum CompactionBound {
+    /// Inclusive bound (the clustering prefix is part of the deletion range).
+    Inclusive(Vec<(String, Value)>),
+    /// Exclusive bound (the clustering prefix is NOT part of the deletion range).
+    Exclusive(Vec<(String, Value)>),
+    /// Before all clustering keys (start of partition).
+    Bottom,
+    /// After all clustering keys (end of partition).
+    Top,
+}
+
 /// Live-or-tombstone payload of a [`CompactionRow`].
 #[derive(Debug, Clone, PartialEq)]
 pub enum CompactionRowData {
+    /// A complete range tombstone (issue #933): the paired start + end bounds of
+    /// a clustering-range delete, with the authoritative deletion timestamps.
+    ///
+    /// The reader pairs the on-disk start/end bound markers (or boundary markers)
+    /// into one self-contained range so the compaction merge can shadow covered
+    /// cells AND re-emit the surviving marker to the output SSTable. `deletion_time`
+    /// is `markedForDeleteAt` (microseconds); `local_deletion_time` is the GC-grace
+    /// clock (seconds, carried as the wrapping `as u32 as i32` for far-future LDTs).
+    RangeMarker {
+        /// Start bound of the deleted clustering range.
+        start: CompactionBound,
+        /// End bound of the deleted clustering range.
+        end: CompactionBound,
+        /// `markedForDeleteAt` in microseconds.
+        deletion_time: i64,
+        /// `localDeletionTime` in seconds (GC-grace clock).
+        local_deletion_time: i32,
+    },
     /// Row tombstone (whole-row delete) carrying its authoritative timestamps.
     Tombstone {
         /// `markedForDeleteAt` in microseconds.

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
@@ -3172,130 +3172,17 @@ impl V5CompressedLegacyParser {
         offset: usize,
         schema: &TableSchema,
     ) -> Result<(Vec<Value>, u8, i64, Option<i64>, usize)> {
-        let mut pos = offset;
-
-        if pos >= data.len() {
-            return Err(Error::corruption(
-                "V5CompressedLegacy: Unexpected end at range tombstone marker (full parse)",
-            ));
-        }
-
-        let marker_flags = data[pos];
-        pos += 1;
-
-        // Extended flags if present
-        if (marker_flags & ROW_HAS_EXTENDED_FLAGS) != 0 {
-            if pos >= data.len() {
-                return Err(Error::corruption(
-                    "V5CompressedLegacy: Unexpected end reading marker extended flags (full)",
-                ));
-            }
-            pos += 1;
-        }
-
-        // Bound kind byte.
-        if pos >= data.len() {
-            return Err(Error::corruption(
-                "V5CompressedLegacy: Unexpected end reading range tombstone bound kind (full)",
-            ));
-        }
-        let bound_kind = data[pos];
-        pos += 1;
-
-        // Cluster count (u16 big-endian).
-        if pos + 2 > data.len() {
-            return Err(Error::corruption(
-                "V5CompressedLegacy: Unexpected end reading range tombstone cluster count (full)",
-            ));
-        }
-        let cluster_count = u16::from_be_bytes([data[pos], data[pos + 1]]) as usize;
-        pos += 2;
-
-        // Clustering values.
-        // Build a truncated schema slice for parsing only `cluster_count` clustering
-        // columns.  Range tombstone bounds may be **prefix** bounds: the Cassandra
-        // serializer writes `cluster_count` < full-arity when a `DELETE WHERE pk=?
-        // AND ck1=?` targets all sub-rows for a given ck1 without specifying ck2.
-        //
-        // If we let `parse_clustering_prefix` iterate over the full schema, it would
-        // read past the `cluster_count` bytes into the marker body (producing garbage
-        // or invalid UTF-8 errors).  Instead we pass a synthetic schema whose
-        // `clustering_keys` vec is truncated to `cluster_count`.
-        let bound_values = if cluster_count > 0 {
-            let prefix_schema_owned = Self::clustering_prefix_schema(schema, cluster_count);
-            let effective_schema = prefix_schema_owned.as_ref().unwrap_or(schema);
-            let (values, new_pos) = self.parse_clustering_prefix(data, pos, effective_schema)?;
-            pos = new_pos;
-            values
-        } else {
-            Vec::new()
-        };
-
-        // marker_body_size VUInt — size of (prev_size VUInt + deletion_time(s)).
-        let (remaining, marker_body_size) = parse_vuint(&data[pos..]).map_err(|e| {
-            Error::corruption(format!(
-                "V5CompressedLegacy: Failed to parse marker_body_size (full) at offset {}: {:?}",
-                pos, e
-            ))
-        })?;
-        let body_size_vint_len = data[pos..].len() - remaining.len();
-        pos += body_size_vint_len;
-
-        let body_start = pos;
-        let body_end = pos + marker_body_size as usize;
-        if body_end > data.len() {
-            return Err(Error::corruption(format!(
-                "V5CompressedLegacy: marker_body_size={} at pos={} exceeds data length {} (full)",
-                marker_body_size,
-                pos,
-                data.len()
-            )));
-        }
-
-        // Inside the body:
-        //   [prev_unfiltered_size: VUInt]    ← skip
-        //   [markedForDeleteAt delta: VUInt]  ← delta from min_timestamp (µs)
-        //   [localDeletionTime delta: VUInt]  ← delta from min_local_deletion_time (s), skip
-        //   (repeat for second deletion time if boundary marker)
-        let (remaining2, _prev_size) = parse_vuint(&data[pos..]).map_err(|e| {
-            Error::corruption(format!(
-                "V5CompressedLegacy: Failed to parse prev_size in marker body at {}: {:?}",
-                pos, e
-            ))
-        })?;
-        pos += data[pos..].len() - remaining2.len();
-
-        // Primary deletion time.
-        let deleted_at_primary = self.parse_deletion_time_pair(data, &mut pos)?;
-
-        // Boundary markers (kind 2 = EXCL_END_INCL_START, kind 5 = INCL_END_EXCL_START)
-        // carry a second deletion time for the adjacent range.
-        let deleted_at_secondary = if bound_kind == 2 || bound_kind == 5 {
-            Some(self.parse_deletion_time_pair(data, &mut pos)?)
-        } else {
-            None
-        };
-
-        // Advance to end of body (in case the secondary parse left pos short).
-        let _ = body_start; // acknowledged
-        pos = body_end;
-
-        log::debug!(
-            "V5CompressedLegacy: Parsed range tombstone marker full: kind={} values={} \
-             deleted_at_primary={} deleted_at_secondary={:?} next_offset={}",
-            bound_kind,
-            bound_values.len(),
-            deleted_at_primary,
-            deleted_at_secondary,
-            pos
-        );
-
+        // Delegate to the LDT-carrying parser and drop the localDeletionTime
+        // fields the delta-scan caller does not need — the on-disk marker grammar
+        // is decoded in exactly one place (issue #933 cleanup).
+        let (bound_values, bound_kind, (mfda_primary, _ldt_primary), secondary, next_offset) =
+            self.parse_range_tombstone_marker_with_ldt(data, offset, schema)?;
         Ok((
             bound_values,
             bound_kind,
-            deleted_at_primary,
-            deleted_at_secondary,
-            pos,
+            mfda_primary,
+            secondary.map(|(mfda, _ldt)| mfda),
+            next_offset,
         ))
     }
 
@@ -3325,40 +3212,11 @@ impl V5CompressedLegacyParser {
         }
     }
 
-    /// Decode one `(markedForDeleteAt delta, localDeletionTime delta)` pair from `data[*pos..]`.
-    ///
-    /// Both fields are unsigned VInts.  `markedForDeleteAt` is a delta from `min_timestamp`
-    /// (µs); `localDeletionTime` is a delta from `min_local_deletion_time` (s) and is
-    /// consumed but not returned (callers do not need the GC-clock value).
-    ///
-    /// Advances `*pos` past both fields and returns the absolute `markedForDeleteAt` in µs.
-    fn parse_deletion_time_pair(&self, data: &[u8], pos: &mut usize) -> Result<i64> {
-        // markedForDeleteAt delta (unsigned VInt, µs since epoch delta).
-        let (remaining, mfda_delta) = parse_vuint(&data[*pos..]).map_err(|e| {
-            Error::corruption(format!(
-                "V5CompressedLegacy: Failed to parse markedForDeleteAt in marker body at {}: {:?}",
-                *pos, e
-            ))
-        })?;
-        *pos += data[*pos..].len() - remaining.len();
-        let absolute_mfda = self.min_timestamp.wrapping_add(mfda_delta as i64);
-
-        // localDeletionTime delta (unsigned VInt, seconds delta) — consume, do not return.
-        let (remaining2, _ldt_delta) = parse_vuint(&data[*pos..]).map_err(|e| {
-            Error::corruption(format!(
-                "V5CompressedLegacy: Failed to parse localDeletionTime in marker body at {}: {:?}",
-                *pos, e
-            ))
-        })?;
-        *pos += data[*pos..].len() - remaining2.len();
-
-        Ok(absolute_mfda)
-    }
-
     /// Decode one `(markedForDeleteAt, localDeletionTime)` pair, returning BOTH
     /// absolute values (issue #933 compaction range-tombstone surfacing).
     ///
-    /// Like [`Self::parse_deletion_time_pair`] but also returns the absolute
+    /// Decodes the `(markedForDeleteAt delta, localDeletionTime delta)` VInt pair
+    /// and returns BOTH absolute values — the absolute
     /// `localDeletionTime` (GC-grace clock, seconds) so the compaction merger can
     /// retain/purge a surviving range marker by gc_grace AND the writer can
     /// re-emit the marker's LDT verbatim. The LDT is decoded with the same

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
@@ -2182,6 +2182,54 @@ impl V5CompressedLegacyParser {
         let mut static_cells: HashMap<String, Value> = HashMap::new();
         let mut pending: Vec<CompactionRow> = Vec::new();
 
+        // In-flight range tombstone start bound (issue #933). A range tombstone is
+        // a pair of adjacent bound markers (start then end), or a sequence of
+        // boundary markers that close one range and open the next. We buffer the
+        // open start here and emit a complete `CompactionRowData::RangeMarker` when
+        // the matching end/boundary arrives. Local to this call so it is re-derived
+        // from the partition start on every sliding-window re-parse (the `pending`
+        // rows are only flushed on a clean `Emitted`).
+        //
+        // Tuple: (start bound, deletion_time µs, local_deletion_time s).
+        let mut pending_range_start: Option<(
+            crate::storage::sstable::reader::compaction_row::CompactionBound,
+            i64,
+            i32,
+        )> = None;
+
+        // Build a `CompactionBound` from decoded clustering prefix values. The
+        // writer emits an OPEN bound (Bottom/Top) as an inclusive bound with zero
+        // clustering values, so an empty prefix decodes to Bottom (start) / Top
+        // (end). A non-empty prefix pairs each value with its schema clustering
+        // column name (positionally; bounds may be PREFIX-length).
+        let make_bound = |values: Vec<Value>, inclusive: bool, is_start: bool| {
+            use crate::storage::sstable::reader::compaction_row::CompactionBound;
+            if values.is_empty() {
+                return if is_start {
+                    CompactionBound::Bottom
+                } else {
+                    CompactionBound::Top
+                };
+            }
+            let pairs: Vec<(String, Value)> = values
+                .into_iter()
+                .enumerate()
+                .map(|(i, v)| {
+                    let name = schema
+                        .clustering_keys
+                        .get(i)
+                        .map(|c| c.name.clone())
+                        .unwrap_or_else(|| format!("ck{i}"));
+                    (name, v)
+                })
+                .collect();
+            if inclusive {
+                CompactionBound::Inclusive(pairs)
+            } else {
+                CompactionBound::Exclusive(pairs)
+            }
+        };
+
         macro_rules! flush_and_emitted {
             ($consumed:expr, $pending:expr, $emit:expr) => {{
                 for row in $pending.drain(..) {
@@ -2208,18 +2256,82 @@ impl V5CompressedLegacyParser {
             }
 
             if Self::is_range_tombstone_marker(data[offset]) {
-                match self.skip_range_tombstone_marker(data, offset, schema) {
-                    Ok(next_offset) => {
-                        offset = next_offset;
-                        continue;
-                    }
-                    Err(_) => {
-                        if at_final_chunk {
-                            return flush_and_emitted!(offset, pending, emit);
+                // Issue #933: parse the range-tombstone bound marker and pair it
+                // into a complete `RangeMarker` so the merge can shadow covered
+                // cells AND re-emit the surviving marker (previously SKIPPED, which
+                // dropped the tombstone entirely).
+                let (bound_values, bound_kind, (mfda_p, ldt_p), secondary, next_offset) =
+                    match self.parse_range_tombstone_marker_with_ldt(data, offset, schema) {
+                        Ok(v) => v,
+                        Err(_) => {
+                            // Truncated marker body at a chunk boundary (or corrupt
+                            // at the final chunk): request more / flush, exactly as
+                            // the prior skip path did.
+                            if at_final_chunk {
+                                return flush_and_emitted!(offset, pending, emit);
+                            }
+                            return Ok(ParseStep::NeedMore);
                         }
-                        return Ok(ParseStep::NeedMore);
+                    };
+                offset = next_offset;
+
+                use crate::storage::sstable::reader::compaction_row::{
+                    CompactionBound, CompactionRowData,
+                };
+
+                // Emit a complete range tombstone given a (start, deletion) and an
+                // end bound + the end's deletion time/ldt.
+                let mut emit_range =
+                    |start: CompactionBound, end: CompactionBound, dt: i64, ldt: i32| {
+                        pending.push(CompactionRow {
+                            key: partition_key.clone(),
+                            row_timestamp: dt,
+                            row_data: CompactionRowData::RangeMarker {
+                                start,
+                                end,
+                                deletion_time: dt,
+                                local_deletion_time: ldt,
+                            },
+                        });
+                    };
+
+                // ClusteringPrefix.Kind ordinals:
+                //   0 EXCL_END, 1 INCL_START, 2 EXCL_END_INCL_START_BOUNDARY,
+                //   5 INCL_END_EXCL_START_BOUNDARY, 6 INCL_END, 7 EXCL_START.
+                match bound_kind {
+                    1 | 7 => {
+                        // Simple start bound: buffer until the matching end.
+                        let start = make_bound(bound_values, bound_kind == 1, true);
+                        pending_range_start = Some((start, mfda_p, ldt_p));
+                    }
+                    0 | 6 => {
+                        // Simple end bound: close the buffered start.
+                        let end = make_bound(bound_values, bound_kind == 6, false);
+                        let start = pending_range_start
+                            .take()
+                            .map(|(s, _, _)| s)
+                            .unwrap_or(CompactionBound::Bottom);
+                        emit_range(start, end, mfda_p, ldt_p);
+                    }
+                    2 | 5 => {
+                        // Boundary marker: primary closes the previous range, the
+                        // secondary opens the next. kind 2 = EXCL_END + INCL_START,
+                        // kind 5 = INCL_END + EXCL_START.
+                        let end_inclusive = bound_kind == 5;
+                        if let Some((start, _, _)) = pending_range_start.take() {
+                            let end = make_bound(bound_values.clone(), end_inclusive, false);
+                            emit_range(start, end, mfda_p, ldt_p);
+                        }
+                        let (new_mfda, new_ldt) = secondary.unwrap_or((mfda_p, ldt_p));
+                        let new_start = make_bound(bound_values, bound_kind == 2, true);
+                        pending_range_start = Some((new_start, new_mfda, new_ldt));
+                    }
+                    _ => {
+                        // Unknown bound kind: skip it rather than mis-parse the
+                        // partition (the offset already advanced past the marker).
                     }
                 }
+                continue;
             }
 
             // Compaction mode: capture per-column complex elements and request
@@ -3241,6 +3353,162 @@ impl V5CompressedLegacyParser {
         *pos += data[*pos..].len() - remaining2.len();
 
         Ok(absolute_mfda)
+    }
+
+    /// Decode one `(markedForDeleteAt, localDeletionTime)` pair, returning BOTH
+    /// absolute values (issue #933 compaction range-tombstone surfacing).
+    ///
+    /// Like [`Self::parse_deletion_time_pair`] but also returns the absolute
+    /// `localDeletionTime` (GC-grace clock, seconds) so the compaction merger can
+    /// retain/purge a surviving range marker by gc_grace AND the writer can
+    /// re-emit the marker's LDT verbatim. The LDT is decoded with the same
+    /// `hasUIntDeletionTime` reinterpretation as the row-level deletion reader
+    /// (`min_local_deletion_time + delta`, then `as u32 as i32` for far-future
+    /// values) so a year-2106 LDT round-trips bit-for-bit (#853/#889).
+    ///
+    /// Advances `*pos` past both fields.
+    fn parse_deletion_time_pair_with_ldt(
+        &self,
+        data: &[u8],
+        pos: &mut usize,
+    ) -> Result<(i64, i32)> {
+        // markedForDeleteAt delta (unsigned VInt, µs since epoch delta).
+        let (remaining, mfda_delta) = parse_vuint(&data[*pos..]).map_err(|e| {
+            Error::corruption(format!(
+                "V5CompressedLegacy: Failed to parse markedForDeleteAt in marker body at {}: {:?}",
+                *pos, e
+            ))
+        })?;
+        *pos += data[*pos..].len() - remaining.len();
+        let absolute_mfda = self.min_timestamp.wrapping_add(mfda_delta as i64);
+
+        // localDeletionTime delta (unsigned VInt, seconds delta).
+        let (remaining2, ldt_delta) = parse_vuint(&data[*pos..]).map_err(|e| {
+            Error::corruption(format!(
+                "V5CompressedLegacy: Failed to parse localDeletionTime in marker body at {}: {:?}",
+                *pos, e
+            ))
+        })?;
+        *pos += data[*pos..].len() - remaining2.len();
+
+        let has_uint_ldt = match self.version_gates.as_ref() {
+            crate::storage::sstable::version_gate::VersionGates::Big(g) => g.has_uint_deletion_time,
+            crate::storage::sstable::version_gate::VersionGates::Bti(g) => g.has_uint_deletion_time,
+        };
+        let raw_ldt = self.min_local_deletion_time.wrapping_add(ldt_delta as i64);
+        let absolute_ldt = if has_uint_ldt {
+            (raw_ldt as u32) as i32
+        } else {
+            raw_ldt as i32
+        };
+
+        Ok((absolute_mfda, absolute_ldt))
+    }
+
+    /// Parse a range-tombstone bound marker in full, returning the decoded bound
+    /// values, kind, AND the primary/secondary `(markedForDeleteAt, localDeletionTime)`
+    /// pairs (issue #933).
+    ///
+    /// This is the compaction counterpart of [`Self::parse_range_tombstone_marker_full`]:
+    /// it additionally surfaces the `localDeletionTime` of each deletion so the
+    /// compaction path can re-emit / gc_grace-purge the marker faithfully.
+    ///
+    /// Returns `(bound_values, bound_kind, (mfda_primary, ldt_primary),
+    /// Option<(mfda_secondary, ldt_secondary)>, next_offset)`.
+    #[allow(clippy::type_complexity)]
+    fn parse_range_tombstone_marker_with_ldt(
+        &self,
+        data: &[u8],
+        offset: usize,
+        schema: &TableSchema,
+    ) -> Result<(Vec<Value>, u8, (i64, i32), Option<(i64, i32)>, usize)> {
+        let mut pos = offset;
+
+        if pos >= data.len() {
+            return Err(Error::corruption(
+                "V5CompressedLegacy: Unexpected end at range tombstone marker (compaction)",
+            ));
+        }
+
+        let marker_flags = data[pos];
+        pos += 1;
+
+        if (marker_flags & ROW_HAS_EXTENDED_FLAGS) != 0 {
+            if pos >= data.len() {
+                return Err(Error::corruption(
+                    "V5CompressedLegacy: Unexpected end reading marker extended flags (compaction)",
+                ));
+            }
+            pos += 1;
+        }
+
+        // Bound kind byte.
+        if pos >= data.len() {
+            return Err(Error::corruption(
+                "V5CompressedLegacy: Unexpected end reading range tombstone bound kind (compaction)",
+            ));
+        }
+        let bound_kind = data[pos];
+        pos += 1;
+
+        // Cluster count (u16 big-endian).
+        if pos + 2 > data.len() {
+            return Err(Error::corruption(
+                "V5CompressedLegacy: Unexpected end reading range tombstone cluster count (compaction)",
+            ));
+        }
+        let cluster_count = u16::from_be_bytes([data[pos], data[pos + 1]]) as usize;
+        pos += 2;
+
+        // Clustering values (may be a PREFIX shorter than the full arity).
+        let bound_values = if cluster_count > 0 {
+            let prefix_schema_owned = Self::clustering_prefix_schema(schema, cluster_count);
+            let effective_schema = prefix_schema_owned.as_ref().unwrap_or(schema);
+            let (values, new_pos) = self.parse_clustering_prefix(data, pos, effective_schema)?;
+            pos = new_pos;
+            values
+        } else {
+            Vec::new()
+        };
+
+        // marker_body_size VUInt — size of (prev_size VUInt + deletion_time(s)).
+        let (remaining, marker_body_size) = parse_vuint(&data[pos..]).map_err(|e| {
+            Error::corruption(format!(
+                "V5CompressedLegacy: Failed to parse marker_body_size (compaction) at offset {}: {:?}",
+                pos, e
+            ))
+        })?;
+        pos += data[pos..].len() - remaining.len();
+
+        let body_end = pos + marker_body_size as usize;
+        if body_end > data.len() {
+            return Err(Error::corruption(format!(
+                "V5CompressedLegacy: marker_body_size={} at pos={} exceeds data length {} (compaction)",
+                marker_body_size,
+                pos,
+                data.len()
+            )));
+        }
+
+        // prev_unfiltered_size VUInt — skip.
+        let (remaining2, _prev_size) = parse_vuint(&data[pos..]).map_err(|e| {
+            Error::corruption(format!(
+                "V5CompressedLegacy: Failed to parse prev_size in marker body (compaction) at {}: {:?}",
+                pos, e
+            ))
+        })?;
+        pos += data[pos..].len() - remaining2.len();
+
+        let primary = self.parse_deletion_time_pair_with_ldt(data, &mut pos)?;
+        let secondary = if bound_kind == 2 || bound_kind == 5 {
+            Some(self.parse_deletion_time_pair_with_ldt(data, &mut pos)?)
+        } else {
+            None
+        };
+
+        pos = body_end;
+
+        Ok((bound_values, bound_kind, primary, secondary, pos))
     }
 
     /// Parse clustering prefix section (between row header and cells)

--- a/cqlite-core/src/storage/write_engine/merge.rs
+++ b/cqlite-core/src/storage/write_engine/merge.rs
@@ -401,6 +401,43 @@ pub struct ComplexDeletion {
     pub local_deletion_time: i32,
 }
 
+/// A cut position on the clustering axis, used to coalesce range tombstones
+/// into a NON-OVERLAPPING canonical sequence (issue #933 / roborev #959 High
+/// #1).
+///
+/// The writer emits each [`RangeTombstone`] as an INDEPENDENT open/close marker
+/// pair, sorted by clustering position; the reader pairs markers using a single
+/// `pending_range_start`. Overlapping or nested ranges with different bounds
+/// would therefore mis-pair on read-back (e.g. `start[1,5] start[2,3] end[2,3]
+/// end[1,5]` resurfaces as `[2,3]` and `[Bottom,5]`), corrupting the persisted
+/// deletion ranges. Coalescing the cross-SSTable union into disjoint ranges
+/// before re-emission mirrors Cassandra's `RangeTombstoneList` invariant
+/// (on-disk range tombstones within a partition never overlap).
+///
+/// A range `[start, end]` is modelled as a closed interval over these cut
+/// positions. [`Self::At`] is the infinitesimal point just before (`after =
+/// false`) or just after (`after = true`) a clustering prefix; an open bound is
+/// [`Self::Bottom`] / [`Self::Top`]. The `after` flag at a SHORTER prefix sorts
+/// relative to all longer extensions (Cassandra's kind-weighted prefix
+/// ordering), so a prefix end bound `[ck1]` correctly covers every `[ck1, *]`.
+#[cfg(feature = "write-support")]
+#[derive(Clone)]
+enum RangeCut {
+    /// Before all clustering keys (start of partition).
+    Bottom,
+    /// Infinitesimally before (`after == false`) or after (`after == true`) the
+    /// clustering prefix.
+    At {
+        /// Clustering prefix (possibly shorter than the full arity).
+        key: ClusteringKey,
+        /// `false` = just before the prefix and all its extensions; `true` =
+        /// just after them.
+        after: bool,
+    },
+    /// After all clustering keys (end of partition).
+    Top,
+}
+
 /// Result of a merge step (incremental merge)
 #[cfg(feature = "write-support")]
 #[derive(Debug)]
@@ -2389,11 +2426,13 @@ impl KWayMerger {
                 .push(row);
         }
 
-        // Canonicalize: a range tombstone with IDENTICAL bounds appearing in
-        // multiple inputs collapses to the one with the greatest deletion time
-        // (Cassandra reconciles overlapping range deletions to the newest). Ranges
-        // with different bounds are all kept.
-        Self::canonicalize_range_tombstones(&mut range_tombstones);
+        // Coalesce the cross-SSTable union into a NON-OVERLAPPING canonical
+        // sequence per partition (newest deletion wins per covered segment). The
+        // writer emits each range as an independent open/close marker pair and the
+        // reader pairs them with a single pending-start, so overlapping re-emitted
+        // ranges would corrupt the persisted ranges on read-back (roborev #959
+        // High #1). This also subsumes the old identical-bounds dedup.
+        Self::coalesce_range_tombstones(&mut range_tombstones, &self.schema);
 
         let mut merged = Vec::new();
         for (ck, cluster_rows) in clustered_rows {
@@ -2474,30 +2513,235 @@ impl KWayMerger {
             && matches!(&entry.row_data, RowData::Live { cells } if cells.is_empty())
     }
 
-    /// Collapse range tombstones with IDENTICAL bounds to the one with the
-    /// greatest deletion time (Cassandra reconciles overlapping range deletions to
-    /// the newest), de-duplicating exact repeats across inputs (issue #933).
-    /// Ranges with different bounds are all retained.
-    fn canonicalize_range_tombstones(rts: &mut Vec<(DecoratedKey, RangeTombstone)>) {
-        // Group by (key bytes, start, end); keep the max (deletion_time, ldt).
-        // `ClusteringBound` derives `PartialEq`, so bounds compare with `==`.
-        let mut out: Vec<(DecoratedKey, RangeTombstone)> = Vec::new();
-        'outer: for (key, rt) in rts.drain(..) {
-            for (existing_key, existing) in out.iter_mut() {
-                let same_bounds = existing_key.key == key.key
-                    && existing.start == rt.start
-                    && existing.end == rt.end;
-                if same_bounds {
-                    if rt.deletion_time > existing.deletion_time {
-                        existing.deletion_time = rt.deletion_time;
-                        existing.local_deletion_time = rt.local_deletion_time;
-                    }
-                    continue 'outer;
-                }
+    /// Coalesce range tombstones into a NON-OVERLAPPING canonical sequence per
+    /// partition, the winning (newest) deletion time per covered segment (issue
+    /// #933 / roborev #959 High #1).
+    ///
+    /// Each input SSTable's range tombstones are individually non-overlapping
+    /// (Cassandra's `RangeTombstoneList` invariant), but the cross-SSTable union
+    /// gathered during compaction can overlap with different bounds. The writer
+    /// emits each retained range as an independent open/close marker pair and the
+    /// reader pairs them with a single `pending_range_start`, so OVERLAPPING
+    /// re-emitted ranges would mis-pair on read-back and corrupt the persisted
+    /// ranges. Splitting the union into disjoint segments (each carrying the max
+    /// `markedForDeleteAt` covering it) keeps the on-disk markers a clean
+    /// alternating open/close sequence. This also subsumes the prior
+    /// identical-bounds dedup.
+    fn coalesce_range_tombstones(
+        rts: &mut Vec<(DecoratedKey, RangeTombstone)>,
+        schema: &TableSchema,
+    ) {
+        // Group by partition-key bytes, preserving the first-seen DecoratedKey as
+        // the representative for each group (token + raw bytes are identical
+        // across the group).
+        let mut groups: Vec<(DecoratedKey, Vec<RangeTombstone>)> = Vec::new();
+        for (key, rt) in rts.drain(..) {
+            if let Some((_, ranges)) = groups.iter_mut().find(|(k, _)| k.key == key.key) {
+                ranges.push(rt);
+            } else {
+                groups.push((key, vec![rt]));
             }
-            out.push((key, rt));
+        }
+
+        let mut out: Vec<(DecoratedKey, RangeTombstone)> = Vec::new();
+        for (key, ranges) in groups {
+            for rt in Self::coalesce_partition_range_tombstones(ranges, schema) {
+                out.push((key.clone(), rt));
+            }
         }
         *rts = out;
+    }
+
+    /// Coalesce the range tombstones of a SINGLE partition into a disjoint,
+    /// clustering-sorted sequence (helper for [`Self::coalesce_range_tombstones`]).
+    fn coalesce_partition_range_tombstones(
+        ranges: Vec<RangeTombstone>,
+        schema: &TableSchema,
+    ) -> Vec<RangeTombstone> {
+        if ranges.len() <= 1 {
+            return ranges;
+        }
+
+        // Model each range as a closed interval [start_cut, end_cut] with its
+        // (mfda, ldt).
+        let items: Vec<(RangeCut, RangeCut, i64, i32)> = ranges
+            .iter()
+            .map(|rt| {
+                (
+                    Self::range_start_cut(&rt.start),
+                    Self::range_end_cut(&rt.end),
+                    rt.deletion_time,
+                    rt.local_deletion_time,
+                )
+            })
+            .collect();
+
+        // Distinct, sorted cut positions (the candidate segment boundaries).
+        let mut cuts: Vec<RangeCut> = Vec::with_capacity(items.len() * 2);
+        for (s, e, _, _) in &items {
+            cuts.push(s.clone());
+            cuts.push(e.clone());
+        }
+        cuts.sort_by(|a, b| Self::cut_cmp(a, b, schema));
+        cuts.dedup_by(|a, b| Self::cut_cmp(a, b, schema) == Ordering::Equal);
+
+        // For each elementary gap (cuts[i], cuts[i+1]), the winning deletion is
+        // the max `markedForDeleteAt` among ranges whose closed interval fully
+        // contains the gap (start <= lo AND hi <= end).
+        let mut segs: Vec<(RangeCut, RangeCut, i64, i32)> = Vec::new();
+        for window in cuts.windows(2) {
+            let (lo, hi) = (&window[0], &window[1]);
+            let mut best: Option<(i64, i32)> = None;
+            for (s, e, mfda, ldt) in &items {
+                let covers = Self::cut_cmp(s, lo, schema) != Ordering::Greater
+                    && Self::cut_cmp(hi, e, schema) != Ordering::Greater;
+                if !covers {
+                    continue;
+                }
+                best = Some(match best {
+                    Some((bm, bl)) if bm > *mfda || (bm == *mfda && bl >= *ldt) => (bm, bl),
+                    _ => (*mfda, *ldt),
+                });
+            }
+            if let Some((mfda, ldt)) = best {
+                segs.push((lo.clone(), hi.clone(), mfda, ldt));
+            }
+        }
+
+        // Merge adjacent segments that share a boundary AND the same deletion
+        // (minimal fragmentation); a gap with no covering range breaks the run.
+        let mut merged: Vec<(RangeCut, RangeCut, i64, i32)> = Vec::new();
+        for seg in segs {
+            if let Some(last) = merged.last_mut() {
+                if last.2 == seg.2
+                    && last.3 == seg.3
+                    && Self::cut_cmp(&last.1, &seg.0, schema) == Ordering::Equal
+                {
+                    last.1 = seg.1;
+                    continue;
+                }
+            }
+            merged.push(seg);
+        }
+
+        merged
+            .into_iter()
+            .map(|(lo, hi, mfda, ldt)| RangeTombstone {
+                start: Self::cut_to_start_bound(lo),
+                end: Self::cut_to_end_bound(hi),
+                deletion_time: mfda,
+                local_deletion_time: ldt,
+            })
+            .collect()
+    }
+
+    /// Total order of two cut positions on the clustering axis (schema-aware,
+    /// honoring per-column ASC/DESC and Cassandra's kind-weighted prefix
+    /// ordering). See [`RangeCut`].
+    fn cut_cmp(a: &RangeCut, b: &RangeCut, schema: &TableSchema) -> Ordering {
+        match (a, b) {
+            (RangeCut::Bottom, RangeCut::Bottom) => Ordering::Equal,
+            (RangeCut::Bottom, _) => Ordering::Less,
+            (_, RangeCut::Bottom) => Ordering::Greater,
+            (RangeCut::Top, RangeCut::Top) => Ordering::Equal,
+            (RangeCut::Top, _) => Ordering::Greater,
+            (_, RangeCut::Top) => Ordering::Less,
+            (RangeCut::At { key: ka, after: aa }, RangeCut::At { key: kb, after: ab }) => {
+                // Compare the common prefix only; a shorter prefix's `after` flag
+                // decides its position relative to every longer extension.
+                let l = ka.columns.len().min(kb.columns.len());
+                let ta = ClusteringKey {
+                    columns: ka.columns[..l].to_vec(),
+                };
+                let tb = ClusteringKey {
+                    columns: kb.columns[..l].to_vec(),
+                };
+                let ord = ta.compare(&tb, schema).unwrap_or_else(|_| ta.cmp(&tb));
+                if ord != Ordering::Equal {
+                    return ord;
+                }
+                match ka.columns.len().cmp(&kb.columns.len()) {
+                    Ordering::Equal => aa.cmp(ab),
+                    // `a` is the shorter prefix: just-after sorts past every
+                    // extension of it, just-before sorts ahead of all of them.
+                    Ordering::Less => {
+                        if *aa {
+                            Ordering::Greater
+                        } else {
+                            Ordering::Less
+                        }
+                    }
+                    // `b` is the shorter prefix (mirror image).
+                    Ordering::Greater => {
+                        if *ab {
+                            Ordering::Less
+                        } else {
+                            Ordering::Greater
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Left edge (cut) of a range's start bound.
+    fn range_start_cut(
+        bound: &crate::storage::write_engine::mutation::ClusteringBound,
+    ) -> RangeCut {
+        use crate::storage::write_engine::mutation::ClusteringBound;
+        match bound {
+            ClusteringBound::Inclusive(ck) => RangeCut::At {
+                key: ck.clone(),
+                after: false,
+            },
+            ClusteringBound::Exclusive(ck) => RangeCut::At {
+                key: ck.clone(),
+                after: true,
+            },
+            ClusteringBound::Bottom => RangeCut::Bottom,
+            ClusteringBound::Top => RangeCut::Top,
+        }
+    }
+
+    /// Right edge (cut) of a range's end bound.
+    fn range_end_cut(bound: &crate::storage::write_engine::mutation::ClusteringBound) -> RangeCut {
+        use crate::storage::write_engine::mutation::ClusteringBound;
+        match bound {
+            ClusteringBound::Inclusive(ck) => RangeCut::At {
+                key: ck.clone(),
+                after: true,
+            },
+            ClusteringBound::Exclusive(ck) => RangeCut::At {
+                key: ck.clone(),
+                after: false,
+            },
+            ClusteringBound::Top => RangeCut::Top,
+            ClusteringBound::Bottom => RangeCut::Bottom,
+        }
+    }
+
+    /// Convert a left-edge cut back into a start [`ClusteringBound`].
+    fn cut_to_start_bound(
+        cut: RangeCut,
+    ) -> crate::storage::write_engine::mutation::ClusteringBound {
+        use crate::storage::write_engine::mutation::ClusteringBound;
+        match cut {
+            RangeCut::Bottom => ClusteringBound::Bottom,
+            RangeCut::At { key, after: false } => ClusteringBound::Inclusive(key),
+            RangeCut::At { key, after: true } => ClusteringBound::Exclusive(key),
+            RangeCut::Top => ClusteringBound::Top,
+        }
+    }
+
+    /// Convert a right-edge cut back into an end [`ClusteringBound`].
+    fn cut_to_end_bound(cut: RangeCut) -> crate::storage::write_engine::mutation::ClusteringBound {
+        use crate::storage::write_engine::mutation::ClusteringBound;
+        match cut {
+            RangeCut::Top => ClusteringBound::Top,
+            RangeCut::At { key, after: true } => ClusteringBound::Inclusive(key),
+            RangeCut::At { key, after: false } => ClusteringBound::Exclusive(key),
+            RangeCut::Bottom => ClusteringBound::Bottom,
+        }
     }
 
     /// Whether a range tombstone's clustering range covers `ck`, comparing bounds
@@ -2579,6 +2823,18 @@ impl KWayMerger {
             return Some(entry);
         };
 
+        // A complex (collection) deletion OLDER than the covering range is
+        // subsumed by the range marker; one STRICTLY NEWER must survive, else
+        // older collection elements from a non-compacted SSTable could resurrect
+        // (roborev #959 High #2 — `apply_range_shadowing` previously dropped
+        // `entry.complex_deletions` on the whole-row-covered path). Filtered once
+        // here and reused by every arm below.
+        let surviving_complex: Vec<ComplexDeletion> = entry
+            .complex_deletions
+            .into_iter()
+            .filter(|cd| cd.marked_for_delete_at > floor)
+            .collect();
+
         match entry.row_data {
             RowData::Tombstone {
                 deletion_time,
@@ -2587,10 +2843,8 @@ impl KWayMerger {
                 // A row tombstone fully covered by a newer/equal range deletion is
                 // redundant (the range marker shadows it); drop it. A strictly
                 // newer row tombstone survives.
-                if deletion_time <= floor {
-                    None
-                } else {
-                    Some(MergeEntry::new(
+                if deletion_time > floor {
+                    let mut rebuilt = MergeEntry::new(
                         entry.run_index,
                         entry.key,
                         Some(ck),
@@ -2599,7 +2853,26 @@ impl KWayMerger {
                             deletion_time,
                             local_deletion_time,
                         },
-                    ))
+                    );
+                    if !surviving_complex.is_empty() {
+                        rebuilt = rebuilt.with_complex_deletions(surviving_complex);
+                    }
+                    Some(rebuilt)
+                } else if !surviving_complex.is_empty() {
+                    // The row tombstone is subsumed by the range, but a newer
+                    // complex deletion must persist as a metadata-only carrier.
+                    Some(
+                        MergeEntry::new(
+                            entry.run_index,
+                            entry.key,
+                            Some(ck),
+                            entry.timestamp,
+                            RowData::Live { cells: Vec::new() },
+                        )
+                        .with_complex_deletions(surviving_complex),
+                    )
+                } else {
+                    None
                 }
             }
             RowData::Live { cells } => {
@@ -2624,11 +2897,14 @@ impl KWayMerger {
                 let marker_live = entry.timestamp > floor;
 
                 if !has_data && !marker_live {
-                    // Whole row covered. Emit a row tombstone only if a coexisting
-                    // row deletion newer than the floor must persist; otherwise the
-                    // re-emitted range marker is the sole survivor.
-                    return surviving_row_del.map(|(dt, ldt)| {
-                        MergeEntry::new(
+                    // Whole row covered by the range. A coexisting row deletion
+                    // (#932) newer than the floor wins and subsumes any collection
+                    // deletion. Otherwise a complex deletion newer than the floor
+                    // must persist as a metadata-only carrier (roborev #959 High
+                    // #2); failing that, the re-emitted range marker is the sole
+                    // survivor and this entry contributes nothing.
+                    if let Some((dt, ldt)) = surviving_row_del {
+                        return Some(MergeEntry::new(
                             entry.run_index,
                             entry.key,
                             Some(ck),
@@ -2637,8 +2913,21 @@ impl KWayMerger {
                                 deletion_time: dt,
                                 local_deletion_time: ldt,
                             },
-                        )
-                    });
+                        ));
+                    }
+                    if !surviving_complex.is_empty() {
+                        return Some(
+                            MergeEntry::new(
+                                entry.run_index,
+                                entry.key,
+                                Some(ck),
+                                entry.timestamp,
+                                RowData::Live { cells: Vec::new() },
+                            )
+                            .with_complex_deletions(surviving_complex),
+                        );
+                    }
+                    return None;
                 }
 
                 let row_ts = if has_data {
@@ -2658,8 +2947,8 @@ impl KWayMerger {
                     row_ts,
                     RowData::Live { cells: kept },
                 );
-                if !entry.complex_deletions.is_empty() {
-                    rebuilt = rebuilt.with_complex_deletions(entry.complex_deletions);
+                if !surviving_complex.is_empty() {
+                    rebuilt = rebuilt.with_complex_deletions(surviving_complex);
                 }
                 if let Some((dt, ldt)) = surviving_row_del {
                     rebuilt = rebuilt.with_row_deletion(dt, ldt);
@@ -11525,6 +11814,282 @@ mod issue_929_bare_udt_compaction {
                 .data_type,
             "person",
             "with unverified headers, a bare UDT column must NOT be registry-normalized"
+        );
+    }
+}
+
+/// Roborev #959 fixes on the #933 range-tombstone compaction path:
+///   - High #1: overlapping cross-SSTable ranges with different bounds must be
+///     coalesced into a NON-OVERLAPPING canonical sequence before re-emission
+///     (the writer emits independent open/close marker pairs and the reader
+///     pairs them with a single pending-start, so overlaps corrupt on read-back).
+///   - High #2: `apply_range_shadowing` must preserve a complex (collection)
+///     deletion newer than the covering range when the row is otherwise fully
+///     shadowed (it previously dropped `complex_deletions`).
+#[cfg(all(test, feature = "write-support"))]
+mod issue_959_range_tombstone_fixes {
+    use super::*;
+    use crate::schema::{Column, KeyColumn};
+    use crate::storage::write_engine::mutation::ClusteringBound;
+    use crate::types::Value;
+    use std::collections::HashMap;
+
+    fn dk(byte: u8) -> DecoratedKey {
+        DecoratedKey::from_key_bytes(vec![byte]).expect("token")
+    }
+
+    /// Single-column `int` partition + single-column `int` clustering schema.
+    fn schema_int_ck(order: crate::schema::ClusteringOrder) -> TableSchema {
+        TableSchema {
+            keyspace: "ks".to_string(),
+            table: "tbl".to_string(),
+            partition_keys: vec![KeyColumn {
+                name: "pk".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![crate::schema::ClusteringColumn {
+                name: "ck".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+                order,
+            }],
+            columns: vec![Column {
+                name: "v".to_string(),
+                data_type: "int".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            }],
+            comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
+        }
+    }
+
+    fn ck(n: i32) -> ClusteringKey {
+        ClusteringKey {
+            columns: vec![("ck".to_string(), Value::Integer(n))],
+        }
+    }
+
+    fn rt(start: ClusteringBound, end: ClusteringBound, dt: i64) -> RangeTombstone {
+        RangeTombstone {
+            start,
+            end,
+            deletion_time: dt,
+            local_deletion_time: (dt / 1_000_000) as i32,
+        }
+    }
+
+    /// High #1: two OVERLAPPING ranges with different bounds split into three
+    /// disjoint segments, the inner (newer) deletion winning its overlap.
+    #[test]
+    fn overlapping_ranges_coalesce_to_disjoint_segments() {
+        let schema = schema_int_ck(Default::default());
+        // [1,5] @100 overlapped by [2,3] @200.
+        let mut rts = vec![
+            (
+                dk(1),
+                rt(
+                    ClusteringBound::Inclusive(ck(1)),
+                    ClusteringBound::Inclusive(ck(5)),
+                    100,
+                ),
+            ),
+            (
+                dk(1),
+                rt(
+                    ClusteringBound::Inclusive(ck(2)),
+                    ClusteringBound::Inclusive(ck(3)),
+                    200,
+                ),
+            ),
+        ];
+        KWayMerger::coalesce_range_tombstones(&mut rts, &schema);
+
+        assert_eq!(rts.len(), 3, "union splits into 3 disjoint segments");
+        // [1, 2) @100
+        assert_eq!(rts[0].1.start, ClusteringBound::Inclusive(ck(1)));
+        assert_eq!(rts[0].1.end, ClusteringBound::Exclusive(ck(2)));
+        assert_eq!(rts[0].1.deletion_time, 100);
+        // [2, 3] @200 (the newer inner range wins the overlap)
+        assert_eq!(rts[1].1.start, ClusteringBound::Inclusive(ck(2)));
+        assert_eq!(rts[1].1.end, ClusteringBound::Inclusive(ck(3)));
+        assert_eq!(rts[1].1.deletion_time, 200);
+        // (3, 5] @100
+        assert_eq!(rts[2].1.start, ClusteringBound::Exclusive(ck(3)));
+        assert_eq!(rts[2].1.end, ClusteringBound::Inclusive(ck(5)));
+        assert_eq!(rts[2].1.deletion_time, 100);
+
+        // Every emitted segment is a valid, well-ordered, non-overlapping range:
+        // each end is >= its start and each start is > the previous end.
+        for i in 0..rts.len() {
+            let s = KWayMerger::range_start_cut(&rts[i].1.start);
+            let e = KWayMerger::range_end_cut(&rts[i].1.end);
+            assert_ne!(
+                KWayMerger::cut_cmp(&s, &e, &schema),
+                Ordering::Greater,
+                "segment {i} start must not exceed its end"
+            );
+            if i > 0 {
+                // Non-overlap: the previous end cut must not exceed this start
+                // cut. Equality is fine and expected — an exclusive end and an
+                // inclusive start at the same value share one boundary cut while
+                // covering complementary value sets (e.g. `< 2` then `>= 2`).
+                let prev_e = KWayMerger::range_end_cut(&rts[i - 1].1.end);
+                assert_ne!(
+                    KWayMerger::cut_cmp(&prev_e, &s, &schema),
+                    Ordering::Greater,
+                    "segment {i} must not overlap the previous segment"
+                );
+            }
+        }
+    }
+
+    /// Identical bounds across inputs collapse to one range at the newest
+    /// deletion (the old `canonicalize` behavior is subsumed).
+    #[test]
+    fn identical_bounds_collapse_to_newest() {
+        let schema = schema_int_ck(Default::default());
+        let mut rts = vec![
+            (
+                dk(1),
+                rt(
+                    ClusteringBound::Inclusive(ck(1)),
+                    ClusteringBound::Inclusive(ck(3)),
+                    100,
+                ),
+            ),
+            (
+                dk(1),
+                rt(
+                    ClusteringBound::Inclusive(ck(1)),
+                    ClusteringBound::Inclusive(ck(3)),
+                    200,
+                ),
+            ),
+        ];
+        KWayMerger::coalesce_range_tombstones(&mut rts, &schema);
+        assert_eq!(rts.len(), 1);
+        assert_eq!(rts[0].1.deletion_time, 200);
+        assert_eq!(rts[0].1.start, ClusteringBound::Inclusive(ck(1)));
+        assert_eq!(rts[0].1.end, ClusteringBound::Inclusive(ck(3)));
+    }
+
+    /// Adjacent (touching) ranges at the SAME deletion merge into one.
+    #[test]
+    fn adjacent_same_deletion_ranges_merge() {
+        let schema = schema_int_ck(Default::default());
+        let mut rts = vec![
+            (
+                dk(1),
+                rt(
+                    ClusteringBound::Inclusive(ck(1)),
+                    ClusteringBound::Inclusive(ck(3)),
+                    100,
+                ),
+            ),
+            (
+                dk(1),
+                rt(
+                    ClusteringBound::Exclusive(ck(3)),
+                    ClusteringBound::Inclusive(ck(5)),
+                    100,
+                ),
+            ),
+        ];
+        KWayMerger::coalesce_range_tombstones(&mut rts, &schema);
+        assert_eq!(rts.len(), 1, "touching equal-deletion ranges coalesce");
+        assert_eq!(rts[0].1.start, ClusteringBound::Inclusive(ck(1)));
+        assert_eq!(rts[0].1.end, ClusteringBound::Inclusive(ck(5)));
+    }
+
+    /// Distinct partition keys are coalesced independently (never merged).
+    #[test]
+    fn distinct_partitions_not_merged() {
+        let schema = schema_int_ck(Default::default());
+        let mut rts = vec![
+            (
+                dk(1),
+                rt(ClusteringBound::Bottom, ClusteringBound::Top, 100),
+            ),
+            (
+                dk(2),
+                rt(ClusteringBound::Bottom, ClusteringBound::Top, 100),
+            ),
+        ];
+        KWayMerger::coalesce_range_tombstones(&mut rts, &schema);
+        assert_eq!(rts.len(), 2);
+        assert_ne!(rts[0].0.key, rts[1].0.key);
+    }
+
+    /// High #2: a complex deletion NEWER than the covering range survives as a
+    /// metadata carrier when the row is otherwise fully shadowed.
+    #[test]
+    fn newer_complex_deletion_survives_full_range_shadow() {
+        let schema = schema_int_ck(Default::default());
+        // Row at ck=2 with only its clustering pseudo-cell (no live data) plus a
+        // collection deletion @200; covered by a whole-partition range @100.
+        let entry = MergeEntry::new(
+            0,
+            dk(1),
+            Some(ck(2)),
+            50,
+            RowData::Live {
+                cells: vec![CellData::new("ck".to_string(), Value::Integer(2), 50)],
+            },
+        )
+        .with_complex_deletions(vec![ComplexDeletion {
+            column: "v".to_string(),
+            marked_for_delete_at: 200,
+            local_deletion_time: 0,
+        }]);
+        let range = vec![(
+            dk(1),
+            rt(ClusteringBound::Bottom, ClusteringBound::Top, 100),
+        )];
+
+        let out = KWayMerger::apply_range_shadowing(entry, &range, &schema)
+            .expect("a complex deletion newer than the range must survive");
+        assert_eq!(
+            out.complex_deletions.len(),
+            1,
+            "the newer collection deletion is preserved"
+        );
+        assert_eq!(out.complex_deletions[0].marked_for_delete_at, 200);
+        match out.row_data {
+            RowData::Live { cells } => assert!(cells.is_empty(), "carrier holds no data cells"),
+            other => panic!("expected an empty Live carrier, got {other:?}"),
+        }
+    }
+
+    /// A complex deletion OLDER than the covering range is subsumed and dropped,
+    /// leaving nothing for the re-emitted range marker to duplicate.
+    #[test]
+    fn older_complex_deletion_subsumed_by_range() {
+        let schema = schema_int_ck(Default::default());
+        let entry = MergeEntry::new(
+            0,
+            dk(1),
+            Some(ck(2)),
+            50,
+            RowData::Live {
+                cells: vec![CellData::new("ck".to_string(), Value::Integer(2), 50)],
+            },
+        )
+        .with_complex_deletions(vec![ComplexDeletion {
+            column: "v".to_string(),
+            marked_for_delete_at: 50,
+            local_deletion_time: 0,
+        }]);
+        let range = vec![(
+            dk(1),
+            rt(ClusteringBound::Bottom, ClusteringBound::Top, 100),
+        )];
+
+        assert!(
+            KWayMerger::apply_range_shadowing(entry, &range, &schema).is_none(),
+            "an older complex deletion is subsumed; nothing survives"
         );
     }
 }

--- a/cqlite-core/src/storage/write_engine/merge.rs
+++ b/cqlite-core/src/storage/write_engine/merge.rs
@@ -177,34 +177,32 @@ impl MergeEntry {
         self
     }
 
-    /// True when this entry exists ONLY to carry metadata the writer CANNOT emit
-    /// today and has no row content — so routing it to the writer would create a
+    /// True when this entry has NO writer-emittable content at all — an empty
+    /// `RowData::Live { cells: vec![] }` with no row tombstone and no carried
+    /// deletion metadata. Routing such an entry to the writer would create a
     /// PHANTOM live empty (pure-PK) row at timestamp 0 (`DataWriter::merge_row_group`
-    /// treats a no-op mutation as a primary-key insert).
+    /// treats a no-op mutation as a primary-key insert), so `merge` filters it.
     ///
-    /// `reconcile_cluster` emits an empty `RowData::Live { cells: vec![] }` (at
-    /// timestamp 0) when a cluster has no surviving cells and no row tombstone but
-    /// still carries deletion metadata, so that metadata survives reconciliation
-    /// in the in-memory merge stream.
+    /// Epic #899 Phase C: a COMPLEX DELETION is consumed by the writer (a real
+    /// `CellOperation::ComplexDeletion` marker), so a complex-deletion-only entry
+    /// is NOT a no-op.
     ///
-    /// Epic #899 Phase C: a COMPLEX DELETION is now consumed by the writer — the
-    /// merge→mutation step emits a real `CellOperation::ComplexDeletion` marker, so
-    /// a complex-deletion-only entry is NO LONGER a no-op and MUST reach the
-    /// SSTable (a fully-deleted-collection marker must survive). It is therefore
-    /// NOT filtered.
-    ///
-    /// A RANGE DELETION, by contrast, is still NOT consumed by the compaction
-    /// writer (deferred to #846): an entry whose only surviving state is a range
-    /// deletion (empty cells, no row tombstone, no complex deletion) would still
-    /// become a phantom live row, so it is filtered here. The merge stream never
-    /// produces a genuine empty-but-live row through this path (an entry with empty
-    /// cells, no row tombstone, AND no carried metadata reconciles to `None`), so
-    /// filtering this synthetic case is safe.
+    /// Issue #933: a RANGE DELETION is now ALSO consumed by the compaction writer —
+    /// `merge_entry_to_mutation` threads it onto the mutation's `range_tombstones`,
+    /// which the writer interleaves as on-disk bound markers AND uses to shadow
+    /// covered same-partition rows. A range-deletion-only carrier is therefore NO
+    /// LONGER a no-op and MUST reach the writer (dropping it would resurrect the
+    /// covered rows it shadowed — roborev #959 High #2). In practice
+    /// `reconcile_cluster` never emits a truly-empty entry (one with empty cells,
+    /// no row tombstone, and no carried metadata reconciles to `None`), so this
+    /// guard is now effectively unreachable but kept as a defensive phantom-row
+    /// filter.
     #[must_use]
     pub fn is_metadata_only_no_op(&self) -> bool {
         matches!(&self.row_data, RowData::Live { cells } if cells.is_empty())
             && self.complex_deletions.is_empty()
-            && self.range_deletion.is_some()
+            && self.range_deletion.is_none()
+            && self.row_deletion.is_none()
     }
 }
 
@@ -860,12 +858,44 @@ impl SSTableRowIteratorAdapter {
         compaction_row: crate::storage::sstable::reader::compaction_row::CompactionRow,
         schema: &TableSchema,
     ) -> Result<MergeEntry> {
+        use crate::storage::sstable::reader::compaction_row::CompactionRowData;
+
         let crate::storage::sstable::reader::compaction_row::CompactionRow {
             key,
             row_timestamp,
             row_data,
         } = compaction_row;
         let decorated_key = DecoratedKey::from_key_bytes(key.0)?;
+
+        // Issue #933: a range-tombstone marker surfaces as a self-contained
+        // carrier `MergeEntry` (empty live row + `range_deletion`), routed into the
+        // partition's `None` clustering bucket so it is never collapsed with data
+        // rows. `merge_partition_rows` extracts these to shadow covered cells and
+        // re-emit the surviving marker to the output SSTable.
+        if let CompactionRowData::RangeMarker {
+            start,
+            end,
+            deletion_time,
+            local_deletion_time,
+        } = row_data
+        {
+            let range = RangeTombstone {
+                start: Self::compaction_bound_to_mutation(start, schema),
+                end: Self::compaction_bound_to_mutation(end, schema),
+                deletion_time,
+                local_deletion_time,
+            };
+            return Ok(MergeEntry::new(
+                run_index,
+                decorated_key,
+                None,
+                // Use the deletion time as the entry timestamp so the writer's
+                // stats baselines see a real value (not 0) for the carrier.
+                deletion_time,
+                RowData::Live { cells: Vec::new() },
+            )
+            .with_range_deletion(range));
+        }
         // #912: derive the clustering identity from the per-element compaction row
         // BEFORE collapsing it to `RowData`. A row tombstone carries no cells in
         // `RowData::Tombstone`, so its clustering key must come from the
@@ -895,6 +925,29 @@ impl SSTableRowIteratorAdapter {
             None => entry,
         };
         Ok(entry)
+    }
+
+    /// Convert a reader-native [`CompactionBound`] into a write-engine
+    /// [`ClusteringBound`] (issue #933).
+    ///
+    /// [`CompactionBound`]: crate::storage::sstable::reader::compaction_row::CompactionBound
+    /// [`ClusteringBound`]: crate::storage::write_engine::mutation::ClusteringBound
+    fn compaction_bound_to_mutation(
+        bound: crate::storage::sstable::reader::compaction_row::CompactionBound,
+        _schema: &TableSchema,
+    ) -> crate::storage::write_engine::mutation::ClusteringBound {
+        use crate::storage::sstable::reader::compaction_row::CompactionBound;
+        use crate::storage::write_engine::mutation::ClusteringBound;
+        match bound {
+            CompactionBound::Inclusive(cols) => {
+                ClusteringBound::Inclusive(ClusteringKey { columns: cols })
+            }
+            CompactionBound::Exclusive(cols) => {
+                ClusteringBound::Exclusive(ClusteringKey { columns: cols })
+            }
+            CompactionBound::Bottom => ClusteringBound::Bottom,
+            CompactionBound::Top => ClusteringBound::Top,
+        }
     }
 
     /// Extract a `ClusteringKey` from the row's live cells using the schema.
@@ -964,6 +1017,9 @@ impl SSTableRowIteratorAdapter {
                     columns: ck_columns,
                 })
             }
+            // Issue #933: a range marker is handled by `build_merge_entry` before
+            // this point and routed into the `None` clustering bucket.
+            CompactionRowData::RangeMarker { .. } => None,
         }
     }
 
@@ -1090,6 +1146,12 @@ impl SSTableRowIteratorAdapter {
                 }
 
                 (RowData::Live { cells }, complex_deletions, row_deletion)
+            }
+            // Issue #933: range markers are intercepted in `build_merge_entry`
+            // (carrier entry with `range_deletion`); they never reach this
+            // conversion. Map defensively to an empty live row.
+            CompactionRowData::RangeMarker { .. } => {
+                (RowData::Live { cells: Vec::new() }, Vec::new(), None)
             }
         }
     }
@@ -2112,11 +2174,11 @@ impl KWayMerger {
         };
 
         while let MergeStep::Partition { key, rows } = self.step()? {
-            // Skip metadata-only entries on the writer path (#886/#899
-            // branch-review). They exist only to carry complex/range deletion
-            // metadata through the in-memory merge stream; the writer does not
-            // yet consume those fields, so emitting them would write a phantom
-            // live empty (pure-PK) row at timestamp 0. See
+            // Skip truly-empty phantom entries on the writer path (#886/#899
+            // branch-review). A range-tombstone carrier is NO LONGER filtered here
+            // (#933): `merge_entry_to_mutation` turns it into a mutation carrying
+            // `range_tombstones`, which the writer emits as on-disk bound markers
+            // (and uses to shadow same-partition rows). See
             // `MergeEntry::is_metadata_only_no_op`.
             let mutations = rows
                 .into_iter()
@@ -2124,18 +2186,30 @@ impl KWayMerger {
                 .map(|entry| Self::merge_entry_to_mutation(entry, &self.schema))
                 .collect::<Result<Vec<_>>>()?;
 
-            // If every merged row was metadata-only, the partition has no
-            // writer-emittable content. Skipping `write_partition` here avoids a
-            // phantom EMPTY partition (header/end marker + Index/Filter/Summary/
-            // statistics registration) in the output SSTable. Such a partition
-            // must not be counted as an output partition or row (#886
-            // branch-review).
+            // If the partition has no writer-emittable content at all, skip
+            // `write_partition` to avoid a phantom EMPTY partition. A partition
+            // carrying ONLY range-tombstone markers (every data row covered) IS
+            // emittable — Cassandra writes such marker-only partitions — so it is
+            // kept here (#933).
             if mutations.is_empty() {
                 continue;
             }
 
+            // Count only real rows toward `output_rows`; a pure range-tombstone
+            // carrier (empty operations, no row tombstone, only `range_tombstones`)
+            // emits a marker, not a row (#933).
+            let row_mutations = mutations
+                .iter()
+                .filter(|m| {
+                    !(m.operations.is_empty()
+                        && m.partition_tombstone.is_none()
+                        && m.row_tombstone.is_none()
+                        && !m.range_tombstones.is_empty())
+                })
+                .count();
+
             stats.output_partitions += 1;
-            stats.output_rows += mutations.len() as u64;
+            stats.output_rows += row_mutations as u64;
 
             output_writer.write_partition(key, mutations)?;
         }
@@ -2269,18 +2343,6 @@ impl KWayMerger {
     fn merge_partition_rows(&self, rows: Vec<MergeEntry>) -> Result<Vec<MergeEntry>> {
         use std::collections::BTreeMap;
 
-        // Group by clustering key using BTreeMap (ClusteringKey implements Ord).
-        // Preserve heap-routing order within each group so the per-cell tiebreak
-        // (first-seen wins at equal timestamp+liveness) follows run_index.
-        let mut clustered_rows: BTreeMap<Option<ClusteringKey>, Vec<MergeEntry>> = BTreeMap::new();
-
-        for row in rows {
-            clustered_rows
-                .entry(row.clustering_key.clone())
-                .or_default()
-                .push(row);
-        }
-
         // Overlap-safety gate for tombstone purging (#921 finding 1, #935):
         // decide BOTH the effective gc_grace cutoff and the overlap-aware
         // max-purgeable timestamp this cluster is reconciled with.
@@ -2294,6 +2356,9 @@ impl KWayMerger {
         //   shadows nothing outside the set.
         // - PARTIAL compaction without a bound (#921 default): retain every
         //   tombstone — collapse the cutoff to `None` (purge no-op).
+        //
+        // Issue #933 builds `clustered_rows` (and splits out range-tombstone
+        // carriers) AFTER this gate, below.
         let (effective_gc_before, max_purgeable_timestamp) = if self.purge_safe {
             (self.gc_before_secs, i64::MAX)
         } else if let Some(bound) = self.max_purgeable_timestamp {
@@ -2301,6 +2366,35 @@ impl KWayMerger {
         } else {
             (None, i64::MIN)
         };
+
+        // Issue #933: split the range-tombstone carrier entries out of the row
+        // stream. They are partition-level markers spanning a clustering range —
+        // NOT per-`(pk, ck)` rows — so routing them through `reconcile_cluster`
+        // (which collapses a cluster to ONE entry, keeping a single max-deletion
+        // range) would lose every range but one. Collect them here, canonicalize
+        // overlapping duplicates, then (a) shadow covered cells per cluster and
+        // (b) re-emit the survivors so the writer persists the markers.
+        let mut range_tombstones: Vec<(DecoratedKey, RangeTombstone)> = Vec::new();
+        let mut clustered_rows: BTreeMap<Option<ClusteringKey>, Vec<MergeEntry>> = BTreeMap::new();
+
+        for row in rows {
+            if Self::is_range_marker_carrier(&row) {
+                if let Some(rt) = row.range_deletion.clone() {
+                    range_tombstones.push((row.key.clone(), rt));
+                    continue;
+                }
+            }
+            clustered_rows
+                .entry(row.clustering_key.clone())
+                .or_default()
+                .push(row);
+        }
+
+        // Canonicalize: a range tombstone with IDENTICAL bounds appearing in
+        // multiple inputs collapses to the one with the greatest deletion time
+        // (Cassandra reconciles overlapping range deletions to the newest). Ranges
+        // with different bounds are all kept.
+        Self::canonicalize_range_tombstones(&mut range_tombstones);
 
         let mut merged = Vec::new();
         for (ck, cluster_rows) in clustered_rows {
@@ -2311,8 +2405,43 @@ impl KWayMerger {
                 effective_gc_before,
                 max_purgeable_timestamp,
             ) {
-                merged.push(entry);
+                // Issue #933: shadow cells covered by a range tombstone. The merge
+                // must do this per-cell (not just per-row at the writer) because a
+                // reconciled row's simple cells lose their individual writetimes
+                // when converted to a mutation — only the merge still sees each
+                // `CellData.timestamp`.
+                if let Some(shadowed) =
+                    Self::apply_range_shadowing(entry, &range_tombstones, &self.schema)
+                {
+                    merged.push(shadowed);
+                }
             }
+        }
+
+        // Re-emit the surviving range tombstones as carrier entries so the writer
+        // persists the markers (otherwise the shadowing above would resurrect the
+        // covered rows from a non-compacted SSTable — issue #933 / roborev #959
+        // High #2). gc_grace purges a marker only when this compaction is
+        // overlap-safe AND the marker's `localDeletionTime` is strictly below
+        // `gcBefore` (coordinate with #845); the covered cells were already removed
+        // above, so dropping the now-redundant marker cannot resurrect data within
+        // this overlap-safe set.
+        for (key, rt) in range_tombstones {
+            if let Some(gc_before) = effective_gc_before {
+                if i64::from(rt.local_deletion_time as u32) < gc_before {
+                    continue;
+                }
+            }
+            merged.push(
+                MergeEntry::new(
+                    usize::MAX,
+                    key,
+                    None,
+                    rt.deletion_time,
+                    RowData::Live { cells: Vec::new() },
+                )
+                .with_range_deletion(rt),
+            );
         }
 
         // Sort merged rows by clustering key for output order
@@ -2333,6 +2462,211 @@ impl KWayMerger {
         });
 
         Ok(merged)
+    }
+
+    /// True when an entry exists ONLY to carry a range-tombstone marker (issue
+    /// #933): an empty live row whose only payload is `range_deletion`. These are
+    /// produced by [`Self::build_merge_entry`] from a reader `RangeMarker` and are
+    /// split out of the row stream by [`Self::merge_partition_rows`].
+    fn is_range_marker_carrier(entry: &MergeEntry) -> bool {
+        entry.range_deletion.is_some()
+            && entry.complex_deletions.is_empty()
+            && entry.row_deletion.is_none()
+            && matches!(&entry.row_data, RowData::Live { cells } if cells.is_empty())
+    }
+
+    /// Collapse range tombstones with IDENTICAL bounds to the one with the
+    /// greatest deletion time (Cassandra reconciles overlapping range deletions to
+    /// the newest), de-duplicating exact repeats across inputs (issue #933).
+    /// Ranges with different bounds are all retained.
+    fn canonicalize_range_tombstones(rts: &mut Vec<(DecoratedKey, RangeTombstone)>) {
+        use crate::storage::write_engine::mutation::ClusteringBound;
+        // Group by (key bytes, start, end); keep the max (deletion_time, ldt).
+        let mut out: Vec<(DecoratedKey, RangeTombstone)> = Vec::new();
+        'outer: for (key, rt) in rts.drain(..) {
+            for (existing_key, existing) in out.iter_mut() {
+                let same_bounds = existing_key.key == key.key
+                    && bounds_eq(&existing.start, &rt.start)
+                    && bounds_eq(&existing.end, &rt.end);
+                if same_bounds {
+                    if rt.deletion_time > existing.deletion_time {
+                        existing.deletion_time = rt.deletion_time;
+                        existing.local_deletion_time = rt.local_deletion_time;
+                    }
+                    continue 'outer;
+                }
+            }
+            out.push((key, rt));
+        }
+        *rts = out;
+
+        fn bounds_eq(a: &ClusteringBound, b: &ClusteringBound) -> bool {
+            a == b
+        }
+    }
+
+    /// Whether a range tombstone's clustering range covers `ck`, comparing bounds
+    /// SCHEMA-AWARE (honoring per-column ASC/DESC via [`ClusteringKey::compare`],
+    /// NOT the schema-agnostic `cmp`) — issue #933 / roborev #959 Medium #3.
+    ///
+    /// Bounds may be a PREFIX shorter than the full clustering arity; comparing
+    /// only the bound's components (via [`ClusteringKey::compare`], which treats an
+    /// absent trailing component as a first-sorting NULL) yields the correct
+    /// containment for the `DELETE WHERE pk=? AND ck1=?` prefix case.
+    fn range_tombstone_covers_ck(
+        ck: &ClusteringKey,
+        rt: &RangeTombstone,
+        schema: &TableSchema,
+    ) -> bool {
+        use crate::storage::write_engine::mutation::ClusteringBound;
+
+        // Compare `ck` against a bound key over the bound's component count so a
+        // prefix bound only compares its present components.
+        let cmp = |bound: &ClusteringKey| -> Ordering {
+            let n = bound.columns.len();
+            let truncated = ClusteringKey {
+                columns: ck.columns.iter().take(n).cloned().collect(),
+            };
+            truncated
+                .compare(bound, schema)
+                .unwrap_or_else(|_| truncated.cmp(bound))
+        };
+
+        let after_start = match &rt.start {
+            ClusteringBound::Inclusive(b) => cmp(b) != Ordering::Less,
+            ClusteringBound::Exclusive(b) => cmp(b) == Ordering::Greater,
+            ClusteringBound::Bottom => true,
+            ClusteringBound::Top => false,
+        };
+        let before_end = match &rt.end {
+            ClusteringBound::Inclusive(b) => cmp(b) != Ordering::Greater,
+            ClusteringBound::Exclusive(b) => cmp(b) == Ordering::Less,
+            ClusteringBound::Top => true,
+            ClusteringBound::Bottom => false,
+        };
+        after_start && before_end
+    }
+
+    /// Shadow the cells of a reconciled cluster entry that are covered by a range
+    /// tombstone (issue #933, the re-applied #846 "Step 2c" made schema-aware).
+    ///
+    /// Computes the max `markedForDeleteAt` among range tombstones covering this
+    /// entry's clustering key, then drops every DATA cell whose own `timestamp` is
+    /// `<= floor` (the `<=` boundary lets a deletion win an equal-ts tie, #498).
+    /// Clustering-key pseudo-cells are retained whenever any data cell survives so
+    /// the row keeps its key columns for read-back. A row whose every data cell is
+    /// shadowed AND whose row-marker liveness is `<= floor` produces nothing (the
+    /// re-emitted range marker covers it); a coexisting row deletion newer than the
+    /// floor is preserved as a row tombstone. A row with no clustering key (static
+    /// / unclustered) is never covered by a range tombstone.
+    fn apply_range_shadowing(
+        entry: MergeEntry,
+        range_tombstones: &[(DecoratedKey, RangeTombstone)],
+        schema: &TableSchema,
+    ) -> Option<MergeEntry> {
+        let Some(ck) = entry.clustering_key.clone() else {
+            return Some(entry);
+        };
+
+        let floor = range_tombstones
+            .iter()
+            .filter(|(key, rt)| {
+                key.key == entry.key.key && Self::range_tombstone_covers_ck(&ck, rt, schema)
+            })
+            .map(|(_, rt)| rt.deletion_time)
+            .max();
+        let Some(floor) = floor else {
+            return Some(entry);
+        };
+
+        match entry.row_data {
+            RowData::Tombstone {
+                deletion_time,
+                local_deletion_time,
+            } => {
+                // A row tombstone fully covered by a newer/equal range deletion is
+                // redundant (the range marker shadows it); drop it. A strictly
+                // newer row tombstone survives.
+                if deletion_time <= floor {
+                    None
+                } else {
+                    Some(MergeEntry::new(
+                        entry.run_index,
+                        entry.key,
+                        Some(ck),
+                        deletion_time,
+                        RowData::Tombstone {
+                            deletion_time,
+                            local_deletion_time,
+                        },
+                    ))
+                }
+            }
+            RowData::Live { cells } => {
+                let ck_names: std::collections::HashSet<&str> =
+                    ck.columns.iter().map(|(n, _)| n.as_str()).collect();
+                let is_data = |c: &CellData| !ck_names.contains(c.column.as_str());
+
+                // Keep clustering pseudo-cells; keep data cells strictly newer than
+                // the covering range deletion.
+                let kept: Vec<CellData> = cells
+                    .into_iter()
+                    .filter(|c| !is_data(c) || c.timestamp > floor)
+                    .collect();
+                let has_data = kept.iter().any(is_data);
+
+                // A coexisting row deletion (#932) older than the range floor is
+                // subsumed by the range marker; a newer one is preserved.
+                let surviving_row_del = entry.row_deletion.filter(|(dt, _)| *dt > floor);
+
+                // The row-marker liveness survives the range only if its own
+                // timestamp is strictly newer than the covering deletion.
+                let marker_live = entry.timestamp > floor;
+
+                if !has_data && !marker_live {
+                    // Whole row covered. Emit a row tombstone only if a coexisting
+                    // row deletion newer than the floor must persist; otherwise the
+                    // re-emitted range marker is the sole survivor.
+                    return surviving_row_del.map(|(dt, ldt)| {
+                        MergeEntry::new(
+                            entry.run_index,
+                            entry.key,
+                            Some(ck),
+                            dt,
+                            RowData::Tombstone {
+                                deletion_time: dt,
+                                local_deletion_time: ldt,
+                            },
+                        )
+                    });
+                }
+
+                let row_ts = if has_data {
+                    kept.iter()
+                        .filter(|c| is_data(c))
+                        .map(|c| c.timestamp)
+                        .max()
+                        .unwrap_or(entry.timestamp)
+                } else {
+                    entry.timestamp
+                };
+
+                let mut rebuilt = MergeEntry::new(
+                    entry.run_index,
+                    entry.key,
+                    Some(ck),
+                    row_ts,
+                    RowData::Live { cells: kept },
+                );
+                if !entry.complex_deletions.is_empty() {
+                    rebuilt = rebuilt.with_complex_deletions(entry.complex_deletions);
+                }
+                if let Some((dt, ldt)) = surviving_row_del {
+                    rebuilt = rebuilt.with_row_deletion(dt, ldt);
+                }
+                Some(rebuilt)
+            }
+        }
     }
 
     /// The cell's effective `localDeletionTime` (GC-clock seconds, on-disk
@@ -3030,6 +3364,13 @@ impl KWayMerger {
         let partition_key = PartitionKey::from_bytes(&entry.key.key, schema)?;
         let table_id = TableId::new(&schema.keyspace, &schema.table);
 
+        // Issue #933: a surviving range tombstone rides on the mutation's
+        // `range_tombstones`, which the writer interleaves as on-disk bound markers
+        // (and uses to shadow same-partition rows). Captured before `entry` is
+        // consumed below. A range carrier has empty operations and no clustering
+        // key, so it produces NO row — only the marker is written.
+        let range_tombstone = entry.range_deletion.clone();
+
         // Capture the row tombstone's source LDT (GC-clock seconds) by borrow,
         // before the `match` below moves `cells` out of `entry.row_data` (#873).
         //
@@ -3132,10 +3473,16 @@ impl KWayMerger {
         };
         // Issue #932: attach the coexisting row deletion (deletion time + LDT) so
         // the writer keeps both the row tombstone and the surviving newer cells.
-        Ok(match coexisting_row_tombstone {
+        let mut mutation = match coexisting_row_tombstone {
             Some((deletion_time, ldt)) => mutation.with_row_tombstone(deletion_time, ldt),
             None => mutation,
-        })
+        };
+        // Issue #933: thread the surviving range tombstone so the writer emits the
+        // on-disk bound markers (and shadows same-partition rows the marker covers).
+        if let Some(rt) = range_tombstone {
+            mutation.range_tombstones.push(rt);
+        }
+        Ok(mutation)
     }
 }
 
@@ -6806,8 +7153,8 @@ mod issue_886_merge_entry_enrichment {
     /// be skipped — the writer now emits a real complex-deletion marker for it
     /// (`merge_entry_to_mutation` produces a `CellOperation::ComplexDeletion`), so
     /// a fully-deleted-collection marker reaches the SSTable instead of being
-    /// dropped. A RANGE-deletion-only entry is still not consumable by the writer
-    /// (deferred to #846) and remains skippable.
+    /// dropped. Issue #933: a RANGE-deletion-only carrier is ALSO now writer-
+    /// visible (the writer emits its bound markers), so it too is no longer skipped.
     #[test]
     fn complex_deletion_only_entry_reaches_writer_but_range_only_is_skipped() {
         let complex = ComplexDeletion {
@@ -6831,14 +7178,15 @@ mod issue_886_merge_entry_enrichment {
             "Phase C: a complex-deletion-only entry must reach the writer"
         );
 
-        // Range-deletion-only (no complex deletion): still skippable — the writer
-        // does not consume range deletions yet (#846), so routing it would write a
-        // phantom pure-PK row.
+        // Range-deletion-only (no complex deletion): now WRITER-VISIBLE (#933) —
+        // `merge_entry_to_mutation` threads it onto the mutation's range_tombstones
+        // so the writer emits the on-disk bound markers; dropping it would
+        // resurrect the rows it shadowed.
         let range_only = MergeEntry::new(0, dk(1), None, 0, RowData::Live { cells: vec![] })
             .with_range_deletion(range.clone());
         assert!(
-            range_only.is_metadata_only_no_op(),
-            "range-deletion-only entry stays writer-skippable (deferred to #846)"
+            !range_only.is_metadata_only_no_op(),
+            "#933: a range-deletion-only carrier must reach the writer"
         );
 
         // Both kinds present → the complex deletion is writer-visible, so the
@@ -6888,10 +7236,12 @@ mod issue_886_merge_entry_enrichment {
         );
         assert!(!live.is_metadata_only_no_op());
 
-        // Empty live row carrying metadata? Yes (skip). Empty live row WITHOUT
-        // metadata never survives reconcile, but defensively it is not skippable.
+        // Empty live row WITHOUT any metadata: a true phantom no-op. It never
+        // survives reconcile in practice, but the defensive filter DOES treat it as
+        // skippable (#933 redefinition: no cells, no complex, no range, no row
+        // deletion).
         let empty_no_meta = MergeEntry::new(0, dk(1), None, 0, RowData::Live { cells: vec![] });
-        assert!(!empty_no_meta.is_metadata_only_no_op());
+        assert!(empty_no_meta.is_metadata_only_no_op());
 
         // Row tombstone — must be written (real deletion).
         let tomb = MergeEntry::new(
@@ -8613,7 +8963,7 @@ mod issue_822_merge_ordering_semantics {
 mod issue_886_empty_partition_skip {
     use super::*;
     use crate::schema::{KeyColumn, TableSchema};
-    use crate::storage::write_engine::mutation::{ClusteringBound, DecoratedKey, PartitionKey};
+    use crate::storage::write_engine::mutation::{DecoratedKey, PartitionKey};
     use std::collections::HashMap;
 
     /// Single-column `int` partition-key schema with one regular `name` column.
@@ -8647,16 +8997,6 @@ mod issue_886_empty_partition_skip {
             .expect("encode int partition key")
     }
 
-    /// A range deletion so an empty Live entry classifies as metadata-only.
-    fn range_deletion() -> RangeTombstone {
-        RangeTombstone {
-            start: ClusteringBound::Bottom,
-            end: ClusteringBound::Top,
-            deletion_time: 8888,
-            local_deletion_time: 0,
-        }
-    }
-
     /// An in-memory run yielding a fixed list of `MergeEntry`s in order.
     struct VecIterator(std::vec::IntoIter<MergeEntry>);
     impl SSTableRowIterator for VecIterator {
@@ -8688,16 +9028,17 @@ mod issue_886_empty_partition_skip {
     async fn empty_partition_is_skipped_on_writer_path() {
         let schema = schema();
 
-        // Partition token 1: ONLY a metadata-only no-op (empty Live + range
-        // deletion). After filtering, this partition's mutations are empty.
+        // Partition token 1: ONLY a truly-empty no-op (empty Live, no metadata).
+        // It reconciles to nothing, so after filtering this partition's mutations
+        // are empty. (A range-deletion carrier is no longer a no-op under #933, so
+        // a genuinely-empty entry is used here to exercise the phantom-skip path.)
         let meta_only = MergeEntry::new(
             0,
             DecoratedKey::new(1, pk_bytes(&schema, 1)),
             None,
             0,
             RowData::Live { cells: vec![] },
-        )
-        .with_range_deletion(range_deletion());
+        );
         assert!(
             meta_only.is_metadata_only_no_op(),
             "test precondition: the token-1 entry must be a metadata-only no-op"

--- a/cqlite-core/src/storage/write_engine/merge.rs
+++ b/cqlite-core/src/storage/write_engine/merge.rs
@@ -880,8 +880,8 @@ impl SSTableRowIteratorAdapter {
         } = row_data
         {
             let range = RangeTombstone {
-                start: Self::compaction_bound_to_mutation(start, schema),
-                end: Self::compaction_bound_to_mutation(end, schema),
+                start: Self::compaction_bound_to_mutation(start),
+                end: Self::compaction_bound_to_mutation(end),
                 deletion_time,
                 local_deletion_time,
             };
@@ -934,7 +934,6 @@ impl SSTableRowIteratorAdapter {
     /// [`ClusteringBound`]: crate::storage::write_engine::mutation::ClusteringBound
     fn compaction_bound_to_mutation(
         bound: crate::storage::sstable::reader::compaction_row::CompactionBound,
-        _schema: &TableSchema,
     ) -> crate::storage::write_engine::mutation::ClusteringBound {
         use crate::storage::sstable::reader::compaction_row::CompactionBound;
         use crate::storage::write_engine::mutation::ClusteringBound;
@@ -2480,14 +2479,14 @@ impl KWayMerger {
     /// the newest), de-duplicating exact repeats across inputs (issue #933).
     /// Ranges with different bounds are all retained.
     fn canonicalize_range_tombstones(rts: &mut Vec<(DecoratedKey, RangeTombstone)>) {
-        use crate::storage::write_engine::mutation::ClusteringBound;
         // Group by (key bytes, start, end); keep the max (deletion_time, ldt).
+        // `ClusteringBound` derives `PartialEq`, so bounds compare with `==`.
         let mut out: Vec<(DecoratedKey, RangeTombstone)> = Vec::new();
         'outer: for (key, rt) in rts.drain(..) {
             for (existing_key, existing) in out.iter_mut() {
                 let same_bounds = existing_key.key == key.key
-                    && bounds_eq(&existing.start, &rt.start)
-                    && bounds_eq(&existing.end, &rt.end);
+                    && existing.start == rt.start
+                    && existing.end == rt.end;
                 if same_bounds {
                     if rt.deletion_time > existing.deletion_time {
                         existing.deletion_time = rt.deletion_time;
@@ -2499,10 +2498,6 @@ impl KWayMerger {
             out.push((key, rt));
         }
         *rts = out;
-
-        fn bounds_eq(a: &ClusteringBound, b: &ClusteringBound) -> bool {
-            a == b
-        }
     }
 
     /// Whether a range tombstone's clustering range covers `ck`, comparing bounds
@@ -2564,6 +2559,11 @@ impl KWayMerger {
         range_tombstones: &[(DecoratedKey, RangeTombstone)],
         schema: &TableSchema,
     ) -> Option<MergeEntry> {
+        // Fast path for the overwhelmingly common partition with no range
+        // tombstones: skip the clustering-key clone and coverage scan entirely.
+        if range_tombstones.is_empty() {
+            return Some(entry);
+        }
         let Some(ck) = entry.clustering_key.clone() else {
             return Some(entry);
         };

--- a/cqlite-core/tests/issue_933_range_tombstone_compaction.rs
+++ b/cqlite-core/tests/issue_933_range_tombstone_compaction.rs
@@ -1,0 +1,526 @@
+//! Issue #933: apply range tombstones during compaction END-TO-END.
+//!
+//! Validates the full pipeline that #933 wired together:
+//!   1. **Reader** surfaces on-disk range-tombstone bound markers (previously
+//!      SKIPPED) through the compaction read contract, pairing start/end bounds
+//!      (incl. open-ended Bottom/Top) into complete ranges.
+//!   2. **Merge** shadows the cells a range tombstone covers (schema-aware,
+//!      honoring DESC) and re-emits the surviving marker.
+//!   3. **Writer** persists the surviving marker to the output SSTable.
+//!
+//! The key safety property (roborev #959 High #2): shadowing covered cells WITHOUT
+//! persisting the marker would RESURRECT rows from a non-compacted SSTable. We
+//! prove the marker persists by RE-COMPACTING the output against a fresh SSTable
+//! that re-introduces the covered rows at an older timestamp — they must stay
+//! shadowed.
+//!
+//! These tests do not require external Cassandra fixtures: the CQLite writer emits
+//! the same on-disk range-tombstone bound markers Cassandra does (IS_MARKER +
+//! ClusteringBoundOrBoundary), and the reader/merge consume them.
+
+#![cfg(feature = "write-support")]
+
+use std::path::{Path, PathBuf};
+
+use cqlite_core::schema::{ClusteringColumn, ClusteringOrder, Column, KeyColumn, TableSchema};
+use cqlite_core::storage::write_engine::merge::{compact_sstables, KWayMerger, MergeStep, RowData};
+use cqlite_core::storage::write_engine::mutation::{
+    CellOperation, ClusteringBound, ClusteringKey, Mutation, PartitionKey, RangeTombstone, TableId,
+};
+use cqlite_core::storage::write_engine::{WriteEngine, WriteEngineConfig};
+use cqlite_core::types::Value;
+use tempfile::TempDir;
+
+const KS: &str = "rt_ks";
+const TBL: &str = "rt_items";
+
+fn schema(order: ClusteringOrder) -> TableSchema {
+    TableSchema {
+        keyspace: KS.to_string(),
+        table: TBL.to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![ClusteringColumn {
+            name: "ck".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+            order,
+        }],
+        columns: vec![
+            Column {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "ck".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "name".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: Default::default(),
+        dropped_columns: Default::default(),
+    }
+}
+
+fn write_row(id: i32, ck: i32, name: &str, ts: i64) -> Mutation {
+    Mutation::new(
+        TableId::new(KS, TBL),
+        PartitionKey::single("id", Value::Integer(id)),
+        Some(ClusteringKey::single("ck", Value::Integer(ck))),
+        vec![CellOperation::Write {
+            column: "name".to_string(),
+            value: Value::Text(name.to_string()),
+        }],
+        ts,
+        None,
+    )
+}
+
+/// A range-tombstone mutation (no row content) for partition `id`.
+fn range_delete(id: i32, start: ClusteringBound, end: ClusteringBound, ts: i64) -> Mutation {
+    let mut m = Mutation::new(
+        TableId::new(KS, TBL),
+        PartitionKey::single("id", Value::Integer(id)),
+        None,
+        vec![],
+        ts,
+        None,
+    );
+    m.range_tombstones.push(RangeTombstone {
+        start,
+        end,
+        deletion_time: ts,
+        // A within-grace LDT (far future) so gc-grace never purges the marker in
+        // these tests.
+        local_deletion_time: 2_000_000_000,
+    });
+    m
+}
+
+fn incl(ck: i32) -> ClusteringBound {
+    ClusteringBound::Inclusive(ClusteringKey::single("ck", Value::Integer(ck)))
+}
+
+/// Flush a batch of mutations into its own SSTable generation and return the
+/// engine so subsequent flushes produce distinct generations.
+fn flush_batch(engine: &mut WriteEngine, rt: &tokio::runtime::Runtime, muts: Vec<Mutation>) {
+    for m in muts {
+        engine.write(m).expect("write");
+    }
+    rt.block_on(engine.flush())
+        .expect("flush")
+        .expect("sstable info");
+}
+
+fn discover_inputs(dir: &Path) -> Vec<PathBuf> {
+    fn collect(dir: &Path, out: &mut Vec<(u64, PathBuf)>, depth: usize) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let name = path
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string();
+            if name.starts_with("nb-") && name.ends_with("-big-Data.db") {
+                let base = name.trim_end_matches("-Data.db");
+                if !path.with_file_name(format!("{base}-TOC.txt")).exists() {
+                    continue;
+                }
+                let generation = name
+                    .strip_prefix("nb-")
+                    .and_then(|s| s.split("-big-").next())
+                    .and_then(|g| g.parse::<u64>().ok())
+                    .unwrap_or(0);
+                out.push((generation, path));
+            } else if depth > 0 && path.is_dir() {
+                collect(&path, out, depth - 1);
+            }
+        }
+    }
+    let mut found = Vec::new();
+    collect(dir, &mut found, 8);
+    // newest generation first (run index 0 = newest)
+    found.sort_by(|a, b| b.0.cmp(&a.0));
+    found.into_iter().map(|(_, p)| p).collect()
+}
+
+/// What a read-back of one or more SSTables yields through the compaction read
+/// path: the surviving `(id, ck)` live rows and the surviving range markers.
+struct ReadBack {
+    live_rows: Vec<(i32, i32)>,
+    markers: Vec<(i32, RangeTombstone)>,
+}
+
+fn read_back(inputs: Vec<PathBuf>, schema: &TableSchema) -> ReadBack {
+    let mut merger = KWayMerger::new(inputs, schema).expect("KWayMerger::new");
+    let mut live_rows = Vec::new();
+    let mut markers = Vec::new();
+    loop {
+        match merger.step().expect("merger step") {
+            MergeStep::Complete => break,
+            MergeStep::Partition { rows, .. } => {
+                for entry in rows {
+                    let id = decode_id(&entry.key.key, schema);
+                    if let Some(rt) = &entry.range_deletion {
+                        markers.push((id, rt.clone()));
+                        continue;
+                    }
+                    if let RowData::Live { cells } = &entry.row_data {
+                        // A genuine data row has at least one non-key cell.
+                        let has_data = cells.iter().any(|c| c.column != "ck" && c.column != "id");
+                        if has_data {
+                            if let Some(ck) = entry.clustering_key.as_ref().and_then(ck_value) {
+                                live_rows.push((id, ck));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    live_rows.sort_unstable();
+    ReadBack { live_rows, markers }
+}
+
+fn decode_id(key_bytes: &[u8], schema: &TableSchema) -> i32 {
+    let pk = PartitionKey::from_bytes(key_bytes, schema).expect("decode pk");
+    match &pk.columns[0].1 {
+        Value::Integer(n) => *n,
+        other => panic!("unexpected pk value {other:?}"),
+    }
+}
+
+fn ck_value(ck: &ClusteringKey) -> Option<i32> {
+    match ck.columns.first().map(|(_, v)| v) {
+        Some(Value::Integer(n)) => Some(*n),
+        _ => None,
+    }
+}
+
+fn compact(inputs: Vec<PathBuf>, out_dir: &Path, schema: &TableSchema, generation: u64) -> PathBuf {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    let report = rt
+        .block_on(compact_sstables(
+            inputs, out_dir, schema, generation, None, None, /* purge_safe */ true,
+        ))
+        .expect("compaction");
+    report.output.data_path
+}
+
+/// Core deliverable: a bounded range tombstone `[1, 3]` from a SEPARATE SSTable
+/// shadows the covered rows during compaction AND the marker is persisted.
+#[test]
+fn bounded_range_tombstone_shadows_and_persists() {
+    let schema = schema(ClusteringOrder::Asc);
+    let temp = TempDir::new().unwrap();
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let data_dir = temp.path().join("inputs");
+    let mut engine = WriteEngine::new(WriteEngineConfig::new(
+        data_dir.clone(),
+        temp.path().join("wal"),
+        schema.clone(),
+    ))
+    .unwrap();
+
+    // SSTable A: rows ck 0..=4 at ts=100.
+    flush_batch(
+        &mut engine,
+        &rt,
+        (0..=4)
+            .map(|ck| write_row(1, ck, &format!("v{ck}"), 100))
+            .collect(),
+    );
+    // SSTable B: range tombstone covering [1, 3] at ts=200.
+    flush_batch(
+        &mut engine,
+        &rt,
+        vec![range_delete(1, incl(1), incl(3), 200)],
+    );
+    rt.block_on(engine.close()).unwrap();
+
+    let inputs = discover_inputs(&data_dir);
+    assert!(
+        inputs.len() >= 2,
+        "expected >= 2 input generations, got {}",
+        inputs.len()
+    );
+
+    // Compact A + B.
+    let out_dir = temp.path().join("out1");
+    let output = compact(inputs, &out_dir, &schema, 1001);
+
+    let rb = read_back(vec![output.clone()], &schema);
+
+    // ck 1,2,3 covered and suppressed; ck 0,4 survive.
+    assert_eq!(
+        rb.live_rows,
+        vec![(1, 0), (1, 4)],
+        "only ck 0 and 4 survive the [1,3] range tombstone"
+    );
+
+    // The surviving marker is persisted to the output (writer→reader round-trip).
+    assert_eq!(rb.markers.len(), 1, "exactly one range marker persisted");
+    let (mid, rtomb) = &rb.markers[0];
+    assert_eq!(*mid, 1);
+    assert_eq!(rtomb.deletion_time, 200);
+    assert!(
+        matches!(&rtomb.start, ClusteringBound::Inclusive(k) if ck_value(k) == Some(1)),
+        "start bound is INCL(1), got {:?}",
+        rtomb.start
+    );
+    assert!(
+        matches!(&rtomb.end, ClusteringBound::Inclusive(k) if ck_value(k) == Some(3)),
+        "end bound is INCL(3), got {:?}",
+        rtomb.end
+    );
+
+    // Cross-SSTable safety: a fresh, NON-compacted SSTable re-introduces the
+    // covered rows at an OLDER timestamp. Re-compacting output1 + C must keep them
+    // shadowed (the persisted marker covers them) — proving we did not silently
+    // drop cells without persisting the shadowing marker.
+    let data_dir2 = temp.path().join("inputs2");
+    let mut engine2 = WriteEngine::new(WriteEngineConfig::new(
+        data_dir2.clone(),
+        temp.path().join("wal2"),
+        schema.clone(),
+    ))
+    .unwrap();
+    flush_batch(
+        &mut engine2,
+        &rt,
+        vec![
+            write_row(1, 1, "resurrect-1", 100),
+            write_row(1, 2, "resurrect-2", 100),
+            write_row(1, 3, "resurrect-3", 100),
+        ],
+    );
+    rt.block_on(engine2.close()).unwrap();
+    let c = discover_inputs(&data_dir2);
+    assert_eq!(c.len(), 1);
+
+    // output1 is the newest generation (1001) so it must sort first.
+    let mut inputs2 = vec![output];
+    inputs2.extend(c);
+    let out_dir2 = temp.path().join("out2");
+    let output2 = compact(inputs2, &out_dir2, &schema, 1002);
+
+    let rb2 = read_back(vec![output2], &schema);
+    assert_eq!(
+        rb2.live_rows,
+        vec![(1, 0), (1, 4)],
+        "covered rows from the non-compacted SSTable stay shadowed by the persisted marker"
+    );
+}
+
+/// Open-ended ranges: `[2, Top]` (open-to-top) and `[Bottom, 1]` (open-from-bottom)
+/// round-trip through compaction and shadow the correct rows.
+#[test]
+fn open_ended_range_tombstones() {
+    let schema = schema(ClusteringOrder::Asc);
+    let temp = TempDir::new().unwrap();
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let data_dir = temp.path().join("inputs");
+    let mut engine = WriteEngine::new(WriteEngineConfig::new(
+        data_dir.clone(),
+        temp.path().join("wal"),
+        schema.clone(),
+    ))
+    .unwrap();
+
+    // SSTable A: id=2 ck 0..=3, id=3 ck 0..=3.
+    let mut rows = Vec::new();
+    for ck in 0..=3 {
+        rows.push(write_row(2, ck, &format!("p2-{ck}"), 100));
+        rows.push(write_row(3, ck, &format!("p3-{ck}"), 100));
+    }
+    flush_batch(&mut engine, &rt, rows);
+
+    // SSTable B: id=2 open-to-top [2, Top]; id=3 open-from-bottom [Bottom, 1].
+    flush_batch(
+        &mut engine,
+        &rt,
+        vec![
+            range_delete(2, incl(2), ClusteringBound::Top, 200),
+            range_delete(3, ClusteringBound::Bottom, incl(1), 200),
+        ],
+    );
+    rt.block_on(engine.close()).unwrap();
+
+    let inputs = discover_inputs(&data_dir);
+    let out_dir = temp.path().join("out");
+    let output = compact(inputs, &out_dir, &schema, 2001);
+    let rb = read_back(vec![output], &schema);
+
+    // id=2: [2, Top] removes ck 2,3 → ck 0,1 survive.
+    // id=3: [Bottom, 1] removes ck 0,1 → ck 2,3 survive.
+    assert_eq!(
+        rb.live_rows,
+        vec![(2, 0), (2, 1), (3, 2), (3, 3)],
+        "open-to-top and open-from-bottom ranges shadow the correct rows"
+    );
+
+    // Both markers persist with their open bounds intact.
+    let mut p2 = None;
+    let mut p3 = None;
+    for (id, m) in &rb.markers {
+        match id {
+            2 => p2 = Some(m.clone()),
+            3 => p3 = Some(m.clone()),
+            other => panic!("unexpected marker partition {other}"),
+        }
+    }
+    let p2 = p2.expect("id=2 marker persisted");
+    assert!(
+        matches!(p2.end, ClusteringBound::Top),
+        "id=2 end is Top, got {:?}",
+        p2.end
+    );
+    assert!(
+        matches!(&p2.start, ClusteringBound::Inclusive(k) if ck_value(k) == Some(2)),
+        "id=2 start is INCL(2), got {:?}",
+        p2.start
+    );
+
+    let p3 = p3.expect("id=3 marker persisted");
+    assert!(
+        matches!(p3.start, ClusteringBound::Bottom),
+        "id=3 start is Bottom, got {:?}",
+        p3.start
+    );
+    assert!(
+        matches!(&p3.end, ClusteringBound::Inclusive(k) if ck_value(k) == Some(1)),
+        "id=3 end is INCL(1), got {:?}",
+        p3.end
+    );
+}
+
+/// A cell strictly NEWER than the range tombstone survives (per-cell shadow
+/// boundary `<=`), while older cells in the covered range are suppressed.
+#[test]
+fn newer_cell_survives_range_tombstone() {
+    let schema = schema(ClusteringOrder::Asc);
+    let temp = TempDir::new().unwrap();
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let data_dir = temp.path().join("inputs");
+    let mut engine = WriteEngine::new(WriteEngineConfig::new(
+        data_dir.clone(),
+        temp.path().join("wal"),
+        schema.clone(),
+    ))
+    .unwrap();
+
+    // A: ck 1 (ts=100, older), ck 2 (ts=100, older), ck 3 (ts=300, NEWER).
+    flush_batch(
+        &mut engine,
+        &rt,
+        vec![
+            write_row(5, 1, "old-1", 100),
+            write_row(5, 2, "old-2", 100),
+            write_row(5, 3, "new-3", 300),
+        ],
+    );
+    // B: range [1, 3] at ts=200.
+    flush_batch(
+        &mut engine,
+        &rt,
+        vec![range_delete(5, incl(1), incl(3), 200)],
+    );
+    rt.block_on(engine.close()).unwrap();
+
+    let inputs = discover_inputs(&data_dir);
+    let out_dir = temp.path().join("out");
+    let output = compact(inputs, &out_dir, &schema, 3001);
+    let rb = read_back(vec![output], &schema);
+
+    // ck 1,2 (ts=100 <= 200) shadowed; ck 3 (ts=300 > 200) survives.
+    assert_eq!(
+        rb.live_rows,
+        vec![(5, 3)],
+        "only the row written strictly after the range deletion survives"
+    );
+}
+
+/// DESC clustering order: the schema-aware bound comparison must honor the
+/// reversed order so a `[1, 3]` range still covers ck 1,2,3 (issue #933 / roborev
+/// #959 Medium #3 — comparing with `ClusteringKey::compare`, not schema-agnostic
+/// `cmp`).
+#[test]
+fn desc_clustering_order_honored() {
+    let schema = schema(ClusteringOrder::Desc);
+    let temp = TempDir::new().unwrap();
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let data_dir = temp.path().join("inputs");
+    let mut engine = WriteEngine::new(WriteEngineConfig::new(
+        data_dir.clone(),
+        temp.path().join("wal"),
+        schema.clone(),
+    ))
+    .unwrap();
+
+    flush_batch(
+        &mut engine,
+        &rt,
+        (0..=4)
+            .map(|ck| write_row(9, ck, &format!("d{ck}"), 100))
+            .collect(),
+    );
+    // Under DESC the on-disk clustering order is 4,3,2,1,0, so the range deleting
+    // ck ∈ {1,2,3} has its START bound at the value that sorts FIRST (3) and its
+    // END bound at the value that sorts LAST (1) — exactly how Cassandra
+    // normalizes a slice on a reversed column. Coverage must be computed
+    // schema-aware (DESC), so ck 1,2,3 are covered and ck 0,4 survive.
+    flush_batch(
+        &mut engine,
+        &rt,
+        vec![range_delete(9, incl(3), incl(1), 200)],
+    );
+    rt.block_on(engine.close()).unwrap();
+
+    let inputs = discover_inputs(&data_dir);
+    let out_dir = temp.path().join("out");
+    let output = compact(inputs, &out_dir, &schema, 4001);
+    let rb = read_back(vec![output], &schema);
+
+    assert_eq!(
+        rb.live_rows,
+        vec![(9, 0), (9, 4)],
+        "DESC range [1,3] still covers ck 1,2,3 (schema-aware bound comparison)"
+    );
+}

--- a/cqlite-core/tests/test_issue_827_streaming_parity.rs
+++ b/cqlite-core/tests/test_issue_827_streaming_parity.rs
@@ -257,6 +257,8 @@ async fn test_streaming_parity_chunk_straddle_wide_partition() {
             .iter()
             .any(|c| matches!(&c.value, Value::Text(s) if s.len() >= 48 * 1024)),
         CompactionRowData::Tombstone { .. } => false,
+        // Issue #933: range-tombstone markers carry no inline cell values.
+        CompactionRowData::RangeMarker { .. } => false,
     });
     assert!(
         has_big,


### PR DESCRIPTION
Closes #933.

Wires range-tombstone handling through the **entire** compaction pipeline so a range delete read from an input SSTable shadows the cells it covers **and** its marker is persisted to the output. Previously the v5 reader only *skipped* range markers, leaving the merge-layer shadowing dormant and unsafe to activate alone (it would resurrect rows from non-compacted SSTables).

## What changed

### 1. Reader — surface range markers (`v5_compressed_legacy.rs`)
The compaction parser (`parse_one_partition_for_compaction`) now **parses and pairs** range-tombstone bound markers instead of skipping them:
- simple `INCL_START`/`EXCL_START` + `INCL_END`/`EXCL_END` pairs,
- `EXCL_END_INCL_START` / `INCL_END_EXCL_START` boundary markers (close one range, open the next),
- open-ended ranges (the writer emits `Bottom`/`Top` as a zero-value inclusive bound → decoded back to `Bottom`/`Top`).

It surfaces each complete range — including its `localDeletionTime` (decoded with the same `hasUIntDeletionTime` reinterpretation as row deletions) — through a new `CompactionRowData::RangeMarker` on the compaction read contract.

### 2. Merge — schema-aware shadowing + re-emit (`merge.rs`)
Range markers become carrier `MergeEntry`s routed into the partition's `None` bucket. `merge_partition_rows`:
- extracts them and canonicalizes overlapping duplicates (identical bounds → newest deletion),
- computes the covering deletion floor **per cluster** via `range_tombstone_covers_ck` — **schema-aware, honoring DESC** via `ClusteringKey::compare` (roborev #959 Medium #3), with prefix-bound support,
- `apply_range_shadowing` drops every covered data cell by **its own writetime** (`ts <= floor`, `<=` so a deletion wins an equal-ts tie), keeping clustering pseudo-cells when any data survives — this per-cell granularity is something the writer alone cannot do (simple cells lose their individual writetimes once converted to a mutation),
- re-emits the surviving markers with gc_grace retention.

### 3. Writer — persist markers
`merge_entry_to_mutation` threads the surviving range onto `mutation.range_tombstones`, which the writer already serializes as on-disk bound markers and uses to shadow same-partition rows. Range carriers are no longer dropped as metadata-only no-ops (`is_metadata_only_no_op` redefined to mean a truly-empty phantom entry).

## Safety property (roborev #959 High #2)
Shadowing covered cells **without** persisting the marker would resurrect rows from a non-compacted SSTable. The new test proves the marker persists by **re-compacting** the output against a fresh SSTable that re-introduces the covered rows at an older timestamp — they stay shadowed.

## Tests
New `cqlite-core/tests/issue_933_range_tombstone_compaction.rs`:
- bounded `[1,3]` range shadows + persists, with writer→reader round-trip of the marker bounds,
- open-to-top `[2,Top]` and open-from-bottom `[Bottom,1]`,
- a cell written **strictly after** the range deletion survives,
- DESC clustering order honored,
- cross-SSTable shadowing via re-compaction.

## Validation
- `cargo fmt --all --check` ✅
- `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features` ✅
- All `cqlite-core --features write-support` tests (lib + every integration target incl. `issue_933`, `issue_819` differential compaction, `issue_672`, roundtrip) ✅
- 2130 lib unit tests ✅

Behavior is neutral for inputs without range tombstones (empty range set → `apply_range_shadowing` returns entries unchanged), and the user-facing scan/get read path is untouched.

https://claude.ai/code/session_01712Lzy82K84efumhAMsZna

---
_Generated by [Claude Code](https://claude.ai/code/session_01712Lzy82K84efumhAMsZna)_