### PR TITLE
docs: bump dataset pin to v3.2 in agent docs (#1099)

### DIFF
--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -106,8 +106,8 @@ the same asset CI uses. Current pins (as of the script source):
 
 ```
 DATASET_TAG:    datasets-v3
-DATASET_ASSET:  cassandra5-small-full-v3.1.tar.gz
-DATASET_SHA256: f5fa0b6599a27c1c493d7c6c063194d55d031cab417396947313e7245afc5ceb
+DATASET_ASSET:  cassandra5-small-full-v3.2.tar.gz
+DATASET_SHA256: bebc763752c8d68c7fb0483a1b31294b4d1d21343d3f7d124da069e5073202fa
 ```
 
 See [Test data](/cqlite/agents-developing/test-data/) for how `fetch-datasets.sh` uses these pins and why

--- a/website/src/content/docs/agents-developing/test-data.md
+++ b/website/src/content/docs/agents-developing/test-data.md
@@ -26,16 +26,16 @@ The fetch script uses these defaults (override with environment variables):
 
 ```bash
 DATASET_TAG=datasets-v3
-DATASET_ASSET=cassandra5-small-full-v3.1.tar.gz
-DATASET_SHA256=f5fa0b6599a27c1c493d7c6c063194d55d031cab417396947313e7245afc5ceb
+DATASET_ASSET=cassandra5-small-full-v3.2.tar.gz
+DATASET_SHA256=bebc763752c8d68c7fb0483a1b31294b4d1d21343d3f7d124da069e5073202fa
 ```
 
 CI reads the same pins from `.github/workflows/sstabledump-parity-gate.yml`:
 
 ```yaml
 DATASET_TAG: datasets-v3
-DATASET_ASSET: cassandra5-small-full-v3.1.tar.gz
-DATASET_SHA256: f5fa0b6599a27c1c493d7c6c063194d55d031cab417396947313e7245afc5ceb
+DATASET_ASSET: cassandra5-small-full-v3.2.tar.gz
+DATASET_SHA256: bebc763752c8d68c7fb0483a1b31294b4d1d21343d3f7d124da069e5073202fa
 ```
 
 **Why SHA256 is the cache key**: CI caches the extracted dataset by SHA256. Using the
@@ -43,11 +43,15 @@ tag name as the cache key would allow a re-published asset (same tag, different
 content) to serve stale data. The SHA256 is content-addressed — cache hit means the
 exact bytes are correct.
 
-**Why v3.1 rather than v3**: The v3 tarball was produced on macOS and contained
-AppleDouble entries. v3.1 was repackaged with `--exclude='*/._*'` to strip them.
-When inspecting or repackaging archives, use Python's `tarfile` module (platform-
-neutral) rather than `tar -tf` (macOS bsdtar hides `._*` on listing and re-embeds
-them on repack).
+**Why v3.2 (asset history)**: The v3 tarball was produced on macOS and contained
+AppleDouble entries; v3.1 was repackaged with `--exclude='*/._*'` to strip them.
+v3.2 (issue #1099) republished the corpus to include the Epic #970 `test_comp` +
+`corruption/test_comp_corrupt` fixtures, which `issue_1000_verifier` requires —
+the v3.1 asset predated those fixtures, so the `test` lane could only clean-skip
+that coverage. All assets share the `datasets-v3` tag (it holds multiple versions;
+the SHA256 pin selects the exact bytes). When inspecting or repackaging archives,
+use Python's `tarfile` module (platform-neutral) rather than `tar -tf` (macOS
+bsdtar hides `._*` on listing and re-embeds them on repack).
 
 ## CQLITE_DATASETS_ROOT
 


### PR DESCRIPTION
Follow-up to #1099 / PR #1137 (merged). The dataset republish updated the pin across all CI workflows + `fetch-datasets.sh`, but two **doc-only** pages still showed the old v3.1 asset/SHA256 (the finalizer flags these but doesn't auto-edit them).

- `gate-contract.md`, `test-data.md`: `cassandra5-small-full-v3.1` → `v3.2`, SHA `f5fa0b…` → `bebc7637…`.
- Refreshed the asset-history note to record why v3.2 exists (Epic #970 `test_comp` + corruption fixtures), keeping the v3/v3.1 AppleDouble provenance.

Docs-only; tag `datasets-v3` unchanged.