### PR TITLE
test(#994): write/load/flush artifact parity manifest scenarios (honest evidence)

### DIFF
--- a/docs/reports/cassandra-test-parity.md
+++ b/docs/reports/cassandra-test-parity.md
@@ -10,20 +10,20 @@ Sources: [`docs/cassandra_test_index.md`](../../docs/cassandra_test_index.md) ·
 
 | Status | Scenarios |
 |---|---|
-| `mirrored` | 176 |
-| `partial` | 10 |
+| `mirrored` | 177 |
+| `partial` | 13 |
 | `planned` | 16 |
 | `out_of_scope` | 14 |
-| **total** | **216** |
+| **total** | **220** |
 
 ## Evidence counts
 
 | Evidence | Scenarios |
 |---|---|
 | `byte_for_byte` | 96 |
-| `canonical_semantic` | 76 |
+| `canonical_semantic` | 77 |
 | `smoke` | 7 |
-| `partial` | 21 |
+| `partial` | 24 |
 | `out_of_scope` | 16 |
 
 ## ⚠️ P0 scenarios with weak evidence
@@ -45,6 +45,9 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 - `cass.tombstone_ttl.range_tombstone_boundaries` — Range tombstone boundary and deletion-time parity (partial)
 - `cass.tombstone_ttl.repaired_unrepaired_purge_gate` — Repaired vs unrepaired purge gate parity (partial)
 - `cass.write_load_path.cassandra_sstable_writer_fixtures` — CQLite-written SSTables load into Cassandra via sstableloader (smoke)
+- `cass.write_load_path.cql_sstable_writer.finished_data_db_artifacts` — Finished CQLite-written Data.db / component artifacts (write path) (partial)
+- `cass.write_load_path.flush.partition_boundary_artifacts` — Flush produces partition-boundary artifacts (promoted index / BTI Partitions.db) (partial)
+- `cass.write_load_path.flush.tombstone_and_ttl_artifacts` — Flush produces tombstone + TTL Data.db / Statistics.db artifacts (partial)
 
 ## P0 scenarios
 
@@ -196,6 +199,10 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 | `cass.verify.inline_crc_validation` | corruption_verify | mirrored | canonical_semantic | `sstable_parity_corruption_verify` | p0_data_loss |
 | `cass.verify.no_silent_empty_result_on_corruption` | corruption_verify | mirrored | canonical_semantic | `sstable_parity_corruption_verify` | p0_data_loss |
 | `cass.write_load_path.cassandra_sstable_writer_fixtures` | write_load_path | mirrored | smoke | `sstable_writer_cassandra_fixture_parity` | p0_data_loss |
+| `cass.write_load_path.cql_sstable_writer.finished_data_db_artifacts` | write_load_path | partial | partial | `sstable_writer_cassandra_fixture_parity` | p0_data_loss |
+| `cass.write_load_path.flush.partition_boundary_artifacts` | write_load_path | partial | partial | `sstable_parity_bti_partitions_rows` | p1_correctness |
+| `cass.write_load_path.flush.tombstone_and_ttl_artifacts` | write_load_path | partial | partial | `sstable_writer_cassandra_fixture_parity` | p0_data_loss |
+| `cass.write_load_path.live_readback.semantic_only` | write_load_path | mirrored | canonical_semantic | `sstable_writer_cassandra_fixture_parity` | p0_data_loss |
 
 ## Byte-for-byte scenarios
 
@@ -477,6 +484,8 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
   - Normalization: During the verify scan each chunk's inline CRC32 trailer is checked; a clean fixture passes and a bit-flip case fails. Decoded rows compared to the JSONL golden.
 - `cass.verify.no_silent_empty_result_on_corruption` — Verifier never returns a silent empty result on corruption
   - Normalization: For every corruption-corpus case the verifier must surface an explicit error; returning an empty (zero-row) result on corrupted input is a contract violation. The clean fixture's full row scan defines the non-empty baseline.
+- `cass.write_load_path.live_readback.semantic_only` — Live Cassandra readback of CQLite-written SSTables (semantic-only)
+  - Normalization: CQLite-written artifacts are loaded into Cassandra 5.0.2 and read back; the sstabledump JSON of the loaded SSTable and the cqlsh SELECT rows (including TTL(col), static columns, clustering rows, and tombstone presence/absence) are compared for semantic equivalence to what CQLite wrote. This proves loaded rows, TTLs, tombstones, static rows and clustering rows are semantically visible — NOT a byte comparison of writer output.
 
 ## Smoke-only scenarios
 
@@ -516,6 +525,9 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 - `cass.summary_db.IndexSummaryRedistributionTest.downsampled_summary_entries` (planned): No downsampled (sampling_level < 128) Summary.db fixture exists. → _Publish a redistributed Summary.db fixture and extend the strict suite to assert downsampled offset tables and size_at_full_sampling > entry count._
 - `cass.tombstone_ttl.range_tombstone_boundaries` (partial): test_deltas dataset asset not published/enforced in CI (#701). → _Publish the test_deltas dataset and enforce scan_delta parity in CI._
 - `cass.tombstone_ttl.repaired_unrepaired_purge_gate` (partial): repairedAt / pendingRepair parsing is not implemented (gated on #968/#988), so the repaired-vs-unrepaired purge gate is only partially exercised. → _Parse repairedAt / pendingRepair from Statistics.db and gate purge on repair status (#968/#988)._
+- `cass.write_load_path.cql_sstable_writer.finished_data_db_artifacts` (partial): Writer byte invariants + component/TOC presence are asserted, but no committed Cassandra-written reference Data.db exists to diff finished CQLite output (whole-file bytes / row offsets / sstabledump JSONL) against for the same schema/data. Consistent with cass.write_load_path.cassandra_sstable_writer_fixtures. → _Commit a Cassandra-written reference SSTable for an identical writer schema/data and add a strict file-vs-file byte + offset + sstabledump JSONL diff test, then upgrade this scenario to byte_for_byte (epic #969)._
+- `cass.write_load_path.flush.partition_boundary_artifacts` (partial): Writer partition-boundary entries round-trip through CQLite's own reader and the Cassandra boundary layout is re-parsed byte-exactly, but no committed Cassandra-written reference exists to diff the finished CQLite-written Partitions.db / promoted Index.db byte-for-byte. → _Commit a Cassandra-written reference for an identical multi-block / multi-partition flush input and add a strict Partitions.db / Index.db byte diff, then upgrade to byte_for_byte (epic #969)._
+- `cass.write_load_path.flush.tombstone_and_ttl_artifacts` (partial): Flushed tombstone/TTL bytes are asserted against derived expected values, but no committed Cassandra-written reference for the same flush input exists to diff the finished artifact byte-for-byte. → _Commit a Cassandra-written tombstone+TTL reference SSTable for an identical flush input and add a strict Data.db + Statistics.db byte diff, then upgrade to byte_for_byte (epic #969)._
 
 ## Out-of-scope taxonomy
 
@@ -790,6 +802,10 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.verify.inline_crc_validation` | required_parity | .github/workflows/cassandra-parity.yml |
 | `cass.verify.no_silent_empty_result_on_corruption` | required_parity | .github/workflows/cassandra-parity.yml |
 | `cass.write_load_path.cassandra_sstable_writer_fixtures` | required_parity | .github/workflows/cassandra-validation.yml |
+| `cass.write_load_path.cql_sstable_writer.finished_data_db_artifacts` | exhaustive_regeneration | .github/workflows/cassandra-parity.yml |
+| `cass.write_load_path.flush.partition_boundary_artifacts` | exhaustive_regeneration | .github/workflows/cassandra-parity.yml |
+| `cass.write_load_path.flush.tombstone_and_ttl_artifacts` | exhaustive_regeneration | .github/workflows/cassandra-parity.yml |
+| `cass.write_load_path.live_readback.semantic_only` | nightly_docker | .github/workflows/cassandra-validation.yml |
 | `cass.zstd_dictionary.dictionary_assisted_decompression` | fast_pr | — |
 | `cass.zstd_dictionary.dictionary_cache_reuse` | fast_pr | — |
 | `cass.zstd_dictionary.dictionary_checksum` | fast_pr | — |
@@ -1011,6 +1027,10 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.verify.inline_crc_validation` | nb | test-data/datasets/sstables/test_comp/lz4_table-25801a0071a911f19b3225f9984c6a77/nb-1-big-Data.db.jsonl |
 | `cass.verify.no_silent_empty_result_on_corruption` | nb | test-data/datasets/corruption/test_comp_corrupt/corruption-manifest.yml<br>test-data/datasets/sstables/test_comp/lz4_table-25801a0071a911f19b3225f9984c6a77/nb-1-big-Data.db.jsonl |
 | `cass.write_load_path.cassandra_sstable_writer_fixtures` | nb | — |
+| `cass.write_load_path.cql_sstable_writer.finished_data_db_artifacts` | nb, da | — |
+| `cass.write_load_path.flush.partition_boundary_artifacts` | nb, da | — |
+| `cass.write_load_path.flush.tombstone_and_ttl_artifacts` | nb | — |
+| `cass.write_load_path.live_readback.semantic_only` | nb | — |
 | `cass.zstd_dictionary.dictionary_assisted_decompression` | — | — |
 | `cass.zstd_dictionary.dictionary_cache_reuse` | — | — |
 | `cass.zstd_dictionary.dictionary_checksum` | — | — |

--- a/test-data/cassandra-parity-manifest.yml
+++ b/test-data/cassandra-parity-manifest.yml
@@ -4457,6 +4457,255 @@ scenarios:
         Add fixture byte comparison once a committed Cassandra-written reference
         fixture exists for the same schema/data.
 
+  - id: cass.write_load_path.cql_sstable_writer.finished_data_db_artifacts
+    title: Finished CQLite-written Data.db / component artifacts (write path)
+    status: partial
+    capability: write_load_path
+    priority: P0
+    risk: p0_data_loss
+    cassandra:
+      category: sstable-format
+      relevance: high
+      files:
+        - CQLSSTableWriterTest.java
+        - BigTableWriterTest.java
+    cqlite:
+      coverage:
+        suite: sstable_writer_cassandra_fixture_parity
+        tests:
+          - cqlite-core/tests/issue_821_writer_byte_invariants.rs
+          - cqlite-core/tests/issue_908_bti_canonical_write.rs
+        notes: >-
+          issue_821 anchors the Data.db row framing (previousUnfilteredSize chain,
+          static-row prev_size=0, 64-bit offsets) byte-by-byte against the exact
+          values read out of real Cassandra "nb" SSTables (uncompressed_table,
+          static_columns_table). issue_908 asserts the finished BTI component set
+          and TOC.txt: a da SSTable emits Data.db + Partitions.db + Rows.db + a TOC
+          listing exactly the BTI component set (no Index/Summary) and self-
+          referencing TOC.txt. Together they cover component presence, TOC.txt, and
+          Data.db row-offset byte invariants of the writer output.
+    fixtures:
+      datasets:
+        - test-data/datasets/sstables
+    evidence:
+      type: partial
+      artifacts: [bytes, offsets, component_files]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb, da]
+      fixture_generation_command: >-
+        bash test-data/scripts/regenerate-datasets.sh  # cassandra:5.0.2 → flush → component files + TOC.txt
+      comparison_command: >-
+        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        --features write-support --test issue_821_writer_byte_invariants &&
+        cargo test -p cqlite-core --features write-support --test issue_908_bti_canonical_write
+      known_limitations: >-
+        Proves writer-output byte INVARIANTS (Data.db row framing / prev_size /
+        64-bit offsets anchored to real Cassandra nb bytes) plus BTI component
+        presence and TOC.txt content. It is NOT a whole-artifact file-vs-file
+        byte diff of finished CQLite Data.db against a committed Cassandra-written
+        reference for the same schema/data, and the sstabledump-JSONL parity of
+        CQLite-written output is covered separately by the live-readback scenario.
+    ci:
+      tier: exhaustive_regeneration
+      workflow: .github/workflows/cassandra-parity.yml
+    scope:
+      gap: >-
+        Writer byte invariants + component/TOC presence are asserted, but no
+        committed Cassandra-written reference Data.db exists to diff finished
+        CQLite output (whole-file bytes / row offsets / sstabledump JSONL) against
+        for the same schema/data. Consistent with
+        cass.write_load_path.cassandra_sstable_writer_fixtures.
+      next_step: >-
+        Commit a Cassandra-written reference SSTable for an identical writer
+        schema/data and add a strict file-vs-file byte + offset + sstabledump JSONL
+        diff test, then upgrade this scenario to byte_for_byte (epic #969).
+
+  - id: cass.write_load_path.flush.tombstone_and_ttl_artifacts
+    title: Flush produces tombstone + TTL Data.db / Statistics.db artifacts
+    status: partial
+    capability: write_load_path
+    priority: P0
+    risk: p0_data_loss
+    cassandra:
+      category: memtable-flush
+      relevance: high
+      files:
+        - CQLSSTableWriterTest.java
+        - SSTableMetadataTrackingTest.java
+    cqlite:
+      coverage:
+        suite: sstable_writer_cassandra_fixture_parity
+        tests:
+          - cqlite-core/tests/issue_764_explicit_local_deletion_time.rs
+          - cqlite-core/tests/issue_821_writer_byte_invariants.rs
+        notes: >-
+          issue_764 flushes a mutation carrying an explicit local_deletion_time and
+          a TTL through the real WriteEngine, then asserts the WRITTEN Data.db row
+          tombstone flags/local-deletion-time bytes AND the parsed Statistics.db
+          min/max localDeletionTime + minTTL aggregates (writer + reader cannot be
+          wrong in the same way). issue_821 anchors the deletion/TTL-bearing row
+          framing byte invariants. These are the finished tombstone/TTL artifacts a
+          flush emits, not Cassandra memtable accounting internals (AC7).
+    fixtures:
+      datasets:
+        - test-data/datasets/sstables
+    evidence:
+      type: partial
+      artifacts: [bytes, component_files]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb]
+      fixture_generation_command: >-
+        bash test-data/scripts/regenerate-datasets.sh  # cassandra:5.0.2 flush → Data.db + Statistics.db
+      comparison_command: >-
+        cargo test -p cqlite-core --features write-support
+        --test issue_764_explicit_local_deletion_time
+      known_limitations: >-
+        Proves the flushed Data.db row-tombstone bytes (deletion flags +
+        local_deletion_time) and the Statistics.db local-deletion-time / TTL
+        aggregate bytes are correct against derived expected values. It is NOT a
+        whole-artifact byte diff of the flushed tombstone/TTL SSTable against a
+        committed Cassandra-written reference; semantic visibility of tombstones
+        and TTLs is covered by the live-readback scenario.
+    ci:
+      tier: exhaustive_regeneration
+      workflow: .github/workflows/cassandra-parity.yml
+    scope:
+      gap: >-
+        Flushed tombstone/TTL bytes are asserted against derived expected values,
+        but no committed Cassandra-written reference for the same flush input
+        exists to diff the finished artifact byte-for-byte.
+      next_step: >-
+        Commit a Cassandra-written tombstone+TTL reference SSTable for an identical
+        flush input and add a strict Data.db + Statistics.db byte diff, then upgrade
+        to byte_for_byte (epic #969).
+
+  - id: cass.write_load_path.flush.partition_boundary_artifacts
+    title: Flush produces partition-boundary artifacts (promoted index / BTI Partitions.db)
+    status: partial
+    capability: write_load_path
+    priority: P0
+    risk: p1_correctness
+    cassandra:
+      category: memtable-flush
+      relevance: high
+      files:
+        - CQLSSTableWriterTest.java
+        - ColumnIndexTest.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_bti_partitions_rows
+        tests:
+          - cqlite-core/tests/issue_766_bti_partitions_writer.rs
+          - cqlite-core/tests/issue_1013_rt_index_block_parity.rs
+        notes: >-
+          issue_766 flushes via SSTableWriter in BTI mode and proves the written
+          Partitions.db trie round-trips through CQLite's own BTI reader: every
+          partition key (int/bigint/text/uuid/timestamp/blob + composite) resolves
+          to the exact Data.db offset that was written. issue_1013 re-parses a
+          committed Cassandra Index.db promoted index byte-exactly (>1 IndexInfo
+          block, promoted-index byte length consumed exactly) at column-index block
+          boundaries, establishing the partition-boundary layout the writer targets.
+    fixtures:
+      datasets:
+        - test-data/datasets/sstables
+    evidence:
+      type: partial
+      artifacts: [bytes, offsets, component_files]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb, da]
+      fixture_generation_command: >-
+        bash test-data/scripts/regenerate-datasets.sh  # cassandra:5.0.2 flush → Index.db / Partitions.db boundaries
+      comparison_command: >-
+        cargo test -p cqlite-core --features write-support
+        --test issue_766_bti_partitions_writer &&
+        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        --features "delta-scan write-support" --test issue_1013_rt_index_block_parity
+      known_limitations: >-
+        Proves the written BTI Partitions.db partition-offset entries round-trip
+        through CQLite's reader, and that the Cassandra promoted Index.db boundary
+        layout is decoded byte-exactly. It is NOT a whole-artifact byte diff of the
+        CQLite-written partition-boundary component against a committed Cassandra-
+        written reference for the same flush input.
+    ci:
+      tier: exhaustive_regeneration
+      workflow: .github/workflows/cassandra-parity.yml
+    scope:
+      gap: >-
+        Writer partition-boundary entries round-trip through CQLite's own reader
+        and the Cassandra boundary layout is re-parsed byte-exactly, but no
+        committed Cassandra-written reference exists to diff the finished
+        CQLite-written Partitions.db / promoted Index.db byte-for-byte.
+      next_step: >-
+        Commit a Cassandra-written reference for an identical multi-block /
+        multi-partition flush input and add a strict Partitions.db / Index.db byte
+        diff, then upgrade to byte_for_byte (epic #969).
+
+  - id: cass.write_load_path.live_readback.semantic_only
+    title: Live Cassandra readback of CQLite-written SSTables (semantic-only)
+    status: mirrored
+    capability: write_load_path
+    priority: P0
+    risk: p0_data_loss
+    cassandra:
+      category: sstable-format
+      relevance: high
+      files:
+        - CQLSSTableWriterTest.java
+        - SSTableLoaderTest.java
+    cqlite:
+      coverage:
+        suite: sstable_writer_cassandra_fixture_parity
+        tests:
+          - cqlite-core/tests/sstableloader_integration.rs
+        notes: >-
+          CQLite writes/flushes/exports SSTables, loads them into a real Cassandra
+          5.0.2 cluster (sstableloader / nodetool refresh), then verifies via
+          sstabledump on the loaded artifact AND cqlsh SELECT that the written rows
+          are visible. Coverage spans simple/clustering/multi-partition tables, all
+          stage-0 types, static rows + static-only partitions (issue_507), TTL
+          rows (TTL(col) within range), and large/wide partitions. The
+          e2e-cassandra-readback.sh harness additionally drives cell-delete,
+          row-delete, range-tombstone and partition-tombstone labels with structured
+          per-row / absence assertions.
+    fixtures:
+      datasets:
+        - test-data/datasets/sstables
+    evidence:
+      type: canonical_semantic
+      strict: false
+      artifacts: [jsonl, logs]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb]
+      fixture_generation_command: >-
+        bash test-data/scripts/e2e-cassandra-readback.sh  # cqlite write → sstableloader/refresh → sstabledump + cqlsh SELECT
+      comparison_command: >-
+        cargo test -p cqlite-core --features write-support --test sstableloader_integration
+      normalization: >-
+        CQLite-written artifacts are loaded into Cassandra 5.0.2 and read back; the
+        sstabledump JSON of the loaded SSTable and the cqlsh SELECT rows
+        (including TTL(col), static columns, clustering rows, and tombstone
+        presence/absence) are compared for semantic equivalence to what CQLite
+        wrote. This proves loaded rows, TTLs, tombstones, static rows and clustering
+        rows are semantically visible — NOT a byte comparison of writer output.
+      known_limitations: >-
+        Canonical-semantic round-trip via a live Cassandra cluster. This is NEVER
+        byte_for_byte: a live readback proves semantic visibility, not that the
+        CQLite-written bytes match a Cassandra-written reference. Byte-for-byte
+        writer parity remains tracked under epic #969.
+    ci:
+      tier: nightly_docker
+      workflow: .github/workflows/cassandra-validation.yml
+    scope:
+      gap: >-
+        Semantic readback only; no byte comparison of CQLite writer output.
+      next_step: >-
+        Pair the readback with a committed Cassandra-written byte reference once it
+        exists (epic #969) so semantic visibility is backed by byte parity.
+
   # ----------------------------------------------------------------------------
   # bti_big_version_matrix
   # ----------------------------------------------------------------------------


### PR DESCRIPTION
Closes #994.

## What
Defines the Data.db-relevant write/load/flush parity lane in the Cassandra parity manifest (capability `write_load_path`, epic #969), with **honest evidence classification** — finished-artifact byte comparison only where a real Cassandra byte reference exists, live readback as canonical-semantic only.

## Scenarios added (4)
| id | evidence | backed by |
|----|----------|-----------|
| `cass.write_load_path.cql_sstable_writer.finished_data_db_artifacts` | **partial** | `issue_821_writer_byte_invariants` (Data.db row-framing byte invariants anchored to real Cassandra nb bytes) + `issue_908_bti_canonical_write` (component/TOC.txt presence) |
| `cass.write_load_path.flush.tombstone_and_ttl_artifacts` | **partial** | `issue_764_explicit_local_deletion_time` (flush → written row-tombstone/LDT bytes + Statistics.db TTL/LDT) + `issue_821` framing |
| `cass.write_load_path.flush.partition_boundary_artifacts` | **partial** | `issue_766_bti_partitions_writer` (Partitions.db offsets round-trip) + `issue_1013_rt_index_block_parity` (byte-exact promoted Index.db re-parse) |
| `cass.write_load_path.live_readback.semantic_only` | **canonical_semantic** | `sstableloader_integration` + `e2e-cassandra-readback.sh` (write → load into live Cassandra 5.0.2 → SELECT) |

## Evidence honesty (the crux)
No committed **Cassandra-*written*** reference SSTable exists to diff finished CQLite writer output against, so the 3 finished/flush scenarios are `partial` (writer byte-*invariants* + read-path byte parity), NOT `byte_for_byte` — each records a `scope.gap` + `next_step` → epic #969, consistent with the existing `cassandra_sstable_writer_fixtures` gap. Live readback is `canonical_semantic`, never `byte_for_byte` (AC4). Memtable internals / flush-observer callbacks kept out of scope (AC7).

## Validation
`scripts/agent-gate.sh` green except the known wall-clock flush/write-throughput flake (this change is YAML+MD only — doesn't compile into cqlite-core; both throughput tests pass in isolation). `cargo test -p cassandra-parity` all green; `cassandra-parity lint` → `OK — 220 scenarios, 0 errors, 0 warnings`; `report --check` up to date.

## Follow-up (NEEDS-OWNER, not a blocker)
Whether to commission a committed Cassandra-written reference fixture so the 3 `partial` scenarios can upgrade to `byte_for_byte` — tracked under epic #969.

Oracle-driven (no OpenSpec). 🤖 flow-lead worker.