### PR TITLE
fix(#1254): sort non-UDT frozen<map>/frozen<set> by serialized key/element bytes (byte-parity)

### DIFF
--- a/cqlite-core/src/storage/sstable/writer/data_writer/encoding.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/encoding.rs
@@ -214,7 +214,8 @@ pub(crate) fn serialize_value(value: &Value) -> Result<Vec<u8>> {
             let serializer = TypeSerializer::new();
             serializer.serialize_udt(value, &schema)
         }
-        Value::List(elements) | Value::Set(elements) => {
+        Value::List(elements) => {
+            // ListType preserves insertion order — do NOT sort.
             let mut buf = Vec::new();
             buf.extend_from_slice(&len_as_i32(elements.len())?.to_be_bytes());
             for elem in elements {
@@ -224,21 +225,55 @@ pub(crate) fn serialize_value(value: &Value) -> Result<Vec<u8>> {
             }
             Ok(buf)
         }
-        Value::Map(entries) => {
+        Value::Set(elements) => {
+            // Cassandra SetType is a sorted collection: a frozen set serializes its
+            // elements in unsigned serialized-byte order (issue #1254). Serialize
+            // every element with the writer's own `serialize_value` (via
+            // `serialize_collection_element`, which rejects null), then sort by the
+            // serialized bytes — the SAME single comparator the non-frozen SET cell
+            // path uses (`write_set_complex_cells` in complex.rs). Without this a
+            // direct write of a `frozen<set<..>>` with unsorted elements produces
+            // non-Cassandra bytes.
+            let mut serialized: Vec<Vec<u8>> = elements
+                .iter()
+                .map(|e| serialize_collection_element(e, "Collection"))
+                .collect::<Result<Vec<_>>>()?;
+            serialized.sort();
+
             let mut buf = Vec::new();
-            buf.extend_from_slice(&len_as_i32(entries.len())?.to_be_bytes());
-            for (key, val) in entries {
-                if matches!(key, Value::Null) {
-                    return Err(Error::InvalidInput(
-                        "MAP keys cannot be null (CQL semantics)".to_string(),
-                    ));
-                }
-                let key_bytes = serialize_value(key)?;
+            buf.extend_from_slice(&len_as_i32(serialized.len())?.to_be_bytes());
+            for elem_bytes in &serialized {
+                buf.extend_from_slice(&len_as_i32(elem_bytes.len())?.to_be_bytes());
+                buf.extend_from_slice(elem_bytes);
+            }
+            Ok(buf)
+        }
+        Value::Map(entries) => {
+            // Cassandra MapType is a sorted collection: a frozen map serializes its
+            // entries in unsigned serialized-KEY-byte order (issue #1254). Serialize
+            // every key/value with the writer's own `serialize_value`, then sort by
+            // the serialized key bytes — the SAME single comparator the non-frozen
+            // MAP cell path uses (`write_map_complex_cells` in complex.rs).
+            let mut serialized: Vec<(Vec<u8>, Vec<u8>)> = entries
+                .iter()
+                .map(|(key, val)| {
+                    if matches!(key, Value::Null) {
+                        return Err(Error::InvalidInput(
+                            "MAP keys cannot be null (CQL semantics)".to_string(),
+                        ));
+                    }
+                    Ok((serialize_value(key)?, serialize_value(val)?))
+                })
+                .collect::<Result<Vec<_>>>()?;
+            serialized.sort_by(|a, b| a.0.cmp(&b.0));
+
+            let mut buf = Vec::new();
+            buf.extend_from_slice(&len_as_i32(serialized.len())?.to_be_bytes());
+            for (key_bytes, val_bytes) in &serialized {
                 buf.extend_from_slice(&len_as_i32(key_bytes.len())?.to_be_bytes());
-                buf.extend_from_slice(&key_bytes);
-                let val_bytes = serialize_value(val)?;
+                buf.extend_from_slice(key_bytes);
                 buf.extend_from_slice(&len_as_i32(val_bytes.len())?.to_be_bytes());
-                buf.extend_from_slice(&val_bytes);
+                buf.extend_from_slice(val_bytes);
             }
             Ok(buf)
         }

--- a/cqlite-core/src/storage/sstable/writer/data_writer/tests/scenarios_4.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/tests/scenarios_4.rs
@@ -251,6 +251,148 @@ fn test_frozen_collection_not_complex() {
 }
 
 #[test]
+fn test_frozen_set_sorted_by_serialized_element_bytes() {
+    // Issue #1254: Cassandra SetType is a sorted collection. A frozen<set<int>>
+    // written with REVERSED elements must serialize in unsigned serialized-byte
+    // order. serialize_value is the exact path a frozen collection cell takes
+    // (cells.rs -> serialize_value). Assert the FULL serialized blob, not a count.
+    let value = Value::Frozen(Box::new(Value::Set(vec![
+        Value::Integer(3),
+        Value::Integer(2),
+        Value::Integer(1),
+    ])));
+
+    let bytes = serialize_value(&value).unwrap();
+
+    // Wire format: [count i32][len i32][value]... — int values are 4 big-endian bytes.
+    let mut expected = Vec::new();
+    expected.extend_from_slice(&3i32.to_be_bytes()); // count
+    for n in [1i32, 2, 3] {
+        // sorted ascending
+        expected.extend_from_slice(&4i32.to_be_bytes());
+        expected.extend_from_slice(&n.to_be_bytes());
+    }
+    assert_eq!(
+        bytes, expected,
+        "frozen<set<int>> must serialize elements in sorted-byte order"
+    );
+}
+
+#[test]
+fn test_frozen_map_sorted_by_serialized_key_bytes() {
+    // Issue #1254: Cassandra MapType is a sorted collection. A frozen<map<text,int>>
+    // written with REVERSED keys must serialize entries in unsigned serialized
+    // key-byte order. Assert the FULL serialized blob.
+    let value = Value::Frozen(Box::new(Value::Map(vec![
+        (Value::Text("c".to_string()), Value::Integer(30)),
+        (Value::Text("b".to_string()), Value::Integer(20)),
+        (Value::Text("a".to_string()), Value::Integer(10)),
+    ])));
+
+    let bytes = serialize_value(&value).unwrap();
+
+    // Wire format: [count i32]([klen i32][key][vlen i32][val])...
+    // Text key bytes are raw UTF-8; int values are 4 big-endian bytes.
+    let mut expected = Vec::new();
+    expected.extend_from_slice(&3i32.to_be_bytes());
+    for (k, v) in [("a", 10i32), ("b", 20), ("c", 30)] {
+        // sorted ascending by key
+        let kb = k.as_bytes();
+        expected.extend_from_slice(&(kb.len() as i32).to_be_bytes());
+        expected.extend_from_slice(kb);
+        expected.extend_from_slice(&4i32.to_be_bytes());
+        expected.extend_from_slice(&v.to_be_bytes());
+    }
+    assert_eq!(
+        bytes, expected,
+        "frozen<map<text,int>> must serialize entries in sorted key-byte order"
+    );
+}
+
+#[test]
+fn test_frozen_map_row_emits_sorted_bytes_end_to_end() {
+    // Issue #1254 AC#3: byte-for-byte check that a full written row for a
+    // multi-entry non-UDT frozen<map<text,int>> contains the map blob in sorted
+    // key order — the same bytes Cassandra's MapType produces — when fed reversed.
+    let schema = TableSchema {
+        keyspace: "test_ks".to_string(),
+        table: "test_table".to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![Column {
+            name: "fm".to_string(),
+            data_type: "frozen<map<text, int>>".to_string(),
+            nullable: true,
+            default: None,
+            is_static: false,
+        }],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    };
+
+    let stats = create_test_stats();
+    let mut writer = DataWriter::new(stats);
+
+    let table_id = TableId::new("test_ks", "test_table");
+    let pk = PartitionKey::single("id", Value::Integer(1));
+    let mutation = Mutation::new(
+        table_id,
+        pk,
+        None,
+        vec![CellOperation::Write {
+            column: "fm".to_string(),
+            value: Value::Frozen(Box::new(Value::Map(vec![
+                (Value::Text("c".to_string()), Value::Integer(30)),
+                (Value::Text("b".to_string()), Value::Integer(20)),
+                (Value::Text("a".to_string()), Value::Integer(10)),
+            ]))),
+        }],
+        1001000,
+        None,
+    );
+
+    writer.write_row(&mutation, &schema).unwrap();
+    let bytes = writer.finish().unwrap();
+
+    // The exact frozen-map blob the cell must carry (sorted a,b,c).
+    let mut sorted_blob = Vec::new();
+    sorted_blob.extend_from_slice(&3i32.to_be_bytes());
+    for (k, v) in [("a", 10i32), ("b", 20), ("c", 30)] {
+        let kb = k.as_bytes();
+        sorted_blob.extend_from_slice(&(kb.len() as i32).to_be_bytes());
+        sorted_blob.extend_from_slice(kb);
+        sorted_blob.extend_from_slice(&4i32.to_be_bytes());
+        sorted_blob.extend_from_slice(&v.to_be_bytes());
+    }
+    let reversed_blob = {
+        let mut b = Vec::new();
+        b.extend_from_slice(&3i32.to_be_bytes());
+        for (k, v) in [("c", 30i32), ("b", 20), ("a", 10)] {
+            let kb = k.as_bytes();
+            b.extend_from_slice(&(kb.len() as i32).to_be_bytes());
+            b.extend_from_slice(kb);
+            b.extend_from_slice(&4i32.to_be_bytes());
+            b.extend_from_slice(&v.to_be_bytes());
+        }
+        b
+    };
+
+    let contains = |hay: &[u8], needle: &[u8]| hay.windows(needle.len()).any(|w| w == needle);
+    assert!(
+        contains(&bytes, &sorted_blob),
+        "written row must contain the frozen map in sorted key-byte order"
+    );
+    assert!(
+        !contains(&bytes, &reversed_blob),
+        "written row must NOT contain the frozen map in input (reversed) order"
+    );
+}
+
+#[test]
 fn test_mixed_simple_and_complex_columns() {
     let schema = TableSchema {
         keyspace: "test_ks".to_string(),


### PR DESCRIPTION
Closes #1254.

## What & why
Cassandra `MapType`/`SetType` are **sorted** collections: a frozen map serializes entries in unsigned serialized-key-byte order, a frozen set its elements in serialized-element-byte order. In `serialize_value` the `Value::Map` and combined `Value::List | Value::Set` arms emitted entries/elements in **input insertion order**, so a CQLite direct write of a non-UDT `frozen<map<…>>` / `frozen<set<…>>` with unsorted keys/elements produced **non-Cassandra bytes**. Latent because prior fixtures fed already-sorted input. Oracle-driven (Cassandra/sstabledump bytes are ground truth) — no OpenSpec.

## The fix (`encoding.rs`, `serialize_value`)
- Split the `List | Set` arm. `Value::List` keeps insertion order (`ListType` is not sorted).
- `Value::Set`: serialize each element via the writer's own `serialize_value`, collect, `serialized.sort()` — the **same single comparator** the non-frozen SET cell path (`write_set_complex_cells`) already uses.
- `Value::Map`: serialize each `(key,val)`, collect, `sort_by` on serialized **key** bytes — matching `write_map_complex_cells`.

No second comparator, no heuristic (no-heuristics mandate #28); null-key rejection preserved; no `unwrap`/`expect`.

## Tests (assert serialized byte order, not counts; verified RED on unmodified src)
- `test_frozen_set_sorted_by_serialized_element_bytes` — reversed `frozen<set<int>>` `[3,2,1]` → sorted blob `[1,2,3]`.
- `test_frozen_map_sorted_by_serialized_key_bytes` — reversed `frozen<map<text,int>>` keys `c,b,a` → sorted blob `a,b,c`.
- `test_frozen_map_row_emits_sorted_bytes_end_to_end` — full `write_row` contains the sorted blob and NOT the reversed blob.

## Validation
- **agent-gate.sh: PASS** — 15/15 (file-size, fmt, clippy, core-tests, tombstones-scan, scan-offload-guard, integration-tests, format-compat, write-tests, cli-tests, python-bindings, delivery-telemetry, tooling-tests, minimal-build, smoke).
- **roborev: clean for scope** — only finding is Low, explicitly *out-of-scope + pre-existing* (signed-numeric type-aware comparator; faithfully mirrors the existing non-frozen path, not a regression). Tracked as a follow-up.

## Follow-up (filed separately, NOT in this PR)
True parity for signed numeric element/key types (`frozen<set<int>>` with negatives, etc.) needs a **type-aware comparator** — raw unsigned-byte sort diverges from Cassandra's `Int32Type` ordering. This limitation is shared with the existing non-frozen `complex.rs` path. Filed for the manager to prioritize.