### PR TITLE
fix(#1247): resolve gate smoke CLI binary via CARGO_TARGET_DIR + guard test

### DIFF
--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -501,11 +501,12 @@ run_delivery_telemetry() {
 
 # tooling-tests: fast shell-tooling regression tests that have no Rust target and
 # no dataset/network needs. Currently scripts/tests/test_agent_gate_summary.sh,
-# which verifies the SUMMARY block survives non-foreground capture (#1175). That
-# test only drives `agent-gate.sh --emit-summary-selftest` (which exits before any
-# component runs), so wiring it here cannot cause the gate to recurse. SKIP-aware:
-# the test's truncation case relies on a python3 reader, so with no python3 we
-# record SKIP (loud, never silent PASS); any test failure -> hard FAIL.
+# which verifies the SUMMARY block survives non-foreground capture (#1175), and
+# scripts/tests/test_agent_gate_smoke_target_dir.sh, which verifies the smoke step
+# resolves the CLI via CARGO_TARGET_DIR (#1247). Neither runs the real gate
+# components, so wiring them here cannot cause the gate to recurse. SKIP-aware:
+# the summary test's truncation case relies on a python3 reader, so with no
+# python3 we record SKIP (loud, never silent PASS); any test failure -> hard FAIL.
 run_tooling_tests() {
   local name=tooling-tests
   if [ -n "$ONLY" ] && ! grep -qw "$name" <<<"${ONLY//,/ }"; then
@@ -537,8 +538,9 @@ run_tooling_tests() {
     NAMES+=("$name"); STATUSES+=("$status"); TIMES+=("0s")
     return 0
   fi
-  echo ">>> [$name] bash scripts/tests/test_agent_gate_summary.sh"
-  if bash "$REPO_ROOT/scripts/tests/test_agent_gate_summary.sh" >>"$log" 2>&1; then
+  echo ">>> [$name] bash scripts/tests/test_agent_gate_summary.sh; bash scripts/tests/test_agent_gate_smoke_target_dir.sh"
+  if bash "$REPO_ROOT/scripts/tests/test_agent_gate_summary.sh" >>"$log" 2>&1 &&
+     bash "$REPO_ROOT/scripts/tests/test_agent_gate_smoke_target_dir.sh" >>"$log" 2>&1; then
     status=PASS
   else
     status=FAIL
@@ -766,9 +768,13 @@ run_component minimal-build cargo build --package cqlite-core --no-default-featu
 # smoke script prefers any existing target/release/cqlite, however stale —
 # the first full gate run caught a May binary failing all test_oa tables
 # that current code reads fine.
+# Resolve the just-built CLI honoring CARGO_TARGET_DIR (issue #1247): when the
+# gate runs from a git worktree sharing a target dir via CARGO_TARGET_DIR, the
+# binary lands in "$CARGO_TARGET_DIR/debug", not "$PWD/target/debug". Fall back
+# to "$PWD/target" when CARGO_TARGET_DIR is unset.
 run_component smoke bash -c '
   cargo build --package cqlite-cli --bin cqlite &&
-  CQLITE_CLI="$PWD/target/debug/cqlite" bash test-data/scripts/smoke-test-all-tables.sh'
+  CQLITE_CLI="${CARGO_TARGET_DIR:-$PWD/target}/debug/cqlite" bash test-data/scripts/smoke-test-all-tables.sh'
 
 declare -a SUMMARY_META=()
 SUMMARY_META+=("commit: $(git rev-parse --short HEAD) branch: $(git rev-parse --abbrev-ref HEAD) dirty: $(test -n "$(git status --porcelain)" && echo yes || echo no)")

--- a/scripts/tests/test_agent_gate_smoke_target_dir.sh
+++ b/scripts/tests/test_agent_gate_smoke_target_dir.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Regression test for issue #1247: the agent-gate smoke step must resolve the
+# just-built CLI binary honoring CARGO_TARGET_DIR. When the gate runs from a git
+# worktree that shares a target dir via CARGO_TARGET_DIR (the disk-saving pattern
+# for parallel worktrees), cargo writes the binary to "$CARGO_TARGET_DIR/debug",
+# NOT "$PWD/target/debug" -- so a hardcoded "$PWD/target/debug/cqlite" makes the
+# smoke step FAIL with "CQLITE_CLI is set but not executable". The fix resolves
+# the path as "${CARGO_TARGET_DIR:-$PWD/target}/debug/cqlite".
+#
+# Fast + hermetic by design: never builds cargo, never runs the real gate. It
+# (a) statically asserts agent-gate.sh contains the CARGO_TARGET_DIR-aware form
+# and no longer hardcodes the broken "$PWD/target/debug/cqlite", and (b) evaluates
+# the documented resolution expression in both modes (CARGO_TARGET_DIR set vs
+# unset) against stubbed binary locations to prove behavior, not just text.
+#
+# This test FAILS against the old hardcoded behavior and PASSES with the fix.
+#
+# Run standalone:   bash scripts/tests/test_agent_gate_smoke_target_dir.sh
+# Or via the gate:  scripts/agent-gate.sh runs it as part of the tooling-tests component.
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+GATE="$SCRIPT_DIR/../agent-gate.sh"
+
+PASS=0
+FAIL=0
+ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
+bad() { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+# 1) Static: the gate must use the CARGO_TARGET_DIR-aware resolution form.
+if grep -q 'CQLITE_CLI="\${CARGO_TARGET_DIR:-\$PWD/target}/debug/cqlite"' "$GATE"; then
+  ok "gate resolves CQLITE_CLI via \${CARGO_TARGET_DIR:-\$PWD/target}/debug/cqlite"
+else
+  bad "gate is missing the CARGO_TARGET_DIR-aware CQLITE_CLI resolution"
+fi
+
+# 2) Static: the gate must NOT hardcode the broken "$PWD/target/debug/cqlite".
+if grep -q 'CQLITE_CLI="\$PWD/target/debug/cqlite"' "$GATE"; then
+  bad "gate still hardcodes CQLITE_CLI=\"\$PWD/target/debug/cqlite\" (the #1247 bug)"
+else
+  ok "gate no longer hardcodes CQLITE_CLI=\"\$PWD/target/debug/cqlite\""
+fi
+
+# resolve_cli mirrors the exact expression the gate uses, so we exercise the real
+# resolution semantics rather than re-implementing them.
+resolve_cli() { printf '%s' "${CARGO_TARGET_DIR:-$PWD/target}/debug/cqlite"; }
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/agent-gate-smoke-test.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT
+
+# 3) CARGO_TARGET_DIR set -> binary resolved under the shared target dir, which
+#    is where cargo would actually place it in a worktree. The hardcoded
+#    "$PWD/target/debug/cqlite" would point at a nonexistent path here.
+shared_target="$tmp/shared-target"
+mkdir -p "$shared_target/debug"
+: >"$shared_target/debug/cqlite"
+chmod +x "$shared_target/debug/cqlite"
+workdir="$tmp/worktree"
+mkdir -p "$workdir"
+(
+  cd "$workdir"
+  CARGO_TARGET_DIR="$shared_target"
+  resolved=$(resolve_cli)
+  expected="$shared_target/debug/cqlite"
+  if [ "$resolved" = "$expected" ] && [ -x "$resolved" ]; then
+    exit 0
+  fi
+  echo "  resolved=$resolved expected=$expected" >&2
+  exit 1
+) && ok "CARGO_TARGET_DIR set: CLI resolves to the shared target dir (executable)" \
+   || bad "CARGO_TARGET_DIR set: CLI did not resolve to the shared target dir"
+
+# 4) CARGO_TARGET_DIR unset -> fall back to "$PWD/target/debug/cqlite".
+workdir2="$tmp/worktree2"
+mkdir -p "$workdir2/target/debug"
+: >"$workdir2/target/debug/cqlite"
+chmod +x "$workdir2/target/debug/cqlite"
+(
+  cd "$workdir2"
+  unset CARGO_TARGET_DIR
+  resolved=$(resolve_cli)
+  expected="$PWD/target/debug/cqlite"
+  if [ "$resolved" = "$expected" ] && [ -x "$resolved" ]; then
+    exit 0
+  fi
+  echo "  resolved=$resolved expected=$expected" >&2
+  exit 1
+) && ok "CARGO_TARGET_DIR unset: CLI falls back to \$PWD/target/debug/cqlite" \
+   || bad "CARGO_TARGET_DIR unset: CLI did not fall back to \$PWD/target/debug/cqlite"
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #1247.

## Problem
`scripts/agent-gate.sh`'s smoke step hardcoded the built CLI binary as `$PWD/target/debug/cqlite`. When the gate runs from a git worktree with `CARGO_TARGET_DIR` pointed at a shared target dir (the disk-saving pattern for parallel worktrees), the binary lands in `$CARGO_TARGET_DIR/debug`, not `$PWD/target/debug` — smoke FAILs with "CQLITE_CLI is set but not executable" until a `target/debug` symlink is hand-created. This actively degraded every worktree-based worker.

## Fix
- `scripts/agent-gate.sh` smoke step: resolve CLI as `${CARGO_TARGET_DIR:-$PWD/target}/debug/cqlite`. This was the only hardcoded spot; downstream `smoke-test-all-tables.sh` already honors `CQLITE_CLI`.
- New guard test `scripts/tests/test_agent_gate_smoke_target_dir.sh`, wired into the `tooling-tests` gate component. Asserts the `CARGO_TARGET_DIR` resolution (set + unset fallback); FAILs against the old hardcoded behavior, PASSes with the fix.

## Validation
Full `agent-gate.sh` from the worktree: **RESULT: PASS** — all components incl. `smoke` (45s) and `tooling-tests` (5s). roborev (codex): no issues found.

Oracle/infra fix — no OpenSpec.