### PR TITLE
fix(ci): gate dataset download on Data.db core fixture, not JSONL count (#1097)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,11 @@ jobs:
         # #1080 no-silent-skip guard hard-fail. Gate on the core fixture instead.
         run: |
           set -euo pipefail
-          if find test-data/datasets/sstables/test_basic -path '*simple_table-*-Data.db' 2>/dev/null | grep -q .; then
+          # Capture into a var rather than piping find into grep -q / head: under
+          # `set -o pipefail`, a downstream consumer that closes the pipe early
+          # makes find exit non-zero (SIGPIPE), which would abort the step.
+          CORE_FIXTURE=$(find test-data/datasets/sstables/test_basic -path '*simple_table-*-Data.db' 2>/dev/null || true)
+          if [ -n "$CORE_FIXTURE" ]; then
             echo "✅ Core Data.db fixture present; skipping download"
           else
             echo "📦 Core Data.db fixture missing — fetching ${DATASET_ASSET}..."
@@ -70,12 +74,14 @@ jobs:
         run: |
           set -euo pipefail
           test -f test-data/datasets/metadata.yml
-          find test-data/datasets/sstables -name "*-Data.db" | head -n 1
-          # Fail loudly here rather than letting the #1080 guard panic mid-test (#1097)
-          if ! find test-data/datasets/sstables/test_basic -path '*simple_table-*-Data.db' 2>/dev/null | grep -q .; then
+          # Fail loudly here rather than letting the #1080 guard panic mid-test (#1097).
+          # Capture into a var (see Fetch step) to stay pipefail-safe.
+          CORE_FIXTURE=$(find test-data/datasets/sstables/test_basic -path '*simple_table-*-Data.db' 2>/dev/null || true)
+          if [ -z "$CORE_FIXTURE" ]; then
             echo "❌ Core fixture test_basic/simple_table-*/*-Data.db missing after fetch" >&2
             exit 1
           fi
+          echo "✅ Core fixture present: ${CORE_FIXTURE}"
 
       - name: Validate environment
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,20 +48,34 @@ jobs:
           path: test-data/datasets
           key: datasets-${{ env.DATASET_TAG }}-${{ env.DATASET_SHA256 }}
 
-      - name: Fetch datasets if cache miss
-        if: steps.dataset-cache.outputs.cache-hit != 'true'
+      - name: Fetch datasets if Data.db fixture missing
+        # Do NOT trust cache-hit alone (#1097): a restored cache can be partial
+        # (JSONL refs without the SSTable Data.db binaries), which makes the
+        # #1080 no-silent-skip guard hard-fail. Gate on the core fixture instead.
         run: |
           set -euo pipefail
-          mkdir -p test-data/datasets
-          curl -fsSL -o /tmp/${DATASET_ASSET} \
-            https://github.com/pmcfadin/cqlite/releases/download/${DATASET_TAG}/${DATASET_ASSET}
-          echo "${DATASET_SHA256}  /tmp/${DATASET_ASSET}" | sha256sum -c -
-          tar -xzf /tmp/${DATASET_ASSET} -C . --exclude='*/._*' --exclude='._*' --exclude='*/.DS_Store' --exclude='.DS_Store'
+          if find test-data/datasets/sstables/test_basic -path '*simple_table-*-Data.db' 2>/dev/null | grep -q .; then
+            echo "✅ Core Data.db fixture present; skipping download"
+          else
+            echo "📦 Core Data.db fixture missing — fetching ${DATASET_ASSET}..."
+            rm -rf test-data/datasets
+            mkdir -p test-data/datasets
+            curl -fsSL -o /tmp/${DATASET_ASSET} \
+              https://github.com/pmcfadin/cqlite/releases/download/${DATASET_TAG}/${DATASET_ASSET}
+            echo "${DATASET_SHA256}  /tmp/${DATASET_ASSET}" | sha256sum -c -
+            tar -xzf /tmp/${DATASET_ASSET} -C . --exclude='*/._*' --exclude='._*' --exclude='*/.DS_Store' --exclude='.DS_Store'
+          fi
 
       - name: Sanity check dataset
         run: |
+          set -euo pipefail
           test -f test-data/datasets/metadata.yml
           find test-data/datasets/sstables -name "*-Data.db" | head -n 1
+          # Fail loudly here rather than letting the #1080 guard panic mid-test (#1097)
+          if ! find test-data/datasets/sstables/test_basic -path '*simple_table-*-Data.db' 2>/dev/null | grep -q .; then
+            echo "❌ Core fixture test_basic/simple_table-*/*-Data.db missing after fetch" >&2
+            exit 1
+          fi
 
       - name: Validate environment
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -73,27 +73,32 @@ jobs:
         echo "🔍 Checking for existing datasets..."
         ls -la test-data/ || echo "📁 test-data directory does not exist"
 
-        DB_COUNT=$(find test-data -name '*.db' 2>/dev/null | wc -l)
-        echo "📊 Current dataset count: $DB_COUNT SSTable files"
+        # Gate the download on the SSTable Data.db core fixture, NOT any *.db
+        # count (#1097). A partial/stale cache can restore JSONL refs (and even
+        # some unrelated *.db files) without the test_basic/simple_table Data.db
+        # binary that the #1080 no-silent-skip guard requires.
+        CORE_FIXTURE_COUNT=$(find test-data/datasets/sstables/test_basic -path '*simple_table-*-Data.db' 2>/dev/null | wc -l)
+        echo "📊 Core Data.db fixture count: $CORE_FIXTURE_COUNT"
 
-        if [ "$DB_COUNT" -eq 0 ]; then
-          echo "📦 No datasets found - downloading full Cassandra 5 datasets from release..."
+        if [ "$CORE_FIXTURE_COUNT" -eq 0 ]; then
+          echo "📦 Core Data.db fixture missing - downloading full Cassandra 5 datasets from release..."
           mkdir -p test-data
           echo "🔍 Downloading cassandra5-small-full-v3.1.tar.gz from datasets-v3 release..."
           gh release download datasets-v3 --pattern "cassandra5-small-full-v3.1.tar.gz" --dir /tmp
           echo "f5fa0b6599a27c1c493d7c6c063194d55d031cab417396947313e7245afc5ceb  /tmp/cassandra5-small-full-v3.1.tar.gz" | sha256sum -c -
           echo "📦 Extracting datasets to repo root..."
+          rm -rf test-data/datasets
           tar -xzf /tmp/cassandra5-small-full-v3.1.tar.gz -C . --exclude='*/._*' --exclude='._*' --exclude='*/.DS_Store' --exclude='.DS_Store'
-          
+
           # Verify extraction
-          NEW_DB_COUNT=$(find test-data -name '*.db' 2>/dev/null | wc -l)
-          echo "✅ Extraction complete - now have $NEW_DB_COUNT SSTable files"
+          NEW_DB_COUNT=$(find test-data/datasets/sstables -name '*-Data.db' 2>/dev/null | wc -l)
+          echo "✅ Extraction complete - now have $NEW_DB_COUNT Data.db fixtures"
           echo "📁 Contents of test-data/:"
           ls -la test-data/
           echo "📁 Contents of test-data/datasets/:"
           ls -la test-data/datasets/ || echo "❌ Datasets directory missing after extraction"
         else
-          echo "✅ Cache hit - using cached Cassandra 5 datasets ($DB_COUNT files)"
+          echo "✅ Cache hit - core Data.db fixture present"
         fi
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/m1-ci.yml
+++ b/.github/workflows/m1-ci.yml
@@ -63,18 +63,22 @@ jobs:
 
     - name: Download Cassandra 5 Datasets (if cache miss)
       run: |
-        JSONL_COUNT=$(find test-data -name '*.jsonl' 2>/dev/null | wc -l)
-        if [ "$JSONL_COUNT" -eq 0 ]; then
-          echo "📦 Downloading real Cassandra 5 datasets from release (datasets-v3, includes oa+da fixtures)..."
+        # Gate the download on the SSTable Data.db core fixture, NOT the JSONL
+        # reference count (#1097). A partial/stale cache can restore the 135 JSONL
+        # refs without the Data.db binaries; gating on JSONL count then skips the
+        # re-download and the #1080 no-silent-skip guard hard-fails mid-test.
+        CORE_FIXTURE_COUNT=$(find test-data/datasets/sstables/test_basic -path '*simple_table-*-Data.db' 2>/dev/null | wc -l)
+        if [ "$CORE_FIXTURE_COUNT" -eq 0 ]; then
+          echo "📦 Core Data.db fixture missing — downloading real Cassandra 5 datasets from release (datasets-v3, includes oa+da fixtures)..."
           mkdir -p test-data
           gh release download datasets-v3 --pattern "cassandra5-small-full-v3.1.tar.gz" --dir /tmp
           echo "f5fa0b6599a27c1c493d7c6c063194d55d031cab417396947313e7245afc5ceb  /tmp/cassandra5-small-full-v3.1.tar.gz" | sha256sum -c -
           rm -rf test-data/datasets
           tar -xzf /tmp/cassandra5-small-full-v3.1.tar.gz -C . --exclude='*/._*' --exclude='._*' --exclude='*/.DS_Store' --exclude='.DS_Store'
-          JSONL_COUNT=$(find test-data -name '*.jsonl' 2>/dev/null | wc -l)
-          echo "✅ Downloaded $JSONL_COUNT reference files and SSTable data for M1 CI"
+          DATA_COUNT=$(find test-data/datasets/sstables -name '*-Data.db' 2>/dev/null | wc -l)
+          echo "✅ Downloaded datasets for M1 CI ($DATA_COUNT Data.db fixtures)"
         else
-          echo "✅ Using cached datasets ($JSONL_COUNT reference files)"
+          echo "✅ Using cached datasets (core Data.db fixture present)"
         fi
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -281,18 +285,22 @@ jobs:
 
     - name: Download Cassandra 5 Datasets (if cache miss)
       run: |
-        JSONL_COUNT=$(find test-data -name '*.jsonl' 2>/dev/null | wc -l)
-        if [ "$JSONL_COUNT" -eq 0 ]; then
-          echo "📦 Downloading real Cassandra 5 datasets from release (datasets-v3, includes oa+da fixtures)..."
+        # Gate the download on the SSTable Data.db core fixture, NOT the JSONL
+        # reference count (#1097). A partial/stale cache can restore the 135 JSONL
+        # refs without the Data.db binaries; gating on JSONL count then skips the
+        # re-download and the #1080 no-silent-skip guard hard-fails mid-test.
+        CORE_FIXTURE_COUNT=$(find test-data/datasets/sstables/test_basic -path '*simple_table-*-Data.db' 2>/dev/null | wc -l)
+        if [ "$CORE_FIXTURE_COUNT" -eq 0 ]; then
+          echo "📦 Core Data.db fixture missing — downloading real Cassandra 5 datasets from release (datasets-v3, includes oa+da fixtures)..."
           mkdir -p test-data
           gh release download datasets-v3 --pattern "cassandra5-small-full-v3.1.tar.gz" --dir /tmp
           echo "f5fa0b6599a27c1c493d7c6c063194d55d031cab417396947313e7245afc5ceb  /tmp/cassandra5-small-full-v3.1.tar.gz" | sha256sum -c -
           rm -rf test-data/datasets
           tar -xzf /tmp/cassandra5-small-full-v3.1.tar.gz -C . --exclude='*/._*' --exclude='._*' --exclude='*/.DS_Store' --exclude='.DS_Store'
-          JSONL_COUNT=$(find test-data -name '*.jsonl' 2>/dev/null | wc -l)
-          echo "✅ Downloaded $JSONL_COUNT reference files for parity validation"
+          DATA_COUNT=$(find test-data/datasets/sstables -name '*-Data.db' 2>/dev/null | wc -l)
+          echo "✅ Downloaded datasets for parity validation ($DATA_COUNT Data.db fixtures)"
         else
-          echo "✅ Using cached datasets ($JSONL_COUNT reference files)"
+          echo "✅ Using cached datasets (core Data.db fixture present)"
         fi
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Fixes #1097 — `main` is red on **Core Validation (Ubuntu)**, **test**, and **Code Coverage Check** because the `#1080` no-silent-skip regression tests hard-fail when `CQLITE_DATASETS_ROOT` points at a fixture-less tree.

**Root cause:** dataset-setup steps gated the release-tarball download on the JSONL reference count (m1-ci.yml), any `*.db` count (coverage.yml), or `actions/cache` cache-hit (ci.yml). A partial/stale cache restores the 135 JSONL refs **without** the SSTable `Data.db` binaries, so the gate skips re-download and the tests panic mid-run.

## Fix
Gate on the core fixture the `#1080` guard actually requires — `test_basic/simple_table-*/*-Data.db` — across all dataset-fetching lanes:

- **ci.yml**: stop trusting `cache-hit`; fetch when the fixture is absent, and make the sanity-check step fail loudly (early, clear) if it is still missing after fetch.
- **m1-ci.yml** (both download steps): replace `JSONL_COUNT` gate with the fixture gate.
- **coverage.yml**: replace any-`*.db` gate with the fixture gate.

All gates use only static `find`/`grep` — no untrusted workflow inputs.

## Validation
- All three workflow YAMLs parse.
- Gate shell logic unit-tested: no dir → download, **jsonl-only → download (the bug case)**, fixture present → skip.
- Fixture glob confirmed to match exactly one real `Data.db` in the dataset layout.

Closes #1097