### PR TITLE
docs(#1245): pre-roborev self-check checklist to reduce recurring findings

### DIFF
--- a/.claude/agents/sstable-developer.md
+++ b/.claude/agents/sstable-developer.md
@@ -35,6 +35,7 @@ You are an expert Rust developer specializing in Cassandra SSTable parsing for t
 3. **sstabledump parity** - Validate output matches Cassandra's sstabledump
 4. **Memory target** - <128MB for large SSTables
 5. **Zero warnings** - `RUSTFLAGS="-D warnings"` must pass
+6. **Pre-roborev self-check** - before reporting an implementation done, scan your diff against the "Pre-roborev self-check (common findings to pre-empt)" checklist in `CLAUDE.md` (clippy `manual_range_contains`, integer overflow/saturation, float-ordering-vs-Java, wall-clock test races, GitHub Actions command injection, no-heuristics, gitignored reference binaries) and fix matches up front — each one pre-empted saves a review round
 
 ## Common Tasks
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -511,6 +511,16 @@ bash test-data/scripts/fetch-datasets.sh
 - Stay within your assigned issue's scope; flag cross-cutting changes to the lead instead of editing another teammate's files.
 - An issue is "done" only when tests pass, coverage meets threshold, roborev is clean, and both the spec-auditor and coverage-reviewer sign off.
 
+### Pre-roborev self-check (common findings to pre-empt)
+`roborev_findings` is the #1 recurring delivery cost (telemetry retro). Before reporting an implementation done, scan your diff for these recurring finding classes and fix them up front — every one avoided is a review round saved. Full guidance: https://pmcfadin.github.io/cqlite/agents-developing/roborev-findings/.
+- **GitHub Actions command injection** — never interpolate `${{ inputs.* }}` / `${{ steps.*.outputs.* }}` directly into a `run:` shell (worst in a step holding secrets). Allowlist-validate the value fail-closed *before* any secret step, then pass it via a quoted env var (`-Pversion="$VAR"`), not inline `${{ }}`.
+- **clippy `manual_range_contains`** — `x >= a && x <= b` fails under `-D warnings`. Write `(a..=b).contains(&x)`.
+- **Integer overflow / saturation** — decoding into `i128`/fixed width and saturating (decimal unscaled values, scale math) loses data. Use `num_bigint::BigInt` (already a dep); bound the computation by comparing signs/adjusted-exponents *before* any large power-of-ten — never materialize `10^scale` with an unbounded exponent (DoS/OOM).
+- **Float ordering vs Java** — Rust `total_cmp` ≠ Java `Float/Double.compare`: Rust puts negative NaN first, Java sorts NaN last; also signed-zero differs. When matching Cassandra, use an explicit comparator (NaN last, `-0.0 < +0.0`).
+- **Wall-clock races in tests** — never assert a value sampled at one instant against a window captured at another (one-second boundary flakes). Capture the window to cover *all* sampled operations.
+- **No-heuristics violations** — never infer type/behavior from byte patterns; use authoritative schema/`Statistics.db` metadata (see no-heuristics mandate).
+- **Gitignored reference binaries / dirty-tree gate** — byte-parity tests silently SKIP in a clean checkout when `.db` references are gitignored. Force-add the tiny reference binaries (`git add -f`) and verify the test against a fresh `git worktree add --detach HEAD`, not the dirty tree.
+
 ### Spec-driven work (OpenSpec)
 - OpenSpec is the front door for **design-driven** new work (bindings/M6, query-engine surface, CLI/REPL UX, perf/M7, process). **Oracle-driven** bug fixes (SSTable parsing, compaction/tombstone parity, type decode) stay as a GitHub issue + a pinned parity test — no OpenSpec change.
 - Merge flow for a design-driven change: `apply → gate (correctness) → C (intent audit) → roborev (code) → merge → archive`. The intent audit **C** is the `spec-auditor` subagent anchored to `openspec/changes/<name>/specs/**`; it runs only after `scripts/agent-gate.sh` is green. **B** (optional) reuses `roborev-design-review-branch` with the change's artifacts as criteria — escalate when C reports `partial`, the change is high-stakes, or it touches doctrine.

--- a/website/src/content/docs/agents-developing/index.md
+++ b/website/src/content/docs/agents-developing/index.md
@@ -25,6 +25,7 @@ Write for AI agents: terse, imperative, copy-pasteable commands. Skip the prose.
 | [Format debugging workflow](/cqlite/agents-developing/format-debugging/) | Hex dumps, definitive-guide chapters, appendix F known limitations |
 | [Spec-driven audit](/cqlite/agents-developing/spec-driven-audit/) | OpenSpec as the front door for design-driven work; the intent audit (C) + roborev escalation (B); superpowers mapping |
 | [Delivery pipeline](/cqlite/agents-developing/delivery-pipeline/) | The `flow-lead` manager agent + `flow-*` pipeline; specialist roster; the two human seams + pre-authorized merge-on-green |
+| [Pre-roborev self-check](/cqlite/agents-developing/roborev-findings/) | The recurring roborev finding classes + the one-line fix for each; scan your diff before handing off (issue #1245) |
 
 ## Non-negotiable rules
 

--- a/website/src/content/docs/agents-developing/roborev-findings.md
+++ b/website/src/content/docs/agents-developing/roborev-findings.md
@@ -1,0 +1,81 @@
+---
+title: Common roborev findings and how to pre-empt them
+description: The recurring roborev finding classes — and the one-line fix pattern for each — so implementations land clean and reviews converge in fewer rounds. (Issue #1245)
+sidebar:
+  label: Pre-roborev self-check
+  order: 9
+---
+
+`roborev_findings` is the #1 recurring delivery cost in the pipeline telemetry retro
+(`docs/reports/delivery-telemetry.jsonl`). Most rounds are spent re-litigating the same
+handful of finding classes. Scan your diff against this checklist **before** reporting an
+implementation done — every one pre-empted is a review round saved.
+
+This mirrors the **Pre-roborev self-check** section in `CLAUDE.md`. Keep both in sync.
+
+## The recurring finding classes
+
+### GitHub Actions command injection
+User- or dispatch-controlled input (`${{ inputs.* }}`, `${{ steps.*.outputs.* }}`)
+interpolated directly into a `run:` shell — worst in a step that holds secrets in `env`.
+
+**Fix:** allowlist-validate the value fail-closed *before* any secret step, then pass it
+through a quoted env var; never inline `${{ }}` in `run:`.
+
+```yaml
+# Not allowed — injection sink
+- run: ./gradlew publish -Pversion=${{ inputs.version }}
+
+# Allowed — validate fail-closed, then quoted env var
+- env:
+    VERSION: ${{ inputs.version }}
+  run: |
+    [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "bad version"; exit 1; }
+    ./gradlew publish -Pversion="$VERSION"
+```
+
+### clippy `manual_range_contains`
+`x >= a && x <= b` fails under `RUSTFLAGS="-D warnings"`.
+
+**Fix:** `(a..=b).contains(&x)`.
+
+### Integer overflow / saturation
+Decoding into `i128` or a fixed width and saturating (decimal unscaled values, scale math)
+silently loses data; materializing `10^scale` with an unbounded exponent is a DoS/OOM risk.
+
+**Fix:** use `num_bigint::BigInt` (already a dependency) and bound the computation —
+compare signs and adjusted exponents *before* computing any large power of ten.
+
+### Float ordering vs Java
+Rust `total_cmp` does not match Java `Float.compare` / `Double.compare`: Rust orders
+negative NaN first, Java sorts NaN last; signed-zero handling also differs.
+
+**Fix:** when matching Cassandra ordering, use an explicit comparator — NaN last,
+`-0.0 < +0.0`.
+
+### Wall-clock races in tests
+Asserting a value sampled at one instant against a window captured at a different instant
+flakes on one-second boundaries.
+
+**Fix:** capture the time window so it covers *all* sampled operations (sample the bounds
+around the whole block, not per-call).
+
+### No-heuristics violations
+Inferring a type or behaviour from byte patterns instead of authoritative metadata.
+
+**Fix:** decode from schema or `Statistics.db` metadata only. See the
+[no-heuristics mandate](/cqlite/agents-developing/no-heuristics/).
+
+### Gitignored reference binaries / dirty-tree gate
+Byte-parity tests silently **SKIP** in a clean checkout because their `.db` references are
+gitignored — so a gate that "passed" against your dirty working tree proves nothing.
+
+**Fix:** force-add the tiny reference binaries (`git add -f`) and verify the test against a
+fresh `git worktree add --detach HEAD`, never the dirty tree.
+
+## How to use this
+
+1. Before handing an issue off, diff your branch against `origin/main` and walk this list.
+2. Fix matches up front rather than waiting for roborev to flag them.
+3. Then run `scripts/agent-gate.sh` and request review as usual — see the
+   [gate contract](/cqlite/agents-developing/gate-contract/).


### PR DESCRIPTION
Closes #1245.

## Why
Delivery-pipeline retro ranks `roborev_findings` as the #1 recurring cost (count=255, weighted 510 over 38 records). This codifies preventive guidance so implementations pre-empt the recurring finding classes, cutting review rounds.

## Change (docs/process only — behavior-preserving)
- **CLAUDE.md**: new "Pre-roborev self-check (common findings to pre-empt)" subsection under Agent-team conventions — a scannable checklist with one-line fixes for the recurring classes: GH Actions command injection, clippy `manual_range_contains`, integer overflow/saturation (BigInt + bounded exponents), float ordering vs Java (NaN-last + signed-zero), wall-clock test races, no-heuristics violations, gitignored reference binaries / dirty-tree gate.
- **website/src/content/docs/agents-developing/roborev-findings.md** (new): companion site page mirroring the checklist with code examples (Astro/Starlight); linked from the agents-developing index.
- **.claude/agents/sstable-developer.md**: implementer self-checks its diff against the checklist before reporting done.

Grounded in the actual recurring finding classes (telemetry ledger + classes observed this session across #1298/#1301).

## Validation
`agent-gate.sh`: **RESULT PASS** (all 16 components). roborev (codex): no issues (docs-only). Manager-routed: skip OpenSpec.