### PR TITLE
fix(#1197): emit CRC.db per-chunk component for uncompressed BIG SSTables

### DIFF
--- a/cqlite-core/src/storage/sstable/writer/crc_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/crc_writer.rs
@@ -1,0 +1,168 @@
+//! `CRC.db` writer — per-chunk CRC32 for uncompressed BIG SSTables.
+//!
+//! Cassandra 5.0 writes a `CRC.db` component for every **uncompressed** BIG
+//! (`nb`) SSTable, alongside (not instead of) `Digest.crc32`. Compressed tables
+//! carry per-chunk CRCs inline after each compressed chunk and describe them in
+//! `CompressionInfo.db`, so they have no `CRC.db`. BTI (`da`) tables likewise do
+//! not emit `CRC.db` (verified against the Cassandra-written `da` fixtures).
+//!
+//! # On-disk format (oracle: Cassandra 5.0)
+//!
+//! Produced by `ChecksummedSequentialWriter` via `ChecksumWriter`
+//! (`org.apache.cassandra.io.util.ChecksumWriter` /
+//! `ChecksummedSequentialWriter`):
+//!
+//! ```text
+//! [chunk size : 4 bytes, signed int, big-endian]   <- data writer buffer.capacity()
+//! [CRC32 chunk 0 : 4 bytes, big-endian]
+//! [CRC32 chunk 1 : 4 bytes, big-endian]
+//! ...
+//! ```
+//!
+//! - **Chunk size** is the data `SequentialWriter`'s `buffer.capacity()`, which
+//!   defaults to `64 * 1024` (`SequentialWriterOption.Builder.bufferSize`). The
+//!   real Cassandra fixtures store `0x00010000` (65536). `ChecksumWriter`
+//!   serializes it with `DataOutput.writeInt` (big-endian).
+//! - Each **CRC32** covers exactly one chunk of the **raw (uncompressed)**
+//!   Data.db bytes — `flushData()` checksums `buffer.position()` bytes per buffer
+//!   flush. The algorithm is `java.util.zip.CRC32` (IEEE / `crc32fast`); the
+//!   value is written as a big-endian `i32`/`u32` via `DataOutput.writeInt`.
+//! - The per-chunk CRC values are **not** folded into the data file's
+//!   `Digest.crc32` (`checksumIncrementalResult = false` for the uncompressed
+//!   path), so `Digest.crc32` remains the CRC32 over the raw data bytes only.
+//!   For a single-chunk file the lone `CRC.db` entry therefore equals the
+//!   `Digest.crc32` value.
+//!
+//! # Seek formula (read side)
+//!
+//! To locate the CRC for byte `offset` in Data.db:
+//! `crc_file_pos = (offset / chunk_size) * 4 + 4`
+//! (`DataIntegrityMetadata.ChecksumValidator`).
+
+use std::path::{Path, PathBuf};
+
+use crate::error::Result;
+
+/// Default uncompressed CRC chunk size, matching Cassandra's
+/// `SequentialWriterOption.Builder` default `bufferSize` of `64 * 1024`.
+///
+/// This is the value stored in the 4-byte `CRC.db` header and the block size
+/// over which each per-chunk CRC32 is computed.
+pub const CRC_CHUNK_SIZE: usize = 64 * 1024;
+
+/// Compute the `CRC.db` bytes for an uncompressed `Data.db`.
+///
+/// Streams `data_path` in `CRC_CHUNK_SIZE` blocks (bounded memory, independent
+/// of the total Data.db size — see the digest-streaming rationale in
+/// `finish.rs`) and emits the Cassandra `CRC.db` layout: a big-endian `i32`
+/// chunk-size header followed by one big-endian `u32` CRC32 per chunk.
+///
+/// An empty `Data.db` yields just the 4-byte header (zero chunks), matching
+/// Cassandra's behaviour when no data buffer is ever flushed.
+pub(super) async fn build_crc_bytes(data_path: &Path) -> Result<Vec<u8>> {
+    use tokio::io::AsyncReadExt;
+
+    let mut out = Vec::new();
+    // Header: chunk size as a big-endian signed 32-bit int (DataOutput.writeInt).
+    out.extend_from_slice(&(CRC_CHUNK_SIZE as i32).to_be_bytes());
+
+    let mut file = tokio::fs::File::open(data_path).await?;
+    let mut buffer = vec![0u8; CRC_CHUNK_SIZE];
+    let mut filled = 0usize;
+    loop {
+        // Fill up to a full chunk before checksumming so each CRC covers a
+        // complete CRC_CHUNK_SIZE block (except the final, short chunk), exactly
+        // as Cassandra's per-buffer flushData() does. A single short read does
+        // not imply EOF, so accumulate until the chunk is full or EOF is hit.
+        let n = file.read(&mut buffer[filled..]).await?;
+        if n == 0 {
+            if filled > 0 {
+                let mut hasher = crc32fast::Hasher::new();
+                hasher.update(&buffer[..filled]);
+                out.extend_from_slice(&hasher.finalize().to_be_bytes());
+            }
+            break;
+        }
+        filled += n;
+        if filled == CRC_CHUNK_SIZE {
+            let mut hasher = crc32fast::Hasher::new();
+            hasher.update(&buffer[..filled]);
+            out.extend_from_slice(&hasher.finalize().to_be_bytes());
+            filled = 0;
+        }
+    }
+
+    Ok(out)
+}
+
+/// Write the `CRC.db` component for an uncompressed `Data.db`, returning the
+/// component path.
+///
+/// Computes the per-chunk CRC bytes (see [`build_crc_bytes`]) and writes them to
+/// `crc_path`. Callers add the returned path to `TOC.txt` and `SSTableInfo`.
+pub(super) async fn write_crc_db(data_path: &Path, crc_path: PathBuf) -> Result<PathBuf> {
+    let bytes = build_crc_bytes(data_path).await?;
+    tokio::fs::write(&crc_path, bytes).await?;
+    Ok(crc_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn empty_data_yields_header_only() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let data = dir.path().join("Data.db");
+        tokio::fs::write(&data, b"").await.expect("write data");
+
+        let bytes = build_crc_bytes(&data).await.expect("crc bytes");
+        assert_eq!(bytes, (CRC_CHUNK_SIZE as i32).to_be_bytes().to_vec());
+    }
+
+    #[tokio::test]
+    async fn single_chunk_crc_matches_whole_file_crc32() {
+        // For data <= one chunk, the single CRC.db entry equals the whole-file
+        // CRC32 (the Digest.crc32 value) — Cassandra-observed invariant.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let data = dir.path().join("Data.db");
+        let payload = b"hello cqlite crc.db parity";
+        tokio::fs::write(&data, payload).await.expect("write data");
+
+        let bytes = build_crc_bytes(&data).await.expect("crc bytes");
+        assert_eq!(bytes.len(), 8, "header + 1 crc");
+
+        let header = i32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+        assert_eq!(header, CRC_CHUNK_SIZE as i32);
+
+        let stored = u32::from_be_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
+        let mut hasher = crc32fast::Hasher::new();
+        hasher.update(payload);
+        assert_eq!(stored, hasher.finalize());
+    }
+
+    #[tokio::test]
+    async fn multi_chunk_emits_one_crc_per_chunk() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let data = dir.path().join("Data.db");
+        // 2.5 chunks of deterministic bytes.
+        let len = CRC_CHUNK_SIZE * 2 + CRC_CHUNK_SIZE / 2;
+        let payload: Vec<u8> = (0..len).map(|i| (i % 251) as u8).collect();
+        tokio::fs::write(&data, &payload).await.expect("write data");
+
+        let bytes = build_crc_bytes(&data).await.expect("crc bytes");
+        // header(4) + 3 CRCs(4 each)
+        assert_eq!(bytes.len(), 4 + 3 * 4);
+
+        // Verify each chunk CRC independently.
+        let mut pos = 4;
+        for chunk in payload.chunks(CRC_CHUNK_SIZE) {
+            let stored =
+                u32::from_be_bytes([bytes[pos], bytes[pos + 1], bytes[pos + 2], bytes[pos + 3]]);
+            let mut hasher = crc32fast::Hasher::new();
+            hasher.update(chunk);
+            assert_eq!(stored, hasher.finalize());
+            pos += 4;
+        }
+    }
+}

--- a/cqlite-core/src/storage/sstable/writer/finish.rs
+++ b/cqlite-core/src/storage/sstable/writer/finish.rs
@@ -160,6 +160,21 @@ impl SSTableWriter {
         let crc32_value = Self::compute_crc32(&data_path).await?;
         digest_writer.write(crc32_value)?;
 
+        // 6.5. Write CRC.db — per-chunk CRC32 for uncompressed BIG (issue #1197).
+        // Cassandra 5.0 writes a CRC.db for every uncompressed BIG (`nb`)
+        // SSTable, alongside Digest.crc32 (ChecksummedSequentialWriter). The
+        // layout is a big-endian i32 chunk-size header (64 KiB) followed by one
+        // big-endian u32 CRC32 per raw-data chunk. BTI (`da`) tables emit no
+        // CRC.db (verified against the Cassandra-written `da` fixtures), and the
+        // compressed path carries per-chunk CRCs inline (CompressionInfo.db),
+        // so this is gated on the BIG + uncompressed write path only.
+        let crc_path = if is_bti {
+            None
+        } else {
+            use crate::storage::sstable::writer::crc_writer;
+            Some(crc_writer::write_crc_db(&data_path, cpath("CRC.db")).await?)
+        };
+
         // 7. Write TOC.txt (LAST - publication barrier).
         //
         // The TOC lists exactly the component set actually written. BIG lists
@@ -180,6 +195,10 @@ impl SSTableWriter {
             ComponentEntry::new(SSTableComponent::Statistics),
             ComponentEntry::new(SSTableComponent::Digest),
         ]);
+        // CRC.db is listed for uncompressed BIG tables (issue #1197).
+        if crc_path.is_some() {
+            components.push(ComponentEntry::new(SSTableComponent::Crc));
+        }
         // BIG lists Index.db + Summary.db; BTI (issue #908) omits both.
         if index_path.is_some() {
             components.push(ComponentEntry::new(SSTableComponent::Index));
@@ -216,6 +235,7 @@ impl SSTableWriter {
             rows_path,
             toc_path,
             digest_path,
+            crc_path,
             partition_count: self.partition_count,
             data_size,
         })

--- a/cqlite-core/src/storage/sstable/writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/mod.rs
@@ -35,6 +35,8 @@ pub mod compressed_data_writer;
 #[cfg(feature = "write-support")]
 pub mod compression_info_writer;
 #[cfg(feature = "write-support")]
+pub mod crc_writer;
+#[cfg(feature = "write-support")]
 pub mod data_writer;
 #[cfg(feature = "write-support")]
 pub mod digest_writer;
@@ -179,6 +181,14 @@ pub struct SSTableInfo {
     pub toc_path: PathBuf,
     /// Path to the Digest.crc32 file
     pub digest_path: PathBuf,
+    /// Path to the `CRC.db` per-chunk checksum file.
+    ///
+    /// `Some` for uncompressed BIG (`nb`) SSTables, which Cassandra 5.0 always
+    /// emits alongside `Digest.crc32` (issue #1197). `None` for BTI (`da`)
+    /// tables and for the compressed path (compressed tables carry per-chunk
+    /// CRCs inline and describe them in `CompressionInfo.db`, so they have no
+    /// `CRC.db`).
+    pub crc_path: Option<PathBuf>,
     /// Number of partitions written
     pub partition_count: usize,
     /// Total size of Data.db file in bytes

--- a/cqlite-core/src/storage/write_engine/compaction.rs
+++ b/cqlite-core/src/storage/write_engine/compaction.rs
@@ -319,6 +319,11 @@ impl WriteEngine {
         }
         non_toc.push(&tmp_info.stats_path);
         non_toc.push(&tmp_info.digest_path);
+        // CRC.db is emitted for uncompressed BIG output (issue #1197); rename it
+        // when present so the published SSTable keeps its per-chunk CRC file.
+        if let Some(ref p) = tmp_info.crc_path {
+            non_toc.push(p);
+        }
         for src in non_toc {
             renames.push(make_rename(src)?);
         }
@@ -440,6 +445,9 @@ impl WriteEngine {
         }
         byte_paths.push(&tmp_info.stats_path);
         byte_paths.push(&tmp_info.digest_path);
+        if let Some(ref p) = tmp_info.crc_path {
+            byte_paths.push(p);
+        }
         if let Some(ref p) = tmp_info.partitions_path {
             byte_paths.push(p);
         }

--- a/cqlite-core/src/storage/write_engine/export.rs
+++ b/cqlite-core/src/storage/write_engine/export.rs
@@ -118,7 +118,14 @@ impl ExportReport {
             .sum()
     }
 
-    /// Check if all expected components exist
+    /// Check that all expected components exist.
+    ///
+    /// Two layers of validation:
+    /// 1. The always-required components must have been exported.
+    /// 2. Every component listed in the exported `TOC.txt` must have a matching
+    ///    file in `self.components`. This catches optional components — such as
+    ///    `CRC.db` for uncompressed BIG SSTables (Issue #1197) — that the
+    ///    TOC references but that may have been missed during the copy step.
     pub fn validate_components(&self) -> Result<()> {
         let required_components = [
             "Data.db",
@@ -131,16 +138,59 @@ impl ExportReport {
         ];
 
         for component in &required_components {
-            let exists = self.components.iter().any(|p| {
-                p.file_name()
-                    .and_then(|n| n.to_str())
-                    .map(|s| s.ends_with(component))
-                    .unwrap_or(false)
-            });
-
-            if !exists {
+            if !self.has_component(component) {
                 return Err(Error::Storage(format!(
                     "Missing required component: {}",
+                    component
+                )));
+            }
+        }
+
+        self.validate_toc_components()?;
+
+        Ok(())
+    }
+
+    /// Returns true when an exported component path ends with `suffix`.
+    fn has_component(&self, suffix: &str) -> bool {
+        self.components.iter().any(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .map(|s| s.ends_with(suffix))
+                .unwrap_or(false)
+        })
+    }
+
+    /// Validate that every component named in the exported `TOC.txt` was
+    /// actually copied. The TOC is the authoritative component manifest, so
+    /// any optional component it lists (e.g. `CRC.db`) must exist on disk.
+    fn validate_toc_components(&self) -> Result<()> {
+        let toc_path = self
+            .components
+            .iter()
+            .find(|p| {
+                p.file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|s| s.ends_with("TOC.txt"))
+                    .unwrap_or(false)
+            })
+            .ok_or_else(|| Error::Storage("Missing required component: TOC.txt".to_string()))?;
+
+        let toc = std::fs::read_to_string(toc_path).map_err(|e| {
+            Error::Storage(format!(
+                "Failed to read exported TOC.txt at {:?}: {}",
+                toc_path, e
+            ))
+        })?;
+
+        for line in toc.lines() {
+            let component = line.trim();
+            if component.is_empty() {
+                continue;
+            }
+            if !self.has_component(component) {
+                return Err(Error::Storage(format!(
+                    "TOC.txt lists component {} but it was not exported",
                     component
                 )));
             }
@@ -316,8 +366,12 @@ impl crate::storage::write_engine::WriteEngine {
         // Get the source generation number from the SSTable info
         let (source_generation, source_dir) = source_sstable;
 
-        // List of components to copy
-        // CompressionInfo.db is omitted for uncompressed data (Issue #429)
+        // List of components to copy.
+        // CompressionInfo.db is omitted for uncompressed data (Issue #429).
+        // CRC.db is an optional component emitted only for uncompressed BIG
+        // SSTables (Issue #1197) and absent for compressed/BTI tables — the
+        // loop below skips any component whose source file does not exist, so
+        // it is only copied when the source actually has it.
         let components_to_copy = [
             ("Data.db", SSTableComponent::Data),
             ("Index.db", SSTableComponent::Index),
@@ -325,6 +379,7 @@ impl crate::storage::write_engine::WriteEngine {
             ("Filter.db", SSTableComponent::Filter),
             ("Summary.db", SSTableComponent::Summary),
             ("Digest.crc32", SSTableComponent::Digest),
+            ("CRC.db", SSTableComponent::Crc),
             ("TOC.txt", SSTableComponent::TOC),
         ];
 
@@ -981,6 +1036,72 @@ mod tests {
         // Manual validation should pass
         let validation_result = report.validate_components();
         assert!(validation_result.is_ok());
+    }
+
+    /// Issue #1197: uncompressed BIG SSTables now emit a `CRC.db` component
+    /// listed in TOC.txt. The export-copy path must copy it (when the source
+    /// has it) and validation — which now cross-checks every TOC-listed
+    /// component — must pass. This pins both halves of the roborev follow-up
+    /// against an in-process flushed SSTable (no external fixture required).
+    #[tokio::test]
+    async fn test_export_copies_crc_db_when_present() {
+        let temp_dir = TempDir::new().unwrap();
+        let export_dir = TempDir::new().unwrap();
+        let schema = create_test_schema();
+
+        let config = WriteEngineConfig::new(
+            temp_dir.path().join("data"),
+            temp_dir.path().join("wal"),
+            schema,
+        );
+
+        let mut engine = WriteEngine::new(config).unwrap();
+
+        for i in 0..3 {
+            let mutation = create_test_mutation(i, &format!("User{}", i), 1_000_000 + i as i64);
+            engine.write(mutation).unwrap();
+        }
+        engine.flush().await.unwrap();
+
+        // Confirm the flushed (uncompressed BIG) source actually has a CRC.db;
+        // if a future writer change drops it, this guard makes the intent clear
+        // rather than silently passing.
+        let source = engine.find_most_recent_sstable().await.unwrap();
+        let (source_gen, source_dir) = source;
+        let source_crc = source_dir.join(format!("nb-{}-big-CRC.db", source_gen));
+        assert!(
+            source_crc.exists(),
+            "uncompressed BIG flush should emit CRC.db at {:?}",
+            source_crc
+        );
+
+        // Export WITH validation enabled (default) — exercises both the copy
+        // path and the TOC-aware validate_components().
+        let options = ExportOptions::new("test_ks", "test_table", 1).skip_compaction();
+        let report = engine
+            .export_sstable(export_dir.path(), options)
+            .await
+            .unwrap();
+
+        let crc_file = export_dir
+            .path()
+            .join("test_ks")
+            .join("test_table")
+            .join("nb-1-big-CRC.db");
+        assert!(
+            crc_file.exists(),
+            "export must copy CRC.db when the source SSTable has it"
+        );
+
+        // The copied CRC.db must be among the tracked components.
+        assert!(
+            report.has_component("CRC.db"),
+            "exported component list must include CRC.db"
+        );
+
+        // Validation passed implicitly via validate_after_export default; assert
+        // explicitly too for clarity.
+        report.validate_components().unwrap();
     }
 
     #[tokio::test]

--- a/cqlite-core/src/storage/write_engine/maintenance.rs
+++ b/cqlite-core/src/storage/write_engine/maintenance.rs
@@ -601,6 +601,10 @@ impl WriteEngine {
             "Summary.db",
             "Statistics.db",
             "CompressionInfo.db",
+            // CRC.db is the per-chunk CRC for uncompressed BIG SSTables
+            // (Issue #1197); without it deletion/compaction would leave an
+            // orphan file. Best-effort like the other optional components.
+            "CRC.db",
             "Filter.db",
             "Digest.crc32",
         ];

--- a/cqlite-core/tests/issue_1190_write_load_byte_parity.rs
+++ b/cqlite-core/tests/issue_1190_write_load_byte_parity.rs
@@ -47,13 +47,13 @@
 //!     both, but their bytes are an implementation detail, not a parity target.
 //!     Their semantic content is covered elsewhere (Filter membership, Statistics
 //!     min/max/EncodingStats are anchored by issue_764 / issue_821).
-//!   * CRC.db → KNOWN WRITER GAP: Cassandra emits an (uncompressed-chunk) CRC.db
-//!     component even for uncompressed BIG SSTables; CQLite's writer does not yet
-//!     emit it (the READ side recognizes it — see
-//!     cass.sstable_format.toc_component_manifest). This is a real
-//!     component-completeness gap recorded as a pinned reference-only assertion
-//!     below (the reference HAS CRC.db, CQLite does NOT). It is tracked as a
-//!     separate writer issue; it does not affect any emitted file's bytes.
+//!   * CRC.db → BYTE-IDENTICAL (issue #1197, gap now closed): Cassandra emits a
+//!     per-chunk CRC.db component for uncompressed BIG SSTables alongside
+//!     Digest.crc32. CQLite's writer now emits it too — a 64 KiB chunk-size
+//!     header (big-endian i32) followed by one big-endian u32 CRC32 per raw-data
+//!     chunk (ChecksummedSequentialWriter / ChecksumWriter). Because Data.db is
+//!     byte-identical and the chunk size matches Cassandra's 64 KiB default, the
+//!     CRC.db bytes match exactly and are diffed byte-for-byte below.
 //!
 //! Dataset-dependency doctrine (issue #719 / parity mandate):
 //!   * If `CQLITE_DATASETS_ROOT` is unset OR the reference Data.db is genuinely
@@ -356,6 +356,9 @@ async fn assert_byte_parity(
         "Statistics.db",
         "Filter.db",
         "TOC.txt",
+        // CRC.db is now emitted by CQLite for uncompressed BIG SSTables
+        // (issue #1197), matching Cassandra. Both sides must carry it.
+        "CRC.db",
     ] {
         assert!(
             ref_components.contains(needed),
@@ -366,25 +369,11 @@ async fn assert_byte_parity(
             "{table}: CQLite output missing component {needed}; have {our_components:?}"
         );
     }
-    // Pinned KNOWN GAP: Cassandra emits CRC.db for uncompressed BIG SSTables;
-    // CQLite's writer does not yet. If this ever flips (CQLite starts emitting
-    // CRC.db), this assertion fails and forces a manifest review — we must never
-    // silently claim component-set parity while a component is missing.
-    assert!(
-        ref_components.contains("CRC.db"),
-        "{table}: reference unexpectedly lacks CRC.db (regenerate fixtures?)"
-    );
-    assert!(
-        !our_components.contains("CRC.db"),
-        "{table}: CQLite now emits CRC.db — the known writer gap is closed; \
-         re-evaluate write_load_path component-set parity in the manifest"
-    );
 
     // No spurious CQLite-only component: every component CQLite emits must be
-    // present in the reference. The CRC.db asymmetry is the OTHER direction
-    // (reference-only), so it does not appear here; if a future carve-out for a
-    // CQLite-only component is ever needed it must be added to this allow-list
-    // (currently empty) with a documented rationale.
+    // present in the reference. With CRC.db now emitted (issue #1197) the
+    // component sets are symmetric for the uncompressed BIG path; the allow-list
+    // stays empty and any CQLite-only component is a regression.
     const CQLITE_ONLY_ALLOWED: &[&str] = &[];
     let spurious: Vec<&String> = our_components
         .difference(&ref_components)
@@ -397,16 +386,18 @@ async fn assert_byte_parity(
          add to CQLITE_ONLY_ALLOWED with a documented rationale"
     );
 
-    // 2. TOC.txt: every component CQLite lists must match the reference TOC; the
-    //    only allowed difference is the known-missing CRC.db line.
+    // 2. TOC.txt: the component SET CQLite lists must match the reference TOC
+    //    exactly. With CRC.db now emitted (issue #1197) there is no longer a
+    //    carve-out — the uncompressed BIG component set is identical.
     let ref_toc = toc_set(&read_component(&ref_dir, "TOC.txt"));
     let our_toc = toc_set(&std::fs::read(out_dir.join("nb-1-big-TOC.txt")).expect("our TOC"));
-    let ref_toc_no_crc: BTreeSet<String> =
-        ref_toc.iter().filter(|c| *c != "CRC.db").cloned().collect();
+    assert!(
+        ref_toc.contains("CRC.db"),
+        "{table}: reference TOC unexpectedly lacks CRC.db (regenerate fixtures?)"
+    );
     assert_eq!(
-        ref_toc_no_crc, our_toc,
-        "{table}: TOC.txt component set differs beyond the known CRC.db gap \
-         (cass-minus-CRC={ref_toc_no_crc:?} ours={our_toc:?})"
+        ref_toc, our_toc,
+        "{table}: TOC.txt component set differs (cass={ref_toc:?} ours={our_toc:?})"
     );
 
     // 3. Data.db: full byte equality (row layout, headers, offsets, cells).
@@ -416,10 +407,15 @@ async fn assert_byte_parity(
     //    the partition/row-offset layout). This is the partition-boundary check.
     assert_component_bytes(table, &ref_dir, &out_dir, "Index.db");
 
-    // 5. Summary.db + Digest.crc32: full byte equality (summary offset index and
-    //    whole-file CRC32). Completes the deterministic byte-parity component set.
+    // 5. Summary.db + Digest.crc32 + CRC.db: full byte equality (summary offset
+    //    index, whole-file CRC32, and the per-chunk CRC32 component). Completes
+    //    the deterministic byte-parity component set. CRC.db (issue #1197) is a
+    //    64 KiB-chunk-size header (big-endian i32) followed by one big-endian u32
+    //    CRC32 per raw-data chunk; since Data.db is byte-identical and the chunk
+    //    size matches Cassandra's 64 KiB default, CRC.db is byte-identical too.
     assert_component_bytes(table, &ref_dir, &out_dir, "Summary.db");
     assert_component_bytes(table, &ref_dir, &out_dir, "Digest.crc32");
+    assert_component_bytes(table, &ref_dir, &out_dir, "CRC.db");
 
     // 6. sstabledump JSONL golden: must exist, be non-empty, and contain exactly
     //    the expected partition count. Present-but-empty / 0-rows is a failure.

--- a/cqlite-core/tests/issue_1197_crc_db_uncompressed_parity.rs
+++ b/cqlite-core/tests/issue_1197_crc_db_uncompressed_parity.rs
@@ -1,0 +1,329 @@
+//! Issue #1197: `CRC.db` per-chunk checksum parity for uncompressed BIG SSTables.
+//!
+//! Cassandra 5.0 emits a `CRC.db` component for every UNCOMPRESSED BIG (`nb`)
+//! SSTable (`ChecksummedSequentialWriter` → `ChecksumWriter`), alongside (not
+//! instead of) `Digest.crc32`. CQLite's writer historically emitted only
+//! `Digest.crc32` — a component-completeness gap pinned during issue #1190.
+//!
+//! This test is the FORMAT ORACLE for that component. It does two things:
+//!
+//!   1. ORACLE (reference-only): against the committed Cassandra-written
+//!      `test_writeparity` references, assert the on-disk `CRC.db` layout is
+//!      exactly what the Cassandra source produces:
+//!        * 4-byte big-endian signed `int` header = the data writer's
+//!          `buffer.capacity()`, which defaults to `64 * 1024` (65536). The real
+//!          fixtures store `0x00010000`.
+//!        * one big-endian `u32` CRC32 per chunk of the RAW (uncompressed)
+//!          Data.db bytes (`java.util.zip.CRC32` == `crc32fast`).
+//!        * total length = `4 + 4 * ceil(data_len / chunk_size)` (and exactly
+//!          `4 + 4` for a single-chunk file).
+//!
+//!      Each stored CRC is recomputed from the reference Data.db and compared.
+//!      For a single-chunk file the lone CRC equals the `Digest.crc32` value
+//!      (the per-chunk CRCs are NOT folded into the data digest for the
+//!      uncompressed path), which is also asserted.
+//!
+//!   2. WRITER PARITY: re-emit the same logical table through CQLite's
+//!      `SSTableWriter` and assert it now (a) emits a `CRC.db` component, (b)
+//!      lists `CRC.db` in `TOC.txt`, and (c) produces a byte-identical `CRC.db`
+//!      vs the Cassandra reference (Data.db is byte-identical and the chunk size
+//!      matches, so CRC.db must match too).
+//!
+//! Dataset-dependency doctrine (issue #719 / #1208): the `test_writeparity`
+//! reference binaries are committed (pinned bundle), but this test still uses
+//! the skip-on-presence idiom so a clean checkout WITHOUT the binaries SKIPS
+//! rather than fails. A reference that is PRESENT but malformed (wrong header,
+//! wrong CRC, missing CRC.db) is a FAILURE.
+
+#![cfg(feature = "write-support")]
+
+use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+use cqlite_core::storage::sstable::writer::{SSTableFormat, SSTableWriter};
+use cqlite_core::storage::write_engine::mutation::{
+    CellOperation, DecoratedKey, Mutation, PartitionKey, TableId,
+};
+use cqlite_core::types::Value;
+use std::collections::{BTreeSet, HashMap};
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+const KEYSPACE: &str = "test_writeparity";
+
+/// Cassandra's default uncompressed CRC chunk size
+/// (`SequentialWriterOption.Builder.bufferSize = 64 * 1024`).
+const CRC_CHUNK_SIZE: usize = 64 * 1024;
+
+/// The single fixed writetime (micros) used by the #1190 generator.
+const T_WRITE: i64 = 1_700_000_000_000_000;
+
+// ---------------------------------------------------------------------------
+// Fixture resolution (skip-on-absence; present-but-malformed is a failure)
+// ---------------------------------------------------------------------------
+
+/// Resolve the committed Cassandra reference directory for `table` under
+/// `test_writeparity`. Returns `None` when the dataset root is unset or the
+/// reference Data.db has not been fetched (genuine absence → skip).
+fn reference_dir(table: &str) -> Option<PathBuf> {
+    let root = std::env::var("CQLITE_DATASETS_ROOT").ok()?;
+    let base = Path::new(&root).join("sstables").join(KEYSPACE);
+    for e in std::fs::read_dir(&base).ok()?.flatten() {
+        let name = e.file_name().to_string_lossy().to_string();
+        if name.starts_with(&format!("{table}-")) {
+            let dir = e.path();
+            if dir.join("nb-1-big-Data.db").is_file() {
+                return Some(dir);
+            }
+            return None;
+        }
+    }
+    None
+}
+
+/// Compute the expected `CRC.db` bytes for a raw `Data.db` payload, matching the
+/// Cassandra layout: big-endian i32 chunk-size header + one big-endian u32 CRC32
+/// per `CRC_CHUNK_SIZE` chunk.
+fn expected_crc_bytes(data: &[u8]) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(&(CRC_CHUNK_SIZE as i32).to_be_bytes());
+    for chunk in data.chunks(CRC_CHUNK_SIZE) {
+        let mut hasher = crc32fast::Hasher::new();
+        hasher.update(chunk);
+        out.extend_from_slice(&hasher.finalize().to_be_bytes());
+    }
+    out
+}
+
+/// Assert the Cassandra-written reference `CRC.db` matches the format derived
+/// from the Cassandra source, reconciled against the reference `Data.db`.
+fn assert_reference_crc_format(table: &str, dir: &Path) {
+    let crc_path = dir.join("nb-1-big-CRC.db");
+    let crc = std::fs::read(&crc_path)
+        .unwrap_or_else(|e| panic!("{table}: reference CRC.db {crc_path:?} unreadable: {e}"));
+    assert!(
+        crc.len() >= 4,
+        "{table}: reference CRC.db too short ({} bytes) — must hold at least the 4-byte header",
+        crc.len()
+    );
+
+    // Header: big-endian signed int == chunk size (Cassandra default 64 KiB).
+    let header = i32::from_be_bytes([crc[0], crc[1], crc[2], crc[3]]);
+    assert_eq!(
+        header, CRC_CHUNK_SIZE as i32,
+        "{table}: reference CRC.db header {header} != expected chunk size {CRC_CHUNK_SIZE}"
+    );
+
+    let data = std::fs::read(dir.join("nb-1-big-Data.db"))
+        .unwrap_or_else(|e| panic!("{table}: reference Data.db unreadable: {e}"));
+    assert!(
+        !data.is_empty(),
+        "{table}: reference Data.db present-but-empty — parity failure"
+    );
+
+    // Length contract: 4-byte header + 4 bytes per chunk.
+    let expected_chunks = data.len().div_ceil(CRC_CHUNK_SIZE);
+    assert_eq!(
+        crc.len(),
+        4 + 4 * expected_chunks,
+        "{table}: reference CRC.db length {} != 4 + 4*{expected_chunks}",
+        crc.len()
+    );
+
+    // Each stored CRC must equal CRC32 over the corresponding raw-data chunk.
+    let expected = expected_crc_bytes(&data);
+    assert_eq!(
+        crc, expected,
+        "{table}: reference CRC.db bytes do not reconcile against the reference Data.db \
+         (per-chunk CRC32 mismatch)"
+    );
+
+    // Single-chunk invariant: the lone CRC == Digest.crc32 (per-chunk CRCs are
+    // NOT folded into the data digest on the uncompressed path).
+    if expected_chunks == 1 {
+        let digest_text = std::fs::read_to_string(dir.join("nb-1-big-Digest.crc32"))
+            .unwrap_or_else(|e| panic!("{table}: reference Digest.crc32 unreadable: {e}"));
+        let digest: u32 = digest_text
+            .trim()
+            .parse()
+            .unwrap_or_else(|e| panic!("{table}: Digest.crc32 not a decimal u32: {e}"));
+        let lone = u32::from_be_bytes([crc[4], crc[5], crc[6], crc[7]]);
+        assert_eq!(
+            lone, digest,
+            "{table}: single-chunk CRC.db value {lone} != Digest.crc32 {digest}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CQLite writer harness (re-emit the same logical table)
+// ---------------------------------------------------------------------------
+
+async fn cqlite_write(schema: &TableSchema, mutations: Vec<Mutation>) -> (TempDir, PathBuf) {
+    let dir = TempDir::new().expect("tempdir");
+    let mut writer =
+        SSTableWriter::with_format(dir.path().to_path_buf(), 1, schema, 16, SSTableFormat::Big)
+            .expect("writer");
+
+    let mut keyed: Vec<(DecoratedKey, Mutation)> = mutations
+        .into_iter()
+        .map(|m| (m.decorated_key(schema).expect("decorated key"), m))
+        .collect();
+    keyed.sort_by_key(|(k, _)| k.token);
+
+    let mut grouped: Vec<(DecoratedKey, Vec<Mutation>)> = Vec::new();
+    for (k, m) in keyed {
+        match grouped.last_mut() {
+            Some((lk, ms)) if lk.token == k.token && lk.key == k.key => ms.push(m),
+            _ => grouped.push((k, vec![m])),
+        }
+    }
+    for (k, ms) in grouped {
+        writer.write_partition(k, ms).expect("write_partition");
+    }
+    let info = writer.finish().await.expect("finish");
+    // The writer must now report a CRC.db path for the uncompressed BIG output.
+    assert!(
+        info.crc_path.as_ref().is_some_and(|p| p.is_file()),
+        "writer did not emit a CRC.db component (info.crc_path={:?})",
+        info.crc_path
+    );
+    let table_dir = info.data_path.parent().expect("data parent").to_path_buf();
+    (dir, table_dir)
+}
+
+/// `finished_data` schema/data — must match the #1190 generator exactly so the
+/// re-emitted Data.db (and therefore CRC.db) is byte-identical.
+fn finished_schema() -> TableSchema {
+    TableSchema {
+        keyspace: KEYSPACE.into(),
+        table: "finished_data".into(),
+        partition_keys: vec![KeyColumn {
+            name: "id".into(),
+            data_type: "int".into(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            Column {
+                name: "id".into(),
+                data_type: "int".into(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "name".into(),
+                data_type: "text".into(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+fn finished_mutations() -> Vec<Mutation> {
+    (0..6)
+        .map(|i| {
+            Mutation::new(
+                TableId::new(KEYSPACE, "finished_data"),
+                PartitionKey::single("id", Value::Integer(i)),
+                None,
+                vec![CellOperation::Write {
+                    column: "name".into(),
+                    value: Value::Text(format!("name{i}")),
+                }],
+                T_WRITE,
+                None,
+            )
+        })
+        .collect()
+}
+
+fn toc_set(toc_bytes: &[u8]) -> BTreeSet<String> {
+    String::from_utf8_lossy(toc_bytes)
+        .lines()
+        .map(|l| l.trim().to_string())
+        .filter(|l| !l.is_empty())
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// ORACLE: the on-disk `CRC.db` of every committed Cassandra `test_writeparity`
+/// reference matches the format derived from the Cassandra 5.0 source.
+#[test]
+fn cassandra_reference_crc_db_format_oracle() {
+    let mut checked = 0usize;
+    for table in [
+        "finished_data",
+        "partition_boundary",
+        "static_clustering_shape",
+    ] {
+        let Some(dir) = reference_dir(table) else {
+            eprintln!("[issue_1197] reference {KEYSPACE}.{table} absent; skipping");
+            continue;
+        };
+        assert!(
+            dir.join("nb-1-big-CRC.db").is_file(),
+            "{table}: present reference is missing CRC.db (broken fixture)"
+        );
+        assert_reference_crc_format(table, &dir);
+        checked += 1;
+    }
+    if checked == 0 {
+        eprintln!("[issue_1197] no references present; oracle skipped");
+    }
+}
+
+/// WRITER PARITY: CQLite re-emits `finished_data` and now produces a `CRC.db`
+/// component that is byte-identical to the Cassandra reference, and lists it in
+/// `TOC.txt`.
+#[tokio::test]
+async fn cqlite_emits_byte_identical_crc_db() {
+    let Some(ref_dir) = reference_dir("finished_data") else {
+        eprintln!("[issue_1197] reference finished_data absent; skipping writer parity");
+        return;
+    };
+
+    let (_guard, out_dir) = cqlite_write(&finished_schema(), finished_mutations()).await;
+
+    // (a) writer emitted the component file.
+    let our_crc_path = out_dir.join("nb-1-big-CRC.db");
+    assert!(
+        our_crc_path.is_file(),
+        "CQLite did not write CRC.db to {our_crc_path:?}"
+    );
+
+    // (b) TOC.txt lists CRC.db.
+    let our_toc = toc_set(&std::fs::read(out_dir.join("nb-1-big-TOC.txt")).expect("our TOC"));
+    assert!(
+        our_toc.contains("CRC.db"),
+        "CQLite TOC.txt does not list CRC.db (toc={our_toc:?})"
+    );
+
+    // (c) byte-for-byte vs the Cassandra reference.
+    let reference = std::fs::read(ref_dir.join("nb-1-big-CRC.db")).expect("reference CRC.db");
+    let ours = std::fs::read(&our_crc_path).expect("our CRC.db");
+    assert_eq!(
+        ours,
+        reference,
+        "CRC.db byte mismatch\n  cass={}\n  ours={}",
+        reference
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect::<String>(),
+        ours.iter().map(|b| format!("{b:02x}")).collect::<String>(),
+    );
+
+    // And it reconciles against our own Data.db.
+    let our_data = std::fs::read(out_dir.join("nb-1-big-Data.db")).expect("our Data.db");
+    assert_eq!(
+        ours,
+        expected_crc_bytes(&our_data),
+        "CQLite CRC.db does not reconcile against its own Data.db"
+    );
+}

--- a/cqlite-core/tests/issue_819_differential_compaction.rs
+++ b/cqlite-core/tests/issue_819_differential_compaction.rs
@@ -1021,6 +1021,7 @@ fn ref_sstable_info(data_path: &Path) -> cqlite_core::storage::sstable::writer::
         rows_path: opt("Rows.db"),
         toc_path: comp("TOC.txt"),
         digest_path: comp("Digest.crc32"),
+        crc_path: opt("CRC.db"),
         partition_count: 0,
         data_size,
     }


### PR DESCRIPTION
Closes #1197 (P0; MGR \`mgr-mbp-0628\` ORDER 2). Oracle-driven (Cassandra component set is truth) → no OpenSpec.

## Problem
The writer emitted \`Digest.crc32\` but not the \`CRC.db\` per-chunk CRC component that Cassandra 5.0.2 emits even for **uncompressed** BIG tables — a TOC component-completeness gap (read side already recognized \`CRC.db\`). Found during #1190.

## Derived format (oracle: Cassandra `ChecksummedSequentialWriter`/`ChecksumWriter` + committed fixtures)
\`\`\`
[chunk size : 4B big-endian i32 = 64 KiB default]
[CRC32 chunk 0 : 4B big-endian] [CRC32 chunk 1 ...]   # CRC32 over raw uncompressed Data.db blocks
\`\`\`
BTI (\`da\`) tables emit no CRC.db; compressed tables use CompressionInfo.db (both left intact). For a single-chunk file the lone CRC == \`Digest.crc32\` (verified).

## Change
- New \`writer/crc_writer.rs\` (streams Data.db in 64 KiB blocks → CRC.db); wired into \`finish.rs\` (gated on \`!is_bti\`), TOC component set, and \`SSTableInfo.crc_path\`.
- Atomic-publish + compaction rename/accounting include CRC.db.
- **roborev follow-ups (this PR):** \`export_sstable()\` now copies CRC.db when present + validates **TOC-listed** components (not just a fixed set); deletion cleanup removes CRC.db (no orphans).

## Verification
- **Pinned parity** (\`issue_1197_crc_db_uncompressed_parity.rs\`, skip-on-presence): byte-identical CRC.db vs 3 Cassandra references (\`test_writeparity/*\`, git-tracked in the pinned bundle), TOC-set parity, CRC↔Data.db reconciliation, single-chunk CRC == Digest. Proven to EXERCISE (negative-control: unset datasets → loud SKIP; set → assertions run).
- **#1190** upgraded to diff CRC.db byte-for-byte.
- **Gate-of-record:** all 14 components PASS (with \`CQLITE_ALLOW_FILE_GROWTH=1\` for pre-existing over-threshold \`writer/mod.rs\` + \`issue_819\` test, per #1116/#1135).
- **roborev (codex):** No issues found.

Out of scope (left untouched): #1196 static-row spurious row-level HAS_TIMESTAMP (still pinned \`partial\` in #1190).