### PR TITLE
fix(#1239): render frozen<UDT> serialization header as FrozenType(UserType(...))

### DIFF
--- a/cqlite-core/src/storage/sstable/writer/data_writer/schema_helpers.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/schema_helpers.rs
@@ -305,6 +305,44 @@ pub(crate) fn normalize_schema_udts(schema: &mut TableSchema, registry: &UdtRegi
     }
 }
 
+/// If `data_type` is a TOP-LEVEL `frozen<...>` wrapper (case-insensitive
+/// keyword), return the trimmed inner type string; otherwise `None`. The whole
+/// string must be the wrapper (the matching `>` is the final char) so a type
+/// like `map<frozen<x>, int>` is NOT mistaken for a top-level frozen.
+fn strip_top_level_frozen(data_type: &str) -> Option<&str> {
+    let lower = data_type.to_lowercase();
+    let rest = lower.strip_prefix("frozen<")?;
+    // The closing '>' that matches this leading 'frozen<' must be the LAST char.
+    if !rest.ends_with('>') {
+        return None;
+    }
+    let mut depth = 1usize;
+    for (i, ch) in rest.char_indices() {
+        match ch {
+            '<' => depth += 1,
+            '>' => {
+                depth -= 1;
+                if depth == 0 {
+                    // The matching close must be the final char for this to be a
+                    // single top-level `frozen<...>` wrapper.
+                    if i != rest.len() - 1 {
+                        return None;
+                    }
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+    if depth != 0 {
+        return None;
+    }
+    // Slice the ORIGINAL (case-preserving) string: skip `frozen<` (7 bytes,
+    // ASCII) and the trailing `>`.
+    let inner = &data_type[7..data_type.len() - 1];
+    Some(inner.trim())
+}
+
 /// If `data_type` is a TOP-LEVEL bare CQL UDT name that resolves in `registry`,
 /// return its rendered `UserType(...)` marshal string; otherwise `None`.
 pub(crate) fn resolve_bare_udt_marshal(
@@ -321,6 +359,22 @@ pub(crate) fn resolve_bare_udt_marshal(
     // Already a marshal string (incl. UserType / frozen marshal) — leave as-is.
     if lower.starts_with("org.apache.cassandra.db.marshal.") {
         return None;
+    }
+    // A TOP-LEVEL `frozen<UDT>` must expand the inner bare UDT name to its
+    // `UserType(...)` marshal, wrapped in `FrozenType(...)` — Cassandra's
+    // reference serialization-header form. Without this branch the `<` guard
+    // below rejected `frozen<person>`, which then fell through
+    // `cql_type_to_marshal_type("frozen<person>")` whose inner bare name hit the
+    // `BytesType` fallback, advertising `FrozenType(BytesType)` and losing the
+    // UDT (issue #1239). Scope mirrors the bare-name case: only the inner UDT's
+    // own `UserType(...)` is expanded (via `resolve_bare_udt_marshal` recursion,
+    // which applies the same fully-representable / primitive-collision guards);
+    // a non-UDT or unresolvable inner is left untouched (returns None).
+    if let Some(inner) = strip_top_level_frozen(trimmed) {
+        let inner_marshal = resolve_bare_udt_marshal(inner, keyspace, registry)?;
+        return Some(format!(
+            "org.apache.cassandra.db.marshal.FrozenType({inner_marshal})"
+        ));
     }
     // Parameterized CQL types are not bare names — leave to the existing path.
     if lower.contains('<') {

--- a/cqlite-core/src/storage/sstable/writer/data_writer/tests/scenarios_6.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/tests/scenarios_6.rs
@@ -1184,10 +1184,20 @@ fn resolve_bare_udt_marshal_scope() {
     assert!(resolve_bare_udt_marshal("unknown", "test_ks", &reg).is_none());
     assert!(resolve_bare_udt_marshal("person", "other_ks", &reg).is_none());
 
-    // Primitives and parameterized types are not bare UDT names.
+    // Primitives and non-frozen parameterized types are not bare UDT names.
     assert!(resolve_bare_udt_marshal("text", "test_ks", &reg).is_none());
     assert!(resolve_bare_udt_marshal("list<person>", "test_ks", &reg).is_none());
-    assert!(resolve_bare_udt_marshal("frozen<person>", "test_ks", &reg).is_none());
+    // A top-level `frozen<UDT>` IS expanded to FrozenType(UserType(...)) (#1239).
+    assert_eq!(
+        resolve_bare_udt_marshal("frozen<person>", "test_ks", &reg).as_deref(),
+        Some(
+            format!(
+                "org.apache.cassandra.db.marshal.FrozenType({})",
+                person_udt_marshal()
+            )
+            .as_str()
+        )
+    );
 
     // An already-marshalled type is left untouched.
     assert!(resolve_bare_udt_marshal(&person_udt_marshal(), "test_ks", &reg).is_none());
@@ -1267,6 +1277,82 @@ fn resolve_bare_udt_marshal_scope() {
     assert!(
         resolve_bare_udt_marshal("text", "test_ks", &shadow).is_none(),
         "primitive keyword must never resolve to a UDT marshal"
+    );
+}
+
+/// Issue #1239: a TOP-LEVEL `frozen<UDT>` column's serialization-header marshal
+/// type must render as `FrozenType(UserType(...))` — Cassandra's reference form
+/// — NOT `FrozenType(BytesType)` (which loses the inner UDT). Before the fix,
+/// `resolve_bare_udt_marshal` rejected anything containing `<`, so `frozen<UDT>`
+/// fell through to `cql_type_to_marshal_type("frozen<person>")`, whose inner
+/// bare name `person` then hit the `_ => BytesType` arm.
+///
+/// This asserts the exact byte string Apache Cassandra 5.0 wrote into the
+/// committed reference fixture
+/// `test_compactionparityudt/udt_frozen_person-…/nb-3-big-Statistics.db`
+/// (RegularColumns `p`):
+///   FrozenType(UserType(test_compactionparityudt,706572736f6e,
+///     66697273745f6e616d65:UTF8Type,6c6173745f6e616d65:UTF8Type,616765:Int32Type))
+/// where 706572736f6e="person", 66697273745f6e616d65="first_name",
+/// 6c6173745f6e616d65="last_name", 616765="age".
+#[test]
+fn frozen_udt_column_renders_frozentype_usertype_cassandra_parity() {
+    // The `person` UDT exactly as defined for the committed Cassandra fixture.
+    let mut reg = UdtRegistry::new();
+    reg.register_udt(
+        UdtTypeDef::new("test_compactionparityudt".to_string(), "person".to_string())
+            .with_field("first_name".to_string(), CqlType::Text, true)
+            .with_field("last_name".to_string(), CqlType::Text, true)
+            .with_field("age".to_string(), CqlType::Int, true),
+    );
+
+    // The exact marshal string Cassandra 5.0 wrote for the `frozen<person>`
+    // regular column `p` (nb-3-big-Statistics.db, verified via sstabledump).
+    let cassandra_reference = "org.apache.cassandra.db.marshal.FrozenType(\
+org.apache.cassandra.db.marshal.UserType(test_compactionparityudt,706572736f6e,\
+66697273745f6e616d65:org.apache.cassandra.db.marshal.UTF8Type,\
+6c6173745f6e616d65:org.apache.cassandra.db.marshal.UTF8Type,\
+616765:org.apache.cassandra.db.marshal.Int32Type))";
+
+    let rendered = resolve_bare_udt_marshal("frozen<person>", "test_compactionparityudt", &reg)
+        .expect("frozen<person> must resolve to a FrozenType(UserType(...)) marshal");
+
+    assert_eq!(
+        rendered, cassandra_reference,
+        "frozen<UDT> header marshal must match Cassandra's FrozenType(UserType(...)) byte-for-byte"
+    );
+    assert!(
+        !rendered.contains("BytesType"),
+        "frozen<UDT> must NOT degrade the inner UDT to BytesType, got: {rendered}"
+    );
+
+    // Case-insensitivity of the `frozen` keyword and the bare UDT name.
+    assert_eq!(
+        resolve_bare_udt_marshal("FROZEN<Person>", "test_compactionparityudt", &reg).as_deref(),
+        Some(cassandra_reference)
+    );
+
+    // End-to-end: a schema column declared `frozen<person>` normalizes to the
+    // FrozenType(UserType(...)) marshal. A frozen UDT is a single-cell frozen
+    // type, so it is NOT a complex column (matches is_complex_column).
+    let mut schema = TableSchema {
+        keyspace: "test_compactionparityudt".to_string(),
+        table: "udt_frozen_person".to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![udt_column("p", "frozen<person>")],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    };
+    normalize_schema_udts(&mut schema, &reg);
+    assert_eq!(schema.columns[0].data_type, cassandra_reference);
+    assert!(
+        !is_complex_column(&schema.columns[0].data_type),
+        "a frozen UDT is a single-cell frozen type, not a complex column"
     );
 }
 


### PR DESCRIPTION
## Summary
Fixes #1239 — the writer rendered a top-level `frozen<UDT>` column's serialization-header marshal type as `FrozenType(BytesType)`, losing the inner `UserType(...)` and diverging byte-for-byte from Cassandra's Statistics.db / serialization header. (Not data loss — value bytes were intact; decode is schema+registry driven.)

### Root cause
`resolve_bare_udt_marshal` (`schema_helpers.rs`, used by both the direct-write `normalize_schema_udts` and the compaction header path) expanded only a **bare** top-level UDT name. An early `if lower.contains('<') { return None; }` guard rejected `frozen<person>` outright, so it fell through `cql_type_to_marshal_type` → bare-name → `_ => BytesType` → `FrozenType(BytesType)`.

### Fix
Added a top-level `frozen<...>` branch (+ `strip_top_level_frozen` helper) that expands the inner UDT and wraps it in `FrozenType(...)`. The inner expansion recurses through `resolve_bare_udt_marshal`, inheriting the existing fully-representable / primitive-collision / registry-resolution guards (a non-UDT or unresolvable inner still returns `None`).
- before: `frozen<UDT>` → header `FrozenType(BytesType)`
- after: `frozen<UDT>` → header `FrozenType(UserType(...))`

### Test (oracle-driven, byte parity)
`frozen_udt_column_renders_frozentype_usertype_cassandra_parity` asserts the rendered marshal equals the **exact string Apache Cassandra 5.0 wrote** into the committed reference `test_compactionparityudt/udt_frozen_person-…/nb-3-big-Statistics.db`:
`FrozenType(UserType(test_compactionparityudt,706572736f6e,66697273745f6e616d65:UTF8Type,6c6173745f6e616d65:UTF8Type,616765:Int32Type))`. Also covers case-insensitive `FROZEN<…>` and the `normalize_schema_udts` schema path. RED→GREEN confirmed; no new fixture commissioning needed.

### Validation
- `scripts/agent-gate.sh`: **RESULT: PASS** (all components).
- roborev (codex, branch): **No issues found.**
- Cassandra 5.0 only (committed reference is `nb-…` BIG, C5).

Closes #1239.

🤖 flow-lead worker
