### PR TITLE
test(#1188): quarantine flaky test_flush_throughput wall-clock assert out of the gate

### DIFF
--- a/cqlite-core/tests/write_integration.rs
+++ b/cqlite-core/tests/write_integration.rs
@@ -1461,6 +1461,7 @@ async fn test_write_throughput() -> Result<()> {
 }
 
 #[tokio::test]
+#[ignore = "perf-only: wall-clock flush throughput; load-sensitive, excluded from the correctness gate (run via `cargo test -- --ignored`). See #1188"]
 async fn test_flush_throughput() -> Result<()> {
     let temp_dir = TempDir::new().unwrap();
     let schema = create_simple_schema("perf_ks", "flush_test");


### PR DESCRIPTION
Closes #1188.

## Problem
`cqlite-core/tests/write_integration.rs::test_flush_throughput` asserts an **absolute wall-clock** throughput (`mb_per_sec >= 5.0`). This is load-dependent and false-REDs `scripts/agent-gate.sh` `core-tests` under concurrent load (observed 4.1 MB/sec under load vs 34–42 MB/sec idle).

## Angle (distinct from the rejected PR #1194)
The owner rejected PR #1194's approach: it **rewrote** the assertion into trivial behavioral asserts (`partition_count`, `data_size`, `data_path.exists()`) and added an inline `RUN_PERF_TESTS` env-gate. This PR does **neither**.

Instead it **quarantines the timing check out of the gate path while preserving the assertion verbatim**:

```rust
#[tokio::test]
#[ignore = "perf-only: wall-clock flush throughput; load-sensitive, excluded from the correctness gate (run via `cargo test -- --ignored`). See #1188"]
async fn test_flush_throughput() -> Result<()> {
```

- Diff is `+1 -0`. The `mb_per_sec >= 5.0` assertion + its panic message are byte-for-byte untouched.
- The gate never passes `--ignored`/`--include-ignored` (verified by grep), so `core-tests` now skips this test (`0 passed, 1 ignored`) and can no longer false-RED under load.
- The throughput assertion remains a real, runnable test: `cargo test -- --ignored` → `1 passed` on an idle host (8.31s).
- Flush correctness is still covered behaviorally by ~12 other tests in the same file (all call `engine.flush()`), so no coverage is lost.

## Acceptance criteria
- [x] `test_flush_throughput` no longer asserts wall-clock MB/sec in the default (gate) run — it's ignored.
- [x] Flush correctness still asserted behaviorally (existing roundtrip tests).
- [x] Retained timing assertion is opt-in (`--ignored`) and excluded from `agent-gate.sh` `core-tests`.
- [x] `agent-gate.sh` `core-tests` passes reliably.

## Gate
`scripts/agent-gate.sh` → **RESULT: PASS** (all correctness components green; `core-tests` PASS in 202s).

Note: `file-size` initially FAILed because the +1 line tripped the campsite growth ratchet — `write_integration.rs` is already over the 1500-line test-file threshold (epic #1135 territory). Splitting it is out of scope for a one-line de-flake, so the PASS run used the documented `CQLITE_ALLOW_FILE_GROWTH=1` ack.

🤖 Oracle/test-quality fix — skips OpenSpec.