### PR TITLE
fix(#1374): exhaustively guard unavailable-sentinel stats + robustify oa/da fixture selection

### DIFF
--- a/cqlite-core/src/parser/statistics.rs
+++ b/cqlite-core/src/parser/statistics.rs
@@ -637,6 +637,19 @@ fn parse_vint_as_u64(input: &[u8]) -> IResult<&[u8], u64> {
     Ok((input, value as u64))
 }
 
+/// Whether `avg_rows_per_partition` holds a REAL derived value rather than the
+/// documented #1325 unavailable sentinel `0.0`.
+///
+/// The average is `total_rows / partition_count`; the parser leaves it `0.0`
+/// whenever EITHER `total_rows` is not authoritatively reachable from STATS OR
+/// `partition_count == 0`. So the value is only real when BOTH counts are
+/// positive. Single-sourced here and reused by every consumer (recommendations
+/// in this module and the report renderer in `statistics_reader`) to keep the
+/// availability condition from drifting. No heuristic (#28); see #1352.
+pub(crate) fn avg_rows_available(stats: &SSTableStatistics) -> bool {
+    stats.row_stats.total_rows > 0 && stats.row_stats.partition_count > 0
+}
+
 /// Statistics analyzer for enhanced reporting
 pub struct StatisticsAnalyzer;
 
@@ -735,14 +748,15 @@ impl StatisticsAnalyzer {
 
         // `avg_rows_per_partition == 0.0` is the documented #1325 unavailable
         // sentinel: the parser leaves it 0.0 whenever `total_rows` is not
-        // authoritatively reachable from STATS (or `partition_count == 0`). Only
-        // emit the granularity recommendation when the average is a REAL derived
-        // value — i.e. `total_rows > 0` (so the average was actually computed).
-        // Otherwise the sentinel `0.0 < 10.0` would always trip this hint on nb
-        // SSTables whose gated walk can't reach `totalRows`, a misleading
-        // recommendation from a non-value. No heuristic (#28); see #1352.
-        let avg_rows_available = stats.row_stats.total_rows > 0;
-        if avg_rows_available && stats.row_stats.avg_rows_per_partition < 10.0 {
+        // authoritatively reachable from STATS OR `partition_count == 0` (the
+        // average is `total_rows / partition_count`). Only emit the granularity
+        // recommendation when the average is a REAL derived value — i.e. BOTH
+        // `total_rows > 0` AND `partition_count > 0` (so the average was actually
+        // computed). Otherwise the sentinel `0.0 < 10.0` would always trip this
+        // hint (e.g. on nb SSTables whose gated walk can't reach `totalRows`, or
+        // when `partition_count == 0`), a misleading recommendation from a
+        // non-value. No heuristic (#28); see #1352.
+        if avg_rows_available(stats) && stats.row_stats.avg_rows_per_partition < 10.0 {
             recommendations.push(
                 "Low average rows per partition - partition key may be too granular".to_string(),
             );
@@ -1106,6 +1120,37 @@ mod tests {
                 .iter()
                 .any(|r| r.contains("too granular")),
             "granularity recommendation must NOT fire for a REAL high avg_rows_per_partition"
+        );
+    }
+
+    /// #1374 roborev finding: `avg_rows_per_partition` is `total_rows /
+    /// partition_count`, so the `0.0` unavailable sentinel also occurs when
+    /// `total_rows > 0` but `partition_count == 0`. The availability guard must
+    /// require BOTH counts positive; a stats object with real `total_rows` but
+    /// zero partitions must still SUPPRESS the "too granular" recommendation.
+    #[test]
+    fn test_granularity_recommendation_suppressed_when_partition_count_zero() {
+        let mut stats = create_test_statistics();
+        stats.row_stats.total_rows = 8; // real authoritative count
+        stats.row_stats.partition_count = 0; // but no partitions -> avg is sentinel
+        stats.row_stats.avg_rows_per_partition = 0.0;
+        stats.table_stats.disk_size = 1024;
+
+        // The shared availability helper must report unavailable.
+        assert!(
+            !avg_rows_available(&stats),
+            "avg_rows must be unavailable when partition_count == 0 despite total_rows > 0"
+        );
+
+        let summary = StatisticsAnalyzer::analyze(&stats);
+
+        assert!(
+            !summary
+                .storage_recommendations
+                .iter()
+                .any(|r| r.contains("too granular")),
+            "granularity recommendation must be suppressed when partition_count == 0 \
+             (avg_rows_per_partition is the unavailable sentinel)"
         );
     }
 

--- a/cqlite-core/src/parser/statistics.rs
+++ b/cqlite-core/src/parser/statistics.rs
@@ -733,7 +733,16 @@ impl StatisticsAnalyzer {
                 .push("Large SSTable detected - consider more frequent compaction".to_string());
         }
 
-        if stats.row_stats.avg_rows_per_partition < 10.0 {
+        // `avg_rows_per_partition == 0.0` is the documented #1325 unavailable
+        // sentinel: the parser leaves it 0.0 whenever `total_rows` is not
+        // authoritatively reachable from STATS (or `partition_count == 0`). Only
+        // emit the granularity recommendation when the average is a REAL derived
+        // value — i.e. `total_rows > 0` (so the average was actually computed).
+        // Otherwise the sentinel `0.0 < 10.0` would always trip this hint on nb
+        // SSTables whose gated walk can't reach `totalRows`, a misleading
+        // recommendation from a non-value. No heuristic (#28); see #1352.
+        let avg_rows_available = stats.row_stats.total_rows > 0;
+        if avg_rows_available && stats.row_stats.avg_rows_per_partition < 10.0 {
             recommendations.push(
                 "Low average rows per partition - partition key may be too granular".to_string(),
             );
@@ -1031,6 +1040,73 @@ mod tests {
             "health_score must be finite (not NaN) when total_rows == 0"
         );
         assert!((0.0..=100.0).contains(&summary.health_score));
+    }
+
+    /// #1325 roborev finding: the "partition key may be too granular" storage
+    /// recommendation compares `avg_rows_per_partition < 10.0`. When
+    /// `total_rows == 0` the parser leaves `avg_rows_per_partition == 0.0` as the
+    /// documented unavailable sentinel, so `0.0 < 10.0` would ALWAYS trip the
+    /// recommendation on nb SSTables whose gated walk cannot reach `totalRows`.
+    /// It must be suppressed. No heuristic (#28); see #1352.
+    #[test]
+    fn test_granularity_recommendation_suppressed_when_avg_rows_sentinel() {
+        let mut stats = create_test_statistics();
+        // Unavailable sentinel: no authoritative total_rows -> avg left 0.0.
+        stats.row_stats.total_rows = 0;
+        stats.row_stats.avg_rows_per_partition = 0.0;
+        // Keep disk_size small so the "large SSTable" recommendation does not fire.
+        stats.table_stats.disk_size = 1024;
+
+        let summary = StatisticsAnalyzer::analyze(&stats);
+
+        assert!(
+            !summary
+                .storage_recommendations
+                .iter()
+                .any(|r| r.contains("too granular")),
+            "granularity recommendation must be suppressed when avg_rows_per_partition \
+             is the unavailable sentinel (total_rows == 0)"
+        );
+    }
+
+    /// #1325 sweep (non-vacuous positive path): with a REAL low average
+    /// (total_rows > 0), the granularity recommendation still fires.
+    #[test]
+    fn test_granularity_recommendation_fires_when_avg_rows_real_and_low() {
+        let mut stats = create_test_statistics();
+        stats.row_stats.total_rows = 8; // real authoritative count
+        stats.row_stats.partition_count = 4;
+        stats.row_stats.avg_rows_per_partition = 2.0; // real, genuinely low (< 10)
+        stats.table_stats.disk_size = 1024;
+
+        let summary = StatisticsAnalyzer::analyze(&stats);
+
+        assert!(
+            summary
+                .storage_recommendations
+                .iter()
+                .any(|r| r.contains("too granular")),
+            "granularity recommendation must fire for a REAL low avg_rows_per_partition"
+        );
+    }
+
+    /// #1325 sweep (non-vacuous): with a real HIGH average the recommendation
+    /// does NOT fire — proving the guard did not just always-suppress.
+    #[test]
+    fn test_granularity_recommendation_absent_when_avg_rows_real_and_high() {
+        let mut stats = create_test_statistics();
+        stats.row_stats.total_rows = 1000; // real; default avg is 20.0 (>= 10)
+        stats.table_stats.disk_size = 1024;
+
+        let summary = StatisticsAnalyzer::analyze(&stats);
+
+        assert!(
+            !summary
+                .storage_recommendations
+                .iter()
+                .any(|r| r.contains("too granular")),
+            "granularity recommendation must NOT fire for a REAL high avg_rows_per_partition"
+        );
     }
 
     #[test]

--- a/cqlite-core/src/storage/sstable/statistics_reader.rs
+++ b/cqlite-core/src/storage/sstable/statistics_reader.rs
@@ -316,17 +316,21 @@ impl StatisticsReader {
         ));
         // `avg_rows_per_partition == 0.0` is the documented #1325 unavailable
         // sentinel: the parser leaves it 0.0 whenever `total_rows` is not
-        // authoritatively reachable (so no real average could be computed).
-        // Render it as `unavailable` in that case rather than a misleading
-        // `0.0` (#1352). No heuristic (#28).
-        report.push_str(&if self.statistics.row_stats.total_rows == 0 {
-            "- Average rows per partition: unavailable\n\n".to_string()
-        } else {
-            format!(
-                "- Average rows per partition: {:.1}\n\n",
-                self.statistics.row_stats.avg_rows_per_partition
-            )
-        });
+        // authoritatively reachable OR `partition_count == 0` (the average is
+        // `total_rows / partition_count`, so BOTH must be positive for the value
+        // to be real). Render it as `unavailable` unless both counts are positive
+        // rather than a misleading `0.0` (#1352). Availability guard is
+        // single-sourced via `avg_rows_available`. No heuristic (#28).
+        report.push_str(
+            &if crate::parser::statistics::avg_rows_available(&self.statistics) {
+                format!(
+                    "- Average rows per partition: {:.1}\n\n",
+                    self.statistics.row_stats.avg_rows_per_partition
+                )
+            } else {
+                "- Average rows per partition: unavailable\n\n".to_string()
+            },
+        );
 
         // Timestamp information
         if self.statistics.timestamp_stats.min_timestamp != 0 {
@@ -839,6 +843,33 @@ mod tests {
         assert!(
             compact.contains("Rows: 1000"),
             "compact summary must render the real total_rows: {compact}"
+        );
+    }
+
+    /// #1374 roborev finding: `avg_rows_per_partition` is
+    /// `total_rows / partition_count`, so its `0.0` unavailable sentinel also
+    /// occurs when `total_rows > 0` but `partition_count == 0`. The report must
+    /// render "unavailable" in that case (guard requires BOTH counts positive).
+    /// Total rows itself is real here, so it must still render concretely.
+    #[tokio::test]
+    async fn test_report_renders_avg_unavailable_when_partition_count_zero() {
+        let mut stats = stats_with(1000, 900, 0.0);
+        stats.row_stats.partition_count = 0; // avg is the unavailable sentinel
+        let reader = super::StatisticsReader::from_statistics_for_test(stats).await;
+
+        let report = reader.generate_report(false);
+        assert!(
+            report.contains("Average rows per partition: unavailable"),
+            "avg rows/partition must render unavailable when partition_count == 0:\n{report}"
+        );
+        assert!(
+            !report.contains("Average rows per partition: 0.0"),
+            "must NOT render the misleading concrete 0.0 avg:\n{report}"
+        );
+        // Total rows is authoritative here, so it must still render concretely.
+        assert!(
+            report.contains("Total rows: 1000"),
+            "row-stats Total rows must still render the real count:\n{report}"
         );
     }
 }

--- a/cqlite-core/src/storage/sstable/statistics_reader.rs
+++ b/cqlite-core/src/storage/sstable/statistics_reader.rs
@@ -258,7 +258,14 @@ impl StatisticsReader {
 
         // Overview section
         report.push_str("## Overview\n");
-        report.push_str(&format!("- **Total Rows**: {}\n", summary.total_rows));
+        // `total_rows == 0` is the documented #1325 "not authoritatively
+        // reachable from STATS" sentinel (the version-gated walk could not reach
+        // `totalRows`), not a measured zero. Render it as `unavailable` rather
+        // than a misleading `0` (#1352). No heuristic (#28).
+        report.push_str(&match summary.total_rows {
+            0 => "- **Total Rows**: unavailable\n".to_string(),
+            n => format!("- **Total Rows**: {}\n", n),
+        });
         // `live_data_percentage` is `None` when `live_rows` is the documented
         // #1325 "not authoritatively available from STATS" sentinel; render it as
         // unavailable rather than a misleading concrete 0.00% (#1352).
@@ -285,10 +292,11 @@ impl StatisticsReader {
 
         // Row statistics
         report.push_str("## Row Statistics\n");
-        report.push_str(&format!(
-            "- Total rows: {}\n",
-            self.statistics.row_stats.total_rows
-        ));
+        // Same #1325 `total_rows == 0` unavailable sentinel as the overview above.
+        report.push_str(&match self.statistics.row_stats.total_rows {
+            0 => "- Total rows: unavailable\n".to_string(),
+            n => format!("- Total rows: {}\n", n),
+        });
         // `live_rows == 0` is the documented #1325 "not authoritatively
         // available from STATS" sentinel (STATS has no per-SSTable live-row
         // count), not a measured zero. Render it as `unavailable` for
@@ -306,10 +314,19 @@ impl StatisticsReader {
             "- Partitions: {}\n",
             self.statistics.row_stats.partition_count
         ));
-        report.push_str(&format!(
-            "- Average rows per partition: {:.1}\n\n",
-            self.statistics.row_stats.avg_rows_per_partition
-        ));
+        // `avg_rows_per_partition == 0.0` is the documented #1325 unavailable
+        // sentinel: the parser leaves it 0.0 whenever `total_rows` is not
+        // authoritatively reachable (so no real average could be computed).
+        // Render it as `unavailable` in that case rather than a misleading
+        // `0.0` (#1352). No heuristic (#28).
+        report.push_str(&if self.statistics.row_stats.total_rows == 0 {
+            "- Average rows per partition: unavailable\n\n".to_string()
+        } else {
+            format!(
+                "- Average rows per partition: {:.1}\n\n",
+                self.statistics.row_stats.avg_rows_per_partition
+            )
+        });
 
         // Timestamp information
         if self.statistics.timestamp_stats.min_timestamp != 0 {
@@ -434,14 +451,38 @@ impl StatisticsReader {
             Some(pct) => format!("{:.1}% live", pct),
             None => "?% live".to_string(),
         };
+        // `total_rows == 0` is the documented #1325 "not authoritatively reachable
+        // from STATS" sentinel; render it as "?" here rather than a misleading `0`
+        // (matches the "?% live" convention above) (#1352). No heuristic (#28).
+        let rows = match summary.total_rows {
+            0 => "?".to_string(),
+            n => n.to_string(),
+        };
         format!(
             "Rows: {} ({}) | Compression: {:.1}% | Health: {:.0}/100 | Size: {:.2} MB",
-            summary.total_rows,
+            rows,
             live,
             summary.compression_efficiency,
             summary.health_score,
             self.statistics.table_stats.disk_size as f64 / 1_048_576.0
         )
+    }
+
+    /// Build a reader directly from in-memory statistics (test-only).
+    ///
+    /// The production constructor requires a real on-disk `Statistics.db`; this
+    /// lets the report-rendering unit tests exercise the #1325 unavailable-sentinel
+    /// rendering without a fixture file.
+    #[cfg(test)]
+    async fn from_statistics_for_test(statistics: SSTableStatistics) -> Self {
+        let config = crate::Config::default();
+        let platform =
+            std::sync::Arc::new(crate::Platform::new(&config).await.expect("test platform"));
+        Self {
+            file_path: PathBuf::from("in-memory-test-Statistics.db"),
+            statistics,
+            platform,
+        }
     }
 }
 
@@ -665,5 +706,139 @@ mod tests {
             ),
             Ok(_) => panic!("below-floor Statistics.db must NOT open even when absent"),
         }
+    }
+
+    /// Minimal in-memory statistics for report-rendering tests. `total_rows`,
+    /// `live_rows`, and `avg_rows_per_partition` are the #1325 sentinel-carrying
+    /// fields the caller sets per-scenario; everything else is a benign default.
+    #[cfg(test)]
+    fn stats_with(
+        total_rows: u64,
+        live_rows: u64,
+        avg_rows_per_partition: f64,
+    ) -> crate::parser::statistics::SSTableStatistics {
+        use crate::parser::statistics::*;
+        SSTableStatistics {
+            header: StatisticsHeader {
+                version: 4,
+                statistics_kind: 0,
+                data_length: 0,
+                metadata1: 0,
+                metadata2: 0,
+                metadata3: 0,
+                checksum: 0,
+                table_id: None,
+            },
+            row_stats: RowStatistics {
+                total_rows,
+                live_rows,
+                tombstone_count: 0,
+                partition_count: 10,
+                avg_rows_per_partition,
+                row_size_histogram: vec![],
+            },
+            timestamp_stats: TimestampStatistics {
+                min_timestamp: 0,
+                max_timestamp: 0,
+                min_deletion_time: 0,
+                max_deletion_time: 0,
+                min_ttl: None,
+                max_ttl: None,
+                rows_with_ttl: 0,
+            },
+            column_stats: vec![],
+            table_stats: TableStatistics {
+                disk_size: 1024,
+                uncompressed_size: 1024,
+                compressed_size: 1024,
+                compression_ratio: 1.0,
+                block_count: 1,
+                avg_block_size: 1024.0,
+                index_size: 0,
+                bloom_filter_size: 0,
+                level_count: 0,
+            },
+            partition_stats: PartitionStatistics {
+                avg_partition_size: 0.0,
+                min_partition_size: 0,
+                max_partition_size: 0,
+                size_histogram: vec![],
+                large_partition_percentage: 0.0,
+            },
+            compression_stats: CompressionStatistics {
+                algorithm: "none".to_string(),
+                original_size: 1024,
+                compressed_size: 1024,
+                ratio: 1.0,
+                compression_speed: 0.0,
+                decompression_speed: 0.0,
+                compressed_blocks: 0,
+            },
+            metadata: std::collections::HashMap::new(),
+            serialization_header_columns: vec![],
+            serialization_header_partition_keys: vec![],
+            serialization_header_clustering_keys: vec![],
+            tombstone_drop_times: vec![],
+        }
+    }
+
+    /// #1325 sweep: `generate_report` and `compact_summary` must render the
+    /// unavailable sentinels (`total_rows == 0`, `avg_rows_per_partition == 0.0`)
+    /// as "unavailable"/"?" rather than a misleading concrete `0`.
+    #[tokio::test]
+    async fn test_report_renders_unavailable_when_counts_sentinel() {
+        let reader = super::StatisticsReader::from_statistics_for_test(stats_with(0, 0, 0.0)).await;
+
+        let report = reader.generate_report(false);
+        assert!(
+            report.contains("**Total Rows**: unavailable"),
+            "overview Total Rows must render unavailable for the total_rows==0 sentinel:\n{report}"
+        );
+        assert!(
+            report.contains("Total rows: unavailable"),
+            "row-stats Total rows must render unavailable for the sentinel:\n{report}"
+        );
+        assert!(
+            report.contains("Average rows per partition: unavailable"),
+            "avg rows/partition must render unavailable for the sentinel:\n{report}"
+        );
+        assert!(
+            !report.contains("Total rows: 0"),
+            "must NOT render the misleading concrete 0:\n{report}"
+        );
+
+        let compact = reader.compact_summary();
+        assert!(
+            compact.contains("Rows: ?"),
+            "compact summary must render '?' for the total_rows==0 sentinel: {compact}"
+        );
+    }
+
+    /// #1325 sweep (non-vacuous positive path): real counts render as concrete
+    /// numbers, not "unavailable".
+    #[tokio::test]
+    async fn test_report_renders_concrete_when_counts_real() {
+        let reader =
+            super::StatisticsReader::from_statistics_for_test(stats_with(1000, 900, 20.0)).await;
+
+        let report = reader.generate_report(false);
+        assert!(
+            report.contains("**Total Rows**: 1000"),
+            "overview must render the real total_rows:\n{report}"
+        );
+        assert!(
+            report.contains("Average rows per partition: 20.0"),
+            "avg rows/partition must render the real value:\n{report}"
+        );
+        assert!(
+            !report.contains("Total Rows**: unavailable"),
+            "must NOT render unavailable when the count is real:\n{report}"
+        );
+
+        let compact = reader.compact_summary();
+        assert!(
+            compact.contains("Rows: 1000"),
+            "compact summary must render the real total_rows: {compact}"
+        );
     }
 }

--- a/cqlite-core/tests/issue_1325_nb_rowstatistics_counts.rs
+++ b/cqlite-core/tests/issue_1325_nb_rowstatistics_counts.rs
@@ -247,17 +247,28 @@ fn nb_rowstatistics_carry_authoritative_counts() {
     );
 }
 
-/// Locate the first `-Statistics.db` binary under any `<root>/<keyspace>/<table>`
-/// directory whose filename version segment is in `versions` (e.g. `["oa", "da"]`).
-fn find_stats_db_for_versions(versions: &[&str]) -> Option<PathBuf> {
-    let root = datasets_root()?;
+/// Locate ALL `-Statistics.db` binaries under any `<root>/<keyspace>/<table>`
+/// directory whose filename version segment is in `versions` (e.g. `["oa", "da"]`),
+/// sorted for determinism. Callers iterate candidates because a single fixture's
+/// gated `total_rows` can legitimately be unavailable (an unmodeled improved
+/// min/max block blocks the walk) even though the file is valid.
+fn find_all_stats_db_for_versions(versions: &[&str]) -> Vec<PathBuf> {
+    let Some(root) = datasets_root() else {
+        return Vec::new();
+    };
     let mut found: Vec<PathBuf> = Vec::new();
-    for ks in fs::read_dir(&root).ok()?.flatten() {
+    let Ok(ks_iter) = fs::read_dir(&root) else {
+        return Vec::new();
+    };
+    for ks in ks_iter.flatten() {
         let ks_path = ks.path();
         if !ks_path.is_dir() {
             continue;
         }
-        for tbl in fs::read_dir(&ks_path).ok()?.flatten() {
+        let Ok(tbl_iter) = fs::read_dir(&ks_path) else {
+            continue;
+        };
+        for tbl in tbl_iter.flatten() {
             let tbl_path = tbl.path();
             if !tbl_path.is_dir() {
                 continue;
@@ -272,7 +283,7 @@ fn find_stats_db_for_versions(versions: &[&str]) -> Option<PathBuf> {
         }
     }
     found.sort();
-    found.into_iter().next()
+    found
 }
 
 /// #1325 (roborev safety property): a NON-nb (`oa`/`da`) Statistics.db fed through
@@ -284,57 +295,83 @@ fn find_stats_db_for_versions(versions: &[&str]) -> Option<PathBuf> {
 /// still decodes the authoritative count.
 ///
 /// SKIP cleanly when no oa/da fixture is available; but when one IS present the
-/// safety assertion MUST run (no vacuous pass).
+/// None-gates safety assertion MUST run for EVERY candidate (no vacuous pass).
+///
+/// Finding #2 (roborev): `read_table_counts` can legitimately return
+/// unavailable/0 for a valid oa/da file whose improved min/max block cannot be
+/// traversed (the walk stops before `totalRows`). Asserting the gated path
+/// decodes a nonzero on the FIRST fixture is therefore fragile. Instead we
+/// iterate candidates: the None-gates-never-fabricates assertion applies to
+/// EVERY candidate, and the gated-path-still-works (nonzero) assertion is
+/// applied to whichever fixture first yields an authoritative gated
+/// `total_rows > 0` (skip cleanly if none is decodable).
 #[test]
 fn oa_da_none_gates_never_fabricates_total_rows() {
-    let Some(_root) = datasets_root() else {
-        println!("[SKIP] CQLITE_DATASETS_ROOT unset — no oa/da fixture to validate");
+    let candidates = find_all_stats_db_for_versions(&["oa", "da"]);
+    if candidates.is_empty() {
+        println!(
+            "[SKIP] no oa/da Statistics.db fixture available under datasets root \
+             (CQLITE_DATASETS_ROOT set: {})",
+            datasets_root().is_some()
+        );
         return;
-    };
-    let Some(stats_path) = find_stats_db_for_versions(&["oa", "da"]) else {
-        println!("[SKIP] no oa/da Statistics.db fixture available under datasets root");
-        return;
-    };
+    }
 
-    let bytes = fs::read(&stats_path)
-        .unwrap_or_else(|e| panic!("read {} failed: {e}", stats_path.display()));
+    let mut gated_nonzero_verified: Option<(PathBuf, u64)> = None;
 
-    // Unsafe path (must be CLOSED): None gates → format is unknown → total_rows
-    // must be honest 0, NEVER a fabricated nonzero from synthesized nb gates.
-    let (_rest, none_stats) = parse_statistics_with_fallback(&bytes, None)
-        .unwrap_or_else(|e| panic!("parse {} [None] failed: {e:?}", stats_path.display()));
-    assert_eq!(
-        none_stats.row_stats.total_rows,
-        0,
-        "SAFETY: an oa/da Statistics.db through the None-gates public entry point must \
-         report total_rows=0 (unavailable), NOT a fabricated count from guessed nb gates ({})",
-        stats_path.display()
-    );
-    assert_eq!(
-        none_stats.row_stats.live_rows,
-        0,
-        "None-gates live_rows must stay 0 ({})",
-        stats_path.display()
-    );
+    for stats_path in &candidates {
+        let bytes = fs::read(stats_path)
+            .unwrap_or_else(|e| panic!("read {} failed: {e}", stats_path.display()));
 
-    // Safe path (must still WORK): gates derived from the filename are
-    // authoritative for the file's real version, so the gated walk reaches the
-    // authoritative totalRows. This proves the fix did not close the legitimate
-    // gates-provided path for oa/da.
-    let gates = VersionGates::from_path(&stats_path)
-        .unwrap_or_else(|e| panic!("derive gates from {}: {e:?}", stats_path.display()));
-    let (_rest, gated_stats) = parse_statistics_with_fallback(&bytes, Some(&gates))
-        .unwrap_or_else(|e| panic!("parse {} [gated] failed: {e:?}", stats_path.display()));
-    assert!(
-        gated_stats.row_stats.total_rows > 0,
-        "gates-provided path for {} must decode an authoritative nonzero total_rows \
-         (got {})",
-        stats_path.display(),
-        gated_stats.row_stats.total_rows
-    );
-    println!(
-        "[INFO] #1325 safety: {} → None-gates total_rows=0 (honest); gated total_rows={} (authoritative)",
-        stats_path.display(),
-        gated_stats.row_stats.total_rows
-    );
+        // Unsafe path (must be CLOSED for EVERY candidate): None gates → format is
+        // unknown → total_rows must be honest 0, NEVER a fabricated nonzero from
+        // synthesized nb gates.
+        let (_rest, none_stats) = parse_statistics_with_fallback(&bytes, None)
+            .unwrap_or_else(|e| panic!("parse {} [None] failed: {e:?}", stats_path.display()));
+        assert_eq!(
+            none_stats.row_stats.total_rows,
+            0,
+            "SAFETY: an oa/da Statistics.db through the None-gates public entry point must \
+             report total_rows=0 (unavailable), NOT a fabricated count from guessed nb gates ({})",
+            stats_path.display()
+        );
+        assert_eq!(
+            none_stats.row_stats.live_rows,
+            0,
+            "None-gates live_rows must stay 0 ({})",
+            stats_path.display()
+        );
+
+        // Safe path (must still WORK for at least one fixture): gates derived from
+        // the filename are authoritative for the file's real version. Some valid
+        // fixtures legitimately report unavailable/0 (unmodeled improved min/max
+        // block blocks the walk) — those do NOT falsify the fix, so only record
+        // the first candidate that yields an authoritative nonzero.
+        if gated_nonzero_verified.is_none() {
+            let gates = VersionGates::from_path(stats_path)
+                .unwrap_or_else(|e| panic!("derive gates from {}: {e:?}", stats_path.display()));
+            let (_rest, gated_stats) = parse_statistics_with_fallback(&bytes, Some(&gates))
+                .unwrap_or_else(|e| panic!("parse {} [gated] failed: {e:?}", stats_path.display()));
+            if gated_stats.row_stats.total_rows > 0 {
+                gated_nonzero_verified =
+                    Some((stats_path.clone(), gated_stats.row_stats.total_rows));
+            }
+        }
+    }
+
+    match gated_nonzero_verified {
+        Some((path, total_rows)) => println!(
+            "[INFO] #1325 safety: {} candidate(s) validated None-gates=0; gated path proven on \
+             {} → total_rows={} (authoritative)",
+            candidates.len(),
+            path.display(),
+            total_rows
+        ),
+        None => println!(
+            "[SKIP-GATED] {} oa/da candidate(s) validated None-gates=0, but none exposed an \
+             authoritatively gated total_rows>0 (all improved min/max blocks unmodeled); \
+             None-gates-never-fabricates still verified",
+            candidates.len()
+        ),
+    }
 }

--- a/cqlite-core/tests/issue_1325_nb_rowstatistics_counts.rs
+++ b/cqlite-core/tests/issue_1325_nb_rowstatistics_counts.rs
@@ -252,6 +252,11 @@ fn nb_rowstatistics_carry_authoritative_counts() {
 /// sorted for determinism. Callers iterate candidates because a single fixture's
 /// gated `total_rows` can legitimately be unavailable (an unmodeled improved
 /// min/max block blocks the walk) even though the file is valid.
+///
+/// Every table directory is scanned exhaustively: ALL generations' matching
+/// `*-Statistics.db` files are collected, not just the first (`find_statistics_db`
+/// stops at the first hit, which could miss the oa/da SSTable that proves the
+/// gated-nonzero path or that would violate the None-gates safety assertion).
 fn find_all_stats_db_for_versions(versions: &[&str]) -> Vec<PathBuf> {
     let Some(root) = datasets_root() else {
         return Vec::new();
@@ -273,11 +278,23 @@ fn find_all_stats_db_for_versions(versions: &[&str]) -> Vec<PathBuf> {
             if !tbl_path.is_dir() {
                 continue;
             }
-            if let Some(stats) = find_statistics_db(&tbl_path) {
-                let name = stats.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            // Enumerate EVERY entry in the table dir and keep every matching
+            // `*-Statistics.db` (all generations), not just the first one.
+            let Ok(file_iter) = fs::read_dir(&tbl_path) else {
+                continue;
+            };
+            for file in file_iter.flatten() {
+                let name_os = file.file_name();
+                let name = name_os.to_str().unwrap_or("");
+                if name.starts_with("._") {
+                    continue;
+                }
+                if !name.ends_with("-Statistics.db") || name.ends_with("-Statistics.db.txt") {
+                    continue;
+                }
                 let version = name.split('-').next().unwrap_or("");
                 if versions.contains(&version) {
-                    found.push(stats);
+                    found.push(file.path());
                 }
             }
         }


### PR DESCRIPTION
Closes #1374. Follow-up to #1325 (PR #1351).

## Why
PR #1351 was squash-merged by a concurrent session on green CI at commit `f14b005e` — **before** the final roborev exhaustive-audit commit landed. So two real, already-identified roborev findings shipped unaddressed. This PR lands that recovered commit.

## Changes
- **`generate_storage_recommendations`**: no longer emits "partition key may be too granular" when `avg_rows_per_partition == 0.0` is the unavailable sentinel (fires only when the average is real+low).
- **`generate_report` / `compact_summary`**: render `total_rows` and `avg_rows_per_partition` as `unavailable` (not a concrete 0) when they are the sentinel.
- **oa/da safety test**: iterates candidate fixtures — asserts None-gates-never-fabricates on all, gated-nonzero on the first decodable one, skips cleanly if none decodable (was: first-match, could flake on a valid-but-untraversable file).
- Complete consumer audit of every unavailable-sentinel field (`live_rows`/`total_rows`/`avg_rows_per_partition`) — see #1325 for the reference table. No `RowStatistics` type change (that's the #1352 redesign). No-heuristics compliant.

## Gate
`scripts/agent-gate.sh` → **RESULT: PASS** (all 17 components; `file-size` used the documented `CQLITE_ALLOW_FILE_GROWTH=1` ack — the two touched files were already over threshold). Statistics lib tests 74 passed; `issue_1325_nb_rowstatistics_counts` 2 passed.