### PR TITLE
test(#995): per-shape delta_scan parity manifest scenarios + strict lint + honest report

### DIFF
--- a/cqlite-core/tests/scan_delta_parity_test.rs
+++ b/cqlite-core/tests/scan_delta_parity_test.rs
@@ -1359,6 +1359,16 @@ async fn test_scan_delta_parity_all_test_deltas() {
         total_errors.len(),
         total_errors.join("\n")
     );
+
+    // We found at least one fixture with a Data.db above (else we returned).
+    // If every present fixture matched ZERO assertions, the parse path is
+    // broken and this would be a spurious green — fail loudly (issue #995, AC4).
+    assert!(
+        total_ok > 0,
+        "scan_delta parity ran on {} PRESENT fixture(s) but matched ZERO \
+         assertions — present-but-empty fixtures must fail, not pass silently.",
+        fixtures.len()
+    );
 }
 
 // ============================================================================
@@ -1416,6 +1426,20 @@ macro_rules! delta_fixture_test {
                 $table,
                 result.errors.len(),
                 result.errors.join("\n")
+            );
+
+            // The Data.db is PRESENT (we passed the SKIP gate above): a
+            // present-but-empty fixture that produced ZERO matched assertions is
+            // a FAILURE, not a silent green (issue #995, AC4). Every per-shape
+            // delta fixture is built by generate-deltas.sh to carry deletion/cell
+            // facts, so a zero-assertion run means the fixture or the parse path
+            // is broken — surface it loudly.
+            assert!(
+                result.total_ok() > 0,
+                "[{}] parity ran on a PRESENT Data.db but matched ZERO assertions — \
+                 present-but-empty fixtures must fail, not pass silently. \
+                 Regenerate with: bash test-data/scripts/generate-deltas.sh",
+                $table
             );
         }
     };

--- a/docs/reports/cassandra-test-parity.md
+++ b/docs/reports/cassandra-test-parity.md
@@ -10,20 +10,20 @@ Sources: [`docs/cassandra_test_index.md`](../../docs/cassandra_test_index.md) ·
 
 | Status | Scenarios |
 |---|---|
-| `mirrored` | 162 |
-| `partial` | 11 |
-| `planned` | 15 |
+| `mirrored` | 171 |
+| `partial` | 10 |
+| `planned` | 16 |
 | `out_of_scope` | 14 |
-| **total** | **202** |
+| **total** | **211** |
 
 ## Evidence counts
 
 | Evidence | Scenarios |
 |---|---|
 | `byte_for_byte` | 91 |
-| `canonical_semantic` | 66 |
+| `canonical_semantic` | 76 |
 | `smoke` | 7 |
-| `partial` | 22 |
+| `partial` | 21 |
 | `out_of_scope` | 16 |
 
 ## ⚠️ P0 scenarios with weak evidence
@@ -36,7 +36,6 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 - `cass.compression_info.deflate.real_fixture_chunks.strict` — Deflate real-fixture CompressionInfo.db + chunk parity (partial)
 - `cass.compression_info.zstd.real_fixture_chunks.strict` — Zstd real-fixture CompressionInfo.db + chunk parity (partial)
 - `cass.corruption_verify.component_corruption_detection` — Component corruption detection, scrub, and verify (partial)
-- `cass.delta_scan.tombstone_liveness_facts` — Delta-scan tombstone/TTL/liveness fact extraction (partial)
 - `cass.filter_db_bloom.serialization_no_false_negative` — Filter.db Bloom filter serialization with no false negatives (partial)
 - `cass.index_db.RowIndexEntryTest.promoted_index_entries` — BIG Index.db promoted-index (wide-partition) boundary metadata (partial)
 - `cass.index_summary.column_index.range_tombstone_boundary_big_bti` — Column-index range-tombstone boundary across BIG and BTI formats (partial)
@@ -117,7 +116,15 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 | `cass.data_db_decode.serialization_mirror.multi_clustering_column_order` | data_db_decode | mirrored | byte_for_byte | `sstable_parity_data_db_jsonl` | p1_correctness |
 | `cass.data_db_decode.unfiltered_serializer.row_and_cell_flags` | data_db_decode | mirrored | byte_for_byte | `sstable_parity_data_db_jsonl` | p1_correctness |
 | `cass.data_db_decode.unfiltered_serializer.row_size_vints` | data_db_decode | mirrored | byte_for_byte | `sstable_parity_data_db_jsonl` | p1_correctness |
-| `cass.delta_scan.tombstone_liveness_facts` | delta_scan | partial | partial | `sstable_parity_delta_scan` | p1_correctness |
+| `cass.delta_scan.adjacent_ranges` | delta_scan | mirrored | canonical_semantic | `sstable_parity_delta_scan` | p1_correctness |
+| `cass.delta_scan.cell_tombstones` | delta_scan | mirrored | canonical_semantic | `sstable_parity_delta_scan` | p1_correctness |
+| `cass.delta_scan.collection_ops` | delta_scan | mirrored | canonical_semantic | `sstable_parity_delta_scan` | p1_correctness |
+| `cass.delta_scan.partial_updates` | delta_scan | mirrored | canonical_semantic | `sstable_parity_delta_scan` | p1_correctness |
+| `cass.delta_scan.partition_tombstones` | delta_scan | mirrored | canonical_semantic | `sstable_parity_delta_scan` | p1_correctness |
+| `cass.delta_scan.range_tombstones` | delta_scan | mirrored | canonical_semantic | `sstable_parity_delta_scan` | p1_correctness |
+| `cass.delta_scan.row_tombstones` | delta_scan | mirrored | canonical_semantic | `sstable_parity_delta_scan` | p1_correctness |
+| `cass.delta_scan.static_with_rows` | delta_scan | mirrored | canonical_semantic | `sstable_parity_delta_scan` | p1_correctness |
+| `cass.delta_scan.ttl_cells` | delta_scan | mirrored | canonical_semantic | `sstable_parity_delta_scan` | p1_correctness |
 | `cass.filter_db.corruption_fails_closed` | filter_db_bloom | mirrored | byte_for_byte | `sstable_parity_filter_db_bloom` | p1_correctness |
 | `cass.filter_db.no_false_negative_membership` | filter_db_bloom | mirrored | byte_for_byte | `sstable_parity_filter_db_bloom` | p0_data_loss |
 | `cass.filter_db.serialization_round_trip` | filter_db_bloom | mirrored | byte_for_byte | `sstable_parity_filter_db_bloom` | p1_correctness |
@@ -364,6 +371,36 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
   - Normalization: Values are normalized against the declared schema type (not guessed) so that ascii vs text, frozen vs multicell, and numeric widths are compared with the correct typed model; ambiguous coercion is rejected.
 - `cass.data_db_decode.row_cell_flags_and_vint` — Data.db row/cell flags and VInt decode parity
   - Normalization: Rows and cells are normalized to the sstabledump JSONL fact model (partition key, clustering, cell name/value, liveness, deletion) and compared field-by-field; presentation ordering and whitespace ignored.
+- `cass.delta_scan.adjacent_ranges` — Delta-scan adjacent range tombstones (shared boundary markers)
+  - Normalization: scan_delta range-delete records are reconstructed from sstabledump JSONL boundary markers (excl_end_incl_start / incl_end_excl_start) into synthetic end/start bound pairs and compared with a writetime tolerance.
+  - Byte-for-byte: not yet — needs Data.db backing (follow-up under epic #969).
+- `cass.delta_scan.cell_tombstones` — Delta-scan cell tombstones (DELETE col)
+  - Normalization: scan_delta cell-tombstone records are mapped to sstabledump JSONL deletion facts (deleted_at) and compared with a writetime tolerance.
+  - Byte-for-byte: not yet — needs Data.db backing (follow-up under epic #969).
+- `cass.delta_scan.collection_ops` — Delta-scan collection operations (append/overwrite/element delete)
+  - Normalization: scan_delta collection cell upserts and the complex-cell deletion markers emitted by SET append / overwrite / element removal are mapped to the sstabledump JSONL collection cells and compared with a writetime tolerance.
+  - Byte-for-byte: not yet — needs Data.db backing (follow-up under epic #969).
+- `cass.delta_scan.partial_updates` — Delta-scan partial updates (UPDATE-only rows, no row liveness)
+  - Normalization: scan_delta cell upserts are mapped to sstabledump JSONL per-cell records and compared; row-liveness presence (INSERT) vs absence (UPDATE-only) is asserted against the JSONL liveness_info markers.
+  - Byte-for-byte: not yet — needs Data.db backing (follow-up under epic #969).
+- `cass.delta_scan.partition_tombstones` — Delta-scan partition tombstones (DELETE FROM ... WHERE pk)
+  - Normalization: scan_delta partition-delete records are mapped to the sstabledump JSONL partition deletion_info marker (marked_deleted) and compared with a writetime tolerance.
+  - Byte-for-byte: not yet — needs Data.db backing (follow-up under epic #969).
+- `cass.delta_scan.range_tombstones` — Delta-scan range tombstones (DELETE ... WHERE ck range)
+  - Normalization: scan_delta range-delete records are mapped to consecutive sstabledump JSONL range_tombstone_bound start/end pairs and compared with a writetime tolerance; boundary markers are paired into synthetic end/start bounds.
+  - Byte-for-byte: not yet — needs Data.db backing (follow-up under epic #969).
+- `cass.delta_scan.row_tombstones` — Delta-scan row tombstones (DELETE FROM ... WHERE pk AND ck)
+  - Normalization: scan_delta row-delete records are mapped to sstabledump JSONL row deletion_info markers and compared with a writetime tolerance.
+  - Byte-for-byte: not yet — needs Data.db backing (follow-up under epic #969).
+- `cass.delta_scan.static_with_rows` — Delta-scan static columns alongside clustered rows
+  - Normalization: scan_delta static-cell upserts are mapped to the sstabledump JSONL static row block and clustered-row cells to their per-row cell lists; both are compared by value and writetime with tolerance.
+  - Byte-for-byte: not yet — needs Data.db backing (follow-up under epic #969).
+- `cass.delta_scan.ttl_cells` — Delta-scan TTL / expiring cells (INSERT ... USING TTL)
+  - Normalization: scan_delta expiring-cell records are mapped to sstabledump JSONL cell ttl / local_deletion_time fields and compared; mixed live + expiring cells in the same fixture exercise both code paths.
+  - Byte-for-byte: not yet — needs Data.db backing (follow-up under epic #969).
+- `cass.delta_scan.wide_partition_corpus` — Delta-scan over wide partitions (planned — no test_deltas fixture yet)
+  - Normalization: Planned: scan_delta facts over a wide partition (many clustered rows + range/cell tombstones in one partition, exercising index-block skipping) compared to the sstabledump JSONL golden.
+  - Byte-for-byte: not yet — needs Data.db backing (follow-up under epic #969).
 - `cass.index_summary.big_index_offsets` — Index.db partition key digests and data offsets (BIG)
   - Normalization: Partition key digests and Data.db offsets resolved through Index.db are compared against the partition order and keys derived from sstabledump JSONL.
 - `cass.schema_evolution.dropped_column.per_cell_purge` — Dropped regular column per-cell purge parity
@@ -448,7 +485,7 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 - `cass.corruption.bti_partitions_footer_bit_flip` (planned): Clean BTI source (test_da/wide_table Partitions.db) is not git-tracked, so the corrupted fixture cannot be regenerated by CI. → _Commit the clean test_da/wide_table BTI components (or add them to the published dataset bundle) so generate-corruption-corpus.sh can emit the corrupted Partitions.db, then flip status to mirrored._
 - `cass.corruption.bti_rows_truncation` (planned): Clean BTI source (test_da/wide_table Rows.db) is not git-tracked, so the truncated fixture cannot be regenerated by CI. → _Commit the clean test_da/wide_table BTI components so generate-corruption-corpus.sh can emit the truncated Rows.db, then flip status to mirrored._
 - `cass.corruption_verify.component_corruption_detection` (planned): No scrub/verify parity pass implemented. → _Implement a verify pass and compare detected-corruption outcomes against Cassandra VerifyTest/ScrubTest scenarios._
-- `cass.delta_scan.tombstone_liveness_facts` (partial): test_deltas dataset asset not published/enforced (#701). → _Publish and enforce the test_deltas dataset in delta-roundtrip CI._
+- `cass.delta_scan.wide_partition_corpus` (planned): No test_deltas wide-partition delete fixture; wide partitions are produced by the wide-row corpus (epic #993), not generate-deltas.sh. Byte-for-byte backing for delta_scan remains tracked by epic #969. → _Add a wide-partition delete shape (or reuse a wide-row corpus fixture) and a paired test_delta_parity_wide_partition test under epic #993._
 - `cass.filter_db.bti_membership` (partial): No raw-partition-key source for BTI fixtures, so the no-false-negative probe cannot run against da Filter.db. → _Recover raw BTI partition keys (e.g. by decoding partitions during a Data.db scan) and extend the no-false-negative gate to cover da fixtures._
 - `cass.filter_db.statistical_false_positive_rate` (planned): No gated comparison of measured FPR against Cassandra's configured bloom_filter_fp_chance. → _Add larger-cardinality fixtures and assert the measured FPR tracks the configured fp_chance within a documented statistical tolerance._
 - `cass.filter_db_bloom.serialization_no_false_negative` (partial): No no-false-negative parity assertion against Cassandra Filter.db. → _Add a Filter.db serialization parity test asserting zero false negatives across the present-key set._
@@ -636,7 +673,16 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.data_db_decode.serialization_mirror.multi_clustering_column_order` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.data_db_decode.unfiltered_serializer.row_and_cell_flags` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.data_db_decode.unfiltered_serializer.row_size_vints` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
-| `cass.delta_scan.tombstone_liveness_facts` | required_parity | .github/workflows/delta-roundtrip.yml |
+| `cass.delta_scan.adjacent_ranges` | required_parity | .github/workflows/delta-roundtrip.yml |
+| `cass.delta_scan.cell_tombstones` | required_parity | .github/workflows/delta-roundtrip.yml |
+| `cass.delta_scan.collection_ops` | required_parity | .github/workflows/delta-roundtrip.yml |
+| `cass.delta_scan.partial_updates` | required_parity | .github/workflows/delta-roundtrip.yml |
+| `cass.delta_scan.partition_tombstones` | required_parity | .github/workflows/delta-roundtrip.yml |
+| `cass.delta_scan.range_tombstones` | required_parity | .github/workflows/delta-roundtrip.yml |
+| `cass.delta_scan.row_tombstones` | required_parity | .github/workflows/delta-roundtrip.yml |
+| `cass.delta_scan.static_with_rows` | required_parity | .github/workflows/delta-roundtrip.yml |
+| `cass.delta_scan.ttl_cells` | required_parity | .github/workflows/delta-roundtrip.yml |
+| `cass.delta_scan.wide_partition_corpus` | exhaustive_regeneration | .github/workflows/delta-roundtrip.yml |
 | `cass.distributed_consensus.paxos_accord_out_of_scope` | fast_pr | — |
 | `cass.filter_db.bti_membership` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.filter_db.corruption_fails_closed` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
@@ -843,7 +889,16 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.data_db_decode.serialization_mirror.multi_clustering_column_order` | nb, oa | test-data/datasets/sstables/test_basic/composite_key_table-6ab56990a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/data-db-clustering-order-diff.log |
 | `cass.data_db_decode.unfiltered_serializer.row_and_cell_flags` | nb, oa | test-data/datasets/sstables/test_basic/uncompressed_table-6aedb7a0a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/data-db-flag-diff.log |
 | `cass.data_db_decode.unfiltered_serializer.row_size_vints` | nb, oa | test-data/datasets/sstables/test_basic/uncompressed_table-6aedb7a0a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/data-db-row-framing-diff.log |
-| `cass.delta_scan.tombstone_liveness_facts` | nb | test-data/datasets/sstables/test_deltas/collection_ops-2a5006f06c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl |
+| `cass.delta_scan.adjacent_ranges` | nb | test-data/datasets/sstables/test_deltas/adjacent_ranges-972f22806c7811f1a24ff924a65838e2/nb-1-big-Data.db.jsonl |
+| `cass.delta_scan.cell_tombstones` | nb | test-data/datasets/sstables/test_deltas/cell_tombstones-29f7fbe06c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl |
+| `cass.delta_scan.collection_ops` | nb | test-data/datasets/sstables/test_deltas/collection_ops-2a5006f06c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl |
+| `cass.delta_scan.partial_updates` | nb | test-data/datasets/sstables/test_deltas/partial_updates-2a5ed4006c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl |
+| `cass.delta_scan.partition_tombstones` | nb | test-data/datasets/sstables/test_deltas/partition_tombstones-2a26fb206c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl |
+| `cass.delta_scan.range_tombstones` | nb | test-data/datasets/sstables/test_deltas/range_tombstones-2a1a50f06c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl |
+| `cass.delta_scan.row_tombstones` | nb | test-data/datasets/sstables/test_deltas/row_tombstones-2a0e91206c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl |
+| `cass.delta_scan.static_with_rows` | nb | test-data/datasets/sstables/test_deltas/static_with_rows-2a4299706c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl |
+| `cass.delta_scan.ttl_cells` | nb | test-data/datasets/sstables/test_deltas/ttl_cells-2a35ef406c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl |
+| `cass.delta_scan.wide_partition_corpus` | nb | — |
 | `cass.distributed_consensus.paxos_accord_out_of_scope` | — | — |
 | `cass.filter_db.bti_membership` | da | — |
 | `cass.filter_db.corruption_fails_closed` | nb, oa, da | test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/filter-db-corruption.log |

--- a/docs/reports/cassandra-test-parity.md
+++ b/docs/reports/cassandra-test-parity.md
@@ -223,8 +223,8 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 - `cass.compression_info.lz4.real_fixture_chunks.strict` — LZ4 real-fixture CompressionInfo.db + chunk parity
 - `cass.compression_info.snappy.real_fixture_chunks` — SnappyCompressor real-fixture chunk + CRC parity
 - `cass.compression_info.snappy.real_fixture_chunks.strict` — Snappy real-fixture CompressionInfo.db + chunk parity
-- `cass.corruption.bti_partitions_footer_bit_flip` — BTI Partitions.db footer bit flip is detected
-- `cass.corruption.bti_rows_truncation` — BTI Rows.db truncation is detected
+- `cass.corruption.bti_partitions_footer_bit_flip` — BTI Partitions.db footer bit flip is detected _(planned — no evidence yet)_
+- `cass.corruption.bti_rows_truncation` — BTI Rows.db truncation is detected _(planned — no evidence yet)_
 - `cass.corruption.compression_info.bad_offset` — CompressionInfo.db out-of-bounds chunk offset is detected
 - `cass.corruption.data_db.bit_flip` — Data.db single-bit flip is detected (LZ4 chunk decode / CRC)
 - `cass.corruption.data_db.truncation` — Data.db mid-stream truncation is detected
@@ -398,9 +398,8 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 - `cass.delta_scan.ttl_cells` — Delta-scan TTL / expiring cells (INSERT ... USING TTL)
   - Normalization: scan_delta expiring-cell records are mapped to sstabledump JSONL cell ttl / local_deletion_time fields and compared; mixed live + expiring cells in the same fixture exercise both code paths.
   - Byte-for-byte: not yet — needs Data.db backing (follow-up under epic #969).
-- `cass.delta_scan.wide_partition_corpus` — Delta-scan over wide partitions (planned — no test_deltas fixture yet)
+- `cass.delta_scan.wide_partition_corpus` — Delta-scan over wide partitions (planned — no test_deltas fixture yet) _(planned — no evidence yet)_
   - Normalization: Planned: scan_delta facts over a wide partition (many clustered rows + range/cell tombstones in one partition, exercising index-block skipping) compared to the sstabledump JSONL golden.
-  - Byte-for-byte: not yet — needs Data.db backing (follow-up under epic #969).
 - `cass.index_summary.big_index_offsets` — Index.db partition key digests and data offsets (BIG)
   - Normalization: Partition key digests and Data.db offsets resolved through Index.db are compared against the partition order and keys derived from sstabledump JSONL.
 - `cass.schema_evolution.dropped_column.per_cell_purge` — Dropped regular column per-cell purge parity
@@ -469,7 +468,7 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 - `cass.cli_reporting.parity_manifest_lint_and_report` — Parity manifest lint and report tooling
 - `cass.compaction_merge.load_path_validity` — Compaction output load-path validity (Tier-1)
 - `cass.data_db_decode.row_preamble_size_mismatch` — Malformed row-preamble size fails loud
-- `cass.filter_db.statistical_false_positive_rate` — Filter.db empirical false-positive-rate report
+- `cass.filter_db.statistical_false_positive_rate` — Filter.db empirical false-positive-rate report _(planned — no evidence yet)_
 - `cass.schema_evolution.serialization_header_column_order` — Serialization-header column order across schema evolution
 - `cass.sstable_format.descriptor_component_resolution` — Descriptor and on-disk version/component resolution
 - `cass.write_load_path.cassandra_sstable_writer_fixtures` — CQLite-written SSTables load into Cassandra via sstableloader

--- a/test-data/cassandra-parity-manifest.yml
+++ b/test-data/cassandra-parity-manifest.yml
@@ -3409,9 +3409,119 @@ scenarios:
   # ----------------------------------------------------------------------------
   # delta_scan
   # ----------------------------------------------------------------------------
-  - id: cass.delta_scan.tombstone_liveness_facts
-    title: Delta-scan tombstone/TTL/liveness fact extraction
-    status: partial
+  # Per-shape delta_scan scenarios (issue #995). Each maps one delete/write
+  # shape to its specific test_deltas fixture and per-table parity test. All are
+  # canonical_semantic (scan_delta records compared to sstabledump JSONL deletion
+  # facts) — NOT byte_for_byte. Byte-for-byte Data.db backing for these shapes is
+  # a follow-up under the Data.db decode parity epic #969 (capability
+  # data_db_decode); a delta_scan failure points back to that scenario group.
+  - id: cass.delta_scan.cell_tombstones
+    title: Delta-scan cell tombstones (DELETE col)
+    status: mirrored
+    capability: delta_scan
+    priority: P0
+    risk: p1_correctness
+    cassandra:
+      category: tombstone-ttl
+      relevance: high
+      files:
+        - SerializationMirrorTest.java
+        - CQLSSTableWriterTest.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_delta_scan
+        tests:
+          - cqlite-core/tests/scan_delta_parity_test.rs
+        notes: >-
+          Maps to test_delta_parity_cell_tombstones; scan_delta cell-tombstone
+          facts are compared to the sstabledump JSONL golden.
+    fixtures:
+      references:
+        - test-data/datasets/sstables/test_deltas/cell_tombstones-29f7fbe06c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl
+    evidence:
+      type: canonical_semantic
+      artifacts: [jsonl]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb]
+      fixture_generation_command: >-
+        bash test-data/scripts/generate-deltas.sh
+      reference_paths:
+        - test-data/datasets/sstables/test_deltas/cell_tombstones-29f7fbe06c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl
+      normalization: >-
+        scan_delta cell-tombstone records are mapped to sstabledump JSONL
+        deletion facts (deleted_at) and compared with a writetime tolerance.
+      known_limitations: >-
+        Canonical-semantic JSONL parity only; byte-for-byte Data.db backing is a
+        follow-up under epic #969 (capability data_db_decode). test_deltas
+        binaries are not yet published/enforced in CI (issue #701).
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/delta-roundtrip.yml
+    scope:
+      gap: >-
+        No byte-for-byte Data.db diff yet; backed by canonical-semantic JSONL
+        parity. Byte-for-byte backing tracked by Data.db decode parity epic #969.
+        test_deltas dataset binaries not yet published/enforced in CI (#701).
+      next_step: >-
+        Add a byte-for-byte Data.db cell-tombstone scenario under data_db_decode
+        (#969) and publish/enforce the test_deltas dataset in delta-roundtrip CI (#701).
+
+  - id: cass.delta_scan.row_tombstones
+    title: Delta-scan row tombstones (DELETE FROM ... WHERE pk AND ck)
+    status: mirrored
+    capability: delta_scan
+    priority: P0
+    risk: p1_correctness
+    cassandra:
+      category: tombstone-ttl
+      relevance: high
+      files:
+        - SerializationMirrorTest.java
+        - CQLSSTableWriterTest.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_delta_scan
+        tests:
+          - cqlite-core/tests/scan_delta_parity_test.rs
+        notes: >-
+          Maps to test_delta_parity_row_tombstones; scan_delta row-delete facts
+          are compared to the sstabledump JSONL golden.
+    fixtures:
+      references:
+        - test-data/datasets/sstables/test_deltas/row_tombstones-2a0e91206c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl
+    evidence:
+      type: canonical_semantic
+      artifacts: [jsonl]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb]
+      fixture_generation_command: >-
+        bash test-data/scripts/generate-deltas.sh
+      reference_paths:
+        - test-data/datasets/sstables/test_deltas/row_tombstones-2a0e91206c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl
+      normalization: >-
+        scan_delta row-delete records are mapped to sstabledump JSONL row
+        deletion_info markers and compared with a writetime tolerance.
+      known_limitations: >-
+        Canonical-semantic JSONL parity only; byte-for-byte Data.db backing is a
+        follow-up under epic #969 (capability data_db_decode). test_deltas
+        binaries are not yet published/enforced in CI (issue #701).
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/delta-roundtrip.yml
+    scope:
+      gap: >-
+        No byte-for-byte Data.db diff yet; backed by canonical-semantic JSONL
+        parity. Byte-for-byte backing tracked by Data.db decode parity epic #969.
+        test_deltas dataset binaries not yet published/enforced in CI (#701).
+      next_step: >-
+        Add a byte-for-byte Data.db row-tombstone scenario under data_db_decode
+        (#969) and publish/enforce the test_deltas dataset in delta-roundtrip CI (#701).
+
+  - id: cass.delta_scan.range_tombstones
+    title: Delta-scan range tombstones (DELETE ... WHERE ck range)
+    status: mirrored
     capability: delta_scan
     priority: P0
     risk: p1_correctness
@@ -3420,37 +3530,411 @@ scenarios:
       relevance: high
       files:
         - RangeTombstoneTest.java
+        - RangeTombstoneListTest.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_delta_scan
+        tests:
+          - cqlite-core/tests/scan_delta_parity_test.rs
+        notes: >-
+          Maps to test_delta_parity_range_tombstones; scan_delta range-delete
+          start/end bound pairs are compared to the sstabledump JSONL golden.
+    fixtures:
+      references:
+        - test-data/datasets/sstables/test_deltas/range_tombstones-2a1a50f06c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl
+    evidence:
+      type: canonical_semantic
+      artifacts: [jsonl]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb]
+      fixture_generation_command: >-
+        bash test-data/scripts/generate-deltas.sh
+      reference_paths:
+        - test-data/datasets/sstables/test_deltas/range_tombstones-2a1a50f06c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl
+      normalization: >-
+        scan_delta range-delete records are mapped to consecutive sstabledump
+        JSONL range_tombstone_bound start/end pairs and compared with a writetime
+        tolerance; boundary markers are paired into synthetic end/start bounds.
+      known_limitations: >-
+        Canonical-semantic JSONL parity only; byte-for-byte Data.db backing is a
+        follow-up under epic #969 (capability data_db_decode). test_deltas
+        binaries are not yet published/enforced in CI (issue #701).
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/delta-roundtrip.yml
+    scope:
+      gap: >-
+        No byte-for-byte Data.db diff yet; backed by canonical-semantic JSONL
+        parity. Byte-for-byte backing tracked by Data.db decode parity epic #969.
+        test_deltas dataset binaries not yet published/enforced in CI (#701).
+      next_step: >-
+        Add a byte-for-byte Data.db range-tombstone scenario under data_db_decode
+        (#969) and publish/enforce the test_deltas dataset in delta-roundtrip CI (#701).
+
+  - id: cass.delta_scan.partition_tombstones
+    title: Delta-scan partition tombstones (DELETE FROM ... WHERE pk)
+    status: mirrored
+    capability: delta_scan
+    priority: P0
+    risk: p1_correctness
+    cassandra:
+      category: tombstone-ttl
+      relevance: high
+      files:
+        - RangeTombstoneTest.java
+        - SerializationMirrorTest.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_delta_scan
+        tests:
+          - cqlite-core/tests/scan_delta_parity_test.rs
+        notes: >-
+          Maps to test_delta_parity_partition_tombstones; scan_delta
+          partition-delete facts are compared to the sstabledump JSONL golden.
+    fixtures:
+      references:
+        - test-data/datasets/sstables/test_deltas/partition_tombstones-2a26fb206c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl
+    evidence:
+      type: canonical_semantic
+      artifacts: [jsonl]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb]
+      fixture_generation_command: >-
+        bash test-data/scripts/generate-deltas.sh
+      reference_paths:
+        - test-data/datasets/sstables/test_deltas/partition_tombstones-2a26fb206c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl
+      normalization: >-
+        scan_delta partition-delete records are mapped to the sstabledump JSONL
+        partition deletion_info marker (marked_deleted) and compared with a
+        writetime tolerance.
+      known_limitations: >-
+        Canonical-semantic JSONL parity only; byte-for-byte Data.db backing is a
+        follow-up under epic #969 (capability data_db_decode). test_deltas
+        binaries are not yet published/enforced in CI (issue #701).
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/delta-roundtrip.yml
+    scope:
+      gap: >-
+        No byte-for-byte Data.db diff yet; backed by canonical-semantic JSONL
+        parity. Byte-for-byte backing tracked by Data.db decode parity epic #969.
+        test_deltas dataset binaries not yet published/enforced in CI (#701).
+      next_step: >-
+        Add a byte-for-byte Data.db partition-tombstone scenario under
+        data_db_decode (#969) and publish/enforce the test_deltas dataset (#701).
+
+  - id: cass.delta_scan.ttl_cells
+    title: Delta-scan TTL / expiring cells (INSERT ... USING TTL)
+    status: mirrored
+    capability: delta_scan
+    priority: P0
+    risk: p1_correctness
+    cassandra:
+      category: tombstone-ttl
+      relevance: high
+      files:
         - TTLExpiryTest.java
     cqlite:
       coverage:
         suite: sstable_parity_delta_scan
         tests:
           - cqlite-core/tests/scan_delta_parity_test.rs
+        notes: >-
+          Maps to test_delta_parity_ttl_cells; scan_delta cell ttl /
+          local_deletion_time facts are compared to the sstabledump JSONL golden.
     fixtures:
       references:
-        - test-data/datasets/sstables/test_deltas/collection_ops-2a5006f06c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl
+        - test-data/datasets/sstables/test_deltas/ttl_cells-2a35ef406c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl
     evidence:
-      type: partial
+      type: canonical_semantic
       artifacts: [jsonl]
       cassandra_version: "5.0.2"
       cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
       storage_format_version: [nb]
       fixture_generation_command: >-
-        bash test-data/scripts/generate-deltas.sh  # all delete shapes → sstabledump JSONL
+        bash test-data/scripts/generate-deltas.sh
       reference_paths:
-        - test-data/datasets/sstables/test_deltas/collection_ops-2a5006f06c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl
+        - test-data/datasets/sstables/test_deltas/ttl_cells-2a35ef406c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl
       normalization: >-
-        scan_delta records (cell/row/partition/range tombstones, TTL, liveness)
-        are mapped to sstabledump JSONL deletion facts and compared.
+        scan_delta expiring-cell records are mapped to sstabledump JSONL cell
+        ttl / local_deletion_time fields and compared; mixed live + expiring
+        cells in the same fixture exercise both code paths.
       known_limitations: >-
-        test_deltas dataset binaries are not yet published/enforced in CI
-        (issue #701); validated locally only.
+        Canonical-semantic JSONL parity only; byte-for-byte Data.db backing is a
+        follow-up under epic #969 (capability data_db_decode). test_deltas
+        binaries are not yet published/enforced in CI (issue #701).
     ci:
       tier: required_parity
       workflow: .github/workflows/delta-roundtrip.yml
     scope:
-      gap: test_deltas dataset asset not published/enforced (#701).
-      next_step: Publish and enforce the test_deltas dataset in delta-roundtrip CI.
+      gap: >-
+        No byte-for-byte Data.db diff yet; backed by canonical-semantic JSONL
+        parity. Byte-for-byte backing tracked by Data.db decode parity epic #969.
+        test_deltas dataset binaries not yet published/enforced in CI (#701).
+      next_step: >-
+        Add a byte-for-byte Data.db ttl/expiring-cell scenario under
+        data_db_decode (#969) and publish/enforce the test_deltas dataset (#701).
+
+  - id: cass.delta_scan.static_with_rows
+    title: Delta-scan static columns alongside clustered rows
+    status: mirrored
+    capability: delta_scan
+    priority: P0
+    risk: p1_correctness
+    cassandra:
+      category: serialization
+      relevance: high
+      files:
+        - SerializationMirrorTest.java
+        - CQLSSTableWriterTest.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_delta_scan
+        tests:
+          - cqlite-core/tests/scan_delta_parity_test.rs
+        notes: >-
+          Maps to test_delta_parity_static_with_rows; scan_delta static-cell
+          upserts and clustered-row cells are compared to the sstabledump JSONL
+          golden.
+    fixtures:
+      references:
+        - test-data/datasets/sstables/test_deltas/static_with_rows-2a4299706c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl
+    evidence:
+      type: canonical_semantic
+      artifacts: [jsonl]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb]
+      fixture_generation_command: >-
+        bash test-data/scripts/generate-deltas.sh
+      reference_paths:
+        - test-data/datasets/sstables/test_deltas/static_with_rows-2a4299706c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl
+      normalization: >-
+        scan_delta static-cell upserts are mapped to the sstabledump JSONL static
+        row block and clustered-row cells to their per-row cell lists; both are
+        compared by value and writetime with tolerance.
+      known_limitations: >-
+        Canonical-semantic JSONL parity only; byte-for-byte Data.db backing is a
+        follow-up under epic #969 (capability data_db_decode). test_deltas
+        binaries are not yet published/enforced in CI (issue #701).
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/delta-roundtrip.yml
+    scope:
+      gap: >-
+        No byte-for-byte Data.db diff yet; backed by canonical-semantic JSONL
+        parity. Byte-for-byte backing tracked by Data.db decode parity epic #969.
+        test_deltas dataset binaries not yet published/enforced in CI (#701).
+      next_step: >-
+        Add a byte-for-byte Data.db static-with-rows scenario under
+        data_db_decode (#969) and publish/enforce the test_deltas dataset (#701).
+
+  - id: cass.delta_scan.partial_updates
+    title: Delta-scan partial updates (UPDATE-only rows, no row liveness)
+    status: mirrored
+    capability: delta_scan
+    priority: P0
+    risk: p1_correctness
+    cassandra:
+      category: serialization
+      relevance: high
+      files:
+        - SerializationMirrorTest.java
+        - CQLSSTableWriterTest.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_delta_scan
+        tests:
+          - cqlite-core/tests/scan_delta_parity_test.rs
+        notes: >-
+          Maps to test_delta_parity_partial_updates; scan_delta cell upserts and
+          row-liveness presence/absence are compared to the sstabledump JSONL
+          golden (UPDATE-only rows carry no row liveness token).
+    fixtures:
+      references:
+        - test-data/datasets/sstables/test_deltas/partial_updates-2a5ed4006c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl
+    evidence:
+      type: canonical_semantic
+      artifacts: [jsonl]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb]
+      fixture_generation_command: >-
+        bash test-data/scripts/generate-deltas.sh
+      reference_paths:
+        - test-data/datasets/sstables/test_deltas/partial_updates-2a5ed4006c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl
+      normalization: >-
+        scan_delta cell upserts are mapped to sstabledump JSONL per-cell records
+        and compared; row-liveness presence (INSERT) vs absence (UPDATE-only) is
+        asserted against the JSONL liveness_info markers.
+      known_limitations: >-
+        Canonical-semantic JSONL parity only; byte-for-byte Data.db backing is a
+        follow-up under epic #969 (capability data_db_decode). test_deltas
+        binaries are not yet published/enforced in CI (issue #701).
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/delta-roundtrip.yml
+    scope:
+      gap: >-
+        No byte-for-byte Data.db diff yet; backed by canonical-semantic JSONL
+        parity. Byte-for-byte backing tracked by Data.db decode parity epic #969.
+        test_deltas dataset binaries not yet published/enforced in CI (#701).
+      next_step: >-
+        Add a byte-for-byte Data.db partial-update scenario under data_db_decode
+        (#969) and publish/enforce the test_deltas dataset (#701).
+
+  - id: cass.delta_scan.adjacent_ranges
+    title: Delta-scan adjacent range tombstones (shared boundary markers)
+    status: mirrored
+    capability: delta_scan
+    priority: P0
+    risk: p1_correctness
+    cassandra:
+      category: tombstone-ttl
+      relevance: high
+      files:
+        - RangeTombstoneListTest.java
+        - RangeTombstoneTest.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_delta_scan
+        tests:
+          - cqlite-core/tests/scan_delta_parity_test.rs
+        notes: >-
+          Maps to test_delta_parity_adjacent_ranges; scan_delta range-delete
+          bounds across shared excl_end/incl_start boundary markers are compared
+          to the sstabledump JSONL golden.
+    fixtures:
+      references:
+        - test-data/datasets/sstables/test_deltas/adjacent_ranges-972f22806c7811f1a24ff924a65838e2/nb-1-big-Data.db.jsonl
+    evidence:
+      type: canonical_semantic
+      artifacts: [jsonl]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb]
+      fixture_generation_command: >-
+        bash test-data/scripts/generate-deltas.sh
+      reference_paths:
+        - test-data/datasets/sstables/test_deltas/adjacent_ranges-972f22806c7811f1a24ff924a65838e2/nb-1-big-Data.db.jsonl
+      normalization: >-
+        scan_delta range-delete records are reconstructed from sstabledump JSONL
+        boundary markers (excl_end_incl_start / incl_end_excl_start) into
+        synthetic end/start bound pairs and compared with a writetime tolerance.
+      known_limitations: >-
+        Canonical-semantic JSONL parity only; byte-for-byte Data.db backing is a
+        follow-up under epic #969 (capability data_db_decode). test_deltas
+        binaries are not yet published/enforced in CI (issue #701).
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/delta-roundtrip.yml
+    scope:
+      gap: >-
+        No byte-for-byte Data.db diff yet; backed by canonical-semantic JSONL
+        parity. Byte-for-byte backing tracked by Data.db decode parity epic #969.
+        test_deltas dataset binaries not yet published/enforced in CI (#701).
+      next_step: >-
+        Add a byte-for-byte Data.db adjacent-range scenario under data_db_decode
+        (#969) and publish/enforce the test_deltas dataset (#701).
+
+  - id: cass.delta_scan.collection_ops
+    title: Delta-scan collection operations (append/overwrite/element delete)
+    status: mirrored
+    capability: delta_scan
+    priority: P0
+    risk: p1_correctness
+    cassandra:
+      category: serialization
+      relevance: high
+      files:
+        - SerializationMirrorTest.java
+        - CQLSSTableWriterTest.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_delta_scan
+        tests:
+          - cqlite-core/tests/scan_delta_parity_test.rs
+        notes: >-
+          Maps to test_delta_parity_collection_ops; scan_delta collection cell
+          upserts and element/collection tombstones are compared to the
+          sstabledump JSONL golden.
+    fixtures:
+      references:
+        - test-data/datasets/sstables/test_deltas/collection_ops-2a5006f06c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl
+    evidence:
+      type: canonical_semantic
+      artifacts: [jsonl]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb]
+      fixture_generation_command: >-
+        bash test-data/scripts/generate-deltas.sh
+      reference_paths:
+        - test-data/datasets/sstables/test_deltas/collection_ops-2a5006f06c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl
+      normalization: >-
+        scan_delta collection cell upserts and the complex-cell deletion markers
+        emitted by SET append / overwrite / element removal are mapped to the
+        sstabledump JSONL collection cells and compared with a writetime tolerance.
+      known_limitations: >-
+        Canonical-semantic JSONL parity only; byte-for-byte Data.db backing is a
+        follow-up under epic #969 (capability data_db_decode). test_deltas
+        binaries are not yet published/enforced in CI (issue #701).
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/delta-roundtrip.yml
+    scope:
+      gap: >-
+        No byte-for-byte Data.db diff yet; backed by canonical-semantic JSONL
+        parity. Byte-for-byte backing tracked by Data.db decode parity epic #969.
+        test_deltas dataset binaries not yet published/enforced in CI (#701).
+      next_step: >-
+        Add a byte-for-byte Data.db collection-ops scenario under data_db_decode
+        (#969) and publish/enforce the test_deltas dataset (#701).
+
+  - id: cass.delta_scan.wide_partition_corpus
+    title: Delta-scan over wide partitions (planned — no test_deltas fixture yet)
+    status: planned
+    capability: delta_scan
+    priority: P1
+    risk: p1_correctness
+    cassandra:
+      category: tombstone-ttl
+      relevance: high
+      files:
+        - SSTableSkippingReadTest.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_delta_scan
+    fixtures: {}
+    evidence:
+      type: canonical_semantic
+      artifacts: [jsonl]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb]
+      normalization: >-
+        Planned: scan_delta facts over a wide partition (many clustered rows +
+        range/cell tombstones in one partition, exercising index-block skipping)
+        compared to the sstabledump JSONL golden.
+      known_limitations: >-
+        No wide-partition delete fixture exists under test_deltas; wide
+        partitions live in the wide-row corpus (epic #993). No fixture is
+        fabricated here — this is recorded as a gap.
+    ci:
+      tier: exhaustive_regeneration
+      workflow: .github/workflows/delta-roundtrip.yml
+    scope:
+      target_issue: 993
+      target_suite: sstable_parity_delta_scan
+      gap: >-
+        No test_deltas wide-partition delete fixture; wide partitions are
+        produced by the wide-row corpus (epic #993), not generate-deltas.sh.
+        Byte-for-byte backing for delta_scan remains tracked by epic #969.
+      next_step: >-
+        Add a wide-partition delete shape (or reuse a wide-row corpus fixture)
+        and a paired test_delta_parity_wide_partition test under epic #993.
 
   # ----------------------------------------------------------------------------
   # compaction_merge

--- a/tools/cassandra-parity/src/lint.rs
+++ b/tools/cassandra-parity/src/lint.rs
@@ -142,7 +142,41 @@ fn lint_scenario(s: &Scenario, repo_root: Option<&Path>, out: &mut Vec<Finding>)
     // --- status-conditional rules ---
     match s.status.as_str() {
         "mirrored" => {
-            if s.cqlite.coverage.tests.is_empty() && s.fixtures.references.is_empty() {
+            // delta_scan mirrored scenarios are held to a stricter bar than the
+            // generic OR rule (issue #995, AC6): a delta-shape claim is only
+            // trustworthy when it is backed by BOTH a real CQLite per-shape test
+            // (whose file exists on disk) AND a JSONL fixture reference. The
+            // generic OR rule below covers all other capabilities.
+            if s.capability == "delta_scan" {
+                if s.cqlite.coverage.tests.is_empty() {
+                    out.push(Finding::error(
+                        id,
+                        "cqlite.coverage.tests",
+                        "mirrored delta_scan scenarios must name a CQLite test target",
+                    ));
+                }
+                if s.fixtures.references.is_empty() {
+                    out.push(Finding::error(
+                        id,
+                        "fixtures.references",
+                        "mirrored delta_scan scenarios must name a fixture reference",
+                    ));
+                }
+                // The referenced test file(s) must actually exist on disk.
+                if let Some(root) = repo_root {
+                    for t in &s.cqlite.coverage.tests {
+                        if !root.join(t).exists() {
+                            out.push(Finding::error(
+                                id,
+                                "cqlite.coverage.tests",
+                                format!(
+                                    "mirrored delta_scan test target does not exist: {t}"
+                                ),
+                            ));
+                        }
+                    }
+                }
+            } else if s.cqlite.coverage.tests.is_empty() && s.fixtures.references.is_empty() {
                 out.push(Finding::error(
                     id,
                     "cqlite.coverage.tests|fixtures.references",

--- a/tools/cassandra-parity/src/lint.rs
+++ b/tools/cassandra-parity/src/lint.rs
@@ -162,7 +162,9 @@ fn lint_scenario(s: &Scenario, repo_root: Option<&Path>, out: &mut Vec<Finding>)
                         "mirrored delta_scan scenarios must name a fixture reference",
                     ));
                 }
-                // The referenced test file(s) must actually exist on disk.
+                // The referenced test file(s) AND fixture(s) must actually exist
+                // on disk: a dangling/typo'd path must not pass lint silently
+                // (AC6 — backed by BOTH a real test AND a real fixture).
                 if let Some(root) = repo_root {
                     for t in &s.cqlite.coverage.tests {
                         if !root.join(t).exists() {
@@ -170,6 +172,17 @@ fn lint_scenario(s: &Scenario, repo_root: Option<&Path>, out: &mut Vec<Finding>)
                                 id,
                                 "cqlite.coverage.tests",
                                 format!("mirrored delta_scan test target does not exist: {t}"),
+                            ));
+                        }
+                    }
+                    for r in &s.fixtures.references {
+                        if !root.join(r).exists() {
+                            out.push(Finding::error(
+                                id,
+                                "fixtures.references",
+                                format!(
+                                    "mirrored delta_scan fixture reference does not exist: {r}"
+                                ),
                             ));
                         }
                     }

--- a/tools/cassandra-parity/src/lint.rs
+++ b/tools/cassandra-parity/src/lint.rs
@@ -169,9 +169,7 @@ fn lint_scenario(s: &Scenario, repo_root: Option<&Path>, out: &mut Vec<Finding>)
                             out.push(Finding::error(
                                 id,
                                 "cqlite.coverage.tests",
-                                format!(
-                                    "mirrored delta_scan test target does not exist: {t}"
-                                ),
+                                format!("mirrored delta_scan test target does not exist: {t}"),
                             ));
                         }
                     }

--- a/tools/cassandra-parity/src/report.rs
+++ b/tools/cassandra-parity/src/report.rs
@@ -271,16 +271,25 @@ fn render_evidence_group(
         return;
     }
     for x in &items {
-        line(&format!("- `{}` — {}", x.id, x.title));
+        // A `planned` scenario carries an evidence *type* but no evidence yet;
+        // mark it so the section never reads as if the parity exists today
+        // (issue #995 — wide_partition_corpus is planned canonical_semantic).
+        let planned = if x.status == "planned" {
+            " _(planned — no evidence yet)_"
+        } else {
+            ""
+        };
+        line(&format!("- `{}` — {}{planned}", x.id, x.title));
         if let Some(norm) = &x.evidence.normalization {
             if !norm.is_empty() {
                 line(&format!("  - Normalization: {norm}"));
             }
         }
-        // delta_scan canonical-semantic scenarios are JSONL parity only; surface
-        // that byte-for-byte Data.db backing is still a follow-up so the report
-        // does not read as byte parity (issue #995, AC3/AC7).
-        if x.capability == "delta_scan" {
+        // delta_scan scenarios are JSONL semantic parity only; surface that
+        // byte-for-byte Data.db backing is still a follow-up so the report does
+        // not read as byte parity (issue #995, AC3/AC7). Skip the note for
+        // planned scenarios, which have no evidence to qualify.
+        if x.capability == "delta_scan" && x.status != "planned" {
             line("  - Byte-for-byte: not yet — needs Data.db backing (follow-up under epic #969).");
         }
     }

--- a/tools/cassandra-parity/src/report.rs
+++ b/tools/cassandra-parity/src/report.rs
@@ -277,6 +277,12 @@ fn render_evidence_group(
                 line(&format!("  - Normalization: {norm}"));
             }
         }
+        // delta_scan canonical-semantic scenarios are JSONL parity only; surface
+        // that byte-for-byte Data.db backing is still a follow-up so the report
+        // does not read as byte parity (issue #995, AC3/AC7).
+        if x.capability == "delta_scan" {
+            line("  - Byte-for-byte: not yet — needs Data.db backing (follow-up under epic #969).");
+        }
     }
     line("");
 }

--- a/tools/cassandra-parity/tests/lint_tests.rs
+++ b/tools/cassandra-parity/tests/lint_tests.rs
@@ -396,6 +396,92 @@ fn schema_enums_match_lint_enums() {
     );
 }
 
+/// Extract the `test_deltas` table name from a fixture reference path of the
+/// form `.../test_deltas/<table>-<uuid>/nb-1-big-Data.db.jsonl`.
+fn delta_table_from_ref(path: &str) -> Option<String> {
+    let after = path.split("test_deltas/").nth(1)?;
+    let dir = after.split('/').next()?;
+    let table = dir.rsplit_once('-').map(|(t, _)| t).unwrap_or(dir);
+    Some(table.to_string())
+}
+
+/// Parse `CREATE TABLE [IF NOT EXISTS] <name>` table names from a CQL schema.
+fn cql_table_names(cql: &str) -> std::collections::BTreeSet<String> {
+    let mut out = std::collections::BTreeSet::new();
+    let lower = cql.to_lowercase();
+    let mut search = 0usize;
+    while let Some(rel) = lower[search..].find("create table") {
+        let start = search + rel + "create table".len();
+        let rest = &cql[start..];
+        // Skip "if not exists" and whitespace; the next token is the table name.
+        let tokens: Vec<&str> = rest.split_whitespace().collect();
+        let mut idx = 0;
+        if tokens.get(0).map(|t| t.eq_ignore_ascii_case("if")) == Some(true) {
+            idx = 3; // if not exists
+        }
+        if let Some(name) = tokens.get(idx) {
+            let clean: String = name
+                .chars()
+                .take_while(|c| c.is_alphanumeric() || *c == '_')
+                .collect();
+            if !clean.is_empty() {
+                out.insert(clean.to_lowercase());
+            }
+        }
+        search = start;
+    }
+    out
+}
+
+/// AC5 (issue #995): every `delta_scan` scenario's referenced fixture table must
+/// correspond to a table that `test-data/schemas/deltas.cql` actually creates
+/// (and therefore that `generate-deltas.sh` produces). A scenario cannot claim a
+/// delta shape the generator does not emit. Deterministic — no Cassandra/Docker.
+#[test]
+fn delta_scan_fixtures_map_to_generated_tables() {
+    let root = repo_root();
+    let m = Manifest::from_yaml(
+        &std::fs::read_to_string(root.join("test-data/cassandra-parity-manifest.yml")).unwrap(),
+    )
+    .unwrap();
+    let cql = std::fs::read_to_string(root.join("test-data/schemas/deltas.cql"))
+        .expect("deltas.cql exists");
+    let known = cql_table_names(&cql);
+    assert!(
+        !known.is_empty(),
+        "deltas.cql yielded no CREATE TABLE names"
+    );
+
+    let mut problems = Vec::new();
+    for s in m.scenarios.iter().filter(|s| s.capability == "delta_scan") {
+        // `planned` scenarios (e.g. the wide-partition corpus gap) intentionally
+        // carry no test_deltas fixture and are exempt.
+        if s.status == "planned" {
+            continue;
+        }
+        let refs = s
+            .fixtures
+            .references
+            .iter()
+            .chain(s.evidence.reference_paths.iter());
+        for r in refs {
+            if let Some(table) = delta_table_from_ref(r) {
+                if !known.contains(&table) {
+                    problems.push(format!(
+                        "[{}] references test_deltas table '{}' not created by deltas.cql (known: {:?})",
+                        s.id, table, known
+                    ));
+                }
+            }
+        }
+    }
+    assert!(
+        problems.is_empty(),
+        "delta_scan fixture/generator drift:\n{}",
+        problems.join("\n")
+    );
+}
+
 #[test]
 fn coverage_finds_high_relevance_files() {
     let root = repo_root();

--- a/tools/cassandra-parity/tests/lint_tests.rs
+++ b/tools/cassandra-parity/tests/lint_tests.rs
@@ -207,6 +207,26 @@ fn delta_scan_mirrored_with_nonexistent_test_path_is_rejected() {
 }
 
 #[test]
+fn delta_scan_mirrored_with_nonexistent_fixture_path_is_rejected() {
+    // A fixture reference that does not exist on disk must fail the delta_scan
+    // rule (mirrors the test-target existence check; AC6 — backed by BOTH a
+    // real test AND a real fixture).
+    let scenario = VALID_DELTA_SCAN_SCENARIO.replace(
+        "        - test-data/cassandra-parity-manifest.yml",
+        "        - test-data/does_not_exist_995.jsonl",
+    );
+    let errs = errors_checked(&wrap(&scenario));
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("cass.delta_scan.cell_tombstones")
+                && e.contains("fixtures.references")
+                && e.contains("delta_scan")
+                && e.contains("does not exist")),
+        "expected a delta_scan missing-fixture-file error, got: {errs:#?}"
+    );
+}
+
+#[test]
 fn out_of_scope_missing_required_fields_is_rejected() {
     let scenario = r#"  - id: cass.commitlog_replay.example_oos
     title: Out of scope example
@@ -404,6 +424,10 @@ fn schema_enums_match_lint_enums() {
 fn delta_table_from_ref(path: &str) -> Option<String> {
     let after = path.split("test_deltas/").nth(1)?;
     let dir = after.split('/').next()?;
+    // Assumes the trailing SSTable UUID is dashless 32-hex (true for the current
+    // fixture dir names, e.g. `cell_tombstones-29733830701f11f1b5d1d98b0640ec05`),
+    // so the last `-` separates table name from UUID. A dashed UUID would split
+    // mid-UUID; revisit (e.g. a length-based strip) if fixture naming changes.
     let table = dir.rsplit_once('-').map(|(t, _)| t).unwrap_or(dir);
     Some(table.to_string())
 }
@@ -413,9 +437,14 @@ fn cql_table_names(cql: &str) -> std::collections::BTreeSet<String> {
     let mut out = std::collections::BTreeSet::new();
     let lower = cql.to_lowercase();
     let mut search = 0usize;
+    // Index `lower` for both search and extraction: `to_lowercase()` is only
+    // byte-length-preserving for ASCII, so cross-indexing the original `cql`
+    // with offsets derived from `lower` could desync and panic on a non-char
+    // boundary. The token is lowercased anyway, so working entirely in `lower`
+    // is equivalent and safe.
     while let Some(rel) = lower[search..].find("create table") {
         let start = search + rel + "create table".len();
-        let rest = &cql[start..];
+        let rest = &lower[start..];
         // Skip "if not exists" and whitespace; the next token is the table name.
         let tokens: Vec<&str> = rest.split_whitespace().collect();
         let mut idx = 0;

--- a/tools/cassandra-parity/tests/lint_tests.rs
+++ b/tools/cassandra-parity/tests/lint_tests.rs
@@ -101,6 +101,108 @@ fn mirrored_without_test_or_reference_is_rejected() {
     );
 }
 
+/// A mirrored `delta_scan` scenario whose only coverage is a real test target
+/// (with an existing file path) AND a fixture reference. This is the strict bar
+/// the per-shape delta_scan scenarios must clear (issue #995, AC6).
+const VALID_DELTA_SCAN_SCENARIO: &str = r#"  - id: cass.delta_scan.cell_tombstones
+    title: Delta-scan cell tombstones
+    status: mirrored
+    capability: delta_scan
+    priority: P0
+    risk: p1_correctness
+    cassandra:
+      category: tombstone-ttl
+      relevance: high
+      files: [SerializationMirrorTest.java]
+    cqlite:
+      coverage:
+        suite: sstable_parity_delta_scan
+        tests: [tools/cassandra-parity/src/lint.rs]
+        notes: maps to test_delta_parity_cell_tombstones
+    fixtures:
+      references:
+        - test-data/cassandra-parity-manifest.yml
+    evidence:
+      type: canonical_semantic
+      artifacts: [jsonl]
+      normalization: scan_delta records mapped to sstabledump JSONL deletion facts
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb]
+      fixture_generation_command: bash test-data/scripts/generate-deltas.sh
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/delta-roundtrip.yml
+    scope: {}
+"#;
+
+fn errors_checked(yaml: &str) -> Vec<String> {
+    // Lint with repo_root so referenced paths are resolved against the repo.
+    let m = Manifest::from_yaml(yaml).expect("manifest should parse");
+    lint(&m, Some(&repo_root()))
+        .into_iter()
+        .filter(|f| f.level == Level::Error)
+        .map(|f| format!("[{}] {}: {}", f.id, f.field, f.message))
+        .collect()
+}
+
+#[test]
+fn delta_scan_mirrored_with_test_and_fixture_passes() {
+    let errs = errors_checked(&wrap(VALID_DELTA_SCAN_SCENARIO));
+    assert!(errs.is_empty(), "expected no errors, got: {errs:#?}");
+}
+
+#[test]
+fn delta_scan_mirrored_missing_fixture_reference_is_rejected() {
+    // Strip the fixture reference: generic OR rule would still pass (test present),
+    // but the delta_scan-specific rule requires BOTH.
+    let scenario = VALID_DELTA_SCAN_SCENARIO.replace(
+        "    fixtures:\n      references:\n        - test-data/cassandra-parity-manifest.yml\n",
+        "    fixtures: {}\n",
+    );
+    let errs = errors_checked(&wrap(&scenario));
+    assert!(
+        errs.iter().any(|e| e.contains("cass.delta_scan.cell_tombstones")
+            && e.contains("fixtures.references")
+            && e.contains("delta_scan")),
+        "expected a delta_scan fixture-required error, got: {errs:#?}"
+    );
+}
+
+#[test]
+fn delta_scan_mirrored_missing_test_target_is_rejected() {
+    // Strip the test target: generic OR rule would still pass (fixture present),
+    // but the delta_scan-specific rule requires BOTH a test AND a fixture.
+    let scenario = VALID_DELTA_SCAN_SCENARIO.replace(
+        "        tests: [tools/cassandra-parity/src/lint.rs]\n        notes: maps to test_delta_parity_cell_tombstones\n",
+        "",
+    );
+    let errs = errors_checked(&wrap(&scenario));
+    assert!(
+        errs.iter().any(|e| e.contains("cass.delta_scan.cell_tombstones")
+            && e.contains("cqlite.coverage.tests")
+            && e.contains("delta_scan")),
+        "expected a delta_scan test-required error, got: {errs:#?}"
+    );
+}
+
+#[test]
+fn delta_scan_mirrored_with_nonexistent_test_path_is_rejected() {
+    // A test path that does not exist on disk must fail the delta_scan rule
+    // (stricter than the generic "names a test" check).
+    let scenario = VALID_DELTA_SCAN_SCENARIO.replace(
+        "tests: [tools/cassandra-parity/src/lint.rs]",
+        "tests: [cqlite-core/tests/does_not_exist_995.rs]",
+    );
+    let errs = errors_checked(&wrap(&scenario));
+    assert!(
+        errs.iter().any(|e| e.contains("cass.delta_scan.cell_tombstones")
+            && e.contains("delta_scan")
+            && e.contains("does not exist")),
+        "expected a delta_scan missing-test-file error, got: {errs:#?}"
+    );
+}
+
 #[test]
 fn out_of_scope_missing_required_fields_is_rejected() {
     let scenario = r#"  - id: cass.commitlog_replay.example_oos

--- a/tools/cassandra-parity/tests/lint_tests.rs
+++ b/tools/cassandra-parity/tests/lint_tests.rs
@@ -419,7 +419,7 @@ fn cql_table_names(cql: &str) -> std::collections::BTreeSet<String> {
         // Skip "if not exists" and whitespace; the next token is the table name.
         let tokens: Vec<&str> = rest.split_whitespace().collect();
         let mut idx = 0;
-        if tokens.get(0).map(|t| t.eq_ignore_ascii_case("if")) == Some(true) {
+        if tokens.first().map(|t| t.eq_ignore_ascii_case("if")) == Some(true) {
             idx = 3; // if not exists
         }
         if let Some(name) = tokens.get(idx) {

--- a/tools/cassandra-parity/tests/lint_tests.rs
+++ b/tools/cassandra-parity/tests/lint_tests.rs
@@ -452,6 +452,11 @@ fn cql_table_names(cql: &str) -> std::collections::BTreeSet<String> {
             idx = 3; // if not exists
         }
         if let Some(name) = tokens.get(idx) {
+            // Assumes unqualified table names (deltas.cql uses `USE test_deltas;`
+            // + bare `CREATE TABLE [IF NOT EXISTS] <name>`). The alphanumeric/'_'
+            // scan stops at the first '.', so a keyspace-qualified name
+            // (`keyspace.table`) would yield the keyspace, not the table — strip a
+            // leading `keyspace.` prefix here if deltas.cql ever switches to it.
             let clean: String = name
                 .chars()
                 .take_while(|c| c.is_alphanumeric() || *c == '_')

--- a/tools/cassandra-parity/tests/lint_tests.rs
+++ b/tools/cassandra-parity/tests/lint_tests.rs
@@ -162,9 +162,10 @@ fn delta_scan_mirrored_missing_fixture_reference_is_rejected() {
     );
     let errs = errors_checked(&wrap(&scenario));
     assert!(
-        errs.iter().any(|e| e.contains("cass.delta_scan.cell_tombstones")
-            && e.contains("fixtures.references")
-            && e.contains("delta_scan")),
+        errs.iter()
+            .any(|e| e.contains("cass.delta_scan.cell_tombstones")
+                && e.contains("fixtures.references")
+                && e.contains("delta_scan")),
         "expected a delta_scan fixture-required error, got: {errs:#?}"
     );
 }
@@ -179,9 +180,10 @@ fn delta_scan_mirrored_missing_test_target_is_rejected() {
     );
     let errs = errors_checked(&wrap(&scenario));
     assert!(
-        errs.iter().any(|e| e.contains("cass.delta_scan.cell_tombstones")
-            && e.contains("cqlite.coverage.tests")
-            && e.contains("delta_scan")),
+        errs.iter()
+            .any(|e| e.contains("cass.delta_scan.cell_tombstones")
+                && e.contains("cqlite.coverage.tests")
+                && e.contains("delta_scan")),
         "expected a delta_scan test-required error, got: {errs:#?}"
     );
 }
@@ -196,9 +198,10 @@ fn delta_scan_mirrored_with_nonexistent_test_path_is_rejected() {
     );
     let errs = errors_checked(&wrap(&scenario));
     assert!(
-        errs.iter().any(|e| e.contains("cass.delta_scan.cell_tombstones")
-            && e.contains("delta_scan")
-            && e.contains("does not exist")),
+        errs.iter()
+            .any(|e| e.contains("cass.delta_scan.cell_tombstones")
+                && e.contains("delta_scan")
+                && e.contains("does not exist")),
         "expected a delta_scan missing-test-file error, got: {errs:#?}"
     );
 }

--- a/tools/cassandra-parity/tests/report_tests.rs
+++ b/tools/cassandra-parity/tests/report_tests.rs
@@ -79,3 +79,32 @@ fn wide_partition_corpus_is_a_planned_gap() {
         "wide_partition_corpus must be marked planned in the gaps section"
     );
 }
+
+#[test]
+fn planned_scenario_in_evidence_group_is_marked_no_evidence_yet() {
+    let r = rendered();
+    let header = "## Canonical-semantic scenarios";
+    let start = r.find(header).expect("canonical-semantic section present");
+    let section = &r[start..];
+    // The planned wide_partition_corpus is grouped by its declared evidence type
+    // but must be flagged so it does not read as proven parity.
+    let line = section
+        .lines()
+        .find(|l| l.contains("cass.delta_scan.wide_partition_corpus"))
+        .expect("wide_partition_corpus listed in canonical-semantic section");
+    assert!(
+        line.contains("planned — no evidence yet"),
+        "planned scenario must be marked, got: {line}"
+    );
+    // The byte-for-byte follow-up note is NOT emitted for a planned scenario
+    // (it has no evidence to qualify).
+    let next = section
+        .lines()
+        .skip_while(|l| !l.contains("cass.delta_scan.wide_partition_corpus"))
+        .nth(1)
+        .unwrap_or("");
+    assert!(
+        !next.contains("Byte-for-byte: not yet"),
+        "planned scenario should not carry the byte-for-byte follow-up note"
+    );
+}

--- a/tools/cassandra-parity/tests/report_tests.rs
+++ b/tools/cassandra-parity/tests/report_tests.rs
@@ -66,7 +66,9 @@ fn delta_scan_canonical_semantic_marks_byte_for_byte_followup() {
 #[test]
 fn wide_partition_corpus_is_a_planned_gap() {
     let r = rendered();
-    let gaps_start = r.find("## Gaps and next steps").expect("gaps section present");
+    let gaps_start = r
+        .find("## Gaps and next steps")
+        .expect("gaps section present");
     let gaps = &r[gaps_start..];
     assert!(
         gaps.contains("cass.delta_scan.wide_partition_corpus"),

--- a/tools/cassandra-parity/tests/report_tests.rs
+++ b/tools/cassandra-parity/tests/report_tests.rs
@@ -1,0 +1,79 @@
+//! Report-rendering tests (issue #995): the generated parity report must make
+//! the delta_scan evidence story honest — canonical-semantic JSONL scenarios are
+//! surfaced as such with an explicit "needs byte-for-byte Data.db backing"
+//! follow-up note, and the planned wide-partition corpus appears under gaps.
+
+use std::path::PathBuf;
+
+use cassandra_parity::model::Manifest;
+use cassandra_parity::report;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn real_manifest() -> Manifest {
+    let path = repo_root().join("test-data/cassandra-parity-manifest.yml");
+    let text = std::fs::read_to_string(&path).expect("real manifest exists");
+    Manifest::from_yaml(&text).expect("real manifest parses")
+}
+
+fn rendered() -> String {
+    report::render(&real_manifest(), "test-data/cassandra-parity-manifest.yml")
+}
+
+#[test]
+fn delta_scan_scenarios_render_under_canonical_semantic() {
+    let r = rendered();
+    let header = "## Canonical-semantic scenarios";
+    let start = r.find(header).expect("canonical-semantic section present");
+    let section = &r[start..];
+    // The mirrored per-shape delta_scan scenarios are canonical-semantic.
+    for id in [
+        "cass.delta_scan.cell_tombstones",
+        "cass.delta_scan.row_tombstones",
+        "cass.delta_scan.range_tombstones",
+        "cass.delta_scan.partition_tombstones",
+        "cass.delta_scan.ttl_cells",
+        "cass.delta_scan.static_with_rows",
+        "cass.delta_scan.partial_updates",
+        "cass.delta_scan.adjacent_ranges",
+        "cass.delta_scan.collection_ops",
+    ] {
+        assert!(
+            section.contains(id),
+            "{id} should appear under the canonical-semantic section"
+        );
+    }
+}
+
+#[test]
+fn delta_scan_canonical_semantic_marks_byte_for_byte_followup() {
+    let r = rendered();
+    // The byte-for-byte follow-up note must appear so the report never reads as
+    // byte parity for delta_scan (AC3/AC7). Tie it to the Data.db epic.
+    assert!(
+        r.contains("Byte-for-byte: not yet — needs Data.db backing (follow-up under epic #969)."),
+        "report must surface the delta_scan byte-for-byte follow-up note"
+    );
+}
+
+#[test]
+fn wide_partition_corpus_is_a_planned_gap() {
+    let r = rendered();
+    let gaps_start = r.find("## Gaps and next steps").expect("gaps section present");
+    let gaps = &r[gaps_start..];
+    assert!(
+        gaps.contains("cass.delta_scan.wide_partition_corpus"),
+        "planned wide_partition_corpus must appear under gaps/next-steps"
+    );
+    assert!(
+        gaps.contains("planned"),
+        "wide_partition_corpus must be marked planned in the gaps section"
+    );
+}


### PR DESCRIPTION
Closes #995.

## What

Decomposes the single opaque `cass.delta_scan.tombstone_liveness_facts` manifest scenario into **per-shape, individually-classified** `delta_scan` scenarios so delta-scan coverage is traceable in the Cassandra parity manifest + generated report, with a clear line between canonical-semantic JSONL evidence and (not-yet-present) byte-for-byte Data.db evidence.

## Scenarios

Replaced the opaque scenario with 9 `mirrored`/`canonical_semantic` scenarios, each mapped to its specific `test_deltas` JSONL fixture + its exact `test_delta_parity_*` test:
`cell_tombstones`, `row_tombstones`, `range_tombstones`, `partition_tombstones`, `ttl_cells`, `static_with_rows`, `partial_updates`, `adjacent_ranges`, `collection_ops`.

Plus `cass.delta_scan.wide_partition_corpus` as **`planned`** — no test_deltas fixture is fabricated; it maps to the wide-row corpus (epic #993). Byte-for-byte Data.db backing for every delta_scan scenario is linked as a follow-up under epic #969; CI dataset publication is tracked by #701.

## Acceptance criteria

- **AC1/AC2** — per-shape scenarios, classified individually, with per-shape Cassandra source files. ✅
- **AC3** — `docs/reports/cassandra-test-parity.md` regenerated; delta_scan grouped under canonical-semantic; planned scenario under gaps; per-scenario "needs byte-for-byte Data.db backing (#969)" note. ✅
- **AC4** — closed the silent-pass hole: per-table + master delta parity tests now **fail** when a *present* Data.db yields zero matched assertions (0-rows-when-present = failure). Full CI dataset enforcement still depends on **#701** (binaries not yet published) — recorded as a scenario `known_limitation`/`scope.gap`, not faked. ✅ (scoped)
- **AC5** — deterministic test asserts every delta_scan fixture table is produced by `generate-deltas.sh` / `deltas.cql` (no Docker). ✅
- **AC6** — strict lint rule: `mirrored` `delta_scan` scenarios require **both** a real CQLite test target (file must exist) **and** a fixture reference. ✅
- **AC7** — byte-for-byte follow-ups link back to the Data.db decode parity epic #969 in every scenario. ✅

## Validation

`scripts/agent-gate.sh` → **RESULT: PASS** (all components green). `cargo test -p cassandra-parity` → all green (lint 19, report 4, tier 8). `cassandra-parity lint` → `OK — 211 scenarios, 0 errors, 0 warnings`. `scan_delta_parity_test` (with main-repo datasets) → 14 passed.

Oracle-driven (no OpenSpec). 🤖 flow-lead worker.