### PR TITLE
ci: split Rust test groups into parallel jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,16 +41,15 @@ env:
   DATASET_SHA256: bebc763752c8d68c7fb0483a1b31294b4d1d21343d3f7d124da069e5073202fa
 
 jobs:
-  test:
+  core_tests:
+    name: Core tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v5
 
-      # This job compiles core+integration+write-support+CLI test deps into one
-      # debug target/ and sits at the standard runner's disk ceiling — 2 of the
-      # 6 epic-663 merge-train runs died of ENOSPC at 'Run CLI unit tests'
-      # (issue #722). Dropping preinstalled toolchains we never use frees ~14 GB.
+      # Rust test jobs can sit near the standard runner's disk ceiling (issue
+      # #722). Dropping preinstalled toolchains we never use frees ~14 GB.
       - name: Free disk space (issue #722)
         run: |
           df -h / | tail -1
@@ -142,6 +141,57 @@ jobs:
           ls -la "$CQLITE_DATASETS_ROOT/sstables/test_basic/" || echo "test_basic directory not found"
           cargo test --package cqlite-core --features cli-helpers -- --skip test_legacy_format_allows_blob_fallback_with_feature
 
+  integration_tests:
+    name: Integration tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Free disk space (issue #722)
+        run: |
+          df -h / | tail -1
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup /usr/local/lib/android /opt/hostedtoolcache/CodeQL
+          df -h / | tail -1
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Restore dataset cache
+        uses: actions/cache@v5
+        with:
+          path: test-data/datasets
+          key: datasets-${{ env.DATASET_TAG }}-${{ env.DATASET_SHA256 }}
+
+      - name: Fetch datasets if required fixture data missing
+        run: bash ./test-data/scripts/fetch-datasets.sh
+
+      - name: Sanity check dataset
+        run: |
+          set -euo pipefail
+          test -f test-data/datasets/metadata.yml
+          CORE_FIXTURE=$(find test-data/datasets/sstables/test_basic -path '*simple_table-*-Data.db' 2>/dev/null || true)
+          if [ -z "$CORE_FIXTURE" ]; then
+            echo "❌ Core fixture test_basic/simple_table-*/*-Data.db missing after fetch" >&2
+            exit 1
+          fi
+          GOLDEN_JSONL="test-data/datasets/sstables/test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294/nb-2-big-Data.db.jsonl"
+          if [ ! -s "$GOLDEN_JSONL" ]; then
+            echo "❌ Required JSONL golden missing after fetch: ${GOLDEN_JSONL}" >&2
+            exit 1
+          fi
+          echo "✅ Core fixture present: ${CORE_FIXTURE}"
+          echo "✅ Required JSONL golden present: ${GOLDEN_JSONL}"
+
       - name: Run integration tests (issue #514)
         env:
           CQLITE_DATASETS_ROOT: ${{ github.workspace }}/test-data/datasets
@@ -160,9 +210,32 @@ jobs:
             --test golden_path_scan_operations_tests \
             --test golden_path_summary_index_integration_tests
 
+  write_support_tests:
+    name: Write-support tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Free disk space (issue #722)
+        run: |
+          df -h / | tail -1
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup /usr/local/lib/android /opt/hostedtoolcache/CodeQL
+          df -h / | tail -1
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Run write-support tests (issue #552)
-        env:
-          CQLITE_DATASETS_ROOT: ${{ github.workspace }}/test-data/datasets
         run: |
           echo "Running write-support unit + roundtrip + compaction tests (issue #552)..."
           # These targets are self-contained: the lib unit tests, the write/read
@@ -175,15 +248,83 @@ jobs:
           # folded into clustering rows (fully synthetic — no fixtures required).
           cargo test --package cqlite-core --features write-support --test issue_1074_static_write_parity
 
+  delta_scan_tests:
+    name: Delta-scan tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Run delta-scan tests (issue #697)
-        env:
-          CQLITE_DATASETS_ROOT: ${{ github.workspace }}/test-data/datasets
         run: |
           echo "Running delta-scan unit tests (issue #697)..."
           # The delta-scan feature flag gates DeltaRecord, RangeBound, and related
           # delta_scan module tests.  These are self-contained unit tests that do
           # not require fixture data.
           cargo test --package cqlite-core --features delta-scan --lib
+
+  cli_smoke_tests:
+    name: CLI tests and smoke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Free disk space (issue #722)
+        run: |
+          df -h / | tail -1
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup /usr/local/lib/android /opt/hostedtoolcache/CodeQL
+          df -h / | tail -1
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Restore dataset cache
+        uses: actions/cache@v5
+        with:
+          path: test-data/datasets
+          key: datasets-${{ env.DATASET_TAG }}-${{ env.DATASET_SHA256 }}
+
+      - name: Fetch datasets if required fixture data missing
+        run: bash ./test-data/scripts/fetch-datasets.sh
+
+      - name: Sanity check dataset
+        run: |
+          set -euo pipefail
+          test -f test-data/datasets/metadata.yml
+          CORE_FIXTURE=$(find test-data/datasets/sstables/test_basic -path '*simple_table-*-Data.db' 2>/dev/null || true)
+          if [ -z "$CORE_FIXTURE" ]; then
+            echo "❌ Core fixture test_basic/simple_table-*/*-Data.db missing after fetch" >&2
+            exit 1
+          fi
+          GOLDEN_JSONL="test-data/datasets/sstables/test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294/nb-2-big-Data.db.jsonl"
+          if [ ! -s "$GOLDEN_JSONL" ]; then
+            echo "❌ Required JSONL golden missing after fetch: ${GOLDEN_JSONL}" >&2
+            exit 1
+          fi
+          echo "✅ Core fixture present: ${CORE_FIXTURE}"
+          echo "✅ Required JSONL golden present: ${GOLDEN_JSONL}"
 
       - name: Run CLI unit tests
         env:
@@ -217,6 +358,40 @@ jobs:
           name: smoke-test-results
           path: test-data/scripts/smoke-test-results/
           retention-days: 7
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    needs:
+      - core_tests
+      - integration_tests
+      - write_support_tests
+      - delta_scan_tests
+      - cli_smoke_tests
+    if: ${{ always() }}
+    steps:
+      - name: Check split test jobs
+        run: |
+          set -euo pipefail
+
+          failed=0
+          check_result() {
+            local job="$1"
+            local result="$2"
+            if [ "$result" != "success" ]; then
+              echo "❌ ${job}: ${result}" >&2
+              failed=1
+            else
+              echo "✅ ${job}: ${result}"
+            fi
+          }
+
+          check_result "core_tests" "${{ needs.core_tests.result }}"
+          check_result "integration_tests" "${{ needs.integration_tests.result }}"
+          check_result "write_support_tests" "${{ needs.write_support_tests.result }}"
+          check_result "delta_scan_tests" "${{ needs.delta_scan_tests.result }}"
+          check_result "cli_smoke_tests" "${{ needs.cli_smoke_tests.result }}"
+          exit "$failed"
 
   cleanup-validation:
     name: Cleanup Safety Validation


### PR DESCRIPTION
## Summary
- Split the monolithic CI test job into parallel Rust test groups: core, integration, write-support, delta-scan, and CLI/smoke
- Keep a final aggregate job named test so existing required-check naming can remain stable
- Reuse the hardened dataset fetch and JSONL sanity checks only in jobs that need fixture data

## Expected impact
The previous CI test job ran these groups serially and took 31m08s on PR #1241. This should make the CI workflow duration track the slowest split group instead of the sum of all groups.

## Local validation
- Parsed all workflow YAML files with Ruby
- Checked the split job graph and aggregate test dependencies with Ruby
- Ran git diff --check for .github/workflows/ci.yml

Note: actionlint is not installed in the local environment, so GitHub Actions is the syntax authority for expression evaluation.