### PR TITLE
docs(#1310): flow-meta — semantic-verdict guards + validate against the actual CI lane

### DIFF
--- a/.claude/commands/worker.md
+++ b/.claude/commands/worker.md
@@ -99,7 +99,18 @@ diff and breaks 1:1:1:1. Instead:
   it — never `checkout`/`reset` the root to "fix" it.
 - **Finalize cleans up YOUR worktree only** (`git worktree remove`), then deletes the origin lock branch.
   Never `git checkout main` / `git reset` the shared root checkout as part of cleanup.
-- The gate is the only run that counts — paste its summary block.
+- The gate is the only run that counts — paste its summary block. **But `agent-gate.sh`
+  PASS ≠ CI green** (L2, flow-meta #1310): the local gate does NOT run every CI lane —
+  it uses pre-existing datasets and a subset of test targets. When a change touches a
+  **regenerate path, a fixture parser, or a fail-closed CI guard**, reproduce the
+  **actual CI lane** locally before relying on the gate — regenerate sources from the
+  live container → run corpus gen → run the lane's exact `--test` target (e.g.
+  `compression-corruption-parity` = regenerate + require-fixtures; `parity-manifest` =
+  `cargo test -p cassandra-parity --test corpus_audit_tests`). Two PRs (#1236, #1199)
+  passed the gate and then failed CI on lanes the gate never ran. Related: #1269
+  reconciles the gate's component set with the CI lane set. And never gate a
+  non-deterministically-regenerated source on a whole-file byte identity — gate the
+  semantic verdict (validation playbook, L1).
 - Merge autonomously on green; do NOT wait for a human merge. Escalate to the owner ONLY for: a genuine
   design-call roborev finding, a scope/product question, or anything outside your issue.
 - Never close an epic or change scope/title. Surface those; don't act.

--- a/.claude/skills/flow-implement/SKILL.md
+++ b/.claude/skills/flow-implement/SKILL.md
@@ -66,6 +66,17 @@ OpenSpec change `<slug>` (design-driven only).
 5. **Gate (correctness).** Run `scripts/agent-gate.sh` in the worktree; it must be PASS. Paste the
    AGENT-GATE SUMMARY block. A known-flaky lane (e.g. `test_flush_throughput`, py3.9) that passes on
    re-run is not a failure — note it.
+   - **Gate PASS ≠ CI green** (L2, flow-meta #1310). The local gate does NOT run every CI lane (it uses
+     pre-existing datasets and a subset of `--test` targets). When the change touches a **regenerate path,
+     a fixture parser, or a fail-closed CI guard**, reproduce the **actual CI lane** locally before relying
+     on the gate — regenerate sources from the live container → corpus gen → the lane's exact target (e.g.
+     `compression-corruption-parity` = regenerate + require-fixtures; `parity-manifest` =
+     `cargo test -p cassandra-parity --test corpus_audit_tests`). #1236 and #1199 both passed the gate then
+     failed CI on lanes the gate never ran. (#1269 reconciles the gate's component set with the CI lanes.)
+   - **Never gate a non-deterministically-regenerated source on a whole-file byte identity** — the BTI trie
+     (`Partitions.db`/`Rows.db`) and `Statistics.db` are not byte-reproducible across regen runs. Gate the
+     **semantic verdict** (the parity test), keep the empty/missing-verdict authoring check fail-closed
+     (validation playbook, L1). Per-component binding is tracked in #1294.
 6. **C — intent audit** (design-driven). Spawn `spec-auditor` (explicit model) anchored to
    `openspec/changes/<slug>/specs/**`. Verdict must be PASS — every requirement `satisfied` with a
    public-surface test as evidence. `unmet`/uncovered/unjustified-`partial` → route the fix back (loop).

--- a/website/src/content/docs/agents-developing/validation-playbook.md
+++ b/website/src/content/docs/agents-developing/validation-playbook.md
@@ -131,6 +131,29 @@ normalization logic.
 4. Add table to the relevant parity test file
 5. Run gate: `scripts/agent-gate.sh`
 
+## Fail-closed guards vs non-deterministically-regenerated sources
+
+A fail-closed guard must key on something the source actually reproduces. CI regenerates
+clean SSTables from a live `cassandra:5.0.2` container on every run, and several
+components are **not byte-reproducible** between runs:
+
+- the **BTI (`da`) trie** — `Partitions.db` / `Rows.db`
+- **`Statistics.db`** — embeds wall-clock, host, and repair metadata
+
+**Rule (L1):** when a source is regenerated non-deterministically, gate on the
+**semantic verdict**, not on a whole-file byte identity. For corruption/verify corpora,
+assert that *CQLite detects the corruption the same way Cassandra does on whatever bytes
+are present* (the parity TEST) — never bind a captured verdict to the `sha256` of the
+whole fixture. Keep the *authoring* check (empty/missing verdict) fail-closed; that part
+IS reproducible. Per-component / full-directory binding is the proper future form
+(tracked in #1294).
+
+Why this matters: a whole-file-sha guard added in #1236 passed locally every run (the
+local gate uses pre-existing, non-regenerated datasets) but tripped in CI on a
+*different* regenerated fixture each round (first the BTI trie, then
+`statistics_db_header_damage`) — three CI-failure root-cause cycles *after* the local
+gate reported PASS. Origin: flow-meta #1310.
+
 ## Row count 0 — silent-pass trap
 
 If parity tests pass but show 0 rows, `CQLITE_DATASETS_ROOT` is unset or points to a


### PR DESCRIPTION
Closes #1310.

Two doctrine rules from the 2026-06-30 unattended run (#1236, #1199):

**L1 — validation playbook.** Non-deterministically-regenerated sources (BTI trie `Partitions.db`/`Rows.db`, `Statistics.db`) must be gated on the **semantic parity verdict**, not a whole-file sha. Keep the empty/missing-verdict authoring check fail-closed. (Root-caused the #1236 3-cycle CI churn.)

**L2 — `worker` + `flow-implement` skills.** `agent-gate.sh` PASS ≠ CI green: reproduce the **actual CI lane** (regenerate → corpus gen → exact `--test` target) for regenerate/parser/fail-closed-guard changes.

Cross-refs #1294 (per-component verdict binding) and #1269 (gate-in-CI). Docs/doctrine only — no code paths touched.