### PR TITLE
ci: path-scope broad workflow triggers

### DIFF
--- a/.github/workflows/cassandra-validation.yml
+++ b/.github/workflows/cassandra-validation.yml
@@ -25,6 +25,13 @@ on:
       # nodetool refresh), so some overlap is intentional — see issue #728.
   push:
     branches: [main]
+    paths:
+      - 'cqlite-core/src/storage/write_engine/**'
+      - 'cqlite-core/src/storage/sstable/writer/**'
+      - 'cqlite-core/src/parser/**'
+      - 'cqlite-core/src/schema/**'
+      - 'cqlite-core/tests/sstableloader_integration.rs'
+      - '.github/workflows/cassandra-validation.yml'
   workflow_dispatch:
     inputs:
       run_stress_tests:

--- a/.github/workflows/ci-minimal-features.yml
+++ b/.github/workflows/ci-minimal-features.yml
@@ -3,8 +3,20 @@ name: Minimal Features CI
 on:
   pull_request:
     branches: [main, develop]
+    paths:
+      - '.github/workflows/ci-minimal-features.yml'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - 'cqlite-core/**'
   push:
     branches: [main, develop]
+    paths:
+      - '.github/workflows/ci-minimal-features.yml'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - 'cqlite-core/**'
 
 concurrency:
   group: minimal-features-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,32 @@ name: CI
 on:
   push:
     branches: [ main ]
+    paths:
+      - '.github/workflows/ci.yml'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - 'cqlite-core/**'
+      - 'cqlite-cli/**'
+      - 'tests/**'
+      - 'test-data/**'
+      - 'scripts/**'
+      - 'tools/**'
+      - 'examples/**'
   pull_request:
     branches: [ main ]
+    paths:
+      - '.github/workflows/ci.yml'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - 'cqlite-core/**'
+      - 'cqlite-cli/**'
+      - 'tests/**'
+      - 'test-data/**'
+      - 'scripts/**'
+      - 'tools/**'
+      - 'examples/**'
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -268,4 +292,3 @@ jobs:
 
       - name: Run flow-finalize cleanup guardrail tests (${{ matrix.os }} /bin/bash)
         run: /bin/bash scripts/flow/tests/finalize-cleanup.test.sh
-

--- a/.github/workflows/m1-ci.yml
+++ b/.github/workflows/m1-ci.yml
@@ -3,8 +3,32 @@ name: "CI: Core Library (minimal)"
 on:
   push:
     branches: [ main, develop ]
+    paths:
+      - '.github/workflows/m1-ci.yml'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - 'cqlite-core/**'
+      - 'cqlite-cli/**'
+      - 'tests/**'
+      - 'test-data/**'
+      - 'scripts/**'
+      - 'tools/**'
+      - 'examples/**'
   pull_request:
     branches: [ main, develop ]
+    paths:
+      - '.github/workflows/m1-ci.yml'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - 'cqlite-core/**'
+      - 'cqlite-cli/**'
+      - 'tests/**'
+      - 'test-data/**'
+      - 'scripts/**'
+      - 'tools/**'
+      - 'examples/**'
 
 concurrency:
   group: m1-ci-${{ github.ref }}

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -20,8 +20,26 @@ name: Smoke Tests - All Tables
 on:
   push:
     branches: [main]
+    paths:
+      - '.github/workflows/smoke-tests.yml'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - 'cqlite-core/**'
+      - 'cqlite-cli/**'
+      - 'test-data/**'
+      - 'scripts/**'
   pull_request:
     branches: [main]
+    paths:
+      - '.github/workflows/smoke-tests.yml'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - 'cqlite-core/**'
+      - 'cqlite-cli/**'
+      - 'test-data/**'
+      - 'scripts/**'
 
 concurrency:
   group: smoke-tests-${{ github.ref }}

--- a/.github/workflows/sstabledump-parity-gate.yml
+++ b/.github/workflows/sstabledump-parity-gate.yml
@@ -3,8 +3,26 @@ name: "CI: SSTableDump Parity Gate"
 on:
   pull_request:
     branches: [main, develop]
+    paths:
+      - '.github/workflows/sstabledump-parity-gate.yml'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - 'cqlite-core/**'
+      - 'tests/**'
+      - 'test-data/**'
+      - 'scripts/**'
   push:
     branches: [main, develop]
+    paths:
+      - '.github/workflows/sstabledump-parity-gate.yml'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - 'cqlite-core/**'
+      - 'tests/**'
+      - 'test-data/**'
+      - 'scripts/**'
 
 permissions:
   issues: write

--- a/.github/workflows/workflow-config.yml
+++ b/.github/workflows/workflow-config.yml
@@ -1,0 +1,93 @@
+name: Workflow Config Validation
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - '.github/workflows/**'
+  push:
+    branches: [main, develop]
+    paths:
+      - '.github/workflows/**'
+  workflow_dispatch:
+
+concurrency:
+  group: workflow-config-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  validate:
+    name: YAML and trigger policy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Validate workflow YAML parses
+        run: |
+          ruby <<'RUBY'
+          require "yaml"
+
+          files = Dir[".github/workflows/*.{yml,yaml}"].sort
+          abort "No workflow files found" if files.empty?
+
+          files.each do |file|
+            YAML.load_file(file)
+            puts "ok #{file}"
+          end
+          RUBY
+
+      - name: Validate workflow trigger policy
+        run: |
+          ruby <<'RUBY'
+          require "yaml"
+
+          missing_concurrency = []
+          unscoped_branch_triggers = []
+
+          Dir[".github/workflows/*.{yml,yaml}"].sort.each do |file|
+            workflow = YAML.load_file(file)
+            triggers = workflow["on"] || workflow[true]
+            next unless triggers.is_a?(Hash)
+
+            if triggers.key?("pull_request") && !workflow.key?("concurrency")
+              missing_concurrency << file
+            end
+
+            %w[pull_request push].each do |event|
+              next unless triggers.key?(event)
+
+              config = triggers[event]
+              if config.nil?
+                unscoped_branch_triggers << "#{file}: #{event}"
+                next
+              end
+
+              unless config.is_a?(Hash)
+                unscoped_branch_triggers << "#{file}: #{event}"
+                next
+              end
+
+              # Tag-only release workflows are not branch CI and do not need path filters.
+              next if event == "push" && config.key?("tags") && !config.key?("branches")
+
+              unless config.key?("paths") || config.key?("paths-ignore")
+                unscoped_branch_triggers << "#{file}: #{event}"
+              end
+            end
+          end
+
+          unless missing_concurrency.empty?
+            warn "PR workflows missing concurrency:"
+            missing_concurrency.each { |entry| warn "  - #{entry}" }
+          end
+
+          unless unscoped_branch_triggers.empty?
+            warn "Branch-based workflow triggers missing paths or paths-ignore:"
+            unscoped_branch_triggers.each { |entry| warn "  - #{entry}" }
+          end
+
+          exit 1 if missing_concurrency.any? || unscoped_branch_triggers.any?
+
+          puts "Workflow trigger policy validated"
+          RUBY


### PR DESCRIPTION
## Summary
- Add path filters to broad Rust/parity workflows so docs-only and unrelated metadata changes do not fan out into heavy CI.
- Match Cassandra sstableloader push scope to its existing PR scope.
- Add a lightweight workflow-config validation workflow to keep workflow YAML parseable and enforce path-scoped PR/push triggers going forward.

## Validation
- ruby YAML parse over .github/workflows/*.{yml,yaml}
- local trigger-policy audit: no PR workflow missing concurrency, no branch-based PR/push trigger missing paths or paths-ignore
- git diff --check