### PR TITLE
fix(compaction): apply partition tombstones across merge sources (#1072)

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/compaction_row.rs
+++ b/cqlite-core/src/storage/sstable/reader/compaction_row.rs
@@ -161,6 +161,24 @@ pub enum CompactionRowData {
         /// `localDeletionTime` in seconds (GC-grace clock).
         local_deletion_time: i32,
     },
+    /// Partition-level tombstone (whole-partition delete) carrying its
+    /// authoritative timestamps (issue #1072).
+    ///
+    /// Surfaced by the compaction read path as a synthetic carrier row (no
+    /// clustering) so the cross-generation merge can apply the partition deletion
+    /// as the OUTERMOST floor — shadowing every older cell/row/range/complex
+    /// marker across ALL merge sources — and re-emit the surviving partition
+    /// tombstone to the output SSTable. Without this carrier a newer partition
+    /// tombstone in one SSTable failed to shadow older live rows in another,
+    /// resurrecting deleted partitions. `deletion_time` is `markedForDeleteAt`
+    /// (microseconds); `local_deletion_time` is the GC-grace clock (seconds,
+    /// carried as the wrapping `as u32 as i32` for far-future LDTs).
+    PartitionDelete {
+        /// `markedForDeleteAt` in microseconds.
+        deletion_time: i64,
+        /// `localDeletionTime` in seconds (GC-grace clock).
+        local_deletion_time: i32,
+    },
     /// Row tombstone (whole-row delete) carrying its authoritative timestamps.
     Tombstone {
         /// `markedForDeleteAt` in microseconds.

--- a/cqlite-core/src/storage/sstable/reader/delta_scan.rs
+++ b/cqlite-core/src/storage/sstable/reader/delta_scan.rs
@@ -2173,7 +2173,7 @@ mod tests {
             "DEAD partition must yield Some(deleted_at); got None"
         );
         assert_eq!(
-            partition_deletion.unwrap(),
+            partition_deletion.unwrap().0,
             dead_ts,
             "deleted_at must equal the markedForDeleteAt bytes in the header"
         );

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
@@ -731,7 +731,7 @@ impl V5CompressedLegacyParser {
             // Issue #699: emit PartitionDelete if the partition header carried
             // a tombstone (markedForDeleteAt != LIVE sentinel).
             // ----------------------------------------------------------------
-            if let Some(deleted_at) = partition_deletion {
+            if let Some((deleted_at, _partition_ldt)) = partition_deletion {
                 match emit((
                     partition_key.clone(),
                     HashMap::new(),
@@ -2255,16 +2255,36 @@ impl V5CompressedLegacyParser {
             });
         }
 
-        let (partition_key, mut offset) = match self.parse_partition_header(data, 0) {
-            Ok(v) => v,
-            Err(_) => return Ok(ParseStep::Emitted(1)),
-        };
+        let (partition_key, mut offset, partition_deletion) =
+            match self.parse_partition_header_full(data, 0) {
+                Ok(v) => v,
+                Err(_) => return Ok(ParseStep::Emitted(1)),
+            };
 
         // Static cells are kept as the collapsed map so they can be folded into
         // subsequent clustering rows, exactly like the legacy path. They are
         // surfaced as simple cells on each emitted row.
         let mut static_cells: HashMap<String, Value> = HashMap::new();
         let mut pending: Vec<CompactionRow> = Vec::new();
+
+        // Issue #1072: a partition-level tombstone in this SSTable must shadow OLDER
+        // live rows in OTHER SSTables during a cross-generation compaction merge.
+        // Surface it as a synthetic partition-deletion `CompactionRow` (mirroring the
+        // `RangeMarker` carrier) so the merge can apply the partition floor and
+        // re-emit the surviving tombstone. Pushed exactly once per partition — even
+        // when the partition has zero rows (tombstone-only case) — because this
+        // header parse runs once per partition emit.
+        if let Some((mfda, ldt)) = partition_deletion {
+            use crate::storage::sstable::reader::compaction_row::CompactionRowData;
+            pending.push(CompactionRow {
+                key: partition_key.clone(),
+                row_timestamp: mfda,
+                row_data: CompactionRowData::PartitionDelete {
+                    deletion_time: mfda,
+                    local_deletion_time: ldt,
+                },
+            });
+        }
 
         // In-flight range tombstone start bound (issue #933). A range tombstone is
         // a pair of adjacent bound markers (start then end), or a sequence of
@@ -3046,27 +3066,29 @@ impl V5CompressedLegacyParser {
     /// Exposed for integration testing to validate partition header parsing
     #[doc(hidden)]
     pub fn parse_partition_header(&self, data: &[u8], offset: usize) -> Result<(RowKey, usize)> {
-        let (row_key, next_offset, _deletion_time) =
-            self.parse_partition_header_full(data, offset)?;
+        let (row_key, next_offset, _deletion) = self.parse_partition_header_full(data, offset)?;
         Ok((row_key, next_offset))
     }
 
     /// Like [`parse_partition_header`] but also returns the partition-level deletion
-    /// timestamp (`markedForDeleteAt` in µs since epoch), if the partition is deleted.
+    /// `(markedForDeleteAt µs, localDeletionTime s)`, if the partition is deleted.
     ///
-    /// Returns `(RowKey, next_offset, Option<markedForDeleteAt_micros>)`.
+    /// Returns `(RowKey, next_offset, Option<(markedForDeleteAt_micros, localDeletionTime_secs)>)`.
     ///
     /// `None` means the partition is live (no partition tombstone).
-    /// `Some(ts)` means the partition carries a tombstone; `ts` is the authoritative
-    /// reconciliation timestamp in microseconds since the Unix epoch.
+    /// `Some((mfda, ldt))` means the partition carries a tombstone; `mfda` is the
+    /// authoritative reconciliation timestamp in microseconds since the Unix epoch and
+    /// `ldt` is the GC-grace clock in seconds (carried as the wrapping `as u32 as i32`
+    /// for far-future local-deletion-times, matching the row/range tombstone contract).
     ///
     /// Authority: DeletionTime.java (getSerializer / legacySerializer / Serializer),
     /// BigFormat.java:409 (`hasUIntDeletionTime`).
+    #[allow(clippy::type_complexity)]
     pub fn parse_partition_header_full(
         &self,
         data: &[u8],
         mut offset: usize,
-    ) -> Result<(RowKey, usize, Option<i64>)> {
+    ) -> Result<(RowKey, usize, Option<(i64, i32)>)> {
         let start_offset = offset;
 
         if offset >= data.len() {
@@ -3131,7 +3153,7 @@ impl V5CompressedLegacyParser {
         //            8 bytes markedForDeleteAt (long) = 12 bytes total
         //
         // Authority: DeletionTime.java:191-219 (getSerializer / Serializer.serialize)
-        let partition_deletion: Option<i64>;
+        let partition_deletion: Option<(i64, i32)>;
         if self.has_uint_deletion_time() {
             // oa / da format
             if offset >= data.len() {
@@ -3165,8 +3187,16 @@ impl V5CompressedLegacyParser {
                         .try_into()
                         .map_err(|_| Error::corruption("V5CompressedLegacy: oa mfda slice"))?,
                 );
+                // localDeletionTime is the next 4 bytes (big-endian u32). Keep the
+                // wrapping `as u32 as i32` representation so far-future LDTs in
+                // [2^31, 2^32) round-trip exactly like row/range tombstones.
+                let ldt = u32::from_be_bytes(
+                    data[offset + 8..offset + 12]
+                        .try_into()
+                        .map_err(|_| Error::corruption("V5CompressedLegacy: oa ldt slice"))?,
+                ) as i32;
                 offset += 12; // markedForDeleteAt(8) + localDeletionTime(4)
-                partition_deletion = Some(mfda);
+                partition_deletion = Some((mfda, ldt));
             }
         } else {
             // nb format: 4 bytes localDeletionTime (big-endian i32)
@@ -3197,7 +3227,7 @@ impl V5CompressedLegacyParser {
             if local_deletion_time == NB_LIVE_LOCAL_DELETION_TIME {
                 partition_deletion = None;
             } else {
-                partition_deletion = Some(mfda);
+                partition_deletion = Some((mfda, local_deletion_time));
             }
         }
 

--- a/cqlite-core/src/storage/write_engine/merge.rs
+++ b/cqlite-core/src/storage/write_engine/merge.rs
@@ -122,6 +122,19 @@ pub struct MergeEntry {
     /// deletion and let older cells of other columns (in SSTables not part of the
     /// compaction) resurrect. `None` for a row with no coexisting deletion.
     pub row_deletion: Option<(i64, i32)>,
+    /// Partition-level deletion `(markedForDeleteAt µs, localDeletionTime s)`
+    /// carried by a synthetic partition-tombstone carrier entry (issue #1072).
+    ///
+    /// `Some(..)` ONLY on the carrier entry the reader emits for a partition
+    /// header that has a tombstone (empty `RowData::Live`, `clustering_key:
+    /// None`). The merge extracts the MAX `markedForDeleteAt` across sources,
+    /// applies it as the OUTERMOST per-cell `<=` shadow floor for the whole
+    /// partition, and re-emits the surviving tombstone via
+    /// `merge_entry_to_mutation` (→ `Mutation::partition_tombstone`). Without
+    /// this a newer partition tombstone in one SSTable failed to shadow older
+    /// live rows in another, resurrecting the deleted partition. `None` for every
+    /// non-carrier entry.
+    pub partition_deletion: Option<(i64, i32)>,
 }
 
 impl MergeEntry {
@@ -148,6 +161,7 @@ impl MergeEntry {
             complex_deletions: Vec::new(),
             range_deletion: None,
             row_deletion: None,
+            partition_deletion: None,
         }
     }
 
@@ -177,6 +191,18 @@ impl MergeEntry {
         self
     }
 
+    /// Attach a partition-level deletion (issue #1072).
+    ///
+    /// `deletion_time` is `markedForDeleteAt` (microseconds); `ldt` is the
+    /// `localDeletionTime` (GC-clock seconds). Marks this entry as the synthetic
+    /// partition-tombstone carrier so the merge applies the partition floor and
+    /// re-emits the surviving tombstone.
+    #[must_use]
+    pub fn with_partition_deletion(mut self, partition_deletion: (i64, i32)) -> Self {
+        self.partition_deletion = Some(partition_deletion);
+        self
+    }
+
     /// True when this entry has NO writer-emittable content at all — an empty
     /// `RowData::Live { cells: vec![] }` with no row tombstone and no carried
     /// deletion metadata. Routing such an entry to the writer would create a
@@ -203,6 +229,18 @@ impl MergeEntry {
             && self.complex_deletions.is_empty()
             && self.range_deletion.is_none()
             && self.row_deletion.is_none()
+            && self.partition_deletion.is_none()
+    }
+
+    /// True when this entry is a synthetic partition-tombstone carrier (issue
+    /// #1072): an empty live row whose only payload is `partition_deletion`.
+    /// Produced by [`Self::build_merge_entry`] from a reader `PartitionDelete`.
+    /// Such an entry produces NO output row (it yields a
+    /// `Mutation::partition_tombstone`, not a clustering row), so the merge must
+    /// not count it toward output row counts — but it MUST reach the writer.
+    #[must_use]
+    pub fn is_partition_delete_carrier(&self) -> bool {
+        self.partition_deletion.is_some()
     }
 }
 
@@ -910,6 +948,37 @@ impl SSTableRowIteratorAdapter {
         } = compaction_row;
         let decorated_key = DecoratedKey::from_key_bytes(key.0)?;
 
+        // Issue #1072: a partition-level tombstone surfaces as a self-contained
+        // carrier `MergeEntry` (empty live row + `partition_deletion`, no
+        // clustering). `merge_partition_rows` extracts these, applies the MAX
+        // partition floor across sources to shadow older cells/rows/ranges, and
+        // re-emits the surviving partition tombstone. Handled BEFORE the
+        // `RangeMarker` block so the partition floor is the outermost shadow.
+        if let CompactionRowData::PartitionDelete {
+            deletion_time,
+            local_deletion_time,
+        } = row_data
+        {
+            // Carry the deletion in `RowData::Tombstone` so the carrier never
+            // surfaces as a phantom live row to consumers iterating the merge step
+            // stream; `partition_deletion` marks it as the partition-level carrier
+            // and `merge_entry_to_mutation` lifts it onto the partition header
+            // (emitting NO clustering-row `DeleteRow`).
+            return Ok(MergeEntry::new(
+                run_index,
+                decorated_key,
+                None,
+                // Use markedForDeleteAt as the entry timestamp so stats baselines
+                // see a real value (not 0) for the carrier.
+                deletion_time,
+                RowData::Tombstone {
+                    deletion_time,
+                    local_deletion_time,
+                },
+            )
+            .with_partition_deletion((deletion_time, local_deletion_time)));
+        }
+
         // Issue #933: a range-tombstone marker surfaces as a self-contained
         // carrier `MergeEntry` (empty live row + `range_deletion`), routed into the
         // partition's `None` clustering bucket so it is never collapsed with data
@@ -1062,6 +1131,9 @@ impl SSTableRowIteratorAdapter {
             // Issue #933: a range marker is handled by `build_merge_entry` before
             // this point and routed into the `None` clustering bucket.
             CompactionRowData::RangeMarker { .. } => None,
+            // Issue #1072: a partition tombstone is handled by `build_merge_entry`
+            // before this point and routed into the `None` clustering bucket.
+            CompactionRowData::PartitionDelete { .. } => None,
         }
     }
 
@@ -1193,6 +1265,12 @@ impl SSTableRowIteratorAdapter {
             // (carrier entry with `range_deletion`); they never reach this
             // conversion. Map defensively to an empty live row.
             CompactionRowData::RangeMarker { .. } => {
+                (RowData::Live { cells: Vec::new() }, Vec::new(), None)
+            }
+            // Issue #1072: partition tombstones are intercepted in
+            // `build_merge_entry` (carrier entry with `partition_deletion`); they
+            // never reach this conversion. Map defensively to an empty live row.
+            CompactionRowData::PartitionDelete { .. } => {
                 (RowData::Live { cells: Vec::new() }, Vec::new(), None)
             }
         }
@@ -2086,6 +2164,8 @@ struct PurgeCounts {
     range_tombstones: u64,
     /// Complex-deletion (collection/UDT) markers purged.
     complex_deletions: u64,
+    /// Partition-level tombstones purged (issue #1072).
+    partition_tombstones: u64,
 }
 
 #[cfg(feature = "write-support")]
@@ -2096,6 +2176,7 @@ impl PurgeCounts {
             .saturating_add(self.row_tombstones)
             .saturating_add(self.range_tombstones)
             .saturating_add(self.complex_deletions)
+            .saturating_add(self.partition_tombstones)
     }
 }
 
@@ -2271,16 +2352,24 @@ impl KWayMerger {
                 continue;
             }
 
-            // Count only real rows toward `output_rows`; a pure range-tombstone
+            // Count only real rows toward `output_rows`. A pure range-tombstone
             // carrier (empty operations, no row tombstone, only `range_tombstones`)
-            // emits a marker, not a row (#933).
+            // emits a marker, not a row (#933). A pure partition-tombstone carrier
+            // (empty operations, no row tombstone, no range tombstones, only
+            // `partition_tombstone`) emits a partition-header deletion, not a row
+            // (#1072).
             let row_mutations = mutations
                 .iter()
                 .filter(|m| {
-                    !(m.operations.is_empty()
+                    let is_range_only = m.operations.is_empty()
                         && m.partition_tombstone.is_none()
                         && m.row_tombstone.is_none()
-                        && !m.range_tombstones.is_empty())
+                        && !m.range_tombstones.is_empty();
+                    let is_partition_only = m.operations.is_empty()
+                        && m.partition_tombstone.is_some()
+                        && m.row_tombstone.is_none()
+                        && m.range_tombstones.is_empty();
+                    !(is_range_only || is_partition_only)
                 })
                 .count();
 
@@ -2461,7 +2550,27 @@ impl KWayMerger {
         let mut range_tombstones: Vec<(DecoratedKey, RangeTombstone)> = Vec::new();
         let mut clustered_rows: BTreeMap<Option<ClusteringKey>, Vec<MergeEntry>> = BTreeMap::new();
 
+        // Issue #1072: extract the synthetic partition-tombstone carriers and keep
+        // the MAX `markedForDeleteAt` across ALL merge sources (with the winning
+        // mfda's localDeletionTime). This is the partition's OUTERMOST shadow floor.
+        // Carriers are NOT pushed into `clustered_rows` (they are partition-level,
+        // not per-`(pk, ck)` rows). The partition key is the same for every entry in
+        // this call (`merge_partition_rows` is invoked per partition), so a single
+        // floor value covers the whole partition.
+        let mut max_partition_deletion: Option<(i64, i32)> = None;
+        let mut partition_delete_key: Option<DecoratedKey> = None;
+
         for row in rows {
+            if row.is_partition_delete_carrier() {
+                if let Some((mfda, ldt)) = row.partition_deletion {
+                    partition_delete_key.get_or_insert_with(|| row.key.clone());
+                    match max_partition_deletion {
+                        Some((cur_mfda, _)) if cur_mfda >= mfda => {}
+                        _ => max_partition_deletion = Some((mfda, ldt)),
+                    }
+                    continue;
+                }
+            }
             if Self::is_range_marker_carrier(&row) {
                 if let Some(rt) = row.range_deletion.clone() {
                     range_tombstones.push((row.key.clone(), rt));
@@ -2500,9 +2609,27 @@ impl KWayMerger {
                 if let Some(shadowed) =
                     Self::apply_range_shadowing(entry, &range_tombstones, &self.schema)
                 {
-                    merged.push(shadowed);
+                    // Issue #1072: apply the partition deletion as the OUTERMOST
+                    // floor — after range shadowing — dropping every cell/row
+                    // whose timestamp is `<= pmfda` (per-cell `<=`, so strictly-
+                    // newer cells survive). A whole-row covered by the partition
+                    // floor contributes nothing (the re-emitted partition
+                    // tombstone covers it).
+                    if let Some(survivor) =
+                        Self::apply_partition_shadowing(shadowed, max_partition_deletion)
+                    {
+                        merged.push(survivor);
+                    }
                 }
             }
+        }
+
+        // Issue #1072: a range tombstone older-or-equal to the partition floor is
+        // subsumed by the partition deletion and must not be re-emitted (it would
+        // be redundant). A strictly-newer range marker survives. Apply BEFORE the
+        // range re-emit loop below.
+        if let Some((pmfda, _)) = max_partition_deletion {
+            range_tombstones.retain(|(_, rt)| rt.deletion_time > pmfda);
         }
 
         // Re-emit the surviving range tombstones as carrier entries so the writer
@@ -2546,6 +2673,48 @@ impl KWayMerger {
                 )
                 .with_range_deletion(rt),
             );
+        }
+
+        // Issue #1072: re-emit the surviving partition tombstone so even a
+        // tombstone-only partition (no rows in any source) still emits a partition
+        // deletion — and the deletion keeps shadowing older rows in non-compacted
+        // SSTables. gc_grace purges the marker only when BOTH conditions hold,
+        // IDENTICAL to the range-marker re-emit gate / #1061 idiom:
+        //   1. the partition's `localDeletionTime` is strictly below `gcBefore`
+        //      (gc-grace expired), AND
+        //   2. its own `markedForDeleteAt` is strictly below
+        //      `max_purgeable_timestamp` (the min write timestamp of every
+        //      non-included overlapping SSTable — #935), proving it shadows
+        //      nothing outside the compaction set.
+        // For a full / overlap-safe compaction `max_purgeable_timestamp` is
+        // `i64::MAX` so any realistic deletion passes condition 2. For a PARTIAL
+        // compaction without an overlap bound `max_purgeable_timestamp` is
+        // `i64::MIN`, so condition 2 never fires and the tombstone is always
+        // retained (never resurrect).
+        if let (Some((pmfda, pldt)), Some(key)) = (max_partition_deletion, partition_delete_key) {
+            let purge = match effective_gc_before {
+                Some(gc_before) => {
+                    i64::from(pldt as u32) < gc_before && pmfda < max_purgeable_timestamp
+                }
+                None => false,
+            };
+            if purge {
+                purges.partition_tombstones += 1;
+            } else {
+                merged.push(
+                    MergeEntry::new(
+                        usize::MAX,
+                        key,
+                        None,
+                        pmfda,
+                        RowData::Tombstone {
+                            deletion_time: pmfda,
+                            local_deletion_time: pldt,
+                        },
+                    )
+                    .with_partition_deletion((pmfda, pldt)),
+                );
+            }
         }
 
         // Sort merged rows by clustering key for output order
@@ -2844,6 +3013,151 @@ impl KWayMerger {
     /// only the bound's components (via [`ClusteringKey::compare`], which treats an
     /// absent trailing component as a first-sorting NULL) yields the correct
     /// containment for the `DELETE WHERE pk=? AND ck1=?` prefix case.
+    /// Shadow the cells / row / metadata of a reconciled cluster entry that are
+    /// covered by the partition-level deletion (issue #1072 — the OUTERMOST floor).
+    ///
+    /// Drops every DATA cell whose own `timestamp` is `<= pmfda` (the `<=` lets the
+    /// partition deletion win an equal-ts tie, like #498/#933). Clustering-key
+    /// pseudo-cells are retained whenever any data cell survives so the row keeps
+    /// its key columns for read-back. A row whose every data cell is shadowed AND
+    /// whose row-marker liveness is `<= pmfda` produces nothing (the re-emitted
+    /// partition tombstone covers it). A row tombstone / coexisting row deletion /
+    /// complex deletion older-or-equal to the floor is subsumed; a strictly-newer
+    /// one survives. `None` floor (`max_partition_deletion == None`) is the common
+    /// case and returns the entry untouched.
+    fn apply_partition_shadowing(
+        entry: MergeEntry,
+        max_partition_deletion: Option<(i64, i32)>,
+    ) -> Option<MergeEntry> {
+        let Some((pmfda, _)) = max_partition_deletion else {
+            return Some(entry);
+        };
+
+        // A complex (collection) deletion older-or-equal to the partition floor is
+        // subsumed; one strictly newer must survive.
+        let surviving_complex: Vec<ComplexDeletion> = entry
+            .complex_deletions
+            .into_iter()
+            .filter(|cd| cd.marked_for_delete_at > pmfda)
+            .collect();
+
+        // A coexisting row deletion (#932) older-or-equal to the floor is subsumed;
+        // a newer one is preserved.
+        let surviving_row_del = entry.row_deletion.filter(|(dt, _)| *dt > pmfda);
+
+        match entry.row_data {
+            RowData::Tombstone {
+                deletion_time,
+                local_deletion_time,
+            } => {
+                // A row tombstone older-or-equal to the partition floor is subsumed
+                // by the partition deletion; a strictly-newer one survives.
+                if deletion_time > pmfda {
+                    let mut rebuilt = MergeEntry::new(
+                        entry.run_index,
+                        entry.key,
+                        entry.clustering_key,
+                        deletion_time,
+                        RowData::Tombstone {
+                            deletion_time,
+                            local_deletion_time,
+                        },
+                    );
+                    if !surviving_complex.is_empty() {
+                        rebuilt = rebuilt.with_complex_deletions(surviving_complex);
+                    }
+                    Some(rebuilt)
+                } else if !surviving_complex.is_empty() {
+                    Some(
+                        MergeEntry::new(
+                            entry.run_index,
+                            entry.key,
+                            entry.clustering_key,
+                            entry.timestamp,
+                            RowData::Live { cells: Vec::new() },
+                        )
+                        .with_complex_deletions(surviving_complex),
+                    )
+                } else {
+                    None
+                }
+            }
+            RowData::Live { cells } => {
+                // Identify clustering pseudo-cells (kept when any data cell
+                // survives). A static / unclustered row has no clustering key.
+                let ck_names: std::collections::HashSet<String> = entry
+                    .clustering_key
+                    .as_ref()
+                    .map(|ck| ck.columns.iter().map(|(n, _)| n.clone()).collect())
+                    .unwrap_or_default();
+                let is_data = |c: &CellData| !ck_names.contains(&c.column);
+
+                let kept: Vec<CellData> = cells
+                    .into_iter()
+                    .filter(|c| !is_data(c) || c.timestamp > pmfda)
+                    .collect();
+                let has_data = kept.iter().any(is_data);
+
+                // The row-marker liveness survives the partition floor only if its
+                // own timestamp is strictly newer.
+                let marker_live = entry.timestamp > pmfda;
+
+                if !has_data && !marker_live {
+                    if let Some((dt, ldt)) = surviving_row_del {
+                        return Some(MergeEntry::new(
+                            entry.run_index,
+                            entry.key,
+                            entry.clustering_key,
+                            dt,
+                            RowData::Tombstone {
+                                deletion_time: dt,
+                                local_deletion_time: ldt,
+                            },
+                        ));
+                    }
+                    if !surviving_complex.is_empty() {
+                        return Some(
+                            MergeEntry::new(
+                                entry.run_index,
+                                entry.key,
+                                entry.clustering_key,
+                                entry.timestamp,
+                                RowData::Live { cells: Vec::new() },
+                            )
+                            .with_complex_deletions(surviving_complex),
+                        );
+                    }
+                    return None;
+                }
+
+                let row_ts = if has_data {
+                    kept.iter()
+                        .filter(|c| is_data(c))
+                        .map(|c| c.timestamp)
+                        .max()
+                        .unwrap_or(entry.timestamp)
+                } else {
+                    entry.timestamp
+                };
+
+                let mut rebuilt = MergeEntry::new(
+                    entry.run_index,
+                    entry.key,
+                    entry.clustering_key,
+                    row_ts,
+                    RowData::Live { cells: kept },
+                );
+                if !surviving_complex.is_empty() {
+                    rebuilt = rebuilt.with_complex_deletions(surviving_complex);
+                }
+                if let Some((dt, ldt)) = surviving_row_del {
+                    rebuilt = rebuilt.with_row_deletion(dt, ldt);
+                }
+                Some(rebuilt)
+            }
+        }
+    }
+
     fn range_tombstone_covers_ck(
         ck: &ClusteringKey,
         rt: &RangeTombstone,
@@ -3794,6 +4108,32 @@ impl KWayMerger {
 
         let partition_key = PartitionKey::from_bytes(&entry.key.key, schema)?;
         let table_id = TableId::new(&schema.keyspace, &schema.table);
+
+        // Issue #1072: a partition-tombstone carrier produces a mutation carrying
+        // ONLY a `partition_tombstone` (no operations, no clustering key, no row /
+        // range tombstone). The writer (`write_partition`) lifts the
+        // partition_tombstone onto the partition HEADER. Emitting any
+        // `CellOperation` here (e.g. `DeleteRow` from a `RowData::Tombstone`) would
+        // wrongly write a clustering-row tombstone instead. Handled first so the
+        // carrier's `row_data` (carried as a deletion so the merge step does not
+        // surface a phantom live row) never reaches the operation builder below.
+        if let Some((deletion_time, local_deletion_time)) = entry.partition_deletion {
+            let mutation = Mutation::new(
+                table_id,
+                partition_key,
+                None,
+                Vec::new(),
+                deletion_time,
+                None,
+            );
+            let mut mutation = mutation;
+            mutation.partition_tombstone =
+                Some(crate::storage::write_engine::mutation::PartitionTombstone {
+                    deletion_time,
+                    local_deletion_time,
+                });
+            return Ok(mutation);
+        }
 
         // Issue #933: a surviving range tombstone rides on the mutation's
         // `range_tombstones`, which the writer interleaves as on-disk bound markers

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -1392,8 +1392,24 @@ impl WriteEngine {
                     }
 
                     // Count rows actually written (skipped metadata-only entries
-                    // produce no row, so they must not inflate the stats).
-                    let row_count = mutations.len() as u64;
+                    // produce no row, so they must not inflate the stats). A pure
+                    // range-tombstone carrier (#933) or a pure partition-tombstone
+                    // carrier (#1072) emits a marker / partition-header deletion,
+                    // not a row — exclude them, matching KWayMerger::merge.
+                    let row_count = mutations
+                        .iter()
+                        .filter(|m| {
+                            let is_range_only = m.operations.is_empty()
+                                && m.partition_tombstone.is_none()
+                                && m.row_tombstone.is_none()
+                                && !m.range_tombstones.is_empty();
+                            let is_partition_only = m.operations.is_empty()
+                                && m.partition_tombstone.is_some()
+                                && m.row_tombstone.is_none()
+                                && m.range_tombstones.is_empty();
+                            !(is_range_only || is_partition_only)
+                        })
+                        .count() as u64;
 
                     // Write partition to output SSTable
                     // Re-borrow active_merge to write

--- a/cqlite-core/tests/issue_1012_skipped_sstable_parity.rs
+++ b/cqlite-core/tests/issue_1012_skipped_sstable_parity.rs
@@ -631,9 +631,6 @@ async fn scanner_tombstone_only_partition_surfaces_in_range() {
 /// query for pk=1 returns NO live rows. The gen-2 source is the one a clustering
 /// /min-max range filter would make look skippable, yet it must stay visible.
 #[test]
-#[ignore = "P0 GAP (#1012): KWayMerger drops partition tombstones — gen-2 DELETE WHERE pk=1 \
-            does NOT shadow gen-1's older live rows (resurrection). De-ignore when the \
-            compaction/merge read path threads partition deletions."]
 fn merge_partition_delete_shadows_older_rows_gap() {
     let Some(dir) = fixture_dir() else {
         skip_or_panic(
@@ -677,9 +674,6 @@ fn merge_partition_delete_shadows_older_rows_gap() {
 /// partition tombstone is also retained. Mirrors the issue_819 two-generation
 /// no-resurrection discipline.
 #[test]
-#[ignore = "P0 GAP (#1012): compaction across the skipped gen-2 source RESURRECTS pk=1 rows \
-            and DROPS the tombstone-only pk=2 partition. De-ignore when partition \
-            tombstones are applied during compaction."]
 fn compaction_partition_delete_shadowing_gap() {
     let Some(dir) = fixture_dir() else {
         skip_or_panic(

--- a/cqlite-core/tests/issue_1014_resurrection_safety_parity.rs
+++ b/cqlite-core/tests/issue_1014_resurrection_safety_parity.rs
@@ -840,9 +840,6 @@ fn repaired_unrepaired_purge_gate_partial() {
 /// specific to the compaction-merge read contract. Un-`ignore` this test once the
 /// compaction read path surfaces partition deletions and the merge shadows them.
 #[test]
-#[ignore = "issue #1014 finding: compaction-merge read path drops partition-level deletions \
-            (parse_one_partition_for_compaction → parse_partition_header), resurrecting pk=2; \
-            tracked for a follow-up fix"]
 fn partition_tombstone_resurrection_gap_pinned() {
     let Some((_dir, nb1, nb2)) = require_fixture("resurrection_gc0") else {
         return;

--- a/cqlite-core/tests/test_issue_827_streaming_parity.rs
+++ b/cqlite-core/tests/test_issue_827_streaming_parity.rs
@@ -259,6 +259,8 @@ async fn test_streaming_parity_chunk_straddle_wide_partition() {
         CompactionRowData::Tombstone { .. } => false,
         // Issue #933: range-tombstone markers carry no inline cell values.
         CompactionRowData::RangeMarker { .. } => false,
+        // Issue #1072: partition tombstones carry no inline cell values.
+        CompactionRowData::PartitionDelete { .. } => false,
     });
     assert!(
         has_big,

--- a/docs/reports/cassandra-test-parity.md
+++ b/docs/reports/cassandra-test-parity.md
@@ -10,8 +10,8 @@ Sources: [`docs/cassandra_test_index.md`](../../docs/cassandra_test_index.md) ·
 
 | Status | Scenarios |
 |---|---|
-| `mirrored` | 49 |
-| `partial` | 18 |
+| `mirrored` | 55 |
+| `partial` | 12 |
 | `planned` | 6 |
 | `out_of_scope` | 8 |
 | **total** | **81** |
@@ -21,9 +21,9 @@ Sources: [`docs/cassandra_test_index.md`](../../docs/cassandra_test_index.md) ·
 | Evidence | Scenarios |
 |---|---|
 | `byte_for_byte` | 18 |
-| `canonical_semantic` | 26 |
+| `canonical_semantic` | 32 |
 | `smoke` | 5 |
-| `partial` | 24 |
+| `partial` | 18 |
 | `out_of_scope` | 8 |
 
 ## ⚠️ P0 scenarios with weak evidence
@@ -32,8 +32,6 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 
 - `cass.compaction_merge.byte_for_byte_output` — Compaction byte-for-byte output parity (future) (partial)
 - `cass.compaction_merge.load_path_validity` — Compaction output load-path validity (Tier-1) (smoke)
-- `cass.compaction_merge.partition_delete_shadowing_across_skipped_sources` — Compaction partition-delete shadowing across skipped sources (partial)
-- `cass.compaction_merge.resurrection_safety.overlapping_sources` — Compaction resurrection-safety across overlapping sources (partial)
 - `cass.compression_checksum.checksum_trailer_detection` — Inline checksum / Digest.crc32 corruption detection (partial)
 - `cass.corruption_verify.component_corruption_detection` — Component corruption detection, scrub, and verify (partial)
 - `cass.delta_scan.tombstone_liveness_facts` — Delta-scan tombstone/TTL/liveness fact extraction (partial)
@@ -45,12 +43,8 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 - `cass.sstable_format.descriptor_component_resolution` — Descriptor and on-disk version/component resolution (smoke)
 - `cass.statistics_metadata.max_local_deletion_time.tombstones_ttl` — Statistics.db max local deletion time for tombstone/TTL fixture (partial)
 - `cass.statistics_metadata.tombstone_histogram.deletion_times` — Statistics.db estimated tombstone-drop-times histogram parity (partial)
-- `cass.tombstone_ttl.gc_grace.partition_row_cell` — gc_grace read-merge parity for partition/row/cell tombstones (partial)
-- `cass.tombstone_ttl.never_purge.cell_row_partition` — never_purge keeps cell/row/partition tombstones on read and compaction (partial)
 - `cass.tombstone_ttl.range_tombstone_boundaries` — Range tombstone boundary and deletion-time parity (partial)
 - `cass.tombstone_ttl.repaired_unrepaired_purge_gate` — Repaired vs unrepaired purge gate parity (partial)
-- `cass.tombstone_ttl.skipped_sstable.partition_delete_reincluded` — Partition delete from a skipped SSTable is reincluded on read (partial)
-- `cass.tombstone_ttl.skipped_sstable.partition_delete_shadows_older_rows` — Skipped-SSTable partition delete shadows older live rows (partial)
 - `cass.write_load_path.cassandra_sstable_writer_fixtures` — CQLite-written SSTables load into Cassandra via sstableloader (smoke)
 
 ## P0 scenarios
@@ -62,8 +56,8 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 | `cass.compaction_merge.byte_for_byte_output` | compaction_merge | planned | partial | `compaction_parity_tombstone_ttl` | p0_data_loss |
 | `cass.compaction_merge.load_path_validity` | compaction_merge | mirrored | smoke | `compaction_parity_tombstone_ttl` | p1_correctness |
 | `cass.compaction_merge.partial_source_retains_tombstones` | compaction_merge | mirrored | canonical_semantic | `compaction_parity_tombstone_ttl` | p0_data_loss |
-| `cass.compaction_merge.partition_delete_shadowing_across_skipped_sources` | compaction_merge | partial | partial | `compaction_parity_tombstone_ttl` | p0_data_loss |
-| `cass.compaction_merge.resurrection_safety.overlapping_sources` | compaction_merge | partial | partial | `compaction_parity_tombstone_ttl` | p0_data_loss |
+| `cass.compaction_merge.partition_delete_shadowing_across_skipped_sources` | compaction_merge | mirrored | canonical_semantic | `compaction_parity_tombstone_ttl` | p0_data_loss |
+| `cass.compaction_merge.resurrection_safety.overlapping_sources` | compaction_merge | mirrored | canonical_semantic | `compaction_parity_tombstone_ttl` | p0_data_loss |
 | `cass.compaction_merge.static_row.survives_tombstone_gc` | compaction_merge | mirrored | canonical_semantic | `compaction_parity_tombstone_ttl` | p0_data_loss |
 | `cass.compaction_merge.tombstone_ttl_shadowing` | compaction_merge | mirrored | canonical_semantic | `compaction_parity_tombstone_ttl` | p0_data_loss |
 | `cass.compression_checksum.checksum_trailer_detection` | compression_checksum | partial | partial | `sstable_parity_corruption_verify` | p0_data_loss |
@@ -105,16 +99,16 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 | `cass.tombstone_ttl.deletion_markers.range_delete_bounds` | tombstone_ttl | mirrored | canonical_semantic | `sstable_parity_delta_scan` | p0_data_loss |
 | `cass.tombstone_ttl.deletion_markers.range_tombstone_boundary` | tombstone_ttl | mirrored | canonical_semantic | `sstable_parity_delta_scan` | p0_data_loss |
 | `cass.tombstone_ttl.deletion_markers.row_delete` | tombstone_ttl | mirrored | canonical_semantic | `sstable_parity_delta_scan` | p0_data_loss |
-| `cass.tombstone_ttl.gc_grace.partition_row_cell` | tombstone_ttl | partial | partial | `sstable_parity_delta_scan` | p0_data_loss |
-| `cass.tombstone_ttl.never_purge.cell_row_partition` | tombstone_ttl | partial | partial | `sstable_parity_delta_scan` | p0_data_loss |
+| `cass.tombstone_ttl.gc_grace.partition_row_cell` | tombstone_ttl | mirrored | canonical_semantic | `sstable_parity_delta_scan` | p0_data_loss |
+| `cass.tombstone_ttl.never_purge.cell_row_partition` | tombstone_ttl | mirrored | canonical_semantic | `sstable_parity_delta_scan` | p0_data_loss |
 | `cass.tombstone_ttl.range_tombstone.closed_last_block` | tombstone_ttl | mirrored | canonical_semantic | `sstable_parity_delta_scan` | p0_data_loss |
 | `cass.tombstone_ttl.range_tombstone.index_block_first_marker` | tombstone_ttl | mirrored | canonical_semantic | `sstable_parity_delta_scan` | p0_data_loss |
 | `cass.tombstone_ttl.range_tombstone.index_block_last_marker` | tombstone_ttl | mirrored | canonical_semantic | `sstable_parity_delta_scan` | p0_data_loss |
 | `cass.tombstone_ttl.range_tombstone.open_ended_middle_block` | tombstone_ttl | mirrored | canonical_semantic | `sstable_parity_delta_scan` | p0_data_loss |
 | `cass.tombstone_ttl.range_tombstone_boundaries` | tombstone_ttl | partial | partial | `sstable_parity_delta_scan` | p0_data_loss |
 | `cass.tombstone_ttl.repaired_unrepaired_purge_gate` | tombstone_ttl | partial | partial | `sstable_parity_statistics_db` | p0_data_loss |
-| `cass.tombstone_ttl.skipped_sstable.partition_delete_reincluded` | tombstone_ttl | partial | partial | `sstable_parity_delta_scan` | p0_data_loss |
-| `cass.tombstone_ttl.skipped_sstable.partition_delete_shadows_older_rows` | tombstone_ttl | partial | partial | `sstable_parity_delta_scan` | p0_data_loss |
+| `cass.tombstone_ttl.skipped_sstable.partition_delete_reincluded` | tombstone_ttl | mirrored | canonical_semantic | `sstable_parity_delta_scan` | p0_data_loss |
+| `cass.tombstone_ttl.skipped_sstable.partition_delete_shadows_older_rows` | tombstone_ttl | mirrored | canonical_semantic | `sstable_parity_delta_scan` | p0_data_loss |
 | `cass.tombstone_ttl.static_row.dropped_static_header_preserved` | tombstone_ttl | mirrored | byte_for_byte | `schema_parity_serialization_header` | p0_data_loss |
 | `cass.tombstone_ttl.static_row.with_row_cell_range_tombstones` | tombstone_ttl | mirrored | canonical_semantic | `sstable_parity_delta_scan` | p0_data_loss |
 | `cass.tombstone_ttl.ttl_and_local_deletion_time` | tombstone_ttl | mirrored | canonical_semantic | `sstable_parity_data_db_jsonl` | p0_data_loss |
@@ -158,6 +152,10 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
   - Normalization: CQLite-written da BTI SSTables are dumped with Cassandra 5 sstabledump and compared for value equivalence; Partitions.db footer shape [firstPos|keyCount|root] is matched against a real Cassandra fixture.
 - `cass.compaction_merge.partial_source_retains_tombstones` — Partial-source compaction retains row/cell tombstones
   - Normalization: When only a subset of the overlapping sources is compacted, row/cell tombstones that may still shadow data in the un-compacted sources are retained; deletion facts are mapped to the sstabledump JSONL and compared.
+- `cass.compaction_merge.partition_delete_shadowing_across_skipped_sources` — Compaction partition-delete shadowing across skipped sources
+  - Normalization: Compacting gen-1 (live pk=1 rows) with gen-2 (partition delete for pk=1, tombstone-only pk=2) now drops the pk=1 rows and retains the tombstone within gc-grace; compared against Cassandra compaction semantics. Verified now that #1072 is fixed.
+- `cass.compaction_merge.resurrection_safety.overlapping_sources` — Compaction resurrection-safety across overlapping sources
+  - Normalization: Compacting overlapping sources where a tombstone in one source shadows live data in another does not resurrect the shadowed data; partition, row, and cell shadowing is compared against Cassandra compaction output. The partition sub-case is verified now that #1072 is fixed.
 - `cass.compaction_merge.static_row.survives_tombstone_gc` — Static row survives tombstone gc through compaction parity
   - Normalization: After compaction purges expired clustered-row tombstones, the live static row must survive; the post-compaction static_block liveness is compared against Cassandra compaction semantics.
 - `cass.compaction_merge.tombstone_ttl_shadowing` — Compaction tombstone/TTL shadowing — canonical semantic parity
@@ -186,6 +184,10 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
   - Normalization: scan_delta adjacent range-tombstone boundary markers (the shared boundary between two adjacent ranges) are mapped to the sstabledump JSONL range_tombstone boundary facts and compared.
 - `cass.tombstone_ttl.deletion_markers.row_delete` — Row-level deletion marker parity
   - Normalization: scan_delta row-deletion records (deletion_info markedForDeleteAt) are mapped to the sstabledump JSONL row deletion_info fact and compared.
+- `cass.tombstone_ttl.gc_grace.partition_row_cell` — gc_grace read-merge parity for partition/row/cell tombstones
+  - Normalization: Read-merge of gc_grace=0 vs gc_grace=864000 fixtures is asserted identical for partition, row, and cell tombstones; deletion facts are mapped to the sstabledump JSONL and compared. The partition sub-case is verified now that #1072 is fixed.
+- `cass.tombstone_ttl.never_purge.cell_row_partition` — never_purge keeps cell/row/partition tombstones on read and compaction
+  - Normalization: With never_purge semantics, cell, row, and partition tombstones are retained on read and across compaction; their deletion facts are mapped to the sstabledump JSONL and compared. The partition sub-case is verified now that #1072 is fixed.
 - `cass.tombstone_ttl.range_tombstone.closed_last_block` — Range-tombstone closing in the last index block parity
   - Normalization: A range tombstone whose end bound lies in the last column-index block has its close marker mapped to the sstabledump JSONL range_tombstone close bound and compared.
 - `cass.tombstone_ttl.range_tombstone.index_block_first_marker` — Range-tombstone first-of-index-block marker parity
@@ -194,6 +196,10 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
   - Normalization: The close marker emitted at the last marker of a column-index block is mapped to the sstabledump JSONL range_tombstone close bound and compared.
 - `cass.tombstone_ttl.range_tombstone.open_ended_middle_block` — Range-tombstone spanning interior index blocks parity
   - Normalization: The materialized fixture range [1500,2500] is a CLOSED range spanning interior column-index blocks (not open-ended); its open/close bounds and the synthetic per-block boundary markers are mapped to the sstabledump JSONL range_tombstone facts and compared. Covered here as an interior-block-spanning closed range.
+- `cass.tombstone_ttl.skipped_sstable.partition_delete_reincluded` — Partition delete from a skipped SSTable is reincluded on read
+  - Normalization: The cross-generation MERGE read path now reincludes the gen-2 partition tombstone; the merged read is compared against the sstabledump JSONL of each generation. Verified end-to-end now that #1072 is fixed.
+- `cass.tombstone_ttl.skipped_sstable.partition_delete_shadows_older_rows` — Skipped-SSTable partition delete shadows older live rows
+  - Normalization: A gen-2 partition delete with a higher timestamp now shadows the gen-1 live rows for pk=1, leaving zero live rows; compared against the merged read semantics implied by the per-generation sstabledump JSONL. Verified now that #1072 is fixed.
 - `cass.tombstone_ttl.static_row.with_row_cell_range_tombstones` — Static row alongside row/cell/range tombstones parity
   - Normalization: The static row liveness and the co-located row/cell/range tombstones are mapped to the sstabledump JSONL static_block and deletion facts and compared.
 - `cass.tombstone_ttl.ttl_and_local_deletion_time` — TTL, local deletion time, and WRITETIME parity
@@ -216,8 +222,6 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 ## Gaps and next steps
 
 - `cass.compaction_merge.byte_for_byte_output` (planned): No gated byte-for-byte comparison of compaction output. → _Promote the debug byte tier in compaction-parity to a gated comparison once writer output is byte-stable._
-- `cass.compaction_merge.partition_delete_shadowing_across_skipped_sources` (partial): Compaction resurrects pk=1 and drops the tombstone-only pk=2 because the compaction-merge read path discards partition-level deletions. → _Apply partition deletions in the compaction-merge read path so shadowing and tombstone retention match Cassandra; tracked by follow-up issue #1072._
-- `cass.compaction_merge.resurrection_safety.overlapping_sources` (partial): The partition-tombstone resurrection-safety sub-case is broken (pinned ignored) because partition deletions are dropped during compaction merge. → _Apply partition tombstones in the compaction-merge read path so overlapping sources do not resurrect partition-deleted data; tracked by follow-up issue #1072._
 - `cass.compression_checksum.checksum_trailer_detection` (partial): No gated byte comparison of Digest.crc32 against the Cassandra reference. → _Add a Digest.crc32 byte comparison to the sstable_parity_corruption_verify suite._
 - `cass.corruption_verify.component_corruption_detection` (planned): No scrub/verify parity pass implemented. → _Implement a verify pass and compare detected-corruption outcomes against Cassandra VerifyTest/ScrubTest scenarios._
 - `cass.delta_scan.tombstone_liveness_facts` (partial): test_deltas dataset asset not published/enforced (#701). → _Publish and enforce the test_deltas dataset in delta-roundtrip CI._
@@ -233,12 +237,8 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 - `cass.statistics_metadata.max_local_deletion_time.tombstones_ttl` (partial): CQLite's minimal Statistics parser does not decode the STATS-component SSTable max local deletion time and returns a placeholder equal to the min baseline. → _Decode the STATS max local-deletion-time field and assert it byte-equal to the sstablemetadata reference; tracked by follow-up issue #1073._
 - `cass.statistics_metadata.tombstone_histogram.deletion_times` (partial): The estimated-tombstone-drop-times histogram in Statistics.db is not decoded or exposed by CQLite. → _Decode the estimated-tombstone-drop-times histogram and assert bucket parity against the sstablemetadata reference; tracked by follow-up issue #1073._
 - `cass.summary_db.IndexSummaryRedistributionTest.downsampled_summary_entries` (planned): No downsampled (sampling_level < 128) Summary.db fixture exists. → _Publish a redistributed Summary.db fixture and extend the strict suite to assert downsampled offset tables and size_at_full_sampling > entry count._
-- `cass.tombstone_ttl.gc_grace.partition_row_cell` (partial): The partition-tombstone read-merge sub-case is broken and gc_grace is not surfaced from the Statistics.db on read. → _Apply partition tombstones in the read-merge path and surface gc_grace from disk; tracked by follow-up issue #1072._
-- `cass.tombstone_ttl.never_purge.cell_row_partition` (partial): The partition-tombstone never-purge sub-case is broken (pinned ignored) because partition deletions are not applied in the compaction-merge read path. → _Apply partition tombstones in the compaction-merge read path so never_purge retains partition deletions; tracked by follow-up issue #1072._
 - `cass.tombstone_ttl.range_tombstone_boundaries` (partial): test_deltas dataset asset not published/enforced in CI (#701). → _Publish the test_deltas dataset and enforce scan_delta parity in CI._
 - `cass.tombstone_ttl.repaired_unrepaired_purge_gate` (partial): repairedAt / pendingRepair parsing is not implemented (gated on #968/#988), so the repaired-vs-unrepaired purge gate is only partially exercised. → _Parse repairedAt / pendingRepair from Statistics.db and gate purge on repair status (#968/#988)._
-- `cass.tombstone_ttl.skipped_sstable.partition_delete_reincluded` (partial): The cross-generation MERGE read path (KWayMerger / parse_one_partition_for_compaction) discards partition-level deletions, so a partition delete from a skipped SSTable is not honored on a merged read. → _Thread partition deletions through the compaction-merge read path; tracked by follow-up issue #1072._
-- `cass.tombstone_ttl.skipped_sstable.partition_delete_shadows_older_rows` (partial): Merging a higher-timestamp gen-2 partition delete over gen-1 leaves the 10 pk=1 rows live instead of 0 (P0 resurrection). → _Thread partition deletions through the compaction-merge read path so the skipped-SSTable partition delete shadows older rows; tracked by follow-up issue #1072._
 
 ## Out-of-scope taxonomy
 

--- a/test-data/cassandra-parity-manifest.yml
+++ b/test-data/cassandra-parity-manifest.yml
@@ -2894,7 +2894,7 @@ scenarios:
 
   - id: cass.tombstone_ttl.skipped_sstable.partition_delete_reincluded
     title: Partition delete from a skipped SSTable is reincluded on read
-    status: partial
+    status: mirrored
     capability: tombstone_ttl
     priority: P0
     risk: p0_data_loss
@@ -2914,7 +2914,7 @@ scenarios:
         - test-data/datasets/sstables/test_tomb/skipped_partition_delete-4caaea90702011f1b8f419c9a388d558/nb-1-big-Data.db.jsonl
         - test-data/datasets/sstables/test_tomb/skipped_partition_delete-4caaea90702011f1b8f419c9a388d558/nb-2-big-Data.db.jsonl
     evidence:
-      type: partial
+      type: canonical_semantic
       artifacts: [jsonl]
       cassandra_version: "5.0.2"
       cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
@@ -2924,28 +2924,17 @@ scenarios:
       reference_paths:
         - test-data/datasets/sstables/test_tomb/skipped_partition_delete-4caaea90702011f1b8f419c9a388d558/nb-2-big-Data.db.jsonl
       normalization: >-
-        The per-generation reader reincludes the gen-2 partition tombstone; this is
-        compared against the sstabledump JSONL of each generation independently.
-      known_limitations: >-
-        The single-generation reader reincludes the partition tombstone, but the
-        cross-generation MERGE read path (KWayMerger / parse_one_partition_for_compaction)
-        discards partition-level deletions, so a merged read does not yet honor the
-        skipped-SSTable partition delete.
+        The cross-generation MERGE read path now reincludes the gen-2 partition
+        tombstone; the merged read is compared against the sstabledump JSONL of each
+        generation. Verified end-to-end now that #1072 is fixed.
     ci:
       tier: nightly_docker
       workflow: .github/workflows/tombstone-ttl-parity.yml
-    scope:
-      gap: >-
-        The cross-generation MERGE read path (KWayMerger /
-        parse_one_partition_for_compaction) discards partition-level deletions, so a
-        partition delete from a skipped SSTable is not honored on a merged read.
-      next_step: >-
-        Thread partition deletions through the compaction-merge read path; tracked
-        by follow-up issue #1072.
+    scope: {}
 
   - id: cass.tombstone_ttl.skipped_sstable.partition_delete_shadows_older_rows
     title: Skipped-SSTable partition delete shadows older live rows
-    status: partial
+    status: mirrored
     capability: tombstone_ttl
     priority: P0
     risk: p0_data_loss
@@ -2965,7 +2954,7 @@ scenarios:
         - test-data/datasets/sstables/test_tomb/skipped_partition_delete-4caaea90702011f1b8f419c9a388d558/nb-1-big-Data.db.jsonl
         - test-data/datasets/sstables/test_tomb/skipped_partition_delete-4caaea90702011f1b8f419c9a388d558/nb-2-big-Data.db.jsonl
     evidence:
-      type: partial
+      type: canonical_semantic
       artifacts: [jsonl]
       cassandra_version: "5.0.2"
       cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
@@ -2975,28 +2964,18 @@ scenarios:
       reference_paths:
         - test-data/datasets/sstables/test_tomb/skipped_partition_delete-4caaea90702011f1b8f419c9a388d558/nb-1-big-Data.db.jsonl
       normalization: >-
-        A gen-2 partition delete with a higher timestamp must shadow the gen-1 live
+        A gen-2 partition delete with a higher timestamp now shadows the gen-1 live
         rows for pk=1, leaving zero live rows; compared against the merged read
-        semantics implied by the per-generation sstabledump JSONL.
-      known_limitations: >-
-        P0 resurrection: merging the gen-2 partition delete over gen-1 currently
-        leaves the 10 pk=1 rows live instead of 0, because the compaction-merge read
-        path drops partition-level deletions.
+        semantics implied by the per-generation sstabledump JSONL. Verified now that
+        #1072 is fixed.
     ci:
       tier: nightly_docker
       workflow: .github/workflows/tombstone-ttl-parity.yml
-    scope:
-      gap: >-
-        Merging a higher-timestamp gen-2 partition delete over gen-1 leaves the 10
-        pk=1 rows live instead of 0 (P0 resurrection).
-      next_step: >-
-        Thread partition deletions through the compaction-merge read path so the
-        skipped-SSTable partition delete shadows older rows; tracked by follow-up
-        issue #1072.
+    scope: {}
 
   - id: cass.compaction_merge.partition_delete_shadowing_across_skipped_sources
     title: Compaction partition-delete shadowing across skipped sources
-    status: partial
+    status: mirrored
     capability: compaction_merge
     priority: P0
     risk: p0_data_loss
@@ -3016,7 +2995,7 @@ scenarios:
         - test-data/datasets/sstables/test_tomb/skipped_partition_delete-4caaea90702011f1b8f419c9a388d558/nb-1-big-Data.db.jsonl
         - test-data/datasets/sstables/test_tomb/skipped_partition_delete-4caaea90702011f1b8f419c9a388d558/nb-2-big-Data.db.jsonl
     evidence:
-      type: partial
+      type: canonical_semantic
       artifacts: [jsonl]
       cassandra_version: "5.0.2"
       cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
@@ -3027,22 +3006,13 @@ scenarios:
         - test-data/datasets/sstables/test_tomb/skipped_partition_delete-4caaea90702011f1b8f419c9a388d558/nb-1-big-Data.db.jsonl
       normalization: >-
         Compacting gen-1 (live pk=1 rows) with gen-2 (partition delete for pk=1,
-        tombstone-only pk=2) should drop pk=1 rows and retain the tombstone within
-        gc-grace; compared against Cassandra compaction semantics.
-      known_limitations: >-
-        Compaction currently resurrects pk=1 (the gen-2 partition delete is dropped
-        by the merge read path) and also drops the tombstone-only pk=2, so partition
-        shadowing across skipped sources is not yet correct.
+        tombstone-only pk=2) now drops the pk=1 rows and retains the tombstone within
+        gc-grace; compared against Cassandra compaction semantics. Verified now that
+        #1072 is fixed.
     ci:
       tier: nightly_docker
       workflow: .github/workflows/tombstone-ttl-parity.yml
-    scope:
-      gap: >-
-        Compaction resurrects pk=1 and drops the tombstone-only pk=2 because the
-        compaction-merge read path discards partition-level deletions.
-      next_step: >-
-        Apply partition deletions in the compaction-merge read path so shadowing and
-        tombstone retention match Cassandra; tracked by follow-up issue #1072.
+    scope: {}
 
   # --- #1013 range-tombstone index-block markers ----------------------------
   - id: cass.tombstone_ttl.range_tombstone.index_block_first_marker
@@ -3281,7 +3251,7 @@ scenarios:
   # --- #1014 resurrection safety -------------------------------------------
   - id: cass.tombstone_ttl.never_purge.cell_row_partition
     title: never_purge keeps cell/row/partition tombstones on read and compaction
-    status: partial
+    status: mirrored
     capability: tombstone_ttl
     priority: P0
     risk: p0_data_loss
@@ -3301,7 +3271,7 @@ scenarios:
         - test-data/datasets/sstables/test_tomb/resurrection_gc0-4cb523c0702011f1b8f419c9a388d558/nb-1-big-Data.db.jsonl
         - test-data/datasets/sstables/test_tomb/resurrection_gc0-4cb523c0702011f1b8f419c9a388d558/nb-2-big-Data.db.jsonl
     evidence:
-      type: partial
+      type: canonical_semantic
       artifacts: [jsonl]
       cassandra_version: "5.0.2"
       cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
@@ -3311,28 +3281,18 @@ scenarios:
       reference_paths:
         - test-data/datasets/sstables/test_tomb/resurrection_gc0-4cb523c0702011f1b8f419c9a388d558/nb-1-big-Data.db.jsonl
       normalization: >-
-        With never_purge semantics, cell and row tombstones are retained on read and
-        across compaction; their deletion facts are mapped to the sstabledump JSONL
-        and compared.
-      known_limitations: >-
-        Row and cell never-purge is proven on both read and compaction; the
-        partition-tombstone sub-case is broken and pinned with an ignored test
-        because the compaction-merge read path drops partition deletions.
+        With never_purge semantics, cell, row, and partition tombstones are retained
+        on read and across compaction; their deletion facts are mapped to the
+        sstabledump JSONL and compared. The partition sub-case is verified now that
+        #1072 is fixed.
     ci:
       tier: nightly_docker
       workflow: .github/workflows/tombstone-ttl-parity.yml
-    scope:
-      gap: >-
-        The partition-tombstone never-purge sub-case is broken (pinned ignored)
-        because partition deletions are not applied in the compaction-merge read
-        path.
-      next_step: >-
-        Apply partition tombstones in the compaction-merge read path so never_purge
-        retains partition deletions; tracked by follow-up issue #1072.
+    scope: {}
 
   - id: cass.tombstone_ttl.gc_grace.partition_row_cell
     title: gc_grace read-merge parity for partition/row/cell tombstones
-    status: partial
+    status: mirrored
     capability: tombstone_ttl
     priority: P0
     risk: p0_data_loss
@@ -3354,7 +3314,7 @@ scenarios:
         - test-data/datasets/sstables/test_tomb/resurrection_gc_positive-4cbfab10702011f1b8f419c9a388d558/nb-1-big-Data.db.jsonl
         - test-data/datasets/sstables/test_tomb/resurrection_gc_positive-4cbfab10702011f1b8f419c9a388d558/nb-2-big-Data.db.jsonl
     evidence:
-      type: partial
+      type: canonical_semantic
       artifacts: [jsonl]
       cassandra_version: "5.0.2"
       cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
@@ -3366,22 +3326,13 @@ scenarios:
         - test-data/datasets/sstables/test_tomb/resurrection_gc_positive-4cbfab10702011f1b8f419c9a388d558/nb-1-big-Data.db.jsonl
       normalization: >-
         Read-merge of gc_grace=0 vs gc_grace=864000 fixtures is asserted identical
-        for row and cell tombstones; deletion facts are mapped to the sstabledump
-        JSONL and compared.
-      known_limitations: >-
-        gc_grace=0 vs 864000 read-merge is proven identical for row/cell tombstones;
-        the partition sub-case is broken and gc_grace is not yet surfaced from disk
-        (Statistics.db) by CQLite.
+        for partition, row, and cell tombstones; deletion facts are mapped to the
+        sstabledump JSONL and compared. The partition sub-case is verified now that
+        #1072 is fixed.
     ci:
       tier: nightly_docker
       workflow: .github/workflows/tombstone-ttl-parity.yml
-    scope:
-      gap: >-
-        The partition-tombstone read-merge sub-case is broken and gc_grace is not
-        surfaced from the Statistics.db on read.
-      next_step: >-
-        Apply partition tombstones in the read-merge path and surface gc_grace from
-        disk; tracked by follow-up issue #1072.
+    scope: {}
 
   - id: cass.tombstone_ttl.repaired_unrepaired_purge_gate
     title: Repaired vs unrepaired purge gate parity
@@ -3436,7 +3387,7 @@ scenarios:
 
   - id: cass.compaction_merge.resurrection_safety.overlapping_sources
     title: Compaction resurrection-safety across overlapping sources
-    status: partial
+    status: mirrored
     capability: compaction_merge
     priority: P0
     risk: p0_data_loss
@@ -3456,7 +3407,7 @@ scenarios:
         - test-data/datasets/sstables/test_tomb/resurrection_gc0-4cb523c0702011f1b8f419c9a388d558/nb-1-big-Data.db.jsonl
         - test-data/datasets/sstables/test_tomb/resurrection_gc0-4cb523c0702011f1b8f419c9a388d558/nb-2-big-Data.db.jsonl
     evidence:
-      type: partial
+      type: canonical_semantic
       artifacts: [jsonl]
       cassandra_version: "5.0.2"
       cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
@@ -3467,23 +3418,13 @@ scenarios:
         - test-data/datasets/sstables/test_tomb/resurrection_gc0-4cb523c0702011f1b8f419c9a388d558/nb-1-big-Data.db.jsonl
       normalization: >-
         Compacting overlapping sources where a tombstone in one source shadows live
-        data in another must not resurrect the shadowed data; row/cell shadowing is
-        compared against Cassandra compaction output.
-      known_limitations: >-
-        Row and cell shadowing on compaction is proven; the partition-tombstone
-        sub-case is broken and pinned with an ignored test because partition
-        deletions are dropped by the compaction-merge read path.
+        data in another does not resurrect the shadowed data; partition, row, and cell
+        shadowing is compared against Cassandra compaction output. The partition
+        sub-case is verified now that #1072 is fixed.
     ci:
       tier: nightly_docker
       workflow: .github/workflows/tombstone-ttl-parity.yml
-    scope:
-      gap: >-
-        The partition-tombstone resurrection-safety sub-case is broken (pinned
-        ignored) because partition deletions are dropped during compaction merge.
-      next_step: >-
-        Apply partition tombstones in the compaction-merge read path so overlapping
-        sources do not resurrect partition-deleted data; tracked by follow-up issue
-        #1072.
+    scope: {}
 
   - id: cass.compaction_merge.partial_source_retains_tombstones
     title: Partial-source compaction retains row/cell tombstones


### PR DESCRIPTION
## Fix #1072 — partition tombstones dropped in compaction-merge read path (P0 resurrection)

Closes #1072.

Surfaced by the epic #972 parity suite (#1012/#1014): CQLite's cross-generation compaction-merge read path discarded partition-level deletions, so a newer partition tombstone in one SSTable failed to shadow older live rows in another → deleted partitions resurrected. The delta-scan read path and the write path were already correct; this is a read/merge fix.

### Change
- `parse_partition_header_full` now returns the partition `(markedForDeleteAt, localDeletionTime)`; `parse_one_partition_for_compaction` emits a synthetic `PartitionDelete` carrier (even for tombstone-only partitions).
- New `CompactionRowData::PartitionDelete` variant; threaded through `MergeEntry`.
- `KWayMerger` computes the max partition `markedForDeleteAt` across sources and shadows every row/cell/marker with `timestamp <= mfda` (strictly-newer survive); re-emits the partition tombstone, honoring the #921/#935/#1061 purge-safety gate; tombstone-only partitions still emit a deletion.
- Row-count accounting excludes partition-/range-only carriers in both merge paths.
- The 3 `#[ignore]`d pinned regression tests (issue_1012/issue_1014) are de-ignored and pass.
- Manifest: the 6 affected scenarios flipped `partial` → `mirrored`.

### Validation
3 pinned tests pass; full `cqlite-core` `delta-scan write-support` suite **3199 passed / 0 failed**; existing compaction suites (issue_819/issue_933) green; lint + report `--check` clean; clippy `-D warnings` + fmt clean. roborev: clean.

> Stacked on epic #972 PR #1075 — merge that first; this PR's diff is the fix only and retargets to `main` after #1075 merges.
