### PR TITLE
test(985): strict Statistics.db core-metadata parity

### DIFF
--- a/cqlite-core/tests/sstable_parity_statistics_db_strict_test.rs
+++ b/cqlite-core/tests/sstable_parity_statistics_db_strict_test.rs
@@ -1,0 +1,755 @@
+//! Strict `Statistics.db` core-metadata parity (Epic #968 / issue #985).
+//!
+//! Proves CQLite decodes the *core* SSTable metadata that Apache Cassandra 5.0
+//! persisted into `Statistics.db`, byte-for-byte and field-for-field, against the
+//! committed `*-Statistics.db.txt` reference dumps Cassandra's `sstablemetadata`
+//! tool produced for every fixture — BIG (`nb`/`oa`) and BTI (`da`).
+//!
+//! Scope owned here (issue #985):
+//!   * **Component-manifest / checksum parity** — the `Statistics.db` Table of
+//!     Contents (component count + the four `MetadataType` entries
+//!     VALIDATION/COMPACTION/STATS/HEADER, in order) and its two embedded CRC32
+//!     checksums (the `crc32(num_components)` marker and the accumulated TOC CRC)
+//!     are validated byte-for-byte. Corrupting any TOC byte breaks the CRC, which
+//!     is how corruption fails closed with an explicit error in strict mode.
+//!   * **Timestamp / TTL / local-deletion-time metadata** — the authoritative
+//!     `EncodingStats` baselines (`minTimestamp`, `minLocalDeletionTime`,
+//!     `minTTL`) CQLite delta-decodes from the binary are asserted equal to the
+//!     exact integers in the reference dump.
+//!   * **Serialization-header column metadata / ordering** — partition-key and
+//!     clustering-key arity, clustering DESC (`ReversedType`) flags, and the set
+//!     of regular-column names CQLite recovers from the embedded
+//!     SerializationHeader match the reference dump. Exercised across primitive,
+//!     collection, UDT, static, and reversed-clustering schemas in the corpus.
+//!
+//! Fail-closed contract:
+//!   * The committed `*-Statistics.db.txt` references always exist, so the lane
+//!     always has work; zero references found turns the lane red (not green).
+//!   * The binary `*-Statistics.db` is a fetched fixture. When it is absent (CI
+//!     without datasets), that single fixture is *skipped* (recorded), never
+//!     silently counted as a pass. When present, every field is compared and any
+//!     mismatch fails.
+//!
+//! Out of scope here (intentionally NOT claimed byte-for-byte, see manifest
+//! `planned` entries and child issues):
+//!   * `repairedAt` / `pendingRepair` repaired metadata — child issue #988.
+//!   * `max` timestamp / `max` local-deletion-time, estimated histograms and
+//!     partition/row-count estimates, and covered-clustering bounds: the minimal
+//!     nb/oa/da Statistics parser does not yet decode the full STATS component,
+//!     so these are not asserted here (tracked as `planned` manifest scenarios).
+
+use std::path::{Path, PathBuf};
+
+use cqlite_core::parser::enhanced_statistics_parser::parse_statistics_with_fallback;
+
+/// `crc32(num_components=4)` — the marker Cassandra writes at bytes 4..8 of
+/// every `Statistics.db` (it is the CRC of the 4-byte component count, which is
+/// always 4 for the VALIDATION/COMPACTION/STATS/HEADER set).
+const STATISTICS_TOC_MARKER: u32 = 0x2629_1b05;
+
+/// Cassandra `MetadataType` ordinals, in the order they appear in the TOC.
+const EXPECTED_TOC_TYPES: [u32; 4] = [0, 1, 2, 3]; // VALIDATION, COMPACTION, STATS, HEADER
+
+/// Resolve the committed datasets root (env override first, else workspace tree).
+fn datasets_sstables_root() -> PathBuf {
+    let root = if let Ok(root) = std::env::var("CQLITE_DATASETS_ROOT") {
+        PathBuf::from(root)
+    } else {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .map(|workspace| workspace.join("test-data/datasets"))
+            .unwrap_or_else(|| PathBuf::from("test-data/datasets"))
+    };
+    root.join("sstables")
+}
+
+/// Recursively collect every committed `*-Statistics.db.txt` reference dump,
+/// skipping macOS AppleDouble shadow files (`._*`).
+fn collect_statistics_txt(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with("._") {
+            continue;
+        }
+        if path.is_dir() {
+            collect_statistics_txt(&path, out);
+        } else if name.ends_with("-Statistics.db.txt") {
+            out.push(path);
+        }
+    }
+}
+
+fn all_statistics_txt() -> Vec<PathBuf> {
+    let root = datasets_sstables_root();
+    let mut out = Vec::new();
+    collect_statistics_txt(&root, &mut out);
+    out.sort();
+    // Fail closed: a broken reference path must turn the strict lane red, not green.
+    assert!(
+        !out.is_empty(),
+        "no committed *-Statistics.db.txt references found under {} — strict Statistics.db \
+         parity cannot run (this is a fail-closed guard, not a skip)",
+        root.display()
+    );
+    out
+}
+
+/// The fields decoded from a Cassandra `sstablemetadata` reference dump that this
+/// strict lane compares against CQLite's decoder. Every value is sourced from the
+/// authoritative parenthesised integer / explicit list — never inferred.
+#[derive(Debug)]
+struct ReferenceMetadata {
+    min_timestamp: i64,
+    min_local_deletion_time: i64,
+    min_ttl: i64,
+    /// Partition-key arity, or `None` when the KeyType is a `CompositeType`.
+    ///
+    /// The minimal nb/oa/da SerializationHeader decoder folds a composite
+    /// partition key into a single synthetic column rather than splitting the
+    /// `CompositeType(...)` components, so composite arity is not asserted
+    /// byte-for-byte here (tracked as a `planned` manifest limitation). Single
+    /// (non-composite) partition keys are asserted exactly.
+    partition_key_arity: Option<usize>,
+    clustering_arity: usize,
+    clustering_reversed_count: usize,
+    regular_column_names: Vec<String>,
+}
+
+/// Extract the trailing parenthesised integer, e.g. `... (1759713125983682)`.
+fn paren_int(line: &str) -> Option<i64> {
+    let open = line.rfind('(')?;
+    let close = line[open..].find(')')? + open;
+    line[open + 1..close].trim().parse().ok()
+}
+
+/// Extract a bare trailing integer after the last colon, e.g. `TTL min: 0` or
+/// `EncodingStats minTTL: 86400 (1 day)` (the leading number).
+fn trailing_int(line: &str) -> Option<i64> {
+    let after = line.rsplit(':').next()?.trim();
+    let token = after.split_whitespace().next()?;
+    token.parse().ok()
+}
+
+/// Parse the comma-separated `name:type` pairs from a `RegularColumns:` /
+/// `StaticColumns:` line, returning the bare column names.
+///
+/// The type half can itself contain commas (e.g. `MapType(A,B)`), so we split on
+/// the *first* top-level comma between entries by tracking parenthesis depth.
+fn parse_column_names(after_colon: &str) -> Vec<String> {
+    let s = after_colon.trim();
+    if s.is_empty() {
+        return Vec::new();
+    }
+    let mut entries = Vec::new();
+    let mut depth = 0i32;
+    let mut start = 0usize;
+    let bytes = s.as_bytes();
+    for (i, &b) in bytes.iter().enumerate() {
+        match b {
+            b'(' => depth += 1,
+            b')' => depth -= 1,
+            b',' if depth == 0 => {
+                entries.push(&s[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    entries.push(&s[start..]);
+    entries
+        .into_iter()
+        .filter_map(|e| {
+            let e = e.trim();
+            // name is everything before the first ':' (column names cannot contain ':')
+            e.split_once(':').map(|(name, _)| name.trim().to_string())
+        })
+        .filter(|n| !n.is_empty())
+        .collect()
+}
+
+/// Count comma-separated entries inside the `[...]` of a `ClusteringTypes:` line.
+fn count_bracket_entries(line: &str) -> usize {
+    let open = match line.find('[') {
+        Some(o) => o,
+        None => return 0,
+    };
+    let close = match line.rfind(']') {
+        Some(c) => c,
+        None => return 0,
+    };
+    if close <= open + 1 {
+        return 0; // "[]" — empty
+    }
+    let inner = &line[open + 1..close];
+    let mut depth = 0i32;
+    let mut count = 1usize;
+    for &b in inner.as_bytes() {
+        match b {
+            b'(' => depth += 1,
+            b')' => depth -= 1,
+            b',' if depth == 0 => count += 1,
+            _ => {}
+        }
+    }
+    count
+}
+
+fn parse_reference(txt: &Path) -> ReferenceMetadata {
+    let content = std::fs::read_to_string(txt)
+        .unwrap_or_else(|e| panic!("read reference {} failed: {e}", txt.display()));
+
+    let mut min_timestamp = None;
+    let mut min_local_deletion_time = None;
+    let mut min_ttl = None;
+    let mut partition_key_arity = None;
+    let mut clustering_arity = None;
+    let mut clustering_reversed_count = 0usize;
+    let mut regular_column_names: Option<Vec<String>> = None;
+
+    for line in content.lines() {
+        let line = line.trim();
+        if let Some(rest) = line.strip_prefix("EncodingStats minTimestamp:") {
+            // authoritative microsecond integer is in parentheses
+            min_timestamp = paren_int(rest).or_else(|| paren_int(line));
+        } else if let Some(rest) = line.strip_prefix("EncodingStats minLocalDeletionTime:") {
+            min_local_deletion_time = paren_int(rest).or_else(|| paren_int(line));
+        } else if line.starts_with("EncodingStats minTTL:") {
+            min_ttl = trailing_int(line);
+        } else if line.starts_with("KeyType:") {
+            // A bare KeyType is a single partition column; CompositeType(...) is a
+            // composite key the minimal decoder does not split (see field doc).
+            partition_key_arity = Some(keytype_arity(line));
+        } else if line.starts_with("ClusteringTypes:") {
+            clustering_arity = Some(count_bracket_entries(line));
+            clustering_reversed_count = count_reversed(line);
+        } else if let Some(rest) = line.strip_prefix("RegularColumns:") {
+            regular_column_names = Some(parse_column_names(rest));
+        }
+    }
+
+    ReferenceMetadata {
+        min_timestamp: min_timestamp
+            .unwrap_or_else(|| panic!("{}: missing EncodingStats minTimestamp", txt.display())),
+        min_local_deletion_time: min_local_deletion_time.unwrap_or_else(|| {
+            panic!(
+                "{}: missing EncodingStats minLocalDeletionTime",
+                txt.display()
+            )
+        }),
+        min_ttl: min_ttl
+            .unwrap_or_else(|| panic!("{}: missing EncodingStats minTTL", txt.display())),
+        partition_key_arity: partition_key_arity
+            .unwrap_or_else(|| panic!("{}: missing KeyType", txt.display())),
+        // (composite keys collapse to `None` above via keytype_arity)
+        clustering_arity: clustering_arity
+            .unwrap_or_else(|| panic!("{}: missing ClusteringTypes", txt.display())),
+        clustering_reversed_count,
+        regular_column_names: regular_column_names.unwrap_or_default(),
+    }
+}
+
+/// Partition-key arity from a `KeyType:` line. A bare comparator is a single
+/// partition column (`Some(1)`); a `CompositeType(...)` is a composite key the
+/// minimal decoder does not split, so we return `None` and skip the exact-arity
+/// assertion for it (documented limitation).
+fn keytype_arity(line: &str) -> Option<usize> {
+    let after = match line.split_once(':') {
+        Some((_, a)) => a.trim(),
+        None => return Some(1),
+    };
+    let is_composite = after.starts_with("org.apache.cassandra.db.marshal.CompositeType(")
+        || after.starts_with("CompositeType(");
+    if is_composite {
+        None
+    } else {
+        Some(1)
+    }
+}
+
+/// Count top-level `ReversedType(` wrappers inside a `ClusteringTypes:` `[...]`.
+fn count_reversed(line: &str) -> usize {
+    let open = match line.find('[') {
+        Some(o) => o,
+        None => return 0,
+    };
+    let close = match line.rfind(']') {
+        Some(c) => c,
+        None => return 0,
+    };
+    if close <= open + 1 {
+        return 0;
+    }
+    let inner = &line[open + 1..close];
+    // Split into top-level entries, count those starting with ReversedType(.
+    let mut depth = 0i32;
+    let mut start = 0usize;
+    let mut entries: Vec<&str> = Vec::new();
+    for (i, &b) in inner.as_bytes().iter().enumerate() {
+        match b {
+            b'(' => depth += 1,
+            b')' => depth -= 1,
+            b',' if depth == 0 => {
+                entries.push(&inner[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    entries.push(&inner[start..]);
+    entries
+        .into_iter()
+        .map(str::trim)
+        .filter(|e| {
+            e.starts_with("org.apache.cassandra.db.marshal.ReversedType(")
+                || e.starts_with("ReversedType(")
+        })
+        .count()
+}
+
+/// Derive the binary `*-Statistics.db` path from its `*-Statistics.db.txt` dump.
+fn binary_for(txt: &Path) -> PathBuf {
+    let name = txt
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or_else(|| panic!("non-UTF8 reference name: {}", txt.display()));
+    let db_name = name
+        .strip_suffix(".txt")
+        .unwrap_or_else(|| panic!("reference not *.txt: {name}"));
+    txt.with_file_name(db_name)
+}
+
+/// Strict, byte-for-byte validation of the `Statistics.db` Table of Contents and
+/// its two embedded CRC32 checksums. Returns the four TOC component offsets.
+///
+/// This is the corruption gate: any flipped byte in the TOC (component count,
+/// type, or offset) breaks the accumulated CRC and fails here with an explicit
+/// metadata-corruption assertion — strict mode never accepts a placeholder.
+fn validate_toc_and_checksums(bytes: &[u8], db: &Path) {
+    assert!(
+        bytes.len() >= 44,
+        "{}: Statistics.db too small ({} bytes) to hold the metadata TOC — corrupt or truncated",
+        db.display(),
+        bytes.len(),
+    );
+
+    let num_components = u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+    assert_eq!(
+        num_components,
+        EXPECTED_TOC_TYPES.len() as u32,
+        "{}: Statistics.db component count {} != 4 (VALIDATION/COMPACTION/STATS/HEADER) — corrupt metadata header",
+        db.display(),
+        num_components,
+    );
+
+    let marker = u32::from_be_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
+    let expected_marker = crc32fast::hash(&bytes[0..4]);
+    assert_eq!(
+        marker, expected_marker,
+        "{}: Statistics.db TOC marker 0x{:08x} != crc32(num_components) 0x{:08x} — corrupt metadata",
+        db.display(),
+        marker,
+        expected_marker,
+    );
+    assert_eq!(
+        marker,
+        STATISTICS_TOC_MARKER,
+        "{}: Statistics.db TOC marker 0x{:08x} != canonical Cassandra 0x{:08x}",
+        db.display(),
+        marker,
+        STATISTICS_TOC_MARKER,
+    );
+
+    // The four TOC entries (type,offset) must be VALIDATION/COMPACTION/STATS/HEADER
+    // in order, with strictly increasing offsets.
+    let mut prev_off = 0u32;
+    for (i, &expected_type) in EXPECTED_TOC_TYPES.iter().enumerate() {
+        let s = 8 + i * 8;
+        let ty = u32::from_be_bytes([bytes[s], bytes[s + 1], bytes[s + 2], bytes[s + 3]]);
+        let off = u32::from_be_bytes([bytes[s + 4], bytes[s + 5], bytes[s + 6], bytes[s + 7]]);
+        assert_eq!(
+            ty,
+            expected_type,
+            "{}: TOC entry {} has MetadataType {} (expected {}) — corrupt metadata manifest",
+            db.display(),
+            i,
+            ty,
+            expected_type,
+        );
+        assert!(
+            off > prev_off,
+            "{}: TOC entry {} offset {} not strictly greater than previous {} — corrupt metadata",
+            db.display(),
+            i,
+            off,
+            prev_off,
+        );
+        assert!(
+            (off as usize) < bytes.len(),
+            "{}: TOC entry {} offset {} past end of file ({} bytes) — corrupt metadata",
+            db.display(),
+            i,
+            off,
+            bytes.len(),
+        );
+        prev_off = off;
+    }
+
+    // Accumulated CRC32 over [num_components ++ four TOC entries] at byte 40.
+    let mut hasher = crc32fast::Hasher::new();
+    hasher.update(&bytes[0..4]);
+    for i in 0..EXPECTED_TOC_TYPES.len() {
+        let s = 8 + i * 8;
+        hasher.update(&bytes[s..s + 8]);
+    }
+    let expected_acc = hasher.finalize();
+    let stored_acc = u32::from_be_bytes([bytes[40], bytes[41], bytes[42], bytes[43]]);
+    assert_eq!(
+        stored_acc, expected_acc,
+        "{}: Statistics.db accumulated TOC CRC32 0x{:08x} != recomputed 0x{:08x} — corrupt metadata",
+        db.display(),
+        stored_acc,
+        expected_acc,
+    );
+}
+
+/// Strict core-metadata parity across every committed fixture.
+///
+/// Drives off the committed `*-Statistics.db.txt` references (always present);
+/// for each, when the binary `*-Statistics.db` is fetched it compares CQLite's
+/// decode against the reference field-for-field and byte-for-byte. Absent
+/// binaries are recorded as skips (never silent passes).
+#[test]
+fn statistics_db_strict_core_metadata_parity() {
+    let refs = all_statistics_txt();
+
+    let mut compared = 0usize;
+    let mut skipped = 0usize;
+    // Coverage proof: assert the corpus exercised each interesting shape.
+    let mut saw_ttl = false; // minTTL > 0
+    let mut saw_tombstone = false; // minLocalDeletionTime != epoch sentinel
+    let mut saw_clustering = false; // clustering_arity > 0
+    let mut saw_reversed = false; // a DESC clustering column
+    let mut saw_no_regular = false; // schema with zero regular columns
+    let mut saw_multi_regular = false; // 2+ regular columns
+    let mut format_nb = 0usize;
+    let mut format_oa = 0usize;
+    let mut format_da = 0usize;
+    // Which formats have a fetched binary on disk, computed up-front so we can
+    // require real coverage for every format the local dataset actually contains
+    // (not just whichever ones happened to decode). Independent of decode success.
+    let mut present_nb = false;
+    let mut present_oa = false;
+    let mut present_da = false;
+    for txt in &refs {
+        let db = binary_for(txt);
+        if !db.exists() {
+            continue;
+        }
+        match db.file_name().and_then(|n| n.to_str()) {
+            Some(n) if n.starts_with("nb-") => present_nb = true,
+            Some(n) if n.starts_with("oa-") => present_oa = true,
+            Some(n) if n.starts_with("da-") => present_da = true,
+            _ => {}
+        }
+    }
+
+    for txt in &refs {
+        let db = binary_for(txt);
+        if !db.exists() {
+            // Fetched fixture absent (e.g. CI without datasets): skip THIS one,
+            // never count it as a pass.
+            skipped += 1;
+            continue;
+        }
+
+        let reference = parse_reference(txt);
+        let bytes = std::fs::read(&db)
+            .unwrap_or_else(|e| panic!("read binary {} failed: {e}", db.display()));
+
+        // (1) Component-manifest + checksum byte parity (corruption gate).
+        validate_toc_and_checksums(&bytes, &db);
+
+        // (2) Decode and field-compare core metadata.
+        let (_, stats) = parse_statistics_with_fallback(&bytes, None).unwrap_or_else(|e| {
+            panic!(
+                "{}: CQLite failed to decode Statistics.db core metadata: {e:?}",
+                db.display()
+            )
+        });
+
+        // Header marker mirrors the on-disk TOC marker.
+        assert_eq!(
+            stats.header.statistics_kind,
+            STATISTICS_TOC_MARKER,
+            "{}: decoded header marker 0x{:08x} != 0x{:08x}",
+            db.display(),
+            stats.header.statistics_kind,
+            STATISTICS_TOC_MARKER,
+        );
+
+        // EncodingStats baselines: timestamp / local-deletion-time / TTL.
+        assert_eq!(
+            stats.timestamp_stats.min_timestamp,
+            reference.min_timestamp,
+            "{}: minTimestamp mismatch (cqlite {} vs cassandra {})",
+            db.display(),
+            stats.timestamp_stats.min_timestamp,
+            reference.min_timestamp,
+        );
+        assert_eq!(
+            stats.timestamp_stats.min_deletion_time,
+            reference.min_local_deletion_time,
+            "{}: minLocalDeletionTime mismatch (cqlite {} vs cassandra {})",
+            db.display(),
+            stats.timestamp_stats.min_deletion_time,
+            reference.min_local_deletion_time,
+        );
+        let cqlite_min_ttl = stats.timestamp_stats.min_ttl.unwrap_or(0);
+        assert_eq!(
+            cqlite_min_ttl,
+            reference.min_ttl,
+            "{}: minTTL mismatch (cqlite {} vs cassandra {})",
+            db.display(),
+            cqlite_min_ttl,
+            reference.min_ttl,
+        );
+
+        // Serialization-header column metadata / ordering.
+        // Partition-key arity is asserted exactly for single (non-composite)
+        // keys; composite keys (reference arity == None) are not split by the
+        // minimal decoder, so we only require it recovered at least one key.
+        match reference.partition_key_arity {
+            Some(arity) => assert_eq!(
+                stats.serialization_header_partition_keys.len(),
+                arity,
+                "{}: partition-key arity mismatch (cqlite {} vs cassandra {})",
+                db.display(),
+                stats.serialization_header_partition_keys.len(),
+                arity,
+            ),
+            None => assert!(
+                !stats.serialization_header_partition_keys.is_empty(),
+                "{}: composite partition key not recovered (cqlite recovered 0 keys)",
+                db.display(),
+            ),
+        }
+        assert_eq!(
+            stats.serialization_header_clustering_keys.len(),
+            reference.clustering_arity,
+            "{}: clustering arity mismatch (cqlite {} vs cassandra {})",
+            db.display(),
+            stats.serialization_header_clustering_keys.len(),
+            reference.clustering_arity,
+        );
+        let cqlite_reversed = stats
+            .serialization_header_clustering_keys
+            .iter()
+            .filter(|c| c.clustering_reversed)
+            .count();
+        assert_eq!(
+            cqlite_reversed,
+            reference.clustering_reversed_count,
+            "{}: reversed-clustering count mismatch (cqlite {} vs cassandra {})",
+            db.display(),
+            cqlite_reversed,
+            reference.clustering_reversed_count,
+        );
+
+        // Regular-column name set (order- and type-mapping-independent).
+        let mut cqlite_regular: Vec<String> = stats
+            .serialization_header_columns
+            .iter()
+            .filter(|c| !c.is_static)
+            .map(|c| c.name.clone())
+            .collect();
+        cqlite_regular.sort();
+        let mut ref_regular = reference.regular_column_names.clone();
+        ref_regular.sort();
+        assert_eq!(
+            cqlite_regular,
+            ref_regular,
+            "{}: regular-column name set mismatch (cqlite {:?} vs cassandra {:?})",
+            db.display(),
+            cqlite_regular,
+            ref_regular,
+        );
+
+        // Coverage bookkeeping.
+        if reference.min_ttl > 0 {
+            saw_ttl = true;
+        }
+        // Cassandra's "no tombstones" sentinel is i64::MAX; anything finite that
+        // is not the EncodingStats epoch (1442880000) is a real deletion time.
+        if reference.min_local_deletion_time != 1_442_880_000 {
+            saw_tombstone = true;
+        }
+        if reference.clustering_arity > 0 {
+            saw_clustering = true;
+        }
+        if reference.clustering_reversed_count > 0 {
+            saw_reversed = true;
+        }
+        if reference.regular_column_names.is_empty() {
+            saw_no_regular = true;
+        }
+        if reference.regular_column_names.len() >= 2 {
+            saw_multi_regular = true;
+        }
+        match db.file_name().and_then(|n| n.to_str()) {
+            Some(n) if n.starts_with("nb-") => format_nb += 1,
+            Some(n) if n.starts_with("oa-") => format_oa += 1,
+            Some(n) if n.starts_with("da-") => format_da += 1,
+            _ => {}
+        }
+
+        compared += 1;
+    }
+
+    eprintln!(
+        "statistics_db_strict_core_metadata_parity: {compared} compared, {skipped} skipped \
+         (binary absent) | formats nb={format_nb} oa={format_oa} da={format_da} \
+         | present nb={present_nb} oa={present_oa} da={present_da}"
+    );
+
+    let any_present = present_nb || present_oa || present_da;
+    if !any_present {
+        // No fetched binaries in this environment: the lane has nothing to assert
+        // against. This is the documented dataset-absent SKIP path (distinct from a
+        // silent pass); the committed references were still validated for presence
+        // above (all_statistics_txt fails closed).
+        eprintln!(
+            "statistics_db_strict_core_metadata_parity: SKIP — no *-Statistics.db binaries \
+             fetched ({skipped} references present without binaries)"
+        );
+        return;
+    }
+
+    // Binaries ARE present: the lane must actually have compared something and must
+    // have exercised every storage format the local dataset contains. A green run
+    // with zero comparisons (or with a present format left uncompared) is a false pass.
+    assert!(
+        compared > 0,
+        "Statistics.db binaries are present (nb={present_nb} oa={present_oa} da={present_da}) \
+         but zero fixtures were compared — strict parity lane proved nothing"
+    );
+    if present_nb {
+        assert!(
+            format_nb > 0,
+            "nb-* Statistics.db binaries are present but none were compared \
+             (format_nb=0) — nb parity unproven"
+        );
+    }
+    if present_oa {
+        assert!(
+            format_oa > 0,
+            "oa-* Statistics.db binaries are present but none were compared \
+             (format_oa=0) — oa parity unproven"
+        );
+    }
+    if present_da {
+        assert!(
+            format_da > 0,
+            "da-* Statistics.db binaries are present but none were compared \
+             (format_da=0) — da parity unproven"
+        );
+    }
+
+    // With binaries present, the corpus must exercise the metadata shapes the
+    // acceptance criteria call out; otherwise the parity claim is unproven.
+    assert!(
+        saw_ttl,
+        "no fixture with minTTL > 0 — TTL metadata parity unproven"
+    );
+    assert!(
+        saw_tombstone,
+        "no fixture with a non-epoch minLocalDeletionTime — deletion-time parity unproven"
+    );
+    assert!(
+        saw_clustering,
+        "no fixture with clustering columns — clustering-key metadata parity unproven"
+    );
+    assert!(
+        saw_reversed,
+        "no fixture with a DESC (ReversedType) clustering column — ordering parity unproven"
+    );
+    assert!(
+        saw_no_regular,
+        "no fixture without regular columns — empty-regular-column parity unproven"
+    );
+    assert!(
+        saw_multi_regular,
+        "no fixture with multiple regular columns — multi-column parity unproven"
+    );
+}
+
+/// Corrupted `Statistics.db` fixtures fail closed with explicit metadata-corruption
+/// errors in strict mode — never silently accepted, never coerced to a placeholder.
+///
+/// Uses a fetched binary as the clean baseline (skips when none is fetched), then
+/// mutates the metadata TOC and asserts the strict checksum gate rejects it.
+#[test]
+fn statistics_db_strict_corruption_fails_closed() {
+    let refs = all_statistics_txt();
+    let Some(db) = refs.iter().map(|p| binary_for(p)).find(|p| p.exists()) else {
+        eprintln!(
+            "statistics_db_strict_corruption_fails_closed: SKIP — no *-Statistics.db binary fetched"
+        );
+        return;
+    };
+
+    let clean = std::fs::read(&db).unwrap_or_else(|e| panic!("read {} failed: {e}", db.display()));
+
+    // Sanity: the clean fixture passes the strict gate.
+    validate_toc_and_checksums(&clean, &db);
+
+    // (a) Flip a byte inside a TOC offset → accumulated CRC must reject it.
+    {
+        let mut corrupt = clean.clone();
+        corrupt[15] ^= 0xff; // last byte of the first TOC entry's offset
+        let result =
+            std::panic::catch_unwind(|| validate_toc_and_checksums(&corrupt, Path::new("corrupt")));
+        assert!(
+            result.is_err(),
+            "strict gate accepted a Statistics.db with a corrupted TOC offset — must fail closed"
+        );
+    }
+
+    // (b) Corrupt the component count → explicit count/marker rejection.
+    {
+        let mut corrupt = clean.clone();
+        corrupt[3] = 0x07; // num_components = 7
+        let result =
+            std::panic::catch_unwind(|| validate_toc_and_checksums(&corrupt, Path::new("corrupt")));
+        assert!(
+            result.is_err(),
+            "strict gate accepted a Statistics.db with a corrupted component count — must fail closed"
+        );
+    }
+
+    // (c) Truncate below the TOC → explicit too-small rejection (the decoder also
+    // refuses to fabricate EncodingStats from a truncated buffer).
+    {
+        let truncated = &clean[..16.min(clean.len())];
+        let result = std::panic::catch_unwind(|| {
+            validate_toc_and_checksums(truncated, Path::new("truncated"))
+        });
+        assert!(
+            result.is_err(),
+            "strict gate accepted a truncated Statistics.db — must fail closed"
+        );
+        assert!(
+            parse_statistics_with_fallback(truncated, None).is_err(),
+            "decoder accepted a truncated Statistics.db instead of erroring"
+        );
+    }
+
+    eprintln!(
+        "statistics_db_strict_corruption_fails_closed: corruption rejected against {}",
+        db.display()
+    );
+}

--- a/docs/reports/cassandra-test-parity.md
+++ b/docs/reports/cassandra-test-parity.md
@@ -10,20 +10,20 @@ Sources: [`docs/cassandra_test_index.md`](../../docs/cassandra_test_index.md) ·
 
 | Status | Scenarios |
 |---|---|
-| `mirrored` | 14 |
+| `mirrored` | 19 |
 | `partial` | 5 |
-| `planned` | 2 |
+| `planned` | 5 |
 | `out_of_scope` | 7 |
-| **total** | **28** |
+| **total** | **36** |
 
 ## Evidence counts
 
 | Evidence | Scenarios |
 |---|---|
-| `byte_for_byte` | 0 |
+| `byte_for_byte` | 5 |
 | `canonical_semantic` | 8 |
 | `smoke` | 5 |
-| `partial` | 8 |
+| `partial` | 11 |
 | `out_of_scope` | 7 |
 
 ## ⚠️ P0 scenarios with weak evidence
@@ -61,6 +61,10 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 | `cass.index_summary.summary_boundaries` | index_summary | partial | partial | `sstable_parity_summary_db_big` | p1_correctness |
 | `cass.sstable_format.descriptor_component_resolution` | sstable_format | mirrored | smoke | `sstable_parity_component_manifest` | p1_correctness |
 | `cass.sstable_format.toc_component_manifest` | sstable_format | mirrored | partial | `sstable_parity_component_manifest` | p1_correctness |
+| `cass.statistics_db.MetadataSerializerTest.metadata_components` | statistics_metadata | mirrored | byte_for_byte | `sstable_parity_statistics_db` | p1_correctness |
+| `cass.statistics_db.SSTableMetadataTrackingTest.timestamp_and_ttl_metadata` | tombstone_ttl | mirrored | byte_for_byte | `sstable_parity_statistics_db` | p1_correctness |
+| `cass.statistics_db.SerializationHeaderTest.schema_evolution_header` | schema_evolution | mirrored | byte_for_byte | `sstable_parity_statistics_db` | p1_correctness |
+| `cass.statistics_db.core_metadata_checksums` | statistics_metadata | mirrored | byte_for_byte | `sstable_parity_statistics_db` | p0_data_loss |
 | `cass.statistics_metadata.serialization_header` | statistics_metadata | mirrored | canonical_semantic | `sstable_parity_statistics_db` | p1_correctness |
 | `cass.tombstone_ttl.range_tombstone_boundaries` | tombstone_ttl | partial | partial | `sstable_parity_delta_scan` | p0_data_loss |
 | `cass.tombstone_ttl.ttl_and_local_deletion_time` | tombstone_ttl | mirrored | canonical_semantic | `sstable_parity_data_db_jsonl` | p0_data_loss |
@@ -68,7 +72,11 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 
 ## Byte-for-byte scenarios
 
-_None yet._ No scenario currently claims byte-for-byte parity; coverage is canonical-semantic or weaker. This is intentional and honest — see the assessment report.
+- `cass.statistics_db.MetadataSerializerTest.metadata_components` — Statistics.db metadata-component TOC byte parity (count + ordered types)
+- `cass.statistics_db.SSTableMetadataTrackingTest.timestamp_and_ttl_metadata` — Statistics.db min timestamp / local-deletion-time / TTL byte parity
+- `cass.statistics_db.SerializationHeaderTest.schema_evolution_header` — Statistics.db serialization-header column metadata byte parity
+- `cass.statistics_db.SerializationMirrorTest.column_ordering_metadata` — Statistics.db clustering-key ordering / ReversedType byte parity
+- `cass.statistics_db.core_metadata_checksums` — Statistics.db embedded CRC32 checksum byte parity
 
 ## Canonical-semantic scenarios
 
@@ -105,6 +113,9 @@ _None yet._ No scenario currently claims byte-for-byte parity; coverage is canon
 - `cass.delta_scan.tombstone_liveness_facts` (partial): test_deltas dataset asset not published/enforced (#701). → _Publish and enforce the test_deltas dataset in delta-roundtrip CI._
 - `cass.filter_db_bloom.serialization_no_false_negative` (partial): No no-false-negative parity assertion against Cassandra Filter.db. → _Add a Filter.db serialization parity test asserting zero false negatives across the present-key set._
 - `cass.index_summary.summary_boundaries` (partial): Cassandra Summary.db reference dumps not published for all tables. → _Publish Summary.db reference dumps and enable strict first/last-key boundary comparison in the sstable_parity_summary_db_big suite._
+- `cass.statistics_db.SSTableMetadataTest.max_local_deletion_time` (planned): STATS-section max timestamp / max local-deletion-time not yet decoded. → _Decode the STATS MetadataType component and assert max timestamp / max local-deletion-time against the reference dump._
+- `cass.statistics_db.clustering_key_bounds` (planned): Covered-clustering min/max bounds not yet decoded from the STATS component. → _Decode the STATS-section clustering bounds and compare against the "Covered clusterings" reference line._
+- `cass.statistics_db.histograms_and_estimates` (planned): STATS-section histograms and partition/row estimates not yet decoded. → _Decode the STATS-section EstimatedHistograms and count estimates and compare bucket boundaries against the reference dump._
 - `cass.tombstone_ttl.range_tombstone_boundaries` (partial): test_deltas dataset asset not published/enforced in CI (#701). → _Publish the test_deltas dataset and enforce scan_delta parity in CI._
 
 ## Out-of-scope taxonomy
@@ -173,6 +184,14 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.schema_evolution.serialization_header_column_order` | fast_pr | — |
 | `cass.sstable_format.descriptor_component_resolution` | fast_pr | — |
 | `cass.sstable_format.toc_component_manifest` | fast_pr | — |
+| `cass.statistics_db.MetadataSerializerTest.metadata_components` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
+| `cass.statistics_db.SSTableMetadataTest.max_local_deletion_time` | manual_debug | — |
+| `cass.statistics_db.SSTableMetadataTrackingTest.timestamp_and_ttl_metadata` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
+| `cass.statistics_db.SerializationHeaderTest.schema_evolution_header` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
+| `cass.statistics_db.SerializationMirrorTest.column_ordering_metadata` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
+| `cass.statistics_db.clustering_key_bounds` | manual_debug | — |
+| `cass.statistics_db.core_metadata_checksums` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
+| `cass.statistics_db.histograms_and_estimates` | manual_debug | — |
 | `cass.statistics_metadata.serialization_header` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.streaming_protocol.node_lifecycle_out_of_scope` | fast_pr | — |
 | `cass.tombstone_ttl.range_tombstone_boundaries` | required_parity | .github/workflows/delta-roundtrip.yml |
@@ -206,6 +225,14 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.schema_evolution.serialization_header_column_order` | nb | — |
 | `cass.sstable_format.descriptor_component_resolution` | nb, oa, da | — |
 | `cass.sstable_format.toc_component_manifest` | nb, oa, da | test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-TOC.txt<br>test-data/datasets/sstables/test_oa/collection_table-4b892c6064e711f1bd3ac7dbf655c673/oa-2-big-TOC.txt<br>test-data/datasets/sstables/test_da/simple_table-de1be8b064e711f19ad401a8c8227b11/da-2-bti-TOC.txt |
+| `cass.statistics_db.MetadataSerializerTest.metadata_components` | nb, oa, da | test-data/datasets/sstables/test_basic/ttl_test_table-6af66a30a25111f0a3fef1a551383fb9/nb-1-big-Statistics.db.txt<br>test-data/datasets/sstables/test_oa/collection_table-4b892c6064e711f1bd3ac7dbf655c673/oa-2-big-Statistics.db.txt<br>test-data/datasets/sstables/test_da/simple_table-de1be8b064e711f19ad401a8c8227b11/da-2-bti-Statistics.db.txt<br>_fail:_ target/cassandra-parity/statistics-db-toc-mismatch.log |
+| `cass.statistics_db.SSTableMetadataTest.max_local_deletion_time` | — | — |
+| `cass.statistics_db.SSTableMetadataTrackingTest.timestamp_and_ttl_metadata` | nb, oa, da | test-data/datasets/sstables/test_basic/ttl_test_table-6af66a30a25111f0a3fef1a551383fb9/nb-1-big-Statistics.db.txt<br>_fail:_ target/cassandra-parity/statistics-db-encodingstats-mismatch.log |
+| `cass.statistics_db.SerializationHeaderTest.schema_evolution_header` | nb, oa, da | test-data/datasets/sstables/test_basic/static_columns_table-6b0425d0a25111f0a3fef1a551383fb9/nb-1-big-Statistics.db.txt<br>test-data/datasets/sstables/test_oa/udt_table-4b9f738064e711f1bd3ac7dbf655c673/oa-2-big-Statistics.db.txt<br>_fail:_ target/cassandra-parity/statistics-db-header-mismatch.log |
+| `cass.statistics_db.SerializationMirrorTest.column_ordering_metadata` | nb, oa, da | test-data/datasets/sstables/test_basic/composite_key_table-6ab56990a25111f0a3fef1a551383fb9/nb-1-big-Statistics.db.txt<br>_fail:_ target/cassandra-parity/statistics-db-ordering-mismatch.log |
+| `cass.statistics_db.clustering_key_bounds` | — | — |
+| `cass.statistics_db.core_metadata_checksums` | nb, oa, da | test-data/datasets/sstables/test_da/simple_table-de1be8b064e711f19ad401a8c8227b11/da-2-bti-Statistics.db.txt<br>_fail:_ target/cassandra-parity/statistics-db-crc-mismatch.log |
+| `cass.statistics_db.histograms_and_estimates` | — | — |
 | `cass.statistics_metadata.serialization_header` | nb | test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Statistics.db.txt |
 | `cass.streaming_protocol.node_lifecycle_out_of_scope` | — | — |
 | `cass.tombstone_ttl.range_tombstone_boundaries` | nb | test-data/datasets/sstables/test_deltas/adjacent_ranges-972f22806c7811f1a24ff924a65838e2/nb-1-big-Data.db.jsonl |

--- a/test-data/cassandra-parity-manifest.yml
+++ b/test-data/cassandra-parity-manifest.yml
@@ -358,6 +358,358 @@ scenarios:
     scope: {}
 
   # ----------------------------------------------------------------------------
+  # statistics_db (strict core-metadata parity, issue #985 / epic #968)
+  # ----------------------------------------------------------------------------
+  - id: cass.statistics_db.MetadataSerializerTest.metadata_components
+    title: Statistics.db metadata-component TOC byte parity (count + ordered types)
+    status: mirrored
+    capability: statistics_metadata
+    priority: P0
+    risk: p1_correctness
+    cassandra:
+      category: serialization
+      relevance: high
+      files:
+        - MetadataSerializerTest.java
+        - SSTableMetadataTest.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_statistics_db
+        tests:
+          - cqlite-core/tests/sstable_parity_statistics_db_strict_test.rs
+        notes: >-
+          statistics_db_strict_core_metadata_parity validates the Statistics.db
+          Table of Contents byte-for-byte: component count == 4 and the ordered
+          MetadataType entries VALIDATION/COMPACTION/STATS/HEADER with strictly
+          increasing offsets, across nb/oa/da fixtures.
+    fixtures:
+      references:
+        - test-data/datasets/sstables/test_basic/ttl_test_table-6af66a30a25111f0a3fef1a551383fb9/nb-1-big-Statistics.db.txt
+        - test-data/datasets/sstables/test_oa/collection_table-4b892c6064e711f1bd3ac7dbf655c673/oa-2-big-Statistics.db.txt
+        - test-data/datasets/sstables/test_da/simple_table-de1be8b064e711f19ad401a8c8227b11/da-2-bti-Statistics.db.txt
+    evidence:
+      type: byte_for_byte
+      strict: true
+      artifacts: [bytes, offsets, component_files]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb, oa, da]
+      fixture_generation_command: >-
+        bash test-data/scripts/regenerate-datasets.sh  # cassandra:5.0.2 writes Statistics.db
+      comparison_command: >-
+        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        --test sstable_parity_statistics_db_strict_test
+        statistics_db_strict_core_metadata_parity
+      reference_paths:
+        - test-data/datasets/sstables/test_basic/ttl_test_table-6af66a30a25111f0a3fef1a551383fb9/nb-1-big-Statistics.db.txt
+        - test-data/datasets/sstables/test_oa/collection_table-4b892c6064e711f1bd3ac7dbf655c673/oa-2-big-Statistics.db.txt
+        - test-data/datasets/sstables/test_da/simple_table-de1be8b064e711f19ad401a8c8227b11/da-2-bti-Statistics.db.txt
+      failure_artifacts:
+        - target/cassandra-parity/statistics-db-toc-mismatch.log
+      known_limitations: >-
+        The fetched *-Statistics.db binary is required; when absent that fixture
+        is skipped (never a silent pass) and the committed *-Statistics.db.txt
+        reference presence is still enforced fail-closed.
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/sstabledump-parity-gate.yml
+    scope: {}
+
+  - id: cass.statistics_db.core_metadata_checksums
+    title: Statistics.db embedded CRC32 checksum byte parity
+    status: mirrored
+    capability: statistics_metadata
+    priority: P0
+    risk: p0_data_loss
+    cassandra:
+      category: checksum
+      relevance: high
+      files:
+        - MetadataSerializerTest.java
+        - VerifyTest.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_statistics_db
+        tests:
+          - cqlite-core/tests/sstable_parity_statistics_db_strict_test.rs
+        notes: >-
+          Validates both embedded CRC32s byte-for-byte: the crc32(num_components)
+          marker (0x26291b05) and the accumulated TOC CRC32 at byte 40. Corrupting
+          any TOC byte breaks the accumulated CRC; the corruption lane
+          (statistics_db_strict_corruption_fails_closed) proves it fails closed.
+    fixtures:
+      references:
+        - test-data/datasets/sstables/test_da/simple_table-de1be8b064e711f19ad401a8c8227b11/da-2-bti-Statistics.db.txt
+    evidence:
+      type: byte_for_byte
+      strict: true
+      artifacts: [bytes, checksums]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb, oa, da]
+      fixture_generation_command: >-
+        bash test-data/scripts/regenerate-datasets.sh  # cassandra:5.0.2 writes Statistics.db
+      comparison_command: >-
+        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        --test sstable_parity_statistics_db_strict_test
+      reference_paths:
+        - test-data/datasets/sstables/test_da/simple_table-de1be8b064e711f19ad401a8c8227b11/da-2-bti-Statistics.db.txt
+      failure_artifacts:
+        - target/cassandra-parity/statistics-db-crc-mismatch.log
+      known_limitations: >-
+        Validates the metadata-TOC CRC32s Cassandra embeds in Statistics.db; the
+        per-component STATS-section internal checksum is not separately decoded.
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/sstabledump-parity-gate.yml
+    scope: {}
+
+  - id: cass.statistics_db.SSTableMetadataTrackingTest.timestamp_and_ttl_metadata
+    title: Statistics.db min timestamp / local-deletion-time / TTL byte parity
+    status: mirrored
+    capability: tombstone_ttl
+    priority: P0
+    risk: p1_correctness
+    cassandra:
+      category: serialization
+      relevance: high
+      files:
+        - SSTableMetadataTrackingTest.java
+        - SSTableMetadataTest.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_statistics_db
+        tests:
+          - cqlite-core/tests/sstable_parity_statistics_db_strict_test.rs
+        notes: >-
+          The EncodingStats baselines CQLite delta-decodes (minTimestamp,
+          minLocalDeletionTime, minTTL) are asserted equal to the exact integers
+          in the Statistics.db.txt dump, exercising a >0 TTL fixture and a real
+          (non-epoch) local-deletion-time fixture.
+    fixtures:
+      references:
+        - test-data/datasets/sstables/test_basic/ttl_test_table-6af66a30a25111f0a3fef1a551383fb9/nb-1-big-Statistics.db.txt
+    evidence:
+      type: byte_for_byte
+      strict: true
+      artifacts: [bytes, jsonl]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb, oa, da]
+      fixture_generation_command: >-
+        bash test-data/scripts/regenerate-datasets.sh && sstablemetadata emit Statistics.db.txt
+      comparison_command: >-
+        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        --test sstable_parity_statistics_db_strict_test
+        statistics_db_strict_core_metadata_parity
+      reference_paths:
+        - test-data/datasets/sstables/test_basic/ttl_test_table-6af66a30a25111f0a3fef1a551383fb9/nb-1-big-Statistics.db.txt
+      failure_artifacts:
+        - target/cassandra-parity/statistics-db-encodingstats-mismatch.log
+      known_limitations: >-
+        Asserts the authoritative EncodingStats min baselines decoded from real
+        bytes; max timestamp / max local-deletion-time are not yet decoded by the
+        minimal Statistics parser (see cass.statistics_db.SSTableMetadataTest.max_local_deletion_time).
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/sstabledump-parity-gate.yml
+    scope: {}
+
+  - id: cass.statistics_db.SerializationHeaderTest.schema_evolution_header
+    title: Statistics.db serialization-header column metadata byte parity
+    status: mirrored
+    capability: schema_evolution
+    priority: P0
+    risk: p1_correctness
+    cassandra:
+      category: serialization
+      relevance: high
+      files:
+        - SerializationHeaderTest.java
+        - CQLSSTableWriterTest.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_statistics_db
+        tests:
+          - cqlite-core/tests/sstable_parity_statistics_db_strict_test.rs
+        notes: >-
+          The regular-column name set CQLite recovers from the embedded
+          SerializationHeader is compared against the RegularColumns line of the
+          reference dump across primitive, collection, UDT, and static schemas;
+          partition-key and clustering-key arity are asserted for non-composite
+          keys.
+    fixtures:
+      references:
+        - test-data/datasets/sstables/test_basic/static_columns_table-6b0425d0a25111f0a3fef1a551383fb9/nb-1-big-Statistics.db.txt
+        - test-data/datasets/sstables/test_oa/udt_table-4b9f738064e711f1bd3ac7dbf655c673/oa-2-big-Statistics.db.txt
+    evidence:
+      type: byte_for_byte
+      strict: true
+      artifacts: [bytes, component_files]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb, oa, da]
+      fixture_generation_command: >-
+        bash test-data/scripts/regenerate-datasets.sh && sstablemetadata emit Statistics.db.txt
+      comparison_command: >-
+        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        --test sstable_parity_statistics_db_strict_test
+        statistics_db_strict_core_metadata_parity
+      reference_paths:
+        - test-data/datasets/sstables/test_basic/static_columns_table-6b0425d0a25111f0a3fef1a551383fb9/nb-1-big-Statistics.db.txt
+        - test-data/datasets/sstables/test_oa/udt_table-4b9f738064e711f1bd3ac7dbf655c673/oa-2-big-Statistics.db.txt
+      failure_artifacts:
+        - target/cassandra-parity/statistics-db-header-mismatch.log
+      known_limitations: >-
+        Composite partition keys are folded into a single synthetic column by the
+        minimal SerializationHeader decoder, so composite partition-key arity is
+        required only to be >= 1 rather than the exact component count.
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/sstabledump-parity-gate.yml
+    scope: {}
+
+  - id: cass.statistics_db.SerializationMirrorTest.column_ordering_metadata
+    title: Statistics.db clustering-key ordering / ReversedType byte parity
+    status: mirrored
+    capability: schema_evolution
+    priority: P1
+    risk: p1_correctness
+    cassandra:
+      category: serialization
+      relevance: high
+      files:
+        - SerializationMirrorTest.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_statistics_db
+        tests:
+          - cqlite-core/tests/sstable_parity_statistics_db_strict_test.rs
+        notes: >-
+          Clustering-key arity and the count of DESC (ReversedType-wrapped)
+          clustering columns CQLite decodes from the SerializationHeader are
+          asserted equal to the ClusteringTypes line of the reference dump,
+          exercised by a reversed-clustering fixture.
+    fixtures:
+      references:
+        - test-data/datasets/sstables/test_basic/composite_key_table-6ab56990a25111f0a3fef1a551383fb9/nb-1-big-Statistics.db.txt
+    evidence:
+      type: byte_for_byte
+      strict: true
+      artifacts: [bytes, component_files]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb, oa, da]
+      fixture_generation_command: >-
+        bash test-data/scripts/regenerate-datasets.sh && sstablemetadata emit Statistics.db.txt
+      comparison_command: >-
+        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        --test sstable_parity_statistics_db_strict_test
+        statistics_db_strict_core_metadata_parity
+      reference_paths:
+        - test-data/datasets/sstables/test_basic/composite_key_table-6ab56990a25111f0a3fef1a551383fb9/nb-1-big-Statistics.db.txt
+      failure_artifacts:
+        - target/cassandra-parity/statistics-db-ordering-mismatch.log
+      known_limitations: >-
+        Compares clustering arity and DESC count; the per-column comparator class
+        bytes are decoded to CQL types rather than compared as raw marshal-class
+        strings.
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/sstabledump-parity-gate.yml
+    scope: {}
+
+  - id: cass.statistics_db.SSTableMetadataTest.max_local_deletion_time
+    title: Statistics.db max local-deletion-time / max timestamp byte parity
+    status: planned
+    capability: statistics_metadata
+    priority: P1
+    risk: p1_correctness
+    cassandra:
+      category: serialization
+      relevance: high
+      files:
+        - SSTableMetadataTest.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_statistics_db
+    fixtures: {}
+    evidence:
+      type: partial
+      known_limitations: >-
+        The minimal nb/oa/da Statistics parser decodes the EncodingStats min
+        baselines but not the STATS-section max timestamp / max local-deletion-time;
+        decoding the full STATS component is required before these can be compared.
+    ci:
+      tier: manual_debug
+    scope:
+      target_issue: 985
+      gap: STATS-section max timestamp / max local-deletion-time not yet decoded.
+      next_step: >-
+        Decode the STATS MetadataType component and assert max timestamp / max
+        local-deletion-time against the reference dump.
+
+  - id: cass.statistics_db.clustering_key_bounds
+    title: Statistics.db covered-clustering (min/max clustering) bounds byte parity
+    status: planned
+    capability: statistics_metadata
+    priority: P1
+    risk: p1_correctness
+    cassandra:
+      category: serialization
+      relevance: high
+      files:
+        - SSTableMetadataTest.java
+        - SSTableMetadataTrackingTest.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_statistics_db
+    fixtures: {}
+    evidence:
+      type: partial
+      known_limitations: >-
+        The "Covered clusterings" min/max clustering bounds live in the STATS
+        component, which the minimal Statistics parser does not yet decode.
+    ci:
+      tier: manual_debug
+    scope:
+      target_issue: 985
+      gap: Covered-clustering min/max bounds not yet decoded from the STATS component.
+      next_step: >-
+        Decode the STATS-section clustering bounds and compare against the
+        "Covered clusterings" reference line.
+
+  - id: cass.statistics_db.histograms_and_estimates
+    title: Statistics.db estimated histograms and partition/row estimates byte parity
+    status: planned
+    capability: statistics_metadata
+    priority: P2
+    risk: p2_coverage
+    cassandra:
+      category: serialization
+      relevance: med
+      files:
+        - SSTableMetadataTest.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_statistics_db
+    fixtures: {}
+    evidence:
+      type: partial
+      known_limitations: >-
+        EstimatedHistogram partition-size / column-count buckets, estimated
+        cardinality, totalRows and totalColumnsSet live in the STATS component and
+        are populated as placeholders by the minimal Statistics parser.
+    ci:
+      tier: manual_debug
+    scope:
+      target_issue: 985
+      gap: STATS-section histograms and partition/row estimates not yet decoded.
+      next_step: >-
+        Decode the STATS-section EstimatedHistograms and count estimates and
+        compare bucket boundaries against the reference dump.
+
+  # ----------------------------------------------------------------------------
   # compression_checksum
   # ----------------------------------------------------------------------------
   - id: cass.compression_checksum.chunk_offsets_and_crc


### PR DESCRIPTION
Closes #985. Part of epic #968.

Strict, fail-closed Statistics.db lane: byte-for-byte TOC/CRC + field-level EncodingStats and SerializationHeader column metadata vs committed `*-Statistics.db.txt` dumps (nb/oa/da; 68 compared / 18 skipped). Corruption fails closed. Repaired metadata excluded (delegated to #988).

Documented partial (STATS MetadataType not yet decoded): max timestamp / max local-deletion-time, clustering bounds, histograms — marked `planned` in manifest, not claimed byte_for_byte.