### PR TITLE
ci: limit python slow parity to ubuntu

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -121,12 +121,15 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             python: "3.12"
+            run_slow_tests: true
           - os: macos-14
             target: aarch64-apple-darwin
             python: "3.12"
+            run_slow_tests: false
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             python: "3.12"
+            run_slow_tests: false
 
     steps:
       - name: Checkout
@@ -156,22 +159,22 @@ jobs:
       # rustup, so this `run:` step before the action has rustup available.
       # This test job does not run clippy. Idempotent: a no-op if clippy is absent.
       - name: Remove preinstalled clippy (avoid clippy-preview install conflict)
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && matrix.run_slow_tests
         shell: bash
         run: rustup component remove clippy 2>/dev/null || true
 
       - name: Setup Rust (for CLI build)
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && matrix.run_slow_tests
         uses: dtolnay/rust-toolchain@stable
 
       - name: Normalize PATH for macOS (prepend ~/.cargo/bin so real cargo wins over rustup-init)
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && matrix.run_slow_tests
         shell: bash
         run: |
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Verify Rust toolchain (macOS)
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && matrix.run_slow_tests
         shell: bash
         run: |
           which -a cargo rustup rustup-init || true
@@ -221,11 +224,13 @@ jobs:
 
       # Issue #331: Pre-build CLI binary for faster CLI parity tests
       - name: Build CLI binary for tests
+        if: matrix.run_slow_tests
         shell: bash
         run: |
           cargo build --package cqlite-cli --release
 
-      - name: Run pytest
+      - name: Run pytest (full, with slow CLI parity)
+        if: matrix.run_slow_tests
         env:
           CQLITE_DATASETS_ROOT: ${{ github.workspace }}/test-data/datasets
           RUN_SLOW_TESTS: "1"  # Issue #331: Run all tests including CLI parity
@@ -241,6 +246,15 @@ jobs:
         shell: bash
         run: |
           pytest bindings/python/tests/ -v --tb=short
+
+      - name: Run pytest (non-slow)
+        if: ${{ !matrix.run_slow_tests }}
+        env:
+          CQLITE_DATASETS_ROOT: ${{ github.workspace }}/test-data/datasets
+          CQLITE_REQUIRE_FIXTURES: "1"
+        shell: bash
+        run: |
+          pytest bindings/python/tests/ -v --tb=short -m "not slow"
 
       - name: Upload test results on failure
         if: failure()
@@ -317,7 +331,9 @@ jobs:
           echo "| x86_64-pc-windows-msvc | :white_check_mark: |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Test Results" >> $GITHUB_STEP_SUMMARY
-          echo "Tests passed on 3 native platforms (ARM64 Linux and x86_64 macOS are build-only)" >> $GITHUB_STEP_SUMMARY
+          echo "Full Python tests, including slow CLI parity, passed on Ubuntu." >> $GITHUB_STEP_SUMMARY
+          echo "Non-slow Python binding tests passed on macOS and Windows." >> $GITHUB_STEP_SUMMARY
+          echo "ARM64 Linux and x86_64 macOS are build-only." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Artifacts" >> $GITHUB_STEP_SUMMARY
           echo "Download wheels: \`cqlite-wheels\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- keep full Python CI, including slow CLI parity tests, on Ubuntu
- run non-slow Python binding tests on macOS and Windows
- skip macOS/Windows release CLI builds in Python CI test jobs

## Expected timing impact
- removes the duplicated release CLI build from macOS and Windows Python test jobs
- preserves native wheel install/test coverage on all three platforms
- keeps CLI parity coverage in Python CI on Ubuntu

## Validation
- ruby YAML parse for .github/workflows/python-ci.yml
- git diff --check

Supersedes the earlier graph reshaping experiment in #1268, which did not show a real end-to-end timing improvement.