### PR TITLE
feat(observability): Python bindings — otel_config, per-query/streaming spans, traceparent, flush (#1039)

### DIFF
--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -21,5 +21,33 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 hex = "0.4"
 
+# Tracing — always available so per-call spans (`python.execute*`) are emitted
+# unconditionally. They are zero-cost unless a subscriber + OTel layer is wired
+# up by the `observability` feature at `Database.open` time.
+tracing = { workspace = true }
+
+# OpenTelemetry wiring — only linked behind the `observability` feature, which
+# pulls in `cqlite-core/observability` so `tracing_layer()` and the W3C
+# traceparent propagator are available. NOT in defaults: the default wheel links
+# no OTel crates and all instrumentation compiles to no-ops.
+tracing-subscriber = { workspace = true, optional = true }
+tracing-opentelemetry = { workspace = true, optional = true }
+opentelemetry = { workspace = true, optional = true }
+opentelemetry_sdk = { workspace = true, optional = true }
+
+[features]
+# Opt-in OpenTelemetry export for the Python bindings (epic #1031, issue #1039).
+# NOT default: a plain `maturin develop` / wheel build links no OTel crates and
+# every span/metric call is a no-op. With this on, `Database.open(otel_config=…)`
+# installs a process-global tracing subscriber + OTLP exporter and spans are
+# exported.
+observability = [
+    "cqlite-core/observability",
+    "dep:tracing-subscriber",
+    "dep:tracing-opentelemetry",
+    "dep:opentelemetry",
+    "dep:opentelemetry_sdk",
+]
+
 [lints]
 workspace = true

--- a/bindings/python/python/cqlite/__init__.pyi
+++ b/bindings/python/python/cqlite/__init__.pyi
@@ -127,7 +127,12 @@ class Database:
         """True if the database connection is closed."""
         ...
 
-    def execute(self, query: str) -> "QueryResult":
+    def execute(
+        self,
+        query: str,
+        *,
+        traceparent: str | None = None,
+    ) -> "QueryResult":
         """Execute a CQL query or DML statement.
 
         For SELECT queries, reads from the SSTable data on disk and returns
@@ -141,6 +146,12 @@ class Database:
 
         Args:
             query: CQL SELECT, INSERT, UPDATE, or DELETE statement.
+            traceparent: Optional W3C ``traceparent`` header value
+                (``00-<trace-id>-<span-id>-01``). When supplied, the
+                ``python.execute`` span emitted for this call is parented to that
+                trace so it correlates with the caller's OpenTelemetry trace,
+                overriding any ``traceparent`` passed to :func:`open`. Ignored
+                when observability is not enabled. Malformed values are ignored.
 
         Returns:
             QueryResult containing rows (for SELECT) or rows_affected (for DML).
@@ -165,6 +176,8 @@ class Database:
         self,
         query: str,
         config: StreamingConfig | None = None,
+        *,
+        traceparent: str | None = None,
     ) -> "StreamingIterator":
         """Execute a CQL query with streaming results.
 
@@ -173,6 +186,11 @@ class Database:
         Args:
             query: CQL SELECT query string
             config: Optional streaming configuration
+            traceparent: Optional W3C ``traceparent`` header value. When supplied,
+                the ``python.execute_streaming`` span is parented to that trace.
+                The span tracks the total rows yielded across iteration and is
+                finalised when the iterator is exhausted, garbage collected, or
+                abandoned. Ignored when observability is not enabled.
 
         Returns:
             StreamingIterator for iterating over rows
@@ -336,6 +354,8 @@ def open(
     config: Config | None = None,
     writable: bool = False,
     write_dir: str | Path | None = None,
+    otel_config: dict[str, object] | None = None,
+    traceparent: str | None = None,
 ) -> Database:
     """Open a database connection to SSTable data.
 
@@ -355,6 +375,21 @@ def open(
                    directory are **not** protected by file locks and will corrupt
                    each other's WAL and SSTable files.  File locking is planned for
                    a future release (see issue #485).
+        otel_config: Optional OpenTelemetry configuration dict, layered over the
+                     ``CQLITE_OTEL_*`` environment. Initialises telemetry once per
+                     process (the first ``open`` wins; later opens reuse it).
+                     Recognised keys (all optional): ``enabled`` (bool),
+                     ``endpoint`` (str), ``protocol`` (``"grpc"`` | ``"http"``),
+                     ``service_name`` (str), ``service_version`` (str),
+                     ``sampling_ratio`` (float, ``[0.0, 1.0]``), ``timeout_ms``
+                     (int). Unknown keys raise ``ValueError``. Telemetry is only
+                     exported when the extension is built with the
+                     ``observability`` feature; otherwise this is accepted but
+                     inert. A bad exporter config never fails ``open``.
+        traceparent: Optional W3C ``traceparent`` header value used as the default
+                     parent for every per-call span on this database (overridable
+                     per call). Correlates the bindings' Rust spans with the
+                     caller's OpenTelemetry trace.
 
     Returns:
         A Database instance

--- a/bindings/python/src/database.rs
+++ b/bindings/python/src/database.rs
@@ -70,6 +70,11 @@ pub struct Database {
     closed: AtomicBool,
     /// Optional write engine — present only when opened with `writable=True`.
     write_engine: Option<Mutex<PyWriteEngine>>,
+    /// W3C `traceparent` captured at `open` time (issue #1039). When set, every
+    /// per-call span is re-parented to this trace unless a per-call traceparent
+    /// overrides it, so the bindings' Rust spans correlate with the caller's
+    /// Python OpenTelemetry trace.
+    default_traceparent: Option<String>,
 }
 
 impl Database {
@@ -88,6 +93,13 @@ impl Database {
     /// the borrow of self.
     pub(crate) fn inner(&self) -> Arc<cqlite_core::Database> {
         Arc::clone(&self.inner)
+    }
+
+    /// Resolve the effective W3C traceparent for a call: the per-call value when
+    /// supplied, otherwise the one captured at `open` time. Returns `None` when
+    /// neither is set (the span keeps its natural parent).
+    fn resolve_traceparent<'a>(&'a self, per_call: Option<&'a str>) -> Option<&'a str> {
+        per_call.or(self.default_traceparent.as_deref())
     }
 
     /// Return a clear error when a write method is called on a read-only database.
@@ -147,6 +159,13 @@ impl Database {
         // Shutdown the read-side storage engine
         py.allow_threads(|| block_on(self.inner.shutdown()))
             .map_err(to_py_err)?;
+
+        // Flush buffered telemetry (issue #1039) so a short-lived script that
+        // closes its database before interpreter shutdown still exports its
+        // spans/metrics. Process-global and idempotent; the guard itself also
+        // flushes on interpreter shutdown via Drop.
+        crate::observability::flush();
+
         Ok(())
     }
 
@@ -230,12 +249,28 @@ impl Database {
     /// result = db.execute("INSERT INTO users (id, name) VALUES (1, 'Alice')")
     /// print(f"Affected {result.rows_affected} row(s)")
     /// ```
-    pub fn execute(&self, py: Python<'_>, query: &str) -> PyResult<QueryResult> {
+    #[pyo3(signature = (query, *, traceparent=None))]
+    pub fn execute(
+        &self,
+        py: Python<'_>,
+        query: &str,
+        traceparent: Option<&str>,
+    ) -> PyResult<QueryResult> {
         self.ensure_open()?;
+
+        // Per-call span (issue #1039). Core's query path (#1035) emits the
+        // query.duration / query.rows metrics and marks the active span on
+        // error, so we intentionally do NOT re-emit those here — we only own the
+        // `python.execute` span and re-parent it to the caller's trace.
+        let span = crate::observability::call_span("python.execute");
+        crate::observability::set_traceparent_parent(&span, self.resolve_traceparent(traceparent));
+        let _enter = span.enter();
 
         // Route DML statements to the write engine when present
         if Self::is_dml_statement(query) {
-            return self.execute_dml(py, query);
+            let result = self.execute_dml(py, query)?;
+            span.record("cqlite.rows", result.rows_affected_value());
+            return Ok(result);
         }
 
         let db = self.inner();
@@ -246,7 +281,9 @@ impl Database {
             .allow_threads(|| block_on(db.execute(&query_owned)))
             .map_err(to_py_err)?;
 
-        QueryResult::from_core(py, core_result)
+        let result = QueryResult::from_core(py, core_result)?;
+        span.record("cqlite.rows", result.row_count() as i64);
+        Ok(result)
     }
 
     /// Execute a CQL query with streaming results.
@@ -287,14 +324,23 @@ impl Database {
     ///     if row["id"] == target_id:
     ///         break
     /// ```
-    #[pyo3(signature = (query, *, config=None))]
+    #[pyo3(signature = (query, *, config=None, traceparent=None))]
     pub fn execute_streaming(
         &self,
         py: Python<'_>,
         query: &str,
         config: Option<&StreamingConfig>,
+        traceparent: Option<&str>,
     ) -> PyResult<StreamingIterator> {
         self.ensure_open()?;
+
+        // Per-call span (issue #1039). The span outlives this method: it is moved
+        // into the StreamingIterator, which records the total rows yielded across
+        // iteration when it is exhausted or dropped. Re-parent to the caller's
+        // trace so the whole stream correlates with the Python OTel span.
+        let span = crate::observability::call_span("python.execute_streaming");
+        crate::observability::set_traceparent_parent(&span, self.resolve_traceparent(traceparent));
+        let _enter = span.enter();
 
         let db = self.inner();
         let query_owned = query.to_string();
@@ -305,7 +351,7 @@ impl Database {
             .allow_threads(|| block_on(db.execute_streaming(&query_owned, core_config)))
             .map_err(to_py_err)?;
 
-        Ok(StreamingIterator::new(core_iter))
+        Ok(StreamingIterator::with_span(core_iter, span.clone()))
     }
 
     /// Export the results of a CQL query to a Parquet file.
@@ -733,7 +779,7 @@ impl Database {
 ///     pass
 /// ```
 #[pyfunction]
-#[pyo3(signature = (path, *, schema=None, config=None, writable=false, write_dir=None))]
+#[pyo3(signature = (path, *, schema=None, config=None, writable=false, write_dir=None, otel_config=None, traceparent=None))]
 pub fn open(
     py: Python<'_>,
     path: PathBuf,
@@ -741,7 +787,17 @@ pub fn open(
     config: Option<&Bound<'_, PyAny>>,
     writable: bool,
     write_dir: Option<PathBuf>,
+    otel_config: Option<&Bound<'_, PyAny>>,
+    traceparent: Option<String>,
 ) -> PyResult<Database> {
+    // Initialise observability once per process (issue #1039). The config is
+    // resolved from the optional `otel_config` dict layered over the
+    // `CQLITE_OTEL_*` environment. The first `open` wins; later opens reuse the
+    // installed exporters. A bad exporter config never blocks the open — it
+    // simply yields no telemetry.
+    let obs_cfg = crate::observability::config_from_py(py, otel_config)?;
+    crate::observability::ensure_initialized(obs_cfg);
+
     // Validate writable-mode requirements upfront before any I/O.
     if writable {
         if write_dir.is_none() {
@@ -844,6 +900,7 @@ pub fn open(
         inner: Arc::new(db),
         closed: AtomicBool::new(false),
         write_engine,
+        default_traceparent: traceparent.filter(|s| !s.trim().is_empty()),
     })
 }
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -8,6 +8,7 @@ use pyo3::prelude::*;
 mod config;
 mod database;
 mod error;
+mod observability;
 mod prepared;
 mod result;
 mod runtime;

--- a/bindings/python/src/observability.rs
+++ b/bindings/python/src/observability.rs
@@ -1,0 +1,312 @@
+//! Observability wiring for the Python bindings (epic #1031, issue #1039).
+//!
+//! This module bridges CQLite's [`cqlite_core::observability`] foundation into
+//! the Python extension module. It is responsible for:
+//!
+//! 1. **Process-global init** — translating an optional `otel_config` dict (or
+//!    the `CQLITE_OTEL_*` environment) into an
+//!    [`cqlite_core::observability::ObservabilityConfig`], calling
+//!    `observability::init` exactly once per interpreter, and holding the
+//!    returned [`ObservabilityGuard`] in a process-global so buffered telemetry
+//!    flushes at interpreter shutdown (guard drop). It also installs a
+//!    `tracing` subscriber composed with the OTel layer when the
+//!    `observability` feature is enabled.
+//! 2. **Per-call spans** — [`call_span`] creates the `python.execute` /
+//!    `python.execute_streaming` spans that `database.rs` enters around each
+//!    operation. When a W3C `traceparent` is supplied (per-call or captured at
+//!    open), [`set_traceparent_parent`] re-parents the span so the Rust spans
+//!    correlate with the caller's Python OpenTelemetry trace.
+//! 3. **Flush** — [`flush`] force-flushes the guard on `Database.close()`.
+//!
+//! The `subsystem` label for every metric/error emitted from this layer is
+//! `"python"`.
+//!
+//! ## Feature gating
+//!
+//! Config plumbing, `ensure_initialized`, the per-call span, and `flush` are
+//! ALWAYS compiled — the core helpers they call are no-ops when
+//! `cqlite-core/observability` is off, so the bindings build and behave
+//! identically in either configuration. Only the OTel-specific pieces
+//! (subscriber composition, traceparent extraction) are gated behind the
+//! bindings' `observability` feature.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+
+use cqlite_core::observability::{self, ObservabilityConfig, ObservabilityGuard, OtelProtocol};
+
+/// Subsystem label attached to every metric/error emitted from the Python
+/// bindings boundary. Bounded by construction.
+pub const SUBSYSTEM: &str = "python";
+
+/// Process-global observability guard. Initialised at most once (the first
+/// `Database.open`, or the first call that triggers [`ensure_initialized`]) and
+/// kept alive for the whole interpreter lifetime so the RAII guard flushes and
+/// shuts the exporters down when the process exits.
+static GUARD: OnceLock<ObservabilityGuard> = OnceLock::new();
+
+/// Build an [`ObservabilityConfig`] from an optional Python `otel_config` dict.
+///
+/// Resolution order: start from `ObservabilityConfig::from_env()` (so the
+/// `CQLITE_OTEL_*` environment is honoured as the baseline), then override any
+/// keys present in the dict. This means a caller can set, e.g., the endpoint via
+/// the environment and just flip `{"enabled": True}` in the dict.
+///
+/// Recognised dict keys (all optional):
+/// - `enabled` (bool)
+/// - `endpoint` (str)
+/// - `protocol` (str — `"grpc"` or `"http"`)
+/// - `service_name` (str)
+/// - `service_version` (str)
+/// - `sampling_ratio` (float, clamped to `[0.0, 1.0]`)
+/// - `timeout_ms` (int)
+///
+/// Unknown keys are rejected with `ValueError` so typos surface immediately
+/// rather than being silently ignored.
+pub fn config_from_py(
+    _py: Python<'_>,
+    otel_config: Option<&Bound<'_, PyAny>>,
+) -> PyResult<ObservabilityConfig> {
+    use pyo3::exceptions::PyValueError;
+
+    let mut cfg = ObservabilityConfig::from_env();
+
+    let Some(obj) = otel_config else {
+        return Ok(cfg);
+    };
+
+    let dict = obj.downcast::<PyDict>().map_err(|_| {
+        PyValueError::new_err("otel_config must be a dict mapping option names to values")
+    })?;
+
+    const KNOWN_KEYS: &[&str] = &[
+        "enabled",
+        "endpoint",
+        "protocol",
+        "service_name",
+        "service_version",
+        "sampling_ratio",
+        "timeout_ms",
+    ];
+
+    // Reject unknown keys up front so a typo never silently disables telemetry.
+    for key in dict.keys() {
+        let key_str: String = key
+            .extract()
+            .map_err(|_| PyValueError::new_err("otel_config keys must be strings"))?;
+        if !KNOWN_KEYS.contains(&key_str.as_str()) {
+            return Err(PyValueError::new_err(format!(
+                "unknown otel_config key '{key_str}'; recognised keys: {}",
+                KNOWN_KEYS.join(", ")
+            )));
+        }
+    }
+
+    if let Some(v) = dict.get_item("enabled")? {
+        cfg.enabled = v
+            .extract::<bool>()
+            .map_err(|_| PyValueError::new_err("otel_config['enabled'] must be a bool"))?;
+    }
+    if let Some(v) = dict.get_item("endpoint")? {
+        cfg.endpoint = v
+            .extract::<String>()
+            .map_err(|_| PyValueError::new_err("otel_config['endpoint'] must be a str"))?;
+    }
+    if let Some(v) = dict.get_item("protocol")? {
+        let s: String = v
+            .extract()
+            .map_err(|_| PyValueError::new_err("otel_config['protocol'] must be a str"))?;
+        cfg.protocol = OtelProtocol::parse(&s).ok_or_else(|| {
+            PyValueError::new_err(format!(
+                "otel_config['protocol'] '{s}' is invalid; expected 'grpc' or 'http'"
+            ))
+        })?;
+    }
+    if let Some(v) = dict.get_item("service_name")? {
+        cfg.service_name = v
+            .extract::<String>()
+            .map_err(|_| PyValueError::new_err("otel_config['service_name'] must be a str"))?;
+    }
+    if let Some(v) = dict.get_item("service_version")? {
+        cfg.service_version = v
+            .extract::<String>()
+            .map_err(|_| PyValueError::new_err("otel_config['service_version'] must be a str"))?;
+    }
+    if let Some(v) = dict.get_item("sampling_ratio")? {
+        let ratio: f64 = v
+            .extract()
+            .map_err(|_| PyValueError::new_err("otel_config['sampling_ratio'] must be a float"))?;
+        // The builder/from_env sanitise non-finite + out-of-range values; reuse
+        // the builder so the same clamping rules apply.
+        cfg = ObservabilityConfig::builder()
+            .enabled(cfg.enabled)
+            .endpoint(cfg.endpoint.clone())
+            .protocol(cfg.protocol)
+            .service_name(cfg.service_name.clone())
+            .service_version(cfg.service_version.clone())
+            .sampling_ratio(ratio)
+            .timeout(cfg.timeout)
+            .build();
+    }
+    if let Some(v) = dict.get_item("timeout_ms")? {
+        let ms: u64 = v.extract().map_err(|_| {
+            PyValueError::new_err("otel_config['timeout_ms'] must be a non-negative int")
+        })?;
+        cfg.timeout = Duration::from_millis(ms);
+    }
+
+    Ok(cfg)
+}
+
+/// Initialise observability once per process from `cfg`.
+///
+/// The first caller installs the OTel exporters (when the feature is on and the
+/// config is enabled) and the process-global tracing subscriber, then stores
+/// the [`ObservabilityGuard`] in [`GUARD`] so it lives for the interpreter and
+/// flushes on shutdown. Subsequent calls are no-ops — the first config wins, so
+/// telemetry is configured by the first `Database.open` and shared by all later
+/// databases in the process. This matches the OpenTelemetry single-provider
+/// model and avoids reinitialising global exporters per database.
+///
+/// Never returns an error to the caller: a misconfigured exporter must not stop
+/// a `Database.open` from succeeding. Initialisation failures degrade to "no
+/// telemetry" silently (the guard simply isn't stored).
+pub fn ensure_initialized(cfg: ObservabilityConfig) {
+    if GUARD.get().is_some() {
+        return;
+    }
+    let guard = match observability::init(cfg) {
+        Ok(g) => g,
+        Err(_) => return,
+    };
+    // Compose the tracing subscriber + OTel layer once the provider exists, so
+    // spans emitted from this layer reach the exporter. Safe to call even when
+    // the guard is inert (the layer is then `None` / a no-op).
+    install_subscriber();
+    // If another thread won the race, our guard drops here (flushing nothing of
+    // consequence since the winner owns the live exporters).
+    let _ = GUARD.set(guard);
+}
+
+/// Force-flush any buffered telemetry through the process-global guard.
+///
+/// Called from `Database.close()` so a short-lived script that closes its
+/// database sees its spans exported even before interpreter shutdown. Safe to
+/// call when uninitialised (no-op) and idempotent.
+pub fn flush() {
+    if let Some(guard) = GUARD.get() {
+        guard.force_flush();
+    }
+}
+
+/// Install the process-global `tracing` subscriber composed with the OTel
+/// bridge layer.
+///
+/// `try_init` is tolerant of a subscriber already being set (e.g. when the host
+/// application configured `tracing` itself), so this never panics and never
+/// clobbers an existing subscriber.
+#[cfg(feature = "observability")]
+fn install_subscriber() {
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::util::SubscriberInitExt;
+    use tracing_subscriber::EnvFilter;
+
+    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+
+    let registry = tracing_subscriber::registry()
+        .with(env_filter)
+        .with(observability::tracing_layer());
+
+    let _ = registry.try_init();
+}
+
+/// When the feature is off there is no OTel layer to compose, so the subscriber
+/// is left to the host application. Per-call spans still compile (and are
+/// no-ops without a subscriber).
+#[cfg(not(feature = "observability"))]
+fn install_subscriber() {}
+
+/// Create the per-call span for a Python binding operation.
+///
+/// `name` is a `&'static str` span name such as `"python.execute"` or
+/// `"python.execute_streaming"`. The returned span is NOT entered — the caller
+/// enters it around the work so the GIL-released async section runs inside it.
+///
+/// The span carries the bounded `cqlite.subsystem = "python"` attribute and a
+/// `cqlite.rows` field the caller fills in with `span.record("cqlite.rows", n)`
+/// once the operation completes (rows returned for a SELECT, rows affected for
+/// DML, or rows yielded for a stream). It NEVER carries query text, partition
+/// keys, or other unbounded data.
+pub fn call_span(name: &'static str) -> tracing::Span {
+    tracing::info_span!(
+        "python.call",
+        otel.name = name,
+        cqlite.subsystem = SUBSYSTEM,
+        cqlite.rows = tracing::field::Empty,
+    )
+}
+
+/// Re-parent `span` to the trace described by a W3C `traceparent` header value,
+/// so the per-call Rust span links to the caller's existing OpenTelemetry trace.
+///
+/// `traceparent` is the value of the W3C `traceparent` header, e.g.
+/// `00-<32 hex trace-id>-<16 hex span-id>-01`. A malformed/absent value is
+/// ignored (the span keeps its natural parent) — propagation is best-effort and
+/// must never fail an operation.
+#[cfg(feature = "observability")]
+pub fn set_traceparent_parent(span: &tracing::Span, traceparent: Option<&str>) {
+    use opentelemetry::propagation::TextMapPropagator;
+    use opentelemetry_sdk::propagation::TraceContextPropagator;
+    use std::collections::HashMap;
+    use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+    let Some(tp) = traceparent else {
+        return;
+    };
+    let tp = tp.trim();
+    if tp.is_empty() {
+        return;
+    }
+
+    let mut carrier: HashMap<String, String> = HashMap::with_capacity(1);
+    carrier.insert("traceparent".to_string(), tp.to_string());
+
+    let propagator = TraceContextPropagator::new();
+    let parent_cx = propagator.extract(&carrier);
+    span.set_parent(parent_cx);
+}
+
+/// No-op when the feature is off: with no OTel layer there is no remote context
+/// to attach, so the traceparent is simply ignored.
+#[cfg(not(feature = "observability"))]
+pub fn set_traceparent_parent(_span: &tracing::Span, _traceparent: Option<&str>) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn call_span_is_constructible() {
+        // Span creation must work in any build, with or without a subscriber.
+        let span = call_span("python.execute");
+        let _enter = span.enter();
+    }
+
+    #[test]
+    fn set_traceparent_tolerates_garbage() {
+        let span = call_span("python.execute");
+        // None, empty, and malformed must all be silently ignored.
+        set_traceparent_parent(&span, None);
+        set_traceparent_parent(&span, Some(""));
+        set_traceparent_parent(&span, Some("not-a-traceparent"));
+    }
+
+    #[test]
+    fn flush_is_safe_when_uninitialized() {
+        // Must not panic even if no guard was ever set in this process.
+        flush();
+    }
+}

--- a/bindings/python/src/result.rs
+++ b/bindings/python/src/result.rs
@@ -129,6 +129,16 @@ impl QueryResult {
 }
 
 impl QueryResult {
+    /// Number of materialised rows (for SELECT spans, issue #1039).
+    pub(crate) fn row_count(&self) -> usize {
+        self.rows.len()
+    }
+
+    /// Number of rows affected (for DML spans, issue #1039).
+    pub(crate) fn rows_affected_value(&self) -> i64 {
+        self.rows_affected as i64
+    }
+
     /// Create a minimal QueryResult for a DML operation (INSERT/UPDATE/DELETE).
     ///
     /// The result has no rows but reflects the number of mutations applied.
@@ -429,13 +439,42 @@ impl ColumnInfo {
 pub struct StreamingIterator {
     /// The wrapped core iterator (Mutex for interior mutability without &mut self)
     inner: Mutex<cqlite_core::query::result::QueryResultIterator>,
+    /// Per-call observability span (`python.execute_streaming`, issue #1039).
+    ///
+    /// The span is kept alive for the whole iteration so the streamed rows are
+    /// attributed to the caller's trace. The total rows yielded is recorded into
+    /// the span's `cqlite.rows` field when the iterator is dropped (fully
+    /// consumed, garbage collected, or abandoned via `break`).
+    span: tracing::Span,
 }
 
 impl StreamingIterator {
-    /// Create a new streaming iterator from a core QueryResultIterator.
+    /// Create a new streaming iterator from a core QueryResultIterator with no
+    /// observability span (used where instrumentation is not wired).
     pub fn new(iter: cqlite_core::query::result::QueryResultIterator) -> Self {
+        Self::with_span(iter, tracing::Span::none())
+    }
+
+    /// Create a streaming iterator that records into `span` as rows are yielded.
+    pub fn with_span(
+        iter: cqlite_core::query::result::QueryResultIterator,
+        span: tracing::Span,
+    ) -> Self {
         Self {
             inner: Mutex::new(iter),
+            span,
+        }
+    }
+}
+
+impl Drop for StreamingIterator {
+    fn drop(&mut self) {
+        // Record total rows yielded once the stream ends (exhausted, GC'd, or
+        // broken out of). `rows_received` is the authoritative count tracked by
+        // the core iterator. Lock may be poisoned if a panic occurred mid-next;
+        // in that case we simply skip recording rather than risk a double panic.
+        if let Ok(iter) = self.inner.lock() {
+            self.span.record("cqlite.rows", iter.rows_received() as i64);
         }
     }
 }

--- a/bindings/python/src/result.rs
+++ b/bindings/python/src/result.rs
@@ -443,9 +443,17 @@ pub struct StreamingIterator {
     ///
     /// The span is kept alive for the whole iteration so the streamed rows are
     /// attributed to the caller's trace. The total rows yielded is recorded into
-    /// the span's `cqlite.rows` field when the iterator is dropped (fully
-    /// consumed, garbage collected, or abandoned via `break`).
-    span: tracing::Span,
+    /// the span's `cqlite.rows` field exactly once, when the stream finalizes —
+    /// whichever comes first of: normal exhaustion (`StopIteration` from
+    /// `__next__`), or `Drop` (garbage collection / early `break`).
+    ///
+    /// Wrapped in `Mutex<Option<..>>` so it can be finalized idempotently from
+    /// `&self` (`__next__`) as well as `&mut self` (`Drop`): the first finalize
+    /// `.take()`s the span (recording the count and ending it), and any later
+    /// finalize is a no-op. This guarantees that a fully-exhausted-but-still-
+    /// referenced iterator has already exported its span before a later
+    /// `Database.close()` flushes telemetry.
+    span: Mutex<Option<tracing::Span>>,
 }
 
 impl StreamingIterator {
@@ -462,20 +470,37 @@ impl StreamingIterator {
     ) -> Self {
         Self {
             inner: Mutex::new(iter),
-            span,
+            span: Mutex::new(Some(span)),
+        }
+    }
+
+    /// Finalize the streaming span exactly once.
+    ///
+    /// Records the authoritative total row count into `cqlite.rows` and ends the
+    /// span by dropping it. Called from both the exhaustion branch of `__next__`
+    /// and from `Drop`; the `.take()` makes the second caller a no-op, so the
+    /// count is never recorded twice. Poisoned locks are skipped rather than
+    /// risking a double panic.
+    fn finalize_span(&self) {
+        let Ok(mut span_slot) = self.span.lock() else {
+            return;
+        };
+        if let Some(span) = span_slot.take() {
+            if let Ok(iter) = self.inner.lock() {
+                span.record("cqlite.rows", iter.rows_received() as i64);
+            }
+            // Dropping `span` here ends it so the span (with its final row count)
+            // is exported now, before any later Database.close()/flush.
         }
     }
 }
 
 impl Drop for StreamingIterator {
     fn drop(&mut self) {
-        // Record total rows yielded once the stream ends (exhausted, GC'd, or
-        // broken out of). `rows_received` is the authoritative count tracked by
-        // the core iterator. Lock may be poisoned if a panic occurred mid-next;
-        // in that case we simply skip recording rather than risk a double panic.
-        if let Ok(iter) = self.inner.lock() {
-            self.span.record("cqlite.rows", iter.rows_received() as i64);
-        }
+        // Finalize the span if it has not already been finalized at exhaustion
+        // (i.e. the iterator was GC'd or abandoned via `break`). Idempotent: if
+        // `__next__` already finalized on StopIteration, this is a no-op.
+        self.finalize_span();
     }
 }
 
@@ -509,7 +534,16 @@ impl StreamingIterator {
                 Py::new(py, py_row)
             }
             Some(Err(e)) => Err(to_py_err(e)),
-            None => Err(PyStopIteration::new_err(())),
+            None => {
+                // Stream exhausted. Finalize the span now (idempotently) so the
+                // per-stream span and its final row count are exported even if
+                // the exhausted iterator stays alive until a later
+                // Database.close()/flush. Release the `inner` lock first because
+                // finalize_span() re-acquires it.
+                drop(iter);
+                self.finalize_span();
+                Err(PyStopIteration::new_err(()))
+            }
         }
     }
 


### PR DESCRIPTION
Part of epic #1031. Depends on merged foundation (#1032).

- `observability` feature on the python crate (`cqlite-core/observability`), not default.
- `Database.open(..., otel_config=dict, traceparent=str)` — dict layered over CQLITE_OTEL_* env; process-global init + guard (flushes at interpreter shutdown). Per-call `python.execute` / `python.execute_streaming` spans; streaming span finalized idempotently on exhaustion AND drop with final row count. W3C traceparent (open-default + per-call override) parents the Rust spans under the caller's Python OTel trace. Flush on `close()`.
- No new metrics (reuses core #1035 query metrics — no double count); `db.stats()` stays canonical. Type stubs updated.

Validation: default + observability builds clean; clippy -D warnings clean; 323 pytest pass (test_parity.py pre-existing py3.9 PEP604 collection failure ignored — also fails on origin/main). roborev clean (job 1191).

Closes #1039