### PR TITLE
test(#283): guard YAML output removal — reject --out/--format yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **BREAKING (CLI):** dropped YAML as a query output format. `--out yaml` and
+  `--format yaml` are no longer accepted — both are now rejected at parse time
+  with a clear error listing the supported values (`table`, `json`, `csv`,
+  `parquet` for `--out`). YAML output was never implemented (it was only an
+  unused `OutputMode`/`OutputFormat` variant), so this removes a dead surface
+  rather than working behavior; anyone scripting `--out yaml`/`--format yaml`
+  must switch to a supported format. A parse-rejection regression test guards
+  against the variant being silently re-added (#283).
+
 ## [v0.12.0] - 2026-06-22
 
 The compaction release. CQLite now rewrites and compacts Cassandra 5.0 SSTables

--- a/cqlite-cli/tests/unit_tests.rs
+++ b/cqlite-cli/tests/unit_tests.rs
@@ -165,6 +165,56 @@ mod cli_parsing_tests {
     use super::*;
     use cqlite_cli::{AdminCommands, BenchCommands, Cli, Commands, SchemaCommands};
 
+    /// Regression guard for #283: `yaml` was removed from the output surface
+    /// (`OutputMode`/`--out` and `OutputFormat`/`--format`). A request for YAML
+    /// output must be a hard parse error with a clear message — never a silent
+    /// fallback to another format. If someone re-adds a `Yaml` variant, this
+    /// fails and forces the deprecation-vs-removal decision back into the open.
+    // (`Cli` derives only `Parser`, not `Debug`, so we inspect the `Err` side
+    // via `.err()` rather than `unwrap_err`/`expect_err`, which would require
+    // the `Ok` type to be `Debug`.)
+    #[test]
+    fn test_yaml_output_is_rejected_not_silently_accepted() {
+        fn rejection_message(args: &[&str]) -> String {
+            let res = Cli::try_parse_from(args.iter().copied());
+            assert!(
+                res.is_err(),
+                "{:?} must be rejected, not silently accepted",
+                args
+            );
+            res.err().map(|e| e.to_string().to_lowercase()).unwrap_or_default()
+        }
+
+        // `--out yaml` (OutputMode value-enum). Subcommand is optional, so the
+        // only error here is the invalid enum value.
+        let msg = rejection_message(&["cqlite", "--out", "yaml"]);
+        assert!(
+            msg.contains("yaml"),
+            "error must name the rejected value `yaml`, got: {msg}"
+        );
+        assert!(
+            msg.contains("invalid value") || msg.contains("possible values"),
+            "error must explain that `yaml` is not a valid output value, got: {msg}"
+        );
+
+        // `--format yaml` (OutputFormat value-enum).
+        let msg = rejection_message(&["cqlite", "--format", "yaml"]);
+        assert!(
+            msg.contains("yaml"),
+            "error must name the rejected value `yaml`, got: {msg}"
+        );
+
+        // Sanity: still-supported output values continue to parse.
+        assert!(
+            Cli::try_parse_from(["cqlite", "--out", "json"]).is_ok(),
+            "`--out json` must remain valid"
+        );
+        assert!(
+            Cli::try_parse_from(["cqlite", "--format", "csv"]).is_ok(),
+            "`--format csv` must remain valid"
+        );
+    }
+
     #[test]
     fn test_basic_command_parsing() -> Result<()> {
         // Test query command

--- a/cqlite-cli/tests/unit_tests.rs
+++ b/cqlite-cli/tests/unit_tests.rs
@@ -182,7 +182,9 @@ mod cli_parsing_tests {
                 "{:?} must be rejected, not silently accepted",
                 args
             );
-            res.err().map(|e| e.to_string().to_lowercase()).unwrap_or_default()
+            res.err()
+                .map(|e| e.to_string().to_lowercase())
+                .unwrap_or_default()
         }
 
         // `--out yaml` (OutputMode value-enum). Subcommand is optional, so the


### PR DESCRIPTION
# Pull Request Description

## Related Issue
- Closes #283
- Epic: #907 (CLI & bindings polish)

## Changes Made

`OutputMode` (`--out`) and `OutputFormat` (`--format`) no longer carry a `Yaml` variant — the enums are `table/json/csv[/parquet]`, and both flags already reject `yaml` at clap parse time. The variant removal itself already landed on `main`; this PR closes the remaining wiring-evidence + documentation gap from manager ORDER 11:

- **Regression guard** in `cqlite-cli/tests/unit_tests.rs` (the gate's `cli-tests` target) asserting `--out yaml` and `--format yaml` are **hard parse errors with a clear message** (names `yaml`, lists valid values) — never a silent fallback — and that supported values (`--out json`, `--format csv`) still parse.
- **CHANGELOG** `[Unreleased] → Removed` entry documenting the breaking CLI removal for anyone scripting `--out yaml`/`--format yaml`.

No production code changed; the removal was already complete. Verified no dangling references remain in match arms, `--out`/`--format`/`CQLITE_OUT` parsing, clap `--help`/value-enums, REPL completion (`table, csv, json, raw`), or README. The only `yaml`-as-output mentions left are unchecked checklist items in archived `docs/specifications/issue-specs/` planning docs — historical, not user-facing support claims (no STOP-and-flag condition triggered).

### Type of Change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Test coverage improvement
- [x] Documentation update

### Component(s) Affected
- [x] cqlite-cli
- [x] Tests
- [x] Documentation

## Testing

### Test Environment
- Remote CI runner (this worker container has no crates.io access — see note below).

### Tests Run
- [x] CLI tests (`cqlite-cli --test unit_tests`) — **via CI** (local gate could not run here)

### Test Results

```
Local note: scripts/agent-gate.sh could NOT be run in this worker container —
crates.io is blocked (HTTP 403 through the proxy), so no dependency build is
possible. CI is the authoritative gate for this PR; not claiming a local
gate PASS. The new test is a pure clap-parse assertion (no test data, no I/O).
```

## Public Surface & Wiring Evidence
- [x] This PR adds/changes feature or performance behavior — **user-facing CLI surface**: `--out` / `--format` flags.
- **Call chain**: `cqlite --out yaml` → `Cli::try_parse_from` (clap) → `OutputMode`/`OutputFormat` `ValueEnum` → rejected (no `Yaml` variant).
- **End-to-end from the public surface**: `test_yaml_output_is_rejected_not_silently_accepted` drives the real `Cli` parser (the CLI's public entry) and asserts the rejection is observable with a clear message — not a helper-only test.
- [x] No new public API stub/placeholder.
- [x] The test distinguishes the rejection path from a silent fallback (asserts an error is returned and names `yaml`, rather than a parsed default).

**Public surface(s) exercised:** CLI `--out` / `--format` flag parsing.

## Cassandra Compatibility
- [x] Maintains compatibility (no format/parsing behavior change).

## Performance Impact
- [x] No performance impact.

## Documentation
- [x] Breaking CLI removal documented in CHANGELOG.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove the behavior (parse-rejection regression guard)
- [x] For feature work, I added an end-to-end test from the public surface (CLI parser), not a helper-only test

## Additional Notes

The manager's order treated this as a user-facing breaking removal. Because YAML output was never actually implemented (dead enum variant only), this is a removal of a dead surface rather than working behavior — captured as such in the CHANGELOG. The enum removal predates this PR (landed on `main` in an earlier change); this PR adds the guard that prevents it being silently re-added and records the breaking change.

https://claude.ai/code/session_017KPRv6ztxj6QwMpKL4eswT

---
_Generated by [Claude Code](https://claude.ai/code/session_017KPRv6ztxj6QwMpKL4eswT)_