### PR TITLE
ci(#1324): portable dataset checksum on macOS runners

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -178,7 +178,13 @@ jobs:
           mkdir -p test-data/datasets
           curl -fsSL -o /tmp/${DATASET_ASSET} \
             https://github.com/pmcfadin/cqlite/releases/download/${DATASET_TAG}/${DATASET_ASSET}
-          echo "${DATASET_SHA256}  /tmp/${DATASET_ASSET}" | sha256sum -c -
+          # Issue #1324: portable checksum — GitHub's macOS runners ship `shasum`
+          # (perl), not GNU coreutils `sha256sum`. Match release.yml's idiom.
+          if command -v sha256sum >/dev/null 2>&1; then
+            echo "${DATASET_SHA256}  /tmp/${DATASET_ASSET}" | sha256sum -c -
+          else
+            echo "${DATASET_SHA256}  /tmp/${DATASET_ASSET}" | shasum -a 256 -c -
+          fi
           tar -xzf /tmp/${DATASET_ASSET} -C . --exclude='*/._*' --exclude='._*' --exclude='*/.DS_Store' --exclude='.DS_Store'
 
       - name: Fetch datasets if cache miss (Windows)

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -207,7 +207,13 @@ jobs:
           mkdir -p test-data/datasets
           curl -fsSL -o /tmp/${DATASET_ASSET} \
             https://github.com/pmcfadin/cqlite/releases/download/${DATASET_TAG}/${DATASET_ASSET}
-          echo "${DATASET_SHA256}  /tmp/${DATASET_ASSET}" | sha256sum -c -
+          # Issue #1324: portable checksum — GitHub's macOS runners ship `shasum`
+          # (perl), not GNU coreutils `sha256sum`. Match release.yml's idiom.
+          if command -v sha256sum >/dev/null 2>&1; then
+            echo "${DATASET_SHA256}  /tmp/${DATASET_ASSET}" | sha256sum -c -
+          else
+            echo "${DATASET_SHA256}  /tmp/${DATASET_ASSET}" | shasum -a 256 -c -
+          fi
           tar -xzf /tmp/${DATASET_ASSET} -C . --exclude='*/._*' --exclude='._*' --exclude='*/.DS_Store' --exclude='.DS_Store'
 
       - name: Fetch datasets if cache miss (Windows)


### PR DESCRIPTION
## Summary
Fixes the recurring **Python CI** (and **Node.js CI**) red on `Test (macos-14)`.

The "Fetch datasets if cache miss (Unix)" step verified the release tarball with GNU coreutils `sha256sum`, which **GitHub's macOS runners don't ship** (they have perl `shasum`). On a dataset **cache miss** the macOS job died:

```
sha256sum: command not found
##[error]Process completed with exit code 127.
```

It's intermittent because the fetch step only runs when the `datasets-v3-<sha>` cache is cold (idle eviction / key rotation). Warm cache → step skipped → macOS passes.

## Fix
Guard on `command -v sha256sum` and fall back to `shasum -a 256 -c -` (present on both Linux and macOS), matching the existing `release.yml` idiom. Applied to the two affected workflows:
- `.github/workflows/python-ci.yml`
- `.github/workflows/node-ci.yml`

No behavioral change on Linux (uses `sha256sum` as before) or Windows (`Get-FileHash`, untouched).

## Validation
- `actionlint` finding count unchanged (46 → 46; no new shellcheck class; fix reuses the existing `${DATASET_SHA256}  /tmp/${DATASET_ASSET}` pattern).
- Functional check on macOS: `shasum -a 256 -c -` verifies a correct hash (PASS) and **fail-closes** on a wrong 64-hex hash (FAILED, nonzero exit).
- YAML parses (ruby YAML.load_file OK).

## Out of scope (already safe — verified)
- `release.yml` already guards `command -v sha256sum` → `shasum` fallback.
- `python-release.yml` / `node-release.yml` run their checksum step on `ubuntu-latest` only.

## Triage note (no action)
`test_parity.py::test_every_discovered_keyspace_is_classified` failures on older branches were a separate, already-resolved ordering issue: `test_signed_coll` fixtures (#1313) landed with their `SKIP_KEYSPACES` entry; `corpus.py` on main classifies it. Clears on rebase.

Fixes #1324