### PR TITLE
ci: cancel stale main validation runs

### DIFF
--- a/.github/workflows/cassandra-parity.yml
+++ b/.github/workflows/cassandra-parity.yml
@@ -61,7 +61,7 @@ env:
 
 concurrency:
   group: cassandra-parity-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
 
 jobs:
   parity-manifest:

--- a/.github/workflows/cassandra-validation.yml
+++ b/.github/workflows/cassandra-validation.yml
@@ -54,10 +54,10 @@ permissions:
   contents: read
   pull-requests: write
 
-# Cancel any in-progress PR run when a new push arrives; let push/scheduled runs complete.
+# Cancel stale PR runs and stale main push runs; keep manual runs independent.
 concurrency:
   group: cassandra-validation-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
 
 # This workflow validates that SSTables written by CQLite can be imported
 # into a real Cassandra 5.0 cluster using the current loader-based harness

--- a/.github/workflows/ci-minimal-features.yml
+++ b/.github/workflows/ci-minimal-features.yml
@@ -20,7 +20,7 @@ on:
 
 concurrency:
   group: minimal-features-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ on:
 
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/delta-roundtrip.yml
+++ b/.github/workflows/delta-roundtrip.yml
@@ -64,7 +64,7 @@ permissions:
 
 concurrency:
   group: delta-roundtrip-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
 
 jobs:
   delta-roundtrip:

--- a/.github/workflows/flight-ci.yml
+++ b/.github/workflows/flight-ci.yml
@@ -30,7 +30,7 @@ permissions:
 
 concurrency:
   group: flight-ci-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/flight-trino-e2e.yml
+++ b/.github/workflows/flight-trino-e2e.yml
@@ -27,7 +27,7 @@ permissions:
 
 concurrency:
   group: flight-trino-e2e-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
 
 jobs:
   e2e:

--- a/.github/workflows/m1-ci.yml
+++ b/.github/workflows/m1-ci.yml
@@ -32,7 +32,7 @@ on:
 
 concurrency:
   group: m1-ci-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -16,7 +16,7 @@ on:
 
 concurrency:
   group: node-ci-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -16,7 +16,7 @@ on:
 
 concurrency:
   group: python-ci-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -43,7 +43,7 @@ on:
 
 concurrency:
   group: smoke-tests-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/sstabledump-parity-gate.yml
+++ b/.github/workflows/sstabledump-parity-gate.yml
@@ -31,7 +31,7 @@ permissions:
 
 concurrency:
   group: sstabledump-parity-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
 
 env:
   DATASET_TAG: datasets-v3

--- a/.github/workflows/trino-connector-ci.yml
+++ b/.github/workflows/trino-connector-ci.yml
@@ -22,7 +22,7 @@ permissions:
 
 concurrency:
   group: trino-connector-ci-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
 
 jobs:
   build:

--- a/.github/workflows/workflow-config.yml
+++ b/.github/workflows/workflow-config.yml
@@ -13,7 +13,7 @@ on:
 
 concurrency:
   group: workflow-config-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
 
 jobs:
   validate:


### PR DESCRIPTION
## Summary
- allow validation-only workflows to cancel stale main push runs, matching the existing stale PR cancellation behavior
- keep release, publish, deploy, nightly-only, and manual-heavy workflows unchanged
- update the Cassandra validation concurrency comment to match the new policy

## Workflows touched
- CI, Core Library minimal, Minimal Features CI
- Python CI, Node.js CI
- Flight CI, Flight ↔ Trino E2E, Trino Connector CI
- SSTableDump Parity Gate, Cassandra Parity Manifest, Cassandra sstableloader Validation
- Delta Round-Trip, Smoke Tests, Workflow Config Validation

## Validation
- git diff --check
- Ruby parse of all workflow YAML
- local Workflow Config Validation trigger-policy Ruby check
- actionlint with shellcheck disabled and known reusable-workflow baseline issues filtered

## Risk
This intentionally means intermediate main commits may have their validation runs canceled when a newer main commit arrives. Release/publish/deploy and manual/nightly-heavy workflows are not included.