### PR TITLE
ci(release): publish multi-arch cqlite-flight gRPC image to GHCR per tag

### DIFF
--- a/.github/workflows/flight-image.yml
+++ b/.github/workflows/flight-image.yml
@@ -1,0 +1,143 @@
+name: cqlite-flight image
+
+# Build and publish the cqlite-flight Arrow Flight (gRPC) server container to
+# GHCR. Runs automatically on every v* release tag, and on demand via the
+# "Run workflow" button (workflow_dispatch) with a custom image tag — so you
+# can cut a one-off image without tagging a release.
+#
+# The image exposes the Flight gRPC listener on :8815 and reads SSTables from a
+# directory mounted at runtime (--data-dir). The Trino connector is released
+# separately (it ships as a Trino plugin, not in this image).
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Tag to publish the image under (e.g. dev, 0.13.0-rc1)'
+        required: true
+        default: 'dev'
+
+env:
+  CARGO_TERM_COLOR: always
+  # GHCR repo. Must be lowercase; `pmcfadin` already is.
+  REGISTRY_IMAGE: ghcr.io/${{ github.repository_owner }}/cqlite-flight
+
+jobs:
+  # Build per architecture on a NATIVE runner (amd64 on ubuntu-latest, arm64 on
+  # ubuntu-24.04-arm) and push each by digest. Native runners avoid
+  # QEMU-emulated Rust compiles, which are slow and prone to OOM. The multi-arch
+  # manifest is assembled in the `merge` job below.
+  build:
+    name: Build (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    steps:
+    - name: Prepare platform tag
+      run: |
+        platform="${{ matrix.platform }}"
+        echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+
+    - uses: actions/checkout@v5
+
+    - name: Docker metadata (labels)
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY_IMAGE }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push by digest
+      id: build
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: cqlite-flight/Dockerfile
+        platforms: ${{ matrix.platform }}
+        labels: ${{ steps.meta.outputs.labels }}
+        outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+    - name: Export digest
+      run: |
+        mkdir -p "${{ runner.temp }}/digests"
+        digest="${{ steps.build.outputs.digest }}"
+        touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+    - name: Upload digest
+      uses: actions/upload-artifact@v4
+      with:
+        name: digests-${{ env.PLATFORM_PAIR }}
+        path: ${{ runner.temp }}/digests/*
+        if-no-files-found: error
+        retention-days: 1
+
+  # Assemble the per-arch digests into one multi-arch manifest list and apply
+  # the human tags. On a v* tag: vX.Y.Z, X.Y, and `latest` (non-prerelease).
+  # On a manual run: the `image_tag` input.
+  merge:
+    name: Publish multi-arch image
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - name: Download digests
+      uses: actions/download-artifact@v4
+      with:
+        path: ${{ runner.temp }}/digests
+        pattern: digests-*
+        merge-multiple: true
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Docker metadata (tags)
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY_IMAGE }}
+        tags: |
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=raw,value=latest,enable=${{ github.event_name == 'push' && !contains(github.ref_name, '-') }}
+          type=raw,value=${{ github.event.inputs.image_tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
+
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Create manifest list and push
+      working-directory: ${{ runner.temp }}/digests
+      run: |
+        docker buildx imagetools create \
+          $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+          $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+
+    - name: Inspect image
+      run: |
+        docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,6 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-  # GHCR repo for the cqlite-flight Arrow Flight (gRPC) server image. Must be
-  # lowercase; `pmcfadin` already is. The Trino connector is released
-  # separately (it ships as a Trino plugin, not in this image).
-  REGISTRY_IMAGE: ghcr.io/${{ github.repository_owner }}/cqlite-flight
 
 jobs:
   build-cli:
@@ -125,124 +121,6 @@ jobs:
           ./cqlite-${{ matrix.target }}.${{ contains(matrix.target, 'windows') && 'zip' || 'tar.gz' }}.sha256
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  # Build the cqlite-flight container per architecture on a NATIVE runner
-  # (amd64 on ubuntu-latest, arm64 on ubuntu-24.04-arm) and push each by digest.
-  # Native runners avoid QEMU-emulated Rust compiles, which are slow and prone
-  # to OOM. The multi-arch manifest is assembled in the `merge-flight-image`
-  # job below. The image exposes the Arrow Flight gRPC listener on :8815 and
-  # reads SSTables from a directory mounted at runtime (`--data-dir`).
-  build-flight-image:
-    name: Build cqlite-flight image (${{ matrix.platform }})
-    runs-on: ${{ matrix.runner }}
-    if: startsWith(github.ref, 'refs/tags/v')
-    permissions:
-      contents: read
-      packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: linux/amd64
-            runner: ubuntu-latest
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-    steps:
-    - name: Prepare platform tag
-      run: |
-        platform="${{ matrix.platform }}"
-        echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
-
-    - uses: actions/checkout@v5
-
-    - name: Docker metadata (labels)
-      id: meta
-      uses: docker/metadata-action@v5
-      with:
-        images: ${{ env.REGISTRY_IMAGE }}
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
-    - name: Log in to GHCR
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Build and push by digest
-      id: build
-      uses: docker/build-push-action@v6
-      with:
-        context: .
-        file: cqlite-flight/Dockerfile
-        platforms: ${{ matrix.platform }}
-        labels: ${{ steps.meta.outputs.labels }}
-        outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-
-    - name: Export digest
-      run: |
-        mkdir -p "${{ runner.temp }}/digests"
-        digest="${{ steps.build.outputs.digest }}"
-        touch "${{ runner.temp }}/digests/${digest#sha256:}"
-
-    - name: Upload digest
-      uses: actions/upload-artifact@v4
-      with:
-        name: digests-${{ env.PLATFORM_PAIR }}
-        path: ${{ runner.temp }}/digests/*
-        if-no-files-found: error
-        retention-days: 1
-
-  # Assemble the per-arch digests into a single multi-arch manifest list and
-  # apply the human tags (vX.Y.Z, X.Y, and `latest` for non-prerelease tags).
-  merge-flight-image:
-    name: Publish multi-arch cqlite-flight image
-    runs-on: ubuntu-latest
-    needs: build-flight-image
-    if: startsWith(github.ref, 'refs/tags/v')
-    permissions:
-      contents: read
-      packages: write
-    steps:
-    - name: Download digests
-      uses: actions/download-artifact@v4
-      with:
-        path: ${{ runner.temp }}/digests
-        pattern: digests-*
-        merge-multiple: true
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
-    - name: Docker metadata (tags)
-      id: meta
-      uses: docker/metadata-action@v5
-      with:
-        images: ${{ env.REGISTRY_IMAGE }}
-        tags: |
-          type=semver,pattern={{version}}
-          type=semver,pattern={{major}}.{{minor}}
-          type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
-
-    - name: Log in to GHCR
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Create manifest list and push
-      working-directory: ${{ runner.temp }}/digests
-      run: |
-        docker buildx imagetools create \
-          $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-          $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
-
-    - name: Inspect image
-      run: |
-        docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
 
   # Append the changelog + hosted API-docs links to the auto-generated release
   # notes. Runs once per tag (no matrix) so the body is set a single time (#563).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # GHCR repo for the cqlite-flight Arrow Flight (gRPC) server image. Must be
+  # lowercase; `pmcfadin` already is. The Trino connector is released
+  # separately (it ships as a Trino plugin, not in this image).
+  REGISTRY_IMAGE: ghcr.io/${{ github.repository_owner }}/cqlite-flight
 
 jobs:
   build-cli:
@@ -121,6 +125,124 @@ jobs:
           ./cqlite-${{ matrix.target }}.${{ contains(matrix.target, 'windows') && 'zip' || 'tar.gz' }}.sha256
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Build the cqlite-flight container per architecture on a NATIVE runner
+  # (amd64 on ubuntu-latest, arm64 on ubuntu-24.04-arm) and push each by digest.
+  # Native runners avoid QEMU-emulated Rust compiles, which are slow and prone
+  # to OOM. The multi-arch manifest is assembled in the `merge-flight-image`
+  # job below. The image exposes the Arrow Flight gRPC listener on :8815 and
+  # reads SSTables from a directory mounted at runtime (`--data-dir`).
+  build-flight-image:
+    name: Build cqlite-flight image (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    steps:
+    - name: Prepare platform tag
+      run: |
+        platform="${{ matrix.platform }}"
+        echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+
+    - uses: actions/checkout@v5
+
+    - name: Docker metadata (labels)
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY_IMAGE }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push by digest
+      id: build
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: cqlite-flight/Dockerfile
+        platforms: ${{ matrix.platform }}
+        labels: ${{ steps.meta.outputs.labels }}
+        outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+    - name: Export digest
+      run: |
+        mkdir -p "${{ runner.temp }}/digests"
+        digest="${{ steps.build.outputs.digest }}"
+        touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+    - name: Upload digest
+      uses: actions/upload-artifact@v4
+      with:
+        name: digests-${{ env.PLATFORM_PAIR }}
+        path: ${{ runner.temp }}/digests/*
+        if-no-files-found: error
+        retention-days: 1
+
+  # Assemble the per-arch digests into a single multi-arch manifest list and
+  # apply the human tags (vX.Y.Z, X.Y, and `latest` for non-prerelease tags).
+  merge-flight-image:
+    name: Publish multi-arch cqlite-flight image
+    runs-on: ubuntu-latest
+    needs: build-flight-image
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - name: Download digests
+      uses: actions/download-artifact@v4
+      with:
+        path: ${{ runner.temp }}/digests
+        pattern: digests-*
+        merge-multiple: true
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Docker metadata (tags)
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY_IMAGE }}
+        tags: |
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
+
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Create manifest list and push
+      working-directory: ${{ runner.temp }}/digests
+      run: |
+        docker buildx imagetools create \
+          $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+          $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+
+    - name: Inspect image
+      run: |
+        docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
 
   # Append the changelog + hosted API-docs links to the auto-generated release
   # notes. Runs once per tag (no matrix) so the body is set a single time (#563).

--- a/README.md
+++ b/README.md
@@ -101,6 +101,23 @@ pip install cqlite-py        # Python
 npm install @cqlite/node     # Node.js
 ```
 
+### Arrow Flight server (container)
+
+Query a Cassandra node's SSTables over Arrow Flight (gRPC) with the
+`cqlite-flight` server, published as a multi-arch image on every release tag.
+Mount the data dir read-only and point `--data-dir` at it:
+
+```bash
+docker run --rm -p 8815:8815 \
+  -v /var/lib/cassandra:/var/lib/cassandra:ro \
+  ghcr.io/pmcfadin/cqlite-flight:latest \
+  --data-dir /var/lib/cassandra/data --listen 0.0.0.0:8815
+```
+
+See [`cqlite-flight/README.md`](cqlite-flight/README.md) for image tags, the
+ticket/predicate API, and the [`trino-connector`](trino-connector) that builds
+on it.
+
 ## Quick Start
 
 ```bash

--- a/cqlite-flight/README.md
+++ b/cqlite-flight/README.md
@@ -90,10 +90,11 @@ cargo run -p cqlite-flight -- \
   --listen 0.0.0.0:8815 \
   --batch-size 8192
 
-# container (built from this repo; see Dockerfile)
+# container — published to GHCR on every release tag (multi-arch amd64/arm64).
+# Mount the Cassandra data dir read-only and point --data-dir at it.
 docker run --rm -p 8815:8815 \
   -v /var/lib/cassandra:/var/lib/cassandra:ro \
-  ghcr.io/<owner>/cqlite-flight:latest \
+  ghcr.io/pmcfadin/cqlite-flight:latest \
   --data-dir /var/lib/cassandra/data --listen 0.0.0.0:8815
 ```
 

--- a/cqlite-flight/README.md
+++ b/cqlite-flight/README.md
@@ -89,13 +89,6 @@ cargo run -p cqlite-flight -- \
   --data-dir /var/lib/cassandra/data \
   --listen 0.0.0.0:8815 \
   --batch-size 8192
-
-# container — published to GHCR on every release tag (multi-arch amd64/arm64).
-# Mount the Cassandra data dir read-only and point --data-dir at it.
-docker run --rm -p 8815:8815 \
-  -v /var/lib/cassandra:/var/lib/cassandra:ro \
-  ghcr.io/pmcfadin/cqlite-flight:latest \
-  --data-dir /var/lib/cassandra/data --listen 0.0.0.0:8815
 ```
 
 | Flag | Default | Description |
@@ -105,6 +98,73 @@ docker run --rm -p 8815:8815 \
 | `--batch-size` | `8192` | Max rows per Arrow record batch. |
 
 `RUST_LOG=info` enables logging (per-SSTable reads, etc.).
+
+## Container image (GHCR)
+
+The server is published as a multi-arch (`linux/amd64` + `linux/arm64`) image to
+the GitHub Container Registry on every release tag:
+
+```
+ghcr.io/pmcfadin/cqlite-flight
+```
+
+| Tag | Points at |
+|-----|-----------|
+| `vX.Y.Z` | An exact release (e.g. `v0.12.0`). |
+| `X.Y` | The latest patch on a minor line (e.g. `0.12`). |
+| `latest` | The most recent **stable** release (prereleases excluded). |
+| custom | One-off images cut via the manual workflow (see below). |
+
+The container exposes the Arrow Flight **gRPC** listener on `:8815` and reads
+SSTables from a directory you **mount at runtime** — it ships no data of its own.
+Run it co-located with a Cassandra node, mounting that node's data dir
+**read-only** and pointing `--data-dir` at it:
+
+```bash
+docker run --rm -p 8815:8815 \
+  -v /var/lib/cassandra:/var/lib/cassandra:ro \
+  -e RUST_LOG=info \
+  ghcr.io/pmcfadin/cqlite-flight:latest \
+  --data-dir /var/lib/cassandra/data --listen 0.0.0.0:8815
+```
+
+Notes:
+- **Read-only mount** (`:ro`) is recommended — the server never modifies the
+  SSTables, it merges them on the fly into Arrow batches.
+- Any directory laid out as `<keyspace>/<table>[-<uuid>]/` works as `--data-dir`;
+  it does not have to be a live Cassandra node (e.g. a snapshot or an exported
+  SSTable tree mounted from elsewhere).
+- The image runs as a non-root user (`uid 10001`); ensure the mounted path is
+  readable by that uid.
+- The Trino connector is **not** in this image — it ships separately as a Trino
+  plugin (see [`../trino-connector`](../trino-connector)).
+
+### Pulling a specific release
+
+```bash
+docker pull ghcr.io/pmcfadin/cqlite-flight:v0.12.0
+```
+
+### Cutting a one-off image (no release tag)
+
+Maintainers can build and push an image on demand without tagging a release:
+run the **“cqlite-flight image”** GitHub Actions workflow via *Run workflow*
+(`workflow_dispatch`) and supply an `image_tag` (e.g. `dev`). It publishes
+`ghcr.io/pmcfadin/cqlite-flight:<image_tag>`. The same workflow also runs
+automatically on every `v*` tag.
+
+To build locally instead (requires Docker Buildx and a GHCR login with
+`write:packages`):
+
+```bash
+# single-arch, load into the local docker daemon
+docker build -f cqlite-flight/Dockerfile -t cqlite-flight:dev .
+
+# multi-arch build + push to GHCR (run from the repo root)
+docker buildx build -f cqlite-flight/Dockerfile \
+  --platform linux/amd64,linux/arm64 \
+  -t ghcr.io/pmcfadin/cqlite-flight:dev --push .
+```
 
 ## Client example (Python / pyarrow)
 


### PR DESCRIPTION
Wire the existing cqlite-flight Arrow Flight (gRPC) server Dockerfile into
the release pipeline. On each v* tag, build the image natively per arch
(amd64 on ubuntu-latest, arm64 on ubuntu-24.04-arm to avoid emulated Rust
compiles), push each by digest, then assemble a multi-arch manifest tagged
vX.Y.Z, X.Y, and latest (non-prerelease) at ghcr.io/pmcfadin/cqlite-flight.

The image exposes the Flight gRPC listener on :8815 and reads SSTables from
a directory mounted at runtime via --data-dir. The Trino connector is not
included here; it ships separately as a Trino plugin.

Claude-Session: https://claude.ai/code/session_01YPqbfuPPxay2CZhiK3hd83