### PR TITLE
fix(#1297): enforce exact version allowlist ceiling (reject unknown above-floor versions)

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/tests.rs
@@ -922,6 +922,36 @@ mod tests {
         }
     }
 
+    /// #1297: opening an SSTable whose descriptor parses to an unknown
+    /// ABOVE-floor BIG version (`nc`, outside the exact `{na, nb, oa}`
+    /// allowlist) fails at open with `UnsupportedVersion` and does NOT proceed
+    /// on nb-compatible gates. Drives the public `SSTableReader::open` path
+    /// (wiring evidence for the ceiling, not just the gate helper).
+    #[tokio::test]
+    async fn test_open_above_floor_unknown_version_rejected() {
+        use super::super::SSTableReader;
+        use crate::{Config, Error, Platform};
+        use std::sync::Arc;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        // `nc` is above the `na` floor but NOT in the supported allowlist.
+        let path = dir.path().join("nc-1-big-Data.db");
+        std::fs::write(&path, b"\x00\x01\x02\x03\x04\x05\x06\x07").expect("write fixture");
+
+        let config = Config::default();
+        let platform = Arc::new(Platform::new(&config).await.expect("platform"));
+
+        let err = SSTableReader::open(&path, &config, platform)
+            .await
+            .expect_err("above-allowlist open must fail, not fall back to nb");
+        match err {
+            Error::UnsupportedVersion { version, .. } => {
+                assert_eq!(version, "nc", "error names the offending version");
+            }
+            other => panic!("expected UnsupportedVersion at open, got {:?}", other),
+        }
+    }
+
     /// R2: a structurally-unparseable descriptor (not a valid version string at
     /// all) preserves the existing fallback behaviour — open may fail for other
     /// reasons (e.g. header parse) but it must NOT raise `UnsupportedVersion`.

--- a/cqlite-core/src/storage/sstable/statistics_reader.rs
+++ b/cqlite-core/src/storage/sstable/statistics_reader.rs
@@ -537,6 +537,42 @@ mod tests {
         }
     }
 
+    /// #1297: an unknown ABOVE-floor BIG version (`nc`, outside the exact
+    /// `{na, nb, oa}` allowlist) must make `StatisticsReader::open` fail with a
+    /// typed `Error::UnsupportedVersion` rather than parse an unvalidated layout
+    /// on nb-compatible gates. Drives the public `StatisticsReader::open`
+    /// surface (wiring evidence for the ceiling, not just the gate helper).
+    #[tokio::test]
+    async fn test_open_above_floor_unknown_statistics_rejected() {
+        use crate::error::Error;
+        use std::sync::Arc;
+
+        let dir = tempfile::tempdir().expect("create tempdir");
+        // `nc` is above the `na` floor but NOT in the supported allowlist.
+        let path = dir.path().join("nc-1-big-Statistics.db");
+        std::fs::write(&path, b"not really a valid statistics file").expect("write fixture");
+
+        let config = crate::Config::default();
+        let platform = Arc::new(
+            crate::Platform::new(&config)
+                .await
+                .expect("create platform"),
+        );
+
+        match super::StatisticsReader::open(&path, platform).await {
+            Err(Error::UnsupportedVersion { version, .. }) => {
+                assert_eq!(version, "nc", "error must name the offending version");
+            }
+            Err(other) => panic!(
+                "expected UnsupportedVersion for above-allowlist Statistics.db, got {:?}",
+                other
+            ),
+            Ok(_) => {
+                panic!("above-allowlist Statistics.db must NOT open on nb-compatible defaults")
+            }
+        }
+    }
+
     /// #1249 R1 (roborev finding 1): the version-floor check fires BEFORE the
     /// file body is read/parsed. A below-floor `*-Statistics.db` with an empty
     /// (0-byte) body must STILL fail with `UnsupportedVersion` rather than a

--- a/cqlite-core/src/storage/sstable/version_gate.rs
+++ b/cqlite-core/src/storage/sstable/version_gate.rs
@@ -321,6 +321,25 @@ impl BigVersionGates {
             });
         }
 
+        // #1297: the supported set is an EXACT allowlist, not just a floor.
+        // CQLite targets Cassandra 5.0 ONLY. The BIG-format versions in scope
+        // are exactly `na`, `nb`, and `oa` (the latter is written with the
+        // `big` filename segment in Cassandra 5.0 `storage_compatibility_mode =
+        // NONE`). Any other above-floor BIG version (`nc`, a typo like `nz`, a
+        // hypothetical future `pa`, …) has NO validated read path, so we reject
+        // it here rather than parse an unvalidated layout with nb-compatible
+        // gates (no-heuristics). This keeps the reader in agreement with
+        // `FormatDetector::is_supported()` / `supported_versions()`, which
+        // already advertise exactly `{na, nb, oa, da}`. A genuine future format
+        // would be added deliberately, once validated. The `< na` floor above
+        // is preserved; this ceiling is purely additive.
+        if !matches!(v, "na" | "nb" | "oa") {
+            return Err(Error::UnsupportedVersion {
+                version: version.to_string(),
+                floor: "na".to_string(),
+            });
+        }
+
         // BigFormat.java:397-398. Both predicates match only `n[a-z]` once the
         // pre-`na` arms are gone: `m[d-z]`/`m[a-z]` are unreachable below the
         // floor, and `oa` (first letter `o`) matches neither (both deprecated
@@ -732,8 +751,10 @@ mod tests {
             "na: hasOriginatingHostId must be FALSE (na < nb)"
         );
 
-        // nb and above: TRUE
-        for v in &["nb", "nc", "oa"] {
+        // nb and above (within the supported allowlist): TRUE. `nc` is no
+        // longer constructible (#1297 ceiling), so only in-scope versions are
+        // exercised here.
+        for v in &["nb", "oa"] {
             let g = BigVersionGates::from_version(v).unwrap();
             assert!(
                 g.has_originating_host_id,
@@ -796,6 +817,76 @@ mod tests {
             assert!(
                 BigVersionGates::from_version(v).is_ok(),
                 "{} must still construct gates",
+                v
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Exact allowlist ceiling (#1297): unknown ABOVE-floor BIG versions are
+    // rejected. The supported BIG set is exactly {na, nb, oa}; anything else
+    // in the n/o/p… space (nc, typos, hypothetical future letters) has no
+    // validated read path and yields a typed `UnsupportedVersion`.
+    // -----------------------------------------------------------------------
+
+    /// #1297 R1: an above-floor but out-of-allowlist BIG version (`nc`, a typo
+    /// `nz`, a hypothetical `pa`/`ob`) yields `UnsupportedVersion`, never gates.
+    #[test]
+    fn test_big_above_floor_unknown_rejected_with_typed_error() {
+        for v in &["nc", "nz", "pa", "ob", "zz"] {
+            let err = match BigVersionGates::from_version(v) {
+                Ok(_) => panic!(
+                    "{} is outside the supported allowlist and must be rejected",
+                    v
+                ),
+                Err(e) => e,
+            };
+            match err {
+                Error::UnsupportedVersion { version, floor } => {
+                    assert_eq!(version, *v, "error must name the offending version");
+                    assert_eq!(floor, "na", "error must name the na floor");
+                }
+                other => panic!("{}: expected UnsupportedVersion, got {:?}", v, other),
+            }
+        }
+    }
+
+    /// #1297: exactly the in-scope BIG allowlist constructs gates; the ceiling
+    /// is additive over the `< na` floor (both below-floor and above-allowlist
+    /// versions are rejected, the three supported versions still succeed).
+    #[test]
+    fn test_big_exact_allowlist_only() {
+        for v in &["na", "nb", "oa"] {
+            assert!(
+                BigVersionGates::from_version(v).is_ok(),
+                "{} is in the supported BIG allowlist and must construct gates",
+                v
+            );
+        }
+        // Below the floor (additive ceiling did not remove the floor):
+        assert!(
+            BigVersionGates::from_version("me").is_err(),
+            "below-floor still rejected"
+        );
+        // Above the floor but outside the allowlist:
+        assert!(
+            BigVersionGates::from_version("nc").is_err(),
+            "above-allowlist rejected"
+        );
+    }
+
+    /// #1297: reader-side allowlist now agrees with `FormatDetector::is_supported`
+    /// for these BIG cases — both accept exactly {na, nb, oa} and reject `nc`.
+    #[test]
+    fn test_big_gate_matches_format_detector_is_supported() {
+        use super::super::format_detector::FormatDetector;
+        let detector = FormatDetector::new();
+        for v in &["na", "nb", "oa", "nc", "me"] {
+            let gate_ok = BigVersionGates::from_version(v).is_ok();
+            let detector_ok = detector.is_supported(v);
+            assert_eq!(
+                gate_ok, detector_ok,
+                "{}: BigVersionGates::from_version and FormatDetector::is_supported must agree",
                 v
             );
         }
@@ -957,6 +1048,57 @@ mod tests {
             }
             VersionGates::Bti(_) => panic!("Expected Big"),
         }
+    }
+
+    /// #1297: an unknown BTI version is rejected through the combined
+    /// `VersionGates::from_descriptor` entry point (the public derivation used
+    /// by readers), not just the `BtiVersionGates` helper. The BTI allowlist is
+    /// exactly `{da}`.
+    #[test]
+    fn test_version_gates_from_descriptor_rejects_unknown_bti() {
+        for v in &["db", "ea", "dz", "zz"] {
+            let desc = SsTableDescriptor {
+                version: v.to_string(),
+                sstable_id: "1".to_string(),
+                format: SsTableFormat::Bti,
+                component: "Data.db".to_string(),
+            };
+            match VersionGates::from_descriptor(&desc) {
+                Err(Error::UnsupportedVersion { version, floor }) => {
+                    assert_eq!(version, *v, "error must name the offending BTI version");
+                    assert_eq!(floor, "da", "error must name the da floor");
+                }
+                other => panic!("{}: expected UnsupportedVersion, got {:?}", v, other),
+            }
+        }
+        // The single supported BTI version still constructs gates via the
+        // combined entry point.
+        let da_desc = SsTableDescriptor {
+            version: "da".to_string(),
+            sstable_id: "1".to_string(),
+            format: SsTableFormat::Bti,
+            component: "Data.db".to_string(),
+        };
+        assert!(matches!(
+            VersionGates::from_descriptor(&da_desc),
+            Ok(VersionGates::Bti(_))
+        ));
+    }
+
+    /// #1297: an unknown above-floor BIG version is rejected through
+    /// `VersionGates::from_descriptor` (the reader's derivation path).
+    #[test]
+    fn test_version_gates_from_descriptor_rejects_unknown_big() {
+        let desc = SsTableDescriptor {
+            version: "nc".to_string(),
+            sstable_id: "1".to_string(),
+            format: SsTableFormat::Big,
+            component: "Data.db".to_string(),
+        };
+        assert!(matches!(
+            VersionGates::from_descriptor(&desc),
+            Err(Error::UnsupportedVersion { .. })
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Closes #1297.

## Decision
Per owner: CQLite targets Cassandra 5.0 **only**. The version gate now rejects any SSTable version outside the supported set `{na, nb, oa, da}` with a typed `Error::UnsupportedVersion`, making the reader agree with `FormatDetector::is_supported()`. No forward-tolerance for unvalidated future formats (no-heuristics).

## Change
- `BigVersionGates::from_version`: additive ceiling after the existing `< na` floor — accept only `{na, nb, oa}` (the BIG-segment versions), reject `nc`/`ob`/`pa`/typos with `UnsupportedVersion`. Floor (#1249) preserved.
- BTI (`BtiVersionGates::from_version`) already enforced exact `da` (#1249); added `VersionGates::from_descriptor` rejection coverage.
- Errors propagate unchanged through `SSTableReader::open` / `StatisticsReader::open` (no fallback, no panic).

## Tests (wiring evidence)
- Helper: unknown above-floor BIG (`nc`/`nz`/`pa`/`ob`) → `UnsupportedVersion`; exact allowlist `{na,nb,oa}` Ok; `from_descriptor` rejects unknown BIG + BTI.
- Public surface: `SSTableReader::open` and `StatisticsReader::open` on `nc-1-big-*` → `UnsupportedVersion` (no nb fallback).
- Consistency: `BigVersionGates::from_version(v).is_ok() == FormatDetector::is_supported(v)`.

## Validation
`scripts/agent-gate.sh` → **RESULT: PASS** (all 16 components, `f67758b9`).

## Note
`version_gate.rs` grew (1094→1236, already over the 800 threshold); used `CQLITE_ALLOW_FILE_GROWTH=1` for this surgical fix. A per-#1116 split (`version_gate/{descriptor,big,bti}.rs`) is the right follow-up.