### PR TITLE
feat(observability): Node.js bindings — otel option, per-query/streaming spans, traceparent, flush (#1040)

### DIFF
--- a/bindings/node/Cargo.toml
+++ b/bindings/node/Cargo.toml
@@ -15,6 +15,12 @@ crate-type = ["cdylib"]
 [features]
 default = []
 write-support = ["cqlite-core/write-support"]
+# OpenTelemetry export for the Node.js bindings (epic #1031, issue #1040).
+# OFF by default: enabling it pulls the OTel exporter stack into cqlite-core and
+# lets `tracing_layer()`/OTLP wiring compile. With it off, every observability
+# call site here is an inert no-op (config plumbing, span macros, and the metric
+# helpers stay available), so the binding builds and behaves identically.
+observability = ["cqlite-core/observability"]
 
 [dependencies]
 cqlite-core = { path = "../../cqlite-core", features = ["state_machine", "all-compression", "cli-helpers", "parquet"] }
@@ -27,6 +33,11 @@ chrono = { workspace = true }
 uuid = { version = "1.6", features = ["v4"] }
 base64 = "0.22"
 hex = "0.4"
+# Always-on: span macros (`tracing::info_span!`, `.instrument`) are used at the
+# binding boundary regardless of the `observability` feature. The OTel layer
+# that bridges these spans to OTLP is only composed when `observability` is on.
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [build-dependencies]
 napi-build = { workspace = true }

--- a/bindings/node/lib/index.d.ts
+++ b/bindings/node/lib/index.d.ts
@@ -374,6 +374,100 @@ export interface DatabaseOptions {
    * ```
    */
   writeDir?: string;
+
+  /**
+   * OpenTelemetry export options (epic #1031, issue #1040).
+   *
+   * When omitted, the `CQLITE_OTEL_*` environment variables are consulted.
+   * Telemetry stays disabled unless `enabled: true` is set (here or via env)
+   * AND the native addon was built with the `observability` Cargo feature.
+   *
+   * Observability is initialised **once per process** on the first
+   * `Database.open()`, so passing different `otel` options to a later open has
+   * no effect.
+   *
+   * @example
+   * ```typescript
+   * const db = await Database.open('/data', {
+   *   schema: 'schema.cql',
+   *   otel: { enabled: true, endpoint: 'http://collector:4317', protocol: 'grpc' },
+   * });
+   * ```
+   */
+  otel?: OtelOptions;
+
+  /**
+   * Incoming W3C `traceparent` header to parent this handle's per-call and
+   * per-stream spans under a remote trace (distributed-tracing propagation).
+   *
+   * Applied as the default parent for every `execute`, `executeNative`, and
+   * `executeStreaming` on the returned handle. Invalid/empty values are
+   * ignored. Only meaningful when telemetry is enabled and the addon was built
+   * with the `observability` feature.
+   *
+   * @example
+   * ```typescript
+   * const db = await Database.open('/data', {
+   *   schema: 'schema.cql',
+   *   otel: { enabled: true },
+   *   traceparent: '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
+   * });
+   * ```
+   */
+  traceparent?: string;
+}
+
+/**
+ * OpenTelemetry export options for the Node.js bindings (epic #1031, issue
+ * #1040).
+ *
+ * Any field left unset falls back to the corresponding `CQLITE_OTEL_*`
+ * environment variable, then to the foundation default. Exporters are only
+ * installed when the effective config has `enabled: true` AND the native addon
+ * was built with the `observability` feature.
+ */
+export interface OtelOptions {
+  /**
+   * Master enable switch. Unset defers to `CQLITE_OTEL_ENABLED`, then `false`.
+   */
+  enabled?: boolean;
+
+  /**
+   * OTLP collector endpoint: a gRPC endpoint or HTTP base URL.
+   * Unset defers to `CQLITE_OTEL_ENDPOINT`, then `http://localhost:4317`.
+   */
+  endpoint?: string;
+
+  /**
+   * Wire protocol: `"grpc"` (default) or `"http"`. Unrecognised values are
+   * ignored (the default/env value is kept).
+   */
+  protocol?: string;
+
+  /**
+   * `service.name` resource attribute.
+   * Unset defers to `CQLITE_OTEL_SERVICE_NAME`, then `cqlite`.
+   */
+  serviceName?: string;
+
+  /**
+   * `service.version` resource attribute.
+   * Unset defers to `CQLITE_OTEL_SERVICE_VERSION`, then the crate version.
+   */
+  serviceVersion?: string;
+
+  /**
+   * Trace-ID-ratio sampling probability in `[0.0, 1.0]` (clamped; non-finite
+   * values fall back to full sampling).
+   * Unset defers to `CQLITE_OTEL_SAMPLING_RATIO`, then `1.0`.
+   */
+  samplingRatio?: number;
+
+  /**
+   * Exporter export timeout in milliseconds.
+   * Unset defers to `CQLITE_OTEL_TIMEOUT_MS`, then `10000`.
+   */
+  timeoutMs?: number;
 }
 
 // ============================================================================

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cqlite/node",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cqlite/node",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^3.5.1",

--- a/bindings/node/src/database.rs
+++ b/bindings/node/src/database.rs
@@ -178,6 +178,24 @@ pub struct DatabaseOptions {
     /// Sub-directories `data/` and `wal/` are created automatically.
     #[napi(js_name = "writeDir")]
     pub write_dir: Option<String>,
+
+    /// OpenTelemetry export options (epic #1031, issue #1040).
+    ///
+    /// When omitted, the `CQLITE_OTEL_*` environment variables are consulted;
+    /// telemetry stays disabled unless `enabled: true` is set (here or via env)
+    /// AND the binding was built with the `observability` feature. The
+    /// foundation initialises ONCE per process on the first `open()`, so passing
+    /// `otel` on a later open has no effect.
+    pub otel: Option<crate::observability::OtelOptions>,
+
+    /// Incoming W3C `traceparent` header to parent this database's per-call and
+    /// per-stream spans under a remote trace (distributed-tracing propagation).
+    ///
+    /// Applied as the default parent for every `execute`/`executeNative`/
+    /// `executeStreaming` issued on this handle. Invalid/empty values are
+    /// ignored. Only meaningful when telemetry is enabled and the
+    /// `observability` feature is built.
+    pub traceparent: Option<String>,
 }
 
 /// Configuration for streaming query execution.
@@ -347,6 +365,9 @@ impl ParquetExportOptions {
 pub struct Database {
     inner: Arc<cqlite_core::Database>,
     closed: AtomicBool,
+    /// Default incoming W3C `traceparent` for this handle's per-call spans
+    /// (issue #1040). `None` when not supplied or invalid.
+    traceparent: Option<String>,
     /// Write engine, present only when `writable: true` was supplied to `open()`.
     /// Wrapped in Arc so it can be shared with async tasks.
     #[cfg(feature = "write-support")]
@@ -424,6 +445,19 @@ impl Database {
         options: Option<DatabaseOptions>,
     ) -> napi::Result<Database> {
         let path = PathBuf::from(&data_dir);
+
+        // Initialise observability ONCE per process from the open options (or the
+        // CQLITE_OTEL_* env fallback). Later opens are no-ops; the first wins.
+        // This must run before any span is created below so the OTel layer is
+        // composed in. Safe + inert when telemetry is disabled or the feature is
+        // off (issue #1040).
+        crate::observability::init_once(options.as_ref().and_then(|o| o.otel.as_ref()));
+
+        // Per-handle default traceparent for this database's per-call spans.
+        let traceparent = options
+            .as_ref()
+            .and_then(|o| o.traceparent.clone())
+            .filter(|t| !t.trim().is_empty());
 
         // Extract all options and build config
         let (schema_path, core_config, writable, write_dir) = if let Some(opts) = options {
@@ -629,6 +663,7 @@ impl Database {
         Ok(Database {
             inner: Arc::new(db),
             closed: AtomicBool::new(false),
+            traceparent,
             #[cfg(feature = "write-support")]
             write_engine: write_engine_opt,
             #[cfg(feature = "write-support")]
@@ -659,71 +694,90 @@ impl Database {
     /// ```
     #[napi]
     pub async fn execute(&self, query: String) -> napi::Result<QueryResult> {
+        use tracing::Instrument;
+
         self.ensure_open()?;
 
-        // Route DML statements to write engine when write support is compiled in.
-        // Use spawn_blocking so the Mutex lock + synchronous engine.execute() call
-        // does not stall the napi async executor thread (same pattern as flush_run).
-        #[cfg(feature = "write-support")]
-        if Self::is_dml_statement(&query) {
-            self.ensure_writable()?;
-            let we_clone = Arc::clone(
-                self.write_engine
-                    .as_ref()
-                    .expect("ensure_writable verified write_engine is Some"),
-            );
-            let elapsed_ms = tokio::task::spawn_blocking(move || {
-                let start = std::time::Instant::now();
-                let mut engine = we_clone
-                    .lock()
-                    .map_err(|_| simple_error("Write engine lock poisoned"))?;
-                engine.execute(&query).map_err(to_napi_error)?;
-                Ok::<u32, napi::Error>(start.elapsed().as_millis() as u32)
+        // Per-call span (issue #1040), parented under the handle's traceparent
+        // when one was supplied. We never hold a span guard across `.await`; the
+        // async work is `.instrument(span)`-ed instead.
+        let span = crate::observability::execute_span("execute", self.traceparent.as_deref());
+        let span_for_record = span.clone();
+
+        async move {
+            // Route DML statements to write engine when write support is compiled
+            // in. Use spawn_blocking so the Mutex lock + synchronous
+            // engine.execute() call does not stall the napi async executor thread.
+            #[cfg(feature = "write-support")]
+            if Self::is_dml_statement(&query) {
+                self.ensure_writable()?;
+                let we_clone = Arc::clone(
+                    self.write_engine
+                        .as_ref()
+                        .expect("ensure_writable verified write_engine is Some"),
+                );
+                let elapsed_ms = tokio::task::spawn_blocking(move || {
+                    let start = std::time::Instant::now();
+                    let mut engine = we_clone
+                        .lock()
+                        .map_err(|_| simple_error("Write engine lock poisoned"))?;
+                    engine.execute(&query).map_err(to_napi_error)?;
+                    Ok::<u32, napi::Error>(start.elapsed().as_millis() as u32)
+                })
+                .await
+                .map_err(|e| simple_error(format!("execute DML task panicked: {e}")))??;
+                crate::observability::record_rows(&span_for_record, 0);
+                return Ok(QueryResult {
+                    rows: vec![],
+                    row_count: 0,
+                    rows_affected: 1,
+                    execution_time_ms: elapsed_ms,
+                    columns: vec![],
+                });
+            }
+
+            let core_result = self.inner.execute(&query).await.map_err(|e| {
+                // Boundary error: record once here (subsystem = "node"), not in
+                // nested helpers, to avoid double counting with core.
+                crate::observability::record_boundary_error(&e);
+                to_napi_error(e)
+            })?;
+
+            // Convert rows to JSON values
+            let rows: Vec<serde_json::Value> = core_result
+                .rows
+                .iter()
+                .map(|row| {
+                    #[allow(deprecated)]
+                    let obj: serde_json::Map<String, serde_json::Value> = row
+                        .values
+                        .iter()
+                        .map(|(k, v)| (k.clone(), value_to_json(v)))
+                        .collect();
+                    serde_json::Value::Object(obj)
+                })
+                .collect();
+
+            // Convert column metadata
+            let columns: Vec<ColumnInfo> = core_result
+                .metadata
+                .columns
+                .iter()
+                .map(ColumnInfo::from_core)
+                .collect();
+
+            let row_count = rows.len() as u32;
+            crate::observability::record_rows(&span_for_record, row_count as u64);
+            Ok(QueryResult {
+                rows_affected: row_count,
+                row_count,
+                rows,
+                execution_time_ms: core_result.execution_time_ms as u32,
+                columns,
             })
-            .await
-            .map_err(|e| simple_error(format!("execute DML task panicked: {e}")))??;
-            return Ok(QueryResult {
-                rows: vec![],
-                row_count: 0,
-                rows_affected: 1,
-                execution_time_ms: elapsed_ms,
-                columns: vec![],
-            });
         }
-
-        let core_result = self.inner.execute(&query).await.map_err(to_napi_error)?;
-
-        // Convert rows to JSON values
-        let rows: Vec<serde_json::Value> = core_result
-            .rows
-            .iter()
-            .map(|row| {
-                #[allow(deprecated)]
-                let obj: serde_json::Map<String, serde_json::Value> = row
-                    .values
-                    .iter()
-                    .map(|(k, v)| (k.clone(), value_to_json(v)))
-                    .collect();
-                serde_json::Value::Object(obj)
-            })
-            .collect();
-
-        // Convert column metadata
-        let columns: Vec<ColumnInfo> = core_result
-            .metadata
-            .columns
-            .iter()
-            .map(ColumnInfo::from_core)
-            .collect();
-
-        let row_count = rows.len() as u32;
-        Ok(QueryResult {
-            rows_affected: row_count,
-            row_count,
-            rows,
-            execution_time_ms: core_result.execution_time_ms as u32,
-            columns,
-        })
+        .instrument(span)
+        .await
     }
 
     /// Get database statistics.
@@ -775,6 +829,11 @@ impl Database {
 
         // Shutdown the storage engine to release resources
         self.inner.shutdown().await.map_err(to_napi_error)?;
+
+        // Flush buffered telemetry promptly on a graceful close (issue #1040)
+        // rather than waiting for the process-exit Drop of the global guard.
+        // No-op when telemetry is disabled / the feature is off.
+        crate::observability::flush();
 
         Ok(())
     }
@@ -830,7 +889,14 @@ impl Database {
         query: String,
         config: Option<StreamingConfig>,
     ) -> napi::Result<crate::streaming::StreamingResult> {
+        use tracing::Instrument;
+
         self.ensure_open()?;
+
+        // Per-stream span (issue #1040). It is handed to the StreamingResult so
+        // rows yielded across `next()` iterations accumulate onto it, and it is
+        // finalised when iteration ends or the result is closed.
+        let span = crate::observability::streaming_span(self.traceparent.as_deref());
 
         // Convert config or use defaults
         let core_config = match config {
@@ -838,15 +904,23 @@ impl Database {
             None => cqlite_core::query::result::StreamingConfig::default(),
         };
 
-        // Execute streaming query via core library
-        let iter = self
-            .inner
-            .execute_streaming(&query, core_config)
-            .await
-            .map_err(to_napi_error)?;
+        // Execute streaming query via core library. The setup is instrumented by
+        // the stream span (no guard held across `.await`).
+        let span_for_iter = span.clone();
+        let iter = async move {
+            self.inner
+                .execute_streaming(&query, core_config)
+                .await
+                .map_err(|e| {
+                    crate::observability::record_boundary_error(&e);
+                    to_napi_error(e)
+                })
+        }
+        .instrument(span)
+        .await?;
 
-        // Create StreamingResult with shared runtime
-        crate::streaming::StreamingResult::new(iter)
+        // Create StreamingResult with shared runtime, carrying the stream span.
+        crate::streaming::StreamingResult::new(iter, span_for_iter)
     }
 
     /// Export the results of a CQL query to a Parquet file.
@@ -977,6 +1051,7 @@ impl Database {
         Ok(napi::bindgen_prelude::AsyncTask::new(ExecuteNativeTask {
             inner: self.inner.clone(),
             query,
+            traceparent: self.traceparent.clone(),
             #[cfg(feature = "write-support")]
             write_engine: self.write_engine.clone(),
         }))
@@ -1185,6 +1260,8 @@ impl Database {
 pub struct ExecuteNativeTask {
     inner: Arc<cqlite_core::Database>,
     query: String,
+    /// Per-handle default traceparent for the per-call span (issue #1040).
+    traceparent: Option<String>,
     /// Write engine handle, present only when write support is compiled and writable=true.
     #[cfg(feature = "write-support")]
     write_engine: Option<Arc<Mutex<cqlite_core::storage::write_engine::WriteEngine>>>,
@@ -1204,16 +1281,25 @@ impl napi::Task for ExecuteNativeTask {
     type JsValue = napi::JsObject;
 
     fn compute(&mut self) -> napi::Result<Self::Output> {
-        // Route DML to write engine when write support is present.
+        use tracing::Instrument;
+
+        // Per-call span (issue #1040), parented under the handle's traceparent.
+        let span =
+            crate::observability::execute_span("executeNative", self.traceparent.as_deref());
+
+        // Route DML to write engine when write support is present. This path is
+        // fully synchronous, so a span guard is correct (no `.await`).
         #[cfg(feature = "write-support")]
         if Database::is_dml_statement(&self.query) {
             if let Some(ref we) = self.write_engine {
+                let _entered = span.enter();
                 let start = std::time::Instant::now();
-                let mut engine = we
-                    .lock()
-                    .map_err(|_| simple_error("Write engine lock poisoned"))?;
+                let mut engine = we.lock().map_err(|_| {
+                    simple_error("Write engine lock poisoned")
+                })?;
                 engine.execute(&self.query).map_err(to_napi_error)?;
                 let elapsed_ms = start.elapsed().as_millis() as u32;
+                crate::observability::record_rows(&span, 0);
                 return Ok(QueryResultData {
                     rows: vec![],
                     execution_time_ms: elapsed_ms,
@@ -1223,11 +1309,23 @@ impl napi::Task for ExecuteNativeTask {
             }
         }
 
-        // Use global runtime for async execution
-        let result =
-            crate::runtime::block_on(self.inner.execute(&self.query)).map_err(to_napi_error)?;
+        // Use global runtime for async execution. The future is `.instrument`-ed
+        // by the span rather than holding a guard across the runtime boundary.
+        let span_for_record = span.clone();
+        let query = &self.query;
+        let inner = &self.inner;
+        let result = crate::runtime::block_on(
+            async move {
+                inner.execute(query).await.map_err(|e| {
+                    crate::observability::record_boundary_error(&e);
+                    to_napi_error(e)
+                })
+            }
+            .instrument(span),
+        )?;
 
         let row_count = result.rows.len() as u32;
+        crate::observability::record_rows(&span_for_record, row_count as u64);
         Ok(QueryResultData {
             rows: result.rows.iter().map(|r| r.values.clone()).collect(),
             execution_time_ms: result.execution_time_ms as u32,

--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -22,6 +22,7 @@
 
 mod database;
 mod error;
+mod observability;
 mod prepared;
 mod runtime;
 mod streaming;
@@ -36,6 +37,7 @@ pub use database::MaintenanceReport;
 pub use database::QueryResult;
 pub use database::StreamingConfig;
 pub use database::WriteStats;
+pub use observability::OtelOptions;
 pub use prepared::PreparedStatement;
 pub use prepared::PreparedStatementStats;
 pub use streaming::StreamingResult;

--- a/bindings/node/src/observability.rs
+++ b/bindings/node/src/observability.rs
@@ -155,25 +155,34 @@ static GUARD: OnceLock<ObservabilityGuard> = OnceLock::new();
 /// Always safe to call. With telemetry disabled or the feature off it installs
 /// an inert guard and a plain subscriber, so behaviour is unchanged.
 pub fn init_once(opts: Option<&OtelOptions>) {
-    if GUARD.get().is_some() {
-        return;
-    }
+    // Serialise the ENTIRE init path through `get_or_init`: the foundation
+    // `obs::init` (which mutates global OTel providers) and the subscriber
+    // install run AT MOST ONCE for the process, even under concurrent
+    // `Database.open()` from multiple worker threads. Computing the guard inside
+    // the closure means the winning thread's guard is the one stored, and no
+    // guard that owns live exporters is ever constructed-then-dropped while the
+    // globals still reference it: only the single closure run touches the
+    // foundation. Losing threads block until the winner finishes, then observe
+    // the already-initialised guard and do nothing.
+    GUARD.get_or_init(|| {
+        let cfg = match opts {
+            Some(o) => o.to_core(),
+            None => ObservabilityConfig::from_env(),
+        };
 
-    let cfg = match opts {
-        Some(o) => o.to_core(),
-        None => ObservabilityConfig::from_env(),
-    };
+        // `init` returns an inert guard for a disabled config and never installs
+        // a global subscriber itself, so it is safe to call unconditionally. A
+        // misconfigured exporter must never take down the host process: on error
+        // we fall back to an inert guard and continue without export.
+        let guard = obs::init(cfg).unwrap_or_else(|_| inert_guard());
 
-    // `init` returns an inert guard for a disabled config and never installs a
-    // global subscriber itself, so it is safe to call unconditionally. A
-    // misconfigured exporter must never take down the host process: on error we
-    // fall back to an inert guard and continue without export.
-    let guard = obs::init(cfg).unwrap_or_else(|_| inert_guard());
+        // Install the bridging subscriber from inside the same once-only closure
+        // so the provider set by `init` above is visible to `tracing_layer()`,
+        // and so the install also happens exactly once.
+        install_subscriber();
 
-    // If another thread won the race between the `get` check and here, keep the
-    // first guard; ours is simply dropped.
-    let _ = GUARD.set(guard);
-    install_subscriber();
+        guard
+    });
 }
 
 /// Build an inert guard for the error fall-back path. `init` on a disabled
@@ -184,26 +193,73 @@ fn inert_guard() -> ObservabilityGuard {
     obs::init(disabled).unwrap_or_else(|_| inert_guard())
 }
 
+/// Default per-layer filter for the OTLP span layer when `RUST_LOG` is unset.
+///
+/// Spans we want exported are emitted at INFO on the node crate
+/// (`node.execute` / `node.execute_streaming`) and at DEBUG/INFO on
+/// `cqlite_core` (read/write/compaction instrumentation). To guarantee those
+/// reach the OTel layer with no `RUST_LOG`, this allows DEBUG on both targets
+/// while leaving everything else `off`. It is applied ONLY to the OTel layer
+/// (via `with_filter`), never as a global registry filter — so it cannot gate
+/// any other layer, and since no fmt layer is attached, stdout/stderr stay quiet
+/// regardless. `OTEL_NODE_TARGET` matches this crate's compiled name (`-`→`_`).
+#[cfg(any(feature = "observability", test))]
+const OTEL_NODE_TARGET: &str = "cqlite_node";
+#[cfg(any(feature = "observability", test))]
+const OTEL_CORE_TARGET: &str = "cqlite_core";
+
+/// Build the directive string that allows the binding + core span targets at the
+/// level their spans are emitted, with everything else off.
+#[cfg(any(feature = "observability", test))]
+fn default_otel_directives() -> String {
+    format!("off,{OTEL_CORE_TARGET}=debug,{OTEL_NODE_TARGET}=debug")
+}
+
 /// Install the bridging `tracing` subscriber once. With the `observability`
 /// feature on, the OTel layer (live only after a successful `init`) is composed
 /// in so the per-call spans reach the OTLP exporter. `try_init` tolerates an
 /// already-installed subscriber (e.g. set by a host or a test).
+///
+/// The filter is attached as a PER-LAYER filter on the OTel layer rather than as
+/// a global registry filter, so it never gates other layers and — critically —
+/// the spans reach the OTel layer even when `RUST_LOG` is unset (a global `off`
+/// filter would otherwise drop every span before the layer could export it).
+/// `RUST_LOG`, when set, still overrides the default directives. No fmt layer is
+/// attached, so the Node process's stdout/stderr stay quiet by default.
 fn install_subscriber() {
-    use tracing_subscriber::layer::SubscriberExt;
     use tracing_subscriber::util::SubscriberInitExt;
-    use tracing_subscriber::EnvFilter;
-
-    // Honour RUST_LOG; otherwise stay quiet (the host owns log routing). We do
-    // not attach an fmt layer by default to avoid writing to the Node process's
-    // stderr unless the operator explicitly opts in via RUST_LOG.
-    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("off"));
-
-    let registry = tracing_subscriber::registry().with(env_filter);
 
     #[cfg(feature = "observability")]
-    let registry = registry.with(cqlite_core::observability::tracing_layer());
+    {
+        use tracing_subscriber::layer::SubscriberExt;
+        use tracing_subscriber::Layer;
 
-    let _ = registry.try_init();
+        // RUST_LOG overrides; otherwise default to allowing the binding + core
+        // span targets so the per-call/per-stream spans are exported with no
+        // RUST_LOG set.
+        let env_filter = env_filter_or_default();
+
+        let registry = tracing_subscriber::registry()
+            .with(cqlite_core::observability::tracing_layer().with_filter(env_filter));
+
+        let _ = registry.try_init();
+    }
+
+    // Without the `observability` feature the OTLP layer is compiled out and
+    // there is nothing to bridge; install a bare registry (no fmt layer) so the
+    // process stays quiet and the macros at the binding boundary remain no-ops.
+    #[cfg(not(feature = "observability"))]
+    {
+        let _ = tracing_subscriber::registry().try_init();
+    }
+}
+
+/// `RUST_LOG` when set, otherwise the default directives that allow the binding
+/// and core span targets so spans are exported even with no `RUST_LOG`.
+#[cfg(feature = "observability")]
+fn env_filter_or_default() -> tracing_subscriber::EnvFilter {
+    use tracing_subscriber::EnvFilter;
+    EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_otel_directives()))
 }
 
 /// Force-flush pending telemetry. Called from `Database.close()` so a graceful
@@ -328,5 +384,60 @@ mod tests {
         let err = cqlite_core::Error::corruption("x");
         record_boundary_error(&err);
         flush();
+    }
+
+    /// Finding 1: with no `RUST_LOG`, the default OTel directives MUST enable the
+    /// binding + core span targets at the level the spans are emitted, so the
+    /// per-call/per-stream spans reach the OTel layer (otherwise enabling `otel`
+    /// would export nothing). We install the default-directive `EnvFilter` as the
+    /// active subscriber and assert, via `tracing::enabled!`, that the binding's
+    /// INFO span target and a core DEBUG span target are enabled — while an
+    /// unrelated target is NOT — proving no blanket `off` filter swallows them.
+    #[test]
+    fn default_directives_enable_binding_and_core_spans_without_rust_log() {
+        use tracing::Level;
+        use tracing_subscriber::layer::SubscriberExt;
+        use tracing_subscriber::EnvFilter;
+
+        // Build the subscriber exactly as `install_subscriber` would when
+        // RUST_LOG is unset (the filter applied to the span layer). We attach the
+        // filter at the registry level here ONLY for the probe — it makes
+        // `tracing::enabled!` consult these directives without a live OTel layer.
+        let subscriber =
+            tracing_subscriber::registry().with(EnvFilter::new(default_otel_directives()));
+
+        tracing::subscriber::with_default(subscriber, || {
+            // node.execute / node.execute_streaming are emitted at INFO on the
+            // node crate target.
+            assert!(
+                tracing::enabled!(target: "cqlite_node", Level::INFO),
+                "node INFO span target must be enabled with default directives (no RUST_LOG)"
+            );
+            // Core read/write/compaction instrumentation includes DEBUG spans.
+            assert!(
+                tracing::enabled!(target: "cqlite_core", Level::DEBUG),
+                "core DEBUG span target must be enabled with default directives"
+            );
+            // Everything else stays off so we do not export unrelated noise.
+            assert!(
+                !tracing::enabled!(target: "some_other_crate", Level::INFO),
+                "unrelated targets must remain off under the default directives"
+            );
+        });
+    }
+
+    /// Finding 2: `init_once` must run the foundation init + subscriber install
+    /// at most once, even when called repeatedly (the production hazard is
+    /// concurrent `Database.open()`). A second call must be a no-op that leaves
+    /// the same guard installed.
+    #[test]
+    fn init_once_is_idempotent() {
+        // Default (disabled) config -> inert guard, no global providers touched.
+        init_once(None);
+        let first = GUARD.get().map(|g| g as *const _);
+        init_once(None);
+        let second = GUARD.get().map(|g| g as *const _);
+        assert!(first.is_some(), "guard installed after first init_once");
+        assert_eq!(first, second, "second init_once must not replace the guard");
     }
 }

--- a/bindings/node/src/observability.rs
+++ b/bindings/node/src/observability.rs
@@ -227,11 +227,10 @@ fn default_otel_directives() -> String {
 /// `RUST_LOG`, when set, still overrides the default directives. No fmt layer is
 /// attached, so the Node process's stdout/stderr stay quiet by default.
 fn install_subscriber() {
-    use tracing_subscriber::util::SubscriberInitExt;
-
     #[cfg(feature = "observability")]
     {
         use tracing_subscriber::layer::SubscriberExt;
+        use tracing_subscriber::util::SubscriberInitExt;
         use tracing_subscriber::Layer;
 
         // RUST_LOG overrides; otherwise default to allowing the binding + core
@@ -246,12 +245,12 @@ fn install_subscriber() {
     }
 
     // Without the `observability` feature the OTLP layer is compiled out and
-    // there is nothing to bridge; install a bare registry (no fmt layer) so the
-    // process stays quiet and the macros at the binding boundary remain no-ops.
-    #[cfg(not(feature = "observability"))]
-    {
-        let _ = tracing_subscriber::registry().try_init();
-    }
+    // there is nothing to bridge, so install NO subscriber at all. A bare
+    // `Registry` would actually ENABLE span callsites (its per-callsite interest
+    // is "always"), causing the binding/core spans to be constructed and stored
+    // on hot paths for nothing. With no global subscriber installed, the
+    // `tracing` span/event macros stay true no-ops, preserving the
+    // zero-cost-when-off contract.
 }
 
 /// `RUST_LOG` when set, otherwise the default directives that allow the binding

--- a/bindings/node/src/observability.rs
+++ b/bindings/node/src/observability.rs
@@ -1,0 +1,332 @@
+//! Observability wiring for the Node.js bindings (epic #1031, issue #1040).
+//!
+//! This module is the binding-side glue between the Node host and the
+//! always-available observability foundation in `cqlite_core::observability`
+//! (issues #1032/#1038). It does three things:
+//!
+//! 1. Exposes the [`OtelOptions`] napi object that callers pass on
+//!    [`crate::database::DatabaseOptions`] (or via the `CQLITE_OTEL_*` env
+//!    fallback) to configure OTLP export.
+//! 2. Initialises the foundation **once per process** ([`init_once`]): it maps
+//!    the options to a [`cqlite_core::observability::ObservabilityConfig`],
+//!    calls `observability::init`, stashes the returned guard
+//!    process-globally so its `Drop` flushes buffered telemetry at exit, and
+//!    installs a `tracing` subscriber that bridges the per-call spans to OTLP
+//!    (only when the `observability` feature is compiled in).
+//! 3. Provides small helpers used at the public binding boundary: building the
+//!    per-call/per-stream spans, parenting them under an incoming W3C
+//!    `traceparent`, recording the canonical query/error metrics, and flushing
+//!    on `close()`.
+//!
+//! Everything here is callable regardless of the `observability` feature: with
+//! the feature off the foundation helpers are inert no-ops and the OTLP layer is
+//! compiled out, so the binding builds and behaves identically.
+
+use std::sync::OnceLock;
+
+use cqlite_core::observability::{self as obs, ObservabilityConfig, ObservabilityGuard};
+
+/// OpenTelemetry options for the Node.js bindings.
+///
+/// Pass as `otel` on the open options:
+///
+/// ```javascript
+/// const db = await Database.open('/data', {
+///   schema: 'schema.cql',
+///   otel: { enabled: true, endpoint: 'http://collector:4317', protocol: 'grpc' },
+/// });
+/// ```
+///
+/// Any field left unset falls back to the corresponding `CQLITE_OTEL_*`
+/// environment variable, then to the foundation default (disabled,
+/// `http://localhost:4317`, gRPC, service name `cqlite`, full sampling). The
+/// foundation only installs exporters when the effective config has
+/// `enabled: true` AND the binding was built with the `observability` feature.
+#[napi_derive::napi(object)]
+#[derive(Clone, Default)]
+pub struct OtelOptions {
+    /// Master enable switch. When unset, defers to `CQLITE_OTEL_ENABLED` (then
+    /// the default, `false`). With telemetry disabled, `open()` installs no
+    /// exporters and per-call spans are dropped.
+    pub enabled: Option<bool>,
+
+    /// OTLP collector endpoint: a gRPC endpoint or HTTP base URL. Unset defers
+    /// to `CQLITE_OTEL_ENDPOINT` then `http://localhost:4317`.
+    pub endpoint: Option<String>,
+
+    /// Wire protocol: `"grpc"` (default) or `"http"`. Unrecognised values are
+    /// ignored (the default/env value is kept), matching the foundation.
+    pub protocol: Option<String>,
+
+    /// `service.name` resource attribute. Unset defers to
+    /// `CQLITE_OTEL_SERVICE_NAME` then `cqlite`.
+    #[napi(js_name = "serviceName")]
+    pub service_name: Option<String>,
+
+    /// `service.version` resource attribute. Unset defers to
+    /// `CQLITE_OTEL_SERVICE_VERSION` then the crate version.
+    #[napi(js_name = "serviceVersion")]
+    pub service_version: Option<String>,
+
+    /// Trace-ID-ratio sampling probability in `[0.0, 1.0]` (clamped;
+    /// non-finite values fall back to full sampling). Unset defers to
+    /// `CQLITE_OTEL_SAMPLING_RATIO` then `1.0`.
+    #[napi(js_name = "samplingRatio")]
+    pub sampling_ratio: Option<f64>,
+
+    /// Exporter export timeout in milliseconds. Unset defers to
+    /// `CQLITE_OTEL_TIMEOUT_MS` then `10000`.
+    #[napi(js_name = "timeoutMs")]
+    pub timeout_ms: Option<f64>,
+}
+
+impl OtelOptions {
+    /// Build a foundation [`ObservabilityConfig`] by layering explicitly-set
+    /// option fields over the `CQLITE_OTEL_*` env defaults.
+    ///
+    /// Starting from `from_env()` (which is itself layered over the documented
+    /// defaults) means an unset option transparently honours the env var, and an
+    /// explicit option always wins — the same precedence the CLI uses.
+    fn to_core(&self) -> ObservabilityConfig {
+        use cqlite_core::observability::OtelProtocol;
+        use std::time::Duration;
+
+        // Start from the env-derived config (itself layered over the documented
+        // defaults), then overwrite only explicitly-set option fields. The
+        // config's fields are all public, so we mutate them directly rather than
+        // round-tripping through the builder.
+        let mut cfg = ObservabilityConfig::from_env();
+
+        if let Some(enabled) = self.enabled {
+            cfg.enabled = enabled;
+        }
+        if let Some(ref endpoint) = self.endpoint {
+            if !endpoint.trim().is_empty() {
+                cfg.endpoint = endpoint.clone();
+            }
+        }
+        if let Some(ref protocol) = self.protocol {
+            if let Some(p) = OtelProtocol::parse(protocol) {
+                cfg.protocol = p;
+            }
+        }
+        if let Some(ref name) = self.service_name {
+            if !name.trim().is_empty() {
+                cfg.service_name = name.clone();
+            }
+        }
+        if let Some(ref version) = self.service_version {
+            if !version.trim().is_empty() {
+                cfg.service_version = version.clone();
+            }
+        }
+        if let Some(ratio) = self.sampling_ratio {
+            if ratio.is_finite() {
+                cfg.sampling_ratio = ratio.clamp(0.0, 1.0);
+            }
+        }
+        if let Some(ms) = self.timeout_ms {
+            if ms.is_finite() && ms >= 0.0 {
+                cfg.timeout = Duration::from_millis(ms as u64);
+            }
+        }
+
+        cfg
+    }
+}
+
+/// Subsystem label attached to all node-binding error metrics.
+pub const SUBSYSTEM: &str = "node";
+
+/// Process-global observability guard. Set exactly once by [`init_once`]; held
+/// for the lifetime of the process so its `Drop` flushes and shuts down the
+/// exporters when Node tears the addon down. `OnceLock` makes the
+/// initialise-once contract explicit and races-free across worker threads.
+static GUARD: OnceLock<ObservabilityGuard> = OnceLock::new();
+
+/// Initialise the observability foundation exactly once for this process.
+///
+/// The first `Database.open()` wins: it maps `opts` (or the env fallback) to a
+/// config, calls `observability::init`, stores the guard process-globally, and
+/// installs the bridging `tracing` subscriber. Subsequent calls are no-ops, so
+/// later opens with different `otel` options do not reconfigure exporters — this
+/// matches the foundation's global-provider model (one exporter per process).
+///
+/// Always safe to call. With telemetry disabled or the feature off it installs
+/// an inert guard and a plain subscriber, so behaviour is unchanged.
+pub fn init_once(opts: Option<&OtelOptions>) {
+    if GUARD.get().is_some() {
+        return;
+    }
+
+    let cfg = match opts {
+        Some(o) => o.to_core(),
+        None => ObservabilityConfig::from_env(),
+    };
+
+    // `init` returns an inert guard for a disabled config and never installs a
+    // global subscriber itself, so it is safe to call unconditionally. A
+    // misconfigured exporter must never take down the host process: on error we
+    // fall back to an inert guard and continue without export.
+    let guard = obs::init(cfg).unwrap_or_else(|_| inert_guard());
+
+    // If another thread won the race between the `get` check and here, keep the
+    // first guard; ours is simply dropped.
+    let _ = GUARD.set(guard);
+    install_subscriber();
+}
+
+/// Build an inert guard for the error fall-back path. `init` on a disabled
+/// config yields one and never errors, so we recurse into a guaranteed-inert
+/// config rather than touching the foundation's private constructor.
+fn inert_guard() -> ObservabilityGuard {
+    let disabled = ObservabilityConfig::builder().enabled(false).build();
+    obs::init(disabled).unwrap_or_else(|_| inert_guard())
+}
+
+/// Install the bridging `tracing` subscriber once. With the `observability`
+/// feature on, the OTel layer (live only after a successful `init`) is composed
+/// in so the per-call spans reach the OTLP exporter. `try_init` tolerates an
+/// already-installed subscriber (e.g. set by a host or a test).
+fn install_subscriber() {
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::util::SubscriberInitExt;
+    use tracing_subscriber::EnvFilter;
+
+    // Honour RUST_LOG; otherwise stay quiet (the host owns log routing). We do
+    // not attach an fmt layer by default to avoid writing to the Node process's
+    // stderr unless the operator explicitly opts in via RUST_LOG.
+    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("off"));
+
+    let registry = tracing_subscriber::registry().with(env_filter);
+
+    #[cfg(feature = "observability")]
+    let registry = registry.with(cqlite_core::observability::tracing_layer());
+
+    let _ = registry.try_init();
+}
+
+/// Force-flush pending telemetry. Called from `Database.close()` so a graceful
+/// close exports buffered spans/metrics promptly rather than waiting for the
+/// process-exit `Drop`. No-op when uninitialised or inert.
+pub fn flush() {
+    if let Some(g) = GUARD.get() {
+        g.force_flush();
+    }
+}
+
+/// Record the rows produced by a call onto its span as the bounded `rows`
+/// field, so the per-call span carries result size without any new metric
+/// series.
+///
+/// The query-level row/duration **metrics** (`cqlite.query.rows`,
+/// `cqlite.query.duration`) are emitted by the core query engine (#1035);
+/// re-emitting them here would double-count, so the binding only annotates its
+/// span. Never attach query text or keys.
+pub fn record_rows(span: &tracing::Span, rows: u64) {
+    span.record("rows", rows);
+}
+
+/// Record an error that escaped the public binding boundary.
+///
+/// Increments `cqlite.errors.total` keyed by `{category, subsystem="node"}`
+/// and marks the active span errored. Call this ONLY at the outermost binding
+/// boundary (where the `cqlite_core::Error` is about to become a JS error), not
+/// nested, so it never double-counts with core's own `record_error` sites.
+pub fn record_boundary_error(err: &cqlite_core::Error) {
+    obs::record_error(err, SUBSYSTEM);
+}
+
+/// Build the per-call span for `execute`/`executeNative`, optionally parented
+/// under an incoming W3C `traceparent`. The span carries only bounded fields
+/// (an `op` label and, after the call, `rows`); never the query text/keys.
+pub fn execute_span(op: &'static str, traceparent: Option<&str>) -> tracing::Span {
+    let span = tracing::info_span!("node.execute", op = op, rows = tracing::field::Empty);
+    obs::set_span_parent_from_traceparent(&span, traceparent);
+    span
+}
+
+/// Build the per-stream span for `executeStreaming`, optionally parented under
+/// an incoming W3C `traceparent`. `rows` is filled in incrementally as the
+/// stream yields and finalised when iteration ends.
+pub fn streaming_span(traceparent: Option<&str>) -> tracing::Span {
+    let span = tracing::info_span!("node.execute_streaming", rows = tracing::field::Empty);
+    obs::set_span_parent_from_traceparent(&span, traceparent);
+    span
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn options_default_to_env_config() {
+        // With no fields set, to_core mirrors from_env (disabled by default).
+        let opts = OtelOptions::default();
+        let cfg = opts.to_core();
+        // Default env (assuming CQLITE_OTEL_* unset in the test env) is disabled.
+        // We only assert the mapping is structurally sane, not the env value.
+        let _ = cfg.enabled;
+        assert!(cfg.sampling_ratio.is_finite());
+    }
+
+    #[test]
+    fn explicit_fields_override() {
+        let opts = OtelOptions {
+            enabled: Some(true),
+            endpoint: Some("http://collector:4318".to_string()),
+            protocol: Some("http".to_string()),
+            service_name: Some("svc".to_string()),
+            service_version: Some("9.9.9".to_string()),
+            sampling_ratio: Some(0.5),
+            timeout_ms: Some(2500.0),
+        };
+        let cfg = opts.to_core();
+        assert!(cfg.enabled);
+        assert_eq!(cfg.endpoint, "http://collector:4318");
+        assert_eq!(cfg.service_name, "svc");
+        assert_eq!(cfg.service_version, "9.9.9");
+        assert_eq!(cfg.sampling_ratio, 0.5);
+        assert_eq!(cfg.timeout.as_millis(), 2500);
+    }
+
+    #[test]
+    fn non_finite_and_blank_fields_ignored() {
+        let opts = OtelOptions {
+            enabled: Some(true),
+            endpoint: Some("   ".to_string()),
+            protocol: Some("carrier-pigeon".to_string()),
+            service_name: Some("".to_string()),
+            service_version: None,
+            sampling_ratio: Some(f64::NAN),
+            timeout_ms: Some(f64::INFINITY),
+        };
+        let cfg = opts.to_core();
+        // Blank endpoint/name ignored -> defaults retained.
+        assert!(!cfg.endpoint.trim().is_empty());
+        assert!(!cfg.service_name.trim().is_empty());
+        // Bad protocol ignored -> default grpc kept.
+        assert_eq!(
+            cfg.protocol,
+            cqlite_core::observability::OtelProtocol::Grpc
+        );
+        // Non-finite ratio ignored -> sane finite value.
+        assert!(cfg.sampling_ratio.is_finite());
+    }
+
+    #[test]
+    fn spans_build_without_panicking() {
+        let _s = execute_span("execute", None);
+        let _s2 = execute_span("executeNative", Some("invalid-traceparent"));
+        let _s3 = streaming_span(None);
+    }
+
+    #[test]
+    fn metrics_helpers_are_callable() {
+        let span = streaming_span(None);
+        record_rows(&span, 3);
+        let err = cqlite_core::Error::corruption("x");
+        record_boundary_error(&err);
+        flush();
+    }
+}

--- a/bindings/node/src/streaming.rs
+++ b/bindings/node/src/streaming.rs
@@ -71,11 +71,20 @@ pub struct StreamingResult {
     inner: Arc<Mutex<Option<cqlite_core::query::result::QueryResultIterator>>>,
     /// Cached column metadata for the result set.
     columns: Vec<ColumnInfo>,
+    /// Per-stream span (issue #1040). Shared with each `next()` task so rows
+    /// yielded across iterations accumulate, and finalised on
+    /// exhaustion/close. `Span` is cheap to clone and is a no-op when telemetry
+    /// is disabled.
+    span: tracing::Span,
 }
 
 impl StreamingResult {
-    /// Create a new StreamingResult from a core QueryResultIterator.
-    pub fn new(iter: cqlite_core::query::result::QueryResultIterator) -> napi::Result<Self> {
+    /// Create a new StreamingResult from a core QueryResultIterator and the
+    /// owning per-stream span.
+    pub fn new(
+        iter: cqlite_core::query::result::QueryResultIterator,
+        span: tracing::Span,
+    ) -> napi::Result<Self> {
         // Cache column metadata from iterator
         let columns: Vec<ColumnInfo> = iter
             .metadata
@@ -94,7 +103,15 @@ impl StreamingResult {
         Ok(Self {
             inner: Arc::new(Mutex::new(Some(iter))),
             columns,
+            span,
         })
+    }
+
+    /// Record the final rows-yielded count onto the stream span. Reads the
+    /// authoritative count from the iterator (or 0 once cleaned up).
+    fn finalize_span(&self) {
+        let rows = self.rows_received().unwrap_or(0);
+        self.span.record("rows", rows as u64);
     }
 }
 
@@ -109,6 +126,9 @@ pub enum NextResult {
 /// Async task for fetching the next row.
 pub struct NextTask {
     inner: Arc<Mutex<Option<cqlite_core::query::result::QueryResultIterator>>>,
+    /// Stream span, finalised with the row count when the stream ends or errors
+    /// (issue #1040).
+    span: tracing::Span,
 }
 
 impl napi::Task for NextTask {
@@ -116,6 +136,8 @@ impl napi::Task for NextTask {
     type JsValue = JsObject;
 
     fn compute(&mut self) -> napi::Result<Self::Output> {
+        use tracing::Instrument;
+
         // Acquire lock - use unwrap_or_else to handle poisoned mutex by clearing the iterator
         let mut guard = self.inner.lock().unwrap_or_else(|poisoned| {
             // Mutex was poisoned by a panic in another thread
@@ -131,19 +153,26 @@ impl napi::Task for NextTask {
             None => return Ok(NextResult::Done),
         };
 
-        // Get next row from core iterator using the global runtime
-        match crate::runtime::block_on(iter.next_async()) {
+        // Get next row from core iterator using the global runtime. The fetch is
+        // `.instrument`-ed by the stream span (no guard across the runtime).
+        let next = crate::runtime::block_on(iter.next_async().instrument(self.span.clone()));
+        match next {
             Some(Ok(row)) => {
                 // Take ownership of values - no clone needed
                 Ok(NextResult::Value(row.values))
             }
             Some(Err(e)) => {
-                // Error occurred - cleanup and propagate
+                // Error occurred - record at the boundary, finalise span, cleanup.
+                crate::observability::record_boundary_error(&e);
+                let yielded: u64 = iter.rows_received();
+                self.span.record("rows", yielded);
                 *guard = None;
                 Err(to_napi_error(e))
             }
             None => {
-                // Stream exhausted - cleanup
+                // Stream exhausted - finalise span with the total yielded, cleanup.
+                let yielded: u64 = iter.rows_received();
+                self.span.record("rows", yielded);
                 *guard = None;
                 Ok(NextResult::Done)
             }
@@ -183,9 +212,10 @@ impl StreamingResult {
     /// @returns Promise resolving to iterator result object
     #[napi]
     pub fn next(&self) -> AsyncTask<NextTask> {
-        // Clone the Arc reference to share with the task
+        // Clone the Arc reference + span to share with the task
         AsyncTask::new(NextTask {
             inner: self.inner.clone(),
+            span: self.span.clone(),
         })
     }
 
@@ -234,6 +264,11 @@ impl StreamingResult {
     /// This method is synchronous and does not need to be awaited.
     #[napi]
     pub fn close(&self) -> napi::Result<()> {
+        // Finalise the stream span with the rows yielded so far before the
+        // iterator is dropped (issue #1040). Reads the count first so an early
+        // `break` from a `for await` loop still records progress.
+        self.finalize_span();
+
         // Use unwrap_or_else to handle poisoned mutex gracefully
         let mut guard = self.inner.lock().unwrap_or_else(|poisoned| {
             // Recover by taking ownership

--- a/cqlite-core/src/observability/mod.rs
+++ b/cqlite-core/src/observability/mod.rs
@@ -218,6 +218,30 @@ pub fn record_result<T>(subsystem: &'static str, result: Result<T>) -> Result<T>
     result
 }
 
+/// Parent a `tracing` span under a remote trace described by a W3C
+/// [`traceparent`](https://www.w3.org/TR/trace-context/#traceparent-header)
+/// header string (issues #1039/#1040/#1041).
+///
+/// Hosts (the Python/Node bindings, the Flight server) frequently receive an
+/// incoming `traceparent` from a caller's tracer and want the per-call CQLite
+/// span to attach to that remote trace. This helper extracts the W3C trace
+/// context with the standard [`TraceContextPropagator`] and sets it as the
+/// parent of `span` via `tracing-opentelemetry`'s `set_parent`.
+///
+/// It is always callable: when the `observability` feature is off — or when
+/// `traceparent` is `None`/empty/unparseable — it is a no-op, so call sites
+/// stay identical across builds. Pass the per-open or per-call traceparent
+/// straight from the binding boundary; never synthesise one.
+#[inline]
+pub fn set_span_parent_from_traceparent(span: &tracing::Span, traceparent: Option<&str>) {
+    #[cfg(feature = "observability")]
+    otel::set_span_parent_from_traceparent(span, traceparent);
+    #[cfg(not(feature = "observability"))]
+    {
+        let _ = (span, traceparent);
+    }
+}
+
 /// Inert observability guard returned by [`init`] when the `observability`
 /// feature is disabled. Flushes and installs nothing.
 #[cfg(not(feature = "observability"))]

--- a/cqlite-core/src/observability/otel.rs
+++ b/cqlite-core/src/observability/otel.rs
@@ -404,6 +404,50 @@ pub(crate) fn mark_span_error(category: crate::observability::ErrorCategory) {
     span.set_attribute(catalog::attr::ERROR_CATEGORY, category.as_str());
 }
 
+/// Extract a W3C `traceparent` header and set the resulting remote context as
+/// the parent of `span`. No-op when `traceparent` is absent/empty/unparseable.
+///
+/// Uses the standard [`TraceContextPropagator`] to parse the header into an
+/// OpenTelemetry [`Context`](opentelemetry::Context), then
+/// `tracing-opentelemetry`'s `set_parent` to link the `tracing` span to that
+/// remote span. Only the `traceparent` header is consulted (no baggage /
+/// tracestate), keeping the surface minimal and the behaviour identical to
+/// other CQLite hosts.
+pub(crate) fn set_span_parent_from_traceparent(span: &tracing::Span, traceparent: Option<&str>) {
+    use opentelemetry::propagation::{Extractor, TextMapPropagator};
+    use opentelemetry::trace::TraceContextExt;
+    use opentelemetry_sdk::propagation::TraceContextPropagator;
+    use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+    let header = match traceparent {
+        Some(h) if !h.trim().is_empty() => h,
+        _ => return,
+    };
+
+    /// Single-header carrier exposing only `traceparent` to the propagator.
+    struct TraceParentCarrier<'a>(&'a str);
+    impl Extractor for TraceParentCarrier<'_> {
+        fn get(&self, key: &str) -> Option<&str> {
+            if key.eq_ignore_ascii_case("traceparent") {
+                Some(self.0)
+            } else {
+                None
+            }
+        }
+        fn keys(&self) -> Vec<&str> {
+            vec!["traceparent"]
+        }
+    }
+
+    let propagator = TraceContextPropagator::new();
+    let cx = propagator.extract(&TraceParentCarrier(header));
+    // Only re-parent when extraction produced a valid remote span context;
+    // otherwise leave the span attached to its in-process parent.
+    if cx.span().span_context().is_valid() {
+        span.set_parent(cx);
+    }
+}
+
 /// Convenience for the default flush timeout used by tests.
 #[allow(dead_code)]
 pub(crate) const DEFAULT_FLUSH: Duration = Duration::from_secs(1);
@@ -425,5 +469,22 @@ mod tests {
         // Just exercise the builder for coverage; sampler has no public getter.
         let _ = build_sampler(0.5);
         let _ = build_sampler(2.0); // clamps internally
+    }
+
+    #[test]
+    fn traceparent_none_empty_and_invalid_are_noops() {
+        // Must not panic for absent / blank / malformed headers.
+        let span = tracing::info_span!("test");
+        set_span_parent_from_traceparent(&span, None);
+        set_span_parent_from_traceparent(&span, Some("   "));
+        set_span_parent_from_traceparent(&span, Some("not-a-traceparent"));
+    }
+
+    #[test]
+    fn traceparent_valid_header_is_accepted() {
+        // A well-formed W3C traceparent should parse and re-parent without panic.
+        let span = tracing::info_span!("test");
+        let valid = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        set_span_parent_from_traceparent(&span, Some(valid));
     }
 }


### PR DESCRIPTION
Part of epic #1031. Depends on merged foundation (#1032).

- `observability` feature on the node crate (`cqlite-core/observability`), not default.
- `DatabaseOptions.otel` (enabled/endpoint/protocol/serviceName/serviceVersion/samplingRatio/timeoutMs, layered over CQLITE_OTEL_* env) + `traceparent`. Per-call node.execute/node.executeNative/node.execute_streaming spans (streaming span finalized on exhaustion/error/close). W3C traceparent parents the Rust spans under the caller's Node OTel trace. Flush on close().
- Adds a small always-callable core helper set_span_parent_from_traceparent (feature-gated impl). No new catalog metrics (reuses core query metrics, no double count). TS defs updated.
- Exactly-once process init via OnceLock::get_or_init (no provider-shutdown race); OTel layer uses a per-layer filter that allows binding+core span targets with no RUST_LOG (spans actually export); with the feature OFF no subscriber is installed so span macros stay no-ops.

Validation: default + observability builds clean; clippy -D warnings clean (both); 49 lib tests + 375 jest (with datasets) pass. roborev clean (job 1201) after High (default filter) + Medium (init race) + Medium (off-path subscriber) fixes.

Closes #1040