### PR TITLE
fix(#1085): tombstones-feature full scan collapsed clustered rows

### DIFF
--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -750,7 +750,14 @@ impl SSTableManager {
     /// Cross-generation reconciliation (last-write-wins + tombstone shadowing) is
     /// applied via the authoritative k-way merger when more than one SSTable
     /// generation backs the table and `write-support` + a schema are available;
-    /// otherwise rows from each reader are concatenated.
+    /// otherwise rows from each reader are concatenated. That concat fallback is
+    /// the documented multi-generation limitation (Issue #883) and is now
+    /// IDENTICAL across every feature build: the `tombstones` build takes exactly
+    /// this path too (it no longer runs its own partition-keyed merge). So no
+    /// build regresses relative to the default — a `tombstones`-without-
+    /// `write-support` multi-generation read behaves the same as the default
+    /// `not(tombstones)`-without-`write-support` build, and the prior `tombstones`
+    /// "merge" it replaces was the row-collapsing bug, not real reconciliation.
     ///
     /// Issue #1085: this is the SINGLE `scan` implementation for every feature
     /// build. The former `#[cfg(feature = "tombstones")]` variant grouped per-row
@@ -898,10 +905,12 @@ impl SSTableManager {
     /// evaluation, so any over-inclusion (e.g. a BTI prefix-collision candidate) is
     /// filtered out downstream.
     ///
-    /// Gated on `not(tombstones)` to match the `scan` variant it parallels: the
-    /// `tombstones` build uses a structurally different reader map, so the method
-    /// is defined only for the default build (the executor falls back to a full
-    /// scan under `tombstones`).
+    /// Gated on `not(tombstones)` because the bloom/BTI prune fast path it relies
+    /// on ([`scan_partition_clustering`](reader::SSTableReader::scan_partition_clustering))
+    /// is itself `not(tombstones)`-only. Under `tombstones` the executor falls back
+    /// to a full [`scan`](Self::scan) + predicate filter (since #1085, `scan` is the
+    /// same correct implementation in both builds, so the fallback is correct — just
+    /// without the single-partition prune).
     ///
     /// `partition_key` is the raw on-disk partition-key bytes produced by
     /// [`encode_partition_key_columns`](crate::storage::partition_key_codec::encode_partition_key_columns),

--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -736,7 +736,7 @@ impl SSTableManager {
         Ok(None)
     }
 
-    /// Scan a range of keys from all SSTables with proper tombstone merging
+    /// Scan a range of keys from all SSTables for a table.
     ///
     /// # Arguments
     /// * `table_id` - The table to scan
@@ -746,81 +746,25 @@ impl SSTableManager {
     /// * `schema` - Optional table schema for schema-aware parsing. When provided,
     ///   enables accurate type detection and avoids heuristic-based parsing.
     ///   Strongly recommended for Cassandra 5.0+ formats.
-    #[cfg(feature = "tombstones")]
-    pub async fn scan(
-        &self,
-        table_id: &TableId,
-        start_key: Option<&RowKey>,
-        end_key: Option<&RowKey>,
-        limit: Option<usize>,
-        schema: Option<&crate::schema::TableSchema>,
-    ) -> Result<Vec<(RowKey, Value)>> {
-        let readers = self.readers.read().await;
-        let mut key_values = std::collections::HashMap::new();
-
-        // Collect results from all SSTables, grouping by key
-        for reader in readers.values() {
-            let results = reader
-                .scan(table_id, start_key, end_key, None, schema)
-                .await?;
-
-            for (row_key, value) in results {
-                let generation = reader.generation;
-                let write_time = reader.extract_write_time_from_entry(&row_key, &value);
-
-                let gen_value = GenerationValue {
-                    value,
-                    metadata: EntryMetadata {
-                        write_time,
-                        generation,
-                        ttl: None,
-                    },
-                };
-
-                key_values
-                    .entry(row_key)
-                    .or_insert_with(Vec::new)
-                    .push(gen_value);
-            }
-        }
-
-        // Merge values for each key using tombstone merger
-        let merger = TombstoneMerger::new();
-        let mut final_results = Vec::new();
-
-        for (row_key, values) in key_values {
-            if let Some(merged_value) = merger.merge_generations(values)? {
-                final_results.push((row_key, merged_value));
-            }
-        }
-
-        // Sort results by key
-        final_results.sort_by(|a, b| a.0.cmp(&b.0));
-
-        // Apply limit
-        if let Some(limit) = limit {
-            final_results.truncate(limit);
-        }
-
-        Ok(final_results)
-    }
-
-    /// Scan a range of keys from all SSTables (simple version without tombstone merging)
     ///
-    /// # Arguments
-    /// * `table_id` - The table to scan
-    /// * `start_key` - Optional start key for range scan
-    /// * `end_key` - Optional end key for range scan
-    /// * `limit` - Optional limit on number of results
-    /// * `schema` - Optional table schema for schema-aware parsing. When provided,
-    ///   enables accurate type detection and avoids heuristic-based parsing.
-    ///   Strongly recommended for Cassandra 5.0+ formats.
+    /// Cross-generation reconciliation (last-write-wins + tombstone shadowing) is
+    /// applied via the authoritative k-way merger when more than one SSTable
+    /// generation backs the table and `write-support` + a schema are available;
+    /// otherwise rows from each reader are concatenated.
+    ///
+    /// Issue #1085: this is the SINGLE `scan` implementation for every feature
+    /// build. The former `#[cfg(feature = "tombstones")]` variant grouped per-row
+    /// results into a `HashMap` keyed on `RowKey` (which carries only the
+    /// partition-key bytes, no clustering) and ran `TombstoneMerger`, so it
+    /// collapsed all clustering rows of a partition into one — a full `SELECT *`
+    /// over a clustered table returned ~one row per partition. Concatenating
+    /// per-reader rows here (and reconciling only ACROSS generations) is correct
+    /// for clustered tables in every build.
     ///
     /// Lookup order (Issue #680):
     ///   1. Exact match on the full `table_id` string (e.g. `"test_basic.simple_table"`)
     ///   2. Unqualified table name (e.g. `"simple_table"`) — for backward compatibility
     ///      with flat/non-Cassandra directory layouts that have no keyspace parent.
-    #[cfg(not(feature = "tombstones"))]
     pub async fn scan(
         &self,
         table_id: &TableId,
@@ -1357,7 +1301,6 @@ impl SSTableManager {
     /// Shared by [`get`](Self::get), [`scan`](Self::scan), and
     /// [`scan_partition`](Self::scan_partition) so the resolution rule lives in
     /// one place and the targeted-lookup path can never drift from `scan`.
-    #[cfg(not(feature = "tombstones"))]
     fn resolve_reader_list<'a>(
         table_readers: &'a HashMap<String, Vec<Arc<reader::SSTableReader>>>,
         table_name: &str,
@@ -1399,7 +1342,7 @@ impl SSTableManager {
     /// full reconciled table (Issue #957). The range filter runs before `limit`, matching
     /// the per-reader scan order (range then limit). With `None`/`None` bounds the output
     /// is byte-for-byte the full reconciled set, unchanged from before.
-    #[cfg(all(not(feature = "tombstones"), feature = "write-support"))]
+    #[cfg(feature = "write-support")]
     async fn merge_generations_for_read(
         &self,
         reader_list: &[Arc<reader::SSTableReader>],

--- a/cqlite-core/tests/issue_1085_tombstones_full_scan_parity.rs
+++ b/cqlite-core/tests/issue_1085_tombstones_full_scan_parity.rs
@@ -8,22 +8,29 @@
 //! `HashMap` keyed on `RowKey`. `RowKey` carries only the *partition-key* bytes
 //! (no clustering), so all clustering rows of a partition collided into one bucket
 //! and `TombstoneMerger::merge_generations` collapsed each bucket to a single row.
-//! A `SELECT *` over `test_timeseries.sensor_data` (10 partitions × 200 clustering
-//! rows = 2000 rows, LZ4-compressed `nb`) therefore returned only ~one partition's
-//! worth of rows, stripped down to just the clustering column — instead of 2000
-//! fully-populated rows. The fix makes the (now single) `scan` implementation
-//! concatenate every row and reconcile only ACROSS generations, exactly like the
-//! default build.
+//! A `SELECT *` over a clustered table therefore returned roughly one row per
+//! partition, stripped down to just the clustering column — instead of every
+//! fully-populated clustering row. The fix makes the (now single) `scan`
+//! implementation concatenate every row and reconcile only ACROSS generations,
+//! exactly like the default build.
 //!
-//! This is an END-TO-END regression test driving the same `Database::execute`
-//! query path the CLI uses. It asserts the full-scan row count for a clustered
+//! These are END-TO-END regression tests driving the same `Database::execute`
+//! query path the CLI uses. They assert the full-scan row count for a clustered
 //! compressed table equals the committed sstabledump JSONL golden, AND that the
 //! rows carry their partition-key + regular columns (not just the clustering key).
 //!
+//! Two complementary fixtures:
+//!   * `test_timeseries.sensor_data` — 10 partitions × 200 clustering rows
+//!     (LZ4 `nb`). The collapse symptom here is 2000 → ~200.
+//!   * `test_tomb.wide_range_tombstone` — a SINGLE partition × 2987 clustering
+//!     rows spanning many compression chunks (LZ4 `nb`). The collapse symptom
+//!     here is the dramatic 2987 → ~1, and it also exercises a partition that
+//!     spans multiple compressed chunks.
+//!
 //! Fixtures resolve via `CQLITE_DATASETS_ROOT`; the table-dir UUID is never
 //! hardcoded (globbed by `<table>-` prefix). When the dataset (or its gitignored
-//! `*.db` binaries) is absent, the test SKIPs cleanly. When the fixture IS present,
-//! a zero-row or mismatched result FAILS loudly.
+//! `*.db` binaries) is absent, the tests SKIP cleanly. When the fixture IS
+//! present, a zero-row or mismatched result FAILS loudly.
 //!
 //! Requires `cli-helpers` (the `ingestion` module that builds a queryable
 //! `Database`) and `state_machine` (the query engine); without them the file
@@ -35,8 +42,6 @@ use std::path::{Path, PathBuf};
 use cqlite_core::ingestion::{ingest, IngestionConfig};
 use cqlite_core::Database;
 
-const KEYSPACE_FILTER: &str = "/test_timeseries/";
-
 fn datasets_root() -> Option<PathBuf> {
     std::env::var("CQLITE_DATASETS_ROOT")
         .ok()
@@ -44,9 +49,11 @@ fn datasets_root() -> Option<PathBuf> {
         .filter(|p| p.exists())
 }
 
-fn schema_path() -> Option<PathBuf> {
+/// Resolve `<repo>/test-data/schemas/<file>`, preferring the location derived from
+/// `CQLITE_DATASETS_ROOT` and falling back to the crate-relative path.
+fn schema_path(file: &str) -> Option<PathBuf> {
     if let Some(root) = datasets_root() {
-        let p = root.parent()?.join("schemas").join("time-series.cql");
+        let p = root.parent()?.join("schemas").join(file);
         if p.exists() {
             return Some(p);
         }
@@ -56,14 +63,14 @@ fn schema_path() -> Option<PathBuf> {
         .parent()?
         .join("test-data")
         .join("schemas")
-        .join("time-series.cql");
+        .join(file);
     p.exists().then_some(p)
 }
 
-/// Resolve `<root>/sstables/test_timeseries/<table>-<uuid>/`, globbing by prefix.
-fn fixture_dir(table: &str) -> Option<PathBuf> {
+/// Resolve `<root>/sstables/<keyspace>/<table>-<uuid>/`, globbing by prefix.
+fn fixture_dir(keyspace: &str, table: &str) -> Option<PathBuf> {
     let root = datasets_root()?;
-    let ks_dir = root.join("sstables").join("test_timeseries");
+    let ks_dir = root.join("sstables").join(keyspace);
     if !ks_dir.is_dir() {
         return None;
     }
@@ -82,9 +89,10 @@ fn fixture_dir(table: &str) -> Option<PathBuf> {
 }
 
 /// Count the total CQL rows in the committed sstabledump JSONL golden (sum of the
-/// `rows` arrays across every partition line, counting only `type == "row"`).
-fn golden_row_count(table: &str) -> Option<usize> {
-    let dir = fixture_dir(table)?;
+/// `rows` arrays across every partition line, counting only `type == "row"` so
+/// range-tombstone bound markers are excluded).
+fn golden_row_count(keyspace: &str, table: &str) -> Option<usize> {
+    let dir = fixture_dir(keyspace, table)?;
     let jsonl = dir.join("nb-1-big-Data.db.jsonl");
     let text = std::fs::read_to_string(&jsonl).ok()?;
     let mut total = 0usize;
@@ -105,19 +113,25 @@ fn golden_row_count(table: &str) -> Option<usize> {
     Some(total)
 }
 
-/// Ingest the `test_timeseries` keyspace and return a queryable `Database`, or a
-/// skip reason. The Data.db binaries are gitignored, so a missing fixture SKIPs.
-async fn setup_db() -> Result<Database, String> {
+/// Ingest a single keyspace and return a queryable `Database`, or a skip reason.
+/// The Data.db binaries are gitignored, so a missing fixture SKIPs.
+async fn setup_db(
+    keyspace: &str,
+    schema_file: &str,
+    sentinel_table: &str,
+) -> Result<Database, String> {
     let root = datasets_root().ok_or("CQLITE_DATASETS_ROOT unset or path missing")?;
-    let schema = schema_path().ok_or("time-series.cql schema not found")?;
+    let schema =
+        schema_path(schema_file).ok_or_else(|| format!("{schema_file} schema not found"))?;
     let data_dir = root.join("sstables");
     if !data_dir.exists() {
         return Err(format!("sstables dir not found at {data_dir:?}"));
     }
-    let sensor = fixture_dir("sensor_data").ok_or("test_timeseries/sensor_data-* dir absent")?;
-    if !sensor.join("nb-1-big-Data.db").exists() {
+    let sentinel = fixture_dir(keyspace, sentinel_table)
+        .ok_or_else(|| format!("{keyspace}/{sentinel_table}-* dir absent"))?;
+    if !sentinel.join("nb-1-big-Data.db").exists() {
         return Err(format!(
-            "sensor_data Data.db missing (binary not fetched) at {sensor:?}"
+            "{sentinel_table} Data.db missing (binary not fetched) at {sentinel:?}"
         ));
     }
 
@@ -126,7 +140,7 @@ async fn setup_db() -> Result<Database, String> {
         data_dir,
         version_hint: None,
         core_config: cqlite_core::Config::default(),
-        table_directory_filter: Some(KEYSPACE_FILTER.to_string()),
+        table_directory_filter: Some(format!("/{keyspace}/")),
     };
     let result = ingest(cfg).await.map_err(|e| format!("ingestion: {e}"))?;
     if result.schema_load_result.schemas_loaded == 0 {
@@ -135,53 +149,91 @@ async fn setup_db() -> Result<Database, String> {
     Ok(result.database)
 }
 
-/// The load-bearing regression: a clustered, LZ4-compressed `nb` table whose
-/// partitions each hold many clustering rows. The `tombstones`-feature scan used
-/// to collapse each partition to one row (≈2000 → ≈200, columns reduced to the
-/// clustering key). This asserts BOTH the full row count and that the rows carry
-/// the partition key + regular columns.
-#[tokio::test]
-async fn sensor_data_full_scan_returns_all_clustering_rows() {
-    let db = match setup_db().await {
+/// Run a full `SELECT *` over `keyspace.table` and assert the row count equals the
+/// sstabledump JSONL golden AND that every row carries the named partition-key and
+/// regular columns (the collapse symptom stripped rows down to the clustering key).
+async fn assert_full_scan_parity(
+    keyspace: &str,
+    schema_file: &str,
+    table: &str,
+    pk_col: &str,
+    regular_cols: &[&str],
+) {
+    let test_name = format!("{keyspace}.{table}");
+    let db = match setup_db(keyspace, schema_file, table).await {
         Ok(db) => db,
         Err(skip) => {
-            eprintln!("SKIP sensor_data_full_scan_returns_all_clustering_rows: {skip}");
+            eprintln!("SKIP full_scan_parity {test_name}: {skip}");
             return;
         }
     };
 
-    let golden = golden_row_count("sensor_data")
-        .expect("sensor_data fixture present but golden JSONL missing/unreadable");
+    let golden = golden_row_count(keyspace, table).unwrap_or_else(|| {
+        panic!("{test_name} fixture present but golden JSONL missing/unreadable")
+    });
     assert!(
         golden > 0,
-        "golden row count must be > 0 (fixture sanity); got {golden}"
+        "{test_name}: golden row count must be > 0 (fixture sanity); got {golden}"
     );
 
+    let query = format!("SELECT * FROM {keyspace}.{table}");
     let result = db
-        .execute("SELECT * FROM test_timeseries.sensor_data")
+        .execute(&query)
         .await
-        .expect("SELECT * over sensor_data must succeed");
+        .unwrap_or_else(|e| panic!("{test_name}: SELECT * must succeed: {e}"));
 
     assert_eq!(
         result.rows.len(),
         golden,
-        "full-scan row count {} != sstabledump golden {} — the tombstones scan path \
-         collapsed multi-row partitions (issue #1085)",
+        "{test_name}: full-scan row count {} != sstabledump golden {} — the tombstones \
+         scan path collapsed multi-row partitions (issue #1085)",
         result.rows.len(),
         golden
     );
 
     // The collapse symptom also stripped every column except the clustering key.
-    // Assert the partition key and a regular column survive on every row.
+    // Assert the partition key and at least one regular column survive on every row.
     for (i, row) in result.rows.iter().enumerate() {
         assert!(
-            row.values.contains_key("sensor_id"),
-            "row {i} is missing the partition-key column `sensor_id` — \
+            row.values.contains_key(pk_col),
+            "{test_name}: row {i} is missing the partition-key column `{pk_col}` — \
              rows were collapsed to the clustering key only (issue #1085)"
         );
         assert!(
-            row.values.contains_key("temperature") || row.values.contains_key("location"),
-            "row {i} is missing all regular columns — rows were collapsed (issue #1085)"
+            regular_cols.iter().any(|c| row.values.contains_key(*c)),
+            "{test_name}: row {i} is missing all regular columns {regular_cols:?} — \
+             rows were collapsed (issue #1085)"
         );
     }
+}
+
+/// Multi-partition clustered table (10 partitions × 200 clustering rows). The
+/// `tombstones` scan used to collapse each partition to one row (2000 → ~200,
+/// columns reduced to the clustering key).
+#[tokio::test]
+async fn sensor_data_full_scan_returns_all_clustering_rows() {
+    assert_full_scan_parity(
+        "test_timeseries",
+        "time-series.cql",
+        "sensor_data",
+        "sensor_id",
+        &["temperature", "location"],
+    )
+    .await;
+}
+
+/// SINGLE-partition clustered table (1 partition × 2987 clustering rows spanning
+/// many compression chunks). The collapse symptom here is the dramatic 2987 → ~1,
+/// and it also exercises a partition spanning multiple compressed chunks. The
+/// golden counter excludes the 6 `range_tombstone_bound` markers (type != "row").
+#[tokio::test]
+async fn wide_range_tombstone_single_partition_full_scan() {
+    assert_full_scan_parity(
+        "test_tomb",
+        "tombstone-parity.cql",
+        "wide_range_tombstone",
+        "pk",
+        &["val"],
+    )
+    .await;
 }

--- a/cqlite-core/tests/issue_1085_tombstones_full_scan_parity.rs
+++ b/cqlite-core/tests/issue_1085_tombstones_full_scan_parity.rs
@@ -1,0 +1,187 @@
+//! Issue #1085: a full-table `SELECT *` over a compressed, *clustered* table must
+//! return every clustering row — in EVERY feature build, including the `tombstones`
+//! feature (which `--all-features` enables).
+//!
+//! ROOT CAUSE (not what the issue title says): the bug was never in `experimental`
+//! / legacy compression heuristics. It was the `#[cfg(feature = "tombstones")]`
+//! variant of `SSTableManager::scan`, which grouped per-row scan results into a
+//! `HashMap` keyed on `RowKey`. `RowKey` carries only the *partition-key* bytes
+//! (no clustering), so all clustering rows of a partition collided into one bucket
+//! and `TombstoneMerger::merge_generations` collapsed each bucket to a single row.
+//! A `SELECT *` over `test_timeseries.sensor_data` (10 partitions × 200 clustering
+//! rows = 2000 rows, LZ4-compressed `nb`) therefore returned only ~one partition's
+//! worth of rows, stripped down to just the clustering column — instead of 2000
+//! fully-populated rows. The fix makes the (now single) `scan` implementation
+//! concatenate every row and reconcile only ACROSS generations, exactly like the
+//! default build.
+//!
+//! This is an END-TO-END regression test driving the same `Database::execute`
+//! query path the CLI uses. It asserts the full-scan row count for a clustered
+//! compressed table equals the committed sstabledump JSONL golden, AND that the
+//! rows carry their partition-key + regular columns (not just the clustering key).
+//!
+//! Fixtures resolve via `CQLITE_DATASETS_ROOT`; the table-dir UUID is never
+//! hardcoded (globbed by `<table>-` prefix). When the dataset (or its gitignored
+//! `*.db` binaries) is absent, the test SKIPs cleanly. When the fixture IS present,
+//! a zero-row or mismatched result FAILS loudly.
+//!
+//! Requires `cli-helpers` (the `ingestion` module that builds a queryable
+//! `Database`) and `state_machine` (the query engine); without them the file
+//! compiles out, matching the other end-to-end SELECT integration tests.
+#![cfg(all(feature = "state_machine", feature = "cli-helpers"))]
+
+use std::path::{Path, PathBuf};
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::Database;
+
+const KEYSPACE_FILTER: &str = "/test_timeseries/";
+
+fn datasets_root() -> Option<PathBuf> {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+}
+
+fn schema_path() -> Option<PathBuf> {
+    if let Some(root) = datasets_root() {
+        let p = root.parent()?.join("schemas").join("time-series.cql");
+        if p.exists() {
+            return Some(p);
+        }
+    }
+    let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let p = manifest
+        .parent()?
+        .join("test-data")
+        .join("schemas")
+        .join("time-series.cql");
+    p.exists().then_some(p)
+}
+
+/// Resolve `<root>/sstables/test_timeseries/<table>-<uuid>/`, globbing by prefix.
+fn fixture_dir(table: &str) -> Option<PathBuf> {
+    let root = datasets_root()?;
+    let ks_dir = root.join("sstables").join("test_timeseries");
+    if !ks_dir.is_dir() {
+        return None;
+    }
+    let prefix = format!("{table}-");
+    std::fs::read_dir(&ks_dir)
+        .ok()?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .find(|p| {
+            p.is_dir()
+                && p.file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|n| n.starts_with(&prefix))
+                    .unwrap_or(false)
+        })
+}
+
+/// Count the total CQL rows in the committed sstabledump JSONL golden (sum of the
+/// `rows` arrays across every partition line, counting only `type == "row"`).
+fn golden_row_count(table: &str) -> Option<usize> {
+    let dir = fixture_dir(table)?;
+    let jsonl = dir.join("nb-1-big-Data.db.jsonl");
+    let text = std::fs::read_to_string(&jsonl).ok()?;
+    let mut total = 0usize;
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let v: serde_json::Value = serde_json::from_str(line)
+            .unwrap_or_else(|e| panic!("{table}: golden JSONL parse failed: {e}\nline: {line}"));
+        if let Some(rows) = v.get("rows").and_then(|r| r.as_array()) {
+            total += rows
+                .iter()
+                .filter(|r| r.get("type").and_then(|t| t.as_str()) == Some("row"))
+                .count();
+        }
+    }
+    Some(total)
+}
+
+/// Ingest the `test_timeseries` keyspace and return a queryable `Database`, or a
+/// skip reason. The Data.db binaries are gitignored, so a missing fixture SKIPs.
+async fn setup_db() -> Result<Database, String> {
+    let root = datasets_root().ok_or("CQLITE_DATASETS_ROOT unset or path missing")?;
+    let schema = schema_path().ok_or("time-series.cql schema not found")?;
+    let data_dir = root.join("sstables");
+    if !data_dir.exists() {
+        return Err(format!("sstables dir not found at {data_dir:?}"));
+    }
+    let sensor = fixture_dir("sensor_data").ok_or("test_timeseries/sensor_data-* dir absent")?;
+    if !sensor.join("nb-1-big-Data.db").exists() {
+        return Err(format!(
+            "sensor_data Data.db missing (binary not fetched) at {sensor:?}"
+        ));
+    }
+
+    let cfg = IngestionConfig {
+        schema_paths: vec![schema],
+        data_dir,
+        version_hint: None,
+        core_config: cqlite_core::Config::default(),
+        table_directory_filter: Some(KEYSPACE_FILTER.to_string()),
+    };
+    let result = ingest(cfg).await.map_err(|e| format!("ingestion: {e}"))?;
+    if result.schema_load_result.schemas_loaded == 0 {
+        return Err("no schemas loaded".into());
+    }
+    Ok(result.database)
+}
+
+/// The load-bearing regression: a clustered, LZ4-compressed `nb` table whose
+/// partitions each hold many clustering rows. The `tombstones`-feature scan used
+/// to collapse each partition to one row (≈2000 → ≈200, columns reduced to the
+/// clustering key). This asserts BOTH the full row count and that the rows carry
+/// the partition key + regular columns.
+#[tokio::test]
+async fn sensor_data_full_scan_returns_all_clustering_rows() {
+    let db = match setup_db().await {
+        Ok(db) => db,
+        Err(skip) => {
+            eprintln!("SKIP sensor_data_full_scan_returns_all_clustering_rows: {skip}");
+            return;
+        }
+    };
+
+    let golden = golden_row_count("sensor_data")
+        .expect("sensor_data fixture present but golden JSONL missing/unreadable");
+    assert!(
+        golden > 0,
+        "golden row count must be > 0 (fixture sanity); got {golden}"
+    );
+
+    let result = db
+        .execute("SELECT * FROM test_timeseries.sensor_data")
+        .await
+        .expect("SELECT * over sensor_data must succeed");
+
+    assert_eq!(
+        result.rows.len(),
+        golden,
+        "full-scan row count {} != sstabledump golden {} — the tombstones scan path \
+         collapsed multi-row partitions (issue #1085)",
+        result.rows.len(),
+        golden
+    );
+
+    // The collapse symptom also stripped every column except the clustering key.
+    // Assert the partition key and a regular column survive on every row.
+    for (i, row) in result.rows.iter().enumerate() {
+        assert!(
+            row.values.contains_key("sensor_id"),
+            "row {i} is missing the partition-key column `sensor_id` — \
+             rows were collapsed to the clustering key only (issue #1085)"
+        );
+        assert!(
+            row.values.contains_key("temperature") || row.values.contains_key("location"),
+            "row {i} is missing all regular columns — rows were collapsed (issue #1085)"
+        );
+    }
+}

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -51,7 +51,7 @@ if ! command -v cargo >/dev/null 2>&1 && [ -d "$HOME/.cargo/bin" ]; then
 fi
 export CQLITE_DATASETS_ROOT="${CQLITE_DATASETS_ROOT:-$REPO_ROOT/test-data/datasets}"
 
-COMPONENTS=(fmt clippy core-tests integration-tests format-compat write-tests cli-tests python-bindings minimal-build smoke)
+COMPONENTS=(fmt clippy core-tests tombstones-scan integration-tests format-compat write-tests cli-tests python-bindings minimal-build smoke)
 ONLY=""
 case "${1:-}" in
   --list) printf '%s\n' "${COMPONENTS[@]}"; exit 0 ;;
@@ -149,6 +149,12 @@ run_component fmt cargo fmt --all --check
 run_component clippy env RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features
 run_component core-tests cargo test --package cqlite-core --features cli-helpers -- \
   --skip test_legacy_format_allows_blob_fallback_with_feature
+# Issue #1085: the row-collapse bug lived in the `tombstones`-feature scan path,
+# which the default gate run (cli-helpers) never compiles. Run the full-scan
+# regression test under `tombstones` so a re-introduction can't ship green.
+run_component tombstones-scan cargo test --package cqlite-core \
+  --features write-support,cli-helpers,tombstones \
+  --test issue_1085_tombstones_full_scan_parity
 # Compile EVERY target in the package first (--no-run, whole package) so a
 # new/edited test file that doesn't compile can't hide behind the enumerated
 # run-list (issue #865); then execute the seven CI-enforced targets.


### PR DESCRIPTION
Closes #1085.

## Real root cause (issue premise was wrong)
The bug attributed to the `experimental` feature / legacy compression heuristics was actually the **`tombstones`** cargo feature (enabled by `--all-features`). Its `#[cfg(feature = "tombstones")]` `SSTableManager::scan` grouped per-row scan results into a `HashMap` keyed on `RowKey` — which carries only the **partition-key bytes, no clustering** — then ran `TombstoneMerger::merge_generations`. All clustering rows of a partition collided into one bucket and collapsed to a single row, stripped down to the clustering column.

Confirmed repro: `SELECT * FROM test_timeseries.sensor_data` (10 partitions × 200 rows, LZ4 `nb`) returned **200 rows** (one partition, `timestamp`-only) under `--features ...,tombstones` / `--all-features`, vs the correct **2000** under `--features write-support,cli-helpers`. `--all-features` enables `tombstones`; CI only ran `--all-features` for clippy/build/doc (not query tests), so CI stayed green.

## Fix
- Remove the broken `tombstones`-only `scan`; make the correct concatenate-then-reconcile-across-generations `scan` the single implementation for all builds.
- De-gate `resolve_reader_list`; widen `merge_generations_for_read` to `#[cfg(feature = "write-support")]` so the unified path compiles under `tombstones`.
- The default (`not(tombstones)`) build is **byte-identical**; only the `tombstones` build changes behavior. The no-write-support multi-generation concat fallback (Issue #883) is now identical across every feature build — no build regresses vs the default.

## Tests / gate
- New end-to-end regression test `issue_1085_tombstones_full_scan_parity.rs`: full `SELECT *` over a multi-partition clustered table (`sensor_data`, 2000 rows) and a **single-partition multi-chunk** table (`test_tomb.wide_range_tombstone`, 2987 rows). Asserts row count == sstabledump JSONL golden and that rows retain partition-key + regular columns. Fails under `tombstones` before the fix; skips when fixtures absent.
- New `tombstones-scan` agent-gate component runs the regression test under `write-support,cli-helpers,tombstones` (the default gate run never compiles that path).
- fmt + `clippy --workspace --all-targets --all-features` clean. Gate green except the known-flaky `test_flush_throughput` perf test (29.9 MB/sec on retry; read-only change, unrelated).

## Reviews
roborev: PASS (job 1378, no issues). rust-reviewer: approve. spec-auditor: PASS. coverage-reviewer findings addressed.