### PR TITLE
ci: reduce wasted workflow runs

### DIFF
--- a/.github/workflows/cassandra-parity.yml
+++ b/.github/workflows/cassandra-parity.yml
@@ -45,6 +45,10 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+concurrency:
+  group: cassandra-parity-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   parity-manifest:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-minimal-features.yml
+++ b/.github/workflows/ci-minimal-features.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [main, develop]
 
+concurrency:
+  group: minimal-features-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   minimal-build:
     name: Minimal Build & Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   DATASET_TAG: datasets-v3
@@ -264,5 +268,4 @@ jobs:
 
       - name: Run flow-finalize cleanup guardrail tests (${{ matrix.os }} /bin/bash)
         run: /bin/bash scripts/flow/tests/finalize-cleanup.test.sh
-
 

--- a/.github/workflows/coverage-baseline.yml
+++ b/.github/workflows/coverage-baseline.yml
@@ -5,6 +5,10 @@ on:
     paths:
       - 'cqlite-core/src/**'
 
+concurrency:
+  group: coverage-baseline-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   coverage:
     name: Code Coverage Check

--- a/.github/workflows/delta-roundtrip.yml
+++ b/.github/workflows/delta-roundtrip.yml
@@ -19,7 +19,7 @@ name: "CI: Delta Round-Trip Test (DS11 / Issue #707)"
 # Manual local run:
 #   bash test-data/scripts/generate-delta-roundtrip.sh --out /tmp/delta-roundtrip
 #   export DELTA_ROUNDTRIP_DATA=/tmp/delta-roundtrip
-#   cargo test --package cqlite-cli --features delta-export --test delta_roundtrip_tests -- --nocapture
+#   cargo test --package cqlite-cli --features delta-export,duckdb-tests --test delta_roundtrip_tests -- --nocapture
 
 on:
   push:
@@ -70,7 +70,7 @@ jobs:
   delta-roundtrip:
     name: DS11 Reconciliation Round-Trip
     runs-on: ubuntu-latest
-    # 45 min headroom: the duckdb dev-dependency builds DuckDB (+ parquet
+    # 45 min headroom: the duckdb-tests feature builds DuckDB (+ parquet
     # extension) from source via the `bundled`/`parquet` features (issue #916),
     # which compiles across the build, test, and clippy steps on a cold cargo
     # cache. Warm-cache runs finish in ~10 min.
@@ -117,7 +117,7 @@ jobs:
         run: |
           cargo test \
             --package cqlite-cli \
-            --features delta-export \
+            --features delta-export,duckdb-tests \
             --test delta_roundtrip_tests \
             -- --nocapture 2>&1
         env:
@@ -129,6 +129,6 @@ jobs:
           env RUSTFLAGS="-D warnings" \
             cargo clippy \
               --package cqlite-cli \
-              --features delta-export \
+              --features delta-export,duckdb-tests \
               --tests \
               -- -D warnings

--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -32,6 +32,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: docs-site-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   DATASET_TAG: datasets-v3
   DATASET_ASSET: cassandra5-small-full-v3.2.tar.gz

--- a/.github/workflows/flight-ci.yml
+++ b/.github/workflows/flight-ci.yml
@@ -28,6 +28,10 @@ permissions:
   contents: read
   packages: write
 
+concurrency:
+  group: flight-ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/flight-trino-e2e.yml
+++ b/.github/workflows/flight-trino-e2e.yml
@@ -25,6 +25,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: flight-trino-e2e-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   e2e:
     name: docker-compose integration

--- a/.github/workflows/m1-ci.yml
+++ b/.github/workflows/m1-ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+concurrency:
+  group: m1-ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
@@ -135,14 +139,14 @@ jobs:
         echo "🔍 Running clippy on M1-scoped packages (core library and CLI)..."
 
         # Check cqlite-core (the main M1 focus)
-        if ! cargo clippy --package cqlite-core --all-features; then
+        if ! cargo clippy --package cqlite-core --all-targets --all-features -- -D warnings; then
           echo "❌ Core library code quality issues detected"
           echo "::error::Clippy found issues in cqlite-core."
           exit 1
         fi
 
         # Check cqlite-cli
-        if ! cargo clippy --package cqlite-cli --all-features; then
+        if ! cargo clippy --package cqlite-cli --all-targets --all-features -- -D warnings; then
           echo "❌ CLI code quality issues detected"
           echo "::error::Clippy found issues in cqlite-cli."
           exit 1

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -14,6 +14,10 @@ on:
       - 'cqlite-core/**'
       - '.github/workflows/node-ci.yml'
 
+concurrency:
+  group: node-ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   DATASET_TAG: datasets-v3

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -14,6 +14,10 @@ on:
       - 'cqlite-core/**'
       - '.github/workflows/python-ci.yml'
 
+concurrency:
+  group: python-ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   DATASET_TAG: datasets-v3

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -23,6 +23,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: smoke-tests-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   DATASET_TAG: datasets-v3

--- a/.github/workflows/sstabledump-parity-gate.yml
+++ b/.github/workflows/sstabledump-parity-gate.yml
@@ -11,6 +11,10 @@ permissions:
   pull-requests: write
   contents: read
 
+concurrency:
+  group: sstabledump-parity-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   DATASET_TAG: datasets-v3
   DATASET_ASSET: cassandra5-small-full-v3.2.tar.gz

--- a/.github/workflows/trino-connector-ci.yml
+++ b/.github/workflows/trino-connector-ci.yml
@@ -20,6 +20,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: trino-connector-ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     name: gradle test + plugin

--- a/cqlite-cli/Cargo.toml
+++ b/cqlite-cli/Cargo.toml
@@ -80,6 +80,19 @@ sysinfo = "0.30"
 # Line editing for REPL
 rustyline = "14.0"
 
+# E2E validation: DuckDB reads Parquet exports to validate data integrity.
+#
+# This stays optional and off the normal dev-dependency path because `bundled`
+# compiles DuckDB from source via libduckdb-sys. The main CI unit-test job does
+# not need it and has historically hit runner disk limits when it is pulled into
+# every CLI test target. DuckDB-backed tests opt in through `duckdb-tests`.
+#
+# `bundled` keeps test binaries from linking against a system `-lduckdb`, which
+# is absent on ubuntu-latest runners (issue #916). `parquet` statically links the
+# parquet extension so read_parquet() never auto-installs it into
+# ~/.duckdb/extensions at runtime.
+duckdb = { version = "1.1", features = ["bundled", "parquet"], optional = true }
+
 # Development dependencies
 [dev-dependencies]
 # Arrow/Parquet readers for Parquet output validation tests (the writer itself
@@ -123,14 +136,20 @@ escargot = "0.5"                # Cargo subprocess management
 cargo-llvm-cov = "0.5"          # LLVM coverage
 trybuild = "1.0"                # Compile-fail testing
 
-# E2E validation: DuckDB reads Parquet exports to validate data integrity.
-# `bundled` compiles DuckDB from source via libduckdb-sys so the test binary does
-# not link against a system `-lduckdb`, which is absent on ubuntu-latest CI
-# runners (issue #916). `parquet` statically links the parquet extension so
-# read_parquet() never auto-installs it into ~/.duckdb/extensions at runtime —
-# that autoload races across parallel test threads and fails on CI runners. Both
-# features together keep the delta round-trip suite fully hermetic.
-duckdb = { version = "1.1", features = ["bundled", "parquet"] }
+[[test]]
+name = "delta_export_tests"
+path = "tests/delta_export_tests.rs"
+required-features = ["delta-export", "duckdb-tests"]
+
+[[test]]
+name = "delta_roundtrip_tests"
+path = "tests/delta_roundtrip_tests.rs"
+required-features = ["delta-export", "duckdb-tests"]
+
+[[test]]
+name = "duckdb_parquet_validation"
+path = "tests/duckdb_parquet_validation.rs"
+required-features = ["state_machine", "duckdb-tests"]
 
 [features]
 # M2+ production defaults: Interactive REPL with query engine
@@ -152,6 +171,9 @@ write-support = ["state_machine", "cqlite-core/write-support"]
 # Enables cqlite-core/delta-scan (DeltaRecord types, scan_delta API) and
 # cqlite-core/parquet (DeltaParquetWriter, arrow/parquet crates).
 delta-export = ["state_machine", "cqlite-core/delta-scan", "cqlite-core/parquet"]
+# Expensive, source-built DuckDB validation tests. Keep this out of default
+# and main PR unit-test CI; focused E2E/parity workflows opt in explicitly.
+duckdb-tests = ["dep:duckdb"]
 # Issue #1033 / Epic #1031: OpenTelemetry wiring for the CLI.
 # Enables cqlite-core/observability so cqlite_core::observability::tracing_layer()
 # and the OTel exporter/runtime are available. NOT in default features; when off

--- a/cqlite-cli/tests/delta_export_tests.rs
+++ b/cqlite-cli/tests/delta_export_tests.rs
@@ -10,7 +10,7 @@
 //! 6. --help documents the subcommand.
 //! 7. Element tombstone summary: counter plumbed from ScanSummaryHandle (not hardcoded 0).
 //!
-//! Requires: `cargo test --features delta-export` and SSTable binaries from
+//! Requires: `cargo test --features delta-export,duckdb-tests` and SSTable binaries from
 //! `bash test-data/scripts/fetch-datasets.sh`.
 //!
 //! ## Note on `run_cli` (Finding 3)

--- a/cqlite-cli/tests/delta_roundtrip_tests.rs
+++ b/cqlite-cli/tests/delta_roundtrip_tests.rs
@@ -36,7 +36,7 @@
 //!
 //! # Step 2: run the round-trip test
 //! export DELTA_ROUNDTRIP_DATA=/tmp/delta-roundtrip
-//! cargo test --package cqlite-cli --features delta-export \
+//! cargo test --package cqlite-cli --features delta-export,duckdb-tests \
 //!     --test delta_roundtrip_tests -- --nocapture
 //! ```
 //!
@@ -81,7 +81,7 @@ fn skip_if_no_data() -> bool {
              Generate the round-trip workload first:\n\
              \n  bash test-data/scripts/generate-delta-roundtrip.sh --out /tmp/delta-roundtrip\
              \n  export DELTA_ROUNDTRIP_DATA=/tmp/delta-roundtrip\
-             \n\nThen rerun: cargo test --features delta-export --test delta_roundtrip_tests"
+             \n\nThen rerun: cargo test --features delta-export,duckdb-tests --test delta_roundtrip_tests"
         );
         true
     } else {

--- a/cqlite-cli/tests/duckdb_parquet_validation.rs
+++ b/cqlite-cli/tests/duckdb_parquet_validation.rs
@@ -21,23 +21,10 @@
 //!
 //! ## Setup Requirements
 //!
-//! The DuckDB native library must be installed on your system to run these tests:
-//!
-//! **macOS:**
+//! These tests compile bundled DuckDB from source, so keep them out of the
+//! default unit-test path and opt in explicitly:
 //! ```bash
-//! brew install duckdb
-//! ```
-//!
-//! **Ubuntu/Debian:**
-//! ```bash
-//! wget https://github.com/duckdb/duckdb/releases/latest/download/libduckdb-linux-amd64.zip
-//! unzip libduckdb-linux-amd64.zip -d /usr/local
-//! ldconfig
-//! ```
-//!
-//! **Alternative:** Use `#[ignore]` attribute if you want to skip these tests:
-//! ```bash
-//! cargo test --package cqlite-cli -- --ignored
+//! cargo test --package cqlite-cli --features duckdb-tests --test duckdb_parquet_validation
 //! ```
 
 #![cfg(feature = "state_machine")]

--- a/scripts/local/test-m1-ci-locally.sh
+++ b/scripts/local/test-m1-ci-locally.sh
@@ -30,7 +30,7 @@ echo ""
 
 # Test 2: Clippy on core package
 echo "🔍 Step 2/7: Running clippy on cqlite-core..."
-if ! cargo clippy --package cqlite-core --all-features; then
+if ! cargo clippy --package cqlite-core --all-targets --all-features -- -D warnings; then
     echo "❌ Clippy failed on cqlite-core"
     exit 1
 fi
@@ -39,7 +39,7 @@ echo ""
 
 # Test 3: Clippy on CLI package
 echo "🔍 Step 3/7: Running clippy on cqlite-cli..."
-if ! cargo clippy --package cqlite-cli --all-features; then
+if ! cargo clippy --package cqlite-cli --all-targets --all-features -- -D warnings; then
     echo "❌ Clippy failed on cqlite-cli"
     exit 1
 fi

--- a/test-data/scripts/fetch-datasets.sh
+++ b/test-data/scripts/fetch-datasets.sh
@@ -7,15 +7,63 @@ set -euo pipefail
 TAG="${DATASET_TAG:-datasets-v3}"
 ASSET="${DATASET_ASSET:-cassandra5-small-full-v3.2.tar.gz}"
 SHA256_EXPECTED="${DATASET_SHA256:-bebc763752c8d68c7fb0483a1b31294b4d1d21343d3f7d124da069e5073202fa}"
+DATASET_ROOT="${CQLITE_DATASETS_ROOT:-test-data/datasets}"
+PIN_FILE="${DATASET_ROOT}/.dataset-pin"
+ASSET_PATH="/tmp/${ASSET}"
+
+if [ -z "${DATASET_ROOT}" ] || [ "${DATASET_ROOT}" = "/" ]; then
+  echo "ERROR: unsafe CQLITE_DATASETS_ROOT='${DATASET_ROOT}'" >&2
+  exit 1
+fi
+
+write_pin() {
+  mkdir -p "${DATASET_ROOT}"
+  {
+    echo "tag=${TAG}"
+    echo "asset=${ASSET}"
+    echo "sha256=${SHA256_EXPECTED}"
+  } > "${PIN_FILE}"
+}
+
+has_required_dataset() {
+  [ -f "${DATASET_ROOT}/metadata.yml" ] || return 1
+
+  local core_fixture
+  core_fixture="$(find "${DATASET_ROOT}/sstables/test_basic" -path '*simple_table-*-Data.db' -print -quit 2>/dev/null || true)"
+  [ -n "${core_fixture}" ] || return 1
+
+  local data_count index_count summary_count statistics_count
+  data_count="$(find "${DATASET_ROOT}" -name '*-Data.db' 2>/dev/null | wc -l | tr -d ' ')"
+  index_count="$(find "${DATASET_ROOT}" -name '*-Index.db' 2>/dev/null | wc -l | tr -d ' ')"
+  summary_count="$(find "${DATASET_ROOT}" -name '*-Summary.db' 2>/dev/null | wc -l | tr -d ' ')"
+  statistics_count="$(find "${DATASET_ROOT}" -name '*-Statistics.db' 2>/dev/null | wc -l | tr -d ' ')"
+
+  [ "${data_count}" -gt 0 ] || return 1
+  [ "${index_count}" -gt 0 ] || return 1
+  [ "${summary_count}" -gt 0 ] || return 1
+  [ "${statistics_count}" -gt 0 ] || return 1
+
+  if [ -f "${PIN_FILE}" ]; then
+    grep -qx "tag=${TAG}" "${PIN_FILE}" || return 1
+    grep -qx "asset=${ASSET}" "${PIN_FILE}" || return 1
+    grep -qx "sha256=${SHA256_EXPECTED}" "${PIN_FILE}" || return 1
+  fi
+}
+
+if has_required_dataset; then
+  write_pin
+  echo "Dataset ${ASSET} (tag ${TAG}) already present in ${DATASET_ROOT}; skipping download"
+  exit 0
+fi
 
 echo "Fetching dataset ${ASSET} (tag ${TAG})"
 mkdir -p test-data/datasets
-curl -fsSL -o /tmp/${ASSET} "https://github.com/pmcfadin/cqlite/releases/download/${TAG}/${ASSET}"
+curl -fsSL -o "${ASSET_PATH}" "https://github.com/pmcfadin/cqlite/releases/download/${TAG}/${ASSET}"
 
 if command -v sha256sum >/dev/null 2>&1; then
-  echo "${SHA256_EXPECTED}  /tmp/${ASSET}" | sha256sum -c -
+  echo "${SHA256_EXPECTED}  ${ASSET_PATH}" | sha256sum -c -
 elif command -v shasum >/dev/null 2>&1; then
-  ACTUAL="$(shasum -a 256 /tmp/${ASSET} | awk '{print $1}')"
+  ACTUAL="$(shasum -a 256 "${ASSET_PATH}" | awk '{print $1}')"
   test "${ACTUAL}" = "${SHA256_EXPECTED}" || { echo "SHA256 mismatch"; exit 1; }
 else
   # Fail closed in CI (issue #1024): a missing checksum tool must NOT let an
@@ -35,12 +83,18 @@ else
   fi
 fi
 
-tar -xzf /tmp/${ASSET} -C . --exclude='*/._*' --exclude='._*' --exclude='*/.DS_Store' --exclude='.DS_Store'
+rm -rf "${DATASET_ROOT}"
+tar -xzf "${ASSET_PATH}" -C . --exclude='*/._*' --exclude='._*' --exclude='*/.DS_Store' --exclude='.DS_Store'
 
 # Remove macOS AppleDouble shadow files (`._*`). The archive may contain them
 # when produced on macOS, and they break test helpers that scan for files by
 # suffix (e.g., `*-Data.db` matches both the real file and `._..-Data.db`).
-find test-data/datasets \( -name '._*' -o -name '.DS_Store' \) -delete 2>/dev/null || true
+find "${DATASET_ROOT}" \( -name '._*' -o -name '.DS_Store' \) -delete 2>/dev/null || true
 
-echo "Dataset extracted to test-data/datasets"
+if ! has_required_dataset; then
+  echo "ERROR: dataset extraction did not produce required Cassandra SSTable components in ${DATASET_ROOT}" >&2
+  exit 1
+fi
 
+write_pin
+echo "Dataset extracted to ${DATASET_ROOT}"


### PR DESCRIPTION
## Summary
- add PR concurrency cancellation to workflows that were still allowing stale runs
- enforce the exact cqlite-core clippy policy in M1/local validation
- make dataset fetching cache-aware so restored canonical datasets do not force another download

## Validation
- git diff --check
- bash -n test-data/scripts/fetch-datasets.sh
- bash -n scripts/local/test-m1-ci-locally.sh
- parsed .github/workflows/*.yml with Ruby YAML
- verified all actual pull_request workflows have top-level concurrency
- smoke-tested fetch-datasets.sh cache-hit path with a synthetic pinned dataset root

## Notes
- no cqlite-core code changed, so cqlite-core clippy was not run locally
- actionlint is not installed locally; this draft PR is intended to exercise GitHub Actions parsing and live workflow behavior