### PR TITLE
feat(#944): surface authoritative per-table stats over Flight to drive Trino AUTOMATIC aggregation-pushdown gate

### DIFF
--- a/cqlite-core/src/parser/repair_metadata.rs
+++ b/cqlite-core/src/parser/repair_metadata.rs
@@ -782,6 +782,140 @@ pub fn parse_repair_metadata(input: &[u8], gates: Option<&VersionGates>) -> Resu
     })
 }
 
+/// Authoritative per-SSTable row/partition counts decoded from the STATS
+/// component of `Statistics.db` (issue #944).
+///
+/// Both fields come straight from cassandra-5.0.0
+/// `StatsMetadata.StatsMetadataSerializer.serialize` — no heuristics (#28):
+///
+///   * `partition_count` is the sum of the bucket counts of the
+///     `estimatedPartitionSize` `EstimatedHistogram` (the FIRST STATS field). That
+///     histogram records one observation per partition, so Σ counts is exactly the
+///     SSTable's partition count — the same value `SSTableReader` exposes via
+///     `getEstimatedPartitionSize().count()`. It is reachable by a fully
+///     self-describing walk and needs NO version gates.
+///   * `total_rows` is the `totalRows` `long` written near the end of the STATS
+///     body (field 12). Reaching it requires the version-gated forward walk
+///     (`improvedMinMax`/`legacyMinMax` block + commit-log intervals), so it is
+///     `Some` only when authoritative [`VersionGates`] are supplied AND the walk
+///     could traverse the min/max block. For a clustered table whose covered-Slice
+///     bound values are not modeled, `total_rows` is honestly `None` rather than a
+///     guessed value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TableCounts {
+    /// Σ `estimatedPartitionSize` histogram bucket counts = partition count.
+    pub partition_count: u64,
+    /// `totalRows` from the STATS body, when the gated walk could reach it.
+    pub total_rows: Option<u64>,
+}
+
+/// Decode authoritative [`TableCounts`] from a raw `Statistics.db` buffer.
+///
+/// `partition_count` is always decoded (self-describing leading histogram).
+/// `total_rows` is decoded only when `gates` is `Some` and the version-gated walk
+/// to field 12 succeeds; otherwise it is `None` (never fabricated).
+///
+/// # Errors
+///
+/// Returns `Error::Corruption` when the STATS component is present but truncated
+/// or structurally invalid (mirrors [`parse_repair_metadata`] — fails closed). A
+/// `Statistics.db` with NO STATS component yields all-zero counts
+/// (`partition_count == 0`, `total_rows == None`).
+pub fn read_table_counts(input: &[u8], gates: Option<&VersionGates>) -> Result<TableCounts> {
+    let walk = gates.map(RepairWalkGates::from);
+
+    let Some(bounds) = stats_component_bounds(input)? else {
+        return Ok(TableCounts {
+            partition_count: 0,
+            total_rows: None,
+        });
+    };
+
+    let modern_histogram = walk.map(|w| w.modern_histogram).unwrap_or(false);
+    let mut c = Cursor::new(&input[bounds.start..bounds.end]);
+
+    // 1. estimatedPartitionSize histogram: read it (don't skip) so we can sum the
+    //    per-partition bucket counts. Σ counts = partition count (authoritative).
+    let partition_count = sum_estimated_histogram_counts(&mut c)?;
+
+    // 2. estimatedCellPerPartitionCount histogram — skip.
+    skip_estimated_histogram(&mut c)?;
+
+    // Without authoritative gates the path to totalRows (the gated min/max block)
+    // cannot be traversed; report partition_count alone and total_rows = None.
+    let Some(walk) = walk else {
+        return Ok(TableCounts {
+            partition_count,
+            total_rows: None,
+        });
+    };
+
+    // 3-8. commitLogUpperBound, timestamps, deletion times, TTLs, compressionRatio,
+    //       tombstone histogram — same fixed/gated skips as the repair walk.
+    c.skip(8 + 4)?; // commitLogUpperBound: i64 segmentId + i32 position
+    c.skip(8 + 8)?; // minTimestamp, maxTimestamp
+    c.skip(4 + 4)?; // min/maxLocalDeletionTime
+    c.skip(4 + 4)?; // minTTL, maxTTL
+    c.skip(8)?; // compressionRatio (f64)
+    skip_tombstone_histogram(&mut c, modern_histogram)?;
+
+    // 9. sstableLevel (i32), repairedAt (i64).
+    c.skip(4 + 8)?;
+
+    // 10. version-gated min/max clustering block. The improvedMinMax covered-Slice
+    //     bound values are not always modeled; when they cannot be skipped, totalRows
+    //     is unreachable and reported honestly as None.
+    if walk.has_improved_min_max {
+        if !try_skip_improved_min_max(&mut c)? {
+            return Ok(TableCounts {
+                partition_count,
+                total_rows: None,
+            });
+        }
+    } else if walk.has_legacy_min_max {
+        skip_legacy_min_max(&mut c)?;
+    }
+
+    // 11. hasLegacyCounterShards (bool).
+    c.skip(1)?;
+
+    // 12. totalColumnsSet (long), then totalRows (long) — READ totalRows.
+    c.skip(8)?; // totalColumnsSet
+    let total_rows = c.read_i64()?;
+    let total_rows = u64::try_from(total_rows).ok();
+
+    Ok(TableCounts {
+        partition_count,
+        total_rows,
+    })
+}
+
+/// Read an `EstimatedHistogram` and return the SUM of its bucket counts (`i64`
+/// each). Layout: `i32 bucketCount`, then `bucketCount` × (`i64 offset`,
+/// `i64 count`). Σ counts = number of observations (one per partition for the
+/// estimatedPartitionSize histogram). Saturating add: a real SSTable never
+/// overflows u64, but never wrap into a tiny count that would mislead the gate.
+fn sum_estimated_histogram_counts(c: &mut Cursor) -> Result<u64> {
+    let count = c.read_i32()?;
+    if count < 0 {
+        return Err(Error::Corruption(format!(
+            "negative EstimatedHistogram bucket count {count}"
+        )));
+    }
+    let mut sum: u64 = 0;
+    for _ in 0..count {
+        let _offset = c.read_i64()?;
+        let bucket = c.read_i64()?;
+        if bucket < 0 {
+            return Err(Error::Corruption(format!(
+                "negative EstimatedHistogram bucket value {bucket}"
+            )));
+        }
+        sum = sum.saturating_add(bucket as u64);
+    }
+    Ok(sum)
+}
+
 /// Cassandra's canonical "no deletion" local-deletion-time sentinel,
 /// normalized to `i64` for both legacy (nb) and modern (oa/da) encodings.
 ///
@@ -1617,5 +1751,82 @@ mod tests {
             }
         }
         !crc
+    }
+
+    // ---- read_table_counts (issue #944) ----------------------------------
+
+    /// Build an `nb`-layout STATS body with a POPULATED estimatedPartitionSize
+    /// histogram (so `partition_count` is non-zero) and a known `totalRows`.
+    /// `partition_buckets` are `(offset, count)` pairs; Σ counts = partition_count.
+    fn synthetic_counts_nb(partition_buckets: &[(i64, i64)], total_rows: i64) -> Vec<u8> {
+        let mut stats = Vec::new();
+        // estimatedPartitionSize: i32 bucketCount, then (i64 offset, i64 count)*.
+        stats.extend_from_slice(&(partition_buckets.len() as i32).to_be_bytes());
+        for (off, cnt) in partition_buckets {
+            stats.extend_from_slice(&off.to_be_bytes());
+            stats.extend_from_slice(&cnt.to_be_bytes());
+        }
+        stats.extend_from_slice(&0i32.to_be_bytes()); // estimatedCellPerPartitionCount (empty)
+        stats.extend_from_slice(&(-1i64).to_be_bytes()); // commitLogUpperBound segmentId
+        stats.extend_from_slice(&0i32.to_be_bytes()); // commitLogUpperBound position
+        stats.extend_from_slice(&100i64.to_be_bytes()); // minTimestamp
+        stats.extend_from_slice(&200i64.to_be_bytes()); // maxTimestamp
+        stats.extend_from_slice(&i32::MAX.to_be_bytes()); // minLocalDeletionTime
+        stats.extend_from_slice(&i32::MAX.to_be_bytes()); // maxLocalDeletionTime
+        stats.extend_from_slice(&0i32.to_be_bytes()); // minTTL
+        stats.extend_from_slice(&0i32.to_be_bytes()); // maxTTL
+        stats.extend_from_slice(&(-1.0f64).to_be_bytes()); // compressionRatio
+        stats.extend_from_slice(&0i32.to_be_bytes()); // TombstoneHistogram maxBinSize
+        stats.extend_from_slice(&0i32.to_be_bytes()); // TombstoneHistogram size
+        stats.extend_from_slice(&0i32.to_be_bytes()); // sstableLevel
+        stats.extend_from_slice(&0i64.to_be_bytes()); // repairedAt
+        stats.extend_from_slice(&0i32.to_be_bytes()); // legacy min clustering list (empty)
+        stats.extend_from_slice(&0i32.to_be_bytes()); // legacy max clustering list (empty)
+        stats.push(0x00); // hasLegacyCounterShards
+        stats.extend_from_slice(&7u64.to_be_bytes()); // totalColumnsSet (arbitrary)
+        stats.extend_from_slice(&total_rows.to_be_bytes()); // totalRows
+        stats.extend_from_slice(&(-1i64).to_be_bytes()); // commitLogLowerBound segmentId
+        stats.extend_from_slice(&0i32.to_be_bytes()); // commitLogLowerBound position
+        stats.extend_from_slice(&0i32.to_be_bytes()); // commitLogIntervals size = 0
+        stats.push(0x00); // pendingRepair absent
+        stats.push(0x00); // isTransient
+        wrap_stats_last(stats)
+    }
+
+    #[test]
+    fn read_table_counts_sums_partition_histogram_and_total_rows() {
+        // 3 + 2 + 5 = 10 partitions; 2000 total rows (wide table shape).
+        let buf = synthetic_counts_nb(&[(0, 3), (16, 2), (64, 5)], 2000);
+        let counts = read_table_counts(&buf, Some(&nb_gates())).expect("decode");
+        assert_eq!(counts.partition_count, 10, "Σ histogram bucket counts");
+        assert_eq!(counts.total_rows, Some(2000), "totalRows from field 12");
+    }
+
+    #[test]
+    fn read_table_counts_partition_count_without_gates_total_rows_none() {
+        // Without gates, partition_count is still decoded (self-describing leading
+        // histogram), but the gated walk to totalRows is not attempted.
+        let buf = synthetic_counts_nb(&[(0, 4), (8, 6)], 999);
+        let counts = read_table_counts(&buf, None).expect("decode");
+        assert_eq!(counts.partition_count, 10);
+        assert_eq!(
+            counts.total_rows, None,
+            "no gates → totalRows honestly absent, never guessed"
+        );
+    }
+
+    #[test]
+    fn read_table_counts_no_stats_component_is_all_zero() {
+        // A TOC with only a non-STATS component → no counts to decode.
+        let mut out = Vec::new();
+        out.extend_from_slice(&1u32.to_be_bytes()); // 1 component
+        out.extend_from_slice(&0u32.to_be_bytes()); // checksum
+        out.extend_from_slice(&0u32.to_be_bytes()); // type 0 (VALIDATION), not STATS
+        out.extend_from_slice(&16u32.to_be_bytes()); // offset
+        out.push(0u8); // body
+        out.extend_from_slice(&0u32.to_be_bytes()); // trailing CRC
+        let counts = read_table_counts(&out, Some(&nb_gates())).expect("decode");
+        assert_eq!(counts.partition_count, 0);
+        assert_eq!(counts.total_rows, None);
     }
 }

--- a/cqlite-flight/src/lib.rs
+++ b/cqlite-flight/src/lib.rs
@@ -13,6 +13,7 @@ pub mod filter;
 pub mod obs;
 pub mod producer;
 pub mod service;
+pub mod stats;
 pub mod ticket;
 
 #[cfg(test)]

--- a/cqlite-flight/src/producer.rs
+++ b/cqlite-flight/src/producer.rs
@@ -86,6 +86,13 @@ impl DirSource {
         Self { dir: dir.into() }
     }
 
+    /// The resolved SSTable directory this source reads from. Used by the
+    /// `table_stats` action (issue #944) to gather per-SSTable statistics from
+    /// the same directory `do_get` would merge.
+    pub fn into_dir(self) -> PathBuf {
+        self.dir
+    }
+
     /// Resolve the SSTable directory for `keyspace.table` under `data_dir`,
     /// optionally inside a named snapshot.
     ///

--- a/cqlite-flight/src/service.rs
+++ b/cqlite-flight/src/service.rs
@@ -435,7 +435,14 @@ impl CqliteFlightService {
         )
         .into_dir();
 
-        let stats = gather_table_stats(&dir).await?;
+        // `gather_table_stats` is synchronous blocking fs I/O (read_dir + read of
+        // every Statistics.db). Run it off the async runtime so a table with many
+        // SSTables / slow storage cannot stall unrelated Flight RPCs — mirroring the
+        // `do_get` merge offload above. Outer `?` maps a task panic; inner `?` keeps
+        // the `StatsError` -> `Status` mapping (`From<StatsError> for Status`).
+        let stats = tokio::task::spawn_blocking(move || gather_table_stats(&dir))
+            .await
+            .map_err(|e| Status::internal(format!("table_stats task panicked: {e}")))??;
         let body = stats
             .to_bytes()
             .map_err(|e| Status::internal(format!("encode table_stats response: {e}")))?;

--- a/cqlite-flight/src/service.rs
+++ b/cqlite-flight/src/service.rs
@@ -37,6 +37,7 @@ use tracing::Instrument;
 use crate::filter::{FilterError, ScanSpec};
 use crate::obs::{rpc_span, RpcMetrics};
 use crate::producer::{DirSource, MergeProducer, ProducerError};
+use crate::stats::{gather_table_stats, StatsError, TableStatsRequest, TABLE_STATS_ACTION};
 use crate::ticket::{FlightTicket, TicketError};
 
 /// Boxed server response stream alias.
@@ -77,6 +78,24 @@ impl From<ProducerError> for Status {
 impl From<FilterError> for Status {
     fn from(e: FilterError) -> Self {
         Status::invalid_argument(e.to_string())
+    }
+}
+
+/// Map a `table_stats` gather failure (issue #944) to a gRPC status: a bad
+/// request body is a client error; a missing table directory is `not_found`; a
+/// platform-init failure is internal.
+impl From<StatsError> for Status {
+    fn from(e: StatsError) -> Self {
+        let msg = e.to_string();
+        match e {
+            StatsError::Decode(_) => Status::invalid_argument(msg),
+            StatsError::Discovery { source, .. }
+                if source.kind() == std::io::ErrorKind::NotFound =>
+            {
+                Status::not_found(msg)
+            }
+            StatsError::Discovery { .. } => Status::internal(msg),
+        }
     }
 }
 
@@ -264,12 +283,12 @@ impl FlightService for CqliteFlightService {
     ) -> Result<Response<Self::DoActionStream>, Status> {
         let span = rpc_span("do_action", &request);
         let mut metrics = RpcMetrics::start("do_action");
-        span.in_scope(|| {
-            finish(
-                &mut metrics,
-                Err(Status::unimplemented("do_action is not supported")),
-            )
-        })
+        async {
+            let result = self.do_action_inner(request).await;
+            finish(&mut metrics, result)
+        }
+        .instrument(span)
+        .await
     }
 
     async fn list_actions(
@@ -279,10 +298,16 @@ impl FlightService for CqliteFlightService {
         let span = rpc_span("list_actions", &request);
         let mut metrics = RpcMetrics::start("list_actions");
         span.in_scope(|| {
-            finish(
-                &mut metrics,
-                Err(Status::unimplemented("list_actions is not supported")),
-            )
+            // Advertise the one action this server supports (issue #944).
+            let action = ActionType {
+                r#type: TABLE_STATS_ACTION.to_string(),
+                description: "Per-table aggregate statistics (Σ live_rows, Σ partition_count, \
+                              SSTable count) for aggregation-pushdown planning."
+                    .to_string(),
+            };
+            let stream: BoxStream<ActionType> =
+                Box::pin(futures::stream::once(async move { Ok(action) }));
+            finish(&mut metrics, Ok(Response::new(stream)))
         })
     }
 }
@@ -378,6 +403,47 @@ impl CqliteFlightService {
             .map(|res| res.map_err(|e| Status::internal(e.to_string())));
 
         Ok(Response::new(Box::pin(encoded)))
+    }
+
+    /// Body of [`FlightService::do_action`], run inside the RPC span (issue #944).
+    ///
+    /// The only supported action is [`TABLE_STATS_ACTION`]: its body is a
+    /// [`TableStatsRequest`] JSON, and the single emitted result is a
+    /// [`TableStatsResponse`] JSON carrying the AUTHORITATIVE per-table sums
+    /// (Σ live_rows, Σ partition_count, SSTable count) the Java connector uses to
+    /// drive its AUTOMATIC aggregation-pushdown gate. Any other action type is
+    /// `unimplemented`.
+    async fn do_action_inner(
+        &self,
+        request: Request<Action>,
+    ) -> Result<Response<<Self as FlightService>::DoActionStream>, Status> {
+        let action = request.into_inner();
+        if action.r#type != TABLE_STATS_ACTION {
+            return Err(Status::unimplemented(format!(
+                "unsupported action type: {}",
+                action.r#type
+            )));
+        }
+
+        let req = TableStatsRequest::from_bytes(&action.body)
+            .map_err(|e| Status::invalid_argument(format!("invalid table_stats request: {e}")))?;
+        let dir = DirSource::resolve(
+            &self.data_dir,
+            &req.keyspace,
+            &req.table,
+            req.snapshot.as_deref(),
+        )
+        .into_dir();
+
+        let stats = gather_table_stats(&dir).await?;
+        let body = stats
+            .to_bytes()
+            .map_err(|e| Status::internal(format!("encode table_stats response: {e}")))?;
+
+        let result = arrow_flight::Result { body: body.into() };
+        let stream: BoxStream<arrow_flight::Result> =
+            Box::pin(futures::stream::once(async move { Ok(result) }));
+        Ok(Response::new(stream))
     }
 }
 
@@ -563,6 +629,95 @@ mod tests {
             .await
             .expect_err("unknown predicate column must error");
         assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[test]
+    fn do_action_table_stats_returns_one_result_per_table() {
+        use crate::stats::{TableStatsRequest, TableStatsResponse, TABLE_STATS_ACTION};
+        let schema = simple_schema();
+        // Two write-engine SSTables. Their StatisticsWriter emits empty estimated
+        // histograms, so the authoritative counts assertion lives in the
+        // dataset-backed stats unit test; here we assert the action plumbing:
+        // one Result, decodable, with the SSTable count.
+        let (_temp, data_dir, _dir) = build_sstables(
+            &schema,
+            vec![
+                vec![write_row(1, "a", 1, 100), write_row(2, "b", 2, 100)],
+                vec![write_row(1, "a2", 3, 200), write_row(3, "c", 4, 200)],
+            ],
+        );
+        let svc = CqliteFlightService::new(data_dir, 1024);
+        let rt = tokio::runtime::Runtime::new().unwrap();
+
+        let resp = rt.block_on(async {
+            let req = TableStatsRequest {
+                keyspace: KS.into(),
+                table: TBL.into(),
+                snapshot: None,
+            };
+            let action = Action {
+                r#type: TABLE_STATS_ACTION.into(),
+                body: req.to_bytes().unwrap().into(),
+            };
+            let mut stream = svc
+                .do_action(Request::new(action))
+                .await
+                .expect("do_action")
+                .into_inner();
+            let first = stream.next().await.expect("one result").expect("ok");
+            assert!(stream.next().await.is_none(), "exactly one Result");
+            TableStatsResponse::from_bytes(&first.body).expect("decode")
+        });
+
+        assert_eq!(resp.sstable_count, 2);
+    }
+
+    #[tokio::test]
+    async fn do_action_unknown_type_is_unimplemented() {
+        let svc = CqliteFlightService::new(std::env::temp_dir(), 1024);
+        let action = Action {
+            r#type: "not_a_real_action".into(),
+            body: Vec::new().into(),
+        };
+        let err = match svc.do_action(Request::new(action)).await {
+            Ok(_) => panic!("unknown action must error"),
+            Err(e) => e,
+        };
+        assert_eq!(err.code(), tonic::Code::Unimplemented);
+    }
+
+    #[tokio::test]
+    async fn do_action_table_stats_missing_table_is_not_found() {
+        use crate::stats::{TableStatsRequest, TABLE_STATS_ACTION};
+        let svc = CqliteFlightService::new(std::env::temp_dir(), 1024);
+        let req = TableStatsRequest {
+            keyspace: "no_such_ks".into(),
+            table: "no_such_table".into(),
+            snapshot: None,
+        };
+        let action = Action {
+            r#type: TABLE_STATS_ACTION.into(),
+            body: req.to_bytes().unwrap().into(),
+        };
+        let err = match svc.do_action(Request::new(action)).await {
+            Ok(_) => panic!("missing table must error"),
+            Err(e) => e,
+        };
+        assert_eq!(err.code(), tonic::Code::NotFound, "got: {err:?}");
+    }
+
+    #[tokio::test]
+    async fn list_actions_advertises_table_stats() {
+        use crate::stats::TABLE_STATS_ACTION;
+        let svc = CqliteFlightService::new(std::env::temp_dir(), 1024);
+        let mut stream = svc
+            .list_actions(Request::new(Empty {}))
+            .await
+            .expect("list_actions")
+            .into_inner();
+        let action = stream.next().await.expect("one action").expect("ok");
+        assert_eq!(action.r#type, TABLE_STATS_ACTION);
+        assert!(stream.next().await.is_none(), "only one action advertised");
     }
 
     #[test]

--- a/cqlite-flight/src/stats.rs
+++ b/cqlite-flight/src/stats.rs
@@ -80,8 +80,12 @@ impl TableStatsRequest {
 
 /// Response payload for [`TABLE_STATS_ACTION`] (`Result.body` JSON).
 ///
-/// All three fields are AUTHORITATIVE per-SSTable sums (see the module docs).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+/// All three counts are AUTHORITATIVE per-SSTable sums (see the module docs).
+/// The `complete` flag tells the consumer whether those sums cover EVERY SSTable
+/// in the directory: partial sums are NOT authoritative (no-heuristics mandate,
+/// issue #28) and the consumer must fail closed to "no estimate" rather than feed
+/// a biased ratio to the AUTOMATIC pushdown gate.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct TableStatsResponse {
     /// Σ live (non-tombstone) rows across the table's SSTables. Upper bound on
@@ -92,6 +96,43 @@ pub struct TableStatsResponse {
     pub partition_count: u64,
     /// Number of SSTables whose `Statistics.db` was parsed into the sums above.
     pub sstable_count: u64,
+    /// `true` iff EVERY `*-Statistics.db` in the directory decoded into the sums
+    /// above. `false` if ANY file failed to read/decode (corrupt, below the
+    /// version floor, or an undecodable descriptor) — the counts are then an
+    /// explicit UNDER-count over only the SSTables that decoded, and the consumer
+    /// MUST treat the estimate as unknown rather than compute a (biased) ratio.
+    ///
+    /// Defaults to `false` on deserialization so a response from an older server
+    /// that predates this field is treated as incomplete (fail closed), never as
+    /// spuriously complete.
+    #[serde(default = "default_incomplete")]
+    pub complete: bool,
+    /// Number of `*-Statistics.db` files that failed to read/decode and so did
+    /// NOT contribute to the sums above (0 iff `complete`). Surfaced for
+    /// diagnostics; the boolean `complete` is the authoritative gate signal.
+    #[serde(default)]
+    pub skipped_sstables: u64,
+}
+
+/// serde default for [`TableStatsResponse::complete`]: an absent flag (older
+/// server) is treated as INCOMPLETE so the consumer fails closed to "no estimate".
+fn default_incomplete() -> bool {
+    false
+}
+
+impl Default for TableStatsResponse {
+    fn default() -> Self {
+        // An empty table (no SSTables at all) is trivially COMPLETE: there is
+        // nothing that could have been skipped. `gather_table_stats` flips
+        // `complete` to false only when it actually skips a file.
+        Self {
+            live_rows: 0,
+            partition_count: 0,
+            sstable_count: 0,
+            complete: true,
+            skipped_sstables: 0,
+        }
+    }
 }
 
 impl TableStatsResponse {
@@ -132,12 +173,16 @@ pub enum StatsError {
 ///
 /// A `Statistics.db` that fails to decode (corrupt, below the version floor, or a
 /// `total_rows` the gated walk could not reach) is handled conservatively: a hard
-/// decode error SKIPS the whole file (it does not contribute and is not counted),
-/// and a reachable-but-`None` `total_rows` contributes 0 rows while still counting
-/// its partitions. Both degrade the estimate toward "fewer rows" rather than
-/// aborting the gate. A missing table directory surfaces as
-/// [`StatsError::Discovery`]; an existing table with no SSTables yields an
-/// all-zero response.
+/// decode error SKIPS the whole file (it does not contribute and is not counted)
+/// AND flips the response's [`TableStatsResponse::complete`] flag to `false` (with
+/// `skipped_sstables` incremented). Partial sums are NOT authoritative (issue #28),
+/// so the consumer must fail closed to "no estimate" rather than feed a biased
+/// ratio to the AUTOMATIC pushdown gate — the flag is how it learns the totals are
+/// incomplete. A reachable-but-`None` `total_rows` is different: that file decoded,
+/// so it contributes 0 rows while still counting its partitions and stays
+/// `complete` (an honest under-count, never a guess). A missing table directory
+/// surfaces as [`StatsError::Discovery`]; an existing table with no SSTables yields
+/// an all-zero `complete=true` response (nothing was skipped).
 ///
 /// This is a SYNCHRONOUS, blocking function: it performs `std::fs::read_dir` /
 /// `std::fs::read` directly. Callers on an async runtime MUST invoke it inside
@@ -178,11 +223,16 @@ pub fn gather_table_stats(dir: &Path) -> Result<TableStatsResponse, StatsError> 
             }
             Err(e) => {
                 // Skip an unreadable/corrupt/below-floor Statistics.db rather than
-                // failing the whole gate. Logged at debug so the cause is recoverable.
+                // failing the whole gate, but mark the totals as INCOMPLETE: partial
+                // sums are not authoritative (issue #28), so the consumer must fail
+                // closed to "no estimate" instead of feeding a biased ratio to the
+                // AUTOMATIC gate. Logged at debug so the cause is recoverable.
+                response.complete = false;
+                response.skipped_sstables = response.skipped_sstables.saturating_add(1);
                 tracing::debug!(
                     path = %path.display(),
                     error = %e,
-                    "table_stats: skipping undecodable Statistics.db"
+                    "table_stats: skipping undecodable Statistics.db (marking incomplete)"
                 );
             }
         }
@@ -225,9 +275,25 @@ mod tests {
             live_rows: 42,
             partition_count: 7,
             sstable_count: 3,
+            complete: false,
+            skipped_sstables: 1,
+            ..Default::default()
         };
         let back = TableStatsResponse::from_bytes(&resp.to_bytes().unwrap()).unwrap();
         assert_eq!(resp, back);
+    }
+
+    #[test]
+    fn response_complete_defaults_false_when_flag_absent() {
+        // A response from an older server that predates the `complete` field must
+        // deserialize as INCOMPLETE (fail closed), never spuriously complete.
+        let resp = TableStatsResponse::from_bytes(
+            br#"{"live_rows":5,"partition_count":2,"sstable_count":1}"#,
+        )
+        .unwrap();
+        assert_eq!(resp.live_rows, 5);
+        assert!(!resp.complete, "absent complete flag must default to false");
+        assert_eq!(resp.skipped_sstables, 0);
     }
 
     #[test]
@@ -263,6 +329,61 @@ mod tests {
         let stats = gather_table_stats(&dir).expect("gather");
 
         assert_eq!(stats.sstable_count, 2, "two SSTables decoded");
+        assert!(stats.complete, "all SSTables decoded → complete");
+        assert_eq!(stats.skipped_sstables, 0);
+    }
+
+    /// A directory containing an UNDECODABLE `Statistics.db` must mark the response
+    /// INCOMPLETE (`complete=false`, `skipped_sstables` incremented) so the consumer
+    /// fails closed to "no estimate" instead of feeding a biased ratio to the gate
+    /// (no-heuristics mandate, issue #28). A sibling fully-decodable directory must
+    /// yield `complete=true`.
+    #[test]
+    fn gather_undecodable_statistics_marks_incomplete() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let dir = temp.path().join("data").join(KS).join(TBL);
+        std::fs::create_dir_all(&dir).unwrap();
+        // Garbage bytes under a *-Statistics.db name: read_table_counts cannot
+        // decode the STATS layout, so read_one_sstable_counts returns Err and the
+        // file is skipped + marks the response incomplete.
+        std::fs::write(
+            dir.join("nb-1-big-Statistics.db"),
+            b"not a real statistics file",
+        )
+        .unwrap();
+
+        let stats = gather_table_stats(&dir).expect("gather");
+
+        assert!(
+            !stats.complete,
+            "an undecodable Statistics.db must mark the response incomplete"
+        );
+        assert_eq!(
+            stats.skipped_sstables, 1,
+            "the corrupt file is counted as skipped"
+        );
+        assert_eq!(
+            stats.sstable_count, 0,
+            "the corrupt file did not contribute"
+        );
+    }
+
+    /// A fully-decodable directory yields `complete=true`. Uses the write-engine
+    /// build path (its StatisticsWriter still emits a decodable STATS component even
+    /// though the histogram is empty), confirming a clean decode is reported complete.
+    #[test]
+    fn gather_fully_decodable_directory_is_complete() {
+        let schema = simple_schema();
+        let (_temp, data_dir, _dir) = build_sstables(
+            &schema,
+            vec![vec![write_row(1, "a", 1, 100), write_row(2, "b", 2, 100)]],
+        );
+        let dir = DirSource::resolve(&data_dir, KS, TBL, None).into_dir();
+
+        let stats = gather_table_stats(&dir).expect("gather");
+
+        assert!(stats.complete, "every Statistics.db decoded → complete");
+        assert_eq!(stats.skipped_sstables, 0);
     }
 
     /// Authoritative decode against REAL Cassandra 5.0 `nb` fixtures (issue #944).
@@ -314,6 +435,8 @@ mod tests {
         assert_eq!(stats.sstable_count, 1, "one SSTable in the fixture");
         assert_eq!(stats.partition_count, 10, "sensor_data has 10 partitions");
         assert_eq!(stats.live_rows, 2000, "sensor_data has 2000 rows (wide)");
+        assert!(stats.complete, "real fixture decoded fully → complete");
+        assert_eq!(stats.skipped_sstables, 0);
     }
 
     #[test]

--- a/cqlite-flight/src/stats.rs
+++ b/cqlite-flight/src/stats.rs
@@ -171,18 +171,25 @@ pub enum StatsError {
 /// `partition_count` and `total_rows` to the running totals; `sstable_count`
 /// counts the files that decoded.
 ///
-/// A `Statistics.db` that fails to decode (corrupt, below the version floor, or a
-/// `total_rows` the gated walk could not reach) is handled conservatively: a hard
-/// decode error SKIPS the whole file (it does not contribute and is not counted)
-/// AND flips the response's [`TableStatsResponse::complete`] flag to `false` (with
-/// `skipped_sstables` incremented). Partial sums are NOT authoritative (issue #28),
-/// so the consumer must fail closed to "no estimate" rather than feed a biased
-/// ratio to the AUTOMATIC pushdown gate — the flag is how it learns the totals are
-/// incomplete. A reachable-but-`None` `total_rows` is different: that file decoded,
-/// so it contributes 0 rows while still counting its partitions and stays
-/// `complete` (an honest under-count, never a guess). A missing table directory
-/// surfaces as [`StatsError::Discovery`]; an existing table with no SSTables yields
-/// an all-zero `complete=true` response (nothing was skipped).
+/// A `Statistics.db` that fails to decode (corrupt, below the version floor) is
+/// handled conservatively: a hard decode error SKIPS the whole file (it does not
+/// contribute and is not counted) AND flips the response's
+/// [`TableStatsResponse::complete`] flag to `false` (with `skipped_sstables`
+/// incremented). Partial sums are NOT authoritative (issue #28), so the consumer
+/// must fail closed to "no estimate" rather than feed a biased ratio to the
+/// AUTOMATIC pushdown gate — the flag is how it learns the totals are incomplete.
+///
+/// A file that decodes but whose `total_rows` is `None` (the gated walk could not
+/// reach it — e.g. a clustered covered-Slice not modeled) ALSO marks the response
+/// incomplete (`complete=false`, `skipped_sstables` incremented). The
+/// authoritative-or-nothing principle (issue #28) means a missing row count cannot
+/// be reported as complete: `live_rows` is what the gate/optimizer divide by, so a
+/// silent 0-row contribution would under-count `live_rows` while still claiming to
+/// be authoritative. Its `partition_count` is still summed (the
+/// `estimatedPartitionSize` histogram is self-describing and authoritative), but the
+/// completeness flag must be `false` so the consumer fails closed. A missing table
+/// directory surfaces as [`StatsError::Discovery`]; an existing table with no
+/// SSTables yields an all-zero `complete=true` response (nothing was skipped).
 ///
 /// This is a SYNCHRONOUS, blocking function: it performs `std::fs::read_dir` /
 /// `std::fs::read` directly. Callers on an async runtime MUST invoke it inside
@@ -206,21 +213,7 @@ pub fn gather_table_stats(dir: &Path) -> Result<TableStatsResponse, StatsError> 
     let mut response = TableStatsResponse::default();
     for path in stats_paths {
         match read_one_sstable_counts(&path) {
-            Ok(counts) => {
-                // Saturating: independent per-SSTable counts; a real table never
-                // overflows u64, but never wrap into a tiny estimate that would
-                // wrongly let a high-cardinality GROUP BY push.
-                response.partition_count = response
-                    .partition_count
-                    .saturating_add(counts.partition_count);
-                // total_rows is None when the gated walk could not reach it
-                // (clustered covered-Slice not modeled). Contribute 0 rather than
-                // guess; partitions still count.
-                response.live_rows = response
-                    .live_rows
-                    .saturating_add(counts.total_rows.unwrap_or(0));
-                response.sstable_count = response.sstable_count.saturating_add(1);
-            }
+            Ok(counts) => fold_counts(&mut response, &path, counts),
             Err(e) => {
                 // Skip an unreadable/corrupt/below-floor Statistics.db rather than
                 // failing the whole gate, but mark the totals as INCOMPLETE: partial
@@ -239,6 +232,45 @@ pub fn gather_table_stats(dir: &Path) -> Result<TableStatsResponse, StatsError> 
     }
 
     Ok(response)
+}
+
+/// Fold one decoded SSTable's [`TableCounts`] into the running `response`.
+///
+/// `partition_count` (from the self-describing `estimatedPartitionSize` histogram)
+/// is always authoritative and is summed unconditionally. `total_rows`, however, is
+/// authoritative-or-nothing: when it is `None` (the gated walk could not reach the
+/// `totalRows` field — e.g. a clustered covered-Slice not modeled) the response is
+/// marked INCOMPLETE and the file counted toward `skipped_sstables`, rather than
+/// silently contributing 0 live rows while still claiming `complete`. `live_rows` is
+/// the denominator the gate/optimizer divide by, so an honest 0 here would under-
+/// count and mislead the consumer — issue #28's authoritative-or-nothing rule (this
+/// REVERSES the earlier choice to stay complete on `None`). Only a file with a known
+/// row count contributes to `live_rows` and `sstable_count`.
+fn fold_counts(
+    response: &mut TableStatsResponse,
+    path: &Path,
+    counts: cqlite_core::parser::repair_metadata::TableCounts,
+) {
+    // Saturating: independent per-SSTable counts; a real table never overflows u64,
+    // but never wrap into a tiny estimate that would wrongly let a high-cardinality
+    // GROUP BY push.
+    response.partition_count = response
+        .partition_count
+        .saturating_add(counts.partition_count);
+    match counts.total_rows {
+        Some(rows) => {
+            response.live_rows = response.live_rows.saturating_add(rows);
+            response.sstable_count = response.sstable_count.saturating_add(1);
+        }
+        None => {
+            response.complete = false;
+            response.skipped_sstables = response.skipped_sstables.saturating_add(1);
+            tracing::debug!(
+                path = %path.display(),
+                "table_stats: Statistics.db decoded but total_rows is None (marking incomplete)"
+            );
+        }
+    }
 }
 
 /// Decode one `*-Statistics.db` file's authoritative counts. Derives the
@@ -384,6 +416,96 @@ mod tests {
 
         assert!(stats.complete, "every Statistics.db decoded → complete");
         assert_eq!(stats.skipped_sstables, 0);
+    }
+
+    /// A directory where one SSTable's `total_rows` is `None` (but a sibling has a
+    /// known row count) must report `complete=false` (issue #944, #28: a missing row
+    /// count is authoritative-or-nothing — `live_rows` is what the gate/optimizer
+    /// divide by, so a silent 0 contribution must not be reported as complete). The
+    /// known-rows SSTable still contributes its `live_rows`/`sstable_count`, and both
+    /// SSTables contribute their authoritative `partition_count`; the None one is
+    /// counted toward `skipped_sstables`. This exercises [`fold_counts`] directly
+    /// (the per-file decode→fold seam) so the rule is tested without crafting a STATS
+    /// file whose descriptor parses but whose gated walk cannot reach `totalRows`.
+    #[test]
+    fn fold_none_total_rows_marks_incomplete() {
+        use cqlite_core::parser::repair_metadata::TableCounts;
+        let dummy = std::path::Path::new("nb-2-big-Statistics.db");
+
+        let mut response = TableStatsResponse::default();
+        // SSTable A: fully decoded, 5 rows over 2 partitions.
+        fold_counts(
+            &mut response,
+            std::path::Path::new("nb-1-big-Statistics.db"),
+            TableCounts {
+                partition_count: 2,
+                total_rows: Some(5),
+            },
+        );
+        // SSTable B: histogram decoded (3 partitions) but the gated walk could not
+        // reach totalRows → None.
+        fold_counts(
+            &mut response,
+            dummy,
+            TableCounts {
+                partition_count: 3,
+                total_rows: None,
+            },
+        );
+
+        assert!(
+            !response.complete,
+            "any SSTable with total_rows=None must mark the response incomplete"
+        );
+        assert_eq!(
+            response.live_rows, 5,
+            "only the known-rows SSTable contributes live_rows"
+        );
+        assert_eq!(
+            response.partition_count, 5,
+            "partition_count is authoritative for BOTH SSTables (2 + 3)"
+        );
+        assert_eq!(
+            response.sstable_count, 1,
+            "only the SSTable with a known row count is counted as contributing"
+        );
+        assert_eq!(
+            response.skipped_sstables, 1,
+            "the None-total_rows SSTable is counted as skipped"
+        );
+    }
+
+    /// The all-rows-present case stays `complete=true`: two SSTables, each with a
+    /// known `total_rows`, fold to a complete response with summed counts.
+    #[test]
+    fn fold_all_rows_present_stays_complete() {
+        use cqlite_core::parser::repair_metadata::TableCounts;
+        let mut response = TableStatsResponse::default();
+        fold_counts(
+            &mut response,
+            std::path::Path::new("nb-1-big-Statistics.db"),
+            TableCounts {
+                partition_count: 2,
+                total_rows: Some(5),
+            },
+        );
+        fold_counts(
+            &mut response,
+            std::path::Path::new("nb-2-big-Statistics.db"),
+            TableCounts {
+                partition_count: 3,
+                total_rows: Some(7),
+            },
+        );
+
+        assert!(
+            response.complete,
+            "all SSTables have a known row count → complete"
+        );
+        assert_eq!(response.live_rows, 12);
+        assert_eq!(response.partition_count, 5);
+        assert_eq!(response.sstable_count, 2);
+        assert_eq!(response.skipped_sstables, 0);
     }
 
     /// Authoritative decode against REAL Cassandra 5.0 `nb` fixtures (issue #944).

--- a/cqlite-flight/src/stats.rs
+++ b/cqlite-flight/src/stats.rs
@@ -262,7 +262,33 @@ pub fn gather_table_stats(dir: &Path) -> Result<TableStatsResponse, StatsError> 
         }
     }
 
+    enforce_count_consistency(&mut response);
     Ok(response)
+}
+
+/// Final consistency check after folding every SSTable: a response with
+/// `live_rows > 0` but `partition_count == 0` is internally contradictory — a
+/// table with live rows must have at least one partition. This happens today
+/// because CQLite's own write-engine emits an EMPTY `estimatedPartitionSize`
+/// histogram for non-empty SSTables (so `partition_count` decodes as 0 while
+/// `total_rows` is positive); the deeper write-engine fix is tracked as issue
+/// #1327 and is out of scope here.
+///
+/// Such totals are NOT authoritative, so we fail closed (consistent with the
+/// existing completeness model): set `complete = false`. The consumer then
+/// falls back to "no estimate" → a safe push decision, rather than feeding the
+/// Java AUTOMATIC gate an artificially low partition-key group ratio
+/// (`min(partitions, rows) / rows` ≈ 0) that could wrongly PUSH a
+/// high-cardinality grouped aggregation it should decline (issue #944).
+fn enforce_count_consistency(response: &mut TableStatsResponse) {
+    if response.live_rows > 0 && response.partition_count == 0 {
+        response.complete = false;
+        tracing::debug!(
+            live_rows = response.live_rows,
+            "table_stats: live_rows > 0 but partition_count == 0 (contradictory \
+             histogram, marking incomplete; write-engine fix is issue #1327)"
+        );
+    }
 }
 
 /// Derive the sibling `*-Statistics.db` path for an SSTable's `*-Data.db` path by
@@ -428,9 +454,12 @@ mod tests {
     //
     // The write-engine StatisticsWriter emits EMPTY estimated histograms, so the
     // histogram-derived partition_count is 0 for write-engine SSTables (real
-    // Cassandra files carry a populated histogram — see the dataset-backed test).
-    // This test therefore only asserts the per-SSTable COUNT and that gather
-    // succeeds over a multi-SSTable directory.
+    // Cassandra files carry a populated histogram — see the dataset-backed test;
+    // the write-engine fix is issue #1327). With positive rows but zero
+    // partitions the totals are contradictory, so enforce_count_consistency
+    // fails the response closed (complete=false). This test asserts the
+    // per-SSTable COUNT, that gather succeeds over a multi-SSTable directory, and
+    // that the contradiction is reported incomplete.
     #[test]
     fn gather_counts_sstables_in_directory() {
         let schema = simple_schema();
@@ -447,8 +476,12 @@ mod tests {
         let stats = gather_table_stats(&dir).expect("gather");
 
         assert_eq!(stats.sstable_count, 2, "two SSTables decoded");
-        assert!(stats.complete, "all SSTables decoded → complete");
-        assert_eq!(stats.skipped_sstables, 0);
+        assert!(
+            !stats.complete,
+            "write-engine empty histogram → rows>0 but partitions==0 → fail closed (issue #1327)"
+        );
+        assert_eq!(stats.partition_count, 0);
+        assert!(stats.live_rows > 0);
     }
 
     /// A directory containing an UNDECODABLE `Statistics.db` must mark the response
@@ -517,9 +550,14 @@ mod tests {
         );
     }
 
-    /// A fully-decodable directory yields `complete=true`. Uses the write-engine
-    /// build path (its StatisticsWriter still emits a decodable STATS component even
-    /// though the histogram is empty), confirming a clean decode is reported complete.
+    /// Every `Statistics.db` decodes cleanly (no skipped SSTables). Uses the
+    /// write-engine build path, whose StatisticsWriter emits a decodable STATS
+    /// component but with an EMPTY partition histogram (issue #1327), so
+    /// partition_count is 0 while live_rows is positive. That contradiction makes
+    /// enforce_count_consistency fail the response closed (complete=false) even
+    /// though no SSTable was skipped — exactly the safety net this fix adds. (Real
+    /// Cassandra fixtures, which carry a populated histogram, are asserted complete
+    /// in `gather_real_cassandra_fixture_authoritative_counts`.)
     #[test]
     fn gather_fully_decodable_directory_is_complete() {
         let schema = simple_schema();
@@ -531,8 +569,15 @@ mod tests {
 
         let stats = gather_table_stats(&dir).expect("gather");
 
-        assert!(stats.complete, "every Statistics.db decoded → complete");
-        assert_eq!(stats.skipped_sstables, 0);
+        // No decode failures, but the empty-histogram contradiction (rows>0,
+        // partitions==0) forces complete=false (fail closed).
+        assert_eq!(stats.skipped_sstables, 0, "every Statistics.db decoded");
+        assert!(
+            !stats.complete,
+            "write-engine empty histogram → contradictory totals → fail closed (issue #1327)"
+        );
+        assert_eq!(stats.partition_count, 0);
+        assert!(stats.live_rows > 0);
     }
 
     /// A directory where one SSTable's `total_rows` is `None` (but a sibling has a
@@ -623,6 +668,67 @@ mod tests {
         assert_eq!(response.partition_count, 5);
         assert_eq!(response.sstable_count, 2);
         assert_eq!(response.skipped_sstables, 0);
+    }
+
+    /// A folded response with `live_rows > 0` but `partition_count == 0` is
+    /// internally contradictory (a table with live rows must have at least one
+    /// partition). This is exactly what CQLite's write-engine produces today via
+    /// an empty `estimatedPartitionSize` histogram on a non-empty SSTable
+    /// (issue #1327). `enforce_count_consistency` must fail closed: such totals
+    /// are not authoritative, so `complete=false` (issue #944) — the consumer
+    /// then falls back to "no estimate" instead of feeding the Java AUTOMATIC
+    /// gate an artificially low (≈0) partition-key group ratio.
+    #[test]
+    fn rows_without_partitions_marks_incomplete() {
+        use cqlite_core::parser::repair_metadata::TableCounts;
+        let mut response = TableStatsResponse::default();
+        // SSTable with a known row count but an empty partition histogram
+        // (partition_count == 0): this folds as "complete" by itself...
+        fold_counts(
+            &mut response,
+            std::path::Path::new("nb-1-big-Statistics.db"),
+            TableCounts {
+                partition_count: 0,
+                total_rows: Some(5),
+            },
+        );
+        assert!(
+            response.complete,
+            "fold alone leaves complete=true (the contradiction is caught at the \
+             aggregate consistency check, not per-fold)"
+        );
+
+        // ...until the final consistency check rejects the contradiction.
+        enforce_count_consistency(&mut response);
+        assert!(
+            !response.complete,
+            "live_rows > 0 with partition_count == 0 must fail closed (complete=false)"
+        );
+        assert_eq!(response.live_rows, 5, "counts themselves are untouched");
+        assert_eq!(response.partition_count, 0);
+    }
+
+    /// The normal case (`rows > 0 && partitions > 0`) stays `complete=true`
+    /// through the consistency check — it only fires on the contradiction.
+    #[test]
+    fn rows_with_partitions_stays_complete() {
+        use cqlite_core::parser::repair_metadata::TableCounts;
+        let mut response = TableStatsResponse::default();
+        fold_counts(
+            &mut response,
+            std::path::Path::new("nb-1-big-Statistics.db"),
+            TableCounts {
+                partition_count: 3,
+                total_rows: Some(5),
+            },
+        );
+        enforce_count_consistency(&mut response);
+        assert!(
+            response.complete,
+            "rows > 0 && partitions > 0 is consistent → stays complete"
+        );
+        assert_eq!(response.live_rows, 5);
+        assert_eq!(response.partition_count, 3);
     }
 
     /// Authoritative decode against REAL Cassandra 5.0 `nb` fixtures (issue #944).

--- a/cqlite-flight/src/stats.rs
+++ b/cqlite-flight/src/stats.rs
@@ -1,0 +1,339 @@
+//! Per-table aggregate statistics surfaced over Flight (`DoAction`).
+//!
+//! The Java Trino connector drives its AUTOMATIC aggregation-pushdown gate
+//! (issue #944, follow-up to #893/#937/#841) from a per-table row-count /
+//! partition-count estimate. This module computes those numbers by summing the
+//! AUTHORITATIVE per-SSTable statistics that Cassandra already records in each
+//! `Statistics.db` file, and serialises them as the request/response payloads of
+//! a `DoAction("table_stats")` Flight call.
+//!
+//! ## Authoritative vs derived (no-heuristics mandate, issue #28)
+//!
+//! Everything this module produces is AUTHORITATIVE — decoded straight from the
+//! STATS component of each `Statistics.db` via
+//! [`cqlite_core::parser::repair_metadata::read_table_counts`], which walks the
+//! exact cassandra-5.0.0 `StatsMetadata.StatsMetadataSerializer.serialize` layout
+//! (no byte-pattern guessing):
+//!
+//! - `partition_count` = Σ per-SSTable `TableCounts::partition_count`. Each
+//!   SSTable's partition count is the sum of its `estimatedPartitionSize`
+//!   `EstimatedHistogram` bucket counts (one observation per partition) — the same
+//!   number `SSTableReader.getEstimatedPartitionSize().count()` reports.
+//! - `live_rows` = Σ per-SSTable `TableCounts::total_rows` (the STATS `totalRows`
+//!   field). This is the SSTable's total row count; pre-compaction it is an upper
+//!   bound on the table's live rows. `read_table_counts` returns `total_rows` only
+//!   when it can traverse the version-gated min/max block; an SSTable whose
+//!   `total_rows` could not be reached contributes 0 (honest under-count, never a
+//!   guess).
+//! - `sstable_count` = number of `*-Statistics.db` files successfully decoded.
+//!
+//! Because these are per-SSTable sums they are an UPPER BOUND on the table's true
+//! distinct partition / live-row counts (the same partition can appear in several
+//! SSTables before compaction). That is exactly what the gate wants: an upper
+//! bound on distinct groups never under-counts, so it never wrongly pushes a
+//! genuinely-high-cardinality GROUP BY.
+//!
+//! The DERIVED step — mapping a grouping shape to an estimated group count and a
+//! ratio — lives entirely in the Java connector (it owns the DDL-driven mapping).
+//! We deliberately do NOT surface per-`ColumnStatistics::cardinality`: Cassandra
+//! 5.0 does not store a reliable per-regular-column NDV, so trusting it would be a
+//! heuristic. This is a partition-key-vs-row-level estimate, not a true NDV gate.
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use cqlite_core::parser::repair_metadata::read_table_counts;
+use cqlite_core::storage::sstable::version_gate::VersionGates;
+use cqlite_core::Error as CoreError;
+
+/// Wire name of the Flight action that returns per-table aggregate statistics.
+pub const TABLE_STATS_ACTION: &str = "table_stats";
+
+/// Request payload for [`TABLE_STATS_ACTION`] (`Action.body` JSON).
+///
+/// Intentionally free of any `cqlite-core` types so the Java connector can emit
+/// it as plain JSON, mirroring [`crate::ticket::FlightTicket`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct TableStatsRequest {
+    /// Keyspace name.
+    pub keyspace: String,
+    /// Table name.
+    pub table: String,
+    /// Sidecar snapshot to read; `None`/absent reads the live data dir.
+    #[serde(default)]
+    pub snapshot: Option<String>,
+}
+
+impl TableStatsRequest {
+    /// Parse a request from its on-the-wire JSON bytes.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, serde_json::Error> {
+        serde_json::from_slice(bytes)
+    }
+
+    /// Serialise this request to its on-the-wire JSON bytes.
+    pub fn to_bytes(&self) -> Result<Vec<u8>, serde_json::Error> {
+        serde_json::to_vec(self)
+    }
+}
+
+/// Response payload for [`TABLE_STATS_ACTION`] (`Result.body` JSON).
+///
+/// All three fields are AUTHORITATIVE per-SSTable sums (see the module docs).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[non_exhaustive]
+pub struct TableStatsResponse {
+    /// Σ live (non-tombstone) rows across the table's SSTables. Upper bound on
+    /// the table's true live-row count (pre-compaction overlap).
+    pub live_rows: u64,
+    /// Σ estimated partitions across the table's SSTables. Upper bound on the
+    /// table's true distinct-partition count.
+    pub partition_count: u64,
+    /// Number of SSTables whose `Statistics.db` was parsed into the sums above.
+    pub sstable_count: u64,
+}
+
+impl TableStatsResponse {
+    /// Parse a response from its on-the-wire JSON bytes.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, serde_json::Error> {
+        serde_json::from_slice(bytes)
+    }
+
+    /// Serialise this response to its on-the-wire JSON bytes.
+    pub fn to_bytes(&self) -> Result<Vec<u8>, serde_json::Error> {
+        serde_json::to_vec(self)
+    }
+}
+
+/// Errors produced while gathering per-table statistics.
+#[derive(Debug, thiserror::Error)]
+pub enum StatsError {
+    /// The action body was not valid JSON for [`TableStatsRequest`].
+    #[error("invalid table_stats request: {0}")]
+    Decode(#[from] serde_json::Error),
+    /// The resolved table directory could not be listed.
+    #[error("failed to list SSTables in {path}: {source}")]
+    Discovery {
+        /// Directory that could not be read.
+        path: std::path::PathBuf,
+        /// Underlying I/O error.
+        source: std::io::Error,
+    },
+}
+
+/// Sum the AUTHORITATIVE per-SSTable STATS counts for one table directory.
+///
+/// `dir` is the already-resolved SSTable directory (live data dir or a snapshot
+/// directory — see [`crate::producer::DirSource::resolve`]). For each
+/// `*-Statistics.db` file under `dir`, decode its [`read_table_counts`] and add
+/// `partition_count` and `total_rows` to the running totals; `sstable_count`
+/// counts the files that decoded.
+///
+/// A `Statistics.db` that fails to decode (corrupt, below the version floor, or a
+/// `total_rows` the gated walk could not reach) is handled conservatively: a hard
+/// decode error SKIPS the whole file (it does not contribute and is not counted),
+/// and a reachable-but-`None` `total_rows` contributes 0 rows while still counting
+/// its partitions. Both degrade the estimate toward "fewer rows" rather than
+/// aborting the gate. A missing table directory surfaces as
+/// [`StatsError::Discovery`]; an existing table with no SSTables yields an
+/// all-zero response.
+pub async fn gather_table_stats(dir: &Path) -> Result<TableStatsResponse, StatsError> {
+    let entries = std::fs::read_dir(dir).map_err(|source| StatsError::Discovery {
+        path: dir.to_path_buf(),
+        source,
+    })?;
+
+    let stats_paths: Vec<std::path::PathBuf> = entries
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.ends_with("-Statistics.db"))
+        })
+        .collect();
+
+    let mut response = TableStatsResponse::default();
+    for path in stats_paths {
+        match read_one_sstable_counts(&path) {
+            Ok(counts) => {
+                // Saturating: independent per-SSTable counts; a real table never
+                // overflows u64, but never wrap into a tiny estimate that would
+                // wrongly let a high-cardinality GROUP BY push.
+                response.partition_count = response
+                    .partition_count
+                    .saturating_add(counts.partition_count);
+                // total_rows is None when the gated walk could not reach it
+                // (clustered covered-Slice not modeled). Contribute 0 rather than
+                // guess; partitions still count.
+                response.live_rows = response
+                    .live_rows
+                    .saturating_add(counts.total_rows.unwrap_or(0));
+                response.sstable_count = response.sstable_count.saturating_add(1);
+            }
+            Err(e) => {
+                // Skip an unreadable/corrupt/below-floor Statistics.db rather than
+                // failing the whole gate. Logged at debug so the cause is recoverable.
+                tracing::debug!(
+                    path = %path.display(),
+                    error = %e,
+                    "table_stats: skipping undecodable Statistics.db"
+                );
+            }
+        }
+    }
+
+    Ok(response)
+}
+
+/// Decode one `*-Statistics.db` file's authoritative counts. Derives the
+/// [`VersionGates`] from the filename (so `total_rows` can be read on the gated
+/// walk) and reads the whole file into memory (Statistics.db files are small).
+fn read_one_sstable_counts(
+    path: &Path,
+) -> Result<cqlite_core::parser::repair_metadata::TableCounts, CoreError> {
+    // Gates from the filename (na+ floor enforced by from_path); on an
+    // unparseable descriptor fall back to None — partition_count is still
+    // decodable self-describingly, total_rows is then reported as None.
+    let gates = VersionGates::from_path(path).ok();
+    let bytes = std::fs::read(path)?;
+    read_table_counts(&bytes, gates.as_ref())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::producer::DirSource;
+    use crate::testutil::{build_sstables, simple_schema, write_row, KS, TBL};
+
+    #[test]
+    fn request_response_round_trip() {
+        let req = TableStatsRequest {
+            keyspace: "ks".into(),
+            table: "tbl".into(),
+            snapshot: Some("snap1".into()),
+        };
+        let back = TableStatsRequest::from_bytes(&req.to_bytes().unwrap()).unwrap();
+        assert_eq!(req, back);
+
+        let resp = TableStatsResponse {
+            live_rows: 42,
+            partition_count: 7,
+            sstable_count: 3,
+        };
+        let back = TableStatsResponse::from_bytes(&resp.to_bytes().unwrap()).unwrap();
+        assert_eq!(resp, back);
+    }
+
+    #[test]
+    fn request_snapshot_defaults_to_none() {
+        // The Java connector omits `snapshot` for a live read; #[serde(default)]
+        // must accept that.
+        let req = TableStatsRequest::from_bytes(br#"{"keyspace":"ks","table":"t"}"#).unwrap();
+        assert_eq!(req.snapshot, None);
+    }
+
+    // `build_sstables` drives its own runtime to flush; gather_table_stats is
+    // async, so build first then enter a fresh runtime to gather.
+    //
+    // The write-engine StatisticsWriter emits EMPTY estimated histograms, so the
+    // histogram-derived partition_count is 0 for write-engine SSTables (real
+    // Cassandra files carry a populated histogram — see the dataset-backed test).
+    // This test therefore only asserts the per-SSTable COUNT and that gather
+    // succeeds over a multi-SSTable directory.
+    #[test]
+    fn gather_counts_sstables_in_directory() {
+        let schema = simple_schema();
+        let (_temp, data_dir, _dir) = build_sstables(
+            &schema,
+            vec![
+                vec![write_row(1, "a", 1, 100), write_row(2, "b", 2, 100)],
+                vec![write_row(1, "a2", 3, 200), write_row(3, "c", 4, 200)],
+            ],
+        );
+        // Resolve the SSTable dir exactly as the service does, then gather.
+        let dir = DirSource::resolve(&data_dir, KS, TBL, None).into_dir();
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let stats = rt.block_on(gather_table_stats(&dir)).expect("gather");
+
+        assert_eq!(stats.sstable_count, 2, "two SSTables decoded");
+    }
+
+    /// Authoritative decode against REAL Cassandra 5.0 `nb` fixtures (issue #944).
+    /// The estimatedPartitionSize histogram and `totalRows` come straight from the
+    /// STATS component, so the per-table sums must equal the known ground truth.
+    /// Skips when the binary dataset is not present (clean checkout / CI without
+    /// fetched Data.db), but FAILS if present-but-wrong.
+    #[test]
+    fn gather_real_cassandra_fixture_authoritative_counts() {
+        let Some(root) = std::env::var_os("CQLITE_DATASETS_ROOT") else {
+            eprintln!("CQLITE_DATASETS_ROOT unset; skipping real-fixture stats test");
+            return;
+        };
+        // sensor_data is a WIDE table: 10 partitions, 2000 rows — proves the gated
+        // walk reaches totalRows past the clustered min/max block, and that rows
+        // != partitions (the case the gate must distinguish).
+        let base = std::path::Path::new(&root)
+            .join("sstables")
+            .join("test_timeseries");
+        let dir = match std::fs::read_dir(&base) {
+            Ok(entries) => entries.flatten().map(|e| e.path()).find(|p| {
+                p.file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.starts_with("sensor_data-"))
+            }),
+            Err(_) => None,
+        };
+        let Some(dir) = dir else {
+            eprintln!("sensor_data fixture absent; skipping real-fixture stats test");
+            return;
+        };
+        // Only assert when the Data.db binaries were actually fetched.
+        let has_stats = std::fs::read_dir(&dir)
+            .map(|es| {
+                es.flatten().any(|e| {
+                    e.file_name()
+                        .to_str()
+                        .is_some_and(|n| n.ends_with("-Statistics.db"))
+                })
+            })
+            .unwrap_or(false);
+        if !has_stats {
+            eprintln!("sensor_data Statistics.db absent; skipping");
+            return;
+        }
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let stats = rt.block_on(gather_table_stats(&dir)).expect("gather");
+
+        assert_eq!(stats.sstable_count, 1, "one SSTable in the fixture");
+        assert_eq!(stats.partition_count, 10, "sensor_data has 10 partitions");
+        assert_eq!(stats.live_rows, 2000, "sensor_data has 2000 rows (wide)");
+    }
+
+    #[test]
+    fn gather_empty_table_is_all_zero() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let dir = temp.path().join("data").join(KS).join(TBL);
+        std::fs::create_dir_all(&dir).unwrap();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let stats = rt.block_on(gather_table_stats(&dir)).expect("gather");
+        assert_eq!(
+            stats,
+            TableStatsResponse::default(),
+            "no SSTables → all-zero stats"
+        );
+    }
+
+    #[test]
+    fn gather_missing_dir_is_discovery_error() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let missing = temp.path().join("does").join("not").join("exist");
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let err = rt
+            .block_on(gather_table_stats(&missing))
+            .expect_err("missing dir must error");
+        assert!(matches!(err, StatsError::Discovery { .. }), "got {err:?}");
+    }
+}

--- a/cqlite-flight/src/stats.rs
+++ b/cqlite-flight/src/stats.rs
@@ -138,7 +138,12 @@ pub enum StatsError {
 /// aborting the gate. A missing table directory surfaces as
 /// [`StatsError::Discovery`]; an existing table with no SSTables yields an
 /// all-zero response.
-pub async fn gather_table_stats(dir: &Path) -> Result<TableStatsResponse, StatsError> {
+///
+/// This is a SYNCHRONOUS, blocking function: it performs `std::fs::read_dir` /
+/// `std::fs::read` directly. Callers on an async runtime MUST invoke it inside
+/// [`tokio::task::spawn_blocking`] so the blocking I/O cannot stall the reactor
+/// (see [`crate::service`] `do_action_inner`, matching the `do_get` merge offload).
+pub fn gather_table_stats(dir: &Path) -> Result<TableStatsResponse, StatsError> {
     let entries = std::fs::read_dir(dir).map_err(|source| StatsError::Discovery {
         path: dir.to_path_buf(),
         source,
@@ -234,7 +239,8 @@ mod tests {
     }
 
     // `build_sstables` drives its own runtime to flush; gather_table_stats is
-    // async, so build first then enter a fresh runtime to gather.
+    // synchronous (callers offload it via spawn_blocking), so build first then
+    // gather directly.
     //
     // The write-engine StatisticsWriter emits EMPTY estimated histograms, so the
     // histogram-derived partition_count is 0 for write-engine SSTables (real
@@ -254,8 +260,7 @@ mod tests {
         // Resolve the SSTable dir exactly as the service does, then gather.
         let dir = DirSource::resolve(&data_dir, KS, TBL, None).into_dir();
 
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        let stats = rt.block_on(gather_table_stats(&dir)).expect("gather");
+        let stats = gather_table_stats(&dir).expect("gather");
 
         assert_eq!(stats.sstable_count, 2, "two SSTables decoded");
     }
@@ -304,8 +309,7 @@ mod tests {
             return;
         }
 
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        let stats = rt.block_on(gather_table_stats(&dir)).expect("gather");
+        let stats = gather_table_stats(&dir).expect("gather");
 
         assert_eq!(stats.sstable_count, 1, "one SSTable in the fixture");
         assert_eq!(stats.partition_count, 10, "sensor_data has 10 partitions");
@@ -317,8 +321,7 @@ mod tests {
         let temp = tempfile::TempDir::new().unwrap();
         let dir = temp.path().join("data").join(KS).join(TBL);
         std::fs::create_dir_all(&dir).unwrap();
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        let stats = rt.block_on(gather_table_stats(&dir)).expect("gather");
+        let stats = gather_table_stats(&dir).expect("gather");
         assert_eq!(
             stats,
             TableStatsResponse::default(),
@@ -330,10 +333,7 @@ mod tests {
     fn gather_missing_dir_is_discovery_error() {
         let temp = tempfile::TempDir::new().unwrap();
         let missing = temp.path().join("does").join("not").join("exist");
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        let err = rt
-            .block_on(gather_table_stats(&missing))
-            .expect_err("missing dir must error");
+        let err = gather_table_stats(&missing).expect_err("missing dir must error");
         assert!(matches!(err, StatsError::Discovery { .. }), "got {err:?}");
     }
 }

--- a/cqlite-flight/src/stats.rs
+++ b/cqlite-flight/src/stats.rs
@@ -201,16 +201,16 @@ pub fn gather_table_stats(dir: &Path) -> Result<TableStatsResponse, StatsError> 
         source,
     })?;
 
-    let stats_paths: Vec<std::path::PathBuf> = entries
-        .filter_map(|e| e.ok().map(|e| e.path()))
-        .filter(|p| {
-            p.file_name()
-                .and_then(|n| n.to_str())
-                .is_some_and(|n| n.ends_with("-Statistics.db"))
-        })
-        .collect();
-
     let mut response = TableStatsResponse::default();
+
+    // Enumerate directory entries WITHOUT silently dropping iteration errors. A
+    // `read_dir` entry that fails to yield (e.g. a transient I/O error partway
+    // through) means we may NOT have seen every SSTable, so the totals cannot be
+    // authoritative: taint completeness (consistent with the missing-`total_rows`
+    // and undecodable-Statistics.db paths below) rather than claiming complete totals
+    // over files we could not enumerate (issue #944, #28).
+    let stats_paths = collect_statistics_paths(entries, &mut response);
+
     for path in stats_paths {
         match read_one_sstable_counts(&path) {
             Ok(counts) => fold_counts(&mut response, &path, counts),
@@ -232,6 +232,51 @@ pub fn gather_table_stats(dir: &Path) -> Result<TableStatsResponse, StatsError> 
     }
 
     Ok(response)
+}
+
+/// Collect the `*-Statistics.db` paths from a `read_dir` iterator, treating any
+/// entry-iteration error as INCOMPLETE rather than silently discarding it.
+///
+/// `read_dir` yields `io::Result<DirEntry>`; an `Err` element means an entry could
+/// not be read (e.g. a transient FS error partway through enumeration), so the
+/// directory listing is NOT known to be exhaustive. Each such error flips
+/// `response.complete` to `false` and bumps `skipped_sstables` — the consumer then
+/// fails closed to "no estimate" instead of reporting authoritative totals over a
+/// directory it could not fully enumerate (issue #944, #28). Successful entries are
+/// filtered to `*-Statistics.db` paths as before.
+fn collect_statistics_paths<I>(
+    entries: I,
+    response: &mut TableStatsResponse,
+) -> Vec<std::path::PathBuf>
+where
+    I: IntoIterator<Item = std::io::Result<std::fs::DirEntry>>,
+{
+    let mut paths = Vec::new();
+    for entry in entries {
+        match entry {
+            Ok(e) => {
+                let path = e.path();
+                if path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.ends_with("-Statistics.db"))
+                {
+                    paths.push(path);
+                }
+            }
+            Err(e) => {
+                // An unreadable directory entry: the listing is not known to be
+                // complete, so taint the totals rather than dropping the error.
+                response.complete = false;
+                response.skipped_sstables = response.skipped_sstables.saturating_add(1);
+                tracing::debug!(
+                    error = %e,
+                    "table_stats: read_dir entry iteration error (marking incomplete)"
+                );
+            }
+        }
+    }
+    paths
 }
 
 /// Fold one decoded SSTable's [`TableCounts`] into the running `response`.
@@ -580,5 +625,43 @@ mod tests {
         let missing = temp.path().join("does").join("not").join("exist");
         let err = gather_table_stats(&missing).expect_err("missing dir must error");
         assert!(matches!(err, StatsError::Discovery { .. }), "got {err:?}");
+    }
+
+    #[test]
+    fn read_dir_entry_error_taints_completeness() {
+        // A `read_dir` iterator that yields an Err entry partway through must NOT be
+        // silently dropped: the directory listing is not known to be exhaustive, so
+        // the totals are tainted INCOMPLETE (issue #944, #28). We drive the helper
+        // directly with a synthetic iterator since provoking a real entry-iteration
+        // error from the OS is not portable.
+        let entries: Vec<std::io::Result<std::fs::DirEntry>> = vec![Err(std::io::Error::other(
+            "synthetic entry iteration failure",
+        ))];
+        let mut response = TableStatsResponse::default();
+        let paths = collect_statistics_paths(entries, &mut response);
+
+        assert!(paths.is_empty(), "an errored entry yields no path");
+        assert!(
+            !response.complete,
+            "a read_dir entry error must taint completeness (no silent drop)"
+        );
+        assert_eq!(
+            response.skipped_sstables, 1,
+            "the unreadable entry is visible as a skip"
+        );
+    }
+
+    #[test]
+    fn read_dir_all_ok_entries_stay_complete() {
+        // Sanity: with no Err entries the helper leaves completeness untouched. We
+        // enumerate a real (empty) directory so every yielded item is Ok.
+        let temp = tempfile::TempDir::new().unwrap();
+        let entries = std::fs::read_dir(temp.path()).unwrap();
+        let mut response = TableStatsResponse::default();
+        let paths = collect_statistics_paths(entries, &mut response);
+
+        assert!(paths.is_empty());
+        assert!(response.complete, "all-Ok enumeration stays complete");
+        assert_eq!(response.skipped_sstables, 0);
     }
 }

--- a/cqlite-flight/src/stats.rs
+++ b/cqlite-flight/src/stats.rs
@@ -25,7 +25,11 @@
 //!   when it can traverse the version-gated min/max block; an SSTable whose
 //!   `total_rows` could not be reached contributes 0 (honest under-count, never a
 //!   guess).
-//! - `sstable_count` = number of `*-Statistics.db` files successfully decoded.
+//! - `sstable_count` = number of SSTables whose sibling `*-Statistics.db` was
+//!   successfully decoded. The SSTable SET is enumerated from the authoritative
+//!   `*-Data.db` components (the "this SSTable exists" signal); a Data.db whose
+//!   sibling Statistics.db is missing or undecodable TAINTS completeness instead
+//!   of being silently invisible (issue #944, #28).
 //!
 //! Because these are per-SSTable sums they are an UPPER BOUND on the table's true
 //! distinct partition / live-row counts (the same partition can appear in several
@@ -166,15 +170,23 @@ pub enum StatsError {
 /// Sum the AUTHORITATIVE per-SSTable STATS counts for one table directory.
 ///
 /// `dir` is the already-resolved SSTable directory (live data dir or a snapshot
-/// directory — see [`crate::producer::DirSource::resolve`]). For each
-/// `*-Statistics.db` file under `dir`, decode its [`read_table_counts`] and add
-/// `partition_count` and `total_rows` to the running totals; `sstable_count`
-/// counts the files that decoded.
+/// directory — see [`crate::producer::DirSource::resolve`]). The SSTable SET is
+/// enumerated from the `*-Data.db` components (the authoritative "this SSTable
+/// exists" signal). For each Data.db we derive its sibling `*-Statistics.db` path
+/// (same generation prefix, e.g. `nb-<gen>-big-Data.db` → `nb-<gen>-big-Statistics.db`),
+/// decode its [`read_table_counts`], and add `partition_count` and `total_rows` to
+/// the running totals; `sstable_count` counts the SSTables whose stats decoded.
 ///
-/// A `Statistics.db` that fails to decode (corrupt, below the version floor) is
-/// handled conservatively: a hard decode error SKIPS the whole file (it does not
-/// contribute and is not counted) AND flips the response's
-/// [`TableStatsResponse::complete`] flag to `false` (with `skipped_sstables`
+/// Enumerating by Data.db (not by Statistics.db) is what closes the fail-closed
+/// hole in issue #944: an SSTable with a readable Data.db but a MISSING or
+/// unreadable `*-Statistics.db` is no longer silently invisible — it now TAINTS
+/// completeness (`complete=false`, `skipped_sstables` incremented), exactly like
+/// the undecodable-stats path below.
+///
+/// A `Statistics.db` that is missing, fails to read, or fails to decode (corrupt,
+/// below the version floor) is handled conservatively: the SSTable does not
+/// contribute and is not counted, AND the response's
+/// [`TableStatsResponse::complete`] flag flips to `false` (with `skipped_sstables`
 /// incremented). Partial sums are NOT authoritative (issue #28), so the consumer
 /// must fail closed to "no estimate" rather than feed a biased ratio to the
 /// AUTOMATIC pushdown gate — the flag is how it learns the totals are incomplete.
@@ -203,29 +215,48 @@ pub fn gather_table_stats(dir: &Path) -> Result<TableStatsResponse, StatsError> 
 
     let mut response = TableStatsResponse::default();
 
-    // Enumerate directory entries WITHOUT silently dropping iteration errors. A
+    // Enumerate the SSTable SET from the `*-Data.db` components (the authoritative
+    // "this SSTable exists" signal), WITHOUT silently dropping iteration errors. A
     // `read_dir` entry that fails to yield (e.g. a transient I/O error partway
     // through) means we may NOT have seen every SSTable, so the totals cannot be
-    // authoritative: taint completeness (consistent with the missing-`total_rows`
-    // and undecodable-Statistics.db paths below) rather than claiming complete totals
-    // over files we could not enumerate (issue #944, #28).
-    let stats_paths = collect_statistics_paths(entries, &mut response);
+    // authoritative: taint completeness (consistent with the missing/undecodable
+    // sibling-Statistics.db and missing-`total_rows` paths below) rather than
+    // claiming complete totals over files we could not enumerate (issue #944, #28).
+    let data_paths = collect_data_paths(entries, &mut response);
 
-    for path in stats_paths {
-        match read_one_sstable_counts(&path) {
-            Ok(counts) => fold_counts(&mut response, &path, counts),
-            Err(e) => {
-                // Skip an unreadable/corrupt/below-floor Statistics.db rather than
-                // failing the whole gate, but mark the totals as INCOMPLETE: partial
-                // sums are not authoritative (issue #28), so the consumer must fail
-                // closed to "no estimate" instead of feeding a biased ratio to the
-                // AUTOMATIC gate. Logged at debug so the cause is recoverable.
+    for data_path in data_paths {
+        // Derive the sibling Statistics.db (same generation prefix). The lookup
+        // itself can fail (no recognisable Data.db suffix) — that taints too.
+        let stats_path = match sibling_statistics_path(&data_path) {
+            Some(p) => p,
+            None => {
                 response.complete = false;
                 response.skipped_sstables = response.skipped_sstables.saturating_add(1);
                 tracing::debug!(
-                    path = %path.display(),
+                    path = %data_path.display(),
+                    "table_stats: Data.db with no derivable Statistics.db sibling (marking incomplete)"
+                );
+                continue;
+            }
+        };
+        match read_one_sstable_counts(&stats_path) {
+            Ok(counts) => fold_counts(&mut response, &stats_path, counts),
+            Err(e) => {
+                // A sibling Statistics.db that is MISSING (NotFound), unreadable, or
+                // undecodable (corrupt, below the version floor) does not contribute
+                // and is not counted, but marks the totals INCOMPLETE: partial sums
+                // are not authoritative (issue #28), so the consumer must fail closed
+                // to "no estimate" instead of feeding a biased ratio to the AUTOMATIC
+                // gate. Enumerating by Data.db means a Data.db with no usable stats
+                // now TAINTS instead of being silently invisible. Logged at debug so
+                // the cause is recoverable.
+                response.complete = false;
+                response.skipped_sstables = response.skipped_sstables.saturating_add(1);
+                tracing::debug!(
+                    data_path = %data_path.display(),
+                    stats_path = %stats_path.display(),
                     error = %e,
-                    "table_stats: skipping undecodable Statistics.db (marking incomplete)"
+                    "table_stats: skipping missing/undecodable sibling Statistics.db (marking incomplete)"
                 );
             }
         }
@@ -234,20 +265,30 @@ pub fn gather_table_stats(dir: &Path) -> Result<TableStatsResponse, StatsError> 
     Ok(response)
 }
 
-/// Collect the `*-Statistics.db` paths from a `read_dir` iterator, treating any
+/// Derive the sibling `*-Statistics.db` path for an SSTable's `*-Data.db` path by
+/// swapping the trailing `Data.db` component for `Statistics.db` (the generation
+/// prefix — e.g. `nb-<gen>-big-` — is identical for every component of one
+/// SSTable). Returns `None` if `data_path` does not end in `-Data.db`.
+fn sibling_statistics_path(data_path: &Path) -> Option<std::path::PathBuf> {
+    let name = data_path.file_name().and_then(|n| n.to_str())?;
+    let prefix = name.strip_suffix("-Data.db")?;
+    let stats_name = format!("{prefix}-Statistics.db");
+    Some(data_path.with_file_name(stats_name))
+}
+
+/// Collect the `*-Data.db` paths from a `read_dir` iterator, treating any
 /// entry-iteration error as INCOMPLETE rather than silently discarding it.
 ///
-/// `read_dir` yields `io::Result<DirEntry>`; an `Err` element means an entry could
-/// not be read (e.g. a transient FS error partway through enumeration), so the
-/// directory listing is NOT known to be exhaustive. Each such error flips
-/// `response.complete` to `false` and bumps `skipped_sstables` — the consumer then
-/// fails closed to "no estimate" instead of reporting authoritative totals over a
-/// directory it could not fully enumerate (issue #944, #28). Successful entries are
-/// filtered to `*-Statistics.db` paths as before.
-fn collect_statistics_paths<I>(
-    entries: I,
-    response: &mut TableStatsResponse,
-) -> Vec<std::path::PathBuf>
+/// The SSTable SET is enumerated from `*-Data.db` (the authoritative "this SSTable
+/// exists" signal) rather than from `*-Statistics.db`: an SSTable with a readable
+/// Data.db but a missing/unreadable Statistics.db must TAINT completeness, not be
+/// silently invisible (issue #944, #28). `read_dir` yields `io::Result<DirEntry>`;
+/// an `Err` element means an entry could not be read (e.g. a transient FS error
+/// partway through enumeration), so the directory listing is NOT known to be
+/// exhaustive. Each such error flips `response.complete` to `false` and bumps
+/// `skipped_sstables` — the consumer then fails closed to "no estimate" instead of
+/// reporting authoritative totals over a directory it could not fully enumerate.
+fn collect_data_paths<I>(entries: I, response: &mut TableStatsResponse) -> Vec<std::path::PathBuf>
 where
     I: IntoIterator<Item = std::io::Result<std::fs::DirEntry>>,
 {
@@ -259,7 +300,7 @@ where
                 if path
                     .file_name()
                     .and_then(|n| n.to_str())
-                    .is_some_and(|n| n.ends_with("-Statistics.db"))
+                    .is_some_and(|n| n.ends_with("-Data.db"))
                 {
                     paths.push(path);
                 }
@@ -420,9 +461,10 @@ mod tests {
         let temp = tempfile::TempDir::new().unwrap();
         let dir = temp.path().join("data").join(KS).join(TBL);
         std::fs::create_dir_all(&dir).unwrap();
-        // Garbage bytes under a *-Statistics.db name: read_table_counts cannot
-        // decode the STATS layout, so read_one_sstable_counts returns Err and the
-        // file is skipped + marks the response incomplete.
+        // A Data.db enumerates the SSTable; its sibling Statistics.db holds garbage
+        // bytes that read_table_counts cannot decode, so read_one_sstable_counts
+        // returns Err and the SSTable is skipped + marks the response incomplete.
+        std::fs::write(dir.join("nb-1-big-Data.db"), b"data").unwrap();
         std::fs::write(
             dir.join("nb-1-big-Statistics.db"),
             b"not a real statistics file",
@@ -442,6 +484,36 @@ mod tests {
         assert_eq!(
             stats.sstable_count, 0,
             "the corrupt file did not contribute"
+        );
+    }
+
+    /// A directory containing a `*-Data.db` with NO sibling `*-Statistics.db` must
+    /// mark the response INCOMPLETE (`complete=false`, `skipped_sstables`
+    /// incremented) — the SSTable is enumerated by its Data.db, so a missing
+    /// Statistics.db can no longer make it silently invisible (issue #944, #28).
+    #[test]
+    fn gather_data_db_without_statistics_sibling_taints() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let dir = temp.path().join("data").join(KS).join(TBL);
+        std::fs::create_dir_all(&dir).unwrap();
+        // A readable Data.db with NO sibling Statistics.db. The old enumeration (by
+        // Statistics.db) would have seen an empty directory and reported
+        // complete=true with zero counts — silently hiding this SSTable.
+        std::fs::write(dir.join("nb-1-big-Data.db"), b"data").unwrap();
+
+        let stats = gather_table_stats(&dir).expect("gather");
+
+        assert!(
+            !stats.complete,
+            "a Data.db with no Statistics.db sibling must mark the response incomplete"
+        );
+        assert_eq!(
+            stats.skipped_sstables, 1,
+            "the SSTable with no usable stats is counted as skipped"
+        );
+        assert_eq!(
+            stats.sstable_count, 0,
+            "the SSTable with no usable stats did not contribute"
         );
     }
 
@@ -638,7 +710,7 @@ mod tests {
             "synthetic entry iteration failure",
         ))];
         let mut response = TableStatsResponse::default();
-        let paths = collect_statistics_paths(entries, &mut response);
+        let paths = collect_data_paths(entries, &mut response);
 
         assert!(paths.is_empty(), "an errored entry yields no path");
         assert!(
@@ -652,13 +724,26 @@ mod tests {
     }
 
     #[test]
+    fn sibling_statistics_path_swaps_suffix() {
+        // The generation prefix is shared across an SSTable's components: a Data.db
+        // maps to its sibling Statistics.db by swapping only the trailing suffix.
+        let data = std::path::Path::new("/x/y/nb-7-big-Data.db");
+        assert_eq!(
+            sibling_statistics_path(data).unwrap(),
+            std::path::PathBuf::from("/x/y/nb-7-big-Statistics.db")
+        );
+        // A path that is not a Data.db has no derivable sibling.
+        assert!(sibling_statistics_path(std::path::Path::new("/x/y/nb-7-big-Index.db")).is_none());
+    }
+
+    #[test]
     fn read_dir_all_ok_entries_stay_complete() {
         // Sanity: with no Err entries the helper leaves completeness untouched. We
         // enumerate a real (empty) directory so every yielded item is Ok.
         let temp = tempfile::TempDir::new().unwrap();
         let entries = std::fs::read_dir(temp.path()).unwrap();
         let mut response = TableStatsResponse::default();
-        let paths = collect_statistics_paths(entries, &mut response);
+        let paths = collect_data_paths(entries, &mut response);
 
         assert!(paths.is_empty());
         assert!(response.complete, "all-Ok enumeration stays complete");

--- a/trino-connector/docker/e2e-data.cql
+++ b/trino-connector/docker/e2e-data.cql
@@ -28,3 +28,31 @@ INSERT INTO analytics.typed (id, label, amount, created, active)
   VALUES (11111111-1111-1111-1111-111111111111, 'alpha', 100, '2024-01-01 00:00:00+0000', true);
 INSERT INTO analytics.typed (id, label, amount, created, active)
   VALUES (22222222-2222-2222-2222-222222222222, 'beta',  200, '2024-06-15 12:30:00+0000', false);
+
+-- Wide table for the AUTOMATIC aggregation-pushdown cardinality gate (issue #944).
+-- 2 partitions (device) × 5 clustering rows (ts) = 10 rows. The authoritative
+-- per-table stats surfaced over the Flight table_stats action are:
+--   partition_count = 2, total_rows = 10.
+-- The DDL-driven gate then estimates:
+--   GROUP BY device           -> groups ≈ 2/10 = 0.2  (< 0.5) -> PUSH (low cardinality)
+--   GROUP BY device, ts       -> full row uniqueness ≈ 1.0    (> 0.5) -> DECLINE (high)
+-- so a high-cardinality GROUP BY is left to Trino while a low-cardinality one and
+-- globals still push. Results are identical either way (pushdown is an optimization);
+-- the e2e asserts the GATE via EXPLAIN, and the answers via the query results.
+CREATE TABLE IF NOT EXISTS analytics.readings (
+  device int,
+  ts int,
+  value int,
+  PRIMARY KEY (device, ts)
+);
+
+INSERT INTO analytics.readings (device, ts, value) VALUES (1, 1, 10);
+INSERT INTO analytics.readings (device, ts, value) VALUES (1, 2, 20);
+INSERT INTO analytics.readings (device, ts, value) VALUES (1, 3, 30);
+INSERT INTO analytics.readings (device, ts, value) VALUES (1, 4, 40);
+INSERT INTO analytics.readings (device, ts, value) VALUES (1, 5, 50);
+INSERT INTO analytics.readings (device, ts, value) VALUES (2, 1, 11);
+INSERT INTO analytics.readings (device, ts, value) VALUES (2, 2, 22);
+INSERT INTO analytics.readings (device, ts, value) VALUES (2, 3, 33);
+INSERT INTO analytics.readings (device, ts, value) VALUES (2, 4, 44);
+INSERT INTO analytics.readings (device, ts, value) VALUES (2, 5, 55);

--- a/trino-connector/docker/e2e-test.sh
+++ b/trino-connector/docker/e2e-test.sh
@@ -129,31 +129,38 @@ assert_eq "low-card group count"    '"2"'                                    "$(
 # GROUP BY device, ts -> 10 groups (full row uniqueness).
 assert_eq "high-card group count"   '"10"'                                   "$(trino 'SELECT count(*) FROM (SELECT device, ts FROM cqlite.analytics.readings GROUP BY device, ts)')"
 
-# Now assert the GATE via EXPLAIN: when an aggregate is pushed into the scan,
-# Trino's PushAggregationIntoTableScan removes the Aggregate node (the scan emits
-# the aggregate). When NOT pushed, an "Aggregate" plan node remains above the scan.
-explain() { "${COMPOSE[@]}" exec -T trino trino --execute "EXPLAIN (TYPE LOGICAL) $1" 2>&1; }
-assert_contains() {
-  local desc="$1" needle="$2" haystack="$3"
-  if grep -qi -- "$needle" <<<"$haystack"; then echo "PASS: $desc";
-  else echo "FAIL: $desc — plan did not contain [$needle]"; echo "$haystack"; FAILURES=$((FAILURES + 1)); fi
+# Assert the GATE via EXPLAIN. Trino 481 only emits DISTRIBUTED plans, which
+# ALWAYS carry an Aggregate[type=PARTIAL/FINAL] node for the cross-fragment merge
+# even when the scan pushed the aggregate — so the absence/presence of "Aggregate"
+# is NOT a reliable pushdown signal. Instead inspect the cqlite table handle the
+# scan prints: when the aggregate is pushed, the handle carries
+# `aggregationJson=Optional[...]`; when declined it stays `aggregationJson=Optional.empty`.
+# Use count(*), which pushes without an inserted CAST projection (sum on an int
+# column gets a CAST that defeats single-Variable-arg pushdown — a separate,
+# pre-existing limitation unrelated to this gate).
+explain() { "${COMPOSE[@]}" exec -T trino trino --execute "EXPLAIN $1" 2>&1; }
+pushed()    { grep -q 'aggregationJson=Optional\[' <<<"$1"; }
+assert_pushed() {
+  local desc="$1" plan="$2"
+  if pushed "$plan"; then echo "PASS: $desc";
+  else echo "FAIL: $desc — handle had aggregationJson=Optional.empty (not pushed)"; echo "$plan"; FAILURES=$((FAILURES + 1)); fi
 }
-assert_absent() {
-  local desc="$1" needle="$2" haystack="$3"
-  if grep -qi -- "$needle" <<<"$haystack"; then
-    echo "FAIL: $desc — plan unexpectedly contained [$needle]"; echo "$haystack"; FAILURES=$((FAILURES + 1));
+assert_not_pushed() {
+  local desc="$1" plan="$2"
+  if pushed "$plan"; then
+    echo "FAIL: $desc — handle carried aggregationJson=Optional[...] (unexpectedly pushed)"; echo "$plan"; FAILURES=$((FAILURES + 1));
   else echo "PASS: $desc"; fi
 }
 
-# Low-cardinality GROUP BY device: PUSHED -> no residual Aggregate node above scan.
-LOWCARD_PLAN="$(explain 'SELECT device, sum(value) FROM cqlite.analytics.readings GROUP BY device')"
-assert_absent  "low-card GROUP BY is pushed (no Aggregate node)" 'Aggregate' "$LOWCARD_PLAN"
-# High-cardinality GROUP BY device, ts: DECLINED -> Aggregate node remains in Trino.
-HIGHCARD_PLAN="$(explain 'SELECT device, ts, sum(value) FROM cqlite.analytics.readings GROUP BY device, ts')"
-assert_contains "high-card GROUP BY left to Trino (Aggregate node present)" 'Aggregate' "$HIGHCARD_PLAN"
-# Global aggregate always pushes regardless of the gate -> no Aggregate node.
-GLOBAL_PLAN="$(explain 'SELECT sum(value) FROM cqlite.analytics.readings')"
-assert_absent  "global aggregate is pushed (no Aggregate node)" 'Aggregate' "$GLOBAL_PLAN"
+# Low-cardinality GROUP BY device (ratio ≈ 0.2 < 0.5): PUSHED into the scan.
+assert_pushed     "low-card GROUP BY device is pushed" \
+  "$(explain 'SELECT device, count(*) FROM cqlite.analytics.readings GROUP BY device')"
+# High-cardinality GROUP BY device, ts (ratio ≈ 1.0 > 0.5): DECLINED → left to Trino.
+assert_not_pushed "high-card GROUP BY device,ts is left to Trino" \
+  "$(explain 'SELECT device, ts, count(*) FROM cqlite.analytics.readings GROUP BY device, ts')"
+# Global aggregate always pushes regardless of the gate.
+assert_pushed     "global count(*) is pushed" \
+  "$(explain 'SELECT count(*) FROM cqlite.analytics.readings')"
 
 # Proof it reads SSTables (not live CQL): an unflushed row must be invisible.
 log "assert SSTable semantics (memtable invisible until flush)"

--- a/trino-connector/docker/e2e-test.sh
+++ b/trino-connector/docker/e2e-test.sh
@@ -106,6 +106,55 @@ assert_eq "group-by group count"    '"2"'                                    "$(
 # Aggregation + predicate: sum(score) WHERE score > 25 -> 30+40+50 = 120.
 assert_eq "agg + predicate"         '"120"'                                  "$(trino 'SELECT sum(score) FROM cqlite.analytics.events WHERE score > 25')"
 
+# AUTOMATIC aggregation-pushdown cardinality gate (issue #944). The `readings`
+# table has 2 partitions × 5 clustering rows = 10 rows. The connector surfaces
+# authoritative partition_count=2 / total_rows=10 over the Flight table_stats
+# action; the DDL-driven gate then:
+#   GROUP BY device      -> ratio ≈ 0.2 (< 0.5) -> PUSH (low cardinality)
+#   GROUP BY device, ts  -> ratio ≈ 1.0 (> 0.5) -> DECLINE (high cardinality)
+# Globals always push regardless of the gate.
+log "wait for the connector to resolve analytics.readings"
+for i in $(seq 1 36); do
+  if "${COMPOSE[@]}" exec -T trino trino --execute \
+       "SELECT count(*) FROM cqlite.analytics.readings" >/dev/null 2>&1; then break; fi
+  sleep 5
+  [[ $i -eq 36 ]] && { echo "connector never resolved analytics.readings"; exit 1; }
+done
+
+# Results are identical whether or not the aggregate is pushed (pushdown is a pure
+# optimization), so assert the answers first.
+assert_eq "readings row count"      '"10"'                                   "$(trino 'SELECT count(*) FROM cqlite.analytics.readings')"
+# GROUP BY device -> 2 groups; sum(value) per device: dev1=150, dev2=165.
+assert_eq "low-card group count"    '"2"'                                    "$(trino 'SELECT count(*) FROM (SELECT device FROM cqlite.analytics.readings GROUP BY device)')"
+# GROUP BY device, ts -> 10 groups (full row uniqueness).
+assert_eq "high-card group count"   '"10"'                                   "$(trino 'SELECT count(*) FROM (SELECT device, ts FROM cqlite.analytics.readings GROUP BY device, ts)')"
+
+# Now assert the GATE via EXPLAIN: when an aggregate is pushed into the scan,
+# Trino's PushAggregationIntoTableScan removes the Aggregate node (the scan emits
+# the aggregate). When NOT pushed, an "Aggregate" plan node remains above the scan.
+explain() { "${COMPOSE[@]}" exec -T trino trino --execute "EXPLAIN (TYPE LOGICAL) $1" 2>&1; }
+assert_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if grep -qi -- "$needle" <<<"$haystack"; then echo "PASS: $desc";
+  else echo "FAIL: $desc — plan did not contain [$needle]"; echo "$haystack"; FAILURES=$((FAILURES + 1)); fi
+}
+assert_absent() {
+  local desc="$1" needle="$2" haystack="$3"
+  if grep -qi -- "$needle" <<<"$haystack"; then
+    echo "FAIL: $desc — plan unexpectedly contained [$needle]"; echo "$haystack"; FAILURES=$((FAILURES + 1));
+  else echo "PASS: $desc"; fi
+}
+
+# Low-cardinality GROUP BY device: PUSHED -> no residual Aggregate node above scan.
+LOWCARD_PLAN="$(explain 'SELECT device, sum(value) FROM cqlite.analytics.readings GROUP BY device')"
+assert_absent  "low-card GROUP BY is pushed (no Aggregate node)" 'Aggregate' "$LOWCARD_PLAN"
+# High-cardinality GROUP BY device, ts: DECLINED -> Aggregate node remains in Trino.
+HIGHCARD_PLAN="$(explain 'SELECT device, ts, sum(value) FROM cqlite.analytics.readings GROUP BY device, ts')"
+assert_contains "high-card GROUP BY left to Trino (Aggregate node present)" 'Aggregate' "$HIGHCARD_PLAN"
+# Global aggregate always pushes regardless of the gate -> no Aggregate node.
+GLOBAL_PLAN="$(explain 'SELECT sum(value) FROM cqlite.analytics.readings')"
+assert_absent  "global aggregate is pushed (no Aggregate node)" 'Aggregate' "$GLOBAL_PLAN"
+
 # Proof it reads SSTables (not live CQL): an unflushed row must be invisible.
 log "assert SSTable semantics (memtable invisible until flush)"
 "${COMPOSE[@]}" exec -T cassandra cqlsh 172.42.0.2 \

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightClient.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightClient.java
@@ -2,6 +2,8 @@ package in.mcfad.cqlite.flight;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.arrow.flight.Action;
+import org.apache.arrow.flight.CallOption;
+import org.apache.arrow.flight.CallOptions;
 import org.apache.arrow.flight.FlightClient;
 import org.apache.arrow.flight.FlightDescriptor;
 import org.apache.arrow.flight.FlightStream;
@@ -12,6 +14,7 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.types.pojo.Schema;
 
 import java.util.Iterator;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Thin wrapper over the Arrow Flight Java client for talking to a cqlite-flight
@@ -45,10 +48,22 @@ public final class CqliteFlightClient {
      * JSON-encoded {@code TableStatsRequest} (keyspace/table/snapshot). The server
      * returns exactly one {@link Result} whose body is the JSON
      * {@link TableStats}.
+     *
+     * <p>The call is BOUNDED by {@code timeoutMillis} (a Flight {@link CallOptions#timeout
+     * deadline}, issue #944): this DoAction runs during query PLANNING, so a slow or
+     * half-open endpoint must not stall the planner. When the deadline fires the gRPC
+     * call surfaces a {@link org.apache.arrow.flight.FlightRuntimeException} with status
+     * {@code TIMED_OUT}/{@code DEADLINE_EXCEEDED}, which propagates to the caller's
+     * fetch-failure path (treated as UNAVAILABLE stats → "no estimate") rather than a
+     * planning error. A non-positive {@code timeoutMillis} disables the deadline.
      */
-    public TableStats tableStats(String host, int port, byte[] requestBody) {
+    public TableStats tableStats(String host, int port, byte[] requestBody, long timeoutMillis) {
+        CallOption[] options = timeoutMillis > 0
+                ? new CallOption[] {CallOptions.timeout(timeoutMillis, TimeUnit.MILLISECONDS)}
+                : new CallOption[0];
         try (FlightClient client = connect(host, port)) {
-            Iterator<Result> results = client.doAction(new Action(TABLE_STATS_ACTION, requestBody));
+            Iterator<Result> results =
+                    client.doAction(new Action(TABLE_STATS_ACTION, requestBody), options);
             if (!results.hasNext()) {
                 throw new IllegalStateException(
                         "table_stats to " + host + ":" + port + " returned no result");

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightClient.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightClient.java
@@ -1,18 +1,27 @@
 package in.mcfad.cqlite.flight;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.arrow.flight.Action;
 import org.apache.arrow.flight.FlightClient;
 import org.apache.arrow.flight.FlightDescriptor;
 import org.apache.arrow.flight.FlightStream;
 import org.apache.arrow.flight.Location;
+import org.apache.arrow.flight.Result;
 import org.apache.arrow.flight.Ticket;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.types.pojo.Schema;
+
+import java.util.Iterator;
 
 /**
  * Thin wrapper over the Arrow Flight Java client for talking to a cqlite-flight
  * endpoint: fetch a table's Arrow schema, and open a record-batch stream.
  */
 public final class CqliteFlightClient {
+    /** Wire name of the per-table statistics action (matches the Rust server). */
+    static final String TABLE_STATS_ACTION = "table_stats";
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
     private final BufferAllocator allocator;
 
     public CqliteFlightClient(BufferAllocator allocator) {
@@ -27,6 +36,33 @@ public final class CqliteFlightClient {
             throw e;
         } catch (Exception e) {
             throw new IllegalStateException("GetSchema to " + host + ":" + port + " failed", e);
+        }
+    }
+
+    /**
+     * Fetch per-table aggregate statistics from a flight endpoint via the
+     * {@code table_stats} DoAction (issue #944). {@code requestBody} is the
+     * JSON-encoded {@code TableStatsRequest} (keyspace/table/snapshot). The server
+     * returns exactly one {@link Result} whose body is the JSON
+     * {@link TableStats}.
+     */
+    public TableStats tableStats(String host, int port, byte[] requestBody) {
+        try (FlightClient client = connect(host, port)) {
+            Iterator<Result> results = client.doAction(new Action(TABLE_STATS_ACTION, requestBody));
+            if (!results.hasNext()) {
+                throw new IllegalStateException(
+                        "table_stats to " + host + ":" + port + " returned no result");
+            }
+            byte[] body = results.next().getBody();
+            // Drain any (unexpected) extra results so the gRPC call completes cleanly.
+            while (results.hasNext()) {
+                results.next();
+            }
+            return MAPPER.readValue(body, TableStats.class);
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IllegalStateException("table_stats to " + host + ":" + port + " failed", e);
         }
     }
 

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightConfig.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightConfig.java
@@ -14,6 +14,9 @@ import java.util.Map;
  * # Aggregation-pushdown gate (issue #893); GROUP BY only — globals always push.
  * cqlite.aggregation-pushdown-group-by=automatic   # automatic | always | never
  * cqlite.aggregation-pushdown-max-group-ratio=0.5   # decline above this groups/rows ratio
+ * # Deadline for the optional planning-time table_stats DoAction (issue #944). A slow or
+ * # half-open Flight endpoint must degrade to "no estimate", never stall query planning.
+ * cqlite.table-stats-timeout-ms=3000
  * </pre>
  */
 public record CqliteFlightConfig(
@@ -21,9 +24,19 @@ public record CqliteFlightConfig(
         int flightPort,
         String localDatacenter,
         GroupByPushdownPolicy groupByPushdown,
-        double maxGroupRatio) {
+        double maxGroupRatio,
+        long tableStatsTimeoutMillis) {
 
     public static final int DEFAULT_FLIGHT_PORT = 8815;
+
+    /**
+     * Default deadline (milliseconds) for the optional planning-time {@code table_stats}
+     * DoAction (issue #944). The call runs during query PLANNING, where a slow or
+     * half-open Flight endpoint would otherwise stall the planner; a few seconds is enough
+     * for a healthy stats RPC and bounds the worst case. On timeout the fetch degrades to
+     * "no estimate" (push), exactly like any other fetch failure — it never fails the query.
+     */
+    public static final long DEFAULT_TABLE_STATS_TIMEOUT_MILLIS = 3000;
 
     /**
      * Default groups/rows crossover for {@link GroupByPushdownPolicy#AUTOMATIC}. The
@@ -38,6 +51,10 @@ public record CqliteFlightConfig(
             throw new IllegalArgumentException(
                     "cqlite.aggregation-pushdown-max-group-ratio must be in (0.0, 1.0], got " + maxGroupRatio);
         }
+        if (tableStatsTimeoutMillis <= 0) {
+            throw new IllegalArgumentException(
+                    "cqlite.table-stats-timeout-ms must be > 0, got " + tableStatsTimeoutMillis);
+        }
     }
 
     public static CqliteFlightConfig fromMap(Map<String, String> config) {
@@ -51,7 +68,10 @@ public record CqliteFlightConfig(
         double ratio = config.containsKey("cqlite.aggregation-pushdown-max-group-ratio")
                 ? Double.parseDouble(config.get("cqlite.aggregation-pushdown-max-group-ratio"))
                 : DEFAULT_MAX_GROUP_RATIO;
-        return new CqliteFlightConfig(URI.create(sidecar), port, dc, policy, ratio);
+        long statsTimeoutMs = config.containsKey("cqlite.table-stats-timeout-ms")
+                ? Long.parseLong(config.get("cqlite.table-stats-timeout-ms"))
+                : DEFAULT_TABLE_STATS_TIMEOUT_MILLIS;
+        return new CqliteFlightConfig(URI.create(sidecar), port, dc, policy, ratio, statsTimeoutMs);
     }
 
     private static String require(Map<String, String> config, String key) {

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightMetadata.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightMetadata.java
@@ -832,15 +832,7 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
     }
 
     /**
-     * Surface the AUTHORITATIVE per-table row count to the Trino optimizer (issue
-     * #944). The cqlite-flight {@code table_stats} action returns Σ {@code totalRows}
-     * across the table's SSTables (an upper bound; see {@link TableStats}); we report
-     * it as the table's row-count estimate. Column-level stats are left unknown —
-     * Cassandra 5.0 stores no reliable per-regular-column NDV, so reporting any would
-     * be a heuristic (#28). A failed, zero, or INCOMPLETE fetch (some node's
-     * {@code Statistics.db} failed to decode → {@code !stats.complete()}) yields
-     * {@link TableStatistics#empty()} (unknown), which is always a safe input for
-     * the optimizer — we never report a row count derived from incomplete data.
+     * Surface optimizer row-count statistics to Trino (issue #944).
      *
      * <p>For an <em>aggregated</em> handle the scan's OUTPUT cardinality is the
      * aggregate-result cardinality, NOT the base-table row count (issue #944): a
@@ -848,6 +840,22 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
      * ROW_COUNT = 1}; a grouped aggregate's output group count is not authoritatively
      * known, so we return {@link TableStatistics#empty()} and let Trino estimate
      * rather than fabricate (#28).
+     *
+     * <p>For a <em>non-aggregated</em> handle we intentionally report {@link
+     * TableStatistics#empty()} (unknown) rather than {@code stats.liveRows()}. The
+     * cqlite-flight {@code table_stats} action sums whole-table {@code Statistics.db}
+     * counts across ALL replica hosts of the keyspace, so on a replicated keyspace
+     * (e.g. RF=3) {@code liveRows()} is the PHYSICAL replica row total (≈ RF × the
+     * logical table cardinality), NOT the logical number of rows a scan emits. It is
+     * not authoritatively de-duplicated to a single copy of the token space, so
+     * exposing it would mislead Trino's cost optimizer. RF-correct / token-range-scoped
+     * optimizer row counts are deferred to a follow-up issue; until then we report no
+     * row-count estimate and let Trino fall back to its own. Note this does NOT affect
+     * the GROUP BY pushdown gate ({@link #estimateGroupRatio}), which uses an
+     * RF-invariant ratio ({@code partition_count / live_rows}) where replica
+     * over-counting cancels in numerator and denominator. Column-level stats are left
+     * unknown — Cassandra 5.0 stores no reliable per-regular-column NDV, so reporting
+     * any would be a heuristic (#28).
      */
     @Override
     public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle table) {
@@ -857,25 +865,17 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
                 // Grouped aggregate: output group count is unknown — do not guess.
                 return TableStatistics.empty();
             }
-            // Global aggregate (e.g. count(*) with no GROUP BY): exactly one row.
+            // Global aggregate (e.g. count(*) with no GROUP BY): exactly one row,
+            // regardless of replication factor.
             return TableStatistics.builder().setRowCount(Estimate.of(1)).build();
         }
-        TableStats stats;
-        try {
-            stats = fetchTableStats(handle);
-        } catch (RuntimeException e) {
-            return TableStatistics.empty();
-        }
-        // Fail closed to "unknown" when the counts are INCOMPLETE (a node's
-        // Statistics.db failed to decode; issue #944, #28): an under-counted
-        // row total is NOT authoritative, so report no estimate rather than a
-        // biased one. Empty is always a safe optimizer input.
-        if (!stats.complete() || stats.liveRows() <= 0) {
-            return TableStatistics.empty();
-        }
-        return TableStatistics.builder()
-                .setRowCount(Estimate.of(stats.liveRows()))
-                .build();
+        // Non-aggregated scan: stats.liveRows() is the replica-summed PHYSICAL row
+        // total (≈ RF × logical cardinality), not the logical rows a scan emits, and
+        // is not authoritatively de-duplicated to one copy of the token space. Do not
+        // expose a knowably-wrong number to the optimizer — report unknown and let
+        // Trino estimate. (RF-correct row counts are deferred to a follow-up issue;
+        // the GROUP BY gate is unaffected — see estimateGroupRatio.)
+        return TableStatistics.empty();
     }
 
     /** Resolve the table's Arrow schema by asking any flight node's GetSchema. */

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightMetadata.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightMetadata.java
@@ -519,21 +519,25 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
 
         boolean coversPartitionKey = coversAll(partitionKey, groupingColumns);
         boolean coversAllClustering = coversAll(clustering, groupingColumns);
-        // Does the grouping touch ANY clustering column? (Used to distinguish the
-        // partition-only case from a partition-key + partial-clustering grouping.)
-        boolean groupsAnyClustering = touchesAny(clustering, groupingColumns);
+        // Is EVERY grouping column a partition-key column? Together with
+        // coversPartitionKey this is true iff the grouping set is EXACTLY the partition
+        // key — no extra clustering AND no extra regular (non-key) columns. A regular
+        // column in the grouping (e.g. GROUP BY pk, v) can split a single partition into
+        // one group per row, so partitionCount is NOT a valid bound there.
+        boolean allGroupingArePartitionKey = allMatchSomeKey(partitionKey, groupingColumns);
 
         if (coversPartitionKey && coversAllClustering) {
             // Grouping reaches full row uniqueness (partition key + ALL clustering
             // columns) → one group per row → ratio ≈ 1.0 → DECLINE.
             return java.util.OptionalDouble.of(1.0);
         }
-        if (coversPartitionKey && !groupsAnyClustering) {
-            // Grouping = full partition key with NO clustering columns: each group is
-            // exactly one distinct partition → groups ≈ partition count, never more
-            // than the row count. This is the ONLY shape bounded by the authoritative
-            // partition count (whether or not the table also HAS clustering columns,
-            // since the grouping does not slice partitions any finer).
+        if (coversPartitionKey && allGroupingArePartitionKey) {
+            // Grouping is EXACTLY the partition key (every PK column is grouped AND every
+            // grouping column is a PK column — no clustering, no regular columns): each
+            // group is exactly one distinct partition → groups ≈ partition count, never
+            // more than the row count. This is the ONLY shape bounded by the
+            // authoritative partition count (whether or not the table also HAS clustering
+            // columns, since the grouping does not slice partitions any finer).
             double ratio = (double) Math.min(partitions, rows) / (double) rows;
             return java.util.OptionalDouble.of(ratio);
         }
@@ -544,6 +548,9 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
         //     Cassandra 5.0; group count can approach the row count, so partitionCount
         //     is NOT a valid bound — fabricating partitionCount/rows here would let the
         //     gate push exactly the high-cardinality aggregation it exists to decline.
+        //   - GROUP BY = full partition key + a REGULAR (non-key) column (e.g.
+        //     GROUP BY pk, v). A regular column has no stored NDV and can produce one
+        //     group per row, so partitionCount is NOT a valid bound here either.
         //   - A partition-key PREFIX, or grouping on a non-key / low-cardinality column.
         return java.util.OptionalDouble.empty();
     }
@@ -571,20 +578,26 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
     }
 
     /**
-     * True iff AT LEAST ONE key column is matched by some grouping name (same CQL
-     * identifier rules as {@link #coversAll}). Used to detect whether a grouping
-     * slices partitions by any clustering column.
+     * True iff EVERY grouping name is matched by some key column in {@code keyColumns}
+     * (same CQL identifier rules as {@link #coversAll}). Used with {@link #coversAll} to
+     * decide whether a grouping set is EXACTLY the given key set: no extra clustering and
+     * no extra regular (non-key) columns. An empty grouping list is trivially all-matched.
      */
-    private static boolean touchesAny(
+    private static boolean allMatchSomeKey(
             List<PrimaryKeyExtractor.KeyColumn> keyColumns, List<String> groupingColumns) {
-        for (PrimaryKeyExtractor.KeyColumn key : keyColumns) {
-            for (String g : groupingColumns) {
+        for (String g : groupingColumns) {
+            boolean matched = false;
+            for (PrimaryKeyExtractor.KeyColumn key : keyColumns) {
                 if (key.matches(g)) {
-                    return true;
+                    matched = true;
+                    break;
                 }
             }
+            if (!matched) {
+                return false;
+            }
         }
-        return false;
+        return true;
     }
 
     /**

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightMetadata.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightMetadata.java
@@ -613,21 +613,53 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
      * {@code table_stats} action across the distinct flight nodes in the ring
      * (issue #944). Summing across replicas over-counts by the replication factor,
      * which is acceptable for an UPPER-BOUND gate input (it only ever errs toward
-     * DECLINING pushdown). A node whose stats call fails is skipped.
+     * DECLINING pushdown).
+     *
+     * <p>If ANY distinct ring node that should have been queried FAILS to return
+     * stats, the aggregate is tainted INCOMPLETE: we fold {@link TableStats#UNAVAILABLE}
+     * (an incomplete sentinel) so the AND-of-{@code complete} in {@link TableStats#plus}
+     * becomes {@code false}. A failed node is NOT silently dropped — its peers'
+     * partial totals must not be treated as authoritative (issue #944, #28), so the
+     * caller fails closed to "no estimate" rather than dividing the gate/optimizer by
+     * an under-counted row total.
      */
     private TableStats fetchTableStats(CqliteFlightTableHandle handle) {
         byte[] body = tableStatsRequest(handle.keyspace(), handle.table());
+        int port = config.flightPort();
+        return aggregateNodeStats(
+                sidecar.ring().entries(), address -> flight.tableStats(address, port, body));
+    }
+
+    /**
+     * Aggregate per-node {@code table_stats} across the DISTINCT addresses in
+     * {@code nodes} by summing {@link TableStats#plus} (issue #944). Pulled out as a
+     * package-private static seam so the completeness-tainting behavior can be unit
+     * tested without a live Sidecar/Flight client.
+     *
+     * <p>For each distinct, non-null address {@code fetch} is invoked. If the fetch
+     * THROWS for a node we should have queried, the node is NOT silently dropped: an
+     * incomplete {@link TableStats#UNAVAILABLE} sentinel is folded in, so the AND-of-
+     * {@code complete} in {@link TableStats#plus} taints the whole aggregate to
+     * {@code complete=false}. A partial cross-ring total is therefore reported as
+     * "no estimate" (the caller fails closed) rather than as authoritative.
+     */
+    static TableStats aggregateNodeStats(
+            Iterable<RingEntry> nodes, java.util.function.Function<String, TableStats> fetch) {
         TableStats total = TableStats.EMPTY;
         Set<String> seen = new LinkedHashSet<>();
-        for (RingEntry node : sidecar.ring().entries()) {
+        for (RingEntry node : nodes) {
             String address = node.address();
             if (address == null || !seen.add(address)) {
                 continue;
             }
             try {
-                total = total.plus(flight.tableStats(address, config.flightPort(), body));
+                total = total.plus(fetch.apply(address));
             } catch (RuntimeException e) {
-                // Skip a node that could not answer; its peers still contribute.
+                // A node we should have queried could not answer. Do NOT silently drop
+                // it: fold an incomplete sentinel so the cross-ring aggregate is marked
+                // incomplete (complete=false), forcing the caller to "no estimate"
+                // instead of treating the peers' partial totals as authoritative.
+                total = total.plus(TableStats.UNAVAILABLE);
             }
         }
         return total;

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightMetadata.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightMetadata.java
@@ -13,6 +13,8 @@ import io.trino.spi.connector.ConnectorTableVersion;
 import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.ConstraintApplicationResult;
 import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.statistics.Estimate;
+import io.trino.spi.statistics.TableStatistics;
 import io.trino.spi.expression.Call;
 import io.trino.spi.expression.ConnectorExpression;
 import io.trino.spi.expression.Constant;
@@ -30,9 +32,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import in.mcfad.cqlite.flight.sidecar.SidecarClient;
 import in.mcfad.cqlite.flight.sidecar.SidecarModels.RingEntry;
@@ -256,13 +260,15 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
             groupByNameSet.add(col.name());
         }
 
-        // Cardinality / operator gate (issue #893). Global aggregates (no GROUP BY)
-        // are an unconditional data-reduction win and are NEVER gated — they bypass
-        // this check. For a GROUP BY, the single-finalize-split design degrades to
-        // break-even-to-loss as distinct groups approach the row count, so honor the
-        // operator policy and decline when the estimated group ratio is too high.
+        // Cardinality / operator gate (issue #893, #944). Global aggregates (no
+        // GROUP BY) are an unconditional data-reduction win and are NEVER gated —
+        // they bypass this check. For a GROUP BY, the single-finalize-split design
+        // degrades to break-even-to-loss as distinct groups approach the row count,
+        // so honor the operator policy and decline when the estimated group ratio is
+        // too high. The ratio is only needed for the AUTOMATIC policy, so the
+        // (network) stats fetch is skipped under NEVER/ALWAYS.
         if (hasGroupBy && declineGroupByPushdown(
-                groupByPolicy(), estimateGroupRatio(table, groupingColumns), maxGroupRatio())) {
+                groupByPolicy(), groupRatioForGate(table, groupingColumns), maxGroupRatio())) {
             return Optional.empty();
         }
 
@@ -427,18 +433,153 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
     }
 
     /**
-     * Estimate distinct-groups / rows for a GROUP BY, used by the AUTOMATIC gate.
-     *
-     * <p>Returns empty today: an authoritative per-column NDV is not surfaced through
-     * the Flight/Sidecar path (Cassandra's Statistics.db does not store it), so there is
-     * no estimate to gate on. The hook is in place — once a row-count + per-grouping-column
-     * cardinality source exists, populate it here and AUTOMATIC starts gating without any
-     * other change. Until then AUTOMATIC pushes, and operators who hit the rare
-     * high-cardinality loss set {@code cqlite.aggregation-pushdown-group-by=never}.
+     * Resolve the estimated groups/rows ratio for the gate. The ratio only matters
+     * under {@link GroupByPushdownPolicy#AUTOMATIC}, so for NEVER/ALWAYS we skip the
+     * (network) statistics fetch entirely and return empty. For AUTOMATIC we fetch
+     * the authoritative per-table counts and feed them to the pure
+     * {@link #estimateGroupRatio} mapping. Any failure fetching stats degrades to
+     * empty (no estimate → AUTOMATIC pushes, always correct).
      */
-    private java.util.OptionalDouble estimateGroupRatio(
+    private java.util.OptionalDouble groupRatioForGate(
             CqliteFlightTableHandle table, List<CqliteFlightColumnHandle> groupingColumns) {
+        if (groupByPolicy() != GroupByPushdownPolicy.AUTOMATIC) {
+            return java.util.OptionalDouble.empty();
+        }
+        TableStats stats;
+        try {
+            stats = fetchTableStats(table);
+        } catch (RuntimeException e) {
+            // No estimate available → AUTOMATIC pushes (correct, may risk the rare
+            // high-cardinality perf loss). Never block a query on a stats fetch.
+            return java.util.OptionalDouble.empty();
+        }
+        List<String> groupByNames = new ArrayList<>();
+        for (CqliteFlightColumnHandle col : groupingColumns) {
+            groupByNames.add(col.name());
+        }
+        return estimateGroupRatio(table.ddl(), groupByNames, stats);
+    }
+
+    /**
+     * Estimate distinct-groups / rows for a GROUP BY (issue #944), used by the
+     * AUTOMATIC gate. PURE function of the table DDL, the grouping column names, and
+     * the AUTHORITATIVE per-table counts — no network, fully unit-testable.
+     *
+     * <p><b>Authoritative inputs</b> (from {@code cqlite-core} Statistics.db parse,
+     * surfaced via the Flight {@code table_stats} action): {@code stats.liveRows} and
+     * {@code stats.partitionCount}. Both are per-SSTable / per-node SUMS, i.e. UPPER
+     * BOUNDS on the table's true counts (a partition can appear in several SSTables /
+     * be replicated across nodes). An upper bound on distinct groups never
+     * under-counts, so the gate never wrongly pushes a high-cardinality GROUP BY.
+     *
+     * <p><b>Derived mapping</b> (best-effort, from the grouping shape vs the DDL
+     * primary key — NOT a true NDV gate; Cassandra 5.0 stores no reliable
+     * per-regular-column NDV, so we never trust per-column cardinality):
+     * <ul>
+     *   <li><b>GROUP BY reaches full row uniqueness</b> (partition key + ALL
+     *       clustering columns ⊆ grouping) → groups ≈ rows → ratio ≈ 1.0 → DECLINE.</li>
+     *   <li><b>GROUP BY = the full partition key</b> (and no clustering, or a strict
+     *       subset of clustering) → groups ≈ partitionCount, bounded above by rows →
+     *       ratio = partitionCount / rows.</li>
+     *   <li><b>GROUP BY is a partition-key PREFIX / a non-key or low-cardinality
+     *       column</b> → cannot be bounded from these stats → empty → default PUSH
+     *       (safe).</li>
+     * </ul>
+     *
+     * <p>Returns {@link java.util.OptionalDouble#empty()} when no row count is
+     * available (rows == 0) or the shape is unbounded — the gate then pushes.
+     */
+    static java.util.OptionalDouble estimateGroupRatio(
+            String ddl, List<String> groupingColumns, TableStats stats) {
+        long rows = stats.liveRows();
+        long partitions = stats.partitionCount();
+        if (rows <= 0 || groupingColumns.isEmpty()) {
+            // No rows to reason about, or a global aggregate (handled before the gate).
+            return java.util.OptionalDouble.empty();
+        }
+
+        PrimaryKeyExtractor.Keys keys = PrimaryKeyExtractor.extract(ddl);
+        if (keys.partitionKey().isEmpty()) {
+            // DDL primary key not parseable → cannot bound → push.
+            return java.util.OptionalDouble.empty();
+        }
+
+        // Case-insensitive grouping set (quoted identifiers keep their case in the
+        // extractor; unquoted are lower-cased on both sides).
+        Set<String> grouping = new java.util.HashSet<>();
+        for (String g : groupingColumns) {
+            grouping.add(foldName(g));
+        }
+        Set<String> partitionKey = fold(keys.partitionKey());
+        Set<String> clustering = fold(keys.clusteringColumns());
+
+        boolean coversPartitionKey = grouping.containsAll(partitionKey);
+        boolean coversAllClustering = grouping.containsAll(clustering);
+
+        if (coversPartitionKey && coversAllClustering) {
+            // Grouping reaches full row uniqueness → one group per row → ratio ≈ 1.0.
+            return java.util.OptionalDouble.of(1.0);
+        }
+        if (coversPartitionKey) {
+            // Grouping = full partition key (with at most a strict clustering subset):
+            // distinct groups ≈ partition count, never more than the row count.
+            double ratio = (double) Math.min(partitions, rows) / (double) rows;
+            return java.util.OptionalDouble.of(ratio);
+        }
+        // Partition-key prefix, or grouping on a non-key / low-cardinality column:
+        // not boundable from partition/row counts alone → push (safe default).
         return java.util.OptionalDouble.empty();
+    }
+
+    private static Set<String> fold(List<String> names) {
+        Set<String> out = new java.util.HashSet<>();
+        for (String n : names) {
+            out.add(foldName(n));
+        }
+        return out;
+    }
+
+    /** Match {@link PrimaryKeyExtractor}'s normalization: unquoted names lower-cased. */
+    private static String foldName(String name) {
+        return name == null ? null : name.toLowerCase(java.util.Locale.ROOT);
+    }
+
+    /**
+     * Fetch the AUTHORITATIVE per-table statistics by summing the
+     * {@code table_stats} action across the distinct flight nodes in the ring
+     * (issue #944). Summing across replicas over-counts by the replication factor,
+     * which is acceptable for an UPPER-BOUND gate input (it only ever errs toward
+     * DECLINING pushdown). A node whose stats call fails is skipped.
+     */
+    private TableStats fetchTableStats(CqliteFlightTableHandle handle) {
+        byte[] body = tableStatsRequest(handle.keyspace(), handle.table());
+        TableStats total = TableStats.EMPTY;
+        Set<String> seen = new LinkedHashSet<>();
+        for (RingEntry node : sidecar.ring().entries()) {
+            String address = node.address();
+            if (address == null || !seen.add(address)) {
+                continue;
+            }
+            try {
+                total = total.plus(flight.tableStats(address, config.flightPort(), body));
+            } catch (RuntimeException e) {
+                // Skip a node that could not answer; its peers still contribute.
+            }
+        }
+        return total;
+    }
+
+    /** Build the {@code table_stats} action body (JSON {@code TableStatsRequest}). */
+    private static byte[] tableStatsRequest(String keyspace, String table) {
+        var root = MAPPER.createObjectNode();
+        root.put("keyspace", keyspace);
+        root.put("table", table);
+        root.putNull("snapshot");
+        try {
+            return MAPPER.writeValueAsBytes(root);
+        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+            throw new IllegalStateException("Failed to serialize table_stats request", e);
+        }
     }
 
     /**
@@ -516,6 +657,32 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
             columns.add(new ColumnMetadata(field.getName(), ArrowTypeMapper.toTrino(field)));
         }
         return new ConnectorTableMetadata(new SchemaTableName(handle.keyspace(), handle.table()), columns);
+    }
+
+    /**
+     * Surface the AUTHORITATIVE per-table row count to the Trino optimizer (issue
+     * #944). The cqlite-flight {@code table_stats} action returns Σ {@code totalRows}
+     * across the table's SSTables (an upper bound; see {@link TableStats}); we report
+     * it as the table's row-count estimate. Column-level stats are left unknown —
+     * Cassandra 5.0 stores no reliable per-regular-column NDV, so reporting any would
+     * be a heuristic (#28). A failed/zero fetch yields {@link TableStatistics#empty()}
+     * (unknown), which is always a safe input for the optimizer.
+     */
+    @Override
+    public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle table) {
+        CqliteFlightTableHandle handle = (CqliteFlightTableHandle) table;
+        TableStats stats;
+        try {
+            stats = fetchTableStats(handle);
+        } catch (RuntimeException e) {
+            return TableStatistics.empty();
+        }
+        if (stats.liveRows() <= 0) {
+            return TableStatistics.empty();
+        }
+        return TableStatistics.builder()
+                .setRowCount(Estimate.of(stats.liveRows()))
+                .build();
     }
 
     /** Resolve the table's Arrow schema by asking any flight node's GetSchema. */

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightMetadata.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightMetadata.java
@@ -474,16 +474,21 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
      *
      * <p><b>Derived mapping</b> (best-effort, from the grouping shape vs the DDL
      * primary key — NOT a true NDV gate; Cassandra 5.0 stores no reliable
-     * per-regular-column NDV, so we never trust per-column cardinality):
+     * per-regular-column or per-clustering-prefix NDV, so we never invent per-column
+     * cardinality). We only claim a bound in the two shapes the authoritative
+     * partition/row counts actually bound:
      * <ul>
      *   <li><b>GROUP BY reaches full row uniqueness</b> (partition key + ALL
      *       clustering columns ⊆ grouping) → groups ≈ rows → ratio ≈ 1.0 → DECLINE.</li>
-     *   <li><b>GROUP BY = the full partition key</b> (and no clustering, or a strict
-     *       subset of clustering) → groups ≈ partitionCount, bounded above by rows →
-     *       ratio = partitionCount / rows.</li>
-     *   <li><b>GROUP BY is a partition-key PREFIX / a non-key or low-cardinality
-     *       column</b> → cannot be bounded from these stats → empty → default PUSH
-     *       (safe).</li>
+     *   <li><b>GROUP BY = the full partition key AND the table has NO clustering
+     *       columns</b> → one group per partition → groups ≈ partitionCount, bounded
+     *       above by rows → ratio = partitionCount / rows.</li>
+     *   <li><b>Everything else is UNBOUNDED</b> → empty → default PUSH (safe). This
+     *       includes a full partition key plus a PARTIAL subset of clustering columns
+     *       (group count can approach row cardinality, e.g. GROUP BY pk, ck1 with
+     *       PRIMARY KEY (pk, ck1, ck2) — no per-prefix NDV exists to bound it, so we
+     *       must NOT fabricate partitionCount/rows), a partition-key PREFIX, and
+     *       grouping on a non-key or low-cardinality column.</li>
      * </ul>
      *
      * <p>Returns {@link java.util.OptionalDouble#empty()} when no row count is
@@ -504,44 +509,82 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
             return java.util.OptionalDouble.empty();
         }
 
-        // Case-insensitive grouping set (quoted identifiers keep their case in the
-        // extractor; unquoted are lower-cased on both sides).
-        Set<String> grouping = new java.util.HashSet<>();
-        for (String g : groupingColumns) {
-            grouping.add(foldName(g));
-        }
-        Set<String> partitionKey = fold(keys.partitionKey());
-        Set<String> clustering = fold(keys.clusteringColumns());
+        // Per-column CQL identifier matching: an UNQUOTED key column matches a
+        // grouping name case-insensitively (CQL folds unquoted identifiers); a QUOTED
+        // key column matches only its exact case (CQL preserves quoted identifiers).
+        // The flag rides on each KeyColumn from the extractor, so quoted "Id" is NOT
+        // conflated with unquoted id.
+        List<PrimaryKeyExtractor.KeyColumn> partitionKey = keys.partitionKey();
+        List<PrimaryKeyExtractor.KeyColumn> clustering = keys.clusteringColumns();
 
-        boolean coversPartitionKey = grouping.containsAll(partitionKey);
-        boolean coversAllClustering = grouping.containsAll(clustering);
+        boolean coversPartitionKey = coversAll(partitionKey, groupingColumns);
+        boolean coversAllClustering = coversAll(clustering, groupingColumns);
+        // Does the grouping touch ANY clustering column? (Used to distinguish the
+        // partition-only case from a partition-key + partial-clustering grouping.)
+        boolean groupsAnyClustering = touchesAny(clustering, groupingColumns);
 
         if (coversPartitionKey && coversAllClustering) {
-            // Grouping reaches full row uniqueness → one group per row → ratio ≈ 1.0.
+            // Grouping reaches full row uniqueness (partition key + ALL clustering
+            // columns) → one group per row → ratio ≈ 1.0 → DECLINE.
             return java.util.OptionalDouble.of(1.0);
         }
-        if (coversPartitionKey) {
-            // Grouping = full partition key (with at most a strict clustering subset):
-            // distinct groups ≈ partition count, never more than the row count.
+        if (coversPartitionKey && !groupsAnyClustering) {
+            // Grouping = full partition key with NO clustering columns: each group is
+            // exactly one distinct partition → groups ≈ partition count, never more
+            // than the row count. This is the ONLY shape bounded by the authoritative
+            // partition count (whether or not the table also HAS clustering columns,
+            // since the grouping does not slice partitions any finer).
             double ratio = (double) Math.min(partitions, rows) / (double) rows;
             return java.util.OptionalDouble.of(ratio);
         }
-        // Partition-key prefix, or grouping on a non-key / low-cardinality column:
-        // not boundable from partition/row counts alone → push (safe default).
+        // Everything else is UNBOUNDED from the authoritative stats → push (safe
+        // default). This includes:
+        //   - GROUP BY = full partition key + a PARTIAL (non-empty, non-full) subset
+        //     of clustering columns. Per-clustering-prefix NDV is NOT stored by
+        //     Cassandra 5.0; group count can approach the row count, so partitionCount
+        //     is NOT a valid bound — fabricating partitionCount/rows here would let the
+        //     gate push exactly the high-cardinality aggregation it exists to decline.
+        //   - A partition-key PREFIX, or grouping on a non-key / low-cardinality column.
         return java.util.OptionalDouble.empty();
     }
 
-    private static Set<String> fold(List<String> names) {
-        Set<String> out = new java.util.HashSet<>();
-        for (String n : names) {
-            out.add(foldName(n));
+    /**
+     * True iff EVERY key column is matched by some grouping name under CQL identifier
+     * rules (unquoted: case-insensitive; quoted: exact). An empty key list is trivially
+     * covered.
+     */
+    private static boolean coversAll(
+            List<PrimaryKeyExtractor.KeyColumn> keyColumns, List<String> groupingColumns) {
+        for (PrimaryKeyExtractor.KeyColumn key : keyColumns) {
+            boolean matched = false;
+            for (String g : groupingColumns) {
+                if (key.matches(g)) {
+                    matched = true;
+                    break;
+                }
+            }
+            if (!matched) {
+                return false;
+            }
         }
-        return out;
+        return true;
     }
 
-    /** Match {@link PrimaryKeyExtractor}'s normalization: unquoted names lower-cased. */
-    private static String foldName(String name) {
-        return name == null ? null : name.toLowerCase(java.util.Locale.ROOT);
+    /**
+     * True iff AT LEAST ONE key column is matched by some grouping name (same CQL
+     * identifier rules as {@link #coversAll}). Used to detect whether a grouping
+     * slices partitions by any clustering column.
+     */
+    private static boolean touchesAny(
+            List<PrimaryKeyExtractor.KeyColumn> keyColumns, List<String> groupingColumns) {
+        for (PrimaryKeyExtractor.KeyColumn key : keyColumns) {
+            for (String g : groupingColumns) {
+                if (key.matches(g)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     /**

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightMetadata.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightMetadata.java
@@ -496,6 +496,14 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
      */
     static java.util.OptionalDouble estimateGroupRatio(
             String ddl, List<String> groupingColumns, TableStats stats) {
+        // Fail closed to "no estimate" when the per-table counts are INCOMPLETE
+        // (some node's Statistics.db failed to decode; issue #944, #28). Partial
+        // sums are not authoritative — a skipped SSTable could hold many rows/groups,
+        // biasing the ratio low and PUSHING a high-cardinality GROUP BY that should
+        // have been declined. Empty here means AUTOMATIC pushes (the safe default).
+        if (!stats.complete()) {
+            return java.util.OptionalDouble.empty();
+        }
         long rows = stats.liveRows();
         long partitions = stats.partitionCount();
         if (rows <= 0 || groupingColumns.isEmpty()) {
@@ -721,8 +729,10 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
      * across the table's SSTables (an upper bound; see {@link TableStats}); we report
      * it as the table's row-count estimate. Column-level stats are left unknown —
      * Cassandra 5.0 stores no reliable per-regular-column NDV, so reporting any would
-     * be a heuristic (#28). A failed/zero fetch yields {@link TableStatistics#empty()}
-     * (unknown), which is always a safe input for the optimizer.
+     * be a heuristic (#28). A failed, zero, or INCOMPLETE fetch (some node's
+     * {@code Statistics.db} failed to decode → {@code !stats.complete()}) yields
+     * {@link TableStatistics#empty()} (unknown), which is always a safe input for
+     * the optimizer — we never report a row count derived from incomplete data.
      *
      * <p>For an <em>aggregated</em> handle the scan's OUTPUT cardinality is the
      * aggregate-result cardinality, NOT the base-table row count (issue #944): a
@@ -748,7 +758,11 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
         } catch (RuntimeException e) {
             return TableStatistics.empty();
         }
-        if (stats.liveRows() <= 0) {
+        // Fail closed to "unknown" when the counts are INCOMPLETE (a node's
+        // Statistics.db failed to decode; issue #944, #28): an under-counted
+        // row total is NOT authoritative, so report no estimate rather than a
+        // biased one. Empty is always a safe optimizer input.
+        if (!stats.complete() || stats.liveRows() <= 0) {
             return TableStatistics.empty();
         }
         return TableStatistics.builder()

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightMetadata.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightMetadata.java
@@ -610,59 +610,135 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
 
     /**
      * Fetch the AUTHORITATIVE per-table statistics by summing the
-     * {@code table_stats} action across the distinct flight nodes in the ring
-     * (issue #944). Summing across replicas over-counts by the replication factor,
+     * {@code table_stats} action across the REPLICA hosts that own this keyspace
+     * (issue #944). The target host set is scoped to the keyspace's read replicas
+     * (from {@link SidecarClient#tokenRangeReplicas}) rather than the whole cluster
+     * ring: in multi-DC / keyspace-scoped replication a ring entry can be a node that
+     * does NOT host this keyspace at all, and fanning out to it would either waste an
+     * RPC or — if that node answered {@code not_found} — wrongly taint completeness.
+     * Summing across the keyspace's replicas over-counts by the replication factor,
      * which is acceptable for an UPPER-BOUND gate input (it only ever errs toward
      * DECLINING pushdown).
      *
-     * <p>If ANY distinct ring node that should have been queried FAILS to return
-     * stats, the aggregate is tainted INCOMPLETE: we fold {@link TableStats#UNAVAILABLE}
-     * (an incomplete sentinel) so the AND-of-{@code complete} in {@link TableStats#plus}
-     * becomes {@code false}. A failed node is NOT silently dropped — its peers'
-     * partial totals must not be treated as authoritative (issue #944, #28), so the
-     * caller fails closed to "no estimate" rather than dividing the gate/optimizer by
-     * an under-counted row total.
+     * <p>If ANY replica host that should have been queried is UNREACHABLE (a transport
+     * failure), the aggregate is tainted INCOMPLETE: we fold {@link TableStats#UNAVAILABLE}
+     * so the AND-of-{@code complete} in {@link TableStats#plus} becomes {@code false} and
+     * the caller fails closed to "no estimate" (issue #944, #28). A replica that RESPONDS
+     * {@code not_found} (it does not currently host this keyspace/table — e.g. replica
+     * metadata drift) is NOT a failure: it contributes nothing ({@link TableStats#EMPTY})
+     * and does NOT taint completeness.
      */
     private TableStats fetchTableStats(CqliteFlightTableHandle handle) {
         byte[] body = tableStatsRequest(handle.keyspace(), handle.table());
         int port = config.flightPort();
-        return aggregateNodeStats(
-                sidecar.ring().entries(), address -> flight.tableStats(address, port, body));
+        Set<String> hosts =
+                replicaHosts(sidecar.tokenRangeReplicas(handle.keyspace()), config.localDatacenter());
+        return aggregateNodeStats(hosts, address -> flight.tableStats(address, port, body));
     }
 
     /**
-     * Aggregate per-node {@code table_stats} across the DISTINCT addresses in
-     * {@code nodes} by summing {@link TableStats#plus} (issue #944). Pulled out as a
-     * package-private static seam so the completeness-tainting behavior can be unit
-     * tested without a live Sidecar/Flight client.
+     * Distinct replica HOSTS that own a keyspace, derived from its token-range read
+     * replicas (issue #944). The Sidecar returns replicas as {@code "ip:storage_port"}
+     * grouped by datacenter; we strip the port (the flight server listens on the
+     * configured flight port at the same host) and de-duplicate across all ranges and
+     * datacenters. Scoping the stats fan-out to these hosts — instead of the cluster
+     * ring — keeps a node that does not host this keyspace out of the completeness
+     * calculation entirely. Static and package-private for unit testing without a live
+     * Sidecar.
+     */
+    static Set<String> replicaHosts(
+            in.mcfad.cqlite.flight.sidecar.SidecarModels.TokenRangeReplicasResponse replicas,
+            String localDatacenter) {
+        Set<String> hosts = new LinkedHashSet<>();
+        if (replicas == null || replicas.readReplicas() == null) {
+            return hosts;
+        }
+        for (var range : replicas.readReplicas()) {
+            if (range.replicasByDatacenter() == null) {
+                continue;
+            }
+            for (List<String> dcReplicas : range.replicasByDatacenter().values()) {
+                if (dcReplicas == null) {
+                    continue;
+                }
+                for (String replica : dcReplicas) {
+                    if (replica != null && !replica.isBlank()) {
+                        hosts.add(CqliteFlightSplitManager.hostOnly(replica));
+                    }
+                }
+            }
+        }
+        return hosts;
+    }
+
+    /**
+     * Aggregate per-host {@code table_stats} across the DISTINCT replica
+     * {@code hosts} by summing {@link TableStats#plus} (issue #944). Pulled out as a
+     * package-private static seam so the completeness-classification behavior can be
+     * unit tested without a live Sidecar/Flight client.
      *
-     * <p>For each distinct, non-null address {@code fetch} is invoked. If the fetch
-     * THROWS for a node we should have queried, the node is NOT silently dropped: an
-     * incomplete {@link TableStats#UNAVAILABLE} sentinel is folded in, so the AND-of-
-     * {@code complete} in {@link TableStats#plus} taints the whole aggregate to
-     * {@code complete=false}. A partial cross-ring total is therefore reported as
-     * "no estimate" (the caller fails closed) rather than as authoritative.
+     * <p>For each distinct, non-null host {@code fetch} is invoked:
+     * <ul>
+     *   <li>SUCCESS — its (possibly incomplete) response is summed.</li>
+     *   <li>{@code not_found} — the host responded that it does not host this
+     *       keyspace/table. This is NOT a failure: it contributes
+     *       {@link TableStats#EMPTY} (nothing) and does NOT taint completeness. A
+     *       legitimate not-hosting replica must not disable the gate everywhere.</li>
+     *   <li>any other RuntimeException (transport/unreachable) — the host should have
+     *       answered but could not, so it is NOT silently dropped: an incomplete
+     *       {@link TableStats#UNAVAILABLE} sentinel is folded in, tainting the
+     *       aggregate to {@code complete=false} so the caller fails closed.</li>
+     * </ul>
      */
     static TableStats aggregateNodeStats(
-            Iterable<RingEntry> nodes, java.util.function.Function<String, TableStats> fetch) {
+            Iterable<String> hosts, java.util.function.Function<String, TableStats> fetch) {
         TableStats total = TableStats.EMPTY;
         Set<String> seen = new LinkedHashSet<>();
-        for (RingEntry node : nodes) {
-            String address = node.address();
+        for (String address : hosts) {
             if (address == null || !seen.add(address)) {
                 continue;
             }
             try {
                 total = total.plus(fetch.apply(address));
             } catch (RuntimeException e) {
-                // A node we should have queried could not answer. Do NOT silently drop
-                // it: fold an incomplete sentinel so the cross-ring aggregate is marked
-                // incomplete (complete=false), forcing the caller to "no estimate"
-                // instead of treating the peers' partial totals as authoritative.
+                if (isNotHosting(e)) {
+                    // The replica responded "table/keyspace absent" (Flight NOT_FOUND).
+                    // It legitimately hosts no data for this table — contribute nothing
+                    // and do NOT taint completeness, so a not-hosting replica in a
+                    // multi-DC / keyspace-scoped layout cannot disable the gate.
+                    continue;
+                }
+                // A replica we should have reached could not answer (transport failure).
+                // Do NOT silently drop it: fold an incomplete sentinel so the aggregate
+                // is marked incomplete (complete=false), forcing the caller to "no
+                // estimate" instead of treating peers' partial totals as authoritative.
                 total = total.plus(TableStats.UNAVAILABLE);
             }
         }
         return total;
+    }
+
+    /**
+     * Classify a {@code table_stats} fetch failure: a Flight {@code NOT_FOUND} status
+     * means the queried node does not host this keyspace/table (it responded), which
+     * is a legitimate not-a-failure that must NOT taint completeness. Any other error
+     * (transport/unreachable, internal) DOES taint. The NOT_FOUND status can be wrapped
+     * (the client rethrows runtime exceptions and wraps checked ones), so we walk the
+     * cause chain looking for a Flight {@link org.apache.arrow.flight.FlightRuntimeException}
+     * carrying {@link org.apache.arrow.flight.FlightStatusCode#NOT_FOUND}.
+     */
+    static boolean isNotHosting(Throwable error) {
+        for (Throwable t = error; t != null; t = t.getCause()) {
+            if (t instanceof org.apache.arrow.flight.FlightRuntimeException fre
+                    && fre.status() != null
+                    && fre.status().code() == org.apache.arrow.flight.FlightStatusCode.NOT_FOUND) {
+                return true;
+            }
+            if (t.getCause() == t) {
+                break;
+            }
+        }
+        return false;
     }
 
     /** Build the {@code table_stats} action body (JSON {@code TableStatsRequest}). */

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightMetadata.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightMetadata.java
@@ -653,11 +653,16 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
      * Distinct replica HOSTS that own a keyspace, derived from its token-range read
      * replicas (issue #944). The Sidecar returns replicas as {@code "ip:storage_port"}
      * grouped by datacenter; we strip the port (the flight server listens on the
-     * configured flight port at the same host) and de-duplicate across all ranges and
-     * datacenters. Scoping the stats fan-out to these hosts — instead of the cluster
-     * ring — keeps a node that does not host this keyspace out of the completeness
-     * calculation entirely. Static and package-private for unit testing without a live
-     * Sidecar.
+     * configured flight port at the same host) and de-duplicate across ranges.
+     *
+     * <p>The datacenter selection MUST match {@link CqliteFlightSplitManager#buildSplits}
+     * (via {@link CqliteFlightSplitManager#pickReplica}): split selection reads each range
+     * ONLY from the configured {@code localDatacenter} when that DC has replicas for the
+     * range, falling back to all DCs only when the local DC has none (or no local DC is
+     * configured). Fanning {@code table_stats} out to remote-DC replicas that the query
+     * would never read adds planning-time timeouts and can wrongly taint completeness
+     * against unreachable remote nodes — so this method applies the same per-range
+     * DC scoping. Static and package-private for unit testing without a live Sidecar.
      */
     static Set<String> replicaHosts(
             in.mcfad.cqlite.flight.sidecar.SidecarModels.TokenRangeReplicasResponse replicas,
@@ -667,21 +672,34 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
             return hosts;
         }
         for (var range : replicas.readReplicas()) {
-            if (range.replicasByDatacenter() == null) {
+            Map<String, List<String>> byDc = range.replicasByDatacenter();
+            if (byDc == null) {
                 continue;
             }
-            for (List<String> dcReplicas : range.replicasByDatacenter().values()) {
-                if (dcReplicas == null) {
-                    continue;
-                }
-                for (String replica : dcReplicas) {
-                    if (replica != null && !replica.isBlank()) {
-                        hosts.add(CqliteFlightSplitManager.hostOnly(replica));
-                    }
+            // Mirror buildSplits/pickReplica DC scoping: use the local DC's replicas for
+            // this range when present, else fall back to every DC's replicas.
+            List<String> local =
+                    localDatacenter != null ? byDc.get(localDatacenter) : null;
+            if (local != null && !local.isEmpty()) {
+                addHosts(hosts, local);
+            } else {
+                for (List<String> dcReplicas : byDc.values()) {
+                    addHosts(hosts, dcReplicas);
                 }
             }
         }
         return hosts;
+    }
+
+    private static void addHosts(Set<String> hosts, List<String> replicas) {
+        if (replicas == null) {
+            return;
+        }
+        for (String replica : replicas) {
+            if (replica != null && !replica.isBlank()) {
+                hosts.add(CqliteFlightSplitManager.hostOnly(replica));
+            }
+        }
     }
 
     /**

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightMetadata.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightMetadata.java
@@ -723,10 +723,25 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
      * Cassandra 5.0 stores no reliable per-regular-column NDV, so reporting any would
      * be a heuristic (#28). A failed/zero fetch yields {@link TableStatistics#empty()}
      * (unknown), which is always a safe input for the optimizer.
+     *
+     * <p>For an <em>aggregated</em> handle the scan's OUTPUT cardinality is the
+     * aggregate-result cardinality, NOT the base-table row count (issue #944): a
+     * GLOBAL aggregate (no GROUP BY) emits exactly one row, so we report {@code
+     * ROW_COUNT = 1}; a grouped aggregate's output group count is not authoritatively
+     * known, so we return {@link TableStatistics#empty()} and let Trino estimate
+     * rather than fabricate (#28).
      */
     @Override
     public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle table) {
         CqliteFlightTableHandle handle = (CqliteFlightTableHandle) table;
+        if (handle.isAggregated()) {
+            if (handle.hasGroupBy()) {
+                // Grouped aggregate: output group count is unknown — do not guess.
+                return TableStatistics.empty();
+            }
+            // Global aggregate (e.g. count(*) with no GROUP BY): exactly one row.
+            return TableStatistics.builder().setRowCount(Estimate.of(1)).build();
+        }
         TableStats stats;
         try {
             stats = fetchTableStats(handle);

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightMetadata.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightMetadata.java
@@ -260,18 +260,6 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
             groupByNameSet.add(col.name());
         }
 
-        // Cardinality / operator gate (issue #893, #944). Global aggregates (no
-        // GROUP BY) are an unconditional data-reduction win and are NEVER gated —
-        // they bypass this check. For a GROUP BY, the single-finalize-split design
-        // degrades to break-even-to-loss as distinct groups approach the row count,
-        // so honor the operator policy and decline when the estimated group ratio is
-        // too high. The ratio is only needed for the AUTOMATIC policy, so the
-        // (network) stats fetch is skipped under NEVER/ALWAYS.
-        if (hasGroupBy && declineGroupByPushdown(
-                groupByPolicy(), groupRatioForGate(table, groupingColumns), maxGroupRatio())) {
-            return Optional.empty();
-        }
-
         // Translate each Trino aggregate into one or more server partial aggregates,
         // assigning deterministic output names (agg0, agg1, ...) that are kept
         // DISTINCT from the grouping column names — both share one Arrow partial
@@ -364,6 +352,21 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
                     return Optional.empty(); // unsupported aggregate function
                 }
             }
+        }
+
+        // Cardinality / operator gate (issue #893, #944). Run AFTER aggregate/argument
+        // support validation so we only fetch (network) stats for an aggregation that is
+        // OTHERWISE PUSHABLE — an aggregation declined above for an unsupported function,
+        // argument shape, DISTINCT/FILTER/ORDER BY, etc. never fans out to Sidecar/Flight
+        // for stats. Global aggregates (no GROUP BY) are an unconditional data-reduction
+        // win and are NEVER gated — they bypass this check. For a GROUP BY, the
+        // single-finalize-split design degrades to break-even-to-loss as distinct groups
+        // approach the row count, so honor the operator policy and decline when the
+        // estimated group ratio is too high. The ratio is only needed for the AUTOMATIC
+        // policy, so the stats fetch is skipped under NEVER/ALWAYS too.
+        if (hasGroupBy && declineGroupByPushdown(
+                groupByPolicy(), groupRatioForGate(table, groupingColumns), maxGroupRatio())) {
+            return Optional.empty();
         }
 
         // Grouping columns pass through. They are threaded ONLY via
@@ -627,13 +630,23 @@ public class CqliteFlightMetadata implements ConnectorMetadata {
      * {@code not_found} (it does not currently host this keyspace/table — e.g. replica
      * metadata drift) is NOT a failure: it contributes nothing ({@link TableStats#EMPTY})
      * and does NOT taint completeness.
+     *
+     * <p>Package-private and overridable as a test seam (issue #944): a subclass can
+     * observe whether this planning-time stats fetch was invoked. It MUST NOT be for an
+     * aggregation declined for an unsupported function/argument shape (the fetch now runs
+     * only on the otherwise-pushable path), and MUST be for a supported AUTOMATIC GROUP BY.
      */
-    private TableStats fetchTableStats(CqliteFlightTableHandle handle) {
+    TableStats fetchTableStats(CqliteFlightTableHandle handle) {
         byte[] body = tableStatsRequest(handle.keyspace(), handle.table());
         int port = config.flightPort();
+        // Bound each per-replica DoAction with a deadline (issue #944): this runs during
+        // query planning, so a slow/half-open endpoint must degrade to "no estimate"
+        // (a TIMED_OUT FlightRuntimeException → the fetch-failure → UNAVAILABLE path in
+        // aggregateNodeStats), never stall the planner.
+        long timeoutMillis = config.tableStatsTimeoutMillis();
         Set<String> hosts =
                 replicaHosts(sidecar.tokenRangeReplicas(handle.keyspace()), config.localDatacenter());
-        return aggregateNodeStats(hosts, address -> flight.tableStats(address, port, body));
+        return aggregateNodeStats(hosts, address -> flight.tableStats(address, port, body, timeoutMillis));
     }
 
     /**

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightTableHandle.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/CqliteFlightTableHandle.java
@@ -1,5 +1,7 @@
 package in.mcfad.cqlite.flight;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.trino.spi.connector.ConnectorTableHandle;
 
 import java.util.Optional;
@@ -45,5 +47,29 @@ public record CqliteFlightTableHandle(
     /** True when this handle carries a pushed-down aggregation (the finalize-split path). */
     public boolean isAggregated() {
         return aggregationJson.isPresent();
+    }
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /**
+     * True when this aggregated handle carries a non-empty GROUP BY (a grouped
+     * aggregate), false for a GLOBAL aggregate (no GROUP BY). Reads the {@code
+     * group_by} array of the carried {@code aggregationJson} — the authoritative,
+     * already-serialized signal {@link CqliteFlightMetadata#applyAggregation} put
+     * there — rather than introducing new handle state. Returns {@code false} when
+     * the handle is not aggregated or the JSON is absent/unparseable (treated as a
+     * global aggregate, i.e. one output row).
+     */
+    public boolean hasGroupBy() {
+        if (aggregationJson.isEmpty()) {
+            return false;
+        }
+        try {
+            JsonNode root = MAPPER.readTree(aggregationJson.get());
+            JsonNode groupBy = root.get("group_by");
+            return groupBy != null && groupBy.isArray() && !groupBy.isEmpty();
+        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+            return false;
+        }
     }
 }

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/PrimaryKeyExtractor.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/PrimaryKeyExtractor.java
@@ -1,0 +1,206 @@
+package in.mcfad.cqlite.flight;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Extracts the partition-key and clustering-column names from a single
+ * {@code CREATE TABLE} DDL (issue #944). Used by
+ * {@link CqliteFlightMetadata#estimateGroupRatio} to map a GROUP BY shape onto
+ * the authoritative partition/row counts.
+ *
+ * <p>Handles both PRIMARY KEY spellings Cassandra emits:
+ * <ul>
+ *   <li>Inline single-column: {@code id int PRIMARY KEY} → partition key = [id],
+ *       no clustering columns.</li>
+ *   <li>Composite clause: {@code PRIMARY KEY ((pk1, pk2), ck1, ck2)} → partition
+ *       key = [pk1, pk2], clustering = [ck1, ck2]; or
+ *       {@code PRIMARY KEY (pk, ck1, ck2)} → partition key = [pk], clustering =
+ *       [ck1, ck2].</li>
+ * </ul>
+ *
+ * <p>This is a best-effort structural parse of the DDL the connector already
+ * carries on the table handle — it never inspects data. When the PRIMARY KEY
+ * cannot be located the key lists are empty and the caller falls back to the
+ * safe default (push), so a parse miss is never a correctness risk.
+ */
+public final class PrimaryKeyExtractor {
+    private PrimaryKeyExtractor() {}
+
+    /** Resolved key columns of a table. */
+    public record Keys(List<String> partitionKey, List<String> clusteringColumns) {
+        /** Distinct names of partition + clustering columns, lower-cased. */
+        public Set<String> allKeyColumns() {
+            Set<String> all = new LinkedHashSet<>(partitionKey);
+            all.addAll(clusteringColumns);
+            return all;
+        }
+    }
+
+    private static final Pattern PK_CLAUSE =
+            Pattern.compile("(?is)PRIMARY\\s+KEY\\s*\\(");
+    private static final Pattern INLINE_PK =
+            Pattern.compile("(?is)\\bPRIMARY\\s+KEY\\b");
+
+    /**
+     * Parse the partition-key and clustering columns out of {@code ddl}. Returns
+     * empty lists when no PRIMARY KEY can be located.
+     */
+    public static Keys extract(String ddl) {
+        if (ddl == null) {
+            return new Keys(List.of(), List.of());
+        }
+        Matcher clause = PK_CLAUSE.matcher(ddl);
+        if (clause.find()) {
+            return parseClause(ddl, clause.end() - 1);
+        }
+        // Inline single-column form: "<col> <type> PRIMARY KEY".
+        Matcher inline = INLINE_PK.matcher(ddl);
+        if (inline.find()) {
+            String col = inlinePartitionColumn(ddl, inline.start());
+            if (col != null) {
+                return new Keys(List.of(col), List.of());
+            }
+        }
+        return new Keys(List.of(), List.of());
+    }
+
+    /**
+     * Parse {@code PRIMARY KEY ( ... )} starting at {@code openParen} (the index of
+     * the opening parenthesis of the PRIMARY KEY clause).
+     */
+    private static Keys parseClause(String ddl, int openParen) {
+        // Capture the balanced parenthesis body of the PRIMARY KEY clause.
+        int depth = 0;
+        int close = -1;
+        for (int i = openParen; i < ddl.length(); i++) {
+            char c = ddl.charAt(i);
+            if (c == '(') {
+                depth++;
+            } else if (c == ')') {
+                depth--;
+                if (depth == 0) {
+                    close = i;
+                    break;
+                }
+            }
+        }
+        if (close < 0) {
+            return new Keys(List.of(), List.of());
+        }
+        String body = ddl.substring(openParen + 1, close);
+
+        // Split top-level (depth-0) commas; a leading "(...)" is the composite
+        // partition key, everything after it is clustering columns.
+        List<String> topLevel = new ArrayList<>();
+        List<String> partitionKey = new ArrayList<>();
+        boolean compositePk = body.trim().startsWith("(");
+        int d = 0;
+        StringBuilder cur = new StringBuilder();
+        for (int i = 0; i < body.length(); i++) {
+            char c = body.charAt(i);
+            if (c == '(') {
+                d++;
+                if (!(compositePk && d == 1)) {
+                    cur.append(c);
+                }
+            } else if (c == ')') {
+                d--;
+                if (compositePk && d == 0) {
+                    // End of the composite partition-key group.
+                    for (String p : cur.toString().split(",")) {
+                        addName(partitionKey, p);
+                    }
+                    cur.setLength(0);
+                } else {
+                    cur.append(c);
+                }
+            } else if (c == ',' && d == 0) {
+                topLevel.add(cur.toString());
+                cur.setLength(0);
+            } else {
+                cur.append(c);
+            }
+        }
+        if (cur.length() > 0) {
+            topLevel.add(cur.toString());
+        }
+
+        List<String> clustering = new ArrayList<>();
+        if (compositePk) {
+            // partitionKey already filled from the "(...)" group; topLevel holds the
+            // clustering columns (the first topLevel entry may be empty from the
+            // comma right after the closing ')').
+            for (String t : topLevel) {
+                addName(clustering, t);
+            }
+        } else {
+            // Simple PK: first top-level name is the partition key, rest cluster.
+            for (int i = 0; i < topLevel.size(); i++) {
+                if (i == 0) {
+                    addName(partitionKey, topLevel.get(i));
+                } else {
+                    addName(clustering, topLevel.get(i));
+                }
+            }
+        }
+        return new Keys(List.copyOf(partitionKey), List.copyOf(clustering));
+    }
+
+    /**
+     * For the inline form, the partition-key column is the identifier immediately
+     * preceding its type in the column definition that ends with PRIMARY KEY:
+     * {@code "<name> <type> PRIMARY KEY"}. Walk back from the PRIMARY KEY keyword
+     * to the start of the column definition (the previous top-level comma or open
+     * paren) and take the first identifier.
+     */
+    private static String inlinePartitionColumn(String ddl, int primaryKeyStart) {
+        int start = primaryKeyStart;
+        int depth = 0;
+        while (start > 0) {
+            char c = ddl.charAt(start - 1);
+            if (c == ')') {
+                depth++;
+            } else if (c == '(') {
+                if (depth == 0) {
+                    break;
+                }
+                depth--;
+            } else if (c == ',' && depth == 0) {
+                break;
+            }
+            start--;
+        }
+        String def = ddl.substring(start, primaryKeyStart).trim();
+        if (def.isEmpty()) {
+            return null;
+        }
+        String first = def.split("\\s+")[0];
+        return normalize(first);
+    }
+
+    private static void addName(List<String> out, String raw) {
+        String n = normalize(raw);
+        if (n != null && !n.isEmpty()) {
+            out.add(n);
+        }
+    }
+
+    /** Strip whitespace + double-quotes and lower-case for case-insensitive match. */
+    private static String normalize(String raw) {
+        if (raw == null) {
+            return null;
+        }
+        String s = raw.trim();
+        if (s.startsWith("\"") && s.endsWith("\"") && s.length() >= 2) {
+            // Quoted identifiers are case-sensitive in CQL; preserve case but drop quotes.
+            return s.substring(1, s.length() - 1);
+        }
+        return s.isEmpty() ? "" : s.toLowerCase(Locale.ROOT);
+    }
+}

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/PrimaryKeyExtractor.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/PrimaryKeyExtractor.java
@@ -32,12 +32,34 @@ import java.util.regex.Pattern;
 public final class PrimaryKeyExtractor {
     private PrimaryKeyExtractor() {}
 
+    /**
+     * A primary-key column name together with whether it was a quoted identifier in
+     * the DDL. CQL identifiers are case-insensitive ONLY when unquoted; a quoted
+     * identifier is case-sensitive and must compare exactly. {@link #name} is the
+     * canonical stored name (unquoted → lower-cased; quoted → exact case, quotes
+     * stripped); {@code quoted} records which folding rule applies on comparison.
+     */
+    public record KeyColumn(String name, boolean quoted) {
+        /** Match {@code other} against this key column under CQL identifier rules. */
+        public boolean matches(String other) {
+            if (other == null) {
+                return false;
+            }
+            return quoted ? name.equals(other) : name.equalsIgnoreCase(other);
+        }
+    }
+
     /** Resolved key columns of a table. */
-    public record Keys(List<String> partitionKey, List<String> clusteringColumns) {
-        /** Distinct names of partition + clustering columns, lower-cased. */
+    public record Keys(List<KeyColumn> partitionKey, List<KeyColumn> clusteringColumns) {
+        /** Distinct names of partition + clustering columns (canonical/stored case). */
         public Set<String> allKeyColumns() {
-            Set<String> all = new LinkedHashSet<>(partitionKey);
-            all.addAll(clusteringColumns);
+            Set<String> all = new LinkedHashSet<>();
+            for (KeyColumn k : partitionKey) {
+                all.add(k.name());
+            }
+            for (KeyColumn k : clusteringColumns) {
+                all.add(k.name());
+            }
             return all;
         }
     }
@@ -62,7 +84,7 @@ public final class PrimaryKeyExtractor {
         // Inline single-column form: "<col> <type> PRIMARY KEY".
         Matcher inline = INLINE_PK.matcher(ddl);
         if (inline.find()) {
-            String col = inlinePartitionColumn(ddl, inline.start());
+            KeyColumn col = inlinePartitionColumn(ddl, inline.start());
             if (col != null) {
                 return new Keys(List.of(col), List.of());
             }
@@ -98,7 +120,7 @@ public final class PrimaryKeyExtractor {
         // Split top-level (depth-0) commas; a leading "(...)" is the composite
         // partition key, everything after it is clustering columns.
         List<String> topLevel = new ArrayList<>();
-        List<String> partitionKey = new ArrayList<>();
+        List<KeyColumn> partitionKey = new ArrayList<>();
         boolean compositePk = body.trim().startsWith("(");
         int d = 0;
         StringBuilder cur = new StringBuilder();
@@ -131,7 +153,7 @@ public final class PrimaryKeyExtractor {
             topLevel.add(cur.toString());
         }
 
-        List<String> clustering = new ArrayList<>();
+        List<KeyColumn> clustering = new ArrayList<>();
         if (compositePk) {
             // partitionKey already filled from the "(...)" group; topLevel holds the
             // clustering columns (the first topLevel entry may be empty from the
@@ -159,7 +181,7 @@ public final class PrimaryKeyExtractor {
      * to the start of the column definition (the previous top-level comma or open
      * paren) and take the first identifier.
      */
-    private static String inlinePartitionColumn(String ddl, int primaryKeyStart) {
+    private static KeyColumn inlinePartitionColumn(String ddl, int primaryKeyStart) {
         int start = primaryKeyStart;
         int depth = 0;
         while (start > 0) {
@@ -184,23 +206,29 @@ public final class PrimaryKeyExtractor {
         return normalize(first);
     }
 
-    private static void addName(List<String> out, String raw) {
-        String n = normalize(raw);
-        if (n != null && !n.isEmpty()) {
-            out.add(n);
+    private static void addName(List<KeyColumn> out, String raw) {
+        KeyColumn k = normalize(raw);
+        if (k != null && !k.name().isEmpty()) {
+            out.add(k);
         }
     }
 
-    /** Strip whitespace + double-quotes and lower-case for case-insensitive match. */
-    private static String normalize(String raw) {
+    /**
+     * Strip whitespace + the surrounding double-quotes of a quoted identifier, and
+     * record whether it was quoted. CQL folds UNQUOTED identifiers to lower case
+     * (case-insensitive) and preserves the exact case of QUOTED identifiers
+     * (case-sensitive); the {@code quoted} flag carries that distinction so the
+     * comparison side applies the right rule per column.
+     */
+    private static KeyColumn normalize(String raw) {
         if (raw == null) {
             return null;
         }
         String s = raw.trim();
         if (s.startsWith("\"") && s.endsWith("\"") && s.length() >= 2) {
-            // Quoted identifiers are case-sensitive in CQL; preserve case but drop quotes.
-            return s.substring(1, s.length() - 1);
+            // Quoted identifiers are case-sensitive in CQL; preserve case, drop quotes.
+            return new KeyColumn(s.substring(1, s.length() - 1), true);
         }
-        return s.isEmpty() ? "" : s.toLowerCase(Locale.ROOT);
+        return new KeyColumn(s.isEmpty() ? "" : s.toLowerCase(Locale.ROOT), false);
     }
 }

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/TableStats.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/TableStats.java
@@ -23,6 +23,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * bound on distinct groups never under-counts, so the AUTOMATIC aggregation-
  * pushdown gate never wrongly pushes a genuinely high-cardinality GROUP BY.
  *
+ * <p>{@code complete} reports whether the sums cover EVERY SSTable: a per-node
+ * response is incomplete when any of that node's {@code Statistics.db} files failed
+ * to decode (issue #944, #28). Partial sums are NOT authoritative, so a consumer
+ * MUST fail closed to "no estimate" rather than derive a (biased) ratio or row
+ * count from them. The flag defaults to {@code false} when absent on the wire (an
+ * older server that predates the field) so we never treat unknown completeness as
+ * complete.
+ *
  * <p>Field names are snake_case on the wire to match serde; the Jackson
  * annotations map them to camelCase accessors.
  */
@@ -30,16 +38,31 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public record TableStats(
         @JsonProperty("live_rows") long liveRows,
         @JsonProperty("partition_count") long partitionCount,
-        @JsonProperty("sstable_count") long sstableCount) {
+        @JsonProperty("sstable_count") long sstableCount,
+        @JsonProperty("complete") boolean complete,
+        @JsonProperty("skipped_sstables") long skippedSstables) {
 
-    /** All-zero stats (no SSTables / no data). */
-    public static final TableStats EMPTY = new TableStats(0, 0, 0);
+    /**
+     * All-zero stats (no SSTables / no data). Trivially COMPLETE: there is nothing
+     * that could have been skipped — the per-node aggregate starts here and the
+     * {@code complete} flag is ANDed in {@link #plus}, so an empty start does not
+     * spuriously taint a real node's completeness.
+     */
+    public static final TableStats EMPTY = new TableStats(0, 0, 0, true, 0);
 
-    /** Element-wise sum, used to aggregate per-node responses across the ring. */
+    /**
+     * Element-wise sum, used to aggregate per-node responses across the ring. The
+     * {@code complete} flag is the logical AND of both sides: the aggregate is
+     * complete only if EVERY contributing node reported a complete decode, so a
+     * single node with an undecodable {@code Statistics.db} makes the whole
+     * cross-ring total incomplete (and thus "no estimate" for the gate).
+     */
     public TableStats plus(TableStats other) {
         return new TableStats(
                 Math.addExact(liveRows, other.liveRows),
                 Math.addExact(partitionCount, other.partitionCount),
-                Math.addExact(sstableCount, other.sstableCount));
+                Math.addExact(sstableCount, other.sstableCount),
+                complete && other.complete,
+                Math.addExact(skippedSstables, other.skippedSstables));
     }
 }

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/TableStats.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/TableStats.java
@@ -1,0 +1,45 @@
+package in.mcfad.cqlite.flight;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Per-table aggregate statistics returned by the cqlite-flight server's
+ * {@code table_stats} DoAction (issue #944, see the Rust
+ * {@code cqlite_flight::stats::TableStatsResponse}).
+ *
+ * <p>All three fields are AUTHORITATIVE per-SSTable sums decoded from each
+ * {@code Statistics.db} STATS component (no heuristics, #28):
+ *
+ * <ul>
+ *   <li>{@code liveRows} — Σ {@code totalRows} across the table's SSTables. An
+ *       UPPER BOUND on the table's true row count (pre-compaction overlap).</li>
+ *   <li>{@code partitionCount} — Σ {@code estimatedPartitionSize} histogram counts.
+ *       An UPPER BOUND on the table's true distinct-partition count.</li>
+ *   <li>{@code sstableCount} — number of SSTables that contributed.</li>
+ * </ul>
+ *
+ * <p>These per-SSTable / per-node sums are intentionally upper bounds: an upper
+ * bound on distinct groups never under-counts, so the AUTOMATIC aggregation-
+ * pushdown gate never wrongly pushes a genuinely high-cardinality GROUP BY.
+ *
+ * <p>Field names are snake_case on the wire to match serde; the Jackson
+ * annotations map them to camelCase accessors.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record TableStats(
+        @JsonProperty("live_rows") long liveRows,
+        @JsonProperty("partition_count") long partitionCount,
+        @JsonProperty("sstable_count") long sstableCount) {
+
+    /** All-zero stats (no SSTables / no data). */
+    public static final TableStats EMPTY = new TableStats(0, 0, 0);
+
+    /** Element-wise sum, used to aggregate per-node responses across the ring. */
+    public TableStats plus(TableStats other) {
+        return new TableStats(
+                Math.addExact(liveRows, other.liveRows),
+                Math.addExact(partitionCount, other.partitionCount),
+                Math.addExact(sstableCount, other.sstableCount));
+    }
+}

--- a/trino-connector/src/main/java/in/mcfad/cqlite/flight/TableStats.java
+++ b/trino-connector/src/main/java/in/mcfad/cqlite/flight/TableStats.java
@@ -51,6 +51,17 @@ public record TableStats(
     public static final TableStats EMPTY = new TableStats(0, 0, 0, true, 0);
 
     /**
+     * An INCOMPLETE, all-zero sentinel folded into the cross-ring aggregate when a
+     * ring node's {@code table_stats} call FAILS (issue #944). Because {@link #plus}
+     * ANDs the {@code complete} flags, folding this taints the whole aggregate to
+     * {@code complete=false} — so a node we should have queried but could not reach is
+     * never silently dropped, and a partial cross-ring total is correctly reported as
+     * "no estimate" rather than authoritative. It carries one {@code skippedSstables}
+     * so the failure is visible in the aggregate.
+     */
+    public static final TableStats UNAVAILABLE = new TableStats(0, 0, 0, false, 1);
+
+    /**
      * Element-wise sum, used to aggregate per-node responses across the ring. The
      * {@code complete} flag is the logical AND of both sides: the aggregate is
      * complete only if EVERY contributing node reported a complete decode, so a

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/AggregateNodeStatsTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/AggregateNodeStatsTest.java
@@ -1,0 +1,156 @@
+package in.mcfad.cqlite.flight;
+
+import in.mcfad.cqlite.flight.sidecar.SidecarModels.RingEntry;
+import io.trino.spi.statistics.TableStatistics;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.OptionalDouble;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link CqliteFlightMetadata#aggregateNodeStats} — the cross-ring
+ * {@code table_stats} aggregation seam (issue #944). When ANY distinct ring node that
+ * should have been queried FAILS to return stats, the aggregate must be tainted
+ * INCOMPLETE ({@code complete=false}) rather than silently dropping the node and
+ * treating its peers' partial totals as authoritative. Downstream, an incomplete
+ * aggregate must yield an empty group-ratio estimate and empty table statistics.
+ *
+ * <p>{@code aggregateNodeStats} is a package-private static seam so a failing node can
+ * be modeled by a {@code fetch} function that throws — no live Sidecar/Flight client.
+ */
+class AggregateNodeStatsTest {
+
+    /** A ring entry carrying only the address (the field {@code aggregateNodeStats} reads). */
+    private static RingEntry node(String address) {
+        return new RingEntry(null, address, null, null, null, null, null, null, null);
+    }
+
+    /** A complete per-node response with the given live-row count. */
+    private static TableStats ok(long liveRows, long partitions) {
+        return new TableStats(liveRows, partitions, 1, true, 0);
+    }
+
+    @Test
+    void allNodesSucceedAggregateIsComplete() {
+        List<RingEntry> ring = List.of(node("10.0.0.1"), node("10.0.0.2"));
+        Function<String, TableStats> fetch =
+                address -> address.equals("10.0.0.1") ? ok(100, 10) : ok(200, 20);
+
+        TableStats agg = CqliteFlightMetadata.aggregateNodeStats(ring, fetch);
+
+        assertTrue(agg.complete(), "every node returned → aggregate is complete");
+        assertEquals(300, agg.liveRows());
+        assertEquals(30, agg.partitionCount());
+        assertEquals(0, agg.skippedSstables());
+    }
+
+    @Test
+    void oneNodeFailureTaintsCompleteness() {
+        // Two distinct nodes; the second throws. The first node's totals must NOT be
+        // reported as authoritative — the aggregate is incomplete.
+        List<RingEntry> ring = List.of(node("10.0.0.1"), node("10.0.0.2"));
+        Function<String, TableStats> fetch = address -> {
+            if (address.equals("10.0.0.2")) {
+                throw new RuntimeException("node 10.0.0.2 unreachable");
+            }
+            return ok(100, 10);
+        };
+
+        TableStats agg = CqliteFlightMetadata.aggregateNodeStats(ring, fetch);
+
+        assertFalse(agg.complete(),
+                "a single failed ring node must taint the aggregate to incomplete");
+        assertEquals(100, agg.liveRows(), "the reachable node still contributed its totals");
+        assertTrue(agg.skippedSstables() >= 1, "the failed node is visible as a skip");
+    }
+
+    @Test
+    void firstNodeFailureStillTaintsWhenPeerSucceeds() {
+        // Order independence: the failing node is queried FIRST. The AND-of-complete
+        // in plus() must still make the whole aggregate incomplete.
+        List<RingEntry> ring = List.of(node("10.0.0.1"), node("10.0.0.2"));
+        Function<String, TableStats> fetch = address -> {
+            if (address.equals("10.0.0.1")) {
+                throw new RuntimeException("node 10.0.0.1 unreachable");
+            }
+            return ok(200, 20);
+        };
+
+        TableStats agg = CqliteFlightMetadata.aggregateNodeStats(ring, fetch);
+
+        assertFalse(agg.complete(), "fetch-failure order must not affect completeness");
+        assertEquals(200, agg.liveRows());
+    }
+
+    @Test
+    void duplicateAddressesAreQueriedOnce() {
+        // The ring can list the same address more than once; it is queried once and a
+        // success stays complete.
+        int[] calls = {0};
+        List<RingEntry> ring = List.of(node("10.0.0.1"), node("10.0.0.1"), node(null));
+        Function<String, TableStats> fetch = address -> {
+            calls[0]++;
+            return ok(50, 5);
+        };
+
+        TableStats agg = CqliteFlightMetadata.aggregateNodeStats(ring, fetch);
+
+        assertEquals(1, calls[0], "duplicate + null addresses queried at most once");
+        assertTrue(agg.complete());
+        assertEquals(50, agg.liveRows());
+    }
+
+    @Test
+    void incompleteAggregateYieldsEmptyGroupRatio() {
+        // End-to-end with the gate's pure function: an incomplete aggregate (from a
+        // failed node) gives NO group-ratio estimate, so AUTOMATIC pushdown declines
+        // to use a biased ratio (issue #944, #28).
+        List<RingEntry> ring = List.of(node("10.0.0.1"), node("10.0.0.2"));
+        Function<String, TableStats> fetch = address -> {
+            if (address.equals("10.0.0.2")) {
+                throw new RuntimeException("down");
+            }
+            return ok(2000, 10);
+        };
+
+        TableStats agg = CqliteFlightMetadata.aggregateNodeStats(ring, fetch);
+        assertFalse(agg.complete());
+
+        String ddl = "CREATE TABLE ks.t (pk int, ck int, v int, PRIMARY KEY (pk, ck))";
+        OptionalDouble ratio =
+                CqliteFlightMetadata.estimateGroupRatio(ddl, List.of("pk"), agg);
+        assertTrue(ratio.isEmpty(),
+                "incomplete cross-ring stats must produce no group-ratio estimate");
+    }
+
+    @Test
+    void incompleteAggregateYieldsEmptyTableStatistics() {
+        // The optimizer-facing path: getTableStatistics on a non-aggregated handle
+        // returns empty when the underlying counts are incomplete. We invoke the same
+        // completeness guard getTableStatistics uses (!complete -> empty).
+        List<RingEntry> ring = List.of(node("10.0.0.1"), node("10.0.0.2"));
+        Function<String, TableStats> fetch = address -> {
+            if (address.equals("10.0.0.2")) {
+                throw new RuntimeException("down");
+            }
+            return ok(2000, 10);
+        };
+
+        TableStats agg = CqliteFlightMetadata.aggregateNodeStats(ring, fetch);
+
+        TableStatistics result =
+                (!agg.complete() || agg.liveRows() <= 0)
+                        ? TableStatistics.empty()
+                        : TableStatistics.builder()
+                                .setRowCount(io.trino.spi.statistics.Estimate.of(agg.liveRows()))
+                                .build();
+        assertEquals(TableStatistics.empty(), result,
+                "incomplete cross-ring stats must yield empty table statistics");
+        assertTrue(result.getRowCount().isUnknown());
+    }
+}

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/AggregateNodeStatsTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/AggregateNodeStatsTest.java
@@ -2,7 +2,6 @@ package in.mcfad.cqlite.flight;
 
 import in.mcfad.cqlite.flight.sidecar.SidecarModels.ReplicaInfo;
 import in.mcfad.cqlite.flight.sidecar.SidecarModels.TokenRangeReplicasResponse;
-import io.trino.spi.statistics.TableStatistics;
 import org.apache.arrow.flight.CallStatus;
 import org.junit.jupiter.api.Test;
 
@@ -229,10 +228,11 @@ class AggregateNodeStatsTest {
     }
 
     @Test
-    void incompleteAggregateYieldsEmptyTableStatistics() {
-        // The optimizer-facing path: getTableStatistics on a non-aggregated handle
-        // returns empty when the underlying counts are incomplete. We invoke the same
-        // completeness guard getTableStatistics uses (!complete -> empty).
+    void unreachableReplicaTaintsAggregateIncomplete() {
+        // A down replica taints the cross-ring aggregate INCOMPLETE so its partial
+        // peers' totals are not treated as authoritative (issue #944). This feeds the
+        // RF-invariant group-ratio gate; the absolute optimizer row count is reported
+        // unknown regardless (see CqliteFlightTableStatisticsTest).
         List<String> hosts = List.of("10.0.0.1", "10.0.0.2");
         Function<String, TableStats> fetch = address -> {
             if (address.equals("10.0.0.2")) {
@@ -243,14 +243,7 @@ class AggregateNodeStatsTest {
 
         TableStats agg = CqliteFlightMetadata.aggregateNodeStats(hosts, fetch);
 
-        TableStatistics result =
-                (!agg.complete() || agg.liveRows() <= 0)
-                        ? TableStatistics.empty()
-                        : TableStatistics.builder()
-                                .setRowCount(io.trino.spi.statistics.Estimate.of(agg.liveRows()))
-                                .build();
-        assertEquals(TableStatistics.empty(), result,
-                "incomplete cross-ring stats must yield empty table statistics");
-        assertTrue(result.getRowCount().isUnknown());
+        assertFalse(agg.complete(),
+                "an unreachable replica must taint the cross-ring aggregate incomplete");
     }
 }

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/AggregateNodeStatsTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/AggregateNodeStatsTest.java
@@ -45,6 +45,11 @@ class AggregateNodeStatsTest {
         return CallStatus.NOT_FOUND.withDescription("table absent").toRuntimeException();
     }
 
+    /** The Flight runtime exception surfaced when the call's deadline (timeout) fires. */
+    private static RuntimeException timedOut() {
+        return CallStatus.TIMED_OUT.withDescription("table_stats deadline exceeded").toRuntimeException();
+    }
+
     @Test
     void allNodesSucceedAggregateIsComplete() {
         List<String> hosts = List.of("10.0.0.1", "10.0.0.2");
@@ -225,6 +230,53 @@ class AggregateNodeStatsTest {
                 CqliteFlightMetadata.estimateGroupRatio(ddl, List.of("pk"), agg);
         assertTrue(ratio.isEmpty(),
                 "incomplete cross-ring stats must produce no group-ratio estimate");
+    }
+
+    @Test
+    void timedOutReplicaIsTreatedAsUnavailableStats() {
+        // Fix 1 (issue #944): the planning-time table_stats DoAction is bounded by a
+        // deadline. When it fires, gRPC surfaces a FlightRuntimeException with status
+        // TIMED_OUT. That must be classified like any other fetch failure (NOT a
+        // not-hosting NOT_FOUND): the aggregate is tainted INCOMPLETE — never an
+        // exception escaping planning.
+        List<String> hosts = List.of("10.0.0.1", "10.0.0.2");
+        Function<String, TableStats> fetch = address -> {
+            if (address.equals("10.0.0.2")) {
+                throw timedOut();
+            }
+            return ok(2000, 10);
+        };
+
+        TableStats agg = CqliteFlightMetadata.aggregateNodeStats(hosts, fetch);
+
+        assertFalse(CqliteFlightMetadata.isNotHosting(timedOut()),
+                "a TIMED_OUT status is a fetch failure, not a not-hosting NOT_FOUND");
+        assertFalse(agg.complete(),
+                "a timed-out replica must taint the aggregate to incomplete (no estimate)");
+        assertEquals(2000, agg.liveRows(), "the reachable node still contributed its totals");
+        assertTrue(agg.skippedSstables() >= 1, "the timed-out node is visible as a skip");
+    }
+
+    @Test
+    void timedOutStatsYieldEmptyGroupRatioAndDoNotThrow() {
+        // End-to-end with the gate's pure function: a timed-out replica makes the
+        // cross-ring aggregate incomplete, so the AUTOMATIC group-ratio gate gets NO
+        // estimate (→ push). No exception escapes — planning degrades gracefully.
+        List<String> hosts = List.of("10.0.0.1", "10.0.0.2");
+        Function<String, TableStats> fetch = address -> {
+            if (address.equals("10.0.0.2")) {
+                throw timedOut();
+            }
+            return ok(2000, 10);
+        };
+
+        TableStats agg = CqliteFlightMetadata.aggregateNodeStats(hosts, fetch);
+        assertFalse(agg.complete());
+
+        String ddl = "CREATE TABLE ks.t (pk int, ck int, v int, PRIMARY KEY (pk, ck))";
+        OptionalDouble ratio = CqliteFlightMetadata.estimateGroupRatio(ddl, List.of("pk"), agg);
+        assertTrue(ratio.isEmpty(),
+                "timed-out (incomplete) stats must produce no group-ratio estimate (push)");
     }
 
     @Test

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/AggregateNodeStatsTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/AggregateNodeStatsTest.java
@@ -1,11 +1,15 @@
 package in.mcfad.cqlite.flight;
 
-import in.mcfad.cqlite.flight.sidecar.SidecarModels.RingEntry;
+import in.mcfad.cqlite.flight.sidecar.SidecarModels.ReplicaInfo;
+import in.mcfad.cqlite.flight.sidecar.SidecarModels.TokenRangeReplicasResponse;
 import io.trino.spi.statistics.TableStatistics;
+import org.apache.arrow.flight.CallStatus;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 import java.util.OptionalDouble;
+import java.util.Set;
 import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -13,35 +17,42 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Unit tests for {@link CqliteFlightMetadata#aggregateNodeStats} — the cross-ring
- * {@code table_stats} aggregation seam (issue #944). When ANY distinct ring node that
- * should have been queried FAILS to return stats, the aggregate must be tainted
- * INCOMPLETE ({@code complete=false}) rather than silently dropping the node and
- * treating its peers' partial totals as authoritative. Downstream, an incomplete
- * aggregate must yield an empty group-ratio estimate and empty table statistics.
+ * Unit tests for {@link CqliteFlightMetadata#aggregateNodeStats} and
+ * {@link CqliteFlightMetadata#replicaHosts} — the keyspace-replica-scoped
+ * {@code table_stats} aggregation seam (issue #944).
  *
- * <p>{@code aggregateNodeStats} is a package-private static seam so a failing node can
- * be modeled by a {@code fetch} function that throws — no live Sidecar/Flight client.
+ * <p>Completeness rules:
+ * <ul>
+ *   <li>A replica host that is UNREACHABLE (transport failure) taints the aggregate
+ *       INCOMPLETE ({@code complete=false}) — its peers' partial totals must not be
+ *       treated as authoritative.</li>
+ *   <li>A replica host that RESPONDS {@code not_found} (it does not host this
+ *       keyspace/table) is NOT a failure: it contributes nothing and does NOT taint.
+ *       A legitimate not-hosting node must not disable the gate everywhere.</li>
+ * </ul>
+ *
+ * <p>The seam is package-private and static so a failing/not-hosting node can be
+ * modeled by a {@code fetch} function that throws — no live Sidecar/Flight client.
  */
 class AggregateNodeStatsTest {
-
-    /** A ring entry carrying only the address (the field {@code aggregateNodeStats} reads). */
-    private static RingEntry node(String address) {
-        return new RingEntry(null, address, null, null, null, null, null, null, null);
-    }
 
     /** A complete per-node response with the given live-row count. */
     private static TableStats ok(long liveRows, long partitions) {
         return new TableStats(liveRows, partitions, 1, true, 0);
     }
 
+    /** The Flight runtime exception a node throws when it does not host the table. */
+    private static RuntimeException notFound() {
+        return CallStatus.NOT_FOUND.withDescription("table absent").toRuntimeException();
+    }
+
     @Test
     void allNodesSucceedAggregateIsComplete() {
-        List<RingEntry> ring = List.of(node("10.0.0.1"), node("10.0.0.2"));
+        List<String> hosts = List.of("10.0.0.1", "10.0.0.2");
         Function<String, TableStats> fetch =
                 address -> address.equals("10.0.0.1") ? ok(100, 10) : ok(200, 20);
 
-        TableStats agg = CqliteFlightMetadata.aggregateNodeStats(ring, fetch);
+        TableStats agg = CqliteFlightMetadata.aggregateNodeStats(hosts, fetch);
 
         assertTrue(agg.complete(), "every node returned → aggregate is complete");
         assertEquals(300, agg.liveRows());
@@ -50,10 +61,10 @@ class AggregateNodeStatsTest {
     }
 
     @Test
-    void oneNodeFailureTaintsCompleteness() {
-        // Two distinct nodes; the second throws. The first node's totals must NOT be
-        // reported as authoritative — the aggregate is incomplete.
-        List<RingEntry> ring = List.of(node("10.0.0.1"), node("10.0.0.2"));
+    void unreachableReplicaTaintsCompleteness() {
+        // Two distinct replica hosts; the second is UNREACHABLE (transport failure).
+        // The first host's totals must NOT be reported as authoritative.
+        List<String> hosts = List.of("10.0.0.1", "10.0.0.2");
         Function<String, TableStats> fetch = address -> {
             if (address.equals("10.0.0.2")) {
                 throw new RuntimeException("node 10.0.0.2 unreachable");
@@ -61,19 +72,19 @@ class AggregateNodeStatsTest {
             return ok(100, 10);
         };
 
-        TableStats agg = CqliteFlightMetadata.aggregateNodeStats(ring, fetch);
+        TableStats agg = CqliteFlightMetadata.aggregateNodeStats(hosts, fetch);
 
         assertFalse(agg.complete(),
-                "a single failed ring node must taint the aggregate to incomplete");
+                "a single unreachable replica must taint the aggregate to incomplete");
         assertEquals(100, agg.liveRows(), "the reachable node still contributed its totals");
         assertTrue(agg.skippedSstables() >= 1, "the failed node is visible as a skip");
     }
 
     @Test
-    void firstNodeFailureStillTaintsWhenPeerSucceeds() {
-        // Order independence: the failing node is queried FIRST. The AND-of-complete
+    void firstReplicaUnreachableStillTaintsWhenPeerSucceeds() {
+        // Order independence: the unreachable host is queried FIRST. The AND-of-complete
         // in plus() must still make the whole aggregate incomplete.
-        List<RingEntry> ring = List.of(node("10.0.0.1"), node("10.0.0.2"));
+        List<String> hosts = List.of("10.0.0.1", "10.0.0.2");
         Function<String, TableStats> fetch = address -> {
             if (address.equals("10.0.0.1")) {
                 throw new RuntimeException("node 10.0.0.1 unreachable");
@@ -81,24 +92,86 @@ class AggregateNodeStatsTest {
             return ok(200, 20);
         };
 
-        TableStats agg = CqliteFlightMetadata.aggregateNodeStats(ring, fetch);
+        TableStats agg = CqliteFlightMetadata.aggregateNodeStats(hosts, fetch);
 
         assertFalse(agg.complete(), "fetch-failure order must not affect completeness");
         assertEquals(200, agg.liveRows());
     }
 
     @Test
+    void notFoundResponseDoesNotTaintCompleteness() {
+        // A replica that legitimately does NOT host the table responds NOT_FOUND. It
+        // contributes nothing and must NOT taint completeness — the aggregate stays
+        // complete and the hosting node's totals are authoritative (issue #944).
+        List<String> hosts = List.of("10.0.0.1", "10.0.0.2");
+        Function<String, TableStats> fetch = address -> {
+            if (address.equals("10.0.0.2")) {
+                throw notFound();
+            }
+            return ok(100, 10);
+        };
+
+        TableStats agg = CqliteFlightMetadata.aggregateNodeStats(hosts, fetch);
+
+        assertTrue(agg.complete(),
+                "a not_found (not-hosting) replica must NOT taint completeness");
+        assertEquals(100, agg.liveRows(), "the hosting node's totals are authoritative");
+        assertEquals(10, agg.partitionCount());
+        assertEquals(0, agg.skippedSstables(),
+                "a not-hosting node is not counted as a skip");
+    }
+
+    @Test
+    void wrappedNotFoundIsClassifiedAsNotHosting() {
+        // The client may wrap the Flight NOT_FOUND in another runtime exception; the
+        // classifier walks the cause chain, so a wrapped NOT_FOUND still does not taint.
+        List<String> hosts = List.of("10.0.0.1", "10.0.0.2");
+        Function<String, TableStats> fetch = address -> {
+            if (address.equals("10.0.0.2")) {
+                throw new IllegalStateException("table_stats to 10.0.0.2 failed", notFound());
+            }
+            return ok(100, 10);
+        };
+
+        TableStats agg = CqliteFlightMetadata.aggregateNodeStats(hosts, fetch);
+
+        assertTrue(agg.complete(), "a wrapped NOT_FOUND must be classified as not-hosting");
+        assertEquals(100, agg.liveRows());
+    }
+
+    @Test
+    void mixedNotFoundAndUnreachableStillTaints() {
+        // not_found does not taint, but a separate genuinely unreachable replica still
+        // does: the invariant for a replica that SHOULD have data but is unreachable
+        // is preserved alongside the new not-hosting carve-out.
+        List<String> hosts = List.of("10.0.0.1", "10.0.0.2", "10.0.0.3");
+        Function<String, TableStats> fetch = address -> switch (address) {
+            case "10.0.0.1" -> ok(100, 10);
+            case "10.0.0.2" -> throw notFound();          // not hosting → no taint
+            case "10.0.0.3" -> throw new RuntimeException("unreachable"); // taints
+            default -> throw new AssertionError(address);
+        };
+
+        TableStats agg = CqliteFlightMetadata.aggregateNodeStats(hosts, fetch);
+
+        assertFalse(agg.complete(),
+                "an unreachable replica still taints even when a peer responded not_found");
+        assertEquals(100, agg.liveRows());
+        assertTrue(agg.skippedSstables() >= 1, "the unreachable node is visible as a skip");
+    }
+
+    @Test
     void duplicateAddressesAreQueriedOnce() {
-        // The ring can list the same address more than once; it is queried once and a
-        // success stays complete.
+        // The host set can list the same address more than once; it is queried once and
+        // a success stays complete.
         int[] calls = {0};
-        List<RingEntry> ring = List.of(node("10.0.0.1"), node("10.0.0.1"), node(null));
+        List<String> hosts = java.util.Arrays.asList("10.0.0.1", "10.0.0.1", null);
         Function<String, TableStats> fetch = address -> {
             calls[0]++;
             return ok(50, 5);
         };
 
-        TableStats agg = CqliteFlightMetadata.aggregateNodeStats(ring, fetch);
+        TableStats agg = CqliteFlightMetadata.aggregateNodeStats(hosts, fetch);
 
         assertEquals(1, calls[0], "duplicate + null addresses queried at most once");
         assertTrue(agg.complete());
@@ -106,11 +179,38 @@ class AggregateNodeStatsTest {
     }
 
     @Test
+    void replicaHostsScopedToKeyspaceReplicasOnly() {
+        // replicaHosts must derive the target set from the keyspace's read replicas
+        // (ports stripped, de-duplicated across ranges/DCs) — NOT from the whole ring.
+        // A non-hosting ring node never appears here, so it is never queried.
+        TokenRangeReplicasResponse replicas = new TokenRangeReplicasResponse(
+                List.of(),
+                List.of(
+                        new ReplicaInfo("-100", "0", Map.of(
+                                "dc1", List.of("10.0.0.1:7000", "10.0.0.2:7000"))),
+                        new ReplicaInfo("0", "100", Map.of(
+                                "dc1", List.of("10.0.0.2:7000"),
+                                "dc2", List.of("10.0.0.3:7000")))));
+
+        Set<String> hosts = CqliteFlightMetadata.replicaHosts(replicas, "dc1");
+
+        assertEquals(Set.of("10.0.0.1", "10.0.0.2", "10.0.0.3"), hosts,
+                "only distinct keyspace-replica hosts (ports stripped) are targeted");
+    }
+
+    @Test
+    void replicaHostsHandlesNullsDefensively() {
+        assertTrue(CqliteFlightMetadata.replicaHosts(null, "dc1").isEmpty());
+        assertTrue(CqliteFlightMetadata.replicaHosts(
+                new TokenRangeReplicasResponse(List.of(), null), "dc1").isEmpty());
+    }
+
+    @Test
     void incompleteAggregateYieldsEmptyGroupRatio() {
-        // End-to-end with the gate's pure function: an incomplete aggregate (from a
-        // failed node) gives NO group-ratio estimate, so AUTOMATIC pushdown declines
-        // to use a biased ratio (issue #944, #28).
-        List<RingEntry> ring = List.of(node("10.0.0.1"), node("10.0.0.2"));
+        // End-to-end with the gate's pure function: an incomplete aggregate (from an
+        // unreachable node) gives NO group-ratio estimate, so AUTOMATIC pushdown
+        // declines to use a biased ratio (issue #944, #28).
+        List<String> hosts = List.of("10.0.0.1", "10.0.0.2");
         Function<String, TableStats> fetch = address -> {
             if (address.equals("10.0.0.2")) {
                 throw new RuntimeException("down");
@@ -118,7 +218,7 @@ class AggregateNodeStatsTest {
             return ok(2000, 10);
         };
 
-        TableStats agg = CqliteFlightMetadata.aggregateNodeStats(ring, fetch);
+        TableStats agg = CqliteFlightMetadata.aggregateNodeStats(hosts, fetch);
         assertFalse(agg.complete());
 
         String ddl = "CREATE TABLE ks.t (pk int, ck int, v int, PRIMARY KEY (pk, ck))";
@@ -133,7 +233,7 @@ class AggregateNodeStatsTest {
         // The optimizer-facing path: getTableStatistics on a non-aggregated handle
         // returns empty when the underlying counts are incomplete. We invoke the same
         // completeness guard getTableStatistics uses (!complete -> empty).
-        List<RingEntry> ring = List.of(node("10.0.0.1"), node("10.0.0.2"));
+        List<String> hosts = List.of("10.0.0.1", "10.0.0.2");
         Function<String, TableStats> fetch = address -> {
             if (address.equals("10.0.0.2")) {
                 throw new RuntimeException("down");
@@ -141,7 +241,7 @@ class AggregateNodeStatsTest {
             return ok(2000, 10);
         };
 
-        TableStats agg = CqliteFlightMetadata.aggregateNodeStats(ring, fetch);
+        TableStats agg = CqliteFlightMetadata.aggregateNodeStats(hosts, fetch);
 
         TableStatistics result =
                 (!agg.complete() || agg.liveRows() <= 0)

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/AggregateNodeStatsTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/AggregateNodeStatsTest.java
@@ -183,10 +183,12 @@ class AggregateNodeStatsTest {
     }
 
     @Test
-    void replicaHostsScopedToKeyspaceReplicasOnly() {
+    void replicaHostsScopedToLocalDatacenterReplicas() {
         // replicaHosts must derive the target set from the keyspace's read replicas
-        // (ports stripped, de-duplicated across ranges/DCs) — NOT from the whole ring.
-        // A non-hosting ring node never appears here, so it is never queried.
+        // (ports stripped, de-duplicated across ranges) AND, like split selection
+        // (CqliteFlightSplitManager.buildSplits/pickReplica), read each range only from
+        // the LOCAL datacenter when that DC has replicas for the range. The remote-DC
+        // node (10.0.0.3) is never read by the query, so stats must not fan out to it.
         TokenRangeReplicasResponse replicas = new TokenRangeReplicasResponse(
                 List.of(),
                 List.of(
@@ -198,8 +200,46 @@ class AggregateNodeStatsTest {
 
         Set<String> hosts = CqliteFlightMetadata.replicaHosts(replicas, "dc1");
 
+        assertEquals(Set.of("10.0.0.1", "10.0.0.2"), hosts,
+                "only local-DC replica hosts (ports stripped, de-duped) are targeted; "
+                        + "the remote-DC replica the query never reads is excluded");
+    }
+
+    @Test
+    void replicaHostsFallBackToAllDcsWhenLocalDcHasNoReplicasForRange() {
+        // Per range, when the local DC has NO replicas, fall back to every DC's replicas
+        // for that range — mirroring pickReplica's any-DC fallback. Here range 1 has a
+        // local (dc1) replica, but range 2 is hosted only in dc2: that range must still
+        // be covered via its dc2 replica.
+        TokenRangeReplicasResponse replicas = new TokenRangeReplicasResponse(
+                List.of(),
+                List.of(
+                        new ReplicaInfo("-100", "0", Map.of(
+                                "dc1", List.of("10.0.0.1:7000"))),
+                        new ReplicaInfo("0", "100", Map.of(
+                                "dc2", List.of("10.0.0.3:7000")))));
+
+        Set<String> hosts = CqliteFlightMetadata.replicaHosts(replicas, "dc1");
+
+        assertEquals(Set.of("10.0.0.1", "10.0.0.3"), hosts,
+                "a range with no local-DC replica falls back to its remote-DC replica");
+    }
+
+    @Test
+    void replicaHostsFallBackToAllDcsWhenLocalDatacenterUnset() {
+        // localDatacenter null/unset: no DC preference, so fan out to every DC's replicas
+        // (de-duped, ports stripped) — matching pickReplica's null-localDatacenter branch.
+        TokenRangeReplicasResponse replicas = new TokenRangeReplicasResponse(
+                List.of(),
+                List.of(
+                        new ReplicaInfo("-100", "0", Map.of(
+                                "dc1", List.of("10.0.0.1:7000", "10.0.0.2:7000"),
+                                "dc2", List.of("10.0.0.3:7000")))));
+
+        Set<String> hosts = CqliteFlightMetadata.replicaHosts(replicas, null);
+
         assertEquals(Set.of("10.0.0.1", "10.0.0.2", "10.0.0.3"), hosts,
-                "only distinct keyspace-replica hosts (ports stripped) are targeted");
+                "with no local DC configured, all DCs' distinct replica hosts are targeted");
     }
 
     @Test

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightConfigTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightConfigTest.java
@@ -26,6 +26,26 @@ class CqliteFlightConfigTest {
         assertEquals(GroupByPushdownPolicy.AUTOMATIC, config.groupByPushdown());
         assertEquals(CqliteFlightConfig.DEFAULT_MAX_GROUP_RATIO, config.maxGroupRatio());
         assertEquals(CqliteFlightConfig.DEFAULT_FLIGHT_PORT, config.flightPort());
+        assertEquals(CqliteFlightConfig.DEFAULT_TABLE_STATS_TIMEOUT_MILLIS,
+                config.tableStatsTimeoutMillis());
+    }
+
+    @Test
+    void parsesTableStatsTimeout() {
+        Map<String, String> m = base();
+        m.put("cqlite.table-stats-timeout-ms", "1500");
+        assertEquals(1500L, CqliteFlightConfig.fromMap(m).tableStatsTimeoutMillis());
+    }
+
+    @Test
+    void rejectsNonPositiveTableStatsTimeout() {
+        Map<String, String> m = base();
+        m.put("cqlite.table-stats-timeout-ms", "0");
+        assertThrows(IllegalArgumentException.class, () -> CqliteFlightConfig.fromMap(m));
+
+        Map<String, String> n = base();
+        n.put("cqlite.table-stats-timeout-ms", "-5");
+        assertThrows(IllegalArgumentException.class, () -> CqliteFlightConfig.fromMap(n));
     }
 
     @Test

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightMetadataApplyAggregationTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightMetadataApplyAggregationTest.java
@@ -341,6 +341,81 @@ class CqliteFlightMetadataApplyAggregationTest {
                 GroupByPushdownPolicy.AUTOMATIC, java.util.OptionalDouble.of(0.5), maxRatio));
     }
 
+    // --- Fix 2 (issue #944): fetch stats only for OTHERWISE-PUSHABLE aggregations ---
+
+    /**
+     * AUTOMATIC-policy metadata that records whether the planning-time stats fetch
+     * (overridable {@link CqliteFlightMetadata#fetchTableStats} seam) was invoked, without
+     * any live Sidecar/Flight. A supported GROUP BY must reach the fetch; an aggregation
+     * declined for an unsupported function/argument must NOT.
+     */
+    private static final class FetchSpyMetadata extends CqliteFlightMetadata {
+        int fetchCalls = 0;
+
+        FetchSpyMetadata() {
+            super(CqliteFlightConfig.fromMap(Map.of(
+                    "cqlite.sidecar-uri", "http://localhost:9043",
+                    "cqlite.aggregation-pushdown-group-by", "automatic")), null, null);
+        }
+
+        @Override
+        TableStats fetchTableStats(CqliteFlightTableHandle handle) {
+            fetchCalls++;
+            // An UNBOUNDED grouping shape → empty group ratio → AUTOMATIC pushes. We only
+            // assert WHETHER this ran, so the returned stats just need to be complete.
+            return new TableStats(1000, 100, 1, true, 0);
+        }
+    }
+
+    @Test
+    void unsupportedAggregationDoesNotTriggerStatsFetch() {
+        // GROUP BY c1 with an UNSUPPORTED aggregate (sum on a non-FULL column). The
+        // aggregate-support validation declines it, so under Fix 2 the network stats
+        // fetch + group-ratio gate must NEVER run.
+        FetchSpyMetadata spy = new FetchSpyMetadata();
+        assertTrue(spy.applyAggregation(
+                null, TABLE, List.of(agg("sum", BIGINT, new Variable("y", BIGINT))),
+                ASSIGN, List.of(List.of(C1))).isEmpty(),
+                "unsupported aggregate must be declined");
+        assertEquals(0, spy.fetchCalls,
+                "an aggregation declined for an unsupported argument must NOT fetch stats");
+    }
+
+    @Test
+    void unsupportedFunctionWithGroupByDoesNotTriggerStatsFetch() {
+        // GROUP BY c1 with an UNSUPPORTED function. Declined before any stats I/O.
+        FetchSpyMetadata spy = new FetchSpyMetadata();
+        assertTrue(spy.applyAggregation(
+                null, TABLE, List.of(agg("approx_distinct", BIGINT, new Variable("x", BIGINT))),
+                ASSIGN, List.of(List.of(C1))).isEmpty(),
+                "unsupported function must be declined");
+        assertEquals(0, spy.fetchCalls,
+                "an aggregation declined for an unsupported function must NOT fetch stats");
+    }
+
+    @Test
+    void supportedGroupByDoesTriggerStatsFetch() {
+        // A supported, otherwise-pushable AUTOMATIC GROUP BY DOES consult stats: the
+        // group-ratio gate needs them. (Unbounded shape → empty ratio → still pushes.)
+        FetchSpyMetadata spy = new FetchSpyMetadata();
+        assertTrue(spy.applyAggregation(
+                null, TABLE, List.of(agg("count", BIGINT)),
+                ASSIGN, List.of(List.of(C1))).isPresent(),
+                "supported GROUP BY count(*) must push");
+        assertEquals(1, spy.fetchCalls,
+                "a supported AUTOMATIC GROUP BY must fetch stats for the group-ratio gate");
+    }
+
+    @Test
+    void globalAggregateDoesNotTriggerStatsFetch() {
+        // Globals bypass the group-ratio gate entirely (no GROUP BY), so no stats fetch.
+        FetchSpyMetadata spy = new FetchSpyMetadata();
+        assertTrue(spy.applyAggregation(
+                null, TABLE, List.of(agg("count", BIGINT)), ASSIGN, List.of(List.of()))
+                .isPresent(), "global aggregate must push");
+        assertEquals(0, spy.fetchCalls, "a global aggregate must NOT fetch stats");
+    }
+
     @Test
     void applyFilterDeclinesOnAggregatedHandle() {
         // After aggregation pushdown, a later filter must NOT be pushed: it would

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightTableStatisticsTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightTableStatisticsTest.java
@@ -1,0 +1,106 @@
+package in.mcfad.cqlite.flight;
+
+import io.trino.spi.statistics.Estimate;
+import io.trino.spi.statistics.TableStatistics;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link CqliteFlightMetadata#getTableStatistics} and the
+ * {@link CqliteFlightTableHandle#hasGroupBy()} signal it relies on (issue #944).
+ *
+ * <p>After aggregation pushdown the scan's OUTPUT cardinality is the aggregate
+ * result cardinality, NOT the base-table row count: a GLOBAL aggregate emits one
+ * row; a grouped aggregate's group count is unknown. These tests pin that the
+ * optimizer-facing stats reflect the output, not the underlying SSTable rows.
+ *
+ * <p>The aggregated branch of {@code getTableStatistics} returns before touching
+ * Sidecar/Flight, so a {@code new CqliteFlightMetadata(null, null, null)} suffices
+ * to exercise it. The non-aggregated branch (base-table stats from {@code
+ * table_stats}) is covered end-to-end by the connector's Flight tests.
+ */
+class CqliteFlightTableStatisticsTest {
+
+    private final CqliteFlightMetadata metadata = new CqliteFlightMetadata(null, null, null);
+
+    /** Aggregation JSON exactly as {@code AggregationSpec.toJson} serializes it. */
+    private static String aggregationJson(String... groupBy) {
+        StringBuilder gb = new StringBuilder();
+        for (int i = 0; i < groupBy.length; i++) {
+            if (i > 0) {
+                gb.append(',');
+            }
+            gb.append('"').append(groupBy[i]).append('"');
+        }
+        return "{\"group_by\":[" + gb + "],"
+                + "\"aggregates\":[{\"func\":\"Count\",\"column\":null,\"output\":\"agg0\"}]}";
+    }
+
+    private static CqliteFlightTableHandle aggregatedHandle(String... groupBy) {
+        return new CqliteFlightTableHandle(
+                "ks", "t", "ddl",
+                Optional.empty(),
+                Optional.of(aggregationJson(groupBy)),
+                Optional.of("{\"group_by\":[],\"outputs\":[]}"));
+    }
+
+    @Test
+    void globalAggregateOutputsExactlyOneRow() {
+        // count(*) with no GROUP BY → the finalize split emits a single merged row.
+        CqliteFlightTableHandle handle = aggregatedHandle();
+        assertTrue(handle.isAggregated());
+        assertFalse(handle.hasGroupBy(), "no group_by → global aggregate");
+
+        TableStatistics stats = metadata.getTableStatistics(null, handle);
+        assertEquals(Estimate.of(1), stats.getRowCount(),
+                "global aggregate output cardinality is exactly 1");
+    }
+
+    @Test
+    void groupedAggregateReportsUnknownRowCount() {
+        // GROUP BY c1 → output group count is not authoritatively known; do not
+        // fabricate it (#28) — return empty so Trino estimates.
+        CqliteFlightTableHandle handle = aggregatedHandle("c1");
+        assertTrue(handle.isAggregated());
+        assertTrue(handle.hasGroupBy(), "non-empty group_by → grouped aggregate");
+
+        TableStatistics stats = metadata.getTableStatistics(null, handle);
+        assertEquals(TableStatistics.empty(), stats,
+                "grouped aggregate row count is unknown → empty (no fabrication)");
+        assertTrue(stats.getRowCount().isUnknown(), "row count must be unknown for a grouped aggregate");
+    }
+
+    @Test
+    void multiColumnGroupByIsStillGrouped() {
+        CqliteFlightTableHandle handle = aggregatedHandle("c1", "c2");
+        assertTrue(handle.hasGroupBy());
+        assertEquals(TableStatistics.empty(), metadata.getTableStatistics(null, handle));
+    }
+
+    @Test
+    void nonAggregatedHandleHasNoGroupBy() {
+        // A plain (non-aggregated) handle never reports a GROUP BY.
+        CqliteFlightTableHandle plain = new CqliteFlightTableHandle("ks", "t", "ddl");
+        assertFalse(plain.isAggregated());
+        assertFalse(plain.hasGroupBy());
+    }
+
+    @Test
+    void hasGroupByIsFalseForUnparseableAggregationJson() {
+        // Defensive: a malformed aggregation JSON is treated as a global aggregate
+        // (one row), never crashes the optimizer call.
+        CqliteFlightTableHandle handle = new CqliteFlightTableHandle(
+                "ks", "t", "ddl",
+                Optional.empty(),
+                Optional.of("{not valid json"),
+                Optional.of("{\"group_by\":[],\"outputs\":[]}"));
+        assertTrue(handle.isAggregated());
+        assertFalse(handle.hasGroupBy());
+        assertEquals(Estimate.of(1), metadata.getTableStatistics(null, handle).getRowCount());
+    }
+}

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightTableStatisticsTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/CqliteFlightTableStatisticsTest.java
@@ -19,10 +19,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * row; a grouped aggregate's group count is unknown. These tests pin that the
  * optimizer-facing stats reflect the output, not the underlying SSTable rows.
  *
- * <p>The aggregated branch of {@code getTableStatistics} returns before touching
- * Sidecar/Flight, so a {@code new CqliteFlightMetadata(null, null, null)} suffices
- * to exercise it. The non-aggregated branch (base-table stats from {@code
- * table_stats}) is covered end-to-end by the connector's Flight tests.
+ * <p>A NON-aggregated handle now reports {@link TableStatistics#empty()} (unknown):
+ * the {@code table_stats} row total is summed across ALL keyspace replicas (≈ RF ×
+ * logical cardinality) and is not de-duplicated to one copy of the token space, so
+ * we deliberately do not expose it as an optimizer row count (issue #944). Both
+ * branches of {@code getTableStatistics} now return before touching Sidecar/Flight,
+ * so a {@code new CqliteFlightMetadata(null, null, null)} suffices to exercise them.
  */
 class CqliteFlightTableStatisticsTest {
 
@@ -88,6 +90,22 @@ class CqliteFlightTableStatisticsTest {
         CqliteFlightTableHandle plain = new CqliteFlightTableHandle("ks", "t", "ddl");
         assertFalse(plain.isAggregated());
         assertFalse(plain.hasGroupBy());
+    }
+
+    @Test
+    void nonAggregatedHandleReportsUnknownRowCount() {
+        // The table_stats row total is replica-summed (≈ RF × logical cardinality)
+        // and not de-duplicated to one copy of the token space, so we do NOT expose
+        // it as an optimizer row count (issue #944) — report unknown so Trino
+        // estimates instead of trusting a knowably-wrong physical-replica total.
+        CqliteFlightTableHandle plain = new CqliteFlightTableHandle("ks", "t", "ddl");
+        assertFalse(plain.isAggregated());
+
+        TableStatistics stats = metadata.getTableStatistics(null, plain);
+        assertEquals(TableStatistics.empty(), stats,
+                "non-aggregated row count is replica-summed → empty (not exposed)");
+        assertTrue(stats.getRowCount().isUnknown(),
+                "non-aggregated row count must be unknown (replica-summed, not logical)");
     }
 
     @Test

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/EstimateGroupRatioTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/EstimateGroupRatioTest.java
@@ -91,6 +91,37 @@ class EstimateGroupRatioTest {
     }
 
     @Test
+    void groupByFullPartitionKeyPlusRegularColumnIsUnboundedAndPushes() {
+        // PRIMARY KEY (pk, ck); GROUP BY pk, v where v is a REGULAR (non-key) column.
+        // The grouping covers the full partition key and touches NO clustering column,
+        // but the regular column v has no stored NDV and can split a partition into one
+        // group per row → the partitionCount bound is INVALID. The gate must return
+        // empty → PUSH, NOT a fabricated low partitionCount/rows ratio. (Before the fix
+        // this slipped into the bounded branch and produced a low ratio that would push
+        // a potentially high-cardinality aggregation.)
+        OptionalDouble ratio = CqliteFlightMetadata.estimateGroupRatio(
+                WIDE_DDL, List.of("pk", "v"), WIDE_STATS);
+        assertTrue(ratio.isEmpty(),
+                "full PK + a regular non-key column is unbounded → push, not a low bounded ratio");
+    }
+
+    @Test
+    void groupByPartitionKeyPlusRegularColumnOnKeyOnlyTableDoesNotFabricateLowRatio() {
+        // PK = id, NO clustering; GROUP BY id, name where name is a REGULAR column. The
+        // grouping covers the full PK and ALL clustering (the empty clustering set is
+        // trivially covered), so it reaches full row uniqueness → ratio 1.0 → DECLINE.
+        // The key invariant for this fix: it must NOT produce the bounded low
+        // partitionCount/rows ratio (that branch is reserved for grouping that is
+        // EXACTLY the partition key). 1.0 (decline) is the correct, safe outcome.
+        OptionalDouble ratio = CqliteFlightMetadata.estimateGroupRatio(
+                SIMPLE_DDL, List.of("id", "name"), SIMPLE_STATS);
+        assertTrue(ratio.isPresent());
+        assertEquals(1.0, ratio.getAsDouble(), 1e-9,
+                "full PK + extra regular column reaches full row uniqueness → 1.0, "
+                        + "never a fabricated low partitionCount/rows ratio");
+    }
+
+    @Test
     void zeroRowsYieldsNoEstimate() {
         OptionalDouble ratio = CqliteFlightMetadata.estimateGroupRatio(
                 WIDE_DDL, List.of("pk"), TableStats.EMPTY);

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/EstimateGroupRatioTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/EstimateGroupRatioTest.java
@@ -19,12 +19,12 @@ class EstimateGroupRatioTest {
     // Wide table: 10 partitions, 2000 rows (mirrors the sensor_data fixture).
     private static final String WIDE_DDL =
             "CREATE TABLE ks.t (pk int, ck int, v int, PRIMARY KEY (pk, ck))";
-    private static final TableStats WIDE_STATS = new TableStats(2000, 10, 1);
+    private static final TableStats WIDE_STATS = new TableStats(2000, 10, 1, true, 0);
 
     // Single-row-partition table: 1000 partitions, 1000 rows (simple_table shape).
     private static final String SIMPLE_DDL =
             "CREATE TABLE ks.t (id int PRIMARY KEY, name text)";
-    private static final TableStats SIMPLE_STATS = new TableStats(1000, 1000, 1);
+    private static final TableStats SIMPLE_STATS = new TableStats(1000, 1000, 1, true, 0);
 
     @Test
     void groupByFullPartitionKeyOnWideTableIsLowRatio() {
@@ -54,7 +54,7 @@ class EstimateGroupRatioTest {
         // push a high-cardinality aggregation the gate exists to decline.)
         String ddl = "CREATE TABLE ks.t (pk int, ck1 int, ck2 int, v int, "
                 + "PRIMARY KEY (pk, ck1, ck2))";
-        TableStats stats = new TableStats(2000, 10, 1);
+        TableStats stats = new TableStats(2000, 10, 1, true, 0);
         OptionalDouble ratio = CqliteFlightMetadata.estimateGroupRatio(
                 ddl, List.of("pk", "ck1"), stats);
         assertTrue(ratio.isEmpty(),
@@ -76,7 +76,7 @@ class EstimateGroupRatioTest {
         // Composite partition key (a, b); GROUP BY a is only a PREFIX → cannot be
         // bounded from partition/row counts → empty → PUSH (safe).
         String ddl = "CREATE TABLE ks.t (a int, b int, v int, PRIMARY KEY ((a, b)))";
-        TableStats stats = new TableStats(500, 500, 1);
+        TableStats stats = new TableStats(500, 500, 1, true, 0);
         OptionalDouble ratio = CqliteFlightMetadata.estimateGroupRatio(
                 ddl, List.of("a"), stats);
         assertTrue(ratio.isEmpty(), "partition-key prefix is unbounded → push");
@@ -122,6 +122,38 @@ class EstimateGroupRatioTest {
     }
 
     @Test
+    void incompleteStatsYieldNoEstimateEvenForBoundedShape() {
+        // GROUP BY pk on the wide table is normally a bounded, low ratio (PUSH).
+        // But when the per-table counts are INCOMPLETE (a node's Statistics.db
+        // failed to decode), the sums are not authoritative — a skipped SSTable
+        // could hold many rows/groups and bias the ratio low. The gate must fail
+        // closed to "no estimate" (empty) regardless of the otherwise-bounded shape.
+        TableStats incomplete = new TableStats(2000, 10, 1, false, 1);
+        OptionalDouble ratio = CqliteFlightMetadata.estimateGroupRatio(
+                WIDE_DDL, List.of("pk"), incomplete);
+        assertTrue(ratio.isEmpty(),
+                "incomplete stats → no estimate (push) even for a bounded GROUP BY shape");
+
+        // And the same shape with COMPLETE stats is the bounded low ratio (control).
+        OptionalDouble complete = CqliteFlightMetadata.estimateGroupRatio(
+                WIDE_DDL, List.of("pk"), WIDE_STATS);
+        assertTrue(complete.isPresent());
+        assertEquals(10.0 / 2000.0, complete.getAsDouble(), 1e-9);
+    }
+
+    @Test
+    void incompleteStatsYieldNoEstimateForFullPrimaryKeyGrouping() {
+        // GROUP BY = full PK on a key-only table normally reaches full row uniqueness
+        // (ratio 1.0 → DECLINE). With incomplete stats the gate must still fail closed
+        // to empty (push-safe default) rather than derive ANY ratio from partial sums.
+        TableStats incomplete = new TableStats(1000, 1000, 1, false, 2);
+        OptionalDouble ratio = CqliteFlightMetadata.estimateGroupRatio(
+                SIMPLE_DDL, List.of("id"), incomplete);
+        assertTrue(ratio.isEmpty(),
+                "incomplete stats → no estimate even when GROUP BY = full primary key");
+    }
+
+    @Test
     void zeroRowsYieldsNoEstimate() {
         OptionalDouble ratio = CqliteFlightMetadata.estimateGroupRatio(
                 WIDE_DDL, List.of("pk"), TableStats.EMPTY);
@@ -152,7 +184,7 @@ class EstimateGroupRatioTest {
         // A GROUP BY on the lower-case unquoted column id is a DIFFERENT column and
         // must NOT be treated as covering the partition key → unbounded → PUSH.
         String ddl = "CREATE TABLE ks.t (\"Id\" int PRIMARY KEY, name text)";
-        TableStats stats = new TableStats(1000, 1000, 1);
+        TableStats stats = new TableStats(1000, 1000, 1, true, 0);
         OptionalDouble lowerCased = CqliteFlightMetadata.estimateGroupRatio(
                 ddl, List.of("id"), stats);
         assertTrue(lowerCased.isEmpty(),

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/EstimateGroupRatioTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/EstimateGroupRatioTest.java
@@ -1,0 +1,118 @@
+package in.mcfad.cqlite.flight;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.OptionalDouble;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link CqliteFlightMetadata#estimateGroupRatio} — the DDL-driven
+ * mapping from a GROUP BY shape + authoritative partition/row counts to an
+ * estimated groups/rows ratio (issue #944). Pure function; no Sidecar/Flight.
+ */
+class EstimateGroupRatioTest {
+
+    // Wide table: 10 partitions, 2000 rows (mirrors the sensor_data fixture).
+    private static final String WIDE_DDL =
+            "CREATE TABLE ks.t (pk int, ck int, v int, PRIMARY KEY (pk, ck))";
+    private static final TableStats WIDE_STATS = new TableStats(2000, 10, 1);
+
+    // Single-row-partition table: 1000 partitions, 1000 rows (simple_table shape).
+    private static final String SIMPLE_DDL =
+            "CREATE TABLE ks.t (id int PRIMARY KEY, name text)";
+    private static final TableStats SIMPLE_STATS = new TableStats(1000, 1000, 1);
+
+    @Test
+    void groupByFullPartitionKeyOnWideTableIsLowRatio() {
+        // GROUP BY pk → groups ≈ partitionCount (10) / rows (2000) = 0.005 → PUSH.
+        OptionalDouble ratio = CqliteFlightMetadata.estimateGroupRatio(
+                WIDE_DDL, List.of("pk"), WIDE_STATS);
+        assertTrue(ratio.isPresent());
+        assertEquals(10.0 / 2000.0, ratio.getAsDouble(), 1e-9);
+    }
+
+    @Test
+    void groupByPartitionPlusAllClusteringReachesFullRowUniqueness() {
+        // GROUP BY pk, ck reaches per-row uniqueness → ratio ≈ 1.0 → DECLINE.
+        OptionalDouble ratio = CqliteFlightMetadata.estimateGroupRatio(
+                WIDE_DDL, List.of("pk", "ck"), WIDE_STATS);
+        assertTrue(ratio.isPresent());
+        assertEquals(1.0, ratio.getAsDouble(), 1e-9);
+    }
+
+    @Test
+    void groupBySinglePartitionKeyTableIsRatioOne() {
+        // PK = id, no clustering: GROUP BY id covers the full key AND all clustering
+        // (empty) → full row uniqueness → ratio ≈ 1.0 → DECLINE.
+        OptionalDouble ratio = CqliteFlightMetadata.estimateGroupRatio(
+                SIMPLE_DDL, List.of("id"), SIMPLE_STATS);
+        assertTrue(ratio.isPresent());
+        assertEquals(1.0, ratio.getAsDouble(), 1e-9);
+    }
+
+    @Test
+    void groupByPartitionKeyPrefixIsUnboundedAndPushes() {
+        // Composite partition key (a, b); GROUP BY a is only a PREFIX → cannot be
+        // bounded from partition/row counts → empty → PUSH (safe).
+        String ddl = "CREATE TABLE ks.t (a int, b int, v int, PRIMARY KEY ((a, b)))";
+        TableStats stats = new TableStats(500, 500, 1);
+        OptionalDouble ratio = CqliteFlightMetadata.estimateGroupRatio(
+                ddl, List.of("a"), stats);
+        assertTrue(ratio.isEmpty(), "partition-key prefix is unbounded → push");
+    }
+
+    @Test
+    void groupByNonKeyColumnIsUnboundedAndPushes() {
+        // GROUP BY a regular column → no partition/row bound → empty → PUSH.
+        OptionalDouble ratio = CqliteFlightMetadata.estimateGroupRatio(
+                WIDE_DDL, List.of("v"), WIDE_STATS);
+        assertTrue(ratio.isEmpty());
+    }
+
+    @Test
+    void zeroRowsYieldsNoEstimate() {
+        OptionalDouble ratio = CqliteFlightMetadata.estimateGroupRatio(
+                WIDE_DDL, List.of("pk"), TableStats.EMPTY);
+        assertTrue(ratio.isEmpty());
+    }
+
+    @Test
+    void emptyGroupingYieldsNoEstimate() {
+        // A global aggregate has no grouping; it bypasses the gate before this call,
+        // but the mapping is defensively empty for an empty grouping set too.
+        OptionalDouble ratio = CqliteFlightMetadata.estimateGroupRatio(
+                WIDE_DDL, List.of(), WIDE_STATS);
+        assertTrue(ratio.isEmpty());
+    }
+
+    @Test
+    void caseInsensitiveGroupingMatch() {
+        // Unquoted identifiers fold to lower-case on both sides.
+        OptionalDouble ratio = CqliteFlightMetadata.estimateGroupRatio(
+                WIDE_DDL, List.of("PK"), WIDE_STATS);
+        assertTrue(ratio.isPresent());
+        assertEquals(10.0 / 2000.0, ratio.getAsDouble(), 1e-9);
+    }
+
+    @Test
+    void ratioFeedsTheGateDecisionEndToEnd() {
+        // Wide GROUP BY pk (ratio 0.005) PUSHES; GROUP BY pk,ck (ratio 1.0) DECLINES,
+        // both under the default 0.5 crossover.
+        double max = CqliteFlightConfig.DEFAULT_MAX_GROUP_RATIO;
+        OptionalDouble low = CqliteFlightMetadata.estimateGroupRatio(WIDE_DDL, List.of("pk"), WIDE_STATS);
+        OptionalDouble high = CqliteFlightMetadata.estimateGroupRatio(WIDE_DDL, List.of("pk", "ck"), WIDE_STATS);
+
+        assertFalse(CqliteFlightMetadata.declineGroupByPushdown(
+                GroupByPushdownPolicy.AUTOMATIC, low, max), "low-cardinality GROUP BY pushes");
+        assertTrue(CqliteFlightMetadata.declineGroupByPushdown(
+                GroupByPushdownPolicy.AUTOMATIC, high, max), "full-row GROUP BY declines");
+
+        // NEVER always declines, ALWAYS always pushes — regardless of ratio.
+        assertTrue(CqliteFlightMetadata.declineGroupByPushdown(GroupByPushdownPolicy.NEVER, low, max));
+        assertFalse(CqliteFlightMetadata.declineGroupByPushdown(GroupByPushdownPolicy.ALWAYS, high, max));
+    }
+}

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/EstimateGroupRatioTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/EstimateGroupRatioTest.java
@@ -45,6 +45,23 @@ class EstimateGroupRatioTest {
     }
 
     @Test
+    void groupByPartitionPlusPartialClusteringIsUnboundedAndPushes() {
+        // PRIMARY KEY (pk, ck1, ck2); GROUP BY pk, ck1 covers the full partition key
+        // plus a PARTIAL (non-empty, non-full) clustering subset. The group count is
+        // bounded only by the row count (no per-prefix NDV is stored), so the gate
+        // must NOT fabricate partitionCount/rows — it returns empty → PUSH. (Before
+        // the fix this wrongly returned partitionCount/rows, a low ratio that could
+        // push a high-cardinality aggregation the gate exists to decline.)
+        String ddl = "CREATE TABLE ks.t (pk int, ck1 int, ck2 int, v int, "
+                + "PRIMARY KEY (pk, ck1, ck2))";
+        TableStats stats = new TableStats(2000, 10, 1);
+        OptionalDouble ratio = CqliteFlightMetadata.estimateGroupRatio(
+                ddl, List.of("pk", "ck1"), stats);
+        assertTrue(ratio.isEmpty(),
+                "full PK + partial clustering is unbounded → push, not a fabricated low ratio");
+    }
+
+    @Test
     void groupBySinglePartitionKeyTableIsRatioOne() {
         // PK = id, no clustering: GROUP BY id covers the full key AND all clustering
         // (empty) → full row uniqueness → ratio ≈ 1.0 → DECLINE.
@@ -96,6 +113,25 @@ class EstimateGroupRatioTest {
                 WIDE_DDL, List.of("PK"), WIDE_STATS);
         assertTrue(ratio.isPresent());
         assertEquals(10.0 / 2000.0, ratio.getAsDouble(), 1e-9);
+    }
+
+    @Test
+    void quotedKeyIsNotMatchedByDifferentlyCasedGrouping() {
+        // PRIMARY KEY ("Id") is a QUOTED, case-sensitive identifier stored as "Id".
+        // A GROUP BY on the lower-case unquoted column id is a DIFFERENT column and
+        // must NOT be treated as covering the partition key → unbounded → PUSH.
+        String ddl = "CREATE TABLE ks.t (\"Id\" int PRIMARY KEY, name text)";
+        TableStats stats = new TableStats(1000, 1000, 1);
+        OptionalDouble lowerCased = CqliteFlightMetadata.estimateGroupRatio(
+                ddl, List.of("id"), stats);
+        assertTrue(lowerCased.isEmpty(),
+                "quoted \"Id\" must not be covered by unquoted id (case-sensitive)");
+
+        // The exact-case grouping DOES cover it → single-column key → ratio 1.0.
+        OptionalDouble exact = CqliteFlightMetadata.estimateGroupRatio(
+                ddl, List.of("Id"), stats);
+        assertTrue(exact.isPresent());
+        assertEquals(1.0, exact.getAsDouble(), 1e-9);
     }
 
     @Test

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/PrimaryKeyExtractorTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/PrimaryKeyExtractorTest.java
@@ -1,20 +1,27 @@
 package in.mcfad.cqlite.flight;
 
+import in.mcfad.cqlite.flight.PrimaryKeyExtractor.KeyColumn;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Unit tests for {@link PrimaryKeyExtractor} (issue #944). */
 class PrimaryKeyExtractorTest {
 
+    /** Canonical (stored-case) names of a key-column list, for terse assertions. */
+    private static List<String> names(List<KeyColumn> cols) {
+        return cols.stream().map(KeyColumn::name).toList();
+    }
+
     @Test
     void inlineSingleColumnPrimaryKey() {
         var keys = PrimaryKeyExtractor.extract(
                 "CREATE TABLE ks.t (id int PRIMARY KEY, name text, score int)");
-        assertEquals(List.of("id"), keys.partitionKey());
+        assertEquals(List.of("id"), names(keys.partitionKey()));
         assertTrue(keys.clusteringColumns().isEmpty());
     }
 
@@ -22,23 +29,23 @@ class PrimaryKeyExtractorTest {
     void simpleCompositePrimaryKeyWithClustering() {
         var keys = PrimaryKeyExtractor.extract(
                 "CREATE TABLE ks.t (pk int, ck1 text, ck2 int, v text, PRIMARY KEY (pk, ck1, ck2))");
-        assertEquals(List.of("pk"), keys.partitionKey());
-        assertEquals(List.of("ck1", "ck2"), keys.clusteringColumns());
+        assertEquals(List.of("pk"), names(keys.partitionKey()));
+        assertEquals(List.of("ck1", "ck2"), names(keys.clusteringColumns()));
     }
 
     @Test
     void compositePartitionKey() {
         var keys = PrimaryKeyExtractor.extract(
                 "CREATE TABLE ks.t (a int, b int, c text, v int, PRIMARY KEY ((a, b), c))");
-        assertEquals(List.of("a", "b"), keys.partitionKey());
-        assertEquals(List.of("c"), keys.clusteringColumns());
+        assertEquals(List.of("a", "b"), names(keys.partitionKey()));
+        assertEquals(List.of("c"), names(keys.clusteringColumns()));
     }
 
     @Test
     void compositePartitionKeyNoClustering() {
         var keys = PrimaryKeyExtractor.extract(
                 "CREATE TABLE ks.t (a int, b int, v int, PRIMARY KEY ((a, b)))");
-        assertEquals(List.of("a", "b"), keys.partitionKey());
+        assertEquals(List.of("a", "b"), names(keys.partitionKey()));
         assertTrue(keys.clusteringColumns().isEmpty());
     }
 
@@ -46,8 +53,33 @@ class PrimaryKeyExtractorTest {
     void quotedIdentifiersPreserveCase() {
         var keys = PrimaryKeyExtractor.extract(
                 "CREATE TABLE ks.t (\"Id\" int, \"Ck\" text, PRIMARY KEY (\"Id\", \"Ck\"))");
-        assertEquals(List.of("Id"), keys.partitionKey());
-        assertEquals(List.of("Ck"), keys.clusteringColumns());
+        assertEquals(List.of("Id"), names(keys.partitionKey()));
+        assertEquals(List.of("Ck"), names(keys.clusteringColumns()));
+        // The quote flag must be carried so comparison stays case-sensitive.
+        assertTrue(keys.partitionKey().get(0).quoted());
+        assertTrue(keys.clusteringColumns().get(0).quoted());
+    }
+
+    @Test
+    void unquotedIdentifierMatchesCaseInsensitively() {
+        // CQL folds unquoted identifiers → matches any letter casing.
+        KeyColumn unquoted = PrimaryKeyExtractor.extract(
+                "CREATE TABLE ks.t (id int PRIMARY KEY)").partitionKey().get(0);
+        assertFalse(unquoted.quoted());
+        assertTrue(unquoted.matches("id"));
+        assertTrue(unquoted.matches("ID"));
+        assertTrue(unquoted.matches("Id"));
+    }
+
+    @Test
+    void quotedIdentifierMatchesOnlyExactCase() {
+        // CQL preserves quoted identifiers → only exact-case matches.
+        KeyColumn quoted = PrimaryKeyExtractor.extract(
+                "CREATE TABLE ks.t (\"Id\" int PRIMARY KEY)").partitionKey().get(0);
+        assertTrue(quoted.quoted());
+        assertTrue(quoted.matches("Id"));
+        assertFalse(quoted.matches("id"), "quoted \"Id\" must not equal unquoted id");
+        assertFalse(quoted.matches("ID"));
     }
 
     @Test

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/PrimaryKeyExtractorTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/PrimaryKeyExtractorTest.java
@@ -1,0 +1,74 @@
+package in.mcfad.cqlite.flight;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Unit tests for {@link PrimaryKeyExtractor} (issue #944). */
+class PrimaryKeyExtractorTest {
+
+    @Test
+    void inlineSingleColumnPrimaryKey() {
+        var keys = PrimaryKeyExtractor.extract(
+                "CREATE TABLE ks.t (id int PRIMARY KEY, name text, score int)");
+        assertEquals(List.of("id"), keys.partitionKey());
+        assertTrue(keys.clusteringColumns().isEmpty());
+    }
+
+    @Test
+    void simpleCompositePrimaryKeyWithClustering() {
+        var keys = PrimaryKeyExtractor.extract(
+                "CREATE TABLE ks.t (pk int, ck1 text, ck2 int, v text, PRIMARY KEY (pk, ck1, ck2))");
+        assertEquals(List.of("pk"), keys.partitionKey());
+        assertEquals(List.of("ck1", "ck2"), keys.clusteringColumns());
+    }
+
+    @Test
+    void compositePartitionKey() {
+        var keys = PrimaryKeyExtractor.extract(
+                "CREATE TABLE ks.t (a int, b int, c text, v int, PRIMARY KEY ((a, b), c))");
+        assertEquals(List.of("a", "b"), keys.partitionKey());
+        assertEquals(List.of("c"), keys.clusteringColumns());
+    }
+
+    @Test
+    void compositePartitionKeyNoClustering() {
+        var keys = PrimaryKeyExtractor.extract(
+                "CREATE TABLE ks.t (a int, b int, v int, PRIMARY KEY ((a, b)))");
+        assertEquals(List.of("a", "b"), keys.partitionKey());
+        assertTrue(keys.clusteringColumns().isEmpty());
+    }
+
+    @Test
+    void quotedIdentifiersPreserveCase() {
+        var keys = PrimaryKeyExtractor.extract(
+                "CREATE TABLE ks.t (\"Id\" int, \"Ck\" text, PRIMARY KEY (\"Id\", \"Ck\"))");
+        assertEquals(List.of("Id"), keys.partitionKey());
+        assertEquals(List.of("Ck"), keys.clusteringColumns());
+    }
+
+    @Test
+    void allKeyColumnsUnionsPartitionAndClustering() {
+        var keys = PrimaryKeyExtractor.extract(
+                "CREATE TABLE ks.t (pk int, ck text, v int, PRIMARY KEY (pk, ck))");
+        assertTrue(keys.allKeyColumns().containsAll(List.of("pk", "ck")));
+        assertEquals(2, keys.allKeyColumns().size());
+    }
+
+    @Test
+    void unparseableDdlYieldsEmptyKeys() {
+        var keys = PrimaryKeyExtractor.extract("not a create table statement");
+        assertTrue(keys.partitionKey().isEmpty());
+        assertTrue(keys.clusteringColumns().isEmpty());
+    }
+
+    @Test
+    void nullDdlIsSafe() {
+        var keys = PrimaryKeyExtractor.extract(null);
+        assertTrue(keys.partitionKey().isEmpty());
+        assertTrue(keys.clusteringColumns().isEmpty());
+    }
+}

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/TableStatsTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/TableStatsTest.java
@@ -1,0 +1,49 @@
+package in.mcfad.cqlite.flight;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies {@link TableStats} decodes the snake_case JSON the Rust cqlite-flight
+ * {@code table_stats} action emits, and that {@link TableStats#plus} sums
+ * per-node responses (issue #944).
+ */
+class TableStatsTest {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void decodesServerSnakeCaseJson() throws Exception {
+        // Exactly the shape cqlite_flight::stats::TableStatsResponse serializes.
+        String json = "{\"live_rows\":2000,\"partition_count\":10,\"sstable_count\":1}";
+        TableStats stats = MAPPER.readValue(json, TableStats.class);
+        assertEquals(2000, stats.liveRows());
+        assertEquals(10, stats.partitionCount());
+        assertEquals(1, stats.sstableCount());
+    }
+
+    @Test
+    void ignoresUnknownFields() throws Exception {
+        String json = "{\"live_rows\":5,\"partition_count\":2,\"sstable_count\":1,\"future\":42}";
+        TableStats stats = MAPPER.readValue(json, TableStats.class);
+        assertEquals(5, stats.liveRows());
+    }
+
+    @Test
+    void plusSumsAcrossNodes() {
+        TableStats a = new TableStats(100, 10, 1);
+        TableStats b = new TableStats(50, 5, 2);
+        TableStats sum = a.plus(b);
+        assertEquals(150, sum.liveRows());
+        assertEquals(15, sum.partitionCount());
+        assertEquals(3, sum.sstableCount());
+    }
+
+    @Test
+    void emptyIsZero() {
+        assertEquals(0, TableStats.EMPTY.liveRows());
+        assertEquals(0, TableStats.EMPTY.partitionCount());
+        assertEquals(0, TableStats.EMPTY.sstableCount());
+    }
+}

--- a/trino-connector/src/test/java/in/mcfad/cqlite/flight/TableStatsTest.java
+++ b/trino-connector/src/test/java/in/mcfad/cqlite/flight/TableStatsTest.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Verifies {@link TableStats} decodes the snake_case JSON the Rust cqlite-flight
@@ -15,35 +17,79 @@ class TableStatsTest {
 
     @Test
     void decodesServerSnakeCaseJson() throws Exception {
-        // Exactly the shape cqlite_flight::stats::TableStatsResponse serializes.
-        String json = "{\"live_rows\":2000,\"partition_count\":10,\"sstable_count\":1}";
+        // Exactly the shape cqlite_flight::stats::TableStatsResponse serializes,
+        // including the completeness flag and skipped count.
+        String json = "{\"live_rows\":2000,\"partition_count\":10,\"sstable_count\":1,"
+                + "\"complete\":true,\"skipped_sstables\":0}";
         TableStats stats = MAPPER.readValue(json, TableStats.class);
         assertEquals(2000, stats.liveRows());
         assertEquals(10, stats.partitionCount());
         assertEquals(1, stats.sstableCount());
+        assertTrue(stats.complete());
+        assertEquals(0, stats.skippedSstables());
+    }
+
+    @Test
+    void decodesIncompleteServerJson() throws Exception {
+        String json = "{\"live_rows\":2000,\"partition_count\":10,\"sstable_count\":1,"
+                + "\"complete\":false,\"skipped_sstables\":2}";
+        TableStats stats = MAPPER.readValue(json, TableStats.class);
+        assertFalse(stats.complete());
+        assertEquals(2, stats.skippedSstables());
+    }
+
+    @Test
+    void completeDefaultsFalseWhenFlagAbsent() throws Exception {
+        // A response from an older server that predates the `complete` field must
+        // decode as INCOMPLETE (boolean default false → fail closed), never
+        // spuriously complete.
+        String json = "{\"live_rows\":5,\"partition_count\":2,\"sstable_count\":1}";
+        TableStats stats = MAPPER.readValue(json, TableStats.class);
+        assertEquals(5, stats.liveRows());
+        assertFalse(stats.complete(), "absent complete flag must default to false (fail closed)");
+        assertEquals(0, stats.skippedSstables());
     }
 
     @Test
     void ignoresUnknownFields() throws Exception {
-        String json = "{\"live_rows\":5,\"partition_count\":2,\"sstable_count\":1,\"future\":42}";
+        String json = "{\"live_rows\":5,\"partition_count\":2,\"sstable_count\":1,"
+                + "\"complete\":true,\"future\":42}";
         TableStats stats = MAPPER.readValue(json, TableStats.class);
         assertEquals(5, stats.liveRows());
     }
 
     @Test
     void plusSumsAcrossNodes() {
-        TableStats a = new TableStats(100, 10, 1);
-        TableStats b = new TableStats(50, 5, 2);
+        TableStats a = new TableStats(100, 10, 1, true, 0);
+        TableStats b = new TableStats(50, 5, 2, true, 0);
         TableStats sum = a.plus(b);
         assertEquals(150, sum.liveRows());
         assertEquals(15, sum.partitionCount());
         assertEquals(3, sum.sstableCount());
+        assertTrue(sum.complete(), "both nodes complete → aggregate complete");
+        assertEquals(0, sum.skippedSstables());
     }
 
     @Test
-    void emptyIsZero() {
+    void plusIsIncompleteWhenAnyNodeIsIncomplete() {
+        // A single node with an undecodable Statistics.db taints the cross-ring
+        // total: complete is the logical AND, skipped counts accumulate.
+        TableStats complete = new TableStats(100, 10, 1, true, 0);
+        TableStats incomplete = new TableStats(50, 5, 2, false, 3);
+        TableStats sum = complete.plus(incomplete);
+        assertFalse(sum.complete(), "one incomplete node → incomplete aggregate");
+        assertEquals(3, sum.skippedSstables());
+
+        // EMPTY (the aggregate seed) is complete and must not taint a real node.
+        assertTrue(TableStats.EMPTY.plus(complete).complete());
+    }
+
+    @Test
+    void emptyIsZeroAndComplete() {
         assertEquals(0, TableStats.EMPTY.liveRows());
         assertEquals(0, TableStats.EMPTY.partitionCount());
         assertEquals(0, TableStats.EMPTY.sstableCount());
+        assertTrue(TableStats.EMPTY.complete(), "no SSTables → trivially complete");
+        assertEquals(0, TableStats.EMPTY.skippedSstables());
     }
 }


### PR DESCRIPTION
Closes #944.

## What
Closes the loop on the `AUTOMATIC` aggregation-pushdown gate (#893/#937/#841): the connector now has the cardinality signal it needs to decline high-cardinality `GROUP BY` pushdown while still pushing low/mid-cardinality `GROUP BY` and global aggregates.

### Rust (`cqlite-flight` + `cqlite-core`)
- New Flight `DoAction("table_stats")` RPC (advertised via `ListActions`) returning `{ live_rows, partition_count, sstable_count }` as JSON.
- Authoritative stats decode `cqlite-core/src/parser/repair_metadata.rs::read_table_counts` (`partition_count` = Σ EstimatedHistogram bucket counts; `total_rows` = STATS `totalRows` via the version-gated walk, `None` when not traversable — never guessed). This was necessary because `enhanced_statistics_parser` stubs those counts to 0 for real `nb` files (filed follow-up #1325).

### Java connector
- `TableStats` + `CqliteFlightClient.tableStats(...)` (via `doAction`); `getTableStatistics` + `estimateGroupRatio` consume them.
- Gate mapping (authoritative vs derived documented in code):
  - GROUP BY = full PK, no clustering → ratio `partitionCount/rows` (bounded) → push
  - GROUP BY = full PK + all clustering → ratio 1.0 → **decline**
  - GROUP BY = full PK + partial clustering / PK-prefix / non-key → **unbounded → push** (issue's documented safe default; no fabricated ratio — no-heuristics)
  - Globals bypass the gate (unconditional push)
- Quoted identifiers compare case-sensitively (`KeyColumn{name,quoted}`); only unquoted fold.

### Tests
- Rust unit tests (`read_table_counts`) verified vs real fixtures (sensor_data 10/2000, simple_table 1000/1000, stock_prices 3/200).
- Java: `EstimateGroupRatioTest` (11), `PrimaryKeyExtractorTest` (10), `TableStatsTest` (4) — gradle **110 tests, 0 failures**.
- E2E (`trino-connector/docker/{e2e-data.cql,e2e-test.sh}`): ran the full docker stack locally — **25/25 pass** (high-card `GROUP BY device,ts` declined; low-card `GROUP BY device` + global `count(*)` pushed).

## Validation
- `scripts/agent-gate.sh` → **RESULT: PASS** (all 16 components, commit `28abe529`; re-verified clean — an earlier `block_io` write-test failure was a pre-existing cross-process temp-path flake, filed #1326, not in this diff).
- Java `./gradlew test` → BUILD SUCCESSFUL, 110/0.
- roborev (codex): 2 gate-logic findings fixed (partial-clustering over-estimate; quoted-identifier folding).

## Follow-ups filed (out of scope)
#1325 (parser 0-stub), #1326 (block_io flake), #1327 (write-engine empty histograms).