### PR TITLE
feat(parity): strict TOC.txt + BIG/BTI component-manifest parity (#982)

### DIFF
--- a/cqlite-core/src/storage/sstable/directory/types.rs
+++ b/cqlite-core/src/storage/sstable/directory/types.rs
@@ -50,6 +50,12 @@ pub enum SSTableComponent {
     CompressionInfo,
     /// CRC32 checksum
     Digest,
+    /// Per-chunk CRC32 file for uncompressed SSTables (Cassandra `CRC.db`).
+    ///
+    /// Cassandra writes this instead of inline compressed-chunk CRCs when the
+    /// table is uncompressed; it coexists with `Digest.crc32`. It is optional
+    /// (absent for compressed tables) and shared by BIG and BTI formats.
+    Crc,
     /// Table of contents listing all components
     TOC,
     /// BTI Partitions index (BTI format only)
@@ -70,6 +76,7 @@ impl FromStr for SSTableComponent {
             "Summary.db" => Ok(SSTableComponent::Summary),
             "CompressionInfo.db" => Ok(SSTableComponent::CompressionInfo),
             "Digest.crc32" => Ok(SSTableComponent::Digest),
+            "CRC.db" => Ok(SSTableComponent::Crc),
             "TOC.txt" => Ok(SSTableComponent::TOC),
             "Partitions.db" => Ok(SSTableComponent::Partitions),
             "Rows.db" => Ok(SSTableComponent::Rows),
@@ -92,6 +99,7 @@ impl SSTableComponent {
             SSTableComponent::Summary => "Summary.db",
             SSTableComponent::CompressionInfo => "CompressionInfo.db",
             SSTableComponent::Digest => "Digest.crc32",
+            SSTableComponent::Crc => "CRC.db",
             SSTableComponent::TOC => "TOC.txt",
             SSTableComponent::Partitions => "Partitions.db",
             SSTableComponent::Rows => "Rows.db",

--- a/cqlite-core/src/storage/sstable/writer/toc_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/toc_writer.rs
@@ -131,11 +131,14 @@ impl TocWriter {
             SSTableComponent::Digest => 2,
             SSTableComponent::TOC => 3,
             SSTableComponent::CompressionInfo => 4,
-            SSTableComponent::Filter => 5,
-            SSTableComponent::Index => 6,
-            SSTableComponent::Summary => 7,
-            SSTableComponent::Partitions => 8,
-            SSTableComponent::Rows => 9,
+            // CRC.db (uncompressed per-chunk CRC) sorts next to CompressionInfo,
+            // its compressed-table counterpart; the two are mutually exclusive.
+            SSTableComponent::Crc => 5,
+            SSTableComponent::Filter => 6,
+            SSTableComponent::Index => 7,
+            SSTableComponent::Summary => 8,
+            SSTableComponent::Partitions => 9,
+            SSTableComponent::Rows => 10,
         });
 
         // Create file with buffered writing

--- a/cqlite-core/tests/sstable_parity_toc_component_test.rs
+++ b/cqlite-core/tests/sstable_parity_toc_component_test.rs
@@ -1,0 +1,232 @@
+//! Strict TOC.txt + component-manifest parity (Epic #968 / issue #982).
+//!
+//! Proves CQLite's component model against the **exact** `TOC.txt` manifests that
+//! Apache Cassandra 5.0 wrote for every committed fixture — BIG (`nb`/`oa`) and
+//! BTI (`da`). These reference files are committed text, so the suite needs no
+//! `Data.db` binary and no live Cassandra: it runs in the Fast PR tier.
+//!
+//! Scope owned here (issue #982):
+//!   * Strict `TOC.txt` parsing parity — every component name Cassandra wrote is
+//!     recognized by CQLite and round-trips byte-exactly (no silent drops, no
+//!     unknown-component fallbacks).
+//!   * Component-set completeness — the components every Cassandra SSTable must
+//!     carry are present in the manifest.
+//!   * BIG-vs-BTI discovery parity — the format declared in the filename
+//!     (`big`/`bti`, parsed authoritatively, no heuristics) agrees with the
+//!     component manifest Cassandra emitted (`Index.db`+`Summary.db` for BIG,
+//!     `Partitions.db`+`Rows.db` for BTI), and the two manifests never mix.
+//!
+//! Out of scope here (tracked as separate #982/#968 follow-ups): `Digest.crc32`
+//! *byte* parity (recomputing the CRC of `Data.db`) and `Index.db`/`Summary.db`/
+//! `Statistics.db`/`CompressionInfo.db`/`Filter.db` byte parity — those require
+//! the binary components and are gated on dataset fetch.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use cqlite_core::storage::sstable::directory::{parse_toc_file_detailed, SSTableComponent};
+use cqlite_core::storage::sstable::version_gate::{SsTableDescriptor, SsTableFormat};
+
+/// Resolve the committed datasets root (env override first, else workspace tree).
+fn datasets_sstables_root() -> PathBuf {
+    let root = if let Ok(root) = std::env::var("CQLITE_DATASETS_ROOT") {
+        PathBuf::from(root)
+    } else {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .map(|workspace| workspace.join("test-data/datasets"))
+            .unwrap_or_else(|| PathBuf::from("test-data/datasets"))
+    };
+    root.join("sstables")
+}
+
+/// Recursively collect every `*-TOC.txt` reference file under `dir`,
+/// skipping macOS AppleDouble shadow files (`._*`).
+fn collect_toc_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with("._") {
+            continue;
+        }
+        if path.is_dir() {
+            collect_toc_files(&path, out);
+        } else if name.ends_with("-TOC.txt") {
+            out.push(path);
+        }
+    }
+}
+
+fn all_toc_files() -> Vec<PathBuf> {
+    let root = datasets_sstables_root();
+    let mut out = Vec::new();
+    collect_toc_files(&root, &mut out);
+    out.sort();
+    // Fail closed: a broken fixture path must turn the strict lane red, not green.
+    assert!(
+        !out.is_empty(),
+        "no committed *-TOC.txt fixtures found under {} — strict TOC parity cannot run \
+         (this is a fail-closed guard, not a skip)",
+        root.display()
+    );
+    out
+}
+
+/// Parse the components named in a TOC, asserting strict recognition and a
+/// byte-exact name round-trip. Returns the recognized components.
+fn parse_strict(toc: &Path) -> Vec<SSTableComponent> {
+    let (components, unknown) = parse_toc_file_detailed(toc)
+        .unwrap_or_else(|e| panic!("parse {} failed: {e}", toc.display()));
+
+    assert!(
+        unknown.is_empty(),
+        "{}: CQLite does not recognize component(s) {:?} that Cassandra wrote into TOC.txt",
+        toc.display(),
+        unknown,
+    );
+
+    // Byte-exact round trip: every recognized component renders back to the
+    // exact filename suffix Cassandra used, and the parsed set equals the raw
+    // set of lines in the file (nothing silently dropped or remapped).
+    let raw: BTreeSet<String> = std::fs::read_to_string(toc)
+        .unwrap_or_else(|e| panic!("read {} failed: {e}", toc.display()))
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        .map(str::to_string)
+        .collect();
+    let parsed: BTreeSet<String> = components
+        .iter()
+        .map(|c| c.file_extension().to_string())
+        .collect();
+    assert_eq!(
+        parsed,
+        raw,
+        "{}: parsed component set does not byte-match the raw TOC manifest",
+        toc.display(),
+    );
+
+    components
+}
+
+/// Strict parsing parity + component-set completeness across every fixture.
+///
+/// Every component name Cassandra wrote must be recognized and round-trip
+/// byte-exactly, and the always-present components must be there.
+#[test]
+fn toc_manifest_strict_parsing_and_completeness() {
+    // Components Cassandra writes for every SSTable regardless of format/options.
+    // (CompressionInfo.db is intentionally excluded — uncompressed tables omit it.)
+    let always_present = [
+        SSTableComponent::Data,
+        SSTableComponent::Statistics,
+        SSTableComponent::TOC,
+        SSTableComponent::Digest,
+        SSTableComponent::Filter,
+    ];
+
+    let tocs = all_toc_files();
+    for toc in &tocs {
+        let components = parse_strict(toc);
+        for required in &always_present {
+            assert!(
+                components.contains(required),
+                "{}: required component {} ({}) missing from Cassandra TOC manifest",
+                toc.display(),
+                required.file_extension(),
+                if required.is_required() {
+                    "read-critical"
+                } else {
+                    "standard"
+                },
+            );
+        }
+    }
+
+    eprintln!(
+        "toc_manifest_strict_parsing_and_completeness: {} TOC fixtures verified",
+        tocs.len()
+    );
+}
+
+/// BIG-vs-BTI component-manifest discovery parity.
+///
+/// The format the filename declares (parsed authoritatively from the `<format>`
+/// segment — no heuristics) must agree with the component manifest Cassandra
+/// emitted, and BIG/BTI component families must never be mixed in one SSTable.
+#[test]
+fn toc_manifest_big_vs_bti_discovery_parity() {
+    let tocs = all_toc_files();
+
+    let mut big_seen = 0usize;
+    let mut bti_seen = 0usize;
+
+    for toc in &tocs {
+        let filename = toc
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_else(|| panic!("non-UTF8 TOC filename: {}", toc.display()));
+
+        // Authoritative format from the filename's <format> segment.
+        let descriptor = SsTableDescriptor::parse_filename(filename)
+            .unwrap_or_else(|e| panic!("{}: descriptor parse failed: {e}", toc.display()));
+
+        let components = parse_strict(toc);
+        let has_big = components.iter().any(SSTableComponent::is_big_specific);
+        let has_bti = components.iter().any(SSTableComponent::is_bti_specific);
+
+        match descriptor.format {
+            SsTableFormat::Big => {
+                big_seen += 1;
+                assert!(
+                    has_big && !has_bti,
+                    "{}: declared BIG but component manifest is {:?} (expected Index.db+Summary.db, \
+                     no Partitions.db/Rows.db)",
+                    toc.display(),
+                    components,
+                );
+                assert!(
+                    components.contains(&SSTableComponent::Index)
+                        && components.contains(&SSTableComponent::Summary),
+                    "{}: BIG manifest must carry both Index.db and Summary.db",
+                    toc.display(),
+                );
+            }
+            SsTableFormat::Bti => {
+                bti_seen += 1;
+                assert!(
+                    has_bti && !has_big,
+                    "{}: declared BTI but component manifest is {:?} (expected Partitions.db+Rows.db, \
+                     no Index.db/Summary.db)",
+                    toc.display(),
+                    components,
+                );
+                assert!(
+                    components.contains(&SSTableComponent::Partitions)
+                        && components.contains(&SSTableComponent::Rows),
+                    "{}: BTI manifest must carry both Partitions.db and Rows.db",
+                    toc.display(),
+                );
+            }
+        }
+    }
+
+    // The committed corpus carries both families (nb/oa BIG and da BTI); if either
+    // assertion path never executed, the discovery parity claim is unproven.
+    assert!(
+        big_seen > 0,
+        "no BIG-format fixtures exercised — BIG discovery parity unproven"
+    );
+    assert!(
+        bti_seen > 0,
+        "no BTI-format fixtures exercised — BTI discovery parity unproven"
+    );
+
+    eprintln!(
+        "toc_manifest_big_vs_bti_discovery_parity: {big_seen} BIG + {bti_seen} BTI manifests verified"
+    );
+}

--- a/docs/reports/cassandra-test-parity.md
+++ b/docs/reports/cassandra-test-parity.md
@@ -10,8 +10,8 @@ Sources: [`docs/cassandra_test_index.md`](../../docs/cassandra_test_index.md) ·
 
 | Status | Scenarios |
 |---|---|
-| `mirrored` | 13 |
-| `partial` | 6 |
+| `mirrored` | 14 |
+| `partial` | 5 |
 | `planned` | 2 |
 | `out_of_scope` | 7 |
 | **total** | **28** |
@@ -60,7 +60,7 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 | `cass.index_summary.big_index_offsets` | index_summary | mirrored | canonical_semantic | `sstable_parity_index_db_big` | p1_correctness |
 | `cass.index_summary.summary_boundaries` | index_summary | partial | partial | `sstable_parity_summary_db_big` | p1_correctness |
 | `cass.sstable_format.descriptor_component_resolution` | sstable_format | mirrored | smoke | `sstable_parity_component_manifest` | p1_correctness |
-| `cass.sstable_format.toc_component_manifest` | sstable_format | partial | partial | `sstable_parity_component_manifest` | p1_correctness |
+| `cass.sstable_format.toc_component_manifest` | sstable_format | mirrored | partial | `sstable_parity_component_manifest` | p1_correctness |
 | `cass.statistics_metadata.serialization_header` | statistics_metadata | mirrored | canonical_semantic | `sstable_parity_statistics_db` | p1_correctness |
 | `cass.tombstone_ttl.range_tombstone_boundaries` | tombstone_ttl | partial | partial | `sstable_parity_delta_scan` | p0_data_loss |
 | `cass.tombstone_ttl.ttl_and_local_deletion_time` | tombstone_ttl | mirrored | canonical_semantic | `sstable_parity_data_db_jsonl` | p0_data_loss |
@@ -105,7 +105,6 @@ _None yet._ No scenario currently claims byte-for-byte parity; coverage is canon
 - `cass.delta_scan.tombstone_liveness_facts` (partial): test_deltas dataset asset not published/enforced (#701). → _Publish and enforce the test_deltas dataset in delta-roundtrip CI._
 - `cass.filter_db_bloom.serialization_no_false_negative` (partial): No no-false-negative parity assertion against Cassandra Filter.db. → _Add a Filter.db serialization parity test asserting zero false negatives across the present-key set._
 - `cass.index_summary.summary_boundaries` (partial): Cassandra Summary.db reference dumps not published for all tables. → _Publish Summary.db reference dumps and enable strict first/last-key boundary comparison in the sstable_parity_summary_db_big suite._
-- `cass.sstable_format.toc_component_manifest` (partial): No gated exact TOC.txt comparison against the Cassandra-produced manifest. → _Add a component-manifest byte comparison to the sstable_parity_component_manifest suite._
 - `cass.tombstone_ttl.range_tombstone_boundaries` (partial): test_deltas dataset asset not published/enforced in CI (#701). → _Publish the test_deltas dataset and enforce scan_delta parity in CI._
 
 ## Out-of-scope taxonomy
@@ -206,7 +205,7 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.sai_sasi_query.secondary_index_out_of_scope` | — | — |
 | `cass.schema_evolution.serialization_header_column_order` | nb | — |
 | `cass.sstable_format.descriptor_component_resolution` | nb, oa, da | — |
-| `cass.sstable_format.toc_component_manifest` | da | test-data/datasets/sstables/test_da/simple_table-de1be8b064e711f19ad401a8c8227b11/da-2-bti-TOC.txt |
+| `cass.sstable_format.toc_component_manifest` | nb, oa, da | test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-TOC.txt<br>test-data/datasets/sstables/test_oa/collection_table-4b892c6064e711f1bd3ac7dbf655c673/oa-2-big-TOC.txt<br>test-data/datasets/sstables/test_da/simple_table-de1be8b064e711f19ad401a8c8227b11/da-2-bti-TOC.txt |
 | `cass.statistics_metadata.serialization_header` | nb | test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Statistics.db.txt |
 | `cass.streaming_protocol.node_lifecycle_out_of_scope` | — | — |
 | `cass.tombstone_ttl.range_tombstone_boundaries` | nb | test-data/datasets/sstables/test_deltas/adjacent_ranges-972f22806c7811f1a24ff924a65838e2/nb-1-big-Data.db.jsonl |

--- a/test-data/cassandra-parity-manifest.yml
+++ b/test-data/cassandra-parity-manifest.yml
@@ -71,7 +71,7 @@ scenarios:
 
   - id: cass.sstable_format.toc_component_manifest
     title: TOC.txt component manifest completeness
-    status: partial
+    status: mirrored
     capability: sstable_format
     priority: P0
     risk: p1_correctness
@@ -84,31 +84,54 @@ scenarios:
       coverage:
         suite: sstable_parity_component_manifest
         tests:
-          - cqlite-core/tests/sstable_parity_integration_test.rs
+          - cqlite-core/tests/sstable_parity_toc_component_test.rs
+        notes: >-
+          Gated, fixture-backed strict lane over every committed Cassandra TOC.txt
+          (nb/oa BIG and da BTI). Asserts (1) every component Cassandra named is
+          recognized and round-trips byte-exactly to its filename suffix — no
+          unknown-component fallbacks, no silent drops; (2) the always-present
+          component set (Data/Statistics/TOC/Digest/Filter) is complete; and
+          (3) BIG-vs-BTI discovery parity — the format declared in the filename
+          (parsed authoritatively, no heuristics) agrees with the on-disk
+          component manifest (Index+Summary for BIG, Partitions+Rows for BTI) and
+          the two families never mix. Exposed and fixed a real gap: CQLite's
+          component model did not recognize the `CRC.db` component Cassandra
+          emits for uncompressed SSTables.
     fixtures:
       references:
+        - test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-TOC.txt
+        - test-data/datasets/sstables/test_oa/collection_table-4b892c6064e711f1bd3ac7dbf655c673/oa-2-big-TOC.txt
         - test-data/datasets/sstables/test_da/simple_table-de1be8b064e711f19ad401a8c8227b11/da-2-bti-TOC.txt
     evidence:
       type: partial
       artifacts: [component_files]
       cassandra_version: "5.0.2"
       cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
-      storage_format_version: [da]
+      storage_format_version: [nb, oa, da]
       fixture_generation_command: >-
-        bash test-data/scripts/regenerate-datasets.sh  # cassandra:5.0.2 BTI flush emits TOC.txt
+        bash test-data/scripts/regenerate-datasets.sh  # cassandra:5.0.2 flush emits TOC.txt per generation
       reference_paths:
+        - test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-TOC.txt
+        - test-data/datasets/sstables/test_oa/collection_table-4b892c6064e711f1bd3ac7dbf655c673/oa-2-big-TOC.txt
         - test-data/datasets/sstables/test_da/simple_table-de1be8b064e711f19ad401a8c8227b11/da-2-bti-TOC.txt
       known_limitations: >-
-        Component set is compared as an unordered set on read; an exact
-        TOC.txt byte/line comparison against the Cassandra reference is not
-        yet a gated test.
+        Parity is on the recognized component *set* and format-discovery, not the
+        exact TOC.txt line order: Cassandra emits components in HashSet iteration
+        order, so line order is not a stable writer goal (cf. epic #968 "exact
+        parsed fields where byte identity is not a stable writer goal"). Digest.crc32
+        byte parity (recomputing the Data.db CRC) and Index/Summary/Statistics/
+        CompressionInfo/Filter byte parity require the binary components and remain
+        separate #982/#968 scenarios.
     ci:
       tier: fast_pr
     scope:
-      gap: No gated exact TOC.txt comparison against the Cassandra-produced manifest.
+      gap: >-
+        Companion-component *byte* parity (Digest.crc32 CRC recomputation,
+        Index.db/Summary.db byte layout) is not yet gated; it depends on fetched
+        binary Data.db components.
       next_step: >-
-        Add a component-manifest byte comparison to the
-        sstable_parity_component_manifest suite.
+        Land the Digest.crc32 and Index.db/Summary.db byte-parity scenarios in the
+        Required parity tier once the binary dataset fetch is wired into CI.
 
   # ----------------------------------------------------------------------------
   # data_db_decode


### PR DESCRIPTION
## Summary

Begins epic #966 (Cassandra byte-for-byte parity program) on its first open leaf — #982, under epic #968 (SSTable Component Byte Parity) — with the binary-free slice that runs in the **Fast PR** tier against the Cassandra `TOC.txt` references already committed to the repo (nb/oa BIG and da BTI). No `Data.db` binary, Docker, or live Cassandra required.

#967 (manifest + lint/report tooling) was already complete; this is the next increment.

## What's in it

**New gated test** `cqlite-core/tests/sstable_parity_toc_component_test.rs`:
- **Strict TOC.txt parsing parity** — every component Cassandra named is recognized and round-trips byte-exactly to its filename suffix; no unknown-component fallbacks, no silent drops (`parsed set == raw TOC lines`).
- **Component-set completeness** — `Data`/`Statistics`/`TOC`/`Digest`/`Filter` present in every one of the 86 committed fixtures.
- **BIG-vs-BTI discovery parity** — the format declared in the filename (parsed authoritatively via `SsTableDescriptor`, **no heuristics**) agrees with the on-disk component manifest (`Index`+`Summary` for BIG, `Partitions`+`Rows` for BTI), and the two families never mix.
- **Fail-closed**: zero fixtures found, or either family never exercised, turns the lane red — not a silent skip.

**Real gap fixed** that the strict lane exposed: CQLite's component model did not recognize the `CRC.db` component Cassandra emits for **uncompressed** SSTables (present in `test_basic.uncompressed_table`). Added `SSTableComponent::Crc` (`from_str` / `file_extension` / writer TOC ordering); it is optional and shared by BIG and BTI. Without this, `CRC.db` was silently dropped as an unknown component.

**Manifest + report**: `cass.sstable_format.toc_component_manifest` `partial → mirrored`, references expanded to nb/oa/da, test target pointed at the new suite. Evidence intentionally kept **`partial`** (component-set + discovery is *not* full companion-component byte parity — that honesty is the point of this program). `docs/reports/cassandra-test-parity.md` regenerated to match.

## Verification

The agent environment cannot compile this workspace (crate downloads are egress-policy-blocked and nothing is cached) and the binary datasets cannot be fetched, so local `cargo test`/`clippy` could not run. Mitigations applied:
- `rustfmt` (stable) passes on all changed Rust files.
- Manifest YAML validated; status/evidence counts recomputed; report hand-reconciled field-by-field against `report.rs`.
- The new test's assertions were validated against the committed corpus out-of-band (all 86 TOCs satisfy completeness + BIG/BTI rules; all 11 distinct component names now recognized).
- Compile audit: the only exhaustive `match` on the enum (`toc_writer.rs` sort) was updated; every other use is `matches!`/`==`/construction.

**CI is the authoritative check** — the `Cassandra Parity Manifest` workflow (lint + `report --check` + tool tests) and `cqlite-core` tests run on this PR.

## Follow-ups filed
- #1047 — Digest.crc32 and companion-component **byte** parity (the remaining `#982` byte-level scope; blocked on wiring the binary dataset fetch into the Required parity tier).
- #1048 — recognize `CRC.db` in the second `format_detector::SSTableComponent` enum for consistency.

Closes #982.

https://claude.ai/code/session_01KExjHWdmVTkt84CiTbHoni

---
_Generated by [Claude Code](https://claude.ai/code/session_01KExjHWdmVTkt84CiTbHoni)_