### PR TITLE
doctrine(#1176): codify merge-on-green, forbid worker CI busy-wait

### DIFF
--- a/.claude/commands/worker.md
+++ b/.claude/commands/worker.md
@@ -72,12 +72,20 @@ onto its own branch). Rules, non-negotiable:
    PASS, returning the summary block; spawn `spec-auditor` for **C** PASS (it audits the impl against
    `openspec/changes/<slug>/specs/**`); run roborev (`--agent claude-code --model opus`) to clean. You
    coordinate and read summaries; you do not open the source yourself.
-7. **Before merging**: re-check for an open `HOLD: merge after #N` → block until #N is merged. Confirm
-   gate PASS + C PASS (design) + roborev clean + CI green. Rebase on `origin/main`; resolve any conflict
-   in YOUR worktree.
-8. **Merge + finalize**: `gh pr merge <pr> --squash --delete-branch`, then `flow-finalize <N>` (archive
-   OpenSpec if any, remove worktree, delete origin lock, close issue with a traceable comment).
-9. Report `#N: merged (<commit>)` and loop to step 2.
+7. **Terminal state — arm merge-on-green, then STOP.** Your terminal state is **PR-open + gate PASS +
+   C PASS (design) + roborev clean**. Re-check for an open `HOLD: merge after #N` → keep merge-on-green
+   gated behind #N (the manager sequences it). Rebase on `origin/main`; resolve any conflict in YOUR
+   worktree. Then **arm merge-on-green and END your turn — do NOT poll the PR's own external CI in a
+   yield/wake loop (repeated `ScheduleWakeup` cycles).** Landing is delegated:
+   - **Primary today — the manager-owned poller.** `main` has no required checks (`contexts=[]`), so
+     `gh pr merge --auto` would merge instantly against an empty check set (forbidden). Hand the PR off to
+     the manager-owned poller/merge-engine, which gates on an explicit lane set and lands it on green.
+   - **Once required checks are configured on `main`** — arm `gh pr merge --auto --squash --delete-branch`
+     (native, zero-token). Log which path you armed.
+8. **Finalize on merge**: once the mechanism lands the PR on green, `flow-finalize <N>` (archive OpenSpec
+   if any, remove worktree, delete origin lock, close issue with a traceable comment) — triggered by the
+   merge event, not a CI busy-wait.
+9. Report `#N: armed merge-on-green (<path>)` and loop to step 2.
 
 ## Discovered bugs & scope (never silently absorb scope creep)
 A bug you find that is **outside the current issue's scope** does not get fixed inline — that bloats the
@@ -111,7 +119,9 @@ diff and breaks 1:1:1:1. Instead:
   reconciles the gate's component set with the CI lane set. And never gate a
   non-deterministically-regenerated source on a whole-file byte identity — gate the
   semantic verdict (validation playbook, L1).
-- Merge autonomously on green; do NOT wait for a human merge. Escalate to the owner ONLY for: a genuine
-  design-call roborev finding, a scope/product question, or anything outside your issue.
+- **Arm merge-on-green and end your turn**; the mechanism lands the PR on green (no human merge click, and
+  **no worker CI busy-wait** — never `ScheduleWakeup`-poll your PR's own external CI after the work is
+  done). Escalate to the owner ONLY for: a genuine design-call roborev finding, a scope/product question,
+  or anything outside your issue.
 - Never close an epic or change scope/title. Surface those; don't act.
 - Doctrine: `docs/development/pm-operating-loop.md`.

--- a/.claude/skills/flow-implement/SKILL.md
+++ b/.claude/skills/flow-implement/SKILL.md
@@ -93,19 +93,28 @@ OpenSpec change `<slug>` (design-driven only).
    # run the flow-board detection snippet first (switches to the project-capable account), then
    # gh project item-edit ... Status=In Review when have_project=1; else the label above + loud ⚠️ warning.
    ```
-9. **Merge autonomously, then finalize.** Workers run the issue to completion — there is no human merge
-   click. Before merging:
+9. **Terminal state — arm merge-on-green, then STOP.** The worker's terminal state for an issue is
+   **PR-open + `agent-gate.sh` PASS + (design-driven) spec-auditor C PASS + roborev clean**. At that point
+   you arm the merge-on-green mechanism and **end your turn** — there is no human merge click, and you do
+   NOT poll the PR's own external CI. Steps:
    - **Check the manager's orders**: read the issue's `🧭 MANAGER <!-- MGR:... -->` comments. If the
-     latest order is `HOLD: merge after #N`, **block** until #N is merged (poll its state); obey `ORDER`.
-   - **Confirm green**: `agent-gate.sh` PASS + (design-driven) spec-auditor C PASS + roborev clean + CI
-     required checks green. Rebase on current `origin/main`; resolve any conflict in your own worktree.
-   - Then squash-merge:
-     ```bash
-     gh auth switch --user pmcfadin >/dev/null 2>&1   # EMU guard
-     gh pr merge <pr> --squash --delete-branch
-     ```
-   - Run **`flow-finalize <N>`** to archive any OpenSpec change, remove the worktree, delete the origin
-     claim lock, and close the issue with a traceable comment.
-   Escalate to the owner (do NOT merge) only for: an unresolved roborev finding that's a genuine design
-   call, a scope/product question, or anything outside this issue. Report the merge + gate/C/roborev
-   summary.
+     latest order is `HOLD: merge after #N`, keep merge-on-green **gated behind #N** (the manager sequences
+     it); obey `ORDER`.
+   - Rebase on current `origin/main`; resolve any conflict in your own worktree.
+   - **Arm merge-on-green and END your turn — do NOT busy-poll CI.** Do not schedule repeated
+     `ScheduleWakeup` cycles to watch the PR's cross-platform CI matrix after the work is done; that is the
+     token bleed this doctrine forbids. Landing on green is delegated:
+     - **Primary today — the manager-owned poller.** `main` has no required status checks (`contexts=[]`),
+       so `gh pr merge --auto` would merge instantly against an empty check set (forbidden). Hand the PR
+       off to the manager-owned poller/merge-engine, which gates on an explicit lane set and lands it on
+       green. Log that you armed the poller path.
+     - **Once required status checks are configured on `main`** — arm `gh pr merge --auto --squash
+       --delete-branch` (GitHub lands it natively when the required checks pass, zero tokens). Log that path.
+   - **`flow-finalize <N>`** runs on the merge event (archive any OpenSpec change, stamp the telemetry
+     ledger, remove the worktree, delete the origin claim lock, close the issue with a traceable comment) —
+     triggered by the merge, not by a CI busy-wait.
+   Escalate to the owner (do NOT arm merge-on-green) only for: an unresolved roborev finding that's a
+   genuine design call, a scope/product question, or anything outside this issue. Report the terminal state
+   + gate/C/roborev summary + which merge-on-green path you armed.
+   (`ScheduleWakeup` remains valid for genuinely external, harness-untracked state — just not for polling a
+   PR's own CI after the work is complete.)

--- a/docs/development/pm-operating-loop.md
+++ b/docs/development/pm-operating-loop.md
@@ -6,9 +6,9 @@ Two roles. One board. The manager orchestrates; the workers do everything else.
 
 | | **Manager** (one window, `/manager`) | **flow-lead workers** (N windows / machines) |
 |---|---|---|
-| Writes code / claims / merges? | **Never** | Yes — owns the issue end-to-end |
+| Writes code / claims / merges? | **Never by hand** (runs the merge-on-green poller for the fleet) | Yes — owns the issue end-to-end |
 | Board | Controls **Ready** (what + order); reconciles; reaps | Reads Ready; claims the oldest unlocked item |
-| Lifecycle | none | full **1:1:1:1**: claim → implement → gate → C → roborev → PR → **merge → cleanup** |
+| Lifecycle | none | full **1:1:1:1**: claim → implement → gate → C → roborev → PR → **arm merge-on-green → cleanup** |
 | Communication | signed **issue comments** (work orders) + Ready ordering | reads manager comments before acting; obeys the latest order |
 | Tempo | sets it via Ready throughput, WIP cap, and ordering | runs flat-out on its claimed issue |
 
@@ -40,11 +40,41 @@ ORDER: k                # queue rank when several are Ready at once
    implements + runs the gate). **Out-of-scope bug found** → a subagent files a new detailed issue (never fix
    it inline / never grow the diff); if it **blocks** completion, comment "blocked on #<new>" on your issue,
    pause, and surface to the manager (it sequences via `HOLD`/Ready) — fix it only as its own 1:1:1:1 claim.
-5. **Before merging**: re-check for an open `HOLD`. If `HOLD: merge after #N`, block until #N is merged.
-   Merge only on `agent-gate.sh` PASS + spec-auditor C PASS (design) + roborev clean + HOLD cleared.
-6. **Merge + clean up** (`flow-finalize`): squash-merge, archive any OpenSpec change, **stamp the
-   telemetry ledger**, remove the worktree, delete the origin claim branch, close the issue with a
-   traceable comment. Board → Done (built-in).
+5. **Terminal state — arm merge-on-green, then STOP.** The worker's terminal state for an issue is
+   **PR-open + `agent-gate.sh` PASS + spec-auditor C PASS (design) + roborev clean** (with any `HOLD`
+   cleared). At that point re-check for an open `HOLD` (if `HOLD: merge after #N`, the merge-on-green
+   mechanism stays gated behind #N — the manager sequences it), rebase on current `origin/main` and resolve
+   any conflict in your own worktree, then **arm the merge-on-green mechanism (below) and end your turn.**
+   Do **NOT** poll the PR's own external CI in a yield/wake loop (repeated `ScheduleWakeup` cycles) waiting
+   for the cross-platform matrix — once the work is done that is pure token bleed, and it is prohibited.
+6. **Merge-on-green lands it; finalize follows the merge.** The armed mechanism lands the PR when its
+   defined green signal passes; the merge event triggers `flow-finalize` (archive any OpenSpec change,
+   **stamp the telemetry ledger**, remove the worktree, delete the origin claim branch, close the issue
+   with a traceable comment). Board → Done (built-in). Finalize is driven by the merge event, not by a CI
+   busy-wait.
+
+## Merge-on-green (how a green PR lands — no worker CI busy-wait)
+
+A worker never busy-polls its PR's own CI. When it reaches its terminal state it **arms** one of two
+merge-on-green paths and stops; the mechanism watches the green signal for it:
+
+- **Primary today — the manager-owned poller.** `main` currently has **no required status checks**
+  (`contexts=[]`), so a naive `gh pr merge --auto` would merge the instant it is set, against an empty
+  check set (forbidden — see the green-signal guard below). So the worker hands the PR off to the
+  manager-owned poller/merge-engine, which gates on an explicit lane set and lands the PR on green. The
+  poller runs **once at the manager level for the whole fleet**, not N times per worker — that concentration
+  is the efficiency win.
+- **`gh pr merge --auto --squash --delete-branch` — primary once required checks are configured on `main`.**
+  When real required status checks exist for the PR's branch, `--auto` is the zero-token native path:
+  GitHub lands the PR the moment the required checks pass and auto-closes the issue via `Closes #N`. Until
+  then it is **not** used as the primary path.
+
+The worker **logs which path it armed**. **Green-signal guard:** merge-on-green SHALL only land a PR once a
+*defined* green signal exists — configured required checks, or the manager-poller's explicit lane set. It
+must never auto-land against an empty required-check set.
+
+**`ScheduleWakeup` is still valid** for genuinely external, harness-untracked state; what is forbidden is
+using it to busy-poll a PR's own external CI after the work is complete.
 
 ## Self-improvement loop (telemetry + retro)
 
@@ -76,7 +106,8 @@ worktree (the manager never rebases someone else's branch).
 - **Seam 1 — spec approval**: design-driven issues stop after `flow-activate` for owner approval.
 - **Exceptions / product calls**: scope, epic close, conflicting requirements → manager surfaces a
   **NEEDS-YOU** list; never decided autonomously.
-- Workers otherwise merge autonomously on green. There is no human merge click for worker-owned issues.
+- Workers otherwise **arm merge-on-green and stop**; the mechanism lands the PR on green. There is no human
+  merge click for worker-owned issues — and no worker CI busy-wait.
 
 ## Hard rules
 - The gate is the only run that counts; paste its summary block.

--- a/openspec/changes/issue-1176-codify-merge-on-green/design.md
+++ b/openspec/changes/issue-1176-codify-merge-on-green/design.md
@@ -1,0 +1,50 @@
+## Context
+
+The busy-wait is structural: a worker that, after opening its PR, calls `ScheduleWakeup` (or any
+yield-and-poll) to watch the cross-platform CI matrix re-loads its full context (~55–60k tokens) on each
+wake with no work to do — the implementation, gate, and review are already complete. The only missing
+signal is external CI, which the harness does not track. The fix decouples "work done" (worker's job)
+from "landed on green" (a merge-on-green mechanism's job).
+
+## Decisions
+
+### D1 — Worker terminates at the green-quality-bar; landing is delegated
+**Chosen:** the worker's terminal state for an issue is **PR-open + `agent-gate.sh` PASS + roborev clean
+(+ spec-auditor C PASS for design-driven)**, with the merge-on-green mechanism armed. It does NOT poll CI.
+**Beat:** the status-quo "open PR → ScheduleWakeup every ~270s until CI green → merge" loop (the token
+bleed this issue exists to kill).
+
+### D2 — `gh pr merge --auto` preferred, manager-poller fallback
+**Chosen:** arm `gh pr merge --auto --squash --delete-branch` when the repo supports branch-protection
+auto-merge; otherwise hand off to a manager-owned poller/merge-engine that lands the PR on green. The
+choice is detectable (auto-merge enabled?) and the worker picks accordingly, logging which path it armed.
+**Beat:** (a) worker-polls-CI (the bug); (b) `--auto`-only (silently never lands if auto-merge is
+disabled — exactly the kind of silent degrade we've been bitten by); (c) manager-poller-only (works, but
+foregoes the zero-token native path when it's available).
+
+### D3 — Guard the green signal so `--auto` can't land on an empty check set
+**Chosen:** the merge-on-green path requires a *defined* green signal. `main` currently has **no required
+status checks** (`contexts=[]`), so a naive `--auto` would merge the instant it's set — defeating the
+"on green" intent. The spec requires either real required checks be configured for the PR, or the
+manager-poller gate on an explicit lane set, before merge-on-green is considered satisfied. **Beat:**
+arming `--auto` against an empty required-check set (would merge before CI even starts).
+
+### D4 — Doctrine + skills are the deliverable surface
+**Chosen:** the change lands as edits to `docs/development/pm-operating-loop.md`, the
+`agents-developing/delivery-pipeline` page, and the `worker`/`flow-implement` skill text — the authoritative
+operating docs the agents read. **Beat:** a code-only lint (there's no code path to lint — this is agent
+behavior governed by skill/doctrine text).
+
+## Risks / Trade-offs
+
+- **`--auto` requires repo config** (auto-merge enabled + ideally required checks). If neither is set, the
+  manager-poller is the operative path; the spec must not assume `--auto` always works (D2/D3).
+- **Manager-poller is itself a session** — it still polls CI, but ONCE at the manager level for the whole
+  fleet, not N times per worker, which is the efficiency win.
+- **Verification of "no busy-wait"** is behavioral (observe a worker run open a PR and end without repeated
+  CI-poll wake-ups), encoded as a scenario rather than a unit test.
+
+## Migration / Rollout
+
+Doctrine + skill text edits; immediately effective for new worker runs. No code, no data, no API change.
+The fallback path means it ships safe regardless of branch-protection configuration.

--- a/openspec/changes/issue-1176-codify-merge-on-green/proposal.md
+++ b/openspec/changes/issue-1176-codify-merge-on-green/proposal.md
@@ -1,0 +1,61 @@
+## Why
+
+A flow-lead **worker** that waits on the cross-platform CI matrix *after opening its PR* spawns a CI
+poller, yields, gets marked "completed", and re-orients at **~55–60k tokens per cycle**. Issue #1086's
+worker did this ~10×; a single unattended session this week (the one that filed this) incurred the same
+busy-wait **~6×** while polling `ScheduleWakeup` against the parity-CI matrix — pure token bleed when the
+work was already done (PR open, gate PASS, roborev clean) and only the external CI matrix remained.
+
+The fix is already proven in practice: the worker reaches **PR-open + agent-gate PASS + roborev clean
+(+ spec-auditor C PASS for design-driven)** and then **STOPS**, leaving the final land to a
+merge-on-green mechanism — GitHub's native `gh pr merge --auto --squash`, or a manager-owned poller as
+the fallback when branch-protection auto-merge isn't enabled. This change codifies that in the delivery
+doctrine + the worker/flow-implement skills so the busy-wait can't recur.
+
+- **Milestone:** maintenance / delivery-pipeline process. **Design-driven** — process + doctrine + skill,
+  with real latitude in *how* merge-on-green is wired (native `--auto` vs manager merge-engine vs both).
+  Hence OpenSpec + Seam 1 (per the manager's routing on the issue).
+- Modifies the existing `delivery-pipeline` capability (adds a merge-on-green / no-busy-wait requirement).
+- No code/library impact; this is agent-operating doctrine + the `flow-*` skill text + the
+  `pm-operating-loop.md` / delivery-pipeline website page.
+
+## What Changes
+
+- **Worker stops at PR-open + green-quality-bar; never polls external CI in a yield loop.** After a
+  worker reaches PR-open with `agent-gate.sh` PASS + roborev clean (+ C PASS for design-driven), it sets
+  the merge-on-green mechanism and **terminates its turn** rather than scheduling repeated CI-poll
+  wake-ups. Observable: a worker run on a simple issue opens the PR and ends without N CI-poll
+  stop/resume cycles.
+- **Merge-on-green mechanism.** Preferred: `gh pr merge --auto --squash --delete-branch` (GitHub lands it
+  when required checks pass; requires repo auto-merge enabled). Fallback when `--auto` is unavailable: a
+  manager-owned poller / merge-engine lands it on green. Either way the issue auto-closes via the PR's
+  `Closes #N`.
+- **Doctrine updated:** `docs/development/pm-operating-loop.md` + the `agents-developing/delivery-pipeline`
+  page describe merge-on-green and **explicitly forbid worker CI busy-waiting**; the worker/flow-implement
+  skill text is aligned.
+
+## Non-goals
+
+- Not changing the quality bar (gate PASS + C + roborev) or the two human seams (spec approval; merge
+  remains the same authority model — this only changes the *mechanism* by which a green PR lands, not who
+  authorizes it).
+- Not building a new bespoke CI service; the manager-poller fallback reuses the existing manager pattern.
+- Not removing `ScheduleWakeup` as a tool — it remains valid for genuinely external, harness-untracked
+  state; what's forbidden is using it to busy-poll a PR's own CI after the work is done.
+
+## Decisions for the owner (recommended defaults — confirm/adjust at approval)
+
+1. **Mechanism** → prefer `gh pr merge --auto --squash --delete-branch`; fall back to the manager poller
+   when branch-protection auto-merge is not enabled on the repo. *Recommended.* (Sub-question: do you want
+   auto-merge enabled on the repo so `--auto` is the primary path? If not, the manager-poller is primary.)
+2. **Where the worker stops** → immediately after PR-open + gate PASS + roborev clean (+ C for
+   design-driven), having set the merge mechanism; it does NOT verify CI itself. *Recommended.*
+3. **Required-checks definition for `--auto`** → since `main` currently has no required status checks,
+   `--auto` would merge immediately; the spec requires that the merge-on-green path only auto-lands once a
+   defined green signal exists (either real required checks are configured, or the manager-poller gates on
+   the chosen lane set). *Recommended — surfaced because it interacts with branch protection config.*
+
+## Impact
+
+- Modifies `delivery-pipeline` capability spec; edits `docs/development/pm-operating-loop.md`, the
+  delivery-pipeline website page, and the `worker`/`flow-implement` skill text. No production code.

--- a/openspec/changes/issue-1176-codify-merge-on-green/specs/delivery-pipeline/spec.md
+++ b/openspec/changes/issue-1176-codify-merge-on-green/specs/delivery-pipeline/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Workers land green PRs via merge-on-green and never busy-wait on external CI
+A flow-lead worker SHALL treat **PR-open + `agent-gate.sh` PASS + roborev clean (+ spec-auditor C PASS for
+design-driven changes)** as its terminal state for an issue, arm a merge-on-green mechanism, and end its
+turn. It SHALL NOT poll the PR's external CI in a yield/wake loop (e.g. repeated `ScheduleWakeup` cycles)
+after the work is complete. The merge-on-green mechanism SHALL be `gh pr merge --auto --squash
+--delete-branch` where branch-protection auto-merge is available, and a manager-owned poller/merge-engine
+otherwise; the chosen path SHALL be logged. Merge-on-green SHALL only land a PR once a defined green
+signal exists (configured required checks, or the manager-poller's explicit lane set) — it SHALL NOT
+auto-land against an empty required-check set.
+
+#### Scenario: Worker opens the PR and stops without CI-poll cycles
+- **WHEN** a worker reaches PR-open with gate PASS + roborev clean (+ C PASS for design-driven)
+- **THEN** it arms the merge-on-green mechanism and ends its turn
+- **AND** it does not schedule repeated wake-ups to poll that PR's external CI (no N stop/resume CI-poll cycles)
+
+#### Scenario: Auto-merge available → native merge-on-green
+- **WHEN** branch-protection auto-merge is enabled for the repo
+- **THEN** the worker arms `gh pr merge --auto --squash --delete-branch` and logs that path
+- **AND** GitHub lands the PR when the defined required checks pass, auto-closing the issue via `Closes #N`
+
+#### Scenario: Auto-merge unavailable → manager-poller fallback
+- **WHEN** branch-protection auto-merge is not available
+- **THEN** the worker hands off to the manager-owned poller/merge-engine and logs that path
+- **AND** the PR is landed on green by that mechanism rather than by the worker polling CI
+
+#### Scenario: No defined green signal → do not auto-land prematurely
+- **WHEN** the PR's branch has no configured required status checks
+- **THEN** the merge-on-green mechanism does not immediately merge on an empty check set
+- **AND** it lands only once the chosen green signal (configured required checks or the poller's explicit lane set) is satisfied
+
+### Requirement: Delivery doctrine forbids worker CI busy-waiting
+The delivery doctrine SHALL document merge-on-green and explicitly forbid worker CI busy-waiting.
+`docs/development/pm-operating-loop.md` and the `agents-developing/delivery-pipeline` page SHALL describe
+the worker terminal state (PR-open + green quality bar → arm merge-on-green → stop) and state that polling
+a PR's own external CI in a yield loop is prohibited; the `worker`/`flow-implement` skill text SHALL be
+consistent with this.
+
+#### Scenario: Doctrine and skills describe merge-on-green and prohibit busy-wait
+- **WHEN** `pm-operating-loop.md`, the delivery-pipeline page, and the worker/flow-implement skill text are read after this change
+- **THEN** they describe the worker terminal state + the merge-on-green mechanism (native `--auto` preferred, manager-poller fallback)
+- **AND** they explicitly state that a worker must not busy-poll its PR's external CI after the work is complete

--- a/openspec/changes/issue-1176-codify-merge-on-green/tasks.md
+++ b/openspec/changes/issue-1176-codify-merge-on-green/tasks.md
@@ -1,18 +1,18 @@
 ## 1. Merge-on-green mechanism
 
-- [ ] 1.1 Define the worker terminal state: PR-open + `agent-gate.sh` PASS + roborev clean (+ C PASS for
+- [x] 1.1 Define the worker terminal state: PR-open + `agent-gate.sh` PASS + roborev clean (+ C PASS for
       design-driven) → arm merge-on-green → end turn. No CI yield-poll.
-- [ ] 1.2 Detect branch-protection auto-merge availability; arm `gh pr merge --auto --squash
+- [x] 1.2 Detect branch-protection auto-merge availability; arm `gh pr merge --auto --squash
       --delete-branch` when available, else hand off to the manager poller/merge-engine. Log which path.
-- [ ] 1.3 Guard the green signal (D3): do not auto-land against an empty required-check set; require
+- [x] 1.3 Guard the green signal (D3): do not auto-land against an empty required-check set; require
       configured required checks or the poller's explicit lane set.
 
 ## 2. Doctrine + skills
 
-- [ ] 2.1 Update `docs/development/pm-operating-loop.md`: worker terminal state + merge-on-green + explicit
+- [x] 2.1 Update `docs/development/pm-operating-loop.md`: worker terminal state + merge-on-green + explicit
       no-CI-busy-wait prohibition.
-- [ ] 2.2 Update the `agents-developing/delivery-pipeline` website page to match.
-- [ ] 2.3 Align the `worker` and `flow-implement` skill text (`.claude/skills/...`) with the new terminal
+- [x] 2.2 Update the `agents-developing/delivery-pipeline` website page to match.
+- [x] 2.3 Align the `worker` and `flow-implement` skill text (`.claude/skills/...`) with the new terminal
       state + merge-on-green mechanism.
 
 ## 3. Quality gates (definition of done)

--- a/openspec/changes/issue-1176-codify-merge-on-green/tasks.md
+++ b/openspec/changes/issue-1176-codify-merge-on-green/tasks.md
@@ -1,0 +1,26 @@
+## 1. Merge-on-green mechanism
+
+- [ ] 1.1 Define the worker terminal state: PR-open + `agent-gate.sh` PASS + roborev clean (+ C PASS for
+      design-driven) → arm merge-on-green → end turn. No CI yield-poll.
+- [ ] 1.2 Detect branch-protection auto-merge availability; arm `gh pr merge --auto --squash
+      --delete-branch` when available, else hand off to the manager poller/merge-engine. Log which path.
+- [ ] 1.3 Guard the green signal (D3): do not auto-land against an empty required-check set; require
+      configured required checks or the poller's explicit lane set.
+
+## 2. Doctrine + skills
+
+- [ ] 2.1 Update `docs/development/pm-operating-loop.md`: worker terminal state + merge-on-green + explicit
+      no-CI-busy-wait prohibition.
+- [ ] 2.2 Update the `agents-developing/delivery-pipeline` website page to match.
+- [ ] 2.3 Align the `worker` and `flow-implement` skill text (`.claude/skills/...`) with the new terminal
+      state + merge-on-green mechanism.
+
+## 3. Quality gates (definition of done)
+
+- [ ] 3.1 `scripts/agent-gate.sh` PASS — paste the AGENT-GATE SUMMARY block verbatim. (Doc/skill-only
+      change; gate still runs.)
+- [ ] 3.2 Intent audit **C** (`spec-auditor` anchored to
+      `openspec/changes/issue-1176-codify-merge-on-green/specs/**`) PASS.
+- [ ] 3.3 roborev (`--agent codex --base origin/main`) clean.
+- [ ] 3.4 PR opened; **dogfood the new doctrine** — arm merge-on-green and stop (do not busy-poll CI);
+      then `flow-finalize` (archive change, cleanup, close #1176).

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -42,11 +42,33 @@ middle; you sit in two seats.
 
 1. **Spec approval** (Seam 1, in `flow-activate`) — you approve the OpenSpec spec + design before any
    implementation. The lead renders it inline and stops.
-2. **Merge** (Seam 2) — **pre-authorized merge-on-green**:
-   - *Default:* the lead opens the PR but does **not** merge or close it — merge is yours.
-   - *Exception:* for a set you **explicitly pre-authorize** ("merge #X, #Y on green"), the lead may
-     squash-merge + finalize, **only** when `agent-gate.sh` PASS + C PASS + roborev clean.
+2. **Merge** (Seam 2) — **merge-on-green** (no human merge click for worker-owned issues):
+   - A worker's **terminal state** for an issue is PR-open + `agent-gate.sh` PASS + C PASS (design-driven)
+     + roborev clean. At that point it **arms the merge-on-green mechanism and ends its turn** — it does
+     **not** poll the PR's own external CI in a yield/wake loop (see [Merge-on-green](#merge-on-green-no-ci-busy-wait)).
    - *Always escalated, never decided by the lead:* product decisions, scope/title changes, epic closes.
+
+## Merge-on-green (no CI busy-wait)
+
+Once a worker reaches its terminal state (PR-open + gate PASS + C PASS + roborev clean) it **arms** a
+merge-on-green mechanism and **stops**. It must **not** busy-poll its PR's own external CI — repeatedly
+waking (`ScheduleWakeup`) to watch the cross-platform matrix after the work is done is pure token bleed and
+is prohibited. Landing on green is delegated:
+
+- **Primary today — the manager-owned poller.** `main` currently has **no required status checks**
+  (`contexts=[]`), so a naive `gh pr merge --auto` would merge instantly against an empty check set — which
+  the green-signal guard forbids. The worker hands the PR to the manager-owned poller/merge-engine, which
+  gates on an explicit lane set and lands it on green. The poller runs **once for the whole fleet** at the
+  manager level, not per worker.
+- **`gh pr merge --auto --squash --delete-branch` — primary once required checks are configured on `main`.**
+  With real required checks in place, `--auto` is the zero-token native path: GitHub lands the PR when the
+  required checks pass and auto-closes the issue via `Closes #N`.
+
+The worker **logs which path it armed**. **Green-signal guard:** merge-on-green lands only once a *defined*
+green signal exists (configured required checks or the poller's explicit lane set) — never against an empty
+required-check set. `flow-finalize` runs on the merge event (not a CI busy-wait). `ScheduleWakeup` remains
+valid for genuinely external, harness-untracked state — just not for polling a PR's own CI after the work
+is complete.
 
 ## The specialist roster
 

--- a/website/src/content/docs/agents-developing/delivery-pipeline.md
+++ b/website/src/content/docs/agents-developing/delivery-pipeline.md
@@ -155,9 +155,13 @@ dataset binaries). Two supported ways to still drive work from the phone:
   `test-data/scripts/cloud-setup.sh` first — it installs `openspec` + `gh` and fetches the dataset
   (`fetch-datasets.sh`) so `flow-implement` can run the gate in the cloud.
 
-The **two human seams are GitHub-mobile-native** regardless of how you drive: approve the spec in the
-session, and merge the PR from the GitHub mobile app / web UI (the merge automation then moves the board
-item to `Done`).
+**Spec approval is the only standing human seam, and it is GitHub-mobile-native** regardless of how you
+drive: approve the OpenSpec spec + design in the session (Seam 1). For worker-owned issues **merge is no
+longer a hand-merge step** — the PR auto-lands via [merge-on-green](#merge-on-green-no-ci-busy-wait)
+(the manager-owned poller today; `gh pr merge --auto` once required checks are configured on `main`), and
+the merge event moves the board item to `Done`. The owner intervenes on merge (from the mobile app / web
+UI) **only on escalation** — a genuine design-call roborev finding, a scope/product question, or work
+outside the issue.
 
 ## Self-improvement loop (telemetry + retro)
 


### PR DESCRIPTION
## What

Codifies **merge-on-green** into the delivery doctrine + `flow-*` skill text and **explicitly forbids a flow-lead worker from busy-polling its PR's own external CI** after the work is done — the ~55–60k-token/cycle bleed this issue exists to kill.

Design-driven; owner approved the OpenSpec spec at Seam 1 (2026-07-01). **No production code** — doctrine + skill text only.

## Worker terminal state (new)
PR-open + `agent-gate.sh` PASS + spec-auditor **C** PASS (design-driven) + roborev clean → **arm merge-on-green → STOP**. No `ScheduleWakeup` CI-poll loops.

## Merge-on-green mechanism (owner decision)
- **Manager-owned poller is the PRIMARY path today** — `main` has no required status checks (`contexts=[]`).
- `gh pr merge --auto --squash --delete-branch` becomes primary **only once required checks are configured** on `main`.
- **D3 guard:** merge-on-green must never auto-land against an empty required-check set.

## Surfaces
- `docs/development/pm-operating-loop.md`
- `website/src/content/docs/agents-developing/delivery-pipeline.md`
- `.claude/skills/flow-implement/SKILL.md`
- `.claude/commands/worker.md`

## Quality bar
- Gate: **PASS** (16/16 lanes)
- Spec-auditor **C**: **PASS** (R1 + R2 satisfied)
- roborev (codex, `--base origin/main`): **clean** (no code changes)

Closes #1176