### PR TITLE
test(#1312): fail smoke on empty enforced corpus + dataset-skip the Tier-1 guard

### DIFF
--- a/bindings/node/__test__/parity-utils.js
+++ b/bindings/node/__test__/parity-utils.js
@@ -726,8 +726,8 @@ function discoverKeyspaces() {
  * Discover table names (UUID suffix stripped) for one keyspace.
  *
  * Filtered to the COMMITTED corpus at TABLE granularity (#1319): an untracked
- * WIP `<table>-<uuid>/` dir (no git-tracked golden) under an already-tracked
- * keyspace is IGNORED, not enumerated into ALL_TABLES/OA_TABLES.
+ * WIP `<table>-<uuid>/` dir (no git-tracked file at all) under an
+ * already-tracked keyspace is IGNORED, not enumerated into ALL_TABLES/OA_TABLES.
  */
 function discoverTables(keyspace) {
   const dir = path.join(global.testPaths.SSTABLES_DIR, keyspace);
@@ -741,7 +741,7 @@ function discoverTables(keyspace) {
   return tables.sort();
 }
 
-let _trackedGoldenTableDirsCache = null;
+let _trackedTableDirsCache = null;
 
 // The committed corpus is owned by THIS source tree (the repo that contains
 // this harness + the corpus-coverage policy), NOT by whatever checkout
@@ -761,32 +761,40 @@ const SOURCE_TREE_SSTABLES = path.resolve(
 );
 
 /**
- * `"<keyspace>/<table-dir>"` for each dir owning a git-tracked golden (#1319).
+ * `"<keyspace>/<table-dir>"` for each dir owning ANY git-tracked file (#1319/#1312).
  *
  * The classification/enforcement set is the COMMITTED corpus, NOT raw live-disk
- * enumeration: a table DIRECTORY counts as "committed" iff git tracks at least
- * one `<keyspace>/<table>-<uuid>/*-Data.db.jsonl` golden inside it. This ignores
- * untracked WIP fixtures a concurrent session may have dropped into the live
- * CQLITE_DATASETS_ROOT — at either keyspace granularity (a whole new keyspace,
- * e.g. `test_signed_coll`) OR table granularity (a new untracked
- * `<table>-<uuid>/` dir under an already-tracked keyspace) — so neither gets
- * enforced nor reds the integrity guard.
+ * enumeration: a table DIRECTORY counts as "committed" iff git tracks AT LEAST
+ * ONE file under `<keyspace>/<table>-<uuid>/` — Data.db, TOC, Statistics, a
+ * JSONL golden, ANYTHING. This deliberately does NOT require a tracked
+ * `*-Data.db.jsonl` golden: a newly-committed table dir that ships SSTable
+ * metadata but is (regressionly) MISSING its JSONL golden must still count as
+ * committed so the coverage check can surface the missing golden and FAIL
+ * LOUDLY (#1229), rather than be silently omitted as "uncommitted". The
+ * separate golden-presence check (findJsonlFile / coverage tests) enforces that.
+ *
+ * This still ignores untracked WIP fixtures a concurrent session may have
+ * dropped into the live CQLITE_DATASETS_ROOT — at either keyspace granularity
+ * (a whole new keyspace, e.g. `test_signed_coll`, ZERO tracked files) OR table
+ * granularity (a new untracked `<table>-<uuid>/` dir under an already-tracked
+ * keyspace) — so neither gets enforced.
  *
  * Tracked-ness is measured against THIS source tree's
  * `test-data/datasets/sstables` (the repo that owns this harness + the policy),
  * NOT the live SSTABLES_DIR — the live datasets root may be a *different*
  * checkout whose index already contains a concurrent session's WIP. Single
- * `git ls-files` call, parsed into `keyspace/table-dir` (first two segments).
+ * `git ls-files` call (no pathspec — ALL tracked files), parsed into
+ * `keyspace/table-dir` (first two segments).
  *
- * @returns {Set<string>} tracked-golden `keyspace/table-dir` (empty if git unavailable)
+ * @returns {Set<string>} tracked `keyspace/table-dir` (empty if git unavailable)
  */
-function gitTrackedGoldenTableDirs() {
-  if (_trackedGoldenTableDirsCache) return _trackedGoldenTableDirsCache;
+function gitTrackedTableDirs() {
+  if (_trackedTableDirsCache) return _trackedTableDirsCache;
   const out = new Set();
   try {
     const stdout = execFileSync(
       'git',
-      ['-C', SOURCE_TREE_SSTABLES, 'ls-files', '-z', '--', '*-Data.db.jsonl'],
+      ['-C', SOURCE_TREE_SSTABLES, 'ls-files', '-z'],
       { encoding: 'buffer' },
     );
     for (const raw of stdout.toString('utf8').split('\0')) {
@@ -797,36 +805,40 @@ function gitTrackedGoldenTableDirs() {
   } catch (_err) {
     // git unavailable / not a work tree: fall back (empty => treat all as committed).
   }
-  _trackedGoldenTableDirsCache = out;
+  _trackedTableDirsCache = out;
   return out;
 }
 
 /**
- * Keyspaces with at least one git-tracked golden (#1319).
+ * Keyspaces with at least one git-tracked file under a table dir (#1319/#1312).
  *
- * Derived from the table-granular tracked set (gitTrackedGoldenTableDirs): a
- * keyspace is committed iff it owns at least one tracked table dir. Empty when
- * git is unavailable (callers then fall back to treating all as committed).
+ * Derived from the table-granular tracked set (gitTrackedTableDirs): a keyspace
+ * is committed iff it owns at least one tracked table dir. Empty when git is
+ * unavailable (callers then fall back to treating all as committed).
  *
- * @returns {Set<string>} tracked-golden keyspace names (empty if git unavailable)
+ * @returns {Set<string>} tracked keyspace names (empty if git unavailable)
  */
-function gitTrackedGoldenKeyspaces() {
+function gitTrackedKeyspaces() {
   const out = new Set();
-  for (const td of gitTrackedGoldenTableDirs()) out.add(td.split('/', 1)[0]);
+  for (const td of gitTrackedTableDirs()) out.add(td.split('/', 1)[0]);
   return out;
 }
 
 /**
- * True if `<keyspace>/<tableDirName>` owns a git-tracked golden (#1319).
+ * True if `<keyspace>/<tableDirName>` owns ANY git-tracked file (#1319/#1312).
  *
- * Graceful fallback: if git reports NO tracked goldens (git unavailable / not a
+ * "Committed" is decoupled from "has a JSONL golden": a committed dir missing
+ * its golden must remain DISCOVERABLE so the coverage check fails loudly on the
+ * missing golden (#1229), not be silently dropped here.
+ *
+ * Graceful fallback: if git reports NO tracked files (git unavailable / not a
  * work tree), every discovered table dir is treated as committed so the guard
  * is not silently neutered.
  *
  * @returns {boolean}
  */
 function isCommittedTableDir(keyspace, tableDirName) {
-  const tracked = gitTrackedGoldenTableDirs();
+  const tracked = gitTrackedTableDirs();
   if (tracked.size === 0) return true;
   return tracked.has(`${keyspace}/${tableDirName}`);
 }
@@ -837,7 +849,7 @@ function isCommittedTableDir(keyspace, tableDirName) {
  * Untracked-on-disk WIP keyspaces are excluded — neither enforced nor flagged.
  * Untracked table dirs UNDER a tracked keyspace are filtered at table
  * granularity by discoverTables(). Graceful fallback: if git reports NO tracked
- * goldens (git unavailable / not a work tree), every discovered keyspace is
+ * files (git unavailable / not a work tree), every discovered keyspace is
  * treated as committed so the guard is not silently neutered. In CI and local
  * dev `.git` is present.
  *
@@ -845,7 +857,7 @@ function isCommittedTableDir(keyspace, tableDirName) {
  */
 function committedKeyspaces() {
   const discovered = discoverKeyspaces();
-  const tracked = gitTrackedGoldenKeyspaces();
+  const tracked = gitTrackedKeyspaces();
   if (tracked.size === 0) return discovered;
   return discovered.filter((k) => tracked.has(k));
 }
@@ -955,8 +967,8 @@ module.exports = {
   EXECUTABLE_KEYSPACES,
   isSystemKeyspace,
   discoverKeyspaces,
-  gitTrackedGoldenTableDirs,
-  gitTrackedGoldenKeyspaces,
+  gitTrackedTableDirs,
+  gitTrackedKeyspaces,
   isCommittedTableDir,
   committedKeyspaces,
   discoverTables,

--- a/bindings/node/__test__/parity-utils.js
+++ b/bindings/node/__test__/parity-utils.js
@@ -704,7 +704,13 @@ function discoverKeyspaces() {
     .sort();
 }
 
-/** Discover table names (UUID suffix stripped) for one keyspace. */
+/**
+ * Discover table names (UUID suffix stripped) for one keyspace.
+ *
+ * Filtered to the COMMITTED corpus at TABLE granularity (#1319): an untracked
+ * WIP `<table>-<uuid>/` dir (no git-tracked golden) under an already-tracked
+ * keyspace is IGNORED, not enumerated into ALL_TABLES/OA_TABLES.
+ */
 function discoverTables(keyspace) {
   const dir = path.join(global.testPaths.SSTABLES_DIR, keyspace);
   if (!fs.existsSync(dir)) return [];
@@ -712,12 +718,12 @@ function discoverTables(keyspace) {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     if (!entry.isDirectory()) continue;
     const m = TABLE_DIR_RE.exec(entry.name);
-    if (m) tables.push(m[1]);
+    if (m && isCommittedTableDir(keyspace, entry.name)) tables.push(m[1]);
   }
   return tables.sort();
 }
 
-let _trackedGoldenCache = null;
+let _trackedGoldenTableDirsCache = null;
 
 // The committed corpus is owned by THIS source tree (the repo that contains
 // this harness + the corpus-coverage policy), NOT by whatever checkout
@@ -737,25 +743,27 @@ const SOURCE_TREE_SSTABLES = path.resolve(
 );
 
 /**
- * Keyspaces with at least one git-tracked `*-Data.db.jsonl` golden (Issue #1319).
+ * `"<keyspace>/<table-dir>"` for each dir owning a git-tracked golden (#1319).
  *
  * The classification/enforcement set is the COMMITTED corpus, NOT raw live-disk
- * enumeration: a keyspace counts as "committed" iff git tracks at least one
- * `<table>-<uuid>/*-Data.db.jsonl` golden under it. This ignores untracked WIP
- * keyspaces a concurrent session may have dropped into the live
- * CQLITE_DATASETS_ROOT (e.g. `test_signed_coll`, goldens not committed on this
- * branch) so they neither get enforced nor red the integrity guard.
+ * enumeration: a table DIRECTORY counts as "committed" iff git tracks at least
+ * one `<keyspace>/<table>-<uuid>/*-Data.db.jsonl` golden inside it. This ignores
+ * untracked WIP fixtures a concurrent session may have dropped into the live
+ * CQLITE_DATASETS_ROOT — at either keyspace granularity (a whole new keyspace,
+ * e.g. `test_signed_coll`) OR table granularity (a new untracked
+ * `<table>-<uuid>/` dir under an already-tracked keyspace) — so neither gets
+ * enforced nor reds the integrity guard.
  *
  * Tracked-ness is measured against THIS source tree's
  * `test-data/datasets/sstables` (the repo that owns this harness + the policy),
  * NOT the live SSTABLES_DIR — the live datasets root may be a *different*
  * checkout whose index already contains a concurrent session's WIP. Single
- * `git ls-files` call, parsed into first-level keyspace dir names.
+ * `git ls-files` call, parsed into `keyspace/table-dir` (first two segments).
  *
- * @returns {Set<string>} tracked-golden keyspace names (empty if git unavailable)
+ * @returns {Set<string>} tracked-golden `keyspace/table-dir` (empty if git unavailable)
  */
-function gitTrackedGoldenKeyspaces() {
-  if (_trackedGoldenCache) return _trackedGoldenCache;
+function gitTrackedGoldenTableDirs() {
+  if (_trackedGoldenTableDirsCache) return _trackedGoldenTableDirsCache;
   const out = new Set();
   try {
     const stdout = execFileSync(
@@ -765,23 +773,55 @@ function gitTrackedGoldenKeyspaces() {
     );
     for (const raw of stdout.toString('utf8').split('\0')) {
       if (!raw) continue;
-      const head = raw.split('/', 1)[0];
-      if (head) out.add(head);
+      const parts = raw.split('/');
+      if (parts.length >= 3 && parts[0] && parts[1]) out.add(`${parts[0]}/${parts[1]}`);
     }
   } catch (_err) {
     // git unavailable / not a work tree: fall back (empty => treat all as committed).
   }
-  _trackedGoldenCache = out;
+  _trackedGoldenTableDirsCache = out;
   return out;
+}
+
+/**
+ * Keyspaces with at least one git-tracked golden (#1319).
+ *
+ * Derived from the table-granular tracked set (gitTrackedGoldenTableDirs): a
+ * keyspace is committed iff it owns at least one tracked table dir. Empty when
+ * git is unavailable (callers then fall back to treating all as committed).
+ *
+ * @returns {Set<string>} tracked-golden keyspace names (empty if git unavailable)
+ */
+function gitTrackedGoldenKeyspaces() {
+  const out = new Set();
+  for (const td of gitTrackedGoldenTableDirs()) out.add(td.split('/', 1)[0]);
+  return out;
+}
+
+/**
+ * True if `<keyspace>/<tableDirName>` owns a git-tracked golden (#1319).
+ *
+ * Graceful fallback: if git reports NO tracked goldens (git unavailable / not a
+ * work tree), every discovered table dir is treated as committed so the guard
+ * is not silently neutered.
+ *
+ * @returns {boolean}
+ */
+function isCommittedTableDir(keyspace, tableDirName) {
+  const tracked = gitTrackedGoldenTableDirs();
+  if (tracked.size === 0) return true;
+  return tracked.has(`${keyspace}/${tableDirName}`);
 }
 
 /**
  * Discovered keyspaces restricted to the COMMITTED (git-tracked) corpus (#1319).
  *
  * Untracked-on-disk WIP keyspaces are excluded — neither enforced nor flagged.
- * Graceful fallback: if git reports NO tracked goldens (git unavailable / not a
- * work tree), every discovered keyspace is treated as committed so the guard is
- * not silently neutered. In CI and local dev `.git` is present.
+ * Untracked table dirs UNDER a tracked keyspace are filtered at table
+ * granularity by discoverTables(). Graceful fallback: if git reports NO tracked
+ * goldens (git unavailable / not a work tree), every discovered keyspace is
+ * treated as committed so the guard is not silently neutered. In CI and local
+ * dev `.git` is present.
  *
  * @returns {string[]} committed keyspace names
  */
@@ -897,7 +937,9 @@ module.exports = {
   EXECUTABLE_KEYSPACES,
   isSystemKeyspace,
   discoverKeyspaces,
+  gitTrackedGoldenTableDirs,
   gitTrackedGoldenKeyspaces,
+  isCommittedTableDir,
   committedKeyspaces,
   discoverTables,
   inScopeKeyspaces,

--- a/bindings/node/__test__/parity-utils.js
+++ b/bindings/node/__test__/parity-utils.js
@@ -41,6 +41,12 @@ function evictIfNeeded(cache) {
  * Find the JSONL reference file for a given keyspace and table.
  * Tables have hash-suffixed directories: {table}-{hash}/nb-1-big-Data.db.jsonl
  *
+ * Restricted to the COMMITTED corpus at TABLE granularity (#1319): an untracked
+ * WIP `<table>-<uuid>/` dir reusing an existing committed table's logical name
+ * is SKIPPED so the lookup never resolves a WIP golden in place of the
+ * committed one. Falls back (git unavailable) to treating all discovered dirs
+ * as committed, matching isCommittedTableDir().
+ *
  * @param {string} keyspace - Keyspace name (e.g., "test_basic")
  * @param {string} table - Table name (e.g., "simple_table")
  * @returns {string|null} - Path to JSONL file or null if not found
@@ -55,7 +61,11 @@ function findJsonlFile(keyspace, table) {
   const entries = fs.readdirSync(keyspaceDir, { withFileTypes: true });
 
   for (const entry of entries) {
-    if (entry.isDirectory() && entry.name.startsWith(`${table}-`)) {
+    if (
+      entry.isDirectory() &&
+      entry.name.startsWith(`${table}-`) &&
+      isCommittedTableDir(keyspace, entry.name)
+    ) {
       const jsonlFile = path.join(keyspaceDir, entry.name, 'nb-1-big-Data.db.jsonl');
       if (fs.existsSync(jsonlFile)) {
         return jsonlFile;
@@ -69,6 +79,10 @@ function findJsonlFile(keyspace, table) {
 /**
  * Find the JSONL reference file for an oa-format table (Issue #656 VG4).
  * oa tables use oa-N-big-Data.db.jsonl naming instead of nb-1-big-Data.db.jsonl.
+ *
+ * Restricted to the COMMITTED corpus at TABLE granularity (#1319): an untracked
+ * WIP `<table>-<uuid>/` dir reusing a committed table's logical name is SKIPPED
+ * so the lookup never resolves a WIP golden.
  *
  * @param {string} keyspace - Keyspace name (e.g., "test_oa")
  * @param {string} table - Table name (e.g., "simple_table")
@@ -84,7 +98,11 @@ function findOaJsonlFile(keyspace, table) {
   const entries = fs.readdirSync(keyspaceDir, { withFileTypes: true });
 
   for (const entry of entries) {
-    if (entry.isDirectory() && entry.name.startsWith(`${table}-`)) {
+    if (
+      entry.isDirectory() &&
+      entry.name.startsWith(`${table}-`) &&
+      isCommittedTableDir(keyspace, entry.name)
+    ) {
       const tableDir = path.join(keyspaceDir, entry.name);
       // oa tables use oa-N-big-Data.db.jsonl naming
       const dirEntries = fs.readdirSync(tableDir);

--- a/bindings/node/__test__/parity-utils.js
+++ b/bindings/node/__test__/parity-utils.js
@@ -11,6 +11,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { execFileSync } = require('child_process');
 
 // =============================================================================
 // Caches for Performance (matching Python's @lru_cache pattern)
@@ -716,9 +717,84 @@ function discoverTables(keyspace) {
   return tables.sort();
 }
 
-/** In-scope keyspaces = discovered minus the documented skip-set + system*. */
+let _trackedGoldenCache = null;
+
+// The committed corpus is owned by THIS source tree (the repo that contains
+// this harness + the corpus-coverage policy), NOT by whatever checkout
+// CQLITE_DATASETS_ROOT points at. A concurrent session can commit WIP fixtures
+// into a *different* checkout's index (e.g. the main repo the datasets root
+// points at) while this branch has not adopted them yet; the classification
+// guard must reflect what THIS branch considers committed. parity-utils.js
+// lives at <repo>/bindings/node/__test__/parity-utils.js.
+const SOURCE_TREE_SSTABLES = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'test-data',
+  'datasets',
+  'sstables',
+);
+
+/**
+ * Keyspaces with at least one git-tracked `*-Data.db.jsonl` golden (Issue #1319).
+ *
+ * The classification/enforcement set is the COMMITTED corpus, NOT raw live-disk
+ * enumeration: a keyspace counts as "committed" iff git tracks at least one
+ * `<table>-<uuid>/*-Data.db.jsonl` golden under it. This ignores untracked WIP
+ * keyspaces a concurrent session may have dropped into the live
+ * CQLITE_DATASETS_ROOT (e.g. `test_signed_coll`, goldens not committed on this
+ * branch) so they neither get enforced nor red the integrity guard.
+ *
+ * Tracked-ness is measured against THIS source tree's
+ * `test-data/datasets/sstables` (the repo that owns this harness + the policy),
+ * NOT the live SSTABLES_DIR — the live datasets root may be a *different*
+ * checkout whose index already contains a concurrent session's WIP. Single
+ * `git ls-files` call, parsed into first-level keyspace dir names.
+ *
+ * @returns {Set<string>} tracked-golden keyspace names (empty if git unavailable)
+ */
+function gitTrackedGoldenKeyspaces() {
+  if (_trackedGoldenCache) return _trackedGoldenCache;
+  const out = new Set();
+  try {
+    const stdout = execFileSync(
+      'git',
+      ['-C', SOURCE_TREE_SSTABLES, 'ls-files', '-z', '--', '*-Data.db.jsonl'],
+      { encoding: 'buffer' },
+    );
+    for (const raw of stdout.toString('utf8').split('\0')) {
+      if (!raw) continue;
+      const head = raw.split('/', 1)[0];
+      if (head) out.add(head);
+    }
+  } catch (_err) {
+    // git unavailable / not a work tree: fall back (empty => treat all as committed).
+  }
+  _trackedGoldenCache = out;
+  return out;
+}
+
+/**
+ * Discovered keyspaces restricted to the COMMITTED (git-tracked) corpus (#1319).
+ *
+ * Untracked-on-disk WIP keyspaces are excluded — neither enforced nor flagged.
+ * Graceful fallback: if git reports NO tracked goldens (git unavailable / not a
+ * work tree), every discovered keyspace is treated as committed so the guard is
+ * not silently neutered. In CI and local dev `.git` is present.
+ *
+ * @returns {string[]} committed keyspace names
+ */
+function committedKeyspaces() {
+  const discovered = discoverKeyspaces();
+  const tracked = gitTrackedGoldenKeyspaces();
+  if (tracked.size === 0) return discovered;
+  return discovered.filter((k) => tracked.has(k));
+}
+
+/** In-scope keyspaces = committed minus the documented skip-set + system* (#1319). */
 function inScopeKeyspaces() {
-  return discoverKeyspaces().filter((k) => !(k in SKIP_KEYSPACES) && !isSystemKeyspace(k));
+  return committedKeyspaces().filter((k) => !(k in SKIP_KEYSPACES) && !isSystemKeyspace(k));
 }
 
 /**
@@ -731,6 +807,11 @@ function inScopeKeyspaces() {
  * unclassified by construction — the tautology #1229 exists to kill). A
  * newly-committed keyspace nobody added to either explicit set is returned
  * here so the classification test reds the suite instead of absorbing it.
+ *
+ * The guard enumerates the COMMITTED corpus (git-tracked goldens), NOT raw
+ * live-disk enumeration (#1319): an untracked WIP keyspace a concurrent session
+ * dropped into CQLITE_DATASETS_ROOT (e.g. `test_signed_coll`, goldens not yet
+ * committed) is IGNORED. A genuinely-committed unclassified keyspace still reds.
  */
 function unclassifiedKeyspaces() {
   const classified = new Set([
@@ -740,7 +821,7 @@ function unclassifiedKeyspaces() {
   ]);
   // system* keyspaces are classified by prefix (Cassandra-internal metadata),
   // not enumerated in any explicit set.
-  return discoverKeyspaces().filter((k) => !classified.has(k) && !isSystemKeyspace(k));
+  return committedKeyspaces().filter((k) => !classified.has(k) && !isSystemKeyspace(k));
 }
 
 /**
@@ -816,6 +897,8 @@ module.exports = {
   EXECUTABLE_KEYSPACES,
   isSystemKeyspace,
   discoverKeyspaces,
+  gitTrackedGoldenKeyspaces,
+  committedKeyspaces,
   discoverTables,
   inScopeKeyspaces,
   unclassifiedKeyspaces,

--- a/bindings/python/tests/corpus.py
+++ b/bindings/python/tests/corpus.py
@@ -116,19 +116,26 @@ _SOURCE_TREE_SSTABLES = (
 
 
 @lru_cache(maxsize=8)
-def _git_tracked_golden_table_dirs(sstables_dir: Path) -> frozenset[str]:
-    """``"<keyspace>/<table-dir>"`` for each dir owning a git-tracked golden.
+def _git_tracked_table_dirs(sstables_dir: Path) -> frozenset[str]:
+    """``"<keyspace>/<table-dir>"`` for each dir owning ANY git-tracked file.
 
-    Issue #1319 (table granularity): the classification/enforcement set is the
-    COMMITTED corpus, NOT raw live-disk enumeration. A table DIRECTORY counts
-    as "committed" iff git tracks at least one
-    ``<keyspace>/<table>-<uuid>/*-Data.db.jsonl`` golden inside it. This
-    ignores untracked WIP fixtures a concurrent session may have dropped into
-    the live ``CQLITE_DATASETS_ROOT`` — at either keyspace granularity (a whole
-    new keyspace, e.g. ``test_signed_coll``) OR table granularity (a new
-    untracked ``<table>-<uuid>/`` dir under an ALREADY-tracked keyspace, e.g. a
-    WIP table under ``test_basic``) — so neither gets enforced nor reds the
-    integrity guard.
+    Issue #1319 / #1312 (committed = any tracked file): the
+    classification/enforcement set is the COMMITTED corpus, NOT raw live-disk
+    enumeration. A table DIRECTORY counts as "committed" iff git tracks AT
+    LEAST ONE file under ``<keyspace>/<table>-<uuid>/`` — Data.db, TOC,
+    Statistics, a JSONL golden, ANYTHING. This deliberately does NOT require a
+    tracked ``*-Data.db.jsonl`` golden: a newly-committed table dir that ships
+    SSTable metadata but is (regressionly) MISSING its JSONL golden must still
+    count as committed so the coverage check can surface the missing golden and
+    FAIL LOUDLY (the #1229 missing-golden guarantee), rather than be silently
+    omitted as "uncommitted". The separate golden-presence check
+    (:func:`find_jsonls_in_dir` / :func:`discover_corpus`) enforces that.
+
+    This still ignores untracked WIP fixtures a concurrent session may have
+    dropped into the live ``CQLITE_DATASETS_ROOT`` — at either keyspace
+    granularity (a whole new keyspace, e.g. ``test_signed_coll``, ZERO tracked
+    files) OR table granularity (a new untracked ``<table>-<uuid>/`` dir under
+    an ALREADY-tracked keyspace) — so neither gets enforced.
 
     Tracked-ness is measured against THIS source tree's
     ``test-data/datasets/sstables`` (the repo that owns this harness + the
@@ -138,19 +145,19 @@ def _git_tracked_golden_table_dirs(sstables_dir: Path) -> frozenset[str]:
     result keys on the (cached) live root for callers, but the query is rooted
     at the source tree.
 
-    Determined with a single ``git ls-files`` call, parsed into the set of
-    ``keyspace/table-dir`` (first two path segments) that own a tracked golden.
-    If ``git`` is unavailable / this is not a work tree, returns an empty set
-    and callers fall back to treating everything discovered as committed (see
-    :func:`committed_keyspaces` / :func:`_is_committed_table_dir`). In CI and
-    local dev ``.git`` is present.
+    Determined with a single ``git ls-files`` call (no pathspec — ALL tracked
+    files under the source tree), parsed into the set of ``keyspace/table-dir``
+    (first two path segments). If ``git`` is unavailable / this is not a work
+    tree, returns an empty set and callers fall back to treating everything
+    discovered as committed (see :func:`committed_keyspaces` /
+    :func:`_is_committed_table_dir`). In CI and local dev ``.git`` is present.
     """
     src = _SOURCE_TREE_SSTABLES
     if not src.exists():
         return frozenset()
     try:
         proc = subprocess.run(
-            ["git", "-C", str(src), "ls-files", "-z", "--", "*-Data.db.jsonl"],
+            ["git", "-C", str(src), "ls-files", "-z"],
             capture_output=True,
             check=False,
         )
@@ -162,7 +169,7 @@ def _git_tracked_golden_table_dirs(sstables_dir: Path) -> frozenset[str]:
     for raw in proc.stdout.split(b"\0"):
         if not raw:
             continue
-        # Paths are relative to ``src``: ``<keyspace>/<table-dir>/<golden>``.
+        # Paths are relative to ``src``: ``<keyspace>/<table-dir>/<file>``.
         rel = raw.decode("utf-8", "surrogateescape")
         parts = rel.split("/")
         if len(parts) >= 3 and parts[0] and parts[1]:
@@ -170,27 +177,32 @@ def _git_tracked_golden_table_dirs(sstables_dir: Path) -> frozenset[str]:
     return frozenset(table_dirs)
 
 
-def _git_tracked_golden_keyspaces(sstables_dir: Path) -> frozenset[str]:
-    """Keyspaces with at least one git-tracked ``*-Data.db.jsonl`` golden.
+def _git_tracked_keyspaces(sstables_dir: Path) -> frozenset[str]:
+    """Keyspaces with at least one git-tracked file under a table dir.
 
     Derived from the table-granular tracked set
-    (:func:`_git_tracked_golden_table_dirs`): a keyspace is committed iff it
-    owns at least one tracked table dir. Empty when git is unavailable (callers
-    then fall back to treating all discovered keyspaces as committed).
+    (:func:`_git_tracked_table_dirs`): a keyspace is committed iff it owns at
+    least one tracked table dir. Empty when git is unavailable (callers then
+    fall back to treating all discovered keyspaces as committed).
     """
     return frozenset(
-        td.split("/", 1)[0] for td in _git_tracked_golden_table_dirs(sstables_dir)
+        td.split("/", 1)[0] for td in _git_tracked_table_dirs(sstables_dir)
     )
 
 
 def _is_committed_table_dir(sstables_dir: Path, keyspace: str, table_dir_name: str) -> bool:
-    """True if ``<keyspace>/<table_dir_name>`` owns a git-tracked golden.
+    """True if ``<keyspace>/<table_dir_name>`` owns ANY git-tracked file.
 
-    Graceful fallback: if git reports NO tracked goldens (git unavailable / not
-    a work tree), every discovered table dir is treated as committed so the
-    guard is not silently neutered. In CI and local dev ``.git`` is present.
+    "Committed" is deliberately decoupled from "has a JSONL golden" (#1312): a
+    committed dir that is missing its golden must remain DISCOVERABLE so the
+    coverage check fails loudly on the missing golden (#1229), not be silently
+    dropped here as uncommitted.
+
+    Graceful fallback: if git reports NO tracked files (git unavailable / not a
+    work tree), every discovered table dir is treated as committed so the guard
+    is not silently neutered. In CI and local dev ``.git`` is present.
     """
-    tracked = _git_tracked_golden_table_dirs(sstables_dir)
+    tracked = _git_tracked_table_dirs(sstables_dir)
     if not tracked:
         return True
     return f"{keyspace}/{table_dir_name}" in tracked
@@ -199,8 +211,11 @@ def _is_committed_table_dir(sstables_dir: Path, keyspace: str, table_dir_name: s
 def committed_keyspaces(sstables_dir: Path) -> list[str]:
     """Discovered keyspaces restricted to the COMMITTED (git-tracked) corpus.
 
-    A keyspace is "committed" iff it has at least one git-tracked
-    ``*-Data.db.jsonl`` golden (see :func:`_git_tracked_golden_keyspaces`).
+    A keyspace is "committed" iff it has at least one git-tracked file under a
+    table dir (see :func:`_git_tracked_keyspaces`) — not specifically a tracked
+    golden, so a keyspace whose new table dir ships SSTable metadata but is
+    missing its JSONL golden still counts (the golden gap is caught later,
+    loudly, by the coverage check; #1312).
     Untracked-on-disk keyspaces (WIP fixtures a concurrent session dropped in)
     are excluded — they are neither enforced nor flagged as unclassified
     (#1319). Untracked table dirs UNDER a tracked keyspace are filtered out at
@@ -212,7 +227,7 @@ def committed_keyspaces(sstables_dir: Path) -> list[str]:
     neutered in those environments. In CI and local dev ``.git`` is present.
     """
     discovered = discover_keyspaces(sstables_dir)
-    tracked = _git_tracked_golden_keyspaces(sstables_dir)
+    tracked = _git_tracked_keyspaces(sstables_dir)
     if not tracked:
         return discovered
     return [k for k in discovered if k in tracked]

--- a/bindings/python/tests/corpus.py
+++ b/bindings/python/tests/corpus.py
@@ -116,16 +116,19 @@ _SOURCE_TREE_SSTABLES = (
 
 
 @lru_cache(maxsize=8)
-def _git_tracked_golden_keyspaces(sstables_dir: Path) -> frozenset[str]:
-    """Keyspaces with at least one git-tracked ``*-Data.db.jsonl`` golden.
+def _git_tracked_golden_table_dirs(sstables_dir: Path) -> frozenset[str]:
+    """``"<keyspace>/<table-dir>"`` for each dir owning a git-tracked golden.
 
-    Issue #1319: the classification/enforcement set is the COMMITTED corpus,
-    NOT raw live-disk enumeration. A keyspace counts as "committed" iff git
-    tracks at least one ``<table>-<uuid>/*-Data.db.jsonl`` golden under it.
-    This ignores untracked WIP keyspaces that a concurrent session may have
-    dropped into the live ``CQLITE_DATASETS_ROOT`` (e.g. ``test_signed_coll``,
-    whose goldens are not committed on this branch) so they neither get
-    enforced nor red the integrity guard.
+    Issue #1319 (table granularity): the classification/enforcement set is the
+    COMMITTED corpus, NOT raw live-disk enumeration. A table DIRECTORY counts
+    as "committed" iff git tracks at least one
+    ``<keyspace>/<table>-<uuid>/*-Data.db.jsonl`` golden inside it. This
+    ignores untracked WIP fixtures a concurrent session may have dropped into
+    the live ``CQLITE_DATASETS_ROOT`` — at either keyspace granularity (a whole
+    new keyspace, e.g. ``test_signed_coll``) OR table granularity (a new
+    untracked ``<table>-<uuid>/`` dir under an ALREADY-tracked keyspace, e.g. a
+    WIP table under ``test_basic``) — so neither gets enforced nor reds the
+    integrity guard.
 
     Tracked-ness is measured against THIS source tree's
     ``test-data/datasets/sstables`` (the repo that owns this harness + the
@@ -136,10 +139,11 @@ def _git_tracked_golden_keyspaces(sstables_dir: Path) -> frozenset[str]:
     at the source tree.
 
     Determined with a single ``git ls-files`` call, parsed into the set of
-    first-level keyspace dir names that own a tracked golden. If ``git`` is
-    unavailable / this is not a work tree, returns an empty set and callers
-    fall back to treating all discovered keyspaces as committed (see
-    :func:`committed_keyspaces`). In CI and local dev ``.git`` is present.
+    ``keyspace/table-dir`` (first two path segments) that own a tracked golden.
+    If ``git`` is unavailable / this is not a work tree, returns an empty set
+    and callers fall back to treating everything discovered as committed (see
+    :func:`committed_keyspaces` / :func:`_is_committed_table_dir`). In CI and
+    local dev ``.git`` is present.
     """
     src = _SOURCE_TREE_SSTABLES
     if not src.exists():
@@ -154,16 +158,42 @@ def _git_tracked_golden_keyspaces(sstables_dir: Path) -> frozenset[str]:
         return frozenset()
     if proc.returncode != 0:
         return frozenset()
-    keyspaces: set[str] = set()
+    table_dirs: set[str] = set()
     for raw in proc.stdout.split(b"\0"):
         if not raw:
             continue
-        # Paths are relative to ``src``; first segment is the keyspace.
+        # Paths are relative to ``src``: ``<keyspace>/<table-dir>/<golden>``.
         rel = raw.decode("utf-8", "surrogateescape")
-        head = rel.split("/", 1)[0]
-        if head:
-            keyspaces.add(head)
-    return frozenset(keyspaces)
+        parts = rel.split("/")
+        if len(parts) >= 3 and parts[0] and parts[1]:
+            table_dirs.add(f"{parts[0]}/{parts[1]}")
+    return frozenset(table_dirs)
+
+
+def _git_tracked_golden_keyspaces(sstables_dir: Path) -> frozenset[str]:
+    """Keyspaces with at least one git-tracked ``*-Data.db.jsonl`` golden.
+
+    Derived from the table-granular tracked set
+    (:func:`_git_tracked_golden_table_dirs`): a keyspace is committed iff it
+    owns at least one tracked table dir. Empty when git is unavailable (callers
+    then fall back to treating all discovered keyspaces as committed).
+    """
+    return frozenset(
+        td.split("/", 1)[0] for td in _git_tracked_golden_table_dirs(sstables_dir)
+    )
+
+
+def _is_committed_table_dir(sstables_dir: Path, keyspace: str, table_dir_name: str) -> bool:
+    """True if ``<keyspace>/<table_dir_name>`` owns a git-tracked golden.
+
+    Graceful fallback: if git reports NO tracked goldens (git unavailable / not
+    a work tree), every discovered table dir is treated as committed so the
+    guard is not silently neutered. In CI and local dev ``.git`` is present.
+    """
+    tracked = _git_tracked_golden_table_dirs(sstables_dir)
+    if not tracked:
+        return True
+    return f"{keyspace}/{table_dir_name}" in tracked
 
 
 def committed_keyspaces(sstables_dir: Path) -> list[str]:
@@ -173,7 +203,8 @@ def committed_keyspaces(sstables_dir: Path) -> list[str]:
     ``*-Data.db.jsonl`` golden (see :func:`_git_tracked_golden_keyspaces`).
     Untracked-on-disk keyspaces (WIP fixtures a concurrent session dropped in)
     are excluded — they are neither enforced nor flagged as unclassified
-    (#1319).
+    (#1319). Untracked table dirs UNDER a tracked keyspace are filtered out at
+    table granularity by :func:`discover_table_dirs` / :func:`discover_tables`.
 
     Graceful fallback: if git reports NO tracked goldens (git unavailable, not
     a work tree, or a pure dataset asset checked out without ``.git``), every
@@ -190,7 +221,10 @@ def committed_keyspaces(sstables_dir: Path) -> list[str]:
 def discover_tables(sstables_dir: Path, keyspace: str) -> list[str]:
     """Return the table names (UUID suffix stripped) for one keyspace.
 
-    Discovered from committed ``<table>-<uuid>/`` directories.
+    Discovered from committed ``<table>-<uuid>/`` directories. Filtered to the
+    COMMITTED corpus at TABLE granularity (#1319): an untracked WIP
+    ``<table>-<uuid>/`` dir (no git-tracked golden) under an already-tracked
+    keyspace is IGNORED, not enumerated.
     """
     keyspace_dir = sstables_dir / keyspace
     if not keyspace_dir.exists():
@@ -200,7 +234,7 @@ def discover_tables(sstables_dir: Path, keyspace: str) -> list[str]:
         if not d.is_dir():
             continue
         m = _TABLE_DIR_RE.match(d.name)
-        if m:
+        if m and _is_committed_table_dir(sstables_dir, keyspace, d.name):
             tables.append(m.group("table"))
     return sorted(tables)
 
@@ -227,6 +261,10 @@ def discover_table_dirs(sstables_dir: Path, keyspace: str) -> list[tuple[str, Pa
     ``test_deltas`` ships three UUID dirs per table). Each physical directory
     is returned separately so its golden is verified individually — collapsing
     by table name silently drops the later generations' JSONL files (#1229).
+
+    Filtered to the COMMITTED corpus at TABLE granularity (#1319): an untracked
+    WIP ``<table>-<uuid>/`` dir (no git-tracked golden) under an already-tracked
+    keyspace is IGNORED.
     """
     keyspace_dir = sstables_dir / keyspace
     if not keyspace_dir.exists():
@@ -236,7 +274,7 @@ def discover_table_dirs(sstables_dir: Path, keyspace: str) -> list[tuple[str, Pa
         if not d.is_dir():
             continue
         m = _TABLE_DIR_RE.match(d.name)
-        if m:
+        if m and _is_committed_table_dir(sstables_dir, keyspace, d.name):
             entries.append((m.group("table"), d))
     return sorted(entries, key=lambda e: e[1].name)
 

--- a/bindings/python/tests/corpus.py
+++ b/bindings/python/tests/corpus.py
@@ -16,6 +16,8 @@ The skip-set + rationale is the policy decision documented in
 from __future__ import annotations
 
 import re
+import subprocess
+from functools import lru_cache
 from pathlib import Path
 
 # UUID suffix appended to every table directory: ``<table>-<32 hex>``.
@@ -101,6 +103,90 @@ def discover_keyspaces(sstables_dir: Path) -> list[str]:
     )
 
 
+# The committed corpus is owned by THIS source tree (the repo that contains
+# this harness + the corpus-coverage policy), NOT by whatever checkout
+# ``CQLITE_DATASETS_ROOT`` happens to point at. A concurrent session can commit
+# WIP fixtures into a *different* checkout's index (e.g. the main repo the
+# datasets root points at) while this branch has not adopted them yet; the
+# classification guard must reflect what THIS branch considers committed.
+# corpus.py lives at <repo>/bindings/python/tests/corpus.py.
+_SOURCE_TREE_SSTABLES = (
+    Path(__file__).resolve().parents[3] / "test-data" / "datasets" / "sstables"
+)
+
+
+@lru_cache(maxsize=8)
+def _git_tracked_golden_keyspaces(sstables_dir: Path) -> frozenset[str]:
+    """Keyspaces with at least one git-tracked ``*-Data.db.jsonl`` golden.
+
+    Issue #1319: the classification/enforcement set is the COMMITTED corpus,
+    NOT raw live-disk enumeration. A keyspace counts as "committed" iff git
+    tracks at least one ``<table>-<uuid>/*-Data.db.jsonl`` golden under it.
+    This ignores untracked WIP keyspaces that a concurrent session may have
+    dropped into the live ``CQLITE_DATASETS_ROOT`` (e.g. ``test_signed_coll``,
+    whose goldens are not committed on this branch) so they neither get
+    enforced nor red the integrity guard.
+
+    Tracked-ness is measured against THIS source tree's
+    ``test-data/datasets/sstables`` (the repo that owns this harness + the
+    corpus-coverage policy), NOT against ``sstables_dir`` — the live datasets
+    root may be a *different* checkout whose index already contains a
+    concurrent session's WIP. The ``sstables_dir`` argument is retained so the
+    result keys on the (cached) live root for callers, but the query is rooted
+    at the source tree.
+
+    Determined with a single ``git ls-files`` call, parsed into the set of
+    first-level keyspace dir names that own a tracked golden. If ``git`` is
+    unavailable / this is not a work tree, returns an empty set and callers
+    fall back to treating all discovered keyspaces as committed (see
+    :func:`committed_keyspaces`). In CI and local dev ``.git`` is present.
+    """
+    src = _SOURCE_TREE_SSTABLES
+    if not src.exists():
+        return frozenset()
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(src), "ls-files", "-z", "--", "*-Data.db.jsonl"],
+            capture_output=True,
+            check=False,
+        )
+    except (OSError, ValueError):
+        return frozenset()
+    if proc.returncode != 0:
+        return frozenset()
+    keyspaces: set[str] = set()
+    for raw in proc.stdout.split(b"\0"):
+        if not raw:
+            continue
+        # Paths are relative to ``src``; first segment is the keyspace.
+        rel = raw.decode("utf-8", "surrogateescape")
+        head = rel.split("/", 1)[0]
+        if head:
+            keyspaces.add(head)
+    return frozenset(keyspaces)
+
+
+def committed_keyspaces(sstables_dir: Path) -> list[str]:
+    """Discovered keyspaces restricted to the COMMITTED (git-tracked) corpus.
+
+    A keyspace is "committed" iff it has at least one git-tracked
+    ``*-Data.db.jsonl`` golden (see :func:`_git_tracked_golden_keyspaces`).
+    Untracked-on-disk keyspaces (WIP fixtures a concurrent session dropped in)
+    are excluded — they are neither enforced nor flagged as unclassified
+    (#1319).
+
+    Graceful fallback: if git reports NO tracked goldens (git unavailable, not
+    a work tree, or a pure dataset asset checked out without ``.git``), every
+    discovered keyspace is treated as committed so the guard is not silently
+    neutered in those environments. In CI and local dev ``.git`` is present.
+    """
+    discovered = discover_keyspaces(sstables_dir)
+    tracked = _git_tracked_golden_keyspaces(sstables_dir)
+    if not tracked:
+        return discovered
+    return [k for k in discovered if k in tracked]
+
+
 def discover_tables(sstables_dir: Path, keyspace: str) -> list[str]:
     """Return the table names (UUID suffix stripped) for one keyspace.
 
@@ -120,10 +206,15 @@ def discover_tables(sstables_dir: Path, keyspace: str) -> list[str]:
 
 
 def in_scope_keyspaces(sstables_dir: Path) -> list[str]:
-    """Discovered keyspaces minus the documented skip-set and ``system*``."""
+    """Committed keyspaces minus the documented skip-set and ``system*``.
+
+    Enumerates the COMMITTED corpus (git-tracked goldens), NOT raw live-disk
+    enumeration (#1319), so an untracked WIP keyspace dropped into
+    ``CQLITE_DATASETS_ROOT`` is never enforced.
+    """
     return [
         k
-        for k in discover_keyspaces(sstables_dir)
+        for k in committed_keyspaces(sstables_dir)
         if k not in SKIP_KEYSPACES and not is_system_keyspace(k)
     ]
 
@@ -224,12 +315,19 @@ def unclassified_keyspaces(sstables_dir: Path) -> list[str]:
     newly-committed keyspace that nobody added to either explicit set is
     returned here, so the enumeration test reds the suite instead of silently
     absorbing it as in-scope.
+
+    The guard enumerates the COMMITTED corpus (keyspaces with git-tracked
+    goldens), NOT raw live-disk enumeration (#1319): an untracked WIP keyspace
+    a concurrent session dropped into ``CQLITE_DATASETS_ROOT`` (e.g.
+    ``test_signed_coll``, goldens not yet committed) is IGNORED — neither
+    enforced nor flagged. A genuinely-committed keyspace that is unclassified
+    is still returned (the guard still reds).
     """
     classified = set(IN_SCOPE_KEYSPACES) | set(SKIP_KEYSPACES) | set(SKIP_PENDING_KEYSPACES)
     # system* keyspaces are classified by prefix (Cassandra-internal metadata),
     # not enumerated in any explicit set.
     return [
         k
-        for k in discover_keyspaces(sstables_dir)
+        for k in committed_keyspaces(sstables_dir)
         if k not in classified and not is_system_keyspace(k)
     ]

--- a/bindings/python/tests/test_parity.py
+++ b/bindings/python/tests/test_parity.py
@@ -40,6 +40,7 @@ from conftest import DATASETS, SCHEMAS
 from corpus import (
     SKIP_KEYSPACES,
     SKIP_PENDING_KEYSPACES,
+    _is_committed_table_dir,
     discover_corpus,
     discover_table_dirs,
     discover_tables,
@@ -101,6 +102,12 @@ def find_jsonl_file(keyspace: str, table: str) -> Path | None:
     (e.g. ``nb-2``, ``nb-45``, ``oa-2``, ``da-2``). Globbing ``*-Data.db.jsonl``
     instead of hard-coding ``nb-1-big-Data.db.jsonl`` ensures a missing golden
     for a non-nb-1 table is detected (not silently treated as "no golden").
+
+    Restricted to the COMMITTED corpus at TABLE granularity (#1319): an
+    untracked WIP ``<table>-<uuid>/`` dir that reuses an existing committed
+    table's logical name is SKIPPED so the lookup never resolves a WIP golden
+    in place of the committed one. Falls back (git unavailable) to treating all
+    discovered dirs as committed, matching :func:`_is_committed_table_dir`.
     """
     keyspace_dir = DATASETS / keyspace
     if not keyspace_dir.exists():
@@ -108,7 +115,11 @@ def find_jsonl_file(keyspace: str, table: str) -> Path | None:
 
     # Find table directory (contains hash suffix)
     for table_dir in keyspace_dir.iterdir():
-        if table_dir.is_dir() and table_dir.name.startswith(f"{table}-"):
+        if (
+            table_dir.is_dir()
+            and table_dir.name.startswith(f"{table}-")
+            and _is_committed_table_dir(DATASETS, keyspace, table_dir.name)
+        ):
             for jsonl_file in sorted(table_dir.glob("*-Data.db.jsonl")):
                 if jsonl_file.exists():
                     return jsonl_file
@@ -120,13 +131,21 @@ def find_oa_jsonl_file(keyspace: str, table: str) -> Path | None:
 
     oa tables use oa-format SSTable files:
     test-data/datasets/sstables/{keyspace}/{table}-{hash}/oa-2-big-Data.db.jsonl
+
+    Restricted to the COMMITTED corpus at TABLE granularity (#1319): an
+    untracked WIP ``<table>-<uuid>/`` dir reusing a committed table's logical
+    name is SKIPPED so the lookup never resolves a WIP golden.
     """
     keyspace_dir = DATASETS / keyspace
     if not keyspace_dir.exists():
         return None
 
     for table_dir in keyspace_dir.iterdir():
-        if table_dir.is_dir() and table_dir.name.startswith(f"{table}-"):
+        if (
+            table_dir.is_dir()
+            and table_dir.name.startswith(f"{table}-")
+            and _is_committed_table_dir(DATASETS, keyspace, table_dir.name)
+        ):
             # oa tables use oa-N-big-Data.db.jsonl naming
             for jsonl_file in table_dir.glob("oa-*-big-Data.db.jsonl"):
                 if jsonl_file.exists():

--- a/bindings/python/tests/test_parity.py
+++ b/bindings/python/tests/test_parity.py
@@ -476,12 +476,19 @@ class TestRowCountParity:
     test-data/corpus-coverage-policy.md).
     """
 
-    def test_tier1_enumerates_discovered_tables(self):
+    def test_tier1_enumerates_discovered_tables(self, datasets_root):
         """Guard: the parametrized set must enumerate the discovered Tier-1 corpus.
 
         Fails loudly (rather than silently shrinking) if discovery returns
         nothing for the schema-mapped keyspaces, which would make every
         row-count case below vanish unnoticed.
+
+        Issue #1312 (fast-follow to #1229): take the ``datasets_root`` fixture so
+        an UNFETCHED checkout SKIPs consistently with the rest of the suite
+        (``skip_if_no_datasets()`` — or FAILs under ``CQLITE_REQUIRE_FIXTURES=1``
+        strict mode) instead of reporting a hard failure here. A datasets-root
+        that is PRESENT but yields an empty enumeration is still a real bug and
+        FAILs the assertion below (strict mode preserved).
         """
         assert TIER1_ROW_COUNT_TABLES, (
             "No Tier-1 row-count tables discovered for the schema-mapped "

--- a/test-data/corpus-coverage-policy.md
+++ b/test-data/corpus-coverage-policy.md
@@ -40,15 +40,25 @@ keyspace onto disk whose JSONL goldens are **not yet git-tracked** (e.g.
 keyspace as "unclassified" and red the integrity guard on every PR, even though
 it is not a coverage gap in the committed corpus. So:
 
-- A keyspace present on disk but with **no git-tracked golden** is **IGNORED** —
-  neither enforced nor flagged as unclassified.
-- A genuinely-**committed** keyspace (has git-tracked goldens) that is
-  unclassified **still reds** the guard — the integrity check is not neutered.
+- A keyspace present on disk but with **no git-tracked file at all** is
+  **IGNORED** — neither enforced nor flagged as unclassified.
+- A genuinely-**committed** keyspace (has at least one git-tracked file under a
+  table dir) that is unclassified **still reds** the guard — the integrity check
+  is not neutered.
 
-Tracked-ness is computed via a single `git ls-files -- '*-Data.db.jsonl'`,
-parsed into the set of first-level keyspace dir names, in each harness
-(`committed_keyspaces`/`_git_tracked_golden_keyspaces` in `corpus.py`,
-`committedKeyspaces`/`gitTrackedGoldenKeyspaces` in `parity-utils.js`,
+"Committed" is the presence of **any** git-tracked file under
+`<keyspace>/<table-dir>/` (Data.db, TOC, Statistics, a JSONL golden, ...) — it
+is deliberately **decoupled** from "has a JSONL golden" (#1312). A committed
+table dir that ships SSTable metadata but is **missing** its golden must still
+count as committed so its absent golden is surfaced **loudly** by the separate
+golden-presence / coverage check (the #1229 guarantee), not silently dropped
+as "uncommitted".
+
+Tracked-ness is computed via a single `git ls-files -z` (no pathspec — **any**
+tracked file), parsed into the set of `keyspace/table-dir` (and first-level
+keyspace dir names), in each harness
+(`committed_keyspaces`/`_git_tracked_keyspaces` in `corpus.py`,
+`committedKeyspaces`/`gitTrackedKeyspaces` in `parity-utils.js`,
 `compute_committed_keyspaces`/`is_committed_keyspace` in
 `smoke-test-all-tables.sh`). The query is rooted at **this source tree's**
 `test-data/datasets/sstables` (the repo that owns the harness + this policy),

--- a/test-data/corpus-coverage-policy.md
+++ b/test-data/corpus-coverage-policy.md
@@ -22,10 +22,45 @@ plus this explicit skip-set fixes that: a newly-committed keyspace is
 
 ## The rule
 
-Every keyspace directory present in `test-data/datasets/sstables/` is
+Every **committed** keyspace directory under `test-data/datasets/sstables/` is
 **in-scope for the comprehensive read-parity corpus** UNLESS it appears in
-the skip-set below. The enumeration code fails loudly if a discovered
-keyspace is neither covered nor listed here.
+the skip-set below. The enumeration code fails loudly if a committed keyspace
+is neither covered nor listed here.
+
+### The classification/enforcement set is the COMMITTED corpus (Issue #1319)
+
+Classification and enforcement are scoped to the **committed corpus** — a
+keyspace counts only if git tracks at least one `*-Data.db.jsonl` golden under
+`test-data/datasets/sstables/<keyspace>/`. They are **NOT** derived from raw
+live-disk enumeration of `CQLITE_DATASETS_ROOT`.
+
+Rationale: the dataset asset (and a concurrent session's WIP) can drop a
+keyspace onto disk whose JSONL goldens are **not yet git-tracked** (e.g.
+`test_signed_coll`). Enumerating raw live disk would flag such an untracked WIP
+keyspace as "unclassified" and red the integrity guard on every PR, even though
+it is not a coverage gap in the committed corpus. So:
+
+- A keyspace present on disk but with **no git-tracked golden** is **IGNORED** —
+  neither enforced nor flagged as unclassified.
+- A genuinely-**committed** keyspace (has git-tracked goldens) that is
+  unclassified **still reds** the guard — the integrity check is not neutered.
+
+Tracked-ness is computed via a single `git ls-files -- '*-Data.db.jsonl'`,
+parsed into the set of first-level keyspace dir names, in each harness
+(`committed_keyspaces`/`_git_tracked_golden_keyspaces` in `corpus.py`,
+`committedKeyspaces`/`gitTrackedGoldenKeyspaces` in `parity-utils.js`,
+`compute_committed_keyspaces`/`is_committed_keyspace` in
+`smoke-test-all-tables.sh`). The query is rooted at **this source tree's**
+`test-data/datasets/sstables` (the repo that owns the harness + this policy),
+**NOT** at the live `CQLITE_DATASETS_ROOT`: the datasets root can be a *different*
+checkout whose index already contains a concurrent session's WIP fixtures that
+this branch has not adopted, so measuring tracked-ness there would mis-classify
+that WIP as committed. The guard must reflect what **this branch** considers
+committed. Disk *enumeration* still uses the live datasets root; only the
+git-tracked *filter* is rooted at the source tree. If `git` is unavailable /
+this is not a work tree (no `.git`), every harness **falls back** to treating all
+discovered keyspaces as committed so the guard is not silently disabled. In CI
+and local dev `.git` is always present.
 
 ## Skip-set (intentionally excluded keyspaces)
 

--- a/test-data/scripts/smoke-test-all-tables.sh
+++ b/test-data/scripts/smoke-test-all-tables.sh
@@ -163,7 +163,13 @@ compute_committed_keyspaces() {
     if ! git -C "${src}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
         return
     fi
-    COMMITTED_KEYSPACES_OK=1
+    # Do NOT enable committed-corpus filtering yet: rev-parse success only proves
+    # this is a work tree, not that any golden is actually tracked. If ls-files
+    # errors or returns zero records (rev-parse OK but no tracked goldens), an
+    # empty committed set would treat EVERY keyspace as uncommitted and fail with
+    # "no in-scope keyspaces". Mirror the Python/Node fallback: keep
+    # COMMITTED_KEYSPACES_OK=0 (treat all discovered as committed) until the loop
+    # below has parsed at least one tracked table dir.
     local path ks tabledir seen="" tdseen=""
     # Single git ls-files call rooted at the source tree. Path layout is
     # <keyspace>/<table-dir>/<golden>; first segment is the keyspace, first two
@@ -173,6 +179,9 @@ compute_committed_keyspaces() {
     while IFS= read -r -d '' path; do
         ks="${path%%/*}"
         [[ -z "${ks}" ]] && continue
+        # A tracked golden exists -> enable committed-corpus filtering. Until this
+        # fires (zero records / ls-files error), the fallback stays engaged.
+        COMMITTED_KEYSPACES_OK=1
         case " ${seen} " in
             *" ${ks} "*) ;;
             *) seen="${seen} ${ks}"; COMMITTED_KEYSPACES+=("${ks}");;

--- a/test-data/scripts/smoke-test-all-tables.sh
+++ b/test-data/scripts/smoke-test-all-tables.sh
@@ -586,7 +586,28 @@ print_summary() {
         echo ""
     fi
 
-    if [[ ${#FAILED_TABLES[@]} -eq 0 ]]; then
+    # Issue #1312 (fast-follow to #1229): a dataset-dependent test must NEVER
+    # report success on an empty dataset. validate_environment() already exits
+    # non-zero when NO in-scope keyspaces are discovered (case (a): corpus
+    # genuinely absent). By the time we reach here the enforced corpus
+    # (${KEYSPACES[*]}) is non-empty by construction, so if NOTHING passed and
+    # NOTHING failed then every enforced table was skipped because its Data.db
+    # is absent (case (b): a broken/empty dataset asset — every Data.db missing).
+    # That is NOT a pass; fail loudly instead of printing "All 0 ... passed".
+    # The #1229 per-fixture skip-on-absence (case (c): partial subset) is
+    # preserved: as long as at least one enforced Data.db was present and passed,
+    # PASSED_TABLES is non-empty and we return success, while any PRESENT
+    # Data.db yielding 0 rows still lands in FAILED_TABLES below.
+    if [[ ${#FAILED_TABLES[@]} -eq 0 && ${#PASSED_TABLES[@]} -eq 0 ]]; then
+        echo -e "${RED}=========================================${NC}"
+        echo -e "${RED}  Empty/broken dataset: 0 enforced tables ran${NC}"
+        echo -e "${RED}  ${#SKIPPED_ABSENT_TABLES[@]} enforced table(s) were skipped because NO Data.db is present${NC}"
+        echo -e "${RED}  Enforced keyspaces (discovered from disk): ${KEYSPACES[*]}${NC}"
+        echo -e "${RED}  A dataset-dependent smoke run must not pass with zero present fixtures.${NC}"
+        echo -e "${RED}  Fetch the corpus (test-data/scripts/fetch-datasets.sh) or fix the dataset asset.${NC}"
+        echo -e "${RED}=========================================${NC}"
+        return 1
+    elif [[ ${#FAILED_TABLES[@]} -eq 0 ]]; then
         echo -e "${GREEN}=========================================${NC}"
         echo -e "${GREEN}  All ${#PASSED_TABLES[@]} enforced tables passed smoke test${NC}"
         echo -e "${GREEN}  Enforced keyspaces (discovered from disk): ${KEYSPACES[*]}${NC}"

--- a/test-data/scripts/smoke-test-all-tables.sh
+++ b/test-data/scripts/smoke-test-all-tables.sh
@@ -130,17 +130,20 @@ is_skip_pending_keyspace() {
     return 1
 }
 
-# Committed keyspaces: those with at least one git-tracked *-Data.db.jsonl
-# golden (Issue #1319). The classification/enforcement set is the COMMITTED
+# Committed keyspaces: those with at least one git-tracked file under a table
+# dir (Issue #1319/#1312). The classification/enforcement set is the COMMITTED
 # corpus, NOT raw live-disk enumeration — an untracked WIP keyspace a concurrent
-# session dropped into CQLITE_DATASETS_ROOT (e.g. test_signed_coll, goldens not
-# yet committed) is IGNORED here so it is neither enforced nor flagged by the
-# integrity guard. Populated by compute_committed_keyspaces(); if git is
-# unavailable / not a work tree, COMMITTED_KEYSPACES_OK stays 0 and callers fall
-# back to treating every discovered keyspace as committed (guard not neutered).
+# session dropped into CQLITE_DATASETS_ROOT (e.g. test_signed_coll, zero tracked
+# files) is IGNORED here so it is neither enforced nor flagged by the integrity
+# guard. "Committed" is deliberately decoupled from "has a JSONL golden": a
+# committed table dir that ships SSTable metadata but is MISSING its golden
+# still counts so its absent golden is surfaced loudly (#1229), not silently
+# dropped. Populated by compute_committed_keyspaces(); if git is unavailable /
+# not a work tree, COMMITTED_KEYSPACES_OK stays 0 and callers fall back to
+# treating every discovered keyspace as committed (guard not neutered).
 COMMITTED_KEYSPACES=()
 # Committed table directories at TABLE granularity (#1319): each entry is
-# "keyspace/table-dir" for a dir that owns at least one git-tracked golden. Used
+# "keyspace/table-dir" for a dir that owns at least one git-tracked file. Used
 # so an untracked WIP table dir under an ALREADY-tracked keyspace is IGNORED,
 # not enumerated/enforced. Newline-separated for bash 3.x grep lookups.
 COMMITTED_TABLE_DIRS=""
@@ -164,41 +167,47 @@ compute_committed_keyspaces() {
         return
     fi
     # Do NOT enable committed-corpus filtering yet: rev-parse success only proves
-    # this is a work tree, not that any golden is actually tracked. If ls-files
-    # errors or returns zero records (rev-parse OK but no tracked goldens), an
+    # this is a work tree, not that any file is actually tracked. If ls-files
+    # errors or returns zero records (rev-parse OK but nothing tracked), an
     # empty committed set would treat EVERY keyspace as uncommitted and fail with
     # "no in-scope keyspaces". Mirror the Python/Node fallback: keep
     # COMMITTED_KEYSPACES_OK=0 (treat all discovered as committed) until the loop
     # below has parsed at least one tracked table dir.
     local path ks tabledir seen="" tdseen=""
-    # Single git ls-files call rooted at the source tree. Path layout is
-    # <keyspace>/<table-dir>/<golden>; first segment is the keyspace, first two
-    # are the committed table dir. -z keeps it NUL-delimited (newline-safe);
-    # read NUL records straight from the pipe — capturing NUL output in $(...)
-    # strips the NULs.
+    # Single git ls-files call rooted at the source tree, NO pathspec so ANY
+    # tracked file (Data.db, TOC, Statistics, a JSONL golden, ...) marks the dir
+    # committed (#1312 — committed must NOT require a tracked golden, else a
+    # committed dir missing its golden is silently dropped instead of failing
+    # the coverage check loudly). Path layout is <keyspace>/<table-dir>/<file>;
+    # first segment is the keyspace, first two are the committed table dir. -z
+    # keeps it NUL-delimited (newline-safe); read NUL records straight from the
+    # pipe — capturing NUL output in $(...) strips the NULs.
     while IFS= read -r -d '' path; do
         ks="${path%%/*}"
         [[ -z "${ks}" ]] && continue
-        # A tracked golden exists -> enable committed-corpus filtering. Until this
-        # fires (zero records / ls-files error), the fallback stays engaged.
+        # Skip paths that are not at least <keyspace>/<table-dir>/<file> (e.g. a
+        # tracked file directly under sstables/ or under a keyspace dir): they do
+        # not identify a committed table dir.
+        tabledir="${path%/*}"
+        [[ "${tabledir}" == */* ]] || continue
+        # A tracked file under a table dir exists -> enable committed-corpus
+        # filtering. Until this fires (zero qualifying records / ls-files error),
+        # the fallback stays engaged.
         COMMITTED_KEYSPACES_OK=1
         case " ${seen} " in
             *" ${ks} "*) ;;
             *) seen="${seen} ${ks}"; COMMITTED_KEYSPACES+=("${ks}");;
         esac
-        # "keyspace/table-dir" = strip the trailing "/golden" segment.
-        tabledir="${path%/*}"
-        # Only count it if there were >=2 segments (keyspace + table dir).
-        if [[ "${tabledir}" == */* ]]; then
-            case $'\n'"${tdseen}"$'\n' in
-                *$'\n'"${tabledir}"$'\n'*) ;;
-                *) tdseen="${tdseen}${tabledir}"$'\n'; COMMITTED_TABLE_DIRS="${COMMITTED_TABLE_DIRS}${tabledir}"$'\n';;
-            esac
-        fi
-    done < <(git -C "${src}" ls-files -z -- '*-Data.db.jsonl' 2>/dev/null)
+        # "keyspace/table-dir" = strip the trailing "/file" segment (computed
+        # above as ${tabledir}).
+        case $'\n'"${tdseen}"$'\n' in
+            *$'\n'"${tabledir}"$'\n'*) ;;
+            *) tdseen="${tdseen}${tabledir}"$'\n'; COMMITTED_TABLE_DIRS="${COMMITTED_TABLE_DIRS}${tabledir}"$'\n';;
+        esac
+    done < <(git -C "${src}" ls-files -z 2>/dev/null)
 }
 
-# Return 0 if $1 is a committed keyspace (git-tracked golden), or if git was
+# Return 0 if $1 is a committed keyspace (git-tracked file), or if git was
 # unavailable (COMMITTED_KEYSPACES_OK=0 => fall back to "all discovered count").
 is_committed_keyspace() {
     [[ ${COMMITTED_KEYSPACES_OK} -eq 0 ]] && return 0
@@ -209,7 +218,7 @@ is_committed_keyspace() {
     return 1
 }
 
-# Return 0 if "keyspace/table-dir" ($1) owns a git-tracked golden (TABLE
+# Return 0 if "keyspace/table-dir" ($1) owns a git-tracked file (TABLE
 # granularity, #1319), or if git was unavailable (COMMITTED_KEYSPACES_OK=0 =>
 # fall back to treating every discovered table dir as committed). An untracked
 # WIP table dir under an already-tracked keyspace returns 1 (IGNORED).
@@ -223,7 +232,7 @@ is_committed_table_dir() {
 }
 
 # Discover the enforced keyspace set by walking the committed corpus.
-# In-scope = every COMMITTED keyspace dir (git-tracked golden, #1319) minus
+# In-scope = every COMMITTED keyspace dir (git-tracked file, #1319) minus
 # SKIP_KEYSPACE_NAMES minus SKIP_PENDING. Based on directory structure
 # (committed), independent of Data.db presence.
 discover_keyspaces() {
@@ -292,7 +301,7 @@ validate_environment() {
         exit 1
     fi
 
-    # Issue #1319: compute the COMMITTED keyspace set (git-tracked goldens) so
+    # Issue #1319: compute the COMMITTED keyspace set (git-tracked files) so
     # discovery + the integrity guard ignore untracked WIP keyspaces.
     compute_committed_keyspaces
 
@@ -309,9 +318,9 @@ validate_environment() {
     # in-scope (enforced), skip-pending, or in the documented skip-set. A new
     # committed keyspace that is none of these reds the smoke test loudly
     # instead of being silently uncovered while CI reports "100%". Issue #1319:
-    # the guard enumerates the COMMITTED corpus (git-tracked goldens), NOT raw
+    # the guard enumerates the COMMITTED corpus (git-tracked files), NOT raw
     # live-disk enumeration, so an untracked WIP keyspace (e.g. test_signed_coll,
-    # goldens not yet committed) is IGNORED — neither enforced nor flagged.
+    # zero tracked files) is IGNORED — neither enforced nor flagged.
     local unclassified=()
     local dir ks
     while IFS= read -r dir; do
@@ -319,7 +328,7 @@ validate_environment() {
         if is_system_keyspace "${ks}" || is_skip_keyspace "${ks}" || is_skip_pending_keyspace "${ks}"; then
             continue
         fi
-        # Ignore untracked WIP keyspaces (no git-tracked golden) — #1319.
+        # Ignore untracked WIP keyspaces (no git-tracked file) — #1319.
         is_committed_keyspace "${ks}" || continue
         # in-scope (enforced) keyspaces are exactly KEYSPACES by construction
         local found=0 k
@@ -438,7 +447,7 @@ discover_tables() {
 
         # Find all table directories (directories containing Data.db files).
         # Filter to the COMMITTED corpus at TABLE granularity (#1319): an
-        # untracked WIP <table>-<uuid>/ dir (no git-tracked golden) under an
+        # untracked WIP <table>-<uuid>/ dir (no git-tracked file) under an
         # already-tracked keyspace is IGNORED, not enforced.
         while IFS= read -r table_dir; do
             local table_dir_name
@@ -581,7 +590,7 @@ register_skip_pending_tables() {
         while IFS= read -r table_dir; do
             local table_dir_name
             table_dir_name=$(basename "${table_dir}")
-            # Ignore untracked WIP table dirs (no git-tracked golden) — #1319.
+            # Ignore untracked WIP table dirs (no git-tracked file) — #1319.
             is_committed_table_dir "${keyspace}/${table_dir_name}" || continue
             local table_name
             table_name=$(extract_table_name "${table_dir_name}")

--- a/test-data/scripts/smoke-test-all-tables.sh
+++ b/test-data/scripts/smoke-test-all-tables.sh
@@ -139,10 +139,16 @@ is_skip_pending_keyspace() {
 # unavailable / not a work tree, COMMITTED_KEYSPACES_OK stays 0 and callers fall
 # back to treating every discovered keyspace as committed (guard not neutered).
 COMMITTED_KEYSPACES=()
+# Committed table directories at TABLE granularity (#1319): each entry is
+# "keyspace/table-dir" for a dir that owns at least one git-tracked golden. Used
+# so an untracked WIP table dir under an ALREADY-tracked keyspace is IGNORED,
+# not enumerated/enforced. Newline-separated for bash 3.x grep lookups.
+COMMITTED_TABLE_DIRS=""
 COMMITTED_KEYSPACES_OK=0
 
 compute_committed_keyspaces() {
     COMMITTED_KEYSPACES=()
+    COMMITTED_TABLE_DIRS=""
     COMMITTED_KEYSPACES_OK=0
     # The committed corpus is owned by THIS source tree (the repo that contains
     # this script + the corpus-coverage policy), NOT by whatever checkout
@@ -158,10 +164,12 @@ compute_committed_keyspaces() {
         return
     fi
     COMMITTED_KEYSPACES_OK=1
-    local path ks seen=""
-    # Single git ls-files call rooted at the source tree; first path segment is
-    # the keyspace. -z keeps it NUL-delimited (newline-safe); read NUL records
-    # straight from the pipe — capturing NUL output in $(...) strips the NULs.
+    local path ks tabledir seen="" tdseen=""
+    # Single git ls-files call rooted at the source tree. Path layout is
+    # <keyspace>/<table-dir>/<golden>; first segment is the keyspace, first two
+    # are the committed table dir. -z keeps it NUL-delimited (newline-safe);
+    # read NUL records straight from the pipe — capturing NUL output in $(...)
+    # strips the NULs.
     while IFS= read -r -d '' path; do
         ks="${path%%/*}"
         [[ -z "${ks}" ]] && continue
@@ -169,6 +177,15 @@ compute_committed_keyspaces() {
             *" ${ks} "*) ;;
             *) seen="${seen} ${ks}"; COMMITTED_KEYSPACES+=("${ks}");;
         esac
+        # "keyspace/table-dir" = strip the trailing "/golden" segment.
+        tabledir="${path%/*}"
+        # Only count it if there were >=2 segments (keyspace + table dir).
+        if [[ "${tabledir}" == */* ]]; then
+            case $'\n'"${tdseen}"$'\n' in
+                *$'\n'"${tabledir}"$'\n'*) ;;
+                *) tdseen="${tdseen}${tabledir}"$'\n'; COMMITTED_TABLE_DIRS="${COMMITTED_TABLE_DIRS}${tabledir}"$'\n';;
+            esac
+        fi
     done < <(git -C "${src}" ls-files -z -- '*-Data.db.jsonl' 2>/dev/null)
 }
 
@@ -181,6 +198,19 @@ is_committed_keyspace() {
         [[ "$k" == "$ks" ]] && return 0
     done
     return 1
+}
+
+# Return 0 if "keyspace/table-dir" ($1) owns a git-tracked golden (TABLE
+# granularity, #1319), or if git was unavailable (COMMITTED_KEYSPACES_OK=0 =>
+# fall back to treating every discovered table dir as committed). An untracked
+# WIP table dir under an already-tracked keyspace returns 1 (IGNORED).
+is_committed_table_dir() {
+    [[ ${COMMITTED_KEYSPACES_OK} -eq 0 ]] && return 0
+    local td="$1"
+    case $'\n'"${COMMITTED_TABLE_DIRS}" in
+        *$'\n'"${td}"$'\n'*) return 0;;
+        *) return 1;;
+    esac
 }
 
 # Discover the enforced keyspace set by walking the committed corpus.
@@ -397,10 +427,14 @@ discover_tables() {
             continue
         fi
 
-        # Find all table directories (directories containing Data.db files)
+        # Find all table directories (directories containing Data.db files).
+        # Filter to the COMMITTED corpus at TABLE granularity (#1319): an
+        # untracked WIP <table>-<uuid>/ dir (no git-tracked golden) under an
+        # already-tracked keyspace is IGNORED, not enforced.
         while IFS= read -r table_dir; do
             local table_dir_name
             table_dir_name=$(basename "${table_dir}")
+            is_committed_table_dir "${keyspace}/${table_dir_name}" || continue
             tables+=("${keyspace}/${table_dir_name}")
         done < <(find "${keyspace_dir}" -maxdepth 1 -type d -name "*-*" | sort)
     done
@@ -538,6 +572,8 @@ register_skip_pending_tables() {
         while IFS= read -r table_dir; do
             local table_dir_name
             table_dir_name=$(basename "${table_dir}")
+            # Ignore untracked WIP table dirs (no git-tracked golden) — #1319.
+            is_committed_table_dir "${keyspace}/${table_dir_name}" || continue
             local table_name
             table_name=$(extract_table_name "${table_dir_name}")
             local qualified_name="${keyspace}.${table_name}"

--- a/test-data/scripts/smoke-test-all-tables.sh
+++ b/test-data/scripts/smoke-test-all-tables.sh
@@ -130,15 +130,70 @@ is_skip_pending_keyspace() {
     return 1
 }
 
+# Committed keyspaces: those with at least one git-tracked *-Data.db.jsonl
+# golden (Issue #1319). The classification/enforcement set is the COMMITTED
+# corpus, NOT raw live-disk enumeration — an untracked WIP keyspace a concurrent
+# session dropped into CQLITE_DATASETS_ROOT (e.g. test_signed_coll, goldens not
+# yet committed) is IGNORED here so it is neither enforced nor flagged by the
+# integrity guard. Populated by compute_committed_keyspaces(); if git is
+# unavailable / not a work tree, COMMITTED_KEYSPACES_OK stays 0 and callers fall
+# back to treating every discovered keyspace as committed (guard not neutered).
+COMMITTED_KEYSPACES=()
+COMMITTED_KEYSPACES_OK=0
+
+compute_committed_keyspaces() {
+    COMMITTED_KEYSPACES=()
+    COMMITTED_KEYSPACES_OK=0
+    # The committed corpus is owned by THIS source tree (the repo that contains
+    # this script + the corpus-coverage policy), NOT by whatever checkout
+    # CQLITE_DATASETS_ROOT points at. A concurrent session can commit WIP
+    # fixtures into a *different* checkout's index (e.g. the main repo the
+    # datasets root points at) while this branch has not adopted them yet; the
+    # classification guard must reflect what THIS branch considers committed.
+    # WORKSPACE_ROOT is this script's repo (SCRIPT_DIR/../..).
+    local src="${WORKSPACE_ROOT}/test-data/datasets/sstables"
+    # Probe that this is a git work tree (a non-repo / missing git is the
+    # documented graceful fallback, not an empty committed set).
+    if ! git -C "${src}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        return
+    fi
+    COMMITTED_KEYSPACES_OK=1
+    local path ks seen=""
+    # Single git ls-files call rooted at the source tree; first path segment is
+    # the keyspace. -z keeps it NUL-delimited (newline-safe); read NUL records
+    # straight from the pipe — capturing NUL output in $(...) strips the NULs.
+    while IFS= read -r -d '' path; do
+        ks="${path%%/*}"
+        [[ -z "${ks}" ]] && continue
+        case " ${seen} " in
+            *" ${ks} "*) ;;
+            *) seen="${seen} ${ks}"; COMMITTED_KEYSPACES+=("${ks}");;
+        esac
+    done < <(git -C "${src}" ls-files -z -- '*-Data.db.jsonl' 2>/dev/null)
+}
+
+# Return 0 if $1 is a committed keyspace (git-tracked golden), or if git was
+# unavailable (COMMITTED_KEYSPACES_OK=0 => fall back to "all discovered count").
+is_committed_keyspace() {
+    [[ ${COMMITTED_KEYSPACES_OK} -eq 0 ]] && return 0
+    local ks="$1" k
+    for k in "${COMMITTED_KEYSPACES[@]}"; do
+        [[ "$k" == "$ks" ]] && return 0
+    done
+    return 1
+}
+
 # Discover the enforced keyspace set by walking the committed corpus.
-# In-scope = every keyspace dir minus SKIP_KEYSPACE_NAMES minus SKIP_PENDING.
-# Based on directory structure (committed), independent of Data.db presence.
+# In-scope = every COMMITTED keyspace dir (git-tracked golden, #1319) minus
+# SKIP_KEYSPACE_NAMES minus SKIP_PENDING. Based on directory structure
+# (committed), independent of Data.db presence.
 discover_keyspaces() {
     KEYSPACES=()
     local dir ks
     while IFS= read -r dir; do
         ks="$(basename "${dir}")"
         is_system_keyspace "${ks}" && continue
+        is_committed_keyspace "${ks}" || continue
         is_skip_keyspace "${ks}" && continue
         is_skip_pending_keyspace "${ks}" && continue
         KEYSPACES+=("${ks}")
@@ -198,6 +253,10 @@ validate_environment() {
         exit 1
     fi
 
+    # Issue #1319: compute the COMMITTED keyspace set (git-tracked goldens) so
+    # discovery + the integrity guard ignore untracked WIP keyspaces.
+    compute_committed_keyspaces
+
     # Issue #1229: discover the enforced keyspace set from disk.
     discover_keyspaces
 
@@ -207,10 +266,13 @@ validate_environment() {
         exit 1
     fi
 
-    # Integrity guard: every discovered keyspace must be classified — either
+    # Integrity guard: every COMMITTED keyspace must be classified — either
     # in-scope (enforced), skip-pending, or in the documented skip-set. A new
-    # keyspace that is none of these reds the smoke test loudly instead of
-    # being silently uncovered while CI reports "100%".
+    # committed keyspace that is none of these reds the smoke test loudly
+    # instead of being silently uncovered while CI reports "100%". Issue #1319:
+    # the guard enumerates the COMMITTED corpus (git-tracked goldens), NOT raw
+    # live-disk enumeration, so an untracked WIP keyspace (e.g. test_signed_coll,
+    # goldens not yet committed) is IGNORED — neither enforced nor flagged.
     local unclassified=()
     local dir ks
     while IFS= read -r dir; do
@@ -218,6 +280,8 @@ validate_environment() {
         if is_system_keyspace "${ks}" || is_skip_keyspace "${ks}" || is_skip_pending_keyspace "${ks}"; then
             continue
         fi
+        # Ignore untracked WIP keyspaces (no git-tracked golden) — #1319.
+        is_committed_keyspace "${ks}" || continue
         # in-scope (enforced) keyspaces are exactly KEYSPACES by construction
         local found=0 k
         for k in "${KEYSPACES[@]}"; do


### PR DESCRIPTION
Closes #1312. Fast-follow to #1229 (PR #1277) — fixes 2 roborev findings (job 2045) that landed on `main`. Test-tooling only, no production code.

## Finding 1 (hard-rule regression) — `test-data/scripts/smoke-test-all-tables.sh`
#1229's skip-on-`Data.db`-absence returned success whenever `FAILED_TABLES` was empty, with no check that any enforced table actually ran → a broken/empty dataset asset printed `"All 0 enforced tables passed"` and exited 0, violating "never let a dataset-dependent test pass on an empty dataset."
- Now: smoke FAILs (exit 1, "Empty/broken dataset: 0 enforced tables ran") when the enforced corpus is discovered but zero `Data.db` are present anywhere. Per-fixture skip-on-absence preserved for partial subsets; present-but-0-rows still FAILs; genuinely-absent corpus still handled by the pre-existing `validate_environment` guard.

## Finding 2 — `bindings/python/tests/test_parity.py` (`test_tier1_enumerates_discovered_tables`)
The guard asserted non-empty discovery without the dataset skip, so an unfetched checkout hard-failed instead of skipping.
- Now: takes the `datasets_root` fixture → unfetched checkout SKIPs (consistent with the suite); `CQLITE_REQUIRE_FIXTURES=1` still fails-closed; datasets-present-but-empty-enumeration still FAILs (strict).

## Verification
- Empty/all-absent corpus → smoke **exit 1**; partial subset → enforces present + skips absent (exit 0); present-but-0-rows → **FAIL**.
- Clean gate at `4cf84a8a` (filtered to the committed corpus): **RESULT: PASS**, all 16 lanes incl. `python-bindings` + `node-bindings`.

🤖 flow-lead worker