### PR TITLE
fix(#1018): preserve per-cell write timestamps through compaction merge + parity coverage

### DIFF
--- a/cqlite-core/examples/gen_wide_sstable.rs
+++ b/cqlite-core/examples/gen_wide_sstable.rs
@@ -89,6 +89,7 @@ async fn main() -> cqlite_core::error::Result<()> {
             range_tombstones: vec![],
             local_deletion_time: None,
             row_tombstone: None,
+            cell_write_timestamps: None,
         };
         engine.write_async(mutation).await?;
     }

--- a/cqlite-core/src/storage/sstable/writer/data_writer/encoding.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/encoding.rs
@@ -448,12 +448,29 @@ pub(crate) fn collect_static_operations(
                 } => continue,
                 crate::storage::write_engine::mutation::CellOperation::DeleteRow => continue,
             };
+            // Issue #1018: a static `Write`/`WriteWithTtl` cell carries its OWN
+            // write timestamp when the compaction merge→mutation path recorded one
+            // in `Mutation::cell_write_timestamps` (it differs from the row's
+            // `timestamp_micros`). Use it for BOTH the stamped candidate timestamp
+            // AND the last-write-wins comparison below, mirroring the regular-row
+            // path in `rows.rs`. Otherwise a compacted static row with surviving
+            // static siblings at differing writetimes would rewrite older static
+            // cells to the newest static mutation's row max. For every other op (and
+            // for cells with no per-cell override) this is exactly
+            // `mutation.timestamp_micros`, so the single-writetime case is unchanged.
+            let candidate_ts = match op {
+                crate::storage::write_engine::mutation::CellOperation::Write { .. }
+                | crate::storage::write_engine::mutation::CellOperation::WriteWithTtl { .. } => {
+                    mutation.cell_write_timestamp(&col_name)
+                }
+                _ => mutation.timestamp_micros,
+            };
             let candidate = StaticMergedOp {
                 // #921 finding 2: preserve a `Delete` cell tombstone's own surfaced
                 // LDT; other ops fall back to the mutation's effective LDT.
                 cell_local_deletion_time: op_cell_local_deletion_time(op, mutation),
                 op: op.clone(),
-                timestamp_micros: mutation.timestamp_micros,
+                timestamp_micros: candidate_ts,
                 // #1196: carry statement-level TTL so a static `USING TTL` Write
                 // is emitted as an expiring cell, not a non-expiring one.
                 row_ttl_seconds: mutation.ttl_seconds,

--- a/cqlite-core/src/storage/sstable/writer/data_writer/encoding.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/encoding.rs
@@ -62,6 +62,36 @@ pub(crate) fn op_cell_local_deletion_time(
     }
 }
 
+/// The write timestamp (microseconds) to stamp on the static cell emitted for
+/// `op` within `mutation` (issue #1018).
+///
+/// A `Write`/`WriteWithTtl`/`Delete` op carries its OWN per-cell write timestamp
+/// when the compaction merge→mutation path recorded one in
+/// [`Mutation::cell_write_timestamps`](crate::storage::write_engine::mutation::Mutation::cell_write_timestamps)
+/// (a surviving live cell's writetime, or a static cell tombstone's
+/// `markedForDeleteAt`). It is resolved via
+/// [`Mutation::cell_write_timestamp`](crate::storage::write_engine::mutation::Mutation::cell_write_timestamp),
+/// which falls back to the mutation's row `timestamp_micros` when no per-cell
+/// override exists. Every other op (and the no-override case) resolves to exactly
+/// `mutation.timestamp_micros`, so the single-writetime behavior is unchanged.
+///
+/// Shared by `collect_static_operations` (the compaction/partition path) and
+/// `DataWriter::write_static_row` (the public single-mutation entry point) so both
+/// resolve per-cell static writetimes IDENTICALLY — without it the public entry
+/// point would rewrite older static cells (live OR cell tombstones) to the row max.
+pub(crate) fn op_cell_write_timestamp(
+    op: &crate::storage::write_engine::mutation::CellOperation,
+    mutation: &Mutation,
+) -> i64 {
+    use crate::storage::write_engine::mutation::CellOperation;
+    match op {
+        CellOperation::Write { column, .. }
+        | CellOperation::WriteWithTtl { column, .. }
+        | CellOperation::Delete { column, .. } => mutation.cell_write_timestamp(column),
+        _ => mutation.timestamp_micros,
+    }
+}
+
 /// Generate a version-1 TimeUUID for use as a list cell path.
 ///
 /// List elements in Cassandra use TimeUUIDs as cell paths to maintain insertion order.
@@ -453,14 +483,7 @@ pub(crate) fn collect_static_operations(
             // statics. For every other op (and for cells with no per-cell override)
             // this is exactly `mutation.timestamp_micros`, so the single-writetime
             // case is unchanged.
-            let candidate_ts = match op {
-                crate::storage::write_engine::mutation::CellOperation::Write { .. }
-                | crate::storage::write_engine::mutation::CellOperation::WriteWithTtl { .. }
-                | crate::storage::write_engine::mutation::CellOperation::Delete { .. } => {
-                    mutation.cell_write_timestamp(&col_name)
-                }
-                _ => mutation.timestamp_micros,
-            };
+            let candidate_ts = op_cell_write_timestamp(op, mutation);
             // Issue #1018 (roborev HIGH): PER-CELL shadow filtering for statics. The
             // mutation-level `shadow_floor` skip above gates on the ROW MAX
             // (`mutation.timestamp_micros`), so a mutation that survives the floor

--- a/cqlite-core/src/storage/sstable/writer/data_writer/encoding.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/encoding.rs
@@ -440,19 +440,23 @@ pub(crate) fn collect_static_operations(
                 } => continue,
                 crate::storage::write_engine::mutation::CellOperation::DeleteRow => continue,
             };
-            // Issue #1018: a static `Write`/`WriteWithTtl` cell carries its OWN
-            // write timestamp when the compaction merge→mutation path recorded one
-            // in `Mutation::cell_write_timestamps` (it differs from the row's
-            // `timestamp_micros`). Use it for BOTH the stamped candidate timestamp
-            // AND the last-write-wins comparison below, mirroring the regular-row
-            // path in `rows.rs`. Otherwise a compacted static row with surviving
-            // static siblings at differing writetimes would rewrite older static
-            // cells to the newest static mutation's row max. For every other op (and
-            // for cells with no per-cell override) this is exactly
-            // `mutation.timestamp_micros`, so the single-writetime case is unchanged.
+            // Issue #1018: a static `Write`/`WriteWithTtl`/`Delete` cell carries
+            // its OWN per-cell timestamp when the compaction merge→mutation path
+            // recorded one in `Mutation::cell_write_timestamps` (it differs from
+            // the row's `timestamp_micros`) — a live cell's writetime OR a static
+            // cell tombstone's markedForDeleteAt. Use it for BOTH the stamped
+            // candidate timestamp AND the last-write-wins comparison below,
+            // mirroring the regular-row path in `rows.rs`. Otherwise a compacted
+            // static row with surviving static siblings at differing timestamps
+            // would rewrite older static cells (live OR tombstone) to the newest
+            // static mutation's row max — re-introducing the over-deletion bug for
+            // statics. For every other op (and for cells with no per-cell override)
+            // this is exactly `mutation.timestamp_micros`, so the single-writetime
+            // case is unchanged.
             let candidate_ts = match op {
                 crate::storage::write_engine::mutation::CellOperation::Write { .. }
-                | crate::storage::write_engine::mutation::CellOperation::WriteWithTtl { .. } => {
+                | crate::storage::write_engine::mutation::CellOperation::WriteWithTtl { .. }
+                | crate::storage::write_engine::mutation::CellOperation::Delete { .. } => {
                     mutation.cell_write_timestamp(&col_name)
                 }
                 _ => mutation.timestamp_micros,
@@ -461,23 +465,23 @@ pub(crate) fn collect_static_operations(
             // mutation-level `shadow_floor` skip above gates on the ROW MAX
             // (`mutation.timestamp_micros`), so a mutation that survives the floor
             // (because a recent static sibling keeps its row max high) can still
-            // carry an individual static `Write`/`WriteWithTtl` whose OWN per-cell
-            // writetime is `<= shadow_floor`. That cell is covered by the partition
-            // tombstone and MUST be shadowed exactly as it would have been when every
-            // static cell used the row max. Apply the SAME boundary the row-max skip
-            // uses (`<= floor`) to the resolved `candidate_ts`, dropping the static
-            // write here so it never reaches the LWW map (and so the static
-            // liveness/TTL the partition path derives from the SURVIVING ops below
-            // cannot resurrect it). A static `Delete` tombstone has no per-cell
-            // writetime override (`candidate_ts == mutation.timestamp_micros`), so it
-            // is unaffected; and every cell with no override already has
-            // `candidate_ts == mutation.timestamp_micros > floor`, leaving the
-            // single-writetime case unchanged.
+            // carry an individual static `Write`/`WriteWithTtl`/`Delete` whose OWN
+            // per-cell timestamp is `<= shadow_floor`. That cell is covered by the
+            // partition tombstone and MUST be shadowed exactly as it would have been
+            // when every static cell used the row max. Apply the SAME boundary the
+            // row-max skip uses (`<= floor`) to the resolved `candidate_ts`,
+            // dropping the static op here so it never reaches the LWW map (and so
+            // the static liveness/TTL the partition path derives from the SURVIVING
+            // ops below cannot resurrect it). A static cell tombstone is itself
+            // shadowed on the same floor using its OWN markedForDeleteAt. Every cell
+            // with no override already has `candidate_ts == mutation.timestamp_micros
+            // > floor`, leaving the single-writetime case unchanged.
             if shadow_floor.is_some_and(|floor| candidate_ts <= floor)
                 && matches!(
                     op,
                     crate::storage::write_engine::mutation::CellOperation::Write { .. }
                         | crate::storage::write_engine::mutation::CellOperation::WriteWithTtl { .. }
+                        | crate::storage::write_engine::mutation::CellOperation::Delete { .. }
                 )
             {
                 continue;

--- a/cqlite-core/src/storage/sstable/writer/data_writer/encoding.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/encoding.rs
@@ -387,14 +387,6 @@ pub(crate) fn is_primary_key_column(column: &str, schema: &TableSchema) -> bool 
         || schema.clustering_keys.iter().any(|k| k.name == column)
 }
 
-/// Returns true if this mutation contributes at least one static-column operation.
-pub(crate) fn has_static_operation(mutation: &Mutation, schema: &TableSchema) -> bool {
-    mutation
-        .operations
-        .iter()
-        .any(|op| is_static_operation(op, schema))
-}
-
 /// Collect and merge static-column operations from all mutations in a partition.
 ///
 /// Scans every mutation (regardless of whether it has a clustering key) and
@@ -465,6 +457,31 @@ pub(crate) fn collect_static_operations(
                 }
                 _ => mutation.timestamp_micros,
             };
+            // Issue #1018 (roborev HIGH): PER-CELL shadow filtering for statics. The
+            // mutation-level `shadow_floor` skip above gates on the ROW MAX
+            // (`mutation.timestamp_micros`), so a mutation that survives the floor
+            // (because a recent static sibling keeps its row max high) can still
+            // carry an individual static `Write`/`WriteWithTtl` whose OWN per-cell
+            // writetime is `<= shadow_floor`. That cell is covered by the partition
+            // tombstone and MUST be shadowed exactly as it would have been when every
+            // static cell used the row max. Apply the SAME boundary the row-max skip
+            // uses (`<= floor`) to the resolved `candidate_ts`, dropping the static
+            // write here so it never reaches the LWW map (and so the static
+            // liveness/TTL the partition path derives from the SURVIVING ops below
+            // cannot resurrect it). A static `Delete` tombstone has no per-cell
+            // writetime override (`candidate_ts == mutation.timestamp_micros`), so it
+            // is unaffected; and every cell with no override already has
+            // `candidate_ts == mutation.timestamp_micros > floor`, leaving the
+            // single-writetime case unchanged.
+            if shadow_floor.is_some_and(|floor| candidate_ts <= floor)
+                && matches!(
+                    op,
+                    crate::storage::write_engine::mutation::CellOperation::Write { .. }
+                        | crate::storage::write_engine::mutation::CellOperation::WriteWithTtl { .. }
+                )
+            {
+                continue;
+            }
             let candidate = StaticMergedOp {
                 // #921 finding 2: preserve a `Delete` cell tombstone's own surfaced
                 // LDT; other ops fall back to the mutation's effective LDT.
@@ -489,6 +506,27 @@ pub(crate) fn collect_static_operations(
     }
 
     best.into_values().collect()
+}
+
+/// Derive a static row's liveness timestamp + TTL from the SURVIVING merged
+/// static ops (issue #1018, roborev HIGH).
+///
+/// The static row carries no row-level liveness in the emitted bytes (#1196 —
+/// the writetime rides on each static CELL), but the partition path still
+/// threads a `(latest_ts, ttl)` pair into `write_static_row_with_prev_size`.
+/// That pair MUST be derived from the ops that actually SURVIVED
+/// `collect_static_operations` — each carrying its own per-cell
+/// `timestamp_micros` after the per-cell shadow floor — NOT from the set of
+/// mutations that merely cleared the floor on their ROW MAX. A static `Write`
+/// whose per-cell writetime is `<= shadow_floor` is already dropped from
+/// `merged`, so it cannot contribute liveness/TTL here; deriving from the
+/// mutations' row max could otherwise resurrect a shadowed static cell's
+/// writetime. Returns the max per-cell timestamp and the TTL of the op holding
+/// it (last-write-wins). `None` when there are no surviving ops.
+pub(crate) fn static_liveness_from_ops(ops: &[StaticMergedOp]) -> Option<(i64, Option<u32>)> {
+    ops.iter()
+        .max_by_key(|mop| mop.timestamp_micros)
+        .map(|mop| (mop.timestamp_micros, mop.row_ttl_seconds))
 }
 
 /// Whether a range tombstone's clustering range covers the given clustering key.

--- a/cqlite-core/src/storage/sstable/writer/data_writer/partition.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/partition.rs
@@ -61,13 +61,6 @@ impl DataWriter {
             // Static cells shadowed by the partition tombstone are dropped.
             let merged = collect_static_operations(mutations, schema, partition_floor);
 
-            // Mutations shadowed by the partition tombstone cannot contribute
-            // the static row's liveness timestamp or TTL either.
-            let unshadowed_static = |m: &&Mutation| {
-                partition_floor.is_none_or(|floor| m.timestamp_micros > floor)
-                    && has_static_operation(m, schema)
-            };
-
             if merged.is_empty() {
                 // Schema declares statics but this partition writes none.
                 // Cassandra still expects the prelude; emit the minimal empty form.
@@ -82,24 +75,17 @@ impl DataWriter {
                 let static_size = self.write_empty_static_row(0, schema)? as u64;
                 prev_unfiltered_size += static_size;
             } else {
-                // Row-level liveness timestamp: the latest timestamp seen across
-                // contributing mutations. `!merged.is_empty()` implies at least
-                // one mutation contributed an unshadowed static op, so `.max()`
-                // is guaranteed `Some`.
-                let latest_ts = mutations
-                    .iter()
-                    .filter(unshadowed_static)
-                    .map(|m| m.timestamp_micros)
-                    .max()
-                    .unwrap_or(mutations.first().map(|m| m.timestamp_micros).unwrap_or(0));
-
-                // Pick the TTL from the mutation with the latest timestamp that
-                // contributed a static op (mirrors Cassandra's last-write-wins).
-                let ttl = mutations
-                    .iter()
-                    .filter(unshadowed_static)
-                    .max_by_key(|m| m.timestamp_micros)
-                    .and_then(|m| m.ttl_seconds);
+                // Issue #1018 (roborev HIGH): derive the static row's liveness
+                // timestamp + TTL from the SURVIVING merged ops (each carrying its
+                // own per-cell writetime after the per-cell shadow floor), NOT from
+                // the mutations that merely cleared the floor on their row max — a
+                // static write whose per-cell ts is `<= partition_floor` is already
+                // dropped from `merged`, so it cannot leak its writetime here.
+                // `!merged.is_empty()` guarantees `Some`.
+                let (latest_ts, ttl) = static_liveness_from_ops(&merged).unwrap_or((
+                    mutations.first().map(|m| m.timestamp_micros).unwrap_or(0),
+                    None,
+                ));
 
                 // Issue #764: pass the per-op merged static ops (each carrying its
                 // own originating timestamp + local_deletion_time) so a surviving
@@ -264,10 +250,6 @@ impl DataWriter {
 
         if schema_has_static {
             let merged = collect_static_operations(mutations, schema, partition_floor);
-            let unshadowed_static = |m: &&Mutation| {
-                partition_floor.is_none_or(|floor| m.timestamp_micros > floor)
-                    && has_static_operation(m, schema)
-            };
 
             if merged.is_empty() {
                 // Issue #821 (finding #2): static row hard-codes prev_size = 0 and
@@ -277,18 +259,14 @@ impl DataWriter {
                 let static_size = self.write_empty_static_row(0, schema)? as u64;
                 prev_unfiltered_size += static_size;
             } else {
-                let latest_ts = mutations
-                    .iter()
-                    .filter(unshadowed_static)
-                    .map(|m| m.timestamp_micros)
-                    .max()
-                    .unwrap_or(mutations.first().map(|m| m.timestamp_micros).unwrap_or(0));
-
-                let ttl = mutations
-                    .iter()
-                    .filter(unshadowed_static)
-                    .max_by_key(|m| m.timestamp_micros)
-                    .and_then(|m| m.ttl_seconds);
+                // Issue #1018 (roborev HIGH): derive liveness/TTL from the SURVIVING
+                // merged ops (per-cell writetimes after the shadow floor), not from
+                // mutations that only cleared the floor on their row max. See the
+                // non-indexed path above for the rationale.
+                let (latest_ts, ttl) = static_liveness_from_ops(&merged).unwrap_or((
+                    mutations.first().map(|m| m.timestamp_micros).unwrap_or(0),
+                    None,
+                ));
 
                 // Issue #764: same per-op LDT preservation as the non-indexed path.
                 // Issue #821 (finding #2): prev_size = 0 for the static row; chain

--- a/cqlite-core/src/storage/sstable/writer/data_writer/rows.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/rows.rs
@@ -4,6 +4,11 @@
 //! holds one `impl DataWriter` block. `use super::*` pulls the shared writer
 //! types, serialization/schema helpers, flag constants, and crate imports
 //! re-exported from `data_writer/mod.rs`. No emitted bytes change.
+//!
+//! Issue #1018 added per-cell write-timestamp threading inside
+//! `merge_row_group` (a small, cohesive growth of the existing liveness/cell
+//! reconciliation logic); a further responsibility split of this over-threshold
+//! file is tracked by epic #1116 rather than done inline here.
 
 use super::*;
 
@@ -262,7 +267,11 @@ impl DataWriter {
             // from. Such a clustering-only write must still keep the row live, so
             // record its contribution inline (it can never be shadowed by a complex
             // marker — primary-key columns are never complex).
-            let mut pk_write_liveness = false;
+            // Issue #1018: track the clustering-only write's OWN write timestamp
+            // (not the mutation row max) so a row whose only liveness source is a
+            // surfaced clustering cell sibling of a higher-ts cell tombstone keeps
+            // the cell's writetime as the row marker. `None` = no such write.
+            let mut pk_write_liveness: Option<i64> = None;
             for op in &m.operations {
                 let column = match op {
                     CellOperation::Write { column, .. }
@@ -367,11 +376,33 @@ impl DataWriter {
                         CellOperation::Write { .. } | CellOperation::WriteWithTtl { .. }
                     ) {
                         // A clustering-only write keeps the row live even though it
-                        // produces no cell survivor (see note above).
-                        pk_write_liveness = true;
+                        // produces no cell survivor (see note above). Issue #1018:
+                        // carry the surfaced clustering cell's OWN write timestamp so
+                        // the row marker reflects it, not the row max (which a
+                        // higher-ts sibling cell tombstone would otherwise force).
+                        let pk_ts = m.cell_write_timestamp(column);
+                        if pk_write_liveness.is_none_or(|cur| pk_ts >= cur) {
+                            pk_write_liveness = Some(pk_ts);
+                        }
                     }
                     continue;
                 }
+
+                // Issue #1018: a simple `Write`/`WriteWithTtl` cell carries its OWN
+                // write timestamp (the compaction merge→mutation path records it in
+                // `Mutation::cell_write_timestamps` when it differs from the row's
+                // `timestamp_micros`). Use it for both the row-marker liveness
+                // candidate and the emitted cell so a live sibling of a higher-ts
+                // cell tombstone is NOT rewritten to the row's max writetime. For
+                // every other op (and for cells with no per-cell override) this is
+                // exactly `m.timestamp_micros`, so the common single-writetime row
+                // is unchanged.
+                let cell_ts = match op {
+                    CellOperation::Write { .. } | CellOperation::WriteWithTtl { .. } => {
+                        m.cell_write_timestamp(column)
+                    }
+                    _ => m.timestamp_micros,
+                };
 
                 // Issue #921: record the ROW-MARKER liveness candidate for this
                 // regular-column write. Done BEFORE the cells LWW dedup so that a
@@ -383,11 +414,11 @@ impl DataWriter {
                 ) {
                     match whole_col_liveness.entry(column) {
                         std::collections::hash_map::Entry::Vacant(entry) => {
-                            entry.insert((m.timestamp_micros, m.ttl_seconds));
+                            entry.insert((cell_ts, m.ttl_seconds));
                         }
                         std::collections::hash_map::Entry::Occupied(mut entry) => {
-                            if m.timestamp_micros >= entry.get().0 {
-                                entry.insert((m.timestamp_micros, m.ttl_seconds));
+                            if cell_ts >= entry.get().0 {
+                                entry.insert((cell_ts, m.ttl_seconds));
                             }
                         }
                     }
@@ -395,7 +426,7 @@ impl DataWriter {
 
                 let candidate = MergedOp {
                     op,
-                    timestamp_micros: m.timestamp_micros,
+                    timestamp_micros: cell_ts,
                     row_ttl_seconds: m.ttl_seconds,
                     // #921 finding 2: a surviving `Delete` cell tombstone keeps its
                     // OWN surfaced LDT; other ops fall back to the mutation's LDT.
@@ -444,10 +475,19 @@ impl DataWriter {
             // Issue #921: only the cell-less liveness sources are folded inline here
             // — a pure-PK insert and a clustering-only write. Whole-column writes
             // that DO produce a `cells` survivor are derived after reconcile.
-            if (pk_write_liveness || pure_pk_insert)
-                && liveness.is_none_or(|(ts, _)| m.timestamp_micros >= ts)
-            {
-                liveness = Some((m.timestamp_micros, m.ttl_seconds));
+            //
+            // Issue #1018: a clustering-only write contributes its surfaced cell's
+            // OWN write timestamp (`pk_write_liveness`); a pure-PK insert has no
+            // cell and contributes the mutation row timestamp as before.
+            let pk_liveness_ts = pk_write_liveness.or(if pure_pk_insert {
+                Some(m.timestamp_micros)
+            } else {
+                None
+            });
+            if let Some(pk_ts) = pk_liveness_ts {
+                if liveness.is_none_or(|(ts, _)| pk_ts >= ts) {
+                    liveness = Some((pk_ts, m.ttl_seconds));
+                }
             }
         }
 

--- a/cqlite-core/src/storage/sstable/writer/data_writer/rows.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/rows.rs
@@ -380,8 +380,15 @@ impl DataWriter {
                         // carry the surfaced clustering cell's OWN write timestamp so
                         // the row marker reflects it, not the row max (which a
                         // higher-ts sibling cell tombstone would otherwise force).
+                        // Issue #1018: a surfaced clustering-only write also
+                        // carries its OWN per-cell writetime, which can be `<=
+                        // deletion_ts` even when the mutation row max survives.
+                        // Shadow it on the same `<= deletion_ts` boundary so it
+                        // cannot resurrect a row marker the tombstone covers.
                         let pk_ts = m.cell_write_timestamp(column);
-                        if pk_write_liveness.is_none_or(|cur| pk_ts >= cur) {
+                        if deletion_ts.is_none_or(|dts| pk_ts > dts)
+                            && pk_write_liveness.is_none_or(|cur| pk_ts >= cur)
+                        {
                             pk_write_liveness = Some(pk_ts);
                         }
                     }
@@ -403,6 +410,30 @@ impl DataWriter {
                     }
                     _ => m.timestamp_micros,
                 };
+
+                // Issue #1018 (roborev HIGH): PER-CELL shadow filtering. The
+                // mutation-level `mutation_shadowed` gate above uses the ROW MAX
+                // (`m.timestamp_micros`), so a mutation whose row max is ABOVE
+                // `deletion_ts` (because a recent sibling cell keeps it live) can
+                // still carry an individual `Write`/`WriteWithTtl` whose OWN
+                // per-cell timestamp is `<= deletion_ts`. Such a cell is covered by
+                // the partition/range/row tombstone and MUST be shadowed exactly as
+                // it would have been when every cell used the row max. Apply the
+                // SAME `<= deletion_ts` boundary the row-max path used (equal-ts
+                // deletion wins, #498) to THIS cell using its resolved `cell_ts`,
+                // dropping both the emitted cell AND its row-marker liveness
+                // candidate. A `Delete` cell tombstone is gated on the mutation row
+                // ts (it has no per-cell writetime override), so this only narrows
+                // live writes — every cell with no per-cell override has
+                // `cell_ts == m.timestamp_micros > deletion_ts` already, leaving the
+                // single-writetime row unchanged.
+                if matches!(
+                    op,
+                    CellOperation::Write { .. } | CellOperation::WriteWithTtl { .. }
+                ) && deletion_ts.is_some_and(|dts| cell_ts <= dts)
+                {
+                    continue;
+                }
 
                 // Issue #921: record the ROW-MARKER liveness candidate for this
                 // regular-column write. Done BEFORE the cells LWW dedup so that a

--- a/cqlite-core/src/storage/sstable/writer/data_writer/rows.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/rows.rs
@@ -395,19 +395,23 @@ impl DataWriter {
                     continue;
                 }
 
-                // Issue #1018: a simple `Write`/`WriteWithTtl` cell carries its OWN
-                // write timestamp (the compaction merge→mutation path records it in
+                // Issue #1018: a simple `Write`/`WriteWithTtl`/`Delete` cell
+                // carries its OWN per-cell timestamp (the compaction
+                // merge→mutation path records it in
                 // `Mutation::cell_write_timestamps` when it differs from the row's
-                // `timestamp_micros`). Use it for both the row-marker liveness
-                // candidate and the emitted cell so a live sibling of a higher-ts
-                // cell tombstone is NOT rewritten to the row's max writetime. For
-                // every other op (and for cells with no per-cell override) this is
-                // exactly `m.timestamp_micros`, so the common single-writetime row
-                // is unchanged.
+                // `timestamp_micros`). For a live write that is its writetime; for
+                // a `Delete` cell tombstone it is its `markedForDeleteAt`. Use it
+                // for the row-marker liveness candidate, the emitted cell AND the
+                // LWW comparison so neither a live sibling of a higher-ts cell
+                // tombstone NOR a cell tombstone sibling of a higher-ts live cell
+                // is rewritten to the row's max timestamp. For every other op (and
+                // for cells with no per-cell override) this is exactly
+                // `m.timestamp_micros`, so the common single-writetime row is
+                // unchanged.
                 let cell_ts = match op {
-                    CellOperation::Write { .. } | CellOperation::WriteWithTtl { .. } => {
-                        m.cell_write_timestamp(column)
-                    }
+                    CellOperation::Write { .. }
+                    | CellOperation::WriteWithTtl { .. }
+                    | CellOperation::Delete { .. } => m.cell_write_timestamp(column),
                     _ => m.timestamp_micros,
                 };
 
@@ -415,21 +419,24 @@ impl DataWriter {
                 // mutation-level `mutation_shadowed` gate above uses the ROW MAX
                 // (`m.timestamp_micros`), so a mutation whose row max is ABOVE
                 // `deletion_ts` (because a recent sibling cell keeps it live) can
-                // still carry an individual `Write`/`WriteWithTtl` whose OWN
-                // per-cell timestamp is `<= deletion_ts`. Such a cell is covered by
-                // the partition/range/row tombstone and MUST be shadowed exactly as
-                // it would have been when every cell used the row max. Apply the
-                // SAME `<= deletion_ts` boundary the row-max path used (equal-ts
-                // deletion wins, #498) to THIS cell using its resolved `cell_ts`,
-                // dropping both the emitted cell AND its row-marker liveness
-                // candidate. A `Delete` cell tombstone is gated on the mutation row
-                // ts (it has no per-cell writetime override), so this only narrows
-                // live writes — every cell with no per-cell override has
+                // still carry an individual `Write`/`WriteWithTtl`/`Delete` whose
+                // OWN per-cell timestamp is `<= deletion_ts`. Such a cell is
+                // covered by the partition/range/row tombstone and MUST be shadowed
+                // exactly as it would have been when every cell used the row max.
+                // Apply the SAME `<= deletion_ts` boundary the row-max path used
+                // (equal-ts deletion wins, #498) to THIS cell using its resolved
+                // `cell_ts`, dropping both the emitted cell AND its row-marker
+                // liveness candidate. A cell tombstone is itself subject to the
+                // same `<= deletion_ts` shadow floor using its OWN
+                // markedForDeleteAt — a tombstone fully covered by the row/range
+                // deletion is redundant. Every cell with no per-cell override has
                 // `cell_ts == m.timestamp_micros > deletion_ts` already, leaving the
                 // single-writetime row unchanged.
                 if matches!(
                     op,
-                    CellOperation::Write { .. } | CellOperation::WriteWithTtl { .. }
+                    CellOperation::Write { .. }
+                        | CellOperation::WriteWithTtl { .. }
+                        | CellOperation::Delete { .. }
                 ) && deletion_ts.is_some_and(|dts| cell_ts <= dts)
                 {
                     continue;

--- a/cqlite-core/src/storage/sstable/writer/data_writer/static_rows.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/static_rows.rs
@@ -30,8 +30,8 @@ impl DataWriter {
     /// [cell_data...]         ← Static column cells only
     /// ```
     pub fn write_static_row(&mut self, mutation: &Mutation, schema: &TableSchema) -> Result<()> {
-        // Legacy/test entry point: derive per-op metadata from the single
-        // mutation (each op inherits the mutation's timestamp + effective LDT).
+        // Legacy/test/public entry point: derive per-op metadata from the single
+        // mutation (each op inherits the mutation's effective LDT).
         let static_ops: Vec<StaticMergedOp> = mutation
             .operations
             .iter()
@@ -39,8 +39,19 @@ impl DataWriter {
                 // #921 finding 2: a `Delete` cell tombstone keeps its own surfaced
                 // LDT; every other op falls back to the mutation's effective LDT.
                 cell_local_deletion_time: op_cell_local_deletion_time(op, mutation),
+                // #1018: a static `Write`/`WriteWithTtl`/`Delete` cell carries its
+                // OWN per-cell timestamp when the compaction merge→mutation path
+                // recorded one in `Mutation::cell_write_timestamps`. Resolve it the
+                // SAME way `collect_static_operations` (encoding.rs) does so a
+                // caller passing a compacted static mutation through this public
+                // entry point does not rewrite older static cells (live OR cell
+                // tombstones) to the row max. There is no partition tombstone
+                // shadow_floor in the single-mutation entry point, so the per-cell
+                // shadow drop does not apply here; the no-override path resolves to
+                // exactly `mutation.timestamp_micros`, leaving the single-writetime
+                // behavior byte-identical.
+                timestamp_micros: op_cell_write_timestamp(op, mutation),
                 op: op.clone(),
-                timestamp_micros: mutation.timestamp_micros,
                 // #1196: carry statement-level TTL so a static `USING TTL` Write
                 // is emitted as an expiring cell, not a non-expiring one.
                 row_ttl_seconds: mutation.ttl_seconds,

--- a/cqlite-core/src/storage/sstable/writer/data_writer/tests/scenarios_3.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/tests/scenarios_3.rs
@@ -477,6 +477,179 @@ fn collect_static_operations_preserves_per_cell_writetimes_1018() {
     );
 }
 
+/// Schema with one clustering key and two REGULAR (non-static) text columns, used
+/// by the #1018 per-cell shadow tests for `merge_row_group`.
+fn two_regular_column_schema() -> TableSchema {
+    TableSchema {
+        keyspace: "test_ks".to_string(),
+        table: "test_table".to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![ClusteringColumn {
+            name: "ck".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+            order: ClusteringOrder::Asc,
+        }],
+        columns: vec![
+            Column {
+                name: "c1".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "c2".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+/// Issue #1018 (roborev HIGH — data resurrection past a tombstone): the per-cell
+/// write-timestamp work made each emitted simple `Write`/`WriteWithTtl` cell use
+/// its OWN `cell_write_timestamp(col)` instead of the row max, but tombstone
+/// SHADOWING in `merge_row_group` still gated by the row max (`shadow_floor` vs
+/// `m.timestamp_micros`). So a reconciled row whose row max is ABOVE a tombstone
+/// floor (a recent sibling keeps it live) could still emit another simple cell
+/// whose own per-cell timestamp is `<= floor` — resurrecting data the tombstone
+/// should shadow. The fix applies the `<= deletion_ts` shadow floor PER CELL using
+/// the cell's resolved per-cell timestamp.
+///
+/// This test FAILS before the fix (the low-ts cell survives) and passes after.
+#[test]
+fn merge_row_group_shadows_low_per_cell_ts_simple_cell_1018() {
+    let schema = two_regular_column_schema();
+    let table_id = TableId::new("test_ks", "test_table");
+    let pk = PartitionKey::single("id", Value::Integer(1));
+    let ck = ClusteringKey::single("ck", Value::Integer(1));
+
+    // Partition/range tombstone floor at 4000. The row's max writetime is 5000
+    // (the `c2` sibling, written AFTER the tombstone) so the mutation as a whole
+    // survives the floor. `c1`'s OWN per-cell writetime is 3000 — BELOW the floor —
+    // so it is covered by the tombstone and must be shadowed.
+    let shadow_floor = Some(4000i64);
+    let row_ts = 5000i64;
+    let c1_ts = 3000i64;
+    let mut cell_ts = HashMap::new();
+    cell_ts.insert("c1".to_string(), c1_ts);
+    cell_ts.insert("c2".to_string(), row_ts);
+
+    let mut mutation = Mutation::new(
+        table_id,
+        pk,
+        Some(ck),
+        vec![
+            CellOperation::Write {
+                column: "c1".to_string(),
+                value: Value::Text("shadowed".to_string()),
+            },
+            CellOperation::Write {
+                column: "c2".to_string(),
+                value: Value::Text("survivor".to_string()),
+            },
+        ],
+        row_ts,
+        None,
+    );
+    mutation.cell_write_timestamps = Some(cell_ts);
+
+    let row = DataWriter::merge_row_group(&[&mutation], &schema, false, shadow_floor)
+        .expect("row with a surviving sibling must be emitted");
+
+    let surviving: Vec<&str> = row
+        .ops
+        .iter()
+        .filter_map(|mop| match mop.op {
+            CellOperation::Write { column, .. } => Some(column.as_str()),
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        surviving.contains(&"c2"),
+        "#1018: the recent sibling (per-cell ts > floor) must survive"
+    );
+    assert!(
+        !surviving.contains(&"c1"),
+        "#1018: a simple cell whose per-cell ts ({c1_ts}) is <= the tombstone floor (4000) \
+         must be SHADOWED, not resurrected"
+    );
+}
+
+/// Issue #1018 static analogue: `collect_static_operations` gates a mutation by
+/// the row max (`shadow_floor` vs `mutation.timestamp_micros`). A static row whose
+/// row max is ABOVE a partition tombstone floor (a recent static sibling survives)
+/// could still keep another static cell whose OWN per-cell timestamp is `<= floor`,
+/// resurrecting data the partition tombstone covers. The fix applies the floor
+/// per-cell to the resolved per-cell timestamp.
+///
+/// FAILS before the fix (the low-ts static cell survives), passes after.
+#[test]
+fn collect_static_operations_shadows_low_per_cell_ts_1018() {
+    let schema = two_static_column_schema();
+    let table_id = TableId::new("test_ks", "test_table");
+    let pk = PartitionKey::single("id", Value::Integer(1));
+
+    // Partition tombstone floor at 4000. Row max is 5000 (`s2`, written after the
+    // tombstone) so the mutation survives the floor. `s1`'s OWN per-cell writetime
+    // is 3000 (BELOW the floor), so it is shadowed by the partition tombstone.
+    let shadow_floor = Some(4000i64);
+    let row_ts = 5000i64;
+    let s1_ts = 3000i64;
+    let mut cell_ts = HashMap::new();
+    cell_ts.insert("s1".to_string(), s1_ts);
+    cell_ts.insert("s2".to_string(), row_ts);
+
+    let mut mutation = Mutation::new(
+        table_id,
+        pk,
+        None,
+        vec![
+            CellOperation::Write {
+                column: "s1".to_string(),
+                value: Value::Text("shadowed".to_string()),
+            },
+            CellOperation::Write {
+                column: "s2".to_string(),
+                value: Value::Text("survivor".to_string()),
+            },
+        ],
+        row_ts,
+        None,
+    );
+    mutation.cell_write_timestamps = Some(cell_ts);
+
+    let ops = collect_static_operations(std::slice::from_ref(&mutation), &schema, shadow_floor);
+
+    let surviving: Vec<&str> = ops
+        .iter()
+        .filter_map(|o| match &o.op {
+            CellOperation::Write { column, .. } => Some(column.as_str()),
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        surviving.contains(&"s2"),
+        "#1018: the recent static sibling (per-cell ts > floor) must survive"
+    );
+    assert!(
+        !surviving.contains(&"s1"),
+        "#1018: a static cell whose per-cell ts ({s1_ts}) is <= the partition floor (4000) \
+         must be SHADOWED, not resurrected"
+    );
+}
+
 #[test]
 fn test_write_column_bitmap_zero_when_all_columns_present() {
     let stats = create_test_stats();

--- a/cqlite-core/src/storage/sstable/writer/data_writer/tests/scenarios_3.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/tests/scenarios_3.rs
@@ -377,6 +377,106 @@ fn static_write_without_ttl_stays_non_expiring_1196() {
     );
 }
 
+/// Schema with two static columns (`s1`, `s2`) plus a clustering column, for the
+/// per-cell static-writetime test below.
+fn two_static_column_schema() -> TableSchema {
+    TableSchema {
+        keyspace: "test_ks".to_string(),
+        table: "test_table".to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![ClusteringColumn {
+            name: "ck".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+            order: ClusteringOrder::Asc,
+        }],
+        columns: vec![
+            Column {
+                name: "s1".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: true,
+            },
+            Column {
+                name: "s2".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: true,
+            },
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+/// Issue #1018 (roborev finding 2): a compacted STATIC row whose surviving static
+/// cells were last written at DIFFERENT writetimes must keep each cell's own
+/// timestamp. The compaction merge→mutation path records those per-cell writetimes
+/// in `Mutation::cell_write_timestamps`; `collect_static_operations` must thread
+/// each into the `StaticMergedOp.timestamp_micros` (and use it for the LWW
+/// comparison), mirroring the regular-row path. Before the fix, every static cell
+/// inherited the row-level `timestamp_micros` (the row max), so an older static
+/// sibling was rewritten to a higher writetime — the same bug class the
+/// regular-row fix addressed.
+#[test]
+fn collect_static_operations_preserves_per_cell_writetimes_1018() {
+    let schema = two_static_column_schema();
+    let table_id = TableId::new("test_ks", "test_table");
+    let pk = PartitionKey::single("id", Value::Integer(1));
+
+    // Row marker timestamp is the MAX of the two static cells (5000). The cell `s1`
+    // genuinely survives from an OLDER write at 3000; only `s2` was written at 5000.
+    let row_ts = 5000i64;
+    let s1_ts = 3000i64;
+    let mut cell_ts = HashMap::new();
+    cell_ts.insert("s1".to_string(), s1_ts);
+    cell_ts.insert("s2".to_string(), row_ts);
+
+    let mut mutation = Mutation::new(
+        table_id,
+        pk,
+        None,
+        vec![
+            CellOperation::Write {
+                column: "s1".to_string(),
+                value: Value::Text("old".to_string()),
+            },
+            CellOperation::Write {
+                column: "s2".to_string(),
+                value: Value::Text("new".to_string()),
+            },
+        ],
+        row_ts,
+        None,
+    );
+    mutation.cell_write_timestamps = Some(cell_ts);
+
+    let ops = collect_static_operations(std::slice::from_ref(&mutation), &schema, None);
+
+    let find_ts = |col: &str| {
+        ops.iter()
+            .find(|o| matches!(&o.op, CellOperation::Write { column, .. } if column == col))
+            .map(|o| o.timestamp_micros)
+    };
+
+    assert_eq!(
+        find_ts("s1"),
+        Some(s1_ts),
+        "#1018: surviving older static cell must keep its OWN writetime, not the row max"
+    );
+    assert_eq!(
+        find_ts("s2"),
+        Some(row_ts),
+        "#1018: newest static cell keeps its own (row-max) writetime"
+    );
+}
+
 #[test]
 fn test_write_column_bitmap_zero_when_all_columns_present() {
     let stats = create_test_stats();

--- a/cqlite-core/src/storage/sstable/writer/data_writer/tests/scenarios_3.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/tests/scenarios_3.rs
@@ -477,6 +477,230 @@ fn collect_static_operations_preserves_per_cell_writetimes_1018() {
     );
 }
 
+/// Read one unsigned VInt (Cassandra encoding) from `buf` at `pos`.
+fn read_uvint_at(buf: &[u8], pos: &mut usize) -> u64 {
+    let first = buf[*pos];
+    *pos += 1;
+    if first == 0xFF {
+        let mut v = 0u64;
+        for _ in 0..8 {
+            v = (v << 8) | buf[*pos] as u64;
+            *pos += 1;
+        }
+        return v;
+    }
+    let extra = first.leading_ones() as usize;
+    let mask = 0xFF_u8.wrapping_shr((extra + 1) as u32);
+    let mut v = (first & mask) as u64;
+    for _ in 0..extra {
+        v = (v << 8) | buf[*pos] as u64;
+        *pos += 1;
+    }
+    v
+}
+
+/// Issue #1018 (roborev Medium): the PUBLIC `DataWriter::write_static_row` entry
+/// point was the last writer path that ignored the per-cell write-timestamp
+/// side-channel — it stamped EVERY static op with `mutation.timestamp_micros`
+/// (the row max). A caller passing a compacted/static mutation that carries
+/// per-cell overrides in `Mutation::cell_write_timestamps` would therefore
+/// rewrite older surviving static cells (live OR cell tombstones) up to the row
+/// max, the same over-deletion bug class already fixed in
+/// `collect_static_operations`.
+///
+/// This drives `write_static_row` END-TO-END (not the lower-level
+/// `write_static_cells`) and decodes the emitted static-cell timestamp deltas,
+/// asserting each static cell keeps its OWN per-cell writetime — and a static
+/// cell tombstone keeps its OWN `markedForDeleteAt` — rather than the row max.
+///
+/// Pre-fix: `write_static_row` did not consult `cell_write_timestamps`, so the
+/// `s1` cell would be stamped at the row max (5000) instead of its own 3000 —
+/// this test fails. Post-fix (resolving via `op_cell_write_timestamp`, exactly
+/// as `collect_static_operations` does) it passes. The no-override case is
+/// covered by the existing `static_write_without_ttl_stays_non_expiring_1196`
+/// (single writetime, byte-identical).
+#[test]
+fn write_static_row_preserves_per_cell_writetimes_1018() {
+    let mut stats = create_test_stats();
+    stats.min_timestamp = 1_000;
+    stats.min_local_deletion_time = 0;
+    stats.min_ttl = 0;
+    let min_ts = stats.min_timestamp;
+    let mut writer = DataWriter::new(stats);
+    let schema = two_static_column_schema();
+    let table_id = TableId::new("test_ks", "test_table");
+    let pk = PartitionKey::single("id", Value::Integer(1));
+
+    // Row max is 5000 (`s2`); `s1` genuinely survives from an OLDER write at 3000.
+    let row_ts = 5000i64;
+    let s1_ts = 3000i64;
+    let mut cell_ts = HashMap::new();
+    cell_ts.insert("s1".to_string(), s1_ts);
+    cell_ts.insert("s2".to_string(), row_ts);
+
+    let mut mutation = Mutation::new(
+        table_id,
+        pk,
+        None,
+        vec![
+            CellOperation::Write {
+                column: "s1".to_string(),
+                value: Value::Text("old".to_string()),
+            },
+            CellOperation::Write {
+                column: "s2".to_string(),
+                value: Value::Text("new".to_string()),
+            },
+        ],
+        row_ts,
+        None,
+    );
+    mutation.cell_write_timestamps = Some(cell_ts);
+
+    writer.write_static_row(&mutation, &schema).unwrap();
+    let buf = &writer.buffer;
+
+    // Decode the static-row body. Layout (#1196: no row-level liveness, ALL columns
+    // present → no subset bitmap): [flags][ext=0x01][row_size uvint][prev_size uvint]
+    // then cells in static-column order (s1, s2), each simple cell:
+    // [cell_flags][ts_delta uvint][value_len uvint][value].
+    assert_eq!(buf[0], ROW_HAS_EXTENDED_FLAGS | ROW_HAS_ALL_COLUMNS);
+    assert_eq!(buf[1], EXTENDED_IS_STATIC);
+    let mut pos = 2usize;
+    let _row_size = read_uvint_at(buf, &mut pos);
+    let _prev_size = read_uvint_at(buf, &mut pos);
+
+    let read_cell_ts = |buf: &[u8], pos: &mut usize| -> i64 {
+        let flags = buf[*pos];
+        *pos += 1;
+        assert_eq!(
+            flags & CELL_USE_ROW_TIMESTAMP,
+            0,
+            "static cell must carry its own explicit timestamp (no row liveness)"
+        );
+        let ts_delta = read_uvint_at(buf, pos) as i64;
+        // skip value (length-prefixed text)
+        let len = read_uvint_at(buf, pos) as usize;
+        *pos += len;
+        min_ts + ts_delta
+    };
+
+    // Sorted static order: s1 then s2.
+    let s1_decoded = read_cell_ts(buf, &mut pos);
+    let s2_decoded = read_cell_ts(buf, &mut pos);
+
+    assert_eq!(
+        s1_decoded, s1_ts,
+        "#1018: write_static_row must keep the surviving older static cell's OWN \
+         writetime ({s1_ts}), not rewrite it to the row max ({row_ts})"
+    );
+    assert_eq!(
+        s2_decoded, row_ts,
+        "#1018: the newest static cell keeps its own (row-max) writetime"
+    );
+}
+
+/// Issue #1018 (roborev Medium) companion: `write_static_row` must also preserve a
+/// static CELL TOMBSTONE's own `markedForDeleteAt` (per-cell write timestamp), not
+/// rewrite it to the row max. A compacted static row can hold a live static cell
+/// alongside an older static cell tombstone at a DIFFERENT (lower) writetime.
+///
+/// Pre-fix the `Delete` op was stamped at the row max; post-fix it carries its own
+/// per-cell timestamp resolved via `op_cell_write_timestamp`.
+#[test]
+fn write_static_row_preserves_cell_tombstone_writetime_1018() {
+    let mut stats = create_test_stats();
+    stats.min_timestamp = 1_000;
+    stats.min_local_deletion_time = 0;
+    stats.min_ttl = 0;
+    let min_ts = stats.min_timestamp;
+    let min_ldt = stats.min_local_deletion_time as i64;
+    let mut writer = DataWriter::new(stats);
+    let schema = two_static_column_schema();
+    let table_id = TableId::new("test_ks", "test_table");
+    let pk = PartitionKey::single("id", Value::Integer(1));
+
+    // `s2` is a live write at the row max (5000); `s1` is an older static cell
+    // tombstone whose own markedForDeleteAt is 3000 and explicit LDT is 1234.
+    let row_ts = 5000i64;
+    let tomb_ts = 3000i64;
+    let tomb_ldt = 1234i32;
+    let mut cell_ts = HashMap::new();
+    cell_ts.insert("s1".to_string(), tomb_ts);
+    cell_ts.insert("s2".to_string(), row_ts);
+
+    let mut mutation = Mutation::new(
+        table_id,
+        pk,
+        None,
+        vec![
+            CellOperation::Delete {
+                column: "s1".to_string(),
+                local_deletion_time: Some(tomb_ldt),
+            },
+            CellOperation::Write {
+                column: "s2".to_string(),
+                value: Value::Text("new".to_string()),
+            },
+        ],
+        row_ts,
+        None,
+    );
+    mutation.cell_write_timestamps = Some(cell_ts);
+
+    writer.write_static_row(&mutation, &schema).unwrap();
+    let buf = &writer.buffer;
+
+    // NOT all-writes (one Delete) → ROW_HAS_ALL_COLUMNS unset, a column subset
+    // bitmap precedes the cells. Both columns present → subset is a single 0x00.
+    assert_eq!(buf[0] & ROW_HAS_ALL_COLUMNS, 0);
+    assert_eq!(buf[1], EXTENDED_IS_STATIC);
+    let mut pos = 2usize;
+    let _row_size = read_uvint_at(buf, &mut pos);
+    let _prev_size = read_uvint_at(buf, &mut pos);
+    let subset = read_uvint_at(buf, &mut pos);
+    assert_eq!(
+        subset, 0,
+        "both static columns present → empty missing subset"
+    );
+
+    // Sorted static order: s1 (tombstone) then s2 (live write).
+    // Tombstone cell: [flags(CELL_IS_DELETED|CELL_HAS_EMPTY_VALUE)][ts_delta][ldt_delta]
+    let s1_flags = buf[pos];
+    pos += 1;
+    assert_eq!(
+        s1_flags & CELL_IS_DELETED,
+        CELL_IS_DELETED,
+        "s1 must be a cell tombstone"
+    );
+    assert_eq!(s1_flags & CELL_USE_ROW_TIMESTAMP, 0);
+    let s1_ts_delta = read_uvint_at(buf, &mut pos) as i64;
+    let s1_ldt_delta = read_uvint_at(buf, &mut pos) as i64;
+    let s1_marked_for_delete = min_ts + s1_ts_delta;
+    let s1_ldt = min_ldt + s1_ldt_delta;
+
+    assert_eq!(
+        s1_marked_for_delete, tomb_ts,
+        "#1018: static cell tombstone must keep its OWN markedForDeleteAt ({tomb_ts}), \
+         not the row max ({row_ts})"
+    );
+    assert_eq!(
+        s1_ldt, tomb_ldt as i64,
+        "#1018: static cell tombstone keeps its own explicit localDeletionTime"
+    );
+
+    // Live cell s2 keeps the row max.
+    let s2_flags = buf[pos];
+    pos += 1;
+    assert_eq!(s2_flags & CELL_IS_DELETED, 0);
+    let s2_ts_delta = read_uvint_at(buf, &mut pos) as i64;
+    assert_eq!(
+        min_ts + s2_ts_delta,
+        row_ts,
+        "#1018: the live static cell keeps its own (row-max) writetime"
+    );
+}
+
 /// Schema with one clustering key and two REGULAR (non-static) text columns, used
 /// by the #1018 per-cell shadow tests for `merge_row_group`.
 fn two_regular_column_schema() -> TableSchema {

--- a/cqlite-core/src/storage/sstable/writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/mod.rs
@@ -574,13 +574,15 @@ impl SSTableWriter {
         // Update statistics from mutations
         for mutation in &mutations {
             self.stats.update_timestamp(mutation.timestamp_micros);
-            // Issue #1018: simple `Write`/`WriteWithTtl` cells may carry their OWN
-            // (lower) write timestamps in `Mutation::cell_write_timestamps` and are
-            // emitted with an explicit `min_timestamp` delta. On the non-preseeded
-            // (incremental) write path, fold every per-cell timestamp into the stats
-            // BEFORE emitting cells so `min_timestamp` can never exceed an emitted
-            // cell's actual timestamp (which would underflow the unsigned-VInt
-            // delta). Mirrors the pre-pass fold in `compute_mutations_baseline_stats`.
+            // Issue #1018: simple `Write`/`WriteWithTtl`/`Delete` cells may carry
+            // their OWN (lower) per-cell timestamps in
+            // `Mutation::cell_write_timestamps` (a live cell's writetime OR a cell
+            // tombstone's markedForDeleteAt) and are emitted with an explicit
+            // `min_timestamp` delta. On the non-preseeded (incremental) write path,
+            // fold every per-cell timestamp into the stats BEFORE emitting cells so
+            // `min_timestamp` can never exceed an emitted cell's actual timestamp
+            // (which would underflow the unsigned-VInt delta). Mirrors the pre-pass
+            // fold in `compute_mutations_baseline_stats`.
             if let Some(cell_ts) = &mutation.cell_write_timestamps {
                 for ts in cell_ts.values() {
                     self.stats.update_timestamp(*ts);
@@ -835,15 +837,17 @@ impl SSTableWriter {
         for mutation in mutations_slice {
             min_timestamp = min_timestamp.min(mutation.timestamp_micros);
 
-            // Issue #1018: a simple `Write`/`WriteWithTtl` cell may carry its OWN
-            // (lower) write timestamp in `Mutation::cell_write_timestamps` (the
-            // compaction merge→mutation path records it when it differs from the
-            // row's `timestamp_micros`). The DataWriter emits that cell's explicit
-            // timestamp as a `min_timestamp` delta, so the pre-seeded baseline must
-            // cover EVERY per-cell timestamp — otherwise `min_timestamp` could be
-            // pre-seeded ABOVE an emitted cell's actual (lower) timestamp and the
-            // unsigned-VInt delta underflows/wraps. Fold them all in here, mirroring
-            // the per-cell timestamp threading in `rows.rs` / `encoding.rs`.
+            // Issue #1018: a simple `Write`/`WriteWithTtl`/`Delete` cell may carry
+            // its OWN (lower) per-cell timestamp in
+            // `Mutation::cell_write_timestamps` — a live cell's writetime OR a cell
+            // tombstone's markedForDeleteAt (the compaction merge→mutation path
+            // records it when it differs from the row's `timestamp_micros`). The
+            // DataWriter emits that cell's explicit timestamp as a `min_timestamp`
+            // delta, so the pre-seeded baseline must cover EVERY per-cell timestamp
+            // — otherwise `min_timestamp` could be pre-seeded ABOVE an emitted
+            // cell's actual (lower) timestamp and the unsigned-VInt delta
+            // underflows/wraps. Fold them all in here, mirroring the per-cell
+            // timestamp threading in `rows.rs` / `encoding.rs`.
             if let Some(cell_ts) = &mutation.cell_write_timestamps {
                 for ts in cell_ts.values() {
                     min_timestamp = min_timestamp.min(*ts);

--- a/cqlite-core/src/storage/sstable/writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/mod.rs
@@ -574,6 +574,18 @@ impl SSTableWriter {
         // Update statistics from mutations
         for mutation in &mutations {
             self.stats.update_timestamp(mutation.timestamp_micros);
+            // Issue #1018: simple `Write`/`WriteWithTtl` cells may carry their OWN
+            // (lower) write timestamps in `Mutation::cell_write_timestamps` and are
+            // emitted with an explicit `min_timestamp` delta. On the non-preseeded
+            // (incremental) write path, fold every per-cell timestamp into the stats
+            // BEFORE emitting cells so `min_timestamp` can never exceed an emitted
+            // cell's actual timestamp (which would underflow the unsigned-VInt
+            // delta). Mirrors the pre-pass fold in `compute_mutations_baseline_stats`.
+            if let Some(cell_ts) = &mutation.cell_write_timestamps {
+                for ts in cell_ts.values() {
+                    self.stats.update_timestamp(*ts);
+                }
+            }
             if let Some(ttl) = mutation.ttl_seconds {
                 self.stats.update_ttl(ttl as i32);
                 let now_seconds = std::time::SystemTime::now()
@@ -822,6 +834,21 @@ impl SSTableWriter {
 
         for mutation in mutations_slice {
             min_timestamp = min_timestamp.min(mutation.timestamp_micros);
+
+            // Issue #1018: a simple `Write`/`WriteWithTtl` cell may carry its OWN
+            // (lower) write timestamp in `Mutation::cell_write_timestamps` (the
+            // compaction merge→mutation path records it when it differs from the
+            // row's `timestamp_micros`). The DataWriter emits that cell's explicit
+            // timestamp as a `min_timestamp` delta, so the pre-seeded baseline must
+            // cover EVERY per-cell timestamp — otherwise `min_timestamp` could be
+            // pre-seeded ABOVE an emitted cell's actual (lower) timestamp and the
+            // unsigned-VInt delta underflows/wraps. Fold them all in here, mirroring
+            // the per-cell timestamp threading in `rows.rs` / `encoding.rs`.
+            if let Some(cell_ts) = &mutation.cell_write_timestamps {
+                for ts in cell_ts.values() {
+                    min_timestamp = min_timestamp.min(*ts);
+                }
+            }
 
             for op in &mutation.operations {
                 match op {
@@ -1792,6 +1819,93 @@ mod tests {
             min_ttl, 600,
             "baseline min_ttl must reflect the per-element TTL"
         );
+    }
+
+    /// Issue #1018 (roborev finding 1): a simple `Write` cell may carry its OWN
+    /// (lower) write timestamp in `Mutation::cell_write_timestamps`. The DataWriter
+    /// emits that cell with an explicit `min_timestamp` delta, so the PRE-SEEDED
+    /// baseline path (`compute_mutations_baseline_stats`, issue #729 two-pass flush)
+    /// must fold every per-cell timestamp into `min_timestamp`. RED before the fix:
+    /// the baseline only saw the row `timestamp_micros` (the row max), so it could
+    /// be locked ABOVE the surviving cell's lower timestamp and the delta underflows.
+    #[test]
+    fn test_compute_baseline_folds_per_cell_write_timestamps_1018() {
+        let table_id = TableId::new("test_ks", "test_table");
+        let pk = PartitionKey::single("id", Value::Integer(1));
+
+        const ROW_TS: i64 = 5_000_000;
+        const CELL_TS: i64 = 3_000_000;
+
+        let mut mutation = Mutation::new(
+            table_id,
+            pk,
+            None,
+            vec![CellOperation::Write {
+                column: "name".to_string(),
+                value: Value::Text("survivor".to_string()),
+            }],
+            ROW_TS,
+            None,
+        );
+        let mut cell_ts = HashMap::new();
+        cell_ts.insert("name".to_string(), CELL_TS);
+        mutation.cell_write_timestamps = Some(cell_ts);
+
+        let (min_ts, _min_ldt, _min_ttl) =
+            SSTableWriter::compute_mutations_baseline_stats(std::slice::from_ref(&mutation));
+
+        assert_eq!(
+            min_ts, CELL_TS,
+            "#1018: baseline min_timestamp must cover the per-cell write timestamp, \
+             not just the row max — else the locked delta underflows on the cell"
+        );
+    }
+
+    /// Issue #1018 (roborev finding 1): the NON-preseeded (incremental)
+    /// `write_partition` stats path must also fold per-cell write timestamps before
+    /// emitting cells, so `min_timestamp` never exceeds an emitted cell's own
+    /// (lower) timestamp. RED before the fix: the write underflows the unsigned-VInt
+    /// timestamp delta (cell ts below the row-max baseline) and errors.
+    #[tokio::test]
+    async fn test_per_cell_write_timestamp_no_underflow_on_write_1018() {
+        let temp_dir = TempDir::new().unwrap();
+        let schema = create_test_schema();
+        let mut writer = SSTableWriter::new(temp_dir.path().to_path_buf(), 1, &schema).unwrap();
+
+        const ROW_TS: i64 = 5_000_000;
+        const CELL_TS: i64 = 3_000_000;
+
+        let table_id = TableId::new("test_ks", "test_table");
+        let pk = PartitionKey::single("id", Value::Integer(7));
+        let mut mutation = Mutation::new(
+            table_id,
+            pk,
+            None,
+            vec![CellOperation::Write {
+                column: "name".to_string(),
+                value: Value::Text("survivor".to_string()),
+            }],
+            ROW_TS,
+            None,
+        );
+        let mut cell_ts = HashMap::new();
+        cell_ts.insert("name".to_string(), CELL_TS);
+        mutation.cell_write_timestamps = Some(cell_ts);
+        let key = mutation.decorated_key(&schema).unwrap();
+
+        // The write must SUCCEED: the per-cell ts (3_000_000) is below the row max
+        // (5_000_000), so if stats only recorded the row ts the cell-ts delta
+        // underflows.
+        writer
+            .write_partition(key, vec![mutation])
+            .expect("#1018: per-cell write ts below the row ts must not underflow the baseline");
+
+        assert_eq!(
+            writer.stats.min_timestamp, CELL_TS,
+            "#1018: min_timestamp must reflect the lower per-cell write timestamp"
+        );
+
+        let _info = writer.finish().await.unwrap();
     }
 
     /// #921 finding 2 (roborev Medium): a `CellOperation::Delete` carrying an

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -3354,34 +3354,36 @@ impl KWayMerger {
             RowData::Live { .. } => None,
         };
 
-        // Issue #1018: capture each surviving SIMPLE live cell's OWN write
+        // Issue #1018: capture each surviving SIMPLE cell's OWN per-cell
         // timestamp BEFORE the cells are consumed by `cells_to_cell_operations`
-        // (which turns them into `CellOperation::Write`/`WriteWithTtl` ops that
-        // carry no per-cell timestamp). A reconciled row's `entry.timestamp` is
-        // the MAX surviving cell timestamp; promoting every live sibling to that
-        // max would rewrite a cell's writetime (e.g. live `name`@100 next to a
-        // `score` cell tombstone@300 → `name` wrongly rewritten to 300). Recording
-        // only cells whose own timestamp DIFFERS from `entry.timestamp` keeps the
-        // side-channel empty for the common single-writetime row (zero behavior
-        // change there) and lets the writer emit the differing cells with their
-        // own explicit delta. Complex-element cells already carry their own
-        // timestamp via `WriteComplexElement` and are excluded; cell tombstones
-        // (`Value::Tombstone`) carry their deletion time independently.
+        // (which turns them into `CellOperation::Write`/`WriteWithTtl`/`Delete`
+        // ops that carry no per-cell timestamp). A reconciled row's
+        // `entry.timestamp` is the MAX surviving cell timestamp; promoting every
+        // sibling to that max would rewrite a cell's timestamp:
+        //   * a live `name`@100 next to a `score` cell tombstone@300 → `name`
+        //     wrongly rewritten to 300 (the original fix), AND
+        //   * a `c1` cell tombstone@100 next to a live `c2`@300 → the tombstone's
+        //     marked-for-delete-at wrongly rewritten to 300, so a LATER
+        //     compaction that sees `c1` live@200 would be incorrectly shadowed
+        //     and DROPPED (over-deletion — roborev HIGH).
+        // For a SIMPLE cell tombstone (`Value::Tombstone(CellTombstone)`) the
+        // cell's `timestamp` IS its `markedForDeleteAt` (µs); its GC-clock
+        // `localDeletionTime` is preserved INDEPENDENTLY via
+        // `CellOperation::Delete::local_deletion_time` (#921). Recording any
+        // simple cell (live OR tombstone) whose own timestamp DIFFERS from
+        // `entry.timestamp` keeps the side-channel empty for the common
+        // single-writetime row (zero behavior change there) and lets the writer
+        // emit the differing cell with its own explicit timestamp. The map is
+        // keyed by column name; per-cell reconciliation already collapses each
+        // column to a single surviving op, so one timestamp per column is exact.
+        // Complex-element cells already carry their own timestamp via
+        // `WriteComplexElement` and are excluded (`!c.is_complex_element`).
         let cell_write_timestamps: Option<std::collections::HashMap<String, i64>> =
             match &entry.row_data {
                 RowData::Live { cells } => {
-                    use crate::types::{TombstoneType, Value};
                     let map: std::collections::HashMap<String, i64> = cells
                         .iter()
-                        .filter(|c| {
-                            !c.is_complex_element
-                                && c.timestamp != entry.timestamp
-                                && !matches!(
-                                    &c.value,
-                                    Value::Tombstone(info)
-                                        if info.tombstone_type == TombstoneType::CellTombstone
-                                )
-                        })
+                        .filter(|c| !c.is_complex_element && c.timestamp != entry.timestamp)
                         .map(|c| (c.column.clone(), c.timestamp))
                         .collect();
                     (!map.is_empty()).then_some(map)
@@ -3455,8 +3457,9 @@ impl KWayMerger {
         if let Some(rt) = range_tombstone {
             mutation.range_tombstones.push(rt);
         }
-        // Issue #1018: thread per-cell write timestamps so the writer preserves
-        // each live sibling cell's own writetime instead of the row max.
+        // Issue #1018: thread per-cell timestamps so the writer preserves each
+        // surviving sibling cell's own timestamp instead of the row max — for
+        // BOTH a live cell's writetime AND a cell tombstone's markedForDeleteAt.
         mutation.cell_write_timestamps = cell_write_timestamps;
         Ok(mutation)
     }

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -3354,6 +3354,41 @@ impl KWayMerger {
             RowData::Live { .. } => None,
         };
 
+        // Issue #1018: capture each surviving SIMPLE live cell's OWN write
+        // timestamp BEFORE the cells are consumed by `cells_to_cell_operations`
+        // (which turns them into `CellOperation::Write`/`WriteWithTtl` ops that
+        // carry no per-cell timestamp). A reconciled row's `entry.timestamp` is
+        // the MAX surviving cell timestamp; promoting every live sibling to that
+        // max would rewrite a cell's writetime (e.g. live `name`@100 next to a
+        // `score` cell tombstone@300 → `name` wrongly rewritten to 300). Recording
+        // only cells whose own timestamp DIFFERS from `entry.timestamp` keeps the
+        // side-channel empty for the common single-writetime row (zero behavior
+        // change there) and lets the writer emit the differing cells with their
+        // own explicit delta. Complex-element cells already carry their own
+        // timestamp via `WriteComplexElement` and are excluded; cell tombstones
+        // (`Value::Tombstone`) carry their deletion time independently.
+        let cell_write_timestamps: Option<std::collections::HashMap<String, i64>> =
+            match &entry.row_data {
+                RowData::Live { cells } => {
+                    use crate::types::{TombstoneType, Value};
+                    let map: std::collections::HashMap<String, i64> = cells
+                        .iter()
+                        .filter(|c| {
+                            !c.is_complex_element
+                                && c.timestamp != entry.timestamp
+                                && !matches!(
+                                    &c.value,
+                                    Value::Tombstone(info)
+                                        if info.tombstone_type == TombstoneType::CellTombstone
+                                )
+                        })
+                        .map(|c| (c.column.clone(), c.timestamp))
+                        .collect();
+                    (!map.is_empty()).then_some(map)
+                }
+                RowData::Tombstone { .. } => None,
+            };
+
         let mut operations = match entry.row_data {
             RowData::Live { cells } => Self::cells_to_cell_operations(cells),
             RowData::Tombstone { .. } => vec![CellOperation::DeleteRow],
@@ -3420,6 +3455,9 @@ impl KWayMerger {
         if let Some(rt) = range_tombstone {
             mutation.range_tombstones.push(rt);
         }
+        // Issue #1018: thread per-cell write timestamps so the writer preserves
+        // each live sibling cell's own writetime instead of the row max.
+        mutation.cell_write_timestamps = cell_write_timestamps;
         Ok(mutation)
     }
 }
@@ -4781,6 +4819,127 @@ mod tests {
         });
         assert!(has_write, "Expected Write operation for 'name'");
         assert!(has_ttl_write, "Expected WriteWithTtl operation for 'age'");
+    }
+
+    /// Issue #1018: a reconciled row whose surviving cells carry DIFFERENT write
+    /// timestamps must preserve each cell's OWN writetime through the
+    /// merge→mutation step. The row's `timestamp_micros` is the MAX surviving
+    /// timestamp; cells whose timestamp differs from that max must be recorded in
+    /// `Mutation::cell_write_timestamps` so the writer does not promote them to
+    /// the row max. Cells at the row max are NOT recorded (they correctly inherit
+    /// the row timestamp), keeping the side-channel empty for single-writetime
+    /// rows.
+    #[test]
+    fn merge_entry_preserves_per_cell_write_timestamps() {
+        use crate::schema::{KeyColumn, TableSchema};
+        use crate::storage::write_engine::mutation::DecoratedKey;
+        use std::collections::HashMap;
+
+        let schema = TableSchema {
+            keyspace: "test_ks".to_string(),
+            table: "test_table".to_string(),
+            partition_keys: vec![KeyColumn {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![],
+            columns: vec![],
+            comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
+        };
+
+        let cell = |column: &str, ts: i64| CellData {
+            column: column.to_string(),
+            value: Value::Text(column.to_string()),
+            timestamp: ts,
+            ttl: None,
+            cell_path: None,
+            local_deletion_time: None,
+            is_complex_element: false,
+            is_deleted: false,
+            has_empty_value: false,
+        };
+
+        // Row max writetime is 300 (the `late` cell); `early`@100 is a live
+        // sibling that must keep its own writetime.
+        let entry = MergeEntry::new(
+            0,
+            DecoratedKey::new(1000, 42i32.to_be_bytes().to_vec()),
+            None,
+            300,
+            RowData::Live {
+                cells: vec![cell("early", 100), cell("late", 300)],
+            },
+        );
+
+        let mutation =
+            KWayMerger::merge_entry_to_mutation(entry, &schema).expect("conversion should succeed");
+
+        assert_eq!(mutation.timestamp_micros, 300);
+        let cwt = mutation
+            .cell_write_timestamps
+            .as_ref()
+            .expect("per-cell write timestamps must be recorded for a mixed-writetime row");
+        // Only the cell whose ts differs from the row max is recorded.
+        assert_eq!(cwt.get("early"), Some(&100));
+        assert_eq!(cwt.get("late"), None);
+        // The lookup helper falls back to the row timestamp for unrecorded cells.
+        assert_eq!(mutation.cell_write_timestamp("early"), 100);
+        assert_eq!(mutation.cell_write_timestamp("late"), 300);
+    }
+
+    /// Issue #1018: a single-writetime row leaves the per-cell side-channel unset
+    /// (zero behavior change for the common case).
+    #[test]
+    fn merge_entry_single_writetime_row_has_no_per_cell_overrides() {
+        use crate::schema::{KeyColumn, TableSchema};
+        use crate::storage::write_engine::mutation::DecoratedKey;
+        use std::collections::HashMap;
+
+        let schema = TableSchema {
+            keyspace: "test_ks".to_string(),
+            table: "test_table".to_string(),
+            partition_keys: vec![KeyColumn {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![],
+            columns: vec![],
+            comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
+        };
+
+        let cell = |column: &str| CellData {
+            column: column.to_string(),
+            value: Value::Text(column.to_string()),
+            timestamp: 555,
+            ttl: None,
+            cell_path: None,
+            local_deletion_time: None,
+            is_complex_element: false,
+            is_deleted: false,
+            has_empty_value: false,
+        };
+
+        let entry = MergeEntry::new(
+            0,
+            DecoratedKey::new(1000, 7i32.to_be_bytes().to_vec()),
+            None,
+            555,
+            RowData::Live {
+                cells: vec![cell("a"), cell("b")],
+            },
+        );
+
+        let mutation =
+            KWayMerger::merge_entry_to_mutation(entry, &schema).expect("conversion should succeed");
+        assert!(
+            mutation.cell_write_timestamps.is_none(),
+            "single-writetime row must not record any per-cell overrides"
+        );
+        assert_eq!(mutation.cell_write_timestamp("a"), 555);
     }
 
     #[test]

--- a/cqlite-core/src/storage/write_engine/mutation.rs
+++ b/cqlite-core/src/storage/write_engine/mutation.rs
@@ -112,6 +112,26 @@ pub struct Mutation {
     /// present, rides as `CellOperation::DeleteRow` at `timestamp_micros`.
     #[serde(default)]
     pub row_tombstone: Option<(i64, i32)>,
+    /// Per-column write timestamps (microseconds) for the simple-cell
+    /// `Write`/`WriteWithTtl` operations of this mutation (issue #1018).
+    ///
+    /// `CellOperation::Write`/`WriteWithTtl` carry no per-cell timestamp — every
+    /// such cell historically inherits the row's single `timestamp_micros`. On
+    /// the compaction merge→mutation path a reconciled row can hold sibling cells
+    /// at DIFFERENT writetimes (e.g. live `name`@100 alongside a `score` cell
+    /// tombstone@300). Promoting every live cell to the row's MAX writetime would
+    /// rewrite `name`'s writetime to 300, losing fidelity. This side-channel maps
+    /// a regular column name → that cell's OWN write timestamp so the writer emits
+    /// it verbatim (clearing `USE_ROW_TIMESTAMP` when it differs from the row
+    /// marker).
+    ///
+    /// `None` / absent column (the default) preserves historical behavior: the
+    /// cell inherits `timestamp_micros`. Populated only by
+    /// `merge_entry_to_mutation`; the WAL / CQL-INSERT paths leave it unset (their
+    /// cells genuinely share one writetime). `#[serde(default)]` keeps backward
+    /// compatibility with mutations serialized before this field existed.
+    #[serde(default)]
+    pub cell_write_timestamps: Option<std::collections::HashMap<String, i64>>,
 }
 
 impl Mutation {
@@ -135,7 +155,19 @@ impl Mutation {
             range_tombstones: Vec::new(),
             local_deletion_time: None,
             row_tombstone: None,
+            cell_write_timestamps: None,
         }
+    }
+
+    /// Per-cell write timestamp (microseconds) for `column`, falling back to the
+    /// mutation's row `timestamp_micros` when no per-cell override was supplied
+    /// (issue #1018). Used by the writer to decide whether a simple cell keeps
+    /// `USE_ROW_TIMESTAMP` or carries its own explicit delta.
+    pub fn cell_write_timestamp(&self, column: &str) -> i64 {
+        self.cell_write_timestamps
+            .as_ref()
+            .and_then(|m| m.get(column).copied())
+            .unwrap_or(self.timestamp_micros)
     }
 
     /// Attach a row-level deletion that coexists with this mutation's live cells

--- a/cqlite-core/src/storage/write_engine/wal.rs
+++ b/cqlite-core/src/storage/write_engine/wal.rs
@@ -282,6 +282,8 @@ impl From<LegacyMutation> for Mutation {
             local_deletion_time: None,
             // Pre-#932 records had no coexisting row tombstone field.
             row_tombstone: None,
+            // Pre-#1018 records had no per-cell write-timestamp side-channel.
+            cell_write_timestamps: None,
         }
     }
 }
@@ -336,6 +338,8 @@ impl From<LegacyMutationWithLdt> for Mutation {
             local_deletion_time: m.local_deletion_time,
             // Layout (B) predates #932; no coexisting row tombstone field.
             row_tombstone: None,
+            // Layout (B) predates #1018; no per-cell write-timestamp side-channel.
+            cell_write_timestamps: None,
         }
     }
 }
@@ -381,6 +385,55 @@ impl From<PreRowTombstoneMutation> for Mutation {
             local_deletion_time: m.local_deletion_time,
             // Pre-#932 records carry no coexisting row tombstone.
             row_tombstone: None,
+            // Pre-#1018 records carry no per-cell write-timestamp side-channel.
+            cell_write_timestamps: None,
+        }
+    }
+}
+
+/// On-disk `Mutation` layout post-Issue #932, pre-Issue #1018.
+///
+/// Issue #1018 appended a trailing `cell_write_timestamps:
+/// Option<HashMap<String, i64>>` field to [`Mutation`]. Because the WAL has no
+/// per-record version field and bincode is positional, a record written by a
+/// #932-era binary (layout (D): current op shapes, mutation LDT AND
+/// `row_tombstone`, but NO trailing `cell_write_timestamps`) has no bytes for
+/// the new field, so decoding it as the current [`Mutation`] runs out of bytes.
+/// This mirror reproduces the EXACT layout-(D) field order so such records still
+/// replay, upgrading `cell_write_timestamps` to `None` (historical behavior:
+/// every cell inherits the row timestamp).
+///
+/// The field order MUST stay in lockstep with [`Mutation`], with only the
+/// trailing `cell_write_timestamps` omitted.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct PreCellWriteTimestampsMutation {
+    table: TableId,
+    partition_key: PartitionKey,
+    clustering_key: Option<ClusteringKey>,
+    operations: Vec<CellOperation>,
+    timestamp_micros: i64,
+    ttl_seconds: Option<u32>,
+    partition_tombstone: Option<PartitionTombstone>,
+    range_tombstones: Vec<RangeTombstone>,
+    local_deletion_time: Option<i32>,
+    row_tombstone: Option<(i64, i32)>,
+}
+
+impl From<PreCellWriteTimestampsMutation> for Mutation {
+    fn from(m: PreCellWriteTimestampsMutation) -> Self {
+        Mutation {
+            table: m.table,
+            partition_key: m.partition_key,
+            clustering_key: m.clustering_key,
+            operations: m.operations,
+            timestamp_micros: m.timestamp_micros,
+            ttl_seconds: m.ttl_seconds,
+            partition_tombstone: m.partition_tombstone,
+            range_tombstones: m.range_tombstones,
+            local_deletion_time: m.local_deletion_time,
+            row_tombstone: m.row_tombstone,
+            // Pre-#1018 records carry no per-cell write-timestamp side-channel.
+            cell_write_timestamps: None,
         }
     }
 }
@@ -399,6 +452,13 @@ fn decode_mutation(bytes: &[u8]) -> std::result::Result<Mutation, bincode::Error
     match bincode::deserialize::<Mutation>(bytes) {
         Ok(mutation) => Ok(mutation),
         Err(current_err) => {
+            // Layout (D): post-#932, pre-#1018 — current op shapes + mutation LDT
+            // + `row_tombstone` but no trailing `cell_write_timestamps`. Tried
+            // first so a #932-era record decodes correctly rather than misaligning
+            // under the older mirrors below.
+            if let Ok(m) = bincode::deserialize::<PreCellWriteTimestampsMutation>(bytes) {
+                return Ok(Mutation::from(m));
+            }
             // Layout (C): post-#921, pre-#932 — current op shapes + mutation LDT
             // but no trailing `row_tombstone`. Tried first so a #921-era record
             // with current `Delete { column, local_deletion_time }` ops decodes

--- a/cqlite-core/tests/issue_819_differential_compaction.rs
+++ b/cqlite-core/tests/issue_819_differential_compaction.rs
@@ -1683,21 +1683,15 @@ fn differential_vs_live_cassandra_env_gated() {
 /// framing is corrupted (garbage clustering values, wrong partition keys).
 ///
 /// This is exactly the "write-side issue only the next merge observes" that the
-/// two-generation check (AC2) is designed to catch. The harness catches it; the
-/// underlying writer/reader fix is OUT OF SCOPE for #819 (it belongs to the
-/// compaction-fidelity epic #817's writer work).
+/// two-generation check (AC2) is designed to catch.
 ///
-/// The test is `#[ignore]`d so the default `cargo test` run stays green (and does
-/// not fabricate a pass), while preserving a runnable, documented reproduction:
-/// ```text
-/// cargo test --package cqlite-core --features write-support \
-///   --test issue_819_differential_compaction \
-///   -- --ignored differential_row_tombstone_wide_partition_regression
-/// ```
-/// When the writer/reader round-trips a clustering-table row tombstone correctly,
-/// this test will PASS and the `#[ignore]` can be removed.
+/// HISTORY (issue #1018): this was `#[ignore]`d while the clustering-table
+/// row-tombstone compaction round-trip was defective (epic #817 writer scope).
+/// That underlying defect was fixed by #899 / #972, so the test now PASSES and
+/// serves as a standing regression guard: it asserts that compacting a wide
+/// partition containing a clustering-row tombstone round-trips the marker
+/// correctly through gen1 read-back.
 #[test]
-#[ignore = "pins a real clustering-table row-tombstone compaction round-trip defect (epic #817 writer scope)"]
 fn differential_row_tombstone_wide_partition_regression() {
     let (_temp, inputs, schema) = build_inputs_with_row_tombstone();
 
@@ -1721,16 +1715,15 @@ fn differential_row_tombstone_wide_partition_regression() {
 /// compacted output must match the tuples observed when *merging the inputs* —
 /// i.e. the writer must persist every input cell's write timestamp exactly.
 ///
-/// Today this FAILS for a row that carries a cell tombstone: the live sibling
-/// cells (`ck`, `name`) of that row are rewritten with the row's max timestamp
-/// (the tombstone's ts) instead of their original write timestamp. The gen1-vs-
-/// gen2 gate does not catch this because BOTH generations exhibit the same
-/// rewrite (it is stable), so it is pinned separately here.
-///
-/// `#[ignore]`d to keep the default run green without fabricating a pass; run on
-/// demand with `-- --ignored differential_input_merge_write_fidelity`.
+/// HISTORY (issue #1018): this previously FAILED for a row carrying a cell
+/// tombstone — the live sibling cells (`ck`, `name`) of that row were rewritten
+/// with the row's max timestamp (the tombstone's ts) instead of their original
+/// write timestamp. The gen1-vs-gen2 gate did not catch it because BOTH
+/// generations exhibited the same stable rewrite, so it was pinned separately
+/// here. Issue #1018 threads each surviving cell's OWN write timestamp through
+/// the merge→mutation→writer path (`Mutation::cell_write_timestamps`), so every
+/// live cell now keeps its writetime and this test PASSES as a regression guard.
 #[test]
-#[ignore = "pins a real cell-timestamp rewrite on cell-tombstone sibling cells (epic #817 writer scope)"]
 fn differential_input_merge_write_fidelity() {
     let (_temp, inputs, schema) = build_three_inputs();
     let g1_dir = TempDir::new().expect("g1 dir");

--- a/cqlite-core/tests/issue_819_differential_compaction.rs
+++ b/cqlite-core/tests/issue_819_differential_compaction.rs
@@ -1738,3 +1738,216 @@ fn differential_input_merge_write_fidelity() {
         &read_back_g1,
     );
 }
+
+// ════════════════════════════════════════════════════════════════════════════
+// SECTION 8 — Issue #1018 (roborev HIGH): cell-tombstone timestamp rewrite →
+//             later over-deletion
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Find the single cell named `column` in the (id, ck) tuple of `tuples`, or
+/// `None` if the tuple/cell is absent.
+fn find_cell<'a>(
+    tuples: &'a [CanonicalTuple],
+    id: i32,
+    ck: i32,
+    column: &str,
+) -> Option<&'a CanonicalCell> {
+    // The canonical tuple carries the RAW on-disk partition-key bytes
+    // (`entry.key.key`) — for a single `int` partition key that is the 4-byte
+    // big-endian value, NOT the tagged `value_to_bytes` form.
+    let want_pk = id.to_be_bytes().to_vec();
+    // Clustering bytes for `ck` as produced by `canonical_clustering_bytes`.
+    let want_ck = {
+        let ck_key = ClusteringKey::single("ck", Value::Integer(ck));
+        canonical_clustering_bytes(&ck_key)
+    };
+    tuples
+        .iter()
+        .find(|t| {
+            t.kind == RowKind::Live
+                && t.partition_key == want_pk
+                && t.clustering_key.as_deref() == Some(want_ck.as_slice())
+        })
+        .and_then(|t| t.cells.iter().find(|c| c.column == column))
+}
+
+/// Build gen-1 inputs that reconcile `score`(=c1) as a CELL TOMBSTONE@100 next to
+/// a live `name`(=c2)@300 on the SAME row (id=1 ck=1). The row's MAX timestamp is
+/// 300, so before the fix the writer rewrote the surviving `score` cell
+/// tombstone's markedForDeleteAt from 100 to 300. Returns inputs newest-first.
+fn build_cell_tombstone_sibling_inputs() -> (TempDir, Vec<PathBuf>, TableSchema) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    let temp = TempDir::new().expect("tempdir");
+    let data_dir = temp.path().join("inputs");
+    let wal_dir = temp.path().join("wal");
+    let schema = make_schema();
+
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir.clone(), schema.clone());
+    let mut engine = WriteEngine::new(config).expect("engine");
+
+    // SSTable A (ts=100): cell-delete `score` on id=1 ck=1 (markedForDeleteAt=100).
+    engine
+        .write(delete_score_cell(1, 1, 100))
+        .expect("cell delete A");
+    rt.block_on(engine.flush())
+        .expect("flush A")
+        .expect("info A");
+
+    // SSTable B (ts=300): write only `name` on id=1 ck=1 (live@300), the
+    // higher-ts sibling that drives the reconciled row's MAX timestamp to 300.
+    engine
+        .write(write_name_only(1, 1, "live-name", 300))
+        .expect("write B name");
+    rt.block_on(engine.flush())
+        .expect("flush B")
+        .expect("info B");
+
+    rt.block_on(engine.close()).expect("close engine");
+
+    let inputs = discover_inputs(&data_dir);
+    assert!(inputs.len() >= 2, "expected >=2 inputs");
+    (temp, inputs, schema)
+}
+
+/// A mutation writing ONLY the `name` column (no `score`), so it cannot mask the
+/// sibling `score` cell tombstone's own timestamp.
+fn write_name_only(id: i32, ck: i32, name: &str, ts: i64) -> Mutation {
+    Mutation::new(
+        TableId::new("diff_ks", "items"),
+        PartitionKey::single("id", Value::Integer(id)),
+        Some(ClusteringKey::single("ck", Value::Integer(ck))),
+        vec![CellOperation::Write {
+            column: "name".to_string(),
+            value: Value::Text(name.to_string()),
+        }],
+        ts,
+        None,
+    )
+}
+
+/// A mutation writing ONLY the `score` column live at `ts`.
+fn write_score_only(id: i32, ck: i32, score: i32, ts: i64) -> Mutation {
+    Mutation::new(
+        TableId::new("diff_ks", "items"),
+        PartitionKey::single("id", Value::Integer(id)),
+        Some(ClusteringKey::single("ck", Value::Integer(ck))),
+        vec![CellOperation::Write {
+            column: "score".to_string(),
+            value: Value::Integer(score),
+        }],
+        ts,
+        None,
+    )
+}
+
+/// **Pinned over-deletion regression (issue #1018, roborev HIGH).**
+///
+/// A simple cell tombstone reconciled next to a higher-ts live sibling must keep
+/// its OWN markedForDeleteAt through compaction; otherwise a LATER compaction sees
+/// the tombstone rewritten to the row max and incorrectly shadows + DROPS a newer
+/// value (over-deletion / data loss).
+///
+/// Two generations:
+///   GEN 1: compact `score`-tombstone@100 + `name`-live@300 → assert the emitted
+///          `score` cell tombstone RETAINS timestamp 100 (NOT 300).
+///   GEN 2: compact gen-1 against a fresh `score`-live@200 → assert `score`=200
+///          SURVIVES (the @100 tombstone must NOT shadow it).
+///
+/// PRE-FIX behavior (the bug this guards): gen-1 rewrites the tombstone to 300,
+/// then gen-2 shadows the @200 write (300 >= 200) and drops it — so `score` is
+/// absent from gen-2. This test FAILS pre-fix at the gen-1 timestamp assertion
+/// (100 != 300) and again at the gen-2 survival assertion, and PASSES post-fix.
+#[test]
+fn differential_cell_tombstone_no_over_deletion_two_generations() {
+    let (_temp, inputs, schema) = build_cell_tombstone_sibling_inputs();
+
+    // ── GEN 1: reconcile the cell tombstone@100 with the live sibling@300. ──
+    let g1_dir = TempDir::new().expect("g1 dir");
+    let g1 = cqlite_compact(inputs.clone(), g1_dir.path(), &schema, 1801);
+    assert_tier1_valid("ct-gen1-output", &load_path_report(&g1, &schema));
+
+    let read_back_g1 = canonical_tuples_from_sstables(vec![g1.data_path.clone()], &schema);
+
+    // The live `name`@300 survives at its own writetime.
+    let name_g1 = find_cell(&read_back_g1, 1, 1, "name").expect("name must survive gen-1");
+    assert_eq!(
+        name_g1.timestamp, 300,
+        "live `name` sibling must keep its own writetime 300"
+    );
+
+    // The surviving `score` cell tombstone must keep markedForDeleteAt=100, NOT
+    // the row max 300. (Cell-tombstone deletion time rides in `value_bytes`; its
+    // surfaced per-cell `timestamp` IS the markedForDeleteAt.)
+    let score_g1 =
+        find_cell(&read_back_g1, 1, 1, "score").expect("score cell tombstone must survive gen-1");
+    assert_eq!(
+        score_g1.timestamp, 100,
+        "BUG (#1018 roborev HIGH): cell tombstone rewritten from 100 to the row \
+         max — got {}",
+        score_g1.timestamp
+    );
+
+    // ── GEN 2: compact gen-1 against a fresh `score` live write@200. ──
+    //
+    // A correct system keeps the @200 write: the surviving tombstone's true
+    // markedForDeleteAt is 100 < 200, so it does NOT shadow the newer value. If
+    // gen-1 had rewritten the tombstone to 300, the @200 write would be shadowed
+    // (300 >= 200) and DROPPED — over-deletion.
+    let temp2 = TempDir::new().expect("tempdir2");
+    let data_dir2 = temp2.path().join("inputs2");
+    let wal_dir2 = temp2.path().join("wal2");
+    {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let config = WriteEngineConfig::new(data_dir2.clone(), wal_dir2.clone(), schema.clone());
+        let mut engine = WriteEngine::new(config).expect("engine2");
+        engine
+            .write(write_score_only(1, 1, 4242, 200))
+            .expect("write score@200");
+        rt.block_on(engine.flush())
+            .expect("flush score@200")
+            .expect("info score@200");
+        rt.block_on(engine.close()).expect("close engine2");
+    }
+    let new_input = discover_inputs(&data_dir2);
+    assert_eq!(new_input.len(), 1, "expected one new input SSTable");
+
+    // Inputs newest-first: the fresh @200 write, then gen-1's output.
+    let gen2_inputs = vec![new_input[0].clone(), g1.data_path.clone()];
+    let g2_dir = TempDir::new().expect("g2 dir");
+    let g2 = cqlite_compact(gen2_inputs, g2_dir.path(), &schema, 1802);
+    assert_tier1_valid("ct-gen2-output", &load_path_report(&g2, &schema));
+
+    let read_back_g2 = canonical_tuples_from_sstables(vec![g2.data_path.clone()], &schema);
+
+    let score_g2 = find_cell(&read_back_g2, 1, 1, "score").unwrap_or_else(|| {
+        panic!(
+            "OVER-DELETION (#1018 roborev HIGH): the `score`@200 write was \
+             incorrectly shadowed by a rewritten cell tombstone and DROPPED"
+        )
+    });
+    assert!(
+        !score_g2.is_deleted,
+        "the surviving `score` must be the LIVE @200 write, not a tombstone"
+    );
+    assert_eq!(
+        score_g2.timestamp, 200,
+        "the newer `score`@200 write must survive gen-2"
+    );
+    assert_eq!(
+        score_g2.value_bytes,
+        value_to_bytes(&Value::Integer(4242)),
+        "the surviving `score` value must be the @200 write's value"
+    );
+
+    eprintln!(
+        "differential_cell_tombstone_no_over_deletion_two_generations PASSED: \
+         cell tombstone kept markedForDeleteAt=100 through gen-1 and the later \
+         score@200 write survived gen-2 (no over-deletion)"
+    );
+}

--- a/docs/reports/cassandra-test-parity.md
+++ b/docs/reports/cassandra-test-parity.md
@@ -10,18 +10,18 @@ Sources: [`docs/cassandra_test_index.md`](../../docs/cassandra_test_index.md) ·
 
 | Status | Scenarios |
 |---|---|
-| `mirrored` | 187 |
+| `mirrored` | 193 |
 | `partial` | 17 |
 | `planned` | 18 |
 | `out_of_scope` | 14 |
-| **total** | **236** |
+| **total** | **242** |
 
 ## Evidence counts
 
 | Evidence | Scenarios |
 |---|---|
-| `byte_for_byte` | 106 |
-| `canonical_semantic` | 80 |
+| `byte_for_byte` | 109 |
+| `canonical_semantic` | 83 |
 | `smoke` | 7 |
 | `partial` | 27 |
 | `out_of_scope` | 16 |
@@ -62,7 +62,10 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 | `cass.compaction.SSTableRewriterTest.output_component_integrity` | compaction_merge | planned | byte_for_byte | `compaction_parity_tombstone_ttl` | p0_data_loss |
 | `cass.compaction.harness_byte_tier_artifacts` | compaction_merge | planned | byte_for_byte | `compaction_parity_tombstone_ttl` | p0_data_loss |
 | `cass.compaction.harness_logical_tier` | compaction_merge | mirrored | canonical_semantic | `compaction_parity_tombstone_ttl` | p1_correctness |
+| `cass.compaction_merge.GcCompactionTest.row_cell_partition_tombstone_gc` | compaction_merge | mirrored | canonical_semantic | `compaction_parity_tombstone_ttl` | p0_data_loss |
 | `cass.compaction_merge.byte_for_byte_output` | compaction_merge | planned | partial | `compaction_parity_tombstone_ttl` | p0_data_loss |
+| `cass.compaction_merge.issue_819.differential_input_merge_write_fidelity` | compaction_merge | mirrored | canonical_semantic | `compaction_parity_tombstone_ttl` | p0_data_loss |
+| `cass.compaction_merge.issue_819.differential_row_tombstone_wide_partition_regression` | compaction_merge | mirrored | canonical_semantic | `compaction_parity_tombstone_ttl` | p0_data_loss |
 | `cass.compaction_merge.load_path_validity` | compaction_merge | mirrored | smoke | `compaction_parity_tombstone_ttl` | p1_correctness |
 | `cass.compaction_merge.partial_source_retains_tombstones` | compaction_merge | mirrored | canonical_semantic | `compaction_parity_tombstone_ttl` | p0_data_loss |
 | `cass.compaction_merge.partition_delete_shadowing_across_skipped_sources` | compaction_merge | mirrored | canonical_semantic | `compaction_parity_tombstone_ttl` | p0_data_loss |
@@ -188,6 +191,9 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 | `cass.summary_db.IndexSummaryTest.serialization_round_trip` | index_summary | mirrored | byte_for_byte | `sstable_parity_summary_db_big` | p1_correctness |
 | `cass.summary_db.big.index_offset_references` | index_summary | mirrored | byte_for_byte | `sstable_parity_summary_db_big` | p1_correctness |
 | `cass.summary_db.bti.summary_discovery_classification` | index_summary | mirrored | byte_for_byte | `sstable_parity_summary_db_big` | p1_correctness |
+| `cass.tombstone_ttl.NeverPurgeTest.preserve_all_tombstone_types` | tombstone_ttl | mirrored | byte_for_byte | `compaction_parity_tombstone_ttl` | p0_data_loss |
+| `cass.tombstone_ttl.RangeTombstoneTest.marker_merge_and_persistence` | tombstone_ttl | mirrored | byte_for_byte | `compaction_parity_tombstone_ttl` | p1_correctness |
+| `cass.tombstone_ttl.TTLExpiryTest.gc_boundary` | tombstone_ttl | mirrored | byte_for_byte | `compaction_parity_tombstone_ttl` | p1_correctness |
 | `cass.tombstone_ttl.deletion_markers.cell_delete` | tombstone_ttl | mirrored | canonical_semantic | `sstable_parity_delta_scan` | p0_data_loss |
 | `cass.tombstone_ttl.deletion_markers.partition_delete` | tombstone_ttl | mirrored | canonical_semantic | `sstable_parity_delta_scan` | p0_data_loss |
 | `cass.tombstone_ttl.deletion_markers.range_delete_bounds` | tombstone_ttl | mirrored | canonical_semantic | `sstable_parity_delta_scan` | p0_data_loss |
@@ -349,6 +355,12 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
   - Normalization: Sampled positions are decoded little-endian (the on-disk truth verified against Index.db) and matched to be16-length-prefixed Index.db keys.
 - `cass.summary_db.bti.summary_discovery_classification` — BTI SSTables carry no Summary.db (trie Partitions.db replaces it)
   - Normalization: TOC.txt component manifests are parsed strictly; format is taken from the descriptor filename, never inferred from contents.
+- `cass.tombstone_ttl.NeverPurgeTest.preserve_all_tombstone_types` — Preserve all tombstone types under never-purge (partition/row/cell/range)
+  - Normalization: Deletion times decoded as deltas / fixed-header at exact wire offsets and reconstructed against EncodingStats minima; fixture lanes are local-only and SKIP when the binary is absent (deterministic lanes run everywhere) but FAIL on a present-but-empty body or 0 rows.
+- `cass.tombstone_ttl.RangeTombstoneTest.marker_merge_and_persistence` — Range-tombstone bound-marker grammar merge and persistence
+  - Normalization: Bound-marker grammar and deltas decoded at exact wire offsets; fixture lanes are local-only and SKIP when the binary is absent (the deterministic lane runs everywhere) but FAIL on 0 markers.
+- `cass.tombstone_ttl.TTLExpiryTest.gc_boundary` — TTL expiry / gc-boundary delta parity (deterministic + fixture)
+  - Normalization: TTL and localDeletionTime are decoded as UNSIGNED VInt deltas at exact wire offsets and reconstructed against the Statistics.db EncodingStats minTTL / minLocalDeletionTime; the fixture lane is local-only and SKIPS when the binary is absent (the deterministic lane runs everywhere) but FAILS on a present-but-empty body or 0 rows.
 - `cass.tombstone_ttl.static_row.dropped_static_header_preserved` — Dropped static column SerializationHeader byte parity
   - Normalization: The dropped static column is preserved in the embedded SerializationHeader; its name set and kind are compared byte-equal against the StaticColumns line of the reference Statistics.db dump.
 - `cass.write_load_path.cql_sstable_writer.finished_data_db_artifacts` — Finished CQLite-written Data.db / component artifacts (write path)
@@ -366,6 +378,12 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
   - Normalization: Both outputs are dumped with Cassandra's own sstabledump (-l) and the wall-clock-derived `expired` flag is normalized out; merged partition/row/cell/timestamp/TTL/deletion facts are compared, file layout and presentation ignored.
 - `cass.compaction.harness_logical_tier` — Differential harness logical tier — canonical sstabledump equality
   - Normalization: sstabledump JSONL of both outputs with the wall-clock `expired` flag normalized out; logical facts compared, layout ignored.
+- `cass.compaction_merge.GcCompactionTest.row_cell_partition_tombstone_gc` — Row/cell/partition tombstone gc through compaction merge (canonical)
+  - Normalization: Tier-2 logical equivalence: merged partition/cell/timestamp/TTL/local deletion time/is_deleted facts compared against Cassandra compaction output; presentation/file layout ignored.
+- `cass.compaction_merge.issue_819.differential_input_merge_write_fidelity` — Differential compaction — per-cell write timestamps preserved (write fidelity)
+  - Normalization: Tier-2 logical equivalence: every surviving cell's timestamp/TTL/local deletion time/is_deleted compared against the merge-from-inputs facts; presentation/file layout ignored.
+- `cass.compaction_merge.issue_819.differential_row_tombstone_wide_partition_regression` — Differential compaction — row tombstone in a wide partition round-trips
+  - Normalization: Tier-2 logical equivalence of merged partition/row/cell/deletion facts; presentation/file layout ignored.
 - `cass.compaction_merge.partial_source_retains_tombstones` — Partial-source compaction retains row/cell tombstones
   - Normalization: When only a subset of the overlapping sources is compacted, row/cell tombstones that may still shadow data in the un-compacted sources are retained; deletion facts are mapped to the sstabledump JSONL and compared.
 - `cass.compaction_merge.partition_delete_shadowing_across_skipped_sources` — Compaction partition-delete shadowing across skipped sources
@@ -646,7 +664,10 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.compaction.SSTableRewriterTest.output_component_integrity` | nightly_docker | .github/workflows/compaction-parity.yml |
 | `cass.compaction.harness_byte_tier_artifacts` | nightly_docker | .github/workflows/compaction-parity.yml |
 | `cass.compaction.harness_logical_tier` | required_parity | .github/workflows/compaction-parity.yml |
+| `cass.compaction_merge.GcCompactionTest.row_cell_partition_tombstone_gc` | required_parity | .github/workflows/compaction-parity.yml |
 | `cass.compaction_merge.byte_for_byte_output` | manual_debug | — |
+| `cass.compaction_merge.issue_819.differential_input_merge_write_fidelity` | required_parity | .github/workflows/compaction-parity.yml |
+| `cass.compaction_merge.issue_819.differential_row_tombstone_wide_partition_regression` | required_parity | .github/workflows/compaction-parity.yml |
 | `cass.compaction_merge.load_path_validity` | required_parity | .github/workflows/compaction-parity.yml |
 | `cass.compaction_merge.partial_source_retains_tombstones` | nightly_docker | .github/workflows/tombstone-ttl-parity.yml |
 | `cass.compaction_merge.partition_delete_shadowing_across_skipped_sources` | nightly_docker | .github/workflows/tombstone-ttl-parity.yml |
@@ -833,6 +854,9 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.summary_db.IndexSummaryTest.serialization_round_trip` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.summary_db.big.index_offset_references` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.summary_db.bti.summary_discovery_classification` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
+| `cass.tombstone_ttl.NeverPurgeTest.preserve_all_tombstone_types` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
+| `cass.tombstone_ttl.RangeTombstoneTest.marker_merge_and_persistence` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
+| `cass.tombstone_ttl.TTLExpiryTest.gc_boundary` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.tombstone_ttl.deletion_markers.cell_delete` | nightly_docker | .github/workflows/tombstone-ttl-parity.yml |
 | `cass.tombstone_ttl.deletion_markers.partition_delete` | nightly_docker | .github/workflows/tombstone-ttl-parity.yml |
 | `cass.tombstone_ttl.deletion_markers.range_delete_bounds` | nightly_docker | .github/workflows/tombstone-ttl-parity.yml |
@@ -887,7 +911,10 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.compaction.SSTableRewriterTest.output_component_integrity` | nb | compaction-parity/build/parity-artifacts-byteParity/<scenario>/cassandra-output/<br>_fail:_ byte-diff.txt: first byte/offset diff per component (component, offset, ref byte, candidate byte, lengths), checksums.txt: SHA-256 of every component on both sides, cassandra-output/ and cqlite-output/: the full component dirs for offline decoding |
 | `cass.compaction.harness_byte_tier_artifacts` | nb | compaction-parity/build/parity-artifacts-byteParity/<scenario>/cassandra-output/<br>_fail:_ byte-diff.txt: first differing byte/offset per component, checksums.txt: SHA-256 per component, both engines, commands.txt: exact cqlite compact + sstabledump command lines, cqlite-compact.stdout / cqlite-compact.stderr |
 | `cass.compaction.harness_logical_tier` | nb | test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl |
+| `cass.compaction_merge.GcCompactionTest.row_cell_partition_tombstone_gc` | nb | test-data/datasets/sstables/test_deltas/cell_tombstones-29733830701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl |
 | `cass.compaction_merge.byte_for_byte_output` | — | — |
+| `cass.compaction_merge.issue_819.differential_input_merge_write_fidelity` | nb | test-data/datasets/sstables/test_deltas/cell_tombstones-29733830701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl |
+| `cass.compaction_merge.issue_819.differential_row_tombstone_wide_partition_regression` | nb | test-data/datasets/sstables/test_deltas/row_tombstones-297f1f10701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl |
 | `cass.compaction_merge.load_path_validity` | nb | — |
 | `cass.compaction_merge.partial_source_retains_tombstones` | nb | test-data/datasets/sstables/test_tomb/resurrection_gc0-4cb523c0702011f1b8f419c9a388d558/nb-1-big-Data.db.jsonl<br>test-data/datasets/sstables/test_tomb/resurrection_gc0-4cb523c0702011f1b8f419c9a388d558/nb-2-big-Data.db.jsonl |
 | `cass.compaction_merge.partition_delete_shadowing_across_skipped_sources` | nb | test-data/datasets/sstables/test_tomb/skipped_partition_delete-4caaea90702011f1b8f419c9a388d558/nb-1-big-Data.db.jsonl<br>test-data/datasets/sstables/test_tomb/skipped_partition_delete-4caaea90702011f1b8f419c9a388d558/nb-2-big-Data.db.jsonl |
@@ -1074,6 +1101,9 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.summary_db.IndexSummaryTest.serialization_round_trip` | nb, oa, big | test-data/datasets/sstables/test_timeseries/app_metrics-6c87b890a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>_fail:_ validation_artifacts/sstabledump/summary/summary_parity_report.md |
 | `cass.summary_db.big.index_offset_references` | nb, oa, big | test-data/datasets/sstables/test_timeseries/app_metrics-6c87b890a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>_fail:_ validation_artifacts/sstabledump/summary/summary_parity_report.md |
 | `cass.summary_db.bti.summary_discovery_classification` | nb, oa, da, big, bti | test-data/datasets/sstables/test_da/simple_table-de1be8b064e711f19ad401a8c8227b11/da-2-bti-TOC.txt<br>_fail:_ validation_artifacts/sstabledump/summary/summary_parity_report.md |
+| `cass.tombstone_ttl.NeverPurgeTest.preserve_all_tombstone_types` | nb, oa | test-data/datasets/sstables/test_deltas/partition_tombstones-299258f0701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl<br>test-data/datasets/sstables/test_deltas/row_tombstones-297f1f10701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl<br>test-data/datasets/sstables/test_deltas/cell_tombstones-29733830701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/tombstone-types-delta-diff.log |
+| `cass.tombstone_ttl.RangeTombstoneTest.marker_merge_and_persistence` | nb, oa | test-data/datasets/sstables/test_deltas/range_tombstones-298894f0701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/range-marker-grammar-diff.log |
+| `cass.tombstone_ttl.TTLExpiryTest.gc_boundary` | nb, oa | test-data/datasets/sstables/test_deltas/ttl_cells-299c9220701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/ttl-gc-boundary-delta-diff.log |
 | `cass.tombstone_ttl.deletion_markers.cell_delete` | nb | test-data/datasets/sstables/test_deltas/cell_tombstones-88c7bde06c9311f1ae1bf55502e5fa53/nb-1-big-Data.db.jsonl |
 | `cass.tombstone_ttl.deletion_markers.partition_delete` | nb | test-data/datasets/sstables/test_deltas/partition_tombstones-88f66f006c9311f1ae1bf55502e5fa53/nb-1-big-Data.db.jsonl |
 | `cass.tombstone_ttl.deletion_markers.range_delete_bounds` | nb | test-data/datasets/sstables/test_deltas/range_tombstones-88e928906c9311f1ae1bf55502e5fa53/nb-1-big-Data.db.jsonl |

--- a/test-data/cassandra-parity-manifest.yml
+++ b/test-data/cassandra-parity-manifest.yml
@@ -11600,7 +11600,7 @@ scenarios:
       comparison_command: >-
         env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
         --features write-support --test issue_992_ttl_tombstone_range_parity
-        ttl_row_preserves fixture_ttl_row
+        ttl_row
       reference_paths:
         - test-data/datasets/sstables/test_deltas/ttl_cells-299c9220701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl
       failure_artifacts:
@@ -11724,7 +11724,7 @@ scenarios:
       comparison_command: >-
         env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
         --features write-support --test issue_992_ttl_tombstone_range_parity
-        range_bound fixture_range
+        range
       reference_paths:
         - test-data/datasets/sstables/test_deltas/range_tombstones-298894f0701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl
       failure_artifacts:

--- a/test-data/cassandra-parity-manifest.yml
+++ b/test-data/cassandra-parity-manifest.yml
@@ -11548,6 +11548,363 @@ scenarios:
         - cass.compression.fixture_matrix.zstd_no_dictionary
         - cass.compression.registry.known_zstd
 
+  # ============================================================================
+  # Issue #1018 — tombstone/TTL + compaction byte-parity scenarios. The two
+  # cass.compaction_merge.issue_819.* entries anchor the differential
+  # write-fidelity regression guards (un-ignored once the per-cell write-
+  # timestamp writer defect was fixed); the cass.tombstone_ttl.* and
+  # cass.compaction_merge.GcCompactionTest.* entries anchor the deterministic +
+  # fixture TTL / partition-tombstone / range-marker delta parity covered by
+  # issue_992_ttl_tombstone_range_parity.rs. (The issue listed two ids under a
+  # cqlite.issue_819.* namespace; remapped here to schema-conforming cass.* ids
+  # with existing capability enum values — there is no `compaction` capability.)
+  # ============================================================================
+  - id: cass.tombstone_ttl.TTLExpiryTest.gc_boundary
+    title: TTL expiry / gc-boundary delta parity (deterministic + fixture)
+    status: mirrored
+    capability: tombstone_ttl
+    priority: P0
+    risk: p1_correctness
+    cassandra:
+      category: tombstone-ttl
+      relevance: high
+      files:
+        - TTLExpiryTest.java
+        - UnfilteredSerializer.java
+    cqlite:
+      coverage:
+        suite: compaction_parity_tombstone_ttl
+        tests:
+          - cqlite-core/tests/issue_992_ttl_tombstone_range_parity.rs
+        notes: >-
+          A TTL row sets HAS_TIMESTAMP | HAS_TTL and writes
+          `[ts delta][ttl delta][localDeletionTime delta]` (all UNSIGNED VInt
+          from the EncodingStats minima); the derived expiration second is the
+          LDT, which fixes the gc-boundary at which the cell becomes purgeable.
+          `ttl_row_preserves_ttl_and_derived_ldt_deltas` asserts the exact byte
+          deltas with NON-ZERO minTTL/minLocalDeletionTime; `fixture_ttl_row_byte_parity`
+          walks the real ttl_cells nb Data.db and reconstructs ttl=3600 +
+          expires_at against the on-disk delta + minima.
+    fixtures:
+      references:
+        - test-data/datasets/sstables/test_deltas/ttl_cells-299c9220701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl
+    evidence:
+      type: byte_for_byte
+      strict: true
+      artifacts: [bytes, offsets, jsonl]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb, oa]
+      fixture_generation_command: >-
+        bash test-data/scripts/regenerate-datasets.sh && sstabledump <Data.db> > <Data.db>.jsonl
+      comparison_command: >-
+        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        --features write-support --test issue_992_ttl_tombstone_range_parity
+        ttl_row_preserves fixture_ttl_row
+      reference_paths:
+        - test-data/datasets/sstables/test_deltas/ttl_cells-299c9220701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl
+      failure_artifacts:
+        - target/cassandra-parity/ttl-gc-boundary-delta-diff.log
+      normalization: >-
+        TTL and localDeletionTime are decoded as UNSIGNED VInt deltas at exact
+        wire offsets and reconstructed against the Statistics.db EncodingStats
+        minTTL / minLocalDeletionTime; the fixture lane is local-only and SKIPS
+        when the binary is absent (the deterministic lane runs everywhere) but
+        FAILS on a present-but-empty body or 0 rows.
+      known_limitations: >-
+        Strict byte parity is asserted for the row TTL/LDT delta encoding and the
+        derived gc-boundary expiration second.
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/sstabledump-parity-gate.yml
+    scope: {}
+
+  - id: cass.tombstone_ttl.NeverPurgeTest.preserve_all_tombstone_types
+    title: Preserve all tombstone types under never-purge (partition/row/cell/range)
+    status: mirrored
+    capability: tombstone_ttl
+    priority: P0
+    risk: p0_data_loss
+    cassandra:
+      category: tombstone-ttl
+      relevance: high
+      files:
+        - NeverPurgeTest.java
+        - UnfilteredSerializer.java
+    cqlite:
+      coverage:
+        suite: compaction_parity_tombstone_ttl
+        tests:
+          - cqlite-core/tests/issue_992_ttl_tombstone_range_parity.rs
+        notes: >-
+          The four tombstone families each write their own deltas with no value
+          bytes: partition deletion uses the FIXED-header form (not a delta), and
+          row / cell / range-bound markers carry their own
+          `markedForDeleteAt` + `localDeletionTime` deltas. The deterministic
+          lanes (`partition_deletion_uses_fixed_header_form_not_delta`,
+          `row_tombstone_carries_own_deltas_and_no_value_bytes`,
+          `cell_tombstone_carries_own_deltas_and_no_value_bytes`,
+          `range_bound_markers_exact_grammar_writer`) and their `fixture_*` peers
+          assert each type is preserved verbatim — none promoted/dropped.
+    fixtures:
+      references:
+        - test-data/datasets/sstables/test_deltas/partition_tombstones-299258f0701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl
+        - test-data/datasets/sstables/test_deltas/row_tombstones-297f1f10701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl
+        - test-data/datasets/sstables/test_deltas/cell_tombstones-29733830701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl
+    evidence:
+      type: byte_for_byte
+      strict: true
+      artifacts: [bytes, offsets, jsonl]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb, oa]
+      fixture_generation_command: >-
+        bash test-data/scripts/regenerate-datasets.sh && sstabledump <Data.db> > <Data.db>.jsonl
+      comparison_command: >-
+        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        --features write-support --test issue_992_ttl_tombstone_range_parity
+      reference_paths:
+        - test-data/datasets/sstables/test_deltas/partition_tombstones-299258f0701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl
+        - test-data/datasets/sstables/test_deltas/row_tombstones-297f1f10701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl
+        - test-data/datasets/sstables/test_deltas/cell_tombstones-29733830701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl
+      failure_artifacts:
+        - target/cassandra-parity/tombstone-types-delta-diff.log
+      normalization: >-
+        Deletion times decoded as deltas / fixed-header at exact wire offsets and
+        reconstructed against EncodingStats minima; fixture lanes are local-only
+        and SKIP when the binary is absent (deterministic lanes run everywhere)
+        but FAIL on a present-but-empty body or 0 rows.
+      known_limitations: >-
+        Asserts each tombstone family round-trips its own deltas with no value
+        bytes; full never-purge gc-grace coordination across compaction tiers is
+        covered by the compaction_merge entries below.
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/sstabledump-parity-gate.yml
+    scope: {}
+
+  - id: cass.tombstone_ttl.RangeTombstoneTest.marker_merge_and_persistence
+    title: Range-tombstone bound-marker grammar merge and persistence
+    status: mirrored
+    capability: tombstone_ttl
+    priority: P0
+    risk: p1_correctness
+    cassandra:
+      category: tombstone-ttl
+      relevance: high
+      files:
+        - RangeTombstoneTest.java
+        - UnfilteredSerializer.java
+    cqlite:
+      coverage:
+        suite: compaction_parity_tombstone_ttl
+        tests:
+          - cqlite-core/tests/issue_992_ttl_tombstone_range_parity.rs
+        notes: >-
+          Range-tombstone bound markers follow an exact on-disk grammar (bound
+          kind byte + clustering prefix + `markedForDeleteAt`/`localDeletionTime`
+          deltas) and must persist through write/compaction. The deterministic
+          lane (`range_bound_markers_exact_grammar_writer`) and fixture lanes
+          (`fixture_range_bound_markers_byte_parity`,
+          `fixture_range_inclusive_end_bound_kind`,
+          `fixture_range_boundary_marker_byte_parity`) assert the grammar and
+          bound-kind bytes match Cassandra.
+    fixtures:
+      references:
+        - test-data/datasets/sstables/test_deltas/range_tombstones-298894f0701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl
+    evidence:
+      type: byte_for_byte
+      strict: true
+      artifacts: [bytes, offsets, jsonl]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb, oa]
+      fixture_generation_command: >-
+        bash test-data/scripts/regenerate-datasets.sh && sstabledump <Data.db> > <Data.db>.jsonl
+      comparison_command: >-
+        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        --features write-support --test issue_992_ttl_tombstone_range_parity
+        range_bound fixture_range
+      reference_paths:
+        - test-data/datasets/sstables/test_deltas/range_tombstones-298894f0701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl
+      failure_artifacts:
+        - target/cassandra-parity/range-marker-grammar-diff.log
+      normalization: >-
+        Bound-marker grammar and deltas decoded at exact wire offsets; fixture
+        lanes are local-only and SKIP when the binary is absent (the
+        deterministic lane runs everywhere) but FAIL on 0 markers.
+      known_limitations: >-
+        Asserts bound-marker grammar / bound-kind / delta byte parity; the
+        harness `raw_clustering_order_walk` reports Unsupported for range markers
+        (Tier-1 raw sub-check skips; Tier-2 logical equivalence still gates).
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/sstabledump-parity-gate.yml
+    scope: {}
+
+  - id: cass.compaction_merge.GcCompactionTest.row_cell_partition_tombstone_gc
+    title: Row/cell/partition tombstone gc through compaction merge (canonical)
+    status: mirrored
+    capability: compaction_merge
+    priority: P0
+    risk: p0_data_loss
+    cassandra:
+      category: compaction
+      relevance: high
+      files:
+        - GcCompactionTest.java
+        - CompactionsPurgeTest.java
+        - UnfilteredSerializer.java
+    cqlite:
+      coverage:
+        suite: compaction_parity_tombstone_ttl
+        tests:
+          - cqlite-core/tests/issue_819_differential_compaction.rs
+          - cqlite-core/tests/issue_992_ttl_tombstone_range_parity.rs
+        notes: >-
+          Compacting overlapping inputs that carry partition / row / cell
+          tombstones must preserve each tombstone's deletion time and shadow only
+          the cells it covers (timestamp <= markedForDeleteAt), without rewriting
+          surviving sibling cells. The #819 differential harness asserts the
+          merged partition/cell/timestamp facts round-trip through a real
+          compaction, and the #992 deterministic + fixture lanes pin each
+          tombstone family's delta encoding.
+    fixtures:
+      references:
+        - test-data/datasets/sstables/test_deltas/cell_tombstones-29733830701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl
+    evidence:
+      type: canonical_semantic
+      strict: false
+      artifacts: [jsonl, logs]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb]
+      fixture_generation_command: >-
+        compaction-parity/scripts/bootstrap-cassandra.sh  # builds cassandra-5.0.2, runs reference compaction
+      comparison_command: >-
+        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        --features write-support --test issue_819_differential_compaction
+      reference_paths:
+        - test-data/datasets/sstables/test_deltas/cell_tombstones-29733830701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl
+      normalization: >-
+        Tier-2 logical equivalence: merged partition/cell/timestamp/TTL/local
+        deletion time/is_deleted facts compared against Cassandra compaction
+        output; presentation/file layout ignored.
+      known_limitations: >-
+        Logical / canonical-semantic equivalence; byte-for-byte compaction output
+        parity is the separate non-gated byte tier (north-star issue #842).
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/compaction-parity.yml
+    scope: {}
+
+  - id: cass.compaction_merge.issue_819.differential_row_tombstone_wide_partition_regression
+    title: Differential compaction — row tombstone in a wide partition round-trips
+    status: mirrored
+    capability: compaction_merge
+    priority: P0
+    risk: p0_data_loss
+    cassandra:
+      category: compaction
+      relevance: high
+      files:
+        - GcCompactionTest.java
+        - CompactionIteratorTest.java
+    cqlite:
+      coverage:
+        suite: compaction_parity_tombstone_ttl
+        tests:
+          - cqlite-core/tests/issue_819_differential_compaction.rs
+        notes: >-
+          Regression guard (un-ignored in #1018): compacting a wide partition
+          that contains a clustering-row tombstone must round-trip the row
+          tombstone marker correctly through the next read-back. The underlying
+          mis-decode was fixed by #899 / #972; this asserts gen1 read-back of the
+          compacted output is Tier-2 equivalent to merging the inputs.
+    fixtures:
+      references:
+        - test-data/datasets/sstables/test_deltas/row_tombstones-297f1f10701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl
+    evidence:
+      type: canonical_semantic
+      strict: false
+      artifacts: [jsonl, logs]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb]
+      fixture_generation_command: >-
+        compaction-parity/scripts/bootstrap-cassandra.sh  # builds cassandra-5.0.2, runs reference compaction
+      comparison_command: >-
+        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        --features write-support --test issue_819_differential_compaction
+        differential_row_tombstone_wide_partition_regression
+      reference_paths:
+        - test-data/datasets/sstables/test_deltas/row_tombstones-297f1f10701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl
+      normalization: >-
+        Tier-2 logical equivalence of merged partition/row/cell/deletion facts;
+        presentation/file layout ignored.
+      known_limitations: >-
+        Logical equivalence only; byte-for-byte compaction output parity is the
+        separate non-gated byte tier (north-star issue #842).
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/compaction-parity.yml
+    scope: {}
+
+  - id: cass.compaction_merge.issue_819.differential_input_merge_write_fidelity
+    title: Differential compaction — per-cell write timestamps preserved (write fidelity)
+    status: mirrored
+    capability: compaction_merge
+    priority: P0
+    risk: p0_data_loss
+    cassandra:
+      category: compaction
+      relevance: high
+      files:
+        - CompactionIteratorTest.java
+        - UnfilteredSerializer.java
+    cqlite:
+      coverage:
+        suite: compaction_parity_tombstone_ttl
+        tests:
+          - cqlite-core/tests/issue_819_differential_compaction.rs
+        notes: >-
+          Strictest write-fidelity guard (un-ignored in #1018): a reconciled row
+          carrying a cell tombstone alongside live sibling cells must persist
+          each surviving cell's OWN write timestamp, NOT the row's max writetime.
+          #1018 threads per-cell write timestamps through the merge->mutation->
+          writer path (`Mutation::cell_write_timestamps`); this asserts the
+          gen1 read-back is Tier-2 equivalent to merging the inputs (live cells
+          keep ts=100 next to a cell tombstone at ts=300).
+    fixtures:
+      references:
+        - test-data/datasets/sstables/test_deltas/cell_tombstones-29733830701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl
+    evidence:
+      type: canonical_semantic
+      strict: false
+      artifacts: [jsonl, logs]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb]
+      fixture_generation_command: >-
+        compaction-parity/scripts/bootstrap-cassandra.sh  # builds cassandra-5.0.2, runs reference compaction
+      comparison_command: >-
+        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        --features write-support --test issue_819_differential_compaction
+        differential_input_merge_write_fidelity
+      reference_paths:
+        - test-data/datasets/sstables/test_deltas/cell_tombstones-29733830701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl
+      normalization: >-
+        Tier-2 logical equivalence: every surviving cell's timestamp/TTL/local
+        deletion time/is_deleted compared against the merge-from-inputs facts;
+        presentation/file layout ignored.
+      known_limitations: >-
+        Logical equivalence of per-cell writetimes; byte-for-byte compaction
+        output parity is the separate non-gated byte tier (north-star #842).
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/compaction-parity.yml
+    scope: {}
+
 # ==============================================================================
 # Public/release-facing parity claims (issue #1023).
 #


### PR DESCRIPTION
Refs #1018 (core slice — see "Scope" below; intentionally does NOT auto-close).

## What this lands
**A real compaction write-path bug** + un-ignores two pinned `issue_819` regressions + parity manifest coverage.

### The bug (regression `differential_input_merge_write_fidelity`)
When a reconciled row carried a **cell tombstone alongside live sibling cells**, the writer rewrote the live siblings' per-cell write timestamps to the row's MAX timestamp (the tombstone's ts). Root cause was upstream of the serializer: `reconcile.rs::build` sets `row_ts = max(surviving cell ts)`, then `cells_to_cell_operations` lowered each live cell to `CellOperation::Write` — a variant carrying **no per-cell timestamp** — so every cell inherited the row max.

Fix (per-cell write-timestamp side-channel, mirroring the existing `row_tombstone`/`local_deletion_time` precedent):
- `mutation.rs`: add `cell_write_timestamps: Option<HashMap<String,i64>>` (+ accessor).
- `merge/mod.rs`: `merge_entry_to_mutation` records each surviving simple live cell whose own ts differs from the row max (cell tombstones/complex excluded; single-writetime rows stay `None`).
- `data_writer/rows.rs`: `merge_row_group` uses the per-cell ts for the emitted op, the whole-col liveness row-marker candidate, and the surfaced-clustering-cell liveness; the existing dispatch then clears `USE_ROW_TIMESTAMP` for differing cells.
- `wal.rs`: a backward-compat layout mirror + decode fallback so pre-#1018 WAL records still replay (bincode is positional).

### Regressions un-ignored
- `differential_input_merge_write_fidelity` — fixed by the above; now passes (+2 focused unit tests on per-cell ts preservation).
- `differential_row_tombstone_wide_partition_regression` — its defect was already fixed (#899/#972); the `#[ignore]` was stale → removed. The `issue_819_differential_compaction` suite is now **6 passed, 0 ignored**.

### Manifest + report
6 parity scenarios added to `cassandra-parity-manifest.yml` (`lint: 0 errors`), report regenerated. NOTE: the issue listed two ids as `cqlite.issue_819.*`, but the manifest schema mandates `^cass\.…` and has no `compaction`/`cqlite` capability — so they were **remapped to schema-conforming `cass.*`** ids (`cass.compaction_merge.issue_819.*`, `cass.tombstone_ttl.*`) following existing precedent. Flagging this remap for the manager to reverse if undesired.

## Scope — why `Refs` not `Closes`
#1018's ACs also include **adding new deterministic TTL/partition-tombstone/range-marker compaction *scenarios*** to the #819 harness. Those are deferred to a follow-up (this PR is already ~700 insertions touching the `Mutation` struct + WAL format; bundling more would balloon it). **The close-vs-keep-open decision for #1018 is the manager's** — surfaced on the issue. Much of the byte-parity those scenarios imply already exists in `issue_992_ttl_tombstone_range_parity.rs`.

## Validation
- `scripts/agent-gate.sh` = **PASS** (rebased on origin/main incl. #1197). `rows.rs` +40 lines acked via `CQLITE_ALLOW_FILE_GROWTH=1` (#1116 note in-file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)