### PR TITLE
ci: harden minimal feature cargo fetches

### DIFF
--- a/.github/workflows/ci-minimal-features.yml
+++ b/.github/workflows/ci-minimal-features.yml
@@ -22,6 +22,13 @@ concurrency:
   group: minimal-features-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  # Avoid one-shot failures from transient crates.io HTTP/2 framing errors.
+  CARGO_HTTP_MULTIPLEXING: false
+
 jobs:
   minimal-build:
     name: Minimal Build & Test


### PR DESCRIPTION
## Summary
- Add Cargo network retry hardening to Minimal Features CI
- Disable Cargo HTTP multiplexing for this lane to avoid transient crates.io HTTP/2 framing failures

## Root cause
The failing Minimal Features CI run died before compilation while fetching the crates.io sparse index entry for crossbeam:

`curl failed [16] Error in the HTTP2 framing layer`

## Local validation
- ruby workflow YAML parse for all workflows
- cargo build --no-default-features --features=lz4,snappy
- cargo build --no-default-features --features=all-compression
- cargo test --no-default-features --features=all-compression --quiet --lib
- cargo build --features=parquet
- cargo test --features=parquet --quiet --lib export::parquet
- default cargo tree excludes arrow/parquet