### PR TITLE
release: prepare v0.12.0 — the compaction release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,139 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.12.0] - 2026-06-22
+
+The compaction release. CQLite now rewrites and compacts Cassandra 5.0 SSTables
+with **byte-for-byte parity against Apache Cassandra**, verified by a differential
+harness that compacts the same inputs with both engines and compares the output
+bytes plus an end-to-end Cassandra readback (Epic #842 → #921 → #938). Reaching
+parity required modelling compaction the way Cassandra does — per-element/per-cell
+merge reconciliation (#886, #899) rather than whole-cell/row-timestamp granularity —
+and then implementing the full reconciliation rule set: complex-deletion
+strict-supersede and shadow-before-purge (#887), tombstone-vs-expiring tie-breaks
+(#848), `gc_grace`/`gcBefore` purging with overlap-aware partial-compaction safety
+(#845, #935), range-tombstone shadowing (#846), per-cell and dropped-column purging
+(#922, #847), row-deletion/live-cell coexistence (#932), row-tombstone
+`localDeletionTime` preservation (#873), clustering identity through row tombstones
+(#912), non-frozen UDT multi-cell read+write (#927, #929), and static-row presence
+read from input headers (#850).
+
+Beyond compaction, this release adds an **Arrow Flight server + Trino connector**
+for querying SSTables as a federated source with predicate, token-range, and
+aggregation pushdown (Epics #874, #918); **canonical BTI (`da`) write support** that
+emits Cassandra-format trie-indexed SSTables and end-to-end BTI read (Epics #872,
+#835); a **CDC-style delta-scan / delta-export** path that projects SSTable
+generations to Parquet envelopes with full tombstone fidelity (Epic #696);
+**`WRITETIME()` / `TTL()` in `SELECT`** (Epic #689); broad **query-engine
+completeness** (PER PARTITION LIMIT, static columns, clustering order, clustering-key
+bounds, cross-generation LWW merge, partition-targeted lookups); and **read-path
+performance** work (parallel single-reader scans, streamed writers, promoted index,
+BTI seeks). Plus crates.io OIDC trusted publishing, a Homebrew tap, and a hardened
+CI/validation pipeline.
+
+### Added
+
+- **Byte-for-byte compaction parity vs Apache Cassandra** (Epics #842, #921, #938) —
+  a `cqlite compact` command and a differential harness that compacts identical
+  inputs with CQLite and Cassandra and diffs the resulting `Data.db` bytes, wired
+  into CI alongside an E2E Cassandra readback (#854, #858, #936). The merge path was
+  re-modelled to per-element/per-cell granularity (#886, #899), enabling the full
+  reconciliation rule set: complex-deletion strict-supersede + shadow-before-purge
+  (#887), tombstone-vs-expiring(TTL) tie-break (#848), `gc_grace`/`gcBefore` purging
+  (#845) with overlap-aware partial-compaction purging via per-key
+  `maxPurgeableTimestamp` (#935), range-tombstone merge shadowing (#846), per-cell
+  dropped-column purging (#922, #847), row-deletion/live-cell coexistence (#932),
+  multi-cell collection/UDT merge per cell-path (#844), non-frozen UDT multi-cell
+  support (#927, #929), single schema-ordered emission for mixed complex writes
+  (#930), row-tombstone `localDeletionTime` preservation (#873), clustering identity
+  through row tombstones (#912), and static-row presence from input headers (#850).
+  Rules are documented in `docs/compaction/byte-parity-rules.md`.
+
+- **Arrow Flight server + Trino connector** (Epics #874, #918) — query Cassandra
+  SSTables as a federated Trino source over Arrow Flight, with predicate pushdown,
+  arbitrary nested predicates (OR/NOT), token-range SSTable pruning, and aggregation
+  pushdown (count/sum/min/max/avg + GROUP BY) including integer `avg` and float
+  min/max with Trino-exact NaN ordering (#836, #898, #919). GROUP BY pushdown has an
+  operator-configurable gate for high-cardinality cases (#937).
+
+- **Canonical BTI (`da`) write + read** (Epics #872, #835) — emit Cassandra-format
+  `da` (BTI) SSTables with a Partitions.db/Rows.db trie, drop legacy
+  Index.db/Summary.db, and validate against `sstabledump`/Cassandra readback (#914);
+  end-to-end BTI full-scan read support (#897); Data.db offset extraction from BTI
+  trie payloads for O(log n) seeks (#833); read-path completion for wide partitions
+  and BTI (#867).
+
+- **CDC-style delta-scan and `delta-export`** (Epic #696) — a `scan_delta` streaming
+  API emitting `DeltaRecord`s (upserts, static upserts, row/range/partition
+  tombstones) with an Arrow envelope schema derived from the table schema, a
+  `DeltaParquetWriter`, and a CLI `delta-export` subcommand for projecting an SSTable
+  generation to a CDC Parquet file (#869, #871, #870, #876, #877, #880, #879). Ships
+  with a DuckDB reference-merge reconciliation guide (#878) and a parity harness
+  (#881, #882).
+
+- **`WRITETIME()` and `TTL()` in `SELECT`** (Epic #689) — parse, validate, thread
+  per-cell writetime/TTL metadata from reader to query rows (opt-in), and evaluate
+  the functions in projections, with coverage across JSON/CSV/Parquet and the
+  bindings (#837, #838, #840, #855, #856).
+
+- **Query-engine completeness** (Epic #756) — `PER PARTITION LIMIT` (#859),
+  `indexes_used` in query-plan results (#861), static-column tracking in discovered
+  schemas (#862), clustering-order (ASC/DESC) discovery from the Statistics.db header
+  (#863), UDT-reference validation against the registry at load (#860), clustering-key
+  inequality bounds (`>=`, `>`, `<`, `<=`) (#791), and a partition-targeted lookup
+  for fully-constrained `WHERE pk = ?` instead of scanning every SSTable (#949).
+
+- **Read-path performance** (Epics #906, #751) — restored parallel reads on a single
+  `SSTableReader` via per-scan positioned reads (#815) with a concurrent-scan scaling
+  benchmark (#917); a size-aware disk-access backend with configurable prefetch
+  (#964); cursor/channel groundwork for a streaming K-way merge (#754); a
+  Cassandra-correct streamed promoted index for wide partitions (#752); and Index.db
+  entries streamed to disk instead of buffered (#753).
+
+- **Distribution** — crates.io publishing for `cqlite-core` + `cqlite-cli` (#782)
+  migrated to OIDC trusted publishing (#786), and a Homebrew tap for the CLI (#781).
+
+### Changed
+
+- Incremental streaming of the read/scan path instead of full materialization (#790).
+- crates.io release publishing now runs on tag via OIDC rather than a stored token
+  (#895); linux-gnu CLI binaries build under `cross` to lower the glibc floor (#864).
+- Cross-generation `SELECT *` now performs an LWW merge with tombstone suppression
+  across SSTable generations (#883), and `WRITETIME`/`TTL` metadata reconciles across
+  generations (#885).
+
+### Fixed
+
+- **Write-path / Statistics.db fidelity** (Epic #796) — populate the
+  `estimatedTombstoneDropTime` histogram (#797), compute final Statistics.db delta
+  baselines before the write loop (#799), wire real `l0_count`/`total_written` from
+  the WriteEngine (#800), and a `write_dir` file lock to prevent concurrent-write
+  corruption (#798).
+- **Bindings** — CLI emits `null` for tombstoned cells in JSON (#806); Python provides
+  a hashable representation for `SET<FROZEN<UDT>>` (#804) and thread-safe schema init
+  for concurrent queries (#805).
+- **Test & CI trustworthiness** (Epic #795) — resolve `CQLITE_DATASETS_ROOT` to
+  `sstables/` and unmask 7 silently-skipped Python failures (#773), harden
+  `agent-gate.sh` to cover the Python bindings and all integration targets (#865),
+  retire a TTL byte-scan flake for a structural assertion (#774), and build DuckDB
+  from source so the DS11 reconciliation job links on ubuntu (#916).
+
+### Contributors
+
+Thanks to everyone who contributed to this release:
+
+- **Patrick McFadin** ([@pmcfadin](https://github.com/pmcfadin)) — maintainer; the
+  bulk of compaction parity, BTI write/read, delta-scan, query engine, read-path
+  performance, write-path fidelity, CI, and release infrastructure.
+- **Jon Haddad** ([@rustyrazorblade](https://github.com/rustyrazorblade)) — the Arrow
+  Flight server + Trino connector (#836) and the compaction byte-parity foundations:
+  the rule spec + parity-auditor agent (#854) and the `cqlite compact` differential
+  harness vs Apache Cassandra (#858).
+
+Development was AI-assisted: substantial portions were implemented and reviewed with
+Claude Code under human direction and review. Reconciliation edge cases were validated
+against the `rustyrazorblade/cassandra` compaction reference.
+
 ## [v0.11.0] - 2026-06-15
 
 Minor release bundling everything merged since v0.10.0. New capability: a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,10 @@ generations to Parquet envelopes with full tombstone fidelity (Epic #696);
 **`WRITETIME()` / `TTL()` in `SELECT`** (Epic #689); broad **query-engine
 completeness** (PER PARTITION LIMIT, static columns, clustering order, clustering-key
 bounds, cross-generation LWW merge, partition-targeted lookups); and **read-path
-performance** work (parallel single-reader scans, streamed writers, promoted index,
-BTI seeks). Plus crates.io OIDC trusted publishing, a Homebrew tap, and a hardened
-CI/validation pipeline.
+performance** work (parallel single-reader scans, a size-aware direct-I/O disk
+backend with configurable prefetch, streamed writers, promoted index, BTI seeks).
+Plus crates.io OIDC trusted publishing, a Homebrew tap, and a hardened CI/validation
+pipeline.
 
 ### Added
 
@@ -89,10 +90,24 @@ CI/validation pipeline.
   inequality bounds (`>=`, `>`, `<`, `<=`) (#791), and a partition-targeted lookup
   for fully-constrained `WHERE pk = ?` instead of scanning every SSTable (#949).
 
+- **Size-aware disk-access backend with direct I/O and configurable prefetch**
+  (#964) — a new `Auto` selector sizes each `Data.db` file against system RAM:
+  small files are memory-mapped (resident in the page cache for repeated scans),
+  while files larger than a configurable fraction of RAM (default half) use **true
+  direct I/O** (`O_DIRECT` on Linux, `F_NOCACHE` on macOS) so a single huge scan does
+  not thrash the page cache. New `StorageConfig` fields — `disk_access_mode`
+  (`auto`/`buffered`/`mmap`/`direct`), `direct_io_memory_fraction`, `prefetch`
+  (`off`/`sequential`/`willneed`/`auto`), and `direct_io_prefetch_bytes` — plus
+  `CQLITE_DISK_ACCESS_MODE` / `CQLITE_PREFETCH` env overrides. Prefetch is wired to
+  both paths (`madvise(SEQUENTIAL/WILLNEED)` on mmap, an aligned read-ahead window on
+  the direct path), and every non-buffered backend degrades gracefully to buffered
+  I/O when the OS/filesystem refuses it (network mounts, `O_DIRECT`-hostile
+  filesystems). All fields are serde-default for backward compatibility; the legacy
+  `use_mmap` flag still forces mmap.
+
 - **Read-path performance** (Epics #906, #751) — restored parallel reads on a single
   `SSTableReader` via per-scan positioned reads (#815) with a concurrent-scan scaling
-  benchmark (#917); a size-aware disk-access backend with configurable prefetch
-  (#964); cursor/channel groundwork for a streaming K-way merge (#754); a
+  benchmark (#917); cursor/channel groundwork for a streaming K-way merge (#754); a
   Cassandra-correct streamed promoted index for wide partitions (#752); and Index.db
   entries streamed to disk instead of buffered (#753).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Guidance for Claude Code when working with CQLite.
 
 CQLite is a Rust library for local Apache Cassandra SSTable access. It reads Cassandra 5.0 data files without cluster dependencies.
 
-**Status**: M5.2 In Progress (Jan 2026) - Core reading (M1), CLI (M2), Output Writers (M3), Python Bindings (M4), and Write Support (M5.1 complete, M5.2 compaction/export in progress).
+**Status**: v0.12.0 (Jun 2026) - Core reading (M1), CLI (M2), Output Writers (M3), Python & Node.js Bindings (M4), and Write Support + STCS compaction (M5) are complete. v0.12.0 adds byte-for-byte compaction parity vs Apache Cassandra, an Arrow Flight + Trino connector, canonical BTI (`da`) write/read, CDC-style delta-export, and `WRITETIME()`/`TTL()` in `SELECT`. Next: M6 (WASM bindings), M7 (perf validation + v1.0).
 
 ## Documentation
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ resolver = "2"
 # belongs to an unrelated project; the CLI publishes as `cqlite-cli` (binary
 # `cqlite`). See issue #782.
 name = "cqlite"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 publish = false
 
@@ -40,7 +40,7 @@ crc32fast = { workspace = true }
 cqlite-integration-tests = { path = "tests" }
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 authors = ["CQLite Team"]
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <a href="https://cassandra.apache.org"><img src="https://img.shields.io/badge/cassandra-5.0+-green.svg" alt="Cassandra"></a>
 </p>
 
-> **Status**: v0.11.0 — Core reading, CLI, output writers, Python & Node.js bindings, and write support (with STCS compaction) are production-ready. See [CHANGELOG.md](CHANGELOG.md).
+> **Status**: v0.12.0 — Core reading, CLI, output writers, Python & Node.js bindings, and write support are production-ready, now with **byte-for-byte compaction parity against Apache Cassandra**, an Arrow Flight + Trino connector, canonical BTI (`da`) write/read, and CDC-style delta export. See [CHANGELOG.md](CHANGELOG.md).
 
 CQLite provides SQLite-like local access to Apache Cassandra SSTables, enabling developers to read Cassandra 5.0+ data files without cluster dependencies. Built in Rust for performance and safety.
 
@@ -296,6 +296,14 @@ cargo build -p cqlite-core --no-default-features
 - [x] Version-gated reads for the Cassandra 5.0 `oa` format; graceful handling of `da` (BTI)
 - [x] Real BTI trie node-type dispatch and schema-typed query result columns
 - [x] Published documentation site at [pmcfadin.github.io/cqlite](https://pmcfadin.github.io/cqlite/)
+
+### ✅ v0.12.0 (Jun 2026) — the compaction release
+- [x] **Byte-for-byte compaction parity vs Apache Cassandra** — `cqlite compact` + a differential harness in CI, full reconciliation rule set (complex deletions, tombstone tie-breaks, `gc_grace` purging, range tombstones, per-cell/dropped-column purging, non-frozen UDT multi-cell)
+- [x] **Arrow Flight server + Trino connector** — query SSTables as a federated source with predicate, token-range, and aggregation pushdown
+- [x] **Canonical BTI (`da`) write + end-to-end read** — emit Cassandra-format trie-indexed SSTables
+- [x] **CDC-style delta-scan / `delta-export`** — project SSTable generations to Parquet envelopes with full tombstone fidelity
+- [x] **`WRITETIME()` / `TTL()` in `SELECT`** and query-engine completeness (`PER PARTITION LIMIT`, static columns, clustering order/bounds, partition-targeted lookups)
+- [x] crates.io OIDC trusted publishing + Homebrew tap
 - See [CHANGELOG.md](CHANGELOG.md) for the full per-release detail
 
 ### 📋 Roadmap
@@ -304,18 +312,16 @@ See the [**Roadmap**](#roadmap) section below for in-flight epics and milestones
 
 ## Roadmap
 
-CQLite is at **v0.11.0** and production-ready for the use cases above. The path to
+CQLite is at **v0.12.0** and production-ready for the use cases above. The path to
 **v1.0** is tracked in the open. Full detail, with milestones, lives at
 [pmcfadin.github.io/cqlite → Roadmap](https://pmcfadin.github.io/cqlite/user-docs/roadmap/).
 
 | Workstream | Epic |
 |------------|------|
-| Query engine completeness — `PER PARTITION LIMIT`, static columns, clustering order, plan metadata | [#756](https://github.com/pmcfadin/cqlite/issues/756) |
-| `WRITETIME()` / `TTL()` in `SELECT` | [#689](https://github.com/pmcfadin/cqlite/issues/689) |
-| Writer format fidelity — `>64`-col headers, deletion-time, `DURATION`, BTI index writing | [#762](https://github.com/pmcfadin/cqlite/issues/762) |
-| Wide-partition & memory performance — promoted index, streamed writers, O(log n) seeks | [#751](https://github.com/pmcfadin/cqlite/issues/751) |
-| BTI (`da`) end-to-end **read** support | [#660](https://github.com/pmcfadin/cqlite/issues/660) |
-| Delta-scan envelope for CDC-style Parquet projections | [#696](https://github.com/pmcfadin/cqlite/issues/696) |
+| Wire storage-layer capabilities (bloom/index/BTI seeks) into the CQL query path + regression guards | [#951](https://github.com/pmcfadin/cqlite/issues/951) |
+| Read-path performance & I/O backend (parallel single-reader scans, io_uring spike) | [#906](https://github.com/pmcfadin/cqlite/issues/906) |
+| CLI & bindings polish (DX & cleanup) | [#907](https://github.com/pmcfadin/cqlite/issues/907) |
+| Compaction byte-parity follow-ups (range tombstones e2e + edge cases) | [#938](https://github.com/pmcfadin/cqlite/issues/938) |
 | M6 — WASM bindings · M7 — performance validation + **v1.0** | _planned_ |
 
 The roadmap follows real-world use. Want something prioritized?
@@ -324,7 +330,7 @@ The roadmap follows real-world use. Want something prioritized?
 
 ## Known Issues
 
-CQLite is honest about its sharp edges. The current release (`v0.11.0`) has a few
+CQLite is honest about its sharp edges. The current release (`v0.12.0`) has a few
 known gaps — none of which block the core read/export workflows. Full, dated list:
 [pmcfadin.github.io/cqlite → Known Issues](https://pmcfadin.github.io/cqlite/user-docs/known-issues/).
 
@@ -466,4 +472,4 @@ Special thanks to the Apache Cassandra community and the many contributors who m
 
 ---
 
-**Note**: M1 through M5 milestones are complete and the project is at **v0.11.0**. Core SSTable reading, CLI, output writers (including Parquet), Python and Node.js bindings, and write support with STCS compaction are production-ready. Next: M6 (WASM bindings) and M7 (performance validation + v1.0).
+**Note**: M1 through M5 milestones are complete and the project is at **v0.12.0**. Core SSTable reading, CLI, output writers (including Parquet), Python and Node.js bindings, and write support with STCS compaction and **byte-for-byte compaction parity vs Apache Cassandra** are production-ready, alongside an Arrow Flight + Trino connector, canonical BTI (`da`) write/read, and CDC-style delta export. Next: M6 (WASM bindings) and M7 (performance validation + v1.0).

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cqlite/node",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Node.js bindings for CQLite - read Apache Cassandra 5.0 SSTables without cluster dependencies",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "cqlite-py"
-version = "0.11.0"
+version = "0.12.0"
 description = "Python bindings for CQLite - read Cassandra 5.0 SSTables locally without a cluster"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/cqlite-cli/Cargo.toml
+++ b/cqlite-cli/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 # version is required (alongside path) so the dep resolves when published to
 # crates.io. Keep this literal in sync with [workspace.package].version on every
 # release (see release checklist).
-cqlite-core = { path = "../cqlite-core", version = "0.11.0" }
+cqlite-core = { path = "../cqlite-core", version = "0.12.0" }
 
 # CLI framework
 clap = { workspace = true }

--- a/docs/README.md
+++ b/docs/README.md
@@ -78,9 +78,10 @@ Welcome to the CQLite documentation hub. This directory holds technical document
 
 ## 📈 Project Status
 
-- **Current Version**: 0.11.0
-- **Cassandra Compatibility**: 5.0+ with BTI format support
+- **Current Version**: 0.12.0
+- **Cassandra Compatibility**: 5.0+ with BTI (`da`) format read **and** write support
 - **Milestones Complete**: M1 (Core Reading), M2 (CLI), M3 (Output Writers), M4 (Python & Node.js Bindings), M5 (Write Support + Compaction)
+- **v0.12.0**: Byte-for-byte compaction parity vs Apache Cassandra · Arrow Flight + Trino connector · canonical BTI write/read · CDC delta-export · `WRITETIME()`/`TTL()` in `SELECT`
 - **Next**: M6 (WebAssembly Bindings), M7 (Performance validation + v1.0)
 - **Test Pass Rate**: 100% (33/33 tables vs sstabledump, see `test-data/validation-matrix.md`)
 

--- a/website/src/content/docs/user-docs/known-issues.md
+++ b/website/src/content/docs/user-docs/known-issues.md
@@ -8,7 +8,7 @@ sidebar:
 
 # Known Issues
 
-This page tracks **active bugs and sharp edges** in the current release (`v0.11.0`).
+This page tracks **active bugs and sharp edges** in the current release (`v0.12.0`).
 It is deliberately short and honest: if something here bites you, you are not doing
 it wrong.
 
@@ -19,7 +19,7 @@ it wrong.
   [**Open an issue**](https://github.com/pmcfadin/cqlite/issues/new/choose) — that is
   the single most useful thing you can do for the project.
 
-_Last reviewed: 2026-06-17 (v0.11.0)._
+_Last reviewed: 2026-06-22 (v0.12.0)._
 
 ## Python bindings
 

--- a/website/src/content/docs/user-docs/limitations.md
+++ b/website/src/content/docs/user-docs/limitations.md
@@ -47,24 +47,15 @@ BTI (trie-based index) is an opt-in feature in Cassandra 5.0, enabled with
 `Partitions.db` and `Rows.db` trie indexes instead of the standard
 `Index.db` / `Summary.db`.
 
-As of v0.11.0, CQLite **detects `da`-format SSTables and rejects them with a clear,
-graceful error** instead of misreading them:
+As of v0.12.0, CQLite **reads `da`-format (BTI) SSTables end-to-end** — a dedicated
+trie-walk read path with `ByteComparable` decode and Data.db chaining, validated
+against `sstabledump` goldens in the `datasets-v3` test set (#897). CQLite can also
+**write** canonical `da`-format SSTables with `Partitions.db`/`Rows.db` trie indexes
+(#872).
 
-```
-Unsupported format: BTI (da) read support not yet implemented. da-format SSTables
-use Partitions.db/Rows.db trie indexes instead of Index.db/Summary.db and require a
-dedicated BTI read path.
-```
-
-The version-gate work (VG5) routes `da` through this graceful-unsupported path today,
-and `da` fixtures plus `sstabledump` goldens ship in the `datasets-v3` test set so a
-real BTI read path can be validated when it lands. That dedicated reader is planned but
-not yet implemented.
-
-**In practice**: because BTI requires explicit cluster opt-in, it is rarely used in
-production. If your SSTables are `da`-format, convert them with Cassandra's
-`sstabledump` first, or use the default BIG format (`nb` / `oa`), which CQLite reads
-fully.
+**In practice**: BTI requires explicit cluster opt-in (`selected_format: bti`) and is
+less common than the default BIG format (`nb` / `oa`), but `da`-format files are now a
+first-class read and write target rather than a rejected one.
 
 ## Data type support
 

--- a/website/src/content/docs/user-docs/roadmap.md
+++ b/website/src/content/docs/user-docs/roadmap.md
@@ -8,8 +8,10 @@ sidebar:
 
 # Roadmap
 
-CQLite is at **v0.11.0**. The read path, CLI, output writers (including Parquet),
-Python and Node.js bindings, and write support with STCS compaction are
+CQLite is at **v0.12.0**. The read path, CLI, output writers (including Parquet),
+Python and Node.js bindings, and write support with STCS compaction — now with
+**byte-for-byte compaction parity against Apache Cassandra**, an Arrow Flight + Trino
+connector, canonical BTI (`da`) write/read, and CDC-style delta export — are
 production-ready. This page is what comes next.
 
 The roadmap is community-driven. The fastest way to move something up the list is to
@@ -17,7 +19,7 @@ The roadmap is community-driven. The fastest way to move something up the list i
 use case — and to [**star the repo**](https://github.com/pmcfadin/cqlite) so the
 project's reach is visible.
 
-_Last reviewed: 2026-06-16 (v0.11.0)._
+_Last reviewed: 2026-06-22 (v0.12.0)._
 
 ## Milestones
 
@@ -33,43 +35,37 @@ _Last reviewed: 2026-06-16 (v0.11.0)._
 
 ## In-flight epics
 
-These are the active workstreams between v0.11.0 and v1.0. Each links to its GitHub
+These are the active workstreams between v0.12.0 and v1.0. Each links to its GitHub
 epic with the child tasks.
 
-### Query engine completeness ([#756](https://github.com/pmcfadin/cqlite/issues/756))
+> Query-engine completeness (#756), `WRITETIME()`/`TTL()` in `SELECT` (#689), writer
+> format fidelity (#762), wide-partition performance (#751), BTI (`da`) end-to-end
+> read (#660), and the CDC delta-scan envelope (#696) all **shipped in v0.12.0** —
+> see the [changelog](https://github.com/pmcfadin/cqlite/blob/main/CHANGELOG.md).
 
-`PER PARTITION LIMIT`, static-column tracking, clustering-order (`ASC`/`DESC`)
-extraction, and query-plan metadata (`indexes_used`). Closes the gap between CQLite's
-`SELECT` support and CQL semantics.
+### Wire storage capabilities into the query path ([#951](https://github.com/pmcfadin/cqlite/issues/951))
 
-### `WRITETIME()` and `TTL()` in `SELECT` ([#689](https://github.com/pmcfadin/cqlite/issues/689))
+CQLite's storage layer already has bloom filters, `Index.db`, the BTI `Partitions.db`
+trie, and a point-lookup path — but parts of the CQL query engine still scan every
+SSTable instead of using them. This epic audits for that pattern, wires the gaps
+(within-SSTable partition seeks, clustering-key pushdown, `IN`/token-range lookups),
+and adds regression guards so single-partition reads scale with candidate SSTables,
+not total count.
 
-Surface per-cell write timestamps and TTLs through the parser, executor, output
-formats, and bindings — a common need for debugging and migration workflows.
+### Read-path performance & I/O backend ([#906](https://github.com/pmcfadin/cqlite/issues/906))
 
-### Writer format fidelity ([#762](https://github.com/pmcfadin/cqlite/issues/762))
+Parallel reads on a single `SSTableReader` (landed) plus a benchmark-first spike on an
+io_uring read backend for Linux.
 
-`> 64`-column serialization headers, explicit deletion-time semantics, `DURATION`
-comparator parsing, and phase 1 of BTI **index writing** for SSTables CQLite produces.
+### Compaction byte-parity follow-ups ([#938](https://github.com/pmcfadin/cqlite/issues/938))
 
-### Wide-partition & memory performance ([#751](https://github.com/pmcfadin/cqlite/issues/751))
+Edge cases deferred from the v0.12.0 parity work: range tombstones end-to-end through
+the compaction writer, and a handful of writer/reconciliation refinements.
 
-Promoted-index writing for wide partitions, streamed index/merge writers to drop the
-in-memory buffer, and BTI-payload Data.db offsets for O(log n) partition seeks. This
-also closes the wide-partition scan listed in
-[Known Issues](/cqlite/user-docs/known-issues/).
+### CLI & bindings polish ([#907](https://github.com/pmcfadin/cqlite/issues/907))
 
-### BTI (`da`) end-to-end read support ([#660](https://github.com/pmcfadin/cqlite/issues/660))
-
-A dedicated read path for trie-indexed SSTables — full trie walk, `ByteComparable`
-decode, and Data.db chaining — so `da`-format files are read instead of rejected.
-Fixtures and `sstabledump` goldens already ship in the test corpus.
-
-### Delta-scan envelope for CDC-style Parquet ([#696](https://github.com/pmcfadin/cqlite/issues/696))
-
-A streaming `scan_delta` API and `cqlite delta-export` subcommand that emit
-upserts, tombstones, and per-cell metadata as Parquet for change-data-capture and
-reconciliation pipelines.
+Developer-experience cleanup: export progress/statistics, clearer
+unsupported-platform errors in the Node loader, and output-mode tidying.
 
 ## Influencing the roadmap
 


### PR DESCRIPTION
Stages the **v0.12.0** release. Version bump + changelog + docs only — no code changes. Tagging/publishing happens separately after merge.

## What's in 0.12.0
The compaction release: **byte-for-byte compaction parity vs Apache Cassandra** (epics #921 → #938, all complete — #933 landed in #950). Plus the Arrow Flight + Trino connector, canonical BTI (`da`) write/read, CDC delta-export, `WRITETIME()`/`TTL()` in `SELECT`, query-engine completeness, and read-path performance. 88 merged PRs since v0.11.0.

## Changes
- **Version → 0.12.0**: root `Cargo.toml` (package + `workspace.package`), `cqlite-cli` core-dep pin, `bindings/node/package.json`, `bindings/python/pyproject.toml`
- **CHANGELOG.md**: full v0.12.0 entry with contributor attribution (@pmcfadin, @rustyrazorblade)
- **README / docs/README.md / CLAUDE.md / website** (roadmap, known-issues, limitations): status → v0.12.0; roadmap swapped to the current in-flight epics (#951/#906/#907); corrected the now-false "rejects `da`-format" BTI claim (read landed in #897)

## Not in this PR (post-merge cut steps)
- [ ] Tag `v0.12.0`
- [ ] crates.io publish (OIDC, on-tag)
- [ ] Homebrew tap auto-bump (needs `HOMEBREW_TAP_TOKEN`)
- [ ] docs-site `/api` rustdoc deploy on tag

> Note: `Cargo.lock` is gitignored in this repo, so its local 0.12.0 sync is intentionally not part of the diff.