### PR TITLE
test(#1231): content-asserting write→read round-trips per public write surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -491,6 +491,19 @@ jobs:
           echo "Running CLI unit tests (Issue #20)..."
           cargo test --package cqlite-cli --test unit_tests
 
+      - name: Run CLI write→read content round-trip tests (issue #1231)
+        env:
+          CQLITE_DATASETS_ROOT: ${{ github.workspace }}/test-data/datasets
+        run: |
+          echo "Running CLI write-path content round-trips (issue #1231)..."
+          # Drives the FULL public CLI chain: CQL INSERT/UPDATE/DELETE → WAL →
+          # flush → SSTable → independent reopen → SELECT → assert decoded VALUES,
+          # plus binary-level export-sstable read-back and compact/maintenance/
+          # write-stats subcommand glue. Self-contained: every test builds its own
+          # SSTables in a tempdir, so no fixture corpus is required.
+          cargo test --package cqlite-cli --features write-support \
+            --test write_readback_content_tests
+
       - name: Build CLI for one-shot smoke tests
         run: |
           echo "🔨 Building CLI binary for smoke tests..."

--- a/bindings/node/__test__/write-readback-content.test.js
+++ b/bindings/node/__test__/write-readback-content.test.js
@@ -1,0 +1,159 @@
+/**
+ * Content-asserting write→read round-trips through the public Node API (Issue #1231).
+ *
+ * Unlike write.test.js (whose one post-write SELECT tolerates 0 rows and asserts
+ * no content), every test here drives the FULL public chain:
+ *
+ *   db.execute("INSERT/UPDATE/DELETE")  →  db.flushRun()  →  real SSTable
+ *     →  Database.open(<writeDir>/data)  (independent reopen)
+ *     →  db.executeNative("SELECT ...")  →  assert decoded VALUES
+ *
+ * A write-format/encoding regression that emits a structurally-present but
+ * semantically-WRONG Data.db will turn these red — shape-only tests could not
+ * (the "CI blind to the write path" hazard, epic #1227).
+ *
+ * These tests generate their own SSTables in a tmp dir, so they do NOT depend on
+ * the fixture corpus.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { Database } = require('../lib/index.js');
+
+// A single-table schema (no-heuristics mandate: one unambiguous write target).
+const SCHEMA_TEXT = `
+CREATE KEYSPACE IF NOT EXISTS write_test
+  WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};
+
+USE write_test;
+
+CREATE TABLE IF NOT EXISTS items (
+    id    INT PRIMARY KEY,
+    name  TEXT,
+    value INT
+);
+`;
+
+/** Create a tmp work dir containing the schema file. */
+function setup() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cqlite-write-content-'));
+  const schema = path.join(dir, 'schema.cql');
+  fs.writeFileSync(schema, SCHEMA_TEXT);
+  const dataDir = path.join(dir, 'data_dir');
+  fs.mkdirSync(dataDir);
+  const writeDir = path.join(dir, 'write_dir');
+  return {
+    dir,
+    schema,
+    dataDir,
+    writeDir,
+    cleanup() {
+      try {
+        fs.rmSync(dir, { recursive: true, force: true });
+      } catch (_) {
+        /* ignore */
+      }
+    },
+  };
+}
+
+/** Reopen the flushed SSTable directory read-only and return the decoded rows. */
+async function readBack(writeDir, schema, query) {
+  const rd = await Database.open(path.join(writeDir, 'data'), { schema });
+  try {
+    const res = await rd.executeNative(query);
+    return res.rows;
+  } finally {
+    await rd.close();
+  }
+}
+
+function rowWithId(rows, id) {
+  return rows.find((r) => Number(r.id) === id);
+}
+
+describe('Write→read content round-trip (Issue #1231)', () => {
+  test('INSERT → flush → reopen → SELECT asserts decoded values', async () => {
+    const env = setup();
+    try {
+      const db = await Database.open(env.dataDir, {
+        schema: env.schema,
+        writable: true,
+        writeDir: env.writeDir,
+      });
+      await db.execute(
+        "INSERT INTO write_test.items (id, name, value) VALUES (1, 'alpha', 10)"
+      );
+      const sstable = await db.flushRun();
+      expect(sstable.length).toBeGreaterThan(0);
+      expect(fs.existsSync(sstable)).toBe(true);
+      await db.close();
+
+      const rows = await readBack(env.writeDir, env.schema, 'SELECT * FROM write_test.items');
+      expect(rows.length).toBe(1);
+      const row = rows[0];
+      expect(Number(row.id)).toBe(1);
+      expect(row.name).toBe('alpha');
+      expect(Number(row.value)).toBe(10);
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test('UPDATE overwrite wins on read-back', async () => {
+    const env = setup();
+    try {
+      const db = await Database.open(env.dataDir, {
+        schema: env.schema,
+        writable: true,
+        writeDir: env.writeDir,
+      });
+      await db.execute(
+        "INSERT INTO write_test.items (id, name, value) VALUES (1, 'alpha', 10)"
+      );
+      await db.execute(
+        "UPDATE write_test.items SET name = 'ALPHA', value = 11 WHERE id = 1"
+      );
+      await db.flushRun();
+      await db.close();
+
+      const rows = await readBack(env.writeDir, env.schema, 'SELECT * FROM write_test.items');
+      expect(rows.length).toBe(1);
+      const row = rows[0];
+      expect(row.name).toBe('ALPHA'); // UPDATE won, not the INSERT value
+      expect(Number(row.value)).toBe(11);
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test('DELETE tombstone makes the row absent on read-back', async () => {
+    const env = setup();
+    try {
+      const db = await Database.open(env.dataDir, {
+        schema: env.schema,
+        writable: true,
+        writeDir: env.writeDir,
+      });
+      await db.execute(
+        "INSERT INTO write_test.items (id, name, value) VALUES (1, 'alpha', 10)"
+      );
+      await db.execute(
+        "INSERT INTO write_test.items (id, name, value) VALUES (2, 'beta', 20)"
+      );
+      await db.execute('DELETE FROM write_test.items WHERE id = 2');
+      await db.flushRun();
+      await db.close();
+
+      const rows = await readBack(env.writeDir, env.schema, 'SELECT * FROM write_test.items');
+      expect(rowWithId(rows, 2)).toBeUndefined(); // deleted row absent
+      const survivor = rowWithId(rows, 1);
+      expect(survivor).toBeDefined();
+      expect(survivor.name).toBe('alpha');
+      expect(Number(survivor.value)).toBe(10);
+    } finally {
+      env.cleanup();
+    }
+  });
+});

--- a/bindings/python/tests/test_write_readback_content.py
+++ b/bindings/python/tests/test_write_readback_content.py
@@ -1,0 +1,144 @@
+"""Content-asserting write→read round-trips through the public Python API (Issue #1231).
+
+Unlike ``test_write_api.py`` (which asserts only ``rows_affected`` / file-exists /
+stat counters and never reopens), every test here drives the FULL public chain:
+
+    db.execute("INSERT/UPDATE/DELETE")  →  db.flush_run()  →  real SSTable
+        →  cqlite.open(<write_dir>/data)  (independent reopen)
+        →  db.execute("SELECT ...")  →  assert decoded VALUES
+
+A write-format/encoding regression that emits a structurally-present but
+semantically-WRONG Data.db will turn these red — the shape-only tests could not
+(the "CI blind to the write path" hazard, epic #1227).
+
+These tests generate their own SSTables in a tmp dir, so they do NOT depend on
+the fixture corpus.
+"""
+
+from pathlib import Path
+
+import pytest
+
+import cqlite
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def schema_file(tmp_path):
+    """A single-table schema (no-heuristics mandate: one unambiguous target)."""
+    text = """\
+CREATE KEYSPACE IF NOT EXISTS write_test
+  WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};
+
+USE write_test;
+
+CREATE TABLE IF NOT EXISTS items (
+    id    INT PRIMARY KEY,
+    name  TEXT,
+    value INT
+);
+"""
+    path = tmp_path / "schema.cql"
+    path.write_text(text)
+    return path
+
+
+def _open_writable(tmp_path, schema_file):
+    """Open a writable database; writes land under ``write_dir``."""
+    data_dir = tmp_path / "data_dir"
+    data_dir.mkdir(exist_ok=True)
+    write_dir = tmp_path / "write_dir"
+    db = cqlite.open(
+        str(data_dir),
+        schema=str(schema_file),
+        writable=True,
+        write_dir=str(write_dir),
+    )
+    return db, write_dir
+
+
+def _read_back(write_dir, schema_file, query):
+    """Reopen the flushed SSTable directory read-only and return row dicts."""
+    with cqlite.open(str(Path(write_dir) / "data"), schema=str(schema_file)) as rd:
+        return [row.to_dict() for row in rd.execute(query)]
+
+
+def _row_with_id(rows, target):
+    return next((r for r in rows if r.get("id") == target), None)
+
+
+# ---------------------------------------------------------------------------
+# INSERT: values survive the round-trip unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_insert_flush_reopen_asserts_values(tmp_path, schema_file):
+    db, write_dir = _open_writable(tmp_path, schema_file)
+    try:
+        db.execute(
+            "INSERT INTO write_test.items (id, name, value) VALUES (1, 'alpha', 10)"
+        )
+        path = db.flush_run()
+        assert path and Path(path).exists(), "flush must produce a real Data.db"
+    finally:
+        db.close()
+
+    rows = _read_back(write_dir, schema_file, "SELECT * FROM write_test.items")
+    assert len(rows) == 1, f"exactly one row expected, got {rows}"
+    row = rows[0]
+    assert row["id"] == 1, f"id value mismatch: {row}"
+    assert row["name"] == "alpha", f"name value mismatch: {row}"
+    assert row["value"] == 10, f"value value mismatch: {row}"
+
+
+# ---------------------------------------------------------------------------
+# UPDATE: a later write overwrites the earlier value (last-write-wins)
+# ---------------------------------------------------------------------------
+
+
+def test_update_overwrite_wins_on_readback(tmp_path, schema_file):
+    db, write_dir = _open_writable(tmp_path, schema_file)
+    try:
+        db.execute(
+            "INSERT INTO write_test.items (id, name, value) VALUES (1, 'alpha', 10)"
+        )
+        db.execute("UPDATE write_test.items SET name = 'ALPHA', value = 11 WHERE id = 1")
+        db.flush_run()
+    finally:
+        db.close()
+
+    rows = _read_back(write_dir, schema_file, "SELECT * FROM write_test.items")
+    assert len(rows) == 1, f"exactly one row expected, got {rows}"
+    row = rows[0]
+    assert row["name"] == "ALPHA", f"UPDATE did not win for name: {row}"
+    assert row["value"] == 11, f"UPDATE did not win for value: {row}"
+
+
+# ---------------------------------------------------------------------------
+# DELETE: the tombstone makes the row absent on read-back
+# ---------------------------------------------------------------------------
+
+
+def test_delete_tombstone_absent_on_readback(tmp_path, schema_file):
+    db, write_dir = _open_writable(tmp_path, schema_file)
+    try:
+        db.execute(
+            "INSERT INTO write_test.items (id, name, value) VALUES (1, 'alpha', 10)"
+        )
+        db.execute(
+            "INSERT INTO write_test.items (id, name, value) VALUES (2, 'beta', 20)"
+        )
+        db.execute("DELETE FROM write_test.items WHERE id = 2")
+        db.flush_run()
+    finally:
+        db.close()
+
+    rows = _read_back(write_dir, schema_file, "SELECT * FROM write_test.items")
+    assert _row_with_id(rows, 2) is None, f"deleted row id=2 must be absent: {rows}"
+    survivor = _row_with_id(rows, 1)
+    assert survivor is not None, f"surviving row id=1 must be present: {rows}"
+    assert survivor["name"] == "alpha", f"survivor corrupted: {survivor}"
+    assert survivor["value"] == 10, f"survivor corrupted: {survivor}"

--- a/cqlite-cli/tests/write_readback_content_tests.rs
+++ b/cqlite-cli/tests/write_readback_content_tests.rs
@@ -339,7 +339,23 @@ fn cli_export_sstable_reopen_exported_asserts_content() {
 // ===========================================================================
 // AC #2: subcommand glue smoke — flags parse, `--writable` gating, output shape
 // for write-stats / maintenance / compact.
+//
+// NOTE: the exact stdout substrings these tests match ("Write Engine
+// Statistics:", "Maintenance complete:", "OK: compacted", "Export complete:",
+// "Flushed:", "OK") are treated as part of the CLI's *output contract*. A
+// deliberate wording change in the CLI must update these strings here so the
+// behavioral coupling stays visible (roborev judged exact-substring matching
+// acceptable for CLI glue smoke). The `--writable` gating checks additionally
+// assert the real gate error phrase on stderr ("requires --writable mode"), so
+// a command that fails for an unrelated reason cannot satisfy the gating tests.
 // ===========================================================================
+
+/// The substring the CLI emits on stderr when a write subcommand is invoked
+/// without `--writable`. Asserting this (not just a non-zero exit) proves the
+/// failure is the gate, not e.g. an empty/invalid data dir. Confirmed against
+/// the real binary: `Error: Write stats requires --writable mode` /
+/// `Error: Maintenance requires --writable mode`.
+const WRITABLE_GATE_MSG: &str = "requires --writable mode";
 
 #[test]
 fn cli_write_stats_subcommand_glue() {
@@ -367,9 +383,14 @@ fn cli_write_stats_subcommand_glue() {
         schema.to_str().unwrap(),
         "write-stats",
     ]);
+    let gated_stderr = String::from_utf8_lossy(&gated.stderr);
     assert!(
         !gated.status.success(),
         "write-stats without --writable must fail (gating)"
+    );
+    assert!(
+        gated_stderr.contains(WRITABLE_GATE_MSG),
+        "write-stats must fail *because of* the --writable gate; expected stderr to contain {WRITABLE_GATE_MSG:?}, got: {gated_stderr}"
     );
 }
 
@@ -400,9 +421,14 @@ fn cli_maintenance_subcommand_glue() {
         "--budget-ms",
         "50",
     ]);
+    let gated_stderr = String::from_utf8_lossy(&gated.stderr);
     assert!(
         !gated.status.success(),
         "maintenance without --writable must fail (gating)"
+    );
+    assert!(
+        gated_stderr.contains(WRITABLE_GATE_MSG),
+        "maintenance must fail *because of* the --writable gate; expected stderr to contain {WRITABLE_GATE_MSG:?}, got: {gated_stderr}"
     );
 }
 

--- a/cqlite-cli/tests/write_readback_content_tests.rs
+++ b/cqlite-cli/tests/write_readback_content_tests.rs
@@ -1,0 +1,461 @@
+//! Content-asserting write→read round-trips through the public CLI (Issue #1231).
+//!
+//! Unlike `cli_dml_integration_tests.rs` (which asserts only exit-code + "OK"),
+//! every test here drives the FULL public chain a user hits:
+//!
+//!   CQL string → parser → Mutation → WriteEngine → WAL → flush → SSTable
+//!     → independent reopen via `--data-dir` → SELECT → assert decoded VALUES
+//!
+//! A write-format/encoding regression that emits a structurally-present but
+//! semantically-WRONG Data.db will turn these red. The earlier shape-only tests
+//! could not (the "CI blind to the write path" hazard, epic #1227).
+//!
+//! Invocation model (proven against the real binary): the one-shot CLI handles
+//! `--flush` BEFORE `--execute`, and `--execute INSERT` returns early, so a
+//! single `--execute INSERT --flush` invocation does NOT persist (see the
+//! discovered-bug note in the issue report). The durable, user-reachable path is
+//! WAL-backed across invocations:
+//!
+//! 1. `--execute "INSERT/UPDATE/DELETE"` appends to the WAL,
+//! 2. a later `--writable --write-dir <wd> --flush` replays the WAL into the
+//!    memtable and flushes a real SSTable under `<wd>/data`,
+//! 3. a read-only `--data-dir <wd>/data --execute "SELECT ..."` reopens and
+//!    decodes it.
+//!
+//! These tests use that path and assert the decoded column values.
+
+#![cfg(feature = "write-support")]
+
+use serde_json::Value as Json;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use tempfile::TempDir;
+
+/// The pre-built `cqlite` binary for this test crate. Using `CARGO_BIN_EXE_*`
+/// runs the exact binary the harness built with `--features write-support`,
+/// without spawning a nested `cargo run` rebuild.
+fn cqlite_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_cqlite")
+}
+
+/// Write the single-table schema used by the round-trip tests.
+fn write_schema(dir: &Path) -> PathBuf {
+    let path = dir.join("schema.cql");
+    std::fs::write(
+        &path,
+        r#"
+CREATE KEYSPACE IF NOT EXISTS test_write WITH replication = {
+  'class': 'SimpleStrategy',
+  'replication_factor': 1
+};
+
+USE test_write;
+
+CREATE TABLE IF NOT EXISTS users (
+    id INT PRIMARY KEY,
+    name TEXT,
+    age INT,
+    active BOOLEAN
+);
+"#,
+    )
+    .expect("write schema file");
+    path
+}
+
+/// Run the binary with the given args and return the captured output.
+fn run(args: &[&str]) -> Output {
+    Command::new(cqlite_bin())
+        .args(args)
+        .output()
+        .expect("spawn cqlite binary")
+}
+
+/// Run a write-side invocation (`--writable --write-dir <wd> --schema <s> ...`).
+fn write_cmd(wd: &Path, schema: &Path, extra: &[&str]) -> Output {
+    let mut args = vec![
+        "--writable",
+        "--write-dir",
+        wd.to_str().unwrap(),
+        "--schema",
+        schema.to_str().unwrap(),
+    ];
+    args.extend_from_slice(extra);
+    run(&args)
+}
+
+/// Execute a single DML statement against the WAL (`--execute`), asserting
+/// success + the "OK" acknowledgement.
+fn dml(wd: &Path, schema: &Path, stmt: &str) {
+    let out = write_cmd(wd, schema, &["--execute", stmt]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "DML failed: `{stmt}`\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("OK"),
+        "expected OK for `{stmt}`, got: {stdout}"
+    );
+}
+
+/// Flush the WAL-backed memtable to a real SSTable under `<wd>/data`.
+fn flush(wd: &Path, schema: &Path) {
+    let out = write_cmd(wd, schema, &["--flush"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "flush failed\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("Flushed:"),
+        "expected a real flush (memtable non-empty after WAL replay), got: {stdout}"
+    );
+}
+
+/// Reopen an SSTable directory read-only and SELECT, returning the rows as a
+/// JSON array (the `--out json` payload on stdout; tracing logs go to stderr).
+fn select_rows(data_dir: &Path, schema: &Path, query: &str) -> Vec<Json> {
+    let out = run(&[
+        "--data-dir",
+        data_dir.to_str().unwrap(),
+        "--schema",
+        schema.to_str().unwrap(),
+        "--execute",
+        query,
+        "--out",
+        "json",
+    ]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "SELECT failed: `{query}`\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    let parsed: Json = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("SELECT did not emit JSON: {e}\nstdout: {stdout}"));
+    match parsed {
+        Json::Array(rows) => rows,
+        other => panic!("expected a JSON array of rows, got: {other}"),
+    }
+}
+
+/// Find the row whose `id` column equals `id`.
+fn row_with_id(rows: &[Json], id: i64) -> Option<&Json> {
+    rows.iter()
+        .find(|r| r.get("id").and_then(|v| v.as_i64()) == Some(id))
+}
+
+// ===========================================================================
+// INSERT: values survive the round-trip unchanged
+// ===========================================================================
+
+#[test]
+fn cli_insert_flush_reopen_select_asserts_values() {
+    let tmp = TempDir::new().unwrap();
+    let schema = write_schema(tmp.path());
+    let wd = tmp.path().join("wd");
+
+    dml(
+        &wd,
+        &schema,
+        "INSERT INTO test_write.users (id, name, age, active) VALUES (1, 'Alice', 30, true)",
+    );
+    flush(&wd, &schema);
+
+    let rows = select_rows(&wd.join("data"), &schema, "SELECT * FROM test_write.users");
+    assert_eq!(rows.len(), 1, "exactly one row expected, got: {rows:?}");
+    let row = &rows[0];
+    assert_eq!(row["id"].as_i64(), Some(1), "id value mismatch in {row}");
+    assert_eq!(
+        row["name"].as_str(),
+        Some("Alice"),
+        "name value mismatch in {row}"
+    );
+    assert_eq!(row["age"].as_i64(), Some(30), "age value mismatch in {row}");
+    assert_eq!(
+        row["active"].as_bool(),
+        Some(true),
+        "active value mismatch in {row}"
+    );
+}
+
+// ===========================================================================
+// UPDATE: a later write overwrites the earlier value (last-write-wins)
+// ===========================================================================
+
+#[test]
+fn cli_update_overwrite_wins_on_readback() {
+    let tmp = TempDir::new().unwrap();
+    let schema = write_schema(tmp.path());
+    let wd = tmp.path().join("wd");
+
+    dml(
+        &wd,
+        &schema,
+        "INSERT INTO test_write.users (id, name, age, active) VALUES (1, 'Alice', 30, true)",
+    );
+    dml(
+        &wd,
+        &schema,
+        "UPDATE test_write.users SET name = 'Alicia', age = 31 WHERE id = 1",
+    );
+    flush(&wd, &schema);
+
+    let rows = select_rows(&wd.join("data"), &schema, "SELECT * FROM test_write.users");
+    assert_eq!(rows.len(), 1, "exactly one row expected, got: {rows:?}");
+    let row = &rows[0];
+    // Overwritten columns reflect the UPDATE, not the INSERT.
+    assert_eq!(
+        row["name"].as_str(),
+        Some("Alicia"),
+        "UPDATE did not win for name: {row}"
+    );
+    assert_eq!(
+        row["age"].as_i64(),
+        Some(31),
+        "UPDATE did not win for age: {row}"
+    );
+    // A column the UPDATE did not touch keeps the INSERT value.
+    assert_eq!(
+        row["active"].as_bool(),
+        Some(true),
+        "untouched column changed: {row}"
+    );
+}
+
+// ===========================================================================
+// DELETE: the tombstone makes the row absent on read-back
+// ===========================================================================
+
+#[test]
+fn cli_delete_tombstone_absent_on_readback() {
+    let tmp = TempDir::new().unwrap();
+    let schema = write_schema(tmp.path());
+    let wd = tmp.path().join("wd");
+
+    dml(
+        &wd,
+        &schema,
+        "INSERT INTO test_write.users (id, name, age, active) VALUES (1, 'Alice', 30, true)",
+    );
+    dml(
+        &wd,
+        &schema,
+        "INSERT INTO test_write.users (id, name, age, active) VALUES (2, 'Bob', 25, false)",
+    );
+    dml(&wd, &schema, "DELETE FROM test_write.users WHERE id = 2");
+    flush(&wd, &schema);
+
+    let rows = select_rows(&wd.join("data"), &schema, "SELECT * FROM test_write.users");
+    assert!(
+        row_with_id(&rows, 2).is_none(),
+        "deleted row id=2 must be absent, got: {rows:?}"
+    );
+    let surviving = row_with_id(&rows, 1).expect("surviving row id=1 must be present");
+    assert_eq!(
+        surviving["name"].as_str(),
+        Some("Alice"),
+        "survivor corrupted: {surviving}"
+    );
+    assert_eq!(
+        surviving["age"].as_i64(),
+        Some(30),
+        "survivor corrupted: {surviving}"
+    );
+}
+
+// ===========================================================================
+// AC #2: binary-level `export-sstable` — write → export → reopen the EXPORTED
+// SSTable → assert content.
+// ===========================================================================
+
+#[test]
+fn cli_export_sstable_reopen_exported_asserts_content() {
+    let tmp = TempDir::new().unwrap();
+    let schema = write_schema(tmp.path());
+    let wd = tmp.path().join("wd");
+    let export_dir = tmp.path().join("exported");
+
+    dml(
+        &wd,
+        &schema,
+        "INSERT INTO test_write.users (id, name, age, active) VALUES (7, 'Zara', 42, true)",
+    );
+
+    // export-sstable replays the WAL into the memtable and writes a fresh
+    // SSTable under <export_dir>/<keyspace>/<table>/.
+    let out = write_cmd(
+        &wd,
+        &schema,
+        &[
+            "export-sstable",
+            export_dir.to_str().unwrap(),
+            "--keyspace",
+            "test_write",
+            "--table",
+            "users",
+        ],
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "export-sstable failed\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("Export complete:"),
+        "export shape: {stdout}"
+    );
+
+    // Reopen the EXPORTED SSTable (not the write-dir) and assert content.
+    let rows = select_rows(&export_dir, &schema, "SELECT * FROM test_write.users");
+    assert_eq!(
+        rows.len(),
+        1,
+        "exported SSTable should hold one row, got: {rows:?}"
+    );
+    let row = &rows[0];
+    assert_eq!(row["id"].as_i64(), Some(7), "exported id mismatch: {row}");
+    assert_eq!(
+        row["name"].as_str(),
+        Some("Zara"),
+        "exported name mismatch: {row}"
+    );
+    assert_eq!(
+        row["age"].as_i64(),
+        Some(42),
+        "exported age mismatch: {row}"
+    );
+    assert_eq!(
+        row["active"].as_bool(),
+        Some(true),
+        "exported active mismatch: {row}"
+    );
+}
+
+// ===========================================================================
+// AC #2: subcommand glue smoke — flags parse, `--writable` gating, output shape
+// for write-stats / maintenance / compact.
+// ===========================================================================
+
+#[test]
+fn cli_write_stats_subcommand_glue() {
+    let tmp = TempDir::new().unwrap();
+    let schema = write_schema(tmp.path());
+    let wd = tmp.path().join("wd");
+
+    // With --writable the subcommand runs and prints the stats banner.
+    let out = write_cmd(&wd, &schema, &["write-stats"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "write-stats should succeed under --writable"
+    );
+    assert!(
+        stdout.contains("Write Engine Statistics:"),
+        "write-stats output shape: {stdout}"
+    );
+
+    // Without --writable the subcommand must be gated (no write engine).
+    let gated = run(&[
+        "--data-dir",
+        wd.to_str().unwrap(),
+        "--schema",
+        schema.to_str().unwrap(),
+        "write-stats",
+    ]);
+    assert!(
+        !gated.status.success(),
+        "write-stats without --writable must fail (gating)"
+    );
+}
+
+#[test]
+fn cli_maintenance_subcommand_glue() {
+    let tmp = TempDir::new().unwrap();
+    let schema = write_schema(tmp.path());
+    let wd = tmp.path().join("wd");
+
+    let out = write_cmd(&wd, &schema, &["maintenance", "--budget-ms", "50"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "maintenance should succeed under --writable"
+    );
+    assert!(
+        stdout.contains("Maintenance complete:"),
+        "maintenance output shape: {stdout}"
+    );
+
+    // Gating: maintenance without --writable must fail.
+    let gated = run(&[
+        "--data-dir",
+        wd.to_str().unwrap(),
+        "--schema",
+        schema.to_str().unwrap(),
+        "maintenance",
+        "--budget-ms",
+        "50",
+    ]);
+    assert!(
+        !gated.status.success(),
+        "maintenance without --writable must fail (gating)"
+    );
+}
+
+#[test]
+fn cli_compact_subcommand_glue() {
+    let tmp = TempDir::new().unwrap();
+    let schema = write_schema(tmp.path());
+    let wd = tmp.path().join("wd");
+    let out_dir = tmp.path().join("compacted");
+
+    // Produce one published input SSTable via the write path.
+    dml(
+        &wd,
+        &schema,
+        "INSERT INTO test_write.users (id, name, age, active) VALUES (5, 'Cara', 19, true)",
+    );
+    flush(&wd, &schema);
+    let input_dir = wd.join("data").join("test_write").join("users");
+
+    // `compact` is policy-free and operates directly on the input files.
+    let out = run(&[
+        "compact",
+        input_dir.to_str().unwrap(),
+        "--output",
+        out_dir.to_str().unwrap(),
+        "--schema",
+        schema.to_str().unwrap(),
+        "--generation",
+        "9",
+    ]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "compact failed\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("OK: compacted"),
+        "compact output shape: {stdout}"
+    );
+
+    // The compacted SSTable must reopen and still decode to the written values.
+    let rows = select_rows(&out_dir, &schema, "SELECT * FROM test_write.users");
+    assert_eq!(
+        rows.len(),
+        1,
+        "compacted output should hold one row, got: {rows:?}"
+    );
+    let row = &rows[0];
+    assert_eq!(row["id"].as_i64(), Some(5), "compacted id mismatch: {row}");
+    assert_eq!(
+        row["name"].as_str(),
+        Some("Cara"),
+        "compacted name mismatch: {row}"
+    );
+}

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -21,7 +21,8 @@
 #   format-compat      cargo test -p format-compatibility-tests (the 'oa' format crate;
 #                      issue #865 folded it into the workspace so fmt/clippy reach it)
 #   write-tests        cargo test -p cqlite-core --features write-support (lib + roundtrip + compaction)
-#   cli-tests          cargo test -p cqlite-cli --test unit_tests
+#   cli-tests          cargo test -p cqlite-cli --test unit_tests + (write-support)
+#                      write_readback_content_tests (CQL write→read content parity, #1231)
 #   python-bindings    maturin develop + pytest bindings/python/tests in a throwaway
 #                      venv; SKIPs (never silently PASSes) if python3 is unavailable.
 #                      Set RUN_SLOW_TESTS=1 to also run the CLI-parity suite.
@@ -674,7 +675,9 @@ run_component write-tests bash -c '
   cargo test --package cqlite-core --features write-support --lib &&
   cargo test --package cqlite-core --features write-support --test write_read_roundtrip &&
   cargo test --package cqlite-core --features write-support --test compaction_integration'
-run_component cli-tests cargo test --package cqlite-cli --test unit_tests
+run_component cli-tests bash -c '
+  cargo test --package cqlite-cli --test unit_tests &&
+  cargo test --package cqlite-cli --features write-support --test write_readback_content_tests'
 run_python_bindings
 run_delivery_telemetry
 run_tooling_tests


### PR DESCRIPTION
Closes #1231. Child of epic #1227 (coverage-integrity). Oracle/infra — wiring-evidence for the write path.

## Problem
The write path was two green halves that never met through a public surface: CQL→Mutation tests asserted only the in-memory struct; Mutation→SSTable tests built Mutations by hand (bypassing CQL). Every test hitting a public write surface asserted exit-code / rows_affected / file-exists — never content. A write-format bug emitting a structurally-present but semantically-wrong Data.db passed green.

## What this adds — one content-asserting round-trip per public write surface
Each drives the full public chain: CQL string → parser → Mutation → WriteEngine → flush → SSTable → independent reopen → SELECT → **assert decoded VALUES**.
- **CLI** `cqlite-cli/tests/write_readback_content_tests.rs` (7): INSERT, UPDATE (overwrite wins), DELETE (tombstone→absent), binary-level **export-sstable** read-back (write→export→reopen exported SSTable→assert content), and **compact/maintenance/write-stats** glue smoke (compact reopens + asserts content).
- **Python** `bindings/python/tests/test_write_readback_content.py` (3): execute INSERT/UPDATE/DELETE → flush_run → reopen → SELECT → assert values.
- **Node** `bindings/node/__test__/write-readback-content.test.js` (3): same via the public Node API.

All build their own SSTables in tempdirs — no fixture-corpus dependency.

## CI wiring (so write-format regressions red CI)
- CLI: new `ci.yml` step + gate `cli-tests` component.
- Python: `python-ci.yml` pytest + gate `python-bindings`.
- Node: `node-ci.yml` `npm test` (builds `--features write-support`).

## Wiring-evidence (teeth proven)
Each round-trip reopens independently and asserts values. Teeth verified on all three by momentarily asserting a wrong value and confirming failure, then reverting (CLI: Alice→WRONG_NAME failed; Python/Node similarly).

## Gate
`scripts/agent-gate.sh` → **RESULT: PASS** (all 15 components).

## Discovered (filing separately) — a real bug this exposes
CLI single-invocation `--execute "INSERT..." --flush` does NOT persist: `--flush` is handled before `--execute`, and `--execute INSERT` returns early with no flush-on-drop, so the combined form flushes an empty memtable (insert lands only in the WAL). The old `test_cli_execute_insert_then_flush` passed anyway (shape-only) — exactly the hazard this issue targets. The durable path (used by these tests) is WAL-backed across invocations. CLAUDE.md's combined example is misleading.

🤖 worker: oracle/infra, 1:1:1:1.