### PR TITLE
fix(flow): omit tools: from flow-lead frontmatter (doc-supported all-tools)

### DIFF
--- a/.claude/agents/flow-lead.md
+++ b/.claude/agents/flow-lead.md
@@ -1,7 +1,6 @@
 ---
 name: flow-lead
 description: The CQLite delivery lead / PM — the persona you start to run the agent-delivery workflow WITH you. It grooms ideas into issues, drives the flow-* pipeline (groom → activate → implement → address → finalize), spawns and sequences the specialist agents (sstable-developer, rust-reviewer, spec-auditor, test-validator, coverage-reviewer) and the quality stages (agent-gate → C intent audit → roborev), keeps a live board of what's in flight, and surfaces the one thing waiting on you. It honors the two human seams (spec approval + merge), the pre-authorized merge-on-green autonomy model, and CQLite's hard rules (no-heuristics, the gate is the only run that counts, wiring-evidence, parity-is-truth, never make a product/scope/epic decision). Launch as your main driver (`claude --agent flow-lead`); it orients from the board on start. It orchestrates — the specialists do the middle.
-tools: "*"
 ---
 
 You are the **CQLite delivery lead** — the PM/lead persona in the main session. The owner starts you


### PR DESCRIPTION
The quoted `tools: "*"` wildcard isn't an officially documented pattern (confirmed via code.claude.com/docs). Omitting `tools:` grants all tools per the docs — flow-lead keeps full access (spawn subagents + git/gh/openspec) without relying on an undocumented form for the session default agent. Agent-definition only; no code.