### PR TITLE
feat(observability): Arrow Flight per-RPC spans + gRPC metrics + traceparent (#1041)

### DIFF
--- a/cqlite-core/src/observability/catalog.rs
+++ b/cqlite-core/src/observability/catalog.rs
@@ -82,6 +82,14 @@ pub mod attr {
     /// `"point_lookup"`, `"index_scan"`, `"range_scan"`, `"aggregation"`
     /// (issue #1035). Bounded by the executor's plan-type taxonomy.
     pub const PLAN_TYPE: &str = "cqlite.query.plan_type";
+    /// Arrow Flight RPC method name (issue #1041), e.g. `"do_get"`,
+    /// `"get_flight_info"`, `"get_schema"`, `"handshake"`. Bounded by the
+    /// `FlightService` trait's fixed set of methods — never a request payload.
+    pub const RPC_METHOD: &str = "cqlite.rpc.method";
+    /// Arrow Flight RPC outcome (issue #1041), exactly `"ok"` or `"error"`.
+    /// Bounded to two values so a single metric series carries both arms for
+    /// success/error-rate dashboards.
+    pub const RPC_STATUS: &str = "cqlite.rpc.status";
 }
 
 /// `cqlite.read.rows` — counter `{row}`.
@@ -319,6 +327,43 @@ pub const COMPACTION_BUDGET_CONSUMED: &str = "cqlite.compaction.budget.consumed"
 /// The raw error message is never attached.
 pub const ERRORS_TOTAL: &str = "cqlite.errors.total";
 
+// ---------------------------------------------------------------------------
+// Arrow Flight gRPC service (issue #1041) — emitted from `cqlite-flight`.
+// ---------------------------------------------------------------------------
+
+/// `cqlite.rpc.requests` — counter `1`.
+///
+/// Total Arrow Flight RPC requests served, one increment per completed RPC.
+/// Bounded attributes: [`attr::RPC_METHOD`] (fixed `FlightService` method set)
+/// and [`attr::RPC_STATUS`] (`ok`/`error`) so a dashboard computes per-method
+/// error rate from one series. NEVER carries request payloads or ticket data.
+pub const RPC_REQUESTS: &str = "cqlite.rpc.requests";
+
+/// `cqlite.rpc.duration` — histogram `s`.
+///
+/// Distribution of Arrow Flight RPC handler durations in seconds (handler entry
+/// to response/stream construction). Bounded attributes: [`attr::RPC_METHOD`],
+/// [`attr::RPC_STATUS`].
+pub const RPC_DURATION: &str = "cqlite.rpc.duration";
+
+/// `cqlite.rpc.in_flight` — gauge `1`.
+///
+/// Number of Arrow Flight RPCs currently being handled (incremented on entry,
+/// decremented on completion). Bounded attributes: [`attr::RPC_METHOD`].
+pub const RPC_IN_FLIGHT: &str = "cqlite.rpc.in_flight";
+
+/// `cqlite.rpc.rows` — counter `{row}`.
+///
+/// Total rows returned to clients by `do_get` (summed across emitted record
+/// batches). Bounded attributes: [`attr::RPC_METHOD`].
+pub const RPC_ROWS: &str = "cqlite.rpc.rows";
+
+/// `cqlite.rpc.bytes` — counter `By`.
+///
+/// Total record-batch payload bytes streamed to clients by `do_get` (in-memory
+/// Arrow batch size, pre-IPC-framing). Bounded attributes: [`attr::RPC_METHOD`].
+pub const RPC_BYTES: &str = "cqlite.rpc.bytes";
+
 /// All catalog metric names, for tests and registration sanity checks.
 pub const ALL_METRICS: &[&str] = &[
     READ_ROWS,
@@ -358,6 +403,12 @@ pub const ALL_METRICS: &[&str] = &[
     COMPACTION_FINALIZE_DURATION,
     COMPACTION_BUDGET_REQUESTED,
     COMPACTION_BUDGET_CONSUMED,
+    // Arrow Flight gRPC service (#1041)
+    RPC_REQUESTS,
+    RPC_DURATION,
+    RPC_IN_FLIGHT,
+    RPC_ROWS,
+    RPC_BYTES,
 ];
 
 #[cfg(test)]
@@ -388,6 +439,8 @@ mod tests {
             attr::LOOKUP_ROUTE,
             attr::ACCESS_PATH,
             attr::PLAN_TYPE,
+            attr::RPC_METHOD,
+            attr::RPC_STATUS,
         ] {
             assert!(key.starts_with("cqlite."), "attr {key} must be namespaced");
         }

--- a/cqlite-flight/Cargo.toml
+++ b/cqlite-flight/Cargo.toml
@@ -27,6 +27,31 @@ clap = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
+# Observability / OpenTelemetry — optional, behind the `observability` feature.
+# Used for incoming W3C `traceparent` extraction (global text-map propagator)
+# and parenting per-RPC spans to the extracted remote context. The catalog
+# metric helpers and span macros do NOT need these crates here — they go
+# through `cqlite_core::observability`, which is no-op when its own feature is
+# off. These are required only for cross-process trace-context propagation.
+opentelemetry = { workspace = true, optional = true }
+opentelemetry_sdk = { workspace = true, optional = true }
+tracing-opentelemetry = { workspace = true, optional = true }
+
+[features]
+# Off by default: the Flight server is normally run without an OTLP collector,
+# and enabling OTel pulls in the exporter stack. Turn it on explicitly with
+# `--features observability` (and set CQLITE_OTEL_ENABLED=1 at runtime). This
+# also activates cqlite-core's `observability` feature so the shared metric
+# helpers and `tracing_layer()` export, and pulls in the propagator crates used
+# for incoming `traceparent` parenting.
+default = []
+observability = [
+    "cqlite-core/observability",
+    "dep:opentelemetry",
+    "dep:opentelemetry_sdk",
+    "dep:tracing-opentelemetry",
+]
+
 [dev-dependencies]
 tempfile = { workspace = true }
 

--- a/cqlite-flight/src/lib.rs
+++ b/cqlite-flight/src/lib.rs
@@ -10,6 +10,7 @@
 
 pub mod agg;
 pub mod filter;
+pub mod obs;
 pub mod producer;
 pub mod service;
 pub mod ticket;

--- a/cqlite-flight/src/main.rs
+++ b/cqlite-flight/src/main.rs
@@ -32,9 +32,23 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .init();
+    // Initialise observability (issue #1041, epic #1031) BEFORE composing the
+    // tracing subscriber, so `observability::tracing_layer()` returns the live
+    // OTel export layer. The guard flushes/shuts down OTel on drop; hold it for
+    // the whole process lifetime. With the `observability` feature off (or
+    // CQLITE_OTEL_ENABLED unset) this is an inert no-op.
+    let _otel_guard = cqlite_core::observability::init(
+        cqlite_core::observability::ObservabilityConfig::from_env(),
+    )?;
+    // Install the global W3C text-map propagator so incoming gRPC `traceparent`
+    // metadata can be extracted into an OTel context and used to parent the
+    // per-RPC spans (continuing a client's distributed trace into the service).
+    #[cfg(feature = "observability")]
+    opentelemetry::global::set_text_map_propagator(
+        opentelemetry_sdk::propagation::TraceContextPropagator::new(),
+    );
+
+    init_tracing_subscriber();
 
     let args = Args::parse();
     let listen = args.listen;
@@ -46,4 +60,31 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .serve(listen)
         .await?;
     Ok(())
+}
+
+/// Install the unified `tracing_subscriber` registry (issue #1041, epic #1031).
+///
+/// Mirrors the CLI (#1033): an `EnvFilter` (honouring `RUST_LOG`, default
+/// `info`) plus a human-readable `fmt` layer, and — when the `observability`
+/// feature is enabled — the OTel bridge layer from
+/// `cqlite_core::observability::tracing_layer()`. That layer is `None` (a no-op)
+/// unless `init()` installed an exporting provider, so this composes safely in
+/// every configuration. `init()` MUST have run first.
+fn init_tracing_subscriber() {
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::util::SubscriberInitExt;
+    use tracing_subscriber::{fmt, EnvFilter};
+
+    let env_filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+
+    let registry = tracing_subscriber::registry()
+        .with(env_filter)
+        .with(fmt::layer());
+
+    #[cfg(feature = "observability")]
+    let registry = registry.with(cqlite_core::observability::tracing_layer());
+
+    // `try_init` is tolerant of a subscriber already being set (e.g. in tests).
+    let _ = registry.try_init();
 }

--- a/cqlite-flight/src/obs.rs
+++ b/cqlite-flight/src/obs.rs
@@ -1,0 +1,288 @@
+//! Per-RPC observability for the Arrow Flight service (issue #1041, epic #1031).
+//!
+//! This module concentrates all telemetry concerns for the gRPC endpoints so the
+//! service handlers stay readable:
+//!
+//! * **Spans** — [`rpc_span`] builds an `info`-level span named `flight.<method>`
+//!   and, when the `observability` feature is enabled, parents it to the W3C
+//!   `traceparent` carried in the incoming gRPC metadata. Entering the handler
+//!   body within this span (via `.instrument(span)`) makes the core
+//!   `query.execute` and read-path spans nest under the RPC span, so a client's
+//!   distributed trace continues seamlessly into CQLite.
+//! * **Metrics** — [`RpcMetrics`] is an RAII recorder: it bumps the in-flight
+//!   gauge and, on drop, records the request counter (by method + ok/error),
+//!   the latency histogram, and decrements the gauge. `do_get` additionally
+//!   reports rows and bytes streamed via [`RpcMetrics::add_rows_bytes`].
+//!
+//! All metric calls go through `cqlite_core::observability`, which is a no-op
+//! when its own feature is off, so the handlers compile and run identically in
+//! every configuration. Cardinality is bounded: the only attributes are the
+//! fixed `FlightService` method name and an `ok`/`error` status — never tickets,
+//! keys, queries, or payloads.
+
+use std::time::Instant;
+
+use cqlite_core::observability::{self as obs, catalog, AttrValue};
+use tonic::Request;
+
+/// Subsystem label for [`obs::record_error`] from the Flight service.
+pub const SUBSYSTEM: &str = "flight";
+
+/// Bounded `cqlite.rpc.status` value for a successful RPC.
+const STATUS_OK: &str = "ok";
+/// Bounded `cqlite.rpc.status` value for a failed RPC.
+const STATUS_ERROR: &str = "error";
+
+/// Build the per-RPC tracing span, parented to the incoming W3C trace context.
+///
+/// `method` is a `&'static str` from the fixed `FlightService` method set (e.g.
+/// `"do_get"`), keeping span-name cardinality bounded. The returned span is
+/// entered by the caller via `.instrument(span)` on the handler future.
+///
+/// # Traceparent propagation
+///
+/// When the `observability` feature is on, the incoming gRPC metadata is read
+/// through the globally-installed W3C text-map propagator
+/// (`TraceContextPropagator`, installed in `main`). If the client sent a
+/// `traceparent` header, the extracted [`opentelemetry::Context`] is attached as
+/// the span's parent with `OpenTelemetrySpanExt::set_parent`, so the server span
+/// (and everything nested under it) shares the client's trace ID. With no header
+/// or with the feature off, the span is simply a new root.
+pub fn rpc_span<T>(method: &'static str, request: &Request<T>) -> tracing::Span {
+    let span = tracing::info_span!("flight.rpc", otel.name = method, rpc.method = method);
+    #[cfg(feature = "observability")]
+    {
+        use tracing_opentelemetry::OpenTelemetrySpanExt;
+        let parent_cx = opentelemetry::global::get_text_map_propagator(|propagator| {
+            propagator.extract(&MetadataExtractor(request.metadata()))
+        });
+        span.set_parent(parent_cx);
+    }
+    #[cfg(not(feature = "observability"))]
+    {
+        let _ = request;
+    }
+    span
+}
+
+/// RAII recorder for the per-RPC gRPC metrics.
+///
+/// Created at handler entry: it records the in-flight gauge as incremented.
+/// Call [`RpcMetrics::ok`] / [`RpcMetrics::error`] to set the terminal status
+/// (defaults to `error` so an early `?` return is still counted as a failure),
+/// and on drop it emits `cqlite.rpc.requests`, `cqlite.rpc.duration`, and the
+/// decremented in-flight gauge.
+pub struct RpcMetrics {
+    method: &'static str,
+    started: Instant,
+    status: &'static str,
+    rows: u64,
+    bytes: u64,
+    /// Tracks the current in-flight count so the gauge decrements correctly. A
+    /// process-wide atomic per method would be ideal, but bounded methods + a
+    /// single shared counter keeps it simple; we record +1 on start and 0-delta
+    /// is fine because the gauge is observed as a level, set on each change.
+    finished: bool,
+}
+
+impl RpcMetrics {
+    /// Begin recording an RPC. Increments the in-flight gauge for `method`.
+    /// `method` must be a `&'static str` from the `FlightService` method set.
+    pub fn start(method: &'static str) -> Self {
+        IN_FLIGHT.with(|cell| {
+            let v = cell.get() + 1;
+            cell.set(v);
+            obs::record_gauge(catalog::RPC_IN_FLIGHT, v, &[method_attr(method)]);
+        });
+        Self {
+            method,
+            started: Instant::now(),
+            status: STATUS_ERROR,
+            rows: 0,
+            bytes: 0,
+            finished: false,
+        }
+    }
+
+    /// Mark this RPC as successful.
+    pub fn ok(&mut self) {
+        self.status = STATUS_OK;
+    }
+
+    /// Add rows + payload bytes streamed (used by `do_get`).
+    pub fn add_rows_bytes(&mut self, rows: u64, bytes: u64) {
+        self.rows = self.rows.saturating_add(rows);
+        self.bytes = self.bytes.saturating_add(bytes);
+    }
+
+    /// Emit the terminal metrics. Idempotent; called from `Drop`.
+    fn finish(&mut self) {
+        if self.finished {
+            return;
+        }
+        self.finished = true;
+        let method = method_attr(self.method);
+        let status: (&'static str, AttrValue) =
+            (catalog::attr::RPC_STATUS, AttrValue::StaticStr(self.status));
+        obs::add_counter(catalog::RPC_REQUESTS, 1, &[method.clone(), status.clone()]);
+        obs::record_histogram(
+            catalog::RPC_DURATION,
+            self.started.elapsed().as_secs_f64(),
+            &[method.clone(), status],
+        );
+        if self.rows > 0 {
+            obs::add_counter(catalog::RPC_ROWS, self.rows, &[method.clone()]);
+        }
+        if self.bytes > 0 {
+            obs::add_counter(catalog::RPC_BYTES, self.bytes, &[method.clone()]);
+        }
+        IN_FLIGHT.with(|cell| {
+            let v = cell.get().saturating_sub(1);
+            cell.set(v);
+            obs::record_gauge(catalog::RPC_IN_FLIGHT, v, &[method]);
+        });
+    }
+}
+
+impl Drop for RpcMetrics {
+    fn drop(&mut self) {
+        self.finish();
+    }
+}
+
+thread_local! {
+    /// Per-thread in-flight RPC count, used to drive the in-flight gauge as a
+    /// level. The gRPC reactor schedules handlers across worker threads, so this
+    /// is an approximation; cardinality and cost stay bounded and it avoids a
+    /// shared atomic on the hot path.
+    static IN_FLIGHT: std::cell::Cell<i64> = const { std::cell::Cell::new(0) };
+}
+
+fn method_attr(method: &'static str) -> (&'static str, AttrValue) {
+    (catalog::attr::RPC_METHOD, AttrValue::StaticStr(method))
+}
+
+/// Record an RPC failure into the error-rate signal (`cqlite.errors.total`,
+/// subsystem `flight`) and mark the active span errored.
+///
+/// The handlers return `tonic::Status`, but [`obs::record_error`] keys the
+/// counter on a bounded `{category, subsystem}` label set derived from a
+/// `cqlite_core::Error` — never the message. We therefore map the gRPC status
+/// *code* (a closed set) to a representative `cqlite_core::Error` so the error
+/// category is meaningful. No part of the status message is ever recorded.
+pub fn record_status_error(status: &tonic::Status) {
+    use cqlite_core::Error;
+    use tonic::Code;
+    // A fixed, bounded code→error mapping. The message text is irrelevant to the
+    // counter (only the category is used) so a constant placeholder is passed.
+    let err = match status.code() {
+        Code::NotFound => Error::not_found("flight"),
+        Code::InvalidArgument | Code::FailedPrecondition | Code::OutOfRange => {
+            Error::invalid_input("flight")
+        }
+        Code::Unimplemented => Error::invalid_operation("flight"),
+        _ => Error::internal("flight"),
+    };
+    obs::record_error(&err, SUBSYSTEM);
+}
+
+/// `opentelemetry::propagation::Extractor` over gRPC request metadata, so the
+/// W3C propagator can read the incoming `traceparent`/`tracestate` headers.
+#[cfg(feature = "observability")]
+struct MetadataExtractor<'a>(&'a tonic::metadata::MetadataMap);
+
+#[cfg(feature = "observability")]
+impl opentelemetry::propagation::Extractor for MetadataExtractor<'_> {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).and_then(|v| v.to_str().ok())
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        self.0
+            .keys()
+            .filter_map(|k| match k {
+                tonic::metadata::KeyRef::Ascii(k) => Some(k.as_str()),
+                tonic::metadata::KeyRef::Binary(_) => None,
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rpc_span_builds_for_any_request() {
+        // A span must always be produced regardless of metadata or feature state.
+        let req = Request::new(());
+        let span = rpc_span("do_get", &req);
+        let _entered = span.enter();
+    }
+
+    #[test]
+    fn rpc_metrics_lifecycle_is_callable() {
+        // The recorder must drive its counters/gauges without panicking in any
+        // build (no-op when the core observability feature is off).
+        let mut m = RpcMetrics::start("do_get");
+        m.add_rows_bytes(5, 1024);
+        m.ok();
+        drop(m);
+    }
+
+    #[test]
+    fn record_status_error_maps_codes() {
+        // Exercise every code arm; the call must not panic and records only the
+        // bounded {category, subsystem} signal.
+        for status in [
+            tonic::Status::not_found("x"),
+            tonic::Status::invalid_argument("x"),
+            tonic::Status::failed_precondition("x"),
+            tonic::Status::out_of_range("x"),
+            tonic::Status::unimplemented("x"),
+            tonic::Status::internal("x"),
+        ] {
+            record_status_error(&status);
+        }
+    }
+
+    #[cfg(feature = "observability")]
+    #[test]
+    fn metadata_extractor_reads_traceparent() {
+        use opentelemetry::propagation::Extractor;
+        let mut md = tonic::metadata::MetadataMap::new();
+        let tp = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+        md.insert("traceparent", tp.parse().expect("ascii value"));
+        let ex = MetadataExtractor(&md);
+        assert_eq!(ex.get("traceparent"), Some(tp));
+        assert!(ex.keys().contains(&"traceparent"));
+    }
+
+    #[cfg(feature = "observability")]
+    #[test]
+    fn propagator_extracts_remote_trace_id() {
+        // The W3C propagator, given metadata carrying a `traceparent`, yields a
+        // context whose span context holds the client's trace id — this is the
+        // exact value `rpc_span` attaches as the span parent.
+        use opentelemetry::trace::TraceContextExt;
+        opentelemetry::global::set_text_map_propagator(
+            opentelemetry_sdk::propagation::TraceContextPropagator::new(),
+        );
+        let mut md = tonic::metadata::MetadataMap::new();
+        md.insert(
+            "traceparent",
+            "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+                .parse()
+                .expect("ascii value"),
+        );
+        let cx = opentelemetry::global::get_text_map_propagator(|p| {
+            p.extract(&MetadataExtractor(&md))
+        });
+        let trace_id = cx.span().span_context().trace_id();
+        assert_eq!(
+            format!("{trace_id:032x}"),
+            "0af7651916cd43dd8448eb211c80319c",
+            "extracted context carries the client's trace id"
+        );
+    }
+}

--- a/cqlite-flight/src/obs.rs
+++ b/cqlite-flight/src/obs.rs
@@ -93,6 +93,13 @@ impl RpcMetrics {
     /// method set (see [`method_index`]).
     pub fn start(method: &'static str) -> Self {
         let method_idx = method_index(method);
+        // Normalize the label to the bounded slot name so an unexpected method
+        // string can never leak as a metric attribute: a value not in the fixed
+        // set resolves to `method_idx` for the `"other"` slot, and we report that
+        // slot's canonical label here (and in `finish`). This keeps metric
+        // cardinality capped at exactly the RPC_METHODS set and makes the in-flight
+        // gauge label match the shared counter that is actually incremented.
+        let method = RPC_METHODS[method_idx];
         // Increment the shared per-method counter and observe the level. Because
         // the counter is process-wide (not thread-local), the matching decrement
         // in `finish` stays correct under Tokio worker-thread hopping.

--- a/cqlite-flight/src/obs.rs
+++ b/cqlite-flight/src/obs.rs
@@ -20,6 +20,7 @@
 //! fixed `FlightService` method name and an `ok`/`error` status — never tickets,
 //! keys, queries, or payloads.
 
+use std::sync::atomic::{AtomicI64, Ordering};
 use std::time::Instant;
 
 use cqlite_core::observability::{self as obs, catalog, AttrValue};
@@ -74,28 +75,32 @@ pub fn rpc_span<T>(method: &'static str, request: &Request<T>) -> tracing::Span 
 /// decremented in-flight gauge.
 pub struct RpcMetrics {
     method: &'static str,
+    /// Index into [`IN_FLIGHT`] for `method`, resolved once at `start`. The
+    /// decrement on completion targets this same shared atomic, so it is correct
+    /// even when Tokio moves the RPC future to a different worker thread across an
+    /// `.await` (the increment and decrement are not thread-bound).
+    method_idx: usize,
     started: Instant,
     status: &'static str,
     rows: u64,
     bytes: u64,
-    /// Tracks the current in-flight count so the gauge decrements correctly. A
-    /// process-wide atomic per method would be ideal, but bounded methods + a
-    /// single shared counter keeps it simple; we record +1 on start and 0-delta
-    /// is fine because the gauge is observed as a level, set on each change.
     finished: bool,
 }
 
 impl RpcMetrics {
-    /// Begin recording an RPC. Increments the in-flight gauge for `method`.
-    /// `method` must be a `&'static str` from the `FlightService` method set.
+    /// Begin recording an RPC. Increments the process-wide in-flight gauge for
+    /// `method`. `method` must be a `&'static str` from the `FlightService`
+    /// method set (see [`method_index`]).
     pub fn start(method: &'static str) -> Self {
-        IN_FLIGHT.with(|cell| {
-            let v = cell.get() + 1;
-            cell.set(v);
-            obs::record_gauge(catalog::RPC_IN_FLIGHT, v, &[method_attr(method)]);
-        });
+        let method_idx = method_index(method);
+        // Increment the shared per-method counter and observe the level. Because
+        // the counter is process-wide (not thread-local), the matching decrement
+        // in `finish` stays correct under Tokio worker-thread hopping.
+        let v = IN_FLIGHT[method_idx].fetch_add(1, Ordering::Relaxed) + 1;
+        obs::record_gauge(catalog::RPC_IN_FLIGHT, v, &[method_attr(method)]);
         Self {
             method,
+            method_idx,
             started: Instant::now(),
             status: STATUS_ERROR,
             rows: 0,
@@ -136,11 +141,13 @@ impl RpcMetrics {
         if self.bytes > 0 {
             obs::add_counter(catalog::RPC_BYTES, self.bytes, &[method.clone()]);
         }
-        IN_FLIGHT.with(|cell| {
-            let v = cell.get().saturating_sub(1);
-            cell.set(v);
-            obs::record_gauge(catalog::RPC_IN_FLIGHT, v, &[method]);
-        });
+        // Decrement the SAME shared per-method counter incremented in `start`.
+        // `fetch_sub` returns the previous value, so the new level is `prev - 1`;
+        // a `max(0)` floor guards against an unexpected underflow without ever
+        // recording a negative gauge.
+        let prev = IN_FLIGHT[self.method_idx].fetch_sub(1, Ordering::Relaxed);
+        let level = (prev - 1).max(0);
+        obs::record_gauge(catalog::RPC_IN_FLIGHT, level, &[method]);
     }
 }
 
@@ -150,12 +157,59 @@ impl Drop for RpcMetrics {
     }
 }
 
-thread_local! {
-    /// Per-thread in-flight RPC count, used to drive the in-flight gauge as a
-    /// level. The gRPC reactor schedules handlers across worker threads, so this
-    /// is an approximation; cardinality and cost stay bounded and it avoids a
-    /// shared atomic on the hot path.
-    static IN_FLIGHT: std::cell::Cell<i64> = const { std::cell::Cell::new(0) };
+/// Fixed, bounded set of `FlightService` RPC method names, in the order used to
+/// index [`IN_FLIGHT`]. Cardinality is exactly the gRPC method set — no ticket,
+/// key, query, or payload ever appears here.
+const RPC_METHODS: [&str; 11] = [
+    "get_flight_info",
+    "get_schema",
+    "do_get",
+    "handshake",
+    "list_flights",
+    "poll_flight_info",
+    "do_put",
+    "do_exchange",
+    "do_action",
+    "list_actions",
+    // Catch-all slot for any method name not in the fixed set above. Keeping a
+    // bounded fallback means an unexpected `method` never panics or allocates and
+    // the gauge cardinality is still capped.
+    "other",
+];
+
+/// Index of the catch-all slot in [`RPC_METHODS`] / [`IN_FLIGHT`].
+const OTHER_IDX: usize = RPC_METHODS.len() - 1;
+
+/// Process-wide, per-method in-flight RPC counters used to drive the in-flight
+/// gauge as a level. A single shared atomic per method means the increment (on
+/// RPC entry) and the matching decrement (on completion, via `RpcMetrics::Drop`)
+/// always target the same counter even when Tokio moves the RPC future between
+/// worker threads across `.await`. Cardinality is bounded by [`RPC_METHODS`].
+static IN_FLIGHT: [AtomicI64; RPC_METHODS.len()] = {
+    // `AtomicI64` is not `Copy`, so the array is built from a const initializer.
+    [
+        AtomicI64::new(0),
+        AtomicI64::new(0),
+        AtomicI64::new(0),
+        AtomicI64::new(0),
+        AtomicI64::new(0),
+        AtomicI64::new(0),
+        AtomicI64::new(0),
+        AtomicI64::new(0),
+        AtomicI64::new(0),
+        AtomicI64::new(0),
+        AtomicI64::new(0),
+    ]
+};
+
+/// Resolve an RPC `method` name to its index in [`IN_FLIGHT`]. Unknown names map
+/// to the bounded catch-all slot, so the gauge cardinality stays capped and the
+/// lookup never panics.
+fn method_index(method: &str) -> usize {
+    RPC_METHODS
+        .iter()
+        .position(|m| *m == method)
+        .unwrap_or(OTHER_IDX)
 }
 
 fn method_attr(method: &'static str) -> (&'static str, AttrValue) {
@@ -228,6 +282,65 @@ mod tests {
         m.add_rows_bytes(5, 1024);
         m.ok();
         drop(m);
+    }
+
+    #[test]
+    fn method_index_maps_known_and_unknown() {
+        // Every fixed FlightService method resolves to a distinct in-bounds slot.
+        for (i, name) in RPC_METHODS.iter().enumerate().take(OTHER_IDX) {
+            assert_eq!(method_index(name), i, "{name} maps to its own slot");
+        }
+        // Unknown names fall into the bounded catch-all slot (no panic, no growth).
+        assert_eq!(method_index("not_a_real_method"), OTHER_IDX);
+    }
+
+    #[test]
+    fn in_flight_gauge_balances_under_thread_hopping() {
+        // Simulate Tokio moving an RPC future across worker threads: increment on
+        // one thread (RpcMetrics::start), drop on another (the decrement). Because
+        // the counter is a process-wide atomic keyed by method — not thread-local
+        // — the per-method count must return to its starting level. The balance
+        // property holds regardless of other concurrently-running tests, since
+        // every start is paired with exactly one drop on the same shared counter.
+        //
+        // Use `poll_flight_info`, a method no other unit test exercises, so the
+        // pre/post snapshots are stable under the parallel test runner.
+        let idx = method_index("poll_flight_info");
+        let base = IN_FLIGHT[idx].load(Ordering::Relaxed);
+
+        // Start on this thread, hand the recorder to another thread to drop it.
+        let m = RpcMetrics::start("poll_flight_info");
+        std::thread::spawn(move || drop(m))
+            .join()
+            .expect("drop thread joins");
+
+        assert_eq!(
+            IN_FLIGHT[idx].load(Ordering::Relaxed),
+            base,
+            "increment + decrement-on-another-thread balances the shared counter"
+        );
+    }
+
+    #[test]
+    fn rpc_metrics_increments_shared_counter_on_start() {
+        // `start` must bump the process-wide per-method counter (and `Drop` must
+        // restore it). Serialise on a dedicated method slot so the +1 assertion is
+        // deterministic: no other unit test creates `do_exchange` metrics.
+        let idx = method_index("do_exchange");
+        let base = IN_FLIGHT[idx].load(Ordering::Relaxed);
+        {
+            let _m = RpcMetrics::start("do_exchange");
+            assert_eq!(
+                IN_FLIGHT[idx].load(Ordering::Relaxed),
+                base + 1,
+                "start increments the shared per-method counter"
+            );
+        }
+        assert_eq!(
+            IN_FLIGHT[idx].load(Ordering::Relaxed),
+            base,
+            "drop decrements the shared per-method counter back to base"
+        );
     }
 
     #[test]

--- a/cqlite-flight/src/service.rs
+++ b/cqlite-flight/src/service.rs
@@ -141,8 +141,15 @@ impl FlightService for CqliteFlightService {
     ) -> Result<Response<FlightInfo>, Status> {
         let span = rpc_span("get_flight_info", &request);
         let mut metrics = RpcMetrics::start("get_flight_info");
-        let result = self.get_flight_info_inner(request).instrument(span).await;
-        finish(&mut metrics, result)
+        // Run the body AND finish() inside the RPC span so error/status recording
+        // (record_status_error → Span::current()) tags THIS span, not whatever
+        // span happens to be current after `.instrument` has completed.
+        async {
+            let result = self.get_flight_info_inner(request).await;
+            finish(&mut metrics, result)
+        }
+        .instrument(span)
+        .await
     }
 
     async fn get_schema(
@@ -151,8 +158,12 @@ impl FlightService for CqliteFlightService {
     ) -> Result<Response<SchemaResult>, Status> {
         let span = rpc_span("get_schema", &request);
         let mut metrics = RpcMetrics::start("get_schema");
-        let result = self.get_schema_inner(request).instrument(span).await;
-        finish(&mut metrics, result)
+        async {
+            let result = self.get_schema_inner(request).await;
+            finish(&mut metrics, result)
+        }
+        .instrument(span)
+        .await
     }
 
     async fn do_get(
@@ -161,98 +172,118 @@ impl FlightService for CqliteFlightService {
     ) -> Result<Response<Self::DoGetStream>, Status> {
         let span = rpc_span("do_get", &request);
         let mut metrics = RpcMetrics::start("do_get");
-        // Run the read body within the RPC span so the core query.execute and
-        // read-path spans nest under `flight.do_get`. The merge eagerly drains
-        // SSTables into memory, so the row/byte totals are known here (before the
-        // result is streamed) and attributed to this RPC.
-        let result = self.do_get_inner(request, &mut metrics).instrument(span).await;
-        finish(&mut metrics, result)
+        // Run the read body AND finish() within the RPC span so the core
+        // query.execute / read-path spans nest under `flight.do_get`, and so
+        // error/status recording in finish() tags this span (not a stale current
+        // span after `.instrument` completes). The merge eagerly drains SSTables
+        // into memory, so the row/byte totals are known here and attributed here.
+        async {
+            let result = self.do_get_inner(request, &mut metrics).await;
+            finish(&mut metrics, result)
+        }
+        .instrument(span)
+        .await
     }
 
     async fn handshake(
         &self,
         request: Request<Streaming<HandshakeRequest>>,
     ) -> Result<Response<Self::HandshakeStream>, Status> {
-        let _span = rpc_span("handshake", &request);
+        let span = rpc_span("handshake", &request);
         let mut metrics = RpcMetrics::start("handshake");
-        finish(
-            &mut metrics,
-            Err(Status::unimplemented("handshake is not supported")),
-        )
+        // Enter the span so finish()'s error recording tags THIS RPC span.
+        span.in_scope(|| {
+            finish(
+                &mut metrics,
+                Err(Status::unimplemented("handshake is not supported")),
+            )
+        })
     }
 
     async fn list_flights(
         &self,
         request: Request<Criteria>,
     ) -> Result<Response<Self::ListFlightsStream>, Status> {
-        let _span = rpc_span("list_flights", &request);
+        let span = rpc_span("list_flights", &request);
         let mut metrics = RpcMetrics::start("list_flights");
-        finish(
-            &mut metrics,
-            Err(Status::unimplemented("list_flights is not yet supported")),
-        )
+        span.in_scope(|| {
+            finish(
+                &mut metrics,
+                Err(Status::unimplemented("list_flights is not yet supported")),
+            )
+        })
     }
 
     async fn poll_flight_info(
         &self,
         request: Request<FlightDescriptor>,
     ) -> Result<Response<PollInfo>, Status> {
-        let _span = rpc_span("poll_flight_info", &request);
+        let span = rpc_span("poll_flight_info", &request);
         let mut metrics = RpcMetrics::start("poll_flight_info");
-        finish(
-            &mut metrics,
-            Err(Status::unimplemented("poll_flight_info is not supported")),
-        )
+        span.in_scope(|| {
+            finish(
+                &mut metrics,
+                Err(Status::unimplemented("poll_flight_info is not supported")),
+            )
+        })
     }
 
     async fn do_put(
         &self,
         request: Request<Streaming<FlightData>>,
     ) -> Result<Response<Self::DoPutStream>, Status> {
-        let _span = rpc_span("do_put", &request);
+        let span = rpc_span("do_put", &request);
         let mut metrics = RpcMetrics::start("do_put");
-        finish(
-            &mut metrics,
-            Err(Status::unimplemented(
-                "do_put is not supported (read-only server)",
-            )),
-        )
+        span.in_scope(|| {
+            finish(
+                &mut metrics,
+                Err(Status::unimplemented(
+                    "do_put is not supported (read-only server)",
+                )),
+            )
+        })
     }
 
     async fn do_exchange(
         &self,
         request: Request<Streaming<FlightData>>,
     ) -> Result<Response<Self::DoExchangeStream>, Status> {
-        let _span = rpc_span("do_exchange", &request);
+        let span = rpc_span("do_exchange", &request);
         let mut metrics = RpcMetrics::start("do_exchange");
-        finish(
-            &mut metrics,
-            Err(Status::unimplemented("do_exchange is not supported")),
-        )
+        span.in_scope(|| {
+            finish(
+                &mut metrics,
+                Err(Status::unimplemented("do_exchange is not supported")),
+            )
+        })
     }
 
     async fn do_action(
         &self,
         request: Request<Action>,
     ) -> Result<Response<Self::DoActionStream>, Status> {
-        let _span = rpc_span("do_action", &request);
+        let span = rpc_span("do_action", &request);
         let mut metrics = RpcMetrics::start("do_action");
-        finish(
-            &mut metrics,
-            Err(Status::unimplemented("do_action is not supported")),
-        )
+        span.in_scope(|| {
+            finish(
+                &mut metrics,
+                Err(Status::unimplemented("do_action is not supported")),
+            )
+        })
     }
 
     async fn list_actions(
         &self,
         request: Request<Empty>,
     ) -> Result<Response<Self::ListActionsStream>, Status> {
-        let _span = rpc_span("list_actions", &request);
+        let span = rpc_span("list_actions", &request);
         let mut metrics = RpcMetrics::start("list_actions");
-        finish(
-            &mut metrics,
-            Err(Status::unimplemented("list_actions is not supported")),
-        )
+        span.in_scope(|| {
+            finish(
+                &mut metrics,
+                Err(Status::unimplemented("list_actions is not supported")),
+            )
+        })
     }
 }
 

--- a/cqlite-flight/src/service.rs
+++ b/cqlite-flight/src/service.rs
@@ -32,8 +32,10 @@ use futures::StreamExt;
 use tonic::{Request, Response, Status, Streaming};
 
 use cqlite_core::schema::{parse_cql_schema, TableSchema};
+use tracing::Instrument;
 
 use crate::filter::{FilterError, ScanSpec};
+use crate::obs::{rpc_span, RpcMetrics};
 use crate::producer::{DirSource, MergeProducer, ProducerError};
 use crate::ticket::{FlightTicket, TicketError};
 
@@ -137,6 +139,141 @@ impl FlightService for CqliteFlightService {
         &self,
         request: Request<FlightDescriptor>,
     ) -> Result<Response<FlightInfo>, Status> {
+        let span = rpc_span("get_flight_info", &request);
+        let mut metrics = RpcMetrics::start("get_flight_info");
+        let result = self.get_flight_info_inner(request).instrument(span).await;
+        finish(&mut metrics, result)
+    }
+
+    async fn get_schema(
+        &self,
+        request: Request<FlightDescriptor>,
+    ) -> Result<Response<SchemaResult>, Status> {
+        let span = rpc_span("get_schema", &request);
+        let mut metrics = RpcMetrics::start("get_schema");
+        let result = self.get_schema_inner(request).instrument(span).await;
+        finish(&mut metrics, result)
+    }
+
+    async fn do_get(
+        &self,
+        request: Request<Ticket>,
+    ) -> Result<Response<Self::DoGetStream>, Status> {
+        let span = rpc_span("do_get", &request);
+        let mut metrics = RpcMetrics::start("do_get");
+        // Run the read body within the RPC span so the core query.execute and
+        // read-path spans nest under `flight.do_get`. The merge eagerly drains
+        // SSTables into memory, so the row/byte totals are known here (before the
+        // result is streamed) and attributed to this RPC.
+        let result = self.do_get_inner(request, &mut metrics).instrument(span).await;
+        finish(&mut metrics, result)
+    }
+
+    async fn handshake(
+        &self,
+        request: Request<Streaming<HandshakeRequest>>,
+    ) -> Result<Response<Self::HandshakeStream>, Status> {
+        let _span = rpc_span("handshake", &request);
+        let mut metrics = RpcMetrics::start("handshake");
+        finish(
+            &mut metrics,
+            Err(Status::unimplemented("handshake is not supported")),
+        )
+    }
+
+    async fn list_flights(
+        &self,
+        request: Request<Criteria>,
+    ) -> Result<Response<Self::ListFlightsStream>, Status> {
+        let _span = rpc_span("list_flights", &request);
+        let mut metrics = RpcMetrics::start("list_flights");
+        finish(
+            &mut metrics,
+            Err(Status::unimplemented("list_flights is not yet supported")),
+        )
+    }
+
+    async fn poll_flight_info(
+        &self,
+        request: Request<FlightDescriptor>,
+    ) -> Result<Response<PollInfo>, Status> {
+        let _span = rpc_span("poll_flight_info", &request);
+        let mut metrics = RpcMetrics::start("poll_flight_info");
+        finish(
+            &mut metrics,
+            Err(Status::unimplemented("poll_flight_info is not supported")),
+        )
+    }
+
+    async fn do_put(
+        &self,
+        request: Request<Streaming<FlightData>>,
+    ) -> Result<Response<Self::DoPutStream>, Status> {
+        let _span = rpc_span("do_put", &request);
+        let mut metrics = RpcMetrics::start("do_put");
+        finish(
+            &mut metrics,
+            Err(Status::unimplemented(
+                "do_put is not supported (read-only server)",
+            )),
+        )
+    }
+
+    async fn do_exchange(
+        &self,
+        request: Request<Streaming<FlightData>>,
+    ) -> Result<Response<Self::DoExchangeStream>, Status> {
+        let _span = rpc_span("do_exchange", &request);
+        let mut metrics = RpcMetrics::start("do_exchange");
+        finish(
+            &mut metrics,
+            Err(Status::unimplemented("do_exchange is not supported")),
+        )
+    }
+
+    async fn do_action(
+        &self,
+        request: Request<Action>,
+    ) -> Result<Response<Self::DoActionStream>, Status> {
+        let _span = rpc_span("do_action", &request);
+        let mut metrics = RpcMetrics::start("do_action");
+        finish(
+            &mut metrics,
+            Err(Status::unimplemented("do_action is not supported")),
+        )
+    }
+
+    async fn list_actions(
+        &self,
+        request: Request<Empty>,
+    ) -> Result<Response<Self::ListActionsStream>, Status> {
+        let _span = rpc_span("list_actions", &request);
+        let mut metrics = RpcMetrics::start("list_actions");
+        finish(
+            &mut metrics,
+            Err(Status::unimplemented("list_actions is not supported")),
+        )
+    }
+}
+
+/// Finalise a handler: on success, mark the metrics OK; on error, record the
+/// error-rate signal (subsystem `flight`). `RpcMetrics` emits the request
+/// counter, latency histogram, and in-flight gauge on drop, so returning the
+/// result here (which drops `metrics` at the call site) closes the RPC.
+fn finish<T>(metrics: &mut RpcMetrics, result: Result<T, Status>) -> Result<T, Status> {
+    match &result {
+        Ok(_) => metrics.ok(),
+        Err(status) => crate::obs::record_status_error(status),
+    }
+    result
+}
+
+impl CqliteFlightService {
+    /// Body of [`FlightService::get_flight_info`], run inside the RPC span.
+    async fn get_flight_info_inner(
+        &self,
+        request: Request<FlightDescriptor>,
+    ) -> Result<Response<FlightInfo>, Status> {
         let descriptor = request.into_inner();
         let ticket = FlightTicket::from_bytes(&descriptor.cmd)?;
         let arrow_schema = self.arrow_schema_for(&ticket)?;
@@ -150,7 +287,8 @@ impl FlightService for CqliteFlightService {
         Ok(Response::new(info))
     }
 
-    async fn get_schema(
+    /// Body of [`FlightService::get_schema`], run inside the RPC span.
+    async fn get_schema_inner(
         &self,
         request: Request<FlightDescriptor>,
     ) -> Result<Response<SchemaResult>, Status> {
@@ -165,10 +303,13 @@ impl FlightService for CqliteFlightService {
         Ok(Response::new(schema_result))
     }
 
-    async fn do_get(
+    /// Body of [`FlightService::do_get`], run inside the RPC span. Reports the
+    /// rows + payload bytes produced by the merge into `metrics`.
+    async fn do_get_inner(
         &self,
         request: Request<Ticket>,
-    ) -> Result<Response<Self::DoGetStream>, Status> {
+        metrics: &mut RpcMetrics,
+    ) -> Result<Response<<Self as FlightService>::DoGetStream>, Status> {
         let ticket = FlightTicket::from_bytes(&request.into_inner().ticket)?;
         let producer = self.build_producer(&ticket)?;
         let schema_ref = Arc::new(producer.arrow_schema()?);
@@ -187,6 +328,16 @@ impl FlightService for CqliteFlightService {
             .await
             .map_err(|e| Status::internal(format!("merge task panicked: {e}")))??;
 
+        // Attribute rows + in-memory payload bytes to this RPC. `get_array_memory_size`
+        // is the buffer footprint of the batch (pre-IPC framing) — a bounded, cheap
+        // count, never the payload contents.
+        let rows: u64 = batches.iter().map(|b| b.num_rows() as u64).sum();
+        let bytes: u64 = batches
+            .iter()
+            .map(|b| b.get_array_memory_size() as u64)
+            .sum();
+        metrics.add_rows_bytes(rows, bytes);
+
         // `with_schema` emits the Arrow schema as the first Flight message even
         // when no record batches follow, so an empty result still carries the schema.
         let input = futures::stream::iter(batches.into_iter().map(Ok::<RecordBatch, FlightError>));
@@ -196,57 +347,6 @@ impl FlightService for CqliteFlightService {
             .map(|res| res.map_err(|e| Status::internal(e.to_string())));
 
         Ok(Response::new(Box::pin(encoded)))
-    }
-
-    async fn handshake(
-        &self,
-        _request: Request<Streaming<HandshakeRequest>>,
-    ) -> Result<Response<Self::HandshakeStream>, Status> {
-        Err(Status::unimplemented("handshake is not supported"))
-    }
-
-    async fn list_flights(
-        &self,
-        _request: Request<Criteria>,
-    ) -> Result<Response<Self::ListFlightsStream>, Status> {
-        Err(Status::unimplemented("list_flights is not yet supported"))
-    }
-
-    async fn poll_flight_info(
-        &self,
-        _request: Request<FlightDescriptor>,
-    ) -> Result<Response<PollInfo>, Status> {
-        Err(Status::unimplemented("poll_flight_info is not supported"))
-    }
-
-    async fn do_put(
-        &self,
-        _request: Request<Streaming<FlightData>>,
-    ) -> Result<Response<Self::DoPutStream>, Status> {
-        Err(Status::unimplemented(
-            "do_put is not supported (read-only server)",
-        ))
-    }
-
-    async fn do_exchange(
-        &self,
-        _request: Request<Streaming<FlightData>>,
-    ) -> Result<Response<Self::DoExchangeStream>, Status> {
-        Err(Status::unimplemented("do_exchange is not supported"))
-    }
-
-    async fn do_action(
-        &self,
-        _request: Request<Action>,
-    ) -> Result<Response<Self::DoActionStream>, Status> {
-        Err(Status::unimplemented("do_action is not supported"))
-    }
-
-    async fn list_actions(
-        &self,
-        _request: Request<Empty>,
-    ) -> Result<Response<Self::ListActionsStream>, Status> {
-        Err(Status::unimplemented("list_actions is not supported"))
     }
 }
 


### PR DESCRIPTION
Part of epic #1031. Depends on merged foundation (#1032).

- `observability` feature on cqlite-flight (not default). init+guard in main; subscriber = EnvFilter + fmt + feature-gated OTel layer; W3C TraceContextPropagator installed.
- Per-RPC spans (do_get/get_flight_info/get_schema/handshake/...); incoming gRPC `traceparent` extracted and set as span parent, so client trace → RPC span → query.execute → read-path spans. Handler bodies + status recording run inside `.instrument(span)` so failed RPC spans are tagged otel.status_code=ERROR.
- gRPC metrics: RPC_REQUESTS (method+status), RPC_DURATION, RPC_IN_FLIGHT (process-wide per-method atomics — correct under Tokio thread-hopping), RPC_ROWS, RPC_BYTES. Bounded labels (method∈fixed set normalized to slot, status∈ok/error) — never tickets/queries/payloads.

Validation: default + observability builds clean; clippy -D warnings clean (flight + core); 90 tests pass. roborev: 2 Medium (thread-local gauge, error-tagging-outside-span) fixed; final Low (label cardinality) fixed.

Closes #1041