### PR TITLE
docs(ci): #1099-A dataset republish runbook + pin-bump finalizer

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -66,7 +66,7 @@ jobs:
           validation_artifacts/sstabledump/
         key: datasets-v3-f5fa0b6599a27c1c493d7c6c063194d55d031cab417396947313e7245afc5ceb-${{ hashFiles('test-data/**/*.md') }}
         restore-keys: |
-          datasets-v3-
+          datasets-v3-f5fa0b6599a27c1c493d7c6c063194d55d031cab417396947313e7245afc5ceb-
 
     - name: Download Cassandra 5 Datasets (if cache miss)
       run: |

--- a/.github/workflows/m1-ci.yml
+++ b/.github/workflows/m1-ci.yml
@@ -59,7 +59,7 @@ jobs:
           test-data/datasets/
         key: datasets-v3-f5fa0b6599a27c1c493d7c6c063194d55d031cab417396947313e7245afc5ceb-${{ hashFiles('test-data/**/*.md') }}
         restore-keys: |
-          datasets-v3-
+          datasets-v3-f5fa0b6599a27c1c493d7c6c063194d55d031cab417396947313e7245afc5ceb-
 
     - name: Download Cassandra 5 Datasets (if cache miss)
       run: |
@@ -281,7 +281,7 @@ jobs:
           test-data/datasets/
         key: datasets-v3-f5fa0b6599a27c1c493d7c6c063194d55d031cab417396947313e7245afc5ceb-${{ hashFiles('test-data/**/*.md') }}
         restore-keys: |
-          datasets-v3-
+          datasets-v3-f5fa0b6599a27c1c493d7c6c063194d55d031cab417396947313e7245afc5ceb-
 
     - name: Download Cassandra 5 Datasets (if cache miss)
       run: |

--- a/docs/runbooks/1099-dataset-republish.md
+++ b/docs/runbooks/1099-dataset-republish.md
@@ -96,7 +96,8 @@ git switch -c chore/1099-bump-dataset-pin-v3.2
 test-data/scripts/bump-dataset-pin.sh --new-sha <sha256-from-step-2>
 # (add --new-tag <tag> if you cut a new release tag)
 
-git add .github/workflows
+# Stage everything the finalizer touched (workflows AND the fetch helper):
+git add .github/workflows test-data/scripts/fetch-datasets.sh
 git commit -m "ci: pin dataset asset to cassandra5-small-full-v3.2 (#1099)"
 git push -u origin chore/1099-bump-dataset-pin-v3.2
 gh pr create --base main --fill
@@ -105,6 +106,12 @@ gh pr create --base main --fill
 The 10 pinned workflows: `ci.yml`, `coverage.yml`, `docs-site.yml`,
 `m1-ci.yml`, `node-ci.yml`, `observability-gate.yml`, `perf-regression.yml`,
 `python-ci.yml`, `smoke-tests.yml`, `sstabledump-parity-gate.yml`.
+
+> **Cache note:** `coverage.yml`/`m1-ci.yml` restore the dataset cache and skip
+> the download when `test_basic/simple_table-*-Data.db` is already present.
+> Their dataset cache `restore-keys` are **SHA-scoped** (`datasets-v3-<sha>-`),
+> so a SHA bump can never warm-restore an older dataset version and silently
+> skip the re-download — the finalizer rewrites that SHA along with the rest.
 
 ## 5. Verify
 

--- a/docs/runbooks/1099-dataset-republish.md
+++ b/docs/runbooks/1099-dataset-republish.md
@@ -1,0 +1,110 @@
+# Runbook — #1099 Path A: republish `cassandra5-small-full` with Epic #970 fixtures
+
+**Goal:** the pinned CI dataset asset (`cassandra5-small-full-v3.1.tar.gz`, tag
+`datasets-v3`) predates Epic #970 (PR #1091), so it lacks the `test_comp` and
+`corruption/test_comp_corrupt` binaries that `issue_1000_verifier.rs` requires.
+Strict/nightly lanes (and any future lane that sets `CQLITE_REQUIRE_FIXTURES=1`)
+therefore can't exercise compression/corruption parity. This runbook regenerates
+the corpus **with** those fixtures, publishes a `v3.2` asset, and repoints CI.
+
+> The PR-lane `test` failure was already mitigated separately (#1094 skip-on-
+> presence). This is the durable fix so the fixtures are actually present.
+
+**Prerequisites:** Docker (or Podman) with `cassandra:5.0.2` pullable, ~10 GB
+free disk, ~4 GB RAM for the container, and `gh` authenticated as a user with
+release-upload rights to `pmcfadin/cqlite`. Run from a clean checkout of `main`.
+
+---
+
+## 1. Generate the Epic #970 fixtures (Docker / Cassandra 5.0.2)
+
+These are the same steps the strict nightly workflow
+(`.github/workflows/compression-corruption-parity.yml`) runs. They write into
+`test-data/datasets`. Run from the repo root:
+
+```bash
+export CQLITE_DATASETS_ROOT="$PWD/test-data/datasets"
+
+# Start from the current canonical corpus so nb/oa/da keyspaces are present.
+# (The Epic #970 fixtures are added alongside them in disjoint keyspaces.)
+bash test-data/scripts/fetch-datasets.sh        # restores v3.1 nb/oa/da binaries
+
+# test_comp keyspace (compression scenarios) — deterministic, re-runnable.
+bash test-data/scripts/generate-compression-parity.sh
+
+# BTI source (test_da/wide_table) needed by the BTI corruption cases.
+OUT="$CQLITE_DATASETS_ROOT" bash test-data/scripts/gen-wide-bti.sh
+
+# Corruption corpus (corruption/test_comp_corrupt) + regenerated manifest.
+bash test-data/scripts/generate-corruption-corpus.sh
+```
+
+Verify the fixtures materialized (mirror of the workflow's strict assert):
+
+```bash
+find "$CQLITE_DATASETS_ROOT/sstables/test_comp" -name '*-Data.db' | wc -l        # expect >= 7
+find "$CQLITE_DATASETS_ROOT/corruption/test_comp_corrupt" -mindepth 1 -maxdepth 1 -type d | sort
+```
+
+Confirm they pass verification locally (strict mode — fail instead of skip):
+
+```bash
+env CQLITE_REQUIRE_FIXTURES=1 CQLITE_DATASETS_ROOT="$CQLITE_DATASETS_ROOT" \
+  cargo test -p cqlite-core --features write-support,cli-helpers \
+  --test issue_1000_verifier
+```
+
+## 2. Package the full corpus as the v3.2 asset
+
+`package_datasets.sh` tars `test-data/datasets`, validates it contains `.db`
+binaries, and writes `<archive>.sha256`:
+
+```bash
+ASSET=cassandra5-small-full-v3.2.tar.gz
+ASSET_NAME="$ASSET" test-data/scripts/package_datasets.sh \
+  --type full --asset-name "$ASSET" --tag datasets-v3
+
+# Archive + checksum land at the repo parent dir:
+cat "../$ASSET.sha256"          # <-- copy this 64-char SHA256 for step 4
+```
+
+## 3. Publish to the GitHub release
+
+Upload the new versioned asset to the **existing** `datasets-v3` release (it can
+hold multiple assets; keeping the tag avoids cache-key churn). `--clobber`
+replaces an asset of the same name if you re-run:
+
+```bash
+gh release upload datasets-v3 "../$ASSET" "../$ASSET.sha256" --clobber
+```
+
+> If you prefer a brand-new release tag instead, create it and pass `--new-tag`
+> in step 4.
+
+## 4. Repoint CI at the new asset (10 workflows)
+
+Use the finalizer — it replaces the asset filename + SHA256 across every
+workflow and verifies no stale reference remains:
+
+```bash
+git switch -c chore/1099-bump-dataset-pin-v3.2
+test-data/scripts/bump-dataset-pin.sh --new-sha <sha256-from-step-2>
+# (add --new-tag <tag> if you cut a new release tag)
+
+git add .github/workflows
+git commit -m "ci: pin dataset asset to cassandra5-small-full-v3.2 (#1099)"
+git push -u origin chore/1099-bump-dataset-pin-v3.2
+gh pr create --base main --fill
+```
+
+The 10 pinned workflows: `ci.yml`, `coverage.yml`, `docs-site.yml`,
+`m1-ci.yml`, `node-ci.yml`, `observability-gate.yml`, `perf-regression.yml`,
+`python-ci.yml`, `smoke-tests.yml`, `sstabledump-parity-gate.yml`.
+
+## 5. Verify
+
+Once the pin-bump PR's CI is green (the cache busts automatically because the
+key includes the SHA), the `test` lane runs the verifier against the real
+`test_comp`/corruption binaries instead of skipping. Optionally trigger the
+strict nightly manually (`compression-corruption-parity.yml` → workflow_dispatch)
+to confirm `CQLITE_REQUIRE_FIXTURES=1` passes end to end. Then close #1099.

--- a/docs/runbooks/1099-dataset-republish.md
+++ b/docs/runbooks/1099-dataset-republish.md
@@ -84,7 +84,12 @@ gh release upload datasets-v3 "../$ASSET" "../$ASSET.sha256" --clobber
 ## 4. Repoint CI at the new asset (10 workflows)
 
 Use the finalizer — it replaces the asset filename + SHA256 across every
-workflow and verifies no stale reference remains:
+pinned workflow **and** `test-data/scripts/fetch-datasets.sh` (which carries its
+own `DATASET_ASSET`/`DATASET_SHA256`/`DATASET_TAG` defaults), then verifies no
+stale reference remains. With `--new-tag` it also rewrites the inline
+`gh release download <tag>` / `releases/download/<tag>/` literals (coverage.yml,
+m1-ci.yml). It never edits its own `OLD_*` defaults or this runbook, and prints
+any doc-only references (website docs) for you to update by hand:
 
 ```bash
 git switch -c chore/1099-bump-dataset-pin-v3.2

--- a/test-data/scripts/bump-dataset-pin.sh
+++ b/test-data/scripts/bump-dataset-pin.sh
@@ -69,12 +69,25 @@ if [[ ! -d "$WF_DIR" ]]; then
   exit 2
 fi
 
-echo "Repointing dataset pin in $WF_DIR"
+echo "Repointing dataset pin"
 echo "  asset: $OLD_ASSET -> $NEW_ASSET"
 echo "  sha:   $OLD_SHA -> $NEW_SHA"
 if [[ "$OLD_TAG" != "$NEW_TAG" ]]; then
   echo "  tag:   $OLD_TAG -> $NEW_TAG"
 fi
+
+# Files that CONSUME the pin (CI workflows + the canonical fetch helper, which
+# carries its own DATASET_ASSET/SHA256/TAG defaults). This is an explicit list
+# rather than a repo-wide grep so we never rewrite the OLD_* constants in THIS
+# script or the example pin in the #1099 runbook.
+FETCH_HELPER="$REPO_ROOT/test-data/scripts/fetch-datasets.sh"
+SELF_PATH="$REPO_ROOT/test-data/scripts/bump-dataset-pin.sh"
+
+FILES=()
+for f in "$WF_DIR"/*.yml "$WF_DIR"/*.yaml; do
+  [[ -e "$f" ]] && FILES+=("$f")
+done
+[[ -e "$FETCH_HELPER" ]] && FILES+=("$FETCH_HELPER")
 
 # Portable in-place sed (BSD/macOS vs GNU).
 sed_inplace() {
@@ -82,31 +95,59 @@ sed_inplace() {
 }
 
 changed=0
-for f in "$WF_DIR"/*.yml "$WF_DIR"/*.yaml; do
-  [[ -e "$f" ]] || continue
-  if grep -qF -e "$OLD_ASSET" -e "$OLD_SHA" "$f" \
-     || { [[ "$OLD_TAG" != "$NEW_TAG" ]] && grep -qF "DATASET_TAG: $OLD_TAG" "$f"; }; then
-    sed_inplace "s|$OLD_ASSET|$NEW_ASSET|g; s|$OLD_SHA|$NEW_SHA|g" "$f"
-    if [[ "$OLD_TAG" != "$NEW_TAG" ]]; then
-      sed_inplace "s|DATASET_TAG: $OLD_TAG|DATASET_TAG: $NEW_TAG|g" "$f"
-    fi
-    echo "  ✓ updated $(basename "$f")"
+for f in "${FILES[@]}"; do
+  [[ "$f" == "$SELF_PATH" ]] && continue
+  before=$(cat "$f")
+  sed_inplace "s|$OLD_ASSET|$NEW_ASSET|g; s|$OLD_SHA|$NEW_SHA|g" "$f"
+  if [[ "$OLD_TAG" != "$NEW_TAG" ]]; then
+    # Replace the tag only in its pin-bearing contexts so unrelated mentions
+    # (e.g. cache keys built from ${{ env.DATASET_TAG }}) are untouched:
+    #   - env decl:                DATASET_TAG: <tag>
+    #   - gh release download:     gh release download <tag>
+    #   - release URL path:        releases/download/<tag>/
+    #   - fetch-datasets default:  DATASET_TAG:-<tag>
+    sed_inplace \
+      "s|DATASET_TAG: $OLD_TAG|DATASET_TAG: $NEW_TAG|g; \
+       s|release download $OLD_TAG|release download $NEW_TAG|g; \
+       s|releases/download/$OLD_TAG/|releases/download/$NEW_TAG/|g; \
+       s|DATASET_TAG:-$OLD_TAG|DATASET_TAG:-$NEW_TAG|g" "$f"
+  fi
+  if [[ "$(cat "$f")" != "$before" ]]; then
+    echo "  ✓ updated ${f#"$REPO_ROOT"/}"
     changed=$((changed + 1))
   fi
 done
 
-echo "Updated $changed workflow file(s)."
+echo "Updated $changed file(s)."
 
-# Verify: no stale references to the OLD asset/sha remain anywhere.
-stale=$(grep -rIlF -e "$OLD_ASSET" -e "$OLD_SHA" "$WF_DIR" 2>/dev/null || true)
+# Verify: no stale OLD asset/sha remains in any pin-consuming file.
+stale=$(grep -lF -e "$OLD_ASSET" -e "$OLD_SHA" "${FILES[@]}" 2>/dev/null || true)
 if [[ -n "$stale" ]]; then
   echo "❌ stale OLD pin still present in:" >&2
   echo "$stale" >&2
   exit 1
 fi
+# If the tag changed, no OLD tag may remain in a pin context in those files.
+if [[ "$OLD_TAG" != "$NEW_TAG" ]]; then
+  tag_stale=$(grep -lE "DATASET_TAG: ?-?$OLD_TAG|release download $OLD_TAG|releases/download/$OLD_TAG/" "${FILES[@]}" 2>/dev/null || true)
+  if [[ -n "$tag_stale" ]]; then
+    echo "❌ stale OLD tag ($OLD_TAG) still present in a pin context in:" >&2
+    echo "$tag_stale" >&2
+    exit 1
+  fi
+fi
 
-# Sanity: the NEW asset+sha should now appear in the expected number of files.
-n_asset=$(grep -rIlF "$NEW_ASSET" "$WF_DIR" 2>/dev/null | wc -l | tr -d ' ')
-n_sha=$(grep -rIlF "$NEW_SHA" "$WF_DIR" 2>/dev/null | wc -l | tr -d ' ')
-echo "NEW asset present in $n_asset file(s); NEW sha present in $n_sha file(s)."
-echo "✅ Pin bump complete. Review 'git diff .github/workflows', then open a PR."
+n_asset=$(grep -lF "$NEW_ASSET" "${FILES[@]}" 2>/dev/null | wc -l | tr -d ' ')
+echo "NEW asset present in $n_asset pin-consuming file(s)."
+
+# Advisory: surface any OTHER tracked files that still NAME the old asset/sha
+# (e.g. website docs). These are descriptive, not pin-consuming, so they are NOT
+# auto-edited — update by hand if you want the docs to match the new pin.
+others=$(cd "$REPO_ROOT" && git grep -lF -e "$OLD_ASSET" -e "$OLD_SHA" 2>/dev/null \
+  | grep -vE '^(test-data/scripts/bump-dataset-pin\.sh|docs/runbooks/1099-dataset-republish\.md|\.github/workflows/|test-data/scripts/fetch-datasets\.sh)$' || true)
+if [[ -n "$others" ]]; then
+  echo "ℹ️  doc-only references to the old pin (not auto-edited — review manually):"
+  echo "$others" | sed 's/^/     /'
+fi
+
+echo "✅ Pin bump complete. Review 'git diff', then open a PR."

--- a/test-data/scripts/bump-dataset-pin.sh
+++ b/test-data/scripts/bump-dataset-pin.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# bump-dataset-pin.sh — repoint every CI workflow at a newly-published dataset asset.
+#
+# Issue #1099 follow-up (Path A): after regenerating + publishing a new
+# `cassandra5-small-full` tarball that INCLUDES the Epic #970 `test_comp` +
+# `corruption/test_comp_corrupt` fixtures, run this to update the dataset pin
+# (asset filename + SHA256, and optionally the release tag) across all
+# `.github/workflows/*.yml` in one shot, then verify no stale references remain.
+#
+# The CI workflows reference the pin in two styles — env vars
+# (DATASET_ASSET/DATASET_SHA256) and inline literals (coverage.yml, m1-ci.yml).
+# Both styles embed the exact asset filename and SHA256 string, so a literal
+# string replacement across the workflow dir updates every site safely.
+#
+# Usage:
+#   test-data/scripts/bump-dataset-pin.sh --new-sha <sha256> \
+#     [--new-asset cassandra5-small-full-v3.2.tar.gz] \
+#     [--new-tag datasets-v3] \
+#     [--old-asset cassandra5-small-full-v3.1.tar.gz] \
+#     [--old-sha f5fa0b6599a27c1c493d7c6c063194d55d031cab417396947313e7245afc5ceb] \
+#     [--old-tag datasets-v3]
+#
+# Only --new-sha is required. Defaults below match the current (v3.1) pin and a
+# v3.2 asset uploaded to the SAME release tag (datasets-v3 can hold multiple
+# assets). If you cut a NEW release tag instead, pass --new-tag (and --old-tag
+# if it differs).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WF_DIR="$REPO_ROOT/.github/workflows"
+
+# Current (to-be-replaced) pin — keep in sync with the committed workflows.
+OLD_ASSET="cassandra5-small-full-v3.1.tar.gz"
+OLD_SHA="f5fa0b6599a27c1c493d7c6c063194d55d031cab417396947313e7245afc5ceb"
+OLD_TAG="datasets-v3"
+
+NEW_ASSET="cassandra5-small-full-v3.2.tar.gz"
+NEW_SHA=""
+NEW_TAG="datasets-v3"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --new-sha)   NEW_SHA="$2"; shift 2 ;;
+    --new-asset) NEW_ASSET="$2"; shift 2 ;;
+    --new-tag)   NEW_TAG="$2"; shift 2 ;;
+    --old-asset) OLD_ASSET="$2"; shift 2 ;;
+    --old-sha)   OLD_SHA="$2"; shift 2 ;;
+    --old-tag)   OLD_TAG="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,33p' "$0"; exit 0 ;;
+    *)
+      echo "Unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$NEW_SHA" ]]; then
+  echo "❌ --new-sha <sha256> is required (the SHA256 of the newly-published asset)." >&2
+  echo "   It is printed by package_datasets.sh and written to <archive>.sha256." >&2
+  exit 2
+fi
+if [[ ! "$NEW_SHA" =~ ^[0-9a-f]{64}$ ]]; then
+  echo "❌ --new-sha must be a 64-char lowercase hex SHA256, got: $NEW_SHA" >&2
+  exit 2
+fi
+if [[ ! -d "$WF_DIR" ]]; then
+  echo "❌ workflow dir not found: $WF_DIR" >&2
+  exit 2
+fi
+
+echo "Repointing dataset pin in $WF_DIR"
+echo "  asset: $OLD_ASSET -> $NEW_ASSET"
+echo "  sha:   $OLD_SHA -> $NEW_SHA"
+if [[ "$OLD_TAG" != "$NEW_TAG" ]]; then
+  echo "  tag:   $OLD_TAG -> $NEW_TAG"
+fi
+
+# Portable in-place sed (BSD/macOS vs GNU).
+sed_inplace() {
+  if sed --version >/dev/null 2>&1; then sed -i "$@"; else sed -i '' "$@"; fi
+}
+
+changed=0
+for f in "$WF_DIR"/*.yml "$WF_DIR"/*.yaml; do
+  [[ -e "$f" ]] || continue
+  if grep -qF -e "$OLD_ASSET" -e "$OLD_SHA" "$f" \
+     || { [[ "$OLD_TAG" != "$NEW_TAG" ]] && grep -qF "DATASET_TAG: $OLD_TAG" "$f"; }; then
+    sed_inplace "s|$OLD_ASSET|$NEW_ASSET|g; s|$OLD_SHA|$NEW_SHA|g" "$f"
+    if [[ "$OLD_TAG" != "$NEW_TAG" ]]; then
+      sed_inplace "s|DATASET_TAG: $OLD_TAG|DATASET_TAG: $NEW_TAG|g" "$f"
+    fi
+    echo "  ✓ updated $(basename "$f")"
+    changed=$((changed + 1))
+  fi
+done
+
+echo "Updated $changed workflow file(s)."
+
+# Verify: no stale references to the OLD asset/sha remain anywhere.
+stale=$(grep -rIlF -e "$OLD_ASSET" -e "$OLD_SHA" "$WF_DIR" 2>/dev/null || true)
+if [[ -n "$stale" ]]; then
+  echo "❌ stale OLD pin still present in:" >&2
+  echo "$stale" >&2
+  exit 1
+fi
+
+# Sanity: the NEW asset+sha should now appear in the expected number of files.
+n_asset=$(grep -rIlF "$NEW_ASSET" "$WF_DIR" 2>/dev/null | wc -l | tr -d ' ')
+n_sha=$(grep -rIlF "$NEW_SHA" "$WF_DIR" 2>/dev/null | wc -l | tr -d ' ')
+echo "NEW asset present in $n_asset file(s); NEW sha present in $n_sha file(s)."
+echo "✅ Pin bump complete. Review 'git diff .github/workflows', then open a PR."


### PR DESCRIPTION
## Summary
Prep for **#1099 Path A** (dataset republish) so it's a turn-key, low-error operation. Path B (verifier skip) already shipped in #1094; this is the durable follow-up so strict/nightly lanes get the Epic #970 `test_comp` + corruption binaries.

Two deliverables (no CI behavior change until the finalizer is run post-publish):
- **`docs/runbooks/1099-dataset-republish.md`** — exact generate → package → publish → repoint → verify steps (derived from `compression-corruption-parity.yml`; needs Docker/Cassandra 5 + release-upload rights).
- **`test-data/scripts/bump-dataset-pin.sh`** — repoints asset + SHA256 (and optionally the release tag, incl. inline `gh release download`/`releases/download/` literals) across all 10 pinned workflows **and** `fetch-datasets.sh`, verifying no stale pin remains. Never rewrites its own `OLD_*` defaults or the runbook; surfaces doc-only refs as advisory.

Also fixes a latent cache hazard surfaced in review:
- **SHA-scope the dataset cache `restore-keys`** in `coverage.yml`/`m1-ci.yml` (`datasets-v3-` → `datasets-v3-<sha>-`). Previously a SHA-keyed pin bump would miss the primary key but warm-restore the OLD dataset via the broad restore-key, and the download step skips when `test_basic` Data.db is present — silently testing the old dataset. SHA-scoped keys can only restore the same version; the finalizer rewrites that SHA on bump.

## Validation
- Finalizer validated on same-tag and tag-change paths (updates exactly 11 pin-consuming files; protects self/runbook; flags website docs).
- roborev branch review (3 rounds): **No issues found**.

Refs #1099 (Path A prep; issue stays open until the republish is executed).