### PR TITLE
fix(flow): gh auth checks must not inherit pipefail from a bad enterprise host token

### DIFF
--- a/test-data/scripts/cloud-setup.sh
+++ b/test-data/scripts/cloud-setup.sh
@@ -46,8 +46,12 @@ fi
 echo "    gh present: $(gh --version 2>/dev/null | head -n1)"
 # Presence is not enough — the flow commands (issues, PRs, Projects) fail immediately
 # if gh is unauthenticated, so verify auth and fail loud rather than report ready (roborev).
-if ! auth_out="$(gh auth status 2>&1)"; then
-  echo "error: gh is not authenticated — flow-* (issues/PRs/Projects) will fail." >&2
+# Don't rely on `gh auth status` exit code — it returns nonzero when ANY configured
+# host has a bad token (e.g. a stale enterprise keyring entry) even though the host
+# we need is fine. Capture the output and check for a github.com login by string.
+auth_out="$(gh auth status 2>&1 || true)"
+if ! printf '%s' "${auth_out}" | grep -q "Logged in to github.com"; then
+  echo "error: gh is not authenticated to github.com — flow-* (issues/PRs/Projects) will fail." >&2
   printf '%s\n' "${auth_out}" >&2
   echo "       Authenticate: gh auth login   (and for the claim board: gh auth refresh -s project)" >&2
   exit 1

--- a/test-data/scripts/setup-project-board.sh
+++ b/test-data/scripts/setup-project-board.sh
@@ -35,7 +35,12 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 # The `project` scope is required for every Projects v2 read/write below.
-if ! gh auth status 2>&1 | grep -q "'project'"; then
+# Capture the output and string-match it — do NOT pipe `gh auth status` directly
+# under `set -o pipefail`: it exits nonzero when ANY configured host has a bad
+# token (e.g. a stale enterprise keyring entry), which would poison the pipeline
+# and make a present scope look missing.
+auth_status="$(gh auth status 2>&1 || true)"
+if ! printf '%s' "${auth_status}" | grep -q "'project'"; then
   echo "error: gh token is missing the 'project' scope." >&2
   echo "       Run: gh auth refresh -s project" >&2
   exit 1


### PR DESCRIPTION
setup-project-board.sh and cloud-setup.sh treated `gh auth status` exit code as authoritative, but it returns nonzero when ANY configured host has a bad token (e.g. a stale enterprise keyring entry) even when github.com is fine — under `set -o pipefail` this made a present `project` scope read as missing and blocked board setup. Capture the output (`|| true`) and string-match it. Verified the scope check now passes in the real multi-host env. Script-only.