### PR TITLE
refactor(#947): unify cell-reconcile + shadow-before-purge rules across merge & write paths

### DIFF
--- a/cqlite-core/src/storage/sstable/writer/data_writer/rows.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/rows.rs
@@ -7,6 +7,11 @@
 
 use super::*;
 
+use crate::storage::write_engine::reconcile_rules;
+// `ReconcileCell` is imported for its methods (`is_tombstone`) used by the
+// shared `Cells#reconcile` tie-break in `merge_row_group` (issue #947).
+use crate::storage::write_engine::reconcile_rules::ReconcileCell;
+
 impl DataWriter {
     /// Write a single row
     ///
@@ -407,28 +412,25 @@ impl DataWriter {
                     }
                     std::collections::hash_map::Entry::Occupied(mut entry) => {
                         let existing = entry.get();
-                        // Per-cell winner resolution mirroring Cassandra
-                        // `Cells#reconcile` (parity `a62c749`; issue #848 / #498),
-                        // kept CONSISTENT with `KWayMerger::cell_reconcile_replace`:
-                        //   1. higher timestamp always wins;
-                        //   2. at EQUAL timestamp a cell DELETION (a `Delete`
-                        //      tombstone) beats a LIVE/EXPIRING write — decided
-                        //      BEFORE any localDeletionTime compare, so an expiring
-                        //      (TTL) write at equal ts can never resurrect data over
-                        //      a same-ts cell tombstone (`WriteWithTtl` is LIVE here,
-                        //      NOT a tombstone). `local_deletion_time` is never used
-                        //      as a tie-break.
-                        // The writer keeps its existing convention for equal-ts
-                        // live-vs-live (later mutation wins) via `!existing_is_tomb`;
-                        // only the tombstone-vs-live/expiring axis is load-bearing
-                        // for #848 and matches reconcile.
-                        let candidate_is_tombstone =
-                            matches!(candidate.op, CellOperation::Delete { .. });
-                        let existing_is_tombstone =
-                            matches!(existing.op, CellOperation::Delete { .. });
-                        let wins = candidate.timestamp_micros > existing.timestamp_micros
+                        // Per-cell winner resolution. The SHARED Cassandra
+                        // `Cells#reconcile` tie-break (issue #947,
+                        // `reconcile_rules::cell_wins`) decides the load-bearing
+                        // axes — higher timestamp wins, and at EQUAL timestamp a
+                        // cell DELETION (`Delete` tombstone) beats a LIVE/EXPIRING
+                        // write BEFORE any localDeletionTime compare (#848/#498;
+                        // `WriteWithTtl` is LIVE, not a tombstone).
+                        //
+                        // The writer overlays a WRITER-ONLY, order-dependent
+                        // last-write-wins tie-break for the one case the shared
+                        // rule leaves to the caller: at EQUAL timestamp with EQUAL
+                        // liveness the later-applied mutation wins (keep-last).
+                        // Cassandra's reconcile is order-independent and the merge
+                        // path keeps first-seen there; this overlay reproduces the
+                        // writer's historical convention exactly and is NOT part of
+                        // the shared rule.
+                        let wins = reconcile_rules::cell_wins(&candidate, existing)
                             || (candidate.timestamp_micros == existing.timestamp_micros
-                                && (candidate_is_tombstone || !existing_is_tombstone));
+                                && candidate.is_tombstone() == existing.is_tombstone());
                         if wins {
                             entry.insert(candidate);
                         }
@@ -559,7 +561,12 @@ impl DataWriter {
                     let col = column.as_str();
                     match active_mfda.get(col) {
                         // STRICTLY GREATER supersedes; equal/lesser does NOT.
-                        Some(existing) if marked_for_delete_at <= existing => {}
+                        // Shared strict-supersede rule (issue #947).
+                        Some(existing)
+                            if !reconcile_rules::complex_deletion_supersedes(
+                                *marked_for_delete_at,
+                                *existing,
+                            ) => {}
                         _ => {
                             active_mfda.insert(col, *marked_for_delete_at);
                         }
@@ -574,9 +581,10 @@ impl DataWriter {
                         column,
                         timestamp_micros: elem_ts,
                         ..
-                    } => active_mfda
-                        .get(column.as_str())
-                        .is_none_or(|mfda| *elem_ts > *mfda),
+                    } => active_mfda.get(column.as_str()).is_none_or(|mfda| {
+                        // Shared shadow-before-purge boundary (issue #947).
+                        reconcile_rules::element_survives_complex_deletion(*elem_ts, *mfda)
+                    }),
                     _ => true,
                 });
             }

--- a/cqlite-core/src/storage/sstable/writer/data_writer/rows.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/rows.rs
@@ -7,10 +7,8 @@
 
 use super::*;
 
-use crate::storage::write_engine::reconcile_rules;
-// `ReconcileCell` is imported for its methods (`is_tombstone`) used by the
-// shared `Cells#reconcile` tie-break in `merge_row_group` (issue #947).
-use crate::storage::write_engine::reconcile_rules::ReconcileCell;
+// Shared reconcile rules (issue #947); `ReconcileCell` in scope for `.is_tombstone()`.
+use crate::storage::write_engine::reconcile_rules::{self, ReconcileCell};
 
 impl DataWriter {
     /// Write a single row
@@ -413,21 +411,14 @@ impl DataWriter {
                     std::collections::hash_map::Entry::Occupied(mut entry) => {
                         let existing = entry.get();
                         // Per-cell winner resolution. The SHARED Cassandra
-                        // `Cells#reconcile` tie-break (issue #947,
-                        // `reconcile_rules::cell_wins`) decides the load-bearing
-                        // axes — higher timestamp wins, and at EQUAL timestamp a
-                        // cell DELETION (`Delete` tombstone) beats a LIVE/EXPIRING
-                        // write BEFORE any localDeletionTime compare (#848/#498;
-                        // `WriteWithTtl` is LIVE, not a tombstone).
-                        //
-                        // The writer overlays a WRITER-ONLY, order-dependent
-                        // last-write-wins tie-break for the one case the shared
-                        // rule leaves to the caller: at EQUAL timestamp with EQUAL
-                        // liveness the later-applied mutation wins (keep-last).
-                        // Cassandra's reconcile is order-independent and the merge
-                        // path keeps first-seen there; this overlay reproduces the
-                        // writer's historical convention exactly and is NOT part of
-                        // the shared rule.
+                        // `Cells#reconcile` tie-break (`reconcile_rules::cell_wins`,
+                        // issue #947) decides the load-bearing axes (#848/#498). The
+                        // writer then overlays its WRITER-ONLY, order-dependent
+                        // last-write-wins for the one case the shared rule leaves to
+                        // the caller — EQUAL timestamp + EQUAL liveness keeps the
+                        // later-applied mutation (Cassandra's reconcile is
+                        // order-independent and the merge path keeps first-seen). The
+                        // overlay reproduces the writer's historical bytes exactly.
                         let wins = reconcile_rules::cell_wins(&candidate, existing)
                             || (candidate.timestamp_micros == existing.timestamp_micros
                                 && candidate.is_tombstone() == existing.is_tombstone());

--- a/cqlite-core/src/storage/sstable/writer/data_writer/types.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/types.rs
@@ -28,6 +28,24 @@ pub(crate) struct MergedOp<'a> {
     pub(crate) cell_local_deletion_time: i32,
 }
 
+/// Adapt a writer-path [`MergedOp`] into the shared
+/// [`ReconcileCell`](crate::storage::write_engine::reconcile_rules::ReconcileCell)
+/// view (issue #947) so the per-column cell tie-break in `merge_row_group` calls
+/// the one shared `Cells#reconcile` rule. A whole-column op is a tombstone iff it
+/// is a `CellOperation::Delete` (a `WriteWithTtl` is an EXPIRING — live — cell,
+/// not a tombstone), matching the merge path's `Value::Tombstone` recognition.
+impl crate::storage::write_engine::reconcile_rules::ReconcileCell for MergedOp<'_> {
+    fn timestamp(&self) -> i64 {
+        self.timestamp_micros
+    }
+    fn is_tombstone(&self) -> bool {
+        matches!(
+            self.op,
+            crate::storage::write_engine::mutation::CellOperation::Delete { .. }
+        )
+    }
+}
+
 /// One element to emit inside a per-element complex column (epic #899, Phase B).
 ///
 /// Carries the element's OWN write metadata and its PRESERVED source cell path

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -59,6 +59,8 @@ use crate::schema::TableSchema;
 #[cfg(feature = "write-support")]
 use crate::storage::write_engine::mutation::{ClusteringKey, DecoratedKey, RangeTombstone};
 #[cfg(feature = "write-support")]
+use crate::storage::write_engine::reconcile_rules;
+#[cfg(feature = "write-support")]
 use crate::types::Value;
 
 #[cfg(feature = "write-support")]
@@ -78,6 +80,22 @@ pub use model::{CellData, ComplexDeletion, MergeEntry, MergeStats, MergeStep, Ro
 /// (issue #945). See [`reconcile::ReconcileState`].
 #[cfg(feature = "write-support")]
 mod reconcile;
+
+/// Adapt a merge-path [`CellData`] into the shared [`ReconcileCell`] view
+/// (issue #947) so per-cell winner resolution calls
+/// [`reconcile_rules::cell_wins`] — the one shared `Cells#reconcile` tie-break —
+/// instead of a hand-synced copy. How a tombstone is RECOGNIZED stays here
+/// (`Value::Tombstone` payload / IS_DELETED via [`KWayMerger::is_cell_tombstone`]),
+/// since that is genuinely type-specific.
+#[cfg(feature = "write-support")]
+impl reconcile_rules::ReconcileCell for CellData {
+    fn timestamp(&self) -> i64 {
+        self.timestamp
+    }
+    fn is_tombstone(&self) -> bool {
+        KWayMerger::is_cell_tombstone(self)
+    }
+}
 
 /// A cut position on the clustering axis, used to coalesce range tombstones
 /// into a NON-OVERLAPPING canonical sequence (issue #933 / roborev #959 High
@@ -3020,35 +3038,6 @@ impl KWayMerger {
             // future element representation that sets the flag without the wrapped
             // value still counts as a deletion for the tie-break.
             || cell.is_deleted
-    }
-
-    /// Per-cell winner resolution mirroring Cassandra `Cells#reconcile`
-    /// (parity commit `a62c749`): returns `true` when `candidate` should replace
-    /// the current `existing` winner.
-    ///
-    /// Ordering (decided IN THIS ORDER, short-circuiting):
-    /// 1. **timestamp** — a strictly higher write timestamp always wins.
-    /// 2. **deletion vs live/expiring at EQUAL timestamp** — a cell DELETION
-    ///    (tombstone) beats a LIVE or EXPIRING (TTL) cell. This is decided
-    ///    *before* any `localDeletionTime` comparison, so an expiring cell can
-    ///    never resurrect data over a same-timestamp tombstone just because its
-    ///    TTL expiry instant is later (issue #848 / #498). `is_cell_tombstone`
-    ///    treats an expiring cell as LIVE (it carries a real value + a TTL, not a
-    ///    `CellTombstone`), so this single rule subsumes both
-    ///    tombstone-beats-live and tombstone-beats-expiring.
-    /// 3. **equal timestamp + equal liveness** — keep the first-seen (newer file)
-    ///    winner. `reconcile_cluster` only calls this for a later-seen candidate,
-    ///    so returning `false` preserves first-seen order deterministically.
-    ///    `localDeletionTime` is intentionally NOT a discriminator here: at equal
-    ///    ts + equal deletion-status the cells are equivalent and first-seen order
-    ///    is the stable choice.
-    fn cell_reconcile_replace(candidate: &CellData, existing: &CellData) -> bool {
-        if candidate.timestamp != existing.timestamp {
-            return candidate.timestamp > existing.timestamp;
-        }
-        // Equal timestamp: deletion wins over a live/expiring cell, BEFORE any
-        // localDeletionTime compare (parity `a62c749`).
-        Self::is_cell_tombstone(candidate) && !Self::is_cell_tombstone(existing)
     }
 
     /// Reconcile all entries for a single clustering-key group into at most one

--- a/cqlite-core/src/storage/write_engine/merge/reconcile.rs
+++ b/cqlite-core/src/storage/write_engine/merge/reconcile.rs
@@ -32,6 +32,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::storage::write_engine::mutation::{ClusteringKey, DecoratedKey, RangeTombstone};
+use crate::storage::write_engine::reconcile_rules;
 
 use super::{CellData, ComplexDeletion, KWayMerger, MergeEntry, PurgeCounts, RowData};
 
@@ -176,7 +177,7 @@ impl ReconcileState {
     /// `cluster_rows` is in heap-routing order (run_index ascending within equal
     /// keys), so when two cells tie on both timestamp and liveness the
     /// first-seen (newer file) is kept (see
-    /// [`KWayMerger::cell_reconcile_replace`]).
+    /// [`reconcile_rules::cell_wins`], the shared tie-break rule).
     pub(super) fn resolve_cell_winners(&mut self, cluster_rows: &[MergeEntry]) {
         for entry in cluster_rows {
             if let RowData::Live { cells } = &entry.row_data {
@@ -194,8 +195,10 @@ impl ReconcileState {
                             // compare (parity Cassandra `a62c749`,
                             // `Cells#reconcile`; issue #848 / #498). At equal ts
                             // + equal deletion-status, keep the first-seen
-                            // (newer file) winner. See `cell_reconcile_replace`.
-                            if KWayMerger::cell_reconcile_replace(cell, existing) {
+                            // (newer file) winner. The tie-break is the SHARED
+                            // [`reconcile_rules::cell_wins`] rule (issue #947),
+                            // also used by the flush/write path.
+                            if reconcile_rules::cell_wins(cell, existing) {
                                 self.winners.insert(cell_key, cell.clone());
                             }
                         }
@@ -238,8 +241,14 @@ impl ReconcileState {
                         active_order.push(cd.column.clone());
                         active.insert(cd.column.clone(), cd);
                     }
-                    // STRICTLY GREATER supersedes; equal/lesser does NOT (bd244649).
-                    Some(existing) if cd.marked_for_delete_at > existing.marked_for_delete_at => {
+                    // STRICTLY GREATER supersedes; equal/lesser does NOT
+                    // (bd244649). Shared rule (issue #947).
+                    Some(existing)
+                        if reconcile_rules::complex_deletion_supersedes(
+                            cd.marked_for_delete_at,
+                            existing.marked_for_delete_at,
+                        ) =>
+                    {
                         *existing = cd;
                     }
                     Some(_) => {}
@@ -262,7 +271,15 @@ impl ReconcileState {
                         }
                         match winners.get(cell_key) {
                             // ts > mfda survives; ts <= mfda is shadowed (purged).
-                            Some(cell) if cell.timestamp > mfda => true,
+                            // Shared shadow-before-purge boundary (issue #947).
+                            Some(cell)
+                                if reconcile_rules::element_survives_complex_deletion(
+                                    cell.timestamp,
+                                    mfda,
+                                ) =>
+                            {
+                                true
+                            }
                             Some(_) => {
                                 winners.remove(cell_key);
                                 false

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -35,6 +35,8 @@ pub mod merge_policy;
 #[cfg(feature = "write-support")]
 pub mod mutation;
 #[cfg(feature = "write-support")]
+pub(crate) mod reconcile_rules;
+#[cfg(feature = "write-support")]
 pub mod wal;
 
 #[cfg(feature = "write-support")]

--- a/cqlite-core/src/storage/write_engine/reconcile_rules.rs
+++ b/cqlite-core/src/storage/write_engine/reconcile_rules.rs
@@ -1,0 +1,186 @@
+//! Shared reconcile rule layer (issue #947).
+//!
+//! The Cassandra `Cells#reconcile` cell tie-break and the complex-deletion
+//! strict-supersede + shadow-before-purge boundaries used to be implemented
+//! TWICE and hand-synced:
+//!
+//! * the COMPACTION/merge path (`merge/mod.rs` + `merge/reconcile.rs`),
+//!   reconciling [`CellData`](super::merge::CellData);
+//! * the FLUSH/write path
+//!   (`sstable::writer::data_writer::rows::DataWriter::merge_row_group`),
+//!   reconciling `MergedOp`.
+//!
+//! Both paths now adapt their concrete cell type into the minimal common
+//! [`ReconcileCell`] view and call the pure decision functions below, so the
+//! load-bearing comparisons live in ONE place and consistency is structural —
+//! not a comment promising two copies were kept in sync.
+//!
+//! These are pure scalar predicates (no allocation, no I/O). The per-container
+//! iteration (a `HashMap` of `CellData` winners vs. a `Vec` of `MergedOp`)
+//! differs between the two call sites and stays at each site; only the
+//! decision rules are shared.
+//!
+//! ## Parity anchors (do not change without a Cassandra reference)
+//!
+//! * [`cell_wins`] — `Cells#reconcile` (commit `a62c749`; issues #848/#498).
+//! * [`complex_deletion_supersedes`] — strict-supersede (commit `bd244649`).
+//! * [`element_survives_complex_deletion`] — shadow-before-purge boundary
+//!   (commit `f66fa14f`; the `<=` element-vs-marker rule, #498).
+
+/// Minimal common view of a reconcilable cell.
+///
+/// The only two accessors BOTH write paths share for the `Cells#reconcile`
+/// tie-break: the cell's write timestamp and whether it is a deletion
+/// (tombstone). Each call site implements this over its concrete type
+/// ([`CellData`](super::merge::CellData) on the merge path, `MergedOp` on the
+/// writer path) and how it RECOGNIZES a tombstone — a `Value::Tombstone`
+/// payload vs. a `CellOperation::Delete` op — stays with the type, since that
+/// recognition is genuinely type-specific.
+///
+/// The on-disk `localDeletionTime` is intentionally NOT part of this view: it
+/// is consulted only by the merge path's gc-grace purge stage (which the flush
+/// path has no analogue for), so sharing it here would force a meaningless
+/// accessor on the writer type. The tie-break itself never consults LDT — a
+/// same-timestamp tombstone wins BEFORE any LDT compare.
+pub(crate) trait ReconcileCell {
+    /// Cell write timestamp in microseconds (`markedForDeleteAt` for a deletion).
+    fn timestamp(&self) -> i64;
+    /// Whether this cell is a deletion (tombstone) rather than a live/expiring
+    /// value.
+    fn is_tombstone(&self) -> bool;
+}
+
+/// Cassandra `Cells#reconcile` replace decision (parity commit `a62c749`):
+/// returns `true` when `candidate` should replace the current `existing` winner.
+///
+/// Decided IN THIS ORDER, short-circuiting:
+/// 1. **timestamp** — a strictly higher write timestamp always wins.
+/// 2. **deletion vs live/expiring at EQUAL timestamp** — a cell DELETION
+///    (tombstone) beats a LIVE or EXPIRING (TTL) cell, decided BEFORE any
+///    `localDeletionTime` compare, so an expiring cell can never resurrect data
+///    over a same-timestamp tombstone (issues #848 / #498). An expiring cell is
+///    treated as LIVE (it carries a real value + a TTL, not a tombstone), so
+///    this one rule subsumes both tombstone-beats-live and
+///    tombstone-beats-expiring.
+/// 3. **equal timestamp + equal liveness** — returns `false`. Cassandra's
+///    reconcile is order-independent and equivalent here, so the caller keeps
+///    its first-seen winner. (The writer path overlays an order-dependent
+///    last-write-wins tie-break for this single case at its call site; that
+///    overlay is writer-only and NOT part of this shared rule.)
+pub(crate) fn cell_wins<C: ReconcileCell + ?Sized>(candidate: &C, existing: &C) -> bool {
+    if candidate.timestamp() != existing.timestamp() {
+        return candidate.timestamp() > existing.timestamp();
+    }
+    // Equal timestamp: a deletion wins over a live/expiring cell, BEFORE any
+    // localDeletionTime compare (parity `a62c749`).
+    candidate.is_tombstone() && !existing.is_tombstone()
+}
+
+/// Strict-supersede predicate for complex (collection / UDT) deletion markers
+/// (parity commit `bd244649`): a candidate marker supersedes the active one for
+/// the SAME column ONLY when its `markedForDeleteAt` is STRICTLY GREATER. Equal
+/// (or lesser) timestamps do NOT supersede.
+///
+/// Both call sites reduce their carried markers to one active deletion per
+/// column NAME using this predicate; the per-column iteration differs but the
+/// strictly-greater comparison is shared here.
+#[inline]
+pub(crate) fn complex_deletion_supersedes(candidate_mfda: i64, active_mfda: i64) -> bool {
+    candidate_mfda > active_mfda
+}
+
+/// Shadow-before-purge boundary (parity commit `f66fa14f`; the element-vs-marker
+/// `<=` rule, #498): a complex ELEMENT survives the active complex deletion on
+/// its column only when the element's own timestamp is STRICTLY GREATER than the
+/// marker's `markedForDeleteAt`. An element with `ts <= mfda` is shadowed
+/// (covered) and dropped before the marker can be purged.
+///
+/// Returns `true` when the element SURVIVES.
+#[inline]
+pub(crate) fn element_survives_complex_deletion(element_ts: i64, mfda: i64) -> bool {
+    element_ts > mfda
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Tiny test double for the [`ReconcileCell`] view.
+    struct Cell {
+        ts: i64,
+        tomb: bool,
+    }
+    impl ReconcileCell for Cell {
+        fn timestamp(&self) -> i64 {
+            self.ts
+        }
+        fn is_tombstone(&self) -> bool {
+            self.tomb
+        }
+    }
+    fn live(ts: i64) -> Cell {
+        Cell { ts, tomb: false }
+    }
+    fn tomb(ts: i64) -> Cell {
+        Cell { ts, tomb: true }
+    }
+
+    // ── cell_wins: timestamp axis ───────────────────────────────────────────
+
+    #[test]
+    fn strictly_greater_timestamp_wins() {
+        assert!(cell_wins(&live(200), &live(100)));
+        assert!(!cell_wins(&live(100), &live(200)));
+        // A live cell at a strictly-greater ts beats an older tombstone.
+        assert!(cell_wins(&live(200), &tomb(100)));
+        // An older live cell does not beat a newer tombstone.
+        assert!(!cell_wins(&live(100), &tomb(200)));
+    }
+
+    // ── cell_wins: EQUAL-ts deletion-vs-live/expiring (the #848/#498 axis) ───
+
+    #[test]
+    fn equal_ts_tombstone_beats_live() {
+        // A same-ts tombstone candidate replaces a live existing winner.
+        assert!(cell_wins(&tomb(100), &live(100)));
+        // A same-ts live candidate does NOT replace a tombstone winner.
+        assert!(!cell_wins(&live(100), &tomb(100)));
+    }
+
+    #[test]
+    fn equal_ts_tombstone_beats_expiring() {
+        // An expiring (TTL) cell is modeled as LIVE here (it is not a tombstone):
+        // the deletion still wins, BEFORE any localDeletionTime/expiry compare.
+        let expiring = live(100); // carries a value + TTL → not a tombstone
+        assert!(cell_wins(&tomb(100), &expiring));
+        assert!(!cell_wins(&expiring, &tomb(100)));
+    }
+
+    #[test]
+    fn equal_ts_equal_liveness_keeps_first_seen() {
+        // Equal ts + equal liveness => no replacement (caller keeps first-seen).
+        assert!(!cell_wins(&live(100), &live(100)));
+        assert!(!cell_wins(&tomb(100), &tomb(100)));
+    }
+
+    // ── complex_deletion_supersedes: STRICT-greater, EQUAL does not ──────────
+
+    #[test]
+    fn complex_deletion_strict_supersede_boundary() {
+        assert!(complex_deletion_supersedes(300, 200)); // strictly greater supersedes
+        assert!(!complex_deletion_supersedes(200, 200)); // EQUAL does NOT supersede
+        assert!(!complex_deletion_supersedes(100, 200)); // lesser does not supersede
+    }
+
+    // ── element_survives_complex_deletion: the `<=` shadow boundary ──────────
+
+    #[test]
+    fn element_shadow_before_purge_boundary() {
+        // ts STRICTLY GREATER than mfda survives.
+        assert!(element_survives_complex_deletion(201, 200));
+        // ts EQUAL to mfda is shadowed (the `<=` boundary, #498).
+        assert!(!element_survives_complex_deletion(200, 200));
+        // ts LESS than mfda is shadowed.
+        assert!(!element_survives_complex_deletion(199, 200));
+    }
+}

--- a/cqlite-core/tests/issue_947_reconcile_parity.rs
+++ b/cqlite-core/tests/issue_947_reconcile_parity.rs
@@ -373,6 +373,48 @@ fn compaction_path(rt: &tokio::runtime::Runtime, schema: &TableSchema) -> BTreeM
     read_back(rt, &output_dir, schema)
 }
 
+/// Byte-identity dump helper (issue #947, manual). Runs the deterministic
+/// compaction into the dir named by `CQLITE_947_DUMP` so an external `sha256sum`
+/// can compare the emitted Data.db before vs. after the refactor. Ignored by
+/// default (it has external side effects and no assertions); not part of the
+/// gate.
+#[test]
+#[ignore = "manual byte-identity dump; set CQLITE_947_DUMP"]
+fn dump_compaction_output_for_byte_identity() {
+    let Ok(dump) = std::env::var("CQLITE_947_DUMP") else {
+        eprintln!("CQLITE_947_DUMP not set; nothing to dump");
+        return;
+    };
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let schema = make_schema();
+    let dump_dir = PathBuf::from(dump);
+    let data_dir = dump_dir.join("data");
+    let wal_dir = dump_dir.join("wal");
+    let output_dir = dump_dir.join("out");
+    let _ = std::fs::remove_dir_all(&dump_dir);
+
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir, schema.clone());
+    let mut engine = WriteEngine::new(config).expect("engine");
+    for (id, edits) in scenarios() {
+        for edit in edits.iter().filter(|e| e.gen == Gen::Old) {
+            engine.write(mutation(id, edit.ops.clone(), edit.ts)).expect("write old");
+        }
+    }
+    rt.block_on(engine.flush()).expect("flush old").expect("info old");
+    for (id, edits) in scenarios() {
+        for edit in edits.iter().filter(|e| e.gen == Gen::New) {
+            engine.write(mutation(id, edit.ops.clone(), edit.ts)).expect("write new");
+        }
+    }
+    rt.block_on(engine.flush()).expect("flush new").expect("info new");
+    drop(engine);
+
+    let inputs = discover_inputs(&data_dir);
+    rt.block_on(compact_sstables(inputs, &output_dir, &schema, 9, None, None, true))
+        .expect("compaction");
+    eprintln!("dumped compaction output under {output_dir:?}");
+}
+
 #[test]
 fn flush_and_compaction_reconcile_boundaries_identically() {
     let rt = tokio::runtime::Runtime::new().expect("runtime");

--- a/cqlite-core/tests/issue_947_reconcile_parity.rs
+++ b/cqlite-core/tests/issue_947_reconcile_parity.rs
@@ -1,0 +1,412 @@
+//! Issue #947 — cross-path reconcile parity (PINNING TEST).
+//!
+//! The Cassandra `Cells#reconcile` tie-break (timestamp wins; at EQUAL timestamp
+//! a cell DELETION beats a LIVE/EXPIRING cell, decided BEFORE any
+//! `localDeletionTime` compare — parity `a62c749`, issues #848/#498) is applied on
+//! TWO independent write paths:
+//!
+//! * the COMPACTION/merge path — `KWayMerger` reconcile (`reconcile.rs` /
+//!   `merge/mod.rs::cell_reconcile_replace`), reconciling `CellData`;
+//! * the FLUSH/write path — `DataWriter::merge_row_group`, reconciling `MergedOp`.
+//!
+//! Issue #947 unifies the two into one shared rule layer. This test PINS the
+//! pre-refactor behavior end-to-end: it feeds the SAME logical boundary scenarios
+//! through BOTH paths and asserts the read-back rows are byte-for-byte identical,
+//! proving the two implementations already agree on the boundary cases (so the
+//! extraction is a behavior-frozen refactor, not a semantic change).
+//!
+//! Boundary cases covered (the cell tie-break axis):
+//! * strict-greater timestamp wins (live over live);
+//! * a live cell with a strictly-greater timestamp beats an older tombstone;
+//! * EQUAL-ts cell tombstone beats a LIVE cell (#848/#498);
+//! * EQUAL-ts cell tombstone beats an EXPIRING (TTL) cell.
+//!
+//! The complex-deletion strict-supersede + shadow-before-purge boundaries
+//! (`mfda` strict-greater vs equal; element `ts == mfda` shadowed vs `ts > mfda`
+//! survives) are pinned as unit tests on the shared rule layer
+//! (`write_engine::reconcile_rules`) and end-to-end by the #819 differential
+//! compaction harness.
+
+#![cfg(feature = "write-support")]
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use cqlite_core::platform::Platform;
+use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+use cqlite_core::storage::sstable::SSTableManager;
+use cqlite_core::storage::write_engine::merge::compact_sstables;
+use cqlite_core::storage::write_engine::{
+    CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::TableId as CqlTableId;
+use cqlite_core::types::Value;
+use cqlite_core::Config;
+use std::collections::HashMap;
+use tempfile::TempDir;
+
+const TS_LO: i64 = 1_700_000_000_000_000;
+const TS_HI: i64 = TS_LO + 1_000_000;
+
+fn make_schema() -> TableSchema {
+    TableSchema {
+        keyspace: "recon_ks".to_string(),
+        table: "items".to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            Column {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "a".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "b".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+/// Which input SSTable an edit lands in for the COMPACTION path. The FLUSH path
+/// puts every edit in one memtable regardless. Reconcile is driven by each
+/// cell's own write TIMESTAMP, not the generation, so a high-ts write may live
+/// in the OLD generation file.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Gen {
+    Old,
+    New,
+}
+
+#[derive(Clone)]
+struct Edit {
+    gen: Gen,
+    ops: Vec<CellOperation>,
+    ts: i64,
+}
+
+fn write(col: &str, v: &str) -> CellOperation {
+    CellOperation::Write {
+        column: col.to_string(),
+        value: Value::Text(v.to_string()),
+    }
+}
+
+fn write_ttl(col: &str, v: &str, ttl: u32) -> CellOperation {
+    CellOperation::WriteWithTtl {
+        column: col.to_string(),
+        value: Value::Text(v.to_string()),
+        ttl_seconds: ttl,
+    }
+}
+
+fn delete(col: &str) -> CellOperation {
+    CellOperation::Delete {
+        column: col.to_string(),
+        local_deletion_time: None,
+    }
+}
+
+/// The boundary scenarios, keyed by partition id. Each value is the ordered list
+/// of edits applied to that partition.
+fn scenarios() -> BTreeMap<i32, Vec<Edit>> {
+    let mut m: BTreeMap<i32, Vec<Edit>> = BTreeMap::new();
+
+    // id=1: strict-greater timestamp wins (live over live) -> a="new".
+    m.insert(
+        1,
+        vec![
+            Edit {
+                gen: Gen::Old,
+                ops: vec![write("a", "old")],
+                ts: TS_LO,
+            },
+            Edit {
+                gen: Gen::New,
+                ops: vec![write("a", "new")],
+                ts: TS_HI,
+            },
+        ],
+    );
+
+    // id=2: a live cell at a strictly-greater ts beats an older tombstone.
+    m.insert(
+        2,
+        vec![
+            Edit {
+                gen: Gen::Old,
+                ops: vec![delete("a"), write("b", "w2")],
+                ts: TS_LO,
+            },
+            Edit {
+                gen: Gen::New,
+                ops: vec![write("a", "live")],
+                ts: TS_HI,
+            },
+        ],
+    );
+
+    // id=3: strict-greater live-over-live with a witness column present.
+    m.insert(
+        3,
+        vec![
+            Edit {
+                gen: Gen::Old,
+                ops: vec![write("a", "A"), write("b", "w3")],
+                ts: TS_LO,
+            },
+            Edit {
+                gen: Gen::New,
+                ops: vec![write("a", "B")],
+                ts: TS_HI,
+            },
+        ],
+    );
+
+    // id=4: a live write at a strictly-greater ts beats a NEWER-generation
+    // tombstone written at a lower ts (reconcile is by cell ts, not gen).
+    m.insert(
+        4,
+        vec![
+            Edit {
+                gen: Gen::Old,
+                ops: vec![write("a", "keep")],
+                ts: TS_HI,
+            },
+            Edit {
+                gen: Gen::New,
+                ops: vec![delete("a")],
+                ts: TS_LO,
+            },
+        ],
+    );
+
+    // id=5: EQUAL-ts cell tombstone beats a LIVE cell (#848/#498). a deleted,
+    // witness b survives.
+    m.insert(
+        5,
+        vec![
+            Edit {
+                gen: Gen::Old,
+                ops: vec![write("a", "x"), write("b", "w5")],
+                ts: TS_LO,
+            },
+            Edit {
+                gen: Gen::New,
+                ops: vec![delete("a")],
+                ts: TS_LO,
+            },
+        ],
+    );
+
+    // id=6: EQUAL-ts cell tombstone beats an EXPIRING (TTL) cell — the deletion
+    // wins BEFORE any localDeletionTime/expiry compare. a deleted, witness b
+    // survives.
+    m.insert(
+        6,
+        vec![
+            Edit {
+                gen: Gen::Old,
+                ops: vec![write_ttl("a", "e", 3600), write("b", "w6")],
+                ts: TS_LO,
+            },
+            Edit {
+                gen: Gen::New,
+                ops: vec![delete("a")],
+                ts: TS_LO,
+            },
+        ],
+    );
+
+    m
+}
+
+fn mutation(id: i32, ops: Vec<CellOperation>, ts: i64) -> Mutation {
+    let table_id = TableId::new("recon_ks", "items");
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    Mutation::new(table_id, pk, None, ops, ts, None)
+}
+
+/// Discover published `nb-*-big-Data.db` input files, newest-generation first.
+fn discover_inputs(dir: &Path) -> Vec<PathBuf> {
+    let mut found: Vec<(u64, PathBuf)> = Vec::new();
+    collect(dir, &mut found, 8);
+    found.sort_by(|a, b| b.0.cmp(&a.0));
+    found.into_iter().map(|(_, p)| p).collect()
+}
+
+fn collect(dir: &Path, out: &mut Vec<(u64, PathBuf)>, depth: usize) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = path.file_name().unwrap_or_default().to_string_lossy().to_string();
+        if name.starts_with("nb-") && name.ends_with("-big-Data.db") {
+            let base = name.trim_end_matches("-Data.db");
+            if !path.with_file_name(format!("{base}-TOC.txt")).exists() {
+                continue;
+            }
+            let generation = name
+                .strip_prefix("nb-")
+                .and_then(|s| s.split("-big-").next())
+                .and_then(|g| g.parse::<u64>().ok())
+                .unwrap_or(0);
+            out.push((generation, path));
+        } else if depth > 0 && path.is_dir() {
+            collect(&path, out, depth - 1);
+        }
+    }
+}
+
+/// Read every partition of an output dir into a stable `pk_bytes -> rendered`
+/// map. The rendered string is the debug form of the row value; if two write
+/// paths reconcile identically, these maps are equal.
+fn read_back(rt: &tokio::runtime::Runtime, dir: &Path, schema: &TableSchema) -> BTreeMap<Vec<u8>, String> {
+    let cqlite_config = Config::default();
+    let manager = rt.block_on(async {
+        let platform = Arc::new(Platform::new(&cqlite_config).await.expect("platform"));
+        SSTableManager::new(
+            dir,
+            &cqlite_config,
+            platform,
+            #[cfg(feature = "state_machine")]
+            None,
+        )
+        .await
+        .expect("SSTableManager opens output")
+    });
+    let table_id = CqlTableId::from("recon_ks.items");
+    let results = rt
+        .block_on(manager.scan(&table_id, None, None, None, Some(schema)))
+        .expect("scan");
+    results
+        .into_iter()
+        .map(|(k, v)| (k.0, format!("{v:?}")))
+        .collect()
+}
+
+/// FLUSH path: write every edit into one memtable, flush to a single SSTable,
+/// read it back.
+fn flush_path(rt: &tokio::runtime::Runtime, schema: &TableSchema) -> BTreeMap<Vec<u8>, String> {
+    let temp = TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    let wal_dir = temp.path().join("wal");
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir, schema.clone());
+    let mut engine = WriteEngine::new(config).expect("engine");
+
+    for (id, edits) in scenarios() {
+        // Old edits first, then New — mirrors the compaction generation order;
+        // for these boundary cases the winner is order-independent.
+        for edit in edits.iter().filter(|e| e.gen == Gen::Old) {
+            engine.write(mutation(id, edit.ops.clone(), edit.ts)).expect("write");
+        }
+        for edit in edits.iter().filter(|e| e.gen == Gen::New) {
+            engine.write(mutation(id, edit.ops.clone(), edit.ts)).expect("write");
+        }
+    }
+    rt.block_on(engine.flush()).expect("flush").expect("info");
+    drop(engine);
+    read_back(rt, &data_dir, schema)
+}
+
+/// COMPACTION path: flush the Old edits into one SSTable and the New edits into
+/// another, compact the two, read the merged output back.
+fn compaction_path(rt: &tokio::runtime::Runtime, schema: &TableSchema) -> BTreeMap<Vec<u8>, String> {
+    let temp = TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    let wal_dir = temp.path().join("wal");
+    let output_dir = temp.path().join("out");
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir, schema.clone());
+    let mut engine = WriteEngine::new(config).expect("engine");
+
+    // Generation 1 (older): all Old edits.
+    for (id, edits) in scenarios() {
+        for edit in edits.iter().filter(|e| e.gen == Gen::Old) {
+            engine.write(mutation(id, edit.ops.clone(), edit.ts)).expect("write old");
+        }
+    }
+    rt.block_on(engine.flush()).expect("flush old").expect("info old");
+
+    // Generation 2 (newer): all New edits.
+    for (id, edits) in scenarios() {
+        for edit in edits.iter().filter(|e| e.gen == Gen::New) {
+            engine.write(mutation(id, edit.ops.clone(), edit.ts)).expect("write new");
+        }
+    }
+    rt.block_on(engine.flush()).expect("flush new").expect("info new");
+    drop(engine);
+
+    let inputs = discover_inputs(&data_dir);
+    assert_eq!(inputs.len(), 2, "expected 2 input SSTables, got {inputs:?}");
+
+    rt.block_on(compact_sstables(
+        inputs,
+        &output_dir,
+        schema,
+        9,    // output generation
+        None, // gc_before: disable gc purge so tombstones are retained (parity with flush)
+        None, // now_sec
+        true, // purge_safe (full compaction)
+    ))
+    .expect("compaction");
+
+    read_back(rt, &output_dir, schema)
+}
+
+#[test]
+fn flush_and_compaction_reconcile_boundaries_identically() {
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let schema = make_schema();
+
+    let flushed = flush_path(&rt, &schema);
+    let compacted = compaction_path(&rt, &schema);
+
+    // The core pinning assertion: the two reconcile implementations produce the
+    // SAME read-back rows for every boundary partition.
+    assert_eq!(
+        flushed, compacted,
+        "flush-path and compaction-path reconcile must agree on every boundary case"
+    );
+
+    // Targeted semantic anchors so a both-paths-wrong regression is also caught.
+    let by_id = |m: &BTreeMap<Vec<u8>, String>, id: i32| -> String {
+        let key: Vec<u8> = id.to_be_bytes().into();
+        m.get(&key).cloned().unwrap_or_default()
+    };
+
+    // id=1 strict-greater live wins.
+    let r1 = by_id(&flushed, 1);
+    assert!(r1.contains("new") && !r1.contains("old"), "id=1: strict-greater live wins, got {r1}");
+    // id=2 live > older tombstone.
+    assert!(by_id(&flushed, 2).contains("live"), "id=2: live beats older tombstone");
+    // id=4 live@HI beats newer-gen tombstone@LO.
+    assert!(by_id(&flushed, 4).contains("keep"), "id=4: live ts wins over lower-ts tombstone");
+    // id=5 EQUAL-ts tombstone beats live: column a gone, witness b survives.
+    let r5 = by_id(&flushed, 5);
+    assert!(r5.contains("w5"), "id=5: witness b must survive, got {r5}");
+    assert!(!r5.contains("\"x\""), "id=5: equal-ts tombstone must delete a, got {r5}");
+    // id=6 EQUAL-ts tombstone beats expiring: a gone, witness b survives.
+    let r6 = by_id(&flushed, 6);
+    assert!(r6.contains("w6"), "id=6: witness b must survive, got {r6}");
+    assert!(!r6.contains("\"e\""), "id=6: equal-ts tombstone must delete expiring a, got {r6}");
+}

--- a/cqlite-core/tests/issue_947_reconcile_parity.rs
+++ b/cqlite-core/tests/issue_947_reconcile_parity.rs
@@ -260,7 +260,11 @@ fn collect(dir: &Path, out: &mut Vec<(u64, PathBuf)>, depth: usize) {
     };
     for entry in entries.flatten() {
         let path = entry.path();
-        let name = path.file_name().unwrap_or_default().to_string_lossy().to_string();
+        let name = path
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string();
         if name.starts_with("nb-") && name.ends_with("-big-Data.db") {
             let base = name.trim_end_matches("-Data.db");
             if !path.with_file_name(format!("{base}-TOC.txt")).exists() {
@@ -281,7 +285,11 @@ fn collect(dir: &Path, out: &mut Vec<(u64, PathBuf)>, depth: usize) {
 /// Read every partition of an output dir into a stable `pk_bytes -> rendered`
 /// map. The rendered string is the debug form of the row value; if two write
 /// paths reconcile identically, these maps are equal.
-fn read_back(rt: &tokio::runtime::Runtime, dir: &Path, schema: &TableSchema) -> BTreeMap<Vec<u8>, String> {
+fn read_back(
+    rt: &tokio::runtime::Runtime,
+    dir: &Path,
+    schema: &TableSchema,
+) -> BTreeMap<Vec<u8>, String> {
     let cqlite_config = Config::default();
     let manager = rt.block_on(async {
         let platform = Arc::new(Platform::new(&cqlite_config).await.expect("platform"));
@@ -318,10 +326,14 @@ fn flush_path(rt: &tokio::runtime::Runtime, schema: &TableSchema) -> BTreeMap<Ve
         // Old edits first, then New — mirrors the compaction generation order;
         // for these boundary cases the winner is order-independent.
         for edit in edits.iter().filter(|e| e.gen == Gen::Old) {
-            engine.write(mutation(id, edit.ops.clone(), edit.ts)).expect("write");
+            engine
+                .write(mutation(id, edit.ops.clone(), edit.ts))
+                .expect("write");
         }
         for edit in edits.iter().filter(|e| e.gen == Gen::New) {
-            engine.write(mutation(id, edit.ops.clone(), edit.ts)).expect("write");
+            engine
+                .write(mutation(id, edit.ops.clone(), edit.ts))
+                .expect("write");
         }
     }
     rt.block_on(engine.flush()).expect("flush").expect("info");
@@ -331,7 +343,10 @@ fn flush_path(rt: &tokio::runtime::Runtime, schema: &TableSchema) -> BTreeMap<Ve
 
 /// COMPACTION path: flush the Old edits into one SSTable and the New edits into
 /// another, compact the two, read the merged output back.
-fn compaction_path(rt: &tokio::runtime::Runtime, schema: &TableSchema) -> BTreeMap<Vec<u8>, String> {
+fn compaction_path(
+    rt: &tokio::runtime::Runtime,
+    schema: &TableSchema,
+) -> BTreeMap<Vec<u8>, String> {
     let temp = TempDir::new().unwrap();
     let data_dir = temp.path().join("data");
     let wal_dir = temp.path().join("wal");
@@ -342,18 +357,26 @@ fn compaction_path(rt: &tokio::runtime::Runtime, schema: &TableSchema) -> BTreeM
     // Generation 1 (older): all Old edits.
     for (id, edits) in scenarios() {
         for edit in edits.iter().filter(|e| e.gen == Gen::Old) {
-            engine.write(mutation(id, edit.ops.clone(), edit.ts)).expect("write old");
+            engine
+                .write(mutation(id, edit.ops.clone(), edit.ts))
+                .expect("write old");
         }
     }
-    rt.block_on(engine.flush()).expect("flush old").expect("info old");
+    rt.block_on(engine.flush())
+        .expect("flush old")
+        .expect("info old");
 
     // Generation 2 (newer): all New edits.
     for (id, edits) in scenarios() {
         for edit in edits.iter().filter(|e| e.gen == Gen::New) {
-            engine.write(mutation(id, edit.ops.clone(), edit.ts)).expect("write new");
+            engine
+                .write(mutation(id, edit.ops.clone(), edit.ts))
+                .expect("write new");
         }
     }
-    rt.block_on(engine.flush()).expect("flush new").expect("info new");
+    rt.block_on(engine.flush())
+        .expect("flush new")
+        .expect("info new");
     drop(engine);
 
     let inputs = discover_inputs(&data_dir);
@@ -397,21 +420,37 @@ fn dump_compaction_output_for_byte_identity() {
     let mut engine = WriteEngine::new(config).expect("engine");
     for (id, edits) in scenarios() {
         for edit in edits.iter().filter(|e| e.gen == Gen::Old) {
-            engine.write(mutation(id, edit.ops.clone(), edit.ts)).expect("write old");
+            engine
+                .write(mutation(id, edit.ops.clone(), edit.ts))
+                .expect("write old");
         }
     }
-    rt.block_on(engine.flush()).expect("flush old").expect("info old");
+    rt.block_on(engine.flush())
+        .expect("flush old")
+        .expect("info old");
     for (id, edits) in scenarios() {
         for edit in edits.iter().filter(|e| e.gen == Gen::New) {
-            engine.write(mutation(id, edit.ops.clone(), edit.ts)).expect("write new");
+            engine
+                .write(mutation(id, edit.ops.clone(), edit.ts))
+                .expect("write new");
         }
     }
-    rt.block_on(engine.flush()).expect("flush new").expect("info new");
+    rt.block_on(engine.flush())
+        .expect("flush new")
+        .expect("info new");
     drop(engine);
 
     let inputs = discover_inputs(&data_dir);
-    rt.block_on(compact_sstables(inputs, &output_dir, &schema, 9, None, None, true))
-        .expect("compaction");
+    rt.block_on(compact_sstables(
+        inputs,
+        &output_dir,
+        &schema,
+        9,
+        None,
+        None,
+        true,
+    ))
+    .expect("compaction");
     eprintln!("dumped compaction output under {output_dir:?}");
 }
 
@@ -438,17 +477,32 @@ fn flush_and_compaction_reconcile_boundaries_identically() {
 
     // id=1 strict-greater live wins.
     let r1 = by_id(&flushed, 1);
-    assert!(r1.contains("new") && !r1.contains("old"), "id=1: strict-greater live wins, got {r1}");
+    assert!(
+        r1.contains("new") && !r1.contains("old"),
+        "id=1: strict-greater live wins, got {r1}"
+    );
     // id=2 live > older tombstone.
-    assert!(by_id(&flushed, 2).contains("live"), "id=2: live beats older tombstone");
+    assert!(
+        by_id(&flushed, 2).contains("live"),
+        "id=2: live beats older tombstone"
+    );
     // id=4 live@HI beats newer-gen tombstone@LO.
-    assert!(by_id(&flushed, 4).contains("keep"), "id=4: live ts wins over lower-ts tombstone");
+    assert!(
+        by_id(&flushed, 4).contains("keep"),
+        "id=4: live ts wins over lower-ts tombstone"
+    );
     // id=5 EQUAL-ts tombstone beats live: column a gone, witness b survives.
     let r5 = by_id(&flushed, 5);
     assert!(r5.contains("w5"), "id=5: witness b must survive, got {r5}");
-    assert!(!r5.contains("\"x\""), "id=5: equal-ts tombstone must delete a, got {r5}");
+    assert!(
+        !r5.contains("\"x\""),
+        "id=5: equal-ts tombstone must delete a, got {r5}"
+    );
     // id=6 EQUAL-ts tombstone beats expiring: a gone, witness b survives.
     let r6 = by_id(&flushed, 6);
     assert!(r6.contains("w6"), "id=6: witness b must survive, got {r6}");
-    assert!(!r6.contains("\"e\""), "id=6: equal-ts tombstone must delete expiring a, got {r6}");
+    assert!(
+        !r6.contains("\"e\""),
+        "id=6: equal-ts tombstone must delete expiring a, got {r6}"
+    );
 }


### PR DESCRIPTION
Closes #947 (P0 — oracle-driven, behavior-frozen refactor).

## What
The Cassandra `Cells#reconcile` tie-break and the complex-deletion **strict-supersede + shadow-before-purge** rules were implemented **twice** (compaction `merge.rs` and flush `data_writer.rs::merge_row_group`) and hand-synced. This unifies them behind one shared, separately-tested rule layer.

## Shared rule layer
`cqlite-core/src/storage/write_engine/reconcile_rules.rs` (write-support-gated):
- trait `ReconcileCell { timestamp() -> i64; is_tombstone() -> bool }` — minimal common view
- `cell_wins` (Cells#reconcile tie-break, `a62c749`), `complex_deletion_supersedes` (strict-supersede, `bd244649`), `element_survives_complex_deletion` (shadow-before-purge `<=` boundary, `f66fa14f`)
- 6 unit tests on the boundary cases

Both call sites adapt their concrete type (`CellData`, `MergedOp`) into the view and call the shared rules. The inline copies and the `// kept CONSISTENT with KWayMerger::cell_reconcile_replace` comment in `data_writer.rs` are **deleted** — consistency is now structural.

The writer-only equal-ts/equal-liveness last-write-wins overlay (order-dependent, NOT part of Cassandra's order-independent reconcile) stays at the writer call site, documented as writer-only, to reproduce historical writer bytes exactly.

## Evidence (behavior-frozen)
- **agent-gate.sh: PASS** (full summary block below)
- **#842 differential harness byte-identical** before/after: all 6 emitted SSTable components sha256-match on origin/main src vs refactored src.
- **Cross-path pinning test** (`tests/issue_947_reconcile_parity.rs`): feeds the same boundary scenarios through both flush + compaction paths, asserts read-back equality. Written FIRST, passed against unmodified origin/main (proving prior agreement), passes after.
- **roborev: No issues found** (claude-code/opus, branch review).

```
==== AGENT-GATE SUMMARY ====
commit: bbbde02a branch: issue-947-unify-reconcile-rules dirty: no
file-size: PASS  fmt: PASS  clippy: PASS  core-tests: PASS
tombstones-scan: PASS  scan-offload-guard: PASS  integration-tests: PASS
format-compat: PASS  write-tests: PASS  cli-tests: PASS  python-bindings: PASS
delivery-telemetry: PASS  minimal-build: PASS  smoke: PASS
RESULT: PASS
==== END AGENT-GATE SUMMARY ====
```

Note: `CQLITE_ALLOW_FILE_GROWTH=1` was used solely for the +2-line module declaration in the already-over-threshold `write_engine/mod.rs` (#1116 split scope); `rows.rs` and `merge/mod.rs` both net-shrank.