### PR TITLE
ci: preserve dataset goldens during fetch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,27 +76,11 @@ jobs:
           path: test-data/datasets
           key: datasets-${{ env.DATASET_TAG }}-${{ env.DATASET_SHA256 }}
 
-      - name: Fetch datasets if Data.db fixture missing
-        # Do NOT trust cache-hit alone (#1097): a restored cache can be partial
-        # (JSONL refs without the SSTable Data.db binaries), which makes the
-        # #1080 no-silent-skip guard hard-fail. Gate on the core fixture instead.
-        run: |
-          set -euo pipefail
-          # Capture into a var rather than piping find into grep -q / head: under
-          # `set -o pipefail`, a downstream consumer that closes the pipe early
-          # makes find exit non-zero (SIGPIPE), which would abort the step.
-          CORE_FIXTURE=$(find test-data/datasets/sstables/test_basic -path '*simple_table-*-Data.db' 2>/dev/null || true)
-          if [ -n "$CORE_FIXTURE" ]; then
-            echo "✅ Core Data.db fixture present; skipping download"
-          else
-            echo "📦 Core Data.db fixture missing — fetching ${DATASET_ASSET}..."
-            rm -rf test-data/datasets
-            mkdir -p test-data/datasets
-            curl -fsSL -o /tmp/${DATASET_ASSET} \
-              https://github.com/pmcfadin/cqlite/releases/download/${DATASET_TAG}/${DATASET_ASSET}
-            echo "${DATASET_SHA256}  /tmp/${DATASET_ASSET}" | sha256sum -c -
-            tar -xzf /tmp/${DATASET_ASSET} -C . --exclude='*/._*' --exclude='._*' --exclude='*/.DS_Store' --exclude='.DS_Store'
-          fi
+      - name: Fetch datasets if required fixture data missing
+        # Do NOT trust cache-hit alone (#1097): a restored cache can be partial.
+        # Keep the CI path on the shared fetch script so binary fixtures and
+        # git-tracked JSONL reference files are validated together.
+        run: bash ./test-data/scripts/fetch-datasets.sh
 
       - name: Sanity check dataset
         run: |
@@ -109,7 +93,13 @@ jobs:
             echo "❌ Core fixture test_basic/simple_table-*/*-Data.db missing after fetch" >&2
             exit 1
           fi
+          GOLDEN_JSONL="test-data/datasets/sstables/test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294/nb-2-big-Data.db.jsonl"
+          if [ ! -s "$GOLDEN_JSONL" ]; then
+            echo "❌ Required JSONL golden missing after fetch: ${GOLDEN_JSONL}" >&2
+            exit 1
+          fi
           echo "✅ Core fixture present: ${CORE_FIXTURE}"
+          echo "✅ Required JSONL golden present: ${GOLDEN_JSONL}"
 
       - name: Validate environment
         run: |

--- a/test-data/scripts/fetch-datasets.sh
+++ b/test-data/scripts/fetch-datasets.sh
@@ -10,6 +10,7 @@ SHA256_EXPECTED="${DATASET_SHA256:-bebc763752c8d68c7fb0483a1b31294b4d1d21343d3f7
 DATASET_ROOT="${CQLITE_DATASETS_ROOT:-test-data/datasets}"
 PIN_FILE="${DATASET_ROOT}/.dataset-pin"
 ASSET_PATH="/tmp/${ASSET}"
+WIDE_PARTITION_GOLDEN="${DATASET_ROOT}/sstables/test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294/nb-2-big-Data.db.jsonl"
 
 if [ -z "${DATASET_ROOT}" ] || [ "${DATASET_ROOT}" = "/" ]; then
   echo "ERROR: unsafe CQLITE_DATASETS_ROOT='${DATASET_ROOT}'" >&2
@@ -25,8 +26,33 @@ write_pin() {
   } > "${PIN_FILE}"
 }
 
+restore_ci_tracked_dataset_files() {
+  [ -n "${CI:-}" ] || return 0
+  command -v git >/dev/null 2>&1 || return 0
+  git rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
+
+  local repo_root dataset_abs dataset_rel tracked_files
+  repo_root="$(git rev-parse --show-toplevel)"
+  case "${DATASET_ROOT}" in
+    /*) dataset_abs="${DATASET_ROOT}" ;;
+    *) dataset_abs="${PWD}/${DATASET_ROOT}" ;;
+  esac
+
+  case "${dataset_abs}" in
+    "${repo_root}"/*) dataset_rel="${dataset_abs#"${repo_root}/"}" ;;
+    *) return 0 ;;
+  esac
+
+  tracked_files="$(git -C "${repo_root}" ls-files -- "${dataset_rel}")"
+  if [ -n "${tracked_files}" ]; then
+    echo "Restoring git-tracked dataset reference files under ${dataset_rel}"
+    git -C "${repo_root}" restore --source=HEAD -- "${dataset_rel}" 2>/dev/null || true
+  fi
+}
+
 has_required_dataset() {
   [ -f "${DATASET_ROOT}/metadata.yml" ] || return 1
+  [ -s "${WIDE_PARTITION_GOLDEN}" ] || return 1
 
   local core_fixture
   core_fixture="$(find "${DATASET_ROOT}/sstables/test_basic" -path '*simple_table-*-Data.db' -print -quit 2>/dev/null || true)"
@@ -49,6 +75,8 @@ has_required_dataset() {
     grep -qx "sha256=${SHA256_EXPECTED}" "${PIN_FILE}" || return 1
   fi
 }
+
+restore_ci_tracked_dataset_files
 
 if has_required_dataset; then
   write_pin
@@ -85,6 +113,7 @@ fi
 
 rm -rf "${DATASET_ROOT}"
 tar -xzf "${ASSET_PATH}" -C . --exclude='*/._*' --exclude='._*' --exclude='*/.DS_Store' --exclude='.DS_Store'
+restore_ci_tracked_dataset_files
 
 # Remove macOS AppleDouble shadow files (`._*`). The archive may contain them
 # when produced on macOS, and they break test helpers that scan for files by


### PR DESCRIPTION
## Summary
- Route CI dataset fetching through the shared test-data/scripts/fetch-datasets.sh helper
- Restore git-tracked dataset reference files in CI after cache/extract operations
- Add an explicit CI sanity check for the wide-partition JSONL golden that failed on main

## Why
A post-merge main CI run failed in cqlite-core because the inline CI fetch step can rm -rf test-data/datasets and extract the release asset without restoring git-tracked JSONL goldens. This makes the result depend on cache contents.

## Local validation
- bash -n test-data/scripts/fetch-datasets.sh
- ruby -e 'require "yaml"; Dir[".github/workflows/*.{yml,yaml}"].sort.each { |f| YAML.load_file(f) }; puts "workflow YAML ok"'
- git diff --check -- .github/workflows/ci.yml test-data/scripts/fetch-datasets.sh
- CI=1 bash test-data/scripts/fetch-datasets.sh