### PR TITLE
hardening(#1307): doc O(partition) reverse walk + assert reverse_served Sort-skip invariant

### DIFF
--- a/cqlite-core/src/query/select_executor/execute.rs
+++ b/cqlite-core/src/query/select_executor/execute.rs
@@ -131,6 +131,32 @@ impl SelectExecutor {
                         intermediate_results = self
                             .execute_sort(intermediate_results, order_by, &mut context)
                             .await?;
+                    } else {
+                        // Issue #1307 (hardening): skipping this Sort is sound ONLY
+                        // because `reverse_served` is set exclusively by
+                        // `targeted_partition_rows`, which serves the reverse
+                        // promoted-index iterator precisely when `statement.order_by`
+                        // requests the reverse of the stored clustering order — and
+                        // the planner emits EXACTLY ONE `Sort` step, cloned from that
+                        // same `statement.order_by` (see `select_optimizer.rs`). So
+                        // the reverse scan's ordering matches this step's `order_by`,
+                        // and skipping it drops a redundant sort rather than a
+                        // different ordering. What would break the invariant: a
+                        // multi-table / join plan (or any plan) that reused the flag
+                        // across a Sort NOT derived from the reverse-served scan's
+                        // `statement.order_by` — such a plan must clear
+                        // `reverse_served` before this step. The debug_assert pins
+                        // the property (the skipped Sort's key equals the statement's
+                        // order_by); it is debug-only and never alters release
+                        // behavior.
+                        debug_assert!(
+                            plan.statement.order_by.as_ref() == Some(order_by),
+                            "reverse_served Sort-skip invariant violated: the skipped \
+                             Sort's order_by must be the statement's order_by that drove \
+                             the reverse-served scan (single-table plan); a plan whose \
+                             Sort is not the reverse scan's matching Sort must clear \
+                             reverse_served first",
+                        );
                     }
                 }
                 ExecutionStep::Aggregate { plan: agg_plan, .. } => {

--- a/cqlite-core/src/storage/sstable/reader/data_access/big_promoted.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/big_promoted.rs
@@ -307,6 +307,30 @@ impl SSTableReader {
     /// the in-memory sort: no Index.db offset, a narrow partition with no promoted
     /// index, a variable-width clustering column, a static column present, or an
     /// open range-tombstone marker.
+    ///
+    /// # Work complexity (Issue #1307)
+    ///
+    /// Per-iteration **memory** is bounded to ONE promoted-index block: `block_rows`
+    /// holds only the rows of the block currently being decoded, is drained into
+    /// `out`, and never accumulates more than a single block at a time (mirrors
+    /// Cassandra `SSTableReversedIterator`).
+    ///
+    /// **Total work is O(partition), independent of any `LIMIT`.** This function
+    /// walks EVERY promoted-index block back-to-front and materializes the full
+    /// partition's rows into `out` before returning; the query-wide `LIMIT` is
+    /// applied by the executor's `Limit` step *after* this call. So `ORDER BY ck DESC
+    /// LIMIT n` still decodes the whole partition — it is O(partition), not O(n). The
+    /// reverse iterator's win over the in-memory-sort fallback is the bounded
+    /// per-block memory high-water mark (and avoiding a full forward re-read to sort),
+    /// NOT reduced total decode work.
+    ///
+    /// A back-to-front early-stop (stop once `n` rows are buffered, giving O(n)) is
+    /// intentionally NOT implemented: the caller (`targeted_partition_rows`) applies a
+    /// post-scan predicate backstop (e.g. `WHERE ck < N ORDER BY ck DESC`) and the
+    /// `LIMIT` is applied only *after* that filtering, so truncating the raw scan at
+    /// `n` rows here could drop rows a predicate would have removed and under-return.
+    /// Threading a *predicate-aware* effective limit down through
+    /// `scan_partition_clustering_reverse` is left as future work (Low, Issue #1307).
     pub(crate) async fn big_reverse_partition_rows(
         &self,
         partition_key: &[u8],


### PR DESCRIPTION
Closes #1307. Two deferred Low hardening items from roborev on #1184. No behavior change (doc + debug_assert only).

## Item 1 — document O(partition) total work (`big_promoted.rs`)
`big_reverse_partition_rows` walks every promoted-index block back-to-front and materializes the full partition before the executor's Limit. Added a doc section: per-block memory bound (one block at a time) but total work is **O(partition) regardless of LIMIT** (`ORDER BY ck DESC LIMIT n` is O(partition), not O(n)).
- **Early-stop threading: intentionally doc-only.** The caller (`targeted_partition_rows`) applies a post-scan predicate backstop before the query LIMIT, so truncating the raw reverse scan at `n` would drop rows a predicate would later remove → under-return. A predicate-aware effective limit is documented as future work (not forced for a Low item).

## Item 2 — reverse_served Sort-skip invariant (`execute.rs`)
Where the executor skips the Sort when `reverse_served` is set, added `debug_assert!(plan.statement.order_by.as_ref() == Some(order_by), ...)` + comment. `reverse_served` is set only by `targeted_partition_rows` when `order_by` requests the reverse of stored clustering order, and the planner emits exactly one Sort cloned from that same `order_by`; the assert pins that the skipped Sort matches, and the comment notes a multi-table/join plan must clear the flag first. Debug-only — no release behavior change.

## Gate
RESULT PASS (all lanes). file-size acked (execute.rs 789→815, split out of scope for a Low debug_assert per #1116).

🤖 flow-lead worker