### PR TITLE
feat(#1026): exhaustive regeneration lane + corpus audit

### DIFF
--- a/.github/workflows/exhaustive-regeneration.yml
+++ b/.github/workflows/exhaustive-regeneration.yml
@@ -128,10 +128,14 @@ jobs:
           find test-data/datasets \( -name '*.jsonl' -o -name '*.db.txt' \) -type f -print0 \
             | sort -z | xargs -0r sha256sum > "$ARTIFACT_DIR/actual.sha256" || true
 
-      # Build the provenance record from the ACTUAL generation environment: the
-      # image tag is the single source of truth in regenerate-datasets.sh, and the
-      # version is derived from it. The audit fails if the recorded version/ref/sha
-      # is not declared by the manifest (a silent image bump is caught).
+      # Build the provenance record. version/ref/sha come from the manifest's
+      # `cassandra_source` block, but `docker_image` MUST be the ACTUAL image used
+      # by regenerate-datasets.sh (grepped from its `CASSANDRA_IMAGE=`), sourced
+      # INDEPENDENTLY of the manifest. That independence is what gives the audit
+      # teeth: validating the manifest-derived version/ref/sha against the manifest
+      # is tautological, so `check_provenance` parses the version out of
+      # `docker_image` and fails when it diverges from the pin — catching a silent
+      # image bump (e.g. cassandra:5.0.2 -> 5.0.3) not mirrored into the manifest.
       - name: Write provenance record
         run: |
           set -euo pipefail

--- a/.github/workflows/exhaustive-regeneration.yml
+++ b/.github/workflows/exhaustive-regeneration.yml
@@ -74,8 +74,8 @@ jobs:
       - name: Snapshot committed reference-golden checksums (expected inventory)
         run: |
           set -euo pipefail
-          find test-data/datasets \( -name '*.jsonl' -o -name '*.db.txt' \) -type f \
-            | sort | xargs -r sha256sum > "$ARTIFACT_DIR/expected.sha256" || true
+          find test-data/datasets \( -name '*.jsonl' -o -name '*.db.txt' \) -type f -print0 \
+            | sort -z | xargs -0r sha256sum > "$ARTIFACT_DIR/expected.sha256" || true
           echo "expected goldens: $(wc -l < "$ARTIFACT_DIR/expected.sha256")"
 
       # ---- exhaustive.regenerate.all_formats ----
@@ -125,8 +125,8 @@ jobs:
       - name: Compute regenerated reference-golden checksums (actual inventory)
         run: |
           set -euo pipefail
-          find test-data/datasets \( -name '*.jsonl' -o -name '*.db.txt' \) -type f \
-            | sort | xargs -r sha256sum > "$ARTIFACT_DIR/actual.sha256" || true
+          find test-data/datasets \( -name '*.jsonl' -o -name '*.db.txt' \) -type f -print0 \
+            | sort -z | xargs -0r sha256sum > "$ARTIFACT_DIR/actual.sha256" || true
 
       # Build the provenance record from the ACTUAL generation environment: the
       # image tag is the single source of truth in regenerate-datasets.sh, and the

--- a/.github/workflows/exhaustive-regeneration.yml
+++ b/.github/workflows/exhaustive-regeneration.yml
@@ -1,0 +1,195 @@
+name: Exhaustive Regeneration (parity corpus)
+
+# CI tier: `exhaustive_regeneration` (issue #1026, child of epic #974).
+#
+# The full, expensive regeneration of the Cassandra-generated parity corpus
+# across the storage-format matrix, the test_deltas fixtures, and the corruption
+# fixtures — followed by the corpus audit (`cassandra-parity corpus-audit`). It
+# uploads ONE report artifact (provenance record + audit report + generator logs)
+# and deliberately does NOT commit regenerated binaries or publish a dataset asset
+# (design D6).
+#
+# Cadence (design D5, owner-pinned): weekly cron + manual dispatch only. It NEVER
+# runs on pull_request and never gates the fast/required PR path. See the tier
+# contract: docs/development/parity-ci-tiers.md (`exhaustive_regeneration`) and the
+# release checklist (`parity-release-checklist.md`).
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    # Weekly, Sunday 06:00 UTC — slower than the nightly Docker lane (#1025),
+    # reflecting the cost of full-corpus generation + a Cassandra container.
+    - cron: '0 6 * * 0'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: exhaustive-regeneration
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  CQLITE_DATASETS_ROOT: ${{ github.workspace }}/test-data/datasets
+  MANIFEST: test-data/cassandra-parity-manifest.yml
+  ARTIFACT_DIR: ${{ github.workspace }}/exhaustive-regeneration-report
+
+jobs:
+  regenerate-and-audit:
+    runs-on: ubuntu-latest
+    # Generous timeout: the matrix regeneration restarts a Cassandra container
+    # twice (oa, da) and compacts every keyspace.
+    timeout-minutes: 180
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: exhaustive-regeneration-${{ hashFiles('**/Cargo.toml') }}
+
+      - name: Check Docker available
+        run: docker info
+
+      - name: Build cassandra-parity (audit tool)
+        run: cargo build -p cassandra-parity
+
+      - name: Prepare report dir
+        run: mkdir -p "$ARTIFACT_DIR"
+
+      # The corruption corpus needs clean nb/BTI sources; fetch the committed
+      # dataset binaries so generate-corruption-corpus.sh has clean inputs and the
+      # reference-golden snapshot below has the committed JSONL/txt goldens.
+      - name: Fetch dataset binaries (clean sources)
+        run: bash test-data/scripts/fetch-datasets.sh
+
+      # Snapshot the committed reference-golden checksums BEFORE regeneration.
+      # After regeneration we recompute the same set; the audit's
+      # "unexpected component change" check flags any golden whose bytes drifted
+      # without a manifest/golden-update PR.
+      - name: Snapshot committed reference-golden checksums (expected inventory)
+        run: |
+          set -euo pipefail
+          find test-data/datasets \( -name '*.jsonl' -o -name '*.db.txt' \) -type f \
+            | sort | xargs -r sha256sum > "$ARTIFACT_DIR/expected.sha256" || true
+          echo "expected goldens: $(wc -l < "$ARTIFACT_DIR/expected.sha256")"
+
+      # ---- exhaustive.regenerate.all_formats ----
+      - name: Regenerate storage-format matrix (nb/oa/da)
+        run: |
+          set -euo pipefail
+          bash test-data/scripts/regenerate-datasets.sh \
+            2>&1 | tee "$ARTIFACT_DIR/regenerate-datasets.log"
+
+      # ---- exhaustive.regenerate.test_deltas ----
+      - name: Regenerate test_deltas fixtures
+        run: |
+          set -euo pipefail
+          bash test-data/scripts/generate-deltas.sh \
+            2>&1 | tee "$ARTIFACT_DIR/generate-deltas.log"
+
+      # Compression fixtures (test_comp) + BTI sources are the clean inputs the
+      # corruption generator mutates; (re)build them so corruption coverage is real.
+      - name: Regenerate compression + BTI source fixtures
+        run: |
+          set -euo pipefail
+          bash test-data/scripts/generate-compression-parity.sh \
+            2>&1 | tee "$ARTIFACT_DIR/generate-compression-parity.log"
+          OUT="$CQLITE_DATASETS_ROOT" bash test-data/scripts/gen-wide-bti.sh \
+            2>&1 | tee "$ARTIFACT_DIR/gen-wide-bti.log"
+
+      # ---- exhaustive.regenerate.corruption_fixtures ----
+      - name: Regenerate corruption fixtures
+        run: |
+          set -euo pipefail
+          bash test-data/scripts/generate-corruption-corpus.sh \
+            2>&1 | tee "$ARTIFACT_DIR/generate-corruption-corpus.log"
+
+      # Package the regenerated corpus to obtain the asset name + SHA256 for the
+      # provenance record. NO publish (design D6 / non-goal).
+      - name: Package dataset asset (name + SHA256 only; no publish)
+        id: package
+        run: |
+          set -euo pipefail
+          ARCHIVE_PATH="$ARTIFACT_DIR/dataset-asset.tar.gz" \
+            bash test-data/scripts/package_datasets.sh --full \
+            2>&1 | tee "$ARTIFACT_DIR/package_datasets.log"
+          ASSET_SHA=$(sha256sum "$ARTIFACT_DIR/dataset-asset.tar.gz" | awk '{print $1}')
+          echo "asset_sha=$ASSET_SHA" >> "$GITHUB_OUTPUT"
+
+      # Recompute the reference-golden checksums AFTER regeneration.
+      - name: Compute regenerated reference-golden checksums (actual inventory)
+        run: |
+          set -euo pipefail
+          find test-data/datasets \( -name '*.jsonl' -o -name '*.db.txt' \) -type f \
+            | sort | xargs -r sha256sum > "$ARTIFACT_DIR/actual.sha256" || true
+
+      # Build the provenance record from the ACTUAL generation environment: the
+      # image tag is the single source of truth in regenerate-datasets.sh, and the
+      # version is derived from it. The audit fails if the recorded version/ref/sha
+      # is not declared by the manifest (a silent image bump is caught).
+      - name: Write provenance record
+        run: |
+          set -euo pipefail
+          IMAGE=$(grep -E '^CASSANDRA_IMAGE=' test-data/scripts/regenerate-datasets.sh \
+            | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+          VERSION="${IMAGE#cassandra:}"
+          SHA=$(grep -E '^[[:space:]]*sha:' "$MANIFEST" | head -1 | awk '{print $2}')
+          python3 - "$IMAGE" "$VERSION" "$SHA" "${{ steps.package.outputs.asset_sha }}" <<'PY' > "$ARTIFACT_DIR/provenance.json"
+          import json, sys
+          image, version, sha, asset_sha = sys.argv[1:5]
+          rec = {
+              "cassandra_version": version,
+              "cassandra_ref": f"cassandra-{version}",
+              "cassandra_git_sha": sha,
+              "docker_image": image,
+              "generator_commands": [
+                  "bash test-data/scripts/regenerate-datasets.sh",
+                  "bash test-data/scripts/generate-deltas.sh",
+                  "bash test-data/scripts/generate-compression-parity.sh",
+                  "bash test-data/scripts/gen-wide-bti.sh",
+                  "bash test-data/scripts/generate-corruption-corpus.sh",
+              ],
+              "dataset_asset_name": "dataset-asset.tar.gz",
+              "dataset_asset_sha256": asset_sha,
+          }
+          print(json.dumps(rec, indent=2))
+          PY
+          cat "$ARTIFACT_DIR/provenance.json"
+
+      # ---- exhaustive.audit.manifest_coverage + exhaustive.audit.generated_references ----
+      # Hard-fails (non-zero exit) and names the offender on any finding: missing/
+      # stale reference, unclassified high-relevance file, unexpected component
+      # change, provenance mismatch, or corruption-coverage gap (owner-pinned:
+      # always hard-fail; no report-but-pass).
+      - name: Corpus audit (manifest coverage + generated references)
+        run: |
+          set -euo pipefail
+          cargo run -p cassandra-parity -- corpus-audit \
+            --manifest "$MANIFEST" \
+            --corpus . \
+            --provenance "$ARTIFACT_DIR/provenance.json" \
+            --checksums "$ARTIFACT_DIR/actual.sha256" \
+            --expected-inventory "$ARTIFACT_DIR/expected.sha256" \
+            --corruption-manifest test-data/datasets/corruption/test_comp_corrupt/corruption-manifest.yml \
+            2>&1 | tee "$ARTIFACT_DIR/corpus-audit-report.txt"
+
+      # One report artifact: provenance + audit report + generator logs. Always
+      # uploaded (pass or fail) so a release can cite the run.
+      - name: Upload regeneration report artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: exhaustive-regeneration-report
+          path: |
+            ${{ env.ARTIFACT_DIR }}/provenance.json
+            ${{ env.ARTIFACT_DIR }}/corpus-audit-report.txt
+            ${{ env.ARTIFACT_DIR }}/expected.sha256
+            ${{ env.ARTIFACT_DIR }}/actual.sha256
+            ${{ env.ARTIFACT_DIR }}/*.log
+          retention-days: 90
+          if-no-files-found: warn

--- a/.github/workflows/exhaustive-regeneration.yml
+++ b/.github/workflows/exhaustive-regeneration.yml
@@ -204,6 +204,13 @@ jobs:
           # the repo root. The audit's WALK_SKIP_DIRS prunes this report dir
           # (`exhaustive-regeneration-report`) so the walk ignores its own
           # artifacts (issue #1026, Finding 1).
+          # The corruption-coverage check cross-references each --corruption-manifest
+          # fixture's `corrupted_path` against this SAME walked corpus, so the
+          # `test-data/datasets/corruption/...` fixtures regenerated above must be
+          # on disk: a required component DECLARED but not produced on disk fails
+          # the audit (spec R4 = on-disk reality, not a manifest declaration;
+          # issue #1026, LOW 2). This is why corruption fixtures are regenerated
+          # before — and walked by — this step.
           cargo run -p cassandra-parity -- corpus-audit \
             --manifest "$MANIFEST" \
             --corpus . \

--- a/.github/workflows/exhaustive-regeneration.yml
+++ b/.github/workflows/exhaustive-regeneration.yml
@@ -137,14 +137,39 @@ jobs:
           set -euo pipefail
           IMAGE=$(grep -E '^CASSANDRA_IMAGE=' test-data/scripts/regenerate-datasets.sh \
             | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
-          VERSION="${IMAGE#cassandra:}"
-          SHA=$(grep -E '^[[:space:]]*sha:' "$MANIFEST" | head -1 | awk '{print $2}')
-          python3 - "$IMAGE" "$VERSION" "$SHA" "${{ steps.package.outputs.asset_sha }}" <<'PY' > "$ARTIFACT_DIR/provenance.json"
-          import json, sys
-          image, version, sha, asset_sha = sys.argv[1:5]
+          # Parse the manifest's top-level `cassandra_source` block specifically
+          # (YAML-aware, indentation-scoped) so we record the intended
+          # cassandra_source.ref/.sha — never a scenario `evidence.cassandra_git_sha`
+          # or any other `sha:` line that happens to precede it (issue #1026).
+          # The ref drives the recorded version (cassandra-X.Y.Z -> X.Y.Z); the
+          # audit then fails on any version/ref/sha the manifest does not declare.
+          python3 - "$MANIFEST" "$IMAGE" "${{ steps.package.outputs.asset_sha }}" \
+            > "$ARTIFACT_DIR/provenance.json" <<'PY'
+          import json, re, sys
+          manifest, image, asset_sha = sys.argv[1:4]
+          ref = sha = ""
+          in_src = False
+          with open(manifest) as f:
+              for line in f:
+                  if re.match(r'^cassandra_source:\s*$', line):
+                      in_src = True
+                      continue
+                  if in_src:
+                      if re.match(r'^\S', line):  # next top-level key ends the block
+                          break
+                      m = re.match(r'^\s+(ref|sha):\s*(.+?)\s*$', line)
+                      if m:
+                          val = m.group(2).strip().strip('"').strip("'")
+                          if m.group(1) == 'ref':
+                              ref = val
+                          else:
+                              sha = val
+          if not ref or not sha:
+              sys.exit("cassandra_source.ref/.sha not found in manifest")
+          version = ref[len("cassandra-"):] if ref.startswith("cassandra-") else ref
           rec = {
               "cassandra_version": version,
-              "cassandra_ref": f"cassandra-{version}",
+              "cassandra_ref": ref,
               "cassandra_git_sha": sha,
               "docker_image": image,
               "generator_commands": [

--- a/.github/workflows/exhaustive-regeneration.yml
+++ b/.github/workflows/exhaustive-regeneration.yml
@@ -194,6 +194,12 @@ jobs:
       - name: Corpus audit (manifest coverage + generated references)
         run: |
           set -euo pipefail
+          # `--corpus .` (repo root) is REQUIRED: manifest references are
+          # repo-root-relative (`test-data/datasets/...`) and the walk yields
+          # paths relative to --corpus, so reference resolution only works from
+          # the repo root. The audit's WALK_SKIP_DIRS prunes this report dir
+          # (`exhaustive-regeneration-report`) so the walk ignores its own
+          # artifacts (issue #1026, Finding 1).
           cargo run -p cassandra-parity -- corpus-audit \
             --manifest "$MANIFEST" \
             --corpus . \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ Key chapters:
 Full contributor doctrine is published at `https://pmcfadin.github.io/cqlite/agents-developing/`:
 - [Gate contract](https://pmcfadin.github.io/cqlite/agents-developing/gate-contract/) — `scripts/agent-gate.sh`, summary-block format
   - Parity CI tier contracts: `docs/development/parity-ci-tiers.md` (what each Cassandra parity CI tier promises; gate-strength smoke/canonical-semantic/byte-for-byte) + `docs/development/parity-release-checklist.md` (gates public parity claims). Belongs alongside the gate-contract page on the `agents-developing/` site — mirror there when the site page lands (issue #1022).
+    - The `exhaustive_regeneration` tier is backed by `.github/workflows/exhaustive-regeneration.yml` (weekly + `workflow_dispatch`, never on PRs; issue #1026), which regenerates the corpus and runs `cargo run -p cassandra-parity -- corpus-audit` (hard-fails on corpus/manifest or provenance drift).
 - [No-heuristics mandate](https://pmcfadin.github.io/cqlite/agents-developing/no-heuristics/) — authoritative metadata only (issue #28)
 - [Test data](https://pmcfadin.github.io/cqlite/agents-developing/test-data/) — fetching, dataset pins, CQLITE_DATASETS_ROOT
 - [Key source paths](https://pmcfadin.github.io/cqlite/agents-developing/source-map/) — parsers, writers, query engine, bindings

--- a/docs/development/parity-ci-tiers.md
+++ b/docs/development/parity-ci-tiers.md
@@ -148,6 +148,20 @@ P0 data-loss path without a recorded gap is a contract violation.
   claim.
 - **Promotion.** Terminal tier — it is the strongest, broadest gate. New
   format-matrix scenarios are *added* here once their generation command exists.
+- **Backing lane (issue #1026).** This tier is realized by
+  [`.github/workflows/exhaustive-regeneration.yml`](../../.github/workflows/exhaustive-regeneration.yml)
+  — a `workflow_dispatch` + weekly-cron lane (never on PRs) that orchestrates the
+  existing generators (`regenerate-datasets.sh`, `generate-deltas.sh`,
+  `generate-corruption-corpus.sh`), records a per-run provenance record (Cassandra
+  version/ref/sha, Docker image, generator commands, dataset asset name + SHA256),
+  and runs the corpus audit:
+  `cargo run -p cassandra-parity -- corpus-audit --corpus . --manifest <manifest> --provenance <record>`.
+  The audit **hard-fails** (non-zero exit, naming the offender) on a missing/stale
+  manifest reference, an unclassified high-relevance Cassandra file, an unexpected
+  component presence/checksum change, a provenance/manifest version divergence, or a
+  corruption-fixture coverage gap. The lane uploads ONE report artifact (provenance +
+  audit report + generator logs) and never commits regenerated binaries or publishes a
+  dataset asset.
 
 ### `manual_debug`
 

--- a/docs/development/parity-release-checklist.md
+++ b/docs/development/parity-release-checklist.md
@@ -26,7 +26,12 @@ exact release commit:
       disabled nightly does not satisfy this item).
 - [ ] **Recent `exhaustive_regeneration` pass (release candidates).** For any RC
       or major format change, an `exhaustive_regeneration` run over the full
-      storage-format matrix passed within the release window.
+      storage-format matrix passed within the release window. This is the
+      [`exhaustive-regeneration.yml`](../../.github/workflows/exhaustive-regeneration.yml)
+      lane (weekly + `workflow_dispatch`, issue #1026); cite the run URL and its
+      uploaded report artifact (provenance record + corpus-audit report). The audit
+      hard-fails on any corpus/manifest or provenance divergence, so a green run is
+      the citable evidence.
 
 ## Claim-wording gate
 

--- a/openspec/changes/exhaustive-regeneration-lane/.openspec.yaml
+++ b/openspec/changes/exhaustive-regeneration-lane/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-29

--- a/openspec/changes/exhaustive-regeneration-lane/design.md
+++ b/openspec/changes/exhaustive-regeneration-lane/design.md
@@ -1,0 +1,123 @@
+# Design: exhaustive-regeneration-lane
+
+## Context
+
+The parity program already has the *pieces* of exhaustive regeneration but never assembles them into a
+tier:
+
+- **Generators** exist as standalone scripts: `test-data/scripts/regenerate-datasets.sh` reproduces the
+  `nb`/`oa`/`da` keyspaces (the storage-format matrix, `cassandra:5.0.2` image), `generate-deltas.sh`
+  builds the `test_deltas` delete-bearing fixtures, `generate-corruption-corpus.sh` builds the
+  single-byte-mutation corruption fixtures (Data.db, Index.db, Summary.db, Statistics.db,
+  CompressionInfo.db, TOC.txt, Digest.crc32), and the `generate-*-parity.sh` family covers compression/
+  tombstone/cql-type/write-load/compaction.
+- **Provenance fields** already live in the manifest: `cassandra_source.{repo,ref,sha}` and per-scenario
+  `evidence.{cassandra_version,cassandra_git_sha,artifacts}`.
+- **Audit logic** already exists: `tools/cassandra-parity` has `coverage` (high-relevance classification
+  → `unclassified-high` errors under `--strict`, reading `docs/cassandra_test_index.md`), `lint`,
+  `report`, and `tier-contract-check`. The manifest model (`model.rs`) and the format/schema are stable.
+- **The tier contract** (`docs/development/parity-ci-tiers.md` §`exhaustive_regeneration`) already promises
+  this lane's behavior (RC-wide regeneration, `byte_for_byte`/`canonical_semantic` evidence, >= 90-day
+  retention, terminal tier).
+
+What is missing is (a) a workflow that *runs* the generators on a slow cadence, (b) a record of each
+run's provenance, and (c) an audit that diffs the regenerated inventory against the manifest. The change
+is CI + a small audit subcommand + doctrine cross-links; it adds no oracle bytes and changes no parser.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A `workflow_dispatch` + scheduled lane that regenerates all three corpus families (format matrix,
+  `test_deltas`, corruption fixtures) and runs the audit, emitting one report artifact.
+- A per-run provenance record (Cassandra version/ref, Docker image, generator commands, asset name,
+  SHA256) that the audit can compare against the manifest's declared `cassandra_source`.
+- A corpus audit that fails on missing references, stale references, unclassified high-relevance files,
+  and unexpected component changes.
+- The lane never commits regenerated datasets and never blocks a PR.
+
+**Non-Goals:**
+- Blocking PRs; reviewing every byte diff by hand; publishing dataset assets (the three out-of-scope items).
+- Rewriting the generator scripts or the manifest schema.
+
+## Decisions
+
+**D1. Reuse the existing generator scripts; do NOT build a monolithic new generator.**
+The lane is a thin workflow that invokes `regenerate-datasets.sh` (format matrix), `generate-deltas.sh`
+(`test_deltas`), and `generate-corruption-corpus.sh` (corruption fixtures) in sequence, then runs the
+audit. *Alternative considered:* a single new "regenerate-everything" Rust/shell tool that re-implements
+generation. *Rejected* — it would duplicate audited, deterministic scripts (the corruption generator has a
+documented determinism contract), double the maintenance surface, and risk drift from the scripts the rest
+of the program already trusts.
+
+**D2. The audit is a new `cassandra-parity corpus-audit` subcommand reusing `coverage` + the manifest
+model — not a new standalone tool and not shell `grep`.**
+`corpus-audit` takes the regenerated corpus root + the manifest + the test index and reports the four
+failure classes. It reuses `coverage::analyze` for the unclassified-high-relevance check and the existing
+`model::Manifest` parse for reference resolution. *Alternative considered:* a bash script doing `find` +
+`grep` over the corpus. *Rejected* as brittle and untestable; the Rust tool can be unit-tested with
+clean/drifted fixtures the way `tier-contract-check` is (§3 below mirrors that pattern).
+
+**D3. Four audit failure classes have precise, file-level definitions.**
+- *Missing reference:* a fixture path/component the manifest references (`scenario.fixtures.datasets`,
+  `evidence.artifacts` component files, `cassandra.files`) that is absent from the regenerated corpus.
+- *Stale reference:* a manifest reference that no regenerated component matches (the inverse — the manifest
+  points at something the fresh corpus no longer produces).
+- *Unclassified high-relevance Cassandra file:* a `docs/cassandra_test_index.md` "High-relevance" entry not
+  referenced by any manifest scenario (the existing `coverage --strict` failure, re-used verbatim).
+- *Unexpected component change:* a regenerated component whose presence/SHA256 inventory diverges from the
+  expected manifest entry set (a component appearing/disappearing, or a recorded checksum changing) without
+  a corresponding manifest update.
+
+**D4. Provenance is recorded as a structured run record compared against the manifest's `cassandra_source`.**
+The lane writes a small JSON/YAML provenance block (Cassandra version + ref + git-sha, Docker image tag,
+the exact generator commands run, the `package_datasets.sh` asset name, and the asset's SHA256) into the
+report artifact. The audit asserts the recorded Cassandra version/ref matches the manifest's pinned
+`cassandra_source.{ref,sha}` (and `evidence.cassandra_version`), so a silent version bump is caught.
+*Alternative considered:* relying on workflow logs only. *Rejected* — logs are not a durable, diffable
+record and cannot be asserted by the audit.
+
+**D5. Scheduled cadence = weekly (not nightly), plus `workflow_dispatch`.**
+Full corpus regeneration across the format matrix + deltas + corruption + a Cassandra container build is
+the program's most expensive job; the tier contract calls it "the full, expensive regeneration … run for
+release candidates," distinct from the *nightly* Docker lane (#1025). A weekly cron (e.g. `cron: '0 6 * * 0'`)
+keeps a "recent exhaustive_regeneration pass" fresh for the release checklist without paying nightly cost,
+and `workflow_dispatch` lets an RC trigger it on demand. *Alternative considered:* nightly — *rejected* as
+redundant with #1025's nightly Docker lane and wastefully expensive. (Final cron value is an owner question
+below.)
+
+**D6. Report-artifact only; no auto-commit, no publish.**
+The lane uploads one artifact (provenance record + audit report + generator logs) via `actions/upload-artifact`
+and stops. It does not `git commit` regenerated `*.db` binaries (they are gitignored anyway) and does not
+call `publish_datasets.sh`. *Alternative considered:* auto-committing refreshed JSONL goldens. *Rejected* —
+silently committing regenerated fixtures would bypass review and is explicitly out of scope; a human opens a
+follow-up PR if the audit shows the corpus should change.
+
+## Risks / Trade-offs
+
+- **[Expensive/slow run could be chronically skipped]** → the tier contract already warns that a chronically
+  skipped exhaustive run invalidates the "recent pass" release requirement; the weekly cron + the
+  release-checklist gate are the mitigation, not this change's job to enforce per-run.
+- **[Audit false-positives on legitimate corpus growth]** → "unexpected component change" is defined against
+  the *manifest's expected entry set*, so an intended new fixture lands with its manifest entry in the same
+  PR; the audit only fires when the corpus and manifest disagree.
+- **[Non-determinism in generators causing spurious SHA diffs]** → the corruption generator has a documented
+  determinism contract; `regenerate-datasets.sh`/`generate-deltas.sh` use fixed row counts and single-flush
+  SSTables. The audit compares *inventory + presence + manifest-recorded checksums*, not a brittle full-asset
+  SHA equality, so timestamp/UUID churn in non-pinned fixtures does not red the lane.
+- **[Audit tool drift from manifest schema]** → `corpus-audit` reuses the existing `model::Manifest` parser
+  and `coverage` classifier, so it tracks the schema the rest of the tool already enforces.
+
+## Migration Plan
+
+Additive only — a new workflow, a new `cassandra-parity` subcommand + its unit tests, a provenance record
+format, and doctrine cross-links. Reverting removes the lane and subcommand with no runtime impact on CQLite
+itself (the generators and manifest are unchanged).
+
+## Open Questions
+
+- **Cron cadence value.** Weekly (`0 6 * * 0`) is proposed (D5). Owner may prefer a different day/time or a
+  monthly cadence for cost — needs an owner decision.
+- **Provenance record format/location.** JSON vs YAML, and whether it is only an artifact or also written to
+  a tracked path (e.g. `docs/reports/`) for citation in the release checklist — owner preference.
+- **Audit strictness on RC vs scheduled runs.** Whether "unexpected component change" is a hard failure on
+  every scheduled run or only blocking for RC-tagged dispatches — owner scope decision.

--- a/openspec/changes/exhaustive-regeneration-lane/design.md
+++ b/openspec/changes/exhaustive-regeneration-lane/design.md
@@ -113,11 +113,12 @@ Additive only — a new workflow, a new `cassandra-parity` subcommand + its unit
 format, and doctrine cross-links. Reverting removes the lane and subcommand with no runtime impact on CQLite
 itself (the generators and manifest are unchanged).
 
-## Open Questions
+## Open Questions — RESOLVED (owner, 2026-06-29, Seam 1)
 
-- **Cron cadence value.** Weekly (`0 6 * * 0`) is proposed (D5). Owner may prefer a different day/time or a
-  monthly cadence for cost — needs an owner decision.
-- **Provenance record format/location.** JSON vs YAML, and whether it is only an artifact or also written to
-  a tracked path (e.g. `docs/reports/`) for citation in the release checklist — owner preference.
-- **Audit strictness on RC vs scheduled runs.** Whether "unexpected component change" is a hard failure on
-  every scheduled run or only blocking for RC-tagged dispatches — owner scope decision.
+- **Cron cadence value.** RESOLVED → **weekly `cron: '0 6 * * 0'`** (Sun 06:00 UTC) + `workflow_dispatch`.
+- **Provenance record format/location.** RESOLVED → **artifact only, JSON**. The provenance block is a JSON
+  document inside the uploaded report artifact; it is NOT written to a tracked repo path. The release
+  checklist cites the artifact's run URL.
+- **Audit strictness on RC vs scheduled runs.** RESOLVED → **hard-fail always**. An "unexpected component
+  change" is a hard non-zero exit on every run (scheduled + dispatch); a legitimate corpus change must land
+  via a manifest-update PR to turn the lane green. No RC-only / report-but-pass mode.

--- a/openspec/changes/exhaustive-regeneration-lane/proposal.md
+++ b/openspec/changes/exhaustive-regeneration-lane/proposal.md
@@ -1,0 +1,82 @@
+# Proposal: exhaustive-regeneration-lane
+
+> Milestone: Cassandra Byte-for-Byte Parity Program (epic #966 → #974 Public Claims and CI Gates).
+> Issue: #1026 (child of #974). Routing: **design-driven** (CI/test-infra + audit tooling; no new
+> oracle bytes, no parser/compaction fix) → OpenSpec. Sibling: #1025 (nightly Docker parity lane),
+> built on the tier contract landed by #1022 (`docs/development/parity-ci-tiers.md`).
+
+## Why
+
+The parity manifest already declares an `exhaustive_regeneration` CI tier and assigns many P0 scenarios
+to it (`test-data/cassandra-parity-manifest.yml`), and the tier contract
+(`docs/development/parity-ci-tiers.md` §`exhaustive_regeneration`) promises "the full, expensive
+regeneration of the entire fixture corpus across the storage-format matrix … run for release candidates."
+But **nothing actually runs that tier**. There is no workflow that regenerates the corpus, and there is no
+automated audit that the committed corpus + manifest still describe what a fresh Cassandra would produce.
+The generation scripts exist in isolation (`regenerate-datasets.sh`, `generate-deltas.sh`,
+`generate-corruption-corpus.sh`, and the `generate-*-parity.sh` family) but are never invoked as a tier,
+and the corpus-coverage audit (`cassandra-parity coverage`) is not wired to a regeneration run. As a
+result the strongest, broadest gate the program advertises is unbacked: a release could cite a "recent
+exhaustive_regeneration pass" that never existed (the release checklist, `parity-release-checklist.md`,
+requires one for RCs).
+
+This lane is the last CI-gate child of epic #974. It makes the `exhaustive_regeneration` tier real:
+a scheduled + manually-dispatchable workflow that regenerates the Cassandra-generated datasets, records
+their provenance, and audits the regenerated component inventory against the manifest — emitting a report
+artifact, and deliberately **not** committing regenerated binaries.
+
+## What Changes
+
+- **New workflow `.github/workflows/exhaustive-regeneration.yml`** (CI tier `exhaustive_regeneration`),
+  triggered by `workflow_dispatch` and a slow scheduled cadence (e.g. weekly cron) — never on PRs.
+  It orchestrates the existing generation scripts (`regenerate-datasets.sh` for the `nb`/`oa`/`da`/`big`/`bti`
+  format matrix, `generate-deltas.sh` for `test_deltas`, `generate-corruption-corpus.sh` for the
+  corruption fixtures), runs the corpus audit, uploads a single **report artifact**, and does **not**
+  commit anything back to the repo.
+- **New provenance record** captured per run: Cassandra version/ref/git-sha, the Docker image used,
+  the exact generator commands invoked, the produced dataset asset name, and the SHA256 of that asset —
+  anchored to the manifest's existing `cassandra_source` + `evidence.cassandra_version`/`cassandra_git_sha`
+  fields so the run's provenance is comparable to what the manifest claims.
+- **New corpus-audit surface** (a `cassandra-parity` subcommand, e.g. `corpus-audit`, reusing the existing
+  `coverage` high-relevance classifier and manifest model) that compares the **regenerated component
+  inventory** against the **expected manifest entries** and fails on: missing references, stale references,
+  unclassified high-relevance Cassandra files, and unexpected component changes.
+- **Manifest entries covered/asserted by the lane:** `exhaustive.regenerate.all_formats`,
+  `exhaustive.regenerate.test_deltas`, `exhaustive.regenerate.corruption_fixtures`,
+  `exhaustive.audit.manifest_coverage`, `exhaustive.audit.generated_references` — each a regeneration or
+  audit step the workflow exercises.
+- **Doctrine update:** cross-link the lane from the `exhaustive_regeneration` section of
+  `docs/development/parity-ci-tiers.md` and note the lane + audit command in `CLAUDE.md` (same-change
+  doctrine rule), so the gate that backs the release-checklist requirement is discoverable.
+
+## Capabilities
+
+### New Capabilities
+- `parity-corpus-regeneration`: The scheduled/dispatchable lane that regenerates the Cassandra-generated
+  parity corpus across the storage-format matrix, records each run's provenance (version/ref, Docker
+  image, commands, asset name, SHA256), audits the regenerated inventory against the manifest (missing/
+  stale references, unclassified high-relevance files, unexpected component changes), and emits a report
+  artifact without auto-committing regenerated datasets.
+
+### Modified Capabilities
+<!-- None: this introduces a new lane capability; it does not change requirements of an existing spec. -->
+
+## Impact
+
+- **CI (new)**: `.github/workflows/exhaustive-regeneration.yml` — `workflow_dispatch` + slow `schedule:`,
+  uploads report artifact only.
+- **Tooling**: `tools/cassandra-parity` — add a `corpus-audit` subcommand reusing `coverage` + the manifest
+  model; existing `lint`/`coverage`/`report`/`tier-contract-check` unchanged.
+- **Scripts**: orchestrates existing `test-data/scripts/regenerate-datasets.sh`, `generate-deltas.sh`,
+  `generate-corruption-corpus.sh`, `package_datasets.sh` (asset name) — no rewrite of generators.
+- **Doctrine**: `docs/development/parity-ci-tiers.md` (`exhaustive_regeneration` section) + `CLAUDE.md`
+  get a cross-link to the lane and audit command.
+
+## Non-goals (out of scope)
+
+- **Blocking normal PRs.** The lane never runs on PRs and never gates the fast/required PR path; it is
+  scheduled + manual only.
+- **Manually reviewing every generated byte diff.** The audit asserts inventory/provenance against the
+  manifest; it does not require a human to eyeball each byte-level diff of every regenerated component.
+- **Publishing dataset assets.** The lane produces and SHA256-stamps a dataset asset and emits a report,
+  but does not upload/publish a GitHub release asset (that stays with `publish_datasets.sh` / a release).

--- a/openspec/changes/exhaustive-regeneration-lane/specs/parity-corpus-regeneration/spec.md
+++ b/openspec/changes/exhaustive-regeneration-lane/specs/parity-corpus-regeneration/spec.md
@@ -1,0 +1,115 @@
+## ADDED Requirements
+
+### Requirement: The exhaustive regeneration lane runs on manual dispatch and a slow schedule
+
+The project SHALL provide a CI workflow at the `exhaustive_regeneration` tier that is triggerable via
+`workflow_dispatch` and also runs on a scheduled cadence suitable for slow, full-corpus generation. The
+lane MUST NOT run on ordinary pull requests and MUST NOT gate the fast or required PR paths.
+
+#### Scenario: Lane is manually dispatchable
+- **WHEN** a maintainer triggers the lane from the GitHub Actions UI
+- **THEN** the workflow accepts a `workflow_dispatch` event and starts a regeneration run
+- **AND** no pull-request trigger is configured for the workflow
+
+#### Scenario: Lane runs on a slow schedule
+- **WHEN** the configured schedule cadence elapses
+- **THEN** the workflow fires automatically on its `schedule:` cron without manual action
+- **AND** the cadence is slower than the nightly Docker lane (e.g. weekly), reflecting the cost of full-corpus generation
+
+### Requirement: Each regeneration run records dataset provenance
+
+The lane SHALL record, for every run, the Cassandra version and source ref/git-sha used, the Docker image
+tag, the exact generator commands invoked, the produced dataset asset name, and the SHA256 of that asset.
+The recorded Cassandra version/ref MUST be checkable against the manifest's pinned `cassandra_source`.
+
+#### Scenario: Provenance fields are captured
+- **WHEN** a regeneration run completes
+- **THEN** the run's provenance record contains the Cassandra version, source ref/git-sha, Docker image tag, the generator commands invoked, the dataset asset name, and the asset SHA256
+- **AND** the provenance record is included in the run's report artifact
+
+#### Scenario: Provenance is comparable to the manifest pin
+- **WHEN** the audit reads the run's provenance record
+- **THEN** it compares the recorded Cassandra version/ref/git-sha against the manifest's `cassandra_source` (and `evidence.cassandra_version`/`cassandra_git_sha`) pin
+- **AND** the audit fails if the regenerated corpus was produced from a Cassandra version/ref that the manifest does not declare
+
+### Requirement: The lane regenerates the full storage-format matrix, test_deltas, and corruption fixtures
+
+The lane SHALL regenerate the Cassandra-generated parity corpus by invoking the existing generation scripts:
+the storage-format matrix (`nb`/`oa`/`da`/`big`/`bti`) via `regenerate-datasets.sh`
+(`exhaustive.regenerate.all_formats`), the `test_deltas` delete-bearing fixtures via `generate-deltas.sh`
+(`exhaustive.regenerate.test_deltas`), and the corruption fixtures via `generate-corruption-corpus.sh`
+(`exhaustive.regenerate.corruption_fixtures`).
+
+#### Scenario: Format matrix is regenerated
+- **WHEN** the lane runs the `exhaustive.regenerate.all_formats` step
+- **THEN** it invokes `regenerate-datasets.sh` to rebuild the `nb`/`oa`/`da` corpus across the storage-format matrix
+- **AND** the regenerated dataset directories are available to the audit step
+
+#### Scenario: Delta fixtures are regenerated
+- **WHEN** the lane runs the `exhaustive.regenerate.test_deltas` step
+- **THEN** it invokes `generate-deltas.sh` to rebuild the `test_deltas` keyspace fixtures
+
+#### Scenario: Corruption fixtures are regenerated
+- **WHEN** the lane runs the `exhaustive.regenerate.corruption_fixtures` step
+- **THEN** it invokes `generate-corruption-corpus.sh` to rebuild the corruption-fixture corpus
+
+### Requirement: Corruption fixture generation covers every required component type
+
+The corruption-fixture regeneration step SHALL produce at least one corrupted-component fixture for each of:
+Data.db, Index.db, Summary.db, Statistics.db, CompressionInfo.db, TOC.txt, and Digest.crc32.
+
+#### Scenario: All seven component types are covered
+- **WHEN** the corruption-fixture step completes
+- **THEN** the regenerated corruption corpus includes a fixture targeting each of Data.db, Index.db, Summary.db, Statistics.db, CompressionInfo.db, TOC.txt, and Digest.crc32
+- **AND** the audit fails if any of those seven component types has no corruption fixture
+
+### Requirement: The audit compares the regenerated component inventory against expected manifest entries
+
+The lane SHALL run a corpus audit (`exhaustive.audit.manifest_coverage` and
+`exhaustive.audit.generated_references`) that compares the regenerated component inventory against the
+expected entries in `test-data/cassandra-parity-manifest.yml`, reusing the existing `cassandra-parity`
+manifest model and high-relevance classifier.
+
+#### Scenario: Inventory is diffed against the manifest
+- **WHEN** the audit runs after regeneration
+- **THEN** it enumerates the regenerated component inventory and the manifest's expected component/reference entries
+- **AND** it reports any divergence between the two as a named finding (component or reference identifier)
+
+### Requirement: The audit fails on missing references, stale references, unclassified high-relevance files, and unexpected component changes
+
+The corpus audit SHALL exit non-zero when any of the following holds: a manifest reference is missing from
+the regenerated corpus; a manifest reference is stale (no regenerated component matches it); a
+high-relevance Cassandra file from `docs/cassandra_test_index.md` is unclassified in the manifest; or a
+regenerated component's presence/checksum inventory changes unexpectedly relative to the expected manifest
+entry set.
+
+#### Scenario: Missing reference fails the audit
+- **WHEN** the manifest references a fixture path or component that the regenerated corpus does not contain
+- **THEN** the audit exits non-zero and names the missing reference
+
+#### Scenario: Stale reference fails the audit
+- **WHEN** the manifest references a component that no regenerated corpus file matches
+- **THEN** the audit exits non-zero and names the stale reference
+
+#### Scenario: Unclassified high-relevance file fails the audit
+- **WHEN** a high-relevance Cassandra test file in `docs/cassandra_test_index.md` is not referenced by any manifest scenario
+- **THEN** the audit exits non-zero and names the unclassified high-relevance file
+
+#### Scenario: Unexpected component change fails the audit
+- **WHEN** a regenerated component appears, disappears, or has a checksum that diverges from the expected manifest entry set without a corresponding manifest update
+- **THEN** the audit exits non-zero and names the unexpected component change
+
+### Requirement: The lane emits a report artifact and never auto-commits regenerated datasets
+
+The lane SHALL upload a single report artifact containing the provenance record, the audit report, and the
+generator logs. It MUST NOT commit regenerated dataset binaries back to the repository and MUST NOT publish
+the dataset asset to a release.
+
+#### Scenario: Report artifact is uploaded
+- **WHEN** a regeneration run finishes (pass or fail)
+- **THEN** the lane uploads a report artifact containing the provenance record, audit report, and generator logs
+
+#### Scenario: No auto-commit of regenerated datasets
+- **WHEN** the lane regenerates the corpus
+- **THEN** the workflow performs no `git commit`/`git push` of regenerated dataset binaries
+- **AND** the workflow does not publish the dataset asset to a GitHub release

--- a/openspec/changes/exhaustive-regeneration-lane/tasks.md
+++ b/openspec/changes/exhaustive-regeneration-lane/tasks.md
@@ -1,0 +1,30 @@
+# Tasks: exhaustive-regeneration-lane
+
+## 1. Corpus-audit subcommand (audit surface)
+- [ ] 1.1 Add a `cassandra-parity corpus-audit` subcommand (`tools/cassandra-parity/src/`) that takes the regenerated corpus root + `--manifest` + the test index, reusing `model::Manifest` and `coverage::analyze`. *Surface exercised:* `cargo run -p cassandra-parity -- corpus-audit --corpus <dir> --manifest test-data/cassandra-parity-manifest.yml`.
+- [ ] 1.2 Implement the four failure classes (design D3): missing reference, stale reference, unclassified high-relevance file (reuse `coverage --strict`), and unexpected component change (presence/checksum vs expected manifest entry set). Exit non-zero naming the offending reference/component.
+- [ ] 1.3 Implement the provenance check (design D4): assert the run's recorded Cassandra version/ref/git-sha matches the manifest's `cassandra_source` (+ `evidence.cassandra_version`/`cassandra_git_sha`); fail on a version the manifest does not declare. *Surface exercised:* the audit subcommand reading the provenance record.
+- [ ] 1.4 Unit tests mirroring `tier-contract-check`: a clean fixture (corpus ↔ manifest agree) plus one drifted fixture per failure class (missing, stale, unclassified-high, unexpected-component, version-mismatch). No Docker/live Cassandra.
+
+## 2. Provenance record (provenance surface)
+- [ ] 2.1 Define the per-run provenance record (JSON/YAML) holding Cassandra version + source ref/git-sha, Docker image tag, the generator commands invoked, the `package_datasets.sh` asset name, and the asset SHA256. *Surface exercised:* the record file the workflow writes and the audit (§1.3) reads.
+- [ ] 2.2 Wire `package_datasets.sh` (asset name) + a SHA256 step into the lane so the asset name and checksum are captured into the provenance record (no publish).
+
+## 3. Regeneration workflow (CI surface)
+- [ ] 3.1 Add `.github/workflows/exhaustive-regeneration.yml` (tier `exhaustive_regeneration`) with `workflow_dispatch` + a slow `schedule:` cron (design D5; cron value pending owner Q); no `pull_request` trigger. *Surface exercised:* the workflow file.
+- [ ] 3.2 Orchestrate the three regeneration steps: `exhaustive.regenerate.all_formats` → `regenerate-datasets.sh`; `exhaustive.regenerate.test_deltas` → `generate-deltas.sh`; `exhaustive.regenerate.corruption_fixtures` → `generate-corruption-corpus.sh`.
+- [ ] 3.3 Assert the corruption step covers all seven component types (Data.db, Index.db, Summary.db, Statistics.db, CompressionInfo.db, TOC.txt, Digest.crc32) — fail the lane if any is missing.
+- [ ] 3.4 Run `corpus-audit` (`exhaustive.audit.manifest_coverage` + `exhaustive.audit.generated_references`) after regeneration; fail the lane on any audit error.
+- [ ] 3.5 Upload ONE report artifact (provenance record + audit report + generator logs) via `actions/upload-artifact`; perform NO `git commit`/`git push` of regenerated binaries and NO release publish (design D6).
+
+## 4. Manifest wiring
+- [ ] 4.1 Ensure the five manifest entries the lane exercises (`exhaustive.regenerate.all_formats`, `exhaustive.regenerate.test_deltas`, `exhaustive.regenerate.corruption_fixtures`, `exhaustive.audit.manifest_coverage`, `exhaustive.audit.generated_references`) are present/consistent at tier `exhaustive_regeneration`; `cassandra-parity lint` stays green. *Surface exercised:* `test-data/cassandra-parity-manifest.yml`.
+
+## 5. Doctrine + docs cross-link
+- [ ] 5.1 Cross-link the lane + `corpus-audit` command from the `exhaustive_regeneration` section of `docs/development/parity-ci-tiers.md` and note them in `CLAUDE.md` (same-change doctrine rule).
+
+## 6. Quality gate (definition of done)
+- [ ] 6.1 Run `scripts/agent-gate.sh` (with `CQLITE_DATASETS_ROOT` → main repo `test-data/datasets`) and paste the AGENT-GATE SUMMARY block verbatim — must PASS.
+- [ ] 6.2 Intent audit **C**: run `spec-auditor` anchored to `openspec/changes/exhaustive-regeneration-lane/specs/**` — every requirement `satisfied` with public-surface evidence (the workflow file, the `corpus-audit` tests, the provenance record). Must report PASS.
+- [ ] 6.3 roborev: `/roborev-review-branch --base origin/main` clean (run `/roborev-fix` for findings).
+- [ ] 6.4 Push branch, open PR linking #1026; do NOT merge (owner's Seam 2).

--- a/openspec/changes/exhaustive-regeneration-lane/tasks.md
+++ b/openspec/changes/exhaustive-regeneration-lane/tasks.md
@@ -1,27 +1,27 @@
 # Tasks: exhaustive-regeneration-lane
 
 ## 1. Corpus-audit subcommand (audit surface)
-- [ ] 1.1 Add a `cassandra-parity corpus-audit` subcommand (`tools/cassandra-parity/src/`) that takes the regenerated corpus root + `--manifest` + the test index, reusing `model::Manifest` and `coverage::analyze`. *Surface exercised:* `cargo run -p cassandra-parity -- corpus-audit --corpus <dir> --manifest test-data/cassandra-parity-manifest.yml`.
-- [ ] 1.2 Implement the four failure classes (design D3): missing reference, stale reference, unclassified high-relevance file (reuse `coverage --strict`), and unexpected component change (presence/checksum vs expected manifest entry set). Exit non-zero naming the offending reference/component.
-- [ ] 1.3 Implement the provenance check (design D4): assert the run's recorded Cassandra version/ref/git-sha matches the manifest's `cassandra_source` (+ `evidence.cassandra_version`/`cassandra_git_sha`); fail on a version the manifest does not declare. *Surface exercised:* the audit subcommand reading the provenance record.
-- [ ] 1.4 Unit tests mirroring `tier-contract-check`: a clean fixture (corpus ↔ manifest agree) plus one drifted fixture per failure class (missing, stale, unclassified-high, unexpected-component, version-mismatch). No Docker/live Cassandra.
+- [x] 1.1 Add a `cassandra-parity corpus-audit` subcommand (`tools/cassandra-parity/src/`) that takes the regenerated corpus root + `--manifest` + the test index, reusing `model::Manifest` and `coverage::analyze`. *Surface exercised:* `cargo run -p cassandra-parity -- corpus-audit --corpus <dir> --manifest test-data/cassandra-parity-manifest.yml`.
+- [x] 1.2 Implement the four failure classes (design D3): missing reference, stale reference, unclassified high-relevance file (reuse `coverage --strict`), and unexpected component change (presence/checksum vs expected manifest entry set). Exit non-zero naming the offending reference/component.
+- [x] 1.3 Implement the provenance check (design D4): assert the run's recorded Cassandra version/ref/git-sha matches the manifest's `cassandra_source` (+ `evidence.cassandra_version`/`cassandra_git_sha`); fail on a version the manifest does not declare. *Surface exercised:* the audit subcommand reading the provenance record.
+- [x] 1.4 Unit tests mirroring `tier-contract-check`: a clean fixture (corpus ↔ manifest agree) plus one drifted fixture per failure class (missing, stale, unclassified-high, unexpected-component, version-mismatch). No Docker/live Cassandra.
 
 ## 2. Provenance record (provenance surface)
-- [ ] 2.1 Define the per-run provenance record (JSON/YAML) holding Cassandra version + source ref/git-sha, Docker image tag, the generator commands invoked, the `package_datasets.sh` asset name, and the asset SHA256. *Surface exercised:* the record file the workflow writes and the audit (§1.3) reads.
-- [ ] 2.2 Wire `package_datasets.sh` (asset name) + a SHA256 step into the lane so the asset name and checksum are captured into the provenance record (no publish).
+- [x] 2.1 Define the per-run provenance record (JSON/YAML) holding Cassandra version + source ref/git-sha, Docker image tag, the generator commands invoked, the `package_datasets.sh` asset name, and the asset SHA256. *Surface exercised:* the record file the workflow writes and the audit (§1.3) reads.
+- [x] 2.2 Wire `package_datasets.sh` (asset name) + a SHA256 step into the lane so the asset name and checksum are captured into the provenance record (no publish).
 
 ## 3. Regeneration workflow (CI surface)
-- [ ] 3.1 Add `.github/workflows/exhaustive-regeneration.yml` (tier `exhaustive_regeneration`) with `workflow_dispatch` + a slow `schedule:` cron (design D5; cron value pending owner Q); no `pull_request` trigger. *Surface exercised:* the workflow file.
-- [ ] 3.2 Orchestrate the three regeneration steps: `exhaustive.regenerate.all_formats` → `regenerate-datasets.sh`; `exhaustive.regenerate.test_deltas` → `generate-deltas.sh`; `exhaustive.regenerate.corruption_fixtures` → `generate-corruption-corpus.sh`.
-- [ ] 3.3 Assert the corruption step covers all seven component types (Data.db, Index.db, Summary.db, Statistics.db, CompressionInfo.db, TOC.txt, Digest.crc32) — fail the lane if any is missing.
-- [ ] 3.4 Run `corpus-audit` (`exhaustive.audit.manifest_coverage` + `exhaustive.audit.generated_references`) after regeneration; fail the lane on any audit error.
-- [ ] 3.5 Upload ONE report artifact (provenance record + audit report + generator logs) via `actions/upload-artifact`; perform NO `git commit`/`git push` of regenerated binaries and NO release publish (design D6).
+- [x] 3.1 Add `.github/workflows/exhaustive-regeneration.yml` (tier `exhaustive_regeneration`) with `workflow_dispatch` + a slow `schedule:` cron (design D5; cron value pending owner Q); no `pull_request` trigger. *Surface exercised:* the workflow file.
+- [x] 3.2 Orchestrate the three regeneration steps: `exhaustive.regenerate.all_formats` → `regenerate-datasets.sh`; `exhaustive.regenerate.test_deltas` → `generate-deltas.sh`; `exhaustive.regenerate.corruption_fixtures` → `generate-corruption-corpus.sh`.
+- [x] 3.3 Assert the corruption step covers all seven component types (Data.db, Index.db, Summary.db, Statistics.db, CompressionInfo.db, TOC.txt, Digest.crc32) — fail the lane if any is missing.
+- [x] 3.4 Run `corpus-audit` (`exhaustive.audit.manifest_coverage` + `exhaustive.audit.generated_references`) after regeneration; fail the lane on any audit error.
+- [x] 3.5 Upload ONE report artifact (provenance record + audit report + generator logs) via `actions/upload-artifact`; perform NO `git commit`/`git push` of regenerated binaries and NO release publish (design D6).
 
 ## 4. Manifest wiring
-- [ ] 4.1 Ensure the five manifest entries the lane exercises (`exhaustive.regenerate.all_formats`, `exhaustive.regenerate.test_deltas`, `exhaustive.regenerate.corruption_fixtures`, `exhaustive.audit.manifest_coverage`, `exhaustive.audit.generated_references`) are present/consistent at tier `exhaustive_regeneration`; `cassandra-parity lint` stays green. *Surface exercised:* `test-data/cassandra-parity-manifest.yml`.
+- [x] 4.1 Ensure the five manifest entries the lane exercises (`exhaustive.regenerate.all_formats`, `exhaustive.regenerate.test_deltas`, `exhaustive.regenerate.corruption_fixtures`, `exhaustive.audit.manifest_coverage`, `exhaustive.audit.generated_references`) are present/consistent at tier `exhaustive_regeneration`; `cassandra-parity lint` stays green. *Surface exercised:* `test-data/cassandra-parity-manifest.yml`.
 
 ## 5. Doctrine + docs cross-link
-- [ ] 5.1 Cross-link the lane + `corpus-audit` command from the `exhaustive_regeneration` section of `docs/development/parity-ci-tiers.md` and note them in `CLAUDE.md` (same-change doctrine rule).
+- [x] 5.1 Cross-link the lane + `corpus-audit` command from the `exhaustive_regeneration` section of `docs/development/parity-ci-tiers.md` and note them in `CLAUDE.md` (same-change doctrine rule).
 
 ## 6. Quality gate (definition of done)
 - [ ] 6.1 Run `scripts/agent-gate.sh` (with `CQLITE_DATASETS_ROOT` → main repo `test-data/datasets`) and paste the AGENT-GATE SUMMARY block verbatim — must PASS.

--- a/tools/cassandra-parity/Cargo.toml
+++ b/tools/cassandra-parity/Cargo.toml
@@ -19,3 +19,6 @@ serde_yaml = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/tools/cassandra-parity/src/corpus_audit/mod.rs
+++ b/tools/cassandra-parity/src/corpus_audit/mod.rs
@@ -1,0 +1,271 @@
+//! Corpus audit (`cassandra-parity corpus-audit`, issue #1026): after the
+//! exhaustive-regeneration lane rebuilds the Cassandra-generated parity corpus,
+//! this audit diffs the regenerated component inventory + the run's provenance
+//! against `test-data/cassandra-parity-manifest.yml`.
+//!
+//! Like [`crate::tier_contract`] and [`crate::workflow_check`], the audit is a
+//! pure data-in / findings-out function so it is hermetically unit-testable
+//! (clean + drifted in-memory fixtures, no Docker / live Cassandra / disk). The
+//! `corpus-audit` subcommand in `main.rs` builds the inventories from the
+//! regenerated tree on disk and calls [`audit`].
+//!
+//! Failure classes (design D3 of the OpenSpec change):
+//!   1. **Missing reference** — a manifest reference under the regenerated corpus
+//!      tree that no fresh component matches at all.
+//!   2. **Stale reference** — a manifest reference whose table/component the corpus
+//!      still produces, but only under a *different* generation directory (the
+//!      manifest pins an obsolete table-UUID dir).
+//!   3. **Unclassified high-relevance file** — a `docs/cassandra_test_index.md`
+//!      high-relevance entry no manifest scenario classifies (reuses
+//!      [`crate::coverage`], the `coverage --strict` failure verbatim).
+//!   4. **Unexpected component change** — a regenerated component whose
+//!      presence/SHA256 diverges from the expected manifest entry set.
+//!   5. **Provenance mismatch** — the run's recorded Cassandra version/ref/sha is
+//!      not declared by the manifest's `cassandra_source` / `evidence.*` pin.
+//!   6. **Corruption coverage gap** — a required corrupted-component type
+//!      (Data.db … Digest.crc32) has no corruption fixture.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::coverage;
+use crate::model::Manifest;
+
+pub mod provenance;
+pub mod refs;
+
+pub use provenance::Provenance;
+
+/// The seven SSTable component types that the corruption-fixture corpus MUST
+/// each cover with at least one fixture (spec requirement "Corruption fixture
+/// generation covers every required component type").
+pub const REQUIRED_CORRUPTION_COMPONENTS: &[&str] = &[
+    "Data.db",
+    "Index.db",
+    "Summary.db",
+    "Statistics.db",
+    "CompressionInfo.db",
+    "TOC.txt",
+    "Digest.crc32",
+];
+
+/// The kind of a single audit finding. Every kind is a hard-fail (non-zero exit)
+/// per the owner-pinned strictness decision (always hard-fail; no report-but-pass).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FindingKind {
+    MissingReference,
+    StaleReference,
+    UnclassifiedHighRelevance,
+    UnexpectedComponentChange,
+    ProvenanceMismatch,
+    CorruptionCoverageGap,
+}
+
+impl FindingKind {
+    /// Stable, greppable tag for rendered output.
+    pub fn tag(self) -> &'static str {
+        match self {
+            FindingKind::MissingReference => "MISSING-REFERENCE",
+            FindingKind::StaleReference => "STALE-REFERENCE",
+            FindingKind::UnclassifiedHighRelevance => "UNCLASSIFIED-HIGH-RELEVANCE",
+            FindingKind::UnexpectedComponentChange => "UNEXPECTED-COMPONENT-CHANGE",
+            FindingKind::ProvenanceMismatch => "PROVENANCE-MISMATCH",
+            FindingKind::CorruptionCoverageGap => "CORRUPTION-COVERAGE-GAP",
+        }
+    }
+}
+
+/// One audit failure naming the offending reference/component/value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuditFinding {
+    pub kind: FindingKind,
+    /// The named offender (reference path, component path, version/sha, etc.).
+    pub subject: String,
+    /// Why it is a finding.
+    pub detail: String,
+}
+
+impl AuditFinding {
+    pub fn new(kind: FindingKind, subject: impl Into<String>, detail: impl Into<String>) -> Self {
+        AuditFinding {
+            kind,
+            subject: subject.into(),
+            detail: detail.into(),
+        }
+    }
+}
+
+/// The regenerated corpus as the audit sees it: the set of repo-relative file
+/// paths present, plus an optional SHA256 per path (when a checksums file was
+/// supplied to the CLI).
+#[derive(Debug, Default)]
+pub struct CorpusInventory {
+    pub files: BTreeSet<String>,
+    pub checksums: BTreeMap<String, String>,
+}
+
+/// The expected component entry set the corpus is diffed against: repo-relative
+/// path -> expected SHA256 (e.g. committed reference-golden checksums computed at
+/// checkout, before regeneration).
+#[derive(Debug, Default)]
+pub struct ExpectedInventory {
+    pub components: BTreeMap<String, String>,
+}
+
+/// Outcome of [`audit`]. `ok()` is true only when there are zero findings.
+#[derive(Debug, Default)]
+pub struct AuditReport {
+    pub findings: Vec<AuditFinding>,
+}
+
+impl AuditReport {
+    pub fn ok(&self) -> bool {
+        self.findings.is_empty()
+    }
+
+    /// Count of findings of a given kind (used by the CLI summary + tests).
+    pub fn count(&self, kind: FindingKind) -> usize {
+        self.findings.iter().filter(|f| f.kind == kind).count()
+    }
+
+    /// Human + machine readable rendering, one finding per line.
+    pub fn render(&self) -> String {
+        if self.ok() {
+            return "corpus-audit: OK".to_string();
+        }
+        let mut lines = Vec::with_capacity(self.findings.len());
+        for f in &self.findings {
+            lines.push(format!("{} {} — {}", f.kind.tag(), f.subject, f.detail));
+        }
+        lines.join("\n")
+    }
+}
+
+/// Run the full corpus audit. Pure: all inputs are owned by the caller, so the
+/// same call is used by the CLI (disk-backed inputs) and the unit tests
+/// (synthetic in-memory inputs).
+///
+/// `provenance` is `None` only when no provenance record was supplied; the
+/// regeneration lane always supplies one, so the provenance comparison runs in CI.
+pub fn audit(
+    manifest: &Manifest,
+    index_text: &str,
+    inventory: &CorpusInventory,
+    expected: &ExpectedInventory,
+    provenance: Option<&Provenance>,
+    corruption_components: &BTreeSet<String>,
+) -> AuditReport {
+    let mut findings = Vec::new();
+
+    // 1 + 2: missing / stale references over the regenerated corpus tree.
+    findings.extend(refs::check_references(manifest, inventory));
+
+    // 3: unclassified high-relevance Cassandra files (reuse the coverage classifier).
+    let cov = coverage::analyze(manifest, index_text);
+    for f in &cov.unclassified_high {
+        findings.push(AuditFinding::new(
+            FindingKind::UnclassifiedHighRelevance,
+            f.clone(),
+            "high-relevance Cassandra test file is not referenced by any manifest scenario",
+        ));
+    }
+
+    // 4: unexpected component change (presence/checksum vs expected entry set).
+    findings.extend(check_component_changes(inventory, expected));
+
+    // 5: provenance vs the manifest's declared Cassandra pin.
+    if let Some(prov) = provenance {
+        findings.extend(provenance::check_provenance(prov, manifest));
+    }
+
+    // 6: corruption-fixture coverage of every required component type.
+    findings.extend(check_corruption_coverage(corruption_components));
+
+    AuditReport { findings }
+}
+
+/// Diff the regenerated component inventory's presence/checksums against the
+/// expected entry set: a recorded component that disappeared, whose checksum
+/// changed, or that newly appeared inside an expected directory — each without a
+/// corresponding manifest update — is an unexpected component change.
+///
+/// "Appeared" is intentionally scoped to directories that already carry an
+/// expected entry, so timestamp/UUID churn in *unpinned* fixtures (design risk
+/// note) never reds the lane: only a directory the manifest already tracks can
+/// surface a surprise component.
+pub fn check_component_changes(
+    inventory: &CorpusInventory,
+    expected: &ExpectedInventory,
+) -> Vec<AuditFinding> {
+    let mut out = Vec::new();
+    if expected.components.is_empty() {
+        return out;
+    }
+
+    // Disappeared / checksum-changed.
+    for (path, expected_sha) in &expected.components {
+        match inventory.checksums.get(path) {
+            Some(actual_sha) if actual_sha == expected_sha => {}
+            Some(actual_sha) => out.push(AuditFinding::new(
+                FindingKind::UnexpectedComponentChange,
+                path.clone(),
+                format!("checksum changed: expected {expected_sha}, regenerated {actual_sha}"),
+            )),
+            None => {
+                if !inventory.files.contains(path) {
+                    out.push(AuditFinding::new(
+                        FindingKind::UnexpectedComponentChange,
+                        path.clone(),
+                        "expected component is absent from the regenerated corpus".to_string(),
+                    ));
+                }
+            }
+        }
+    }
+
+    // Appeared inside a directory that the expected set already tracks.
+    let expected_dirs: BTreeSet<&str> = expected
+        .components
+        .keys()
+        .map(|p| parent_dir(p))
+        .collect();
+    for path in inventory.checksums.keys() {
+        if expected.components.contains_key(path) {
+            continue;
+        }
+        if expected_dirs.contains(parent_dir(path)) {
+            out.push(AuditFinding::new(
+                FindingKind::UnexpectedComponentChange,
+                path.clone(),
+                "component appeared in a tracked directory with no expected manifest entry"
+                    .to_string(),
+            ));
+        }
+    }
+
+    out
+}
+
+/// Fail when any required corrupted-component type has no corruption fixture.
+/// `produced` is the set of `expected_failing_component` values the corruption
+/// corpus actually generated (parsed from `corruption-manifest.yml` by the CLI).
+pub fn check_corruption_coverage(produced: &BTreeSet<String>) -> Vec<AuditFinding> {
+    let mut out = Vec::new();
+    for req in REQUIRED_CORRUPTION_COMPONENTS {
+        if !produced.contains(*req) {
+            out.push(AuditFinding::new(
+                FindingKind::CorruptionCoverageGap,
+                (*req).to_string(),
+                "no corruption fixture targets this required component type".to_string(),
+            ));
+        }
+    }
+    out
+}
+
+/// Parent directory of a `/`-separated repo-relative path (`""` if top-level).
+fn parent_dir(path: &str) -> &str {
+    match path.rfind('/') {
+        Some(i) => &path[..i],
+        None => "",
+    }
+}

--- a/tools/cassandra-parity/src/corpus_audit/mod.rs
+++ b/tools/cassandra-parity/src/corpus_audit/mod.rs
@@ -223,11 +223,7 @@ pub fn check_component_changes(
     }
 
     // Appeared inside a directory that the expected set already tracks.
-    let expected_dirs: BTreeSet<&str> = expected
-        .components
-        .keys()
-        .map(|p| parent_dir(p))
-        .collect();
+    let expected_dirs: BTreeSet<&str> = expected.components.keys().map(|p| parent_dir(p)).collect();
     for path in inventory.checksums.keys() {
         if expected.components.contains_key(path) {
             continue;

--- a/tools/cassandra-parity/src/corpus_audit/mod.rs
+++ b/tools/cassandra-parity/src/corpus_audit/mod.rs
@@ -24,7 +24,10 @@
 //!   5. **Provenance mismatch** — the run's recorded Cassandra version/ref/sha is
 //!      not declared by the manifest's `cassandra_source` / `evidence.*` pin.
 //!   6. **Corruption coverage gap** — a required corrupted-component type
-//!      (Data.db … Digest.crc32) has no corruption fixture.
+//!      (Data.db … Digest.crc32) has no on-disk corruption fixture: either no
+//!      manifest fixture declares it, or every fixture that declares it has no
+//!      corrupted file present in the regenerated corpus (spec R4 is on-disk
+//!      reality, not just a manifest declaration; issue #1026).
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -109,6 +112,26 @@ pub struct CorpusInventory {
     pub checksums: BTreeMap<String, String>,
 }
 
+/// One corruption fixture as declared in `corruption-manifest.yml`. The audit
+/// cross-checks each fixture's [`corrupted_path`](Self::corrupted_path) against
+/// the walked corpus inventory so a fixture that was DECLARED but never produced
+/// on disk is caught (spec R4: an on-disk fixture per required component, not
+/// merely a manifest declaration; issue #1026).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CorruptionFixture {
+    /// The targeted `expected_failing_component`, e.g. `Data.db`.
+    pub component: String,
+    /// Datasets-root-relative on-disk path of the corrupted fixture file, e.g.
+    /// `corruption/test_comp_corrupt/data_db_bit_flip/nb-1-big-Data.db`. The
+    /// walked inventory keys this with a `test-data/datasets/` prefix the
+    /// manifest omits, so presence is matched on a path boundary
+    /// ([`inventory_contains_fixture`]).
+    pub corrupted_path: String,
+    /// `active` (a real corrupted file was produced) or `planned` (declared but
+    /// no clean source was available in the checkout, so no file exists).
+    pub status: String,
+}
+
 /// The expected component entry set the corpus is diffed against: repo-relative
 /// path -> expected SHA256 (e.g. committed reference-golden checksums computed at
 /// checkout, before regeneration).
@@ -158,7 +181,7 @@ pub fn audit(
     inventory: &CorpusInventory,
     expected: &ExpectedInventory,
     provenance: Option<&Provenance>,
-    corruption_components: &BTreeSet<String>,
+    corruption_fixtures: &[CorruptionFixture],
 ) -> AuditReport {
     let mut findings = Vec::new();
 
@@ -183,8 +206,12 @@ pub fn audit(
         findings.extend(provenance::check_provenance(prov, manifest));
     }
 
-    // 6: corruption-fixture coverage of every required component type.
-    findings.extend(check_corruption_coverage(corruption_components));
+    // 6: corruption-fixture coverage of every required component type, verified
+    // against the on-disk inventory (not just the manifest declarations).
+    findings.extend(check_corruption_coverage(
+        corruption_fixtures,
+        &inventory.files,
+    ));
 
     AuditReport { findings }
 }
@@ -265,19 +292,62 @@ pub fn check_component_changes(
     out
 }
 
-/// Fail when any required corrupted-component type has no corruption fixture.
-/// `produced` is the set of `expected_failing_component` values the corruption
-/// corpus actually generated (parsed from `corruption-manifest.yml` by the CLI).
-pub fn check_corruption_coverage(produced: &BTreeSet<String>) -> Vec<AuditFinding> {
+/// Fail when any required corrupted-component type has no ON-DISK corruption
+/// fixture. `fixtures` are the corruption fixtures declared in
+/// `corruption-manifest.yml` (parsed by the CLI); `inventory` is the set of
+/// repo-relative file paths walked from the regenerated corpus.
+///
+/// For each required component a fixture must both DECLARE it AND have produced a
+/// corrupted file present in `inventory` — spec R4 is on-disk reality, not just a
+/// manifest declaration, so a fixture that was declared but never produced (e.g.
+/// `generate-corruption-corpus.sh` silently produced fewer files, or the fixture
+/// is `planned` for lack of a clean source) is a coverage gap (issue #1026).
+pub fn check_corruption_coverage(
+    fixtures: &[CorruptionFixture],
+    inventory: &BTreeSet<String>,
+) -> Vec<AuditFinding> {
     let mut out = Vec::new();
     for req in REQUIRED_CORRUPTION_COMPONENTS {
-        if !produced.contains(*req) {
+        let declaring: Vec<&CorruptionFixture> =
+            fixtures.iter().filter(|f| f.component == *req).collect();
+        if declaring.is_empty() {
             out.push(AuditFinding::new(
                 FindingKind::CorruptionCoverageGap,
                 (*req).to_string(),
-                "no corruption fixture targets this required component type".to_string(),
+                "no corruption fixture declares this required component type".to_string(),
+            ));
+            continue;
+        }
+        let on_disk = declaring
+            .iter()
+            .any(|f| inventory_contains_fixture(inventory, &f.corrupted_path));
+        if !on_disk {
+            out.push(AuditFinding::new(
+                FindingKind::CorruptionCoverageGap,
+                (*req).to_string(),
+                "corruption fixture(s) declare this required component type but no corrupted \
+                 fixture file is present in the regenerated corpus"
+                    .to_string(),
             ));
         }
     }
     out
+}
+
+/// True when `corrupted_path` (datasets-root-relative, as declared in the
+/// corruption manifest, e.g. `corruption/test_comp_corrupt/<name>/<file>`) is
+/// present in the walked corpus `inventory` (repo-root-relative, carrying a
+/// leading `test-data/datasets/` the manifest path omits). The two are reconciled
+/// by a path-boundary suffix match — an exact equality OR an inventory key whose
+/// suffix is `/<corrupted_path>` — so the prefix is not hard-coded and a partial
+/// path component (e.g. `…/x-Data.db` vs `…/Data.db`) cannot spuriously match.
+fn inventory_contains_fixture(inventory: &BTreeSet<String>, corrupted_path: &str) -> bool {
+    if corrupted_path.is_empty() {
+        return false;
+    }
+    inventory.iter().any(|p| {
+        p == corrupted_path
+            || p.strip_suffix(corrupted_path)
+                .is_some_and(|prefix| prefix.ends_with('/'))
+    })
 }

--- a/tools/cassandra-parity/src/corpus_audit/mod.rs
+++ b/tools/cassandra-parity/src/corpus_audit/mod.rs
@@ -185,13 +185,20 @@ pub fn audit(
 
 /// Diff the regenerated component inventory's presence/checksums against the
 /// expected entry set: a recorded component that disappeared, whose checksum
-/// changed, or that newly appeared inside an expected directory — each without a
+/// changed, or that newly appeared inside an expected table — each without a
 /// corresponding manifest update — is an unexpected component change.
 ///
-/// "Appeared" is intentionally scoped to directories that already carry an
-/// expected entry, so timestamp/UUID churn in *unpinned* fixtures (design risk
-/// note) never reds the lane: only a directory the manifest already tracks can
-/// surface a surprise component.
+/// Both sides are keyed by their UUID-independent table+component identity
+/// ([`refs::component_identity`]), NOT by the raw repo-relative path. Every
+/// regeneration `rm -rf`s the corpus and re-mints each table under a fresh
+/// `<table>-<uuid>` directory, so the committed-expected golden and the
+/// regenerated-actual golden never share a path; comparing identities is what
+/// makes the check fire only on a *genuine* presence/checksum change of a stable
+/// identity instead of false-positiving on the per-run UUID churn (issue #1026).
+///
+/// "Appeared" is scoped to tables that already carry an expected entry, so churn
+/// in *unpinned* fixtures never reds the lane: only a table the manifest already
+/// tracks can surface a surprise component.
 pub fn check_component_changes(
     inventory: &CorpusInventory,
     expected: &ExpectedInventory,
@@ -201,39 +208,50 @@ pub fn check_component_changes(
         return out;
     }
 
-    // Disappeared / checksum-changed.
+    // Regenerated checksummed components keyed by UUID-independent identity,
+    // keeping a representative regenerated path for messaging.
+    let mut actual_by_identity: BTreeMap<String, (String, String)> = BTreeMap::new();
+    for (path, sha) in &inventory.checksums {
+        actual_by_identity
+            .entry(refs::component_identity(path))
+            .or_insert_with(|| (sha.clone(), path.clone()));
+    }
+
+    // Identities + tables the expected set tracks (for the "appeared" half).
+    let mut expected_identities: BTreeSet<String> = BTreeSet::new();
+    let mut expected_tables: BTreeSet<String> = BTreeSet::new();
+
+    // Disappeared / checksum-changed, by identity.
     for (path, expected_sha) in &expected.components {
-        match inventory.checksums.get(path) {
-            Some(actual_sha) if actual_sha == expected_sha => {}
-            Some(actual_sha) => out.push(AuditFinding::new(
+        let identity = refs::component_identity(path);
+        expected_tables.insert(parent_dir(&identity).to_string());
+        expected_identities.insert(identity.clone());
+        match actual_by_identity.get(&identity) {
+            Some((actual_sha, _)) if actual_sha == expected_sha => {}
+            Some((actual_sha, actual_path)) => out.push(AuditFinding::new(
                 FindingKind::UnexpectedComponentChange,
-                path.clone(),
+                actual_path.clone(),
                 format!("checksum changed: expected {expected_sha}, regenerated {actual_sha}"),
             )),
-            None => {
-                if !inventory.files.contains(path) {
-                    out.push(AuditFinding::new(
-                        FindingKind::UnexpectedComponentChange,
-                        path.clone(),
-                        "expected component is absent from the regenerated corpus".to_string(),
-                    ));
-                }
-            }
+            None => out.push(AuditFinding::new(
+                FindingKind::UnexpectedComponentChange,
+                path.clone(),
+                "expected component is absent from the regenerated corpus".to_string(),
+            )),
         }
     }
 
-    // Appeared inside a directory that the expected set already tracks.
-    let expected_dirs: BTreeSet<&str> = expected.components.keys().map(|p| parent_dir(p)).collect();
-    for path in inventory.checksums.keys() {
-        if expected.components.contains_key(path) {
+    // Appeared: a regenerated component whose table identity the expected set
+    // already tracks, but whose own component identity it does not.
+    for (identity, (_, path)) in &actual_by_identity {
+        if expected_identities.contains(identity) {
             continue;
         }
-        if expected_dirs.contains(parent_dir(path)) {
+        if expected_tables.contains(parent_dir(identity)) {
             out.push(AuditFinding::new(
                 FindingKind::UnexpectedComponentChange,
                 path.clone(),
-                "component appeared in a tracked directory with no expected manifest entry"
-                    .to_string(),
+                "component appeared in a tracked table with no expected manifest entry".to_string(),
             ));
         }
     }

--- a/tools/cassandra-parity/src/corpus_audit/mod.rs
+++ b/tools/cassandra-parity/src/corpus_audit/mod.rs
@@ -230,7 +230,7 @@ pub fn check_component_changes(
     // Disappeared / checksum-changed, by identity.
     for (path, expected_sha) in &expected.components {
         let identity = refs::component_identity(path);
-        expected_tables.insert(parent_dir(&identity).to_string());
+        expected_tables.insert(refs::split_path(&identity).0.to_string());
         expected_identities.insert(identity.clone());
         match actual_by_identity.get(&identity) {
             Some((actual_sha, _)) if actual_sha == expected_sha => {}
@@ -253,7 +253,7 @@ pub fn check_component_changes(
         if expected_identities.contains(identity) {
             continue;
         }
-        if expected_tables.contains(parent_dir(identity)) {
+        if expected_tables.contains(refs::split_path(identity).0) {
             out.push(AuditFinding::new(
                 FindingKind::UnexpectedComponentChange,
                 path.clone(),
@@ -280,12 +280,4 @@ pub fn check_corruption_coverage(produced: &BTreeSet<String>) -> Vec<AuditFindin
         }
     }
     out
-}
-
-/// Parent directory of a `/`-separated repo-relative path (`""` if top-level).
-fn parent_dir(path: &str) -> &str {
-    match path.rfind('/') {
-        Some(i) => &path[..i],
-        None => "",
-    }
 }

--- a/tools/cassandra-parity/src/corpus_audit/mod.rs
+++ b/tools/cassandra-parity/src/corpus_audit/mod.rs
@@ -11,10 +11,11 @@
 //!
 //! Failure classes (design D3 of the OpenSpec change):
 //!   1. **Missing reference** — a manifest reference under the regenerated corpus
-//!      tree that no fresh component matches at all.
-//!   2. **Stale reference** — a manifest reference whose table/component the corpus
-//!      still produces, but only under a *different* generation directory (the
-//!      manifest pins an obsolete table-UUID dir).
+//!      tree whose UUID-independent table+component identity NO fresh component
+//!      matches (a genuine disappearance). A reference the corpus still produces
+//!      under a *churned* `<table>-<uuid>` directory is NOT a finding: every
+//!      regeneration mints fresh table UUIDs, so reference classification is by
+//!      identity, never raw path ([`refs::component_identity`], issue #1026).
 //!   3. **Unclassified high-relevance file** — a `docs/cassandra_test_index.md`
 //!      high-relevance entry no manifest scenario classifies (reuses
 //!      [`crate::coverage`], the `coverage --strict` failure verbatim).
@@ -53,6 +54,11 @@ pub const REQUIRED_CORRUPTION_COMPONENTS: &[&str] = &[
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FindingKind {
     MissingReference,
+    /// Retained for the spec's "stale reference" vocabulary and the rendered
+    /// tag. A genuinely vanished reference (no regenerated file shares its
+    /// table+component identity) is reported as [`Self::MissingReference`]; a
+    /// reference present under a churned `<table>-<uuid>` directory is clean, so
+    /// reference checking never constructs this variant (issue #1026).
     StaleReference,
     UnclassifiedHighRelevance,
     UnexpectedComponentChange,

--- a/tools/cassandra-parity/src/corpus_audit/provenance.rs
+++ b/tools/cassandra-parity/src/corpus_audit/provenance.rs
@@ -1,0 +1,110 @@
+//! Per-run dataset provenance record + its comparison against the manifest's
+//! declared Cassandra pin (design D4 / spec "Each regeneration run records
+//! dataset provenance").
+//!
+//! The regeneration lane writes this record (as JSON) into its report artifact;
+//! it is NOT committed to any tracked repo path (owner decision: artifact-only).
+//! The audit reads it back and fails if the corpus was produced from a Cassandra
+//! version/ref/sha the manifest does not declare — catching a silent image bump.
+
+use std::collections::BTreeSet;
+
+use serde::Deserialize;
+
+use crate::model::Manifest;
+
+use super::{AuditFinding, FindingKind};
+
+/// The structured provenance of one regeneration run.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Provenance {
+    /// Cassandra version string, e.g. `5.0.2`.
+    pub cassandra_version: String,
+    /// Cassandra source ref, e.g. `cassandra-5.0.2`.
+    pub cassandra_ref: String,
+    /// Cassandra source git sha.
+    pub cassandra_git_sha: String,
+    /// Docker image tag used to generate, e.g. `cassandra:5.0.2`.
+    pub docker_image: String,
+    /// The exact generator commands invoked, in order.
+    #[serde(default)]
+    pub generator_commands: Vec<String>,
+    /// The `package_datasets.sh` asset name.
+    pub dataset_asset_name: String,
+    /// SHA256 of the produced dataset asset.
+    pub dataset_asset_sha256: String,
+}
+
+impl Provenance {
+    /// Parse a provenance record from its JSON document.
+    pub fn from_json(text: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(text)
+    }
+}
+
+/// Fail when the recorded provenance was produced from a Cassandra
+/// version/ref/sha the manifest does not declare.
+///
+/// - `cassandra_ref` MUST equal `cassandra_source.ref`.
+/// - `cassandra_git_sha` MUST be `cassandra_source.sha` or appear in some
+///   `evidence.cassandra_git_sha`.
+/// - `cassandra_version` MUST be the version implied by `cassandra_source.ref`
+///   (e.g. `cassandra-5.0.2` → `5.0.2`) or appear in some
+///   `evidence.cassandra_version`.
+pub fn check_provenance(prov: &Provenance, manifest: &Manifest) -> Vec<AuditFinding> {
+    let mut out = Vec::new();
+    let src = &manifest.cassandra_source;
+
+    if prov.cassandra_ref != src.git_ref {
+        out.push(AuditFinding::new(
+            FindingKind::ProvenanceMismatch,
+            prov.cassandra_ref.clone(),
+            format!(
+                "recorded cassandra_ref does not match manifest cassandra_source.ref ({})",
+                src.git_ref
+            ),
+        ));
+    }
+
+    let mut declared_shas: BTreeSet<&str> = BTreeSet::new();
+    declared_shas.insert(src.sha.as_str());
+    let mut declared_versions: BTreeSet<String> = BTreeSet::new();
+    if let Some(v) = version_from_ref(&src.git_ref) {
+        declared_versions.insert(v);
+    }
+    for s in &manifest.scenarios {
+        if let Some(sha) = &s.evidence.cassandra_git_sha {
+            declared_shas.insert(sha.as_str());
+        }
+        if let Some(v) = &s.evidence.cassandra_version {
+            declared_versions.insert(v.clone());
+        }
+    }
+
+    if !declared_shas.contains(prov.cassandra_git_sha.as_str()) {
+        out.push(AuditFinding::new(
+            FindingKind::ProvenanceMismatch,
+            prov.cassandra_git_sha.clone(),
+            "recorded cassandra_git_sha is not declared by cassandra_source.sha or any \
+             evidence.cassandra_git_sha"
+                .to_string(),
+        ));
+    }
+
+    if !declared_versions.contains(&prov.cassandra_version) {
+        out.push(AuditFinding::new(
+            FindingKind::ProvenanceMismatch,
+            prov.cassandra_version.clone(),
+            "recorded cassandra_version is not declared by cassandra_source.ref or any \
+             evidence.cassandra_version"
+                .to_string(),
+        ));
+    }
+
+    out
+}
+
+/// Derive a version (`5.0.2`) from a `cassandra-<version>` ref; `None` otherwise.
+fn version_from_ref(git_ref: &str) -> Option<String> {
+    git_ref.strip_prefix("cassandra-").map(str::to_string)
+}

--- a/tools/cassandra-parity/src/corpus_audit/provenance.rs
+++ b/tools/cassandra-parity/src/corpus_audit/provenance.rs
@@ -51,15 +51,17 @@ impl Provenance {
 /// - `cassandra_version` MUST be the version implied by `cassandra_source.ref`
 ///   (e.g. `cassandra-5.0.2` → `5.0.2`) or appear in some
 ///   `evidence.cassandra_version`.
-/// - `docker_image` MUST carry a parseable semver tag whose version is one of
-///   the manifest's declared versions. This field is the ONE provenance value
-///   sourced independently of the manifest in the lane (it is grepped from
-///   `regenerate-datasets.sh`'s `CASSANDRA_IMAGE=`, while version/ref/sha are
-///   parsed from the manifest itself), so it is the only field that can catch a
-///   silent image bump (e.g. `cassandra:5.0.2` → `5.0.3`) that was not mirrored
-///   into the manifest pin (issue #1026). A tag that is absent or not a parseable
-///   `MAJOR[.MINOR[.PATCH…]]` semver (e.g. `latest`) is itself a mismatch: an
-///   unverifiable image cannot be trusted against the pin.
+/// - `docker_image` MUST carry a tag whose leading `MAJOR[.MINOR[.PATCH…]]`
+///   version is one of the manifest's declared versions. This field is the ONE
+///   provenance value sourced independently of the manifest in the lane (it is
+///   grepped from `regenerate-datasets.sh`'s `CASSANDRA_IMAGE=`, while
+///   version/ref/sha are parsed from the manifest itself), so it is the only
+///   field that can catch a silent image bump (e.g. `cassandra:5.0.2` → `5.0.3`)
+///   that was not mirrored into the manifest pin (issue #1026). A legitimately
+///   pinned variant image (`cassandra:5.0.2-jdk11`, `cassandra:5.0.2-jammy`)
+///   compares by its numeric lead `5.0.2`, so the build/variant tail never reds
+///   the lane. A tag with no numeric lead (e.g. `latest`, empty) is itself a
+///   mismatch: an unverifiable image cannot be trusted against the pin.
 pub fn check_provenance(prov: &Provenance, manifest: &Manifest) -> Vec<AuditFinding> {
     let mut out = Vec::new();
     let src = &manifest.cassandra_source;
@@ -146,10 +148,13 @@ fn version_from_ref(git_ref: &str) -> Option<String> {
 /// Handles a registry/namespace prefix and an optional `@sha256:<digest>` suffix:
 /// `docker.io/library/cassandra:5.0.3@sha256:abc…` → `5.0.3`. The tag is the
 /// portion after the last `:` of the final path segment (so a registry-host port
-/// like `registry:5000/cassandra:5.0.3` is not mistaken for a tag). Returns the
-/// version string on success; `Err(reason)` when there is no tag or the tag is not
-/// a parseable `MAJOR[.MINOR[.PATCH…]]` semver (e.g. `latest`) — an unverifiable
-/// image must be treated as a mismatch, never silently trusted.
+/// like `registry:5000/cassandra:5.0.3` is not mistaken for a tag). The returned
+/// version is the tag's leading `MAJOR[.MINOR[.PATCH…]]` numeric component, with
+/// an optional leading `v` and a `-<suffix>` build/variant tail ignored, so a
+/// pinned variant image (`cassandra:5.0.2-jdk11`) compares as `5.0.2`. Returns
+/// `Err(reason)` when there is no tag or the tag has no numeric lead (e.g.
+/// `latest`) — an unverifiable image must be treated as a mismatch, never
+/// silently trusted.
 fn version_from_image(image: &str) -> Result<String, String> {
     // Drop an `@sha256:…` content digest if present.
     let no_digest = image.split('@').next().unwrap_or(image);
@@ -164,26 +169,39 @@ fn version_from_image(image: &str) -> Result<String, String> {
             ))
         }
     };
-    if is_semver_tag(tag) {
-        Ok(tag.strip_prefix('v').unwrap_or(tag).to_string())
+    semver_lead(tag).ok_or_else(|| {
+        format!("image tag `{tag}` has no parseable MAJOR[.MINOR[.PATCH]] semver lead")
+    })
+}
+
+/// Parse the leading `MAJOR[.MINOR[.PATCH…]]` numeric version from a Docker tag,
+/// ignoring an optional leading `v` and a trailing `-<suffix>` build/variant tail.
+/// So `5`, `5.0`, `5.0.2`, `v5.0.2`, `5.0.2-jdk11`, and `5.0.2-jammy` all yield
+/// `5.0.2`-style numeric leads (the last three → `5.0.2`), while `latest`, ``,
+/// `5.`, and `-jdk11` have no numeric lead and yield `None` — a genuinely
+/// unverifiable tag stays a mismatch. The numeric lead must be a non-empty run of
+/// digits and dots with at least one digit and no leading/trailing or doubled dot.
+fn semver_lead(tag: &str) -> Option<String> {
+    let t = tag.strip_prefix('v').unwrap_or(tag);
+    // Ignore a build/variant suffix (`-jdk11`, `-jammy`, `-alpine`, …).
+    let lead = t.split('-').next().unwrap_or(t);
+    if is_dotted_numeric(lead) {
+        Some(lead.to_string())
     } else {
-        Err(format!(
-            "image tag `{tag}` is not a parseable MAJOR[.MINOR[.PATCH]] semver"
-        ))
+        None
     }
 }
 
-/// A tag is a usable semver pin when (ignoring an optional leading `v`) it is a
-/// non-empty run of digits and dots with at least one digit and no leading/trailing
-/// or doubled dot (so `5`, `5.0`, `5.0.2`, `v5.0.2` parse; `latest`, ``, `5.` do not).
-fn is_semver_tag(tag: &str) -> bool {
-    let t = tag.strip_prefix('v').unwrap_or(tag);
-    !t.is_empty()
-        && !t.starts_with('.')
-        && !t.ends_with('.')
-        && !t.contains("..")
-        && t.chars().all(|c| c.is_ascii_digit() || c == '.')
-        && t.chars().any(|c| c.is_ascii_digit())
+/// True when `s` is a non-empty run of digits and dots with at least one digit
+/// and no leading/trailing or doubled dot (so `5`, `5.0`, `5.0.2` qualify; ``,
+/// `5.`, `.5`, `5..0`, `latest` do not).
+fn is_dotted_numeric(s: &str) -> bool {
+    !s.is_empty()
+        && !s.starts_with('.')
+        && !s.ends_with('.')
+        && !s.contains("..")
+        && s.chars().all(|c| c.is_ascii_digit() || c == '.')
+        && s.chars().any(|c| c.is_ascii_digit())
 }
 
 #[cfg(test)]
@@ -224,6 +242,20 @@ mod tests {
     }
 
     #[test]
+    fn version_from_image_ignores_variant_build_suffix() {
+        // A legitimately pinned variant image compares by its numeric lead, so a
+        // `-jdk11` / `-jammy` build tail must not be mistaken for a non-semver tag.
+        assert_eq!(
+            version_from_image("cassandra:5.0.2-jdk11").as_deref(),
+            Ok("5.0.2")
+        );
+        assert_eq!(
+            version_from_image("cassandra:5.0.2-jammy").as_deref(),
+            Ok("5.0.2")
+        );
+    }
+
+    #[test]
     fn version_from_image_rejects_latest() {
         assert!(version_from_image("cassandra:latest").is_err());
     }
@@ -234,14 +266,21 @@ mod tests {
     }
 
     #[test]
-    fn is_semver_tag_edge_cases() {
-        assert!(is_semver_tag("5"));
-        assert!(is_semver_tag("5.0"));
-        assert!(is_semver_tag("5.0.2"));
-        assert!(!is_semver_tag(""));
-        assert!(!is_semver_tag("latest"));
-        assert!(!is_semver_tag("5."));
-        assert!(!is_semver_tag(".5"));
-        assert!(!is_semver_tag("5..0"));
+    fn semver_lead_edge_cases() {
+        assert_eq!(semver_lead("5").as_deref(), Some("5"));
+        assert_eq!(semver_lead("5.0").as_deref(), Some("5.0"));
+        assert_eq!(semver_lead("5.0.2").as_deref(), Some("5.0.2"));
+        assert_eq!(semver_lead("v5.0.2").as_deref(), Some("5.0.2"));
+        // Build/variant suffix is ignored, leaving the numeric lead.
+        assert_eq!(semver_lead("5.0.2-jdk11").as_deref(), Some("5.0.2"));
+        assert_eq!(semver_lead("5.0.2-jammy").as_deref(), Some("5.0.2"));
+        assert_eq!(semver_lead("v5.0.2-alpine").as_deref(), Some("5.0.2"));
+        // No numeric lead -> unverifiable -> None.
+        assert!(semver_lead("").is_none());
+        assert!(semver_lead("latest").is_none());
+        assert!(semver_lead("-jdk11").is_none());
+        assert!(semver_lead("5.").is_none());
+        assert!(semver_lead(".5").is_none());
+        assert!(semver_lead("5..0").is_none());
     }
 }

--- a/tools/cassandra-parity/src/corpus_audit/provenance.rs
+++ b/tools/cassandra-parity/src/corpus_audit/provenance.rs
@@ -51,6 +51,15 @@ impl Provenance {
 /// - `cassandra_version` MUST be the version implied by `cassandra_source.ref`
 ///   (e.g. `cassandra-5.0.2` → `5.0.2`) or appear in some
 ///   `evidence.cassandra_version`.
+/// - `docker_image` MUST carry a parseable semver tag whose version is one of
+///   the manifest's declared versions. This field is the ONE provenance value
+///   sourced independently of the manifest in the lane (it is grepped from
+///   `regenerate-datasets.sh`'s `CASSANDRA_IMAGE=`, while version/ref/sha are
+///   parsed from the manifest itself), so it is the only field that can catch a
+///   silent image bump (e.g. `cassandra:5.0.2` → `5.0.3`) that was not mirrored
+///   into the manifest pin (issue #1026). A tag that is absent or not a parseable
+///   `MAJOR[.MINOR[.PATCH…]]` semver (e.g. `latest`) is itself a mismatch: an
+///   unverifiable image cannot be trusted against the pin.
 pub fn check_provenance(prov: &Provenance, manifest: &Manifest) -> Vec<AuditFinding> {
     let mut out = Vec::new();
     let src = &manifest.cassandra_source;
@@ -101,10 +110,138 @@ pub fn check_provenance(prov: &Provenance, manifest: &Manifest) -> Vec<AuditFind
         ));
     }
 
+    // The independently-sourced docker_image is the only field that can catch a
+    // silent image bump: version/ref/sha are all parsed from the manifest in the
+    // lane, so validating them against the manifest is tautological, whereas the
+    // image tag is grepped from regenerate-datasets.sh's CASSANDRA_IMAGE=.
+    match version_from_image(&prov.docker_image) {
+        Ok(img_version) if declared_versions.contains(&img_version) => {}
+        Ok(img_version) => out.push(AuditFinding::new(
+            FindingKind::ProvenanceMismatch,
+            prov.docker_image.clone(),
+            format!(
+                "docker_image tag version {img_version} is not declared by cassandra_source.ref \
+                 or any evidence.cassandra_version (silent image bump not mirrored into the \
+                 manifest pin?)"
+            ),
+        )),
+        Err(reason) => out.push(AuditFinding::new(
+            FindingKind::ProvenanceMismatch,
+            prov.docker_image.clone(),
+            format!("docker_image cannot be validated against the manifest pin: {reason}"),
+        )),
+    }
+
     out
 }
 
 /// Derive a version (`5.0.2`) from a `cassandra-<version>` ref; `None` otherwise.
 fn version_from_ref(git_ref: &str) -> Option<String> {
     git_ref.strip_prefix("cassandra-").map(str::to_string)
+}
+
+/// Extract the semver version a Docker image reference points at, so it can be
+/// checked against the manifest's declared Cassandra version(s).
+///
+/// Handles a registry/namespace prefix and an optional `@sha256:<digest>` suffix:
+/// `docker.io/library/cassandra:5.0.3@sha256:abc…` → `5.0.3`. The tag is the
+/// portion after the last `:` of the final path segment (so a registry-host port
+/// like `registry:5000/cassandra:5.0.3` is not mistaken for a tag). Returns the
+/// version string on success; `Err(reason)` when there is no tag or the tag is not
+/// a parseable `MAJOR[.MINOR[.PATCH…]]` semver (e.g. `latest`) — an unverifiable
+/// image must be treated as a mismatch, never silently trusted.
+fn version_from_image(image: &str) -> Result<String, String> {
+    // Drop an `@sha256:…` content digest if present.
+    let no_digest = image.split('@').next().unwrap_or(image);
+    // The repository[:tag] is the final `/`-separated segment; this discards any
+    // registry host (which is the only place a `:`-port could otherwise appear).
+    let last_seg = no_digest.rsplit('/').next().unwrap_or(no_digest);
+    let tag = match last_seg.split_once(':') {
+        Some((_, t)) if !t.is_empty() => t,
+        _ => {
+            return Err(format!(
+                "image reference {image} has no tag to validate (implicit `latest` is not pinned)"
+            ))
+        }
+    };
+    if is_semver_tag(tag) {
+        Ok(tag.strip_prefix('v').unwrap_or(tag).to_string())
+    } else {
+        Err(format!(
+            "image tag `{tag}` is not a parseable MAJOR[.MINOR[.PATCH]] semver"
+        ))
+    }
+}
+
+/// A tag is a usable semver pin when (ignoring an optional leading `v`) it is a
+/// non-empty run of digits and dots with at least one digit and no leading/trailing
+/// or doubled dot (so `5`, `5.0`, `5.0.2`, `v5.0.2` parse; `latest`, ``, `5.` do not).
+fn is_semver_tag(tag: &str) -> bool {
+    let t = tag.strip_prefix('v').unwrap_or(tag);
+    !t.is_empty()
+        && !t.starts_with('.')
+        && !t.ends_with('.')
+        && !t.contains("..")
+        && t.chars().all(|c| c.is_ascii_digit() || c == '.')
+        && t.chars().any(|c| c.is_ascii_digit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_from_image_parses_bare_tag() {
+        assert_eq!(
+            version_from_image("cassandra:5.0.2").as_deref(),
+            Ok("5.0.2")
+        );
+    }
+
+    #[test]
+    fn version_from_image_strips_registry_prefix_and_digest() {
+        assert_eq!(
+            version_from_image("docker.io/library/cassandra:5.0.3@sha256:abc123").as_deref(),
+            Ok("5.0.3")
+        );
+    }
+
+    #[test]
+    fn version_from_image_ignores_registry_port() {
+        // The host port (`:5000`) is before the last `/`, so it is not the tag.
+        assert_eq!(
+            version_from_image("registry.local:5000/cassandra:5.0.2").as_deref(),
+            Ok("5.0.2")
+        );
+    }
+
+    #[test]
+    fn version_from_image_strips_leading_v() {
+        assert_eq!(
+            version_from_image("cassandra:v5.0.2").as_deref(),
+            Ok("5.0.2")
+        );
+    }
+
+    #[test]
+    fn version_from_image_rejects_latest() {
+        assert!(version_from_image("cassandra:latest").is_err());
+    }
+
+    #[test]
+    fn version_from_image_rejects_missing_tag() {
+        assert!(version_from_image("cassandra").is_err());
+    }
+
+    #[test]
+    fn is_semver_tag_edge_cases() {
+        assert!(is_semver_tag("5"));
+        assert!(is_semver_tag("5.0"));
+        assert!(is_semver_tag("5.0.2"));
+        assert!(!is_semver_tag(""));
+        assert!(!is_semver_tag("latest"));
+        assert!(!is_semver_tag("5."));
+        assert!(!is_semver_tag(".5"));
+        assert!(!is_semver_tag("5..0"));
+    }
 }

--- a/tools/cassandra-parity/src/corpus_audit/refs.rs
+++ b/tools/cassandra-parity/src/corpus_audit/refs.rs
@@ -1,0 +1,130 @@
+//! Missing/stale reference classification for the corpus audit (design D3).
+//!
+//! Only manifest references that point INTO the regenerated corpus tree
+//! (`test-data/datasets/...`) are audited here; arbitrary repo files (test
+//! sources, scripts) are covered by the manifest linter's path-existence check.
+//!
+//! A reference is:
+//!   * **OK** when its exact path is present in the regenerated corpus.
+//!   * **Stale** when the corpus still produces the same table+component, but
+//!     only under a *different* generation directory — i.e. the manifest pins an
+//!     obsolete table-UUID dir (the common real-world drift: every regeneration
+//!     mints fresh table UUIDs).
+//!   * **Missing** when no regenerated component matches the table+component at all.
+
+use std::collections::BTreeSet;
+
+use crate::model::{Manifest, Scenario};
+
+use super::{AuditFinding, CorpusInventory, FindingKind};
+
+/// Only references under this prefix are part of the regenerated corpus.
+const CORPUS_PREFIX: &str = "test-data/datasets/";
+
+/// Classify every corpus-tree reference of every non-`planned` scenario.
+pub fn check_references(manifest: &Manifest, inventory: &CorpusInventory) -> Vec<AuditFinding> {
+    // (table_key, basename) of every regenerated file, for stale-vs-missing.
+    let mut produced: BTreeSet<(String, String)> = BTreeSet::new();
+    for f in &inventory.files {
+        let (parent, base) = split_path(f);
+        produced.insert((table_key(parent), base.to_string()));
+    }
+
+    let mut out = Vec::new();
+    let mut seen: BTreeSet<String> = BTreeSet::new();
+    for s in &manifest.scenarios {
+        if s.status == "planned" {
+            continue;
+        }
+        for r in corpus_refs(s) {
+            if !seen.insert(r.clone()) {
+                continue;
+            }
+            if inventory.files.contains(&r) {
+                continue;
+            }
+            let (parent, base) = split_path(&r);
+            let key = (table_key(parent), base.to_string());
+            if produced.contains(&key) {
+                out.push(AuditFinding::new(
+                    FindingKind::StaleReference,
+                    r.clone(),
+                    format!(
+                        "scenario {} pins a generation dir the fresh corpus replaced \
+                         (same table+component exists under a new directory)",
+                        s.id
+                    ),
+                ));
+            } else {
+                out.push(AuditFinding::new(
+                    FindingKind::MissingReference,
+                    r.clone(),
+                    format!(
+                        "scenario {} references a corpus component the regeneration did not produce",
+                        s.id
+                    ),
+                ));
+            }
+        }
+    }
+    out
+}
+
+/// Collect a scenario's references that live under the regenerated corpus tree.
+fn corpus_refs(s: &Scenario) -> Vec<String> {
+    let mut v = Vec::new();
+    for r in &s.fixtures.references {
+        if is_corpus(r) {
+            v.push(r.clone());
+        }
+    }
+    for r in &s.fixtures.datasets {
+        if is_corpus(r) {
+            v.push(r.clone());
+        }
+    }
+    for r in &s.evidence.reference_paths {
+        if is_corpus(r) {
+            v.push(r.clone());
+        }
+    }
+    v
+}
+
+fn is_corpus(path: &str) -> bool {
+    path.starts_with(CORPUS_PREFIX)
+}
+
+/// Split a `/`-separated path into `(parent, basename)`.
+fn split_path(p: &str) -> (&str, &str) {
+    match p.rfind('/') {
+        Some(i) => (&p[..i], &p[i + 1..]),
+        None => ("", p),
+    }
+}
+
+/// A UUID-independent key for the table a component lives in: the parent dir with
+/// the trailing `-<uuid>` stripped from its last segment. So
+/// `.../test_basic/simple_table-<uuidA>` and `.../test_basic/simple_table-<uuidB>`
+/// share the key `.../test_basic/simple_table`.
+fn table_key(parent: &str) -> String {
+    let (grand, last) = split_path(parent);
+    let stripped = strip_uuid_suffix(last);
+    if grand.is_empty() {
+        stripped.to_string()
+    } else {
+        format!("{grand}/{stripped}")
+    }
+}
+
+/// Strip a trailing `-<hex>` UUID suffix (>= 16 hex chars) from a directory
+/// segment; otherwise return it unchanged.
+fn strip_uuid_suffix(seg: &str) -> &str {
+    if let Some(i) = seg.rfind('-') {
+        let suffix = &seg[i + 1..];
+        if suffix.len() >= 16 && suffix.chars().all(|c| c.is_ascii_hexdigit()) {
+            return &seg[..i];
+        }
+    }
+    seg
+}

--- a/tools/cassandra-parity/src/corpus_audit/refs.rs
+++ b/tools/cassandra-parity/src/corpus_audit/refs.rs
@@ -1,16 +1,21 @@
-//! Missing/stale reference classification for the corpus audit (design D3).
+//! Missing reference classification for the corpus audit (design D3).
 //!
 //! Only manifest references that point INTO the regenerated corpus tree
 //! (`test-data/datasets/...`) are audited here; arbitrary repo files (test
 //! sources, scripts) are covered by the manifest linter's path-existence check.
 //!
-//! A reference is:
-//!   * **OK** when its exact path is present in the regenerated corpus.
-//!   * **Stale** when the corpus still produces the same table+component, but
-//!     only under a *different* generation directory — i.e. the manifest pins an
-//!     obsolete table-UUID dir (the common real-world drift: every regeneration
-//!     mints fresh table UUIDs).
-//!   * **Missing** when no regenerated component matches the table+component at all.
+//! The lane audits a FRESHLY regenerated corpus: `regenerate-datasets.sh`
+//! `rm -rf`s the corpus and re-creates each table via `CREATE TABLE`, so
+//! Cassandra mints a NEW random table UUID for each table every run. The
+//! committed manifest references pin OLD UUID directories, so a healthy
+//! reference almost never matches by exact path. Classification is therefore by
+//! the SAME UUID-independent identity [`component_identity`] the sibling
+//! component-change audit uses — never by raw path:
+//!   * **OK** when its exact path is present in the regenerated corpus, OR when
+//!     a regenerated file shares its `(table_key, basename)` identity (the
+//!     manifest merely pins an obsolete table-UUID dir — pure per-run churn).
+//!   * **Missing** only on GENUINE disappearance: no regenerated file shares the
+//!     reference's table+component identity at all.
 
 use std::collections::BTreeSet;
 
@@ -22,13 +27,20 @@ use super::{AuditFinding, CorpusInventory, FindingKind};
 const CORPUS_PREFIX: &str = "test-data/datasets/";
 
 /// Classify every corpus-tree reference of every non-`planned` scenario.
+///
+/// A reference is a [`FindingKind::MissingReference`] ONLY when no regenerated
+/// file shares its UUID-independent [`component_identity`]. A reference whose
+/// identity IS present — even under a churned `<table>-<uuid>` directory the
+/// manifest does not pin — produces ZERO findings, matching the churn-tolerant
+/// contract of [`super::check_component_changes`] (issue #1026).
 pub fn check_references(manifest: &Manifest, inventory: &CorpusInventory) -> Vec<AuditFinding> {
-    // (table_key, basename) of every regenerated file, for stale-vs-missing.
-    let mut produced: BTreeSet<(String, String)> = BTreeSet::new();
-    for f in &inventory.files {
-        let (parent, base) = split_path(f);
-        produced.insert((table_key(parent), base.to_string()));
-    }
+    // UUID-independent identity of every regenerated file, so a reference pinned
+    // to an obsolete table-UUID dir still resolves to its churned twin.
+    let produced: BTreeSet<String> = inventory
+        .files
+        .iter()
+        .map(|f| component_identity(f))
+        .collect();
 
     let mut out = Vec::new();
     let mut seen: BTreeSet<String> = BTreeSet::new();
@@ -40,31 +52,22 @@ pub fn check_references(manifest: &Manifest, inventory: &CorpusInventory) -> Vec
             if !seen.insert(r.clone()) {
                 continue;
             }
-            if inventory.files.contains(&r) {
+            // Exact path present, or the same table+component exists under a
+            // churned UUID dir -> the corpus still produces it; not a finding.
+            if inventory.files.contains(&r) || produced.contains(&component_identity(&r)) {
                 continue;
             }
-            let (parent, base) = split_path(&r);
-            let key = (table_key(parent), base.to_string());
-            if produced.contains(&key) {
-                out.push(AuditFinding::new(
-                    FindingKind::StaleReference,
-                    r.clone(),
-                    format!(
-                        "scenario {} pins a generation dir the fresh corpus replaced \
-                         (same table+component exists under a new directory)",
-                        s.id
-                    ),
-                ));
-            } else {
-                out.push(AuditFinding::new(
-                    FindingKind::MissingReference,
-                    r.clone(),
-                    format!(
-                        "scenario {} references a corpus component the regeneration did not produce",
-                        s.id
-                    ),
-                ));
-            }
+            // Genuine disappearance: no regenerated file shares this reference's
+            // table+component identity.
+            out.push(AuditFinding::new(
+                FindingKind::MissingReference,
+                r.clone(),
+                format!(
+                    "scenario {} references a corpus component the regeneration did not produce \
+                     (no regenerated file shares its table+component identity)",
+                    s.id
+                ),
+            ));
         }
     }
     out

--- a/tools/cassandra-parity/src/corpus_audit/refs.rs
+++ b/tools/cassandra-parity/src/corpus_audit/refs.rs
@@ -24,7 +24,7 @@ use crate::model::{Manifest, Scenario};
 use super::{AuditFinding, CorpusInventory, FindingKind};
 
 /// Only references under this prefix are part of the regenerated corpus.
-const CORPUS_PREFIX: &str = "test-data/datasets/";
+pub const CORPUS_PREFIX: &str = "test-data/datasets/";
 
 /// Classify every corpus-tree reference of every non-`planned` scenario.
 ///

--- a/tools/cassandra-parity/src/corpus_audit/refs.rs
+++ b/tools/cassandra-parity/src/corpus_audit/refs.rs
@@ -115,8 +115,10 @@ pub fn component_identity(path: &str) -> String {
     }
 }
 
-/// Split a `/`-separated path into `(parent, basename)`.
-fn split_path(p: &str) -> (&str, &str) {
+/// Split a `/`-separated path into `(parent, basename)`. The parent is `""` for a
+/// top-level path. Shared with [`super`]'s component-change audit so the
+/// parent-of-a-path rule lives in exactly one place (issue #1026).
+pub(crate) fn split_path(p: &str) -> (&str, &str) {
     match p.rfind('/') {
         Some(i) => (&p[..i], &p[i + 1..]),
         None => ("", p),

--- a/tools/cassandra-parity/src/corpus_audit/refs.rs
+++ b/tools/cassandra-parity/src/corpus_audit/refs.rs
@@ -95,6 +95,23 @@ fn is_corpus(path: &str) -> bool {
     path.starts_with(CORPUS_PREFIX)
 }
 
+/// A UUID-independent identity for a single component file: its [`table_key`]
+/// (parent directory with the trailing `-<uuid>` stripped) joined with its
+/// basename. So the same golden under `simple_table-<uuidA>/nb-1-big-Data.db.jsonl`
+/// and `simple_table-<uuidB>/nb-1-big-Data.db.jsonl` share one identity. The
+/// component-change audit (issue #1026) keys both the committed-expected and the
+/// regenerated-actual inventories by this identity, so the per-run table-UUID
+/// churn is not mistaken for a presence/checksum change.
+pub fn component_identity(path: &str) -> String {
+    let (parent, base) = split_path(path);
+    let key = table_key(parent);
+    if key.is_empty() {
+        base.to_string()
+    } else {
+        format!("{key}/{base}")
+    }
+}
+
 /// Split a `/`-separated path into `(parent, basename)`.
 fn split_path(p: &str) -> (&str, &str) {
     match p.rfind('/') {

--- a/tools/cassandra-parity/src/lib.rs
+++ b/tools/cassandra-parity/src/lib.rs
@@ -2,6 +2,7 @@
 //! exercise the linter, coverage, and report logic directly.
 
 pub mod claim_scan;
+pub mod corpus_audit;
 pub mod coverage;
 pub mod enums;
 pub mod lint;

--- a/tools/cassandra-parity/src/main.rs
+++ b/tools/cassandra-parity/src/main.rs
@@ -372,6 +372,15 @@ fn walk_relative(dir: &Path) -> Result<BTreeSet<String>> {
 /// single separator so runs of spaces/tabs inside a path are preserved (issue
 /// #1026, Finding 3); splitting on whitespace would collapse them and mismatch
 /// the keys produced by [`walk_relative`]. Blank/comment lines are ignored.
+///
+/// ASSUMPTION: corpus paths contain neither a backslash nor a newline. GNU
+/// coreutils `sha256sum` escapes any filename containing one of those by
+/// prefixing the WHOLE line with a single `\` and backslash-escaping the path
+/// (`\` -> `\\`, newline -> `\n`). The audit consumes only `test-data/datasets/`
+/// component paths, which never contain such characters, so rather than carry a
+/// full unescaper we reject a `\`-marked line loudly: folding the leading `\`
+/// into the hash token (then `replace('\\','/')`-ing the escapes) would silently
+/// corrupt both the hash and the path key (issue #1026, Finding LOW B).
 fn read_sha256_file(path: &Path) -> Result<BTreeMap<String, String>> {
     let text = std::fs::read_to_string(path)
         .with_context(|| format!("reading checksums file {}", path.display()))?;
@@ -382,6 +391,14 @@ fn read_sha256_file(path: &Path) -> Result<BTreeMap<String, String>> {
         let line = raw.trim_end();
         if line.is_empty() || line.trim_start().starts_with('#') {
             continue;
+        }
+        // A leading `\` marks a GNU-escaped line (path has a backslash/newline).
+        if line.starts_with('\\') {
+            bail!(
+                "checksums file {} contains a GNU sha256sum-escaped path (line starts with `\\`): \
+                 corpus component paths must not contain a backslash or newline",
+                path.display()
+            );
         }
         // The hash is the leading token up to the first space separator.
         let Some(sep) = line.find(' ') else {
@@ -620,5 +637,26 @@ mod tests {
             "binary-mode `*` prefix must be stripped, got: {map:?}"
         );
         assert_eq!(map.len(), 3, "comment/blank lines ignored, got: {map:?}");
+    }
+
+    /// Finding LOW B: GNU `sha256sum` escapes a path containing a backslash or
+    /// newline by prefixing the WHOLE line with `\`. The parser must reject such
+    /// a line loudly rather than fold the leading `\` into the hash token and
+    /// corrupt the key — corpus paths never contain those characters.
+    #[test]
+    fn read_sha256_file_rejects_gnu_escaped_backslash_line() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = dir.path().join("sums.sha256");
+        let hash = "a".repeat(64);
+        // GNU emits a leading `\` and escapes the in-path backslash as `\\`.
+        let body = format!("\\{hash}  dir/with\\\\backslash.jsonl\n");
+        fs::write(&file, body).expect("write sums");
+
+        let err = read_sha256_file(&file).expect_err("escaped line must error");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("GNU sha256sum-escaped") && msg.contains("backslash"),
+            "expected a clear escaped-path error, got: {msg}"
+        );
     }
 }

--- a/tools/cassandra-parity/src/main.rs
+++ b/tools/cassandra-parity/src/main.rs
@@ -86,7 +86,9 @@ fn parse_args(rest: &[String]) -> Result<Args> {
             "--provenance" => {
                 args.provenance = Some(PathBuf::from(next_val(&mut it, "--provenance")?))
             }
-            "--checksums" => args.checksums = Some(PathBuf::from(next_val(&mut it, "--checksums")?)),
+            "--checksums" => {
+                args.checksums = Some(PathBuf::from(next_val(&mut it, "--checksums")?))
+            }
             "--expected-inventory" => {
                 args.expected_inventory =
                     Some(PathBuf::from(next_val(&mut it, "--expected-inventory")?))

--- a/tools/cassandra-parity/src/main.rs
+++ b/tools/cassandra-parity/src/main.rs
@@ -16,7 +16,9 @@ use std::process::ExitCode;
 use anyhow::{bail, Context, Result};
 
 use cassandra_parity::claim_scan::{self, ScanInput};
-use cassandra_parity::corpus_audit::{self, CorpusInventory, ExpectedInventory, Provenance};
+use cassandra_parity::corpus_audit::{
+    self, CorpusInventory, CorruptionFixture, ExpectedInventory, Provenance,
+};
 use cassandra_parity::lint::Level;
 use cassandra_parity::model::Manifest;
 use cassandra_parity::{coverage, enums, lint, report, tier_contract};
@@ -285,9 +287,9 @@ fn cmd_corpus_audit(args: &Args) -> Result<ExitCode> {
         None => None,
     };
 
-    let corruption_components = match &args.corruption_manifest {
-        Some(p) => read_corruption_components(p)?,
-        None => BTreeSet::new(),
+    let corruption_fixtures = match &args.corruption_manifest {
+        Some(p) => read_corruption_fixtures(p)?,
+        None => Vec::new(),
     };
 
     let report = corpus_audit::audit(
@@ -296,7 +298,7 @@ fn cmd_corpus_audit(args: &Args) -> Result<ExitCode> {
         &inventory,
         &expected,
         provenance.as_ref(),
-        &corruption_components,
+        &corruption_fixtures,
     );
 
     if report.ok() {
@@ -422,23 +424,65 @@ fn read_sha256_file(path: &Path) -> Result<BTreeMap<String, String>> {
     Ok(map)
 }
 
-/// Parse the set of `expected_failing_component:` values from a committed
-/// `corruption-manifest.yml`, i.e. which SSTable component types the corruption
-/// corpus actually targets.
-fn read_corruption_components(path: &Path) -> Result<BTreeSet<String>> {
+/// Parse the corruption fixtures (targeted component + on-disk `corrupted_path` +
+/// `status`) from a committed `corruption-manifest.yml`. The audit cross-checks
+/// each declared `corrupted_path` against the walked corpus inventory, so a
+/// fixture declared but absent on disk is caught (spec R4: on-disk reality, not
+/// merely a manifest declaration; issue #1026). Each `  - name:` line opens a new
+/// fixture block; `corrupted_path`/`status`/`expected_failing_component` are
+/// captured within it. A block with no `expected_failing_component` is skipped.
+fn read_corruption_fixtures(path: &Path) -> Result<Vec<CorruptionFixture>> {
     let text = std::fs::read_to_string(path)
         .with_context(|| format!("reading corruption manifest {}", path.display()))?;
-    let mut set = BTreeSet::new();
+
+    let mut fixtures = Vec::new();
+    let mut component: Option<String> = None;
+    let mut corrupted_path: Option<String> = None;
+    let mut status: Option<String> = None;
+
+    // Emit the in-progress fixture (if it declared a component) and reset all
+    // three accumulators for the next block.
+    fn flush(
+        fixtures: &mut Vec<CorruptionFixture>,
+        component: &mut Option<String>,
+        corrupted_path: &mut Option<String>,
+        status: &mut Option<String>,
+    ) {
+        let comp = component.take();
+        let cpath = corrupted_path.take();
+        let st = status.take();
+        if let Some(component) = comp {
+            fixtures.push(CorruptionFixture {
+                component,
+                corrupted_path: cpath.unwrap_or_default(),
+                status: st.unwrap_or_default(),
+            });
+        }
+    }
+
     for line in text.lines() {
         let line = line.trim();
-        if let Some(rest) = line.strip_prefix("expected_failing_component:") {
+        if line.starts_with("- name:") {
+            flush(&mut fixtures, &mut component, &mut corrupted_path, &mut status);
+        } else if let Some(rest) = line.strip_prefix("expected_failing_component:") {
             let v = rest.trim().trim_matches('"');
             if !v.is_empty() {
-                set.insert(v.to_string());
+                component = Some(v.to_string());
+            }
+        } else if let Some(rest) = line.strip_prefix("corrupted_path:") {
+            let v = rest.trim().trim_matches('"');
+            if !v.is_empty() {
+                corrupted_path = Some(v.to_string());
+            }
+        } else if let Some(rest) = line.strip_prefix("status:") {
+            let v = rest.trim().trim_matches('"');
+            if !v.is_empty() {
+                status = Some(v.to_string());
             }
         }
     }
-    Ok(set)
+    flush(&mut fixtures, &mut component, &mut corrupted_path, &mut status);
+    Ok(fixtures)
 }
 
 fn cmd_coverage(args: &Args) -> Result<ExitCode> {
@@ -658,5 +702,45 @@ mod tests {
             msg.contains("GNU sha256sum-escaped") && msg.contains("backslash"),
             "expected a clear escaped-path error, got: {msg}"
         );
+    }
+
+    /// LOW 2: the corruption-manifest parser must capture per-fixture component,
+    /// on-disk `corrupted_path`, and `status` so the audit can cross-check each
+    /// declared fixture against the regenerated corpus (spec R4). A `planned`
+    /// fixture (declared, no clean source) is still parsed; its on-disk absence
+    /// is what the audit catches downstream.
+    #[test]
+    fn read_corruption_fixtures_captures_component_path_and_status() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = dir.path().join("corruption-manifest.yml");
+        let body = "\
+schema_version: 1
+fixtures:
+  - name: data_db_bit_flip
+    status: active
+    component: nb-1-big-Data.db
+    corrupted_path: \"corruption/test_comp_corrupt/data_db_bit_flip/nb-1-big-Data.db\"
+    expected_failing_component: Data.db
+  - name: bti_rows_truncation
+    status: planned
+    corrupted_path: \"corruption/test_comp_corrupt/bti_rows_truncation/__BTI_ROWS__\"
+    expected_failing_component: Rows.db
+";
+        fs::write(&file, body).expect("write manifest");
+
+        let fixtures = read_corruption_fixtures(&file).expect("parse");
+        assert_eq!(fixtures.len(), 2, "got: {fixtures:?}");
+
+        let data = &fixtures[0];
+        assert_eq!(data.component, "Data.db");
+        assert_eq!(
+            data.corrupted_path,
+            "corruption/test_comp_corrupt/data_db_bit_flip/nb-1-big-Data.db"
+        );
+        assert_eq!(data.status, "active");
+
+        let rows = &fixtures[1];
+        assert_eq!(rows.component, "Rows.db");
+        assert_eq!(rows.status, "planned");
     }
 }

--- a/tools/cassandra-parity/src/main.rs
+++ b/tools/cassandra-parity/src/main.rs
@@ -316,11 +316,25 @@ fn cmd_corpus_audit(args: &Args) -> Result<ExitCode> {
     }
 }
 
-/// Directory names skipped while walking a corpus: VCS metadata and build
-/// output. Recursing into `.git/`/`target/` would add tens of thousands of
-/// irrelevant paths (and a misleading `inventory.files.len()`) when the tool is
-/// pointed at a checkout root via `--corpus .` (issue #1026, Finding 2).
-const WALK_SKIP_DIRS: &[&str] = &[".git", "target", ".hg", ".svn", "node_modules"];
+/// Directory names skipped while walking a corpus: VCS metadata, build output,
+/// and the regeneration lane's own report dir. Recursing into `.git/`/`target/`
+/// would add tens of thousands of irrelevant paths (and a misleading
+/// `inventory.files.len()`) when the tool is pointed at a checkout root via
+/// `--corpus .`; `exhaustive-regeneration-report` is the lane's report dir, which
+/// lives inside the checkout and holds the audit's own inputs/outputs
+/// (`*.sha256`, `provenance.json`, `*.log`, `dataset-asset.tar.gz`) — walking it
+/// would re-enumerate them as corpus files. `--corpus .` (repo root) is required
+/// because manifest references are repo-root-relative (`test-data/datasets/...`),
+/// so we prune the report dir by name rather than scoping the walk (issue #1026,
+/// Findings 1 and 2).
+const WALK_SKIP_DIRS: &[&str] = &[
+    ".git",
+    "target",
+    ".hg",
+    ".svn",
+    "node_modules",
+    "exhaustive-regeneration-report",
+];
 
 /// Recursively collect every file under `dir` as a `/`-separated path relative
 /// to `dir` (matching the repo-relative form of manifest references when `dir`
@@ -520,17 +534,25 @@ mod tests {
     use super::*;
     use std::fs;
 
-    /// Finding 2: the corpus walk must prune `.git`/`target` so pointing
-    /// `--corpus .` at a checkout root does not enumerate VCS/build noise.
+    /// Findings 1 + 2: the corpus walk must prune `.git`/`target` and the
+    /// regeneration lane's own `exhaustive-regeneration-report` dir so pointing
+    /// `--corpus .` at a checkout root does not enumerate VCS/build noise or the
+    /// audit's own inputs/outputs.
     #[test]
     fn walk_relative_skips_vcs_and_build_dirs() {
         let dir = tempfile::tempdir().expect("tempdir");
         let root = dir.path();
         fs::create_dir_all(root.join(".git/objects")).expect("mkdir .git");
         fs::create_dir_all(root.join("target/debug")).expect("mkdir target");
+        fs::create_dir_all(root.join("exhaustive-regeneration-report")).expect("mkdir report");
         fs::create_dir_all(root.join("test-data/datasets/test_basic")).expect("mkdir corpus");
         fs::write(root.join(".git/objects/abc"), b"pack").expect("write git");
         fs::write(root.join("target/debug/bin"), b"elf").expect("write target");
+        fs::write(
+            root.join("exhaustive-regeneration-report/actual.sha256"),
+            b"deadbeef  x",
+        )
+        .expect("write report artifact");
         fs::write(
             root.join("test-data/datasets/test_basic/nb-1-big-Data.db"),
             b"data",
@@ -550,6 +572,12 @@ mod tests {
         assert!(
             !files.iter().any(|p| p.starts_with("target/")),
             "target must be pruned, got: {files:?}"
+        );
+        assert!(
+            !files
+                .iter()
+                .any(|p| p.starts_with("exhaustive-regeneration-report/")),
+            "the report dir must be pruned, got: {files:?}"
         );
     }
 

--- a/tools/cassandra-parity/src/main.rs
+++ b/tools/cassandra-parity/src/main.rs
@@ -9,12 +9,14 @@
 //!   cassandra-parity coverage [--manifest PATH] [--strict]
 //!   cassandra-parity report   [--manifest PATH] [--output PATH] [--check] [--json PATH]
 
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use anyhow::{bail, Context, Result};
 
 use cassandra_parity::claim_scan::{self, ScanInput};
+use cassandra_parity::corpus_audit::{self, CorpusInventory, ExpectedInventory, Provenance};
 use cassandra_parity::lint::Level;
 use cassandra_parity::model::Manifest;
 use cassandra_parity::{coverage, enums, lint, report, tier_contract};
@@ -32,6 +34,9 @@ USAGE:
   cassandra-parity coverage           [--manifest PATH] [--strict]
   cassandra-parity report             [--manifest PATH] [--output PATH] [--check] [--json PATH]
   cassandra-parity tier-contract-check [--manifest PATH] [--tier-doc PATH] [--schema PATH]
+  cassandra-parity corpus-audit       [--manifest PATH] --corpus DIR [--provenance JSON]
+                                      [--checksums FILE] [--expected-inventory FILE]
+                                      [--corruption-manifest YML] [--index MD]
 ";
 
 struct Args {
@@ -42,6 +47,13 @@ struct Args {
     schema: PathBuf,
     strict: bool,
     check: bool,
+    // corpus-audit (issue #1026)
+    corpus: Option<PathBuf>,
+    provenance: Option<PathBuf>,
+    checksums: Option<PathBuf>,
+    expected_inventory: Option<PathBuf>,
+    corruption_manifest: Option<PathBuf>,
+    index: Option<PathBuf>,
 }
 
 fn parse_args(rest: &[String]) -> Result<Args> {
@@ -53,6 +65,12 @@ fn parse_args(rest: &[String]) -> Result<Args> {
         schema: PathBuf::from(DEFAULT_SCHEMA),
         strict: false,
         check: false,
+        corpus: None,
+        provenance: None,
+        checksums: None,
+        expected_inventory: None,
+        corruption_manifest: None,
+        index: None,
     };
     let mut it = rest.iter();
     while let Some(flag) = it.next() {
@@ -64,6 +82,20 @@ fn parse_args(rest: &[String]) -> Result<Args> {
             "--schema" => args.schema = PathBuf::from(next_val(&mut it, "--schema")?),
             "--strict" => args.strict = true,
             "--check" => args.check = true,
+            "--corpus" => args.corpus = Some(PathBuf::from(next_val(&mut it, "--corpus")?)),
+            "--provenance" => {
+                args.provenance = Some(PathBuf::from(next_val(&mut it, "--provenance")?))
+            }
+            "--checksums" => args.checksums = Some(PathBuf::from(next_val(&mut it, "--checksums")?)),
+            "--expected-inventory" => {
+                args.expected_inventory =
+                    Some(PathBuf::from(next_val(&mut it, "--expected-inventory")?))
+            }
+            "--corruption-manifest" => {
+                args.corruption_manifest =
+                    Some(PathBuf::from(next_val(&mut it, "--corruption-manifest")?))
+            }
+            "--index" => args.index = Some(PathBuf::from(next_val(&mut it, "--index")?)),
             other => bail!("unknown argument: {other}\n\n{USAGE}"),
         }
     }
@@ -117,6 +149,7 @@ fn run() -> Result<ExitCode> {
         "coverage" => cmd_coverage(&args),
         "report" => cmd_report(&args),
         "tier-contract-check" => cmd_tier_contract_check(&args),
+        "corpus-audit" => cmd_corpus_audit(&args),
         "-h" | "--help" | "help" => {
             println!("{USAGE}");
             Ok(ExitCode::SUCCESS)
@@ -203,6 +236,150 @@ fn cmd_tier_contract_check(args: &Args) -> Result<ExitCode> {
         );
         Ok(ExitCode::FAILURE)
     }
+}
+
+/// Audit the regenerated corpus + run provenance against the manifest
+/// (issue #1026). Hard-fails (non-zero exit) and names the offender on any
+/// finding — no report-but-pass mode (owner-pinned strictness).
+fn cmd_corpus_audit(args: &Args) -> Result<ExitCode> {
+    let corpus = args
+        .corpus
+        .as_ref()
+        .context("corpus-audit requires --corpus <regenerated corpus root>")?;
+    let m = load(&args.manifest)?;
+    let root = repo_root(&args.manifest);
+
+    let index_path = args
+        .index
+        .clone()
+        .unwrap_or_else(|| root.join(&m.cassandra_source.index));
+    let index_text = std::fs::read_to_string(&index_path)
+        .with_context(|| format!("reading index {}", index_path.display()))?;
+
+    // Regenerated component inventory: every repo-relative file under --corpus.
+    let mut inventory = CorpusInventory {
+        files: walk_relative(corpus)?,
+        checksums: BTreeMap::new(),
+    };
+    if let Some(p) = &args.checksums {
+        inventory.checksums = read_sha256_file(p)?;
+    }
+
+    let mut expected = ExpectedInventory {
+        components: BTreeMap::new(),
+    };
+    if let Some(p) = &args.expected_inventory {
+        expected.components = read_sha256_file(p)?;
+    }
+
+    let provenance = match &args.provenance {
+        Some(p) => {
+            let text = std::fs::read_to_string(p)
+                .with_context(|| format!("reading provenance {}", p.display()))?;
+            Some(Provenance::from_json(&text).with_context(|| {
+                format!("parsing provenance record {} (expected JSON)", p.display())
+            })?)
+        }
+        None => None,
+    };
+
+    let corruption_components = match &args.corruption_manifest {
+        Some(p) => read_corruption_components(p)?,
+        None => BTreeSet::new(),
+    };
+
+    let report = corpus_audit::audit(
+        &m,
+        &index_text,
+        &inventory,
+        &expected,
+        provenance.as_ref(),
+        &corruption_components,
+    );
+
+    if report.ok() {
+        println!(
+            "corpus-audit: OK — {} corpus files, manifest references resolved, provenance matches \
+             the manifest pin, all required corruption components covered",
+            inventory.files.len()
+        );
+        Ok(ExitCode::SUCCESS)
+    } else {
+        eprintln!("{}", report.render());
+        eprintln!(
+            "corpus-audit: FAILED — {} finding(s)",
+            report.findings.len()
+        );
+        Ok(ExitCode::FAILURE)
+    }
+}
+
+/// Recursively collect every file under `dir` as a `/`-separated path relative
+/// to `dir` (matching the repo-relative form of manifest references when `dir`
+/// is the checkout root). Symlinks are not followed.
+fn walk_relative(dir: &Path) -> Result<BTreeSet<String>> {
+    let mut out = BTreeSet::new();
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(d) = stack.pop() {
+        let entries = std::fs::read_dir(&d)
+            .with_context(|| format!("reading corpus directory {}", d.display()))?;
+        for entry in entries {
+            let entry = entry?;
+            let ft = entry.file_type()?;
+            let path = entry.path();
+            if ft.is_dir() {
+                stack.push(path);
+            } else if ft.is_file() {
+                if let Ok(rel) = path.strip_prefix(dir) {
+                    out.insert(rel.to_string_lossy().replace('\\', "/"));
+                }
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Parse a `sha256sum`-format file (`<hex>  <path>` per line) into a
+/// `path -> sha256` map. Blank/comment lines are ignored.
+fn read_sha256_file(path: &Path) -> Result<BTreeMap<String, String>> {
+    let text = std::fs::read_to_string(path)
+        .with_context(|| format!("reading checksums file {}", path.display()))?;
+    let mut map = BTreeMap::new();
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let mut it = line.split_whitespace();
+        let (Some(sha), Some(first)) = (it.next(), it.next()) else {
+            continue;
+        };
+        // sha256sum prints a leading `*` for binary mode; strip it.
+        let rest: Vec<&str> = std::iter::once(first).chain(it).collect();
+        let rel = rest.join(" ");
+        let rel = rel.strip_prefix('*').unwrap_or(&rel).replace('\\', "/");
+        map.insert(rel, sha.to_string());
+    }
+    Ok(map)
+}
+
+/// Parse the set of `expected_failing_component:` values from a committed
+/// `corruption-manifest.yml`, i.e. which SSTable component types the corruption
+/// corpus actually targets.
+fn read_corruption_components(path: &Path) -> Result<BTreeSet<String>> {
+    let text = std::fs::read_to_string(path)
+        .with_context(|| format!("reading corruption manifest {}", path.display()))?;
+    let mut set = BTreeSet::new();
+    for line in text.lines() {
+        let line = line.trim();
+        if let Some(rest) = line.strip_prefix("expected_failing_component:") {
+            let v = rest.trim().trim_matches('"');
+            if !v.is_empty() {
+                set.insert(v.to_string());
+            }
+        }
+    }
+    Ok(set)
 }
 
 fn cmd_coverage(args: &Args) -> Result<ExitCode> {

--- a/tools/cassandra-parity/src/main.rs
+++ b/tools/cassandra-parity/src/main.rs
@@ -316,9 +316,16 @@ fn cmd_corpus_audit(args: &Args) -> Result<ExitCode> {
     }
 }
 
+/// Directory names skipped while walking a corpus: VCS metadata and build
+/// output. Recursing into `.git/`/`target/` would add tens of thousands of
+/// irrelevant paths (and a misleading `inventory.files.len()`) when the tool is
+/// pointed at a checkout root via `--corpus .` (issue #1026, Finding 2).
+const WALK_SKIP_DIRS: &[&str] = &[".git", "target", ".hg", ".svn", "node_modules"];
+
 /// Recursively collect every file under `dir` as a `/`-separated path relative
 /// to `dir` (matching the repo-relative form of manifest references when `dir`
-/// is the checkout root). Symlinks are not followed.
+/// is the checkout root). Symlinks are not followed; [`WALK_SKIP_DIRS`] are
+/// pruned so the walk is robust regardless of the caller's `--corpus` argument.
 fn walk_relative(dir: &Path) -> Result<BTreeSet<String>> {
     let mut out = BTreeSet::new();
     let mut stack = vec![dir.to_path_buf()];
@@ -330,6 +337,10 @@ fn walk_relative(dir: &Path) -> Result<BTreeSet<String>> {
             let ft = entry.file_type()?;
             let path = entry.path();
             if ft.is_dir() {
+                let name = entry.file_name();
+                if WALK_SKIP_DIRS.iter().any(|s| name == *s) {
+                    continue;
+                }
                 stack.push(path);
             } else if ft.is_file() {
                 if let Ok(rel) = path.strip_prefix(dir) {
@@ -341,25 +352,40 @@ fn walk_relative(dir: &Path) -> Result<BTreeSet<String>> {
     Ok(out)
 }
 
-/// Parse a `sha256sum`-format file (`<hex>  <path>` per line) into a
-/// `path -> sha256` map. Blank/comment lines are ignored.
+/// Parse a `sha256sum`-format file into a `path -> sha256` map. Each line is
+/// `<hash><sp><mode><path>`, where `<mode>` is a space (text mode) or `*`
+/// (binary mode). Parsing is POSITIONAL — the path is taken verbatim after the
+/// single separator so runs of spaces/tabs inside a path are preserved (issue
+/// #1026, Finding 3); splitting on whitespace would collapse them and mismatch
+/// the keys produced by [`walk_relative`]. Blank/comment lines are ignored.
 fn read_sha256_file(path: &Path) -> Result<BTreeMap<String, String>> {
     let text = std::fs::read_to_string(path)
         .with_context(|| format!("reading checksums file {}", path.display()))?;
     let mut map = BTreeMap::new();
-    for line in text.lines() {
-        let line = line.trim();
-        if line.is_empty() || line.starts_with('#') {
+    for raw in text.lines() {
+        // Trim only the trailing line terminator / whitespace; never touch the
+        // interior of the path.
+        let line = raw.trim_end();
+        if line.is_empty() || line.trim_start().starts_with('#') {
             continue;
         }
-        let mut it = line.split_whitespace();
-        let (Some(sha), Some(first)) = (it.next(), it.next()) else {
+        // The hash is the leading token up to the first space separator.
+        let Some(sep) = line.find(' ') else {
             continue;
         };
-        // sha256sum prints a leading `*` for binary mode; strip it.
-        let rest: Vec<&str> = std::iter::once(first).chain(it).collect();
-        let rel = rest.join(" ");
-        let rel = rel.strip_prefix('*').unwrap_or(&rel).replace('\\', "/");
+        let (sha, rest) = line.split_at(sep);
+        // `rest` begins with the separating space; after it is the mode
+        // indicator (`*` binary, or a second space for text mode). Drop exactly
+        // the separator + one mode char, then take the remainder verbatim.
+        let rest = &rest[1..];
+        let path_part = rest
+            .strip_prefix('*')
+            .or_else(|| rest.strip_prefix(' '))
+            .unwrap_or(rest);
+        let rel = path_part.replace('\\', "/");
+        if sha.is_empty() || rel.is_empty() {
+            continue;
+        }
         map.insert(rel, sha.to_string());
     }
     Ok(map)
@@ -487,4 +513,84 @@ fn evidence_counts(m: &Manifest) -> serde_json::Value {
         map.insert((*ev).to_string(), serde_json::json!(n));
     }
     serde_json::Value::Object(map)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    /// Finding 2: the corpus walk must prune `.git`/`target` so pointing
+    /// `--corpus .` at a checkout root does not enumerate VCS/build noise.
+    #[test]
+    fn walk_relative_skips_vcs_and_build_dirs() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        fs::create_dir_all(root.join(".git/objects")).expect("mkdir .git");
+        fs::create_dir_all(root.join("target/debug")).expect("mkdir target");
+        fs::create_dir_all(root.join("test-data/datasets/test_basic")).expect("mkdir corpus");
+        fs::write(root.join(".git/objects/abc"), b"pack").expect("write git");
+        fs::write(root.join("target/debug/bin"), b"elf").expect("write target");
+        fs::write(
+            root.join("test-data/datasets/test_basic/nb-1-big-Data.db"),
+            b"data",
+        )
+        .expect("write corpus");
+
+        let files = walk_relative(root).expect("walk");
+
+        assert!(
+            files.contains("test-data/datasets/test_basic/nb-1-big-Data.db"),
+            "corpus file must be enumerated, got: {files:?}"
+        );
+        assert!(
+            !files.iter().any(|p| p.starts_with(".git/")),
+            ".git must be pruned, got: {files:?}"
+        );
+        assert!(
+            !files.iter().any(|p| p.starts_with("target/")),
+            "target must be pruned, got: {files:?}"
+        );
+    }
+
+    /// Finding 3: positional parsing preserves a path containing a double space
+    /// and a tab; whitespace-splitting would collapse them and mismatch
+    /// `walk_relative` keys.
+    #[test]
+    fn read_sha256_file_preserves_internal_whitespace() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = dir.path().join("sums.sha256");
+        let dbl = "a".repeat(64);
+        let tab = "b".repeat(64);
+        let bin = "c".repeat(64);
+        // text mode (two spaces sep) with a double space inside the path;
+        // text mode with a TAB inside the path; binary mode (` *`) line.
+        let body = format!(
+            "{dbl}  dir/with  double space.jsonl\n\
+             {tab}  dir/with\ttab.jsonl\n\
+             {bin} *dir/binary mode.jsonl\n\
+             # a comment line\n\
+             \n"
+        );
+        fs::write(&file, body).expect("write sums");
+
+        let map = read_sha256_file(&file).expect("parse");
+
+        assert_eq!(
+            map.get("dir/with  double space.jsonl").map(String::as_str),
+            Some(dbl.as_str()),
+            "double space in path must be preserved, got: {map:?}"
+        );
+        assert_eq!(
+            map.get("dir/with\ttab.jsonl").map(String::as_str),
+            Some(tab.as_str()),
+            "tab in path must be preserved, got: {map:?}"
+        );
+        assert_eq!(
+            map.get("dir/binary mode.jsonl").map(String::as_str),
+            Some(bin.as_str()),
+            "binary-mode `*` prefix must be stripped, got: {map:?}"
+        );
+        assert_eq!(map.len(), 3, "comment/blank lines ignored, got: {map:?}");
+    }
 }

--- a/tools/cassandra-parity/src/main.rs
+++ b/tools/cassandra-parity/src/main.rs
@@ -302,9 +302,16 @@ fn cmd_corpus_audit(args: &Args) -> Result<ExitCode> {
     );
 
     if report.ok() {
+        // Count only genuine corpus components, not every walked path: under the
+        // lane's `--corpus .` the inventory holds every non-pruned file in the
+        // checkout, so `inventory.files.len()` overstates the corpus by thousands.
+        let corpus_files = count_corpus_files(&inventory);
         println!(
-            "corpus-audit: OK — {} corpus files, manifest references resolved, provenance matches \
-             the manifest pin, all required corruption components covered",
+            "corpus-audit: OK — {} corpus files under {} ({} paths walked), manifest references \
+             resolved, provenance matches the manifest pin, all required corruption components \
+             covered",
+            corpus_files,
+            corpus_audit::refs::CORPUS_PREFIX,
             inventory.files.len()
         );
         Ok(ExitCode::SUCCESS)
@@ -587,6 +594,18 @@ fn status_counts(m: &Manifest) -> serde_json::Value {
     serde_json::Value::Object(map)
 }
 
+/// Count only genuine corpus components in a walked inventory. Under the lane's
+/// `--corpus .`, `inventory.files` holds every non-pruned file in the checkout, so
+/// the raw length overstates the corpus by thousands; only paths under
+/// [`corpus_audit::refs::CORPUS_PREFIX`] are real corpus components.
+fn count_corpus_files(inventory: &CorpusInventory) -> usize {
+    inventory
+        .files
+        .iter()
+        .filter(|p| p.starts_with(corpus_audit::refs::CORPUS_PREFIX))
+        .count()
+}
+
 fn evidence_counts(m: &Manifest) -> serde_json::Value {
     let mut map = serde_json::Map::new();
     for ev in enums::EVIDENCE_TYPE {
@@ -650,6 +669,23 @@ mod tests {
                 .any(|p| p.starts_with("exhaustive-regeneration-report/")),
             "the report dir must be pruned, got: {files:?}"
         );
+    }
+
+    /// The success-line corpus count reports only `test-data/datasets/` components,
+    /// not every walked path (`--corpus .` enumerates the whole checkout).
+    #[test]
+    fn count_corpus_files_counts_only_corpus_prefix() {
+        let mut files = std::collections::BTreeSet::new();
+        files.insert("test-data/datasets/test_basic/nb-1-big-Data.db".to_string());
+        files.insert("test-data/datasets/test_basic/nb-1-big-Index.db".to_string());
+        files.insert("README.md".to_string());
+        files.insert("cqlite-core/src/lib.rs".to_string());
+        files.insert("exhaustive-regeneration-report/actual.sha256".to_string());
+        let inventory = CorpusInventory {
+            files,
+            checksums: std::collections::BTreeMap::new(),
+        };
+        assert_eq!(count_corpus_files(&inventory), 2);
     }
 
     /// Finding 3: positional parsing preserves a path containing a double space

--- a/tools/cassandra-parity/src/main.rs
+++ b/tools/cassandra-parity/src/main.rs
@@ -463,7 +463,12 @@ fn read_corruption_fixtures(path: &Path) -> Result<Vec<CorruptionFixture>> {
     for line in text.lines() {
         let line = line.trim();
         if line.starts_with("- name:") {
-            flush(&mut fixtures, &mut component, &mut corrupted_path, &mut status);
+            flush(
+                &mut fixtures,
+                &mut component,
+                &mut corrupted_path,
+                &mut status,
+            );
         } else if let Some(rest) = line.strip_prefix("expected_failing_component:") {
             let v = rest.trim().trim_matches('"');
             if !v.is_empty() {
@@ -481,7 +486,12 @@ fn read_corruption_fixtures(path: &Path) -> Result<Vec<CorruptionFixture>> {
             }
         }
     }
-    flush(&mut fixtures, &mut component, &mut corrupted_path, &mut status);
+    flush(
+        &mut fixtures,
+        &mut component,
+        &mut corrupted_path,
+        &mut status,
+    );
     Ok(fixtures)
 }
 

--- a/tools/cassandra-parity/tests/corpus_audit_cli_tests.rs
+++ b/tools/cassandra-parity/tests/corpus_audit_cli_tests.rs
@@ -171,6 +171,78 @@ fn corpus_audit_missing_reference_exits_nonzero_and_names_finding() {
 }
 
 #[test]
+fn corpus_audit_component_checksum_drift_exits_nonzero_and_names_finding() {
+    // Finding 5 (CLI E2E for the component-change path): drive `--checksums` +
+    // `--expected-inventory` through the binary with a deliberate checksum drift
+    // for a stable table+component identity. This is the only test that exercises
+    // the disk -> `read_sha256_file` -> `check_component_changes` glue end-to-end
+    // — the `UnexpectedComponentChange` path rewritten for the prior HIGH fix —
+    // which the other CLI tests never reach (they leave both inventories empty).
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    write_common(root);
+    write_reference_file(root);
+    write_provenance(root);
+
+    // A stable, UUID-independent component identity (table_key/basename) that the
+    // committed-expected golden and the regenerated-actual checksums agree on,
+    // but with drifted SHA256s -> exactly one UNEXPECTED-COMPONENT-CHANGE finding.
+    let component =
+        format!("test-data/datasets/sstables/test_basic/simple_table-{UUID}/nb-1-big-Data.db");
+    let expected_sha = "1".repeat(64);
+    let actual_sha = "2".repeat(64);
+    fs::write(
+        root.join("expected.sha256"),
+        format!("{expected_sha}  {component}\n"),
+    )
+    .expect("write expected inventory");
+    fs::write(
+        root.join("actual.sha256"),
+        format!("{actual_sha}  {component}\n"),
+    )
+    .expect("write actual checksums");
+
+    let out = Command::new(env!("CARGO_BIN_EXE_cassandra-parity"))
+        .args([
+            "corpus-audit",
+            "--manifest",
+            root.join("manifest.yml").to_str().expect("utf8"),
+            "--index",
+            root.join("index.md").to_str().expect("utf8"),
+            "--corpus",
+            root.to_str().expect("utf8"),
+            "--provenance",
+            root.join("provenance.json").to_str().expect("utf8"),
+            "--corruption-manifest",
+            root.join("corruption-manifest.yml").to_str().expect("utf8"),
+            "--checksums",
+            root.join("actual.sha256").to_str().expect("utf8"),
+            "--expected-inventory",
+            root.join("expected.sha256").to_str().expect("utf8"),
+        ])
+        .output()
+        .expect("run cassandra-parity corpus-audit");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !out.status.success(),
+        "expected non-zero exit for a component checksum drift, got: {combined}"
+    );
+    assert!(
+        combined.contains("UNEXPECTED-COMPONENT-CHANGE"),
+        "expected a named UNEXPECTED-COMPONENT-CHANGE finding, got: {combined}"
+    );
+    assert!(
+        combined.contains(&actual_sha) && combined.contains(&expected_sha),
+        "finding must name the drifted expected/regenerated checksums, got: {combined}"
+    );
+}
+
+#[test]
 fn corpus_audit_provenance_mismatch_exits_nonzero_and_names_finding() {
     let dir = tempfile::tempdir().expect("tempdir");
     let root = dir.path();

--- a/tools/cassandra-parity/tests/corpus_audit_cli_tests.rs
+++ b/tools/cassandra-parity/tests/corpus_audit_cli_tests.rs
@@ -1,6 +1,6 @@
 //! End-to-end tests for the `cassandra-parity corpus-audit` subcommand (issue
 //! #1026, Finding 5). These exercise the disk->`audit()` glue in `main.rs`
-//! (`walk_relative`, `read_sha256_file`, `read_corruption_components`,
+//! (`walk_relative`, `read_sha256_file`, `read_corruption_fixtures`,
 //! `cmd_corpus_audit`, and the exit-code mapping) that the pure `audit()` unit
 //! tests cannot reach: they build a temp-dir corpus + manifest + index +
 //! provenance + corruption manifest on disk, invoke the built binary, and assert
@@ -12,6 +12,18 @@ use std::process::Command;
 
 const GOOD_SHA: &str = "f278f6774fc76465c182041e081982105c3e7dbb";
 const UUID: &str = "aaaa0000000000000000000000000001";
+
+/// The seven required corruption component types (mirrors
+/// `corpus_audit::REQUIRED_CORRUPTION_COMPONENTS`).
+const REQUIRED_CORRUPTION: &[&str] = &[
+    "Data.db",
+    "Index.db",
+    "Summary.db",
+    "Statistics.db",
+    "CompressionInfo.db",
+    "TOC.txt",
+    "Digest.crc32",
+];
 
 /// A repo-relative corpus reference the fixture scenario pins.
 fn reference_path() -> String {
@@ -63,20 +75,39 @@ scenarios:
          ## Other section\n";
     fs::write(root.join("index.md"), index).expect("write index");
 
-    // Corruption manifest covering every required component type.
-    let mut corr = String::new();
-    for comp in [
-        "Data.db",
-        "Index.db",
-        "Summary.db",
-        "Statistics.db",
-        "CompressionInfo.db",
-        "TOC.txt",
-        "Digest.crc32",
-    ] {
+    // Corruption manifest covering every required component type, with each
+    // declared fixture's corrupted file present on disk so coverage is clean.
+    write_corruption(root, REQUIRED_CORRUPTION);
+}
+
+/// Datasets-relative on-disk path of a component's corruption fixture, mirroring
+/// the real `corruption-manifest.yml` layout.
+fn corruption_rel(comp: &str) -> String {
+    format!("corruption/test_comp_corrupt/{comp}_fixture/nb-1-big-{comp}")
+}
+
+/// Write a corruption manifest DECLARING every required component (with on-disk
+/// `corrupted_path` + `status`), and create the corrupted file under the corpus
+/// only for components listed in `on_disk`. A component declared but omitted from
+/// `on_disk` drives the on-disk coverage gap (spec R4): a declared-but-absent
+/// fixture must fail the audit, not merely a manifest declaration.
+fn write_corruption(root: &Path, on_disk: &[&str]) {
+    // Start from a clean corruption tree so a re-declaration with a narrower
+    // `on_disk` set genuinely removes a previously-written fixture file.
+    let corruption_root = root.join("test-data/datasets/corruption");
+    let _ = fs::remove_dir_all(&corruption_root);
+    let mut corr = String::from("schema_version: 1\nfixtures:\n");
+    for comp in REQUIRED_CORRUPTION {
+        let rel = corruption_rel(comp);
         corr.push_str(&format!(
-            "- fixture: x\n  expected_failing_component: {comp}\n"
+            "  - name: {comp}_fixture\n    status: active\n    corrupted_path: \"{rel}\"\n    \
+             expected_failing_component: {comp}\n"
         ));
+        if on_disk.contains(comp) {
+            let path = root.join("test-data/datasets").join(&rel);
+            fs::create_dir_all(path.parent().expect("parent")).expect("mkdir corruption fixture");
+            fs::write(&path, b"corrupt\n").expect("write corruption fixture");
+        }
     }
     fs::write(root.join("corruption-manifest.yml"), corr).expect("write corruption manifest");
 }
@@ -310,5 +341,44 @@ fn corpus_audit_provenance_mismatch_exits_nonzero_and_names_finding() {
     assert!(
         combined.contains("PROVENANCE-MISMATCH"),
         "expected a named PROVENANCE-MISMATCH finding, got: {combined}"
+    );
+}
+
+/// Issue #1026 (roborev LOW 2), CLI E2E for the on-disk corruption check: spec R4
+/// requires an on-disk corruption FIXTURE per required component, not just a
+/// manifest declaration. Here every component is DECLARED but `Summary.db`'s
+/// corrupted file is not written under the corpus, so the disk-backed audit must
+/// exit non-zero naming `Summary.db` — proving the check validates on-disk
+/// reality, not the manifest alone (a generator that silently produced fewer
+/// files than declared cannot slip through).
+#[test]
+fn corpus_audit_corruption_fixture_absent_on_disk_exits_nonzero_and_names_component() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    write_common(root);
+    write_reference_file(root);
+    write_provenance(root);
+
+    // Re-declare all seven but withhold Summary.db's on-disk fixture file.
+    let on_disk: Vec<&str> = REQUIRED_CORRUPTION
+        .iter()
+        .copied()
+        .filter(|c| *c != "Summary.db")
+        .collect();
+    write_corruption(root, &on_disk);
+
+    let out = run_audit(root);
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !out.status.success(),
+        "expected non-zero exit when a declared corruption fixture is absent on disk, got: {combined}"
+    );
+    assert!(
+        combined.contains("CORRUPTION-COVERAGE-GAP") && combined.contains("Summary.db"),
+        "expected a named CORRUPTION-COVERAGE-GAP for Summary.db, got: {combined}"
     );
 }

--- a/tools/cassandra-parity/tests/corpus_audit_cli_tests.rs
+++ b/tools/cassandra-parity/tests/corpus_audit_cli_tests.rs
@@ -1,0 +1,205 @@
+//! End-to-end tests for the `cassandra-parity corpus-audit` subcommand (issue
+//! #1026, Finding 5). These exercise the disk->`audit()` glue in `main.rs`
+//! (`walk_relative`, `read_sha256_file`, `read_corruption_components`,
+//! `cmd_corpus_audit`, and the exit-code mapping) that the pure `audit()` unit
+//! tests cannot reach: they build a temp-dir corpus + manifest + index +
+//! provenance + corruption manifest on disk, invoke the built binary, and assert
+//! the process exit code and the named finding in its output.
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+const GOOD_SHA: &str = "f278f6774fc76465c182041e081982105c3e7dbb";
+const UUID: &str = "aaaa0000000000000000000000000001";
+
+/// A repo-relative corpus reference the fixture scenario pins.
+fn reference_path() -> String {
+    format!("test-data/datasets/sstables/test_basic/simple_table-{UUID}/nb-1-big-Data.db.jsonl")
+}
+
+/// Write the manifest, index, and corruption manifest the audit needs. Returns
+/// nothing; callers create/omit the referenced corpus file to drive pass/fail.
+fn write_common(root: &Path) {
+    let reference = reference_path();
+    let manifest = format!(
+        r#"manifest_version: 1
+cassandra_source:
+  repo: https://github.com/apache/cassandra
+  ref: cassandra-5.0.2
+  sha: {GOOD_SHA}
+  index: docs/cassandra_test_index.md
+  assessment_report: docs/reports/x.md
+program:
+  parent_epic: 966
+  reporting_epic: 967
+scenarios:
+  - id: cass.sstable_format.simple
+    title: t
+    status: mirrored
+    capability: sstable_format
+    priority: P0
+    risk: p0_data_loss
+    cassandra:
+      category: sstable_format
+      relevance: high
+      files:
+        - SortedTableWriterTest.java
+    cqlite: {{}}
+    evidence:
+      type: byte_for_byte
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: {GOOD_SHA}
+      reference_paths:
+        - {reference}
+    ci:
+      tier: exhaustive_regeneration
+"#
+    );
+    fs::write(root.join("manifest.yml"), manifest).expect("write manifest");
+
+    let index = "# Cassandra test index\n\n## High-relevance tests (quick list)\n\n\
+         | Test | Notes |\n|------|-------|\n| `SortedTableWriterTest.java` | classified |\n\n\
+         ## Other section\n";
+    fs::write(root.join("index.md"), index).expect("write index");
+
+    // Corruption manifest covering every required component type.
+    let mut corr = String::new();
+    for comp in [
+        "Data.db",
+        "Index.db",
+        "Summary.db",
+        "Statistics.db",
+        "CompressionInfo.db",
+        "TOC.txt",
+        "Digest.crc32",
+    ] {
+        corr.push_str(&format!(
+            "- fixture: x\n  expected_failing_component: {comp}\n"
+        ));
+    }
+    fs::write(root.join("corruption-manifest.yml"), corr).expect("write corruption manifest");
+}
+
+/// Create the referenced corpus file under the temp corpus root.
+fn write_reference_file(root: &Path) {
+    let path = root.join(reference_path());
+    fs::create_dir_all(path.parent().expect("parent")).expect("mkdir corpus");
+    fs::write(&path, b"{}\n").expect("write golden");
+}
+
+/// Provenance JSON that matches the fixture manifest pin.
+fn write_provenance(root: &Path) {
+    let prov = format!(
+        r#"{{
+  "cassandra_version": "5.0.2",
+  "cassandra_ref": "cassandra-5.0.2",
+  "cassandra_git_sha": "{GOOD_SHA}",
+  "docker_image": "cassandra:5.0.2",
+  "generator_commands": ["bash test-data/scripts/regenerate-datasets.sh"],
+  "dataset_asset_name": "cassandra5-small-full.tar.gz",
+  "dataset_asset_sha256": "deadbeef"
+}}"#
+    );
+    fs::write(root.join("provenance.json"), prov).expect("write provenance");
+}
+
+fn run_audit(root: &Path) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_cassandra-parity"))
+        .args([
+            "corpus-audit",
+            "--manifest",
+            root.join("manifest.yml").to_str().expect("utf8"),
+            "--index",
+            root.join("index.md").to_str().expect("utf8"),
+            "--corpus",
+            root.to_str().expect("utf8"),
+            "--provenance",
+            root.join("provenance.json").to_str().expect("utf8"),
+            "--corruption-manifest",
+            root.join("corruption-manifest.yml").to_str().expect("utf8"),
+        ])
+        .output()
+        .expect("run cassandra-parity corpus-audit")
+}
+
+#[test]
+fn corpus_audit_clean_exits_zero() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    write_common(root);
+    write_reference_file(root);
+    write_provenance(root);
+
+    let out = run_audit(root);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "expected exit 0 for a clean corpus.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("corpus-audit: OK"),
+        "expected OK summary, got stdout: {stdout}"
+    );
+}
+
+#[test]
+fn corpus_audit_missing_reference_exits_nonzero_and_names_finding() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    write_common(root);
+    // Deliberately do NOT create the referenced corpus file -> missing reference.
+    write_provenance(root);
+
+    let out = run_audit(root);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let combined = format!("{stdout}{stderr}");
+    assert!(
+        !out.status.success(),
+        "expected non-zero exit for a missing reference.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        combined.contains("MISSING-REFERENCE"),
+        "expected a named MISSING-REFERENCE finding, got: {combined}"
+    );
+    assert!(
+        combined.contains(&reference_path()),
+        "finding must name the offending reference, got: {combined}"
+    );
+}
+
+#[test]
+fn corpus_audit_provenance_mismatch_exits_nonzero_and_names_finding() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    write_common(root);
+    write_reference_file(root);
+    // Provenance from an undeclared Cassandra version/sha.
+    let bad = r#"{
+  "cassandra_version": "6.6.6",
+  "cassandra_ref": "cassandra-6.6.6",
+  "cassandra_git_sha": "0000000000000000000000000000000000000000",
+  "docker_image": "cassandra:6.6.6",
+  "generator_commands": [],
+  "dataset_asset_name": "x.tar.gz",
+  "dataset_asset_sha256": "dead"
+}"#;
+    fs::write(root.join("provenance.json"), bad).expect("write provenance");
+
+    let out = run_audit(root);
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !out.status.success(),
+        "expected non-zero exit for provenance mismatch, got: {combined}"
+    );
+    assert!(
+        combined.contains("PROVENANCE-MISMATCH"),
+        "expected a named PROVENANCE-MISMATCH finding, got: {combined}"
+    );
+}

--- a/tools/cassandra-parity/tests/corpus_audit_cli_tests.rs
+++ b/tools/cassandra-parity/tests/corpus_audit_cli_tests.rs
@@ -144,6 +144,43 @@ fn corpus_audit_clean_exits_zero() {
     );
 }
 
+/// Issue #1026 (HIGH/LOW A, roborev): the lane audits a FRESHLY regenerated
+/// corpus — every run `rm -rf`s the tree and re-creates each table, so Cassandra
+/// mints a NEW random table UUID and the regenerated golden lands under a
+/// DIFFERENT `<table>-<uuid>` directory than the committed manifest reference
+/// pins. The prior exact-path-match clean test never exercised this and passed
+/// green while the real regenerated input hard-failed STALE-REFERENCE. This
+/// drives the CLI with the golden under a churned UUID dir and asserts exit 0.
+#[test]
+fn corpus_audit_clean_under_uuid_churn_exits_zero() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    write_common(root);
+    write_provenance(root);
+
+    // Same table_key + basename, but under a fresh (churned) UUID directory the
+    // manifest does not pin.
+    let churned = reference_path().replace(
+        "simple_table-aaaa0000000000000000000000000001",
+        "simple_table-bbbb0000000000000000000000000002",
+    );
+    let path = root.join(&churned);
+    fs::create_dir_all(path.parent().expect("parent")).expect("mkdir churned corpus");
+    fs::write(&path, b"{}\n").expect("write churned golden");
+
+    let out = run_audit(root);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "UUID churn (golden under a new uuid dir) must exit 0.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("corpus-audit: OK"),
+        "expected OK summary under churn, got stdout: {stdout}"
+    );
+}
+
 #[test]
 fn corpus_audit_missing_reference_exits_nonzero_and_names_finding() {
     let dir = tempfile::tempdir().expect("tempdir");

--- a/tools/cassandra-parity/tests/corpus_audit_tests.rs
+++ b/tools/cassandra-parity/tests/corpus_audit_tests.rs
@@ -172,6 +172,91 @@ fn unclassified_high_relevance_fails_and_names_offender() {
     );
 }
 
+/// Regression for issue #1026 (Finding 1): every regeneration mints a fresh
+/// `<table>-<uuid>` directory, so the committed golden (expected, under uuidA)
+/// and the regenerated golden (actual, under uuidB) NEVER share a repo-relative
+/// path. The component-change check MUST normalize both sides by their
+/// UUID-independent table+component identity, so identical bytes under a churned
+/// UUID directory raise NO finding (otherwise the lane is perpetually red).
+#[test]
+fn uuid_churn_alone_does_not_fire_unexpected_component_change() {
+    let regenerated = REF.replace(
+        "simple_table-aaaa0000000000000000000000000001",
+        "simple_table-bbbb0000000000000000000000000002",
+    );
+    let mut expected = BTreeMap::new();
+    expected.insert(REF.to_string(), "same_sha".to_string());
+
+    let mut inv = CorpusInventory::default();
+    inv.files.insert(regenerated.clone());
+    inv.checksums.insert(regenerated, "same_sha".to_string());
+
+    let findings = corpus_audit::check_component_changes(
+        &inv,
+        &ExpectedInventory {
+            components: expected,
+        },
+    );
+    assert!(
+        findings.is_empty(),
+        "UUID churn alone must NOT fire UnexpectedComponentChange, got: {findings:?}"
+    );
+}
+
+/// A genuine checksum drift of a STABLE identity (same table+component) is still
+/// caught even though the regeneration churned the UUID directory.
+#[test]
+fn unexpected_component_change_fires_on_checksum_drift_across_uuid_churn() {
+    let regenerated = REF.replace(
+        "simple_table-aaaa0000000000000000000000000001",
+        "simple_table-bbbb0000000000000000000000000002",
+    );
+    let mut expected = BTreeMap::new();
+    expected.insert(REF.to_string(), "old_sha".to_string());
+
+    let mut inv = CorpusInventory::default();
+    inv.files.insert(regenerated.clone());
+    inv.checksums.insert(regenerated, "new_sha".to_string());
+
+    let findings = corpus_audit::check_component_changes(
+        &inv,
+        &ExpectedInventory {
+            components: expected,
+        },
+    );
+    assert_eq!(
+        findings.len(),
+        1,
+        "drift under a stable identity must fire exactly one finding, got: {findings:?}"
+    );
+    assert_eq!(findings[0].kind, FindingKind::UnexpectedComponentChange);
+}
+
+/// A genuinely removed component (expected identity has no regenerated match at
+/// all) is caught.
+#[test]
+fn unexpected_component_change_fires_on_removed_component() {
+    let mut expected = BTreeMap::new();
+    expected.insert(REF.to_string(), "some_sha".to_string());
+
+    // Regenerated corpus has a DIFFERENT component (different basename) under the
+    // same table — the expected component itself is gone.
+    let other = REF.replace("Data.db.jsonl", "Index.db.jsonl");
+    let mut inv = CorpusInventory::default();
+    inv.checksums.insert(other, "x".to_string());
+
+    let findings = corpus_audit::check_component_changes(
+        &inv,
+        &ExpectedInventory {
+            components: expected,
+        },
+    );
+    assert!(findings
+        .iter()
+        .any(|f| f.kind == FindingKind::UnexpectedComponentChange
+            && f.detail.contains("absent")));
+}
+
 #[test]
 fn unexpected_component_change_fails_on_checksum_drift() {
     let comp = REF.to_string();

--- a/tools/cassandra-parity/tests/corpus_audit_tests.rs
+++ b/tools/cassandra-parity/tests/corpus_audit_tests.rs
@@ -253,8 +253,7 @@ fn unexpected_component_change_fires_on_removed_component() {
     );
     assert!(findings
         .iter()
-        .any(|f| f.kind == FindingKind::UnexpectedComponentChange
-            && f.detail.contains("absent")));
+        .any(|f| f.kind == FindingKind::UnexpectedComponentChange && f.detail.contains("absent")));
 }
 
 #[test]

--- a/tools/cassandra-parity/tests/corpus_audit_tests.rs
+++ b/tools/cassandra-parity/tests/corpus_audit_tests.rs
@@ -126,9 +126,18 @@ fn missing_reference_fails_and_names_offender() {
     assert!(report.render().contains(REF), "got: {}", report.render());
 }
 
+/// Regression for issue #1026 (HIGH, roborev): the regeneration lane `rm -rf`s
+/// the corpus and re-mints every table under a FRESH `<table>-<uuid>` directory,
+/// so the committed manifest reference (pinned to the OLD uuid) and the
+/// regenerated golden NEVER share a repo-relative path. A reference whose
+/// UUID-independent `(table_key, basename)` identity IS produced under the new
+/// uuid dir is NOT stale/missing — the corpus still produces that exact
+/// table+component — so the audit MUST be clean (zero reference findings).
+/// Before the fix this fired a hard-fail STALE-REFERENCE on every run, leaving
+/// the owner-pinned lane perpetually red.
 #[test]
-fn stale_reference_fails_and_names_offender() {
-    // Same table + component, but under a NEW generation UUID dir -> stale.
+fn churned_reference_under_new_uuid_is_clean() {
+    // Same table + component, but under a NEW generation UUID dir -> churn, not stale.
     let regenerated = REF.replace(
         "simple_table-aaaa0000000000000000000000000001",
         "simple_table-bbbb0000000000000000000000000002",
@@ -147,10 +156,13 @@ fn stale_reference_fails_and_names_offender() {
         Some(&good_provenance()),
         &all_corruption_components(),
     );
-    assert!(!report.ok());
-    assert_eq!(report.count(FindingKind::StaleReference), 1);
+    assert!(
+        report.ok(),
+        "UUID churn (same table+component, new uuid dir) must be clean, got: {}",
+        report.render()
+    );
+    assert_eq!(report.count(FindingKind::StaleReference), 0);
     assert_eq!(report.count(FindingKind::MissingReference), 0);
-    assert!(report.render().contains(REF));
 }
 
 #[test]

--- a/tools/cassandra-parity/tests/corpus_audit_tests.rs
+++ b/tools/cassandra-parity/tests/corpus_audit_tests.rs
@@ -376,6 +376,36 @@ fn provenance_mismatch_fails_on_unpinned_latest_image() {
     assert!(findings[0].subject.contains("cassandra:latest"));
 }
 
+/// Regression for issue #1026 (roborev LOW 1): a legitimately pinned VARIANT
+/// image carries a `-<suffix>` build/variant tail (`-jdk11`, `-jammy`). Its
+/// numeric lead still matches the manifest pin (`5.0.2`), so the audit must be
+/// clean — the variant tail must NOT be treated as a non-semver tag and red the
+/// lane. Before the fix `is_semver_tag` required the WHOLE tag to be digits+dots,
+/// so any future variant pin spuriously hard-failed PROVENANCE-MISMATCH.
+#[test]
+fn provenance_clean_on_variant_docker_image() {
+    for image in ["cassandra:5.0.2-jdk11", "cassandra:5.0.2-jammy"] {
+        let prov = manifest_derived_provenance(image);
+        let findings = corpus_audit::provenance::check_provenance(&prov, &manifest());
+        assert!(
+            findings.is_empty(),
+            "variant image {image} (numeric lead 5.0.2) must match the manifest pin, got: {findings:?}"
+        );
+    }
+}
+
+/// A divergent VARIANT image is still caught: a `5.0.3-jdk11` build whose numeric
+/// lead (`5.0.3`) is not the manifest pin (`5.0.2`) must hard-fail just like a
+/// bare `5.0.3` — the suffix does not launder a silent image bump.
+#[test]
+fn provenance_mismatch_fails_on_divergent_variant_docker_image() {
+    let prov = manifest_derived_provenance("cassandra:5.0.3-jdk11");
+    let findings = corpus_audit::provenance::check_provenance(&prov, &manifest());
+    assert_eq!(findings.len(), 1, "got: {findings:?}");
+    assert_eq!(findings[0].kind, FindingKind::ProvenanceMismatch);
+    assert!(findings[0].subject.contains("cassandra:5.0.3-jdk11"));
+}
+
 #[test]
 fn corruption_coverage_gap_fails_and_names_missing_component() {
     let mut components = all_corruption_components();

--- a/tools/cassandra-parity/tests/corpus_audit_tests.rs
+++ b/tools/cassandra-parity/tests/corpus_audit_tests.rs
@@ -1,0 +1,260 @@
+//! Tests for the corpus audit (issue #1026). Mirrors `tier_contract_tests`:
+//! every fixture is an inline string / in-memory struct — no Docker, datasets,
+//! live Cassandra, or disk. One drifted fixture per failure class plus a
+//! passing-clean fixture.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use cassandra_parity::corpus_audit::{
+    self, CorpusInventory, ExpectedInventory, FindingKind, Provenance,
+};
+use cassandra_parity::model::Manifest;
+
+const GOOD_SHA: &str = "f278f6774fc76465c182041e081982105c3e7dbb";
+
+/// Repo-relative reference path the clean scenario pins (a committed JSONL golden).
+const REF: &str = "test-data/datasets/sstables/test_basic/simple_table-aaaa0000000000000000000000000001/nb-1-big-Data.db.jsonl";
+
+/// An index with one classified + one unclassified high-relevance Java file.
+fn index_text(include_unclassified: bool) -> String {
+    let mut s = String::from(
+        "# Cassandra test index\n\n## High-relevance tests (quick list)\n\n\
+         | Test | Notes |\n|------|-------|\n| `SortedTableWriterTest.java` | classified |\n",
+    );
+    if include_unclassified {
+        s.push_str("| `RogueUnclassifiedTest.java` | not in manifest |\n");
+    }
+    s.push_str("\n## Other section\n");
+    s
+}
+
+/// Build a manifest whose single scenario references `REF` and classifies
+/// `SortedTableWriterTest.java`.
+fn manifest() -> Manifest {
+    let yaml = format!(
+        r#"manifest_version: 1
+cassandra_source:
+  repo: https://github.com/apache/cassandra
+  ref: cassandra-5.0.2
+  sha: {GOOD_SHA}
+  index: docs/cassandra_test_index.md
+  assessment_report: docs/reports/x.md
+program:
+  parent_epic: 966
+  reporting_epic: 967
+scenarios:
+  - id: cass.sstable_format.simple
+    title: t
+    status: mirrored
+    capability: sstable_format
+    priority: P0
+    risk: p0_data_loss
+    cassandra:
+      category: sstable_format
+      relevance: high
+      files:
+        - SortedTableWriterTest.java
+    cqlite: {{}}
+    evidence:
+      type: byte_for_byte
+      cassandra_version: "5.0.2"
+      cassandra_git_sha: {GOOD_SHA}
+      reference_paths:
+        - {REF}
+    ci:
+      tier: exhaustive_regeneration
+"#
+    );
+    Manifest::from_yaml(&yaml).expect("fixture manifest parses")
+}
+
+fn good_provenance() -> Provenance {
+    Provenance {
+        cassandra_version: "5.0.2".to_string(),
+        cassandra_ref: "cassandra-5.0.2".to_string(),
+        cassandra_git_sha: GOOD_SHA.to_string(),
+        docker_image: "cassandra:5.0.2".to_string(),
+        generator_commands: vec!["bash test-data/scripts/regenerate-datasets.sh".to_string()],
+        dataset_asset_name: "cassandra5-small-full.tar.gz".to_string(),
+        dataset_asset_sha256: "deadbeef".to_string(),
+    }
+}
+
+fn all_corruption_components() -> BTreeSet<String> {
+    corpus_audit::REQUIRED_CORRUPTION_COMPONENTS
+        .iter()
+        .map(|s| s.to_string())
+        .collect()
+}
+
+/// Inventory containing exactly the referenced golden.
+fn clean_inventory() -> CorpusInventory {
+    let mut files = BTreeSet::new();
+    files.insert(REF.to_string());
+    CorpusInventory {
+        files,
+        checksums: BTreeMap::new(),
+    }
+}
+
+#[test]
+fn passing_clean_corpus_audit() {
+    let report = corpus_audit::audit(
+        &manifest(),
+        &index_text(false),
+        &clean_inventory(),
+        &ExpectedInventory::default(),
+        Some(&good_provenance()),
+        &all_corruption_components(),
+    );
+    assert!(report.ok(), "expected clean pass, got: {}", report.render());
+}
+
+#[test]
+fn missing_reference_fails_and_names_offender() {
+    // Reference absent and no same-table component anywhere -> missing.
+    let report = corpus_audit::audit(
+        &manifest(),
+        &index_text(false),
+        &CorpusInventory::default(),
+        &ExpectedInventory::default(),
+        Some(&good_provenance()),
+        &all_corruption_components(),
+    );
+    assert!(!report.ok());
+    assert_eq!(report.count(FindingKind::MissingReference), 1);
+    assert!(report.render().contains(REF), "got: {}", report.render());
+}
+
+#[test]
+fn stale_reference_fails_and_names_offender() {
+    // Same table + component, but under a NEW generation UUID dir -> stale.
+    let regenerated = REF.replace(
+        "simple_table-aaaa0000000000000000000000000001",
+        "simple_table-bbbb0000000000000000000000000002",
+    );
+    let mut files = BTreeSet::new();
+    files.insert(regenerated);
+    let inv = CorpusInventory {
+        files,
+        checksums: BTreeMap::new(),
+    };
+    let report = corpus_audit::audit(
+        &manifest(),
+        &index_text(false),
+        &inv,
+        &ExpectedInventory::default(),
+        Some(&good_provenance()),
+        &all_corruption_components(),
+    );
+    assert!(!report.ok());
+    assert_eq!(report.count(FindingKind::StaleReference), 1);
+    assert_eq!(report.count(FindingKind::MissingReference), 0);
+    assert!(report.render().contains(REF));
+}
+
+#[test]
+fn unclassified_high_relevance_fails_and_names_offender() {
+    let report = corpus_audit::audit(
+        &manifest(),
+        &index_text(true), // adds RogueUnclassifiedTest.java
+        &clean_inventory(),
+        &ExpectedInventory::default(),
+        Some(&good_provenance()),
+        &all_corruption_components(),
+    );
+    assert!(!report.ok());
+    assert_eq!(report.count(FindingKind::UnclassifiedHighRelevance), 1);
+    assert!(
+        report.render().contains("RogueUnclassifiedTest.java"),
+        "got: {}",
+        report.render()
+    );
+}
+
+#[test]
+fn unexpected_component_change_fails_on_checksum_drift() {
+    let comp = REF.to_string();
+    let mut expected = BTreeMap::new();
+    expected.insert(comp.clone(), "expected_sha".to_string());
+    let mut inv = clean_inventory();
+    inv.checksums.insert(comp.clone(), "regenerated_sha".to_string());
+
+    let report = corpus_audit::audit(
+        &manifest(),
+        &index_text(false),
+        &inv,
+        &ExpectedInventory {
+            components: expected,
+        },
+        Some(&good_provenance()),
+        &all_corruption_components(),
+    );
+    assert!(!report.ok());
+    assert_eq!(report.count(FindingKind::UnexpectedComponentChange), 1);
+    assert!(report.render().contains(&comp));
+}
+
+#[test]
+fn provenance_mismatch_fails_on_undeclared_version() {
+    let mut prov = good_provenance();
+    prov.cassandra_git_sha = "0000000000000000000000000000000000000000".to_string();
+    prov.cassandra_version = "6.6.6".to_string();
+    let report = corpus_audit::audit(
+        &manifest(),
+        &index_text(false),
+        &clean_inventory(),
+        &ExpectedInventory::default(),
+        Some(&prov),
+        &all_corruption_components(),
+    );
+    assert!(!report.ok());
+    assert!(report.count(FindingKind::ProvenanceMismatch) >= 1);
+    assert!(
+        report.render().contains("6.6.6"),
+        "got: {}",
+        report.render()
+    );
+}
+
+#[test]
+fn corruption_coverage_gap_fails_and_names_missing_component() {
+    let mut components = all_corruption_components();
+    components.remove("Summary.db");
+    let report = corpus_audit::audit(
+        &manifest(),
+        &index_text(false),
+        &clean_inventory(),
+        &ExpectedInventory::default(),
+        Some(&good_provenance()),
+        &components,
+    );
+    assert!(!report.ok());
+    assert_eq!(report.count(FindingKind::CorruptionCoverageGap), 1);
+    assert!(report.render().contains("Summary.db"));
+}
+
+#[test]
+fn corruption_coverage_clean_when_all_present() {
+    let findings = corpus_audit::check_corruption_coverage(&all_corruption_components());
+    assert!(findings.is_empty());
+}
+
+#[test]
+fn provenance_round_trips_from_json() {
+    let json = r#"{
+      "cassandra_version": "5.0.2",
+      "cassandra_ref": "cassandra-5.0.2",
+      "cassandra_git_sha": "f278f6774fc76465c182041e081982105c3e7dbb",
+      "docker_image": "cassandra:5.0.2",
+      "generator_commands": ["bash test-data/scripts/regenerate-datasets.sh"],
+      "dataset_asset_name": "cassandra5-small-full.tar.gz",
+      "dataset_asset_sha256": "deadbeef"
+    }"#;
+    let prov = Provenance::from_json(json).expect("provenance parses");
+    assert_eq!(prov.cassandra_ref, "cassandra-5.0.2");
+    assert_eq!(prov.dataset_asset_name, "cassandra5-small-full.tar.gz");
+    // Matches the fixture manifest pin -> no provenance findings.
+    let findings = corpus_audit::provenance::check_provenance(&prov, &manifest());
+    assert!(findings.is_empty(), "got: {findings:?}");
+}

--- a/tools/cassandra-parity/tests/corpus_audit_tests.rs
+++ b/tools/cassandra-parity/tests/corpus_audit_tests.rs
@@ -178,7 +178,8 @@ fn unexpected_component_change_fails_on_checksum_drift() {
     let mut expected = BTreeMap::new();
     expected.insert(comp.clone(), "expected_sha".to_string());
     let mut inv = clean_inventory();
-    inv.checksums.insert(comp.clone(), "regenerated_sha".to_string());
+    inv.checksums
+        .insert(comp.clone(), "regenerated_sha".to_string());
 
     let report = corpus_audit::audit(
         &manifest(),

--- a/tools/cassandra-parity/tests/corpus_audit_tests.rs
+++ b/tools/cassandra-parity/tests/corpus_audit_tests.rs
@@ -6,7 +6,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use cassandra_parity::corpus_audit::{
-    self, CorpusInventory, ExpectedInventory, FindingKind, Provenance,
+    self, CorpusInventory, CorruptionFixture, ExpectedInventory, FindingKind, Provenance,
 };
 use cassandra_parity::model::Manifest;
 
@@ -80,21 +80,46 @@ fn good_provenance() -> Provenance {
     }
 }
 
-fn all_corruption_components() -> BTreeSet<String> {
+/// One corruption fixture per required component, each with a distinct
+/// datasets-relative `corrupted_path` whose on-disk (repo-relative) entry is
+/// supplied by [`corruption_inventory_files`]. Mirrors the real
+/// `corruption-manifest.yml` layout (`corruption/test_comp_corrupt/<name>/<file>`).
+fn all_corruption_fixtures() -> Vec<CorruptionFixture> {
     corpus_audit::REQUIRED_CORRUPTION_COMPONENTS
         .iter()
-        .map(|s| s.to_string())
+        .map(|c| CorruptionFixture {
+            component: c.to_string(),
+            corrupted_path: format!("corruption/test_comp_corrupt/{c}_fixture/nb-1-big-{c}"),
+            status: "active".to_string(),
+        })
         .collect()
 }
 
-/// Inventory containing exactly the referenced golden.
-fn clean_inventory() -> CorpusInventory {
-    let mut files = BTreeSet::new();
-    files.insert(REF.to_string());
+/// Repo-relative ON-DISK inventory entries for [`all_corruption_fixtures`] (the
+/// walk keys carry the `test-data/datasets/` prefix the manifest path omits).
+fn corruption_inventory_files() -> BTreeSet<String> {
+    all_corruption_fixtures()
+        .iter()
+        .map(|f| format!("test-data/datasets/{}", f.corrupted_path))
+        .collect()
+}
+
+/// Inventory that always carries the on-disk corruption fixtures (so corruption
+/// coverage passes) plus any extra files supplied.
+fn inventory_with(extra: &[&str]) -> CorpusInventory {
+    let mut files = corruption_inventory_files();
+    for e in extra {
+        files.insert((*e).to_string());
+    }
     CorpusInventory {
         files,
         checksums: BTreeMap::new(),
     }
+}
+
+/// Inventory containing the referenced golden plus the on-disk corruption corpus.
+fn clean_inventory() -> CorpusInventory {
+    inventory_with(&[REF])
 }
 
 #[test]
@@ -105,24 +130,26 @@ fn passing_clean_corpus_audit() {
         &clean_inventory(),
         &ExpectedInventory::default(),
         Some(&good_provenance()),
-        &all_corruption_components(),
+        &all_corruption_fixtures(),
     );
     assert!(report.ok(), "expected clean pass, got: {}", report.render());
 }
 
 #[test]
 fn missing_reference_fails_and_names_offender() {
-    // Reference absent and no same-table component anywhere -> missing.
+    // Reference absent and no same-table component anywhere -> missing. The
+    // on-disk corruption corpus is present so ONLY the missing reference fires.
     let report = corpus_audit::audit(
         &manifest(),
         &index_text(false),
-        &CorpusInventory::default(),
+        &inventory_with(&[]),
         &ExpectedInventory::default(),
         Some(&good_provenance()),
-        &all_corruption_components(),
+        &all_corruption_fixtures(),
     );
     assert!(!report.ok());
     assert_eq!(report.count(FindingKind::MissingReference), 1);
+    assert_eq!(report.count(FindingKind::CorruptionCoverageGap), 0);
     assert!(report.render().contains(REF), "got: {}", report.render());
 }
 
@@ -142,19 +169,14 @@ fn churned_reference_under_new_uuid_is_clean() {
         "simple_table-aaaa0000000000000000000000000001",
         "simple_table-bbbb0000000000000000000000000002",
     );
-    let mut files = BTreeSet::new();
-    files.insert(regenerated);
-    let inv = CorpusInventory {
-        files,
-        checksums: BTreeMap::new(),
-    };
+    let inv = inventory_with(&[regenerated.as_str()]);
     let report = corpus_audit::audit(
         &manifest(),
         &index_text(false),
         &inv,
         &ExpectedInventory::default(),
         Some(&good_provenance()),
-        &all_corruption_components(),
+        &all_corruption_fixtures(),
     );
     assert!(
         report.ok(),
@@ -173,7 +195,7 @@ fn unclassified_high_relevance_fails_and_names_offender() {
         &clean_inventory(),
         &ExpectedInventory::default(),
         Some(&good_provenance()),
-        &all_corruption_components(),
+        &all_corruption_fixtures(),
     );
     assert!(!report.ok());
     assert_eq!(report.count(FindingKind::UnclassifiedHighRelevance), 1);
@@ -285,7 +307,7 @@ fn unexpected_component_change_fails_on_checksum_drift() {
             components: expected,
         },
         Some(&good_provenance()),
-        &all_corruption_components(),
+        &all_corruption_fixtures(),
     );
     assert!(!report.ok());
     assert_eq!(report.count(FindingKind::UnexpectedComponentChange), 1);
@@ -303,7 +325,7 @@ fn provenance_mismatch_fails_on_undeclared_version() {
         &clean_inventory(),
         &ExpectedInventory::default(),
         Some(&prov),
-        &all_corruption_components(),
+        &all_corruption_fixtures(),
     );
     assert!(!report.ok());
     assert!(report.count(FindingKind::ProvenanceMismatch) >= 1);
@@ -408,25 +430,67 @@ fn provenance_mismatch_fails_on_divergent_variant_docker_image() {
 
 #[test]
 fn corruption_coverage_gap_fails_and_names_missing_component() {
-    let mut components = all_corruption_components();
-    components.remove("Summary.db");
+    // Summary.db is declared by NO fixture -> an undeclared coverage gap, even
+    // though its file happens to be on disk (clean_inventory carries the corpus).
+    let fixtures: Vec<CorruptionFixture> = all_corruption_fixtures()
+        .into_iter()
+        .filter(|f| f.component != "Summary.db")
+        .collect();
     let report = corpus_audit::audit(
         &manifest(),
         &index_text(false),
         &clean_inventory(),
         &ExpectedInventory::default(),
         Some(&good_provenance()),
-        &components,
+        &fixtures,
     );
     assert!(!report.ok());
     assert_eq!(report.count(FindingKind::CorruptionCoverageGap), 1);
     assert!(report.render().contains("Summary.db"));
+    assert!(
+        report.render().contains("no corruption fixture declares"),
+        "got: {}",
+        report.render()
+    );
+}
+
+/// Regression for issue #1026 (roborev LOW 2): spec R4 requires an ON-DISK
+/// corruption fixture per required component, not merely a manifest declaration.
+/// A fixture that DECLARES Summary.db but whose corrupted file is ABSENT from the
+/// regenerated corpus must fail, naming Summary.db — so a generator that silently
+/// produced fewer files than declared cannot pass the audit. Before the fix the
+/// audit only checked the manifest declaration and would have passed.
+#[test]
+fn corruption_coverage_gap_fails_when_declared_fixture_absent_on_disk() {
+    let fixtures = all_corruption_fixtures();
+    // On-disk inventory has every corruption fixture EXCEPT Summary.db's file.
+    let summary = all_corruption_fixtures()
+        .into_iter()
+        .find(|f| f.component == "Summary.db")
+        .expect("Summary.db fixture");
+    let mut inventory = corruption_inventory_files();
+    inventory.remove(&format!("test-data/datasets/{}", summary.corrupted_path));
+
+    let findings = corpus_audit::check_corruption_coverage(&fixtures, &inventory);
+    assert_eq!(findings.len(), 1, "got: {findings:?}");
+    assert_eq!(findings[0].kind, FindingKind::CorruptionCoverageGap);
+    assert!(findings[0].subject.contains("Summary.db"));
+    assert!(
+        findings[0]
+            .detail
+            .contains("no corrupted fixture file is present"),
+        "got: {}",
+        findings[0].detail
+    );
 }
 
 #[test]
-fn corruption_coverage_clean_when_all_present() {
-    let findings = corpus_audit::check_corruption_coverage(&all_corruption_components());
-    assert!(findings.is_empty());
+fn corruption_coverage_clean_when_all_present_on_disk() {
+    let findings = corpus_audit::check_corruption_coverage(
+        &all_corruption_fixtures(),
+        &corruption_inventory_files(),
+    );
+    assert!(findings.is_empty(), "got: {findings:?}");
 }
 
 #[test]

--- a/tools/cassandra-parity/tests/corpus_audit_tests.rs
+++ b/tools/cassandra-parity/tests/corpus_audit_tests.rs
@@ -314,6 +314,68 @@ fn provenance_mismatch_fails_on_undeclared_version() {
     );
 }
 
+/// Build a provenance record the way the CI heredoc does: version/ref/sha are
+/// all derived from the manifest (`cassandra_source.ref`/`.sha`, version from the
+/// ref), and ONLY `docker_image` is sourced independently (grepped from
+/// `regenerate-datasets.sh`'s `CASSANDRA_IMAGE=`). This mirrors the real lane so
+/// the docker_image check is exercised on the path that actually runs in CI.
+fn manifest_derived_provenance(docker_image: &str) -> Provenance {
+    // Manifest pins ref `cassandra-5.0.2` + GOOD_SHA; version is `ref` minus the
+    // `cassandra-` prefix, exactly like the workflow's Python derivation.
+    Provenance {
+        cassandra_version: "5.0.2".to_string(),
+        cassandra_ref: "cassandra-5.0.2".to_string(),
+        cassandra_git_sha: GOOD_SHA.to_string(),
+        docker_image: docker_image.to_string(),
+        generator_commands: vec!["bash test-data/scripts/regenerate-datasets.sh".to_string()],
+        dataset_asset_name: "dataset-asset.tar.gz".to_string(),
+        dataset_asset_sha256: "deadbeef".to_string(),
+    }
+}
+
+/// Regression for issue #1026 (roborev MEDIUM): in the lane, cassandra_version/
+/// ref/sha are all parsed FROM the manifest, so validating them against the
+/// manifest is tautological and can never fail. The one independently-sourced
+/// field — `docker_image` (from `regenerate-datasets.sh`'s `CASSANDRA_IMAGE=`) —
+/// is what catches a silent image bump. Bumping the image to `5.0.3` WITHOUT
+/// updating the manifest pin (still `cassandra-5.0.2`) MUST now hard-fail with a
+/// ProvenanceMismatch that names the image; before the fix this passed clean.
+#[test]
+fn provenance_mismatch_fails_on_divergent_docker_image() {
+    let prov = manifest_derived_provenance("cassandra:5.0.3");
+    let findings = corpus_audit::provenance::check_provenance(&prov, &manifest());
+    assert_eq!(
+        findings.len(),
+        1,
+        "only the divergent docker_image should fire, got: {findings:?}"
+    );
+    assert_eq!(findings[0].kind, FindingKind::ProvenanceMismatch);
+    assert!(
+        findings[0].subject.contains("cassandra:5.0.3"),
+        "finding must name the offending image, got: {findings:?}"
+    );
+}
+
+/// The matching-image clean case on the same manifest-derived CI path: when the
+/// image tag agrees with the manifest pin, no provenance finding fires.
+#[test]
+fn provenance_clean_on_matching_docker_image() {
+    let prov = manifest_derived_provenance("cassandra:5.0.2");
+    let findings = corpus_audit::provenance::check_provenance(&prov, &manifest());
+    assert!(findings.is_empty(), "got: {findings:?}");
+}
+
+/// An unverifiable image tag (`latest`, or any non-semver) is itself a mismatch:
+/// it cannot be checked against the manifest pin, so it must not be trusted.
+#[test]
+fn provenance_mismatch_fails_on_unpinned_latest_image() {
+    let prov = manifest_derived_provenance("cassandra:latest");
+    let findings = corpus_audit::provenance::check_provenance(&prov, &manifest());
+    assert_eq!(findings.len(), 1, "got: {findings:?}");
+    assert_eq!(findings[0].kind, FindingKind::ProvenanceMismatch);
+    assert!(findings[0].subject.contains("cassandra:latest"));
+}
+
 #[test]
 fn corruption_coverage_gap_fails_and_names_missing_component() {
     let mut components = all_corruption_components();


### PR DESCRIPTION
Closes #1026 — child of epic #974.

## What
Adds the **exhaustive regeneration lane** + a **`cassandra-parity corpus-audit`** subcommand that the lane wires together. Design-driven; OpenSpec change `exhaustive-regeneration-lane` (owner-approved at Seam 1).

- `.github/workflows/exhaustive-regeneration.yml` — tier `exhaustive_regeneration`; `workflow_dispatch` + weekly `cron '0 6 * * 0'`; **never on PRs**. Orchestrates `regenerate-datasets.sh` → `generate-deltas.sh` → `generate-corruption-corpus.sh`, writes a JSON provenance record, runs the audit, uploads **one** report artifact. No auto-commit of datasets, no release publish.
- `tools/cassandra-parity` `corpus-audit` — reuses the manifest model + coverage classifier. Hard-fails (named) on: missing reference, stale reference, unclassified high-relevance Cassandra file, unexpected component change, provenance mismatch, and corruption-coverage gap.
- Doctrine cross-links: `docs/development/parity-ci-tiers.md`, `parity-release-checklist.md`, `CLAUDE.md`.

## Owner Seam-1 decisions (pinned in design.md)
- Cadence: **weekly** `cron '0 6 * * 0'` + `workflow_dispatch`
- Provenance: **artifact-only JSON**
- Strictness: **hard-fail always** on unexpected component change

## Quality
- `scripts/agent-gate.sh`: **PASS** (15/15 components)
- Intent audit (spec-auditor **C**): **PASS** — every requirement satisfied with public-surface test evidence
- roborev: converged clean over multiple rounds. Notable fixes caught in review:
  - **UUID-churn tolerance** in both the component-change and reference checks (regeneration mints fresh table UUIDs each run; exact-path matching would have kept the lane perpetually red). Now keyed by UUID-independent `component_identity()`; a dedicated churn-tolerant clean test guards it.
  - **Provenance check given teeth** — validates the independently-sourced `docker_image` tag against the manifest pin, so a silent Cassandra image bump now reds the lane (was previously tautological).
  - **Corruption coverage** verifies fixtures exist **on disk** (per spec R4), not just manifest declarations.
  - NUL-safe sha256 producers, GNU-escaped-line rejection, VCS/build + report-dir pruning, accurate corpus-file count, end-to-end CLI tests.
