### PR TITLE
test(#1208): make #991 test_tomb fixture tests skip-on-presence (local-only, not in pinned bundle)

### DIFF
--- a/cqlite-core/tests/issue_991_static_clustering_parity.rs
+++ b/cqlite-core/tests/issue_991_static_clustering_parity.rs
@@ -330,7 +330,18 @@ fn fixture_static_only_partition_jsonl_parity() {
 /// declared order.
 #[test]
 fn fixture_static_with_clustering_rows_byte_parity() {
-    let raw = decompress_fixture(STATIC_TOMB_DIR);
+    // #1208: the test_tomb/static_with_tombstones binary is NOT in the pinned
+    // CI bundle (refs-only), so read it skip-on-presence — the same fixture is
+    // read this way by sibling #1015. Present-but-empty still fails (the
+    // raw.len() > 8 assert in decompress_with_info), and the canonical static +
+    // clustering shape is also covered by deterministic writer tests.
+    let Some(raw) = decompress_local_only_fixture(STATIC_TOMB_DIR) else {
+        eprintln!(
+            "SKIP fixture_static_with_clustering_rows_byte_parity: local-only fixture \
+             {STATIC_TOMB_DIR}/nb-1-big-Data.db absent (not in pinned bundle; covered deterministically)"
+        );
+        return;
+    };
 
     // Derive which PK is at file offset 0 from the golden (token order, not key
     // value), so a dataset regen that reshuffles partition order is reported as a
@@ -1017,7 +1028,18 @@ fn null_vs_empty_clustering_value_byte_distinction() {
 
 #[test]
 fn fixture_static_row_flag_byte_well_formed() {
-    let raw = decompress_fixture(STATIC_TOMB_DIR);
+    // #1208: the test_tomb/static_with_tombstones binary is NOT in the pinned
+    // CI bundle (refs-only), so read it skip-on-presence — the same fixture is
+    // read this way by sibling #1015. Present-but-empty still fails (the
+    // raw.len() > 8 assert in decompress_with_info), and the static row-flag
+    // mask is also anchored by deterministic writer tests.
+    let Some(raw) = decompress_local_only_fixture(STATIC_TOMB_DIR) else {
+        eprintln!(
+            "SKIP fixture_static_row_flag_byte_well_formed: local-only fixture \
+             {STATIC_TOMB_DIR}/nb-1-big-Data.db absent (not in pinned bundle; covered deterministically)"
+        );
+        return;
+    };
 
     // Cassandra UnfilteredSerializer leading-byte sentinels that a LIVE STATIC
     // ROW must NOT carry: 0x01 is the END_OF_PARTITION marker (Unfiltered.Kind),


### PR DESCRIPTION
Closes #1208 (P0 gate-integrity blocker; MGR order \`mgr-mbp-0628\` ORDER 1).

## Problem
#991's two fail-closed byte-parity tests (\`fixture_static_with_clustering_rows_byte_parity\`, \`fixture_static_row_flag_byte_well_formed\`) \`panic!\` when \`test_tomb/static_with_tombstones-<uuid>/nb-1-big-Data.db\` is absent. That binary ships **refs-only** in the pinned bundle (\`cassandra5-small-full-v3.2.tar.gz\`), so \`scripts/agent-gate.sh\` \`core-tests\` failed on **every clean checkout** — threatening the autonomous-merge gate for every fresh worker.

## Fix (Option B — skip-on-presence, the documented local-only-fixtures pattern)
Convert ONLY those two entry points from the fail-closed \`decompress_fixture(STATIC_TOMB_DIR)\` to the existing skip variant \`decompress_local_only_fixture(...)\` with a SKIP guard — mirroring the in-file precedent (\`fixture_static_only_partition_marker_byte_parity\`) and **sibling #1015, which already reads this same fixture skip-on-presence**. #991 reading it fail-closed was the inconsistency.

- Present-but-empty still **FAILs** (the \`raw.len() > 8\` assert in \`decompress_with_info\` is unchanged) → "0-rows-when-present is a failure" preserved.
- \`decompress_fixture\` and the three genuinely-pinned callers (STATIC_COLUMNS/WIDE/COMPOSITE) untouched.
- No bundle/pin churn. The canonical static+clustering / row-flag shapes are also covered by deterministic writer tests (per the doctrine comment at helpers/mod.rs:224-230).

## Verification
- **Absent (clean-checkout sim, refs-only datasets):** both tests PASS via SKIP — no panic.
- **Present (binary available):** both tests PASS, parity actually exercised.
- **Gate-of-record:** all 14 components PASS, including the previously-red \`core-tests\` and \`write-support\`.
- **roborev (codex):** No issues found.

Sibling #1205 (publish test_deltas fixtures) intentionally NOT folded in — that's the publish route; this P0 takes the faster documented skip-on-presence path.