### PR TITLE
feat(observability): instrument query engine — query.execute span tree, access-path + plan-type metrics (#1035)

### DIFF
--- a/cqlite-core/src/observability/catalog.rs
+++ b/cqlite-core/src/observability/catalog.rs
@@ -61,6 +61,18 @@ pub mod attr {
     pub const SSTABLE_FORMAT: &str = "cqlite.sstable.format";
     /// Compression algorithm, e.g. `"lz4"`, `"snappy"`, `"none"`. Bounded.
     pub const COMPRESSION: &str = "cqlite.compression";
+    /// Access path a `SELECT` chose for its SSTable-scan step (issue #1035).
+    ///
+    /// Values come from [`crate::query::access_path::AccessPath::label`] — a
+    /// closed set such as `"full_scan"`, `"partition_lookup"`,
+    /// `"multi_partition_lookup"`, `"clustering_slice"`,
+    /// `"fallback_full_scan"`. Bounded by the `AccessPath` enum itself, so it is
+    /// safe as a metric dimension and span attribute. NEVER carries key values.
+    pub const ACCESS_PATH: &str = "cqlite.query.access_path";
+    /// Query plan family chosen by the planner / executor, e.g. `"table_scan"`,
+    /// `"point_lookup"`, `"index_scan"`, `"range_scan"`, `"aggregation"`
+    /// (issue #1035). Bounded by the executor's plan-type taxonomy.
+    pub const PLAN_TYPE: &str = "cqlite.query.plan_type";
 }
 
 /// `cqlite.read.rows` — counter `{row}`.
@@ -94,9 +106,18 @@ pub const QUERY_DURATION: &str = "cqlite.query.duration";
 
 /// `cqlite.query.rows` — counter `{row}`.
 ///
-/// Total rows returned to callers by the query engine. No high-cardinality
-/// attributes.
+/// Total rows returned to callers by the query engine. Bounded attributes:
+/// [`attr::ACCESS_PATH`], [`attr::PLAN_TYPE`]. No high-cardinality attributes.
 pub const QUERY_ROWS: &str = "cqlite.query.rows";
+
+/// `cqlite.query.rows_scanned` — counter `{row}`.
+///
+/// Total rows materialised/examined by the SELECT scan step before predicate
+/// filtering, projection, and `LIMIT` (issue #1035). The gap between this and
+/// [`QUERY_ROWS`] is the read-amplification of a query — large for a
+/// `full_scan`, ~1 for a `partition_lookup`. Bounded attributes:
+/// [`attr::ACCESS_PATH`]. Emitted by the modern `SelectExecutor` only.
+pub const QUERY_ROWS_SCANNED: &str = "cqlite.query.rows_scanned";
 
 /// `cqlite.sstables.open` — gauge `{sstable}`.
 ///
@@ -125,6 +146,7 @@ pub const ALL_METRICS: &[&str] = &[
     READ_DURATION,
     QUERY_DURATION,
     QUERY_ROWS,
+    QUERY_ROWS_SCANNED,
     SSTABLES_OPEN,
     COMPACTION_DURATION,
     ERRORS_TOTAL,
@@ -154,6 +176,8 @@ mod tests {
             attr::SUBSYSTEM,
             attr::SSTABLE_FORMAT,
             attr::COMPRESSION,
+            attr::ACCESS_PATH,
+            attr::PLAN_TYPE,
         ] {
             assert!(key.starts_with("cqlite."), "attr {key} must be namespaced");
         }

--- a/cqlite-core/src/query/engine.rs
+++ b/cqlite-core/src/query/engine.rs
@@ -137,6 +137,22 @@ impl QueryEngine {
     }
 
     /// Execute a CQL query
+    ///
+    /// This is the parent of the query span tree (epic #1031, issue #1035): the
+    /// `query.execute` span created here is the context every read-path span
+    /// (issue #1034) and SELECT sub-span nests under. Bounded span attributes
+    /// (plan type, access path, rows returned) are recorded once the result is
+    /// known via [`Self::update_execution_stats`]; the query text is never
+    /// attached.
+    #[tracing::instrument(
+        name = "query.execute",
+        skip(self, cql),
+        fields(
+            cqlite.query.plan_type = tracing::field::Empty,
+            cqlite.query.access_path = tracing::field::Empty,
+            cqlite.query.rows = tracing::field::Empty,
+        )
+    )]
     pub async fn execute(&self, cql: &str) -> Result<QueryResult> {
         let start_time = Instant::now();
         self.inc_total_queries();
@@ -161,22 +177,29 @@ impl QueryEngine {
             self.record_cache_hit();
             cached_entry.hit_count += 1;
 
-            let mut result = self.executor.execute(&cached_entry.plan).await?;
+            let mut result = crate::observability::record_result(
+                "query",
+                self.executor.execute(&cached_entry.plan).await,
+            )?;
             self.update_execution_stats(&mut result, start_time);
             return Ok(result);
         }
 
-        let parsed_query = self
-            .parser
-            .parse(cql)
-            .inspect_err(|_| self.inc_error_queries())?;
-        let plan = self.planner.plan(&parsed_query).await?;
+        let parsed_query = self.parser.parse(cql).inspect_err(|e| {
+            self.inc_error_queries();
+            crate::observability::record_error(e, "query");
+        })?;
+        let plan = crate::observability::record_result(
+            "query",
+            self.planner.plan(&parsed_query).await,
+        )?;
 
         if self.config.query.query_cache_size.unwrap_or(0) > 0 {
             self.cache_query_plan(cql, parsed_query, plan.clone());
         }
 
-        let mut result = self.executor.execute(&plan).await?;
+        let mut result =
+            crate::observability::record_result("query", self.executor.execute(&plan).await)?;
         self.update_execution_stats(&mut result, start_time);
         Ok(result)
     }
@@ -233,7 +256,10 @@ impl QueryEngine {
                 self.record_cache_hit();
                 cached_entry.hit_count += 1;
 
-                let mut result = self.executor.execute(&cached_entry.plan).await?;
+                let mut result = crate::observability::record_result(
+                    "query",
+                    self.executor.execute(&cached_entry.plan).await,
+                )?;
                 self.update_execution_stats(&mut result, start_time);
                 return Ok(result);
             }
@@ -250,10 +276,18 @@ impl QueryEngine {
 
         #[cfg(feature = "state_machine")]
         {
-            let select_statement =
-                select_parser::parse_select(cql).inspect_err(|_| self.inc_error_queries())?;
-            let optimized_plan = self.select_optimizer.optimize(select_statement).await?;
-            let mut result = self.select_executor.execute(optimized_plan).await?;
+            let select_statement = select_parser::parse_select(cql).inspect_err(|e| {
+                self.inc_error_queries();
+                crate::observability::record_error(e, "query");
+            })?;
+            let optimized_plan = crate::observability::record_result(
+                "query",
+                self.select_optimizer.optimize(select_statement).await,
+            )?;
+            let mut result = crate::observability::record_result(
+                "query",
+                self.select_executor.execute(optimized_plan).await,
+            )?;
             self.update_execution_stats(&mut result, start_time);
             Ok(result)
         }
@@ -603,8 +637,20 @@ impl QueryEngine {
         }
     }
 
-    /// Update execution statistics
+    /// Update execution statistics.
+    ///
+    /// This is the single chokepoint every materializing query path (cache hit,
+    /// parsed-plan, SELECT, parameterized, prepared) funnels through once its
+    /// result is known, so it is also where observability emits the end-to-end
+    /// query signals exactly once (issue #1035): the [`catalog::QUERY_DURATION`]
+    /// histogram and the [`catalog::QUERY_ROWS`] counter, both dimensioned by the
+    /// bounded access path the SELECT chose (when available). It also records the
+    /// bounded span attributes on the active `query.execute` span so the parent of
+    /// the read-path span tree is self-describing. Durations are reported in
+    /// seconds, per the catalog convention.
     fn update_execution_stats(&self, result: &mut QueryResult, start_time: Instant) {
+        use crate::observability::{self as obs, catalog, AttrValue};
+
         let execution_time = start_time.elapsed();
         // Ensure any non-zero execution time is at least 1ms for reporting
         result.execution_time_ms = if execution_time.is_zero() {
@@ -612,6 +658,50 @@ impl QueryEngine {
         } else {
             std::cmp::max(1, execution_time.as_millis() as u64)
         };
+
+        // Bounded access-path dimension, sourced from the honest per-query signal
+        // the modern SelectExecutor attaches to the result (epic #951/#960). We
+        // CONSUME that existing label rather than reinventing it; `None` (legacy
+        // executor / non-SELECT) is reported as "unknown" to keep the dimension
+        // bounded without fabricating a path.
+        let access_path_label: &'static str = result
+            .metadata
+            .access_path
+            .as_ref()
+            .map(|p| p.label())
+            .unwrap_or("unknown");
+        let plan_type_label: &'static str = result
+            .metadata
+            .plan_info
+            .as_ref()
+            .map(|p| Self::plan_type_label(&p.plan_type))
+            .unwrap_or("unknown");
+
+        // Emit the end-to-end query metrics exactly once, here.
+        obs::record_histogram(
+            catalog::QUERY_DURATION,
+            execution_time.as_secs_f64(),
+            &[
+                (catalog::attr::SUBSYSTEM, AttrValue::StaticStr("query")),
+                (catalog::attr::ACCESS_PATH, AttrValue::StaticStr(access_path_label)),
+                (catalog::attr::PLAN_TYPE, AttrValue::StaticStr(plan_type_label)),
+            ],
+        );
+        obs::add_counter(
+            catalog::QUERY_ROWS,
+            result.rows.len() as u64,
+            &[
+                (catalog::attr::ACCESS_PATH, AttrValue::StaticStr(access_path_label)),
+                (catalog::attr::PLAN_TYPE, AttrValue::StaticStr(plan_type_label)),
+            ],
+        );
+
+        // Record bounded attributes on the active `query.execute` span (parent of
+        // the read-path span tree). Never attach the query text or key values.
+        let span = tracing::Span::current();
+        span.record(catalog::attr::PLAN_TYPE, plan_type_label);
+        span.record(catalog::attr::ACCESS_PATH, access_path_label);
+        span.record("cqlite.query.rows", result.rows.len());
 
         let new_time_us = execution_time.as_micros() as u64;
         let mut stats = self.stats.write();
@@ -622,6 +712,23 @@ impl QueryEngine {
                 / stats.total_queries
         };
         stats.rows_affected += result.rows_affected;
+    }
+
+    /// Map a `PlanInfo.plan_type` (an executor `Debug`-formatted plan family such
+    /// as `"TableScan"`) onto a bounded, lower-snake label suitable as a metric
+    /// dimension and span attribute (issue #1035). Falls back to `"other"` for
+    /// any value outside the known taxonomy so the dimension stays bounded.
+    fn plan_type_label(plan_type: &str) -> &'static str {
+        match plan_type {
+            "TableScan" => "table_scan",
+            "IndexScan" => "index_scan",
+            "PointLookup" => "point_lookup",
+            "RangeScan" => "range_scan",
+            "Join" => "join",
+            "Aggregation" => "aggregation",
+            "Subquery" => "subquery",
+            _ => "other",
+        }
     }
 }
 

--- a/cqlite-core/src/query/executor.rs
+++ b/cqlite-core/src/query/executor.rs
@@ -62,9 +62,26 @@ impl QueryExecutor {
         }
     }
 
-    /// Execute a query plan
+    /// Execute a query plan.
+    ///
+    /// Instrumented as `query.execute` (issue #1035) so that surfaces which reach
+    /// the legacy executor directly — notably prepared/parameterized statements
+    /// that bypass `QueryEngine::execute` — still root a query span tree under
+    /// which the per-branch sub-spans (`query.point_lookup`, `query.table_scan`,
+    /// …) and the read-path spans (issue #1034) nest. When invoked via
+    /// `QueryEngine::execute` this nests under that span. The bounded plan-type
+    /// attribute is recorded; the query text and key values never are.
+    #[tracing::instrument(
+        name = "query.execute",
+        skip_all,
+        fields(cqlite.query.plan_type = tracing::field::Empty),
+    )]
     pub async fn execute(&self, plan: &QueryPlan) -> Result<QueryResult> {
         let start_time = Instant::now();
+        tracing::Span::current().record(
+            crate::observability::catalog::attr::PLAN_TYPE,
+            Self::plan_type_label(&plan.plan_type),
+        );
 
         // Classify the plan once so subsequent dispatch is a single match.
         let has_insert_step = plan
@@ -144,6 +161,22 @@ impl QueryExecutor {
     }
 
     // -- helpers ------------------------------------------------------------
+
+    /// Bounded, lower-snake label for a [`super::planner::PlanType`], used as a
+    /// span attribute (issue #1035). The value space is the closed `PlanType`
+    /// taxonomy, so it is safe as a telemetry dimension.
+    fn plan_type_label(plan_type: &super::planner::PlanType) -> &'static str {
+        use super::planner::PlanType;
+        match plan_type {
+            PlanType::TableScan => "table_scan",
+            PlanType::IndexScan => "index_scan",
+            PlanType::PointLookup => "point_lookup",
+            PlanType::RangeScan => "range_scan",
+            PlanType::Join => "join",
+            PlanType::Aggregation => "aggregation",
+            PlanType::Subquery => "subquery",
+        }
+    }
 
     /// Report the access path(s) the executor *actually consulted* for `plan`,
     /// for the `indexes_used` field of [`super::result::PlanInfo`] (issue #760,
@@ -271,6 +304,7 @@ impl QueryExecutor {
     // -- plan executors -----------------------------------------------------
 
     /// Execute point lookup plan
+    #[tracing::instrument(name = "query.point_lookup", skip_all)]
     async fn execute_point_lookup(&self, plan: &QueryPlan) -> Result<QueryResult> {
         let table = self.require_table(plan)?;
 
@@ -298,6 +332,7 @@ impl QueryExecutor {
     }
 
     /// Execute index scan plan
+    #[tracing::instrument(name = "query.index_scan", skip_all)]
     async fn execute_index_scan(&self, plan: &QueryPlan) -> Result<QueryResult> {
         let table = self.require_table(plan)?;
 
@@ -330,6 +365,7 @@ impl QueryExecutor {
     }
 
     /// Execute range scan plan
+    #[tracing::instrument(name = "query.range_scan", skip_all)]
     async fn execute_range_scan(&self, plan: &QueryPlan) -> Result<QueryResult> {
         let table = self.require_table(plan)?;
 
@@ -341,6 +377,7 @@ impl QueryExecutor {
     }
 
     /// Execute table scan plan
+    #[tracing::instrument(name = "query.table_scan", skip_all)]
     async fn execute_table_scan(&self, plan: &QueryPlan) -> Result<QueryResult> {
         let table = self.require_table(plan)?;
 
@@ -436,6 +473,7 @@ impl QueryExecutor {
     /// receiver deduplicates implicitly by virtue of preserving emission order;
     /// this matches the behavior present before refactoring. A real parallel
     /// scan would partition the key range across workers.
+    #[tracing::instrument(name = "query.parallel_table_scan", skip_all)]
     async fn execute_parallel_table_scan(
         &self,
         table: &TableId,

--- a/cqlite-core/src/query/select_executor.rs
+++ b/cqlite-core/src/query/select_executor.rs
@@ -94,6 +94,11 @@ struct ExecutionContext {
     pub columns: Vec<ColumnInfo>,
     /// Row count processed so far
     pub rows_processed: u64,
+    /// Rows examined by the SSTable-scan step ONLY (issue #1035). Distinct from
+    /// `rows_processed`, which is also bumped by the residual `Filter` step, so
+    /// this is the correct, non-double-counted source for the
+    /// `cqlite.query.rows_scanned` metric and span field.
+    pub scan_rows: u64,
     /// Projection flags controlling opt-in metadata collection (Issue #692).
     ///
     /// Set to `include_cell_metadata = true` when any `WRITETIME` or `TTL`
@@ -1325,6 +1330,7 @@ impl SelectExecutor {
             table_id,
             columns: self.get_result_columns(&plan.statement).await?,
             rows_processed: 0,
+            scan_rows: 0,
             projection_flags,
             access_path: None,
         };
@@ -1470,7 +1476,7 @@ impl SelectExecutor {
 
             obs::add_counter(
                 catalog::QUERY_ROWS_SCANNED,
-                context.rows_processed,
+                context.scan_rows,
                 &[(
                     catalog::attr::ACCESS_PATH,
                     AttrValue::StaticStr(access_path_label),
@@ -1479,7 +1485,7 @@ impl SelectExecutor {
 
             let span = tracing::Span::current();
             span.record(catalog::attr::ACCESS_PATH, access_path_label);
-            span.record("cqlite.query.rows_scanned", context.rows_processed);
+            span.record("cqlite.query.rows_scanned", context.scan_rows);
             span.record("cqlite.query.rows", total_rows);
         }
 
@@ -2050,6 +2056,7 @@ impl SelectExecutor {
 
             for (key, value, cell_meta) in scan_results {
                 context.rows_processed += 1;
+                context.scan_rows += 1;
 
                 let Some(mut row) =
                     build_row_from_scan(key, value, projection, schema_opt.as_ref())
@@ -2184,6 +2191,7 @@ impl SelectExecutor {
 
             for (key, value) in scan_results {
                 context.rows_processed += 1;
+                context.scan_rows += 1;
 
                 // build_row_from_scan returns None for tombstoned/null rows (Issue #191).
                 let Some(row) = build_row_from_scan(key, value, projection, schema_opt.as_ref())

--- a/cqlite-core/src/query/select_executor.rs
+++ b/cqlite-core/src/query/select_executor.rs
@@ -1225,6 +1225,59 @@ impl SelectExecutor {
         }
     }
 
+    /// Derive a bounded plan-family label for a SELECT, from the plan it executed
+    /// and the honest access path the SSTable-scan step actually took (issue #1035).
+    ///
+    /// The string is one of the `PlanType` `Debug` forms (`"TableScan"`,
+    /// `"PointLookup"`, `"RangeScan"`, `"Aggregation"`) so that
+    /// `QueryEngine::plan_type_label` maps it onto the same bounded metric/span
+    /// taxonomy the legacy executor already uses — keeping cardinality bounded and
+    /// the dimension consistent across surfaces. The access path is the same
+    /// per-query signal surfaced on `QueryMetadata.access_path` (epic #951/#960);
+    /// this never inspects query text or key values.
+    fn select_plan_family(plan: &OptimizedQueryPlan, access_path: Option<&AccessPath>) -> String {
+        // Aggregation dominates: a query that aggregates is reported as such
+        // regardless of how its underlying scan was served.
+        if plan.aggregation_plan.is_some() {
+            return "Aggregation".to_string();
+        }
+        match access_path {
+            Some(
+                AccessPath::PartitionLookup
+                | AccessPath::MultiPartitionLookup
+                | AccessPath::MetadataPartitionLookup
+                | AccessPath::StreamingPartitionLookup,
+            ) => "PointLookup".to_string(),
+            Some(AccessPath::ClusteringSlice) => "RangeScan".to_string(),
+            // Full scan, any documented fallback, or no recorded path (e.g. a plan
+            // with no scan step) is honestly a table scan.
+            Some(AccessPath::FullScan | AccessPath::FallbackFullScan { .. }) | None => {
+                "TableScan".to_string()
+            }
+        }
+    }
+
+    /// Build the bounded `PlanInfo` carried on a SELECT result so the engine's
+    /// single observability chokepoint can dimension `QUERY_DURATION`/`QUERY_ROWS`
+    /// and the parent span by a real plan family instead of `"unknown"`
+    /// (issue #1035). Only the bounded plan-family string and the chosen access
+    /// path (as the single "index used" entry) are recorded — never query text.
+    fn select_plan_info(
+        plan: &OptimizedQueryPlan,
+        access_path: Option<&AccessPath>,
+    ) -> crate::query::result::PlanInfo {
+        crate::query::result::PlanInfo {
+            plan_type: Self::select_plan_family(plan, access_path),
+            estimated_cost: 0.0,
+            actual_cost: 0.0,
+            indexes_used: access_path
+                .map(|p| vec![p.label().to_string()])
+                .unwrap_or_default(),
+            steps: vec![],
+            parallelization: None,
+        }
+    }
+
     /// Execute an optimized query plan.
     ///
     /// Instrumented as `query.select.plan` (issue #1035): this span covers the
@@ -1400,6 +1453,42 @@ impl SelectExecutor {
             }
         }
 
+        // Observability (issue #1035): the `query.select.plan` span declared
+        // `access_path`/`rows_scanned`/`rows` but never recorded them, and
+        // `QUERY_ROWS_SCANNED` was never emitted. Do both here, sourced from the
+        // honest per-query signal (`context.access_path`, set by the SSTable-scan
+        // step) and the rows the scan examined (`context.rows_processed`). Bounded
+        // attributes only — never the query text or key values.
+        {
+            use crate::observability::{self as obs, catalog, AttrValue};
+
+            let access_path_label: &'static str = context
+                .access_path
+                .as_ref()
+                .map(|p| p.label())
+                .unwrap_or("unknown");
+
+            obs::add_counter(
+                catalog::QUERY_ROWS_SCANNED,
+                context.rows_processed,
+                &[(
+                    catalog::attr::ACCESS_PATH,
+                    AttrValue::StaticStr(access_path_label),
+                )],
+            );
+
+            let span = tracing::Span::current();
+            span.record(catalog::attr::ACCESS_PATH, access_path_label);
+            span.record("cqlite.query.rows_scanned", context.rows_processed);
+            span.record("cqlite.query.rows", total_rows);
+        }
+
+        // Issue #1035: carry a bounded plan family on the result so the engine's
+        // single observability chokepoint reports a real plan type for SELECTs
+        // (the modern executor previously always returned `plan_info: None`,
+        // forcing plan_type to "unknown").
+        let plan_info = Self::select_plan_info(&plan, context.access_path.as_ref());
+
         Ok(QueryResult {
             rows: intermediate_results,
             rows_affected: total_rows, // Use actual number of rows returned
@@ -1407,7 +1496,7 @@ impl SelectExecutor {
             metadata: crate::query::result::QueryMetadata {
                 columns,
                 total_rows: Some(total_rows),
-                plan_info: None,
+                plan_info: Some(plan_info),
                 performance: Default::default(),
                 warnings: vec![],
                 // Issue #960: surface the access path the SSTable-scan step chose

--- a/cqlite-core/src/query/select_executor.rs
+++ b/cqlite-core/src/query/select_executor.rs
@@ -1225,7 +1225,25 @@ impl SelectExecutor {
         }
     }
 
-    /// Execute an optimized query plan
+    /// Execute an optimized query plan.
+    ///
+    /// Instrumented as `query.select.plan` (issue #1035): this span covers the
+    /// modern SELECT pipeline — SSTable scan, filtering, projection, aggregation,
+    /// and WRITETIME/TTL metadata extraction — and is the parent under which the
+    /// read-path spans (issue #1034) nest. On completion it emits
+    /// [`catalog::QUERY_ROWS_SCANNED`] (rows the scan step examined) dimensioned by
+    /// the honest access path, so the rows-scanned vs rows-returned gap is
+    /// observable. The bounded access-path attribute is recorded on the span; the
+    /// query text and key values never are.
+    #[tracing::instrument(
+        name = "query.select.plan",
+        skip_all,
+        fields(
+            cqlite.query.access_path = tracing::field::Empty,
+            cqlite.query.rows_scanned = tracing::field::Empty,
+            cqlite.query.rows = tracing::field::Empty,
+        )
+    )]
     pub async fn execute(&self, plan: OptimizedQueryPlan) -> Result<QueryResult> {
         // Issue #960: clear the global access-path probe so a stale value from a
         // previous query cannot satisfy a test assertion against this one.


### PR DESCRIPTION
Part of epic #1031. Depends on merged foundation (#1032).

- `query.execute` parent span (top of the trace; read-path spans nest under it) with bounded attributes: plan type, access path, rows returned/scanned.
- QUERY_DURATION histogram + QUERY_ROWS counter emitted once at the engine chokepoint, dimensioned by bounded access_path + plan_type. New `query.select.plan` span + QUERY_ROWS_SCANNED (scan-step rows only — no residual-filter double count).
- SELECT results carry a bounded PlanInfo so plan_type is a real family instead of 'unknown'. Consumes the #951/#960 access-path signal (no reinvention).
- record_error(subsystem=query) at boundaries.

Validation: default + observability builds clean; clippy -D warnings clean; query test suite passes (208). roborev: addressed both Medium findings (rows_scanned emission + SELECT plan_type/access_path; scan-only row counting); remaining finding is a Low test-coverage nicety.

Closes #1035