### PR TITLE
ci: shard core tests and enable sccache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,8 @@ env:
   DATASET_SHA256: bebc763752c8d68c7fb0483a1b31294b4d1d21343d3f7d124da069e5073202fa
 
 jobs:
-  core_tests:
-    name: Core tests
+  core_lib_doc_tests:
+    name: Core lib/doc tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -58,6 +58,14 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Enable sccache
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
 
       - name: Cache cargo
         uses: actions/cache@v5
@@ -129,17 +137,123 @@ jobs:
           fi
           echo "::endgroup::"
 
-      - name: Run core tests
+      - name: Run core lib/doc tests with timings
         env:
           CQLITE_DATASETS_ROOT: ${{ github.workspace }}/test-data/datasets
           RUST_LOG: debug
           RUST_BACKTRACE: full
+        run: bash scripts/ci/run-core-test-group.sh lib-doc
+
+      - name: Show sccache stats
+        if: always()
+        run: ${SCCACHE_PATH:-sccache} --show-stats
+
+  core_integration_shards:
+    name: Core integration tests shard ${{ matrix.shard }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2]
+    env:
+      CORE_TEST_SHARD_INDEX: ${{ matrix.shard }}
+      CORE_TEST_SHARD_TOTAL: 3
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      # Rust test jobs can sit near the standard runner's disk ceiling (issue
+      # #722). Dropping preinstalled toolchains we never use frees ~14 GB.
+      - name: Free disk space (issue #722)
         run: |
-          echo "🧪 Running core tests..."
-          echo "CQLITE_DATASETS_ROOT=$CQLITE_DATASETS_ROOT"
-          echo "Checking dataset files:"
-          ls -la "$CQLITE_DATASETS_ROOT/sstables/test_basic/" || echo "test_basic directory not found"
-          cargo test --package cqlite-core --features cli-helpers -- --skip test_legacy_format_allows_blob_fallback_with_feature
+          df -h / | tail -1
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup /usr/local/lib/android /opt/hostedtoolcache/CodeQL
+          df -h / | tail -1
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Enable sccache
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+
+      - name: Cache cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Restore dataset cache
+        uses: actions/cache@v5
+        with:
+          path: test-data/datasets
+          key: datasets-${{ env.DATASET_TAG }}-${{ env.DATASET_SHA256 }}
+
+      - name: Fetch datasets if required fixture data missing
+        run: bash ./test-data/scripts/fetch-datasets.sh
+
+      - name: Sanity check dataset
+        run: |
+          set -euo pipefail
+          test -f test-data/datasets/metadata.yml
+          CORE_FIXTURE=$(find test-data/datasets/sstables/test_basic -path '*simple_table-*-Data.db' 2>/dev/null || true)
+          if [ -z "$CORE_FIXTURE" ]; then
+            echo "❌ Core fixture test_basic/simple_table-*/*-Data.db missing after fetch" >&2
+            exit 1
+          fi
+          GOLDEN_JSONL="test-data/datasets/sstables/test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294/nb-2-big-Data.db.jsonl"
+          if [ ! -s "$GOLDEN_JSONL" ]; then
+            echo "❌ Required JSONL golden missing after fetch: ${GOLDEN_JSONL}" >&2
+            exit 1
+          fi
+          echo "✅ Core fixture present: ${CORE_FIXTURE}"
+          echo "✅ Required JSONL golden present: ${GOLDEN_JSONL}"
+
+      - name: Run core integration shard with timings
+        env:
+          CQLITE_DATASETS_ROOT: ${{ github.workspace }}/test-data/datasets
+          RUST_LOG: debug
+          RUST_BACKTRACE: full
+        run: bash scripts/ci/run-core-test-group.sh integration-shard
+
+      - name: Show sccache stats
+        if: always()
+        run: ${SCCACHE_PATH:-sccache} --show-stats
+
+  core_tests:
+    name: Core tests
+    runs-on: ubuntu-latest
+    needs:
+      - core_lib_doc_tests
+      - core_integration_shards
+    if: ${{ always() }}
+    steps:
+      - name: Check core test shards
+        run: |
+          set -euo pipefail
+          failed=0
+
+          check_result() {
+            local job="$1"
+            local result="$2"
+            if [ "$result" != "success" ]; then
+              echo "❌ ${job}: ${result}" >&2
+              failed=1
+            else
+              echo "✅ ${job}: ${result}"
+            fi
+          }
+
+          check_result "core_lib_doc_tests" "${{ needs.core_lib_doc_tests.result }}"
+          check_result "core_integration_shards" "${{ needs.core_integration_shards.result }}"
+          exit "$failed"
 
   integration_tests:
     name: Integration tests
@@ -156,6 +270,14 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Enable sccache
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
 
       - name: Cache cargo
         uses: actions/cache@v5
@@ -210,6 +332,10 @@ jobs:
             --test golden_path_scan_operations_tests \
             --test golden_path_summary_index_integration_tests
 
+      - name: Show sccache stats
+        if: always()
+        run: ${SCCACHE_PATH:-sccache} --show-stats
+
   write_support_tests:
     name: Write-support tests
     runs-on: ubuntu-latest
@@ -225,6 +351,14 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Enable sccache
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
 
       - name: Cache cargo
         uses: actions/cache@v5
@@ -248,6 +382,10 @@ jobs:
           # folded into clustering rows (fully synthetic — no fixtures required).
           cargo test --package cqlite-core --features write-support --test issue_1074_static_write_parity
 
+      - name: Show sccache stats
+        if: always()
+        run: ${SCCACHE_PATH:-sccache} --show-stats
+
   delta_scan_tests:
     name: Delta-scan tests
     runs-on: ubuntu-latest
@@ -257,6 +395,14 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Enable sccache
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
 
       - name: Cache cargo
         uses: actions/cache@v5
@@ -275,6 +421,10 @@ jobs:
           # not require fixture data.
           cargo test --package cqlite-core --features delta-scan --lib
 
+      - name: Show sccache stats
+        if: always()
+        run: ${SCCACHE_PATH:-sccache} --show-stats
+
   cli_smoke_tests:
     name: CLI tests and smoke
     runs-on: ubuntu-latest
@@ -290,6 +440,14 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Enable sccache
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
 
       - name: Cache cargo
         uses: actions/cache@v5
@@ -359,6 +517,10 @@ jobs:
           path: test-data/scripts/smoke-test-results/
           retention-days: 7
 
+      - name: Show sccache stats
+        if: always()
+        run: ${SCCACHE_PATH:-sccache} --show-stats
+
   test:
     name: test
     runs-on: ubuntu-latest
@@ -426,6 +588,14 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Enable sccache
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+
       - name: Cache cargo
         uses: actions/cache@v5
         with:
@@ -437,6 +607,10 @@ jobs:
 
       - name: cargo publish --dry-run (cqlite-core)
         run: cargo publish --package cqlite-core --dry-run
+
+      - name: Show sccache stats
+        if: always()
+        run: ${SCCACHE_PATH:-sccache} --show-stats
 
   # Guards the delivery-pipeline tooling itself (issue #1162). The flow-finalize
   # cleanup destroyed an unrelated active claim via an issue-<N>-* glob on

--- a/scripts/ci/run-core-test-group.sh
+++ b/scripts/ci/run-core-test-group.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="${1:-}"
+SKIP_TEST="test_legacy_format_allows_blob_fallback_with_feature"
+SUMMARY_FILE="${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+if [ -z "${MODE}" ]; then
+  echo "usage: $0 <lib-doc|integration-shard>" >&2
+  exit 2
+fi
+
+write_summary_header() {
+  local title="$1"
+  {
+    echo "### ${title}"
+    echo
+    echo "| Group | Status | Duration |"
+    echo "|---|---:|---:|"
+  } >> "${SUMMARY_FILE}"
+}
+
+write_summary_row() {
+  local label="$1"
+  local status="$2"
+  local duration="$3"
+  printf '| %s | %s | %ss |\n' "${label}" "${status}" "${duration}" >> "${SUMMARY_FILE}"
+}
+
+timed_run() {
+  local label="$1"
+  shift
+
+  local start end duration status
+  start="$(date +%s)"
+  echo "::group::${label}"
+  printf '+'
+  printf ' %q' "$@"
+  printf '\n'
+
+  set +e
+  "$@"
+  status="$?"
+  set -e
+
+  end="$(date +%s)"
+  duration="$((end - start))"
+
+  if [ "${status}" -eq 0 ]; then
+    write_summary_row "${label}" "success" "${duration}"
+  else
+    write_summary_row "${label}" "failed (${status})" "${duration}"
+  fi
+
+  echo "::endgroup::"
+  return "${status}"
+}
+
+run_lib_doc() {
+  write_summary_header "Core lib/doc test timings"
+
+  if [ "${CORE_TEST_DRY_RUN:-}" = "1" ]; then
+    echo "Dry run: would run cqlite-core lib tests, doc tests, and example builds"
+    write_summary_row "cqlite-core lib/doc dry run" "success" "0"
+    return 0
+  fi
+
+  timed_run "cqlite-core lib tests" \
+    cargo test --package cqlite-core --features cli-helpers --lib -- --skip "${SKIP_TEST}"
+  timed_run "cqlite-core doc tests" \
+    cargo test --package cqlite-core --features cli-helpers --doc
+  timed_run "cqlite-core example builds" \
+    cargo test --package cqlite-core --features cli-helpers --examples --no-run
+}
+
+run_integration_shard() {
+  local shard_index="${CORE_TEST_SHARD_INDEX:-}"
+  local shard_total="${CORE_TEST_SHARD_TOTAL:-}"
+
+  if [ -z "${shard_index}" ] || [ -z "${shard_total}" ]; then
+    echo "CORE_TEST_SHARD_INDEX and CORE_TEST_SHARD_TOTAL must be set" >&2
+    exit 2
+  fi
+
+  if ! [[ "${shard_index}" =~ ^[0-9]+$ ]] || ! [[ "${shard_total}" =~ ^[0-9]+$ ]]; then
+    echo "Shard index and total must be non-negative integers" >&2
+    exit 2
+  fi
+
+  if [ "${shard_total}" -le 0 ] || [ "${shard_index}" -ge "${shard_total}" ]; then
+    echo "Invalid shard ${shard_index}/${shard_total}" >&2
+    exit 2
+  fi
+
+  local all_tests=()
+  local selected_tests=()
+  mapfile -t all_tests < <(
+    find cqlite-core/tests -maxdepth 1 -type f -name '*.rs' -print \
+      | sed 's#^cqlite-core/tests/##; s#\.rs$##' \
+      | sort
+  )
+
+  local idx
+  for idx in "${!all_tests[@]}"; do
+    if [ "$((idx % shard_total))" -eq "${shard_index}" ]; then
+      selected_tests+=("${all_tests[$idx]}")
+    fi
+  done
+
+  if [ "${#selected_tests[@]}" -eq 0 ]; then
+    echo "No tests selected for shard ${shard_index}/${shard_total}" >&2
+    exit 1
+  fi
+
+  {
+    echo "### Core integration shard ${shard_index}/${shard_total}"
+    echo
+    echo "Selected ${#selected_tests[@]} of ${#all_tests[@]} cqlite-core integration test binaries."
+    echo
+    echo "<details><summary>Selected test binaries</summary>"
+    echo
+    printf -- '- `%s`\n' "${selected_tests[@]}"
+    echo
+    echo "</details>"
+    echo
+    echo "| Group | Status | Duration |"
+    echo "|---|---:|---:|"
+  } >> "${SUMMARY_FILE}"
+
+  if [ "${CORE_TEST_DRY_RUN:-}" = "1" ]; then
+    echo "Dry run: selected ${#selected_tests[@]} of ${#all_tests[@]} cqlite-core integration test binaries"
+    printf '%s\n' "${selected_tests[@]}"
+    write_summary_row "cqlite-core integration shard ${shard_index}/${shard_total} dry run" "success" "0"
+    return 0
+  fi
+
+  local cmd=(cargo test --package cqlite-core --features cli-helpers)
+  local test_name
+  for test_name in "${selected_tests[@]}"; do
+    cmd+=(--test "${test_name}")
+  done
+  cmd+=(-- --skip "${SKIP_TEST}")
+
+  timed_run "cqlite-core integration shard ${shard_index}/${shard_total}" "${cmd[@]}"
+}
+
+case "${MODE}" in
+  lib-doc)
+    run_lib_doc
+    ;;
+  integration-shard)
+    run_integration_shard
+    ;;
+  *)
+    echo "unknown mode: ${MODE}" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Summary
- Add scripts/ci/run-core-test-group.sh to time core lib/doc/example checks and deterministic integration shards
- Split the Core tests gate into lib/doc plus three integration shard jobs, keeping a Core tests aggregate check
- Enable mozilla-actions/sccache-action v0.0.10 for cargo-heavy CI jobs and print sccache stats after each job

## Expected measurement
The current bottleneck is Core tests at about 16m45s. This PR should show whether sharding plus sccache lowers that critical path or whether duplicated compile work offsets the sharding benefit.

## Local validation
- bash -n scripts/ci/run-core-test-group.sh
- Parsed all workflow YAML files with Ruby
- Verified workflow job graph with Ruby
- git diff --check for workflow and helper script
- Dry-ran core shard selection: 185 cqlite-core integration tests split 62 / 62 / 61
- Verified latest mozilla-actions/sccache-action release tag is v0.0.10 via GitHub API

Note: actionlint is not installed locally, so the PR run is the expression and action-resolution authority.