### PR TITLE
fix(#1151): golden-gen sstabledump against exported fixtures, not live container

### DIFF
--- a/test-data/scripts/generate-deltas.sh
+++ b/test-data/scripts/generate-deltas.sh
@@ -419,16 +419,20 @@ generate_sstabledump_jsonl() {
   log "Generating sstabledump JSONL golden files for test_deltas..."
   while IFS= read -r -d '' data_file; do
     local rel
+    # Path relative to the export root ($sstables_dir), mounted at /data in a
+    # fresh --rm container. We dump the EXPORTED file, not the live container's
+    # mutable data dir, so auto-compaction in the live container cannot delete
+    # the freshly-flushed generation out from under us (issue #1151).
     rel="${data_file#"$sstables_dir"/}"
-    # Strip "data/" prefix (the archive was created from /var/lib/cassandra)
-    local rel_sstabledump="${rel#data/}"
     local jsonl_file="${data_file%.db}.db.jsonl"
     log "  sstabledump: $rel"
     if [[ "$DRY_RUN" -eq 1 ]]; then
-      echo "[dry-run] sstabledump $data_file > $jsonl_file"
+      echo "[dry-run] $ENGINE run --rm -v $sstables_dir:/data $CASSANDRA_IMAGE sstabledump /data/${rel} -l > $jsonl_file"
     else
-      $ENGINE exec "$CONTAINER_NAME" bash -lc \
-        "/opt/cassandra/tools/bin/sstabledump /var/lib/cassandra/data/${rel_sstabledump} -l" \
+      $ENGINE run --rm \
+        -v "$sstables_dir:/data" \
+        "$CASSANDRA_IMAGE" \
+        bash -lc "/opt/cassandra/tools/bin/sstabledump /data/${rel} -l" \
         | python3 -c "
 import json, sys
 try:
@@ -503,6 +507,11 @@ apply_schema "$ROOT/schemas/deltas.cql"
 
 # Insert all rows
 insert_deltas_rows
+
+# Disable autocompaction so the freshly-flushed nb-1-big generation cannot be
+# compacted away between export and the per-table sstabledump loop (issue #1151).
+log "Disabling autocompaction for test_deltas..."
+run $ENGINE exec "$CONTAINER_NAME" nodetool disableautocompaction "test_deltas"
 
 # Flush all tables to produce SSTables
 log "Flushing test_deltas keyspace to SSTables..."

--- a/test-data/scripts/generate-tombstone-parity.sh
+++ b/test-data/scripts/generate-tombstone-parity.sh
@@ -552,15 +552,20 @@ generate_sstabledump_jsonl() {
   log "Generating sstabledump JSONL golden files for $KEYSPACE..."
   while IFS= read -r -d '' data_file; do
     local rel
+    # Path relative to the export root ($sstables_dir), mounted at /data in a
+    # fresh --rm container. We dump the EXPORTED file, not the live container's
+    # mutable data dir, so auto-compaction in the live container cannot delete
+    # the freshly-flushed generation out from under us (issue #1151).
     rel="${data_file#"$sstables_dir"/}"
-    local rel_sstabledump="${rel#data/}"
     local jsonl_file="${data_file%.db}.db.jsonl"
     log "  sstabledump: $rel"
     if [[ "$DRY_RUN" -eq 1 ]]; then
-      echo "[dry-run] sstabledump $data_file > $jsonl_file"
+      echo "[dry-run] $ENGINE run --rm -v $sstables_dir:/data $CASSANDRA_IMAGE sstabledump /data/${rel} -l > $jsonl_file"
     else
-      $ENGINE exec "$CONTAINER_NAME" bash -lc \
-        "/opt/cassandra/tools/bin/sstabledump /var/lib/cassandra/data/${rel_sstabledump} -l" \
+      $ENGINE run --rm \
+        -v "$sstables_dir:/data" \
+        "$CASSANDRA_IMAGE" \
+        bash -lc "/opt/cassandra/tools/bin/sstabledump /data/${rel} -l" \
         | python3 -c "
 import json, sys
 try:
@@ -639,6 +644,10 @@ apply_schema "$ROOT/schemas/tombstone-parity.cql"
 # Generation 1: live data + single-flush tombstone shapes.
 # ---------------------------------------------------------------------------
 run_gen1
+# Disable autocompaction so freshly-flushed generations cannot be compacted away
+# between export and the per-table sstabledump loop (issue #1151).
+log "Disabling autocompaction for $KEYSPACE..."
+run $ENGINE exec "$CONTAINER_NAME" nodetool disableautocompaction "$KEYSPACE"
 flush_generation "gen-1"
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
The `Tombstone / TTL parity (regenerate + require-fixtures)` Docker lane fails reproducibly on `main` (red since the 870f4dde run, 2026-06-27): golden-gen reports `Cannot find file /var/lib/cassandra/data/test_deltas/partial_updates-29b5e680…/nb-1-big-Data.db` and exits 1. Closes #1151.

## Root cause
`generate_sstabledump_jsonl()` in both fixture generators ran `sstabledump` via `$ENGINE exec "$CONTAINER" … /var/lib/cassandra/data/<rel>` — i.e. against the **live** container's mutable data dir, with `<rel>` derived from the **tar-exported** file list. Cassandra can auto-compact the freshly-flushed `nb-1-big` generation away between the tar snapshot and the per-table `sstabledump` loop (`partial_updates` is table [8], processed late, and is UPDATE-heavy → quick STCS trigger). Once the old generation is gone from the live container, `sstabledump` fails. The Statistics.db.txt step right below was already robust — it mounts the **exported** dir into a fresh `--rm` container.

## Fix
- `generate_sstabledump_jsonl()` in **both** `test-data/scripts/generate-deltas.sh` and `generate-tombstone-parity.sh` now runs `sstabledump` against the **exported** files via a mounted `--rm` container (`-v "$SSTABLES_DIR:/data" … sstabledump /data/<rel> -l`), mirroring the existing Statistics.db.txt step. This removes the dependency on live-container mutable state entirely.
- Belt-and-suspenders: `nodetool disableautocompaction <keyspace>` before `nodetool flush` in both scripts, so the exported `nb-1-big` generation is deterministic.

## Validation
- `bash -n` clean on both scripts; dry-run confirms the command targets the mounted export, not `/var/lib/cassandra/data`.
- Real validation is **this lane** — the workflow is path-filtered to the generators, so this PR runs the exact lane that was red. Watching `Tombstone / TTL parity (regenerate + require-fixtures)`.

Oracle-driven fix (no OpenSpec). No Rust touched → `agent-gate.sh` gives no signal here; the Docker lane is the gate.