### PR TITLE
test(#1188): de-flake test_flush_throughput — behavioral check, env-gated timing

### DIFF
--- a/cqlite-core/tests/write_integration.rs
+++ b/cqlite-core/tests/write_integration.rs
@@ -1497,12 +1497,36 @@ async fn test_flush_throughput() -> Result<()> {
         mb_per_sec, info.data_size, elapsed
     );
 
-    // Target: 5 MB/sec (conservative for CI, accounts for index/statistics overhead)
-    assert!(
-        mb_per_sec >= 5.0,
-        "Flush throughput {:.1} MB/sec below target of 5 MB/sec",
-        mb_per_sec
+    // Behavioral correctness (issue #1188, mirrors #1149 -> PR #1168): replace the
+    // load-flaky `mb_per_sec >= 5.0` wall-clock assert with a deterministic check
+    // that the flush produced a valid SSTable holding all 1000 rows.
+    assert_eq!(
+        info.partition_count, 1_000,
+        "flush should persist all 1000 partitions, got {}",
+        info.partition_count
     );
+    assert!(
+        info.data_size > 0,
+        "flush should write a non-empty Data.db, got {} bytes",
+        info.data_size
+    );
+    assert!(
+        info.data_path.exists(),
+        "flushed Data.db should exist on disk at {:?}",
+        info.data_path
+    );
+
+    // Optional throughput floor — opt-in only via RUN_PERF_TESTS=1, so it never
+    // runs in `scripts/agent-gate.sh` core-tests and cannot false-RED the gate
+    // under load. Run `RUN_PERF_TESTS=1 cargo test ... test_flush_throughput` to
+    // exercise it on an idle host.
+    if std::env::var("RUN_PERF_TESTS").as_deref() == Ok("1") {
+        assert!(
+            mb_per_sec >= 5.0,
+            "Flush throughput {:.1} MB/sec below target of 5 MB/sec",
+            mb_per_sec
+        );
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Closes #1188. Test-quality / flaky fix — oracle-driven, skip OpenSpec. Mirrors #1149 → PR #1168.

## Problem
`test_flush_throughput` asserted an absolute `mb_per_sec >= 5.0` wall-clock floor. `write-support` is a **default** feature, so the gate's `core-tests` lane runs it — and it flaked under concurrent load (observed **4.1 MB/sec** under gate+roborev load vs **34–42 MB/sec** idle), false-RED'ing the gate and forcing isolated re-runs.

## Fix
Replace the wall-clock assert with a **deterministic behavioral** check on the flush result:
- `info.partition_count == 1000` (all rows persisted)
- `info.data_size > 0` (non-empty Data.db)
- `info.data_path.exists()` (SSTable on disk)

The throughput floor is **retained but opt-in** behind `RUN_PERF_TESTS=1`, so it never runs in `scripts/agent-gate.sh` and can't false-RED the gate. Diagnostic `println!` of the measured rate is kept.

## Acceptance criteria
- [x] No absolute wall-clock MB/sec assert in the default (gate) run.
- [x] Flush correctness asserted behaviorally (partitions / bytes / on-disk).
- [x] Timing assertion opt-in (`RUN_PERF_TESTS=1`), excluded from the gate.
- [x] core-tests no longer flakes on this test under load.

## Diff scope
One test file (`cqlite-core/tests/write_integration.rs`) — **zero production code**.

## Validation
- `test_flush_throughput` runs deterministically: default → PASS (38.8 MB/sec diagnostic); `RUN_PERF_TESTS=1` → PASS (gated floor exercised).
- CI is the authoritative gate here. Two local-gate caveats, **both unrelated to this one-test-file change** and surfaced separately:
  - `core-tests` also fails on **#991's** `fixture_static_*` tests, which fail-closed on a **missing `test_tomb` Data.db binary not in the pinned dataset bundle** (verified: 0 Data.db under `test_tomb`; the tests live in a file this PR doesn't touch). Pre-existing dataset-bundle gap from #991's merge.
  - `smoke`/`file-size` are local-only artifacts (CARGO_TARGET_DIR override for the shared build dir; the campsite ratchet has no CI enforcement — `write_integration.rs` was already 1508>1500 on main; growth acknowledged, a split belongs to #1135).

## ⚠️ NEEDS YOU (separate from this PR)
#991's fail-closed fixture tests require `test_tomb/*` Data.db binaries that aren't in the published dataset bundle (v3.2), so `core-tests` fails for any local run on current main. The bundle needs those binaries (or #991's fixtures regenerated/published).