### PR TITLE
perf(#1143): default Auto disk-access to buffered (not mmap+SEQUENTIAL) — fix read-p99 regression under concurrent write

### DIFF
--- a/cqlite-core/src/config.rs
+++ b/cqlite-core/src/config.rs
@@ -106,18 +106,25 @@ pub struct StorageConfig {
     ///
     /// Defaults to [`DiskAccessMode::Auto`], which sizes each Data.db file
     /// against system RAM and picks the backend automatically:
-    /// - files below [`Self::mmap_min_size_bytes`] use buffered I/O (mapping a
-    ///   tiny file is not worth the setup cost);
-    /// - files up to [`Self::direct_io_memory_fraction`] of system memory are
-    ///   **memory-mapped**, so repeated scans stay resident in the page cache;
+    /// - files up to [`Self::direct_io_memory_fraction`] of system memory use
+    ///   **buffered I/O** through the OS page cache with ordinary kernel
+    ///   read-ahead — the safe, contention-friendly default;
     /// - files larger than that fraction use **direct I/O** (`O_DIRECT` on
     ///   Linux, `F_NOCACHE` on macOS), which bypasses the page cache so a
     ///   single huge scan does not evict everything else the host has cached.
     ///
+    /// `Auto` deliberately does **not** select memory-mapping (issue #1143):
+    /// mmap with `madvise(MADV_SEQUENTIAL)` read-ahead has aggressive drop-behind
+    /// that thrashes the shared page cache when multiple readers scan the same
+    /// file while a writer flushes, roughly doubling read p99 under concurrent
+    /// write load even though it speeds up an *isolated* scan. Use mmap only when
+    /// you ask for it explicitly.
+    ///
     /// Set an explicit [`DiskAccessMode::Buffered`], [`DiskAccessMode::Mmap`],
     /// or [`DiskAccessMode::Direct`] to override the heuristic. The legacy
     /// [`Self::use_mmap`] flag still forces mmap when `Auto` would otherwise
-    /// pick buffered, for backward compatibility.
+    /// pick buffered, for backward compatibility (and for the repeated-rescan
+    /// workload mmap was built for).
     ///
     /// Can also be set at runtime via `CQLITE_DISK_ACCESS_MODE`
     /// (`auto` / `buffered` / `mmap` / `direct`).
@@ -125,7 +132,7 @@ pub struct StorageConfig {
     pub disk_access_mode: DiskAccessMode,
 
     /// Fraction of total system memory above which [`DiskAccessMode::Auto`]
-    /// switches a file from memory-mapped to direct I/O. Defaults to `0.5`
+    /// switches a file from buffered to direct I/O. Defaults to `0.5`
     /// (half of RAM). Clamped to `(0.0, 1.0]`; values outside that range fall
     /// back to the default. Ignored when system memory cannot be determined
     /// (in which case `Auto` never escalates to direct I/O).

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -428,17 +428,8 @@ impl SSTableReader {
 
         let file_size = tokio::fs::metadata(path).await?.len();
 
-        // The explicit mode comes from env > config. The legacy `use_mmap` flag
-        // is folded in by promoting an otherwise-`Buffered` request to `Mmap` so
-        // the old opt-in keeps working (`Auto` and explicit non-buffered modes
-        // are left untouched, so a real backend decision always wins).
+        // The explicit mode comes from env > config.
         let configured_mode = disk_access_mode_via_env().unwrap_or(config.storage.disk_access_mode);
-        let configured_mode =
-            if reader_config.use_mmap && matches!(configured_mode, DiskAccessMode::Buffered) {
-                DiskAccessMode::Mmap
-            } else {
-                configured_mode
-            };
 
         let resolved_mode = resolve_disk_access_mode(
             configured_mode,
@@ -448,6 +439,26 @@ impl SSTableReader {
             system_memory_bytes(),
             direct_io_available(),
         );
+
+        // Fold in the legacy `use_mmap` / `CQLITE_USE_MMAP` opt-in AFTER resolving
+        // the backend so it works for the DEFAULT (`Auto`) config too (issue #1143:
+        // `Auto` now resolves to `Buffered`, so gating the promotion on the
+        // *configured* mode being `Buffered` silently dropped the legacy flag). We
+        // promote only when the RESOLVED mode is `Buffered` — i.e. it came from an
+        // explicit `Buffered` request OR from `Auto` falling through to buffered —
+        // and the file meets the mmap size threshold. An explicit `Direct`/`Mmap`
+        // backend decision (or `Auto` selecting `Direct`) always wins, so the
+        // legacy flag never overrides a real backend choice. The flag stays strictly
+        // opt-in: the default (`Auto`, no `use_mmap`) still resolves to `Buffered`.
+        let resolved_mode = if reader_config.use_mmap
+            && matches!(resolved_mode, DiskAccessMode::Buffered)
+            && file_size > 0
+            && file_size >= reader_config.mmap_min_size_bytes as u64
+        {
+            DiskAccessMode::Mmap
+        } else {
+            resolved_mode
+        };
 
         // Build both the shared point-read source and the per-scan factory from
         // the same backend decision so concurrent scans get independent cursors

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -52,6 +52,14 @@ pub use compaction_row::{
 #[doc(hidden)]
 pub use parsing::PublicV5CompressedLegacyParser as V5CompressedLegacyParser;
 
+// Issue #1143: probe for the disk-access-backend regression guard. Exposed only
+// under the non-default `scan-offload-probe` feature (alongside the existing
+// scan-offload thread probe) so the guard test can deterministically assert the
+// default `Auto` backend selection. Never present in normal/release builds.
+#[cfg(feature = "scan-offload-probe")]
+#[doc(hidden)]
+pub use probe_resolved_disk_access_mode as probe_disk_access_mode;
+
 // Re-export compression utilities for testing (Issue #202)
 #[doc(hidden)]
 pub use compression::extract_sstable_base_name;
@@ -181,9 +189,35 @@ fn system_memory_bytes() -> Option<u64> {
 /// heuristic can be unit-tested deterministically. Resolution rules:
 /// - explicit `Buffered`/`Mmap`/`Direct` are returned unchanged (the caller
 ///   applies graceful fallback if the OS refuses the backend);
-/// - `Auto` returns `Buffered` for files below `mmap_min_size_bytes`, `Direct`
-///   when the file exceeds `memory_fraction` of `system_memory` (and memory is
-///   known and direct I/O is available on this platform), otherwise `Mmap`.
+/// - `Auto` returns `Direct` when the file exceeds `memory_fraction` of
+///   `system_memory` (and memory is known and direct I/O is available on this
+///   platform), otherwise `Buffered`.
+///
+/// # Why `Auto` defaults to `Buffered`, not `Mmap` (issue #1143)
+///
+/// `Auto` used to escalate every sub-RAM-fraction file to `Mmap` with
+/// `madvise(MADV_SEQUENTIAL)` read-ahead (PrefetchMode::Auto → Sequential). That
+/// silently flipped the *default* read backend from buffered I/O — the pre-#964
+/// behaviour — to mmap-with-aggressive-sequential-readahead. `MADV_SEQUENTIAL`
+/// enables aggressive read-ahead **and drop-behind** (the kernel evicts pages
+/// behind each reader's cursor). Under concurrent write load — N readers all
+/// scanning the same Data.db while a writer flushes (the `mixed.read_while_write`
+/// shape, issue #1143) — that is pathological: each reader's drop-behind evicts
+/// pages the *other* readers still need (re-fault storms / page-cache thrash) and
+/// the eager read-ahead competes with the concurrent flush for the same I/O queue
+/// and page cache. Isolated single-reader throughput *improved* (sequential
+/// read-ahead is ideal with no contention), but read p99 under concurrent write
+/// roughly doubled — the classic "faster isolated, worse tail under contention"
+/// regression. Restoring `Buffered` as the `Auto` default removes the shared-page
+/// drop-behind hazard while keeping ordinary kernel read-ahead. `Mmap` stays
+/// available as an explicit opt-in (config / `CQLITE_DISK_ACCESS_MODE=mmap` /
+/// the legacy `use_mmap` flag) for the repeated-rescan workload it was built for.
+///
+/// `Direct` is still the right pick for a genuinely > RAM-fraction one-shot scan:
+/// it bypasses the page cache via its OWN per-cursor aligned read-ahead buffer
+/// (`DirectCursor`), so it neither thrashes the shared page cache nor performs
+/// cross-reader drop-behind — there is no contention hazard, and it keeps a giant
+/// scan from evicting everything else the host has warm.
 ///
 /// The deprecated `use_mmap` flag / `CQLITE_USE_MMAP` env is folded in by the
 /// caller (it promotes a `Buffered` request to `Mmap`), so it is not an input
@@ -206,9 +240,10 @@ fn resolve_disk_access_mode(
         DiskAccessMode::Mmap => DiskAccessMode::Mmap,
         DiskAccessMode::Direct => DiskAccessMode::Direct,
         DiskAccessMode::Auto => {
-            if file_size < mmap_min_size_bytes {
-                return DiskAccessMode::Buffered;
-            }
+            // `mmap_min_size_bytes` no longer gates `Auto` (it never picks mmap),
+            // but it remains meaningful for the explicit/`use_mmap` mmap path the
+            // caller resolves separately; reference it so the contract is explicit.
+            let _ = mmap_min_size_bytes;
             let fraction = if memory_fraction.is_finite() && memory_fraction > 0.0 {
                 memory_fraction.min(1.0)
             } else {
@@ -222,9 +257,37 @@ fn resolve_disk_access_mode(
                     }
                 }
             }
-            DiskAccessMode::Mmap
+            // Default: buffered I/O. See the regression note above (issue #1143)
+            // for why `Auto` must NOT silently select mmap+SEQUENTIAL read-ahead.
+            DiskAccessMode::Buffered
         }
     }
+}
+
+/// Issue #1143 regression guard probe: deterministically resolve the
+/// disk-access backend the DEFAULT (`Auto`) config picks for a given file size,
+/// using the same `resolve_disk_access_mode` + real system-memory inputs the
+/// reader uses at `open()`. Exposed ONLY under the non-default
+/// `scan-offload-probe` feature so the guard test can assert that `Auto` does
+/// NOT silently select mmap for an ordinary sub-RAM SSTable (the
+/// read-while-write tail regression's root cause). Adds zero cost to normal /
+/// release builds — the symbol does not exist there.
+#[cfg(feature = "scan-offload-probe")]
+#[doc(hidden)]
+pub fn probe_resolved_disk_access_mode(
+    configured: DiskAccessMode,
+    file_size: u64,
+    mmap_min_size_bytes: u64,
+    memory_fraction: f64,
+) -> DiskAccessMode {
+    resolve_disk_access_mode(
+        configured,
+        file_size,
+        mmap_min_size_bytes,
+        memory_fraction,
+        system_memory_bytes(),
+        direct_io_available(),
+    )
 }
 
 /// Whether the direct-I/O backend is compiled in for this platform.

--- a/cqlite-core/src/storage/sstable/reader/tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/tests.rs
@@ -767,8 +767,37 @@ mod tests {
             "use_mmap=true must select the mmap backend for a >4KiB file"
         );
 
+        // Legacy opt-in (roborev #1143): `use_mmap=true` on the DEFAULT (`Auto`)
+        // config — without ALSO setting `disk_access_mode=Buffered` — must still
+        // promote to mmap. The promotion is applied AFTER `Auto` resolves to
+        // `Buffered`, so the documented back-compat path works for the default
+        // config too (it previously gated on the *configured* mode being
+        // `Buffered`, silently dropping the flag once `Auto`→`Buffered` landed).
+        config.storage.disk_access_mode = DiskAccessMode::Auto;
+        config.storage.use_mmap = true;
+        let auto_mapped = SSTableReader::open(&data_file, &config, platform.clone()).await?;
+        assert!(
+            auto_mapped.is_mmap_backed().await,
+            "use_mmap=true on the default Auto config must promote to mmap (roborev #1143)"
+        );
+
+        // The legacy flag must NEVER override an EXPLICIT non-buffered backend or
+        // be promoted when it does not also win the resolver: with `use_mmap=true`
+        // but an explicit `Mmap` mode, mmap is selected because mode is explicit —
+        // and the flag stays strictly opt-in (default Auto, no flag, stays
+        // buffered, asserted below).
+        config.storage.disk_access_mode = DiskAccessMode::Mmap;
+        config.storage.use_mmap = true;
+        let explicit_mmap_flag = SSTableReader::open(&data_file, &config, platform.clone()).await?;
+        assert!(
+            explicit_mmap_flag.is_mmap_backed().await,
+            "explicit Mmap must select the mmap backend regardless of the legacy flag"
+        );
+
         // Auto stays buffered regardless of the (now Auto-irrelevant) min-size
-        // threshold: Auto never maps, so it is buffered here too.
+        // threshold: Auto never maps WITHOUT the legacy opt-in, so it is buffered
+        // here too. This pins that the flag remains strictly opt-in (no #1143
+        // regression: default Auto, no flag ⇒ Buffered).
         config.storage.use_mmap = false;
         config.storage.disk_access_mode = DiskAccessMode::Auto;
         config.storage.mmap_min_size_bytes = usize::MAX;
@@ -776,6 +805,20 @@ mod tests {
         assert!(
             !small.is_mmap_backed().await,
             "Auto must stay buffered (issue #1143)"
+        );
+
+        // Legacy opt-in respects the mmap size threshold: `use_mmap=true` on the
+        // default `Auto` config but with the min-size set above the file size must
+        // NOT promote to mmap (the promotion is gated on the file meeting the
+        // threshold, matching the explicit-Buffered+use_mmap behaviour).
+        config.storage.disk_access_mode = DiskAccessMode::Auto;
+        config.storage.use_mmap = true;
+        config.storage.mmap_min_size_bytes = usize::MAX;
+        let auto_below_threshold =
+            SSTableReader::open(&data_file, &config, platform.clone()).await?;
+        assert!(
+            !auto_below_threshold.is_mmap_backed().await,
+            "use_mmap on Auto must respect mmap_min_size_bytes (no promotion below threshold)"
         );
 
         Ok(())

--- a/cqlite-core/src/storage/sstable/reader/tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/tests.rs
@@ -602,8 +602,10 @@ mod tests {
         assert_eq!(parse_prefetch_mode("???"), None);
     }
 
-    /// The `Auto` heuristic: tiny → buffered, sub-RAM → mmap, > fraction of
-    /// RAM → direct (when memory is known and direct I/O is compiled in).
+    /// The `Auto` heuristic (issue #1143): sub-RAM-fraction → buffered (NEVER
+    /// mmap — mmap+SEQUENTIAL drop-behind thrashes the page cache under
+    /// concurrent write load), > fraction of RAM → direct (when memory is known
+    /// and direct I/O is compiled in, else buffered).
     #[test]
     fn test_resolve_disk_access_mode_auto() {
         use super::super::resolve_disk_access_mode;
@@ -618,25 +620,30 @@ mod tests {
             DiskAccessMode::Buffered
         );
 
-        // Below mmap_min_size_bytes → buffered.
+        // Tiny file → buffered.
         assert_eq!(
             resolve_disk_access_mode(DiskAccessMode::Auto, 100, min, 0.5, Some(8 * gib), true),
             DiskAccessMode::Buffered
         );
 
-        // Comfortably sub-RAM → mmap.
+        // Comfortably sub-RAM → buffered (issue #1143: no longer mmap). This is
+        // the load-bearing assertion the read-while-write tail regression turned
+        // on: `Auto` must not silently pick mmap+SEQUENTIAL read-ahead for an
+        // ordinary-sized SSTable, which is the common benchmark/production case.
         assert_eq!(
             resolve_disk_access_mode(DiskAccessMode::Auto, gib, min, 0.5, Some(8 * gib), true),
-            DiskAccessMode::Mmap
+            DiskAccessMode::Buffered
         );
 
-        // Larger than half of RAM → direct.
+        // Larger than half of RAM → direct (page-cache-bypassing one-shot scan;
+        // no shared-page drop-behind, so no cross-reader thrash).
         assert_eq!(
             resolve_disk_access_mode(DiskAccessMode::Auto, 5 * gib, min, 0.5, Some(8 * gib), true),
             DiskAccessMode::Direct
         );
 
-        // Larger than half of RAM but direct I/O unavailable → mmap.
+        // Larger than half of RAM but direct I/O unavailable → buffered (NOT
+        // mmap: the contention hazard outweighs avoiding cache eviction).
         assert_eq!(
             resolve_disk_access_mode(
                 DiskAccessMode::Auto,
@@ -646,13 +653,13 @@ mod tests {
                 Some(8 * gib),
                 false
             ),
-            DiskAccessMode::Mmap
+            DiskAccessMode::Buffered
         );
 
-        // Unknown system memory → never escalates to direct.
+        // Unknown system memory → never escalates to direct; stays buffered.
         assert_eq!(
             resolve_disk_access_mode(DiskAccessMode::Auto, 100 * gib, min, 0.5, None, true),
-            DiskAccessMode::Mmap
+            DiskAccessMode::Buffered
         );
 
         // A non-finite/zero fraction falls back to the 0.5 default.
@@ -697,9 +704,10 @@ mod tests {
     }
 
     /// End-to-end: `disk_access_mode` drives backend selection. The default
-    /// `Auto` mode maps a small (sub-RAM) Data.db file; an explicit `Buffered`
-    /// mode and the `mmap_min_size_bytes` threshold both force buffered I/O; the
-    /// legacy `use_mmap` flag still selects mmap.
+    /// `Auto` mode now uses buffered I/O for a small (sub-RAM) Data.db file
+    /// (issue #1143 — `Auto` no longer silently maps); an explicit `Buffered`
+    /// mode also stays buffered; the legacy `use_mmap` flag and an explicit
+    /// `Mmap` mode both still select the mmap backend.
     #[tokio::test]
     async fn test_config_drives_mmap_backend() -> crate::Result<()> {
         use super::super::SSTableReader;
@@ -725,11 +733,13 @@ mod tests {
         let mut config = Config::default();
         let platform = Arc::new(Platform::new(&config).await?);
 
-        // Default config (Auto): a >4KiB file far below system RAM is mapped.
+        // Default config (Auto): a sub-RAM file is now BUFFERED, not mapped
+        // (issue #1143). `Auto` must never silently select mmap+SEQUENTIAL
+        // read-ahead, whose drop-behind doubled read p99 under concurrent write.
         let reader = SSTableReader::open(&data_file, &config, platform.clone()).await?;
         assert!(
-            reader.is_mmap_backed().await,
-            "Auto must map a small (sub-RAM) file"
+            !reader.is_mmap_backed().await,
+            "Auto must use buffered I/O for a sub-RAM file (issue #1143), not mmap"
         );
 
         // Explicit Buffered mode forces buffered I/O.
@@ -740,7 +750,16 @@ mod tests {
             "explicit Buffered mode must not map"
         );
 
+        // Explicit Mmap mode still selects the mmap backend (opt-in preserved).
+        config.storage.disk_access_mode = DiskAccessMode::Mmap;
+        let explicit_mmap = SSTableReader::open(&data_file, &config, platform.clone()).await?;
+        assert!(
+            explicit_mmap.is_mmap_backed().await,
+            "explicit Mmap mode must select the mmap backend"
+        );
+
         // Legacy opt-in still selects mmap even with mode left at Buffered.
+        config.storage.disk_access_mode = DiskAccessMode::Buffered;
         config.storage.use_mmap = true;
         let mapped = SSTableReader::open(&data_file, &config, platform.clone()).await?;
         assert!(
@@ -748,14 +767,15 @@ mod tests {
             "use_mmap=true must select the mmap backend for a >4KiB file"
         );
 
-        // A min-size threshold above the file size forces buffered under Auto.
+        // Auto stays buffered regardless of the (now Auto-irrelevant) min-size
+        // threshold: Auto never maps, so it is buffered here too.
         config.storage.use_mmap = false;
         config.storage.disk_access_mode = DiskAccessMode::Auto;
         config.storage.mmap_min_size_bytes = usize::MAX;
         let small = SSTableReader::open(&data_file, &config, platform.clone()).await?;
         assert!(
             !small.is_mmap_backed().await,
-            "files below mmap_min_size_bytes must stay buffered"
+            "Auto must stay buffered (issue #1143)"
         );
 
         Ok(())

--- a/cqlite-core/tests/issue_1143_default_disk_access_backend.rs
+++ b/cqlite-core/tests/issue_1143_default_disk_access_backend.rs
@@ -1,0 +1,141 @@
+//! Issue #1143 (regression guard for #964): the DEFAULT disk-access backend
+//! must not silently memory-map an ordinary SSTable under read-while-write load.
+//!
+//! ## What regressed
+//!
+//! Commit `1021577` / `e26df3f` ("feat(reader): size-aware disk-access backend
+//! with configurable prefetch", #964) added `StorageConfig::disk_access_mode`,
+//! defaulting to [`DiskAccessMode::Auto`], and `prefetch`, defaulting to
+//! [`PrefetchMode::Auto`]. For an ordinary-sized SSTable (above one page, below
+//! `direct_io_memory_fraction` of system RAM — the common benchmark/production
+//! case) `Auto` resolved to **mmap with `madvise(MADV_SEQUENTIAL)`** read-ahead.
+//!
+//! Before #964 the default read backend was buffered I/O (`use_mmap` defaulted to
+//! `false`). So #964 silently flipped the default from buffered to
+//! mmap-with-aggressive-sequential-readahead.
+//!
+//! `MADV_SEQUENTIAL` enables aggressive read-ahead AND drop-behind: the kernel
+//! evicts pages behind each reader's cursor. With several readers concurrently
+//! scanning the same Data.db while a writer flushes (the `mixed.read_while_write`
+//! workload, conc=8), each reader's drop-behind evicts pages the *other* readers
+//! still need (re-fault storms / page-cache thrash) and the eager read-ahead
+//! competes with the concurrent flush for the same I/O queue and page cache.
+//! Isolated single-reader throughput *improved* (sequential read-ahead is ideal
+//! with no contention) but read p99 under concurrent write roughly doubled
+//! (~200µs → ~371µs in the external A/B) — the classic "faster isolated, worse
+//! tail under contention" backend regression.
+//!
+//! ## Why a structural backend-selection guard (not a p99 threshold)
+//!
+//! Absolute p99 latency is machine-dependent, flaky, and the regression only
+//! surfaces under sustained multi-reader + writer load against large production
+//! data — a criterion micro-bench went green and missed it. The true root cause
+//! is purely STRUCTURAL and fully deterministic: the *default* `Auto` config
+//! selecting the mmap+SEQUENTIAL backend for an ordinary file. This guard pins
+//! that decision directly.
+//!
+//! It asserts the load-bearing invariant via the probe-gated
+//! `probe_resolved_disk_access_mode` (which runs the real
+//! `resolve_disk_access_mode` against actual system memory, exactly as the reader
+//! does at `open()`): for a representative ordinary SSTable size, the default
+//! `Auto` config must resolve to **Buffered** (or, only when the file genuinely
+//! exceeds the RAM fraction, page-cache-bypassing **Direct**) — but NEVER
+//! **Mmap**. Mmap stays available only as an explicit opt-in.
+//!
+//! Pre-fix (#964 heuristic): `Auto` → `Mmap` for a sub-RAM file → FAIL.
+//! Post-fix: `Auto` → `Buffered` for a sub-RAM file → PASS.
+
+// Requires the non-default `scan-offload-probe` feature, which exposes
+// `probe_resolved_disk_access_mode` (the regression-guard probe). The agent gate
+// runs this binary with that feature enabled.
+#![cfg(feature = "scan-offload-probe")]
+
+use cqlite_core::config::{DiskAccessMode, PrefetchMode};
+use cqlite_core::storage::sstable::reader::probe_resolved_disk_access_mode as resolve;
+
+/// One page (the `mmap_min_size_bytes` default) and the `direct_io_memory_fraction`
+/// default, mirroring `StorageConfig::default()`.
+const ONE_PAGE: u64 = 4096;
+const RAM_FRACTION: f64 = 0.5;
+
+/// A representative ordinary SSTable size: well above one page, well below any
+/// plausible machine's `RAM_FRACTION` of RAM. 64 MiB is the default
+/// `max_sstable_size`, so a single generation never exceeds it; the
+/// `read_while_write` corpus (a static 100k-row lz4 table) is in this ballpark.
+const ORDINARY_SSTABLE_BYTES: u64 = 64 * 1024 * 1024;
+
+/// The default-config (`Auto`) backend for an ordinary sub-RAM SSTable must NOT
+/// be memory-mapped. This is the exact structural decision the read-while-write
+/// p99 regression turned on (issue #1143 / #964).
+#[test]
+fn default_auto_backend_is_not_mmap_for_ordinary_sstable() {
+    let resolved = resolve(
+        DiskAccessMode::Auto,
+        ORDINARY_SSTABLE_BYTES,
+        ONE_PAGE,
+        RAM_FRACTION,
+    );
+
+    eprintln!(
+        "issue #1143 backend guard: Auto for a {ORDINARY_SSTABLE_BYTES}-byte SSTable \
+         resolved to {resolved:?}"
+    );
+
+    assert_ne!(
+        resolved,
+        DiskAccessMode::Mmap,
+        "Issue #1143 REGRESSION: the default `Auto` disk-access mode selected the \
+         mmap backend for an ordinary sub-RAM SSTable. #964 made `Auto` pick \
+         mmap+madvise(SEQUENTIAL), whose drop-behind thrashes the shared page cache \
+         under concurrent write load and roughly doubled read p99 \
+         (mixed.read_while_write). `Auto` must default to buffered I/O; mmap is an \
+         explicit opt-in only."
+    );
+
+    // The only acceptable Auto outcomes are Buffered (the contention-safe
+    // default) or Direct (a genuinely > RAM-fraction one-shot scan; uses its own
+    // per-cursor aligned buffer, so no shared-page drop-behind). An ordinary
+    // 64 MiB file is far below the RAM fraction on any real host, so this should
+    // be Buffered — but accept Direct defensively for tiny-RAM CI containers.
+    assert!(
+        matches!(resolved, DiskAccessMode::Buffered | DiskAccessMode::Direct),
+        "Auto must resolve to Buffered (or Direct for > RAM-fraction files), got {resolved:?}"
+    );
+}
+
+/// Tiny files are buffered under `Auto` (mapping a tiny file is pointless and
+/// mmap is the contention hazard regardless).
+#[test]
+fn default_auto_backend_is_buffered_for_tiny_file() {
+    assert_eq!(
+        resolve(DiskAccessMode::Auto, 1024, ONE_PAGE, RAM_FRACTION),
+        DiskAccessMode::Buffered,
+        "Auto must use buffered I/O for a sub-page file"
+    );
+}
+
+/// An explicit `Mmap` request is still honored (the opt-in is preserved); only
+/// the silent `Auto` default changed. Guards against an over-broad fix that
+/// removes mmap entirely.
+#[test]
+fn explicit_mmap_is_still_honored() {
+    assert_eq!(
+        resolve(
+            DiskAccessMode::Mmap,
+            ORDINARY_SSTABLE_BYTES,
+            ONE_PAGE,
+            RAM_FRACTION,
+        ),
+        DiskAccessMode::Mmap,
+        "explicit Mmap mode must still select the mmap backend"
+    );
+}
+
+/// `PrefetchMode::Auto` remains the configured default — this guard is about the
+/// *backend* selection, not prefetch; assert the default is unchanged so the two
+/// stay decoupled (a future change that flips the prefetch default should be a
+/// deliberate, separately-reviewed decision).
+#[test]
+fn prefetch_default_unchanged() {
+    assert_eq!(PrefetchMode::default(), PrefetchMode::Auto);
+}

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -727,15 +727,23 @@ run_component core-tests cargo test --package cqlite-core --features cli-helpers
 run_component tombstones-scan cargo test --package cqlite-core \
   --features write-support,cli-helpers,tombstones \
   --test issue_1085_tombstones_full_scan_parity
-# Issue #1143: the thread-identity guard proves the windowed scan's
-# decompress+parse runs OFF the async worker pool. Its probe is gated behind the
-# non-default `scan-offload-probe` feature (so the instrumentation never ships in
-# normal builds), and the test only compiles under that feature — so the default
-# core-tests run never executes it. Run it here with the feature on; a guard that
-# doesn't run in CI is not a guard.
-run_component scan-offload-guard cargo test --package cqlite-core \
-  --features cli-helpers,scan-offload-probe \
-  --test issue_1143_scan_offload_thread
+# Issue #1143: two regression guards, both gated behind the non-default
+# `scan-offload-probe` feature (so the probe instrumentation never ships in
+# normal builds) and so only compiled/run here:
+#   1. issue_1143_scan_offload_thread — the windowed scan's decompress+parse runs
+#      OFF the async worker pool (PR #1156 scan-stream starvation fix).
+#   2. issue_1143_default_disk_access_backend — the DEFAULT `Auto` disk-access
+#      backend does NOT silently memory-map an ordinary SSTable (#964 read-while-
+#      write tail regression: mmap+MADV_SEQUENTIAL drop-behind thrashed the page
+#      cache under concurrent write, ~doubling read p99). A guard that doesn't run
+#      in CI is not a guard, so run both with the feature on.
+run_component scan-offload-guard bash -c '
+  cargo test --package cqlite-core \
+    --features cli-helpers,scan-offload-probe \
+    --test issue_1143_scan_offload_thread &&
+  cargo test --package cqlite-core \
+    --features cli-helpers,scan-offload-probe \
+    --test issue_1143_default_disk_access_backend'
 # Compile EVERY target in the package first (--no-run, whole package) so a
 # new/edited test file that doesn't compile can't hide behind the enumerated
 # run-list (issue #865); then execute the seven CI-enforced targets.


### PR DESCRIPTION
Closes #1143.

## Root cause (bisect-confirmed)
#964 (`1021577`/`e26df3f`) added `disk_access_mode: Auto` + `prefetch: Auto` and silently flipped the default backend from **buffered I/O** to **mmap + `MADV_SEQUENTIAL`** for ordinary-sized SSTables. `MADV_SEQUENTIAL` does aggressive read-ahead **plus drop-behind**: with multiple readers full-scanning the same file while writers flush, each reader's drop-behind evicts pages the others still need (page-cache thrash) and read-ahead competes with flush I/O. That is exactly the reported shape — **isolated** scan throughput improved ~41%, but **read p99 under concurrent write load ~doubled** (~200µs → ~371µs). Verified against `git show 9054734:...config.rs`: the pre-#964 default was buffered.

Suspect verdict: #964 **CONFIRMED**; #815 (`f5a1317`), #917 (`563f3fd`), pk=? lookup (`d8381b2`) ruled out.

## Fix
`resolve_disk_access_mode`: `Auto` now resolves to **`Buffered`** for sub-RAM-fraction files (restoring the pre-#964 default) and **`Direct`** only when a file exceeds `direct_io_memory_fraction` (Direct uses its own per-cursor aligned buffer — no shared-page-cache drop-behind). Explicit `Mmap`/`Direct` and the legacy `use_mmap`/`CQLITE_USE_MMAP` opt-in are preserved (legacy promotion now applied **after** Auto resolution so it still works for default configs — fixes a roborev-caught back-compat break).

## Guard
New `cqlite-core/tests/issue_1143_default_disk_access_backend.rs` (run under `scan-offload-guard`) pins the structural invariant the regression turns on: default `Auto` for an ordinary SSTable must NOT resolve to `Mmap`. Proven to FAIL pre-fix, PASS post-fix. A structural invariant is used rather than a p99 assertion because absolute latency is machine-dependent and the tail only manifests under sustained multi-reader+writer load.

## Verification
- `scripts/agent-gate.sh` → **RESULT: PASS** (all components; `file-size` PASS under the documented `CQLITE_ALLOW_FILE_GROWTH=1` ack — this grows 3 pre-existing over-threshold files modestly; a split is out of scope for a targeted contention fix).
- roborev (codex, vs origin/main): **No issues found** (a MEDIUM back-compat finding on the `use_mmap` opt-in was fixed).

## ⚠️ Still needs owner action
End-to-end p99 validation requires the **external `cqlite-perf` harness** (`mixed.read_while_write`, conc=8) — cannot run in-repo. Recommend an A/B (this branch's buffered default vs v0.12.0 mmap default) to confirm read p99 returns toward the ~200µs baseline.

Routing: oracle-driven — no OpenSpec.