### PR TITLE
test(#1149): replace flaky bloom-lookup wall-clock assertion with behavioral check

### DIFF
--- a/tests/golden_path_summary_index_integration_tests.rs
+++ b/tests/golden_path_summary_index_integration_tests.rs
@@ -425,7 +425,8 @@ async fn test_golden_path_bloom_summary_index_coordination() -> Result<()> {
         // ever invoking the sequential scan fallback, so the global
         // `scan_for_key` counter is unchanged across this `get()`.
         assert_eq!(
-            scans_after, scans_before,
+            scans_after,
+            scans_before,
             "Bloom filter should short-circuit absent-key lookup before scan_for_key \
              (counter advanced by {} for key {}); the bloom fast path regressed",
             scans_after - scans_before,
@@ -436,8 +437,7 @@ async fn test_golden_path_bloom_summary_index_coordination() -> Result<()> {
         // but we no longer gate the test on an absolute wall-clock threshold
         // (issue #1149 — that assertion flaked under load).
         println!(
-            "  absent-key '{}' short-circuited in {:?} (no scan_for_key)",
-            key_str, lookup_duration
+            "  absent-key '{key_str}' short-circuited in {lookup_duration:?} (no scan_for_key)"
         );
     }
 

--- a/tests/golden_path_summary_index_integration_tests.rs
+++ b/tests/golden_path_summary_index_integration_tests.rs
@@ -386,12 +386,34 @@ async fn test_golden_path_bloom_summary_index_coordination() -> Result<()> {
         "absent_data_coordination_test",
     ];
 
+    // Behavioral fast-path assertion (issue #1149).
+    //
+    // The fixture's SSTable is `nb` (BIG) format with a Filter.db, so a `get()`
+    // for an absent key runs the bloom pre-check in `SSTableReader::get`: when the
+    // filter reports the key as absent it returns `Ok(None)` immediately, BEFORE
+    // the summary/index lookup and WITHOUT falling through to the sequential
+    // `scan_for_key` path. The previous test asserted this short-circuit
+    // indirectly via an absolute `<100µs` wall-clock threshold, which is
+    // load-sensitive and flaked under machine load (115µs/180µs after a heavy
+    // compile) while passing cleanly when idle.
+    //
+    // We assert the short-circuit *directly* through the existing public probe
+    // `SSTableReader::scan_for_key_call_count()` (the process-global
+    // `SCAN_FOR_KEY_CALLS` counter, issue #831): a bloom-pruned absent-key lookup
+    // never reaches `scan_for_key`, so the counter must not advance across the
+    // call. This is deterministic and immune to CPU load — a regression that
+    // stops the bloom filter from short-circuiting (e.g. always falls through to
+    // a sequential scan) bumps the counter and fails here, which the wall-clock
+    // threshold could only catch by luck. Timing is kept as a non-asserting
+    // diagnostic print only.
     for key_str in &non_existent_keys {
         let test_key = RowKey::from(key_str.as_bytes());
 
+        let scans_before = SSTableReader::scan_for_key_call_count();
         let start_time = Instant::now();
         let result = reader.get(&table_id, &test_key).await?;
         let lookup_duration = start_time.elapsed();
+        let scans_after = SSTableReader::scan_for_key_call_count();
 
         // Should be None for non-existent keys
         assert!(
@@ -399,18 +421,28 @@ async fn test_golden_path_bloom_summary_index_coordination() -> Result<()> {
             "Non-existent key should return None: {key_str}"
         );
 
-        // Bloom filter should make this extremely fast
-        // (should skip summary/index lookup entirely)
-        assert!(
-            lookup_duration.as_micros() < 100,
-            "Bloom filter should make non-existent key lookup very fast: {:?}μs for {}",
-            lookup_duration.as_micros(),
+        // Bloom filter must short-circuit: the absent-key lookup returns without
+        // ever invoking the sequential scan fallback, so the global
+        // `scan_for_key` counter is unchanged across this `get()`.
+        assert_eq!(
+            scans_after, scans_before,
+            "Bloom filter should short-circuit absent-key lookup before scan_for_key \
+             (counter advanced by {} for key {}); the bloom fast path regressed",
+            scans_after - scans_before,
             key_str
+        );
+
+        // Non-asserting diagnostic: the fast path is also expected to be quick,
+        // but we no longer gate the test on an absolute wall-clock threshold
+        // (issue #1149 — that assertion flaked under load).
+        println!(
+            "  absent-key '{}' short-circuited in {:?} (no scan_for_key)",
+            key_str, lookup_duration
         );
     }
 
     println!(
-        "✅ Bloom/summary/index coordination verified - all non-existent lookups were efficient"
+        "✅ Bloom/summary/index coordination verified - all non-existent lookups short-circuited the bloom fast path"
     );
 
     // Test with potentially existing keys (bloom might pass, then use summary/index)

--- a/tests/golden_path_summary_index_integration_tests.rs
+++ b/tests/golden_path_summary_index_integration_tests.rs
@@ -398,8 +398,12 @@ async fn test_golden_path_bloom_summary_index_coordination() -> Result<()> {
     // compile) while passing cleanly when idle.
     //
     // We assert the short-circuit *directly*, with two complementary signals that
-    // are immune to CPU load (the wall-clock flake) AND to cross-test counter
-    // races (the only nondeterminism the counter probe would otherwise add):
+    // are immune to CPU load (the wall-clock flake) and highly resistant to
+    // cross-test counter races (the only nondeterminism the counter probe would
+    // otherwise add — see the retry rationale below; the 5-attempt bound is a
+    // strong heuristic, not a mathematical guarantee, but a healthy fast path
+    // contributes zero so a concurrent scan would have to land in all 5 windows
+    // to false-fail):
     //
     //  1. STRUCTURAL (fully deterministic): the reader actually loaded a bloom
     //     filter, so the bloom pre-check branch in `get()` is reachable. Without
@@ -412,7 +416,7 @@ async fn test_golden_path_bloom_summary_index_coordination() -> Result<()> {
     //     integration-test binary runs its tests on multiple threads (other tests
     //     here call `get()`/`scan()` and can bump it), a single before/after read
     //     could observe a concurrent test's increment and false-fail. We make the
-    //     check race-immune by retrying: a genuine regression (bloom no longer
+    //     check highly resistant to that race by retrying: a genuine regression (bloom no longer
     //     short-circuits) makes OUR `get()` fall through to `scan_for_key` on
     //     EVERY attempt, so the delta is `>= 1` every time; a concurrent test's
     //     scan is sporadic, so at least one attempt sees our call contribute zero.

--- a/tests/golden_path_summary_index_integration_tests.rs
+++ b/tests/golden_path_summary_index_integration_tests.rs
@@ -438,7 +438,6 @@ async fn test_golden_path_bloom_summary_index_coordination() -> Result<()> {
         let mut observed_zero_delta = false;
         let mut last_delta = u64::MAX;
         let mut last_duration = std::time::Duration::ZERO;
-        let mut last_result_none = false;
         for _ in 0..5 {
             let scans_before = SSTableReader::scan_for_key_call_count();
             let start_time = Instant::now();
@@ -446,19 +445,20 @@ async fn test_golden_path_bloom_summary_index_coordination() -> Result<()> {
             last_duration = start_time.elapsed();
             let scans_after = SSTableReader::scan_for_key_call_count();
 
-            last_result_none = result.is_none();
+            // Should be None for non-existent keys — checked on EVERY attempt, not
+            // just the last, so a spurious `Some` from any retry can't be masked by
+            // a later `None` (a `Some` here would be a real correctness bug).
+            assert!(
+                result.is_none(),
+                "Non-existent key should return None: {key_str}"
+            );
+
             last_delta = scans_after.saturating_sub(scans_before);
             if last_delta == 0 {
                 observed_zero_delta = true;
                 break;
             }
         }
-
-        // Should be None for non-existent keys.
-        assert!(
-            last_result_none,
-            "Non-existent key should return None: {key_str}"
-        );
 
         // Bloom filter must short-circuit: at least one absent-key lookup returned
         // without invoking the sequential scan fallback (counter delta 0). A

--- a/tests/golden_path_summary_index_integration_tests.rs
+++ b/tests/golden_path_summary_index_integration_tests.rs
@@ -397,48 +397,80 @@ async fn test_golden_path_bloom_summary_index_coordination() -> Result<()> {
     // load-sensitive and flaked under machine load (115µs/180µs after a heavy
     // compile) while passing cleanly when idle.
     //
-    // We assert the short-circuit *directly* through the existing public probe
-    // `SSTableReader::scan_for_key_call_count()` (the process-global
-    // `SCAN_FOR_KEY_CALLS` counter, issue #831): a bloom-pruned absent-key lookup
-    // never reaches `scan_for_key`, so the counter must not advance across the
-    // call. This is deterministic and immune to CPU load — a regression that
-    // stops the bloom filter from short-circuiting (e.g. always falls through to
-    // a sequential scan) bumps the counter and fails here, which the wall-clock
-    // threshold could only catch by luck. Timing is kept as a non-asserting
-    // diagnostic print only.
+    // We assert the short-circuit *directly*, with two complementary signals that
+    // are immune to CPU load (the wall-clock flake) AND to cross-test counter
+    // races (the only nondeterminism the counter probe would otherwise add):
+    //
+    //  1. STRUCTURAL (fully deterministic): the reader actually loaded a bloom
+    //     filter, so the bloom pre-check branch in `get()` is reachable. Without
+    //     this the "short-circuit" would be vacuous.
+    //
+    //  2. BEHAVIORAL: the existing public probe
+    //     `SSTableReader::scan_for_key_call_count()` (the process-global
+    //     `SCAN_FOR_KEY_CALLS` counter, issue #831) must NOT advance as a result
+    //     of an absent-key `get()`. Because the counter is process-global and the
+    //     integration-test binary runs its tests on multiple threads (other tests
+    //     here call `get()`/`scan()` and can bump it), a single before/after read
+    //     could observe a concurrent test's increment and false-fail. We make the
+    //     check race-immune by retrying: a genuine regression (bloom no longer
+    //     short-circuits) makes OUR `get()` fall through to `scan_for_key` on
+    //     EVERY attempt, so the delta is `>= 1` every time; a concurrent test's
+    //     scan is sporadic, so at least one attempt sees our call contribute zero.
+    //     Requiring a single zero-delta attempt therefore fails a real regression
+    //     while tolerating concurrent interference. Timing is kept as a
+    //     non-asserting diagnostic print only.
+    let health = reader.get_health_metrics().await?;
+    assert!(
+        health.bloom_filter_enabled,
+        "fixture SSTable must have a bloom filter loaded for the fast-path check to be meaningful"
+    );
+
     for key_str in &non_existent_keys {
         let test_key = RowKey::from(key_str.as_bytes());
 
-        let scans_before = SSTableReader::scan_for_key_call_count();
-        let start_time = Instant::now();
-        let result = reader.get(&table_id, &test_key).await?;
-        let lookup_duration = start_time.elapsed();
-        let scans_after = SSTableReader::scan_for_key_call_count();
+        // Retry to distinguish a true bloom-fast-path regression (our get() scans
+        // on every attempt) from a transient concurrent test bumping the global
+        // counter in our measurement window.
+        let mut observed_zero_delta = false;
+        let mut last_delta = u64::MAX;
+        let mut last_duration = std::time::Duration::ZERO;
+        let mut last_result_none = false;
+        for _ in 0..5 {
+            let scans_before = SSTableReader::scan_for_key_call_count();
+            let start_time = Instant::now();
+            let result = reader.get(&table_id, &test_key).await?;
+            last_duration = start_time.elapsed();
+            let scans_after = SSTableReader::scan_for_key_call_count();
 
-        // Should be None for non-existent keys
+            last_result_none = result.is_none();
+            last_delta = scans_after.saturating_sub(scans_before);
+            if last_delta == 0 {
+                observed_zero_delta = true;
+                break;
+            }
+        }
+
+        // Should be None for non-existent keys.
         assert!(
-            result.is_none(),
+            last_result_none,
             "Non-existent key should return None: {key_str}"
         );
 
-        // Bloom filter must short-circuit: the absent-key lookup returns without
-        // ever invoking the sequential scan fallback, so the global
-        // `scan_for_key` counter is unchanged across this `get()`.
-        assert_eq!(
-            scans_after,
-            scans_before,
+        // Bloom filter must short-circuit: at least one absent-key lookup returned
+        // without invoking the sequential scan fallback (counter delta 0). A
+        // regression that always falls through to scan_for_key never observes a
+        // zero delta and fails here.
+        assert!(
+            observed_zero_delta,
             "Bloom filter should short-circuit absent-key lookup before scan_for_key \
-             (counter advanced by {} for key {}); the bloom fast path regressed",
-            scans_after - scans_before,
-            key_str
+             for {key_str}; every attempt advanced scan_for_key (last delta {last_delta}), \
+             the bloom fast path regressed"
         );
 
         // Non-asserting diagnostic: the fast path is also expected to be quick,
         // but we no longer gate the test on an absolute wall-clock threshold
         // (issue #1149 — that assertion flaked under load).
-        println!(
-            "  absent-key '{key_str}' short-circuited in {lookup_duration:?} (no scan_for_key)"
-        );
+        println!("  absent-key '{key_str}' short-circuited in {last_duration:?} (no scan_for_key)");
     }
 
     println!(


### PR DESCRIPTION
Closes #1149

## Problem
`tests/golden_path_summary_index_integration_tests.rs` (`test_golden_path_bloom_summary_index_coordination`) asserted an **absolute `<100µs` wall-clock threshold** on absent-key `get()` lookups. That threshold is load-sensitive: it flaked under machine load (observed 115µs/180µs after a heavy compile during an agent-gate run) while passing cleanly when idle. Absolute microsecond thresholds are inherently flaky across CI runners, emulation, and local load.

## Fix
Replace the brittle wall-clock assertion with a deterministic, load-insensitive **behavioral** check that still meaningfully verifies the bloom fast path, using only existing public surface (no production/core changes):

1. **Structural (fully deterministic):** assert `reader.get_health_metrics().bloom_filter_enabled` — the fixture SSTable actually loaded a bloom filter, so the bloom pre-check branch in `SSTableReader::get` is reachable (the short-circuit is non-vacuous).
2. **Behavioral:** assert the existing public probe `SSTableReader::scan_for_key_call_count()` (process-global `SCAN_FOR_KEY_CALLS`, issue #831) does **not** advance as a result of an absent-key `get()`. When the bloom filter reports a key absent, `get()` returns `Ok(None)` immediately and never falls through to the sequential `scan_for_key` path. A regression that stops the short-circuit makes every absent-key lookup scan, which this catches deterministically — something the wall-clock threshold could only catch by luck.

Because the counter is process-global and the integration-test binary runs tests multi-threaded, the counter check uses a bounded retry (5 attempts, accept the first zero-delta) so a sporadic concurrent test's scan can't false-fail a healthy fast path, while a true regression (our `get()` scans on every attempt) still fails. The absent-key `None` check runs on every attempt. Timing is kept only as a non-asserting diagnostic print.

## Scope
Test file only (`tests/golden_path_summary_index_integration_tests.rs`). No production/core/CLI changes — epic #1116's source-split work is untouched. Oracle/test-driven; no OpenSpec.

## Verification
- `scripts/agent-gate.sh`: **RESULT: PASS** (commit d7413018; all components green incl. fmt/clippy `-D warnings`, core-tests, integration-tests, write-tests, cli-tests, python-bindings, smoke).
- Previously-flaky assertion now deterministic: full multi-threaded test binary green **5/5 under heavy simulated CPU load** (the condition that flaked the old `<100µs` threshold).
- roborev (`--base origin/main`, agent claude-code): no defects — remaining notes are documented accepted-tradeoffs ("a sound and meaningfully more robust test").