### PR TITLE
test(#1185): pin test_big.wide_partition fixture into CI dataset + promote 6 wide-partition scenarios to byte_for_byte

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,8 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   DATASET_TAG: datasets-v3
-  DATASET_ASSET: cassandra5-small-full-v3.3.tar.gz
-  DATASET_SHA256: 44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac
+  DATASET_ASSET: cassandra5-small-full-v3.4.tar.gz
+  DATASET_SHA256: 3cae644360e0142a6bb5e96ddab445ff18e3478e7058104842ce1a455fba8a33
 
 jobs:
   core_lib_doc_tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,8 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   DATASET_TAG: datasets-v3
-  DATASET_ASSET: cassandra5-small-full-v3.2.tar.gz
-  DATASET_SHA256: bebc763752c8d68c7fb0483a1b31294b4d1d21343d3f7d124da069e5073202fa
+  DATASET_ASSET: cassandra5-small-full-v3.3.tar.gz
+  DATASET_SHA256: 44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac
 
 jobs:
   core_lib_doc_tests:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -64,9 +64,9 @@ jobs:
         path: |
           test-data/datasets/
           validation_artifacts/sstabledump/
-        key: datasets-v3-bebc763752c8d68c7fb0483a1b31294b4d1d21343d3f7d124da069e5073202fa-${{ hashFiles('test-data/**/*.md') }}
+        key: datasets-v3-44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac-${{ hashFiles('test-data/**/*.md') }}
         restore-keys: |
-          datasets-v3-bebc763752c8d68c7fb0483a1b31294b4d1d21343d3f7d124da069e5073202fa-
+          datasets-v3-44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac-
 
     - name: Download Cassandra 5 Datasets (if cache miss)
       run: |
@@ -83,12 +83,12 @@ jobs:
         if [ "$CORE_FIXTURE_COUNT" -eq 0 ]; then
           echo "📦 Core Data.db fixture missing - downloading full Cassandra 5 datasets from release..."
           mkdir -p test-data
-          echo "🔍 Downloading cassandra5-small-full-v3.2.tar.gz from datasets-v3 release..."
-          gh release download datasets-v3 --pattern "cassandra5-small-full-v3.2.tar.gz" --dir /tmp
-          echo "bebc763752c8d68c7fb0483a1b31294b4d1d21343d3f7d124da069e5073202fa  /tmp/cassandra5-small-full-v3.2.tar.gz" | sha256sum -c -
+          echo "🔍 Downloading cassandra5-small-full-v3.3.tar.gz from datasets-v3 release..."
+          gh release download datasets-v3 --pattern "cassandra5-small-full-v3.3.tar.gz" --dir /tmp
+          echo "44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac  /tmp/cassandra5-small-full-v3.3.tar.gz" | sha256sum -c -
           echo "📦 Extracting datasets to repo root..."
           rm -rf test-data/datasets
-          tar -xzf /tmp/cassandra5-small-full-v3.2.tar.gz -C . --exclude='*/._*' --exclude='._*' --exclude='*/.DS_Store' --exclude='.DS_Store'
+          tar -xzf /tmp/cassandra5-small-full-v3.3.tar.gz -C . --exclude='*/._*' --exclude='._*' --exclude='*/.DS_Store' --exclude='.DS_Store'
 
           # Verify extraction
           NEW_DB_COUNT=$(find test-data/datasets/sstables -name '*-Data.db' 2>/dev/null | wc -l)

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -64,9 +64,9 @@ jobs:
         path: |
           test-data/datasets/
           validation_artifacts/sstabledump/
-        key: datasets-v3-44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac-${{ hashFiles('test-data/**/*.md') }}
+        key: datasets-v3-3cae644360e0142a6bb5e96ddab445ff18e3478e7058104842ce1a455fba8a33-${{ hashFiles('test-data/**/*.md') }}
         restore-keys: |
-          datasets-v3-44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac-
+          datasets-v3-3cae644360e0142a6bb5e96ddab445ff18e3478e7058104842ce1a455fba8a33-
 
     - name: Download Cassandra 5 Datasets (if cache miss)
       run: |
@@ -83,12 +83,12 @@ jobs:
         if [ "$CORE_FIXTURE_COUNT" -eq 0 ]; then
           echo "📦 Core Data.db fixture missing - downloading full Cassandra 5 datasets from release..."
           mkdir -p test-data
-          echo "🔍 Downloading cassandra5-small-full-v3.3.tar.gz from datasets-v3 release..."
-          gh release download datasets-v3 --pattern "cassandra5-small-full-v3.3.tar.gz" --dir /tmp
-          echo "44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac  /tmp/cassandra5-small-full-v3.3.tar.gz" | sha256sum -c -
+          echo "🔍 Downloading cassandra5-small-full-v3.4.tar.gz from datasets-v3 release..."
+          gh release download datasets-v3 --pattern "cassandra5-small-full-v3.4.tar.gz" --dir /tmp
+          echo "3cae644360e0142a6bb5e96ddab445ff18e3478e7058104842ce1a455fba8a33  /tmp/cassandra5-small-full-v3.4.tar.gz" | sha256sum -c -
           echo "📦 Extracting datasets to repo root..."
           rm -rf test-data/datasets
-          tar -xzf /tmp/cassandra5-small-full-v3.3.tar.gz -C . --exclude='*/._*' --exclude='._*' --exclude='*/.DS_Store' --exclude='.DS_Store'
+          tar -xzf /tmp/cassandra5-small-full-v3.4.tar.gz -C . --exclude='*/._*' --exclude='._*' --exclude='*/.DS_Store' --exclude='.DS_Store'
 
           # Verify extraction
           NEW_DB_COUNT=$(find test-data/datasets/sstables -name '*-Data.db' 2>/dev/null | wc -l)

--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -38,8 +38,8 @@ concurrency:
 
 env:
   DATASET_TAG: datasets-v3
-  DATASET_ASSET: cassandra5-small-full-v3.3.tar.gz
-  DATASET_SHA256: 44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac
+  DATASET_ASSET: cassandra5-small-full-v3.4.tar.gz
+  DATASET_SHA256: 3cae644360e0142a6bb5e96ddab445ff18e3478e7058104842ce1a455fba8a33
 
 jobs:
   build:

--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -38,8 +38,8 @@ concurrency:
 
 env:
   DATASET_TAG: datasets-v3
-  DATASET_ASSET: cassandra5-small-full-v3.2.tar.gz
-  DATASET_SHA256: bebc763752c8d68c7fb0483a1b31294b4d1d21343d3f7d124da069e5073202fa
+  DATASET_ASSET: cassandra5-small-full-v3.3.tar.gz
+  DATASET_SHA256: 44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac
 
 jobs:
   build:

--- a/.github/workflows/m1-ci.yml
+++ b/.github/workflows/m1-ci.yml
@@ -238,9 +238,9 @@ jobs:
       with:
         path: |
           test-data/datasets/
-        key: datasets-v3-44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac-${{ hashFiles('test-data/**/*.md') }}
+        key: datasets-v3-3cae644360e0142a6bb5e96ddab445ff18e3478e7058104842ce1a455fba8a33-${{ hashFiles('test-data/**/*.md') }}
         restore-keys: |
-          datasets-v3-44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac-
+          datasets-v3-3cae644360e0142a6bb5e96ddab445ff18e3478e7058104842ce1a455fba8a33-
 
     - name: Download Cassandra 5 Datasets (if cache miss)
       run: |
@@ -252,10 +252,10 @@ jobs:
         if [ "$CORE_FIXTURE_COUNT" -eq 0 ]; then
           echo "📦 Core Data.db fixture missing — downloading real Cassandra 5 datasets from release (datasets-v3, includes oa+da fixtures)..."
           mkdir -p test-data
-          gh release download datasets-v3 --pattern "cassandra5-small-full-v3.3.tar.gz" --dir /tmp
-          echo "44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac  /tmp/cassandra5-small-full-v3.3.tar.gz" | sha256sum -c -
+          gh release download datasets-v3 --pattern "cassandra5-small-full-v3.4.tar.gz" --dir /tmp
+          echo "3cae644360e0142a6bb5e96ddab445ff18e3478e7058104842ce1a455fba8a33  /tmp/cassandra5-small-full-v3.4.tar.gz" | sha256sum -c -
           rm -rf test-data/datasets
-          tar -xzf /tmp/cassandra5-small-full-v3.3.tar.gz -C . --exclude='*/._*' --exclude='._*' --exclude='*/.DS_Store' --exclude='.DS_Store'
+          tar -xzf /tmp/cassandra5-small-full-v3.4.tar.gz -C . --exclude='*/._*' --exclude='._*' --exclude='*/.DS_Store' --exclude='.DS_Store'
           DATA_COUNT=$(find test-data/datasets/sstables -name '*-Data.db' 2>/dev/null | wc -l)
           echo "✅ Downloaded datasets for M1 CI ($DATA_COUNT Data.db fixtures)"
         else
@@ -442,9 +442,9 @@ jobs:
       with:
         path: |
           test-data/datasets/
-        key: datasets-v3-44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac-${{ hashFiles('test-data/**/*.md') }}
+        key: datasets-v3-3cae644360e0142a6bb5e96ddab445ff18e3478e7058104842ce1a455fba8a33-${{ hashFiles('test-data/**/*.md') }}
         restore-keys: |
-          datasets-v3-44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac-
+          datasets-v3-3cae644360e0142a6bb5e96ddab445ff18e3478e7058104842ce1a455fba8a33-
 
     - name: Download Cassandra 5 Datasets (if cache miss)
       run: |
@@ -456,10 +456,10 @@ jobs:
         if [ "$CORE_FIXTURE_COUNT" -eq 0 ]; then
           echo "📦 Core Data.db fixture missing — downloading real Cassandra 5 datasets from release (datasets-v3, includes oa+da fixtures)..."
           mkdir -p test-data
-          gh release download datasets-v3 --pattern "cassandra5-small-full-v3.3.tar.gz" --dir /tmp
-          echo "44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac  /tmp/cassandra5-small-full-v3.3.tar.gz" | sha256sum -c -
+          gh release download datasets-v3 --pattern "cassandra5-small-full-v3.4.tar.gz" --dir /tmp
+          echo "3cae644360e0142a6bb5e96ddab445ff18e3478e7058104842ce1a455fba8a33  /tmp/cassandra5-small-full-v3.4.tar.gz" | sha256sum -c -
           rm -rf test-data/datasets
-          tar -xzf /tmp/cassandra5-small-full-v3.3.tar.gz -C . --exclude='*/._*' --exclude='._*' --exclude='*/.DS_Store' --exclude='.DS_Store'
+          tar -xzf /tmp/cassandra5-small-full-v3.4.tar.gz -C . --exclude='*/._*' --exclude='._*' --exclude='*/.DS_Store' --exclude='.DS_Store'
           DATA_COUNT=$(find test-data/datasets/sstables -name '*-Data.db' 2>/dev/null | wc -l)
           echo "✅ Downloaded datasets for parity validation ($DATA_COUNT Data.db fixtures)"
         else

--- a/.github/workflows/m1-ci.yml
+++ b/.github/workflows/m1-ci.yml
@@ -238,9 +238,9 @@ jobs:
       with:
         path: |
           test-data/datasets/
-        key: datasets-v3-bebc763752c8d68c7fb0483a1b31294b4d1d21343d3f7d124da069e5073202fa-${{ hashFiles('test-data/**/*.md') }}
+        key: datasets-v3-44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac-${{ hashFiles('test-data/**/*.md') }}
         restore-keys: |
-          datasets-v3-bebc763752c8d68c7fb0483a1b31294b4d1d21343d3f7d124da069e5073202fa-
+          datasets-v3-44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac-
 
     - name: Download Cassandra 5 Datasets (if cache miss)
       run: |
@@ -252,10 +252,10 @@ jobs:
         if [ "$CORE_FIXTURE_COUNT" -eq 0 ]; then
           echo "📦 Core Data.db fixture missing — downloading real Cassandra 5 datasets from release (datasets-v3, includes oa+da fixtures)..."
           mkdir -p test-data
-          gh release download datasets-v3 --pattern "cassandra5-small-full-v3.2.tar.gz" --dir /tmp
-          echo "bebc763752c8d68c7fb0483a1b31294b4d1d21343d3f7d124da069e5073202fa  /tmp/cassandra5-small-full-v3.2.tar.gz" | sha256sum -c -
+          gh release download datasets-v3 --pattern "cassandra5-small-full-v3.3.tar.gz" --dir /tmp
+          echo "44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac  /tmp/cassandra5-small-full-v3.3.tar.gz" | sha256sum -c -
           rm -rf test-data/datasets
-          tar -xzf /tmp/cassandra5-small-full-v3.2.tar.gz -C . --exclude='*/._*' --exclude='._*' --exclude='*/.DS_Store' --exclude='.DS_Store'
+          tar -xzf /tmp/cassandra5-small-full-v3.3.tar.gz -C . --exclude='*/._*' --exclude='._*' --exclude='*/.DS_Store' --exclude='.DS_Store'
           DATA_COUNT=$(find test-data/datasets/sstables -name '*-Data.db' 2>/dev/null | wc -l)
           echo "✅ Downloaded datasets for M1 CI ($DATA_COUNT Data.db fixtures)"
         else
@@ -442,9 +442,9 @@ jobs:
       with:
         path: |
           test-data/datasets/
-        key: datasets-v3-bebc763752c8d68c7fb0483a1b31294b4d1d21343d3f7d124da069e5073202fa-${{ hashFiles('test-data/**/*.md') }}
+        key: datasets-v3-44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac-${{ hashFiles('test-data/**/*.md') }}
         restore-keys: |
-          datasets-v3-bebc763752c8d68c7fb0483a1b31294b4d1d21343d3f7d124da069e5073202fa-
+          datasets-v3-44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac-
 
     - name: Download Cassandra 5 Datasets (if cache miss)
       run: |
@@ -456,10 +456,10 @@ jobs:
         if [ "$CORE_FIXTURE_COUNT" -eq 0 ]; then
           echo "📦 Core Data.db fixture missing — downloading real Cassandra 5 datasets from release (datasets-v3, includes oa+da fixtures)..."
           mkdir -p test-data
-          gh release download datasets-v3 --pattern "cassandra5-small-full-v3.2.tar.gz" --dir /tmp
-          echo "bebc763752c8d68c7fb0483a1b31294b4d1d21343d3f7d124da069e5073202fa  /tmp/cassandra5-small-full-v3.2.tar.gz" | sha256sum -c -
+          gh release download datasets-v3 --pattern "cassandra5-small-full-v3.3.tar.gz" --dir /tmp
+          echo "44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac  /tmp/cassandra5-small-full-v3.3.tar.gz" | sha256sum -c -
           rm -rf test-data/datasets
-          tar -xzf /tmp/cassandra5-small-full-v3.2.tar.gz -C . --exclude='*/._*' --exclude='._*' --exclude='*/.DS_Store' --exclude='.DS_Store'
+          tar -xzf /tmp/cassandra5-small-full-v3.3.tar.gz -C . --exclude='*/._*' --exclude='._*' --exclude='*/.DS_Store' --exclude='.DS_Store'
           DATA_COUNT=$(find test-data/datasets/sstables -name '*-Data.db' 2>/dev/null | wc -l)
           echo "✅ Downloaded datasets for parity validation ($DATA_COUNT Data.db fixtures)"
         else

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -21,8 +21,8 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   DATASET_TAG: datasets-v3
-  DATASET_ASSET: cassandra5-small-full-v3.3.tar.gz
-  DATASET_SHA256: 44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac
+  DATASET_ASSET: cassandra5-small-full-v3.4.tar.gz
+  DATASET_SHA256: 3cae644360e0142a6bb5e96ddab445ff18e3478e7058104842ce1a455fba8a33
   APP_NAME: cqlite-node
 
 jobs:

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -21,8 +21,8 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   DATASET_TAG: datasets-v3
-  DATASET_ASSET: cassandra5-small-full-v3.2.tar.gz
-  DATASET_SHA256: bebc763752c8d68c7fb0483a1b31294b4d1d21343d3f7d124da069e5073202fa
+  DATASET_ASSET: cassandra5-small-full-v3.3.tar.gz
+  DATASET_SHA256: 44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac
   APP_NAME: cqlite-node
 
 jobs:

--- a/.github/workflows/observability-gate.yml
+++ b/.github/workflows/observability-gate.yml
@@ -45,8 +45,8 @@ concurrency:
 
 env:
   DATASET_TAG: datasets-v3
-  DATASET_ASSET: cassandra5-small-full-v3.2.tar.gz
-  DATASET_SHA256: bebc763752c8d68c7fb0483a1b31294b4d1d21343d3f7d124da069e5073202fa
+  DATASET_ASSET: cassandra5-small-full-v3.3.tar.gz
+  DATASET_SHA256: 44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac
   CQLITE_DATASETS_ROOT: ${{ github.workspace }}/test-data/datasets
   # Tolerated median overhead of the export-disabled observability build over the
   # default build (see benches/observability_overhead.rs OVERHEAD_THRESHOLD_PCT).

--- a/.github/workflows/observability-gate.yml
+++ b/.github/workflows/observability-gate.yml
@@ -45,8 +45,8 @@ concurrency:
 
 env:
   DATASET_TAG: datasets-v3
-  DATASET_ASSET: cassandra5-small-full-v3.3.tar.gz
-  DATASET_SHA256: 44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac
+  DATASET_ASSET: cassandra5-small-full-v3.4.tar.gz
+  DATASET_SHA256: 3cae644360e0142a6bb5e96ddab445ff18e3478e7058104842ce1a455fba8a33
   CQLITE_DATASETS_ROOT: ${{ github.workspace }}/test-data/datasets
   # Tolerated median overhead of the export-disabled observability build over the
   # default build (see benches/observability_overhead.rs OVERHEAD_THRESHOLD_PCT).

--- a/.github/workflows/perf-regression.yml
+++ b/.github/workflows/perf-regression.yml
@@ -38,8 +38,8 @@ concurrency:
 
 env:
   DATASET_TAG: datasets-v3
-  DATASET_ASSET: cassandra5-small-full-v3.3.tar.gz
-  DATASET_SHA256: 44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac
+  DATASET_ASSET: cassandra5-small-full-v3.4.tar.gz
+  DATASET_SHA256: 3cae644360e0142a6bb5e96ddab445ff18e3478e7058104842ce1a455fba8a33
   CQLITE_DATASETS_ROOT: ${{ github.workspace }}/test-data/datasets
   # Features needed by the benches: cli-helpers for the read suite (queryable
   # Database), write-support for the write suite (WriteEngine).

--- a/.github/workflows/perf-regression.yml
+++ b/.github/workflows/perf-regression.yml
@@ -38,8 +38,8 @@ concurrency:
 
 env:
   DATASET_TAG: datasets-v3
-  DATASET_ASSET: cassandra5-small-full-v3.2.tar.gz
-  DATASET_SHA256: bebc763752c8d68c7fb0483a1b31294b4d1d21343d3f7d124da069e5073202fa
+  DATASET_ASSET: cassandra5-small-full-v3.3.tar.gz
+  DATASET_SHA256: 44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac
   CQLITE_DATASETS_ROOT: ${{ github.workspace }}/test-data/datasets
   # Features needed by the benches: cli-helpers for the read suite (queryable
   # Database), write-support for the write suite (WriteEngine).

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -21,8 +21,8 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   DATASET_TAG: datasets-v3
-  DATASET_ASSET: cassandra5-small-full-v3.3.tar.gz
-  DATASET_SHA256: 44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac
+  DATASET_ASSET: cassandra5-small-full-v3.4.tar.gz
+  DATASET_SHA256: 3cae644360e0142a6bb5e96ddab445ff18e3478e7058104842ce1a455fba8a33
 
 jobs:
   build-only-wheels:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -21,8 +21,8 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   DATASET_TAG: datasets-v3
-  DATASET_ASSET: cassandra5-small-full-v3.2.tar.gz
-  DATASET_SHA256: bebc763752c8d68c7fb0483a1b31294b4d1d21343d3f7d124da069e5073202fa
+  DATASET_ASSET: cassandra5-small-full-v3.3.tar.gz
+  DATASET_SHA256: 44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac
 
 jobs:
   build-only-wheels:

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -48,8 +48,8 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   DATASET_TAG: datasets-v3
-  DATASET_ASSET: cassandra5-small-full-v3.2.tar.gz
-  DATASET_SHA256: bebc763752c8d68c7fb0483a1b31294b4d1d21343d3f7d124da069e5073202fa
+  DATASET_ASSET: cassandra5-small-full-v3.3.tar.gz
+  DATASET_SHA256: 44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac
   CQLITE_DATASETS_ROOT: ${{ github.workspace }}/test-data/datasets
   OUTPUT_DIR: ${{ github.workspace }}/smoke-test-results
 

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -48,8 +48,8 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   DATASET_TAG: datasets-v3
-  DATASET_ASSET: cassandra5-small-full-v3.3.tar.gz
-  DATASET_SHA256: 44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac
+  DATASET_ASSET: cassandra5-small-full-v3.4.tar.gz
+  DATASET_SHA256: 3cae644360e0142a6bb5e96ddab445ff18e3478e7058104842ce1a455fba8a33
   CQLITE_DATASETS_ROOT: ${{ github.workspace }}/test-data/datasets
   OUTPUT_DIR: ${{ github.workspace }}/smoke-test-results
 

--- a/.github/workflows/sstabledump-parity-gate.yml
+++ b/.github/workflows/sstabledump-parity-gate.yml
@@ -35,8 +35,8 @@ concurrency:
 
 env:
   DATASET_TAG: datasets-v3
-  DATASET_ASSET: cassandra5-small-full-v3.2.tar.gz
-  DATASET_SHA256: bebc763752c8d68c7fb0483a1b31294b4d1d21343d3f7d124da069e5073202fa
+  DATASET_ASSET: cassandra5-small-full-v3.3.tar.gz
+  DATASET_SHA256: 44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac
   CQLITE_DATASETS_ROOT: ${{ github.workspace }}/test-data/datasets
   # Fail-closed switch (issue #1024): strict parity lanes must PANIC instead of
   # skipping when dataset binaries are absent. A vanished/unfetched dataset can

--- a/.github/workflows/sstabledump-parity-gate.yml
+++ b/.github/workflows/sstabledump-parity-gate.yml
@@ -35,8 +35,8 @@ concurrency:
 
 env:
   DATASET_TAG: datasets-v3
-  DATASET_ASSET: cassandra5-small-full-v3.3.tar.gz
-  DATASET_SHA256: 44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac
+  DATASET_ASSET: cassandra5-small-full-v3.4.tar.gz
+  DATASET_SHA256: 3cae644360e0142a6bb5e96ddab445ff18e3478e7058104842ce1a455fba8a33
   CQLITE_DATASETS_ROOT: ${{ github.workspace }}/test-data/datasets
   # Fail-closed switch (issue #1024): strict parity lanes must PANIC instead of
   # skipping when dataset binaries are absent. A vanished/unfetched dataset can

--- a/cqlite-core/tests/issue_993_wide_partition_promoted_index_parity.rs
+++ b/cqlite-core/tests/issue_993_wide_partition_promoted_index_parity.rs
@@ -202,20 +202,19 @@ fn require_or_skip_binaries(test: &str) -> bool {
     // component in REQUIRED_BINARY_COMPONENTS was present.
     if parity_datasets_required() {
         let missing = missing_required_components();
-        if !missing.is_empty() {
-            panic!(
-                "{test}: CQLITE_PARITY_REQUIRE_DATASETS=1 but the wide_partition byte-parity \
-                 reference is incomplete at {} (missing {} of {} required component(s): {:?}) — \
-                 these scenarios are pinned `byte_for_byte` in \
-                 test-data/cassandra-parity-manifest.yml and the fixture is in the pinned CI \
-                 dataset (v3.4). The required parity gate must FAIL CLOSED here, not skip. \
-                 Fetch the dataset: bash test-data/scripts/fetch-datasets.sh",
-                fixture_dir().display(),
-                missing.len(),
-                REQUIRED_BINARY_COMPONENTS.len(),
-                missing,
-            );
-        }
+        assert!(
+            missing.is_empty(),
+            "{test}: CQLITE_PARITY_REQUIRE_DATASETS=1 but the wide_partition byte-parity \
+             reference is incomplete at {} (missing {} of {} required component(s): {:?}) — \
+             these scenarios are pinned `byte_for_byte` in \
+             test-data/cassandra-parity-manifest.yml and the fixture is in the pinned CI \
+             dataset (v3.4). The required parity gate must FAIL CLOSED here, not skip. \
+             Fetch the dataset: bash test-data/scripts/fetch-datasets.sh",
+            fixture_dir().display(),
+            missing.len(),
+            REQUIRED_BINARY_COMPONENTS.len(),
+            missing,
+        );
         return true;
     }
     // Local dev (env unset): the byte-level decode only needs Data.db+Index.db;

--- a/cqlite-core/tests/issue_993_wide_partition_promoted_index_parity.rs
+++ b/cqlite-core/tests/issue_993_wide_partition_promoted_index_parity.rs
@@ -147,11 +147,70 @@ fn jsonl_golden_path() -> Option<PathBuf> {
     None
 }
 
+/// CI fail-closed switch (issue #1185). Returns `true` when
+/// `CQLITE_PARITY_REQUIRE_DATASETS=1` is set — the same env idiom used by every
+/// other strict parity lane (`cqlite-core/tests/parity_support/mod.rs`,
+/// `sstable_parity_index_db_test.rs`). In that mode a missing wide_partition
+/// binary is a HARD FAILURE (panic), never a skip, because these scenarios are
+/// pinned `byte_for_byte` in `test-data/cassandra-parity-manifest.yml` and the
+/// fixture is now part of the pinned CI dataset (v3.4). Locally (env unset) the
+/// byte-level checks keep their skip-on-absence behavior.
+fn parity_datasets_required() -> bool {
+    std::env::var("CQLITE_PARITY_REQUIRE_DATASETS")
+        .map(|v| v == "1")
+        .unwrap_or(false)
+}
+
+/// The exact binary components every byte-level scenario depends on. Their
+/// absence under `CQLITE_PARITY_REQUIRE_DATASETS=1` is a gate failure (the
+/// wide_partition fixture is now pinned in the CI dataset, v3.4).
+const REQUIRED_BINARY_COMPONENTS: [&str; 4] =
+    ["Data.db", "Index.db", "Digest.crc32", "CompressionInfo.db"];
+
 /// Whether the binary components needed by a byte-level test are present. The
 /// committed tree always carries the JSONL/TOC; the binaries (Data.db/Index.db)
 /// are gitignored and only present after a dataset fetch.
 fn binaries_present() -> bool {
     component("Data.db").exists() && component("Index.db").exists()
+}
+
+/// List the exact strict components that are missing on disk (empty when all
+/// present). Used by the fail-closed guard so the failure names precisely which
+/// reference binary is absent.
+fn missing_required_components() -> Vec<String> {
+    REQUIRED_BINARY_COMPONENTS
+        .iter()
+        .filter(|suffix| !component(suffix).exists())
+        .map(|suffix| format!("{PREFIX}-{suffix}"))
+        .collect()
+}
+
+/// Gate a byte-level scenario on fixture presence. Returns `true` when the
+/// caller should proceed (binaries present), `false` when it should skip.
+///
+/// Fail-closed contract (issue #1185): under `CQLITE_PARITY_REQUIRE_DATASETS=1`
+/// (the REQUIRED "Real M5 SSTableDump parity validation" CI lane sets it) the
+/// absence of the EXACT wide_partition reference binaries is a HARD FAILURE — it
+/// must NOT skip-and-green. With the env unset (local dev without the fetched
+/// binaries) the byte-level checks skip cleanly while the JSONL canonical-semantic
+/// tier still runs.
+fn require_or_skip_binaries(test: &str) -> bool {
+    if binaries_present() {
+        return true;
+    }
+    if parity_datasets_required() {
+        panic!(
+            "{test}: CQLITE_PARITY_REQUIRE_DATASETS=1 but the wide_partition byte-parity \
+             reference binaries are absent at {} (missing: {:?}) — these scenarios are pinned \
+             `byte_for_byte` in test-data/cassandra-parity-manifest.yml and the fixture is in \
+             the pinned CI dataset (v3.4). The required parity gate must FAIL CLOSED here, not \
+             skip. Fetch the dataset: bash test-data/scripts/fetch-datasets.sh",
+            fixture_dir().display(),
+            missing_required_components(),
+        );
+    }
+    byte_level_skip(test);
+    false
 }
 
 /// Emit a uniform line noting the byte-level checks are skipped (binaries absent)
@@ -412,8 +471,7 @@ fn jsonl_golden_canonical_semantics() {
 #[tokio::test]
 async fn row_boundaries_index_info_offsets() {
     let test = "row_boundaries_index_info_offsets";
-    if !binaries_present() {
-        byte_level_skip(test);
+    if !require_or_skip_binaries(test) {
         return;
     }
 
@@ -570,8 +628,7 @@ async fn row_boundaries_index_info_offsets() {
 #[tokio::test]
 async fn clustering_bounds() {
     let test = "clustering_bounds";
-    if !binaries_present() {
-        byte_level_skip(test);
+    if !require_or_skip_binaries(test) {
         return;
     }
 
@@ -639,8 +696,7 @@ async fn clustering_bounds() {
 #[tokio::test]
 async fn range_tombstone_boundary_at_block_edge() {
     let test = "range_tombstone_boundary_at_block_edge";
-    if !binaries_present() {
-        byte_level_skip(test);
+    if !require_or_skip_binaries(test) {
         return;
     }
 
@@ -740,8 +796,7 @@ async fn range_tombstone_boundary_at_block_edge() {
 #[tokio::test]
 async fn forward_bounds_completeness() {
     let test = "forward_bounds_completeness";
-    if !binaries_present() {
-        byte_level_skip(test);
+    if !require_or_skip_binaries(test) {
         return;
     }
 

--- a/cqlite-core/tests/issue_993_wide_partition_promoted_index_parity.rs
+++ b/cqlite-core/tests/issue_993_wide_partition_promoted_index_parity.rs
@@ -195,19 +195,33 @@ fn missing_required_components() -> Vec<String> {
 /// binaries) the byte-level checks skip cleanly while the JSONL canonical-semantic
 /// tier still runs.
 fn require_or_skip_binaries(test: &str) -> bool {
-    if binaries_present() {
+    // Strict CI lane: enforce the FULL required-component set, not just the
+    // Data.db+Index.db subset that `binaries_present()` checks. A partial fixture
+    // (e.g. missing Digest.crc32 or CompressionInfo.db) must turn the required
+    // lane red, never skip-and-green. Invariant: strict mode passing ⇒ every
+    // component in REQUIRED_BINARY_COMPONENTS was present.
+    if parity_datasets_required() {
+        let missing = missing_required_components();
+        if !missing.is_empty() {
+            panic!(
+                "{test}: CQLITE_PARITY_REQUIRE_DATASETS=1 but the wide_partition byte-parity \
+                 reference is incomplete at {} (missing {} of {} required component(s): {:?}) — \
+                 these scenarios are pinned `byte_for_byte` in \
+                 test-data/cassandra-parity-manifest.yml and the fixture is in the pinned CI \
+                 dataset (v3.4). The required parity gate must FAIL CLOSED here, not skip. \
+                 Fetch the dataset: bash test-data/scripts/fetch-datasets.sh",
+                fixture_dir().display(),
+                missing.len(),
+                REQUIRED_BINARY_COMPONENTS.len(),
+                missing,
+            );
+        }
         return true;
     }
-    if parity_datasets_required() {
-        panic!(
-            "{test}: CQLITE_PARITY_REQUIRE_DATASETS=1 but the wide_partition byte-parity \
-             reference binaries are absent at {} (missing: {:?}) — these scenarios are pinned \
-             `byte_for_byte` in test-data/cassandra-parity-manifest.yml and the fixture is in \
-             the pinned CI dataset (v3.4). The required parity gate must FAIL CLOSED here, not \
-             skip. Fetch the dataset: bash test-data/scripts/fetch-datasets.sh",
-            fixture_dir().display(),
-            missing_required_components(),
-        );
+    // Local dev (env unset): the byte-level decode only needs Data.db+Index.db;
+    // skip cleanly when those are absent while the JSONL semantic tier still runs.
+    if binaries_present() {
+        return true;
     }
     byte_level_skip(test);
     false

--- a/cqlite-core/tests/sstable_parity_toc_component_test.rs
+++ b/cqlite-core/tests/sstable_parity_toc_component_test.rs
@@ -38,6 +38,22 @@ use std::path::{Path, PathBuf};
 use cqlite_core::storage::sstable::directory::{parse_toc_file_detailed, SSTableComponent};
 use cqlite_core::storage::sstable::version_gate::{SsTableDescriptor, SsTableFormat};
 
+/// CI fail-closed switch (issue #1185 / #1205). Returns `true` when
+/// `CQLITE_PARITY_REQUIRE_DATASETS=1` is set — the same env idiom every other
+/// strict parity lane uses. In that mode a missing pinned binary turns a would-be
+/// skip into a hard failure so a required CI lane cannot false-green.
+fn parity_datasets_required() -> bool {
+    std::env::var("CQLITE_PARITY_REQUIRE_DATASETS")
+        .map(|v| v == "1")
+        .unwrap_or(false)
+}
+
+/// Relative path (under `datasets/sstables`) of the wide_partition `Data.db`
+/// whose digest is now pinned `byte_for_byte` and shipped in the CI dataset
+/// (v3.4). Under `CQLITE_PARITY_REQUIRE_DATASETS=1` its absence is a gate failure.
+const WIDE_PARTITION_DATA_REL: &str =
+    "test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294/nb-2-big-Data.db";
+
 /// Resolve the committed datasets root (env override first, else workspace tree).
 fn datasets_sstables_root() -> PathBuf {
     let root = if let Ok(root) = std::env::var("CQLITE_DATASETS_ROOT") {
@@ -375,6 +391,24 @@ fn digest_crc32_byte_for_byte_parity() {
         );
 
         compared += 1;
+    }
+
+    // Fail-closed on the PINNED wide_partition fixture (issue #1185): its
+    // Digest.crc32 is now promoted `byte_for_byte` in the parity manifest and the
+    // binary is shipped in the CI dataset (v3.4). Under
+    // CQLITE_PARITY_REQUIRE_DATASETS=1 (the required "Real M5 SSTableDump parity
+    // validation" lane sets it) the absence of THIS exact Data.db must turn the
+    // lane red — it must not skip-and-green even when other fixtures are present.
+    if parity_datasets_required() {
+        let wide_data = datasets_sstables_root().join(WIDE_PARTITION_DATA_REL);
+        assert!(
+            wide_data.exists(),
+            "CQLITE_PARITY_REQUIRE_DATASETS=1 but the pinned wide_partition Data.db is absent \
+             at {} — its Digest.crc32 is promoted `byte_for_byte` and the binary is in the \
+             pinned CI dataset (v3.4); the required digest-parity lane must FAIL CLOSED here, \
+             not skip. Fetch the dataset: bash test-data/scripts/fetch-datasets.sh",
+            wide_data.display(),
+        );
     }
 
     // Skip-on-total-absence: a fresh checkout (or CI without the binary dataset

--- a/cqlite-core/tests/sstable_parity_toc_component_test.rs
+++ b/cqlite-core/tests/sstable_parity_toc_component_test.rs
@@ -54,6 +54,13 @@ fn parity_datasets_required() -> bool {
 const WIDE_PARTITION_DATA_REL: &str =
     "test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294/nb-2-big-Data.db";
 
+/// Relative path (under `datasets/sstables`) of the wide_partition `Digest.crc32`
+/// reference whose payload is now pinned `byte_for_byte` and shipped in the CI
+/// dataset (v3.4). Under `CQLITE_PARITY_REQUIRE_DATASETS=1` its absence — or its
+/// absence from the digest comparison set — is a gate failure.
+const WIDE_PARTITION_DIGEST_REL: &str =
+    "test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294/nb-2-big-Digest.crc32";
+
 /// Resolve the committed datasets root (env override first, else workspace tree).
 fn datasets_sstables_root() -> PathBuf {
     let root = if let Ok(root) = std::env::var("CQLITE_DATASETS_ROOT") {
@@ -349,9 +356,14 @@ fn render_digest_payload(crc32: u32) -> Vec<u8> {
 #[test]
 fn digest_crc32_byte_for_byte_parity() {
     let digests = all_digest_files();
+    let wide_digest = datasets_sstables_root().join(WIDE_PARTITION_DIGEST_REL);
 
     let mut compared = 0usize;
     let mut skipped_no_data = 0usize;
+    // Track whether a real digest comparison ran for the pinned wide_partition
+    // reference (FINDING 2): a present Data.db alone is not enough — the comparison
+    // must actually execute for that exact fixture.
+    let mut wide_partition_compared = false;
 
     for digest_path in &digests {
         let digest_name = digest_path
@@ -391,6 +403,9 @@ fn digest_crc32_byte_for_byte_parity() {
         );
 
         compared += 1;
+        if digest_path == &wide_digest {
+            wide_partition_compared = true;
+        }
     }
 
     // Fail-closed on the PINNED wide_partition fixture (issue #1185): its
@@ -408,6 +423,29 @@ fn digest_crc32_byte_for_byte_parity() {
              pinned CI dataset (v3.4); the required digest-parity lane must FAIL CLOSED here, \
              not skip. Fetch the dataset: bash test-data/scripts/fetch-datasets.sh",
             wide_data.display(),
+        );
+        // The Digest.crc32 reference itself must be present: if it is absent,
+        // `all_digest_files()` never sees it and no comparison runs for the pinned
+        // fixture, so strict mode would false-green on the very component being
+        // promoted `byte_for_byte` (FINDING 2).
+        assert!(
+            wide_digest.exists(),
+            "CQLITE_PARITY_REQUIRE_DATASETS=1 but the pinned wide_partition Digest.crc32 \
+             reference is absent at {} — it is promoted `byte_for_byte` and shipped in the \
+             pinned CI dataset (v3.4); without it no digest comparison runs for this fixture. \
+             The required digest-parity lane must FAIL CLOSED here, not skip. Fetch the \
+             dataset: bash test-data/scripts/fetch-datasets.sh",
+            wide_digest.display(),
+        );
+        // Both the Data.db and the Digest.crc32 exist ⇒ the comparison loop MUST
+        // have actually run a byte-for-byte digest comparison for this exact
+        // fixture. Assert it ran (not merely that the files are on disk).
+        assert!(
+            wide_partition_compared,
+            "CQLITE_PARITY_REQUIRE_DATASETS=1: the pinned wide_partition Digest.crc32 ({}) and \
+             its Data.db are both present, yet no digest comparison ran for it — the required \
+             digest-parity lane must compare the pinned fixture, not skip it.",
+            wide_digest.display(),
         );
     }
 

--- a/docs/reports/cassandra-test-parity.md
+++ b/docs/reports/cassandra-test-parity.md
@@ -10,8 +10,8 @@ Sources: [`docs/cassandra_test_index.md`](../../docs/cassandra_test_index.md) ·
 
 | Status | Scenarios |
 |---|---|
-| `mirrored` | 219 |
-| `partial` | 15 |
+| `mirrored` | 225 |
+| `partial` | 9 |
 | `planned` | 50 |
 | `out_of_scope` | 31 |
 | **total** | **315** |
@@ -22,10 +22,10 @@ _Counts are per scenario; see [Distinct test backing](#distinct-test-backing-ded
 
 | Evidence | Scenarios |
 |---|---|
-| `byte_for_byte` | 118 |
+| `byte_for_byte` | 124 |
 | `canonical_semantic` | 99 |
 | `smoke` | 7 |
-| `partial` | 58 |
+| `partial` | 52 |
 | `out_of_scope` | 33 |
 
 ## ⚠️ P0 scenarios with weak evidence
@@ -37,11 +37,6 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 - `cass.compression_checksum.checksum_trailer_detection` — Inline checksum / Digest.crc32 corruption detection (partial)
 - `cass.compression_info.deflate.real_fixture_chunks.strict` — Deflate real-fixture CompressionInfo.db + chunk parity (partial)
 - `cass.compression_info.zstd.real_fixture_chunks.strict` — Zstd real-fixture CompressionInfo.db + chunk parity (partial)
-- `cass.data_db_decode.wide_partition.row_boundaries` — Wide-partition Data.db row boundaries align with promoted-index offsets (partial)
-- `cass.index_db.RowIndexEntryTest.promoted_index_entries` — BIG Index.db promoted-index (wide-partition) boundary metadata (partial)
-- `cass.index_db.promoted_index.clustering_bounds` — BIG promoted-index IndexInfo clustering bounds ordering and coverage (partial)
-- `cass.index_db.promoted_index.index_info_offsets` — BIG promoted-index IndexInfo Data.db offsets and width chain (partial)
-- `cass.index_db.promoted_index.range_tombstone_boundary_at_block_edge` — BIG promoted-index decode across a range-tombstone block boundary (partial)
 - `cass.index_summary.column_index.range_tombstone_boundary_big_bti` — Column-index range-tombstone boundary across BIG and BTI formats (partial)
 - `cass.schema_evolution.dropped_column.empty_index_block_reverse_scan` — Dropped-column empty-index-block reverse-scan parity (partial)
 - `cass.sstable_format.descriptor_component_resolution` — Descriptor and on-disk version/component resolution (smoke)
@@ -151,7 +146,7 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 | `cass.data_db_decode.ttl.local_deletion_time_delta` | tombstone_ttl | mirrored | byte_for_byte | `compaction_parity_tombstone_ttl` | p1_correctness |
 | `cass.data_db_decode.unfiltered_serializer.row_and_cell_flags` | data_db_decode | mirrored | byte_for_byte | `sstable_parity_data_db_jsonl` | p1_correctness |
 | `cass.data_db_decode.unfiltered_serializer.row_size_vints` | data_db_decode | mirrored | byte_for_byte | `sstable_parity_data_db_jsonl` | p1_correctness |
-| `cass.data_db_decode.wide_partition.row_boundaries` | data_db_decode | partial | partial | `sstable_parity_data_db_jsonl` | p1_correctness |
+| `cass.data_db_decode.wide_partition.row_boundaries` | data_db_decode | mirrored | byte_for_byte | `sstable_parity_data_db_jsonl` | p1_correctness |
 | `cass.delta_scan.adjacent_ranges` | delta_scan | mirrored | canonical_semantic | `sstable_parity_delta_scan` | p1_correctness |
 | `cass.delta_scan.cell_tombstones` | delta_scan | mirrored | canonical_semantic | `sstable_parity_delta_scan` | p1_correctness |
 | `cass.delta_scan.collection_ops` | delta_scan | mirrored | canonical_semantic | `sstable_parity_delta_scan` | p1_correctness |
@@ -167,14 +162,14 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 | `cass.filter_db_bloom.serialization_no_false_negative` | filter_db_bloom | mirrored | byte_for_byte | `sstable_parity_filter_db_bloom` | p0_data_loss |
 | `cass.index_db.CorruptPrimaryIndexTest.big_primary_index_corruption` | index_summary | mirrored | byte_for_byte | `sstable_parity_index_db_big` | p0_data_loss |
 | `cass.index_db.RowIndexEntryTest.partition_offsets` | index_summary | mirrored | byte_for_byte | `sstable_parity_index_db_big` | p1_correctness |
-| `cass.index_db.RowIndexEntryTest.promoted_index_entries` | index_summary | partial | partial | `sstable_parity_index_db_big` | p1_correctness |
+| `cass.index_db.RowIndexEntryTest.promoted_index_entries` | index_summary | mirrored | byte_for_byte | `sstable_parity_index_db_big` | p1_correctness |
 | `cass.index_db.SSTableReaderTest.point_lookup_offsets` | index_summary | mirrored | byte_for_byte | `sstable_parity_index_db_big` | p1_correctness |
 | `cass.index_db.SSTableScannerTest.range_boundaries` | index_summary | mirrored | byte_for_byte | `sstable_parity_index_db_big` | p1_correctness |
 | `cass.index_db.big.raw_partition_keys_and_offsets` | index_summary | mirrored | byte_for_byte | `sstable_parity_index_db_big` | p1_correctness |
 | `cass.index_db.bti.index_component_discovery` | index_summary | mirrored | byte_for_byte | `sstable_parity_bti_partitions_rows` | p1_correctness |
-| `cass.index_db.promoted_index.clustering_bounds` | index_summary | partial | partial | `sstable_parity_index_db_big` | p1_correctness |
-| `cass.index_db.promoted_index.index_info_offsets` | index_summary | partial | partial | `sstable_parity_index_db_big` | p1_correctness |
-| `cass.index_db.promoted_index.range_tombstone_boundary_at_block_edge` | index_summary | partial | partial | `sstable_parity_index_db_big` | p1_correctness |
+| `cass.index_db.promoted_index.clustering_bounds` | index_summary | mirrored | byte_for_byte | `sstable_parity_index_db_big` | p1_correctness |
+| `cass.index_db.promoted_index.index_info_offsets` | index_summary | mirrored | byte_for_byte | `sstable_parity_index_db_big` | p1_correctness |
+| `cass.index_db.promoted_index.range_tombstone_boundary_at_block_edge` | index_summary | mirrored | byte_for_byte | `sstable_parity_index_db_big` | p1_correctness |
 | `cass.index_summary.big_index_offsets` | index_summary | mirrored | canonical_semantic | `sstable_parity_index_db_big` | p1_correctness |
 | `cass.index_summary.column_index.range_tombstone_boundary_big_bti` | index_summary | partial | partial | `sstable_parity_index_db_big` | p1_correctness |
 | `cass.index_summary.summary_boundaries` | index_summary | mirrored | byte_for_byte | `sstable_parity_summary_db_big` | p1_correctness |
@@ -345,6 +340,7 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
   - Normalization: Flag bytes are compared as raw u8 values at their exact wire offset; the fixture lane additionally checks every leading flag byte stays within the known UnfilteredSerializer row-flag mask (FAIL CLOSED on a missing fixture).
 - `cass.data_db_decode.unfiltered_serializer.row_size_vints` — Data.db row-size and previous-size VInt framing parity
   - Normalization: row_size/prev_size are unsigned VInt deltas; the deterministic lane compares raw encoded bytes and decoded values at the exact width boundaries, the fixture lane compares the framing offsets of a real nb Data.db (FAIL CLOSED on a missing fixture).
+- `cass.data_db_decode.wide_partition.row_boundaries` — Wide-partition Data.db row boundaries align with promoted-index offsets
 - `cass.filter_db.corruption_fails_closed` — Filter.db malformed-byte rejection (fail-closed)
 - `cass.filter_db.no_false_negative_membership` — Filter.db no-false-negative membership over Cassandra present keys
   - Normalization: Present keys are the raw partition-key bytes from Index.db (not the decoded CQL values), matching the bytes Cassandra's Murmur3 hashed into Filter.db. The reference_paths point at the committed per-fixture Data.db.jsonl siblings (the binary Filter.db and Index.db are gitignored, fetched on demand).
@@ -354,11 +350,16 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 - `cass.index_db.CorruptPrimaryIndexTest.big_primary_index_corruption` — Truncated BIG Index.db fails explicitly
 - `cass.index_db.RowIndexEntryTest.partition_offsets` — BIG Index.db partition data offsets vs Cassandra positions
   - Normalization: Index.db data offsets are relative to the Data.db data section while JSONL positions are absolute file offsets; the per-partition Data.db header is a constant only for uniform partition-key lengths without static blocks, so successive deltas (not absolute values) are compared in that case.
+- `cass.index_db.RowIndexEntryTest.promoted_index_entries` — BIG Index.db promoted-index (wide-partition) boundary metadata
 - `cass.index_db.SSTableReaderTest.point_lookup_offsets` — BIG Index.db point/absent-key lookup offsets
 - `cass.index_db.SSTableScannerTest.range_boundaries` — BIG Index.db key order and range boundaries
 - `cass.index_db.big.raw_partition_keys_and_offsets` — BIG Index.db raw partition-key bytes and entry-byte parity
   - Normalization: JSONL single-column partition keys are decoded to their raw on-disk byte encoding (UUID text -> 16 bytes) before comparison; composite-key byte decoding is not attempted (those fixtures are covered by entry-byte + count + offset parity).
+- `cass.index_db.big.wide_partition_promoted_entries` — BIG Index.db wide-partition promoted entries
 - `cass.index_db.bti.index_component_discovery` — BTI index-component discovery and classification
+- `cass.index_db.promoted_index.clustering_bounds` — BIG promoted-index IndexInfo clustering bounds ordering and coverage
+- `cass.index_db.promoted_index.index_info_offsets` — BIG promoted-index IndexInfo Data.db offsets and width chain
+- `cass.index_db.promoted_index.range_tombstone_boundary_at_block_edge` — BIG promoted-index decode across a range-tombstone block boundary
 - `cass.index_summary.summary_boundaries` — Summary.db sampling boundaries (BIG)
 - `cass.repaired_metadata.statistics_db.repaired_at_field` — Statistics.db repairedAt field decode + report parity (unrepaired state)
 - `cass.schema_evolution.serialization_header.altered_column_type` — Serialization-header parity after ALTER column type
@@ -714,17 +715,11 @@ Scenario counts above can overstate distinct proof: one backing test may exercis
 - `cass.compression_info.zstd.real_fixture_chunks.strict` (planned): No real Cassandra Zstd-compressed fixture in the corpus (non-dictionary). → _Generate a non-dictionary ZstdCompressor SSTable fixture via issue #996 (epic #970); the strict lane will then decode and round-trip it._
 - `cass.corruption.bti_partitions_footer_bit_flip` (planned): Clean BTI source (test_da/wide_table Partitions.db) is not git-tracked, so the corrupted fixture cannot be regenerated by CI. → _Commit the clean test_da/wide_table BTI components (or add them to the published dataset bundle) so generate-corruption-corpus.sh can emit the corrupted Partitions.db, then flip status to mirrored._
 - `cass.corruption.bti_rows_truncation` (planned): Clean BTI source (test_da/wide_table Rows.db) is not git-tracked, so the truncated fixture cannot be regenerated by CI. → _Commit the clean test_da/wide_table BTI components so generate-corruption-corpus.sh can emit the truncated Rows.db, then flip status to mirrored._
-- `cass.data_db_decode.wide_partition.row_boundaries` (partial): This scenario's proving evidence is the byte-level Index.db promoted-index decode (offsets, widths, clustering bounds), which SKIPS in CI because the test_big/wide_partition binaries are not in the pinned dataset (issue #1185 in progress). Marking it required_parity would report coverage for a check that does not run; the only CI-running assertion in this test binary is the JSONL canonical-semantic check, which does not decode the promoted index and so does not satisfy this scenario's evidence on its own. → _Re-promote to required_parity once issue #1185 pins the test_big.wide_partition binaries into the CI dataset (regenerate the tarball + update DATASET_SHA256) so the byte-level promoted-index assertions actually run fail-closed._
 - `cass.delta_scan.wide_partition_corpus` (planned): No test_deltas wide-partition delete fixture; wide partitions are produced by the wide-row corpus (epic #993), not generate-deltas.sh. Byte-for-byte backing for delta_scan remains tracked by epic #969. → _Add a wide-partition delete shape (or reuse a wide-row corpus fixture) and a paired test_delta_parity_wide_partition test under epic #993._
 - `cass.filter_db.bti_membership` (partial): No raw-partition-key source for BTI fixtures, so the no-false-negative probe cannot run against da Filter.db. → _Recover raw BTI partition keys (e.g. by decoding partitions during a Data.db scan) and extend the no-false-negative gate to cover da fixtures._
 - `cass.filter_db.statistical_false_positive_rate` (planned): No gated comparison of measured FPR against Cassandra's configured bloom_filter_fp_chance. → _Add larger-cardinality fixtures and assert the measured FPR tracks the configured fp_chance within a documented statistical tolerance._
 - `cass.filter_db_bloom.SerializationsTest.bloom_filter_deserialization` (planned): No dedicated fixture mirrors the bloom-filter serialization round-trip cases from SerializationsTest. → _Commission bloom-filter serialization fixtures and assert deserialized membership goldens._
-- `cass.index_db.RowIndexEntryTest.promoted_index_entries` (partial): This scenario's proving evidence is the byte-level Index.db promoted-index decode (offsets, widths, clustering bounds), which SKIPS in CI because the test_big/wide_partition binaries are not in the pinned dataset (issue #1185 in progress). Marking it required_parity would report coverage for a check that does not run; the only CI-running assertion in this test binary is the JSONL canonical-semantic check, which does not decode the promoted index and so does not satisfy this scenario's evidence on its own. → _Re-promote to required_parity once issue #1185 pins the test_big.wide_partition binaries into the CI dataset (regenerate the tarball + update DATASET_SHA256) so the byte-level promoted-index assertions actually run fail-closed._
 - `cass.index_db.RowIndexTest.row_index_sort_order` (planned): No dedicated fixture mirrors the RowIndex out-of-order / duplicate-key cases. → _Commission RowIndex fixtures with out-of-order/duplicate keys and assert offset/order goldens._
-- `cass.index_db.big.wide_partition_promoted_entries` (partial): This scenario's proving evidence is the byte-level Index.db promoted-index decode (offsets, widths, clustering bounds), which SKIPS in CI because the test_big/wide_partition binaries are not in the pinned dataset (issue #1185 in progress). Marking it required_parity would report coverage for a check that does not run; the only CI-running assertion in this test binary is the JSONL canonical-semantic check, which does not decode the promoted index and so does not satisfy this scenario's evidence on its own. → _Re-promote to required_parity once issue #1185 pins the test_big.wide_partition binaries into the CI dataset (regenerate the tarball + update DATASET_SHA256) so the byte-level promoted-index assertions actually run fail-closed._
-- `cass.index_db.promoted_index.clustering_bounds` (partial): This scenario's proving evidence is the byte-level Index.db promoted-index decode across the range-tombstone block edge, which SKIPS in CI because the test_big/wide_partition binaries are not in the pinned dataset (issue #1185 in progress). The CI-running JSONL canonical-semantic check does assert pk=1 is missing exactly ck 30..39 (the range-tombstone fact), but it does NOT decode the promoted index across the block boundary — the headline claim of this scenario — so the running part alone does not justify required_parity. → _Re-promote to required_parity once issue #1185 pins the test_big.wide_partition binaries into the CI dataset (regenerate the tarball + update DATASET_SHA256) so the byte-level promoted-index block-edge assertions actually run fail-closed._
-- `cass.index_db.promoted_index.index_info_offsets` (partial): This scenario's proving evidence is the byte-level Index.db promoted-index decode (offsets, widths, clustering bounds), which SKIPS in CI because the test_big/wide_partition binaries are not in the pinned dataset (issue #1185 in progress). Marking it required_parity would report coverage for a check that does not run; the only CI-running assertion in this test binary is the JSONL canonical-semantic check, which does not decode the promoted index and so does not satisfy this scenario's evidence on its own. → _Re-promote to required_parity once issue #1185 pins the test_big.wide_partition binaries into the CI dataset (regenerate the tarball + update DATASET_SHA256) so the byte-level promoted-index assertions actually run fail-closed._
-- `cass.index_db.promoted_index.range_tombstone_boundary_at_block_edge` (partial): This scenario's proving evidence is the byte-level Index.db promoted-index decode (offsets, widths, clustering bounds), which SKIPS in CI because the test_big/wide_partition binaries are not in the pinned dataset (issue #1185 in progress). Marking it required_parity would report coverage for a check that does not run; the only CI-running assertion in this test binary is the JSONL canonical-semantic check, which does not decode the promoted index and so does not satisfy this scenario's evidence on its own. → _Re-promote to required_parity once issue #1185 pins the test_big.wide_partition binaries into the CI dataset (regenerate the tarball + update DATASET_SHA256) so the byte-level promoted-index assertions actually run fail-closed._
 - `cass.index_summary.column_index.range_tombstone_boundary_big_bti` (partial): BTI (da) range-tombstone-at-block-edge fixtures are not yet generated (no da tombstone generator). → _Add a da/BTI wide-partition range-tombstone fixture generator and assert BTI column-index boundary parity; file a follow-up issue._
 - `cass.repair.PendingAntiCompactionTest.pending_repair_metadata` (partial): No SSTable carrying a real pendingRepair session UUID exists in the corpus; such a file is produced only by an in-flight incremental repair / PendingAntiCompaction on a live cluster. The UUID parse/preserve/reject path is proven via synthetic bytes + a writer round-trip. → _Commission a live-cluster PendingAntiCompaction fixture (an SSTable with a real pendingRepair UUID) + sstablemetadata goldens, then assert the decoded UUID against the reference to promote to mirrored._
 - `cass.repaired_metadata.statistics_db.pending_repair_uuid` (planned): No Cassandra 5.0 pending-repair fixture available; the reference null (`Pending repair: --`) state is confirmed, and the read path reports the field as Unparsed (it is not walked from bytes) rather than a fabricated absent value. → _When a pending-repair fixture is generated, decode the pendingRepair UUID (type-aware skip past improvedMinMax + commitLogIntervals) — promoting the field from RepairField::Unparsed to Decoded — and assert it byte-for-byte against the `Pending repair: <uuid>` reference line._
@@ -1020,7 +1015,7 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.data_db_decode.ttl.local_deletion_time_delta` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.data_db_decode.unfiltered_serializer.row_and_cell_flags` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.data_db_decode.unfiltered_serializer.row_size_vints` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
-| `cass.data_db_decode.wide_partition.row_boundaries` | manual_debug | — |
+| `cass.data_db_decode.wide_partition.row_boundaries` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.delta_scan.adjacent_ranges` | manual_debug | — |
 | `cass.delta_scan.cell_tombstones` | manual_debug | — |
 | `cass.delta_scan.collection_ops` | manual_debug | — |
@@ -1041,16 +1036,16 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.filter_db_bloom.serialization_no_false_negative` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.index_db.CorruptPrimaryIndexTest.big_primary_index_corruption` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.index_db.RowIndexEntryTest.partition_offsets` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
-| `cass.index_db.RowIndexEntryTest.promoted_index_entries` | manual_debug | — |
+| `cass.index_db.RowIndexEntryTest.promoted_index_entries` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.index_db.RowIndexTest.row_index_sort_order` | manual_debug | — |
 | `cass.index_db.SSTableReaderTest.point_lookup_offsets` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.index_db.SSTableScannerTest.range_boundaries` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.index_db.big.raw_partition_keys_and_offsets` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
-| `cass.index_db.big.wide_partition_promoted_entries` | manual_debug | — |
+| `cass.index_db.big.wide_partition_promoted_entries` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.index_db.bti.index_component_discovery` | manual_debug | — |
-| `cass.index_db.promoted_index.clustering_bounds` | manual_debug | — |
-| `cass.index_db.promoted_index.index_info_offsets` | manual_debug | — |
-| `cass.index_db.promoted_index.range_tombstone_boundary_at_block_edge` | manual_debug | — |
+| `cass.index_db.promoted_index.clustering_bounds` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
+| `cass.index_db.promoted_index.index_info_offsets` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
+| `cass.index_db.promoted_index.range_tombstone_boundary_at_block_edge` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.index_summary.big_index_offsets` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.index_summary.column_index.range_tombstone_boundary_big_bti` | nightly_docker | .github/workflows/tombstone-ttl-parity.yml |
 | `cass.index_summary.summary_boundaries` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
@@ -1340,7 +1335,7 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.data_db_decode.ttl.local_deletion_time_delta` | nb, oa | test-data/datasets/sstables/test_deltas/ttl_cells-299c9220701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/data-db-ttl-delta-diff.log |
 | `cass.data_db_decode.unfiltered_serializer.row_and_cell_flags` | nb, oa | test-data/datasets/sstables/test_basic/uncompressed_table-6aedb7a0a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/data-db-flag-diff.log |
 | `cass.data_db_decode.unfiltered_serializer.row_size_vints` | nb, oa | test-data/datasets/sstables/test_basic/uncompressed_table-6aedb7a0a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/data-db-row-framing-diff.log |
-| `cass.data_db_decode.wide_partition.row_boundaries` | nb | test-data/datasets/sstables/test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294/nb-2-big-Data.db.jsonl |
+| `cass.data_db_decode.wide_partition.row_boundaries` | nb | test-data/datasets/sstables/test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294/nb-2-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/wide-partition-promoted-index-diff.log |
 | `cass.delta_scan.adjacent_ranges` | nb | test-data/datasets/sstables/test_deltas/adjacent_ranges-29bdd5c0701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl |
 | `cass.delta_scan.cell_tombstones` | nb | test-data/datasets/sstables/test_deltas/cell_tombstones-29733830701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl |
 | `cass.delta_scan.collection_ops` | nb | test-data/datasets/sstables/test_deltas/collection_ops-2a5006f06c2a11f18135b3f5f7fa4418/nb-1-big-Data.db.jsonl |
@@ -1361,16 +1356,16 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.filter_db_bloom.serialization_no_false_negative` | nb, oa | test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>test-data/datasets/sstables/test_basic/composite_key_table-6ab56990a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/filter-db-false-negative.log |
 | `cass.index_db.CorruptPrimaryIndexTest.big_primary_index_corruption` | nb, oa | test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/index-db-diff.log |
 | `cass.index_db.RowIndexEntryTest.partition_offsets` | nb, oa | test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/index-db-diff.log |
-| `cass.index_db.RowIndexEntryTest.promoted_index_entries` | nb | test-data/datasets/sstables/test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294/nb-2-big-Data.db.jsonl |
+| `cass.index_db.RowIndexEntryTest.promoted_index_entries` | nb | test-data/datasets/sstables/test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294/nb-2-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/wide-partition-promoted-index-diff.log |
 | `cass.index_db.RowIndexTest.row_index_sort_order` | nb, oa, big | — |
 | `cass.index_db.SSTableReaderTest.point_lookup_offsets` | nb, oa | test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/index-db-diff.log |
 | `cass.index_db.SSTableScannerTest.range_boundaries` | nb, oa | test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/index-db-diff.log |
 | `cass.index_db.big.raw_partition_keys_and_offsets` | nb, oa | test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>test-data/datasets/sstables/test_oa/collection_table-4b892c6064e711f1bd3ac7dbf655c673/oa-2-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/index-db-diff.log |
-| `cass.index_db.big.wide_partition_promoted_entries` | nb | test-data/datasets/sstables/test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294/nb-2-big-Data.db.jsonl |
+| `cass.index_db.big.wide_partition_promoted_entries` | nb | test-data/datasets/sstables/test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294/nb-2-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/wide-partition-promoted-index-diff.log |
 | `cass.index_db.bti.index_component_discovery` | da | test-data/datasets/sstables/test_da/simple_table-de1be8b064e711f19ad401a8c8227b11/da-2-bti-TOC.txt<br>_fail:_ target/cassandra-parity/index-db-diff.log |
-| `cass.index_db.promoted_index.clustering_bounds` | nb | test-data/datasets/sstables/test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294/nb-2-big-Data.db.jsonl |
-| `cass.index_db.promoted_index.index_info_offsets` | nb | test-data/datasets/sstables/test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294/nb-2-big-Data.db.jsonl |
-| `cass.index_db.promoted_index.range_tombstone_boundary_at_block_edge` | nb | test-data/datasets/sstables/test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294/nb-2-big-Data.db.jsonl |
+| `cass.index_db.promoted_index.clustering_bounds` | nb | test-data/datasets/sstables/test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294/nb-2-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/wide-partition-promoted-index-diff.log |
+| `cass.index_db.promoted_index.index_info_offsets` | nb | test-data/datasets/sstables/test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294/nb-2-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/wide-partition-promoted-index-diff.log |
+| `cass.index_db.promoted_index.range_tombstone_boundary_at_block_edge` | nb | test-data/datasets/sstables/test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294/nb-2-big-Data.db.jsonl<br>_fail:_ target/cassandra-parity/wide-partition-promoted-index-diff.log |
 | `cass.index_summary.big_index_offsets` | nb | test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl |
 | `cass.index_summary.column_index.range_tombstone_boundary_big_bti` | nb | test-data/datasets/sstables/test_tomb/wide_range_tombstone-4ce3add0702011f1b8f419c9a388d558/nb-1-big-Statistics.db.txt |
 | `cass.index_summary.summary_boundaries` | nb, oa, big | test-data/datasets/sstables/test_timeseries/app_metrics-6c87b890a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>_fail:_ validation_artifacts/sstabledump/summary/summary_parity_report.md |

--- a/docs/runbooks/1099-dataset-republish.md
+++ b/docs/runbooks/1099-dataset-republish.md
@@ -60,7 +60,7 @@ env CQLITE_REQUIRE_FIXTURES=1 CQLITE_DATASETS_ROOT="$CQLITE_DATASETS_ROOT" \
 binaries, and writes `<archive>.sha256`:
 
 ```bash
-ASSET=cassandra5-small-full-v3.3.tar.gz
+ASSET=cassandra5-small-full-v3.4.tar.gz
 ASSET_NAME="$ASSET" test-data/scripts/package_datasets.sh \
   --type full --asset-name "$ASSET" --tag datasets-v3
 
@@ -98,7 +98,7 @@ test-data/scripts/bump-dataset-pin.sh --new-sha <sha256-from-step-2>
 
 # Stage everything the finalizer touched (workflows AND the fetch helper):
 git add .github/workflows test-data/scripts/fetch-datasets.sh
-git commit -m "ci: pin dataset asset to cassandra5-small-full-v3.3 (#1099)"
+git commit -m "ci: pin dataset asset to cassandra5-small-full-v3.4 (#1099)"
 git push -u origin chore/1099-bump-dataset-pin-v3.2
 gh pr create --base main --fill
 ```

--- a/docs/runbooks/1099-dataset-republish.md
+++ b/docs/runbooks/1099-dataset-republish.md
@@ -60,7 +60,7 @@ env CQLITE_REQUIRE_FIXTURES=1 CQLITE_DATASETS_ROOT="$CQLITE_DATASETS_ROOT" \
 binaries, and writes `<archive>.sha256`:
 
 ```bash
-ASSET=cassandra5-small-full-v3.2.tar.gz
+ASSET=cassandra5-small-full-v3.3.tar.gz
 ASSET_NAME="$ASSET" test-data/scripts/package_datasets.sh \
   --type full --asset-name "$ASSET" --tag datasets-v3
 
@@ -98,7 +98,7 @@ test-data/scripts/bump-dataset-pin.sh --new-sha <sha256-from-step-2>
 
 # Stage everything the finalizer touched (workflows AND the fetch helper):
 git add .github/workflows test-data/scripts/fetch-datasets.sh
-git commit -m "ci: pin dataset asset to cassandra5-small-full-v3.2 (#1099)"
+git commit -m "ci: pin dataset asset to cassandra5-small-full-v3.3 (#1099)"
 git push -u origin chore/1099-bump-dataset-pin-v3.2
 gh pr create --base main --fill
 ```

--- a/test-data/cassandra-parity-manifest.yml
+++ b/test-data/cassandra-parity-manifest.yml
@@ -1435,7 +1435,7 @@ scenarios:
       fixture_generation_command: >-
         bash test-data/scripts/gen-wide-big.sh
       comparison_command: >-
-        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        env CQLITE_PARITY_REQUIRE_DATASETS=1 CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
         --features write-support --test issue_993_wide_partition_promoted_index_parity
         row_boundaries_index_info_offsets
       reference_paths:
@@ -1694,7 +1694,7 @@ scenarios:
       fixture_generation_command: >-
         bash test-data/scripts/gen-wide-big.sh
       comparison_command: >-
-        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        env CQLITE_PARITY_REQUIRE_DATASETS=1 CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
         --features write-support --test issue_993_wide_partition_promoted_index_parity
         row_boundaries_index_info_offsets
       reference_paths:
@@ -1746,7 +1746,7 @@ scenarios:
       fixture_generation_command: >-
         bash test-data/scripts/gen-wide-big.sh
       comparison_command: >-
-        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        env CQLITE_PARITY_REQUIRE_DATASETS=1 CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
         --features write-support --test issue_993_wide_partition_promoted_index_parity
         row_boundaries_index_info_offsets
       reference_paths:
@@ -1797,7 +1797,7 @@ scenarios:
       fixture_generation_command: >-
         bash test-data/scripts/gen-wide-big.sh
       comparison_command: >-
-        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        env CQLITE_PARITY_REQUIRE_DATASETS=1 CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
         --features write-support --test issue_993_wide_partition_promoted_index_parity
         row_boundaries_index_info_offsets
       reference_paths:
@@ -1850,7 +1850,7 @@ scenarios:
       fixture_generation_command: >-
         bash test-data/scripts/gen-wide-big.sh
       comparison_command: >-
-        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        env CQLITE_PARITY_REQUIRE_DATASETS=1 CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
         --features write-support --test issue_993_wide_partition_promoted_index_parity
         clustering_bounds
       reference_paths:
@@ -1903,7 +1903,7 @@ scenarios:
       fixture_generation_command: >-
         bash test-data/scripts/gen-wide-big.sh
       comparison_command: >-
-        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        env CQLITE_PARITY_REQUIRE_DATASETS=1 CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
         --features write-support --test issue_993_wide_partition_promoted_index_parity
         range_tombstone_boundary_at_block_edge
       reference_paths:

--- a/test-data/cassandra-parity-manifest.yml
+++ b/test-data/cassandra-parity-manifest.yml
@@ -1402,7 +1402,7 @@ scenarios:
 
   - id: cass.index_db.RowIndexEntryTest.promoted_index_entries
     title: BIG Index.db promoted-index (wide-partition) boundary metadata
-    status: partial
+    status: mirrored
     capability: index_summary
     priority: P0
     risk: p1_correctness
@@ -1426,39 +1426,31 @@ scenarios:
       references:
         - test-data/datasets/sstables/test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294/nb-2-big-Data.db.jsonl
     evidence:
-      type: partial
+      type: byte_for_byte
+      strict: true
       artifacts: [bytes, offsets]
       cassandra_version: "5.0.2"
       cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
       storage_format_version: [nb]
       fixture_generation_command: >-
         bash test-data/scripts/gen-wide-big.sh
+      comparison_command: >-
+        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        --features write-support --test issue_993_wide_partition_promoted_index_parity
+        row_boundaries_index_info_offsets
       reference_paths:
         - test-data/datasets/sstables/test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294/nb-2-big-Data.db.jsonl
+      failure_artifacts:
+        - target/cassandra-parity/wide-partition-promoted-index-diff.log
       known_limitations: >-
-        The BIG promoted IndexInfo[] decode is implemented and proven byte-for-byte
-        LOCALLY against the real Cassandra wide-partition fixture (see
-        cqlite-core/tests/issue_993_wide_partition_promoted_index_parity.rs). The
-        committed-JSONL canonical-semantic checks (3 partitions, live counts
-        290/300/300, pk=1 missing exactly ck 30..39, ascending clustering) ARE
-        enforced in the required CI lane on every run; the byte-level Index.db
-        promoted-offset/bounds assertions are NOT in the required lane because they
-        depend on local-only binaries absent from the pinned CI dataset.
+        Byte-level promoted-index parity now runs fail-closed in the required lane:
+        issue #1185 pins the test_big.wide_partition binaries into the CI dataset.
+        Validation is scoped to the single-int clustering schema, where the on-disk
+        clustering prefix length (6 bytes) is unambiguous.
     ci:
-      tier: manual_debug
-    scope:
-      gap: >-
-        This scenario's proving evidence is the byte-level Index.db promoted-index
-        decode (offsets, widths, clustering bounds), which SKIPS in CI because the
-        test_big/wide_partition binaries are not in the pinned dataset (issue #1185
-        in progress). Marking it required_parity would report coverage for a check
-        that does not run; the only CI-running assertion in this test binary is the
-        JSONL canonical-semantic check, which does not decode the promoted index and
-        so does not satisfy this scenario's evidence on its own.
-      next_step: >-
-        Re-promote to required_parity once issue #1185 pins the test_big.wide_partition
-        binaries into the CI dataset (regenerate the tarball + update DATASET_SHA256)
-        so the byte-level promoted-index assertions actually run fail-closed.
+      tier: required_parity
+      workflow: .github/workflows/sstabledump-parity-gate.yml
+    scope: {}
 
   - id: cass.index_db.SSTableReaderTest.point_lookup_offsets
     title: BIG Index.db point/absent-key lookup offsets
@@ -1667,7 +1659,7 @@ scenarios:
 
   - id: cass.index_db.big.wide_partition_promoted_entries
     title: BIG Index.db wide-partition promoted entries
-    status: partial
+    status: mirrored
     capability: index_summary
     priority: P1
     risk: p1_correctness
@@ -1693,43 +1685,35 @@ scenarios:
       references:
         - test-data/datasets/sstables/test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294/nb-2-big-Data.db.jsonl
     evidence:
-      type: partial
+      type: byte_for_byte
+      strict: true
       artifacts: [bytes, offsets]
       cassandra_version: "5.0.2"
       cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
       storage_format_version: [nb]
       fixture_generation_command: >-
         bash test-data/scripts/gen-wide-big.sh
+      comparison_command: >-
+        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        --features write-support --test issue_993_wide_partition_promoted_index_parity
+        row_boundaries_index_info_offsets
       reference_paths:
         - test-data/datasets/sstables/test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294/nb-2-big-Data.db.jsonl
+      failure_artifacts:
+        - target/cassandra-parity/wide-partition-promoted-index-diff.log
       known_limitations: >-
-        The BIG promoted IndexInfo[] decode is implemented and proven byte-for-byte
-        LOCALLY against the real Cassandra wide-partition fixture (see
-        cqlite-core/tests/issue_993_wide_partition_promoted_index_parity.rs). The
-        committed-JSONL canonical-semantic checks (3 partitions, live counts
-        290/300/300, pk=1 missing exactly ck 30..39, ascending clustering) ARE
-        enforced in the required CI lane on every run; the byte-level Index.db
-        promoted-offset/bounds assertions are NOT in the required lane because they
-        depend on local-only binaries absent from the pinned CI dataset.
+        Byte-level promoted-index parity now runs fail-closed in the required lane:
+        issue #1185 pins the test_big.wide_partition binaries into the CI dataset.
+        Validation is scoped to the single-int clustering schema, where the on-disk
+        clustering prefix length (6 bytes) is unambiguous.
     ci:
-      tier: manual_debug
-    scope:
-      gap: >-
-        This scenario's proving evidence is the byte-level Index.db promoted-index
-        decode (offsets, widths, clustering bounds), which SKIPS in CI because the
-        test_big/wide_partition binaries are not in the pinned dataset (issue #1185
-        in progress). Marking it required_parity would report coverage for a check
-        that does not run; the only CI-running assertion in this test binary is the
-        JSONL canonical-semantic check, which does not decode the promoted index and
-        so does not satisfy this scenario's evidence on its own.
-      next_step: >-
-        Re-promote to required_parity once issue #1185 pins the test_big.wide_partition
-        binaries into the CI dataset (regenerate the tarball + update DATASET_SHA256)
-        so the byte-level promoted-index assertions actually run fail-closed.
+      tier: required_parity
+      workflow: .github/workflows/sstabledump-parity-gate.yml
+    scope: {}
 
   - id: cass.data_db_decode.wide_partition.row_boundaries
     title: Wide-partition Data.db row boundaries align with promoted-index offsets
-    status: partial
+    status: mirrored
     capability: data_db_decode
     priority: P0
     risk: p1_correctness
@@ -1753,43 +1737,35 @@ scenarios:
       references:
         - test-data/datasets/sstables/test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294/nb-2-big-Data.db.jsonl
     evidence:
-      type: partial
+      type: byte_for_byte
+      strict: true
       artifacts: [bytes, offsets, jsonl]
       cassandra_version: "5.0.2"
       cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
       storage_format_version: [nb]
       fixture_generation_command: >-
         bash test-data/scripts/gen-wide-big.sh
+      comparison_command: >-
+        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        --features write-support --test issue_993_wide_partition_promoted_index_parity
+        row_boundaries_index_info_offsets
       reference_paths:
         - test-data/datasets/sstables/test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294/nb-2-big-Data.db.jsonl
+      failure_artifacts:
+        - target/cassandra-parity/wide-partition-promoted-index-diff.log
       known_limitations: >-
-        The BIG promoted IndexInfo[] decode is implemented and proven byte-for-byte
-        LOCALLY against the real Cassandra wide-partition fixture (see
-        cqlite-core/tests/issue_993_wide_partition_promoted_index_parity.rs). The
-        committed-JSONL canonical-semantic checks (3 partitions, live counts
-        290/300/300, pk=1 missing exactly ck 30..39, ascending clustering) ARE
-        enforced in the required CI lane on every run; the byte-level Index.db
-        promoted-offset/bounds assertions are NOT in the required lane because they
-        depend on local-only binaries absent from the pinned CI dataset.
+        Byte-level promoted-index parity now runs fail-closed in the required lane:
+        issue #1185 pins the test_big.wide_partition binaries into the CI dataset.
+        Validation is scoped to the single-int clustering schema, where the on-disk
+        clustering prefix length (6 bytes) is unambiguous.
     ci:
-      tier: manual_debug
-    scope:
-      gap: >-
-        This scenario's proving evidence is the byte-level Index.db promoted-index
-        decode (offsets, widths, clustering bounds), which SKIPS in CI because the
-        test_big/wide_partition binaries are not in the pinned dataset (issue #1185
-        in progress). Marking it required_parity would report coverage for a check
-        that does not run; the only CI-running assertion in this test binary is the
-        JSONL canonical-semantic check, which does not decode the promoted index and
-        so does not satisfy this scenario's evidence on its own.
-      next_step: >-
-        Re-promote to required_parity once issue #1185 pins the test_big.wide_partition
-        binaries into the CI dataset (regenerate the tarball + update DATASET_SHA256)
-        so the byte-level promoted-index assertions actually run fail-closed.
+      tier: required_parity
+      workflow: .github/workflows/sstabledump-parity-gate.yml
+    scope: {}
 
   - id: cass.index_db.promoted_index.index_info_offsets
     title: BIG promoted-index IndexInfo Data.db offsets and width chain
-    status: partial
+    status: mirrored
     capability: index_summary
     priority: P0
     risk: p1_correctness
@@ -1812,43 +1788,35 @@ scenarios:
       references:
         - test-data/datasets/sstables/test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294/nb-2-big-Data.db.jsonl
     evidence:
-      type: partial
+      type: byte_for_byte
+      strict: true
       artifacts: [bytes, offsets]
       cassandra_version: "5.0.2"
       cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
       storage_format_version: [nb]
       fixture_generation_command: >-
         bash test-data/scripts/gen-wide-big.sh
+      comparison_command: >-
+        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        --features write-support --test issue_993_wide_partition_promoted_index_parity
+        row_boundaries_index_info_offsets
       reference_paths:
         - test-data/datasets/sstables/test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294/nb-2-big-Data.db.jsonl
+      failure_artifacts:
+        - target/cassandra-parity/wide-partition-promoted-index-diff.log
       known_limitations: >-
-        The BIG promoted IndexInfo[] decode is implemented and proven byte-for-byte
-        LOCALLY against the real Cassandra wide-partition fixture (see
-        cqlite-core/tests/issue_993_wide_partition_promoted_index_parity.rs). The
-        committed-JSONL canonical-semantic checks (3 partitions, live counts
-        290/300/300, pk=1 missing exactly ck 30..39, ascending clustering) ARE
-        enforced in the required CI lane on every run; the byte-level Index.db
-        promoted-offset/bounds assertions are NOT in the required lane because they
-        depend on local-only binaries absent from the pinned CI dataset.
+        Byte-level promoted-index parity now runs fail-closed in the required lane:
+        issue #1185 pins the test_big.wide_partition binaries into the CI dataset.
+        Validation is scoped to the single-int clustering schema, where the on-disk
+        clustering prefix length (6 bytes) is unambiguous.
     ci:
-      tier: manual_debug
-    scope:
-      gap: >-
-        This scenario's proving evidence is the byte-level Index.db promoted-index
-        decode (offsets, widths, clustering bounds), which SKIPS in CI because the
-        test_big/wide_partition binaries are not in the pinned dataset (issue #1185
-        in progress). Marking it required_parity would report coverage for a check
-        that does not run; the only CI-running assertion in this test binary is the
-        JSONL canonical-semantic check, which does not decode the promoted index and
-        so does not satisfy this scenario's evidence on its own.
-      next_step: >-
-        Re-promote to required_parity once issue #1185 pins the test_big.wide_partition
-        binaries into the CI dataset (regenerate the tarball + update DATASET_SHA256)
-        so the byte-level promoted-index assertions actually run fail-closed.
+      tier: required_parity
+      workflow: .github/workflows/sstabledump-parity-gate.yml
+    scope: {}
 
   - id: cass.index_db.promoted_index.clustering_bounds
     title: BIG promoted-index IndexInfo clustering bounds ordering and coverage
-    status: partial
+    status: mirrored
     capability: index_summary
     priority: P0
     risk: p1_correctness
@@ -1873,43 +1841,35 @@ scenarios:
       references:
         - test-data/datasets/sstables/test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294/nb-2-big-Data.db.jsonl
     evidence:
-      type: partial
+      type: byte_for_byte
+      strict: true
       artifacts: [bytes, offsets]
       cassandra_version: "5.0.2"
       cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
       storage_format_version: [nb]
       fixture_generation_command: >-
         bash test-data/scripts/gen-wide-big.sh
+      comparison_command: >-
+        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        --features write-support --test issue_993_wide_partition_promoted_index_parity
+        clustering_bounds
       reference_paths:
         - test-data/datasets/sstables/test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294/nb-2-big-Data.db.jsonl
+      failure_artifacts:
+        - target/cassandra-parity/wide-partition-promoted-index-diff.log
       known_limitations: >-
-        The BIG promoted IndexInfo[] decode is implemented and proven byte-for-byte
-        LOCALLY against the real Cassandra wide-partition fixture (see
-        cqlite-core/tests/issue_993_wide_partition_promoted_index_parity.rs). The
-        committed-JSONL canonical-semantic checks (3 partitions, live counts
-        290/300/300, pk=1 missing exactly ck 30..39, ascending clustering) ARE
-        enforced in the required CI lane on every run; the byte-level Index.db
-        promoted-offset/bounds assertions are NOT in the required lane because they
-        depend on local-only binaries absent from the pinned CI dataset.
+        Byte-level promoted-index parity now runs fail-closed in the required lane:
+        issue #1185 pins the test_big.wide_partition binaries into the CI dataset.
+        Validation is scoped to the single-int clustering schema, where the on-disk
+        clustering prefix length (6 bytes) is unambiguous.
     ci:
-      tier: manual_debug
-    scope:
-      gap: >-
-        This scenario's proving evidence is the byte-level Index.db promoted-index
-        decode across the range-tombstone block edge, which SKIPS in CI because the
-        test_big/wide_partition binaries are not in the pinned dataset (issue #1185
-        in progress). The CI-running JSONL canonical-semantic check does assert pk=1
-        is missing exactly ck 30..39 (the range-tombstone fact), but it does NOT
-        decode the promoted index across the block boundary — the headline claim of
-        this scenario — so the running part alone does not justify required_parity.
-      next_step: >-
-        Re-promote to required_parity once issue #1185 pins the test_big.wide_partition
-        binaries into the CI dataset (regenerate the tarball + update DATASET_SHA256)
-        so the byte-level promoted-index block-edge assertions actually run fail-closed.
+      tier: required_parity
+      workflow: .github/workflows/sstabledump-parity-gate.yml
+    scope: {}
 
   - id: cass.index_db.promoted_index.range_tombstone_boundary_at_block_edge
     title: BIG promoted-index decode across a range-tombstone block boundary
-    status: partial
+    status: mirrored
     capability: index_summary
     priority: P0
     risk: p1_correctness
@@ -1934,39 +1894,31 @@ scenarios:
       references:
         - test-data/datasets/sstables/test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294/nb-2-big-Data.db.jsonl
     evidence:
-      type: partial
+      type: byte_for_byte
+      strict: true
       artifacts: [bytes, offsets, jsonl]
       cassandra_version: "5.0.2"
       cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
       storage_format_version: [nb]
       fixture_generation_command: >-
         bash test-data/scripts/gen-wide-big.sh
+      comparison_command: >-
+        env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets cargo test -p cqlite-core
+        --features write-support --test issue_993_wide_partition_promoted_index_parity
+        range_tombstone_boundary_at_block_edge
       reference_paths:
         - test-data/datasets/sstables/test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294/nb-2-big-Data.db.jsonl
+      failure_artifacts:
+        - target/cassandra-parity/wide-partition-promoted-index-diff.log
       known_limitations: >-
-        The BIG promoted IndexInfo[] decode is implemented and proven byte-for-byte
-        LOCALLY against the real Cassandra wide-partition fixture (see
-        cqlite-core/tests/issue_993_wide_partition_promoted_index_parity.rs). The
-        committed-JSONL canonical-semantic checks (3 partitions, live counts
-        290/300/300, pk=1 missing exactly ck 30..39, ascending clustering) ARE
-        enforced in the required CI lane on every run; the byte-level Index.db
-        promoted-offset/bounds assertions are NOT in the required lane because they
-        depend on local-only binaries absent from the pinned CI dataset.
+        Byte-level promoted-index parity now runs fail-closed in the required lane:
+        issue #1185 pins the test_big.wide_partition binaries into the CI dataset.
+        Validation is scoped to the single-int clustering schema, where the on-disk
+        clustering prefix length (6 bytes) is unambiguous.
     ci:
-      tier: manual_debug
-    scope:
-      gap: >-
-        This scenario's proving evidence is the byte-level Index.db promoted-index
-        decode (offsets, widths, clustering bounds), which SKIPS in CI because the
-        test_big/wide_partition binaries are not in the pinned dataset (issue #1185
-        in progress). Marking it required_parity would report coverage for a check
-        that does not run; the only CI-running assertion in this test binary is the
-        JSONL canonical-semantic check, which does not decode the promoted index and
-        so does not satisfy this scenario's evidence on its own.
-      next_step: >-
-        Re-promote to required_parity once issue #1185 pins the test_big.wide_partition
-        binaries into the CI dataset (regenerate the tarball + update DATASET_SHA256)
-        so the byte-level promoted-index assertions actually run fail-closed.
+      tier: required_parity
+      workflow: .github/workflows/sstabledump-parity-gate.yml
+    scope: {}
 
   - id: cass.sstable_scan.wide_partition.forward_reverse_bounds
     title: Wide-partition forward and reverse scan boundary parity

--- a/test-data/scripts/bump-dataset-pin.sh
+++ b/test-data/scripts/bump-dataset-pin.sh
@@ -14,14 +14,14 @@
 #
 # Usage:
 #   test-data/scripts/bump-dataset-pin.sh --new-sha <sha256> \
-#     [--new-asset cassandra5-small-full-v3.2.tar.gz] \
+#     [--new-asset cassandra5-small-full-v3.3.tar.gz] \
 #     [--new-tag datasets-v3] \
-#     [--old-asset cassandra5-small-full-v3.1.tar.gz] \
-#     [--old-sha f5fa0b6599a27c1c493d7c6c063194d55d031cab417396947313e7245afc5ceb] \
+#     [--old-asset cassandra5-small-full-v3.2.tar.gz] \
+#     [--old-sha bebc763752c8d68c7fb0483a1b31294b4d1d21343d3f7d124da069e5073202fa] \
 #     [--old-tag datasets-v3]
 #
-# Only --new-sha is required. Defaults below match the current (v3.1) pin and a
-# v3.2 asset uploaded to the SAME release tag (datasets-v3 can hold multiple
+# Only --new-sha is required. Defaults below match the current (v3.2) pin and a
+# v3.3 asset uploaded to the SAME release tag (datasets-v3 can hold multiple
 # assets). If you cut a NEW release tag instead, pass --new-tag (and --old-tag
 # if it differs).
 
@@ -32,11 +32,11 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 WF_DIR="$REPO_ROOT/.github/workflows"
 
 # Current (to-be-replaced) pin — keep in sync with the committed workflows.
-OLD_ASSET="cassandra5-small-full-v3.1.tar.gz"
-OLD_SHA="f5fa0b6599a27c1c493d7c6c063194d55d031cab417396947313e7245afc5ceb"
+OLD_ASSET="cassandra5-small-full-v3.2.tar.gz"
+OLD_SHA="bebc763752c8d68c7fb0483a1b31294b4d1d21343d3f7d124da069e5073202fa"
 OLD_TAG="datasets-v3"
 
-NEW_ASSET="cassandra5-small-full-v3.2.tar.gz"
+NEW_ASSET="cassandra5-small-full-v3.3.tar.gz"
 NEW_SHA=""
 NEW_TAG="datasets-v3"
 

--- a/test-data/scripts/bump-dataset-pin.sh
+++ b/test-data/scripts/bump-dataset-pin.sh
@@ -32,11 +32,14 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 WF_DIR="$REPO_ROOT/.github/workflows"
 
 # Current (to-be-replaced) pin — keep in sync with the committed workflows.
-OLD_ASSET="cassandra5-small-full-v3.3.tar.gz"
-OLD_SHA="44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac"
+# This MUST match the asset/SHA actually committed across the workflows, or the
+# default next bump is a no-op/false-success. Currently v3.4 (issue #1185).
+OLD_ASSET="cassandra5-small-full-v3.4.tar.gz"
+OLD_SHA="3cae644360e0142a6bb5e96ddab445ff18e3478e7058104842ce1a455fba8a33"
 OLD_TAG="datasets-v3"
 
-NEW_ASSET="cassandra5-small-full-v3.4.tar.gz"
+# Next (to-be-written) pin — bump the asset version and pass the new --new-sha.
+NEW_ASSET="cassandra5-small-full-v3.5.tar.gz"
 NEW_SHA=""
 NEW_TAG="datasets-v3"
 

--- a/test-data/scripts/bump-dataset-pin.sh
+++ b/test-data/scripts/bump-dataset-pin.sh
@@ -14,14 +14,14 @@
 #
 # Usage:
 #   test-data/scripts/bump-dataset-pin.sh --new-sha <sha256> \
-#     [--new-asset cassandra5-small-full-v3.3.tar.gz] \
+#     [--new-asset cassandra5-small-full-v3.4.tar.gz] \
 #     [--new-tag datasets-v3] \
-#     [--old-asset cassandra5-small-full-v3.2.tar.gz] \
-#     [--old-sha bebc763752c8d68c7fb0483a1b31294b4d1d21343d3f7d124da069e5073202fa] \
+#     [--old-asset cassandra5-small-full-v3.3.tar.gz] \
+#     [--old-sha 44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac] \
 #     [--old-tag datasets-v3]
 #
-# Only --new-sha is required. Defaults below match the current (v3.2) pin and a
-# v3.3 asset uploaded to the SAME release tag (datasets-v3 can hold multiple
+# Only --new-sha is required. Defaults below match the current (v3.3) pin and a
+# v3.4 asset uploaded to the SAME release tag (datasets-v3 can hold multiple
 # assets). If you cut a NEW release tag instead, pass --new-tag (and --old-tag
 # if it differs).
 
@@ -32,11 +32,11 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 WF_DIR="$REPO_ROOT/.github/workflows"
 
 # Current (to-be-replaced) pin — keep in sync with the committed workflows.
-OLD_ASSET="cassandra5-small-full-v3.2.tar.gz"
-OLD_SHA="bebc763752c8d68c7fb0483a1b31294b4d1d21343d3f7d124da069e5073202fa"
+OLD_ASSET="cassandra5-small-full-v3.3.tar.gz"
+OLD_SHA="44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac"
 OLD_TAG="datasets-v3"
 
-NEW_ASSET="cassandra5-small-full-v3.3.tar.gz"
+NEW_ASSET="cassandra5-small-full-v3.4.tar.gz"
 NEW_SHA=""
 NEW_TAG="datasets-v3"
 

--- a/test-data/scripts/bump-dataset-pin.sh
+++ b/test-data/scripts/bump-dataset-pin.sh
@@ -14,14 +14,14 @@
 #
 # Usage:
 #   test-data/scripts/bump-dataset-pin.sh --new-sha <sha256> \
-#     [--new-asset cassandra5-small-full-v3.4.tar.gz] \
+#     [--new-asset cassandra5-small-full-v3.5.tar.gz] \
 #     [--new-tag datasets-v3] \
-#     [--old-asset cassandra5-small-full-v3.3.tar.gz] \
-#     [--old-sha 44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac] \
+#     [--old-asset cassandra5-small-full-v3.4.tar.gz] \
+#     [--old-sha 3cae644360e0142a6bb5e96ddab445ff18e3478e7058104842ce1a455fba8a33] \
 #     [--old-tag datasets-v3]
 #
-# Only --new-sha is required. Defaults below match the current (v3.3) pin and a
-# v3.4 asset uploaded to the SAME release tag (datasets-v3 can hold multiple
+# Only --new-sha is required. Defaults below match the current (v3.4) pin and a
+# v3.5 asset uploaded to the SAME release tag (datasets-v3 can hold multiple
 # assets). If you cut a NEW release tag instead, pass --new-tag (and --old-tag
 # if it differs).
 

--- a/test-data/scripts/fetch-datasets.sh
+++ b/test-data/scripts/fetch-datasets.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 # Usage: DATASET_TAG=datasets-v2 DATASET_ASSET=cassandra5-small-full.tar.gz DATASET_SHA256=<sha> ./test-data/scripts/fetch-datasets.sh
 
 TAG="${DATASET_TAG:-datasets-v3}"
-ASSET="${DATASET_ASSET:-cassandra5-small-full-v3.2.tar.gz}"
-SHA256_EXPECTED="${DATASET_SHA256:-bebc763752c8d68c7fb0483a1b31294b4d1d21343d3f7d124da069e5073202fa}"
+ASSET="${DATASET_ASSET:-cassandra5-small-full-v3.3.tar.gz}"
+SHA256_EXPECTED="${DATASET_SHA256:-44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac}"
 DATASET_ROOT="${CQLITE_DATASETS_ROOT:-test-data/datasets}"
 PIN_FILE="${DATASET_ROOT}/.dataset-pin"
 ASSET_PATH="/tmp/${ASSET}"

--- a/test-data/scripts/fetch-datasets.sh
+++ b/test-data/scripts/fetch-datasets.sh
@@ -10,7 +10,18 @@ SHA256_EXPECTED="${DATASET_SHA256:-3cae644360e0142a6bb5e96ddab445ff18e3478e70581
 DATASET_ROOT="${CQLITE_DATASETS_ROOT:-test-data/datasets}"
 PIN_FILE="${DATASET_ROOT}/.dataset-pin"
 ASSET_PATH="/tmp/${ASSET}"
-WIDE_PARTITION_GOLDEN="${DATASET_ROOT}/sstables/test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294/nb-2-big-Data.db.jsonl"
+WIDE_PARTITION_DIR="${DATASET_ROOT}/sstables/test_big/wide_partition-ffe2ee50733111f19e8f6d08b8e7a294"
+WIDE_PARTITION_GOLDEN="${WIDE_PARTITION_DIR}/nb-2-big-Data.db.jsonl"
+# Exact promoted wide_partition reference binaries the byte_for_byte parity
+# scenarios + the digest strict test require (mirrors REQUIRED_BINARY_COMPONENTS
+# in cqlite-core/tests/issue_993_wide_partition_promoted_index_parity.rs). A
+# dataset missing any of these must force a re-fetch (issue #1185 fail-closed).
+WIDE_PARTITION_REQUIRED_COMPONENTS=(
+  "nb-2-big-Data.db"
+  "nb-2-big-Index.db"
+  "nb-2-big-Digest.crc32"
+  "nb-2-big-CompressionInfo.db"
+)
 
 if [ -z "${DATASET_ROOT}" ] || [ "${DATASET_ROOT}" = "/" ]; then
   echo "ERROR: unsafe CQLITE_DATASETS_ROOT='${DATASET_ROOT}'" >&2
@@ -69,11 +80,21 @@ has_required_dataset() {
   [ "${summary_count}" -gt 0 ] || return 1
   [ "${statistics_count}" -gt 0 ] || return 1
 
-  if [ -f "${PIN_FILE}" ]; then
-    grep -qx "tag=${TAG}" "${PIN_FILE}" || return 1
-    grep -qx "asset=${ASSET}" "${PIN_FILE}" || return 1
-    grep -qx "sha256=${SHA256_EXPECTED}" "${PIN_FILE}" || return 1
-  fi
+  # The global counts above can be satisfied by other tables; explicitly require
+  # the EXACT promoted wide_partition reference binaries so a partial/stale
+  # dataset (other tables present, wide_partition absent) cannot be accepted and
+  # stamped as the new pin (issue #1185 fail-closed).
+  local component
+  for component in "${WIDE_PARTITION_REQUIRED_COMPONENTS[@]}"; do
+    [ -f "${WIDE_PARTITION_DIR}/${component}" ] || return 1
+  done
+
+  # The pin file MUST exist and match. A missing pin is NOT acceptable — it would
+  # otherwise let an unverified dataset fall through and be re-stamped (#1185).
+  [ -f "${PIN_FILE}" ] || return 1
+  grep -qx "tag=${TAG}" "${PIN_FILE}" || return 1
+  grep -qx "asset=${ASSET}" "${PIN_FILE}" || return 1
+  grep -qx "sha256=${SHA256_EXPECTED}" "${PIN_FILE}" || return 1
 }
 
 restore_ci_tracked_dataset_files

--- a/test-data/scripts/fetch-datasets.sh
+++ b/test-data/scripts/fetch-datasets.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 # Usage: DATASET_TAG=datasets-v2 DATASET_ASSET=cassandra5-small-full.tar.gz DATASET_SHA256=<sha> ./test-data/scripts/fetch-datasets.sh
 
 TAG="${DATASET_TAG:-datasets-v3}"
-ASSET="${DATASET_ASSET:-cassandra5-small-full-v3.3.tar.gz}"
-SHA256_EXPECTED="${DATASET_SHA256:-44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac}"
+ASSET="${DATASET_ASSET:-cassandra5-small-full-v3.4.tar.gz}"
+SHA256_EXPECTED="${DATASET_SHA256:-3cae644360e0142a6bb5e96ddab445ff18e3478e7058104842ce1a455fba8a33}"
 DATASET_ROOT="${CQLITE_DATASETS_ROOT:-test-data/datasets}"
 PIN_FILE="${DATASET_ROOT}/.dataset-pin"
 ASSET_PATH="/tmp/${ASSET}"

--- a/test-data/scripts/fetch-datasets.sh
+++ b/test-data/scripts/fetch-datasets.sh
@@ -61,7 +61,12 @@ restore_ci_tracked_dataset_files() {
   fi
 }
 
-has_required_dataset() {
+# Validates the dataset CONTENT only (no pin tag/asset/sha checks). A freshly
+# extracted archive is in exactly this state — content present but the pin not
+# yet stamped — so the post-extraction validation uses this to confirm the
+# archive is complete (incl. the exact wide_partition reference binaries) before
+# write_pin runs.
+has_required_content() {
   [ -f "${DATASET_ROOT}/metadata.yml" ] || return 1
   [ -s "${WIDE_PARTITION_GOLDEN}" ] || return 1
 
@@ -88,6 +93,13 @@ has_required_dataset() {
   for component in "${WIDE_PARTITION_REQUIRED_COMPONENTS[@]}"; do
     [ -f "${WIDE_PARTITION_DIR}/${component}" ] || return 1
   done
+}
+
+# Strict fast-path check: content present AND pinned to the expected v3.4 tag/
+# asset/sha. The skip-download path requires BOTH so a stale/unpinned dataset
+# forces a re-fetch (issue #1185 fail-closed).
+has_required_dataset() {
+  has_required_content || return 1
 
   # The pin file MUST exist and match. A missing pin is NOT acceptable — it would
   # otherwise let an unverified dataset fall through and be re-stamped (#1185).
@@ -141,7 +153,10 @@ restore_ci_tracked_dataset_files
 # suffix (e.g., `*-Data.db` matches both the real file and `._..-Data.db`).
 find "${DATASET_ROOT}" \( -name '._*' -o -name '.DS_Store' \) -delete 2>/dev/null || true
 
-if ! has_required_dataset; then
+# Validate the freshly extracted CONTENT (not the pin — package_datasets.sh does
+# not embed a .dataset-pin in the archive). A bad/partial archive still fails
+# loudly here; the pin is stamped only after content is confirmed.
+if ! has_required_content; then
   echo "ERROR: dataset extraction did not produce required Cassandra SSTable components in ${DATASET_ROOT}" >&2
   exit 1
 fi

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -182,8 +182,8 @@ the same asset CI uses. Current pins (as of the script source):
 
 ```
 DATASET_TAG:    datasets-v3
-DATASET_ASSET:  cassandra5-small-full-v3.2.tar.gz
-DATASET_SHA256: bebc763752c8d68c7fb0483a1b31294b4d1d21343d3f7d124da069e5073202fa
+DATASET_ASSET:  cassandra5-small-full-v3.3.tar.gz
+DATASET_SHA256: 44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac
 ```
 
 See [Test data](/cqlite/agents-developing/test-data/) for how `fetch-datasets.sh` uses these pins and why

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -182,8 +182,8 @@ the same asset CI uses. Current pins (as of the script source):
 
 ```
 DATASET_TAG:    datasets-v3
-DATASET_ASSET:  cassandra5-small-full-v3.3.tar.gz
-DATASET_SHA256: 44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac
+DATASET_ASSET:  cassandra5-small-full-v3.4.tar.gz
+DATASET_SHA256: 3cae644360e0142a6bb5e96ddab445ff18e3478e7058104842ce1a455fba8a33
 ```
 
 See [Test data](/cqlite/agents-developing/test-data/) for how `fetch-datasets.sh` uses these pins and why

--- a/website/src/content/docs/agents-developing/test-data.md
+++ b/website/src/content/docs/agents-developing/test-data.md
@@ -26,16 +26,16 @@ The fetch script uses these defaults (override with environment variables):
 
 ```bash
 DATASET_TAG=datasets-v3
-DATASET_ASSET=cassandra5-small-full-v3.2.tar.gz
-DATASET_SHA256=bebc763752c8d68c7fb0483a1b31294b4d1d21343d3f7d124da069e5073202fa
+DATASET_ASSET=cassandra5-small-full-v3.3.tar.gz
+DATASET_SHA256=44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac
 ```
 
 CI reads the same pins from `.github/workflows/sstabledump-parity-gate.yml`:
 
 ```yaml
 DATASET_TAG: datasets-v3
-DATASET_ASSET: cassandra5-small-full-v3.2.tar.gz
-DATASET_SHA256: bebc763752c8d68c7fb0483a1b31294b4d1d21343d3f7d124da069e5073202fa
+DATASET_ASSET: cassandra5-small-full-v3.3.tar.gz
+DATASET_SHA256: 44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac
 ```
 
 **Why SHA256 is the cache key**: CI caches the extracted dataset by SHA256. Using the

--- a/website/src/content/docs/agents-developing/test-data.md
+++ b/website/src/content/docs/agents-developing/test-data.md
@@ -26,16 +26,16 @@ The fetch script uses these defaults (override with environment variables):
 
 ```bash
 DATASET_TAG=datasets-v3
-DATASET_ASSET=cassandra5-small-full-v3.3.tar.gz
-DATASET_SHA256=44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac
+DATASET_ASSET=cassandra5-small-full-v3.4.tar.gz
+DATASET_SHA256=3cae644360e0142a6bb5e96ddab445ff18e3478e7058104842ce1a455fba8a33
 ```
 
 CI reads the same pins from `.github/workflows/sstabledump-parity-gate.yml`:
 
 ```yaml
 DATASET_TAG: datasets-v3
-DATASET_ASSET: cassandra5-small-full-v3.3.tar.gz
-DATASET_SHA256: 44a3dc5d1fdb918dbf9d7568676cf906ccad7881991aaadcf96a7993627951ac
+DATASET_ASSET: cassandra5-small-full-v3.4.tar.gz
+DATASET_SHA256: 3cae644360e0142a6bb5e96ddab445ff18e3478e7058104842ce1a455fba8a33
 ```
 
 **Why SHA256 is the cache key**: CI caches the extracted dataset by SHA256. Using the


### PR DESCRIPTION
Closes #1185. Follow-up to #993; unblocks #1184. Oracle-driven — no OpenSpec.

## What changed
- Published dataset asset **`cassandra5-small-full-v3.3.tar.gz`** (superset of v3.2, +wide-partition binaries, reusing the canonical #993 fixture bytes to preserve the byte-pinned UUID) and bumped the pin (TAG/ASSET/**SHA256**) across CI + agent-gate.
- Force-committed the `test_big/wide_partition-*` SSTable components (matches #1190 precedent; the lint requires `byte_for_byte` reference paths to exist in a clean checkout, and the lint lane doesn't fetch the tarball).
- Wired `issue_993_wide_partition_promoted_index_parity` **fail-closed** into the required `sstabledump-parity-gate.yml` (build-fail aggregator + failure-comment), under `CQLITE_PARITY_REQUIRE_DATASETS=1` (panics, not skips, on absent fixture).
- Promoted the 6 wide-partition scenarios `partial`→`byte_for_byte` (#1242 had literally noted 're-promote once #1185 pins the binaries').
- **Hardened `fetch-datasets.sh`**: a single `git ls-files`-derived source of truth lists every real published SSTable component (Data/Index/CompressionInfo/Filter/Statistics/Summary/CRC.db/Digest.crc32/TOC.txt) for the protected fixture dirs (wide-partition + #1190 write-parity); these are presence-validated against the freshly-extracted asset AND excluded from the tracked-file restore, so a missing/stale/incomplete published tarball **fails CI loudly** instead of being masked by checkout copies. Pure validation sidecars (`.jsonl`/`.db.txt`) remain restorable.

## Validation
`scripts/agent-gate.sh` → **RESULT: PASS** (all 16 components incl. node-bindings). `cassandra-parity lint` 265/0 + tier-contract-check + report --check green. roborev (codex) clean. Merge-resolved against #1242/#1020 (union, no scenario dropped, no downgrade).