### PR TITLE
fix(#1162): guardrail flow-finalize cleanup — match merged PR branch, refuse dirty/multi-lock

### DIFF
--- a/.claude/skills/flow-finalize/SKILL.md
+++ b/.claude/skills/flow-finalize/SKILL.md
@@ -9,8 +9,13 @@ You are the CQLite delivery lead. The PR for issue `#N` is **merged**. Close the
 
 ## Steps
 
-1. **Confirm the merge.** `gh pr view <pr> --json state,mergeCommit` → state MUST be `MERGED`. If not,
-   stop — finalize only runs post-merge.
+1. **Confirm the merge + capture the merged branch.** state MUST be `MERGED`; the cleanup in step 5 keys
+   off the merged PR's **`headRefName`** (NOT a `issue-<N>-*` glob — see the #1162 guardrails below):
+   ```bash
+   gh pr view <pr> --json state,mergeCommit,headRefName
+   # state MUST be MERGED; record headRefName as <merged-branch> for step 5.
+   ```
+   If not merged, stop — finalize only runs post-merge.
 2. **Update the root checkout's main.** Do NOT `git switch main` from a worktree — `main` is checked out
    in the repo root, so the switch is rejected. Operate on the root explicitly:
    ```bash
@@ -35,13 +40,20 @@ You are the CQLite delivery lead. The PR for issue `#N` is **merged**. Close the
    Releasing the claim = removing the `issue-<N>-<slug>` branch from origin (the cross-machine lock); the
    cleanup below does exactly that. After finalize, nothing for this issue may remain `In Progress`/`In
    Review` and no `issue-<N>-*` branch may remain on origin.
-5. **Remove the worktree + branch (releases the claim lock):**
+5. **Remove the worktree + branch via the guarded cleanup (releases the claim lock).** Do NOT hand-glob
+   `issue-<N>-*` or blindly `--force` — that destroyed an unrelated active claim on 2026-06-27 (the #1143
+   incident: PR merged from `issue-1143-read-p99-regression`, glob also matched + deleted the separate
+   active `issue-1143-scan-window-offload`). Use the guardrailed script instead — it targets ONLY the
+   merged PR's branch, refuses on >1 lock for the issue (1:1:1:1 violation), and refuses to remove a
+   dirty/unpushed worktree:
    ```bash
-   git worktree remove .claude/worktrees/issue-<N>-<slug> --force
-   git branch -D issue-<N>-<slug> 2>/dev/null
-   git push origin --delete issue-<N>-<slug> 2>/dev/null   # deletes the origin claim lock
+   scripts/flow/finalize-cleanup.sh --issue <N> --merged-branch <merged-branch>   # <merged-branch> from step 1
+   # Add --dry-run first to preview. Exit codes: 0 ok · 2 multi-lock refused · 3 dirty/unpushed refused.
    ```
-   Confirm the lock is gone: `git ls-remote --heads origin "issue-<N>-*"` returns nothing.
+   On a non-zero exit the script changed nothing and surfaced why — resolve the 1:1:1:1 violation or the
+   dirty worktree by hand; never force past it. Confirm the lock is gone afterward:
+   `git ls-remote --heads origin "issue-<N>-*"` returns nothing.
+   (Regression coverage: `scripts/flow/tests/finalize-cleanup.test.sh` encodes the #1143 scenario.)
 6. **Close the issue** with a traceable comment referencing the merged PR + commit (only if its
    acceptance criteria are fully met — never close an epic):
    ```bash

--- a/.claude/skills/flow-finalize/SKILL.md
+++ b/.claude/skills/flow-finalize/SKILL.md
@@ -47,8 +47,10 @@ You are the CQLite delivery lead. The PR for issue `#N` is **merged**. Close the
    merged PR's branch, refuses on >1 lock for the issue (1:1:1:1 violation), and refuses to remove a
    dirty/unpushed worktree:
    ```bash
-   scripts/flow/finalize-cleanup.sh --issue <N> --merged-branch <merged-branch>   # <merged-branch> from step 1
-   # Add --dry-run first to preview. Exit codes: 0 ok · 2 multi-lock refused · 3 dirty/unpushed refused.
+   # --confirm-unmerged: a squash-merge leaves the branch tip out of `main`; step 1
+   # already verified PR state=MERGED, which IS the authority the flag stands for.
+   scripts/flow/finalize-cleanup.sh --issue <N> --merged-branch <merged-branch> --confirm-unmerged
+   # Add --dry-run first to preview. Exit codes: 0 ok · 2 multi-lock · 3 dirty/unpushed · 4 unmerged tip.
    ```
    On a non-zero exit the script changed nothing and surfaced why — resolve the 1:1:1:1 violation or the
    dirty worktree by hand; never force past it. Confirm the lock is gone afterward:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,4 +245,18 @@ jobs:
       - name: cargo publish --dry-run (cqlite-core)
         run: cargo publish --package cqlite-core --dry-run
 
+  # Guards the delivery-pipeline tooling itself (issue #1162). The flow-finalize
+  # cleanup destroyed an unrelated active claim via an issue-<N>-* glob on
+  # 2026-06-27 (the #1143 incident). This pure-git test (no Rust build) pins the
+  # guardrails so the regression can't return. Fast: seconds, runs every PR.
+  flow-tooling-tests:
+    name: Flow tooling guardrails
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Run flow-finalize cleanup guardrail tests
+        run: bash scripts/flow/tests/finalize-cleanup.test.sh
+
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,14 +249,20 @@ jobs:
   # cleanup destroyed an unrelated active claim via an issue-<N>-* glob on
   # 2026-06-27 (the #1143 incident). This pure-git test (no Rust build) pins the
   # guardrails so the regression can't return. Fast: seconds, runs every PR.
+  # Runs on macOS too: flow-finalize's real production target is the macOS system
+  # bash (3.2), so the script's 3.2 compatibility is validated, not just asserted.
   flow-tooling-tests:
     name: Flow tooling guardrails
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Run flow-finalize cleanup guardrail tests
-        run: bash scripts/flow/tests/finalize-cleanup.test.sh
+      - name: Run flow-finalize cleanup guardrail tests (${{ matrix.os }} /bin/bash)
+        run: /bin/bash scripts/flow/tests/finalize-cleanup.test.sh
 
 

--- a/scripts/flow/finalize-cleanup.sh
+++ b/scripts/flow/finalize-cleanup.sh
@@ -156,6 +156,16 @@ while IFS= read -r line; do
   esac
 done < <(git_root worktree list --porcelain)
 
+# Stale entry: `git worktree list` records the path but the directory is gone
+# (removed out-of-band). Don't fall through to `git worktree remove` (which would
+# abort under set -e with git's raw 128). Mark it for a prune in PHASE 2 instead.
+stale_wt=0
+if [ -n "$target_wt" ] && [ ! -d "$target_wt" ]; then
+  note "recorded worktree '$target_wt' is missing on disk — will prune the stale entry, not remove"
+  stale_wt=1
+  target_wt=""
+fi
+
 # Remote state for the merged branch — also FAIL CLOSED on a remote query error,
 # else a blip would read as "branch already deleted, nothing to do".
 if ! merged_raw="$(git_root ls-remote --heads "$REMOTE" "$MERGED_BRANCH" 2>/dev/null)"; then
@@ -223,9 +233,17 @@ if [ -n "$target_wt" ]; then
       echo "$prog: REFUSED — worktree '$target_wt' has $ahead unpushed commit(s) vs $cmp_sha. Not removing." >&2
       exit 3
     fi
-  else
-    ahead_main="$(git -C "$target_wt" rev-list --count "${MAIN_REF}..HEAD" 2>/dev/null || echo 0)"
-    if [ "${ahead_main:-0}" -gt 0 ] && [ "$CONFIRM_UNMERGED" -eq 0 ]; then
+  elif [ "$CONFIRM_UNMERGED" -eq 0 ]; then
+    # No resolvable pushed ref. Fall back to "is HEAD ahead of main?" — but FAIL
+    # CLOSED if even that comparison can't be made (MAIN_REF unresolvable: not
+    # fetched, renamed default, --main-ref typo). `|| echo 0` here would be a
+    # fail-open data-loss hole, so capture the rc explicitly.
+    if ! ahead_main="$(git -C "$target_wt" rev-list --count "${MAIN_REF}..HEAD" 2>/dev/null)"; then
+      echo "$prog: REFUSED — cannot compare worktree '$target_wt' against $MAIN_REF (unresolvable)." >&2
+      echo "  Cannot confirm the work was pushed. Not removing." >&2
+      exit 3
+    fi
+    if [ "${ahead_main:-0}" -gt 0 ]; then
       echo "$prog: REFUSED — worktree '$target_wt' has no locally-resolvable pushed ref (no upstream;" >&2
       echo "  origin tip absent or unfetched) and HEAD is $ahead_main commit(s) ahead of $MAIN_REF —" >&2
       echo "  cannot confirm the work was pushed. Pass --confirm-unmerged only if the PR is MERGED. Not removing." >&2
@@ -252,6 +270,9 @@ fi
 if [ -n "$target_wt" ]; then
   run git_root worktree remove "$target_wt"
   note "removed worktree $target_wt"
+elif [ "$stale_wt" -eq 1 ]; then
+  run git_root worktree prune
+  note "pruned stale worktree entry for '$MERGED_BRANCH'"
 else
   note "no worktree checked out on '$MERGED_BRANCH' — skipping worktree removal"
 fi

--- a/scripts/flow/finalize-cleanup.sh
+++ b/scripts/flow/finalize-cleanup.sh
@@ -114,42 +114,69 @@ if [ "${#LOCKS[@]}" -gt 1 ]; then
   exit 2
 fi
 
-# ---------------------------------------------------------------------------
-# Guard 3: never --force-remove a dirty / unpushed worktree.
-# Only the worktree whose checked-out branch == MERGED_BRANCH is a target.
-# ---------------------------------------------------------------------------
+# Canonicalize a path (portable; falls back to the literal if it can't cd).
+canon() { ( cd "$1" 2>/dev/null && pwd -P ) || echo "$1"; }
+
+# ===========================================================================
+# PHASE 1 — VALIDATE. Gather state and run EVERY refusal guard (2/3/4) BEFORE
+# any destructive action, so a refused run never half-deletes (the #1143 lesson:
+# no mutation on a guarded path).
+# ===========================================================================
+
+# Locate the worktree (if any) checked out on MERGED_BRANCH — the ONLY removal
+# target. `git worktree list --porcelain` groups: worktree <path> / HEAD / branch.
 target_wt=""
-# `git worktree list --porcelain` groups: worktree <path> / HEAD <sha> / branch refs/heads/<name>
 while IFS= read -r line; do
   case "$line" in
     worktree\ *) cur_path="${line#worktree }" ;;
     branch\ *)
       cur_branch="${line#branch refs/heads/}"
-      if [ "$cur_branch" = "$MERGED_BRANCH" ]; then
-        target_wt="$cur_path"
-      fi
+      [ "$cur_branch" = "$MERGED_BRANCH" ] && target_wt="$cur_path"
       ;;
   esac
 done < <(git_root worktree list --porcelain)
 
+# Remote state for the merged branch.
+remote_sha="$(git_root ls-remote --heads "$REMOTE" "$MERGED_BRANCH" | awk '{print $1}')"
+remote_has_branch=0
+[ -n "$remote_sha" ] && remote_has_branch=1
+# tip_in_main: true for ff/merge-commit merges; false for squash (where
+# --confirm-unmerged is the authority that the PR was MERGED).
+tip_in_main=0
+if [ -n "$remote_sha" ] && git_root merge-base --is-ancestor "$remote_sha" "$MAIN_REF" 2>/dev/null; then
+  tip_in_main=1
+fi
+# Local-branch mergeability (independent of remote; governs -d vs -D vs skip).
+local_tip_in_main=0
+if git_root show-ref --verify --quiet "refs/heads/${MERGED_BRANCH}" \
+   && git_root merge-base --is-ancestor "refs/heads/${MERGED_BRANCH}" "$MAIN_REF" 2>/dev/null; then
+  local_tip_in_main=1
+fi
+
+# Guard 3 — worktree must be under --worktrees-dir, clean, and pushed.
 if [ -n "$target_wt" ]; then
   note "merged-branch worktree: $target_wt"
-  # uncommitted changes?
+  # 3a: containment — never remove a worktree outside the expected dir.
+  wt_canon="$(canon "$target_wt")"
+  dir_canon="$(canon "$WORKTREES_DIR")"
+  case "$wt_canon/" in
+    "$dir_canon"/*) : ;;  # under the expected worktrees dir — OK
+    *)
+      echo "$prog: REFUSED — worktree '$target_wt' is not under --worktrees-dir '$WORKTREES_DIR'. Not removing." >&2
+      exit 3
+      ;;
+  esac
+  # 3b: uncommitted changes?
   if [ -n "$(git -C "$target_wt" status --porcelain 2>/dev/null)" ]; then
     echo "$prog: REFUSED — worktree '$target_wt' has uncommitted changes. Not removing." >&2
     exit 3
   fi
-  # Unpushed commits? Compare HEAD against the best available "pushed" ref:
-  #   1. the configured upstream (@{u}), else
-  #   2. the live origin tip for this branch (in case @{u} was never set).
-  # If neither exists we cannot prove the work was pushed — refuse when HEAD is
-  # ahead of main unless --confirm-unmerged authorizes it (the merged-branch
-  # authority). This closes the no-upstream blind spot.
+  # 3c: unpushed commits? Compare HEAD against the best available "pushed" ref —
+  # the configured upstream (@{u}), else the live origin tip. If neither exists we
+  # cannot prove the work was pushed: refuse when HEAD is ahead of main unless
+  # --confirm-unmerged authorizes it (closes the no-upstream blind spot).
   cmp_ref=""
-  if cmp_ref="$(git -C "$target_wt" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null)"; then
-    :
-  else
-    remote_sha="$(git_root ls-remote --heads "$REMOTE" "$MERGED_BRANCH" | awk '{print $1}')"
+  if ! cmp_ref="$(git -C "$target_wt" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null)"; then
     cmp_ref="$remote_sha"
   fi
   if [ -n "$cmp_ref" ]; then
@@ -167,52 +194,45 @@ if [ -n "$target_wt" ]; then
       exit 3
     fi
   fi
+fi
+
+# Guard 4 — never delete an origin branch whose tip is not in main unless the
+# caller confirms the merge (squash). Validated here, BEFORE the worktree is
+# touched, so an exit-4 refusal leaves everything intact.
+if [ "$remote_has_branch" -eq 1 ] && [ "$tip_in_main" -eq 0 ] && [ "$CONFIRM_UNMERGED" -eq 0 ]; then
+  echo "$prog: REFUSED — origin branch '$MERGED_BRANCH' tip is not contained in $MAIN_REF" >&2
+  echo "  and --confirm-unmerged was not given. If this branch's PR is MERGED (e.g. squash)," >&2
+  echo "  re-run with --confirm-unmerged. Not deleting." >&2
+  exit 4
+fi
+
+# ===========================================================================
+# PHASE 2 — EXECUTE. All guards passed; mutations below are safe.
+# ===========================================================================
+
+# Guard 1: remove ONLY the merged-branch worktree (never a glob).
+if [ -n "$target_wt" ]; then
   run git_root worktree remove "$target_wt"
   note "removed worktree $target_wt"
 else
   note "no worktree checked out on '$MERGED_BRANCH' — skipping worktree removal"
 fi
 
-# ---------------------------------------------------------------------------
-# Guard 1 + 4: delete only the MERGED_BRANCH on origin; never a glob, and never
-# an unmerged tip without explicit confirmation.
-# ---------------------------------------------------------------------------
-remote_has_branch=0
-if git_root ls-remote --heads "$REMOTE" "$MERGED_BRANCH" | grep -q .; then
-  remote_has_branch=1
-fi
-
-# Is the merged-branch tip already contained in main? (true for ff / merge-commit
-# merges; false for squash merges, where --confirm-unmerged is the authority.)
-tip_in_main=0
-remote_sha="$(git_root ls-remote --heads "$REMOTE" "$MERGED_BRANCH" | awk '{print $1}')"
-if [ -n "$remote_sha" ] && git_root merge-base --is-ancestor "$remote_sha" "$MAIN_REF" 2>/dev/null; then
-  tip_in_main=1
-fi
-
+# Delete the origin lock (only the merged branch).
 if [ "$remote_has_branch" -eq 1 ]; then
-  # Guard 4: never delete an origin branch whose tip is not in main unless the
-  # caller explicitly confirms it was merged (e.g. squash-merge: tip never
-  # becomes an ancestor of main). flow-finalize passes --confirm-unmerged after
-  # verifying the PR state is MERGED in step 1.
-  if [ "$tip_in_main" -eq 0 ] && [ "$CONFIRM_UNMERGED" -eq 0 ]; then
-    echo "$prog: REFUSED — origin branch '$MERGED_BRANCH' tip is not contained in $MAIN_REF" >&2
-    echo "  and --confirm-unmerged was not given. If this branch's PR is MERGED (e.g. squash)," >&2
-    echo "  re-run with --confirm-unmerged. Not deleting." >&2
-    exit 4
-  fi
   run git_root push "$REMOTE" --delete "$MERGED_BRANCH"
   note "deleted origin lock $REMOTE/$MERGED_BRANCH"
 else
   note "origin branch '$MERGED_BRANCH' already absent (likely deleted by gh pr merge --delete-branch) — nothing to delete"
 fi
 
-# Local branch: safe-delete (-d refuses unmerged). Force (-D) only when the tip
-# is in main or the caller confirmed the merge; otherwise leave the local ref.
+# Local branch: -d when mergeable, -D when merge is confirmed, else leave it.
+# Decision is computed (not inferred from run's echo) so --dry-run previews truly.
 if git_root show-ref --verify --quiet "refs/heads/${MERGED_BRANCH}"; then
-  if run git_root branch -d "$MERGED_BRANCH" 2>/dev/null; then
+  if [ "$local_tip_in_main" -eq 1 ]; then
+    run git_root branch -d "$MERGED_BRANCH"
     note "deleted local branch $MERGED_BRANCH"
-  elif [ "$tip_in_main" -eq 1 ] || [ "$CONFIRM_UNMERGED" -eq 1 ]; then
+  elif [ "$CONFIRM_UNMERGED" -eq 1 ]; then
     run git_root branch -D "$MERGED_BRANCH"
     note "force-deleted local branch $MERGED_BRANCH (confirmed merged)"
   else

--- a/scripts/flow/finalize-cleanup.sh
+++ b/scripts/flow/finalize-cleanup.sh
@@ -71,13 +71,19 @@ while [ $# -gt 0 ]; do
     --main-ref)         MAIN_REF="${2:-}"; shift 2 ;;
     --confirm-unmerged) CONFIRM_UNMERGED=1; shift ;;
     --dry-run)          DRY_RUN=1; shift ;;
-    -h|--help)          sed -n '2,40p' "$0"; exit 0 ;;
+    -h|--help)          awk 'NR>=2 && /^set -euo pipefail/{exit} NR>=2' "$0"; exit 0 ;;
     *)                  die_usage "unknown argument: $1" ;;
   esac
 done
 
 [ -n "$ISSUE" ] || die_usage "--issue is required"
 [ -n "$MERGED_BRANCH" ] || die_usage "--merged-branch is required (the merged PR's headRefName)"
+# Identity guard: the merged branch MUST belong to this issue (1:1:1:1). Catches a
+# typo or a cross-issue branch name before any lock is touched.
+case "$MERGED_BRANCH" in
+  issue-${ISSUE}-*) : ;;
+  *) die_usage "--merged-branch '$MERGED_BRANCH' does not match --issue $ISSUE (expected issue-${ISSUE}-*)" ;;
+esac
 
 if [ -z "$REPO_ROOT" ]; then
   REPO_ROOT="$(git rev-parse --show-toplevel)"
@@ -171,25 +177,32 @@ if [ -n "$target_wt" ]; then
     echo "$prog: REFUSED — worktree '$target_wt' has uncommitted changes. Not removing." >&2
     exit 3
   fi
-  # 3c: unpushed commits? Compare HEAD against the best available "pushed" ref —
-  # the configured upstream (@{u}), else the live origin tip. If neither exists we
-  # cannot prove the work was pushed: refuse when HEAD is ahead of main unless
-  # --confirm-unmerged authorizes it (closes the no-upstream blind spot).
-  cmp_ref=""
-  if ! cmp_ref="$(git -C "$target_wt" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null)"; then
-    cmp_ref="$remote_sha"
+  # 3c: unpushed commits? Compare HEAD against a "pushed" ref RESOLVED TO A SHA.
+  # A configured-but-deleted upstream (the common `gh pr merge --delete-branch`
+  # case) resolves by NAME but not as a ref, so we use `rev-parse --verify`, which
+  # only succeeds when @{u} names a live commit; otherwise fall back to the live
+  # origin tip. If neither resolves we cannot prove the work was pushed: refuse
+  # when HEAD is ahead of main unless --confirm-unmerged authorizes it.
+  cmp_sha=""
+  if cmp_sha="$(git -C "$target_wt" rev-parse --verify --quiet '@{u}' 2>/dev/null)"; then
+    :
   fi
-  if [ -n "$cmp_ref" ]; then
-    ahead="$(git -C "$target_wt" rev-list --count "${cmp_ref}..HEAD" 2>/dev/null || echo 0)"
-    if [ "${ahead:-0}" -gt 0 ]; then
-      echo "$prog: REFUSED — worktree '$target_wt' has $ahead unpushed commit(s) vs $cmp_ref. Not removing." >&2
+  [ -n "$cmp_sha" ] || cmp_sha="$remote_sha"
+  if [ -n "$cmp_sha" ]; then
+    ahead="$(git -C "$target_wt" rev-list --count "${cmp_sha}..HEAD" 2>/dev/null || echo "")"
+    if [ -z "$ahead" ]; then
+      echo "$prog: REFUSED — cannot compare worktree '$target_wt' against pushed ref $cmp_sha. Not removing." >&2
+      exit 3
+    fi
+    if [ "$ahead" -gt 0 ]; then
+      echo "$prog: REFUSED — worktree '$target_wt' has $ahead unpushed commit(s) vs $cmp_sha. Not removing." >&2
       exit 3
     fi
   else
     ahead_main="$(git -C "$target_wt" rev-list --count "${MAIN_REF}..HEAD" 2>/dev/null || echo 0)"
     if [ "${ahead_main:-0}" -gt 0 ] && [ "$CONFIRM_UNMERGED" -eq 0 ]; then
-      echo "$prog: REFUSED — worktree '$target_wt' has no upstream and no origin branch, and HEAD is" >&2
-      echo "  $ahead_main commit(s) ahead of $MAIN_REF — cannot confirm the work was pushed." >&2
+      echo "$prog: REFUSED — worktree '$target_wt' has no resolvable upstream and no origin branch, and" >&2
+      echo "  HEAD is $ahead_main commit(s) ahead of $MAIN_REF — cannot confirm the work was pushed." >&2
       echo "  Pass --confirm-unmerged only if you have verified the PR is MERGED. Not removing." >&2
       exit 3
     fi

--- a/scripts/flow/finalize-cleanup.sh
+++ b/scripts/flow/finalize-cleanup.sh
@@ -104,13 +104,19 @@ run() {
 
 # ---------------------------------------------------------------------------
 # Guard 2: exactly one issue-<N>-* lock on origin (1:1:1:1).
+# FAIL CLOSED: a remote query error (auth/network/rate-limit) must NOT look like
+# "0 locks" — that would bypass the very guard the #1143 incident created. Capture
+# ls-remote in a checked statement and refuse (exit 3) on failure.
 # ---------------------------------------------------------------------------
+if ! locks_raw="$(git_root ls-remote --heads "$REMOTE" "issue-${ISSUE}-*" 2>/dev/null)"; then
+  echo "$prog: REFUSED — cannot query $REMOTE for 'issue-${ISSUE}-*' locks (remote error). Failing closed." >&2
+  exit 3
+fi
 # bash 3.2 compatible (no `mapfile`)
 LOCKS=()
 while IFS= read -r _lock; do
   [ -n "$_lock" ] && LOCKS+=("$_lock")
-done < <(git_root ls-remote --heads "$REMOTE" "issue-${ISSUE}-*" \
-           | awk '{print $2}' | sed 's,^refs/heads/,,')
+done < <(printf '%s\n' "$locks_raw" | awk 'NF{print $2}' | sed 's,^refs/heads/,,')
 note "origin locks for issue #$ISSUE: ${LOCKS[*]:-<none>}"
 
 if [ "${#LOCKS[@]}" -gt 1 ]; then
@@ -142,8 +148,13 @@ while IFS= read -r line; do
   esac
 done < <(git_root worktree list --porcelain)
 
-# Remote state for the merged branch.
-remote_sha="$(git_root ls-remote --heads "$REMOTE" "$MERGED_BRANCH" | awk '{print $1}')"
+# Remote state for the merged branch — also FAIL CLOSED on a remote query error,
+# else a blip would read as "branch already deleted, nothing to do".
+if ! merged_raw="$(git_root ls-remote --heads "$REMOTE" "$MERGED_BRANCH" 2>/dev/null)"; then
+  echo "$prog: REFUSED — cannot query $REMOTE for '$MERGED_BRANCH' (remote error). Failing closed." >&2
+  exit 3
+fi
+remote_sha="$(printf '%s\n' "$merged_raw" | awk 'NF{print $1}')"
 remote_has_branch=0
 [ -n "$remote_sha" ] && remote_has_branch=1
 # tip_in_main: true for ff/merge-commit merges; false for squash (where
@@ -187,7 +198,13 @@ if [ -n "$target_wt" ]; then
   if cmp_sha="$(git -C "$target_wt" rev-parse --verify --quiet '@{u}' 2>/dev/null)"; then
     :
   fi
-  [ -n "$cmp_sha" ] || cmp_sha="$remote_sha"
+  # Fall back to the live origin tip ONLY if that object is present locally — an
+  # ls-remote SHA need not have been fetched, and a missing object would make the
+  # comparison fail. If it's absent we drop to the conservative indeterminate path.
+  if [ -z "$cmp_sha" ] && [ -n "$remote_sha" ] \
+     && git -C "$target_wt" cat-file -e "${remote_sha}^{commit}" 2>/dev/null; then
+    cmp_sha="$remote_sha"
+  fi
   if [ -n "$cmp_sha" ]; then
     ahead="$(git -C "$target_wt" rev-list --count "${cmp_sha}..HEAD" 2>/dev/null || echo "")"
     if [ -z "$ahead" ]; then
@@ -201,9 +218,9 @@ if [ -n "$target_wt" ]; then
   else
     ahead_main="$(git -C "$target_wt" rev-list --count "${MAIN_REF}..HEAD" 2>/dev/null || echo 0)"
     if [ "${ahead_main:-0}" -gt 0 ] && [ "$CONFIRM_UNMERGED" -eq 0 ]; then
-      echo "$prog: REFUSED — worktree '$target_wt' has no resolvable upstream and no origin branch, and" >&2
-      echo "  HEAD is $ahead_main commit(s) ahead of $MAIN_REF — cannot confirm the work was pushed." >&2
-      echo "  Pass --confirm-unmerged only if you have verified the PR is MERGED. Not removing." >&2
+      echo "$prog: REFUSED — worktree '$target_wt' has no locally-resolvable pushed ref (no upstream;" >&2
+      echo "  origin tip absent or unfetched) and HEAD is $ahead_main commit(s) ahead of $MAIN_REF —" >&2
+      echo "  cannot confirm the work was pushed. Pass --confirm-unmerged only if the PR is MERGED. Not removing." >&2
       exit 3
     fi
   fi

--- a/scripts/flow/finalize-cleanup.sh
+++ b/scripts/flow/finalize-cleanup.sh
@@ -237,6 +237,10 @@ if [ -n "$target_wt" ]; then
       exit 3
     fi
     if [ "$ahead" -gt 0 ]; then
+      # NOTE: --confirm-unmerged does NOT override this. That flag confirms the PR
+      # was MERGED (a branch-tip-vs-main question); it says nothing about local
+      # commits that were never pushed. Unpushed work is unrecoverable once the
+      # worktree is gone, so this always fails closed.
       echo "$prog: REFUSED — worktree '$target_wt' has $ahead unpushed commit(s) vs $cmp_sha. Not removing." >&2
       exit 3
     fi
@@ -273,13 +277,15 @@ fi
 # PHASE 2 — EXECUTE. All guards passed; mutations below are safe.
 # ===========================================================================
 
-# Guard 1: remove ONLY the merged-branch worktree (never a glob).
+# Guard 1: remove ONLY the merged-branch worktree (never a glob). The success
+# `note` is suppressed in --dry-run (the DRY-RUN: line already states the action),
+# so dry-run never reports work as done that was only previewed.
 if [ -n "$target_wt" ]; then
   run git_root worktree remove "$target_wt"
-  note "removed worktree $target_wt"
+  [ "$DRY_RUN" -eq 1 ] || note "removed worktree $target_wt"
 elif [ "$stale_wt" -eq 1 ]; then
   run git_root worktree prune
-  note "pruned stale worktree entry for '$MERGED_BRANCH'"
+  [ "$DRY_RUN" -eq 1 ] || note "pruned stale worktree entry for '$MERGED_BRANCH'"
 else
   note "no worktree checked out on '$MERGED_BRANCH' — skipping worktree removal"
 fi
@@ -289,7 +295,7 @@ fi
 # worktree is already gone — surface it instead.
 if [ "$remote_has_branch" -eq 1 ]; then
   if run git_root push "$REMOTE" --delete "$MERGED_BRANCH"; then
-    note "deleted origin lock $REMOTE/$MERGED_BRANCH"
+    [ "$DRY_RUN" -eq 1 ] || note "deleted origin lock $REMOTE/$MERGED_BRANCH"
   else
     note "could not delete origin lock $REMOTE/$MERGED_BRANCH — left in place (delete it manually)"
   fi
@@ -307,7 +313,7 @@ fi
 if git_root show-ref --verify --quiet "refs/heads/${MERGED_BRANCH}"; then
   if [ "$local_tip_in_main" -eq 1 ] || [ "$CONFIRM_UNMERGED" -eq 1 ]; then
     if run git_root branch -D "$MERGED_BRANCH"; then
-      note "deleted local branch $MERGED_BRANCH"
+      [ "$DRY_RUN" -eq 1 ] || note "deleted local branch $MERGED_BRANCH"
     else
       note "could not delete local branch '$MERGED_BRANCH' — left in place"
     fi

--- a/scripts/flow/finalize-cleanup.sh
+++ b/scripts/flow/finalize-cleanup.sh
@@ -47,12 +47,16 @@
 #   5  refused: remote query (ls-remote) failed — fail closed, changed nothing
 #   64 usage error
 #
+# ---END-HELP---
 set -euo pipefail
 
 prog="$(basename "$0")"
 
 die_usage() { echo "$prog: $*" >&2; exit 64; }
 note()      { echo "[finalize-cleanup] $*" >&2; }
+# Assert a value-taking flag actually has a value (else `shift 2` would exit 1
+# under set -e instead of a clean usage error). Call as: need2 "$@".
+need2()     { [ "$#" -ge 2 ] || die_usage "$1 requires a value"; }
 
 ISSUE=""
 MERGED_BRANCH=""
@@ -65,15 +69,15 @@ DRY_RUN=0
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    --issue)            ISSUE="${2:-}"; shift 2 ;;
-    --merged-branch)    MERGED_BRANCH="${2:-}"; shift 2 ;;
-    --repo-root)        REPO_ROOT="${2:-}"; shift 2 ;;
-    --worktrees-dir)    WORKTREES_DIR="${2:-}"; shift 2 ;;
-    --remote)           REMOTE="${2:-}"; shift 2 ;;
-    --main-ref)         MAIN_REF="${2:-}"; shift 2 ;;
+    --issue)            need2 "$@"; ISSUE="$2"; shift 2 ;;
+    --merged-branch)    need2 "$@"; MERGED_BRANCH="$2"; shift 2 ;;
+    --repo-root)        need2 "$@"; REPO_ROOT="$2"; shift 2 ;;
+    --worktrees-dir)    need2 "$@"; WORKTREES_DIR="$2"; shift 2 ;;
+    --remote)           need2 "$@"; REMOTE="$2"; shift 2 ;;
+    --main-ref)         need2 "$@"; MAIN_REF="$2"; shift 2 ;;
     --confirm-unmerged) CONFIRM_UNMERGED=1; shift ;;
     --dry-run)          DRY_RUN=1; shift ;;
-    -h|--help)          awk 'NR>=2 && /^set -euo pipefail/{exit} NR>=2' "$0"; exit 0 ;;
+    -h|--help)          awk 'NR>=2 && /^# ---END-HELP---/{exit} NR>=2' "$0"; exit 0 ;;
     *)                  die_usage "unknown argument: $1" ;;
   esac
 done
@@ -285,15 +289,20 @@ else
   note "origin branch '$MERGED_BRANCH' already absent (likely deleted by gh pr merge --delete-branch) — nothing to delete"
 fi
 
-# Local branch: -d when mergeable, -D when merge is confirmed, else leave it.
+# Local branch: delete when we've PROVEN containment in $MAIN_REF
+# (local_tip_in_main) or the merge is confirmed; otherwise leave it. We use -D in
+# both delete cases because we've done the merge check ourselves against
+# $MAIN_REF — `git branch -d` would re-judge against the repo's *local* main,
+# which often lags origin/main and would 128-abort post-mutation. Deletion is also
+# made non-fatal (|| note) so it can never abort after the worktree/lock are gone.
 # Decision is computed (not inferred from run's echo) so --dry-run previews truly.
 if git_root show-ref --verify --quiet "refs/heads/${MERGED_BRANCH}"; then
-  if [ "$local_tip_in_main" -eq 1 ]; then
-    run git_root branch -d "$MERGED_BRANCH"
-    note "deleted local branch $MERGED_BRANCH"
-  elif [ "$CONFIRM_UNMERGED" -eq 1 ]; then
-    run git_root branch -D "$MERGED_BRANCH"
-    note "force-deleted local branch $MERGED_BRANCH (confirmed merged)"
+  if [ "$local_tip_in_main" -eq 1 ] || [ "$CONFIRM_UNMERGED" -eq 1 ]; then
+    if run git_root branch -D "$MERGED_BRANCH"; then
+      note "deleted local branch $MERGED_BRANCH"
+    else
+      note "could not delete local branch '$MERGED_BRANCH' — left in place"
+    fi
   else
     note "local branch '$MERGED_BRANCH' left in place (unmerged tip; pass --confirm-unmerged to force-delete)"
   fi

--- a/scripts/flow/finalize-cleanup.sh
+++ b/scripts/flow/finalize-cleanup.sh
@@ -83,6 +83,9 @@ while [ $# -gt 0 ]; do
 done
 
 [ -n "$ISSUE" ] || die_usage "--issue is required"
+case "$ISSUE" in
+  *[!0-9]*|'') die_usage "--issue must be a positive integer (got '$ISSUE')" ;;
+esac
 [ -n "$MERGED_BRANCH" ] || die_usage "--merged-branch is required (the merged PR's headRefName)"
 # Identity guard: the merged branch MUST belong to this issue (1:1:1:1). Catches a
 # typo or a cross-issue branch name before any lock is touched.
@@ -281,10 +284,15 @@ else
   note "no worktree checked out on '$MERGED_BRANCH' — skipping worktree removal"
 fi
 
-# Delete the origin lock (only the merged branch).
+# Delete the origin lock (only the merged branch). Non-fatal: a TOCTOU race (ref
+# removed concurrently) or a network blip must not abort under set -e after the
+# worktree is already gone — surface it instead.
 if [ "$remote_has_branch" -eq 1 ]; then
-  run git_root push "$REMOTE" --delete "$MERGED_BRANCH"
-  note "deleted origin lock $REMOTE/$MERGED_BRANCH"
+  if run git_root push "$REMOTE" --delete "$MERGED_BRANCH"; then
+    note "deleted origin lock $REMOTE/$MERGED_BRANCH"
+  else
+    note "could not delete origin lock $REMOTE/$MERGED_BRANCH — left in place (delete it manually)"
+  fi
 else
   note "origin branch '$MERGED_BRANCH' already absent (likely deleted by gh pr merge --delete-branch) — nothing to delete"
 fi

--- a/scripts/flow/finalize-cleanup.sh
+++ b/scripts/flow/finalize-cleanup.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+#
+# finalize-cleanup.sh — guarded destructive cleanup for `flow-finalize` (issue #1162).
+#
+# WHY THIS EXISTS
+# ---------------
+# The old flow-finalize cleanup globbed `issue-<N>-*` and unconditionally
+# `--force`-removed worktrees + `--delete`d origin branches. On 2026-06-27 that
+# destroyed an UNRELATED active claim: PR #1156 merged from
+# `issue-1143-read-p99-regression`, but the glob also matched a separate active
+# effort `issue-1143-scan-window-offload` (unmerged, dirty worktree) and deleted
+# it. This script makes finalize cleanup deterministic and safe:
+#
+#   1. It only ever targets the MERGED PR's branch (headRefName), never a glob.
+#   2. It refuses if >1 `issue-<N>-*` lock exists on origin (1:1:1:1 violation).
+#   3. It refuses to remove a worktree with uncommitted changes or unpushed
+#      commits (no blind --force).
+#   4. It never deletes an origin branch whose tip is not contained in `main`
+#      and is not the confirmed-merged branch, unless --confirm-unmerged.
+#
+# The merged-branch name is the authoritative "this one was merged" signal — the
+# caller (flow-finalize SKILL) resolves it from `gh pr view <pr> --json
+# headRefName` AFTER confirming the PR state is MERGED, then passes it here. This
+# keeps the script pure-git and unit-testable against a local bare remote.
+#
+# USAGE
+#   scripts/flow/finalize-cleanup.sh \
+#     --issue <N> \
+#     --merged-branch <headRefName> \
+#     [--repo-root <path>]          (default: git toplevel)
+#     [--worktrees-dir <path>]      (default: <repo-root>/.claude/worktrees)
+#     [--remote <name>]             (default: origin)
+#     [--main-ref <ref>]            (default: <remote>/main)
+#     [--confirm-unmerged]          (allow deleting a branch whose tip is not in main)
+#     [--dry-run]                   (print actions, change nothing)
+#
+# EXIT CODES
+#   0  cleanup completed (or nothing to do)
+#   2  refused: >1 lock for the issue (1:1:1:1 violation)
+#   3  refused: target worktree is dirty / has unpushed commits
+#   4  refused: target branch tip not contained in main (use --confirm-unmerged)
+#   64 usage error
+#
+set -euo pipefail
+
+prog="$(basename "$0")"
+
+die_usage() { echo "$prog: $*" >&2; exit 64; }
+note()      { echo "[finalize-cleanup] $*" >&2; }
+
+ISSUE=""
+MERGED_BRANCH=""
+REPO_ROOT=""
+WORKTREES_DIR=""
+REMOTE="origin"
+MAIN_REF=""
+CONFIRM_UNMERGED=0
+DRY_RUN=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --issue)            ISSUE="${2:-}"; shift 2 ;;
+    --merged-branch)    MERGED_BRANCH="${2:-}"; shift 2 ;;
+    --repo-root)        REPO_ROOT="${2:-}"; shift 2 ;;
+    --worktrees-dir)    WORKTREES_DIR="${2:-}"; shift 2 ;;
+    --remote)           REMOTE="${2:-}"; shift 2 ;;
+    --main-ref)         MAIN_REF="${2:-}"; shift 2 ;;
+    --confirm-unmerged) CONFIRM_UNMERGED=1; shift ;;
+    --dry-run)          DRY_RUN=1; shift ;;
+    -h|--help)          sed -n '2,40p' "$0"; exit 0 ;;
+    *)                  die_usage "unknown argument: $1" ;;
+  esac
+done
+
+[ -n "$ISSUE" ] || die_usage "--issue is required"
+[ -n "$MERGED_BRANCH" ] || die_usage "--merged-branch is required (the merged PR's headRefName)"
+
+if [ -z "$REPO_ROOT" ]; then
+  REPO_ROOT="$(git rev-parse --show-toplevel)"
+fi
+[ -d "$REPO_ROOT/.git" ] || [ -f "$REPO_ROOT/.git" ] || die_usage "not a git repo: $REPO_ROOT"
+[ -n "$WORKTREES_DIR" ] || WORKTREES_DIR="$REPO_ROOT/.claude/worktrees"
+[ -n "$MAIN_REF" ] || MAIN_REF="$REMOTE/main"
+
+git_root() { git -C "$REPO_ROOT" "$@"; }
+
+run() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "DRY-RUN: $*" >&2
+  else
+    "$@"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Guard 2: exactly one issue-<N>-* lock on origin (1:1:1:1).
+# ---------------------------------------------------------------------------
+# bash 3.2 compatible (no `mapfile`)
+LOCKS=()
+while IFS= read -r _lock; do
+  [ -n "$_lock" ] && LOCKS+=("$_lock")
+done < <(git_root ls-remote --heads "$REMOTE" "issue-${ISSUE}-*" \
+           | awk '{print $2}' | sed 's,^refs/heads/,,')
+note "origin locks for issue #$ISSUE: ${LOCKS[*]:-<none>}"
+
+if [ "${#LOCKS[@]}" -gt 1 ]; then
+  echo "$prog: REFUSED — ${#LOCKS[@]} 'issue-${ISSUE}-*' locks exist on $REMOTE:" >&2
+  for l in "${LOCKS[@]}"; do echo "  - $l" >&2; done
+  echo "$prog: this is a 1:1:1:1 violation. Resolve manually; not deleting anything." >&2
+  exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Guard 3: never --force-remove a dirty / unpushed worktree.
+# Only the worktree whose checked-out branch == MERGED_BRANCH is a target.
+# ---------------------------------------------------------------------------
+target_wt=""
+# `git worktree list --porcelain` groups: worktree <path> / HEAD <sha> / branch refs/heads/<name>
+while IFS= read -r line; do
+  case "$line" in
+    worktree\ *) cur_path="${line#worktree }" ;;
+    branch\ *)
+      cur_branch="${line#branch refs/heads/}"
+      if [ "$cur_branch" = "$MERGED_BRANCH" ]; then
+        target_wt="$cur_path"
+      fi
+      ;;
+  esac
+done < <(git_root worktree list --porcelain)
+
+if [ -n "$target_wt" ]; then
+  note "merged-branch worktree: $target_wt"
+  # uncommitted changes?
+  if [ -n "$(git -C "$target_wt" status --porcelain 2>/dev/null)" ]; then
+    echo "$prog: REFUSED — worktree '$target_wt' has uncommitted changes. Not removing." >&2
+    exit 3
+  fi
+  # unpushed commits (branch ahead of its upstream)? Only checkable when upstream set.
+  if upstream="$(git -C "$target_wt" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null)"; then
+    ahead="$(git -C "$target_wt" rev-list --count "${upstream}..HEAD" 2>/dev/null || echo 0)"
+    if [ "${ahead:-0}" -gt 0 ]; then
+      echo "$prog: REFUSED — worktree '$target_wt' has $ahead unpushed commit(s) vs $upstream. Not removing." >&2
+      exit 3
+    fi
+  fi
+  run git_root worktree remove "$target_wt"
+  note "removed worktree $target_wt"
+else
+  note "no worktree checked out on '$MERGED_BRANCH' — skipping worktree removal"
+fi
+
+# ---------------------------------------------------------------------------
+# Guard 1 + 4: delete only the MERGED_BRANCH on origin; never a glob, and never
+# an unmerged tip without explicit confirmation.
+# ---------------------------------------------------------------------------
+remote_has_branch=0
+if git_root ls-remote --heads "$REMOTE" "$MERGED_BRANCH" | grep -q .; then
+  remote_has_branch=1
+fi
+
+if [ "$remote_has_branch" -eq 1 ]; then
+  # The merged PR's branch is authoritatively merged (caller confirmed state=MERGED),
+  # so a squash-merge tip not being an ancestor of main is expected and OK to delete.
+  # We still honor guard 4 for safety when the caller did NOT confirm a merge.
+  tip_in_main=0
+  if git_root merge-base --is-ancestor "refs/remotes/${REMOTE}/${MERGED_BRANCH}" "$MAIN_REF" 2>/dev/null \
+     || git_root merge-base --is-ancestor "$(git_root ls-remote --heads "$REMOTE" "$MERGED_BRANCH" | awk '{print $1}')" "$MAIN_REF" 2>/dev/null; then
+    tip_in_main=1
+  fi
+  if [ "$tip_in_main" -eq 0 ] && [ "$CONFIRM_UNMERGED" -eq 0 ]; then
+    note "branch '$MERGED_BRANCH' tip not contained in $MAIN_REF (expected for squash-merge of a MERGED PR)."
+    note "deleting because it is the confirmed-merged PR branch passed via --merged-branch."
+  fi
+  run git_root push "$REMOTE" --delete "$MERGED_BRANCH"
+  note "deleted origin lock $REMOTE/$MERGED_BRANCH"
+else
+  note "origin branch '$MERGED_BRANCH' already absent (likely deleted by gh pr merge --delete-branch) — nothing to delete"
+fi
+
+# Local branch: safe-delete; force only the confirmed-merged branch.
+if git_root show-ref --verify --quiet "refs/heads/${MERGED_BRANCH}"; then
+  if ! run git_root branch -d "$MERGED_BRANCH" 2>/dev/null; then
+    # squash-merge => not an ancestor of main; -d refuses. It's the confirmed
+    # merged branch, so -D is safe here (and only here).
+    run git_root branch -D "$MERGED_BRANCH"
+  fi
+  note "deleted local branch $MERGED_BRANCH"
+fi
+
+note "cleanup complete for issue #$ISSUE (branch $MERGED_BRANCH)"

--- a/scripts/flow/finalize-cleanup.sh
+++ b/scripts/flow/finalize-cleanup.sh
@@ -35,14 +35,16 @@
 #     [--dry-run]                   (print actions, change nothing)
 #
 # --dry-run previews the destructive git actions but STILL honors the refusal
-# guards: a dirty/unpushed worktree or an unmerged tip aborts with exit 3/4 even
-# in dry-run, since those are the conditions worth surfacing before any real run.
+# guards: a dirty/unpushed worktree, an unmerged tip, or a remote-query failure
+# aborts with exit 3/4/5 even in dry-run — those are the conditions worth
+# surfacing before any real run.
 #
 # EXIT CODES
 #   0  cleanup completed (or nothing to do)
 #   2  refused: >1 lock for the issue (1:1:1:1 violation)
 #   3  refused: target worktree is dirty / has unpushed commits
 #   4  refused: target branch tip not contained in main (use --confirm-unmerged)
+#   5  refused: remote query (ls-remote) failed — fail closed, changed nothing
 #   64 usage error
 #
 set -euo pipefail
@@ -96,7 +98,13 @@ git_root() { git -C "$REPO_ROOT" "$@"; }
 
 run() {
   if [ "$DRY_RUN" -eq 1 ]; then
-    echo "DRY-RUN: $*" >&2
+    # Render the internal git_root wrapper as the real command for an honest preview.
+    if [ "${1:-}" = "git_root" ]; then
+      shift
+      echo "DRY-RUN: git -C $REPO_ROOT $*" >&2
+    else
+      echo "DRY-RUN: $*" >&2
+    fi
   else
     "$@"
   fi
@@ -106,11 +114,11 @@ run() {
 # Guard 2: exactly one issue-<N>-* lock on origin (1:1:1:1).
 # FAIL CLOSED: a remote query error (auth/network/rate-limit) must NOT look like
 # "0 locks" — that would bypass the very guard the #1143 incident created. Capture
-# ls-remote in a checked statement and refuse (exit 3) on failure.
+# ls-remote in a checked statement and refuse (exit 5) on failure.
 # ---------------------------------------------------------------------------
 if ! locks_raw="$(git_root ls-remote --heads "$REMOTE" "issue-${ISSUE}-*" 2>/dev/null)"; then
   echo "$prog: REFUSED — cannot query $REMOTE for 'issue-${ISSUE}-*' locks (remote error). Failing closed." >&2
-  exit 3
+  exit 5
 fi
 # bash 3.2 compatible (no `mapfile`)
 LOCKS=()
@@ -152,7 +160,7 @@ done < <(git_root worktree list --porcelain)
 # else a blip would read as "branch already deleted, nothing to do".
 if ! merged_raw="$(git_root ls-remote --heads "$REMOTE" "$MERGED_BRANCH" 2>/dev/null)"; then
   echo "$prog: REFUSED — cannot query $REMOTE for '$MERGED_BRANCH' (remote error). Failing closed." >&2
-  exit 3
+  exit 5
 fi
 remote_sha="$(printf '%s\n' "$merged_raw" | awk 'NF{print $1}')"
 remote_has_branch=0

--- a/scripts/flow/finalize-cleanup.sh
+++ b/scripts/flow/finalize-cleanup.sh
@@ -34,6 +34,10 @@
 #     [--confirm-unmerged]          (allow deleting a branch whose tip is not in main)
 #     [--dry-run]                   (print actions, change nothing)
 #
+# --dry-run previews the destructive git actions but STILL honors the refusal
+# guards: a dirty/unpushed worktree or an unmerged tip aborts with exit 3/4 even
+# in dry-run, since those are the conditions worth surfacing before any real run.
+#
 # EXIT CODES
 #   0  cleanup completed (or nothing to do)
 #   2  refused: >1 lock for the issue (1:1:1:1 violation)
@@ -135,11 +139,31 @@ if [ -n "$target_wt" ]; then
     echo "$prog: REFUSED — worktree '$target_wt' has uncommitted changes. Not removing." >&2
     exit 3
   fi
-  # unpushed commits (branch ahead of its upstream)? Only checkable when upstream set.
-  if upstream="$(git -C "$target_wt" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null)"; then
-    ahead="$(git -C "$target_wt" rev-list --count "${upstream}..HEAD" 2>/dev/null || echo 0)"
+  # Unpushed commits? Compare HEAD against the best available "pushed" ref:
+  #   1. the configured upstream (@{u}), else
+  #   2. the live origin tip for this branch (in case @{u} was never set).
+  # If neither exists we cannot prove the work was pushed — refuse when HEAD is
+  # ahead of main unless --confirm-unmerged authorizes it (the merged-branch
+  # authority). This closes the no-upstream blind spot.
+  cmp_ref=""
+  if cmp_ref="$(git -C "$target_wt" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null)"; then
+    :
+  else
+    remote_sha="$(git_root ls-remote --heads "$REMOTE" "$MERGED_BRANCH" | awk '{print $1}')"
+    cmp_ref="$remote_sha"
+  fi
+  if [ -n "$cmp_ref" ]; then
+    ahead="$(git -C "$target_wt" rev-list --count "${cmp_ref}..HEAD" 2>/dev/null || echo 0)"
     if [ "${ahead:-0}" -gt 0 ]; then
-      echo "$prog: REFUSED — worktree '$target_wt' has $ahead unpushed commit(s) vs $upstream. Not removing." >&2
+      echo "$prog: REFUSED — worktree '$target_wt' has $ahead unpushed commit(s) vs $cmp_ref. Not removing." >&2
+      exit 3
+    fi
+  else
+    ahead_main="$(git -C "$target_wt" rev-list --count "${MAIN_REF}..HEAD" 2>/dev/null || echo 0)"
+    if [ "${ahead_main:-0}" -gt 0 ] && [ "$CONFIRM_UNMERGED" -eq 0 ]; then
+      echo "$prog: REFUSED — worktree '$target_wt' has no upstream and no origin branch, and HEAD is" >&2
+      echo "  $ahead_main commit(s) ahead of $MAIN_REF — cannot confirm the work was pushed." >&2
+      echo "  Pass --confirm-unmerged only if you have verified the PR is MERGED. Not removing." >&2
       exit 3
     fi
   fi
@@ -158,18 +182,24 @@ if git_root ls-remote --heads "$REMOTE" "$MERGED_BRANCH" | grep -q .; then
   remote_has_branch=1
 fi
 
+# Is the merged-branch tip already contained in main? (true for ff / merge-commit
+# merges; false for squash merges, where --confirm-unmerged is the authority.)
+tip_in_main=0
+remote_sha="$(git_root ls-remote --heads "$REMOTE" "$MERGED_BRANCH" | awk '{print $1}')"
+if [ -n "$remote_sha" ] && git_root merge-base --is-ancestor "$remote_sha" "$MAIN_REF" 2>/dev/null; then
+  tip_in_main=1
+fi
+
 if [ "$remote_has_branch" -eq 1 ]; then
-  # The merged PR's branch is authoritatively merged (caller confirmed state=MERGED),
-  # so a squash-merge tip not being an ancestor of main is expected and OK to delete.
-  # We still honor guard 4 for safety when the caller did NOT confirm a merge.
-  tip_in_main=0
-  if git_root merge-base --is-ancestor "refs/remotes/${REMOTE}/${MERGED_BRANCH}" "$MAIN_REF" 2>/dev/null \
-     || git_root merge-base --is-ancestor "$(git_root ls-remote --heads "$REMOTE" "$MERGED_BRANCH" | awk '{print $1}')" "$MAIN_REF" 2>/dev/null; then
-    tip_in_main=1
-  fi
+  # Guard 4: never delete an origin branch whose tip is not in main unless the
+  # caller explicitly confirms it was merged (e.g. squash-merge: tip never
+  # becomes an ancestor of main). flow-finalize passes --confirm-unmerged after
+  # verifying the PR state is MERGED in step 1.
   if [ "$tip_in_main" -eq 0 ] && [ "$CONFIRM_UNMERGED" -eq 0 ]; then
-    note "branch '$MERGED_BRANCH' tip not contained in $MAIN_REF (expected for squash-merge of a MERGED PR)."
-    note "deleting because it is the confirmed-merged PR branch passed via --merged-branch."
+    echo "$prog: REFUSED — origin branch '$MERGED_BRANCH' tip is not contained in $MAIN_REF" >&2
+    echo "  and --confirm-unmerged was not given. If this branch's PR is MERGED (e.g. squash)," >&2
+    echo "  re-run with --confirm-unmerged. Not deleting." >&2
+    exit 4
   fi
   run git_root push "$REMOTE" --delete "$MERGED_BRANCH"
   note "deleted origin lock $REMOTE/$MERGED_BRANCH"
@@ -177,14 +207,17 @@ else
   note "origin branch '$MERGED_BRANCH' already absent (likely deleted by gh pr merge --delete-branch) — nothing to delete"
 fi
 
-# Local branch: safe-delete; force only the confirmed-merged branch.
+# Local branch: safe-delete (-d refuses unmerged). Force (-D) only when the tip
+# is in main or the caller confirmed the merge; otherwise leave the local ref.
 if git_root show-ref --verify --quiet "refs/heads/${MERGED_BRANCH}"; then
-  if ! run git_root branch -d "$MERGED_BRANCH" 2>/dev/null; then
-    # squash-merge => not an ancestor of main; -d refuses. It's the confirmed
-    # merged branch, so -D is safe here (and only here).
+  if run git_root branch -d "$MERGED_BRANCH" 2>/dev/null; then
+    note "deleted local branch $MERGED_BRANCH"
+  elif [ "$tip_in_main" -eq 1 ] || [ "$CONFIRM_UNMERGED" -eq 1 ]; then
     run git_root branch -D "$MERGED_BRANCH"
+    note "force-deleted local branch $MERGED_BRANCH (confirmed merged)"
+  else
+    note "local branch '$MERGED_BRANCH' left in place (unmerged tip; pass --confirm-unmerged to force-delete)"
   fi
-  note "deleted local branch $MERGED_BRANCH"
 fi
 
 note "cleanup complete for issue #$ISSUE (branch $MERGED_BRANCH)"

--- a/scripts/flow/tests/finalize-cleanup.test.sh
+++ b/scripts/flow/tests/finalize-cleanup.test.sh
@@ -284,7 +284,7 @@ g -C "$WORK" show-ref --verify --quiet refs/heads/issue-1214-feature && fail "lo
 rm -rf "$T"
 
 # ===========================================================================
-echo "TEST 19: local main lagging origin/main (tip in origin/main) → still exit 0"
+echo "TEST 17: local main lagging origin/main (tip in origin/main) → still exit 0"
 # ===========================================================================
 # Realistic production state: the worktree repo's LOCAL main lags origin/main.
 # `git branch -d` judges against local main and would refuse + 128-abort
@@ -305,7 +305,7 @@ g -C "$WORK" show-ref --verify --quiet refs/heads/issue-1217-feature && fail "lo
 rm -rf "$T"
 
 # ===========================================================================
-echo "TEST 17: unresolvable --main-ref in indeterminate path → fail closed (exit 3)"
+echo "TEST 18: unresolvable --main-ref in indeterminate path → fail closed (exit 3)"
 # ===========================================================================
 # No upstream, no origin branch → indeterminate path falls back to MAIN_REF; if
 # that is unresolvable we must refuse, not silently treat as '0 ahead' and delete.
@@ -321,7 +321,7 @@ bash "$CLEANUP" --issue 1215 --merged-branch issue-1215-local --main-ref refs/he
 rm -rf "$T"
 
 # ===========================================================================
-echo "TEST 18: stale worktree dir (removed out-of-band) → prune, not a 128 abort"
+echo "TEST 19: stale worktree dir (removed out-of-band) → prune, not a 128 abort"
 # ===========================================================================
 T=$(mktemp -d); build_sandbox "$T"; WORK="$T/work"
 add_branch_worktree "$WORK" "issue-1216-feature" "$T/wt" ""

--- a/scripts/flow/tests/finalize-cleanup.test.sh
+++ b/scripts/flow/tests/finalize-cleanup.test.sh
@@ -345,6 +345,15 @@ bash "$CLEANUP" --issue 'abc' --merged-branch issue-abc-x \
 [ "$rc" -eq 64 ] && ok "exit 64 — non-numeric --issue rejected" || fail "expected exit 64, got $rc"
 rm -rf "$T"
 
+# ===========================================================================
+echo "TEST 21: --help exits 0 and renders the usage block"
+# ===========================================================================
+out="$(bash "$CLEANUP" --help 2>&1)"; rc=$?
+[ "$rc" -eq 0 ] && ok "--help exits 0" || fail "expected exit 0, got $rc"
+echo "$out" | grep -q "USAGE" && ok "--help shows USAGE" || fail "--help missing USAGE"
+echo "$out" | grep -q "EXIT CODES" && ok "--help shows EXIT CODES" || fail "--help missing EXIT CODES"
+echo "$out" | grep -q "END-HELP" && fail "--help leaked the sentinel" || ok "--help stops before sentinel"
+
 echo ""
 echo "================  finalize-cleanup: $PASS passed, $FAIL failed  ================"
 [ "$FAIL" -eq 0 ]

--- a/scripts/flow/tests/finalize-cleanup.test.sh
+++ b/scripts/flow/tests/finalize-cleanup.test.sh
@@ -259,9 +259,28 @@ add_branch_worktree "$WORK" "issue-1213-feature" "$T/wt" ""
 rc=0
 bash "$CLEANUP" --issue 1213 --merged-branch issue-1213-feature --remote no-such-remote \
   --repo-root "$WORK" --worktrees-dir "$T" >/dev/null 2>&1 || rc=$?
-[ "$rc" -eq 3 ] && ok "exit 3 — fail closed on remote query error" || fail "expected exit 3, got $rc"
+[ "$rc" -eq 5 ] && ok "exit 5 — fail closed on remote query error" || fail "expected exit 5, got $rc"
 [ -d "$T/wt" ] && ok "worktree intact (no fail-open mutation)" || fail "worktree removed on remote error"
 remote_branches "$WORK" | grep -qx "issue-1213-feature" && ok "origin branch intact" || fail "branch deleted on remote error"
+rm -rf "$T"
+
+# ===========================================================================
+echo "TEST 16: ff/merge-commit path (tip in main) → cleanup WITHOUT --confirm-unmerged"
+# ===========================================================================
+# Exercises the tip_in_main=1 / local -d branch that the squash tests never hit.
+T=$(mktemp -d); build_sandbox "$T"; WORK="$T/work"
+add_branch_worktree "$WORK" "issue-1214-feature" "$T/wt" ""
+( cd "$WORK" || exit 1
+  g fetch -q origin issue-1214-feature
+  g merge -q --no-ff -m "merge 1214" origin/issue-1214-feature
+  g push -q origin main )   # origin tip now contained in main
+rc=0
+bash "$CLEANUP" --issue 1214 --merged-branch issue-1214-feature \
+  --repo-root "$WORK" --worktrees-dir "$T" >/dev/null 2>&1 || rc=$?
+[ "$rc" -eq 0 ] && ok "exit 0 on merged tip without --confirm-unmerged" || fail "expected exit 0, got $rc"
+[ ! -d "$T/wt" ] && ok "worktree removed" || fail "worktree not removed"
+remote_branches "$WORK" | grep -qx "issue-1214-feature" && fail "origin branch not deleted" || ok "origin branch deleted"
+g -C "$WORK" show-ref --verify --quiet refs/heads/issue-1214-feature && fail "local branch not deleted" || ok "local branch deleted (-d)"
 rm -rf "$T"
 
 echo ""

--- a/scripts/flow/tests/finalize-cleanup.test.sh
+++ b/scripts/flow/tests/finalize-cleanup.test.sh
@@ -169,6 +169,8 @@ bash "$CLEANUP" --issue 1206 --merged-branch issue-1206-feature \
   --repo-root "$WORK" --worktrees-dir "$T" >/dev/null 2>&1 || rc=$?
 [ "$rc" -eq 4 ] && ok "exit 4 — unmerged origin tip refused without confirmation" || fail "expected exit 4, got $rc"
 remote_branches "$WORK" | grep -qx "issue-1206-feature" && ok "origin branch survives (Guard 4)" || fail "origin branch deleted without confirmation"
+# validate-before-mutate: a refused (exit 4) run must NOT have removed the worktree
+[ -d "$T/wt" ] && ok "worktree intact on refused path (no half-deletion)" || fail "worktree removed on exit-4 path — non-atomic"
 rm -rf "$T"
 
 # ===========================================================================
@@ -180,6 +182,32 @@ bash "$CLEANUP" --issue 1207 --merged-branch issue-1207-feature --confirm-unmerg
   --repo-root "$WORK" --worktrees-dir "$T" >/dev/null 2>&1; rc=$?
 [ "$rc" -eq 0 ] && ok "exit 0 with --confirm-unmerged" || fail "expected exit 0, got $rc"
 remote_branches "$WORK" | grep -qx "issue-1207-feature" && fail "origin branch NOT deleted" || ok "origin branch deleted with confirmation"
+rm -rf "$T"
+
+# ===========================================================================
+echo "TEST 10: worktree outside --worktrees-dir → refuse (exit 3), no removal"
+# ===========================================================================
+T=$(mktemp -d); build_sandbox "$T"; WORK="$T/work"
+add_branch_worktree "$WORK" "issue-1208-feature" "$T/wt" ""
+rc=0
+# point --worktrees-dir at a sibling dir that does NOT contain the worktree
+bash "$CLEANUP" --issue 1208 --merged-branch issue-1208-feature --confirm-unmerged \
+  --repo-root "$WORK" --worktrees-dir "$T/elsewhere" >/dev/null 2>&1 || rc=$?
+[ "$rc" -eq 3 ] && ok "exit 3 — worktree not under --worktrees-dir" || fail "expected exit 3, got $rc"
+[ -d "$T/wt" ] && ok "out-of-dir worktree survives" || fail "out-of-dir worktree removed"
+rm -rf "$T"
+
+# ===========================================================================
+echo "TEST 11: --dry-run previews without mutating (happy path)"
+# ===========================================================================
+T=$(mktemp -d); build_sandbox "$T"; WORK="$T/work"
+add_branch_worktree "$WORK" "issue-1209-feature" "$T/wt" ""
+out=$(bash "$CLEANUP" --issue 1209 --merged-branch issue-1209-feature --confirm-unmerged --dry-run \
+  --repo-root "$WORK" --worktrees-dir "$T" 2>&1); rc=$?
+[ "$rc" -eq 0 ] && ok "exit 0 on dry-run" || fail "expected exit 0, got $rc"
+[ -d "$T/wt" ] && ok "dry-run did not remove worktree" || fail "dry-run removed worktree"
+remote_branches "$WORK" | grep -qx "issue-1209-feature" && ok "dry-run did not delete origin branch" || fail "dry-run deleted branch"
+echo "$out" | grep -q "DRY-RUN" && ok "dry-run prints planned actions" || fail "no DRY-RUN output"
 rm -rf "$T"
 
 echo ""

--- a/scripts/flow/tests/finalize-cleanup.test.sh
+++ b/scripts/flow/tests/finalize-cleanup.test.sh
@@ -280,7 +280,28 @@ bash "$CLEANUP" --issue 1214 --merged-branch issue-1214-feature \
 [ "$rc" -eq 0 ] && ok "exit 0 on merged tip without --confirm-unmerged" || fail "expected exit 0, got $rc"
 [ ! -d "$T/wt" ] && ok "worktree removed" || fail "worktree not removed"
 remote_branches "$WORK" | grep -qx "issue-1214-feature" && fail "origin branch not deleted" || ok "origin branch deleted"
-g -C "$WORK" show-ref --verify --quiet refs/heads/issue-1214-feature && fail "local branch not deleted" || ok "local branch deleted (-d)"
+g -C "$WORK" show-ref --verify --quiet refs/heads/issue-1214-feature && fail "local branch not deleted" || ok "local branch deleted"
+rm -rf "$T"
+
+# ===========================================================================
+echo "TEST 19: local main lagging origin/main (tip in origin/main) → still exit 0"
+# ===========================================================================
+# Realistic production state: the worktree repo's LOCAL main lags origin/main.
+# `git branch -d` judges against local main and would refuse + 128-abort
+# post-mutation; the script proves containment against origin/main and uses -D.
+T=$(mktemp -d); build_sandbox "$T"; WORK="$T/work"
+add_branch_worktree "$WORK" "issue-1217-feature" "$T/wt" ""
+g clone -q "$T/origin.git" "$T/work2" 2>/dev/null
+( cd "$T/work2" || exit 1
+  g fetch -q origin issue-1217-feature
+  g merge -q --no-ff -m "merge 1217" origin/issue-1217-feature
+  g push -q origin main )                 # origin/main now contains the feature
+g -C "$WORK" fetch -q origin              # WORK: remote-tracking current; LOCAL main still behind
+rc=0
+bash "$CLEANUP" --issue 1217 --merged-branch issue-1217-feature \
+  --repo-root "$WORK" --worktrees-dir "$T" >/dev/null 2>&1 || rc=$?
+[ "$rc" -eq 0 ] && ok "exit 0 with local main lagging origin/main" || fail "expected exit 0, got $rc"
+g -C "$WORK" show-ref --verify --quiet refs/heads/issue-1217-feature && fail "local branch not deleted" || ok "local branch deleted despite lagging local main"
 rm -rf "$T"
 
 # ===========================================================================

--- a/scripts/flow/tests/finalize-cleanup.test.sh
+++ b/scripts/flow/tests/finalize-cleanup.test.sh
@@ -210,6 +210,45 @@ remote_branches "$WORK" | grep -qx "issue-1209-feature" && ok "dry-run did not d
 echo "$out" | grep -q "DRY-RUN" && ok "dry-run prints planned actions" || fail "no DRY-RUN output"
 rm -rf "$T"
 
+# ===========================================================================
+echo "TEST 12: --dry-run still honors a refusal guard (dirty → exit 3)"
+# ===========================================================================
+T=$(mktemp -d); build_sandbox "$T"; WORK="$T/work"
+add_branch_worktree "$WORK" "issue-1211-feature" "$T/wt" dirty
+rc=0
+bash "$CLEANUP" --issue 1211 --merged-branch issue-1211-feature --dry-run \
+  --repo-root "$WORK" --worktrees-dir "$T" >/dev/null 2>&1 || rc=$?
+[ "$rc" -eq 3 ] && ok "dry-run aborts on dirty worktree (exit 3)" || fail "expected exit 3, got $rc"
+[ -d "$T/wt" ] && ok "worktree intact" || fail "worktree removed in dry-run"
+rm -rf "$T"
+
+# ===========================================================================
+echo "TEST 13: stale upstream must not mask unpushed commits (exit 3)"
+# ===========================================================================
+# Round-3 regression: @{u} stays *configured* after the origin branch is deleted,
+# so a name-only lookup + `|| echo 0` silently reported 0 unpushed. The SHA-verify
+# fallback must catch the real unpushed commit.
+T=$(mktemp -d); build_sandbox "$T"; WORK="$T/work"
+add_branch_worktree "$WORK" "issue-1210-feature" "$T/wt" ""    # pushed, upstream set
+( cd "$T/wt" || exit 1; echo more > h.txt; g add h.txt; g commit -qm "unpushed after push" )
+g -C "$WORK" push -q origin --delete issue-1210-feature        # origin branch gone; @{u} now stale
+rc=0
+bash "$CLEANUP" --issue 1210 --merged-branch issue-1210-feature \
+  --repo-root "$WORK" --worktrees-dir "$T" >/dev/null 2>&1 || rc=$?
+[ "$rc" -eq 3 ] && ok "exit 3 — unpushed work not masked by stale upstream" || fail "expected exit 3, got $rc"
+[ -d "$T/wt" ] && ok "worktree with unpushed work survives" || fail "worktree removed — REGRESSION"
+rm -rf "$T"
+
+# ===========================================================================
+echo "TEST 14: --merged-branch not matching --issue → usage error (exit 64)"
+# ===========================================================================
+T=$(mktemp -d); build_sandbox "$T"; WORK="$T/work"
+rc=0
+bash "$CLEANUP" --issue 1212 --merged-branch issue-9999-wrong-issue \
+  --repo-root "$WORK" --worktrees-dir "$T" >/dev/null 2>&1 || rc=$?
+[ "$rc" -eq 64 ] && ok "exit 64 — issue/branch identity mismatch rejected" || fail "expected exit 64, got $rc"
+rm -rf "$T"
+
 echo ""
 echo "================  finalize-cleanup: $PASS passed, $FAIL failed  ================"
 [ "$FAIL" -eq 0 ]

--- a/scripts/flow/tests/finalize-cleanup.test.sh
+++ b/scripts/flow/tests/finalize-cleanup.test.sh
@@ -249,6 +249,21 @@ bash "$CLEANUP" --issue 1212 --merged-branch issue-9999-wrong-issue \
 [ "$rc" -eq 64 ] && ok "exit 64 — issue/branch identity mismatch rejected" || fail "expected exit 64, got $rc"
 rm -rf "$T"
 
+# ===========================================================================
+echo "TEST 15: remote query error → fail closed (exit 3), no mutation"
+# ===========================================================================
+# A transient ls-remote failure must NOT read as '0 locks / branch deleted' and
+# bypass Guard 2. Point at a non-existent remote to force the error.
+T=$(mktemp -d); build_sandbox "$T"; WORK="$T/work"
+add_branch_worktree "$WORK" "issue-1213-feature" "$T/wt" ""
+rc=0
+bash "$CLEANUP" --issue 1213 --merged-branch issue-1213-feature --remote no-such-remote \
+  --repo-root "$WORK" --worktrees-dir "$T" >/dev/null 2>&1 || rc=$?
+[ "$rc" -eq 3 ] && ok "exit 3 — fail closed on remote query error" || fail "expected exit 3, got $rc"
+[ -d "$T/wt" ] && ok "worktree intact (no fail-open mutation)" || fail "worktree removed on remote error"
+remote_branches "$WORK" | grep -qx "issue-1213-feature" && ok "origin branch intact" || fail "branch deleted on remote error"
+rm -rf "$T"
+
 echo ""
 echo "================  finalize-cleanup: $PASS passed, $FAIL failed  ================"
 [ "$FAIL" -eq 0 ]

--- a/scripts/flow/tests/finalize-cleanup.test.sh
+++ b/scripts/flow/tests/finalize-cleanup.test.sh
@@ -283,6 +283,37 @@ remote_branches "$WORK" | grep -qx "issue-1214-feature" && fail "origin branch n
 g -C "$WORK" show-ref --verify --quiet refs/heads/issue-1214-feature && fail "local branch not deleted" || ok "local branch deleted (-d)"
 rm -rf "$T"
 
+# ===========================================================================
+echo "TEST 17: unresolvable --main-ref in indeterminate path → fail closed (exit 3)"
+# ===========================================================================
+# No upstream, no origin branch → indeterminate path falls back to MAIN_REF; if
+# that is unresolvable we must refuse, not silently treat as '0 ahead' and delete.
+T=$(mktemp -d); build_sandbox "$T"; WORK="$T/work"
+( cd "$WORK" || exit 1
+  g worktree add -q -b issue-1215-local "$T/wt" main
+  ( cd "$T/wt" || exit 1; echo x > f.txt; g add f.txt; g commit -qm "local only" ) )
+rc=0
+bash "$CLEANUP" --issue 1215 --merged-branch issue-1215-local --main-ref refs/heads/does-not-exist \
+  --repo-root "$WORK" --worktrees-dir "$T" >/dev/null 2>&1 || rc=$?
+[ "$rc" -eq 3 ] && ok "exit 3 — unresolvable --main-ref fails closed" || fail "expected exit 3, got $rc"
+[ -d "$T/wt" ] && ok "worktree survives" || fail "worktree removed on unresolvable main-ref"
+rm -rf "$T"
+
+# ===========================================================================
+echo "TEST 18: stale worktree dir (removed out-of-band) → prune, not a 128 abort"
+# ===========================================================================
+T=$(mktemp -d); build_sandbox "$T"; WORK="$T/work"
+add_branch_worktree "$WORK" "issue-1216-feature" "$T/wt" ""
+rm -rf "$T/wt"   # delete the worktree dir out-of-band; git's admin entry lingers
+rc=0
+bash "$CLEANUP" --issue 1216 --merged-branch issue-1216-feature --confirm-unmerged \
+  --repo-root "$WORK" --worktrees-dir "$T" >/dev/null 2>&1 || rc=$?
+[ "$rc" -eq 0 ] && ok "exit 0 — stale entry handled (no set -e 128 abort)" || fail "expected exit 0, got $rc"
+remote_branches "$WORK" | grep -qx "issue-1216-feature" && fail "origin branch not deleted" || ok "origin branch deleted"
+n=$(g -C "$WORK" worktree list --porcelain | grep -c '^worktree ')
+[ "$n" -eq 1 ] && ok "stale worktree entry pruned (only root remains)" || fail "stale entry remains ($n worktrees)"
+rm -rf "$T"
+
 echo ""
 echo "================  finalize-cleanup: $PASS passed, $FAIL failed  ================"
 [ "$FAIL" -eq 0 ]

--- a/scripts/flow/tests/finalize-cleanup.test.sh
+++ b/scripts/flow/tests/finalize-cleanup.test.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+#
+# Regression tests for scripts/flow/finalize-cleanup.sh (issue #1162).
+#
+# Each test builds an isolated sandbox: a bare "origin" remote + a working clone,
+# feature branches, and worktrees — then runs the cleanup script and asserts the
+# guardrails. No network, no GitHub; the merged-branch name stands in for the
+# `gh pr view --json headRefName` the SKILL resolves in production.
+#
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLEANUP="$SCRIPT_DIR/../finalize-cleanup.sh"
+
+PASS=0
+FAIL=0
+fail() { echo "  ✗ $*"; FAIL=$((FAIL+1)); }
+ok()   { echo "  ✓ $*"; PASS=$((PASS+1)); }
+
+# git in a throwaway identity so commits work in CI sandboxes
+g() { git -c user.email=t@t -c user.name=t -c init.defaultBranch=main -c commit.gpgsign=false "$@"; }
+
+# build_sandbox <dir> : a bare origin + a clone on `main` with one commit.
+build_sandbox() {
+  local root="$1"
+  mkdir -p "$root"
+  g init --bare -q "$root/origin.git"
+  g clone -q "$root/origin.git" "$root/work"
+  ( cd "$root/work" || exit 1
+    echo seed > seed.txt
+    g add seed.txt
+    g commit -qm "seed"
+    g push -q -u origin main
+  )
+}
+
+# add_branch_worktree <work> <branch> <wtdir> [dirty]
+# creates <branch> off main, pushes it, and checks it out in a worktree.
+add_branch_worktree() {
+  local work="$1" branch="$2" wt="$3" dirty="${4:-}"
+  ( cd "$work" || exit 1
+    g worktree add -q -b "$branch" "$wt" main
+    ( cd "$wt" || exit 1; echo "$branch" > f.txt; g add f.txt; g commit -qm "$branch work"; g push -q -u origin "$branch" )
+    if [ "$dirty" = "dirty" ]; then ( cd "$wt" || exit 1; echo extra >> f.txt ); fi
+  )
+}
+
+remote_branches() { g -C "$1" ls-remote --heads origin "issue-*" | awk '{print $2}' | sed 's,^refs/heads/,,' | sort; }
+
+# ===========================================================================
+echo "TEST 1: #1143 regression — merged branch's sibling active claim survives"
+# ===========================================================================
+T=$(mktemp -d); build_sandbox "$T"
+WORK="$T/work"
+# active, unmerged, DIRTY effort that must survive
+add_branch_worktree "$WORK" "issue-1143-scan-window-offload" "$T/wt-active" dirty
+# the merged branch: simulate gh pr merge --delete-branch already removed it from
+# origin, and finalize already... no: finalize is what we're testing. Create it,
+# push, then delete from origin to mimic --delete-branch, leaving only the sibling.
+add_branch_worktree "$WORK" "issue-1143-read-p99-regression" "$T/wt-merged" ""
+g -C "$WORK" push -q origin --delete issue-1143-read-p99-regression
+g -C "$WORK" worktree remove "$T/wt-merged" --force 2>/dev/null
+# Now origin has ONLY issue-1143-scan-window-offload (the active one).
+bash "$CLEANUP" --issue 1143 --merged-branch issue-1143-read-p99-regression \
+  --repo-root "$WORK" --worktrees-dir "$T" >/dev/null 2>&1
+rc=$?
+[ "$rc" -eq 0 ] && ok "exit 0 (clean no-op for already-deleted merged branch)" || fail "expected exit 0, got $rc"
+if remote_branches "$WORK" | grep -qx "issue-1143-scan-window-offload"; then
+  ok "active sibling 'issue-1143-scan-window-offload' SURVIVES on origin"
+else
+  fail "active sibling was deleted from origin — REGRESSION"
+fi
+[ -d "$T/wt-active" ] && ok "active worktree survives" || fail "active worktree was removed"
+rm -rf "$T"
+
+# ===========================================================================
+echo "TEST 2: >1 lock for the issue → refuse (exit 2), delete nothing"
+# ===========================================================================
+T=$(mktemp -d); build_sandbox "$T"; WORK="$T/work"
+add_branch_worktree "$WORK" "issue-1200-alpha" "$T/wt-a" ""
+add_branch_worktree "$WORK" "issue-1200-beta"  "$T/wt-b" ""
+out=$(bash "$CLEANUP" --issue 1200 --merged-branch issue-1200-alpha \
+  --repo-root "$WORK" --worktrees-dir "$T" 2>&1); rc=$?
+[ "$rc" -eq 2 ] && ok "exit 2 on multi-lock" || fail "expected exit 2, got $rc"
+echo "$out" | grep -q "1:1:1:1 violation" && ok "surfaces 1:1:1:1 violation" || fail "no 1:1:1:1 message"
+n=$(remote_branches "$WORK" | grep -c "issue-1200-")
+[ "$n" -eq 2 ] && ok "both branches still on origin (nothing deleted)" || fail "expected 2 branches, got $n"
+rm -rf "$T"
+
+# ===========================================================================
+echo "TEST 3: dirty worktree → refuse (exit 3), no deletion"
+# ===========================================================================
+T=$(mktemp -d); build_sandbox "$T"; WORK="$T/work"
+add_branch_worktree "$WORK" "issue-1201-feature" "$T/wt" dirty
+out=$(bash "$CLEANUP" --issue 1201 --merged-branch issue-1201-feature \
+  --repo-root "$WORK" --worktrees-dir "$T" 2>&1); rc=$?
+[ "$rc" -eq 3 ] && ok "exit 3 on dirty worktree" || fail "expected exit 3, got $rc"
+[ -d "$T/wt" ] && ok "dirty worktree survives" || fail "dirty worktree removed"
+remote_branches "$WORK" | grep -qx "issue-1201-feature" && ok "origin branch survives" || fail "origin branch deleted"
+rm -rf "$T"
+
+# ===========================================================================
+echo "TEST 4: unpushed commits → refuse (exit 3)"
+# ===========================================================================
+T=$(mktemp -d); build_sandbox "$T"; WORK="$T/work"
+add_branch_worktree "$WORK" "issue-1202-feature" "$T/wt" ""
+( cd "$T/wt" || exit 1; echo more > g.txt; g add g.txt; g commit -qm "unpushed" )  # ahead of upstream
+rc=0
+bash "$CLEANUP" --issue 1202 --merged-branch issue-1202-feature \
+  --repo-root "$WORK" --worktrees-dir "$T" >/dev/null 2>&1 || rc=$?
+[ "$rc" -eq 3 ] && ok "exit 3 on unpushed commits" || fail "expected exit 3, got $rc"
+[ -d "$T/wt" ] && ok "worktree with unpushed work survives" || fail "worktree removed"
+rm -rf "$T"
+
+# ===========================================================================
+echo "TEST 5: happy path (squash-merge semantics) → worktree + origin lock removed"
+# ===========================================================================
+T=$(mktemp -d); build_sandbox "$T"; WORK="$T/work"
+add_branch_worktree "$WORK" "issue-1203-feature" "$T/wt" ""
+# clean worktree, branch pushed; tip NOT in main (squash). Confirmed-merged via --merged-branch.
+bash "$CLEANUP" --issue 1203 --merged-branch issue-1203-feature \
+  --repo-root "$WORK" --worktrees-dir "$T" >/dev/null 2>&1; rc=$?
+[ "$rc" -eq 0 ] && ok "exit 0 on happy path" || fail "expected exit 0, got $rc"
+[ ! -d "$T/wt" ] && ok "clean worktree removed" || fail "worktree not removed"
+remote_branches "$WORK" | grep -qx "issue-1203-feature" && fail "origin lock NOT deleted" || ok "origin lock deleted"
+rm -rf "$T"
+
+# ===========================================================================
+echo "TEST 6: glob safety — only the merged branch is targeted, sibling untouched"
+# ===========================================================================
+# Here the merged branch IS still on origin (gh did not --delete-branch), so two
+# locks exist → guard 2 refuses. This proves the script never silently picks one
+# of an ambiguous pair. (The clean-resolution path is TEST 1.)
+T=$(mktemp -d); build_sandbox "$T"; WORK="$T/work"
+add_branch_worktree "$WORK" "issue-1204-merged" "$T/wt-m" ""
+add_branch_worktree "$WORK" "issue-1204-active" "$T/wt-x" dirty
+rc=0
+bash "$CLEANUP" --issue 1204 --merged-branch issue-1204-merged \
+  --repo-root "$WORK" --worktrees-dir "$T" >/dev/null 2>&1 || rc=$?
+[ "$rc" -eq 2 ] && ok "exit 2 — ambiguous pair refused, not guessed" || fail "expected exit 2, got $rc"
+[ -d "$T/wt-x" ] && ok "active sibling worktree survives" || fail "sibling worktree removed"
+rm -rf "$T"
+
+echo ""
+echo "================  finalize-cleanup: $PASS passed, $FAIL failed  ================"
+[ "$FAIL" -eq 0 ]

--- a/scripts/flow/tests/finalize-cleanup.test.sh
+++ b/scripts/flow/tests/finalize-cleanup.test.sh
@@ -25,7 +25,7 @@ build_sandbox() {
   local root="$1"
   mkdir -p "$root"
   g init --bare -q "$root/origin.git"
-  g clone -q "$root/origin.git" "$root/work"
+  g clone -q "$root/origin.git" "$root/work" 2>/dev/null
   ( cd "$root/work" || exit 1
     echo seed > seed.txt
     g add seed.txt
@@ -113,12 +113,13 @@ bash "$CLEANUP" --issue 1202 --merged-branch issue-1202-feature \
 rm -rf "$T"
 
 # ===========================================================================
-echo "TEST 5: happy path (squash-merge semantics) → worktree + origin lock removed"
+echo "TEST 5: happy path (squash-merge, --confirm-unmerged) → worktree + origin lock removed"
 # ===========================================================================
 T=$(mktemp -d); build_sandbox "$T"; WORK="$T/work"
 add_branch_worktree "$WORK" "issue-1203-feature" "$T/wt" ""
-# clean worktree, branch pushed; tip NOT in main (squash). Confirmed-merged via --merged-branch.
-bash "$CLEANUP" --issue 1203 --merged-branch issue-1203-feature \
+# clean worktree, branch pushed; tip NOT in main (squash). flow-finalize passes
+# --confirm-unmerged after verifying PR state=MERGED.
+bash "$CLEANUP" --issue 1203 --merged-branch issue-1203-feature --confirm-unmerged \
   --repo-root "$WORK" --worktrees-dir "$T" >/dev/null 2>&1; rc=$?
 [ "$rc" -eq 0 ] && ok "exit 0 on happy path" || fail "expected exit 0, got $rc"
 [ ! -d "$T/wt" ] && ok "clean worktree removed" || fail "worktree not removed"
@@ -139,6 +140,46 @@ bash "$CLEANUP" --issue 1204 --merged-branch issue-1204-merged \
   --repo-root "$WORK" --worktrees-dir "$T" >/dev/null 2>&1 || rc=$?
 [ "$rc" -eq 2 ] && ok "exit 2 — ambiguous pair refused, not guessed" || fail "expected exit 2, got $rc"
 [ -d "$T/wt-x" ] && ok "active sibling worktree survives" || fail "sibling worktree removed"
+rm -rf "$T"
+
+# ===========================================================================
+echo "TEST 7: no upstream + no origin branch + HEAD ahead of main → refuse (exit 3)"
+# ===========================================================================
+# The blind-spot case: a branch created locally, committed, but never pushed
+# (no @{u}, no origin branch). The script must NOT silently remove it.
+T=$(mktemp -d); build_sandbox "$T"; WORK="$T/work"
+( cd "$WORK" || exit 1
+  g worktree add -q -b issue-1205-local-only "$T/wt" main
+  ( cd "$T/wt" || exit 1; echo x > f.txt; g add f.txt; g commit -qm "local only, never pushed" )
+)
+rc=0
+bash "$CLEANUP" --issue 1205 --merged-branch issue-1205-local-only \
+  --repo-root "$WORK" --worktrees-dir "$T" >/dev/null 2>&1 || rc=$?
+[ "$rc" -eq 3 ] && ok "exit 3 — no-upstream unpushed work refused" || fail "expected exit 3, got $rc"
+[ -d "$T/wt" ] && ok "local-only worktree survives" || fail "local-only worktree removed — REGRESSION"
+rm -rf "$T"
+
+# ===========================================================================
+echo "TEST 8: origin branch, unmerged tip, no --confirm-unmerged → refuse (exit 4)"
+# ===========================================================================
+T=$(mktemp -d); build_sandbox "$T"; WORK="$T/work"
+add_branch_worktree "$WORK" "issue-1206-feature" "$T/wt" ""
+rc=0
+bash "$CLEANUP" --issue 1206 --merged-branch issue-1206-feature \
+  --repo-root "$WORK" --worktrees-dir "$T" >/dev/null 2>&1 || rc=$?
+[ "$rc" -eq 4 ] && ok "exit 4 — unmerged origin tip refused without confirmation" || fail "expected exit 4, got $rc"
+remote_branches "$WORK" | grep -qx "issue-1206-feature" && ok "origin branch survives (Guard 4)" || fail "origin branch deleted without confirmation"
+rm -rf "$T"
+
+# ===========================================================================
+echo "TEST 9: same as 8 but with --confirm-unmerged → deletes (exit 0)"
+# ===========================================================================
+T=$(mktemp -d); build_sandbox "$T"; WORK="$T/work"
+add_branch_worktree "$WORK" "issue-1207-feature" "$T/wt" ""
+bash "$CLEANUP" --issue 1207 --merged-branch issue-1207-feature --confirm-unmerged \
+  --repo-root "$WORK" --worktrees-dir "$T" >/dev/null 2>&1; rc=$?
+[ "$rc" -eq 0 ] && ok "exit 0 with --confirm-unmerged" || fail "expected exit 0, got $rc"
+remote_branches "$WORK" | grep -qx "issue-1207-feature" && fail "origin branch NOT deleted" || ok "origin branch deleted with confirmation"
 rm -rf "$T"
 
 echo ""

--- a/scripts/flow/tests/finalize-cleanup.test.sh
+++ b/scripts/flow/tests/finalize-cleanup.test.sh
@@ -250,7 +250,7 @@ bash "$CLEANUP" --issue 1212 --merged-branch issue-9999-wrong-issue \
 rm -rf "$T"
 
 # ===========================================================================
-echo "TEST 15: remote query error → fail closed (exit 3), no mutation"
+echo "TEST 15: remote query error → fail closed (exit 5), no mutation"
 # ===========================================================================
 # A transient ls-remote failure must NOT read as '0 locks / branch deleted' and
 # bypass Guard 2. Point at a non-existent remote to force the error.
@@ -333,6 +333,16 @@ bash "$CLEANUP" --issue 1216 --merged-branch issue-1216-feature --confirm-unmerg
 remote_branches "$WORK" | grep -qx "issue-1216-feature" && fail "origin branch not deleted" || ok "origin branch deleted"
 n=$(g -C "$WORK" worktree list --porcelain | grep -c '^worktree ')
 [ "$n" -eq 1 ] && ok "stale worktree entry pruned (only root remains)" || fail "stale entry remains ($n worktrees)"
+rm -rf "$T"
+
+# ===========================================================================
+echo "TEST 20: non-numeric --issue rejected (exit 64) — keeps Guard 2 glob tight"
+# ===========================================================================
+T=$(mktemp -d); build_sandbox "$T"; WORK="$T/work"
+rc=0
+bash "$CLEANUP" --issue 'abc' --merged-branch issue-abc-x \
+  --repo-root "$WORK" --worktrees-dir "$T" >/dev/null 2>&1 || rc=$?
+[ "$rc" -eq 64 ] && ok "exit 64 — non-numeric --issue rejected" || fail "expected exit 64, got $rc"
 rm -rf "$T"
 
 echo ""


### PR DESCRIPTION
Closes #1162.

## Problem
`flow-finalize` cleanup globbed `issue-<N>-*` and unconditionally `--force`-removed
worktrees + `--delete`d origin branches. On 2026-06-27 it destroyed an **unrelated
active claim** (the #1143 incident): PR merged from `issue-1143-read-p99-regression`,
the glob also matched + deleted the separate active `issue-1143-scan-window-offload`
(dirty worktree, unmerged). Recovered, but nearly lost.

## Fix
`scripts/flow/finalize-cleanup.sh` — deterministic, guarded cleanup:
1. Targets **only the merged PR's `headRefName`**, never a `issue-<N>-*` glob. *(AC1)*
2. Asserts **exactly one** `issue-<N>-*` lock on origin; **>1 → STOP (exit 2)** + surface 1:1:1:1 violation. *(AC2)*
3. **Refuses to `--force` remove** a worktree with uncommitted changes or unpushed commits (**exit 3**). *(AC3)*
4. Never deletes a non-merged-branch origin tip not contained in `main` without `--confirm-unmerged`. *(AC4)*

## Tests (each AC → a test)
`scripts/flow/tests/finalize-cleanup.test.sh` — 16 asserts over a sandboxed bare
origin + worktrees. **TEST 1 encodes the exact #1143 scenario** (two branches, one
merged) and asserts the active branch + worktree survive. *(AC5)*. bash 3.2 compatible;
production script is shellcheck-clean. Bug was reproduced against the old glob behavior
to confirm the test guards it.

## Wiring
- `flow-finalize` SKILL: step 1 captures `headRefName`; step 5 calls the guarded script.
- `.github/workflows/ci.yml`: new **Flow tooling guardrails** job runs the test every PR (pure git, seconds).

## Validation
`scripts/agent-gate.sh` → **RESULT: PASS** (all 12 components; zero `.rs` changed, so the
Rust surface is identical to main). Routing: process/tooling bug with deterministic
correct behavior → skip OpenSpec (no spec-auditor C), regression-test pinned.