### PR TITLE
ci(#1217): extend clippy-conflict normalization to remaining @stable Rust-building workflows

### DIFF
--- a/.github/workflows/cassandra-parity.yml
+++ b/.github/workflows/cassandra-parity.yml
@@ -82,7 +82,7 @@ jobs:
       # This lane does not run clippy. Idempotent: a no-op if clippy is absent.
       - name: Remove preinstalled clippy (avoid clippy-preview install conflict)
         shell: bash
-        run: rustup component remove clippy 2>/dev/null || true
+        run: rustup component remove clippy --toolchain stable 2>/dev/null || true
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/cassandra-parity.yml
+++ b/.github/workflows/cassandra-parity.yml
@@ -70,6 +70,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      # Issue #1209/#1217: GitHub runner images ship a stable toolchain that
+      # already provides bin/cargo-clippy. The dtolnay/rust-toolchain@stable
+      # action performs a rustup reconcile that can intermittently try to
+      # (re)install the 'clippy-preview' component and fail with
+      # "detected conflict: 'bin/cargo-clippy'". Remove the conflicting
+      # component FIRST — before the toolchain action runs any rustup work — so
+      # the @stable setup (minimal profile, no clippy) cannot reinstall
+      # clippy-preview. The runner ships a working rustup, so this `run:` step
+      # before the action has rustup available.
+      # This lane does not run clippy. Idempotent: a no-op if clippy is absent.
+      - name: Remove preinstalled clippy (avoid clippy-preview install conflict)
+        shell: bash
+        run: rustup component remove clippy 2>/dev/null || true
+
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/compression-corruption-parity.yml
+++ b/.github/workflows/compression-corruption-parity.yml
@@ -113,7 +113,7 @@ jobs:
       # This lane does not run clippy. Idempotent: a no-op if clippy is absent.
       - name: Remove preinstalled clippy (avoid clippy-preview install conflict)
         shell: bash
-        run: rustup component remove clippy 2>/dev/null || true
+        run: rustup component remove clippy --toolchain stable 2>/dev/null || true
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/compression-corruption-parity.yml
+++ b/.github/workflows/compression-corruption-parity.yml
@@ -101,6 +101,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Issue #1209/#1217: GitHub runner images ship a stable toolchain that
+      # already provides bin/cargo-clippy. The dtolnay/rust-toolchain@stable
+      # action performs a rustup reconcile that can intermittently try to
+      # (re)install the 'clippy-preview' component and fail with
+      # "detected conflict: 'bin/cargo-clippy'". Remove the conflicting
+      # component FIRST — before the toolchain action runs any rustup work — so
+      # the @stable setup (minimal profile, no clippy) cannot reinstall
+      # clippy-preview. The runner ships a working rustup, so this `run:` step
+      # before the action has rustup available.
+      # This lane does not run clippy. Idempotent: a no-op if clippy is absent.
+      - name: Remove preinstalled clippy (avoid clippy-preview install conflict)
+        shell: bash
+        run: rustup component remove clippy 2>/dev/null || true
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/cql-type-parity.yml
+++ b/.github/workflows/cql-type-parity.yml
@@ -92,6 +92,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Issue #1209/#1217: GitHub runner images ship a stable toolchain that
+      # already provides bin/cargo-clippy. The dtolnay/rust-toolchain@stable
+      # action performs a rustup reconcile that can intermittently try to
+      # (re)install the 'clippy-preview' component and fail with
+      # "detected conflict: 'bin/cargo-clippy'". Remove the conflicting
+      # component FIRST — before the toolchain action runs any rustup work — so
+      # the @stable setup (minimal profile, no clippy) cannot reinstall
+      # clippy-preview. The runner ships a working rustup, so this `run:` step
+      # before the action has rustup available.
+      # This lane does not run clippy. Idempotent: a no-op if clippy is absent.
+      - name: Remove preinstalled clippy (avoid clippy-preview install conflict)
+        shell: bash
+        run: rustup component remove clippy 2>/dev/null || true
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/cql-type-parity.yml
+++ b/.github/workflows/cql-type-parity.yml
@@ -104,7 +104,7 @@ jobs:
       # This lane does not run clippy. Idempotent: a no-op if clippy is absent.
       - name: Remove preinstalled clippy (avoid clippy-preview install conflict)
         shell: bash
-        run: rustup component remove clippy 2>/dev/null || true
+        run: rustup component remove clippy --toolchain stable 2>/dev/null || true
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -93,7 +93,7 @@ jobs:
       # This lane does not run clippy. Idempotent: a no-op if clippy is absent.
       - name: Remove preinstalled clippy (avoid clippy-preview install conflict)
         shell: bash
-        run: rustup component remove clippy 2>/dev/null || true
+        run: rustup component remove clippy --toolchain stable 2>/dev/null || true
 
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -81,6 +81,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Issue #1209/#1217: GitHub runner images ship a stable toolchain that
+      # already provides bin/cargo-clippy. The dtolnay/rust-toolchain@stable
+      # action performs a rustup reconcile that can intermittently try to
+      # (re)install the 'clippy-preview' component and fail with
+      # "detected conflict: 'bin/cargo-clippy'". Remove the conflicting
+      # component FIRST — before the toolchain action runs any rustup work — so
+      # the @stable setup (minimal profile, no clippy) cannot reinstall
+      # clippy-preview. The runner ships a working rustup, so this `run:` step
+      # before the action has rustup available.
+      # This lane does not run clippy. Idempotent: a no-op if clippy is absent.
+      - name: Remove preinstalled clippy (avoid clippy-preview install conflict)
+        shell: bash
+        run: rustup component remove clippy 2>/dev/null || true
+
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -74,7 +74,7 @@ jobs:
       # This lane does not run clippy. Idempotent: a no-op if clippy is absent.
       - name: Remove preinstalled clippy (avoid clippy-preview install conflict)
         shell: bash
-        run: rustup component remove clippy 2>/dev/null || true
+        run: rustup component remove clippy --toolchain stable 2>/dev/null || true
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -62,6 +62,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
+      # Issue #1209/#1217: GitHub runner images ship a stable toolchain that
+      # already provides bin/cargo-clippy. The dtolnay/rust-toolchain@stable
+      # action performs a rustup reconcile that can intermittently try to
+      # (re)install the 'clippy-preview' component and fail with
+      # "detected conflict: 'bin/cargo-clippy'". Remove the conflicting
+      # component FIRST — before the toolchain action runs any rustup work — so
+      # the @stable setup (minimal profile, no clippy) cannot reinstall
+      # clippy-preview. The runner ships a working rustup, so this `run:` step
+      # before the action has rustup available.
+      # This lane does not run clippy. Idempotent: a no-op if clippy is absent.
+      - name: Remove preinstalled clippy (avoid clippy-preview install conflict)
+        shell: bash
+        run: rustup component remove clippy 2>/dev/null || true
+
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/tombstone-ttl-parity.yml
+++ b/.github/workflows/tombstone-ttl-parity.yml
@@ -76,6 +76,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Issue #1209/#1217: GitHub runner images ship a stable toolchain that
+      # already provides bin/cargo-clippy. The dtolnay/rust-toolchain@stable
+      # action performs a rustup reconcile that can intermittently try to
+      # (re)install the 'clippy-preview' component and fail with
+      # "detected conflict: 'bin/cargo-clippy'". Remove the conflicting
+      # component FIRST — before the toolchain action runs any rustup work — so
+      # the @stable setup (minimal profile, no clippy) cannot reinstall
+      # clippy-preview. The runner ships a working rustup, so this `run:` step
+      # before the action has rustup available.
+      # This lane does not run clippy. Idempotent: a no-op if clippy is absent.
+      - name: Remove preinstalled clippy (avoid clippy-preview install conflict)
+        shell: bash
+        run: rustup component remove clippy 2>/dev/null || true
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/tombstone-ttl-parity.yml
+++ b/.github/workflows/tombstone-ttl-parity.yml
@@ -88,7 +88,7 @@ jobs:
       # This lane does not run clippy. Idempotent: a no-op if clippy is absent.
       - name: Remove preinstalled clippy (avoid clippy-preview install conflict)
         shell: bash
-        run: rustup component remove clippy 2>/dev/null || true
+        run: rustup component remove clippy --toolchain stable 2>/dev/null || true
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Closes #1217.

Mirrors the #1209/PR #1216 fix for the intermittent `detected conflict: 'bin/cargo-clippy'` rustup flake across the remaining `@stable` Rust-building lanes that don't run `cargo clippy`.

## Changes
Adds an idempotent pre-setup step `rustup component remove clippy --toolchain stable 2>/dev/null || true` before `dtolnay/rust-toolchain@stable` in:
- cassandra-parity.yml, compression-corruption-parity.yml, tombstone-ttl-parity.yml, cql-type-parity.yml, smoke-tests.yml, docs-site.yml

`--toolchain stable` is explicit because the repo's `rust-toolchain.toml` pins `1.88.0`; without it the removal would target the pinned toolchain rather than the `stable` one being set up (roborev finding, fixed).

Excluded (untouched): lanes that run `cargo clippy` (flight-ci, quality-gates, coverage, delta-roundtrip) and pinned `@1.88.0` lanes (m1-ci).

## Quality
- agent-gate.sh **PASS**; actionlint clean (the 4 pre-existing SC2086 infos in smoke-tests are unrelated).
- roborev (codex): **No issues found**.

## Note
The original #1209 inline snippet (in python-ci.yml / node-ci.yml) lacks `--toolchain stable` and may have the same latent gap — out of scope here; flag for follow-up if those flakes recur.