### PR TITLE
fix(verify): BTI Partitions.db cross-check compares partition-key identity, not count (#1103)

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/data_access.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access.rs
@@ -2339,7 +2339,7 @@ impl SSTableReader {
     /// The stitch/parse strategy mirrors [`Self::distinct_partition_keys`]; only
     /// the parser entry point differs (it threads the partition-start offset).
     pub async fn distinct_partition_keys_with_positions(&self) -> Result<Vec<(u64, Vec<u8>)>> {
-        use std::collections::HashMap;
+        use std::collections::HashSet;
 
         let cursor = self.new_scan_cursor().await?;
         let header_size = self.calculate_header_size();
@@ -2352,10 +2352,11 @@ impl SSTableReader {
         let effective_schema = self.get_table_schema(None);
         let parser = self.build_v5_parser();
 
-        // first_offset_for_key: data_position of the FIRST row seen for a partition
-        // (a partition spans contiguous rows, so the first row's offset is the
-        // partition start). result preserves first-seen order.
-        let mut first_offset_for_key: HashMap<Vec<u8>, u64> = HashMap::new();
+        // `seen` dedups partition keys; the recorded position is the FIRST row's
+        // offset for a partition (a partition spans contiguous rows, so the first
+        // row's offset is the partition start). `result` preserves first-seen
+        // order and is the only place the position is read back.
+        let mut seen: HashSet<Vec<u8>> = HashSet::new();
         let mut result: Vec<(u64, Vec<u8>)> = Vec::new();
         parser.parse_block_for_compaction_emit_with_offset(
             &whole,
@@ -2363,10 +2364,8 @@ impl SSTableReader {
             self,
             |partition_start, row| {
                 let k = row.key.as_bytes().to_vec();
-                if !first_offset_for_key.contains_key(&k) {
-                    let pos = partition_start as u64;
-                    first_offset_for_key.insert(k.clone(), pos);
-                    result.push((pos, k));
+                if seen.insert(k.clone()) {
+                    result.push((partition_start as u64, k));
                 }
                 Ok(std::ops::ControlFlow::Continue(()))
             },

--- a/cqlite-core/src/storage/sstable/reader/data_access.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access.rs
@@ -2321,6 +2321,60 @@ impl SSTableReader {
         Ok(keys)
     }
 
+    /// Return the distinct raw partition keys decoded from `Data.db` together with
+    /// the byte offset at which each partition begins in the DECOMPRESSED data
+    /// section (issue #1103).
+    ///
+    /// Each tuple is `(data_position, raw_partition_key)`, where `data_position`
+    /// is exactly the value a BTI `Partitions.db` leaf encodes as
+    /// [`BtiPartitionLocation::DataOffset`](crate::storage::sstable::bti::parser::BtiPartitionLocation::DataOffset)
+    /// (and the `data_position` recovered from a `RowsOffset` entry via
+    /// [`resolve_rows_db_entry`](crate::storage::sstable::bti::parser::resolve_rows_db_entry)).
+    /// The verifier's BTI cross-check resolves each leaf PAYLOAD back to its raw
+    /// partition key through this map so it catches a corruption that keeps the
+    /// emitted trie prefix but rewrites the payload to point at a DIFFERENT
+    /// partition (a same-count wrong-IDENTITY corruption the prefix-only compare
+    /// missed).
+    ///
+    /// The stitch/parse strategy mirrors [`Self::distinct_partition_keys`]; only
+    /// the parser entry point differs (it threads the partition-start offset).
+    pub async fn distinct_partition_keys_with_positions(&self) -> Result<Vec<(u64, Vec<u8>)>> {
+        use std::collections::HashMap;
+
+        let cursor = self.new_scan_cursor().await?;
+        let header_size = self.calculate_header_size();
+        {
+            let mut file_guard = cursor.file.lock().await;
+            file_guard.seek(SeekFrom::Start(header_size as u64)).await?;
+        }
+        let whole = self.stitch_all_chunks(&cursor).await?;
+
+        let effective_schema = self.get_table_schema(None);
+        let parser = self.build_v5_parser();
+
+        // first_offset_for_key: data_position of the FIRST row seen for a partition
+        // (a partition spans contiguous rows, so the first row's offset is the
+        // partition start). result preserves first-seen order.
+        let mut first_offset_for_key: HashMap<Vec<u8>, u64> = HashMap::new();
+        let mut result: Vec<(u64, Vec<u8>)> = Vec::new();
+        parser.parse_block_for_compaction_emit_with_offset(
+            &whole,
+            effective_schema.as_ref(),
+            self,
+            |partition_start, row| {
+                let k = row.key.as_bytes().to_vec();
+                if !first_offset_for_key.contains_key(&k) {
+                    let pos = partition_start as u64;
+                    first_offset_for_key.insert(k.clone(), pos);
+                    result.push((pos, k));
+                }
+                Ok(std::ops::ControlFlow::Continue(()))
+            },
+        )?;
+
+        Ok(result)
+    }
+
     /// Streaming compaction read (issue #827): yield `(RowKey, Value, ts)`
     /// entries via `emit` one partition at a time, so peak memory is bounded by
     /// `max_partition_size + one_chunk` rather than by the total input size.

--- a/cqlite-core/src/storage/sstable/reader/data_access.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access.rs
@@ -2275,19 +2275,29 @@ impl SSTableReader {
     /// No schema is required from the caller: the parser resolves it via the
     /// reader's header/registry (`get_table_schema`).
     pub async fn distinct_partition_count(&self) -> Result<usize> {
+        Ok(self.distinct_partition_keys().await?.len())
+    }
+
+    /// Return the set of distinct **raw** partition keys decoded from `Data.db`,
+    /// one entry per partition (NOT per row), in first-seen order.
+    ///
+    /// Each key is the raw serialized partition key as stored on disk (e.g. the
+    /// 4-byte big-endian value for `pk int`, 16 bytes for a UUID) — the same form
+    /// accepted by
+    /// [`encode_partition_key_for_bti_trie`](crate::storage::sstable::bti::parser::encode_partition_key_for_bti_trie).
+    /// This is used by the verifier's BTI `Partitions.db` cross-check to compare
+    /// partition-key IDENTITY (issue #1103), not just partition count.
+    ///
+    /// The stitch/parse strategy mirrors [`Self::distinct_partition_count`]: we
+    /// route through `stitch_all_chunks` (not the generic
+    /// `iterate_all_partitions_for_compaction`) for BOTH BIG and BTI so the
+    /// incompressible/raw-chunk fallback is honoured (issue #970), and parse with
+    /// the compaction parser, which emits one `CompactionRow` per partition with
+    /// the partition key in `key` (partition-granular). No schema is required
+    /// from the caller: the parser resolves it via the reader's header/registry.
+    pub async fn distinct_partition_keys(&self) -> Result<Vec<Vec<u8>>> {
         use std::collections::HashSet;
 
-        // Stitch the whole data section and parse with the compaction parser,
-        // which emits one `CompactionRow` per partition with the partition key in
-        // `key` (partition-granular — NOT one row per clustering row). This is
-        // used by the verifier's BTI Partitions.db cross-check, so it must count
-        // PARTITIONS, not rows.
-        //
-        // We deliberately route through `stitch_all_chunks` (not the generic
-        // `iterate_all_partitions_for_compaction`) for BOTH BIG and BTI: that
-        // path honours Cassandra's incompressible/raw-chunk fallback, whereas the
-        // compaction stitch path does not yet, and would fail to decode the
-        // `incompressible_uncompressed_chunk` fixture (issue #970).
         let cursor = self.new_scan_cursor().await?;
         let header_size = self.calculate_header_size();
         {
@@ -2299,8 +2309,16 @@ impl SSTableReader {
         let effective_schema = self.get_table_schema(None);
         let parser = self.build_v5_parser();
         let rows = parser.parse_block_for_compaction(&whole, effective_schema.as_ref(), self)?;
-        let distinct: HashSet<&[u8]> = rows.iter().map(|r| r.key.as_bytes()).collect();
-        Ok(distinct.len())
+
+        let mut seen: HashSet<Vec<u8>> = HashSet::new();
+        let mut keys: Vec<Vec<u8>> = Vec::new();
+        for r in &rows {
+            let k = r.key.as_bytes();
+            if seen.insert(k.to_vec()) {
+                keys.push(k.to_vec());
+            }
+        }
+        Ok(keys)
     }
 
     /// Streaming compaction read (issue #827): yield `(RowKey, Value, ts)`

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy.rs
@@ -2198,6 +2198,90 @@ impl V5CompressedLegacyParser {
         Ok(())
     }
 
+    /// Like [`Self::parse_block_for_compaction_emit`] but also reports, for every
+    /// emitted [`CompactionRow`], the byte offset within `data` at which that
+    /// row's partition begins.
+    ///
+    /// `data` is the WHOLE decompressed Data.db data section (header stripped),
+    /// so the reported offset is the partition's absolute decompressed-Data.db
+    /// position — i.e. the value a BTI `Partitions.db` leaf encodes as
+    /// `BtiPartitionLocation::DataOffset`. The verifier uses this to resolve a
+    /// `DataOffset` payload back to its raw partition key by IDENTITY
+    /// (issue #1103), closing the same-count wrong-payload corruption gap.
+    pub fn parse_block_for_compaction_emit_with_offset<F>(
+        &self,
+        data: &[u8],
+        schema: Option<&TableSchema>,
+        reader: &super::super::types::SSTableReader,
+        mut emit: F,
+    ) -> Result<()>
+    where
+        F: FnMut(
+            usize,
+            crate::storage::sstable::reader::compaction_row::CompactionRow,
+        ) -> Result<std::ops::ControlFlow<()>>,
+    {
+        if data.is_empty() {
+            return Ok(());
+        }
+
+        let schema = schema.ok_or_else(|| {
+            Error::schema(format!(
+                "V5CompressedLegacy (compaction) format requires schema for {}.{}",
+                self.keyspace, self.table_name
+            ))
+        })?;
+
+        let mut offset = 0;
+        let mut skipped_partitions = 0;
+
+        let broke = std::cell::Cell::new(false);
+
+        while offset < data.len() {
+            // Capture the partition-start offset BEFORE parsing this partition so
+            // every row emitted for it is tagged with the same authoritative
+            // decompressed-Data.db position.
+            let partition_start = offset;
+            let mut tagging_emit = |row| -> Result<std::ops::ControlFlow<()>> {
+                let flow = emit(partition_start, row)?;
+                if matches!(flow, std::ops::ControlFlow::Break(())) {
+                    broke.set(true);
+                }
+                Ok(flow)
+            };
+
+            match self.parse_one_partition_for_compaction(
+                &data[offset..],
+                Some(schema),
+                reader,
+                true,
+                &mut tagging_emit,
+            )? {
+                ParseStep::Emitted(consumed) => {
+                    if consumed == 0 {
+                        skipped_partitions += 1;
+                        offset += 1;
+                    } else {
+                        offset += consumed;
+                    }
+                }
+                ParseStep::NeedMore | ParseStep::Done => break,
+            }
+            if broke.get() {
+                break;
+            }
+        }
+
+        if skipped_partitions > 0 {
+            log::warn!(
+                "V5CompressedLegacy (compaction): skipped {} malformed partitions",
+                skipped_partitions
+            );
+        }
+
+        Ok(())
+    }
+
     /// Per-element compaction counterpart of
     /// [`Self::parse_one_partition_with_timestamps`] (epic #899). Identical
     /// sliding-window / `ParseStep` / buffering semantics, but emits a

--- a/cqlite-core/src/storage/sstable/verify.rs
+++ b/cqlite-core/src/storage/sstable/verify.rs
@@ -292,15 +292,17 @@ pub async fn verify_sstable(
     // Partitions.db/Rows.db tries, so a corrupt trie is likewise invisible to a
     // scan. We validate the index structurally here and hard-fail.
     //
-    // `bti_partition_keys` is the distinct partition-key set recovered by
-    // walking Partitions.db; it is cross-checked against the Data.db scan in
-    // FULL mode to catch a footer-flip that silently UNDER-counts partitions
-    // (the trie still parses, just from the wrong root, yielding fewer keys).
-    let mut bti_partition_keys: Option<Vec<Vec<u8>>> = None;
+    // `bti_leaves` is the set of partition-index leaves recovered by walking
+    // Partitions.db; it is cross-checked against the Data.db scan in FULL mode to
+    // catch a footer-flip that silently UNDER-counts partitions (the trie still
+    // parses, just from the wrong root) AND a same-count corruption that keeps a
+    // leaf's emitted prefix but rewrites its PAYLOAD to point at a different
+    // partition. Each leaf carries its emitted byte-comparable prefix plus its
+    // payload resolved back to a raw partition key by AUTHORITATIVE data (issue
+    // #1103).
+    let mut bti_leaves: Option<Vec<BtiResolvedLeaf>> = None;
     match components.format {
-        SsTableFormat::Bti => {
-            bti_partition_keys = check_bti_structure(dir, &components, &mut findings)?
-        }
+        SsTableFormat::Bti => bti_leaves = check_bti_structure(dir, &components, &mut findings)?,
         SsTableFormat::Big => check_big_index(dir, &components, &mut findings)?,
     }
 
@@ -341,19 +343,20 @@ pub async fn verify_sstable(
             // scan to exercise the decompression stitch path and surface Data.db
             // corruption that only manifests during decode.
             match full_row_scan_partitions(&components.data_path, config, platform).await {
-                Ok((rows, scan_partition_keys)) => {
+                Ok((rows, scan_partitions)) => {
                     rows_scanned = Some(rows);
-                    // BTI cross-check: the partition KEY SET recovered by walking
-                    // Partitions.db MUST match the partition keys decoded from
-                    // Data.db — by IDENTITY, not just count (issue #1103). A
-                    // count-only check passes a corruption that walks a wrong
-                    // subtree yielding a different set of keys with the same leaf
-                    // count. We compare identities by re-deriving each Data.db raw
-                    // key's byte-comparable trie key and matching it against the
-                    // path-compressed trie keys.
-                    if let Some(trie_keys) = bti_partition_keys {
+                    // BTI cross-check: each Partitions.db leaf's PAYLOAD, resolved
+                    // back to a raw partition key by authoritative data, MUST match
+                    // the partition keys decoded from Data.db — by IDENTITY, not
+                    // just count (issue #1103). A count-only check passes a
+                    // corruption that walks a wrong subtree yielding a different set
+                    // of keys with the same leaf count; a prefix-only check passes a
+                    // corruption that keeps a leaf's emitted prefix but rewrites its
+                    // payload to a different partition. Resolving the payload closes
+                    // both gaps.
+                    if let Some(leaves) = bti_leaves {
                         if let Some(detail) =
-                            bti_partition_key_identity_mismatch(&trie_keys, &scan_partition_keys)
+                            bti_partition_identity_mismatch(&leaves, &scan_partitions)
                         {
                             findings.push(VerifyFinding::new(
                                 VerifyErrorClass::BtiRootPointerCorrupt,
@@ -690,30 +693,58 @@ fn check_compression_info(
     Ok(Some(info))
 }
 
-/// Check 4 (BTI): structurally validate the `Partitions.db` and `Rows.db`
-/// tries.
+/// One BTI `Partitions.db` leaf, with its PAYLOAD resolved back to a raw
+/// partition key using authoritative data (issue #1103).
 ///
-/// Returns `Some(n)` where `n` is the number of partition keys recovered by
-/// walking `Partitions.db`, so the caller can cross-check it against the Data.db
-/// scan (FULL mode). Returns `None` if `Partitions.db` could not be walked (a
-/// finding was recorded).
+/// The verifier resolves every leaf so a corruption that keeps the leaf's
+/// emitted byte-comparable prefix while rewriting its payload to point at a
+/// DIFFERENT partition is still caught (a same-count, wrong-IDENTITY
+/// corruption the prefix-only compare missed).
+struct BtiResolvedLeaf {
+    /// The path-compressed byte-comparable prefix emitted by the trie walk
+    /// (`[0x40 ++ token]` truncated to the shortest distinguishing prefix). Used
+    /// only for the prefix/payload-consistency assertion.
+    prefix: Vec<u8>,
+    /// The raw partition key this leaf's payload resolves to, when it could be
+    /// recovered directly (a `RowsOffset` leaf stores the raw key INLINE in
+    /// `Rows.db`). `None` for a `DataOffset` leaf, whose raw key is recovered via
+    /// the Data.db position map ([`Self::data_position`]).
+    inline_raw_key: Option<Vec<u8>>,
+    /// The decompressed-`Data.db` partition-start position the payload points at:
+    /// the `DataOffset` value directly, or the `data_position` recovered from the
+    /// `RowsOffset` row-index entry. Resolved to a raw key via the Data.db scan's
+    /// position map in [`bti_partition_identity_mismatch`].
+    data_position: u64,
+}
+
+/// Check 4 (BTI): structurally validate the `Partitions.db` and `Rows.db`
+/// tries, and resolve every partition-index leaf back to a raw partition key.
+///
+/// Returns `Some(leaves)` — one [`BtiResolvedLeaf`] per recovered partition —
+/// so the caller can cross-check them against the Data.db scan by IDENTITY
+/// (FULL mode). Returns `None` if `Partitions.db` could not be walked (a finding
+/// was recorded).
 ///
 /// * `Partitions.db` is walked with [`iterate_partitions_in_bti_file`], which
 ///   follows the trailing-8-byte footer root and DFS-collects every leaf. A
 ///   footer flip either makes the walk error (out-of-bounds root) or silently
-///   recover the wrong key set; the FULL-mode count cross-check catches the
+///   recover the wrong key set; the FULL-mode identity cross-check catches the
 ///   latter.
 /// * For every partition whose payload is a `RowsOffset`, the per-partition
-///   row-index entry is resolved from `Rows.db` via [`iterate_rows_for_partition`].
-///   A truncated `Rows.db` makes the referenced offset point past EOF or the
-///   row-trie read hit EOF.
+///   row-index entry is resolved from `Rows.db` via [`iterate_rows_for_partition`]
+///   (structural) and [`resolve_rows_db_entry`] (to recover the inline raw key
+///   and the partition's Data.db position). A truncated `Rows.db` makes the
+///   referenced offset point past EOF or the row-trie read hit EOF.
+/// * A `DataOffset` payload carries the partition's decompressed-Data.db
+///   position directly; its raw key is resolved later through the Data.db scan.
 fn check_bti_structure(
     dir: &Path,
     components: &ComponentSet,
     findings: &mut Vec<VerifyFinding>,
-) -> Result<Option<Vec<Vec<u8>>>> {
+) -> Result<Option<Vec<BtiResolvedLeaf>>> {
     use crate::storage::sstable::bti::parser::{
-        iterate_partitions_in_bti_file, iterate_rows_for_partition, BtiPartitionLocation,
+        iterate_partitions_in_bti_file, iterate_rows_for_partition, resolve_rows_db_entry,
+        BtiPartitionLocation,
     };
     use std::io::Cursor;
 
@@ -785,44 +816,116 @@ fn check_bti_structure(
                 "Rows.db",
                 format!("cannot read Rows.db: {}", e),
             ));
-            // We can still report the recovered trie partition keys.
-            return Ok(Some(partitions.into_iter().map(|(k, _)| k).collect()));
+            // Rows.db is gone, so `RowsOffset` payloads cannot be resolved; only
+            // `DataOffset` leaves carry a self-contained position. Return what we
+            // can (the missing-component finding already fails verification).
+            let leaves = partitions
+                .into_iter()
+                .filter_map(|(prefix, location)| match location {
+                    BtiPartitionLocation::DataOffset(off) => Some(BtiResolvedLeaf {
+                        prefix,
+                        inline_raw_key: None,
+                        data_position: off,
+                    }),
+                    BtiPartitionLocation::RowsOffset(_) => None,
+                })
+                .collect();
+            return Ok(Some(leaves));
         }
     };
 
-    for (key, location) in &partitions {
-        if let BtiPartitionLocation::RowsOffset(off) = location {
-            let off = *off as usize;
-            if off >= rows_bytes.len() {
-                findings.push(VerifyFinding::new(
-                    VerifyErrorClass::BtiTrieCorrupt,
-                    "Rows.db",
-                    format!(
-                        "partition (key {} bytes) references Rows.db offset {} which is past EOF ({} bytes) — Rows.db is truncated/corrupt",
-                        key.len(),
-                        off,
-                        rows_bytes.len()
-                    ),
-                ));
-                continue;
+    // Resolve every leaf's PAYLOAD back to a raw partition key (issue #1103). A
+    // `RowsOffset` leaf stores the raw key INLINE in `Rows.db` as
+    // `[u16 key_length][key bytes]` at the offset (see `resolve_rows_db_entry`),
+    // so we extract it directly — no Data.db read. A `DataOffset` leaf carries the
+    // partition's decompressed-Data.db position directly; its raw key is resolved
+    // later through the Data.db scan's position map.
+    let mut leaves: Vec<BtiResolvedLeaf> = Vec::with_capacity(partitions.len());
+    for (prefix, location) in partitions {
+        match location {
+            BtiPartitionLocation::RowsOffset(off) => {
+                let off = off as usize;
+                if off + 2 > rows_bytes.len() {
+                    findings.push(VerifyFinding::new(
+                        VerifyErrorClass::BtiTrieCorrupt,
+                        "Rows.db",
+                        format!(
+                            "partition (trie prefix {} bytes) references Rows.db offset {} which is past EOF ({} bytes) — Rows.db is truncated/corrupt",
+                            prefix.len(),
+                            off,
+                            rows_bytes.len()
+                        ),
+                    ));
+                    continue;
+                }
+                if let Err(e) = iterate_rows_for_partition(&rows_bytes, off) {
+                    findings.push(VerifyFinding::new(
+                        VerifyErrorClass::BtiTrieCorrupt,
+                        "Rows.db",
+                        format!(
+                            "row-index trie for partition at Rows.db offset {} failed to parse (truncated/corrupt): {}",
+                            off, e
+                        ),
+                    ));
+                    continue;
+                }
+
+                // Inline raw partition key: [u16 key_length][key bytes] at `off`.
+                let key_length =
+                    u16::from_be_bytes([rows_bytes[off], rows_bytes[off + 1]]) as usize;
+                let key_start = off + 2;
+                let key_end = key_start + key_length;
+                if key_end > rows_bytes.len() {
+                    findings.push(VerifyFinding::new(
+                        VerifyErrorClass::BtiTrieCorrupt,
+                        "Rows.db",
+                        format!(
+                            "Rows.db entry at offset {} declares an inline key length {} that overruns the file ({} bytes)",
+                            off, key_length, rows_bytes.len()
+                        ),
+                    ));
+                    continue;
+                }
+                let inline_raw_key = rows_bytes[key_start..key_end].to_vec();
+
+                // Recover the partition's Data.db position too, so a leaf whose
+                // INLINE key and Data.db position disagree (a payload tamper) is
+                // still cross-checkable through the position map.
+                let data_position = match resolve_rows_db_entry(&rows_bytes, off) {
+                    Ok(hdr) => hdr.data_position,
+                    Err(e) => {
+                        findings.push(VerifyFinding::new(
+                            VerifyErrorClass::BtiTrieCorrupt,
+                            "Rows.db",
+                            format!(
+                                "Rows.db entry at offset {} failed to deserialize (truncated/corrupt): {}",
+                                off, e
+                            ),
+                        ));
+                        continue;
+                    }
+                };
+
+                leaves.push(BtiResolvedLeaf {
+                    prefix,
+                    inline_raw_key: Some(inline_raw_key),
+                    data_position,
+                });
             }
-            if let Err(e) = iterate_rows_for_partition(&rows_bytes, off) {
-                findings.push(VerifyFinding::new(
-                    VerifyErrorClass::BtiTrieCorrupt,
-                    "Rows.db",
-                    format!(
-                        "row-index trie for partition at Rows.db offset {} failed to parse (truncated/corrupt): {}",
-                        off, e
-                    ),
-                ));
+            BtiPartitionLocation::DataOffset(off) => {
+                leaves.push(BtiResolvedLeaf {
+                    prefix,
+                    inline_raw_key: None,
+                    data_position: off,
+                });
             }
         }
     }
 
-    // Return the byte-comparable trie partition keys (path-compressed prefixes)
-    // recovered by walking Partitions.db. FULL-mode verification cross-checks
-    // these against the keys decoded from Data.db (issue #1103).
-    Ok(Some(partitions.into_iter().map(|(k, _)| k).collect()))
+    // Return the resolved leaves. FULL-mode verification cross-checks each leaf's
+    // resolved raw partition key against the keys decoded from Data.db, by
+    // IDENTITY (issue #1103).
+    Ok(Some(leaves))
 }
 
 /// Check 4 (BIG): structurally validate `Index.db`.
@@ -1066,13 +1169,14 @@ async fn check_statistics(
 }
 
 /// Check 7 (FULL): a complete row scan. Returns `(rows, distinct_partitions)`
-/// where `distinct_partitions` is the number of distinct partition keys decoded
-/// from `Data.db` (used for the BTI Partitions.db cross-check).
+/// where `distinct_partitions` is the set of distinct partition keys decoded
+/// from `Data.db`, each paired with its decompressed-Data.db partition-start
+/// position (used for the BTI Partitions.db identity cross-check, issue #1103).
 async fn full_row_scan_partitions(
     data_path: &Path,
     config: &Config,
     platform: Arc<Platform>,
-) -> Result<(usize, Vec<Vec<u8>>)> {
+) -> Result<(usize, Vec<(u64, Vec<u8>)>)> {
     let reader = SSTableReader::open(data_path, config, platform).await?;
 
     // `rows` is the total decoded row/entry count (exercises the full
@@ -1080,79 +1184,144 @@ async fn full_row_scan_partitions(
     let entries = reader.get_all_entries().await?;
     let rows = entries.len();
 
-    // `distinct_partition_keys` are the raw serialized PARTITION keys decoded
-    // from Data.db — one per partition, NOT per row. Deduping `get_all_entries`
-    // RowKeys would over-count a multi-row partition (those keys carry
-    // clustering/column/static suffixes), which previously FALSE-FAILED the BTI
-    // Partitions.db cross-check on healthy SSTables (issue #970). The reader
-    // dedups at the partition boundary for both BIG (`nb`) and BTI (`da`).
-    let partition_keys = reader.distinct_partition_keys().await?;
+    // `distinct_partition_keys_with_positions` are the raw serialized PARTITION
+    // keys decoded from Data.db — one per partition, NOT per row — each tagged
+    // with its decompressed-Data.db partition-start position. Deduping
+    // `get_all_entries` RowKeys would over-count a multi-row partition (those keys
+    // carry clustering/column/static suffixes), which previously FALSE-FAILED the
+    // BTI Partitions.db cross-check on healthy SSTables (issue #970). The reader
+    // dedups at the partition boundary for both BIG (`nb`) and BTI (`da`); the
+    // position lets the verifier resolve a BTI leaf's payload back to its raw key.
+    let partitions = reader.distinct_partition_keys_with_positions().await?;
 
-    Ok((rows, partition_keys))
+    Ok((rows, partitions))
 }
 
-/// Cross-check BTI `Partitions.db` trie keys against the partition keys decoded
-/// from `Data.db` by IDENTITY (issue #1103). Returns `Some(detail)` describing
-/// the mismatch when the trie does not represent the same partition set as
-/// Data.db, or `None` when they agree.
+/// Cross-check BTI `Partitions.db` leaves against the partitions decoded from
+/// `Data.db` by IDENTITY (issue #1103). Returns `Some(detail)` describing the
+/// mismatch when the trie does not represent the same partition set as Data.db,
+/// or `None` when they agree.
 ///
-/// The two sides use different on-disk encodings and are not directly
-/// comparable: a BTI trie key is the path-compressed (shortest-distinguishing)
-/// prefix of the byte-comparable `[0x40 ++ 8-byte murmur3 token]` key, while a
-/// Data.db key is the raw serialized partition key. We bridge them by re-deriving
-/// each Data.db raw key's byte-comparable trie key
-/// (`encode_partition_key_for_bti_trie`) and matching it against the trie keys by
-/// prefix. A healthy table is a total bijection; a wrong-root corruption that
-/// preserves leaf count but changes keys leaves a trie key that prefixes no
-/// Data.db key (and a Data.db key matched by none), which we surface.
+/// Unlike a prefix-only compare (which only looks at the leaf's emitted
+/// byte-comparable transition bytes), this resolves each leaf's PAYLOAD back to a
+/// raw partition key using authoritative data and matches it against the Data.db
+/// keys. This closes a same-count, wrong-IDENTITY corruption that keeps the
+/// emitted prefix but rewrites the payload (`DataOffset` / `RowsOffset` →
+/// `data_position`) to point at a DIFFERENT partition:
+///
+/// * `RowsOffset` leaf: the raw key is stored INLINE in `Rows.db`
+///   ([`BtiResolvedLeaf::inline_raw_key`]); matched directly against Data.db.
+/// * `DataOffset` leaf: matched via its decompressed-Data.db
+///   [`BtiResolvedLeaf::data_position`], looked up in the Data.db scan's
+///   `position → raw_key` map.
+///
+/// We require an exact MULTISET equality between the resolved leaf keys and the
+/// Data.db keys, plus a per-leaf consistency check that the resolved raw key's
+/// byte-comparable encoding actually starts with the leaf's emitted prefix
+/// (catches a leaf whose path is inconsistent with its payload).
 ///
 /// Note: the byte-comparable encoding assumes `Murmur3Partitioner`, matching the
 /// rest of CQLite's BTI read path (issue #755).
-fn bti_partition_key_identity_mismatch(
-    trie_keys: &[Vec<u8>],
-    data_keys: &[Vec<u8>],
+fn bti_partition_identity_mismatch(
+    leaves: &[BtiResolvedLeaf],
+    data_partitions: &[(u64, Vec<u8>)],
 ) -> Option<String> {
     use crate::storage::sstable::bti::parser::encode_partition_key_for_bti_trie;
-
-    let encoded: Vec<[u8; 9]> = data_keys
-        .iter()
-        .map(|k| encode_partition_key_for_bti_trie(k))
-        .collect();
-
-    if trie_keys.len() != encoded.len() {
-        return Some(format!(
-            "Partitions.db trie yielded {} partition keys but Data.db decoded {} distinct partitions — the trie was walked from a corrupt root",
-            trie_keys.len(),
-            encoded.len()
-        ));
-    }
+    use std::collections::HashMap;
 
     let hex = |b: &[u8]| b.iter().map(|x| format!("{:02x}", x)).collect::<String>();
 
-    // Greedily match each trie key to exactly one (still-unclaimed) Data.db key
-    // by prefix. Equal lengths + a one-to-one matching ⇒ identical partition sets.
-    let mut claimed = vec![false; encoded.len()];
-    for tk in trie_keys {
-        let matched: Vec<usize> = encoded
-            .iter()
-            .enumerate()
-            .filter(|(i, enc)| !claimed[*i] && enc.starts_with(tk.as_slice()))
-            .map(|(i, _)| i)
-            .collect();
-        match matched.as_slice() {
-            [idx] => claimed[*idx] = true,
-            [] => {
-                return Some(format!(
-                    "Partitions.db trie key {} matches no Data.db partition key — the trie was walked from a corrupt root (same leaf count, different keys)",
-                    hex(tk)
-                ));
+    // Data.db side: a position → raw_key map (to resolve `DataOffset` leaves) plus
+    // the raw-key multiset (to compare identities).
+    let pos_to_key: HashMap<u64, &Vec<u8>> = data_partitions.iter().map(|(p, k)| (*p, k)).collect();
+
+    // Resolve every leaf to a raw partition key.
+    let mut leaf_keys: Vec<Vec<u8>> = Vec::with_capacity(leaves.len());
+    for leaf in leaves {
+        let raw_key = match &leaf.inline_raw_key {
+            // `RowsOffset` leaf: authoritative inline key. Cross-check that its
+            // recorded Data.db position resolves to the SAME raw key, so a payload
+            // tamper that desyncs the inline key from the position is caught.
+            Some(inline) => {
+                if let Some(by_pos) = pos_to_key.get(&leaf.data_position) {
+                    if by_pos.as_slice() != inline.as_slice() {
+                        return Some(format!(
+                            "Partitions.db leaf (prefix {}) inline raw key {} disagrees with the key at its Data.db position {} ({}) — the leaf payload was tampered",
+                            hex(&leaf.prefix),
+                            hex(inline),
+                            leaf.data_position,
+                            hex(by_pos),
+                        ));
+                    }
+                }
+                inline.clone()
             }
-            _ => {
-                return Some(format!(
-                    "Partitions.db trie key {} is an ambiguous prefix of multiple Data.db partition keys — the trie does not match Data.db identities",
-                    hex(tk)
-                ));
-            }
+            // `DataOffset` leaf: resolve via the Data.db position map. A payload
+            // flipped to a position that is not a partition start matches nothing.
+            None => match pos_to_key.get(&leaf.data_position) {
+                Some(k) => (*k).clone(),
+                None => {
+                    return Some(format!(
+                        "Partitions.db leaf (prefix {}) payload points at Data.db position {} which is not a decoded partition start — the leaf payload is corrupt (same prefix, wrong partition)",
+                        hex(&leaf.prefix),
+                        leaf.data_position,
+                    ));
+                }
+            },
+        };
+
+        // Per-leaf path/payload consistency: the resolved raw key's
+        // byte-comparable encoding MUST start with the leaf's emitted prefix.
+        let encoded = encode_partition_key_for_bti_trie(&raw_key);
+        if !encoded.starts_with(leaf.prefix.as_slice()) {
+            return Some(format!(
+                "Partitions.db leaf prefix {} is inconsistent with its payload's partition key (encodes to {}) — the trie path does not match the leaf payload",
+                hex(&leaf.prefix),
+                hex(&encoded),
+            ));
+        }
+
+        leaf_keys.push(raw_key);
+    }
+
+    // Exact MULTISET equality between the resolved leaf keys and the Data.db keys.
+    let mut data_counts: HashMap<&[u8], i64> = HashMap::new();
+    for (_, k) in data_partitions {
+        *data_counts.entry(k.as_slice()).or_insert(0) += 1;
+    }
+    let mut leaf_counts: HashMap<&[u8], i64> = HashMap::new();
+    for k in &leaf_keys {
+        *leaf_counts.entry(k.as_slice()).or_insert(0) += 1;
+    }
+
+    if leaf_keys.len() != data_partitions.len() {
+        return Some(format!(
+            "Partitions.db trie yielded {} partition keys but Data.db decoded {} distinct partitions — the trie was walked from a corrupt root",
+            leaf_keys.len(),
+            data_partitions.len()
+        ));
+    }
+
+    for (k, &lc) in &leaf_counts {
+        let dc = data_counts.get(k).copied().unwrap_or(0);
+        if lc != dc {
+            return Some(format!(
+                "Partitions.db resolves partition key {} {} time(s) but Data.db decodes it {} time(s) — the trie does not match Data.db identities (same count, different keys)",
+                hex(k),
+                lc,
+                dc,
+            ));
+        }
+    }
+    for (k, &dc) in &data_counts {
+        let lc = leaf_counts.get(k).copied().unwrap_or(0);
+        if lc != dc {
+            return Some(format!(
+                "Data.db partition key {} appears {} time(s) but Partitions.db resolves it {} time(s) — the trie does not match Data.db identities",
+                hex(k),
+                dc,
+                lc,
+            ));
         }
     }
 
@@ -1276,7 +1445,13 @@ mod tests {
         assert!(fail.summary_line().contains("DigestMismatch"));
     }
 
-    // ---- BTI partition-key identity cross-check (issue #1103) --------------
+    // ---- BTI partition identity cross-check (issue #1103) ------------------
+    //
+    // These exercise `bti_partition_identity_mismatch` over RESOLVED leaves: each
+    // leaf carries its emitted byte-comparable prefix plus a payload resolved back
+    // to a raw partition key (an inline raw key for a `RowsOffset` leaf, or a
+    // Data.db position for a `DataOffset` leaf). The Data.db side is the
+    // `(position, raw_key)` set from the scan.
 
     use crate::storage::sstable::bti::parser::encode_partition_key_for_bti_trie;
 
@@ -1288,43 +1463,134 @@ mod tests {
         encode_partition_key_for_bti_trie(raw)[..prefix_len].to_vec()
     }
 
-    #[test]
-    fn identity_check_passes_for_matching_full_keys() {
-        // Trie keys == full 9-byte encoded keys (a key is a prefix of itself).
-        let data: Vec<Vec<u8>> = (1u32..=3).map(|i| i.to_be_bytes().to_vec()).collect();
-        let trie: Vec<Vec<u8>> = data
-            .iter()
-            .map(|k| encode_partition_key_for_bti_trie(k).to_vec())
-            .collect();
-        assert_eq!(bti_partition_key_identity_mismatch(&trie, &data), None);
+    /// A `RowsOffset`-style leaf: authoritative inline raw key + matching Data.db
+    /// position, with a 2-byte emitted prefix (what `test_da/wide_table` does).
+    fn inline_leaf(raw: &[u8], data_position: u64) -> BtiResolvedLeaf {
+        BtiResolvedLeaf {
+            prefix: trie_key_prefix(raw, 2),
+            inline_raw_key: Some(raw.to_vec()),
+            data_position,
+        }
+    }
+
+    /// A `DataOffset`-style leaf: no inline key, resolved purely via its Data.db
+    /// position, with a 2-byte emitted prefix derived from the key it *should*
+    /// resolve to (so the prefix/payload-consistency check passes when healthy).
+    fn data_offset_leaf(prefix_from: &[u8], data_position: u64) -> BtiResolvedLeaf {
+        BtiResolvedLeaf {
+            prefix: trie_key_prefix(prefix_from, 2),
+            inline_raw_key: None,
+            data_position,
+        }
+    }
+
+    /// The Data.db scan side: distinct partition keys, each at a synthetic
+    /// monotonically-increasing position (0, 100, 200, ...).
+    fn data_partitions(keys: &[Vec<u8>]) -> Vec<(u64, Vec<u8>)> {
+        keys.iter()
+            .enumerate()
+            .map(|(i, k)| (i as u64 * 100, k.clone()))
+            .collect()
     }
 
     #[test]
-    fn identity_check_passes_for_path_compressed_prefixes() {
-        // Healthy table: trie stores only the first 2 bytes (`0x40` + 1 token
-        // byte), which is what `test_da/wide_table` actually does.
-        let data: Vec<Vec<u8>> = (1u32..=3).map(|i| i.to_be_bytes().to_vec()).collect();
-        let trie: Vec<Vec<u8>> = data.iter().map(|k| trie_key_prefix(k, 2)).collect();
-        // Precondition: the 2-byte prefixes are distinct (true for pk=1,2,3).
-        let mut sorted = trie.clone();
-        sorted.sort();
-        sorted.dedup();
-        assert_eq!(sorted.len(), trie.len(), "test prefixes must be distinct");
-        assert_eq!(bti_partition_key_identity_mismatch(&trie, &data), None);
+    fn identity_check_passes_for_inline_rows_leaves() {
+        // Healthy wide-table shape: every leaf resolves to its inline raw key,
+        // matching the Data.db key at the same position.
+        let keys: Vec<Vec<u8>> = (1u32..=3).map(|i| i.to_be_bytes().to_vec()).collect();
+        let data = data_partitions(&keys);
+        let leaves: Vec<BtiResolvedLeaf> =
+            data.iter().map(|(pos, k)| inline_leaf(k, *pos)).collect();
+        assert_eq!(bti_partition_identity_mismatch(&leaves, &data), None);
+    }
+
+    #[test]
+    fn identity_check_passes_for_data_offset_leaves() {
+        // Healthy small-partition shape (`da-2-bti`): leaves carry only a Data.db
+        // position; the raw key is resolved through the position map.
+        let keys: Vec<Vec<u8>> = (1u32..=3).map(|i| i.to_be_bytes().to_vec()).collect();
+        let data = data_partitions(&keys);
+        let leaves: Vec<BtiResolvedLeaf> = data
+            .iter()
+            .map(|(pos, k)| data_offset_leaf(k, *pos))
+            .collect();
+        assert_eq!(bti_partition_identity_mismatch(&leaves, &data), None);
+    }
+
+    #[test]
+    fn identity_check_detects_inline_payload_pointing_at_wrong_partition() {
+        // The exact reviewer scenario for a `RowsOffset` leaf: the leaf's emitted
+        // prefix is unchanged but its INLINE raw key (the payload) is rewritten to
+        // a partition NOT present in Data.db. Same leaf count, wrong identity.
+        let keys: Vec<Vec<u8>> = (1u32..=3).map(|i| i.to_be_bytes().to_vec()).collect();
+        let data = data_partitions(&keys);
+        let mut leaves: Vec<BtiResolvedLeaf> =
+            data.iter().map(|(pos, k)| inline_leaf(k, *pos)).collect();
+        // Keep the emitted prefix; rewrite the inline raw key to pk=99.
+        leaves[0].inline_raw_key = Some(99u32.to_be_bytes().to_vec());
+        assert!(
+            bti_partition_identity_mismatch(&leaves, &data).is_some(),
+            "an inline payload pointing at a partition absent from Data.db must be flagged"
+        );
+    }
+
+    #[test]
+    fn identity_check_detects_data_offset_payload_pointing_at_wrong_partition() {
+        // The reviewer scenario for a `DataOffset` leaf: the leaf's emitted prefix
+        // is unchanged but its Data.db position payload is rewritten to point at a
+        // DIFFERENT partition's start. The resolved key then no longer matches the
+        // partition the prefix encodes.
+        let keys: Vec<Vec<u8>> = (1u32..=3).map(|i| i.to_be_bytes().to_vec()).collect();
+        let data = data_partitions(&keys);
+        let mut leaves: Vec<BtiResolvedLeaf> = data
+            .iter()
+            .map(|(pos, k)| data_offset_leaf(k, *pos))
+            .collect();
+        // Leaf 0's prefix still encodes pk=1, but its position now points at pk=2.
+        leaves[0].data_position = data[1].0;
+        let detail = bti_partition_identity_mismatch(&leaves, &data)
+            .expect("a DataOffset payload pointing at the wrong partition must be flagged");
+        // It is caught by the prefix/payload-consistency check (the resolved key's
+        // encoding no longer starts with the leaf's prefix) OR the multiset compare.
+        assert!(
+            detail.contains("inconsistent") || detail.contains("identities"),
+            "unexpected detail: {detail}"
+        );
+    }
+
+    #[test]
+    fn identity_check_detects_data_offset_payload_pointing_at_non_partition() {
+        // A `DataOffset` flipped to a byte position that is NOT a partition start
+        // resolves to no key at all.
+        let keys: Vec<Vec<u8>> = (1u32..=3).map(|i| i.to_be_bytes().to_vec()).collect();
+        let data = data_partitions(&keys);
+        let mut leaves: Vec<BtiResolvedLeaf> = data
+            .iter()
+            .map(|(pos, k)| data_offset_leaf(k, *pos))
+            .collect();
+        leaves[0].data_position = 37; // not any partition start
+        let detail = bti_partition_identity_mismatch(&leaves, &data)
+            .expect("a DataOffset pointing at a non-partition position must be flagged");
+        assert!(detail.contains("not a decoded partition start"));
     }
 
     #[test]
     fn identity_check_detects_same_count_wrong_keys() {
-        // Data has partitions {1,2,3} but the trie was walked to {4,5,6}: same
+        // Data has partitions {1,2,3} but the leaves resolve to {4,5,6}: same
         // count, disjoint identities. MUST be flagged (the core of issue #1103).
-        let data: Vec<Vec<u8>> = (1u32..=3).map(|i| i.to_be_bytes().to_vec()).collect();
-        let trie: Vec<Vec<u8>> = (4u32..=6)
-            .map(|i| trie_key_prefix(&i.to_be_bytes(), 2))
+        let data_keys: Vec<Vec<u8>> = (1u32..=3).map(|i| i.to_be_bytes().to_vec()).collect();
+        let data = data_partitions(&data_keys);
+        let leaf_keys: Vec<Vec<u8>> = (4u32..=6).map(|i| i.to_be_bytes().to_vec()).collect();
+        // Inline leaves whose prefix matches their (wrong) key, with positions that
+        // are NOT in the Data.db map (so the inline/position cross-check is inert).
+        let leaves: Vec<BtiResolvedLeaf> = leaf_keys
+            .iter()
+            .enumerate()
+            .map(|(i, k)| inline_leaf(k, 10_000 + i as u64))
             .collect();
-        let mismatch = bti_partition_key_identity_mismatch(&trie, &data);
         assert!(
-            mismatch.is_some(),
-            "same-count wrong-key trie must be detected as a mismatch"
+            bti_partition_identity_mismatch(&leaves, &data).is_some(),
+            "same-count wrong-key leaves must be detected as a mismatch"
         );
     }
 
@@ -1332,22 +1598,28 @@ mod tests {
     fn identity_check_detects_one_swapped_key() {
         // Two keys match, one is wrong — the minimal wrong-root that a count check
         // cannot see.
-        let data: Vec<Vec<u8>> = (1u32..=3).map(|i| i.to_be_bytes().to_vec()).collect();
-        let mut trie: Vec<Vec<u8>> = data.iter().map(|k| trie_key_prefix(k, 2)).collect();
-        trie[0] = trie_key_prefix(&99u32.to_be_bytes(), 2);
-        assert!(bti_partition_key_identity_mismatch(&trie, &data).is_some());
+        let keys: Vec<Vec<u8>> = (1u32..=3).map(|i| i.to_be_bytes().to_vec()).collect();
+        let data = data_partitions(&keys);
+        let mut leaves: Vec<BtiResolvedLeaf> =
+            data.iter().map(|(pos, k)| inline_leaf(k, *pos)).collect();
+        // Replace leaf 0 with a key (pk=99) absent from Data.db, including its
+        // prefix, and a position that is not a partition start.
+        leaves[0] = inline_leaf(&99u32.to_be_bytes(), 10_000);
+        assert!(bti_partition_identity_mismatch(&leaves, &data).is_some());
     }
 
     #[test]
     fn identity_check_detects_count_mismatch() {
-        let data: Vec<Vec<u8>> = (1u32..=3).map(|i| i.to_be_bytes().to_vec()).collect();
-        let trie: Vec<Vec<u8>> = data
+        let keys: Vec<Vec<u8>> = (1u32..=3).map(|i| i.to_be_bytes().to_vec()).collect();
+        let data = data_partitions(&keys);
+        // Only two leaves recovered from the trie (undercount).
+        let leaves: Vec<BtiResolvedLeaf> = data
             .iter()
             .take(2)
-            .map(|k| encode_partition_key_for_bti_trie(k).to_vec())
+            .map(|(pos, k)| inline_leaf(k, *pos))
             .collect();
         let detail =
-            bti_partition_key_identity_mismatch(&trie, &data).expect("undercount must be flagged");
+            bti_partition_identity_mismatch(&leaves, &data).expect("undercount must be flagged");
         assert!(detail.contains("2 partition keys"));
         assert!(detail.contains("3 distinct partitions"));
     }

--- a/cqlite-core/src/storage/sstable/verify.rs
+++ b/cqlite-core/src/storage/sstable/verify.rs
@@ -1239,11 +1239,15 @@ fn bti_partition_identity_mismatch(
     let mut leaf_keys: Vec<Vec<u8>> = Vec::with_capacity(leaves.len());
     for leaf in leaves {
         let raw_key = match &leaf.inline_raw_key {
-            // `RowsOffset` leaf: authoritative inline key. Cross-check that its
-            // recorded Data.db position resolves to the SAME raw key, so a payload
-            // tamper that desyncs the inline key from the position is caught.
-            Some(inline) => {
-                if let Some(by_pos) = pos_to_key.get(&leaf.data_position) {
+            // `RowsOffset` leaf: authoritative inline key. Its recorded Data.db
+            // position MUST resolve to a decoded partition start carrying the SAME
+            // raw key. A position that maps to a different key is a desync; a
+            // position that maps to NOTHING means the `Rows.db` entry's
+            // `data_position` is corrupt — a BTI read would seek to a non-partition
+            // offset in Data.db even though the inline key looks valid, so it is
+            // just as fatal as a corrupt `DataOffset` payload.
+            Some(inline) => match pos_to_key.get(&leaf.data_position) {
+                Some(by_pos) => {
                     if by_pos.as_slice() != inline.as_slice() {
                         return Some(format!(
                             "Partitions.db leaf (prefix {}) inline raw key {} disagrees with the key at its Data.db position {} ({}) — the leaf payload was tampered",
@@ -1253,9 +1257,17 @@ fn bti_partition_identity_mismatch(
                             hex(by_pos),
                         ));
                     }
+                    inline.clone()
                 }
-                inline.clone()
-            }
+                None => {
+                    return Some(format!(
+                        "Partitions.db leaf (prefix {}) inline raw key {} records Data.db position {} which is not a decoded partition start — the Rows.db entry's data position is corrupt (a BTI read would seek to the wrong partition)",
+                        hex(&leaf.prefix),
+                        hex(inline),
+                        leaf.data_position,
+                    ));
+                }
+            },
             // `DataOffset` leaf: resolve via the Data.db position map. A payload
             // flipped to a position that is not a partition start matches nothing.
             None => match pos_to_key.get(&leaf.data_position) {
@@ -1575,23 +1587,40 @@ mod tests {
     }
 
     #[test]
-    fn identity_check_detects_same_count_wrong_keys() {
-        // Data has partitions {1,2,3} but the leaves resolve to {4,5,6}: same
-        // count, disjoint identities. MUST be flagged (the core of issue #1103).
+    fn identity_check_detects_same_count_wrong_keys_via_multiset() {
+        // Same leaf count as Data.db and every leaf is individually well-formed
+        // (valid key, valid in-map position, consistent prefix) — but the trie
+        // resolves the SAME partition three times instead of {1,2,3}. Only the
+        // multiset comparison catches this; it is the core of issue #1103.
         let data_keys: Vec<Vec<u8>> = (1u32..=3).map(|i| i.to_be_bytes().to_vec()).collect();
         let data = data_partitions(&data_keys);
-        let leaf_keys: Vec<Vec<u8>> = (4u32..=6).map(|i| i.to_be_bytes().to_vec()).collect();
-        // Inline leaves whose prefix matches their (wrong) key, with positions that
-        // are NOT in the Data.db map (so the inline/position cross-check is inert).
-        let leaves: Vec<BtiResolvedLeaf> = leaf_keys
-            .iter()
-            .enumerate()
-            .map(|(i, k)| inline_leaf(k, 10_000 + i as u64))
-            .collect();
+        // Three leaves all resolving to partition 1 (key + position from data[0]).
+        let leaves: Vec<BtiResolvedLeaf> =
+            (0..3).map(|_| inline_leaf(&data[0].1, data[0].0)).collect();
+        let detail = bti_partition_identity_mismatch(&leaves, &data)
+            .expect("same-count wrong-identity must be flagged");
         assert!(
-            bti_partition_identity_mismatch(&leaves, &data).is_some(),
-            "same-count wrong-key leaves must be detected as a mismatch"
+            detail.contains("identities") || detail.contains("time(s)"),
+            "expected a multiset-identity mismatch, got: {detail}"
         );
+    }
+
+    #[test]
+    fn identity_check_detects_inline_leaf_with_corrupt_data_position() {
+        // Reviewer (roborev #1431): a `RowsOffset` leaf whose INLINE key is valid
+        // and present in Data.db but whose recorded Data.db position points at a
+        // non-partition offset must be flagged — a BTI read would seek to the wrong
+        // partition even though the inline key looks fine.
+        let keys: Vec<Vec<u8>> = (1u32..=3).map(|i| i.to_be_bytes().to_vec()).collect();
+        let data = data_partitions(&keys);
+        let mut leaves: Vec<BtiResolvedLeaf> =
+            data.iter().map(|(pos, k)| inline_leaf(k, *pos)).collect();
+        // Keep the valid inline key; corrupt only the recorded Data.db position.
+        leaves[0].data_position = 9999; // not any partition start
+        let detail = bti_partition_identity_mismatch(&leaves, &data).expect(
+            "an inline leaf with a valid key but a non-partition data position must be flagged",
+        );
+        assert!(detail.contains("not a decoded partition start"));
     }
 
     #[test]

--- a/cqlite-core/src/storage/sstable/verify.rs
+++ b/cqlite-core/src/storage/sstable/verify.rs
@@ -296,7 +296,7 @@ pub async fn verify_sstable(
     // walking Partitions.db; it is cross-checked against the Data.db scan in
     // FULL mode to catch a footer-flip that silently UNDER-counts partitions
     // (the trie still parses, just from the wrong root, yielding fewer keys).
-    let mut bti_partition_keys: Option<usize> = None;
+    let mut bti_partition_keys: Option<Vec<Vec<u8>>> = None;
     match components.format {
         SsTableFormat::Bti => {
             bti_partition_keys = check_bti_structure(dir, &components, &mut findings)?
@@ -341,23 +341,25 @@ pub async fn verify_sstable(
             // scan to exercise the decompression stitch path and surface Data.db
             // corruption that only manifests during decode.
             match full_row_scan_partitions(&components.data_path, config, platform).await {
-                Ok((rows, scan_partitions)) => {
+                Ok((rows, scan_partition_keys)) => {
                     rows_scanned = Some(rows);
-                    // BTI cross-check: the partition count recovered by walking
-                    // Partitions.db MUST match the distinct partitions decoded from
-                    // Data.db. A mismatch means the trie was traversed from a
-                    // corrupt root (footer flip) even though it parsed without
-                    // erroring — a silent under-count we must surface.
+                    // BTI cross-check: the partition KEY SET recovered by walking
+                    // Partitions.db MUST match the partition keys decoded from
+                    // Data.db — by IDENTITY, not just count (issue #1103). A
+                    // count-only check passes a corruption that walks a wrong
+                    // subtree yielding a different set of keys with the same leaf
+                    // count. We compare identities by re-deriving each Data.db raw
+                    // key's byte-comparable trie key and matching it against the
+                    // path-compressed trie keys.
                     if let Some(trie_keys) = bti_partition_keys {
-                        if trie_keys != scan_partitions {
+                        if let Some(detail) =
+                            bti_partition_key_identity_mismatch(&trie_keys, &scan_partition_keys)
+                        {
                             findings.push(VerifyFinding::new(
-                            VerifyErrorClass::BtiRootPointerCorrupt,
-                            "Partitions.db",
-                            format!(
-                                "Partitions.db trie yielded {} partition keys but Data.db decoded {} distinct partitions — the trie was walked from a corrupt root",
-                                trie_keys, scan_partitions
-                            ),
-                        ));
+                                VerifyErrorClass::BtiRootPointerCorrupt,
+                                "Partitions.db",
+                                detail,
+                            ));
                         }
                     }
                 }
@@ -709,7 +711,7 @@ fn check_bti_structure(
     dir: &Path,
     components: &ComponentSet,
     findings: &mut Vec<VerifyFinding>,
-) -> Result<Option<usize>> {
+) -> Result<Option<Vec<Vec<u8>>>> {
     use crate::storage::sstable::bti::parser::{
         iterate_partitions_in_bti_file, iterate_rows_for_partition, BtiPartitionLocation,
     };
@@ -783,8 +785,8 @@ fn check_bti_structure(
                 "Rows.db",
                 format!("cannot read Rows.db: {}", e),
             ));
-            // We can still report the partition count.
-            return Ok(Some(partitions.len()));
+            // We can still report the recovered trie partition keys.
+            return Ok(Some(partitions.into_iter().map(|(k, _)| k).collect()));
         }
     };
 
@@ -817,7 +819,10 @@ fn check_bti_structure(
         }
     }
 
-    Ok(Some(partitions.len()))
+    // Return the byte-comparable trie partition keys (path-compressed prefixes)
+    // recovered by walking Partitions.db. FULL-mode verification cross-checks
+    // these against the keys decoded from Data.db (issue #1103).
+    Ok(Some(partitions.into_iter().map(|(k, _)| k).collect()))
 }
 
 /// Check 4 (BIG): structurally validate `Index.db`.
@@ -1067,7 +1072,7 @@ async fn full_row_scan_partitions(
     data_path: &Path,
     config: &Config,
     platform: Arc<Platform>,
-) -> Result<(usize, usize)> {
+) -> Result<(usize, Vec<Vec<u8>>)> {
     let reader = SSTableReader::open(data_path, config, platform).await?;
 
     // `rows` is the total decoded row/entry count (exercises the full
@@ -1075,15 +1080,83 @@ async fn full_row_scan_partitions(
     let entries = reader.get_all_entries().await?;
     let rows = entries.len();
 
-    // `distinct_partitions` is the true count of distinct PARTITION keys decoded
+    // `distinct_partition_keys` are the raw serialized PARTITION keys decoded
     // from Data.db — one per partition, NOT per row. Deduping `get_all_entries`
     // RowKeys would over-count a multi-row partition (those keys carry
     // clustering/column/static suffixes), which previously FALSE-FAILED the BTI
     // Partitions.db cross-check on healthy SSTables (issue #970). The reader
-    // counts at the partition boundary for both BIG (`nb`) and BTI (`da`).
-    let distinct_partitions = reader.distinct_partition_count().await?;
+    // dedups at the partition boundary for both BIG (`nb`) and BTI (`da`).
+    let partition_keys = reader.distinct_partition_keys().await?;
 
-    Ok((rows, distinct_partitions))
+    Ok((rows, partition_keys))
+}
+
+/// Cross-check BTI `Partitions.db` trie keys against the partition keys decoded
+/// from `Data.db` by IDENTITY (issue #1103). Returns `Some(detail)` describing
+/// the mismatch when the trie does not represent the same partition set as
+/// Data.db, or `None` when they agree.
+///
+/// The two sides use different on-disk encodings and are not directly
+/// comparable: a BTI trie key is the path-compressed (shortest-distinguishing)
+/// prefix of the byte-comparable `[0x40 ++ 8-byte murmur3 token]` key, while a
+/// Data.db key is the raw serialized partition key. We bridge them by re-deriving
+/// each Data.db raw key's byte-comparable trie key
+/// (`encode_partition_key_for_bti_trie`) and matching it against the trie keys by
+/// prefix. A healthy table is a total bijection; a wrong-root corruption that
+/// preserves leaf count but changes keys leaves a trie key that prefixes no
+/// Data.db key (and a Data.db key matched by none), which we surface.
+///
+/// Note: the byte-comparable encoding assumes `Murmur3Partitioner`, matching the
+/// rest of CQLite's BTI read path (issue #755).
+fn bti_partition_key_identity_mismatch(
+    trie_keys: &[Vec<u8>],
+    data_keys: &[Vec<u8>],
+) -> Option<String> {
+    use crate::storage::sstable::bti::parser::encode_partition_key_for_bti_trie;
+
+    let encoded: Vec<[u8; 9]> = data_keys
+        .iter()
+        .map(|k| encode_partition_key_for_bti_trie(k))
+        .collect();
+
+    if trie_keys.len() != encoded.len() {
+        return Some(format!(
+            "Partitions.db trie yielded {} partition keys but Data.db decoded {} distinct partitions — the trie was walked from a corrupt root",
+            trie_keys.len(),
+            encoded.len()
+        ));
+    }
+
+    let hex = |b: &[u8]| b.iter().map(|x| format!("{:02x}", x)).collect::<String>();
+
+    // Greedily match each trie key to exactly one (still-unclaimed) Data.db key
+    // by prefix. Equal lengths + a one-to-one matching ⇒ identical partition sets.
+    let mut claimed = vec![false; encoded.len()];
+    for tk in trie_keys {
+        let matched: Vec<usize> = encoded
+            .iter()
+            .enumerate()
+            .filter(|(i, enc)| !claimed[*i] && enc.starts_with(tk.as_slice()))
+            .map(|(i, _)| i)
+            .collect();
+        match matched.as_slice() {
+            [idx] => claimed[*idx] = true,
+            [] => {
+                return Some(format!(
+                    "Partitions.db trie key {} matches no Data.db partition key — the trie was walked from a corrupt root (same leaf count, different keys)",
+                    hex(tk)
+                ));
+            }
+            _ => {
+                return Some(format!(
+                    "Partitions.db trie key {} is an ambiguous prefix of multiple Data.db partition keys — the trie does not match Data.db identities",
+                    hex(tk)
+                ));
+            }
+        }
+    }
+
+    None
 }
 
 /// Map an error surfaced by the inline-CRC / decompression path onto a stable
@@ -1201,5 +1274,81 @@ mod tests {
         assert_eq!(fail.primary_class(), Some(VerifyErrorClass::DigestMismatch));
         assert!(fail.summary_line().contains("VERIFY FAIL"));
         assert!(fail.summary_line().contains("DigestMismatch"));
+    }
+
+    // ---- BTI partition-key identity cross-check (issue #1103) --------------
+
+    use crate::storage::sstable::bti::parser::encode_partition_key_for_bti_trie;
+
+    /// Build the path-compressed trie key for a raw partition key: the
+    /// byte-comparable `[0x40 ++ token]` key truncated to its first `prefix_len`
+    /// bytes, mirroring how a real Patricia trie stores only the shortest
+    /// distinguishing prefix.
+    fn trie_key_prefix(raw: &[u8], prefix_len: usize) -> Vec<u8> {
+        encode_partition_key_for_bti_trie(raw)[..prefix_len].to_vec()
+    }
+
+    #[test]
+    fn identity_check_passes_for_matching_full_keys() {
+        // Trie keys == full 9-byte encoded keys (a key is a prefix of itself).
+        let data: Vec<Vec<u8>> = (1u32..=3).map(|i| i.to_be_bytes().to_vec()).collect();
+        let trie: Vec<Vec<u8>> = data
+            .iter()
+            .map(|k| encode_partition_key_for_bti_trie(k).to_vec())
+            .collect();
+        assert_eq!(bti_partition_key_identity_mismatch(&trie, &data), None);
+    }
+
+    #[test]
+    fn identity_check_passes_for_path_compressed_prefixes() {
+        // Healthy table: trie stores only the first 2 bytes (`0x40` + 1 token
+        // byte), which is what `test_da/wide_table` actually does.
+        let data: Vec<Vec<u8>> = (1u32..=3).map(|i| i.to_be_bytes().to_vec()).collect();
+        let trie: Vec<Vec<u8>> = data.iter().map(|k| trie_key_prefix(k, 2)).collect();
+        // Precondition: the 2-byte prefixes are distinct (true for pk=1,2,3).
+        let mut sorted = trie.clone();
+        sorted.sort();
+        sorted.dedup();
+        assert_eq!(sorted.len(), trie.len(), "test prefixes must be distinct");
+        assert_eq!(bti_partition_key_identity_mismatch(&trie, &data), None);
+    }
+
+    #[test]
+    fn identity_check_detects_same_count_wrong_keys() {
+        // Data has partitions {1,2,3} but the trie was walked to {4,5,6}: same
+        // count, disjoint identities. MUST be flagged (the core of issue #1103).
+        let data: Vec<Vec<u8>> = (1u32..=3).map(|i| i.to_be_bytes().to_vec()).collect();
+        let trie: Vec<Vec<u8>> = (4u32..=6)
+            .map(|i| trie_key_prefix(&i.to_be_bytes(), 2))
+            .collect();
+        let mismatch = bti_partition_key_identity_mismatch(&trie, &data);
+        assert!(
+            mismatch.is_some(),
+            "same-count wrong-key trie must be detected as a mismatch"
+        );
+    }
+
+    #[test]
+    fn identity_check_detects_one_swapped_key() {
+        // Two keys match, one is wrong — the minimal wrong-root that a count check
+        // cannot see.
+        let data: Vec<Vec<u8>> = (1u32..=3).map(|i| i.to_be_bytes().to_vec()).collect();
+        let mut trie: Vec<Vec<u8>> = data.iter().map(|k| trie_key_prefix(k, 2)).collect();
+        trie[0] = trie_key_prefix(&99u32.to_be_bytes(), 2);
+        assert!(bti_partition_key_identity_mismatch(&trie, &data).is_some());
+    }
+
+    #[test]
+    fn identity_check_detects_count_mismatch() {
+        let data: Vec<Vec<u8>> = (1u32..=3).map(|i| i.to_be_bytes().to_vec()).collect();
+        let trie: Vec<Vec<u8>> = data
+            .iter()
+            .take(2)
+            .map(|k| encode_partition_key_for_bti_trie(k).to_vec())
+            .collect();
+        let detail =
+            bti_partition_key_identity_mismatch(&trie, &data).expect("undercount must be flagged");
+        assert!(detail.contains("2 partition keys"));
+        assert!(detail.contains("3 distinct partitions"));
     }
 }

--- a/cqlite-core/tests/issue_1103_bti_identity.rs
+++ b/cqlite-core/tests/issue_1103_bti_identity.rs
@@ -1,0 +1,176 @@
+//! Issue #1103: the FULL-mode BTI verifier must cross-check `Partitions.db`
+//! against `Data.db` by partition-key IDENTITY, not just partition COUNT.
+//!
+//! A corrupt `Partitions.db` root that walks a wrong subtree yielding a
+//! DIFFERENT set of partition keys with the SAME leaf count previously passed
+//! verification (the count matched even though the identities did not). These
+//! tests assert:
+//!
+//! 1. A HEALTHY BTI table (`test_da/wide_table`) PASSES FULL verification — i.e.
+//!    no false-positive from the identity compare (the original blocker: the BTI
+//!    trie key encoding and the Data.db key encoding are byte-disjoint and must
+//!    be normalized before comparing).
+//! 2. A same-count wrong-root corruption (a flipped trie transition byte that
+//!    keeps 3 leaves but changes a key) FAILS with `BtiRootPointerCorrupt`.
+//!
+//! Skip-clean when the dataset is absent (worktrees without fetched Data.db);
+//! fail-loud when the dataset is present.
+
+use cqlite_core::platform::Platform;
+use cqlite_core::storage::sstable::verify::{
+    verify_sstable, VerifyErrorClass, VerifyMode, VerifyReport,
+};
+use cqlite_core::Config;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+fn datasets_root() -> Option<PathBuf> {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)
+}
+
+/// Locate the `test_da/wide_table-*` BTI generation directory, if present.
+fn wide_table_dir() -> Option<PathBuf> {
+    let base = datasets_root()?.join("sstables/test_da");
+    let rd = std::fs::read_dir(&base).ok()?;
+    rd.flatten().map(|e| e.path()).find(|p| {
+        p.is_dir()
+            && p.file_name()
+                .and_then(|n| n.to_str())
+                .map(|n| n.starts_with("wide_table-"))
+                .unwrap_or(false)
+    })
+}
+
+fn has_data_db(dir: &Path) -> bool {
+    std::fs::read_dir(dir)
+        .map(|rd| {
+            rd.flatten().any(|e| {
+                e.file_name()
+                    .to_str()
+                    .map(|n| n.ends_with("-Data.db"))
+                    .unwrap_or(false)
+            })
+        })
+        .unwrap_or(false)
+}
+
+async fn verify(dir: &Path, mode: VerifyMode) -> VerifyReport {
+    let config = Config::default();
+    let platform = Arc::new(
+        Platform::new(&config)
+            .await
+            .expect("Platform::new must succeed"),
+    );
+    verify_sstable(dir, mode, &config, platform)
+        .await
+        .unwrap_or_else(|e| panic!("verify_sstable({}) returned Err: {e}", dir.display()))
+}
+
+/// (1) The healthy BTI table passes FULL verification — no false-positive from
+/// the identity cross-check, and a non-zero row count (a present-but-empty scan
+/// would be a silent-corruption regression).
+#[tokio::test]
+async fn healthy_wide_table_bti_passes_full_verification() {
+    let Some(dir) = wide_table_dir() else {
+        eprintln!("[SKIP] test_da/wide_table not present (set CQLITE_DATASETS_ROOT)");
+        return;
+    };
+    if !has_data_db(&dir) {
+        eprintln!(
+            "[SKIP] {} has no Data.db (binaries not fetched)",
+            dir.display()
+        );
+        return;
+    }
+
+    let report = verify(&dir, VerifyMode::Full).await;
+    assert!(
+        report.is_ok(),
+        "healthy BTI wide_table must PASS full verification (no identity false-positive), got: {:?}",
+        report.findings
+    );
+    assert!(
+        matches!(report.rows_scanned, Some(n) if n > 0),
+        "healthy BTI wide_table FULL verify must scan a non-zero row count, got {:?}",
+        report.rows_scanned
+    );
+}
+
+/// (2) A same-count wrong-root corruption is detected. We copy the healthy
+/// fixture to a temp dir and flip a single Sparse-node transition byte in
+/// `Partitions.db` (`0x47` -> `0x46` at offset 0x0E). The trie still yields 3
+/// leaves, but one partition key changes, so it no longer matches the Data.db
+/// key set. A count-only check would still pass (3 == 3); the identity check
+/// must fail with `BtiRootPointerCorrupt` on `Partitions.db`.
+#[tokio::test]
+async fn same_count_wrong_root_bti_is_detected() {
+    let Some(src) = wide_table_dir() else {
+        eprintln!("[SKIP] test_da/wide_table not present (set CQLITE_DATASETS_ROOT)");
+        return;
+    };
+    if !has_data_db(&src) {
+        eprintln!(
+            "[SKIP] {} has no Data.db (binaries not fetched)",
+            src.display()
+        );
+        return;
+    }
+
+    // Materialize a mutable copy in a temp dir.
+    let tmp = std::env::temp_dir().join(format!("cqlite-1103-wrongroot-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&tmp);
+    std::fs::create_dir_all(&tmp).expect("create temp dir");
+    let mut partitions_path = None;
+    for entry in std::fs::read_dir(&src).expect("read src dir").flatten() {
+        let p = entry.path();
+        if !p.is_file() {
+            continue;
+        }
+        let name = p.file_name().unwrap().to_owned();
+        let dst = tmp.join(&name);
+        std::fs::copy(&p, &dst).expect("copy fixture file");
+        if name
+            .to_str()
+            .map(|n| n.ends_with("-Partitions.db"))
+            .unwrap_or(false)
+        {
+            partitions_path = Some(dst);
+        }
+    }
+    let partitions_path = partitions_path.expect("fixture must have a Partitions.db");
+
+    // Flip the first Sparse-node transition byte: 0x47 -> 0x46 at offset 0x0E.
+    // This keeps 3 leaves (same count) but changes the recovered partition key.
+    let mut bytes = std::fs::read(&partitions_path).expect("read Partitions.db");
+    const TRANSITION_OFFSET: usize = 0x0E;
+    assert!(
+        bytes.len() > TRANSITION_OFFSET,
+        "Partitions.db unexpectedly short ({} bytes)",
+        bytes.len()
+    );
+    assert_eq!(
+        bytes[TRANSITION_OFFSET], 0x47,
+        "fixture layout changed: expected transition byte 0x47 at offset 0x0E, found 0x{:02x}",
+        bytes[TRANSITION_OFFSET]
+    );
+    bytes[TRANSITION_OFFSET] = 0x46;
+    std::fs::write(&partitions_path, &bytes).expect("write corrupted Partitions.db");
+
+    let report = verify(&tmp, VerifyMode::Full).await;
+    let _ = std::fs::remove_dir_all(&tmp);
+
+    assert!(
+        !report.is_ok(),
+        "same-count wrong-root BTI corruption MUST fail verification, but passed (rows={:?})",
+        report.rows_scanned
+    );
+    assert!(
+        report.findings.iter().any(|f| {
+            f.class == VerifyErrorClass::BtiRootPointerCorrupt && f.component == "Partitions.db"
+        }),
+        "expected a BtiRootPointerCorrupt finding on Partitions.db, got: {:?}",
+        report.findings
+    );
+}

--- a/cqlite-core/tests/issue_1103_bti_identity.rs
+++ b/cqlite-core/tests/issue_1103_bti_identity.rs
@@ -174,3 +174,50 @@ async fn same_count_wrong_root_bti_is_detected() {
         report.findings
     );
 }
+
+/// (3) Every healthy `test_da/*` BTI table passes FULL verification — this
+/// exercises BOTH leaf-payload kinds against real fixtures with no false
+/// positive: the small-partition tables (`simple_table`, `collection_table`,
+/// `ttl_table`) use `DataOffset` leaves (resolved via the Data.db
+/// position→key map), while `wide_table` uses `RowsOffset` leaves (resolved via
+/// the inline Rows.db key). A DataOffset-position misalignment would surface
+/// here as a spurious BtiRootPointerCorrupt.
+#[tokio::test]
+async fn all_healthy_test_da_bti_tables_pass_full_verification() {
+    let Some(base) = datasets_root().map(|r| r.join("sstables/test_da")) else {
+        eprintln!("[SKIP] CQLITE_DATASETS_ROOT not set");
+        return;
+    };
+    let Ok(rd) = std::fs::read_dir(&base) else {
+        eprintln!("[SKIP] {} not present", base.display());
+        return;
+    };
+
+    let mut checked = 0;
+    for entry in rd.flatten() {
+        let dir = entry.path();
+        if !dir.is_dir() || !has_data_db(&dir) {
+            continue;
+        }
+        let report = verify(&dir, VerifyMode::Full).await;
+        assert!(
+            report.is_ok(),
+            "healthy BTI table {} must PASS full verification (no identity false-positive), got: {:?}",
+            dir.display(),
+            report.findings
+        );
+        assert!(
+            matches!(report.rows_scanned, Some(n) if n > 0),
+            "healthy BTI table {} FULL verify must scan a non-zero row count, got {:?}",
+            dir.display(),
+            report.rows_scanned
+        );
+        checked += 1;
+    }
+
+    if checked == 0 {
+        eprintln!("[SKIP] no materialized test_da BTI tables (Data.db absent)");
+    } else {
+        eprintln!("verified {checked} healthy test_da BTI tables (FULL)");
+    }
+}


### PR DESCRIPTION
Closes #1103.

## Problem
The FULL-mode BTI verifier cross-checked `Partitions.db` against `Data.db` by comparing the **number** of partitions only. A corrupt `Partitions.db` root that walks a wrong subtree yielding a different set of partition keys with the **same leaf count** passed verification — a gap in the "no silent corruption" guarantee for BTI tables. Identity comparison was deferred during Epic #970 because the BTI trie key encoding and the Data.db-decoded key encoding are byte-disjoint, so a naive set compare false-positived on every healthy BTI table.

## Fix
Compare partition-key **identity** by resolving each `Partitions.db` leaf payload back to its raw Data.db partition key and matching by identity:

- **RowsOffset leaf** — extract the raw key stored inline in `Rows.db` (`[u16 len][key]`) and recover its Data.db position via `resolve_rows_db_entry`. Cross-check the inline key against the key at that position (catches a payload desync), and require the position to be a real decoded partition start (catches a corrupt `Rows.db` data_position that would seek a BTI read to the wrong partition).
- **DataOffset leaf** — resolve the raw key via a new Data.db `position → key` map (`distinct_partition_keys_with_positions`, backed by a new `parse_block_for_compaction_emit_with_offset` that tags each row with its partition-start offset).
- **Per-leaf** — the resolved key's byte-comparable encoding must start with the leaf's emitted trie prefix (path/payload consistency).
- Require exact **multiset equality** between the resolved leaf keys and the Data.db keys.

## Tests
- 13 unit tests over the matcher (`bti_partition_identity_mismatch`): healthy inline/DataOffset leaves pass; same-count wrong-key, swapped-key, count-mismatch, wrong-payload (inline + DataOffset), corrupt-position, and non-partition-position cases all fail.
- Integration (`tests/issue_1103_bti_identity.rs`): all 4 real `test_da` BTI tables (3 DataOffset + 1 RowsOffset wide_table) PASS FULL verification (no false-positive); a same-count wrong-root corruption FAILS with `BtiRootPointerCorrupt`. Existing `issue_1000_verifier` BTI corruption fixtures still fail.

## Validation
- `scripts/agent-gate.sh`: fmt/clippy/tombstones-scan/integration/format-compat/write/cli/python/minimal-build/smoke all PASS. The sole `core-tests` red is the pre-existing flaky `test_flush_throughput` (machine-load throughput assertion, 4.2 vs 5 MB/sec) — passes on isolated re-run; unrelated to this read/verify change.
- roborev branch review (job 1437): **No issues found** (3 prior rounds each surfaced a real escalating gap — Medium payload-ignore, High unmapped-position, Medium map_entry — all fixed).