### PR TITLE
ci: split minimal feature validation lanes

### DIFF
--- a/.github/workflows/ci-minimal-features.yml
+++ b/.github/workflows/ci-minimal-features.yml
@@ -30,8 +30,8 @@ env:
   CARGO_HTTP_MULTIPLEXING: false
 
 jobs:
-  minimal-build:
-    name: Minimal Build & Test
+  minimal_compression_build:
+    name: Minimal Compression Build
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -49,6 +49,22 @@ jobs:
       - name: Build with minimal compression (lz4 + snappy only)
         run: cargo build --no-default-features --features=lz4,snappy
 
+  all_compression_test:
+    name: All Compression Build & Test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: cqlite-core
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+
       - name: Build with all compression support
         run: cargo build --no-default-features --features=all-compression
 
@@ -62,12 +78,44 @@ jobs:
           # is validating feature gating and minimal compilation, not data parity.
           cargo test --no-default-features --features=all-compression --quiet --lib
 
+  parquet_export_test:
+    name: Parquet Export Build & Test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: cqlite-core
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+
       - name: Build and test with parquet export feature (Epic #682)
         run: |
           # The optional parquet feature must compile and its writer unit
           # tests must pass (no test-data dependency for the lib tests).
           cargo build --features=parquet
           cargo test --features=parquet --quiet --lib export::parquet
+
+  default_dependency_guard:
+    name: Default Dependency Guard
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: cqlite-core
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
 
       - name: Verify default build does not compile arrow/parquet (Epic #682)
         run: |


### PR DESCRIPTION
## Summary
- Split the serial Minimal Features CI build/test job into parallel lanes:
  - minimal compression build
  - all-compression build/test
  - parquet export build/test
  - default dependency guard
- Removed the serial aggregate job after confirming main branch protection has no required status checks configured; this avoids paying for a queued no-op runner after the real work is done.

## Measured impact
- Baseline post-merge main run: Minimal Build & Test completed in 8m30s.
- Split PR run, full Minimal Features CI workflow wall-clock including queue time: 6m22s.
- Net improvement: 2m08s faster, about 25% lower wall-clock.
- Slowest actual lane after scheduling: Parquet Export Build & Test at 2m47s.

## Validation
- Parsed all workflow YAML with Ruby YAML.
- `git diff --check` passed.
- PR checks passed:
  - Parquet Export Build & Test: 2m47s
  - All Compression Build & Test: 1m35s
  - Minimal Compression Build: 32s
  - Default Dependency Guard: 13s
  - Feature Gate Validation: 8s
  - YAML and trigger policy: 8s
  - parity-manifest: 33s