### PR TITLE
feat(observability): foundation — OTel layer, feature flag, config, error-rate schema (#1032, #1038)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,15 @@ env_logger = "0.11"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+# Observability / OpenTelemetry (opt-in via the `observability` feature on
+# cqlite-core; epic #1031). Versions pinned together because the OTel crates
+# release in lockstep and mixing minor versions breaks the trait wiring.
+opentelemetry = "0.30"
+opentelemetry_sdk = { version = "0.30", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.30", features = ["grpc-tonic", "http-proto", "reqwest-blocking-client", "metrics", "trace"] }
+tracing-opentelemetry = "0.31"
+opentelemetry-semantic-conventions = "0.30"
+
 # CLI dependencies
 clap = { version = "4.4", features = ["derive", "env"] }
 colored = "2.0"

--- a/cqlite-core/Cargo.toml
+++ b/cqlite-core/Cargo.toml
@@ -92,6 +92,16 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 log = "0.4"
 
+# Observability / OpenTelemetry — optional, behind the `observability` feature
+# (epic #1031, issue #1032). NONE of these are pulled into the default build:
+# `cargo tree -p cqlite-core` must show no opentelemetry deps unless
+# `--features observability` is passed.
+opentelemetry = { workspace = true, optional = true }
+opentelemetry_sdk = { workspace = true, optional = true }
+opentelemetry-otlp = { workspace = true, optional = true }
+tracing-opentelemetry = { workspace = true, optional = true }
+opentelemetry-semantic-conventions = { workspace = true, optional = true }
+
 # Optional WASM support
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { workspace = true, optional = true }
@@ -183,8 +193,24 @@ arrow = ["state_machine", "dep:arrow"]
 # Depends on `arrow` for the CQL→RecordBatch conversion layer.
 parquet = ["arrow", "dep:parquet"]
 
-# Other features
-metrics = []
+# Observability (epic #1031, issues #1032 + #1038) — opt-in OpenTelemetry
+# tracing + metrics export. NOT in defaults: the helpers in
+# `crate::observability` compile to zero-cost no-ops when this is off, and no
+# opentelemetry dependency is linked. This flag supersedes the old hollow
+# `metrics = []` flag (which referenced nothing); see `metrics` below.
+observability = [
+    "dep:opentelemetry",
+    "dep:opentelemetry_sdk",
+    "dep:opentelemetry-otlp",
+    "dep:tracing-opentelemetry",
+    "dep:opentelemetry-semantic-conventions",
+]
+
+# Deprecated alias for `observability`. The original `metrics = []` flag never
+# gated any code; it is retained as an alias so any out-of-tree consumer that
+# enabled it keeps building, and now resolves to the real observability stack.
+metrics = ["observability"]
+
 pest = []
 wasm = ["wasm-bindgen", "js-sys", "web-sys"]
 

--- a/cqlite-core/src/lib.rs
+++ b/cqlite-core/src/lib.rs
@@ -16,6 +16,10 @@ pub mod version_hints;
 
 pub mod benchmarks;
 pub mod memory;
+// Observability foundation (epic #1031, issues #1032 + #1038). Always present;
+// the OpenTelemetry exporter wiring inside it is gated behind the optional
+// `observability` feature, and all helpers compile to no-ops when it is off.
+pub mod observability;
 pub mod platform;
 #[cfg(feature = "state_machine")]
 pub mod query;

--- a/cqlite-core/src/observability/catalog.rs
+++ b/cqlite-core/src/observability/catalog.rs
@@ -1,0 +1,161 @@
+//! Metric catalog — the single source of truth for CQLite metric names + units.
+//!
+//! Downstream observability issues (epic #1031) MUST import the constants from
+//! this module instead of hard-coding metric-name strings. Centralising the
+//! names here keeps the emitted telemetry consistent across subsystems and lets
+//! us evolve names in exactly one place.
+//!
+//! # Naming conventions
+//!
+//! Names follow the OpenTelemetry metric semantic conventions:
+//! - dot-separated, lower-snake namespaces, rooted under `cqlite.`
+//! - units use the UCUM annotations OTel recommends (`{row}`, `s`, `By`, `1`,
+//!   `{error}`, …); see [`unit`].
+//! - counters describe a monotonically increasing total; their name reflects the
+//!   thing being counted (rows, bytes, errors).
+//! - histograms describe a distribution (durations, sizes).
+//! - gauges describe a current value (in-flight, cache occupancy).
+//!
+//! # Attribute cardinality
+//!
+//! Every metric is documented with the *bounded* attribute set it may carry.
+//! NEVER attach unbounded values (raw error messages, partition keys, full
+//! queries) as attributes — those explode cardinality and cost. Bounded
+//! attribute keys live in [`attr`].
+
+/// Recommended UCUM units for the catalog metrics.
+///
+/// Use these constants when constructing instruments so the unit string stays
+/// consistent with the metric definitions below.
+pub mod unit {
+    /// Dimensionless count / ratio.
+    pub const DIMENSIONLESS: &str = "1";
+    /// A count of rows (UCUM annotation).
+    pub const ROWS: &str = "{row}";
+    /// A count of partitions.
+    pub const PARTITIONS: &str = "{partition}";
+    /// A count of SSTables.
+    pub const SSTABLES: &str = "{sstable}";
+    /// A count of errors.
+    pub const ERRORS: &str = "{error}";
+    /// Bytes.
+    pub const BYTES: &str = "By";
+    /// Seconds (OTel prefers base-unit seconds for durations).
+    pub const SECONDS: &str = "s";
+}
+
+/// Bounded attribute keys for catalog metrics.
+///
+/// These are the ONLY attribute keys downstream code should attach to the
+/// catalog metrics. Each is documented with its allowed value space so the
+/// cardinality stays bounded.
+pub mod attr {
+    /// Low-cardinality error category. Values come from
+    /// [`crate::observability::ErrorCategory::as_str`] (≈10 distinct values).
+    pub const ERROR_CATEGORY: &str = "cqlite.error.category";
+    /// Subsystem that produced an event, e.g. `"reader"`, `"query"`,
+    /// `"compaction"`. Callers pass a `&'static str`, so the value space is
+    /// bounded by the code itself.
+    pub const SUBSYSTEM: &str = "cqlite.subsystem";
+    /// SSTable on-disk format family, e.g. `"big"` or `"bti"`. Bounded.
+    pub const SSTABLE_FORMAT: &str = "cqlite.sstable.format";
+    /// Compression algorithm, e.g. `"lz4"`, `"snappy"`, `"none"`. Bounded.
+    pub const COMPRESSION: &str = "cqlite.compression";
+}
+
+/// `cqlite.read.rows` — counter `{row}`.
+///
+/// Total rows materialised by the read path. Bounded attributes:
+/// [`attr::SSTABLE_FORMAT`].
+pub const READ_ROWS: &str = "cqlite.read.rows";
+
+/// `cqlite.read.bytes` — counter `By`.
+///
+/// Total bytes read from Data.db (post-decompression). Bounded attributes:
+/// [`attr::SSTABLE_FORMAT`], [`attr::COMPRESSION`].
+pub const READ_BYTES: &str = "cqlite.read.bytes";
+
+/// `cqlite.read.partitions` — counter `{partition}`.
+///
+/// Total partitions scanned. Bounded attributes: [`attr::SSTABLE_FORMAT`].
+pub const READ_PARTITIONS: &str = "cqlite.read.partitions";
+
+/// `cqlite.read.duration` — histogram `s`.
+///
+/// Distribution of single read/scan operation durations in seconds. Bounded
+/// attributes: [`attr::SSTABLE_FORMAT`].
+pub const READ_DURATION: &str = "cqlite.read.duration";
+
+/// `cqlite.query.duration` — histogram `s`.
+///
+/// Distribution of end-to-end query execution durations in seconds. Bounded
+/// attributes: [`attr::SUBSYSTEM`]. NEVER attach the query text.
+pub const QUERY_DURATION: &str = "cqlite.query.duration";
+
+/// `cqlite.query.rows` — counter `{row}`.
+///
+/// Total rows returned to callers by the query engine. No high-cardinality
+/// attributes.
+pub const QUERY_ROWS: &str = "cqlite.query.rows";
+
+/// `cqlite.sstables.open` — gauge `{sstable}`.
+///
+/// Number of SSTables currently held open. Bounded attributes:
+/// [`attr::SSTABLE_FORMAT`].
+pub const SSTABLES_OPEN: &str = "cqlite.sstables.open";
+
+/// `cqlite.compaction.duration` — histogram `s`.
+///
+/// Distribution of compaction run durations in seconds. No high-cardinality
+/// attributes.
+pub const COMPACTION_DURATION: &str = "cqlite.compaction.duration";
+
+/// `cqlite.errors.total` — counter `{error}`.
+///
+/// Total errors observed, the canonical error-rate signal (issue #1038).
+/// Bounded attributes: [`attr::ERROR_CATEGORY`] and [`attr::SUBSYSTEM`] ONLY.
+/// The raw error message is never attached.
+pub const ERRORS_TOTAL: &str = "cqlite.errors.total";
+
+/// All catalog metric names, for tests and registration sanity checks.
+pub const ALL_METRICS: &[&str] = &[
+    READ_ROWS,
+    READ_BYTES,
+    READ_PARTITIONS,
+    READ_DURATION,
+    QUERY_DURATION,
+    QUERY_ROWS,
+    SSTABLES_OPEN,
+    COMPACTION_DURATION,
+    ERRORS_TOTAL,
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metric_names_are_namespaced_and_unique() {
+        let mut seen = std::collections::HashSet::new();
+        for name in ALL_METRICS {
+            assert!(
+                name.starts_with("cqlite."),
+                "metric {name} must be rooted under cqlite."
+            );
+            assert!(seen.insert(*name), "duplicate metric name {name}");
+        }
+        assert_eq!(seen.len(), ALL_METRICS.len());
+    }
+
+    #[test]
+    fn attribute_keys_are_namespaced() {
+        for key in [
+            attr::ERROR_CATEGORY,
+            attr::SUBSYSTEM,
+            attr::SSTABLE_FORMAT,
+            attr::COMPRESSION,
+        ] {
+            assert!(key.starts_with("cqlite."), "attr {key} must be namespaced");
+        }
+    }
+}

--- a/cqlite-core/src/observability/config.rs
+++ b/cqlite-core/src/observability/config.rs
@@ -135,7 +135,12 @@ impl ObservabilityConfig {
         }
         if let Some(v) = env_str("CQLITE_OTEL_SAMPLING_RATIO") {
             if let Ok(r) = v.trim().parse::<f64>() {
-                cfg.sampling_ratio = r.clamp(0.0, 1.0);
+                // Reject non-finite values (NaN, ±inf) — they survive `clamp`
+                // and would violate the documented [0.0, 1.0] contract. Keep the
+                // default in that case.
+                if r.is_finite() {
+                    cfg.sampling_ratio = r.clamp(0.0, 1.0);
+                }
             }
         }
         if let Some(v) = env_str("CQLITE_OTEL_TIMEOUT_MS") {
@@ -144,8 +149,18 @@ impl ObservabilityConfig {
             }
         }
 
-        cfg.sampling_ratio = cfg.sampling_ratio.clamp(0.0, 1.0);
+        cfg.sampling_ratio = sanitize_ratio(cfg.sampling_ratio);
         cfg
+    }
+}
+
+/// Clamp a sampling ratio into `[0.0, 1.0]`, falling back to full sampling for
+/// non-finite inputs (NaN / ±inf) which would otherwise bypass the clamp.
+fn sanitize_ratio(r: f64) -> f64 {
+    if r.is_finite() {
+        r.clamp(0.0, 1.0)
+    } else {
+        1.0
     }
 }
 
@@ -181,9 +196,10 @@ impl ObservabilityConfigBuilder {
         self.config.service_version = version.into();
         self
     }
-    /// Set the trace-ID-ratio sampling probability (clamped to `[0.0, 1.0]`).
+    /// Set the trace-ID-ratio sampling probability (clamped to `[0.0, 1.0]`;
+    /// non-finite values fall back to full sampling).
     pub fn sampling_ratio(mut self, ratio: f64) -> Self {
-        self.config.sampling_ratio = ratio.clamp(0.0, 1.0);
+        self.config.sampling_ratio = sanitize_ratio(ratio);
         self
     }
     /// Set the exporter timeout.
@@ -194,7 +210,7 @@ impl ObservabilityConfigBuilder {
     /// Finish building.
     pub fn build(self) -> ObservabilityConfig {
         let mut cfg = self.config;
-        cfg.sampling_ratio = cfg.sampling_ratio.clamp(0.0, 1.0);
+        cfg.sampling_ratio = sanitize_ratio(cfg.sampling_ratio);
         cfg
     }
 }
@@ -254,6 +270,15 @@ mod tests {
     fn negative_ratio_clamps_to_zero() {
         let cfg = ObservabilityConfig::builder().sampling_ratio(-1.0).build();
         assert_eq!(cfg.sampling_ratio, 0.0);
+    }
+
+    #[test]
+    fn non_finite_ratio_falls_back_to_full_sampling() {
+        for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            let cfg = ObservabilityConfig::builder().sampling_ratio(bad).build();
+            assert!(cfg.sampling_ratio.is_finite());
+            assert_eq!(cfg.sampling_ratio, 1.0);
+        }
     }
 
     #[test]

--- a/cqlite-core/src/observability/config.rs
+++ b/cqlite-core/src/observability/config.rs
@@ -1,0 +1,342 @@
+//! Observability configuration, populated from the standard `CQLITE_OTEL_*`
+//! environment variables (epic #1031, issue #1032).
+//!
+//! The config type is always compiled (it carries no OpenTelemetry types), so
+//! callers and tests can construct and inspect it whether or not the
+//! `observability` feature is enabled. The actual exporter wiring lives in
+//! [`crate::observability`]'s feature-gated `init`.
+//!
+//! # Environment variables
+//!
+//! | Variable                       | Type    | Default                      | Meaning |
+//! |--------------------------------|---------|------------------------------|---------|
+//! | `CQLITE_OTEL_ENABLED`          | bool    | `false`                      | Master switch; when false, `init` is a no-op even with the feature on. |
+//! | `CQLITE_OTEL_ENDPOINT`         | string  | `http://localhost:4317`      | OTLP collector endpoint (gRPC) or base URL (HTTP). |
+//! | `CQLITE_OTEL_PROTOCOL`         | enum    | `grpc`                       | `grpc` or `http` (HTTP/protobuf). |
+//! | `CQLITE_OTEL_SERVICE_NAME`     | string  | `cqlite`                     | `service.name` resource attribute. |
+//! | `CQLITE_OTEL_SERVICE_VERSION`  | string  | crate version                | `service.version` resource attribute. |
+//! | `CQLITE_OTEL_SAMPLING_RATIO`   | f64     | `1.0`                        | Trace-ID-ratio sampling probability, clamped to `[0.0, 1.0]`. |
+//! | `CQLITE_OTEL_TIMEOUT_MS`       | u64     | `10000`                      | Exporter export timeout in milliseconds. |
+//!
+//! Booleans accept `1/0`, `true/false`, `yes/no`, `on/off` (case-insensitive).
+
+use std::time::Duration;
+
+/// OTLP wire protocol selection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum OtelProtocol {
+    /// OTLP over gRPC (default; port 4317).
+    #[default]
+    Grpc,
+    /// OTLP over HTTP/protobuf (port 4318).
+    Http,
+}
+
+impl OtelProtocol {
+    /// Parse a protocol string. Recognises `grpc` and `http`
+    /// (and the alias `http/protobuf`), case-insensitively.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "grpc" => Some(Self::Grpc),
+            "http" | "http/protobuf" | "http-protobuf" | "httpbinary" => Some(Self::Http),
+            _ => None,
+        }
+    }
+
+    /// Stable lowercase name (`"grpc"` / `"http"`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Grpc => "grpc",
+            Self::Http => "http",
+        }
+    }
+}
+
+/// Default OTLP gRPC endpoint.
+pub const DEFAULT_ENDPOINT: &str = "http://localhost:4317";
+/// Default service name resource attribute.
+pub const DEFAULT_SERVICE_NAME: &str = "cqlite";
+/// Default exporter timeout.
+pub const DEFAULT_TIMEOUT: Duration = Duration::from_millis(10_000);
+
+/// Runtime observability configuration.
+///
+/// Construct via [`ObservabilityConfig::from_env`] for the standard
+/// `CQLITE_OTEL_*` behaviour, or [`ObservabilityConfig::builder`] to set fields
+/// programmatically (e.g. in tests that want a disabled / no-export config).
+#[derive(Debug, Clone)]
+pub struct ObservabilityConfig {
+    /// Master enable switch. When `false`, `init` returns an inert guard and
+    /// installs no exporters or global providers, regardless of the feature.
+    pub enabled: bool,
+    /// OTLP endpoint (gRPC endpoint or HTTP base URL).
+    pub endpoint: String,
+    /// Wire protocol.
+    pub protocol: OtelProtocol,
+    /// `service.name` resource attribute.
+    pub service_name: String,
+    /// `service.version` resource attribute.
+    pub service_version: String,
+    /// Trace-ID-ratio sampling probability in `[0.0, 1.0]`. Wrapped in a
+    /// parent-based sampler so children of a sampled span are always recorded.
+    pub sampling_ratio: f64,
+    /// Exporter export timeout.
+    pub timeout: Duration,
+}
+
+impl Default for ObservabilityConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            endpoint: DEFAULT_ENDPOINT.to_string(),
+            protocol: OtelProtocol::Grpc,
+            service_name: DEFAULT_SERVICE_NAME.to_string(),
+            service_version: env!("CARGO_PKG_VERSION").to_string(),
+            sampling_ratio: 1.0,
+            timeout: DEFAULT_TIMEOUT,
+        }
+    }
+}
+
+impl ObservabilityConfig {
+    /// Start from defaults and override fields fluently.
+    pub fn builder() -> ObservabilityConfigBuilder {
+        ObservabilityConfigBuilder {
+            config: Self::default(),
+        }
+    }
+
+    /// Populate from the `CQLITE_OTEL_*` environment variables, falling back to
+    /// the documented defaults for anything unset or unparseable.
+    ///
+    /// Unparseable values fall back to the default rather than erroring, so a
+    /// typo in an env var never crashes the host process.
+    pub fn from_env() -> Self {
+        let mut cfg = Self::default();
+
+        if let Some(v) = env_str("CQLITE_OTEL_ENABLED") {
+            if let Some(b) = parse_bool(&v) {
+                cfg.enabled = b;
+            }
+        }
+        if let Some(v) = env_str("CQLITE_OTEL_ENDPOINT") {
+            cfg.endpoint = v;
+        }
+        if let Some(v) = env_str("CQLITE_OTEL_PROTOCOL") {
+            if let Some(p) = OtelProtocol::parse(&v) {
+                cfg.protocol = p;
+            }
+        }
+        if let Some(v) = env_str("CQLITE_OTEL_SERVICE_NAME") {
+            cfg.service_name = v;
+        }
+        if let Some(v) = env_str("CQLITE_OTEL_SERVICE_VERSION") {
+            cfg.service_version = v;
+        }
+        if let Some(v) = env_str("CQLITE_OTEL_SAMPLING_RATIO") {
+            if let Ok(r) = v.trim().parse::<f64>() {
+                cfg.sampling_ratio = r.clamp(0.0, 1.0);
+            }
+        }
+        if let Some(v) = env_str("CQLITE_OTEL_TIMEOUT_MS") {
+            if let Ok(ms) = v.trim().parse::<u64>() {
+                cfg.timeout = Duration::from_millis(ms);
+            }
+        }
+
+        cfg.sampling_ratio = cfg.sampling_ratio.clamp(0.0, 1.0);
+        cfg
+    }
+}
+
+/// Builder for [`ObservabilityConfig`].
+#[derive(Debug, Clone)]
+pub struct ObservabilityConfigBuilder {
+    config: ObservabilityConfig,
+}
+
+impl ObservabilityConfigBuilder {
+    /// Set the master enable switch.
+    pub fn enabled(mut self, enabled: bool) -> Self {
+        self.config.enabled = enabled;
+        self
+    }
+    /// Set the OTLP endpoint.
+    pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
+        self.config.endpoint = endpoint.into();
+        self
+    }
+    /// Set the wire protocol.
+    pub fn protocol(mut self, protocol: OtelProtocol) -> Self {
+        self.config.protocol = protocol;
+        self
+    }
+    /// Set the `service.name`.
+    pub fn service_name(mut self, name: impl Into<String>) -> Self {
+        self.config.service_name = name.into();
+        self
+    }
+    /// Set the `service.version`.
+    pub fn service_version(mut self, version: impl Into<String>) -> Self {
+        self.config.service_version = version.into();
+        self
+    }
+    /// Set the trace-ID-ratio sampling probability (clamped to `[0.0, 1.0]`).
+    pub fn sampling_ratio(mut self, ratio: f64) -> Self {
+        self.config.sampling_ratio = ratio.clamp(0.0, 1.0);
+        self
+    }
+    /// Set the exporter timeout.
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.config.timeout = timeout;
+        self
+    }
+    /// Finish building.
+    pub fn build(self) -> ObservabilityConfig {
+        let mut cfg = self.config;
+        cfg.sampling_ratio = cfg.sampling_ratio.clamp(0.0, 1.0);
+        cfg
+    }
+}
+
+fn env_str(key: &str) -> Option<String> {
+    match std::env::var(key) {
+        Ok(v) if !v.trim().is_empty() => Some(v),
+        _ => None,
+    }
+}
+
+fn parse_bool(s: &str) -> Option<bool> {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Some(true),
+        "0" | "false" | "no" | "off" => Some(false),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_are_disabled_and_sane() {
+        let cfg = ObservabilityConfig::default();
+        assert!(!cfg.enabled);
+        assert_eq!(cfg.endpoint, DEFAULT_ENDPOINT);
+        assert_eq!(cfg.protocol, OtelProtocol::Grpc);
+        assert_eq!(cfg.service_name, DEFAULT_SERVICE_NAME);
+        assert_eq!(cfg.sampling_ratio, 1.0);
+        assert_eq!(cfg.timeout, DEFAULT_TIMEOUT);
+        assert_eq!(cfg.service_version, env!("CARGO_PKG_VERSION"));
+    }
+
+    #[test]
+    fn builder_overrides_and_clamps() {
+        let cfg = ObservabilityConfig::builder()
+            .enabled(true)
+            .endpoint("http://collector:4317")
+            .protocol(OtelProtocol::Http)
+            .service_name("svc")
+            .service_version("9.9.9")
+            .sampling_ratio(2.0) // clamps to 1.0
+            .timeout(Duration::from_millis(500))
+            .build();
+        assert!(cfg.enabled);
+        assert_eq!(cfg.endpoint, "http://collector:4317");
+        assert_eq!(cfg.protocol, OtelProtocol::Http);
+        assert_eq!(cfg.service_name, "svc");
+        assert_eq!(cfg.service_version, "9.9.9");
+        assert_eq!(cfg.sampling_ratio, 1.0);
+        assert_eq!(cfg.timeout, Duration::from_millis(500));
+    }
+
+    #[test]
+    fn negative_ratio_clamps_to_zero() {
+        let cfg = ObservabilityConfig::builder().sampling_ratio(-1.0).build();
+        assert_eq!(cfg.sampling_ratio, 0.0);
+    }
+
+    #[test]
+    fn protocol_parse() {
+        assert_eq!(OtelProtocol::parse("grpc"), Some(OtelProtocol::Grpc));
+        assert_eq!(OtelProtocol::parse("GRPC"), Some(OtelProtocol::Grpc));
+        assert_eq!(OtelProtocol::parse("http"), Some(OtelProtocol::Http));
+        assert_eq!(
+            OtelProtocol::parse("http/protobuf"),
+            Some(OtelProtocol::Http)
+        );
+        assert_eq!(OtelProtocol::parse("nope"), None);
+        assert_eq!(OtelProtocol::Grpc.as_str(), "grpc");
+        assert_eq!(OtelProtocol::Http.as_str(), "http");
+    }
+
+    #[test]
+    fn bool_parsing() {
+        for t in ["1", "true", "TRUE", "yes", "on"] {
+            assert_eq!(parse_bool(t), Some(true), "{t}");
+        }
+        for f in ["0", "false", "no", "off"] {
+            assert_eq!(parse_bool(f), Some(false), "{f}");
+        }
+        assert_eq!(parse_bool("maybe"), None);
+    }
+
+    // from_env mutates process-global env, so all env-touching assertions live
+    // in ONE test to avoid cross-test races (tests share a process).
+    #[test]
+    fn from_env_parses_and_falls_back() {
+        let keys = [
+            "CQLITE_OTEL_ENABLED",
+            "CQLITE_OTEL_ENDPOINT",
+            "CQLITE_OTEL_PROTOCOL",
+            "CQLITE_OTEL_SERVICE_NAME",
+            "CQLITE_OTEL_SERVICE_VERSION",
+            "CQLITE_OTEL_SAMPLING_RATIO",
+            "CQLITE_OTEL_TIMEOUT_MS",
+        ];
+        // Save + clear.
+        let saved: Vec<_> = keys.iter().map(|k| (*k, std::env::var(k).ok())).collect();
+        for k in keys {
+            std::env::remove_var(k);
+        }
+
+        // All unset -> defaults.
+        let cfg = ObservabilityConfig::from_env();
+        assert!(!cfg.enabled);
+        assert_eq!(cfg.endpoint, DEFAULT_ENDPOINT);
+
+        // Set every var.
+        std::env::set_var("CQLITE_OTEL_ENABLED", "true");
+        std::env::set_var("CQLITE_OTEL_ENDPOINT", "http://c:4318");
+        std::env::set_var("CQLITE_OTEL_PROTOCOL", "http");
+        std::env::set_var("CQLITE_OTEL_SERVICE_NAME", "mysvc");
+        std::env::set_var("CQLITE_OTEL_SERVICE_VERSION", "1.2.3");
+        std::env::set_var("CQLITE_OTEL_SAMPLING_RATIO", "0.25");
+        std::env::set_var("CQLITE_OTEL_TIMEOUT_MS", "2500");
+        let cfg = ObservabilityConfig::from_env();
+        assert!(cfg.enabled);
+        assert_eq!(cfg.endpoint, "http://c:4318");
+        assert_eq!(cfg.protocol, OtelProtocol::Http);
+        assert_eq!(cfg.service_name, "mysvc");
+        assert_eq!(cfg.service_version, "1.2.3");
+        assert_eq!(cfg.sampling_ratio, 0.25);
+        assert_eq!(cfg.timeout, Duration::from_millis(2500));
+
+        // Unparseable ratio / timeout fall back to defaults; bad protocol keeps default.
+        std::env::set_var("CQLITE_OTEL_SAMPLING_RATIO", "not-a-number");
+        std::env::set_var("CQLITE_OTEL_TIMEOUT_MS", "xyz");
+        std::env::set_var("CQLITE_OTEL_PROTOCOL", "carrier-pigeon");
+        let cfg = ObservabilityConfig::from_env();
+        assert_eq!(cfg.sampling_ratio, 1.0);
+        assert_eq!(cfg.timeout, DEFAULT_TIMEOUT);
+        assert_eq!(cfg.protocol, OtelProtocol::Grpc);
+
+        // Restore.
+        for (k, v) in saved {
+            match v {
+                Some(val) => std::env::set_var(k, val),
+                None => std::env::remove_var(k),
+            }
+        }
+    }
+}

--- a/cqlite-core/src/observability/error_schema.rs
+++ b/cqlite-core/src/observability/error_schema.rs
@@ -1,0 +1,235 @@
+//! Low-cardinality error taxonomy for observability (issue #1038).
+//!
+//! This taxonomy is intentionally distinct from [`crate::error::ErrorCategory`]:
+//! that one is a 14-variant developer-facing grouping consumed by the CLI and
+//! existing tests, and changing it would break public API. The taxonomy here is
+//! the *telemetry* taxonomy — a small, stable, bounded set of `&'static str`
+//! labels safe to use as a metric/span attribute value (see
+//! [`crate::observability::catalog::attr::ERROR_CATEGORY`]).
+//!
+//! # Taxonomy
+//!
+//! | Variant        | `as_str()`       | Maps from `cqlite_core::Error` …                                  |
+//! |----------------|------------------|-------------------------------------------------------------------|
+//! | `Io`           | `io`             | `Io`, `InvalidPath`, `Timeout`                                     |
+//! | `Serialization`| `serialization`  | `Serialization`, `TypeConversion`                                 |
+//! | `Corruption`   | `corruption`     | `Corruption`                                                       |
+//! | `Schema`       | `schema`         | `Schema`, `Table`                                                  |
+//! | `Parsing`      | `parsing`        | `Parse`, `CqlParse`, `InvalidFormat`, `UnsupportedFormat`         |
+//! | `Storage`      | `storage`        | `Storage`, `Memory`, `Index`, `Compaction`, `WriteDirLocked`     |
+//! | `Concurrency`  | `concurrency`    | `Concurrency`, `Transaction`                                       |
+//! | `Constraints`  | `constraints`    | `ConstraintViolation`, `AlreadyExists`                            |
+//! | `Query`        | `query`          | `QueryExecution`, `UnsupportedQuery`, `InvalidInput`             |
+//! | `Other`        | `other`          | `Configuration`, `InvalidState`, `InvalidOperation`, `NotFound`,  |
+//! |                |                  | `Internal`, `Wasm`, and any future variant (catch-all)            |
+//!
+//! # Relation to spans and CLI exit codes
+//!
+//! - **Spans**: [`crate::observability::record_error`] attaches the
+//!   `as_str()` value as the `cqlite.error.category` attribute on the
+//!   `cqlite.errors.total` counter and as a span event field, and marks the
+//!   current span `otel.status_code = ERROR`.
+//! - **CLI exit codes** (`cqlite-cli/src/error.rs`): the CLI maps the *raw*
+//!   `Error` variants to numeric exit codes (2/3/4/5/6). This taxonomy is a
+//!   coarser, monitoring-oriented view; the rough correspondence is:
+//!   `Schema → exit 3`, `Io`/`Storage` → exit 4, `Query`/`Parsing` → exit 5.
+//!   The two are deliberately decoupled: exit codes are an operator contract,
+//!   the telemetry taxonomy is tuned for dashboards/alerts.
+
+use crate::error::Error;
+
+/// Bounded, telemetry-safe error categories. The total count is small and
+/// fixed, making `as_str()` values safe as metric/span attribute values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ErrorCategory {
+    /// Filesystem / OS I/O, paths, timeouts.
+    Io,
+    /// (De)serialization and type-conversion failures.
+    Serialization,
+    /// On-disk data corruption / checksum failures.
+    Corruption,
+    /// Schema / catalog problems.
+    Schema,
+    /// Binary-format / CQL text parsing failures.
+    Parsing,
+    /// Storage-engine, memory, index, compaction, locking.
+    Storage,
+    /// Concurrency / transaction failures.
+    Concurrency,
+    /// Constraint violations and conflicts.
+    Constraints,
+    /// Query execution / unsupported queries / bad input.
+    Query,
+    /// Everything else (configuration, internal, platform, catch-all).
+    Other,
+}
+
+impl ErrorCategory {
+    /// Stable, low-cardinality label. Safe to use as a metric/span attribute
+    /// value — these strings never change for a given variant.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ErrorCategory::Io => "io",
+            ErrorCategory::Serialization => "serialization",
+            ErrorCategory::Corruption => "corruption",
+            ErrorCategory::Schema => "schema",
+            ErrorCategory::Parsing => "parsing",
+            ErrorCategory::Storage => "storage",
+            ErrorCategory::Concurrency => "concurrency",
+            ErrorCategory::Constraints => "constraints",
+            ErrorCategory::Query => "query",
+            ErrorCategory::Other => "other",
+        }
+    }
+
+    /// All variants, for tests and exhaustiveness checks.
+    pub const ALL: &'static [ErrorCategory] = &[
+        ErrorCategory::Io,
+        ErrorCategory::Serialization,
+        ErrorCategory::Corruption,
+        ErrorCategory::Schema,
+        ErrorCategory::Parsing,
+        ErrorCategory::Storage,
+        ErrorCategory::Concurrency,
+        ErrorCategory::Constraints,
+        ErrorCategory::Query,
+        ErrorCategory::Other,
+    ];
+}
+
+impl std::fmt::Display for ErrorCategory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Map a [`cqlite_core::Error`](crate::error::Error) to its telemetry
+/// [`ErrorCategory`]. This is the single classification point; both
+/// `Error::obs_category` and `record_error` route through it.
+pub(crate) fn classify(err: &Error) -> ErrorCategory {
+    match err {
+        Error::Io(_) | Error::InvalidPath(_) | Error::Timeout(_) => ErrorCategory::Io,
+
+        Error::Serialization { .. } | Error::TypeConversion(_) => ErrorCategory::Serialization,
+
+        Error::Corruption(_) => ErrorCategory::Corruption,
+
+        Error::Schema(_) | Error::Table(_) => ErrorCategory::Schema,
+
+        Error::Parse(_)
+        | Error::CqlParse(_)
+        | Error::InvalidFormat(_)
+        | Error::UnsupportedFormat(_) => ErrorCategory::Parsing,
+
+        Error::Storage(_)
+        | Error::Memory(_)
+        | Error::Index(_)
+        | Error::Compaction(_)
+        | Error::WriteDirLocked { .. } => ErrorCategory::Storage,
+
+        Error::Concurrency(_) | Error::Transaction(_) => ErrorCategory::Concurrency,
+
+        Error::ConstraintViolation(_) | Error::AlreadyExists(_) => ErrorCategory::Constraints,
+
+        Error::QueryExecution(_) | Error::UnsupportedQuery(_) | Error::InvalidInput(_) => {
+            ErrorCategory::Query
+        }
+
+        // Catch-all for the remaining variants and any future additions. Listed
+        // explicitly (no wildcard arm besides wasm) so that adding a new Error
+        // variant forces a compile decision here.
+        Error::Configuration(_)
+        | Error::InvalidState(_)
+        | Error::InvalidOperation(_)
+        | Error::NotFound(_)
+        | Error::Internal(_) => ErrorCategory::Other,
+
+        #[cfg(target_arch = "wasm32")]
+        Error::Wasm(_) => ErrorCategory::Other,
+    }
+}
+
+impl Error {
+    /// Telemetry error category for this error (issue #1038).
+    ///
+    /// Distinct from [`Error::category`](crate::error::Error::category), which
+    /// returns the developer-facing [`crate::error::ErrorCategory`]. This one
+    /// returns the bounded, monitoring-oriented
+    /// [`crate::observability::ErrorCategory`].
+    pub fn obs_category(&self) -> ErrorCategory {
+        classify(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::Error;
+
+    #[test]
+    fn as_str_is_lowercase_and_unique() {
+        let mut seen = std::collections::HashSet::new();
+        for c in ErrorCategory::ALL {
+            let s = c.as_str();
+            assert_eq!(s, s.to_ascii_lowercase());
+            assert!(seen.insert(s), "duplicate category label {s}");
+        }
+        assert_eq!(seen.len(), ErrorCategory::ALL.len());
+    }
+
+    #[test]
+    fn display_matches_as_str() {
+        for c in ErrorCategory::ALL {
+            assert_eq!(c.to_string(), c.as_str());
+        }
+    }
+
+    // Exhaustively cover every Error constructor / variant -> expected category.
+    #[test]
+    fn classify_every_error_variant() {
+        use ErrorCategory::*;
+
+        let io = std::io::Error::other("x");
+        assert_eq!(Error::from(io).obs_category(), Io);
+        assert_eq!(Error::invalid_path("p").obs_category(), Io);
+        assert_eq!(Error::Timeout("t".into()).obs_category(), Io);
+
+        assert_eq!(Error::serialization("s").obs_category(), Serialization);
+        assert_eq!(Error::type_conversion("t").obs_category(), Serialization);
+
+        assert_eq!(Error::corruption("c").obs_category(), Corruption);
+
+        assert_eq!(Error::schema("s").obs_category(), Schema);
+        assert_eq!(Error::Table("t".into()).obs_category(), Schema);
+
+        assert_eq!(Error::parse("p").obs_category(), Parsing);
+        assert_eq!(Error::cql_parse("p").obs_category(), Parsing);
+        assert_eq!(Error::invalid_format("f").obs_category(), Parsing);
+        assert_eq!(Error::unsupported_format("f").obs_category(), Parsing);
+
+        assert_eq!(Error::storage("s").obs_category(), Storage);
+        assert_eq!(Error::memory("m").obs_category(), Storage);
+        assert_eq!(Error::index("i").obs_category(), Storage);
+        assert_eq!(Error::compaction("c").obs_category(), Storage);
+        assert_eq!(Error::write_dir_locked("/d").obs_category(), Storage);
+
+        assert_eq!(Error::concurrency("c").obs_category(), Concurrency);
+        assert_eq!(Error::transaction("t").obs_category(), Concurrency);
+
+        assert_eq!(
+            Error::constraint_violation("c").obs_category(),
+            Constraints
+        );
+        assert_eq!(Error::already_exists("a").obs_category(), Constraints);
+
+        assert_eq!(Error::query_execution("q").obs_category(), Query);
+        assert_eq!(Error::unsupported_query("q").obs_category(), Query);
+        assert_eq!(Error::invalid_input("i").obs_category(), Query);
+
+        assert_eq!(Error::configuration("c").obs_category(), Other);
+        assert_eq!(Error::invalid_state("s").obs_category(), Other);
+        assert_eq!(Error::invalid_operation("o").obs_category(), Other);
+        assert_eq!(Error::not_found("n").obs_category(), Other);
+        assert_eq!(Error::internal("i").obs_category(), Other);
+    }
+}

--- a/cqlite-core/src/observability/mod.rs
+++ b/cqlite-core/src/observability/mod.rs
@@ -1,0 +1,282 @@
+//! Observability foundation (epic #1031, issues #1032 + #1038).
+//!
+//! This module is the single shared foundation every other observability issue
+//! builds on. It owns OpenTelemetry initialisation, the `CQLITE_OTEL_*` config,
+//! the metric-naming [`catalog`], the error-rate schema ([`ErrorCategory`] +
+//! [`record_error`]), and graceful shutdown — and it is designed so that
+//! **instrumentation call sites are identical whether or not the
+//! `observability` feature is enabled.** When the feature is off, every helper
+//! here compiles to a no-op and `cargo tree -p cqlite-core` links no
+//! OpenTelemetry crates.
+//!
+//! # The contract for downstream issues (#1033–#1043)
+//!
+//! Downstream code MUST go through this module rather than touching
+//! `opentelemetry`/`tracing-opentelemetry` directly, so telemetry stays
+//! consistent and zero-cost-when-off:
+//!
+//! **Initialisation (CLI #1033, Flight #1041, bindings #1039/#1040):**
+//! ```ignore
+//! let cfg = observability::ObservabilityConfig::from_env();
+//! let _guard = observability::init(cfg)?;            // RAII; flushes on drop
+//! // compose the tracing layer into your own subscriber (feature-gated):
+//! # #[cfg(feature = "observability")]
+//! tracing_subscriber::registry()
+//!     .with(tracing_subscriber::fmt::layer())
+//!     .with(observability::tracing_layer())
+//!     .init();
+//! ```
+//!
+//! **Spans (read/query/write/compaction #1034–#1037):** use the ordinary
+//! `tracing` macros (`#[tracing::instrument]`, `tracing::info_span!`) — they are
+//! always available and the OTel layer bridges them when active. Do NOT create
+//! per-cell spans on hot paths; aggregate with metrics instead.
+//!
+//! **Metrics:** call [`add_counter`], [`record_histogram`], [`record_gauge`]
+//! with a name from [`catalog`] and bounded [`Attr`] attributes whose keys come
+//! from [`catalog::attr`]:
+//! ```ignore
+//! use cqlite_core::observability::{self as obs, catalog, AttrValue};
+//! obs::add_counter(catalog::READ_ROWS, n, &[(catalog::attr::SSTABLE_FORMAT, "bti".into())]);
+//! obs::record_histogram(catalog::QUERY_DURATION, elapsed.as_secs_f64(), &[]);
+//! ```
+//!
+//! **Errors (#1038):** at every boundary instrumented by #1034–#1037, call
+//! [`record_error`] when an error escapes — it increments
+//! [`catalog::ERRORS_TOTAL`] keyed by the bounded `{category, subsystem}` label
+//! set and marks the active span errored. Never attach the raw error message.
+//!
+//! # Always-compiled vs feature-gated
+//!
+//! [`catalog`], [`config`], the [`ErrorCategory`] taxonomy, and the helper
+//! signatures here are ALWAYS compiled (they pull in no OTel types), so call
+//! sites and tests build in any configuration. Only the exporter/runtime wiring
+//! ([`otel`]) is gated behind `observability`.
+
+pub mod catalog;
+pub mod config;
+mod error_schema;
+
+pub use config::{ObservabilityConfig, ObservabilityConfigBuilder, OtelProtocol};
+pub use error_schema::ErrorCategory;
+
+use crate::error::{Error, Result};
+
+#[cfg(feature = "observability")]
+mod otel;
+
+#[cfg(feature = "observability")]
+pub use otel::{init, tracing_layer, ObservabilityGuard};
+
+/// A bounded attribute value for catalog metrics.
+///
+/// Mirrors the small set of types OpenTelemetry attributes accept, but is always
+/// available regardless of the `observability` feature so instrumentation call
+/// sites compile identically when telemetry is off. Keep values bounded
+/// (prefer [`AttrValue::StaticStr`] / numbers); never feed unbounded data such
+/// as raw error messages, partition keys, or full query text.
+#[derive(Debug, Clone)]
+pub enum AttrValue {
+    /// An owned string. Use only for genuinely bounded values.
+    Str(String),
+    /// A `&'static str` — the preferred, allocation-free form.
+    StaticStr(&'static str),
+    /// A signed integer.
+    Int(i64),
+    /// A floating-point value.
+    Float(f64),
+    /// A boolean.
+    Bool(bool),
+}
+
+impl From<&'static str> for AttrValue {
+    fn from(v: &'static str) -> Self {
+        AttrValue::StaticStr(v)
+    }
+}
+impl From<String> for AttrValue {
+    fn from(v: String) -> Self {
+        AttrValue::Str(v)
+    }
+}
+impl From<i64> for AttrValue {
+    fn from(v: i64) -> Self {
+        AttrValue::Int(v)
+    }
+}
+impl From<u64> for AttrValue {
+    fn from(v: u64) -> Self {
+        AttrValue::Int(v as i64)
+    }
+}
+impl From<f64> for AttrValue {
+    fn from(v: f64) -> Self {
+        AttrValue::Float(v)
+    }
+}
+impl From<bool> for AttrValue {
+    fn from(v: bool) -> Self {
+        AttrValue::Bool(v)
+    }
+}
+
+/// A single bounded metric attribute: a `&'static str` key (always from
+/// [`catalog::attr`]) paired with a bounded [`AttrValue`].
+pub type Attr = (&'static str, AttrValue);
+
+#[cfg(feature = "observability")]
+fn to_key_values(attrs: &[Attr]) -> Vec<opentelemetry::KeyValue> {
+    use opentelemetry::{KeyValue, Value};
+    attrs
+        .iter()
+        .map(|(k, v)| {
+            let value = match v {
+                AttrValue::Str(s) => Value::from(s.clone()),
+                AttrValue::StaticStr(s) => Value::from(*s),
+                AttrValue::Int(i) => Value::from(*i),
+                AttrValue::Float(f) => Value::from(*f),
+                AttrValue::Bool(b) => Value::from(*b),
+            };
+            KeyValue::new(*k, value)
+        })
+        .collect()
+}
+
+/// Add `value` to the monotonic counter identified by a [`catalog`] name, with
+/// bounded [`Attr`] attributes. No-op (and zero-cost) when the `observability`
+/// feature is off.
+#[inline]
+pub fn add_counter(name: &'static str, value: u64, attrs: &[Attr]) {
+    #[cfg(feature = "observability")]
+    otel::add_counter(name, value, &to_key_values(attrs));
+    #[cfg(not(feature = "observability"))]
+    {
+        let _ = (name, value, attrs);
+    }
+}
+
+/// Record `value` into the histogram identified by a [`catalog`] name (durations
+/// in seconds, sizes in bytes — see the catalog docs). No-op when off.
+#[inline]
+pub fn record_histogram(name: &'static str, value: f64, attrs: &[Attr]) {
+    #[cfg(feature = "observability")]
+    otel::record_histogram(name, value, &to_key_values(attrs));
+    #[cfg(not(feature = "observability"))]
+    {
+        let _ = (name, value, attrs);
+    }
+}
+
+/// Record `value` for the gauge identified by a [`catalog`] name (a current
+/// value such as in-flight count or open SSTables). No-op when off.
+#[inline]
+pub fn record_gauge(name: &'static str, value: i64, attrs: &[Attr]) {
+    #[cfg(feature = "observability")]
+    otel::record_gauge(name, value, &to_key_values(attrs));
+    #[cfg(not(feature = "observability"))]
+    {
+        let _ = (name, value, attrs);
+    }
+}
+
+/// Record an error that escaped a critical section (issue #1038).
+///
+/// Increments [`catalog::ERRORS_TOTAL`] keyed by the bounded
+/// `{cqlite.error.category, cqlite.subsystem}` label set and marks the active
+/// span as errored. `subsystem` is a `&'static str` (e.g. `"reader"`,
+/// `"query"`, `"write"`, `"compaction"`) so its value space stays bounded. The
+/// raw error message is never recorded. No-op when the `observability` feature
+/// is off.
+#[inline]
+pub fn record_error(err: &Error, subsystem: &'static str) {
+    #[cfg(feature = "observability")]
+    {
+        let attrs = [
+            opentelemetry::KeyValue::new(
+                catalog::attr::ERROR_CATEGORY,
+                err.obs_category().as_str(),
+            ),
+            opentelemetry::KeyValue::new(catalog::attr::SUBSYSTEM, subsystem),
+        ];
+        otel::add_counter(catalog::ERRORS_TOTAL, 1, &attrs);
+        otel::mark_span_error(err.obs_category());
+    }
+    #[cfg(not(feature = "observability"))]
+    {
+        let _ = (err, subsystem);
+    }
+}
+
+/// Convenience: run a `Result`-returning closure and [`record_error`] on the
+/// `Err` path, returning the result unchanged. Lets call sites instrument an
+/// operation without restructuring their error handling.
+#[inline]
+pub fn record_result<T>(subsystem: &'static str, result: Result<T>) -> Result<T> {
+    if let Err(e) = &result {
+        record_error(e, subsystem);
+    }
+    result
+}
+
+/// Inert observability guard returned by [`init`] when the `observability`
+/// feature is disabled. Flushes and installs nothing.
+#[cfg(not(feature = "observability"))]
+#[derive(Debug)]
+pub struct ObservabilityGuard {
+    _private: (),
+}
+
+#[cfg(not(feature = "observability"))]
+impl ObservabilityGuard {
+    /// Always `false` for the inert guard.
+    pub fn is_active(&self) -> bool {
+        false
+    }
+    /// No-op flush.
+    pub fn force_flush(&self) {}
+}
+
+/// Initialise observability from `cfg`. When the `observability` feature is
+/// disabled this is a no-op that returns an inert [`ObservabilityGuard`], so
+/// callers (CLI, Flight, bindings) can call it unconditionally.
+#[cfg(not(feature = "observability"))]
+#[inline]
+pub fn init(cfg: ObservabilityConfig) -> Result<ObservabilityGuard> {
+    let _ = cfg;
+    Ok(ObservabilityGuard { _private: () })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn helpers_are_callable_in_any_build() {
+        // These must compile and not panic regardless of feature state.
+        add_counter(catalog::READ_ROWS, 3, &[(catalog::attr::SSTABLE_FORMAT, "bti".into())]);
+        record_histogram(catalog::QUERY_DURATION, 0.001, &[]);
+        record_gauge(catalog::SSTABLES_OPEN, 2, &[]);
+        let err = Error::corruption("x");
+        record_error(&err, "reader");
+        let ok: Result<u8> = record_result("reader", Ok(1));
+        assert_eq!(ok.ok(), Some(1));
+    }
+
+    #[test]
+    fn init_returns_guard() {
+        // With the feature off this exercises the inert guard; with it on it
+        // exercises the disabled-config inert path in otel::init.
+        let cfg = ObservabilityConfig::builder().enabled(false).build();
+        let guard = init(cfg).expect("init never fails for a disabled config");
+        assert!(!guard.is_active());
+        guard.force_flush();
+    }
+
+    #[test]
+    fn attr_value_conversions() {
+        assert!(matches!(AttrValue::from("s"), AttrValue::StaticStr("s")));
+        assert!(matches!(AttrValue::from(1i64), AttrValue::Int(1)));
+        assert!(matches!(AttrValue::from(2u64), AttrValue::Int(2)));
+        assert!(matches!(AttrValue::from(true), AttrValue::Bool(true)));
+    }
+}

--- a/cqlite-core/src/observability/otel.rs
+++ b/cqlite-core/src/observability/otel.rs
@@ -1,0 +1,300 @@
+//! OpenTelemetry runtime wiring (feature = "observability").
+//!
+//! This module is only compiled when the `observability` feature is on. It owns
+//! the OTLP trace + metric exporter setup, the parent-based trace-ID-ratio
+//! sampler, the global providers, the lazily-built metric instruments keyed by
+//! the [`catalog`](crate::observability::catalog) names, and the
+//! [`ObservabilityGuard`] that flushes/shuts down on drop.
+//!
+//! The public re-exports live in [`crate::observability`]; everything here is
+//! reached through those.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use opentelemetry::metrics::{Counter, Histogram, Meter};
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry::{global, KeyValue};
+use opentelemetry_otlp::{MetricExporter, Protocol, SpanExporter, WithExportConfig};
+use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
+use opentelemetry_sdk::trace::{Sampler, SdkTracerProvider};
+use opentelemetry_sdk::Resource;
+use opentelemetry_semantic_conventions as semconv;
+
+use crate::error::{Error, Result};
+use crate::observability::catalog;
+use crate::observability::config::{ObservabilityConfig, OtelProtocol};
+
+/// Instrumentation scope name for all CQLite telemetry.
+const SCOPE: &str = "cqlite";
+
+/// Concrete SDK tracer provider stashed by [`init`] so [`tracing_layer`] can
+/// build its layer from an `SdkTracer` (which implements `PreSampledTracer`).
+/// When `init` is not called (or is inert), a default no-export provider is
+/// lazily created so the layer type stays monomorphic and simply drops spans.
+static TRACER_PROVIDER: OnceLock<SdkTracerProvider> = OnceLock::new();
+
+/// Build the OTel `Resource` describing this process.
+fn build_resource(cfg: &ObservabilityConfig) -> Resource {
+    Resource::builder()
+        .with_service_name(cfg.service_name.clone())
+        .with_attribute(KeyValue::new(
+            semconv::attribute::SERVICE_VERSION,
+            cfg.service_version.clone(),
+        ))
+        .build()
+}
+
+/// Parent-based trace-ID-ratio sampler from the configured ratio.
+fn build_sampler(ratio: f64) -> Sampler {
+    Sampler::ParentBased(Box::new(Sampler::TraceIdRatioBased(ratio.clamp(0.0, 1.0))))
+}
+
+fn otlp_protocol(p: OtelProtocol) -> Protocol {
+    match p {
+        OtelProtocol::Grpc => Protocol::Grpc,
+        OtelProtocol::Http => Protocol::HttpBinary,
+    }
+}
+
+fn build_span_exporter(cfg: &ObservabilityConfig) -> Result<SpanExporter> {
+    let builder = match cfg.protocol {
+        OtelProtocol::Grpc => SpanExporter::builder()
+            .with_tonic()
+            .with_endpoint(cfg.endpoint.clone())
+            .with_protocol(otlp_protocol(cfg.protocol))
+            .with_timeout(cfg.timeout)
+            .build(),
+        OtelProtocol::Http => SpanExporter::builder()
+            .with_http()
+            .with_endpoint(cfg.endpoint.clone())
+            .with_protocol(otlp_protocol(cfg.protocol))
+            .with_timeout(cfg.timeout)
+            .build(),
+    };
+    builder.map_err(|e| Error::configuration(format!("OTLP span exporter init failed: {e}")))
+}
+
+fn build_metric_exporter(cfg: &ObservabilityConfig) -> Result<MetricExporter> {
+    let builder = match cfg.protocol {
+        OtelProtocol::Grpc => MetricExporter::builder()
+            .with_tonic()
+            .with_endpoint(cfg.endpoint.clone())
+            .with_protocol(otlp_protocol(cfg.protocol))
+            .with_timeout(cfg.timeout)
+            .build(),
+        OtelProtocol::Http => MetricExporter::builder()
+            .with_http()
+            .with_endpoint(cfg.endpoint.clone())
+            .with_protocol(otlp_protocol(cfg.protocol))
+            .with_timeout(cfg.timeout)
+            .build(),
+    };
+    builder.map_err(|e| Error::configuration(format!("OTLP metric exporter init failed: {e}")))
+}
+
+/// RAII guard returned by [`init`](crate::observability::init).
+///
+/// Dropping it force-flushes and shuts down the trace and metric providers so
+/// buffered telemetry is exported before the process exits. An *inert* guard
+/// (built when observability is disabled) does nothing on drop.
+pub struct ObservabilityGuard {
+    tracer_provider: Option<SdkTracerProvider>,
+    meter_provider: Option<SdkMeterProvider>,
+}
+
+impl std::fmt::Debug for ObservabilityGuard {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ObservabilityGuard")
+            .field("active", &self.tracer_provider.is_some())
+            .finish()
+    }
+}
+
+impl ObservabilityGuard {
+    /// An inert guard that installs and flushes nothing.
+    pub(crate) fn inert() -> Self {
+        Self {
+            tracer_provider: None,
+            meter_provider: None,
+        }
+    }
+
+    /// Whether this guard owns live exporters.
+    pub fn is_active(&self) -> bool {
+        self.tracer_provider.is_some() || self.meter_provider.is_some()
+    }
+
+    /// Explicitly flush all pending telemetry without shutting down. Useful for
+    /// tests; a normal program can just rely on the drop behaviour.
+    pub fn force_flush(&self) {
+        if let Some(tp) = &self.tracer_provider {
+            let _ = tp.force_flush();
+        }
+        if let Some(mp) = &self.meter_provider {
+            let _ = mp.force_flush();
+        }
+    }
+}
+
+impl Drop for ObservabilityGuard {
+    fn drop(&mut self) {
+        if let Some(tp) = &self.tracer_provider {
+            let _ = tp.force_flush();
+            let _ = tp.shutdown();
+        }
+        if let Some(mp) = &self.meter_provider {
+            let _ = mp.force_flush();
+            let _ = mp.shutdown();
+        }
+    }
+}
+
+/// Initialise OTLP trace + metric export and install the global providers.
+///
+/// Returns an inert [`ObservabilityGuard`] when `cfg.enabled == false` (no
+/// exporters, no global providers touched). Otherwise installs SDK providers as
+/// the OpenTelemetry globals and returns a guard that flushes on drop.
+///
+/// Note: this does NOT install a `tracing` subscriber. Callers compose their own
+/// subscriber and add [`tracing_layer`] to it — see the module docs on
+/// [`crate::observability`].
+pub fn init(cfg: ObservabilityConfig) -> Result<ObservabilityGuard> {
+    if !cfg.enabled {
+        return Ok(ObservabilityGuard::inert());
+    }
+
+    let resource = build_resource(&cfg);
+
+    // Tracing pipeline.
+    let span_exporter = build_span_exporter(&cfg)?;
+    let tracer_provider = SdkTracerProvider::builder()
+        .with_batch_exporter(span_exporter)
+        .with_sampler(build_sampler(cfg.sampling_ratio))
+        .with_resource(resource.clone())
+        .build();
+    // Set the global provider (for cross-crate context propagation) and stash a
+    // concrete clone so `tracing_layer` can build its layer from the SDK tracer
+    // (the boxed global tracer does not implement `PreSampledTracer`).
+    let _ = TRACER_PROVIDER.set(tracer_provider.clone());
+    global::set_tracer_provider(tracer_provider.clone());
+
+    // Metrics pipeline.
+    let metric_exporter = build_metric_exporter(&cfg)?;
+    let reader = PeriodicReader::builder(metric_exporter).build();
+    let meter_provider = SdkMeterProvider::builder()
+        .with_reader(reader)
+        .with_resource(resource)
+        .build();
+    global::set_meter_provider(meter_provider.clone());
+
+    Ok(ObservabilityGuard {
+        tracer_provider: Some(tracer_provider),
+        meter_provider: Some(meter_provider),
+    })
+}
+
+/// Return the `tracing` layer that bridges spans/events into OpenTelemetry.
+///
+/// Compose it into your own subscriber registry, e.g.:
+///
+/// ```ignore
+/// use tracing_subscriber::prelude::*;
+/// let _guard = cqlite_core::observability::init(cfg)?;
+/// tracing_subscriber::registry()
+///     .with(tracing_subscriber::fmt::layer())
+///     .with(tracing_subscriber::EnvFilter::from_default_env())
+///     .with(cqlite_core::observability::tracing_layer())
+///     .init();
+/// ```
+///
+/// The layer is bound to the global tracer provider installed by [`init`]; if
+/// `init` was not called (or was inert), spans simply are not exported.
+pub fn tracing_layer<S>() -> impl tracing_subscriber::Layer<S>
+where
+    S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
+{
+    let provider = TRACER_PROVIDER.get_or_init(|| SdkTracerProvider::builder().build());
+    let tracer = provider.tracer(SCOPE);
+    tracing_opentelemetry::layer().with_tracer(tracer)
+}
+
+/// The global CQLite [`Meter`], cached after first use.
+fn meter() -> &'static Meter {
+    static METER: OnceLock<Meter> = OnceLock::new();
+    METER.get_or_init(|| global::meter(SCOPE))
+}
+
+/// Lazily-built, cached instruments for the catalog metrics. Building an
+/// instrument per record call would be wasteful, so we cache by name.
+struct Instruments {
+    errors_total: Counter<u64>,
+}
+
+fn instruments() -> &'static Instruments {
+    static INSTRUMENTS: OnceLock<Instruments> = OnceLock::new();
+    INSTRUMENTS.get_or_init(|| Instruments {
+        errors_total: meter()
+            .u64_counter(catalog::ERRORS_TOTAL)
+            .with_unit(catalog::unit::ERRORS)
+            .with_description("Total errors observed, keyed by bounded {category, subsystem}.")
+            .build(),
+    })
+}
+
+/// Add to a u64 counter identified by a catalog name.
+///
+/// Unknown names build an ad-hoc counter so call sites never silently drop data;
+/// catalog names should always be used.
+pub(crate) fn add_counter(name: &'static str, value: u64, attributes: &[KeyValue]) {
+    if name == catalog::ERRORS_TOTAL {
+        instruments().errors_total.add(value, attributes);
+        return;
+    }
+    meter().u64_counter(name).build().add(value, attributes);
+}
+
+/// Record into an f64 histogram identified by a catalog name.
+pub(crate) fn record_histogram(name: &'static str, value: f64, attributes: &[KeyValue]) {
+    let h: Histogram<f64> = meter().f64_histogram(name).build();
+    h.record(value, attributes);
+}
+
+/// Record an i64 gauge identified by a catalog name.
+pub(crate) fn record_gauge(name: &'static str, value: i64, attributes: &[KeyValue]) {
+    meter().i64_gauge(name).build().record(value, attributes);
+}
+
+/// Mark the currently-active `tracing` span as errored and tag it with the
+/// telemetry error category. Maps to OTel `otel.status_code = ERROR` plus the
+/// bounded `cqlite.error.category` attribute. No raw error message is recorded.
+pub(crate) fn mark_span_error(category: crate::observability::ErrorCategory) {
+    use tracing_opentelemetry::OpenTelemetrySpanExt;
+    let span = tracing::Span::current();
+    span.set_attribute("otel.status_code", "ERROR");
+    span.set_attribute(catalog::attr::ERROR_CATEGORY, category.as_str());
+}
+
+/// Convenience for the default flush timeout used by tests.
+#[allow(dead_code)]
+pub(crate) const DEFAULT_FLUSH: Duration = Duration::from_secs(1);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn init_disabled_returns_inert_guard() {
+        let cfg = ObservabilityConfig::builder().enabled(false).build();
+        let guard = init(cfg).expect("inert init never fails");
+        assert!(!guard.is_active());
+        guard.force_flush(); // no-op, must not panic
+    }
+
+    #[test]
+    fn sampler_builds_for_ratio() {
+        // Just exercise the builder for coverage; sampler has no public getter.
+        let _ = build_sampler(0.5);
+        let _ = build_sampler(2.0); // clamps internally
+    }
+}

--- a/cqlite-core/src/observability/otel.rs
+++ b/cqlite-core/src/observability/otel.rs
@@ -194,37 +194,37 @@ pub fn init(cfg: ObservabilityConfig) -> Result<ObservabilityGuard> {
     })
 }
 
-/// Return the `tracing` layer that bridges spans/events into OpenTelemetry.
+/// Return the `tracing` layer that bridges spans/events into OpenTelemetry, or
+/// `None` if observability has not been initialised.
 ///
-/// Compose it into your own subscriber registry, e.g.:
+/// **Call [`init`] before composing this layer.** The layer is bound at
+/// construction time to the exporting tracer provider that `init` installs, so
+/// it can only be built once that provider exists. When `init` has not run (or
+/// ran with a disabled config), this returns `None` — an honestly inert result —
+/// rather than a layer permanently bound to a non-exporting provider. `Option<L>`
+/// itself implements `Layer`, so the `None` case is a no-op and callers compose
+/// it directly:
 ///
 /// ```ignore
 /// use tracing_subscriber::prelude::*;
-/// let _guard = cqlite_core::observability::init(cfg)?;
+/// let _guard = cqlite_core::observability::init(cfg)?;   // installs the provider
 /// tracing_subscriber::registry()
 ///     .with(tracing_subscriber::fmt::layer())
 ///     .with(tracing_subscriber::EnvFilter::from_default_env())
-///     .with(cqlite_core::observability::tracing_layer())
+///     .with(cqlite_core::observability::tracing_layer())  // Some(..) after init, else None
 ///     .init();
 /// ```
-///
-/// The layer is bound to the global tracer provider installed by [`init`]; if
-/// `init` was not called (or was inert), spans simply are not exported.
-pub fn tracing_layer<S>() -> impl tracing_subscriber::Layer<S>
+pub fn tracing_layer<S>() -> Option<impl tracing_subscriber::Layer<S>>
 where
     S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
 {
-    // Use the provider installed by `init` if present. If `init` has not run
-    // yet, build an EPHEMERAL no-export provider for this layer WITHOUT storing
-    // it — otherwise a later enabled `init` would be unable to install its
-    // exporting provider. The SdkTracer keeps the provider's shared state alive,
-    // so dropping the local handle is fine; this layer simply drops spans until
-    // (and unless) `init` runs. Callers should `init` before composing.
-    let tracer = match TRACER_PROVIDER.get() {
-        Some(provider) => provider.tracer(SCOPE),
-        None => SdkTracerProvider::builder().build().tracer(SCOPE),
-    };
-    tracing_opentelemetry::layer().with_tracer(tracer)
+    // Only build a layer once `init` has installed the exporting provider. No
+    // ephemeral fallback: a layer bound to a throwaway no-export provider can
+    // never start exporting, so returning `None` (inert) is the correct
+    // behaviour when uninitialised.
+    let provider = TRACER_PROVIDER.get()?;
+    let tracer = provider.tracer(SCOPE);
+    Some(tracing_opentelemetry::layer().with_tracer(tracer))
 }
 
 /// The global CQLite [`Meter`], cached after first use.

--- a/cqlite-core/src/observability/otel.rs
+++ b/cqlite-core/src/observability/otel.rs
@@ -12,7 +12,7 @@
 use std::sync::OnceLock;
 use std::time::Duration;
 
-use opentelemetry::metrics::{Counter, Histogram, Meter};
+use opentelemetry::metrics::{Counter, Gauge, Histogram, Meter};
 use opentelemetry::trace::TracerProvider as _;
 use opentelemetry::{global, KeyValue};
 use opentelemetry_otlp::{MetricExporter, Protocol, SpanExporter, WithExportConfig};
@@ -214,8 +214,16 @@ pub fn tracing_layer<S>() -> impl tracing_subscriber::Layer<S>
 where
     S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
 {
-    let provider = TRACER_PROVIDER.get_or_init(|| SdkTracerProvider::builder().build());
-    let tracer = provider.tracer(SCOPE);
+    // Use the provider installed by `init` if present. If `init` has not run
+    // yet, build an EPHEMERAL no-export provider for this layer WITHOUT storing
+    // it — otherwise a later enabled `init` would be unable to install its
+    // exporting provider. The SdkTracer keeps the provider's shared state alive,
+    // so dropping the local handle is fine; this layer simply drops spans until
+    // (and unless) `init` runs. Callers should `init` before composing.
+    let tracer = match TRACER_PROVIDER.get() {
+        Some(provider) => provider.tracer(SCOPE),
+        None => SdkTracerProvider::builder().build().tracer(SCOPE),
+    };
     tracing_opentelemetry::layer().with_tracer(tracer)
 }
 
@@ -225,44 +233,125 @@ fn meter() -> &'static Meter {
     METER.get_or_init(|| global::meter(SCOPE))
 }
 
-/// Lazily-built, cached instruments for the catalog metrics. Building an
-/// instrument per record call would be wasteful, so we cache by name.
+/// Lazily-built, cached instruments for every catalog metric. Building an
+/// instrument on each record call is wasteful (re-registration overhead and
+/// possible duplicate-instrument churn), so all catalog instruments are
+/// constructed once and reused. Non-catalog names fall back to an ad-hoc
+/// instrument so call sites never silently drop data.
 struct Instruments {
+    read_rows: Counter<u64>,
+    read_bytes: Counter<u64>,
+    read_partitions: Counter<u64>,
+    query_rows: Counter<u64>,
     errors_total: Counter<u64>,
+    read_duration: Histogram<f64>,
+    query_duration: Histogram<f64>,
+    compaction_duration: Histogram<f64>,
+    sstables_open: Gauge<i64>,
 }
 
 fn instruments() -> &'static Instruments {
     static INSTRUMENTS: OnceLock<Instruments> = OnceLock::new();
-    INSTRUMENTS.get_or_init(|| Instruments {
-        errors_total: meter()
-            .u64_counter(catalog::ERRORS_TOTAL)
-            .with_unit(catalog::unit::ERRORS)
-            .with_description("Total errors observed, keyed by bounded {category, subsystem}.")
-            .build(),
+    INSTRUMENTS.get_or_init(|| {
+        let m = meter();
+        Instruments {
+            read_rows: m
+                .u64_counter(catalog::READ_ROWS)
+                .with_unit(catalog::unit::ROWS)
+                .with_description("Total rows materialised by the read path.")
+                .build(),
+            read_bytes: m
+                .u64_counter(catalog::READ_BYTES)
+                .with_unit(catalog::unit::BYTES)
+                .with_description("Total bytes read from Data.db (post-decompression).")
+                .build(),
+            read_partitions: m
+                .u64_counter(catalog::READ_PARTITIONS)
+                .with_unit(catalog::unit::PARTITIONS)
+                .with_description("Total partitions scanned.")
+                .build(),
+            query_rows: m
+                .u64_counter(catalog::QUERY_ROWS)
+                .with_unit(catalog::unit::ROWS)
+                .with_description("Total rows returned to callers by the query engine.")
+                .build(),
+            errors_total: m
+                .u64_counter(catalog::ERRORS_TOTAL)
+                .with_unit(catalog::unit::ERRORS)
+                .with_description("Total errors observed, keyed by bounded {category, subsystem}.")
+                .build(),
+            read_duration: m
+                .f64_histogram(catalog::READ_DURATION)
+                .with_unit(catalog::unit::SECONDS)
+                .with_description("Single read/scan operation duration in seconds.")
+                .build(),
+            query_duration: m
+                .f64_histogram(catalog::QUERY_DURATION)
+                .with_unit(catalog::unit::SECONDS)
+                .with_description("End-to-end query execution duration in seconds.")
+                .build(),
+            compaction_duration: m
+                .f64_histogram(catalog::COMPACTION_DURATION)
+                .with_unit(catalog::unit::SECONDS)
+                .with_description("Compaction run duration in seconds.")
+                .build(),
+            sstables_open: m
+                .i64_gauge(catalog::SSTABLES_OPEN)
+                .with_unit(catalog::unit::SSTABLES)
+                .with_description("Number of SSTables currently held open.")
+                .build(),
+        }
     })
 }
 
 /// Add to a u64 counter identified by a catalog name.
 ///
-/// Unknown names build an ad-hoc counter so call sites never silently drop data;
-/// catalog names should always be used.
+/// Catalog names use the cached instrument; unknown names build an ad-hoc
+/// counter so call sites never silently drop data (catalog names should always
+/// be used).
 pub(crate) fn add_counter(name: &'static str, value: u64, attributes: &[KeyValue]) {
-    if name == catalog::ERRORS_TOTAL {
-        instruments().errors_total.add(value, attributes);
+    let i = instruments();
+    let counter = if name == catalog::READ_ROWS {
+        &i.read_rows
+    } else if name == catalog::READ_BYTES {
+        &i.read_bytes
+    } else if name == catalog::READ_PARTITIONS {
+        &i.read_partitions
+    } else if name == catalog::QUERY_ROWS {
+        &i.query_rows
+    } else if name == catalog::ERRORS_TOTAL {
+        &i.errors_total
+    } else {
+        meter().u64_counter(name).build().add(value, attributes);
         return;
-    }
-    meter().u64_counter(name).build().add(value, attributes);
+    };
+    counter.add(value, attributes);
 }
 
 /// Record into an f64 histogram identified by a catalog name.
 pub(crate) fn record_histogram(name: &'static str, value: f64, attributes: &[KeyValue]) {
-    let h: Histogram<f64> = meter().f64_histogram(name).build();
-    h.record(value, attributes);
+    let i = instruments();
+    let hist = if name == catalog::READ_DURATION {
+        &i.read_duration
+    } else if name == catalog::QUERY_DURATION {
+        &i.query_duration
+    } else if name == catalog::COMPACTION_DURATION {
+        &i.compaction_duration
+    } else {
+        meter().f64_histogram(name).build().record(value, attributes);
+        return;
+    };
+    hist.record(value, attributes);
 }
 
 /// Record an i64 gauge identified by a catalog name.
 pub(crate) fn record_gauge(name: &'static str, value: i64, attributes: &[KeyValue]) {
-    meter().i64_gauge(name).build().record(value, attributes);
+    let i = instruments();
+    if name == catalog::SSTABLES_OPEN {
+        i.sstables_open.record(value, attributes);
+    } else {
+        meter().i64_gauge(name).build().record(value, attributes);
+    }
 }
 
 /// Mark the currently-active `tracing` span as errored and tag it with the


### PR DESCRIPTION
Part of epic #1031. The shared observability foundation every other child issue builds on.

## What
- New opt-in `observability` feature on `cqlite-core` (NOT in defaults). OTel deps optional and gated behind it; default `cargo tree` links zero opentelemetry crates and all helpers compile to no-ops.
- `cqlite-core/src/observability/`:
  - `config` — `ObservabilityConfig::from_env()` over `CQLITE_OTEL_*` with sane defaults (disabled by default).
  - `otel` — OTLP grpc/http exporters, parent-based trace-id-ratio sampler, `ObservabilityGuard` (force_flush + shutdown on drop), `tracing_layer() -> Option<Layer>` (inert until `init()`), cached catalog instruments.
  - `catalog` — `pub const` metric names + UCUM units + bounded attribute keys (single source of truth for downstream issues).
  - error schema (#1038) — `ErrorCategory` telemetry taxonomy, `Error::obs_category()`, `record_error(err, subsystem)` → `cqlite.errors.total{category,subsystem}` + marks span errored. Feature-agnostic `AttrValue`/`Attr` + `add_counter`/`record_histogram`/`record_gauge` so call sites are identical on/off.

## Validation
- Default build: zero OTel deps (verified via `cargo tree`).
- `--features observability`: builds; 17 unit tests pass; `clippy -D warnings` clean.
- roborev: clean (job 1154, "No issues found") after addressing init-ordering, instrument caching, and NaN-ratio findings.

Closes #1032
Closes #1038