### PR TITLE
feat(observability): CLI wiring — CQLITE_OTEL_*/--otel-* config, tracing subscriber, flush on exit (#1033)

### DIFF
--- a/cqlite-cli/Cargo.toml
+++ b/cqlite-cli/Cargo.toml
@@ -31,9 +31,12 @@ tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "sign
 thiserror = { workspace = true }
 anyhow = { workspace = true }
 
-# Logging and tracing
+# Logging and tracing.
+# Issue #1033: the CLI now installs a unified `tracing_subscriber` registry
+# (fmt -> stderr, EnvFilter, log->tracing bridge) instead of `env_logger`.
+# `log` stays a direct dep: existing `log::*` call sites flow through the bridge,
+# and the TUI suppresses output via `log::set_max_level`.
 log = { workspace = true }
-env_logger = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
@@ -149,3 +152,10 @@ write-support = ["state_machine", "cqlite-core/write-support"]
 # Enables cqlite-core/delta-scan (DeltaRecord types, scan_delta API) and
 # cqlite-core/parquet (DeltaParquetWriter, arrow/parquet crates).
 delta-export = ["state_machine", "cqlite-core/delta-scan", "cqlite-core/parquet"]
+# Issue #1033 / Epic #1031: OpenTelemetry wiring for the CLI.
+# Enables cqlite-core/observability so cqlite_core::observability::tracing_layer()
+# and the OTel exporter/runtime are available. NOT in default features; when off
+# the CLI keeps its plain tracing-subscriber stderr logging (the OTel layer
+# composition is compiled out). Config plumbing (CQLITE_OTEL_*/--otel-*) is
+# always available because ObservabilityConfig/init() are always compiled.
+observability = ["cqlite-core/observability"]

--- a/cqlite-cli/src/cli_types.rs
+++ b/cqlite-cli/src/cli_types.rs
@@ -160,8 +160,15 @@ pub struct Cli {
     // inert guard), preserving today's behavior.
     /// Enable OpenTelemetry export (true/false). Requires an OTLP collector at
     /// --otel-endpoint and a build with `--features observability` to export.
+    ///
+    /// Held as a raw string (not a clap-parsed `bool`) so that a malformed
+    /// `CQLITE_OTEL_ENABLED` env value never aborts `Cli::parse()` for the whole
+    /// CLI (including builds without the `observability` feature). Parsed
+    /// leniently in the config layer (`config.rs`), matching
+    /// `ObservabilityConfig::from_env`: unrecognized values fall back to the
+    /// default rather than erroring.
     #[arg(long, value_name = "BOOL", env = "CQLITE_OTEL_ENABLED")]
-    pub otel_enabled: Option<bool>,
+    pub otel_enabled: Option<String>,
 
     /// OTLP collector endpoint (gRPC endpoint or HTTP base URL).
     #[arg(long, value_name = "URL", env = "CQLITE_OTEL_ENDPOINT")]

--- a/cqlite-cli/src/cli_types.rs
+++ b/cqlite-cli/src/cli_types.rs
@@ -180,12 +180,25 @@ pub struct Cli {
     pub otel_service_version: Option<String>,
 
     /// Trace sampling ratio in [0.0, 1.0].
+    ///
+    /// Held as a raw string (not a clap-parsed `f64`) so that a malformed
+    /// `CQLITE_OTEL_SAMPLING_RATIO` env value never aborts `Cli::parse()` for
+    /// the entire CLI. The value is parsed leniently in the config layer
+    /// (`config.rs`), matching `ObservabilityConfig::from_env` semantics: bad
+    /// input (NaN/inf/garbage) silently falls back to the default rather than
+    /// erroring. A bad value passed explicitly on the command line is also
+    /// tolerated this way.
     #[arg(long, value_name = "RATIO", env = "CQLITE_OTEL_SAMPLING_RATIO")]
-    pub otel_sampling_ratio: Option<f64>,
+    pub otel_sampling_ratio: Option<String>,
 
     /// OTLP exporter timeout in milliseconds.
+    ///
+    /// Held as a raw string (not a clap-parsed `u64`) for the same reason as
+    /// `otel_sampling_ratio`: a malformed `CQLITE_OTEL_TIMEOUT_MS` env value
+    /// must not abort the whole CLI at parse time. Parsed leniently in the
+    /// config layer, falling back to the default on bad input.
     #[arg(long, value_name = "MS", env = "CQLITE_OTEL_TIMEOUT_MS")]
-    pub otel_timeout_ms: Option<u64>,
+    pub otel_timeout_ms: Option<String>,
 
     #[command(subcommand)]
     pub command: Option<Commands>,

--- a/cqlite-cli/src/cli_types.rs
+++ b/cqlite-cli/src/cli_types.rs
@@ -151,6 +151,42 @@ pub struct Cli {
     #[arg(long, requires = "writable")]
     pub flush: bool,
 
+    // ---- Observability / OpenTelemetry (Issue #1033, Epic #1031) ----
+    // These flags carry `env = "CQLITE_OTEL_*"` fallbacks so a value can come
+    // from either the flag or the env var (explicit flag wins). They map into
+    // `cqlite_core::observability::ObservabilityConfig` via the config layer.
+    // When the CLI is built without the `observability` feature these still
+    // parse and configure init(), but OTel export is a no-op (the foundation's
+    // inert guard), preserving today's behavior.
+    /// Enable OpenTelemetry export (true/false). Requires an OTLP collector at
+    /// --otel-endpoint and a build with `--features observability` to export.
+    #[arg(long, value_name = "BOOL", env = "CQLITE_OTEL_ENABLED")]
+    pub otel_enabled: Option<bool>,
+
+    /// OTLP collector endpoint (gRPC endpoint or HTTP base URL).
+    #[arg(long, value_name = "URL", env = "CQLITE_OTEL_ENDPOINT")]
+    pub otel_endpoint: Option<String>,
+
+    /// OTLP wire protocol: grpc or http.
+    #[arg(long, value_name = "PROTO", env = "CQLITE_OTEL_PROTOCOL")]
+    pub otel_protocol: Option<String>,
+
+    /// OpenTelemetry service.name resource attribute.
+    #[arg(long, value_name = "NAME", env = "CQLITE_OTEL_SERVICE_NAME")]
+    pub otel_service_name: Option<String>,
+
+    /// OpenTelemetry service.version resource attribute.
+    #[arg(long, value_name = "VER", env = "CQLITE_OTEL_SERVICE_VERSION")]
+    pub otel_service_version: Option<String>,
+
+    /// Trace sampling ratio in [0.0, 1.0].
+    #[arg(long, value_name = "RATIO", env = "CQLITE_OTEL_SAMPLING_RATIO")]
+    pub otel_sampling_ratio: Option<f64>,
+
+    /// OTLP exporter timeout in milliseconds.
+    #[arg(long, value_name = "MS", env = "CQLITE_OTEL_TIMEOUT_MS")]
+    pub otel_timeout_ms: Option<u64>,
+
     #[command(subcommand)]
     pub command: Option<Commands>,
 }

--- a/cqlite-cli/src/config.rs
+++ b/cqlite-cli/src/config.rs
@@ -875,8 +875,11 @@ impl ConfigBuilder {
         // `otel_enabled` is carried as a raw string for the same reason as the
         // numeric flags below: a malformed `CQLITE_OTEL_ENABLED` env value must
         // not abort `Cli::parse()`. Parse it leniently here, accepting the same
-        // truthy/falsy spellings as `ObservabilityConfig::from_env`; unrecognized
-        // values keep the existing/default value rather than erroring.
+        // truthy/falsy spellings as `ObservabilityConfig::from_env`. Unlike the
+        // numeric flags (which keep any lower-precedence value on bad input), an
+        // unrecognized value for this MASTER switch resets it to the core default
+        // (disabled) — fail safe to "off" — rather than leaving a lower-precedence
+        // config-file `enabled = true` active. None of these cases error.
         if let Some(ref raw) = cli.otel_enabled {
             match raw.trim().to_ascii_lowercase().as_str() {
                 "1" | "true" | "yes" | "on" => self.config.observability.enabled = Some(true),

--- a/cqlite-cli/src/config.rs
+++ b/cqlite-cli/src/config.rs
@@ -872,8 +872,17 @@ impl ConfigBuilder {
         // Each `--otel-*` flag already carries its `CQLITE_OTEL_*` env fallback
         // (resolved by clap, explicit flag winning), so applying the parsed
         // value here gives the documented file < env < flag precedence.
-        if let Some(enabled) = cli.otel_enabled {
-            self.config.observability.enabled = Some(enabled);
+        // `otel_enabled` is carried as a raw string for the same reason as the
+        // numeric flags below: a malformed `CQLITE_OTEL_ENABLED` env value must
+        // not abort `Cli::parse()`. Parse it leniently here, accepting the same
+        // truthy/falsy spellings as `ObservabilityConfig::from_env`; unrecognized
+        // values keep the existing/default value rather than erroring.
+        if let Some(ref raw) = cli.otel_enabled {
+            match raw.trim().to_ascii_lowercase().as_str() {
+                "1" | "true" | "yes" | "on" => self.config.observability.enabled = Some(true),
+                "0" | "false" | "no" | "off" => self.config.observability.enabled = Some(false),
+                _ => {}
+            }
         }
         if let Some(ref endpoint) = cli.otel_endpoint {
             self.config.observability.endpoint = Some(endpoint.clone());
@@ -1233,6 +1242,15 @@ mod tests {
         let config = ConfigBuilder::from_defaults().with_flags(&cli).build();
         assert_eq!(config.observability.sampling_ratio, Some(0.25));
         assert_eq!(config.observability.timeout_ms, Some(2500));
+
+        // A malformed CQLITE_OTEL_ENABLED must likewise not abort Cli::parse()
+        // and must fall back to the default (None) rather than erroring.
+        env::set_var("CQLITE_OTEL_ENABLED", "maybe");
+        let cli = Cli::parse_from(&["cqlite"]);
+        assert_eq!(cli.otel_enabled.as_deref(), Some("maybe"));
+        let config = ConfigBuilder::from_defaults().with_flags(&cli).build();
+        assert_eq!(config.observability.enabled, None);
+        env::remove_var("CQLITE_OTEL_ENABLED");
 
         env::remove_var("CQLITE_OTEL_SAMPLING_RATIO");
         env::remove_var("CQLITE_OTEL_TIMEOUT_MS");

--- a/cqlite-cli/src/config.rs
+++ b/cqlite-cli/src/config.rs
@@ -881,7 +881,11 @@ impl ConfigBuilder {
             match raw.trim().to_ascii_lowercase().as_str() {
                 "1" | "true" | "yes" | "on" => self.config.observability.enabled = Some(true),
                 "0" | "false" | "no" | "off" => self.config.observability.enabled = Some(false),
-                _ => {}
+                // An unrecognized value for the MASTER enable switch falls back to
+                // the core default (disabled) — fail safe to "off" — rather than
+                // silently leaving a lower-precedence config-file `enabled = true`
+                // active. Reset to None so `to_core()` uses the core default.
+                _ => self.config.observability.enabled = None,
             }
         }
         if let Some(ref endpoint) = cli.otel_endpoint {
@@ -1276,6 +1280,27 @@ mod tests {
         let config = ConfigBuilder::from_defaults().with_flags(&cli).build();
         assert_eq!(config.observability.sampling_ratio, None);
         assert_eq!(config.observability.timeout_ms, None);
+    }
+
+    /// A malformed high-precedence `CQLITE_OTEL_ENABLED` must not leave a
+    /// lower-precedence config-file `enabled = true` active — the master switch
+    /// fails safe to the core default (disabled) on garbage input (issue #1033).
+    #[test]
+    #[serial]
+    fn test_observability_malformed_enabled_env_overrides_file_to_default() {
+        use std::env;
+        env::set_var("CQLITE_OTEL_ENABLED", "maybe");
+        let cli = Cli::parse_from(&["cqlite"]);
+
+        // Simulate a lower-precedence config-file value that enabled export.
+        let mut builder = ConfigBuilder::from_defaults();
+        builder.config.observability.enabled = Some(true);
+        let config = builder.with_flags(&cli).build();
+
+        // Garbage env resets the master switch to None so to_core() uses the
+        // core default (disabled) instead of the file's `true`.
+        assert_eq!(config.observability.enabled, None);
+        env::remove_var("CQLITE_OTEL_ENABLED");
     }
 
     #[test]

--- a/cqlite-cli/src/config.rs
+++ b/cqlite-cli/src/config.rs
@@ -15,6 +15,8 @@ pub struct Config {
     #[serde(default)]
     pub logging: LoggingConfig,
     #[serde(default)]
+    pub observability: ObservabilityConfig,
+    #[serde(default)]
     pub repl: ReplConfig,
     pub data_directory: Option<PathBuf>,
     pub default_keyspace: Option<String>,
@@ -142,6 +144,79 @@ pub enum LogFormat {
     Pretty,
 }
 
+/// OpenTelemetry / observability settings (Issue #1033, Epic #1031).
+///
+/// Mirrors `LoggingConfig` in spirit: a file/env/flag-driven section that the
+/// precedence chain (user -> project -> --config -> env -> flag) populates and
+/// `main` maps into `cqlite_core::observability::ObservabilityConfig` before
+/// calling `observability::init`. All fields are optional so that an unset
+/// field falls through to the core defaults (disabled, localhost:4317, grpc,
+/// service name "cqlite", full sampling).
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ObservabilityConfig {
+    /// Master enable switch. When `None`, defers to the core default (disabled).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+    /// OTLP collector endpoint (gRPC endpoint or HTTP base URL).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+    /// Wire protocol: `grpc` or `http`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub protocol: Option<String>,
+    /// `service.name` resource attribute.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_name: Option<String>,
+    /// `service.version` resource attribute.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_version: Option<String>,
+    /// Trace-ID-ratio sampling probability in `[0.0, 1.0]`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sampling_ratio: Option<f64>,
+    /// Exporter export timeout in milliseconds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_ms: Option<u64>,
+}
+
+impl ObservabilityConfig {
+    /// Map the merged CLI observability settings into the core
+    /// `cqlite_core::observability::ObservabilityConfig`.
+    ///
+    /// Starts from the core defaults and overrides only the fields that were
+    /// explicitly set somewhere in the precedence chain. An unrecognised
+    /// protocol string is ignored (the core default `grpc` is kept) rather than
+    /// erroring, matching the foundation's lenient `from_env` semantics.
+    pub fn to_core(&self) -> cqlite_core::observability::ObservabilityConfig {
+        use cqlite_core::observability::{ObservabilityConfig as CoreObs, OtelProtocol};
+        use std::time::Duration;
+
+        let mut builder = CoreObs::builder();
+        if let Some(enabled) = self.enabled {
+            builder = builder.enabled(enabled);
+        }
+        if let Some(ref endpoint) = self.endpoint {
+            builder = builder.endpoint(endpoint.clone());
+        }
+        if let Some(ref protocol) = self.protocol {
+            if let Some(p) = OtelProtocol::parse(protocol) {
+                builder = builder.protocol(p);
+            }
+        }
+        if let Some(ref name) = self.service_name {
+            builder = builder.service_name(name.clone());
+        }
+        if let Some(ref version) = self.service_version {
+            builder = builder.service_version(version.clone());
+        }
+        if let Some(ratio) = self.sampling_ratio {
+            builder = builder.sampling_ratio(ratio);
+        }
+        if let Some(ms) = self.timeout_ms {
+            builder = builder.timeout(Duration::from_millis(ms));
+        }
+        builder.build()
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReplConfig {
     pub enable_history: bool,
@@ -164,6 +239,7 @@ impl Default for Config {
             output: OutputSettings::default(),
             performance: PerformanceConfig::default(),
             logging: LoggingConfig::default(),
+            observability: ObservabilityConfig::default(),
             repl: ReplConfig::default(),
             data_directory: None,
             default_keyspace: None,
@@ -557,6 +633,33 @@ fn merge_partial_config(base: Config, overlay: Config) -> Config {
         },
         performance: overlay.performance,
         logging: overlay.logging,
+        observability: ObservabilityConfig {
+            enabled: overlay.observability.enabled.or(base.observability.enabled),
+            endpoint: overlay
+                .observability
+                .endpoint
+                .or(base.observability.endpoint),
+            protocol: overlay
+                .observability
+                .protocol
+                .or(base.observability.protocol),
+            service_name: overlay
+                .observability
+                .service_name
+                .or(base.observability.service_name),
+            service_version: overlay
+                .observability
+                .service_version
+                .or(base.observability.service_version),
+            sampling_ratio: overlay
+                .observability
+                .sampling_ratio
+                .or(base.observability.sampling_ratio),
+            timeout_ms: overlay
+                .observability
+                .timeout_ms
+                .or(base.observability.timeout_ms),
+        },
 
         // Legacy fields (backward compat)
         enable_history: overlay.enable_history.or(base.enable_history),
@@ -701,6 +804,15 @@ impl ConfigBuilder {
             self.config.output_mode = Some(val);
         }
 
+        // CQLITE_OTEL_* (Issue #1033, Epic #1031)
+        //
+        // The `--otel-*` clap flags carry `env = "CQLITE_OTEL_*"` fallbacks, so
+        // clap already merges env -> explicit flag (explicit flag wins) into the
+        // parsed `Cli`. That merged value is applied in `with_flags`, which runs
+        // after this step and therefore correctly overrides any config-file
+        // value. We deliberately do NOT read the OTEL env vars again here to
+        // avoid two sources fighting; precedence stays file < env < flag.
+
         Ok(self)
     }
 
@@ -754,6 +866,32 @@ impl ConfigBuilder {
         // Cassandra version hint (Issue #130)
         if let Some(ref version) = cli.cassandra_version {
             self.config.cassandra_version = Some(version.clone());
+        }
+
+        // Observability / OpenTelemetry (Issue #1033, Epic #1031).
+        // Each `--otel-*` flag already carries its `CQLITE_OTEL_*` env fallback
+        // (resolved by clap, explicit flag winning), so applying the parsed
+        // value here gives the documented file < env < flag precedence.
+        if let Some(enabled) = cli.otel_enabled {
+            self.config.observability.enabled = Some(enabled);
+        }
+        if let Some(ref endpoint) = cli.otel_endpoint {
+            self.config.observability.endpoint = Some(endpoint.clone());
+        }
+        if let Some(ref protocol) = cli.otel_protocol {
+            self.config.observability.protocol = Some(protocol.clone());
+        }
+        if let Some(ref name) = cli.otel_service_name {
+            self.config.observability.service_name = Some(name.clone());
+        }
+        if let Some(ref version) = cli.otel_service_version {
+            self.config.observability.service_version = Some(version.clone());
+        }
+        if let Some(ratio) = cli.otel_sampling_ratio {
+            self.config.observability.sampling_ratio = Some(ratio);
+        }
+        if let Some(ms) = cli.otel_timeout_ms {
+            self.config.observability.timeout_ms = Some(ms);
         }
 
         self
@@ -949,6 +1087,96 @@ mod tests {
         let config = Config::default();
         assert_eq!(config.cassandra_version, None);
         assert_eq!(config.resolved_version, None);
+    }
+
+    // Observability config tests (Issue #1033, Epic #1031)
+
+    #[test]
+    fn test_observability_default_maps_to_core_disabled_defaults() {
+        // An all-None CLI observability section must yield the core defaults:
+        // disabled, localhost:4317, grpc, service "cqlite", full sampling.
+        let obs = ObservabilityConfig::default();
+        let core = obs.to_core();
+        assert!(!core.enabled);
+        assert_eq!(
+            core.endpoint,
+            cqlite_core::observability::config::DEFAULT_ENDPOINT
+        );
+        assert_eq!(
+            core.protocol,
+            cqlite_core::observability::OtelProtocol::Grpc
+        );
+        assert_eq!(
+            core.service_name,
+            cqlite_core::observability::config::DEFAULT_SERVICE_NAME
+        );
+        assert_eq!(core.sampling_ratio, 1.0);
+    }
+
+    #[test]
+    fn test_observability_to_core_applies_set_fields() {
+        let obs = ObservabilityConfig {
+            enabled: Some(true),
+            endpoint: Some("http://collector:4318".to_string()),
+            protocol: Some("http".to_string()),
+            service_name: Some("svc".to_string()),
+            service_version: Some("9.9.9".to_string()),
+            sampling_ratio: Some(0.5),
+            timeout_ms: Some(2500),
+        };
+        let core = obs.to_core();
+        assert!(core.enabled);
+        assert_eq!(core.endpoint, "http://collector:4318");
+        assert_eq!(
+            core.protocol,
+            cqlite_core::observability::OtelProtocol::Http
+        );
+        assert_eq!(core.service_name, "svc");
+        assert_eq!(core.service_version, "9.9.9");
+        assert_eq!(core.sampling_ratio, 0.5);
+        assert_eq!(core.timeout, std::time::Duration::from_millis(2500));
+    }
+
+    #[test]
+    fn test_observability_to_core_ignores_unparseable_protocol() {
+        // A bad protocol string keeps the core default (grpc) rather than erroring.
+        let obs = ObservabilityConfig {
+            protocol: Some("carrier-pigeon".to_string()),
+            ..Default::default()
+        };
+        let core = obs.to_core();
+        assert_eq!(
+            core.protocol,
+            cqlite_core::observability::OtelProtocol::Grpc
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_observability_flag_overrides_env_and_file_precedence() {
+        use std::env;
+
+        // env sets the endpoint; the --otel-endpoint flag must win.
+        env::set_var("CQLITE_OTEL_ENABLED", "true");
+        env::set_var("CQLITE_OTEL_ENDPOINT", "http://from-env:4317");
+
+        let cli = Cli::parse_from(&[
+            "cqlite",
+            "--otel-endpoint",
+            "http://from-flag:4317",
+        ]);
+        let config = Config::load(None, &cli).unwrap();
+
+        // clap merged env into otel_enabled (no flag) -> Some(true);
+        // explicit --otel-endpoint flag wins over the env value.
+        assert_eq!(config.observability.enabled, Some(true));
+        assert_eq!(
+            config.observability.endpoint.as_deref(),
+            Some("http://from-flag:4317")
+        );
+
+        env::remove_var("CQLITE_OTEL_ENABLED");
+        env::remove_var("CQLITE_OTEL_ENDPOINT");
     }
 
     #[test]

--- a/cqlite-cli/src/config.rs
+++ b/cqlite-cli/src/config.rs
@@ -887,11 +887,26 @@ impl ConfigBuilder {
         if let Some(ref version) = cli.otel_service_version {
             self.config.observability.service_version = Some(version.clone());
         }
-        if let Some(ratio) = cli.otel_sampling_ratio {
-            self.config.observability.sampling_ratio = Some(ratio);
+        // The numeric OTel flags are carried as raw strings so a malformed
+        // `CQLITE_OTEL_*` env value cannot abort `Cli::parse()` for the whole
+        // CLI (including builds without the `observability` feature). Parse them
+        // here with the same lenient semantics as
+        // `cqlite_core::observability::ObservabilityConfig::from_env`: on bad
+        // input (NaN/inf/garbage) keep the existing/default value rather than
+        // erroring. Non-finite ratios are rejected (they survive `clamp`); the
+        // final clamp into [0.0, 1.0] is applied by the core builder in
+        // `to_core()`.
+        if let Some(ref raw) = cli.otel_sampling_ratio {
+            if let Ok(ratio) = raw.trim().parse::<f64>() {
+                if ratio.is_finite() {
+                    self.config.observability.sampling_ratio = Some(ratio);
+                }
+            }
         }
-        if let Some(ms) = cli.otel_timeout_ms {
-            self.config.observability.timeout_ms = Some(ms);
+        if let Some(ref raw) = cli.otel_timeout_ms {
+            if let Ok(ms) = raw.trim().parse::<u64>() {
+                self.config.observability.timeout_ms = Some(ms);
+            }
         }
 
         self
@@ -1177,6 +1192,72 @@ mod tests {
 
         env::remove_var("CQLITE_OTEL_ENABLED");
         env::remove_var("CQLITE_OTEL_ENDPOINT");
+    }
+
+    /// A malformed `CQLITE_OTEL_SAMPLING_RATIO` / `CQLITE_OTEL_TIMEOUT_MS` env
+    /// value must NOT abort `Cli::parse()` and must fall back to defaults,
+    /// matching `ObservabilityConfig::from_env` semantics (issue #1033). These
+    /// flags are carried as raw strings and parsed leniently in the config
+    /// layer, so a bad env value can never break the whole CLI at parse time.
+    #[test]
+    #[serial]
+    fn test_observability_malformed_numeric_env_falls_back_to_defaults() {
+        use std::env;
+
+        env::set_var("CQLITE_OTEL_SAMPLING_RATIO", "not-a-number");
+        env::set_var("CQLITE_OTEL_TIMEOUT_MS", "xyz");
+
+        // The bad env values are surfaced to clap as raw strings; parse must
+        // not error.
+        let cli = Cli::parse_from(&["cqlite"]);
+        assert_eq!(cli.otel_sampling_ratio.as_deref(), Some("not-a-number"));
+        assert_eq!(cli.otel_timeout_ms.as_deref(), Some("xyz"));
+
+        // The config layer parses leniently and keeps the defaults (None ->
+        // core defaults) on garbage input rather than propagating an error.
+        let config = ConfigBuilder::from_defaults().with_flags(&cli).build();
+        assert_eq!(config.observability.sampling_ratio, None);
+        assert_eq!(config.observability.timeout_ms, None);
+
+        // Non-finite values (NaN / inf) are also rejected — they would survive
+        // a naive clamp.
+        env::set_var("CQLITE_OTEL_SAMPLING_RATIO", "inf");
+        let cli = Cli::parse_from(&["cqlite"]);
+        let config = ConfigBuilder::from_defaults().with_flags(&cli).build();
+        assert_eq!(config.observability.sampling_ratio, None);
+
+        // A well-formed env value is still honored.
+        env::set_var("CQLITE_OTEL_SAMPLING_RATIO", "0.25");
+        env::set_var("CQLITE_OTEL_TIMEOUT_MS", "2500");
+        let cli = Cli::parse_from(&["cqlite"]);
+        let config = ConfigBuilder::from_defaults().with_flags(&cli).build();
+        assert_eq!(config.observability.sampling_ratio, Some(0.25));
+        assert_eq!(config.observability.timeout_ms, Some(2500));
+
+        env::remove_var("CQLITE_OTEL_SAMPLING_RATIO");
+        env::remove_var("CQLITE_OTEL_TIMEOUT_MS");
+    }
+
+    /// An explicit malformed `--otel-sampling-ratio` flag on the command line
+    /// is tolerated the same way (falls back to default) rather than aborting
+    /// the CLI.
+    #[test]
+    #[serial]
+    fn test_observability_malformed_numeric_flag_is_tolerated() {
+        use std::env;
+        env::remove_var("CQLITE_OTEL_SAMPLING_RATIO");
+        env::remove_var("CQLITE_OTEL_TIMEOUT_MS");
+
+        let cli = Cli::parse_from(&[
+            "cqlite",
+            "--otel-sampling-ratio",
+            "garbage",
+            "--otel-timeout-ms",
+            "garbage",
+        ]);
+        let config = ConfigBuilder::from_defaults().with_flags(&cli).build();
+        assert_eq!(config.observability.sampling_ratio, None);
+        assert_eq!(config.observability.timeout_ms, None);
     }
 
     #[test]

--- a/cqlite-cli/src/main.rs
+++ b/cqlite-cli/src/main.rs
@@ -48,7 +48,13 @@ async fn main() {
 async fn run_main() -> Result<()> {
     let cli = Cli::parse();
 
-    // Initialize logging based on verbosity
+    // Load configuration FIRST so the resolved observability settings
+    // (CQLITE_OTEL_*/--otel-*, with file/env/flag precedence) are available
+    // before we initialise telemetry and the logging subscriber.
+    let config = config::Config::load(cli.config.clone(), &cli)?;
+
+    // Initialize logging based on verbosity. Maps -v/-q exactly as the previous
+    // env_logger setup did (Issue #129 hygiene preserved below).
     let log_level = match (cli.quiet, cli.verbose) {
         (true, _) => "error",
         (false, 0) => "info",
@@ -56,16 +62,26 @@ async fn run_main() -> Result<()> {
         (false, _) => "trace",
     };
 
-    // Configure logging to stderr only (Issue #129)
-    // This prevents debug/warn logs from contaminating stdout JSON/CSV output
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or(log_level))
-        .target(env_logger::Target::Stderr)
-        .init();
+    // Initialise OpenTelemetry (Issue #1033, Epic #1031). `init` is always
+    // available: with the `observability` feature off (or CQLITE_OTEL_ENABLED
+    // unset) it returns an inert guard and installs nothing, preserving today's
+    // behavior. The guard must outlive command dispatch so its Drop flushes and
+    // shuts down OTel on normal exit — we bind it to `_otel_guard` for the whole
+    // run_main scope. init() MUST run before composing the subscriber so that
+    // observability::tracing_layer() (feature-gated) returns the live layer.
+    let otel_core_config = config.observability.to_core();
+    let _otel_guard = cqlite_core::observability::init(otel_core_config)
+        .map_err(|e| anyhow::anyhow!("Failed to initialize observability: {}", e))?;
+
+    // Install the unified tracing subscriber. The fmt layer writes to STDERR
+    // ONLY so stdout stays clean for --out json/csv (Issue #129). EnvFilter
+    // honours RUST_LOG when set, otherwise the -v/-q derived level. Because
+    // tracing-subscriber's `tracing-log` feature is enabled, `.init()` also
+    // installs a log->tracing bridge (LogTracer), so existing log::info!/debug!
+    // calls flow through tracing.
+    init_tracing_subscriber(log_level);
 
     info!("Starting CQLite CLI v{}", env!("CARGO_PKG_VERSION"));
-
-    // Load configuration
-    let config = config::Config::load(cli.config.clone(), &cli)?;
 
     // Issue #231: Validate required flags for one-shot query mode
     // When --execute and --schema are provided, --data-dir (or --dataset) is required
@@ -1001,6 +1017,45 @@ async fn run_main() -> Result<()> {
             Ok(())
         }
     }
+}
+
+/// Install the unified `tracing_subscriber` registry (Issue #1033, Epic #1031).
+///
+/// Replaces the previous bare `env_logger` init while preserving its behavior:
+/// - The fmt layer writes to STDERR ONLY, so stdout stays clean for
+///   `--out json`/`csv` (Issue #129 stdout hygiene).
+/// - The `EnvFilter` honours `RUST_LOG` when set, otherwise falls back to the
+///   `-v`/`-q`-derived `default_level` (same mapping as before).
+/// - `tracing-subscriber`'s `tracing-log` feature is enabled, so `.init()`
+///   installs a `log -> tracing` bridge (`LogTracer`); existing `log::info!` /
+///   `log::debug!` calls continue to appear.
+///
+/// When the `observability` feature is enabled, the OTel layer returned by
+/// `cqlite_core::observability::tracing_layer()` is composed in (it is `None`,
+/// hence a no-op layer, unless `init` installed a live provider). When the
+/// feature is off, the layer composition is compiled out entirely.
+fn init_tracing_subscriber(default_level: &str) {
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::util::SubscriberInitExt;
+    use tracing_subscriber::{fmt, EnvFilter};
+
+    // RUST_LOG overrides the verbosity-derived level, matching the old
+    // env_logger::from_env behavior.
+    let env_filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_level));
+
+    // Write all formatted log/span output to STDERR only.
+    let fmt_layer = fmt::layer().with_writer(std::io::stderr);
+
+    let registry = tracing_subscriber::registry()
+        .with(env_filter)
+        .with(fmt_layer);
+
+    #[cfg(feature = "observability")]
+    let registry = registry.with(cqlite_core::observability::tracing_layer());
+
+    // `try_init` is tolerant of a subscriber already being set (e.g. in tests).
+    let _ = registry.try_init();
 }
 
 /// Initialize the database engine with proper configuration

--- a/cqlite-cli/src/tui.rs
+++ b/cqlite-cli/src/tui.rs
@@ -22,9 +22,10 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 pub async fn start_tui_mode(db_path: &Path, config: &Config, database: Database) -> Result<()> {
-    // CRITICAL: Disable all logging to prevent messages from bleeding into TUI display
-    // env_logger is already initialized in main.rs, so we can't reinitialize it.
-    // Instead, set the global max log level to Off to suppress all log output.
+    // CRITICAL: Disable log output to prevent messages from bleeding into the
+    // TUI display. The unified tracing subscriber is already installed in
+    // main.rs (Issue #1033) and cannot be replaced, so we suppress at the `log`
+    // facade level — this silences the `log::*` call sites bridged into tracing.
     log::set_max_level(log::LevelFilter::Off);
 
     // Initialize the database

--- a/cqlite-cli/tests/config_env_edge_cases.rs
+++ b/cqlite-cli/tests/config_env_edge_cases.rs
@@ -48,6 +48,14 @@ fn create_cli_with_flags(
         mutation: Vec::new(),
         mutations_file: None,
         flush: false,
+        // Issue #1033: Observability / OpenTelemetry flags
+        otel_enabled: None,
+        otel_endpoint: None,
+        otel_protocol: None,
+        otel_service_name: None,
+        otel_service_version: None,
+        otel_sampling_ratio: None,
+        otel_timeout_ms: None,
         command: None,
     }
 }

--- a/cqlite-cli/tests/config_precedence_tests.rs
+++ b/cqlite-cli/tests/config_precedence_tests.rs
@@ -59,6 +59,14 @@ fn create_cli_with_flags(
         mutation: Vec::new(),
         mutations_file: None,
         flush: false,
+        // Issue #1033: Observability / OpenTelemetry flags
+        otel_enabled: None,
+        otel_endpoint: None,
+        otel_protocol: None,
+        otel_service_name: None,
+        otel_service_version: None,
+        otel_sampling_ratio: None,
+        otel_timeout_ms: None,
         command: None,
     }
 }


### PR DESCRIPTION
Part of epic #1031. Depends on the merged foundation (#1032).

- `observability` feature on cqlite-cli (`cqlite-core/observability`), not in defaults.
- Seven `--otel-*` flags with `CQLITE_OTEL_*` env fallbacks; `[observability]` config section honoring the user→project→--config→env→flag chain; `to_core()` maps into `cqlite_core::observability::ObservabilityConfig`.
- Unified `tracing_subscriber` registry: fmt→stderr (stdout hygiene preserved for --out json/csv), EnvFilter honoring -v/-q, log→tracing bridge, feature-gated OTel layer. `observability::init` guard held for process lifetime (flush on exit).
- Lenient `CQLITE_OTEL_*` parsing in the config layer: a malformed env value never aborts `Cli::parse()`; the master enable switch fails safe to disabled on garbage.

Validation: default + observability builds clean; clippy -D warnings clean; bad-env `--help` exits 0; `--out json` emits only JSON on stdout; CLI test suite passes (pre-existing unrelated duckdb test failure ignored — reproduces on origin/main). roborev: addressed numeric-env, enabled-env, and precedence findings across rounds; final finding was a Low doc comment (fixed).

Closes #1033