### PR TITLE
fix(#1238): wire real Data.db byte count into MergeStats.bytes_written

### DIFF
--- a/cqlite-core/src/storage/sstable/writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/mod.rs
@@ -819,6 +819,20 @@ impl SSTableWriter {
         Ok(())
     }
 
+    /// Total number of Data.db bytes produced so far (issue #1238).
+    ///
+    /// Returns the running Data.db size: bytes already flushed to the streaming
+    /// sink plus the current per-partition scratch. After the last
+    /// `write_partition` call this equals the `data_size` that
+    /// [`SSTableWriter::finish`] will report (and the on-disk Data.db length),
+    /// because the streaming `DataWriter` flushes each partition as it is written
+    /// and `finish` only flushes residual scratch (normally empty). Callers that
+    /// drive `write_partition` directly — e.g. `KWayMerger::merge` — use this to
+    /// fill in the authoritative output byte count without re-stat-ing the file.
+    pub fn data_bytes_written(&self) -> u64 {
+        self.data_writer.position()
+    }
+
     /// Pre-seed the encoding baselines with pre-computed final values.
     ///
     /// Call this BEFORE any `write_partition` call with the minimum values

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -2077,6 +2077,15 @@ impl KWayMerger {
             output_writer.write_partition(key, mutations)?;
         }
 
+        // Issue #1238: report the REAL output Data.db byte count instead of a
+        // hardcoded 0. The streaming writer flushes each partition as it is
+        // written, so its running position is the authoritative total Data.db
+        // size — identical to the `data_size` the caller's later
+        // `writer.finish()` reports (only residual scratch, normally empty, is
+        // flushed there). This is the writer's own byte accounting, not an
+        // estimate or a re-stat of the produced file.
+        stats.bytes_written = output_writer.data_bytes_written();
+
         stats.elapsed = start_time.elapsed();
         Ok(stats)
     }

--- a/cqlite-core/tests/compact_command.rs
+++ b/cqlite-core/tests/compact_command.rs
@@ -522,3 +522,78 @@ fn compact_clustering_table_preserves_rows_and_lww() {
         );
     }
 }
+
+/// Issue #1238 regression: `MergeStats.bytes_written` must report the REAL output
+/// Data.db byte count, not a hardcoded 0.
+///
+/// Before the fix `KWayMerger::merge` initialized `bytes_written: 0` and never
+/// updated it, so callers treating it as a byte count saw a misleading 0 even
+/// after compacting non-empty input into a non-empty output. This compacts a
+/// single non-empty SSTable (10 partitions) and asserts:
+///   1. `report.stats.bytes_written > 0`, and
+///   2. it EQUALS the authoritative output size — both `report.output.data_size`
+///      (what `writer.finish()` reports) and the actual on-disk Data.db length.
+#[test]
+fn compact_sstables_reports_real_bytes_written() {
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let temp = TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    let wal_dir = temp.path().join("wal");
+    let output_dir = temp.path().join("out");
+    let schema = make_schema();
+
+    // ── Build one non-empty input SSTable via the public WriteEngine API ──
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir.clone(), schema.clone());
+    let mut engine = WriteEngine::new(config).expect("engine creation");
+    for id in 1_i32..=10 {
+        engine
+            .write(write_row(id, &format!("name-{id}"), 100))
+            .expect("write");
+    }
+    let info = rt.block_on(engine.flush()).expect("flush").expect("info");
+    assert_eq!(info.partition_count, 10, "input SSTable: 10 partitions");
+    drop(engine);
+
+    let inputs = discover_inputs(&data_dir);
+    assert_eq!(inputs.len(), 1, "expected 1 input SSTable, got {inputs:?}");
+
+    let report = rt
+        .block_on(compact_sstables(
+            inputs,
+            &output_dir,
+            &schema,
+            9,
+            Some(1_700_000_000),
+            None,
+            true,
+        ))
+        .expect("compaction must succeed");
+
+    // The output is non-empty.
+    assert_eq!(
+        report.stats.output_partitions, 10,
+        "non-empty compaction output expected"
+    );
+
+    // (1) bytes_written must be non-zero (was hardcoded 0 before #1238).
+    assert!(
+        report.stats.bytes_written > 0,
+        "MergeStats.bytes_written must be > 0 for a non-empty output, got {}",
+        report.stats.bytes_written
+    );
+
+    // (2) bytes_written must equal the writer's authoritative output Data.db size.
+    assert_eq!(
+        report.stats.bytes_written, report.output.data_size,
+        "MergeStats.bytes_written must equal SSTableInfo.data_size"
+    );
+
+    // (3) and that size must match the actual on-disk Data.db file length.
+    let on_disk = std::fs::metadata(&report.output.data_path)
+        .expect("output Data.db must exist")
+        .len();
+    assert_eq!(
+        report.stats.bytes_written, on_disk,
+        "MergeStats.bytes_written must equal the on-disk Data.db length"
+    );
+}


### PR DESCRIPTION
Closes #1238.

## Problem
`KWayMerger::merge` initialized `MergeStats { bytes_written: 0, .. }` and never updated it — callers treating it as a byte count got a misleading 0 even for non-empty compaction output.

## Fix
- `sstable/writer/mod.rs`: add `SSTableWriter::data_bytes_written()` delegating to the streaming `DataWriter::position()` (authoritative running Data.db size).
- `write_engine/merge/mod.rs`: after the write loop, set `stats.bytes_written = output_writer.data_bytes_written()`. Equals the `data_size` from `writer.finish()` and the on-disk Data.db length — no estimate, no re-stat.

## Test
`compact_sstables_reports_real_bytes_written` (`cqlite-core/tests/compact_command.rs`): compacts a 10-partition input, asserts `bytes_written > 0`, `== output.data_size`, and `== fs::metadata(Data.db).len()`. Fails before / passes after.

## Validation
`agent-gate.sh`: **RESULT PASS** (core-tests, write-tests green). file-size used `CQLITE_ALLOW_FILE_GROWTH=1` — the two edited files (writer/mod.rs 2.4k, merge/mod.rs 12k) are pre-existing over-threshold; minimal change, flagged for the #1116/#1135 split epic, not split here. roborev (codex): no issues.

Oracle-driven correctness fix — no OpenSpec.