### PR TITLE
fix(#1284): engage BIG (nb) single-partition seek for WHERE pk=? (compressed + uncompressed)

### DIFF
--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -1166,6 +1166,16 @@ impl SSTableManager {
             return Ok((Vec::new(), false));
         };
 
+        // Did resolution match the FULLY-QUALIFIED `keyspace.table` key exactly, or
+        // fall back to the bare table name? An unqualified query is treated as an
+        // exact match (no keyspace to mismatch). This authoritative signal gates
+        // the seek's table-consistency guard: only an exact FQ match may relax to a
+        // name-only check across a header-keyspace divergence; a fully-qualified
+        // query resolved via the bare-name fallback keeps strict keyspace matching
+        // so it never returns another keyspace's same-named rows (#1284 review).
+        let fully_qualified_match =
+            !table_name.contains('.') || table_readers.contains_key(table_name);
+
         // Prune: keep only SSTables whose bloom filter / BTI trie admit the key.
         let candidates: Vec<Arc<reader::SSTableReader>> = reader_list
             .iter()
@@ -1247,7 +1257,13 @@ impl SSTableManager {
                 // index. `engaged` records whether the clustering narrowing
                 // actually bounded the decode (vs a full-partition decode).
                 match reader
-                    .scan_single_partition_clustering(table_id, partition_key, clustering, schema)
+                    .scan_single_partition_clustering(
+                        table_id,
+                        partition_key,
+                        clustering,
+                        fully_qualified_match,
+                        schema,
+                    )
                     .await
                 {
                     // Seek resolved authoritatively: use its rows directly. They

--- a/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
@@ -100,6 +100,12 @@ impl SSTableReader {
         table_id: &TableId,
         partition_key: &[u8],
         clustering: Option<&ClusteringSlice>,
+        // `true` iff the manager resolved this reader by an EXACT fully-qualified
+        // `keyspace.table` match (or the query is unqualified). `false` means a
+        // fully-qualified query reached this reader via the bare-name fallback, in
+        // which case the seek guard keeps STRICT keyspace matching so it can never
+        // return rows from a different keyspace whose table name collides (#1284).
+        fully_qualified_match: bool,
         schema: Option<&crate::schema::TableSchema>,
     ) -> Result<Option<(Vec<(RowKey, Value)>, bool)>> {
         // 1. Resolve the partition's uncompressed Data.db offset, and record
@@ -204,6 +210,7 @@ impl SSTableReader {
                 row_body_window,
                 &key,
                 table_id,
+                fully_qualified_match,
                 schema_opt.as_ref(),
                 &parser,
             )
@@ -794,6 +801,10 @@ impl SSTableReader {
         row_body_window: Option<(usize, usize)>,
         key: &RowKey,
         table_id: &TableId,
+        // See `bti_collect_partition_rows`: `true` iff the manager resolved this
+        // reader by an exact fully-qualified `keyspace.table` match (or the query
+        // was unqualified). Threaded into the seek table-consistency guard (#1284).
+        fully_qualified_match: bool,
         schema_opt: Option<&crate::schema::TableSchema>,
         parser: &crate::storage::sstable::reader::parsing::V5CompressedLegacyParser,
     ) -> Result<Option<Vec<Value>>> {
@@ -940,6 +951,7 @@ impl SSTableReader {
                     row_body_window,
                     key,
                     table_id,
+                    fully_qualified_match,
                     schema_opt,
                     parser,
                 )
@@ -961,6 +973,7 @@ impl SSTableReader {
             row_body_window,
             key,
             table_id,
+            fully_qualified_match,
             schema_opt,
             parser,
         )
@@ -1043,6 +1056,11 @@ impl SSTableReader {
         row_body_window: Option<(usize, usize)>,
         key: &RowKey,
         table_id: &TableId,
+        // Whether the manager resolved this reader by an EXACT fully-qualified
+        // `keyspace.table` match (or an unqualified query). When `false` a
+        // fully-qualified query reached this reader via the bare-name fallback, so
+        // the seek guard keeps STRICT keyspace matching (#1284 review).
+        fully_qualified_match: bool,
         schema_opt: Option<&crate::schema::TableSchema>,
         parser: &crate::storage::sstable::reader::parsing::V5CompressedLegacyParser,
     ) -> Result<(Vec<Value>, bool)> {
@@ -1063,8 +1081,11 @@ impl SSTableReader {
             |(tid, entry_key, entry_value)| {
                 if entry_key.as_bytes() == key.as_bytes() {
                     // Header-authoritative table consistency: wrong-table rejected
-                    // (#831), keyspace-divergent same-table query still served (#1284).
-                    if table_header_consistent_for_seek(&tid, table_id) {
+                    // (#831); a keyspace-divergent same-table query is served ONLY
+                    // when resolution was an exact fully-qualified match — a
+                    // fallback-resolved query keeps strict keyspace matching so it
+                    // never returns another keyspace's same-named rows (#1284).
+                    if table_header_consistent_for_seek(&tid, table_id, fully_qualified_match) {
                         rows.push(entry_value);
                     }
                     Ok(std::ops::ControlFlow::Continue(()))

--- a/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
@@ -20,7 +20,10 @@ use tokio::io::AsyncSeekExt;
 #[cfg(not(feature = "tombstones"))]
 use super::super::source::ScanCursor;
 #[cfg(not(feature = "tombstones"))]
-use super::model::{physical_byte_bounds_for_slice, ClusteringRowWindow, ClusteringSlice};
+use super::model::{
+    physical_byte_bounds_for_slice, table_header_consistent_for_seek, ClusteringRowWindow,
+    ClusteringSlice,
+};
 
 impl SSTableReader {
     /// Current value of the test-only `scan_for_key` invocation counter.
@@ -1059,9 +1062,9 @@ impl SSTableReader {
             clamped_window,
             |(tid, entry_key, entry_value)| {
                 if entry_key.as_bytes() == key.as_bytes() {
-                    // A row of the TARGET partition. Verify the table id matches
-                    // (a wrong-table query never returns a row, issue #831).
-                    if table_ids_match_strict(&tid, table_id) {
+                    // Header-authoritative table consistency: wrong-table rejected
+                    // (#831), keyspace-divergent same-table query still served (#1284).
+                    if table_header_consistent_for_seek(&tid, table_id) {
                         rows.push(entry_value);
                     }
                     Ok(std::ops::ControlFlow::Continue(()))

--- a/cqlite-core/src/storage/sstable/reader/data_access/model.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/model.rs
@@ -227,32 +227,41 @@ pub(super) fn table_ids_match_strict(entry_table_id: &TableId, query_table_id: &
     }
 }
 
-/// Seek-path table-id consistency check (issue #1284).
+/// Seek-path table-id consistency check (issue #1284, hardened per #1284 review).
 ///
 /// The single-partition SEEK (`bti_decompress_and_parse_target_all`) builds
 /// `entry_table_id` from THIS reader's AUTHORITATIVE serialization header
-/// (`{header.keyspace}.{header.table_name}`), and the reader was already resolved
-/// as the query's target table by the manager's `resolve_reader_list`. So the
-/// emitted `entry_table_id` is the SSTable's own authoritative identity for the
-/// data it is decoding.
+/// (`{header.keyspace}.{header.table_name}`). `query_table_id` is the query's id.
 ///
-/// [`table_ids_match_strict`] additionally requires the *keyspace* to match the
-/// query id when BOTH are fully qualified. That is the correct defensive guard
-/// for a `get()` point lookup (issue #831) — but it falsely REJECTS every row of
-/// a legitimately-resolved seek when the SSTable's header keyspace differs from
-/// the query's keyspace (e.g. a header whose embedded keyspace was not the
-/// path-derived one, or a writer-produced header), silently zeroing the result
-/// and forcing a full-scan fallback (issue #1284).
+/// `fully_qualified_match` records HOW the manager resolved this reader for the
+/// query (`resolve_reader_list`):
+///   - `true`  — the query's fully-qualified `keyspace.table` key matched the
+///     reader map EXACTLY (path-authoritative: this reader genuinely IS the
+///     queried table), or the query was unqualified.
+///   - `false` — the query was fully qualified but reached this reader via the
+///     bare/unqualified NAME fallback (its keyspace did NOT match any map key).
 ///
-/// For the seek the authoritative consistency test is: does the SSTable header's
-/// TABLE NAME equal the query's table name? A matching table name means the
-/// header is consistent with what was queried, so the decoded rows belong to the
-/// target table and are accepted — even when the keyspaces differ. A DIFFERENT
-/// table name still rejects (the #831 wrong-table guard is preserved), because
-/// the unqualified-name comparison in [`table_ids_match`] fails for it.
+/// [`table_ids_match_strict`] additionally requires the *keyspace* to match when
+/// BOTH ids are fully qualified — the correct `get()` defensive guard (#831). For
+/// a seek it falsely REJECTS every row when the reader's HEADER keyspace differs
+/// from the query keyspace even though resolution was an exact FQ match (e.g. a
+/// writer-produced header, or a header whose embedded keyspace is not the
+/// path-derived one), silently zeroing the result and forcing a full-scan
+/// fallback (#1284).
 ///
-/// This is no-heuristic: it relies only on the authoritative header identity and
-/// the query id, never on guessing.
+/// The relaxation (accept on a consistent TABLE NAME despite a header-keyspace
+/// divergence) is therefore gated on `fully_qualified_match`:
+///   - Exact FQ match (or unqualified query): the reader is authoritatively the
+///     target table, so a header-keyspace divergence is benign — accept when the
+///     table names agree, reject a different table name (the #831 wrong-table
+///     guard survives via [`table_ids_match`]). This is #1284's actual goal.
+///   - FQ query reached via the bare-name FALLBACK: the keyspace genuinely did
+///     NOT match, so a relaxed name-only check could surface rows from ANOTHER
+///     keyspace whose table name collides — keep STRICT keyspace matching
+///     ([`table_ids_match_strict`]) and REJECT the wrong-keyspace rows.
+///
+/// This is no-heuristic: it relies only on the authoritative header identity, the
+/// query id, and the authoritative resolution mode — never on guessing.
 ///
 /// Compiled only for the default (`not(tombstones)`) build: its only caller,
 /// `bti_collect_partition_rows`, exists only there (the manager's seek-driven
@@ -262,14 +271,15 @@ pub(super) fn table_ids_match_strict(entry_table_id: &TableId, query_table_id: &
 pub(super) fn table_header_consistent_for_seek(
     entry_table_id: &TableId,
     query_table_id: &TableId,
+    fully_qualified_match: bool,
 ) -> bool {
-    // Accept when the query is fully qualified and the header table name is
-    // consistent (matching unqualified table names), OR when the strict guard
-    // already accepts (identical qualified ids / qualified-vs-unqualified). The
-    // first arm is exactly the #1284 relaxation: a fully-qualified query whose
-    // keyspace differs from the SSTable header's keyspace is still served when the
-    // table names agree.
-    if query_table_id.name().contains('.') {
+    // Only relax to the name-only consistency check for a fully-qualified query
+    // when resolution was an EXACT fully-qualified match (the reader is
+    // path-authoritatively the queried table). A fully-qualified query that
+    // reached this reader via the bare-name fallback keeps STRICT keyspace
+    // matching, so it can never return rows from a different keyspace whose table
+    // name collides (#1284 review correctness fix).
+    if fully_qualified_match && query_table_id.name().contains('.') {
         table_ids_match(entry_table_id, query_table_id)
     } else {
         table_ids_match_strict(entry_table_id, query_table_id)
@@ -388,53 +398,80 @@ mod tests {
         assert!(table_ids_match_strict(&unq, &a));
     }
 
-    /// Issue #1284: the SEEK consistency check must ACCEPT a decoded row whose
-    /// SSTable header keyspace differs from a fully-qualified query keyspace, so
-    /// long as the TABLE NAME is consistent — the strict guard would otherwise
-    /// zero the result and force a full-scan fallback. A genuinely different
-    /// table name still rejects (the #831 wrong-table guard is preserved).
+    /// Issue #1284 (hardened per review): the SEEK consistency check relaxes to a
+    /// name-only match across a header-keyspace divergence ONLY when resolution
+    /// was an EXACT fully-qualified match. A fully-qualified query that reached
+    /// the reader via the bare-name FALLBACK keeps STRICT keyspace matching, so a
+    /// wrong-keyspace query can never return another keyspace's same-named rows.
+    /// A different table name always rejects (the #831 wrong-table guard).
     #[cfg(not(feature = "tombstones"))]
     #[test]
-    fn test_table_header_consistent_for_seek_accepts_keyspace_divergence() {
+    fn test_table_header_consistent_for_seek_gates_on_resolution_mode() {
         // The seek builds `entry` from the SSTable's authoritative header.
         let header = TableId::new("ks_a.users".to_string());
 
-        // 1. Fully-qualified query, SAME table name, DIFFERENT keyspace: the
-        //    strict guard REJECTS (the #1284 bug), but the seek check ACCEPTS
-        //    because the table names are consistent and the header is authoritative.
+        // 1. EXACT fully-qualified match, header keyspace MATCHES, same table:
+        //    ACCEPT (seek engages — the genuine #1284 goal, no regression).
+        let query_same = TableId::new("ks_a.users".to_string());
+        assert!(
+            table_header_consistent_for_seek(&header, &query_same, /*fq_match=*/ true),
+            "exact FQ match with a consistent header keyspace+table must accept (seek engages)"
+        );
+
+        // 1b. EXACT fully-qualified match, header keyspace DIFFERS but resolution
+        //     was path-authoritative (the benign #1284 divergence): ACCEPT on the
+        //     consistent table name. The strict guard alone would wrongly reject.
+        let query_div_exact = TableId::new("ks_b.users".to_string());
+        assert!(
+            !table_ids_match_strict(&header, &query_div_exact),
+            "precondition: the strict guard rejects a different-keyspace same-name query"
+        );
+        assert!(
+            table_header_consistent_for_seek(&header, &query_div_exact, /*fq_match=*/ true),
+            "Issue #1284: an EXACT fully-qualified resolution must accept rows when only the \
+             header keyspace diverges and the table name is consistent"
+        );
+
+        // 2. Fully-qualified query, header keyspace DIFFERS, reached via the
+        //    bare-name FALLBACK (fq_match = false), SAME table name: REJECT — the
+        //    keyspaces genuinely differ, so accepting would surface another
+        //    keyspace's same-named rows (#1284 review correctness fix).
         let query_other_ks = TableId::new("ks_b.users".to_string());
         assert!(
-            !table_ids_match_strict(&header, &query_other_ks),
-            "precondition: the strict guard rejects a different-keyspace same-name query (the bug)"
-        );
-        assert!(
-            table_header_consistent_for_seek(&header, &query_other_ks),
-            "Issue #1284: the seek must accept rows when the query is fully qualified and the \
-             header table name is consistent, even across a keyspace divergence"
+            !table_header_consistent_for_seek(&header, &query_other_ks, /*fq_match=*/ false),
+            "Issue #1284 review: a fully-qualified query resolved via the bare-name fallback must \
+             NOT accept rows from a reader whose header keyspace differs (no wrong-keyspace rows)"
         );
 
-        // 2. Fully-qualified query, SAME keyspace and table: accepted (no regression).
-        let query_same = TableId::new("ks_a.users".to_string());
-        assert!(table_header_consistent_for_seek(&header, &query_same));
-
-        // 3. Fully-qualified query, DIFFERENT table name: still REJECTED (the
-        //    #831 wrong-table guard must survive the relaxation).
+        // 3. DIFFERENT table name: REJECT regardless of resolution mode (the #831
+        //    wrong-table guard must survive the relaxation).
         let query_wrong_table = TableId::new("ks_b.accounts".to_string());
         assert!(
-            !table_header_consistent_for_seek(&header, &query_wrong_table),
-            "Issue #1284: a genuinely different table name must still be rejected"
+            !table_header_consistent_for_seek(&header, &query_wrong_table, /*fq_match=*/ true),
+            "Issue #831: a genuinely different table name must still be rejected (exact match)"
+        );
+        assert!(
+            !table_header_consistent_for_seek(
+                &header,
+                &query_wrong_table,
+                /*fq_match=*/ false
+            ),
+            "Issue #831: a genuinely different table name must still be rejected (fallback)"
         );
 
-        // 4. UNqualified query: defers to the strict guard's permissive name match.
+        // 4. UNqualified query: defers to the strict guard's permissive name match
+        //    (resolution mode irrelevant — there is no keyspace to mismatch).
         let query_unqualified = TableId::new("users".to_string());
         assert!(table_header_consistent_for_seek(
             &header,
-            &query_unqualified
+            &query_unqualified,
+            /*fq_match=*/ false
         ));
         let query_unqualified_wrong = TableId::new("accounts".to_string());
         assert!(!table_header_consistent_for_seek(
             &header,
-            &query_unqualified_wrong
+            &query_unqualified_wrong,
+            /*fq_match=*/ true
         ));
     }
 

--- a/cqlite-core/src/storage/sstable/reader/data_access/model.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/model.rs
@@ -227,6 +227,55 @@ pub(super) fn table_ids_match_strict(entry_table_id: &TableId, query_table_id: &
     }
 }
 
+/// Seek-path table-id consistency check (issue #1284).
+///
+/// The single-partition SEEK (`bti_decompress_and_parse_target_all`) builds
+/// `entry_table_id` from THIS reader's AUTHORITATIVE serialization header
+/// (`{header.keyspace}.{header.table_name}`), and the reader was already resolved
+/// as the query's target table by the manager's `resolve_reader_list`. So the
+/// emitted `entry_table_id` is the SSTable's own authoritative identity for the
+/// data it is decoding.
+///
+/// [`table_ids_match_strict`] additionally requires the *keyspace* to match the
+/// query id when BOTH are fully qualified. That is the correct defensive guard
+/// for a `get()` point lookup (issue #831) — but it falsely REJECTS every row of
+/// a legitimately-resolved seek when the SSTable's header keyspace differs from
+/// the query's keyspace (e.g. a header whose embedded keyspace was not the
+/// path-derived one, or a writer-produced header), silently zeroing the result
+/// and forcing a full-scan fallback (issue #1284).
+///
+/// For the seek the authoritative consistency test is: does the SSTable header's
+/// TABLE NAME equal the query's table name? A matching table name means the
+/// header is consistent with what was queried, so the decoded rows belong to the
+/// target table and are accepted — even when the keyspaces differ. A DIFFERENT
+/// table name still rejects (the #831 wrong-table guard is preserved), because
+/// the unqualified-name comparison in [`table_ids_match`] fails for it.
+///
+/// This is no-heuristic: it relies only on the authoritative header identity and
+/// the query id, never on guessing.
+///
+/// Compiled only for the default (`not(tombstones)`) build: its only caller,
+/// `bti_collect_partition_rows`, exists only there (the manager's seek-driven
+/// `scan_partition` is gated the same way), so under `tombstones` this would be
+/// dead code.
+#[cfg(not(feature = "tombstones"))]
+pub(super) fn table_header_consistent_for_seek(
+    entry_table_id: &TableId,
+    query_table_id: &TableId,
+) -> bool {
+    // Accept when the query is fully qualified and the header table name is
+    // consistent (matching unqualified table names), OR when the strict guard
+    // already accepts (identical qualified ids / qualified-vs-unqualified). The
+    // first arm is exactly the #1284 relaxation: a fully-qualified query whose
+    // keyspace differs from the SSTable header's keyspace is still served when the
+    // table names agree.
+    if query_table_id.name().contains('.') {
+        table_ids_match(entry_table_id, query_table_id)
+    } else {
+        table_ids_match_strict(entry_table_id, query_table_id)
+    }
+}
+
 /// Per-iteration decision for the BTI chunk-targeted point-lookup loop.
 #[derive(Debug, PartialEq, Eq)]
 pub(super) enum BtiLookupStep {
@@ -337,6 +386,56 @@ mod tests {
         let unq = TableId::new("users".to_string());
         assert!(table_ids_match_strict(&a, &unq));
         assert!(table_ids_match_strict(&unq, &a));
+    }
+
+    /// Issue #1284: the SEEK consistency check must ACCEPT a decoded row whose
+    /// SSTable header keyspace differs from a fully-qualified query keyspace, so
+    /// long as the TABLE NAME is consistent — the strict guard would otherwise
+    /// zero the result and force a full-scan fallback. A genuinely different
+    /// table name still rejects (the #831 wrong-table guard is preserved).
+    #[cfg(not(feature = "tombstones"))]
+    #[test]
+    fn test_table_header_consistent_for_seek_accepts_keyspace_divergence() {
+        // The seek builds `entry` from the SSTable's authoritative header.
+        let header = TableId::new("ks_a.users".to_string());
+
+        // 1. Fully-qualified query, SAME table name, DIFFERENT keyspace: the
+        //    strict guard REJECTS (the #1284 bug), but the seek check ACCEPTS
+        //    because the table names are consistent and the header is authoritative.
+        let query_other_ks = TableId::new("ks_b.users".to_string());
+        assert!(
+            !table_ids_match_strict(&header, &query_other_ks),
+            "precondition: the strict guard rejects a different-keyspace same-name query (the bug)"
+        );
+        assert!(
+            table_header_consistent_for_seek(&header, &query_other_ks),
+            "Issue #1284: the seek must accept rows when the query is fully qualified and the \
+             header table name is consistent, even across a keyspace divergence"
+        );
+
+        // 2. Fully-qualified query, SAME keyspace and table: accepted (no regression).
+        let query_same = TableId::new("ks_a.users".to_string());
+        assert!(table_header_consistent_for_seek(&header, &query_same));
+
+        // 3. Fully-qualified query, DIFFERENT table name: still REJECTED (the
+        //    #831 wrong-table guard must survive the relaxation).
+        let query_wrong_table = TableId::new("ks_b.accounts".to_string());
+        assert!(
+            !table_header_consistent_for_seek(&header, &query_wrong_table),
+            "Issue #1284: a genuinely different table name must still be rejected"
+        );
+
+        // 4. UNqualified query: defers to the strict guard's permissive name match.
+        let query_unqualified = TableId::new("users".to_string());
+        assert!(table_header_consistent_for_seek(
+            &header,
+            &query_unqualified
+        ));
+        let query_unqualified_wrong = TableId::new("accounts".to_string());
+        assert!(!table_header_consistent_for_seek(
+            &header,
+            &query_unqualified_wrong
+        ));
     }
 
     #[test]

--- a/cqlite-core/tests/issue_1284_big_single_partition_seek.rs
+++ b/cqlite-core/tests/issue_1284_big_single_partition_seek.rs
@@ -49,6 +49,7 @@ use cqlite_core::query::access_path::AccessPath;
 use cqlite_core::query::result::QueryRow;
 use cqlite_core::storage::sstable::work_counters;
 use cqlite_core::{Database, Value};
+use serial_test::serial;
 
 fn datasets_root() -> Option<PathBuf> {
     std::env::var("CQLITE_DATASETS_ROOT")
@@ -246,13 +247,24 @@ async fn assert_seek_engages_and_matches_full_scan(keyspace: &str, table: &str) 
 }
 
 /// Compressed (Snappy) BIG `nb` SSTable.
+///
+/// `#[serial(work_counters)]`: both cases reset and read the process-global
+/// `work_counters` to prove the seek engaged (`partitions_decoded == 1`), so they
+/// must not run concurrently within the test binary — an interleaved reset/read
+/// would make the engagement signal nondeterministic. Shares the `work_counters`
+/// serial group with the other counter-asserting tests in this crate.
 #[tokio::test]
+#[serial(work_counters)]
 async fn big_compressed_where_pk_eq_engages_seek_and_matches_full_scan() {
     assert_seek_engages_and_matches_full_scan("test_basic", "simple_table").await;
 }
 
 /// Uncompressed BIG `nb` SSTable (`compression_info = None`).
+///
+/// Serialized on the `work_counters` group for the same reason as the compressed
+/// case above: it resets and reads the process-global counters.
 #[tokio::test]
+#[serial(work_counters)]
 async fn big_uncompressed_where_pk_eq_engages_seek_and_matches_full_scan() {
     assert_seek_engages_and_matches_full_scan("test_basic", "uncompressed_table").await;
 }

--- a/cqlite-core/tests/issue_1284_big_single_partition_seek.rs
+++ b/cqlite-core/tests/issue_1284_big_single_partition_seek.rs
@@ -1,0 +1,258 @@
+//! Issue #1284: the BIG (`nb`) single-partition seek
+//! (`scan_single_partition_clustering` → `bti_decompress_and_parse_target_all`)
+//! must ENGAGE for a `WHERE pk = ?` point lookup — for BOTH compressed and
+//! uncompressed BIG SSTables — rather than silently returning zero rows and
+//! falling back to a full scan.
+//!
+//! Two pre-existing failure modes the fix closes:
+//!   1. The `table_ids_match_strict` guard rejected every decoded row when the
+//!      SSTable's serialization-header keyspace/table differed from a fully
+//!      qualified query id, so the seek decoded the partition but kept nothing →
+//!      empty result, silent full-scan fallback.
+//!   2. The chunk-targeted path was skipped for UNCOMPRESSED BIG SSTables
+//!      (`compression_info = None`) and the whole-section fallback within it did
+//!      not bound/decode them → the seek never engaged.
+//!
+//! The wiring oracle is the `work_counters::partitions_decoded()` counter: the
+//! seek bumps it exactly once when it decodes the target partition DIRECTLY (the
+//! targeted path). An internal `Ok(None)` → full-scan fallback leaves it at 0
+//! (the full scan path bumps `partitions_parsed`, not `partitions_decoded`). So
+//! `partitions_decoded == 1` proves the targeted seek actually engaged — not a
+//! full scan that returned the same rows.
+//!
+//! The parity oracle: the rows the seek returns MUST equal the rows a full scan
+//! returns filtered to the same partition key (byte-faithful, same rows).
+//!
+//! Fixtures (real Cassandra 5.0 BIG `nb` SSTables, single UUID partition key so
+//! each partition is one row — narrow partitions exercise the point-lookup path):
+//!   - compressed  : `test_basic.simple_table`      (Snappy)
+//!   - uncompressed : `test_basic.uncompressed_table` (compression disabled)
+//!
+//! Requires `CQLITE_DATASETS_ROOT` + fetched binaries; SKIPS on fixture absence,
+//! but a present-but-empty result is a HARD FAILURE (parity-is-truth).
+//!
+//! Excluded under `tombstones`: that build compiles out the targeted prune /
+//! work-counter mutators (see `scan_single_partition_clustering` is
+//! `cfg(not(tombstones))`), so the engagement signal is inapplicable there.
+
+#![cfg(all(
+    feature = "state_machine",
+    feature = "cli-helpers",
+    not(feature = "tombstones")
+))]
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::query::access_path::AccessPath;
+use cqlite_core::query::result::QueryRow;
+use cqlite_core::storage::sstable::work_counters;
+use cqlite_core::{Database, Value};
+
+fn datasets_root() -> Option<PathBuf> {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+}
+
+fn schemas_dir() -> Option<PathBuf> {
+    if let Some(root) = datasets_root() {
+        if let Some(dir) = root.parent().and_then(|p| {
+            let d = p.join("schemas");
+            d.exists().then_some(d)
+        }) {
+            return Some(dir);
+        }
+    }
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let dir = manifest_dir.parent()?.join("test-data").join("schemas");
+    dir.exists().then_some(dir)
+}
+
+/// True iff `<datasets>/sstables/<keyspace>/<table>-*/` holds a `*-Data.db`. The
+/// skip keys off fixture PRESENCE, so a present fixture that returns 0 rows is a
+/// hard failure, not a silent skip.
+fn fixture_data_present(keyspace: &str, table: &str) -> bool {
+    let Some(root) = datasets_root() else {
+        return false;
+    };
+    let Ok(entries) = std::fs::read_dir(root.join("sstables").join(keyspace)) else {
+        return false;
+    };
+    let prefix = format!("{table}-");
+    for e in entries.flatten() {
+        if !e.file_name().to_string_lossy().starts_with(&prefix) {
+            continue;
+        }
+        if let Ok(files) = std::fs::read_dir(e.path()) {
+            for f in files.flatten() {
+                if f.file_name().to_string_lossy().ends_with("-Data.db") {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+async fn setup() -> Result<Database, String> {
+    let root = datasets_root().ok_or("CQLITE_DATASETS_ROOT not set or missing")?;
+    let schema_path = schemas_dir()
+        .ok_or("schemas dir not found")?
+        .join("basic-types.cql");
+    if !schema_path.exists() {
+        return Err(format!("schema not found at {schema_path:?}"));
+    }
+    let data_dir = root.join("sstables");
+    if !data_dir.exists() {
+        return Err(format!("sstables dir not found at {data_dir:?}"));
+    }
+    let config = IngestionConfig {
+        schema_paths: vec![schema_path],
+        data_dir,
+        version_hint: None,
+        core_config: cqlite_core::Config::default(),
+        table_directory_filter: Some("/test_basic/".to_string()),
+    };
+    let result = ingest(config)
+        .await
+        .map_err(|e| format!("ingestion failed: {e}"))?;
+    if result.schema_load_result.schemas_loaded == 0 {
+        return Err("no schemas loaded".to_string());
+    }
+    Ok(result.database)
+}
+
+fn row_fingerprint(row: &QueryRow) -> BTreeMap<String, String> {
+    row.values
+        .iter()
+        .map(|(k, v)| (k.clone(), format!("{v:?}")))
+        .collect()
+}
+
+fn fingerprints(rows: &[QueryRow]) -> Vec<BTreeMap<String, String>> {
+    let mut out: Vec<_> = rows.iter().map(row_fingerprint).collect();
+    out.sort_by_key(|m| format!("{m:?}"));
+    out
+}
+
+/// Drive the shared oracle for one BIG fixture with a UUID partition key:
+///   - learn a real partition key from a full scan,
+///   - run `WHERE id = <uuid>` and assert the seek ENGAGED (`partitions_decoded
+///     == 1`, NOT 0), the access path is targeted (NOT FallbackFullScan), and
+///   - the rows EQUAL the full scan filtered to that key (parity-is-truth).
+async fn assert_seek_engages_and_matches_full_scan(keyspace: &str, table: &str) {
+    let db = match setup().await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping ({keyspace}.{table}): {e}");
+            return;
+        }
+    };
+    if !fixture_data_present(keyspace, table) {
+        eprintln!("Skipping ({keyspace}.{table}): fixture Data.db not present");
+        return;
+    }
+
+    // Full scan: the parity oracle + the source of a real partition key.
+    let full = db
+        .execute(&format!("SELECT * FROM {keyspace}.{table}"))
+        .await
+        .unwrap_or_else(|e| panic!("full scan {keyspace}.{table} failed: {e}"));
+    assert!(
+        !full.rows.is_empty(),
+        "{keyspace}.{table}: fixture present but full scan returned 0 rows (parity-is-truth: a \
+         present-but-empty fixture is a failure, not a skip)"
+    );
+    let Some(Value::Uuid(id)) = full.rows.first().and_then(|r| r.values.get("id").cloned()) else {
+        panic!("{keyspace}.{table}: first row has no UUID `id` column");
+    };
+
+    // Expected rows = full scan filtered to this partition key.
+    let expected: Vec<QueryRow> = full
+        .rows
+        .iter()
+        .filter(|r| matches!(r.values.get("id"), Some(Value::Uuid(b)) if *b == id))
+        .cloned()
+        .collect();
+    assert!(
+        !expected.is_empty(),
+        "{keyspace}.{table}: full scan must contain the learned partition key"
+    );
+
+    // The targeted point lookup, with the work counters reset so the engagement
+    // signal reflects exactly this query. Routed through `execute_with_params`
+    // (a bound `WHERE id = ?`) so it takes the SELECT-executor partition-targeted
+    // pipeline — `targeted_partition_rows` → `scan_partition_clustering` →
+    // `scan_single_partition_clustering` — rather than the legacy ≤8-token
+    // simple-id point-lookup path, which is what this issue's seek lives on.
+    work_counters::reset();
+    let seek = db
+        .execute_with_params(
+            &format!("SELECT * FROM {keyspace}.{table} WHERE id = ?"),
+            &[Value::Uuid(id)],
+        )
+        .await
+        .unwrap_or_else(|e| panic!("seek {keyspace}.{table} failed: {e}"));
+    let decoded = work_counters::partitions_decoded();
+
+    // (a) WIRING: the targeted single-partition SEEK actually engaged. The seek
+    // bumps `partitions_decoded` once when it decodes the target partition
+    // directly; an internal `Ok(None)` → full-scan fallback leaves it at 0. So
+    // `== 1` is hard evidence the targeted path ran, not a full scan that
+    // happened to return the same rows.
+    assert_eq!(
+        decoded, 1,
+        "Issue #1284: BIG WHERE pk = ? must ENGAGE the targeted single-partition seek for \
+         {keyspace}.{table} (partitions_decoded == 1), got {decoded} — 0 means the seek \
+         decoded nothing and silently fell back to a full scan",
+    );
+
+    // (a') The reported access path is a TARGETED partition lookup, never a
+    // FallbackFullScan.
+    let path = seek
+        .metadata
+        .access_path
+        .clone()
+        .expect("a WHERE pk = ? query records an access path");
+    assert!(
+        path.is_targeted() && !path.is_full_scan(),
+        "Issue #1284: BIG WHERE pk = ? must report a targeted access path for {keyspace}.{table}, \
+         got {path:?}",
+    );
+    assert_ne!(
+        path,
+        AccessPath::FallbackFullScan {
+            reason: cqlite_core::query::access_path::FallbackReason::TombstonesBuildNoPrune,
+        },
+        "Issue #1284: the seek must not report a FallbackFullScan for {keyspace}.{table}",
+    );
+
+    // (b) PARITY: the seek returns EXACTLY the rows the full scan does for this
+    // key (byte-faithful, same rows).
+    assert!(
+        !seek.rows.is_empty(),
+        "Issue #1284: BIG WHERE pk = ? returned 0 rows for {keyspace}.{table} even though the \
+         partition exists in the full scan — this is the headline regression",
+    );
+    assert_eq!(
+        fingerprints(&seek.rows),
+        fingerprints(&expected),
+        "Issue #1284: the targeted seek rows must equal the full-scan rows filtered to the same \
+         partition key for {keyspace}.{table}",
+    );
+}
+
+/// Compressed (Snappy) BIG `nb` SSTable.
+#[tokio::test]
+async fn big_compressed_where_pk_eq_engages_seek_and_matches_full_scan() {
+    assert_seek_engages_and_matches_full_scan("test_basic", "simple_table").await;
+}
+
+/// Uncompressed BIG `nb` SSTable (`compression_info = None`).
+#[tokio::test]
+async fn big_uncompressed_where_pk_eq_engages_seek_and_matches_full_scan() {
+    assert_seek_engages_and_matches_full_scan("test_basic", "uncompressed_table").await;
+}


### PR DESCRIPTION
Closes #1284. Oracle-driven read-path/wiring fix — BIG `WHERE pk = ?` was silently falling back to full scan.

## Change
- `cqlite-core/src/storage/sstable/reader/data_access/model.rs` — new `table_header_consistent_for_seek(entry, query)` (no-heuristics): for a fully-qualified query, accept rows when the SSTable header's table NAME is consistent even if the keyspace differs (header is authoritative; the reader already resolved the target table); a different table name still rejects (#831 guard preserved). Unit test pins old-strict-rejects vs new-accepts for the keyspace-divergent same-table case.
- `cqlite-core/src/storage/sstable/reader/data_access/bti.rs` — seek row-collection guard (`bti_collect_partition_rows`) switched from `table_ids_match_strict` to `table_header_consistent_for_seek`; the `get()` point-lookup path keeps strict.
- `cqlite-core/tests/issue_1284_big_single_partition_seek.rs` — pinned integration test on real BIG fixtures (compressed `simple_table`, uncompressed `uncompressed_table`): asserts the seek ENGAGES (targeted AccessPath, not FallbackFullScan; `partitions_decoded == 1`) AND returns exactly the full-scan rows for the key.

## Acceptance criteria
- ✅ BIG `WHERE pk=?` engages the targeted seek (targeted AccessPath, not FallbackFullScan) for compressed AND uncompressed `nb`.
- ✅ Keyspace/table-id guard accepts rows when the query id is fully qualified and the header is consistent.
- ✅ Pinned test asserts seek-engagement + exact rows-match parity for both compression modes.

## Honest scope note
Post-#1184, mode-2 (uncompressed whole-section) engagement+parity for these fixtures already worked at baseline; the genuinely-fixed piece is failure mode 1 (the strict keyspace guard), pinned by the deterministic `model.rs` unit test. The integration test stands as the engagement+parity regression guard for both modes.

## Follow-ups filed
- `get()` point-lookup decoder (bti.rs) retains the same latent strict-guard false-rejection — to be filed separately (out of scope).

## Gate
All change-exercising lanes PASS (core-tests, integration, clippy -D warnings, fmt, format-compat, file-size). The lone `python-bindings` FAIL is the pre-existing untracked-`test_signed_coll` classification red (see #1319) — unrelated; this diff touches no python/corpus files. Clean filtered re-gate attached on merge.

🤖 flow-lead worker