### PR TITLE
style(#1266): cargo fmt select_executor/execute.rs (fix main fmt-red from #1214)

### DIFF
--- a/cqlite-core/src/query/select_executor/execute.rs
+++ b/cqlite-core/src/query/select_executor/execute.rs
@@ -14,14 +14,14 @@
 //! and error handling are unchanged.
 
 use super::{
-    AccessPath, ColumnInfo, Error, ExecutionContext, ExecutionStep, FallbackReason,
-    OptimizedQueryPlan, ProjectionFlags, QueryResult, QueryRow, Result, SchemaManager,
-    SelectExecutor, StorageEngine, TableId,
-};
-use super::{
     build_row_from_scan, classify_partition_lookup, column_info_from_type_str, evaluate_predicates,
     honest_targeted_path, parse_table_id, select_has_writetime_ttl, sort_rows_by_token,
     validate_token_predicates, PartitionLookupOutcome, SSTablePredicate,
+};
+use super::{
+    AccessPath, ColumnInfo, Error, ExecutionContext, ExecutionStep, FallbackReason,
+    OptimizedQueryPlan, ProjectionFlags, QueryResult, QueryRow, Result, SchemaManager,
+    SelectExecutor, StorageEngine, TableId,
 };
 use std::sync::Arc;
 use tokio::sync::mpsc;


### PR DESCRIPTION
Fixes #1266. `origin/main` failed `cargo fmt --check` in `cqlite-core/src/query/select_executor/execute.rs` (the file PR #1214 extracted) — two adjacent `use super::{…}` blocks in non-canonical order. Pure `cargo fmt`, no logic touched (1 file, 5+/5-).

Oracle/mechanical → no OpenSpec. Gate **PASS** at `1453d439` (dirty: no): fmt PASS, clippy PASS, core/integration/write/cli/python/smoke all PASS. Unblocks #1263 and every new branch rebased on main.