### PR TITLE
feat(flow): wire claim board env + SessionStart board-on-start hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,9 @@
   "agent": "flow-lead",
   "env": {
     "ISSUE_GATE_TEST_CMD": "scripts/agent-gate.sh",
-    "ISSUE_GATE_COVERAGE_CMD": ""
+    "ISSUE_GATE_COVERAGE_CMD": "",
+    "CQLITE_PROJECT_OWNER": "pmcfadin",
+    "CQLITE_PROJECT_NUMBER": "1"
   },
   "permissions": {
     "allow": [
@@ -51,6 +53,16 @@
   },
   "includeCoAuthoredBy": false,
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo 'flow-lead: before anything else, orient — run the flow-board skill to render the CQLite Delivery claim board (open issues by Status + claims) and surface the single furthest-along item waiting on the owner (a green PR to merge, a spec to approve), or a claim-aware pick-list. Do not wait for a prompt.'"
+          }
+        ]
+      }
+    ],
     "TaskCompleted": [
       {
         "hooks": [


### PR DESCRIPTION
Setup steps #1 and #3 for the delivery pipeline:
- `.claude/settings.json` env: CQLITE_PROJECT_OWNER=pmcfadin + CQLITE_PROJECT_NUMBER=1 → flow-* skills target the live 'CQLite Delivery' Project #1 on every machine.
- SessionStart hook: nudges flow-lead to run flow-board first, so plain `claude` greets with the board instead of a blank prompt.

Config-only; JSON validated. NOTE: roborev could not run (its codex backend returned 401 Unauthorized — infra, not a finding); merging the verified trivial config per request, will re-review when roborev auth is restored.