### PR TITLE
fix(reader): decode non-frozen (multicell) top-level UDT as structured UDT (#1081)

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
@@ -7822,9 +7822,16 @@ impl V5CompressedLegacyParser {
     /// form (`"int"`) understood by [`parse_value_from_raw_bytes`]'s match
     /// (issue #1081). Returns `None` for any non-primitive marshal form
     /// (UserType / collection / tuple / reversed / frozen / custom), so the
-    /// caller leaves those to the dedicated arms. The suffix set mirrors the
-    /// authoritative marshal→`CqlType` mapping in
-    /// [`parse_cassandra_type_with_depth`] (no heuristics — issue #28).
+    /// caller leaves those to the dedicated arms. The suffix set is a *superset*
+    /// of the authoritative marshal→`CqlType` mapping in
+    /// [`parse_cassandra_type_with_depth`] (no heuristics — issue #28): in
+    /// addition to the scalars that mapping enumerates, this also normalizes a
+    /// few marshal forms that `parse_cassandra_type_with_depth` routes to
+    /// `Custom` (`VarcharType`, `CounterColumnType`, `LexicalUUIDType`,
+    /// `ShortType`, `ByteType`). Those extra mappings are required so we can
+    /// decode the corresponding scalar UDT field values — e.g. `ShortType`/
+    /// `ByteType` are needed to read `smallint`/`tinyint` UDT fields, which
+    /// otherwise fall through to the blob default.
     fn primitive_marshal_to_cql_short(marshal_type: &str) -> Option<&'static str> {
         // Composite marshal forms carry a `(` after the type name; primitives do
         // not. Reject anything parameterised so we never misread a collection /
@@ -10133,6 +10140,65 @@ impl V5CompressedLegacyParser {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Issue #1081: `primitive_marshal_to_cql_short` must normalize every
+    /// PRIMITIVE Cassandra marshal type (fully-qualified) to its canonical CQL
+    /// short form, and must reject any parameterised/composite marshal form
+    /// (anything containing `(` — UDT / collection / reversed) so the
+    /// no-heuristics `(`-rejection guard never misreads a composite as a scalar.
+    #[test]
+    fn primitive_marshal_to_cql_short_maps_scalars_and_rejects_composites() {
+        const P: &str = "org.apache.cassandra.db.marshal.";
+
+        // (marshal type name, expected canonical CQL short form)
+        let cases: &[(&str, &str)] = &[
+            ("UTF8Type", "text"),
+            ("AsciiType", "ascii"),
+            ("Int32Type", "int"),
+            ("LongType", "bigint"),
+            ("FloatType", "float"),
+            ("DoubleType", "double"),
+            ("BooleanType", "boolean"),
+            ("UUIDType", "uuid"),
+            ("TimeUUIDType", "timeuuid"),
+            ("TimestampType", "timestamp"),
+            ("SimpleDateType", "date"),
+            ("TimeType", "time"),
+            ("DecimalType", "decimal"),
+            ("IntegerType", "varint"),
+            ("ShortType", "smallint"),
+            ("ByteType", "tinyint"),
+            ("InetAddressType", "inet"),
+            ("BytesType", "blob"),
+        ];
+
+        for (marshal, expected) in cases {
+            let full = format!("{}{}", P, marshal);
+            assert_eq!(
+                V5CompressedLegacyParser::primitive_marshal_to_cql_short(&full),
+                Some(*expected),
+                "primitive marshal {} should map to {}",
+                full,
+                expected
+            );
+        }
+
+        // Parameterised / composite marshal forms must be rejected (return None)
+        // by the `(`-guard, leaving them to the dedicated composite arms.
+        let composites = [
+            "org.apache.cassandra.db.marshal.UserType(...)",
+            "org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.UTF8Type)",
+            "org.apache.cassandra.db.marshal.ReversedType(org.apache.cassandra.db.marshal.Int32Type)",
+        ];
+        for composite in composites {
+            assert_eq!(
+                V5CompressedLegacyParser::primitive_marshal_to_cql_short(composite),
+                None,
+                "composite marshal {} must be rejected by the `(`-guard",
+                composite
+            );
+        }
+    }
 
     /// Local VInt encoder for test helpers — avoids depending on
     /// `storage::serialization` which is gated behind `write-support`.

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
@@ -7858,12 +7858,19 @@ impl V5CompressedLegacyParser {
             "timeuuid"
         } else if s.ends_with("UUIDType") || s.ends_with("LexicalUUIDType") {
             "uuid"
+        } else if s.ends_with("SimpleDateType") {
+            // CQL `date` (`SimpleDateType`) is a 4-byte unsigned days-since-epoch
+            // value. This is distinct from the legacy `DateType` handled below.
+            "date"
+        } else if s.ends_with("DateType") {
+            // Legacy Cassandra `DateType` is an 8-byte millis-since-epoch value —
+            // the same wire format as `TimestampType`. Mapping it to `date` would
+            // wrongly decode only the first 4 bytes, so route it to `timestamp`.
+            // NOTE: this `ends_with` arm must follow the `SimpleDateType` arm above
+            // because `SimpleDateType` also ends with `DateType`.
+            "timestamp"
         } else if s.ends_with("TimestampType") {
             "timestamp"
-        } else if s.ends_with("SimpleDateType") || s.ends_with("DateType") {
-            // Note: legacy `DateType` (millis-since-epoch) is intentionally mapped
-            // to `date`; modern UDT fields use `SimpleDateType`. Both are 4-byte.
-            "date"
         } else if s.ends_with("TimeType") {
             "time"
         } else if s.ends_with("DecimalType") {
@@ -7923,6 +7930,18 @@ impl V5CompressedLegacyParser {
             }
         }
 
+        // Preserve the ORIGINAL-CASE type string. Below, the `match` scrutinee is
+        // `type_str.to_lowercase()` and each `type_str if ...` arm binding SHADOWS
+        // the function parameter with the lowercased string. The collection/tuple/
+        // frozen extraction helpers slice their element/inner types out of the
+        // string they are handed, so if we passed the lowercased binding the nested
+        // element marshal type would come back lowercased (e.g. `...int32type`) and
+        // would NOT re-normalize via the CASE-SENSITIVE `primitive_marshal_to_cql_short`
+        // suffix match, wrongly falling through to blob. The marshal-form arms below
+        // therefore extract from `raw_type_str` (original case) so nested element
+        // marshal types keep their case. The CQL-short-form arms are unaffected
+        // because their inner types are already canonical lowercase.
+        let raw_type_str = type_str;
         let normalized_type = type_str.to_lowercase();
         match normalized_type.as_str() {
             "text"
@@ -8078,9 +8097,23 @@ impl V5CompressedLegacyParser {
                 Ok(Value::Decimal { scale, unscaled })
             }
             "inet" => Ok(Value::Inet(data.to_vec())),
-            // Nested list/set/map inside a bounded element (e.g. map<text, list<int>>)
-            type_str if type_str.starts_with("list<") => {
-                let element_type = self.extract_collection_element_type(type_str, "list")?;
+            // Nested list/set/map inside a bounded element (e.g. map<text, list<int>>).
+            //
+            // Issue #1081: the guards accept BOTH the CQL short form (`list<...>`)
+            // and the authoritative Cassandra marshal form
+            // (`org.apache.cassandra.db.marshal.ListType(...)`). Multicell-UDT field
+            // values resolve their field types from the on-disk `UserType(...)`
+            // marshal string, so a collection-typed UDT field arrives here in marshal
+            // form and would otherwise fall through to the blob default. The
+            // extraction helpers (`extract_collection_element_type` / `extract_map_types`)
+            // already accept marshal forms; we extract from `raw_type_str`
+            // (original case) so the returned nested element marshal type keeps its
+            // case and re-normalizes correctly on recursion (see note above).
+            type_str
+                if type_str.starts_with("list<")
+                    || type_str.starts_with("org.apache.cassandra.db.marshal.listtype(") =>
+            {
+                let element_type = self.extract_collection_element_type(raw_type_str, "list")?;
                 let (val, _) = self.parse_frozen_list_value_raw(
                     data,
                     0,
@@ -8090,8 +8123,11 @@ impl V5CompressedLegacyParser {
                 )?;
                 Ok(val)
             }
-            type_str if type_str.starts_with("set<") => {
-                let element_type = self.extract_collection_element_type(type_str, "set")?;
+            type_str
+                if type_str.starts_with("set<")
+                    || type_str.starts_with("org.apache.cassandra.db.marshal.settype(") =>
+            {
+                let element_type = self.extract_collection_element_type(raw_type_str, "set")?;
                 let (val, _) = self.parse_frozen_set_value_raw(
                     data,
                     0,
@@ -8101,8 +8137,11 @@ impl V5CompressedLegacyParser {
                 )?;
                 Ok(val)
             }
-            type_str if type_str.starts_with("map<") => {
-                let (key_type, value_type) = self.extract_map_types(type_str)?;
+            type_str
+                if type_str.starts_with("map<")
+                    || type_str.starts_with("org.apache.cassandra.db.marshal.maptype(") =>
+            {
+                let (key_type, value_type) = self.extract_map_types(raw_type_str)?;
                 let (val, _) = self.parse_frozen_map_value_raw(
                     data,
                     0,
@@ -8117,8 +8156,13 @@ impl V5CompressedLegacyParser {
             // The caller (read_frozen_element) has already extracted the raw element bytes
             // into `data`, so there is no outer VUInt length here — just the sequence of
             // [i32 BE len][bytes] fields as written by serialize_value for Value::Tuple.
-            type_str if type_str.starts_with("tuple<") => {
-                let element_types = self.extract_tuple_element_types(type_str)?;
+            // Issue #1081: also accept the marshal form `TupleType(...)`, extracting
+            // element types from the original-case `raw_type_str`.
+            type_str
+                if type_str.starts_with("tuple<")
+                    || type_str.starts_with("org.apache.cassandra.db.marshal.tupletype(") =>
+            {
+                let element_types = self.extract_tuple_element_types(raw_type_str)?;
                 if element_types.is_empty() {
                     return Err(Error::schema(format!(
                         "Nested tuple element '{}': empty tuple type",
@@ -8137,8 +8181,13 @@ impl V5CompressedLegacyParser {
                 )?;
                 Ok(Value::Tuple(elements))
             }
+            // Issue #1081: `frozen<...>` has no distinct marshal form (the marshal
+            // string carries the inner composite directly, e.g. `ListType(...)`
+            // for a frozen collection, which the arms above already handle). Only
+            // the CQL short form needs handling here; extract from `raw_type_str`
+            // to preserve the inner type's case on recursion.
             type_str if type_str.starts_with("frozen<") => {
-                let inner_type = self.extract_frozen_inner_type(type_str)?;
+                let inner_type = self.extract_frozen_inner_type(raw_type_str)?;
                 let inner =
                     self.parse_value_from_raw_bytes(data, &inner_type, column_name, depth + 1)?;
                 Ok(Value::Frozen(Box::new(inner)))
@@ -10014,36 +10063,52 @@ impl V5CompressedLegacyParser {
         Ok(elements)
     }
 
-    /// Extract tuple element types from tuple<T1, T2, ...> string
+    /// Extract tuple element types from a `tuple<T1, T2, ...>` (CQL short) or
+    /// `org.apache.cassandra.db.marshal.TupleType(T1, T2, ...)` (Cassandra marshal)
+    /// type string. Marshal support (issue #1081) is required so a tuple-typed
+    /// multicell-UDT field, whose type arrives in marshal form, decodes its
+    /// elements instead of falling through to the blob default.
     fn extract_tuple_element_types(&self, type_str: &str) -> Result<Vec<String>> {
-        if !type_str.starts_with("tuple<") || !type_str.ends_with('>') {
+        let type_lower = type_str.to_lowercase();
+
+        // Determine the inner element-list content based on format. Slice from the
+        // ORIGINAL-CASE `type_str` so nested element marshal types keep their case.
+        let inner = if type_lower.starts_with("org.apache.cassandra.db.marshal.tupletype(")
+            && type_str.ends_with(')')
+        {
+            let prefix = "org.apache.cassandra.db.marshal.TupleType(";
+            &type_str[prefix.len()..type_str.len() - 1]
+        } else if type_lower.starts_with("tuple<") && type_str.ends_with('>') {
+            &type_str[6..type_str.len() - 1]
+        } else {
             return Err(Error::schema(format!(
                 "Invalid tuple type format: {}",
                 type_str
             )));
-        }
+        };
 
-        let inner = &type_str[6..type_str.len() - 1];
         if inner.is_empty() {
             return Ok(Vec::new());
         }
 
-        // Split by comma, handling nested angle brackets
+        // Split by top-level comma, handling both CQL angle brackets (`<`/`>`)
+        // and marshal parentheses (`(`/`)`) so nested composite element types
+        // (e.g. `ListType(UTF8Type)`) are not split internally.
         let mut types = Vec::new();
         let mut current = String::new();
-        let mut depth = 0;
+        let mut depth = 0i32;
 
         for ch in inner.chars() {
             match ch {
-                '<' => {
+                '<' | '(' => {
                     depth += 1;
                     current.push(ch);
                 }
-                '>' => {
+                '>' | ')' => {
                     if depth == 0 {
                         return Err(Error::schema(format!(
-                            "Unmatched '>' in tuple type: {}",
-                            type_str
+                            "Unmatched '{}' in tuple type: {}",
+                            ch, type_str
                         )));
                     }
                     depth -= 1;
@@ -10163,6 +10228,10 @@ mod tests {
             ("TimeUUIDType", "timeuuid"),
             ("TimestampType", "timestamp"),
             ("SimpleDateType", "date"),
+            // Legacy `DateType` is an 8-byte millis-since-epoch value (same wire
+            // format as `TimestampType`), NOT the 4-byte CQL `date`
+            // (`SimpleDateType`). It must normalize to `timestamp`.
+            ("DateType", "timestamp"),
             ("TimeType", "time"),
             ("DecimalType", "decimal"),
             ("IntegerType", "varint"),
@@ -10629,6 +10698,105 @@ mod tests {
                 Value::Integer(100),
                 Value::Integer(200)
             ])))
+        );
+    }
+
+    /// Helper: build a frozen list<text> raw binary in the same
+    /// `[i32 BE count]` + per-element `[i32 BE len][utf8 bytes]` framing that
+    /// `parse_frozen_list_value_raw` expects for an already-bounded element.
+    fn build_frozen_list_text(values: &[&str]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&(values.len() as i32).to_be_bytes());
+        for v in values {
+            let b = v.as_bytes();
+            buf.extend_from_slice(&(b.len() as i32).to_be_bytes());
+            buf.extend_from_slice(b);
+        }
+        buf
+    }
+
+    /// Issue #1081 (FINDING 1): a multicell-UDT field whose declared type arrives
+    /// in Cassandra MARSHAL form for a COLLECTION — here
+    /// `ListType(UTF8Type)` — must decode to a real `Value::List`, NOT fall
+    /// through to the blob default. This also exercises the case-sensitivity
+    /// path: the lowercased match binding must NOT corrupt the original-case
+    /// nested element marshal type (`UTF8Type`), which would otherwise fail to
+    /// re-normalize and blob.
+    #[test]
+    fn test_parse_value_from_raw_bytes_marshal_list_utf8() {
+        let parser =
+            V5CompressedLegacyParser::new("test".to_string(), "table".to_string(), 0, 0, None);
+
+        let data = build_frozen_list_text(&["alpha", "beta"]);
+        let val = parser
+            .parse_value_from_raw_bytes(
+                &data,
+                "org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.UTF8Type)",
+                "udt_field",
+                0,
+            )
+            .expect("marshal ListType(UTF8Type) must decode, not blob");
+        assert_eq!(
+            val,
+            Value::List(vec![
+                Value::Text("alpha".to_string()),
+                Value::Text("beta".to_string()),
+            ]),
+            "marshal-form list field must produce a List of Text (not a Blob)"
+        );
+    }
+
+    /// Issue #1081 (FINDING 1): a multicell-UDT field declared as a marshal-form
+    /// `MapType(UTF8Type, Int32Type)` must decode to a `Value::Map`. The
+    /// Int32Type VALUE proves the nested element marshal type keeps its original
+    /// case through the lowercased match arm (a lowercased `...int32type` would
+    /// fail the case-sensitive primitive normalizer and blob).
+    #[test]
+    fn test_parse_value_from_raw_bytes_marshal_map_utf8_int32() {
+        let parser =
+            V5CompressedLegacyParser::new("test".to_string(), "table".to_string(), 0, 0, None);
+
+        // Same [count][i32 key_len][key][i32 val_len][i32 value] framing the
+        // frozen map raw parser expects; the int value is a 4-byte i32.
+        let data = build_frozen_map_text_int(&[("alice", 1), ("bob", 2)]);
+        let val = parser
+            .parse_value_from_raw_bytes(
+                &data,
+                "org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.Int32Type)",
+                "udt_field",
+                0,
+            )
+            .expect("marshal MapType(UTF8Type, Int32Type) must decode, not blob");
+        assert_eq!(
+            val,
+            Value::Map(vec![
+                (Value::Text("alice".to_string()), Value::Integer(1)),
+                (Value::Text("bob".to_string()), Value::Integer(2)),
+            ]),
+            "marshal-form map field must produce a Map of (Text, Integer) (not a Blob)"
+        );
+    }
+
+    /// Issue #1081 (FINDING 1): a marshal-form `SetType(Int32Type)` field must
+    /// decode to a `Value::Set` rather than a blob.
+    #[test]
+    fn test_parse_value_from_raw_bytes_marshal_set_int32() {
+        let parser =
+            V5CompressedLegacyParser::new("test".to_string(), "table".to_string(), 0, 0, None);
+
+        let data = build_frozen_list_int(&[7, 9]);
+        let val = parser
+            .parse_value_from_raw_bytes(
+                &data,
+                "org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.Int32Type)",
+                "udt_field",
+                0,
+            )
+            .expect("marshal SetType(Int32Type) must decode, not blob");
+        assert_eq!(
+            val,
+            Value::Set(vec![Value::Integer(7), Value::Integer(9)]),
+            "marshal-form set field must produce a Set of Integer (not a Blob)"
         );
     }
 

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
@@ -5523,8 +5523,12 @@ impl V5CompressedLegacyParser {
             return Ok(inner.to_string());
         }
 
-        // CQL format: frozen<T>
-        if type_str.starts_with("frozen<") && type_str.ends_with('>') {
+        // CQL format: frozen<T> — match the prefix/suffix case-insensitively
+        // (parse_value_from_raw_bytes routes here off a lowercased guard but
+        // passes the ORIGINAL-CASE string, so a mixed-case `Frozen<...>` reaches
+        // this branch and must still be accepted) while slicing from the
+        // original string to preserve nested-type case.
+        if type_lower.starts_with("frozen<") && type_lower.ends_with('>') {
             let inner = &type_str[7..type_str.len() - 1];
             if inner.is_empty() {
                 return Err(Error::schema(format!("Empty frozen type: {}", type_str)));
@@ -10987,6 +10991,13 @@ mod tests {
             "org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.Int32Type)",
             "marshal frozen inner type must be original-case (Int32Type preserved)"
         );
+
+        // Mixed-case CQL spelling must also parse (the prefix/suffix check is
+        // case-insensitive) while the sliced inner keeps its original case.
+        let mixed_inner = parser
+            .extract_frozen_inner_type("Frozen<List<Int>>")
+            .expect("mixed-case Frozen<...> must parse");
+        assert_eq!(mixed_inner, "List<Int>");
     }
 
     #[test]

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
@@ -4076,7 +4076,19 @@ impl V5CompressedLegacyParser {
         //   - Regular rows: bitmap covers only regular columns
         // Including the wrong group shifts all bitmap indices, causing columns to be
         // silently absent or misread.  Filter columns_in_order to the matching kind.
-        let columns_in_order: Vec<_> = if !reader.header.columns.is_empty() {
+        // Issue #1081: each entry pairs the SUPPLIED schema `Column` (which drives
+        // column identity / order) with the AUTHORITATIVE on-disk
+        // SerializationHeader marshal type (`ColumnInfo.column_type`, e.g.
+        // `org.apache.cassandra.db.marshal.UserType(...)`). The on-disk marshal
+        // type is the no-heuristics source of truth (issue #28) used to decide
+        // complex-ness and to decode complex values — the supplied schema's bare
+        // CQL short form (e.g. `person_type`) cannot disambiguate a non-frozen UDT.
+        // It is `None` only on the header-empty fallback path below.
+        let columns_in_order: Vec<(&crate::schema::Column, Option<&str>)> = if !reader
+            .header
+            .columns
+            .is_empty()
+        {
             // Build lookup map from schema for column details
             let schema_map: HashMap<String, &crate::schema::Column> = schema
                 .columns
@@ -4095,7 +4107,12 @@ impl V5CompressedLegacyParser {
                         && !col_info.is_clustering
                         && col_info.is_static == is_static
                 })
-                .filter_map(|col_info| schema_map.get(&col_info.name).copied())
+                .filter_map(|col_info| {
+                    schema_map
+                        .get(&col_info.name)
+                        .copied()
+                        .map(|col| (col, Some(col_info.column_type.as_str())))
+                })
                 .collect()
         } else {
             // Fallback to schema order when header is empty (shouldn't happen for real SSTables)
@@ -4108,41 +4125,47 @@ impl V5CompressedLegacyParser {
                         && !clustering_key_names.contains(col.name.as_str())
                         && col.is_static == is_static // Issue #702: match row kind
                 })
+                .map(|col| (col, None))
                 .collect()
         };
 
         // Filter columns by missing_columns_bitmap when present.
         // The bitmap indicates which columns are MISSING (bit=1 → absent).
         // We only parse cells for columns that are actually present in the data.
-        let columns_to_parse: Vec<&crate::schema::Column> = match row_header.missing_columns_bitmap
-        {
-            Some(bitmap) => {
-                let filtered: Vec<_> = columns_in_order
-                    .iter()
-                    .enumerate()
-                    .filter(|(idx, _)| {
-                        // Bitmap only covers the first 64 columns (u64).
-                        // Columns beyond index 63 are not represented in the
-                        // bitmap and are treated as present.
-                        *idx >= 64 || (bitmap & (1u64 << idx)) == 0
-                    })
-                    .map(|(_, col)| *col)
-                    .collect();
-                log::debug!(
-                    "V5CompressedLegacy: Column bitmap 0x{:X} filters {} → {} columns",
-                    bitmap,
-                    columns_in_order.len(),
-                    filtered.len()
-                );
-                filtered
-            }
-            None => columns_in_order,
-        };
+        // Issue #1081: carries the same (schema Column, authoritative on-disk
+        // marshal type) pairing produced above.
+        let columns_to_parse: Vec<(&crate::schema::Column, Option<&str>)> =
+            match row_header.missing_columns_bitmap {
+                Some(bitmap) => {
+                    let filtered: Vec<_> = columns_in_order
+                        .iter()
+                        .enumerate()
+                        .filter(|(idx, _)| {
+                            // Bitmap only covers the first 64 columns (u64).
+                            // Columns beyond index 63 are not represented in the
+                            // bitmap and are treated as present.
+                            *idx >= 64 || (bitmap & (1u64 << idx)) == 0
+                        })
+                        .map(|(_, col)| *col)
+                        .collect();
+                    log::debug!(
+                        "V5CompressedLegacy: Column bitmap 0x{:X} filters {} → {} columns",
+                        bitmap,
+                        columns_in_order.len(),
+                        filtered.len()
+                    );
+                    filtered
+                }
+                None => columns_in_order,
+            };
 
         log::debug!("V5CompressedLegacy: Parsing {} cells in SERIALIZATION HEADER ORDER starting at offset {} (row header was {} bytes)", columns_to_parse.len(), offset, row_header.header_size);
         log::debug!(
             "V5CompressedLegacy: Column order: {:?}",
-            columns_to_parse.iter().map(|c| &c.name).collect::<Vec<_>>()
+            columns_to_parse
+                .iter()
+                .map(|(c, _)| &c.name)
+                .collect::<Vec<_>>()
         );
         log::debug!(
             "V5CompressedLegacy: Cell data hex (first 64 bytes): {}",
@@ -4155,7 +4178,14 @@ impl V5CompressedLegacyParser {
             log::debug!("V5CompressedLegacy: Row has HAS_COMPLEX_DELETION flag (0x40) set");
         }
 
-        for (col_idx, &column) in columns_to_parse.iter().enumerate() {
+        for (col_idx, &(column, on_disk_type)) in columns_to_parse.iter().enumerate() {
+            // Issue #1081: the AUTHORITATIVE complex-ness / complex-decode type.
+            // Prefer the on-disk SerializationHeader marshal type (carries
+            // `UserType(...)` for a non-frozen UDT, which the supplied schema's
+            // bare short form cannot express); fall back to the supplied schema
+            // type only on the header-empty path (no-heuristics: both are
+            // authoritative metadata, never guessed from bytes — issue #28).
+            let complex_type: &str = on_disk_type.unwrap_or(&column.data_type);
             if offset >= data.len() {
                 log::debug!(
                     "V5CompressedLegacy: Reached end of data at column {} ('{}'), parsed {}/{} cells",
@@ -4170,9 +4200,9 @@ impl V5CompressedLegacyParser {
             // Issue #221: Branch based on column type - complex columns need special parsing
             // Issue #693: simple columns return 4-tuple including cell timestamp / expiration;
             //             complex columns return 2-tuple and inherit the row-level timestamp.
-            if Self::is_complex_column(&column.data_type) {
+            if Self::is_complex_column(complex_type) {
                 log::debug!(
-                    "V5CompressedLegacy: Column '{}' is complex (non-frozen collection), using parse_complex_column",
+                    "V5CompressedLegacy: Column '{}' is complex (non-frozen collection / multicell UDT), using parse_complex_column",
                     column.name
                 );
                 // Epic #899: on the compaction read path collect per-element
@@ -4187,6 +4217,7 @@ impl V5CompressedLegacyParser {
                         data,
                         offset,
                         column,
+                        complex_type,
                         has_complex_deletion,
                         row_ts,
                         Some(&mut element_buf),
@@ -4203,7 +4234,14 @@ impl V5CompressedLegacyParser {
                         (value, new_offset, col_meta)
                     })
                 } else {
-                    self.parse_complex_column(data, offset, column, has_complex_deletion, reader)
+                    self.parse_complex_column(
+                        data,
+                        offset,
+                        column,
+                        complex_type,
+                        has_complex_deletion,
+                        reader,
+                    )
                 };
                 match parse_result {
                     Ok((value, new_offset, col_meta)) => {
@@ -6681,13 +6719,35 @@ impl V5CompressedLegacyParser {
         data: &[u8],
         offset: usize,
         column: &crate::schema::Column,
+        // Issue #1081: authoritative on-disk marshal type used to decode the
+        // complex value (e.g. `UserType(...)` for a non-frozen UDT). See
+        // [`parse_complex_column_inner`].
+        complex_type: &str,
         has_complex_deletion: bool,
         _reader: &super::super::types::SSTableReader,
     ) -> Result<(Value, usize, ComplexColumnMeta)> {
-        self.parse_complex_column_inner(data, offset, column, has_complex_deletion, 0, None)
+        self.parse_complex_column_inner(
+            data,
+            offset,
+            column,
+            complex_type,
+            has_complex_deletion,
+            0,
+            None,
+        )
     }
 
     /// Inner complex-column parser.
+    ///
+    /// `complex_type` is the AUTHORITATIVE marshal type that drives the
+    /// complex-value decode — for the live read/compaction paths this is the
+    /// on-disk SerializationHeader `ColumnInfo.column_type` (issue #1081), which
+    /// is the only source that carries `UserType(...)` for a non-frozen
+    /// top-level UDT (the supplied schema's `column.data_type` is the bare CQL
+    /// short form, e.g. `person_type`, and cannot express it). `column` still
+    /// supplies the column identity (name) and is used for collection element /
+    /// map-key decode where the supplied schema form is sufficient. No
+    /// heuristics: both inputs are authoritative metadata (issue #28).
     ///
     /// When `elements_out` is `Some`, each parsed element (live, empty, or
     /// tombstoned) is also pushed as a
@@ -6702,6 +6762,7 @@ impl V5CompressedLegacyParser {
         data: &[u8],
         mut offset: usize,
         column: &crate::schema::Column,
+        complex_type: &str,
         has_complex_deletion: bool,
         row_timestamp: i64,
         mut elements_out: Option<
@@ -6865,8 +6926,12 @@ impl V5CompressedLegacyParser {
             }
         }
 
-        // Determine collection type and extract element type(s)
-        let dt = column.data_type.to_lowercase();
+        // Determine collection / UDT type from the AUTHORITATIVE marshal type
+        // (issue #1081). For collection branches the supplied schema short form
+        // (`column.data_type`) is still used to extract element/key types below —
+        // those paths are unchanged and proven. Only the top-level non-frozen UDT
+        // branch needs the marshal form, which `complex_type` carries.
+        let dt = complex_type.to_lowercase();
         let value = if dt.starts_with("list<")
             || dt.starts_with("org.apache.cassandra.db.marshal.listtype(")
         {
@@ -7085,7 +7150,12 @@ impl V5CompressedLegacyParser {
             // cell_path is the 2-byte (signed ShortType) declared field index and
             // whose value bytes are the field datum. Decode each cell's value with
             // the DECLARED field type resolved from the marshal string.
-            let field_defs = Self::udt_field_marshal_types(&column.data_type)?;
+            //
+            // Issue #1081: resolve the field layout from the AUTHORITATIVE on-disk
+            // marshal type (`complex_type`), not the supplied schema's bare short
+            // form (`column.data_type`, e.g. `person_type`) which cannot express
+            // the field list. This is the no-heuristics source of truth (issue #28).
+            let field_defs = Self::udt_field_marshal_types(complex_type)?;
             // Field values keyed by declared index; absent / null fields stay None.
             let mut field_values: Vec<Option<Value>> = vec![None; field_defs.len()];
 
@@ -7160,8 +7230,9 @@ impl V5CompressedLegacyParser {
             }
 
             // Build the collapsed UDT in DECLARED field order for the user-facing
-            // read path. The keyspace/type-name come from the marshal string.
-            let (udt_keyspace, udt_name) = Self::udt_keyspace_and_name(&column.data_type)?;
+            // read path. The keyspace/type-name come from the authoritative
+            // on-disk marshal string (issue #1081).
+            let (udt_keyspace, udt_name) = Self::udt_keyspace_and_name(complex_type)?;
             let fields = field_defs
                 .iter()
                 .zip(field_values)
@@ -7746,6 +7817,66 @@ impl V5CompressedLegacyParser {
         Ok((key_type, value_type))
     }
 
+    /// Map a PRIMITIVE Cassandra marshal type (e.g.
+    /// `org.apache.cassandra.db.marshal.Int32Type`) to the canonical CQL short
+    /// form (`"int"`) understood by [`parse_value_from_raw_bytes`]'s match
+    /// (issue #1081). Returns `None` for any non-primitive marshal form
+    /// (UserType / collection / tuple / reversed / frozen / custom), so the
+    /// caller leaves those to the dedicated arms. The suffix set mirrors the
+    /// authoritative marshal→`CqlType` mapping in
+    /// [`parse_cassandra_type_with_depth`] (no heuristics — issue #28).
+    fn primitive_marshal_to_cql_short(marshal_type: &str) -> Option<&'static str> {
+        // Composite marshal forms carry a `(` after the type name; primitives do
+        // not. Reject anything parameterised so we never misread a collection /
+        // UDT as a scalar.
+        if marshal_type.contains('(') {
+            return None;
+        }
+        let s = marshal_type;
+        let short = if s.ends_with("UTF8Type") || s.ends_with("VarcharType") {
+            "text"
+        } else if s.ends_with("AsciiType") {
+            "ascii"
+        } else if s.ends_with("Int32Type") {
+            "int"
+        } else if s.ends_with("LongType") || s.ends_with("CounterColumnType") {
+            "bigint"
+        } else if s.ends_with("FloatType") {
+            "float"
+        } else if s.ends_with("DoubleType") {
+            "double"
+        } else if s.ends_with("BooleanType") {
+            "boolean"
+        } else if s.ends_with("TimeUUIDType") {
+            "timeuuid"
+        } else if s.ends_with("UUIDType") || s.ends_with("LexicalUUIDType") {
+            "uuid"
+        } else if s.ends_with("TimestampType") {
+            "timestamp"
+        } else if s.ends_with("SimpleDateType") || s.ends_with("DateType") {
+            // Note: legacy `DateType` (millis-since-epoch) is intentionally mapped
+            // to `date`; modern UDT fields use `SimpleDateType`. Both are 4-byte.
+            "date"
+        } else if s.ends_with("TimeType") {
+            "time"
+        } else if s.ends_with("DecimalType") {
+            "decimal"
+        } else if s.ends_with("IntegerType") {
+            "varint"
+        } else if s.ends_with("ShortType") {
+            "smallint"
+        } else if s.ends_with("ByteType") {
+            "tinyint"
+        } else if s.ends_with("InetAddressType") {
+            "inet"
+        } else if s.ends_with("BytesType") {
+            "blob"
+        } else {
+            return None;
+        };
+        Some(short)
+    }
+
     /// Parse a value from a complete, bounded byte slice.
     ///
     /// This is used when the outer Cassandra collection format already provides
@@ -7768,6 +7899,23 @@ impl V5CompressedLegacyParser {
                 column_name, depth, MAX_TYPE_NESTING_DEPTH
             )));
         }
+        // Issue #1081: scalar marshal forms (e.g.
+        // `org.apache.cassandra.db.marshal.Int32Type` / `BooleanType`) reach this
+        // function for multicell-UDT field values, which resolve their field
+        // types from the authoritative on-disk `UserType(...)` marshal string.
+        // The match below only enumerates short forms plus a handful of text
+        // marshal aliases, so a bare scalar marshal type would otherwise fall
+        // through to the blob default. Normalize a primitive marshal type to its
+        // canonical CQL short form (via the existing authoritative marshal→CqlType
+        // mapping, no heuristics) and re-dispatch. Composite/UDT marshal forms
+        // (UserType/ListType/MapType/SetType/etc.) are left untouched here — they
+        // are handled by the dedicated arms below — so this only rewrites scalars.
+        if type_str.contains("org.apache.cassandra.db.marshal.") {
+            if let Some(short) = Self::primitive_marshal_to_cql_short(type_str) {
+                return self.parse_value_from_raw_bytes(data, short, column_name, depth);
+            }
+        }
+
         let normalized_type = type_str.to_lowercase();
         match normalized_type.as_str() {
             "text"
@@ -11425,7 +11573,7 @@ mod tests {
         blob.extend_from_slice(&udt_bytes);
 
         let (value, consumed, _meta) = parser
-            .parse_complex_column_inner(&blob, 0, &column, false, 0, None)
+            .parse_complex_column_inner(&blob, 0, &column, &column.data_type, false, 0, None)
             .expect("parse_complex_column_inner must succeed for list<frozen<address_type>>");
         assert_eq!(consumed, blob.len(), "all bytes must be consumed");
 
@@ -11513,7 +11661,7 @@ mod tests {
         blob.extend(build_set_cell_bytes(world));
 
         let (value, consumed, _meta) = parser
-            .parse_complex_column_inner(&blob, 0, &column, false, 0, None)
+            .parse_complex_column_inner(&blob, 0, &column, &column.data_type, false, 0, None)
             .expect("parse_complex_column_inner should succeed");
 
         assert_eq!(consumed, blob.len());
@@ -11566,7 +11714,7 @@ mod tests {
         blob.extend(build_set_tombstone_cell_bytes(dead));
 
         let (value, consumed, meta) = parser
-            .parse_complex_column_inner(&blob, 0, &column, false, 0, None)
+            .parse_complex_column_inner(&blob, 0, &column, &column.data_type, false, 0, None)
             .expect("parse_complex_column_inner should succeed");
 
         assert_eq!(consumed, blob.len(), "parser must consume the entire blob");
@@ -12221,8 +12369,13 @@ mod tests {
 
         let (value, consumed, meta) = parser
             .parse_complex_column_inner(
-                &blob, 0, &column, true, /* has_complex_deletion */
-                0, None,
+                &blob,
+                0,
+                &column,
+                &column.data_type,
+                true, /* has_complex_deletion */
+                0,
+                None,
             )
             .expect("parse_complex_column_inner must succeed for collection tombstone");
 
@@ -12334,6 +12487,7 @@ mod tests {
                 &blob,
                 0,
                 &column,
+                &column.data_type,
                 true, // has_complex_deletion
                 min_timestamp,
                 Some(&mut elements),

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
@@ -5500,21 +5500,42 @@ impl V5CompressedLegacyParser {
         Ok((value, cell_timestamp, cell_expiration, offset))
     }
 
-    /// Extract inner type from frozen<T> type string
+    /// Extract inner type from a frozen type string (CQL or Cassandra internal format).
+    ///
+    /// Accepts both the CQL short form `frozen<T>` and the authoritative on-disk
+    /// marshal form `org.apache.cassandra.db.marshal.FrozenType(T)`. Multicell-UDT
+    /// field types resolve from the `UserType(...)` marshal string, where frozen
+    /// fields are spelled `FrozenType(...)` (e.g. `frozen<list<int>>` →
+    /// `FrozenType(ListType(Int32Type))`), so we mirror how
+    /// `extract_collection_element_type` supports both forms. In both cases the
+    /// inner substring is sliced from the ORIGINAL-CASE input so nested marshal
+    /// types keep their case and re-normalize correctly on recursion.
     fn extract_frozen_inner_type(&self, type_str: &str) -> Result<String> {
-        if !type_str.starts_with("frozen<") || !type_str.ends_with('>') {
-            return Err(Error::schema(format!(
-                "Invalid frozen type format: {}",
-                type_str
-            )));
+        let type_lower = type_str.to_lowercase();
+
+        // Cassandra internal format: org.apache.cassandra.db.marshal.FrozenType(T)
+        let internal_prefix_lower = "org.apache.cassandra.db.marshal.frozentype(";
+        if type_lower.starts_with(internal_prefix_lower) && type_lower.ends_with(')') {
+            let inner = &type_str[internal_prefix_lower.len()..type_str.len() - 1];
+            if inner.is_empty() {
+                return Err(Error::schema(format!("Empty frozen type: {}", type_str)));
+            }
+            return Ok(inner.to_string());
         }
 
-        let inner = &type_str[7..type_str.len() - 1];
-        if inner.is_empty() {
-            return Err(Error::schema(format!("Empty frozen type: {}", type_str)));
+        // CQL format: frozen<T>
+        if type_str.starts_with("frozen<") && type_str.ends_with('>') {
+            let inner = &type_str[7..type_str.len() - 1];
+            if inner.is_empty() {
+                return Err(Error::schema(format!("Empty frozen type: {}", type_str)));
+            }
+            return Ok(inner.to_string());
         }
 
-        Ok(inner.to_string())
+        Err(Error::schema(format!(
+            "Invalid frozen type format: {}",
+            type_str
+        )))
     }
 
     /// Check if a type string represents a UDT (User-Defined Type).
@@ -8219,12 +8240,22 @@ impl V5CompressedLegacyParser {
                 )?;
                 Ok(Value::Tuple(elements))
             }
-            // Issue #1081: `frozen<...>` has no distinct marshal form (the marshal
-            // string carries the inner composite directly, e.g. `ListType(...)`
-            // for a frozen collection, which the arms above already handle). Only
-            // the CQL short form needs handling here; extract from `raw_type_str`
-            // to preserve the inner type's case on recursion.
-            type_str if type_str.starts_with("frozen<") => {
+            // Issue #1081: accept BOTH the CQL short form (`frozen<...>`) and the
+            // authoritative Cassandra marshal form
+            // (`org.apache.cassandra.db.marshal.FrozenType(...)`). Collection/UDT
+            // fields inside a multicell UDT must be frozen, and their field types
+            // resolve from the on-disk `UserType(...)` marshal string where a frozen
+            // field is spelled `FrozenType(...)` — e.g. `frozen<list<int>>` arrives
+            // as `FrozenType(ListType(Int32Type))` and `frozen<some_udt>` as
+            // `FrozenType(UserType(...))`. Without this arm those bypass the frozen
+            // handling and fall through to the blob default. `extract_frozen_inner_type`
+            // accepts both forms; we extract from `raw_type_str` (original case) so the
+            // inner marshal type keeps its case and re-routes to the marshal
+            // collection/UDT/scalar arms above on recursion.
+            type_str
+                if type_str.starts_with("frozen<")
+                    || type_str.starts_with("org.apache.cassandra.db.marshal.frozentype(") =>
+            {
                 let inner_type = self.extract_frozen_inner_type(raw_type_str)?;
                 let inner =
                     self.parse_value_from_raw_bytes(data, &inner_type, column_name, depth + 1)?;
@@ -10896,6 +10927,65 @@ mod tests {
             val,
             Value::Set(vec![Value::Integer(7), Value::Integer(9)]),
             "marshal-form set field must produce a Set of Integer (not a Blob)"
+        );
+    }
+
+    /// Issue #1081 (FINDING — last type-tree gap): a multicell-UDT field declared
+    /// `frozen<list<text>>` resolves from the on-disk `UserType(...)` marshal string
+    /// as `FrozenType(ListType(UTF8Type))`. Before the fix the frozen arm in
+    /// `parse_value_from_raw_bytes` only matched the CQL `frozen<...>` form, so this
+    /// marshal form bypassed it and fell through to `Value::Blob`. It must now decode
+    /// to `Value::Frozen(List([Text, ...]))`. (Collection/UDT fields inside a UDT must
+    /// be frozen, so this marshal form is the common real case.)
+    #[test]
+    fn test_parse_value_from_raw_bytes_marshal_frozen_list_utf8() {
+        let parser =
+            V5CompressedLegacyParser::new("test".to_string(), "table".to_string(), 0, 0, None);
+
+        let data = build_frozen_list_text(&["gamma", "delta"]);
+        let val = parser
+            .parse_value_from_raw_bytes(
+                &data,
+                "org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.UTF8Type))",
+                "udt_field",
+                0,
+            )
+            .expect("marshal FrozenType(ListType(UTF8Type)) must decode, not blob");
+        assert_eq!(
+            val,
+            Value::Frozen(Box::new(Value::List(vec![
+                Value::Text("gamma".to_string()),
+                Value::Text("delta".to_string()),
+            ]))),
+            "marshal-form frozen-list field must produce Frozen(List(Text)) (not a Blob)"
+        );
+    }
+
+    /// Issue #1081: `extract_frozen_inner_type` must accept BOTH the CQL short form
+    /// (`frozen<list<int>>`) and the authoritative marshal form
+    /// (`FrozenType(ListType(Int32Type))`), returning the inner type with its
+    /// ORIGINAL case preserved so nested marshal types re-normalize on recursion.
+    #[test]
+    fn test_extract_frozen_inner_type_cql_and_marshal() {
+        let parser =
+            V5CompressedLegacyParser::new("test".to_string(), "table".to_string(), 0, 0, None);
+
+        // CQL short form
+        let cql_inner = parser
+            .extract_frozen_inner_type("frozen<list<int>>")
+            .expect("CQL frozen<...> must parse");
+        assert_eq!(cql_inner, "list<int>");
+
+        // Marshal form — original case (Int32Type) must be preserved.
+        let marshal_inner = parser
+            .extract_frozen_inner_type(
+                "org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.Int32Type))",
+            )
+            .expect("marshal FrozenType(...) must parse");
+        assert_eq!(
+            marshal_inner,
+            "org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.Int32Type)",
+            "marshal frozen inner type must be original-case (Int32Type preserved)"
         );
     }
 

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
@@ -7877,6 +7877,8 @@ impl V5CompressedLegacyParser {
             "decimal"
         } else if s.ends_with("IntegerType") {
             "varint"
+        } else if s.ends_with("DurationType") {
+            "duration"
         } else if s.ends_with("ShortType") {
             "smallint"
         } else if s.ends_with("ByteType") {
@@ -8082,6 +8084,42 @@ impl V5CompressedLegacyParser {
                 Ok(Value::Time(i64::from_be_bytes([
                     data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7],
                 ])))
+            }
+            "duration" => {
+                // Issue #1081: in this function the entire `data` slice IS the value
+                // (the element/cell length prefix already bounded it) — there is NO
+                // outer `[VInt len]` prefix. Decode three consecutive SIGNED VInts
+                // directly over `data`: months, days, nanos (Cassandra
+                // DurationSerializer). Contrast `parse_raw_type_value`'s duration arm,
+                // which reads an outer `[VInt len]` first because its framing differs.
+                let (remaining, months) = parse_vint(data).map_err(|e| {
+                    Error::corruption(format!(
+                        "Frozen element '{}': failed to parse duration months: {:?}",
+                        column_name, e
+                    ))
+                })?;
+                let pos = data.len() - remaining.len();
+
+                let (remaining, days) = parse_vint(&data[pos..]).map_err(|e| {
+                    Error::corruption(format!(
+                        "Frozen element '{}': failed to parse duration days: {:?}",
+                        column_name, e
+                    ))
+                })?;
+                let pos = data.len() - remaining.len();
+
+                let (_remaining, nanos) = parse_vint(&data[pos..]).map_err(|e| {
+                    Error::corruption(format!(
+                        "Frozen element '{}': failed to parse duration nanos: {:?}",
+                        column_name, e
+                    ))
+                })?;
+
+                Ok(Value::Duration {
+                    months: months as i32,
+                    days: days as i32,
+                    nanos,
+                })
             }
             "varint" => Ok(Value::Varint(data.to_vec())),
             "decimal" => {
@@ -10235,6 +10273,7 @@ mod tests {
             ("TimeType", "time"),
             ("DecimalType", "decimal"),
             ("IntegerType", "varint"),
+            ("DurationType", "duration"),
             ("ShortType", "smallint"),
             ("ByteType", "tinyint"),
             ("InetAddressType", "inet"),
@@ -10632,6 +10671,66 @@ mod tests {
                 unscaled: vec![0x01, 0xC8]
             }
         );
+    }
+
+    /// Issue #1081: a multicell-UDT field declared `duration` resolves its
+    /// field type from the authoritative on-disk `UserType(...)` marshal string
+    /// as `org.apache.cassandra.db.marshal.DurationType`. That bare scalar
+    /// marshal form must normalize to `"duration"` and decode the three
+    /// consecutive SIGNED VInts (months, days, nanos) that constitute the value
+    /// — NOT fall through to `Value::Blob`. In `parse_value_from_raw_bytes` the
+    /// entire slice IS the value (no outer `[VInt len]` prefix).
+    #[test]
+    fn test_parse_value_from_raw_bytes_duration_marshal() {
+        let parser =
+            V5CompressedLegacyParser::new("test".to_string(), "table".to_string(), 0, 0, None);
+
+        // Build three SIGNED VInts (months=1, days=2, nanos=3) using the same
+        // ZigZag-over-unsigned-VInt scheme `parse_vint` decodes. ZigZag:
+        // 1 -> 2, 2 -> 4, 3 -> 6.
+        let zigzag = |v: i64| ((v << 1) ^ (v >> 63)) as u64;
+        let mut data = Vec::new();
+        encode_unsigned(zigzag(1), &mut data); // months
+        encode_unsigned(zigzag(2), &mut data); // days
+        encode_unsigned(zigzag(3), &mut data); // nanos
+
+        // Round-trip via the signed VInt parser to confirm the encoding before
+        // exercising the decode arm under test.
+        let (rem, m) = parse_vint(&data).unwrap();
+        let consumed = data.len() - rem.len();
+        let (rem2, d) = parse_vint(&data[consumed..]).unwrap();
+        let consumed2 = data.len() - rem2.len();
+        let (_rem3, n) = parse_vint(&data[consumed2..]).unwrap();
+        assert_eq!(
+            (m, d, n),
+            (1, 2, 3),
+            "hand-encoded duration vints round-trip"
+        );
+
+        // The bare scalar marshal form must normalize and decode to Duration,
+        // NOT fall through to Blob.
+        let val = parser
+            .parse_value_from_raw_bytes(
+                &data,
+                "org.apache.cassandra.db.marshal.DurationType",
+                "col",
+                0,
+            )
+            .unwrap();
+        assert_eq!(
+            val,
+            Value::Duration {
+                months: 1,
+                days: 2,
+                nanos: 3
+            }
+        );
+
+        // The canonical CQL short form must decode identically.
+        let val_short = parser
+            .parse_value_from_raw_bytes(&data, "duration", "col", 0)
+            .unwrap();
+        assert_eq!(val_short, val);
     }
 
     #[test]

--- a/cqlite-core/src/storage/sstable/writer/data_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer.rs
@@ -10206,7 +10206,7 @@ mod tests {
         // True round-trip through the reader.
         let parser = person_reader();
         let (value, _off, _meta) = parser
-            .parse_complex_column_inner(&buf, 0, &col, true, row_ts, None)
+            .parse_complex_column_inner(&buf, 0, &col, &col.data_type, true, row_ts, None)
             .expect("reader must parse the UDT complex column");
 
         match value {
@@ -11829,7 +11829,7 @@ mod tests {
 
         let parser = person_reader();
         let (value, _off, _meta) = parser
-            .parse_complex_column_inner(&buf, 0, &col, true, row_ts, None)
+            .parse_complex_column_inner(&buf, 0, &col, &col.data_type, true, row_ts, None)
             .expect("reader must parse the UDT complex column");
 
         match value {

--- a/cqlite-core/tests/issue_1007_complex_type_parity.rs
+++ b/cqlite-core/tests/issue_1007_complex_type_parity.rs
@@ -682,12 +682,14 @@ async fn nested_frozen_collections_parity() {
 
 /// `cass.cql_types.complex.multicell_udt_collection_paths`
 ///
-/// EXPECTED-FAIL (bug found by this lane): the multicell `ml list<text>` column
-/// decodes correctly (ordered list via cell-paths), but the multicell
-/// `mp person_type` (non-frozen UDT) decodes to a raw blob (`0x08020000`) rather
-/// than a structured UDT reassembled from its per-field cells. Written to the
-/// CORRECT Cassandra behavior; unignore when issue #1079 lands.
-#[ignore = "issue #1081: non-frozen (multicell) top-level UDT decodes as opaque blob, not structured UDT"]
+/// Both multicell columns decode structurally: the `ml list<text>` column as an
+/// ordered list via cell-paths, and the `mp person_type` (non-frozen, top-level
+/// UDT) reassembled from its per-field cells into a structured UDT. Fixed by
+/// issue #1081: the complex-ness decision and the multicell-UDT decode now use
+/// the AUTHORITATIVE on-disk SerializationHeader marshal type
+/// (`ColumnInfo.column_type`, which carries `UserType(...)`) instead of the
+/// supplied schema's bare CQL short form (`person_type`), which previously
+/// misrouted the column to the scalar path and yielded a raw blob (`0x08020000`).
 #[tokio::test]
 async fn multicell_udt_collection_paths_parity() {
     let schema = load_table_schema("cx_multicell_udt_collection_paths");


### PR DESCRIPTION
## Summary
Fixes #1081 — a non-frozen (multicell) top-level UDT column decoded as an opaque blob (e.g. `0x08020000`) instead of a structured UDT.

## Root cause
The decode loop iterated the on-disk SerializationHeader columns but called `is_complex_column` on the **supplied schema's CQL short-form** type (e.g. `person_type`), which only the marshal form `UserType(...)` was recognized — so the column was misrouted to the scalar path. A secondary gap: once routed to the multicell-UDT branch, field values typed by their on-disk **marshal** strings (`Int32Type`, `BooleanType`, `ListType(...)`, `FrozenType(...)`, `DurationType`, …) were not decoded by `parse_value_from_raw_bytes`, which only enumerated CQL short forms.

## Fix
- Thread the authoritative on-disk `ColumnInfo.column_type` marshal string through the decode loop and into `parse_complex_column`; supplied schema still drives column identity/order, the on-disk header drives complex-value decode (no heuristics, #28).
- Add `primitive_marshal_to_cql_short` (a documented **superset** of the authoritative primitive map) and route marshal scalars through it.
- Extend `parse_value_from_raw_bytes` to accept marshal-form **collections** (`ListType/SetType/MapType/TupleType`), **frozen** (`FrozenType(...)`, case-insensitive CQL `frozen<...>` too), **duration**, decoding nested types from the original-case string. Frozen-UDT/collection/tuple/scalar paths unchanged.
- Correct `DateType` → `timestamp` (8-byte millis) vs `SimpleDateType` → `date`.

Un-ignores the pinned parity test `multicell_udt_collection_paths_parity`. Adds direct `parse_value_from_raw_bytes` regression tests for marshal list/set/map/frozen/duration field values and a `primitive_marshal_to_cql_short` table-driven test.

The top-level **frozen** UDT *column* case (#1080) is intentionally out of scope and remains pinned/ignored.

## Validation
- `scripts/agent-gate.sh`: **RESULT: PASS** (all 10 lanes) on commit `0f7efaf6`.
- roborev branch review: **No issues found** (after iterating scalar/collection/duration/frozen coverage).
- spec-auditor / coverage-reviewer / rust-reviewer: PASS.

Closes #1081