### PR TITLE
fix(summary): Summary.db entry Index.db-position is little-endian (#1054)

### DIFF
--- a/cqlite-core/src/storage/sstable/s3_verification_test.rs
+++ b/cqlite-core/src/storage/sstable/s3_verification_test.rs
@@ -282,9 +282,9 @@ mod s3_verification {
         // BE interpretation of same bytes = 0x20000000 (536870912) — wrong!
         assert_ne!(be_value, 32, "big-endian would misread the offset");
 
-        // The Summary.db offset table is the ONLY little-endian component in the
-        // entire SSTable format.  All other fields (header, entry positions, key
-        // lengths) are big-endian.
+        // The Summary.db offset table and the per-entry trailing Index.db
+        // position (issue #1054) are little-endian. The header fields and the
+        // length-prefixed first/last keys are big-endian.
         assert_eq!(
             u32::from_le_bytes([0x18, 0x00, 0x00, 0x00]),
             24,
@@ -559,7 +559,7 @@ mod s3_verification {
 
         // summary_entries_size: offset_table (3*4=12) + entry_data (3*(2+8)=30) = 42
         let key_size: u64 = 2; // 2-byte keys
-        let entry_size: u64 = key_size + 8; // key + be_u64 position
+        let entry_size: u64 = key_size + 8; // key + le_u64 position
         let offset_table_size: u64 = entries_count as u64 * 4;
         let entry_data_size: u64 = entries_count as u64 * entry_size;
         let summary_entries_size: u64 = offset_table_size + entry_data_size;

--- a/cqlite-core/src/storage/sstable/summary_reader.rs
+++ b/cqlite-core/src/storage/sstable/summary_reader.rs
@@ -14,7 +14,7 @@
 //! +----------------------+
 //! | Offset table (LE)    |  ← Little-endian u32 offsets!
 //! +----------------------+
-//! | Entry data           |  ← key_data + be_u64 position
+//! | Entry data           |  ← key_data + le_u64 position
 //! +----------------------+
 //! | First key (prefixed) |  ← be_u32 size + key data
 //! +----------------------+
@@ -31,8 +31,8 @@
 //!
 //! ### Entry Format
 //! - No length prefix for keys - boundaries determined by offset differences
-//! - Entry = key_data (variable) + position (be_u64)
-//! - Position is offset in Index.db file
+//! - Entry = key_data (variable) + position (le_u64)
+//! - Position is offset in Index.db file (little-endian, issue #1054)
 //!
 //! ### Critical: Offset Table is LITTLE-ENDIAN
 //! Unlike all other Cassandra binary formats which use big-endian, the offset
@@ -362,7 +362,7 @@ pub(crate) fn parse_summary_header(input: &[u8]) -> IResult<&[u8], SummaryHeader
 
 /// Parse entries using offset table
 ///
-/// Each entry is: key_data (variable) + position (be_u64)
+/// Each entry is: key_data (variable) + position (le_u64)
 /// Key boundaries are determined by offset differences.
 fn parse_entries_from_offsets(
     entry_data: &[u8],
@@ -405,7 +405,7 @@ fn parse_entries_from_offsets(
 
         let entry_bytes = &entry_data[start..end];
 
-        // Entry format: key_data + be_u64 position
+        // Entry format: key_data + le_u64 position
         // Key length = entry length - 8 (for the position)
         if entry_bytes.len() < 8 {
             return Err(Error::corruption(format!(
@@ -418,9 +418,10 @@ fn parse_entries_from_offsets(
         let key_len = entry_bytes.len() - 8;
         let partition_key = entry_bytes[..key_len].to_vec();
 
-        // Parse position (last 8 bytes, big-endian)
+        // Parse position (last 8 bytes, little-endian — Cassandra serializes the
+        // trailing Index.db position as LE u64; see issue #1054).
         let position_bytes = &entry_bytes[key_len..];
-        let position = u64::from_be_bytes([
+        let position = u64::from_le_bytes([
             position_bytes[0],
             position_bytes[1],
             position_bytes[2],
@@ -526,7 +527,7 @@ mod tests {
     fn test_entry_parsing_from_offsets() {
         // Entry data with one entry:
         // - Key: 16 bytes (partition key digest)
-        // - Position: 8 bytes (be_u64)
+        // - Position: 8 bytes (le_u64)
         let key_bytes = vec![
             0xdc, 0x67, 0x26, 0xa6, 0x05, 0xc6, 0x48, 0x50, 0x86, 0xcd, 0x0f, 0xe3, 0x1b, 0x67,
             0x57, 0xaf,
@@ -551,9 +552,9 @@ mod tests {
         let key1 = vec![0xBB; 16];
 
         let mut entry_data = key0.clone();
-        entry_data.extend_from_slice(&0u64.to_be_bytes());
+        entry_data.extend_from_slice(&0u64.to_le_bytes());
         entry_data.extend_from_slice(&key1);
-        entry_data.extend_from_slice(&128u64.to_be_bytes());
+        entry_data.extend_from_slice(&128u64.to_le_bytes());
 
         let offsets = vec![8u32, 32u32];
         let entries = parse_entries_from_offsets(&entry_data, &offsets, 8, 56).unwrap();
@@ -651,10 +652,10 @@ mod tests {
         data.extend_from_slice(&key0);
         data.extend_from_slice(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
 
-        // Entry 1: 16-byte key + position 100
+        // Entry 1: 16-byte key + position 100 (little-endian u64)
         let key1: [u8; 16] = [0x02; 16];
         data.extend_from_slice(&key1);
-        data.extend_from_slice(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x64]);
+        data.extend_from_slice(&[0x64, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
 
         // First key
         data.extend_from_slice(&[0x00, 0x00, 0x00, 0x10]);

--- a/cqlite-core/src/storage/sstable/writer/summary_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/summary_writer.rs
@@ -4,7 +4,8 @@
 //! Used for efficient partition key range scanning without reading full index.
 //!
 //! Critical requirements:
-//! - Little-endian offsets (ONLY LE component in SSTable!)
+//! - Little-endian offset table AND little-endian per-entry Index.db position
+//!   (issue #1054) — the only LE fields; header + first/last keys are BE
 //! - Sampling every N entries (default: 128)
 //! - First and last keys always included
 //!
@@ -17,7 +18,7 @@
 //! | Offset Table (LE u32[])| <- Little-endian!
 //! +------------------------+
 //! | Entry Data             |
-//! |   key + position (BE)  |
+//! |   key + position (LE)  |
 //! +------------------------+
 //! | First Key (serialized) |
 //! +------------------------+
@@ -50,7 +51,7 @@
 //! ```c
 //! struct summary_entry {
 //!     byte key[];        // Variable length - no prefix!
-//!     be64 position;     // Position in Index.db file (big-endian)
+//!     le64 position;     // Position in Index.db file (little-endian, issue #1054)
 //! };
 //! ```
 //!
@@ -308,8 +309,9 @@ impl SummaryWriter {
             // Write key bytes (no length prefix!)
             entry_data.extend_from_slice(&entry.key);
 
-            // Write position (big-endian u64)
-            entry_data.extend_from_slice(&entry.index_position.to_be_bytes());
+            // Write position (little-endian u64 — Cassandra serializes the trailing
+            // Index.db position as LE; see issue #1054).
+            entry_data.extend_from_slice(&entry.index_position.to_le_bytes());
         }
 
         let summary_entries_size = (offset_table_size + entry_data.len()) as u64;
@@ -486,7 +488,7 @@ mod tests {
         // Verify entry data
         // Key: [0x01, 0x02, 0x03, 0x04]
         assert_eq!(&bytes[28..32], &[0x01, 0x02, 0x03, 0x04]);
-        // Position: 0 (BE u64)
+        // Position: 0 (LE u64)
         assert_eq!(
             &bytes[32..40],
             &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
@@ -542,10 +544,10 @@ mod tests {
 
         // Verify entry 2 data
         assert_eq!(&bytes[42..45], &[0xCC, 0xDD, 0xEE]); // key
-                                                         // position = 1024 (0x0000000000000400)
+                                                         // position = 1024 (little-endian u64)
         assert_eq!(
             &bytes[45..53],
-            &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00]
+            &[0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
         );
 
         // Verify first key (2 bytes)
@@ -687,10 +689,10 @@ mod tests {
         let bytes = writer.finish().unwrap();
 
         // Position is at offset: 24 (header) + 4 (offset table) + 1 (key) = 29
-        // Position: 0x0000000040000000 (1GB in big-endian)
+        // Position: 1GB (0x40000000) as little-endian u64
         assert_eq!(
             &bytes[29..37],
-            &[0x00, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00]
+            &[0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00, 0x00]
         );
     }
 
@@ -706,10 +708,10 @@ mod tests {
         let bytes = writer.finish().unwrap();
 
         // Position is at: 24 (header) + 4 (offset) + 1 (key) = 29
-        // 12381 in big-endian u64: 0x000000000000305D
+        // 12381 (0x305D) as little-endian u64
         assert_eq!(
             &bytes[29..37],
-            &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x5D]
+            &[0x5D, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
         );
     }
 

--- a/cqlite-core/tests/sstabledump_parity_summary.rs
+++ b/cqlite-core/tests/sstabledump_parity_summary.rs
@@ -765,9 +765,9 @@ async fn save_summary_validation_artifacts(
 //   * Each entry's key bytes are reconstructed from the offset table and must
 //     byte-match `SummaryReader`'s entries; entries must be ordered by ascending
 //     offset and ascending (little-endian) Index.db position. The on-disk
-//     position is little-endian (proven against Index.db); the production
-//     `SummaryReader` currently returns it big-endian, so the reader's returned
-//     position is intentionally NOT asserted here (KNOWN LIMITATION #1054).
+//     position is little-endian (proven against Index.db); as of issue #1054 the
+//     production `SummaryReader` decodes it little-endian too, so the reader's
+//     returned position is asserted byte-for-byte against the LE on-disk value.
 //   * The trailing length-prefixed first/last decorated keys are decoded and
 //     byte-compared to `SummaryReader`, and the first summary sample's key must
 //     equal the SSTable's first key (Cassandra always samples partition 0).
@@ -806,10 +806,10 @@ mod strict {
     /// Index.db position as a **little-endian** u64 (verified byte-for-byte:
     /// the LE value lands exactly on the matching `Index.db` partition entry,
     /// while the big-endian interpretation produces an out-of-range offset).
-    /// Only the authoritative LE offset is retained and asserted against
-    /// `Index.db`; the production `SummaryReader` currently returns this field
-    /// big-endian (see KNOWN LIMITATION #1054 at the entry-parity assertion),
-    /// so the test deliberately does not assert the reader's returned position.
+    /// The authoritative LE offset is retained and asserted against `Index.db`;
+    /// as of issue #1054 the production `SummaryReader` returns this field
+    /// little-endian too, so the entry-parity assertion checks the reader's
+    /// returned position byte-for-byte against this value.
     struct RawEntry {
         key: Vec<u8>,
         /// Authoritative Index.db offset (little-endian, on-disk truth).
@@ -1167,10 +1167,17 @@ mod strict {
                     summary_path.display()
                 );
                 // The on-disk truth is the little-endian position, proven below
-                // by resolving it against Index.db. We deliberately do NOT assert
-                // the reader's returned position here.
-                // KNOWN LIMITATION (#1054): SummaryReader currently returns this
-                // field big-endian; when #1054 lands, assert entry.position == position_le.
+                // by resolving it against Index.db. As of issue #1054 the
+                // production `SummaryReader` decodes this field little-endian, so
+                // its returned position must byte-match the raw LE on-disk value.
+                assert_eq!(
+                    entry.position,
+                    raw_entry.position_le,
+                    "{}: entry[{i}] position mismatch reader={} raw_le={} (issue #1054)",
+                    summary_path.display(),
+                    entry.position,
+                    raw_entry.position_le
+                );
             }
 
             // Entry ordering: keys are stored in ascending offset order, so the

--- a/docs/sstables-definitive-guide/chapters/06-index-and-summary.md
+++ b/docs/sstables-definitive-guide/chapters/06-index-and-summary.md
@@ -193,9 +193,15 @@ Entries have **no length prefix**. Key boundaries are determined by offset diffe
 ```c
 struct summary_entry {
     byte key[];        // Variable length - no prefix!
-    be64 position;     // Position in Index.db file
+    le64 position;     // Position in Index.db file (LITTLE-ENDIAN — issue #1054)
 };
 ```
+
+> **Endianness note (issue #1054):** the trailing per-entry `position` is the
+> only other little-endian field besides the offset table. Cassandra serializes
+> it with `out.writeLong` against a little-endian buffer, so it must be decoded
+> with `u64::from_le_bytes`. The 24-byte header and the length-prefixed
+> first/last keys are big-endian.
 
 Key length calculation:
 ```
@@ -398,7 +404,7 @@ Summary entries have **no length prefix**. Key boundaries are determined by offs
 ```c
 struct summary_entry {
     byte key[];        // Variable length partition key bytes (no prefix!)
-    be64 position;     // Position in Index.db file (big-endian)
+    le64 position;     // Position in Index.db file (LITTLE-ENDIAN — issue #1054)
 };
 ```
 
@@ -407,8 +413,8 @@ Entry serialization:
 // Write key bytes (no length prefix!)
 buffer.extend_from_slice(&key_bytes);
 
-// Write position (big-endian u64)
-buffer.extend_from_slice(&index_position.to_be_bytes());
+// Write position (little-endian u64 — issue #1054)
+buffer.extend_from_slice(&index_position.to_le_bytes());
 ```
 
 ### Summary.db Offset Table


### PR DESCRIPTION
Closes #1054. Parent epic: #968.

## Problem
Cassandra serializes the Summary.db per-entry trailing Index.db position as a **little-endian u64**. CQLite decoded it big-endian (`summary_reader.rs`) and encoded it big-endian (`summary_writer.rs`), so CQLite-written multi-entry Summary.db files were not byte-compatible with Cassandra. Latent today (positions aren't yet consumed for partition lookups), but a correctness landmine for any future code that trusts `SummaryReader` positions.

Discovered during #984. On `system/sstable_activity`, the LE interpretation lands exactly on the matching `system_schema/columns` Index.db partition entry; BE is out-of-range.

## Fix
- `summary_reader.rs`: decode position with `u64::from_le_bytes`.
- `summary_writer.rs`: encode position with `u64::to_le_bytes`.
- Guide ch.6 (`06-index-and-summary.md`): `be64 position` → `le64 position` + endianness note.
- Reader/writer unit tests + `s3_verification_test.rs` comments updated to LE (with non-palindromic byte assertions: 100, 1024, 12381, 1GB).
- #984 strict parity test (`sstabledump_parity_summary.rs`): documented-limitation note promoted to a hard `entry.position == raw_entry.position_le` assertion, cross-validated against real Index.db offsets.

Header fields and length-prefixed first/last keys remain big-endian (unchanged).

## Validation
- `scripts/agent-gate.sh`: **RESULT: PASS** (fmt, clippy, core-tests, tombstones-scan, integration-tests, format-compat, write-tests, cli-tests, python-bindings, minimal-build, smoke — all PASS).
- Strict byte-parity test passed against real fixtures incl. multi-entry summaries (the BE-would-fail case).
- roborev branch review: **No issues found.**
- spec-auditor + coverage-reviewer: **PASS.**