### PR TITLE
test(#1030): reconcile parity-manifest closed-gap rows + fix test_deltas UUID drift + regen report

### DIFF
--- a/docs/reports/cassandra-test-parity.md
+++ b/docs/reports/cassandra-test-parity.md
@@ -10,8 +10,8 @@ Sources: [`docs/cassandra_test_index.md`](../../docs/cassandra_test_index.md) ·
 
 | Status | Scenarios |
 |---|---|
-| `mirrored` | 205 |
-| `partial` | 17 |
+| `mirrored` | 207 |
+| `partial` | 15 |
 | `planned` | 18 |
 | `out_of_scope` | 14 |
 | **total** | **254** |
@@ -20,10 +20,10 @@ Sources: [`docs/cassandra_test_index.md`](../../docs/cassandra_test_index.md) ·
 
 | Evidence | Scenarios |
 |---|---|
-| `byte_for_byte` | 111 |
+| `byte_for_byte` | 113 |
 | `canonical_semantic` | 93 |
 | `smoke` | 7 |
-| `partial` | 27 |
+| `partial` | 25 |
 | `out_of_scope` | 16 |
 
 ## ⚠️ P0 scenarios with weak evidence
@@ -37,13 +37,11 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 - `cass.compression_info.zstd.real_fixture_chunks.strict` — Zstd real-fixture CompressionInfo.db + chunk parity (partial)
 - `cass.corruption_verify.component_corruption_detection` — Component corruption detection, scrub, and verify (partial)
 - `cass.data_db_decode.wide_partition.row_boundaries` — Wide-partition Data.db row boundaries align with promoted-index offsets (partial)
-- `cass.filter_db_bloom.serialization_no_false_negative` — Filter.db Bloom filter serialization with no false negatives (partial)
 - `cass.index_db.RowIndexEntryTest.promoted_index_entries` — BIG Index.db promoted-index (wide-partition) boundary metadata (partial)
 - `cass.index_db.promoted_index.clustering_bounds` — BIG promoted-index IndexInfo clustering bounds ordering and coverage (partial)
 - `cass.index_db.promoted_index.index_info_offsets` — BIG promoted-index IndexInfo Data.db offsets and width chain (partial)
 - `cass.index_db.promoted_index.range_tombstone_boundary_at_block_edge` — BIG promoted-index decode across a range-tombstone block boundary (partial)
 - `cass.index_summary.column_index.range_tombstone_boundary_big_bti` — Column-index range-tombstone boundary across BIG and BTI formats (partial)
-- `cass.index_summary.summary_boundaries` — Summary.db sampling boundaries (BIG) (partial)
 - `cass.schema_evolution.dropped_column.empty_index_block_reverse_scan` — Dropped-column empty-index-block reverse-scan parity (partial)
 - `cass.sstable_format.descriptor_component_resolution` — Descriptor and on-disk version/component resolution (smoke)
 - `cass.tombstone_ttl.range_tombstone_boundaries` — Range tombstone boundary and deletion-time parity (partial)
@@ -161,7 +159,7 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 | `cass.filter_db.corruption_fails_closed` | filter_db_bloom | mirrored | byte_for_byte | `sstable_parity_filter_db_bloom` | p1_correctness |
 | `cass.filter_db.no_false_negative_membership` | filter_db_bloom | mirrored | byte_for_byte | `sstable_parity_filter_db_bloom` | p0_data_loss |
 | `cass.filter_db.serialization_round_trip` | filter_db_bloom | mirrored | byte_for_byte | `sstable_parity_filter_db_bloom` | p1_correctness |
-| `cass.filter_db_bloom.serialization_no_false_negative` | filter_db_bloom | partial | partial | `sstable_parity_filter_db_bloom` | p0_data_loss |
+| `cass.filter_db_bloom.serialization_no_false_negative` | filter_db_bloom | mirrored | byte_for_byte | `sstable_parity_filter_db_bloom` | p0_data_loss |
 | `cass.index_db.CorruptPrimaryIndexTest.big_primary_index_corruption` | index_summary | mirrored | byte_for_byte | `sstable_parity_index_db_big` | p0_data_loss |
 | `cass.index_db.RowIndexEntryTest.partition_offsets` | index_summary | mirrored | byte_for_byte | `sstable_parity_index_db_big` | p1_correctness |
 | `cass.index_db.RowIndexEntryTest.promoted_index_entries` | index_summary | partial | partial | `sstable_parity_index_db_big` | p1_correctness |
@@ -174,7 +172,7 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 | `cass.index_db.promoted_index.range_tombstone_boundary_at_block_edge` | index_summary | partial | partial | `sstable_parity_index_db_big` | p1_correctness |
 | `cass.index_summary.big_index_offsets` | index_summary | mirrored | canonical_semantic | `sstable_parity_index_db_big` | p1_correctness |
 | `cass.index_summary.column_index.range_tombstone_boundary_big_bti` | index_summary | partial | partial | `sstable_parity_index_db_big` | p1_correctness |
-| `cass.index_summary.summary_boundaries` | index_summary | partial | partial | `sstable_parity_summary_db_big` | p1_correctness |
+| `cass.index_summary.summary_boundaries` | index_summary | mirrored | byte_for_byte | `sstable_parity_summary_db_big` | p1_correctness |
 | `cass.schema_evolution.dropped_column.empty_index_block_reverse_scan` | schema_evolution | partial | partial | `sstable_parity_delta_scan` | p1_correctness |
 | `cass.schema_evolution.dropped_column.per_cell_purge` | schema_evolution | mirrored | canonical_semantic | `sstable_parity_delta_scan` | p1_correctness |
 | `cass.schema_evolution.issue_847_dropped_column_filter` | schema_evolution | mirrored | canonical_semantic | `compaction_parity_tombstone_ttl` | p0_data_loss |
@@ -337,6 +335,8 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 - `cass.filter_db.no_false_negative_membership` — Filter.db no-false-negative membership over Cassandra present keys
   - Normalization: Present keys are the raw partition-key bytes from Index.db (not the decoded CQL values), matching the bytes Cassandra's Murmur3 hashed into Filter.db. The reference_paths point at the committed per-fixture Data.db.jsonl siblings (the binary Filter.db and Index.db are gitignored, fetched on demand).
 - `cass.filter_db.serialization_round_trip` — Filter.db byte-exact serialization round-trip and parameter decode
+- `cass.filter_db_bloom.serialization_no_false_negative` — Filter.db Bloom filter serialization with no false negatives
+  - Normalization: Present keys are the raw partition-key bytes from Index.db (not the decoded CQL values), matching the bytes Cassandra's Murmur3 hashed into Filter.db. The reference_paths point at the committed per-fixture Data.db.jsonl siblings (the binary Filter.db and Index.db are gitignored, fetched on demand).
 - `cass.index_db.CorruptPrimaryIndexTest.big_primary_index_corruption` — Truncated BIG Index.db fails explicitly
 - `cass.index_db.RowIndexEntryTest.partition_offsets` — BIG Index.db partition data offsets vs Cassandra positions
   - Normalization: Index.db data offsets are relative to the Data.db data section while JSONL positions are absolute file offsets; the per-partition Data.db header is a constant only for uniform partition-key lengths without static blocks, so successive deltas (not absolute values) are compared in that case.
@@ -345,6 +345,7 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 - `cass.index_db.big.raw_partition_keys_and_offsets` — BIG Index.db raw partition-key bytes and entry-byte parity
   - Normalization: JSONL single-column partition keys are decoded to their raw on-disk byte encoding (UUID text -> 16 bytes) before comparison; composite-key byte decoding is not attempted (those fixtures are covered by entry-byte + count + offset parity).
 - `cass.index_db.bti.index_component_discovery` — BTI index-component discovery and classification
+- `cass.index_summary.summary_boundaries` — Summary.db sampling boundaries (BIG)
 - `cass.repaired_metadata.statistics_db.repaired_at_field` — Statistics.db repairedAt field decode + report parity (unrepaired state)
 - `cass.schema_evolution.serialization_header.altered_column_type` — Serialization-header parity after ALTER column type
 - `cass.schema_evolution.serialization_header.altered_then_dropped_column` — Serialization-header parity after ALTER then DROP column
@@ -594,7 +595,7 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 - `cass.compaction.SSTableRewriterTest.output_component_integrity` (planned): Byte-for-byte compaction output parity is computed and reported but not gated; the writer is not yet byte-identical to Cassandra. → _Land the divergence-fix children (#844/#846/#848 …), then drop continue-on-error on the byte step to promote it to a hard gate._
 - `cass.compaction.harness_byte_tier_artifacts` (planned): No gated byte-for-byte comparison; the tier reports diffs + artifacts but does not fail the build yet. → _Promote to a hard gate (drop continue-on-error) once compaction output is byte-stable across the scenario matrix._
 - `cass.compaction_merge.byte_for_byte_output` (planned): No gated byte-for-byte comparison of compaction output. → _Promote the debug byte tier in compaction-parity to a gated comparison once writer output is byte-stable._
-- `cass.compression_checksum.checksum_trailer_detection` (partial): No gated byte comparison of Digest.crc32 against the Cassandra reference. → _Add a Digest.crc32 byte comparison to the sstable_parity_corruption_verify suite._
+- `cass.compression_checksum.checksum_trailer_detection` (partial): No gated test injects corruption and asserts rejection; only inline-checksum validation on read is implemented. (Byte-compare of clean Digest.crc32 is already covered by cass.sstable_format.toc_component_manifest.) → _Byte-compare of clean Digest.crc32 is covered by cass.sstable_format.toc_component_manifest; corruption-detection / rejection remains open and is tracked by the carved-out scrub/verify issue #1236._
 - `cass.compression_info.deflate.real_fixture_chunks` (planned): No real DeflateCompressor CompressionInfo.db / Data.db fixture in the committed corpus, so chunk + CRC parity cannot be byte-compared. → _Generate a DeflateCompressor SSTable via regenerate-datasets.sh and let the existing test exercise it (the codec dispatch already handles it)._
 - `cass.compression_info.deflate.real_fixture_chunks.strict` (planned): No real Cassandra Deflate-compressed fixture in the corpus. → _Generate a DeflateCompressor SSTable fixture via issue #996 (epic #970) and add it to the dataset; the strict lane will then decode and round-trip it._
 - `cass.compression_info.zstd.real_fixture_chunks` (planned): No real ZstdCompressor CompressionInfo.db / Data.db fixture in the committed corpus, so chunk + CRC parity cannot be byte-compared. → _Generate a ZstdCompressor SSTable via regenerate-datasets.sh and let the existing test exercise it (the codec dispatch already handles it)._
@@ -607,14 +608,12 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 - `cass.delta_scan.wide_partition_corpus` (planned): No test_deltas wide-partition delete fixture; wide partitions are produced by the wide-row corpus (epic #993), not generate-deltas.sh. Byte-for-byte backing for delta_scan remains tracked by epic #969. → _Add a wide-partition delete shape (or reuse a wide-row corpus fixture) and a paired test_delta_parity_wide_partition test under epic #993._
 - `cass.filter_db.bti_membership` (partial): No raw-partition-key source for BTI fixtures, so the no-false-negative probe cannot run against da Filter.db. → _Recover raw BTI partition keys (e.g. by decoding partitions during a Data.db scan) and extend the no-false-negative gate to cover da fixtures._
 - `cass.filter_db.statistical_false_positive_rate` (planned): No gated comparison of measured FPR against Cassandra's configured bloom_filter_fp_chance. → _Add larger-cardinality fixtures and assert the measured FPR tracks the configured fp_chance within a documented statistical tolerance._
-- `cass.filter_db_bloom.serialization_no_false_negative` (partial): No no-false-negative parity assertion against Cassandra Filter.db. → _Add a Filter.db serialization parity test asserting zero false negatives across the present-key set._
 - `cass.index_db.RowIndexEntryTest.promoted_index_entries` (partial): Byte-level promoted-index parity (Index.db offsets, widths, clustering bounds) runs only against local-only binaries that are not in the pinned CI dataset; the required lane enforces only the committed-JSONL canonical-semantic facts. → _Add the test_big.wide_partition binaries to the dataset release pin (regenerate the tarball + update DATASET_SHA256) to promote these scenarios to byte_for_byte enforced in the required_parity lane._
 - `cass.index_db.big.wide_partition_promoted_entries` (partial): Byte-level promoted-index parity (Index.db offsets, widths, clustering bounds) runs only against local-only binaries that are not in the pinned CI dataset; the required lane enforces only the committed-JSONL canonical-semantic facts. → _Add the test_big.wide_partition binaries to the dataset release pin (regenerate the tarball + update DATASET_SHA256) to promote these scenarios to byte_for_byte enforced in the required_parity lane._
 - `cass.index_db.promoted_index.clustering_bounds` (partial): Byte-level promoted-index parity (Index.db offsets, widths, clustering bounds) runs only against local-only binaries that are not in the pinned CI dataset; the required lane enforces only the committed-JSONL canonical-semantic facts. → _Add the test_big.wide_partition binaries to the dataset release pin (regenerate the tarball + update DATASET_SHA256) to promote these scenarios to byte_for_byte enforced in the required_parity lane._
 - `cass.index_db.promoted_index.index_info_offsets` (partial): Byte-level promoted-index parity (Index.db offsets, widths, clustering bounds) runs only against local-only binaries that are not in the pinned CI dataset; the required lane enforces only the committed-JSONL canonical-semantic facts. → _Add the test_big.wide_partition binaries to the dataset release pin (regenerate the tarball + update DATASET_SHA256) to promote these scenarios to byte_for_byte enforced in the required_parity lane._
 - `cass.index_db.promoted_index.range_tombstone_boundary_at_block_edge` (partial): Byte-level promoted-index parity (Index.db offsets, widths, clustering bounds) runs only against local-only binaries that are not in the pinned CI dataset; the required lane enforces only the committed-JSONL canonical-semantic facts. → _Add the test_big.wide_partition binaries to the dataset release pin (regenerate the tarball + update DATASET_SHA256) to promote these scenarios to byte_for_byte enforced in the required_parity lane._
 - `cass.index_summary.column_index.range_tombstone_boundary_big_bti` (partial): BTI (da) range-tombstone-at-block-edge fixtures are not yet generated (no da tombstone generator). → _Add a da/BTI wide-partition range-tombstone fixture generator and assert BTI column-index boundary parity; file a follow-up issue._
-- `cass.index_summary.summary_boundaries` (partial): Cassandra Summary.db reference dumps not published for all tables. → _Publish Summary.db reference dumps and enable strict first/last-key boundary comparison in the sstable_parity_summary_db_big suite._
 - `cass.repaired_metadata.statistics_db.pending_repair_uuid` (planned): No Cassandra 5.0 pending-repair fixture available; the reference null (`Pending repair: --`) state is confirmed, and the read path reports the field as Unparsed (it is not walked from bytes) rather than a fabricated absent value. → _When a pending-repair fixture is generated, decode the pendingRepair UUID (type-aware skip past improvedMinMax + commitLogIntervals) — promoting the field from RepairField::Unparsed to Decoded — and assert it byte-for-byte against the `Pending repair: <uuid>` reference line._
 - `cass.repaired_metadata.statistics_db.transient_repair_flag` (planned): No transiently-replicated fixture available; the reference `IsTransient: false` state is confirmed, and the read path reports the field as Unparsed (it is not walked from bytes) rather than a fabricated `false`. → _When a transient-replication fixture is generated, decode the isTransient flag (after the version-gated improvedMinMax block and commitLogIntervals) — promoting it from RepairField::Unparsed to Decoded — and assert it byte-for-byte against the `IsTransient: true` reference line._
 - `cass.schema_evolution.dropped_column.empty_index_block_reverse_scan` (partial): A wide dropped-column empty-index-block reverse-scan fixture is not yet generated. → _Generate a wide dropped-column fixture that yields an empty index block under reverse scan and assert parity; file a follow-up issue._
@@ -841,7 +840,7 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.filter_db.no_false_negative_membership` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.filter_db.serialization_round_trip` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.filter_db.statistical_false_positive_rate` | manual_debug | — |
-| `cass.filter_db_bloom.serialization_no_false_negative` | fast_pr | — |
+| `cass.filter_db_bloom.serialization_no_false_negative` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.index_db.CorruptPrimaryIndexTest.big_primary_index_corruption` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.index_db.RowIndexEntryTest.partition_offsets` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.index_db.RowIndexEntryTest.promoted_index_entries` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
@@ -855,7 +854,7 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.index_db.promoted_index.range_tombstone_boundary_at_block_edge` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.index_summary.big_index_offsets` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.index_summary.column_index.range_tombstone_boundary_big_bti` | nightly_docker | .github/workflows/tombstone-ttl-parity.yml |
-| `cass.index_summary.summary_boundaries` | fast_pr | — |
+| `cass.index_summary.summary_boundaries` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.nodetool_jmx_metrics.operational_out_of_scope` | fast_pr | — |
 | `cass.read_repair_coordinator.out_of_scope` | fast_pr | — |
 | `cass.repair_coordinator.anti_entropy_out_of_scope` | fast_pr | — |
@@ -1084,15 +1083,15 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.data_db_decode.unfiltered_serializer.row_and_cell_flags` | nb, oa | test-data/datasets/sstables/test_basic/uncompressed_table-6aedb7a0a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/data-db-flag-diff.log |
 | `cass.data_db_decode.unfiltered_serializer.row_size_vints` | nb, oa | test-data/datasets/sstables/test_basic/uncompressed_table-6aedb7a0a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/data-db-row-framing-diff.log |
 | `cass.data_db_decode.wide_partition.row_boundaries` | nb | test-data/datasets/sstables/test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294/nb-2-big-Data.db.jsonl |
-| `cass.delta_scan.adjacent_ranges` | nb | test-data/datasets/sstables/test_deltas/adjacent_ranges-972f22806c7811f1a24ff924a65838e2/nb-1-big-Data.db.jsonl |
-| `cass.delta_scan.cell_tombstones` | nb | test-data/datasets/sstables/test_deltas/cell_tombstones-29f7fbe06c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl |
+| `cass.delta_scan.adjacent_ranges` | nb | test-data/datasets/sstables/test_deltas/adjacent_ranges-29bdd5c0701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl |
+| `cass.delta_scan.cell_tombstones` | nb | test-data/datasets/sstables/test_deltas/cell_tombstones-29733830701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl |
 | `cass.delta_scan.collection_ops` | nb | test-data/datasets/sstables/test_deltas/collection_ops-2a5006f06c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl |
 | `cass.delta_scan.partial_updates` | nb | test-data/datasets/sstables/test_deltas/partial_updates-2a5ed4006c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl |
-| `cass.delta_scan.partition_tombstones` | nb | test-data/datasets/sstables/test_deltas/partition_tombstones-2a26fb206c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl |
-| `cass.delta_scan.range_tombstones` | nb | test-data/datasets/sstables/test_deltas/range_tombstones-2a1a50f06c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl |
-| `cass.delta_scan.row_tombstones` | nb | test-data/datasets/sstables/test_deltas/row_tombstones-2a0e91206c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl |
+| `cass.delta_scan.partition_tombstones` | nb | test-data/datasets/sstables/test_deltas/partition_tombstones-299258f0701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl |
+| `cass.delta_scan.range_tombstones` | nb | test-data/datasets/sstables/test_deltas/range_tombstones-298894f0701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl |
+| `cass.delta_scan.row_tombstones` | nb | test-data/datasets/sstables/test_deltas/row_tombstones-297f1f10701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl |
 | `cass.delta_scan.static_with_rows` | nb | test-data/datasets/sstables/test_deltas/static_with_rows-2a4299706c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl |
-| `cass.delta_scan.ttl_cells` | nb | test-data/datasets/sstables/test_deltas/ttl_cells-2a35ef406c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl |
+| `cass.delta_scan.ttl_cells` | nb | test-data/datasets/sstables/test_deltas/ttl_cells-299c9220701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl |
 | `cass.delta_scan.wide_partition_corpus` | nb | — |
 | `cass.distributed_consensus.paxos_accord_out_of_scope` | — | — |
 | `cass.filter_db.bti_membership` | da | — |
@@ -1100,7 +1099,7 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.filter_db.no_false_negative_membership` | nb, oa, da | test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>test-data/datasets/sstables/test_basic/composite_key_table-6ab56990a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/filter-db-false-negative.log |
 | `cass.filter_db.serialization_round_trip` | nb, oa, da | test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>test-data/datasets/sstables/test_da/simple_table-de1be8b064e711f19ad401a8c8227b11/da-2-bti-Data.db.jsonl<br>_fail:_ target/cassandra-parity/filter-db-roundtrip.log |
 | `cass.filter_db.statistical_false_positive_rate` | nb, oa, da | — |
-| `cass.filter_db_bloom.serialization_no_false_negative` | nb | — |
+| `cass.filter_db_bloom.serialization_no_false_negative` | nb, oa | test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>test-data/datasets/sstables/test_basic/composite_key_table-6ab56990a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/filter-db-false-negative.log |
 | `cass.index_db.CorruptPrimaryIndexTest.big_primary_index_corruption` | nb, oa | test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/index-db-diff.log |
 | `cass.index_db.RowIndexEntryTest.partition_offsets` | nb, oa | test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/index-db-diff.log |
 | `cass.index_db.RowIndexEntryTest.promoted_index_entries` | nb | test-data/datasets/sstables/test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294/nb-2-big-Data.db.jsonl |
@@ -1114,7 +1113,7 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.index_db.promoted_index.range_tombstone_boundary_at_block_edge` | nb | test-data/datasets/sstables/test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294/nb-2-big-Data.db.jsonl |
 | `cass.index_summary.big_index_offsets` | nb | test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl |
 | `cass.index_summary.column_index.range_tombstone_boundary_big_bti` | nb | test-data/datasets/sstables/test_tomb/wide_range_tombstone-4ce3add0702011f1b8f419c9a388d558/nb-1-big-Statistics.db.txt |
-| `cass.index_summary.summary_boundaries` | nb | test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl |
+| `cass.index_summary.summary_boundaries` | nb, oa, big | test-data/datasets/sstables/test_timeseries/app_metrics-6c87b890a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>_fail:_ validation_artifacts/sstabledump/summary/summary_parity_report.md |
 | `cass.nodetool_jmx_metrics.operational_out_of_scope` | — | — |
 | `cass.read_repair_coordinator.out_of_scope` | — | — |
 | `cass.repair_coordinator.anti_entropy_out_of_scope` | — | — |
@@ -1166,7 +1165,7 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.tombstone_ttl.deletion_markers.cell_delete` | nb | test-data/datasets/sstables/test_deltas/cell_tombstones-88c7bde06c9311f1ae1bf55502e5fa53/nb-1-big-Data.db.jsonl |
 | `cass.tombstone_ttl.deletion_markers.partition_delete` | nb | test-data/datasets/sstables/test_deltas/partition_tombstones-88f66f006c9311f1ae1bf55502e5fa53/nb-1-big-Data.db.jsonl |
 | `cass.tombstone_ttl.deletion_markers.range_delete_bounds` | nb | test-data/datasets/sstables/test_deltas/range_tombstones-88e928906c9311f1ae1bf55502e5fa53/nb-1-big-Data.db.jsonl |
-| `cass.tombstone_ttl.deletion_markers.range_tombstone_boundary` | nb | test-data/datasets/sstables/test_deltas/adjacent_ranges-972f22806c7811f1a24ff924a65838e2/nb-1-big-Data.db.jsonl |
+| `cass.tombstone_ttl.deletion_markers.range_tombstone_boundary` | nb | test-data/datasets/sstables/test_deltas/adjacent_ranges-29bdd5c0701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl |
 | `cass.tombstone_ttl.deletion_markers.row_delete` | nb | test-data/datasets/sstables/test_deltas/row_tombstones-88dd41b06c9311f1ae1bf55502e5fa53/nb-1-big-Data.db.jsonl |
 | `cass.tombstone_ttl.gc_grace.partition_row_cell` | nb | test-data/datasets/sstables/test_tomb/resurrection_gc0-4cb523c0702011f1b8f419c9a388d558/nb-1-big-Data.db.jsonl<br>test-data/datasets/sstables/test_tomb/resurrection_gc0-4cb523c0702011f1b8f419c9a388d558/nb-2-big-Data.db.jsonl<br>test-data/datasets/sstables/test_tomb/resurrection_gc_positive-4cbfab10702011f1b8f419c9a388d558/nb-1-big-Data.db.jsonl<br>test-data/datasets/sstables/test_tomb/resurrection_gc_positive-4cbfab10702011f1b8f419c9a388d558/nb-2-big-Data.db.jsonl |
 | `cass.tombstone_ttl.never_purge.cell_row_partition` | nb | test-data/datasets/sstables/test_tomb/resurrection_gc0-4cb523c0702011f1b8f419c9a388d558/nb-1-big-Data.db.jsonl<br>test-data/datasets/sstables/test_tomb/resurrection_gc0-4cb523c0702011f1b8f419c9a388d558/nb-2-big-Data.db.jsonl |
@@ -1174,7 +1173,7 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.tombstone_ttl.range_tombstone.index_block_first_marker` | nb | test-data/datasets/sstables/test_tomb/wide_range_tombstone-4ce3add0702011f1b8f419c9a388d558/nb-1-big-Data.db.jsonl |
 | `cass.tombstone_ttl.range_tombstone.index_block_last_marker` | nb | test-data/datasets/sstables/test_tomb/wide_range_tombstone-4ce3add0702011f1b8f419c9a388d558/nb-1-big-Data.db.jsonl |
 | `cass.tombstone_ttl.range_tombstone.open_ended_middle_block` | nb | test-data/datasets/sstables/test_tomb/wide_range_tombstone-4ce3add0702011f1b8f419c9a388d558/nb-1-big-Data.db.jsonl |
-| `cass.tombstone_ttl.range_tombstone_boundaries` | nb | test-data/datasets/sstables/test_deltas/adjacent_ranges-972f22806c7811f1a24ff924a65838e2/nb-1-big-Data.db.jsonl |
+| `cass.tombstone_ttl.range_tombstone_boundaries` | nb | test-data/datasets/sstables/test_deltas/adjacent_ranges-29bdd5c0701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl |
 | `cass.tombstone_ttl.repaired_unrepaired_purge_gate` | nb | test-data/datasets/sstables/test_tomb/resurrection_gc0-4cb523c0702011f1b8f419c9a388d558/nb-1-big-Statistics.db.txt<br>test-data/datasets/sstables/test_tomb/resurrection_gc0-4cb523c0702011f1b8f419c9a388d558/nb-2-big-Statistics.db.txt |
 | `cass.tombstone_ttl.skipped_sstable.partition_delete_reincluded` | nb | test-data/datasets/sstables/test_tomb/skipped_partition_delete-4caaea90702011f1b8f419c9a388d558/nb-1-big-Data.db.jsonl<br>test-data/datasets/sstables/test_tomb/skipped_partition_delete-4caaea90702011f1b8f419c9a388d558/nb-2-big-Data.db.jsonl |
 | `cass.tombstone_ttl.skipped_sstable.partition_delete_shadows_older_rows` | nb | test-data/datasets/sstables/test_tomb/skipped_partition_delete-4caaea90702011f1b8f419c9a388d558/nb-1-big-Data.db.jsonl<br>test-data/datasets/sstables/test_tomb/skipped_partition_delete-4caaea90702011f1b8f419c9a388d558/nb-2-big-Data.db.jsonl |

--- a/test-data/cassandra-parity-manifest.yml
+++ b/test-data/cassandra-parity-manifest.yml
@@ -1287,7 +1287,7 @@ scenarios:
 
   - id: cass.index_summary.summary_boundaries
     title: Summary.db sampling boundaries (BIG)
-    status: partial
+    status: mirrored
     capability: index_summary
     priority: P0
     risk: p1_correctness
@@ -1296,36 +1296,46 @@ scenarios:
       relevance: high
       files:
         - SSTableReaderTest.java
+        - IndexSummaryTest.java
     cqlite:
       coverage:
         suite: sstable_parity_summary_db_big
         tests:
           - cqlite-core/tests/sstabledump_parity_summary.rs
+        notes: >-
+          Closed by strict::test_summary_db_strict_byte_parity — the same gated lane
+          that backs cass.summary_db.IndexSummaryTest.first_last_key_boundaries, which
+          is the canonical superseding scenario for this row. It decodes the trailing
+          length-prefixed first/last keys and byte-compares them to SummaryReader, and
+          requires the first sampled entry key to equal the SSTable's first decorated
+          key. This row is retained as a public claim and now mirrors that scenario's
+          real evidence rather than carrying a stale partial gap (issue #1030).
     fixtures:
-      references:
-        - test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl
+      datasets:
+        - test-data/datasets/sstables
     evidence:
-      type: partial
-      artifacts: [offsets]
+      type: byte_for_byte
+      strict: true
+      artifacts: [bytes, offsets, logs]
       cassandra_version: "5.0.2"
       cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
-      storage_format_version: [nb]
+      storage_format_version: [nb, oa, big]
       fixture_generation_command: >-
         bash test-data/scripts/regenerate-datasets.sh  # cassandra:5.0.2 flush emits Summary.db
+      comparison_command: >-
+        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        --features write-support --test sstabledump_parity_summary strict::
       reference_paths:
-        - test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl
+        - test-data/datasets/sstables/test_timeseries/app_metrics-6c87b890a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl
+      failure_artifacts:
+        - validation_artifacts/sstabledump/summary/summary_parity_report.md
       known_limitations: >-
-        Summary.db first/last key boundaries are validated on read, but the
-        Cassandra Summary.db reference dumps are not published for the full
-        dataset (references.yml records summary_txt.present=false), so strict
-        boundary comparison is not enforced.
+        Superseded by cass.summary_db.IndexSummaryTest.first_last_key_boundaries.
+        Skip-on-absence: validated only when the sibling Data.db is present.
     ci:
-      tier: fast_pr
-    scope:
-      gap: Cassandra Summary.db reference dumps not published for all tables.
-      next_step: >-
-        Publish Summary.db reference dumps and enable strict first/last-key
-        boundary comparison in the sstable_parity_summary_db_big suite.
+      tier: required_parity
+      workflow: .github/workflows/sstabledump-parity-gate.yml
+    scope: {}
 
   # ----------------------------------------------------------------------------
   # index_db — strict Index.db byte parity (issue #983 / epic #968)
@@ -3141,6 +3151,16 @@ scenarios:
         suite: sstable_parity_corruption_verify
         tests:
           - cqlite-core/tests/sstable_parity_integration_test.rs
+        notes: >-
+          The byte-for-byte comparison of a CLEAN Digest.crc32 against the Cassandra
+          reference is covered by cass.sstable_format.toc_component_manifest (its
+          digest_crc32_byte_for_byte_parity lane recomputes and byte-compares the
+          digest payload). That comparison does NOT mutate inputs or prove corruption
+          rejection. The corruption-detection / rejection capability described by this
+          scenario's Cassandra sources (Checksumed* tests) is genuinely unimplemented:
+          CQLite validates inline checksums on read and surfaces mismatches, but there
+          is no gated test that injects corruption and asserts rejection. That gap is
+          tracked by the carved-out scrub/verify issue #1236.
     fixtures:
       references:
         - test-data/datasets/sstables/test_da/simple_table-de1be8b064e711f19ad401a8c8227b11/da-2-bti-Digest.crc32
@@ -3157,16 +3177,22 @@ scenarios:
       failure_artifacts:
         - target/cassandra-parity/checksum-mismatch.log
       known_limitations: >-
-        CQLite validates inline checksums on read and surfaces mismatches, but
-        an exact byte comparison of Digest.crc32 against the Cassandra value is
-        not yet a gated test.
+        Byte-compare of a clean Digest.crc32 is covered by
+        cass.sstable_format.toc_component_manifest. CQLite validates inline checksums
+        on read and surfaces mismatches, but corruption-detection / rejection (the
+        capability this scenario's Cassandra sources exercise) is not yet a gated
+        test. That gap remains open and is tracked by issue #1236.
     ci:
       tier: fast_pr
     scope:
-      gap: No gated byte comparison of Digest.crc32 against the Cassandra reference.
+      gap: >-
+        No gated test injects corruption and asserts rejection; only inline-checksum
+        validation on read is implemented. (Byte-compare of clean Digest.crc32 is
+        already covered by cass.sstable_format.toc_component_manifest.)
       next_step: >-
-        Add a Digest.crc32 byte comparison to the sstable_parity_corruption_verify
-        suite.
+        Byte-compare of clean Digest.crc32 is covered by
+        cass.sstable_format.toc_component_manifest; corruption-detection / rejection
+        remains open and is tracked by the carved-out scrub/verify issue #1236.
 
   - id: cass.compression_info.CompressionMetadataTest.metadata_serialization
     title: CompressionInfo.db metadata byte-for-byte serialization parity
@@ -4101,7 +4127,7 @@ scenarios:
   # ----------------------------------------------------------------------------
   - id: cass.filter_db_bloom.serialization_no_false_negative
     title: Filter.db Bloom filter serialization with no false negatives
-    status: partial
+    status: mirrored
     capability: filter_db_bloom
     priority: P0
     risk: p0_data_loss
@@ -4115,28 +4141,57 @@ scenarios:
       coverage:
         suite: sstable_parity_filter_db_bloom
         tests:
-          - cqlite-core/tests/sstable_parity_integration_test.rs
+          - cqlite-core/tests/sstable_parity_filter_db_test.rs
+        notes: >-
+          Closed by the strict, fail-closed lane
+          filter_db_strict_parameters_and_no_false_negative — the same gated lane
+          that backs cass.filter_db.no_false_negative_membership (issue #987 / epic
+          #968), which is the canonical superseding scenario for this row. For every
+          committed BIG Filter.db it independently re-reads the on-disk header,
+          asserts CQLite's decoded hash_count / bit_count match the bytes, then
+          enumerates every raw partition key Cassandra wrote (from the sibling
+          Index.db key_digest) and asserts the filter reports "maybe present" for all
+          of them; a single false negative fails the lane. This row is retained as a
+          public claim and now mirrors that scenario's real evidence rather than
+          carrying a stale partial gap (issue #1030).
     fixtures:
       datasets:
         - test-data/datasets/sstables
     evidence:
-      type: partial
-      artifacts: [component_files]
+      type: byte_for_byte
+      strict: true
+      artifacts: [bytes, component_files]
       cassandra_version: "5.0.2"
       cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
-      storage_format_version: [nb]
+      # BIG formats only: the no-false-negative membership probe runs over BIG
+      # fixtures whose Index.db exposes the raw partition keys. BTI (da) membership
+      # is a separate open gap, tracked by cass.filter_db.bti_membership.
+      storage_format_version: [nb, oa]
       fixture_generation_command: >-
-        bash test-data/scripts/regenerate-datasets.sh  # cassandra:5.0.2 emits Filter.db
+        bash test-data/scripts/regenerate-datasets.sh  # cassandra:5.0.2 flush emits Filter.db
+      comparison_command: >-
+        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        --features write-support --test sstable_parity_filter_db_test
+        filter_db_strict_parameters_and_no_false_negative
+      normalization: >-
+        Present keys are the raw partition-key bytes from Index.db (not the decoded
+        CQL values), matching the bytes Cassandra's Murmur3 hashed into Filter.db.
+        The reference_paths point at the committed per-fixture Data.db.jsonl siblings
+        (the binary Filter.db and Index.db are gitignored, fetched on demand).
+      reference_paths:
+        - test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl
+        - test-data/datasets/sstables/test_basic/composite_key_table-6ab56990a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl
+      failure_artifacts:
+        - target/cassandra-parity/filter-db-false-negative.log
       known_limitations: >-
-        CQLite reads Filter.db, but there is no gated test proving that lookups
-        never produce false negatives against a Cassandra-generated Filter.db.
+        Superseded by cass.filter_db.no_false_negative_membership; the no-false-negative
+        gate runs over BIG fixtures whose Index.db exposes the raw partition keys.
+        BTI (da) membership is tracked separately under
+        cass.filter_db.bti_membership.
     ci:
-      tier: fast_pr
-    scope:
-      gap: No no-false-negative parity assertion against Cassandra Filter.db.
-      next_step: >-
-        Add a Filter.db serialization parity test asserting zero false negatives
-        across the present-key set.
+      tier: required_parity
+      workflow: .github/workflows/sstabledump-parity-gate.yml
+    scope: {}
 
   # ----------------------------------------------------------------------------
   # filter_db — strict Filter.db Bloom parity (issue #987 / epic #968)
@@ -4425,7 +4480,7 @@ scenarios:
           - cqlite-core/tests/scan_delta_parity_test.rs
     fixtures:
       references:
-        - test-data/datasets/sstables/test_deltas/adjacent_ranges-972f22806c7811f1a24ff924a65838e2/nb-1-big-Data.db.jsonl
+        - test-data/datasets/sstables/test_deltas/adjacent_ranges-29bdd5c0701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl
     evidence:
       type: partial
       artifacts: [jsonl]
@@ -4435,7 +4490,7 @@ scenarios:
       fixture_generation_command: >-
         bash test-data/scripts/generate-deltas.sh  # cassandra:5.0.2 delete shapes → sstabledump JSONL
       reference_paths:
-        - test-data/datasets/sstables/test_deltas/adjacent_ranges-972f22806c7811f1a24ff924a65838e2/nb-1-big-Data.db.jsonl
+        - test-data/datasets/sstables/test_deltas/adjacent_ranges-29bdd5c0701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl
       normalization: >-
         Range/cell/row tombstone bounds and deletion timestamps are mapped to
         the sstabledump JSONL deletion-fact model and compared.
@@ -4525,7 +4580,7 @@ scenarios:
           facts are compared to the sstabledump JSONL golden.
     fixtures:
       references:
-        - test-data/datasets/sstables/test_deltas/cell_tombstones-29f7fbe06c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl
+        - test-data/datasets/sstables/test_deltas/cell_tombstones-29733830701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl
     evidence:
       type: canonical_semantic
       artifacts: [jsonl]
@@ -4535,7 +4590,7 @@ scenarios:
       fixture_generation_command: >-
         bash test-data/scripts/generate-deltas.sh
       reference_paths:
-        - test-data/datasets/sstables/test_deltas/cell_tombstones-29f7fbe06c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl
+        - test-data/datasets/sstables/test_deltas/cell_tombstones-29733830701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl
       normalization: >-
         scan_delta cell-tombstone records are mapped to sstabledump JSONL
         deletion facts (deleted_at) and compared with a writetime tolerance.
@@ -4577,7 +4632,7 @@ scenarios:
           are compared to the sstabledump JSONL golden.
     fixtures:
       references:
-        - test-data/datasets/sstables/test_deltas/row_tombstones-2a0e91206c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl
+        - test-data/datasets/sstables/test_deltas/row_tombstones-297f1f10701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl
     evidence:
       type: canonical_semantic
       artifacts: [jsonl]
@@ -4587,7 +4642,7 @@ scenarios:
       fixture_generation_command: >-
         bash test-data/scripts/generate-deltas.sh
       reference_paths:
-        - test-data/datasets/sstables/test_deltas/row_tombstones-2a0e91206c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl
+        - test-data/datasets/sstables/test_deltas/row_tombstones-297f1f10701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl
       normalization: >-
         scan_delta row-delete records are mapped to sstabledump JSONL row
         deletion_info markers and compared with a writetime tolerance.
@@ -4629,7 +4684,7 @@ scenarios:
           start/end bound pairs are compared to the sstabledump JSONL golden.
     fixtures:
       references:
-        - test-data/datasets/sstables/test_deltas/range_tombstones-2a1a50f06c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl
+        - test-data/datasets/sstables/test_deltas/range_tombstones-298894f0701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl
     evidence:
       type: canonical_semantic
       artifacts: [jsonl]
@@ -4639,7 +4694,7 @@ scenarios:
       fixture_generation_command: >-
         bash test-data/scripts/generate-deltas.sh
       reference_paths:
-        - test-data/datasets/sstables/test_deltas/range_tombstones-2a1a50f06c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl
+        - test-data/datasets/sstables/test_deltas/range_tombstones-298894f0701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl
       normalization: >-
         scan_delta range-delete records are mapped to consecutive sstabledump
         JSONL range_tombstone_bound start/end pairs and compared with a writetime
@@ -4682,7 +4737,7 @@ scenarios:
           partition-delete facts are compared to the sstabledump JSONL golden.
     fixtures:
       references:
-        - test-data/datasets/sstables/test_deltas/partition_tombstones-2a26fb206c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl
+        - test-data/datasets/sstables/test_deltas/partition_tombstones-299258f0701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl
     evidence:
       type: canonical_semantic
       artifacts: [jsonl]
@@ -4692,7 +4747,7 @@ scenarios:
       fixture_generation_command: >-
         bash test-data/scripts/generate-deltas.sh
       reference_paths:
-        - test-data/datasets/sstables/test_deltas/partition_tombstones-2a26fb206c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl
+        - test-data/datasets/sstables/test_deltas/partition_tombstones-299258f0701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl
       normalization: >-
         scan_delta partition-delete records are mapped to the sstabledump JSONL
         partition deletion_info marker (marked_deleted) and compared with a
@@ -4734,7 +4789,7 @@ scenarios:
           local_deletion_time facts are compared to the sstabledump JSONL golden.
     fixtures:
       references:
-        - test-data/datasets/sstables/test_deltas/ttl_cells-2a35ef406c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl
+        - test-data/datasets/sstables/test_deltas/ttl_cells-299c9220701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl
     evidence:
       type: canonical_semantic
       artifacts: [jsonl]
@@ -4744,7 +4799,7 @@ scenarios:
       fixture_generation_command: >-
         bash test-data/scripts/generate-deltas.sh
       reference_paths:
-        - test-data/datasets/sstables/test_deltas/ttl_cells-2a35ef406c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl
+        - test-data/datasets/sstables/test_deltas/ttl_cells-299c9220701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl
       normalization: >-
         scan_delta expiring-cell records are mapped to sstabledump JSONL cell
         ttl / local_deletion_time fields and compared; mixed live + expiring
@@ -4896,7 +4951,7 @@ scenarios:
           to the sstabledump JSONL golden.
     fixtures:
       references:
-        - test-data/datasets/sstables/test_deltas/adjacent_ranges-972f22806c7811f1a24ff924a65838e2/nb-1-big-Data.db.jsonl
+        - test-data/datasets/sstables/test_deltas/adjacent_ranges-29bdd5c0701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl
     evidence:
       type: canonical_semantic
       artifacts: [jsonl]
@@ -4906,7 +4961,7 @@ scenarios:
       fixture_generation_command: >-
         bash test-data/scripts/generate-deltas.sh
       reference_paths:
-        - test-data/datasets/sstables/test_deltas/adjacent_ranges-972f22806c7811f1a24ff924a65838e2/nb-1-big-Data.db.jsonl
+        - test-data/datasets/sstables/test_deltas/adjacent_ranges-29bdd5c0701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl
       normalization: >-
         scan_delta range-delete records are reconstructed from sstabledump JSONL
         boundary markers (excl_end_incl_start / incl_end_excl_start) into
@@ -7047,7 +7102,7 @@ scenarios:
           - cqlite-core/tests/issue_1010_deletion_markers_parity.rs
     fixtures:
       references:
-        - test-data/datasets/sstables/test_deltas/adjacent_ranges-972f22806c7811f1a24ff924a65838e2/nb-1-big-Data.db.jsonl
+        - test-data/datasets/sstables/test_deltas/adjacent_ranges-29bdd5c0701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl
     evidence:
       type: canonical_semantic
       strict: false
@@ -7061,7 +7116,7 @@ scenarios:
         env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
         --features "delta-scan write-support" --test issue_1010_deletion_markers_parity
       reference_paths:
-        - test-data/datasets/sstables/test_deltas/adjacent_ranges-972f22806c7811f1a24ff924a65838e2/nb-1-big-Data.db.jsonl
+        - test-data/datasets/sstables/test_deltas/adjacent_ranges-29bdd5c0701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl
       normalization: >-
         scan_delta adjacent range-tombstone boundary markers (the shared boundary
         between two adjacent ranges) are mapped to the sstabledump JSONL


### PR DESCRIPTION
## Summary
Close-out of #1030's parity-manifest byte-gap tracking — exactly what #1030's "How to track progress" prescribes (flip closed scenarios' status/evidence to reflect reality, regenerate the report, lint stays green). **No fabricated evidence; no `required_parity`/`out_of_scope` scenario deleted; lint 0 errors.**

Assessment found the manifest grew 115→254 scenarios since #1030 was filed: 4 of the 7 gaps are already byte-parity-closed by newer superseding scenarios (only the original rows were stale), 2 are owned elsewhere, and 1 is genuinely open (carved out).

### Changes
- **Gap 1 — Filter.db no-false-negative** (`cass.filter_db_bloom.serialization_no_false_negative`): upgraded `partial → mirrored`/`byte_for_byte` (strict), pointed at the real strict test; **claim narrowed to BIG (`nb`/`oa`) only** — BTI/`da` membership is a separate open gap (`cass.filter_db.bti_membership`).
- **Gap 4 — Summary.db boundaries** (`cass.index_summary.summary_boundaries`): upgraded `partial → mirrored`/`byte_for_byte` (strict) mirroring the real strict Summary.db parity test's artifacts.
- **Gap 5 — TOC.txt** (`cass.sstable_format.toc_component_manifest`): verified already `byte_for_byte`/strict — no change.
- **Gap 3 — Digest.crc32 / checksum** (`cass.compression_checksum.checksum_trailer_detection`): kept honest at `partial`. The clean **Digest.crc32 byte comparison** that #1030 asked for is satisfied by `cass.sstable_format.toc_component_manifest`; **corruption detection/rejection is genuinely unimplemented → tracked by #1236**.
- **Gap 7 — test_deltas UUID drift**: remapped 6 drifted reference UUIDs to the complete on-disk fixture family (`…701f11…`); 3 tables (`static_with_rows`, `partial_updates`, `collection_ops`) left unchanged (no complete on-disk fixture). Full CI publishing owned by **#701**.
- Regenerated `docs/reports/cassandra-test-parity.md` (`report --check` = up to date). Report deltas: `partial` 17→15, `byte_for_byte` 111→113, `mirrored` 205→207.

### Disposition (not auto-closing #1030)
- **Gap 2 (scrub/verify)** — the only genuinely-open work — carved to **#1236** (design-driven, needs OpenSpec + commissioned corrupted fixtures).
- **Gap 6 (full-scope compaction byte parity)** owned by **#842**; **Gap 7 CI-publish** by **#701**; byte-for-byte Data.db backing by **#969**.

Refs #1030. **Manager call** (per the surface comment on #1030): does #1030 close on this PR + the carve-outs, or stay open pending #1236? Held for GO — not closing the umbrella here.

### Validation
- `scripts/agent-gate.sh`: **RESULT: PASS** (all components; no flakes).
- `cassandra-parity lint`: OK — 254 scenarios, 0 errors, 0 warnings.
- roborev (codex, branch): **No issues found** (two earlier overstatement findings corrected).

🤖 flow-lead worker
