### PR TITLE
fix(#1222): compaction CRC.db full byte parity (trailing empty-chunk CRC32=0)

### DIFF
--- a/cqlite-core/src/storage/sstable/writer/crc_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/crc_writer.rs
@@ -33,6 +33,18 @@
 //!   For a single-chunk file the lone `CRC.db` entry therefore equals the
 //!   `Digest.crc32` value.
 //!
+//! # Flush vs compaction: the trailing empty-chunk CRC32 (issue #1222)
+//!
+//! Cassandra's **compaction** write path (`CompactionAwareWriter` →
+//! `SSTableRewriter` → `BigTableWriter`) flushes the data `SequentialWriter` once
+//! more at close after the last real chunk, checksumming a ZERO-length buffer.
+//! `java.util.zip.CRC32` over zero bytes is `0`, so the compacted `CRC.db` carries
+//! one extra trailing `00000000` group after the last real per-chunk CRC32. The
+//! **flush** path does NOT do this (verified against the #1190 flush goldens,
+//! whose `CRC.db` ends exactly on the last real chunk CRC). The writer therefore
+//! takes an explicit [`CrcTrailer`] so the compaction path can request the
+//! trailing empty-chunk CRC32 without changing the byte-identical flush output.
+//!
 //! # Seek formula (read side)
 //!
 //! To locate the CRC for byte `offset` in Data.db:
@@ -50,6 +62,25 @@ use crate::error::Result;
 /// over which each per-chunk CRC32 is computed.
 pub const CRC_CHUNK_SIZE: usize = 64 * 1024;
 
+/// Whether the `CRC.db` carries Cassandra's compaction-only trailing
+/// empty-final-chunk CRC32 (issue #1222).
+///
+/// The two SSTable write paths produce byte-different `CRC.db` tails:
+/// - [`CrcTrailer::None`] — the **flush** path: the file ends on the last real
+///   per-chunk CRC32. This is the byte-identical match for the #1190 flush
+///   goldens and MUST stay unchanged.
+/// - [`CrcTrailer::EmptyFinalChunk`] — the **compaction** path: Cassandra's
+///   `CompactionAwareWriter` flushes the data writer once more at close over a
+///   zero-length buffer, appending one trailing `00000000` (`CRC32` of zero
+///   bytes). This is the byte-identical match for the #1017 compacted goldens.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum CrcTrailer {
+    /// No trailing chunk — the flush path (default).
+    None,
+    /// Append one trailing empty-final-chunk `CRC32 = 0` — the compaction path.
+    EmptyFinalChunk,
+}
+
 /// Compute the `CRC.db` bytes for an uncompressed `Data.db`.
 ///
 /// Streams `data_path` in `CRC_CHUNK_SIZE` blocks (bounded memory, independent
@@ -57,9 +88,14 @@ pub const CRC_CHUNK_SIZE: usize = 64 * 1024;
 /// `finish.rs`) and emits the Cassandra `CRC.db` layout: a big-endian `i32`
 /// chunk-size header followed by one big-endian `u32` CRC32 per chunk.
 ///
+/// When `trailer` is [`CrcTrailer::EmptyFinalChunk`] (the compaction path,
+/// issue #1222), one extra big-endian `u32` `CRC32 = 0` is appended after the
+/// last real chunk, matching Cassandra's compaction close-time empty-buffer
+/// flush. [`CrcTrailer::None`] (the flush path) appends nothing.
+///
 /// An empty `Data.db` yields just the 4-byte header (zero chunks), matching
 /// Cassandra's behaviour when no data buffer is ever flushed.
-pub(super) async fn build_crc_bytes(data_path: &Path) -> Result<Vec<u8>> {
+pub(super) async fn build_crc_bytes(data_path: &Path, trailer: CrcTrailer) -> Result<Vec<u8>> {
     use tokio::io::AsyncReadExt;
 
     let mut out = Vec::new();
@@ -92,6 +128,15 @@ pub(super) async fn build_crc_bytes(data_path: &Path) -> Result<Vec<u8>> {
         }
     }
 
+    // Compaction-only trailing empty-final-chunk CRC32 (issue #1222). Cassandra's
+    // compaction close flushes the data writer once more over a zero-length
+    // buffer; CRC32 of zero bytes is 0, so emit one trailing `00000000`. The
+    // flush path (CrcTrailer::None) never reaches this.
+    if matches!(trailer, CrcTrailer::EmptyFinalChunk) {
+        let empty_crc = crc32fast::Hasher::new().finalize();
+        out.extend_from_slice(&empty_crc.to_be_bytes());
+    }
+
     Ok(out)
 }
 
@@ -100,8 +145,16 @@ pub(super) async fn build_crc_bytes(data_path: &Path) -> Result<Vec<u8>> {
 ///
 /// Computes the per-chunk CRC bytes (see [`build_crc_bytes`]) and writes them to
 /// `crc_path`. Callers add the returned path to `TOC.txt` and `SSTableInfo`.
-pub(super) async fn write_crc_db(data_path: &Path, crc_path: PathBuf) -> Result<PathBuf> {
-    let bytes = build_crc_bytes(data_path).await?;
+///
+/// `trailer` selects the flush vs compaction tail (issue #1222): flush callers
+/// pass [`CrcTrailer::None`]; compaction callers pass
+/// [`CrcTrailer::EmptyFinalChunk`].
+pub(super) async fn write_crc_db(
+    data_path: &Path,
+    crc_path: PathBuf,
+    trailer: CrcTrailer,
+) -> Result<PathBuf> {
+    let bytes = build_crc_bytes(data_path, trailer).await?;
     tokio::fs::write(&crc_path, bytes).await?;
     Ok(crc_path)
 }
@@ -116,8 +169,46 @@ mod tests {
         let data = dir.path().join("Data.db");
         tokio::fs::write(&data, b"").await.expect("write data");
 
-        let bytes = build_crc_bytes(&data).await.expect("crc bytes");
+        let bytes = build_crc_bytes(&data, CrcTrailer::None)
+            .await
+            .expect("crc bytes");
         assert_eq!(bytes, (CRC_CHUNK_SIZE as i32).to_be_bytes().to_vec());
+    }
+
+    #[tokio::test]
+    async fn compaction_trailer_appends_one_empty_chunk_crc32_zero() {
+        // Issue #1222: the compaction path appends one trailing empty-final-chunk
+        // CRC32 = 0 (00000000) after the last real chunk; the flush path does not.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let data = dir.path().join("Data.db");
+        let payload = b"compaction crc.db trailer parity";
+        tokio::fs::write(&data, payload).await.expect("write data");
+
+        let flush = build_crc_bytes(&data, CrcTrailer::None)
+            .await
+            .expect("flush crc bytes");
+        let compaction = build_crc_bytes(&data, CrcTrailer::EmptyFinalChunk)
+            .await
+            .expect("compaction crc bytes");
+
+        // Flush: header + 1 real chunk CRC.
+        assert_eq!(flush.len(), 8, "flush = header + 1 chunk crc");
+        // Compaction: flush bytes + a trailing 00000000.
+        assert_eq!(
+            compaction.len(),
+            flush.len() + 4,
+            "compaction appends one trailing chunk crc"
+        );
+        assert_eq!(
+            &compaction[..flush.len()],
+            &flush[..],
+            "compaction must be flush bytes plus the trailer (flush output unchanged)"
+        );
+        assert_eq!(
+            &compaction[flush.len()..],
+            &[0u8, 0, 0, 0],
+            "trailing chunk crc32 of an empty buffer is 0"
+        );
     }
 
     #[tokio::test]
@@ -129,7 +220,9 @@ mod tests {
         let payload = b"hello cqlite crc.db parity";
         tokio::fs::write(&data, payload).await.expect("write data");
 
-        let bytes = build_crc_bytes(&data).await.expect("crc bytes");
+        let bytes = build_crc_bytes(&data, CrcTrailer::None)
+            .await
+            .expect("crc bytes");
         assert_eq!(bytes.len(), 8, "header + 1 crc");
 
         let header = i32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
@@ -150,7 +243,9 @@ mod tests {
         let payload: Vec<u8> = (0..len).map(|i| (i % 251) as u8).collect();
         tokio::fs::write(&data, &payload).await.expect("write data");
 
-        let bytes = build_crc_bytes(&data).await.expect("crc bytes");
+        let bytes = build_crc_bytes(&data, CrcTrailer::None)
+            .await
+            .expect("crc bytes");
         // header(4) + 3 CRCs(4 each)
         assert_eq!(bytes.len(), 4 + 3 * 4);
 

--- a/cqlite-core/src/storage/sstable/writer/crc_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/crc_writer.rs
@@ -94,7 +94,14 @@ pub(super) enum CrcTrailer {
 /// flush. [`CrcTrailer::None`] (the flush path) appends nothing.
 ///
 /// An empty `Data.db` yields just the 4-byte header (zero chunks), matching
-/// Cassandra's behaviour when no data buffer is ever flushed.
+/// Cassandra's behaviour when no data buffer is ever flushed. This empty-file
+/// behaviour is preserved for BOTH trailers: the compaction trailing
+/// empty-final-chunk `CRC32 = 0` is appended only when at least one real data
+/// chunk was checksummed (non-empty `Data.db`). A compaction that purges all
+/// partitions and finalizes an empty BIG SSTable therefore still gets the
+/// documented header-only `CRC.db`, never a lone trailing `00000000` after the
+/// header — the trailing zero only makes sense after a real chunk, and we have
+/// no Cassandra golden for the empty-compaction case (issue #1222 roborev).
 pub(super) async fn build_crc_bytes(data_path: &Path, trailer: CrcTrailer) -> Result<Vec<u8>> {
     use tokio::io::AsyncReadExt;
 
@@ -105,6 +112,10 @@ pub(super) async fn build_crc_bytes(data_path: &Path, trailer: CrcTrailer) -> Re
     let mut file = tokio::fs::File::open(data_path).await?;
     let mut buffer = vec![0u8; CRC_CHUNK_SIZE];
     let mut filled = 0usize;
+    // Track whether any real data-chunk CRC was emitted (non-empty Data.db). The
+    // compaction trailer is gated on this so an empty Data.db keeps the
+    // documented header-only output for both trailers (issue #1222).
+    let mut emitted_real_chunk = false;
     loop {
         // Fill up to a full chunk before checksumming so each CRC covers a
         // complete CRC_CHUNK_SIZE block (except the final, short chunk), exactly
@@ -116,6 +127,7 @@ pub(super) async fn build_crc_bytes(data_path: &Path, trailer: CrcTrailer) -> Re
                 let mut hasher = crc32fast::Hasher::new();
                 hasher.update(&buffer[..filled]);
                 out.extend_from_slice(&hasher.finalize().to_be_bytes());
+                emitted_real_chunk = true;
             }
             break;
         }
@@ -124,6 +136,7 @@ pub(super) async fn build_crc_bytes(data_path: &Path, trailer: CrcTrailer) -> Re
             let mut hasher = crc32fast::Hasher::new();
             hasher.update(&buffer[..filled]);
             out.extend_from_slice(&hasher.finalize().to_be_bytes());
+            emitted_real_chunk = true;
             filled = 0;
         }
     }
@@ -131,8 +144,12 @@ pub(super) async fn build_crc_bytes(data_path: &Path, trailer: CrcTrailer) -> Re
     // Compaction-only trailing empty-final-chunk CRC32 (issue #1222). Cassandra's
     // compaction close flushes the data writer once more over a zero-length
     // buffer; CRC32 of zero bytes is 0, so emit one trailing `00000000`. The
-    // flush path (CrcTrailer::None) never reaches this.
-    if matches!(trailer, CrcTrailer::EmptyFinalChunk) {
+    // flush path (CrcTrailer::None) never reaches this. Gated on a real chunk
+    // having been emitted: an empty Data.db keeps the documented header-only
+    // output even on the compaction path (the trailing zero only makes sense
+    // after at least one real data chunk, and there is no empty-compaction
+    // golden to match).
+    if matches!(trailer, CrcTrailer::EmptyFinalChunk) && emitted_real_chunk {
         let empty_crc = crc32fast::Hasher::new().finalize();
         out.extend_from_slice(&empty_crc.to_be_bytes());
     }
@@ -173,6 +190,36 @@ mod tests {
             .await
             .expect("crc bytes");
         assert_eq!(bytes, (CRC_CHUNK_SIZE as i32).to_be_bytes().to_vec());
+    }
+
+    #[tokio::test]
+    async fn empty_data_with_compaction_trailer_stays_header_only() {
+        // Issue #1222 (roborev): the compaction trailing empty-final-chunk
+        // CRC32 = 0 must be gated on a real data chunk having been emitted. An
+        // empty Data.db (e.g. a compaction that purges all partitions and
+        // finalizes an empty BIG SSTable) keeps the documented header-only
+        // CRC.db — NO trailing 00000000 — for BOTH trailers.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let data = dir.path().join("Data.db");
+        tokio::fs::write(&data, b"").await.expect("write data");
+
+        let header_only = (CRC_CHUNK_SIZE as i32).to_be_bytes().to_vec();
+
+        let flush = build_crc_bytes(&data, CrcTrailer::None)
+            .await
+            .expect("flush crc bytes");
+        let compaction = build_crc_bytes(&data, CrcTrailer::EmptyFinalChunk)
+            .await
+            .expect("compaction crc bytes");
+
+        assert_eq!(
+            flush, header_only,
+            "empty Data.db on the flush path is header-only"
+        );
+        assert_eq!(
+            compaction, header_only,
+            "empty Data.db on the compaction path stays header-only (no trailing 00000000)"
+        );
     }
 
     #[tokio::test]

--- a/cqlite-core/src/storage/sstable/writer/finish.rs
+++ b/cqlite-core/src/storage/sstable/writer/finish.rs
@@ -168,11 +168,21 @@ impl SSTableWriter {
         // CRC.db (verified against the Cassandra-written `da` fixtures), and the
         // compressed path carries per-chunk CRCs inline (CompressionInfo.db),
         // so this is gated on the BIG + uncompressed write path only.
+        // Flush vs compaction CRC.db tail (issue #1222). The compaction write
+        // path appends one trailing empty-final-chunk CRC32 = 0 (Cassandra's
+        // close-time zero-length buffer flush); the flush path does not. Selected
+        // by `is_compaction_output` so the flush CRC.db stays byte-identical to
+        // the #1190 goldens while the compaction CRC.db matches the #1017 goldens.
         let crc_path = if is_bti {
             None
         } else {
-            use crate::storage::sstable::writer::crc_writer;
-            Some(crc_writer::write_crc_db(&data_path, cpath("CRC.db")).await?)
+            use crate::storage::sstable::writer::crc_writer::{self, CrcTrailer};
+            let trailer = if self.is_compaction_output {
+                CrcTrailer::EmptyFinalChunk
+            } else {
+                CrcTrailer::None
+            };
+            Some(crc_writer::write_crc_db(&data_path, cpath("CRC.db"), trailer).await?)
         };
 
         // 7. Write TOC.txt (LAST - publication barrier).

--- a/cqlite-core/src/storage/sstable/writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/mod.rs
@@ -297,6 +297,15 @@ pub struct SSTableWriter {
     /// (>= 2 column-index blocks) — the row-index blocks. `None` for BIG so that
     /// path allocates nothing. See [`bti_state::PendingBtiPartition`].
     bti_pending: Option<Vec<bti_state::PendingBtiPartition>>,
+    /// Whether this writer produces a COMPACTION output (issue #1222).
+    ///
+    /// `false` for the default FLUSH path. When `true`, [`Self::finish`] emits
+    /// the uncompressed-BIG `CRC.db` with Cassandra's compaction-only trailing
+    /// empty-final-chunk `CRC32 = 0` (see [`crc_writer::CrcTrailer`]); the flush
+    /// path's `CRC.db` is byte-for-byte unchanged. Set via
+    /// [`Self::mark_compaction_output`] by the two compaction producers
+    /// (`compact_sstables` and the WriteEngine background compactor).
+    is_compaction_output: bool,
 }
 
 #[cfg(feature = "write-support")]
@@ -505,12 +514,26 @@ impl SSTableWriter {
             format,
             partitions_trie,
             bti_pending,
+            is_compaction_output: false,
         })
     }
 
     /// The on-disk index format this writer emits (issue #766).
     pub fn format(&self) -> SSTableFormat {
         self.format
+    }
+
+    /// Mark this writer as producing a COMPACTION output (issue #1222).
+    ///
+    /// Cassandra's compaction write path appends one trailing empty-final-chunk
+    /// `CRC32 = 0` to the uncompressed-BIG `CRC.db` (its close-time zero-length
+    /// buffer flush); the flush path does not. Compaction producers
+    /// (`compact_sstables`, the WriteEngine background compactor) call this so
+    /// [`Self::finish`] emits the byte-faithful compacted `CRC.db`. Leaving it
+    /// unset (the default) keeps the flush `CRC.db` byte-for-byte unchanged.
+    pub fn mark_compaction_output(&mut self) -> &mut Self {
+        self.is_compaction_output = true;
+        self
     }
 
     /// Write a partition (partition key + all mutations)

--- a/cqlite-core/src/storage/write_engine/compaction.rs
+++ b/cqlite-core/src/storage/write_engine/compaction.rs
@@ -195,6 +195,10 @@ impl WriteEngine {
             output_generation,
             &write_schema,
         )?;
+        // Compaction output (issue #1222): emit the uncompressed-BIG CRC.db with
+        // Cassandra's compaction-only trailing empty-final-chunk CRC32 = 0. The
+        // flush path leaves this unset, keeping its CRC.db byte-identical.
+        writer.mark_compaction_output();
 
         // Carry the inputs' shared repair state into the merged output's
         // Statistics.db (issue #1021). For a normal unrepaired corpus this is the

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -1796,6 +1796,9 @@ pub async fn compact_sstables_with_registry(
         repair_state.pending_repair,
         repair_state.is_transient,
     );
+    // Compaction output (issue #1222): emit the uncompressed-BIG CRC.db with
+    // Cassandra's compaction-only trailing empty-final-chunk CRC32 = 0.
+    writer.mark_compaction_output();
 
     // Two-pass compaction (issue #729): seed the output's encoding baselines from
     // the inputs' Statistics.db before writing any partition.

--- a/cqlite-core/tests/issue_1017_live_cell_compaction_byte_parity.rs
+++ b/cqlite-core/tests/issue_1017_live_cell_compaction_byte_parity.rs
@@ -41,18 +41,14 @@
 //!     here; any mismatch FAILS. This is the core compaction byte-parity claim:
 //!     the merged data artifact, its partition/row offset table, the summary
 //!     index, and the whole-file CRC32 all match Cassandra's compaction output.
-//!   * CRC.db → CQLite's bytes are a byte-identical PREFIX of Cassandra's: the
-//!     chunk-size header and every REAL per-chunk CRC32 match byte-for-byte. The
-//!     SOLE divergence is that Cassandra's COMPACTION write path appends one
-//!     trailing empty-final-chunk CRC32 = 0 (`00000000`) that its FLUSH path does
-//!     NOT (verified: the #1190 flush goldens carry no trailing chunk, so CQLite's
-//!     unified writer byte-matches flush CRC.db exactly). Replicating this
-//!     compaction-only artifact would require a flush-vs-compaction split in the
-//!     shared CRC writer and risks regressing the passing #1190 flush parity, so
-//!     it is documented + FLAGGED as a follow-up (see `assert_crc_db_prefix_parity`)
-//!     rather than expanded into this minimal slice. The check is STRICT: any
-//!     divergence in the matching bytes, or a trailing group that is NOT an
-//!     empty-chunk CRC32 = 0, FAILS.
+//!   * CRC.db → BYTE-IDENTICAL and diffed here (issue #1222, upgraded from the
+//!     #1017 prefix-only claim). The chunk-size header, every real per-chunk
+//!     CRC32, AND Cassandra's compaction-only trailing empty-final-chunk
+//!     CRC32 = 0 (`00000000`) all match byte-for-byte. CQLite's compaction write
+//!     path now appends that trailing empty-chunk CRC (its data-writer close-time
+//!     zero-length flush) via a flush-vs-compaction split in the shared CRC
+//!     writer (`crc_writer::CrcTrailer`); the FLUSH path is unchanged and stays
+//!     byte-identical to the #1190 flush goldens (regression-guarded there).
 //!   * Statistics.db and Filter.db → present on BOTH sides (asserted), but their
 //!     bytes are an implementation detail that CANNOT byte-match across two
 //!     independent engines (Statistics.db embeds metadata histograms + HyperLogLog
@@ -499,9 +495,15 @@ fn collect(dir: &Path, out: &mut Vec<(u64, PathBuf)>, depth: usize) {
 // ════════════════════════════════════════════════════════════════════════════
 
 /// Components diffed BYTE-FOR-BYTE between the compacted reference and candidate.
-/// CRC.db is handled separately (prefix parity) by [`assert_crc_db_prefix_parity`]
-/// because of Cassandra's compaction-only trailing empty-chunk CRC (see module docs).
-const BYTE_FOR_BYTE_COMPONENTS: &[&str] = &["Data.db", "Index.db", "Summary.db", "Digest.crc32"];
+/// CRC.db is now in this set (issue #1222): CQLite's compaction path emits
+/// Cassandra's trailing empty-final-chunk CRC32 = 0, so the whole CRC.db matches.
+const BYTE_FOR_BYTE_COMPONENTS: &[&str] = &[
+    "Data.db",
+    "Index.db",
+    "Summary.db",
+    "Digest.crc32",
+    "CRC.db",
+];
 
 /// Components present on BOTH sides but INTENTIONALLY NOT byte-diffed (their bytes
 /// are an implementation detail across two independent engines). Documented per
@@ -590,14 +592,15 @@ async fn assert_compaction_byte_parity(
         "{table}: TOC.txt component set differs (cass={ref_toc:?} ours={our_toc:?})"
     );
 
-    // ── 3. Byte-for-byte component set (AC3) ──
+    // ── 3. Byte-for-byte component set (AC3) — now includes CRC.db (#1222) ──
     for suffix in BYTE_FOR_BYTE_COMPONENTS {
         assert_component_bytes(table, &ref_dir, &out_dir, suffix);
     }
 
-    // ── 3b. CRC.db prefix parity (the chunk header + real chunk CRCs match;
-    //        Cassandra's compaction-only trailing empty-chunk CRC is documented) ──
-    assert_crc_db_prefix_parity(table, &ref_dir, &out_dir);
+    // ── 3b. CRC.db: confirm the compacted golden carries Cassandra's trailing
+    //        empty-final-chunk CRC32 = 0, so the byte-for-byte match above is the
+    //        meaningful #1222 upgrade (not a fixture that lost its trailer) ──
+    assert_crc_db_carries_compaction_trailer(table, &ref_dir);
 
     // ── 4. Present-but-not-diffed components: assert presence only (AC6) ──
     for suffix in PRESENT_NOT_DIFFED {
@@ -648,48 +651,38 @@ fn assert_component_bytes(table: &str, ref_dir: &Path, out_dir: &Path, suffix: &
     }
 }
 
-/// CRC.db prefix parity (see module docs). CQLite's CRC.db must be a
-/// byte-identical PREFIX of Cassandra's, and Cassandra's remaining suffix must
-/// consist SOLELY of trailing empty-chunk CRC32 = 0 groups (`00000000`). This
-/// strictly pins: (a) the 4-byte chunk-size header matches, (b) every real
-/// per-chunk CRC32 matches byte-for-byte, (c) the ONLY divergence is Cassandra's
-/// compaction-path trailing empty-chunk CRC. A divergence in the matching bytes,
-/// or a trailing 4-byte group that is not all-zero (i.e. a real data chunk CQLite
-/// dropped), FAILS.
-fn assert_crc_db_prefix_parity(table: &str, ref_dir: &Path, out_dir: &Path) {
+/// Confirm the compacted CRC.db GOLDEN ends with Cassandra's compaction-only
+/// trailing empty-final-chunk CRC32 = 0 (`00000000`) (issue #1222).
+///
+/// The byte-for-byte diff in `assert_component_bytes` already proves CQLite emits
+/// this trailer (its compaction path now appends it). This extra check guards the
+/// FIXTURE: it asserts the golden still carries the trailing zero chunk, so a
+/// future regeneration that somehow dropped it can't make the byte diff trivially
+/// pass against a CQLite output that also dropped it. The CRC.db must be at least
+/// header(4) + 1 real chunk(4) + trailer(4) = 12 bytes and end in `00000000`.
+fn assert_crc_db_carries_compaction_trailer(table: &str, ref_dir: &Path) {
     let cass = read_component(ref_dir, "CRC.db");
-    let ours = read_component(out_dir, "CRC.db");
     assert!(
-        !cass.is_empty() && !ours.is_empty(),
-        "{table}: CRC.db present-but-empty (cass={} ours={} bytes)",
+        cass.len() >= 12 && cass.len() % 4 == 0,
+        "{table}: CRC.db golden too short / misaligned for header + chunk + trailer \
+         (len={}, hex={})",
         cass.len(),
-        ours.len()
+        hex(&cass)
     );
-    // (a)+(b): ours is a byte-identical prefix of Cassandra's.
-    assert!(
-        ours.len() <= cass.len() && cass[..ours.len()] == ours[..],
-        "{table}: CRC.db prefix mismatch (cass={} ours={} bytes)\n  cass={}\n  ours={}",
-        cass.len(),
-        ours.len(),
-        hex(&cass),
-        hex(&ours)
-    );
-    // (c): the divergent suffix is whole 4-byte empty-chunk CRC32 = 0 groups only.
-    let suffix = &cass[ours.len()..];
-    assert!(
-        suffix.len() % 4 == 0 && suffix.iter().all(|&b| b == 0),
-        "{table}: CRC.db divergent suffix is NOT trailing empty-chunk CRC32=0 groups \
-         (a real data chunk was dropped?): suffix={} (cass={} ours={})",
-        hex(suffix),
-        hex(&cass),
-        hex(&ours)
+    let trailer = &cass[cass.len() - 4..];
+    assert_eq!(
+        trailer,
+        &[0u8, 0, 0, 0],
+        "{table}: compacted CRC.db golden must end in the compaction-only trailing \
+         empty-final-chunk CRC32=0 (#1222); got trailer {} (full={})",
+        hex(trailer),
+        hex(&cass)
     );
     eprintln!(
-        "[issue_1017] {table}: CRC.db prefix parity OK — header + {} real chunk CRC(s) \
-         byte-identical; Cassandra appends {} trailing empty-chunk CRC32=0 group(s) on the \
-         compaction path (documented follow-up, not a data divergence).",
-        (ours.len().saturating_sub(4)) / 4,
-        suffix.len() / 4
+        "[issue_1017/#1222] {table}: CRC.db FULL byte parity — header + {} real chunk \
+         CRC(s) + trailing empty-final-chunk CRC32=0, byte-identical to the Cassandra \
+         5.0.2 compacted golden.",
+        (cass.len() - 8) / 4
     );
 }
 


### PR DESCRIPTION
## Summary
Fixes #1222 — promotes compaction `CRC.db` from prefix-parity to **full byte-for-byte** parity vs Cassandra 5.0.2. Follow-up to #1017; parent epic #973.

### Root cause
The shared CRC.db writer emitted only the chunk-size header + one CRC32 per real data chunk. Cassandra's **compaction** write path flushes the data `SequentialWriter` once more over a zero-length buffer at close, appending one trailing empty-final-chunk `CRC32=0` (golden ends `…96c8f7f5` **+** `00000000`); its **flush** path does not. The single CRC.db call site (`finish.rs`) is shared by both paths with no distinction — so CQLite could only ever match a prefix of the compacted golden.

### Fix
- Added `SSTableWriter::mark_compaction_output()` (`is_compaction_output`, default false = flush). The two production compaction producers set it: `compact_sstables` (merge) + the WriteEngine background compactor. Flush never calls it → flush CRC.db byte-unchanged.
- `crc_writer.rs`: `CrcTrailer::{None, EmptyFinalChunk}`; `build_crc_bytes` appends one `00000000` for `EmptyFinalChunk` — but **only when ≥1 real data chunk was emitted**, so an empty Data.db keeps the documented header-only CRC.db (no speculative empty-compaction behavior). `finish.rs` selects the trailer from `is_compaction_output`.

### Tests (oracle-driven, byte parity)
- `compaction_trailer_appends_one_empty_chunk_crc32_zero` — compaction = flush bytes + one trailing `00000000` (proves flush unchanged).
- `empty_data_with_compaction_trailer_stays_header_only` — empty Data.db keeps header-only output even on the compaction path.
- `issue_1017_live_cell_compaction_byte_parity.rs` — CRC.db moved into `BYTE_FOR_BYTE_COMPONENTS` (was prefix-only); RED→GREEN.
- `issue_1190_write_load_byte_parity.rs` — flush CRC.db byte-for-byte regression guard, GREEN.

### Validation
- `scripts/agent-gate.sh`: **RESULT: PASS** (all components).
- roborev (codex, branch): **No issues found** (one empty-output edge case caught + fixed).
- Cassandra 5.0.2 only (live-cell BIG `nb` goldens).

Closes #1222.

🤖 flow-lead worker
