### PR TITLE
Epic #968 Wave 2: CompressionInfo/Filter/repaired-metadata byte parity + CRC.db detector

### DIFF
--- a/.github/workflows/sstabledump-parity-gate.yml
+++ b/.github/workflows/sstabledump-parity-gate.yml
@@ -106,7 +106,10 @@ jobs:
             --test sstabledump_parity_summary \
             --test sstable_parity_toc_component_test \
             --test sstable_parity_index_db_test \
-            --test sstable_parity_statistics_db_strict_test
+            --test sstable_parity_statistics_db_strict_test \
+            --test sstable_parity_compression_info_test \
+            --test sstable_parity_filter_db_test \
+            --test sstable_parity_repaired_metadata_test
 
       - name: Run Data.db parity tests
         id: data_parity
@@ -165,6 +168,30 @@ jobs:
             --test sstable_parity_statistics_db_strict_test \
             -- --nocapture
 
+      - name: Run CompressionInfo.db strict parity tests
+        id: compression_info_parity
+        continue-on-error: true
+        run: |
+          cargo test --package cqlite-core --features write-support \
+            --test sstable_parity_compression_info_test \
+            -- --nocapture
+
+      - name: Run Filter.db strict parity tests
+        id: filter_db_parity
+        continue-on-error: true
+        run: |
+          cargo test --package cqlite-core --features write-support \
+            --test sstable_parity_filter_db_test \
+            -- --nocapture
+
+      - name: Run repaired-metadata strict parity tests
+        id: repaired_metadata_parity
+        continue-on-error: true
+        run: |
+          cargo test --package cqlite-core --features write-support \
+            --test sstable_parity_repaired_metadata_test \
+            -- --nocapture
+
       - name: Generate parity summary
         if: always()
         run: |
@@ -178,6 +205,9 @@ jobs:
           - TOC/Digest.crc32 (strict): ${{ steps.toc_component_parity.outcome }}
           - Index.db (strict): ${{ steps.index_db_strict_parity.outcome }}
           - Statistics.db (strict): ${{ steps.statistics_db_strict_parity.outcome }}
+          - CompressionInfo.db (strict): ${{ steps.compression_info_parity.outcome }}
+          - Filter.db (strict): ${{ steps.filter_db_parity.outcome }}
+          - Repaired-metadata (strict): ${{ steps.repaired_metadata_parity.outcome }}
 
           Dataset:
           - Tag: ${{ env.DATASET_TAG }}
@@ -199,7 +229,7 @@ jobs:
           retention-days: 30
 
       - name: Comment on PR (Success)
-        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && steps.data_parity.outcome == 'success' && steps.index_parity.outcome == 'success' && steps.summary_parity.outcome == 'success' && steps.statistics_parity.outcome == 'success' && steps.toc_component_parity.outcome == 'success' && steps.index_db_strict_parity.outcome == 'success' && steps.statistics_db_strict_parity.outcome == 'success'
+        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && steps.data_parity.outcome == 'success' && steps.index_parity.outcome == 'success' && steps.summary_parity.outcome == 'success' && steps.statistics_parity.outcome == 'success' && steps.toc_component_parity.outcome == 'success' && steps.index_db_strict_parity.outcome == 'success' && steps.statistics_db_strict_parity.outcome == 'success' && steps.compression_info_parity.outcome == 'success' && steps.filter_db_parity.outcome == 'success' && steps.repaired_metadata_parity.outcome == 'success'
         uses: actions/github-script@v8
         with:
           script: |
@@ -214,6 +244,9 @@ jobs:
             - TOC/Digest.crc32 (strict): success
             - Index.db (strict): success
             - Statistics.db (strict): success
+            - CompressionInfo.db (strict): success
+            - Filter.db (strict): success
+            - Repaired-metadata (strict): success
 
             Issue #440 remains green only while all dataset-backed parity checks stay green.`;
 
@@ -225,7 +258,7 @@ jobs:
             });
 
       - name: Comment on PR (Failure)
-        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && (steps.data_parity.outcome != 'success' || steps.index_parity.outcome != 'success' || steps.summary_parity.outcome != 'success' || steps.statistics_parity.outcome != 'success' || steps.toc_component_parity.outcome != 'success' || steps.index_db_strict_parity.outcome != 'success' || steps.statistics_db_strict_parity.outcome != 'success')
+        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && (steps.data_parity.outcome != 'success' || steps.index_parity.outcome != 'success' || steps.summary_parity.outcome != 'success' || steps.statistics_parity.outcome != 'success' || steps.toc_component_parity.outcome != 'success' || steps.index_db_strict_parity.outcome != 'success' || steps.statistics_db_strict_parity.outcome != 'success' || steps.compression_info_parity.outcome != 'success' || steps.filter_db_parity.outcome != 'success' || steps.repaired_metadata_parity.outcome != 'success')
         uses: actions/github-script@v8
         with:
           script: |
@@ -240,6 +273,9 @@ jobs:
             - TOC/Digest.crc32 (strict): ${{ steps.toc_component_parity.outcome }}
             - Index.db (strict): ${{ steps.index_db_strict_parity.outcome }}
             - Statistics.db (strict): ${{ steps.statistics_db_strict_parity.outcome }}
+            - CompressionInfo.db (strict): ${{ steps.compression_info_parity.outcome }}
+            - Filter.db (strict): ${{ steps.filter_db_parity.outcome }}
+            - Repaired-metadata (strict): ${{ steps.repaired_metadata_parity.outcome }}
 
             Download the uploaded parity artifacts and reproduce locally with:
 
@@ -252,6 +288,9 @@ jobs:
             cargo test --package cqlite-core --features write-support --test sstable_parity_toc_component_test -- --nocapture
             cargo test --package cqlite-core --features write-support --test sstable_parity_index_db_test -- --nocapture
             cargo test --package cqlite-core --features write-support --test sstable_parity_statistics_db_strict_test -- --nocapture
+            cargo test --package cqlite-core --features write-support --test sstable_parity_compression_info_test -- --nocapture
+            cargo test --package cqlite-core --features write-support --test sstable_parity_filter_db_test -- --nocapture
+            cargo test --package cqlite-core --features write-support --test sstable_parity_repaired_metadata_test -- --nocapture
             \`\`\``;
 
             github.rest.issues.createComment({
@@ -262,7 +301,7 @@ jobs:
             });
 
       - name: Fail build on parity differences
-        if: always() && (steps.data_parity.outcome != 'success' || steps.index_parity.outcome != 'success' || steps.summary_parity.outcome != 'success' || steps.statistics_parity.outcome != 'success' || steps.toc_component_parity.outcome != 'success' || steps.index_db_strict_parity.outcome != 'success' || steps.statistics_db_strict_parity.outcome != 'success')
+        if: always() && (steps.data_parity.outcome != 'success' || steps.index_parity.outcome != 'success' || steps.summary_parity.outcome != 'success' || steps.statistics_parity.outcome != 'success' || steps.toc_component_parity.outcome != 'success' || steps.index_db_strict_parity.outcome != 'success' || steps.statistics_db_strict_parity.outcome != 'success' || steps.compression_info_parity.outcome != 'success' || steps.filter_db_parity.outcome != 'success' || steps.repaired_metadata_parity.outcome != 'success')
         run: |
           echo "❌ M5 parity gate failed"
           echo "Data.db: ${{ steps.data_parity.outcome }}"
@@ -272,4 +311,7 @@ jobs:
           echo "TOC/Digest.crc32 (strict): ${{ steps.toc_component_parity.outcome }}"
           echo "Index.db (strict): ${{ steps.index_db_strict_parity.outcome }}"
           echo "Statistics.db (strict): ${{ steps.statistics_db_strict_parity.outcome }}"
+          echo "CompressionInfo.db (strict): ${{ steps.compression_info_parity.outcome }}"
+          echo "Filter.db (strict): ${{ steps.filter_db_parity.outcome }}"
+          echo "Repaired-metadata (strict): ${{ steps.repaired_metadata_parity.outcome }}"
           exit 1

--- a/cqlite-core/src/parser/mod.rs
+++ b/cqlite-core/src/parser/mod.rs
@@ -132,6 +132,7 @@ pub mod enhanced_statistics_parser;
 #[cfg(test)]
 pub mod enhanced_statistics_test;
 pub mod header;
+pub mod repair_metadata;
 pub mod statistics;
 #[cfg(test)]
 pub mod statistics_test;

--- a/cqlite-core/src/parser/repair_metadata.rs
+++ b/cqlite-core/src/parser/repair_metadata.rs
@@ -1,0 +1,717 @@
+//! Repair-state metadata decode from the `Statistics.db` STATS component
+//! (issue #988, epic #968).
+//!
+//! Apache Cassandra persists three repair-coordination fields inside the STATS
+//! `MetadataType` component of `Statistics.db`:
+//!
+//!   * `repairedAt` (`long`) — the repair timestamp, `0` for an unrepaired
+//!     SSTable. Rendered by `sstablemetadata` as `Repaired at: <n>`.
+//!   * `pendingRepair` (`UUID`, nullable) — the in-flight (incremental) repair
+//!     session id, `null` for an SSTable not part of a pending repair. Rendered
+//!     as `Pending repair: --` when null.
+//!   * `isTransient` (`boolean`) — whether the SSTable holds only transiently
+//!     replicated data. Rendered as `IsTransient: false`.
+//!
+//! # Scope — persisted-metadata parse/report ONLY
+//!
+//! This module decodes and **reports** the *persisted* repair state. It does
+//! **not** implement, and must not be read as implying, repair coordination,
+//! incremental-repair session tracking, or **repair-aware compaction /
+//! tombstone purging**. Exposing `repairedAt` here establishes nothing about
+//! whether tombstones are safe to purge against a repair boundary — that is a
+//! separate correctness concern that lives in the compaction layer.
+//!
+//! # What is decoded from real bytes
+//!
+//! `repairedAt` is decoded directly from the STATS component. It is reachable by
+//! a fully *self-describing* forward walk over the leading STATS fields (two
+//! `EstimatedHistogram`s and one `TombstoneHistogram`, every one length-prefixed
+//! and free of any column-type dependency), so it is decoded for **every**
+//! storage format (nb / oa / da) without needing the serialization header.
+//!
+//! `pendingRepair` and `isTransient` sit *after* the version-gated
+//! `improvedMinMax` block (oa/da) and the variable `commitLogIntervals` set,
+//! both of which require type-aware / interval-aware skipping to traverse. The
+//! Cassandra 5.0 corpus contains **no** repaired / pending-repair / transient
+//! fixture (every fixture is the unrepaired/null/non-transient state), and this
+//! module does **not** perform that type-aware walk. It therefore reports those
+//! two fields **honestly as `Unparsed`** (an explicit "not yet decoded" state)
+//! rather than fabricating a concrete `null` / `false`, so a real SSTable that
+//! *did* carry a pending-repair UUID or transient flag is never silently
+//! misreported as absent. The strict test lane proves the *reference* state is
+//! null / false across the corpus while asserting CQLite reports those fields as
+//! `Unparsed`, rather than fabricating repaired bytes.
+
+use crate::error::{Error, Result};
+use crate::storage::sstable::version_gate::VersionGates;
+
+/// Cassandra `MetadataType.STATS` ordinal (MetadataType.java).
+const METADATA_TYPE_STATS: u32 = 2;
+
+/// A STATS repair field that may either have been decoded from real bytes
+/// (`Decoded`) or is honestly reported as not-yet-decoded (`Unparsed`).
+///
+/// This exists so the public API never fabricates a concrete value for a field
+/// this module does not actually walk from the STATS bytes. A real SSTable
+/// carrying a pending-repair UUID or a transient flag is reported as `Unparsed`
+/// — never silently misreported as the absent/false default — until a
+/// type-aware forward walk past `improvedMinMax` + `commitLogIntervals` is
+/// implemented (which requires a fixture that does not exist in the corpus; see
+/// module docs).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RepairField<T> {
+    /// The field was decoded directly from the STATS-component bytes.
+    Decoded(T),
+    /// The field was not decoded; its real value is unknown. Callers must NOT
+    /// treat this as the absent/default state.
+    Unparsed,
+}
+
+impl<T> RepairField<T> {
+    /// The decoded value, or `None` when the field is `Unparsed`. Callers that
+    /// need to distinguish "decoded as absent" from "not decoded" must match on
+    /// the variant directly rather than using this.
+    pub fn decoded(&self) -> Option<&T> {
+        match self {
+            RepairField::Decoded(v) => Some(v),
+            RepairField::Unparsed => None,
+        }
+    }
+
+    /// Whether this field was decoded from real bytes.
+    pub fn is_decoded(&self) -> bool {
+        matches!(self, RepairField::Decoded(_))
+    }
+}
+
+/// Repair-coordination metadata persisted in the `Statistics.db` STATS
+/// component. Read-side / report-only (see module docs).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepairMetadata {
+    /// `repairedAt` timestamp; `0` for an unrepaired SSTable. Decoded directly
+    /// from the STATS-component bytes (genuinely walked, so concrete).
+    pub repaired_at: i64,
+
+    /// `pendingRepair` session UUID (`Decoded(Some(uuid))`), an explicitly
+    /// decoded null (`Decoded(None)`), or `Unparsed` when this module did not
+    /// decode it from the STATS bytes.
+    ///
+    /// This module does NOT currently walk this field (it sits after the
+    /// version-gated `improvedMinMax` block and the variable
+    /// `commitLogIntervals` set), so it is reported as `Unparsed` rather than a
+    /// fabricated `None`. See module docs.
+    pub pending_repair: RepairField<Option<[u8; 16]>>,
+
+    /// `isTransient` flag (`Decoded(bool)`) or `Unparsed` when not decoded.
+    ///
+    /// As with `pending_repair`, this module does not walk this field, so it is
+    /// reported honestly as `Unparsed` rather than a fabricated `false`.
+    pub is_transient: RepairField<bool>,
+
+    /// `true` when `repaired_at` was decoded from the STATS component bytes;
+    /// `false` when it could only be reported as the unrepaired default (e.g.
+    /// the STATS component was not locatable). Lets callers distinguish a
+    /// byte-proven value from a defaulted one.
+    pub repaired_at_decoded: bool,
+}
+
+impl RepairMetadata {
+    /// The canonical unrepaired state for an SSTable whose STATS component could
+    /// not be located: `repairedAt` defaults to `0` (undecoded), and the two
+    /// not-walked fields are reported honestly as `Unparsed`.
+    pub fn unrepaired_default() -> Self {
+        RepairMetadata {
+            repaired_at: 0,
+            pending_repair: RepairField::Unparsed,
+            is_transient: RepairField::Unparsed,
+            repaired_at_decoded: false,
+        }
+    }
+}
+
+/// Number of CRC bytes Cassandra writes after EACH metadata component. The
+/// `Statistics.db` MetadataSerializer emits a 4-byte CRC32 (over the component's
+/// own bytes) immediately after every component body — including the last.
+/// Verified empirically against real nb/oa/da fixtures: for a component at TOC
+/// offset `o` whose successor is at offset `next`, the bytes `[next-4, next)`
+/// are `crc32(buf[o..next-4])`; for the final component the CRC occupies the
+/// last 4 bytes of the file. The STATS component must never be decoded into this
+/// CRC, so both the next-component bound and the last-component bound subtract it.
+const METADATA_COMPONENT_CRC_LEN: usize = 4;
+
+/// The located STATS component, as a `[start, end)` byte range within the
+/// `Statistics.db` buffer. `end` is the *next* component's offset minus the
+/// 4-byte per-component CRC that sits between STATS and that component (the
+/// smallest component offset strictly greater than `start`), or — when STATS is
+/// the last component — the end of the file minus the trailing 4-byte CRC. The
+/// decode cursor is constructed over ONLY this slice so that a truncated STATS
+/// body or an over-long internal length field fails closed instead of spilling
+/// into the CRC or the following component.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct StatsComponentBounds {
+    start: usize,
+    end: usize,
+}
+
+/// Locate the byte range of the STATS (`MetadataType` ordinal 2) component from
+/// the `Statistics.db` Table of Contents.
+///
+/// The TOC carries `(type, offset)` pairs for every metadata component. The
+/// STATS component's end is derived authoritatively from those same offsets —
+/// the next component begins where STATS must end — rather than from the rest of
+/// the file. When STATS is the final component, its end is the start of the
+/// trailing CRC. The returned range is validated `start < end <= file_len`.
+///
+/// Returns:
+///   * `Ok(None)` ONLY when the TOC is well-formed but carries NO STATS
+///     component (nothing to decode → the caller reports the unrepaired
+///     default).
+///   * `Ok(Some(bounds))` for a valid STATS range.
+///   * `Err(Corruption)` for a malformed/truncated TOC (too short for the
+///     header, component count out of range, or a TOC that overruns the
+///     buffer), OR when a STATS entry IS present but its derived range is
+///     invalid (offset past EOF, inverted, or zero-length) — fail closed so a
+///     corrupt `Statistics.db` is never silently reported as unrepaired.
+fn stats_component_bounds(input: &[u8]) -> Result<Option<StatsComponentBounds>> {
+    // A malformed or truncated TOC must FAIL CLOSED rather than be silently
+    // reported as "no STATS component" (which would misreport corrupt repair
+    // metadata as the unrepaired default). `Ok(None)` is reserved exclusively
+    // for a well-formed TOC that genuinely carries no STATS entry (below).
+    if input.len() < 8 {
+        return Err(Error::Corruption(format!(
+            "Statistics.db too short for a metadata TOC header: {} bytes",
+            input.len()
+        )));
+    }
+    let num_components = u32::from_be_bytes([input[0], input[1], input[2], input[3]]);
+    if num_components == 0 || num_components > 100 {
+        return Err(Error::Corruption(format!(
+            "Statistics.db TOC component count out of range: {num_components}"
+        )));
+    }
+    let toc_start = 8usize;
+    let entry_size = 8usize;
+    let toc_size = match (num_components as usize)
+        .checked_mul(entry_size)
+        .and_then(|n| n.checked_add(toc_start))
+    {
+        Some(n) => n,
+        None => {
+            return Err(Error::Corruption(format!(
+                "Statistics.db TOC size overflow for {num_components} components"
+            )))
+        }
+    };
+    if input.len() < toc_size {
+        return Err(Error::Corruption(format!(
+            "Statistics.db TOC truncated: need {toc_size} bytes, have {}",
+            input.len()
+        )));
+    }
+
+    let mut stats_off: Option<usize> = None;
+    let mut offsets: Vec<usize> = Vec::with_capacity(num_components as usize);
+    for i in 0..num_components as usize {
+        let entry = match i
+            .checked_mul(entry_size)
+            .and_then(|n| n.checked_add(toc_start))
+        {
+            Some(e) => e,
+            None => {
+                return Err(Error::Corruption(format!(
+                    "Statistics.db TOC entry offset overflow at index {i}"
+                )))
+            }
+        };
+        let ty = u32::from_be_bytes([
+            input[entry],
+            input[entry + 1],
+            input[entry + 2],
+            input[entry + 3],
+        ]);
+        let off = u32::from_be_bytes([
+            input[entry + 4],
+            input[entry + 5],
+            input[entry + 6],
+            input[entry + 7],
+        ]) as usize;
+        offsets.push(off);
+        if ty == METADATA_TYPE_STATS {
+            stats_off = Some(off);
+        }
+    }
+
+    // No STATS component in the TOC → nothing to decode (not an error).
+    let Some(start) = stats_off else {
+        return Ok(None);
+    };
+
+    // The STATS body ends 4 bytes before the *next* component begins: Cassandra
+    // writes a per-component CRC32 between each component body and the next
+    // component's offset (verified against real fixtures). Use the smallest
+    // component offset strictly greater than `start`, minus that CRC; when STATS
+    // is the last component, bound by the file end minus the trailing CRC. Both
+    // cases exclude the 4-byte CRC so it is never decoded as metadata.
+    let next_boundary = offsets
+        .iter()
+        .copied()
+        .filter(|&o| o > start)
+        .min()
+        .unwrap_or(input.len());
+    let end = next_boundary.saturating_sub(METADATA_COMPONENT_CRC_LEN);
+
+    // A STATS entry exists but its derived range is invalid (offset past EOF,
+    // inverted, or empty): this is genuine corruption — fail closed rather than
+    // silently reporting the unrepaired default or building a cursor over
+    // garbage.
+    if start >= end || end > input.len() {
+        return Err(Error::Corruption(format!(
+            "STATS component range invalid: start {start}, derived end {end}, \
+             Statistics.db {} bytes",
+            input.len()
+        )));
+    }
+
+    Ok(Some(StatsComponentBounds { start, end }))
+}
+
+/// A bounded cursor over the STATS component bytes that fails closed (explicit
+/// error) on any read past the end rather than panicking.
+struct Cursor<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Cursor<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Cursor { bytes, pos: 0 }
+    }
+
+    fn need(&self, n: usize) -> Result<usize> {
+        let end = self
+            .pos
+            .checked_add(n)
+            .ok_or_else(|| Error::Corruption("STATS cursor overflow".to_string()))?;
+        if end > self.bytes.len() {
+            return Err(Error::Corruption(format!(
+                "STATS component truncated: need {n} bytes at offset {} but only {} remain",
+                self.pos,
+                self.bytes.len().saturating_sub(self.pos),
+            )));
+        }
+        Ok(end)
+    }
+
+    fn skip(&mut self, n: usize) -> Result<()> {
+        let end = self.need(n)?;
+        self.pos = end;
+        Ok(())
+    }
+
+    fn read_i32(&mut self) -> Result<i32> {
+        let end = self.need(4)?;
+        let v = i32::from_be_bytes([
+            self.bytes[self.pos],
+            self.bytes[self.pos + 1],
+            self.bytes[self.pos + 2],
+            self.bytes[self.pos + 3],
+        ]);
+        self.pos = end;
+        Ok(v)
+    }
+
+    fn read_i64(&mut self) -> Result<i64> {
+        let end = self.need(8)?;
+        let mut buf = [0u8; 8];
+        buf.copy_from_slice(&self.bytes[self.pos..end]);
+        self.pos = end;
+        Ok(i64::from_be_bytes(buf))
+    }
+}
+
+/// Skip an `EstimatedHistogram`: `i32 count`, then `count` × (`i64 offset`,
+/// `i64 count`). Self-describing — no column-type knowledge required.
+fn skip_estimated_histogram(c: &mut Cursor) -> Result<()> {
+    let count = c.read_i32()?;
+    if count < 0 {
+        return Err(Error::Corruption(format!(
+            "negative EstimatedHistogram bucket count {count}"
+        )));
+    }
+    let bytes = (count as usize)
+        .checked_mul(16)
+        .ok_or_else(|| Error::Corruption("EstimatedHistogram size overflow".to_string()))?;
+    c.skip(bytes)
+}
+
+/// Skip a `TombstoneHistogram`: `i32 maxBinSize`, `i32 size`, then `size` bins.
+///
+/// `modern` selects the entry width: the modern (`oa`/`da`)
+/// `HistogramSerializer` writes `i64 point + i32 value` (12 bytes); the legacy
+/// (`nb`/`mc`) serializer writes `f64 point + i64 value` (16 bytes). The choice
+/// follows `TombstoneHistogram.getSerializer(version)` — the only format-gated
+/// decision needed to reach `repairedAt`.
+fn skip_tombstone_histogram(c: &mut Cursor, modern: bool) -> Result<()> {
+    let _max_bin_size = c.read_i32()?;
+    let size = c.read_i32()?;
+    if size < 0 {
+        return Err(Error::Corruption(format!(
+            "negative TombstoneHistogram size {size}"
+        )));
+    }
+    let entry_width = if modern { 12 } else { 16 };
+    let bytes = (size as usize)
+        .checked_mul(entry_width)
+        .ok_or_else(|| Error::Corruption("TombstoneHistogram size overflow".to_string()))?;
+    c.skip(bytes)
+}
+
+/// Whether this version uses the modern tombstone-histogram entry encoding.
+///
+/// `TombstoneHistogram.getSerializer` resolves to the modern `HistogramSerializer`
+/// for `oa`+ (incl. BTI `da`) and the legacy serializer for older versions.
+fn uses_modern_tombstone_histogram(gates: &VersionGates) -> bool {
+    match gates {
+        // The oa-only `hasUIntDeletionTime` gate cleanly separates the modern
+        // (oa/da) histogram encoding from the legacy (nb) one.
+        VersionGates::Big(g) => g.has_uint_deletion_time,
+        VersionGates::Bti(_) => true,
+    }
+}
+
+/// Decode the repair-state metadata from a raw `Statistics.db` buffer.
+///
+/// `repairedAt` is decoded from the STATS component for every format. When
+/// `gates` is `None`, the legacy (nb) tombstone-histogram width is assumed
+/// (nb-compatible default), matching the rest of the minimal Statistics parser.
+///
+/// `pendingRepair` / `isTransient` are reported honestly as `RepairField::Unparsed`
+/// (this module does not walk them; see module docs); this function never
+/// fabricates a repaired state.
+///
+/// # Errors
+///
+/// Returns an error only when the STATS component is present but its leading
+/// (self-describing) fields are truncated/corrupt, OR overrun the STATS
+/// component's authoritative end bound — strict callers can rely on this to fail
+/// closed (a truncated body or an over-long internal length never spills into
+/// the trailing CRC or the following component). A *missing* STATS component is
+/// reported as the unrepaired default with `repaired_at_decoded = false` (the
+/// buffer carried no STATS section to decode). A STATS entry that IS present but
+/// whose derived byte range is invalid (offset past EOF, inverted) is treated as
+/// corruption and fails closed.
+pub fn parse_repair_metadata(input: &[u8], gates: Option<&VersionGates>) -> Result<RepairMetadata> {
+    let Some(bounds) = stats_component_bounds(input)? else {
+        return Ok(RepairMetadata::unrepaired_default());
+    };
+
+    let modern_histogram = gates.map(uses_modern_tombstone_histogram).unwrap_or(false);
+
+    // Bound the cursor over ONLY the STATS component slice (start..end, with the
+    // trailing CRC and following components excluded). Any read past this slice
+    // fails closed with Error::Corruption.
+    let mut c = Cursor::new(&input[bounds.start..bounds.end]);
+
+    // 1-2. estimatedPartitionSize + estimatedCellPerPartitionCount.
+    skip_estimated_histogram(&mut c)?;
+    skip_estimated_histogram(&mut c)?;
+
+    // 3. commitLogUpperBound: i64 segmentId + i32 position.
+    c.skip(8 + 4)?;
+
+    // 4. minTimestamp, maxTimestamp.
+    c.skip(8 + 8)?;
+
+    // 5. min/maxLocalDeletionTime. Both encodings (nb 2× i32, oa/da 2× u32)
+    //    occupy 8 bytes total, so the width does not branch here.
+    c.skip(4 + 4)?;
+
+    // 6. minTTL, maxTTL.
+    c.skip(4 + 4)?;
+
+    // 7. compressionRatio (f64).
+    c.skip(8)?;
+
+    // 8. estimatedTombstoneDropTime (TombstoneHistogram) — the only format-gated
+    //    field width on the path to repairedAt.
+    skip_tombstone_histogram(&mut c, modern_histogram)?;
+
+    // 9. sstableLevel (i32), then repairedAt (i64).
+    let _sstable_level = c.read_i32()?;
+    let repaired_at = c.read_i64()?;
+
+    Ok(RepairMetadata {
+        repaired_at,
+        // Not walked by this module — reported honestly as not-yet-decoded
+        // rather than a fabricated null / false (see module docs).
+        pending_repair: RepairField::Unparsed,
+        is_transient: RepairField::Unparsed,
+        repaired_at_decoded: true,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a minimal but valid STATS component (through `repairedAt`) plus a
+    /// 4-component TOC pointing at it, so the decoder can be exercised in-memory
+    /// without a fetched fixture.
+    fn synthetic_statistics(modern_histogram: bool, repaired_at: i64) -> Vec<u8> {
+        // --- STATS body ---
+        let mut stats = Vec::new();
+        let est_hist = |b: &mut Vec<u8>| {
+            b.extend_from_slice(&0i32.to_be_bytes()); // bucket count 0 (self-describing)
+        };
+        est_hist(&mut stats); // estimatedPartitionSize
+        est_hist(&mut stats); // estimatedCellPerPartitionCount
+        stats.extend_from_slice(&(-1i64).to_be_bytes()); // commitLogUpperBound segmentId
+        stats.extend_from_slice(&0i32.to_be_bytes()); // commitLogUpperBound position
+        stats.extend_from_slice(&100i64.to_be_bytes()); // minTimestamp
+        stats.extend_from_slice(&200i64.to_be_bytes()); // maxTimestamp
+        stats.extend_from_slice(&i32::MAX.to_be_bytes()); // minLocalDeletionTime
+        stats.extend_from_slice(&i32::MAX.to_be_bytes()); // maxLocalDeletionTime
+        stats.extend_from_slice(&0i32.to_be_bytes()); // minTTL
+        stats.extend_from_slice(&0i32.to_be_bytes()); // maxTTL
+        stats.extend_from_slice(&(-1.0f64).to_be_bytes()); // compressionRatio
+                                                           // TombstoneHistogram: empty (maxBinSize=0, size=0) regardless of width
+        stats.extend_from_slice(&0i32.to_be_bytes());
+        stats.extend_from_slice(&0i32.to_be_bytes());
+        let _ = modern_histogram; // empty histogram has identical bytes for both
+        stats.extend_from_slice(&0i32.to_be_bytes()); // sstableLevel
+        stats.extend_from_slice(&repaired_at.to_be_bytes()); // repairedAt
+
+        // --- TOC: 4 components, STATS (type 2) points at the body ---
+        // Layout: [u32 count][u32 marker][4 × (u32 type, u32 offset)][stats][crc]
+        // The three non-STATS components are placed BEFORE the STATS body (with
+        // tiny one-byte bodies) so STATS is the last component, and its end is
+        // derived as `file_len - trailing CRC`. This exercises the
+        // last-component bound path.
+        let toc_len = 4 + 4 + 4 * 8; // count + marker + entries (no trailing acc here)
+                                     // 3 one-byte placeholder bodies precede STATS.
+        let comp0_off = toc_len; // HEADER-ish placeholder
+        let comp1_off = comp0_off + 1;
+        let comp3_off = comp1_off + 1;
+        let stats_off = comp3_off + 1;
+        let mut out = Vec::new();
+        out.extend_from_slice(&4u32.to_be_bytes()); // num components
+        out.extend_from_slice(&0u32.to_be_bytes()); // marker (unused by this decoder)
+        for (ty, off) in [
+            (0u32, comp0_off as u32),
+            (1u32, comp1_off as u32),
+            (2u32, stats_off as u32), // STATS (last by offset)
+            (3u32, comp3_off as u32),
+        ] {
+            out.extend_from_slice(&ty.to_be_bytes());
+            out.extend_from_slice(&off.to_be_bytes());
+        }
+        // 3 placeholder component bodies (1 byte each).
+        out.extend_from_slice(&[0u8, 0u8, 0u8]);
+        debug_assert_eq!(out.len(), stats_off);
+        out.extend_from_slice(&stats);
+        out.extend_from_slice(&0u32.to_be_bytes()); // trailing metadata CRC
+        out
+    }
+
+    #[test]
+    fn decodes_repaired_at_legacy_histogram() {
+        let bytes = synthetic_statistics(false, 0);
+        let md = parse_repair_metadata(&bytes, None).expect("decode");
+        assert_eq!(md.repaired_at, 0);
+        assert!(md.repaired_at_decoded);
+        // pending_repair / is_transient are not walked → reported as Unparsed,
+        // NOT as a fabricated null / false.
+        assert_eq!(md.pending_repair, RepairField::Unparsed);
+        assert_eq!(md.is_transient, RepairField::Unparsed);
+        assert!(!md.pending_repair.is_decoded());
+        assert!(!md.is_transient.is_decoded());
+    }
+
+    #[test]
+    fn decodes_nonzero_repaired_at() {
+        let bytes = synthetic_statistics(false, 1_700_000_000_000);
+        let md = parse_repair_metadata(&bytes, None).expect("decode");
+        assert_eq!(md.repaired_at, 1_700_000_000_000);
+        assert!(md.repaired_at_decoded);
+    }
+
+    #[test]
+    fn malformed_toc_fails_closed() {
+        // A corrupt/truncated TOC must NOT be silently reported as the
+        // unrepaired default (repaired_at=0); it must fail closed.
+        // (a) non-empty file shorter than the 8-byte TOC header.
+        assert!(parse_repair_metadata(&[0u8, 0, 0], None).is_err());
+        // (b) component count of zero.
+        let mut zero = Vec::new();
+        zero.extend_from_slice(&0u32.to_be_bytes());
+        zero.extend_from_slice(&0u32.to_be_bytes());
+        assert!(parse_repair_metadata(&zero, None).is_err());
+        // (c) absurd component count.
+        let mut huge = Vec::new();
+        huge.extend_from_slice(&101u32.to_be_bytes());
+        huge.extend_from_slice(&0u32.to_be_bytes());
+        assert!(parse_repair_metadata(&huge, None).is_err());
+        // (d) well-formed count but the TOC body is truncated.
+        let mut truncated = Vec::new();
+        truncated.extend_from_slice(&4u32.to_be_bytes()); // claims 4 entries
+        truncated.extend_from_slice(&0u32.to_be_bytes()); // marker
+        truncated.extend_from_slice(&2u32.to_be_bytes()); // only a partial first entry
+        assert!(parse_repair_metadata(&truncated, None).is_err());
+    }
+
+    #[test]
+    fn missing_stats_component_reports_unrepaired_default() {
+        // TOC with no STATS entry (only HEADER) → default, not an error.
+        let mut out = Vec::new();
+        out.extend_from_slice(&1u32.to_be_bytes()); // 1 component
+        out.extend_from_slice(&0u32.to_be_bytes()); // marker
+        out.extend_from_slice(&3u32.to_be_bytes()); // type HEADER
+        out.extend_from_slice(&16u32.to_be_bytes()); // offset (irrelevant)
+        let md = parse_repair_metadata(&out, None).expect("default");
+        assert_eq!(md, RepairMetadata::unrepaired_default());
+        assert!(!md.repaired_at_decoded);
+    }
+
+    #[test]
+    fn truncated_stats_fails_closed() {
+        let mut bytes = synthetic_statistics(false, 0);
+        // Truncate inside the STATS body so the forward walk runs off the end.
+        bytes.truncate(bytes.len() - 4);
+        let err = parse_repair_metadata(&bytes, None);
+        assert!(
+            err.is_err(),
+            "truncated STATS component must fail closed, got {err:?}"
+        );
+    }
+
+    /// A STATS body whose internal length field overruns the component's end
+    /// bound (but still fits within the rest of the file) must fail closed,
+    /// proving the cursor is bounded by the STATS component, not by the file.
+    #[test]
+    fn stats_overrunning_component_bound_fails_closed() {
+        // Build a buffer where STATS is NOT the last component, so there is a
+        // following component AND a trailing CRC the decoder must never read.
+        let mut stats = Vec::new();
+        // Empty estimatedPartitionSize.
+        stats.extend_from_slice(&0i32.to_be_bytes());
+        // A SECOND EstimatedHistogram whose bucket count overruns the bound.
+        // We will set this count after we know how many bytes remain.
+        let bad_count_pos = stats.len();
+        stats.extend_from_slice(&0i32.to_be_bytes()); // placeholder
+                                                      // No more STATS bytes: the component ends right after this field.
+
+        // Layout: [count][marker][3 entries][stats][NEXT component bytes][crc].
+        // STATS is entry index 1; a HEADER component follows it in the file so
+        // there ARE bytes after STATS that the bad count would spill into.
+        let toc_len = 4 + 4 + 3 * 8;
+        let stats_off = toc_len;
+        let next_off = stats_off + stats.len(); // HEADER directly after STATS
+        let header_bytes = [0xAAu8; 64]; // plenty of bytes after STATS
+
+        // Now make the second histogram's bucket count large enough that
+        // 16*count would run past the STATS end but still inside the file.
+        let bad_count: i32 = 8; // 8 * 16 = 128 bytes, far past the 0-byte remainder
+        stats[bad_count_pos..bad_count_pos + 4].copy_from_slice(&bad_count.to_be_bytes());
+
+        let mut out = Vec::new();
+        out.extend_from_slice(&3u32.to_be_bytes());
+        out.extend_from_slice(&0u32.to_be_bytes());
+        for (ty, off) in [
+            (3u32, next_off as u32), // HEADER (follows STATS)
+            (2u32, stats_off as u32),
+            (0u32, (next_off + header_bytes.len()) as u32),
+        ] {
+            out.extend_from_slice(&ty.to_be_bytes());
+            out.extend_from_slice(&off.to_be_bytes());
+        }
+        debug_assert_eq!(out.len(), stats_off);
+        out.extend_from_slice(&stats);
+        out.extend_from_slice(&header_bytes); // next component
+        out.extend_from_slice(&0u32.to_be_bytes()); // trailing CRC
+
+        let err = parse_repair_metadata(&out, None);
+        assert!(
+            err.is_err(),
+            "a STATS body that overruns its component bound must fail closed \
+             (not spill into the next component / CRC), got {err:?}"
+        );
+    }
+
+    /// The component end bound is derived from the NEXT TOC offset (when STATS
+    /// is not last), excluding the trailing CRC when STATS IS last.
+    #[test]
+    fn component_bounds_derive_end_from_next_offset() {
+        // STATS-last synthetic: end == file_len - 4 (the CRC).
+        let bytes = synthetic_statistics(false, 0);
+        let bounds = stats_component_bounds(&bytes)
+            .expect("no error")
+            .expect("bounds present");
+        assert_eq!(
+            bounds.end,
+            bytes.len() - METADATA_COMPONENT_CRC_LEN,
+            "STATS-last end must exclude the trailing CRC"
+        );
+        assert!(bounds.start < bounds.end);
+    }
+
+    /// When STATS is NOT the last component, its end must be the next component's
+    /// TOC offset MINUS the 4-byte per-component CRC32 Cassandra writes between
+    /// each component body and the next component's offset — never the raw next
+    /// offset (which would let the decoder read 4 CRC bytes as metadata).
+    #[test]
+    fn nonlast_stats_end_excludes_component_crc() {
+        // Realistic layout: [count][marker][2 entries][STATS body][STATS crc][HEADER body][HEADER crc]
+        let mut stats = Vec::new();
+        stats.extend_from_slice(&0i32.to_be_bytes()); // estimatedPartitionSize (empty)
+        stats.extend_from_slice(&0i32.to_be_bytes()); // estimatedCellPerPartitionCount (empty)
+        stats.extend_from_slice(&7i64.to_be_bytes()); // a few more bytes of body
+
+        let toc_len = 4 + 4 + 2 * 8;
+        let stats_off = toc_len;
+        // HEADER begins AFTER the STATS body + its 4-byte CRC.
+        let header_off = stats_off + stats.len() + METADATA_COMPONENT_CRC_LEN;
+        let header_body = [0xABu8; 8];
+
+        let mut out = Vec::new();
+        out.extend_from_slice(&2u32.to_be_bytes()); // 2 components
+        out.extend_from_slice(&0u32.to_be_bytes()); // marker
+        for (ty, off) in [(2u32, stats_off as u32), (3u32, header_off as u32)] {
+            out.extend_from_slice(&ty.to_be_bytes());
+            out.extend_from_slice(&off.to_be_bytes());
+        }
+        debug_assert_eq!(out.len(), stats_off);
+        out.extend_from_slice(&stats);
+        let stats_crc = crc32_ieee(&out[stats_off..stats_off + stats.len()]);
+        out.extend_from_slice(&stats_crc.to_be_bytes()); // per-component CRC after STATS
+        debug_assert_eq!(out.len(), header_off);
+        out.extend_from_slice(&header_body);
+        out.extend_from_slice(&0u32.to_be_bytes()); // HEADER's trailing CRC
+
+        let bounds = stats_component_bounds(&out)
+            .expect("no error")
+            .expect("bounds present");
+        assert_eq!(
+            bounds.end,
+            header_off - METADATA_COMPONENT_CRC_LEN,
+            "non-last STATS end must exclude the inter-component CRC"
+        );
+        assert_eq!(
+            bounds.end,
+            stats_off + stats.len(),
+            "non-last STATS end must equal the true STATS body end"
+        );
+    }
+
+    /// Minimal CRC32 (IEEE) for the regression test's synthetic CRC bytes.
+    fn crc32_ieee(data: &[u8]) -> u32 {
+        let mut crc: u32 = 0xFFFF_FFFF;
+        for &byte in data {
+            crc ^= byte as u32;
+            for _ in 0..8 {
+                let mask = (crc & 1).wrapping_neg();
+                crc = (crc >> 1) ^ (0xEDB8_8320 & mask);
+            }
+        }
+        !crc
+    }
+}

--- a/cqlite-core/src/storage/sstable/bloom.rs
+++ b/cqlite-core/src/storage/sstable/bloom.rs
@@ -2,6 +2,13 @@
 
 use crate::{Error, Result};
 
+/// Maximum bloom-filter hash count CQLite will deserialize. Cassandra derives the
+/// number of hash functions (k) from the target false-positive rate via
+/// `BloomCalculations` (max ~20). This bound is far above any real filter yet
+/// rejects absurd positive header values that would otherwise drive `contains()`
+/// to loop billions of times on malformed/corrupt `Filter.db` bytes.
+const MAX_HASH_COUNT: i32 = 1024;
+
 /// Branchless absolute value matching Cassandra's `FBUtilities.abs()`.
 ///
 /// ```java
@@ -202,11 +209,53 @@ impl BloomFilter {
             return Err(Error::serialization("Invalid bloom filter data: too short"));
         }
 
-        // Read hash count (4 bytes, big-endian i32)
-        let hash_count = u32::from_be_bytes([data[0], data[1], data[2], data[3]]);
+        // Cassandra writes both header counts as signed 32-bit big-endian ints:
+        //   BloomFilterSerializer: `dos.writeInt(bf.hashCount)`
+        //   OffHeapBitSet:         `out.writeInt((int)(bytes.size() / 8))` (num longs)
+        // (see docs/sstables-definitive-guide/chapters/07-bloom-filter.md:107-111).
+        // We must read them as i32 so a high-bit-set value (e.g. 0xFFFF_FFFF == -1,
+        // or 0x8000_0000 == i32::MIN) is recognised as negative/garbage rather than
+        // a huge positive count. A pathologically large hash_count would otherwise
+        // make contains() loop billions of times (DoS); a negative num_longs cast to
+        // usize would also produce nonsense size math.
+        let hash_count_i32 = i32::from_be_bytes([data[0], data[1], data[2], data[3]]);
+        let num_longs_i32 = i32::from_be_bytes([data[4], data[5], data[6], data[7]]);
 
-        // Read number of longs (4 bytes, big-endian i32)
-        let num_longs = u32::from_be_bytes([data[4], data[5], data[6], data[7]]) as usize;
+        // Strict-mode: reject malformed/unusable headers. A filter with a
+        // non-positive hash count or non-positive bit-word count is degenerate —
+        // it would fail OPEN (always report "not present", producing false
+        // negatives), drive a pathological lookup loop, or break size math.
+        // Real Cassandra Filter.db headers always carry hash_count >= 1 and
+        // num_longs >= 1, so rejecting `<= 0` (which subsumes the old `== 0`
+        // guard while also covering negative / high-bit-set garbage) only rejects
+        // corrupt/unsupported metadata.
+        if hash_count_i32 <= 0 {
+            return Err(Error::corruption(format!(
+                "Invalid bloom filter header: hash_count is {hash_count_i32} (must be > 0; \
+                 unsupported/malformed/corrupt filter metadata)"
+            )));
+        }
+        // Upper bound: a positive-but-absurd hash_count (e.g. i32::MAX) passes the
+        // `<= 0` guard yet makes every contains() loop billions of times (DoS).
+        // Cassandra derives k from the target FP rate via BloomCalculations, whose
+        // maximum is ~20; MAX_HASH_COUNT is far above any real filter while still
+        // bounding the lookup loop. Reject anything larger as malformed.
+        if hash_count_i32 > MAX_HASH_COUNT {
+            return Err(Error::corruption(format!(
+                "Invalid bloom filter header: hash_count {hash_count_i32} exceeds the maximum \
+                 supported ({MAX_HASH_COUNT}); malformed/corrupt filter metadata"
+            )));
+        }
+        if num_longs_i32 <= 0 {
+            return Err(Error::corruption(format!(
+                "Invalid bloom filter header: num_longs is {num_longs_i32} (must be > 0; \
+                 malformed/corrupt filter, zero or negative bits)"
+            )));
+        }
+
+        // Safe to widen now that both values are validated as strictly positive i32.
+        let hash_count = hash_count_i32 as u32;
+        let num_longs = num_longs_i32 as usize;
 
         let expected_size = 8 + (num_longs * 8);
 

--- a/cqlite-core/src/storage/sstable/format_detector.rs
+++ b/cqlite-core/src/storage/sstable/format_detector.rs
@@ -189,6 +189,12 @@ pub enum SSTableComponent {
     CompressionInfo,
     Statistics,
     Digest,
+    /// Per-chunk CRC32 file for uncompressed SSTables (Cassandra `CRC.db`).
+    ///
+    /// Optional: emitted for uncompressed tables only (mutually exclusive with
+    /// `CompressionInfo.db`) and shared by BIG and BTI formats. Recognized here
+    /// for consistency with `directory::types::SSTableComponent::Crc`.
+    Crc,
     TOC,
 }
 
@@ -209,6 +215,8 @@ impl SSTableComponent {
             Some(SSTableComponent::Statistics)
         } else if filename.ends_with("-Digest.crc32") {
             Some(SSTableComponent::Digest)
+        } else if filename.ends_with("-CRC.db") {
+            Some(SSTableComponent::Crc)
         } else if filename.ends_with("-TOC.txt") {
             Some(SSTableComponent::TOC)
         } else {
@@ -226,6 +234,7 @@ impl SSTableComponent {
             SSTableComponent::CompressionInfo => "CompressionInfo.db",
             SSTableComponent::Statistics => "Statistics.db",
             SSTableComponent::Digest => "Digest.crc32",
+            SSTableComponent::Crc => "CRC.db",
             SSTableComponent::TOC => "TOC.txt",
         }
     }
@@ -498,6 +507,29 @@ mod tests {
             SSTableComponent::from_filename("nb-1-big-TOC.txt"),
             Some(SSTableComponent::TOC)
         );
+    }
+
+    /// `CRC.db` must round-trip in BOTH `SSTableComponent` models (#1048).
+    ///
+    /// Cassandra emits `CRC.db` for uncompressed SSTables. The
+    /// `directory::types` enum already recognized it (#966); this confirms the
+    /// filename-scan `format_detector` enum now agrees.
+    #[test]
+    fn test_crc_component_round_trips_in_both_models() {
+        // format_detector model: from_filename -> variant -> suffix
+        assert_eq!(
+            SSTableComponent::from_filename("nb-1-big-CRC.db"),
+            Some(SSTableComponent::Crc)
+        );
+        assert_eq!(SSTableComponent::Crc.suffix(), "CRC.db");
+
+        // directory::types model: from_str -> variant -> file_extension
+        use crate::storage::sstable::directory::types::SSTableComponent as DirComponent;
+        let dir_component = "CRC.db"
+            .parse::<DirComponent>()
+            .expect("directory model must parse CRC.db");
+        assert_eq!(dir_component, DirComponent::Crc);
+        assert_eq!(dir_component.file_extension(), "CRC.db");
     }
 
     #[test]

--- a/cqlite-core/tests/sstable_parity_compression_info_test.rs
+++ b/cqlite-core/tests/sstable_parity_compression_info_test.rs
@@ -1,0 +1,816 @@
+//! Strict `CompressionInfo.db` metadata + compressed-chunk boundary parity
+//! (Epic #968 / issue #986).
+//!
+//! Proves CQLite decodes the compression metadata Apache Cassandra 5.0 persisted
+//! into `CompressionInfo.db` and reads the inline per-chunk CRC trailers Cassandra
+//! wrote into `Data.db`, byte-for-byte and field-for-field — with no name/path
+//! heuristics (the compressor and every numeric field come from the parsed bytes).
+//!
+//! Scope owned here (issue #986):
+//!   * **CompressionInfo.db byte layout + decoded metadata.** The compressor
+//!     simple-name, option key/value pairs, `chunk_length`, `max_compressed_length`,
+//!     uncompressed `data_length`, chunk count, and the ordered chunk-offset table
+//!     are each re-derived independently from the raw bytes (a second, in-test
+//!     reader) and asserted equal to CQLite's `CompressionInfo::parse` decode. The
+//!     file must end *exactly* after the offset table — Cassandra appends no
+//!     trailing metadata CRC to `CompressionInfo.db` (per-chunk CRCs live inline in
+//!     `Data.db`). Offsets are compared as an ordered vector, not just a count.
+//!   * **Compressed-chunk boundary parity against Data.db.** For every chunk, the
+//!     record size (delta to the next offset, or to EOF for the final partial
+//!     chunk) is checked against the `Data.db` length, and the trailing 4-byte
+//!     big-endian inline CRC32 is recomputed over the compressed payload and
+//!     asserted equal to the stored CRC — exactly as
+//!     `CompressedSequentialWriter.java` writes it. Final partial-chunk handling
+//!     (last record runs to EOF) is exercised by multi-chunk fixtures.
+//!   * **Codec coverage from real fixtures.** The committed corpus carries real
+//!     `LZ4Compressor` and `SnappyCompressor` fixtures; both are required to be
+//!     exercised. `DeflateCompressor` / `ZstdCompressor` have NO Cassandra fixture
+//!     in the corpus — they are classified explicitly as "no fixture available"
+//!     and logged, never faked.
+//!   * **Negative / fail-closed tests.** Corrupting `CompressionInfo.db` bytes
+//!     (mutated in memory) makes `parse` reject the buffer, and corrupting a
+//!     compressed chunk's bytes or its inline CRC in a copied `Data.db` buffer
+//!     makes the strict CRC gate fail. Truncating the final record below its CRC
+//!     trailer also fails closed.
+//!
+//! Fail-closed contract (matches the established dataset convention — see
+//! `sstable_parity_toc_component_test.rs`):
+//!   * The binary `*-CompressionInfo.db` and `*-Data.db` are fetched fixtures
+//!     (gitignored). When the dataset is *entirely* absent (fresh checkout / CI
+//!     without `fetch-datasets.sh`), the lane SKIPS — there is nothing to compare.
+//!     Data.db presence is tracked INDEPENDENTLY of the compare count.
+//!   * When binaries ARE present, the lane must actually compare fixtures and must
+//!     exercise every codec the local corpus contains; a green run with zero
+//!     comparisons, or with a present codec left uncovered, is a false pass and
+//!     fails closed.
+//!
+//! Out of scope here (see manifest `planned` entries and issue #986 "Out of
+//! scope"): Zstd dictionary compression, compression performance benchmarking,
+//! Cassandra upgrade orchestration beyond persisted component bytes, and network
+//! streaming compression.
+
+use std::path::{Path, PathBuf};
+
+use cqlite_core::storage::sstable::compression_info::CompressionInfo;
+
+/// Resolve the committed datasets root (env override first, else workspace tree).
+fn datasets_sstables_root() -> PathBuf {
+    let root = if let Ok(root) = std::env::var("CQLITE_DATASETS_ROOT") {
+        PathBuf::from(root)
+    } else {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .map(|workspace| workspace.join("test-data/datasets"))
+            .unwrap_or_else(|| PathBuf::from("test-data/datasets"))
+    };
+    root.join("sstables")
+}
+
+/// Recursively collect every committed `*-TOC.txt` reference under `dir`,
+/// skipping macOS AppleDouble shadow files (`._*`).
+///
+/// The `TOC.txt` manifest is the committed (git-tracked) anchor: it lists
+/// `CompressionInfo.db` whenever the SSTable is compressed, so it lets the lane
+/// fail closed when references vanish, independent of whether the gitignored
+/// binary `CompressionInfo.db` has been fetched.
+fn collect_toc_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with("._") {
+            continue;
+        }
+        if path.is_dir() {
+            collect_toc_files(&path, out);
+        } else if name.ends_with("-TOC.txt") {
+            out.push(path);
+        }
+    }
+}
+
+fn all_toc_files() -> Vec<PathBuf> {
+    let root = datasets_sstables_root();
+    let mut out = Vec::new();
+    collect_toc_files(&root, &mut out);
+    out.sort();
+    // Fail closed: a broken fixture path must turn the strict lane red, not green.
+    assert!(
+        !out.is_empty(),
+        "no committed *-TOC.txt references found under {} — strict CompressionInfo.db parity \
+         cannot run (this is a fail-closed guard, not a skip)",
+        root.display()
+    );
+    out
+}
+
+/// True iff the committed `TOC.txt` manifest lists a `CompressionInfo.db`
+/// component (i.e. the SSTable is compressed). Authoritative — read from the
+/// manifest text Cassandra wrote, never inferred from a directory name.
+fn toc_lists_compression_info(toc: &Path) -> bool {
+    let Ok(content) = std::fs::read_to_string(toc) else {
+        return false;
+    };
+    content
+        .lines()
+        .map(str::trim)
+        .any(|l| l == "CompressionInfo.db")
+}
+
+/// Derive the SSTable base path (e.g. `.../nb-1-big`) from its `*-TOC.txt`.
+fn base_from_toc(toc: &Path) -> PathBuf {
+    let name = toc
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or_else(|| panic!("non-UTF8 TOC filename: {}", toc.display()));
+    let base = name
+        .strip_suffix("-TOC.txt")
+        .unwrap_or_else(|| panic!("TOC not *-TOC.txt: {name}"));
+    toc.with_file_name(base)
+}
+
+/// The fields of a `CompressionInfo.db` re-derived independently from the raw
+/// bytes by this test (a second reader), so the comparison against
+/// `CompressionInfo::parse` is a genuine cross-check rather than a tautology.
+#[derive(Debug, PartialEq, Eq)]
+struct RawCompressionInfo {
+    algorithm: String,
+    options: Vec<(String, String)>,
+    chunk_length: u32,
+    max_compressed_length: u32,
+    data_length: u64,
+    chunk_offsets: Vec<u64>,
+    /// Total bytes consumed (must equal the file length: no trailing metadata CRC).
+    consumed: usize,
+}
+
+/// Independent re-implementation of the Cassandra `CompressionInfo.db` layout
+/// (`CompressionMetadata.java:375-392`), used only to cross-check CQLite's parser.
+/// Returns `Err` on any structural problem so corruption tests can assert failure.
+fn read_raw_compression_info(d: &[u8]) -> Result<RawCompressionInfo, String> {
+    let mut o = 0usize;
+    let read_u16 = |d: &[u8], o: &mut usize| -> Result<u16, String> {
+        if *o + 2 > d.len() {
+            return Err(format!("short read u16 at {}", *o));
+        }
+        let v = u16::from_be_bytes([d[*o], d[*o + 1]]);
+        *o += 2;
+        Ok(v)
+    };
+    let read_utf = |d: &[u8], o: &mut usize| -> Result<String, String> {
+        let len = read_u16(d, o)? as usize;
+        if *o + len > d.len() {
+            return Err(format!("short read utf({len}) at {}", *o));
+        }
+        let s = String::from_utf8(d[*o..*o + len].to_vec()).map_err(|e| e.to_string())?;
+        *o += len;
+        Ok(s)
+    };
+    let read_u32 = |d: &[u8], o: &mut usize| -> Result<u32, String> {
+        if *o + 4 > d.len() {
+            return Err(format!("short read u32 at {}", *o));
+        }
+        let v = u32::from_be_bytes([d[*o], d[*o + 1], d[*o + 2], d[*o + 3]]);
+        *o += 4;
+        Ok(v)
+    };
+    let read_u64 = |d: &[u8], o: &mut usize| -> Result<u64, String> {
+        if *o + 8 > d.len() {
+            return Err(format!("short read u64 at {}", *o));
+        }
+        let v = u64::from_be_bytes([
+            d[*o],
+            d[*o + 1],
+            d[*o + 2],
+            d[*o + 3],
+            d[*o + 4],
+            d[*o + 5],
+            d[*o + 6],
+            d[*o + 7],
+        ]);
+        *o += 8;
+        Ok(v)
+    };
+
+    let algorithm = read_utf(d, &mut o)?;
+    let option_count = read_u32(d, &mut o)?;
+    let mut options = Vec::new();
+    for _ in 0..option_count {
+        let k = read_utf(d, &mut o)?;
+        let v = read_utf(d, &mut o)?;
+        options.push((k, v));
+    }
+    let chunk_length = read_u32(d, &mut o)?;
+    let max_compressed_length = read_u32(d, &mut o)?;
+    let data_length = read_u64(d, &mut o)?;
+    let chunk_count = read_u32(d, &mut o)? as usize;
+    let mut chunk_offsets = Vec::with_capacity(chunk_count);
+    for _ in 0..chunk_count {
+        chunk_offsets.push(read_u64(d, &mut o)?);
+    }
+
+    Ok(RawCompressionInfo {
+        algorithm,
+        options,
+        chunk_length,
+        max_compressed_length,
+        data_length,
+        chunk_offsets,
+        consumed: o,
+    })
+}
+
+/// Codecs whose decode CQLite supports but for which the committed corpus carries
+/// NO real Cassandra fixture. These are classified explicitly (logged), never
+/// faked with synthetic reference data.
+const CODECS_WITHOUT_FIXTURE: [&str; 2] = ["DeflateCompressor", "ZstdCompressor"];
+
+/// Strict CompressionInfo.db metadata + Data.db chunk-boundary / inline-CRC parity.
+#[test]
+fn compression_info_strict_metadata_and_chunk_parity() {
+    let tocs = all_toc_files();
+
+    // Anchor presence in the committed manifests: how many SSTables are compressed
+    // (TOC lists CompressionInfo.db). This is independent of binary fetch and lets
+    // the lane fail closed if the committed references ever stop describing
+    // compression.
+    let compressed_tocs: Vec<&PathBuf> = tocs
+        .iter()
+        .filter(|t| toc_lists_compression_info(t))
+        .collect();
+    assert!(
+        !compressed_tocs.is_empty(),
+        "no committed TOC.txt manifest lists CompressionInfo.db — the compression corpus \
+         vanished from the references (fail-closed, not a skip)"
+    );
+
+    // Track binary presence (any fetched CompressionInfo.db) INDEPENDENTLY of how
+    // many we successfully compared, so a present-but-zero-compared run fails.
+    let mut any_ci_present = false;
+    let mut any_data_present = false;
+    // Tracks Data.db presence INDEPENDENTLY of CompressionInfo.db, so a partial /
+    // broken fetch (Data.db fetched but CompressionInfo.db missing) FAILS rather
+    // than silently skipping green.
+    let mut any_data_db_on_disk = false;
+
+    let mut compared = 0usize;
+    let mut skipped_absent = 0usize;
+
+    let mut saw_lz4 = false;
+    let mut saw_snappy = false;
+    let mut codec_present_lz4 = false; // a fetched LZ4 CompressionInfo.db existed
+    let mut codec_present_snappy = false; // a fetched Snappy CompressionInfo.db existed
+    let mut saw_multi_chunk = false; // >1 chunk (final partial chunk -> EOF)
+    let mut saw_options = false; // a fixture carrying option pairs
+    let mut crc_validated_chunks = 0usize;
+
+    for toc in &compressed_tocs {
+        let base = base_from_toc(toc);
+        let dir = base.parent().unwrap_or_else(|| Path::new("."));
+        let base_name = base
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_else(|| panic!("non-UTF8 base name from {}", toc.display()));
+
+        let ci_path = dir.join(format!("{base_name}-CompressionInfo.db"));
+        let data_path = dir.join(format!("{base_name}-Data.db"));
+
+        // Track Data.db presence independently of CompressionInfo.db so a partial
+        // fetch is detectable even for fixtures whose CompressionInfo.db is missing.
+        if data_path.exists() {
+            any_data_db_on_disk = true;
+        }
+
+        // Local-only binaries: skip THIS fixture on absence (never on parse failure).
+        if !ci_path.exists() {
+            skipped_absent += 1;
+            continue;
+        }
+        any_ci_present = true;
+
+        let ci_bytes = std::fs::read(&ci_path)
+            .unwrap_or_else(|e| panic!("read {} failed: {e}", ci_path.display()));
+
+        // (1) CQLite decode.
+        let info = CompressionInfo::parse(&ci_bytes).unwrap_or_else(|e| {
+            panic!(
+                "{}: CQLite failed to parse CompressionInfo.db: {e:?}",
+                ci_path.display()
+            )
+        });
+
+        // (2) Independent re-derivation from the raw bytes (the cross-check).
+        let raw = read_raw_compression_info(&ci_bytes).unwrap_or_else(|e| {
+            panic!(
+                "{}: independent re-derivation of CompressionInfo.db failed: {e}",
+                ci_path.display()
+            )
+        });
+
+        // Compressor name + options come from the bytes (no path heuristic).
+        assert_eq!(
+            info.algorithm,
+            raw.algorithm,
+            "{}: compressor name mismatch (cqlite {:?} vs raw {:?})",
+            ci_path.display(),
+            info.algorithm,
+            raw.algorithm,
+        );
+        assert_eq!(
+            info.option_pairs,
+            raw.options,
+            "{}: option key/value pairs mismatch (cqlite {:?} vs raw {:?})",
+            ci_path.display(),
+            info.option_pairs,
+            raw.options,
+        );
+        assert_eq!(
+            info.chunk_length,
+            raw.chunk_length,
+            "{}: chunk_length mismatch (cqlite {} vs raw {})",
+            ci_path.display(),
+            info.chunk_length,
+            raw.chunk_length,
+        );
+        assert_eq!(
+            info.max_compressed_length,
+            raw.max_compressed_length,
+            "{}: max_compressed_length mismatch (cqlite {} vs raw {})",
+            ci_path.display(),
+            info.max_compressed_length,
+            raw.max_compressed_length,
+        );
+        assert_eq!(
+            info.data_length,
+            raw.data_length,
+            "{}: uncompressed data_length mismatch (cqlite {} vs raw {})",
+            ci_path.display(),
+            info.data_length,
+            raw.data_length,
+        );
+        // Ordered offset vector — not just the count. Catches any reordering bug.
+        assert_eq!(
+            info.chunk_offsets,
+            raw.chunk_offsets,
+            "{}: chunk-offset table mismatch (ordered) (cqlite len {} vs raw len {})",
+            ci_path.display(),
+            info.chunk_offsets.len(),
+            raw.chunk_offsets.len(),
+        );
+
+        // No trailing metadata CRC: the file ends exactly after the offset table.
+        assert_eq!(
+            raw.consumed,
+            ci_bytes.len(),
+            "{}: CompressionInfo.db has {} trailing byte(s) after the offset table — Cassandra \
+             appends no metadata CRC here (per-chunk CRCs are inline in Data.db)",
+            ci_path.display(),
+            ci_bytes.len() - raw.consumed,
+        );
+
+        // Offsets strictly ascending and starting at 0 (Cassandra's first chunk).
+        assert_eq!(
+            info.chunk_offsets.first().copied(),
+            Some(0),
+            "{}: first chunk offset must be 0, got {:?}",
+            ci_path.display(),
+            info.chunk_offsets.first(),
+        );
+        for w in info.chunk_offsets.windows(2) {
+            assert!(
+                w[1] > w[0],
+                "{}: chunk offsets not strictly ascending: {} <= {}",
+                ci_path.display(),
+                w[1],
+                w[0],
+            );
+        }
+
+        // Codec bookkeeping (authoritative — from parsed bytes).
+        match info.algorithm.as_str() {
+            "LZ4Compressor" => codec_present_lz4 = true,
+            "SnappyCompressor" => codec_present_snappy = true,
+            other if CODECS_WITHOUT_FIXTURE.contains(&other) => {
+                // A real Deflate/Zstd fixture would be a corpus addition; if one
+                // ever appears, exercise it rather than ignoring it.
+            }
+            other => panic!(
+                "{}: unexpected compressor {:?} — corpus changed; extend the test's codec coverage",
+                ci_path.display(),
+                other
+            ),
+        }
+        if !info.option_pairs.is_empty() {
+            saw_options = true;
+        }
+        if info.chunk_offsets.len() > 1 {
+            saw_multi_chunk = true;
+        }
+
+        // (3) Data.db chunk-boundary + inline-CRC parity. Data.db is local-only;
+        // skip the chunk pass for this fixture on absence (still counts the
+        // metadata comparison above).
+        if data_path.exists() {
+            any_data_present = true;
+            let data_bytes = std::fs::read(&data_path)
+                .unwrap_or_else(|e| panic!("read {} failed: {e}", data_path.display()));
+            crc_validated_chunks +=
+                validate_data_db_chunks(&info, &data_bytes, &data_path).chunks_validated;
+            match info.algorithm.as_str() {
+                "LZ4Compressor" => saw_lz4 = true,
+                "SnappyCompressor" => saw_snappy = true,
+                _ => {}
+            }
+        }
+
+        compared += 1;
+    }
+
+    eprintln!(
+        "compression_info_strict_metadata_and_chunk_parity: {compared} CompressionInfo.db \
+         compared ({skipped_absent} skipped — binary absent), {crc_validated_chunks} compressed \
+         chunks CRC-validated | codec_present lz4={codec_present_lz4} snappy={codec_present_snappy} \
+         | data_present={any_data_present}"
+    );
+
+    // Deflate / Zstd: explicit "no fixture available" classification (never faked).
+    for codec in CODECS_WITHOUT_FIXTURE {
+        eprintln!(
+            "compression_info_strict_metadata_and_chunk_parity: {codec} — no fixture available \
+             in the corpus (only LZ4Compressor and SnappyCompressor fixtures exist); classified \
+             as no-fixture, not faked with synthetic reference data (issue #986)"
+        );
+    }
+
+    // Partial/broken fetch guard: if Data.db binaries are present but NOT a single
+    // CompressionInfo.db is, the dataset is inconsistent (every compressed table
+    // emits a CompressionInfo.db). Fail rather than skip green.
+    if !any_ci_present && any_data_db_on_disk {
+        panic!(
+            "CompressionInfo.db binaries are absent but Data.db binaries ARE present — \
+             partial/broken dataset fetch. Compressed fixtures require CompressionInfo.db; \
+             re-fetch with bash test-data/scripts/fetch-datasets.sh (issue #986)."
+        );
+    }
+
+    // Skip-on-total-absence: a fresh checkout has the committed TOC.txt references
+    // but no fetched binaries to compare. Nothing to assert -> skip (not red).
+    if !any_ci_present {
+        debug_assert_eq!(
+            skipped_absent,
+            compressed_tocs.len(),
+            "internal: no CompressionInfo.db present implies every compressed fixture was skipped"
+        );
+        eprintln!(
+            "compression_info_strict_metadata_and_chunk_parity: SKIP — no *-CompressionInfo.db \
+             binaries fetched ({} compressed TOC references present without binaries; fetch with \
+             bash test-data/scripts/fetch-datasets.sh)",
+            compressed_tocs.len(),
+        );
+        return;
+    }
+
+    // Binaries ARE present: the lane must have compared something and must have
+    // exercised every codec the local corpus actually contains.
+    assert!(
+        compared > 0,
+        "CompressionInfo.db binaries are present but zero fixtures were compared — strict \
+         compression parity proved nothing"
+    );
+    // Metadata parity for LZ4 is proven by the comparison above; chunk-CRC parity
+    // additionally requires Data.db (asserted below only when Data.db present).
+    assert!(
+        codec_present_lz4,
+        "no LZ4Compressor CompressionInfo.db was compared despite present binaries — LZ4 metadata \
+         parity unproven (the corpus contains LZ4 fixtures)"
+    );
+    assert!(
+        codec_present_snappy,
+        "no SnappyCompressor CompressionInfo.db was compared despite present binaries — Snappy \
+         metadata parity unproven (the corpus contains Snappy fixtures)"
+    );
+    assert!(
+        saw_multi_chunk,
+        "no multi-chunk CompressionInfo.db was compared — final partial-chunk / chunk-boundary \
+         handling unproven (the corpus contains multi-chunk fixtures)"
+    );
+
+    // When Data.db is also present, the inline-CRC chunk gate must actually have run
+    // for both real codecs (proves the per-chunk CRC trailer parity, not just metadata).
+    if any_data_present {
+        assert!(
+            crc_validated_chunks > 0,
+            "Data.db binaries are present but zero compressed chunks were CRC-validated — \
+             inline-CRC chunk parity proved nothing"
+        );
+        assert!(
+            saw_lz4,
+            "no LZ4 Data.db chunks were CRC-validated despite present Data.db — LZ4 inline-CRC \
+             parity unproven"
+        );
+        assert!(
+            saw_snappy,
+            "no Snappy Data.db chunks were CRC-validated despite present Data.db — Snappy \
+             inline-CRC parity unproven"
+        );
+    }
+
+    // The committed corpus carries fixtures with compression options on some tables;
+    // if none were seen the option-pair decode path went unexercised. This is a soft
+    // coverage note (some corpora use all-default options), so log rather than fail.
+    if !saw_options {
+        eprintln!(
+            "compression_info_strict_metadata_and_chunk_parity: note — no fixture carried \
+             compression option pairs (all default options); option-pair decode covered by unit \
+             tests in compression_info.rs"
+        );
+    }
+}
+
+/// Result of validating every compressed chunk record in a `Data.db`.
+struct ChunkValidation {
+    chunks_validated: usize,
+}
+
+/// Walk every compressed chunk record in `Data.db` using the offset table, verify
+/// the record fits within the file (final record runs to EOF — the partial chunk),
+/// and recompute + compare the trailing 4-byte big-endian inline CRC32 over the
+/// compressed payload. Fails closed on truncation, offset inconsistency, or CRC
+/// mismatch. Mirrors `CompressedSequentialWriter.java` (payload + 4-byte CRC).
+fn validate_data_db_chunks(
+    info: &CompressionInfo,
+    data: &[u8],
+    data_path: &Path,
+) -> ChunkValidation {
+    let file_len = data.len() as u64;
+    let n = info.chunk_offsets.len();
+    let mut validated = 0usize;
+
+    for i in 0..n {
+        let start = info.chunk_offsets[i];
+        // Record end is the next offset, or EOF for the final (partial) chunk.
+        let end = if i + 1 < n {
+            info.chunk_offsets[i + 1]
+        } else {
+            file_len
+        };
+        assert!(
+            end > start,
+            "{}: chunk {i} record end {end} <= start {start} — offset inconsistency",
+            data_path.display(),
+        );
+        let record_size = end - start;
+        assert!(
+            record_size >= 4,
+            "{}: chunk {i} record size {record_size} < 4 — too small to hold the inline CRC \
+             trailer (truncation)",
+            data_path.display(),
+        );
+        assert!(
+            end <= file_len,
+            "{}: chunk {i} record end {end} past Data.db EOF {file_len} — truncation / offset \
+             inconsistency",
+            data_path.display(),
+        );
+
+        let start = start as usize;
+        let end = end as usize;
+        let payload = &data[start..end - 4];
+        let crc_bytes = [data[end - 4], data[end - 3], data[end - 2], data[end - 1]];
+        let stored_crc = u32::from_be_bytes(crc_bytes);
+        let computed_crc = crc32fast::hash(payload);
+        assert_eq!(
+            stored_crc,
+            computed_crc,
+            "{}: chunk {i} inline CRC32 mismatch at record [0x{:x}..0x{:x}): stored=0x{:08x} \
+             computed=0x{:08x} (payload {} bytes) — corrupt or truncated compressed chunk",
+            data_path.display(),
+            start,
+            end,
+            stored_crc,
+            computed_crc,
+            payload.len(),
+        );
+        validated += 1;
+    }
+
+    ChunkValidation {
+        chunks_validated: validated,
+    }
+}
+
+/// Structurally-invalid `CompressionInfo.db` and corrupted compressed-chunk
+/// fixtures fail closed in strict mode — never silently accepted. Uses fetched
+/// binaries as the clean baseline (skips when none is fetched), then mutates copies
+/// in memory.
+///
+/// Scope note: this lane asserts that *truncation* and *length-prefix corruption*
+/// are rejected (cases a–c) and that chunk-payload / CRC corruption is rejected
+/// (cases d–f). It does NOT assert rejection of bytes appended *after* a
+/// structurally complete record: `CompressionInfo::parse` does not verify EOF, so
+/// trailing garbage is tolerated (and ignored). Case (c2) documents that tolerant
+/// behavior explicitly. Making parse reject trailing bytes is a production behavior
+/// change deferred to a separate issue.
+#[test]
+fn compression_info_strict_corruption_fails_closed() {
+    let tocs = all_toc_files();
+
+    // Find a fetched CompressionInfo.db (+ its Data.db when present) to corrupt.
+    let mut ci_path: Option<PathBuf> = None;
+    let mut data_path: Option<PathBuf> = None;
+    for toc in &tocs {
+        if !toc_lists_compression_info(toc) {
+            continue;
+        }
+        let base = base_from_toc(toc);
+        let dir = base.parent().unwrap_or_else(|| Path::new("."));
+        let base_name = match base.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n,
+            None => continue,
+        };
+        let ci = dir.join(format!("{base_name}-CompressionInfo.db"));
+        if ci.exists() {
+            let dd = dir.join(format!("{base_name}-Data.db"));
+            ci_path = Some(ci);
+            if dd.exists() {
+                data_path = Some(dd);
+            }
+            // Prefer a fixture that also has Data.db so the chunk-corruption case runs.
+            if data_path.is_some() {
+                break;
+            }
+        }
+    }
+
+    let Some(ci_path) = ci_path else {
+        eprintln!(
+            "compression_info_strict_corruption_fails_closed: SKIP — no *-CompressionInfo.db \
+             binary fetched"
+        );
+        return;
+    };
+
+    let clean_ci = std::fs::read(&ci_path)
+        .unwrap_or_else(|e| panic!("read {} failed: {e}", ci_path.display()));
+
+    // Baseline: the clean fixture parses.
+    let info = CompressionInfo::parse(&clean_ci)
+        .unwrap_or_else(|e| panic!("clean {} should parse: {e:?}", ci_path.display()));
+
+    // (a) Corrupt the compressor-name length prefix (bytes 0..2) to an absurd value
+    //     -> UTF read overruns the buffer -> parse rejects it.
+    {
+        let mut corrupt = clean_ci.clone();
+        corrupt[0] = 0x7f;
+        corrupt[1] = 0xff;
+        assert!(
+            CompressionInfo::parse(&corrupt).is_err(),
+            "parse accepted a CompressionInfo.db with a corrupted compressor-name length — must \
+             fail closed"
+        );
+    }
+
+    // (b) Truncate below the fixed header -> parse rejects it.
+    {
+        let truncated = &clean_ci[..clean_ci.len().min(6)];
+        assert!(
+            CompressionInfo::parse(truncated).is_err(),
+            "parse accepted a truncated CompressionInfo.db (no chunk table) — must fail closed"
+        );
+    }
+
+    // (c) Drop the last 8 bytes (one chunk offset) while leaving chunk_count
+    //     unchanged -> the final offset read overruns -> parse rejects it.
+    if clean_ci.len() > 8 {
+        let truncated = &clean_ci[..clean_ci.len() - 8];
+        assert!(
+            CompressionInfo::parse(truncated).is_err(),
+            "parse accepted a CompressionInfo.db missing a declared chunk offset — must fail closed"
+        );
+    }
+
+    // (c2) Trailing garbage appended after a structurally complete record.
+    //      Cassandra never writes trailing bytes after the chunk-offset table, so
+    //      `CompressionInfo::parse` does NOT verify EOF: it reads exactly the
+    //      declared fixed header + option pairs + chunk-offset table and ignores
+    //      anything after it. This case documents that tolerant behavior explicitly
+    //      (parse still succeeds and yields the same metadata) rather than asserting
+    //      a rejection the parser does not perform. Tightening parse to reject
+    //      trailing bytes would be a production behavior change and is deferred to a
+    //      separate issue — it is intentionally NOT covered by this strict-fail-closed
+    //      lane.
+    {
+        let mut with_trailer = clean_ci.clone();
+        with_trailer.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+        let reparsed = CompressionInfo::parse(&with_trailer).unwrap_or_else(|e| {
+            panic!(
+                "parse rejected valid CompressionInfo.db with appended trailing bytes; \
+                 the parser does not (and is not asserted to) verify EOF: {e:?}"
+            )
+        });
+        assert_eq!(
+            reparsed.chunk_offsets, info.chunk_offsets,
+            "appended trailing bytes changed the decoded chunk-offset table — trailing data must \
+             be ignored, never misinterpreted as chunk metadata"
+        );
+        assert_eq!(
+            reparsed.option_pairs, info.option_pairs,
+            "appended trailing bytes changed the decoded compression options"
+        );
+    }
+
+    // Chunk-level corruption requires a fetched Data.db.
+    let Some(data_path) = data_path else {
+        eprintln!(
+            "compression_info_strict_corruption_fails_closed: CompressionInfo.db corruption \
+             rejected against {} (Data.db absent — chunk-corruption case skipped)",
+            ci_path.display()
+        );
+        return;
+    };
+
+    let clean_data = std::fs::read(&data_path)
+        .unwrap_or_else(|e| panic!("read {} failed: {e}", data_path.display()));
+
+    // Sanity: the clean Data.db passes the strict chunk-CRC gate.
+    let baseline = validate_data_db_chunks(&info, &clean_data, &data_path);
+    assert!(
+        baseline.chunks_validated > 0,
+        "{}: clean Data.db validated zero chunks — corruption baseline is meaningless",
+        data_path.display()
+    );
+
+    // (d) Flip a byte inside the first compressed chunk's payload -> inline CRC must
+    //     reject it (the stored CRC no longer matches the recomputed CRC).
+    {
+        let mut corrupt = clean_data.clone();
+        let first_payload_byte = info.chunk_offsets.first().copied().unwrap_or(0) as usize;
+        assert!(
+            first_payload_byte < corrupt.len(),
+            "{}: first chunk offset past EOF — cannot corrupt",
+            data_path.display()
+        );
+        corrupt[first_payload_byte] ^= 0xff;
+        let result = std::panic::catch_unwind(|| {
+            validate_data_db_chunks(&info, &corrupt, Path::new("corrupt-payload"))
+        });
+        assert!(
+            result.is_err(),
+            "strict chunk gate accepted a Data.db with a corrupted compressed-chunk payload — \
+             must fail closed on CRC mismatch"
+        );
+    }
+
+    // (e) Flip a byte inside the first chunk's inline CRC trailer -> reject it.
+    {
+        let mut corrupt = clean_data.clone();
+        // End of the first chunk record = second offset, or EOF for a single chunk.
+        let first_end = if info.chunk_offsets.len() > 1 {
+            info.chunk_offsets[1] as usize
+        } else {
+            corrupt.len()
+        };
+        assert!(
+            first_end >= 4 && first_end <= corrupt.len(),
+            "{}: cannot locate first chunk CRC trailer",
+            data_path.display()
+        );
+        corrupt[first_end - 1] ^= 0xff; // last byte of the 4-byte CRC
+        let result = std::panic::catch_unwind(|| {
+            validate_data_db_chunks(&info, &corrupt, Path::new("corrupt-crc"))
+        });
+        assert!(
+            result.is_err(),
+            "strict chunk gate accepted a Data.db with a corrupted inline CRC trailer — must fail \
+             closed"
+        );
+    }
+
+    // (f) Truncate the final record below its 4-byte CRC trailer -> reject it.
+    {
+        let last_start = *info.chunk_offsets.last().unwrap_or(&0) as usize;
+        // Cut to 3 bytes past the last record start so the final record < 4 bytes.
+        let cut = (last_start + 3).min(clean_data.len());
+        if cut > last_start && cut < clean_data.len() {
+            let truncated = &clean_data[..cut];
+            let result = std::panic::catch_unwind(|| {
+                validate_data_db_chunks(&info, truncated, Path::new("truncated-data"))
+            });
+            assert!(
+                result.is_err(),
+                "strict chunk gate accepted a Data.db whose final record is truncated below its \
+                 inline CRC trailer — must fail closed"
+            );
+        }
+    }
+
+    eprintln!(
+        "compression_info_strict_corruption_fails_closed: CompressionInfo.db + chunk corruption \
+         rejected against {} / {}",
+        ci_path.display(),
+        data_path.display()
+    );
+}

--- a/cqlite-core/tests/sstable_parity_filter_db_test.rs
+++ b/cqlite-core/tests/sstable_parity_filter_db_test.rs
@@ -1,0 +1,745 @@
+//! Strict `Filter.db` Bloom-filter parity (Epic #968 / issue #987).
+//!
+//! Proves that CQLite decodes the on-disk Cassandra 5.0 `Filter.db` Bloom filter
+//! and reproduces its membership semantics exactly, with the core correctness gate
+//! being **no false negatives**: every partition key Cassandra actually wrote into
+//! an SSTable must be reported "maybe present" by the filter CQLite decoded.
+//!
+//! Scope owned here (issue #987):
+//!   * **Decoded-parameter parity** — the Cassandra `Filter.db` on-disk layout is
+//!     `[hash_count: i32 BE][num_longs: i32 BE][bitset: num_longs * 8 bytes]`
+//!     (`BloomFilterSerializer` over an `OffHeapBitSet`). For every fixture the raw
+//!     header bytes are re-read independently and asserted to match the parameters
+//!     `BloomFilter::deserialize` recovers (hash count, bitset word/bit length).
+//!   * **No-false-negative membership (the correctness gate)** — for every fixture
+//!     whose raw partition keys are enumerable (BIG `Index.db`), every key is
+//!     probed and the filter MUST report "maybe present". A single false negative
+//!     fails the lane.
+//!   * **Absent-key false-positive reporting** — deterministically-generated keys
+//!     known NOT to be in the SSTable are probed; false positives are *counted and
+//!     reported*, never treated as correctness failures (a Bloom filter is allowed
+//!     false positives by definition).
+//!   * **Serialization round-trip byte-exactness** — `deserialize` then `serialize`
+//!     must reproduce the exact on-disk Filter.db bytes (header + bitset).
+//!   * **Strict corruption / malformed-byte rejection** — truncated headers,
+//!     declared-but-missing bitset bytes, and zero-length buffers must fail closed
+//!     (no fabricated filter, no panic-on-unwrap).
+//!   * **BIG vs BTI coverage classification** — BIG fixtures carry `Index.db`, the
+//!     authoritative raw-key source, so they drive the no-false-negative gate. BTI
+//!     (`da`) fixtures have no `Index.db`; the trie's byte-comparable, hash-routed
+//!     `Partitions.db` does not expose the raw partition-key bytes the Bloom filter
+//!     hashed, so BTI fixtures are covered for *parameter decode + round-trip* only
+//!     and the membership gap is classified explicitly (not faked).
+//!
+//! Fail-closed contract (matches the established dataset convention, see
+//! `sstable_parity_toc_component_test.rs`):
+//!   * `Filter.db` binaries are local-only (gitignored, fetched on demand). When
+//!     the dataset is entirely absent (0 `Data.db` anywhere), the lane SKIPS
+//!     cleanly. When binaries ARE present, the lane FAILS if zero filters were
+//!     compared, or if a present storage format (BIG/BTI) was left uncovered.
+//!   * Data.db presence is tracked INDEPENDENTLY of the compare count so a green
+//!     run that silently compared nothing is impossible when fixtures exist.
+//!
+//! Why the slow statistical FPR check is gated:
+//!   * The empirical false-positive-rate check probes a large deterministic
+//!     absent-key sample. It is correctness-irrelevant (false positives are legal)
+//!     and slow, so it is gated behind `CQLITE_FILTER_FPR_SLOW=1` to keep the
+//!     required lane fast — identical pattern to the project's other slow lanes.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use cqlite_core::platform::Platform;
+use cqlite_core::storage::sstable::bloom::BloomFilter;
+use cqlite_core::storage::sstable::index_reader::IndexReader;
+use cqlite_core::storage::sstable::version_gate::{SsTableDescriptor, SsTableFormat};
+use cqlite_core::Config;
+
+/// Resolve the committed datasets root (env override first, else workspace tree).
+fn datasets_sstables_root() -> PathBuf {
+    let root = if let Ok(root) = std::env::var("CQLITE_DATASETS_ROOT") {
+        PathBuf::from(root)
+    } else {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .map(|workspace| workspace.join("test-data/datasets"))
+            .unwrap_or_else(|| PathBuf::from("test-data/datasets"))
+    };
+    root.join("sstables")
+}
+
+/// Recursively collect every `*-Filter.db` binary under `dir`, skipping macOS
+/// AppleDouble shadow files (`._*`).
+fn collect_filter_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with("._") {
+            continue;
+        }
+        if path.is_dir() {
+            collect_filter_files(&path, out);
+        } else if name.ends_with("-Filter.db") {
+            out.push(path);
+        }
+    }
+}
+
+/// All committed `*-Filter.db` binaries, sorted. Unlike the TOC/Statistics
+/// reference text files, the binary `Filter.db` is local-only: an empty set means
+/// the dataset was not fetched, which is a clean skip (handled by the callers),
+/// NOT a fail-closed condition here.
+fn all_filter_files() -> Vec<PathBuf> {
+    let root = datasets_sstables_root();
+    let mut out = Vec::new();
+    collect_filter_files(&root, &mut out);
+    out.sort();
+    out
+}
+
+/// Whether ANY `Data.db` binary exists under the dataset root — the independent
+/// "dataset present" signal. Tracked separately from the filter-compare count so
+/// a run that has binaries on disk but silently compared nothing fails closed
+/// instead of masquerading as a clean skip.
+fn any_data_db_present(dir: &Path) -> bool {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with("._") {
+            continue;
+        }
+        if path.is_dir() {
+            if any_data_db_present(&path) {
+                return true;
+            }
+        } else if name.ends_with("-Data.db") {
+            return true;
+        }
+    }
+    false
+}
+
+/// Authoritative storage format for a fixture, parsed from the filename's
+/// `<format>` segment (`big`/`bti`) — never inferred from the directory path.
+fn format_for(filter_path: &Path) -> SsTableFormat {
+    let name = filter_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or_else(|| panic!("non-UTF8 Filter.db name: {}", filter_path.display()));
+    SsTableDescriptor::parse_filename(name)
+        .unwrap_or_else(|e| panic!("{}: descriptor parse failed: {e}", filter_path.display()))
+        .format
+}
+
+/// Re-read the Cassandra `Filter.db` header straight from the raw bytes,
+/// independent of CQLite's decoder, returning `(hash_count, num_longs)`.
+///
+/// On-disk layout (`BloomFilterSerializer` + `OffHeapBitSet`):
+///   `[hash_count: i32 BE][num_longs: i32 BE][bitset: num_longs * 8 bytes]`
+fn read_raw_header(bytes: &[u8], path: &Path) -> (u32, u32) {
+    assert!(
+        bytes.len() >= 8,
+        "{}: Filter.db too small ({} bytes) for the 8-byte Bloom header",
+        path.display(),
+        bytes.len(),
+    );
+    let hash_count = u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+    let num_longs = u32::from_be_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
+    (hash_count, num_longs)
+}
+
+/// Per-fixture outcome of decoding + validating a `Filter.db`. `present_keys` and
+/// `false_negatives` are only meaningful for fixtures whose raw keys are
+/// enumerable (BIG); BTI fixtures record `keys_enumerable = false`.
+struct FilterOutcome {
+    format: SsTableFormat,
+    hash_count: u32,
+    num_longs: u32,
+    keys_enumerable: bool,
+    present_keys: usize,
+    false_negatives: usize,
+    absent_probes: usize,
+    false_positives: usize,
+}
+
+/// Decode the on-disk header, validate it against CQLite's decoder, and assert a
+/// byte-exact serialize round-trip. Shared by every membership / parameter test.
+fn decode_and_validate(bytes: &[u8], path: &Path, format: SsTableFormat) -> BloomFilter {
+    // (1) Raw header parity: CQLite's decoded parameters must equal the bytes.
+    let (raw_hash_count, raw_num_longs) = read_raw_header(bytes, path);
+    assert!(
+        raw_hash_count > 0,
+        "{}: Filter.db declares hash_count=0 — Cassandra always writes >= 1",
+        path.display(),
+    );
+    assert!(
+        raw_num_longs > 0,
+        "{}: Filter.db declares num_longs=0 — Cassandra always writes >= 1",
+        path.display(),
+    );
+    let expected_len = 8 + (raw_num_longs as usize) * 8;
+    assert_eq!(
+        bytes.len(),
+        expected_len,
+        "{}: Filter.db length {} != header-implied {} (8 + num_longs*8) — truncated/corrupt",
+        path.display(),
+        bytes.len(),
+        expected_len,
+    );
+
+    let bloom = BloomFilter::deserialize(bytes).unwrap_or_else(|e| {
+        panic!(
+            "{}: CQLite failed to decode Cassandra Filter.db ({format:?}): {e:?}",
+            path.display()
+        )
+    });
+    assert_eq!(
+        bloom.hash_count(),
+        raw_hash_count,
+        "{}: decoded hash_count {} != on-disk {}",
+        path.display(),
+        bloom.hash_count(),
+        raw_hash_count,
+    );
+    assert_eq!(
+        bloom.bit_count(),
+        (raw_num_longs as u64) * 64,
+        "{}: decoded bit_count {} != on-disk num_longs*64 ({})",
+        path.display(),
+        bloom.bit_count(),
+        (raw_num_longs as u64) * 64,
+    );
+
+    // (2) Serialization round-trip: re-emit and assert byte-exact preservation.
+    let reemitted = bloom
+        .serialize()
+        .unwrap_or_else(|e| panic!("{}: re-serialize failed: {e:?}", path.display()));
+    assert_eq!(
+        reemitted,
+        bytes,
+        "{}: Filter.db serialize round-trip is not byte-exact ({} vs {} bytes)",
+        path.display(),
+        reemitted.len(),
+        bytes.len(),
+    );
+
+    bloom
+}
+
+/// Deterministically generate `count` absent-key probes for a fixture, salted by
+/// the fixture path so two fixtures never share a probe set, and seeded by `seed`
+/// for reproducibility. These are byte strings that, by construction (the
+/// `__cqlite_absent__` prefix never appears in a real partition key), are not
+/// members of the SSTable — used to *measure* (never gate) false positives.
+fn absent_key_probes(path: &Path, seed: u64, count: usize) -> Vec<Vec<u8>> {
+    let salt = path.to_string_lossy();
+    (0..count)
+        .map(|i| {
+            // Splitmix64 for a deterministic, well-mixed pseudo-random tail.
+            let mut z = seed
+                .wrapping_add(i as u64)
+                .wrapping_mul(0x9e37_79b9_7f4a_7c15);
+            z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+            z ^= z >> 31;
+            let mut key = format!("__cqlite_absent__{salt}#{i}#").into_bytes();
+            key.extend_from_slice(&z.to_le_bytes());
+            key
+        })
+        .collect()
+}
+
+/// Strict, byte-and-field `Filter.db` parameter parity + serialization round-trip
+/// across every committed fixture (BIG and BTI), plus the no-false-negative
+/// membership gate for every fixture whose raw partition keys are enumerable.
+#[tokio::test]
+async fn filter_db_strict_parameters_and_no_false_negative() {
+    let root = datasets_sstables_root();
+    let filters = all_filter_files();
+    let data_present = any_data_db_present(&root);
+
+    // Skip-on-total-absence: no binaries fetched at all. The committed corpus has
+    // no text reference for Filter.db (it is a pure binary component), so an empty
+    // dataset is a clean skip, not a fail-closed condition.
+    if filters.is_empty() && !data_present {
+        eprintln!(
+            "filter_db_strict_parameters_and_no_false_negative: SKIP — no Filter.db / Data.db \
+             binaries fetched under {} (run bash test-data/scripts/fetch-datasets.sh)",
+            root.display()
+        );
+        return;
+    }
+
+    let config = Config::default();
+    let platform = Arc::new(
+        Platform::new(&config)
+            .await
+            .unwrap_or_else(|e| panic!("Platform init failed: {e:?}")),
+    );
+
+    let mut outcomes: Vec<(PathBuf, FilterOutcome)> = Vec::new();
+
+    let mut present_big = false;
+    let mut present_bti = false;
+
+    for filter in &filters {
+        let format = format_for(filter);
+        match format {
+            SsTableFormat::Big => present_big = true,
+            SsTableFormat::Bti => present_bti = true,
+        }
+
+        let bytes = std::fs::read(filter)
+            .unwrap_or_else(|e| panic!("read {} failed: {e}", filter.display()));
+
+        let bloom = decode_and_validate(&bytes, filter, format);
+        let (hash_count, num_longs) = read_raw_header(&bytes, filter);
+
+        // Enumerate raw partition keys when an Index.db sibling exists (BIG).
+        let name = filter
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_else(|| panic!("non-UTF8 Filter.db name: {}", filter.display()));
+        let base = name
+            .strip_suffix("-Filter.db")
+            .unwrap_or_else(|| panic!("Filter.db name without suffix: {name}"));
+        let index_path = filter.with_file_name(format!("{base}-Index.db"));
+
+        let mut present_keys = 0usize;
+        let mut false_negatives = 0usize;
+        let mut absent_probes = 0usize;
+        let mut false_positives = 0usize;
+        let keys_enumerable = index_path.exists();
+
+        if keys_enumerable {
+            let reader = IndexReader::open(&index_path, platform.clone())
+                .await
+                .unwrap_or_else(|e| panic!("open {} failed: {e:?}", index_path.display()));
+
+            // NO-FALSE-NEGATIVE GATE: every key Cassandra wrote MUST be reported
+            // "maybe present". The Index.db `key_digest` holds the RAW partition-key
+            // bytes (Issue #552) — exactly what Cassandra hashed into Filter.db —
+            // so this is the authoritative present-key set (no path heuristics).
+            for entry in reader.get_partition_entries() {
+                present_keys += 1;
+                if !bloom.contains(&entry.key_digest) {
+                    false_negatives += 1;
+                    eprintln!(
+                        "FALSE NEGATIVE in {} for present key (len={})",
+                        filter.display(),
+                        entry.key_digest.len()
+                    );
+                }
+            }
+            assert_eq!(
+                false_negatives,
+                0,
+                "{}: Bloom filter produced {} false negative(s) over {} present partition keys \
+                 — Filter.db membership is broken (a present key was reported absent)",
+                filter.display(),
+                false_negatives,
+                present_keys,
+            );
+            assert!(
+                present_keys > 0,
+                "{}: Index.db present but yielded zero partition keys — cannot prove \
+                 no-false-negative membership for this fixture",
+                filter.display(),
+            );
+
+            // Absent-key probes: REPORT false positives, never gate on them. Use a
+            // probe count comparable to the present-key set so the report is
+            // meaningful but the lane stays fast.
+            let probe_count = present_keys.max(64);
+            let probes = absent_key_probes(filter, 0x5151_5151_5151_5151, probe_count);
+            absent_probes = probes.len();
+            for probe in &probes {
+                if bloom.contains(probe) {
+                    false_positives += 1;
+                }
+            }
+        }
+
+        outcomes.push((
+            filter.clone(),
+            FilterOutcome {
+                format,
+                hash_count,
+                num_longs,
+                keys_enumerable,
+                present_keys,
+                false_negatives,
+                absent_probes,
+                false_positives,
+            },
+        ));
+    }
+
+    // Aggregate reporting.
+    let compared = outcomes.len();
+    let big_count = outcomes
+        .iter()
+        .filter(|(_, o)| o.format == SsTableFormat::Big)
+        .count();
+    let bti_count = outcomes
+        .iter()
+        .filter(|(_, o)| o.format == SsTableFormat::Bti)
+        .count();
+    let membership_fixtures = outcomes.iter().filter(|(_, o)| o.keys_enumerable).count();
+    let total_present_keys: usize = outcomes.iter().map(|(_, o)| o.present_keys).sum();
+    let total_false_neg: usize = outcomes.iter().map(|(_, o)| o.false_negatives).sum();
+    let total_absent_probes: usize = outcomes.iter().map(|(_, o)| o.absent_probes).sum();
+    let total_false_pos: usize = outcomes.iter().map(|(_, o)| o.false_positives).sum();
+
+    // Distinct decoded Bloom parameters across the corpus (hash_count, num_longs),
+    // reported so a parameter regression in any fixture is visible in the log.
+    let mut params: Vec<(u32, u32)> = outcomes
+        .iter()
+        .map(|(_, o)| (o.hash_count, o.num_longs))
+        .collect();
+    params.sort_unstable();
+    params.dedup();
+    eprintln!(
+        "filter_db_strict_parameters_and_no_false_negative: distinct (hash_count, num_longs) = {params:?}"
+    );
+
+    eprintln!(
+        "filter_db_strict_parameters_and_no_false_negative: compared={compared} \
+         (BIG={big_count} BTI={bti_count}) | membership-fixtures={membership_fixtures} \
+         present-keys-probed={total_present_keys} false-negatives={total_false_neg} \
+         | absent-probes={total_absent_probes} false-positives(reported,not-failures)={total_false_pos}"
+    );
+
+    // Coverage proof: a present format must actually have been compared, and the
+    // no-false-negative gate must have probed at least one real present key.
+    if data_present {
+        assert!(
+            compared > 0,
+            "Data.db binaries are present but zero Filter.db fixtures were compared — \
+             strict Filter.db parity proved nothing"
+        );
+        if present_big {
+            assert!(
+                big_count > 0,
+                "BIG Filter.db fixtures present but none compared — BIG parity unproven"
+            );
+            // BIG fixtures carry Index.db, so the no-false-negative gate must have run.
+            assert!(
+                membership_fixtures > 0 && total_present_keys > 0,
+                "BIG fixtures present but no partition keys were probed — \
+                 no-false-negative gate proved nothing"
+            );
+        }
+        if present_bti {
+            assert!(
+                bti_count > 0,
+                "BTI Filter.db fixtures present but none compared — BTI parameter parity unproven"
+            );
+        }
+    } else {
+        // Defensive: filters present without any Data.db is an inconsistent dataset.
+        assert!(
+            compared > 0,
+            "Filter.db binaries present without Data.db — inconsistent dataset, nothing compared"
+        );
+    }
+
+    // The total no-false-negative invariant (already asserted per-fixture; this is
+    // the aggregate restatement that makes the gate impossible to skip).
+    assert_eq!(
+        total_false_neg, 0,
+        "Filter.db lane observed {total_false_neg} total false negative(s) across \
+         {total_present_keys} present keys — membership correctness is broken"
+    );
+}
+
+/// Classify the storage-format coverage of the Filter.db corpus explicitly, so a
+/// missing format family (e.g. no BTI fixtures fetched) is a documented, visible
+/// fact rather than a silent gap. BIG drives the membership gate; BTI is covered
+/// for parameter-decode + round-trip only (its trie does not expose raw keys).
+#[tokio::test]
+async fn filter_db_format_coverage_classification() {
+    let root = datasets_sstables_root();
+    let filters = all_filter_files();
+    let data_present = any_data_db_present(&root);
+
+    if filters.is_empty() && !data_present {
+        eprintln!("filter_db_format_coverage_classification: SKIP — no Filter.db binaries fetched");
+        return;
+    }
+
+    let mut big_with_index = 0usize;
+    let mut big_without_index = 0usize;
+    let mut bti = 0usize;
+
+    for filter in &filters {
+        let format = format_for(filter);
+        let name = filter.file_name().and_then(|n| n.to_str()).unwrap_or("");
+        let base = name.strip_suffix("-Filter.db").unwrap_or(name);
+        let index_path = filter.with_file_name(format!("{base}-Index.db"));
+        match format {
+            SsTableFormat::Big if index_path.exists() => big_with_index += 1,
+            SsTableFormat::Big => big_without_index += 1,
+            SsTableFormat::Bti => bti += 1,
+        }
+    }
+
+    eprintln!(
+        "filter_db_format_coverage_classification: BIG-with-Index.db(membership-capable)={big_with_index} \
+         BIG-without-Index.db(parameter-only)={big_without_index} \
+         BTI(parameter-only,no-raw-keys)={bti}"
+    );
+
+    if data_present {
+        // The committed corpus is BIG-dominated with Index.db; at least the
+        // membership-capable family must exist when binaries are present.
+        assert!(
+            big_with_index > 0,
+            "Data.db present but no BIG fixture with an Index.db sibling found — \
+             the no-false-negative membership gate would never run"
+        );
+    }
+}
+
+/// Strict corruption / malformed-byte rejection: the decoder must fail closed on
+/// truncated headers, declared-but-missing bitset bytes, and zero-length buffers
+/// (never fabricate a filter, never panic-on-unwrap). Uses a real fixture as the
+/// clean baseline when present; otherwise exercises synthetic byte mutations so
+/// the negative contract is always tested.
+#[test]
+fn filter_db_strict_corruption_fails_closed() {
+    // Synthetic baseline: a valid header (hash_count=5, num_longs=1) + 8 bitset
+    // bytes. This always exercises the negative paths even with no dataset.
+    let mut clean = Vec::new();
+    clean.extend_from_slice(&5u32.to_be_bytes());
+    clean.extend_from_slice(&1u32.to_be_bytes());
+    clean.extend_from_slice(&[0xAB; 8]);
+    assert!(
+        BloomFilter::deserialize(&clean).is_ok(),
+        "clean synthetic Filter.db should decode"
+    );
+
+    // (a) Empty buffer → error (too short for the 8-byte header).
+    assert!(
+        BloomFilter::deserialize(&[]).is_err(),
+        "empty Filter.db buffer must be rejected"
+    );
+
+    // (b) Header-only truncation (claims a bitset that is not present).
+    let header_only = &clean[..8];
+    assert!(
+        BloomFilter::deserialize(header_only).is_err(),
+        "Filter.db with a header declaring num_longs=1 but zero bitset bytes must be rejected"
+    );
+
+    // (c) Partial bitset (declares 1 long = 8 bytes, only 4 present).
+    let partial = &clean[..12];
+    assert!(
+        BloomFilter::deserialize(partial).is_err(),
+        "Filter.db with a truncated bitset must be rejected (size mismatch)"
+    );
+
+    // (d) Trailing junk (declares 1 long but carries 9 bitset bytes).
+    let mut trailing = clean.clone();
+    trailing.push(0xFF);
+    assert!(
+        BloomFilter::deserialize(&trailing).is_err(),
+        "Filter.db with extra trailing bytes beyond the declared bitset must be rejected"
+    );
+
+    // (f) Length-consistent but degenerate header: hash_count=0. The buffer size
+    // is internally consistent (header + declared bitset), so the size check alone
+    // would accept it — but a filter with zero hash functions fails OPEN (always
+    // "not present"), producing false negatives. Strict mode must reject it.
+    let mut zero_hash = Vec::new();
+    zero_hash.extend_from_slice(&0u32.to_be_bytes()); // hash_count = 0
+    zero_hash.extend_from_slice(&1u32.to_be_bytes()); // num_longs = 1
+    zero_hash.extend_from_slice(&[0xAB; 8]);
+    let zero_hash_result = std::panic::catch_unwind(|| BloomFilter::deserialize(&zero_hash));
+    assert!(
+        matches!(zero_hash_result, Ok(Err(_))),
+        "Filter.db header with hash_count=0 must be rejected (Err, not Ok, not panic)"
+    );
+
+    // (g) Length-consistent but degenerate header: num_longs=0. Zero bit-words
+    // means a zero-capacity filter; the size check would accept an 8-byte buffer,
+    // but such a filter is malformed and must be rejected in strict mode.
+    let mut zero_longs = Vec::new();
+    zero_longs.extend_from_slice(&5u32.to_be_bytes()); // hash_count = 5
+    zero_longs.extend_from_slice(&0u32.to_be_bytes()); // num_longs = 0
+    let zero_longs_result = std::panic::catch_unwind(|| BloomFilter::deserialize(&zero_longs));
+    assert!(
+        matches!(zero_longs_result, Ok(Err(_))),
+        "Filter.db header with num_longs=0 must be rejected (Err, not Ok, not panic)"
+    );
+
+    // (h) High-bit-set hash_count: 0xFFFF_FFFF reads as i32 == -1. Parsing the
+    // field as u32 would treat it as ~4 billion hash functions, making contains()
+    // loop billions of times (DoS / pathological lookup). The header is otherwise
+    // length-consistent (num_longs=1 + 8 bitset bytes), so only the signed reject
+    // catches it. Must be rejected as Err with no panic and no pathological loop.
+    let mut neg_hash = Vec::new();
+    neg_hash.extend_from_slice(&0xFFFF_FFFFu32.to_be_bytes()); // hash_count = -1 (i32)
+    neg_hash.extend_from_slice(&1u32.to_be_bytes()); // num_longs = 1
+    neg_hash.extend_from_slice(&[0xAB; 8]);
+    let neg_hash_result = std::panic::catch_unwind(|| BloomFilter::deserialize(&neg_hash));
+    assert!(
+        matches!(neg_hash_result, Ok(Err(_))),
+        "Filter.db header with hash_count=0xFFFF_FFFF (-1 as i32) must be rejected (Err, not Ok, not panic)"
+    );
+
+    // (i) i32::MIN hash_count: 0x8000_0000 reads as i32 == -2147483648. As u32 this
+    // is ~2.1 billion hash functions. Length-consistent header; must be rejected.
+    let mut min_hash = Vec::new();
+    min_hash.extend_from_slice(&0x8000_0000u32.to_be_bytes()); // hash_count = i32::MIN
+    min_hash.extend_from_slice(&1u32.to_be_bytes()); // num_longs = 1
+    min_hash.extend_from_slice(&[0xAB; 8]);
+    let min_hash_result = std::panic::catch_unwind(|| BloomFilter::deserialize(&min_hash));
+    assert!(
+        matches!(min_hash_result, Ok(Err(_))),
+        "Filter.db header with hash_count=0x8000_0000 (i32::MIN) must be rejected (Err, not Ok, not panic)"
+    );
+
+    // (j) High-bit-set num_longs: 0xFFFF_FFFF reads as i32 == -1. As u32 cast to
+    // usize this would be a huge bit-word count and break size math (and could try
+    // to allocate enormous buffers). Must be rejected by the signed `<= 0` guard
+    // before any `as usize` widening. We keep hash_count valid to isolate the
+    // num_longs path.
+    let mut neg_longs = Vec::new();
+    neg_longs.extend_from_slice(&5u32.to_be_bytes()); // hash_count = 5
+    neg_longs.extend_from_slice(&0xFFFF_FFFFu32.to_be_bytes()); // num_longs = -1 (i32)
+    let neg_longs_result = std::panic::catch_unwind(|| BloomFilter::deserialize(&neg_longs));
+    assert!(
+        matches!(neg_longs_result, Ok(Err(_))),
+        "Filter.db header with num_longs=0xFFFF_FFFF (-1 as i32) must be rejected (Err, not Ok, not panic)"
+    );
+
+    // (k) i32::MIN num_longs: 0x8000_0000. Same hazard as (j); must be rejected.
+    let mut min_longs = Vec::new();
+    min_longs.extend_from_slice(&5u32.to_be_bytes()); // hash_count = 5
+    min_longs.extend_from_slice(&0x8000_0000u32.to_be_bytes()); // num_longs = i32::MIN
+    let min_longs_result = std::panic::catch_unwind(|| BloomFilter::deserialize(&min_longs));
+    assert!(
+        matches!(min_longs_result, Ok(Err(_))),
+        "Filter.db header with num_longs=0x8000_0000 (i32::MIN) must be rejected (Err, not Ok, not panic)"
+    );
+
+    // (l) Absurd-but-POSITIVE hash_count: 0x7FFF_FFFF (i32::MAX) passes the signed
+    // `<= 0` guard, yet would make every contains() loop ~2.1 billion times (DoS).
+    // The upper-bound guard must reject it. num_longs=1 keeps the header
+    // length-consistent so only the hash_count bound catches it.
+    let mut huge_hash = Vec::new();
+    huge_hash.extend_from_slice(&0x7FFF_FFFFu32.to_be_bytes()); // hash_count = i32::MAX
+    huge_hash.extend_from_slice(&1u32.to_be_bytes()); // num_longs = 1
+    huge_hash.extend_from_slice(&[0xAB; 8]);
+    let huge_hash_result = std::panic::catch_unwind(|| BloomFilter::deserialize(&huge_hash));
+    assert!(
+        matches!(huge_hash_result, Ok(Err(_))),
+        "Filter.db header with hash_count=0x7FFF_FFFF (i32::MAX) must be rejected (Err, not Ok, not panic)"
+    );
+
+    // (e) Real-fixture corruption when a binary is available: flip the declared
+    // num_longs to an absurd value so the size check rejects it.
+    if let Some(filter) = all_filter_files().into_iter().next() {
+        let bytes = std::fs::read(&filter)
+            .unwrap_or_else(|e| panic!("read {} failed: {e}", filter.display()));
+        // Sanity: the clean fixture decodes.
+        assert!(
+            BloomFilter::deserialize(&bytes).is_ok(),
+            "{}: clean fixture should decode",
+            filter.display()
+        );
+        let mut corrupt = bytes.clone();
+        // num_longs lives at bytes 4..8 (BE). Bump it so the declared bitset length
+        // no longer matches the actual buffer size.
+        corrupt[4] = 0x7F;
+        corrupt[5] = 0xFF;
+        assert!(
+            BloomFilter::deserialize(&corrupt).is_err(),
+            "{}: corrupted num_longs must be rejected by the size check",
+            filter.display()
+        );
+        eprintln!(
+            "filter_db_strict_corruption_fails_closed: corruption rejected against {}",
+            filter.display()
+        );
+    } else {
+        eprintln!(
+            "filter_db_strict_corruption_fails_closed: synthetic-only (no Filter.db binary fetched)"
+        );
+    }
+}
+
+/// Slow, deterministic empirical false-positive-rate report. NOT a correctness
+/// gate — false positives are legal for a Bloom filter — so it is gated behind
+/// `CQLITE_FILTER_FPR_SLOW=1` to keep the required lane fast. When enabled it
+/// probes a large deterministic absent-key sample per fixture and asserts only a
+/// generous sanity ceiling (the filter is not pathologically saturated): the
+/// measured FPR must stay well under 50%. The detailed per-fixture rate is
+/// reported for human inspection.
+#[tokio::test]
+async fn filter_db_statistical_false_positive_rate_slow() {
+    if std::env::var("CQLITE_FILTER_FPR_SLOW").ok().as_deref() != Some("1") {
+        eprintln!(
+            "filter_db_statistical_false_positive_rate_slow: SKIP — set CQLITE_FILTER_FPR_SLOW=1 \
+             to run the slow empirical FPR report (false positives are not correctness failures)"
+        );
+        return;
+    }
+
+    let filters = all_filter_files();
+    if filters.is_empty() {
+        eprintln!("filter_db_statistical_false_positive_rate_slow: SKIP — no Filter.db fetched");
+        return;
+    }
+
+    // Deterministic large absent-key sample. The same seed + per-fixture salt make
+    // the measured rate reproducible across runs and machines.
+    const SAMPLE: usize = 50_000;
+    const SEED: u64 = 0xC0FF_EE00_1234_5678;
+    // Generous sanity ceiling: a healthy Cassandra-sized filter for these small
+    // fixtures should be far below this. This only catches a pathologically broken
+    // (near-saturated) bitset, never a normal false-positive rate.
+    const FPR_CEILING: f64 = 0.50;
+
+    let mut reported = 0usize;
+    for filter in &filters {
+        let format = format_for(filter);
+        let bytes = std::fs::read(filter)
+            .unwrap_or_else(|e| panic!("read {} failed: {e}", filter.display()));
+        let bloom = decode_and_validate(&bytes, filter, format);
+
+        let probes = absent_key_probes(filter, SEED, SAMPLE);
+        let hits = probes.iter().filter(|p| bloom.contains(p)).count();
+        let rate = hits as f64 / SAMPLE as f64;
+        eprintln!(
+            "FPR {} ({:?}): hash_count={} num_longs={} measured_fpr={:.4} ({hits}/{SAMPLE})",
+            filter.display(),
+            format,
+            bloom.hash_count(),
+            bloom.bit_count() / 64,
+            rate,
+        );
+        assert!(
+            rate < FPR_CEILING,
+            "{}: measured false-positive rate {:.4} exceeds sanity ceiling {:.2} — \
+             the bitset appears pathologically saturated / broken",
+            filter.display(),
+            rate,
+            FPR_CEILING,
+        );
+        reported += 1;
+    }
+
+    eprintln!(
+        "filter_db_statistical_false_positive_rate_slow: reported FPR for {reported} fixtures"
+    );
+}

--- a/cqlite-core/tests/sstable_parity_repaired_metadata_test.rs
+++ b/cqlite-core/tests/sstable_parity_repaired_metadata_test.rs
@@ -1,0 +1,583 @@
+//! Repaired-metadata `Statistics.db` parity sub-lane (issue #988 / epic #968).
+//!
+//! Proves CQLite decodes and reports the *persisted* repair-state metadata that
+//! Apache Cassandra 5.0 writes into the STATS component of `Statistics.db`,
+//! validated against the committed `*-Statistics.db.txt` reference dumps
+//! `sstablemetadata` produced for every fixture (nb / oa / da).
+//!
+//! Scope owned here (issue #988):
+//!   * **repairedAt** — decoded directly from the STATS-component bytes for
+//!     every fixture and asserted equal to the `Repaired at: <n>` reference
+//!     line. The whole Cassandra 5.0 corpus is in the UNREPAIRED state
+//!     (`Repaired at: 0`), so this proves the unrepaired `repairedAt=0` field
+//!     round-trips byte-for-byte across nb/oa/da.
+//!   * **pendingRepair** — this module does NOT walk this field (it sits after
+//!     the version-gated improvedMinMax block + commitLogIntervals), so CQLite
+//!     reports it honestly as `RepairField::Unparsed`. The lane asserts the
+//!     authoritative reference is null (`Pending repair: --`) AND that CQLite
+//!     reports `Unparsed` — never a fabricated `None` that would silently
+//!     misreport a real pending-repair UUID as absent.
+//!   * **isTransient** — likewise not walked; reported as
+//!     `RepairField::Unparsed`. The lane asserts the reference is
+//!     `IsTransient: false` AND that CQLite reports `Unparsed`.
+//!   * **read -> report -> write round-trip** — the Statistics.db writer's
+//!     persisted repair state (repairedAt=0 / pendingRepair=null /
+//!     isTransient=false) is written and re-decoded through the read path and
+//!     asserted field-exact (write-support feature only).
+//!   * **negative tests** — synthetic in-memory byte mutation of the STATS
+//!     component fails closed with an explicit error in strict mode.
+//!
+//! ============================================================================
+//! PRESERVATION / REPORTING vs REPAIR-AWARE CORRECTNESS — read this.
+//!
+//! This lane validates *metadata preservation and reporting* ONLY. Decoding
+//! `repairedAt` / `pendingRepair` / `isTransient` from `Statistics.db` proves
+//! CQLite reports the persisted repair STATE accurately. It does NOT establish
+//! repair-aware compaction or repair-aware tombstone purging correctness: this
+//! lane makes no claim that tombstones are dropped (or retained) with respect to
+//! a repair boundary, and asserts nothing about compaction's use of these
+//! fields. Repair coordination, incremental-repair session tracking, and
+//! repair-aware tombstone GC are explicitly out of scope (they live in the
+//! compaction layer, not in persisted-metadata parse/report).
+//! ============================================================================
+//!
+//! No-fixture states (honest classification): the Cassandra 5.0 corpus contains
+//! NO repaired (`repairedAt>0`), pending-repair, or transient SSTable fixture.
+//! Those *distinct* states are therefore covered by SYNTHETIC round-trip /
+//! negative tests here and recorded in the manifest as `planned`
+//! ("no Cassandra 5.0 fixture available"); this lane never fabricates reference
+//! bytes for a repaired state in the strict real-fixture path.
+
+use std::path::{Path, PathBuf};
+
+use cqlite_core::parser::repair_metadata::{parse_repair_metadata, RepairField, RepairMetadata};
+use cqlite_core::storage::sstable::version_gate::VersionGates;
+
+/// Resolve the committed datasets root (env override first, else workspace tree).
+fn datasets_sstables_root() -> PathBuf {
+    let root = if let Ok(root) = std::env::var("CQLITE_DATASETS_ROOT") {
+        PathBuf::from(root)
+    } else {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .map(|workspace| workspace.join("test-data/datasets"))
+            .unwrap_or_else(|| PathBuf::from("test-data/datasets"))
+    };
+    root.join("sstables")
+}
+
+/// Recursively collect every committed `*-Statistics.db.txt` reference dump,
+/// skipping macOS AppleDouble shadow files (`._*`).
+fn collect_statistics_txt(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with("._") {
+            continue;
+        }
+        if path.is_dir() {
+            collect_statistics_txt(&path, out);
+        } else if name.ends_with("-Statistics.db.txt") {
+            out.push(path);
+        }
+    }
+}
+
+fn all_statistics_txt() -> Vec<PathBuf> {
+    let root = datasets_sstables_root();
+    let mut out = Vec::new();
+    collect_statistics_txt(&root, &mut out);
+    out.sort();
+    // Fail closed: a broken reference path must turn the lane red, not green.
+    assert!(
+        !out.is_empty(),
+        "no committed *-Statistics.db.txt references found under {} — repaired-metadata \
+         parity cannot run (this is a fail-closed guard, not a skip)",
+        root.display()
+    );
+    out
+}
+
+/// Derive the binary `*-Statistics.db` path from its `*-Statistics.db.txt` dump.
+fn binary_for(txt: &Path) -> PathBuf {
+    let name = txt
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or_else(|| panic!("non-UTF8 reference name: {}", txt.display()));
+    let db_name = name
+        .strip_suffix(".txt")
+        .unwrap_or_else(|| panic!("reference not *.txt: {name}"));
+    txt.with_file_name(db_name)
+}
+
+/// The repair-state fields parsed from an `sstablemetadata` reference dump.
+/// Every value is sourced from the authoritative reference line — never
+/// inferred from the file path.
+#[derive(Debug)]
+struct ReferenceRepairState {
+    /// From `Repaired at: <n>`.
+    repaired_at: i64,
+    /// From `Pending repair: <uuid|-->` — `None` when `--` (null).
+    pending_repair_is_null: bool,
+    /// From `IsTransient: <bool>`.
+    is_transient: bool,
+}
+
+fn parse_reference_repair_state(txt: &Path) -> ReferenceRepairState {
+    let content = std::fs::read_to_string(txt)
+        .unwrap_or_else(|e| panic!("read reference {} failed: {e}", txt.display()));
+
+    let mut repaired_at = None;
+    let mut pending_repair_is_null = None;
+    let mut is_transient = None;
+
+    for line in content.lines() {
+        let line = line.trim();
+        if let Some(rest) = line.strip_prefix("Repaired at:") {
+            repaired_at = rest.trim().parse::<i64>().ok();
+        } else if let Some(rest) = line.strip_prefix("Pending repair:") {
+            // Cassandra renders a null pending-repair session as "--".
+            pending_repair_is_null = Some(rest.trim() == "--");
+        } else if let Some(rest) = line.strip_prefix("IsTransient:") {
+            is_transient = match rest.trim() {
+                "true" => Some(true),
+                "false" => Some(false),
+                _ => None,
+            };
+        }
+    }
+
+    ReferenceRepairState {
+        repaired_at: repaired_at
+            .unwrap_or_else(|| panic!("{}: missing `Repaired at:` line", txt.display())),
+        pending_repair_is_null: pending_repair_is_null
+            .unwrap_or_else(|| panic!("{}: missing `Pending repair:` line", txt.display())),
+        is_transient: is_transient
+            .unwrap_or_else(|| panic!("{}: missing `IsTransient:` line", txt.display())),
+    }
+}
+
+/// Derive version gates from a `*-Statistics.db` path (authoritative descriptor
+/// parse — the gates come from the parsed version, not a path heuristic).
+fn gates_for(db: &Path) -> Option<VersionGates> {
+    VersionGates::from_path(db).ok()
+}
+
+/// Strict repaired-metadata parity across every committed fixture.
+///
+/// Drives off the committed `*-Statistics.db.txt` references (always present);
+/// for each, when the binary `*-Statistics.db` is fetched it decodes the repair
+/// state from real bytes and compares against the reference. Absent binaries are
+/// recorded as skips (never silent passes).
+#[test]
+fn repaired_metadata_strict_parity() {
+    let refs = all_statistics_txt();
+
+    let mut compared = 0usize;
+    let mut skipped = 0usize;
+    let mut format_nb = 0usize;
+    let mut format_oa = 0usize;
+    let mut format_da = 0usize;
+
+    // Track which formats have a fetched binary on disk INDEPENDENTLY of the
+    // compare count, so "binaries present yet 0 compared" fails the lane.
+    let mut present_nb = false;
+    let mut present_oa = false;
+    let mut present_da = false;
+    for txt in &refs {
+        let db = binary_for(txt);
+        if !db.exists() {
+            continue;
+        }
+        match db.file_name().and_then(|n| n.to_str()) {
+            Some(n) if n.starts_with("nb-") => present_nb = true,
+            Some(n) if n.starts_with("oa-") => present_oa = true,
+            Some(n) if n.starts_with("da-") => present_da = true,
+            _ => {}
+        }
+    }
+
+    for txt in &refs {
+        let db = binary_for(txt);
+        if !db.exists() {
+            skipped += 1;
+            continue;
+        }
+
+        let reference = parse_reference_repair_state(txt);
+        let bytes = std::fs::read(&db)
+            .unwrap_or_else(|e| panic!("read binary {} failed: {e}", db.display()));
+
+        let gates = gates_for(&db);
+        let decoded = parse_repair_metadata(&bytes, gates.as_ref()).unwrap_or_else(|e| {
+            panic!(
+                "{}: CQLite failed to decode repair metadata from STATS component: {e:?}",
+                db.display()
+            )
+        });
+
+        // repairedAt is decoded from real bytes for every fixture.
+        assert!(
+            decoded.repaired_at_decoded,
+            "{}: repairedAt should have been decoded from the STATS component, not defaulted",
+            db.display(),
+        );
+        assert_eq!(
+            decoded.repaired_at,
+            reference.repaired_at,
+            "{}: repairedAt mismatch (cqlite {} vs cassandra {})",
+            db.display(),
+            decoded.repaired_at,
+            reference.repaired_at,
+        );
+
+        // The whole corpus is unrepaired; guard the precondition so that if a
+        // repaired fixture is ever added, this lane is extended deliberately
+        // rather than silently passing on a stale assumption.
+        assert_eq!(
+            reference.repaired_at,
+            0,
+            "{}: reference is NOT unrepaired (Repaired at: {}); the repaired-metadata lane \
+             currently asserts the unrepaired state only — extend it before adding repaired fixtures",
+            db.display(),
+            reference.repaired_at,
+        );
+
+        // pendingRepair / isTransient: this module does NOT walk these fields,
+        // so the read path must report them honestly as `Unparsed` rather than a
+        // fabricated null / false. The authoritative reference confirms the
+        // corpus is in the null / non-transient state, but CQLite does not CLAIM
+        // to have decoded that — it reports `Unparsed` (no silent misreport).
+        assert!(
+            reference.pending_repair_is_null,
+            "{}: reference Pending repair is NOT null; extend the lane (and the \
+             decoder) before adding pending-repair fixtures",
+            db.display(),
+        );
+        assert_eq!(
+            decoded.pending_repair,
+            RepairField::Unparsed,
+            "{}: pendingRepair must be reported as Unparsed (not a fabricated \
+             value), got {:?}",
+            db.display(),
+            decoded.pending_repair,
+        );
+        assert!(
+            !reference.is_transient,
+            "{}: reference IsTransient is NOT false; extend the lane (and the \
+             decoder) before adding transient fixtures",
+            db.display(),
+        );
+        assert_eq!(
+            decoded.is_transient,
+            RepairField::Unparsed,
+            "{}: isTransient must be reported as Unparsed (not a fabricated \
+             value), got {:?}",
+            db.display(),
+            decoded.is_transient,
+        );
+
+        // Idempotent re-decode: the read-side metadata API is stable across
+        // repeated reads of the same bytes (read -> report preservation).
+        let redecoded = parse_repair_metadata(&bytes, gates.as_ref())
+            .unwrap_or_else(|e| panic!("{}: re-decode failed: {e:?}", db.display()));
+        assert_eq!(
+            decoded,
+            redecoded,
+            "{}: repair metadata not stable across re-decode",
+            db.display(),
+        );
+
+        match db.file_name().and_then(|n| n.to_str()) {
+            Some(n) if n.starts_with("nb-") => format_nb += 1,
+            Some(n) if n.starts_with("oa-") => format_oa += 1,
+            Some(n) if n.starts_with("da-") => format_da += 1,
+            _ => {}
+        }
+        compared += 1;
+    }
+
+    eprintln!(
+        "repaired_metadata_strict_parity: {compared} compared, {skipped} skipped (binary absent) \
+         | formats nb={format_nb} oa={format_oa} da={format_da} \
+         | present nb={present_nb} oa={present_oa} da={present_da}"
+    );
+
+    let any_present = present_nb || present_oa || present_da;
+    if !any_present {
+        // Dataset-absent SKIP path (distinct from a silent pass); the committed
+        // references were still validated for presence above.
+        eprintln!(
+            "repaired_metadata_strict_parity: SKIP — no *-Statistics.db binaries fetched \
+             ({skipped} references present without binaries)"
+        );
+        return;
+    }
+
+    // Binaries present: the lane must actually have compared something, and must
+    // have exercised every storage format the local dataset contains.
+    assert!(
+        compared > 0,
+        "Statistics.db binaries are present (nb={present_nb} oa={present_oa} da={present_da}) \
+         but zero fixtures were compared — repaired-metadata lane proved nothing"
+    );
+    if present_nb {
+        assert!(
+            format_nb > 0,
+            "nb-* Statistics.db binaries present but none compared — nb repair parity unproven"
+        );
+    }
+    if present_oa {
+        assert!(
+            format_oa > 0,
+            "oa-* Statistics.db binaries present but none compared — oa repair parity unproven"
+        );
+    }
+    if present_da {
+        assert!(
+            format_da > 0,
+            "da-* Statistics.db binaries present but none compared — da repair parity unproven"
+        );
+    }
+}
+
+/// Negative tests (synthetic, in-memory byte mutation): malformed STATS-section
+/// repair metadata and unsupported states fail closed with an explicit error in
+/// strict mode — never silently accepted, never coerced to a placeholder.
+///
+/// These build a self-contained Statistics.db in memory (no fetched fixture),
+/// so they run everywhere — including CI without datasets.
+#[test]
+fn repaired_metadata_negative_fails_closed() {
+    // A minimal but valid Statistics.db with a TOC and a STATS component that is
+    // self-describing through `repairedAt`.
+    let clean = synthetic_statistics(/* repaired_at */ 0);
+
+    // Baseline: the clean synthetic decodes repairedAt and reports the two
+    // not-walked fields honestly as Unparsed (never a fabricated null / false).
+    let md = parse_repair_metadata(&clean, None).expect("clean synthetic must decode");
+    assert_eq!(md.repaired_at, 0);
+    assert!(md.repaired_at_decoded);
+    assert_eq!(md.pending_repair, RepairField::Unparsed);
+    assert_eq!(md.is_transient, RepairField::Unparsed);
+
+    // (a) Truncate inside the STATS body (past the trailing CRC) so the forward
+    //     walk runs off the bounded component end.
+    {
+        let mut corrupt = clean.clone();
+        // Drop the trailing CRC (4) plus the repairedAt i64 (8) so the bounded
+        // STATS slice can no longer satisfy the repairedAt read.
+        corrupt.truncate(corrupt.len() - (4 + 8));
+        assert!(
+            parse_repair_metadata(&corrupt, None).is_err(),
+            "truncated STATS repair metadata must fail closed, not default"
+        );
+    }
+
+    // (b) Corrupt the STATS TombstoneHistogram `size` to a huge value so the
+    //     length-prefixed skip overruns the buffer → explicit corruption error.
+    {
+        let mut corrupt = clean.clone();
+        let off = stats_offset(&corrupt);
+        // Walk to the TombstoneHistogram `size` field and set it absurdly large.
+        // STATS layout up to it: 2× EstimatedHistogram (empty: 4 bytes each)
+        // + commitLogUpperBound (12) + min/maxTimestamp (16) + min/maxLDT (8)
+        // + min/maxTTL (8) + compressionRatio (8) + maxBinSize (4) = 64 bytes,
+        // then the `size` i32 at +64.
+        let size_pos = off + 4 + 4 + 12 + 16 + 8 + 8 + 8 + 4;
+        corrupt[size_pos..size_pos + 4].copy_from_slice(&i32::MAX.to_be_bytes());
+        assert!(
+            parse_repair_metadata(&corrupt, None).is_err(),
+            "an over-large TombstoneHistogram size must overrun and fail closed"
+        );
+    }
+
+    // (c) A negative EstimatedHistogram bucket count is an unsupported/malformed
+    //     state and must be rejected explicitly.
+    {
+        let mut corrupt = clean.clone();
+        let off = stats_offset(&corrupt);
+        corrupt[off..off + 4].copy_from_slice(&(-1i32).to_be_bytes());
+        assert!(
+            parse_repair_metadata(&corrupt, None).is_err(),
+            "a negative EstimatedHistogram bucket count must fail closed"
+        );
+    }
+
+    // (d) A STATS TOC offset past the end of the buffer must error, not panic or
+    //     silently default.
+    {
+        let mut corrupt = clean.clone();
+        // Rewrite the STATS TOC entry offset (type 2) to past EOF.
+        let toc_entry_off = stats_toc_entry_offset(&corrupt);
+        let bogus = (corrupt.len() as u32) + 1024;
+        corrupt[toc_entry_off + 4..toc_entry_off + 8].copy_from_slice(&bogus.to_be_bytes());
+        assert!(
+            parse_repair_metadata(&corrupt, None).is_err(),
+            "a STATS offset past EOF must fail closed"
+        );
+    }
+}
+
+/// Synthetic positive: a STATS component carrying a non-zero `repairedAt` (a
+/// repaired-state SSTable, for which the corpus has NO fixture) is decoded
+/// exactly from bytes. This covers the repaired DISTINCT state honestly via a
+/// synthetic round-trip rather than fabricated reference bytes.
+#[test]
+fn repaired_metadata_synthetic_repaired_state_roundtrip() {
+    let repaired_at: i64 = 1_700_000_000_000;
+    let bytes = synthetic_statistics(repaired_at);
+    let md = parse_repair_metadata(&bytes, None).expect("decode synthetic repaired state");
+    assert_eq!(md.repaired_at, repaired_at);
+    assert!(md.repaired_at_decoded);
+    // pendingRepair / isTransient are not walked — reported honestly as
+    // Unparsed. This synthetic exercises the repaired-at DISTINCT state only
+    // (see module docs).
+    assert_eq!(md.pending_repair, RepairField::Unparsed);
+    assert_eq!(md.is_transient, RepairField::Unparsed);
+}
+
+/// read -> report -> write round-trip through the real Statistics.db writer.
+///
+/// The writer persists the unrepaired repair state (repairedAt=0,
+/// pendingRepair=null, isTransient=false). We write a real Statistics.db, decode
+/// the repair metadata back through the read path, and assert it is preserved
+/// field-exact: repairedAt round-trips to 0 (decoded), and the two not-walked
+/// fields are reported honestly as `Unparsed` (the read path makes no claim to
+/// have decoded the null / false the writer persisted). This proves the
+/// persisted repairedAt survives a write->read round-trip.
+///
+/// SCOPE: this proves the writer's persisted repair STATE round-trips through
+/// the read path; it does NOT prove repair-aware compaction/tombstone behaviour
+/// (see the module-level preservation-vs-repair-aware note).
+#[cfg(feature = "write-support")]
+#[test]
+fn repaired_metadata_writer_roundtrip_preserves_unrepaired_state() {
+    use cqlite_core::storage::sstable::writer::{StatisticsMetadata, StatisticsWriter};
+
+    let dir = std::env::temp_dir().join("cqlite-988-repaired-roundtrip");
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    let stats_path = dir.join("nb-1-big-Statistics.db");
+
+    let mut meta = StatisticsMetadata::new();
+    meta.update_timestamp(1_000_000);
+    meta.update_timestamp(2_000_000);
+    meta.increment_partition_count();
+    meta.row_count = 10;
+
+    let writer = StatisticsWriter::new(stats_path.clone());
+    writer.write(&meta, None).expect("write Statistics.db");
+
+    let written = std::fs::read(&stats_path).expect("read written Statistics.db");
+
+    // Decode the repair state back through the read path. The writer emits the
+    // legacy (nb) tombstone-histogram width, matching the `None`-gates default.
+    let decoded = parse_repair_metadata(&written, None).expect("decode written repair metadata");
+
+    assert!(
+        decoded.repaired_at_decoded,
+        "writer round-trip: repairedAt should be decoded from the written STATS bytes"
+    );
+    assert_eq!(
+        decoded,
+        RepairMetadata {
+            repaired_at: 0,
+            // The writer's persisted null / false state is NOT walked by the
+            // read path, so it is reported honestly as Unparsed rather than a
+            // fabricated decoded value.
+            pending_repair: RepairField::Unparsed,
+            is_transient: RepairField::Unparsed,
+            repaired_at_decoded: true,
+        },
+        "writer-persisted unrepaired repair state must round-trip field-exact \
+         (repairedAt decoded; pending_repair / is_transient reported as Unparsed)"
+    );
+
+    let _ = std::fs::remove_file(&stats_path);
+}
+
+// ---------------------------------------------------------------------------
+// Synthetic Statistics.db builders (in-memory; used by negative + synthetic
+// positive tests so they run without a fetched fixture).
+// ---------------------------------------------------------------------------
+
+/// Fixed-size TOC region for `synthetic_statistics`: 4 components, STATS placed
+/// LAST by offset (its end derives from `file_len - trailing CRC`).
+const SYNTH_TOC_LEN: usize = 4 + 4 + 4 * 8; // count + marker + 4 entries
+/// Three one-byte placeholder component bodies precede the STATS body.
+const SYNTH_PLACEHOLDER_BODIES: usize = 3;
+
+/// Byte offset of the STATS component body within a `synthetic_statistics`
+/// buffer (after the TOC region and the three placeholder component bodies).
+fn stats_offset(_bytes: &[u8]) -> usize {
+    SYNTH_TOC_LEN + SYNTH_PLACEHOLDER_BODIES
+}
+
+/// Byte offset of the STATS (type 2) entry within the TOC of a
+/// `synthetic_statistics` buffer. STATS is the 3rd entry (index 2).
+fn stats_toc_entry_offset(_bytes: &[u8]) -> usize {
+    let toc_start = 8; // after count + marker
+    toc_start + 2 * 8
+}
+
+/// Build a minimal valid Statistics.db (TOC + STATS component through
+/// `repairedAt`) carrying the given `repaired_at`. The STATS leading fields are
+/// all self-describing, so the read-path decoder can walk to `repairedAt`.
+///
+/// STATS is placed as the LAST component (by offset), with three one-byte
+/// placeholder component bodies preceding it and a trailing 4-byte metadata CRC,
+/// so the decoder's component-end bound resolves to `file_len - CRC`.
+fn synthetic_statistics(repaired_at: i64) -> Vec<u8> {
+    // --- STATS body ---
+    let mut stats = Vec::new();
+    // 1-2. Two empty EstimatedHistograms (bucket count 0).
+    stats.extend_from_slice(&0i32.to_be_bytes());
+    stats.extend_from_slice(&0i32.to_be_bytes());
+    // 3. commitLogUpperBound: i64 segmentId + i32 position.
+    stats.extend_from_slice(&(-1i64).to_be_bytes());
+    stats.extend_from_slice(&0i32.to_be_bytes());
+    // 4. minTimestamp, maxTimestamp.
+    stats.extend_from_slice(&100i64.to_be_bytes());
+    stats.extend_from_slice(&200i64.to_be_bytes());
+    // 5. min/maxLocalDeletionTime (8 bytes total).
+    stats.extend_from_slice(&i32::MAX.to_be_bytes());
+    stats.extend_from_slice(&i32::MAX.to_be_bytes());
+    // 6. minTTL, maxTTL.
+    stats.extend_from_slice(&0i32.to_be_bytes());
+    stats.extend_from_slice(&0i32.to_be_bytes());
+    // 7. compressionRatio.
+    stats.extend_from_slice(&(-1.0f64).to_be_bytes());
+    // 8. TombstoneHistogram: empty (maxBinSize=0, size=0).
+    stats.extend_from_slice(&0i32.to_be_bytes());
+    stats.extend_from_slice(&0i32.to_be_bytes());
+    // 9. sstableLevel, repairedAt.
+    stats.extend_from_slice(&0i32.to_be_bytes());
+    stats.extend_from_slice(&repaired_at.to_be_bytes());
+
+    // --- TOC: 4 components, STATS (type 2) last by offset ---
+    let comp0_off = SYNTH_TOC_LEN;
+    let comp1_off = comp0_off + 1;
+    let comp3_off = comp1_off + 1;
+    let stats_off = comp3_off + 1; // == stats_offset()
+    let mut out = Vec::new();
+    out.extend_from_slice(&4u32.to_be_bytes()); // num components
+    out.extend_from_slice(&0u32.to_be_bytes()); // marker (unused by repair decoder)
+    for (ty, off) in [
+        (0u32, comp0_off as u32),
+        (1u32, comp1_off as u32),
+        (2u32, stats_off as u32), // STATS (last by offset)
+        (3u32, comp3_off as u32),
+    ] {
+        out.extend_from_slice(&ty.to_be_bytes());
+        out.extend_from_slice(&off.to_be_bytes());
+    }
+    out.extend_from_slice(&[0u8; SYNTH_PLACEHOLDER_BODIES]); // placeholder bodies
+    assert_eq!(out.len(), stats_off);
+    out.extend_from_slice(&stats);
+    out.extend_from_slice(&0u32.to_be_bytes()); // trailing metadata CRC
+    out
+}

--- a/docs/reports/cassandra-test-parity.md
+++ b/docs/reports/cassandra-test-parity.md
@@ -10,21 +10,21 @@ Sources: [`docs/cassandra_test_index.md`](../../docs/cassandra_test_index.md) ·
 
 | Status | Scenarios |
 |---|---|
-| `mirrored` | 55 |
-| `partial` | 12 |
-| `planned` | 6 |
+| `mirrored` | 68 |
+| `partial` | 13 |
+| `planned` | 11 |
 | `out_of_scope` | 8 |
-| **total** | **81** |
+| **total** | **100** |
 
 ## Evidence counts
 
 | Evidence | Scenarios |
 |---|---|
-| `byte_for_byte` | 18 |
+| `byte_for_byte` | 30 |
 | `canonical_semantic` | 32 |
-| `smoke` | 5 |
-| `partial` | 18 |
-| `out_of_scope` | 8 |
+| `smoke` | 6 |
+| `partial` | 22 |
+| `out_of_scope` | 10 |
 
 ## ⚠️ P0 scenarios with weak evidence
 
@@ -62,9 +62,20 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 | `cass.compaction_merge.tombstone_ttl_shadowing` | compaction_merge | mirrored | canonical_semantic | `compaction_parity_tombstone_ttl` | p0_data_loss |
 | `cass.compression_checksum.checksum_trailer_detection` | compression_checksum | partial | partial | `sstable_parity_corruption_verify` | p0_data_loss |
 | `cass.compression_checksum.chunk_offsets_and_crc` | compression_checksum | mirrored | canonical_semantic | `sstable_parity_compression_info_chunks` | p0_data_loss |
+| `cass.compression_info.CompressedInputStreamTest.truncated_chunk_detection` | compression_checksum | mirrored | byte_for_byte | `sstable_parity_compression_info_chunks` | p0_data_loss |
+| `cass.compression_info.CompressedRandomAccessReaderTest.chunk_offsets` | compression_checksum | mirrored | byte_for_byte | `sstable_parity_compression_info_chunks` | p0_data_loss |
+| `cass.compression_info.CompressedSequentialWriterTest.chunk_boundaries` | compression_checksum | mirrored | byte_for_byte | `sstable_parity_compression_info_chunks` | p0_data_loss |
+| `cass.compression_info.CompressionMetadataTest.metadata_serialization` | compression_checksum | mirrored | byte_for_byte | `sstable_parity_compression_info_chunks` | p0_data_loss |
+| `cass.compression_info.DirectCompressedChunkReaderTest.inline_crc_validation` | compression_checksum | mirrored | byte_for_byte | `sstable_parity_compression_info_chunks` | p0_data_loss |
+| `cass.compression_info.StandardCompressedChunkReaderTest.round_trip_chunk_bytes` | compression_checksum | mirrored | byte_for_byte | `sstable_parity_compression_info_chunks` | p0_data_loss |
+| `cass.compression_info.lz4.real_fixture_chunks` | compression_checksum | mirrored | byte_for_byte | `sstable_parity_compression_info_chunks` | p0_data_loss |
+| `cass.compression_info.snappy.real_fixture_chunks` | compression_checksum | mirrored | byte_for_byte | `sstable_parity_compression_info_chunks` | p0_data_loss |
 | `cass.corruption_verify.component_corruption_detection` | corruption_verify | planned | partial | `sstable_parity_corruption_verify` | p0_data_loss |
 | `cass.data_db_decode.row_cell_flags_and_vint` | data_db_decode | mirrored | canonical_semantic | `sstable_parity_data_db_jsonl` | p1_correctness |
 | `cass.delta_scan.tombstone_liveness_facts` | delta_scan | partial | partial | `sstable_parity_delta_scan` | p1_correctness |
+| `cass.filter_db.corruption_fails_closed` | filter_db_bloom | mirrored | byte_for_byte | `sstable_parity_filter_db_bloom` | p1_correctness |
+| `cass.filter_db.no_false_negative_membership` | filter_db_bloom | mirrored | byte_for_byte | `sstable_parity_filter_db_bloom` | p0_data_loss |
+| `cass.filter_db.serialization_round_trip` | filter_db_bloom | mirrored | byte_for_byte | `sstable_parity_filter_db_bloom` | p1_correctness |
 | `cass.filter_db_bloom.serialization_no_false_negative` | filter_db_bloom | partial | partial | `sstable_parity_filter_db_bloom` | p0_data_loss |
 | `cass.index_db.CorruptPrimaryIndexTest.big_primary_index_corruption` | index_summary | mirrored | byte_for_byte | `sstable_parity_index_db_big` | p0_data_loss |
 | `cass.index_db.RowIndexEntryTest.partition_offsets` | index_summary | mirrored | byte_for_byte | `sstable_parity_index_db_big` | p1_correctness |
@@ -119,6 +130,18 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 
 ## Byte-for-byte scenarios
 
+- `cass.compression_info.CompressedInputStreamTest.truncated_chunk_detection` — Truncated compressed chunk fail-closed parity
+- `cass.compression_info.CompressedRandomAccessReaderTest.chunk_offsets` — CompressionInfo.db ordered chunk-offset table parity
+- `cass.compression_info.CompressedSequentialWriterTest.chunk_boundaries` — Compressed chunk record boundaries vs Data.db parity
+- `cass.compression_info.CompressionMetadataTest.metadata_serialization` — CompressionInfo.db metadata byte-for-byte serialization parity
+- `cass.compression_info.DirectCompressedChunkReaderTest.inline_crc_validation` — Inline per-chunk CRC32 trailer validation parity
+- `cass.compression_info.StandardCompressedChunkReaderTest.round_trip_chunk_bytes` — Compressed chunk payload + CRC round-trip byte parity
+- `cass.compression_info.lz4.real_fixture_chunks` — LZ4Compressor real-fixture chunk + CRC parity
+- `cass.compression_info.snappy.real_fixture_chunks` — SnappyCompressor real-fixture chunk + CRC parity
+- `cass.filter_db.corruption_fails_closed` — Filter.db malformed-byte rejection (fail-closed)
+- `cass.filter_db.no_false_negative_membership` — Filter.db no-false-negative membership over Cassandra present keys
+  - Normalization: Present keys are the raw partition-key bytes from Index.db (not the decoded CQL values), matching the bytes Cassandra's Murmur3 hashed into Filter.db. The reference_paths point at the committed per-fixture Data.db.jsonl siblings (the binary Filter.db and Index.db are gitignored, fetched on demand).
+- `cass.filter_db.serialization_round_trip` — Filter.db byte-exact serialization round-trip and parameter decode
 - `cass.index_db.CorruptPrimaryIndexTest.big_primary_index_corruption` — Truncated BIG Index.db fails explicitly
 - `cass.index_db.RowIndexEntryTest.partition_offsets` — BIG Index.db partition data offsets vs Cassandra positions
   - Normalization: Index.db data offsets are relative to the Data.db data section while JSONL positions are absolute file offsets; the per-partition Data.db header is a constant only for uniform partition-key lengths without static blocks, so successive deltas (not absolute values) are compared in that case.
@@ -127,6 +150,7 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 - `cass.index_db.big.raw_partition_keys_and_offsets` — BIG Index.db raw partition-key bytes and entry-byte parity
   - Normalization: JSONL single-column partition keys are decoded to their raw on-disk byte encoding (UUID text -> 16 bytes) before comparison; composite-key byte decoding is not attempted (those fixtures are covered by entry-byte + count + offset parity).
 - `cass.index_db.bti.index_component_discovery` — BTI index-component discovery and classification
+- `cass.repaired_metadata.statistics_db.repaired_at_field` — Statistics.db repairedAt field decode + report parity (unrepaired state)
 - `cass.sstable_format.toc_component_manifest` — TOC.txt component manifest completeness
 - `cass.statistics_db.MetadataSerializerTest.metadata_components` — Statistics.db metadata-component TOC byte parity (count + ordered types)
 - `cass.statistics_db.SSTableMetadataTrackingTest.timestamp_and_ttl_metadata` — Statistics.db min timestamp / local-deletion-time / TTL byte parity
@@ -215,6 +239,7 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 
 - `cass.cli_reporting.parity_manifest_lint_and_report` — Parity manifest lint and report tooling
 - `cass.compaction_merge.load_path_validity` — Compaction output load-path validity (Tier-1)
+- `cass.filter_db.statistical_false_positive_rate` — Filter.db empirical false-positive-rate report
 - `cass.schema_evolution.serialization_header_column_order` — Serialization-header column order across schema evolution
 - `cass.sstable_format.descriptor_component_resolution` — Descriptor and on-disk version/component resolution
 - `cass.write_load_path.cassandra_sstable_writer_fixtures` — CQLite-written SSTables load into Cassandra via sstableloader
@@ -223,13 +248,19 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 
 - `cass.compaction_merge.byte_for_byte_output` (planned): No gated byte-for-byte comparison of compaction output. → _Promote the debug byte tier in compaction-parity to a gated comparison once writer output is byte-stable._
 - `cass.compression_checksum.checksum_trailer_detection` (partial): No gated byte comparison of Digest.crc32 against the Cassandra reference. → _Add a Digest.crc32 byte comparison to the sstable_parity_corruption_verify suite._
+- `cass.compression_info.deflate.real_fixture_chunks` (planned): No real DeflateCompressor CompressionInfo.db / Data.db fixture in the committed corpus, so chunk + CRC parity cannot be byte-compared. → _Generate a DeflateCompressor SSTable via regenerate-datasets.sh and let the existing test exercise it (the codec dispatch already handles it)._
+- `cass.compression_info.zstd.real_fixture_chunks` (planned): No real ZstdCompressor CompressionInfo.db / Data.db fixture in the committed corpus, so chunk + CRC parity cannot be byte-compared. → _Generate a ZstdCompressor SSTable via regenerate-datasets.sh and let the existing test exercise it (the codec dispatch already handles it)._
 - `cass.corruption_verify.component_corruption_detection` (planned): No scrub/verify parity pass implemented. → _Implement a verify pass and compare detected-corruption outcomes against Cassandra VerifyTest/ScrubTest scenarios._
 - `cass.delta_scan.tombstone_liveness_facts` (partial): test_deltas dataset asset not published/enforced (#701). → _Publish and enforce the test_deltas dataset in delta-roundtrip CI._
+- `cass.filter_db.bti_membership` (partial): No raw-partition-key source for BTI fixtures, so the no-false-negative probe cannot run against da Filter.db. → _Recover raw BTI partition keys (e.g. by decoding partitions during a Data.db scan) and extend the no-false-negative gate to cover da fixtures._
+- `cass.filter_db.statistical_false_positive_rate` (planned): No gated comparison of measured FPR against Cassandra's configured bloom_filter_fp_chance. → _Add larger-cardinality fixtures and assert the measured FPR tracks the configured fp_chance within a documented statistical tolerance._
 - `cass.filter_db_bloom.serialization_no_false_negative` (partial): No no-false-negative parity assertion against Cassandra Filter.db. → _Add a Filter.db serialization parity test asserting zero false negatives across the present-key set._
 - `cass.index_db.RowIndexEntryTest.promoted_index_entries` (partial): No committed BIG fixture triggers promoted-index emission (all partitions are below the column_index_size threshold). → _Generate a wide-partition BIG fixture (partition exceeding column_index_size_in_kb) and assert decoded promoted-index clustering boundaries against the Cassandra reference._
 - `cass.index_db.big.wide_partition_promoted_entries` (partial): No committed wide BIG fixture exercises promoted clustering boundaries. → _Add a BIG fixture with a partition exceeding column_index_size_in_kb and compare decoded promoted clustering boundaries to the Cassandra reference._
 - `cass.index_summary.column_index.range_tombstone_boundary_big_bti` (partial): BTI (da) range-tombstone-at-block-edge fixtures are not yet generated (no da tombstone generator). → _Add a da/BTI wide-partition range-tombstone fixture generator and assert BTI column-index boundary parity; file a follow-up issue._
 - `cass.index_summary.summary_boundaries` (partial): Cassandra Summary.db reference dumps not published for all tables. → _Publish Summary.db reference dumps and enable strict first/last-key boundary comparison in the sstable_parity_summary_db_big suite._
+- `cass.repaired_metadata.statistics_db.pending_repair_uuid` (planned): No Cassandra 5.0 pending-repair fixture available; the reference null (`Pending repair: --`) state is confirmed, and the read path reports the field as Unparsed (it is not walked from bytes) rather than a fabricated absent value. → _When a pending-repair fixture is generated, decode the pendingRepair UUID (type-aware skip past improvedMinMax + commitLogIntervals) — promoting the field from RepairField::Unparsed to Decoded — and assert it byte-for-byte against the `Pending repair: <uuid>` reference line._
+- `cass.repaired_metadata.statistics_db.transient_repair_flag` (planned): No transiently-replicated fixture available; the reference `IsTransient: false` state is confirmed, and the read path reports the field as Unparsed (it is not walked from bytes) rather than a fabricated `false`. → _When a transient-replication fixture is generated, decode the isTransient flag (after the version-gated improvedMinMax block and commitLogIntervals) — promoting it from RepairField::Unparsed to Decoded — and assert it byte-for-byte against the `IsTransient: true` reference line._
 - `cass.schema_evolution.dropped_column.empty_index_block_reverse_scan` (partial): A wide dropped-column empty-index-block reverse-scan fixture is not yet generated. → _Generate a wide dropped-column fixture that yields an empty index block under reverse scan and assert parity; file a follow-up issue._
 - `cass.statistics_db.SSTableMetadataTest.max_local_deletion_time` (planned): STATS-section max timestamp / max local-deletion-time not yet decoded. → _Decode the STATS MetadataType component and assert max timestamp / max local-deletion-time against the reference dump._
 - `cass.statistics_db.clustering_key_bounds` (planned): Covered-clustering min/max bounds not yet decoded from the STATS component. → _Decode the STATS-section clustering bounds and compare against the "Covered clusterings" reference line._
@@ -301,10 +332,25 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.compaction_merge.tombstone_ttl_shadowing` | required_parity | .github/workflows/compaction-parity.yml |
 | `cass.compression_checksum.checksum_trailer_detection` | fast_pr | — |
 | `cass.compression_checksum.chunk_offsets_and_crc` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
+| `cass.compression_info.CompressedInputStreamTest.truncated_chunk_detection` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
+| `cass.compression_info.CompressedRandomAccessReaderTest.chunk_offsets` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
+| `cass.compression_info.CompressedSequentialWriterTest.chunk_boundaries` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
+| `cass.compression_info.CompressionMetadataTest.metadata_serialization` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
+| `cass.compression_info.DirectCompressedChunkReaderTest.inline_crc_validation` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
+| `cass.compression_info.StandardCompressedChunkReaderTest.round_trip_chunk_bytes` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
+| `cass.compression_info.deflate.real_fixture_chunks` | manual_debug | — |
+| `cass.compression_info.lz4.real_fixture_chunks` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
+| `cass.compression_info.snappy.real_fixture_chunks` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
+| `cass.compression_info.zstd.real_fixture_chunks` | manual_debug | — |
 | `cass.corruption_verify.component_corruption_detection` | manual_debug | — |
 | `cass.data_db_decode.row_cell_flags_and_vint` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.delta_scan.tombstone_liveness_facts` | required_parity | .github/workflows/delta-roundtrip.yml |
 | `cass.distributed_consensus.paxos_accord_out_of_scope` | fast_pr | — |
+| `cass.filter_db.bti_membership` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
+| `cass.filter_db.corruption_fails_closed` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
+| `cass.filter_db.no_false_negative_membership` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
+| `cass.filter_db.serialization_round_trip` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
+| `cass.filter_db.statistical_false_positive_rate` | manual_debug | — |
 | `cass.filter_db_bloom.serialization_no_false_negative` | fast_pr | — |
 | `cass.index_db.CorruptPrimaryIndexTest.big_primary_index_corruption` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.index_db.RowIndexEntryTest.partition_offsets` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
@@ -320,6 +366,10 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.nodetool_jmx_metrics.operational_out_of_scope` | fast_pr | — |
 | `cass.read_repair_coordinator.out_of_scope` | fast_pr | — |
 | `cass.repair_coordinator.anti_entropy_out_of_scope` | fast_pr | — |
+| `cass.repaired_metadata.statistics_db.pending_repair_uuid` | manual_debug | — |
+| `cass.repaired_metadata.statistics_db.repaired_at_field` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
+| `cass.repaired_metadata.statistics_db.transient_repair_flag` | manual_debug | — |
+| `cass.repaired_metadata.statistics_db.write_roundtrip` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.sai_sasi_query.secondary_index_out_of_scope` | fast_pr | — |
 | `cass.schema_evolution.dropped_column.empty_index_block_reverse_scan` | nightly_docker | .github/workflows/tombstone-ttl-parity.yml |
 | `cass.schema_evolution.dropped_column.per_cell_purge` | nightly_docker | .github/workflows/tombstone-ttl-parity.yml |
@@ -387,10 +437,25 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.compaction_merge.tombstone_ttl_shadowing` | nb | test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl |
 | `cass.compression_checksum.checksum_trailer_detection` | da | test-data/datasets/sstables/test_da/simple_table-de1be8b064e711f19ad401a8c8227b11/da-2-bti-Digest.crc32<br>_fail:_ target/cassandra-parity/checksum-mismatch.log |
 | `cass.compression_checksum.chunk_offsets_and_crc` | nb | test-data/datasets/sstables/test_basic/compression_test_table-6ad6ad30a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl |
+| `cass.compression_info.CompressedInputStreamTest.truncated_chunk_detection` | nb | test-data/datasets/sstables/test_basic/compression_test_table-6ad6ad30a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/compression-info-truncated-chunk.log |
+| `cass.compression_info.CompressedRandomAccessReaderTest.chunk_offsets` | nb | test-data/datasets/sstables/test_basic/compression_test_table-6ad6ad30a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/compression-info-chunk-offsets-mismatch.log |
+| `cass.compression_info.CompressedSequentialWriterTest.chunk_boundaries` | nb | test-data/datasets/sstables/test_basic/compression_test_table-6ad6ad30a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/compression-info-chunk-boundaries-mismatch.log |
+| `cass.compression_info.CompressionMetadataTest.metadata_serialization` | nb | test-data/datasets/sstables/test_basic/compression_test_table-6ad6ad30a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/compression-info-metadata-mismatch.log |
+| `cass.compression_info.DirectCompressedChunkReaderTest.inline_crc_validation` | nb | test-data/datasets/sstables/test_basic/compression_test_table-6ad6ad30a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/compression-info-chunk-crc-mismatch.log |
+| `cass.compression_info.StandardCompressedChunkReaderTest.round_trip_chunk_bytes` | nb | test-data/datasets/sstables/test_basic/compression_test_table-6ad6ad30a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/compression-info-round-trip-mismatch.log |
+| `cass.compression_info.deflate.real_fixture_chunks` | — | — |
+| `cass.compression_info.lz4.real_fixture_chunks` | nb | test-data/datasets/sstables/test_basic/compression_test_table-6ad6ad30a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/compression-info-lz4-mismatch.log |
+| `cass.compression_info.snappy.real_fixture_chunks` | nb | test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/compression-info-snappy-mismatch.log |
+| `cass.compression_info.zstd.real_fixture_chunks` | — | — |
 | `cass.corruption_verify.component_corruption_detection` | — | — |
 | `cass.data_db_decode.row_cell_flags_and_vint` | nb, oa | test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl |
 | `cass.delta_scan.tombstone_liveness_facts` | nb | test-data/datasets/sstables/test_deltas/collection_ops-2a5006f06c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl |
 | `cass.distributed_consensus.paxos_accord_out_of_scope` | — | — |
+| `cass.filter_db.bti_membership` | da | — |
+| `cass.filter_db.corruption_fails_closed` | nb, oa, da | test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/filter-db-corruption.log |
+| `cass.filter_db.no_false_negative_membership` | nb, oa, da | test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>test-data/datasets/sstables/test_basic/composite_key_table-6ab56990a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/filter-db-false-negative.log |
+| `cass.filter_db.serialization_round_trip` | nb, oa, da | test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>test-data/datasets/sstables/test_da/simple_table-de1be8b064e711f19ad401a8c8227b11/da-2-bti-Data.db.jsonl<br>_fail:_ target/cassandra-parity/filter-db-roundtrip.log |
+| `cass.filter_db.statistical_false_positive_rate` | nb, oa, da | — |
 | `cass.filter_db_bloom.serialization_no_false_negative` | nb | — |
 | `cass.index_db.CorruptPrimaryIndexTest.big_primary_index_corruption` | nb, oa | test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/index-db-diff.log |
 | `cass.index_db.RowIndexEntryTest.partition_offsets` | nb, oa | test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/index-db-diff.log |
@@ -406,6 +471,10 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.nodetool_jmx_metrics.operational_out_of_scope` | — | — |
 | `cass.read_repair_coordinator.out_of_scope` | — | — |
 | `cass.repair_coordinator.anti_entropy_out_of_scope` | — | — |
+| `cass.repaired_metadata.statistics_db.pending_repair_uuid` | nb, oa, da | test-data/datasets/sstables/test_basic/composite_key_table-6ab56990a25111f0a3fef1a551383fb9/nb-1-big-Statistics.db.txt |
+| `cass.repaired_metadata.statistics_db.repaired_at_field` | nb, oa, da | test-data/datasets/sstables/test_basic/composite_key_table-6ab56990a25111f0a3fef1a551383fb9/nb-1-big-Statistics.db.txt<br>test-data/datasets/sstables/test_oa/collection_table-4b892c6064e711f1bd3ac7dbf655c673/oa-2-big-Statistics.db.txt<br>test-data/datasets/sstables/test_da/simple_table-de1be8b064e711f19ad401a8c8227b11/da-2-bti-Statistics.db.txt<br>_fail:_ target/cassandra-parity/statistics-db-repaired-at-mismatch.log |
+| `cass.repaired_metadata.statistics_db.transient_repair_flag` | nb, oa, da | test-data/datasets/sstables/test_da/simple_table-de1be8b064e711f19ad401a8c8227b11/da-2-bti-Statistics.db.txt |
+| `cass.repaired_metadata.statistics_db.write_roundtrip` | nb | — |
 | `cass.sai_sasi_query.secondary_index_out_of_scope` | — | — |
 | `cass.schema_evolution.dropped_column.empty_index_block_reverse_scan` | nb | test-data/datasets/sstables/test_tomb/dropped_regular_col-4cc79a50702011f1b8f419c9a388d558/nb-1-big-Data.db.jsonl |
 | `cass.schema_evolution.dropped_column.per_cell_purge` | nb | test-data/datasets/sstables/test_tomb/dropped_regular_col-4cc79a50702011f1b8f419c9a388d558/nb-1-big-Data.db.jsonl<br>test-data/datasets/sstables/test_tomb/dropped_regular_col-4cc79a50702011f1b8f419c9a388d558/nb-1-big-Statistics.db.txt<br>test-data/datasets/sstables/test_tomb/dropped_regular_col-4cc79a50702011f1b8f419c9a388d558/nb-2-big-Statistics.db.txt |

--- a/test-data/cassandra-parity-manifest.yml
+++ b/test-data/cassandra-parity-manifest.yml
@@ -1512,6 +1512,232 @@ scenarios:
         compare bucket boundaries against the reference dump.
 
   # ----------------------------------------------------------------------------
+  # statistics_db repaired-metadata (issue #988 / epic #968)
+  #
+  # PRESERVATION / REPORTING ONLY. Decoding repairedAt / pendingRepair /
+  # isTransient from Statistics.db proves CQLite reports the persisted repair
+  # STATE accurately. It does NOT establish repair-aware compaction or
+  # repair-aware tombstone purging correctness; those (and repair coordination /
+  # incremental-repair session tracking) are out of scope here and live in the
+  # compaction layer. See cass.tombstone_ttl.* for tombstone correctness.
+  # ----------------------------------------------------------------------------
+  - id: cass.repaired_metadata.statistics_db.repaired_at_field
+    title: Statistics.db repairedAt field decode + report parity (unrepaired state)
+    status: mirrored
+    capability: statistics_metadata
+    priority: P1
+    risk: p1_correctness
+    cassandra:
+      category: serialization
+      relevance: high
+      files:
+        - StatsMetadata.java
+        - SSTableMetadataTest.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_statistics_db
+        tests:
+          - cqlite-core/tests/sstable_parity_repaired_metadata_test.rs
+        notes: >-
+          repaired_metadata_strict_parity decodes the STATS-component repairedAt
+          directly from the Statistics.db bytes (self-describing forward walk over
+          the two EstimatedHistograms + the version-gated TombstoneHistogram) for
+          every nb/oa/da fixture and asserts it equals the `Repaired at: <n>`
+          reference line. The whole Cassandra 5.0 corpus is unrepaired
+          (repairedAt=0), so this proves the unrepaired repairedAt field
+          round-trips byte-for-byte across formats. PRESERVATION/REPORTING ONLY —
+          establishes nothing about repair-aware tombstone purging.
+    fixtures:
+      references:
+        - test-data/datasets/sstables/test_basic/composite_key_table-6ab56990a25111f0a3fef1a551383fb9/nb-1-big-Statistics.db.txt
+        - test-data/datasets/sstables/test_oa/collection_table-4b892c6064e711f1bd3ac7dbf655c673/oa-2-big-Statistics.db.txt
+        - test-data/datasets/sstables/test_da/simple_table-de1be8b064e711f19ad401a8c8227b11/da-2-bti-Statistics.db.txt
+    evidence:
+      type: byte_for_byte
+      strict: true
+      artifacts: [bytes, offsets]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb, oa, da]
+      fixture_generation_command: >-
+        bash test-data/scripts/regenerate-datasets.sh && sstablemetadata emit Statistics.db.txt
+      comparison_command: >-
+        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        --features write-support --test sstable_parity_repaired_metadata_test
+        repaired_metadata_strict_parity
+      reference_paths:
+        - test-data/datasets/sstables/test_basic/composite_key_table-6ab56990a25111f0a3fef1a551383fb9/nb-1-big-Statistics.db.txt
+        - test-data/datasets/sstables/test_oa/collection_table-4b892c6064e711f1bd3ac7dbf655c673/oa-2-big-Statistics.db.txt
+        - test-data/datasets/sstables/test_da/simple_table-de1be8b064e711f19ad401a8c8227b11/da-2-bti-Statistics.db.txt
+      failure_artifacts:
+        - target/cassandra-parity/statistics-db-repaired-at-mismatch.log
+      known_limitations: >-
+        repairedAt is decoded from real bytes; pendingRepair / isTransient are
+        NOT walked and are reported honestly as RepairField::Unparsed (not a
+        fabricated null / false), so a real pending-repair UUID or transient flag
+        is never silently misreported as absent (see
+        cass.repaired_metadata.statistics_db.pending_repair_uuid and
+        .transient_repair_flag). The fetched *-Statistics.db binary is required;
+        when absent that fixture is skipped (never a silent pass) and the
+        committed *-Statistics.db.txt reference presence is enforced fail-closed.
+        This lane is metadata preservation/reporting only — NOT repair-aware
+        tombstone purging.
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/sstabledump-parity-gate.yml
+    scope:
+      cqlite_boundary: >-
+        Persisted-metadata parse/report of the STATS-component repairedAt field;
+        no repair coordination and no repair-aware compaction/tombstone GC.
+
+  - id: cass.repaired_metadata.statistics_db.pending_repair_uuid
+    title: Statistics.db pendingRepair reported as Unparsed — no repaired fixture available
+    status: planned
+    capability: statistics_metadata
+    priority: P2
+    risk: p2_coverage
+    cassandra:
+      category: serialization
+      relevance: med
+      files:
+        - StatsMetadata.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_statistics_db
+        tests:
+          - cqlite-core/tests/sstable_parity_repaired_metadata_test.rs
+    fixtures:
+      references:
+        - test-data/datasets/sstables/test_basic/composite_key_table-6ab56990a25111f0a3fef1a551383fb9/nb-1-big-Statistics.db.txt
+    evidence:
+      type: partial
+      storage_format_version: [nb, oa, da]
+      known_limitations: >-
+        The Cassandra 5.0 corpus contains NO pending-repair SSTable fixture
+        (every reference shows `Pending repair: --`, i.e. null). The reference is
+        asserted null, but the read path does NOT decode this field: it reports
+        pendingRepair as RepairField::Unparsed (an explicit not-yet-decoded
+        state) rather than fabricating a `None`, so a real non-null pendingRepair
+        UUID could not be silently misreported as absent. A non-null pendingRepair
+        UUID cannot be decoded byte-for-byte until a pending-repair fixture
+        exists. The pendingRepair field sits after the version-gated
+        improvedMinMax block and the variable commitLogIntervals set, so a
+        non-null UUID requires a type-aware / interval-aware forward walk to
+        reach. Reporting/preservation only — not repair-aware tombstone purging.
+    ci:
+      tier: manual_debug
+    scope:
+      target_issue: 988
+      gap: >-
+        No Cassandra 5.0 pending-repair fixture available; the reference null
+        (`Pending repair: --`) state is confirmed, and the read path reports the
+        field as Unparsed (it is not walked from bytes) rather than a fabricated
+        absent value.
+      next_step: >-
+        When a pending-repair fixture is generated, decode the pendingRepair UUID
+        (type-aware skip past improvedMinMax + commitLogIntervals) — promoting
+        the field from RepairField::Unparsed to Decoded — and assert it
+        byte-for-byte against the `Pending repair: <uuid>` reference line.
+
+  - id: cass.repaired_metadata.statistics_db.transient_repair_flag
+    title: Statistics.db isTransient reported as Unparsed — no transient fixture available
+    status: planned
+    capability: statistics_metadata
+    priority: P2
+    risk: p2_coverage
+    cassandra:
+      category: serialization
+      relevance: med
+      files:
+        - StatsMetadata.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_statistics_db
+        tests:
+          - cqlite-core/tests/sstable_parity_repaired_metadata_test.rs
+    fixtures:
+      references:
+        - test-data/datasets/sstables/test_da/simple_table-de1be8b064e711f19ad401a8c8227b11/da-2-bti-Statistics.db.txt
+    evidence:
+      type: partial
+      storage_format_version: [nb, oa, da]
+      known_limitations: >-
+        The Cassandra 5.0 corpus contains NO transiently-replicated SSTable
+        fixture (every reference shows `IsTransient: false`). The reference is
+        asserted false, but the read path does NOT decode this field: it reports
+        isTransient as RepairField::Unparsed (an explicit not-yet-decoded state)
+        rather than fabricating `false`, so a real isTransient=true could not be
+        silently misreported as false. isTransient=true cannot be decoded
+        byte-for-byte until a transient fixture exists (transient replication
+        requires a multi-node cluster with transient replicas to produce).
+        Reporting/preservation only — not repair-aware tombstone purging.
+    ci:
+      tier: manual_debug
+    scope:
+      target_issue: 988
+      gap: >-
+        No transiently-replicated fixture available; the reference `IsTransient:
+        false` state is confirmed, and the read path reports the field as
+        Unparsed (it is not walked from bytes) rather than a fabricated `false`.
+      next_step: >-
+        When a transient-replication fixture is generated, decode the isTransient
+        flag (after the version-gated improvedMinMax block and commitLogIntervals)
+        — promoting it from RepairField::Unparsed to Decoded — and assert it
+        byte-for-byte against the `IsTransient: true` reference line.
+
+  - id: cass.repaired_metadata.statistics_db.write_roundtrip
+    title: Statistics.db repair fields survive a write -> read round-trip (unrepaired)
+    status: mirrored
+    capability: statistics_metadata
+    priority: P2
+    risk: p2_coverage
+    cassandra:
+      category: serialization
+      relevance: med
+      files:
+        - StatsMetadata.java
+        - MetadataSerializer.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_statistics_db
+        tests:
+          - cqlite-core/tests/sstable_parity_repaired_metadata_test.rs
+        notes: >-
+          repaired_metadata_writer_roundtrip_preserves_unrepaired_state writes a
+          real Statistics.db via StatisticsWriter (persisting repairedAt=0 /
+          pendingRepair=null / isTransient=false), decodes the repair metadata
+          back through the read path, and asserts it is preserved field-exact.
+          Proves persisted repair STATE survives write -> read; NOT repair-aware
+          compaction behaviour.
+    fixtures: {}
+    evidence:
+      type: partial
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb]
+      fixture_generation_command: >-
+        n/a — writer round-trip; the CQLite StatisticsWriter produces the
+        Statistics.db in-test (no fetched Cassandra fixture). Targets the
+        cassandra 5.0.2 nb StatsMetadata layout.
+      known_limitations: >-
+        Round-trips the writer's unrepaired persisted state (repairedAt=0,
+        pendingRepair=null, isTransient=false); the writer does not emit a
+        repaired / pending / transient state, so those distinct states are
+        covered by the synthetic round-trip
+        (repaired_metadata_synthetic_repaired_state_roundtrip) and the planned
+        no-fixture scenarios above. Preservation/reporting only.
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/sstabledump-parity-gate.yml
+    scope:
+      gap: >-
+        Writer emits only the unrepaired repair state; repaired/pending/transient
+        write round-trips are synthetic until repaired fixtures exist.
+      next_step: >-
+        Extend the writer round-trip to repaired/pending/transient states once a
+        repaired-fixture generation path exists.
+
+  # ----------------------------------------------------------------------------
   # compression_checksum
   # ----------------------------------------------------------------------------
   - id: cass.compression_checksum.chunk_offsets_and_crc
@@ -1606,6 +1832,456 @@ scenarios:
         Add a Digest.crc32 byte comparison to the sstable_parity_corruption_verify
         suite.
 
+  - id: cass.compression_info.CompressionMetadataTest.metadata_serialization
+    title: CompressionInfo.db metadata byte-for-byte serialization parity
+    status: mirrored
+    capability: compression_checksum
+    priority: P0
+    risk: p0_data_loss
+    cassandra:
+      category: compression
+      relevance: high
+      files:
+        - CompressionMetadataTest.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_compression_info_chunks
+        tests:
+          - cqlite-core/tests/sstable_parity_compression_info_test.rs
+        notes: >-
+          Re-derives the CompressionInfo.db layout (compressor simple-name, option
+          key/value pairs, chunk_length, max_compressed_length, uncompressed
+          data_length, chunk count, ordered chunk-offset vector) independently from
+          the raw bytes and asserts equality field-for-field against
+          CompressionInfo::parse. The file must end exactly after the offset table
+          (no trailing metadata CRC). Compares ordered offsets, not just counts.
+    fixtures:
+      references:
+        - test-data/datasets/sstables/test_basic/compression_test_table-6ad6ad30a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl
+    evidence:
+      type: byte_for_byte
+      strict: true
+      artifacts: [bytes, offsets]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb]
+      fixture_generation_command: >-
+        bash test-data/scripts/regenerate-datasets.sh  # cassandra:5.0.2 writes CompressionInfo.db
+      comparison_command: >-
+        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        --features write-support --test sstable_parity_compression_info_test
+      reference_paths:
+        - test-data/datasets/sstables/test_basic/compression_test_table-6ad6ad30a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl
+      failure_artifacts:
+        - target/cassandra-parity/compression-info-metadata-mismatch.log
+      known_limitations: >-
+        Validates the CompressionInfo.db metadata Cassandra persisted; the codecs
+        actually exercised are LZ4Compressor and SnappyCompressor (the only ones in
+        the committed corpus).
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/sstabledump-parity-gate.yml
+    scope: {}
+
+  - id: cass.compression_info.CompressedRandomAccessReaderTest.chunk_offsets
+    title: CompressionInfo.db ordered chunk-offset table parity
+    status: mirrored
+    capability: compression_checksum
+    priority: P0
+    risk: p0_data_loss
+    cassandra:
+      category: compression
+      relevance: high
+      files:
+        - CompressedRandomAccessReaderTest.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_compression_info_chunks
+        tests:
+          - cqlite-core/tests/sstable_parity_compression_info_test.rs
+        notes: >-
+          The decoded chunk-offset table is compared as an ordered vector against
+          the independent re-derivation, asserted to start at offset 0, and checked
+          to be strictly ascending — catching any reordering or off-by-one bug in
+          the offset decode.
+    fixtures:
+      references:
+        - test-data/datasets/sstables/test_basic/compression_test_table-6ad6ad30a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl
+    evidence:
+      type: byte_for_byte
+      strict: true
+      artifacts: [offsets]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb]
+      fixture_generation_command: >-
+        bash test-data/scripts/regenerate-datasets.sh  # cassandra:5.0.2 writes CompressionInfo.db
+      comparison_command: >-
+        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        --features write-support --test sstable_parity_compression_info_test
+      reference_paths:
+        - test-data/datasets/sstables/test_basic/compression_test_table-6ad6ad30a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl
+      failure_artifacts:
+        - target/cassandra-parity/compression-info-chunk-offsets-mismatch.log
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/sstabledump-parity-gate.yml
+    scope: {}
+
+  - id: cass.compression_info.CompressedSequentialWriterTest.chunk_boundaries
+    title: Compressed chunk record boundaries vs Data.db parity
+    status: mirrored
+    capability: compression_checksum
+    priority: P0
+    risk: p0_data_loss
+    cassandra:
+      category: compression
+      relevance: high
+      files:
+        - CompressedSequentialWriterTest.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_compression_info_chunks
+        tests:
+          - cqlite-core/tests/sstable_parity_compression_info_test.rs
+        notes: >-
+          For every chunk, the record size (delta to the next offset, or to EOF for
+          the final partial chunk) is checked against the Data.db length and proven
+          to hold at least the 4-byte inline CRC trailer. Multi-chunk fixtures
+          exercise final partial-chunk handling (last record runs to EOF), mirroring
+          CompressedSequentialWriter.java.
+    fixtures:
+      references:
+        - test-data/datasets/sstables/test_basic/compression_test_table-6ad6ad30a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl
+    evidence:
+      type: byte_for_byte
+      strict: true
+      artifacts: [bytes, offsets]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb]
+      fixture_generation_command: >-
+        bash test-data/scripts/regenerate-datasets.sh  # cassandra:5.0.2 writes Data.db chunks
+      comparison_command: >-
+        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        --features write-support --test sstable_parity_compression_info_test
+      reference_paths:
+        - test-data/datasets/sstables/test_basic/compression_test_table-6ad6ad30a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl
+      failure_artifacts:
+        - target/cassandra-parity/compression-info-chunk-boundaries-mismatch.log
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/sstabledump-parity-gate.yml
+    scope: {}
+
+  - id: cass.compression_info.DirectCompressedChunkReaderTest.inline_crc_validation
+    title: Inline per-chunk CRC32 trailer validation parity
+    status: mirrored
+    capability: compression_checksum
+    priority: P0
+    risk: p0_data_loss
+    cassandra:
+      category: checksum
+      relevance: high
+      files:
+        - CompressedSequentialWriterTest.java
+        - CompressedRandomAccessReaderTest.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_compression_info_chunks
+        tests:
+          - cqlite-core/tests/sstable_parity_compression_info_test.rs
+        notes: >-
+          The trailing 4-byte big-endian CRC32 of each compressed chunk record is
+          recomputed over the compressed payload and asserted equal to the stored
+          CRC, exactly as CompressedSequentialWriter.java writes it. The corruption
+          lane (compression_info_strict_corruption_fails_closed) flips a payload
+          byte and a CRC byte and proves both fail closed.
+    fixtures:
+      references:
+        - test-data/datasets/sstables/test_basic/compression_test_table-6ad6ad30a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl
+    evidence:
+      type: byte_for_byte
+      strict: true
+      artifacts: [bytes, checksums]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb]
+      fixture_generation_command: >-
+        bash test-data/scripts/regenerate-datasets.sh  # cassandra:5.0.2 writes inline chunk CRCs
+      comparison_command: >-
+        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        --features write-support --test sstable_parity_compression_info_test
+      reference_paths:
+        - test-data/datasets/sstables/test_basic/compression_test_table-6ad6ad30a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl
+      failure_artifacts:
+        - target/cassandra-parity/compression-info-chunk-crc-mismatch.log
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/sstabledump-parity-gate.yml
+    scope: {}
+
+  - id: cass.compression_info.StandardCompressedChunkReaderTest.round_trip_chunk_bytes
+    title: Compressed chunk payload + CRC round-trip byte parity
+    status: mirrored
+    capability: compression_checksum
+    priority: P0
+    risk: p0_data_loss
+    cassandra:
+      category: compression
+      relevance: high
+      files:
+        - CompressedRandomAccessReaderTest.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_compression_info_chunks
+        tests:
+          - cqlite-core/tests/sstable_parity_compression_info_test.rs
+        notes: >-
+          Each compressed chunk record [payload][4-byte CRC] is walked from the
+          offset table against the real Data.db bytes; the payload+CRC framing is
+          validated byte-for-byte across 350+ chunks of the committed corpus.
+    fixtures:
+      references:
+        - test-data/datasets/sstables/test_basic/compression_test_table-6ad6ad30a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl
+    evidence:
+      type: byte_for_byte
+      strict: true
+      artifacts: [bytes, checksums]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb]
+      fixture_generation_command: >-
+        bash test-data/scripts/regenerate-datasets.sh  # cassandra:5.0.2 writes Data.db chunks
+      comparison_command: >-
+        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        --features write-support --test sstable_parity_compression_info_test
+      reference_paths:
+        - test-data/datasets/sstables/test_basic/compression_test_table-6ad6ad30a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl
+      failure_artifacts:
+        - target/cassandra-parity/compression-info-round-trip-mismatch.log
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/sstabledump-parity-gate.yml
+    scope: {}
+
+  - id: cass.compression_info.CompressedInputStreamTest.truncated_chunk_detection
+    title: Truncated compressed chunk fail-closed parity
+    status: mirrored
+    capability: compression_checksum
+    priority: P0
+    risk: p0_data_loss
+    cassandra:
+      category: corruption-recovery
+      relevance: high
+      files:
+        - CompressedInputStreamTest.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_compression_info_chunks
+        tests:
+          - cqlite-core/tests/sstable_parity_compression_info_test.rs
+        notes: >-
+          The corruption lane (compression_info_strict_corruption_fails_closed)
+          truncates the final chunk record below its 4-byte CRC trailer, drops a
+          declared chunk offset, and corrupts the CompressionInfo.db header, proving
+          parse and the strict chunk gate fail closed rather than silently accepting
+          truncated input.
+    fixtures:
+      references:
+        - test-data/datasets/sstables/test_basic/compression_test_table-6ad6ad30a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl
+    evidence:
+      type: byte_for_byte
+      strict: true
+      artifacts: [bytes, checksums]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb]
+      fixture_generation_command: >-
+        bash test-data/scripts/regenerate-datasets.sh  # cassandra:5.0.2 writes Data.db chunks
+      comparison_command: >-
+        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        --features write-support --test sstable_parity_compression_info_test
+      reference_paths:
+        - test-data/datasets/sstables/test_basic/compression_test_table-6ad6ad30a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl
+      failure_artifacts:
+        - target/cassandra-parity/compression-info-truncated-chunk.log
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/sstabledump-parity-gate.yml
+    scope: {}
+
+  - id: cass.compression_info.lz4.real_fixture_chunks
+    title: LZ4Compressor real-fixture chunk + CRC parity
+    status: mirrored
+    capability: compression_checksum
+    priority: P0
+    risk: p0_data_loss
+    cassandra:
+      category: compression
+      relevance: high
+      files:
+        - CompressionMetadataTest.java
+        - CompressedRandomAccessReaderTest.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_compression_info_chunks
+        tests:
+          - cqlite-core/tests/sstable_parity_compression_info_test.rs
+        notes: >-
+          The corpus carries 76 LZ4Compressor CompressionInfo.db fixtures. The lane
+          fails closed if no LZ4 metadata is compared or no LZ4 Data.db chunks are
+          CRC-validated when the binaries are present.
+    fixtures:
+      references:
+        - test-data/datasets/sstables/test_basic/compression_test_table-6ad6ad30a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl
+    evidence:
+      type: byte_for_byte
+      strict: true
+      artifacts: [bytes, offsets, checksums]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb]
+      fixture_generation_command: >-
+        bash test-data/scripts/regenerate-datasets.sh  # cassandra:5.0.2 with LZ4Compressor
+      comparison_command: >-
+        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        --features write-support --test sstable_parity_compression_info_test
+      reference_paths:
+        - test-data/datasets/sstables/test_basic/compression_test_table-6ad6ad30a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl
+      failure_artifacts:
+        - target/cassandra-parity/compression-info-lz4-mismatch.log
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/sstabledump-parity-gate.yml
+    scope: {}
+
+  - id: cass.compression_info.snappy.real_fixture_chunks
+    title: SnappyCompressor real-fixture chunk + CRC parity
+    status: mirrored
+    capability: compression_checksum
+    priority: P0
+    risk: p0_data_loss
+    cassandra:
+      category: compression
+      relevance: high
+      files:
+        - CompressionMetadataTest.java
+        - CompressedRandomAccessReaderTest.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_compression_info_chunks
+        tests:
+          - cqlite-core/tests/sstable_parity_compression_info_test.rs
+        notes: >-
+          The corpus carries 15 SnappyCompressor CompressionInfo.db fixtures. The
+          lane fails closed if no Snappy metadata is compared or no Snappy Data.db
+          chunks are CRC-validated when the binaries are present.
+    fixtures:
+      references:
+        - test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl
+    evidence:
+      type: byte_for_byte
+      strict: true
+      artifacts: [bytes, offsets, checksums]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb]
+      fixture_generation_command: >-
+        bash test-data/scripts/regenerate-datasets.sh  # cassandra:5.0.2 with SnappyCompressor
+      comparison_command: >-
+        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        --features write-support --test sstable_parity_compression_info_test
+      reference_paths:
+        - test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl
+      failure_artifacts:
+        - target/cassandra-parity/compression-info-snappy-mismatch.log
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/sstabledump-parity-gate.yml
+    scope: {}
+
+  - id: cass.compression_info.deflate.real_fixture_chunks
+    title: DeflateCompressor real-fixture chunk + CRC parity (no fixture available)
+    status: planned
+    capability: compression_checksum
+    priority: P2
+    risk: p2_coverage
+    cassandra:
+      category: compression
+      relevance: med
+      files:
+        - CompressionMetadataTest.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_compression_info_chunks
+        tests:
+          - cqlite-core/tests/sstable_parity_compression_info_test.rs
+        notes: >-
+          CQLite decodes DeflateCompressor, but the committed corpus carries NO
+          Cassandra-written Deflate fixture. The lane classifies Deflate explicitly
+          as no-fixture-available and logs it rather than faking synthetic reference
+          data — no byte_for_byte claim is made.
+    fixtures: {}
+    evidence:
+      type: out_of_scope
+      known_limitations: >-
+        No Cassandra-generated DeflateCompressor SSTable exists in the corpus
+        (only LZ4Compressor and SnappyCompressor). Parity is unproven until such a
+        fixture is added.
+    ci:
+      tier: manual_debug
+    scope:
+      target_issue: 986
+      target_suite: sstable_parity_compression_info_chunks
+      gap: >-
+        No real DeflateCompressor CompressionInfo.db / Data.db fixture in the
+        committed corpus, so chunk + CRC parity cannot be byte-compared.
+      next_step: >-
+        Generate a DeflateCompressor SSTable via regenerate-datasets.sh and let the
+        existing test exercise it (the codec dispatch already handles it).
+
+  - id: cass.compression_info.zstd.real_fixture_chunks
+    title: ZstdCompressor real-fixture chunk + CRC parity (no fixture available)
+    status: planned
+    capability: compression_checksum
+    priority: P2
+    risk: p2_coverage
+    cassandra:
+      category: compression
+      relevance: med
+      files:
+        - CompressionMetadataTest.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_compression_info_chunks
+        tests:
+          - cqlite-core/tests/sstable_parity_compression_info_test.rs
+        notes: >-
+          CQLite decodes ZstdCompressor, but the committed corpus carries NO
+          Cassandra-written Zstd fixture. The lane classifies Zstd explicitly as
+          no-fixture-available and logs it rather than faking synthetic reference
+          data — no byte_for_byte claim is made. Zstd dictionary compression remains
+          out of scope per issue #986.
+    fixtures: {}
+    evidence:
+      type: out_of_scope
+      known_limitations: >-
+        No Cassandra-generated ZstdCompressor SSTable exists in the corpus (only
+        LZ4Compressor and SnappyCompressor). Parity is unproven until such a fixture
+        is added; Zstd dictionary compression stays out of scope.
+    ci:
+      tier: manual_debug
+    scope:
+      target_issue: 986
+      target_suite: sstable_parity_compression_info_chunks
+      gap: >-
+        No real ZstdCompressor CompressionInfo.db / Data.db fixture in the
+        committed corpus, so chunk + CRC parity cannot be byte-compared.
+      next_step: >-
+        Generate a ZstdCompressor SSTable via regenerate-datasets.sh and let the
+        existing test exercise it (the codec dispatch already handles it).
+
   # ----------------------------------------------------------------------------
   # corruption_verify
   # ----------------------------------------------------------------------------
@@ -1681,6 +2357,270 @@ scenarios:
       next_step: >-
         Add a Filter.db serialization parity test asserting zero false negatives
         across the present-key set.
+
+  # ----------------------------------------------------------------------------
+  # filter_db — strict Filter.db Bloom parity (issue #987 / epic #968)
+  # ----------------------------------------------------------------------------
+  - id: cass.filter_db.no_false_negative_membership
+    title: Filter.db no-false-negative membership over Cassandra present keys
+    status: mirrored
+    capability: filter_db_bloom
+    priority: P0
+    risk: p0_data_loss
+    cassandra:
+      category: bloom-filter
+      relevance: high
+      files:
+        - BloomFilterTest.java
+        - LongBloomFilterTest.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_filter_db_bloom
+        tests:
+          - cqlite-core/tests/sstable_parity_filter_db_test.rs
+        notes: >-
+          Strict, fail-closed lane (filter_db_strict_parameters_and_no_false_negative).
+          For every committed BIG Filter.db it independently re-reads the on-disk
+          header ([hash_count: i32 BE][num_longs: i32 BE][bitset: num_longs*8 bytes],
+          BloomFilterSerializer over OffHeapBitSet), asserts CQLite's decoded
+          hash_count / bit_count match the bytes, then enumerates EVERY raw partition
+          key Cassandra wrote (from the sibling Index.db key_digest, which holds the
+          raw key bytes per Issue #552 — the exact bytes Cassandra hashed) and asserts
+          the filter reports "maybe present" for all of them. A single false negative
+          fails the lane. Absent-key probes (deterministic, __cqlite_absent__-prefixed)
+          count and REPORT false positives without gating, since false positives are
+          legal for a Bloom filter.
+    fixtures:
+      datasets:
+        - test-data/datasets/sstables
+    evidence:
+      type: byte_for_byte
+      strict: true
+      artifacts: [bytes, component_files]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb, oa, da]
+      fixture_generation_command: >-
+        bash test-data/scripts/regenerate-datasets.sh  # cassandra:5.0.2 flush emits Filter.db
+      comparison_command: >-
+        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        --features write-support --test sstable_parity_filter_db_test
+        filter_db_strict_parameters_and_no_false_negative
+      normalization: >-
+        Present keys are the raw partition-key bytes from Index.db (not the decoded
+        CQL values), matching the bytes Cassandra's Murmur3 hashed into Filter.db.
+        The reference_paths point at the committed per-fixture Data.db.jsonl siblings
+        (the binary Filter.db and Index.db are gitignored, fetched on demand).
+      reference_paths:
+        - test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl
+        - test-data/datasets/sstables/test_basic/composite_key_table-6ab56990a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl
+      failure_artifacts:
+        - target/cassandra-parity/filter-db-false-negative.log
+      known_limitations: >-
+        The no-false-negative gate runs over BIG fixtures, whose Index.db exposes the
+        raw partition keys. BTI (da) fixtures have no Index.db and their Partitions.db
+        trie stores byte-comparable, hash-routed keys that do not expose the raw key
+        bytes, so BTI membership is tracked separately (cass.filter_db.bti_membership).
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/sstabledump-parity-gate.yml
+    scope: {}
+
+  - id: cass.filter_db.serialization_round_trip
+    title: Filter.db byte-exact serialization round-trip and parameter decode
+    status: mirrored
+    capability: filter_db_bloom
+    priority: P0
+    risk: p1_correctness
+    cassandra:
+      category: bloom-filter
+      relevance: high
+      files:
+        - BloomFilterSerializerTest.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_filter_db_bloom
+        tests:
+          - cqlite-core/tests/sstable_parity_filter_db_test.rs
+        notes: >-
+          For every committed Filter.db (BIG and BTI), the strict lane decodes the
+          Bloom filter and re-serializes it, asserting the re-emitted bytes are
+          byte-for-byte identical to the on-disk component (header + bitset), and that
+          the decoded hash_count / num_longs equal the on-disk header values. This is
+          the write-side parity that lets CQLite re-emit a Cassandra-faithful Filter.db.
+    fixtures:
+      datasets:
+        - test-data/datasets/sstables
+    evidence:
+      type: byte_for_byte
+      strict: true
+      artifacts: [bytes, component_files]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb, oa, da]
+      fixture_generation_command: >-
+        bash test-data/scripts/regenerate-datasets.sh  # cassandra:5.0.2 flush emits Filter.db
+      comparison_command: >-
+        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        --features write-support --test sstable_parity_filter_db_test
+        filter_db_strict_parameters_and_no_false_negative
+      reference_paths:
+        - test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl
+        - test-data/datasets/sstables/test_da/simple_table-de1be8b064e711f19ad401a8c8227b11/da-2-bti-Data.db.jsonl
+      failure_artifacts:
+        - target/cassandra-parity/filter-db-roundtrip.log
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/sstabledump-parity-gate.yml
+    scope: {}
+
+  - id: cass.filter_db.corruption_fails_closed
+    title: Filter.db malformed-byte rejection (fail-closed)
+    status: mirrored
+    capability: filter_db_bloom
+    priority: P0
+    risk: p1_correctness
+    cassandra:
+      category: bloom-filter
+      relevance: med
+      files:
+        - BloomFilterSerializerTest.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_filter_db_bloom
+        tests:
+          - cqlite-core/tests/sstable_parity_filter_db_test.rs
+        notes: >-
+          filter_db_strict_corruption_fails_closed asserts the decoder rejects (never
+          fabricates, never unwrap-panics) empty buffers, header-only truncation, a
+          partial bitset, trailing bytes beyond the declared bitset, and — when a real
+          fixture is present — a fixture whose num_longs header is corrupted so the
+          declared bitset length no longer matches the buffer.
+    fixtures:
+      datasets:
+        - test-data/datasets/sstables
+    evidence:
+      type: byte_for_byte
+      strict: true
+      artifacts: [bytes]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb, oa, da]
+      fixture_generation_command: >-
+        bash test-data/scripts/regenerate-datasets.sh  # cassandra:5.0.2 flush emits Filter.db
+      comparison_command: >-
+        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        --features write-support --test sstable_parity_filter_db_test
+        filter_db_strict_corruption_fails_closed
+      reference_paths:
+        - test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl
+      failure_artifacts:
+        - target/cassandra-parity/filter-db-corruption.log
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/sstabledump-parity-gate.yml
+    scope: {}
+
+  - id: cass.filter_db.bti_membership
+    title: BTI (da) Filter.db no-false-negative membership
+    status: partial
+    capability: filter_db_bloom
+    priority: P1
+    risk: p1_correctness
+    cassandra:
+      category: bloom-filter
+      relevance: med
+      files:
+        - BloomFilterTest.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_filter_db_bloom
+        tests:
+          - cqlite-core/tests/sstable_parity_filter_db_test.rs
+        notes: >-
+          BTI (da) Filter.db is covered for parameter-decode + byte-exact round-trip
+          by the strict lane, and filter_db_format_coverage_classification records the
+          BTI fixture count explicitly. The no-false-negative membership gate does NOT
+          yet run for BTI because its Partitions.db trie stores byte-comparable,
+          hash-routed keys and exposes no raw partition-key bytes to probe with.
+    fixtures:
+      datasets:
+        - test-data/datasets/sstables
+    evidence:
+      type: partial
+      artifacts: [bytes, component_files]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [da]
+      fixture_generation_command: >-
+        bash test-data/scripts/regenerate-datasets.sh  # cassandra:5.0.2 BTI flush emits da Filter.db
+      known_limitations: >-
+        BTI fixtures lack Index.db; the BTI Partitions.db trie does not expose raw
+        partition keys, so BTI Filter.db membership is verified for parameter decode
+        and serialization round-trip only, not the no-false-negative probe.
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/sstabledump-parity-gate.yml
+    scope:
+      gap: >-
+        No raw-partition-key source for BTI fixtures, so the no-false-negative probe
+        cannot run against da Filter.db.
+      next_step: >-
+        Recover raw BTI partition keys (e.g. by decoding partitions during a Data.db
+        scan) and extend the no-false-negative gate to cover da fixtures.
+
+  - id: cass.filter_db.statistical_false_positive_rate
+    title: Filter.db empirical false-positive-rate report
+    status: planned
+    capability: filter_db_bloom
+    priority: P2
+    risk: p2_coverage
+    cassandra:
+      category: bloom-filter
+      relevance: low
+      files:
+        - LongBloomFilterTest.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_filter_db_bloom
+        tests:
+          - cqlite-core/tests/sstable_parity_filter_db_test.rs
+        notes: >-
+          filter_db_statistical_false_positive_rate_slow probes a large deterministic
+          absent-key sample (50k keys, fixed seed + per-fixture salt) and reports the
+          measured FPR per fixture, asserting only a generous saturation ceiling
+          (< 0.50). It is gated behind CQLITE_FILTER_FPR_SLOW=1 so the required lane
+          stays fast — false positives are legal and never a correctness failure.
+    fixtures:
+      datasets:
+        - test-data/datasets/sstables
+    evidence:
+      type: smoke
+      artifacts: [logs]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb, oa, da]
+      fixture_generation_command: >-
+        bash test-data/scripts/regenerate-datasets.sh  # cassandra:5.0.2 flush emits Filter.db
+      comparison_command: >-
+        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets CQLITE_FILTER_FPR_SLOW=1
+        cargo test -p cqlite-core --features write-support
+        --test sstable_parity_filter_db_test
+        filter_db_statistical_false_positive_rate_slow -- --nocapture
+      known_limitations: >-
+        The measured FPR is reported, not gated against Cassandra's target fp_chance,
+        because the committed fixtures are tiny (single-long bitsets) where the
+        analytic FPR is dominated by quantization, not the configured fp_chance.
+    ci:
+      tier: manual_debug
+    scope:
+      target_issue: 987
+      gap: >-
+        No gated comparison of measured FPR against Cassandra's configured
+        bloom_filter_fp_chance.
+      next_step: >-
+        Add larger-cardinality fixtures and assert the measured FPR tracks the
+        configured fp_chance within a documented statistical tolerance.
 
   # ----------------------------------------------------------------------------
   # tombstone_ttl


### PR DESCRIPTION
Wave 2 of Epic #968 (SSTable Component Byte Parity). Closes #986, #987, #988, #1048.

Three strict parity lanes + a format-detector consistency fix, all wired into the required `sstabledump-parity-gate` workflow. Manifest unioned to **100 scenarios** (19 new), report regenerated.

## #986 — CompressionInfo.db strict metadata + chunk-boundary parity
- `sstable_parity_compression_info_test`: 91 `*-CompressionInfo.db` compared (76 LZ4, 15 Snappy), 356 inline `Data.db` chunk CRCs validated.
- Compressor name/options, chunk length/count, ordered chunk offsets, compressed/uncompressed sizes, final partial chunk. Negative tests fail closed (corrupt CompressionInfo / corrupt chunk).
- Deflate/Zstd: honestly classified `planned` (no fixture in corpus — never faked).
- Guard: Data.db present + zero CompressionInfo compared now **fails** (partial-fetch detection), not a green skip.

## #987 — Filter.db bloom serialization + no-false-negative parity
- `sstable_parity_filter_db_test`: all present partition keys probed across fixtures → **zero false negatives**; absent-key false positives reported separately. Statistical FPR check gated behind `CQLITE_FILTER_FPR_SLOW`.
- Hardened `BloomFilter::deserialize`: header counts parsed as **i32**, rejecting `<= 0` (negative/zero) and an absurd-positive upper bound (`hash_count > 1024`) — closes a fail-open / pathological-`contains()` DoS on malformed headers.

## #988 — Statistics.db repaired-metadata sub-lane
- New read-path parser `parser/repair_metadata.rs`. STATS cursor bounded by the **next component offset minus the 4-byte per-component CRC32** (verified empirically against nb/oa/da fixtures), failing closed on overrun/truncation/malformed TOC.
- Decodes `repaired_at`; reports undecoded `pending_repair`/`is_transient` as `RepairField::Unparsed` (no silent misreport). **Preservation/reporting only — does not imply repair-aware compaction or tombstone purging.**

## #1048 — CRC.db in `format_detector::SSTableComponent`
- `from_filename` + `suffix` recognize `CRC.db` (uncompressed SSTables), matching the directory component model. Unit test covers round-trip in both models.

## Validation
- `agent-gate`: fmt PASS, clippy PASS (`-D warnings`, workspace/all-targets/all-features), all parity + integration + write + cli + python + minimal-build + smoke PASS. (Sole flake: `test_flush_throughput` perf threshold — pre-existing, passes on retry; unrelated to these changes.)
- `cassandra-parity lint`: OK — 100 scenarios, 0 errors. `report --check`: up to date.
- roborev: clean (job 1310, no issues) after iterative review.