### PR TITLE
fix(ci): Feature-Gate marker + minimal-build fix (fmt skew handed off)

### DIFF
--- a/cqlite-core/Cargo.toml
+++ b/cqlite-core/Cargo.toml
@@ -211,6 +211,7 @@ observability = [
 # enabled it keeps building, and now resolves to the real observability stack.
 metrics = ["observability"]
 
+# Other features
 pest = []
 wasm = ["wasm-bindgen", "js-sys", "web-sys"]
 

--- a/cqlite-core/src/storage/mod.rs
+++ b/cqlite-core/src/storage/mod.rs
@@ -62,7 +62,7 @@ impl StorageEngine {
     /// This is now a read-only storage layer focused on SSTable access.
     #[tracing::instrument(
         name = "storage.engine.open",
-        skip(path, config, platform),
+        skip_all,
         fields(sstables = tracing::field::Empty, bytes = tracing::field::Empty)
     )]
     pub async fn open(
@@ -166,7 +166,7 @@ impl StorageEngine {
     /// ```
     #[tracing::instrument(
         name = "storage.engine.open",
-        skip(path, discovered_table_dirs, config, platform),
+        skip_all,
         fields(sstables = tracing::field::Empty, bytes = tracing::field::Empty)
     )]
     pub async fn open_with_sstables(


### PR DESCRIPTION
## Status: handed off to another team (2026-06-24)

This branch carries **two of the three** CI regressions the observability epic wave (#1058–#1066) left on `main`. The third (rustfmt skew) is **not done** and is being picked up by another team — details below so they can continue.

### ✅ Done on this branch (rebased on current `main`)
1. **Feature Gate Validation** — restored the `# Other features` section-header marker in `cqlite-core/Cargo.toml` that #1056 overwrote. (commit `72d66ec`)
2. **Minimal Build & Test** (`E0425: cannot find value schema_registry`) — `StorageEngine::open` / `open_with_sstables` had a `#[cfg(feature = "state_machine")]`-gated `schema_registry` param that `#[tracing::instrument(skip(...))]` left unskipped, so the macro emitted an unconditional reference that dangled when the cfg stripped the param under `--no-default-features`. Switched both to `skip_all`. (commit `dd18a7e`)

### ❌ Not done — rustfmt skew (for the next team)
`rust-toolchain.toml` pins **rustfmt 1.88.0**, but the epic formatted with a newer rustfmt, so CI's 1.88.0 rejects **12 files** (the `observability` modules in core/flight/python/node plus `query/engine.rs`, `storage/sstable/reader/mod.rs`, `storage/sstable/writer/mod.rs`, `cqlite-cli/src/config.rs`, `bindings/node/src/database.rs`, `cqlite-flight/src/main.rs`). This keeps the `Core Validation` and flight-ci `fmt` lanes red.

Two clean ways to resolve:
- **Bump the pin** to current stable + `cargo fmt --all` (one shot, permanently ends the skew; the toolchain file invites quarterly bumps) — note it also moves CI clippy/build to the newer compiler, which may surface new lints.
- **Keep the pin** and reformat the 12 files to satisfy 1.88.0 exactly.

(Context for why this PR couldn't finish it: the working environment's egress proxy policy-denies `static.rust-lang.org` and `static.crates.io`, so rustfmt 1.88.0 can't be installed and the crate deps can't be downloaded to compile/clippy — fmt could only be validated against CI, not locally.)

All three issues live on `main`; until the fmt lane is also fixed there, the parity PR #1057 stays blocked on `Core Validation`.

https://claude.ai/code/session_016L9TYoCzhu8xDffdbGs72X