### PR TITLE
fix(read): run windowed scan parse off the async worker pool (#1143)

### DIFF
--- a/cqlite-core/Cargo.toml
+++ b/cqlite-core/Cargo.toml
@@ -298,5 +298,15 @@ delta-scan = []
 # adds overhead). See docs/profiling.md.
 dhat-heap = []
 
+# Scan-offload thread-identity probe (issue #1143 regression guard). TEST-ONLY,
+# NOT in defaults: gates the `scan_stream_windowed::probe` module, the pub
+# visibility of `scan_stream_windowed`, and the single `record_parse_thread()`
+# call-site in the windowed parse half. With this OFF, no probe code, statics, or
+# public surface compile into the build — verify with
+# `cargo build -p cqlite-core` that nothing probe-related is referenced. The
+# guard test (tests/issue_1143_scan_offload_thread.rs) only compiles under this
+# feature; the agent gate runs it via a dedicated component.
+scan-offload-probe = []
+
 [lints]
 workspace = true

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -27,8 +27,8 @@ mod key_digest;
 pub(crate) mod parsing; // Needs to be accessible from row_cell_state_machine
 mod partition_lookup;
 /// Sliding-window stitch+parse driver for the user-facing streaming scan
-/// (issue #1143); extracted from `data_access` per epic #1116.
-mod scan_stream_windowed;
+/// (issue #1143); `pub` only to expose `scan_stream_windowed::probe` (#1143 guard).
+pub mod scan_stream_windowed;
 mod source;
 #[cfg(test)]
 mod tests;

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -26,8 +26,11 @@ mod integrity;
 mod key_digest;
 pub(crate) mod parsing; // Needs to be accessible from row_cell_state_machine
 mod partition_lookup;
-/// Sliding-window stitch+parse driver for the user-facing streaming scan
-/// (issue #1143); `pub` only to expose `scan_stream_windowed::probe` (#1143 guard).
+// Windowed streaming-scan driver (issue #1143); `pub` ONLY under non-default
+// `scan-offload-probe` so the #1143 guard reaches its probe, else private.
+#[cfg(not(feature = "scan-offload-probe"))]
+mod scan_stream_windowed;
+#[cfg(feature = "scan-offload-probe")]
 pub mod scan_stream_windowed;
 mod source;
 #[cfg(test)]

--- a/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
+++ b/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
@@ -65,6 +65,26 @@ use tokio::sync::mpsc;
 /// `max_partition_size + (RAW_CHUNK_CHANNEL_CAP + 1) * one_chunk`.
 const RAW_CHUNK_CHANNEL_CAP: usize = 2;
 
+/// Decide whether the blocking parse half should run its terminal
+/// (`at_final_chunk = true`) drain once the raw-chunk stream has ended.
+///
+/// The terminal drain parses the trailing window AS IF it were a complete final
+/// partition (it collapses `NeedMore` → `Done`). That is correct only on a CLEAN
+/// EOF. If the I/O half stopped on a mid-stream read error it sets `io_failed`
+/// before dropping the raw-chunk sender, so the trailing window is a TRUNCATED
+/// fragment; running the terminal drain on it would emit a spurious/garbage
+/// partition through `tx` BEFORE the caller surfaces the I/O `Err` (issue #1143
+/// finding 2). Skipping it makes a truncated/corrupt stream yield ONLY the error.
+///
+/// Pulled out as a tiny pure function so the drain-skip decision is unit-tested
+/// directly (issue #1143 finding 1): a future refactor that drops the flag,
+/// flips the load, or reorders the store-before-`drop(raw_tx)` must fail
+/// [`tests::terminal_drain_skipped_iff_io_failed`].
+#[inline]
+fn should_run_terminal_drain(io_failed: bool) -> bool {
+    !io_failed
+}
+
 /// Inputs the blocking parse half needs that the I/O half resolves once up front
 /// (so the blocking task does not have to touch the async runtime).
 struct WindowParseCtx {
@@ -235,7 +255,7 @@ impl SSTableReader {
         // stream yields ONLY the error (issue #1143 finding 2). The store in the
         // I/O half happens-before the `drop(raw_tx)` that ended `blocking_recv`,
         // so this load observes it.
-        if !broke && !io_failed.load(Ordering::SeqCst) {
+        if !broke && should_run_terminal_drain(io_failed.load(Ordering::SeqCst)) {
             self.drain_scan_window(&parser, &ctx, &mut window, true, &tx, &mut broke)?;
         }
 
@@ -401,5 +421,216 @@ pub mod probe {
     /// The [`ThreadId`] recorded by the most recent parse, if any.
     pub fn recorded_parse_thread() -> Option<ThreadId> {
         LAST_PARSE_THREAD.lock().ok().and_then(|g| *g)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Issue #1143 finding 2 — pure decision guard. The blocking parse half runs
+    /// its terminal (`at_final_chunk = true`) drain IFF the I/O half did NOT fail
+    /// mid-stream. This pins the truth table the call site in
+    /// [`SSTableReader::drain_scan_window_blocking`] depends on; a refactor that
+    /// drops the flag, flips the load, or inverts the condition flips one of these
+    /// assertions and fails the build.
+    #[test]
+    fn terminal_drain_skipped_iff_io_failed() {
+        // Clean EOF (io_failed == false): run the terminal drain so a trailing
+        // partition with no END_OF_PARTITION marker is emitted (Done, not a
+        // refill request that will never come).
+        assert!(
+            should_run_terminal_drain(false),
+            "clean EOF must run the terminal drain (else the last partition is dropped)"
+        );
+        // Mid-stream read error (io_failed == true): SKIP the terminal drain so
+        // the truncated trailing window cannot surface a spurious/garbage
+        // partition before the caller returns the I/O Err.
+        assert!(
+            !should_run_terminal_drain(true),
+            "Issue #1143: a mid-stream I/O failure MUST skip the terminal drain so a \
+             truncated window emits no spurious trailing partition"
+        );
+    }
+
+    // Real-behavior guard (issue #1143 finding 2): drive the private blocking
+    // parse half (`drain_scan_window_blocking`) directly over a genuinely
+    // multi-chunk fixture, with the SAME truncated input, toggling ONLY
+    // `io_failed`. With `io_failed = false` the terminal drain parses the
+    // truncated trailing window and emits an extra (final) partition; with
+    // `io_failed = true` that terminal drain is skipped, so it emits strictly
+    // fewer rows. This proves the skip is the `io_failed` gate's doing, not a
+    // side effect — and it fails if the gate is removed (both runs would then
+    // emit the same trailing partition).
+    //
+    // Dataset-dependent: skips when the fixture's Data.db is absent (matches the
+    // other #1143 integration guards). The pure `terminal_drain_skipped_iff_io_failed`
+    // test above runs dataset-independently in every gate, so the gate is never
+    // vacuous even without fetched data.
+    mod fixture_drain {
+        use super::*;
+        use crate::storage::sstable::SSTableReader;
+        use std::path::PathBuf;
+        use tokio::io::AsyncSeekExt;
+
+        const KEYSPACE: &str = "test_wide_rows";
+        const TABLE: &str = "wide_partition_table";
+
+        fn datasets_root() -> Option<PathBuf> {
+            std::env::var("CQLITE_DATASETS_ROOT")
+                .ok()
+                .map(PathBuf::from)
+                .filter(|p| p.exists())
+        }
+
+        fn fixture_data_db() -> Option<PathBuf> {
+            let table_root = datasets_root()?.join("sstables").join(KEYSPACE);
+            for entry in std::fs::read_dir(&table_root).ok()?.flatten() {
+                let name = entry.file_name();
+                if name.to_string_lossy().starts_with(&format!("{TABLE}-")) && entry.path().is_dir()
+                {
+                    for f in std::fs::read_dir(entry.path()).ok()?.flatten() {
+                        if f.file_name()
+                            .to_str()
+                            .is_some_and(|n| n.ends_with("-Data.db"))
+                        {
+                            return Some(f.path());
+                        }
+                    }
+                }
+            }
+            None
+        }
+
+        /// Collect every raw compressed chunk of the data section, in order, the
+        /// way `run_scan_stream_windowed`'s I/O half would feed them.
+        async fn collect_raw_chunks(reader: &SSTableReader) -> Vec<Vec<u8>> {
+            let cursor = reader.new_scan_cursor().await.expect("scan cursor");
+            let header_size = reader.calculate_header_size();
+            {
+                let mut g = cursor.file.lock().await;
+                g.seek(std::io::SeekFrom::Start(header_size as u64))
+                    .await
+                    .expect("seek to data section");
+            }
+            let mut chunks = Vec::new();
+            while let Some(c) = reader.read_next_block(&cursor).await.expect("read chunk") {
+                chunks.push(c);
+            }
+            chunks
+        }
+
+        /// Run the blocking parse half over `chunks` with the given `io_failed`,
+        /// returning the number of `(RowKey, Value)` entries it emitted. Runs on
+        /// the current thread (the function is synchronous); the bounded channel
+        /// is pre-filled and its sender dropped so `blocking_recv` never blocks.
+        fn drain_count(reader: &SSTableReader, chunks: &[Vec<u8>], io_failed: bool) -> usize {
+            let ctx = WindowParseCtx {
+                table_id: TableId::new(format!(
+                    "{}.{}",
+                    reader.header.keyspace, reader.header.table_name
+                )),
+                start_key: None,
+                end_key: None,
+                schema: reader.get_table_schema(None),
+                max_compressed_length: reader
+                    .compression_info
+                    .as_ref()
+                    .map(|ci| ci.max_compressed_length as usize)
+                    .unwrap_or(usize::MAX),
+            };
+            // Feed raw chunks through an unbounded->bounded-shaped channel large
+            // enough to hold them all, then drop the sender so the parse half sees
+            // a CLEAN close; the `io_failed` flag (not the close reason) drives the
+            // terminal-drain decision under test.
+            let (raw_tx, raw_rx) = mpsc::channel::<Vec<u8>>(chunks.len().max(1));
+            for c in chunks {
+                raw_tx.try_send(c.clone()).expect("prefill raw chunk");
+            }
+            drop(raw_tx);
+            // Output channel: big enough that `blocking_send` never blocks here.
+            let (out_tx, mut out_rx) = mpsc::channel::<Result<(RowKey, Value)>>(4096);
+            let flag = Arc::new(AtomicBool::new(io_failed));
+            reader
+                .drain_scan_window_blocking(ctx, raw_rx, out_tx, flag)
+                .expect("drain_scan_window_blocking");
+            let mut n = 0usize;
+            while out_rx.try_recv().is_ok() {
+                n += 1;
+            }
+            n
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn io_failed_skips_terminal_drain_on_truncated_window() {
+            let Some(data_db) = fixture_data_db() else {
+                eprintln!(
+                    "Skipping {KEYSPACE}.{TABLE}: no Data.db present (run fetch-datasets.sh). \
+                     The pure terminal_drain_skipped_iff_io_failed guard still runs."
+                );
+                return;
+            };
+
+            let cfg = crate::Config::default();
+            let platform = Arc::new(
+                crate::platform::Platform::new(&cfg)
+                    .await
+                    .expect("platform"),
+            );
+            let reader = SSTableReader::open(&data_db, &cfg, platform)
+                .await
+                .expect("open reader");
+            // The fixture must be chunk-compressed (the windowed path's
+            // precondition); `collect_raw_chunks` below reads >1 raw chunk only
+            // for a multi-chunk compressed Data.db, which the assert enforces.
+            assert!(
+                reader.compression_info.is_some(),
+                "fixture must be compressed to exercise the windowed chunk-stitching path"
+            );
+
+            let chunks = collect_raw_chunks(&reader).await;
+            assert!(
+                chunks.len() > 1,
+                "Issue #1143: need a multi-chunk fixture so dropping the last chunk \
+                 leaves a non-empty truncated trailing window ({} chunk(s))",
+                chunks.len()
+            );
+
+            // Drop the LAST raw chunk to simulate a mid-stream truncation: the
+            // trailing window now holds a PARTIAL final partition that the
+            // terminal drain would otherwise parse and emit.
+            let truncated = &chunks[..chunks.len() - 1];
+
+            // The blocking parse half is synchronous; run it off the async runtime
+            // via spawn_blocking (it uses blocking_recv/blocking_send).
+            let reader = Arc::new(reader);
+            let r1 = Arc::clone(&reader);
+            let t1 = truncated.to_vec();
+            let clean = tokio::task::spawn_blocking(move || drain_count(&r1, &t1, false))
+                .await
+                .expect("clean drain task");
+            let r2 = Arc::clone(&reader);
+            let t2 = truncated.to_vec();
+            let failed = tokio::task::spawn_blocking(move || drain_count(&r2, &t2, true))
+                .await
+                .expect("failed drain task");
+
+            eprintln!(
+                "Issue #1143 terminal-drain guard: truncated window emitted clean(io_failed=false)={clean} \
+                 rows vs failed(io_failed=true)={failed} rows"
+            );
+
+            // The clean run MUST have something to lose: its terminal drain parses
+            // the truncated trailing window into at least one extra partition.
+            // (If this fails the fixture's last chunk ended exactly on a partition
+            // boundary — pick a fixture whose tail straddles a chunk.)
+            assert!(
+                clean > failed,
+                "Issue #1143 REGRESSION: io_failed did NOT skip the terminal drain — \
+                 truncated window emitted the SAME {failed} rows with and without the \
+                 io_failed gate. A mid-stream read error must NOT surface the partial \
+                 trailing partition (clean={clean}, failed={failed})."
+            );
+        }
     }
 }

--- a/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
+++ b/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
@@ -1,47 +1,93 @@
 //! Sliding-window stitch+parse driver for the user-facing streaming scan
 //! (issue #1143).
 //!
-//! Extracted verbatim from `data_access.rs` (epic #1116 file-size split). These
-//! are private `impl SSTableReader` methods called via `self.` from
-//! `data_access.rs`'s `scan_stream`; behavior is unchanged.
+//! # Design (issue #1143 regression fix)
+//!
+//! The V5CompressedLegacy full scan must reconcile two goals that PR #1156
+//! treated as mutually exclusive:
+//!
+//!   1. **Bounded heap.** Keep only a sliding `window: Vec<u8>` of decompressed
+//!      bytes (peak `max_partition_size + one_chunk`), not an O(file) stitched
+//!      buffer per scan. (PR #1156's contribution — KEPT.)
+//!   2. **CPU off the async worker pool.** Decompress +
+//!      `parse_one_partition_with_timestamps` are CPU-bound; running them inline
+//!      on the small async worker pool (as PR #1156 did, relying on
+//!      `yield_now()`) lets a scan starve everything else scheduled there
+//!      (writer flush/compaction in production), halving reader throughput under
+//!      concurrent write load. The pre-#1156 path ran the whole parse under a
+//!      dedicated `spawn_blocking` thread — restore that.
+//!
+//! Both are achievable together. This driver splits the work across two halves
+//! of one bounded pipeline:
+//!
+//!   - **Async I/O half** (`run_scan_stream_windowed`): the only thing that must
+//!     touch the async runtime is the chunk read (`read_next_block().await`
+//!     awaits the per-scan cursor's async file lock). It does ONLY I/O: read the
+//!     next raw compressed chunk and hand it to the parse half over a small
+//!     bounded channel (`raw` channel, capacity [`RAW_CHUNK_CHANNEL_CAP`]).
+//!   - **Blocking parse half** (`drain_scan_window_blocking`): a single
+//!     `spawn_blocking` task owns the parser, the schema, and the sliding
+//!     window. It pulls raw chunks with `blocking_recv`, decompresses, appends
+//!     to the window, drains every confirmed partition, and emits each surviving
+//!     `(RowKey, Value)` via `tx.blocking_send` — exactly the pre-#1156
+//!     backpressure shape. ALL decompress+parse CPU runs here, off the async
+//!     worker pool.
+//!
+//! ## Backpressure (preserved end-to-end)
+//!
+//! A slow consumer blocks `tx.blocking_send` in the parse half, which stops the
+//! parse loop, which stops draining the `raw` channel, which (being bounded)
+//! blocks `raw_tx.send().await` in the I/O half, which stops reading from disk.
+//! Nothing buffers the whole file; live heap stays `window +
+//! RAW_CHUNK_CHANNEL_CAP` chunks.
+//!
+//! ## Parity
+//!
+//! The emitted set/order is byte-identical to the prior inline driver: same
+//! schema resolution, same incompressible-chunk raw fallback, same
+//! `table_ids_match` / key-range / `filter_tombstone` filters, same
+//! NeedMore/Done straddle handling and final-chunk semantics, same
+//! `READ_SCAN_WINDOW_REFILL` counter. The only change is WHERE the CPU runs.
 
 use super::data_access::table_ids_match;
 use super::source::ScanCursor;
 use super::SSTableReader;
 use crate::types::{TableId, Value};
 use crate::{Error, Result, RowKey};
+use std::sync::Arc;
 use tokio::sync::mpsc;
 
+/// Bound on the raw-compressed-chunk channel feeding the blocking parse task.
+/// Small: the parse half consumes chunks roughly as fast as the I/O half
+/// produces them, so a tiny buffer absorbs scheduling jitter without unbounding
+/// heap. Combined with the sliding window this keeps live heap at
+/// `max_partition_size + (RAW_CHUNK_CHANNEL_CAP + 1) * one_chunk`.
+const RAW_CHUNK_CHANNEL_CAP: usize = 2;
+
+/// Inputs the blocking parse half needs that the I/O half resolves once up front
+/// (so the blocking task does not have to touch the async runtime).
+struct WindowParseCtx {
+    table_id: TableId,
+    start_key: Option<RowKey>,
+    end_key: Option<RowKey>,
+    schema: Option<crate::schema::TableSchema>,
+    /// Cassandra stores a chunk RAW when its compressed length would meet or
+    /// exceed this (Bug #639, epic #970, issue #1104); honour the same rule as
+    /// `stitch_all_chunks` so the windowed path decodes identically.
+    max_compressed_length: usize,
+}
+
 impl SSTableReader {
-    /// Sliding-window stitch+parse driver for the user-facing streaming scan
-    /// (issue #1143). The async counterpart of the compaction read path's
-    /// [`stream_all_partitions_for_compaction`](Self::stream_all_partitions_for_compaction):
-    /// it keeps a `window: Vec<u8>` of decompressed bytes, appends one
-    /// decompressed chunk at a time, drains every confirmed partition out of the
-    /// front via [`drain_scan_window`](Self::drain_scan_window), and stops at
-    /// `NeedMore` to await the next chunk (a partition/row/cell can straddle a
-    /// 64 KiB chunk boundary). Live heap is bounded by
-    /// `max_partition_size + one_chunk`, not O(file).
+    /// Async I/O half of the windowed streaming scan (issue #1143).
     ///
-    /// Backpressure: each emitted `(RowKey, Value)` is forwarded via the bounded
-    /// `tx` (async `send().await`), so the consumer's lag pauses parsing exactly
-    /// as the previous whole-buffer path's `blocking_send` did. Because the parse
-    /// happens between `await` points on this async task (not in `spawn_blocking`)
-    /// the work is naturally yielding at chunk granularity.
-    ///
-    /// Cooperative scheduling (issue #1143, finding #2): the old
-    /// `parse_stitched_stream` ran the whole-file parse under
-    /// `tokio::task::spawn_blocking`; this driver instead parses inline on the
-    /// async worker. We yield between partitions and between chunks for free
-    /// (the `tx.send().await` / `read_next_block().await` points), but a single
-    /// very wide partition can parse with neither point reached, so
-    /// [`drain_scan_window`](Self::drain_scan_window) adds an explicit
-    /// `tokio::task::yield_now().await` after each partition to keep one wide
-    /// partition from monopolizing a worker thread.
+    /// Reads raw compressed chunks from `cursor` and forwards them to a single
+    /// `spawn_blocking` parse task ([`drain_scan_window_blocking`]) over a
+    /// bounded channel; the parse task owns all decompress+parse CPU and emits
+    /// results through `tx`. See the module docs for the full rationale.
     ///
     /// Precondition: `cursor`'s file is seeked to the start of the data section.
     pub(super) async fn run_scan_stream_windowed(
-        &self,
+        self: Arc<Self>,
         table_id: TableId,
         start_key: Option<RowKey>,
         end_key: Option<RowKey>,
@@ -49,35 +95,98 @@ impl SSTableReader {
         cursor: &ScanCursor,
         tx: &mpsc::Sender<Result<(RowKey, Value)>>,
     ) -> Result<()> {
+        // Resolve everything the parser needs ONCE, here on the async side, so
+        // the blocking task never touches the async runtime. Schema resolution
+        // matches the previous `parse_stitched_stream` resolution exactly.
+        let ctx = WindowParseCtx {
+            table_id,
+            start_key,
+            end_key,
+            schema: schema.or_else(|| self.get_table_schema(None)),
+            max_compressed_length: self
+                .compression_info
+                .as_ref()
+                .map(|ci| ci.max_compressed_length as usize)
+                .unwrap_or(usize::MAX),
+        };
+
+        // Raw-chunk pipe: I/O half -> blocking parse half (bounded for heap +
+        // backpressure). Output backpressure rides on `tx` inside the task.
+        let (raw_tx, raw_rx) = mpsc::channel::<Vec<u8>>(RAW_CHUNK_CHANNEL_CAP);
+        let reader = Arc::clone(&self);
+        let out_tx = tx.clone();
+        let parse_task = tokio::task::spawn_blocking(move || {
+            reader.drain_scan_window_blocking(ctx, raw_rx, out_tx)
+        });
+
+        // Feed raw compressed chunks to the parse task. The bounded `raw_tx`
+        // applies backpressure all the way back to disk reads when the consumer
+        // (and thus the parse task) falls behind.
+        let mut io_err: Option<Error> = None;
+        loop {
+            match self.read_next_block(cursor).await {
+                Ok(Some(chunk)) => {
+                    if raw_tx.send(chunk).await.is_err() {
+                        // Parse task ended early (consumer dropped or parse
+                        // error). Stop reading; the task's result is canonical.
+                        break;
+                    }
+                }
+                Ok(None) => break, // EOF
+                Err(e) => {
+                    io_err = Some(e);
+                    break;
+                }
+            }
+        }
+        // Drop the sender so the blocking task sees EOF and runs its final drain.
+        drop(raw_tx);
+
+        // Join the parse task; its Result is the scan's Result. An I/O error
+        // takes precedence (the task only saw a truncated stream).
+        let parse_result = match parse_task.await {
+            Ok(r) => r,
+            Err(join_err) => Err(Error::corruption(format!(
+                "run_scan_stream_windowed: parse task failed: {join_err}"
+            ))),
+        };
+        if let Some(e) = io_err {
+            return Err(e);
+        }
+        parse_result
+    }
+
+    /// Blocking parse half of the windowed streaming scan (issue #1143).
+    ///
+    /// Runs entirely on a `spawn_blocking` thread — NEVER on an async worker.
+    /// Owns the sliding `window: Vec<u8>`; for each raw chunk pulled from
+    /// `raw_rx` it applies the incompressible-raw fallback or decompresses,
+    /// appends to the window, and drains every confirmed partition via
+    /// [`drain_scan_window`]. On `raw_rx` close (I/O EOF) it runs a final drain
+    /// with `at_final_chunk = true`. Surviving `(RowKey, Value)` entries are sent
+    /// through `tx` with `blocking_send`, mirroring the pre-#1156
+    /// `parse_stitched_stream` backpressure.
+    fn drain_scan_window_blocking(
+        &self,
+        ctx: WindowParseCtx,
+        mut raw_rx: mpsc::Receiver<Vec<u8>>,
+        tx: mpsc::Sender<Result<(RowKey, Value)>>,
+    ) -> Result<()> {
         use crate::storage::sstable::compression::Compression;
 
-        // Resolve the schema the parser needs (cells lack column names on disk),
-        // matching the previous `parse_stitched_stream` resolution exactly.
-        let owned_schema = schema.or_else(|| self.get_table_schema(None));
         let parser = self.build_v5_parser();
-
-        // Incompressible-chunk fallback (Bug #639, epic #970, issue #1104):
-        // Cassandra stores a chunk RAW when its compressed length would meet or
-        // exceed `max_compressed_length`. Honour the same rule as
-        // `stitch_all_chunks` so the windowed path decodes identically.
-        let max_compressed_length = self
-            .compression_info
-            .as_ref()
-            .map(|ci| ci.max_compressed_length as usize)
-            .unwrap_or(usize::MAX);
-
         let mut window: Vec<u8> = Vec::new();
         let mut broke = false;
         let mut chunk_count = 0usize;
 
-        while let Some(compressed_chunk) = self.read_next_block(cursor).await? {
-            let decompressed_chunk = if compressed_chunk.len() >= max_compressed_length {
+        while let Some(compressed_chunk) = raw_rx.blocking_recv() {
+            let decompressed_chunk = if compressed_chunk.len() >= ctx.max_compressed_length {
                 compressed_chunk
             } else if let Some(compression_reader) = &self.compression_reader {
                 let compression = Compression::new(*compression_reader.algorithm())?;
                 compression.decompress(&compressed_chunk).map_err(|e| {
                     Error::corruption(format!(
-                        "run_scan_stream_windowed: Failed to decompress chunk {}: {}",
+                        "drain_scan_window_blocking: Failed to decompress chunk {}: {}",
                         chunk_count, e
                     ))
                 })?
@@ -89,18 +198,7 @@ impl SSTableReader {
 
             // Not the final chunk yet: drain confirmed partitions; NeedMore means
             // "await more bytes" (a partition straddles this chunk boundary).
-            self.drain_scan_window(
-                &parser,
-                owned_schema.as_ref(),
-                &table_id,
-                start_key.as_ref(),
-                end_key.as_ref(),
-                &mut window,
-                false,
-                tx,
-                &mut broke,
-            )
-            .await?;
+            self.drain_scan_window(&parser, &ctx, &mut window, false, &tx, &mut broke)?;
             if broke {
                 return Ok(());
             }
@@ -109,22 +207,15 @@ impl SSTableReader {
         // EOF: final drain — a trailing partition with no END_OF_PARTITION marker
         // is now terminal (Done), not a refill request that will never come.
         if !broke {
-            self.drain_scan_window(
-                &parser,
-                owned_schema.as_ref(),
-                &table_id,
-                start_key.as_ref(),
-                end_key.as_ref(),
-                &mut window,
-                true,
-                tx,
-                &mut broke,
-            )
-            .await?;
+            self.drain_scan_window(&parser, &ctx, &mut window, true, &tx, &mut broke)?;
         }
 
+        // Test-only probe (issue #1143 regression guard): record the thread that
+        // ran the parse so a guard test can prove it was NOT an async worker.
+        probe::record_parse_thread();
+
         log::debug!(
-            "run_scan_stream_windowed: drained {} chunks (final window {} bytes)",
+            "drain_scan_window_blocking: drained {} chunks (final window {} bytes)",
             chunk_count,
             window.len()
         );
@@ -134,25 +225,17 @@ impl SSTableReader {
     /// Drain every confirmed partition from the front of the sliding `window`,
     /// emitting each surviving `(RowKey, Value)` through `tx` (issue #1143).
     ///
-    /// Mirrors [`drain_compaction_window`](Self::drain_compaction_window) but for
-    /// the user-facing scan: it drives [`parse_one_partition_with_timestamps`],
-    /// drops the per-row timestamp, and applies the same key-range + tombstone
-    /// filters the previous whole-buffer `parse_stitched_stream` applied. It
-    /// ADDITIONALLY applies a [`table_ids_match`] filter (consistent with the
-    /// non-stitching `scan_stream` branch in `data_access.rs`); that filter is a
-    /// no-op for a single-table SSTable, so for the single-table corpus the
-    /// emitted set is unchanged from the old path. After each `Emitted(consumed)`
-    /// the consumed prefix is removed, keeping the window's peak bounded by
+    /// Synchronous (runs on the `spawn_blocking` thread). Drives
+    /// [`parse_one_partition_with_timestamps`], drops the per-row timestamp, and
+    /// applies the same `table_ids_match` + key-range + `filter_tombstone`
+    /// filters the prior driver applied. After each `Emitted(consumed)` the
+    /// consumed prefix is removed, keeping the window's peak bounded by
     /// `max_partition_size + one_chunk`. Stops at `NeedMore` / `Done` (await the
     /// next chunk / genuine end) or when the consumer is dropped (`*broke`).
-    #[allow(clippy::too_many_arguments)]
-    pub(super) async fn drain_scan_window(
+    fn drain_scan_window(
         &self,
         parser: &crate::storage::sstable::reader::parsing::V5CompressedLegacyParser,
-        schema: Option<&crate::schema::TableSchema>,
-        table_id: &TableId,
-        start_key: Option<&RowKey>,
-        end_key: Option<&RowKey>,
+        ctx: &WindowParseCtx,
         window: &mut Vec<u8>,
         at_final_chunk: bool,
         tx: &mpsc::Sender<Result<(RowKey, Value)>>,
@@ -165,15 +248,15 @@ impl SSTableReader {
                 return Ok(());
             }
 
-            // Buffer this partition's surviving entries, then forward them async
-            // AFTER the parser returns. `parse_one_partition_with_timestamps`
-            // takes a synchronous `FnMut` emit, so we cannot `.await` inside it;
-            // a partition's rows are bounded by `max_partition_size`, so this
-            // stays within the documented window bound.
+            // Buffer this partition's surviving entries, then forward them via
+            // `blocking_send` AFTER the parser returns.
+            // `parse_one_partition_with_timestamps` takes a synchronous `FnMut`
+            // emit, so we cannot send inside it; a partition's rows are bounded
+            // by `max_partition_size`, so this stays within the window bound.
             let mut surviving: Vec<(RowKey, Value)> = Vec::new();
             let step = parser.parse_one_partition_with_timestamps(
                 window.as_slice(),
-                schema,
+                ctx.schema.as_ref(),
                 self,
                 at_final_chunk,
                 &mut |(entry_table_id, key, value, _ts)| {
@@ -181,15 +264,15 @@ impl SSTableReader {
                     // `parse_stitched_stream`; the `table_ids_match` guard is the
                     // ADDITIONAL filter the non-stitching `scan_stream` branch
                     // also applies (a no-op for single-table SSTables).
-                    if !table_ids_match(&entry_table_id, table_id) {
+                    if !table_ids_match(&entry_table_id, &ctx.table_id) {
                         return Ok(std::ops::ControlFlow::Continue(()));
                     }
-                    if let Some(start) = start_key {
+                    if let Some(start) = ctx.start_key.as_ref() {
                         if &key < start {
                             return Ok(std::ops::ControlFlow::Continue(()));
                         }
                     }
-                    if let Some(end) = end_key {
+                    if let Some(end) = ctx.end_key.as_ref() {
                         if &key > end {
                             return Ok(std::ops::ControlFlow::Continue(()));
                         }
@@ -207,20 +290,14 @@ impl SSTableReader {
                 ParseStep::Emitted(consumed) => {
                     let take = if consumed == 0 { 1 } else { consumed };
                     window.drain(0..take.min(window.len()));
-                    // Forward this partition's surviving entries with backpressure.
+                    // Forward this partition's surviving entries with backpressure
+                    // (blocking_send: this runs on a spawn_blocking thread).
                     for entry in surviving {
-                        if tx.send(Ok(entry)).await.is_err() {
+                        if tx.blocking_send(Ok(entry)).is_err() {
                             *broke = true; // consumer dropped
                             return Ok(());
                         }
                     }
-                    // Cooperative yield (issue #1143, finding #2): a partition with
-                    // no surviving entries (all filtered/tombstoned) reaches no
-                    // `send().await`, and a very wide partition parses with no
-                    // intervening `await`, so yield explicitly after each partition
-                    // to avoid monopolizing a worker thread on a multi-thread
-                    // runtime. Cheap (no reschedule when the queue is empty).
-                    tokio::task::yield_now().await;
                 }
                 // NeedMore: the partition straddles this chunk boundary. The
                 // per-partition parser buffers a partition's rows internally and
@@ -243,5 +320,49 @@ impl SSTableReader {
                 ParseStep::Done => return Ok(()),
             }
         }
+    }
+}
+
+/// Test-only probe (issue #1143): records the [`std::thread::ThreadId`] on which
+/// the windowed scan's decompress+parse half actually ran, so a guard test can
+/// deterministically prove that work executed on a `spawn_blocking` thread and
+/// NOT on a tokio async worker. Disarmed by default and effectively zero cost
+/// (one relaxed atomic load per scan); never observes anything in production.
+#[doc(hidden)]
+pub mod probe {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Mutex;
+    use std::thread::ThreadId;
+
+    static ARMED: AtomicBool = AtomicBool::new(false);
+    static LAST_PARSE_THREAD: Mutex<Option<ThreadId>> = Mutex::new(None);
+
+    /// Arm the probe and clear any previously recorded thread. Call from a test
+    /// before driving a scan.
+    pub fn arm() {
+        if let Ok(mut g) = LAST_PARSE_THREAD.lock() {
+            *g = None;
+        }
+        ARMED.store(true, Ordering::SeqCst);
+    }
+
+    /// Disarm the probe (restores the production no-op state).
+    pub fn disarm() {
+        ARMED.store(false, Ordering::SeqCst);
+    }
+
+    /// Record the current thread as the parse thread, if armed. Called from the
+    /// blocking parse half after a scan's parse work completes.
+    pub(super) fn record_parse_thread() {
+        if ARMED.load(Ordering::Relaxed) {
+            if let Ok(mut g) = LAST_PARSE_THREAD.lock() {
+                *g = Some(std::thread::current().id());
+            }
+        }
+    }
+
+    /// The [`ThreadId`] recorded by the most recent parse, if any.
+    pub fn recorded_parse_thread() -> Option<ThreadId> {
+        LAST_PARSE_THREAD.lock().ok().and_then(|g| *g)
     }
 }

--- a/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
+++ b/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
@@ -241,6 +241,9 @@ impl SSTableReader {
 
         // Test-only probe (issue #1143 regression guard): record the thread that
         // ran the parse so a guard test can prove it was NOT an async worker.
+        // Compiled ONLY under the non-default `scan-offload-probe` feature; a
+        // true no-op (not even referenced) in normal/release builds.
+        #[cfg(feature = "scan-offload-probe")]
         probe::record_parse_thread();
 
         log::debug!(
@@ -355,8 +358,13 @@ impl SSTableReader {
 /// Test-only probe (issue #1143): records the [`std::thread::ThreadId`] on which
 /// the windowed scan's decompress+parse half actually ran, so a guard test can
 /// deterministically prove that work executed on a `spawn_blocking` thread and
-/// NOT on a tokio async worker. Disarmed by default and effectively zero cost
-/// (one relaxed atomic load per scan); never observes anything in production.
+/// NOT on a tokio async worker.
+///
+/// Compiled ONLY under the non-default `scan-offload-probe` feature. In a
+/// normal/default/release build this module, its statics, and its call-site do
+/// not exist at all — the probe never enters the crate's public surface and adds
+/// zero cost (issue #1143 finding 1).
+#[cfg(feature = "scan-offload-probe")]
 #[doc(hidden)]
 pub mod probe {
     use std::sync::atomic::{AtomicBool, Ordering};

--- a/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
+++ b/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
@@ -41,6 +41,30 @@
 //! Nothing buffers the whole file; live heap stays `window +
 //! RAW_CHUNK_CHANNEL_CAP` chunks.
 //!
+//! ## Cancellation (issue #1143 finding 2)
+//!
+//! The outer scan runs inside the `tokio::spawn` in `scan_stream`; if that task
+//! is dropped/cancelled at an `await`, the parse task's `JoinHandle` (held in
+//! `run_scan_stream_windowed`) is dropped too. Dropping a `spawn_blocking`
+//! `JoinHandle` DETACHES the task — it does NOT abort it (there is no portable
+//! way to interrupt a running blocking thread). The detached parse task keeps
+//! running: `raw_rx.blocking_recv()` observes the dropped `raw_tx`, and because a
+//! clean cancellation leaves `io_failed == false`, it proceeds to a final drain
+//! and `tx.blocking_send`s into `out_tx`.
+//!
+//! This is harmless in practice and needs no abort machinery: on cancellation
+//! the consumer drops the `mpsc::Receiver` (`rx`) returned by `scan_stream`, so
+//! the very first `tx.blocking_send` fails (`*broke = true`), the parse loop
+//! returns immediately, and the task — and the `reader: Arc<Self>` it holds —
+//! are released. The only window in which it can still emit is when a chunk was
+//! already in flight AND the consumer's `rx` has not yet dropped, i.e. the
+//! consumer is still reading; those rows are valid scan output, not garbage.
+//! Worst case the task lingers for one partition's parse before its
+//! `blocking_send` fails, keeping `Arc<Self>` alive only that long. Pre-#1156
+//! the parse ran inline on the cancellable async task, so this detach window is
+//! new to the offload split; it is bounded and self-terminating, so we document
+//! it rather than add abort plumbing.
+//!
 //! ## Parity
 //!
 //! The emitted set/order is byte-identical to the prior inline driver: same

--- a/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
+++ b/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
@@ -54,6 +54,7 @@ use super::source::ScanCursor;
 use super::SSTableReader;
 use crate::types::{TableId, Value};
 use crate::{Error, Result, RowKey};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tokio::sync::mpsc;
 
@@ -113,10 +114,20 @@ impl SSTableReader {
         // Raw-chunk pipe: I/O half -> blocking parse half (bounded for heap +
         // backpressure). Output backpressure rides on `tx` inside the task.
         let (raw_tx, raw_rx) = mpsc::channel::<Vec<u8>>(RAW_CHUNK_CHANNEL_CAP);
+        // Distinguishes a clean EOF (sender dropped after `Ok(None)`) from a
+        // mid-stream read error (sender dropped after `Err`). On error the parse
+        // half must NOT run its `at_final_chunk = true` terminal drain — a
+        // truncated/partial trailing window would otherwise emit a spurious
+        // partition through `tx` BEFORE this function returns the `Err` (issue
+        // #1143 finding 2; the pre-#1156 path `?`-propagated the read error and
+        // never ran a final drain). Set before `raw_tx` is dropped so the parse
+        // half observes it via the channel-close happens-before.
+        let io_failed = Arc::new(AtomicBool::new(false));
         let reader = Arc::clone(&self);
         let out_tx = tx.clone();
+        let task_io_failed = Arc::clone(&io_failed);
         let parse_task = tokio::task::spawn_blocking(move || {
-            reader.drain_scan_window_blocking(ctx, raw_rx, out_tx)
+            reader.drain_scan_window_blocking(ctx, raw_rx, out_tx, task_io_failed)
         });
 
         // Feed raw compressed chunks to the parse task. The bounded `raw_tx`
@@ -134,12 +145,18 @@ impl SSTableReader {
                 }
                 Ok(None) => break, // EOF
                 Err(e) => {
+                    // Tell the parse half to SKIP the terminal final drain: the
+                    // stream is truncated, so the trailing window is partial and
+                    // must not be emitted. The store is sequenced before the
+                    // `drop(raw_tx)` the parse half synchronizes on.
+                    io_failed.store(true, Ordering::SeqCst);
                     io_err = Some(e);
                     break;
                 }
             }
         }
-        // Drop the sender so the blocking task sees EOF and runs its final drain.
+        // Drop the sender so the blocking task sees EOF and runs its final drain
+        // (only if `io_failed` is still false — see the parse half).
         drop(raw_tx);
 
         // Join the parse task; its Result is the scan's Result. An I/O error
@@ -162,15 +179,19 @@ impl SSTableReader {
     /// Owns the sliding `window: Vec<u8>`; for each raw chunk pulled from
     /// `raw_rx` it applies the incompressible-raw fallback or decompresses,
     /// appends to the window, and drains every confirmed partition via
-    /// [`drain_scan_window`]. On `raw_rx` close (I/O EOF) it runs a final drain
-    /// with `at_final_chunk = true`. Surviving `(RowKey, Value)` entries are sent
-    /// through `tx` with `blocking_send`, mirroring the pre-#1156
-    /// `parse_stitched_stream` backpressure.
+    /// [`drain_scan_window`]. On a CLEAN `raw_rx` close (I/O EOF) it runs a final
+    /// drain with `at_final_chunk = true`; on a close caused by a mid-stream read
+    /// error (`io_failed` set by the I/O half before it dropped the sender) it
+    /// SKIPS that terminal drain so a truncated window cannot emit a spurious
+    /// trailing partition (issue #1143 finding 2). Surviving `(RowKey, Value)`
+    /// entries are sent through `tx` with `blocking_send`, mirroring the
+    /// pre-#1156 `parse_stitched_stream` backpressure.
     fn drain_scan_window_blocking(
         &self,
         ctx: WindowParseCtx,
         mut raw_rx: mpsc::Receiver<Vec<u8>>,
         tx: mpsc::Sender<Result<(RowKey, Value)>>,
+        io_failed: Arc<AtomicBool>,
     ) -> Result<()> {
         use crate::storage::sstable::compression::Compression;
 
@@ -204,9 +225,17 @@ impl SSTableReader {
             }
         }
 
-        // EOF: final drain — a trailing partition with no END_OF_PARTITION marker
-        // is now terminal (Done), not a refill request that will never come.
-        if !broke {
+        // Stream end. On a CLEAN EOF run the final drain — a trailing partition
+        // with no END_OF_PARTITION marker is now terminal (Done), not a refill
+        // request that will never come. But if the I/O half stopped on a read
+        // ERROR (`io_failed`), the trailing window is a truncated fragment of a
+        // partition; running `at_final_chunk = true` here would parse and emit it
+        // as if complete, surfacing a partial/garbage row BEFORE the caller
+        // returns the I/O `Err`. Skip the final drain so a truncated/corrupt
+        // stream yields ONLY the error (issue #1143 finding 2). The store in the
+        // I/O half happens-before the `drop(raw_tx)` that ended `blocking_recv`,
+        // so this load observes it.
+        if !broke && !io_failed.load(Ordering::SeqCst) {
             self.drain_scan_window(&parser, &ctx, &mut window, true, &tx, &mut broke)?;
         }
 

--- a/cqlite-core/tests/issue_1143_scan_offload_thread.rs
+++ b/cqlite-core/tests/issue_1143_scan_offload_thread.rs
@@ -1,0 +1,241 @@
+//! Issue #1143 (regression guard for PR #1156): the windowed streaming
+//! `SELECT *` scan must run its CPU-bound work (decompress +
+//! `parse_one_partition_with_timestamps`) OFF the async worker pool, on a
+//! `spawn_blocking` thread.
+//!
+//! ## What regressed
+//!
+//! PR #1156 reworked the V5CompressedLegacy full-scan path into a bounded
+//! sliding-window stitch+parse (`run_scan_stream_windowed` /
+//! `drain_scan_window`, `scan_stream_windowed.rs`). That change bundled TWO
+//! things:
+//!   1. a bounded `window: Vec<u8>` (peak `max_partition_size + one_chunk`
+//!      instead of O(file)) — correct, kept;
+//!   2. moving the decompress+parse work from a dedicated `spawn_blocking`
+//!      thread (the pre-#1156 `parse_stitched_stream`) ONTO the async worker
+//!      pool, relying only on `tokio::task::yield_now()` between partitions.
+//!
+//! Change (2) is the regression: heavy decode/parse on the small async worker
+//! pool competes with everything else scheduled there; cooperative `yield_now()`
+//! is far weaker isolation than a dedicated blocking pool, so concurrent work
+//! (writer flush/compaction in production) starves and the reader distribution
+//! shifts (reader scans/s halved in the measured A/B).
+//!
+//! ## Why a thread-identity guard (not an absolute p99 / timing threshold)
+//!
+//! `read_while_write.rs` (criterion) measures but does not ASSERT, and absolute
+//! latency thresholds are machine-dependent and flaky — that bench went green
+//! and missed this regression. A *timing*-based starvation guard is also
+//! unreliable here: the test corpus fixtures are tiny (tens of KiB), so a single
+//! scan's parse is sub-millisecond and never monopolizes a worker long enough to
+//! observe wall-clock starvation (the regression only surfaced under sustained
+//! 6-reader load against far larger production data).
+//!
+//! So this guard pins the MECHANISM directly and deterministically: it records
+//! the `ThreadId` on which the windowed scan's parse actually ran (via the
+//! always-compiled, default-disarmed `scan_offload_probe`), and asserts that
+//! thread is NOT one of the tokio async worker threads. This is exactly the
+//! distinction the fix turns on:
+//!   - inline-on-async-worker parse (regressed): parse runs ON a worker thread
+//!     → recorded thread is in the worker set → FAIL;
+//!   - `spawn_blocking` offload (fixed): parse runs on a blocking-pool thread
+//!     → recorded thread is OUTSIDE the worker set → PASS.
+//!
+//! Requirements:
+//! - `CQLITE_DATASETS_ROOT` pointing to `test-data/datasets`
+//! - real SSTable Data.db files (`bash test-data/scripts/fetch-datasets.sh`).
+//!   Dataset-dependent: skips when Data.db is absent, but a present fixture that
+//!   returns zero rows is a FAILURE (never vacuously passes).
+
+#![cfg(all(feature = "state_machine", feature = "cli-helpers"))]
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::sync::{Arc, Barrier};
+use std::thread::ThreadId;
+use std::time::Duration;
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::query::result::StreamingConfig;
+use cqlite_core::storage::sstable::reader::scan_stream_windowed::probe as scan_offload_probe;
+use cqlite_core::Database;
+
+const KEYSPACE: &str = "test_wide_rows";
+const TABLE: &str = "wide_partition_table";
+const SCHEMA_FILE: &str = "wide-rows.cql";
+/// Async worker threads on this test's runtime. MUST match the literal in the
+/// `#[tokio::test(... worker_threads = N)]` attribute below (the macro requires a
+/// literal, so they are kept in sync by hand).
+const WORKER_THREADS: usize = 2;
+
+fn get_datasets_root() -> Option<PathBuf> {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+}
+
+fn get_schemas_dir() -> Option<PathBuf> {
+    if let Some(datasets_root) = get_datasets_root() {
+        if let Some(parent) = datasets_root.parent() {
+            let schemas_dir = parent.join("schemas");
+            if schemas_dir.exists() {
+                return Some(schemas_dir);
+            }
+        }
+    }
+    let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let schemas_dir = manifest_dir.parent()?.join("test-data").join("schemas");
+    if schemas_dir.exists() {
+        return Some(schemas_dir);
+    }
+    None
+}
+
+/// Directory holding the fixture's SSTable components, if a Data.db is present.
+fn fixture_dir() -> Option<PathBuf> {
+    let root = get_datasets_root()?;
+    let table_root = root.join("sstables").join(KEYSPACE);
+    let entries = std::fs::read_dir(&table_root).ok()?;
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with(&format!("{TABLE}-"))
+            && entry.path().is_dir()
+            && std::fs::read_dir(entry.path()).ok()?.flatten().any(|f| {
+                f.file_name()
+                    .to_str()
+                    .is_some_and(|n| n.ends_with("-Data.db"))
+            })
+        {
+            return Some(entry.path());
+        }
+    }
+    None
+}
+
+async fn setup_db() -> Database {
+    let datasets_root = get_datasets_root().expect("CQLITE_DATASETS_ROOT");
+    let schemas_dir = get_schemas_dir().expect("schemas dir");
+    let schema_path = schemas_dir.join(SCHEMA_FILE);
+    assert!(schema_path.exists(), "schema not found: {schema_path:?}");
+
+    let config = IngestionConfig {
+        schema_paths: vec![schema_path],
+        data_dir: datasets_root.join("sstables"),
+        version_hint: None,
+        core_config: cqlite_core::Config::default(),
+        table_directory_filter: Some(format!("/{KEYSPACE}/")),
+    };
+    ingest(config)
+        .await
+        .expect("ingest wide_partition_table")
+        .database
+}
+
+/// Enumerate the runtime's async worker `ThreadId`s by parking exactly
+/// `WORKER_THREADS` tasks at a barrier so each must occupy a distinct worker,
+/// each recording its own thread id. (A task can only make progress to the
+/// barrier if scheduled on a worker; with all workers held simultaneously we
+/// observe the full worker set.)
+async fn worker_thread_ids() -> HashSet<ThreadId> {
+    let barrier = Arc::new(Barrier::new(WORKER_THREADS));
+    let mut handles = Vec::with_capacity(WORKER_THREADS);
+    for _ in 0..WORKER_THREADS {
+        let b = Arc::clone(&barrier);
+        handles.push(tokio::spawn(async move {
+            let id = std::thread::current().id();
+            // Block this worker until all workers are here (forces distinct
+            // workers). Blocking in a task is fine for this one-shot probe.
+            b.wait();
+            id
+        }));
+    }
+    let mut ids = HashSet::new();
+    for h in handles {
+        ids.insert(h.await.expect("worker probe task"));
+    }
+    ids
+}
+
+/// Drain a single full streaming scan to completion, returning the row count.
+/// `buffer_size = 1` maximizes per-partition backpressure so the parse loop runs
+/// in tight bursts (the worst case for an inline-on-worker parse).
+async fn drain_one_scan(db: &Database, sql: &str) -> usize {
+    let config = StreamingConfig {
+        buffer_size: 1,
+        ..StreamingConfig::default()
+    };
+    let mut iter = db
+        .execute_streaming(sql, config)
+        .await
+        .expect("execute_streaming should succeed");
+    let mut n = 0usize;
+    while let Some(row) = iter.next_async().await {
+        row.expect("streamed row should be Ok");
+        n += 1;
+    }
+    n
+}
+
+/// The windowed streaming scan's decompress+parse must run off the async worker
+/// pool (on a `spawn_blocking` thread), not inline on a tokio worker.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)] // keep == WORKER_THREADS
+async fn streaming_scan_parse_runs_off_async_worker_pool() {
+    let Some(_dir) = fixture_dir() else {
+        eprintln!(
+            "Skipping {KEYSPACE}.{TABLE}: no Data.db present (run fetch-datasets.sh). \
+             This guard is non-vacuous only with the real multi-chunk fixture."
+        );
+        return;
+    };
+
+    // Capture the runtime's async worker thread ids up front.
+    let workers = worker_thread_ids().await;
+    assert_eq!(
+        workers.len(),
+        WORKER_THREADS,
+        "expected to enumerate {WORKER_THREADS} distinct async worker threads, saw {}",
+        workers.len()
+    );
+
+    let db = setup_db().await;
+    let sql = format!("SELECT * FROM {KEYSPACE}.{TABLE}");
+
+    // Arm the probe, run a full streaming scan over the multi-chunk fixture,
+    // then read back the thread that ran the parse.
+    scan_offload_probe::arm();
+    let rows = drain_one_scan(&db, &sql).await;
+    // Small settle: the parse task records its thread just before the stream
+    // closes; ensure the record is visible before we read it.
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    let parse_thread = scan_offload_probe::recorded_parse_thread();
+    scan_offload_probe::disarm();
+
+    // Non-vacuous: a present fixture must return rows AND must have routed
+    // through the windowed (chunk-stitching) parse path that arms the probe.
+    assert!(
+        rows > 0,
+        "Issue #1143: {KEYSPACE}.{TABLE} is present but the streaming scan \
+         returned 0 rows — guard would be vacuous"
+    );
+    let parse_thread = parse_thread.expect(
+        "Issue #1143: scan_offload_probe recorded no parse thread — the windowed \
+         (chunk-stitching) scan path did not run; fixture may not be the `nb` \
+         chunk-compressed format the probe instruments",
+    );
+
+    eprintln!(
+        "Issue #1143 offload guard: rows={rows} parse_thread={parse_thread:?} \
+         async_workers={workers:?}"
+    );
+
+    assert!(
+        !workers.contains(&parse_thread),
+        "Issue #1143 REGRESSION: the windowed scan's decompress/parse ran on async \
+         worker thread {parse_thread:?} (one of {workers:?}) instead of a \
+         spawn_blocking thread. PR #1156 ran the CPU-bound parse inline on the async \
+         worker pool, starving concurrent work (writer flush/compaction) and halving \
+         reader throughput. Move the parse back onto spawn_blocking."
+    );
+}

--- a/cqlite-core/tests/issue_1143_scan_offload_thread.rs
+++ b/cqlite-core/tests/issue_1143_scan_offload_thread.rs
@@ -33,9 +33,10 @@
 //!
 //! So this guard pins the MECHANISM directly and deterministically: it records
 //! the `ThreadId` on which the windowed scan's parse actually ran (via the
-//! always-compiled, default-disarmed `scan_offload_probe`), and asserts that
-//! thread is NOT one of the tokio async worker threads. This is exactly the
-//! distinction the fix turns on:
+//! `scan_offload_probe`, compiled only under the non-default
+//! `scan-offload-probe` feature so the instrumentation never ships in a normal
+//! build — issue #1143 finding 1), and asserts that thread is NOT one of the
+//! tokio async worker threads. This is exactly the distinction the fix turns on:
 //!   - inline-on-async-worker parse (regressed): parse runs ON a worker thread
 //!     → recorded thread is in the worker set → FAIL;
 //!   - `spawn_blocking` offload (fixed): parse runs on a blocking-pool thread
@@ -47,7 +48,14 @@
 //!   Dataset-dependent: skips when Data.db is absent, but a present fixture that
 //!   returns zero rows is a FAILURE (never vacuously passes).
 
-#![cfg(all(feature = "state_machine", feature = "cli-helpers"))]
+// Requires the non-default `scan-offload-probe` feature: that gates the
+// `scan_stream_windowed::probe` instrumentation this guard reads (issue #1143
+// finding 1). The agent gate runs this binary with the feature enabled.
+#![cfg(all(
+    feature = "state_machine",
+    feature = "cli-helpers",
+    feature = "scan-offload-probe"
+))]
 
 use std::collections::HashSet;
 use std::path::PathBuf;

--- a/cqlite-core/tests/issue_1143_scan_offload_thread.rs
+++ b/cqlite-core/tests/issue_1143_scan_offload_thread.rs
@@ -53,7 +53,6 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::{Arc, Barrier};
 use std::thread::ThreadId;
-use std::time::Duration;
 
 use cqlite_core::ingestion::{ingest, IngestionConfig};
 use cqlite_core::query::result::StreamingConfig;
@@ -206,9 +205,12 @@ async fn streaming_scan_parse_runs_off_async_worker_pool() {
     // then read back the thread that ran the parse.
     scan_offload_probe::arm();
     let rows = drain_one_scan(&db, &sql).await;
-    // Small settle: the parse task records its thread just before the stream
-    // closes; ensure the record is visible before we read it.
-    tokio::time::sleep(Duration::from_millis(20)).await;
+    // No settle sleep needed: `record_parse_thread()` stores the ThreadId under
+    // the probe Mutex strictly BEFORE the parse closure drops its output sender,
+    // and `drain_one_scan` returns only after the stream ends — which is observed
+    // only once every sender (including that one) has dropped. That channel-close
+    // happens-before ordering already guarantees the recorded thread is visible
+    // to this read (issue #1143 finding 3).
     let parse_thread = scan_offload_probe::recorded_parse_thread();
     scan_offload_probe::disarm();
 

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -12,6 +12,10 @@
 #   fmt                cargo fmt --all --check
 #   clippy             RUSTFLAGS="-D warnings" clippy --workspace --all-targets --all-features
 #   core-tests         cargo test -p cqlite-core --features cli-helpers (CI skip-list applied)
+#   scan-offload-guard cargo test -p cqlite-core --features cli-helpers,scan-offload-probe
+#                      --test issue_1143_scan_offload_thread (windowed-scan parse
+#                      runs off the async worker pool; probe is feature-gated so
+#                      the default core-tests run can't execute it — issue #1143)
 #   integration-tests  cargo test -p cqlite-integration-tests: compile ALL targets
 #                      (--no-run, whole package) then run the seven CI-enforced ones
 #   format-compat      cargo test -p format-compatibility-tests (the 'oa' format crate;
@@ -55,7 +59,7 @@ if ! command -v cargo >/dev/null 2>&1 && [ -d "$HOME/.cargo/bin" ]; then
 fi
 export CQLITE_DATASETS_ROOT="${CQLITE_DATASETS_ROOT:-$REPO_ROOT/test-data/datasets}"
 
-COMPONENTS=(file-size fmt clippy core-tests tombstones-scan integration-tests format-compat write-tests cli-tests python-bindings minimal-build smoke)
+COMPONENTS=(file-size fmt clippy core-tests tombstones-scan scan-offload-guard integration-tests format-compat write-tests cli-tests python-bindings minimal-build smoke)
 ONLY=""
 case "${1:-}" in
   --list) printf '%s\n' "${COMPONENTS[@]}"; exit 0 ;;
@@ -248,6 +252,15 @@ run_component core-tests cargo test --package cqlite-core --features cli-helpers
 run_component tombstones-scan cargo test --package cqlite-core \
   --features write-support,cli-helpers,tombstones \
   --test issue_1085_tombstones_full_scan_parity
+# Issue #1143: the thread-identity guard proves the windowed scan's
+# decompress+parse runs OFF the async worker pool. Its probe is gated behind the
+# non-default `scan-offload-probe` feature (so the instrumentation never ships in
+# normal builds), and the test only compiles under that feature — so the default
+# core-tests run never executes it. Run it here with the feature on; a guard that
+# doesn't run in CI is not a guard.
+run_component scan-offload-guard cargo test --package cqlite-core \
+  --features cli-helpers,scan-offload-probe \
+  --test issue_1143_scan_offload_thread
 # Compile EVERY target in the package first (--no-run, whole package) so a
 # new/edited test file that doesn't compile can't hide behind the enumerated
 # run-list (issue #865); then execute the seven CI-enforced targets.


### PR DESCRIPTION
## What & why

PR #1156 ("windowed scan-stream to bound per-scan heap") fixed #1143's per-scan heap
but **regressed the metric #1143 was actually filed for** — read p99 under concurrent
write load. On a same-machine interleaved A/B (`mixed.read_while_write`, 6 readers + 2
writers) the reader cohort got **~2× worse than the shipped v0.12.0**: scans/s halved
(21.9 → 10.2), p50/p99/p999 all ~doubled.

**Root cause:** #1156 bundled two changes. The bounded sliding window (good, kept). And
it moved the CPU-bound decompress + `parse_one_partition_with_timestamps` **off
`spawn_blocking` onto the async worker pool**, with only cooperative `yield_now()` for
isolation. Under concurrent writes the readers' heavy parse starves on the small async
worker pool the writers also use — cooperative yielding ≠ a dedicated blocking pool.

## The fix

Keep the bounded sliding window; run the per-window decompress+parse **off the async
worker pool again**:
- async half does only `read_next_block(cursor).await` I/O, feeding a bounded raw-chunk
  channel (cap 2);
- a single `spawn_blocking` parse task (owning `Arc<Self>`) does all decompress + parse
  and emits via `tx.blocking_send` — the pre-#1156 isolation, with the bounded heap kept.

Bounded-heap and off-async-worker execution are not mutually exclusive; #1156
over-corrected. `data_access.rs` is untouched (call site already passed `Arc<Self>`).

Also addressed in review:
- **Terminal-drain correctness:** a mid-stream I/O error no longer runs the
  `at_final_chunk` drain over a partial window, so a truncated stream yields only the
  `Err`, not a spurious trailing partition (guarded by `io_failed`, with a unit + fixture
  test that fails if the gate is removed).
- **Probe is test-only:** the thread-identity instrumentation is gated behind a
  non-default `scan-offload-probe` feature — it does not ship in release builds or the
  public API. The regression guard runs in the gate via a dedicated `scan-offload-guard`
  component (proven: `1 passed`).

## Regression guard

A criterion bench can't catch this (fixtures are ≤86 KB; a single parse is ~2 ms — too
brief to observe starvation, which is exactly why #1156's bench went green). Instead a
deterministic guard records the `ThreadId` where parse runs and asserts it is **not** a
tokio async-worker thread — fail-on-regression / pass-on-fix, verified both directions.

## Verification status

- `scripts/agent-gate.sh`: PASS (only the documented pre-existing `test_flush_throughput`
  / bloom-latency wall-clock flakes intermittently trip; pass in isolation).
- roborev: clean except one Low "acceptable as-is" test-robustness note.
- **The definitive p99 proof is the external `cqlite-perf` harness** (pmcfadin/cqlite-perf#27),
  which can't run in this repo. This PR proves the *mechanism* is fixed (parse off the
  worker pool); the absolute p99 recovery should be confirmed by a harness A/B against
  this branch before merge.

Refs #1143 (left open intentionally pending the external-harness A/B).
