### PR TITLE
ci(#1335): stamp .dataset-pin in manual-curl dataset workflows (shared-cache consistency)

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -186,6 +186,13 @@ jobs:
             echo "${DATASET_SHA256}  /tmp/${DATASET_ASSET}" | shasum -a 256 -c -
           fi
           tar -xzf /tmp/${DATASET_ASSET} -C . --exclude='*/._*' --exclude='._*' --exclude='*/.DS_Store' --exclude='.DS_Store'
+          # Issue #1335: stamp the .dataset-pin that fetch-datasets.sh writes so
+          # the shared `datasets-${DATASET_TAG}-${DATASET_SHA256}` cache entry is
+          # accepted by has_required_dataset() in jobs that use fetch-datasets.sh
+          # (no needless re-download; a genuinely stale pin still forces refetch).
+          printf 'tag=%s\nasset=%s\nsha256=%s\n' \
+            "${DATASET_TAG}" "${DATASET_ASSET}" "${DATASET_SHA256}" \
+            > test-data/datasets/.dataset-pin
 
       - name: Fetch datasets if cache miss (Windows)
         if: steps.dataset-cache.outputs.cache-hit != 'true' && runner.os == 'Windows'
@@ -199,6 +206,11 @@ jobs:
             throw "SHA256 mismatch: expected $env:DATASET_SHA256, got $hash"
           }
           tar -xzf "$env:TEMP\$env:DATASET_ASSET" -C . --exclude='*/._*' --exclude='._*' --exclude='*/.DS_Store' --exclude='.DS_Store'
+          # Issue #1335: stamp the .dataset-pin fetch-datasets.sh writes so the
+          # shared cache entry is accepted by has_required_dataset(). LF newlines
+          # to match the bash-written pin (grep -qx exact-line match).
+          $pin = "tag=$env:DATASET_TAG`nasset=$env:DATASET_ASSET`nsha256=$env:DATASET_SHA256`n"
+          [System.IO.File]::WriteAllText("test-data/datasets/.dataset-pin", $pin)
 
       - name: Sanity check dataset
         shell: bash

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -215,6 +215,13 @@ jobs:
             echo "${DATASET_SHA256}  /tmp/${DATASET_ASSET}" | shasum -a 256 -c -
           fi
           tar -xzf /tmp/${DATASET_ASSET} -C . --exclude='*/._*' --exclude='._*' --exclude='*/.DS_Store' --exclude='.DS_Store'
+          # Issue #1335: stamp the .dataset-pin that fetch-datasets.sh writes so
+          # the shared `datasets-${DATASET_TAG}-${DATASET_SHA256}` cache entry is
+          # accepted by has_required_dataset() in jobs that use fetch-datasets.sh
+          # (no needless re-download; a genuinely stale pin still forces refetch).
+          printf 'tag=%s\nasset=%s\nsha256=%s\n' \
+            "${DATASET_TAG}" "${DATASET_ASSET}" "${DATASET_SHA256}" \
+            > test-data/datasets/.dataset-pin
 
       - name: Fetch datasets if cache miss (Windows)
         if: steps.dataset-cache.outputs.cache-hit != 'true' && runner.os == 'Windows'
@@ -229,6 +236,11 @@ jobs:
             throw "SHA256 mismatch: expected $env:DATASET_SHA256, got $hash"
           }
           tar -xzf "$env:TEMP\$env:DATASET_ASSET" -C . --exclude='*/._*' --exclude='._*' --exclude='*/.DS_Store' --exclude='.DS_Store'
+          # Issue #1335: stamp the .dataset-pin fetch-datasets.sh writes so the
+          # shared cache entry is accepted by has_required_dataset(). LF newlines
+          # to match the bash-written pin (grep -qx exact-line match).
+          $pin = "tag=$env:DATASET_TAG`nasset=$env:DATASET_ASSET`nsha256=$env:DATASET_SHA256`n"
+          [System.IO.File]::WriteAllText("test-data/datasets/.dataset-pin", $pin)
 
       - name: Sanity check dataset
         shell: bash

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -110,6 +110,14 @@ jobs:
           echo "📂 Extracting dataset..."
           tar -xzf /tmp/${DATASET_ASSET} -C . --exclude='*/._*' --exclude='._*' --exclude='*/.DS_Store' --exclude='.DS_Store'
 
+          # Issue #1335: stamp the .dataset-pin that fetch-datasets.sh writes so
+          # the shared `datasets-${DATASET_TAG}-${DATASET_SHA256}` cache entry is
+          # accepted by has_required_dataset() in jobs that use fetch-datasets.sh
+          # (no needless re-download; a genuinely stale pin still forces refetch).
+          printf 'tag=%s\nasset=%s\nsha256=%s\n' \
+            "${DATASET_TAG}" "${DATASET_ASSET}" "${DATASET_SHA256}" \
+            > test-data/datasets/.dataset-pin
+
           echo "✅ Dataset ready"
 
       - name: Sanity check dataset exists


### PR DESCRIPTION
Closes #1335. Follow-up to #1185. CI-only (workflow YAML), no production code.

## Problem
#1185 made `fetch-datasets.sh::has_required_dataset()` require a matching `.dataset-pin` before skipping download. But `node-ci.yml`, `python-ci.yml`, `smoke-tests.yml` populate `test-data/datasets` via manual `curl`/`tar` (no `fetch-datasets.sh`), so they never wrote `.dataset-pin` — yet they share the cache key `datasets-${DATASET_TAG}-${DATASET_SHA256}`. A manual-curl job could seed the shared cache without a pin → a later `fetch-datasets.sh` job restores a pin-less cache and needlessly re-downloads.

## Fix
Stamp the `.dataset-pin` (matching tag/asset/sha, in `fetch-datasets.sh`'s exact format) after the manual curl/tar in all three workflows, so a shared-cache restore is accepted while staying fail-closed (a stale pin still re-downloads).

## Validation
YAML + `.dataset-pin` format verified against `fetch-datasets.sh`; gate RESULT PASS. The node-ci/python-ci/smoke-tests CI lanes on this PR exercise the changed workflows directly.

🤖 flow-lead worker