### PR TITLE
fix(stats): decode STATS max local deletion time + tombstone-drop histogram (#1073)

### DIFF
--- a/cqlite-core/src/parser/enhanced_statistics_parser.rs
+++ b/cqlite-core/src/parser/enhanced_statistics_parser.rs
@@ -2345,7 +2345,7 @@ pub fn parse_enhanced_statistics_file<'a>(
     match result {
         Ok((
             row_stats,
-            timestamp_stats,
+            mut timestamp_stats,
             table_stats,
             partition_stats,
             compression_stats,
@@ -2360,6 +2360,29 @@ pub fn parse_enhanced_statistics_file<'a>(
                 columns.len()
             );
 
+            // Best-effort STATS-extras decode over the FULL buffer (with TOC):
+            // recover the authoritative maxLocalDeletionTime (the inner parser
+            // leaves it as a placeholder equal to min_deletion_time) and the
+            // estimated tombstone-drop-times histogram (Issue #1073). This is
+            // strictly additive — a Statistics.db that parses today must keep
+            // parsing, so an Err here is logged and the placeholders are kept.
+            let tombstone_drop_times =
+                match crate::parser::repair_metadata::parse_stats_extras(input, gates) {
+                    Ok(extras) => {
+                        // Only set max_deletion_time. Do NOT touch min_deletion_time
+                        // (the EncodingStats min baseline consumed elsewhere).
+                        timestamp_stats.max_deletion_time = extras.max_local_deletion_time;
+                        extras.tombstone_drop_times
+                    }
+                    Err(e) => {
+                        log::debug!(
+                            "Best-effort STATS-extras decode failed; keeping placeholders: {:?}",
+                            e
+                        );
+                        vec![]
+                    }
+                };
+
             let statistics = SSTableStatistics {
                 header,
                 row_stats,
@@ -2372,6 +2395,7 @@ pub fn parse_enhanced_statistics_file<'a>(
                 serialization_header_columns: columns,
                 serialization_header_partition_keys: partition_columns,
                 serialization_header_clustering_keys: clustering_columns,
+                tombstone_drop_times,
             };
 
             Ok((remaining, statistics))

--- a/cqlite-core/src/parser/repair_metadata.rs
+++ b/cqlite-core/src/parser/repair_metadata.rs
@@ -327,6 +327,26 @@ impl<'a> Cursor<'a> {
         self.pos = end;
         Ok(i64::from_be_bytes(buf))
     }
+
+    fn read_u32(&mut self) -> Result<u32> {
+        let end = self.need(4)?;
+        let v = u32::from_be_bytes([
+            self.bytes[self.pos],
+            self.bytes[self.pos + 1],
+            self.bytes[self.pos + 2],
+            self.bytes[self.pos + 3],
+        ]);
+        self.pos = end;
+        Ok(v)
+    }
+
+    fn read_f64(&mut self) -> Result<f64> {
+        let end = self.need(8)?;
+        let mut buf = [0u8; 8];
+        buf.copy_from_slice(&self.bytes[self.pos..end]);
+        self.pos = end;
+        Ok(f64::from_be_bytes(buf))
+    }
 }
 
 /// Skip an `EstimatedHistogram`: `i32 count`, then `count` × (`i64 offset`,
@@ -450,9 +470,189 @@ pub fn parse_repair_metadata(input: &[u8], gates: Option<&VersionGates>) -> Resu
     })
 }
 
+/// Cassandra's canonical "no deletion" local-deletion-time sentinel,
+/// normalized to `i64` for both legacy (nb) and modern (oa/da) encodings.
+///
+/// `LivenessInfo.NO_DELETION_TIME` is `Cell.MAX_DELETION_TIME` =
+/// `Integer.MAX_VALUE` for legacy (signed `i32`) SSTables, and `0xFFFF_FFFF`
+/// (the `u32` saturation value) for modern SSTables that store the field as an
+/// unsigned 32-bit integer. `sstablemetadata` prints `Long.MAX_VALUE`
+/// (`9223372036854775807`) for "no tombstones"; we normalize to that here so
+/// the decoded `max_local_deletion_time` matches the reference tool's printed
+/// integer in BOTH cases.
+const NO_DELETION_TIME: i64 = i64::MAX;
+
+/// Additional STATS-component facts decoded by [`parse_stats_extras`] that are
+/// not part of the repair-coordination metadata: the SSTable's maximum local
+/// deletion time and the estimated tombstone-drop-times histogram.
+///
+/// Decoded best-effort: a `Statistics.db` that parses today must keep parsing,
+/// so callers treat an `Err` from [`parse_stats_extras`] as "leave the existing
+/// placeholders" rather than propagating it.
+#[derive(Debug, Clone)]
+pub struct StatsExtras {
+    /// SSTable `maxLocalDeletionTime`, normalized so that the version-specific
+    /// "no tombstones" sentinel (`i32::MAX` for nb, `0xFFFF_FFFF` for oa/da)
+    /// maps to [`NO_DELETION_TIME`] (`i64::MAX`); any real deletion time is the
+    /// seconds-since-epoch value as `i64`.
+    pub max_local_deletion_time: i64,
+    /// `estimatedTombstoneDropTime` histogram as `(point, count)` pairs. Empty
+    /// when the histogram carries no bins (the common case for SSTables with no
+    /// tombstones).
+    pub tombstone_drop_times: Vec<(i64, u64)>,
+}
+
+impl Default for StatsExtras {
+    /// The default reported when no STATS component is locatable: "no
+    /// tombstones" max-LDT ([`NO_DELETION_TIME`]) and an empty histogram.
+    fn default() -> Self {
+        StatsExtras {
+            max_local_deletion_time: NO_DELETION_TIME,
+            tombstone_drop_times: Vec::new(),
+        }
+    }
+}
+
+/// Decode the SSTable `maxLocalDeletionTime` and the estimated
+/// tombstone-drop-times histogram from a raw `Statistics.db` buffer.
+///
+/// This walks the same self-describing leading STATS fields as
+/// [`parse_repair_metadata`], but reads (rather than skips) field 5
+/// (min/maxLocalDeletionTime) and field 8 (the tombstone histogram).
+///
+/// When `gates` is `None`, the legacy (nb) encoding is assumed for BOTH the
+/// max-LDT sentinel comparison and the histogram entry width (nb-compatible
+/// default, matching the rest of the minimal Statistics parser and the
+/// `merge.rs` caller).
+///
+/// # Returns
+///
+/// * `Ok(StatsExtras::default())` — max-LDT = [`NO_DELETION_TIME`], empty
+///   histogram — when the buffer carries no STATS component (nothing to decode).
+/// * `Ok(extras)` with the decoded facts otherwise.
+///
+/// # Errors
+///
+/// Returns an error when the STATS component is present but its leading
+/// (self-describing) fields are truncated/corrupt or overrun the component's
+/// authoritative end bound. Best-effort callers must treat this as "leave the
+/// existing placeholders" and MUST NOT propagate it (a `Statistics.db` that
+/// parses today must keep parsing).
+pub fn parse_stats_extras(input: &[u8], gates: Option<&VersionGates>) -> Result<StatsExtras> {
+    let Some(bounds) = stats_component_bounds(input)? else {
+        // No STATS component → nothing to decode. Report the canonical
+        // "no tombstones" default rather than failing.
+        return Ok(StatsExtras::default());
+    };
+
+    let modern = gates.map(uses_modern_tombstone_histogram).unwrap_or(false);
+
+    // Bound the cursor over ONLY the STATS component slice (start..end, CRC and
+    // following components excluded). Any read past this slice fails closed.
+    let mut c = Cursor::new(&input[bounds.start..bounds.end]);
+
+    // 1-2. estimatedPartitionSize + estimatedCellPerPartitionCount.
+    skip_estimated_histogram(&mut c)?;
+    skip_estimated_histogram(&mut c)?;
+
+    // 3. commitLogUpperBound: i64 segmentId + i32 position.
+    c.skip(8 + 4)?;
+
+    // 4. minTimestamp, maxTimestamp.
+    c.skip(8 + 8)?;
+
+    // 5. min/maxLocalDeletionTime. Width is 4 bytes each in both encodings; the
+    //    signedness/sentinel differs by version (handled below).
+    let _min_ldt = c.read_u32()?;
+    let raw_max_ldt = c.read_u32()?;
+    let max_local_deletion_time = decode_max_local_deletion_time(raw_max_ldt, modern);
+
+    // 6. minTTL, maxTTL.
+    c.skip(4 + 4)?;
+
+    // 7. compressionRatio (f64).
+    c.read_f64()?;
+
+    // 8. estimatedTombstoneDropTime (TombstoneHistogram).
+    let tombstone_drop_times = read_tombstone_histogram(&mut c, modern)?;
+
+    Ok(StatsExtras {
+        max_local_deletion_time,
+        tombstone_drop_times,
+    })
+}
+
+/// Normalize a raw 4-byte `maxLocalDeletionTime` to a canonical `i64`.
+///
+/// * modern (oa/da): the field is an unsigned `u32`; the sentinel is
+///   `0xFFFF_FFFF`.
+/// * legacy (nb): the field is a signed `i32`; the sentinel is `i32::MAX`.
+///
+/// The version sentinel maps to [`NO_DELETION_TIME`] (`i64::MAX`); any real
+/// deletion time (always `< 2^31` seconds-since-epoch) is returned as its
+/// integer value.
+fn decode_max_local_deletion_time(raw: u32, modern: bool) -> i64 {
+    if modern {
+        if raw == u32::MAX {
+            NO_DELETION_TIME
+        } else {
+            raw as i64
+        }
+    } else {
+        let signed = raw as i32;
+        if signed == i32::MAX {
+            NO_DELETION_TIME
+        } else {
+            signed as i64
+        }
+    }
+}
+
+/// Read a `TombstoneHistogram` as `(point, count)` pairs.
+///
+/// Header: `i32 maxBinSize`, `i32 size` (bin count, must be `>= 0`). Each bin is
+/// `f64 point + i64 value` (16 bytes) for legacy (nb), or `i64 point + i32 value`
+/// (12 bytes) for modern (oa/da). The legacy `f64` point is cast to `i64`
+/// (Cassandra rounds drop-times to integer bucket boundaries, so the cast is
+/// exact). An empty histogram yields an empty `Vec`.
+fn read_tombstone_histogram(c: &mut Cursor, modern: bool) -> Result<Vec<(i64, u64)>> {
+    let _max_bin_size = c.read_i32()?;
+    let size = c.read_i32()?;
+    if size < 0 {
+        return Err(Error::Corruption(format!(
+            "negative TombstoneHistogram size {size}"
+        )));
+    }
+    // Bound the allocation by the bytes actually present BEFORE reserving:
+    // a corrupt Statistics.db can advertise a huge positive `size`, and
+    // `Vec::with_capacity(size)` would otherwise attempt a massive (or aborting)
+    // allocation. Each bin is `entry_width` bytes; validate that all bins fit in
+    // the remaining cursor span (fail-closed via `need`) so the reserve below is
+    // capped by real data, not the untrusted header.
+    let entry_width = if modern { 12usize } else { 16usize };
+    let required = (size as usize)
+        .checked_mul(entry_width)
+        .ok_or_else(|| Error::Corruption("TombstoneHistogram size overflow".to_string()))?;
+    c.need(required)?;
+    let mut out = Vec::with_capacity(size as usize);
+    for _ in 0..size {
+        if modern {
+            let point = c.read_i64()?;
+            let value = c.read_i32()?;
+            out.push((point, value as u64));
+        } else {
+            let point = c.read_f64()?;
+            let value = c.read_i64()?;
+            out.push((point as i64, value as u64));
+        }
+    }
+    Ok(out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::storage::sstable::version_gate::BigVersionGates;
 
     /// Build a minimal but valid STATS component (through `repairedAt`) plus a
     /// 4-component TOC pointing at it, so the decoder can be exercised in-memory
@@ -511,6 +711,192 @@ mod tests {
         out.extend_from_slice(&stats);
         out.extend_from_slice(&0u32.to_be_bytes()); // trailing metadata CRC
         out
+    }
+
+    /// Build a STATS component (through `repairedAt`) wrapped in a 4-component
+    /// TOC (STATS last), with caller-controlled `maxLocalDeletionTime` (raw
+    /// 4-byte field, written verbatim) and tombstone-histogram bins. The bins
+    /// are written using the legacy (16-byte: `f64 point + i64 value`) or
+    /// modern (12-byte: `i64 point + i32 value`) layout per `modern`.
+    fn synthetic_statistics_extras(modern: bool, raw_max_ldt: u32, bins: &[(i64, u64)]) -> Vec<u8> {
+        let mut stats = Vec::new();
+        // estimatedPartitionSize + estimatedCellPerPartitionCount (empty).
+        stats.extend_from_slice(&0i32.to_be_bytes());
+        stats.extend_from_slice(&0i32.to_be_bytes());
+        // commitLogUpperBound: i64 segmentId + i32 position.
+        stats.extend_from_slice(&(-1i64).to_be_bytes());
+        stats.extend_from_slice(&0i32.to_be_bytes());
+        // minTimestamp, maxTimestamp.
+        stats.extend_from_slice(&100i64.to_be_bytes());
+        stats.extend_from_slice(&200i64.to_be_bytes());
+        // minLocalDeletionTime (any), maxLocalDeletionTime (verbatim raw u32).
+        stats.extend_from_slice(&0u32.to_be_bytes());
+        stats.extend_from_slice(&raw_max_ldt.to_be_bytes());
+        // minTTL, maxTTL.
+        stats.extend_from_slice(&0i32.to_be_bytes());
+        stats.extend_from_slice(&0i32.to_be_bytes());
+        // compressionRatio (f64).
+        stats.extend_from_slice(&(-1.0f64).to_be_bytes());
+        // TombstoneHistogram: maxBinSize, size, then bins.
+        stats.extend_from_slice(&100i32.to_be_bytes()); // maxBinSize
+        stats.extend_from_slice(&(bins.len() as i32).to_be_bytes());
+        for &(point, value) in bins {
+            if modern {
+                stats.extend_from_slice(&point.to_be_bytes()); // i64 point
+                stats.extend_from_slice(&(value as i32).to_be_bytes()); // i32 value
+            } else {
+                stats.extend_from_slice(&(point as f64).to_be_bytes()); // f64 point
+                stats.extend_from_slice(&(value as i64).to_be_bytes()); // i64 value
+            }
+        }
+        // sstableLevel, repairedAt.
+        stats.extend_from_slice(&0i32.to_be_bytes());
+        stats.extend_from_slice(&0i64.to_be_bytes());
+
+        // TOC: 4 components, STATS (type 2) last by offset.
+        let toc_len = 4 + 4 + 4 * 8;
+        let comp0_off = toc_len;
+        let comp1_off = comp0_off + 1;
+        let comp3_off = comp1_off + 1;
+        let stats_off = comp3_off + 1;
+        let mut out = Vec::new();
+        out.extend_from_slice(&4u32.to_be_bytes());
+        out.extend_from_slice(&0u32.to_be_bytes());
+        for (ty, off) in [
+            (0u32, comp0_off as u32),
+            (1u32, comp1_off as u32),
+            (2u32, stats_off as u32),
+            (3u32, comp3_off as u32),
+        ] {
+            out.extend_from_slice(&ty.to_be_bytes());
+            out.extend_from_slice(&off.to_be_bytes());
+        }
+        out.extend_from_slice(&[0u8, 0u8, 0u8]);
+        debug_assert_eq!(out.len(), stats_off);
+        out.extend_from_slice(&stats);
+        out.extend_from_slice(&0u32.to_be_bytes()); // trailing CRC
+        out
+    }
+
+    fn nb_gates() -> VersionGates {
+        VersionGates::Big(BigVersionGates::from_version("nb").expect("nb gates"))
+    }
+
+    fn oa_gates() -> VersionGates {
+        VersionGates::Big(BigVersionGates::from_version("oa").expect("oa gates"))
+    }
+
+    #[test]
+    fn stats_extras_real_max_ldt_nb() {
+        // Real seconds-since-epoch deletion time, well under 2^31.
+        let bytes = synthetic_statistics_extras(false, 1_700_000_000, &[]);
+        let extras = parse_stats_extras(&bytes, Some(&nb_gates())).expect("decode");
+        assert_eq!(extras.max_local_deletion_time, 1_700_000_000);
+        assert!(extras.tombstone_drop_times.is_empty());
+    }
+
+    #[test]
+    fn stats_extras_nb_sentinel_maps_to_i64_max() {
+        // nb sentinel: i32::MAX → i64::MAX (NO_DELETION_TIME).
+        let bytes = synthetic_statistics_extras(false, i32::MAX as u32, &[]);
+        let extras = parse_stats_extras(&bytes, Some(&nb_gates())).expect("decode");
+        assert_eq!(extras.max_local_deletion_time, i64::MAX);
+        // gates == None also defaults to legacy → same result.
+        let extras_none = parse_stats_extras(&bytes, None).expect("decode");
+        assert_eq!(extras_none.max_local_deletion_time, i64::MAX);
+    }
+
+    #[test]
+    fn stats_extras_modern_sentinel_maps_to_i64_max() {
+        // modern sentinel: 0xFFFF_FFFF → i64::MAX (NO_DELETION_TIME).
+        let bytes = synthetic_statistics_extras(true, u32::MAX, &[]);
+        let extras = parse_stats_extras(&bytes, Some(&oa_gates())).expect("decode");
+        assert_eq!(extras.max_local_deletion_time, i64::MAX);
+    }
+
+    #[test]
+    fn stats_extras_modern_real_max_ldt() {
+        // A real deletion time above i32::MAX is representable as u32 on modern.
+        let raw: u32 = 3_000_000_000; // > i32::MAX, < u32::MAX
+        let bytes = synthetic_statistics_extras(true, raw, &[]);
+        let extras = parse_stats_extras(&bytes, Some(&oa_gates())).expect("decode");
+        assert_eq!(extras.max_local_deletion_time, raw as i64);
+    }
+
+    #[test]
+    fn stats_extras_histogram_nb_width() {
+        let bins = [(1_700_000_000i64, 3u64), (1_700_000_100i64, 7u64)];
+        let bytes = synthetic_statistics_extras(false, i32::MAX as u32, &bins);
+        let extras = parse_stats_extras(&bytes, Some(&nb_gates())).expect("decode");
+        assert_eq!(
+            extras.tombstone_drop_times,
+            vec![(1_700_000_000, 3), (1_700_000_100, 7)]
+        );
+    }
+
+    #[test]
+    fn stats_extras_histogram_modern_width() {
+        let bins = [(1_700_000_000i64, 11u64), (1_700_000_500i64, 2u64)];
+        let bytes = synthetic_statistics_extras(true, u32::MAX, &bins);
+        let extras = parse_stats_extras(&bytes, Some(&oa_gates())).expect("decode");
+        assert_eq!(
+            extras.tombstone_drop_times,
+            vec![(1_700_000_000, 11), (1_700_000_500, 2)]
+        );
+    }
+
+    #[test]
+    fn stats_extras_empty_histogram() {
+        let bytes = synthetic_statistics_extras(false, i32::MAX as u32, &[]);
+        let extras = parse_stats_extras(&bytes, Some(&nb_gates())).expect("decode");
+        assert!(extras.tombstone_drop_times.is_empty());
+    }
+
+    #[test]
+    fn stats_extras_missing_component_returns_default() {
+        // TOC with no STATS entry → default (max = i64::MAX, empty histogram),
+        // not an error.
+        let mut out = Vec::new();
+        out.extend_from_slice(&1u32.to_be_bytes()); // 1 component
+        out.extend_from_slice(&0u32.to_be_bytes()); // marker
+        out.extend_from_slice(&3u32.to_be_bytes()); // type HEADER
+        out.extend_from_slice(&16u32.to_be_bytes()); // offset
+        let extras = parse_stats_extras(&out, None).expect("default");
+        assert_eq!(extras.max_local_deletion_time, i64::MAX);
+        assert!(extras.tombstone_drop_times.is_empty());
+    }
+
+    #[test]
+    fn stats_extras_truncated_fails_closed() {
+        // Two bins so the histogram region is large; truncate deep enough that
+        // the cursor runs off the end while still reading the histogram (the
+        // sstableLevel/repairedAt tail is not read by parse_stats_extras).
+        let mut bytes =
+            synthetic_statistics_extras(false, 1_700_000_000, &[(1i64, 1u64), (2i64, 2u64)]);
+        // Drop the trailing CRC + sstableLevel + repairedAt + one full bin
+        // (16 bytes legacy) + part of the next, so a histogram read overruns.
+        bytes.truncate(bytes.len() - (4 + 4 + 8 + 16 + 4));
+        assert!(
+            parse_stats_extras(&bytes, Some(&nb_gates())).is_err(),
+            "truncated STATS body must fail closed"
+        );
+    }
+
+    #[test]
+    fn tombstone_histogram_huge_size_fails_closed_without_allocating() {
+        // A corrupt header advertising a massive bin count must fail closed via
+        // the remaining-bytes precheck rather than attempting a huge (or
+        // aborting) `Vec::with_capacity` (roborev High finding, #1073).
+        for modern in [false, true] {
+            let mut buf = Vec::new();
+            buf.extend_from_slice(&100i32.to_be_bytes()); // maxBinSize
+            buf.extend_from_slice(&i32::MAX.to_be_bytes()); // size = 2.1B bins, no body
+            let mut c = Cursor::new(&buf);
+            assert!(
+                read_tombstone_histogram(&mut c, modern).is_err(),
+                "huge histogram size (modern={modern}) must fail closed, not allocate"
+            );
+        }
     }
 
     #[test]

--- a/cqlite-core/src/parser/statistics.rs
+++ b/cqlite-core/src/parser/statistics.rs
@@ -69,6 +69,11 @@ pub struct SSTableStatistics {
     /// Clustering key definitions extracted from SerializationHeader (Issue #195)
     #[serde(default)]
     pub serialization_header_clustering_keys: Vec<super::header::ColumnInfo>,
+    /// Estimated tombstone-drop-times histogram as `(point, count)` pairs,
+    /// decoded best-effort from the STATS component (Issue #1073). Empty when
+    /// the SSTable carries no tombstones or the histogram could not be decoded.
+    #[serde(default)]
+    pub tombstone_drop_times: Vec<(i64, u64)>,
 }
 
 /// Row count and distribution statistics
@@ -251,6 +256,7 @@ pub fn parse_statistics_file(input: &[u8]) -> IResult<&[u8], SSTableStatistics> 
             serialization_header_columns: vec![], // Not available in legacy format
             serialization_header_partition_keys: vec![],
             serialization_header_clustering_keys: vec![],
+            tombstone_drop_times: vec![],
         },
     ))
 }
@@ -1473,6 +1479,7 @@ mod tests {
             serialization_header_columns: vec![],
             serialization_header_partition_keys: vec![],
             serialization_header_clustering_keys: vec![],
+            tombstone_drop_times: vec![],
         }
     }
 }

--- a/cqlite-core/src/parser/statistics_test.rs
+++ b/cqlite-core/src/parser/statistics_test.rs
@@ -574,6 +574,7 @@ mod tests {
             serialization_header_columns: vec![],
             serialization_header_partition_keys: vec![],
             serialization_header_clustering_keys: vec![],
+            tombstone_drop_times: vec![],
         }
     }
 }

--- a/cqlite-core/src/storage/sstable/statistics_reader.rs
+++ b/cqlite-core/src/storage/sstable/statistics_reader.rs
@@ -59,10 +59,16 @@ impl StatisticsReader {
         file.read_to_end(&mut buffer).await?;
 
         // Parse the statistics data using enhanced parser with fallback.
-        // Gates are not available at StatisticsReader construction time (the reader
-        // is opened before SSTableReader has gates). Pass None here; nb-compatible
-        // defaults apply. VG3 will wire gates through SSTableReader instead.
-        let statistics = match parse_statistics_with_fallback(&buffer, None) {
+        //
+        // Derive the format gates from the component filename (e.g.
+        // `da-1-bti-Statistics.db` vs `nb-1-big-Statistics.db`) so the best-effort
+        // STATS-extras decode (max local deletion time + tombstone-drop histogram,
+        // #1073) interprets the version-sensitive fields correctly: the modern
+        // (oa/da) `u32::MAX` no-deletion sentinel and the 12-byte modern histogram
+        // bin width differ from the legacy (nb) signed-i32 / 16-byte forms. When the
+        // filename does not parse, fall back to None (nb-compatible defaults).
+        let gates = crate::storage::sstable::version_gate::VersionGates::from_path(path).ok();
+        let statistics = match parse_statistics_with_fallback(&buffer, gates.as_ref()) {
             Ok((_, stats)) => stats,
             Err(e) => {
                 return Err(Error::corruption(format!(

--- a/cqlite-core/src/storage/sstable/version_gate.rs
+++ b/cqlite-core/src/storage/sstable/version_gate.rs
@@ -991,6 +991,18 @@ mod tests {
         }
     }
 
+    /// `StatisticsReader::open` derives gates from the Statistics.db component
+    /// filename to decode the version-sensitive STATS extras (#1073). Confirm the
+    /// descriptor parses a non-Data.db component so modern (oa/da) gates are
+    /// available on that read path, not just for Data.db.
+    #[test]
+    fn test_version_gates_from_statistics_component_path() {
+        let nb = VersionGates::from_path(&PathBuf::from("nb-1-big-Statistics.db")).unwrap();
+        assert!(matches!(nb, VersionGates::Big(g) if g.version == "nb"));
+        let da = VersionGates::from_path(&PathBuf::from("da-1-bti-Statistics.db")).unwrap();
+        assert!(matches!(da, VersionGates::Bti(g) if g.version == "da"));
+    }
+
     /// Verify that UUID-based ids (corpus filenames) parse correctly into gates.
     #[test]
     fn test_version_gates_from_corpus_filename() {

--- a/cqlite-core/tests/issue_1011_ttl_local_deletion_parity.rs
+++ b/cqlite-core/tests/issue_1011_ttl_local_deletion_parity.rs
@@ -31,17 +31,18 @@
 //! (86400 / 86401 / 3600) and writetime (`tstamp`) ARE deterministic and asserted
 //! exactly.
 //!
-//! ## Known gap (reported, NOT hacked green)
+//! ## STATS max-LDT + tombstone-drop histogram (issue #1073 — gap closed)
 //!
-//! CQLite's minimal Statistics parser does NOT yet decode the STATS-component
-//! `SSTable max local deletion time` (it stores a placeholder equal to the min)
-//! nor the estimated-tombstone-drop-times histogram.  The two
-//! `statistics_metadata` scenarios that depend on those are therefore covered
-//! only for the DECODABLE half (EncodingStats min LDT / minTTL), and the
-//! still-undecoded fields are documented below as a partial.  We assert the
-//! reference dump carries those facts (so the lane proves it ran) and assert the
-//! current placeholder behaviour explicitly so a future fix that wires up the
-//! real decode trips this test.
+//! CQLite now decodes the STATS-component `SSTable max local deletion time`
+//! (the "no tombstones" sentinel normalizes to `i64::MAX`) and the
+//! estimated-tombstone-drop-times histogram (issue #1073).  The two
+//! `statistics_metadata` scenarios that depend on those are therefore asserted
+//! against the REAL decoded values: `timestamp_stats.max_deletion_time` equals
+//! the dump's parenthesised integer, and `tombstone_drop_times` reproduces the
+//! dump's histogram bucket cardinality and total count.  A focused parity test
+//! lives in `issue_1073_statistics_max_ldt_tombstone_histogram_parity.rs`; here
+//! we keep the assertions in the combined #1011 scenario so a regression in
+//! either source trips this lane too.
 //!
 //! ## Discipline
 //!
@@ -425,6 +426,18 @@ fn paren_int(line: &str) -> Option<i64> {
     let open = line.rfind('(')?;
     let close = line[open..].find(')')? + open;
     line[open + 1..close].trim().parse().ok()
+}
+
+/// The literal parenthesised integer on the `SSTable max local deletion time`
+/// line of a dump, including the "no tombstones (9223372036854775807)" sentinel
+/// (which equals `i64::MAX`).  Returns `None` if the line is absent.
+fn max_local_deletion_time_paren_int(txt: &Path) -> Option<i64> {
+    let content = fs::read_to_string(txt).ok()?;
+    content
+        .lines()
+        .map(str::trim)
+        .find(|l| l.starts_with("SSTable max local deletion time:"))
+        .and_then(paren_int)
 }
 
 /// Bare integer after the last colon, e.g. `TTL min: 0` or
@@ -907,14 +920,16 @@ async fn statistics_encoding_stats_local_deletion_parity() {
 //   Manifest: cass.statistics_metadata.tombstone_histogram.deletion_times
 //             cass.statistics_metadata.max_local_deletion_time.tombstones_ttl
 //
-//   KNOWN GAP: CQLite's minimal Statistics parser does NOT decode the STATS
-//   component, so neither the estimated-tombstone-drop-times histogram nor the
-//   real `SSTable max local deletion time` are available.  We:
-//     (a) prove the committed reference dump CARRIES those facts (so the lane
-//         demonstrably ran against real data), and
-//     (b) pin CQLite's CURRENT behaviour (max_deletion_time == min placeholder)
-//         so a future fix that wires up the real decode trips this test and the
-//         scenario can be upgraded from `partial` to `mirrored`.
+//   Issue #1073 closed the gap: CQLite now decodes the STATS-component
+//   `SSTable max local deletion time` (the "no tombstones" sentinel normalizes
+//   to i64::MAX) and the estimated-tombstone-drop-times histogram.  We assert
+//   the REAL decoded values against the committed reference dump:
+//     (a) `timestamp_stats.max_deletion_time` equals the dump's parenthesised
+//         integer (real max LDT for ttl_test_table; i64::MAX sentinel for
+//         tombstone_histogram), and
+//     (b) `tombstone_drop_times` reproduces the dump's histogram bucket
+//         cardinality and total count.
+//   We still fail loudly if the dump carries facts but CQLite matched zero.
 // ===========================================================================
 
 #[tokio::test]
@@ -959,24 +974,58 @@ async fn statistics_tombstone_histogram_and_max_ldt_reference_facts() {
             "{name}: histogram total count must be > 0 (got {total_count})"
         );
 
-        // GAP: CQLite does not decode the estimated-tombstone-drop-times histogram.
-        // SSTableStatistics has no such field, so there is nothing to compare yet.
-        // Assert the binary-decode path at least succeeds and exposes NO histogram,
-        // pinning the current state.
+        // Issue #1073: CQLite now decodes the estimated-tombstone-drop-times
+        // histogram into `tombstone_drop_times`. Assert it is non-empty and that
+        // its total count equals the dump's bucket-count total.
         if let Some(db) = find_statistics_db(&dir) {
             let bytes = fs::read(&db).unwrap();
             let (_, stats) = parse_statistics_with_fallback(&bytes, None)
                 .unwrap_or_else(|e| panic!("{name}: decode {} failed: {e:?}", db.display()));
-            // The minimal parser leaves row_size / partition histograms empty and
-            // does not expose a tombstone-drop histogram at all.
+            // Fail loudly: the dump carries histogram facts, so CQLite must too.
             assert!(
-                stats.row_stats.row_size_histogram.is_empty(),
-                "{name}: minimal parser unexpectedly populated a row-size histogram \
-                 — STATS-component decode may now exist; upgrade this scenario"
+                !stats.tombstone_drop_times.is_empty(),
+                "{name}: dump carries {bucket_count} drop-time bucket(s) (total {total_count}) \
+                 but CQLite decoded ZERO — histogram decode regressed (no silent pass)"
+            );
+            assert_eq!(
+                stats.tombstone_drop_times.len(),
+                bucket_count,
+                "{name}: drop-time bucket cardinality cqlite={} cassandra={bucket_count}",
+                stats.tombstone_drop_times.len()
+            );
+            let cqlite_total: i64 = stats
+                .tombstone_drop_times
+                .iter()
+                .map(|(_, c)| *c as i64)
+                .sum();
+            assert_eq!(
+                cqlite_total, total_count,
+                "{name}: drop-time total count cqlite={cqlite_total} cassandra={total_count}"
+            );
+
+            // Issue #1073: this fixture's dump reports
+            // `SSTable max local deletion time: no tombstones (9223372036854775807)`.
+            // Parse that literal integer from the dump and assert CQLite decoded
+            // the same value (it equals i64::MAX). Parsed, never hardcoded.
+            let sentinel = max_local_deletion_time_paren_int(&txt).unwrap_or_else(|| {
+                panic!("{name}: tombstone_histogram dump missing 'SSTable max local deletion time'")
+            });
+            assert_eq!(
+                sentinel,
+                i64::MAX,
+                "{name}: tombstone_histogram dump sentinel must be i64::MAX (got {sentinel})"
+            );
+            assert_eq!(
+                stats.timestamp_stats.max_deletion_time, sentinel,
+                "{name}: SSTable max local deletion time (no-tombstones sentinel) \
+                 cqlite={} cassandra={sentinel}",
+                stats.timestamp_stats.max_deletion_time
             );
             println!(
                 "[PASS] {name}: tombstone-drop histogram reference has {bucket_count} bucket(s), \
-                 total count {total_count}; CQLite decode succeeds (histogram not yet exposed — GAP)"
+                 total count {total_count}; CQLite decoded {} bucket(s), total {cqlite_total}; \
+                 max LDT sentinel == i64::MAX (issue #1073)",
+                stats.tombstone_drop_times.len()
             );
         } else {
             skip_or_panic(
@@ -1022,24 +1071,26 @@ async fn statistics_tombstone_histogram_and_max_ldt_reference_facts() {
             let bytes = fs::read(&db).unwrap();
             let (_, stats) = parse_statistics_with_fallback(&bytes, None)
                 .unwrap_or_else(|e| panic!("{name}: decode {} failed: {e:?}", db.display()));
-            // GAP: the minimal parser sets max_deletion_time = min_deletion_time
-            // (a placeholder), so it does NOT yet equal the reference max LDT.
-            // Pin the current behaviour: equal to the decoded MIN, and NOT the real
-            // reference MAX (which differs here: min=1759799525 max=1759799526).
+            // Issue #1073: CQLite now decodes the real STATS `SSTable max local
+            // deletion time`. Assert byte-parity against the dump's parenthesised
+            // integer (here min=1759799525 max=1759799526, so max != min proves a
+            // real decode, not a min placeholder). Parsed from the dump, never
+            // hardcoded.
             assert_eq!(
-                stats.timestamp_stats.max_deletion_time, stats.timestamp_stats.min_deletion_time,
-                "{name}: expected max_deletion_time placeholder == min; if these now differ \
-                 the real STATS decode landed — upgrade this scenario to a strict max-LDT assert"
-            );
-            assert_ne!(
                 stats.timestamp_stats.max_deletion_time, max_ldt,
-                "{name}: CQLite now decodes the REAL max LDT ({max_ldt}) — the gap is closed; \
-                 upgrade cass.statistics_metadata.max_local_deletion_time.tombstones_ttl to mirrored"
+                "{name}: SSTable max local deletion time cqlite={} cassandra={max_ldt}",
+                stats.timestamp_stats.max_deletion_time
+            );
+            // Cross-check this fixture exercises a real (non-placeholder) max: it
+            // differs from the decoded min baseline.
+            assert_ne!(
+                stats.timestamp_stats.max_deletion_time, stats.timestamp_stats.min_deletion_time,
+                "{name}: ttl_test_table must exercise max LDT != min (real decode, not placeholder)"
             );
             println!(
-                "[PASS] {name}: ttl_test_table reference max LDT={max_ldt} (min={}); \
-                 CQLite max_deletion_time placeholder={} (== min) — GAP confirmed, not hacked",
-                reference.enc_min_local_deletion_time, stats.timestamp_stats.max_deletion_time
+                "[PASS] {name}: ttl_test_table max LDT cqlite={} == cassandra={max_ldt} (min={}); \
+                 issue #1073 real decode",
+                stats.timestamp_stats.max_deletion_time, reference.enc_min_local_deletion_time
             );
         } else {
             skip_or_panic(

--- a/cqlite-core/tests/issue_1073_statistics_max_ldt_tombstone_histogram_parity.rs
+++ b/cqlite-core/tests/issue_1073_statistics_max_ldt_tombstone_histogram_parity.rs
@@ -1,0 +1,350 @@
+//! Issue #1073: Statistics.db `SSTable max local deletion time` + estimated
+//! tombstone-drop-times histogram decode parity.
+//!
+//! Task 1 (PR for #1073) wired the STATS-component decoder
+//! (`parse_stats_extras`) into `parse_statistics_with_fallback`, so the enhanced
+//! Statistics parser now fills:
+//!
+//!   * `timestamp_stats.max_deletion_time` with the authoritative STATS
+//!     `SSTable max local deletion time` integer (the "no tombstones" sentinel
+//!     `9223372036854775807` normalizes to `i64::MAX`), and
+//!   * `tombstone_drop_times: Vec<(i64, u64)>` with the estimated
+//!     tombstone-drop-times histogram buckets `(drop_time, count)`.
+//!
+//! This test pins both against the committed `nb-1-big-Statistics.db.txt`
+//! sstablemetadata goldens for two fixtures:
+//!
+//!   * `test_basic/ttl_test_table`     — a real (non-sentinel) max LDT that
+//!     differs from the min LDT, plus a 1-bucket drop-times histogram.
+//!   * `test_tomb/tombstone_histogram` — `no tombstones` max LDT sentinel
+//!     (`i64::MAX`) alongside a non-empty (1-bucket) drop-times histogram.
+//!
+//! ## Discipline (copied from issue_1011)
+//!
+//! - We NEVER hardcode an epoch integer: every expected value is parsed at
+//!   runtime from the committed dump (fixtures get regenerated and the
+//!   wall-clock-derived LDT values change). The "no tombstones" case parses the
+//!   dump's literal `9223372036854775807`, which equals `i64::MAX`.
+//! - SKIP cleanly (`[SKIP]`, return) when `CQLITE_DATASETS_ROOT` is unset or the
+//!   binary `Data.db` / `Statistics.db` is absent; in strict mode
+//!   (`CQLITE_REQUIRE_FIXTURES=1`/`true`) PANIC instead so a CI gate cannot
+//!   false-pass on missing data (issue #972).
+//! - FAIL loudly if the dump carries drop-time / max-LDT facts but CQLite
+//!   matched ZERO (no silent pass).
+//! - No path/name type heuristics: the facts come from the Statistics dump.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use cqlite_core::parser::enhanced_statistics_parser::parse_statistics_with_fallback;
+
+// ===========================================================================
+// Dataset path / SKIP helpers (mirrors issue_1011)
+// ===========================================================================
+
+fn datasets_root() -> Option<PathBuf> {
+    let root = std::env::var("CQLITE_DATASETS_ROOT").ok()?;
+    let path = PathBuf::from(root).join("sstables");
+    path.exists().then_some(path)
+}
+
+/// `true` when `CQLITE_REQUIRE_FIXTURES` is set to a truthy value ("1"/"true").
+fn require_fixtures_strict() -> bool {
+    matches!(
+        std::env::var("CQLITE_REQUIRE_FIXTURES").as_deref(),
+        Ok("1") | Ok("true")
+    )
+}
+
+/// Skip cleanly (default) or PANIC (strict mode) when a required fixture is absent.
+fn skip_or_panic(fixture: &str, reason: &str) {
+    if require_fixtures_strict() {
+        panic!(
+            "CQLITE_REQUIRE_FIXTURES=1 but fixture {fixture} is absent — {reason}; \
+             fetch/generate it (bash test-data/scripts/fetch-datasets.sh)"
+        );
+    }
+    println!("[SKIP] {reason}");
+}
+
+/// Find the table directory whose name starts with `prefix` inside `<root>/<ks>`.
+fn find_table_dir(keyspace: &str, prefix: &str) -> Option<PathBuf> {
+    let root = datasets_root()?;
+    let ks_dir = root.join(keyspace);
+    let mut candidates: Vec<PathBuf> = fs::read_dir(&ks_dir)
+        .ok()?
+        .flatten()
+        .filter_map(|e| {
+            let name = e.file_name();
+            let s = name.to_str()?;
+            s.starts_with(prefix).then(|| e.path())
+        })
+        .collect();
+    candidates.sort();
+    candidates.into_iter().next()
+}
+
+fn find_with_suffix(dir: &Path, suffix: &str, reject: &[&str]) -> Option<PathBuf> {
+    for entry in fs::read_dir(dir).ok()?.flatten() {
+        let name = entry.file_name();
+        let n = name.to_str().unwrap_or("");
+        if n.starts_with("._") {
+            continue;
+        }
+        if n.ends_with(suffix) && !reject.iter().any(|r| n.ends_with(r)) {
+            return Some(entry.path());
+        }
+    }
+    None
+}
+
+fn find_statistics_db(dir: &Path) -> Option<PathBuf> {
+    find_with_suffix(dir, "-Statistics.db", &["-Statistics.db.txt"])
+}
+
+fn find_statistics_txt(dir: &Path) -> Option<PathBuf> {
+    find_with_suffix(dir, "-Statistics.db.txt", &[])
+}
+
+fn find_data_db(dir: &Path) -> Option<PathBuf> {
+    find_with_suffix(dir, "-Data.db", &["-Data.db.jsonl"])
+}
+
+// ===========================================================================
+// Statistics.db.txt reference parsing (authoritative integers from the dump)
+// ===========================================================================
+
+/// Trailing parenthesised integer, e.g. `... (1759799526)`.
+fn paren_int(line: &str) -> Option<i64> {
+    let open = line.rfind('(')?;
+    let close = line[open..].find(')')? + open;
+    line[open + 1..close].trim().parse().ok()
+}
+
+/// Authoritative facts pulled from a `*-Statistics.db.txt` dump.
+#[derive(Debug)]
+struct StatsReference {
+    /// `SSTable max local deletion time: ... (N)` — the literal parenthesised
+    /// integer (for the "no tombstones" sentinel this is `9223372036854775807`,
+    /// which equals `i64::MAX`).
+    sstable_max_local_deletion_time: i64,
+    /// Estimated-tombstone-drop-times histogram buckets: (drop_time, count).
+    tombstone_drop_buckets: Vec<(i64, u64)>,
+}
+
+fn parse_stats_reference(txt: &Path) -> StatsReference {
+    let content = fs::read_to_string(txt)
+        .unwrap_or_else(|e| panic!("read reference {} failed: {e}", txt.display()));
+
+    let mut max_ldt = None;
+    let mut tombstone_drop_buckets = Vec::new();
+    let mut in_drop_histogram = false;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+
+        if trimmed.starts_with("SSTable max local deletion time:") {
+            // Both the real case ("... (1759799526)") and the sentinel case
+            // ("no tombstones (9223372036854775807)") carry a parenthesised
+            // integer; parse it literally (sentinel == i64::MAX).
+            max_ldt = paren_int(trimmed);
+        } else if trimmed.starts_with("Estimated tombstone drop times:") {
+            in_drop_histogram = true;
+            continue;
+        } else if in_drop_histogram {
+            // Histogram rows look like:
+            //   "Drop Time                        | Count  (%)  Histogram"
+            //   "1782342000 (06/24/2026 23:00:00) |     5 (100) OOOO..."
+            // Stop at "Percentiles" or any line without the column separator.
+            if trimmed.starts_with("Percentiles") || !trimmed.contains('|') {
+                in_drop_histogram = false;
+                continue;
+            }
+            if trimmed.starts_with("Drop Time") {
+                continue; // header row
+            }
+            if let Some((left, right)) = trimmed.split_once('|') {
+                let drop_time = left.split_whitespace().next().and_then(|t| t.parse().ok());
+                let count = right.split_whitespace().next().and_then(|t| t.parse().ok());
+                if let (Some(d), Some(c)) = (drop_time, count) {
+                    tombstone_drop_buckets.push((d, c));
+                }
+            }
+        }
+    }
+
+    StatsReference {
+        sstable_max_local_deletion_time: max_ldt.unwrap_or_else(|| {
+            panic!(
+                "{}: missing 'SSTable max local deletion time' line",
+                txt.display()
+            )
+        }),
+        tombstone_drop_buckets,
+    }
+}
+
+// ===========================================================================
+// Parity assertion driver
+// ===========================================================================
+
+/// Compare CQLite's decoded STATS max-LDT + tombstone-drop histogram against the
+/// committed dump for one fixture. Returns `true` if the binary was present and
+/// compared, `false` if it was skipped.
+fn assert_max_ldt_and_histogram_parity(name: &str, keyspace: &str, prefix: &str) -> bool {
+    let Some(dir) = find_table_dir(keyspace, prefix) else {
+        skip_or_panic(
+            &format!("{keyspace}/{prefix} fixture dir"),
+            &format!("{name}: no {keyspace}/{prefix} fixture dir"),
+        );
+        return false;
+    };
+
+    // The committed dump is the golden — it MUST be present (fail closed).
+    let txt = find_statistics_txt(&dir).unwrap_or_else(|| {
+        panic!(
+            "{name}: committed Statistics.db.txt missing in {} (fail closed)",
+            dir.display()
+        )
+    });
+    let reference = parse_stats_reference(&txt);
+
+    // Fail closed: this scenario only proves anything if the dump carries a
+    // non-empty drop-times histogram with a positive total count.
+    assert!(
+        !reference.tombstone_drop_buckets.is_empty(),
+        "{name}: dump {} carries ZERO tombstone-drop buckets — reference broken \
+         or parser regressed (this scenario requires a histogram)",
+        txt.display()
+    );
+    let ref_total: u64 = reference
+        .tombstone_drop_buckets
+        .iter()
+        .map(|(_, c)| c)
+        .sum();
+    assert!(
+        ref_total > 0,
+        "{name}: dump histogram total count must be > 0 (got {ref_total})"
+    );
+
+    // SKIP if the binary fixtures are absent (worktrees ship dumps only).
+    if find_data_db(&dir).is_none() {
+        skip_or_panic(
+            &format!("{keyspace}/{prefix} Data.db"),
+            &format!("{name}: binary Data.db absent in {}", dir.display()),
+        );
+        return false;
+    }
+    let Some(db) = find_statistics_db(&dir) else {
+        skip_or_panic(
+            &format!("{keyspace}/{prefix} Statistics.db"),
+            &format!("{name}: binary Statistics.db absent in {}", dir.display()),
+        );
+        return false;
+    };
+
+    let bytes =
+        fs::read(&db).unwrap_or_else(|e| panic!("{name}: read {} failed: {e}", db.display()));
+    // `None` gates → nb/legacy default, correct for these nb fixtures.
+    let (_, stats) = parse_statistics_with_fallback(&bytes, None)
+        .unwrap_or_else(|e| panic!("{name}: CQLite failed to decode {}: {e:?}", db.display()));
+
+    // (1) SSTable max local deletion time parity. The dump's parenthesised
+    //     integer is the authoritative value; the "no tombstones" sentinel is
+    //     literally 9223372036854775807 == i64::MAX, which CQLite normalizes to
+    //     i64::MAX, so a direct equality holds in both cases.
+    assert_eq!(
+        stats.timestamp_stats.max_deletion_time, reference.sstable_max_local_deletion_time,
+        "{name}: SSTable max local deletion time cqlite={} cassandra={}",
+        stats.timestamp_stats.max_deletion_time, reference.sstable_max_local_deletion_time
+    );
+
+    // (2) Estimated tombstone-drop-times histogram parity. Bucket points are
+    //     Cassandra-rounded; we require bucket CARDINALITY and TOTAL COUNT parity
+    //     (the must), and additionally check point parity when the cardinalities
+    //     allow a 1:1 ordered comparison.
+    let cqlite_buckets = &stats.tombstone_drop_times;
+    assert!(
+        !cqlite_buckets.is_empty(),
+        "{name}: dump carries {} drop-time bucket(s) (total {ref_total}) but CQLite \
+         decoded ZERO — histogram decode regressed (no silent pass)",
+        reference.tombstone_drop_buckets.len()
+    );
+    assert_eq!(
+        cqlite_buckets.len(),
+        reference.tombstone_drop_buckets.len(),
+        "{name}: drop-time bucket cardinality cqlite={} cassandra={}",
+        cqlite_buckets.len(),
+        reference.tombstone_drop_buckets.len()
+    );
+    let cqlite_total: u64 = cqlite_buckets.iter().map(|(_, c)| c).sum();
+    assert_eq!(
+        cqlite_total, ref_total,
+        "{name}: drop-time total count cqlite={cqlite_total} cassandra={ref_total}"
+    );
+
+    // Best-effort point parity: when both sides have the same cardinality, the
+    // bucket drop-time points should match the dump's (Cassandra-rounded) points
+    // positionally. This is asserted as an exact ordered comparison since the
+    // cardinalities are equal.
+    let cqlite_points: Vec<i64> = cqlite_buckets.iter().map(|(d, _)| *d).collect();
+    let ref_points: Vec<i64> = reference
+        .tombstone_drop_buckets
+        .iter()
+        .map(|(d, _)| *d)
+        .collect();
+    assert_eq!(
+        cqlite_points, ref_points,
+        "{name}: drop-time bucket points cqlite={cqlite_points:?} cassandra={ref_points:?}"
+    );
+
+    println!(
+        "[PASS] {name}: max_local_deletion_time={} ({} buckets, total {ref_total}) byte-parity vs {}",
+        reference.sstable_max_local_deletion_time,
+        reference.tombstone_drop_buckets.len(),
+        txt.file_name().and_then(|n| n.to_str()).unwrap_or("?")
+    );
+    true
+}
+
+#[test]
+fn statistics_max_ldt_and_tombstone_histogram_parity() {
+    let name = "statistics_max_ldt_and_tombstone_histogram_parity";
+    if datasets_root().is_none() {
+        skip_or_panic(
+            "dataset root",
+            &format!("{name}: CQLITE_DATASETS_ROOT unset"),
+        );
+        return;
+    }
+
+    let mut compared = 0usize;
+
+    // ttl_test_table: real (non-sentinel) max LDT (1759799526 != min 1759799525)
+    // and a 1-bucket drop-times histogram (count 400).
+    if assert_max_ldt_and_histogram_parity(
+        "ttl_test_table.max_ldt_histogram",
+        "test_basic",
+        "ttl_test_table-",
+    ) {
+        compared += 1;
+    }
+
+    // tombstone_histogram: "no tombstones" max-LDT sentinel (== i64::MAX) with a
+    // non-empty 1-bucket drop-times histogram (count 5).
+    if assert_max_ldt_and_histogram_parity(
+        "tombstone_histogram.max_ldt_histogram",
+        "test_tomb",
+        "tombstone_histogram-",
+    ) {
+        compared += 1;
+    }
+
+    if compared == 0 {
+        println!("[SKIP] {name}: no Statistics.db binaries present — nothing compared");
+        return;
+    }
+    println!(
+        "[PASS] {name}: {compared} fixture(s) STATS max-LDT + tombstone-drop histogram byte-parity"
+    );
+}

--- a/test-data/cassandra-parity-manifest.yml
+++ b/test-data/cassandra-parity-manifest.yml
@@ -3642,7 +3642,7 @@ scenarios:
 
   - id: cass.statistics_metadata.max_local_deletion_time.tombstones_ttl
     title: Statistics.db max local deletion time for tombstone/TTL fixture
-    status: partial
+    status: mirrored
     capability: statistics_metadata
     priority: P0
     risk: p1_correctness
@@ -3656,43 +3656,50 @@ scenarios:
       coverage:
         suite: sstable_parity_statistics_db
         tests:
+          - cqlite-core/tests/issue_1073_statistics_max_ldt_tombstone_histogram_parity.rs
           - cqlite-core/tests/issue_1011_ttl_local_deletion_parity.rs
+        notes: >-
+          The STATS-component `SSTable max local deletion time` decoded from the
+          Statistics.db is asserted equal to the parenthesised integer in the
+          sstablemetadata dump (real max LDT 1759799526, distinct from the min
+          baseline 1759799525); the "no tombstones" sentinel normalizes to
+          i64::MAX (issue #1073).
     fixtures:
       references:
         - test-data/datasets/sstables/test_basic/ttl_test_table-6af66a30a25111f0a3fef1a551383fb9/nb-1-big-Statistics.db.txt
     evidence:
-      type: partial
+      type: byte_for_byte
+      strict: true
       artifacts: [bytes]
       cassandra_version: "5.0.2"
       cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
       storage_format_version: [nb]
       fixture_generation_command: >-
         bash test-data/scripts/regenerate-datasets.sh && sstablemetadata emit Statistics.db.txt
+      comparison_command: >-
+        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        --test issue_1073_statistics_max_ldt_tombstone_histogram_parity
+        statistics_max_ldt_and_tombstone_histogram_parity
       reference_paths:
         - test-data/datasets/sstables/test_basic/ttl_test_table-6af66a30a25111f0a3fef1a551383fb9/nb-1-big-Statistics.db.txt
+      failure_artifacts:
+        - target/cassandra-parity/statistics-db-max-ldt-mismatch.log
       normalization: >-
-        The EncodingStats min local-deletion-time baseline decoded from the
-        Statistics.db is compared against the reference dump; the max local
-        deletion time is asserted to be the unparsed placeholder.
+        The STATS-component SSTable max local deletion time decoded by CQLite is
+        compared against the parenthesised integer parsed from the reference
+        dump; the "no tombstones" sentinel (9223372036854775807) is treated as
+        i64::MAX on both sides.
       known_limitations: >-
-        The minimal Statistics parser does not yet decode the STATS-component
-        SSTable max local deletion time, returning a placeholder equal to the min
-        baseline; only the min local-deletion-time baseline is asserted equal.
+        Resolved by issue #1073: CQLite now decodes the real STATS max local
+        deletion time rather than a min-baseline placeholder.
     ci:
       tier: nightly_docker
       workflow: .github/workflows/tombstone-ttl-parity.yml
-    scope:
-      gap: >-
-        CQLite's minimal Statistics parser does not decode the STATS-component
-        SSTable max local deletion time and returns a placeholder equal to the min
-        baseline.
-      next_step: >-
-        Decode the STATS max local-deletion-time field and assert it byte-equal to
-        the sstablemetadata reference; tracked by follow-up issue #1073.
+    scope: {}
 
   - id: cass.statistics_metadata.tombstone_histogram.deletion_times
     title: Statistics.db estimated tombstone-drop-times histogram parity
-    status: partial
+    status: mirrored
     capability: statistics_metadata
     priority: P0
     risk: p1_correctness
@@ -3706,37 +3713,46 @@ scenarios:
       coverage:
         suite: sstable_parity_statistics_db
         tests:
+          - cqlite-core/tests/issue_1073_statistics_max_ldt_tombstone_histogram_parity.rs
           - cqlite-core/tests/issue_1011_ttl_local_deletion_parity.rs
+        notes: >-
+          The estimated-tombstone-drop-times histogram decoded by CQLite into
+          `tombstone_drop_times` is asserted to reproduce the reference dump's
+          bucket cardinality, total bucket count, and (Cassandra-rounded) drop-time
+          points (issue #1073).
     fixtures:
       references:
         - test-data/datasets/sstables/test_tomb/tombstone_histogram-4ca1e9e0702011f1b8f419c9a388d558/nb-1-big-Statistics.db.txt
     evidence:
-      type: partial
+      type: byte_for_byte
+      strict: true
       artifacts: [bytes]
       cassandra_version: "5.0.2"
       cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
       storage_format_version: [nb]
       fixture_generation_command: >-
         bash test-data/scripts/generate-tomb-fixtures.sh && sstablemetadata emit Statistics.db.txt
+      comparison_command: >-
+        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        --test issue_1073_statistics_max_ldt_tombstone_histogram_parity
+        statistics_max_ldt_and_tombstone_histogram_parity
       reference_paths:
         - test-data/datasets/sstables/test_tomb/tombstone_histogram-4ca1e9e0702011f1b8f419c9a388d558/nb-1-big-Statistics.db.txt
+      failure_artifacts:
+        - target/cassandra-parity/statistics-db-tombstone-histogram-mismatch.log
       normalization: >-
-        Statistics.db core min baselines are decoded and compared; the
-        estimated-tombstone-drop-times histogram buckets present in the reference
-        dump are not yet exposed by CQLite.
+        The estimated-tombstone-drop-times histogram buckets decoded by CQLite are
+        compared against the `Estimated tombstone drop times` rows parsed from the
+        reference dump (bucket cardinality, total count, and rounded drop-time
+        points).
       known_limitations: >-
-        The estimated-tombstone-drop-times histogram is not decoded or exposed by
-        the minimal Statistics parser, so histogram-bucket parity is not asserted.
+        Resolved by issue #1073: CQLite now decodes and exposes the
+        estimated-tombstone-drop-times histogram, so bucket-count and cardinality
+        parity are asserted.
     ci:
       tier: nightly_docker
       workflow: .github/workflows/tombstone-ttl-parity.yml
-    scope:
-      gap: >-
-        The estimated-tombstone-drop-times histogram in Statistics.db is not decoded
-        or exposed by CQLite.
-      next_step: >-
-        Decode the estimated-tombstone-drop-times histogram and assert bucket parity
-        against the sstablemetadata reference; tracked by follow-up issue #1073.
+    scope: {}
 
   # --- #1012 skipped-sstable / partition delete across generations ----------
   - id: cass.sstable_io.reader.tombstone_only_partition


### PR DESCRIPTION
Closes #1073.

## Summary
CQLite's minimal `Statistics.db` parser did not decode two STATS-component fields, surfaced by the #1011 parity suite:
1. **SSTable max local deletion time** — returned a placeholder equal to `min_deletion_time`.
2. **Estimated tombstone-drop-times histogram** — not exposed on `SSTableStatistics`.

## Changes
- **`repair_metadata.rs`**: new `parse_stats_extras(input, gates)` reusing the existing TOC locator + bounded `Cursor` to decode `maxLocalDeletionTime` and the tombstone-drop-times histogram. Version-aware: nb signed-`i32` (sentinel `i32::MAX`) and oa/da `u32` (sentinel `0xFFFF_FFFF`) both normalize the no-tombstones sentinel to `i64::MAX`; histogram bin width is nb `f64+i64` (16B) vs modern `i64+i32` (12B). Allocation is bounds-checked against remaining bytes (fail-closed on a forged size).
- **`statistics.rs`**: adds `tombstone_drop_times: Vec<(i64,u64)>` (`#[serde(default)]`).
- **`enhanced_statistics_parser.rs`**: best-effort wiring — fills the real `max_deletion_time` + histogram; an error keeps the placeholder so a Statistics.db that parses today still parses. `min_deletion_time` (EncodingStats baseline) untouched.
- **`statistics_reader.rs`**: derives `VersionGates` from the component filename so oa/da formats decode correctly on the production read path.
- **Tests**: `issue_1011` placeholder pins flipped to assert the real decoded values; new `issue_1073_*` parity test compares decoded max-LDT + histogram against committed sstablemetadata dumps for `ttl_test_table` (real value) and `tombstone_histogram` (sentinel). Regen-safe (values parsed from the dump, never hardcoded); SKIP/strict-fixture discipline.
- **Manifest**: `cass.statistics_metadata.max_local_deletion_time.tombstones_ttl` and `cass.statistics_metadata.tombstone_histogram.deletion_times` upgraded `partial` → `mirrored`.

## Validation
- `cargo fmt`; workspace `clippy -D warnings --all-features` clean.
- repair_metadata (18) + version_gate (44) + statistics_reader unit tests pass.
- `issue_1073` parity test RUNS (not skip) + passes; `issue_1011` (delta-scan) 4/4 pass against real fixtures.
- roborev: clean ("No issues found") over both commits after fixing 1 High (unbounded histogram allocation) + 2 Medium (gates threading, stale test) findings.