### PR TITLE
docs(observability): local OTel stack, config reference, metric catalog, dashboards, quickstart (#1042)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,11 @@ Welcome to the CQLite documentation hub. This directory holds technical document
 - **[Performance Methodology](performance.md)** - Benchmark reproducibility and the CI perf gate
 - **[Profiling Guide](profiling.md)** - Flamegraphs, heap profiling, and the `scripts/profile.sh` improvement loop
 
+### 📡 Runtime Observability
+- **[Observability Overview](observability/README.md)** - One-command local OTel stack (Collector + Jaeger + Prometheus + Grafana)
+- **[Observability Quickstart](observability/quickstart.md)** - End-to-end: bring up the stack, run a query, view traces and dashboards
+- **[Observability Configuration Reference](observability/configuration.md)** - `CQLITE_OTEL_*` env vars, per-surface config, and the metric naming/units catalog
+
 ### 💻 Development Documentation
 - **[Contributing Guide](development/contributing.md)** - How to contribute to CQLite
 - **[Development Guide](development/DEVELOPMENT.md)** - Local development workflow

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -1,0 +1,53 @@
+# CQLite Runtime Observability
+
+CQLite emits OpenTelemetry traces and metrics at runtime so you can see query,
+read, write, compaction, and Arrow Flight behavior in a real telemetry backend.
+This directory makes that usable end-to-end.
+
+> This is the **runtime** observability documentation. For **offline** CPU/heap
+> profiling (flamegraphs, dhat, `scripts/profile.sh`), see the
+> [Profiling Guide](../profiling.md).
+
+## Contents
+
+- **[Quickstart](quickstart.md)** — `docker compose up`, run a query/flush with
+  telemetry on, view the trace in Jaeger and the dashboards in Grafana.
+- **[Configuration Reference](configuration.md)** — shared `CQLITE_OTEL_*` env
+  vars, per-surface config (CLI, Python, Node.js, Arrow Flight), and the full
+  metric naming/units catalog.
+- **[`docker-compose.yml`](docker-compose.yml)** — one-command local stack:
+  OpenTelemetry Collector + Jaeger + Prometheus + Grafana.
+- **`otel-collector/`, `prometheus/`, `grafana/`** — provisioning for the stack
+  (collector pipelines, Prometheus scrape config, Grafana datasources +
+  auto-loaded dashboards).
+
+## One command
+
+```bash
+docker compose -f docs/observability/docker-compose.yml up
+```
+
+Then point CQLite at it:
+
+```bash
+CQLITE_OTEL_ENABLED=true CQLITE_OTEL_ENDPOINT=http://localhost:4317 \
+  cqlite --schema test-data/schemas/basic-types.cql \
+  --data-dir test-data/datasets/sstables \
+  --query "SELECT * FROM test_basic.simple_table LIMIT 5"
+```
+
+- Jaeger (traces): http://localhost:16686
+- Grafana (dashboards): http://localhost:3000
+- Prometheus (raw metrics): http://localhost:9090
+
+See the [Quickstart](quickstart.md) for the full walkthrough.
+
+## Source of truth
+
+The metric names, units, attribute keys, and env vars documented here are
+generated to match the implementation exactly:
+
+- Metric catalog + attributes + units: `cqlite-core/src/observability/catalog.rs`
+- Env-var config: `cqlite-core/src/observability/config.rs`
+- Per-surface config: `cqlite-cli/src/cli_types.rs` / `cqlite-cli/src/config.rs`,
+  `bindings/python/src/observability.rs`, `cqlite-flight/src/obs.rs`.

--- a/docs/observability/configuration.md
+++ b/docs/observability/configuration.md
@@ -134,9 +134,36 @@ with cqlite.open(
 
 ### Node.js
 
-The Node.js bindings do not yet expose a dedicated OTel option object; configure
-them through the shared `CQLITE_OTEL_*` environment variables before launching
-the process. (Tracked under epic #1031.)
+`Database.open(dir, options)` accepts an optional `otel` object (and a
+`traceparent` string), each field layered over the shared `CQLITE_OTEL_*`
+environment variables (env is the baseline; the object overrides). Requires a
+build with the `observability` feature.
+
+```js
+const { Database } = require('@cqlite/node');
+const db = await Database.open('test-data/datasets/sstables', {
+  schema: 'test-data/schemas/basic-types.cql',
+  otel: {
+    enabled: true,
+    endpoint: 'http://localhost:4317',
+    protocol: 'grpc',          // 'grpc' | 'http'
+    serviceName: 'cqlite-node',
+    serviceVersion: '0.12.0',
+    samplingRatio: 1.0,
+    timeoutMs: 10000,
+  },
+  // Optional W3C traceparent to parent the Rust spans under your Node trace:
+  traceparent: '00-<trace-id>-<span-id>-01',
+});
+```
+
+Each `otel` field is optional and falls back to the matching `CQLITE_OTEL_*`
+env var, then the built-in default. `Database.close()` flushes telemetry. Per
+call (`execute` / `executeNative` / `executeStreaming`) a `node.execute*` span
+is emitted; streaming spans record rows yielded. Source:
+`bindings/node/src/observability.rs`, `bindings/node/src/database.rs`.
+
+You can also configure purely through the shared environment variables:
 
 ```bash
 CQLITE_OTEL_ENABLED=true \

--- a/docs/observability/configuration.md
+++ b/docs/observability/configuration.md
@@ -1,0 +1,269 @@
+# Observability Configuration Reference
+
+CQLite emits OpenTelemetry traces and metrics at runtime. This page is the
+configuration reference for every surface (shared env vars, CLI, Python, Node.js,
+Arrow Flight) and the canonical metric naming/units catalog.
+
+> This complements — it does not replace — the offline
+> [Profiling Guide](../profiling.md), which covers flamegraphs and heap
+> profiling with `scripts/profile.sh`.
+
+The runtime observability foundation must be compiled in: build with the
+`observability` feature on the relevant crate to enable OTLP export. Without it,
+all telemetry calls are inert no-ops, and configuration still parses but exports
+nothing.
+
+---
+
+## Shared environment variables (`CQLITE_OTEL_*`)
+
+These are read by every surface through
+`cqlite_core::observability::ObservabilityConfig::from_env`. Booleans accept
+`1/0`, `true/false`, `yes/no`, `on/off` (case-insensitive). Source of truth:
+`cqlite-core/src/observability/config.rs`.
+
+| Variable | Type | Default | Meaning |
+|----------|------|---------|---------|
+| `CQLITE_OTEL_ENABLED` | bool | `false` | Master switch; when false, `init` is a no-op even with the feature on. |
+| `CQLITE_OTEL_ENDPOINT` | string | `http://localhost:4317` | OTLP collector endpoint (gRPC) or base URL (HTTP). |
+| `CQLITE_OTEL_PROTOCOL` | enum | `grpc` | `grpc` or `http` (HTTP/protobuf). |
+| `CQLITE_OTEL_SERVICE_NAME` | string | `cqlite` | `service.name` resource attribute. |
+| `CQLITE_OTEL_SERVICE_VERSION` | string | crate version | `service.version` resource attribute. |
+| `CQLITE_OTEL_SAMPLING_RATIO` | f64 | `1.0` | Trace-ID-ratio sampling probability, clamped to `[0.0, 1.0]`. |
+| `CQLITE_OTEL_TIMEOUT_MS` | u64 | `10000` | Exporter export timeout in milliseconds. |
+
+Unparseable values fall back to the documented default rather than erroring, so
+a typo never crashes the host process.
+
+Copy-paste example (point any surface at the local stack):
+
+```bash
+export CQLITE_OTEL_ENABLED=true
+export CQLITE_OTEL_ENDPOINT=http://localhost:4317
+export CQLITE_OTEL_PROTOCOL=grpc
+export CQLITE_OTEL_SERVICE_NAME=cqlite
+export CQLITE_OTEL_SAMPLING_RATIO=1.0
+export CQLITE_OTEL_TIMEOUT_MS=10000
+```
+
+---
+
+## Per-surface configuration
+
+Every surface ultimately builds the same
+`cqlite_core::observability::ObservabilityConfig`. Each starts from the
+`CQLITE_OTEL_*` environment as a baseline, then applies surface-specific
+overrides.
+
+### CLI
+
+The `cqlite` CLI exposes one `--otel-*` flag per setting. Each flag carries its
+`CQLITE_OTEL_*` env fallback (the explicit flag wins). Precedence is
+`config file < env < flag`. Source: `cqlite-cli/src/cli_types.rs`.
+
+| Flag | Value | Env fallback |
+|------|-------|--------------|
+| `--otel-enabled` | `BOOL` | `CQLITE_OTEL_ENABLED` |
+| `--otel-endpoint` | `URL` | `CQLITE_OTEL_ENDPOINT` |
+| `--otel-protocol` | `PROTO` (`grpc`/`http`) | `CQLITE_OTEL_PROTOCOL` |
+| `--otel-service-name` | `NAME` | `CQLITE_OTEL_SERVICE_NAME` |
+| `--otel-service-version` | `VER` | `CQLITE_OTEL_SERVICE_VERSION` |
+| `--otel-sampling-ratio` | `RATIO` | `CQLITE_OTEL_SAMPLING_RATIO` |
+| `--otel-timeout-ms` | `MS` | `CQLITE_OTEL_TIMEOUT_MS` |
+
+```bash
+cqlite \
+  --otel-enabled true \
+  --otel-endpoint http://localhost:4317 \
+  --otel-protocol grpc \
+  --otel-service-name cqlite-cli \
+  --schema test-data/schemas/basic-types.cql \
+  --data-dir test-data/datasets/sstables \
+  --query "SELECT * FROM test_basic.simple_table LIMIT 5" \
+  --out json
+```
+
+The CLI config file also has an `[observability]` section
+(`cqlite-cli/src/config.rs`). Keys mirror the env vars (without the
+`CQLITE_OTEL_` prefix); all keys are optional and fall through to core defaults:
+
+```toml
+[observability]
+enabled = true
+endpoint = "http://localhost:4317"
+protocol = "grpc"
+service_name = "cqlite-cli"
+service_version = "0.12.0"
+sampling_ratio = 1.0
+timeout_ms = 10000
+```
+
+### Python
+
+`cqlite.open(...)` takes an optional `otel_config` dict (layered over the
+`CQLITE_OTEL_*` environment) and an optional W3C `traceparent` string used as the
+default parent for every per-call span. `execute()` /
+`execute_streaming()` also accept a per-call `traceparent` that overrides the
+open-time default. Source: `bindings/python/src/observability.rs`,
+`bindings/python/src/database.rs`.
+
+Recognised `otel_config` keys (unknown keys raise `ValueError`):
+`enabled`, `endpoint`, `protocol` (`grpc`/`http`), `service_name`,
+`service_version`, `sampling_ratio`, `timeout_ms`.
+
+```python
+import cqlite
+
+with cqlite.open(
+    "test-data/datasets/sstables",
+    schema="test-data/schemas/basic-types.cql",
+    otel_config={
+        "enabled": True,
+        "endpoint": "http://localhost:4317",
+        "protocol": "grpc",
+        "service_name": "cqlite-python",
+        "sampling_ratio": 1.0,
+        "timeout_ms": 10000,
+    },
+    # Optional: re-parent CQLite spans under your existing trace.
+    traceparent="00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+) as db:
+    for row in db.execute("SELECT * FROM test_basic.simple_table LIMIT 5"):
+        print(row.to_dict())
+```
+
+### Node.js
+
+The Node.js bindings do not yet expose a dedicated OTel option object; configure
+them through the shared `CQLITE_OTEL_*` environment variables before launching
+the process. (Tracked under epic #1031.)
+
+```bash
+CQLITE_OTEL_ENABLED=true \
+CQLITE_OTEL_ENDPOINT=http://localhost:4317 \
+CQLITE_OTEL_SERVICE_NAME=cqlite-node \
+node app.js
+```
+
+### Arrow Flight server
+
+`cqlite-flight` reads the shared `CQLITE_OTEL_*` environment at startup via
+`ObservabilityConfig::from_env()` and installs the exporter for the process
+lifetime. It also propagates the incoming W3C `traceparent` gRPC metadata so a
+client's distributed trace continues into CQLite. Source:
+`cqlite-flight/src/main.rs`, `cqlite-flight/src/obs.rs`.
+
+```bash
+CQLITE_OTEL_ENABLED=true \
+CQLITE_OTEL_ENDPOINT=http://localhost:4317 \
+CQLITE_OTEL_PROTOCOL=grpc \
+CQLITE_OTEL_SERVICE_NAME=cqlite-flight \
+cqlite-flight --listen 0.0.0.0:8815
+```
+
+---
+
+## Metric naming / units catalog
+
+Generated to match `cqlite-core/src/observability/catalog.rs` exactly. Names are
+dot-separated under the `cqlite.` root; units use UCUM annotations
+(`{row}`, `By`, `s`, `1`, `{partition}`, `{sstable}`, `{tombstone}`, `{error}`).
+
+> **Prometheus name mangling.** The OTel Collector's Prometheus exporter
+> sanitises dotted names to underscores, appends `_total` to counters, and adds
+> unit suffixes (`_seconds` for `s`, `_bytes` for `By`). For example,
+> `cqlite.read.rows` → `cqlite_read_rows_total`,
+> `cqlite.query.duration` → `cqlite_query_duration_seconds_bucket/_sum/_count`.
+> The provided Grafana dashboard uses the sanitised forms.
+
+### Read path
+
+| Metric | Instrument | Unit | Bounded attributes |
+|--------|-----------|------|--------------------|
+| `cqlite.read.rows` | counter | `{row}` | `cqlite.sstable.format` |
+| `cqlite.read.bytes` | counter | `By` | `cqlite.sstable.format`, `cqlite.compression` |
+| `cqlite.read.partitions` | counter | `{partition}` | `cqlite.sstable.format` |
+| `cqlite.read.duration` | histogram | `s` | `cqlite.sstable.format` |
+| `cqlite.read.partition_lookup.total` | counter | `1` | `cqlite.result`, `cqlite.query.access_path`, `cqlite.sstable.format` |
+| `cqlite.read.bloom.checks` | counter | `1` | `cqlite.result`, `cqlite.sstable.format` |
+| `cqlite.storage.open.sstables` | counter | `{sstable}` | (none) |
+| `cqlite.storage.open.bytes` | counter | `By` | (none) |
+| `cqlite.storage.open.tables` | counter | `1` | (none) |
+| `cqlite.sstables.open` | gauge | `{sstable}` | `cqlite.sstable.format` |
+
+### Query engine
+
+| Metric | Instrument | Unit | Bounded attributes |
+|--------|-----------|------|--------------------|
+| `cqlite.query.duration` | histogram | `s` | `cqlite.subsystem` |
+| `cqlite.query.rows` | counter | `{row}` | `cqlite.query.access_path`, `cqlite.query.plan_type` |
+| `cqlite.query.rows_scanned` | counter | `{row}` | `cqlite.query.access_path` |
+
+### Write path
+
+| Metric | Instrument | Unit | Bounded attributes |
+|--------|-----------|------|--------------------|
+| `cqlite.write.mutations` | counter | `{row}` | (none) |
+| `cqlite.write.partitions` | counter | `{partition}` | (none) |
+| `cqlite.write.bytes` | counter | `By` | (none) |
+| `cqlite.memtable.size_bytes` | gauge | `By` | (none) |
+| `cqlite.memtable.rows` | gauge | `{row}` | (none) |
+| `cqlite.wal.sync.duration` | histogram | `s` | (none) |
+| `cqlite.flush.duration` | histogram | `s` | (none) |
+| `cqlite.flush.rows` | counter | `{row}` | (none) |
+| `cqlite.flush.bytes` | counter | `By` | (none) |
+| `cqlite.flush.sstables` | counter | `{sstable}` | (none) |
+| `cqlite.compression.ratio` | histogram | `1` | `cqlite.compression` |
+
+### Compaction & maintenance
+
+| Metric | Instrument | Unit | Bounded attributes |
+|--------|-----------|------|--------------------|
+| `cqlite.compaction.duration` | histogram | `s` | (none) |
+| `cqlite.compaction.rows_merged` | counter | `{row}` | (none) |
+| `cqlite.compaction.bytes_written` | counter | `By` | (none) |
+| `cqlite.compaction.sstables_in` | counter | `{sstable}` | (none) |
+| `cqlite.compaction.sstables_out` | counter | `{sstable}` | (none) |
+| `cqlite.compaction.tombstones_purged` | counter | `{tombstone}` | (none) |
+| `cqlite.compaction.lag` | gauge | `{sstable}` | (none) |
+| `cqlite.compaction.finalize.duration` | histogram | `s` | (none) |
+| `cqlite.compaction.budget.requested` | histogram | `s` | (none) |
+| `cqlite.compaction.budget.consumed` | histogram | `s` | (none) |
+
+### Errors
+
+| Metric | Instrument | Unit | Bounded attributes |
+|--------|-----------|------|--------------------|
+| `cqlite.errors.total` | counter | `{error}` | `cqlite.error.category`, `cqlite.subsystem` |
+
+### Arrow Flight gRPC service
+
+| Metric | Instrument | Unit | Bounded attributes |
+|--------|-----------|------|--------------------|
+| `cqlite.rpc.requests` | counter | `1` | `cqlite.rpc.method`, `cqlite.rpc.status` |
+| `cqlite.rpc.duration` | histogram | `s` | `cqlite.rpc.method`, `cqlite.rpc.status` |
+| `cqlite.rpc.in_flight` | gauge | `1` | `cqlite.rpc.method` |
+| `cqlite.rpc.rows` | counter | `{row}` | `cqlite.rpc.method` |
+| `cqlite.rpc.bytes` | counter | `By` | `cqlite.rpc.method` |
+
+### Bounded attribute keys
+
+These are the only attribute keys CQLite attaches to catalog metrics; each has a
+closed value space so cardinality stays bounded. Source:
+`cqlite-core/src/observability/catalog.rs` (`mod attr`).
+
+| Attribute key | Value space |
+|---------------|-------------|
+| `cqlite.error.category` | low-cardinality error category (≈10 values) |
+| `cqlite.subsystem` | e.g. `reader`, `query`, `compaction`, `python`, `flight` |
+| `cqlite.sstable.format` | `big`, `bti` |
+| `cqlite.compression` | `lz4`, `snappy`, `none`, … |
+| `cqlite.result` | `hit`, `miss` |
+| `cqlite.read.lookup_route` | `index`, `bti_trie` |
+| `cqlite.query.access_path` | `full_scan`, `partition_lookup`, `multi_partition_lookup`, `clustering_slice`, `fallback_full_scan` |
+| `cqlite.query.plan_type` | `table_scan`, `point_lookup`, `index_scan`, `range_scan`, `aggregation` |
+| `cqlite.rpc.method` | fixed `FlightService` method set (`do_get`, `get_flight_info`, `get_schema`, `handshake`, …) |
+| `cqlite.rpc.status` | `ok`, `error` |
+
+> Unbounded values (raw error messages, partition keys, full query text) are
+> NEVER attached as attributes or span fields.

--- a/docs/observability/docker-compose.yml
+++ b/docs/observability/docker-compose.yml
@@ -1,0 +1,74 @@
+# Local OpenTelemetry stack for CQLite runtime observability (epic #1031, issue #1042).
+#
+# One command brings up a complete, working telemetry backend wired to the OTLP
+# endpoint CQLite exports to:
+#
+#   docker compose -f docs/observability/docker-compose.yml up
+#
+# Components:
+#   - otel-collector : receives OTLP (gRPC 4317 / HTTP 4318) from CQLite, fans
+#                      traces out to Jaeger and exposes metrics for Prometheus.
+#   - jaeger         : trace UI at http://localhost:16686
+#   - prometheus     : scrapes the collector's Prometheus exporter; UI at
+#                      http://localhost:9090
+#   - grafana        : dashboards at http://localhost:3000 (anonymous admin),
+#                      Prometheus + Jaeger datasources and the CQLite dashboards
+#                      auto-provisioned.
+#
+# Point CQLite at the collector with:
+#   CQLITE_OTEL_ENABLED=true CQLITE_OTEL_ENDPOINT=http://localhost:4317
+# (the default endpoint is already http://localhost:4317, gRPC).
+#
+# Image versions are pinned for reproducibility.
+
+services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.110.0
+    container_name: cqlite-otel-collector
+    command: ["--config=/etc/otelcol/config.yaml"]
+    volumes:
+      - ./otel-collector/config.yaml:/etc/otelcol/config.yaml:ro
+    ports:
+      - "4317:4317"   # OTLP gRPC  (CQLITE_OTEL_PROTOCOL=grpc, the default)
+      - "4318:4318"   # OTLP HTTP  (CQLITE_OTEL_PROTOCOL=http)
+      - "8889:8889"   # Prometheus exporter (scraped by Prometheus)
+    depends_on:
+      - jaeger
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.62.0
+    container_name: cqlite-jaeger
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+    ports:
+      - "16686:16686" # Jaeger UI
+      # 4317/4318 are owned by the collector above; the collector forwards
+      # traces to Jaeger over its internal OTLP port 4317 (see collector config).
+
+  prometheus:
+    image: prom/prometheus:v2.55.1
+    container_name: cqlite-prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - "9090:9090"   # Prometheus UI
+    depends_on:
+      - otel-collector
+
+  grafana:
+    image: grafana/grafana:11.3.0
+    container_name: cqlite-grafana
+    environment:
+      # Anonymous access so the dashboards open without a login prompt locally.
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+    ports:
+      - "3000:3000"   # Grafana UI
+    depends_on:
+      - prometheus

--- a/docs/observability/grafana/dashboards/cqlite-overview.json
+++ b/docs/observability/grafana/dashboards/cqlite-overview.json
@@ -1,0 +1,269 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Starter CQLite runtime signals: throughput, latency, error rate. Metric names match cqlite-core/src/observability/catalog.rs. The OTel Collector Prometheus exporter sanitises dotted names to underscores, appends _total to counters, and unit suffixes (_seconds for s, _bytes for By).",
+  "editable": true,
+  "graphTooltip": 1,
+  "schemaVersion": 39,
+  "tags": ["cqlite", "observability"],
+  "templating": {
+    "list": [
+      {
+        "current": { "text": "Prometheus", "value": "cqlite-prometheus" },
+        "name": "DS_PROMETHEUS",
+        "label": "Prometheus",
+        "type": "datasource",
+        "query": "prometheus",
+        "hide": 0
+      }
+    ]
+  },
+  "time": { "from": "now-15m", "to": "now" },
+  "refresh": "5s",
+  "title": "CQLite — Overview (Throughput / Latency / Errors)",
+  "uid": "cqlite-overview",
+  "panels": [
+    {
+      "type": "row",
+      "title": "Throughput",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }
+    },
+    {
+      "type": "timeseries",
+      "title": "Read rows/sec (cqlite.read.rows)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "rps" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 1 },
+      "targets": [
+        {
+          "expr": "sum(rate(cqlite_read_rows_total[1m]))",
+          "legendFormat": "read rows/s",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Query rows returned/sec (cqlite.query.rows)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "rps" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 1 },
+      "targets": [
+        {
+          "expr": "sum(rate(cqlite_query_rows_total[1m]))",
+          "legendFormat": "query rows/s",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Mutations/sec & Flush rows/sec (cqlite.write.mutations, cqlite.flush.rows)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "rps" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 1 },
+      "targets": [
+        {
+          "expr": "sum(rate(cqlite_write_mutations_total[1m]))",
+          "legendFormat": "mutations/s",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(cqlite_flush_rows_total[1m]))",
+          "legendFormat": "flush rows/s",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Compaction rows merged/sec (cqlite.compaction.rows_merged)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "rps" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 9 },
+      "targets": [
+        {
+          "expr": "sum(rate(cqlite_compaction_rows_merged_total[1m]))",
+          "legendFormat": "compaction rows merged/s",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "RPC rows streamed/sec (cqlite.rpc.rows)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "rps" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 9 },
+      "targets": [
+        {
+          "expr": "sum(rate(cqlite_rpc_rows_total[1m])) by (cqlite_rpc_method)",
+          "legendFormat": "{{cqlite_rpc_method}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Read bytes/sec (cqlite.read.bytes)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "Bps" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 9 },
+      "targets": [
+        {
+          "expr": "sum(rate(cqlite_read_bytes_total[1m]))",
+          "legendFormat": "read bytes/s",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Latency (p50 / p95 / p99)",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 17 }
+    },
+    {
+      "type": "timeseries",
+      "title": "Query duration (cqlite.query.duration)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 18 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(cqlite_query_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(cqlite_query_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(cqlite_query_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Flush duration (cqlite.flush.duration)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 18 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(cqlite_flush_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(cqlite_flush_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(cqlite_flush_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Compaction duration (cqlite.compaction.duration)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 26 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(cqlite_compaction_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(cqlite_compaction_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(cqlite_compaction_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "WAL fsync duration (cqlite.wal.sync.duration)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 26 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(cqlite_wal_sync_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(cqlite_wal_sync_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(cqlite_wal_sync_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Error rate",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 34 }
+    },
+    {
+      "type": "timeseries",
+      "title": "Errors/sec by category (cqlite.errors.total)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "errps" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 35 },
+      "targets": [
+        {
+          "expr": "sum(rate(cqlite_errors_total[1m])) by (cqlite_error_category)",
+          "legendFormat": "{{cqlite_error_category}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Errors/sec by subsystem (cqlite.errors.total)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "errps" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 35 },
+      "targets": [
+        {
+          "expr": "sum(rate(cqlite_errors_total[1m])) by (cqlite_subsystem)",
+          "legendFormat": "{{cqlite_subsystem}}",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/observability/grafana/provisioning/dashboards/dashboards.yml
+++ b/docs/observability/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,16 @@
+# Grafana dashboard provisioning for the CQLite local stack (issue #1042).
+# Auto-loads every dashboard JSON found under /var/lib/grafana/dashboards.
+
+apiVersion: 1
+
+providers:
+  - name: cqlite
+    orgId: 1
+    folder: CQLite
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/docs/observability/grafana/provisioning/datasources/datasources.yml
+++ b/docs/observability/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,18 @@
+# Grafana datasource provisioning for the CQLite local stack (issue #1042).
+# Both datasources are auto-loaded on Grafana startup.
+
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    uid: cqlite-prometheus
+
+  - name: Jaeger
+    type: jaeger
+    access: proxy
+    url: http://jaeger:16686
+    uid: cqlite-jaeger

--- a/docs/observability/otel-collector/config.yaml
+++ b/docs/observability/otel-collector/config.yaml
@@ -1,0 +1,51 @@
+# OpenTelemetry Collector config for the CQLite local stack (issue #1042).
+#
+# Receives OTLP traces + metrics from CQLite (any surface: CLI, Python, Node,
+# Arrow Flight), exports traces to Jaeger and metrics to a Prometheus scrape
+# endpoint.
+
+receivers:
+  # CQLite's OTLP exporter targets this receiver. gRPC is the default
+  # (CQLITE_OTEL_PROTOCOL=grpc, port 4317); HTTP/protobuf is on 4318.
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  # Small batches keep the local UI responsive for ad-hoc runs.
+  batch:
+    timeout: 1s
+
+exporters:
+  # Traces -> Jaeger (OTLP gRPC into the all-in-one's collector port).
+  otlp/jaeger:
+    endpoint: jaeger:4317
+    tls:
+      insecure: true
+
+  # Metrics -> Prometheus pull endpoint scraped by the prometheus service.
+  prometheus:
+    endpoint: 0.0.0.0:8889
+    # Keep CQLite's dotted metric names intact (cqlite.read.rows) — Prometheus
+    # itself sanitises them to cqlite_read_rows for queries; the dashboards use
+    # the sanitised form.
+    resource_to_telemetry_conversion:
+      enabled: true
+
+  # Handy when debugging the pipeline locally.
+  debug:
+    verbosity: normal
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp/jaeger, debug]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheus, debug]

--- a/docs/observability/prometheus/prometheus.yml
+++ b/docs/observability/prometheus/prometheus.yml
@@ -1,0 +1,13 @@
+# Prometheus scrape config for the CQLite local stack (issue #1042).
+#
+# The OpenTelemetry Collector re-exports CQLite's OTLP metrics on a Prometheus
+# pull endpoint (port 8889); Prometheus scrapes that.
+
+global:
+  scrape_interval: 5s
+  evaluation_interval: 5s
+
+scrape_configs:
+  - job_name: cqlite-otel-collector
+    static_configs:
+      - targets: ["otel-collector:8889"]

--- a/docs/observability/quickstart.md
+++ b/docs/observability/quickstart.md
@@ -1,0 +1,136 @@
+# Observability Quickstart
+
+End-to-end: bring up a local OpenTelemetry stack, run a CQLite query/flush with
+telemetry on, then view the trace in Jaeger and the dashboards in Grafana.
+
+Prerequisites: Docker (with `docker compose`), a CQLite build with the
+`observability` feature, and the test datasets fetched
+(`bash test-data/scripts/fetch-datasets.sh`).
+
+---
+
+## 1. Start the local OTel stack
+
+One command brings up the OpenTelemetry Collector, Jaeger, Prometheus, and
+Grafana:
+
+```bash
+docker compose -f docs/observability/docker-compose.yml up
+```
+
+Endpoints once it is healthy:
+
+| Service | URL | Purpose |
+|---------|-----|---------|
+| OTLP gRPC | `http://localhost:4317` | CQLite exports here (default) |
+| OTLP HTTP | `http://localhost:4318` | CQLite exports here with `--otel-protocol http` |
+| Jaeger UI | http://localhost:16686 | traces |
+| Prometheus | http://localhost:9090 | raw metrics |
+| Grafana | http://localhost:3000 | dashboards (anonymous admin) |
+
+The "CQLite — Overview" dashboard auto-loads in Grafana under the **CQLite**
+folder.
+
+---
+
+## 2. Run CQLite with telemetry on
+
+Build the CLI with the `observability` feature, then run a query pointed at the
+local collector. `CQLITE_OTEL_ENDPOINT` defaults to `http://localhost:4317`, so
+enabling is the only required flag:
+
+```bash
+cargo build --package cqlite-cli --features observability
+
+CQLITE_OTEL_ENABLED=true \
+CQLITE_OTEL_ENDPOINT=http://localhost:4317 \
+CQLITE_OTEL_SERVICE_NAME=cqlite-cli \
+  cargo run --package cqlite-cli --features observability -- \
+  --schema test-data/schemas/basic-types.cql \
+  --data-dir test-data/datasets/sstables \
+  --query "SELECT * FROM test_basic.simple_table LIMIT 5" \
+  --out json
+```
+
+To exercise the write path (flush) metrics as well, build with both features and
+run a flush:
+
+```bash
+cargo build --package cqlite-cli --features "write-support,observability"
+
+CQLITE_OTEL_ENABLED=true \
+  cargo run --package cqlite-cli --features "write-support,observability" -- \
+  --writable --write-dir /tmp/cqlite-write \
+  --schema test-data/schemas/basic-types.cql \
+  --flush
+```
+
+For the Arrow Flight server, set the same env vars before starting it; for
+Python, pass `otel_config={"enabled": True}` to `cqlite.open(...)`. See the
+[Configuration Reference](configuration.md) for per-surface details.
+
+---
+
+## 3. View the trace in Jaeger
+
+Open http://localhost:16686, pick the `cqlite-cli` service, and click **Find
+Traces**. A `SELECT` produces a span tree like:
+
+```
+query.execute                       (root span for the CLI; plan_type attribute)
+└─ query.table_scan                 (or query.point_lookup / query.range_scan)
+   └─ sstable.partition_lookup.index   (BIG)  or  sstable.partition_lookup.bti_trie  (BTI)
+```
+
+When the query arrives over the Arrow Flight server instead of the CLI, the same
+tree nests under the per-RPC span, and the client's `traceparent` is honored:
+
+```
+flight.rpc (do_get)
+└─ query.execute
+   └─ query.table_scan
+      └─ sstable.partition_lookup.index
+```
+
+(SSTable open emits its own `sstable.reader.open*` spans the first time a table
+is read.)
+
+---
+
+## 4. View the dashboards in Grafana
+
+Open http://localhost:3000, go to **Dashboards → CQLite → CQLite — Overview**.
+Three signal groups populate after a few queries/flushes:
+
+- **Throughput** — read rows/sec (`cqlite.read.rows`), query rows/sec
+  (`cqlite.query.rows`), mutations/sec (`cqlite.write.mutations`), flush rows/sec
+  (`cqlite.flush.rows`), compaction rows merged/sec
+  (`cqlite.compaction.rows_merged`).
+- **Latency** — p50/p95/p99 of `cqlite.query.duration`, `cqlite.flush.duration`,
+  `cqlite.compaction.duration`, `cqlite.wal.sync.duration`.
+- **Error rate** — `cqlite.errors.total` broken out by `cqlite.error.category`
+  and `cqlite.subsystem`.
+
+Metrics take a few seconds to appear (Prometheus scrapes the collector every
+5s). If a panel is empty, confirm in Prometheus (http://localhost:9090) that a
+series such as `cqlite_read_rows_total` exists — that confirms the collector is
+receiving CQLite's OTLP metrics.
+
+---
+
+## 5. Tear down
+
+```bash
+docker compose -f docs/observability/docker-compose.yml down
+```
+
+## Troubleshooting
+
+- **No data anywhere.** Confirm the CLI was built `--features observability` and
+  that `CQLITE_OTEL_ENABLED=true`. Without the feature, telemetry is an inert
+  no-op.
+- **Traces but no metrics (or vice-versa).** Check the collector logs
+  (`docker compose -f docs/observability/docker-compose.yml logs otel-collector`);
+  the `debug` exporter prints received spans/metrics.
+- **Connection refused on 4317.** The collector may still be starting, or
+  another process owns the port. `docker compose ... ps` shows container health.

--- a/website/src/content/docs/user-docs/index.md
+++ b/website/src/content/docs/user-docs/index.md
@@ -30,6 +30,7 @@ daemon required.
 ### Topics
 
 - [Write Support](/cqlite/user-docs/write-support/) — offline SSTable writing, flush, compaction (M5)
+- [Observability](/cqlite/user-docs/observability/) — runtime OpenTelemetry traces/metrics, local stack, config, metric catalog
 - [Limitations](/cqlite/user-docs/limitations/) — what CQLite can and cannot read (format matrix, known gaps)
 - [Troubleshooting](/cqlite/user-docs/troubleshooting/) — common problems and fixes
 - [Use Cases](/cqlite/user-docs/use-cases/) — Cassandra sidecar, data science, services, operational scenarios

--- a/website/src/content/docs/user-docs/observability.md
+++ b/website/src/content/docs/user-docs/observability.md
@@ -1,0 +1,209 @@
+---
+title: Observability
+description: Runtime OpenTelemetry traces and metrics — one-command local stack, configuration for every surface, and the metric naming/units catalog.
+sidebar:
+  label: Observability
+  order: 8
+---
+
+# Observability
+
+CQLite emits OpenTelemetry **traces** and **metrics** at runtime so you can see
+query, read, write, compaction, and Arrow Flight behavior in a real telemetry
+backend. This page covers the one-command local stack, configuration for every
+surface, and the metric catalog.
+
+This is the *runtime* observability guide. For *offline* CPU/heap profiling
+(flamegraphs, dhat), see the profiling docs in the repository
+(`docs/profiling.md`).
+
+The runtime foundation must be compiled in: build with the `observability`
+feature on the relevant crate. Without it, telemetry calls are inert no-ops.
+
+## One-command local stack
+
+A ready-to-run Docker Compose stack — OpenTelemetry Collector + Jaeger +
+Prometheus + Grafana — lives in the repository under
+[`docs/observability/`](https://github.com/pmcfadin/cqlite/tree/main/docs/observability).
+
+```bash
+docker compose -f docs/observability/docker-compose.yml up
+```
+
+| Service | URL | Purpose |
+|---------|-----|---------|
+| OTLP gRPC | `http://localhost:4317` | CQLite exports here (default) |
+| OTLP HTTP | `http://localhost:4318` | with `CQLITE_OTEL_PROTOCOL=http` |
+| Jaeger UI | `http://localhost:16686` | traces |
+| Prometheus | `http://localhost:9090` | raw metrics |
+| Grafana | `http://localhost:3000` | dashboards (anonymous admin) |
+
+The "CQLite — Overview" dashboard (throughput, latency, error rate) auto-loads in
+Grafana under the **CQLite** folder.
+
+Then point CQLite at it:
+
+```bash
+CQLITE_OTEL_ENABLED=true CQLITE_OTEL_ENDPOINT=http://localhost:4317 \
+  cqlite --schema test-data/schemas/basic-types.cql \
+  --data-dir test-data/datasets/sstables \
+  --query "SELECT * FROM test_basic.simple_table LIMIT 5"
+```
+
+A `SELECT` produces this span tree in Jaeger:
+
+```
+query.execute
+└─ query.table_scan            (or query.point_lookup / query.range_scan)
+   └─ sstable.partition_lookup.index   (BIG)  or  sstable.partition_lookup.bti_trie  (BTI)
+```
+
+Over Arrow Flight the same tree nests under the per-RPC span and honors the
+client's `traceparent`:
+
+```
+flight.rpc (do_get)
+└─ query.execute
+   └─ query.table_scan
+      └─ sstable.partition_lookup.index
+```
+
+## Shared environment variables (`CQLITE_OTEL_*`)
+
+Read by every surface. Booleans accept `1/0`, `true/false`, `yes/no`, `on/off`.
+
+| Variable | Type | Default | Meaning |
+|----------|------|---------|---------|
+| `CQLITE_OTEL_ENABLED` | bool | `false` | Master switch; when false, init is a no-op. |
+| `CQLITE_OTEL_ENDPOINT` | string | `http://localhost:4317` | OTLP collector endpoint (gRPC) or base URL (HTTP). |
+| `CQLITE_OTEL_PROTOCOL` | enum | `grpc` | `grpc` or `http` (HTTP/protobuf). |
+| `CQLITE_OTEL_SERVICE_NAME` | string | `cqlite` | `service.name` resource attribute. |
+| `CQLITE_OTEL_SERVICE_VERSION` | string | crate version | `service.version` resource attribute. |
+| `CQLITE_OTEL_SAMPLING_RATIO` | f64 | `1.0` | Trace-ID-ratio sampling probability, clamped to `[0.0, 1.0]`. |
+| `CQLITE_OTEL_TIMEOUT_MS` | u64 | `10000` | Exporter export timeout in milliseconds. |
+
+## Per-surface configuration
+
+### CLI
+
+One `--otel-*` flag per setting, each with a `CQLITE_OTEL_*` env fallback
+(explicit flag wins; precedence is `config file < env < flag`):
+`--otel-enabled`, `--otel-endpoint`, `--otel-protocol`, `--otel-service-name`,
+`--otel-service-version`, `--otel-sampling-ratio`, `--otel-timeout-ms`.
+
+```bash
+cqlite --otel-enabled true --otel-endpoint http://localhost:4317 \
+  --otel-protocol grpc --otel-service-name cqlite-cli \
+  --schema test-data/schemas/basic-types.cql \
+  --data-dir test-data/datasets/sstables \
+  --query "SELECT * FROM test_basic.simple_table LIMIT 5"
+```
+
+The CLI config file also has an `[observability]` section (keys mirror the env
+vars without the prefix): `enabled`, `endpoint`, `protocol`, `service_name`,
+`service_version`, `sampling_ratio`, `timeout_ms`.
+
+```toml
+[observability]
+enabled = true
+endpoint = "http://localhost:4317"
+protocol = "grpc"
+service_name = "cqlite-cli"
+sampling_ratio = 1.0
+timeout_ms = 10000
+```
+
+### Python
+
+`cqlite.open(...)` takes an optional `otel_config` dict (layered over the
+environment) and a default `traceparent`; `execute()` / `execute_streaming()`
+accept a per-call `traceparent`. Recognised `otel_config` keys: `enabled`,
+`endpoint`, `protocol`, `service_name`, `service_version`, `sampling_ratio`,
+`timeout_ms` (unknown keys raise `ValueError`).
+
+```python
+import cqlite
+
+with cqlite.open(
+    "test-data/datasets/sstables",
+    schema="test-data/schemas/basic-types.cql",
+    otel_config={"enabled": True, "endpoint": "http://localhost:4317",
+                 "service_name": "cqlite-python"},
+    traceparent="00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+) as db:
+    for row in db.execute("SELECT * FROM test_basic.simple_table LIMIT 5"):
+        print(row.to_dict())
+```
+
+### Node.js
+
+Configure via the shared `CQLITE_OTEL_*` environment variables before launching
+the process (a dedicated option object is tracked under epic #1031):
+
+```bash
+CQLITE_OTEL_ENABLED=true CQLITE_OTEL_ENDPOINT=http://localhost:4317 \
+  CQLITE_OTEL_SERVICE_NAME=cqlite-node node app.js
+```
+
+### Arrow Flight server
+
+Reads the shared `CQLITE_OTEL_*` environment at startup and propagates the
+incoming W3C `traceparent` gRPC metadata into CQLite's spans.
+
+```bash
+CQLITE_OTEL_ENABLED=true CQLITE_OTEL_ENDPOINT=http://localhost:4317 \
+  CQLITE_OTEL_SERVICE_NAME=cqlite-flight cqlite-flight --listen 0.0.0.0:8815
+```
+
+## Metric catalog
+
+Names are dot-separated under `cqlite.`; units use UCUM annotations. The OTel
+Collector's Prometheus exporter sanitises dotted names to underscores, appends
+`_total` to counters, and adds unit suffixes (`_seconds` for `s`, `_bytes` for
+`By`) — e.g. `cqlite.read.rows` → `cqlite_read_rows_total`.
+
+| Metric | Instrument | Unit | Bounded attributes |
+|--------|-----------|------|--------------------|
+| `cqlite.read.rows` | counter | `{row}` | `cqlite.sstable.format` |
+| `cqlite.read.bytes` | counter | `By` | `cqlite.sstable.format`, `cqlite.compression` |
+| `cqlite.read.partitions` | counter | `{partition}` | `cqlite.sstable.format` |
+| `cqlite.read.duration` | histogram | `s` | `cqlite.sstable.format` |
+| `cqlite.read.partition_lookup.total` | counter | `1` | `cqlite.result`, `cqlite.query.access_path`, `cqlite.sstable.format` |
+| `cqlite.read.bloom.checks` | counter | `1` | `cqlite.result`, `cqlite.sstable.format` |
+| `cqlite.storage.open.sstables` | counter | `{sstable}` | (none) |
+| `cqlite.storage.open.bytes` | counter | `By` | (none) |
+| `cqlite.storage.open.tables` | counter | `1` | (none) |
+| `cqlite.sstables.open` | gauge | `{sstable}` | `cqlite.sstable.format` |
+| `cqlite.query.duration` | histogram | `s` | `cqlite.subsystem` |
+| `cqlite.query.rows` | counter | `{row}` | `cqlite.query.access_path`, `cqlite.query.plan_type` |
+| `cqlite.query.rows_scanned` | counter | `{row}` | `cqlite.query.access_path` |
+| `cqlite.write.mutations` | counter | `{row}` | (none) |
+| `cqlite.write.partitions` | counter | `{partition}` | (none) |
+| `cqlite.write.bytes` | counter | `By` | (none) |
+| `cqlite.memtable.size_bytes` | gauge | `By` | (none) |
+| `cqlite.memtable.rows` | gauge | `{row}` | (none) |
+| `cqlite.wal.sync.duration` | histogram | `s` | (none) |
+| `cqlite.flush.duration` | histogram | `s` | (none) |
+| `cqlite.flush.rows` | counter | `{row}` | (none) |
+| `cqlite.flush.bytes` | counter | `By` | (none) |
+| `cqlite.flush.sstables` | counter | `{sstable}` | (none) |
+| `cqlite.compression.ratio` | histogram | `1` | `cqlite.compression` |
+| `cqlite.compaction.duration` | histogram | `s` | (none) |
+| `cqlite.compaction.rows_merged` | counter | `{row}` | (none) |
+| `cqlite.compaction.bytes_written` | counter | `By` | (none) |
+| `cqlite.compaction.sstables_in` | counter | `{sstable}` | (none) |
+| `cqlite.compaction.sstables_out` | counter | `{sstable}` | (none) |
+| `cqlite.compaction.tombstones_purged` | counter | `{tombstone}` | (none) |
+| `cqlite.compaction.lag` | gauge | `{sstable}` | (none) |
+| `cqlite.compaction.finalize.duration` | histogram | `s` | (none) |
+| `cqlite.compaction.budget.requested` | histogram | `s` | (none) |
+| `cqlite.compaction.budget.consumed` | histogram | `s` | (none) |
+| `cqlite.errors.total` | counter | `{error}` | `cqlite.error.category`, `cqlite.subsystem` |
+| `cqlite.rpc.requests` | counter | `1` | `cqlite.rpc.method`, `cqlite.rpc.status` |
+| `cqlite.rpc.duration` | histogram | `s` | `cqlite.rpc.method`, `cqlite.rpc.status` |
+| `cqlite.rpc.in_flight` | gauge | `1` | `cqlite.rpc.method` |
+| `cqlite.rpc.rows` | counter | `{row}` | `cqlite.rpc.method` |
+| `cqlite.rpc.bytes` | counter | `By` | `cqlite.rpc.method` |
+
+Unbounded values (raw error messages, partition keys, full query text) are NEVER
+attached as attributes or span fields.

--- a/website/src/content/docs/user-docs/observability.md
+++ b/website/src/content/docs/user-docs/observability.md
@@ -137,8 +137,20 @@ with cqlite.open(
 
 ### Node.js
 
-Configure via the shared `CQLITE_OTEL_*` environment variables before launching
-the process (a dedicated option object is tracked under epic #1031):
+`Database.open(dir, options)` accepts an optional `otel` object (and a
+`traceparent` string), each field layered over the shared `CQLITE_OTEL_*`
+environment variables. Requires a build with the `observability` feature.
+
+```js
+const db = await Database.open('test-data/datasets/sstables', {
+  schema: 'test-data/schemas/basic-types.cql',
+  otel: { enabled: true, endpoint: 'http://localhost:4317', protocol: 'grpc',
+          serviceName: 'cqlite-node', samplingRatio: 1.0, timeoutMs: 10000 },
+  traceparent: '00-<trace-id>-<span-id>-01',
+});
+```
+
+Or configure purely through the shared environment variables:
 
 ```bash
 CQLITE_OTEL_ENABLED=true CQLITE_OTEL_ENDPOINT=http://localhost:4317 \


### PR DESCRIPTION
Part of epic #1031.

- `docs/observability/`: one-command local stack (`docker compose up`) — OTel Collector + Jaeger + Prometheus + Grafana (pinned images, provisioned datasources + dashboards).
- Configuration reference: all 7 CQLITE_OTEL_* env vars + per-surface config (CLI flags, Python otel_config, Node otel option, Flight env), cross-checked against the merged code.
- Metric catalog table covering all catalog.rs metric names/units/bounded attrs (auto cross-checked: every ALL_METRICS entry documented, none invented).
- Starter Grafana dashboard (throughput / latency p50-p95-p99 / error-rate) using real metric names.
- End-to-end quickstart + expected span tree; published site page (Starlight) + nav links.

Validation: `docker compose config` EXIT 0; all YAML/JSON parse; Astro site builds (all internal links valid); agent-plumbing CI gate passes. All changed files are docs/** or *.md (excluded from roborev).

Closes #1042