### PR TITLE
test(#1178): fix node-20 musl-host loader test (unblock red Node.js CI on main)

### DIFF
--- a/bindings/node/__test__/loader.test.js
+++ b/bindings/node/__test__/loader.test.js
@@ -110,10 +110,19 @@ describe('Platform loader (Issue #571)', () => {
     test('reports linux-<arch>-musl on a musl host (no gnu/musl contradiction)', () => {
       // Force the musl branch by faking the libc probe used by isMusl():
       // process.report.getReport().header.glibcVersionRuntime === undefined.
+      //
+      // `process.report` is a getter-only accessor, so a plain
+      // `process.report = {...}` assignment is SILENTLY IGNORED — on a glibc
+      // host (e.g. ubuntu CI on Node 20) the real report still reports a
+      // defined glibcVersionRuntime, isMusl() returns false, and no musl error
+      // is thrown (the #1178 regression: green on a musl-less macOS host but
+      // red in CI). Redefine the property with Object.defineProperty so the
+      // fake actually takes effect on every Node version.
       const preamble = `
-        process.report = {
-          getReport: () => ({ header: {} }),
-        };
+        Object.defineProperty(process, 'report', {
+          value: { getReport: () => ({ header: {} }) },
+          configurable: true,
+        });
       `;
       const { threw, stderr } = loadUnderFakePlatform('linux', 'x64', preamble);
       expect(threw).toBe(true);


### PR DESCRIPTION
## Summary
Fixes the Node.js CI red on `main` (since #1167 merged, 03:49Z). The
`loader.test.js` musl-host case failed in ubuntu CI (Node 20) while passing
locally on macOS.

## Root cause
The test faked the libc probe used by `isMusl()` with a plain
`process.report = {...}` assignment. `process.report` is a **getter-only
accessor**, so that assignment is silently ignored:
- **macOS (local):** the *real* report has no `glibcVersionRuntime` → `isMusl()`
  accidentally returns true → musl error thrown → test passes (for the wrong reason).
- **glibc ubuntu CI (Node 20):** the real report *has* `glibcVersionRuntime` →
  `isMusl()` returns false → loader loads `linux-x64-gnu` → **no throw** →
  `expect(threw).toBe(true)` fails → Node.js CI Quality Gate red.

The loader (`scripts/generate-loader.mjs`) was already correct — this is purely a
non-portable test-faking technique.

## Fix
Redefine `process.report` via `Object.defineProperty(..., {configurable:true})`
so the fake actually takes effect on every Node version. Proven against a
simulated glibc host: old plain-assign → wrong `linux-x64` (the bug);
new defineProperty → correct `linux-x64-musl`.

## Validation
- `npm test` (full node suite, datasets root set): **382 passed, 2 skipped, 0 failed**
- `loader.test.js`: 7/7 pass
- `scripts/agent-gate.sh`: **RESULT PASS** (all 14 components)
- roborev (claude-code/opus): **No issues found**

Oracle/deterministic test fix → OpenSpec skipped per manager order (ORDER 1).

Closes #1178. Refs #571, #1167.