### PR TITLE
Partition-targeted lookup for fully-constrained WHERE pk = ? (#949)

### DIFF
--- a/cqlite-core/src/query/select_executor.rs
+++ b/cqlite-core/src/query/select_executor.rs
@@ -402,6 +402,43 @@ pub fn build_row_from_scan(
     })
 }
 
+/// If the pushed-down predicates fully constrain the partition key with
+/// equality, return the raw on-disk partition-key bytes so the scan can be
+/// turned into a partition-targeted lookup (Issue #949).
+///
+/// Returns `None` — and the caller falls back to a full table scan — when:
+/// - no schema is available (we cannot identify the partition-key columns),
+/// - any partition-key column is missing an `=` predicate (partial key, or an
+///   `IN`/range restriction — those still require the scan path today), or
+/// - the constrained values cannot be encoded to the on-disk key form (e.g. a
+///   type mismatch), in which case a full scan is the safe, correct fallback.
+///
+/// Only an all-equality restriction over the complete partition key qualifies,
+/// mirroring Cassandra's requirement for a single-partition read.
+#[cfg(not(feature = "tombstones"))]
+fn full_partition_key_lookup(
+    predicates: &[SSTablePredicate],
+    schema: Option<&crate::schema::TableSchema>,
+) -> Option<Vec<u8>> {
+    use super::select_optimizer::SSTableFilterOp;
+
+    let schema = schema?;
+    if schema.partition_keys.is_empty() {
+        return None;
+    }
+
+    let mut values = Vec::with_capacity(schema.partition_keys.len());
+    for pk in &schema.partition_keys {
+        let predicate = predicates
+            .iter()
+            .find(|p| p.column == pk.name && matches!(p.operation, SSTableFilterOp::Equal))?;
+        // An `Equal` predicate always carries exactly one value.
+        values.push(predicate.values.first()?.clone());
+    }
+
+    crate::storage::partition_key_codec::encode_partition_key_columns(&values, schema).ok()
+}
+
 /// Apply an `ArithmeticOperator` to two same-typed numeric `Value`s.
 ///
 /// Behaviour matches the previous inline implementations: same-type only
@@ -1118,6 +1155,57 @@ impl SelectExecutor {
                         .find_schema_by_table(&keyspace, &table_name)
                         .await;
 
+                    // Issue #949: a fully-constrained `WHERE pk = ?` is served by a
+                    // partition-targeted lookup that prunes SSTables via bloom/BTI,
+                    // instead of streaming a scan over every SSTable. The result is
+                    // a single partition's rows, sent through the same per-row
+                    // pipeline (predicates, PER PARTITION LIMIT, OFFSET, LIMIT) as
+                    // the streaming scan below.
+                    #[cfg(not(feature = "tombstones"))]
+                    if let Some(pk_bytes) =
+                        full_partition_key_lookup(predicates, schema_opt.as_ref())
+                    {
+                        let rows = storage
+                            .scan_partition(table, &pk_bytes, schema_opt.as_ref())
+                            .await?;
+                        for (key, value) in rows {
+                            let part_sig = per_partition_limit.map(|_| key.0.clone());
+                            let Some(row) =
+                                build_row_from_scan(key, value, projection, schema_opt.as_ref())
+                            else {
+                                continue;
+                            };
+                            if !evaluate_predicates(&row, predicates)? {
+                                continue;
+                            }
+                            if let (Some(cap), Some(sig)) = (per_partition_limit, part_sig) {
+                                if current_partition.as_deref() != Some(sig.as_slice()) {
+                                    current_partition = Some(sig);
+                                    partition_count = 0;
+                                }
+                                if partition_count >= cap {
+                                    continue;
+                                }
+                                partition_count += 1;
+                            }
+                            if offset_remaining > 0 {
+                                offset_remaining -= 1;
+                                continue;
+                            }
+                            if tx.send(Ok(row)).await.is_err() {
+                                return Ok(());
+                            }
+                            sent += 1;
+                            if let Some(count) = limit_count {
+                                if sent >= count {
+                                    return Ok(());
+                                }
+                            }
+                        }
+                        // This SSTableScan step is fully served by the lookup.
+                        continue;
+                    }
+
                     // Issue #790: pull rows lazily from a bounded streaming scan
                     // instead of materializing the full result `Vec`. The reader
                     // parses one entry at a time into this channel, so live heap
@@ -1269,10 +1357,40 @@ impl SelectExecutor {
                 }
             }
         } else {
-            let scan_results = self
-                .storage
-                .scan(table, None, None, None, schema_opt.as_ref())
-                .await?;
+            // Issue #949: a fully-constrained `WHERE pk = ?` is served by a
+            // partition-targeted lookup that prunes SSTables via bloom/BTI and only
+            // parses the candidates, instead of scanning every SSTable for the
+            // table. Falls back to a full scan when the partition key isn't fully
+            // pinned or can't be encoded. The per-row predicate evaluation below is
+            // unchanged, so clustering predicates and the pk equality itself are
+            // still applied (and any over-inclusion is filtered out).
+            let scan_results = {
+                #[cfg(not(feature = "tombstones"))]
+                {
+                    if let Some(pk_bytes) =
+                        full_partition_key_lookup(predicates, schema_opt.as_ref())
+                    {
+                        log::info!(
+                            "SSTableScan: partition-key point lookup (key len={}) for \"{}\"",
+                            pk_bytes.len(),
+                            table
+                        );
+                        self.storage
+                            .scan_partition(table, &pk_bytes, schema_opt.as_ref())
+                            .await?
+                    } else {
+                        self.storage
+                            .scan(table, None, None, None, schema_opt.as_ref())
+                            .await?
+                    }
+                }
+                #[cfg(feature = "tombstones")]
+                {
+                    self.storage
+                        .scan(table, None, None, None, schema_opt.as_ref())
+                        .await?
+                }
+            };
 
             log::info!("Scan returned {} rows", scan_results.len());
 

--- a/cqlite-core/src/query/select_executor.rs
+++ b/cqlite-core/src/query/select_executor.rs
@@ -415,7 +415,6 @@ pub fn build_row_from_scan(
 ///
 /// Only an all-equality restriction over the complete partition key qualifies,
 /// mirroring Cassandra's requirement for a single-partition read.
-#[cfg(not(feature = "tombstones"))]
 fn full_partition_key_lookup(
     predicates: &[SSTablePredicate],
     schema: Option<&crate::schema::TableSchema>,
@@ -1164,7 +1163,6 @@ impl SelectExecutor {
                     // materializing `scan()` (last-write-wins + tombstone shadowing),
                     // which is the authoritative read semantics; it does not merely
                     // mirror `scan_stream`'s per-key merge.
-                    #[cfg(not(feature = "tombstones"))]
                     if let Some(pk_bytes) =
                         full_partition_key_lookup(predicates, schema_opt.as_ref())
                     {
@@ -1367,32 +1365,21 @@ impl SelectExecutor {
             // pinned or can't be encoded. The per-row predicate evaluation below is
             // unchanged, so clustering predicates and the pk equality itself are
             // still applied (and any over-inclusion is filtered out).
-            let scan_results = {
-                #[cfg(not(feature = "tombstones"))]
-                {
-                    if let Some(pk_bytes) =
-                        full_partition_key_lookup(predicates, schema_opt.as_ref())
-                    {
-                        log::info!(
-                            "SSTableScan: partition-key point lookup (key len={}) for \"{}\"",
-                            pk_bytes.len(),
-                            table
-                        );
-                        self.storage
-                            .scan_partition(table, &pk_bytes, schema_opt.as_ref())
-                            .await?
-                    } else {
-                        self.storage
-                            .scan(table, None, None, None, schema_opt.as_ref())
-                            .await?
-                    }
-                }
-                #[cfg(feature = "tombstones")]
-                {
-                    self.storage
-                        .scan(table, None, None, None, schema_opt.as_ref())
-                        .await?
-                }
+            let scan_results = if let Some(pk_bytes) =
+                full_partition_key_lookup(predicates, schema_opt.as_ref())
+            {
+                log::info!(
+                    "SSTableScan: partition-key point lookup (key len={}) for \"{}\"",
+                    pk_bytes.len(),
+                    table
+                );
+                self.storage
+                    .scan_partition(table, &pk_bytes, schema_opt.as_ref())
+                    .await?
+            } else {
+                self.storage
+                    .scan(table, None, None, None, schema_opt.as_ref())
+                    .await?
             };
 
             log::info!("Scan returned {} rows", scan_results.len());

--- a/cqlite-core/src/query/select_executor.rs
+++ b/cqlite-core/src/query/select_executor.rs
@@ -1157,10 +1157,13 @@ impl SelectExecutor {
 
                     // Issue #949: a fully-constrained `WHERE pk = ?` is served by a
                     // partition-targeted lookup that prunes SSTables via bloom/BTI,
-                    // instead of streaming a scan over every SSTable. The result is
-                    // a single partition's rows, sent through the same per-row
-                    // pipeline (predicates, PER PARTITION LIMIT, OFFSET, LIMIT) as
-                    // the streaming scan below.
+                    // instead of streaming a scan over every SSTable. The resulting
+                    // rows are sent through the same per-row pipeline below
+                    // (predicates, PER PARTITION LIMIT, OFFSET, LIMIT). Note
+                    // `scan_partition` reconciles across SSTable generations like the
+                    // materializing `scan()` (last-write-wins + tombstone shadowing),
+                    // which is the authoritative read semantics; it does not merely
+                    // mirror `scan_stream`'s per-key merge.
                     #[cfg(not(feature = "tombstones"))]
                     if let Some(pk_bytes) =
                         full_partition_key_lookup(predicates, schema_opt.as_ref())

--- a/cqlite-core/src/storage/mod.rs
+++ b/cqlite-core/src/storage/mod.rs
@@ -219,6 +219,25 @@ impl StorageEngine {
             .await
     }
 
+    /// Partition-targeted scan for a fully-constrained `WHERE pk = ?` (Issue #949).
+    ///
+    /// Returns only the rows for the single partition identified by the raw
+    /// `partition_key` bytes, after pruning the SSTable set down to those whose
+    /// bloom filter / BTI trie admit the key — so unrelated SSTables are never
+    /// parsed. Output matches filtering the full [`scan`](Self::scan) result to the
+    /// partition. Delegates to [`SSTableManager::scan_partition`].
+    #[cfg(not(feature = "tombstones"))]
+    pub async fn scan_partition(
+        &self,
+        table_id: &TableId,
+        partition_key: &[u8],
+        schema: Option<&crate::schema::TableSchema>,
+    ) -> Result<Vec<(RowKey, Value)>> {
+        self.sstables
+            .scan_partition(table_id, partition_key, schema)
+            .await
+    }
+
     /// Scan a table and return per-cell write metadata alongside row values.
     ///
     /// Delegates to [`SSTableManager::scan_with_cell_metadata`].  Used when

--- a/cqlite-core/src/storage/mod.rs
+++ b/cqlite-core/src/storage/mod.rs
@@ -225,8 +225,9 @@ impl StorageEngine {
     /// `partition_key` bytes, after pruning the SSTable set down to those whose
     /// bloom filter / BTI trie admit the key — so unrelated SSTables are never
     /// parsed. Output matches filtering the full [`scan`](Self::scan) result to the
-    /// partition. Delegates to [`SSTableManager::scan_partition`].
-    #[cfg(not(feature = "tombstones"))]
+    /// partition. Delegates to [`SSTableManager::scan_partition`] (which has a
+    /// bloom-prune implementation for the default build and a scan-and-filter
+    /// fallback for the `tombstones` build, so callers need no cfg branching).
     pub async fn scan_partition(
         &self,
         table_id: &TableId,

--- a/cqlite-core/src/storage/partition_key_codec.rs
+++ b/cqlite-core/src/storage/partition_key_codec.rs
@@ -526,4 +526,59 @@ mod tests {
         let schema = schema_with_pks(&[("id", "int")]);
         assert!(encode_partition_key_columns(&[Value::BigInt(i64::MAX)], &schema).is_err());
     }
+
+    /// Drift guard (review follow-up): this module's encoder must stay
+    /// byte-for-byte identical to the write engine's `PartitionKey::to_bytes`,
+    /// because a write persists keys with one and the read-side bloom/BTI prune
+    /// matches with the other. If they ever diverge, a `WHERE pk = ?` could prune
+    /// away the very SSTable holding the row. Values are pre-typed so no coercion
+    /// is involved — we're comparing the raw serializers and framing directly.
+    #[cfg(feature = "write-support")]
+    #[test]
+    fn encoder_matches_write_engine_partition_key_to_bytes() {
+        use crate::storage::write_engine::mutation::PartitionKey;
+
+        let uuid = [
+            0u8, 35, 236, 231, 124, 78, 71, 5, 144, 104, 209, 165, 158, 197, 254, 25,
+        ];
+        let cases: Vec<(Vec<(&str, &str)>, Vec<(&str, Value)>)> = vec![
+            (
+                vec![("id", "text")],
+                vec![("id", Value::Text("k123".to_string()))],
+            ),
+            (vec![("id", "int")], vec![("id", Value::Integer(42))]),
+            (vec![("id", "bigint")], vec![("id", Value::BigInt(-7))]),
+            (vec![("id", "uuid")], vec![("id", Value::Uuid(uuid))]),
+            (
+                vec![("app", "text"), ("metric", "text")],
+                vec![
+                    ("app", Value::Text("a".to_string())),
+                    ("metric", Value::Text("view".to_string())),
+                ],
+            ),
+            (
+                vec![("app", "text"), ("part", "int")],
+                vec![
+                    ("app", Value::Text("svc".to_string())),
+                    ("part", Value::Integer(3)),
+                ],
+            ),
+        ];
+
+        for (pks, values) in cases {
+            let schema = schema_with_pks(&pks);
+            let value_only: Vec<Value> = values.iter().map(|(_, v)| v.clone()).collect();
+            let columns: Vec<(String, Value)> = values
+                .iter()
+                .map(|(n, v)| (n.to_string(), v.clone()))
+                .collect();
+
+            let codec_bytes = encode_partition_key_columns(&value_only, &schema).unwrap();
+            let write_bytes = PartitionKey::new(columns).to_bytes(&schema).unwrap();
+            assert_eq!(
+                codec_bytes, write_bytes,
+                "codec encoder and write-engine PartitionKey::to_bytes disagree for {pks:?}",
+            );
+        }
+    }
 }

--- a/cqlite-core/src/storage/partition_key_codec.rs
+++ b/cqlite-core/src/storage/partition_key_codec.rs
@@ -88,6 +88,152 @@ pub fn decode_partition_key_columns(
     Ok(columns)
 }
 
+/// Encode partition-key column values into the raw on-disk partition-key bytes.
+///
+/// This is the inverse of [`decode_partition_key_columns`] and produces byte-for-byte
+/// the same layout the write path emits (`PartitionKey::to_bytes`):
+///
+/// - **Single-component keys** — raw value bytes, no length prefix.
+/// - **Multi-component (composite) keys** — `[len:u16 BE][value bytes][0x00]` per
+///   component, including a trailing `0x00` after the final component.
+///
+/// `values` must be in schema-declared partition-key order and have exactly one
+/// entry per partition-key column. Because the encoding reproduces the on-disk raw
+/// key bytes exactly, the result can be matched directly against (a) the partition
+/// RowKeys returned by a scan and (b) the bloom filter / BTI trie, which are keyed
+/// on the same raw bytes. Used by the query engine to turn a fully-constrained
+/// `WHERE pk = ?` into a partition-targeted lookup.
+///
+/// Returns an error (so callers can fall back to a full scan) when the column count
+/// disagrees with the schema or a value cannot be serialized for its declared type.
+pub fn encode_partition_key_columns(values: &[Value], schema: &TableSchema) -> Result<Vec<u8>> {
+    if schema.partition_keys.is_empty() {
+        return Err(Error::InvalidInput(
+            "Schema has no partition keys".to_string(),
+        ));
+    }
+    if values.len() != schema.partition_keys.len() {
+        return Err(Error::InvalidInput(format!(
+            "Partition key column count mismatch: expected {}, got {}",
+            schema.partition_keys.len(),
+            values.len()
+        )));
+    }
+
+    // Single-component key: raw value bytes, no length prefix.
+    if schema.partition_keys.len() == 1 {
+        let comparator = ComparatorType::from_data_type(&schema.partition_keys[0].data_type)?;
+        let coerced = coerce_value_for_comparator(&values[0], &comparator);
+        return serialize_value_bytes(&coerced, &comparator);
+    }
+
+    // Multi-component: [len:u16 BE][value bytes][0x00] per component.
+    let mut result = Vec::new();
+    for (key_col, value) in schema.partition_keys.iter().zip(values.iter()) {
+        let comparator = ComparatorType::from_data_type(&key_col.data_type)?;
+        let coerced = coerce_value_for_comparator(value, &comparator);
+        let value_bytes = serialize_value_bytes(&coerced, &comparator)?;
+        if value_bytes.len() > u16::MAX as usize {
+            return Err(Error::InvalidInput(format!(
+                "Partition key component too large: {} bytes",
+                value_bytes.len()
+            )));
+        }
+        result.extend_from_slice(&(value_bytes.len() as u16).to_be_bytes());
+        result.extend_from_slice(&value_bytes);
+        result.push(0x00);
+    }
+    Ok(result)
+}
+
+/// Best-effort coercion of a parsed CQL literal `Value` to the variant the
+/// partition-key serializer expects for `comparator`.
+///
+/// The SELECT parser emits every integer literal as [`Value::BigInt`], so a
+/// `WHERE id = 5` against an `int`/`smallint`/`tinyint`/`timestamp` partition key
+/// would otherwise fail to serialize. This narrows those numeric literals to the
+/// declared type (only when the value fits); every other case is returned
+/// unchanged so an unrepresentable value falls through to a serialization error
+/// and the caller reverts to a full scan.
+fn coerce_value_for_comparator(value: &Value, comparator: &ComparatorType) -> Value {
+    match (value, comparator) {
+        (Value::BigInt(n), ComparatorType::Int)
+            if *n >= i32::MIN as i64 && *n <= i32::MAX as i64 =>
+        {
+            Value::Integer(*n as i32)
+        }
+        (Value::BigInt(n), ComparatorType::SmallInt)
+            if *n >= i16::MIN as i64 && *n <= i16::MAX as i64 =>
+        {
+            Value::SmallInt(*n as i16)
+        }
+        (Value::BigInt(n), ComparatorType::TinyInt)
+            if *n >= i8::MIN as i64 && *n <= i8::MAX as i64 =>
+        {
+            Value::TinyInt(*n as i8)
+        }
+        (Value::BigInt(n), ComparatorType::Timestamp) => Value::Timestamp(*n),
+        (Value::Integer(n), ComparatorType::BigInt) => Value::BigInt(*n as i64),
+        _ => value.clone(),
+    }
+}
+
+/// Serialize a single partition-key value to its raw on-disk bytes.
+///
+/// Mirrors the write engine's `serialize_value_bytes`
+/// ([`crate::storage::write_engine::mutation`]); kept here as the inverse of
+/// [`deserialize_value_bytes`] so the read-side encoder has no dependency on the
+/// (feature-gated) write engine.
+fn serialize_value_bytes(value: &Value, comparator: &ComparatorType) -> Result<Vec<u8>> {
+    match (value, comparator) {
+        (Value::Boolean(b), ComparatorType::Boolean) => Ok(vec![u8::from(*b)]),
+        (Value::TinyInt(n), ComparatorType::TinyInt) => Ok(vec![*n as u8]),
+        (Value::SmallInt(n), ComparatorType::SmallInt) => Ok(n.to_be_bytes().to_vec()),
+        (Value::Integer(n), ComparatorType::Int) => Ok(n.to_be_bytes().to_vec()),
+        (Value::BigInt(n), ComparatorType::BigInt) => Ok(n.to_be_bytes().to_vec()),
+        (Value::Counter(n), ComparatorType::Counter) => Ok(n.to_be_bytes().to_vec()),
+        (Value::Float32(f), ComparatorType::Float32) => Ok(f.to_bits().to_be_bytes().to_vec()),
+        (Value::Float(f), ComparatorType::Float) => Ok(f.to_bits().to_be_bytes().to_vec()),
+        (Value::Text(s), ComparatorType::Text) => Ok(s.as_bytes().to_vec()),
+        (Value::Blob(bytes), ComparatorType::Blob) => Ok(bytes.clone()),
+        (Value::Timestamp(millis), ComparatorType::Timestamp) => Ok(millis.to_be_bytes().to_vec()),
+        (Value::Date(days), ComparatorType::Date) => {
+            let stored = days.wrapping_sub(i32::MIN) as u32;
+            Ok(stored.to_be_bytes().to_vec())
+        }
+        (Value::Uuid(bytes), ComparatorType::Uuid) => Ok(bytes.to_vec()),
+        (Value::Time(nanos), ComparatorType::Custom(name)) if name == "time" => {
+            Ok(nanos.to_be_bytes().to_vec())
+        }
+        (Value::Inet(bytes), ComparatorType::Custom(name)) if name == "inet" => Ok(bytes.clone()),
+        (Value::Varint(bytes), ComparatorType::Varint) => Ok(bytes.clone()),
+        (Value::Decimal { scale, unscaled }, ComparatorType::Decimal) => {
+            let mut result = Vec::with_capacity(4 + unscaled.len());
+            result.extend_from_slice(&scale.to_be_bytes());
+            result.extend_from_slice(unscaled);
+            Ok(result)
+        }
+        (
+            Value::Duration {
+                months,
+                days,
+                nanos,
+            },
+            ComparatorType::Duration,
+        ) => {
+            let mut result = Vec::with_capacity(16);
+            result.extend_from_slice(&months.to_be_bytes());
+            result.extend_from_slice(&days.to_be_bytes());
+            result.extend_from_slice(&nanos.to_be_bytes());
+            Ok(result)
+        }
+        _ => Err(Error::InvalidInput(format!(
+            "Type mismatch encoding partition key: value {:?} does not match comparator {:?}",
+            value, comparator
+        ))),
+    }
+}
+
 /// Deserialize a single raw value from its byte-comparable key encoding.
 ///
 /// `data` is the raw value bytes for one component (no length prefix). This is
@@ -311,5 +457,73 @@ mod tests {
     fn empty_bytes_error() {
         let schema = schema_with_pks(&[("id", "text")]);
         assert!(decode_partition_key_columns(&[], &schema).is_err());
+    }
+
+    #[test]
+    fn encode_single_text_pk_is_raw_bytes() {
+        let schema = schema_with_pks(&[("id", "text")]);
+        let bytes =
+            encode_partition_key_columns(&[Value::Text("k0000000000000000".to_string())], &schema)
+                .unwrap();
+        assert_eq!(bytes, b"k0000000000000000");
+    }
+
+    #[test]
+    fn encode_decode_roundtrip_single_uuid() {
+        let schema = schema_with_pks(&[("id", "uuid")]);
+        let raw = [
+            0u8, 35, 236, 231, 124, 78, 71, 5, 144, 104, 209, 165, 158, 197, 254, 25,
+        ];
+        let bytes = encode_partition_key_columns(&[Value::Uuid(raw)], &schema).unwrap();
+        assert_eq!(bytes, raw);
+        let decoded = decode_partition_key_columns(&bytes, &schema).unwrap();
+        assert_eq!(decoded, vec![("id".to_string(), Value::Uuid(raw))]);
+    }
+
+    #[test]
+    fn encode_decode_roundtrip_composite() {
+        let schema = schema_with_pks(&[("application_id", "text"), ("metric_name", "text")]);
+        let values = vec![
+            Value::Text("a".to_string()),
+            Value::Text("view".to_string()),
+        ];
+        let bytes = encode_partition_key_columns(&values, &schema).unwrap();
+        // [len=1]['a'][0x00][len=4]["view"][0x00]
+        assert_eq!(
+            bytes,
+            vec![0u8, 1, b'a', 0, 0, 4, b'v', b'i', b'e', b'w', 0]
+        );
+        let decoded = decode_partition_key_columns(&bytes, &schema).unwrap();
+        assert_eq!(
+            decoded,
+            vec![
+                ("application_id".to_string(), Value::Text("a".to_string())),
+                ("metric_name".to_string(), Value::Text("view".to_string())),
+            ]
+        );
+    }
+
+    #[test]
+    fn encode_coerces_bigint_literal_to_int_column() {
+        // The SELECT parser emits integer literals as Value::BigInt; an `int`
+        // partition key must still encode to the canonical 4-byte form.
+        let schema = schema_with_pks(&[("id", "int")]);
+        let bytes = encode_partition_key_columns(&[Value::BigInt(5)], &schema).unwrap();
+        assert_eq!(bytes, 5i32.to_be_bytes().to_vec());
+        let decoded = decode_partition_key_columns(&bytes, &schema).unwrap();
+        assert_eq!(decoded, vec![("id".to_string(), Value::Integer(5))]);
+    }
+
+    #[test]
+    fn encode_column_count_mismatch_errors() {
+        let schema = schema_with_pks(&[("a", "text"), ("b", "text")]);
+        assert!(encode_partition_key_columns(&[Value::Text("a".to_string())], &schema).is_err());
+    }
+
+    #[test]
+    fn encode_out_of_range_bigint_for_int_column_errors() {
+        // Too large to narrow to i32 -> serialization fails -> caller falls back to scan.
+        let schema = schema_with_pks(&[("id", "int")]);
+        assert!(encode_partition_key_columns(&[Value::BigInt(i64::MAX)], &schema).is_err());
     }
 }

--- a/cqlite-core/src/storage/partition_key_codec.rs
+++ b/cqlite-core/src/storage/partition_key_codec.rs
@@ -120,19 +120,23 @@ pub fn encode_partition_key_columns(values: &[Value], schema: &TableSchema) -> R
         )));
     }
 
+    // Serialize one component to its raw value bytes (the framing differs
+    // between single- and multi-component keys, but the value encoding does not).
+    let encode_one = |data_type: &str, value: &Value| -> Result<Vec<u8>> {
+        let comparator = ComparatorType::from_data_type(data_type)?;
+        let coerced = coerce_value_for_comparator(value, &comparator);
+        serialize_value_bytes(&coerced, &comparator)
+    };
+
     // Single-component key: raw value bytes, no length prefix.
     if schema.partition_keys.len() == 1 {
-        let comparator = ComparatorType::from_data_type(&schema.partition_keys[0].data_type)?;
-        let coerced = coerce_value_for_comparator(&values[0], &comparator);
-        return serialize_value_bytes(&coerced, &comparator);
+        return encode_one(&schema.partition_keys[0].data_type, &values[0]);
     }
 
     // Multi-component: [len:u16 BE][value bytes][0x00] per component.
     let mut result = Vec::new();
     for (key_col, value) in schema.partition_keys.iter().zip(values.iter()) {
-        let comparator = ComparatorType::from_data_type(&key_col.data_type)?;
-        let coerced = coerce_value_for_comparator(value, &comparator);
-        let value_bytes = serialize_value_bytes(&coerced, &comparator)?;
+        let value_bytes = encode_one(&key_col.data_type, value)?;
         if value_bytes.len() > u16::MAX as usize {
             return Err(Error::InvalidInput(format!(
                 "Partition key component too large: {} bytes",

--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -961,6 +961,119 @@ impl SSTableManager {
         }
     }
 
+    /// Partition-targeted scan: return only the rows for a single partition key,
+    /// touching only the SSTables whose bloom filter / BTI trie admit the key.
+    ///
+    /// This is the storage-layer fast path for a fully-constrained `WHERE pk = ?`
+    /// (Issue #949). Rather than scanning every SSTable for the table and filtering
+    /// in memory, it prunes the reader set with
+    /// [`might_contain_partition`](reader::SSTableReader::might_contain_partition)
+    /// — an O(1) bloom check for BIG format, an O(log n) trie walk for BTI — and
+    /// only parses the surviving candidates. On a table backed by thousands of
+    /// SSTables, a single-partition read drops from "open and scan all of them" to
+    /// "scan only the handful that can hold the key".
+    ///
+    /// Output is byte-for-byte identical to filtering the full [`scan`](Self::scan)
+    /// result down to `partition_key`: the same per-reader parse and the same
+    /// cross-generation reconciliation run, just over the pruned candidate set. The
+    /// caller still applies its own predicate evaluation, so any over-inclusion
+    /// (e.g. a BTI prefix-collision candidate) is filtered out downstream.
+    ///
+    /// `partition_key` is the raw on-disk partition-key bytes produced by
+    /// [`encode_partition_key_columns`](crate::storage::partition_key_codec::encode_partition_key_columns),
+    /// which match the bytes the bloom filter, Index.db/BTI trie, and scan RowKeys
+    /// are keyed on.
+    ///
+    /// Note: within a surviving SSTable this still performs a full parse (then keeps
+    /// only the matching partition). Seeking directly to the partition's Data.db
+    /// offset via Index.db/BTI for the single-candidate case is a follow-up; the
+    /// dominant win for the "thousands of SSTables" scenario is the cross-SSTable
+    /// pruning above.
+    #[cfg(not(feature = "tombstones"))]
+    pub async fn scan_partition(
+        &self,
+        table_id: &TableId,
+        partition_key: &[u8],
+        schema: Option<&crate::schema::TableSchema>,
+    ) -> Result<Vec<(RowKey, Value)>> {
+        let table_readers = self.table_readers.read().await;
+        let table_name = table_id.name();
+
+        // Same qualified-then-unqualified resolution as `scan` (Issue #680).
+        let reader_list = if table_readers.contains_key(table_name) {
+            table_readers.get(table_name)
+        } else {
+            let unqualified_name = if let Some(dot_pos) = table_name.rfind('.') {
+                &table_name[dot_pos + 1..]
+            } else {
+                table_name
+            };
+            table_readers.get(unqualified_name)
+        };
+
+        let Some(reader_list) = reader_list else {
+            return Ok(Vec::new());
+        };
+
+        // Prune: keep only SSTables whose bloom filter / BTI trie admit the key.
+        let candidates: Vec<Arc<reader::SSTableReader>> = reader_list
+            .iter()
+            .filter(|r| r.might_contain_partition(partition_key))
+            .cloned()
+            .collect();
+
+        log::debug!(
+            "SSTableManager::scan_partition - {}/{} SSTables admit partition key (len={}) for '{}'",
+            candidates.len(),
+            reader_list.len(),
+            partition_key.len(),
+            table_id
+        );
+
+        if candidates.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let matches_key = |entry: &(RowKey, Value)| entry.0.as_bytes() == partition_key;
+
+        // Multiple candidate generations may hold the same partition; reconcile
+        // with the same authoritative k-way merge the full scan uses (write-support
+        // only), then keep just this partition's rows.
+        #[cfg(feature = "write-support")]
+        if candidates.len() > 1 {
+            if let Some(schema) = schema {
+                match self
+                    .merge_generations_for_read(&candidates, schema, None)
+                    .await
+                {
+                    Ok(mut merged) => {
+                        merged.retain(matches_key);
+                        return Ok(merged);
+                    }
+                    Err(e) => {
+                        log::warn!(
+                            "SSTableManager::scan_partition - cross-generation merge failed for \
+                             '{}' ({}); falling back to per-reader concatenation",
+                            table_id,
+                            e
+                        );
+                    }
+                }
+            }
+        }
+
+        // Single candidate (the common case), or the concat fallback: parse each
+        // candidate and keep only the target partition's rows.
+        let mut all_results = Vec::new();
+        for reader in &candidates {
+            let mut results = reader.scan(table_id, None, None, None, schema).await?;
+            results.retain(matches_key);
+            all_results.extend(results);
+        }
+        all_results.sort_by(|a, b| a.0.cmp(&b.0));
+        Ok(all_results)
+    }
+
     /// Reconcile multiple SSTable generations of one table into the single
     /// authoritative live-row set, matching Cassandra read semantics (Issue #883).
     ///

--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -973,11 +973,21 @@ impl SSTableManager {
     /// SSTables, a single-partition read drops from "open and scan all of them" to
     /// "scan only the handful that can hold the key".
     ///
-    /// Output is byte-for-byte identical to filtering the full [`scan`](Self::scan)
-    /// result down to `partition_key`: the same per-reader parse and the same
-    /// cross-generation reconciliation run, just over the pruned candidate set. The
-    /// caller still applies its own predicate evaluation, so any over-inclusion
-    /// (e.g. a BTI prefix-collision candidate) is filtered out downstream.
+    /// Output matches filtering the full [`scan`](Self::scan) result down to
+    /// `partition_key`: the same per-reader parse and the same cross-generation
+    /// reconciliation run, just over the pruned candidate set. Concretely, with
+    /// more than one candidate generation this drives the authoritative k-way
+    /// merge (write-support, schema present); the single-candidate and concat
+    /// fallbacks behave exactly as the corresponding `scan` paths do — including
+    /// sharing `scan`'s known multi-generation concat limitation (Issue #883) when
+    /// the merge is unavailable. The caller still applies its own predicate
+    /// evaluation, so any over-inclusion (e.g. a BTI prefix-collision candidate) is
+    /// filtered out downstream.
+    ///
+    /// Gated on `not(tombstones)` to match the `scan` variant it parallels: the
+    /// `tombstones` build uses a structurally different reader map, so the method
+    /// is defined only for the default build (the executor falls back to a full
+    /// scan under `tombstones`).
     ///
     /// `partition_key` is the raw on-disk partition-key bytes produced by
     /// [`encode_partition_key_columns`](crate::storage::partition_key_codec::encode_partition_key_columns),

--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -721,19 +721,8 @@ impl SSTableManager {
 
         let table_name = table_id.name();
 
-        // Try exact (qualified) lookup first, then fall back to unqualified name.
-        let reader_list = if let Some(list) = table_readers.get(table_name) {
-            list
-        } else {
-            let unqualified_name = if let Some(dot_pos) = table_name.rfind('.') {
-                &table_name[dot_pos + 1..]
-            } else {
-                table_name
-            };
-            match table_readers.get(unqualified_name) {
-                Some(list) => list,
-                None => return Ok(None),
-            }
+        let Some(reader_list) = Self::resolve_reader_list(&table_readers, table_name) else {
+            return Ok(None);
         };
 
         // Return the first value found across all SSTables for this table
@@ -845,27 +834,7 @@ impl SSTableManager {
 
         let table_name = table_id.name();
 
-        // Try exact (qualified) lookup first, then fall back to unqualified name.
-        // This ensures that same-named tables in different keyspaces are correctly
-        // distinguished (Issue #680).
-        let readers = if table_readers.contains_key(table_name) {
-            log::debug!(
-                "SSTableManager::scan - Found readers via qualified name '{}'",
-                table_name
-            );
-            table_readers.get(table_name)
-        } else {
-            let unqualified_name = if let Some(dot_pos) = table_name.rfind('.') {
-                &table_name[dot_pos + 1..]
-            } else {
-                table_name
-            };
-            log::debug!(
-                "SSTableManager::scan - Falling back to unqualified name '{}'",
-                unqualified_name
-            );
-            table_readers.get(unqualified_name)
-        };
+        let readers = Self::resolve_reader_list(&table_readers, table_name);
 
         if let Some(reader_list) = readers {
             log::debug!(
@@ -1009,19 +978,7 @@ impl SSTableManager {
         let table_readers = self.table_readers.read().await;
         let table_name = table_id.name();
 
-        // Same qualified-then-unqualified resolution as `scan` (Issue #680).
-        let reader_list = if table_readers.contains_key(table_name) {
-            table_readers.get(table_name)
-        } else {
-            let unqualified_name = if let Some(dot_pos) = table_name.rfind('.') {
-                &table_name[dot_pos + 1..]
-            } else {
-                table_name
-            };
-            table_readers.get(unqualified_name)
-        };
-
-        let Some(reader_list) = reader_list else {
+        let Some(reader_list) = Self::resolve_reader_list(&table_readers, table_name) else {
             return Ok(Vec::new());
         };
 
@@ -1080,8 +1037,53 @@ impl SSTableManager {
             results.retain(matches_key);
             all_results.extend(results);
         }
-        all_results.sort_by(|a, b| a.0.cmp(&b.0));
+        // A single candidate's rows already come back in on-disk key order; only
+        // concatenating more than one candidate needs a re-sort to merge them.
+        if candidates.len() > 1 {
+            all_results.sort_by(|a, b| a.0.cmp(&b.0));
+        }
         Ok(all_results)
+    }
+
+    /// `tombstones`-build counterpart of [`scan_partition`](Self::scan_partition).
+    ///
+    /// That build uses a structurally different reader map and has no bloom-prune
+    /// `scan_partition` path, so a fully-constrained `WHERE pk = ?` is served by
+    /// scanning and filtering to the partition key. The output is a subset of
+    /// [`scan`](Self::scan) — identical to what the `not(tombstones)`
+    /// `scan_partition` returns — which keeps the query executor free of any
+    /// `tombstones` cfg branching.
+    #[cfg(feature = "tombstones")]
+    pub async fn scan_partition(
+        &self,
+        table_id: &TableId,
+        partition_key: &[u8],
+        schema: Option<&crate::schema::TableSchema>,
+    ) -> Result<Vec<(RowKey, Value)>> {
+        let mut rows = self.scan(table_id, None, None, None, schema).await?;
+        rows.retain(|entry| entry.0.as_bytes() == partition_key);
+        Ok(rows)
+    }
+
+    /// Resolve the reader list for a table id, trying the fully-qualified
+    /// `keyspace.table` name first and falling back to the bare table name, so
+    /// same-named tables in different keyspaces stay distinct (Issue #680).
+    ///
+    /// Shared by [`get`](Self::get), [`scan`](Self::scan), and
+    /// [`scan_partition`](Self::scan_partition) so the resolution rule lives in
+    /// one place and the targeted-lookup path can never drift from `scan`.
+    #[cfg(not(feature = "tombstones"))]
+    fn resolve_reader_list<'a>(
+        table_readers: &'a HashMap<String, Vec<Arc<reader::SSTableReader>>>,
+        table_name: &str,
+    ) -> Option<&'a Vec<Arc<reader::SSTableReader>>> {
+        if let Some(list) = table_readers.get(table_name) {
+            return Some(list);
+        }
+        let unqualified = table_name
+            .rfind('.')
+            .map_or(table_name, |dot| &table_name[dot + 1..]);
+        table_readers.get(unqualified)
     }
 
     /// Reconcile multiple SSTable generations of one table into the single

--- a/cqlite-core/src/storage/sstable/reader/partition_lookup.rs
+++ b/cqlite-core/src/storage/sstable/reader/partition_lookup.rs
@@ -144,6 +144,38 @@ impl SSTableReader {
         }
     }
 
+    /// Cheap presence oracle: can this SSTable possibly contain `partition_key`?
+    ///
+    /// Used to prune SSTables before a partition-targeted scan (the query engine's
+    /// `WHERE pk = ?` fast path). Returning `false` MUST be definitive — the SSTable
+    /// is then skipped entirely without being parsed — so this only ever returns
+    /// `false` for an authoritative "absent" signal:
+    ///
+    /// - **BTI ("da")** readers have no bloom filter; the Partitions.db trie is the
+    ///   authoritative present/absent oracle. A trie miss (`Ok(None)`) is definitive
+    ///   absence. A trie hit may be a prefix-collision candidate, which is a safe
+    ///   *false positive* here (the partition scan re-verifies the key). Any trie
+    ///   parse error is treated conservatively as "maybe present".
+    /// - **BIG-format** readers consult the bloom filter, which never reports false
+    ///   negatives: `might_contain == false` is definitive absence. With no bloom
+    ///   filter loaded we cannot prune, so we conservatively return `true`.
+    ///
+    /// `partition_key` must be the raw partition-key bytes (same encoding the bloom
+    /// filter and Index.db/BTI trie are keyed on).
+    pub fn might_contain_partition(&self, partition_key: &[u8]) -> bool {
+        if self.bti_partitions_db.is_some() {
+            // BTI: trie miss is authoritative absence; any error is conservative.
+            return matches!(
+                self.lookup_partition_via_bti_trie(partition_key),
+                Ok(Some(_)) | Err(_)
+            );
+        }
+        match &self.bloom_filter {
+            Some(bloom) => bloom.might_contain(partition_key),
+            None => true,
+        }
+    }
+
     /// Enhanced partition lookup using schema-driven key digest computation
     pub async fn lookup_partition_with_schema_context(
         &self,

--- a/cqlite-core/tests/issue_949_partition_lookup_parity.rs
+++ b/cqlite-core/tests/issue_949_partition_lookup_parity.rs
@@ -1,0 +1,196 @@
+//! Issue #949: partition-targeted lookup parity.
+//!
+//! A `SELECT ... WHERE <partition_key> = ?` that fully constrains the partition
+//! key is served by [`StorageEngine::scan_partition`], which prunes the SSTable
+//! set via the bloom filter / BTI trie and only parses the candidates, instead of
+//! scanning every SSTable for the table and filtering in memory.
+//!
+//! These tests assert that the optimized path returns *exactly* the same rows as
+//! a full scan filtered down to the same partition key, for every real partition
+//! in a composite-text-keyed table, plus the empty result for an absent key.
+//!
+//! Uses `test_timeseries.app_metrics`, whose partition key is the composite
+//! `(application_id TEXT, metric_name TEXT)` — a key the SELECT parser encodes
+//! from string literals, so the fast path actually engages end-to-end. (Tables
+//! with UUID partition keys can't be exercised through the CQL WHERE path yet:
+//! the parser has no unquoted-UUID literal, an unrelated limitation.)
+//!
+//! Requires `CQLITE_DATASETS_ROOT` and the fetched binary SSTables; skipped
+//! (not failed) when the data isn't present, matching the repo's other
+//! dataset-backed integration tests.
+
+#![cfg(all(feature = "state_machine", feature = "cli-helpers"))]
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::query::result::QueryRow;
+use cqlite_core::{Database, Value};
+
+const QUALIFIED_TABLE: &str = "test_timeseries.app_metrics";
+const KEYSPACE_FILTER: &str = "/test_timeseries/";
+
+fn datasets_root() -> Option<PathBuf> {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+}
+
+fn schemas_dir() -> Option<PathBuf> {
+    if let Some(root) = datasets_root() {
+        let dir = root.parent()?.join("schemas");
+        if dir.exists() {
+            return Some(dir);
+        }
+    }
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let dir = manifest_dir.parent()?.join("test-data").join("schemas");
+    dir.exists().then_some(dir)
+}
+
+async fn setup() -> Result<Database, String> {
+    let root = datasets_root().ok_or("CQLITE_DATASETS_ROOT not set or missing")?;
+    let schema_path = schemas_dir()
+        .ok_or("schemas dir not found")?
+        .join("time-series.cql");
+    if !schema_path.exists() {
+        return Err(format!("schema not found at {schema_path:?}"));
+    }
+    let data_dir = root.join("sstables");
+    if !data_dir.exists() {
+        return Err(format!("sstables dir not found at {data_dir:?}"));
+    }
+
+    let config = IngestionConfig {
+        schema_paths: vec![schema_path],
+        data_dir,
+        version_hint: None,
+        core_config: cqlite_core::Config::default(),
+        table_directory_filter: Some(KEYSPACE_FILTER.to_string()),
+    };
+    let result = ingest(config)
+        .await
+        .map_err(|e| format!("ingestion failed: {e}"))?;
+    if result.schema_load_result.schemas_loaded == 0 {
+        return Err("no schemas loaded".to_string());
+    }
+    Ok(result.database)
+}
+
+fn text(row: &QueryRow, col: &str) -> Option<String> {
+    match row.values.get(col) {
+        Some(Value::Text(s)) => Some(s.clone()),
+        _ => None,
+    }
+}
+
+/// Canonical, order-independent fingerprint of a row's columns for set comparison.
+fn row_fingerprint(row: &QueryRow) -> BTreeMap<String, String> {
+    row.values
+        .iter()
+        .map(|(k, v)| (k.clone(), format!("{v:?}")))
+        .collect()
+}
+
+fn fingerprints(rows: &[QueryRow]) -> Vec<BTreeMap<String, String>> {
+    let mut out: Vec<_> = rows.iter().map(row_fingerprint).collect();
+    out.sort_by_key(|m| format!("{m:?}"));
+    out
+}
+
+#[tokio::test]
+async fn partition_lookup_matches_full_scan_for_every_partition() {
+    let db = match setup().await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+
+    // Full scan once: the reference. Group rows by their composite partition key.
+    let full = db
+        .execute(&format!(
+            "SELECT application_id, metric_name, unit, value FROM {QUALIFIED_TABLE}"
+        ))
+        .await
+        .expect("full scan must succeed");
+
+    if full.rows.is_empty() {
+        eprintln!("Skipping: app_metrics returned 0 rows (Data.db not fetched?)");
+        return;
+    }
+
+    let mut by_partition: BTreeMap<(String, String), Vec<QueryRow>> = BTreeMap::new();
+    for row in full.rows {
+        let (Some(app), Some(metric)) = (text(&row, "application_id"), text(&row, "metric_name"))
+        else {
+            continue;
+        };
+        by_partition.entry((app, metric)).or_default().push(row);
+    }
+
+    // Bound runtime on large datasets while still covering many real partitions.
+    let mut checked = 0usize;
+    for ((app, metric), expected_rows) in by_partition.iter() {
+        // Skip values that would break naive quoting; real test data is simple words.
+        if app.contains('\'') || metric.contains('\'') {
+            continue;
+        }
+
+        let targeted = db
+            .execute(&format!(
+                "SELECT application_id, metric_name, unit, value FROM {QUALIFIED_TABLE} \
+                 WHERE application_id = '{app}' AND metric_name = '{metric}'"
+            ))
+            .await
+            .unwrap_or_else(|e| panic!("targeted lookup for ({app},{metric}) failed: {e}"));
+
+        assert_eq!(
+            fingerprints(&targeted.rows),
+            fingerprints(expected_rows),
+            "Issue #949: partition lookup for ({app}, {metric}) must equal the full-scan rows \
+             for that partition",
+        );
+
+        checked += 1;
+        if checked >= 50 {
+            break;
+        }
+    }
+
+    assert!(
+        checked > 0,
+        "expected at least one partition to validate; dataset may be missing",
+    );
+    println!("Issue #949: validated partition-lookup parity for {checked} partitions");
+}
+
+#[tokio::test]
+async fn partition_lookup_for_absent_key_is_empty() {
+    let db = match setup().await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let result = db
+        .execute(&format!(
+            "SELECT application_id FROM {QUALIFIED_TABLE} \
+             WHERE application_id = 'definitely-not-a-real-app-key-zzz' \
+             AND metric_name = 'definitely-not-a-real-metric-zzz'"
+        ))
+        .await
+        .expect("absent-key lookup must succeed");
+
+    assert!(
+        result.rows.is_empty(),
+        "Issue #949: a fully-constrained lookup on an absent partition key must return no rows, \
+         got {}",
+        result.rows.len()
+    );
+}


### PR DESCRIPTION
Closes #949. First step of Epic #951.

## Problem

A `SELECT ... WHERE <partition_key> = ?` that fully constrains the partition key opened and sequentially scanned **every** SSTable for the table, decoded every partition, and filtered rows in memory — O(total rows across all SSTables), regardless of the partition key. On a node with thousands of SSTables, a single-partition read touched all of them.

The machinery to avoid this already existed and was tested (bloom filters, Index.db, the BTI Partitions.db trie, `get()`), but it was reachable only from the low-level KV `get()` API and from tests — the CQL query engine never called it (see #949 for the full call-chain analysis).

## Fix

Route a fully-constrained partition-key equality through a new partition-targeted path that prunes the SSTable set via the bloom filter (BIG format) / Partitions.db trie (BTI) and only parses the surviving candidates.

- **`partition_key_codec::encode_partition_key_columns`** — inverse of the existing decoder, producing the exact on-disk raw key bytes (so it matches scan RowKeys, the bloom filter, and the trie). Includes literal coercion because the SELECT parser emits integer literals as `BigInt`.
- **`SSTableReader::might_contain_partition`** — cheap, authoritative-absence presence oracle (bloom never false-negatives; a BTI trie miss is definitive).
- **`SSTableManager` / `StorageEngine::scan_partition`** — prune to candidate SSTables, then reuse the existing per-reader parse and cross-generation merge over just the candidates, filtered to the partition key. Output matches filtering the full `scan` result to that key.
- **`select_executor`** — detect a complete partition-key equality restriction and call `scan_partition` (materializing + streaming paths); fall back to a full scan when the key isn't fully pinned or can't be encoded. Per-row predicate evaluation is unchanged, so clustering predicates and the pk equality itself are still applied.

**Parity is by construction:** same parse + same cross-generation merge, restricted to the pruned candidate set. This deliberately sidesteps a latent per-partition-vs-per-row granularity inconsistency between the index path and the write-support merge path.

## Scope / deliberate non-goals (tracked under Epic #951)

- Within-SSTable seek for the single-candidate case (#953): surviving SSTables are still full-parsed; the dominant "don't open thousands of SSTables" win lands here, the offset-seek is a follow-up.
- `IN` / token-range restrictions (#955) and clustering-key pushdown (#954) still fall back to scan.
- The WRITETIME/TTL metadata scan path is unchanged (still a full scan).
- Unquoted-UUID `WHERE` literals (#956) are a pre-existing, unrelated parser gap.

## Commits

1. `feat(query)` — the implementation above.
2. `review` — a write-support drift-guard test pinning `encode_partition_key_columns` byte-for-byte to the write engine's `PartitionKey::to_bytes`, plus precise parity wording (from a high-effort code review).
3. `simplify` — extracted `resolve_reader_list` shared by `get`/`scan`/`scan_partition`; de-leaked the `tombstones` cfg out of the executor via a delegating `scan_partition`; conditional sort; encoder closure dedup.

## Validation

- Default **and** `tombstones` builds compile; `clippy --all-features -D warnings` clean (passed in the agent gate before an unrelated CI-disk issue; re-validated affected areas directly).
- New integration test (`issue_949_partition_lookup_parity.rs`) against real Cassandra 5.0 SSTables: `scan_partition` output equals the full-scan rows for **every** partition of a composite-text-keyed table (50 partitions sampled) and returns empty for an absent key.
- Codec roundtrip + drift-guard unit tests (12) pass.
- Manual CLI e2e confirmed the fast path engages, partial keys fall back, and absent keys return `[]`.

## Reviewer notes

- The encoder is intentionally duplicated from the write engine (codec must compile without the `write-support` feature); the drift-guard test keeps the two byte-identical. Consolidation was considered and deferred because delegating would loosen write-path type strictness / `Null` handling.
- Follow-up work is laid out in Epic #951 (#952–#958), including a perf-regression guard (#958) that would fail if a future change reintroduced full-table scanning for a single-partition read.

https://claude.ai/code/session_019dp42F6iJUaGLYsFmwdCMH

---
_Generated by [Claude Code](https://claude.ai/code/session_019dp42F6iJUaGLYsFmwdCMH)_