### PR TITLE
fix(#1230): make dataset-dependent tests + CI lanes fail-closed on missing fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,9 +108,9 @@ jobs:
           echo "✅ Core fixture present: ${CORE_FIXTURE}"
           echo "✅ Required JSONL golden present: ${GOLDEN_JSONL}"
           # Issue #1230: broaden the sanity check beyond the single core fixture —
-          # assert the WHOLE 33-table validation corpus is present so a partial
-          # extraction or a dropped table reds CI here instead of letting the
-          # dataset-dependent lanes skip-and-pass.
+          # assert the WHOLE 39-table enforced corpus (33 nb + 6 test_oa) is
+          # present so a partial extraction or a dropped table reds CI here
+          # instead of letting the dataset-dependent lanes skip-and-pass.
           bash test-data/scripts/check-dataset-manifest.sh test-data/datasets
 
       - name: Validate environment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,11 @@ jobs:
           fi
           echo "✅ Core fixture present: ${CORE_FIXTURE}"
           echo "✅ Required JSONL golden present: ${GOLDEN_JSONL}"
+          # Issue #1230: broaden the sanity check beyond the single core fixture —
+          # assert the WHOLE 33-table validation corpus is present so a partial
+          # extraction or a dropped table reds CI here instead of letting the
+          # dataset-dependent lanes skip-and-pass.
+          bash test-data/scripts/check-dataset-manifest.sh test-data/datasets
 
       - name: Validate environment
         run: |
@@ -140,6 +145,11 @@ jobs:
       - name: Run core lib/doc tests with timings
         env:
           CQLITE_DATASETS_ROOT: ${{ github.workspace }}/test-data/datasets
+          # Issue #1230: fail-closed. The ~70 legacy dataset-dependent tests skip
+          # on missing data; with these flags an absent/empty fixture FAILS the
+          # lane (via require_fixtures_strict) instead of false-greening.
+          CQLITE_REQUIRE_FIXTURES: "1"
+          CQLITE_PARITY_REQUIRE_DATASETS: "1"
           RUST_LOG: debug
           RUST_BACKTRACE: full
         run: bash scripts/ci/run-core-test-group.sh lib-doc
@@ -317,6 +327,9 @@ jobs:
       - name: Run integration tests (issue #514)
         env:
           CQLITE_DATASETS_ROOT: ${{ github.workspace }}/test-data/datasets
+          # Issue #1230: fail-closed for the dataset-dependent golden-path lane.
+          CQLITE_REQUIRE_FIXTURES: "1"
+          CQLITE_PARITY_REQUIRE_DATASETS: "1"
         run: |
           echo "Running revived orphan integration tests (issue #514)..."
           # Run the seven golden-path / chunked-reader / component tests that were

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -207,9 +207,12 @@ jobs:
         working-directory: bindings/node
         env:
           CQLITE_DATASETS_ROOT: ${{ github.workspace }}/test-data/datasets
-          # Issue #1230: fail-closed flag for parity with the other CI lanes. The
-          # node helper (skipIfNoDatasets) already throws on missing data; this
-          # documents intent and is honored by the Rust core it calls.
+          # Issue #1230: for the node lane this flag is DOCUMENTARY only — it is a
+          # cqlite-core TEST-ONLY helper and is NOT consulted by the node binding
+          # runtime. Actual fail-closed coverage here comes from the
+          # check-dataset-manifest.sh step above (hard-fails on a partial/dropped
+          # corpus) plus the JS skipIfNoDatasets throw on missing data. The flag
+          # is set for parity of intent with the Rust/Python lanes.
           CQLITE_REQUIRE_FIXTURES: "1"
         run: npm test
 

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -199,8 +199,9 @@ jobs:
         run: |
           set -euo pipefail
           test -f test-data/datasets/metadata.yml
-          # Issue #1230: assert the full 33-table corpus (was: a non-failing
-          # `ls ... || true` that passed even on a partial extraction).
+          # Issue #1230: assert the full 39-table enforced corpus (33 nb + 6
+          # test_oa) — was a non-failing `ls ... || true` that passed even on a
+          # partial extraction.
           bash test-data/scripts/check-dataset-manifest.sh test-data/datasets
 
       - name: Run smoke tests
@@ -211,7 +212,7 @@ jobs:
           # cqlite-core TEST-ONLY helper and is NOT consulted by the node binding
           # runtime. Actual fail-closed coverage here comes from the
           # check-dataset-manifest.sh step above (hard-fails on a partial/dropped
-          # corpus) plus the JS skipIfNoDatasets throw on missing data. The flag
+          # 39-table corpus) plus the JS skipIfNoDatasets throw on missing data. The flag
           # is set for parity of intent with the Rust/Python lanes.
           CQLITE_REQUIRE_FIXTURES: "1"
         run: npm test

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -197,14 +197,20 @@ jobs:
       - name: Sanity check dataset
         shell: bash
         run: |
+          set -euo pipefail
           test -f test-data/datasets/metadata.yml
-          # Verify at least one keyspace directory exists
-          ls -1 test-data/datasets/sstables/test_basic/ 2>/dev/null | head -n 1 || true
+          # Issue #1230: assert the full 33-table corpus (was: a non-failing
+          # `ls ... || true` that passed even on a partial extraction).
+          bash test-data/scripts/check-dataset-manifest.sh test-data/datasets
 
       - name: Run smoke tests
         working-directory: bindings/node
         env:
           CQLITE_DATASETS_ROOT: ${{ github.workspace }}/test-data/datasets
+          # Issue #1230: fail-closed flag for parity with the other CI lanes. The
+          # node helper (skipIfNoDatasets) already throws on missing data; this
+          # documents intent and is honored by the Rust core it calls.
+          CQLITE_REQUIRE_FIXTURES: "1"
         run: npm test
 
       - name: Upload test results on failure

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -212,8 +212,11 @@ jobs:
       - name: Sanity check dataset
         shell: bash
         run: |
+          set -euo pipefail
           test -f test-data/datasets/metadata.yml
-          ls test-data/datasets/sstables/test_basic/ | head -n 1
+          # Issue #1230: assert the full 33-table corpus, not just test_basic, so a
+          # partial extraction reds CI instead of skip-greening the pytest lane.
+          bash test-data/scripts/check-dataset-manifest.sh test-data/datasets
 
       # Issue #331: Pre-build CLI binary for faster CLI parity tests
       - name: Build CLI binary for tests
@@ -225,6 +228,11 @@ jobs:
         env:
           CQLITE_DATASETS_ROOT: ${{ github.workspace }}/test-data/datasets
           RUN_SLOW_TESTS: "1"  # Issue #331: Run all tests including CLI parity
+          # Issue #1230: fail-closed. With this flag the conftest skip helper turns
+          # a missing dataset into a FAILURE (not a silent skip), and the
+          # "no tests ran" floor (pytest_sessionfinish) fails the lane if 0 tests
+          # pass — so a dropped table / #773-class path regression reds CI.
+          CQLITE_REQUIRE_FIXTURES: "1"
         shell: bash
         run: |
           pytest bindings/python/tests/ -v --tb=short

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -214,8 +214,9 @@ jobs:
         run: |
           set -euo pipefail
           test -f test-data/datasets/metadata.yml
-          # Issue #1230: assert the full 33-table corpus, not just test_basic, so a
-          # partial extraction reds CI instead of skip-greening the pytest lane.
+          # Issue #1230: assert the full 39-table enforced corpus (33 nb + 6
+          # test_oa), not just test_basic, so a partial extraction reds CI
+          # instead of skip-greening the pytest lane.
           bash test-data/scripts/check-dataset-manifest.sh test-data/datasets
 
       # Issue #331: Pre-build CLI binary for faster CLI parity tests
@@ -231,7 +232,7 @@ jobs:
           # Issue #1230: fail-closed. With this flag the conftest skip helper turns
           # a missing dataset into a FAILURE (not a silent skip). What catches a
           # dropped/renamed table or a #773-class path regression is the
-          # check-dataset-manifest.sh step above (full 33-table corpus) plus that
+          # check-dataset-manifest.sh step above (full 39-table corpus) plus that
           # strict skip-helper failure. The pytest_sessionfinish "no tests ran"
           # floor is only a whole-session no-op guard (it reds when 0 tests pass
           # at all); it does NOT detect dataset tests skipping while non-dataset

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -229,9 +229,13 @@ jobs:
           CQLITE_DATASETS_ROOT: ${{ github.workspace }}/test-data/datasets
           RUN_SLOW_TESTS: "1"  # Issue #331: Run all tests including CLI parity
           # Issue #1230: fail-closed. With this flag the conftest skip helper turns
-          # a missing dataset into a FAILURE (not a silent skip), and the
-          # "no tests ran" floor (pytest_sessionfinish) fails the lane if 0 tests
-          # pass — so a dropped table / #773-class path regression reds CI.
+          # a missing dataset into a FAILURE (not a silent skip). What catches a
+          # dropped/renamed table or a #773-class path regression is the
+          # check-dataset-manifest.sh step above (full 33-table corpus) plus that
+          # strict skip-helper failure. The pytest_sessionfinish "no tests ran"
+          # floor is only a whole-session no-op guard (it reds when 0 tests pass
+          # at all); it does NOT detect dataset tests skipping while non-dataset
+          # tests still pass.
           CQLITE_REQUIRE_FIXTURES: "1"
         shell: bash
         run: |

--- a/bindings/python/tests/conftest.py
+++ b/bindings/python/tests/conftest.py
@@ -418,13 +418,20 @@ def pytest_collection_modifyitems(config, items):
 
 
 # =============================================================================
-# "No tests ran" floor (issue #1230)
+# Whole-session no-op floor (issue #1230)
 # =============================================================================
 
-# Count of tests that actually PASSED their call phase. Under strict mode a lane
-# in which 0 tests pass (everything skipped, or nothing collected) is a failure,
-# not a green run — this catches the degenerate case where the whole dataset
-# lane silently no-ops.
+# Count of tests that actually PASSED their call phase. Under strict mode a
+# session in which 0 tests pass (everything skipped, or nothing collected) is a
+# failure, not a green run.
+#
+# SCOPE (be honest): this is a whole-session no-op guard ONLY. It fires solely
+# when the ENTIRE session has zero passing call-phase tests. Because this lane
+# also runs many passing NON-dataset tests, the floor does NOT catch "the
+# dataset tests all skipped while the rest passed" — i.e. it will NOT catch a
+# dropped/renamed table or a #773-class path regression on its own. Those are
+# covered by check-dataset-manifest.sh (hard-fails on a partial corpus) and by
+# skip_if_no_datasets() failing closed under strict mode.
 _PASSED_CALLS = 0
 
 

--- a/bindings/python/tests/conftest.py
+++ b/bindings/python/tests/conftest.py
@@ -61,10 +61,36 @@ SCHEMA_WIDE_ROWS = SCHEMAS / "wide-rows.cql"
 # =============================================================================
 
 
+def _require_fixtures_strict() -> bool:
+    """True when strict fixture mode is requested (issue #1230).
+
+    Mirrors the Rust ``require_fixtures_strict`` helper: either
+    ``CQLITE_REQUIRE_FIXTURES`` or ``CQLITE_PARITY_REQUIRE_DATASETS`` set to a
+    truthy value flips the dataset-dependent pytest lane FAIL-CLOSED — a missing
+    dataset becomes a hard failure instead of a silent skip, so a dropped table
+    or a path regression reds CI rather than false-greening. Local dev without
+    the binaries (neither flag set) still skips.
+    """
+    return os.environ.get("CQLITE_REQUIRE_FIXTURES") in ("1", "true") or os.environ.get(
+        "CQLITE_PARITY_REQUIRE_DATASETS"
+    ) in ("1", "true")
+
+
 def skip_if_no_datasets():
-    """Skip test if datasets directory doesn't exist."""
+    """Skip (or, under strict mode, FAIL) when the datasets dir is absent.
+
+    Issue #1230: under ``CQLITE_REQUIRE_FIXTURES=1`` (used by CI) a missing
+    dataset is a hard failure, never a silent skip.
+    """
     if not DATASETS.exists():
-        pytest.skip(f"Test data not found: {DATASETS}")
+        msg = f"Test data not found: {DATASETS}"
+        if _require_fixtures_strict():
+            pytest.fail(
+                f"{msg} (CQLITE_REQUIRE_FIXTURES=1 — fetch with "
+                "bash test-data/scripts/fetch-datasets.sh)",
+                pytrace=False,
+            )
+        pytest.skip(msg)
 
 
 def skip_if_no_schema(schema_path: Path):
@@ -389,3 +415,36 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if "slow" in item.keywords:
             item.add_marker(skip_slow)
+
+
+# =============================================================================
+# "No tests ran" floor (issue #1230)
+# =============================================================================
+
+# Count of tests that actually PASSED their call phase. Under strict mode a lane
+# in which 0 tests pass (everything skipped, or nothing collected) is a failure,
+# not a green run — this catches the degenerate case where the whole dataset
+# lane silently no-ops.
+_PASSED_CALLS = 0
+
+
+def pytest_runtest_logreport(report):
+    global _PASSED_CALLS
+    if report.when == "call" and report.passed:
+        _PASSED_CALLS += 1
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Fail the session under strict mode if no test passed (issue #1230)."""
+    if not _require_fixtures_strict():
+        return
+    if _PASSED_CALLS == 0:
+        reporter = session.config.pluginmanager.get_plugin("terminalreporter")
+        if reporter is not None:
+            reporter.write_line(
+                "ERROR (issue #1230): CQLITE_REQUIRE_FIXTURES=1 but 0 tests passed "
+                "— the dataset lane ran nothing or everything skipped (fail-closed).",
+                red=True,
+            )
+        # Override exit status so CI reds even though no test technically failed.
+        session.exitstatus = 1

--- a/cqlite-core/src/testing/dataset_helpers.rs
+++ b/cqlite-core/src/testing/dataset_helpers.rs
@@ -73,6 +73,25 @@ fn get_datasets_root() -> PathBuf {
     }
 }
 
+/// `true` when strict fixture mode is requested (issue #1230). Either
+/// `CQLITE_REQUIRE_FIXTURES` (the repo-wide convention used by the newer
+/// `issue_10xx`/`issue_99x` parity tests) or `CQLITE_PARITY_REQUIRE_DATASETS`
+/// (issue #1205) set to a truthy value ("1"/"true") flips dataset-dependent
+/// tests FAIL-CLOSED: an absent/empty fixture PANICS (test failure) instead of
+/// skipping, so a required CI lane cannot false-green when a table is dropped or
+/// a #773-class path regression hides the data. When neither is set, the default
+/// skip-on-absence behavior is preserved so local dev without the binaries still
+/// works. This is the single shared definition — do NOT fork a parallel copy.
+pub fn require_fixtures_strict() -> bool {
+    matches!(
+        std::env::var("CQLITE_REQUIRE_FIXTURES").as_deref(),
+        Ok("1") | Ok("true")
+    ) || matches!(
+        std::env::var("CQLITE_PARITY_REQUIRE_DATASETS").as_deref(),
+        Ok("1") | Ok("true")
+    )
+}
+
 /// Load metadata.yml from datasets root
 pub fn load_metadata() -> Result<Metadata, DatasetError> {
     load_metadata_at(&get_datasets_root())

--- a/cqlite-core/src/testing/mod.rs
+++ b/cqlite-core/src/testing/mod.rs
@@ -8,6 +8,8 @@ pub use dataset_helpers::{
     list_tables_at,
     load_metadata,
     load_metadata_at,
+    // Strict fixture gate (issue #1230): single shared definition.
+    require_fixtures_strict,
     resolve_table_to_sstable_path,
     resolve_table_to_sstable_path_at,
     TableInfo,

--- a/cqlite-core/tests/reader_compression_tests.rs
+++ b/cqlite-core/tests/reader_compression_tests.rs
@@ -15,6 +15,12 @@ use cqlite_core::{Config, Platform};
 /// (issue #1230). Under strict mode (`require_fixtures_strict`) every one of
 /// these MUST be present and openable, so a dropped table or a partial dataset
 /// extraction reds CI instead of silently passing on whatever survived.
+///
+/// SINGLE SOURCE OF TRUTH (intent): this 8-table list is hand-duplicated from
+/// the full corpus manifest. Keep it in sync with the `test_basic` block in
+/// `test-data/scripts/check-dataset-manifest.sh` and `test-data/validation-matrix.md`.
+/// A future change should derive all three from metadata.yml / validation-matrix.md
+/// so a table add/rename updates everything at once.
 const EXPECTED_TEST_BASIC_TABLES: &[&str] = &[
     "composite_key_table",
     "compression_test_table",

--- a/cqlite-core/tests/reader_compression_tests.rs
+++ b/cqlite-core/tests/reader_compression_tests.rs
@@ -8,7 +8,23 @@ use std::sync::Arc;
 
 use cqlite_core::storage::sstable::compression_info::CompressionInfo;
 use cqlite_core::storage::sstable::reader::{extract_sstable_base_name, SSTableReader};
+use cqlite_core::testing::dataset_helpers::require_fixtures_strict;
 use cqlite_core::{Config, Platform};
+
+/// Tables that the pinned `test_basic` keyspace fixture is expected to ship
+/// (issue #1230). Under strict mode (`require_fixtures_strict`) every one of
+/// these MUST be present and openable, so a dropped table or a partial dataset
+/// extraction reds CI instead of silently passing on whatever survived.
+const EXPECTED_TEST_BASIC_TABLES: &[&str] = &[
+    "composite_key_table",
+    "compression_test_table",
+    "counters",
+    "multi_partition_table",
+    "simple_table",
+    "static_columns_table",
+    "ttl_test_table",
+    "uncompressed_table",
+];
 
 /// Helper to get test datasets root
 fn get_test_datasets_root() -> Option<std::path::PathBuf> {
@@ -358,13 +374,27 @@ async fn test_compression_info_file_sizes() {
 
 #[tokio::test]
 async fn test_open_all_test_basic_tables_with_compression() {
+    // Fail-closed gate (issue #1230): if the dataset root is unset/absent, a
+    // strict CI lane must FAIL rather than silently pass on missing data; local
+    // dev without the fixtures still skips.
     let Some(datasets_root) = get_test_datasets_root() else {
+        assert!(
+            !require_fixtures_strict(),
+            "CQLITE_REQUIRE_FIXTURES=1 but CQLITE_DATASETS_ROOT is unset — \
+             fetch with bash test-data/scripts/fetch-datasets.sh"
+        );
         eprintln!("CQLITE_DATASETS_ROOT not set, skipping test");
         return;
     };
 
     let keyspace_dir = datasets_root.join("sstables").join("test_basic");
     if !keyspace_dir.exists() {
+        assert!(
+            !require_fixtures_strict(),
+            "CQLITE_REQUIRE_FIXTURES=1 but test_basic keyspace is absent under {} — \
+             fetch with bash test-data/scripts/fetch-datasets.sh",
+            keyspace_dir.display()
+        );
         eprintln!("test_basic keyspace not found, skipping test");
         return;
     }
@@ -376,53 +406,70 @@ async fn test_open_all_test_basic_tables_with_compression() {
             .expect("Failed to create platform"),
     );
 
-    let entries: Vec<_> = std::fs::read_dir(&keyspace_dir)
-        .expect("Should read keyspace dir")
-        .filter_map(|e| e.ok())
-        .filter(|e| e.path().is_dir())
-        .collect();
+    let strict = require_fixtures_strict();
+    let mut opened: Vec<&str> = Vec::new();
 
-    let mut success_count = 0;
-    let mut fail_count = 0;
+    for &table in EXPECTED_TEST_BASIC_TABLES {
+        // Resolve the <table>-<uuid> directory, then its Data.db.
+        let data_file = find_table_dir(&datasets_root, "test_basic", &format!("{table}-"))
+            .as_deref()
+            .and_then(find_data_file);
 
-    for entry in entries {
-        let table_dir = entry.path();
-        let table_name = table_dir
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("unknown");
-
-        let Some(data_file) = find_data_file(&table_dir) else {
-            eprintln!("  {} - No Data.db found", table_name);
+        let Some(data_file) = data_file else {
+            // A missing expected table is a hard failure under strict mode so a
+            // dropped table or a partial extraction reds CI (was: silent
+            // `continue` that still let `success_count > 0` pass).
+            assert!(
+                !strict,
+                "CQLITE_REQUIRE_FIXTURES=1 but expected table test_basic.{table} \
+                 has no Data.db under {} — dropped table or partial dataset?",
+                keyspace_dir.display()
+            );
+            eprintln!("  {table} - No Data.db found (skipped, non-strict)");
             continue;
         };
 
-        match SSTableReader::open(&data_file, &config, platform.clone()).await {
-            Ok(reader) => {
-                eprintln!(
-                    "  ✓ {} - Opened successfully (version: {:?})",
-                    table_name,
-                    reader.header().cassandra_version
-                );
-                success_count += 1;
-            }
-            Err(e) => {
-                eprintln!("  ✗ {} - Failed: {}", table_name, e);
-                fail_count += 1;
-            }
-        }
+        let reader = SSTableReader::open(&data_file, &config, platform.clone())
+            .await
+            .unwrap_or_else(|e| panic!("test_basic.{table} failed to open: {e}"));
+
+        // Real content assertion (not just "opened without error"): the on-disk
+        // Data.db is non-empty and the reader parsed a header.
+        let version = reader.header().cassandra_version;
+        let data_len = std::fs::metadata(&data_file)
+            .map(|m| m.len())
+            .unwrap_or_else(|e| panic!("test_basic.{table} Data.db metadata: {e}"));
+        assert!(
+            data_len > 0,
+            "test_basic.{table} Data.db is present but empty (0 bytes)"
+        );
+        eprintln!("  ✓ {table} - Opened (version: {version:?}, {data_len} bytes)");
+        opened.push(table);
     }
 
     eprintln!(
-        "\nResults: {} succeeded, {} failed",
-        success_count, fail_count
+        "\nResults: {}/{} expected test_basic tables opened",
+        opened.len(),
+        EXPECTED_TEST_BASIC_TABLES.len()
     );
 
-    // Most tables should open successfully
-    assert!(
-        success_count > 0,
-        "Expected at least some tables to open successfully"
-    );
+    if strict {
+        // Under strict mode every expected table must be present and openable.
+        assert_eq!(
+            opened.len(),
+            EXPECTED_TEST_BASIC_TABLES.len(),
+            "strict mode: only {:?} of the expected {:?} tables opened",
+            opened,
+            EXPECTED_TEST_BASIC_TABLES
+        );
+    } else {
+        // Non-strict local dev: at least the core table must be readable so the
+        // test still proves the read path works when any fixtures are present.
+        assert!(
+            !opened.is_empty(),
+            "Expected at least one test_basic table to open successfully"
+        );
+    }
 }
 
 /// Helper: find any nb-1-big-CompressionInfo.db under the datasets root.

--- a/cqlite-core/tests/sstable_parity_integration_test.rs
+++ b/cqlite-core/tests/sstable_parity_integration_test.rs
@@ -588,15 +588,21 @@ fn handle_parity_error(e: &str) {
 /// that legitimately parses to 95–99% of reference partitions stays green.
 const DEFAULT_PARITY_MIN_PERCENT: u64 = 95;
 
-/// Real presence/content assertion (issue #1230) replacing the thin
-/// `partition_count > 0`. Requires the JSONL golden to be present and non-empty
-/// and the parser to cover at least `min_percent`% of the reference partitions,
-/// so a dropped or truncated table FAILS rather than passing on a single stray
-/// partition. The tolerance is an explicit parameter (call sites pass
-/// [`DEFAULT_PARITY_MIN_PERCENT`]) and is the SINGLE source of truth for the
-/// pass/fail threshold — call sites must not stack a second, conflicting
-/// partition-count check. #1230 only adds the fail-closed-on-empty guard; it
-/// deliberately does NOT tighten the established lenient ratio to 100%.
+/// Ratio-based presence/content assertion (issue #1230). Requires the JSONL
+/// golden to be present and non-empty and the parser to cover at least
+/// `min_percent`% of the reference partitions. The tolerance is an explicit
+/// parameter and is the single source of truth for the RATIO threshold. A call
+/// site MAY additionally pin a separate ABSOLUTE partition-count floor (a
+/// regression pin distinct from this ratio check — e.g.
+/// `test_collection_table_map_parsing`'s `>= 50`); that is permitted because it
+/// is not a second, conflicting expression of the same ratio. What is forbidden
+/// is restating the ratio as a different percentage.
+///
+/// This helper is used ONLY at the call site that had a 95% tolerance BEFORE
+/// #1230 (`test_simple_table_key_parsing_parity`). #1230 preserves that 95%
+/// exactly — it does not tighten it to 100%. Call sites whose pre-#1230 baseline
+/// was the lenient `partition_count > 0` use [`assert_parity_present`] instead,
+/// so #1230 leaves their pass criteria unchanged.
 fn assert_parity_content(r: &ParityResult, min_percent: u64) {
     assert!(
         r.reference_count > 0,
@@ -610,6 +616,25 @@ fn assert_parity_content(r: &ParityResult, min_percent: u64) {
         min_partitions,
         min_percent,
         r.reference_count
+    );
+}
+
+/// Fail-closed-on-empty presence assertion (issue #1230) for the call sites
+/// whose pre-#1230 baseline was the lenient `partition_count > 0`. It preserves
+/// that exact lenient pass criterion (any non-zero partition count passes) while
+/// ADDING only the fail-closed guarantee: the JSONL golden must be present and
+/// non-empty, so a dropped table or a #773-class missing-fixture regression
+/// FAILS rather than silently passing on absent reference data. It deliberately
+/// does NOT impose a ratio floor — that would tighten these tables' criteria,
+/// which is out of scope for #1230.
+fn assert_parity_present(r: &ParityResult) {
+    assert!(
+        r.reference_count > 0,
+        "JSONL golden is absent or empty (0 reference partitions)"
+    );
+    assert!(
+        r.partition_count > 0,
+        "parsed 0 partitions (expected > 0) — table dropped or truncated?"
     );
 }
 
@@ -664,7 +689,7 @@ async fn test_composite_key_table_parsing_parity() {
                 "composite_key_table: {} partitions, {}/{} keys matched",
                 r.partition_count, r.matched_keys, r.reference_count
             );
-            assert_parity_content(&r, DEFAULT_PARITY_MIN_PERCENT);
+            assert_parity_present(&r);
         }
         Err(e) => handle_parity_error(&e),
     }
@@ -684,7 +709,7 @@ async fn test_static_columns_table_parsing() {
                 "static_columns_table: {} partitions, {}/{} keys matched",
                 r.partition_count, r.matched_keys, r.reference_count
             );
-            assert_parity_content(&r, DEFAULT_PARITY_MIN_PERCENT);
+            assert_parity_present(&r);
         }
         Err(e) => handle_parity_error(&e),
     }
@@ -708,7 +733,7 @@ async fn test_collection_table_list_parsing() {
                 "collection_table: {} partitions, {}/{} cells validated",
                 r.partition_count, r.validated_cells, r.total_cells
             );
-            assert_parity_content(&r, DEFAULT_PARITY_MIN_PERCENT);
+            assert_parity_present(&r);
         }
         Err(e) => handle_parity_error(&e),
     }
@@ -759,7 +784,7 @@ async fn test_nested_collections_parsing() {
                 "nested_collections_table: {} partitions, {}/{} cells validated",
                 r.partition_count, r.validated_cells, r.total_cells
             );
-            assert_parity_content(&r, DEFAULT_PARITY_MIN_PERCENT);
+            assert_parity_present(&r);
         }
         Err(e) => handle_parity_error(&e),
     }
@@ -779,7 +804,7 @@ async fn test_collections_with_udts_parsing() {
                 "collections_with_udts: {} partitions, {}/{} cells validated",
                 r.partition_count, r.validated_cells, r.total_cells
             );
-            assert_parity_content(&r, DEFAULT_PARITY_MIN_PERCENT);
+            assert_parity_present(&r);
         }
         Err(e) => handle_parity_error(&e),
     }
@@ -803,7 +828,7 @@ async fn test_sensor_data_clustering_key_parsing() {
                 "sensor_data: {} partitions, {}/{} keys matched",
                 r.partition_count, r.matched_keys, r.reference_count
             );
-            assert_parity_content(&r, DEFAULT_PARITY_MIN_PERCENT);
+            assert_parity_present(&r);
         }
         Err(e) => handle_parity_error(&e),
     }
@@ -823,7 +848,7 @@ async fn test_stock_prices_bti_format() {
                 "stock_prices: {} partitions, {}/{} keys matched",
                 r.partition_count, r.matched_keys, r.reference_count
             );
-            assert_parity_content(&r, DEFAULT_PARITY_MIN_PERCENT);
+            assert_parity_present(&r);
         }
         Err(e) => handle_parity_error(&e),
     }
@@ -847,7 +872,7 @@ async fn test_wide_partition_table_many_rows() {
                 "wide_partition_table: {} partitions, {}/{} keys matched",
                 r.partition_count, r.matched_keys, r.reference_count
             );
-            assert_parity_content(&r, DEFAULT_PARITY_MIN_PERCENT);
+            assert_parity_present(&r);
         }
         Err(e) => handle_parity_error(&e),
     }
@@ -867,7 +892,7 @@ async fn test_chat_messages_frozen_types() {
                 "chat_messages: {} partitions, {}/{} cells validated",
                 r.partition_count, r.validated_cells, r.total_cells
             );
-            assert_parity_content(&r, DEFAULT_PARITY_MIN_PERCENT);
+            assert_parity_present(&r);
         }
         Err(e) => handle_parity_error(&e),
     }
@@ -887,7 +912,7 @@ async fn test_many_columns_table_sparse_bitmap() {
                 "many_columns_table: {} partitions, {}/{} keys matched",
                 r.partition_count, r.matched_keys, r.reference_count
             );
-            assert_parity_content(&r, DEFAULT_PARITY_MIN_PERCENT);
+            assert_parity_present(&r);
         }
         Err(e) => handle_parity_error(&e),
     }
@@ -918,9 +943,11 @@ async fn test_all_tables_basic_parity() {
     for (keyspace, table) in &test_cases {
         match run_parity_test(keyspace, table).await {
             Ok(r) => {
-                // Fail-closed (issue #1230): real content/presence assertion, not
-                // the old `if partition_count > 0 { pass } else { fail }`.
-                assert_parity_content(&r, DEFAULT_PARITY_MIN_PERCENT);
+                // Fail-closed (issue #1230): presence assertion, not the old
+                // `if partition_count > 0 { pass } else { fail }`. Preserves the
+                // pre-#1230 lenient `> 0` pass criterion (no ratio floor added)
+                // while failing closed when the golden is absent/empty.
+                assert_parity_present(&r);
                 println!(
                     "PASS: {}.{} ({} partitions)",
                     keyspace, table, r.partition_count

--- a/cqlite-core/tests/sstable_parity_integration_test.rs
+++ b/cqlite-core/tests/sstable_parity_integration_test.rs
@@ -25,8 +25,8 @@
 
 use cqlite_core::storage::sstable::reader::SSTableReader;
 use cqlite_core::testing::dataset_helpers::{
-    derive_reference_paths_from_data_db, resolve_table_to_sstable_path, should_ignore_file,
-    DatasetError,
+    derive_reference_paths_from_data_db, require_fixtures_strict, resolve_table_to_sstable_path,
+    should_ignore_file, DatasetError,
 };
 use cqlite_core::{Config, Platform, Value};
 use num_bigint::BigInt;
@@ -540,14 +540,68 @@ fn test_data_available() -> bool {
         || resolve_table_to_sstable_path("test_basic", "simple_table").is_ok()
 }
 
+/// Skip-or-fail gate for dataset-dependent tests (issue #1230). When the dataset
+/// is unavailable this PANICS under strict mode (`require_fixtures_strict`) so a
+/// required CI lane cannot false-green on missing data, and otherwise returns
+/// `true` (the caller `return`s) to preserve the local-dev skip-on-absence flow.
+fn skip_when_data_unavailable() -> bool {
+    if test_data_available() {
+        return false;
+    }
+    assert!(
+        !require_fixtures_strict(),
+        "CQLITE_REQUIRE_FIXTURES=1 but dataset unavailable (CQLITE_DATASETS_ROOT \
+         unset or metadata.yml missing) — fetch with bash test-data/scripts/fetch-datasets.sh"
+    );
+    eprintln!("Skipping test: dataset unavailable (set CQLITE_DATASETS_ROOT)");
+    true
+}
+
+/// Handle a `run_parity_test` Err per the fail-closed contract (issue #1230).
+/// A genuine parse failure ALWAYS panics. A missing-fixture error (the data was
+/// not there) PANICS under strict mode and is skipped — with a note — only in
+/// non-strict local-dev mode. The previous code unconditionally swallowed
+/// "not set"/"not found", which let a dropped table or a #773-class path
+/// regression pass green.
+fn handle_parity_error(e: &str) {
+    let missing_fixture = e.contains("not set")
+        || e.contains("not found")
+        || e.contains("No Data.db")
+        || e.contains("metadata.yml missing");
+    assert!(missing_fixture, "parity test failed (genuine error): {e}");
+    assert!(
+        !require_fixtures_strict(),
+        "CQLITE_REQUIRE_FIXTURES=1 but fixture missing: {e} — \
+         fetch with bash test-data/scripts/fetch-datasets.sh"
+    );
+    eprintln!("parity test skipped (fixture absent): {e}");
+}
+
+/// Real presence/content assertion (issue #1230) replacing the thin
+/// `partition_count > 0`. Requires the JSONL golden to be present and non-empty
+/// and the parser to cover at least every reference partition (wide-partition
+/// tables expand to >= reference rows), so a dropped or truncated table FAILS
+/// rather than passing on a single stray partition.
+fn assert_parity_content(r: &ParityResult) {
+    assert!(
+        r.reference_count > 0,
+        "JSONL golden is absent or empty (0 reference partitions)"
+    );
+    assert!(
+        r.partition_count >= r.reference_count,
+        "parsed {} partitions < {} reference partitions — table dropped or truncated?",
+        r.partition_count,
+        r.reference_count
+    );
+}
+
 // ============================================================================
 // test_basic Keyspace Tests
 // ============================================================================
 
 #[tokio::test]
 async fn test_simple_table_key_parsing_parity() {
-    if !test_data_available() {
-        eprintln!("Skipping test: CQLITE_DATASETS_ROOT not set");
+    if skip_when_data_unavailable() {
         return;
     }
 
@@ -563,6 +617,7 @@ async fn test_simple_table_key_parsing_parity() {
                 r.validated_cells,
                 r.total_cells
             );
+            assert_parity_content(&r);
             assert!(
                 r.partition_count >= r.reference_count * 95 / 100,
                 "Partition count too low: {} vs {} expected",
@@ -576,20 +631,13 @@ async fn test_simple_table_key_parsing_parity() {
                 key_match_rate * 100.0
             );
         }
-        Err(e) => {
-            eprintln!("Test skipped or failed: {}", e);
-            // Don't fail test if data unavailable
-            if !e.contains("not set") && !e.contains("not found") {
-                panic!("Test failed: {}", e);
-            }
-        }
+        Err(e) => handle_parity_error(&e),
     }
 }
 
 #[tokio::test]
 async fn test_composite_key_table_parsing_parity() {
-    if !test_data_available() {
-        eprintln!("Skipping test: CQLITE_DATASETS_ROOT not set");
+    if skip_when_data_unavailable() {
         return;
     }
 
@@ -601,23 +649,15 @@ async fn test_composite_key_table_parsing_parity() {
                 "composite_key_table: {} partitions, {}/{} keys matched",
                 r.partition_count, r.matched_keys, r.reference_count
             );
-            assert!(
-                r.partition_count > 0,
-                "Should have parsed at least some partitions"
-            );
+            assert_parity_content(&r);
         }
-        Err(e) => {
-            if !e.contains("not set") && !e.contains("not found") {
-                panic!("Test failed: {}", e);
-            }
-        }
+        Err(e) => handle_parity_error(&e),
     }
 }
 
 #[tokio::test]
 async fn test_static_columns_table_parsing() {
-    if !test_data_available() {
-        eprintln!("Skipping test: CQLITE_DATASETS_ROOT not set");
+    if skip_when_data_unavailable() {
         return;
     }
 
@@ -629,16 +669,9 @@ async fn test_static_columns_table_parsing() {
                 "static_columns_table: {} partitions, {}/{} keys matched",
                 r.partition_count, r.matched_keys, r.reference_count
             );
-            assert!(
-                r.partition_count > 0,
-                "Should have parsed at least some partitions"
-            );
+            assert_parity_content(&r);
         }
-        Err(e) => {
-            if !e.contains("not set") && !e.contains("not found") {
-                panic!("Test failed: {}", e);
-            }
-        }
+        Err(e) => handle_parity_error(&e),
     }
 }
 
@@ -648,8 +681,7 @@ async fn test_static_columns_table_parsing() {
 
 #[tokio::test]
 async fn test_collection_table_list_parsing() {
-    if !test_data_available() {
-        eprintln!("Skipping test: CQLITE_DATASETS_ROOT not set");
+    if skip_when_data_unavailable() {
         return;
     }
 
@@ -661,23 +693,15 @@ async fn test_collection_table_list_parsing() {
                 "collection_table: {} partitions, {}/{} cells validated",
                 r.partition_count, r.validated_cells, r.total_cells
             );
-            assert!(
-                r.partition_count > 0,
-                "Should have parsed at least some partitions"
-            );
+            assert_parity_content(&r);
         }
-        Err(e) => {
-            if !e.contains("not set") && !e.contains("not found") {
-                panic!("Test failed: {}", e);
-            }
-        }
+        Err(e) => handle_parity_error(&e),
     }
 }
 
 #[tokio::test]
 async fn test_collection_table_map_parsing() {
-    if !test_data_available() {
-        eprintln!("Skipping test: CQLITE_DATASETS_ROOT not set");
+    if skip_when_data_unavailable() {
         return;
     }
 
@@ -694,6 +718,7 @@ async fn test_collection_table_map_parsing() {
             // due to the double length-prefix bug and the set path-elements bug.
             // This assertion pins the fix: if either regression is reintroduced, the
             // test will catch it.
+            assert_parity_content(&r);
             assert!(
                 r.partition_count >= 50,
                 "typed_collections_table should have at least 50 partitions (got {}). \
@@ -701,18 +726,13 @@ async fn test_collection_table_map_parsing() {
                 r.partition_count
             );
         }
-        Err(e) => {
-            if !e.contains("not set") && !e.contains("not found") {
-                panic!("Test failed: {}", e);
-            }
-        }
+        Err(e) => handle_parity_error(&e),
     }
 }
 
 #[tokio::test]
 async fn test_nested_collections_parsing() {
-    if !test_data_available() {
-        eprintln!("Skipping test: CQLITE_DATASETS_ROOT not set");
+    if skip_when_data_unavailable() {
         return;
     }
 
@@ -724,23 +744,15 @@ async fn test_nested_collections_parsing() {
                 "nested_collections_table: {} partitions, {}/{} cells validated",
                 r.partition_count, r.validated_cells, r.total_cells
             );
-            assert!(
-                r.partition_count > 0,
-                "Should have parsed at least some partitions"
-            );
+            assert_parity_content(&r);
         }
-        Err(e) => {
-            if !e.contains("not set") && !e.contains("not found") {
-                panic!("Test failed: {}", e);
-            }
-        }
+        Err(e) => handle_parity_error(&e),
     }
 }
 
 #[tokio::test]
 async fn test_collections_with_udts_parsing() {
-    if !test_data_available() {
-        eprintln!("Skipping test: CQLITE_DATASETS_ROOT not set");
+    if skip_when_data_unavailable() {
         return;
     }
 
@@ -752,16 +764,9 @@ async fn test_collections_with_udts_parsing() {
                 "collections_with_udts: {} partitions, {}/{} cells validated",
                 r.partition_count, r.validated_cells, r.total_cells
             );
-            assert!(
-                r.partition_count > 0,
-                "Should have parsed at least some partitions"
-            );
+            assert_parity_content(&r);
         }
-        Err(e) => {
-            if !e.contains("not set") && !e.contains("not found") {
-                panic!("Test failed: {}", e);
-            }
-        }
+        Err(e) => handle_parity_error(&e),
     }
 }
 
@@ -771,8 +776,7 @@ async fn test_collections_with_udts_parsing() {
 
 #[tokio::test]
 async fn test_sensor_data_clustering_key_parsing() {
-    if !test_data_available() {
-        eprintln!("Skipping test: CQLITE_DATASETS_ROOT not set");
+    if skip_when_data_unavailable() {
         return;
     }
 
@@ -784,23 +788,15 @@ async fn test_sensor_data_clustering_key_parsing() {
                 "sensor_data: {} partitions, {}/{} keys matched",
                 r.partition_count, r.matched_keys, r.reference_count
             );
-            assert!(
-                r.partition_count > 0,
-                "Should have parsed at least some partitions"
-            );
+            assert_parity_content(&r);
         }
-        Err(e) => {
-            if !e.contains("not set") && !e.contains("not found") {
-                panic!("Test failed: {}", e);
-            }
-        }
+        Err(e) => handle_parity_error(&e),
     }
 }
 
 #[tokio::test]
 async fn test_stock_prices_bti_format() {
-    if !test_data_available() {
-        eprintln!("Skipping test: CQLITE_DATASETS_ROOT not set");
+    if skip_when_data_unavailable() {
         return;
     }
 
@@ -812,16 +808,9 @@ async fn test_stock_prices_bti_format() {
                 "stock_prices: {} partitions, {}/{} keys matched",
                 r.partition_count, r.matched_keys, r.reference_count
             );
-            assert!(
-                r.partition_count > 0,
-                "Should have parsed at least some partitions"
-            );
+            assert_parity_content(&r);
         }
-        Err(e) => {
-            if !e.contains("not set") && !e.contains("not found") {
-                panic!("Test failed: {}", e);
-            }
-        }
+        Err(e) => handle_parity_error(&e),
     }
 }
 
@@ -831,8 +820,7 @@ async fn test_stock_prices_bti_format() {
 
 #[tokio::test]
 async fn test_wide_partition_table_many_rows() {
-    if !test_data_available() {
-        eprintln!("Skipping test: CQLITE_DATASETS_ROOT not set");
+    if skip_when_data_unavailable() {
         return;
     }
 
@@ -844,23 +832,15 @@ async fn test_wide_partition_table_many_rows() {
                 "wide_partition_table: {} partitions, {}/{} keys matched",
                 r.partition_count, r.matched_keys, r.reference_count
             );
-            assert!(
-                r.partition_count > 0,
-                "Should have parsed at least some partitions"
-            );
+            assert_parity_content(&r);
         }
-        Err(e) => {
-            if !e.contains("not set") && !e.contains("not found") {
-                panic!("Test failed: {}", e);
-            }
-        }
+        Err(e) => handle_parity_error(&e),
     }
 }
 
 #[tokio::test]
 async fn test_chat_messages_frozen_types() {
-    if !test_data_available() {
-        eprintln!("Skipping test: CQLITE_DATASETS_ROOT not set");
+    if skip_when_data_unavailable() {
         return;
     }
 
@@ -872,23 +852,15 @@ async fn test_chat_messages_frozen_types() {
                 "chat_messages: {} partitions, {}/{} cells validated",
                 r.partition_count, r.validated_cells, r.total_cells
             );
-            assert!(
-                r.partition_count > 0,
-                "Should have parsed at least some partitions"
-            );
+            assert_parity_content(&r);
         }
-        Err(e) => {
-            if !e.contains("not set") && !e.contains("not found") {
-                panic!("Test failed: {}", e);
-            }
-        }
+        Err(e) => handle_parity_error(&e),
     }
 }
 
 #[tokio::test]
 async fn test_many_columns_table_sparse_bitmap() {
-    if !test_data_available() {
-        eprintln!("Skipping test: CQLITE_DATASETS_ROOT not set");
+    if skip_when_data_unavailable() {
         return;
     }
 
@@ -900,16 +872,9 @@ async fn test_many_columns_table_sparse_bitmap() {
                 "many_columns_table: {} partitions, {}/{} keys matched",
                 r.partition_count, r.matched_keys, r.reference_count
             );
-            assert!(
-                r.partition_count > 0,
-                "Should have parsed at least some partitions"
-            );
+            assert_parity_content(&r);
         }
-        Err(e) => {
-            if !e.contains("not set") && !e.contains("not found") {
-                panic!("Test failed: {}", e);
-            }
-        }
+        Err(e) => handle_parity_error(&e),
     }
 }
 
@@ -919,8 +884,7 @@ async fn test_many_columns_table_sparse_bitmap() {
 
 #[tokio::test]
 async fn test_all_tables_basic_parity() {
-    if !test_data_available() {
-        eprintln!("Skipping test: CQLITE_DATASETS_ROOT not set");
+    if skip_when_data_unavailable() {
         return;
     }
 
@@ -935,28 +899,24 @@ async fn test_all_tables_basic_parity() {
     ];
 
     let mut passed = 0;
-    let mut failed = 0;
 
     for (keyspace, table) in &test_cases {
         match run_parity_test(keyspace, table).await {
             Ok(r) => {
-                if r.partition_count > 0 {
-                    println!(
-                        "PASS: {}.{} ({} partitions)",
-                        keyspace, table, r.partition_count
-                    );
-                    passed += 1;
-                } else {
-                    println!("FAIL: {}.{} (0 partitions)", keyspace, table);
-                    failed += 1;
-                }
+                // Fail-closed (issue #1230): real content/presence assertion, not
+                // the old `if partition_count > 0 { pass } else { fail }`.
+                assert_parity_content(&r);
+                println!(
+                    "PASS: {}.{} ({} partitions)",
+                    keyspace, table, r.partition_count
+                );
+                passed += 1;
             }
-            Err(e) => {
-                println!("SKIP: {}.{}: {}", keyspace, table, e);
-            }
+            // A genuine parse error always panics; a missing fixture panics under
+            // strict mode and only skips in non-strict local-dev mode.
+            Err(e) => handle_parity_error(&e),
         }
     }
 
-    println!("\nSummary: {} passed, {} failed", passed, failed);
-    assert!(failed == 0, "{} tests failed", failed);
+    println!("\nSummary: {} passed (of {})", passed, test_cases.len());
 }

--- a/cqlite-core/tests/sstable_parity_integration_test.rs
+++ b/cqlite-core/tests/sstable_parity_integration_test.rs
@@ -591,12 +591,7 @@ const DEFAULT_PARITY_MIN_PERCENT: u64 = 95;
 /// Ratio-based presence/content assertion (issue #1230). Requires the JSONL
 /// golden to be present and non-empty and the parser to cover at least
 /// `min_percent`% of the reference partitions. The tolerance is an explicit
-/// parameter and is the single source of truth for the RATIO threshold. A call
-/// site MAY additionally pin a separate ABSOLUTE partition-count floor (a
-/// regression pin distinct from this ratio check — e.g.
-/// `test_collection_table_map_parsing`'s `>= 50`); that is permitted because it
-/// is not a second, conflicting expression of the same ratio. What is forbidden
-/// is restating the ratio as a different percentage.
+/// parameter and is the single source of truth for the RATIO threshold.
 ///
 /// This helper is used ONLY at the call site that had a 95% tolerance BEFORE
 /// #1230 (`test_simple_table_key_parsing_parity`). #1230 preserves that 95%
@@ -753,12 +748,16 @@ async fn test_collection_table_map_parsing() {
                 "typed_collections_table: {} partitions, {}/{} cells validated",
                 r.partition_count, r.validated_cells, r.total_cells
             );
+            // Fail-closed-on-empty guard: the JSONL golden must be present and
+            // non-empty (a missing/empty fixture fails rather than silently
+            // passing). This site's pre-#1230 baseline was the lenient
+            // `partition_count > 0`, so it uses assert_parity_present (not the
+            // 95% ratio helper, which is reserved for simple_table).
+            assert_parity_present(&r);
             // Issue #481 fix: typed_collections_table has 50 partitions.
             // Before the fix, the V5CompressedLegacy reader returned only 1 partition
             // due to the double length-prefix bug and the set path-elements bug.
-            // This assertion pins the fix: if either regression is reintroduced, the
-            // test will catch it.
-            assert_parity_content(&r, DEFAULT_PARITY_MIN_PERCENT);
+            // This absolute regression pin catches reintroduction of either bug.
             assert!(
                 r.partition_count >= 50,
                 "typed_collections_table should have at least 50 partitions (got {}). \

--- a/cqlite-core/tests/sstable_parity_integration_test.rs
+++ b/cqlite-core/tests/sstable_parity_integration_test.rs
@@ -563,6 +563,9 @@ fn skip_when_data_unavailable() -> bool {
 /// non-strict local-dev mode. The previous code unconditionally swallowed
 /// "not set"/"not found", which let a dropped table or a #773-class path
 /// regression pass green.
+// TODO(#1230 follow-up): classify via a typed DatasetError variant, not substring
+// match — a genuine error whose message happens to contain "not found" etc. is
+// currently misclassified as a missing fixture. Pre-existing pattern.
 fn handle_parity_error(e: &str) {
     let missing_fixture = e.contains("not set")
         || e.contains("not found")
@@ -577,20 +580,35 @@ fn handle_parity_error(e: &str) {
     eprintln!("parity test skipped (fixture absent): {e}");
 }
 
+/// Established lenient parity tolerance (95%): parsed partitions must reach at
+/// least 95% of the reference partition count. This is the long-standing
+/// threshold `test_simple_table_key_parsing_parity` used BEFORE #1230 (integer
+/// math `reference_count * 95 / 100`). #1230 only adds the fail-closed-on-empty
+/// guard; it deliberately does NOT tighten the ratio to 100%, so a real table
+/// that legitimately parses to 95–99% of reference partitions stays green.
+const DEFAULT_PARITY_MIN_PERCENT: u64 = 95;
+
 /// Real presence/content assertion (issue #1230) replacing the thin
 /// `partition_count > 0`. Requires the JSONL golden to be present and non-empty
-/// and the parser to cover at least every reference partition (wide-partition
-/// tables expand to >= reference rows), so a dropped or truncated table FAILS
-/// rather than passing on a single stray partition.
-fn assert_parity_content(r: &ParityResult) {
+/// and the parser to cover at least `min_percent`% of the reference partitions,
+/// so a dropped or truncated table FAILS rather than passing on a single stray
+/// partition. The tolerance is an explicit parameter (call sites pass
+/// [`DEFAULT_PARITY_MIN_PERCENT`]) and is the SINGLE source of truth for the
+/// pass/fail threshold — call sites must not stack a second, conflicting
+/// partition-count check. #1230 only adds the fail-closed-on-empty guard; it
+/// deliberately does NOT tighten the established lenient ratio to 100%.
+fn assert_parity_content(r: &ParityResult, min_percent: u64) {
     assert!(
         r.reference_count > 0,
         "JSONL golden is absent or empty (0 reference partitions)"
     );
+    let min_partitions = r.reference_count as u64 * min_percent / 100;
     assert!(
-        r.partition_count >= r.reference_count,
-        "parsed {} partitions < {} reference partitions — table dropped or truncated?",
+        r.partition_count as u64 >= min_partitions,
+        "parsed {} partitions < {} required ({}% of {} reference) — table dropped or truncated?",
         r.partition_count,
+        min_partitions,
+        min_percent,
         r.reference_count
     );
 }
@@ -617,13 +635,10 @@ async fn test_simple_table_key_parsing_parity() {
                 r.validated_cells,
                 r.total_cells
             );
-            assert_parity_content(&r);
-            assert!(
-                r.partition_count >= r.reference_count * 95 / 100,
-                "Partition count too low: {} vs {} expected",
-                r.partition_count,
-                r.reference_count
-            );
+            // Single coherent threshold: the 95% tolerance lives in
+            // assert_parity_content (DEFAULT_PARITY_MIN_PERCENT). No second
+            // stacked partition-count assertion (would be dead/conflicting).
+            assert_parity_content(&r, DEFAULT_PARITY_MIN_PERCENT);
             let key_match_rate = r.matched_keys as f64 / r.partition_count.max(1) as f64;
             assert!(
                 key_match_rate >= 0.95,
@@ -649,7 +664,7 @@ async fn test_composite_key_table_parsing_parity() {
                 "composite_key_table: {} partitions, {}/{} keys matched",
                 r.partition_count, r.matched_keys, r.reference_count
             );
-            assert_parity_content(&r);
+            assert_parity_content(&r, DEFAULT_PARITY_MIN_PERCENT);
         }
         Err(e) => handle_parity_error(&e),
     }
@@ -669,7 +684,7 @@ async fn test_static_columns_table_parsing() {
                 "static_columns_table: {} partitions, {}/{} keys matched",
                 r.partition_count, r.matched_keys, r.reference_count
             );
-            assert_parity_content(&r);
+            assert_parity_content(&r, DEFAULT_PARITY_MIN_PERCENT);
         }
         Err(e) => handle_parity_error(&e),
     }
@@ -693,7 +708,7 @@ async fn test_collection_table_list_parsing() {
                 "collection_table: {} partitions, {}/{} cells validated",
                 r.partition_count, r.validated_cells, r.total_cells
             );
-            assert_parity_content(&r);
+            assert_parity_content(&r, DEFAULT_PARITY_MIN_PERCENT);
         }
         Err(e) => handle_parity_error(&e),
     }
@@ -718,7 +733,7 @@ async fn test_collection_table_map_parsing() {
             // due to the double length-prefix bug and the set path-elements bug.
             // This assertion pins the fix: if either regression is reintroduced, the
             // test will catch it.
-            assert_parity_content(&r);
+            assert_parity_content(&r, DEFAULT_PARITY_MIN_PERCENT);
             assert!(
                 r.partition_count >= 50,
                 "typed_collections_table should have at least 50 partitions (got {}). \
@@ -744,7 +759,7 @@ async fn test_nested_collections_parsing() {
                 "nested_collections_table: {} partitions, {}/{} cells validated",
                 r.partition_count, r.validated_cells, r.total_cells
             );
-            assert_parity_content(&r);
+            assert_parity_content(&r, DEFAULT_PARITY_MIN_PERCENT);
         }
         Err(e) => handle_parity_error(&e),
     }
@@ -764,7 +779,7 @@ async fn test_collections_with_udts_parsing() {
                 "collections_with_udts: {} partitions, {}/{} cells validated",
                 r.partition_count, r.validated_cells, r.total_cells
             );
-            assert_parity_content(&r);
+            assert_parity_content(&r, DEFAULT_PARITY_MIN_PERCENT);
         }
         Err(e) => handle_parity_error(&e),
     }
@@ -788,7 +803,7 @@ async fn test_sensor_data_clustering_key_parsing() {
                 "sensor_data: {} partitions, {}/{} keys matched",
                 r.partition_count, r.matched_keys, r.reference_count
             );
-            assert_parity_content(&r);
+            assert_parity_content(&r, DEFAULT_PARITY_MIN_PERCENT);
         }
         Err(e) => handle_parity_error(&e),
     }
@@ -808,7 +823,7 @@ async fn test_stock_prices_bti_format() {
                 "stock_prices: {} partitions, {}/{} keys matched",
                 r.partition_count, r.matched_keys, r.reference_count
             );
-            assert_parity_content(&r);
+            assert_parity_content(&r, DEFAULT_PARITY_MIN_PERCENT);
         }
         Err(e) => handle_parity_error(&e),
     }
@@ -832,7 +847,7 @@ async fn test_wide_partition_table_many_rows() {
                 "wide_partition_table: {} partitions, {}/{} keys matched",
                 r.partition_count, r.matched_keys, r.reference_count
             );
-            assert_parity_content(&r);
+            assert_parity_content(&r, DEFAULT_PARITY_MIN_PERCENT);
         }
         Err(e) => handle_parity_error(&e),
     }
@@ -852,7 +867,7 @@ async fn test_chat_messages_frozen_types() {
                 "chat_messages: {} partitions, {}/{} cells validated",
                 r.partition_count, r.validated_cells, r.total_cells
             );
-            assert_parity_content(&r);
+            assert_parity_content(&r, DEFAULT_PARITY_MIN_PERCENT);
         }
         Err(e) => handle_parity_error(&e),
     }
@@ -872,7 +887,7 @@ async fn test_many_columns_table_sparse_bitmap() {
                 "many_columns_table: {} partitions, {}/{} keys matched",
                 r.partition_count, r.matched_keys, r.reference_count
             );
-            assert_parity_content(&r);
+            assert_parity_content(&r, DEFAULT_PARITY_MIN_PERCENT);
         }
         Err(e) => handle_parity_error(&e),
     }
@@ -905,7 +920,7 @@ async fn test_all_tables_basic_parity() {
             Ok(r) => {
                 // Fail-closed (issue #1230): real content/presence assertion, not
                 // the old `if partition_count > 0 { pass } else { fail }`.
-                assert_parity_content(&r);
+                assert_parity_content(&r, DEFAULT_PARITY_MIN_PERCENT);
                 println!(
                     "PASS: {}.{} ({} partitions)",
                     keyspace, table, r.partition_count

--- a/test-data/scripts/check-dataset-manifest.sh
+++ b/test-data/scripts/check-dataset-manifest.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# check-dataset-manifest.sh (issue #1230)
+#
+# Fail-closed CI sanity check: assert that the fetched dataset asset contains a
+# Data.db for EVERY expected (keyspace, table) in the 33-table validation corpus,
+# not just test_basic/simple_table. A partial extraction or a dropped table reds
+# CI here instead of silently turning the dataset-dependent test lanes green by
+# letting them skip on absence.
+#
+# Usage: check-dataset-manifest.sh [DATASETS_ROOT]
+#   DATASETS_ROOT defaults to test-data/datasets (the parent of sstables/).
+#
+set -euo pipefail
+
+ROOT="${1:-test-data/datasets}"
+SSTABLES="${ROOT}/sstables"
+
+# Expected user-keyspace tables (33 total). Keep in sync with the validation
+# matrix (test-data/validation-matrix.md) and the test_basic manifest in
+# cqlite-core/tests/reader_compression_tests.rs.
+EXPECTED=(
+  # test_basic (8)
+  "test_basic/composite_key_table"
+  "test_basic/compression_test_table"
+  "test_basic/counters"
+  "test_basic/multi_partition_table"
+  "test_basic/simple_table"
+  "test_basic/static_columns_table"
+  "test_basic/ttl_test_table"
+  "test_basic/uncompressed_table"
+  # test_collections (8)
+  "test_collections/collection_clustering_table"
+  "test_collections/collection_table"
+  "test_collections/collections_with_udts"
+  "test_collections/empty_collections_table"
+  "test_collections/frozen_collections_table"
+  "test_collections/large_collections_table"
+  "test_collections/nested_collections_table"
+  "test_collections/typed_collections_table"
+  # test_timeseries (9)
+  "test_timeseries/app_metrics"
+  "test_timeseries/event_store"
+  "test_timeseries/log_entries"
+  "test_timeseries/sensor_data"
+  "test_timeseries/stock_prices"
+  "test_timeseries/tick_data"
+  "test_timeseries/time_bucketed_counters"
+  "test_timeseries/user_activity"
+  "test_timeseries/user_sessions"
+  # test_wide_rows (8)
+  "test_wide_rows/chat_messages"
+  "test_wide_rows/document_versions"
+  "test_wide_rows/large_blob_table"
+  "test_wide_rows/many_columns_table"
+  "test_wide_rows/multi_metric_timeseries"
+  "test_wide_rows/product_catalog"
+  "test_wide_rows/sparse_data_table"
+  "test_wide_rows/wide_partition_table"
+)
+
+if [ ! -d "$SSTABLES" ]; then
+  echo "❌ dataset manifest check: sstables dir missing: $SSTABLES" >&2
+  exit 1
+fi
+
+missing=0
+found=0
+for entry in "${EXPECTED[@]}"; do
+  table="${entry#*/}"
+  # Match <table>-<uuid>/<prefix>-Data.db; -path keeps us pipefail-safe.
+  data_db=$(find "$SSTABLES/$(dirname "$entry")" -path "*${table}-*-Data.db" 2>/dev/null | head -1 || true)
+  if [ -z "$data_db" ]; then
+    echo "❌ missing Data.db for expected table: $entry" >&2
+    missing=$((missing + 1))
+  else
+    found=$((found + 1))
+  fi
+done
+
+echo "dataset manifest: ${found}/${#EXPECTED[@]} expected tables present"
+if [ "$missing" -ne 0 ]; then
+  echo "❌ dataset manifest check FAILED: $missing expected table(s) missing — partial extraction or dropped table?" >&2
+  exit 1
+fi
+echo "✅ dataset manifest check passed (all ${#EXPECTED[@]} expected tables present)"

--- a/test-data/scripts/check-dataset-manifest.sh
+++ b/test-data/scripts/check-dataset-manifest.sh
@@ -3,10 +3,12 @@
 # check-dataset-manifest.sh (issue #1230)
 #
 # Fail-closed CI sanity check: assert that the fetched dataset asset contains a
-# Data.db for EVERY expected (keyspace, table) in the 33-table validation corpus,
-# not just test_basic/simple_table. A partial extraction or a dropped table reds
-# CI here instead of silently turning the dataset-dependent test lanes green by
-# letting them skip on absence.
+# Data.db for EVERY expected (keyspace, table) in the 39-table enforced corpus
+# (33 nb + 6 test_oa), not just test_basic/simple_table. A partial extraction or
+# a dropped table reds CI here instead of silently turning the dataset-dependent
+# test lanes green by letting them skip on absence. The enforced corpus is
+# defined in test-data/validation-matrix.md ("Enforced Tables": 39); test_da and
+# test_deltas are skip-pending and intentionally NOT enforced here.
 #
 # Usage: check-dataset-manifest.sh [DATASETS_ROOT]
 #   DATASETS_ROOT defaults to test-data/datasets (the parent of sstables/).
@@ -16,11 +18,11 @@ set -euo pipefail
 ROOT="${1:-test-data/datasets}"
 SSTABLES="${ROOT}/sstables"
 
-# Expected user-keyspace tables (33 total).
+# Expected user-keyspace tables (39 total: 33 nb + 6 test_oa).
 #
 # SINGLE SOURCE OF TRUTH (intent): this list is hand-duplicated from the corpus
-# definition. Keep it in sync with test-data/validation-matrix.md and the
-# 8-table EXPECTED_TEST_BASIC_TABLES const in
+# definition. Keep it in sync with test-data/validation-matrix.md ("Enforced
+# Tables": 39) and the 8-table EXPECTED_TEST_BASIC_TABLES const in
 # cqlite-core/tests/reader_compression_tests.rs. A future change should derive
 # all of these from metadata.yml / validation-matrix.md so a table add/rename
 # updates every copy at once.
@@ -62,6 +64,13 @@ EXPECTED=(
   "test_wide_rows/product_catalog"
   "test_wide_rows/sparse_data_table"
   "test_wide_rows/wide_partition_table"
+  # test_oa (6) — the OA-format keyspace enforced by validation-matrix.md
+  "test_oa/collection_table"
+  "test_oa/simple_table"
+  "test_oa/static_table"
+  "test_oa/tombstone_table"
+  "test_oa/ttl_table"
+  "test_oa/udt_table"
 )
 
 if [ ! -d "$SSTABLES" ]; then

--- a/test-data/scripts/check-dataset-manifest.sh
+++ b/test-data/scripts/check-dataset-manifest.sh
@@ -16,9 +16,14 @@ set -euo pipefail
 ROOT="${1:-test-data/datasets}"
 SSTABLES="${ROOT}/sstables"
 
-# Expected user-keyspace tables (33 total). Keep in sync with the validation
-# matrix (test-data/validation-matrix.md) and the test_basic manifest in
-# cqlite-core/tests/reader_compression_tests.rs.
+# Expected user-keyspace tables (33 total).
+#
+# SINGLE SOURCE OF TRUTH (intent): this list is hand-duplicated from the corpus
+# definition. Keep it in sync with test-data/validation-matrix.md and the
+# 8-table EXPECTED_TEST_BASIC_TABLES const in
+# cqlite-core/tests/reader_compression_tests.rs. A future change should derive
+# all of these from metadata.yml / validation-matrix.md so a table add/rename
+# updates every copy at once.
 EXPECTED=(
   # test_basic (8)
   "test_basic/composite_key_table"


### PR DESCRIPTION
Closes #1230. Child of epic #1227 (coverage-integrity). Oracle/infra hardening.

## Problem
~70 legacy dataset-dependent tests skip-and-pass silently on missing data, and `ci.yml`/`python-ci.yml`/`node-ci.yml` ran them without a strict flag (sanity-checking only `test_basic/simple_table`). A dropped table or #773-class path regression turned them GREEN instead of red.

## Changes (all 4 acceptance criteria)
1. **CI lanes fail-closed** — `CQLITE_REQUIRE_FIXTURES=1` (+ `CQLITE_PARITY_REQUIRE_DATASETS=1` on Rust lanes) on the dataset-dependent steps of all three workflows.
2. **"No tests ran" floor** — Python `conftest.py` now `pytest.fail()`s under strict instead of skipping, plus a session-finish hook that fails the run if 0 tests passed under strict. Rust floor = strict env (absent fixture panics).
3. **Strengthened the two mislabeled "parity" tests** — `sstable_parity_integration_test.rs` and `reader_compression_tests.rs`: stop double-skipping / swallowing "not found", replace `count > 0` with content/presence assertions, fail-closed under the strict flag.
4. **Broadened CI sanity check** — new `test-data/scripts/check-dataset-manifest.sh` asserts a Data.db for all 33 corpus tables, wired into the sanity step of all three workflows.

One shared `require_fixtures_strict()` helper (no parallel mechanism), honoring both env vars.

## Fail-closed proof (strict flag + fixture absent → FAIL, not skip)
- `reader_compression_tests`: FAILED — panic `CQLITE_REQUIRE_FIXTURES=1 but test_basic keyspace is absent`.
- `sstable_parity_integration_test`: 13 FAILED — `CQLITE_REQUIRE_FIXTURES=1 but fixture missing`.
- Counter-proofs: strict+present → pass; no-flag+absent → still skips (local dev preserved); manifest checker exits 1 on 1/33, 0 on 33/33.

## Gate
`scripts/agent-gate.sh` → **RESULT: PASS** (all 15 components). No file-growth override.

## Discovered (filed separately)
- `agent-gate.sh` smoke step hardcodes `$PWD/target/debug/cqlite`, incompatible with a shared `CARGO_TARGET_DIR` from a worktree.

🤖 worker: oracle/infra, 1:1:1:1. Conflict in ci.yml with main's f75b1e61 resolved (kept both the golden-present echo and the manifest check).