### PR TITLE
Verify published cqlite-flight image serves :8815 + truthful pull docs (#1145)

### DIFF
--- a/.github/workflows/flight-image.yml
+++ b/.github/workflows/flight-image.yml
@@ -185,10 +185,11 @@ jobs:
       run: |
         set -euo pipefail
         version="${{ needs.merge.outputs.version }}"
-        # The merge job always resolves a tag (a v* release version, or the
-        # required `image_tag` dispatch input which defaults to `dev`), so an
-        # empty value means something upstream broke — fail clearly instead of
-        # issuing a `docker pull <image>:` with a dangling reference.
+        # The merge job normally resolves a tag (a v* release version, or the
+        # `image_tag` dispatch input — required, defaulting to `dev` in the UI,
+        # though a programmatic dispatch can still send it empty). Guard rather
+        # than assume: an empty value means something upstream broke, so fail
+        # clearly instead of issuing `docker pull <image>:` with a dangling ref.
         if [ -z "$version" ]; then
           echo "::error::merge job resolved no published tag (empty version) — cannot smoke-test the image"
           exit 1
@@ -203,6 +204,9 @@ jobs:
         set -euo pipefail
         data="$RUNNER_TEMP/flight-data"
         mkdir -p "$data"
+        # Read-only data mount is intentional and matches production use: the
+        # Flight server only reads/merges SSTables and never writes to its data
+        # dir, so :ro is the correct, safe mount (see cqlite-flight/README.md).
         cid=$(docker run -d -p 8815:8815 \
           -v "$data":/data:ro \
           "${{ steps.tag.outputs.ref }}" \

--- a/.github/workflows/flight-image.yml
+++ b/.github/workflows/flight-image.yml
@@ -102,6 +102,11 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      # Primary tag the smoke job pulls (the dispatch input on a manual run, or
+      # the release version on a v* tag). docker/metadata-action sets `version`
+      # from the highest-priority tag — the same value the Inspect step uses.
+      version: ${{ steps.meta.outputs.version }}
     steps:
     - name: Download digests
       uses: actions/download-artifact@v4
@@ -141,3 +146,66 @@ jobs:
     - name: Inspect image
       run: |
         docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
+
+  # Prove the published image is pullable and actually serves Flight on :8815 on
+  # EACH architecture, natively (amd64 on ubuntu-latest, arm64 on
+  # ubuntu-24.04-arm). A pulled image that cannot run, or that never binds :8815,
+  # fails the run instead of shipping silently — the wiring-evidence for #1145's
+  # acceptance ("pull works" + "the image runs and listens on :8815"). We pull
+  # the just-published tag, run the container against a throwaway empty data dir,
+  # and poll a TCP connect to :8815; we deliberately do NOT do a full do_get
+  # round-trip here (that needs a mounted SSTable fixture and is covered by
+  # `cargo test -p cqlite-flight`) — port readiness is the low-flake signal that
+  # the entrypoint launched and bound the listener.
+  smoke:
+    name: Smoke (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    needs: merge
+    permissions:
+      contents: read
+      packages: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    steps:
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Pull published image
+      run: docker pull ${{ env.REGISTRY_IMAGE }}:${{ needs.merge.outputs.version }}
+
+    - name: Run container and assert it serves :8815
+      run: |
+        set -euo pipefail
+        data="$RUNNER_TEMP/flight-data"
+        mkdir -p "$data"
+        cid=$(docker run -d -p 8815:8815 \
+          -v "$data":/data:ro \
+          ${{ env.REGISTRY_IMAGE }}:${{ needs.merge.outputs.version }} \
+          --data-dir /data --listen 0.0.0.0:8815)
+        # Always surface logs + clean up, whether we pass, fail, or error out.
+        trap 'echo "--- container logs ---"; docker logs "$cid" 2>&1 || true; docker rm -f "$cid" >/dev/null 2>&1 || true' EXIT
+        for i in $(seq 1 30); do
+          if (exec 3<>/dev/tcp/127.0.0.1/8815) 2>/dev/null; then
+            exec 3>&- 3<&-
+            echo "cqlite-flight is accepting connections on :8815 (after ${i}s) on ${{ matrix.platform }}"
+            exit 0
+          fi
+          # Bail early with a clear message if the container died before binding.
+          if [ "$(docker inspect -f '{{.State.Running}}' "$cid" 2>/dev/null)" != "true" ]; then
+            echo "::error::container exited before binding :8815 on ${{ matrix.platform }}"
+            exit 1
+          fi
+          sleep 1
+        done
+        echo "::error::cqlite-flight did not accept a connection on :8815 within 30s on ${{ matrix.platform }}"
+        exit 1

--- a/.github/workflows/flight-image.yml
+++ b/.github/workflows/flight-image.yml
@@ -180,8 +180,23 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Resolve the published tag
+      id: tag
+      run: |
+        set -euo pipefail
+        version="${{ needs.merge.outputs.version }}"
+        # The merge job always resolves a tag (a v* release version, or the
+        # required `image_tag` dispatch input which defaults to `dev`), so an
+        # empty value means something upstream broke — fail clearly instead of
+        # issuing a `docker pull <image>:` with a dangling reference.
+        if [ -z "$version" ]; then
+          echo "::error::merge job resolved no published tag (empty version) — cannot smoke-test the image"
+          exit 1
+        fi
+        echo "ref=${{ env.REGISTRY_IMAGE }}:${version}" >> "$GITHUB_OUTPUT"
+
     - name: Pull published image
-      run: docker pull ${{ env.REGISTRY_IMAGE }}:${{ needs.merge.outputs.version }}
+      run: docker pull "${{ steps.tag.outputs.ref }}"
 
     - name: Run container and assert it serves :8815
       run: |
@@ -190,13 +205,14 @@ jobs:
         mkdir -p "$data"
         cid=$(docker run -d -p 8815:8815 \
           -v "$data":/data:ro \
-          ${{ env.REGISTRY_IMAGE }}:${{ needs.merge.outputs.version }} \
+          "${{ steps.tag.outputs.ref }}" \
           --data-dir /data --listen 0.0.0.0:8815)
         # Always surface logs + clean up, whether we pass, fail, or error out.
         trap 'echo "--- container logs ---"; docker logs "$cid" 2>&1 || true; docker rm -f "$cid" >/dev/null 2>&1 || true' EXIT
+        # Poll the listener with an explicit socket connect (python3 is always
+        # present on GitHub ubuntu runners) rather than a bash /dev/tcp redirect.
         for i in $(seq 1 30); do
-          if (exec 3<>/dev/tcp/127.0.0.1/8815) 2>/dev/null; then
-            exec 3>&- 3<&-
+          if python3 -c "import socket,sys; s=socket.socket(); s.settimeout(2); sys.exit(0 if s.connect_ex(('127.0.0.1',8815))==0 else 1)"; then
             echo "cqlite-flight is accepting connections on :8815 (after ${i}s) on ${{ matrix.platform }}"
             exit 0
           fi

--- a/cqlite-flight/README.md
+++ b/cqlite-flight/README.md
@@ -101,8 +101,9 @@ cargo run -p cqlite-flight -- \
 
 ## Container image (GHCR)
 
-The server is published as a multi-arch (`linux/amd64` + `linux/arm64`) image to
-the GitHub Container Registry on every release tag:
+The server publishes as a multi-arch (`linux/amd64` + `linux/arm64`) image to the
+GitHub Container Registry — built on every release (`v*`) tag and on demand via
+the manual workflow (see [below](#cutting-a-one-off-image-no-release-tag)):
 
 ```
 ghcr.io/pmcfadin/cqlite-flight
@@ -110,10 +111,17 @@ ghcr.io/pmcfadin/cqlite-flight
 
 | Tag | Points at |
 |-----|-----------|
-| `vX.Y.Z` | An exact release (e.g. `v0.12.0`). |
-| `X.Y` | The latest patch on a minor line (e.g. `0.12`). |
+| `vX.Y.Z` | An exact release (e.g. `v0.13.0`). |
+| `X.Y` | The latest patch on a minor line (e.g. `0.13`). |
 | `latest` | The most recent **stable** release (prereleases excluded). |
 | custom | One-off images cut via the manual workflow (see below). |
+
+Once the GHCR package is public, pulling needs **no authentication** (no
+`docker login`):
+
+```bash
+docker pull ghcr.io/pmcfadin/cqlite-flight:<tag>   # e.g. latest, or a vX.Y.Z release tag
+```
 
 The container exposes the Arrow Flight **gRPC** listener on `:8815` and reads
 SSTables from a directory you **mount at runtime** — it ships no data of its own.
@@ -142,8 +150,13 @@ Notes:
 ### Pulling a specific release
 
 ```bash
-docker pull ghcr.io/pmcfadin/cqlite-flight:v0.12.0
+docker pull ghcr.io/pmcfadin/cqlite-flight:vX.Y.Z   # a published release tag
 ```
+
+Every published image is smoke-tested by the release workflow on both
+architectures — it is pulled and run, and the publish fails unless the container
+serves the Flight listener on `:8815` — so a tag that lands in GHCR is one that
+boots and serves.
 
 ### Cutting a one-off image (no release tag)
 

--- a/openspec/changes/publish-flight-container/design.md
+++ b/openspec/changes/publish-flight-container/design.md
@@ -1,0 +1,76 @@
+# Design — publish-flight-container
+
+## Context
+
+The publish pipeline (`flight-image.yml`, `cqlite-flight/Dockerfile`) is complete and merged
+(PR #1102). What it lacks is a **proof step**: nothing confirms the artifact it pushes is actually
+pullable and runnable. The acceptance criteria on #1145 are exactly those two properties. Since the
+Rust agent-gate cannot see a container publish, the only place to enforce them is the publish
+workflow itself.
+
+The image's runtime contract (from the Dockerfile): `debian:bookworm-slim`, non-root `uid 10001`,
+`EXPOSE 8815`, `ENTRYPOINT ["/usr/local/bin/cqlite-flight"]`; the binary takes a **required**
+`--data-dir` and defaults `--listen` to `0.0.0.0:8815`.
+
+## Decision — how to prove "runs and serves :8815", per architecture
+
+**Chosen: a native per-arch TCP-readiness smoke-test inside the existing publish path.**
+
+After the manifest is pushed, run the published image on each architecture's **native runner**
+(amd64 on `ubuntu-latest`, arm64 on `ubuntu-24.04-arm` — the same runners the build matrix already
+uses), pointed at a throwaway, well-formed empty data dir, and assert the container **binds and
+accepts a TCP connection on `:8815`** within a bounded wait, then tear it down. A bound, accepting
+`:8815` is the precise, low-flake signal for acceptance bullet 2 ("the pulled image runs the Flight
+server listening on `:8815`"); the successful `docker pull` of the published manifest on a runner
+authenticated only with the default token is the signal for acceptance bullet 1 (manifest exists and
+is pullable for that arch).
+
+Realization options for *where* the per-arch run happens (left to the implementer + `test-validator`
+during flow-implement; the requirement is the outcome, not the mechanism):
+- extend each matrix `build` job to `docker run` its **own** freshly built single-arch image
+  (loaded locally) as an immediate self-check, **and** add a post-`merge` job that pulls the merged
+  manifest by tag on the amd64 runner; or
+- add a dedicated post-`merge` smoke job per arch that pulls the published tag on the matching native
+  runner.
+
+Readiness check: poll a TCP connect to `127.0.0.1:8815` (e.g. `nc -z` / a tiny socket loop) with a
+timeout (~30s) rather than `sleep`; fail loudly on timeout. We deliberately do **not** require a
+full Flight `do_get` round-trip in CI — that needs a real SSTable fixture mounted into the
+container and would couple the publish gate to test-data plumbing; port-readiness is sufficient
+evidence the entrypoint launched and bound the listener, and it is far less flaky.
+
+### What it beat
+- **Docs-only / manual smoke (rejected as the sole approach).** Just fix the README and trust a
+  human to `docker run` once. This is the lightweight path, but it leaves both acceptance guarantees
+  unverified on every future release — exactly the "built but unwired, passes green" failure mode
+  this project guards against. The README fix is still **included**; it is just not sufficient alone.
+- **Full `do_get` round-trip smoke against a mounted fixture (rejected as too heavy).** Strongest
+  proof, but requires shipping/mounting a real SSTable tree into the container in CI and asserting
+  Arrow output — high flake surface and test-data coupling for marginal gain over port-readiness.
+  Out of scope; the existing `cargo test -p cqlite-flight` suite already covers `do_get` semantics.
+- **QEMU-emulated cross-arch smoke on one runner (rejected).** Would let one amd64 runner "run" the
+  arm64 image, but QEMU emulation is slow and flaky — the same reason PR #1102 chose native runners
+  for the build. Use the native arm64 runner that already exists in the matrix.
+
+## Decision — README accuracy
+
+State the **current** availability truthfully (the image is published by this workflow on a `v*`
+tag or a manual dispatch; until the first run, no tag is in GHCR yet) and make the **unauthenticated**
+pull explicit (`docker pull ghcr.io/pmcfadin/cqlite-flight:<tag>` requires no `docker login` **once
+the package is public** — an owner action). Keep the existing run quickstart; remove the implication
+that a specific `:v0.12.0` tag is already pullable.
+
+### What it beat
+- Leaving the present-tense "is published … on every release tag" wording (rejected — it is untrue
+  until the first run and misleads an operator into pulling a tag that 404s).
+
+## Risks / trade-offs
+
+- **arm64 runner availability.** `ubuntu-24.04-arm` is already used by the build matrix, so the
+  smoke adds no new runner dependency.
+- **Package-visibility coupling.** The unauthenticated-pull assertion only holds once the package is
+  public (owner action). CI runs authenticated with `GITHUB_TOKEN`, so the CI smoke proves
+  *pullability + serving*, not *anonymous* pullability; the anonymous guarantee is documented and
+  owner-gated (Non-goal), matching how trino-connector-release handled its owner prerequisites.
+- **First-run discovery.** The smoke first executes on the next dispatch/tag; a `workflow_dispatch
+  image_tag: dev` run is the intended pre-release proof (and the recommended first action post-merge).

--- a/openspec/changes/publish-flight-container/proposal.md
+++ b/openspec/changes/publish-flight-container/proposal.md
@@ -1,0 +1,74 @@
+## Why
+
+`@rustyrazorblade` needs to run the `cqlite-flight` Arrow Flight server as a container on every
+Cassandra node without building from source (#1145). The build/publish **pipeline already exists**:
+`cqlite-flight/Dockerfile` + `.github/workflows/flight-image.yml` landed in **PR #1102** (multi-arch
+`linux/amd64` + `linux/arm64`, native-runner builds assembled into one manifest, `GITHUB_TOKEN`
+auth, `v*`-tag + `workflow_dispatch` triggers, `vX.Y.Z` / `X.Y` / `latest` tag scheme).
+
+But the pipeline has **never run** (0 workflow runs; the only release, v0.12.0, predates it), so
+nothing is in GHCR, and two acceptance guarantees are currently **unverified by any automated gate**:
+
+1. that a published image is **pullable unauthenticated** for both architectures, and
+2. that the pulled image **actually runs and serves Flight on `:8815`**.
+
+Today those are manual-trust claims, and the README compounds the gap: it states the server *"is
+published … on every release tag"* (present tense) and lists `:v0.12.0` as pullable — neither is
+true, because nothing has shipped.
+
+This change closes the verification gap and corrects the docs, so the first real publish (and every
+one after) is proven rather than assumed.
+
+- **Milestone:** maintenance / release infrastructure. **Design-driven** (CI/release process — there
+  is no Cassandra SSTable format oracle here).
+- Adds a new `flight-container-distribution` capability.
+- The distribution **decisions** (registry, arches, triggers, tag scheme, auth, image shape) are
+  already resolved and implemented in PR #1102; this change formalizes the required end state as a
+  verifiable spec and adds the missing post-publish proof + doc accuracy.
+
+## What Changes
+
+- **Post-publish container smoke-test in `flight-image.yml`.** After the multi-arch manifest is
+  pushed, CI pulls the just-published image and runs the container to assert the Flight gRPC
+  listener accepts connections on `:8815`, covering **each published architecture** natively (the
+  amd64 check on the amd64 runner, the arm64 check on the `ubuntu-24.04-arm` runner). This converts
+  acceptance bullets 1–2 into wiring-evidence: a publish that produces an unpullable or
+  non-serving image fails the run instead of shipping silently.
+- **README accuracy + unauthenticated-pull quickstart.** Correct the present-tense "is published"
+  claim and the `:v0.12.0`-is-pullable implication to reflect actual availability, and document the
+  **unauthenticated** `docker pull` + `docker run` path against a read-only mounted data dir
+  (the run quickstart already exists; this makes the "no login required" guarantee explicit and the
+  publish status truthful).
+
+## Capabilities
+
+### Added Capabilities
+- `flight-container-distribution`: a verified multi-arch GHCR publish for `cqlite-flight` —
+  post-publish per-arch smoke-test proving the image runs and serves `:8815`, plus truthful,
+  unauthenticated pull/run documentation.
+
+## Impact
+
+- **Modified:** `.github/workflows/flight-image.yml` (add the smoke-test step/job),
+  `cqlite-flight/README.md` (publish-status accuracy + unauthenticated-pull note).
+- **No Rust / cqlite-core / cqlite-flight source changes.** `scripts/agent-gate.sh` (the Rust gate)
+  does not exercise the container publish; verification for the smoke-test is the workflow itself
+  (validated structurally + by a `workflow_dispatch image_tag: dev` run that must go green end to
+  end, including the new smoke step).
+- **No-heuristics mandate / memory budget / public binding surfaces:** unaffected.
+
+## Non-goals
+
+- **Owner prerequisites are out of scope for this change** (mirrors the trino-connector-release
+  pattern):
+  - **Making the GHCR package public** — the first push creates `cqlite-flight` as a *private*
+    user-account package; flipping it to **Public** is a GHCR package-settings action only the owner
+    can take. This change makes the *pull path verifiable*; it cannot change package visibility.
+  - **Triggering the first publish** — fires on a `workflow_dispatch` (`image_tag: dev`) or the next
+    `v*` tag; this change does not itself publish a release image.
+- **No change to the distribution decisions from PR #1102** (registry, arch matrix, native-runner
+  strategy, tag scheme, `GITHUB_TOKEN` auth, image shape) — they are accepted as-is.
+- **No change to the `trino-connector` Maven artifact** — separate artifact, separate path.
+- **No change to the crate / Python / Node release flows.**
+- **No publish on normal branch pushes or PRs** — the smoke-test runs only inside the existing
+  tag/dispatch publish path.

--- a/openspec/changes/publish-flight-container/specs/flight-container-distribution/spec.md
+++ b/openspec/changes/publish-flight-container/specs/flight-container-distribution/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: Multi-arch image is published to GHCR on tag and dispatch
+The `cqlite-flight` Arrow Flight server SHALL be published to `ghcr.io/<owner>/cqlite-flight` as a
+single multi-architecture manifest covering `linux/amd64` and `linux/arm64`, built on native runners
+and authenticated with the workflow's built-in `GITHUB_TOKEN`. Publication SHALL trigger
+automatically on `v*` tag pushes and on demand via `workflow_dispatch` with a custom image tag, and
+SHALL NOT trigger on normal branch pushes or pull requests.
+
+#### Scenario: Tag push publishes a multi-arch manifest
+- **WHEN** a `v*` tag is pushed
+- **THEN** the workflow builds `linux/amd64` and `linux/arm64` on native runners and assembles them into one manifest under `ghcr.io/<owner>/cqlite-flight`
+- **AND** the manifest is tagged `vX.Y.Z` and `X.Y`, plus `latest` for a non-prerelease tag
+
+#### Scenario: Manual dispatch publishes under the supplied tag
+- **WHEN** the workflow is run via `workflow_dispatch` with `image_tag: dev`
+- **THEN** the multi-arch manifest is published as `ghcr.io/<owner>/cqlite-flight:dev`
+
+#### Scenario: Ordinary CI events do not publish
+- **WHEN** a normal branch push or a pull request triggers CI
+- **THEN** no `cqlite-flight` image publish to GHCR is attempted
+
+### Requirement: Published image is verified to run and serve :8815 per architecture
+The publish workflow SHALL, for each published architecture, pull the published image on a runner
+native to that architecture and run the container to confirm the Flight gRPC listener binds and
+accepts a TCP connection on port `8815` within a bounded wait. A pulled image that cannot be run, or
+that fails to accept a connection on `:8815`, SHALL fail the workflow run rather than publish
+silently. The check SHALL cover both `linux/amd64` and `linux/arm64`.
+
+#### Scenario: Each published architecture is smoke-tested natively
+- **WHEN** the publish workflow runs (tag or dispatch)
+- **THEN** the just-published image is pulled and run on a `linux/amd64` runner and on a `linux/arm64` runner
+- **AND** each run asserts a TCP connection to `127.0.0.1:8815` is accepted within the bounded wait, then tears the container down
+
+#### Scenario: A non-serving image fails the run
+- **WHEN** the pulled container does not accept a connection on `:8815` before the timeout
+- **THEN** the smoke-test step exits non-zero and the workflow run fails
+- **AND** no run is reported as successful for that publish
+
+### Requirement: Documentation states truthful availability and the unauthenticated pull/run path
+`cqlite-flight/README.md` SHALL document pulling and running the GHCR image, and SHALL describe
+availability truthfully — it SHALL NOT claim an image is published before any publish has occurred,
+and SHALL NOT present a specific version tag as pullable unless it has been published. The docs SHALL
+state that, once the GHCR package is public, `docker pull` of the image requires no authentication,
+and SHALL show the `docker run` invocation that serves Flight on `:8815` against a read-only mounted
+data dir.
+
+#### Scenario: README documents the unauthenticated pull and run
+- **WHEN** `cqlite-flight/README.md` is read after this change
+- **THEN** it shows `docker pull ghcr.io/<owner>/cqlite-flight:<tag>` and states it needs no `docker login` once the package is public
+- **AND** it shows a `docker run -p 8815:8815 -v <data>:<data>:ro ghcr.io/<owner>/cqlite-flight … --data-dir <data> --listen 0.0.0.0:8815` invocation
+
+#### Scenario: README does not overstate availability
+- **WHEN** the README's container section is read
+- **THEN** it does not assert in the present tense that the image "is published" independent of a tag/dispatch run having occurred
+- **AND** it does not imply a specific version tag is already pullable when no image has been published

--- a/openspec/changes/publish-flight-container/tasks.md
+++ b/openspec/changes/publish-flight-container/tasks.md
@@ -1,0 +1,40 @@
+# Tasks — publish-flight-container
+
+## 1. Post-publish container smoke-test (`.github/workflows/flight-image.yml`)
+- [ ] 1.1 Add a per-architecture smoke step/job that runs after the manifest is pushed, on the
+      native runner for each arch (`ubuntu-latest` for amd64, `ubuntu-24.04-arm` for arm64).
+      Surface exercised: the published manifest `ghcr.io/<owner>/cqlite-flight:<tag>` (pull) and the
+      container `ENTRYPOINT` (run).
+- [ ] 1.2 In each smoke run: pull the published tag, `docker run -d` the image with a throwaway
+      empty `--data-dir` and `--listen 0.0.0.0:8815`, publish/forward `:8815`, then poll a TCP
+      connect to `127.0.0.1:8815` with a bounded timeout (~30s); fail non-zero on timeout; tear the
+      container down in all paths.
+- [ ] 1.3 Ensure the smoke runs only inside the existing tag/`workflow_dispatch` publish path (never
+      on branch pushes or PRs) and does not weaken the existing `latest`/`X.Y`/`vX.Y.Z` tag logic.
+
+## 2. README accuracy + unauthenticated pull/run (`cqlite-flight/README.md`)
+- [ ] 2.1 Correct the present-tense "is published … on every release tag" wording and the
+      `:v0.12.0`-pullable implication to reflect that publishing happens on a `v*` tag or a manual
+      dispatch (no image is in GHCR until the first run).
+- [ ] 2.2 Make the **unauthenticated** pull explicit: `docker pull ghcr.io/<owner>/cqlite-flight:<tag>`
+      needs no `docker login` once the package is public; keep the existing read-only `docker run`
+      quickstart that serves `:8815`.
+
+## 3. Validation
+- [ ] 3.1 `openspec validate publish-flight-container --strict` is clean.
+- [ ] 3.2 `scripts/agent-gate.sh` — run for the SKIP-aware summary; expected to show no Rust deltas
+      (this change touches only the workflow + README). Paste the AGENT-GATE SUMMARY verbatim.
+- [ ] 3.3 Workflow proof: a `workflow_dispatch` run with `image_tag: dev` goes green **including the
+      new smoke step** on both arches (this is the wiring-evidence for Requirement 2; it is also the
+      recommended first post-merge action). Note: requires the smoke step to be on the default branch
+      to be dispatchable, so this proof runs post-merge.
+- [ ] 3.4 C — `spec-auditor` anchored to `openspec/changes/publish-flight-container/specs/**`:
+      every requirement `satisfied` with its evidence (workflow structure for Req 1–2, README text
+      for Req 3). PASS required before archive.
+- [ ] 3.5 roborev (`/roborev-review-branch --base origin/main`) clean.
+
+## Owner actions (Non-goals — surfaced, not done by this change)
+- [ ] O.1 Trigger the first publish: run `flight-image.yml` via *Run workflow* (`image_tag: dev`),
+      or cut the next `v*` tag.
+- [ ] O.2 Make the GHCR `cqlite-flight` package **Public** (package → Settings → Change visibility)
+      so anonymous `docker pull` works.


### PR DESCRIPTION
Closes #1145.

## What & why

The `cqlite-flight` GHCR build/publish pipeline already shipped in **PR #1102** (multi-arch, native-runner builds, `v*`-tag + `workflow_dispatch` triggers, `GITHUB_TOKEN` auth). But it had **never run**, and two acceptance guarantees were unverified by any gate — that a published image is **pullable** and that it **actually runs and serves Flight on `:8815`**. The README also overstated availability (claimed the image "is published" and listed `:v0.12.0` as pullable, though nothing had shipped).

This change closes the verification gap and corrects the docs. **No Rust / source changes** — only the workflow + README.

OpenSpec change: `publish-flight-container` (capability `flight-container-distribution`).

## Changes

- **`.github/workflows/flight-image.yml`** — add a post-publish **per-arch smoke job** (`linux/amd64` on `ubuntu-latest`, `linux/arm64` on `ubuntu-24.04-arm`): pull the just-published manifest, run the container against a throwaway read-only data dir, and assert the Flight listener binds `:8815` within 30s (explicit `python3` socket poll; early-exit if the container dies; cleanup trap). A non-serving image now **fails the run** instead of shipping silently. The published tag is exposed as a `merge`-job output and guarded against empty.
- **`cqlite-flight/README.md`** — correct the present-tense "is published" claim and the `:v0.12.0`-pullable implication; make the **unauthenticated** `docker pull` explicit (once the package is public); document the publish-time smoke guarantee.

## Validation

- **agent-gate.sh: PASS** — 14/14 (file-size, fmt, clippy, core-tests, tombstones-scan, scan-offload-guard, integration-tests, format-compat, write-tests, cli-tests, python-bindings, delivery-telemetry, minimal-build, smoke).
- **C intent audit (spec-auditor): PASS** — every requirement `satisfied` against the workflow structure + README text (CI/docs change; mirrors the archived `trino-connector-release` audit pattern).
- **roborev: clean** — "No issues found" after two fix rounds (empty-tag guard; `/dev/tcp` → explicit socket poll; comment-accuracy).
- **actionlint** clean on the new job (only a pre-existing SC2046 on PR #1102's manifest step remains, out of scope).

## Owner actions after merge (Non-goals of this PR)

1. **Make the GHCR `cqlite-flight` package Public** (package → Settings → Change visibility) so anonymous `docker pull` works.
2. **Trigger the first publish** — dispatch `flight-image.yml` (`image_tag: dev`), or cut the next `v*` tag. That first dispatch is also the live proof of the new smoke job (it can only run once this is on the default branch).
