### PR TITLE
test(observability): overhead bench + OTLP correctness/sampling + cargo-tree guard + CI gate (#1043)

### DIFF
--- a/.github/workflows/observability-gate.yml
+++ b/.github/workflows/observability-gate.yml
@@ -1,0 +1,97 @@
+name: "CI: Observability Gate"
+
+# Validation gate for the observability stack (epic #1031, issue #1043):
+#
+#   1. Dependency isolation — the DEFAULT cqlite-core build links NO opentelemetry
+#      crates; the stack appears only under `--features observability`.
+#   2. Correctness + sampling — the in-memory-OTLP span/metric tests pass.
+#   3. Zero-overhead-when-disabled — the `observability_overhead` bench, run under
+#      the default build vs `--features observability` (export disabled) on the
+#      SAME runner, stays within the documented overhead threshold.
+#
+# Like the perf-regression gate, both bench arms run on one runner so the delta is
+# immune to cross-machine variance.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "cqlite-core/src/observability/**"
+      - "cqlite-core/benches/observability_overhead.rs"
+      - "cqlite-core/tests/observability_correctness.rs"
+      - "cqlite-core/tests/observability_no_otel_default.rs"
+      - "cqlite-core/Cargo.toml"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "scripts/ci/observability_overhead.sh"
+      - "scripts/ci/observability_no_otel_default.sh"
+      - ".github/workflows/observability-gate.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: observability-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  DATASET_TAG: datasets-v3
+  DATASET_ASSET: cassandra5-small-full-v3.1.tar.gz
+  DATASET_SHA256: f5fa0b6599a27c1c493d7c6c063194d55d031cab417396947313e7245afc5ceb
+  CQLITE_DATASETS_ROOT: ${{ github.workspace }}/test-data/datasets
+  # Tolerated median overhead of the export-disabled observability build over the
+  # default build (see benches/observability_overhead.rs OVERHEAD_THRESHOLD_PCT).
+  OVERHEAD_THRESHOLD_PCT: "2.0"
+  # Keep CI bench runs short but stable.
+  BENCH_ARGS: "--sample-size 30 --warm-up-time 1 --measurement-time 5"
+
+jobs:
+  observability-gate:
+    name: Dependency isolation + correctness + overhead
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-obsgate-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-obsgate-cargo-
+            ${{ runner.os }}-cargo-
+
+      - name: Cache canonical datasets
+        uses: actions/cache@v5
+        with:
+          path: test-data/datasets/
+          key: ${{ runner.os }}-datasets-${{ env.DATASET_TAG }}-${{ env.DATASET_SHA256 }}
+
+      - name: Fetch canonical datasets
+        run: bash ./test-data/scripts/fetch-datasets.sh
+
+      # 1. Dependency isolation: default build links no OTel; obs build does.
+      - name: cargo-tree no-OTel guard
+        run: bash scripts/ci/observability_no_otel_default.sh
+
+      # 2. Correctness + sampling: in-memory OTLP span/metric tests.
+      - name: Observability correctness + sampling tests
+        run: |
+          cargo test -p cqlite-core \
+            --features observability-testing,cli-helpers \
+            --test observability_correctness \
+            --test observability_no_otel_default
+
+      # 3. Zero-overhead-when-disabled: two-build bench comparison on one runner.
+      - name: Observability overhead gate
+        run: bash scripts/ci/observability_overhead.sh

--- a/.github/workflows/observability-gate.yml
+++ b/.github/workflows/observability-gate.yml
@@ -17,6 +17,14 @@ on:
     branches: [main]
     paths:
       - "cqlite-core/src/observability/**"
+      # Instrumented PRODUCTION paths: these define the spans/metrics the gate's
+      # tests guard, so a regression here must run the gate. (Without these the
+      # gate would never fire on the code it actually protects.)
+      - "cqlite-core/src/query/**"
+      - "cqlite-core/src/storage/**"
+      # Binding/flight surfaces are also instrumented (per-query/RPC spans + metrics).
+      - "bindings/**"
+      - "cqlite-flight/**"
       - "cqlite-core/benches/observability_overhead.rs"
       - "cqlite-core/tests/observability_correctness.rs"
       - "cqlite-core/tests/observability_no_otel_default.rs"

--- a/cqlite-core/Cargo.toml
+++ b/cqlite-core/Cargo.toml
@@ -164,6 +164,10 @@ harness = false
 name = "concurrent_scan"
 harness = false
 
+[[bench]]
+name = "observability_overhead"
+harness = false
+
 [features]
 # M2+ production defaults: Full query engine + write path enabled.
 # write-support is a pure first-party code-gating flag (no extra dependencies),
@@ -210,6 +214,15 @@ observability = [
 # gated any code; it is retained as an alias so any out-of-tree consumer that
 # enabled it keeps building, and now resolves to the real observability stack.
 metrics = ["observability"]
+
+# Observability test harness (issue #1043) — enables the in-memory OTLP
+# exporters (`InMemorySpanExporter` / `InMemoryMetricExporter`) the SDK only
+# exposes under its own `testing` feature, and compiles the shared
+# `observability::testing` capture fixture + the correctness/sampling tests.
+# NOT in defaults and NOT implied by `observability`: production builds never
+# link the SDK's testing surface. Enable explicitly to run the #1043 tests:
+#   cargo test -p cqlite-core --features observability-testing
+observability-testing = ["observability", "opentelemetry_sdk?/testing"]
 
 pest = []
 wasm = ["wasm-bindgen", "js-sys", "web-sys"]

--- a/cqlite-core/benches/README.md
+++ b/cqlite-core/benches/README.md
@@ -91,6 +91,37 @@ env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets \
 | `fixtures_smoke` | added (#537) | Smoke/acceptance bench proving the fixture loaders are deterministic (seeded RNG + stable scan row count). Read/write portions activate under `cli-helpers` / `write-support`. |
 | `read` | added (#538) | Read suite (needs `--features cli-helpers`): `point_lookup`, `clustering_slice`, `full_scan`, `type_heavy` over the fixtures via the public query API. |
 | `write` | added (#539, #574) | Write suite (needs `--features write-support`): `ingest_wal_on`, `ingest_wal_off`, and `flush` — see below. |
+| `observability_overhead` | added (#1043) | Zero-overhead-when-disabled gate: `read_scan` (needs `cli-helpers`) and `write_merge` (needs `write-support`). The SAME bench source runs under the default build vs `--features observability` with export disabled; the two arms are compared by `scripts/ci/observability_overhead.sh` — see below. |
+
+### `observability_overhead` two-build comparison (Issue #1043)
+
+`benches/observability_overhead.rs` runs an identical read/scan (and write/merge)
+workload that carries the production `#[tracing::instrument]` spans and catalog
+metric calls. It proves the observability contract: when the feature is OFF — or
+ON but export disabled (`init` never called) — instrumentation costs effectively
+nothing.
+
+A single `cargo bench` process compiles one feature set, so the two builds run as
+two invocations of the **same** bench, compared on the same runner (immune to
+cross-machine variance, like the perf-regression gate):
+
+```bash
+# Runs both arms and fails if export-disabled overhead exceeds the threshold.
+OVERHEAD_THRESHOLD_PCT=2.0 \
+  CQLITE_DATASETS_ROOT=$PWD/test-data/datasets \
+  scripts/ci/observability_overhead.sh
+```
+
+- **Arm 1 (default):** `--features cli-helpers,write-support` → baseline `obs_default_off`.
+- **Arm 2 (export disabled):** `--features cli-helpers,write-support,observability`
+  → baseline `obs_export_disabled`. OTel is linked but no provider/exporter exists.
+- **Threshold:** `OVERHEAD_THRESHOLD_PCT` (default **2%**), documented as
+  `OVERHEAD_THRESHOLD_PCT` in the bench source. The comparison reads each arm's
+  Criterion median from `target/criterion/<id>/<baseline>/estimates.json`.
+
+CI wiring lives in `.github/workflows/observability-gate.yml`, which also runs the
+`cargo-tree` no-OTel guard (`scripts/ci/observability_no_otel_default.sh`) and the
+in-memory-OTLP correctness/sampling tests.
 
 ### `write` bench breakdown
 

--- a/cqlite-core/benches/observability_overhead.rs
+++ b/cqlite-core/benches/observability_overhead.rs
@@ -1,0 +1,201 @@
+//! Observability zero-overhead-when-disabled benchmark (epic #1031, issue #1043).
+//!
+//! # What this proves
+//!
+//! The observability contract (see `crate::observability`) is that
+//! **instrumentation call sites are identical whether or not the `observability`
+//! feature is enabled, and when the feature is off — OR on but export is
+//! disabled — the cost is negligible.** This bench measures that empirically.
+//!
+//! It runs a representative read/scan flow (and a write/merge flow when
+//! `write-support` is on) that already carries the production `#[tracing::instrument]`
+//! spans and catalog metric calls. The SAME bench source runs under two builds:
+//!
+//! 1. the DEFAULT build (`observability` OFF — every helper is a compile-time no-op);
+//! 2. `--features observability` WITH EXPORT DISABLED — the OTel crates are linked
+//!    and the helper bodies execute, but `init` is never called, so there is no
+//!    global meter/tracer provider and no exporter. Metric helpers fall through the
+//!    global no-op meter and the `tracing` spans have no OTel layer attached.
+//!
+//! Because a single `cargo bench` process compiles exactly one feature set, the
+//! two builds cannot run in one process. The comparison is therefore performed
+//! across two invocations by `scripts/ci/observability_overhead.sh`, which runs
+//! this bench under both builds and asserts the median deltas stay within
+//! [`OVERHEAD_THRESHOLD_PCT`]. This file's only job is to be a stable, identical
+//! workload in both builds; it never reads the threshold itself.
+//!
+//! # Threshold
+//!
+//! [`OVERHEAD_THRESHOLD_PCT`] = 2.0%. The "disabled" arm should be within ~2% of
+//! the default arm. The bench uses a fixed deterministic workload and the
+//! comparison script re-measures both arms on the SAME runner (like the existing
+//! perf-regression gate), so the delta is immune to cross-machine variance. The
+//! threshold is deliberately generous relative to the true cost (the helpers are
+//! `#[inline]` and branch on a `const` feature predicate) to keep the CI signal
+//! non-flaky on shared runners.
+//!
+//! Bench group/IDs (consumed by the comparison script):
+//! - `observability_overhead/read_scan`
+//! - `observability_overhead/write_merge`  (only when `write-support` is enabled)
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+#[path = "fixtures/mod.rs"]
+mod fixtures;
+
+#[path = "profiling/mod.rs"]
+mod profiling;
+
+/// Maximum tolerated median overhead of the export-disabled `observability`
+/// build over the default build, in percent. Documented here as the single
+/// source of truth; the comparison script reads this exact value.
+///
+/// Kept as a `pub const` (not just a doc number) so a future Rust-side check or
+/// test can reference it without drifting from the script.
+pub const OVERHEAD_THRESHOLD_PCT: f64 = 2.0;
+
+// ---------------------------------------------------------------------------
+// read/scan workload — identical source under both builds
+// ---------------------------------------------------------------------------
+
+/// Representative read flow: a full scan of `test_basic.simple_table` through the
+/// public query API, which crosses every instrumented read boundary
+/// (`query.execute`, the storage-open spans, the per-SSTable read spans, and the
+/// `cqlite.read.*` / `cqlite.query.*` catalog metrics). Whether those spans/metrics
+/// do any work depends solely on the build, which is exactly what we are measuring.
+#[cfg(feature = "cli-helpers")]
+fn bench_read_scan(c: &mut Criterion) {
+    use criterion::{black_box, Throughput};
+
+    let fx = fixtures::ReadFixture::SIMPLE;
+    let loaded = fixtures::open_read_db(&fx);
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let sql = format!("SELECT * FROM {}", fx.qualified());
+
+    let setup = rt
+        .block_on(loaded.db.execute(&sql))
+        .expect("overhead read setup query");
+    let row_count = setup.rows.len() as u64;
+    assert!(
+        row_count > 0,
+        "observability_overhead read_scan: scan of {} returned zero rows — fixtures not fetched?",
+        fx.qualified()
+    );
+
+    let mut group = c.benchmark_group("observability_overhead");
+    group.throughput(Throughput::Elements(row_count));
+    group.bench_function("read_scan", |b| {
+        b.iter(|| {
+            let res = rt
+                .block_on(loaded.db.execute(black_box(&sql)))
+                .expect("overhead read scan");
+            black_box(res.rows.len())
+        });
+    });
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// write/merge workload — identical source under both builds (write-support only)
+// ---------------------------------------------------------------------------
+
+/// Representative write/merge flow: ingest a fixed batch of rows into a fresh
+/// `WriteEngine` and flush them to an SSTable. This crosses the instrumented
+/// write boundaries (`write.mutation`, `memtable.insert`, `wal.append`/`wal.sync`,
+/// `flush.memtable`, `writer.*`) and emits the `cqlite.write.*` / `cqlite.flush.*`
+/// catalog metrics. The flush exercises the SSTable writer (the "merge"-shaped
+/// output path) without needing a multi-SSTable compaction setup, keeping the
+/// bench deterministic and fast. Mirrors the proven `write/flush` bench pattern.
+#[cfg(feature = "write-support")]
+fn bench_write_merge(c: &mut Criterion) {
+    use criterion::{black_box, BatchSize, Throughput};
+    use rand::Rng;
+
+    /// Fixed number of rows ingested + flushed per iteration. Deterministic via
+    /// the shared seeded RNG.
+    const ROWS: u64 = 256;
+
+    fn fill_engine(engine: &mut cqlite_core::storage::write_engine::WriteEngine) {
+        let mut rng = fixtures::seeded_rng();
+        for _ in 0..ROWS {
+            let id = uuid::Uuid::from_u128(rng.gen());
+            let age: i32 = rng.gen_range(0..100);
+            let salary: i64 = rng.gen_range(30_000..200_000);
+            let stmt = format!(
+                "INSERT INTO test_basic.simple_table \
+                 (id, name, age, salary, active) \
+                 VALUES ({id}, 'overhead-row', {age}, {salary}, true)"
+            );
+            engine.execute(&stmt).expect("overhead write row");
+        }
+    }
+
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime for write overhead bench");
+
+    let mut group = c.benchmark_group("observability_overhead");
+    group.throughput(Throughput::Elements(ROWS));
+    group.bench_function("write_merge", |b| {
+        b.iter_batched(
+            // SETUP (untimed): fresh temp dir + engine.
+            || {
+                let tmp = tempfile::TempDir::new().expect("temp dir for write overhead bench");
+                // usize::MAX flush threshold so ingest never auto-flushes; we
+                // flush explicitly in the routine.
+                let engine = fixtures::open_write_engine(tmp.path(), usize::MAX);
+                (tmp, engine)
+            },
+            // ROUTINE (timed): ingest ROWS rows then flush to an SSTable.
+            |(_tmp, mut engine)| {
+                fill_engine(&mut engine);
+                let result = rt.block_on(engine.flush()).expect("overhead flush");
+                assert!(
+                    result.is_some(),
+                    "write_merge overhead: flush produced no SSTable"
+                );
+                black_box(result)
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// criterion wiring — feature-gated so the binary always compiles
+// ---------------------------------------------------------------------------
+
+#[cfg(all(feature = "cli-helpers", feature = "write-support"))]
+criterion_group!(
+    name = benches;
+    config = profiling::configure();
+    targets = bench_read_scan, bench_write_merge
+);
+
+#[cfg(all(feature = "cli-helpers", not(feature = "write-support")))]
+criterion_group!(
+    name = benches;
+    config = profiling::configure();
+    targets = bench_read_scan
+);
+
+#[cfg(all(not(feature = "cli-helpers"), feature = "write-support"))]
+criterion_group!(
+    name = benches;
+    config = profiling::configure();
+    targets = bench_write_merge
+);
+
+#[cfg(not(any(feature = "cli-helpers", feature = "write-support")))]
+fn bench_noop(_c: &mut Criterion) {
+    // Without cli-helpers (read) or write-support (write) there is no workload to
+    // run; the binary still compiles and runs so the bench harness stays valid.
+}
+
+#[cfg(not(any(feature = "cli-helpers", feature = "write-support")))]
+criterion_group!(
+    name = benches;
+    config = profiling::configure();
+    targets = bench_noop
+);
+
+criterion_main!(benches);

--- a/cqlite-core/src/observability/mod.rs
+++ b/cqlite-core/src/observability/mod.rs
@@ -68,6 +68,17 @@ mod otel;
 #[cfg(feature = "observability")]
 pub use otel::{init, tracing_layer, ObservabilityGuard};
 
+/// Shared in-memory OTLP capture harness for observability tests (issue #1043).
+///
+/// Gated behind the `observability-testing` feature, which pulls in the OTel
+/// SDK's in-memory exporters (`InMemorySpanExporter` / `InMemoryMetricExporter`)
+/// via `opentelemetry_sdk/testing`. Public so integration tests and future child
+/// issues can reuse the same fixture API to assert span trees and metric
+/// names/units/attributes. Production `observability` builds never compile this,
+/// so they never link the SDK's testing surface.
+#[cfg(feature = "observability-testing")]
+pub mod testing;
+
 /// A bounded attribute value for catalog metrics.
 ///
 /// Mirrors the small set of types OpenTelemetry attributes accept, but is always

--- a/cqlite-core/src/observability/testing.rs
+++ b/cqlite-core/src/observability/testing.rs
@@ -1,0 +1,465 @@
+//! Shared in-memory OpenTelemetry capture harness for observability tests
+//! (epic #1031, issue #1043).
+//!
+//! This module is the **single shared fixture** every observability-correctness
+//! test (and future child issue) reuses. It installs in-memory OTLP exporters,
+//! runs a flow, force-flushes, and hands back the captured spans and metrics so a
+//! test can assert the expected span tree, metric names/units, and bounded
+//! attribute sets — all deterministically, with no collector, network, or timing
+//! dependence.
+//!
+//! It is gated behind the `observability` feature (it needs the OTel SDK) and is
+//! intended for tests, so it lives under `#[cfg(feature = "observability")]` and
+//! depends on `opentelemetry_sdk`'s in-memory exporters (available because the
+//! crate enables the SDK's `testing` feature as a dev-dependency; the
+//! library/default build links no OTel at all).
+//!
+//! # Why a single process-global meter provider
+//!
+//! The metric helpers in [`crate::observability`] record through
+//! `opentelemetry::global::meter("cqlite")`, and the concrete `Meter` is cached
+//! in a `OnceLock` the first time any metric is recorded in the process. So the
+//! global meter provider must be installed **once, before the first metric
+//! record**, and cannot be swapped per-test. [`metrics_capture`] therefore
+//! returns a handle to a single process-wide [`InMemoryMetricExporter`]; tests
+//! call [`MetricsCapture::reset`] + [`MetricsCapture::flush_and_collect`] around
+//! their own flow rather than installing a fresh provider each time.
+//!
+//! Spans, by contrast, flow through `tracing`, so a test can install its own
+//! tracer + subscriber for the duration of a flow via [`capture_spans`] and get
+//! perfectly isolated span trees with no global state.
+//!
+//! # Typical use
+//!
+//! ```ignore
+//! use cqlite_core::observability::{self as obs, catalog};
+//! use cqlite_core::observability::testing;
+//!
+//! // Spans: scoped, isolated per call.
+//! let spans = testing::capture_spans(|| {
+//!     obs::record_histogram(catalog::QUERY_DURATION, 0.001, &[]);
+//!     // ... run an instrumented flow inside a `tracing` span ...
+//! });
+//! assert!(spans.iter().any(|s| s.name == "query.execute"));
+//!
+//! // Metrics: process-global, reset around the flow.
+//! let mc = testing::metrics_capture();
+//! mc.reset();
+//! obs::add_counter(catalog::READ_ROWS, 7, &[]);
+//! let metrics = mc.flush_and_collect();
+//! assert_eq!(metrics.counter_sum(catalog::READ_ROWS), 7);
+//! ```
+
+use std::sync::OnceLock;
+
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry::Value;
+use opentelemetry_sdk::metrics::data::AggregatedMetrics;
+use opentelemetry_sdk::metrics::data::MetricData;
+use opentelemetry_sdk::metrics::{InMemoryMetricExporter, PeriodicReader, SdkMeterProvider};
+use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider, SpanData};
+use tracing_subscriber::prelude::*;
+
+/// Instrumentation scope used by the production telemetry (mirrors `otel::SCOPE`).
+const SCOPE: &str = "cqlite";
+
+// ---------------------------------------------------------------------------
+// Span capture (per-call, isolated)
+// ---------------------------------------------------------------------------
+
+/// A captured, simplified view of an exported span. Wraps the SDK [`SpanData`]
+/// with ergonomic accessors so tests read span trees without depending on the
+/// SDK's exact field layout.
+#[derive(Debug, Clone)]
+pub struct CapturedSpan {
+    /// Span name (`#[tracing::instrument]` name or `info_span!` name).
+    pub name: String,
+    /// The raw SDK span data, for advanced assertions (timing, events, links).
+    pub data: SpanData,
+}
+
+impl CapturedSpan {
+    /// This span's own 16-byte span id.
+    pub fn span_id(&self) -> opentelemetry::trace::SpanId {
+        self.data.span_context.span_id()
+    }
+
+    /// This span's parent span id (`SpanId::INVALID` for a root span).
+    pub fn parent_span_id(&self) -> opentelemetry::trace::SpanId {
+        self.data.parent_span_id
+    }
+
+    /// The trace id this span belongs to.
+    pub fn trace_id(&self) -> opentelemetry::trace::TraceId {
+        self.data.span_context.trace_id()
+    }
+
+    /// Look up a bounded span attribute value (as a display string) by key.
+    pub fn attribute(&self, key: &str) -> Option<String> {
+        self.data
+            .attributes
+            .iter()
+            .find(|kv| kv.key.as_str() == key)
+            .map(|kv| kv.value.as_str().into_owned())
+    }
+
+    /// Whether the span's status was set to error (via `record_error` /
+    /// `mark_span_error`).
+    pub fn is_error(&self) -> bool {
+        matches!(self.data.status, opentelemetry::trace::Status::Error { .. })
+            || self.attribute("otel.status_code").as_deref() == Some("ERROR")
+    }
+}
+
+/// A captured set of spans from one [`capture_spans`] call, with tree helpers.
+#[derive(Debug, Clone, Default)]
+pub struct CapturedSpans {
+    spans: Vec<CapturedSpan>,
+}
+
+impl CapturedSpans {
+    /// Build a [`CapturedSpans`] from already-exported `(name, SpanData)` pairs.
+    ///
+    /// Lets a test that drives its own tracer (e.g. with a custom sampler) reuse
+    /// the tree/name helpers here instead of duplicating them.
+    pub fn from_raw(raw: Vec<(String, SpanData)>) -> Self {
+        Self {
+            spans: raw
+                .into_iter()
+                .map(|(name, data)| CapturedSpan { name, data })
+                .collect(),
+        }
+    }
+
+    /// All captured spans, in export order.
+    pub fn all(&self) -> &[CapturedSpan] {
+        &self.spans
+    }
+
+    /// Iterate the captured spans.
+    pub fn iter(&self) -> std::slice::Iter<'_, CapturedSpan> {
+        self.spans.iter()
+    }
+
+    /// Find the first span with the given name.
+    pub fn find(&self, name: &str) -> Option<&CapturedSpan> {
+        self.spans.iter().find(|s| s.name == name)
+    }
+
+    /// Whether any captured span has the given name.
+    pub fn contains(&self, name: &str) -> bool {
+        self.find(name).is_some()
+    }
+
+    /// Whether `child` is a direct child of `parent` (matched by name): there
+    /// exists a span named `parent` whose span id equals a span named `child`'s
+    /// parent span id, sharing the same trace.
+    pub fn is_parent_of(&self, parent: &str, child: &str) -> bool {
+        let parents: Vec<_> = self.spans.iter().filter(|s| s.name == parent).collect();
+        self.spans
+            .iter()
+            .filter(|s| s.name == child)
+            .any(|c| {
+                parents.iter().any(|p| {
+                    p.span_id() == c.parent_span_id() && p.trace_id() == c.trace_id()
+                })
+            })
+    }
+}
+
+/// Run `flow` with an isolated in-memory tracer installed as the default
+/// `tracing` subscriber, then return every span it produced.
+///
+/// The tracer + subscriber are scoped to this call (via
+/// [`tracing::subscriber::with_default`]), so concurrent or subsequent calls do
+/// not see each other's spans. A [`SimpleSpanProcessor`] exports each span
+/// synchronously as it closes, and the provider is force-flushed before reading,
+/// so the result is deterministic with no timing dependence.
+///
+/// Spans only close (and thus export) when their guard is dropped — make sure
+/// `flow` fully completes any instrumented work (e.g. `block_on` an async flow)
+/// before returning.
+pub fn capture_spans<F, R>(flow: F) -> CapturedSpans
+where
+    F: FnOnce() -> R,
+{
+    let exporter = InMemorySpanExporter::default();
+    let provider = SdkTracerProvider::builder()
+        .with_simple_exporter(exporter.clone())
+        .build();
+    let tracer = provider.tracer(SCOPE);
+    let layer = tracing_opentelemetry::layer().with_tracer(tracer);
+    let subscriber = tracing_subscriber::registry().with(layer);
+
+    tracing::subscriber::with_default(subscriber, flow);
+
+    // Ensure everything is flushed before we read.
+    let _ = provider.force_flush();
+
+    let spans = exporter
+        .get_finished_spans()
+        .expect("in-memory span exporter must yield finished spans")
+        .into_iter()
+        .map(|data| CapturedSpan {
+            name: data.name.to_string(),
+            data,
+        })
+        .collect();
+    let _ = provider.shutdown();
+    CapturedSpans { spans }
+}
+
+// ---------------------------------------------------------------------------
+// Metric capture (process-global, reset around the flow)
+// ---------------------------------------------------------------------------
+
+/// Process-wide in-memory metric exporter handle.
+///
+/// There is exactly one of these per process because the production metric
+/// helpers bind a single global `Meter` on first use (see the module docs).
+/// Obtain it via [`metrics_capture`]; [`reset`](Self::reset) before your flow and
+/// [`flush_and_collect`](Self::flush_and_collect) after it.
+#[derive(Clone)]
+pub struct MetricsCapture {
+    exporter: InMemoryMetricExporter,
+    provider: SdkMeterProvider,
+}
+
+/// A snapshot of metrics collected by [`MetricsCapture::flush_and_collect`],
+/// with name/unit/value accessors for assertions.
+#[derive(Debug, Default)]
+pub struct CapturedMetrics {
+    entries: Vec<MetricEntry>,
+}
+
+/// A single collected metric: its name, unit, kind, and aggregated value(s).
+#[derive(Debug, Clone)]
+pub struct MetricEntry {
+    /// Instrument name (a `catalog::*` constant).
+    pub name: String,
+    /// Instrument unit (a `catalog::unit::*` string).
+    pub unit: String,
+    /// The aggregated data points.
+    pub points: Vec<MetricPoint>,
+}
+
+/// One aggregated data point: its numeric value (as f64) and bounded attributes.
+#[derive(Debug, Clone)]
+pub struct MetricPoint {
+    /// The aggregated value (counter sum, gauge value, or histogram sum).
+    pub value: f64,
+    /// The bounded attributes as `(key, value-as-string)` pairs.
+    pub attributes: Vec<(String, String)>,
+}
+
+impl CapturedMetrics {
+    /// Every collected metric entry.
+    pub fn entries(&self) -> &[MetricEntry] {
+        &self.entries
+    }
+
+    /// Find a collected metric by name.
+    pub fn find(&self, name: &str) -> Option<&MetricEntry> {
+        self.entries.iter().find(|m| m.name == name)
+    }
+
+    /// Whether a metric with the given name was collected.
+    pub fn contains(&self, name: &str) -> bool {
+        self.find(name).is_some()
+    }
+
+    /// The unit string reported for a metric, if collected.
+    pub fn unit(&self, name: &str) -> Option<&str> {
+        self.find(name).map(|m| m.unit.as_str())
+    }
+
+    /// Sum of all data-point values for a metric (counter total, histogram sum,
+    /// or gauge value), or `0.0` if the metric was not collected.
+    pub fn counter_sum(&self, name: &str) -> f64 {
+        self.find(name)
+            .map(|m| m.points.iter().map(|p| p.value).sum())
+            .unwrap_or(0.0)
+    }
+
+    /// Sum of values for the data points whose attribute set contains ALL of the
+    /// given `(key, value)` pairs. Lets a test assert, e.g., that
+    /// `cqlite.errors.total{category=…,subsystem=…}` incremented.
+    pub fn sum_where(&self, name: &str, required: &[(&str, &str)]) -> f64 {
+        let Some(m) = self.find(name) else {
+            return 0.0;
+        };
+        m.points
+            .iter()
+            .filter(|p| {
+                required.iter().all(|(k, v)| {
+                    p.attributes
+                        .iter()
+                        .any(|(pk, pv)| pk == k && pv == v)
+                })
+            })
+            .map(|p| p.value)
+            .sum()
+    }
+}
+
+impl MetricsCapture {
+    /// Drop everything collected so far so the next
+    /// [`flush_and_collect`](Self::flush_and_collect) reflects only the flow run
+    /// after this call. Call this immediately before your flow.
+    pub fn reset(&self) {
+        // Flush first so any straggler exports land, then clear.
+        let _ = self.provider.force_flush();
+        self.exporter.reset();
+    }
+
+    /// Force the meter provider to collect + export, then return a snapshot.
+    pub fn flush_and_collect(&self) -> CapturedMetrics {
+        let _ = self.provider.force_flush();
+        let resource_metrics = self
+            .exporter
+            .get_finished_metrics()
+            .expect("in-memory metric exporter must yield collected metrics");
+
+        let mut entries = Vec::new();
+        for rm in &resource_metrics {
+            for sm in rm.scope_metrics() {
+                for metric in sm.metrics() {
+                    entries.push(metric_to_entry(metric));
+                }
+            }
+        }
+        CapturedMetrics { entries }
+    }
+}
+
+/// The process-wide [`MetricsCapture`], installing the global in-memory meter
+/// provider exactly once on first call.
+///
+/// MUST be called before any code path records a catalog metric in the process,
+/// otherwise the global `Meter` binds to a no-op provider and nothing is
+/// captured. Observability tests call this at the start of the relevant test.
+pub fn metrics_capture() -> MetricsCapture {
+    static CAPTURE: OnceLock<MetricsCapture> = OnceLock::new();
+    CAPTURE
+        .get_or_init(|| {
+            let exporter = InMemoryMetricExporter::default();
+            let reader = PeriodicReader::builder(exporter.clone()).build();
+            let provider = SdkMeterProvider::builder().with_reader(reader).build();
+            opentelemetry::global::set_meter_provider(provider.clone());
+            MetricsCapture { exporter, provider }
+        })
+        .clone()
+}
+
+fn value_to_string(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.to_string(),
+        Value::Bool(b) => b.to_string(),
+        Value::I64(i) => i.to_string(),
+        Value::F64(f) => f.to_string(),
+        other => format!("{other:?}"),
+    }
+}
+
+/// Convert one SDK `Metric` into the simplified [`MetricEntry`], flattening the
+/// f64/u64/i64 aggregation variants into f64 values for uniform assertions.
+fn metric_to_entry(metric: &opentelemetry_sdk::metrics::data::Metric) -> MetricEntry {
+    let mut points = Vec::new();
+    match metric.data() {
+        AggregatedMetrics::F64(data) => collect_points_f64(data, &mut points),
+        AggregatedMetrics::U64(data) => collect_points_u64(data, &mut points),
+        AggregatedMetrics::I64(data) => collect_points_i64(data, &mut points),
+    }
+    MetricEntry {
+        name: metric.name().to_string(),
+        unit: metric.unit().to_string(),
+        points,
+    }
+}
+
+macro_rules! collect_points_impl {
+    ($fn_name:ident, $ty:ty, $to_f64:expr) => {
+        fn $fn_name(data: &MetricData<$ty>, out: &mut Vec<MetricPoint>) {
+            let to_f64: fn($ty) -> f64 = $to_f64;
+            match data {
+                MetricData::Sum(sum) => {
+                    for dp in sum.data_points() {
+                        out.push(MetricPoint {
+                            value: to_f64(dp.value()),
+                            attributes: attrs(dp.attributes()),
+                        });
+                    }
+                }
+                MetricData::Gauge(gauge) => {
+                    for dp in gauge.data_points() {
+                        out.push(MetricPoint {
+                            value: to_f64(dp.value()),
+                            attributes: attrs(dp.attributes()),
+                        });
+                    }
+                }
+                MetricData::Histogram(hist) => {
+                    for dp in hist.data_points() {
+                        out.push(MetricPoint {
+                            // For histograms, expose the running sum so a test can
+                            // assert "something was recorded" and read total magnitude.
+                            value: to_f64(dp.sum()),
+                            attributes: attrs(dp.attributes()),
+                        });
+                    }
+                }
+                MetricData::ExponentialHistogram(hist) => {
+                    for dp in hist.data_points() {
+                        out.push(MetricPoint {
+                            value: to_f64(dp.sum()),
+                            attributes: attrs(dp.attributes()),
+                        });
+                    }
+                }
+            }
+        }
+    };
+}
+
+fn attrs<'a>(it: impl Iterator<Item = &'a opentelemetry::KeyValue>) -> Vec<(String, String)> {
+    it.map(|kv| (kv.key.as_str().to_string(), value_to_string(&kv.value)))
+        .collect()
+}
+
+collect_points_impl!(collect_points_f64, f64, |v| v);
+collect_points_impl!(collect_points_u64, u64, |v| v as f64);
+collect_points_impl!(collect_points_i64, i64, |v| v as f64);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Span capture uses a per-call isolated tracer, so this self-test needs no
+    // global state and is safe under parallel test execution.
+    #[test]
+    fn capture_spans_records_tree_and_attributes() {
+        let spans = capture_spans(|| {
+            let parent = tracing::info_span!("parent.span");
+            let _g = parent.enter();
+            let child = tracing::info_span!("child.span", cqlite.result = "hit");
+            child.in_scope(|| {});
+        });
+
+        assert!(spans.contains("parent.span"));
+        assert!(spans.contains("child.span"));
+        assert!(
+            spans.is_parent_of("parent.span", "child.span"),
+            "child.span must nest under parent.span; saw {:?}",
+            spans.iter().map(|s| s.name.clone()).collect::<Vec<_>>()
+        );
+        let child = spans.find("child.span").expect("child present");
+        assert_eq!(child.attribute("cqlite.result").as_deref(), Some("hit"));
+    }
+
+    #[test]
+    fn captured_spans_from_raw_roundtrips_empty() {
+        let empty = CapturedSpans::from_raw(Vec::new());
+        assert!(empty.all().is_empty());
+        assert!(!empty.contains("anything"));
+    }
+}

--- a/cqlite-core/src/observability/testing.rs
+++ b/cqlite-core/src/observability/testing.rs
@@ -25,6 +25,20 @@
 //! call [`MetricsCapture::reset`] + [`MetricsCapture::flush_and_collect`] around
 //! their own flow rather than installing a fresh provider each time.
 //!
+//! ## Metric isolation guarantee
+//!
+//! The shared exporter is configured with **DELTA** temporality
+//! ([`Temporality::Delta`]). Each [`MetricsCapture::flush_and_collect`] therefore
+//! reports only the values aggregated *since the previous collect*, not a
+//! running cumulative total. [`MetricsCapture::reset`] force-flushes (draining and
+//! discarding any prior deltas) and clears the exporter buffer, so a subsequent
+//! `flush_and_collect` reflects **only the work done between `reset` and
+//! `flush_and_collect`** — never metrics accumulated by an earlier flow or test.
+//! This holds even under parallel test execution: although the meter provider is
+//! process-global, all metric assertions run inside a single serial test (see
+//! `tests/observability_correctness.rs`), and DELTA temporality means that test
+//! never re-observes another flow's already-collected counters.
+//!
 //! Spans, by contrast, flow through `tracing`, so a test can install its own
 //! tracer + subscriber for the duration of a flow via [`capture_spans`] and get
 //! perfectly isolated span trees with no global state.
@@ -56,7 +70,10 @@ use opentelemetry::trace::TracerProvider as _;
 use opentelemetry::Value;
 use opentelemetry_sdk::metrics::data::AggregatedMetrics;
 use opentelemetry_sdk::metrics::data::MetricData;
-use opentelemetry_sdk::metrics::{InMemoryMetricExporter, PeriodicReader, SdkMeterProvider};
+use opentelemetry_sdk::metrics::{
+    InMemoryMetricExporter, InMemoryMetricExporterBuilder, PeriodicReader, SdkMeterProvider,
+    Temporality,
+};
 use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider, SpanData};
 use tracing_subscriber::prelude::*;
 
@@ -306,8 +323,15 @@ impl MetricsCapture {
     /// Drop everything collected so far so the next
     /// [`flush_and_collect`](Self::flush_and_collect) reflects only the flow run
     /// after this call. Call this immediately before your flow.
+    ///
+    /// This force-flushes first (draining the SDK's pending DELTA aggregation so
+    /// any straggler deltas land in the exporter), then clears the exporter
+    /// buffer. Because the exporter uses DELTA temporality, the *next* collect
+    /// starts a fresh aggregation window — no cumulative state from before this
+    /// `reset` can leak into a later `flush_and_collect`.
     pub fn reset(&self) {
-        // Flush first so any straggler exports land, then clear.
+        // Flush first so any straggler deltas land, then clear the buffer. With
+        // DELTA temporality this also resets the aggregation window.
         let _ = self.provider.force_flush();
         self.exporter.reset();
     }
@@ -342,7 +366,13 @@ pub fn metrics_capture() -> MetricsCapture {
     static CAPTURE: OnceLock<MetricsCapture> = OnceLock::new();
     CAPTURE
         .get_or_init(|| {
-            let exporter = InMemoryMetricExporter::default();
+            // DELTA temporality so each `flush_and_collect` returns only the
+            // values recorded since the previous collect (see the module-level
+            // "Metric isolation guarantee"). This prevents an earlier flow/test's
+            // cumulative counters from re-appearing in a later collect.
+            let exporter = InMemoryMetricExporterBuilder::new()
+                .with_temporality(Temporality::Delta)
+                .build();
             let reader = PeriodicReader::builder(exporter.clone()).build();
             let provider = SdkMeterProvider::builder().with_reader(reader).build();
             opentelemetry::global::set_meter_provider(provider.clone());

--- a/cqlite-core/tests/observability_correctness.rs
+++ b/cqlite-core/tests/observability_correctness.rs
@@ -1,0 +1,555 @@
+//! Observability correctness + sampling validation (epic #1031, issue #1043).
+//!
+//! These tests use the shared in-memory OTLP capture fixture
+//! ([`cqlite_core::observability::testing`]) to assert that representative read,
+//! query, write, and compaction flows produce the EXPECTED span trees and the
+//! catalog metric names/units, and that parent-based trace-ID-ratio sampling
+//! behaves as configured. No collector, network, or timing dependence: every
+//! flow is force-flushed before assertions.
+//!
+//! Feature gating: the whole file requires `observability-testing` (which pulls
+//! in the SDK in-memory exporters). The read/query flows additionally need
+//! `cli-helpers`; the write/compaction flows need `write-support` (on by default).
+//!
+//! Run with:
+//! ```text
+//! cargo test -p cqlite-core \
+//!   --features observability-testing,cli-helpers --test observability_correctness
+//! ```
+//!
+//! # Why metric assertions live in one serial test
+//!
+//! The production metric helpers record through a single process-global `Meter`
+//! that binds on first use, so the in-memory meter provider is process-wide and
+//! cannot be swapped per test. All metric assertions therefore run in ONE test
+//! that resets the capture, runs its flows, and reads back — avoiding cross-test
+//! races on the shared provider. Span assertions, by contrast, use a per-call
+//! isolated tracer and can be split across tests freely.
+
+#![cfg(feature = "observability-testing")]
+
+use cqlite_core::error::Error;
+use cqlite_core::observability::{self as obs, catalog, testing, ErrorCategory};
+
+/// Install (idempotently) the process-global in-memory meter provider.
+///
+/// The production metric helpers bind a single global `Meter` on FIRST use, so
+/// whichever test records a metric first determines the provider for the whole
+/// process. Every test here that runs an instrumented flow (which emits catalog
+/// metrics) calls this first so the global meter is always the in-memory one,
+/// regardless of test order or parallelism. The metric-assertion test additionally
+/// `reset`s + `flush_and_collect`s around its own emissions.
+fn ensure_meter_installed() {
+    let _ = testing::metrics_capture();
+}
+
+// ---------------------------------------------------------------------------
+// Span tree correctness — read + query flow (cli-helpers)
+// ---------------------------------------------------------------------------
+
+/// A read/query flow through the public `Database::execute` API produces a
+/// `query.execute` span that parents the read-path spans (issue #1034/#1035).
+#[cfg(feature = "cli-helpers")]
+#[test]
+fn query_execute_span_parents_read_path() {
+    ensure_meter_installed();
+    let fx = read_fixtures::SIMPLE;
+    let loaded = read_fixtures::open_read_db(&fx);
+    let sql = format!("SELECT * FROM {}", fx.qualified());
+
+    // capture_spans installs an isolated tracer as the thread-local default; run
+    // the async flow on a CURRENT-THREAD runtime so every instrumented future is
+    // polled on this thread and seen by that subscriber.
+    let spans = testing::capture_spans(|| {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("current-thread runtime");
+        let res = rt
+            .block_on(loaded.db.execute(&sql))
+            .expect("read flow query");
+        assert!(!res.rows.is_empty(), "read flow returned zero rows");
+    });
+
+    assert!(
+        spans.contains("query.execute"),
+        "expected a query.execute span; saw: {:?}",
+        span_names(&spans)
+    );
+
+    // At least one read-path span (the query.* sub-spans or storage/sstable
+    // spans) must nest under query.execute. We assert the SELECT plan span, which
+    // is created inside execute for SELECTs.
+    let read_child = spans
+        .iter()
+        .map(|s| s.name.as_str())
+        .find(|n| {
+            n.starts_with("query.")
+                && *n != "query.execute"
+                || n.starts_with("sstable.")
+                || n.starts_with("storage.")
+        });
+    assert!(
+        read_child.is_some(),
+        "expected a read-path child span under query.execute; saw: {:?}",
+        span_names(&spans)
+    );
+    let child = read_child.expect("read child span present");
+    assert!(
+        spans.is_parent_of("query.execute", child),
+        "query.execute must parent {child}; saw spans: {:?}",
+        span_tree(&spans)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Span tree correctness — write flow (write-support)
+// ---------------------------------------------------------------------------
+
+/// A write flow (ingest one row, flush) produces the instrumented write spans
+/// (`write.mutation`, `flush.public` / `flush.memtable`).
+#[cfg(feature = "write-support")]
+#[test]
+fn write_flow_emits_write_spans() {
+    ensure_meter_installed();
+    let spans = testing::capture_spans(|| {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("current-thread runtime");
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let mut engine = write_helpers::open_engine(tmp.path());
+        engine
+            .execute(
+                "INSERT INTO obs_ks.items (id, name, score) VALUES (1, 'one', 10)",
+            )
+            .expect("write row");
+        let info = rt.block_on(engine.flush()).expect("flush").expect("sstable");
+        assert!(info.data_path.exists(), "flush must produce a Data.db");
+    });
+
+    // The CQL write path is instrumented as `write.cql_execute`, which in turn
+    // crosses `memtable.insert` + `wal.append`/`wal.sync`.
+    assert!(
+        spans.contains("write.cql_execute"),
+        "expected a write.cql_execute span; saw: {:?}",
+        span_names(&spans)
+    );
+    assert!(
+        spans.contains("memtable.insert"),
+        "expected a memtable.insert span; saw: {:?}",
+        span_names(&spans)
+    );
+    assert!(
+        spans.contains("flush.public") || spans.contains("flush.memtable"),
+        "expected a flush span; saw: {:?}",
+        span_names(&spans)
+    );
+    // The flush writer path is instrumented too.
+    assert!(
+        spans.contains("writer.finish"),
+        "expected a writer.finish span; saw: {:?}",
+        span_names(&spans)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Span tree correctness — compaction flow (write-support)
+// ---------------------------------------------------------------------------
+
+/// A compaction flow produces the instrumented compaction spans
+/// (`compaction.maintenance_step` and, when a merge runs, `compaction.start_merge`).
+#[cfg(feature = "write-support")]
+#[test]
+fn compaction_flow_emits_compaction_spans() {
+    ensure_meter_installed();
+    let spans = testing::capture_spans(|| {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("current-thread runtime");
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let mut engine = write_helpers::open_engine(tmp.path());
+        engine.set_merge_policy(Box::new(write_helpers::policy()))
+            .expect("set policy");
+
+        // Three small SSTables so STCS(min_threshold=3) selects them.
+        for table in 0..3 {
+            for id in 0..5 {
+                let pk = table * 100 + id;
+                engine
+                    .execute(&format!(
+                        "INSERT INTO obs_ks.items (id, name, score) VALUES ({pk}, 'n', {pk})"
+                    ))
+                    .expect("write row");
+            }
+            rt.block_on(engine.flush()).expect("flush").expect("sstable");
+        }
+
+        // maintenance_step uses an internal block_on; safe here because we run it
+        // on a current-thread runtime via spawn_blocking-free direct call OUTSIDE
+        // an active runtime context.
+        let budget = std::time::Duration::from_secs(30);
+        for _ in 0..5 {
+            let report = engine.maintenance_step(budget).expect("maintenance_step");
+            if !report.completed_merges.is_empty() || !report.pending_compaction {
+                break;
+            }
+        }
+        drop(rt);
+    });
+
+    assert!(
+        spans.contains("compaction.maintenance_step"),
+        "expected a compaction.maintenance_step span; saw: {:?}",
+        span_names(&spans)
+    );
+    assert!(
+        spans.contains("compaction.start_merge"),
+        "expected a compaction.start_merge span (a merge should have run); saw: {:?}",
+        span_names(&spans)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Metric correctness — names, units, and induced error increment (one serial test)
+// ---------------------------------------------------------------------------
+
+/// Catalog metrics are emitted with the right names + units, and
+/// `cqlite.errors.total` increments on an induced error with bounded
+/// `{category, subsystem}` labels.
+#[test]
+fn catalog_metrics_have_expected_names_units_and_error_labels() {
+    let mc = testing::metrics_capture();
+    mc.reset();
+
+    // Emit one of each instrument kind via the production helpers.
+    obs::add_counter(
+        catalog::READ_ROWS,
+        42,
+        &[(catalog::attr::SSTABLE_FORMAT, "bti".into())],
+    );
+    obs::record_histogram(catalog::QUERY_DURATION, 0.005, &[]);
+    obs::record_gauge(catalog::SSTABLES_OPEN, 3, &[]);
+
+    // Induce an error so errors.total increments with bounded labels.
+    let err: Error = Error::corruption("induced for test");
+    let expected_category = err.obs_category().as_str();
+    obs::record_error(&err, "reader");
+
+    let metrics = mc.flush_and_collect();
+
+    // Names + units.
+    assert!(
+        metrics.contains(catalog::READ_ROWS),
+        "cqlite.read.rows must be collected; saw: {:?}",
+        metric_names(&metrics)
+    );
+    assert_eq!(
+        metrics.unit(catalog::READ_ROWS),
+        Some(catalog::unit::ROWS),
+        "cqlite.read.rows unit must be {}",
+        catalog::unit::ROWS
+    );
+    assert!(metrics.counter_sum(catalog::READ_ROWS) >= 42.0);
+
+    assert!(metrics.contains(catalog::QUERY_DURATION));
+    assert_eq!(
+        metrics.unit(catalog::QUERY_DURATION),
+        Some(catalog::unit::SECONDS),
+        "cqlite.query.duration unit must be seconds"
+    );
+
+    assert!(metrics.contains(catalog::SSTABLES_OPEN));
+    assert_eq!(
+        metrics.unit(catalog::SSTABLES_OPEN),
+        Some(catalog::unit::SSTABLES)
+    );
+
+    // errors.total with bounded {category, subsystem} labels.
+    assert!(metrics.contains(catalog::ERRORS_TOTAL));
+    assert_eq!(
+        metrics.unit(catalog::ERRORS_TOTAL),
+        Some(catalog::unit::ERRORS)
+    );
+    let labeled = metrics.sum_where(
+        catalog::ERRORS_TOTAL,
+        &[
+            (catalog::attr::ERROR_CATEGORY, expected_category),
+            (catalog::attr::SUBSYSTEM, "reader"),
+        ],
+    );
+    assert!(
+        labeled >= 1.0,
+        "cqlite.errors.total{{category={expected_category},subsystem=reader}} must increment; \
+         saw entries: {:?}",
+        metrics.find(catalog::ERRORS_TOTAL)
+    );
+
+    // The induced category must be one of the bounded taxonomy values, never a
+    // raw message.
+    assert!(
+        ErrorCategory::ALL.iter().any(|c| c.as_str() == expected_category),
+        "induced error category {expected_category} must be a bounded taxonomy value"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Sampling validation (parent-based trace-id-ratio)
+// ---------------------------------------------------------------------------
+
+/// `sampling_ratio = 0.0` drops spans; `sampling_ratio = 1.0` keeps them; and a
+/// parent-based sampler keeps children of a sampled parent. We validate this at
+/// the sampler level (the same `Sampler::ParentBased(TraceIdRatioBased)` the
+/// production `init` builds from `ObservabilityConfig.sampling_ratio`) using an
+/// in-memory tracer so the result is deterministic.
+#[test]
+fn sampling_ratio_zero_drops_and_one_keeps() {
+    // ratio = 0.0 → root spans dropped.
+    let dropped = capture_with_sampler(0.0, || {
+        let span = tracing::info_span!("sampled.root");
+        let _g = span.enter();
+        tracing::info_span!("sampled.child").in_scope(|| {});
+    });
+    assert!(
+        dropped.all().is_empty(),
+        "ratio=0.0 must drop all spans; saw: {:?}",
+        span_names(&dropped)
+    );
+
+    // ratio = 1.0 → spans kept, and child nests under parent.
+    let kept = capture_with_sampler(1.0, || {
+        let span = tracing::info_span!("sampled.root");
+        let _g = span.enter();
+        tracing::info_span!("sampled.child").in_scope(|| {});
+    });
+    assert!(
+        kept.contains("sampled.root") && kept.contains("sampled.child"),
+        "ratio=1.0 must keep both spans; saw: {:?}",
+        span_names(&kept)
+    );
+    assert!(
+        kept.is_parent_of("sampled.root", "sampled.child"),
+        "parent-based sampler must keep the child under its sampled parent"
+    );
+}
+
+/// Hot-path span creation is cheap when not sampled: with ratio=0.0 a large
+/// number of spans produces no exported spans (and does not panic / allocate
+/// exporter buffers). This is a behavioural smoke test of the "cheap when not
+/// sampled" property, not a microbenchmark (the bench covers timing).
+#[test]
+fn unsampled_hot_path_creates_no_spans() {
+    let captured = capture_with_sampler(0.0, || {
+        for i in 0..10_000u32 {
+            tracing::info_span!("hot.span", i).in_scope(|| {});
+        }
+    });
+    assert!(
+        captured.all().is_empty(),
+        "ratio=0.0 hot path must export zero spans, got {}",
+        captured.all().len()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Local helpers
+// ---------------------------------------------------------------------------
+
+/// Build an in-memory tracer with the SAME sampler the production `init` uses
+/// (`ParentBased(TraceIdRatioBased(ratio))`), install it as the thread-local
+/// default subscriber, run `flow`, and return the captured spans.
+fn capture_with_sampler<F: FnOnce()>(ratio: f64, flow: F) -> testing::CapturedSpans {
+    use opentelemetry::trace::TracerProvider as _;
+    use opentelemetry_sdk::trace::{Sampler, SdkTracerProvider};
+    use tracing_subscriber::prelude::*;
+
+    let exporter = opentelemetry_sdk::trace::InMemorySpanExporter::default();
+    let sampler = Sampler::ParentBased(Box::new(Sampler::TraceIdRatioBased(ratio)));
+    let provider = SdkTracerProvider::builder()
+        .with_simple_exporter(exporter.clone())
+        .with_sampler(sampler)
+        .build();
+    let tracer = provider.tracer("cqlite");
+    let layer = tracing_opentelemetry::layer().with_tracer(tracer);
+    let subscriber = tracing_subscriber::registry().with(layer);
+
+    tracing::subscriber::with_default(subscriber, flow);
+    let _ = provider.force_flush();
+
+    let raw: Vec<(String, opentelemetry_sdk::trace::SpanData)> = exporter
+        .get_finished_spans()
+        .expect("in-memory spans")
+        .into_iter()
+        .map(|data| (data.name.to_string(), data))
+        .collect();
+    let _ = provider.shutdown();
+    testing::CapturedSpans::from_raw(raw)
+}
+
+fn span_names(spans: &testing::CapturedSpans) -> Vec<String> {
+    spans.iter().map(|s| s.name.clone()).collect()
+}
+
+fn span_tree(spans: &testing::CapturedSpans) -> Vec<(String, String)> {
+    spans
+        .iter()
+        .map(|s| (s.name.clone(), format!("{:?}", s.parent_span_id())))
+        .collect()
+}
+
+fn metric_names(m: &testing::CapturedMetrics) -> Vec<String> {
+    m.entries().iter().map(|e| e.name.clone()).collect()
+}
+
+// ---------------------------------------------------------------------------
+// Read fixtures (mirrors benches/fixtures, trimmed to what these tests need)
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "cli-helpers")]
+mod read_fixtures {
+    use std::path::PathBuf;
+
+    pub struct ReadFixture {
+        pub keyspace: &'static str,
+        pub table: &'static str,
+        pub schema_file: &'static str,
+    }
+
+    impl ReadFixture {
+        pub fn qualified(&self) -> String {
+            format!("{}.{}", self.keyspace, self.table)
+        }
+    }
+
+    pub const SIMPLE: ReadFixture = ReadFixture {
+        keyspace: "test_basic",
+        table: "simple_table",
+        schema_file: "basic-types.cql",
+    };
+
+    pub struct ReadDb {
+        pub db: cqlite_core::Database,
+        _tmp: tempfile::TempDir,
+    }
+
+    fn datasets_root() -> PathBuf {
+        match std::env::var("CQLITE_DATASETS_ROOT") {
+            Ok(root) => PathBuf::from(root),
+            Err(_) => PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../test-data/datasets"),
+        }
+    }
+
+    fn table_dir(keyspace: &str, table: &str) -> PathBuf {
+        let parent = datasets_root().join("sstables").join(keyspace);
+        let prefix = format!("{table}-");
+        std::fs::read_dir(&parent)
+            .unwrap_or_else(|e| panic!("read fixture dir {}: {e}", parent.display()))
+            .filter_map(|e| e.ok())
+            .find(|e| e.file_name().to_string_lossy().starts_with(&prefix))
+            .map(|e| e.path())
+            .unwrap_or_else(|| {
+                panic!(
+                    "fixture {keyspace}/{table} not found under {} — fetch datasets first",
+                    parent.display()
+                )
+            })
+    }
+
+    fn copy_dir(src: &std::path::Path, dst: &std::path::Path) {
+        std::fs::create_dir_all(dst).expect("create dst");
+        for entry in std::fs::read_dir(src).expect("read src") {
+            let entry = entry.expect("dir entry");
+            let from = entry.path();
+            let to = dst.join(entry.file_name());
+            if from.is_dir() {
+                copy_dir(&from, &to);
+            } else {
+                std::fs::copy(&from, &to).expect("copy file");
+            }
+        }
+    }
+
+    pub fn open_read_db(fx: &ReadFixture) -> ReadDb {
+        use cqlite_core::ingestion::{ingest, IngestionConfig};
+
+        let src = table_dir(fx.keyspace, fx.table);
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let dst = tmp
+            .path()
+            .join(fx.keyspace)
+            .join(src.file_name().expect("dir name"));
+        copy_dir(&src, &dst);
+
+        let schema_path = datasets_root().join("../schemas").join(fx.schema_file);
+        let cfg = IngestionConfig {
+            schema_paths: vec![schema_path],
+            data_dir: tmp.path().to_path_buf(),
+            version_hint: Some("5.0".to_string()),
+            core_config: cqlite_core::Config::default(),
+            table_directory_filter: Some(format!("/{}/{}", fx.keyspace, fx.table)),
+        };
+
+        let rt = tokio::runtime::Runtime::new().expect("runtime");
+        let db = rt.block_on(ingest(cfg)).expect("ingest").database;
+        ReadDb { db, _tmp: tmp }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Write helpers
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "write-support")]
+mod write_helpers {
+    use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+    use cqlite_core::storage::write_engine::{STCSPolicy, WriteEngine, WriteEngineConfig};
+    use std::collections::HashMap;
+
+    fn schema() -> TableSchema {
+        TableSchema {
+            keyspace: "obs_ks".to_string(),
+            table: "items".to_string(),
+            partition_keys: vec![KeyColumn {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![],
+            columns: vec![
+                Column {
+                    name: "id".to_string(),
+                    data_type: "int".to_string(),
+                    nullable: false,
+                    default: None,
+                    is_static: false,
+                },
+                Column {
+                    name: "name".to_string(),
+                    data_type: "text".to_string(),
+                    nullable: true,
+                    default: None,
+                    is_static: false,
+                },
+                Column {
+                    name: "score".to_string(),
+                    data_type: "int".to_string(),
+                    nullable: true,
+                    default: None,
+                    is_static: false,
+                },
+            ],
+            comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
+        }
+    }
+
+    pub fn open_engine(dir: &std::path::Path) -> WriteEngine {
+        let cfg = WriteEngineConfig::new(dir.join("data"), dir.join("wal"), schema());
+        WriteEngine::new(cfg).expect("build write engine")
+    }
+
+    pub fn policy() -> STCSPolicy {
+        STCSPolicy::new(3, 32, 0.5, 1.5, 0).expect("valid STCS policy")
+    }
+}

--- a/cqlite-core/tests/observability_correctness.rs
+++ b/cqlite-core/tests/observability_correctness.rs
@@ -223,6 +223,16 @@ fn catalog_metrics_have_expected_names_units_and_error_labels() {
     let mc = testing::metrics_capture();
     mc.reset();
 
+    // Defense-in-depth against cross-test metric bleed: the in-memory exporter is
+    // process-global and uses DELTA temporality (so each collect returns only the
+    // values recorded since `reset`). To stay correct even if another test's
+    // instrumented flow emits into the same DELTA window concurrently, every
+    // assertion here keys on a UNIQUE per-test attribute value so it only ever
+    // observes ITS OWN time series. The subsystem label below is unique to this
+    // test, and the counter/gauge/histogram assertions check presence/units (not
+    // exact totals across shared series).
+    let unique_subsystem = "obs_correctness_self_test";
+
     // Emit one of each instrument kind via the production helpers.
     obs::add_counter(
         catalog::READ_ROWS,
@@ -232,10 +242,12 @@ fn catalog_metrics_have_expected_names_units_and_error_labels() {
     obs::record_histogram(catalog::QUERY_DURATION, 0.005, &[]);
     obs::record_gauge(catalog::SSTABLES_OPEN, 3, &[]);
 
-    // Induce an error so errors.total increments with bounded labels.
+    // Induce an error so errors.total increments with bounded labels. Tag it with
+    // a subsystem value unique to this test so the labeled-sum assertion below
+    // matches only this emission, never another flow's `errors.total`.
     let err: Error = Error::corruption("induced for test");
     let expected_category = err.obs_category().as_str();
-    obs::record_error(&err, "reader");
+    obs::record_error(&err, unique_subsystem);
 
     let metrics = mc.flush_and_collect();
 
@@ -276,13 +288,15 @@ fn catalog_metrics_have_expected_names_units_and_error_labels() {
         catalog::ERRORS_TOTAL,
         &[
             (catalog::attr::ERROR_CATEGORY, expected_category),
-            (catalog::attr::SUBSYSTEM, "reader"),
+            (catalog::attr::SUBSYSTEM, unique_subsystem),
         ],
     );
+    // The unique subsystem label means this matches only this test's emission, so
+    // the DELTA-window count is exactly one regardless of concurrent flows.
     assert!(
-        labeled >= 1.0,
-        "cqlite.errors.total{{category={expected_category},subsystem=reader}} must increment; \
-         saw entries: {:?}",
+        (labeled - 1.0).abs() < f64::EPSILON,
+        "cqlite.errors.total{{category={expected_category},subsystem={unique_subsystem}}} must \
+         increment exactly once; saw entries: {:?}",
         metrics.find(catalog::ERRORS_TOTAL)
     );
 
@@ -391,6 +405,8 @@ fn span_names(spans: &testing::CapturedSpans) -> Vec<String> {
     spans.iter().map(|s| s.name.clone()).collect()
 }
 
+// Only used by the cli-helpers read/query span test.
+#[cfg(feature = "cli-helpers")]
 fn span_tree(spans: &testing::CapturedSpans) -> Vec<(String, String)> {
     spans
         .iter()

--- a/cqlite-core/tests/observability_no_otel_default.rs
+++ b/cqlite-core/tests/observability_no_otel_default.rs
@@ -1,0 +1,63 @@
+//! Dependency-isolation guard for observability (epic #1031, issue #1043).
+//!
+//! Asserts the "zero-cost when off" contract at the dependency level: the DEFAULT
+//! `cqlite-core` build must link NO opentelemetry crates, and the OTel stack must
+//! appear ONLY under `--features observability`. This runs in the ordinary test
+//! suite (it does not itself need the `observability` feature) by shelling out to
+//! `cargo tree`.
+//!
+//! It mirrors `scripts/ci/observability_no_otel_default.sh` so the same guarantee
+//! is enforced both in CI (script) and in `cargo test` (this file).
+
+use std::process::Command;
+
+/// Run `cargo tree` for cqlite-core with the given extra args and return stdout.
+fn cargo_tree(extra_args: &[&str]) -> String {
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+    let mut cmd = Command::new(cargo);
+    cmd.arg("tree")
+        .args(["-p", "cqlite-core", "-e", "features"])
+        .args(extra_args);
+    // Run from the workspace root (this crate's parent dir).
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    cmd.current_dir(format!("{manifest_dir}/.."));
+    let out = cmd
+        .output()
+        .expect("failed to invoke `cargo tree` — is cargo on PATH?");
+    assert!(
+        out.status.success(),
+        "cargo tree exited non-zero: {}\nstderr:\n{}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+fn opentelemetry_lines(tree: &str) -> Vec<String> {
+    tree.lines()
+        .filter(|l| l.to_ascii_lowercase().contains("opentelemetry"))
+        .map(|l| l.to_string())
+        .collect()
+}
+
+#[test]
+fn default_build_links_no_opentelemetry() {
+    let tree = cargo_tree(&[]);
+    let hits = opentelemetry_lines(&tree);
+    assert!(
+        hits.is_empty(),
+        "DEFAULT cqlite-core build must link NO opentelemetry crates, but found:\n{}",
+        hits.join("\n")
+    );
+}
+
+#[test]
+fn observability_build_links_opentelemetry() {
+    let tree = cargo_tree(&["--features", "observability"]);
+    let hits = opentelemetry_lines(&tree);
+    assert!(
+        hits.iter().any(|l| l.contains("opentelemetry v")),
+        "--features observability build must link the OTel stack, but cargo tree had no \
+         `opentelemetry v` entry:\n{tree}"
+    );
+}

--- a/scripts/ci/observability_no_otel_default.sh
+++ b/scripts/ci/observability_no_otel_default.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Observability dependency-isolation guard (epic #1031, issue #1043).
+#
+# Asserts that the DEFAULT cqlite-core build links NO opentelemetry crates, and
+# that the OTel stack appears ONLY under `--features observability`. This is the
+# enforcement arm of the "zero-cost when off" contract: the helpers in
+# `crate::observability` compile to no-ops when the feature is off, and the
+# dependency surface must prove it.
+#
+# Run from the repo root:
+#   scripts/ci/observability_no_otel_default.sh
+#
+# Exits non-zero (and prints the offending lines) if the default build pulls in
+# any opentelemetry crate, or if the observability build does NOT.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+fail=0
+
+echo "== cargo tree: DEFAULT build (must contain NO opentelemetry) =="
+default_hits="$(cargo tree -p cqlite-core -e features 2>/dev/null | grep -i opentelemetry || true)"
+if [[ -n "$default_hits" ]]; then
+  echo "FAIL: default cqlite-core build links opentelemetry crates:"
+  echo "$default_hits"
+  fail=1
+else
+  echo "OK: default build links no opentelemetry crates."
+fi
+
+echo
+echo "== cargo tree: --features observability (must contain opentelemetry) =="
+obs_hits="$(cargo tree -p cqlite-core --features observability -e features 2>/dev/null | grep -i 'opentelemetry v' || true)"
+if [[ -z "$obs_hits" ]]; then
+  echo "FAIL: --features observability build does NOT link opentelemetry — wiring broken."
+  fail=1
+else
+  echo "OK: observability build links the OTel stack:"
+  echo "$obs_hits" | sed 's/^/    /' | sort -u | head
+fi
+
+exit "$fail"

--- a/scripts/ci/observability_overhead.sh
+++ b/scripts/ci/observability_overhead.sh
@@ -58,9 +58,12 @@ import json, os, sys
 crit_dir, base_off, base_disabled, threshold = sys.argv[1:5]
 threshold = float(threshold)
 
-# Bench IDs produced by benches/observability_overhead.rs. write_merge is only
-# present when write-support is on (it is, in both arms here); read_scan needs
-# cli-helpers (also on). Missing baselines are reported as SKIP, never a failure.
+# Bench IDs produced by benches/observability_overhead.rs. write_merge needs
+# write-support and read_scan needs cli-helpers — BOTH are enabled in BOTH arms
+# above, so BOTH baselines MUST exist. A missing baseline means the bench was
+# renamed, gated out, or its ID drifted from this list, which would silently let
+# the overhead gate pass without measuring anything — so we FAIL (not skip) on a
+# missing expected baseline.
 BENCH_IDS = ["observability_overhead/read_scan", "observability_overhead/write_merge"]
 
 def median_ns(bench_id, baseline):
@@ -77,7 +80,16 @@ for bid in BENCH_IDS:
     off = median_ns(bid, base_off)
     dis = median_ns(bid, base_disabled)
     if off is None or dis is None:
-        print(f"{bid:40} {'-':>14} {'-':>14} {'-':>12}  SKIP (baseline missing)")
+        missing = []
+        if off is None:
+            missing.append(base_off)
+        if dis is None:
+            missing.append(base_disabled)
+        fail = 1
+        print(
+            f"{bid:40} {'-':>14} {'-':>14} {'-':>12}  "
+            f"FAIL (expected baseline missing: {', '.join(missing)})"
+        )
         continue
     overhead_pct = (dis - off) / off * 100.0
     ok = overhead_pct <= threshold
@@ -88,7 +100,10 @@ for bid in BENCH_IDS:
 
 print("-" * 90)
 if fail:
-    print(f"FAIL: export-disabled observability overhead exceeded {threshold}% on at least one bench.")
+    print(
+        f"FAIL: export-disabled observability overhead exceeded {threshold}% on at least "
+        "one bench, or an expected bench baseline was missing (renamed/gated-out bench?)."
+    )
 else:
     print(f"OK: all benches within the {threshold}% overhead threshold.")
 sys.exit(fail)

--- a/scripts/ci/observability_overhead.sh
+++ b/scripts/ci/observability_overhead.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Observability zero-overhead-when-disabled gate (epic #1031, issue #1043).
+#
+# Runs the SAME `observability_overhead` Criterion bench under two builds on the
+# SAME machine and fails if the export-disabled `observability` build is more than
+# OVERHEAD_THRESHOLD_PCT (default 2%) slower (median) than the default build:
+#
+#   1) DEFAULT build              — `observability` OFF; helpers are no-ops.
+#   2) --features observability   — OTel linked, but EXPORT DISABLED (init never
+#      called → no global provider/exporter). The helper bodies run but do no work.
+#
+# Because one `cargo bench` process compiles exactly one feature set, the two
+# arms are two separate invocations; comparing them on the same runner makes the
+# delta immune to cross-machine variance (same approach as the perf-regression
+# gate). The bench source is identical in both builds — only the feature set
+# differs — so any delta is pure instrumentation overhead.
+#
+# Usage (from repo root):
+#   scripts/ci/observability_overhead.sh
+#
+# Env:
+#   OVERHEAD_THRESHOLD_PCT  max tolerated median overhead, percent (default 2.0)
+#   BENCH_ARGS              extra Criterion args (default keeps CI runs short)
+#   CQLITE_DATASETS_ROOT    required for the read_scan arm (fixtures)
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+THRESHOLD_PCT="${OVERHEAD_THRESHOLD_PCT:-2.0}"
+# Small but stable Criterion config for CI. Override via BENCH_ARGS locally.
+BENCH_ARGS="${BENCH_ARGS:---sample-size 30 --warm-up-time 1 --measurement-time 5}"
+
+# Read arm needs cli-helpers; write arm needs write-support (default-on). Both
+# builds below carry cli-helpers so the read_scan arm is present in each.
+DEFAULT_FEATURES="cli-helpers,write-support"
+OBS_FEATURES="cli-helpers,write-support,observability"
+
+CRIT_DIR="$ROOT/target/criterion"
+BASE_OFF="obs_default_off"
+BASE_DISABLED="obs_export_disabled"
+
+echo "== Arm 1/2: DEFAULT build (observability OFF), baseline '$BASE_OFF' =="
+cargo bench -p cqlite-core --features "$DEFAULT_FEATURES" \
+  --bench observability_overhead -- --save-baseline "$BASE_OFF" $BENCH_ARGS
+
+echo
+echo "== Arm 2/2: --features observability (EXPORT DISABLED), baseline '$BASE_DISABLED' =="
+cargo bench -p cqlite-core --features "$OBS_FEATURES" \
+  --bench observability_overhead -- --save-baseline "$BASE_DISABLED" $BENCH_ARGS
+
+echo
+echo "== Comparing medians (threshold ${THRESHOLD_PCT}%) =="
+python3 - "$CRIT_DIR" "$BASE_OFF" "$BASE_DISABLED" "$THRESHOLD_PCT" <<'PY'
+import json, os, sys
+
+crit_dir, base_off, base_disabled, threshold = sys.argv[1:5]
+threshold = float(threshold)
+
+# Bench IDs produced by benches/observability_overhead.rs. write_merge is only
+# present when write-support is on (it is, in both arms here); read_scan needs
+# cli-helpers (also on). Missing baselines are reported as SKIP, never a failure.
+BENCH_IDS = ["observability_overhead/read_scan", "observability_overhead/write_merge"]
+
+def median_ns(bench_id, baseline):
+    path = os.path.join(crit_dir, bench_id, baseline, "estimates.json")
+    if not os.path.isfile(path):
+        return None
+    with open(path) as fh:
+        return json.load(fh)["median"]["point_estimate"]
+
+fail = 0
+print(f"{'bench':40} {'off (ns)':>14} {'disabled (ns)':>14} {'overhead %':>12}  result")
+print("-" * 90)
+for bid in BENCH_IDS:
+    off = median_ns(bid, base_off)
+    dis = median_ns(bid, base_disabled)
+    if off is None or dis is None:
+        print(f"{bid:40} {'-':>14} {'-':>14} {'-':>12}  SKIP (baseline missing)")
+        continue
+    overhead_pct = (dis - off) / off * 100.0
+    ok = overhead_pct <= threshold
+    status = "OK" if ok else "FAIL"
+    if not ok:
+        fail = 1
+    print(f"{bid:40} {off:14.1f} {dis:14.1f} {overhead_pct:12.2f}  {status}")
+
+print("-" * 90)
+if fail:
+    print(f"FAIL: export-disabled observability overhead exceeded {threshold}% on at least one bench.")
+else:
+    print(f"OK: all benches within the {threshold}% overhead threshold.")
+sys.exit(fail)
+PY


### PR DESCRIPTION
Part of epic #1031. Closes the non-functional bar.

- Criterion overhead bench (read_scan + write_merge): default vs --features observability with export DISABLED; <2% threshold (measured ~0%). Two-build comparison script + CI workflow (paths include instrumented query/storage/bindings/flight so regressions trigger the gate; missing baseline now FAILS, not skips).
- Shared in-memory OTLP capture fixture (cqlite_core::observability::testing, behind observability-testing feature) using SDK in-memory exporters with DELTA temporality for parallel-safe metric isolation.
- Correctness tests: query.execute parents read-path spans; write/compaction span trees; catalog metric names+units; cqlite.errors.total increments with bounded {category,subsystem}; sampling (ratio 0/1, parent-based, unsampled hot path = 0 spans).
- cargo-tree guard: default build links zero opentelemetry crates. Heap budget holds (6.9 MiB << 128 MiB) with observability on.

Validation: builds + clippy -D warnings clean; 6 correctness tests pass (parallel-safe, verified 5x); cargo-tree empty by default. roborev clean (job 1206).

Closes #1043