### PR TITLE
feat(#1249): enforce Cassandra 5.0 SSTable version floor + codify doctrine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -362,6 +362,14 @@ Use authoritative metadata only — no type guessing. Schema-aware decoding when
 present. Legacy heuristics behind opt-in `experimental` feature flag only.
 See canonical doctrine: [no-heuristics mandate](https://pmcfadin.github.io/cqlite/agents-developing/no-heuristics/)
 
+### Supported formats (version floor)
+CQLite targets Cassandra 5.0 — `na`+/`nb` BIG and `oa`/`da` BTI are in scope; pre-`na`
+(`ma`–`me`, Cassandra 3.x) is out of scope and SHALL NOT be introduced, supported, or
+reviewed for correctness (this guidance is for reviewers incl. roborev too). The floor is
+enforced in code: `BigVersionGates::from_version` rejects `< na` and `BtiVersionGates::from_version`
+rejects non-`da`, both with `Error::UnsupportedVersion`; `SSTableReader::open` propagates that
+error rather than falling back. Do not re-litigate pre-`na` "regressions."
+
 ### Code Quality
 - `RUSTFLAGS="-D warnings"` must pass
 - No `unwrap()`/`expect()` in library code

--- a/bindings/node/src/error.rs
+++ b/bindings/node/src/error.rs
@@ -416,6 +416,7 @@ mod tests {
                 Error::Corruption(_) => {}
                 Error::InvalidFormat(_) => {}
                 Error::UnsupportedFormat(_) => {}
+                Error::UnsupportedVersion { .. } => {}
                 Error::InvalidPath(_) => {}
                 Error::TypeConversion(_) => {}
                 Error::Storage(_) => {}

--- a/bindings/python/src/error.rs
+++ b/bindings/python/src/error.rs
@@ -371,6 +371,7 @@ mod tests {
                 Error::Corruption(_) => { /* Maps to CqliteError */ }
                 Error::InvalidFormat(_) => { /* Maps to CqliteError */ }
                 Error::UnsupportedFormat(_) => { /* Maps to CqliteError */ }
+                Error::UnsupportedVersion { .. } => { /* Maps to CqliteError */ }
                 Error::InvalidPath(_) => { /* Maps to CqliteError */ }
                 Error::TypeConversion(_) => { /* Maps to CqliteError */ }
                 Error::Storage(_) => { /* Maps to CqliteError */ }

--- a/cqlite-core/src/error.rs
+++ b/cqlite-core/src/error.rs
@@ -41,6 +41,14 @@ pub enum Error {
     #[error("Unsupported format: {0}")]
     UnsupportedFormat(String),
 
+    /// SSTable version below the supported Cassandra 5.0 floor.
+    ///
+    /// CQLite targets Cassandra 5.0 (`na`+/`nb` BIG, `oa`/`da` BTI). A
+    /// pre-`na` (`ma`–`me`, Cassandra 3.x) BIG version, or a non-`da` BTI
+    /// version, is out of scope and rejected at version-parse time.
+    #[error("Unsupported SSTable version {version:?}: below supported floor {floor:?}")]
+    UnsupportedVersion { version: String, floor: String },
+
     /// Timeout error
     #[error("Operation timeout: {0}")]
     Timeout(String),
@@ -337,6 +345,7 @@ impl Error {
             Error::InvalidInput(_) => false,
             Error::InvalidFormat(_) => false,
             Error::UnsupportedFormat(_) => false,
+            Error::UnsupportedVersion { .. } => false,
             Error::InvalidPath(_) => false,
             Error::InvalidState(_) => false,
             Error::Timeout(_) => false,
@@ -380,6 +389,7 @@ impl Error {
             Error::InvalidInput(_) => ErrorCategory::Data,
             Error::InvalidFormat(_) => ErrorCategory::Data,
             Error::UnsupportedFormat(_) => ErrorCategory::Data,
+            Error::UnsupportedVersion { .. } => ErrorCategory::Data,
             Error::InvalidPath(_) => ErrorCategory::System,
             Error::InvalidState(_) => ErrorCategory::Logic,
             Error::Timeout(_) => ErrorCategory::System,

--- a/cqlite-core/src/observability/error_schema.rs
+++ b/cqlite-core/src/observability/error_schema.rs
@@ -119,7 +119,8 @@ pub(crate) fn classify(err: &Error) -> ErrorCategory {
         Error::Parse(_)
         | Error::CqlParse(_)
         | Error::InvalidFormat(_)
-        | Error::UnsupportedFormat(_) => ErrorCategory::Parsing,
+        | Error::UnsupportedFormat(_)
+        | Error::UnsupportedVersion { .. } => ErrorCategory::Parsing,
 
         Error::Storage(_)
         | Error::Memory(_)

--- a/cqlite-core/src/storage/sstable/bulletproof_reader.rs
+++ b/cqlite-core/src/storage/sstable/bulletproof_reader.rs
@@ -83,6 +83,18 @@ impl BulletproofReader {
         let path = sstable_path.as_ref();
         let info = SSTableInfo::from_path(path)?;
 
+        // #1249: reject below-floor formats (Cassandra 2.x and pre-`na` 3.x
+        // BIG, i.e. `ma`–`me`) BEFORE any initialization or file-body read.
+        // There is no correctness-modeling read path for them; return the
+        // typed version error naming the supported floor rather than opening
+        // files and reading rows we cannot interpret.
+        if let SSTableFormat::V2x(v) | SSTableFormat::V3x(v) = &info.format {
+            return Err(Error::UnsupportedVersion {
+                version: v.clone(),
+                floor: "na".to_string(),
+            });
+        }
+
         let base_dir = path
             .parent()
             .ok_or_else(|| Error::InvalidPath("No parent directory".to_string()))?
@@ -228,6 +240,20 @@ impl BulletproofReader {
     /// This is where we'll implement the actual SSTable parsing
     /// based on the detected format version
     pub fn parse_sstable_data(&mut self) -> Result<Vec<SSTableEntry>> {
+        // #1249: reject below-floor formats (Cassandra 2.x and pre-`na` 3.x
+        // BIG, i.e. `ma`–`me`) BEFORE reading any row bytes. There is no
+        // correctness-modeling read path for them; return the typed version
+        // error naming the supported floor instead of routing into a stub
+        // parser or surfacing a downstream parse/corruption error. `open`
+        // already rejects these, but readers built via `new()` reach here
+        // directly, so guard before `read_all_data()`.
+        if let SSTableFormat::V2x(v) | SSTableFormat::V3x(v) = &self.info.format {
+            return Err(Error::UnsupportedVersion {
+                version: v.clone(),
+                floor: "na".to_string(),
+            });
+        }
+
         let data = self.read_all_data()?;
 
         info!(
@@ -238,14 +264,9 @@ impl BulletproofReader {
 
         match &self.info.format {
             SSTableFormat::V4x(_) | SSTableFormat::V5x(_) => self.parse_modern_format(&data),
-            // #1249: pre-`na` (Cassandra 3.x BIG, `ma`–`me`) and 2.x are below
-            // the supported floor. There is no correctness-modeling read path
-            // for them; reject with the typed version error naming the floor
-            // instead of routing into a stub parser.
-            SSTableFormat::V3x(v) | SSTableFormat::V2x(v) => Err(Error::UnsupportedVersion {
-                version: v.clone(),
-                floor: "na".to_string(),
-            }),
+            SSTableFormat::V2x(_) | SSTableFormat::V3x(_) => {
+                unreachable!("below-floor V2x/V3x formats are rejected before read_all_data")
+            }
             SSTableFormat::Unknown(version) => Err(Error::UnsupportedFormat(format!(
                 "Unknown SSTable version: {}",
                 version
@@ -785,5 +806,57 @@ mod tests {
         assert_eq!(value, 128);
         assert_eq!(bytes_read, 2);
         Ok(())
+    }
+
+    /// #1249: a below-floor format (Cassandra 3.x BIG `ma`) must yield the typed
+    /// `UnsupportedVersion` error from `parse_sstable_data` BEFORE any row bytes
+    /// are read. The reader points at a non-existent Data.db: if the rejection
+    /// happened after `read_all_data()` we would instead get an IO/parse error,
+    /// so observing `UnsupportedVersion` proves no body read occurred.
+    #[test]
+    fn test_below_floor_rejected_before_read() {
+        let info = SSTableInfo::from_path(&std::path::PathBuf::from("ma-1-big-Data.db")).unwrap();
+        assert!(matches!(info.format, SSTableFormat::V3x(_)));
+
+        let mut reader = BulletproofReader {
+            info,
+            // Intentionally bogus base dir + no data_reader so that any attempt
+            // to read the body would fail loudly with a non-version error.
+            base_dir: std::path::PathBuf::from("/nonexistent/cqlite-1249"),
+            decompressor: None,
+            data_reader: None,
+        };
+
+        match reader.parse_sstable_data() {
+            Err(Error::UnsupportedVersion { version, floor }) => {
+                assert_eq!(version, "ma");
+                assert_eq!(floor, "na");
+            }
+            other => panic!("expected UnsupportedVersion, got {:?}", other),
+        }
+    }
+
+    /// #1249: `open` rejects a below-floor descriptor before initialization,
+    /// even when the Data.db body exists (here a truncated/garbage body). The
+    /// typed `UnsupportedVersion` must surface rather than a parse/corruption
+    /// error from reading the body.
+    #[test]
+    fn test_open_below_floor_rejected_with_body_present() {
+        let dir = std::env::temp_dir().join(format!("cqlite-1249-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let data_path = dir.join("ma-1-big-Data.db");
+        // Non-empty, non-'oa' body: would error during parsing if ever read.
+        std::fs::write(&data_path, b"not a valid sstable body").unwrap();
+
+        let result = BulletproofReader::open(&data_path);
+        let _ = std::fs::remove_dir_all(&dir);
+
+        match result {
+            Err(Error::UnsupportedVersion { version, floor }) => {
+                assert_eq!(version, "ma");
+                assert_eq!(floor, "na");
+            }
+            other => panic!("expected UnsupportedVersion, got {:?}", other.map(|_| ())),
+        }
     }
 }

--- a/cqlite-core/src/storage/sstable/bulletproof_reader.rs
+++ b/cqlite-core/src/storage/sstable/bulletproof_reader.rs
@@ -238,8 +238,14 @@ impl BulletproofReader {
 
         match &self.info.format {
             SSTableFormat::V4x(_) | SSTableFormat::V5x(_) => self.parse_modern_format(&data),
-            SSTableFormat::V3x(_) => self.parse_v3_format(&data),
-            SSTableFormat::V2x(_) => self.parse_v2_format(&data),
+            // #1249: pre-`na` (Cassandra 3.x BIG, `ma`–`me`) and 2.x are below
+            // the supported floor. There is no correctness-modeling read path
+            // for them; reject with the typed version error naming the floor
+            // instead of routing into a stub parser.
+            SSTableFormat::V3x(v) | SSTableFormat::V2x(v) => Err(Error::UnsupportedVersion {
+                version: v.clone(),
+                floor: "na".to_string(),
+            }),
             SSTableFormat::Unknown(version) => Err(Error::UnsupportedFormat(format!(
                 "Unknown SSTable version: {}",
                 version
@@ -512,20 +518,6 @@ impl BulletproofReader {
 
         Ok((result, bytes_read))
     }
-    /// Parse V3.x format
-    fn parse_v3_format(&self, _data: &[u8]) -> Result<Vec<SSTableEntry>> {
-        debug!("Parsing V3.x SSTable format");
-        // TODO: Implement V3.x specific parsing
-        Ok(Vec::new())
-    }
-
-    /// Parse V2.x format
-    fn parse_v2_format(&self, _data: &[u8]) -> Result<Vec<SSTableEntry>> {
-        debug!("Parsing V2.x SSTable format");
-        // TODO: Implement V2.x specific parsing
-        Ok(Vec::new())
-    }
-
     /// Get information about the SSTable
     pub fn info(&self) -> &SSTableInfo {
         &self.info

--- a/cqlite-core/src/storage/sstable/bulletproof_reader.rs
+++ b/cqlite-core/src/storage/sstable/bulletproof_reader.rs
@@ -33,6 +33,7 @@ use super::{
     chunk_decompressor::{create_decompressor_from_file, ChunkDecompressor},
     compression_info::CompressionInfo,
     format_detector::{SSTableComponent, SSTableFormat, SSTableInfo},
+    version_gate::VersionGates,
 };
 use crate::parser::vint::parse_vint;
 use crate::{Error, Result};
@@ -81,19 +82,23 @@ impl BulletproofReader {
     /// proper compression handling if needed.
     pub fn open<P: AsRef<Path>>(sstable_path: P) -> Result<Self> {
         let path = sstable_path.as_ref();
-        let info = SSTableInfo::from_path(path)?;
 
-        // #1249: reject below-floor formats (Cassandra 2.x and pre-`na` 3.x
-        // BIG, i.e. `ma`–`me`) BEFORE any initialization or file-body read.
-        // There is no correctness-modeling read path for them; return the
-        // typed version error naming the supported floor rather than opening
-        // files and reading rows we cannot interpret.
-        if let SSTableFormat::V2x(v) | SSTableFormat::V3x(v) = &info.format {
-            return Err(Error::UnsupportedVersion {
-                version: v.clone(),
-                floor: "na".to_string(),
-            });
+        // #1249: reject ALL below-floor versions BEFORE any initialization or
+        // file-body read, using the SAME authoritative gate the production
+        // readers use (`reader/mod.rs::open_inner`, `statistics_reader.rs::open`).
+        // `VersionGates::from_path` derives the version from the filename alone
+        // (no I/O) and rejects every pre-`na` BIG (`la`/`ic`/`jb`/`ma`–`me`) and
+        // non-`da` BTI descriptor with a typed `UnsupportedVersion` naming the
+        // supported floor — including below-floor versions that
+        // `SSTableInfo::from_path` classifies as `Unknown` (e.g. `la`), which the
+        // old `V2x`/`V3x` format match silently bypassed. A structurally-
+        // unparseable descriptor falls through to current behaviour (it is not
+        // made fatal); the floor only fires on a *parsed* below-floor version.
+        if let Err(e @ Error::UnsupportedVersion { .. }) = VersionGates::from_path(path) {
+            return Err(e);
         }
+
+        let info = SSTableInfo::from_path(path)?;
 
         let base_dir = path
             .parent()
@@ -240,18 +245,21 @@ impl BulletproofReader {
     /// This is where we'll implement the actual SSTable parsing
     /// based on the detected format version
     pub fn parse_sstable_data(&mut self) -> Result<Vec<SSTableEntry>> {
-        // #1249: reject below-floor formats (Cassandra 2.x and pre-`na` 3.x
-        // BIG, i.e. `ma`–`me`) BEFORE reading any row bytes. There is no
-        // correctness-modeling read path for them; return the typed version
-        // error naming the supported floor instead of routing into a stub
-        // parser or surfacing a downstream parse/corruption error. `open`
-        // already rejects these, but readers built via `new()` reach here
-        // directly, so guard before `read_all_data()`.
-        if let SSTableFormat::V2x(v) | SSTableFormat::V3x(v) = &self.info.format {
-            return Err(Error::UnsupportedVersion {
-                version: v.clone(),
-                floor: "na".to_string(),
-            });
+        // #1249: reject ALL below-floor versions BEFORE reading any row bytes,
+        // using the same authoritative gate as `open` and the production
+        // readers. `open` already rejects these, but readers built via `new()`
+        // reach here directly, so re-derive from the same descriptor (the
+        // `<version>-<id>-<format>` `base_name` plus the Data component). This
+        // catches every pre-`na` BIG (`la`/`ma`–`me`) and non-`da` BTI
+        // version — including ones classified as `Unknown` (e.g. `la`) that the
+        // old `V2x`/`V3x` format match silently bypassed — with a typed
+        // `UnsupportedVersion` before `read_all_data()`. A structurally-
+        // unparseable descriptor is NOT made fatal: it falls through to the
+        // format-family match below.
+        if let Err(e @ Error::UnsupportedVersion { .. }) =
+            VersionGates::from_path(Path::new(&format!("{}-Data.db", self.info.base_name)))
+        {
+            return Err(e);
         }
 
         let data = self.read_all_data()?;
@@ -264,10 +272,13 @@ impl BulletproofReader {
 
         match &self.info.format {
             SSTableFormat::V4x(_) | SSTableFormat::V5x(_) => self.parse_modern_format(&data),
-            SSTableFormat::V2x(_) | SSTableFormat::V3x(_) => {
-                unreachable!("below-floor V2x/V3x formats are rejected before read_all_data")
-            }
-            SSTableFormat::Unknown(version) => Err(Error::UnsupportedFormat(format!(
+            // Below-floor V2x/V3x (and below-floor Unknown like `la`) are
+            // rejected via VersionGates above before any read, so they never
+            // reach this match. An above-floor Unknown (e.g. `nc`/`ob`/`pa`,
+            // tracked separately in #1297) still surfaces UnsupportedFormat.
+            SSTableFormat::V2x(version)
+            | SSTableFormat::V3x(version)
+            | SSTableFormat::Unknown(version) => Err(Error::UnsupportedFormat(format!(
                 "Unknown SSTable version: {}",
                 version
             ))),
@@ -857,6 +868,63 @@ mod tests {
                 assert_eq!(floor, "na");
             }
             other => panic!("expected UnsupportedVersion, got {:?}", other.map(|_| ())),
+        }
+    }
+
+    /// #1249 regression: a below-floor BIG descriptor that `SSTableInfo`
+    /// classifies as `SSTableFormat::Unknown` (Cassandra 2.x `la`) must STILL
+    /// be rejected by the floor. The old `V2x`/`V3x` format-match guard let
+    /// `la` (Unknown) bypass the floor entirely; routing through the
+    /// authoritative `VersionGates` rejects it via `BigVersionGates`'s `< na`
+    /// gate. We point at a non-existent Data.db so any post-read code path
+    /// would surface an IO/parse error instead of `UnsupportedVersion`.
+    #[test]
+    fn test_below_floor_unknown_la_rejected_before_read() {
+        let info = SSTableInfo::from_path(&std::path::PathBuf::from("la-1-big-Data.db")).unwrap();
+        // `la` is NOT classified as V2x/V3x — it falls into Unknown, which the
+        // old guard did not catch. This assertion documents that gap.
+        assert!(matches!(info.format, SSTableFormat::Unknown(ref v) if v == "la"));
+
+        let mut reader = BulletproofReader {
+            info,
+            base_dir: std::path::PathBuf::from("/nonexistent/cqlite-1249-la"),
+            decompressor: None,
+            data_reader: None,
+        };
+
+        match reader.parse_sstable_data() {
+            Err(Error::UnsupportedVersion { version, floor }) => {
+                assert_eq!(version, "la");
+                assert_eq!(floor, "na");
+            }
+            other => panic!("expected UnsupportedVersion for la, got {:?}", other),
+        }
+    }
+
+    /// #1249 regression: `open` rejects a below-floor `Unknown`-classified BIG
+    /// descriptor (`la`) before initialization, even when a (garbage) Data.db
+    /// body exists on disk. Proves pre-read rejection via the authoritative
+    /// gate rather than a parse/corruption error from reading the body.
+    #[test]
+    fn test_open_below_floor_unknown_la_rejected_with_body_present() {
+        let dir = std::env::temp_dir().join(format!("cqlite-1249-la-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let data_path = dir.join("la-1-big-Data.db");
+        // Garbage body: would error during parsing if it were ever read.
+        std::fs::write(&data_path, b"not a valid sstable body").unwrap();
+
+        let result = BulletproofReader::open(&data_path);
+        let _ = std::fs::remove_dir_all(&dir);
+
+        match result {
+            Err(Error::UnsupportedVersion { version, floor }) => {
+                assert_eq!(version, "la");
+                assert_eq!(floor, "na");
+            }
+            other => panic!(
+                "expected UnsupportedVersion for la, got {:?}",
+                other.map(|_| ())
+            ),
         }
     }
 }

--- a/cqlite-core/src/storage/sstable/format_detector.rs
+++ b/cqlite-core/src/storage/sstable/format_detector.rs
@@ -87,8 +87,12 @@ impl SSTableFormat {
     /// reject-at-open behaviour of `SSTableReader`/`StatisticsReader`.
     pub fn is_supported(&self) -> bool {
         match self {
-            // na/nb BIG and oa/da BTI/BIG — the only versions with a read path.
-            SSTableFormat::V4x(_) | SSTableFormat::V5x(_) => true,
+            // Exactly the four versions with a real read path — matching
+            // `supported_versions()`. A future/typo'd letter in the same family
+            // (e.g. `V4x("nc")`, `V5x("ob")`) is NOT a supported version and
+            // must return false (#1249).
+            SSTableFormat::V4x(v) => matches!(v.as_str(), "na" | "nb"),
+            SSTableFormat::V5x(v) => matches!(v.as_str(), "oa" | "da"),
             // Pre-`na` (Cassandra 3.x) and 2.x are below the floor.
             SSTableFormat::V2x(_) | SSTableFormat::V3x(_) => false,
             SSTableFormat::Unknown(_) => false,
@@ -519,6 +523,18 @@ mod tests {
         assert!(!SSTableFormat::V3x("ma".to_string()).is_supported());
         assert!(!SSTableFormat::V2x("jb".to_string()).is_supported());
         assert!(!SSTableFormat::Unknown("zz".to_string()).is_supported());
+
+        // #1249: the predicate must match EXACT version letters, not whole
+        // families — a future/typo'd letter in a supported family is NOT
+        // supported. `is_supported` is exactly {na, nb, oa, da}.
+        assert!(
+            !SSTableFormat::V4x("nc".to_string()).is_supported(),
+            "V4x(\"nc\") is not in the supported set and must be unsupported"
+        );
+        assert!(
+            !SSTableFormat::V5x("ob".to_string()).is_supported(),
+            "V5x(\"ob\") is not in the supported set and must be unsupported"
+        );
     }
 
     #[test]

--- a/cqlite-core/src/storage/sstable/format_detector.rs
+++ b/cqlite-core/src/storage/sstable/format_detector.rs
@@ -1,8 +1,19 @@
 //! SSTable format detection and version identification
 //!
-//! This module provides bulletproof detection of SSTable format versions
-//! across all Cassandra versions (2.x, 3.x, 4.x, 5.x) with automatic
-//! format-specific parser selection.
+//! This module *classifies* SSTable version letters into format families for
+//! diagnostics and routing. Classification (recognition) is deliberately
+//! broader than the **supported** read floor: a pre-`na` (`ma`–`me`,
+//! Cassandra 3.x) or pre-3.0 (`ic`/`jb`) version is still *recognized* so we
+//! can name it in errors, but it is NOT *supported*.
+//!
+//! ## Supported floor (#1249)
+//!
+//! "Supported" means CQLite has a real read path for the version: `na`/`nb`
+//! BIG (Cassandra 4.0 / 5.0 compat mode) and `oa`/`da` (Cassandra 5.0 BIG /
+//! BTI). Anything below `na` is recognized-but-unsupported so this preflight
+//! API agrees with `SSTableReader::open` / `StatisticsReader::open`, which
+//! reject below-floor SSTables outright. "Known" never implies "supported":
+//! `is_supported("ma")` is `false`.
 
 use crate::{Error, Result};
 use std::collections::HashMap;
@@ -67,6 +78,22 @@ impl SSTableFormat {
             SSTableFormat::Unknown(_) => "LZ4Compressor",
         }
     }
+
+    /// Whether CQLite *supports reading* this classified format (#1249).
+    ///
+    /// Supported = the na+ version floor: `na`/`nb` BIG (V4x) and `oa`/`da`
+    /// (V5x). Pre-`na` BIG (`ma`–`me`, V3x) and Cassandra 2.x (V2x) are
+    /// *recognized* by classification but are NOT supported, matching the
+    /// reject-at-open behaviour of `SSTableReader`/`StatisticsReader`.
+    pub fn is_supported(&self) -> bool {
+        match self {
+            // na/nb BIG and oa/da BTI/BIG — the only versions with a read path.
+            SSTableFormat::V4x(_) | SSTableFormat::V5x(_) => true,
+            // Pre-`na` (Cassandra 3.x) and 2.x are below the floor.
+            SSTableFormat::V2x(_) | SSTableFormat::V3x(_) => false,
+            SSTableFormat::Unknown(_) => false,
+        }
+    }
 }
 
 /// SSTable format detector with comprehensive version support
@@ -76,15 +103,20 @@ pub struct FormatDetector {
 }
 
 impl FormatDetector {
-    /// Create a new format detector with all known versions
+    /// Create a new format detector with all *known* (recognizable) versions.
+    ///
+    /// The map is the recognition set, NOT the supported set: it includes
+    /// pre-`na` (`ma`–`me`) and 2.x letters so they can be classified and named
+    /// in diagnostics. Use [`FormatDetector::is_supported`] /
+    /// [`FormatDetector::supported_versions`] for the na+ supported floor.
     pub fn new() -> Self {
         let mut format_map = HashMap::new();
 
-        // Cassandra 2.x formats
+        // Cassandra 2.x formats (recognized for diagnostics; NOT supported)
         format_map.insert("ic".to_string(), SSTableFormat::V2x("ic".to_string()));
         format_map.insert("jb".to_string(), SSTableFormat::V2x("jb".to_string()));
 
-        // Cassandra 3.x formats
+        // Cassandra 3.x formats (recognized for diagnostics; NOT supported — #1249)
         format_map.insert("ma".to_string(), SSTableFormat::V3x("ma".to_string()));
         format_map.insert("mb".to_string(), SSTableFormat::V3x("mb".to_string()));
         format_map.insert("mc".to_string(), SSTableFormat::V3x("mc".to_string()));
@@ -161,14 +193,30 @@ impl FormatDetector {
         ))
     }
 
-    /// Get all supported format versions
+    /// Get all *supported* format versions (na+ floor, #1249).
+    ///
+    /// Returns only versions CQLite can actually read: `na`/`nb` BIG and
+    /// `oa`/`da` (V4x/V5x). Pre-`na` (`ma`–`me`) and 2.x letters are
+    /// recognizable via [`FormatDetector::detect_from_version`] but are
+    /// deliberately absent here.
     pub fn supported_versions(&self) -> Vec<String> {
-        self.format_map.keys().cloned().collect()
+        self.format_map
+            .iter()
+            .filter(|(_, fmt)| fmt.is_supported())
+            .map(|(v, _)| v.clone())
+            .collect()
     }
 
-    /// Check if a format version is supported
+    /// Check if a format version is *supported* (has a read path).
+    ///
+    /// This is the na+ floor (#1249), NOT mere recognition: a recognized but
+    /// below-floor version such as `ma` returns `false`, so preflighting with
+    /// this API agrees with `SSTableReader::open`, which rejects it.
     pub fn is_supported(&self, version: &str) -> bool {
-        self.format_map.contains_key(version)
+        self.format_map
+            .get(version)
+            .map(SSTableFormat::is_supported)
+            .unwrap_or(false)
     }
 }
 
@@ -383,7 +431,8 @@ mod tests {
     fn test_format_detection() {
         let detector = FormatDetector::new();
 
-        // Test various format versions
+        // detect_from_version *classifies* (recognizes) a version; this is
+        // distinct from whether it is supported (see floor tests below).
         assert_eq!(
             detector.detect_from_version("nb").unwrap(),
             SSTableFormat::V4x("nb".to_string())
@@ -396,6 +445,80 @@ mod tests {
             detector.detect_from_version("oa").unwrap(),
             SSTableFormat::V5x("oa".to_string())
         );
+    }
+
+    /// #1249 R3: `is_supported` reflects the na+ read floor, NOT recognition.
+    /// Pre-`na` (`ma`–`me`, Cassandra 3.x) and 2.x letters MUST be unsupported,
+    /// while `na`/`nb`/`oa`/`da` MUST be supported. This keeps the preflight
+    /// API consistent with `SSTableReader`/`StatisticsReader::open`.
+    #[test]
+    fn test_is_supported_respects_na_floor() {
+        let detector = FormatDetector::new();
+
+        // Pre-`na` BIG (Cassandra 3.x) and 2.x: recognized but NOT supported.
+        for v in &["ma", "mb", "mc", "md", "me", "ic", "jb"] {
+            assert!(
+                !detector.is_supported(v),
+                "{} is below the na floor and must NOT be supported",
+                v
+            );
+            // Still recognizable/classifiable for diagnostics.
+            assert!(
+                detector.detect_from_version(v).is_ok(),
+                "{} must still be recognized (classified) for diagnostics",
+                v
+            );
+        }
+
+        // na+ floor: BIG na/nb and BIG/BTI oa/da are supported.
+        for v in &["na", "nb", "oa", "da"] {
+            assert!(detector.is_supported(v), "{} must be supported", v);
+        }
+
+        // Completely unknown letters are neither recognized nor supported.
+        assert!(!detector.is_supported("zz"));
+    }
+
+    /// #1249 R3: `supported_versions` enumerates ONLY the na+ floor and never
+    /// advertises any pre-`na` / 2.x version.
+    #[test]
+    fn test_supported_versions_excludes_pre_na() {
+        let detector = FormatDetector::new();
+        let supported = detector.supported_versions();
+
+        for v in &["ma", "mb", "mc", "md", "me", "ic", "jb"] {
+            assert!(
+                !supported.contains(&v.to_string()),
+                "supported_versions must NOT list pre-`na`/2.x version {}",
+                v
+            );
+        }
+        for v in &["na", "nb", "oa", "da"] {
+            assert!(
+                supported.contains(&v.to_string()),
+                "supported_versions must list na+ version {}",
+                v
+            );
+        }
+        // Exactly the four na+ versions, nothing else.
+        assert_eq!(
+            supported.len(),
+            4,
+            "supported set must be exactly {{na, nb, oa, da}}, got {:?}",
+            supported
+        );
+    }
+
+    /// `SSTableFormat::is_supported` family-level mapping (#1249).
+    #[test]
+    fn test_format_family_is_supported() {
+        assert!(SSTableFormat::V4x("na".to_string()).is_supported());
+        assert!(SSTableFormat::V4x("nb".to_string()).is_supported());
+        assert!(SSTableFormat::V5x("oa".to_string()).is_supported());
+        assert!(SSTableFormat::V5x("da".to_string()).is_supported());
+        assert!(!SSTableFormat::V3x("ma".to_string()).is_supported());
+        assert!(!SSTableFormat::V2x("jb".to_string()).is_supported());
+        assert!(!SSTableFormat::Unknown("zz".to_string()).is_supported());
     }
 
     #[test]

--- a/cqlite-core/src/storage/sstable/reader/header_helpers.rs
+++ b/cqlite-core/src/storage/sstable/reader/header_helpers.rs
@@ -14,17 +14,25 @@ use std::path::Path;
 pub(crate) fn extract_generation_from_path(path: &Path) -> u64 {
     let filename = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
 
-    // Common Cassandra SSTable filename patterns:
+    // Common Cassandra SSTable filename patterns (na+ floor, #1249):
     // nb-1-big-Data.db -> generation 1
-    // mc-1-big-Data.db -> generation 1
-    // la-123-big-Data.db -> generation 123
+    // oa-123-big-Data.db -> generation 123
+    // da-2-bti-Data.db -> generation 2
     // keyspace-table-nb-456-big-Data.db -> generation 456
+    //
+    // Only the na+ supported version letters are recognized here. Pre-`na`
+    // (`mc`) and 2.x (`la`) prefixes are NOT modeled — a below-floor SSTable is
+    // rejected with `UnsupportedVersion` at `SSTableReader::open` long before
+    // generation extraction runs, so this helper never legitimately sees them.
+
+    /// na+ BIG/BTI version letters this read-path helper recognizes (#1249).
+    const SUPPORTED_VERSION_PREFIXES: [&str; 4] = ["na", "nb", "oa", "da"];
 
     // Try to find generation number in different patterns
     let parts: Vec<&str> = filename.split('-').collect();
 
-    // Pattern 1: nb-{generation}-big-Data.db
-    if parts.len() >= 3 && (parts[0] == "nb" || parts[0] == "mc" || parts[0] == "la") {
+    // Pattern 1: {version}-{generation}-big-Data.db
+    if parts.len() >= 3 && SUPPORTED_VERSION_PREFIXES.contains(&parts[0]) {
         if let Ok(generation) = parts[1].parse::<u64>() {
             debug!(
                 "Extracted generation {} from pattern 1: {}",
@@ -34,10 +42,10 @@ pub(crate) fn extract_generation_from_path(path: &Path) -> u64 {
         }
     }
 
-    // Pattern 2: keyspace-table-nb-{generation}-big-Data.db
+    // Pattern 2: keyspace-table-{version}-{generation}-big-Data.db
     if parts.len() >= 5 {
         for i in 0..parts.len() - 2 {
-            if (parts[i] == "nb" || parts[i] == "mc" || parts[i] == "la") && i + 1 < parts.len() {
+            if SUPPORTED_VERSION_PREFIXES.contains(&parts[i]) && i + 1 < parts.len() {
                 if let Ok(generation) = parts[i + 1].parse::<u64>() {
                     log::debug!(
                         "Extracted generation {} from pattern 2: {}",

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -401,6 +401,11 @@ impl SSTableReader {
         // decisions until VG3 actually flips behaviour.
         let version_gates = Arc::new(match VersionGates::from_path(path) {
             Ok(gates) => gates,
+            // #1249: a parsed-but-below-floor version is FATAL — never degrade a
+            // pre-`na` (BIG) or non-`da` (BTI) SSTable to the nb fallback. Only a
+            // genuinely unparseable / structurally-malformed descriptor may fall
+            // back so existing tolerance for odd-but-5.0 filenames is preserved.
+            Err(e @ Error::UnsupportedVersion { .. }) => return Err(e),
             Err(e) => {
                 log::debug!(
                     "SSTableReader::open: could not derive VersionGates from {:?} ({}); \

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -334,6 +334,29 @@ impl SSTableReader {
 
     /// Open implementation; see [`open`](Self::open) for the instrumented wrapper.
     async fn open_inner(path: &Path, config: &Config, platform: Arc<Platform>) -> Result<Self> {
+        // #1249 (spec R1): reject below-floor versions BEFORE any file I/O.
+        // Gates derive solely from the filename, so this is the earliest point
+        // that can enforce the na+ floor — a pre-`na` (BIG) or non-`da` (BTI)
+        // descriptor is rejected with a typed `UnsupportedVersion` before we
+        // open/mmap/read the body (it never surfaces an I/O/parse error). Only a
+        // structurally-unparseable descriptor falls back to nb-compatible BIG
+        // gates (preserving existing tolerance for odd-but-5.0 unit-test paths);
+        // the gates do not change parsing decisions until VG3 flips behaviour.
+        let version_gates = Arc::new(match VersionGates::from_path(path) {
+            Ok(gates) => gates,
+            // A parsed-but-below-floor version is FATAL — never degrade it.
+            Err(e @ Error::UnsupportedVersion { .. }) => return Err(e),
+            Err(e) => {
+                log::debug!(
+                    "SSTableReader::open: could not derive VersionGates from {:?} ({}); \
+                     defaulting to nb-compatible BIG gates",
+                    path,
+                    e
+                );
+                VersionGates::Big(BigVersionGates::nb_fallback())
+            }
+        });
+
         // Resolve the disk-access backend (buffered / mmap / direct, or auto)
         // from config + environment overrides. See `Config::storage.disk_access_mode`.
         let mut reader_config = SSTableReaderConfig::default();
@@ -390,32 +413,6 @@ impl SSTableReader {
             let bytes_read = file_guard.read(&mut header_buffer).await?;
             header_buffer.truncate(bytes_read);
         }
-
-        // Derive VersionGates from the SSTable filename BEFORE header parsing so
-        // parse_header_with_version_detection can receive them.  Gates are derived
-        // solely from the filename and need no file I/O, so this is safe to do here.
-        //
-        // Falls back to nb-compatible BIG gates when the filename is not a valid
-        // SSTable descriptor (e.g. paths used in unit tests).  Using nb-fallback
-        // maintains existing behaviour — the gates will not change parsing
-        // decisions until VG3 actually flips behaviour.
-        let version_gates = Arc::new(match VersionGates::from_path(path) {
-            Ok(gates) => gates,
-            // #1249: a parsed-but-below-floor version is FATAL — never degrade a
-            // pre-`na` (BIG) or non-`da` (BTI) SSTable to the nb fallback. Only a
-            // genuinely unparseable / structurally-malformed descriptor may fall
-            // back so existing tolerance for odd-but-5.0 filenames is preserved.
-            Err(e @ Error::UnsupportedVersion { .. }) => return Err(e),
-            Err(e) => {
-                log::debug!(
-                    "SSTableReader::open: could not derive VersionGates from {:?} ({}); \
-                     defaulting to nb-compatible BIG gates",
-                    path,
-                    e
-                );
-                VersionGates::Big(BigVersionGates::nb_fallback())
-            }
-        });
 
         // VG5 / Issue #831 / #909: BTI ("da") read support.
         //

--- a/cqlite-core/src/storage/sstable/reader/tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/tests.rs
@@ -884,4 +884,68 @@ mod tests {
 
         Ok(())
     }
+
+    // -----------------------------------------------------------------------
+    // Version floor at open (#1249): the reader does NOT silently downgrade a
+    // below-floor SSTable to nb-fallback — it fails at open with the typed
+    // `Error::UnsupportedVersion`. A structurally-unparseable descriptor still
+    // tolerates the fallback (no `UnsupportedVersion` raised for it).
+    // -----------------------------------------------------------------------
+
+    /// R2: opening an SSTable whose descriptor parses to a pre-`na` BIG version
+    /// fails at open with `UnsupportedVersion` and does NOT proceed on the nb
+    /// fallback. Drives the public `SSTableReader::open` path (wiring evidence).
+    #[tokio::test]
+    async fn test_open_below_floor_version_fails_not_nb_fallback() {
+        use super::super::SSTableReader;
+        use crate::{Config, Error, Platform};
+        use std::sync::Arc;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        // A pre-`na` (Cassandra 3.x) BIG descriptor — valid filename shape,
+        // parses to version "mc", which is below the `na` floor.
+        let path = dir.path().join("mc-1-big-Data.db");
+        std::fs::write(&path, b"\x00\x01\x02\x03\x04\x05\x06\x07").expect("write fixture");
+
+        let config = Config::default();
+        let platform = Arc::new(Platform::new(&config).await.expect("platform"));
+
+        let err = SSTableReader::open(&path, &config, platform)
+            .await
+            .expect_err("below-floor open must fail, not fall back to nb");
+        match err {
+            Error::UnsupportedVersion { version, floor } => {
+                assert_eq!(version, "mc", "error names the offending version");
+                assert_eq!(floor, "na", "error names the na floor");
+            }
+            other => panic!("expected UnsupportedVersion at open, got {:?}", other),
+        }
+    }
+
+    /// R2: a structurally-unparseable descriptor (not a valid version string at
+    /// all) preserves the existing fallback behaviour — open may fail for other
+    /// reasons (e.g. header parse) but it must NOT raise `UnsupportedVersion`.
+    #[tokio::test]
+    async fn test_open_unparseable_descriptor_does_not_raise_unsupported_version() {
+        use super::super::SSTableReader;
+        use crate::{Config, Error, Platform};
+        use std::sync::Arc;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        // Not a valid SSTable descriptor (no version/format segments): the gate
+        // derivation cannot parse it and falls back to nb gates as before.
+        let path = dir.path().join("not-a-descriptor.db");
+        std::fs::write(&path, b"\x00\x01\x02\x03\x04\x05\x06\x07").expect("write fixture");
+
+        let config = Config::default();
+        let platform = Arc::new(Platform::new(&config).await.expect("platform"));
+
+        // Open will likely error later (bad header), but never with the typed
+        // version-floor error — that is the contract for unparseable descriptors.
+        if let Err(Error::UnsupportedVersion { .. }) =
+            SSTableReader::open(&path, &config, platform).await
+        {
+            panic!("unparseable descriptor must not raise UnsupportedVersion (fallback preserved)");
+        }
+    }
 }

--- a/cqlite-core/src/storage/sstable/reader/tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/tests.rs
@@ -948,4 +948,40 @@ mod tests {
             panic!("unparseable descriptor must not raise UnsupportedVersion (fallback preserved)");
         }
     }
+
+    /// R1 (roborev finding 1): the version-floor check fires BEFORE any file
+    /// I/O. A below-floor descriptor that does not even exist on disk must fail
+    /// with the typed `UnsupportedVersion` — NOT an I/O `NotFound` from
+    /// `tokio::fs::metadata` / `build_block_sources` — proving the reader never
+    /// opens, mmaps, or reads the body of a below-floor SSTable.
+    #[tokio::test]
+    async fn test_open_below_floor_rejected_before_any_file_io() {
+        use super::super::SSTableReader;
+        use crate::{Config, Error, Platform};
+        use std::sync::Arc;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        // Pre-`na` BIG descriptor that is intentionally NOT created on disk: if
+        // the floor check ran after file I/O we would get an I/O error here.
+        let path = dir.path().join("mc-1-big-Data.db");
+        assert!(!path.exists(), "fixture path must not exist on disk");
+
+        let config = Config::default();
+        let platform = Arc::new(Platform::new(&config).await.expect("platform"));
+
+        let err = SSTableReader::open(&path, &config, platform)
+            .await
+            .expect_err("below-floor open must fail before touching the file");
+        match err {
+            Error::UnsupportedVersion { version, floor } => {
+                assert_eq!(version, "mc");
+                assert_eq!(floor, "na");
+            }
+            other => panic!(
+                "expected UnsupportedVersion before file I/O, got {:?} \
+                 (a NotFound/I-O error would mean the floor check ran too late)",
+                other
+            ),
+        }
+    }
 }

--- a/cqlite-core/src/storage/sstable/statistics_reader.rs
+++ b/cqlite-core/src/storage/sstable/statistics_reader.rs
@@ -67,7 +67,24 @@ impl StatisticsReader {
         // (oa/da) `u32::MAX` no-deletion sentinel and the 12-byte modern histogram
         // bin width differ from the legacy (nb) signed-i32 / 16-byte forms. When the
         // filename does not parse, fall back to None (nb-compatible defaults).
-        let gates = crate::storage::sstable::version_gate::VersionGates::from_path(path).ok();
+        //
+        // #1249: a parsed-but-below-floor version is FATAL — propagate
+        // `Error::UnsupportedVersion` instead of silently degrading to nb-compatible
+        // defaults (mirrors `SSTableReader::open` in reader/mod.rs). Only a genuinely
+        // unparseable / structurally-malformed descriptor falls back to None.
+        let gates = match crate::storage::sstable::version_gate::VersionGates::from_path(path) {
+            Ok(gates) => Some(gates),
+            Err(e @ Error::UnsupportedVersion { .. }) => return Err(e),
+            Err(e) => {
+                log::debug!(
+                    "StatisticsReader::open: could not derive VersionGates from {:?} ({}); \
+                     defaulting to nb-compatible behaviour",
+                    path,
+                    e
+                );
+                None
+            }
+        };
         let statistics = match parse_statistics_with_fallback(&buffer, gates.as_ref()) {
             Ok((_, stats)) => stats,
             Err(e) => {
@@ -469,6 +486,46 @@ mod tests {
                     assert_eq!(stats_name, "users-123abc-Statistics.db");
                 }
             }
+        }
+    }
+
+    /// #1249 (roborev finding 1): a below-floor `*-Statistics.db` descriptor
+    /// MUST make `StatisticsReader::open` fail with a typed
+    /// `Error::UnsupportedVersion` rather than silently degrading to
+    /// nb-compatible defaults and proceeding to parse. Drives the public
+    /// `StatisticsReader::open` surface against a real on-disk file whose
+    /// version (`ma`, a pre-`na` BIG version) is below the floor.
+    #[tokio::test]
+    async fn test_open_below_floor_statistics_rejected() {
+        use crate::error::Error;
+        use std::sync::Arc;
+
+        let dir = tempfile::tempdir().expect("create tempdir");
+        // `ma` is a pre-`na` BIG version, below the version floor (#1249).
+        let path = dir.path().join("ma-1-big-Statistics.db");
+        // The file must exist: the existence check precedes gate derivation, so
+        // we are exercising the gate-floor branch and not the not-found branch.
+        std::fs::write(&path, b"not really a valid statistics file").expect("write fixture");
+
+        let config = crate::Config::default();
+        let platform = Arc::new(
+            crate::Platform::new(&config)
+                .await
+                .expect("create platform"),
+        );
+
+        let result = super::StatisticsReader::open(&path, platform).await;
+
+        match result {
+            Err(Error::UnsupportedVersion { version, floor }) => {
+                assert_eq!(version, "ma", "error must name the offending version");
+                assert_eq!(floor, "na", "error must name the na BIG floor");
+            }
+            Err(other) => panic!(
+                "expected UnsupportedVersion for below-floor Statistics.db, got {:?}",
+                other
+            ),
+            Ok(_) => panic!("below-floor Statistics.db must NOT open on nb-compatible defaults"),
         }
     }
 }

--- a/cqlite-core/src/storage/sstable/statistics_reader.rs
+++ b/cqlite-core/src/storage/sstable/statistics_reader.rs
@@ -53,13 +53,6 @@ impl StatisticsReader {
             )));
         }
 
-        // Read the entire file (Statistics.db files are typically small)
-        let mut file = File::open(path).await?;
-        let mut buffer = Vec::new();
-        file.read_to_end(&mut buffer).await?;
-
-        // Parse the statistics data using enhanced parser with fallback.
-        //
         // Derive the format gates from the component filename (e.g.
         // `da-1-bti-Statistics.db` vs `nb-1-big-Statistics.db`) so the best-effort
         // STATS-extras decode (max local deletion time + tombstone-drop histogram,
@@ -68,10 +61,13 @@ impl StatisticsReader {
         // bin width differ from the legacy (nb) signed-i32 / 16-byte forms. When the
         // filename does not parse, fall back to None (nb-compatible defaults).
         //
-        // #1249: a parsed-but-below-floor version is FATAL — propagate
-        // `Error::UnsupportedVersion` instead of silently degrading to nb-compatible
-        // defaults (mirrors `SSTableReader::open` in reader/mod.rs). Only a genuinely
-        // unparseable / structurally-malformed descriptor falls back to None.
+        // #1249 (spec R1): reject below-floor versions BEFORE reading the file.
+        // Gates derive solely from the filename (no file I/O), so a parsed-but-
+        // below-floor version is propagated as a FATAL `Error::UnsupportedVersion`
+        // here — before `File::open`/`read_to_end` — instead of silently degrading
+        // to nb-compatible defaults (mirrors `SSTableReader::open` in reader/mod.rs).
+        // Only a genuinely unparseable / structurally-malformed descriptor falls
+        // back to None.
         let gates = match crate::storage::sstable::version_gate::VersionGates::from_path(path) {
             Ok(gates) => Some(gates),
             Err(e @ Error::UnsupportedVersion { .. }) => return Err(e),
@@ -85,6 +81,14 @@ impl StatisticsReader {
                 None
             }
         };
+
+        // Read the entire file (Statistics.db files are typically small).
+        // Reached only for at-or-above-floor (or structurally-unparseable)
+        // descriptors — a below-floor version was already rejected above.
+        let mut file = File::open(path).await?;
+        let mut buffer = Vec::new();
+        file.read_to_end(&mut buffer).await?;
+
         let statistics = match parse_statistics_with_fallback(&buffer, gates.as_ref()) {
             Ok((_, stats)) => stats,
             Err(e) => {
@@ -526,6 +530,45 @@ mod tests {
                 other
             ),
             Ok(_) => panic!("below-floor Statistics.db must NOT open on nb-compatible defaults"),
+        }
+    }
+
+    /// #1249 R1 (roborev finding 1): the version-floor check fires BEFORE the
+    /// file body is read/parsed. A below-floor `*-Statistics.db` with an empty
+    /// (0-byte) body must STILL fail with `UnsupportedVersion` rather than a
+    /// parse/corruption error — proving `read_to_end` + the enhanced parser are
+    /// never reached for a below-floor descriptor.
+    #[tokio::test]
+    async fn test_open_below_floor_statistics_rejected_before_body_read() {
+        use crate::error::Error;
+        use std::sync::Arc;
+
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let path = dir.path().join("ma-1-big-Statistics.db");
+        // Empty body: if the gate ran AFTER read_to_end/parse, an empty file
+        // would surface as a parse/corruption error, not UnsupportedVersion.
+        std::fs::write(&path, b"").expect("write empty fixture");
+
+        let config = crate::Config::default();
+        let platform = Arc::new(
+            crate::Platform::new(&config)
+                .await
+                .expect("create platform"),
+        );
+
+        match super::StatisticsReader::open(&path, platform).await {
+            Err(Error::UnsupportedVersion { version, floor }) => {
+                assert_eq!(version, "ma");
+                assert_eq!(floor, "na");
+            }
+            Err(other) => panic!(
+                "expected UnsupportedVersion before body read for empty below-floor \
+                 Statistics.db, got {:?}",
+                other
+            ),
+            Ok(_) => {
+                panic!("below-floor Statistics.db with empty body must be rejected before parse")
+            }
         }
     }
 }

--- a/cqlite-core/src/storage/sstable/statistics_reader.rs
+++ b/cqlite-core/src/storage/sstable/statistics_reader.rs
@@ -46,13 +46,6 @@ pub struct StatisticsReader {
 impl StatisticsReader {
     /// Open and parse a Statistics.db file
     pub async fn open(path: &Path, platform: Arc<Platform>) -> Result<Self> {
-        if !platform.fs().exists(path).await? {
-            return Err(Error::not_found(format!(
-                "Statistics.db file not found: {}",
-                path.display()
-            )));
-        }
-
         // Derive the format gates from the component filename (e.g.
         // `da-1-bti-Statistics.db` vs `nb-1-big-Statistics.db`) so the best-effort
         // STATS-extras decode (max local deletion time + tombstone-drop histogram,
@@ -61,13 +54,16 @@ impl StatisticsReader {
         // bin width differ from the legacy (nb) signed-i32 / 16-byte forms. When the
         // filename does not parse, fall back to None (nb-compatible defaults).
         //
-        // #1249 (spec R1): reject below-floor versions BEFORE reading the file.
-        // Gates derive solely from the filename (no file I/O), so a parsed-but-
+        // #1249 (spec R1): reject below-floor versions BEFORE *any* filesystem
+        // access. Gates derive solely from the filename string (no file I/O), so
+        // this is the earliest point the na+ floor can be enforced: a parsed-but-
         // below-floor version is propagated as a FATAL `Error::UnsupportedVersion`
-        // here — before `File::open`/`read_to_end` — instead of silently degrading
-        // to nb-compatible defaults (mirrors `SSTableReader::open` in reader/mod.rs).
-        // Only a genuinely unparseable / structurally-malformed descriptor falls
-        // back to None.
+        // here — before the existence check, `File::open`, and `read_to_end` —
+        // instead of returning `NotFound` after touching the filesystem or
+        // silently degrading to nb-compatible defaults (mirrors
+        // `SSTableReader::open_inner` in reader/mod.rs, which gates before
+        // `tokio::fs::metadata`). Only a genuinely unparseable / structurally-
+        // malformed descriptor falls back to None and proceeds to the FS checks.
         let gates = match crate::storage::sstable::version_gate::VersionGates::from_path(path) {
             Ok(gates) => Some(gates),
             Err(e @ Error::UnsupportedVersion { .. }) => return Err(e),
@@ -81,6 +77,13 @@ impl StatisticsReader {
                 None
             }
         };
+
+        if !platform.fs().exists(path).await? {
+            return Err(Error::not_found(format!(
+                "Statistics.db file not found: {}",
+                path.display()
+            )));
+        }
 
         // Read the entire file (Statistics.db files are typically small).
         // Reached only for at-or-above-floor (or structurally-unparseable)
@@ -507,8 +510,9 @@ mod tests {
         let dir = tempfile::tempdir().expect("create tempdir");
         // `ma` is a pre-`na` BIG version, below the version floor (#1249).
         let path = dir.path().join("ma-1-big-Statistics.db");
-        // The file must exist: the existence check precedes gate derivation, so
-        // we are exercising the gate-floor branch and not the not-found branch.
+        // A present-but-below-floor file must still be rejected with the typed
+        // floor error rather than parsed; this exercises the gate-floor branch
+        // for an on-disk file.
         std::fs::write(&path, b"not really a valid statistics file").expect("write fixture");
 
         let config = crate::Config::default();
@@ -569,6 +573,47 @@ mod tests {
             Ok(_) => {
                 panic!("below-floor Statistics.db with empty body must be rejected before parse")
             }
+        }
+    }
+
+    /// #1249 R1: the version-floor check fires BEFORE *any* filesystem access.
+    /// A below-floor `*-Statistics.db` descriptor whose path does NOT exist on
+    /// disk must STILL fail with the typed `Error::UnsupportedVersion`, NOT a
+    /// `NotFound`/I/O error. This proves the floor is enforced from the filename
+    /// alone, before the existence check, `File::open`, and `read_to_end`
+    /// (mirrors `SSTableReader::open_inner` gating before `tokio::fs::metadata`).
+    #[tokio::test]
+    async fn test_open_below_floor_statistics_rejected_before_fs_access() {
+        use crate::error::Error;
+        use std::sync::Arc;
+
+        let dir = tempfile::tempdir().expect("create tempdir");
+        // `ma` is below the `na` BIG floor. Deliberately DO NOT create the file:
+        // if the existence check ran first, this would surface as NotFound.
+        let path = dir.path().join("ma-1-big-Statistics.db");
+        assert!(
+            !path.exists(),
+            "fixture path must not exist on disk for this test"
+        );
+
+        let config = crate::Config::default();
+        let platform = Arc::new(
+            crate::Platform::new(&config)
+                .await
+                .expect("create platform"),
+        );
+
+        match super::StatisticsReader::open(&path, platform).await {
+            Err(Error::UnsupportedVersion { version, floor }) => {
+                assert_eq!(version, "ma", "error must name the offending version");
+                assert_eq!(floor, "na", "error must name the na BIG floor");
+            }
+            Err(other) => panic!(
+                "expected UnsupportedVersion before any FS access for a nonexistent \
+                 below-floor Statistics.db, got {:?}",
+                other
+            ),
+            Ok(_) => panic!("below-floor Statistics.db must NOT open even when absent"),
         }
     }
 }

--- a/cqlite-core/src/storage/sstable/version_gate.rs
+++ b/cqlite-core/src/storage/sstable/version_gate.rs
@@ -296,7 +296,9 @@ impl BigVersionGates {
     ///
     /// # Errors
     ///
-    /// Returns `Err` if `version` is not exactly two ASCII lowercase letters.
+    /// Returns `Err(Error::InvalidFormat)` if `version` is not exactly two
+    /// ASCII lowercase letters, and `Err(Error::UnsupportedVersion)` if the
+    /// version is below the supported floor (`na`).
     pub fn from_version(version: &str) -> Result<Self> {
         if version.len() != 2 || !version.chars().all(|c| c.is_ascii_lowercase()) {
             return Err(Error::InvalidFormat(format!(
@@ -307,41 +309,45 @@ impl BigVersionGates {
 
         let v = version;
 
-        // `version.matches("(m[d-z])|(n[a-z])")` from BigFormat.java line 397.
-        let has_accurate_min_max = {
-            let first = v.chars().next().unwrap();
-            let second = v.chars().nth(1).unwrap();
-            (first == 'm' && ('d'..='z').contains(&second))
-                || (first == 'n' && second.is_ascii_lowercase())
-        };
+        // #1249: the supported BIG floor is `na` (Cassandra 5.0). Pre-`na`
+        // (`ma`–`me`, Cassandra 3.x) is out of scope and rejected here so the
+        // struct never *models* a below-floor version as readable. Because of
+        // this, every gate threshold below collapses to "`na` and above" — the
+        // old `mb`/`mc`/`md`/`me` branches are unreachable and are gone.
+        if v < "na" {
+            return Err(Error::UnsupportedVersion {
+                version: version.to_string(),
+                floor: "na".to_string(),
+            });
+        }
 
-        // `version.matches("(m[a-z])|(n[a-z])")` from BigFormat.java line 398.
-        let has_legacy_min_max = {
-            let first = v.chars().next().unwrap();
-            let second = v.chars().nth(1).unwrap();
-            (first == 'm' && second.is_ascii_lowercase())
-                || (first == 'n' && second.is_ascii_lowercase())
-        };
+        // BigFormat.java:397-398. Both predicates match only `n[a-z]` once the
+        // pre-`na` arms are gone: `m[d-z]`/`m[a-z]` are unreachable below the
+        // floor, and `oa` (first letter `o`) matches neither (both deprecated
+        // in `oa`). So both gates are exactly "first letter is `n`".
+        let first = v.chars().next().unwrap_or('\0');
+        let has_accurate_min_max = first == 'n';
+        let has_legacy_min_max = first == 'n';
 
-        // `version.compareTo("nb") >= 0 || version.matches("(m[e-z])")` (line 400).
-        let has_originating_host_id = {
-            let first = v.chars().next().unwrap();
-            let second = v.chars().nth(1).unwrap();
-            v >= "nb" || (first == 'm' && ('e'..='z').contains(&second))
-        };
+        // `version.compareTo("nb") >= 0` (BigFormat.java:400); the `m[e-z]` arm
+        // is unreachable now that pre-`na` is rejected.
+        let has_originating_host_id = v >= "nb";
 
         Ok(Self {
             version: version.to_string(),
-            has_commit_log_lower_bound: v >= "mb",
-            has_commit_log_intervals: v >= "mc",
+            // All of these were introduced at or before `na`, so they are
+            // unconditionally TRUE at the floor and above.
+            has_commit_log_lower_bound: true,
+            has_commit_log_intervals: true,
             has_accurate_min_max,
             has_legacy_min_max,
             has_originating_host_id,
-            has_max_compressed_length: v >= "na",
-            has_pending_repair: v >= "na",
-            has_is_transient: v >= "na",
-            has_metadata_checksum: v >= "na",
-            has_old_bf_format: v < "na",
+            has_max_compressed_length: true,
+            has_pending_repair: true,
+            has_is_transient: true,
+            has_metadata_checksum: true,
+            // `hasOldBfFormat` is `v < "na"`, which is never true at the floor.
+            has_old_bf_format: false,
             // oa-only gates: all false for nb, all true for oa
             has_improved_min_max: v >= "oa",
             has_partition_level_deletion_presence_marker: v >= "oa",
@@ -349,17 +355,6 @@ impl BigVersionGates {
             has_uint_deletion_time: v >= "oa",
             has_token_space_coverage: v >= "oa",
         })
-    }
-
-    /// Returns `true` if this version is compatible for reading according to
-    /// `BigVersion.isCompatible()` (BigFormat.java:516-519).
-    ///
-    /// A version is compatible when:
-    /// - It is >= `ma` (the earliest supported version), **and**
-    /// - Its first letter is <= `o` (the first letter of the current `oa`)
-    pub fn is_compatible(&self) -> bool {
-        let v = self.version.as_str();
-        v >= "ma" && v.chars().next().is_some_and(|c| c <= 'o')
     }
 
     /// Returns `true` when this is a stock Cassandra 5.0 default-mode SSTable
@@ -453,13 +448,14 @@ impl BtiVersionGates {
     ///
     /// # Errors
     ///
-    /// Returns `Err` if the version is not `"da"` (the only BTI version).
+    /// Returns `Err(Error::UnsupportedVersion)` if the version is not `"da"`
+    /// (the only supported BTI version; #1249 version floor).
     pub fn from_version(version: &str) -> Result<Self> {
         if version != "da" {
-            return Err(Error::InvalidFormat(format!(
-                "BTI format only supports version 'da', got {:?}",
-                version
-            )));
+            return Err(Error::UnsupportedVersion {
+                version: version.to_string(),
+                floor: "da".to_string(),
+            });
         }
         Ok(Self {
             version: version.to_string(),
@@ -724,37 +720,16 @@ mod tests {
     // BigVersionGates: hasOriginatingHostId straddle gate
     // -----------------------------------------------------------------------
 
-    /// `hasOriginatingHostId` introduced in `me` (straddles letter boundary).
-    /// Source: BigFormat.java:400
-    ///   `version.compareTo("nb") >= 0 || version.matches("(m[e-z])")`
+    /// `hasOriginatingHostId` is TRUE from `nb` onward (the `m[e-z]` arm of the
+    /// Cassandra predicate is unreachable now that pre-`na` is rejected at the
+    /// floor; see `from_version`). `na` (< `nb`) must be FALSE.
     #[test]
     fn test_originating_host_id_straddle_gate() {
-        // Must be FALSE for versions before me in the m-series
-        for v in &["ma", "mb", "mc", "md"] {
-            let g = BigVersionGates::from_version(v).unwrap();
-            assert!(
-                !g.has_originating_host_id,
-                "{}: hasOriginatingHostId must be FALSE",
-                v
-            );
-        }
-
-        // Must be TRUE for me..mz
-        for v in &["me", "mf", "mz"] {
-            let g = BigVersionGates::from_version(v).unwrap();
-            assert!(
-                g.has_originating_host_id,
-                "{}: hasOriginatingHostId must be TRUE (m[e-z] match)",
-                v
-            );
-        }
-
-        // Must be TRUE for na..nz (>= nb is lexicographically satisfied by the
-        // whole n-series above nb: na < nb so na must be FALSE)
+        // na (< nb): FALSE
         let na = BigVersionGates::from_version("na").unwrap();
         assert!(
             !na.has_originating_host_id,
-            "na: hasOriginatingHostId must be FALSE (na < nb, not m[e-z])"
+            "na: hasOriginatingHostId must be FALSE (na < nb)"
         );
 
         // nb and above: TRUE
@@ -769,25 +744,8 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // BigVersionGates: older versions
+    // BigVersionGates: na (the supported floor)
     // -----------------------------------------------------------------------
-
-    #[test]
-    fn test_big_ma_gates() {
-        let g = BigVersionGates::from_version("ma").unwrap();
-        // ma has none of the later features
-        assert!(!g.has_commit_log_lower_bound);
-        assert!(!g.has_commit_log_intervals);
-        assert!(!g.has_accurate_min_max);
-        assert!(g.has_legacy_min_max, "ma is in m[a-z]");
-        assert!(!g.has_originating_host_id);
-        assert!(!g.has_max_compressed_length);
-        assert!(g.has_old_bf_format, "ma: hasOldBfFormat");
-        assert!(!g.has_improved_min_max);
-        assert!(!g.has_key_range);
-        assert!(!g.has_uint_deletion_time);
-        assert!(!g.has_token_space_coverage);
-    }
 
     #[test]
     fn test_big_na_gates() {
@@ -803,39 +761,42 @@ mod tests {
         assert!(!g.has_improved_min_max, "oa-only");
     }
 
-    #[test]
-    fn test_big_md_gates() {
-        let g = BigVersionGates::from_version("md").unwrap();
-        assert!(g.has_accurate_min_max, "md is m[d-z]");
-        assert!(g.has_legacy_min_max, "md is m[a-z]");
-        assert!(!g.has_originating_host_id, "md < me");
-    }
-
-    #[test]
-    fn test_big_me_gates() {
-        let g = BigVersionGates::from_version("me").unwrap();
-        assert!(g.has_accurate_min_max, "me is m[d-z]");
-        assert!(g.has_originating_host_id, "me matches m[e-z]");
-    }
-
     // -----------------------------------------------------------------------
-    // BigVersionGates: isCompatible
+    // Version floor (#1249): pre-`na` BIG is rejected at the floor with a
+    // typed `Error::UnsupportedVersion` naming the version + floor.
     // -----------------------------------------------------------------------
 
+    /// R1/R3: a below-`na` BIG version yields `UnsupportedVersion`, not gates.
     #[test]
-    fn test_big_is_compatible() {
-        // All known valid versions should be compatible
-        for v in &["ma", "mb", "mc", "md", "me", "na", "nb", "oa"] {
-            let g = BigVersionGates::from_version(v).unwrap();
-            assert!(g.is_compatible(), "{} should be compatible", v);
+    fn test_big_below_na_rejected_with_typed_error() {
+        for v in &["ma", "mb", "mc", "md", "me"] {
+            let err = BigVersionGates::from_version(v)
+                .expect_err(&format!("{} is below the na floor and must be rejected", v));
+            match err {
+                Error::UnsupportedVersion { version, floor } => {
+                    assert_eq!(version, *v, "error must name the offending version");
+                    assert_eq!(floor, "na", "error must name the na floor");
+                }
+                other => panic!("{}: expected UnsupportedVersion, got {:?}", v, other),
+            }
         }
-        // 'pa' would be next major after oa — not compatible if current is oa
-        // (first letter 'p' > 'o')
-        let pa = BigVersionGates::from_version("pa").unwrap();
+    }
+
+    /// R3: there is no branch returning usable gates for a below-floor version.
+    #[test]
+    fn test_big_below_na_yields_no_usable_gates() {
         assert!(
-            !pa.is_compatible(),
-            "pa is beyond current 'oa' major letter"
+            BigVersionGates::from_version("ma").is_err(),
+            "ma must not construct usable gates"
         );
+        // Supported floor and above still succeed.
+        for v in &["na", "nb", "oa"] {
+            assert!(
+                BigVersionGates::from_version(v).is_ok(),
+                "{} must still construct gates",
+                v
+            );
+        }
     }
 
     #[test]
@@ -947,11 +908,24 @@ mod tests {
         assert!(g.has_uint_deletion_time);
     }
 
+    /// R1: a non-`da` BTI version is rejected with the typed
+    /// `Error::UnsupportedVersion` (naming the `da` floor), not a generic
+    /// `InvalidFormat`.
     #[test]
     fn test_bti_rejects_non_da() {
-        assert!(BtiVersionGates::from_version("nb").is_err());
-        assert!(BtiVersionGates::from_version("oa").is_err());
-        assert!(BtiVersionGates::from_version("na").is_err());
+        for v in &["nb", "oa", "na", "ca"] {
+            let err = BtiVersionGates::from_version(v)
+                .expect_err(&format!("{} is not da and must be rejected", v));
+            match err {
+                Error::UnsupportedVersion { version, floor } => {
+                    assert_eq!(version, *v, "error must name the offending version");
+                    assert_eq!(floor, "da", "error must name the da floor");
+                }
+                other => panic!("{}: expected UnsupportedVersion, got {:?}", v, other),
+            }
+        }
+        // The single supported BTI version still constructs gates.
+        assert!(BtiVersionGates::from_version("da").is_ok());
     }
 
     // -----------------------------------------------------------------------

--- a/cqlite-core/src/storage/sstable/version_gate.rs
+++ b/cqlite-core/src/storage/sstable/version_gate.rs
@@ -770,8 +770,10 @@ mod tests {
     #[test]
     fn test_big_below_na_rejected_with_typed_error() {
         for v in &["ma", "mb", "mc", "md", "me"] {
-            let err = BigVersionGates::from_version(v)
-                .expect_err(&format!("{} is below the na floor and must be rejected", v));
+            let err = match BigVersionGates::from_version(v) {
+                Ok(_) => panic!("{} is below the na floor and must be rejected", v),
+                Err(e) => e,
+            };
             match err {
                 Error::UnsupportedVersion { version, floor } => {
                     assert_eq!(version, *v, "error must name the offending version");
@@ -914,8 +916,10 @@ mod tests {
     #[test]
     fn test_bti_rejects_non_da() {
         for v in &["nb", "oa", "na", "ca"] {
-            let err = BtiVersionGates::from_version(v)
-                .expect_err(&format!("{} is not da and must be rejected", v));
+            let err = match BtiVersionGates::from_version(v) {
+                Ok(_) => panic!("{} is not da and must be rejected", v),
+                Err(e) => e,
+            };
             match err {
                 Error::UnsupportedVersion { version, floor } => {
                     assert_eq!(version, *v, "error must name the offending version");

--- a/openspec/changes/sstable-version-floor/design.md
+++ b/openspec/changes/sstable-version-floor/design.md
@@ -1,0 +1,87 @@
+## Context
+
+The Cassandra-5.0 support floor exists only implicitly (magic-number mismatch) and is contradicted by
+dead modeling code that spans Cassandra 3.x. The audit (file:line in `proposal.md`) pins three facts
+that drive the design:
+
+1. The only thing that rejects pre-`na` today is an **untyped nom error** at header-read time, not a
+   version check at descriptor time.
+2. `BigVersionGates::is_compatible()` is **dead** and its predicate `v >= "ma"` *admits* `ma`–`me` —
+   the exact surface that mislead reviewers on #1021.
+3. The reader's `nb_fallback()` arm (`reader/mod.rs:411`) **swallows** descriptor-parse failures and
+   continues as `nb`. Any floor check that lives only in descriptor parsing is silently bypassed here.
+
+## Goals / Non-Goals
+
+- **Goal:** one named, enforced floor that rejects pre-`na` at open with a typed error + a test that
+  proves it (not implicit magic mismatch).
+- **Goal:** remove the pre-`na` correctness surface so reviewers/authors stop trying to make `ma`–`me`
+  correct; declare the floor as doctrine.
+- **Non-goal:** adding/removing 5.0 format support, re-architecting gates, write-path changes.
+
+## Decisions
+
+### Decision 1 — Floor lives in version parsing, enforced as a typed error; reader fallback is tightened
+
+**Chosen:** Add the floor check at `BigVersionGates::from_version` (`version_gate.rs:300`) — the single
+function that validates the BIG version string — returning a new typed `Error::UnsupportedVersion`
+when the version is below `na`. AND tighten `reader/mod.rs:402-413` so that arm propagates an
+`UnsupportedVersion` error (fatal) instead of degrading to `nb_fallback()`; only a genuinely
+*unparseable / structurally-malformed* descriptor (not a parsed-but-below-floor one) may fall back.
+
+- **What it beat — "floor only in `from_version`":** rejected because `reader/mod.rs:411` swallows the
+  error and continues as `nb`, so the floor would not bite and AC #1's test could not pass.
+- **What it beat — "floor only at the magic table":** rejected because the version *string* (which is
+  what `na`/`nb`/`oa`/`da` is) comes from the **filename descriptor**, not the magic; a pre-`na`
+  filename with a (hypothetically) matching magic, or the common real case of a pre-`na` file, is best
+  caught at the version string with a clear message naming the floor — and the magic path only yields an
+  untyped error at a later stage.
+- **What it beat — "a brand-new standalone `version_floor()` module":** rejected as redundant;
+  `from_version` already shape-validates the version and is the natural single authority. The floor is
+  one comparison there, plus the doctrine line names it.
+
+The floor constant is `na` (BIG). BTI is already floored at `da` by `BtiVersionGates::from_version`
+(`version_gate.rs:457-463`), which rejects anything but `da` — that path already enforces a floor and a
+typed-error upgrade there is in scope so both gate families speak the same error.
+
+### Decision 2 — New typed `Error::UnsupportedVersion` variant (vs reuse `UnsupportedFormat`)
+
+**Chosen:** add `Error::UnsupportedVersion { version: String, floor: String }` (additive enum variant)
+mapping to the existing non-recoverable `ErrorCategory::Data`.
+
+- **What it beat — "reuse `UnsupportedFormat(String)`":** a distinct variant lets tests and
+  review-criteria key on the *category* "below floor" rather than string-matching, and reads clearly at
+  the call site. It is additive (no breaking change to existing variants).
+
+### Decision 3 — Delete the dead pre-`na` modeling surface (vs mark test-only)
+
+**Chosen:** **delete** `BigVersionGates::is_compatible()` (dead; only callers are its own unit test) and
+its test, and make `BigVersionGates::from_version` reject `< na` (Decision 1) so the struct no longer
+*models* pre-`na` as acceptable. Gate-threshold branches that only mattered for `mb`/`mc`/`md`/`me`
+become unreachable once `< na` is rejected and are simplified/removed with a comment that the floor is
+`na`.
+
+- **What it beat — "mark `#[cfg(test)]` / leave a comment":** leaving the code (even annotated) keeps a
+  predicate that admits `ma` in the tree, which is exactly what re-triggers pre-`na` review churn.
+  Deletion removes the surface entirely; doctrine + the floor gate are the durable record.
+
+### Decision 4 — Doctrine in both CLAUDE.md and the agents-developing site
+
+**Chosen:** add a **"Supported formats"** rule (not prose) to `CLAUDE.md` under Development Standards,
+and mirror it on the `agents-developing/` doctrine (the no-heuristics / gate-contract neighborhood) so
+roborev's repo-context read carries the 5.0 scope and the "do not review pre-`na` correctness"
+instruction. The rule states the accepted set (`na`/`nb` BIG, `oa`/`da` BTI) and the explicit
+out-of-scope (`ma`–`me`).
+
+## Risks / Trade-offs
+
+- **Risk:** an existing test or fixture relies on `from_version` accepting a `< na` string. *Mitigation:*
+  the implementer greps for `ma`/`mb`/`mc`/`md`/`me` literals in tests (the audit found these only in
+  `version_gate.rs` tests) and updates/removes them as part of the change; the gate runs the full suite.
+- **Trade-off:** tightening `nb_fallback()` narrows a permissive path. *Mitigation:* only a parsed
+  below-floor version becomes fatal; a structurally-unparseable descriptor still degrades, preserving
+  today's tolerance for odd-but-5.0 filenames.
+
+## Migration
+
+None. No data migration; additive error variant; no public API removed (the deleted method is dead).

--- a/openspec/changes/sstable-version-floor/proposal.md
+++ b/openspec/changes/sstable-version-floor/proposal.md
@@ -1,0 +1,64 @@
+## Why
+
+While landing #1021 (repair-metadata-through-compaction), roborev raised a **series of "regression
+for older SSTable versions" findings** about pre-`na` (Cassandra 3.x `ma`–`me`) formats — driving ~4
+review rounds + 3 implementer dispatches on out-of-scope work before we recognized **CQLite does not
+read pre-`na` at all**. The findings were not roborev malfunctioning: the code carries pre-`na`
+*modeling surface* (version gates whose predicates span `ma`–`me`), and a reviewer reasonably reads
+"this branch exists ⇒ it must be correct." There is **no single authoritative statement — in code or
+doctrine — that the support floor is Cassandra 5.0**. This recurs on any change touching the
+version-gate / parser layer.
+
+A read-only audit confirmed the floor is real but **emergent, not declared or enforced**:
+
+- `cqlite-core/src/parser/header.rs:330-352` — `SUPPORTED_MAGIC_NUMBERS` contains only Cassandra 5.0 /
+  legacy-`oa` magics; **no `ma`–`me` magic exists**, so pre-`na` files are rejected *implicitly* by
+  magic mismatch — and that rejection is an **untyped nom parser error** (`header.rs:438,453-456`), not
+  a typed version error, surfaced only at header-read time.
+- `cqlite-core/src/storage/sstable/version_gate.rs:360` — `BigVersionGates::is_compatible()` is
+  **dead/test-only** (its only callers are the unit test in the same file), and its predicate
+  `v >= "ma"` actually **admits** Cassandra 3.x. This is precisely the pre-`na` modeling surface that
+  invites pre-`na` review findings.
+- `BigVersionGates::from_version` (`version_gate.rs:300`) accepts **any** two-lowercase-letter version
+  string and models gate thresholds across `mb`/`mc`/`md`/`me`/`na`/`nb`/`oa` — so it half-handles
+  pre-`na` by formula.
+- `cqlite-core/src/storage/sstable/reader/mod.rs:402-413` — derives gates from the filename, but on
+  **any** descriptor parse failure **silently falls back to `nb` BIG gates** (`mod.rs:411`) and
+  continues. This escape hatch means a floor check placed in descriptor parsing alone would be
+  **bypassed** — it must be addressed for any floor to actually bite.
+- `cqlite-core/src/error.rs` — has `InvalidFormat`/`UnsupportedFormat` but **no** typed
+  `UnsupportedVersion` variant.
+- `CLAUDE.md` — states "reads Cassandra 5.0 data files" in **prose only** (`CLAUDE.md:7`); there is no
+  floor stated as a **rule**.
+
+- **Milestone:** maintenance / process hardening. **Design-driven** (doctrine + a small enforcement
+  gate; touches contributor doctrine and a public error variant — real latitude in where the floor
+  lives and whether the pre-`na` surface is deleted vs quarantined). There is no Cassandra SSTable
+  format oracle being newly decoded here.
+- Adds a new `sstable-version-floor` capability.
+
+## What Changes
+
+- **Explicit, enforced version-floor gate.** Add a single authoritative minimum-supported-version check
+  that rejects pre-`na` (`ma`–`me`) at descriptor/open time with a **typed** error, replacing reliance
+  on implicit magic mismatch. One named place declares "we support `na`+ (`nb`/`oa` BIG, `da` BTI);
+  everything older is rejected here."
+- **Tighten the reader fallback so the floor bites.** The `nb_fallback()` arm in `reader/mod.rs` must
+  distinguish a *below-floor* descriptor (fatal — propagate the typed error) from a genuinely
+  *unparseable* descriptor; a pre-`na` version string must NOT degrade to `nb` and continue.
+- **Quarantine/remove the pre-`na` modeling surface.** Remove the dead `BigVersionGates::is_compatible()`
+  (test-only, and its predicate wrongly admits `ma`), and make `BigVersionGates` stop *modeling* pre-`na`
+  as an acceptable read surface so no reviewer/author tries to make `ma`–`me` "correct."
+- **Doctrine line (source of truth).** Add an explicit **"Supported formats"** rule to `CLAUDE.md` and
+  the published `agents-developing/` doctrine: *CQLite targets Cassandra 5.0 (`na`+/`nb` BIG, `oa`/`da`
+  BTI); pre-`na` (`ma`–`me`, Cassandra 3.x) is out of scope — do not introduce, support, or review
+  pre-`na` correctness.* Includes the "do not review pre-`na`" guidance for reviewers/roborev.
+
+## Non-goals
+
+- **No new format support.** This does not add pre-`na` reading, nor change which 5.0 formats are read.
+- **No re-architecture of version gates / VG3 wiring.** The gates' parsing-behavior wiring
+  (`reader/types.rs:273-279`) stays as-is; we only add the floor and remove dead pre-`na` surface.
+- **No change to the magic-number table or header decode** beyond what the typed floor error requires;
+  the magic table already excludes pre-`na`.
+- **No write-path changes.** CQLite only writes `na`+/`da`; the floor is a read-path concern.

--- a/openspec/changes/sstable-version-floor/specs/sstable-version-floor/spec.md
+++ b/openspec/changes/sstable-version-floor/specs/sstable-version-floor/spec.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+### Requirement: A single enforced version floor rejects pre-`na` SSTables at open with a typed error
+CQLite SHALL enforce a single, named minimum-supported SSTable version. A BIG-format SSTable whose
+version is below `na` (i.e. Cassandra 3.x `ma`–`me`) SHALL be rejected at descriptor/version-parse time
+with a typed `Error::UnsupportedVersion` that names the offending version and the floor, rather than
+being rejected only implicitly by magic-number mismatch or an untyped parser error. A BTI-format
+SSTable whose version is not `da` SHALL likewise be rejected with that typed error. The rejection SHALL
+occur before any row data is read.
+
+#### Scenario: A pre-`na` BIG version is rejected at version parse
+- **WHEN** the BIG version gate is constructed from a version string below `na` (e.g. `ma`, `mc`, `me`)
+- **THEN** construction returns `Err(Error::UnsupportedVersion { .. })` naming the version and the `na` floor
+- **AND** no `nb` (or any) gate is returned for that version
+
+#### Scenario: A non-`da` BTI version is rejected with the typed version error
+- **WHEN** the BTI version gate is constructed from a version string other than `da`
+- **THEN** construction returns `Err(Error::UnsupportedVersion { .. })` (not a generic `InvalidFormat`)
+
+#### Scenario: Supported 5.0 versions are still accepted
+- **WHEN** the version gate is constructed from `na`, `nb`, `oa` (BIG) or `da` (BTI)
+- **THEN** construction succeeds and returns the corresponding gates
+
+### Requirement: The reader does not silently downgrade a below-floor SSTable
+The reader's descriptor-derived gate path SHALL propagate an `UnsupportedVersion` error to the caller
+instead of degrading to the default `nb` fallback. Only a genuinely unparseable / structurally
+malformed descriptor MAY use the fallback; a descriptor that parses to a below-floor version SHALL be
+fatal at open.
+
+#### Scenario: Opening a below-floor SSTable fails instead of falling back to nb
+- **WHEN** a reader opens an SSTable whose descriptor version parses to a pre-`na` value
+- **THEN** the open fails with `Error::UnsupportedVersion`
+- **AND** the reader does NOT proceed using `nb` fallback gates
+
+#### Scenario: A structurally-unparseable descriptor still tolerates fallback
+- **WHEN** a reader opens an SSTable whose descriptor version cannot be parsed as a valid version string at all
+- **THEN** the existing fallback behavior is preserved (no `UnsupportedVersion` is raised for an unparseable, not below-floor, descriptor)
+
+### Requirement: No read path contains pre-`na` correctness modeling
+The codebase SHALL NOT carry version-gate logic whose purpose is to make pre-`na` (`ma`–`me`) reads
+"correct." The dead `BigVersionGates::is_compatible()` method (whose predicate admits `ma`) SHALL be
+removed, and `BigVersionGates` SHALL NOT model any below-`na` version as an acceptable read surface.
+
+#### Scenario: The dead pre-`na` compatibility predicate is gone
+- **WHEN** the source is searched for `BigVersionGates::is_compatible`
+- **THEN** no definition or caller exists in production or test code
+
+#### Scenario: BigVersionGates no longer admits below-floor versions
+- **WHEN** any code path constructs `BigVersionGates` for a below-`na` version
+- **THEN** it cannot obtain a usable gate (construction errors per the floor requirement); there is no branch that returns valid pre-`na` gates
+
+### Requirement: Doctrine states the Cassandra 5.0 support floor as an explicit rule
+`CLAUDE.md` and the published `agents-developing/` doctrine SHALL state the support floor as a rule (not
+prose): CQLite targets Cassandra 5.0 — `na`+/`nb` BIG and `oa`/`da` BTI are in scope; pre-`na`
+(`ma`–`me`, Cassandra 3.x) is out of scope and SHALL NOT be introduced, supported, or reviewed for
+correctness. The doctrine SHALL include the explicit guidance for reviewers (incl. roborev) not to
+re-litigate pre-`na` correctness.
+
+#### Scenario: CLAUDE.md carries the Supported formats rule
+- **WHEN** `CLAUDE.md` is read after this change
+- **THEN** it contains a "Supported formats" rule naming the accepted versions (`na`/`nb` BIG, `oa`/`da` BTI) and the out-of-scope pre-`na` (`ma`–`me`) set
+- **AND** it instructs that pre-`na` correctness is not to be introduced, supported, or reviewed
+
+#### Scenario: The agents-developing doctrine mirrors the floor rule
+- **WHEN** the `agents-developing/` doctrine source is read after this change
+- **THEN** it states the same Cassandra 5.0 floor and the do-not-review-pre-`na` guidance for reviewers/roborev

--- a/openspec/changes/sstable-version-floor/tasks.md
+++ b/openspec/changes/sstable-version-floor/tasks.md
@@ -1,0 +1,46 @@
+# Tasks — sstable-version-floor (#1249)
+
+## 1. Typed error
+- [ ] 1.1 Add `Error::UnsupportedVersion { version: String, floor: String }` to
+  `cqlite-core/src/error.rs`; map it to `ErrorCategory::Data` (non-recoverable), matching
+  `UnsupportedFormat`. Surface: the `Error` enum + its category/recoverability match arms.
+
+## 2. Enforce the floor in version parsing
+- [ ] 2.1 In `cqlite-core/src/storage/sstable/version_gate.rs`, make `BigVersionGates::from_version`
+  reject any version `< "na"` with `Error::UnsupportedVersion`. Surface: `BigVersionGates::from_version`.
+- [ ] 2.2 Upgrade `BtiVersionGates::from_version` to return `Error::UnsupportedVersion` (not
+  `InvalidFormat`) for any version other than `da`. Surface: `BtiVersionGates::from_version`.
+- [ ] 2.3 Unit tests: a below-`na` string (`ma`/`mc`/`me`) and a non-`da` BTI string each yield
+  `UnsupportedVersion` naming version + floor; `na`/`nb`/`oa`/`da` still succeed.
+
+## 3. Stop the reader from swallowing the floor
+- [ ] 3.1 In `cqlite-core/src/storage/sstable/reader/mod.rs:402-413`, propagate `UnsupportedVersion`
+  from gate construction instead of degrading to `nb_fallback()`; reserve fallback for a structurally
+  unparseable descriptor. Surface: `SSTableReader::open` gate-derivation arm.
+- [ ] 3.2 Read-path test (wiring-evidence): opening an SSTable whose descriptor version parses to a
+  pre-`na` value fails at open with `UnsupportedVersion` and does NOT proceed on `nb` fallback. Prefer a
+  descriptor/open-level test that exercises the public open path, not a helper-only unit test.
+- [ ] 3.3 Test: a structurally-unparseable descriptor still uses the existing fallback (no
+  `UnsupportedVersion` for the not-below-floor-but-unparseable case).
+
+## 4. Remove the pre-`na` modeling surface
+- [ ] 4.1 Delete `BigVersionGates::is_compatible()` and its unit test
+  (`version_gate.rs:360`, tests ~`826-836`). Surface: `BigVersionGates`.
+- [ ] 4.2 Simplify/remove gate-threshold branches in `from_version` that only mattered for `mb`–`me`
+  now that `< na` is rejected; leave a comment that the floor is `na`. Grep tests for `ma`/`mb`/`mc`/
+  `md`/`me` literals and update/remove (audit found these only in `version_gate.rs` tests).
+
+## 5. Doctrine
+- [ ] 5.1 Add a "Supported formats" **rule** to `CLAUDE.md` under Development Standards: accepted
+  `na`/`nb` BIG + `oa`/`da` BTI; out-of-scope pre-`na` (`ma`–`me`); do-not-introduce/support/review
+  pre-`na` correctness (incl. reviewers/roborev).
+- [ ] 5.2 Mirror the rule on the `agents-developing/` doctrine source (no-heuristics / gate-contract
+  neighborhood) so roborev's repo-context read carries the floor + do-not-review guidance.
+
+## 6. Quality gates (definition of done)
+- [ ] 6.1 `scripts/agent-gate.sh` PASS (run with `CQLITE_DATASETS_ROOT=~/projects/cqlite/test-data/datasets`);
+  paste the AGENT-GATE SUMMARY block verbatim.
+- [ ] 6.2 spec-auditor **C** PASS — every requirement `satisfied` with a public-surface test as evidence
+  (anchored to `openspec/changes/sstable-version-floor/specs/**`).
+- [ ] 6.3 roborev clean (`--agent codex --base origin/main`).
+- [ ] 6.4 `openspec validate sstable-version-floor --strict` clean.

--- a/openspec/changes/sstable-version-floor/tasks.md
+++ b/openspec/changes/sstable-version-floor/tasks.md
@@ -1,40 +1,40 @@
 # Tasks — sstable-version-floor (#1249)
 
 ## 1. Typed error
-- [ ] 1.1 Add `Error::UnsupportedVersion { version: String, floor: String }` to
+- [x] 1.1 Add `Error::UnsupportedVersion { version: String, floor: String }` to
   `cqlite-core/src/error.rs`; map it to `ErrorCategory::Data` (non-recoverable), matching
   `UnsupportedFormat`. Surface: the `Error` enum + its category/recoverability match arms.
 
 ## 2. Enforce the floor in version parsing
-- [ ] 2.1 In `cqlite-core/src/storage/sstable/version_gate.rs`, make `BigVersionGates::from_version`
+- [x] 2.1 In `cqlite-core/src/storage/sstable/version_gate.rs`, make `BigVersionGates::from_version`
   reject any version `< "na"` with `Error::UnsupportedVersion`. Surface: `BigVersionGates::from_version`.
-- [ ] 2.2 Upgrade `BtiVersionGates::from_version` to return `Error::UnsupportedVersion` (not
+- [x] 2.2 Upgrade `BtiVersionGates::from_version` to return `Error::UnsupportedVersion` (not
   `InvalidFormat`) for any version other than `da`. Surface: `BtiVersionGates::from_version`.
-- [ ] 2.3 Unit tests: a below-`na` string (`ma`/`mc`/`me`) and a non-`da` BTI string each yield
+- [x] 2.3 Unit tests: a below-`na` string (`ma`/`mc`/`me`) and a non-`da` BTI string each yield
   `UnsupportedVersion` naming version + floor; `na`/`nb`/`oa`/`da` still succeed.
 
 ## 3. Stop the reader from swallowing the floor
-- [ ] 3.1 In `cqlite-core/src/storage/sstable/reader/mod.rs:402-413`, propagate `UnsupportedVersion`
+- [x] 3.1 In `cqlite-core/src/storage/sstable/reader/mod.rs:402-413`, propagate `UnsupportedVersion`
   from gate construction instead of degrading to `nb_fallback()`; reserve fallback for a structurally
   unparseable descriptor. Surface: `SSTableReader::open` gate-derivation arm.
-- [ ] 3.2 Read-path test (wiring-evidence): opening an SSTable whose descriptor version parses to a
+- [x] 3.2 Read-path test (wiring-evidence): opening an SSTable whose descriptor version parses to a
   pre-`na` value fails at open with `UnsupportedVersion` and does NOT proceed on `nb` fallback. Prefer a
   descriptor/open-level test that exercises the public open path, not a helper-only unit test.
-- [ ] 3.3 Test: a structurally-unparseable descriptor still uses the existing fallback (no
+- [x] 3.3 Test: a structurally-unparseable descriptor still uses the existing fallback (no
   `UnsupportedVersion` for the not-below-floor-but-unparseable case).
 
 ## 4. Remove the pre-`na` modeling surface
-- [ ] 4.1 Delete `BigVersionGates::is_compatible()` and its unit test
+- [x] 4.1 Delete `BigVersionGates::is_compatible()` and its unit test
   (`version_gate.rs:360`, tests ~`826-836`). Surface: `BigVersionGates`.
-- [ ] 4.2 Simplify/remove gate-threshold branches in `from_version` that only mattered for `mb`–`me`
+- [x] 4.2 Simplify/remove gate-threshold branches in `from_version` that only mattered for `mb`–`me`
   now that `< na` is rejected; leave a comment that the floor is `na`. Grep tests for `ma`/`mb`/`mc`/
   `md`/`me` literals and update/remove (audit found these only in `version_gate.rs` tests).
 
 ## 5. Doctrine
-- [ ] 5.1 Add a "Supported formats" **rule** to `CLAUDE.md` under Development Standards: accepted
+- [x] 5.1 Add a "Supported formats" **rule** to `CLAUDE.md` under Development Standards: accepted
   `na`/`nb` BIG + `oa`/`da` BTI; out-of-scope pre-`na` (`ma`–`me`); do-not-introduce/support/review
   pre-`na` correctness (incl. reviewers/roborev).
-- [ ] 5.2 Mirror the rule on the `agents-developing/` doctrine source (no-heuristics / gate-contract
+- [x] 5.2 Mirror the rule on the `agents-developing/` doctrine source (no-heuristics / gate-contract
   neighborhood) so roborev's repo-context read carries the floor + do-not-review guidance.
 
 ## 6. Quality gates (definition of done)

--- a/website/src/content/docs/agents-developing/format-debugging.md
+++ b/website/src/content/docs/agents-developing/format-debugging.md
@@ -3,7 +3,7 @@ title: Format Debugging Workflow
 description: Hex dumps, the definitive-guide chapters to consult, and appendix F for known limitations — how to debug SSTable binary format issues.
 sidebar:
   label: Format debugging
-  order: 7
+  order: 8
 ---
 
 Use this workflow when parsed output is wrong and you need to trace the problem to a

--- a/website/src/content/docs/agents-developing/index.md
+++ b/website/src/content/docs/agents-developing/index.md
@@ -17,6 +17,7 @@ Write for AI agents: terse, imperative, copy-pasteable commands. Skip the prose.
 |------|----------------|
 | [Gate contract](/cqlite/agents-developing/gate-contract/) | `scripts/agent-gate.sh` — the only run that counts; summary-block format |
 | [No-heuristics mandate](/cqlite/agents-developing/no-heuristics/) | Authoritative metadata only; legacy fallbacks behind flags (issue #28) |
+| [Supported formats](/cqlite/agents-developing/supported-formats/) | Cassandra 5.0 version floor — `na`/`nb` BIG + `oa`/`da` BTI in scope; pre-`na` out of scope, do not review (issue #1249) |
 | [Test data](/cqlite/agents-developing/test-data/) | Fetching datasets, dataset pins, CQLITE_DATASETS_ROOT, missing-data behaviour |
 | [Key source paths](/cqlite/agents-developing/source-map/) | Where parsers, writers, query engine, and bindings live |
 | [sstabledump validation playbook](/cqlite/agents-developing/validation-playbook/) | JSONL golden files, parity tests, smoke-test-all-tables |
@@ -29,9 +30,10 @@ Write for AI agents: terse, imperative, copy-pasteable commands. Skip the prose.
 
 1. Run `scripts/agent-gate.sh` before opening any PR. Paste its summary block verbatim. Ad-hoc `cargo test` runs do not count.
 2. Use authoritative metadata only — no type guessing, no heuristics (see [no-heuristics mandate](/cqlite/agents-developing/no-heuristics/)).
-3. Integration tests use real SSTable data. Fetch it before running: `bash test-data/scripts/fetch-datasets.sh`.
-4. `RUSTFLAGS="-D warnings"` must pass — zero clippy warnings allowed.
-5. A feature is done only when its **public surface** exercises it. Name the surface, the
+3. CQLite targets Cassandra 5.0 — `na`/`nb` BIG + `oa`/`da` BTI are in scope; pre-`na` (`ma`–`me`) is out of scope. Do not introduce, support, or review pre-`na` correctness (see [Supported formats](/cqlite/agents-developing/supported-formats/)).
+4. Integration tests use real SSTable data. Fetch it before running: `bash test-data/scripts/fetch-datasets.sh`.
+5. `RUSTFLAGS="-D warnings"` must pass — zero clippy warnings allowed.
+6. A feature is done only when its **public surface** exercises it. Name the surface, the
    call chain, and add an end-to-end test from that surface — green helper unit tests are
    not sufficient (see [Wiring evidence](/cqlite/agents-developing/wiring-evidence/)).
 

--- a/website/src/content/docs/agents-developing/source-map.md
+++ b/website/src/content/docs/agents-developing/source-map.md
@@ -3,7 +3,7 @@ title: Key Source Paths
 description: Where parsers, writers, query engine, bindings, and test infrastructure live in the CQLite codebase.
 sidebar:
   label: Key source paths
-  order: 4
+  order: 5
 ---
 
 Use this page to locate code before reading. Grep in the right subtree rather than

--- a/website/src/content/docs/agents-developing/supported-formats.md
+++ b/website/src/content/docs/agents-developing/supported-formats.md
@@ -1,0 +1,46 @@
+---
+title: Supported formats (version floor)
+description: CQLite targets Cassandra 5.0. na+/nb BIG and oa/da BTI are in scope; pre-na (ma–me, Cassandra 3.x) is out of scope — do not introduce, support, or review pre-na correctness. (Issue #1249)
+sidebar:
+  label: Supported formats
+  order: 3
+---
+
+Issue #1249 codified this as a hard rule after roborev repeatedly raised
+"regression for older SSTable versions" findings on pre-`na` (Cassandra 3.x)
+formats — formats CQLite does not read at all. The churn came from dead version-gate
+modeling surface that *looked* like pre-`na` support. This page is the single
+authoritative statement of the support floor.
+
+## The rule
+
+**CQLite targets Cassandra 5.0. `na`+/`nb` BIG and `oa`/`da` BTI are in scope.
+Pre-`na` (`ma`–`me`, Cassandra 3.x) is out of scope and SHALL NOT be introduced,
+supported, or reviewed for correctness.**
+
+| Format | In scope | Out of scope |
+|--------|----------|--------------|
+| BIG    | `na`, `nb`, `oa` | `ma`–`me` (Cassandra 3.x) and anything `< na` |
+| BTI    | `da` | any version other than `da` |
+
+## For reviewers (including roborev)
+
+- **Do not re-litigate pre-`na` correctness.** A branch, gate, or test that touches
+  `ma`–`me` is not a regression surface — pre-`na` reads are unsupported by design.
+- Do not request changes that "fix" pre-`na` behaviour, add pre-`na` gates, or restore
+  deleted pre-`na` modeling code. The floor is the contract.
+
+## How it is enforced
+
+The floor lives in version parsing and is propagated by the reader:
+
+- `BigVersionGates::from_version` returns `Error::UnsupportedVersion { version, floor: "na" }`
+  for any BIG version `< na`. It never constructs gates for a below-floor version.
+- `BtiVersionGates::from_version` returns `Error::UnsupportedVersion { version, floor: "da" }`
+  for any BTI version other than `da`.
+- `SSTableReader::open` **propagates** `Error::UnsupportedVersion` instead of degrading to
+  the `nb` fallback. Only a structurally-unparseable descriptor (not a parsed-but-below-floor
+  one) may use the fallback.
+
+The rejection happens before any row data is read. `Error::UnsupportedVersion` maps to the
+non-recoverable `ErrorCategory::Data`.

--- a/website/src/content/docs/agents-developing/test-data.md
+++ b/website/src/content/docs/agents-developing/test-data.md
@@ -3,7 +3,7 @@ title: Test Data
 description: Fetching the dataset, dataset pins, CQLITE_DATASETS_ROOT, and what happens without Data.db files.
 sidebar:
   label: Test data
-  order: 3
+  order: 4
 ---
 
 The git repository contains only JSONL reference files (sstabledump output, used for

--- a/website/src/content/docs/agents-developing/validation-playbook.md
+++ b/website/src/content/docs/agents-developing/validation-playbook.md
@@ -3,7 +3,7 @@ title: sstabledump Validation Playbook
 description: JSONL golden files, parity tests, and smoke-test-all-tables — how CQLite validates parsing correctness against Cassandra's reference output.
 sidebar:
   label: Validation playbook
-  order: 5
+  order: 6
 ---
 
 CQLite validates parsing correctness by comparing output against `sstabledump` — the

--- a/website/src/content/docs/agents-developing/wiring-evidence.md
+++ b/website/src/content/docs/agents-developing/wiring-evidence.md
@@ -3,7 +3,7 @@ title: Wiring Evidence
 description: A feature is done when the intended public surface exercises it — not when a helper passes unit tests in isolation. How to name the public surface and prove the call chain reaches it. (Issues #949/#963)
 sidebar:
   label: Wiring evidence
-  order: 6
+  order: 7
 ---
 
 A capability is **done** when the intended USER-FACING surface exercises it — not when a


### PR DESCRIPTION
Closes #1249.

Codifies the Cassandra 5.0 SSTable support floor — previously real but emergent (magic-number mismatch) and contradicted by dead pre-\`na\` modeling that drove ~4 wasted roborev rounds on #1021.

## Changes
- **Typed error**: new \`Error::UnsupportedVersion { version, floor }\` (additive; \`ErrorCategory::Data\`, non-recoverable), wired into observability classify + python/node binding error maps.
- **Enforced floor**: \`BigVersionGates::from_version\` rejects \`< na\`; \`BtiVersionGates::from_version\` returns \`UnsupportedVersion\` (not \`InvalidFormat\`) for non-\`da\`. Pre-\`na\` gate-threshold branches collapsed.
- **Reader bites**: \`reader/mod.rs\` propagates \`UnsupportedVersion\` (fatal) instead of degrading to \`nb_fallback()\`; structurally-unparseable descriptors still fall back.
- **Dead surface removed**: deleted \`BigVersionGates::is_compatible()\` (test-only; predicate wrongly admitted \`ma\`) + its test.
- **Doctrine**: "Supported formats (version floor)" rule in CLAUDE.md + new \`agents-developing/supported-formats.md\` with do-not-review-pre-\`na\` guidance for reviewers/roborev.

## Quality
- OpenSpec change \`sstable-version-floor\` (proposal/design/specs/tasks), \`openspec validate --strict\` clean.
- agent-gate.sh **PASS** (commit f4cac653).
- spec-auditor **C: PASS** — all 4 requirements satisfied with public-surface (\`SSTableReader::open\`) test evidence.
- New tests: below-\`na\` BIG + non-\`da\` BTI typed-error; below-floor open is fatal (not nb fallback); unparseable descriptor still tolerates fallback.