### PR TITLE
docs(#1086): inline chunk CRC32 in Data.db is big-endian, not little-endian

### DIFF
--- a/cqlite-core/src/storage/sstable/compression_info.rs
+++ b/cqlite-core/src/storage/sstable/compression_info.rs
@@ -22,8 +22,10 @@
 //! ## Note on CRCs
 //!
 //! Per-chunk CRC32 checksums are stored INLINE in Data.db, not in CompressionInfo.db.
-//! Each compressed chunk in Data.db is followed by a 4-byte little-endian CRC32 of the
-//! compressed bytes. See: CompressedSequentialWriter.java:192.
+//! Each compressed chunk in Data.db is followed by a 4-byte big-endian CRC32 of the
+//! compressed bytes. See: CompressedSequentialWriter.java:192. The big-endian byte
+//! order was verified against 356 real Cassandra 5.0 inline trailers by the
+//! `sstable_parity_compression_info_test` parity test (issue #986 / #1086).
 //! There is NO trailing metadata CRC in CompressionInfo.db.
 
 use crate::{Error, Result};


### PR DESCRIPTION
## Summary

Doc-comment-only fix. The module doc in `cqlite-core/src/storage/sstable/compression_info.rs` claimed the 4-byte inline per-chunk CRC32 trailer in `Data.db` is **little-endian**. It is **big-endian**.

The `sstable_parity_compression_info_test` parity test (filed under #986 / Epic #968) validated 356 real Cassandra 5.0 inline CRC32 trailers and reads them with `u32::from_be_bytes`, proving big-endian. This corrects the doc to match verified behavior and cites the parity test.

## Why this is safe

- No decode logic changed. `CompressionInfo::parse` never reads the inline CRC; the parity test already reads it big-endian.
- The two `little-endian` mentions in `chunk_decompressor.rs` are about the LZ4 length prefix (a different field, correctly little-endian) — left unchanged.
- Repo-wide grep confirms no other comment propagated the inaccurate little-endian claim for the inline chunk CRC.

## Validation

`scripts/agent-gate.sh` RESULT: PASS (all components green, including python-bindings this run).

Closes #1086