### PR TITLE
fix(#1253): persist single-invocation --execute INSERT --flush

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,6 +204,15 @@ cargo run --package cqlite-cli --features write-support -- \
   --schema test-data/schemas/basic-types.cql \
   --flush
 
+# Issue #1253: a single combined invocation persists durably. `--execute` DML
+# now runs BEFORE the flush within the same invocation, so the inserted row
+# lands in Data.db (not just the WAL):
+cargo run --package cqlite-cli --features write-support -- \
+  --writable --write-dir /tmp/cqlite-write \
+  --schema test-data/schemas/basic-types.cql \
+  --execute "INSERT INTO test_basic.simple_table (id, name) VALUES (33333333-3333-3333-3333-333333333333, 'Carol')" \
+  --flush
+
 # Write subcommands
 cargo run --package cqlite-cli --features write-support -- \
   maintenance --budget-ms 100 \

--- a/cqlite-cli/src/main.rs
+++ b/cqlite-cli/src/main.rs
@@ -523,12 +523,25 @@ async fn run_main() -> Result<()> {
         result.display();
     }
 
-    // Issue #392: Handle --flush flag
+    // Issue #392: Handle --flush flag.
+    //
+    // Issue #1253: defer the flush when this same invocation also carries a DML
+    // `--execute` statement. That write runs later (in the --execute block), so
+    // flushing here would flush an empty memtable. The --execute DML branch
+    // performs the flush itself after the write so the row reaches the SSTable.
     #[cfg(feature = "write-support")]
-    if cli.flush {
-        if let Some(engine) = write_engine.as_mut() {
-            let info = commands::write::handle_flush(engine).await?;
-            commands::write::display_flush_result(info.as_ref());
+    {
+        let defer_flush_to_execute = cli
+            .execute
+            .as_deref()
+            .map(is_dml_statement)
+            .unwrap_or(false);
+
+        if cli.flush && !defer_flush_to_execute {
+            if let Some(engine) = write_engine.as_mut() {
+                let info = commands::write::handle_flush(engine).await?;
+                commands::write::display_flush_result(info.as_ref());
+            }
         }
     }
 
@@ -561,6 +574,18 @@ async fn run_main() -> Result<()> {
                     .map_err(|e| anyhow::anyhow!("DML execution failed: {}", e))?;
 
                 println!("OK");
+
+                // Issue #1253: when `--flush` is combined with `--execute` in a
+                // single invocation, the standalone `--flush` block above runs
+                // BEFORE this DML executes, so it would flush an empty memtable
+                // (the row would only reach the WAL, never Data.db). Flush here,
+                // after the write, so the inserted row is persisted to the
+                // SSTable within this one invocation.
+                if cli.flush {
+                    let info = commands::write::handle_flush(engine).await?;
+                    commands::write::display_flush_result(info.as_ref());
+                }
+
                 return Ok(());
             }
         }

--- a/cqlite-cli/src/main.rs
+++ b/cqlite-cli/src/main.rs
@@ -529,13 +529,19 @@ async fn run_main() -> Result<()> {
     // `--execute` statement. That write runs later (in the --execute block), so
     // flushing here would flush an empty memtable. The --execute DML branch
     // performs the flush itself after the write so the row reaches the SSTable.
+    //
+    // The DML `--execute` branch is only reached when `cli.file.is_none()`,
+    // because `--file` is handled first and returns early. So only defer when
+    // `--file` is absent; otherwise the standalone `--flush` must run now (the
+    // deferred-to branch would never execute this invocation).
     #[cfg(feature = "write-support")]
     {
-        let defer_flush_to_execute = cli
-            .execute
-            .as_deref()
-            .map(is_dml_statement)
-            .unwrap_or(false);
+        let defer_flush_to_execute = cli.file.is_none()
+            && cli
+                .execute
+                .as_deref()
+                .map(is_dml_statement)
+                .unwrap_or(false);
 
         if cli.flush && !defer_flush_to_execute {
             if let Some(engine) = write_engine.as_mut() {

--- a/cqlite-cli/tests/cli_dml_integration_tests.rs
+++ b/cqlite-cli/tests/cli_dml_integration_tests.rs
@@ -457,3 +457,93 @@ fn test_cli_execute_insert_and_flush_single_invocation_persists_value() {
          Got read stdout: {read_stdout}\nread stderr: {read_stderr}"
     );
 }
+
+/// Issue #1253 (roborev follow-up): the standalone `--flush` must run even when
+/// the same invocation carries a DML `--execute`, IF `--file` is also present.
+///
+/// `--file` is handled BEFORE `--execute` and returns early, so the `--execute`
+/// DML branch (which performs the deferred flush) never runs. If we still defer
+/// the flush in that case, the flush is silently dropped. This test seeds the
+/// memtable via a prior `--execute INSERT` (WAL only), then runs a combined
+/// `--flush --file <noop> --execute "INSERT ..."` invocation and asserts the
+/// PRIOR row is persisted to the SSTable — proving the standalone `--flush` ran.
+#[test]
+fn test_cli_flush_runs_when_file_short_circuits_execute() {
+    let temp_dir = TempDir::new().unwrap();
+    let schema_path = create_simple_schema(&temp_dir);
+    let write_dir = temp_dir.path().join("write_data");
+
+    // Step 1: seed the WAL/memtable with a row (no flush — WAL only).
+    let seed = run_write_cli(&[
+        "--writable",
+        "--write-dir",
+        write_dir.to_str().unwrap(),
+        "--schema",
+        schema_path.to_str().unwrap(),
+        "--execute",
+        "INSERT INTO test_write.users (id, name, age) VALUES (9, 'Heidi', 55)",
+    ]);
+    assert!(
+        seed.status.success(),
+        "Seed INSERT should succeed. stderr: {}",
+        String::from_utf8_lossy(&seed.stderr)
+    );
+
+    // A no-op script file (comment only → zero statements).
+    let script_path = temp_dir.path().join("noop.cql");
+    std::fs::write(&script_path, "-- no-op script\n").expect("write script file");
+
+    // Step 2: combined `--flush --file <noop> --execute INSERT`. `--file` takes
+    // precedence and returns early; the `--execute` DML branch never runs. The
+    // standalone `--flush` MUST still run and persist the seeded row.
+    let output = run_write_cli(&[
+        "--writable",
+        "--write-dir",
+        write_dir.to_str().unwrap(),
+        "--schema",
+        schema_path.to_str().unwrap(),
+        "--flush",
+        "--file",
+        script_path.to_str().unwrap(),
+        "--execute",
+        "INSERT INTO test_write.users (id, name, age) VALUES (10, 'Ivan', 66)",
+    ]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "Combined --flush --file --execute should succeed. \
+         stdout: {stdout}\nstderr: {stderr}"
+    );
+
+    // The flush must have produced a real Data.db for the seeded row.
+    let data_db = write_dir.join("data/test_write/users/nb-1-big-Data.db");
+    assert!(
+        data_db.exists(),
+        "--flush must run (not be deferred) when --file short-circuits --execute. \
+         stdout: {stdout}\nstderr: {stderr}"
+    );
+
+    // Reopen read-only and confirm the SEEDED row reached the SSTable.
+    let read_output = run_write_cli(&[
+        "--schema",
+        schema_path.to_str().unwrap(),
+        "--data-dir",
+        write_dir.join("data").to_str().unwrap(),
+        "--execute",
+        "SELECT * FROM test_write.users",
+        "--out",
+        "json",
+    ]);
+    let read_stdout = String::from_utf8_lossy(&read_output.stdout);
+    let read_stderr = String::from_utf8_lossy(&read_output.stderr);
+    assert!(
+        read_output.status.success(),
+        "Read-back SELECT should succeed. stderr: {read_stderr}"
+    );
+    assert!(
+        read_stdout.contains("\"Heidi\"") && read_stdout.contains("55"),
+        "The seeded row must be flushed/persisted when --file short-circuits --execute. \
+         Got read stdout: {read_stdout}\nread stderr: {read_stderr}"
+    );
+}

--- a/cqlite-cli/tests/cli_dml_integration_tests.rs
+++ b/cqlite-cli/tests/cli_dml_integration_tests.rs
@@ -396,3 +396,64 @@ fn test_cli_execute_insert_then_flush() {
         "Should print OK for INSERT. stdout: {stdout}"
     );
 }
+
+/// Issue #1253: a SINGLE combined `--execute INSERT ... --flush` invocation must
+/// persist the inserted row's VALUE into the produced SSTable. Previously the
+/// `--flush` handler ran before `--execute`, flushing an empty memtable; the row
+/// only landed in the WAL, never in Data.db. This is a content assertion: it
+/// reopens the produced SSTable read-only and reads the row back.
+#[test]
+fn test_cli_execute_insert_and_flush_single_invocation_persists_value() {
+    let temp_dir = TempDir::new().unwrap();
+    let schema_path = create_simple_schema(&temp_dir);
+    let write_dir = temp_dir.path().join("write_data");
+
+    // Single invocation: INSERT + flush together.
+    let output = run_write_cli(&[
+        "--writable",
+        "--write-dir",
+        write_dir.to_str().unwrap(),
+        "--schema",
+        schema_path.to_str().unwrap(),
+        "--execute",
+        "INSERT INTO test_write.users (id, name, age) VALUES (7, 'Grace', 42)",
+        "--flush",
+    ]);
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "Combined INSERT + flush should succeed. stderr: {stderr}"
+    );
+
+    // The flush must produce a real Data.db (not an empty-memtable no-op).
+    let data_db = write_dir.join("data/test_write/users/nb-1-big-Data.db");
+    assert!(
+        data_db.exists(),
+        "Combined INSERT + flush must produce Data.db. stdout: {stdout}\nstderr: {stderr}"
+    );
+
+    // Reopen the produced SSTable READ-ONLY and assert the inserted VALUE is present.
+    let read_output = run_write_cli(&[
+        "--schema",
+        schema_path.to_str().unwrap(),
+        "--data-dir",
+        write_dir.join("data").to_str().unwrap(),
+        "--execute",
+        "SELECT * FROM test_write.users",
+        "--out",
+        "json",
+    ]);
+    let read_stdout = String::from_utf8_lossy(&read_output.stdout);
+    let read_stderr = String::from_utf8_lossy(&read_output.stderr);
+    assert!(
+        read_output.status.success(),
+        "Read-back SELECT should succeed. stderr: {read_stderr}"
+    );
+    assert!(
+        read_stdout.contains("\"Grace\"") && read_stdout.contains("42"),
+        "Inserted row value must be persisted in the SSTable and readable back. \
+         Got read stdout: {read_stdout}\nread stderr: {read_stderr}"
+    );
+}


### PR DESCRIPTION
Closes #1253

## Bug
In `cqlite-cli/src/main.rs`, `--flush` ran before `--execute`, so a single `cqlite --writable --execute "INSERT ..." --flush` flushed an empty memtable; the row landed only in the WAL, never in Data.db. The old test asserted only exit-code/"OK" (shape-only), so it stayed hidden.

## Fix (oracle/mechanical)
Reorder within one invocation: defer the standalone `--flush` when the same invocation also carries a DML `--execute`; the `--execute` DML branch flushes itself after the write before its early return. Standalone `--flush`, standalone `--execute`, and the WAL-backed cross-invocation path are unchanged.

## Wiring-evidence test
New `test_cli_execute_insert_and_flush_single_invocation_persists_value` drives the real CLI binary, then a separate read-only invocation SELECTs the row back and asserts the **value** (`"Grace"`, `42`) is present — fails before, passes after. CLAUDE.md combined-invocation example corrected.

## Gate
AGENT-GATE: **PASS** (commit 3b218f99, all 16 components). `main.rs` file-size growth (+25) ack'd via `CQLITE_ALLOW_FILE_GROWTH=1` (split tracked by epic #1116).