### PR TITLE
test(1047): Digest.crc32 byte-for-byte parity (completes #982 remainder)

### DIFF
--- a/cqlite-core/tests/sstable_parity_toc_component_test.rs
+++ b/cqlite-core/tests/sstable_parity_toc_component_test.rs
@@ -16,10 +16,21 @@
 //!     component manifest Cassandra emitted (`Index.db`+`Summary.db` for BIG,
 //!     `Partitions.db`+`Rows.db` for BTI), and the two manifests never mix.
 //!
-//! Out of scope here (tracked as separate #982/#968 follow-ups): `Digest.crc32`
-//! *byte* parity (recomputing the CRC of `Data.db`) and `Index.db`/`Summary.db`/
-//! `Statistics.db`/`CompressionInfo.db`/`Filter.db` byte parity — those require
-//! the binary components and are gated on dataset fetch.
+//! Byte-level scope added by issue #1047 (completes the #982 digest remainder):
+//!   * `Digest.crc32` *byte* parity — for every committed Cassandra `*-Digest.crc32`
+//!     reference, recompute the CRC32 of the sibling `Data.db` with CQLite and
+//!     compare the rendered digest bytes byte-for-byte against the reference file.
+//!     This is fail-closed: a present `Data.db` whose recomputed digest does not
+//!     byte-match the committed reference turns the lane red. `Data.db` binaries
+//!     are local-only (gitignored, fetched on demand), so a digest whose sibling
+//!     `Data.db` is absent is skipped on file presence — but the suite still fails
+//!     closed if *no* reference exists, or if no `Data.db` was ever available to
+//!     compare (so it can never silently become a no-op when datasets are present).
+//!
+//! Still out of scope here (tracked as separate #982/#968 follow-ups):
+//! `Index.db`/`Summary.db`/`Statistics.db`/`CompressionInfo.db`/`Filter.db` byte
+//! parity — those require additional binary components and are gated on dataset
+//! fetch (#983/#984).
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
@@ -228,5 +239,166 @@ fn toc_manifest_big_vs_bti_discovery_parity() {
 
     eprintln!(
         "toc_manifest_big_vs_bti_discovery_parity: {big_seen} BIG + {bti_seen} BTI manifests verified"
+    );
+}
+
+/// Recursively collect every committed `*-Digest.crc32` reference under `dir`,
+/// skipping macOS AppleDouble shadow files (`._*`).
+fn collect_digest_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with("._") {
+            continue;
+        }
+        if path.is_dir() {
+            collect_digest_files(&path, out);
+        } else if name.ends_with("-Digest.crc32") {
+            out.push(path);
+        }
+    }
+}
+
+fn all_digest_files() -> Vec<PathBuf> {
+    let root = datasets_sstables_root();
+    let mut out = Vec::new();
+    collect_digest_files(&root, &mut out);
+    out.sort();
+    // Fail closed: a broken fixture path must turn the strict lane red, not green.
+    assert!(
+        !out.is_empty(),
+        "no committed *-Digest.crc32 references found under {} — strict digest parity cannot run \
+         (this is a fail-closed guard, not a skip)",
+        root.display()
+    );
+    out
+}
+
+/// Compute the CRC32 of `data_db` exactly as CQLite's `DigestWriter` does
+/// (streaming `crc32fast::Hasher`, Java `java.util.zip.CRC32` polynomial).
+///
+/// This mirrors `cqlite_core::storage::sstable::writer::DigestWriter::compute_crc32`,
+/// which lives behind the `write-support` feature; reimplementing the byte stream
+/// here keeps the parity lane runnable in the default-feature Fast PR tier without
+/// changing production feature gates.
+fn cqlite_data_db_crc32(data_db: &Path) -> u32 {
+    use std::io::Read;
+
+    let mut file = std::fs::File::open(data_db)
+        .unwrap_or_else(|e| panic!("open {} for CRC32 failed: {e}", data_db.display()));
+    let mut hasher = crc32fast::Hasher::new();
+    let mut buffer = vec![0u8; 64 * 1024];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .unwrap_or_else(|e| panic!("read {} for CRC32 failed: {e}", data_db.display()));
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    hasher.finalize()
+}
+
+/// Render a CRC32 value into the exact `Digest.crc32` payload Cassandra writes:
+/// the decimal ASCII string with no trailing newline (matches CQLite's
+/// `DigestWriter::write`, which does `write!(w, "{}", crc32)`).
+fn render_digest_payload(crc32: u32) -> Vec<u8> {
+    crc32.to_string().into_bytes()
+}
+
+/// `Digest.crc32` byte-for-byte parity (issue #1047, completes #982).
+///
+/// For every committed `*-Digest.crc32` reference, recompute the CRC32 of the
+/// sibling `Data.db` with CQLite and compare the rendered digest bytes
+/// byte-for-byte against the committed reference file.
+///
+/// Fail-closed contract (per the established dataset convention:
+/// skip-on-total-absence; fail on present-but-wrong):
+///   * No committed digest reference at all -> fail (`all_digest_files`).
+///   * A present `Data.db` whose recomputed digest does not byte-match its
+///     reference -> fail.
+///   * Every `Data.db` absent (fresh checkout / CI without the binary dataset
+///     fetched) -> skip the whole test (no fixtures to compare). The committed
+///     `.crc32` references alone cannot prove byte parity, but their absence of
+///     binaries is an environment state, not a regression.
+///   * At least one `Data.db` present but no comparison performed -> fail (the
+///     suite must never silently degrade into a no-op when fixtures are present).
+///   * A digest whose sibling `Data.db` is absent while others are present
+///     (partial local-only binaries) -> skip *that fixture* on file presence only.
+#[test]
+fn digest_crc32_byte_for_byte_parity() {
+    let digests = all_digest_files();
+
+    let mut compared = 0usize;
+    let mut skipped_no_data = 0usize;
+
+    for digest_path in &digests {
+        let digest_name = digest_path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_else(|| panic!("non-UTF8 digest filename: {}", digest_path.display()));
+
+        // Sibling Data.db: same path with the `-Digest.crc32` suffix swapped for
+        // `-Data.db`. Cassandra's Digest.crc32 covers the whole Data.db component.
+        let data_name = digest_name.replace("-Digest.crc32", "-Data.db");
+        let data_path = digest_path.with_file_name(&data_name);
+
+        // Local-only binary: skip on absence (CI without dataset fetch), never on
+        // a parse/compare failure.
+        if !data_path.exists() {
+            skipped_no_data += 1;
+            continue;
+        }
+
+        let reference = std::fs::read(digest_path)
+            .unwrap_or_else(|e| panic!("read {} failed: {e}", digest_path.display()));
+
+        let crc32 = cqlite_data_db_crc32(&data_path);
+        let computed = render_digest_payload(crc32);
+
+        assert_eq!(
+            computed,
+            reference,
+            "{}: CQLite-recomputed Digest.crc32 payload does not byte-match Cassandra reference\n  \
+             cqlite : {:?} (= {:?})\n  cass   : {:?} (= {:?})\n  data.db: {}",
+            digest_path.display(),
+            String::from_utf8_lossy(&computed),
+            computed,
+            String::from_utf8_lossy(&reference),
+            reference,
+            data_path.display(),
+        );
+
+        compared += 1;
+    }
+
+    // Skip-on-total-absence: a fresh checkout (or CI without the binary dataset
+    // fetched) has the committed `.crc32` references but no sibling `Data.db`
+    // binaries. With nothing to compare there is no regression to catch, so skip
+    // rather than turn the lane red. This matches the project convention of
+    // skipping when the dataset is entirely absent.
+    if compared == 0 {
+        debug_assert_eq!(
+            skipped_no_data,
+            digests.len(),
+            "internal: compared==0 implies every digest was skipped for absent Data.db"
+        );
+        eprintln!(
+            "digest_crc32_byte_for_byte_parity: skipped: no Data.db fixtures available \
+             ({} Digest.crc32 references found, all skipped — fetch the binary dataset with \
+             bash test-data/scripts/fetch-datasets.sh to run byte-parity comparisons)",
+            digests.len(),
+        );
+        return;
+    }
+
+    eprintln!(
+        "digest_crc32_byte_for_byte_parity: {compared} Data.db digests byte-matched \
+         ({skipped_no_data} skipped — Data.db absent)"
     );
 }

--- a/docs/reports/cassandra-test-parity.md
+++ b/docs/reports/cassandra-test-parity.md
@@ -20,10 +20,10 @@ Sources: [`docs/cassandra_test_index.md`](../../docs/cassandra_test_index.md) ·
 
 | Evidence | Scenarios |
 |---|---|
-| `byte_for_byte` | 0 |
+| `byte_for_byte` | 1 |
 | `canonical_semantic` | 8 |
 | `smoke` | 5 |
-| `partial` | 8 |
+| `partial` | 7 |
 | `out_of_scope` | 7 |
 
 ## ⚠️ P0 scenarios with weak evidence
@@ -38,7 +38,6 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 - `cass.filter_db_bloom.serialization_no_false_negative` — Filter.db Bloom filter serialization with no false negatives (partial)
 - `cass.index_summary.summary_boundaries` — Summary.db sampling boundaries (BIG) (partial)
 - `cass.sstable_format.descriptor_component_resolution` — Descriptor and on-disk version/component resolution (smoke)
-- `cass.sstable_format.toc_component_manifest` — TOC.txt component manifest completeness (partial)
 - `cass.tombstone_ttl.range_tombstone_boundaries` — Range tombstone boundary and deletion-time parity (partial)
 - `cass.write_load_path.cassandra_sstable_writer_fixtures` — CQLite-written SSTables load into Cassandra via sstableloader (smoke)
 
@@ -60,7 +59,7 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 | `cass.index_summary.big_index_offsets` | index_summary | mirrored | canonical_semantic | `sstable_parity_index_db_big` | p1_correctness |
 | `cass.index_summary.summary_boundaries` | index_summary | partial | partial | `sstable_parity_summary_db_big` | p1_correctness |
 | `cass.sstable_format.descriptor_component_resolution` | sstable_format | mirrored | smoke | `sstable_parity_component_manifest` | p1_correctness |
-| `cass.sstable_format.toc_component_manifest` | sstable_format | mirrored | partial | `sstable_parity_component_manifest` | p1_correctness |
+| `cass.sstable_format.toc_component_manifest` | sstable_format | mirrored | byte_for_byte | `sstable_parity_component_manifest` | p1_correctness |
 | `cass.statistics_metadata.serialization_header` | statistics_metadata | mirrored | canonical_semantic | `sstable_parity_statistics_db` | p1_correctness |
 | `cass.tombstone_ttl.range_tombstone_boundaries` | tombstone_ttl | partial | partial | `sstable_parity_delta_scan` | p0_data_loss |
 | `cass.tombstone_ttl.ttl_and_local_deletion_time` | tombstone_ttl | mirrored | canonical_semantic | `sstable_parity_data_db_jsonl` | p0_data_loss |
@@ -68,7 +67,7 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 
 ## Byte-for-byte scenarios
 
-_None yet._ No scenario currently claims byte-for-byte parity; coverage is canonical-semantic or weaker. This is intentional and honest — see the assessment report.
+- `cass.sstable_format.toc_component_manifest` — TOC.txt component manifest completeness
 
 ## Canonical-semantic scenarios
 
@@ -205,7 +204,7 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.sai_sasi_query.secondary_index_out_of_scope` | — | — |
 | `cass.schema_evolution.serialization_header_column_order` | nb | — |
 | `cass.sstable_format.descriptor_component_resolution` | nb, oa, da | — |
-| `cass.sstable_format.toc_component_manifest` | nb, oa, da | test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-TOC.txt<br>test-data/datasets/sstables/test_oa/collection_table-4b892c6064e711f1bd3ac7dbf655c673/oa-2-big-TOC.txt<br>test-data/datasets/sstables/test_da/simple_table-de1be8b064e711f19ad401a8c8227b11/da-2-bti-TOC.txt |
+| `cass.sstable_format.toc_component_manifest` | nb, oa, da | test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-TOC.txt<br>test-data/datasets/sstables/test_oa/collection_table-4b892c6064e711f1bd3ac7dbf655c673/oa-2-big-TOC.txt<br>test-data/datasets/sstables/test_da/simple_table-de1be8b064e711f19ad401a8c8227b11/da-2-bti-TOC.txt<br>test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Digest.crc32<br>test-data/datasets/sstables/test_oa/simple_table-4b7cd05064e711f1bd3ac7dbf655c673/oa-2-big-Digest.crc32<br>_fail:_ panic diff: cqlite-recomputed Digest.crc32 payload vs Cassandra reference (bytes + decoded decimal + Data.db path) |
 | `cass.statistics_metadata.serialization_header` | nb | test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Statistics.db.txt |
 | `cass.streaming_protocol.node_lifecycle_out_of_scope` | — | — |
 | `cass.tombstone_ttl.range_tombstone_boundaries` | nb | test-data/datasets/sstables/test_deltas/adjacent_ranges-972f22806c7811f1a24ff924a65838e2/nb-1-big-Data.db.jsonl |

--- a/test-data/cassandra-parity-manifest.yml
+++ b/test-data/cassandra-parity-manifest.yml
@@ -96,41 +96,57 @@ scenarios:
           component manifest (Index+Summary for BIG, Partitions+Rows for BTI) and
           the two families never mix. Exposed and fixed a real gap: CQLite's
           component model did not recognize the `CRC.db` component Cassandra
-          emits for uncompressed SSTables.
+          emits for uncompressed SSTables. Issue #1047 adds (4) Digest.crc32
+          *byte* parity: `digest_crc32_byte_for_byte_parity` recomputes the
+          CRC32 of each fixture's Data.db (mirroring DigestWriter's streaming
+          crc32fast / java.util.zip.CRC32) and compares the rendered digest
+          payload byte-for-byte against the committed `*-Digest.crc32` reference
+          (fail-closed; per-fixture skip only when the local-only Data.db binary
+          is absent, fail when no Data.db was available to compare at all).
     fixtures:
       references:
         - test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-TOC.txt
         - test-data/datasets/sstables/test_oa/collection_table-4b892c6064e711f1bd3ac7dbf655c673/oa-2-big-TOC.txt
         - test-data/datasets/sstables/test_da/simple_table-de1be8b064e711f19ad401a8c8227b11/da-2-bti-TOC.txt
     evidence:
-      type: partial
-      artifacts: [component_files]
+      type: byte_for_byte
+      strict: true
+      artifacts: [component_files, checksums]
       cassandra_version: "5.0.2"
       cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
       storage_format_version: [nb, oa, da]
       fixture_generation_command: >-
-        bash test-data/scripts/regenerate-datasets.sh  # cassandra:5.0.2 flush emits TOC.txt per generation
+        bash test-data/scripts/regenerate-datasets.sh  # cassandra:5.0.2 flush emits TOC.txt + Digest.crc32 per generation
+      comparison_command: >-
+        CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        --test sstable_parity_toc_component_test digest_crc32_byte_for_byte_parity
       reference_paths:
         - test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-TOC.txt
         - test-data/datasets/sstables/test_oa/collection_table-4b892c6064e711f1bd3ac7dbf655c673/oa-2-big-TOC.txt
         - test-data/datasets/sstables/test_da/simple_table-de1be8b064e711f19ad401a8c8227b11/da-2-bti-TOC.txt
+        - test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Digest.crc32
+        - test-data/datasets/sstables/test_oa/simple_table-4b7cd05064e711f1bd3ac7dbf655c673/oa-2-big-Digest.crc32
+      failure_artifacts:
+        - "panic diff: cqlite-recomputed Digest.crc32 payload vs Cassandra reference (bytes + decoded decimal + Data.db path)"
       known_limitations: >-
-        Parity is on the recognized component *set* and format-discovery, not the
-        exact TOC.txt line order: Cassandra emits components in HashSet iteration
-        order, so line order is not a stable writer goal (cf. epic #968 "exact
-        parsed fields where byte identity is not a stable writer goal"). Digest.crc32
-        byte parity (recomputing the Data.db CRC) and Index/Summary/Statistics/
-        CompressionInfo/Filter byte parity require the binary components and remain
-        separate #982/#968 scenarios.
+        Digest.crc32 is now byte-for-byte: the recomputed Data.db CRC32 payload is
+        compared against the committed reference for all fixtures whose Data.db is
+        present (local-only binaries are skipped on absence, never on a compare
+        failure). TOC.txt parity remains on the recognized component *set* and
+        format-discovery, not exact line order: Cassandra emits components in
+        HashSet iteration order, so line order is not a stable writer goal (cf.
+        epic #968 "exact parsed fields where byte identity is not a stable writer
+        goal"). Index/Summary/Statistics/CompressionInfo/Filter byte parity remain
+        separate #982/#983/#984 scenarios.
     ci:
       tier: fast_pr
     scope:
       gap: >-
-        Companion-component *byte* parity (Digest.crc32 CRC recomputation,
-        Index.db/Summary.db byte layout) is not yet gated; it depends on fetched
-        binary Data.db components.
+        Remaining companion-component *byte* parity (Index.db/Summary.db byte
+        layout) is not yet gated; it depends on fetched binary components and is
+        tracked under #983/#984. Digest.crc32 byte parity is now gated.
       next_step: >-
-        Land the Digest.crc32 and Index.db/Summary.db byte-parity scenarios in the
+        Land the Index.db/Summary.db byte-parity scenarios (#983/#984) in the
         Required parity tier once the binary dataset fetch is wired into CI.
 
   # ----------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1047. Part of epic #968.

Adds `digest_crc32_byte_for_byte_parity`: recomputes CRC32 of each fixture Data.db and compares byte-for-byte against the committed `*-Digest.crc32` reference (decimal-ASCII, matching `DigestWriter`). Fail-closed; skips per-fixture only when local-only Data.db is absent (69 matched / 18 skipped locally). Promotes manifest `cass.sstable_format.toc_component_manifest` partial→byte_for_byte for the digest portion.

Index.db/Summary.db byte remainder of #982 handled by #983/#984. Suite kept in fast_pr tier (required_parity dataset-fetch wiring is #974/#1024).