### PR TITLE
feat(#1023): manifest-driven public claim lint

### DIFF
--- a/.github/workflows/cassandra-parity.yml
+++ b/.github/workflows/cassandra-parity.yml
@@ -15,8 +15,15 @@ on:
       - 'tools/cassandra-parity/**'
       - 'docs/reports/cassandra-test-parity*.md'
       - 'docs/cassandra_test_index.md'
-      - 'docs/development/parity-ci-tiers.md'
       - '.github/workflows/cassandra-parity.yml'
+      # Release-facing docs the public-claim scanner (`lint`) reads — must stay in
+      # sync with `claim_scan::RELEASE_FILES` so an over-claim added to one of
+      # these still triggers the lint job. (issue #1023)
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - 'docs/development/parity-ci-tiers.md'
+      - 'docs/development/parity-release-checklist.md'
+      - 'docs/development/cassandra-parity-manifest.md'
   pull_request:
     branches: [ main ]
     paths:
@@ -25,8 +32,15 @@ on:
       - 'tools/cassandra-parity/**'
       - 'docs/reports/cassandra-test-parity*.md'
       - 'docs/cassandra_test_index.md'
-      - 'docs/development/parity-ci-tiers.md'
       - '.github/workflows/cassandra-parity.yml'
+      # Release-facing docs the public-claim scanner (`lint`) reads — must stay in
+      # sync with `claim_scan::RELEASE_FILES` so an over-claim added to one of
+      # these still triggers the lint job. (issue #1023)
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - 'docs/development/parity-ci-tiers.md'
+      - 'docs/development/parity-release-checklist.md'
+      - 'docs/development/cassandra-parity-manifest.md'
 
 env:
   CARGO_TERM_COLOR: always

--- a/docs/reports/cassandra-test-parity.md
+++ b/docs/reports/cassandra-test-parity.md
@@ -1086,9 +1086,31 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.zstd_dictionary.dictionary_serialization` | — | — |
 | `cass.zstd_dictionary.invalid_dictionary_rejected` | — | — |
 
-## Claim language
+## Release-safe claim language
 
-**Safe:** CQLite reads and writes Cassandra 5.0 SSTables and is validated for canonical-semantic equivalence against `sstabledump` for the covered dataset, with byte-for-byte parity proven only where this report records `byte_for_byte` evidence.
+Public/release-facing parity claims are enforced by the claim-scan lint. Safe wordings below are manifest-backed; the blocked phrases are unqualified over-claims rejected unless explicitly scoped as a counter-example.
 
-**Unsafe:** "CQLite passes the same tests as Cassandra" or "CQLite is byte-for-byte identical to Cassandra" — these overclaim node behavior and byte parity the manifest does not support.
+### Safe wordings
+
+- **claim.safe.rust_byte_level_coverage** — byte-for-byte parity is proven only where this manifest records byte_for_byte evidence
+  - Why safe: Byte-level equivalence is asserted only for scenarios carrying explicit byte_for_byte evidence (bytes/offsets/checksums/component files with a strict comparison). The wording forbids generalizing byte parity beyond those scenarios.
+  - Backed by: `cass.compaction_merge.byte_for_byte_output`, `cass.compaction.harness_byte_tier_artifacts`
+- **claim.safe.selected_fixture_validation** — validated against selected Apache Cassandra 5.0 SSTable fixtures
+  - Why safe: CQLite is validated against the specific Cassandra-generated fixtures and datasets recorded in this manifest, not against every possible SSTable. The wording scopes the claim to the covered corpus rather than implying exhaustive coverage.
+  - Backed by: `cass.sstable_format.toc_component_manifest`, `cass.data_db_decode.row_cell_flags_and_vint`, `cass.compression_info.lz4.real_fixture_chunks`
+- **claim.safe.traceable_cassandra_parity_suite** — a traceable parity suite mapping CQLite tests to specific Cassandra scenarios
+  - Why safe: The parity manifest maps each CQLite test/fixture to the Cassandra scenario it mirrors, so claims are traceable to named evidence. This is distinct from running Cassandra's own JVM test suite.
+  - Backed by: `cass.compaction.CompactionIteratorTest.differential_compaction_loop`, `cass.data_db_decode.serialization_mirror.multi_clustering_column_order`
+
+### Blocked phrases (rejected unless explicitly scoped)
+
+- **claim.blocked.full_compaction_byte_parity** — "full compaction byte parity"
+  - Why blocked: Byte-for-byte compaction parity is proven only for the scenarios that carry byte_for_byte evidence, not for all compaction inputs/strategies. "Full" generalizes byte parity beyond the manifest's evidence.
+  - Use instead: `claim.safe.rust_byte_level_coverage`
+- **claim.blocked.same_tests_as_cassandra** — "same tests as Cassandra"
+  - Why blocked: CQLite does not run Apache Cassandra's JVM test suite; it runs its own Rust parity suite against recorded fixtures. Claiming the "same tests" overstates coverage and implies node-behavior parity CQLite never asserts.
+  - Use instead: `claim.safe.traceable_cassandra_parity_suite`
+- **claim.blocked.zero_diff_sstabledump_all_datasets** — "zero-diff sstabledump across every dataset"
+  - Why blocked: sstabledump parity is validated for the selected fixtures in this manifest, not for every conceivable dataset. "Across every dataset" claims exhaustive coverage the evidence does not support.
+  - Use instead: `claim.safe.selected_fixture_validation`
 

--- a/test-data/cassandra-parity-manifest.schema.json
+++ b/test-data/cassandra-parity-manifest.schema.json
@@ -33,9 +33,41 @@
       "type": "array",
       "minItems": 1,
       "items": { "$ref": "#/$defs/scenario" }
+    },
+    "claims": {
+      "type": "array",
+      "description": "Public/release-facing parity claims (issue #1023). `claim.safe.*` entries record manifest-backed wording; `claim.blocked.*` entries record unqualified over-claims the claim-scan lint rejects in release docs unless explicitly scoped.",
+      "items": { "$ref": "#/$defs/claim" }
     }
   },
   "$defs": {
+    "claim": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "kind", "phrase", "rationale"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^claim\\.(safe|blocked)\\.[a-z0-9_]+$",
+          "description": "claim.safe.<slug> or claim.blocked.<slug>."
+        },
+        "kind": { "enum": ["safe", "blocked"] },
+        "phrase": { "type": "string", "minLength": 1 },
+        "rationale": { "type": "string", "minLength": 1 },
+        "evidence_scenarios": { "type": "array", "items": { "type": "string" } },
+        "safe_alternative": { "type": "string" }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "kind": { "const": "safe" } } },
+          "then": { "required": ["evidence_scenarios"], "properties": { "evidence_scenarios": { "minItems": 1 } } }
+        },
+        {
+          "if": { "properties": { "kind": { "const": "blocked" } } },
+          "then": { "required": ["safe_alternative"] }
+        }
+      ]
+    },
     "scenario": {
       "type": "object",
       "additionalProperties": false,

--- a/test-data/cassandra-parity-manifest.yml
+++ b/test-data/cassandra-parity-manifest.yml
@@ -11063,3 +11063,79 @@ scenarios:
       related_in_scope_scenarios:
         - cass.compression.fixture_matrix.zstd_no_dictionary
         - cass.compression.registry.known_zstd
+
+# ==============================================================================
+# Public/release-facing parity claims (issue #1023).
+#
+# `claim.safe.*`  — the manifest-backed wording the project is allowed to publish,
+#                   each cited to the scenarios that supply its evidence.
+# `claim.blocked.*` — unqualified absolute over-claims the claim-scan lint rejects
+#                   in release-facing docs unless the line explicitly scopes them
+#                   as a counter-example. Each names the safe wording to use.
+# ==============================================================================
+claims:
+  - id: claim.safe.selected_fixture_validation
+    kind: safe
+    phrase: >-
+      validated against selected Apache Cassandra 5.0 SSTable fixtures
+    rationale: >-
+      CQLite is validated against the specific Cassandra-generated fixtures and
+      datasets recorded in this manifest, not against every possible SSTable. The
+      wording scopes the claim to the covered corpus rather than implying
+      exhaustive coverage.
+    evidence_scenarios:
+      - cass.sstable_format.toc_component_manifest
+      - cass.data_db_decode.row_cell_flags_and_vint
+      - cass.compression_info.lz4.real_fixture_chunks
+
+  - id: claim.safe.rust_byte_level_coverage
+    kind: safe
+    phrase: >-
+      byte-for-byte parity is proven only where this manifest records byte_for_byte evidence
+    rationale: >-
+      Byte-level equivalence is asserted only for scenarios carrying explicit
+      byte_for_byte evidence (bytes/offsets/checksums/component files with a
+      strict comparison). The wording forbids generalizing byte parity beyond
+      those scenarios.
+    evidence_scenarios:
+      - cass.compaction_merge.byte_for_byte_output
+      - cass.compaction.harness_byte_tier_artifacts
+
+  - id: claim.safe.traceable_cassandra_parity_suite
+    kind: safe
+    phrase: >-
+      a traceable parity suite mapping CQLite tests to specific Cassandra scenarios
+    rationale: >-
+      The parity manifest maps each CQLite test/fixture to the Cassandra
+      scenario it mirrors, so claims are traceable to named evidence. This is
+      distinct from running Cassandra's own JVM test suite.
+    evidence_scenarios:
+      - cass.compaction.CompactionIteratorTest.differential_compaction_loop
+      - cass.data_db_decode.serialization_mirror.multi_clustering_column_order
+
+  - id: claim.blocked.same_tests_as_cassandra
+    kind: blocked
+    phrase: same tests as Cassandra
+    rationale: >-
+      CQLite does not run Apache Cassandra's JVM test suite; it runs its own
+      Rust parity suite against recorded fixtures. Claiming the "same tests"
+      overstates coverage and implies node-behavior parity CQLite never asserts.
+    safe_alternative: claim.safe.traceable_cassandra_parity_suite
+
+  - id: claim.blocked.full_compaction_byte_parity
+    kind: blocked
+    phrase: full compaction byte parity
+    rationale: >-
+      Byte-for-byte compaction parity is proven only for the scenarios that
+      carry byte_for_byte evidence, not for all compaction inputs/strategies.
+      "Full" generalizes byte parity beyond the manifest's evidence.
+    safe_alternative: claim.safe.rust_byte_level_coverage
+
+  - id: claim.blocked.zero_diff_sstabledump_all_datasets
+    kind: blocked
+    phrase: zero-diff sstabledump across every dataset
+    rationale: >-
+      sstabledump parity is validated for the selected fixtures in this manifest,
+      not for every conceivable dataset. "Across every dataset" claims exhaustive
+      coverage the evidence does not support.
+    safe_alternative: claim.safe.selected_fixture_validation

--- a/tools/cassandra-parity/src/claim_scan.rs
+++ b/tools/cassandra-parity/src/claim_scan.rs
@@ -284,12 +284,26 @@ fn occurrence_is_scoped(norm: &str, occ_start: usize) -> bool {
 /// expressed as repo-relative paths. These are the public/marketing-adjacent
 /// surfaces where an over-claim would actually ship; the giant generated indices
 /// under `docs/` are intentionally excluded.
+///
+/// RELEASE_FILES ↔ CI path-filter sync (issue #1023): the `cassandra-parity`
+/// GitHub workflow (`.github/workflows/cassandra-parity.yml`) runs `lint` for
+/// changes to these same files, plus the glob `docs/reports/cassandra-test-parity*.md`.
+/// That glob matches BOTH the generated `docs/reports/cassandra-test-parity.md`
+/// (regenerated, claim-language-free by construction) AND the hand-written
+/// `docs/reports/cassandra-test-parity-assessment.md`, which is release-facing and
+/// contains parity claim language. The invariant: every release-facing file the CI
+/// lint job triggers on is actually scanned here, and vice-versa — so the assessment
+/// report below is in the scanned set, closing the guardrail hole where an over-claim
+/// in it would trigger CI but escape the lint. The generated report is *not* listed:
+/// it is produced from the manifest by `report` and re-checked by `report --check`,
+/// so it cannot accrue an unreviewed over-claim.
 pub const RELEASE_FILES: &[&str] = &[
     "README.md",
     "CHANGELOG.md",
     "docs/development/parity-ci-tiers.md",
     "docs/development/parity-release-checklist.md",
     "docs/development/cassandra-parity-manifest.md",
+    "docs/reports/cassandra-test-parity-assessment.md",
 ];
 
 #[cfg(test)]

--- a/tools/cassandra-parity/src/claim_scan.rs
+++ b/tools/cassandra-parity/src/claim_scan.rs
@@ -11,10 +11,13 @@
 //! supply the literal over-claim phrases to scan for, and `claim.safe.*` entries
 //! supply the manifest-backed wording that is allowed to appear verbatim.
 //!
-//! A blocked phrase occurrence is allowed only when its line is **explicitly
-//! scoped** — i.e. it is framed as a counter-example ("unsafe", "do not claim",
-//! "reject", quoted as a negative) or it is the manifest-anchored safe wording.
-//! A bare assertion of a blocked phrase fails lint.
+//! A blocked phrase occurrence is allowed only when that **specific occurrence**
+//! is **explicitly scoped** — i.e. a scope marker ("unsafe", "do not claim",
+//! "reject", quoted as a negative) appears within a bounded window immediately
+//! preceding the phrase (so `do not claim <phrase>` / `unsafe: "<phrase>"` count,
+//! but an unrelated `reject` elsewhere on the line does not) — or it is the
+//! manifest-anchored safe wording. A bare assertion of a blocked phrase fails
+//! lint.
 
 use crate::lint::{Finding, Level};
 use crate::model::Manifest;
@@ -25,8 +28,9 @@ pub struct ScanInput<'a> {
     pub text: &'a str,
 }
 
-/// Lowercased markers that, when present on the same line as a blocked phrase,
-/// indicate the phrase is being explicitly scoped/negated rather than asserted.
+/// Lowercased markers that, when present in the bounded window immediately
+/// preceding a blocked phrase (see [`SCOPE_WINDOW_BYTES`]), indicate the phrase is
+/// being explicitly scoped/negated rather than asserted.
 const SCOPE_MARKERS: &[&str] = &[
     "unsafe",
     "do not",
@@ -47,6 +51,16 @@ const SCOPE_MARKERS: &[&str] = &[
     "counter-example",
     "anti-pattern",
 ];
+
+/// How many normalized bytes immediately before a blocked-phrase occurrence are
+/// searched for a [`SCOPE_MARKERS`] entry. A scope marker must *start* within this
+/// bounded prefix window for the occurrence to count as explicitly scoped, so an
+/// unrelated marker elsewhere on the same line does not exempt the over-claim.
+/// 32 bytes covers direct framings: `do not claim <phrase>` (marker ~17B back),
+/// `unsafe: "<phrase>"` (~9B), `reviewers must reject any "<phrase>"` (~12B) —
+/// while staying local enough that a marker in an unrelated earlier clause
+/// (e.g. `we reject stale fixtures and run the <phrase>`, ~34B back) does not.
+const SCOPE_WINDOW_BYTES: usize = 32;
 
 /// Normalize a string for phrase matching: lowercase and collapse runs of
 /// whitespace. Used to canonicalize a manifest phrase before matching it against
@@ -160,8 +174,9 @@ fn covered_by(inner: Span, outer: &[Span]) -> bool {
 ///   * that specific occurrence's span falls inside a `claim.safe.*` phrase span
 ///     (span-based exemption — a safe phrase elsewhere on the line does not
 ///     exempt a separate over-claim), or
-///   * the source line the occurrence starts on is explicitly scoped (see
-///     [`SCOPE_MARKERS`]; scope markers remain line-level).
+///   * a [`SCOPE_MARKERS`] entry appears within [`SCOPE_WINDOW_BYTES`] of
+///     normalized text immediately preceding the occurrence (occurrence-bounded
+///     exemption — an unrelated marker elsewhere on the line does not exempt it).
 ///
 /// Findings name the file, line, claim id, and the safe alternative to use.
 pub fn scan_docs(m: &Manifest, files: &[ScanInput<'_>]) -> Vec<Finding> {
@@ -188,20 +203,16 @@ pub fn scan_docs(m: &Manifest, files: &[ScanInput<'_>]) -> Vec<Finding> {
             .iter()
             .flat_map(|p| find_spans(&nf.text, p))
             .collect();
-        // Source lines explicitly framing a counter-example/negation. Scope
-        // markers stay line-level, keyed by the 1-based source line they sit on.
-        let scoped_lines = scoped_source_lines(f.text);
-
         for c in &blocked {
             let phrase = normalize(&c.phrase);
             for occ in find_spans(&nf.text, &phrase) {
                 if covered_by(occ, &safe_spans) {
                     continue;
                 }
-                let lineno = nf.line_at(occ.start);
-                if scoped_lines.contains(&lineno) {
+                if occurrence_is_scoped(&nf.text, occ.start) {
                     continue;
                 }
+                let lineno = nf.line_at(occ.start);
                 let alt = c
                     .safe_alternative
                     .as_deref()
@@ -223,18 +234,20 @@ pub fn scan_docs(m: &Manifest, files: &[ScanInput<'_>]) -> Vec<Finding> {
     out
 }
 
-/// 1-based source line numbers that contain an explicit scope/negation marker.
-fn scoped_source_lines(raw: &str) -> std::collections::HashSet<usize> {
-    raw.lines()
-        .enumerate()
-        .filter_map(|(i, line)| {
-            let lower = line.to_lowercase();
-            SCOPE_MARKERS
-                .iter()
-                .any(|mk| lower.contains(mk))
-                .then_some(i + 1)
-        })
-        .collect()
+/// True if a [`SCOPE_MARKERS`] entry appears within the bounded prefix window
+/// ([`SCOPE_WINDOW_BYTES`]) immediately preceding the blocked-phrase occurrence
+/// that starts at `occ_start` in the normalized (lowercased, whitespace-collapsed)
+/// `norm` text. Tying scope detection to the occurrence — not the whole line —
+/// means an unrelated marker elsewhere on the line does not exempt the over-claim.
+fn occurrence_is_scoped(norm: &str, occ_start: usize) -> bool {
+    let window_start = occ_start.saturating_sub(SCOPE_WINDOW_BYTES);
+    // `norm` is already lowercased; snap the window start onto a char boundary so
+    // slicing never splits a multi-byte char.
+    let window_start = (window_start..=occ_start)
+        .find(|&i| norm.is_char_boundary(i))
+        .unwrap_or(occ_start);
+    let prefix = &norm[window_start..occ_start];
+    SCOPE_MARKERS.iter().any(|mk| prefix.contains(mk))
 }
 
 /// The curated, conservative set of release-facing files the claim scan reads,

--- a/tools/cassandra-parity/src/claim_scan.rs
+++ b/tools/cassandra-parity/src/claim_scan.rs
@@ -62,21 +62,38 @@ const SCOPE_MARKERS: &[&str] = &[
 /// (e.g. `we reject stale fixtures and run the <phrase>`, ~34B back) does not.
 const SCOPE_WINDOW_BYTES: usize = 32;
 
-/// Normalize a string for phrase matching: lowercase and collapse runs of
-/// whitespace. Used to canonicalize a manifest phrase before matching it against
-/// the normalized whole-file view (see [`NormalizedFile`]).
+/// Inline Markdown formatting markers (`*` emphasis/strong, `_` emphasis,
+/// `` ` `` code span) that are stripped from the matching view so a phrase
+/// wrapped in emphasis/code (`same **tests** as Cassandra`) normalizes to the
+/// same token stream as the plain phrase. Only these inline markers are removed
+/// — no attempt is made to parse Markdown structure.
+const MD_MARKERS: &[char] = &['*', '_', '`'];
+
+/// Normalize a string for phrase matching: lowercase, drop inline Markdown
+/// emphasis/code markers ([`MD_MARKERS`]), and collapse runs of whitespace. Used
+/// to canonicalize a manifest phrase before matching it against the normalized
+/// whole-file view (see [`NormalizedFile`]). Stripping the markers means a
+/// formatted occurrence in a doc matches the plain manifest phrase.
 fn normalize(s: &str) -> String {
     s.to_lowercase()
         .split_whitespace()
+        .map(|tok| {
+            tok.chars()
+                .filter(|c| !MD_MARKERS.contains(c))
+                .collect::<String>()
+        })
+        .filter(|tok| !tok.is_empty())
         .collect::<Vec<_>>()
         .join(" ")
 }
 
 /// A whole-file view normalized to lowercase with all whitespace runs (including
-/// newlines) collapsed to single spaces, so a phrase split across a soft-wrap
-/// still matches. `offsets[i]` maps byte index `i` of `text` back to the 1-based
-/// source line number it originated from, so a match reports the line where the
-/// phrase starts.
+/// newlines) collapsed to single spaces and inline Markdown emphasis/code markers
+/// ([`MD_MARKERS`]) dropped, so a phrase split across a soft-wrap *and* a phrase
+/// wrapped in `**bold**`/`_em_`/`` `code` `` both still match the plain manifest
+/// phrase. `offsets[i]` maps byte index `i` of `text` back to the 1-based source
+/// line number it originated from, so a match reports the line where the phrase
+/// starts.
 struct NormalizedFile {
     /// Lowercased, whitespace-collapsed text of the whole file.
     text: String,
@@ -89,7 +106,10 @@ impl NormalizedFile {
     /// Build the normalized view of `raw`, recording the source line each emitted
     /// byte came from. A run of whitespace collapses to one space attributed to
     /// the line where the run *started* (so a phrase wrapped across a soft-wrap
-    /// reports its starting line).
+    /// reports its starting line). Inline Markdown markers ([`MD_MARKERS`]) are
+    /// skipped entirely — zero-width, no emitted byte and no offset — without
+    /// disturbing the whitespace state, so `same **tests** as` normalizes to the
+    /// same token stream (and offsets) as `same tests as`.
     fn new(raw: &str) -> Self {
         let lower = raw.to_lowercase();
         let mut text = String::with_capacity(lower.len());
@@ -98,6 +118,12 @@ impl NormalizedFile {
         let mut in_ws = false;
         let mut ws_line = 1usize;
         for ch in lower.chars() {
+            if MD_MARKERS.contains(&ch) {
+                // Drop inline formatting markers from the matching view. They are
+                // not whitespace, so they neither emit a byte nor reset the
+                // whitespace state; the surrounding tokens stay adjacent.
+                continue;
+            }
             if ch.is_whitespace() {
                 if !in_ws {
                     in_ws = true;

--- a/tools/cassandra-parity/src/claim_scan.rs
+++ b/tools/cassandra-parity/src/claim_scan.rs
@@ -1,0 +1,132 @@
+//! Manifest-driven public-claim scanning (issue #1023).
+//!
+//! Acceptance criteria 4 & 5: every public parity claim in release-facing docs
+//! must reference manifest evidence or be rejected, and unqualified absolute
+//! phrases (e.g. "same tests as Cassandra", "full compaction byte parity",
+//! "zero-diff sstabledump across every dataset") fail lint unless explicitly
+//! scoped.
+//!
+//! The authoritative source of which phrases are public claims is the manifest
+//! `claims:` section (no hard-coded phrase list here): `claim.blocked.*` entries
+//! supply the literal over-claim phrases to scan for, and `claim.safe.*` entries
+//! supply the manifest-backed wording that is allowed to appear verbatim.
+//!
+//! A blocked phrase occurrence is allowed only when its line is **explicitly
+//! scoped** — i.e. it is framed as a counter-example ("unsafe", "do not claim",
+//! "reject", quoted as a negative) or it is the manifest-anchored safe wording.
+//! A bare assertion of a blocked phrase fails lint.
+
+use crate::lint::{Finding, Level};
+use crate::model::Manifest;
+
+/// One release-facing file to scan: a repo-relative display path and its text.
+pub struct ScanInput<'a> {
+    pub path: &'a str,
+    pub text: &'a str,
+}
+
+/// Lowercased markers that, when present on the same line as a blocked phrase,
+/// indicate the phrase is being explicitly scoped/negated rather than asserted.
+const SCOPE_MARKERS: &[&str] = &[
+    "unsafe",
+    "do not",
+    "don't",
+    "not claim",
+    "never claim",
+    "must not",
+    "reject",
+    "rejected",
+    "out of scope",
+    "out-of-scope",
+    "overclaim",
+    "over-claim",
+    "avoid",
+    "no unqualified",
+    "instead of",
+    "rather than",
+    "counter-example",
+    "anti-pattern",
+];
+
+/// Normalize a string for phrase matching: lowercase and collapse runs of
+/// whitespace (so a phrase split across a soft-wrap still matches).
+fn normalize(s: &str) -> String {
+    s.to_lowercase()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// True if the line frames the phrase as a scoped/negated counter-example.
+fn line_is_scoped(line_lower: &str) -> bool {
+    SCOPE_MARKERS.iter().any(|m| line_lower.contains(m))
+}
+
+/// Scan the given release-facing files for unqualified public-claim phrases.
+///
+/// For each `claim.blocked.*` entry, every release file is searched for the
+/// claim phrase. An occurrence is a lint error unless the line it appears on is
+/// explicitly scoped (see [`SCOPE_MARKERS`]) or is the verbatim wording of a
+/// `claim.safe.*` entry. Findings name the file, line, claim id, and the safe
+/// alternative to use instead.
+pub fn scan_docs(m: &Manifest, files: &[ScanInput<'_>]) -> Vec<Finding> {
+    let mut out = Vec::new();
+
+    let blocked: Vec<&crate::model::Claim> =
+        m.claims.iter().filter(|c| c.kind == "blocked").collect();
+    let safe_phrases: Vec<String> = m
+        .claims
+        .iter()
+        .filter(|c| c.kind == "safe")
+        .map(|c| normalize(&c.phrase))
+        .collect();
+
+    for f in files {
+        for (lineno, raw) in f.text.lines().enumerate() {
+            let line_norm = normalize(raw);
+            if line_norm.is_empty() {
+                continue;
+            }
+            // A line that is (or contains) a verbatim safe wording is allowed
+            // even if a blocked substring overlaps it.
+            let is_safe_wording = safe_phrases.iter().any(|p| line_norm.contains(p.as_str()));
+            for c in &blocked {
+                let phrase = normalize(&c.phrase);
+                if phrase.is_empty() || !line_norm.contains(&phrase) {
+                    continue;
+                }
+                if is_safe_wording || line_is_scoped(&line_norm) {
+                    continue;
+                }
+                let alt = c
+                    .safe_alternative
+                    .as_deref()
+                    .map(|a| format!(" Use the manifest-backed wording `{a}` instead."))
+                    .unwrap_or_default();
+                out.push(Finding {
+                    level: Level::Error,
+                    id: c.id.clone(),
+                    field: format!("{}:{}", f.path, lineno + 1),
+                    message: format!(
+                        "unqualified public parity claim \"{}\" — must be explicitly scoped or dropped.{alt}",
+                        c.phrase.trim()
+                    ),
+                });
+            }
+        }
+    }
+
+    out
+}
+
+/// The curated, conservative set of release-facing files the claim scan reads,
+/// expressed as repo-relative paths. These are the public/marketing-adjacent
+/// surfaces where an over-claim would actually ship; the giant generated indices
+/// under `docs/` are intentionally excluded.
+pub const RELEASE_FILES: &[&str] = &[
+    "README.md",
+    "CHANGELOG.md",
+    "docs/development/parity-ci-tiers.md",
+    "docs/development/parity-release-checklist.md",
+    "docs/development/cassandra-parity-manifest.md",
+];

--- a/tools/cassandra-parity/src/claim_scan.rs
+++ b/tools/cassandra-parity/src/claim_scan.rs
@@ -49,7 +49,8 @@ const SCOPE_MARKERS: &[&str] = &[
 ];
 
 /// Normalize a string for phrase matching: lowercase and collapse runs of
-/// whitespace (so a phrase split across a soft-wrap still matches).
+/// whitespace. Used to canonicalize a manifest phrase before matching it against
+/// the normalized whole-file view (see [`NormalizedFile`]).
 fn normalize(s: &str) -> String {
     s.to_lowercase()
         .split_whitespace()
@@ -57,18 +58,112 @@ fn normalize(s: &str) -> String {
         .join(" ")
 }
 
-/// True if the line frames the phrase as a scoped/negated counter-example.
-fn line_is_scoped(line_lower: &str) -> bool {
-    SCOPE_MARKERS.iter().any(|m| line_lower.contains(m))
+/// A whole-file view normalized to lowercase with all whitespace runs (including
+/// newlines) collapsed to single spaces, so a phrase split across a soft-wrap
+/// still matches. `offsets[i]` maps byte index `i` of `text` back to the 1-based
+/// source line number it originated from, so a match reports the line where the
+/// phrase starts.
+struct NormalizedFile {
+    /// Lowercased, whitespace-collapsed text of the whole file.
+    text: String,
+    /// Per-byte source-line map: `offsets[i]` is the 1-based source line that the
+    /// byte at `text[i]` came from. Length always equals `text.len()`.
+    offsets: Vec<usize>,
+}
+
+impl NormalizedFile {
+    /// Build the normalized view of `raw`, recording the source line each emitted
+    /// byte came from. A run of whitespace collapses to one space attributed to
+    /// the line where the run *started* (so a phrase wrapped across a soft-wrap
+    /// reports its starting line).
+    fn new(raw: &str) -> Self {
+        let lower = raw.to_lowercase();
+        let mut text = String::with_capacity(lower.len());
+        let mut offsets = Vec::with_capacity(lower.len());
+        let mut line = 1usize;
+        let mut in_ws = false;
+        let mut ws_line = 1usize;
+        for ch in lower.chars() {
+            if ch.is_whitespace() {
+                if !in_ws {
+                    in_ws = true;
+                    ws_line = line;
+                }
+                if ch == '\n' {
+                    line += 1;
+                }
+            } else {
+                if in_ws {
+                    // Emit a single collapsing space if it sits between tokens.
+                    if !text.is_empty() {
+                        for _ in 0..' '.len_utf8() {
+                            offsets.push(ws_line);
+                        }
+                        text.push(' ');
+                    }
+                    in_ws = false;
+                }
+                let start = text.len();
+                text.push(ch);
+                for _ in start..text.len() {
+                    offsets.push(line);
+                }
+            }
+        }
+        debug_assert_eq!(text.len(), offsets.len());
+        Self { text, offsets }
+    }
+
+    /// 1-based source line for the byte at `idx` in [`Self::text`].
+    fn line_at(&self, idx: usize) -> usize {
+        self.offsets.get(idx).copied().unwrap_or(1)
+    }
+}
+
+/// A half-open byte span `[start, end)` within a [`NormalizedFile`].
+#[derive(Clone, Copy)]
+struct Span {
+    start: usize,
+    end: usize,
+}
+
+/// All occurrences of `needle` within `hay`, as byte spans.
+fn find_spans(hay: &str, needle: &str) -> Vec<Span> {
+    let mut spans = Vec::new();
+    if needle.is_empty() {
+        return spans;
+    }
+    let mut from = 0;
+    while let Some(rel) = hay[from..].find(needle) {
+        let start = from + rel;
+        let end = start + needle.len();
+        spans.push(Span { start, end });
+        from = start + 1; // allow overlapping matches
+    }
+    spans
+}
+
+/// True if `inner` is fully contained within any span in `outer`.
+fn covered_by(inner: Span, outer: &[Span]) -> bool {
+    outer
+        .iter()
+        .any(|s| s.start <= inner.start && inner.end <= s.end)
 }
 
 /// Scan the given release-facing files for unqualified public-claim phrases.
 ///
-/// For each `claim.blocked.*` entry, every release file is searched for the
-/// claim phrase. An occurrence is a lint error unless the line it appears on is
-/// explicitly scoped (see [`SCOPE_MARKERS`]) or is the verbatim wording of a
-/// `claim.safe.*` entry. Findings name the file, line, claim id, and the safe
-/// alternative to use instead.
+/// Each file is normalized to a single whitespace-collapsed lowercase view (see
+/// [`NormalizedFile`]) so a phrase split across a soft-wrap is still detected,
+/// while a per-byte line map lets findings report the source line where the
+/// phrase starts. For each `claim.blocked.*` entry, every occurrence is a lint
+/// error unless either:
+///   * that specific occurrence's span falls inside a `claim.safe.*` phrase span
+///     (span-based exemption — a safe phrase elsewhere on the line does not
+///     exempt a separate over-claim), or
+///   * the source line the occurrence starts on is explicitly scoped (see
+///     [`SCOPE_MARKERS`]; scope markers remain line-level).
+///
+/// Findings name the file, line, claim id, and the safe alternative to use.
 pub fn scan_docs(m: &Manifest, files: &[ScanInput<'_>]) -> Vec<Finding> {
     let mut out = Vec::new();
 
@@ -79,23 +174,32 @@ pub fn scan_docs(m: &Manifest, files: &[ScanInput<'_>]) -> Vec<Finding> {
         .iter()
         .filter(|c| c.kind == "safe")
         .map(|c| normalize(&c.phrase))
+        .filter(|p| !p.is_empty())
         .collect();
 
     for f in files {
-        for (lineno, raw) in f.text.lines().enumerate() {
-            let line_norm = normalize(raw);
-            if line_norm.is_empty() {
-                continue;
-            }
-            // A line that is (or contains) a verbatim safe wording is allowed
-            // even if a blocked substring overlaps it.
-            let is_safe_wording = safe_phrases.iter().any(|p| line_norm.contains(p.as_str()));
-            for c in &blocked {
-                let phrase = normalize(&c.phrase);
-                if phrase.is_empty() || !line_norm.contains(&phrase) {
+        let nf = NormalizedFile::new(f.text);
+        if nf.text.is_empty() {
+            continue;
+        }
+        // Spans covered by manifest-backed safe wording — a blocked occurrence is
+        // exempt only when *its own* span sits inside one of these.
+        let safe_spans: Vec<Span> = safe_phrases
+            .iter()
+            .flat_map(|p| find_spans(&nf.text, p))
+            .collect();
+        // Source lines explicitly framing a counter-example/negation. Scope
+        // markers stay line-level, keyed by the 1-based source line they sit on.
+        let scoped_lines = scoped_source_lines(f.text);
+
+        for c in &blocked {
+            let phrase = normalize(&c.phrase);
+            for occ in find_spans(&nf.text, &phrase) {
+                if covered_by(occ, &safe_spans) {
                     continue;
                 }
-                if is_safe_wording || line_is_scoped(&line_norm) {
+                let lineno = nf.line_at(occ.start);
+                if scoped_lines.contains(&lineno) {
                     continue;
                 }
                 let alt = c
@@ -106,7 +210,7 @@ pub fn scan_docs(m: &Manifest, files: &[ScanInput<'_>]) -> Vec<Finding> {
                 out.push(Finding {
                     level: Level::Error,
                     id: c.id.clone(),
-                    field: format!("{}:{}", f.path, lineno + 1),
+                    field: format!("{}:{}", f.path, lineno),
                     message: format!(
                         "unqualified public parity claim \"{}\" — must be explicitly scoped or dropped.{alt}",
                         c.phrase.trim()
@@ -117,6 +221,20 @@ pub fn scan_docs(m: &Manifest, files: &[ScanInput<'_>]) -> Vec<Finding> {
     }
 
     out
+}
+
+/// 1-based source line numbers that contain an explicit scope/negation marker.
+fn scoped_source_lines(raw: &str) -> std::collections::HashSet<usize> {
+    raw.lines()
+        .enumerate()
+        .filter_map(|(i, line)| {
+            let lower = line.to_lowercase();
+            SCOPE_MARKERS
+                .iter()
+                .any(|mk| lower.contains(mk))
+                .then_some(i + 1)
+        })
+        .collect()
 }
 
 /// The curated, conservative set of release-facing files the claim scan reads,

--- a/tools/cassandra-parity/src/claim_scan.rs
+++ b/tools/cassandra-parity/src/claim_scan.rs
@@ -178,7 +178,11 @@ fn find_spans(hay: &str, needle: &str) -> Vec<Span> {
         let start = from + rel;
         let end = start + needle.len();
         spans.push(Span { start, end });
-        from = start + 1; // allow overlapping matches
+        // Advance past the first char of the match so overlapping matches are
+        // still found, but always to a valid UTF-8 char boundary: a manifest
+        // claim phrase may begin with a multi-byte char, so `start + 1` could
+        // land mid-character and panic on the next `hay[from..]` slice.
+        from = start + hay[start..].chars().next().map(char::len_utf8).unwrap_or(1);
     }
     spans
 }
@@ -287,3 +291,28 @@ pub const RELEASE_FILES: &[&str] = &[
     "docs/development/parity-release-checklist.md",
     "docs/development/cassandra-parity-manifest.md",
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn find_spans_handles_non_ascii_phrase_without_panic() {
+        // A claim phrase beginning with a multi-byte UTF-8 char must not panic
+        // when `find_spans` advances its cursor, and must still match correctly.
+        let hay = "prefix é… é… tail";
+        let needle = "é…"; // starts with a 2-byte 'é'
+        let spans = find_spans(hay, needle);
+        assert_eq!(spans.len(), 2, "expected both occurrences");
+        for s in &spans {
+            assert_eq!(&hay[s.start..s.end], needle);
+        }
+    }
+
+    #[test]
+    fn find_spans_overlapping_ascii_still_works() {
+        // Regression guard: boundary-aware advance keeps overlapping ASCII matches.
+        let spans = find_spans("aaaa", "aa");
+        assert_eq!(spans.len(), 3);
+    }
+}

--- a/tools/cassandra-parity/src/enums.rs
+++ b/tools/cassandra-parity/src/enums.rs
@@ -119,3 +119,8 @@ pub const OUT_OF_SCOPE_CATEGORY: &[&str] = &[
 
 /// Artifacts that count as byte-level evidence for a `byte_for_byte` claim.
 pub const BYTE_LEVEL_ARTIFACTS: &[&str] = &["bytes", "offsets", "checksums", "component_files"];
+
+/// Closed set of public-claim kinds (issue #1023). `safe` = manifest-backed
+/// wording the project may publish; `blocked` = unqualified over-claim phrase the
+/// claim-scan lint rejects in release-facing docs unless explicitly scoped.
+pub const CLAIM_KIND: &[&str] = &["safe", "blocked"];

--- a/tools/cassandra-parity/src/lib.rs
+++ b/tools/cassandra-parity/src/lib.rs
@@ -1,6 +1,7 @@
 //! Library surface for the `cassandra-parity` tool so integration tests can
 //! exercise the linter, coverage, and report logic directly.
 
+pub mod claim_scan;
 pub mod coverage;
 pub mod enums;
 pub mod lint;

--- a/tools/cassandra-parity/src/lint.rs
+++ b/tools/cassandra-parity/src/lint.rs
@@ -110,6 +110,19 @@ fn lint_claims(m: &Manifest, out: &mut Vec<Finding>) {
                 "claims.id",
                 format!("{} claim id must start with `{expected_prefix}`", c.kind),
             ));
+        } else if matches!(c.kind.as_str(), "safe" | "blocked") && !valid_claim_id(id) {
+            // The prefix is correct but the full id is malformed (empty or
+            // non-`[a-z0-9_]` slug). The schema requires
+            // `^claim\.(safe|blocked)\.[a-z0-9_]+$`; enforce it here so the CI
+            // `lint` gate cannot publish a malformed id.
+            out.push(Finding::error(
+                id,
+                "claims.id",
+                format!(
+                    "claim id must match `^claim\\.(safe|blocked)\\.[a-z0-9_]+$` \
+                     (non-empty lowercase/digit/underscore slug): {id}"
+                ),
+            ));
         }
         if c.phrase.trim().is_empty() {
             out.push(Finding::error(
@@ -522,6 +535,25 @@ fn check_enum(out: &mut Vec<Finding>, id: &str, field: &str, value: &str, allowe
             field,
             format!("invalid value '{value}'; allowed: {}", allowed.join(", ")),
         ));
+    }
+}
+
+/// True if `id` matches the schema pattern `^claim\.(safe|blocked)\.[a-z0-9_]+$`:
+/// a `claim.safe.` / `claim.blocked.` prefix followed by a non-empty slug of
+/// `[a-z0-9_]`. Dependency-free char-class check (no `regex` crate) matching the
+/// existing [`valid_id`] style. Callers should only invoke this once the prefix
+/// is known to be correct; it re-checks the prefix anyway so it is total.
+fn valid_claim_id(id: &str) -> bool {
+    let slug = id
+        .strip_prefix("claim.safe.")
+        .or_else(|| id.strip_prefix("claim.blocked."));
+    match slug {
+        Some(s) => {
+            !s.is_empty()
+                && s.chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+        }
+        None => false,
     }
 }
 

--- a/tools/cassandra-parity/src/lint.rs
+++ b/tools/cassandra-parity/src/lint.rs
@@ -70,7 +70,98 @@ pub fn lint(m: &Manifest, repo_root: Option<&Path>) -> Vec<Finding> {
         lint_scenario(s, repo_root, &mut out);
     }
 
+    lint_claims(m, &mut out);
+
     out
+}
+
+/// Validate the public-claim entries (issue #1023): closed `kind`, well-formed
+/// ids, non-empty phrase/rationale, `safe` claims must cite real scenario ids,
+/// and `blocked` claims should point at a `claim.safe.*` alternative.
+fn lint_claims(m: &Manifest, out: &mut Vec<Finding>) {
+    let scenario_ids: std::collections::HashSet<&str> =
+        m.scenarios.iter().map(|s| s.id.as_str()).collect();
+    let safe_ids: std::collections::HashSet<&str> = m
+        .claims
+        .iter()
+        .filter(|c| c.kind == "safe")
+        .map(|c| c.id.as_str())
+        .collect();
+
+    let mut seen: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+    for c in &m.claims {
+        *seen.entry(c.id.as_str()).or_insert(0) += 1;
+    }
+
+    for c in &m.claims {
+        let id = c.id.as_str();
+        if seen.get(id).copied().unwrap_or(0) > 1 {
+            out.push(Finding::error(id, "claims.id", "duplicate claim id"));
+        }
+        check_enum(out, id, "claims.kind", &c.kind, enums::CLAIM_KIND);
+        let expected_prefix = match c.kind.as_str() {
+            "safe" => "claim.safe.",
+            "blocked" => "claim.blocked.",
+            _ => "claim.",
+        };
+        if !id.starts_with(expected_prefix) {
+            out.push(Finding::error(
+                id,
+                "claims.id",
+                format!("{} claim id must start with `{expected_prefix}`", c.kind),
+            ));
+        }
+        if c.phrase.trim().is_empty() {
+            out.push(Finding::error(
+                id,
+                "claims.phrase",
+                "claim phrase is required",
+            ));
+        }
+        if c.rationale.trim().is_empty() {
+            out.push(Finding::error(
+                id,
+                "claims.rationale",
+                "claim rationale is required",
+            ));
+        }
+        match c.kind.as_str() {
+            "safe" => {
+                if c.evidence_scenarios.is_empty() {
+                    out.push(Finding::error(
+                        id,
+                        "claims.evidence_scenarios",
+                        "safe claims must cite at least one backing scenario id",
+                    ));
+                }
+                for sid in &c.evidence_scenarios {
+                    if !scenario_ids.contains(sid.as_str()) {
+                        out.push(Finding::error(
+                            id,
+                            "claims.evidence_scenarios",
+                            format!("references unknown scenario id: {sid}"),
+                        ));
+                    }
+                }
+            }
+            "blocked" => match &c.safe_alternative {
+                Some(alt) if !safe_ids.contains(alt.as_str()) => {
+                    out.push(Finding::error(
+                        id,
+                        "claims.safe_alternative",
+                        format!("references unknown claim.safe.* id: {alt}"),
+                    ));
+                }
+                Some(_) => {}
+                None => out.push(Finding::error(
+                    id,
+                    "claims.safe_alternative",
+                    "blocked claims must name a claim.safe.* alternative",
+                )),
+            },
+            _ => {}
+        }
+    }
 }
 
 fn lint_scenario(s: &Scenario, repo_root: Option<&Path>, out: &mut Vec<Finding>) {

--- a/tools/cassandra-parity/src/main.rs
+++ b/tools/cassandra-parity/src/main.rs
@@ -14,6 +14,7 @@ use std::process::ExitCode;
 
 use anyhow::{bail, Context, Result};
 
+use cassandra_parity::claim_scan::{self, ScanInput};
 use cassandra_parity::lint::Level;
 use cassandra_parity::model::Manifest;
 use cassandra_parity::{coverage, enums, lint, report, tier_contract};
@@ -130,7 +131,28 @@ fn run() -> Result<ExitCode> {
 fn cmd_lint(args: &Args) -> Result<ExitCode> {
     let m = load(&args.manifest)?;
     let root = repo_root(&args.manifest);
-    let findings = lint::lint(&m, Some(&root));
+    let mut findings = lint::lint(&m, Some(&root));
+
+    // Claim-scan over release-facing docs (issue #1023): a file that is absent
+    // from this checkout is skipped rather than failing, so the lint stays usable
+    // from sub-trees; the curated file set lives in `claim_scan::RELEASE_FILES`.
+    let texts: Vec<(String, String)> = claim_scan::RELEASE_FILES
+        .iter()
+        .filter_map(|rel| {
+            std::fs::read_to_string(root.join(rel))
+                .ok()
+                .map(|t| ((*rel).to_string(), t))
+        })
+        .collect();
+    let inputs: Vec<ScanInput<'_>> = texts
+        .iter()
+        .map(|(p, t)| ScanInput {
+            path: p.as_str(),
+            text: t.as_str(),
+        })
+        .collect();
+    findings.extend(claim_scan::scan_docs(&m, &inputs));
+
     let errors = findings.iter().filter(|f| f.level == Level::Error).count();
     let warns = findings.iter().filter(|f| f.level == Level::Warn).count();
     for f in &findings {

--- a/tools/cassandra-parity/src/model.rs
+++ b/tools/cassandra-parity/src/model.rs
@@ -13,6 +13,33 @@ pub struct Manifest {
     pub cassandra_source: CassandraSource,
     pub program: Program,
     pub scenarios: Vec<Scenario>,
+    /// Public/release-facing parity claims. `claim.safe.*` entries record the
+    /// manifest-backed wording the project is allowed to publish; `claim.blocked.*`
+    /// entries record the unqualified over-claim phrases the claim-scan lint must
+    /// reject in release-facing docs unless explicitly scoped (issue #1023).
+    #[serde(default)]
+    pub claims: Vec<Claim>,
+}
+
+/// A single public parity claim. Drives both the report's claim-language section
+/// and the claim-scan lint over release-facing docs.
+#[derive(Debug, Deserialize)]
+pub struct Claim {
+    /// `claim.safe.<slug>` or `claim.blocked.<slug>`.
+    pub id: String,
+    /// `safe` or `blocked` (closed set, enforced by the linter).
+    pub kind: String,
+    /// The literal phrase. For `blocked`, the unqualified over-claim the scan
+    /// rejects; for `safe`, the release-safe wording the project may publish.
+    pub phrase: String,
+    /// Why this wording is safe (for `safe`) or why it is rejected (for `blocked`).
+    pub rationale: String,
+    /// Scenario ids that back a `safe` claim's evidence. Required for `safe`.
+    #[serde(default)]
+    pub evidence_scenarios: Vec<String>,
+    /// For a `blocked` claim, the `claim.safe.*` id that should be used instead.
+    #[serde(default)]
+    pub safe_alternative: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/tools/cassandra-parity/src/report.rs
+++ b/tools/cassandra-parity/src/report.rs
@@ -6,11 +6,7 @@
 
 use std::collections::BTreeMap;
 
-use crate::model::{Manifest, Scenario};
-
-const SAFE_CLAIM: &str = "CQLite reads and writes Cassandra 5.0 SSTables and is validated for canonical-semantic equivalence against `sstabledump` for the covered dataset, with byte-for-byte parity proven only where this report records `byte_for_byte` evidence.";
-
-const UNSAFE_CLAIM: &str = "\"CQLite passes the same tests as Cassandra\" or \"CQLite is byte-for-byte identical to Cassandra\" — these overclaim node behavior and byte parity the manifest does not support.";
+use crate::model::{Claim, Manifest, Scenario};
 
 pub fn render(m: &Manifest, manifest_path: &str) -> String {
     let mut scenarios: Vec<&Scenario> = m.scenarios.iter().collect();
@@ -233,15 +229,71 @@ pub fn render(m: &Manifest, manifest_path: &str) -> String {
     }
     line("");
 
-    // --- claim language ---
-    line("## Claim language");
-    line("");
-    line(&format!("**Safe:** {SAFE_CLAIM}"));
-    line("");
-    line(&format!("**Unsafe:** {UNSAFE_CLAIM}"));
-    line("");
+    // --- release-safe claim language (manifest-driven, issue #1023) ---
+    render_claim_language(&mut s, m);
 
     s
+}
+
+/// Render the release-safe / blocked public-claim language from the manifest's
+/// `claims:` section (issue #1023). Safe wordings cite their backing scenarios;
+/// blocked phrases name the safe alternative to use instead. Sorted by id for a
+/// deterministic, `report --check`-stable render.
+fn render_claim_language(s: &mut String, m: &Manifest) {
+    let mut line = |text: &str| {
+        s.push_str(text);
+        s.push('\n');
+    };
+    line("## Release-safe claim language");
+    line("");
+    line(
+        "Public/release-facing parity claims are enforced by the claim-scan lint. \
+         Safe wordings below are manifest-backed; the blocked phrases are unqualified \
+         over-claims rejected unless explicitly scoped as a counter-example.",
+    );
+    line("");
+
+    let mut safe: Vec<&Claim> = m.claims.iter().filter(|c| c.kind == "safe").collect();
+    safe.sort_by(|a, b| a.id.cmp(&b.id));
+    let mut blocked: Vec<&Claim> = m.claims.iter().filter(|c| c.kind == "blocked").collect();
+    blocked.sort_by(|a, b| a.id.cmp(&b.id));
+
+    line("### Safe wordings");
+    line("");
+    if safe.is_empty() {
+        line("_None._");
+    } else {
+        for c in &safe {
+            line(&format!("- **{}** — {}", c.id, c.phrase.trim()));
+            line(&format!("  - Why safe: {}", c.rationale.trim()));
+            if !c.evidence_scenarios.is_empty() {
+                line(&format!(
+                    "  - Backed by: {}",
+                    c.evidence_scenarios
+                        .iter()
+                        .map(|e| format!("`{e}`"))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ));
+            }
+        }
+    }
+    line("");
+
+    line("### Blocked phrases (rejected unless explicitly scoped)");
+    line("");
+    if blocked.is_empty() {
+        line("_None._");
+    } else {
+        for c in &blocked {
+            line(&format!("- **{}** — \"{}\"", c.id, c.phrase.trim()));
+            line(&format!("  - Why blocked: {}", c.rationale.trim()));
+            if let Some(alt) = &c.safe_alternative {
+                line(&format!("  - Use instead: `{alt}`"));
+            }
+        }
+    }
+    line("");
 }
 
 fn render_evidence_group(

--- a/tools/cassandra-parity/tests/lint_tests.rs
+++ b/tools/cassandra-parity/tests/lint_tests.rs
@@ -718,6 +718,48 @@ fn blocked_phrase_wrapped_across_lines_is_caught() {
 }
 
 #[test]
+fn markdown_emphasis_inside_blocked_phrase_is_caught() {
+    // Roborev finding (issue #1023): Markdown emphasis markers INSIDE a blocked
+    // phrase (`same **tests** as Cassandra`) are semantically the same over-claim
+    // and must FAIL lint at the phrase's start line.
+    let docs = [("README.md", "CQLite runs the same **tests** as Cassandra.")];
+    let errs = claim_findings(&wrap_with_claims(), &docs);
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("claim.blocked.same_tests_as_cassandra")
+                && e.contains("README.md:1")),
+        "markdown emphasis inside a blocked phrase must be caught, got: {errs:#?}"
+    );
+}
+
+#[test]
+fn markdown_code_span_inside_blocked_phrase_is_caught() {
+    // Roborev finding (issue #1023): a Markdown code span inside a blocked phrase
+    // (`` same `tests` as Cassandra ``) must FAIL lint just like the plain phrase.
+    let docs = [("README.md", "CQLite runs the same `tests` as Cassandra.")];
+    let errs = claim_findings(&wrap_with_claims(), &docs);
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("claim.blocked.same_tests_as_cassandra")
+                && e.contains("README.md:1")),
+        "markdown code span inside a blocked phrase must be caught, got: {errs:#?}"
+    );
+}
+
+#[test]
+fn markdown_underscore_emphasis_inside_blocked_phrase_is_caught() {
+    // Roborev finding (issue #1023): underscore emphasis inside a blocked phrase
+    // (`same _tests_ as Cassandra`) must FAIL lint.
+    let docs = [("README.md", "CQLite runs the same _tests_ as Cassandra.")];
+    let errs = claim_findings(&wrap_with_claims(), &docs);
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("claim.blocked.same_tests_as_cassandra")),
+        "markdown underscore emphasis inside a blocked phrase must be caught, got: {errs:#?}"
+    );
+}
+
+#[test]
 fn blocked_finding_names_safe_alternative() {
     let docs = [("README.md", "We have full compaction byte parity.")];
     let errs = claim_findings(&wrap_with_claims(), &docs);

--- a/tools/cassandra-parity/tests/lint_tests.rs
+++ b/tools/cassandra-parity/tests/lint_tests.rs
@@ -651,6 +651,41 @@ fn manifest_backed_safe_wording_passes() {
 }
 
 #[test]
+fn same_line_safe_phrase_does_not_exempt_separate_blocked_phrase() {
+    // Roborev finding 1: a line that contains a manifest-backed safe phrase AND a
+    // separate unqualified over-claim must still FAIL — the safe wording only
+    // exempts the span it covers, not the whole line.
+    let docs = [(
+        "README.md",
+        "CQLite is validated against selected Apache Cassandra 5.0 SSTable fixtures \
+         and runs the same tests as Cassandra.",
+    )];
+    let errs = claim_findings(&wrap_with_claims(), &docs);
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("claim.blocked.same_tests_as_cassandra")),
+        "separate blocked phrase on a safe-wording line must be caught, got: {errs:#?}"
+    );
+}
+
+#[test]
+fn blocked_phrase_wrapped_across_lines_is_caught() {
+    // Roborev finding 2: a blocked phrase split across a soft-wrap must still be
+    // detected, with the finding reporting the line where the phrase starts.
+    let docs = [(
+        "README.md",
+        "CQLite runs the same tests as\nCassandra in every build.",
+    )];
+    let errs = claim_findings(&wrap_with_claims(), &docs);
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("claim.blocked.same_tests_as_cassandra")
+                && e.contains("README.md:1")),
+        "wrapped blocked phrase must be caught at its start line, got: {errs:#?}"
+    );
+}
+
+#[test]
 fn blocked_finding_names_safe_alternative() {
     let docs = [("README.md", "We have full compaction byte parity.")];
     let errs = claim_findings(&wrap_with_claims(), &docs);

--- a/tools/cassandra-parity/tests/lint_tests.rs
+++ b/tools/cassandra-parity/tests/lint_tests.rs
@@ -802,6 +802,46 @@ fn blocked_claim_without_safe_alternative_is_rejected() {
 }
 
 #[test]
+fn malformed_claim_id_empty_slug_is_rejected() {
+    // Roborev finding (issue #1023): an id with the right prefix but an empty
+    // slug (`claim.safe.`) must FAIL lint — prefix-only validation let it pass.
+    let yaml = wrap_with_claims().replace("claim.safe.selected_fixture_validation", "claim.safe.");
+    let errs = errors(&yaml);
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("claim.safe.") && e.contains("claims.id") && e.contains("slug")),
+        "empty-slug claim id must be rejected, got: {errs:#?}"
+    );
+}
+
+#[test]
+fn malformed_claim_id_bad_chars_is_rejected() {
+    // An id with the right prefix but uppercase/hyphen in the slug
+    // (`claim.blocked.Bad-Slug`) violates `[a-z0-9_]+` and must FAIL lint.
+    let yaml = wrap_with_claims().replace(
+        "claim.blocked.same_tests_as_cassandra",
+        "claim.blocked.Bad-Slug",
+    );
+    let errs = errors(&yaml);
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("claim.blocked.Bad-Slug") && e.contains("claims.id")),
+        "bad-char claim id must be rejected, got: {errs:#?}"
+    );
+}
+
+#[test]
+fn well_formed_claim_ids_pass() {
+    // The positive counterpart: the well-formed claim ids in `wrap_with_claims`
+    // must NOT trigger any `claims.id` slug error.
+    let errs = errors(&wrap_with_claims());
+    assert!(
+        !errs.iter().any(|e| e.contains("claims.id")),
+        "well-formed claim ids must pass id validation, got: {errs:#?}"
+    );
+}
+
+#[test]
 fn real_manifest_has_the_six_claim_entries() {
     // The six claim entries from issue #1023 must exist and lint clean.
     let root = repo_root();

--- a/tools/cassandra-parity/tests/lint_tests.rs
+++ b/tools/cassandra-parity/tests/lint_tests.rs
@@ -418,6 +418,17 @@ fn schema_enums_match_lint_enums() {
         schema_enum(&props["scope"]["properties"]["out_of_scope_category"]),
         expect(enums::OUT_OF_SCOPE_CATEGORY)
     );
+
+    // Issue #1023 (roborev): the claim-kind enum lives under `$defs.claim`, not
+    // `$defs.scenario`, so it was missed by the loop above. Assert it too, so
+    // drift between `enums::CLAIM_KIND` and the schema's `claim.kind` enum can't
+    // slip through.
+    let claim_props = &schema["$defs"]["claim"]["properties"];
+    assert_eq!(
+        schema_enum(&claim_props["kind"]),
+        expect(enums::CLAIM_KIND),
+        "enums::CLAIM_KIND must match $defs.claim.properties.kind.enum"
+    );
 }
 
 /// Extract the `test_deltas` table name from a fixture reference path of the
@@ -861,6 +872,38 @@ fn real_manifest_has_the_six_claim_entries() {
             "manifest missing claim entry {id}"
         );
     }
+}
+
+#[test]
+fn assessment_report_is_in_release_files() {
+    // Roborev finding 1 (issue #1023): the CI path filter for the cassandra-parity
+    // lint job uses the glob `docs/reports/cassandra-test-parity*.md`, which matches
+    // the hand-written, release-facing assessment report. `RELEASE_FILES` must list
+    // that file so the lint actually scans it — otherwise an over-claim there would
+    // trigger CI but escape the scanner (a guardrail hole).
+    assert!(
+        cassandra_parity::claim_scan::RELEASE_FILES
+            .contains(&"docs/reports/cassandra-test-parity-assessment.md"),
+        "assessment report must be in RELEASE_FILES (CI glob covers it), got: {:?}",
+        cassandra_parity::claim_scan::RELEASE_FILES
+    );
+}
+
+#[test]
+fn blocked_claim_in_assessment_report_path_fails() {
+    // Roborev finding 1 (issue #1023): a blocked over-claim placed in the assessment
+    // report's path must be caught by the claim scan, proving that path is scanned.
+    let docs = [(
+        "docs/reports/cassandra-test-parity-assessment.md",
+        "CQLite runs the same tests as Cassandra.",
+    )];
+    let errs = claim_findings(&wrap_with_claims(), &docs);
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("claim.blocked.same_tests_as_cassandra")
+                && e.contains("docs/reports/cassandra-test-parity-assessment.md")),
+        "over-claim in the assessment report path must be caught, got: {errs:#?}"
+    );
 }
 
 #[test]

--- a/tools/cassandra-parity/tests/lint_tests.rs
+++ b/tools/cassandra-parity/tests/lint_tests.rs
@@ -669,6 +669,38 @@ fn same_line_safe_phrase_does_not_exempt_separate_blocked_phrase() {
 }
 
 #[test]
+fn unrelated_scope_marker_on_same_line_does_not_exempt_blocked_phrase() {
+    // Roborev finding (issue #1023): a scope marker (`reject`) that is unrelated to
+    // and far from the over-claim must NOT exempt it. Scope detection is tied to the
+    // blocked-phrase occurrence, not the whole line.
+    let docs = [(
+        "README.md",
+        "We reject stale fixtures and run the same tests as Cassandra.",
+    )];
+    let errs = claim_findings(&wrap_with_claims(), &docs);
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("claim.blocked.same_tests_as_cassandra")),
+        "unrelated scope marker must not exempt the over-claim, got: {errs:#?}"
+    );
+}
+
+#[test]
+fn scope_marker_adjacent_to_blocked_phrase_still_exempts() {
+    // The positive counterpart: a scope marker in the bounded window immediately
+    // preceding the blocked phrase still scopes (exempts) the occurrence.
+    let docs = [(
+        "docs/development/parity-release-checklist.md",
+        "Reviewers must reject any \"same tests as Cassandra\" wording.",
+    )];
+    let errs = claim_findings(&wrap_with_claims(), &docs);
+    assert!(
+        errs.is_empty(),
+        "adjacent scope marker should still exempt, got: {errs:#?}"
+    );
+}
+
+#[test]
 fn blocked_phrase_wrapped_across_lines_is_caught() {
     // Roborev finding 2: a blocked phrase split across a soft-wrap must still be
     // detected, with the finding reporting the line where the phrase starts.

--- a/tools/cassandra-parity/tests/lint_tests.rs
+++ b/tools/cassandra-parity/tests/lint_tests.rs
@@ -3,6 +3,7 @@
 
 use std::path::PathBuf;
 
+use cassandra_parity::claim_scan::{scan_docs, ScanInput};
 use cassandra_parity::lint::{lint, Level};
 use cassandra_parity::model::Manifest;
 use cassandra_parity::{coverage, enums, report};
@@ -517,6 +518,200 @@ fn delta_scan_fixtures_map_to_generated_tables() {
         "delta_scan fixture/generator drift:\n{}",
         problems.join("\n")
     );
+}
+
+// ----------------------------------------------------------------------------
+// Public-claim scan + manifest claim validation (issue #1023).
+// ----------------------------------------------------------------------------
+
+/// A manifest with one mirrored scenario plus the claim entries the claim-scan
+/// lint needs. `VALID_SCENARIO` supplies a real scenario id for `safe` claims to
+/// cite, so manifest-level claim lint stays clean.
+fn wrap_with_claims() -> String {
+    format!(
+        "{}claims:
+  - id: claim.safe.selected_fixture_validation
+    kind: safe
+    phrase: validated against selected Apache Cassandra 5.0 SSTable fixtures
+    rationale: scoped to the covered corpus, not exhaustive
+    evidence_scenarios:
+      - cass.sstable_format.example_mirrored
+  - id: claim.blocked.same_tests_as_cassandra
+    kind: blocked
+    phrase: same tests as Cassandra
+    rationale: CQLite does not run Cassandra's JVM test suite
+    safe_alternative: claim.safe.selected_fixture_validation
+  - id: claim.blocked.full_compaction_byte_parity
+    kind: blocked
+    phrase: full compaction byte parity
+    rationale: byte parity only where the manifest records byte_for_byte
+    safe_alternative: claim.safe.selected_fixture_validation
+  - id: claim.blocked.zero_diff_sstabledump_all_datasets
+    kind: blocked
+    phrase: zero-diff sstabledump across every dataset
+    rationale: only selected fixtures are validated
+    safe_alternative: claim.safe.selected_fixture_validation
+",
+        wrap(VALID_SCENARIO)
+    )
+}
+
+fn claim_findings(yaml: &str, files: &[(&str, &str)]) -> Vec<String> {
+    let m = Manifest::from_yaml(yaml).expect("manifest parses");
+    let inputs: Vec<ScanInput<'_>> = files
+        .iter()
+        .map(|(p, t)| ScanInput { path: p, text: t })
+        .collect();
+    scan_docs(&m, &inputs)
+        .into_iter()
+        .filter(|f| f.level == Level::Error)
+        .map(|f| format!("[{}] {}: {}", f.id, f.field, f.message))
+        .collect()
+}
+
+#[test]
+fn manifest_supports_all_four_statuses() {
+    // AC1: the closed status set is exactly these four.
+    assert_eq!(
+        enums::STATUS,
+        ["mirrored", "partial", "planned", "out_of_scope"]
+    );
+}
+
+#[test]
+fn unqualified_same_tests_claim_fails() {
+    let docs = [("README.md", "CQLite runs the same tests as Cassandra.")];
+    let errs = claim_findings(&wrap_with_claims(), &docs);
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("claim.blocked.same_tests_as_cassandra")),
+        "got: {errs:#?}"
+    );
+}
+
+#[test]
+fn unqualified_full_compaction_byte_parity_fails() {
+    let docs = [("README.md", "We ship full compaction byte parity today.")];
+    let errs = claim_findings(&wrap_with_claims(), &docs);
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("claim.blocked.full_compaction_byte_parity")),
+        "got: {errs:#?}"
+    );
+}
+
+#[test]
+fn unqualified_zero_diff_all_datasets_fails() {
+    let docs = [(
+        "CHANGELOG.md",
+        "Now with zero-diff sstabledump across every dataset.",
+    )];
+    let errs = claim_findings(&wrap_with_claims(), &docs);
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("claim.blocked.zero_diff_sstabledump_all_datasets")),
+        "got: {errs:#?}"
+    );
+}
+
+#[test]
+fn explicitly_scoped_blocked_phrase_passes() {
+    // AC5: a blocked phrase framed as a counter-example is allowed.
+    let docs = [(
+        "docs/development/parity-release-checklist.md",
+        "Do not claim the same tests as Cassandra; scope every parity claim.",
+    )];
+    let errs = claim_findings(&wrap_with_claims(), &docs);
+    assert!(errs.is_empty(), "scoped phrase should pass, got: {errs:#?}");
+}
+
+#[test]
+fn unsafe_marked_blocked_phrase_passes() {
+    let docs = [(
+        "README.md",
+        "Unsafe: \"full compaction byte parity\" — overclaims byte parity.",
+    )];
+    let errs = claim_findings(&wrap_with_claims(), &docs);
+    assert!(
+        errs.is_empty(),
+        "unsafe-marked phrase should pass: {errs:#?}"
+    );
+}
+
+#[test]
+fn manifest_backed_safe_wording_passes() {
+    // AC4: a claim that uses the manifest-backed safe wording passes even though
+    // it mentions parity, because it is the recorded safe phrase.
+    let docs = [(
+        "README.md",
+        "CQLite is validated against selected Apache Cassandra 5.0 SSTable fixtures.",
+    )];
+    let errs = claim_findings(&wrap_with_claims(), &docs);
+    assert!(errs.is_empty(), "safe wording should pass, got: {errs:#?}");
+}
+
+#[test]
+fn blocked_finding_names_safe_alternative() {
+    let docs = [("README.md", "We have full compaction byte parity.")];
+    let errs = claim_findings(&wrap_with_claims(), &docs);
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("claim.safe.selected_fixture_validation")),
+        "finding must point at the safe alternative, got: {errs:#?}"
+    );
+}
+
+#[test]
+fn safe_claim_with_unknown_scenario_is_rejected() {
+    // Manifest-level claim lint: a safe claim citing a missing scenario fails.
+    let yaml = wrap_with_claims().replace(
+        "      - cass.sstable_format.example_mirrored",
+        "      - cass.does.not_exist",
+    );
+    let errs = errors(&yaml);
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("claim.safe.selected_fixture_validation")
+                && e.contains("unknown scenario id")),
+        "got: {errs:#?}"
+    );
+}
+
+#[test]
+fn blocked_claim_without_safe_alternative_is_rejected() {
+    let yaml = wrap_with_claims().replace(
+        "    safe_alternative: claim.safe.selected_fixture_validation\n  - id: claim.blocked.full_compaction_byte_parity",
+        "  - id: claim.blocked.full_compaction_byte_parity",
+    );
+    let errs = errors(&yaml);
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("claim.blocked.same_tests_as_cassandra")
+                && e.contains("safe_alternative")),
+        "got: {errs:#?}"
+    );
+}
+
+#[test]
+fn real_manifest_has_the_six_claim_entries() {
+    // The six claim entries from issue #1023 must exist and lint clean.
+    let root = repo_root();
+    let text =
+        std::fs::read_to_string(root.join("test-data/cassandra-parity-manifest.yml")).unwrap();
+    let m = Manifest::from_yaml(&text).expect("real manifest parses");
+    for id in [
+        "claim.safe.selected_fixture_validation",
+        "claim.safe.rust_byte_level_coverage",
+        "claim.safe.traceable_cassandra_parity_suite",
+        "claim.blocked.same_tests_as_cassandra",
+        "claim.blocked.full_compaction_byte_parity",
+        "claim.blocked.zero_diff_sstabledump_all_datasets",
+    ] {
+        assert!(
+            m.claims.iter().any(|c| c.id == id),
+            "manifest missing claim entry {id}"
+        );
+    }
 }
 
 #[test]

--- a/tools/cassandra-parity/tests/report_tests.rs
+++ b/tools/cassandra-parity/tests/report_tests.rs
@@ -81,6 +81,31 @@ fn wide_partition_corpus_is_a_planned_gap() {
 }
 
 #[test]
+fn report_has_manifest_driven_claim_language_section() {
+    // AC6 (issue #1023): the report summarizes release-safe claim language from
+    // the manifest's claims section — safe wordings (with backing scenarios) and
+    // blocked phrases (with the safe alternative to use instead).
+    let r = rendered();
+    let header = "## Release-safe claim language";
+    let start = r.find(header).expect("claim-language section present");
+    let section = &r[start..];
+    assert!(section.contains("### Safe wordings"));
+    assert!(section.contains("### Blocked phrases"));
+    for id in [
+        "claim.safe.selected_fixture_validation",
+        "claim.safe.rust_byte_level_coverage",
+        "claim.safe.traceable_cassandra_parity_suite",
+        "claim.blocked.same_tests_as_cassandra",
+        "claim.blocked.full_compaction_byte_parity",
+        "claim.blocked.zero_diff_sstabledump_all_datasets",
+    ] {
+        assert!(section.contains(id), "claim section must list {id}");
+    }
+    // A blocked phrase must name its safe alternative.
+    assert!(section.contains("Use instead: `claim.safe."));
+}
+
+#[test]
 fn planned_scenario_in_evidence_group_is_marked_no_evidence_yet() {
     let r = rendered();
     let header = "## Canonical-semantic scenarios";


### PR DESCRIPTION
Closes #1023 (epic #974).

## What
Manifest-driven public-claim lint: the parity manifest's new `claims:` section is the authoritative oracle for which phrases are public claims; the lint scans release-facing docs and rejects unqualified over-claims unless explicitly scoped, and the generated report surfaces release-safe wording.

- **Claim-scan lint** (`tools/cassandra-parity/src/claim_scan.rs`, new) wired into the `lint` subcommand (the fast_pr CI lane) — scans the curated release-facing file set for each `claim.blocked.*` phrase; an occurrence is an error unless the line is explicitly scoped or is a verbatim `claim.safe.*` wording. Findings name file:line, claim id, and the safe alternative.
- **Manifest-level claim validation** (`lint.rs`): closed `kind` enum, id-prefix check, non-empty phrase/rationale, dup-id detection, `safe` claims cite real scenario ids, `blocked` claims name an existing `claim.safe.*` alternative.
- **Model/enums/schema**: `Manifest.claims`, `Claim`, `enums::CLAIM_KIND`, schema `claims` array.
- **6 manifest entries**: 3 `claim.safe.*` (each cites backing scenario ids) + 3 `claim.blocked.*` (each names a safe alternative) — exact ids from #1023.
- **Report section** (`report.rs`): manifest-driven "Release-safe claim language" section (deterministic so `report --check` stays stable); regenerated `docs/reports/cassandra-test-parity.md`.
- **Tests** (TDD): `tests/lint_tests.rs` + `tests/report_tests.rs` — 44 pass. Each unqualified phrase fails lint; scoped/manifest-backed wording passes; findings name the safe alternative.

## Acceptance criteria (spec-auditor verified)
AC1 (4 statuses), AC3 (mirrored entries name real targets/fixtures/tier/evidence), AC4 (every public claim references manifest evidence or is rejected — claim-scan wired into the `lint` CLI that CI invokes), AC5 (the 3 named unqualified phrases fail unless scoped), AC6 (report summarizes coverage/gaps/out-of-scope/release-safe wording) — **all satisfied with wiring evidence.**

**AC2** (every high-relevance Cassandra file classified) was a **pre-existing 62/115 gap identical on `origin/main`** (not introduced here) — descoped by owner decision to follow-up **#1199** to keep 1:1:1:1.

## Validation
- `scripts/agent-gate.sh`: all components PASS except `core-tests`, whose only failure is the **known-flaky** `test_flush_throughput` perf timing test (passes in isolation; this change touches only `tools/cassandra-parity`, never `cqlite-core`).
- `cassandra-parity lint` OK (230 scenarios, 0 errors), `report --check` up to date, `tier-contract-check` OK, `cargo test -p cassandra-parity` 44 passed.
- End-to-end proof: planting a bare "full compaction byte parity" line in README made `lint` FAIL with the `claim.blocked.full_compaction_byte_parity` finding + safe-alternative hint, then OK after restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)