### PR TITLE
fix(#1325): populate nb RowStatistics counts from authoritative STATS (reuse read_table_counts)

### DIFF
--- a/cqlite-core/src/parser/enhanced_statistics_parser/mod.rs
+++ b/cqlite-core/src/parser/enhanced_statistics_parser/mod.rs
@@ -135,13 +135,56 @@ pub fn parse_nb_format_statistics_data(
                 regular_columns,
             ),
         )) => {
-            // Create minimal statistics with only timestamp data populated
+            // Populate the authoritative row/partition counts from the STATS
+            // component (issue #1325). We reuse the single source of truth added
+            // in #944 — `repair_metadata::read_table_counts` — rather than
+            // re-deriving the walk here:
+            //   * `partition_count` = Σ `estimatedPartitionSize` histogram bucket
+            //     counts (self-describing; always decodable).
+            //   * `total_rows`      = STATS `totalRows` via the version-gated walk,
+            //     `None` when not authoritatively traversable (e.g. a clustered
+            //     covered-Slice whose bound values are not modeled).
+            // No-heuristics mandate (#28): when a value is NOT authoritatively
+            // reachable we leave the documented 0 rather than fabricating a count.
+            //   * `total_rows`: `None` from `read_table_counts` → 0 (meaning
+            //     "not authoritatively reachable", never a guessed count).
+            //   * `live_rows`: STATS carries no per-SSTable live-row count that is
+            //     authoritatively distinguishable from `total_rows` here, so it is
+            //     left as 0 (documented "not authoritatively derivable") rather
+            //     than guessed. (Consumers that need an upper bound use
+            //     `total_rows`; see cqlite-flight `read_table_counts` doctrine.)
+            //   * `avg_rows_per_partition`: computed only when BOTH counts are
+            //     authoritative and `partition_count > 0`; otherwise left 0.0.
+            // `full_input` is the raw Statistics.db buffer (with TOC), exactly the
+            // input `read_table_counts` expects. This is strictly additive — an
+            // Err is logged and the fields stay at 0 (a Statistics.db that parses
+            // today must keep parsing).
+            let (total_rows, partition_count) =
+                match crate::parser::repair_metadata::read_table_counts(full_input, gates) {
+                    Ok(counts) => (counts.total_rows.unwrap_or(0), counts.partition_count),
+                    Err(e) => {
+                        log::debug!(
+                            "Best-effort authoritative row/partition-count decode failed; \
+                             leaving RowStatistics counts at 0: {:?}",
+                            e
+                        );
+                        (0, 0)
+                    }
+                };
+            let avg_rows_per_partition = if partition_count > 0 && total_rows > 0 {
+                total_rows as f64 / partition_count as f64
+            } else {
+                0.0
+            };
+
             let row_stats = RowStatistics {
-                total_rows: 0,
+                total_rows,
+                // Not authoritatively derivable from STATS as a value distinct
+                // from `total_rows`; left 0 (documented) rather than guessed (#28).
                 live_rows: 0,
                 tombstone_count: 0,
-                partition_count: 0,
-                avg_rows_per_partition: 0.0,
+                partition_count,
+                avg_rows_per_partition,
                 row_size_histogram: vec![],
             };
 

--- a/cqlite-core/src/parser/enhanced_statistics_parser/mod.rs
+++ b/cqlite-core/src/parser/enhanced_statistics_parser/mod.rs
@@ -160,22 +160,31 @@ pub fn parse_nb_format_statistics_data(
             // Err is logged and the fields stay at 0 (a Statistics.db that parses
             // today must keep parsing).
             //
-            // Default the gates locally when the caller threaded `None` (#1325
-            // finding 2). We are DEFINITIVELY inside the nb-format parser here, so
-            // `nb`'s gate values are AUTHORITATIVE — not a heuristic (#28): they
-            // are the literal BigFormat.java gates for version "nb". Without them
-            // `read_table_counts` cannot traverse the gated min/max block and would
-            // return `total_rows = None` (→ a silently-wrong 0) even for a real nb
-            // file. Reuse the canonical infallible `nb_fallback` constructor.
-            let nb_gates = crate::storage::sstable::version_gate::VersionGates::Big(
-                crate::storage::sstable::version_gate::BigVersionGates::nb_fallback(),
-            );
-            let effective_gates = gates.unwrap_or(&nb_gates);
+            // No-heuristics gate discipline (#28, #1325 roborev finding): the
+            // version-gated `read_table_counts` walk MUST run with gates that match
+            // the file's actual on-disk layout — Statistics.db does NOT self-describe
+            // its SSTable version (the version comes from the filename → the gates).
+            // The `nb` and `oa`/`da` STATS min/max blocks have DIFFERENT layouts, so
+            // synthesizing `nb` gates for a file whose format we have not
+            // authoritatively established would mis-walk an `oa`/`da` buffer and could
+            // read a BOGUS nonzero `totalRows`. This function is the SINGLE entry point
+            // for `parse_statistics_with_fallback`, which is a public API reachable with
+            // `None` gates for ANY format (standalone tools, tests) — there is no
+            // format-detection dispatch that guarantees only `nb` bytes arrive here.
+            //
+            // Therefore we pass the caller's gates through UNCHANGED and NEVER
+            // synthesize a version:
+            //   * `Some(gates)` — the caller (e.g. `StatisticsReader::open`) derived
+            //     these from the filename, so they are authoritative for the file's
+            //     real version (nb / oa / da). The gated walk reaches `totalRows`.
+            //   * `None` — the format is UNKNOWN. We cannot authoritatively establish
+            //     it, so `read_table_counts` stops before the gated min/max block and
+            //     reports `total_rows = None`. We surface that as `0` meaning "not
+            //     authoritatively available", NEVER a guessed count. This is strictly
+            //     safer than the old `nb` synthesis, which could fabricate a nonzero
+            //     count for an oa/da file.
             let (total_rows, partition_count) =
-                match crate::parser::repair_metadata::read_table_counts(
-                    full_input,
-                    Some(effective_gates),
-                ) {
+                match crate::parser::repair_metadata::read_table_counts(full_input, gates) {
                     // `total_rows.unwrap_or(0)`: a `None` here means STATS does NOT
                     // authoritatively expose `totalRows` (e.g. an unmodeled
                     // improvedMinMax covered-Slice bound blocks the walk). The 0 is

--- a/cqlite-core/src/parser/enhanced_statistics_parser/mod.rs
+++ b/cqlite-core/src/parser/enhanced_statistics_parser/mod.rs
@@ -159,8 +159,28 @@ pub fn parse_nb_format_statistics_data(
             // input `read_table_counts` expects. This is strictly additive — an
             // Err is logged and the fields stay at 0 (a Statistics.db that parses
             // today must keep parsing).
+            //
+            // Default the gates locally when the caller threaded `None` (#1325
+            // finding 2). We are DEFINITIVELY inside the nb-format parser here, so
+            // `nb`'s gate values are AUTHORITATIVE — not a heuristic (#28): they
+            // are the literal BigFormat.java gates for version "nb". Without them
+            // `read_table_counts` cannot traverse the gated min/max block and would
+            // return `total_rows = None` (→ a silently-wrong 0) even for a real nb
+            // file. Reuse the canonical infallible `nb_fallback` constructor.
+            let nb_gates = crate::storage::sstable::version_gate::VersionGates::Big(
+                crate::storage::sstable::version_gate::BigVersionGates::nb_fallback(),
+            );
+            let effective_gates = gates.unwrap_or(&nb_gates);
             let (total_rows, partition_count) =
-                match crate::parser::repair_metadata::read_table_counts(full_input, gates) {
+                match crate::parser::repair_metadata::read_table_counts(
+                    full_input,
+                    Some(effective_gates),
+                ) {
+                    // `total_rows.unwrap_or(0)`: a `None` here means STATS does NOT
+                    // authoritatively expose `totalRows` (e.g. an unmodeled
+                    // improvedMinMax covered-Slice bound blocks the walk). The 0 is
+                    // therefore "not authoritatively available from STATS", NOT a
+                    // measured zero — never a guessed count (#1325, no-heuristics #28).
                     Ok(counts) => (counts.total_rows.unwrap_or(0), counts.partition_count),
                     Err(e) => {
                         log::debug!(
@@ -179,8 +199,13 @@ pub fn parse_nb_format_statistics_data(
 
             let row_stats = RowStatistics {
                 total_rows,
-                // Not authoritatively derivable from STATS as a value distinct
-                // from `total_rows`; left 0 (documented) rather than guessed (#28).
+                // `live_rows = 0` here means "NOT authoritatively available from
+                // STATS for nb", NOT a measured zero. STATS carries no per-SSTable
+                // live-row count that is authoritatively distinguishable from
+                // `total_rows`, so per #1325's acceptance criteria this unreachable
+                // field stays "0-with-documented-meaning" rather than being guessed
+                // or aliased to `total_rows` (no-heuristics mandate #28). Changing
+                // this field to `Option` is a broader API change tracked separately.
                 live_rows: 0,
                 tombstone_count: 0,
                 partition_count,

--- a/cqlite-core/src/parser/enhanced_statistics_test.rs
+++ b/cqlite-core/src/parser/enhanced_statistics_test.rs
@@ -297,10 +297,10 @@ mod tests {
             "- **Health Score**: {:.1}/100\n",
             analysis.health_score
         ));
-        report.push_str(&format!(
-            "- **Data Efficiency**: {:.1}%\n",
-            analysis.data_efficiency
-        ));
+        report.push_str(&match analysis.data_efficiency {
+            Some(eff) => format!("- **Data Efficiency**: {:.1}%\n", eff),
+            None => "- **Data Efficiency**: unavailable\n".to_string(),
+        });
         report.push_str(&format!(
             "- **Timestamp Range**: {:.1} days\n",
             analysis.timestamp_range_days

--- a/cqlite-core/src/parser/statistics.rs
+++ b/cqlite-core/src/parser/statistics.rs
@@ -677,12 +677,26 @@ impl StatisticsAnalyzer {
         Some((stats.row_stats.live_rows as f64 / stats.row_stats.total_rows as f64) * 100.0)
     }
 
-    fn calculate_data_efficiency(stats: &SSTableStatistics) -> f64 {
+    /// Overall data efficiency, or `None` when it is not authoritatively
+    /// derivable.
+    ///
+    /// Data efficiency blends the live-row ratio with compression and partition
+    /// efficiency, so it can only be computed when the live ratio is available.
+    /// `live_rows == 0` is the documented #1325 sentinel meaning "not
+    /// authoritatively available from STATS" (STATS has no per-SSTable live-row
+    /// count), and `total_rows == 0` would make the ratio `NaN`; in either case
+    /// we return `None` rather than a misleading concrete number. This reuses
+    /// the exact availability check of `live_data_percentage`. No heuristic
+    /// (#28); representation redesign is tracked by #1352.
+    fn calculate_data_efficiency(stats: &SSTableStatistics) -> Option<f64> {
+        if stats.row_stats.live_rows == 0 || stats.row_stats.total_rows == 0 {
+            return None;
+        }
         let live_ratio = stats.row_stats.live_rows as f64 / stats.row_stats.total_rows as f64;
         let compression_ratio = stats.compression_stats.ratio;
         let partition_efficiency = 1.0 - (stats.partition_stats.large_partition_percentage / 100.0);
 
-        (live_ratio + compression_ratio + partition_efficiency) / 3.0 * 100.0
+        Some((live_ratio + compression_ratio + partition_efficiency) / 3.0 * 100.0)
     }
 
     fn generate_query_hints(stats: &SSTableStatistics) -> Vec<String> {
@@ -692,7 +706,15 @@ impl StatisticsAnalyzer {
             hints.push("Consider reviewing partition key design - high percentage of large partitions detected".to_string());
         }
 
-        if stats.row_stats.tombstone_count > stats.row_stats.live_rows / 4 {
+        // The "high tombstone ratio" hint compares tombstones against the live
+        // row count. When `live_rows == 0` that is the documented #1325 sentinel
+        // for "not authoritatively available from STATS" (not a measured zero),
+        // so `live_rows / 4 == 0` would make ANY tombstone trip the hint. Skip
+        // the hint entirely when the live count is unavailable rather than emit
+        // a misleading recommendation. No heuristic (#28); see #1352.
+        if stats.row_stats.live_rows > 0
+            && stats.row_stats.tombstone_count > stats.row_stats.live_rows / 4
+        {
             hints.push("High tombstone ratio - consider running compaction".to_string());
         }
 
@@ -723,10 +745,15 @@ impl StatisticsAnalyzer {
     fn calculate_health_score(stats: &SSTableStatistics) -> f64 {
         let mut score = 100.0;
 
-        // Deduct for high tombstone ratio
-        let tombstone_ratio =
-            stats.row_stats.tombstone_count as f64 / stats.row_stats.total_rows as f64;
-        score -= tombstone_ratio * 30.0;
+        // Deduct for high tombstone ratio. This derives from `total_rows` (an
+        // authoritative STATS count), NOT the #1325 `live_rows` unavailable
+        // sentinel, so it stays a concrete score. Guard `total_rows == 0` so the
+        // ratio does not become `NaN` (which would poison the whole score).
+        if stats.row_stats.total_rows > 0 {
+            let tombstone_ratio =
+                stats.row_stats.tombstone_count as f64 / stats.row_stats.total_rows as f64;
+            score -= tombstone_ratio * 30.0;
+        }
 
         // Deduct for poor compression
         if stats.compression_stats.ratio < 0.5 {
@@ -757,7 +784,11 @@ pub struct StatisticsSummary {
     pub compression_efficiency: f64,
     pub timestamp_range_days: f64,
     pub largest_partition_mb: f64,
-    pub data_efficiency: f64,
+    /// Blended data-efficiency score, or `None` when the live-row ratio is not
+    /// authoritatively available (the #1325 `live_rows == 0` sentinel, or
+    /// `total_rows == 0`); see `StatisticsAnalyzer::calculate_data_efficiency`
+    /// and #1352.
+    pub data_efficiency: Option<f64>,
     pub query_performance_hints: Vec<String>,
     pub storage_recommendations: Vec<String>,
     pub health_score: f64,
@@ -918,8 +949,88 @@ mod tests {
             summary.live_data_percentage, None,
             "live_rows==0 sentinel with total_rows>0 must report None, not 0.00%"
         );
+        // Data efficiency is derived from the live ratio, so it must be
+        // unavailable under the same sentinel (not an artificially low number).
+        assert_eq!(
+            summary.data_efficiency, None,
+            "data_efficiency must be None when live_rows is the unavailable sentinel"
+        );
         // Authoritative counts are unaffected.
         assert_eq!(summary.total_rows, 1000);
+        // Health score derives from total_rows (authoritative), not live_rows,
+        // so it stays a concrete, finite value.
+        assert!(
+            summary.health_score.is_finite(),
+            "health_score must stay finite when live_rows is the sentinel"
+        );
+    }
+
+    /// #1325 sweep: the "high tombstone ratio" query hint compares tombstones
+    /// against `live_rows`. When `live_rows == 0` (unavailable sentinel), the
+    /// old `live_rows / 4 == 0` comparison would trip the hint for ANY
+    /// tombstone. It must be suppressed instead. No heuristic (#28); see #1352.
+    #[test]
+    fn test_query_hint_suppressed_when_live_rows_sentinel() {
+        let mut stats = create_test_statistics();
+        stats.row_stats.total_rows = 1000;
+        stats.row_stats.live_rows = 0; // unavailable sentinel
+        stats.row_stats.tombstone_count = 500; // would trip vs. live_rows/4 == 0
+
+        let summary = StatisticsAnalyzer::analyze(&stats);
+
+        assert!(
+            !summary
+                .query_performance_hints
+                .iter()
+                .any(|h| h.contains("tombstone")),
+            "tombstone hint must be suppressed when live_rows is the unavailable sentinel"
+        );
+    }
+
+    /// #1325 sweep: when `live_rows` is a real count, the tombstone hint and
+    /// data-efficiency stay concrete (non-vacuous positive path).
+    #[test]
+    fn test_derived_metrics_available_when_live_rows_present() {
+        let mut stats = create_test_statistics();
+        stats.row_stats.total_rows = 1000;
+        stats.row_stats.live_rows = 100; // real count; live_rows/4 == 25
+        stats.row_stats.tombstone_count = 500; // 500 > 25 -> hint fires
+
+        let summary = StatisticsAnalyzer::analyze(&stats);
+
+        assert!(
+            summary.live_data_percentage.is_some(),
+            "live_data_percentage must be Some when live_rows > 0"
+        );
+        let eff = summary
+            .data_efficiency
+            .expect("data_efficiency must be Some when live_rows > 0");
+        assert!(eff.is_finite());
+        assert!(
+            summary
+                .query_performance_hints
+                .iter()
+                .any(|h| h.contains("tombstone")),
+            "tombstone hint must fire when tombstones exceed live_rows/4"
+        );
+    }
+
+    /// #1325 sweep: health score must not become `NaN` when `total_rows == 0`
+    /// (guard the div-by-zero in the tombstone-ratio deduction).
+    #[test]
+    fn test_health_score_finite_when_total_rows_zero() {
+        let mut stats = create_test_statistics();
+        stats.row_stats.total_rows = 0;
+        stats.row_stats.live_rows = 0;
+        stats.row_stats.tombstone_count = 0;
+
+        let summary = StatisticsAnalyzer::analyze(&stats);
+
+        assert!(
+            summary.health_score.is_finite(),
+            "health_score must be finite (not NaN) when total_rows == 0"
+        );
+        assert!((0.0..=100.0).contains(&summary.health_score));
     }
 
     #[test]

--- a/cqlite-core/src/parser/statistics.rs
+++ b/cqlite-core/src/parser/statistics.rs
@@ -650,9 +650,8 @@ impl StatisticsAnalyzer {
 
         StatisticsSummary {
             total_rows: stats.row_stats.total_rows,
-            live_data_percentage: (stats.row_stats.live_rows as f64
-                / stats.row_stats.total_rows as f64)
-                * 100.0,
+            // `None` when not authoritatively available; see `live_data_percentage`.
+            live_data_percentage: Self::live_data_percentage(stats),
             compression_efficiency: stats.compression_stats.ratio * 100.0,
             timestamp_range_days: Self::calculate_timestamp_range_days(stats),
             largest_partition_mb: stats.partition_stats.max_partition_size as f64 / 1_048_576.0,
@@ -661,6 +660,21 @@ impl StatisticsAnalyzer {
             storage_recommendations,
             health_score,
         }
+    }
+
+    /// Live-data percentage, or `None` when it is not authoritatively available.
+    ///
+    /// `live_rows == 0` is the documented #1325 sentinel meaning "not
+    /// authoritatively derivable from STATS" (STATS has no per-SSTable live-row
+    /// count), so we return `None` rather than a misleading concrete `0.00%`.
+    /// A genuinely fully-tombstoned SSTable also reads as unavailable here —
+    /// honest, since we cannot distinguish it from "unknown" until the
+    /// `RowStatistics` representation is redesigned (#1352). No heuristic (#28).
+    fn live_data_percentage(stats: &SSTableStatistics) -> Option<f64> {
+        if stats.row_stats.live_rows == 0 || stats.row_stats.total_rows == 0 {
+            return None;
+        }
+        Some((stats.row_stats.live_rows as f64 / stats.row_stats.total_rows as f64) * 100.0)
     }
 
     fn calculate_data_efficiency(stats: &SSTableStatistics) -> f64 {
@@ -736,7 +750,10 @@ impl StatisticsAnalyzer {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StatisticsSummary {
     pub total_rows: u64,
-    pub live_data_percentage: f64,
+    /// Percentage of live (non-tombstoned) data, or `None` when not
+    /// authoritatively available (the #1325 `live_rows == 0` sentinel; see
+    /// `StatisticsAnalyzer::live_data_percentage` and #1352).
+    pub live_data_percentage: Option<f64>,
     pub compression_efficiency: f64,
     pub timestamp_range_days: f64,
     pub largest_partition_mb: f64,
@@ -878,7 +895,31 @@ mod tests {
 
         assert!(summary.total_rows > 0);
         assert!(summary.health_score >= 0.0 && summary.health_score <= 100.0);
-        assert!(summary.live_data_percentage >= 0.0 && summary.live_data_percentage <= 100.0);
+        let live_pct = summary
+            .live_data_percentage
+            .expect("fixture has authoritative live_rows > 0");
+        assert!((0.0..=100.0).contains(&live_pct));
+    }
+
+    /// #1325 roborev finding: when `live_rows` is the documented "not
+    /// authoritatively available from STATS" sentinel (0) but `total_rows` is a
+    /// real authoritative count, the analyzer MUST report live-data% as
+    /// unavailable (`None`) rather than a misleading concrete `0.00%`. Other
+    /// authoritative fields (`total_rows`) stay intact. See #1352.
+    #[test]
+    fn test_live_data_percentage_unavailable_when_live_rows_sentinel() {
+        let mut stats = create_test_statistics();
+        stats.row_stats.total_rows = 1000; // real authoritative count
+        stats.row_stats.live_rows = 0; // documented "unavailable" sentinel
+
+        let summary = StatisticsAnalyzer::analyze(&stats);
+
+        assert_eq!(
+            summary.live_data_percentage, None,
+            "live_rows==0 sentinel with total_rows>0 must report None, not 0.00%"
+        );
+        // Authoritative counts are unaffected.
+        assert_eq!(summary.total_rows, 1000);
     }
 
     #[test]

--- a/cqlite-core/src/parser/statistics_test.rs
+++ b/cqlite-core/src/parser/statistics_test.rs
@@ -434,7 +434,10 @@ mod tests {
 
         // Validate analysis results
         assert_eq!(analysis.total_rows, 1000);
-        assert!(analysis.live_data_percentage > 0.0 && analysis.live_data_percentage <= 100.0);
+        let live_pct = analysis
+            .live_data_percentage
+            .expect("fixture has authoritative live_rows > 0");
+        assert!(live_pct > 0.0 && live_pct <= 100.0);
         assert!(analysis.compression_efficiency > 0.0);
         assert!(analysis.health_score >= 0.0 && analysis.health_score <= 100.0);
         assert!(analysis.timestamp_range_days >= 0.0);

--- a/cqlite-core/src/storage/sstable/statistics_reader.rs
+++ b/cqlite-core/src/storage/sstable/statistics_reader.rs
@@ -289,10 +289,15 @@ impl StatisticsReader {
             "- Total rows: {}\n",
             self.statistics.row_stats.total_rows
         ));
-        report.push_str(&format!(
-            "- Live rows: {}\n",
-            self.statistics.row_stats.live_rows
-        ));
+        // `live_rows == 0` is the documented #1325 "not authoritatively
+        // available from STATS" sentinel (STATS has no per-SSTable live-row
+        // count), not a measured zero. Render it as `unavailable` for
+        // consistency with the overview live-data% above rather than a
+        // misleading `0` (#1352).
+        report.push_str(&match self.statistics.row_stats.live_rows {
+            0 => "- Live rows: unavailable\n".to_string(),
+            live => format!("- Live rows: {}\n", live),
+        });
         report.push_str(&format!(
             "- Tombstones: {}\n",
             self.statistics.row_stats.tombstone_count

--- a/cqlite-core/src/storage/sstable/statistics_reader.rs
+++ b/cqlite-core/src/storage/sstable/statistics_reader.rs
@@ -259,10 +259,13 @@ impl StatisticsReader {
         // Overview section
         report.push_str("## Overview\n");
         report.push_str(&format!("- **Total Rows**: {}\n", summary.total_rows));
-        report.push_str(&format!(
-            "- **Live Data**: {:.2}%\n",
-            summary.live_data_percentage
-        ));
+        // `live_data_percentage` is `None` when `live_rows` is the documented
+        // #1325 "not authoritatively available from STATS" sentinel; render it as
+        // unavailable rather than a misleading concrete 0.00% (#1352).
+        report.push_str(&match summary.live_data_percentage {
+            Some(pct) => format!("- **Live Data**: {:.2}%\n", pct),
+            None => "- **Live Data**: unavailable\n".to_string(),
+        });
         report.push_str(&format!(
             "- **Compression Efficiency**: {:.2}%\n",
             summary.compression_efficiency
@@ -420,10 +423,16 @@ impl StatisticsReader {
     /// Get a compact summary for CLI display
     pub fn compact_summary(&self) -> String {
         let summary = self.analyze();
+        // See `generate_report`: `None` = live-data% not authoritatively available
+        // (#1325 sentinel), rendered as "?% live" instead of a misleading 0.0%.
+        let live = match summary.live_data_percentage {
+            Some(pct) => format!("{:.1}% live", pct),
+            None => "?% live".to_string(),
+        };
         format!(
-            "Rows: {} ({:.1}% live) | Compression: {:.1}% | Health: {:.0}/100 | Size: {:.2} MB",
+            "Rows: {} ({}) | Compression: {:.1}% | Health: {:.0}/100 | Size: {:.2} MB",
             summary.total_rows,
-            summary.live_data_percentage,
+            live,
             summary.compression_efficiency,
             summary.health_score,
             self.statistics.table_stats.disk_size as f64 / 1_048_576.0

--- a/cqlite-core/tests/issue_1325_nb_rowstatistics_counts.rs
+++ b/cqlite-core/tests/issue_1325_nb_rowstatistics_counts.rs
@@ -21,6 +21,18 @@
 //!   `Statistics.db` is absent; but a fixture that IS present MUST carry the
 //!   authoritative counts — a present-but-zero/wrong result FAILS (never let the
 //!   test false-pass on an empty dataset).
+//!
+//! ## Safety property (roborev #1325 follow-up)
+//!
+//! `parse_statistics_with_fallback` is a PUBLIC entry point reachable with `None`
+//! gates for ANY format, and Statistics.db does NOT self-describe its SSTable
+//! version. Synthesizing `nb` gates for an unknown-format buffer is a guess that
+//! can mis-walk an `oa`/`da` STATS layout and expose a BOGUS nonzero `totalRows`
+//! (worse than an honest 0; violates the no-heuristics mandate #28). The
+//! `oa_da_none_gates_never_fabricates_total_rows` test proves that path is closed:
+//! feeding a real `oa`/`da` Statistics.db through the `None`-gates entry point
+//! yields `total_rows == 0` (honest/unavailable), while the gates-provided path
+//! (version derived from the filename) still yields the authoritative count.
 
 use std::fs;
 use std::path::PathBuf;
@@ -87,7 +99,8 @@ fn assert_counts(keyspace: &str, prefix: &str, want_partitions: u64, want_total_
         .unwrap_or_else(|e| panic!("read {} failed: {e}", stats_path.display()));
 
     // Path A — gates-provided: gates from the filename so the version-gated walk
-    // to `totalRows` succeeds via the caller-threaded path.
+    // to `totalRows` succeeds via the caller-threaded path. This is the normal
+    // production path (`StatisticsReader::open` derives gates from the filename).
     let gates = VersionGates::from_path(&stats_path).ok();
     assert_row_counts(
         keyspace,
@@ -100,23 +113,55 @@ fn assert_counts(keyspace: &str, prefix: &str, want_partitions: u64, want_total_
         want_total_rows,
     );
 
-    // Path B — None-gates (#1325 finding 2): a direct caller of
-    // `parse_statistics_with_fallback(.., None)` must ALSO get the authoritative
-    // counts, because the nb parser now defaults to the authoritative nb gates
-    // internally (we are definitively in the nb-format parser). This is the
-    // regression guard for the fix.
-    assert_row_counts(
-        keyspace,
-        prefix,
-        &bytes,
-        &stats_path,
-        None,
-        "None-gates",
-        want_partitions,
-        want_total_rows,
-    );
+    // Path B — None-gates (#1325 roborev finding): `parse_statistics_with_fallback`
+    // is a PUBLIC entry point reachable with `None` gates for ANY format, and
+    // Statistics.db does NOT self-describe its SSTable version. With an unknown
+    // format we MUST NOT synthesize `nb` gates (a guess that could mis-walk an
+    // oa/da layout and expose a bogus `totalRows`; no-heuristics #28). So the
+    // None-gates path reports counts HONESTLY:
+    //   * `partition_count` is still authoritative — it is the Σ of the leading,
+    //     fully self-describing `estimatedPartitionSize` histogram, which needs
+    //     NO version gates.
+    //   * `total_rows` becomes 0 meaning "not authoritatively available" (the
+    //     gated walk to `totalRows` is not attempted without gates), NEVER a
+    //     guessed count.
+    assert_none_gates_honest(keyspace, prefix, &bytes, &stats_path, want_partitions);
 
     true
+}
+
+/// Parse `bytes` with `None` gates through the public entry point and assert the
+/// HONEST no-heuristics behavior: `partition_count` is the authoritative
+/// self-describing count, but `total_rows`/`live_rows` are 0 (not authoritatively
+/// available without gates — never a guess).
+fn assert_none_gates_honest(
+    keyspace: &str,
+    prefix: &str,
+    bytes: &[u8],
+    stats_path: &std::path::Path,
+    want_partitions: u64,
+) {
+    let (_rest, stats) = parse_statistics_with_fallback(bytes, None)
+        .unwrap_or_else(|e| panic!("parse {} [None-gates] failed: {e:?}", stats_path.display()));
+    let row = &stats.row_stats;
+    assert_eq!(
+        row.partition_count,
+        want_partitions,
+        "{keyspace}/{prefix} [None-gates]: partition_count is self-describing and must \
+         still be authoritative ({})",
+        stats_path.display()
+    );
+    assert_eq!(
+        row.total_rows,
+        0,
+        "{keyspace}/{prefix} [None-gates]: total_rows must be 0 (unavailable without \
+         gates), NOT synthesized from guessed nb gates ({})",
+        stats_path.display()
+    );
+    assert_eq!(
+        row.live_rows, 0,
+        "{keyspace}/{prefix} [None-gates]: live_rows must stay 0"
+    );
 }
 
 /// Parse `bytes` with the given `gates` and assert the authoritative counts.
@@ -199,5 +244,97 @@ fn nb_rowstatistics_carry_authoritative_counts() {
         asserted > 0,
         "CQLITE_DATASETS_ROOT is configured but no #1325 fixture Statistics.db was \
          exercised — refusing to false-pass on an empty/missing dataset"
+    );
+}
+
+/// Locate the first `-Statistics.db` binary under any `<root>/<keyspace>/<table>`
+/// directory whose filename version segment is in `versions` (e.g. `["oa", "da"]`).
+fn find_stats_db_for_versions(versions: &[&str]) -> Option<PathBuf> {
+    let root = datasets_root()?;
+    let mut found: Vec<PathBuf> = Vec::new();
+    for ks in fs::read_dir(&root).ok()?.flatten() {
+        let ks_path = ks.path();
+        if !ks_path.is_dir() {
+            continue;
+        }
+        for tbl in fs::read_dir(&ks_path).ok()?.flatten() {
+            let tbl_path = tbl.path();
+            if !tbl_path.is_dir() {
+                continue;
+            }
+            if let Some(stats) = find_statistics_db(&tbl_path) {
+                let name = stats.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                let version = name.split('-').next().unwrap_or("");
+                if versions.contains(&version) {
+                    found.push(stats);
+                }
+            }
+        }
+    }
+    found.sort();
+    found.into_iter().next()
+}
+
+/// #1325 (roborev safety property): a NON-nb (`oa`/`da`) Statistics.db fed through
+/// the `None`-gates public entry point must NOT yield a fabricated nonzero
+/// `total_rows`. Statistics.db does not self-describe its version, so the
+/// `None`-gates path cannot synthesize `nb` gates (that guess could mis-walk the
+/// oa/da min/max block and expose a bogus count). It must report `total_rows == 0`
+/// (honest/unavailable) while the gates-provided path (version from the filename)
+/// still decodes the authoritative count.
+///
+/// SKIP cleanly when no oa/da fixture is available; but when one IS present the
+/// safety assertion MUST run (no vacuous pass).
+#[test]
+fn oa_da_none_gates_never_fabricates_total_rows() {
+    let Some(_root) = datasets_root() else {
+        println!("[SKIP] CQLITE_DATASETS_ROOT unset — no oa/da fixture to validate");
+        return;
+    };
+    let Some(stats_path) = find_stats_db_for_versions(&["oa", "da"]) else {
+        println!("[SKIP] no oa/da Statistics.db fixture available under datasets root");
+        return;
+    };
+
+    let bytes = fs::read(&stats_path)
+        .unwrap_or_else(|e| panic!("read {} failed: {e}", stats_path.display()));
+
+    // Unsafe path (must be CLOSED): None gates → format is unknown → total_rows
+    // must be honest 0, NEVER a fabricated nonzero from synthesized nb gates.
+    let (_rest, none_stats) = parse_statistics_with_fallback(&bytes, None)
+        .unwrap_or_else(|e| panic!("parse {} [None] failed: {e:?}", stats_path.display()));
+    assert_eq!(
+        none_stats.row_stats.total_rows,
+        0,
+        "SAFETY: an oa/da Statistics.db through the None-gates public entry point must \
+         report total_rows=0 (unavailable), NOT a fabricated count from guessed nb gates ({})",
+        stats_path.display()
+    );
+    assert_eq!(
+        none_stats.row_stats.live_rows,
+        0,
+        "None-gates live_rows must stay 0 ({})",
+        stats_path.display()
+    );
+
+    // Safe path (must still WORK): gates derived from the filename are
+    // authoritative for the file's real version, so the gated walk reaches the
+    // authoritative totalRows. This proves the fix did not close the legitimate
+    // gates-provided path for oa/da.
+    let gates = VersionGates::from_path(&stats_path)
+        .unwrap_or_else(|e| panic!("derive gates from {}: {e:?}", stats_path.display()));
+    let (_rest, gated_stats) = parse_statistics_with_fallback(&bytes, Some(&gates))
+        .unwrap_or_else(|e| panic!("parse {} [gated] failed: {e:?}", stats_path.display()));
+    assert!(
+        gated_stats.row_stats.total_rows > 0,
+        "gates-provided path for {} must decode an authoritative nonzero total_rows \
+         (got {})",
+        stats_path.display(),
+        gated_stats.row_stats.total_rows
+    );
+    println!(
+        "[INFO] #1325 safety: {} → None-gates total_rows=0 (honest); gated total_rows={} (authoritative)",
+        stats_path.display(),
+        gated_stats.row_stats.total_rows
     );
 }

--- a/cqlite-core/tests/issue_1325_nb_rowstatistics_counts.rs
+++ b/cqlite-core/tests/issue_1325_nb_rowstatistics_counts.rs
@@ -1,0 +1,147 @@
+//! Issue #1325: the enhanced (`nb`) Statistics.db parser must populate
+//! `RowStatistics.{partition_count, total_rows}` with the AUTHORITATIVE counts
+//! from the STATS component instead of the hard-coded `0` stubs.
+//!
+//! Before this fix `parse_nb_format_statistics_data` set `total_rows`,
+//! `live_rows`, and `partition_count` to `0` for every real `nb` SSTable, so a
+//! consumer reading those counts got a silently-wrong `0`. The fix delegates to
+//! the single source of truth added in #944 —
+//! `repair_metadata::read_table_counts` (partition_count = Σ
+//! `estimatedPartitionSize` histogram bucket counts; total_rows = STATS
+//! `totalRows` via the version-gated walk).
+//!
+//! ## No-heuristics / authoritative-values discipline
+//!
+//! - Expected counts are the values verified in #944 against these real
+//!   fixtures. They are structural (partition/row cardinality of the committed
+//!   dataset), not wall-clock derived, so pinning literals is safe here.
+//! - `live_rows` is left `0` by the fix (STATS carries no per-SSTable live-row
+//!   count distinct from `total_rows`); we assert that documented behavior.
+//! - SKIP cleanly when `CQLITE_DATASETS_ROOT` is unset or the fixture's binary
+//!   `Statistics.db` is absent; but a fixture that IS present MUST carry the
+//!   authoritative counts — a present-but-zero/wrong result FAILS (never let the
+//!   test false-pass on an empty dataset).
+
+use std::fs;
+use std::path::PathBuf;
+
+use cqlite_core::parser::enhanced_statistics_parser::parse_statistics_with_fallback;
+use cqlite_core::storage::sstable::version_gate::VersionGates;
+
+fn datasets_root() -> Option<PathBuf> {
+    let root = std::env::var("CQLITE_DATASETS_ROOT").ok()?;
+    let path = PathBuf::from(root).join("sstables");
+    path.exists().then_some(path)
+}
+
+/// Find the table directory whose name starts with `prefix` inside `<root>/<ks>`.
+fn find_table_dir(keyspace: &str, prefix: &str) -> Option<PathBuf> {
+    let root = datasets_root()?;
+    let ks_dir = root.join(keyspace);
+    let mut candidates: Vec<PathBuf> = fs::read_dir(&ks_dir)
+        .ok()?
+        .flatten()
+        .filter_map(|e| {
+            let name = e.file_name();
+            let s = name.to_str()?;
+            s.starts_with(prefix).then(|| e.path())
+        })
+        .collect();
+    candidates.sort();
+    candidates.into_iter().next()
+}
+
+/// Find the `-Statistics.db` binary (rejecting the `.txt` dump) in `dir`.
+fn find_statistics_db(dir: &std::path::Path) -> Option<PathBuf> {
+    for entry in fs::read_dir(dir).ok()?.flatten() {
+        let name = entry.file_name();
+        let n = name.to_str().unwrap_or("");
+        if n.starts_with("._") {
+            continue;
+        }
+        if n.ends_with("-Statistics.db") && !n.ends_with("-Statistics.db.txt") {
+            return Some(entry.path());
+        }
+    }
+    None
+}
+
+/// Assert the authoritative row/partition counts for one real `nb` fixture.
+///
+/// Returns `true` when the fixture was present and its counts asserted; `false`
+/// when it was cleanly skipped (fixture dir or Statistics.db genuinely absent).
+fn assert_counts(keyspace: &str, prefix: &str, want_partitions: u64, want_total_rows: u64) -> bool {
+    let Some(dir) = find_table_dir(keyspace, prefix) else {
+        println!("[SKIP] {keyspace}/{prefix}: no fixture dir");
+        return false;
+    };
+    let Some(stats_path) = find_statistics_db(&dir) else {
+        println!(
+            "[SKIP] {keyspace}/{prefix}: no Statistics.db in {}",
+            dir.display()
+        );
+        return false;
+    };
+
+    let bytes = fs::read(&stats_path)
+        .unwrap_or_else(|e| panic!("read {} failed: {e}", stats_path.display()));
+    // Gates from the filename so the version-gated walk to `totalRows` succeeds.
+    let gates = VersionGates::from_path(&stats_path).ok();
+
+    let (_rest, stats) = parse_statistics_with_fallback(&bytes, gates.as_ref())
+        .unwrap_or_else(|e| panic!("parse {} failed: {e:?}", stats_path.display()));
+
+    let row = &stats.row_stats;
+    assert_eq!(
+        row.partition_count,
+        want_partitions,
+        "{keyspace}/{prefix}: partition_count must be the authoritative STATS count \
+         (Σ estimatedPartitionSize buckets), not the old stub 0 ({})",
+        stats_path.display()
+    );
+    assert_eq!(
+        row.total_rows,
+        want_total_rows,
+        "{keyspace}/{prefix}: total_rows must be the authoritative STATS totalRows, \
+         not the old stub 0 ({})",
+        stats_path.display()
+    );
+    // `live_rows` is intentionally left 0 (not authoritatively derivable from
+    // STATS as a value distinct from total_rows; #28 no-heuristics).
+    assert_eq!(
+        row.live_rows, 0,
+        "{keyspace}/{prefix}: live_rows is left 0 (not authoritatively derivable); \
+         a nonzero value would be a fabricated count"
+    );
+    true
+}
+
+/// #1325: real `nb` fixtures carry the authoritative row/partition counts.
+///
+/// Fixture values verified in #944:
+///   * `sensor_data`  → partition_count=10,   total_rows=2000
+///   * `simple_table` → partition_count=1000, total_rows=1000
+///   * `stock_prices` → partition_count=3,    total_rows=200
+#[test]
+fn nb_rowstatistics_carry_authoritative_counts() {
+    let Some(_root) = datasets_root() else {
+        println!("[SKIP] CQLITE_DATASETS_ROOT unset — no fixtures to validate");
+        return;
+    };
+
+    let mut asserted = 0usize;
+    if assert_counts("test_timeseries", "sensor_data", 10, 2000) {
+        asserted += 1;
+    }
+    if assert_counts("test_basic", "simple_table", 1000, 1000) {
+        asserted += 1;
+    }
+    if assert_counts("test_timeseries", "stock_prices", 3, 200) {
+        asserted += 1;
+    }
+
+    // With CQLITE_DATASETS_ROOT set, at least one fixture is expected present.
+    // If ALL three were genuinely absent we skipped cleanly above; that is only
+    // acceptable when the dataset truly lacks them (not a false-pass on zeros).
+    println!("[INFO] #1325: asserted authoritative counts for {asserted}/3 fixtures");
+}

--- a/cqlite-core/tests/issue_1325_nb_rowstatistics_counts.rs
+++ b/cqlite-core/tests/issue_1325_nb_rowstatistics_counts.rs
@@ -85,35 +85,83 @@ fn assert_counts(keyspace: &str, prefix: &str, want_partitions: u64, want_total_
 
     let bytes = fs::read(&stats_path)
         .unwrap_or_else(|e| panic!("read {} failed: {e}", stats_path.display()));
-    // Gates from the filename so the version-gated walk to `totalRows` succeeds.
-    let gates = VersionGates::from_path(&stats_path).ok();
 
-    let (_rest, stats) = parse_statistics_with_fallback(&bytes, gates.as_ref())
-        .unwrap_or_else(|e| panic!("parse {} failed: {e:?}", stats_path.display()));
+    // Path A — gates-provided: gates from the filename so the version-gated walk
+    // to `totalRows` succeeds via the caller-threaded path.
+    let gates = VersionGates::from_path(&stats_path).ok();
+    assert_row_counts(
+        keyspace,
+        prefix,
+        &bytes,
+        &stats_path,
+        gates.as_ref(),
+        "gates-provided",
+        want_partitions,
+        want_total_rows,
+    );
+
+    // Path B — None-gates (#1325 finding 2): a direct caller of
+    // `parse_statistics_with_fallback(.., None)` must ALSO get the authoritative
+    // counts, because the nb parser now defaults to the authoritative nb gates
+    // internally (we are definitively in the nb-format parser). This is the
+    // regression guard for the fix.
+    assert_row_counts(
+        keyspace,
+        prefix,
+        &bytes,
+        &stats_path,
+        None,
+        "None-gates",
+        want_partitions,
+        want_total_rows,
+    );
+
+    true
+}
+
+/// Parse `bytes` with the given `gates` and assert the authoritative counts.
+/// `path_label` distinguishes the gates-provided vs None-gates entry point in
+/// failure messages.
+#[allow(clippy::too_many_arguments)]
+fn assert_row_counts(
+    keyspace: &str,
+    prefix: &str,
+    bytes: &[u8],
+    stats_path: &std::path::Path,
+    gates: Option<&VersionGates>,
+    path_label: &str,
+    want_partitions: u64,
+    want_total_rows: u64,
+) {
+    let (_rest, stats) = parse_statistics_with_fallback(bytes, gates).unwrap_or_else(|e| {
+        panic!(
+            "parse {} [{path_label}] failed: {e:?}",
+            stats_path.display()
+        )
+    });
 
     let row = &stats.row_stats;
     assert_eq!(
         row.partition_count,
         want_partitions,
-        "{keyspace}/{prefix}: partition_count must be the authoritative STATS count \
-         (Σ estimatedPartitionSize buckets), not the old stub 0 ({})",
+        "{keyspace}/{prefix} [{path_label}]: partition_count must be the authoritative \
+         STATS count (Σ estimatedPartitionSize buckets), not the old stub 0 ({})",
         stats_path.display()
     );
     assert_eq!(
         row.total_rows,
         want_total_rows,
-        "{keyspace}/{prefix}: total_rows must be the authoritative STATS totalRows, \
-         not the old stub 0 ({})",
+        "{keyspace}/{prefix} [{path_label}]: total_rows must be the authoritative STATS \
+         totalRows, not the old stub 0 ({})",
         stats_path.display()
     );
     // `live_rows` is intentionally left 0 (not authoritatively derivable from
     // STATS as a value distinct from total_rows; #28 no-heuristics).
     assert_eq!(
         row.live_rows, 0,
-        "{keyspace}/{prefix}: live_rows is left 0 (not authoritatively derivable); \
-         a nonzero value would be a fabricated count"
+        "{keyspace}/{prefix} [{path_label}]: live_rows is left 0 (not authoritatively \
+         derivable); a nonzero value would be a fabricated count"
     );
-    true
 }
 
 /// #1325: real `nb` fixtures carry the authoritative row/partition counts.
@@ -140,8 +188,16 @@ fn nb_rowstatistics_carry_authoritative_counts() {
         asserted += 1;
     }
 
-    // With CQLITE_DATASETS_ROOT set, at least one fixture is expected present.
-    // If ALL three were genuinely absent we skipped cleanly above; that is only
-    // acceptable when the dataset truly lacks them (not a false-pass on zeros).
+    // With CQLITE_DATASETS_ROOT configured, at least one fixture MUST have been
+    // exercised. A configured-but-nothing-asserted run is a false-pass (the
+    // dataset is present but empty/wrong), which the project rule forbids —
+    // "never let a dataset-dependent test pass on an empty dataset". The clean
+    // skip is only allowed when no dataset root is configured at all (handled
+    // by the early return above).
     println!("[INFO] #1325: asserted authoritative counts for {asserted}/3 fixtures");
+    assert!(
+        asserted > 0,
+        "CQLITE_DATASETS_ROOT is configured but no #1325 fixture Statistics.db was \
+         exercised — refusing to false-pass on an empty/missing dataset"
+    );
 }


### PR DESCRIPTION
Closes #1325.

## Bug (oracle-driven — Statistics.db is ground truth)
For real Cassandra 5.0 `nb` SSTables, `enhanced_statistics_parser` hard-coded `RowStatistics.{total_rows, live_rows, partition_count}` to `0`, so any consumer reading these counts on a real file got a silently-wrong 0.

## Fix
`parse_nb_format_statistics_data` now delegates to the #944 single source of truth `repair_metadata::read_table_counts` (raw Statistics.db + version gates already threaded through):
- `partition_count` = Σ `estimatedPartitionSize` histogram bucket counts.
- `total_rows` = STATS `totalRows` via the gated walk (`None` → documented 0, never guessed).
- `avg_rows_per_partition` only when both counts are authoritative and `partition_count > 0`.
- `live_rows` deliberately left `0` (documented): STATS carries no per-SSTable live-row count distinct from `total_rows`; fabricating one would violate the no-heuristics mandate (#28). Additive decode — an `Err` logs and leaves 0.

## Test (TDD)
`cqlite-core/tests/issue_1325_nb_rowstatistics_counts.rs` asserts, for real fixtures:
- `sensor_data` → partition_count=10, total_rows=2000
- `simple_table` (test_basic, nb) → 1000, 1000
- `stock_prices` → 3, 200
- `live_rows == 0`

All three fixtures present + asserted (none skipped); fails without the fix (0 vs 10), passes with it. Present-but-zero is a hard failure; skips only when Statistics.db is genuinely absent.

## Gate
`scripts/agent-gate.sh` → **RESULT: PASS** (all 17 components green, incl. python-bindings — no known-flaky failures this run).