### PR TITLE
Define Cassandra parity CI tier contracts + release checklist (#1022)

### DIFF
--- a/.github/workflows/cassandra-parity.yml
+++ b/.github/workflows/cassandra-parity.yml
@@ -15,6 +15,7 @@ on:
       - 'tools/cassandra-parity/**'
       - 'docs/reports/cassandra-test-parity*.md'
       - 'docs/cassandra_test_index.md'
+      - 'docs/development/parity-ci-tiers.md'
       - '.github/workflows/cassandra-parity.yml'
   pull_request:
     branches: [ main ]
@@ -24,6 +25,7 @@ on:
       - 'tools/cassandra-parity/**'
       - 'docs/reports/cassandra-test-parity*.md'
       - 'docs/cassandra_test_index.md'
+      - 'docs/development/parity-ci-tiers.md'
       - '.github/workflows/cassandra-parity.yml'
 
 env:
@@ -53,6 +55,10 @@ jobs:
 
       - name: Lint manifest (schema + cross-field parity rules)
         run: cargo run -p cassandra-parity -- lint --manifest test-data/cassandra-parity-manifest.yml
+
+      - name: Tier contract is not drifted (doc == schema == code enum; #1022)
+        # Fast, dependency-free: reads only the tier doc, schema JSON, and manifest YAML.
+        run: cargo run -p cassandra-parity -- tier-contract-check --manifest test-data/cassandra-parity-manifest.yml
 
       - name: Report is not stale
         run: cargo run -p cassandra-parity -- report --manifest test-data/cassandra-parity-manifest.yml --output docs/reports/cassandra-test-parity.md --check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ Key chapters:
 
 Full contributor doctrine is published at `https://pmcfadin.github.io/cqlite/agents-developing/`:
 - [Gate contract](https://pmcfadin.github.io/cqlite/agents-developing/gate-contract/) — `scripts/agent-gate.sh`, summary-block format
+  - Parity CI tier contracts: `docs/development/parity-ci-tiers.md` (what each Cassandra parity CI tier promises; gate-strength smoke/canonical-semantic/byte-for-byte) + `docs/development/parity-release-checklist.md` (gates public parity claims). Belongs alongside the gate-contract page on the `agents-developing/` site — mirror there when the site page lands (issue #1022).
 - [No-heuristics mandate](https://pmcfadin.github.io/cqlite/agents-developing/no-heuristics/) — authoritative metadata only (issue #28)
 - [Test data](https://pmcfadin.github.io/cqlite/agents-developing/test-data/) — fetching, dataset pins, CQLITE_DATASETS_ROOT
 - [Key source paths](https://pmcfadin.github.io/cqlite/agents-developing/source-map/) — parsers, writers, query engine, bindings

--- a/docs/development/parity-ci-tiers.md
+++ b/docs/development/parity-ci-tiers.md
@@ -11,9 +11,9 @@
 >
 > **Doctrine cross-link:** this contract sits beside the
 > [gate contract](https://pmcfadin.github.io/cqlite/agents-developing/gate-contract/)
-> on the agent developer site. TODO: when the `agents-developing/` site mirror
-> gains a parity-tiers page, link it here (no local mirror exists under `docs/`
-> today).
+> on the agent developer site; the local site mirror
+> (`website/src/content/docs/agents-developing/gate-contract.md`) carries a
+> "Parity CI tier contracts" section pointing back here.
 
 ## The documented tier enum (machine-parseable)
 

--- a/docs/development/parity-ci-tiers.md
+++ b/docs/development/parity-ci-tiers.md
@@ -1,0 +1,159 @@
+# Parity CI Tier Contracts
+
+> Source-of-truth contract for the five Cassandra parity CI tiers (epic #966 →
+> #974, issue #1022). Defines what each tier *promises*: purpose, accepted
+> evidence, skip/failure policy, artifact retention, and promotion rules.
+>
+> This contract is the reference that downstream gate work (#1023 claim lint,
+> #1024 gate hardening, #1025 nightly Docker, #1026 exhaustive regen) builds on.
+> See also the [release checklist](./parity-release-checklist.md) and the
+> [manifest reference](./cassandra-parity-manifest.md).
+>
+> **Doctrine cross-link:** this contract sits beside the
+> [gate contract](https://pmcfadin.github.io/cqlite/agents-developing/gate-contract/)
+> on the agent developer site. TODO: when the `agents-developing/` site mirror
+> gains a parity-tiers page, link it here (no local mirror exists under `docs/`
+> today).
+
+## The documented tier enum (machine-parseable)
+
+The cross-check (`cargo run -p cassandra-parity -- tier-contract-check`) parses
+the fenced block below as **the documented enum**. It MUST equal
+`enums::CI_TIER` in `tools/cassandra-parity/src/enums.rs` and the `ci.tier`
+enum in `test-data/cassandra-parity-manifest.schema.json`. Keep the block exact:
+one tier name per line, lowercase `snake_case`, no surrounding prose. Do not add
+list markers or commentary inside the fence.
+
+```parity-ci-tiers
+fast_pr
+required_parity
+nightly_docker
+exhaustive_regeneration
+manual_debug
+```
+
+## Gate-strength classification
+
+Every gate has a *strength* that bounds what it can prove. Strengths map to the
+`evidence.type` values already defined in the manifest schema:
+
+| Gate strength       | `evidence.type`       | What it proves |
+|---------------------|-----------------------|----------------|
+| smoke               | `smoke`               | CQLite parses/loads the artifact without error. **Not** byte parity and **not** value parity. |
+| canonical-semantic  | `canonical_semantic`  | Decoded values match Cassandra after a documented normalization (e.g. JSONL goldens). Proves *value* parity, not byte layout. |
+| byte-for-byte       | `byte_for_byte`       | CQLite output is byte-identical to Cassandra's (bytes/offsets/checksums/component files). The strongest claim. |
+
+The remaining two `evidence.type` values are **non-proving** and cannot back a
+parity claim on their own:
+
+- `partial` — partial coverage; requires `known_limitations` plus `scope.gap`
+  and `scope.next_step` in the manifest.
+- `out_of_scope` — explicitly excluded; requires a rationale, boundary, and a
+  safe-claim statement in the manifest.
+
+**P0 data-loss rule:** smoke evidence alone CANNOT satisfy a `P0` /
+`p0_data_loss` scenario. Such a scenario must either carry canonical-semantic or
+byte-for-byte evidence, or record an explicit `scope.gap` acknowledging the
+missing proof (enforced by `cassandra-parity lint`). A green smoke gate over a
+P0 data-loss path without a recorded gap is a contract violation.
+
+## Tier contracts
+
+### `fast_pr`
+
+- **Purpose.** The cheap, always-on PR gate. Static and structural checks that
+  run on every pull request with no heavy dependencies (no Docker, no live
+  Cassandra, no downloaded dataset binaries). The tier-contract cross-check
+  itself runs here.
+- **Allowed `evidence.type`.** `smoke`, `partial`, `out_of_scope`. (A scenario
+  may *also* have stronger evidence proven in a higher tier; `fast_pr` only
+  asserts the cheap checks.)
+- **Skip policy.** Must not skip on PRs that touch parity surfaces. Path-filtered
+  workflows may legitimately not trigger when no parity file changed; that is a
+  non-trigger, not a skip.
+- **Failure policy.** Blocking. A red `fast_pr` check blocks the PR.
+- **Artifact retention.** Logs only; default CI retention. No fixtures produced.
+- **Promotion.** A `fast_pr` scenario is promoted to `required_parity` once a
+  deterministic, dataset-backed comparison (canonical-semantic or byte-for-byte)
+  exists and is wired into a named workflow. Record the workflow path in
+  `ci.workflow` when promoting.
+
+### `required_parity`
+
+- **Purpose.** The blocking parity gate on PRs and `main`: deterministic
+  comparisons against committed reference goldens (JSONL, TOC, digests, byte
+  fixtures) that run without spinning up Cassandra.
+- **Allowed `evidence.type`.** `canonical_semantic`, `byte_for_byte` (the
+  proving strengths). `partial` is permitted only with a recorded `scope.gap`
+  and `scope.next_step`.
+- **Skip policy.** Must not skip on the release commit. A skipped
+  `required_parity` is treated as a failure for release purposes (see the
+  release checklist).
+- **Failure policy.** Blocking. Every `required_parity` scenario MUST name a
+  workflow (`ci.workflow`); a missing workflow is a lint error.
+- **Artifact retention.** On failure, retain the diff/failure artifacts named in
+  `evidence.failure_artifacts` long enough to triage (>= 14 days recommended).
+- **Promotion.** A `canonical_semantic` `required_parity` scenario is promoted
+  to `byte_for_byte` once byte/offset/checksum fixtures and a strict comparison
+  command exist. Heavy regeneration of those fixtures moves to `nightly_docker`
+  or `exhaustive_regeneration`.
+
+### `nightly_docker`
+
+- **Purpose.** Scheduled (nightly) verification that regenerates or re-validates
+  fixtures inside a real Cassandra Docker image — catching drift the committed
+  goldens cannot (version bumps, environment differences).
+- **Allowed `evidence.type`.** `canonical_semantic`, `byte_for_byte`.
+- **Skip policy.** May skip on ordinary PRs (it is scheduled, not per-PR). It
+  must run on its schedule; a chronically skipped/disabled nightly invalidates
+  the "recent nightly pass" release requirement.
+- **Failure policy.** Non-blocking for in-flight PRs, but a failure files/updates
+  a tracking issue and blocks release until resolved (see release checklist).
+- **Artifact retention.** Retain regenerated fixtures and logs for the comparison
+  window (>= 30 days recommended) so a release can cite a recent pass.
+- **Promotion.** Scenarios do not "promote" out of `nightly_docker`; rather, a
+  `required_parity` scenario whose fixtures need a live Cassandra to regenerate
+  is *attached* to the nightly so its goldens stay fresh.
+
+### `exhaustive_regeneration`
+
+- **Purpose.** The full, expensive regeneration of the entire fixture corpus
+  across the storage-format matrix (`nb`/`oa`/`da`/`big`/`bti`), run for release
+  candidates and major format work — the broadest proof the program offers.
+- **Allowed `evidence.type`.** `byte_for_byte`, `canonical_semantic`.
+- **Skip policy.** Not run per-PR. Required for release candidates; skipping it
+  for an RC means broad parity claims cannot ship (see release checklist).
+- **Failure policy.** Blocking for release candidates. A failure blocks the RC
+  until the corpus regenerates cleanly.
+- **Artifact retention.** Retain the full regenerated corpus + logs for the RC's
+  lifetime (>= 90 days recommended) as the citable evidence behind the release
+  claim.
+- **Promotion.** Terminal tier — it is the strongest, broadest gate. New
+  format-matrix scenarios are *added* here once their generation command exists.
+
+### `manual_debug`
+
+- **Purpose.** Investigative, human-run scenarios used to triage a specific
+  failure or explore a format question. Not an automated gate.
+- **Allowed `evidence.type`.** Any, including `partial` and `out_of_scope`,
+  because the tier itself proves nothing automatically.
+- **Skip policy.** Always "skipped" in automation — it never runs in CI by
+  design.
+- **Failure policy.** Non-gating. Findings feed back into a stronger tier or an
+  issue; they never block a PR or a release on their own.
+- **Artifact retention.** Ad hoc; attach artifacts to the relevant issue.
+- **Promotion.** A `manual_debug` scenario is promoted to `fast_pr` or
+  `required_parity` once it is made deterministic and dataset-free (for
+  `fast_pr`) or backed by committed goldens (for `required_parity`).
+
+## Promotion ladder (summary)
+
+```
+manual_debug ──▶ fast_pr ──▶ required_parity ──▶ nightly_docker / exhaustive_regeneration
+ (investigate)   (cheap,      (committed-golden    (live-Cassandra regen; RC-wide
+                  static)      comparison)          corpus regeneration)
+```
+
+A scenario is only as strong as the evidence backing it: moving up the ladder
+requires upgrading the `evidence.type` to a proving strength
+(`canonical_semantic` or `byte_for_byte`) and recording the gate's workflow.

--- a/docs/development/parity-release-checklist.md
+++ b/docs/development/parity-release-checklist.md
@@ -1,0 +1,54 @@
+# Parity Release Checklist
+
+> Run this checklist **before publishing any broad public Cassandra parity
+> claim** (release notes, README, blog, talk). It gates the claim on
+> demonstrably-green parity gates. Copy it into the release issue and check every
+> box on the **release commit / RC tag**, not on a stale branch.
+>
+> Tier definitions live in the [parity CI tier contracts](./parity-ci-tiers.md).
+> Manifest mechanics live in the [manifest reference](./cassandra-parity-manifest.md).
+
+## Required green gates
+
+A broad parity claim MUST NOT ship unless **all** of the following hold on the
+exact release commit:
+
+- [ ] **Manifest lint green.** `cargo run -p cassandra-parity -- lint` exits 0 on
+      the release commit (schema + cross-field parity rules pass).
+- [ ] **Tier contract intact.** `cargo run -p cassandra-parity -- tier-contract-check`
+      exits 0 — the documented tier enum, the schema enum, and `enums::CI_TIER`
+      agree, and every manifest `ci.tier` is a documented tier.
+- [ ] **`required_parity` green on the release commit.** The `required_parity`
+      workflow(s) passed on the commit being released — not a parent, not a
+      retried-after-edit run. A skipped `required_parity` counts as **not green**.
+- [ ] **Recent `nightly_docker` pass.** A `nightly_docker` run passed within the
+      release window (within the retention window in the tier contract; a stale or
+      disabled nightly does not satisfy this item).
+- [ ] **Recent `exhaustive_regeneration` pass (release candidates).** For any RC
+      or major format change, an `exhaustive_regeneration` run over the full
+      storage-format matrix passed within the release window.
+
+## Claim-wording gate
+
+- [ ] **No unqualified "same tests as Cassandra" claims.** Reject any wording
+      that asserts CQLite runs the *same tests* as Apache Cassandra, or implies
+      blanket byte-for-byte parity. Parity claims MUST be scoped to the gate
+      strength that actually backs them (smoke / canonical-semantic /
+      byte-for-byte per the [tier contracts](./parity-ci-tiers.md)) and to the
+      capabilities and storage formats covered by the manifest. A `smoke`-only
+      capability MUST NOT be described as "verified parity".
+
+## Evidence sources (link these in the release notes)
+
+- [ ] [Cassandra test index](../cassandra_test_index.md) — the inventory of
+      Cassandra tests/files the program tracks.
+- [ ] [Cassandra test parity assessment](../reports/cassandra-test-parity-assessment.md)
+      — the relevance/coverage assessment behind the manifest.
+- [ ] [Generated parity report](../reports/cassandra-test-parity.md) — the report
+      rendered from the manifest (`cargo run -p cassandra-parity -- report`); confirm
+      it is not stale (`report ... --check` exits 0).
+
+## Sign-off
+
+- [ ] Release manager has confirmed every box above on the release commit and
+      linked the three evidence sources in the published claim.

--- a/openspec/changes/parity-ci-tier-contracts/.openspec.yaml
+++ b/openspec/changes/parity-ci-tier-contracts/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-27

--- a/openspec/changes/parity-ci-tier-contracts/design.md
+++ b/openspec/changes/parity-ci-tier-contracts/design.md
@@ -1,0 +1,66 @@
+# Design: parity-ci-tier-contracts
+
+## Context
+
+The parity program already has the *mechanism* for tiers: the manifest schema enumerates
+`fast_pr | required_parity | nightly_docker | exhaustive_regeneration | manual_debug`, the
+`cassandra-parity` linter validates `ci.tier` against `enums::CI_TIER`, and several workflows
+(`cassandra-parity.yml`, `compaction-parity.yml`, `tombstone-ttl-parity.yml`, …) implement individual
+gates. What is missing is the *contract*: a public definition of what each tier promises. Downstream
+epic-#974 issues (#1023 claim lint, #1024 gate hardening, #1025 nightly Docker, #1026 exhaustive regen)
+need this contract as their reference, so it lands first. The change is documentation + a small linter
+cross-check; it adds no parity tests and changes no tier values.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One authoritative doc per the spec's four requirements: tier contracts, gate-strength classification,
+  release checklist, and a CI cross-check that keeps doc ↔ schema ↔ code enums in agreement.
+- The cross-check runs in fast PR CI with zero heavy dependencies (no Docker/datasets/live Cassandra).
+- Discoverable from existing doctrine (CLAUDE.md + website gate-contract page).
+
+**Non-Goals:**
+- No new parity tests; no fixing of parity failures; no GitHub releases.
+- No change to the five tier enum values themselves.
+
+## Decisions
+
+**D1. Two separate docs, not one.** `parity-ci-tiers.md` (the contract) and
+`parity-release-checklist.md` (the gate) serve different readers and change cadences — the contract is
+stable reference; the checklist is run per release. *Alternative considered:* one combined doc — rejected
+because the checklist would be buried and harder to copy into a release issue.
+
+**D2. The documented enum is sourced from a machine-readable list, not free prose.** The tier doc carries
+a fenced, parseable tier list (e.g. a small table or code block) that the cross-check reads, so "the
+documented enum" is a real artifact the linter can diff against `enums::CI_TIER` and the schema's enum —
+satisfying the spec's drift scenario. *Alternative considered:* validating only manifest-vs-code enum
+(the linter already does this) — rejected because #1022 explicitly requires validating against the
+*documented* enum, so the doc must be a checkable source.
+
+**D3. Cross-check lives in `cassandra-parity` as a new subcommand (e.g. `tier-contract-check`), wired
+into a fast-PR workflow step.** Reuses the existing tool, its enum constants, and its no-Docker/no-dataset
+property. *Alternative considered:* a standalone shell/CI grep — rejected as brittle and untestable.
+
+**D4. Gate-strength taxonomy maps to existing `evidence.type` values.** smoke ↔ `smoke`;
+canonical-semantic ↔ `canonical_semantic`; byte-for-byte ↔ `byte_for_byte`; `partial`/`out_of_scope` are
+documented as non-proving. This anchors the taxonomy to the schema already in use rather than inventing
+new labels.
+
+## Risks / Trade-offs
+
+- **[Doc/enum drift despite the check]** → the cross-check is the mitigation; it fails CI on any
+  divergence between doc, schema, and `enums::CI_TIER`, and is itself unit-tested with a passing fixture
+  and a drifted fixture.
+- **[Parser brittleness reading the doc enum]** → keep the documented enum in a single, strictly-formatted
+  block (table or fenced list) with a stable shape; the check errors clearly if it cannot locate/parse it.
+- **[Scope creep into actually enforcing the release checklist in CI]** → out of scope; the checklist is a
+  human gate doc here. Automated claim-lint enforcement is #1023.
+
+## Migration Plan
+
+Additive only — new docs, a new linter subcommand, a new fast-PR CI step, and cross-links. No rollback
+concern; reverting the change removes the docs/check with no runtime impact on CQLite itself.
+
+## Open Questions
+
+- None blocking. (Whether the checklist later becomes machine-enforced is tracked by #1023, not here.)

--- a/openspec/changes/parity-ci-tier-contracts/proposal.md
+++ b/openspec/changes/parity-ci-tier-contracts/proposal.md
@@ -1,0 +1,55 @@
+# Proposal: parity-ci-tier-contracts
+
+> Milestone: Cassandra Byte-for-Byte Parity Program (epic #966 → #974 Public Claims and CI Gates).
+> Issue: #1022. Routing: **design-driven** (process/contract + docs; no new parity tests, no oracle bytes) → OpenSpec.
+
+## Why
+
+The Cassandra parity program already enumerates five CI tiers (`fast_pr`, `required_parity`,
+`nightly_docker`, `exhaustive_regeneration`, `manual_debug`) in the manifest schema and the
+`cassandra-parity` linter, but **nowhere defines what each tier promises** — which evidence types it
+accepts, when it may skip, how it fails, what artifacts it must preserve, and how a scenario is promoted
+to a stronger tier. As a result "parity" claims are not anchored to a gate contract, and there is no
+release gate stopping a broad public parity claim from shipping on a commit where the required gates were
+never green. This is the contract layer the rest of epic #974 (#1023 claim lint, #1024 gate hardening,
+#1025 nightly Docker, #1026 exhaustive regen) builds on, so it must land first.
+
+## What Changes
+
+- **New source-of-truth doc** `docs/development/parity-ci-tiers.md` defining, for each of the five tiers:
+  the tier's purpose, allowed `evidence.type` values, skip policy, failure policy, artifact retention
+  expectations, and promotion rules (when/how a scenario moves to a stronger tier). It explicitly
+  distinguishes **smoke**, **canonical-semantic**, and **byte-for-byte** gates.
+- **New release checklist** `docs/development/parity-release-checklist.md` that blocks broad public
+  parity claims unless: manifest lint is green, `required_parity` is green on the release commit, a recent
+  `nightly_docker` pass exists, a recent `exhaustive_regeneration` pass exists for release candidates, and
+  there are no unqualified "same tests as Cassandra" claims. It links the Cassandra test index, the
+  assessment report, and the generated parity report.
+- **CI cross-check**: a `cassandra-parity` lint rule + a fast-PR CI step that validates the tier names
+  used in the manifest against the **documented** enum (doc ↔ schema ↔ `enums::CI_TIER` must agree), so
+  the doc cannot silently drift from the code enum.
+- **Doctrine update**: cross-link the new tier contract from `CLAUDE.md` and the website
+  `agents-developing/` gate-contract page so the gate contract and the parity tiers are discoverable
+  together (same-change doctrine rule).
+
+Non-goals (see Out of scope below) — no new parity tests, no parity-failure fixes, no GitHub releases.
+
+## Capabilities
+
+### New Capabilities
+- `parity-ci-tiers`: The public contract for each Cassandra parity CI tier (evidence types, skip/failure
+  policy, artifact retention, promotion rules) and the release checklist that gates public parity claims,
+  plus the doc↔enum validation that keeps the contract honest.
+
+### Modified Capabilities
+<!-- None: this introduces a new contract capability; it does not change requirements of an existing spec. -->
+
+## Impact
+
+- **Docs (new)**: `docs/development/parity-ci-tiers.md`, `docs/development/parity-release-checklist.md`.
+- **Tooling**: `tools/cassandra-parity` (linter) — add a doc-enum cross-check command/rule; existing
+  `lint` enum check stays.
+- **CI**: a fast-PR workflow step invoking the cross-check (no Docker, no datasets, no live Cassandra).
+- **Doctrine**: `CLAUDE.md` + website `agents-developing/` gate-contract page get a cross-link.
+- **Out of scope**: adding new parity tests; fixing parity failures found by gates; creating GitHub
+  releases; changing the tier enum values themselves.

--- a/openspec/changes/parity-ci-tier-contracts/specs/parity-ci-tiers/spec.md
+++ b/openspec/changes/parity-ci-tier-contracts/specs/parity-ci-tiers/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: Each parity CI tier has a documented public contract
+
+The project SHALL maintain a single source-of-truth document
+(`docs/development/parity-ci-tiers.md`) that defines, for every CI tier in the manifest enum
+(`fast_pr`, `required_parity`, `nightly_docker`, `exhaustive_regeneration`, `manual_debug`), all of:
+its purpose, the `evidence.type` values it accepts, its skip policy, its failure policy, its
+artifact-retention expectations, and its promotion rules. The document MUST exist before downstream
+CI-gate work (#1023–#1026) relies on it.
+
+#### Scenario: Every tier is fully specified
+- **WHEN** the tier-contract document is reviewed against the five manifest tier names
+- **THEN** each of the five tiers has a section defining purpose, allowed evidence types, skip policy, failure policy, artifact expectations, and promotion rules
+- **AND** no tier name from the manifest enum is missing a section
+
+#### Scenario: Promotion rules are explicit
+- **WHEN** a reader needs to know how a scenario moves from a weaker tier to a stronger one
+- **THEN** the document states the promotion rule for that transition (e.g. `fast_pr` → `required_parity`, `required_parity` → `nightly_docker`/`exhaustive_regeneration`)
+
+### Requirement: The contract distinguishes smoke, canonical-semantic, and byte-for-byte gates
+
+The tier-contract document SHALL explicitly classify each gate's strength as one of **smoke**,
+**canonical-semantic**, or **byte-for-byte**, and SHALL state which `evidence.type` values map to each
+strength so a reader cannot conflate a smoke check with byte-for-byte proof.
+
+#### Scenario: Gate strengths are named and mapped
+- **WHEN** the document describes the evidence a tier accepts
+- **THEN** it labels that evidence as smoke, canonical-semantic, or byte-for-byte
+- **AND** it states that smoke evidence alone cannot satisfy a P0 data-loss scenario without an explicit recorded gap
+
+### Requirement: A release checklist gates public parity claims
+
+The project SHALL maintain a release checklist (`docs/development/parity-release-checklist.md`) that
+blocks broad public parity claims unless all required gates are demonstrably green. The checklist MUST
+require: manifest lint green; `required_parity` green on the release commit; a recent `nightly_docker`
+pass; a recent `exhaustive_regeneration` pass for release candidates; and the absence of any unqualified
+"same tests as Cassandra" claim. It MUST link the Cassandra test index, the assessment report, and the
+generated parity report.
+
+#### Scenario: Checklist enumerates the required green gates
+- **WHEN** a release manager opens the checklist before publishing parity claims
+- **THEN** the checklist lists each required gate (manifest lint, required_parity on the release commit, recent nightly_docker, recent exhaustive_regeneration for RCs) as an explicit check item
+- **AND** it includes a check that forbids unqualified "same tests as Cassandra" claims
+
+#### Scenario: Checklist links the evidence sources
+- **WHEN** a reviewer follows the checklist
+- **THEN** it links to `docs/cassandra_test_index.md`, the assessment report, and the generated parity report
+
+### Requirement: CI validates manifest tier names against the documented enum
+
+CI SHALL fail when a tier name used in `test-data/cassandra-parity-manifest.yml` is not part of the
+documented tier enum, and SHALL fail when the documented tier set, the manifest schema enum, and the
+`cassandra-parity` code enum disagree. This check MUST run in a fast PR path and MUST NOT require Docker,
+live Cassandra, or downloaded dataset assets.
+
+#### Scenario: Unknown tier name fails the gate
+- **WHEN** a manifest scenario declares a `ci.tier` value not present in the documented enum
+- **THEN** the `cassandra-parity` check exits non-zero and names the offending scenario ID and the invalid tier value
+
+#### Scenario: Doc and code enum drift fails the gate
+- **WHEN** the tier set listed in `docs/development/parity-ci-tiers.md` differs from `enums::CI_TIER` or the manifest schema enum
+- **THEN** the cross-check exits non-zero and reports which tier is present in one source but missing in another
+
+#### Scenario: The check runs without heavy dependencies
+- **WHEN** the tier-name validation runs in the fast PR CI path
+- **THEN** it completes without Docker, live Cassandra, or downloaded dataset binaries

--- a/openspec/changes/parity-ci-tier-contracts/tasks.md
+++ b/openspec/changes/parity-ci-tier-contracts/tasks.md
@@ -1,0 +1,27 @@
+# Tasks: parity-ci-tier-contracts
+
+## 1. Tier contract document
+- [ ] 1.1 Author `docs/development/parity-ci-tiers.md` with one section per tier (`fast_pr`, `required_parity`, `nightly_docker`, `exhaustive_regeneration`, `manual_debug`) covering purpose, allowed `evidence.type`, skip policy, failure policy, artifact-retention expectations, and promotion rules. *Surface exercised:* the doc itself (read by the cross-check in §3).
+- [ ] 1.2 Add the gate-strength classification (smoke / canonical-semantic / byte-for-byte) and map each to `evidence.type` values; state that smoke alone cannot satisfy a P0 data-loss scenario without a recorded gap.
+- [ ] 1.3 Embed a single strictly-formatted, machine-parseable tier list (table or fenced block) that the cross-check reads as "the documented enum" (design D2).
+
+## 2. Release checklist document
+- [ ] 2.1 Author `docs/development/parity-release-checklist.md` with explicit check items: manifest lint green, `required_parity` green on the release commit, recent `nightly_docker` pass, recent `exhaustive_regeneration` pass for RCs, and a no-unqualified-"same-tests-as-Cassandra"-claims check.
+- [ ] 2.2 Link the Cassandra test index (`docs/cassandra_test_index.md`), the assessment report (`docs/reports/cassandra-test-parity-assessment.md`), and the generated parity report.
+
+## 3. Doc ↔ enum cross-check (CI surface)
+- [ ] 3.1 Add a `cassandra-parity` subcommand (e.g. `tier-contract-check`) that parses the documented enum from `parity-ci-tiers.md` and asserts it equals `enums::CI_TIER` and the manifest schema enum; exits non-zero with the specific divergent tier on mismatch. *Surface exercised:* `cargo run -p cassandra-parity -- tier-contract-check`.
+- [ ] 3.2 Validate that every `ci.tier` used in `test-data/cassandra-parity-manifest.yml` is in the documented enum; report offending scenario ID + tier value on failure.
+- [ ] 3.3 Unit tests: one passing fixture (doc/schema/code agree) and ≥1 drifted fixture per failure mode (doc-vs-code drift, unknown manifest tier). No Docker/datasets/live Cassandra.
+
+## 4. CI wiring
+- [ ] 4.1 Add a fast-PR workflow step (extend an existing fast-PR job or add a lightweight one) invoking `tier-contract-check`; confirm it needs no Docker, datasets, or live Cassandra.
+
+## 5. Doctrine + docs cross-link
+- [ ] 5.1 Cross-link the tier contract from `CLAUDE.md` and the website `agents-developing/` gate-contract page (same-change doctrine rule).
+
+## 6. Quality gate (definition of done)
+- [ ] 6.1 Run `scripts/agent-gate.sh` (with `CQLITE_DATASETS_ROOT` → main repo `test-data/datasets`) and paste the AGENT-GATE SUMMARY block verbatim — must PASS.
+- [ ] 6.2 Intent audit **C**: run `spec-auditor` anchored to `openspec/changes/parity-ci-tier-contracts/specs/**` — every requirement `satisfied` with public-surface evidence (the doc, the `tier-contract-check` tests, the CI step). Must report PASS.
+- [ ] 6.3 roborev: `/roborev-review-branch --base origin/main` clean (run `/roborev-fix` for findings).
+- [ ] 6.4 Push branch, open PR linking #1022; do NOT merge (owner's Seam 2).

--- a/openspec/changes/parity-ci-tier-contracts/tasks.md
+++ b/openspec/changes/parity-ci-tier-contracts/tasks.md
@@ -1,24 +1,24 @@
 # Tasks: parity-ci-tier-contracts
 
 ## 1. Tier contract document
-- [ ] 1.1 Author `docs/development/parity-ci-tiers.md` with one section per tier (`fast_pr`, `required_parity`, `nightly_docker`, `exhaustive_regeneration`, `manual_debug`) covering purpose, allowed `evidence.type`, skip policy, failure policy, artifact-retention expectations, and promotion rules. *Surface exercised:* the doc itself (read by the cross-check in §3).
-- [ ] 1.2 Add the gate-strength classification (smoke / canonical-semantic / byte-for-byte) and map each to `evidence.type` values; state that smoke alone cannot satisfy a P0 data-loss scenario without a recorded gap.
-- [ ] 1.3 Embed a single strictly-formatted, machine-parseable tier list (table or fenced block) that the cross-check reads as "the documented enum" (design D2).
+- [x] 1.1 Author `docs/development/parity-ci-tiers.md` with one section per tier (`fast_pr`, `required_parity`, `nightly_docker`, `exhaustive_regeneration`, `manual_debug`) covering purpose, allowed `evidence.type`, skip policy, failure policy, artifact-retention expectations, and promotion rules. *Surface exercised:* the doc itself (read by the cross-check in §3).
+- [x] 1.2 Add the gate-strength classification (smoke / canonical-semantic / byte-for-byte) and map each to `evidence.type` values; state that smoke alone cannot satisfy a P0 data-loss scenario without a recorded gap.
+- [x] 1.3 Embed a single strictly-formatted, machine-parseable tier list (table or fenced block) that the cross-check reads as "the documented enum" (design D2).
 
 ## 2. Release checklist document
-- [ ] 2.1 Author `docs/development/parity-release-checklist.md` with explicit check items: manifest lint green, `required_parity` green on the release commit, recent `nightly_docker` pass, recent `exhaustive_regeneration` pass for RCs, and a no-unqualified-"same-tests-as-Cassandra"-claims check.
-- [ ] 2.2 Link the Cassandra test index (`docs/cassandra_test_index.md`), the assessment report (`docs/reports/cassandra-test-parity-assessment.md`), and the generated parity report.
+- [x] 2.1 Author `docs/development/parity-release-checklist.md` with explicit check items: manifest lint green, `required_parity` green on the release commit, recent `nightly_docker` pass, recent `exhaustive_regeneration` pass for RCs, and a no-unqualified-"same-tests-as-Cassandra"-claims check.
+- [x] 2.2 Link the Cassandra test index (`docs/cassandra_test_index.md`), the assessment report (`docs/reports/cassandra-test-parity-assessment.md`), and the generated parity report.
 
 ## 3. Doc ↔ enum cross-check (CI surface)
-- [ ] 3.1 Add a `cassandra-parity` subcommand (e.g. `tier-contract-check`) that parses the documented enum from `parity-ci-tiers.md` and asserts it equals `enums::CI_TIER` and the manifest schema enum; exits non-zero with the specific divergent tier on mismatch. *Surface exercised:* `cargo run -p cassandra-parity -- tier-contract-check`.
-- [ ] 3.2 Validate that every `ci.tier` used in `test-data/cassandra-parity-manifest.yml` is in the documented enum; report offending scenario ID + tier value on failure.
-- [ ] 3.3 Unit tests: one passing fixture (doc/schema/code agree) and ≥1 drifted fixture per failure mode (doc-vs-code drift, unknown manifest tier). No Docker/datasets/live Cassandra.
+- [x] 3.1 Add a `cassandra-parity` subcommand (e.g. `tier-contract-check`) that parses the documented enum from `parity-ci-tiers.md` and asserts it equals `enums::CI_TIER` and the manifest schema enum; exits non-zero with the specific divergent tier on mismatch. *Surface exercised:* `cargo run -p cassandra-parity -- tier-contract-check`.
+- [x] 3.2 Validate that every `ci.tier` used in `test-data/cassandra-parity-manifest.yml` is in the documented enum; report offending scenario ID + tier value on failure.
+- [x] 3.3 Unit tests: one passing fixture (doc/schema/code agree) and ≥1 drifted fixture per failure mode (doc-vs-code drift, unknown manifest tier). No Docker/datasets/live Cassandra.
 
 ## 4. CI wiring
-- [ ] 4.1 Add a fast-PR workflow step (extend an existing fast-PR job or add a lightweight one) invoking `tier-contract-check`; confirm it needs no Docker, datasets, or live Cassandra.
+- [x] 4.1 Add a fast-PR workflow step (extend an existing fast-PR job or add a lightweight one) invoking `tier-contract-check`; confirm it needs no Docker, datasets, or live Cassandra.
 
 ## 5. Doctrine + docs cross-link
-- [ ] 5.1 Cross-link the tier contract from `CLAUDE.md` and the website `agents-developing/` gate-contract page (same-change doctrine rule).
+- [x] 5.1 Cross-link the tier contract from `CLAUDE.md` and the website `agents-developing/` gate-contract page (same-change doctrine rule).
 
 ## 6. Quality gate (definition of done)
 - [ ] 6.1 Run `scripts/agent-gate.sh` (with `CQLITE_DATASETS_ROOT` → main repo `test-data/datasets`) and paste the AGENT-GATE SUMMARY block verbatim — must PASS.

--- a/openspec/changes/parity-ci-tier-contracts/tasks.md
+++ b/openspec/changes/parity-ci-tier-contracts/tasks.md
@@ -21,7 +21,7 @@
 - [x] 5.1 Cross-link the tier contract from `CLAUDE.md` and the website `agents-developing/` gate-contract page (same-change doctrine rule).
 
 ## 6. Quality gate (definition of done)
-- [ ] 6.1 Run `scripts/agent-gate.sh` (with `CQLITE_DATASETS_ROOT` → main repo `test-data/datasets`) and paste the AGENT-GATE SUMMARY block verbatim — must PASS.
+- [x] 6.1 Run `scripts/agent-gate.sh` (with `CQLITE_DATASETS_ROOT` → main repo `test-data/datasets`) and paste the AGENT-GATE SUMMARY block verbatim — must PASS. (RESULT: PASS on commit bb9c47c8.)
 - [ ] 6.2 Intent audit **C**: run `spec-auditor` anchored to `openspec/changes/parity-ci-tier-contracts/specs/**` — every requirement `satisfied` with public-surface evidence (the doc, the `tier-contract-check` tests, the CI step). Must report PASS.
 - [ ] 6.3 roborev: `/roborev-review-branch --base origin/main` clean (run `/roborev-fix` for findings).
 - [ ] 6.4 Push branch, open PR linking #1022; do NOT merge (owner's Seam 2).

--- a/tools/cassandra-parity/Cargo.toml
+++ b/tools/cassandra-parity/Cargo.toml
@@ -18,3 +18,4 @@ serde = { workspace = true }
 serde_yaml = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
+thiserror = { workspace = true }

--- a/tools/cassandra-parity/src/lib.rs
+++ b/tools/cassandra-parity/src/lib.rs
@@ -6,3 +6,4 @@ pub mod enums;
 pub mod lint;
 pub mod model;
 pub mod report;
+pub mod tier_contract;

--- a/tools/cassandra-parity/src/main.rs
+++ b/tools/cassandra-parity/src/main.rs
@@ -16,24 +16,29 @@ use anyhow::{bail, Context, Result};
 
 use cassandra_parity::lint::Level;
 use cassandra_parity::model::Manifest;
-use cassandra_parity::{coverage, enums, lint, report};
+use cassandra_parity::{coverage, enums, lint, report, tier_contract};
 
 const DEFAULT_MANIFEST: &str = "test-data/cassandra-parity-manifest.yml";
 const DEFAULT_OUTPUT: &str = "docs/reports/cassandra-test-parity.md";
+const DEFAULT_TIER_DOC: &str = "docs/development/parity-ci-tiers.md";
+const DEFAULT_SCHEMA: &str = "test-data/cassandra-parity-manifest.schema.json";
 
 const USAGE: &str = "\
 cassandra-parity — CQLite ↔ Cassandra parity manifest tooling
 
 USAGE:
-  cassandra-parity lint     [--manifest PATH]
-  cassandra-parity coverage [--manifest PATH] [--strict]
-  cassandra-parity report   [--manifest PATH] [--output PATH] [--check] [--json PATH]
+  cassandra-parity lint               [--manifest PATH]
+  cassandra-parity coverage           [--manifest PATH] [--strict]
+  cassandra-parity report             [--manifest PATH] [--output PATH] [--check] [--json PATH]
+  cassandra-parity tier-contract-check [--manifest PATH] [--tier-doc PATH] [--schema PATH]
 ";
 
 struct Args {
     manifest: PathBuf,
     output: PathBuf,
     json: Option<PathBuf>,
+    tier_doc: PathBuf,
+    schema: PathBuf,
     strict: bool,
     check: bool,
 }
@@ -43,6 +48,8 @@ fn parse_args(rest: &[String]) -> Result<Args> {
         manifest: PathBuf::from(DEFAULT_MANIFEST),
         output: PathBuf::from(DEFAULT_OUTPUT),
         json: None,
+        tier_doc: PathBuf::from(DEFAULT_TIER_DOC),
+        schema: PathBuf::from(DEFAULT_SCHEMA),
         strict: false,
         check: false,
     };
@@ -52,6 +59,8 @@ fn parse_args(rest: &[String]) -> Result<Args> {
             "--manifest" => args.manifest = PathBuf::from(next_val(&mut it, "--manifest")?),
             "--output" => args.output = PathBuf::from(next_val(&mut it, "--output")?),
             "--json" => args.json = Some(PathBuf::from(next_val(&mut it, "--json")?)),
+            "--tier-doc" => args.tier_doc = PathBuf::from(next_val(&mut it, "--tier-doc")?),
+            "--schema" => args.schema = PathBuf::from(next_val(&mut it, "--schema")?),
             "--strict" => args.strict = true,
             "--check" => args.check = true,
             other => bail!("unknown argument: {other}\n\n{USAGE}"),
@@ -106,6 +115,7 @@ fn run() -> Result<ExitCode> {
         "lint" => cmd_lint(&args),
         "coverage" => cmd_coverage(&args),
         "report" => cmd_report(&args),
+        "tier-contract-check" => cmd_tier_contract_check(&args),
         "-h" | "--help" | "help" => {
             println!("{USAGE}");
             Ok(ExitCode::SUCCESS)
@@ -138,6 +148,37 @@ fn cmd_lint(args: &Args) -> Result<ExitCode> {
         Ok(ExitCode::SUCCESS)
     } else {
         eprintln!("lint: FAILED — {errors} errors, {warns} warnings");
+        Ok(ExitCode::FAILURE)
+    }
+}
+
+/// Cross-check the documented tier enum (`docs/development/parity-ci-tiers.md`)
+/// against `enums::CI_TIER` and the manifest schema, and validate that every
+/// manifest `ci.tier` is a documented tier. No Docker/datasets/live Cassandra.
+fn cmd_tier_contract_check(args: &Args) -> Result<ExitCode> {
+    let doc = std::fs::read_to_string(&args.tier_doc)
+        .with_context(|| format!("reading tier doc {}", args.tier_doc.display()))?;
+    let schema = std::fs::read_to_string(&args.schema)
+        .with_context(|| format!("reading schema {}", args.schema.display()))?;
+    let manifest = std::fs::read_to_string(&args.manifest)
+        .with_context(|| format!("reading manifest {}", args.manifest.display()))?;
+
+    let report = tier_contract::check(&doc, &schema, enums::CI_TIER, &manifest)
+        .context("running tier-contract cross-check")?;
+
+    if report.ok() {
+        println!(
+            "tier-contract-check: OK — documented enum == code enum == schema enum, \
+             all manifest ci.tier values documented"
+        );
+        Ok(ExitCode::SUCCESS)
+    } else {
+        eprintln!("{}", report.render());
+        eprintln!(
+            "tier-contract-check: FAILED — {} enum divergence(s), {} unknown manifest tier(s)",
+            report.enum_divergences.len(),
+            report.unknown_manifest_tiers.len()
+        );
         Ok(ExitCode::FAILURE)
     }
 }

--- a/tools/cassandra-parity/src/tier_contract.rs
+++ b/tools/cassandra-parity/src/tier_contract.rs
@@ -128,7 +128,9 @@ pub fn schema_tier_enum(schema_json: &str) -> Result<Vec<String>, TierContractEr
         .filter_map(|x| x.as_str().map(str::to_string))
         .collect();
     if tiers.is_empty() {
-        return Err(TierContractError::SchemaEnum("ci.tier enum is empty".to_string()));
+        return Err(TierContractError::SchemaEnum(
+            "ci.tier enum is empty".to_string(),
+        ));
     }
     Ok(tiers)
 }

--- a/tools/cassandra-parity/src/tier_contract.rs
+++ b/tools/cassandra-parity/src/tier_contract.rs
@@ -1,0 +1,220 @@
+//! Cross-check that keeps the parity CI tier enum honest across three sources:
+//! the **documented** enum in `docs/development/parity-ci-tiers.md`, the
+//! `cassandra-parity` code enum ([`crate::enums::CI_TIER`]), and the manifest
+//! schema's `ci.tier` enum. It also validates that every `ci.tier` used in the
+//! manifest YAML is one of the documented tiers.
+//!
+//! No Docker, datasets, or live Cassandra: this reads only text (doc, schema
+//! JSON, manifest YAML) already present in the repository.
+
+use serde::Deserialize;
+use thiserror::Error;
+
+/// The fence language tag marking the machine-parseable documented-enum block
+/// in `parity-ci-tiers.md` (design D2).
+const DOC_FENCE_TAG: &str = "parity-ci-tiers";
+
+/// Errors that prevent the cross-check from running at all (as opposed to a
+/// divergence the check is designed to *report*).
+#[derive(Debug, Error)]
+pub enum TierContractError {
+    /// The documented-enum fenced block could not be located in the doc.
+    #[error(
+        "tier-contract doc is missing its ```{DOC_FENCE_TAG} fenced block \
+         (the machine-parseable documented enum)"
+    )]
+    DocBlockMissing,
+
+    /// The doc's fenced block is present but empty.
+    #[error("tier-contract doc's ```{DOC_FENCE_TAG} block is empty")]
+    DocBlockEmpty,
+
+    /// The schema JSON could not be parsed or lacks the `ci.tier` enum.
+    #[error("could not read ci.tier enum from manifest schema: {0}")]
+    SchemaEnum(String),
+
+    /// The manifest YAML could not be parsed for `id` + `ci.tier`.
+    #[error("could not parse manifest tiers: {0}")]
+    Manifest(String),
+}
+
+/// A single tier present in one source but missing from another.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnumDivergence {
+    pub tier: String,
+    pub present_in: &'static str,
+    pub missing_from: &'static str,
+}
+
+/// A manifest scenario whose `ci.tier` is not a documented tier.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnknownManifestTier {
+    pub scenario_id: String,
+    pub tier: String,
+}
+
+/// Outcome of [`check`]. `ok()` is true only when there are no divergences and
+/// no unknown manifest tiers.
+#[derive(Debug, Default)]
+pub struct Report {
+    pub enum_divergences: Vec<EnumDivergence>,
+    pub unknown_manifest_tiers: Vec<UnknownManifestTier>,
+}
+
+impl Report {
+    /// True when documented, code, and schema enums agree AND every manifest
+    /// `ci.tier` is documented.
+    pub fn ok(&self) -> bool {
+        self.enum_divergences.is_empty() && self.unknown_manifest_tiers.is_empty()
+    }
+
+    /// Human + machine readable summary of every problem found.
+    pub fn render(&self) -> String {
+        if self.ok() {
+            return "tier-contract-check: OK".to_string();
+        }
+        let mut lines = Vec::new();
+        for d in &self.enum_divergences {
+            lines.push(format!(
+                "ENUM-DRIFT tier '{}' present in {} but missing from {}",
+                d.tier, d.present_in, d.missing_from
+            ));
+        }
+        for u in &self.unknown_manifest_tiers {
+            lines.push(format!(
+                "UNKNOWN-MANIFEST-TIER scenario '{}' uses undocumented tier '{}'",
+                u.scenario_id, u.tier
+            ));
+        }
+        lines.join("\n")
+    }
+}
+
+/// Parse the documented tier enum from the fenced ```parity-ci-tiers block.
+///
+/// The block must contain one tier name per non-blank line and nothing else.
+pub fn parse_documented_enum(doc: &str) -> Result<Vec<String>, TierContractError> {
+    let open = format!("```{DOC_FENCE_TAG}");
+    let after = doc
+        .find(&open)
+        .map(|i| i + open.len())
+        .ok_or(TierContractError::DocBlockMissing)?;
+    let rest = &doc[after..];
+    // Skip to the end of the opening fence line, then read until the closing ```.
+    let body_start = rest.find('\n').map(|n| n + 1).unwrap_or(rest.len());
+    let body = &rest[body_start..];
+    let close = body.find("```").ok_or(TierContractError::DocBlockMissing)?;
+    let tiers: Vec<String> = body[..close]
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(str::to_string)
+        .collect();
+    if tiers.is_empty() {
+        return Err(TierContractError::DocBlockEmpty);
+    }
+    Ok(tiers)
+}
+
+/// Read the `ci.tier` enum from the manifest JSON schema.
+pub fn schema_tier_enum(schema_json: &str) -> Result<Vec<String>, TierContractError> {
+    let v: serde_json::Value = serde_json::from_str(schema_json)
+        .map_err(|e| TierContractError::SchemaEnum(e.to_string()))?;
+    let arr = v["$defs"]["scenario"]["properties"]["ci"]["properties"]["tier"]["enum"]
+        .as_array()
+        .ok_or_else(|| TierContractError::SchemaEnum("ci.tier.enum is not an array".to_string()))?;
+    let tiers: Vec<String> = arr
+        .iter()
+        .filter_map(|x| x.as_str().map(str::to_string))
+        .collect();
+    if tiers.is_empty() {
+        return Err(TierContractError::SchemaEnum("ci.tier enum is empty".to_string()));
+    }
+    Ok(tiers)
+}
+
+/// Minimal view of the manifest: just scenario id + declared `ci.tier`.
+/// Permissive on purpose so test fixtures need not be full scenarios.
+#[derive(Debug, Deserialize)]
+struct TierManifest {
+    #[serde(default)]
+    scenarios: Vec<TierScenario>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TierScenario {
+    id: String,
+    ci: TierCi,
+}
+
+#[derive(Debug, Deserialize)]
+struct TierCi {
+    tier: String,
+}
+
+/// Extract `(scenario_id, ci.tier)` pairs from the manifest YAML.
+pub fn manifest_tiers(manifest_yaml: &str) -> Result<Vec<(String, String)>, TierContractError> {
+    let m: TierManifest = serde_yaml::from_str(manifest_yaml)
+        .map_err(|e| TierContractError::Manifest(e.to_string()))?;
+    Ok(m.scenarios.into_iter().map(|s| (s.id, s.ci.tier)).collect())
+}
+
+/// Run the full cross-check across the documented enum, the code enum, the
+/// schema enum, and the manifest's declared tiers.
+pub fn check(
+    doc: &str,
+    schema_json: &str,
+    code_enum: &[&str],
+    manifest_yaml: &str,
+) -> Result<Report, TierContractError> {
+    let documented = parse_documented_enum(doc)?;
+    let schema = schema_tier_enum(schema_json)?;
+    let code: Vec<String> = code_enum.iter().map(|s| s.to_string()).collect();
+
+    let mut report = Report::default();
+
+    // Pairwise set comparison across the three enum sources.
+    compare("documented", &documented, "code", &code, &mut report);
+    compare("code", &code, "documented", &documented, &mut report);
+    compare("documented", &documented, "schema", &schema, &mut report);
+    compare("schema", &schema, "documented", &documented, &mut report);
+    compare("code", &code, "schema", &schema, &mut report);
+    compare("schema", &schema, "code", &code, &mut report);
+
+    // Every manifest ci.tier must be a documented tier.
+    let documented_set: std::collections::HashSet<&str> =
+        documented.iter().map(String::as_str).collect();
+    for (id, tier) in manifest_tiers(manifest_yaml)? {
+        if !documented_set.contains(tier.as_str()) {
+            report.unknown_manifest_tiers.push(UnknownManifestTier {
+                scenario_id: id,
+                tier,
+            });
+        }
+    }
+
+    Ok(report)
+}
+
+/// Record every tier present in `a` (`a_name`) but missing from `b` (`b_name`).
+fn compare(
+    a_name: &'static str,
+    a: &[String],
+    b_name: &'static str,
+    b: &[String],
+    report: &mut Report,
+) {
+    let b_set: std::collections::HashSet<&str> = b.iter().map(String::as_str).collect();
+    for tier in a {
+        if !b_set.contains(tier.as_str()) {
+            let div = EnumDivergence {
+                tier: tier.clone(),
+                present_in: a_name,
+                missing_from: b_name,
+            };
+            if !report.enum_divergences.contains(&div) {
+                report.enum_divergences.push(div);
+            }
+        }
+    }
+}

--- a/tools/cassandra-parity/src/tier_contract.rs
+++ b/tools/cassandra-parity/src/tier_contract.rs
@@ -123,10 +123,17 @@ pub fn schema_tier_enum(schema_json: &str) -> Result<Vec<String>, TierContractEr
     let arr = v["$defs"]["scenario"]["properties"]["ci"]["properties"]["tier"]["enum"]
         .as_array()
         .ok_or_else(|| TierContractError::SchemaEnum("ci.tier.enum is not an array".to_string()))?;
-    let tiers: Vec<String> = arr
-        .iter()
-        .filter_map(|x| x.as_str().map(str::to_string))
-        .collect();
+    let mut tiers: Vec<String> = Vec::with_capacity(arr.len());
+    for x in arr {
+        match x.as_str() {
+            Some(s) => tiers.push(s.to_string()),
+            None => {
+                return Err(TierContractError::SchemaEnum(format!(
+                    "ci.tier enum contains a non-string entry: {x}"
+                )))
+            }
+        }
+    }
     if tiers.is_empty() {
         return Err(TierContractError::SchemaEnum(
             "ci.tier enum is empty".to_string(),

--- a/tools/cassandra-parity/tests/tier_contract_tests.rs
+++ b/tools/cassandra-parity/tests/tier_contract_tests.rs
@@ -93,10 +93,8 @@ fn doc_vs_code_drift_fails_with_specific_tier() {
 #[test]
 fn doc_vs_schema_drift_fails() {
     // Schema has an extra tier the doc does not document.
-    let drifted_schema = GOOD_SCHEMA.replace(
-        r#""manual_debug"]"#,
-        r#""manual_debug", "rogue_tier"]"#,
-    );
+    let drifted_schema =
+        GOOD_SCHEMA.replace(r#""manual_debug"]"#, r#""manual_debug", "rogue_tier"]"#);
     let report = tier_contract::check(GOOD_DOC, &drifted_schema, enums::CI_TIER, "scenarios: []")
         .expect("check runs");
     assert!(!report.ok());

--- a/tools/cassandra-parity/tests/tier_contract_tests.rs
+++ b/tools/cassandra-parity/tests/tier_contract_tests.rs
@@ -1,0 +1,137 @@
+//! Tests for the doc <-> schema <-> code tier-enum cross-check.
+//!
+//! No Docker, datasets, or live Cassandra: every fixture is an inline string.
+
+use cassandra_parity::enums;
+use cassandra_parity::tier_contract::{self, TierContractError};
+
+/// A documented-enum fenced block that agrees with the code enum.
+const GOOD_DOC: &str = "\
+# Parity CI Tier Contracts
+
+intro prose
+
+```parity-ci-tiers
+fast_pr
+required_parity
+nightly_docker
+exhaustive_regeneration
+manual_debug
+```
+
+trailing prose
+";
+
+/// A schema fragment carrying the same five tiers.
+const GOOD_SCHEMA: &str = r#"{
+  "$defs": {
+    "scenario": {
+      "properties": {
+        "ci": {
+          "properties": {
+            "tier": { "enum": ["fast_pr", "required_parity", "nightly_docker", "exhaustive_regeneration", "manual_debug"] }
+          }
+        }
+      }
+    }
+  }
+}"#;
+
+fn manifest_with_tiers(tiers: &[&str]) -> String {
+    let mut s = String::from("scenarios:\n");
+    for (i, t) in tiers.iter().enumerate() {
+        s.push_str(&format!(
+            "  - id: cass.sstable_format.s{i}\n    ci:\n      tier: {t}\n"
+        ));
+    }
+    s
+}
+
+#[test]
+fn parses_documented_enum_from_fenced_block() {
+    let parsed = tier_contract::parse_documented_enum(GOOD_DOC).expect("block parses");
+    assert_eq!(
+        parsed,
+        vec![
+            "fast_pr",
+            "required_parity",
+            "nightly_docker",
+            "exhaustive_regeneration",
+            "manual_debug"
+        ]
+    );
+}
+
+#[test]
+fn missing_fenced_block_is_an_error() {
+    let err = tier_contract::parse_documented_enum("# no block here\n").unwrap_err();
+    assert!(matches!(err, TierContractError::DocBlockMissing));
+}
+
+#[test]
+fn passing_fixture_all_three_agree() {
+    let manifest = manifest_with_tiers(&["fast_pr", "required_parity"]);
+    let report =
+        tier_contract::check(GOOD_DOC, GOOD_SCHEMA, enums::CI_TIER, &manifest).expect("check runs");
+    assert!(report.ok(), "expected pass, got: {report:#?}");
+}
+
+#[test]
+fn doc_vs_code_drift_fails_with_specific_tier() {
+    // Doc is missing `manual_debug` -> drift vs the code enum.
+    let drifted_doc = GOOD_DOC.replace("manual_debug\n", "");
+    let report = tier_contract::check(&drifted_doc, GOOD_SCHEMA, enums::CI_TIER, "scenarios: []")
+        .expect("check runs");
+    assert!(!report.ok());
+    let rendered = report.render();
+    assert!(
+        rendered.contains("manual_debug"),
+        "should name the divergent tier, got: {rendered}"
+    );
+}
+
+#[test]
+fn doc_vs_schema_drift_fails() {
+    // Schema has an extra tier the doc does not document.
+    let drifted_schema = GOOD_SCHEMA.replace(
+        r#""manual_debug"]"#,
+        r#""manual_debug", "rogue_tier"]"#,
+    );
+    let report = tier_contract::check(GOOD_DOC, &drifted_schema, enums::CI_TIER, "scenarios: []")
+        .expect("check runs");
+    assert!(!report.ok());
+    assert!(report.render().contains("rogue_tier"));
+}
+
+#[test]
+fn unknown_manifest_tier_fails_with_scenario_and_value() {
+    let manifest = manifest_with_tiers(&["fast_pr", "bogus_tier"]);
+    let report =
+        tier_contract::check(GOOD_DOC, GOOD_SCHEMA, enums::CI_TIER, &manifest).expect("check runs");
+    assert!(!report.ok());
+    let rendered = report.render();
+    assert!(rendered.contains("bogus_tier"), "got: {rendered}");
+    assert!(
+        rendered.contains("cass.sstable_format.s1"),
+        "should name offending scenario id, got: {rendered}"
+    );
+}
+
+#[test]
+fn real_doc_schema_code_and_manifest_agree() {
+    let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    let doc = std::fs::read_to_string(root.join("docs/development/parity-ci-tiers.md")).unwrap();
+    let schema =
+        std::fs::read_to_string(root.join("test-data/cassandra-parity-manifest.schema.json"))
+            .unwrap();
+    let manifest =
+        std::fs::read_to_string(root.join("test-data/cassandra-parity-manifest.yml")).unwrap();
+    let report = tier_contract::check(&doc, &schema, enums::CI_TIER, &manifest)
+        .expect("real cross-check runs");
+    assert!(report.ok(), "real tier contract drift: {}", report.render());
+}

--- a/tools/cassandra-parity/tests/tier_contract_tests.rs
+++ b/tools/cassandra-parity/tests/tier_contract_tests.rs
@@ -116,6 +116,28 @@ fn unknown_manifest_tier_fails_with_scenario_and_value() {
 }
 
 #[test]
+fn non_string_schema_enum_entry_is_an_error() {
+    // A widened/malformed schema enum mixing strings with a `null` and an
+    // integer must be rejected outright, not silently filtered down to the
+    // valid strings (which would defeat the doc<->schema<->code guarantee).
+    let bad_schema = GOOD_SCHEMA.replace(r#""manual_debug"]"#, r#""manual_debug", null, 42]"#);
+
+    // The low-level parser surfaces the schema-enum error directly.
+    let err = tier_contract::schema_tier_enum(&bad_schema).unwrap_err();
+    assert!(
+        matches!(err, TierContractError::SchemaEnum(_)),
+        "expected SchemaEnum error, got: {err:?}"
+    );
+
+    // And the full cross-check refuses to run rather than passing.
+    let result = tier_contract::check(GOOD_DOC, &bad_schema, enums::CI_TIER, "scenarios: []");
+    assert!(
+        matches!(result, Err(TierContractError::SchemaEnum(_))),
+        "cross-check must fail with SchemaEnum, got: {result:?}"
+    );
+}
+
+#[test]
 fn real_doc_schema_code_and_manifest_agree() {
     let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -120,8 +120,8 @@ the same asset CI uses. Current pins (as of the script source):
 
 ```
 DATASET_TAG:    datasets-v3
-DATASET_ASSET:  cassandra5-small-full-v3.1.tar.gz
-DATASET_SHA256: f5fa0b6599a27c1c493d7c6c063194d55d031cab417396947313e7245afc5ceb
+DATASET_ASSET:  cassandra5-small-full-v3.2.tar.gz
+DATASET_SHA256: bebc763752c8d68c7fb0483a1b31294b4d1d21343d3f7d124da069e5073202fa
 ```
 
 See [Test data](/cqlite/agents-developing/test-data/) for how `fetch-datasets.sh` uses these pins and why

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -98,6 +98,20 @@ RESULT: PARTIAL
 ==== END AGENT-GATE SUMMARY ====
 ```
 
+## Parity CI tier contracts
+
+The agent gate proves a change is *correct*; the **parity CI tiers** define what
+each Cassandra-parity gate *promises*. The two are read together: see
+`docs/development/parity-ci-tiers.md` for the per-tier contract (purpose, accepted
+`evidence.type`, skip/failure policy, artifact retention, promotion rules) and the
+gate-strength classification — **smoke** vs **canonical-semantic** vs
+**byte-for-byte** — that bounds what a green gate can claim. Smoke alone cannot
+satisfy a P0 data-loss scenario without a recorded gap. Before publishing a broad
+public parity claim, run `docs/development/parity-release-checklist.md`. A
+fast-PR cross-check (`cargo run -p cassandra-parity -- tier-contract-check`) keeps
+the documented tier enum in sync with the code (`enums::CI_TIER`) and the manifest
+schema (issue #1022).
+
 ## CI parity
 
 The gate reads dataset pins from `.github/workflows/sstabledump-parity-gate.yml`


### PR DESCRIPTION
Closes #1022. Epic #974 (Public Claims and CI Gates). Design-driven (OpenSpec change `parity-ci-tier-contracts`).

## What
Defines the public contract for each Cassandra parity CI tier and a release checklist gating public parity claims.

- **`docs/development/parity-ci-tiers.md`** — per-tier contract (purpose, allowed `evidence.type`, skip policy, failure policy, artifact retention, promotion rules) for all five tiers (`fast_pr`, `required_parity`, `nightly_docker`, `exhaustive_regeneration`, `manual_debug`); gate-strength taxonomy (smoke / canonical-semantic / byte-for-byte) mapped to `evidence.type`; the P0-data-loss-needs-recorded-gap rule; and a machine-parseable documented-enum block (design D2).
- **`docs/development/parity-release-checklist.md`** — required-green-gate checklist (manifest lint, `required_parity` on the release commit, recent `nightly_docker`, RC `exhaustive_regeneration`), a no-unqualified-"same-tests-as-Cassandra"-claim gate, and links to the test index, assessment report, and generated parity report.
- **`cassandra-parity tier-contract-check`** — new subcommand cross-checking the documented enum == `enums::CI_TIER` == schema enum, and that every manifest `ci.tier` is documented; fails non-zero naming the divergent tier / offending scenario. No Docker/datasets/live Cassandra. 7 unit tests (passing fixture + drift/unknown-tier failure modes).
- Fast-PR CI step in `cassandra-parity.yml`; doctrine cross-links in `CLAUDE.md` + the website gate-contract page.

Non-goals: no new parity tests, no parity-failure fixes, no GitHub releases, no change to the tier enum values.

## Quality gates
- **agent-gate.sh: PASS** (all 12 components green).
- **Intent audit (C): PASS** — all 4 requirements / 8 scenarios satisfied with public-surface evidence.
- **roborev: clean** — the one High finding (claimed `{DOC_FENCE_TAG}` won't compile under thiserror 1.0.69) was verified as a false positive (clean build, 7 passing tests, green gate; `DOC_FENCE_TAG` is an in-scope const resolved via implicit format-arg capture) and closed with evidence (job 1485).

🤖 Generated with [Claude Code](https://claude.com/claude-code)