### PR TITLE
ci(#1204): add workflow_dispatch (version + dry_run) to trino-publish.yml

### DIFF
--- a/.github/workflows/trino-publish.yml
+++ b/.github/workflows/trino-publish.yml
@@ -9,11 +9,29 @@ name: Publish Trino Connector
 # are not addressable in a job-level `if:`, so a guard step checks them and
 # exposes a boolean output that the publish step keys off; when absent the job
 # logs a notice and succeeds without publishing.
+#
+# A `workflow_dispatch` trigger allows exercising the publish on demand. Manual
+# runs have no tag to derive the version from, so the `version` input supplies
+# it. By default `dry_run` is true: the connector is published to the local
+# Maven repo (publishToMavenLocal) — no Central upload, no signing/Central
+# secrets needed — so the pipeline can be validated without cutting a release.
+# Set `dry_run=false` to perform the real Central publish (still gated on the
+# secrets being present, exactly like the tag path).
 
 on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (no leading v), e.g. 0.13.0'
+        type: string
+        required: true
+      dry_run:
+        description: 'Dry run: publishToMavenLocal only (no Central upload, no secrets needed)'
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -33,9 +51,18 @@ jobs:
           cache: gradle
           cache-dependency-path: trino-connector/*.gradle.kts
 
-      - name: Derive version from tag
+      # Tag runs derive the version from GITHUB_REF_NAME (v0.13.0 -> 0.13.0);
+      # manual workflow_dispatch runs have no tag, so use the `version` input.
+      - name: Resolve version
         id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "version=${INPUT_VERSION#v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          fi
 
       # Secrets cannot be referenced in a job/step-level `if:`. Read them here and
       # publish a boolean output the publish step gates on.
@@ -54,8 +81,16 @@ jobs:
             echo "should_publish=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # Dry run (manual workflow_dispatch with dry_run=true): publish only to the
+      # local Maven repo. No Central upload and no signing/Central secrets needed,
+      # so this path is independent of the guard step above.
+      - name: Publish to Maven local (dry run)
+        if: github.event_name == 'workflow_dispatch' && inputs.dry_run
+        working-directory: trino-connector
+        run: ./gradlew --no-daemon publishToMavenLocal -Pversion=${{ steps.version.outputs.version }}
+
       - name: Publish to Maven Central
-        if: steps.guard.outputs.should_publish == 'true'
+        if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) && steps.guard.outputs.should_publish == 'true' }}
         working-directory: trino-connector
         env:
           # vanniktech reads Central credentials + the in-memory GPG key from
@@ -67,5 +102,5 @@ jobs:
         run: ./gradlew --no-daemon publishToMavenCentral -Pversion=${{ steps.version.outputs.version }}
 
       - name: Skip notice (secrets absent)
-        if: steps.guard.outputs.should_publish != 'true'
+        if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) && steps.guard.outputs.should_publish != 'true' }}
         run: echo "::notice::Maven Central secrets absent — skipping connector publish"

--- a/.github/workflows/trino-publish.yml
+++ b/.github/workflows/trino-publish.yml
@@ -59,10 +59,19 @@ jobs:
           INPUT_VERSION: ${{ inputs.version }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "version=${INPUT_VERSION#v}" >> "$GITHUB_OUTPUT"
+            resolved="${INPUT_VERSION#v}"
           else
-            echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+            resolved="${GITHUB_REF_NAME#v}"
           fi
+          # Strict allowlist: semver core with an optional pre-release suffix
+          # (e.g. 0.13.0, 0.13.0-test, 0.13.0-rc.1). Reject anything else so a
+          # crafted version cannot inject shell metacharacters into the gradle
+          # invocations below — which run with Maven Central + signing secrets.
+          if ! printf '%s' "$resolved" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$'; then
+            echo "::error::Refusing to publish: version '$resolved' is not a valid release version (expected ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$)"
+            exit 1
+          fi
+          echo "version=$resolved" >> "$GITHUB_OUTPUT"
 
       # Secrets cannot be referenced in a job/step-level `if:`. Read them here and
       # publish a boolean output the publish step gates on.
@@ -87,7 +96,9 @@ jobs:
       - name: Publish to Maven local (dry run)
         if: github.event_name == 'workflow_dispatch' && inputs.dry_run
         working-directory: trino-connector
-        run: ./gradlew --no-daemon publishToMavenLocal -Pversion=${{ steps.version.outputs.version }}
+        env:
+          PUBLISH_VERSION: ${{ steps.version.outputs.version }}
+        run: ./gradlew --no-daemon publishToMavenLocal -Pversion="$PUBLISH_VERSION"
 
       - name: Publish to Maven Central
         if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) && steps.guard.outputs.should_publish == 'true' }}
@@ -99,7 +110,8 @@ jobs:
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
-        run: ./gradlew --no-daemon publishToMavenCentral -Pversion=${{ steps.version.outputs.version }}
+          PUBLISH_VERSION: ${{ steps.version.outputs.version }}
+        run: ./gradlew --no-daemon publishToMavenCentral -Pversion="$PUBLISH_VERSION"
 
       - name: Skip notice (secrets absent)
         if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) && steps.guard.outputs.should_publish != 'true' }}


### PR DESCRIPTION
Closes #1204.

## Goal
Add a `workflow_dispatch` manual trigger to `trino-publish.yml` so the Maven Central publish path can be exercised on demand (dry-run) without cutting a `v*` tag — letting the owner validate sign/upload before a real release.

## Changes
- `workflow_dispatch` added alongside the unchanged `push: tags: ['v*']`, inputs: `version` (string, required), `dry_run` (boolean, default true).
- Version resolution: dispatch uses `inputs.version`, tag path derives `${GITHUB_REF_NAME#v}` (byte-for-byte unchanged).
- New dry-run step (`dry_run=true`): `publishToMavenLocal` — no secrets, bypasses the guard.
- **Security hardening** (roborev High): resolved version is allowlist-validated (`^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$`, fail-closed before any secret-bearing step) and passed via quoted `PUBLISH_VERSION` env var (`-Pversion="$PUBLISH_VERSION"`) — no `${{ }}` version interpolation remains in any `run:` body, closing a command-injection vector.
- Guard-step → output `if:` secret-gate, `::notice::` secret-absent skip, and tag-path behavior all preserved; no secret referenced in any `if:`.

## Validation
`actionlint` exit 0, YAML parses, gate **PASS** (no Rust changed). roborev (codex): clean after the injection fix.

Note: full *runtime* verification of the dispatch (AC#1–3) requires an actual `gh workflow run` against `main` once secrets are configured — a post-merge/owner check (it's the feature's purpose). Manager-routed: skip OpenSpec.