### PR TITLE
ci: run M1 parity and coverage concurrently

### DIFF
--- a/.github/workflows/m1-ci.yml
+++ b/.github/workflows/m1-ci.yml
@@ -403,12 +403,13 @@ jobs:
         exit "$failed"
 
   # SSTableDump Parity Harness
+  # Run independently from the core aggregate to avoid adding an avoidable
+  # post-validation tail to the M1 workflow. This remains a blocking job.
   sstabledump-parity-m1:
     name: 🔄 SSTableDump Parity Harness
     runs-on: ubuntu-latest
     timeout-minutes: 35
     continue-on-error: false
-    needs: [m1-core-validation]
     
     steps:
     - name: Checkout code
@@ -777,12 +778,13 @@ jobs:
       run: ${SCCACHE_PATH:-sccache} --show-stats
 
   # Coverage Analysis (informational)
+  # Non-blocking and independent from core validation, so start it immediately
+  # instead of waiting for the aggregate core gate.
   m1-coverage-analysis:
     name: 📊 Coverage Analysis (informational)
     runs-on: ubuntu-latest
     timeout-minutes: 20
     continue-on-error: true  # Non-blocking for M1
-    needs: [m1-core-validation]
     
     steps:
     - name: Checkout code


### PR DESCRIPTION
## Summary
- Start the M1 SSTableDump parity job immediately instead of waiting for the aggregate core validation job.
- Start informational M1 coverage immediately instead of waiting for the aggregate core validation job.
- Keep parity blocking, coverage non-blocking, and keep the aggregate core validation check intact.

## Expected timing impact
Baseline from PR #1258: CI: Core Library (minimal) took about 21m35s end-to-end. The slowest core lane was M1 quality checks at 11m12s, then parity/coverage started and coverage added a 10m10s tail. Running parity and coverage concurrently should move wall-clock time toward the slowest single lane, roughly 11-12 minutes if runner scheduling is similar.

## Local validation
- Parsed .github/workflows/m1-ci.yml with Ruby YAML
- Parsed all workflow YAML files with Ruby YAML
- Checked M1 job graph: core aggregate still depends on the four core lanes; parity/coverage no longer have needs; parity remains blocking; coverage remains non-blocking
- Ran workflow trigger policy validation
- Ran git diff --check

Note: actionlint is not installed locally.