### PR TITLE
feat(#1021): preserve repaired metadata through compaction (Cassandra 5.0)

### DIFF
--- a/.github/workflows/tombstone-ttl-parity.yml
+++ b/.github/workflows/tombstone-ttl-parity.yml
@@ -125,4 +125,6 @@ jobs:
               --test issue_1014_resurrection_safety_parity \
               --test issue_1015_dropped_static_parity \
               --test issue_1019_static_dropped_collection_compaction_parity \
+              --test issue_1021_repaired_metadata_compaction_parity \
+              --test sstable_parity_repaired_metadata_test \
               -- --nocapture

--- a/cqlite-core/src/parser/mod.rs
+++ b/cqlite-core/src/parser/mod.rs
@@ -132,6 +132,7 @@ pub mod enhanced_statistics_parser;
 #[cfg(test)]
 pub mod enhanced_statistics_test;
 pub mod header;
+pub(crate) mod repair_clustering;
 pub mod repair_metadata;
 pub mod statistics;
 #[cfg(test)]

--- a/cqlite-core/src/parser/repair_clustering.rs
+++ b/cqlite-core/src/parser/repair_clustering.rs
@@ -58,9 +58,24 @@ pub(crate) enum ClusteringValueLayout {
 /// The fixed lengths come straight from each type's `valueLengthIfFixed()`
 /// override in cassandra-5.0.0 `org.apache.cassandra.db.marshal.*`. `ReversedType`
 /// delegates to its base type, and frozen-collection / tuple / UDT comparators are
-/// variable. Types that do NOT override `valueLengthIfFixed()` (e.g. `ByteType`,
-/// `ShortType`, `TimeType`, `SimpleDateType`, all string/blob/number/collection
-/// comparators) inherit `VARIABLE_LENGTH` and so are `Variable` here.
+/// variable. Types that do NOT override `valueLengthIfFixed()` (all string/blob/
+/// number/collection comparators) inherit `VARIABLE_LENGTH` and so are `Variable`
+/// here.
+///
+/// AUTHORITY NOTE — do NOT "fix" the tinyint/smallint/date/time entries to fixed
+/// widths. The serialization layer (`AbstractType.writeValue` / `writtenLength` /
+/// `skipValue`) branches PURELY on `valueLengthIfFixed()`, NOT on the CQL type's
+/// logical byte width. Verified against cassandra-5.0.0 (and 5.0.2) marshal source,
+/// none of `ByteType` (tinyint) / `ShortType` (smallint) — both extending
+/// `NumberType` — nor `SimpleDateType` (date) / `TimeType` (time) — both extending
+/// `TemporalType` — override `valueLengthIfFixed()`. `NumberType`/`TemporalType` do
+/// not override it either, so all four inherit `AbstractType.VARIABLE_LENGTH == -1`
+/// and are written/skipped via `writeWithVIntLength` (unsigned-VInt length prefix +
+/// bytes) — i.e. genuinely `Variable`. Classifying them as `Fixed(1/2/4/8)` would
+/// read the first VALUE byte as the VInt length and misalign the cursor before
+/// `pendingRepair`/`isTransient`. (`TimeUUIDType` is the inverse case: no direct
+/// override but its parent `AbstractTimeUUIDType.valueLengthIfFixed()` returns 16,
+/// hence `Fixed(16)`.)
 pub(crate) fn resolve_clustering_value_layout(type_name: &str) -> Option<ClusteringValueLayout> {
     // Strip a `ReversedType(...)` wrapper: it delegates valueLengthIfFixed to the
     // wrapped base type (ReversedType.valueLengthIfFixed -> baseType...).
@@ -101,6 +116,9 @@ pub(crate) fn resolve_clustering_value_layout(type_name: &str) -> Option<Cluster
             | "IntegerType"
             | "DecimalType"
             | "InetAddressType"
+            // tinyint / smallint / date / time: VARIABLE per cassandra-5.0.0 (no
+            // valueLengthIfFixed() override — see AUTHORITY NOTE above). They are
+            // vint-length-prefixed, NOT fixed 1/2/4/8.
             | "ByteType"
             | "ShortType"
             | "TimeType"
@@ -401,6 +419,77 @@ mod tests {
         bytes.extend_from_slice(&2u16.to_be_bytes()); // size 2 > 1 type
         let mut c = Buf { b: &bytes, p: 0 };
         assert!(!skip_covered_slice(&mut c, &layouts).unwrap());
+    }
+
+    /// tinyint / smallint / date / time clustering values are VARIABLE-length in
+    /// cassandra-5.0.0 (they do not override `valueLengthIfFixed()`), so each is
+    /// serialized with an unsigned-VInt length prefix even though its natural CQL
+    /// width is 1/2/4/8. These tests pin that the covered-slice skip advances by
+    /// `1 (header) + 1 (vint len) + width` per present value and lands exactly at
+    /// the byte where `pendingRepair`/`isTransient` would begin — guarding against
+    /// the misclassification that would read the first VALUE byte as a VInt length.
+    fn assert_variable_covered_skip(type_name: &str, natural_width: usize) {
+        // Confirm the authoritative classification first.
+        assert_eq!(
+            resolve_clustering_value_layout(type_name),
+            Some(ClusteringValueLayout::Variable),
+            "type {type_name} must resolve Variable (no valueLengthIfFixed override)"
+        );
+        let layouts = vec![Some(ClusteringValueLayout::Variable)];
+        let value: Vec<u8> = (0..natural_width as u8).collect();
+        let mut bytes = Vec::new();
+        // start bound: kind, size=1, header (present), vint len, value bytes.
+        bytes.push(1u8);
+        bytes.extend_from_slice(&1u16.to_be_bytes());
+        bytes.push(0x00); // value 0 present
+        bytes.push(natural_width as u8); // single-byte unsigned vint length
+        bytes.extend_from_slice(&value);
+        let start_len = bytes.len();
+        // end bound: empty.
+        bytes.push(6u8);
+        bytes.extend_from_slice(&0u16.to_be_bytes());
+        // A trailing sentinel standing in for pendingRepair's first byte: the walk
+        // must STOP before it.
+        bytes.push(0xAB);
+
+        let mut c = Buf { b: &bytes, p: 0 };
+        assert!(
+            skip_covered_slice(&mut c, &layouts).unwrap(),
+            "covered slice for {type_name} should skip cleanly"
+        );
+        // Cursor lands at the end bound's terminator, just before the sentinel.
+        assert_eq!(
+            c.p,
+            bytes.len() - 1,
+            "type {type_name}: skip must advance past kind+size+header+vint+{natural_width}B value \
+             and the empty end bound, stopping before pendingRepair"
+        );
+        // And specifically the start bound consumed kind+size+header+vint+width.
+        assert_eq!(start_len, 1 + 2 + 1 + 1 + natural_width);
+    }
+
+    #[test]
+    fn skip_slice_tinyint_clustering_advances_vint_prefixed() {
+        // ByteType (tinyint) natural width 1 — but vint-length-prefixed.
+        assert_variable_covered_skip("org.apache.cassandra.db.marshal.ByteType", 1);
+    }
+
+    #[test]
+    fn skip_slice_smallint_clustering_advances_vint_prefixed() {
+        // ShortType (smallint) natural width 2 — vint-length-prefixed.
+        assert_variable_covered_skip("org.apache.cassandra.db.marshal.ShortType", 2);
+    }
+
+    #[test]
+    fn skip_slice_date_clustering_advances_vint_prefixed() {
+        // SimpleDateType (date) natural width 4 — vint-length-prefixed.
+        assert_variable_covered_skip("org.apache.cassandra.db.marshal.SimpleDateType", 4);
+    }
+
+    #[test]
+    fn skip_slice_time_clustering_advances_vint_prefixed() {
+        // TimeType (time) natural width 8 — vint-length-prefixed.
+        assert_variable_covered_skip("org.apache.cassandra.db.marshal.TimeType", 8);
     }
 
     #[test]

--- a/cqlite-core/src/parser/repair_clustering.rs
+++ b/cqlite-core/src/parser/repair_clustering.rs
@@ -1,0 +1,420 @@
+//! Type-aware skip of the `improvedMinMax` covered-clustering `Slice` inside the
+//! `Statistics.db` STATS component (issue #1021).
+//!
+//! The `oa`/`da` STATS layout serializes, in place of the legacy min/max
+//! clustering-value lists, a `clusteringTypes` list followed by a covered
+//! `Slice` (two `ClusteringBound`s). To reach the `pendingRepair` / `isTransient`
+//! fields that follow, that `Slice` must be walked PAST.
+//!
+//! Unlike the legacy lists, the bound VALUES are NOT length-prefixed: they are
+//! raw comparator-encoded, exactly as Cassandra's
+//! `ClusteringPrefix.Serializer.serializeValuesWithoutSize` writes them (verified
+//! against cassandra-5.0.0). Each bound is:
+//!
+//! ```text
+//! [byte kind ordinal][unsigned short size][values...]
+//! ```
+//!
+//! where `values` is, per `serializeValuesWithoutSize`:
+//!   * a sequence of 32-value BATCHES; each batch starts with an unsigned-VInt
+//!     "header" carrying 2 bits per value (null / empty / present), then the raw
+//!     bytes of every non-null, non-empty value in batch order.
+//!   * each present value is written by `AbstractType.writeValue`, i.e. RAW
+//!     fixed-width bytes for a fixed-length type (`valueLengthIfFixed() >= 0`),
+//!     or `writeWithVIntLength` (unsigned-VInt length prefix + bytes) for a
+//!     variable-length type.
+//!
+//! Skipping therefore mirrors `ClusteringBoundOrBoundary.Serializer.skipValues`
+//! → `ClusteringPrefix.Serializer.skipValuesWithoutSize` → `AbstractType.skipValue`.
+//! No value bytes are interpreted; only their lengths are computed. This is the
+//! ONLY type knowledge required, so it is authoritative (no heuristics, #28): a
+//! fixed-width type contributes exactly `valueLengthIfFixed()` bytes; any other
+//! recognized type is variable (vint-length-prefixed); an UNRECOGNIZED type makes
+//! the skip impossible (we cannot know fixed-vs-variable) and the caller reports
+//! the trailing fields honestly as `Unparsed` rather than guessing.
+
+use crate::error::Result;
+
+/// How a clustering column's value is serialized inside a `ClusteringBound`,
+/// resolved authoritatively from the column's persisted `AbstractType` name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ClusteringValueLayout {
+    /// `valueLengthIfFixed() >= 0` — exactly this many raw bytes, no length
+    /// prefix (Cassandra `AbstractType.writeValue` fixed branch).
+    Fixed(usize),
+    /// Variable-length — an unsigned-VInt length prefix then that many bytes
+    /// (`writeWithVIntLength`).
+    Variable,
+}
+
+/// Resolve a clustering column's value layout from the fully-qualified Cassandra
+/// `AbstractType` name as persisted by `AbstractTypeSerializer.serialize`
+/// (`UTF8(type.toString())`).
+///
+/// Returns `None` for a type whose fixed-vs-variable nature this decoder does not
+/// model — in that case the covered `Slice` cannot be skipped safely and the
+/// caller must report the trailing repair fields as `Unparsed` (never guess).
+///
+/// The fixed lengths come straight from each type's `valueLengthIfFixed()`
+/// override in cassandra-5.0.0 `org.apache.cassandra.db.marshal.*`. `ReversedType`
+/// delegates to its base type, and frozen-collection / tuple / UDT comparators are
+/// variable. Types that do NOT override `valueLengthIfFixed()` (e.g. `ByteType`,
+/// `ShortType`, `TimeType`, `SimpleDateType`, all string/blob/number/collection
+/// comparators) inherit `VARIABLE_LENGTH` and so are `Variable` here.
+pub(crate) fn resolve_clustering_value_layout(type_name: &str) -> Option<ClusteringValueLayout> {
+    // Strip a `ReversedType(...)` wrapper: it delegates valueLengthIfFixed to the
+    // wrapped base type (ReversedType.valueLengthIfFixed -> baseType...).
+    let inner = strip_reversed(type_name);
+    // The type CONSTRUCTOR is everything before the first `(` (parametric types
+    // like `SetType(...)` carry their argument list there). Strip the package
+    // prefix off that constructor so both fully-qualified and short names resolve;
+    // a `.` inside the parenthesised argument list must not be mistaken for the
+    // constructor's own package separator.
+    let ctor = inner.split('(').next().unwrap_or(inner);
+    let simple = ctor.rsplit('.').next().unwrap_or(ctor);
+
+    // Fixed-width comparators (exact `valueLengthIfFixed()` from cassandra-5.0.0).
+    let fixed = match simple {
+        "BooleanType" => Some(1),
+        "Int32Type" | "FloatType" => Some(4),
+        "LongType" | "DoubleType" | "TimestampType" | "DateType" => Some(8),
+        "UUIDType" | "TimeUUIDType" | "LexicalUUIDType" => Some(16),
+        // EmptyType.valueLengthIfFixed() == 0: contributes no value bytes.
+        "EmptyType" => Some(0),
+        _ => None,
+    };
+    if let Some(n) = fixed {
+        return Some(ClusteringValueLayout::Fixed(n));
+    }
+
+    // Recognized variable-length comparators that may legitimately appear as (or
+    // wrap, for frozen) clustering columns — scalar variable types plus the
+    // parametric collection / tuple / UDT comparators (each serialized as a
+    // single opaque blob via `writeWithVIntLength`, so the parameterised argument
+    // list need not be modeled). Anything not enumerated is treated as UNKNOWN
+    // (None) so the walk fails honest-Unparsed rather than mis-skipping.
+    let variable = matches!(
+        simple,
+        "UTF8Type"
+            | "AsciiType"
+            | "BytesType"
+            | "IntegerType"
+            | "DecimalType"
+            | "InetAddressType"
+            | "ByteType"
+            | "ShortType"
+            | "TimeType"
+            | "SimpleDateType"
+            | "DurationType"
+            | "MapType"
+            | "SetType"
+            | "ListType"
+            | "TupleType"
+            | "UserType"
+            | "FrozenType"
+            | "CompositeType"
+            | "DynamicCompositeType"
+            | "VectorType"
+    );
+    if variable {
+        return Some(ClusteringValueLayout::Variable);
+    }
+    None
+}
+
+/// Unwrap a `ReversedType(inner)` to its inner type name; returns the input
+/// unchanged when it is not a reversed type. The `ReversedType` constructor is
+/// matched on its (package-stripped) leading name, then its single parenthesised
+/// argument is returned.
+fn strip_reversed(type_name: &str) -> &str {
+    // Leading constructor name, package-stripped.
+    let ctor_full = type_name.split('(').next().unwrap_or(type_name);
+    let ctor = ctor_full.rsplit('.').next().unwrap_or(ctor_full);
+    if ctor == "ReversedType" {
+        if let Some(open) = type_name.find('(') {
+            let body = &type_name[open + 1..];
+            return body.strip_suffix(')').unwrap_or(body);
+        }
+    }
+    type_name
+}
+
+/// A minimal cursor abstraction the skip logic reads through, so it can be shared
+/// with the STATS-component `Cursor` without coupling to it.
+pub(crate) trait ByteSkip {
+    fn read_u8(&mut self) -> Result<u8>;
+    fn read_u16(&mut self) -> Result<u16>;
+    fn read_unsigned_vint(&mut self) -> Result<u64>;
+    fn skip(&mut self, n: usize) -> Result<()>;
+}
+
+/// Skip the covered-clustering `Slice` (its two `ClusteringBound`s) given the
+/// resolved per-column value layouts, mirroring
+/// `ClusteringBoundOrBoundary.Serializer.skipValues`.
+///
+/// Returns `Ok(true)` when both bounds were fully skipped (the walk may continue
+/// to `pendingRepair` / `isTransient`), or `Ok(false)` when a bound carries more
+/// values than there are known clustering types, or any required type is unknown
+/// — in which case the caller reports the trailing fields as `Unparsed`.
+pub(crate) fn skip_covered_slice<C: ByteSkip>(
+    c: &mut C,
+    layouts: &[Option<ClusteringValueLayout>],
+) -> Result<bool> {
+    for _ in 0..2 {
+        let _kind = c.read_u8()?; // ClusteringPrefix.Kind ordinal
+        let size = c.read_u16()? as usize; // bound value count (writeShort)
+        if size == 0 {
+            continue;
+        }
+        if size > layouts.len() {
+            // The bound claims more values than the clusteringTypes list
+            // describes — we cannot know each value's length. Bail honestly.
+            return Ok(false);
+        }
+        if !skip_values_without_size(c, size, layouts)? {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+/// Mirror `ClusteringPrefix.Serializer.skipValuesWithoutSize`: 32-value header
+/// batches, each value present/empty/null per its 2-bit header slot, present
+/// non-empty values skipped per their type layout.
+fn skip_values_without_size<C: ByteSkip>(
+    c: &mut C,
+    size: usize,
+    layouts: &[Option<ClusteringValueLayout>],
+) -> Result<bool> {
+    let mut offset = 0usize;
+    while offset < size {
+        let header = c.read_unsigned_vint()?;
+        let limit = size.min(offset + 32);
+        while offset < limit {
+            // 2 bits per value at position `offset` (modulo 32 within the batch,
+            // which the shift's RH-operand modulus handles exactly as Cassandra's
+            // `makeHeader` does). Bit `2*i+1` = null, bit `2*i` = empty.
+            let shift = (offset * 2) % 64;
+            let is_null = (header >> (shift + 1)) & 1 == 1;
+            let is_empty = (header >> shift) & 1 == 1;
+            if !is_null && !is_empty {
+                match layouts[offset] {
+                    Some(ClusteringValueLayout::Fixed(n)) => c.skip(n)?,
+                    Some(ClusteringValueLayout::Variable) => {
+                        // writeWithVIntLength: unsigned-VInt length then bytes.
+                        let len = c.read_unsigned_vint()? as usize;
+                        c.skip(len)?;
+                    }
+                    None => return Ok(false), // unknown type → cannot skip safely
+                }
+            }
+            offset += 1;
+        }
+    }
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::Error;
+
+    #[test]
+    fn fixed_widths_match_cassandra() {
+        use ClusteringValueLayout::*;
+        let cases = [
+            ("org.apache.cassandra.db.marshal.Int32Type", Fixed(4)),
+            ("org.apache.cassandra.db.marshal.LongType", Fixed(8)),
+            ("org.apache.cassandra.db.marshal.TimestampType", Fixed(8)),
+            ("org.apache.cassandra.db.marshal.DateType", Fixed(8)),
+            ("org.apache.cassandra.db.marshal.DoubleType", Fixed(8)),
+            ("org.apache.cassandra.db.marshal.FloatType", Fixed(4)),
+            ("org.apache.cassandra.db.marshal.BooleanType", Fixed(1)),
+            ("org.apache.cassandra.db.marshal.UUIDType", Fixed(16)),
+            ("org.apache.cassandra.db.marshal.TimeUUIDType", Fixed(16)),
+            ("org.apache.cassandra.db.marshal.LexicalUUIDType", Fixed(16)),
+            ("org.apache.cassandra.db.marshal.EmptyType", Fixed(0)),
+        ];
+        for (name, want) in cases {
+            assert_eq!(
+                resolve_clustering_value_layout(name),
+                Some(want),
+                "type {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn variable_types_resolve_variable() {
+        for name in [
+            "org.apache.cassandra.db.marshal.UTF8Type",
+            "org.apache.cassandra.db.marshal.AsciiType",
+            "org.apache.cassandra.db.marshal.BytesType",
+            "org.apache.cassandra.db.marshal.IntegerType",
+            "org.apache.cassandra.db.marshal.DecimalType",
+            "org.apache.cassandra.db.marshal.ByteType",
+            "org.apache.cassandra.db.marshal.ShortType",
+            "org.apache.cassandra.db.marshal.SimpleDateType",
+            "org.apache.cassandra.db.marshal.TimeType",
+        ] {
+            assert_eq!(
+                resolve_clustering_value_layout(name),
+                Some(ClusteringValueLayout::Variable),
+                "type {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn reversed_delegates_to_base() {
+        assert_eq!(
+            resolve_clustering_value_layout(
+                "org.apache.cassandra.db.marshal.ReversedType(org.apache.cassandra.db.marshal.Int32Type)"
+            ),
+            Some(ClusteringValueLayout::Fixed(4))
+        );
+        assert_eq!(
+            resolve_clustering_value_layout(
+                "org.apache.cassandra.db.marshal.ReversedType(org.apache.cassandra.db.marshal.UTF8Type)"
+            ),
+            Some(ClusteringValueLayout::Variable)
+        );
+    }
+
+    #[test]
+    fn parametric_collections_are_variable() {
+        for name in [
+            "org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.UTF8Type)",
+            "org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.Int32Type)",
+            "org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type)",
+        ] {
+            assert_eq!(
+                resolve_clustering_value_layout(name),
+                Some(ClusteringValueLayout::Variable),
+                "type {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_type_is_none() {
+        assert_eq!(
+            resolve_clustering_value_layout("org.apache.cassandra.db.marshal.SomeFutureType"),
+            None
+        );
+    }
+
+    /// Tiny in-memory cursor implementing `ByteSkip` for the slice-skip tests.
+    struct Buf<'a> {
+        b: &'a [u8],
+        p: usize,
+    }
+    impl ByteSkip for Buf<'_> {
+        fn read_u8(&mut self) -> Result<u8> {
+            let v = *self
+                .b
+                .get(self.p)
+                .ok_or_else(|| Error::Corruption("eof".into()))?;
+            self.p += 1;
+            Ok(v)
+        }
+        fn read_u16(&mut self) -> Result<u16> {
+            let hi = self.read_u8()? as u16;
+            let lo = self.read_u8()? as u16;
+            Ok((hi << 8) | lo)
+        }
+        fn read_unsigned_vint(&mut self) -> Result<u64> {
+            // Single-byte vints suffice for these tests.
+            Ok(self.read_u8()? as u64)
+        }
+        fn skip(&mut self, n: usize) -> Result<()> {
+            let end = self
+                .p
+                .checked_add(n)
+                .filter(|&e| e <= self.b.len())
+                .ok_or_else(|| Error::Corruption("eof".into()))?;
+            self.p = end;
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn skip_empty_slice() {
+        // start bound kind=1 size=0, end bound kind=6 size=0.
+        let bytes = [1u8, 0, 0, 6, 0, 0];
+        let mut c = Buf { b: &bytes, p: 0 };
+        assert!(skip_covered_slice(&mut c, &[]).unwrap());
+        assert_eq!(c.p, bytes.len());
+    }
+
+    #[test]
+    fn skip_slice_with_fixed_int_values() {
+        // One Int32 clustering column. Each bound carries size=1, one present
+        // value (header 0x00 => present), 4 raw bytes.
+        let layouts = vec![Some(ClusteringValueLayout::Fixed(4))];
+        let mut bytes = Vec::new();
+        for kind in [1u8, 6u8] {
+            bytes.push(kind);
+            bytes.extend_from_slice(&1u16.to_be_bytes()); // size = 1
+            bytes.push(0x00); // header: value 0 present (not null/empty)
+            bytes.extend_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF]); // 4 raw bytes
+        }
+        let mut c = Buf { b: &bytes, p: 0 };
+        assert!(skip_covered_slice(&mut c, &layouts).unwrap());
+        assert_eq!(c.p, bytes.len());
+    }
+
+    #[test]
+    fn skip_slice_with_variable_value() {
+        // One UTF8 clustering column; one present value of length 3.
+        let layouts = vec![Some(ClusteringValueLayout::Variable)];
+        let mut bytes = Vec::new();
+        bytes.push(1); // start kind
+        bytes.extend_from_slice(&1u16.to_be_bytes()); // size = 1
+        bytes.push(0x00); // header present
+        bytes.push(3); // vint length
+        bytes.extend_from_slice(b"abc");
+        bytes.push(6); // end kind
+        bytes.extend_from_slice(&0u16.to_be_bytes()); // empty end bound
+        let mut c = Buf { b: &bytes, p: 0 };
+        assert!(skip_covered_slice(&mut c, &layouts).unwrap());
+        assert_eq!(c.p, bytes.len());
+    }
+
+    #[test]
+    fn skip_slice_unknown_type_bails_false() {
+        let layouts = vec![None];
+        let mut bytes = Vec::new();
+        bytes.push(1);
+        bytes.extend_from_slice(&1u16.to_be_bytes());
+        bytes.push(0x00);
+        // (no value bytes follow because we expect a bail before reading them)
+        let mut c = Buf { b: &bytes, p: 0 };
+        assert!(!skip_covered_slice(&mut c, &layouts).unwrap());
+    }
+
+    #[test]
+    fn skip_slice_size_exceeds_types_bails_false() {
+        let layouts = vec![Some(ClusteringValueLayout::Fixed(4))];
+        let mut bytes = Vec::new();
+        bytes.push(1);
+        bytes.extend_from_slice(&2u16.to_be_bytes()); // size 2 > 1 type
+        let mut c = Buf { b: &bytes, p: 0 };
+        assert!(!skip_covered_slice(&mut c, &layouts).unwrap());
+    }
+
+    #[test]
+    fn skip_slice_null_value_consumes_no_bytes() {
+        // size=1 but value 0 is null (header bit 1 set => 0b10 = 0x02).
+        let layouts = vec![Some(ClusteringValueLayout::Fixed(4))];
+        let mut bytes = Vec::new();
+        bytes.push(1);
+        bytes.extend_from_slice(&1u16.to_be_bytes());
+        bytes.push(0x02); // header: value 0 is null
+        bytes.push(6);
+        bytes.extend_from_slice(&0u16.to_be_bytes());
+        let mut c = Buf { b: &bytes, p: 0 };
+        assert!(skip_covered_slice(&mut c, &layouts).unwrap());
+        assert_eq!(c.p, bytes.len());
+    }
+}

--- a/cqlite-core/src/parser/repair_metadata.rs
+++ b/cqlite-core/src/parser/repair_metadata.rs
@@ -30,19 +30,32 @@
 //! storage format (nb / oa / da) without needing the serialization header.
 //!
 //! `pendingRepair` and `isTransient` sit *after* the version-gated
-//! `improvedMinMax` block (oa/da) and the variable `commitLogIntervals` set,
-//! both of which require type-aware / interval-aware skipping to traverse. The
-//! Cassandra 5.0 corpus contains **no** repaired / pending-repair / transient
-//! fixture (every fixture is the unrepaired/null/non-transient state), and this
-//! module does **not** perform that type-aware walk. It therefore reports those
-//! two fields **honestly as `Unparsed`** (an explicit "not yet decoded" state)
-//! rather than fabricating a concrete `null` / `false`, so a real SSTable that
-//! *did* carry a pending-repair UUID or transient flag is never silently
-//! misreported as absent. The strict test lane proves the *reference* state is
-//! null / false across the corpus while asserting CQLite reports those fields as
-//! `Unparsed`, rather than fabricating repaired bytes.
+//! `improvedMinMax` / `legacyMinMax` block and the variable `commitLogIntervals`
+//! set, both of which require version-gated / type-aware skipping to traverse.
+//!
+//! # Full repair-state walk (issue #1021)
+//!
+//! When the caller supplies authoritative [`VersionGates`],
+//! [`parse_repair_metadata`] now performs that version-gated forward walk and
+//! decodes `pendingRepair` (UUID) and `isTransient` **from real bytes** in
+//! addition to `repairedAt`. The walk is driven ENTIRELY by the version gates
+//! (`hasLegacyMinMax` / `hasImprovedMinMax` / `hasUIntDeletionTime` /
+//! `hasPendingRepair` / `hasIsTransient`) read from the parsed descriptor — no
+//! heuristics, no type guessing (#28). Mirrors the exact field order of
+//! cassandra-5.0.0 `StatsMetadata.StatsMetadataSerializer.serialize`, the same
+//! layout the `da` STATS writer emits (`build_stats_component_da`).
+//!
+//! When `gates` is `None` the walk past `repairedAt` is NOT attempted (the
+//! min/max block and the commit-log-interval shape are version-dependent and
+//! cannot be traversed without the descriptor), so `pendingRepair` /
+//! `isTransient` are reported honestly as [`RepairField::Unparsed`] rather than a
+//! fabricated `null` / `false` — a real SSTable that carried a pending-repair
+//! UUID or transient flag is never silently misreported as absent.
 
 use crate::error::{Error, Result};
+use crate::parser::repair_clustering::{
+    resolve_clustering_value_layout, skip_covered_slice, ByteSkip,
+};
 use crate::storage::sstable::version_gate::VersionGates;
 
 /// Cassandra `MetadataType.STATS` ordinal (MetadataType.java).
@@ -96,16 +109,22 @@ pub struct RepairMetadata {
     /// decoded null (`Decoded(None)`), or `Unparsed` when this module did not
     /// decode it from the STATS bytes.
     ///
-    /// This module does NOT currently walk this field (it sits after the
-    /// version-gated `improvedMinMax` block and the variable
-    /// `commitLogIntervals` set), so it is reported as `Unparsed` rather than a
-    /// fabricated `None`. See module docs.
+    /// Decoded from real bytes by the version-gated forward walk when
+    /// authoritative [`VersionGates`] are supplied. `hasPendingRepair` is
+    /// `>= na`, so the field is present and decoded for every Cassandra 5.0
+    /// format CQLite reads (`nb`/`oa`/`da`). `Unparsed` is reserved for "present
+    /// but not safely reachable" (an unmodeled clustering comparator) or when
+    /// `gates` is `None` (the walk past `repairedAt` is not attempted). See
+    /// module docs.
     pub pending_repair: RepairField<Option<[u8; 16]>>,
 
     /// `isTransient` flag (`Decoded(bool)`) or `Unparsed` when not decoded.
     ///
-    /// As with `pending_repair`, this module does not walk this field, so it is
-    /// reported honestly as `Unparsed` rather than a fabricated `false`.
+    /// Decoded from real bytes by the version-gated forward walk when
+    /// authoritative [`VersionGates`] are supplied. `hasIsTransient` is `>= na`,
+    /// so the field is present and decoded for every supported Cassandra 5.0
+    /// format (`nb`/`oa`/`da`). `Unparsed` is reserved for "present but not
+    /// safely reachable" or when `gates` is `None`.
     pub is_transient: RepairField<bool>,
 
     /// `true` when `repaired_at` was decoded from the STATS component bytes;
@@ -160,7 +179,14 @@ struct StatsComponentBounds {
 /// STATS component's end is derived authoritatively from those same offsets —
 /// the next component begins where STATS must end — rather than from the rest of
 /// the file. When STATS is the final component, its end is the start of the
-/// trailing CRC. The returned range is validated `start < end <= file_len`.
+/// trailing CRC.
+///
+/// Every Cassandra 5.0 format CQLite reads (`nb` BIG, `oa` BIG, `da` BTI) is
+/// `>= na`, so `hasMetadataChecksum` is always true and
+/// `MetadataSerializer.serialize` always writes a 4-byte CRC32 after each
+/// component body (`MetadataSerializer.java:110-111,117`). The body bound
+/// therefore always subtracts that CRC. (Pre-`na` BIG versions — `ma`–`me` — are
+/// out of scope: CQLite is a Cassandra 5.0 reader and does not open them.)
 ///
 /// Returns:
 ///   * `Ok(None)` ONLY when the TOC is well-formed but carries NO STATS
@@ -246,12 +272,14 @@ fn stats_component_bounds(input: &[u8]) -> Result<Option<StatsComponentBounds>> 
         return Ok(None);
     };
 
-    // The STATS body ends 4 bytes before the *next* component begins: Cassandra
-    // writes a per-component CRC32 between each component body and the next
-    // component's offset (verified against real fixtures). Use the smallest
-    // component offset strictly greater than `start`, minus that CRC; when STATS
-    // is the last component, bound by the file end minus the trailing CRC. Both
-    // cases exclude the 4-byte CRC so it is never decoded as metadata.
+    // The STATS body ends where the *next* component (or the file) begins. For
+    // The STATS body ends 4 bytes before the *next* component begins: every
+    // supported Cassandra 5.0 format (`nb`/`oa`/`da`, all `>= na`) writes a
+    // per-component CRC32 between each component body and the next component's
+    // offset (`MetadataSerializer.java:110-111`). Use the smallest component
+    // offset strictly greater than `start`, minus that CRC; when STATS is the last
+    // component, bound by the file end minus the trailing CRC. Both cases exclude
+    // the 4-byte CRC so it is never decoded as metadata.
     let next_boundary = offsets
         .iter()
         .copied()
@@ -347,6 +375,85 @@ impl<'a> Cursor<'a> {
         self.pos = end;
         Ok(f64::from_be_bytes(buf))
     }
+
+    fn read_u8(&mut self) -> Result<u8> {
+        let end = self.need(1)?;
+        let v = self.bytes[self.pos];
+        self.pos = end;
+        Ok(v)
+    }
+
+    fn read_u16(&mut self) -> Result<u16> {
+        let end = self.need(2)?;
+        let v = u16::from_be_bytes([self.bytes[self.pos], self.bytes[self.pos + 1]]);
+        self.pos = end;
+        Ok(v)
+    }
+
+    /// Read a 16-byte raw UUID (the two `long`s Cassandra writes via
+    /// `UUIDSerializer`: most-significant then least-significant bits, each BE).
+    fn read_uuid(&mut self) -> Result<[u8; 16]> {
+        let end = self.need(16)?;
+        let mut buf = [0u8; 16];
+        buf.copy_from_slice(&self.bytes[self.pos..end]);
+        self.pos = end;
+        Ok(buf)
+    }
+
+    /// Read an unsigned VInt (Cassandra `VIntCoding.readUnsignedVInt`):
+    /// the first byte's leading 1-bits give the number of EXTRA bytes; the
+    /// remaining low bits of the first byte are the high-order value bits.
+    fn read_unsigned_vint(&mut self) -> Result<u64> {
+        let first = self.read_u8()?;
+        let extra = first.leading_ones() as usize;
+        if extra == 0 {
+            return Ok(first as u64);
+        }
+        if extra > 8 {
+            return Err(Error::Corruption(format!(
+                "invalid unsigned VInt: {extra} extra bytes"
+            )));
+        }
+        let mut value: u64 = 0;
+        for _ in 0..extra {
+            let b = self.read_u8()?;
+            value = (value << 8) | b as u64;
+        }
+        // The first byte contributes `8 - extra` low bits (its bits below the
+        // `extra` leading 1s and the separator 0). For extra == 8 there are no
+        // first-byte value bits.
+        if extra < 8 {
+            let mask = (1u8 << (8 - extra)) as u64;
+            // bits below the separator bit
+            let first_bits = first as u64 & (mask - 1);
+            value |= first_bits << (8 * extra);
+        }
+        Ok(value)
+    }
+
+    /// Read `n` raw bytes as an owned `Vec`, bounded by the cursor (fails closed
+    /// on overrun). Used for the clusteringTypes UTF-8 names.
+    fn read_bytes(&mut self, n: usize) -> Result<Vec<u8>> {
+        let end = self.need(n)?;
+        let v = self.bytes[self.pos..end].to_vec();
+        self.pos = end;
+        Ok(v)
+    }
+}
+
+impl ByteSkip for Cursor<'_> {
+    fn read_u8(&mut self) -> Result<u8> {
+        Cursor::read_u8(self)
+    }
+    fn read_u16(&mut self) -> Result<u16> {
+        Cursor::read_u16(self)
+    }
+    fn read_unsigned_vint(&mut self) -> Result<u64> {
+        Cursor::read_unsigned_vint(self)
+    }
+    fn skip(&mut self, n: usize) -> Result<()> {
+        Cursor::skip(self, n)
+    }
 }
 
 /// Skip an `EstimatedHistogram`: `i32 count`, then `count` × (`i64 offset`,
@@ -399,33 +506,163 @@ fn uses_modern_tombstone_histogram(gates: &VersionGates) -> bool {
     }
 }
 
+/// The version-gate flags the post-`repairedAt` forward walk needs, projected
+/// out of [`VersionGates`] so the walk depends only on the AUTHORITATIVE parsed
+/// descriptor (no heuristics, #28). Every flag mirrors a single Cassandra
+/// `BigFormat`/`BtiFormat` version gate consumed by
+/// `StatsMetadata.StatsMetadataSerializer.serialize`.
+#[derive(Debug, Clone, Copy)]
+struct RepairWalkGates {
+    /// Modern tombstone-histogram entry width (`oa`+/`da`).
+    modern_histogram: bool,
+    /// `hasImprovedMinMax` — emits clusteringTypes + a covered `Slice` in place
+    /// of the legacy min/max clustering-value lists.
+    has_improved_min_max: bool,
+    /// `hasLegacyMinMax` — emits min/max clustering-value lists (each
+    /// `i32 count` then `count` × vint-length value).
+    has_legacy_min_max: bool,
+    /// `hasPendingRepair` (`na`+/`da`) — the `pendingRepair` nullable-UUID field
+    /// is present in the body.
+    has_pending_repair: bool,
+    /// `hasIsTransient` (`na`+/`da`) — the `isTransient` boolean is present.
+    has_is_transient: bool,
+}
+
+impl RepairWalkGates {
+    fn from(gates: &VersionGates) -> Self {
+        match gates {
+            VersionGates::Big(g) => RepairWalkGates {
+                modern_histogram: g.has_uint_deletion_time,
+                has_improved_min_max: g.has_improved_min_max,
+                has_legacy_min_max: g.has_legacy_min_max,
+                has_pending_repair: g.has_pending_repair,
+                has_is_transient: g.has_is_transient,
+            },
+            VersionGates::Bti(g) => RepairWalkGates {
+                modern_histogram: true,
+                has_improved_min_max: g.has_improved_min_max,
+                has_legacy_min_max: g.has_legacy_min_max,
+                has_pending_repair: g.has_pending_repair,
+                has_is_transient: g.has_is_transient,
+            },
+        }
+    }
+}
+
+/// Skip the legacy min/max clustering-value lists (`hasLegacyMinMax`).
+///
+/// Each list is `i32 count` then `count` × a value written with
+/// `ByteBufferUtil.writeWithShortLength` — an UNSIGNED 16-bit length prefix
+/// (`writeShort`) then the raw bytes (cassandra-5.0.0
+/// `StatsMetadata.StatsMetadataSerializer.serialize` legacy branch). Verified
+/// against a real `nb` `system_schema` fixture (clustering values present).
+fn skip_legacy_min_max(c: &mut Cursor) -> Result<()> {
+    for _ in 0..2 {
+        let count = c.read_i32()?;
+        if count < 0 {
+            return Err(Error::Corruption(format!(
+                "negative legacy min/max clustering count {count}"
+            )));
+        }
+        for _ in 0..count {
+            let len = c.read_u16()? as usize;
+            c.skip(len)?;
+        }
+    }
+    Ok(())
+}
+
+/// Attempt to skip the improvedMinMax block (`hasImprovedMinMax`): a
+/// clusteringTypes list (unsigned-VInt count, then each type a vint-length UTF-8
+/// string) followed by the covered `Slice` (two `ClusteringBound`s, each
+/// `byte kind` + `short size` + `size` comparator-encoded values).
+///
+/// The covered-clustering bound VALUES are RAW comparator-encoded (no per-value
+/// length prefix), exactly as cassandra-5.0.0
+/// `ClusteringPrefix.Serializer.serializeValuesWithoutSize` writes them: 32-value
+/// header batches then each present value's bytes via `AbstractType.writeValue`
+/// (fixed-width raw, or `writeWithVIntLength` for variable types). We skip them
+/// authoritatively by resolving each clustering column's `valueLengthIfFixed()`
+/// from the persisted `clusteringTypes` and mirroring
+/// `ClusteringBoundOrBoundary.Serializer.skipValues` (see [`repair_clustering`]).
+///
+/// Returns `Ok(true)` when the whole block (types + covered Slice) was skipped, so
+/// the walk may continue to `pendingRepair`/`isTransient`. Returns `Ok(false)`
+/// ONLY when a clustering type is not modeled (its fixed-vs-variable nature is
+/// unknown) or a bound advertises more values than the types describe — i.e. the
+/// length of some value cannot be computed. In that case the caller reports the
+/// trailing fields honestly as `Unparsed` rather than guessing (#28). Empty
+/// bounds (`Slice.ALL`, the no-clustering shape) skip cleanly to `Ok(true)`.
+fn try_skip_improved_min_max(c: &mut Cursor) -> Result<bool> {
+    // clusteringTypes list → resolved per-column value layouts. The raw UTF-8
+    // type names are read through the same bounded cursor.
+    let layouts = {
+        // Borrow the cursor mutably inside the closure by reading bytes directly;
+        // read_clustering_type_layouts drives both the vint reads and the name
+        // reads through `c`, but the closure also needs `c`, so we inline the
+        // loop here instead of passing a borrow twice.
+        let count = ByteSkip::read_unsigned_vint(c)? as usize;
+        let mut v = Vec::with_capacity(count.min(64));
+        for _ in 0..count {
+            let len = ByteSkip::read_unsigned_vint(c)? as usize;
+            let bytes = c.read_bytes(len)?;
+            let name = std::str::from_utf8(&bytes).map_err(|_| {
+                Error::Corruption("clusteringTypes entry is not valid UTF-8".to_string())
+            })?;
+            v.push(resolve_clustering_value_layout(name));
+        }
+        v
+    };
+    // coveredClustering = Slice: start bound, then end bound, each skipped per the
+    // resolved layouts. A bool result distinguishes "skipped" from "unmodeled".
+    skip_covered_slice(c, &layouts)
+}
+
+/// Skip the `commitLogIntervals` IntervalSet: `i32 size` then `size` × an
+/// interval (`CommitLogPosition` start + end = 2 × (`i64 segmentId` +
+/// `i32 position`) = 24 bytes per interval).
+fn skip_commit_log_intervals(c: &mut Cursor) -> Result<()> {
+    let size = c.read_i32()?;
+    if size < 0 {
+        return Err(Error::Corruption(format!(
+            "negative commitLogIntervals size {size}"
+        )));
+    }
+    let bytes = (size as usize)
+        .checked_mul(24)
+        .ok_or_else(|| Error::Corruption("commitLogIntervals size overflow".to_string()))?;
+    c.skip(bytes)
+}
+
 /// Decode the repair-state metadata from a raw `Statistics.db` buffer.
 ///
 /// `repairedAt` is decoded from the STATS component for every format. When
-/// `gates` is `None`, the legacy (nb) tombstone-histogram width is assumed
-/// (nb-compatible default), matching the rest of the minimal Statistics parser.
-///
-/// `pendingRepair` / `isTransient` are reported honestly as `RepairField::Unparsed`
-/// (this module does not walk them; see module docs); this function never
-/// fabricates a repaired state.
+/// authoritative [`VersionGates`] are supplied, the full version-gated forward
+/// walk continues past `repairedAt` and decodes `pendingRepair` and
+/// `isTransient` from real bytes too (issue #1021). When `gates` is `None`, the
+/// legacy (nb) tombstone-histogram width is assumed to reach `repairedAt`, and
+/// the two later fields are reported honestly as [`RepairField::Unparsed`] (the
+/// min/max block and commit-log-interval shape are version-dependent and cannot
+/// be traversed without the descriptor).
 ///
 /// # Errors
 ///
-/// Returns an error only when the STATS component is present but its leading
-/// (self-describing) fields are truncated/corrupt, OR overrun the STATS
-/// component's authoritative end bound — strict callers can rely on this to fail
-/// closed (a truncated body or an over-long internal length never spills into
-/// the trailing CRC or the following component). A *missing* STATS component is
-/// reported as the unrepaired default with `repaired_at_decoded = false` (the
-/// buffer carried no STATS section to decode). A STATS entry that IS present but
-/// whose derived byte range is invalid (offset past EOF, inverted) is treated as
+/// Returns an error only when the STATS component is present but its fields are
+/// truncated/corrupt, OR overrun the STATS component's authoritative end bound —
+/// strict callers can rely on this to fail closed (a truncated body or an
+/// over-long internal length never spills into the trailing CRC or the following
+/// component). A *missing* STATS component is reported as the unrepaired default
+/// with `repaired_at_decoded = false`. A STATS entry that IS present but whose
+/// derived byte range is invalid (offset past EOF, inverted) is treated as
 /// corruption and fails closed.
 pub fn parse_repair_metadata(input: &[u8], gates: Option<&VersionGates>) -> Result<RepairMetadata> {
+    let walk = gates.map(RepairWalkGates::from);
+
     let Some(bounds) = stats_component_bounds(input)? else {
         return Ok(RepairMetadata::unrepaired_default());
     };
 
-    let modern_histogram = gates.map(uses_modern_tombstone_histogram).unwrap_or(false);
+    let modern_histogram = walk.map(|w| w.modern_histogram).unwrap_or(false);
 
     // Bound the cursor over ONLY the STATS component slice (start..end, with the
     // trailing CRC and following components excluded). Any read past this slice
@@ -460,12 +697,87 @@ pub fn parse_repair_metadata(input: &[u8], gates: Option<&VersionGates>) -> Resu
     let _sstable_level = c.read_i32()?;
     let repaired_at = c.read_i64()?;
 
+    // Without authoritative gates the post-repairedAt min/max block and the
+    // commit-log-interval shape cannot be traversed; report the two later fields
+    // honestly as Unparsed rather than a fabricated null / false.
+    let Some(walk) = walk else {
+        return Ok(RepairMetadata {
+            repaired_at,
+            pending_repair: RepairField::Unparsed,
+            is_transient: RepairField::Unparsed,
+            repaired_at_decoded: true,
+        });
+    };
+
+    // 10. min/max clustering block. Cassandra serializes the improvedMinMax
+    //     variant when present, otherwise the legacy variant; a version that
+    //     carries neither (pre-mb) writes nothing here.
+    //
+    //     The improvedMinMax covered-clustering Slice carries comparator-encoded
+    //     bound VALUES that this repair-only decoder does not model. When those
+    //     values are present (a table with clustering data) the walk cannot
+    //     safely continue, so the two later fields are reported honestly as
+    //     `Unparsed` rather than mis-decoded.
+    if walk.has_improved_min_max {
+        if !try_skip_improved_min_max(&mut c)? {
+            return Ok(RepairMetadata {
+                repaired_at,
+                pending_repair: RepairField::Unparsed,
+                is_transient: RepairField::Unparsed,
+                repaired_at_decoded: true,
+            });
+        }
+    } else if walk.has_legacy_min_max {
+        skip_legacy_min_max(&mut c)?;
+    }
+
+    // 11. hasLegacyCounterShards (bool).
+    c.skip(1)?;
+
+    // 12. totalColumnsSet (long), totalRows (long).
+    c.skip(8 + 8)?;
+
+    // 13. commitLogLowerBound (CommitLogPosition) + commitLogIntervals
+    //     (IntervalSet). `hasCommitLogLowerBound` is `>= mb` and
+    //     `hasCommitLogIntervals` is `>= mc` in Cassandra; both gates are below
+    //     `na`, so every Cassandra 5.0 format CQLite reads (`nb`/`oa`/`da`) always
+    //     carries both fields. Skip them unconditionally. (The pre-`mc` absent
+    //     case is out of scope — CQLite is a Cassandra 5.0 reader.)
+    c.skip(8 + 4)?; // commitLogLowerBound CommitLogPosition: i64 segmentId + i32 position
+    skip_commit_log_intervals(&mut c)?;
+
+    // 14. pendingRepair: a presence byte (writeBoolean), then a 16-byte UUID
+    //     when present. `hasPendingRepair` is `version.compareTo("na") >= 0`
+    //     (cassandra-5.0.0 `BigFormat`/`BtiFormat`), so it is ALWAYS true for
+    //     every Cassandra 5.0 format CQLite reads (`nb`/`oa`/`da`) and the field
+    //     is always present and decoded. The `else` is unreachable for supported
+    //     formats (pre-`na` BIG `ma`–`me` is out of scope — CQLite is a Cassandra
+    //     5.0 reader); it fails closed via `Unparsed` rather than fabricating a
+    //     value, which `classify_inputs` rejects.
+    let pending_repair = if walk.has_pending_repair {
+        let present = c.read_u8()?;
+        if present != 0 {
+            RepairField::Decoded(Some(c.read_uuid()?))
+        } else {
+            RepairField::Decoded(None)
+        }
+    } else {
+        RepairField::Unparsed
+    };
+
+    // 15. isTransient (bool). Same `>= na` gate as pendingRepair, so always
+    //     present and decoded for supported Cassandra 5.0 formats. The `else` is
+    //     unreachable for `nb`/`oa`/`da`; it fails closed (`Unparsed`).
+    let is_transient = if walk.has_is_transient {
+        RepairField::Decoded(c.read_u8()? != 0)
+    } else {
+        RepairField::Unparsed
+    };
+
     Ok(RepairMetadata {
         repaired_at,
-        // Not walked by this module — reported honestly as not-yet-decoded
-        // rather than a fabricated null / false (see module docs).
-        pending_repair: RepairField::Unparsed,
-        is_transient: RepairField::Unparsed,
+        pending_repair,
+        is_transient,
         repaired_at_decoded: true,
     })
 }
@@ -784,6 +1096,212 @@ mod tests {
 
     fn oa_gates() -> VersionGates {
         VersionGates::Big(BigVersionGates::from_version("oa").expect("oa gates"))
+    }
+
+    fn da_gates() -> VersionGates {
+        use crate::storage::sstable::version_gate::BtiVersionGates;
+        VersionGates::Bti(BtiVersionGates::from_version("da").expect("da gates"))
+    }
+
+    /// Append an unsigned VInt (Cassandra `VIntCoding.writeUnsignedVInt`) so the
+    /// full-walk synthetic builders match the bytes [`Cursor::read_unsigned_vint`]
+    /// consumes. Values used by these tests fit in `< 128`, encoded as one byte.
+    fn push_uvint(buf: &mut Vec<u8>, v: u64) {
+        assert!(
+            v < 0x80,
+            "test uvint helper only handles single-byte values"
+        );
+        buf.push(v as u8);
+    }
+
+    /// Build a complete STATS body through `isTransient` for the legacy (`nb`)
+    /// layout (legacy min/max clustering lists; pendingRepair UUID + transient
+    /// flag carried by `na`+). Wrapped in a STATS-last 2-component TOC + CRC.
+    fn synthetic_full_nb(
+        repaired_at: i64,
+        pending_repair: Option<[u8; 16]>,
+        is_transient: bool,
+    ) -> Vec<u8> {
+        let mut stats = Vec::new();
+        stats.extend_from_slice(&0i32.to_be_bytes()); // estimatedPartitionSize
+        stats.extend_from_slice(&0i32.to_be_bytes()); // estimatedCellPerPartitionCount
+        stats.extend_from_slice(&(-1i64).to_be_bytes()); // commitLogUpperBound segmentId
+        stats.extend_from_slice(&0i32.to_be_bytes()); // commitLogUpperBound position
+        stats.extend_from_slice(&100i64.to_be_bytes()); // minTimestamp
+        stats.extend_from_slice(&200i64.to_be_bytes()); // maxTimestamp
+        stats.extend_from_slice(&i32::MAX.to_be_bytes()); // minLocalDeletionTime
+        stats.extend_from_slice(&i32::MAX.to_be_bytes()); // maxLocalDeletionTime
+        stats.extend_from_slice(&0i32.to_be_bytes()); // minTTL
+        stats.extend_from_slice(&0i32.to_be_bytes()); // maxTTL
+        stats.extend_from_slice(&(-1.0f64).to_be_bytes()); // compressionRatio
+        stats.extend_from_slice(&0i32.to_be_bytes()); // TombstoneHistogram maxBinSize
+        stats.extend_from_slice(&0i32.to_be_bytes()); // TombstoneHistogram size
+        stats.extend_from_slice(&0i32.to_be_bytes()); // sstableLevel
+        stats.extend_from_slice(&repaired_at.to_be_bytes()); // repairedAt
+                                                             // legacy min/max clustering lists (both empty: count 0).
+        stats.extend_from_slice(&0i32.to_be_bytes());
+        stats.extend_from_slice(&0i32.to_be_bytes());
+        stats.push(0x00); // hasLegacyCounterShards
+        stats.extend_from_slice(&0u64.to_be_bytes()); // totalColumnsSet
+        stats.extend_from_slice(&0u64.to_be_bytes()); // totalRows
+        stats.extend_from_slice(&(-1i64).to_be_bytes()); // commitLogLowerBound segmentId
+        stats.extend_from_slice(&0i32.to_be_bytes()); // commitLogLowerBound position
+        stats.extend_from_slice(&0i32.to_be_bytes()); // commitLogIntervals size = 0
+                                                      // pendingRepair: presence byte + optional UUID.
+        match pending_repair {
+            Some(uuid) => {
+                stats.push(0x01);
+                stats.extend_from_slice(&uuid);
+            }
+            None => stats.push(0x00),
+        }
+        stats.push(if is_transient { 0x01 } else { 0x00 }); // isTransient
+        wrap_stats_last(stats)
+    }
+
+    /// Build a complete STATS body through `isTransient` for the `da` (BtiFormat)
+    /// layout (improvedMinMax: clusteringTypes + covered Slice). One clustering
+    /// type and an empty covered slice exercise the improved-min/max walk.
+    fn synthetic_full_da(
+        repaired_at: i64,
+        pending_repair: Option<[u8; 16]>,
+        is_transient: bool,
+    ) -> Vec<u8> {
+        let mut stats = Vec::new();
+        stats.extend_from_slice(&0i32.to_be_bytes()); // estimatedPartitionSize
+        stats.extend_from_slice(&0i32.to_be_bytes()); // estimatedCellPerPartitionCount
+        stats.extend_from_slice(&(-1i64).to_be_bytes()); // commitLogUpperBound segmentId
+        stats.extend_from_slice(&0i32.to_be_bytes()); // commitLogUpperBound position
+        stats.extend_from_slice(&100i64.to_be_bytes()); // minTimestamp
+        stats.extend_from_slice(&200i64.to_be_bytes()); // maxTimestamp
+        stats.extend_from_slice(&u32::MAX.to_be_bytes()); // minLocalDeletionTime (uint)
+        stats.extend_from_slice(&u32::MAX.to_be_bytes()); // maxLocalDeletionTime (uint)
+        stats.extend_from_slice(&0i32.to_be_bytes()); // minTTL
+        stats.extend_from_slice(&0i32.to_be_bytes()); // maxTTL
+        stats.extend_from_slice(&(-1.0f64).to_be_bytes()); // compressionRatio
+        stats.extend_from_slice(&0i32.to_be_bytes()); // TombstoneHistogram maxBinSize (modern)
+        stats.extend_from_slice(&0i32.to_be_bytes()); // TombstoneHistogram size (modern)
+        stats.extend_from_slice(&0i32.to_be_bytes()); // sstableLevel
+        stats.extend_from_slice(&repaired_at.to_be_bytes()); // repairedAt
+                                                             // improvedMinMax: clusteringTypes list (1 type) + covered Slice.
+        push_uvint(&mut stats, 1); // clusteringTypes count
+        let ty = b"org.apache.cassandra.db.marshal.Int32Type";
+        push_uvint(&mut stats, ty.len() as u64);
+        stats.extend_from_slice(ty);
+        // covered Slice: start bound (kind=1, size=0), end bound (kind=6, size=0).
+        stats.push(1);
+        stats.extend_from_slice(&0u16.to_be_bytes());
+        stats.push(6);
+        stats.extend_from_slice(&0u16.to_be_bytes());
+        stats.push(0x00); // hasLegacyCounterShards
+        stats.extend_from_slice(&0u64.to_be_bytes()); // totalColumnsSet
+        stats.extend_from_slice(&0u64.to_be_bytes()); // totalRows
+        stats.extend_from_slice(&(-1i64).to_be_bytes()); // commitLogLowerBound segmentId
+        stats.extend_from_slice(&0i32.to_be_bytes()); // commitLogLowerBound position
+        stats.extend_from_slice(&0i32.to_be_bytes()); // commitLogIntervals size = 0
+        match pending_repair {
+            Some(uuid) => {
+                stats.push(0x01);
+                stats.extend_from_slice(&uuid);
+            }
+            None => stats.push(0x00),
+        }
+        stats.push(if is_transient { 0x01 } else { 0x00 }); // isTransient
+        wrap_stats_last(stats)
+    }
+
+    /// Wrap a STATS body in a 2-component TOC (STATS type 2 last by offset) plus a
+    /// trailing 4-byte CRC, so the decoder's end bound is `file_len - CRC`.
+    fn wrap_stats_last(stats: Vec<u8>) -> Vec<u8> {
+        let toc_len = 4 + 4 + 2 * 8;
+        let comp0_off = toc_len;
+        let stats_off = comp0_off + 1;
+        let mut out = Vec::new();
+        out.extend_from_slice(&2u32.to_be_bytes());
+        out.extend_from_slice(&0u32.to_be_bytes());
+        for (ty, off) in [(0u32, comp0_off as u32), (2u32, stats_off as u32)] {
+            out.extend_from_slice(&ty.to_be_bytes());
+            out.extend_from_slice(&off.to_be_bytes());
+        }
+        out.push(0u8); // placeholder body for comp0
+        debug_assert_eq!(out.len(), stats_off);
+        out.extend_from_slice(&stats);
+        out.extend_from_slice(&0u32.to_be_bytes()); // trailing CRC
+        out
+    }
+
+    #[test]
+    fn full_walk_nb_decodes_null_pending_and_transient() {
+        let bytes = synthetic_full_nb(0, None, false);
+        let md = parse_repair_metadata(&bytes, Some(&nb_gates())).expect("decode");
+        assert_eq!(md.repaired_at, 0);
+        assert!(md.repaired_at_decoded);
+        assert_eq!(md.pending_repair, RepairField::Decoded(None));
+        assert_eq!(md.is_transient, RepairField::Decoded(false));
+    }
+
+    #[test]
+    fn full_walk_nb_decodes_pending_uuid_and_transient_true() {
+        let uuid = [
+            0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE,
+            0xFF, 0x00,
+        ];
+        let bytes = synthetic_full_nb(1_700_000_000_000, Some(uuid), true);
+        let md = parse_repair_metadata(&bytes, Some(&nb_gates())).expect("decode");
+        assert_eq!(md.repaired_at, 1_700_000_000_000);
+        assert_eq!(md.pending_repair, RepairField::Decoded(Some(uuid)));
+        assert_eq!(md.is_transient, RepairField::Decoded(true));
+    }
+
+    #[test]
+    fn full_walk_da_decodes_pending_uuid_and_transient() {
+        let uuid = [0xABu8; 16];
+        let bytes = synthetic_full_da(42, Some(uuid), true);
+        let md = parse_repair_metadata(&bytes, Some(&da_gates())).expect("decode");
+        assert_eq!(md.repaired_at, 42);
+        assert_eq!(md.pending_repair, RepairField::Decoded(Some(uuid)));
+        assert_eq!(md.is_transient, RepairField::Decoded(true));
+    }
+
+    #[test]
+    fn full_walk_da_decodes_null_pending_non_transient() {
+        let bytes = synthetic_full_da(0, None, false);
+        let md = parse_repair_metadata(&bytes, Some(&da_gates())).expect("decode");
+        assert_eq!(md.pending_repair, RepairField::Decoded(None));
+        assert_eq!(md.is_transient, RepairField::Decoded(false));
+    }
+
+    #[test]
+    fn full_walk_none_gates_reports_unparsed() {
+        // Without gates the walk past repairedAt is not attempted, so the two
+        // later fields are reported honestly as Unparsed (not fabricated).
+        let bytes = synthetic_full_nb(7, Some([0x01u8; 16]), true);
+        let md = parse_repair_metadata(&bytes, None).expect("decode repairedAt only");
+        assert_eq!(md.repaired_at, 7);
+        assert_eq!(md.pending_repair, RepairField::Unparsed);
+        assert_eq!(md.is_transient, RepairField::Unparsed);
+    }
+
+    #[test]
+    fn full_walk_truncated_pending_fails_closed() {
+        // Drop the trailing CRC + isTransient + part of the UUID so the
+        // pendingRepair UUID read overruns the bounded STATS slice.
+        let mut bytes = synthetic_full_nb(0, Some([0x07u8; 16]), true);
+        bytes.truncate(bytes.len() - (4 + 1 + 8));
+        assert!(
+            parse_repair_metadata(&bytes, Some(&nb_gates())).is_err(),
+            "a truncated pendingRepair UUID must fail closed, not default"
+        );
+    }
+
+    #[test]
+    fn read_unsigned_vint_matches_encode_vuint() {
+        use crate::parser::vint::encode_vuint;
+        for v in [0u64, 1, 63, 127, 128, 255, 300, 16383, 16384, 1_000_000] {
+            let enc = encode_vuint(v);
+            let mut c = Cursor::new(&enc);
+            assert_eq!(c.read_unsigned_vint().expect("decode vint"), v, "v={v}");
+        }
     }
 
     #[test]

--- a/cqlite-core/src/storage/sstable/writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/mod.rs
@@ -822,6 +822,23 @@ impl SSTableWriter {
         self.baselines_locked = true;
     }
 
+    /// Preserve the persisted repair state (`repairedAt`, `pendingRepair`,
+    /// `isTransient`) into this writer's output `Statistics.db` (issue #1021).
+    ///
+    /// Called by the compaction merge path with the single shared repair state of
+    /// the (compatible) inputs so the merged SSTable carries the inputs' repair
+    /// metadata forward. A fresh memtable flush never calls this, so the output
+    /// stays unrepaired (`repaired_at = 0`, no pending repair, non-transient).
+    pub fn set_repair_state(
+        &mut self,
+        repaired_at: i64,
+        pending_repair: Option<[u8; 16]>,
+        is_transient: bool,
+    ) {
+        self.stats
+            .set_repair_state(repaired_at, pending_repair, is_transient);
+    }
+
     /// Compute the encoding baseline stats (min values only) from a slice of mutations.
     ///
     /// Used for the pre-pass before `write_partition` is called (issue #729

--- a/cqlite-core/src/storage/sstable/writer/stats_writer/components.rs
+++ b/cqlite-core/src/storage/sstable/writer/stats_writer/components.rs
@@ -11,6 +11,25 @@ use crate::parser::vint::encode_vuint;
 use crate::schema::TableSchema;
 use std::io::Write;
 
+/// Serialise the STATS `pendingRepair` nullable field: a single presence byte
+/// (`0x01` present, `0x00` null) followed by the raw 16-byte UUID when present.
+///
+/// Mirrors cassandra-5.0.0 `StatsMetadata.StatsMetadataSerializer.serialize`:
+/// `out.writeBoolean(pendingRepair != null)` then, if present,
+/// `UUIDSerializer.serialize` (the two `long`s, MSB then LSB, big-endian — which
+/// is exactly the 16 raw bytes). Used by both the `nb`/`oa` and `da` builders so
+/// a preserved pending-repair UUID round-trips through the read-path walk.
+fn write_pending_repair(buffer: &mut Vec<u8>, pending_repair: Option<[u8; 16]>) -> Result<()> {
+    match pending_repair {
+        Some(uuid) => {
+            buffer.write_all(&[0x01])?;
+            buffer.write_all(&uuid)?;
+        }
+        None => buffer.write_all(&[0x00])?,
+    }
+    Ok(())
+}
+
 impl StatisticsWriter {
     /// Build VALIDATION component (MetadataType ordinal 0)
     ///
@@ -130,8 +149,9 @@ impl StatisticsWriter {
         // 12. int sstableLevel
         buffer.write_all(&0i32.to_be_bytes())?;
 
-        // 13. long repairedAt
-        buffer.write_all(&0i64.to_be_bytes())?;
+        // 13. long repairedAt — preserved from the (compatible) compaction
+        // inputs (issue #1021); 0 for an unrepaired SSTable / fresh flush.
+        buffer.write_all(&metadata.repaired_at.to_be_bytes())?;
 
         // 14. int minClusteringCount (no clustering = 0)
         buffer.write_all(&0i32.to_be_bytes())?;
@@ -159,11 +179,12 @@ impl StatisticsWriter {
         // 22. IntervalSet<CommitLogPosition> commitLogIntervals (empty set: size=0)
         buffer.write_all(&0i32.to_be_bytes())?;
 
-        // 23. byte pendingRepair (0 = null, no pending repair)
-        buffer.write_all(&[0x00])?;
+        // 23. pendingRepair (nullable): presence byte, then the 16-byte UUID
+        // when present. Preserved from compatible compaction inputs (#1021).
+        write_pending_repair(&mut buffer, metadata.pending_repair)?;
 
-        // 24. boolean isTransient
-        buffer.write_all(&[0x00])?; // false
+        // 24. boolean isTransient — preserved from compatible inputs (#1021).
+        buffer.write_all(&[if metadata.is_transient { 0x01 } else { 0x00 }])?;
 
         // 25. byte originatingHostId (0 = null)
         buffer.write_all(&[0x00])?;
@@ -255,9 +276,10 @@ impl StatisticsWriter {
         // subsequent `coveredClustering` Slice deserialization in Cassandra.
         self.write_tombstone_histogram_modern(&mut buffer, &metadata.tombstone_histogram)?;
 
-        // 9. sstableLevel, repairedAt
+        // 9. sstableLevel, repairedAt (repairedAt preserved from compatible
+        // compaction inputs, issue #1021).
         buffer.write_all(&0i32.to_be_bytes())?;
-        buffer.write_all(&0i64.to_be_bytes())?;
+        buffer.write_all(&metadata.repaired_at.to_be_bytes())?;
 
         // 10. improvedMinMax: clusteringTypes list + coveredClustering Slice.
         //
@@ -300,11 +322,12 @@ impl StatisticsWriter {
         buffer.write_all(&0i32.to_be_bytes())?; // position
         buffer.write_all(&0i32.to_be_bytes())?; // interval set size = 0
 
-        // 14. pendingRepair (null)
-        buffer.write_all(&[0x00])?;
+        // 14. pendingRepair (nullable): presence byte + optional UUID, preserved
+        // from compatible compaction inputs (#1021).
+        write_pending_repair(&mut buffer, metadata.pending_repair)?;
 
-        // 15. isTransient
-        buffer.write_all(&[0x00])?;
+        // 15. isTransient — preserved from compatible inputs (#1021).
+        buffer.write_all(&[if metadata.is_transient { 0x01 } else { 0x00 }])?;
 
         // 16. originatingHostId (null)
         buffer.write_all(&[0x00])?;

--- a/cqlite-core/src/storage/sstable/writer/stats_writer/metadata.rs
+++ b/cqlite-core/src/storage/sstable/writer/stats_writer/metadata.rs
@@ -157,6 +157,23 @@ pub struct StatisticsMetadata {
     /// contributes a `partition_tombstone`. Ignored by the legacy BIG (nb/oa)
     /// STATS body, which never serialises this field.
     pub has_partition_level_deletions: bool,
+
+    /// `repairedAt` repair timestamp (`0` = unrepaired). Serialised verbatim
+    /// into the STATS component `repairedAt` field. Preserved through compaction
+    /// from the (compatible) input SSTables (issue #1021); a fresh memtable flush
+    /// leaves it `0`.
+    pub repaired_at: i64,
+
+    /// `pendingRepair` incremental-repair session UUID (`None` = no pending
+    /// repair). Serialised as the STATS `pendingRepair` nullable field (presence
+    /// byte then 16-byte UUID). Preserved through compaction from compatible
+    /// inputs (issue #1021); a fresh flush leaves it `None`.
+    pub pending_repair: Option<[u8; 16]>,
+
+    /// `isTransient` flag (transiently-replicated data). Serialised as the STATS
+    /// `isTransient` boolean. Preserved through compaction from compatible inputs
+    /// (issue #1021); a fresh flush leaves it `false`.
+    pub is_transient: bool,
 }
 
 impl Default for StatisticsMetadata {
@@ -176,6 +193,9 @@ impl Default for StatisticsMetadata {
             first_key: None,
             last_key: None,
             has_partition_level_deletions: false,
+            repaired_at: 0,
+            pending_repair: None,
+            is_transient: false,
         }
     }
 }
@@ -270,6 +290,25 @@ impl StatisticsMetadata {
     /// `partition_tombstone`.
     pub fn mark_partition_level_deletion(&mut self) {
         self.has_partition_level_deletions = true;
+    }
+
+    /// Set the persisted repair state (`repairedAt`, `pendingRepair`,
+    /// `isTransient`) carried into the output STATS component.
+    ///
+    /// Used by the compaction merge path to preserve the repair metadata of
+    /// compatible inputs through to the merged output (issue #1021). A fresh
+    /// memtable flush never calls this, so the default unrepaired state
+    /// (`repaired_at = 0`, `pending_repair = None`, `is_transient = false`) is
+    /// retained.
+    pub fn set_repair_state(
+        &mut self,
+        repaired_at: i64,
+        pending_repair: Option<[u8; 16]>,
+        is_transient: bool,
+    ) {
+        self.repaired_at = repaired_at;
+        self.pending_repair = pending_repair;
+        self.is_transient = is_transient;
     }
 
     /// Increment row count

--- a/cqlite-core/src/storage/write_engine/compaction.rs
+++ b/cqlite-core/src/storage/write_engine/compaction.rs
@@ -175,6 +175,17 @@ impl WriteEngine {
         // the partial bound unconditionally is safe.
         .with_max_purgeable_timestamp(max_purgeable_timestamp);
 
+        // Repair-state preservation + mixed-state rejection (issue #1021).
+        //
+        // Cassandra partitions compaction candidates by repair state and never
+        // mixes repaired / unrepaired / pending-repair SSTables in one
+        // compaction. CQLite cannot reproduce the repair-boundary tombstone
+        // constraints, so it MUST NOT silently merge across that boundary: read
+        // each input's persisted repair state from its Statistics.db, reject a
+        // mixed set with a typed error, and PRESERVE the single shared state into
+        // the merged output below. Authoritative metadata only (no heuristics).
+        let repair_state = merge::classify_inputs(&input_paths)?;
+
         // Point the SSTableWriter at the tmp root; it will write to
         // tmp_dir/keyspace/table/nb-{gen}-big-*.db. Use the post-drop
         // `write_schema` (NOT `effective_schema`) so fully-purged dropped
@@ -184,6 +195,15 @@ impl WriteEngine {
             output_generation,
             &write_schema,
         )?;
+
+        // Carry the inputs' shared repair state into the merged output's
+        // Statistics.db (issue #1021). For a normal unrepaired corpus this is the
+        // unrepaired default (a no-op vs the previous hardcoded zeros).
+        writer.set_repair_state(
+            repair_state.repaired_at,
+            repair_state.pending_repair,
+            repair_state.is_transient,
+        );
 
         // Two-pass compaction (issue #729): compute output FINAL encoding baselines
         // by reading the minimum values from each input SSTable's Statistics.db.

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -76,6 +76,14 @@ mod model;
 #[cfg(feature = "write-support")]
 pub use model::{CellData, ComplexDeletion, MergeEntry, MergeStats, MergeStep, RowData};
 
+/// Repair-state classification + mixed-state rejection for compaction
+/// (issue #1021). Reads each input's persisted repair state from `Statistics.db`
+/// and either returns the shared state to preserve or rejects a mixed-state set.
+#[cfg(feature = "write-support")]
+pub mod repair_state;
+#[cfg(feature = "write-support")]
+pub use repair_state::{classify_inputs, RepairState};
+
 /// Clustering-group reconciliation kernel, decomposed into named steps
 /// (issue #945). See [`reconcile::ReconcileState`].
 #[cfg(feature = "write-support")]
@@ -1773,11 +1781,21 @@ pub async fn compact_sstables_with_registry(
     )?
     .with_purge_safe(purge_safe);
 
+    // Repair-state preservation + mixed-state rejection (issue #1021): reject a
+    // mixed repaired/unrepaired/pending-repair input set (Cassandra never mixes
+    // them in one compaction) and otherwise carry the shared state forward.
+    let repair_state = classify_inputs(&input_paths)?;
+
     let mut writer = crate::storage::sstable::writer::SSTableWriter::new(
         output_dir.to_path_buf(),
         generation,
         &write_schema,
     )?;
+    writer.set_repair_state(
+        repair_state.repaired_at,
+        repair_state.pending_repair,
+        repair_state.is_transient,
+    );
 
     // Two-pass compaction (issue #729): seed the output's encoding baselines from
     // the inputs' Statistics.db before writing any partition.

--- a/cqlite-core/src/storage/write_engine/merge/repair_state.rs
+++ b/cqlite-core/src/storage/write_engine/merge/repair_state.rs
@@ -1,0 +1,374 @@
+//! Repair-state classification + mixed-state rejection for compaction
+//! (issue #1021, parent epic #973 compaction byte parity).
+//!
+//! Apache Cassandra refuses to compact SSTables that disagree on their repair
+//! state — `CompactionTask`/`CompactionStrategyManager` partition candidates by
+//! `(repairedAt, pendingRepair, isTransient)` so a single compaction never mixes
+//! repaired, unrepaired, and pending-repair data (this is what
+//! `CompactionTaskTest`'s reject-mixed-repair-state expectations assert). CQLite
+//! cannot reproduce Cassandra's repair-boundary tombstone constraints, so it
+//! MUST NOT silently merge across that boundary.
+//!
+//! This module reads the persisted repair state of each compaction input from
+//! its `Statistics.db` STATS component (via
+//! [`parse_repair_metadata`](crate::parser::repair_metadata::parse_repair_metadata),
+//! authoritative metadata only — no heuristics, #28), classifies the set, and
+//! either:
+//!   * returns the single common [`RepairState`] to PRESERVE into the merged
+//!     output's `Statistics.db` (compatible inputs — same repair state), or
+//!   * returns a typed [`Error::Compaction`] naming the conflicting states
+//!     (mixed inputs) so the caller fails closed instead of merging.
+//!
+//! Scope: parse + preserve + classify + reject ONLY. This establishes nothing
+//! about repair-aware tombstone purging (a separate correctness concern); the
+//! merged output simply carries the inputs' shared repair state forward.
+
+use std::path::{Path, PathBuf};
+
+use crate::error::{Error, Result};
+use crate::parser::repair_metadata::{parse_repair_metadata, RepairField};
+use crate::storage::sstable::version_gate::VersionGates;
+
+/// The persisted repair state of an SSTable, decoded from its `Statistics.db`
+/// STATS component. Two SSTables are compaction-compatible iff their
+/// `RepairState`s are equal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RepairState {
+    /// `repairedAt` (`0` = unrepaired).
+    pub repaired_at: i64,
+    /// `pendingRepair` session UUID (`None` = no pending repair).
+    pub pending_repair: Option<[u8; 16]>,
+    /// `isTransient` flag.
+    pub is_transient: bool,
+}
+
+impl RepairState {
+    /// The unrepaired / no-pending / non-transient state — the state of every
+    /// SSTable produced by a fresh memtable flush.
+    pub fn unrepaired() -> Self {
+        RepairState {
+            repaired_at: 0,
+            pending_repair: None,
+            is_transient: false,
+        }
+    }
+
+    /// Human-readable classification (`unrepaired` / `repaired` / `pending-repair`).
+    /// Test-only: the rejection message is built from the per-field decoded
+    /// states in [`classify_inputs`] (issue #1021), not from a whole-`RepairState`
+    /// render, so this is retained only to assert the classification kinds.
+    #[cfg(test)]
+    fn describe(&self) -> String {
+        let kind = if self.pending_repair.is_some() {
+            "pending-repair"
+        } else if self.repaired_at != 0 {
+            "repaired"
+        } else {
+            "unrepaired"
+        };
+        format!(
+            "{kind}(repairedAt={}, pendingRepair={}, isTransient={})",
+            self.repaired_at,
+            match self.pending_repair {
+                Some(u) => uuid_hex(&u),
+                None => "--".to_string(),
+            },
+            self.is_transient,
+        )
+    }
+}
+
+fn uuid_hex(u: &[u8; 16]) -> String {
+    let mut s = String::with_capacity(32);
+    for b in u {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+/// Derive the sibling `Statistics.db` path for an SSTable `Data.db` path.
+fn stats_path_for(data_path: &Path) -> PathBuf {
+    let filename = data_path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    let stats_filename = filename.replace("Data.db", "Statistics.db");
+    data_path.parent().unwrap_or(data_path).join(stats_filename)
+}
+
+/// The AUTHORITATIVELY decoded repair fields of one compaction input, preserving
+/// the `Decoded` vs `Unparsed` distinction from [`parse_repair_metadata`] so the
+/// classifier can reason about what was actually proven from bytes rather than
+/// treating "couldn't parse" as a concrete value.
+///
+/// `repaired_at` is always decoded (the STATS walk reads it before any
+/// version-gated / comparator-encoded field). `pending_repair` / `is_transient`
+/// are decoded authoritatively for the supported formats — the walk now skips
+/// PAST the `improvedMinMax` covered-clustering `Slice` using each clustering
+/// column's resolved `valueLengthIfFixed()` — and can only be
+/// [`RepairField::Unparsed`] when a clustering comparator is not modeled (an
+/// exotic / future type), which [`classify_inputs`] treats as fail-closed.
+struct InputRepairFields {
+    repaired_at: i64,
+    pending_repair: RepairField<Option<[u8; 16]>>,
+    is_transient: RepairField<bool>,
+}
+
+/// Read the authoritatively decoded repair fields of a single SSTable from its
+/// `Statistics.db`. Requires the authoritative version gates so the full
+/// version-gated walk decodes `pendingRepair` / `isTransient` whenever the format
+/// AND its clustering layout permit (not just `repairedAt`).
+///
+/// The `Decoded` vs `Unparsed` distinction is preserved and resolved by
+/// [`classify_inputs`]: a field that decodes authoritatively (the common case,
+/// including clustered `oa`/`da`) is compared; a genuinely-`Unparsed` field (an
+/// unmodeled clustering comparator) fails the classification closed there rather
+/// than being defaulted.
+///
+/// # Errors
+///
+/// * the `Statistics.db` sibling cannot be read, or
+/// * its descriptor / STATS component is malformed (parse fails closed).
+fn read_repair_fields(data_path: &Path) -> Result<InputRepairFields> {
+    let stats_path = stats_path_for(data_path);
+    let bytes = std::fs::read(&stats_path).map_err(|e| {
+        Error::Compaction(format!(
+            "cannot read {stats_path:?} to classify repair state for compaction: {e}"
+        ))
+    })?;
+    let gates = VersionGates::from_path(&stats_path).map_err(|e| {
+        Error::Compaction(format!(
+            "cannot derive version gates from {stats_path:?} for repair-state classification: {e:?}"
+        ))
+    })?;
+    let md = parse_repair_metadata(&bytes, Some(&gates)).map_err(|e| {
+        Error::Compaction(format!(
+            "cannot decode repair metadata from {stats_path:?} for compaction: {e:?}"
+        ))
+    })?;
+
+    Ok(InputRepairFields {
+        repaired_at: md.repaired_at,
+        pending_repair: md.pending_repair,
+        is_transient: md.is_transient,
+    })
+}
+
+/// Classify a set of compaction inputs by repair state.
+///
+/// Reads each input's authoritatively decoded repair fields and either returns
+/// the single shared [`RepairState`] to preserve into the merged output, or a
+/// typed [`Error::Compaction`] naming the conflicting states.
+///
+/// # How the mixed-state gate decides (issue #1021)
+///
+/// Every repair field is now decoded AUTHORITATIVELY from real bytes for the
+/// supported formats: the version-gated STATS walk skips PAST the `improvedMinMax`
+/// covered-clustering `Slice` by resolving each clustering column's
+/// `valueLengthIfFixed()` from the persisted `clusteringTypes`, so clustered
+/// `oa`/`da` SSTables no longer report `pendingRepair`/`isTransient` as
+/// `Unparsed`. The gate compares those decoded values:
+///
+///   * `repairedAt` is ALWAYS decoded; a genuine mismatch is rejected.
+///   * `pendingRepair` / `isTransient`: a decoded mismatch between any two inputs
+///     (different UUIDs, `Some` vs decoded `None`, or `true` vs `false`) is
+///     rejected — Cassandra never mixes inputs across a repair boundary.
+///
+/// ## Genuinely-Unparsed inputs fail closed (HIGH-safe, never default an unknown)
+///
+/// A field can still be [`RepairField::Unparsed`] only for a clustering column
+/// whose `AbstractType` this decoder does not model (an exotic / future type whose
+/// fixed-vs-variable length is unknown, so the covered-Slice cannot be skipped).
+/// In that case the field's REAL value is unknown: it could be a pending-repair
+/// session id or a transient flag. We therefore CANNOT prove the inputs share a
+/// repair state, and — critically — we must NOT persist a fabricated `None` /
+/// `false` default derived from an `Unparsed` field (that would silently emit a
+/// real pending-repair / transient SSTable as unrepaired and merge it across a
+/// real boundary, violating AC2/AC3). So any `Unparsed` `pendingRepair` /
+/// `isTransient` on ANY input REJECTS the compaction (fail closed). This never
+/// fires for the supported corpus, where every field decodes authoritatively.
+///
+/// The preserved output state carries the decoded `repairedAt` forward; for
+/// `pendingRepair` / `isTransient`, the single agreed decoded value (all decoded
+/// values agree by the checks above) is written — never a default synthesized
+/// from an `Unparsed` field.
+///
+/// An empty input set returns the unrepaired state (a degenerate compaction
+/// produces an unrepaired output).
+///
+/// # Errors
+///
+/// * any input's repair fields cannot be read/decoded from bytes (fails closed —
+///   a corrupt/truncated `Statistics.db`), or
+/// * any input's `pendingRepair` / `isTransient` is `Unparsed` (an unmodeled
+///   clustering type whose real repair value cannot be proven — fail closed rather
+///   than default an unknown), or
+/// * the inputs disagree on an AUTHORITATIVELY decoded field (mixed `repairedAt`,
+///   or a decoded `pendingRepair`/`isTransient` that another input's decoded state
+///   contradicts) — Cassandra refuses such a compaction, so CQLite rejects it
+///   rather than producing an output that silently merges across the repair
+///   boundary.
+pub fn classify_inputs(input_paths: &[PathBuf]) -> Result<RepairState> {
+    // Authoritative repairedAt: always decoded, always compared.
+    let mut common_repaired_at: Option<i64> = None;
+    // The single agreed decoded pendingRepair / isTransient (all inputs agree by
+    // the checks below). A genuinely-Unparsed field fails closed before reaching
+    // these, so they are only ever populated from authoritative bytes.
+    let mut decoded_pending: Option<Option<[u8; 16]>> = None;
+    let mut decoded_transient: Option<bool> = None;
+
+    for path in input_paths {
+        let fields = read_repair_fields(path)?;
+
+        // repairedAt: authoritative for every format → reject a genuine mismatch.
+        match common_repaired_at {
+            None => common_repaired_at = Some(fields.repaired_at),
+            Some(prev) if prev == fields.repaired_at => {}
+            Some(prev) => {
+                return Err(repair_boundary_error(
+                    path,
+                    &format!("decoded repairedAt {}", fields.repaired_at),
+                    &format!("a prior input's decoded repairedAt {prev}"),
+                ));
+            }
+        }
+
+        // pendingRepair: must be authoritatively decoded. An Unparsed field (an
+        // unmodeled clustering type) has an UNKNOWN real value — we cannot prove
+        // compatibility and must never default it, so fail closed (HIGH-safe,
+        // AC2/AC3). A decoded mismatch is a real repair-boundary rejection.
+        match fields.pending_repair {
+            RepairField::Decoded(v) => match decoded_pending {
+                None => decoded_pending = Some(v),
+                Some(prev) if prev == v => {}
+                Some(prev) => {
+                    return Err(repair_boundary_error(
+                        path,
+                        &format!("decoded pendingRepair {}", describe_pending(&v)),
+                        &format!(
+                            "a prior input's decoded pendingRepair {}",
+                            describe_pending(&prev)
+                        ),
+                    ));
+                }
+            },
+            RepairField::Unparsed => return Err(unparsed_field_error(path, "pendingRepair")),
+        }
+
+        // isTransient: same authoritative-or-fail-closed rule.
+        match fields.is_transient {
+            RepairField::Decoded(v) => match decoded_transient {
+                None => decoded_transient = Some(v),
+                Some(prev) if prev == v => {}
+                Some(prev) => {
+                    return Err(repair_boundary_error(
+                        path,
+                        &format!("decoded isTransient {v}"),
+                        &format!("a prior input's decoded isTransient {prev}"),
+                    ));
+                }
+            },
+            RepairField::Unparsed => return Err(unparsed_field_error(path, "isTransient")),
+        }
+    }
+
+    Ok(RepairState {
+        repaired_at: common_repaired_at.unwrap_or(0),
+        // Every value here was decoded from real bytes (all decoded values agree);
+        // a defaulted-from-Unparsed value can never reach this point.
+        pending_repair: decoded_pending.flatten(),
+        is_transient: decoded_transient.unwrap_or(false),
+    })
+}
+
+/// Build the fail-closed error for an input whose `pendingRepair` / `isTransient`
+/// could not be authoritatively decoded (an unmodeled clustering type). We refuse
+/// to default an unknown repair field, so the compaction is rejected.
+fn unparsed_field_error(path: &Path, field: &str) -> Error {
+    Error::Compaction(format!(
+        "refusing to compact: input {path:?} has a {field} that could not be decoded from its \
+         Statistics.db (its clustering comparator is not modeled, so the covered-clustering \
+         Slice could not be skipped to reach this field). Its real repair value is unknown; \
+         CQLite will not default an unknown repair field to unrepaired (that could silently \
+         merge a pending-repair / transient SSTable across a real repair boundary), so this \
+         compaction is rejected (issue #1021)"
+    ))
+}
+
+/// Render a `pendingRepair` value for an error/diagnostic message.
+fn describe_pending(v: &Option<[u8; 16]>) -> String {
+    match v {
+        Some(u) => uuid_hex(u),
+        None => "--".to_string(),
+    }
+}
+
+/// Build the typed repair-boundary rejection error naming the conflicting,
+/// AUTHORITATIVELY-decoded states.
+fn repair_boundary_error(path: &Path, this: &str, prior: &str) -> Error {
+    Error::Compaction(format!(
+        "refusing to compact across a repair boundary: input {path:?} has {this} but \
+         {prior} — Cassandra partitions compaction candidates by repair state and never \
+         mixes them; CQLite cannot safely reproduce the repair-boundary tombstone \
+         constraints, so this compaction is rejected (issue #1021)"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unrepaired_default_is_zero_none_false() {
+        let s = RepairState::unrepaired();
+        assert_eq!(s.repaired_at, 0);
+        assert_eq!(s.pending_repair, None);
+        assert!(!s.is_transient);
+    }
+
+    #[test]
+    fn equal_states_are_compatible() {
+        let a = RepairState {
+            repaired_at: 123,
+            pending_repair: None,
+            is_transient: false,
+        };
+        let b = a;
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn differing_repaired_at_is_incompatible() {
+        let a = RepairState::unrepaired();
+        let b = RepairState {
+            repaired_at: 999,
+            pending_repair: None,
+            is_transient: false,
+        };
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn describe_classifies_kind() {
+        assert!(RepairState::unrepaired()
+            .describe()
+            .starts_with("unrepaired"));
+        assert!(RepairState {
+            repaired_at: 5,
+            pending_repair: None,
+            is_transient: false,
+        }
+        .describe()
+        .starts_with("repaired"));
+        assert!(RepairState {
+            repaired_at: 0,
+            pending_repair: Some([0xab; 16]),
+            is_transient: false,
+        }
+        .describe()
+        .starts_with("pending-repair"));
+    }
+
+    #[test]
+    fn empty_inputs_classify_unrepaired() {
+        let state = classify_inputs(&[]).expect("empty inputs");
+        assert_eq!(state, RepairState::unrepaired());
+    }
+}

--- a/cqlite-core/tests/issue_1021_repaired_metadata_compaction_parity.rs
+++ b/cqlite-core/tests/issue_1021_repaired_metadata_compaction_parity.rs
@@ -1,0 +1,495 @@
+//! Repair-metadata compaction parity (issue #1021, parent epic #973).
+//!
+//! Proves CQLite PRESERVES the persisted repair state (`repairedAt`,
+//! `pendingRepair`, `isTransient`) through compaction when the inputs are
+//! COMPATIBLE (same repair state), and REJECTS a compaction that mixes
+//! repaired / unrepaired / pending-repair inputs — Apache Cassandra partitions
+//! compaction candidates by repair state and never mixes them in one compaction
+//! (the `CompactionTaskTest` reject-mixed-repair-state expectation). CQLite
+//! cannot reproduce Cassandra's repair-boundary tombstone constraints, so a
+//! mixed set is rejected with a typed error rather than silently merged.
+//!
+//! Fixtures: the published Cassandra 5.0 corpus contains NO repaired /
+//! pending-repair / transient SSTable (every fixture is unrepaired; producing a
+//! repaired fixture requires a live cluster + `nodetool repair` /
+//! `sstablerepairedset` / anticompaction, which this environment lacks — see the
+//! manifest `partial` reason). These tests therefore CONSTRUCT input SSTables
+//! with controlled repair states via the real `SSTableWriter`
+//! (`set_repair_state`), which is the same byte-level mechanism the compaction
+//! merge path uses to carry repair metadata forward. This is provable,
+//! non-fabricated coverage of the repaired / pending / transient DISTINCT
+//! states. The read-side decode is validated against the real corpus by
+//! `sstable_parity_repaired_metadata_test`.
+//!
+//! SCOPE: parse + preserve + classify + reject ONLY. Nothing here establishes
+//! repair-aware tombstone purging (a separate correctness concern).
+
+#![cfg(feature = "write-support")]
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use cqlite_core::parser::repair_metadata::{parse_repair_metadata, RepairField};
+use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+use cqlite_core::storage::sstable::version_gate::{BigVersionGates, VersionGates};
+use cqlite_core::storage::sstable::writer::SSTableWriter;
+use cqlite_core::storage::write_engine::merge::{classify_inputs, compact_sstables, RepairState};
+use cqlite_core::storage::write_engine::{CellOperation, Mutation, PartitionKey, TableId};
+use cqlite_core::types::Value;
+use tempfile::TempDir;
+
+/// Minimal single-partition-key, no-clustering schema so the compaction output's
+/// covered-clustering Slice is empty and the full repair-state walk succeeds on
+/// the output (issue #1021 read-path note).
+fn schema() -> TableSchema {
+    TableSchema {
+        keyspace: "repair_ks".to_string(),
+        table: "items".to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            Column {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "name".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+fn write_row(id: i32, name: &str, ts: i64) -> Mutation {
+    Mutation::new(
+        TableId::new("repair_ks", "items"),
+        PartitionKey::single("id", Value::Integer(id)),
+        None,
+        vec![CellOperation::Write {
+            column: "name".to_string(),
+            value: Value::Text(name.to_string()),
+        }],
+        ts,
+        None,
+    )
+}
+
+/// Write a single `nb`-format input SSTable carrying the given partitions and a
+/// chosen repair state. Returns the published `Data.db` path.
+fn write_input(
+    dir: &Path,
+    generation: u64,
+    rows: &[(i32, &str, i64)],
+    repaired_at: i64,
+    pending_repair: Option<[u8; 16]>,
+    is_transient: bool,
+) -> PathBuf {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    let s = schema();
+    let mut writer = SSTableWriter::new(dir.to_path_buf(), generation, &s).expect("writer");
+    writer.set_repair_state(repaired_at, pending_repair, is_transient);
+
+    for &(id, name, ts) in rows {
+        let m = write_row(id, name, ts);
+        let key = m.decorated_key(&s).expect("decorated key");
+        writer
+            .write_partition(key, vec![m])
+            .expect("write partition");
+    }
+    let info = rt.block_on(writer.finish()).expect("finish");
+    info.data_path
+}
+
+fn nb_gates() -> VersionGates {
+    VersionGates::Big(BigVersionGates::from_version("nb").expect("nb gates"))
+}
+
+/// Decode the persisted repair state of a published SSTable from its
+/// `Statistics.db` sibling, using the full version-gated walk.
+fn decode_output_repair_state(
+    data_path: &Path,
+) -> (i64, RepairField<Option<[u8; 16]>>, RepairField<bool>) {
+    let name = data_path.file_name().and_then(|n| n.to_str()).unwrap();
+    let stats = data_path.with_file_name(name.replace("Data.db", "Statistics.db"));
+    let bytes = std::fs::read(&stats).expect("read output Statistics.db");
+    let md = parse_repair_metadata(&bytes, Some(&nb_gates())).expect("decode output repair state");
+    (md.repaired_at, md.pending_repair, md.is_transient)
+}
+
+/// AC2: compacting COMPATIBLE inputs (identical repair state) preserves the
+/// repairedAt / pendingRepair / isTransient into the merged output Statistics.db.
+#[test]
+fn compaction_preserves_shared_repaired_state() {
+    let temp = TempDir::new().expect("tempdir");
+    let in_dir = temp.path().join("inputs");
+    let out_dir = temp.path().join("out");
+    std::fs::create_dir_all(&in_dir).unwrap();
+
+    let repaired_at: i64 = 1_700_000_000_000;
+    let pending: [u8; 16] = [
+        0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x10, 0x32, 0x54, 0x76, 0x98, 0xba, 0xdc,
+        0xfe,
+    ];
+
+    // Two inputs in the SAME repair state (repaired + pending + transient).
+    let a = write_input(
+        &in_dir.join("a"),
+        1,
+        &[(1, "a-1", 100), (2, "a-2", 100)],
+        repaired_at,
+        Some(pending),
+        true,
+    );
+    let b = write_input(
+        &in_dir.join("b"),
+        2,
+        &[(1, "b-1", 200), (3, "b-3", 200)],
+        repaired_at,
+        Some(pending),
+        true,
+    );
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    let report = rt
+        .block_on(compact_sstables(
+            vec![b, a],
+            &out_dir,
+            &schema(),
+            10,
+            None,
+            None,
+            true,
+        ))
+        .expect("compaction of compatible inputs must succeed");
+
+    let (out_repaired, out_pending, out_transient) =
+        decode_output_repair_state(&report.output.data_path);
+    assert_eq!(
+        out_repaired, repaired_at,
+        "merged output must preserve repairedAt"
+    );
+    assert_eq!(
+        out_pending,
+        RepairField::Decoded(Some(pending)),
+        "merged output must preserve the pendingRepair UUID"
+    );
+    assert_eq!(
+        out_transient,
+        RepairField::Decoded(true),
+        "merged output must preserve isTransient"
+    );
+}
+
+/// AC2 (unrepaired baseline): two unrepaired inputs compact to an unrepaired
+/// output (the common corpus case — preservation is a no-op vs the previous
+/// hardcoded zeros, but proven end-to-end).
+#[test]
+fn compaction_preserves_unrepaired_state() {
+    let temp = TempDir::new().expect("tempdir");
+    let in_dir = temp.path().join("inputs");
+    let out_dir = temp.path().join("out");
+    std::fs::create_dir_all(&in_dir).unwrap();
+
+    let a = write_input(&in_dir.join("a"), 1, &[(1, "a-1", 100)], 0, None, false);
+    let b = write_input(&in_dir.join("b"), 2, &[(2, "b-2", 200)], 0, None, false);
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    let report = rt
+        .block_on(compact_sstables(
+            vec![b, a],
+            &out_dir,
+            &schema(),
+            10,
+            None,
+            None,
+            true,
+        ))
+        .expect("compaction of unrepaired inputs must succeed");
+
+    let (out_repaired, out_pending, out_transient) =
+        decode_output_repair_state(&report.output.data_path);
+    assert_eq!(out_repaired, 0);
+    assert_eq!(out_pending, RepairField::Decoded(None));
+    assert_eq!(out_transient, RepairField::Decoded(false));
+}
+
+/// AC3: a compaction mixing repaired and unrepaired inputs is REJECTED with a
+/// typed error — never silently merged.
+#[test]
+fn compaction_rejects_mixed_repaired_unrepaired() {
+    let temp = TempDir::new().expect("tempdir");
+    let in_dir = temp.path().join("inputs");
+    let out_dir = temp.path().join("out");
+    std::fs::create_dir_all(&in_dir).unwrap();
+
+    // One repaired input, one unrepaired input → mixed.
+    let repaired = write_input(
+        &in_dir.join("a"),
+        1,
+        &[(1, "a-1", 100)],
+        1_700_000_000_000,
+        None,
+        false,
+    );
+    let unrepaired = write_input(&in_dir.join("b"), 2, &[(2, "b-2", 200)], 0, None, false);
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    let result = rt.block_on(compact_sstables(
+        vec![unrepaired, repaired],
+        &out_dir,
+        &schema(),
+        10,
+        None,
+        None,
+        true,
+    ));
+
+    let err = result.expect_err("mixed repaired/unrepaired compaction must be rejected");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("repair boundary"),
+        "rejection error must name the repair boundary, got: {msg}"
+    );
+
+    // No output SSTable must have been published.
+    let published_outputs = std::fs::read_dir(&out_dir)
+        .map(|rd| rd.flatten().count())
+        .unwrap_or(0);
+    assert_eq!(
+        published_outputs, 0,
+        "a rejected mixed-state compaction must not publish any output"
+    );
+}
+
+/// AC3 (pending-repair boundary): inputs that disagree on `pendingRepair` are
+/// also rejected (a pending-repair input must not merge with a non-pending one).
+#[test]
+fn compaction_rejects_mixed_pending_repair() {
+    let temp = TempDir::new().expect("tempdir");
+    let in_dir = temp.path().join("inputs");
+    let out_dir = temp.path().join("out");
+    std::fs::create_dir_all(&in_dir).unwrap();
+
+    let pending = write_input(
+        &in_dir.join("a"),
+        1,
+        &[(1, "a-1", 100)],
+        0,
+        Some([0x42; 16]),
+        false,
+    );
+    let no_pending = write_input(&in_dir.join("b"), 2, &[(2, "b-2", 200)], 0, None, false);
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    let result = rt.block_on(compact_sstables(
+        vec![no_pending, pending],
+        &out_dir,
+        &schema(),
+        10,
+        None,
+        None,
+        true,
+    ));
+    assert!(
+        result.is_err(),
+        "a pending-repair input must not compact with a non-pending input"
+    );
+}
+
+/// AC3 (classifier unit): `classify_inputs` returns the shared state for
+/// compatible inputs and an error for a mixed set, independent of the merge
+/// machinery.
+#[test]
+fn classify_inputs_returns_shared_or_rejects() {
+    let temp = TempDir::new().expect("tempdir");
+    let in_dir = temp.path().join("inputs");
+    std::fs::create_dir_all(&in_dir).unwrap();
+
+    let a = write_input(&in_dir.join("a"), 1, &[(1, "a-1", 100)], 500, None, false);
+    let b = write_input(&in_dir.join("b"), 2, &[(2, "b-2", 200)], 500, None, false);
+    let c = write_input(&in_dir.join("c"), 3, &[(3, "c-3", 300)], 0, None, false);
+
+    // Compatible (a, b): shared repairedAt = 500.
+    let shared = classify_inputs(&[a.clone(), b.clone()]).expect("compatible classify");
+    assert_eq!(
+        shared,
+        RepairState {
+            repaired_at: 500,
+            pending_repair: None,
+            is_transient: false,
+        }
+    );
+
+    // Mixed (a, c): rejected.
+    assert!(
+        classify_inputs(&[a, c]).is_err(),
+        "mixed repairedAt must be rejected by classify_inputs"
+    );
+}
+
+/// Resolve the committed datasets root (env override first, else workspace tree).
+fn datasets_sstables_root() -> PathBuf {
+    let root = if let Ok(root) = std::env::var("CQLITE_DATASETS_ROOT") {
+        PathBuf::from(root)
+    } else {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .map(|workspace| workspace.join("test-data/datasets"))
+            .unwrap_or_else(|| PathBuf::from("test-data/datasets"))
+    };
+    root.join("sstables")
+}
+
+/// Derive the `Statistics.db` sibling path from a `Data.db` path.
+fn stats_sibling(data: &Path) -> PathBuf {
+    let name = data.file_name().and_then(|n| n.to_str()).unwrap();
+    data.with_file_name(name.replace("Data.db", "Statistics.db"))
+}
+
+/// Authoritatively decode a real clustered SSTable's repair fields from its
+/// `Statistics.db`. Returns the full `RepairMetadata` so the caller can assert on
+/// the `Decoded` vs `Unparsed` distinction directly.
+fn decode_real_repair(data: &Path) -> Option<cqlite_core::parser::repair_metadata::RepairMetadata> {
+    let stats = stats_sibling(data);
+    let bytes = std::fs::read(&stats).ok()?;
+    let gates = VersionGates::from_path(&stats).ok()?;
+    parse_repair_metadata(&bytes, Some(&gates)).ok()
+}
+
+/// REGRESSION + AC2/AC3 (issue #1021, HIGH finding resolved): for clustered
+/// `oa`/`da` SSTables the full version-gated walk now skips PAST the
+/// `improvedMinMax` covered-clustering `Slice` by resolving each clustering
+/// column's `valueLengthIfFixed()` from the persisted `clusteringTypes` and
+/// mirroring Cassandra's `ClusteringBoundOrBoundary.Serializer.skipValues`. So
+/// `pendingRepair` / `isTransient` are now decoded AUTHORITATIVELY (from real
+/// bytes) instead of reported as `Unparsed`.
+///
+/// This drives off the REAL corpus: the `test_oa` `static_table` /
+/// `tombstone_table` fixtures (clustered, non-empty covered-clustering Slice) must
+/// now report `pendingRepair = Decoded(None)` and `isTransient = Decoded(false)`
+/// — the genuine unrepaired state proven from bytes. `classify_inputs` must
+/// SUCCEED on a set of such inputs and PRESERVE the (unrepaired) repair state,
+/// keying off the authoritatively decoded fields (NOT defaulting an unknown).
+///
+/// Skip-on-absence (datasets not fetched) but fail-on-present-wrong: if a real
+/// clustered fixture is on disk, the fields MUST decode and classification MUST
+/// succeed with the authoritative unrepaired state.
+#[test]
+fn classify_inputs_decodes_clustered_oa_repair_fields_authoritatively() {
+    let root = datasets_sstables_root();
+    // Real clustered oa/da fixtures whose covered-clustering Slice is non-empty:
+    // before #1021's type-aware skip these decoded pendingRepair/isTransient as
+    // Unparsed; they must now decode authoritatively.
+    let candidates = [
+        root.join("test_oa/static_table-4bba006064e711f1bd3ac7dbf655c673/oa-2-big-Data.db"),
+        root.join("test_oa/tombstone_table-4bc746d064e711f1bd3ac7dbf655c673/oa-2-big-Data.db"),
+        root.join("test_da/simple_table-de1be8b064e711f19ad401a8c8227b11/da-2-bti-Data.db"),
+    ];
+
+    let present: Vec<PathBuf> = candidates.iter().filter(|p| p.exists()).cloned().collect();
+
+    if present.is_empty() {
+        eprintln!(
+            "classify_inputs_decodes_clustered_oa_repair_fields_authoritatively: SKIP — \
+             no clustered Data.db fixtures fetched under {}",
+            root.display()
+        );
+        return;
+    }
+
+    // The fields must now DECODE (not be Unparsed) and decode to the genuine
+    // unrepaired state. Fail-on-present-wrong: a clustered fixture that still
+    // reports Unparsed would mean the type-aware skip failed to traverse it.
+    for data in &present {
+        let md = decode_real_repair(data)
+            .unwrap_or_else(|| panic!("{}: repair metadata must decode", data.display()));
+        assert_eq!(
+            md.pending_repair,
+            RepairField::Decoded(None),
+            "{}: clustered SSTable pendingRepair must now decode authoritatively (None) \
+             via the type-aware covered-Slice skip, not be reported Unparsed",
+            data.display()
+        );
+        assert_eq!(
+            md.is_transient,
+            RepairField::Decoded(false),
+            "{}: clustered SSTable isTransient must now decode authoritatively (false)",
+            data.display()
+        );
+        assert_eq!(
+            md.repaired_at,
+            0,
+            "{}: corpus is unrepaired",
+            data.display()
+        );
+    }
+
+    // Single-input classification: must succeed and report the authoritatively
+    // decoded unrepaired state.
+    for data in &present {
+        let state = classify_inputs(std::slice::from_ref(data)).unwrap_or_else(|e| {
+            panic!(
+                "{}: classify_inputs must SUCCEED for a valid clustered SSTable whose \
+                 repair fields now decode authoritatively (issue #1021), got: {e}",
+                data.display()
+            )
+        });
+        assert_eq!(
+            state,
+            RepairState {
+                repaired_at: 0,
+                pending_repair: None,
+                is_transient: false,
+            },
+            "{}: a valid unrepaired clustered SSTable must classify as the unrepaired state",
+            data.display()
+        );
+    }
+
+    // Multi-input common case: two same-state inputs classify as compatible and
+    // return the shared (authoritatively decoded) unrepaired state.
+    if present.len() >= 2 {
+        let shared = classify_inputs(&present).unwrap_or_else(|e| {
+            panic!(
+                "classify_inputs must SUCCEED for valid same-state clustered SSTables \
+                 (issue #1021), got: {e}"
+            )
+        });
+        assert_eq!(
+            shared,
+            RepairState {
+                repaired_at: 0,
+                pending_repair: None,
+                is_transient: false,
+            },
+            "valid unrepaired clustered SSTables must classify as the shared unrepaired state"
+        );
+    }
+}

--- a/cqlite-core/tests/sstable_parity_repaired_metadata_test.rs
+++ b/cqlite-core/tests/sstable_parity_repaired_metadata_test.rs
@@ -102,6 +102,15 @@ fn all_statistics_txt() -> Vec<PathBuf> {
     out
 }
 
+/// Lower-hex of a raw 16-byte UUID, for failure messages.
+fn hex(uuid: &[u8; 16]) -> String {
+    let mut s = String::with_capacity(32);
+    for b in uuid {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
 /// Derive the binary `*-Statistics.db` path from its `*-Statistics.db.txt` dump.
 fn binary_for(txt: &Path) -> PathBuf {
     let name = txt
@@ -247,39 +256,45 @@ fn repaired_metadata_strict_parity() {
             reference.repaired_at,
         );
 
-        // pendingRepair / isTransient: this module does NOT walk these fields,
-        // so the read path must report them honestly as `Unparsed` rather than a
-        // fabricated null / false. The authoritative reference confirms the
-        // corpus is in the null / non-transient state, but CQLite does not CLAIM
-        // to have decoded that — it reports `Unparsed` (no silent misreport).
+        // pendingRepair / isTransient: with authoritative version gates the read
+        // path performs the version-gated walk (issue #1021). The walk decodes
+        // these two fields FROM REAL BYTES whenever it can safely traverse the
+        // min/max-clustering block — always for the legacy (`nb`) layout, and for
+        // the improved (`oa`/`da`) layout only when the covered-clustering Slice
+        // is empty (no clustering values). When the improved Slice carries
+        // comparator-encoded values this decoder does not model, the walk stops
+        // and reports the two fields honestly as `Unparsed`.
+        //
+        // So the valid outcomes are: the reference value DECODED, or `Unparsed`.
+        // A fabricated NON-reference decoded value (e.g. a pending UUID or
+        // isTransient=true when the reference is null/false) must FAIL.
         assert!(
             reference.pending_repair_is_null,
-            "{}: reference Pending repair is NOT null; extend the lane (and the \
-             decoder) before adding pending-repair fixtures",
+            "{}: reference Pending repair is NOT null — the corpus is expected \
+             unrepaired; extend the lane before adding pending-repair fixtures",
             db.display(),
         );
-        assert_eq!(
-            decoded.pending_repair,
-            RepairField::Unparsed,
-            "{}: pendingRepair must be reported as Unparsed (not a fabricated \
-             value), got {:?}",
-            db.display(),
-            decoded.pending_repair,
-        );
-        assert!(
-            !reference.is_transient,
-            "{}: reference IsTransient is NOT false; extend the lane (and the \
-             decoder) before adding transient fixtures",
-            db.display(),
-        );
-        assert_eq!(
-            decoded.is_transient,
-            RepairField::Unparsed,
-            "{}: isTransient must be reported as Unparsed (not a fabricated \
-             value), got {:?}",
-            db.display(),
-            decoded.is_transient,
-        );
+        match decoded.pending_repair {
+            RepairField::Unparsed => {}
+            RepairField::Decoded(None) => {} // matches reference null
+            RepairField::Decoded(Some(uuid)) => panic!(
+                "{}: pendingRepair decoded a UUID {} but reference is null (--) — \
+                 a fabricated/mis-decoded value",
+                db.display(),
+                hex(&uuid),
+            ),
+        }
+        match decoded.is_transient {
+            RepairField::Unparsed => {}
+            RepairField::Decoded(v) => assert_eq!(
+                v,
+                reference.is_transient,
+                "{}: isTransient decoded {} but reference is {}",
+                db.display(),
+                v,
+                reference.is_transient,
+            ),
+        }
 
         // Idempotent re-decode: the read-side metadata API is stable across
         // repeated reads of the same bytes (read -> report preservation).
@@ -487,14 +502,94 @@ fn repaired_metadata_writer_roundtrip_preserves_unrepaired_state() {
         RepairMetadata {
             repaired_at: 0,
             // The writer's persisted null / false state is NOT walked by the
-            // read path, so it is reported honestly as Unparsed rather than a
-            // fabricated decoded value.
+            // read path WITHOUT gates, so it is reported honestly as Unparsed
+            // rather than a fabricated decoded value.
             pending_repair: RepairField::Unparsed,
             is_transient: RepairField::Unparsed,
             repaired_at_decoded: true,
         },
         "writer-persisted unrepaired repair state must round-trip field-exact \
          (repairedAt decoded; pending_repair / is_transient reported as Unparsed)"
+    );
+
+    // With authoritative nb gates the full walk decodes the writer's persisted
+    // null / false state from real bytes (issue #1021).
+    let gates = VersionGates::Big(
+        cqlite_core::storage::sstable::version_gate::BigVersionGates::from_version("nb")
+            .expect("nb gates"),
+    );
+    let decoded_full =
+        parse_repair_metadata(&written, Some(&gates)).expect("decode written repair metadata");
+    assert_eq!(
+        decoded_full,
+        RepairMetadata {
+            repaired_at: 0,
+            pending_repair: RepairField::Decoded(None),
+            is_transient: RepairField::Decoded(false),
+            repaired_at_decoded: true,
+        },
+        "writer-persisted unrepaired state must decode null / false through the \
+         full version-gated walk"
+    );
+
+    let _ = std::fs::remove_file(&stats_path);
+}
+
+/// Compaction-preservation round-trip (issue #1021 AC2): a `StatisticsMetadata`
+/// carrying a NON-default repair state (repairedAt != 0, a pendingRepair UUID,
+/// isTransient = true — the state the compaction merge path preserves from
+/// compatible inputs) is written by the real Statistics.db writer and decoded
+/// back through the full version-gated read walk field-exact.
+///
+/// This proves the writer→read repair-state round-trip for the repaired /
+/// pending / transient DISTINCT states for which the Cassandra 5.0 corpus has NO
+/// fixture (so this is the provable, honest coverage of those states), and it is
+/// the byte-level mechanism the compaction output relies on to carry repair
+/// metadata forward.
+#[cfg(feature = "write-support")]
+#[test]
+fn repaired_state_writer_roundtrip_preserves_repaired_pending_transient() {
+    use cqlite_core::storage::sstable::writer::{StatisticsMetadata, StatisticsWriter};
+
+    let dir = std::env::temp_dir().join("cqlite-1021-repaired-preserve");
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    let stats_path = dir.join("nb-1-big-Statistics.db");
+
+    let repaired_at: i64 = 1_700_000_000_000;
+    let pending_uuid: [u8; 16] = [
+        0x9a, 0x1b, 0x2c, 0x3d, 0x4e, 0x5f, 0x60, 0x71, 0x82, 0x93, 0xa4, 0xb5, 0xc6, 0xd7, 0xe8,
+        0xf9,
+    ];
+
+    let mut meta = StatisticsMetadata::new();
+    meta.update_timestamp(1_000_000);
+    meta.update_timestamp(2_000_000);
+    meta.increment_partition_count();
+    meta.row_count = 3;
+    meta.set_repair_state(repaired_at, Some(pending_uuid), true);
+
+    let writer = StatisticsWriter::new(stats_path.clone());
+    writer.write(&meta, None).expect("write Statistics.db");
+
+    let written = std::fs::read(&stats_path).expect("read written Statistics.db");
+
+    let gates = VersionGates::Big(
+        cqlite_core::storage::sstable::version_gate::BigVersionGates::from_version("nb")
+            .expect("nb gates"),
+    );
+    let decoded =
+        parse_repair_metadata(&written, Some(&gates)).expect("decode preserved repair state");
+
+    assert_eq!(
+        decoded,
+        RepairMetadata {
+            repaired_at,
+            pending_repair: RepairField::Decoded(Some(pending_uuid)),
+            is_transient: RepairField::Decoded(true),
+            repaired_at_decoded: true,
+        },
+        "the writer must preserve a non-default repair state (repairedAt / \
+         pendingRepair UUID / isTransient) byte-exact through a write→read round-trip"
     );
 
     let _ = std::fs::remove_file(&stats_path);

--- a/docs/reports/cassandra-test-parity.md
+++ b/docs/reports/cassandra-test-parity.md
@@ -10,20 +10,20 @@ Sources: [`docs/cassandra_test_index.md`](../../docs/cassandra_test_index.md) ·
 
 | Status | Scenarios |
 |---|---|
-| `mirrored` | 207 |
-| `partial` | 15 |
+| `mirrored` | 210 |
+| `partial` | 17 |
 | `planned` | 18 |
 | `out_of_scope` | 14 |
-| **total** | **254** |
+| **total** | **259** |
 
 ## Evidence counts
 
 | Evidence | Scenarios |
 |---|---|
 | `byte_for_byte` | 113 |
-| `canonical_semantic` | 93 |
+| `canonical_semantic` | 96 |
 | `smoke` | 7 |
-| `partial` | 25 |
+| `partial` | 27 |
 | `out_of_scope` | 16 |
 
 ## ⚠️ P0 scenarios with weak evidence
@@ -60,6 +60,7 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 | `cass.compaction.CompactionIteratorTest.differential_compaction_loop` | compaction_merge | mirrored | canonical_semantic | `compaction_parity_tombstone_ttl` | p0_data_loss |
 | `cass.compaction.CompactionIteratorTest.live_partition_merge` | compaction_merge | mirrored | canonical_semantic | `compaction_parity_tombstone_ttl` | p0_data_loss |
 | `cass.compaction.CompactionSimpleValueMergeTest.static_row_merge` | compaction_merge | mirrored | canonical_semantic | `compaction_parity_tombstone_ttl` | p1_correctness |
+| `cass.compaction.CompactionTaskTest.reject_mixed_repair_state` | compaction_merge | mirrored | canonical_semantic | `compaction_parity_tombstone_ttl` | p1_correctness |
 | `cass.compaction.GcCompactionTest.static_and_complex_columns_survive_gc` | compaction_merge | mirrored | canonical_semantic | `compaction_parity_tombstone_ttl` | p0_data_loss |
 | `cass.compaction.LongCompactionsTest.live_rows_lww_overlap` | compaction_merge | mirrored | canonical_semantic | `compaction_parity_tombstone_ttl` | p0_data_loss |
 | `cass.compaction.SSTableRewriterTest.output_component_integrity` | compaction_merge | planned | byte_for_byte | `compaction_parity_tombstone_ttl` | p0_data_loss |
@@ -398,6 +399,8 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
   - Normalization: Cassandra-test-class perspective cross-referencing the byte-level claim cass.compaction.live_cells_no_clustering. The JSONL golden pins the single-output constraint and LWW survivors semantically. Byte-level component verification is covered by the real byte_for_byte claim.
 - `cass.compaction.CompactionSimpleValueMergeTest.static_row_merge` — Static row survives compaction with a Cassandra-compatible static prelude
   - Normalization: Static-cell presence + static kind are read back via KWayMerger and the output Statistics.db static-column set is decoded byte-derived; layout ignored.
+- `cass.compaction.CompactionTaskTest.reject_mixed_repair_state` — Compaction rejects a mixed repaired / unrepaired / pending-repair input set
+  - Normalization: The rejection is asserted behaviorally: a mixed-state compaction returns a typed repair-boundary error and publishes zero output components; a same-state compaction succeeds. (Cassandra's candidate partitioning is not byte-comparable; the constraint — never merge across the boundary — is.)
 - `cass.compaction.GcCompactionTest.static_and_complex_columns_survive_gc` — Static and non-frozen-collection columns survive a GC compaction by cell identity
   - Normalization: Per-element complex cells are read back via the compaction KWayMerger and the full (column, cell_path, ts, ttl, ldt, is_deleted) substrate is compared input-vs-output; the input is genuine Cassandra output so this is a faithful round-trip against the on-disk layout.
 - `cass.compaction.LongCompactionsTest.live_rows_lww_overlap` — Live-row last-write-wins overlap compaction byte parity (partition-key-only)
@@ -422,6 +425,8 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
   - Normalization: After compaction purges expired clustered-row tombstones, the live static row must survive; the post-compaction static_block liveness is compared against Cassandra compaction semantics.
 - `cass.compaction_merge.tombstone_ttl_shadowing` — Compaction tombstone/TTL shadowing — canonical semantic parity
   - Normalization: Tier-2 logical equivalence: merged partition/cell/timestamp/TTL/local deletion time/is_deleted facts compared against Cassandra compaction output; presentation/file layout ignored.
+- `cass.compaction_parity.statistics.repaired_metadata_preserve` — Compaction preserves the shared repair state of compatible inputs into the output Statistics.db
+  - Normalization: The output Statistics.db repair fields are decoded byte-derived through the full version-gated read walk and compared field-exact to the inputs' shared repair state.
 - `cass.compression.registry.known_deflate` — Compressor registry resolves Deflate by Cassandra class name
   - Normalization: The DeflateCompressor class name resolves to the CQLite zlib decoder; the resolved decoder decodes rows compared against the sstabledump JSONL.
 - `cass.compression.registry.known_lz4` — Compressor registry resolves LZ4 by Cassandra class name
@@ -509,6 +514,8 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
   - Normalization: Planned: scan_delta facts over a wide partition (many clustered rows + range/cell tombstones in one partition, exercising index-block skipping) compared to the sstabledump JSONL golden.
 - `cass.index_summary.big_index_offsets` — Index.db partition key digests and data offsets (BIG)
   - Normalization: Partition key digests and Data.db offsets resolved through Index.db are compared against the partition order and keys derived from sstabledump JSONL.
+- `cass.repair.RepairedDataInfoTest.repaired_metadata_roundtrip` — repairedAt / pendingRepair / isTransient round-trip through the Statistics.db read+write path
+  - Normalization: Each repair field decoded byte-derived from the STATS component is compared to the authoritative sstablemetadata reference line (Repaired at:, Pending repair:, IsTransient:); the non-default repaired/pending/transient state is covered by a writer write->read round-trip (the corpus has no such fixture).
 - `cass.schema_evolution.dropped_column.per_cell_purge` — Dropped regular column per-cell purge parity
   - Normalization: Cells for a dropped regular column are purged per-cell on read; the surviving cells and the dropped-column metadata in the SerializationHeader are mapped to the sstabledump JSONL and Statistics.db dump and compared.
 - `cass.schema_evolution.issue_847_dropped_column_filter` — Dropped-column cells purged by per-cell timestamp and stripped from the output header
@@ -614,6 +621,7 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 - `cass.index_db.promoted_index.index_info_offsets` (partial): Byte-level promoted-index parity (Index.db offsets, widths, clustering bounds) runs only against local-only binaries that are not in the pinned CI dataset; the required lane enforces only the committed-JSONL canonical-semantic facts. → _Add the test_big.wide_partition binaries to the dataset release pin (regenerate the tarball + update DATASET_SHA256) to promote these scenarios to byte_for_byte enforced in the required_parity lane._
 - `cass.index_db.promoted_index.range_tombstone_boundary_at_block_edge` (partial): Byte-level promoted-index parity (Index.db offsets, widths, clustering bounds) runs only against local-only binaries that are not in the pinned CI dataset; the required lane enforces only the committed-JSONL canonical-semantic facts. → _Add the test_big.wide_partition binaries to the dataset release pin (regenerate the tarball + update DATASET_SHA256) to promote these scenarios to byte_for_byte enforced in the required_parity lane._
 - `cass.index_summary.column_index.range_tombstone_boundary_big_bti` (partial): BTI (da) range-tombstone-at-block-edge fixtures are not yet generated (no da tombstone generator). → _Add a da/BTI wide-partition range-tombstone fixture generator and assert BTI column-index boundary parity; file a follow-up issue._
+- `cass.repair.PendingAntiCompactionTest.pending_repair_metadata` (partial): No SSTable carrying a real pendingRepair session UUID exists in the corpus; such a file is produced only by an in-flight incremental repair / PendingAntiCompaction on a live cluster. The UUID parse/preserve/reject path is proven via synthetic bytes + a writer round-trip. → _Commission a live-cluster PendingAntiCompaction fixture (an SSTable with a real pendingRepair UUID) + sstablemetadata goldens, then assert the decoded UUID against the reference to promote to mirrored._
 - `cass.repaired_metadata.statistics_db.pending_repair_uuid` (planned): No Cassandra 5.0 pending-repair fixture available; the reference null (`Pending repair: --`) state is confirmed, and the read path reports the field as Unparsed (it is not walked from bytes) rather than a fabricated absent value. → _When a pending-repair fixture is generated, decode the pendingRepair UUID (type-aware skip past improvedMinMax + commitLogIntervals) — promoting the field from RepairField::Unparsed to Decoded — and assert it byte-for-byte against the `Pending repair: <uuid>` reference line._
 - `cass.repaired_metadata.statistics_db.transient_repair_flag` (planned): No transiently-replicated fixture available; the reference `IsTransient: false` state is confirmed, and the read path reports the field as Unparsed (it is not walked from bytes) rather than a fabricated `false`. → _When a transient-replication fixture is generated, decode the isTransient flag (after the version-gated improvedMinMax block and commitLogIntervals) — promoting it from RepairField::Unparsed to Decoded — and assert it byte-for-byte against the `IsTransient: true` reference line._
 - `cass.schema_evolution.dropped_column.empty_index_block_reverse_scan` (partial): A wide dropped-column empty-index-block reverse-scan fixture is not yet generated. → _Generate a wide dropped-column fixture that yields an empty index block under reverse scan and assert parity; file a follow-up issue._
@@ -622,6 +630,7 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 - `cass.statistics_db.clustering_key_bounds` (planned): Covered-clustering min/max bounds not yet decoded from the STATS component. → _Decode the STATS-section clustering bounds and compare against the "Covered clusterings" reference line._
 - `cass.statistics_db.histograms_and_estimates` (planned): STATS-section histograms and partition/row estimates not yet decoded. → _Decode the STATS-section EstimatedHistograms and count estimates and compare bucket boundaries against the reference dump._
 - `cass.summary_db.IndexSummaryRedistributionTest.downsampled_summary_entries` (planned): No downsampled (sampling_level < 128) Summary.db fixture exists. → _Publish a redistributed Summary.db fixture and extend the strict suite to assert downsampled offset tables and size_at_full_sampling > entry count._
+- `cass.tombstone_ttl.RepairedDataTombstonesTest.repair_metadata_gates_purge` (partial): Repair-aware tombstone purge gating is unimplemented (and out of scope for #1021); only the parse/preserve/reject-mixed prerequisite exists. No real repaired fixture exists in the corpus (the published Cassandra 5.0 datasets are all unrepaired; a repaired SSTable requires a live cluster + nodetool repair / anticompaction). → _File a follow-up to (1) commission a live-cluster repaired+unrepaired fixture with a cross-repair-boundary shadowing tombstone (nodetool repair / sstablerepairedset + sstabledump/sstablemetadata goldens), and (2) implement + test repair-aware tombstone purge gating against it._
 - `cass.tombstone_ttl.range_tombstone_boundaries` (partial): test_deltas dataset asset not published/enforced in CI (#701). → _Publish the test_deltas dataset and enforce scan_delta parity in CI._
 - `cass.tombstone_ttl.repaired_unrepaired_purge_gate` (partial): repairedAt / pendingRepair parsing is not implemented (gated on #968/#988), so the repaired-vs-unrepaired purge gate is only partially exercised. → _Parse repairedAt / pendingRepair from Statistics.db and gate purge on repair status (#968/#988)._
 - `cass.write_load_path.flush.tombstone_and_ttl_artifacts` (partial): The static-row writer gap (row-level HAS_TIMESTAMP / PK liveness wrongly set on a static-only UPDATE) is now RESOLVED (issue #1196): CQLite emits the static block byte-identical to Cassandra (flags 0xa0, static cell carries its own explicit timestamp), verified file-vs-file against the committed test_writeparity.static_clustering_shape reference. Whole-artifact byte parity for the broader tombstone/TTL shape REMAINS blocked by wall-clock-derived localDeletionTime on TTL/DELETE cells (nowInSeconds, not reproducible across independent writers). → _The remaining blocker is intrinsic: TTL/DELETE cells carry a wall-clock-derived localDeletionTime (nowInSeconds) that cannot byte-match an independent writer, so they stay semantic-only by nature. A future upgrade to byte_for_byte would require a non-TTL static-tombstone reference whose deletion time is deterministic (explicit localDeletionTime) plus a strict Data.db byte diff._
@@ -698,6 +707,7 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.compaction.CompactionIteratorTest.differential_compaction_loop` | required_parity | .github/workflows/compaction-parity.yml |
 | `cass.compaction.CompactionIteratorTest.live_partition_merge` | required_parity | .github/workflows/live-cell-compaction-parity.yml |
 | `cass.compaction.CompactionSimpleValueMergeTest.static_row_merge` | required_parity | .github/workflows/tombstone-ttl-parity.yml |
+| `cass.compaction.CompactionTaskTest.reject_mixed_repair_state` | required_parity | .github/workflows/tombstone-ttl-parity.yml |
 | `cass.compaction.GcCompactionTest.static_and_complex_columns_survive_gc` | required_parity | .github/workflows/tombstone-ttl-parity.yml |
 | `cass.compaction.LongCompactionsTest.live_rows_lww_overlap` | required_parity | .github/workflows/live-cell-compaction-parity.yml |
 | `cass.compaction.SSTableRewriterTest.output_component_integrity` | nightly_docker | .github/workflows/compaction-parity.yml |
@@ -716,6 +726,7 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.compaction_merge.resurrection_safety.overlapping_sources` | nightly_docker | .github/workflows/tombstone-ttl-parity.yml |
 | `cass.compaction_merge.static_row.survives_tombstone_gc` | nightly_docker | .github/workflows/tombstone-ttl-parity.yml |
 | `cass.compaction_merge.tombstone_ttl_shadowing` | required_parity | .github/workflows/compaction-parity.yml |
+| `cass.compaction_parity.statistics.repaired_metadata_preserve` | required_parity | .github/workflows/tombstone-ttl-parity.yml |
 | `cass.compression.fixture_matrix.deflate` | exhaustive_regeneration | .github/workflows/compression-corruption-parity.yml |
 | `cass.compression.fixture_matrix.incompressible_uncompressed_chunk` | exhaustive_regeneration | .github/workflows/compression-corruption-parity.yml |
 | `cass.compression.fixture_matrix.lz4` | exhaustive_regeneration | .github/workflows/compression-corruption-parity.yml |
@@ -857,6 +868,8 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.index_summary.summary_boundaries` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.nodetool_jmx_metrics.operational_out_of_scope` | fast_pr | — |
 | `cass.read_repair_coordinator.out_of_scope` | fast_pr | — |
+| `cass.repair.PendingAntiCompactionTest.pending_repair_metadata` | required_parity | .github/workflows/tombstone-ttl-parity.yml |
+| `cass.repair.RepairedDataInfoTest.repaired_metadata_roundtrip` | required_parity | .github/workflows/tombstone-ttl-parity.yml |
 | `cass.repair_coordinator.anti_entropy_out_of_scope` | fast_pr | — |
 | `cass.repaired_metadata.statistics_db.pending_repair_uuid` | manual_debug | — |
 | `cass.repaired_metadata.statistics_db.repaired_at_field` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
@@ -902,6 +915,7 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.summary_db.bti.summary_discovery_classification` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.tombstone_ttl.NeverPurgeTest.preserve_all_tombstone_types` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.tombstone_ttl.RangeTombstoneTest.marker_merge_and_persistence` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
+| `cass.tombstone_ttl.RepairedDataTombstonesTest.repair_metadata_gates_purge` | required_parity | .github/workflows/tombstone-ttl-parity.yml |
 | `cass.tombstone_ttl.TTLExpiryTest.gc_boundary` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.tombstone_ttl.deletion_markers.cell_delete` | nightly_docker | .github/workflows/tombstone-ttl-parity.yml |
 | `cass.tombstone_ttl.deletion_markers.partition_delete` | nightly_docker | .github/workflows/tombstone-ttl-parity.yml |
@@ -957,6 +971,7 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.compaction.CompactionIteratorTest.differential_compaction_loop` | nb | test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl |
 | `cass.compaction.CompactionIteratorTest.live_partition_merge` | nb | test-data/datasets/sstables/test_compactionparity/live_no_clustering-e08194b073a611f1b17b3da6654e7580/nb-3-big-Data.db.jsonl |
 | `cass.compaction.CompactionSimpleValueMergeTest.static_row_merge` | nb | — |
+| `cass.compaction.CompactionTaskTest.reject_mixed_repair_state` | nb | cqlite-core/tests/issue_1021_repaired_metadata_compaction_parity.rs |
 | `cass.compaction.GcCompactionTest.static_and_complex_columns_survive_gc` | nb | test-data/datasets/sstables/test_collections |
 | `cass.compaction.LongCompactionsTest.live_rows_lww_overlap` | nb | test-data/datasets/sstables/test_compactionparity/live_no_clustering-e08194b073a611f1b17b3da6654e7580/nb-3-big-Data.db.jsonl |
 | `cass.compaction.SSTableRewriterTest.output_component_integrity` | nb | compaction-parity/build/parity-artifacts-byteParity/<scenario>/cassandra-output/<br>_fail:_ byte-diff.txt: first byte/offset diff per component (component, offset, ref byte, candidate byte, lengths), checksums.txt: SHA-256 of every component on both sides, cassandra-output/ and cqlite-output/: the full component dirs for offline decoding |
@@ -975,6 +990,7 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.compaction_merge.resurrection_safety.overlapping_sources` | nb | test-data/datasets/sstables/test_tomb/resurrection_gc0-4cb523c0702011f1b8f419c9a388d558/nb-1-big-Data.db.jsonl<br>test-data/datasets/sstables/test_tomb/resurrection_gc0-4cb523c0702011f1b8f419c9a388d558/nb-2-big-Data.db.jsonl |
 | `cass.compaction_merge.static_row.survives_tombstone_gc` | nb | test-data/datasets/sstables/test_tomb/static_with_tombstones-4cdb9780702011f1b8f419c9a388d558/nb-1-big-Data.db.jsonl |
 | `cass.compaction_merge.tombstone_ttl_shadowing` | nb | test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl |
+| `cass.compaction_parity.statistics.repaired_metadata_preserve` | nb | cqlite-core/tests/issue_1021_repaired_metadata_compaction_parity.rs |
 | `cass.compression.fixture_matrix.deflate` | nb | test-data/datasets/sstables/test_comp/deflate_table-2592698071a911f19b3225f9984c6a77/nb-1-big-CompressionInfo.db.txt<br>test-data/datasets/sstables/test_comp/deflate_table-2592698071a911f19b3225f9984c6a77/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/compression-fixture-deflate.log |
 | `cass.compression.fixture_matrix.incompressible_uncompressed_chunk` | nb | test-data/datasets/sstables/test_comp/incompressible_uncompressed_chunk-25b8dd4071a911f19b3225f9984c6a77/nb-1-big-CompressionInfo.db.txt<br>test-data/datasets/sstables/test_comp/incompressible_uncompressed_chunk-25b8dd4071a911f19b3225f9984c6a77/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/compression-fixture-incompressible.log |
 | `cass.compression.fixture_matrix.lz4` | nb | test-data/datasets/sstables/test_comp/lz4_table-25801a0071a911f19b3225f9984c6a77/nb-1-big-CompressionInfo.db.txt<br>test-data/datasets/sstables/test_comp/lz4_table-25801a0071a911f19b3225f9984c6a77/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/compression-fixture-lz4.log |
@@ -1116,6 +1132,8 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.index_summary.summary_boundaries` | nb, oa, big | test-data/datasets/sstables/test_timeseries/app_metrics-6c87b890a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>_fail:_ validation_artifacts/sstabledump/summary/summary_parity_report.md |
 | `cass.nodetool_jmx_metrics.operational_out_of_scope` | — | — |
 | `cass.read_repair_coordinator.out_of_scope` | — | — |
+| `cass.repair.PendingAntiCompactionTest.pending_repair_metadata` | nb | — |
+| `cass.repair.RepairedDataInfoTest.repaired_metadata_roundtrip` | nb, oa, da | test-data/datasets/sstables/system_schema/column_masks-738cc5ed01683268b9d1853d4bc278af/nb-45-big-Statistics.db.txt |
 | `cass.repair_coordinator.anti_entropy_out_of_scope` | — | — |
 | `cass.repaired_metadata.statistics_db.pending_repair_uuid` | nb, oa, da | test-data/datasets/sstables/test_basic/composite_key_table-6ab56990a25111f0a3fef1a551383fb9/nb-1-big-Statistics.db.txt |
 | `cass.repaired_metadata.statistics_db.repaired_at_field` | nb, oa, da | test-data/datasets/sstables/test_basic/composite_key_table-6ab56990a25111f0a3fef1a551383fb9/nb-1-big-Statistics.db.txt<br>test-data/datasets/sstables/test_oa/collection_table-4b892c6064e711f1bd3ac7dbf655c673/oa-2-big-Statistics.db.txt<br>test-data/datasets/sstables/test_da/simple_table-de1be8b064e711f19ad401a8c8227b11/da-2-bti-Statistics.db.txt<br>_fail:_ target/cassandra-parity/statistics-db-repaired-at-mismatch.log |
@@ -1161,6 +1179,7 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.summary_db.bti.summary_discovery_classification` | nb, oa, da, big, bti | test-data/datasets/sstables/test_da/simple_table-de1be8b064e711f19ad401a8c8227b11/da-2-bti-TOC.txt<br>_fail:_ validation_artifacts/sstabledump/summary/summary_parity_report.md |
 | `cass.tombstone_ttl.NeverPurgeTest.preserve_all_tombstone_types` | nb, oa | test-data/datasets/sstables/test_deltas/partition_tombstones-299258f0701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl<br>test-data/datasets/sstables/test_deltas/row_tombstones-297f1f10701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl<br>test-data/datasets/sstables/test_deltas/cell_tombstones-29733830701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/tombstone-types-delta-diff.log |
 | `cass.tombstone_ttl.RangeTombstoneTest.marker_merge_and_persistence` | nb, oa | test-data/datasets/sstables/test_deltas/range_tombstones-298894f0701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/range-marker-grammar-diff.log |
+| `cass.tombstone_ttl.RepairedDataTombstonesTest.repair_metadata_gates_purge` | nb | — |
 | `cass.tombstone_ttl.TTLExpiryTest.gc_boundary` | nb, oa | test-data/datasets/sstables/test_deltas/ttl_cells-299c9220701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/ttl-gc-boundary-delta-diff.log |
 | `cass.tombstone_ttl.deletion_markers.cell_delete` | nb | test-data/datasets/sstables/test_deltas/cell_tombstones-88c7bde06c9311f1ae1bf55502e5fa53/nb-1-big-Data.db.jsonl |
 | `cass.tombstone_ttl.deletion_markers.partition_delete` | nb | test-data/datasets/sstables/test_deltas/partition_tombstones-88f66f006c9311f1ae1bf55502e5fa53/nb-1-big-Data.db.jsonl |

--- a/test-data/cassandra-parity-manifest.yml
+++ b/test-data/cassandra-parity-manifest.yml
@@ -12669,6 +12669,332 @@ scenarios:
       workflow: .github/workflows/compaction-parity.yml
     scope: {}
 
+  # ----------------------------------------------------------------------------
+  # Repair-metadata parse / preserve / classify through compaction (issue #1021,
+  # epic #973). CQLite parses repairedAt/pendingRepair/isTransient from the
+  # Statistics.db STATS component, PRESERVES them through compaction of compatible
+  # inputs, and REJECTS a compaction that mixes repair states (Cassandra never
+  # compacts across a repair boundary). SCOPE: parse + preserve + classify +
+  # reject ONLY — this establishes NOTHING about repair-aware tombstone purging
+  # (out of scope; a separate correctness concern), and makes no repair / read-
+  # repair / coordinator-behavior claim.
+  # ----------------------------------------------------------------------------
+  - id: cass.repair.RepairedDataInfoTest.repaired_metadata_roundtrip
+    title: repairedAt / pendingRepair / isTransient round-trip through the Statistics.db read+write path
+    status: mirrored
+    capability: statistics_metadata
+    priority: P1
+    risk: p1_correctness
+    cassandra:
+      category: repair
+      relevance: high
+      files:
+        - StatsMetadata.java
+        - RepairedDataInfoTest.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_statistics_db
+        tests:
+          - cqlite-core/tests/sstable_parity_repaired_metadata_test.rs
+        notes: >-
+          The read path decodes repairedAt from the STATS component for every
+          fixture (nb/oa/da) and — with authoritative version gates — performs the
+          full version-gated forward walk past the min/max-clustering block +
+          commitLogIntervals to decode pendingRepair (nullable UUID) and isTransient
+          from real bytes. The strict corpus lane asserts each decoded field equals
+          the authoritative sstablemetadata reference (Repaired at: / Pending repair:
+          / IsTransient:), or — for the oa/da improved-min/max layout whose covered-
+          clustering Slice carries comparator-encoded values this repair-only decoder
+          does not model — reports the two later fields honestly as Unparsed (never a
+          fabricated value). A write->read round-trip writes a non-default repaired /
+          pending-UUID / transient state via the real Statistics.db writer and
+          re-decodes it field-exact.
+    fixtures:
+      datasets:
+        - test-data/datasets/sstables
+    evidence:
+      type: canonical_semantic
+      strict: false
+      artifacts: [bytes, component_files, jsonl, logs]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb, oa, da]
+      fixture_generation_command: >-
+        bash test-data/scripts/regenerate-datasets.sh  # unrepaired corpus only; repaired fixtures need a live cluster (see partial scenarios)
+      comparison_command: >-
+        env CQLITE_REQUIRE_FIXTURES=1 CQLITE_DATASETS_ROOT=$PWD/test-data/datasets
+        cargo test -p cqlite-core --features write-support
+        --test sstable_parity_repaired_metadata_test
+      reference_paths:
+        - test-data/datasets/sstables/system_schema/column_masks-738cc5ed01683268b9d1853d4bc278af/nb-45-big-Statistics.db.txt
+      normalization: >-
+        Each repair field decoded byte-derived from the STATS component is compared
+        to the authoritative sstablemetadata reference line (Repaired at:, Pending
+        repair:, IsTransient:); the non-default repaired/pending/transient state is
+        covered by a writer write->read round-trip (the corpus has no such fixture).
+      known_limitations: >-
+        Canonical-semantic over the three repair fields + a writer round-trip of the
+        non-default state. The corpus is entirely unrepaired, so repairedAt>0 /
+        pendingRepair-UUID / transient are proven via the writer round-trip rather
+        than a real Cassandra repaired fixture. For the oa/da improved-min/max layout
+        with NON-empty covered clustering the decoder reports pendingRepair/isTransient
+        as Unparsed (the Slice value encoding is comparator-driven and not modeled
+        here); the legacy (nb) layout decodes all three fully.
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/tombstone-ttl-parity.yml
+    scope: {}
+
+  - id: cass.compaction.CompactionTaskTest.reject_mixed_repair_state
+    title: Compaction rejects a mixed repaired / unrepaired / pending-repair input set
+    status: mirrored
+    capability: compaction_merge
+    priority: P0
+    risk: p1_correctness
+    cassandra:
+      category: compaction
+      relevance: high
+      files:
+        - CompactionTask.java
+        - CompactionTaskTest.java
+    cqlite:
+      coverage:
+        suite: compaction_parity_tombstone_ttl
+        tests:
+          - cqlite-core/tests/issue_1021_repaired_metadata_compaction_parity.rs
+        notes: >-
+          Cassandra partitions compaction candidates by (repairedAt, pendingRepair,
+          isTransient) and never mixes them in one compaction. CQLite reads each
+          input's persisted repair state from its Statistics.db (classify_inputs),
+          and both compaction paths (start_merge + compact_sstables_with_registry)
+          reject a mixed set with a typed Error::Compaction naming the repair boundary
+          BEFORE writing any output — never a silent merge. The tests construct inputs
+          with controlled repair states via the real SSTableWriter and assert mixed
+          repaired/unrepaired and mixed pending-repair sets are rejected and publish
+          no output, while compatible inputs succeed.
+    fixtures:
+      datasets:
+        - test-data/datasets/sstables
+    evidence:
+      type: canonical_semantic
+      strict: false
+      artifacts: [component_files, jsonl, logs]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb]
+      fixture_generation_command: >-
+        # inputs are constructed in-test via SSTableWriter::set_repair_state (no fixture)
+      comparison_command: >-
+        env CQLITE_REQUIRE_FIXTURES=1 CQLITE_DATASETS_ROOT=$PWD/test-data/datasets
+        cargo test -p cqlite-core --features write-support
+        --test issue_1021_repaired_metadata_compaction_parity
+      reference_paths:
+        - cqlite-core/tests/issue_1021_repaired_metadata_compaction_parity.rs
+      normalization: >-
+        The rejection is asserted behaviorally: a mixed-state compaction returns a
+        typed repair-boundary error and publishes zero output components; a
+        same-state compaction succeeds. (Cassandra's candidate partitioning is not
+        byte-comparable; the constraint — never merge across the boundary — is.)
+      known_limitations: >-
+        Canonical-semantic (behavioral): proves CQLite refuses to merge across a
+        repair boundary, matching Cassandra's CompactionTask candidate partitioning.
+        Inputs carry SSTableWriter-set repair states (the corpus has no repaired
+        fixture); the byte shape of the preserved metadata is covered by
+        cqlite.compaction_parity.statistics.repaired_metadata_preserve.
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/tombstone-ttl-parity.yml
+    scope: {}
+
+  - id: cass.compaction_parity.statistics.repaired_metadata_preserve
+    title: Compaction preserves the shared repair state of compatible inputs into the output Statistics.db
+    status: mirrored
+    capability: compaction_merge
+    priority: P1
+    risk: p1_correctness
+    cassandra:
+      category: compaction
+      relevance: high
+      files:
+        - StatsMetadata.java
+        - CompactionTask.java
+    cqlite:
+      coverage:
+        suite: compaction_parity_tombstone_ttl
+        tests:
+          - cqlite-core/tests/issue_1021_repaired_metadata_compaction_parity.rs
+        notes: >-
+          Compacting inputs that share a repair state carries repairedAt /
+          pendingRepair / isTransient forward into the merged output's Statistics.db
+          (StatisticsMetadata::set_repair_state, emitted by both the nb and da STATS
+          builders). The tests compact compatible inputs (repaired + pending-UUID +
+          transient, and the unrepaired baseline) and decode the output Statistics.db
+          repair fields back through the full version-gated walk, asserting they
+          equal the inputs' shared state.
+    fixtures:
+      datasets:
+        - test-data/datasets/sstables
+    evidence:
+      type: canonical_semantic
+      strict: false
+      artifacts: [bytes, component_files, jsonl, logs]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb]
+      fixture_generation_command: >-
+        # compatible inputs constructed in-test via SSTableWriter::set_repair_state
+      comparison_command: >-
+        env CQLITE_REQUIRE_FIXTURES=1 CQLITE_DATASETS_ROOT=$PWD/test-data/datasets
+        cargo test -p cqlite-core --features write-support
+        --test issue_1021_repaired_metadata_compaction_parity
+      reference_paths:
+        - cqlite-core/tests/issue_1021_repaired_metadata_compaction_parity.rs
+      normalization: >-
+        The output Statistics.db repair fields are decoded byte-derived through the
+        full version-gated read walk and compared field-exact to the inputs' shared
+        repair state.
+      known_limitations: >-
+        Canonical-semantic over the three preserved repair fields of the merged
+        output. Inputs carry SSTableWriter-set repair states (the corpus has no
+        repaired fixture), which is the same byte-level mechanism the merge path
+        uses; whole-Statistics.db byte identity vs a Cassandra-compacted repaired
+        output is blocked on the absent live-cluster repaired fixture.
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/tombstone-ttl-parity.yml
+    scope: {}
+
+  - id: cass.tombstone_ttl.RepairedDataTombstonesTest.repair_metadata_gates_purge
+    title: Repaired-metadata gating of tombstone purge across a repair boundary
+    status: partial
+    capability: tombstone_ttl
+    priority: P1
+    risk: p1_correctness
+    cassandra:
+      category: repair
+      relevance: high
+      files:
+        - RepairedDataTombstonesTest.java
+    cqlite:
+      coverage:
+        suite: compaction_parity_tombstone_ttl
+        tests:
+          - cqlite-core/tests/issue_1021_repaired_metadata_compaction_parity.rs
+        notes: >-
+          PREREQUISITE ONLY. CQLite now parses + preserves repair metadata and
+          rejects mixed-repair-state compaction, which is the prerequisite for any
+          repair-aware tombstone-purge claim. CQLite does NOT implement repair-aware
+          tombstone gating (it does not retain/drop tombstones with respect to a
+          repair boundary), and this issue (#1021) explicitly makes no such claim.
+    fixtures:
+      datasets:
+        - test-data/datasets/sstables
+    evidence:
+      type: partial
+      strict: false
+      artifacts: [logs]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb]
+      fixture_generation_command: >-
+        # BLOCKED: requires a live Cassandra cluster (nodetool repair / anticompaction)
+        # to produce a repaired SSTable (repairedAt != 0) plus an unrepaired SSTable
+        # holding a shadowing tombstone, then sstabledump/sstablemetadata goldens.
+      comparison_command: >-
+        env CQLITE_REQUIRE_FIXTURES=1 CQLITE_DATASETS_ROOT=$PWD/test-data/datasets
+        cargo test -p cqlite-core --features write-support
+        --test issue_1021_repaired_metadata_compaction_parity
+      normalization: >-
+        N/A — repair-aware purge gating is not implemented; only the parse/preserve/
+        reject prerequisite is covered.
+      known_limitations: >-
+        PARTIAL: repair-aware tombstone-purge gating is NOT implemented and not
+        claimed by #1021. The metadata prerequisite (parse + preserve + reject mixed)
+        IS done. Promoting requires (1) a live-cluster repaired+unrepaired fixture
+        with a cross-boundary shadowing tombstone and (2) a separate repair-aware
+        purge implementation + tombstone-purge parity test — tracked as a follow-up.
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/tombstone-ttl-parity.yml
+    scope:
+      gap: >-
+        Repair-aware tombstone purge gating is unimplemented (and out of scope for
+        #1021); only the parse/preserve/reject-mixed prerequisite exists. No real
+        repaired fixture exists in the corpus (the published Cassandra 5.0 datasets
+        are all unrepaired; a repaired SSTable requires a live cluster + nodetool
+        repair / anticompaction).
+      next_step: >-
+        File a follow-up to (1) commission a live-cluster repaired+unrepaired fixture
+        with a cross-repair-boundary shadowing tombstone (nodetool repair /
+        sstablerepairedset + sstabledump/sstablemetadata goldens), and (2) implement
+        + test repair-aware tombstone purge gating against it.
+
+  - id: cass.repair.PendingAntiCompactionTest.pending_repair_metadata
+    title: pendingRepair session metadata written by anticompaction
+    status: partial
+    capability: statistics_metadata
+    priority: P2
+    risk: p2_coverage
+    cassandra:
+      category: repair
+      relevance: med
+      files:
+        - PendingAntiCompactionTest.java
+    cqlite:
+      coverage:
+        suite: sstable_parity_statistics_db
+        tests:
+          - cqlite-core/tests/sstable_parity_repaired_metadata_test.rs
+          - cqlite-core/tests/issue_1021_repaired_metadata_compaction_parity.rs
+        notes: >-
+          CQLite decodes a pendingRepair UUID from the STATS component (legacy nb
+          layout and empty-clustering oa/da) and preserves/rejects on it through
+          compaction. The pendingRepair-UUID DISTINCT state is covered via synthetic
+          STATS bytes + a writer round-trip (parse exact, preserve exact, reject on
+          mismatch), since the corpus has no pending-repair fixture.
+    fixtures:
+      datasets:
+        - test-data/datasets/sstables
+    evidence:
+      type: partial
+      strict: false
+      artifacts: [bytes, logs]
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
+      storage_format_version: [nb]
+      fixture_generation_command: >-
+        # BLOCKED: a pendingRepair UUID is written only by an in-flight incremental
+        # repair / PendingAntiCompaction on a live cluster — not reproducible here.
+      comparison_command: >-
+        env CQLITE_REQUIRE_FIXTURES=1 CQLITE_DATASETS_ROOT=$PWD/test-data/datasets
+        cargo test -p cqlite-core --features write-support
+        --test sstable_parity_repaired_metadata_test
+        --test issue_1021_repaired_metadata_compaction_parity
+      normalization: >-
+        The pendingRepair UUID is decoded byte-derived from the STATS component and
+        compared exact (synthetic + writer round-trip), since no real pending-repair
+        fixture exists.
+      known_limitations: >-
+        PARTIAL (no real fixture): the pendingRepair-UUID state is proven via
+        synthetic STATS bytes + a writer round-trip rather than a Cassandra
+        anticompaction-produced SSTable. Anticompaction execution / repair session
+        coordination is explicitly OUT OF SCOPE. Promoting to mirrored requires a
+        live-cluster PendingAntiCompaction fixture (an SSTable carrying a real
+        pendingRepair session UUID) plus sstablemetadata goldens.
+    ci:
+      tier: required_parity
+      workflow: .github/workflows/tombstone-ttl-parity.yml
+    scope:
+      gap: >-
+        No SSTable carrying a real pendingRepair session UUID exists in the corpus;
+        such a file is produced only by an in-flight incremental repair /
+        PendingAntiCompaction on a live cluster. The UUID parse/preserve/reject path
+        is proven via synthetic bytes + a writer round-trip.
+      next_step: >-
+        Commission a live-cluster PendingAntiCompaction fixture (an SSTable with a
+        real pendingRepair UUID) + sstablemetadata goldens, then assert the decoded
+        UUID against the reference to promote to mirrored.
+
 # ==============================================================================
 # Public/release-facing parity claims (issue #1023).
 #


### PR DESCRIPTION
Closes #1021. Parent epic #973 (Compaction Byte Parity). Oracle-driven (Cassandra 5.0 `Statistics.db` + sstablemetadata truth) — no OpenSpec, no heuristics.

## What
Parse, preserve, and report Cassandra repair metadata through CQLite compaction — the prerequisite for any future repair-aware tombstone-purge claim (this PR does **not** make purge claims; it is parse + preserve + report + reject only).

**Production behavior added** (was previously: pendingRepair/isTransient always `Unparsed`, repair state always written as unrepaired, compaction silently merged across repair boundaries):
- Decode `repairedAt`, `pendingRepair` (nullable UUID), `isTransient` from `Statistics.db` STATS — authoritatively, by version-gated forward walk. For `oa`/`da` BTI this includes decoding the `improvedMinMax` covered-clustering bounds (per `AbstractType.skipValue`: fixed types skip `valueLengthIfFixed()` bytes, variable types skip a VInt-length prefix) so the repair fields are reachable.
- Preserve all three fields when compacting compatible inputs (`SSTableWriter::set_repair_state`, emitted by both `nb` and `da` STATS builders).
- Reject (typed `Error::Compaction`) compaction across a genuine repair boundary; `classify_inputs` fails closed on a genuinely-`Unparsed` field (unmodeled comparator) — never defaults an unknown.

## Scope
**Cassandra 5.0 only** (`nb`/`oa`/`da`, `na`+). CQLite's reader does not open pre-`na` formats (magic-gated; `BtiVersionGates` rejects non-`da`; `BigVersionGates::is_compatible` is never on a read path). An earlier iteration added pre-`na` (`ma`–`me`) handling that was trimmed back as out-of-scope — see #1249 (filed to codify the 5.0 version floor + reject-pre-`na` gate + doctrine line).

## Acceptance criteria → proving tests
- **AC1 parse** → `classify_inputs_decodes_clustered_oa_repair_fields_authoritatively`, `repair_clustering` units (incl. tinyint/smallint/date/time covered-slice skips), `sstable_parity_repaired_metadata_test`.
- **AC2 preserve** → `compaction_preserves_shared_repaired_state` / `_unrepaired_state`, writer roundtrip.
- **AC3 reject mixed** → `compaction_rejects_mixed_repaired_unrepaired`, `compaction_rejects_mixed_pending_repair`, `classify_inputs_returns_shared_or_rejects`.
- **AC4 fixtures** — unrepaired state REAL across the nb/oa/da corpus; repaired/pending/transient honestly `partial` in the manifest (need a live-cluster fixture; flagged for a follow-up).

## Manifest
5 scenarios (`nb`/`oa`/`da`), wired into the `tombstone-ttl-parity.yml` fail-closed lane (`CQLITE_REQUIRE_FIXTURES=1`). lint / tier-contract-check / report --check green.

## Validation
`scripts/agent-gate.sh` → **RESULT: PASS** (all 15 components) on clean tree `22fd4fc4`. roborev (codex, branch vs origin/main): **No issues found** — after several rounds incl. a refuted false positive (tinyint/smallint/date/time are VInt-length-prefixed in Cassandra 5.0, NOT fixed-width — verified against `ByteType`/`ShortType`/`SimpleDateType`/`TimeType` not overriding `valueLengthIfFixed()`).

🤖 flow-lead worker