### PR TITLE
feat(observability): instrument SSTable read path — open/discovery, partition lookup, bloom, decode (#1034)

### DIFF
--- a/cqlite-core/src/observability/catalog.rs
+++ b/cqlite-core/src/observability/catalog.rs
@@ -61,6 +61,13 @@ pub mod attr {
     pub const SSTABLE_FORMAT: &str = "cqlite.sstable.format";
     /// Compression algorithm, e.g. `"lz4"`, `"snappy"`, `"none"`. Bounded.
     pub const COMPRESSION: &str = "cqlite.compression";
+    /// Outcome of a lookup/check, exactly `"hit"` or `"miss"`. Bounded to two
+    /// values; used by partition-lookup and bloom-check counters so a single
+    /// metric carries both arms for ratio dashboards.
+    pub const RESULT: &str = "cqlite.result";
+    /// Read-path access route for a partition lookup, e.g. `"index"` (BIG
+    /// Index.db) or `"bti_trie"` (BTI Partitions.db). Bounded by the code.
+    pub const ACCESS_PATH: &str = "cqlite.access_path";
 }
 
 /// `cqlite.read.rows` — counter `{row}`.
@@ -85,6 +92,42 @@ pub const READ_PARTITIONS: &str = "cqlite.read.partitions";
 /// Distribution of single read/scan operation durations in seconds. Bounded
 /// attributes: [`attr::SSTABLE_FORMAT`].
 pub const READ_DURATION: &str = "cqlite.read.duration";
+
+/// `cqlite.storage.open.sstables` — counter `{sstable}`.
+///
+/// SSTables discovered and opened by a single [`StorageEngine`] open, summed
+/// across opens over the process lifetime. No high-cardinality attributes.
+pub const STORAGE_OPEN_SSTABLES: &str = "cqlite.storage.open.sstables";
+
+/// `cqlite.storage.open.bytes` — counter `By`.
+///
+/// Total on-disk Data.db bytes across the SSTables discovered by a
+/// [`StorageEngine`] open. No high-cardinality attributes.
+pub const STORAGE_OPEN_BYTES: &str = "cqlite.storage.open.bytes";
+
+/// `cqlite.storage.open.tables` — counter `1`.
+///
+/// Total logical tables represented by the SSTables discovered at
+/// [`StorageEngine`] open. No high-cardinality attributes.
+pub const STORAGE_OPEN_TABLES: &str = "cqlite.storage.open.tables";
+
+/// `cqlite.read.partition_lookup.total` — counter `1`.
+///
+/// Total partition point lookups attempted on the read path, one increment per
+/// lookup. Bounded attributes: [`attr::RESULT`] (`hit`/`miss`),
+/// [`attr::ACCESS_PATH`] (`index`/`bti_trie`), and [`attr::SSTABLE_FORMAT`].
+/// Carrying `result` as an attribute (instead of separate metric names) lets a
+/// dashboard compute hit ratio from one series.
+pub const READ_PARTITION_LOOKUP: &str = "cqlite.read.partition_lookup.total";
+
+/// `cqlite.read.bloom.checks` — counter `1`.
+///
+/// Total bloom-filter / BTI-trie present-or-absent checks on the read path, one
+/// increment per check. Bounded attributes: [`attr::RESULT`] (`hit` = maybe
+/// present, `miss` = definitely absent) and [`attr::SSTABLE_FORMAT`]. The
+/// miss-rate of this metric is the pruning effectiveness; pairing it with
+/// [`READ_PARTITION_LOOKUP`] reveals the bloom false-positive rate.
+pub const READ_BLOOM_CHECKS: &str = "cqlite.read.bloom.checks";
 
 /// `cqlite.query.duration` — histogram `s`.
 ///
@@ -123,6 +166,11 @@ pub const ALL_METRICS: &[&str] = &[
     READ_BYTES,
     READ_PARTITIONS,
     READ_DURATION,
+    READ_PARTITION_LOOKUP,
+    READ_BLOOM_CHECKS,
+    STORAGE_OPEN_SSTABLES,
+    STORAGE_OPEN_BYTES,
+    STORAGE_OPEN_TABLES,
     QUERY_DURATION,
     QUERY_ROWS,
     SSTABLES_OPEN,
@@ -154,6 +202,8 @@ mod tests {
             attr::SUBSYSTEM,
             attr::SSTABLE_FORMAT,
             attr::COMPRESSION,
+            attr::RESULT,
+            attr::ACCESS_PATH,
         ] {
             assert!(key.starts_with("cqlite."), "attr {key} must be namespaced");
         }

--- a/cqlite-core/src/observability/otel.rs
+++ b/cqlite-core/src/observability/otel.rs
@@ -242,6 +242,11 @@ struct Instruments {
     read_rows: Counter<u64>,
     read_bytes: Counter<u64>,
     read_partitions: Counter<u64>,
+    read_partition_lookup: Counter<u64>,
+    read_bloom_checks: Counter<u64>,
+    storage_open_sstables: Counter<u64>,
+    storage_open_bytes: Counter<u64>,
+    storage_open_tables: Counter<u64>,
     query_rows: Counter<u64>,
     errors_total: Counter<u64>,
     read_duration: Histogram<f64>,
@@ -269,6 +274,31 @@ fn instruments() -> &'static Instruments {
                 .u64_counter(catalog::READ_PARTITIONS)
                 .with_unit(catalog::unit::PARTITIONS)
                 .with_description("Total partitions scanned.")
+                .build(),
+            read_partition_lookup: m
+                .u64_counter(catalog::READ_PARTITION_LOOKUP)
+                .with_unit(catalog::unit::DIMENSIONLESS)
+                .with_description("Total partition point lookups, keyed by {result, access_path}.")
+                .build(),
+            read_bloom_checks: m
+                .u64_counter(catalog::READ_BLOOM_CHECKS)
+                .with_unit(catalog::unit::DIMENSIONLESS)
+                .with_description("Total bloom/BTI-trie presence checks, keyed by {result}.")
+                .build(),
+            storage_open_sstables: m
+                .u64_counter(catalog::STORAGE_OPEN_SSTABLES)
+                .with_unit(catalog::unit::SSTABLES)
+                .with_description("SSTables discovered and opened, summed across opens.")
+                .build(),
+            storage_open_bytes: m
+                .u64_counter(catalog::STORAGE_OPEN_BYTES)
+                .with_unit(catalog::unit::BYTES)
+                .with_description("On-disk Data.db bytes across SSTables discovered at open.")
+                .build(),
+            storage_open_tables: m
+                .u64_counter(catalog::STORAGE_OPEN_TABLES)
+                .with_unit(catalog::unit::DIMENSIONLESS)
+                .with_description("Logical tables represented by SSTables discovered at open.")
                 .build(),
             query_rows: m
                 .u64_counter(catalog::QUERY_ROWS)
@@ -317,6 +347,16 @@ pub(crate) fn add_counter(name: &'static str, value: u64, attributes: &[KeyValue
         &i.read_bytes
     } else if name == catalog::READ_PARTITIONS {
         &i.read_partitions
+    } else if name == catalog::READ_PARTITION_LOOKUP {
+        &i.read_partition_lookup
+    } else if name == catalog::READ_BLOOM_CHECKS {
+        &i.read_bloom_checks
+    } else if name == catalog::STORAGE_OPEN_SSTABLES {
+        &i.storage_open_sstables
+    } else if name == catalog::STORAGE_OPEN_BYTES {
+        &i.storage_open_bytes
+    } else if name == catalog::STORAGE_OPEN_TABLES {
+        &i.storage_open_tables
     } else if name == catalog::QUERY_ROWS {
         &i.query_rows
     } else if name == catalog::ERRORS_TOTAL {

--- a/cqlite-core/src/storage/mod.rs
+++ b/cqlite-core/src/storage/mod.rs
@@ -60,6 +60,11 @@ impl StorageEngine {
     ///
     /// NOTE: Issue #176 removed write infrastructure (compaction, manifest).
     /// This is now a read-only storage layer focused on SSTable access.
+    #[tracing::instrument(
+        name = "storage.engine.open",
+        skip(path, config, platform),
+        fields(sstables = tracing::field::Empty, bytes = tracing::field::Empty)
+    )]
     pub async fn open(
         path: &Path,
         config: &Config,
@@ -69,10 +74,14 @@ impl StorageEngine {
         >,
     ) -> Result<Self> {
         // Create storage directory if it doesn't exist
-        platform.fs().create_dir_all(path).await?;
+        crate::observability::record_result(
+            "reader",
+            platform.fs().create_dir_all(path).await,
+        )?;
 
         // Initialize SSTable manager with schema registry
-        let sstables = Arc::new(
+        let sstables = Arc::new(crate::observability::record_result(
+            "reader",
             sstable::SSTableManager::new(
                 path,
                 config,
@@ -80,8 +89,10 @@ impl StorageEngine {
                 #[cfg(feature = "state_machine")]
                 schema_registry.clone(),
             )
-            .await?,
-        );
+            .await,
+        )?);
+
+        Self::record_discovery_metrics(&sstables).await;
 
         Ok(Self {
             sstables,
@@ -90,6 +101,26 @@ impl StorageEngine {
             #[cfg(feature = "state_machine")]
             schema_registry: Arc::new(RwLock::new(schema_registry)),
         })
+    }
+
+    /// Emit SSTable-discovery telemetry (issue #1034) for a freshly built
+    /// manager: total SSTables discovered, their on-disk byte total, and the
+    /// number of logical tables. Best-effort — a stats failure is logged and the
+    /// open continues, since telemetry must never change open behaviour.
+    async fn record_discovery_metrics(sstables: &sstable::SSTableManager) {
+        use crate::observability::{self as obs, catalog};
+        match sstables.stats().await {
+            Ok(stats) => {
+                tracing::Span::current().record("sstables", stats.sstable_count as u64);
+                tracing::Span::current().record("bytes", stats.total_size);
+                obs::add_counter(catalog::STORAGE_OPEN_SSTABLES, stats.sstable_count as u64, &[]);
+                obs::add_counter(catalog::STORAGE_OPEN_BYTES, stats.total_size, &[]);
+                obs::add_counter(catalog::STORAGE_OPEN_TABLES, stats.total_tables, &[]);
+            }
+            Err(e) => {
+                log::debug!("storage.engine.open: discovery metrics unavailable: {}", e);
+            }
+        }
     }
 
     /// Open a storage engine with pre-discovered SSTable table directories
@@ -133,6 +164,11 @@ impl StorageEngine {
     /// # Ok(())
     /// # }
     /// ```
+    #[tracing::instrument(
+        name = "storage.engine.open",
+        skip(path, discovered_table_dirs, config, platform),
+        fields(sstables = tracing::field::Empty, bytes = tracing::field::Empty)
+    )]
     pub async fn open_with_sstables(
         path: &Path,
         discovered_table_dirs: Vec<PathBuf>,
@@ -143,10 +179,14 @@ impl StorageEngine {
         >,
     ) -> Result<Self> {
         // Create storage directory if it doesn't exist
-        platform.fs().create_dir_all(path).await?;
+        crate::observability::record_result(
+            "reader",
+            platform.fs().create_dir_all(path).await,
+        )?;
 
         // Initialize SSTable manager with pre-discovered paths and schema registry
-        let sstables = Arc::new(
+        let sstables = Arc::new(crate::observability::record_result(
+            "reader",
             sstable::SSTableManager::new_from_discovered_paths(
                 path,
                 discovered_table_dirs,
@@ -155,8 +195,10 @@ impl StorageEngine {
                 #[cfg(feature = "state_machine")]
                 schema_registry.clone(),
             )
-            .await?,
-        );
+            .await,
+        )?);
+
+        Self::record_discovery_metrics(&sstables).await;
 
         Ok(Self {
             sstables,

--- a/cqlite-core/src/storage/sstable/reader/data_access.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access.rs
@@ -331,6 +331,8 @@ impl SSTableReader {
 
     /// Get a value by key from the SSTable
     pub async fn get(&self, table_id: &TableId, key: &RowKey) -> Result<Option<Value>> {
+        use crate::observability::{self as obs, catalog};
+
         // Issue #831 / #909: BTI ("da") readers resolve partitions via the
         // Partitions.db trie (O(log n)), never via Index.db (absent for BTI) or
         // the sequential scan. The trie is the AUTHORITATIVE presence oracle for a
@@ -347,7 +349,22 @@ impl SSTableReader {
 
         // First check bloom filter if available
         if let Some(bloom_filter) = &self.bloom_filter {
-            if !bloom_filter.might_contain(key.as_bytes()) {
+            let present = bloom_filter.might_contain(key.as_bytes());
+            obs::add_counter(
+                catalog::READ_BLOOM_CHECKS,
+                1,
+                &[
+                    (
+                        catalog::attr::RESULT,
+                        if present { "hit" } else { "miss" }.into(),
+                    ),
+                    (
+                        catalog::attr::SSTABLE_FORMAT,
+                        self.sstable_format_label().into(),
+                    ),
+                ],
+            );
+            if !present {
                 return Ok(None);
             }
         }

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -317,7 +317,14 @@ impl SSTableReader {
                     &[(catalog::attr::SSTABLE_FORMAT, format.into())],
                 );
             }
-            Err(e) => obs::record_error(e, "reader"),
+            Err(e) => {
+                // Record the error WHILE the open span is current so
+                // `mark_span_error` marks THIS `sstable.reader.open` span. The
+                // instrumented future has already completed here, so the span is
+                // no longer entered; `in_scope` re-enters it for the duration of
+                // the error-recording call.
+                span.in_scope(|| obs::record_error(e, "reader"));
+            }
         }
         result
     }

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -61,7 +61,7 @@ use header::{
 
 use std::collections::HashMap;
 use std::path::Path;
-use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::fs::File;
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
@@ -253,9 +253,53 @@ fn mmap_advice_for(prefetch: PrefetchMode) -> Option<memmap2::Advice> {
     }
 }
 
+/// Process-wide count of currently-open [`SSTableReader`]s, the source value
+/// for the [`SSTABLES_OPEN`](crate::observability::catalog::SSTABLES_OPEN)
+/// gauge. Incremented when [`SSTableReader::open`] succeeds and decremented when
+/// a reader is dropped, so the gauge reflects live readers regardless of the
+/// `observability` feature state (the helper calls are no-ops when off).
+static SSTABLES_OPEN_COUNT: AtomicU64 = AtomicU64::new(0);
+
 impl SSTableReader {
-    /// Open an SSTable file for reading
+    /// Open an SSTable file for reading.
+    ///
+    /// Instrumented (epic #1031 / #1034): wraps the open in a
+    /// `sstable.reader.open` span, increments the [`SSTABLES_OPEN`] gauge on
+    /// success, and records an error on the `reader` subsystem when open fails.
+    ///
+    /// [`SSTABLES_OPEN`]: crate::observability::catalog::SSTABLES_OPEN
     pub async fn open(path: &Path, config: &Config, platform: Arc<Platform>) -> Result<Self> {
+        use crate::observability::{self as obs, catalog};
+
+        let span = tracing::debug_span!(
+            "sstable.reader.open",
+            file_size = tracing::field::Empty,
+            sstable_format = tracing::field::Empty,
+        );
+        let _entered = span.enter();
+
+        let result = Self::open_inner(path, config, platform).await;
+        match &result {
+            Ok(reader) => {
+                let format = reader.sstable_format_label();
+                span.record("file_size", reader.stats.file_size);
+                span.record("sstable_format", format);
+                // SSTABLES_OPEN is a snapshot gauge of the live reader count;
+                // record the current count after this open succeeds.
+                let now = SSTABLES_OPEN_COUNT.fetch_add(1, Ordering::Relaxed) + 1;
+                obs::record_gauge(
+                    catalog::SSTABLES_OPEN,
+                    now as i64,
+                    &[(catalog::attr::SSTABLE_FORMAT, format.into())],
+                );
+            }
+            Err(e) => obs::record_error(e, "reader"),
+        }
+        result
+    }
+
+    /// Open implementation; see [`open`](Self::open) for the instrumented wrapper.
+    async fn open_inner(path: &Path, config: &Config, platform: Arc<Platform>) -> Result<Self> {
         // Resolve the disk-access backend (buffered / mmap / direct, or auto)
         // from config + environment overrides. See `Config::storage.disk_access_mode`.
         let mut reader_config = SSTableReaderConfig::default();
@@ -394,12 +438,15 @@ impl SSTableReader {
             (none.clone(), none)
         };
 
+        use tracing::Instrument;
+
         let config = crate::cql::config::ParserConfig::default();
         let parser = SSTableParser::new(config)?;
         // Parse the header using enhanced version detection - strict error propagation.
         // VersionGates are passed so VG3 can flip version-sensitive parsing decisions
         // inside header parsing without re-deriving gates from the filename.
         let header = parse_header_with_version_detection(&header_buffer, path, &version_gates)
+            .instrument(tracing::debug_span!("sstable.reader.open.header_parse"))
             .await
             .map_err(|e| {
                 Error::corruption(format!(
@@ -444,15 +491,25 @@ impl SSTableReader {
         }
 
         // Load index if available (supports both integrated and component-based)
-        let index = Self::load_index(&file, &header, &platform, path).await?;
+        let index = Self::load_index(&file, &header, &platform, path)
+            .instrument(tracing::debug_span!("sstable.reader.open.load_index"))
+            .await?;
 
         // Load bloom filter if available (supports both integrated and component-based)
-        let bloom_filter = Self::load_bloom_filter(&file, &header, &platform, path).await?;
+        let bloom_filter = Self::load_bloom_filter(&file, &header, &platform, path)
+            .instrument(tracing::debug_span!("sstable.reader.open.load_bloom"))
+            .await?;
 
         // Load spec readers for enhanced metadata and lookups
-        let index_reader = Self::load_index_reader(path, &platform).await;
-        let summary_reader = Self::load_summary_reader(path, &platform).await;
-        let statistics_reader = Self::load_statistics_reader(path, &platform).await;
+        let index_reader = Self::load_index_reader(path, &platform)
+            .instrument(tracing::debug_span!("sstable.reader.open.load_index_reader"))
+            .await;
+        let summary_reader = Self::load_summary_reader(path, &platform)
+            .instrument(tracing::debug_span!("sstable.reader.open.load_summary"))
+            .await;
+        let statistics_reader = Self::load_statistics_reader(path, &platform)
+            .instrument(tracing::debug_span!("sstable.reader.open.load_statistics"))
+            .await;
 
         // Extract SerializationHeader columns from Statistics.db (Issue #163)
         // This enables schema extraction for V5CompressedLegacy format
@@ -849,6 +906,18 @@ impl SSTableReader {
         self.header.cassandra_version
     }
 
+    /// Low-cardinality on-disk format family label for telemetry attributes
+    /// (`"bti"` or `"big"`). Derived from the authoritative [`VersionGates`], so
+    /// it stays bounded to exactly two values — safe to attach to metrics. NOT a
+    /// substitute for [`format_version`](Self::format_version), which returns the
+    /// exact on-disk version token.
+    pub(crate) fn sstable_format_label(&self) -> &'static str {
+        match *self.version_gates {
+            VersionGates::Bti(_) => "bti",
+            VersionGates::Big(_) => "big",
+        }
+    }
+
     /// Get the SSTable format version string
     pub fn format_version(&self) -> Result<String> {
         let filename = self
@@ -896,6 +965,24 @@ impl SSTableReader {
                     0
                 }),
         }
+    }
+}
+
+impl Drop for SSTableReader {
+    fn drop(&mut self) {
+        use crate::observability::{self as obs, catalog};
+        // Keep the live-reader count and the SSTABLES_OPEN gauge in sync as
+        // readers are released. `saturating_sub`-style guard via fetch_update
+        // would be heavier than needed: open() only ever increments on success,
+        // so the count never underflows in practice; clamp defensively anyway.
+        let prev = SSTABLES_OPEN_COUNT.load(Ordering::Relaxed);
+        let now = prev.saturating_sub(1);
+        SSTABLES_OPEN_COUNT.store(now, Ordering::Relaxed);
+        obs::record_gauge(
+            catalog::SSTABLES_OPEN,
+            now as i64,
+            &[(catalog::attr::SSTABLE_FORMAT, self.sstable_format_label().into())],
+        );
     }
 }
 

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -61,7 +61,7 @@ use header::{
 
 use std::collections::HashMap;
 use std::path::Path;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::fs::File;
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
@@ -255,10 +255,26 @@ fn mmap_advice_for(prefetch: PrefetchMode) -> Option<memmap2::Advice> {
 
 /// Process-wide count of currently-open [`SSTableReader`]s, the source value
 /// for the [`SSTABLES_OPEN`](crate::observability::catalog::SSTABLES_OPEN)
-/// gauge. Incremented when [`SSTableReader::open`] succeeds and decremented when
-/// a reader is dropped, so the gauge reflects live readers regardless of the
-/// `observability` feature state (the helper calls are no-ops when off).
-static SSTABLES_OPEN_COUNT: AtomicU64 = AtomicU64::new(0);
+/// gauge. Tracked PER FORMAT so the gauge — which carries the
+/// [`cqlite.sstable.format`](crate::observability::catalog::attr::SSTABLE_FORMAT)
+/// attribute — reports the correct live count for each `big`/`bti` label series
+/// instead of a single global total stamped onto every series. Incremented when
+/// [`SSTableReader::open`] succeeds and decremented when a reader is dropped, so
+/// each gauge series reflects live readers regardless of the `observability`
+/// feature state (the helper calls are no-ops when off).
+static SSTABLES_OPEN_COUNT_BIG: AtomicI64 = AtomicI64::new(0);
+static SSTABLES_OPEN_COUNT_BTI: AtomicI64 = AtomicI64::new(0);
+
+/// Select the per-format open-reader counter for a `sstable_format_label()`
+/// value (`"big"` / `"bti"`). Defaults to the BIG counter for any unexpected
+/// label so the value is never silently dropped; the label set is bounded to
+/// the two [`sstable_format_label`](SSTableReader::sstable_format_label) returns.
+fn sstables_open_count_for(format: &str) -> &'static AtomicI64 {
+    match format {
+        "bti" => &SSTABLES_OPEN_COUNT_BTI,
+        _ => &SSTABLES_OPEN_COUNT_BIG,
+    }
+}
 
 impl SSTableReader {
     /// Open an SSTable file for reading.
@@ -270,26 +286,34 @@ impl SSTableReader {
     /// [`SSTABLES_OPEN`]: crate::observability::catalog::SSTABLES_OPEN
     pub async fn open(path: &Path, config: &Config, platform: Arc<Platform>) -> Result<Self> {
         use crate::observability::{self as obs, catalog};
+        use tracing::Instrument as _;
 
         let span = tracing::debug_span!(
             "sstable.reader.open",
             file_size = tracing::field::Empty,
             sstable_format = tracing::field::Empty,
         );
-        let _entered = span.enter();
 
-        let result = Self::open_inner(path, config, platform).await;
+        // Instrument the future rather than holding an entered guard across the
+        // `.await`: entering a span guard and then awaiting can attach unrelated
+        // async work scheduled on this task to the span. `Instrument` enters the
+        // span only while this specific future is polled.
+        let result = Self::open_inner(path, config, platform)
+            .instrument(span.clone())
+            .await;
         match &result {
             Ok(reader) => {
                 let format = reader.sstable_format_label();
                 span.record("file_size", reader.stats.file_size);
                 span.record("sstable_format", format);
                 // SSTABLES_OPEN is a snapshot gauge of the live reader count;
-                // record the current count after this open succeeds.
-                let now = SSTABLES_OPEN_COUNT.fetch_add(1, Ordering::Relaxed) + 1;
+                // record the current PER-FORMAT count after this open succeeds so
+                // the format-attributed gauge series stays correct under mixed
+                // BIG/BTI readers.
+                let now = sstables_open_count_for(format).fetch_add(1, Ordering::Relaxed) + 1;
                 obs::record_gauge(
                     catalog::SSTABLES_OPEN,
-                    now as i64,
+                    now,
                     &[(catalog::attr::SSTABLE_FORMAT, format.into())],
                 );
             }
@@ -971,17 +995,18 @@ impl SSTableReader {
 impl Drop for SSTableReader {
     fn drop(&mut self) {
         use crate::observability::{self as obs, catalog};
-        // Keep the live-reader count and the SSTABLES_OPEN gauge in sync as
-        // readers are released. `saturating_sub`-style guard via fetch_update
-        // would be heavier than needed: open() only ever increments on success,
-        // so the count never underflows in practice; clamp defensively anyway.
-        let prev = SSTABLES_OPEN_COUNT.load(Ordering::Relaxed);
-        let now = prev.saturating_sub(1);
-        SSTABLES_OPEN_COUNT.store(now, Ordering::Relaxed);
+        // Keep the per-format live-reader count and the SSTABLES_OPEN gauge in
+        // sync as readers are released. Use a single atomic read-modify-write
+        // (`fetch_sub`) on the SAME per-format counter `open()` incremented: a
+        // load-then-store would race concurrent drops and lose decrements,
+        // drifting the gauge permanently high. `open()` only ever increments on
+        // success, so this never underflows in practice.
+        let format = self.sstable_format_label();
+        let now = sstables_open_count_for(format).fetch_sub(1, Ordering::Relaxed) - 1;
         obs::record_gauge(
             catalog::SSTABLES_OPEN,
-            now as i64,
-            &[(catalog::attr::SSTABLE_FORMAT, self.sstable_format_label().into())],
+            now,
+            &[(catalog::attr::SSTABLE_FORMAT, format.into())],
         );
     }
 }

--- a/cqlite-core/src/storage/sstable/reader/partition_lookup.rs
+++ b/cqlite-core/src/storage/sstable/reader/partition_lookup.rs
@@ -136,6 +136,29 @@ impl SSTableReader {
             }
         };
 
+        // The BTI Partitions.db trie IS the presence oracle for a BTI SSTable
+        // (BTI has no bloom filter). Emit READ_BLOOM_CHECKS exactly ONCE here — the
+        // single common path every BTI presence/point lookup funnels through
+        // (get / get_with_spec_readers / get_with_schema_context / point lookup /
+        // might_contain_partition). `cqlite.result` is hit for a trie HIT
+        // (maybe-present/found: a DataOffset/RowsOffset, possibly a prefix-collision
+        // candidate the caller re-verifies) and miss for a trie MISS (definitive
+        // absence). A trie parse error returns above without an outcome and is
+        // counted as an error, not a bloom check, so this never double counts.
+        // Emitting before the per-arm handling (which can still error on a missing
+        // Rows.db for a wide partition) guarantees a single emission per call.
+        obs::add_counter(
+            catalog::READ_BLOOM_CHECKS,
+            1,
+            &[
+                (
+                    catalog::attr::RESULT,
+                    if lookup.is_some() { "hit" } else { "miss" }.into(),
+                ),
+                (catalog::attr::SSTABLE_FORMAT, "bti".into()),
+            ],
+        );
+
         match lookup {
             Some(BtiPartitionLocation::DataOffset(off)) => {
                 span.record("partition_shape", "narrow");
@@ -386,40 +409,39 @@ impl SSTableReader {
 
         if self.bti_partitions_db.is_some() {
             // BTI: trie miss is authoritative absence; any error is conservative.
-            let present = matches!(
+            // `lookup_partition_via_bti_trie` is the single common path that emits
+            // READ_BLOOM_CHECKS for the BTI presence check — do NOT emit again here
+            // or the metric would be double counted.
+            return matches!(
                 self.lookup_partition_via_bti_trie(partition_key),
                 Ok(Some(_)) | Err(_)
             );
-            obs::add_counter(
-                catalog::READ_BLOOM_CHECKS,
-                1,
-                &[
-                    (
-                        catalog::attr::RESULT,
-                        if present { "hit" } else { "miss" }.into(),
-                    ),
-                    (catalog::attr::SSTABLE_FORMAT, "bti".into()),
-                ],
-            );
-            return present;
         }
-        let format = self.sstable_format_label();
-        let present = match &self.bloom_filter {
-            Some(bloom) => bloom.might_contain(partition_key),
+        // BIG: only record READ_BLOOM_CHECKS when a bloom filter actually exists.
+        // With no filter loaded we cannot prune, so we conservatively return `true`
+        // WITHOUT recording a check (a no-filter "hit" is not a real bloom check and
+        // would inflate the metric).
+        match &self.bloom_filter {
+            Some(bloom) => {
+                let present = bloom.might_contain(partition_key);
+                obs::add_counter(
+                    catalog::READ_BLOOM_CHECKS,
+                    1,
+                    &[
+                        (
+                            catalog::attr::RESULT,
+                            if present { "hit" } else { "miss" }.into(),
+                        ),
+                        (
+                            catalog::attr::SSTABLE_FORMAT,
+                            self.sstable_format_label().into(),
+                        ),
+                    ],
+                );
+                present
+            }
             None => true,
-        };
-        obs::add_counter(
-            catalog::READ_BLOOM_CHECKS,
-            1,
-            &[
-                (
-                    catalog::attr::RESULT,
-                    if present { "hit" } else { "miss" }.into(),
-                ),
-                (catalog::attr::SSTABLE_FORMAT, format.into()),
-            ],
-        );
-        present
+        }
     }
 
     /// Enhanced partition lookup using schema-driven key digest computation

--- a/cqlite-core/src/storage/sstable/reader/partition_lookup.rs
+++ b/cqlite-core/src/storage/sstable/reader/partition_lookup.rs
@@ -382,17 +382,44 @@ impl SSTableReader {
     /// `partition_key` must be the raw partition-key bytes (same encoding the bloom
     /// filter and Index.db/BTI trie are keyed on).
     pub fn might_contain_partition(&self, partition_key: &[u8]) -> bool {
+        use crate::observability::{self as obs, catalog};
+
         if self.bti_partitions_db.is_some() {
             // BTI: trie miss is authoritative absence; any error is conservative.
-            return matches!(
+            let present = matches!(
                 self.lookup_partition_via_bti_trie(partition_key),
                 Ok(Some(_)) | Err(_)
             );
+            obs::add_counter(
+                catalog::READ_BLOOM_CHECKS,
+                1,
+                &[
+                    (
+                        catalog::attr::RESULT,
+                        if present { "hit" } else { "miss" }.into(),
+                    ),
+                    (catalog::attr::SSTABLE_FORMAT, "bti".into()),
+                ],
+            );
+            return present;
         }
-        match &self.bloom_filter {
+        let format = self.sstable_format_label();
+        let present = match &self.bloom_filter {
             Some(bloom) => bloom.might_contain(partition_key),
             None => true,
-        }
+        };
+        obs::add_counter(
+            catalog::READ_BLOOM_CHECKS,
+            1,
+            &[
+                (
+                    catalog::attr::RESULT,
+                    if present { "hit" } else { "miss" }.into(),
+                ),
+                (catalog::attr::SSTABLE_FORMAT, format.into()),
+            ],
+        );
+        present
     }
 
     /// Enhanced partition lookup using schema-driven key digest computation
@@ -585,9 +612,26 @@ impl SSTableReader {
         table_id: &TableId,
         key: &RowKey,
     ) -> Result<Option<Value>> {
+        use crate::observability::{self as obs, catalog};
+
         // Step 1: Use bloom filter for existence check
         if let Some(bloom_filter) = &self.bloom_filter {
-            if !bloom_filter.might_contain(key.as_bytes()) {
+            let present = bloom_filter.might_contain(key.as_bytes());
+            obs::add_counter(
+                catalog::READ_BLOOM_CHECKS,
+                1,
+                &[
+                    (
+                        catalog::attr::RESULT,
+                        if present { "hit" } else { "miss" }.into(),
+                    ),
+                    (
+                        catalog::attr::SSTABLE_FORMAT,
+                        self.sstable_format_label().into(),
+                    ),
+                ],
+            );
+            if !present {
                 debug!("Bloom filter indicates key does not exist");
                 return Ok(None);
             }
@@ -611,9 +655,26 @@ impl SSTableReader {
         key: &RowKey,
         parsing_context: &ParsingContext,
     ) -> Result<Option<Value>> {
+        use crate::observability::{self as obs, catalog};
+
         // Step 1: Use bloom filter for existence check
         if let Some(bloom_filter) = &self.bloom_filter {
-            if !bloom_filter.might_contain(key.as_bytes()) {
+            let present = bloom_filter.might_contain(key.as_bytes());
+            obs::add_counter(
+                catalog::READ_BLOOM_CHECKS,
+                1,
+                &[
+                    (
+                        catalog::attr::RESULT,
+                        if present { "hit" } else { "miss" }.into(),
+                    ),
+                    (
+                        catalog::attr::SSTABLE_FORMAT,
+                        self.sstable_format_label().into(),
+                    ),
+                ],
+            );
+            if !present {
                 debug!("Bloom filter indicates key does not exist");
                 return Ok(None);
             }

--- a/cqlite-core/src/storage/sstable/reader/partition_lookup.rs
+++ b/cqlite-core/src/storage/sstable/reader/partition_lookup.rs
@@ -27,6 +27,11 @@ impl SSTableReader {
         &self,
         partition_key: &[u8],
     ) -> Result<Option<(u64, u32)>> {
+        use crate::observability::{self as obs, catalog};
+
+        let _span = tracing::debug_span!("sstable.partition_lookup.index").entered();
+        let format = self.sstable_format_label();
+
         if let Some(index_reader) = &self.index_reader {
             // Direct raw-key lookup — O(1) HashMap lookup.
             // Index.db entries are keyed on the raw partition key bytes since #552;
@@ -35,6 +40,15 @@ impl SSTableReader {
                 debug!(
                     "Found partition via Index.db raw-key lookup: offset={}, size={}",
                     entry.data_offset, entry.data_size
+                );
+                obs::add_counter(
+                    catalog::READ_PARTITION_LOOKUP,
+                    1,
+                    &[
+                        (catalog::attr::RESULT, "hit".into()),
+                        (catalog::attr::ACCESS_PATH, "index".into()),
+                        (catalog::attr::SSTABLE_FORMAT, format.into()),
+                    ],
                 );
                 return Ok(Some((entry.data_offset, entry.data_size)));
             } else {
@@ -46,6 +60,15 @@ impl SSTableReader {
         } else {
             debug!("No Index.db reader available for partition lookup");
         }
+        obs::add_counter(
+            catalog::READ_PARTITION_LOOKUP,
+            1,
+            &[
+                (catalog::attr::RESULT, "miss".into()),
+                (catalog::attr::ACCESS_PATH, "index".into()),
+                (catalog::attr::SSTABLE_FORMAT, format.into()),
+            ],
+        );
         Ok(None)
     }
 
@@ -78,24 +101,53 @@ impl SSTableReader {
     ///
     /// [`resolve_rows_db_entry`]: crate::storage::sstable::bti::resolve_rows_db_entry
     pub fn lookup_partition_via_bti_trie(&self, partition_key: &[u8]) -> Result<Option<u64>> {
+        use crate::observability::{self as obs, catalog};
         use crate::storage::sstable::bti::{
             lookup_raw_key_in_bti_partitions_db, resolve_rows_db_entry, BtiPartitionLocation,
         };
+
+        let span = tracing::debug_span!(
+            "sstable.partition_lookup.bti_trie",
+            partition_shape = tracing::field::Empty,
+        );
+        let _entered = span.enter();
 
         let Some(partitions_db) = &self.bti_partitions_db else {
             // Not a BTI reader — no trie to consult.
             return Ok(None);
         };
 
-        let mut cursor = std::io::Cursor::new(partitions_db.as_slice());
-        match lookup_raw_key_in_bti_partitions_db(&mut cursor, partition_key).map_err(|e| {
+        let lookup = lookup_raw_key_in_bti_partitions_db(
+            &mut std::io::Cursor::new(partitions_db.as_slice()),
+            partition_key,
+        )
+        .map_err(|e| {
             Error::corruption(format!(
                 "BTI Partitions.db trie lookup failed for partition key (len={}): {}",
                 partition_key.len(),
                 e
             ))
-        })? {
+        });
+        let lookup = match lookup {
+            Ok(v) => v,
+            Err(e) => {
+                obs::record_error(&e, "reader");
+                return Err(e);
+            }
+        };
+
+        match lookup {
             Some(BtiPartitionLocation::DataOffset(off)) => {
+                span.record("partition_shape", "narrow");
+                obs::add_counter(
+                    catalog::READ_PARTITION_LOOKUP,
+                    1,
+                    &[
+                        (catalog::attr::RESULT, "hit".into()),
+                        (catalog::attr::ACCESS_PATH, "bti_trie".into()),
+                        (catalog::attr::SSTABLE_FORMAT, "bti".into()),
+                    ],
+                );
                 debug!(
                     "BTI trie resolved NARROW partition (key len={}) to Data.db offset {}",
                     partition_key.len(),
@@ -109,7 +161,8 @@ impl SSTableReader {
                 // partition's Data.db start position (`data_position`), which lives
                 // in the SAME uncompressed-offset domain the narrow path uses, so
                 // the caller can decode the partition identically (#909/#910).
-                let rows_db = self.bti_rows_db.as_ref().ok_or_else(|| {
+                span.record("partition_shape", "wide");
+                let rows_db = match self.bti_rows_db.as_ref().ok_or_else(|| {
                     Error::corruption(format!(
                         "BTI Partitions.db trie returned RowsOffset({}) for partition key \
                          (len={}) but this reader has no Rows.db loaded; the SSTable is \
@@ -117,9 +170,15 @@ impl SSTableReader {
                         rows_offset,
                         partition_key.len()
                     ))
-                })?;
+                }) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        obs::record_error(&e, "reader");
+                        return Err(e);
+                    }
+                };
 
-                let header = resolve_rows_db_entry(rows_db.as_slice(), rows_offset as usize)
+                let header = match resolve_rows_db_entry(rows_db.as_slice(), rows_offset as usize)
                     .map_err(|e| {
                         Error::corruption(format!(
                             "BTI Rows.db row-index entry at RowsOffset({}) is unreadable for \
@@ -128,8 +187,23 @@ impl SSTableReader {
                             partition_key.len(),
                             e
                         ))
-                    })?;
+                    }) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        obs::record_error(&e, "reader");
+                        return Err(e);
+                    }
+                };
 
+                obs::add_counter(
+                    catalog::READ_PARTITION_LOOKUP,
+                    1,
+                    &[
+                        (catalog::attr::RESULT, "hit".into()),
+                        (catalog::attr::ACCESS_PATH, "bti_trie".into()),
+                        (catalog::attr::SSTABLE_FORMAT, "bti".into()),
+                    ],
+                );
                 debug!(
                     "BTI trie resolved WIDE partition (key len={}) via RowsOffset {} -> Data.db \
                      position {} ({} row-index blocks)",
@@ -140,7 +214,18 @@ impl SSTableReader {
                 );
                 Ok(Some(header.data_position))
             }
-            None => Ok(None),
+            None => {
+                obs::add_counter(
+                    catalog::READ_PARTITION_LOOKUP,
+                    1,
+                    &[
+                        (catalog::attr::RESULT, "miss".into()),
+                        (catalog::attr::ACCESS_PATH, "bti_trie".into()),
+                        (catalog::attr::SSTABLE_FORMAT, "bti".into()),
+                    ],
+                );
+                Ok(None)
+            }
         }
     }
 

--- a/cqlite-core/src/storage/sstable/reader/partition_lookup.rs
+++ b/cqlite-core/src/storage/sstable/reader/partition_lookup.rs
@@ -636,6 +636,19 @@ impl SSTableReader {
     ) -> Result<Option<Value>> {
         use crate::observability::{self as obs, catalog};
 
+        // Issue #1034: BTI ("da") readers resolve partitions via the Partitions.db
+        // trie, which is the AUTHORITATIVE presence oracle. Branch to the trie path
+        // FIRST and skip the bloom/Index.db pre-check entirely. This mirrors `get()`
+        // (which routes BTI to `bti_point_lookup` → `lookup_partition_via_bti_trie`)
+        // and is required for correctness: a BTI bloom false negative must never
+        // short-circuit the trie lookup. Routing through `get()` also guarantees the
+        // BTI presence check emits READ_BLOOM_CHECKS exactly once (from
+        // `lookup_partition_via_bti_trie`) instead of being counted here AND again on
+        // the fallback path. BIG readers keep the bloom → Index.db behavior below.
+        if self.bti_partitions_db.is_some() {
+            return self.get(table_id, key).await;
+        }
+
         // Step 1: Use bloom filter for existence check
         if let Some(bloom_filter) = &self.bloom_filter {
             let present = bloom_filter.might_contain(key.as_bytes());
@@ -678,6 +691,19 @@ impl SSTableReader {
         parsing_context: &ParsingContext,
     ) -> Result<Option<Value>> {
         use crate::observability::{self as obs, catalog};
+
+        // Issue #1034: BTI ("da") readers resolve partitions via the Partitions.db
+        // trie keyed on RAW partition-key bytes, not Index.db key digests, so the
+        // schema-driven digest path below does not apply. Branch to the trie path
+        // FIRST and skip the bloom/Index.db pre-check entirely, mirroring `get()`
+        // (which routes BTI to `bti_point_lookup` → `lookup_partition_via_bti_trie`).
+        // This keeps BTI correct (a bloom false negative can never short-circuit the
+        // authoritative trie lookup) and ensures the BTI presence check emits
+        // READ_BLOOM_CHECKS exactly once instead of being double counted across this
+        // helper and its fallback. BIG readers keep the bloom → Index.db behavior.
+        if self.bti_partitions_db.is_some() {
+            return self.get(table_id, key).await;
+        }
 
         // Step 1: Use bloom filter for existence check
         if let Some(bloom_filter) = &self.bloom_filter {


### PR DESCRIPTION
Part of epic #1031. Depends on merged foundation (#1032).

- Spans + metrics: storage.engine.open, sstable.reader.open (sub-spans for header/index/summary/stats/bloom), partition lookup (index + BTI trie), bloom/trie presence checks, decode. No per-cell spans.
- New catalog consts: storage.open.{sstables,bytes,tables}, read.partition_lookup.total, read.bloom.checks; attrs RESULT (hit/miss) and LOOKUP_ROUTE (index/bti_trie — renamed from a colliding ACCESS_PATH to coexist with #1035's query access_path).
- Per-format open-reader gauge with atomic fetch_sub on drop; BTI presence checks emit exactly once via the authoritative trie path (spec-reader helpers route BTI through get() before bloom/index, no bypass/double-count); cached OTel instruments for all new counters; open error recorded within the span scope.
- record_error(subsystem=reader) at boundaries.

Validation: default + observability builds clean; clippy -D warnings clean; 2238 lib / 1426 storage tests pass (flush_throughput known-flaky). roborev clean (job 1181, 'No issues found') after 3 fix rounds.

Closes #1034