### PR TITLE
fix(#1232): path-scope keyspace enumeration in fixture generators + gate guard

### DIFF
--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -33,6 +33,11 @@
 #                      exits before running any component, so there is no recursion.
 #                      SKIP-aware: no python3 -> SKIP (the selftest's truncation
 #                      assertion needs a python reader), never silent PASS.
+#                      Also runs scripts/tests/test_generator_keyspace_scoping.sh
+#                      (#1232) — fails if a generate-*.sh enumerates the whole
+#                      SSTable corpus and grep -z filters by keyspace; needs no
+#                      python3 so it runs even on the SKIP path, and any failure
+#                      hard-FAILs this component.
 #   minimal-build      cargo build -p cqlite-core --no-default-features --features all-compression
 #   smoke              bash test-data/scripts/smoke-test-all-tables.sh
 #   file-size          campsite-rule ratchet (epic #1116 / #1135): lists changed
@@ -452,6 +457,23 @@ run_tooling_tests() {
   local log="$LOG_DIR/$name.log"
   local start end status
   start=$(date +%s)
+  : >"$log"
+
+  # generator keyspace-scoping guard (#1232): no python3 needed, always runs. A
+  # failure here FAILs the component, mirroring the summary selftest semantics.
+  echo ">>> [$name] bash scripts/tests/test_generator_keyspace_scoping.sh"
+  if ! bash "$REPO_ROOT/scripts/tests/test_generator_keyspace_scoping.sh" >>"$log" 2>&1; then
+    status=FAIL
+    OVERALL=FAIL
+    echo "--- [$name] FAILED (keyspace-scoping guard); last 40 lines of $log ---"
+    tail -40 "$log"
+    echo "--- end of $name output ---"
+    end=$(date +%s)
+    NAMES+=("$name"); STATUSES+=("$status"); TIMES+=("$((end - start))s")
+    echo ">>> [$name] $status ($((end - start))s)"
+    return 0
+  fi
+
   if ! command -v python3 >/dev/null 2>&1; then
     status=SKIP
     echo ">>> [$name] SKIP (no python3 on PATH; selftest truncation reader needs it)"
@@ -459,7 +481,7 @@ run_tooling_tests() {
     return 0
   fi
   echo ">>> [$name] bash scripts/tests/test_agent_gate_summary.sh"
-  if bash "$REPO_ROOT/scripts/tests/test_agent_gate_summary.sh" >"$log" 2>&1; then
+  if bash "$REPO_ROOT/scripts/tests/test_agent_gate_summary.sh" >>"$log" 2>&1; then
     status=PASS
   else
     status=FAIL

--- a/scripts/tests/test_generator_keyspace_scoping.sh
+++ b/scripts/tests/test_generator_keyspace_scoping.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# test_generator_keyspace_scoping.sh — lint guard for issue #1232.
+#
+# The test-data fixture generators MUST enumerate their own keyspace's SSTables
+# by rooting `find` at the per-keyspace directory ("$SSTABLES_DIR/$KEYSPACE" /
+# "$sstables_dir/$KEYSPACE"), NOT by enumerating the WHOLE corpus and filtering
+# with a substring match such as `find "$SSTABLES_DIR" ... | grep -z "$KEYSPACE"`.
+#
+# A substring filter silently breaks the moment a prefix-colliding keyspace is
+# committed (e.g. `test_comp` also matches `test_compactionparity`): the
+# generator would then walk and dump foreign keyspaces' SSTables.
+#
+# This guard fails if any generate-*.sh under test-data/scripts/ reintroduces a
+# whole-corpus substring enumeration pattern.
+#
+# Backs: issue #1232.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+GEN_DIR="$REPO_ROOT/test-data/scripts"
+
+fail=0
+
+# Anti-pattern: piping a find into `grep -z "$KEYSPACE"` (NUL-delimited substring
+# filter over the whole corpus). The correct idiom roots find at the keyspace dir.
+while IFS= read -r script; do
+  if grep -nE 'grep[[:space:]]+-z[[:space:]]+"\$KEYSPACE"' "$script" >/dev/null 2>&1; then
+    echo "[lint][FAIL] $script reintroduces whole-corpus substring enumeration:" >&2
+    grep -nE 'grep[[:space:]]+-z[[:space:]]+"\$KEYSPACE"' "$script" >&2
+    echo "  Use a path-scoped find rooted at the keyspace dir instead, e.g.:" >&2
+    echo "    find \"\$SSTABLES_DIR/\$KEYSPACE\" -type f -name '*-Data.db' -not -name '._*' -print0" >&2
+    fail=1
+  fi
+done < <(find "$GEN_DIR" -maxdepth 1 -type f -name 'generate-*.sh' -print 2>/dev/null | sort)
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "[lint] generator keyspace-scoping guard FAILED (issue #1232)." >&2
+  exit 1
+fi
+
+echo "[lint] generator keyspace-scoping guard PASSED: no whole-corpus substring enumeration."

--- a/scripts/tests/test_generator_keyspace_scoping.sh
+++ b/scripts/tests/test_generator_keyspace_scoping.sh
@@ -3,15 +3,19 @@
 #
 # The test-data fixture generators MUST enumerate their own keyspace's SSTables
 # by rooting `find` at the per-keyspace directory ("$SSTABLES_DIR/$KEYSPACE" /
-# "$sstables_dir/$KEYSPACE"), NOT by enumerating the WHOLE corpus and filtering
-# with a substring match such as `find "$SSTABLES_DIR" ... | grep -z "$KEYSPACE"`.
+# "$sstables_dir/$KEYSPACE" / "$sstables_dir/test_x"), NOT by enumerating the
+# WHOLE corpus and filtering with a NUL-delimited substring match such as
+# `find "$SSTABLES_DIR" ... | grep -z "$KEYSPACE"` (or a literal-quoted form,
+# e.g. `grep -z 'test_deltas'`).
 #
 # A substring filter silently breaks the moment a prefix-colliding keyspace is
 # committed (e.g. `test_comp` also matches `test_compactionparity`): the
 # generator would then walk and dump foreign keyspaces' SSTables.
 #
 # This guard fails if any generate-*.sh under test-data/scripts/ reintroduces a
-# whole-corpus substring enumeration pattern.
+# whole-corpus substring enumeration pattern, in either the variable form
+# (grep -z "$KEYSPACE") or the literal form (grep -z 'test_x' / "test_x").
+# It does NOT flag the legitimate path-scoped idiom `find "$dir/$KEYSPACE" ...`.
 #
 # Backs: issue #1232.
 
@@ -23,12 +27,32 @@ GEN_DIR="$REPO_ROOT/test-data/scripts"
 
 fail=0
 
-# Anti-pattern: piping a find into `grep -z "$KEYSPACE"` (NUL-delimited substring
-# filter over the whole corpus). The correct idiom roots find at the keyspace dir.
+# Anti-pattern (two parts, on the same OR adjacent line because the pipe is often
+# wrapped): a `find` rooted at the WHOLE corpus directory — `find "$sstables_dir"`
+# or `find "$SSTABLES_DIR"` with NO `/...` path scope after the variable — piped
+# into a NUL-delimited keyspace substring filter `grep -z <keyspace>`, where the
+# keyspace is a variable ("$KEYSPACE") or a literal ('test_x' / "test_x").
+#
+# We detect it by joining each script into a single logical stream (so a wrapped
+# pipe matches) and looking for the bare-root find immediately feeding a `grep -z`.
+#
+# - Whole-corpus root, NOT path-scoped:  find "$sstables_dir"   (followed by space,
+#   not by `/`).  The correct idiom `find "$sstables_dir/$KEYSPACE"` has a `/`
+#   right after the closing quote and is therefore NOT matched.
+# - keyspace grep -z filter:  grep -z "$KEYSPACE" | grep -z 'test_x' | grep -z "test_x"
+WHOLE_CORPUS_FIND='find[[:space:]]+"\$[Ss][Ss][Tt][Aa][Bb][Ll][Ee][Ss]_[Dd][Ii][Rr]"[[:space:]]'
+GREP_Z_KEYSPACE="grep[[:space:]]+-z[[:space:]]+(\"\\\$[A-Za-z_]+\"|'[A-Za-z0-9_]+'|\"[A-Za-z0-9_]+\")"
+
 while IFS= read -r script; do
-  if grep -nE 'grep[[:space:]]+-z[[:space:]]+"\$KEYSPACE"' "$script" >/dev/null 2>&1; then
+  # Flatten line-continuations and pipes so a wrapped `find ... \<newline>| grep -z`
+  # is matched as one logical command; then scan for the anti-pattern.
+  matches="$(
+    tr '\n' ' ' < "$script" \
+      | grep -oE "${WHOLE_CORPUS_FIND}[^|]*\|[[:space:]]*${GREP_Z_KEYSPACE}" 2>/dev/null || true
+  )"
+  if [[ -n "$matches" ]]; then
     echo "[lint][FAIL] $script reintroduces whole-corpus substring enumeration:" >&2
-    grep -nE 'grep[[:space:]]+-z[[:space:]]+"\$KEYSPACE"' "$script" >&2
+    printf '  %s\n' "$matches" >&2
     echo "  Use a path-scoped find rooted at the keyspace dir instead, e.g.:" >&2
     echo "    find \"\$SSTABLES_DIR/\$KEYSPACE\" -type f -name '*-Data.db' -not -name '._*' -print0" >&2
     fail=1

--- a/test-data/scripts/generate-cql-type-parity.sh
+++ b/test-data/scripts/generate-cql-type-parity.sh
@@ -828,8 +828,8 @@ except Exception as e:
         log "  OK: $jsonl_file ($lines partitions)"
       fi
     fi
-  done < <(find "$sstables_dir" -type f -name "*-Data.db" -not -name "._*" -print0 \
-            | grep -z "$KEYSPACE" 2>/dev/null || true)
+  done < <(find "$sstables_dir/$KEYSPACE" -type f -name "*-Data.db" -not -name "._*" -print0 \
+            2>/dev/null || true)
 }
 
 # ---------------------------------------------------------------------------

--- a/test-data/scripts/generate-deltas.sh
+++ b/test-data/scripts/generate-deltas.sh
@@ -454,8 +454,8 @@ except Exception as e:
         log "  OK: $jsonl_file ($lines partitions)"
       fi
     fi
-  done < <(find "$sstables_dir" -type f -name "*-Data.db" -not -name "._*" -print0 \
-            | grep -z 'test_deltas' 2>/dev/null || true)
+  done < <(find "$sstables_dir/test_deltas" -type f -name "*-Data.db" -not -name "._*" -print0 \
+            2>/dev/null || true)
 }
 
 # ---------------------------------------------------------------------------

--- a/test-data/scripts/generate-tombstone-parity.sh
+++ b/test-data/scripts/generate-tombstone-parity.sh
@@ -587,8 +587,8 @@ except Exception as e:
         log "  OK: $jsonl_file ($lines partitions)"
       fi
     fi
-  done < <(find "$sstables_dir" -type f -name "*-Data.db" -not -name "._*" -print0 \
-            | grep -z "$KEYSPACE" 2>/dev/null || true)
+  done < <(find "$sstables_dir/$KEYSPACE" -type f -name "*-Data.db" -not -name "._*" -print0 \
+            2>/dev/null || true)
 }
 
 # ---------------------------------------------------------------------------

--- a/test-data/scripts/generate-write-load-parity.sh
+++ b/test-data/scripts/generate-write-load-parity.sh
@@ -199,8 +199,8 @@ for line in sys.stdin:
         log "  OK: $jsonl_file ($lines partitions)"
       fi
     fi
-  done < <(find "$sstables_dir" -type f -name "*-Data.db" -not -name "._*" -print0 \
-            | grep -z "$KEYSPACE" 2>/dev/null || true)
+  done < <(find "$sstables_dir/$KEYSPACE" -type f -name "*-Data.db" -not -name "._*" -print0 \
+            2>/dev/null || true)
 }
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1232.

## What
Four fixture generators selected SSTables with a whole-corpus `find "$sstables_dir" | grep -z "<keyspace>"` **substring** match, which breaks the moment a prefix-colliding keyspace is committed (e.g. `test_comp` matched `test_compactionparity`). Path-scoped each to `find "$sstables_dir/$KEYSPACE"`, matching the already-correct siblings (`generate-compression-parity.sh` / `generate-compaction-parity.sh`).

- `generate-tombstone-parity.sh` (`test_tomb`)
- `generate-write-load-parity.sh` (`test_writeparity`)
- `generate-cql-type-parity.sh` (`test_types`)
- `generate-deltas.sh` (`test_deltas`, literal-quoted form) — surfaced by roborev; same latent anti-pattern, fixed for consistency so the new guard is truthful.

## Guard (regression lint)
New `scripts/tests/test_generator_keyspace_scoping.sh` fails if any `generate-*.sh` reintroduces a whole-corpus `find … | grep -z <keyspace>` (variable or literal form). Wired into `scripts/agent-gate.sh` `tooling-tests` (hard-FAIL semantics) so it runs in the gate.

## Verification
- Dry-run proof: each generator enumerates exactly its own keyspace (tombstone 14, write-load 3, cql-type 28), zero foreign keyspaces, against a corpus containing prefix-colliding keyspaces.
- Guard PASSES on fixed tree, FAILs on reinjected literal+variable anti-patterns, does not flag path-scoped finds.
- `scripts/agent-gate.sh` → **RESULT: PASS** (all components, incl. `tooling-tests` now exercising the guard).
- roborev (codex, branch vs origin/main): **No issues found.**

Routing: oracle/infra — no OpenSpec.