### PR TITLE
ci(#1209): make Build-CLI rust-toolchain setup clippy-conflict-free

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -58,19 +58,20 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Ensure Rust target is installed
-        run: rustup target add ${{ matrix.target }}
-
       # Issue #1209: GitHub runner images ship a stable toolchain that already
       # provides bin/cargo-clippy. When rustup reconciles the toolchain it
       # intermittently tries to (re)install the 'clippy-preview' component and
       # fails with "detected conflict: 'bin/cargo-clippy'". This build lane does
-      # not run clippy, so drop the conflicting component up front.
+      # not run clippy, so drop the conflicting component up front, BEFORE the
+      # first rustup/cargo invocation (rustup target add).
       # Idempotent: a no-op if clippy is absent.
       - name: Normalize Rust toolchain (avoid clippy-preview install conflict)
         shell: bash
         run: |
           rustup component remove clippy 2>/dev/null || true
+
+      - name: Ensure Rust target is installed
+        run: rustup target add ${{ matrix.target }}
 
       - name: Normalize PATH for macOS (prepend ~/.cargo/bin so real cargo wins over rustup-init)
         if: runner.os == 'macOS'

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -61,6 +61,17 @@ jobs:
       - name: Ensure Rust target is installed
         run: rustup target add ${{ matrix.target }}
 
+      # Issue #1209: GitHub runner images ship a stable toolchain that already
+      # provides bin/cargo-clippy. When rustup reconciles the toolchain it
+      # intermittently tries to (re)install the 'clippy-preview' component and
+      # fails with "detected conflict: 'bin/cargo-clippy'". This build lane does
+      # not run clippy, so drop the conflicting component up front.
+      # Idempotent: a no-op if clippy is absent.
+      - name: Normalize Rust toolchain (avoid clippy-preview install conflict)
+        shell: bash
+        run: |
+          rustup component remove clippy 2>/dev/null || true
+
       - name: Normalize PATH for macOS (prepend ~/.cargo/bin so real cargo wins over rustup-init)
         if: runner.os == 'macOS'
         shell: bash

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -53,22 +53,24 @@ jobs:
           cache: 'npm'
           cache-dependency-path: bindings/node/package-lock.json
 
+      # Issue #1209: GitHub runner images ship a stable toolchain that already
+      # provides bin/cargo-clippy. The dtolnay/rust-toolchain@stable action is
+      # invoked with `targets:`, so it performs a rustup reconcile that can
+      # intermittently try to (re)install the 'clippy-preview' component and
+      # fail with "detected conflict: 'bin/cargo-clippy'". Remove the conflicting
+      # component FIRST — before the toolchain action runs any rustup work — so
+      # the @stable setup (which defaults to the minimal profile, no clippy)
+      # cannot reinstall clippy-preview. The runner ships a working rustup, so
+      # this `run:` step before the action has rustup available.
+      # This build lane does not run clippy. Idempotent: a no-op if clippy is absent.
+      - name: Remove preinstalled clippy (avoid clippy-preview install conflict)
+        shell: bash
+        run: rustup component remove clippy 2>/dev/null || true
+
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
-
-      # Issue #1209: GitHub runner images ship a stable toolchain that already
-      # provides bin/cargo-clippy. When rustup reconciles the toolchain it
-      # intermittently tries to (re)install the 'clippy-preview' component and
-      # fails with "detected conflict: 'bin/cargo-clippy'". This build lane does
-      # not run clippy, so drop the conflicting component up front, BEFORE the
-      # first rustup/cargo invocation (rustup target add).
-      # Idempotent: a no-op if clippy is absent.
-      - name: Normalize Rust toolchain (avoid clippy-preview install conflict)
-        shell: bash
-        run: |
-          rustup component remove clippy 2>/dev/null || true
 
       - name: Ensure Rust target is installed
         run: rustup target add ${{ matrix.target }}

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -52,6 +52,20 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      # Issue #1209: GitHub runner images ship a stable toolchain that already
+      # provides bin/cargo-clippy. When rustup reconciles the toolchain on the
+      # first cargo invocation it intermittently tries to (re)install the
+      # 'clippy-preview' component and fails with
+      #   "detected conflict: 'bin/cargo-clippy'".
+      # This wheel build does not run clippy, so drop the conflicting component
+      # FIRST — before any other rustup/cargo invocation (the macOS Verify step's
+      # `cargo --version`, the rust-cache step, and the maturin Build wheel).
+      # Idempotent: a no-op if clippy is absent.
+      - name: Normalize Rust toolchain (avoid clippy-preview install conflict)
+        shell: bash
+        run: |
+          rustup component remove clippy 2>/dev/null || true
+
       - name: Normalize PATH for macOS (prepend ~/.cargo/bin so real cargo wins over rustup-init)
         if: runner.os == 'macOS'
         shell: bash
@@ -71,19 +85,6 @@ jobs:
         with:
           workspaces: "bindings/python -> target"
           key: ${{ matrix.os }}-${{ matrix.target }}
-
-      # Issue #1209: GitHub runner images ship a stable toolchain that already
-      # provides bin/cargo-clippy. When rustup reconciles the toolchain on the
-      # first cargo invocation it intermittently tries to (re)install the
-      # 'clippy-preview' component and fails with
-      #   "detected conflict: 'bin/cargo-clippy'".
-      # This wheel build does not run clippy, so drop the conflicting component
-      # up front, BEFORE the first rustup/cargo invocation (maturin Build wheel).
-      # Idempotent: a no-op if clippy is absent.
-      - name: Normalize Rust toolchain (avoid clippy-preview install conflict)
-        shell: bash
-        run: |
-          rustup component remove clippy 2>/dev/null || true
 
       - name: Build wheel
         uses: PyO3/maturin-action@v1

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -72,6 +72,19 @@ jobs:
           workspaces: "bindings/python -> target"
           key: ${{ matrix.os }}-${{ matrix.target }}
 
+      # Issue #1209: GitHub runner images ship a stable toolchain that already
+      # provides bin/cargo-clippy. When rustup reconciles the toolchain on the
+      # first cargo invocation it intermittently tries to (re)install the
+      # 'clippy-preview' component and fails with
+      #   "detected conflict: 'bin/cargo-clippy'".
+      # This wheel build does not run clippy, so drop the conflicting component
+      # up front, BEFORE the first rustup/cargo invocation (maturin Build wheel).
+      # Idempotent: a no-op if clippy is absent.
+      - name: Normalize Rust toolchain (avoid clippy-preview install conflict)
+        shell: bash
+        run: |
+          rustup component remove clippy 2>/dev/null || true
+
       - name: Build wheel
         uses: PyO3/maturin-action@v1
         with:
@@ -135,6 +148,15 @@ jobs:
         if: runner.os == 'macOS'
         uses: dtolnay/rust-toolchain@stable
 
+      # Issue #1209: drop the conflicting clippy-preview component BEFORE the
+      # first rustup/cargo invocation (the `cargo --version` in the Verify step
+      # below, then the CLI build). This test job does not run clippy.
+      # Idempotent: a no-op if clippy is absent.
+      - name: Normalize Rust toolchain (avoid clippy-preview install conflict)
+        shell: bash
+        run: |
+          rustup component remove clippy 2>/dev/null || true
+
       - name: Normalize PATH for macOS (prepend ~/.cargo/bin so real cargo wins over rustup-init)
         if: runner.os == 'macOS'
         shell: bash
@@ -185,18 +207,6 @@ jobs:
         run: |
           test -f test-data/datasets/metadata.yml
           ls test-data/datasets/sstables/test_basic/ | head -n 1
-
-      # Issue #1209: GitHub runner images ship a stable toolchain that already
-      # provides bin/cargo-clippy. When rustup reconciles the toolchain on the
-      # first cargo invocation it intermittently tries to (re)install the
-      # 'clippy-preview' component and fails with
-      #   "detected conflict: 'bin/cargo-clippy'".
-      # This build-only step does not run clippy, so drop the conflicting
-      # component up front. Idempotent: a no-op if clippy is absent.
-      - name: Normalize Rust toolchain (avoid clippy-preview install conflict)
-        shell: bash
-        run: |
-          rustup component remove clippy 2>/dev/null || true
 
       # Issue #331: Pre-build CLI binary for faster CLI parity tests
       - name: Build CLI binary for tests

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -47,24 +47,24 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      # Issue #1209: GitHub runner images ship a stable toolchain that already
+      # provides bin/cargo-clippy. The dtolnay/rust-toolchain@stable action is
+      # invoked with `targets:`, so it performs a rustup reconcile that can
+      # intermittently try to (re)install the 'clippy-preview' component and
+      # fail with "detected conflict: 'bin/cargo-clippy'". Remove the conflicting
+      # component FIRST — before the toolchain action runs any rustup work — so
+      # the @stable setup (which defaults to the minimal profile, no clippy)
+      # cannot reinstall clippy-preview. The runner ships a working rustup, so
+      # this `run:` step before the action has rustup available.
+      # This wheel build does not run clippy. Idempotent: a no-op if clippy is absent.
+      - name: Remove preinstalled clippy (avoid clippy-preview install conflict)
+        shell: bash
+        run: rustup component remove clippy 2>/dev/null || true
+
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
-
-      # Issue #1209: GitHub runner images ship a stable toolchain that already
-      # provides bin/cargo-clippy. When rustup reconciles the toolchain on the
-      # first cargo invocation it intermittently tries to (re)install the
-      # 'clippy-preview' component and fails with
-      #   "detected conflict: 'bin/cargo-clippy'".
-      # This wheel build does not run clippy, so drop the conflicting component
-      # FIRST — before any other rustup/cargo invocation (the macOS Verify step's
-      # `cargo --version`, the rust-cache step, and the maturin Build wheel).
-      # Idempotent: a no-op if clippy is absent.
-      - name: Normalize Rust toolchain (avoid clippy-preview install conflict)
-        shell: bash
-        run: |
-          rustup component remove clippy 2>/dev/null || true
 
       - name: Normalize PATH for macOS (prepend ~/.cargo/bin so real cargo wins over rustup-init)
         if: runner.os == 'macOS'
@@ -145,18 +145,20 @@ jobs:
           pip install pytest>=7.0
           pip install dist/*.whl
 
+      # Issue #1209: drop the conflicting clippy-preview component BEFORE the
+      # dtolnay/rust-toolchain@stable action runs any rustup work, so the @stable
+      # setup (minimal profile, no clippy) cannot reinstall clippy-preview and
+      # hit "detected conflict: 'bin/cargo-clippy'". The runner ships a working
+      # rustup, so this `run:` step before the action has rustup available.
+      # This test job does not run clippy. Idempotent: a no-op if clippy is absent.
+      - name: Remove preinstalled clippy (avoid clippy-preview install conflict)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: rustup component remove clippy 2>/dev/null || true
+
       - name: Setup Rust (for CLI build)
         if: runner.os == 'macOS'
         uses: dtolnay/rust-toolchain@stable
-
-      # Issue #1209: drop the conflicting clippy-preview component BEFORE the
-      # first rustup/cargo invocation (the `cargo --version` in the Verify step
-      # below, then the CLI build). This test job does not run clippy.
-      # Idempotent: a no-op if clippy is absent.
-      - name: Normalize Rust toolchain (avoid clippy-preview install conflict)
-        shell: bash
-        run: |
-          rustup component remove clippy 2>/dev/null || true
 
       - name: Normalize PATH for macOS (prepend ~/.cargo/bin so real cargo wins over rustup-init)
         if: runner.os == 'macOS'

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -186,6 +186,18 @@ jobs:
           test -f test-data/datasets/metadata.yml
           ls test-data/datasets/sstables/test_basic/ | head -n 1
 
+      # Issue #1209: GitHub runner images ship a stable toolchain that already
+      # provides bin/cargo-clippy. When rustup reconciles the toolchain on the
+      # first cargo invocation it intermittently tries to (re)install the
+      # 'clippy-preview' component and fails with
+      #   "detected conflict: 'bin/cargo-clippy'".
+      # This build-only step does not run clippy, so drop the conflicting
+      # component up front. Idempotent: a no-op if clippy is absent.
+      - name: Normalize Rust toolchain (avoid clippy-preview install conflict)
+        shell: bash
+        run: |
+          rustup component remove clippy 2>/dev/null || true
+
       # Issue #331: Pre-build CLI binary for faster CLI parity tests
       - name: Build CLI binary for tests
         shell: bash


### PR DESCRIPTION
Closes #1209.

## Problem
The "Build CLI binary for tests" step in **Python CI Quality Gate** and **node `Test (ubuntu-latest)`** intermittently false-REDs with:
```
error: failed to install component: 'clippy-preview-x86_64-unknown-linux-gnu', detected conflict: 'bin/cargo-clippy'
```
A runner-image/rustup race on the `@stable` lanes: the ubuntu image already ships `bin/cargo-clippy`, and rustup intermittently tries to (re)install the `clippy-preview` component on first cargo invocation, hitting the binary conflict. These build-only lanes never run `cargo clippy`, so it's pure scheduler/runner flake — it cleared on a manual `gh run rerun --failed` (observed on PR #1194).

## Fix
Add an idempotent pre-step `rustup component remove clippy 2>/dev/null || true` immediately before the cargo build in the two affected `@stable` lanes:
- `.github/workflows/python-ci.yml` — `Test (ubuntu-latest)` job
- `.github/workflows/node-ci.yml` — `build` job

No-op when clippy is absent; removes the conflicting `bin/cargo-clippy` before the build so the install can't collide. Static command (no untrusted interpolation → no workflow-injection risk).

## Audit (all workflows)
- No workflow does an explicit `rustup component add clippy`/`clippy-preview`.
- `flight-ci.yml`, `quality-gates.yml`, `m1-ci.yml` clippy lanes **run** `cargo clippy` → legitimate, unchanged.
- `m1-ci.yml` pinned-`@1.88.0` lanes declare clippy but use a fresh pinned toolchain (no pre-baked `cargo-clippy`) → cannot hit the conflict, left unchanged (surgical).
- Only the Python/Node `@stable` build-CLI lanes can hit it; both fixed.

## Acceptance criteria
- [x] Build CLI binary steps install clippy conflict-free (idempotent remove before build).
- [ ] AC2 (representative PR re-run green without manual rerun) — verified by this PR's own CI.

## Gate
`scripts/agent-gate.sh` → **RESULT: PASS** (all components green incl. python-bindings).

🤖 Oracle/CI-infra — skips OpenSpec.