### PR TITLE
feat(observability): instrument write path + compaction (#1036, #1037)

### DIFF
--- a/cqlite-core/src/observability/catalog.rs
+++ b/cqlite-core/src/observability/catalog.rs
@@ -211,10 +211,13 @@ pub const COMPACTION_SSTABLES_IN: &str = "cqlite.compaction.sstables_in";
 /// attributes.
 pub const COMPACTION_SSTABLES_OUT: &str = "cqlite.compaction.sstables_out";
 
-/// `cqlite.compaction.tombstones_purged` — counter `{row}`.
+/// `cqlite.compaction.tombstones_purged` — counter `{tombstone}`.
 ///
-/// Total tombstones purged (gc_grace / overlap-safe) during compaction. No
-/// high-cardinality attributes.
+/// Total tombstones GENUINELY PURGED (gc_grace / overlap-safe) during compaction,
+/// summed across cell tombstones, whole-row tombstones, range-tombstone markers,
+/// and complex-deletion (collection/UDT) markers. Counted only at the actual
+/// purge decision points in the merge/reconcile logic; ordinary last-write-wins
+/// reconciliation collapse is NOT counted. No high-cardinality attributes.
 pub const COMPACTION_TOMBSTONES_PURGED: &str = "cqlite.compaction.tombstones_purged";
 
 /// `cqlite.compaction.lag` — gauge `{sstable}`.

--- a/cqlite-core/src/observability/catalog.rs
+++ b/cqlite-core/src/observability/catalog.rs
@@ -110,6 +110,139 @@ pub const SSTABLES_OPEN: &str = "cqlite.sstables.open";
 /// attributes.
 pub const COMPACTION_DURATION: &str = "cqlite.compaction.duration";
 
+// ---------------------------------------------------------------------------
+// Write path (issue #1036) — emitted from the `write-support` write engine.
+// ---------------------------------------------------------------------------
+
+/// `cqlite.write.mutations` — counter `{row}`.
+///
+/// Total mutations accepted by the write path (one per `write`/`write_async`
+/// call that successfully inserts into the memtable). No high-cardinality
+/// attributes.
+pub const WRITE_MUTATIONS: &str = "cqlite.write.mutations";
+
+/// `cqlite.memtable.size_bytes` — gauge `By`.
+///
+/// Current approximate in-memory size of the active memtable in bytes. No
+/// high-cardinality attributes.
+pub const MEMTABLE_SIZE_BYTES: &str = "cqlite.memtable.size_bytes";
+
+/// `cqlite.memtable.rows` — gauge `{row}`.
+///
+/// Current number of buffered rows in the active memtable. No high-cardinality
+/// attributes.
+pub const MEMTABLE_ROWS: &str = "cqlite.memtable.rows";
+
+/// `cqlite.wal.sync.duration` — histogram `s`.
+///
+/// Distribution of WAL `fsync` durations in seconds. No high-cardinality
+/// attributes.
+pub const WAL_SYNC_DURATION: &str = "cqlite.wal.sync.duration";
+
+/// `cqlite.flush.duration` — histogram `s`.
+///
+/// Distribution of memtable→SSTable flush durations in seconds. No
+/// high-cardinality attributes.
+pub const FLUSH_DURATION: &str = "cqlite.flush.duration";
+
+/// `cqlite.flush.rows` — counter `{row}`.
+///
+/// Total rows flushed from the memtable to L0 SSTables. No high-cardinality
+/// attributes.
+pub const FLUSH_ROWS: &str = "cqlite.flush.rows";
+
+/// `cqlite.flush.bytes` — counter `By`.
+///
+/// Total Data.db bytes produced by memtable flushes. No high-cardinality
+/// attributes.
+pub const FLUSH_BYTES: &str = "cqlite.flush.bytes";
+
+/// `cqlite.flush.sstables` — counter `{sstable}`.
+///
+/// Total L0 SSTables created by memtable flushes. No high-cardinality
+/// attributes.
+pub const FLUSH_SSTABLES: &str = "cqlite.flush.sstables";
+
+/// `cqlite.write.partitions` — counter `{partition}`.
+///
+/// Total partitions written by the SSTable writer (flush + compaction output).
+/// No high-cardinality attributes.
+pub const WRITE_PARTITIONS: &str = "cqlite.write.partitions";
+
+/// `cqlite.write.bytes` — counter `By`.
+///
+/// Total Data.db bytes produced by the SSTable writer across all output
+/// components' Data.db. No high-cardinality attributes.
+pub const WRITE_BYTES: &str = "cqlite.write.bytes";
+
+/// `cqlite.compression.ratio` — histogram `1`.
+///
+/// Per-chunk compression ratio (compressed bytes / uncompressed bytes; ≤1.0
+/// means the chunk shrank). Bounded attributes: [`attr::COMPRESSION`].
+pub const COMPRESSION_RATIO: &str = "cqlite.compression.ratio";
+
+// ---------------------------------------------------------------------------
+// Compaction & maintenance (issue #1037) — emitted from the write engine's
+// STCS compaction/k-way-merge path (write-support).
+// ---------------------------------------------------------------------------
+
+/// `cqlite.compaction.rows_merged` — counter `{row}`.
+///
+/// Total rows emitted by the k-way merge across all compactions. Combined with
+/// [`COMPACTION_DURATION`] this yields rows-merged-per-second throughput. No
+/// high-cardinality attributes.
+pub const COMPACTION_ROWS_MERGED: &str = "cqlite.compaction.rows_merged";
+
+/// `cqlite.compaction.bytes_written` — counter `By`.
+///
+/// Total bytes written to compaction output SSTables (all components). No
+/// high-cardinality attributes.
+pub const COMPACTION_BYTES_WRITTEN: &str = "cqlite.compaction.bytes_written";
+
+/// `cqlite.compaction.sstables_in` — counter `{sstable}`.
+///
+/// Total input SSTables consumed by compactions. No high-cardinality
+/// attributes.
+pub const COMPACTION_SSTABLES_IN: &str = "cqlite.compaction.sstables_in";
+
+/// `cqlite.compaction.sstables_out` — counter `{sstable}`.
+///
+/// Total output SSTables produced by compactions. No high-cardinality
+/// attributes.
+pub const COMPACTION_SSTABLES_OUT: &str = "cqlite.compaction.sstables_out";
+
+/// `cqlite.compaction.tombstones_purged` — counter `{row}`.
+///
+/// Total tombstones purged (gc_grace / overlap-safe) during compaction. No
+/// high-cardinality attributes.
+pub const COMPACTION_TOMBSTONES_PURGED: &str = "cqlite.compaction.tombstones_purged";
+
+/// `cqlite.compaction.lag` — gauge `{sstable}`.
+///
+/// Current L0 SSTables pending compaction (compaction lag). No high-cardinality
+/// attributes.
+pub const COMPACTION_LAG: &str = "cqlite.compaction.lag";
+
+/// `cqlite.compaction.finalize.duration` — histogram `s`.
+///
+/// Distribution of compaction finalize (atomic rename / publication-barrier)
+/// durations in seconds. No high-cardinality attributes.
+pub const COMPACTION_FINALIZE_DURATION: &str = "cqlite.compaction.finalize.duration";
+
+/// `cqlite.compaction.budget.requested` — histogram `s`.
+///
+/// Distribution of maintenance budget requested per `maintenance_step` call, in
+/// seconds. No high-cardinality attributes.
+pub const COMPACTION_BUDGET_REQUESTED: &str = "cqlite.compaction.budget.requested";
+
+/// `cqlite.compaction.budget.consumed` — histogram `s`.
+///
+/// Distribution of maintenance budget actually consumed per `maintenance_step`
+/// call, in seconds (compare against [`COMPACTION_BUDGET_REQUESTED`] to track
+/// the ~10% tolerance honored by the scheduler). No high-cardinality
+/// attributes.
+pub const COMPACTION_BUDGET_CONSUMED: &str = "cqlite.compaction.budget.consumed";
+
 /// `cqlite.errors.total` — counter `{error}`.
 ///
 /// Total errors observed, the canonical error-rate signal (issue #1038).
@@ -128,6 +261,28 @@ pub const ALL_METRICS: &[&str] = &[
     SSTABLES_OPEN,
     COMPACTION_DURATION,
     ERRORS_TOTAL,
+    // Write path (#1036)
+    WRITE_MUTATIONS,
+    MEMTABLE_SIZE_BYTES,
+    MEMTABLE_ROWS,
+    WAL_SYNC_DURATION,
+    FLUSH_DURATION,
+    FLUSH_ROWS,
+    FLUSH_BYTES,
+    FLUSH_SSTABLES,
+    WRITE_PARTITIONS,
+    WRITE_BYTES,
+    COMPRESSION_RATIO,
+    // Compaction & maintenance (#1037)
+    COMPACTION_ROWS_MERGED,
+    COMPACTION_BYTES_WRITTEN,
+    COMPACTION_SSTABLES_IN,
+    COMPACTION_SSTABLES_OUT,
+    COMPACTION_TOMBSTONES_PURGED,
+    COMPACTION_LAG,
+    COMPACTION_FINALIZE_DURATION,
+    COMPACTION_BUDGET_REQUESTED,
+    COMPACTION_BUDGET_CONSUMED,
 ];
 
 #[cfg(test)]

--- a/cqlite-core/src/storage/sstable/writer/compressed_data_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/compressed_data_writer.rs
@@ -277,9 +277,22 @@ impl CompressedDataWriter {
         }
     }
 
+    /// Map the active compressor to a bounded [`catalog::attr::COMPRESSION`]
+    /// value (issue #1036). Bounded set: lz4/snappy/deflate/zstd/none.
+    fn compression_attr(&self) -> &'static str {
+        match self.compressor.algorithm() {
+            CompressionAlgorithm::Lz4 => "lz4",
+            CompressionAlgorithm::Snappy => "snappy",
+            CompressionAlgorithm::Deflate => "deflate",
+            CompressionAlgorithm::Zstd => "zstd",
+            CompressionAlgorithm::None => "none",
+        }
+    }
+
     /// Write uncompressed data
     ///
     /// Data is buffered until chunk_size is reached, then compressed and written.
+    #[tracing::instrument(name = "compression.write_chunk", skip(self, data))]
     pub fn write(&mut self, data: &[u8]) -> Result<()> {
         let mut remaining = data;
 
@@ -308,10 +321,26 @@ impl CompressedDataWriter {
 
         // Record chunk offset BEFORE writing (points to start of chunk record)
         self.chunk_offsets.push(self.position);
-        self.uncompressed_length += self.buffer.len() as u64;
+        let uncompressed_len = self.buffer.len();
+        self.uncompressed_length += uncompressed_len as u64;
 
         // Compress the buffer
         let compressed = self.compressor.compress(&self.buffer)?;
+
+        // Per-chunk compression ratio (issue #1036): compressed/uncompressed,
+        // tagged with the bounded algorithm attribute. Guard against a zero
+        // divisor (flush_chunk early-returns on an empty buffer, so this is just
+        // defensive).
+        if uncompressed_len > 0 {
+            crate::observability::record_histogram(
+                crate::observability::catalog::COMPRESSION_RATIO,
+                compressed.len() as f64 / uncompressed_len as f64,
+                &[(
+                    crate::observability::catalog::attr::COMPRESSION,
+                    self.compression_attr().into(),
+                )],
+            );
+        }
 
         // Compute CRC32 of compressed data — stored INLINE in Data.db after compressed bytes.
         // Authority: CompressedSequentialWriter.java:192.

--- a/cqlite-core/src/storage/sstable/writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/mod.rs
@@ -544,6 +544,7 @@ impl SSTableWriter {
     /// ];
     /// writer.write_partition(key, mutations)?;
     /// ```
+    #[tracing::instrument(name = "writer.write_partition", skip(self, key, mutations))]
     pub fn write_partition(&mut self, key: DecoratedKey, mutations: Vec<Mutation>) -> Result<()> {
         // Validate token ordering
         if let Some(last_token) = self.last_token {
@@ -829,6 +830,13 @@ impl SSTableWriter {
         self.partition_count += 1;
         self.stats.increment_partition_count();
 
+        // Partitions-written counter (issue #1036). One per successful partition.
+        crate::observability::add_counter(
+            crate::observability::catalog::WRITE_PARTITIONS,
+            1,
+            &[],
+        );
+
         Ok(())
     }
 
@@ -1006,6 +1014,7 @@ impl SSTableWriter {
     /// let info = writer.finish().await?;
     /// println!("SSTable written to {}", info.data_path.display());
     /// ```
+    #[tracing::instrument(name = "writer.finish", skip(self))]
     pub async fn finish(mut self) -> Result<SSTableInfo> {
         // Create keyspace/table subdirectory structure so the reader can
         // extract the table name from the parent directory path. Owned clone so
@@ -1231,6 +1240,14 @@ impl SSTableWriter {
             components.push(ComponentEntry::new(SSTableComponent::Rows));
         }
         toc_writer.write(&components)?;
+
+        // Data.db bytes written by this SSTable writer (issue #1036). Counts
+        // flush and compaction output alike; finalize sums all components.
+        crate::observability::add_counter(
+            crate::observability::catalog::WRITE_BYTES,
+            data_size,
+            &[],
+        );
 
         Ok(SSTableInfo {
             data_path,

--- a/cqlite-core/src/storage/write_engine/memtable.rs
+++ b/cqlite-core/src/storage/write_engine/memtable.rs
@@ -66,6 +66,7 @@ impl Memtable {
     ///
     /// This is the primary insertion API. The caller is responsible for computing
     /// the decorated key from the partition key using the table schema.
+    #[tracing::instrument(name = "memtable.insert", skip(self, key, mutation))]
     pub fn insert_with_key(&mut self, key: DecoratedKey, mutation: Mutation) -> Result<()> {
         // Calculate mutation size (conservative estimate)
         let mutation_size = Self::estimate_mutation_size(&mutation);

--- a/cqlite-core/src/storage/write_engine/merge.rs
+++ b/cqlite-core/src/storage/write_engine/merge.rs
@@ -2516,9 +2516,14 @@ impl KWayMerger {
         for (key, rt) in range_tombstones {
             if let Some(gc_before) = effective_gc_before {
                 if i64::from(rt.local_deletion_time as u32) < gc_before {
-                    // True gc-safe purge of a range-tombstone marker (issue
-                    // #1037): the covered cells were already removed above, so
-                    // dropping the now-redundant marker is a genuine purge.
+                    // Count the range-tombstone marker purge (issue #1037). NOTE:
+                    // this branch's DROP decision is PRE-EXISTING and gated on
+                    // gc_before only — unlike the cell/row/complex purge paths it
+                    // does not also require `rt.deletion_time < max_purgeable_timestamp`.
+                    // That overlap-guard gap is a separate compaction-correctness
+                    // bug tracked in #1061; this metric faithfully counts what the
+                    // code currently drops and is NOT guaranteed overlap-safe for
+                    // range tombstones until #1061 lands.
                     purges.range_tombstones += 1;
                     continue;
                 }

--- a/cqlite-core/src/storage/write_engine/merge.rs
+++ b/cqlite-core/src/storage/write_engine/merge.rs
@@ -2066,6 +2066,39 @@ pub async fn compact_sstables_with_registry(
     Ok(CompactReport { output, stats })
 }
 
+/// Tally of tombstones GENUINELY PURGED during a partition merge (issue #1037).
+///
+/// Accumulated only at the true gc_grace / overlap-safe purge decision points in
+/// [`KWayMerger::reconcile_cluster_with_overlap_counted`] and
+/// [`KWayMerger::merge_partition_rows`] — never from a coarse input-vs-output
+/// entry-count diff. Last-write-wins reconciliation collapse (e.g. two duplicate
+/// row tombstones merging to one) is deliberately NOT counted, since that is
+/// ordinary deduplication rather than a gc/overlap-safe purge. Backs the
+/// `cqlite.compaction.tombstones_purged` counter.
+#[cfg(feature = "write-support")]
+#[derive(Debug, Default, Clone, Copy)]
+struct PurgeCounts {
+    /// Cell tombstones (simple cells + complex-collection elements) purged.
+    cell_tombstones: u64,
+    /// Whole-row tombstones purged.
+    row_tombstones: u64,
+    /// Range-tombstone markers purged.
+    range_tombstones: u64,
+    /// Complex-deletion (collection/UDT) markers purged.
+    complex_deletions: u64,
+}
+
+#[cfg(feature = "write-support")]
+impl PurgeCounts {
+    /// Total tombstones purged across every category.
+    fn total(self) -> u64 {
+        self.cell_tombstones
+            .saturating_add(self.row_tombstones)
+            .saturating_add(self.range_tombstones)
+            .saturating_add(self.complex_deletions)
+    }
+}
+
 #[cfg(feature = "write-support")]
 impl KWayMerger {
     /// Create a new k-way merger from input SSTable paths
@@ -2387,11 +2420,12 @@ impl KWayMerger {
     fn merge_partition_rows(&self, rows: Vec<MergeEntry>) -> Result<Vec<MergeEntry>> {
         use std::collections::BTreeMap;
 
-        // Tombstone-purge accounting (issue #1037): count tombstone-bearing
-        // input entries up front so we can report how many were dropped by
-        // reconciliation/gc purging below. Read-only over the input — does not
-        // change any merge decision.
-        let input_tombstones = rows.iter().filter(|e| Self::entry_is_tombstone(e)).count();
+        // Tombstone-purge accounting (issue #1037). Accumulated at the ACTUAL
+        // gc/overlap-safe purge decision points (not derived from an input-vs-
+        // output entry-count diff, which both missed cell/complex purges and
+        // mis-counted last-write-wins collapse as a purge). See the comment on
+        // `COMPACTION_TOMBSTONES_PURGED` emission at the end of this method.
+        let mut purges = PurgeCounts::default();
 
         // Overlap-safety gate for tombstone purging (#921 finding 1, #935):
         // decide BOTH the effective gc_grace cutoff and the overlap-aware
@@ -2450,12 +2484,13 @@ impl KWayMerger {
 
         let mut merged = Vec::new();
         for (ck, cluster_rows) in clustered_rows {
-            if let Some(entry) = Self::reconcile_cluster_with_overlap(
+            if let Some(entry) = Self::reconcile_cluster_with_overlap_counted(
                 ck,
                 cluster_rows,
                 &self.schema.dropped_columns,
                 effective_gc_before,
                 max_purgeable_timestamp,
+                &mut purges,
             ) {
                 // Issue #933: shadow cells covered by a range tombstone. The merge
                 // must do this per-cell (not just per-row at the writer) because a
@@ -2481,6 +2516,10 @@ impl KWayMerger {
         for (key, rt) in range_tombstones {
             if let Some(gc_before) = effective_gc_before {
                 if i64::from(rt.local_deletion_time as u32) < gc_before {
+                    // True gc-safe purge of a range-tombstone marker (issue
+                    // #1037): the covered cells were already removed above, so
+                    // dropping the now-redundant marker is a genuine purge.
+                    purges.range_tombstones += 1;
                     continue;
                 }
             }
@@ -2513,28 +2552,33 @@ impl KWayMerger {
             }
         });
 
-        // Emit the count of tombstones dropped during reconciliation/purge
-        // (issue #1037). A positive delta means tombstones disappeared from the
-        // input (gc-purged or collapsed by last-write-wins). Saturating so the
-        // counter is never negative.
-        let output_tombstones = merged.iter().filter(|e| Self::entry_is_tombstone(e)).count();
-        let purged = input_tombstones.saturating_sub(output_tombstones);
+        // Emit the count of tombstones GENUINELY PURGED during this merge (issue
+        // #1037).
+        //
+        // `COMPACTION_TOMBSTONES_PURGED` now counts ONLY true gc_grace /
+        // overlap-safe purges, accumulated at the exact decision points where a
+        // tombstone is dropped because it is safe to drop:
+        //   - cell tombstones (simple + complex-element) removed by the Step 3c
+        //     gc/overlap retain in `reconcile_cluster_with_overlap_counted`;
+        //   - row tombstones cleared by that same gc/overlap gate;
+        //   - complex-deletion markers removed by that gate;
+        //   - range-tombstone markers dropped by the gc-grace gate in the
+        //     re-emit loop above.
+        // It explicitly does NOT count last-write-wins reconciliation collapse
+        // (e.g. two duplicate row tombstones merging to one), which is ordinary
+        // deduplication, not a purge. When no gc cutoff applies (partial
+        // compaction without an overlap bound) the purge stages are no-ops and
+        // this counter stays at zero.
+        let purged = purges.total();
         if purged > 0 {
             crate::observability::add_counter(
                 crate::observability::catalog::COMPACTION_TOMBSTONES_PURGED,
-                purged as u64,
+                purged,
                 &[],
             );
         }
 
         Ok(merged)
-    }
-
-    /// Whether a merge entry carries a tombstone (row tombstone or a range
-    /// deletion marker). Used only for the tombstone-purge metric (issue #1037);
-    /// never influences merge output.
-    fn entry_is_tombstone(entry: &MergeEntry) -> bool {
-        matches!(entry.row_data, RowData::Tombstone { .. }) || entry.range_deletion.is_some()
     }
 
     /// True when an entry exists ONLY to carry a range-tombstone marker (issue
@@ -3103,7 +3147,40 @@ impl KWayMerger {
     /// Reconcile a clustering-key group with an explicit overlap-aware
     /// max-purgeable timestamp (#935). See [`Self::reconcile_cluster`] for the base
     /// reconciliation rules.
+    ///
+    /// Thin wrapper over [`Self::reconcile_cluster_with_overlap_counted`] that
+    /// discards the tombstone-purge tally. The production merge path
+    /// (`merge_partition_rows`) calls the `_counted` form directly to accumulate
+    /// genuine gc/overlap-safe purges for `COMPACTION_TOMBSTONES_PURGED` (#1037);
+    /// this wrapper keeps the simpler signature for tests and other callers.
+    #[cfg(test)]
     fn reconcile_cluster_with_overlap(
+        clustering_key: Option<ClusteringKey>,
+        cluster_rows: Vec<MergeEntry>,
+        dropped_columns: &std::collections::HashMap<String, i64>,
+        gc_before_secs: Option<i64>,
+        max_purgeable_timestamp: i64,
+    ) -> Option<MergeEntry> {
+        let mut sink = PurgeCounts::default();
+        Self::reconcile_cluster_with_overlap_counted(
+            clustering_key,
+            cluster_rows,
+            dropped_columns,
+            gc_before_secs,
+            max_purgeable_timestamp,
+            &mut sink,
+        )
+    }
+
+    /// Reconcile a clustering-key group, accumulating genuine gc/overlap-safe
+    /// tombstone purges into `purges` (issue #1037).
+    ///
+    /// Identical merge OUTPUT to [`Self::reconcile_cluster_with_overlap`]; the
+    /// only addition is that each true purge decision (a cell tombstone, row
+    /// tombstone, or complex deletion dropped because it is gc/overlap-safe to
+    /// drop in Step 3c) increments the matching `purges` field. Last-write-wins
+    /// reconciliation collapse is NOT counted.
+    fn reconcile_cluster_with_overlap_counted(
         clustering_key: Option<ClusteringKey>,
         cluster_rows: Vec<MergeEntry>,
         dropped_columns: &std::collections::HashMap<String, i64>,
@@ -3126,6 +3203,9 @@ impl KWayMerger {
         // compaction; `i64::MIN` when purging is disabled (`gc_before_secs` is then
         // `None`, so this is unused).
         max_purgeable_timestamp: i64,
+        // Tombstone-purge tally accumulated at the true purge decision points
+        // (issue #1037). Never read here; only incremented.
+        purges: &mut PurgeCounts,
     ) -> Option<MergeEntry> {
         use std::collections::HashMap;
 
@@ -3449,7 +3529,13 @@ impl KWayMerger {
                     // every gc-purgeable tombstone through unchanged.
                     let overlap_purgeable = cell.timestamp < max_purgeable_timestamp;
                     // RETAIN unless BOTH gates allow the purge.
-                    !(gc_purgeable && overlap_purgeable)
+                    let keep = !(gc_purgeable && overlap_purgeable);
+                    if !keep {
+                        // True gc/overlap-safe purge of a cell tombstone (simple
+                        // or complex-element), issue #1037.
+                        purges.cell_tombstones += 1;
+                    }
+                    keep
                 } else {
                     true
                 }
@@ -3477,6 +3563,8 @@ impl KWayMerger {
                 && row_del.is_some_and(|d| d < max_purgeable_timestamp)
             {
                 row_del = None;
+                // True gc/overlap-safe purge of a row tombstone (issue #1037).
+                purges.row_tombstones += 1;
             }
 
             // (c) Complex-deletion markers: drop each purgeable marker. The
@@ -3487,7 +3575,13 @@ impl KWayMerger {
             complex_deletions.retain(|cd| {
                 let gc_purgeable = i64::from(cd.local_deletion_time as u32) < gc_before;
                 let overlap_purgeable = cd.marked_for_delete_at < max_purgeable_timestamp;
-                !(gc_purgeable && overlap_purgeable)
+                let keep = !(gc_purgeable && overlap_purgeable);
+                if !keep {
+                    // True gc/overlap-safe purge of a complex-deletion marker
+                    // (issue #1037).
+                    purges.complex_deletions += 1;
+                }
+                keep
             });
         }
 

--- a/cqlite-core/src/storage/write_engine/merge.rs
+++ b/cqlite-core/src/storage/write_engine/merge.rs
@@ -2111,6 +2111,7 @@ impl KWayMerger {
     /// * `schema` - Table schema for schema-aware merging
     /// * `gc_before_secs` - gc_grace cutoff (seconds since epoch), or `None` to not purge
     /// * `now_secs` - "now" (seconds since epoch) for TTL expiry, or `None` for engine default
+    #[tracing::instrument(name = "merger.new", skip(input_paths, schema, gc_before_secs, now_secs), fields(inputs = input_paths.len()))]
     pub fn new_with_gc(
         input_paths: Vec<PathBuf>,
         schema: &TableSchema,
@@ -2273,6 +2274,7 @@ impl KWayMerger {
     /// # Errors
     ///
     /// Returns an error if reading fails.
+    #[tracing::instrument(name = "merger.step", skip(self))]
     pub fn step(&mut self) -> Result<MergeStep> {
         // Initialize heap on first call
         if self.heap.is_empty() && self.current_partition.is_none() {
@@ -2384,6 +2386,12 @@ impl KWayMerger {
     ///      row stays shadowed downstream; else emit nothing.
     fn merge_partition_rows(&self, rows: Vec<MergeEntry>) -> Result<Vec<MergeEntry>> {
         use std::collections::BTreeMap;
+
+        // Tombstone-purge accounting (issue #1037): count tombstone-bearing
+        // input entries up front so we can report how many were dropped by
+        // reconciliation/gc purging below. Read-only over the input — does not
+        // change any merge decision.
+        let input_tombstones = rows.iter().filter(|e| Self::entry_is_tombstone(e)).count();
 
         // Overlap-safety gate for tombstone purging (#921 finding 1, #935):
         // decide BOTH the effective gc_grace cutoff and the overlap-aware
@@ -2505,7 +2513,28 @@ impl KWayMerger {
             }
         });
 
+        // Emit the count of tombstones dropped during reconciliation/purge
+        // (issue #1037). A positive delta means tombstones disappeared from the
+        // input (gc-purged or collapsed by last-write-wins). Saturating so the
+        // counter is never negative.
+        let output_tombstones = merged.iter().filter(|e| Self::entry_is_tombstone(e)).count();
+        let purged = input_tombstones.saturating_sub(output_tombstones);
+        if purged > 0 {
+            crate::observability::add_counter(
+                crate::observability::catalog::COMPACTION_TOMBSTONES_PURGED,
+                purged as u64,
+                &[],
+            );
+        }
+
         Ok(merged)
+    }
+
+    /// Whether a merge entry carries a tombstone (row tombstone or a range
+    /// deletion marker). Used only for the tombstone-purge metric (issue #1037);
+    /// never influences merge output.
+    fn entry_is_tombstone(entry: &MergeEntry) -> bool {
+        matches!(entry.row_data, RowData::Tombstone { .. }) || entry.range_deletion.is_some()
     }
 
     /// True when an entry exists ONLY to carry a range-tombstone marker (issue

--- a/cqlite-core/src/storage/write_engine/merge_policy.rs
+++ b/cqlite-core/src/storage/write_engine/merge_policy.rs
@@ -278,6 +278,7 @@ impl STCSPolicy {
 // Implement the MergePolicy trait from parent module
 #[cfg(feature = "write-support")]
 impl super::MergePolicy for STCSPolicy {
+    #[tracing::instrument(name = "compaction.policy_select", skip(self, candidates), fields(candidates = candidates.len()))]
     fn select_merge(&self, candidates: &[PathBuf]) -> Result<Vec<PathBuf>> {
         self.select_merge_internal(candidates)
     }

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -760,17 +760,22 @@ impl WriteEngine {
 
         let trimmed = statement.trim();
 
-        // BATCH statements produce multiple mutations
+        // BATCH statements produce multiple mutations.
+        //
+        // Single-boundary error recording (issue #1036): call the *unrecorded*
+        // `write_inner` here rather than the public `write`. `execute` already
+        // wraps this method in `record_result`, so the escaping error is counted
+        // exactly once at the public boundary instead of twice.
         if trimmed.len() >= 5 && trimmed.as_bytes()[..5].eq_ignore_ascii_case(b"BEGIN") {
             let mutations =
                 cql_to_mutation::convert_cql_to_mutations(trimmed, &self.config.schema)?;
             for mutation in mutations {
-                self.write(mutation)?;
+                self.write_inner(mutation)?;
             }
             Ok(())
         } else {
             let mutation = self.parse_cql_to_mutation(statement)?;
-            self.write(mutation)
+            self.write_inner(mutation)
         }
     }
 
@@ -790,14 +795,25 @@ impl WriteEngine {
     /// - Engine has been closed
     /// - SSTable write fails
     /// - WAL truncate fails
+    #[tracing::instrument(name = "flush.public", skip(self))]
     pub async fn flush(&mut self) -> Result<Option<SSTableInfo>> {
-        if self.closed.load(Ordering::SeqCst) {
-            return Err(Error::InvalidInput(
-                "WriteEngine has been closed".to_string(),
-            ));
-        }
+        // Single-boundary error recording (issue #1036): `flush` is a public API
+        // entry point, so it records here. The nested `flush_internal_async`
+        // helper is intentionally *unrecorded* to avoid double-counting when the
+        // write/close paths trigger a flush internally.
+        crate::observability::record_result(
+            "write",
+            async {
+                if self.closed.load(Ordering::SeqCst) {
+                    return Err(Error::InvalidInput(
+                        "WriteEngine has been closed".to_string(),
+                    ));
+                }
 
-        self.flush_internal_async().await
+                self.flush_internal_async().await
+            }
+            .await,
+        )
     }
 
     /// Internal synchronous flush helper.
@@ -810,13 +826,15 @@ impl WriteEngine {
         Ok(())
     }
 
-    /// Internal async flush implementation
+    /// Internal async flush implementation.
+    ///
+    /// This is an *unrecorded* inner helper (issue #1036): it never calls
+    /// `record_error`/`record_result` itself. Error counting happens exactly once
+    /// at the public boundary that invoked it (`flush`, `close`, or the
+    /// `write`/`write_async` auto-flush path, all of which wrap their work in
+    /// `record_result`).
     #[tracing::instrument(name = "flush.memtable", skip(self))]
     async fn flush_internal_async(&mut self) -> Result<Option<SSTableInfo>> {
-        crate::observability::record_result("write", self.flush_internal_async_impl().await)
-    }
-
-    async fn flush_internal_async_impl(&mut self) -> Result<Option<SSTableInfo>> {
         // Check if memtable is empty
         if self.memtable.is_empty() {
             return Ok(None);
@@ -954,6 +972,10 @@ impl WriteEngine {
                 Err(e) => {
                     // If flush fails, log error and return it
                     log::error!("Failed to flush memtable during close: {}", e);
+                    // Single-boundary error recording (issue #1036): `close` is a
+                    // public entry point and `flush_internal_async` is unrecorded,
+                    // so record the escaping flush failure here, exactly once.
+                    crate::observability::record_error(&e, "write");
                     // Reset closed flag since we failed to close cleanly
                     self.closed.store(false, Ordering::SeqCst);
                     return Err(e);
@@ -1761,12 +1783,14 @@ impl WriteEngine {
     ///
     /// If any step 2 rename fails, the partially-renamed output components are
     /// cleaned up and an error is returned. The input SSTables remain intact.
+    ///
+    /// Single-boundary error recording (issue #1037): this is an *unrecorded*
+    /// inner helper. Any error returned here escapes through
+    /// `maintenance_step_inner` to the public `maintenance_step`, which wraps the
+    /// whole step in `record_result("compaction", ..)` and counts it exactly
+    /// once. Recording here too would double-count finalize failures.
     #[tracing::instrument(name = "compaction.finalize", skip(self, report))]
     async fn finalize_merge_async(&mut self, report: &mut MaintenanceReport) -> Result<()> {
-        crate::observability::record_result("compaction", self.finalize_merge_async_impl(report).await)
-    }
-
-    async fn finalize_merge_async_impl(&mut self, report: &mut MaintenanceReport) -> Result<()> {
         let merge = match self.active_merge.take() {
             Some(m) => m,
             None => return Ok(()),

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -564,7 +564,12 @@ impl WriteEngine {
     /// - WAL append fails
     /// - Memtable insert fails
     /// - Automatic flush fails (sync context only)
+    #[tracing::instrument(name = "write.mutation", skip(self, mutation))]
     pub fn write(&mut self, mutation: Mutation) -> Result<()> {
+        crate::observability::record_result("write", self.write_inner(mutation))
+    }
+
+    fn write_inner(&mut self, mutation: Mutation) -> Result<()> {
         if self.closed.load(Ordering::SeqCst) {
             return Err(Error::InvalidInput(
                 "WriteEngine has been closed".to_string(),
@@ -597,6 +602,8 @@ impl WriteEngine {
         // 4. Increment the cumulative rows-written counter (Issue #486).
         //    Done after a successful insert so that failed writes are not counted.
         self.rows_written += 1;
+        crate::observability::add_counter(crate::observability::catalog::WRITE_MUTATIONS, 1, &[]);
+        self.record_memtable_gauges();
 
         // 5. Check if memtable should be flushed (only in non-async context)
         if self
@@ -639,7 +646,12 @@ impl WriteEngine {
     /// - WAL append fails
     /// - Memtable insert fails
     /// - Automatic flush fails
+    #[tracing::instrument(name = "write.mutation", skip(self, mutation))]
     pub async fn write_async(&mut self, mutation: Mutation) -> Result<()> {
+        crate::observability::record_result("write", self.write_async_inner(mutation).await)
+    }
+
+    async fn write_async_inner(&mut self, mutation: Mutation) -> Result<()> {
         if self.closed.load(Ordering::SeqCst) {
             return Err(Error::InvalidInput(
                 "WriteEngine has been closed".to_string(),
@@ -672,6 +684,8 @@ impl WriteEngine {
         // 4. Increment the cumulative rows-written counter (Issue #486).
         //    Done after a successful insert so that failed writes are not counted.
         self.rows_written += 1;
+        crate::observability::add_counter(crate::observability::catalog::WRITE_MUTATIONS, 1, &[]);
+        self.record_memtable_gauges();
 
         // 5. Check if memtable should be flushed
         if self
@@ -687,6 +701,21 @@ impl WriteEngine {
         }
 
         Ok(())
+    }
+
+    /// Emit the current memtable size/row gauges (issue #1036). No-op when the
+    /// `observability` feature is off.
+    fn record_memtable_gauges(&self) {
+        crate::observability::record_gauge(
+            crate::observability::catalog::MEMTABLE_SIZE_BYTES,
+            self.memtable.size_bytes() as i64,
+            &[],
+        );
+        crate::observability::record_gauge(
+            crate::observability::catalog::MEMTABLE_ROWS,
+            self.memtable.row_count() as i64,
+            &[],
+        );
     }
 
     /// Execute a CQL statement (INSERT, UPDATE, DELETE)
@@ -717,7 +746,12 @@ impl WriteEngine {
     /// engine.execute("UPDATE users SET name = 'Bob' WHERE id = 1")?;
     /// engine.execute("DELETE FROM users WHERE id = 1")?;
     /// ```
+    #[tracing::instrument(name = "write.cql_execute", skip(self, statement))]
     pub fn execute(&mut self, statement: &str) -> Result<()> {
+        crate::observability::record_result("write", self.execute_inner(statement))
+    }
+
+    fn execute_inner(&mut self, statement: &str) -> Result<()> {
         if self.closed.load(Ordering::SeqCst) {
             return Err(Error::InvalidInput(
                 "WriteEngine has been closed".to_string(),
@@ -777,11 +811,19 @@ impl WriteEngine {
     }
 
     /// Internal async flush implementation
+    #[tracing::instrument(name = "flush.memtable", skip(self))]
     async fn flush_internal_async(&mut self) -> Result<Option<SSTableInfo>> {
+        crate::observability::record_result("write", self.flush_internal_async_impl().await)
+    }
+
+    async fn flush_internal_async_impl(&mut self) -> Result<Option<SSTableInfo>> {
         // Check if memtable is empty
         if self.memtable.is_empty() {
             return Ok(None);
         }
+
+        let flush_start = Instant::now();
+        let rows_to_flush = self.memtable.row_count() as u64;
 
         log::info!(
             "Flushing memtable: {} partitions, {} rows, {} bytes",
@@ -854,6 +896,23 @@ impl WriteEngine {
 
         // Increment generation for next flush
         self.generation += 1;
+
+        // Flush metrics (issue #1036): latency in seconds, rows/bytes flushed,
+        // and one L0 SSTable created. Emit the post-clear memtable gauges (now
+        // zero) and the current compaction lag (L0 pending) gauge.
+        {
+            use crate::observability::{self as obs, catalog};
+            obs::record_histogram(
+                catalog::FLUSH_DURATION,
+                flush_start.elapsed().as_secs_f64(),
+                &[],
+            );
+            obs::add_counter(catalog::FLUSH_ROWS, rows_to_flush, &[]);
+            obs::add_counter(catalog::FLUSH_BYTES, info.data_size, &[]);
+            obs::add_counter(catalog::FLUSH_SSTABLES, 1, &[]);
+            obs::record_gauge(catalog::COMPACTION_LAG, self.l0_count as i64, &[]);
+        }
+        self.record_memtable_gauges();
 
         Ok(Some(info))
     }

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -1187,7 +1187,37 @@ impl WriteEngine {
     ///     println!("Merged {} rows in {:?}", report.rows_merged, report.time_spent);
     /// }
     /// ```
+    #[tracing::instrument(name = "compaction.maintenance_step", skip(self))]
     pub fn maintenance_step(&mut self, budget: Duration) -> Result<MaintenanceReport> {
+        // Budget requested for this step (issue #1037). Compared with the
+        // consumed budget below (the scheduler honors a ~10% tolerance).
+        crate::observability::record_histogram(
+            crate::observability::catalog::COMPACTION_BUDGET_REQUESTED,
+            budget.as_secs_f64(),
+            &[],
+        );
+
+        let result = self.maintenance_step_inner(budget);
+
+        // Budget consumed + lifetime-throughput counters (issue #1037). Recorded
+        // for every step (even a no-op one) so the budget-tolerance signal is
+        // complete; rows-merged is per-step and feeds the throughput rate when
+        // combined with COMPACTION_DURATION at finalize.
+        if let Ok(report) = &result {
+            use crate::observability::{self as obs, catalog};
+            obs::record_histogram(
+                catalog::COMPACTION_BUDGET_CONSUMED,
+                report.time_spent.as_secs_f64(),
+                &[],
+            );
+            obs::add_counter(catalog::COMPACTION_ROWS_MERGED, report.rows_merged, &[]);
+            obs::record_gauge(catalog::COMPACTION_LAG, self.l0_count as i64, &[]);
+        }
+
+        crate::observability::record_result("compaction", result)
+    }
+
+    fn maintenance_step_inner(&mut self, budget: Duration) -> Result<MaintenanceReport> {
         if self.closed.load(Ordering::SeqCst) {
             return Err(Error::InvalidInput(
                 "WriteEngine has been closed".to_string(),
@@ -1460,6 +1490,7 @@ impl WriteEngine {
         }
     }
 
+    #[tracing::instrument(name = "compaction.scan_candidates", skip(self))]
     fn scan_sstable_candidates(&self) -> Result<Vec<PathBuf>> {
         let mut candidates = Vec::new();
 
@@ -1541,6 +1572,7 @@ impl WriteEngine {
     /// SSTables — see [`merge::compute_max_purgeable_timestamp`]. When `Some`, a
     /// tombstone older than every outside SSTable is purged even in a partial
     /// compaction; `None` keeps the conservative #921 behavior (no purging).
+    #[tracing::instrument(name = "compaction.start_merge", skip(self, input_paths, max_purgeable_timestamp), fields(inputs = input_paths.len()))]
     fn start_merge(
         &mut self,
         input_paths: Vec<PathBuf>,
@@ -1729,12 +1761,19 @@ impl WriteEngine {
     ///
     /// If any step 2 rename fails, the partially-renamed output components are
     /// cleaned up and an error is returned. The input SSTables remain intact.
+    #[tracing::instrument(name = "compaction.finalize", skip(self, report))]
     async fn finalize_merge_async(&mut self, report: &mut MaintenanceReport) -> Result<()> {
+        crate::observability::record_result("compaction", self.finalize_merge_async_impl(report).await)
+    }
+
+    async fn finalize_merge_async_impl(&mut self, report: &mut MaintenanceReport) -> Result<()> {
         let merge = match self.active_merge.take() {
             Some(m) => m,
             None => return Ok(()),
         };
 
+        let input_count = merge.input_paths.len() as u64;
+        let merge_rows = merge.rows_merged;
         let elapsed = merge.started_at.elapsed();
         log::info!(
             "Finalizing compaction merge: {} rows, {:?} elapsed",
@@ -1823,6 +1862,8 @@ impl WriteEngine {
 
         // Perform the renames. On failure, remove any already-renamed files so
         // we don't leave a half-published SSTable, then return the error.
+        // Time the rename/publication-barrier phase (issue #1037).
+        let finalize_start = Instant::now();
         let mut renamed: Vec<PathBuf> = Vec::with_capacity(renames.len());
         let mut rename_error: Option<Error> = None;
 
@@ -1855,6 +1896,14 @@ impl WriteEngine {
             let _ = std::fs::remove_dir_all(&merge.tmp_dir);
             return Err(err);
         }
+
+        // Finalize/rename latency in seconds (issue #1037): the atomic
+        // publication barrier just completed successfully.
+        crate::observability::record_histogram(
+            crate::observability::catalog::COMPACTION_FINALIZE_DURATION,
+            finalize_start.elapsed().as_secs_f64(),
+            &[],
+        );
 
         // Step 3: All renames succeeded. The new SSTable is now visible.
         // Delete input SSTable files. If deletion fails we log a warning but do
@@ -1942,6 +1991,20 @@ impl WriteEngine {
         self.cumulative_stats.bytes_written += total_bytes_written;
         self.cumulative_stats.rows_merged += merge.rows_merged;
         self.cumulative_stats.total_time += elapsed;
+
+        // Compaction completion metrics (issue #1037): full-compaction duration
+        // (pairs with COMPACTION_ROWS_MERGED — emitted incrementally per
+        // maintenance step — for rows/sec throughput), bytes written across all
+        // output components, and SSTables in/out. Rows are NOT re-counted here to
+        // avoid double-counting the per-step COMPACTION_ROWS_MERGED increments.
+        let _ = merge_rows;
+        {
+            use crate::observability::{self as obs, catalog};
+            obs::record_histogram(catalog::COMPACTION_DURATION, elapsed.as_secs_f64(), &[]);
+            obs::add_counter(catalog::COMPACTION_BYTES_WRITTEN, total_bytes_written, &[]);
+            obs::add_counter(catalog::COMPACTION_SSTABLES_IN, input_count, &[]);
+            obs::add_counter(catalog::COMPACTION_SSTABLES_OUT, 1, &[]);
+        }
 
         log::info!(
             "Compaction complete: merged {} inputs → 1 output ({} bytes total across all components, {} rows, {:?})",

--- a/cqlite-core/src/storage/write_engine/wal.rs
+++ b/cqlite-core/src/storage/write_engine/wal.rs
@@ -576,6 +576,7 @@ impl WriteAheadLog {
     /// # Errors
     ///
     /// Returns an error if serialization fails or the write fails.
+    #[tracing::instrument(name = "wal.append", skip(self, mutation))]
     pub fn append(&mut self, mutation: &Mutation) -> Result<()> {
         // Serialize mutation using bincode
         let mutation_bytes = bincode::serialize(mutation)
@@ -615,15 +616,24 @@ impl WriteAheadLog {
     /// # Errors
     ///
     /// Returns an error if the flush or sync operation fails.
+    #[tracing::instrument(name = "wal.sync", skip(self))]
     pub fn sync(&mut self) -> Result<()> {
         self.file
             .flush()
             .map_err(|e| Error::Storage(format!("Failed to flush WAL buffer: {}", e)))?;
 
+        // Record fsync latency in seconds (issue #1036). The histogram captures
+        // only the durable-write step, which dominates WAL sync cost.
+        let fsync_start = std::time::Instant::now();
         self.file
             .get_ref()
             .sync_all()
             .map_err(|e| Error::Storage(format!("Failed to sync WAL to disk: {}", e)))?;
+        crate::observability::record_histogram(
+            crate::observability::catalog::WAL_SYNC_DURATION,
+            fsync_start.elapsed().as_secs_f64(),
+            &[],
+        );
 
         Ok(())
     }


### PR DESCRIPTION
Part of epic #1031. Depends on merged foundation (#1032). Requires write-support.

### #1036 write path
- Spans: write.mutation, write.cql_execute, memtable.insert, wal.append/wal.sync, flush.memtable, writer.write_partition/finish, compression.write_chunk.
- Metrics: WRITE_MUTATIONS, MEMTABLE_SIZE_BYTES/ROWS gauges, WAL_SYNC_DURATION, FLUSH_DURATION/ROWS/BYTES/SSTABLES, WRITE_PARTITIONS/BYTES, COMPRESSION_RATIO (by algorithm).

### #1037 compaction & maintenance
- Spans: compaction.maintenance_step, scan_candidates, start_merge, policy_select, merger.new/step, compaction.finalize.
- Metrics: COMPACTION_DURATION, ROWS_MERGED, BYTES_WRITTEN, SSTABLES_IN/OUT, TOMBSTONES_PURGED, LAG gauge, FINALIZE_DURATION, BUDGET_REQUESTED/CONSUMED.

### Correctness
- record_error recorded at single public boundaries only (write/write_async/execute/flush/close, maintenance_step) — no double counting.
- COMPACTION_TOMBSTONES_PURGED counted at real gc/overlap-safe purge decision points (cell/row/range/complex), excluding LWW collapse. Merge OUTPUT is byte-identical (only counters/recording boundaries moved; reconcile logic untouched).
- A pre-existing range-tombstone purge overlap-guard gap surfaced during review is split to #1061 (out of scope; would change compaction byte-output); metric comment clarified accordingly.

Validation: default/write-support/observability+write-support builds clean; clippy -D warnings clean; 2238 lib tests pass (flush_throughput known-flaky/passes in isolation). roborev: double-count + tombstone-accounting findings fixed; remaining finding split to #1061.

Closes #1036
Closes #1037