### PR TITLE
test(seek): fix work_counters intra-binary race greening main (#1071)

### DIFF
--- a/cqlite-core/Cargo.toml
+++ b/cqlite-core/Cargo.toml
@@ -123,6 +123,10 @@ proptest = { workspace = true }
 tempfile = "3.8"
 rand = "0.8"
 tokio-test = "0.4"
+# Serialize tests that read/mutate the process-global work_counters within one
+# test binary so cargo's parallel intra-binary threads cannot race the shared
+# atomics between a counter test's reset() and its read (issue #1071).
+serial_test = "3"
 insta = { version = "1.34", features = ["json"] }
 # cqlite-validation = { path = "../cqlite-validation" }
 fastrand = "2.0"

--- a/cqlite-core/tests/issue_953_within_sstable_seek.rs
+++ b/cqlite-core/tests/issue_953_within_sstable_seek.rs
@@ -49,6 +49,7 @@ use cqlite_core::ingestion::{ingest, IngestionConfig};
 use cqlite_core::query::result::QueryRow;
 use cqlite_core::storage::sstable::work_counters;
 use cqlite_core::{Database, Value};
+use serial_test::serial;
 
 /// Upper bound on `partitions_decoded()` for a single-partition seek.
 ///
@@ -246,8 +247,14 @@ async fn find_seek_positive_key(
 /// THE seek gate (Issue #953): a single-partition read decodes O(1) partitions.
 ///
 /// Both formats are checked in one test because `partitions_decoded()` is a
-/// process-global counter — two parallel `#[tokio::test]`s would race on it.
+/// process-global counter. `#[serial(work_counters)]` additionally serializes
+/// this test against the parity tests in this binary: those run `WHERE id = ?`
+/// lookups that bump the same global counter, and `cargo test` runs a binary's
+/// tests as parallel threads in ONE process — so without the named serial lock a
+/// sibling could increment `partitions_decoded` between this test's `reset()` and
+/// its read, inflating the count (issue #1071).
 #[tokio::test]
+#[serial(work_counters)]
 async fn within_sstable_seek_decodes_o1_partitions() {
     let mut checked_any = false;
 
@@ -348,8 +355,12 @@ async fn within_sstable_seek_decodes_o1_partitions() {
 }
 
 /// Byte-parity (BIG): the seek result equals the full-scan result filtered to the
-/// key, for every partition. Does NOT read the counter, so it runs in parallel.
+/// key, for every partition. It does not READ the counter, but its `WHERE id = ?`
+/// lookups MUTATE the process-global `partitions_decoded`, so it carries
+/// `#[serial(work_counters)]` to stay off the decode-bound test's measurement
+/// window (issue #1071).
 #[tokio::test]
+#[serial(work_counters)]
 async fn within_sstable_seek_matches_full_scan_big() {
     let db = match setup("basic-types.cql", "/test_basic/").await {
         Ok(db) => db,
@@ -401,8 +412,11 @@ async fn within_sstable_seek_matches_full_scan_big() {
     println!("Issue #953 (BIG): seek == full-scan parity for {checked} partitions");
 }
 
-/// Byte-parity (BTI): same as above for the trie-resolved seek path.
+/// Byte-parity (BTI): same as above for the trie-resolved seek path. Carries
+/// `#[serial(work_counters)]` for the same reason as the BIG parity test: its
+/// lookups mutate the shared counter (issue #1071).
 #[tokio::test]
+#[serial(work_counters)]
 async fn within_sstable_seek_matches_full_scan_bti() {
     let db = match setup("da-test.cql", "/test_da/").await {
         Ok(db) => db,


### PR DESCRIPTION
## Summary
Fixes #1071 and un-reds `main`'s `test` lane.

`main` was intermittently red on `issue_953_within_sstable_seek::within_sstable_seek_decodes_o1_partitions` (`decoded 4` vs `<= 2`). This is **not** a seek regression — the seek code and test are unchanged from a previously-green commit. Root cause is the process-global `work_counters` atomics: `cargo test` runs a binary's `#[tokio::test]`s as parallel threads in one process, and the two sibling parity tests in that binary run `WHERE id = ?` lookups that bump `PARTITIONS_DECODED` between the asserting test's `reset()` and its read.

## Fix
- Add `serial_test` dev-dependency to `cqlite-core`.
- Annotate all 3 tests in `issue_953_within_sstable_seek.rs` with `#[serial(work_counters)]` (named lock — serializes only the counter tests, not unrelated tests).

Reproduced ~1/30 at `--test-threads=8`; **40/40 stable** after the fix. The other counter-reading binaries (`issue_954`, `issue_962`) already serialize via a `PROBE_LOCK`; single-test binaries can't race intra-binary; `counters_round_trip` already uses a local `Counters` instance. **No production code changed** — counter semantics stay process-global atomics.

## Validation
- roborev branch review: **No issues found**.
- `agent-gate.sh`: fmt PASS, clippy PASS, tombstones-scan/integration/format-compat PASS. The sole `core-tests` failure was the **known pre-existing flaky** `test_flush_throughput` (perf test), which passes on re-run — unrelated to this change.

Closes #1071