### PR TITLE
fix(ci): repair pre-existing minimal-build, fmt, and py3.9 gate lanes

### DIFF
--- a/bindings/node/src/database.rs
+++ b/bindings/node/src/database.rs
@@ -1284,8 +1284,7 @@ impl napi::Task for ExecuteNativeTask {
         use tracing::Instrument;
 
         // Per-call span (issue #1040), parented under the handle's traceparent.
-        let span =
-            crate::observability::execute_span("executeNative", self.traceparent.as_deref());
+        let span = crate::observability::execute_span("executeNative", self.traceparent.as_deref());
 
         // Route DML to write engine when write support is present. This path is
         // fully synchronous, so a span guard is correct (no `.await`).
@@ -1294,9 +1293,9 @@ impl napi::Task for ExecuteNativeTask {
             if let Some(ref we) = self.write_engine {
                 let _entered = span.enter();
                 let start = std::time::Instant::now();
-                let mut engine = we.lock().map_err(|_| {
-                    simple_error("Write engine lock poisoned")
-                })?;
+                let mut engine = we
+                    .lock()
+                    .map_err(|_| simple_error("Write engine lock poisoned"))?;
                 engine.execute(&self.query).map_err(to_napi_error)?;
                 let elapsed_ms = start.elapsed().as_millis() as u32;
                 crate::observability::record_rows(&span, 0);

--- a/bindings/node/src/observability.rs
+++ b/bindings/node/src/observability.rs
@@ -361,10 +361,7 @@ mod tests {
         assert!(!cfg.endpoint.trim().is_empty());
         assert!(!cfg.service_name.trim().is_empty());
         // Bad protocol ignored -> default grpc kept.
-        assert_eq!(
-            cfg.protocol,
-            cqlite_core::observability::OtelProtocol::Grpc
-        );
+        assert_eq!(cfg.protocol, cqlite_core::observability::OtelProtocol::Grpc);
         // Non-finite ratio ignored -> sane finite value.
         assert!(cfg.sampling_ratio.is_finite());
     }

--- a/bindings/python/tests/test_parity.py
+++ b/bindings/python/tests/test_parity.py
@@ -23,6 +23,12 @@ Tables Tested (33 total):
                         multi_metric_timeseries, product_catalog, sparse_data_table
 """
 
+# Defer annotation evaluation so PEP 604 unions (e.g. `Path | None`) parse on
+# Python 3.9, the project's minimum supported version. Without this, the
+# module-level `-> Path | None` annotation is evaluated at import time and
+# raises `TypeError` on 3.9 (PEP 604 runtime support is 3.10+).
+from __future__ import annotations
+
 import functools
 import json
 import re

--- a/cqlite-cli/src/config.rs
+++ b/cqlite-cli/src/config.rs
@@ -1191,11 +1191,7 @@ mod tests {
         env::set_var("CQLITE_OTEL_ENABLED", "true");
         env::set_var("CQLITE_OTEL_ENDPOINT", "http://from-env:4317");
 
-        let cli = Cli::parse_from(&[
-            "cqlite",
-            "--otel-endpoint",
-            "http://from-flag:4317",
-        ]);
+        let cli = Cli::parse_from(&["cqlite", "--otel-endpoint", "http://from-flag:4317"]);
         let config = Config::load(None, &cli).unwrap();
 
         // clap merged env into otel_enabled (no flag) -> Some(true);

--- a/cqlite-core/Cargo.toml
+++ b/cqlite-core/Cargo.toml
@@ -183,6 +183,8 @@ deflate = ["dep:flate2"]
 zstd = ["dep:zstd"]
 all-compression = ["lz4", "snappy", "deflate", "zstd"]
 
+# Other features - non-compression, all opt-in (NOT in defaults unless noted).
+
 # CLI-specific helpers (Issue #249) - NOT in defaults for pure library mode
 # Requires state_machine for query engine and discovery dependencies
 cli-helpers = ["state_machine"]

--- a/cqlite-core/src/observability/error_schema.rs
+++ b/cqlite-core/src/observability/error_schema.rs
@@ -216,10 +216,7 @@ mod tests {
         assert_eq!(Error::concurrency("c").obs_category(), Concurrency);
         assert_eq!(Error::transaction("t").obs_category(), Concurrency);
 
-        assert_eq!(
-            Error::constraint_violation("c").obs_category(),
-            Constraints
-        );
+        assert_eq!(Error::constraint_violation("c").obs_category(), Constraints);
         assert_eq!(Error::already_exists("a").obs_category(), Constraints);
 
         assert_eq!(Error::query_execution("q").obs_category(), Query);

--- a/cqlite-core/src/observability/mod.rs
+++ b/cqlite-core/src/observability/mod.rs
@@ -288,7 +288,11 @@ mod tests {
     #[test]
     fn helpers_are_callable_in_any_build() {
         // These must compile and not panic regardless of feature state.
-        add_counter(catalog::READ_ROWS, 3, &[(catalog::attr::SSTABLE_FORMAT, "bti".into())]);
+        add_counter(
+            catalog::READ_ROWS,
+            3,
+            &[(catalog::attr::SSTABLE_FORMAT, "bti".into())],
+        );
         record_histogram(catalog::QUERY_DURATION, 0.001, &[]);
         record_gauge(catalog::SSTABLES_OPEN, 2, &[]);
         let err = Error::corruption("x");

--- a/cqlite-core/src/observability/otel.rs
+++ b/cqlite-core/src/observability/otel.rs
@@ -378,7 +378,10 @@ pub(crate) fn record_histogram(name: &'static str, value: f64, attributes: &[Key
     } else if name == catalog::COMPACTION_DURATION {
         &i.compaction_duration
     } else {
-        meter().f64_histogram(name).build().record(value, attributes);
+        meter()
+            .f64_histogram(name)
+            .build()
+            .record(value, attributes);
         return;
     };
     hist.record(value, attributes);

--- a/cqlite-core/src/observability/testing.rs
+++ b/cqlite-core/src/observability/testing.rs
@@ -173,14 +173,11 @@ impl CapturedSpans {
     /// parent span id, sharing the same trace.
     pub fn is_parent_of(&self, parent: &str, child: &str) -> bool {
         let parents: Vec<_> = self.spans.iter().filter(|s| s.name == parent).collect();
-        self.spans
-            .iter()
-            .filter(|s| s.name == child)
-            .any(|c| {
-                parents.iter().any(|p| {
-                    p.span_id() == c.parent_span_id() && p.trace_id() == c.trace_id()
-                })
-            })
+        self.spans.iter().filter(|s| s.name == child).any(|c| {
+            parents
+                .iter()
+                .any(|p| p.span_id() == c.parent_span_id() && p.trace_id() == c.trace_id())
+        })
     }
 }
 
@@ -308,11 +305,9 @@ impl CapturedMetrics {
         m.points
             .iter()
             .filter(|p| {
-                required.iter().all(|(k, v)| {
-                    p.attributes
-                        .iter()
-                        .any(|(pk, pv)| pk == k && pv == v)
-                })
+                required
+                    .iter()
+                    .all(|(k, v)| p.attributes.iter().any(|(pk, pv)| pk == k && pv == v))
             })
             .map(|p| p.value)
             .sum()

--- a/cqlite-core/src/query/engine.rs
+++ b/cqlite-core/src/query/engine.rs
@@ -189,10 +189,8 @@ impl QueryEngine {
             self.inc_error_queries();
             crate::observability::record_error(e, "query");
         })?;
-        let plan = crate::observability::record_result(
-            "query",
-            self.planner.plan(&parsed_query).await,
-        )?;
+        let plan =
+            crate::observability::record_result("query", self.planner.plan(&parsed_query).await)?;
 
         if self.config.query.query_cache_size.unwrap_or(0) > 0 {
             self.cache_query_plan(cql, parsed_query, plan.clone());
@@ -683,16 +681,28 @@ impl QueryEngine {
             execution_time.as_secs_f64(),
             &[
                 (catalog::attr::SUBSYSTEM, AttrValue::StaticStr("query")),
-                (catalog::attr::ACCESS_PATH, AttrValue::StaticStr(access_path_label)),
-                (catalog::attr::PLAN_TYPE, AttrValue::StaticStr(plan_type_label)),
+                (
+                    catalog::attr::ACCESS_PATH,
+                    AttrValue::StaticStr(access_path_label),
+                ),
+                (
+                    catalog::attr::PLAN_TYPE,
+                    AttrValue::StaticStr(plan_type_label),
+                ),
             ],
         );
         obs::add_counter(
             catalog::QUERY_ROWS,
             result.rows.len() as u64,
             &[
-                (catalog::attr::ACCESS_PATH, AttrValue::StaticStr(access_path_label)),
-                (catalog::attr::PLAN_TYPE, AttrValue::StaticStr(plan_type_label)),
+                (
+                    catalog::attr::ACCESS_PATH,
+                    AttrValue::StaticStr(access_path_label),
+                ),
+                (
+                    catalog::attr::PLAN_TYPE,
+                    AttrValue::StaticStr(plan_type_label),
+                ),
             ],
         );
 

--- a/cqlite-core/src/storage/mod.rs
+++ b/cqlite-core/src/storage/mod.rs
@@ -60,9 +60,13 @@ impl StorageEngine {
     ///
     /// NOTE: Issue #176 removed write infrastructure (compaction, manifest).
     /// This is now a read-only storage layer focused on SSTable access.
+    // `skip_all` (not an explicit skip list): the `schema_registry` parameter is
+    // `#[cfg(feature = "state_machine")]`-gated, so naming it in `skip(...)` would
+    // reference a nonexistent binding in the minimal build. `skip_all` records no
+    // args as fields regardless of cfg; the `fields(...)` below are set in the body.
     #[tracing::instrument(
         name = "storage.engine.open",
-        skip(path, config, platform),
+        skip_all,
         fields(sstables = tracing::field::Empty, bytes = tracing::field::Empty)
     )]
     pub async fn open(
@@ -74,10 +78,7 @@ impl StorageEngine {
         >,
     ) -> Result<Self> {
         // Create storage directory if it doesn't exist
-        crate::observability::record_result(
-            "reader",
-            platform.fs().create_dir_all(path).await,
-        )?;
+        crate::observability::record_result("reader", platform.fs().create_dir_all(path).await)?;
 
         // Initialize SSTable manager with schema registry
         let sstables = Arc::new(crate::observability::record_result(
@@ -113,7 +114,11 @@ impl StorageEngine {
             Ok(stats) => {
                 tracing::Span::current().record("sstables", stats.sstable_count as u64);
                 tracing::Span::current().record("bytes", stats.total_size);
-                obs::add_counter(catalog::STORAGE_OPEN_SSTABLES, stats.sstable_count as u64, &[]);
+                obs::add_counter(
+                    catalog::STORAGE_OPEN_SSTABLES,
+                    stats.sstable_count as u64,
+                    &[],
+                );
                 obs::add_counter(catalog::STORAGE_OPEN_BYTES, stats.total_size, &[]);
                 obs::add_counter(catalog::STORAGE_OPEN_TABLES, stats.total_tables, &[]);
             }
@@ -164,9 +169,11 @@ impl StorageEngine {
     /// # Ok(())
     /// # }
     /// ```
+    // `skip_all`: see the note on `open` — the cfg-gated `schema_registry` cannot
+    // be named in an explicit `skip(...)` without breaking the minimal build.
     #[tracing::instrument(
         name = "storage.engine.open",
-        skip(path, discovered_table_dirs, config, platform),
+        skip_all,
         fields(sstables = tracing::field::Empty, bytes = tracing::field::Empty)
     )]
     pub async fn open_with_sstables(
@@ -179,10 +186,7 @@ impl StorageEngine {
         >,
     ) -> Result<Self> {
         // Create storage directory if it doesn't exist
-        crate::observability::record_result(
-            "reader",
-            platform.fs().create_dir_all(path).await,
-        )?;
+        crate::observability::record_result("reader", platform.fs().create_dir_all(path).await)?;
 
         // Initialize SSTable manager with pre-discovered paths and schema registry
         let sstables = Arc::new(crate::observability::record_result(

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -533,7 +533,9 @@ impl SSTableReader {
 
         // Load spec readers for enhanced metadata and lookups
         let index_reader = Self::load_index_reader(path, &platform)
-            .instrument(tracing::debug_span!("sstable.reader.open.load_index_reader"))
+            .instrument(tracing::debug_span!(
+                "sstable.reader.open.load_index_reader"
+            ))
             .await;
         let summary_reader = Self::load_summary_reader(path, &platform)
             .instrument(tracing::debug_span!("sstable.reader.open.load_summary"))

--- a/cqlite-core/src/storage/sstable/writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/mod.rs
@@ -831,11 +831,7 @@ impl SSTableWriter {
         self.stats.increment_partition_count();
 
         // Partitions-written counter (issue #1036). One per successful partition.
-        crate::observability::add_counter(
-            crate::observability::catalog::WRITE_PARTITIONS,
-            1,
-            &[],
-        );
+        crate::observability::add_counter(crate::observability::catalog::WRITE_PARTITIONS, 1, &[]);
 
         Ok(())
     }

--- a/cqlite-core/tests/observability_correctness.rs
+++ b/cqlite-core/tests/observability_correctness.rs
@@ -80,15 +80,11 @@ fn query_execute_span_parents_read_path() {
     // At least one read-path span (the query.* sub-spans or storage/sstable
     // spans) must nest under query.execute. We assert the SELECT plan span, which
     // is created inside execute for SELECTs.
-    let read_child = spans
-        .iter()
-        .map(|s| s.name.as_str())
-        .find(|n| {
-            n.starts_with("query.")
-                && *n != "query.execute"
-                || n.starts_with("sstable.")
-                || n.starts_with("storage.")
-        });
+    let read_child = spans.iter().map(|s| s.name.as_str()).find(|n| {
+        n.starts_with("query.") && *n != "query.execute"
+            || n.starts_with("sstable.")
+            || n.starts_with("storage.")
+    });
     assert!(
         read_child.is_some(),
         "expected a read-path child span under query.execute; saw: {:?}",
@@ -120,11 +116,12 @@ fn write_flow_emits_write_spans() {
         let tmp = tempfile::TempDir::new().expect("temp dir");
         let mut engine = write_helpers::open_engine(tmp.path());
         engine
-            .execute(
-                "INSERT INTO obs_ks.items (id, name, score) VALUES (1, 'one', 10)",
-            )
+            .execute("INSERT INTO obs_ks.items (id, name, score) VALUES (1, 'one', 10)")
             .expect("write row");
-        let info = rt.block_on(engine.flush()).expect("flush").expect("sstable");
+        let info = rt
+            .block_on(engine.flush())
+            .expect("flush")
+            .expect("sstable");
         assert!(info.data_path.exists(), "flush must produce a Data.db");
     });
 
@@ -170,7 +167,8 @@ fn compaction_flow_emits_compaction_spans() {
             .expect("current-thread runtime");
         let tmp = tempfile::TempDir::new().expect("temp dir");
         let mut engine = write_helpers::open_engine(tmp.path());
-        engine.set_merge_policy(Box::new(write_helpers::policy()))
+        engine
+            .set_merge_policy(Box::new(write_helpers::policy()))
             .expect("set policy");
 
         // Three small SSTables so STCS(min_threshold=3) selects them.
@@ -183,7 +181,9 @@ fn compaction_flow_emits_compaction_spans() {
                     ))
                     .expect("write row");
             }
-            rt.block_on(engine.flush()).expect("flush").expect("sstable");
+            rt.block_on(engine.flush())
+                .expect("flush")
+                .expect("sstable");
         }
 
         // maintenance_step uses an internal block_on; safe here because we run it
@@ -303,7 +303,9 @@ fn catalog_metrics_have_expected_names_units_and_error_labels() {
     // The induced category must be one of the bounded taxonomy values, never a
     // raw message.
     assert!(
-        ErrorCategory::ALL.iter().any(|c| c.as_str() == expected_category),
+        ErrorCategory::ALL
+            .iter()
+            .any(|c| c.as_str() == expected_category),
         "induced error category {expected_category} must be a bounded taxonomy value"
     );
 }

--- a/cqlite-flight/src/main.rs
+++ b/cqlite-flight/src/main.rs
@@ -75,8 +75,7 @@ fn init_tracing_subscriber() {
     use tracing_subscriber::util::SubscriberInitExt;
     use tracing_subscriber::{fmt, EnvFilter};
 
-    let env_filter =
-        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
 
     let registry = tracing_subscriber::registry()
         .with(env_filter)

--- a/cqlite-flight/src/obs.rs
+++ b/cqlite-flight/src/obs.rs
@@ -395,9 +395,8 @@ mod tests {
                 .parse()
                 .expect("ascii value"),
         );
-        let cx = opentelemetry::global::get_text_map_propagator(|p| {
-            p.extract(&MetadataExtractor(&md))
-        });
+        let cx =
+            opentelemetry::global::get_text_map_propagator(|p| p.extract(&MetadataExtractor(&md)));
         let trace_id = cx.span().span_context().trace_id();
         assert_eq!(
             format!("{trace_id:032x}"),


### PR DESCRIPTION
## Summary
Repairs three **pre-existing** breakages on `main`, all from the observability epic (#1034/#1043) merging without these gate lanes green. Discovered while validating #1061; split out so the compaction fix stays scoped.

### 1. `minimal-build` — compile error (`cqlite-core/src/storage/mod.rs`)
`StorageEngine::open` / `open_with_sstables` carried `#[tracing::instrument(skip(...))]` that did not skip the `#[cfg(feature = "state_machine")]`-gated `schema_registry` param. With `state_machine` off (`--no-default-features --features all-compression`), the param is stripped but `instrument`'s generated field-recording still referenced it → `error[E0425]: cannot find value schema_registry`. Switched both to `skip_all` (cfg-agnostic; records no args, the explicit `fields(...)` are set in the body).

### 2. `fmt`
`cargo fmt --all` over node/cli/observability/flight files merged unformatted.

### 3. `python-bindings` — Python 3.9 incompatibility (`bindings/python/tests/test_parity.py`)
A module-level PEP 604 annotation (`-> Path | None`) was evaluated at import time and raised `TypeError` on Python 3.9 (the project minimum). Added `from __future__ import annotations`.

## Validation
- `scripts/agent-gate.sh`: **RESULT: PASS** — all 10 lanes green (fmt, clippy, core/integration/format-compat/write/cli tests, python-bindings, minimal-build, smoke).
- roborev: clean (job 1212).
- python: 367 passed / 59 skipped / 1 xfailed on Python 3.9.6.