### PR TITLE
feat(#1392): fsync data dir before WAL truncate (SSTable durability)

### DIFF
--- a/cqlite-core/src/storage/sstable/writer/bti_state.rs
+++ b/cqlite-core/src/storage/sstable/writer/bti_state.rs
@@ -202,10 +202,14 @@ impl SSTableWriter {
         // Partitions.db must be non-empty here (pending is non-empty).
         let part_path = cpath("Partitions.db");
         tokio::fs::write(&part_path, partitions_bytes).await?;
+        // fsync Partitions.db contents (issue #1392): tokio::fs::write does not
+        // fsync, so the bytes would only reach the page cache.
+        Self::fsync_component(&part_path).await?;
 
         // Rows.db is ALWAYS emitted for BTI (possibly 0 bytes).
         let rows_path = cpath("Rows.db");
         tokio::fs::write(&rows_path, rows_bytes).await?;
+        Self::fsync_component(&rows_path).await?;
 
         Ok((Some(part_path), Some(rows_path)))
     }

--- a/cqlite-core/src/storage/sstable/writer/data_writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/mod.rs
@@ -184,6 +184,15 @@ pub struct DataWriter {
     position: u64,
     /// Encoding baselines used for delta encoding.
     stats: EncodingStatsBaselines,
+    /// Ancestor directories this writer newly created when it lazily opened its
+    /// sink (issue #1392). `ensure_sink` runs during the first `write_partition`,
+    /// i.e. BEFORE `SSTableWriter::finish`, so it is the FIRST point the
+    /// keyspace/table directory tree can be materialized on a non-empty flush.
+    /// Recording it here (rather than only re-deriving it in `finish`, where the
+    /// dirs already exist and would be reported as empty) lets the flush
+    /// durability barrier fsync every newly created ancestor before the WAL is
+    /// truncated. Empty in in-memory mode and once the sink already exists.
+    created_dirs: Vec<PathBuf>,
 }
 
 mod cells;
@@ -256,6 +265,7 @@ impl DataWriter {
             data_path: None,
             position: 0,
             stats: EncodingStatsBaselines::from(&stats),
+            created_dirs: Vec::new(),
         }
     }
 
@@ -276,6 +286,7 @@ impl DataWriter {
             data_path: Some(data_path),
             position: 0,
             stats: EncodingStatsBaselines::from(&stats),
+            created_dirs: Vec::new(),
         }
     }
 
@@ -288,7 +299,15 @@ impl DataWriter {
         }
         if let Some(path) = self.data_path.clone() {
             if let Some(parent) = path.parent() {
-                std::fs::create_dir_all(parent)?;
+                // Record which ancestor directories this creation materializes so
+                // the flush durability barrier can fsync them before the WAL is
+                // truncated (issue #1392). This is the FIRST point a non-empty
+                // flush creates the keyspace/table tree — recording only in
+                // `SSTableWriter::finish` would report an empty list (the dirs
+                // already exist by then) and leave the ancestor dirents unsynced.
+                let created =
+                    crate::storage::write_engine::durability::create_dir_all_recording(parent)?;
+                self.created_dirs.extend(created);
             }
             let file = std::fs::File::create(&path)?;
             // Use a large BufWriter so a partition's bytes coalesce into a few
@@ -365,13 +384,20 @@ impl DataWriter {
                 "finish_streaming() called on an in-memory DataWriter".to_string(),
             ));
         }
-        // Flush any residual scratch (normally empty), then flush the sink so all
-        // bytes reach the OS file (the subsequent Digest CRC re-read of the same
-        // file sees them via the page cache). This matches the durability of the
-        // previous `tokio::fs::write`, which did not fsync either.
+        // Flush any residual scratch (normally empty), then flush the BufWriter
+        // so all bytes reach the OS file, and fsync the file so its *contents*
+        // are durable on the storage device (issue #1392). A plain `flush()`
+        // only pushes bytes into the page cache; without the fsync a crash after
+        // the WAL is truncated could lose the Data.db contents even though the
+        // directory entry was persisted. This fsync (plus the per-component
+        // fsyncs in `SSTableWriter::finish`) is the durability guarantee for
+        // both the flush and compaction write paths.
         self.flush_partition()?;
         if let Some(mut sink) = self.sink.take() {
             sink.flush()?;
+            sink.get_ref()
+                .sync_all()
+                .map_err(|e| Error::Storage(format!("Failed to fsync Data.db contents: {e}")))?;
         }
         Ok(self.position)
     }
@@ -383,6 +409,18 @@ impl DataWriter {
     /// in both streaming and in-memory modes.
     pub fn position(&self) -> u64 {
         self.position + self.buffer.len() as u64
+    }
+
+    /// Ancestor directories this writer newly created when lazily opening its
+    /// sink (issue #1392).
+    ///
+    /// `SSTableWriter::finish` collects this (before consuming the writer via
+    /// `finish_streaming`) and folds it into `SSTableInfo::created_dirs` so the
+    /// flush durability barrier fsyncs every newly created ancestor before the
+    /// WAL is truncated — including on a non-empty first flush, where the dirs
+    /// were created here during `write_partition` rather than in `finish`.
+    pub(crate) fn created_dirs(&self) -> &[PathBuf] {
+        &self.created_dirs
     }
 
     /// Length of the per-partition scratch buffer.

--- a/cqlite-core/src/storage/sstable/writer/data_writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/mod.rs
@@ -184,15 +184,6 @@ pub struct DataWriter {
     position: u64,
     /// Encoding baselines used for delta encoding.
     stats: EncodingStatsBaselines,
-    /// Ancestor directories this writer newly created when it lazily opened its
-    /// sink (issue #1392). `ensure_sink` runs during the first `write_partition`,
-    /// i.e. BEFORE `SSTableWriter::finish`, so it is the FIRST point the
-    /// keyspace/table directory tree can be materialized on a non-empty flush.
-    /// Recording it here (rather than only re-deriving it in `finish`, where the
-    /// dirs already exist and would be reported as empty) lets the flush
-    /// durability barrier fsync every newly created ancestor before the WAL is
-    /// truncated. Empty in in-memory mode and once the sink already exists.
-    created_dirs: Vec<PathBuf>,
 }
 
 mod cells;
@@ -265,7 +256,6 @@ impl DataWriter {
             data_path: None,
             position: 0,
             stats: EncodingStatsBaselines::from(&stats),
-            created_dirs: Vec::new(),
         }
     }
 
@@ -286,7 +276,6 @@ impl DataWriter {
             data_path: Some(data_path),
             position: 0,
             stats: EncodingStatsBaselines::from(&stats),
-            created_dirs: Vec::new(),
         }
     }
 
@@ -299,15 +288,11 @@ impl DataWriter {
         }
         if let Some(path) = self.data_path.clone() {
             if let Some(parent) = path.parent() {
-                // Record which ancestor directories this creation materializes so
-                // the flush durability barrier can fsync them before the WAL is
-                // truncated (issue #1392). This is the FIRST point a non-empty
-                // flush creates the keyspace/table tree — recording only in
-                // `SSTableWriter::finish` would report an empty list (the dirs
-                // already exist by then) and leave the ancestor dirents unsynced.
-                let created =
-                    crate::storage::write_engine::durability::create_dir_all_recording(parent)?;
-                self.created_dirs.extend(created);
+                // Create the keyspace/table tree. The flush durability barrier
+                // fsyncs the full leaf→data-root chain unconditionally before
+                // the WAL truncate, so this creation need not track which
+                // ancestors it made (issue #1392).
+                crate::storage::write_engine::durability::create_dir_all(parent)?;
             }
             let file = std::fs::File::create(&path)?;
             // Use a large BufWriter so a partition's bytes coalesce into a few
@@ -409,18 +394,6 @@ impl DataWriter {
     /// in both streaming and in-memory modes.
     pub fn position(&self) -> u64 {
         self.position + self.buffer.len() as u64
-    }
-
-    /// Ancestor directories this writer newly created when lazily opening its
-    /// sink (issue #1392).
-    ///
-    /// `SSTableWriter::finish` collects this (before consuming the writer via
-    /// `finish_streaming`) and folds it into `SSTableInfo::created_dirs` so the
-    /// flush durability barrier fsyncs every newly created ancestor before the
-    /// WAL is truncated — including on a non-empty first flush, where the dirs
-    /// were created here during `write_partition` rather than in `finish`.
-    pub(crate) fn created_dirs(&self) -> &[PathBuf] {
-        &self.created_dirs
     }
 
     /// Length of the per-partition scratch buffer.

--- a/cqlite-core/src/storage/sstable/writer/data_writer/tests/scenarios_5.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/tests/scenarios_5.rs
@@ -423,6 +423,41 @@ fn test_streaming_writer_bounds_memory_to_one_partition() {
         );
 }
 
+/// Issue #1392: `finish_streaming` must fsync the Data.db contents (not merely
+/// `flush()` them to the page cache) so the bytes are durable before the flush
+/// handoff fsyncs the directory and truncates the WAL. fsync is not directly
+/// observable, but the durable contract is: after `finish_streaming` returns,
+/// the on-disk file exists with the full reported length and the exact bytes,
+/// with no writer handle still buffering. Regression guard for the previous
+/// flush-only path.
+#[test]
+fn finish_streaming_persists_data_db_contents() {
+    let schema = create_test_schema();
+    let partitions = streaming_test_partitions();
+
+    let dir = tempfile::tempdir().unwrap();
+    let data_path = dir.path().join("nb-1-big-Data.db");
+    let mut writer = DataWriter::with_sink(create_test_stats(), data_path.clone());
+    for (key, mutations) in &partitions {
+        writer
+            .write_partition(key, mutations, &schema, None, &[])
+            .unwrap();
+    }
+    let data_size = writer.finish_streaming().unwrap();
+
+    // The file length on disk equals the reported size (all bytes durable).
+    let meta = std::fs::metadata(&data_path).unwrap();
+    assert_eq!(
+        meta.len(),
+        data_size,
+        "on-disk Data.db length must equal finish_streaming()'s reported size"
+    );
+    assert!(data_size > 0, "streamed Data.db must be non-empty");
+    // And the content is fully readable (writer handle released, bytes flushed).
+    let on_disk = std::fs::read(&data_path).unwrap();
+    assert_eq!(on_disk.len() as u64, data_size);
+}
+
 /// (a) Two elements at DIFFERENT per-element timestamps must produce two
 /// cells, each carrying its OWN explicit timestamp delta (NOT
 /// USE_ROW_TIMESTAMP, NOT a single promoted row timestamp).

--- a/cqlite-core/src/storage/sstable/writer/finish.rs
+++ b/cqlite-core/src/storage/sstable/writer/finish.rs
@@ -47,7 +47,35 @@ impl SSTableWriter {
         // `finish_streaming()` can move `self.data_writer` out below.
         let sstable_dir = self.sstable_dir.clone();
         let sstable_dir = sstable_dir.as_path();
-        tokio::fs::create_dir_all(sstable_dir).await?;
+        // Record which ancestor directories are newly created so the flush
+        // durability barrier can fsync them (and their parents) before the WAL
+        // is truncated (issue #1392). On a first flush this includes the
+        // keyspace/table directories; fsyncing only the leaf would leave those
+        // ancestors' own dirents unsynced and a crash could lose the whole tree.
+        //
+        // For a NON-EMPTY flush the streaming writers' `ensure_sink` already
+        // created this tree during `write_partition` (before `finish` runs), so
+        // THIS call reports an empty list — the newly created ancestors were
+        // recorded on the writers instead and are folded in below. For an EMPTY
+        // flush no partition was written, so `ensure_sink` never ran and this
+        // call is the point of creation. Both sources are merged (and
+        // de-duplicated) so `SSTableInfo::created_dirs` always reflects every
+        // ancestor this flush created, regardless of which path created it.
+        let mut created_dirs =
+            crate::storage::write_engine::durability::create_dir_all_recording(sstable_dir)?;
+        // Fold in the ancestor dirs the streaming Data.db / Index.db writers
+        // recorded when they lazily opened their sinks. Captured now, before the
+        // by-value `finish_streaming` calls below consume the writers.
+        for dir in self.data_writer.created_dirs() {
+            if !created_dirs.contains(dir) {
+                created_dirs.push(dir.clone());
+            }
+        }
+        for dir in self.index_writer.created_dirs() {
+            if !created_dirs.contains(dir) {
+                created_dirs.push(dir.clone());
+            }
+        }
 
         // Finalize statistics metadata (normalize sentinel values)
         self.stats.finalize();
@@ -72,6 +100,9 @@ impl SSTableWriter {
             StatisticsWriter::new(stats_path.clone())
         };
         stats_writer.write(&self.stats, Some(&self.schema))?;
+        // fsync Statistics.db contents (issue #1392): stats_writer uses
+        // std::fs::write, which does not fsync.
+        Self::fsync_component(&stats_path).await?;
 
         // 2. Finalize Data.db (Issue #492)
         // The DataWriter has been streaming each partition to disk as it was
@@ -83,9 +114,13 @@ impl SSTableWriter {
         // The BTI `Data.db` row/partition serialization is identical to BIG in
         // Cassandra 5 (issue #908); only the filename descriptor differs.
         let data_path = cpath("Data.db");
+        // The streamed Data.db is fsynced inside `finish_streaming` (issue
+        // #1392). The empty-Data fallback below is written via tokio::fs::write
+        // (no fsync), so it is fsynced explicitly.
         let data_size = self.data_writer.finish_streaming()?;
         if data_size == 0 && !data_path.exists() {
             tokio::fs::write(&data_path, b"").await?;
+            Self::fsync_component(&data_path).await?;
         }
 
         // 3. Finalize Index.db (Issue #753) — BIG only.
@@ -136,6 +171,8 @@ impl SSTableWriter {
         } else {
             let path = cpath("Summary.db");
             tokio::fs::write(&path, summary_bytes).await?;
+            // fsync Summary.db contents (issue #1392).
+            Self::fsync_component(&path).await?;
             Some(path)
         };
 
@@ -182,7 +219,11 @@ impl SSTableWriter {
             } else {
                 CrcTrailer::None
             };
-            Some(crc_writer::write_crc_db(&data_path, cpath("CRC.db"), trailer).await?)
+            let crc_path = crc_writer::write_crc_db(&data_path, cpath("CRC.db"), trailer).await?;
+            // fsync CRC.db contents (issue #1392): write_crc_db uses
+            // tokio::fs::write, which does not fsync.
+            Self::fsync_component(&crc_path).await?;
+            Some(crc_path)
         };
 
         // 7. Write TOC.txt (LAST - publication barrier).
@@ -248,6 +289,39 @@ impl SSTableWriter {
             crc_path,
             partition_count: self.partition_count,
             data_size,
+            created_dirs,
+        })
+    }
+
+    /// Fsync a component file's *contents* to the storage device (issue #1392).
+    ///
+    /// Components written via `tokio::fs::write` / `std::fs::write` (Statistics,
+    /// Summary, CRC, Rows, Partitions, and the empty-Data fallback) only reach
+    /// the OS page cache; a crash after the WAL is truncated could lose their
+    /// contents even though the directory entry was persisted. This reopens the
+    /// finished file and calls `sync_all` so the bytes are durable before the
+    /// caller (`SSTableWriter::finish`) returns — and therefore before the
+    /// flush's directory fsync and WAL truncate run. (Data.db and Index.db are
+    /// fsynced at their streaming-writer finish; Filter/Digest/TOC fsync inside
+    /// their own writers — none are re-synced here.)
+    pub(super) async fn fsync_component(path: &Path) -> Result<()> {
+        // Reopen with write access, not read-only: `sync_all` on a read-only
+        // handle can fail on Windows (issue #1392, FINDING 2). `read(true)` is
+        // kept so behavior is identical on unix (the file is only fsynced, never
+        // written through this handle).
+        let file = tokio::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(path)
+            .await
+            .map_err(|e| {
+                crate::error::Error::Storage(format!(
+                    "Failed to open {} for fsync: {e}",
+                    path.display()
+                ))
+            })?;
+        file.sync_all().await.map_err(|e| {
+            crate::error::Error::Storage(format!("Failed to fsync {}: {e}", path.display()))
         })
     }
 

--- a/cqlite-core/src/storage/sstable/writer/finish.rs
+++ b/cqlite-core/src/storage/sstable/writer/finish.rs
@@ -47,35 +47,13 @@ impl SSTableWriter {
         // `finish_streaming()` can move `self.data_writer` out below.
         let sstable_dir = self.sstable_dir.clone();
         let sstable_dir = sstable_dir.as_path();
-        // Record which ancestor directories are newly created so the flush
-        // durability barrier can fsync them (and their parents) before the WAL
-        // is truncated (issue #1392). On a first flush this includes the
-        // keyspace/table directories; fsyncing only the leaf would leave those
-        // ancestors' own dirents unsynced and a crash could lose the whole tree.
-        //
-        // For a NON-EMPTY flush the streaming writers' `ensure_sink` already
-        // created this tree during `write_partition` (before `finish` runs), so
-        // THIS call reports an empty list — the newly created ancestors were
-        // recorded on the writers instead and are folded in below. For an EMPTY
-        // flush no partition was written, so `ensure_sink` never ran and this
-        // call is the point of creation. Both sources are merged (and
-        // de-duplicated) so `SSTableInfo::created_dirs` always reflects every
-        // ancestor this flush created, regardless of which path created it.
-        let mut created_dirs =
-            crate::storage::write_engine::durability::create_dir_all_recording(sstable_dir)?;
-        // Fold in the ancestor dirs the streaming Data.db / Index.db writers
-        // recorded when they lazily opened their sinks. Captured now, before the
-        // by-value `finish_streaming` calls below consume the writers.
-        for dir in self.data_writer.created_dirs() {
-            if !created_dirs.contains(dir) {
-                created_dirs.push(dir.clone());
-            }
-        }
-        for dir in self.index_writer.created_dirs() {
-            if !created_dirs.contains(dir) {
-                created_dirs.push(dir.clone());
-            }
-        }
+        // Ensure the keyspace/table directory tree exists (an empty flush never
+        // opened a streaming sink, so this may be the point of creation). The
+        // flush durability barrier later fsyncs the full leaf→data-root ancestor
+        // chain unconditionally before truncating the WAL, so directory
+        // *creation* no longer needs to record which ancestors it made (issue
+        // #1392).
+        crate::storage::write_engine::durability::create_dir_all(sstable_dir)?;
 
         // Finalize statistics metadata (normalize sentinel values)
         self.stats.finalize();
@@ -289,7 +267,6 @@ impl SSTableWriter {
             crc_path,
             partition_count: self.partition_count,
             data_size,
-            created_dirs,
         })
     }
 

--- a/cqlite-core/src/storage/sstable/writer/index_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/index_writer.rs
@@ -185,6 +185,13 @@ pub struct IndexWriter {
     position: u64,
     /// Entry count (for validation)
     entry_count: usize,
+    /// Ancestor directories this writer newly created when it lazily opened its
+    /// sink (issue #1392). Recorded here — the first `add_partition` may open the
+    /// Index.db sink before the Data.db sink, so this is one of the earliest
+    /// points the keyspace/table tree is materialized on a non-empty BIG flush.
+    /// `SSTableWriter::finish` folds it into `SSTableInfo::created_dirs` so the
+    /// flush durability barrier fsyncs the new ancestors before WAL truncate.
+    created_dirs: Vec<PathBuf>,
 }
 
 /// Information about a written index entry
@@ -220,6 +227,7 @@ impl IndexWriter {
             counting: false,
             position: 0,
             entry_count: 0,
+            created_dirs: Vec::new(),
         }
     }
 
@@ -256,6 +264,7 @@ impl IndexWriter {
             counting: true,
             position: 0,
             entry_count: 0,
+            created_dirs: Vec::new(),
         }
     }
 
@@ -275,6 +284,7 @@ impl IndexWriter {
             counting: false,
             position: 0,
             entry_count: 0,
+            created_dirs: Vec::new(),
         }
     }
 
@@ -287,7 +297,15 @@ impl IndexWriter {
         }
         if let Some(path) = self.index_path.clone() {
             if let Some(parent) = path.parent() {
-                std::fs::create_dir_all(parent)?;
+                // Record the newly created ancestor directories so the flush
+                // durability barrier fsyncs them before WAL truncate (issue
+                // #1392). `add_partition` can open this sink before the Data.db
+                // sink on a non-empty BIG flush, so recording only in
+                // `SSTableWriter::finish` (after the dirs already exist) would
+                // miss them and leave the ancestor dirents unsynced.
+                let created =
+                    crate::storage::write_engine::durability::create_dir_all_recording(parent)?;
+                self.created_dirs.extend(created);
             }
             let file = std::fs::File::create(&path)?;
             self.sink = Some(std::io::BufWriter::with_capacity(
@@ -492,9 +510,14 @@ impl IndexWriter {
         }
         // Flush any residual scratch (normally empty after per-entry flushes).
         self.flush_entry()?;
-        // Flush the BufWriter so all bytes reach the OS file.
+        // Flush the BufWriter so all bytes reach the OS file, then fsync so the
+        // Index.db *contents* are durable on the storage device (issue #1392),
+        // not merely resident in the page cache.
         if let Some(mut sink) = self.sink.take() {
             sink.flush()?;
+            sink.get_ref()
+                .sync_all()
+                .map_err(|e| Error::Storage(format!("Failed to fsync Index.db contents: {e}")))?;
         }
         Ok(self.position)
     }
@@ -516,6 +539,17 @@ impl IndexWriter {
     /// ```
     pub fn entry_count(&self) -> usize {
         self.entry_count
+    }
+
+    /// Ancestor directories this writer newly created when lazily opening its
+    /// Index.db sink (issue #1392).
+    ///
+    /// `SSTableWriter::finish` collects this (before consuming the writer via
+    /// `finish_streaming`) and folds it into `SSTableInfo::created_dirs` so the
+    /// flush durability barrier fsyncs every newly created ancestor before the
+    /// WAL is truncated.
+    pub(crate) fn created_dirs(&self) -> &[PathBuf] {
+        &self.created_dirs
     }
 
     /// Number of bytes currently held in the per-entry scratch buffer.

--- a/cqlite-core/src/storage/sstable/writer/index_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/index_writer.rs
@@ -185,13 +185,6 @@ pub struct IndexWriter {
     position: u64,
     /// Entry count (for validation)
     entry_count: usize,
-    /// Ancestor directories this writer newly created when it lazily opened its
-    /// sink (issue #1392). Recorded here — the first `add_partition` may open the
-    /// Index.db sink before the Data.db sink, so this is one of the earliest
-    /// points the keyspace/table tree is materialized on a non-empty BIG flush.
-    /// `SSTableWriter::finish` folds it into `SSTableInfo::created_dirs` so the
-    /// flush durability barrier fsyncs the new ancestors before WAL truncate.
-    created_dirs: Vec<PathBuf>,
 }
 
 /// Information about a written index entry
@@ -227,7 +220,6 @@ impl IndexWriter {
             counting: false,
             position: 0,
             entry_count: 0,
-            created_dirs: Vec::new(),
         }
     }
 
@@ -264,7 +256,6 @@ impl IndexWriter {
             counting: true,
             position: 0,
             entry_count: 0,
-            created_dirs: Vec::new(),
         }
     }
 
@@ -284,7 +275,6 @@ impl IndexWriter {
             counting: false,
             position: 0,
             entry_count: 0,
-            created_dirs: Vec::new(),
         }
     }
 
@@ -297,15 +287,11 @@ impl IndexWriter {
         }
         if let Some(path) = self.index_path.clone() {
             if let Some(parent) = path.parent() {
-                // Record the newly created ancestor directories so the flush
-                // durability barrier fsyncs them before WAL truncate (issue
-                // #1392). `add_partition` can open this sink before the Data.db
-                // sink on a non-empty BIG flush, so recording only in
-                // `SSTableWriter::finish` (after the dirs already exist) would
-                // miss them and leave the ancestor dirents unsynced.
-                let created =
-                    crate::storage::write_engine::durability::create_dir_all_recording(parent)?;
-                self.created_dirs.extend(created);
+                // Create the keyspace/table tree. The flush durability barrier
+                // fsyncs the full leaf→data-root chain unconditionally before
+                // the WAL truncate, so this creation need not track which
+                // ancestors it made (issue #1392).
+                crate::storage::write_engine::durability::create_dir_all(parent)?;
             }
             let file = std::fs::File::create(&path)?;
             self.sink = Some(std::io::BufWriter::with_capacity(
@@ -539,17 +525,6 @@ impl IndexWriter {
     /// ```
     pub fn entry_count(&self) -> usize {
         self.entry_count
-    }
-
-    /// Ancestor directories this writer newly created when lazily opening its
-    /// Index.db sink (issue #1392).
-    ///
-    /// `SSTableWriter::finish` collects this (before consuming the writer via
-    /// `finish_streaming`) and folds it into `SSTableInfo::created_dirs` so the
-    /// flush durability barrier fsyncs every newly created ancestor before the
-    /// WAL is truncated.
-    pub(crate) fn created_dirs(&self) -> &[PathBuf] {
-        &self.created_dirs
     }
 
     /// Number of bytes currently held in the per-entry scratch buffer.

--- a/cqlite-core/src/storage/sstable/writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/mod.rs
@@ -193,6 +193,16 @@ pub struct SSTableInfo {
     pub partition_count: usize,
     /// Total size of Data.db file in bytes
     pub data_size: u64,
+    /// Directories that `finish()` newly created for this SSTable, shallowest
+    /// first (issue #1392).
+    ///
+    /// On the first flush into a brand-new keyspace/table path this includes
+    /// the keyspace and table directories in addition to the leaf. The flush
+    /// durability barrier fsyncs each of these ancestors' parents (deepest
+    /// first) before truncating the WAL so a crash cannot lose the newly
+    /// created directory tree. Empty on subsequent flushes where the directory
+    /// tree already existed.
+    pub created_dirs: Vec<PathBuf>,
 }
 
 /// SSTable writer coordinator
@@ -1451,6 +1461,84 @@ mod tests {
             .to_str()
             .unwrap()
             .contains("nb-1-big-Data.db"));
+    }
+
+    /// Issue #1392 (roborev r3): a NON-EMPTY first flush into a brand-new
+    /// keyspace/table path must report the newly created ancestor directories in
+    /// `SSTableInfo::created_dirs`, so the flush durability barrier can fsync them
+    /// (deepest-first) BEFORE truncating the WAL.
+    ///
+    /// This is the case that was silently broken: for a non-empty flush the
+    /// streaming `DataWriter`/`IndexWriter` create the keyspace/table tree in
+    /// `ensure_sink` during `write_partition` — BEFORE `finish` runs — so the
+    /// old finish-time `create_dir_all_recording` returned an EMPTY list and only
+    /// the leaf was fsynced, leaving the ancestor dirents unsynced (crash-loss
+    /// gap). RED before the fix (`created_dirs` empty → assertion fails); GREEN
+    /// after (the writers record at their first create point and finish folds it
+    /// in). The end-to-end handoff through `finalize_flush_durability` then
+    /// fsyncs those dirs and truncates the WAL.
+    #[tokio::test]
+    async fn nonempty_first_flush_records_and_fsyncs_ancestor_dirs_before_wal_truncate() {
+        use crate::storage::write_engine::durability::{
+            finalize_flush_durability, RealDurabilityBarrier,
+        };
+        use crate::storage::write_engine::wal::WriteAheadLog;
+
+        let root = TempDir::new().unwrap();
+        let data_dir = root.path();
+        let schema = create_test_schema();
+
+        // Brand-new nested SSTable dir: data_dir/test_ks/test_table (neither the
+        // keyspace nor the table directory exists yet). A non-empty flush creates
+        // this whole tree via the streaming writers' `ensure_sink`.
+        let ks_dir = data_dir.join("test_ks");
+        let leaf_dir = ks_dir.join("test_table");
+        assert!(!ks_dir.exists() && !leaf_dir.exists());
+
+        // A real WAL at the data_dir root, with an entry that must survive until
+        // the SSTable's dirents are durable.
+        let mut wal = WriteAheadLog::create(data_dir).unwrap();
+        let mutation = create_test_mutation("test_ks", "test_table", 1, "Alice", 1_000_000);
+        wal.append(&mutation).unwrap();
+        wal.sync().unwrap();
+
+        let mut writer = SSTableWriter::new(leaf_dir.clone(), 1, &schema).unwrap();
+        let key = mutation.decorated_key(&schema).unwrap();
+        writer.write_partition(key, vec![mutation]).unwrap();
+        let info = writer.finish().await.unwrap();
+
+        // The non-empty flush is what created these ancestors — they MUST be
+        // recorded (this list was silently empty before the fix).
+        assert!(info.data_size > 0, "flush must be non-empty");
+        assert!(
+            info.created_dirs.contains(&ks_dir),
+            "keyspace dir must be recorded as newly created: {:?}",
+            info.created_dirs
+        );
+        assert!(
+            info.created_dirs.contains(&leaf_dir),
+            "table (leaf) dir must be recorded as newly created: {:?}",
+            info.created_dirs
+        );
+
+        // End-to-end handoff: fsync the leaf + every new ancestor (deepest-first)
+        // then truncate the WAL. With the ancestors recorded, data_dir itself is
+        // reached (as the parent of ks_dir) and synced before the WAL is dropped.
+        finalize_flush_durability(
+            &RealDurabilityBarrier,
+            &info.data_path,
+            data_dir,
+            &info.created_dirs,
+            &mut wal,
+        )
+        .unwrap();
+
+        // The WAL truncate ran only after the dir fsyncs succeeded.
+        assert_eq!(
+            wal.replay().unwrap().mutations.len(),
+            0,
+            "WAL must be truncated after the ancestor dirs are fsynced"
+        );
     }
 
     /// Issue #852: a table with `bloom_filter_fp_chance = 1.0` disables the

--- a/cqlite-core/src/storage/sstable/writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/mod.rs
@@ -193,16 +193,6 @@ pub struct SSTableInfo {
     pub partition_count: usize,
     /// Total size of Data.db file in bytes
     pub data_size: u64,
-    /// Directories that `finish()` newly created for this SSTable, shallowest
-    /// first (issue #1392).
-    ///
-    /// On the first flush into a brand-new keyspace/table path this includes
-    /// the keyspace and table directories in addition to the leaf. The flush
-    /// durability barrier fsyncs each of these ancestors' parents (deepest
-    /// first) before truncating the WAL so a crash cannot lose the newly
-    /// created directory tree. Empty on subsequent flushes where the directory
-    /// tree already existed.
-    pub created_dirs: Vec<PathBuf>,
 }
 
 /// SSTable writer coordinator
@@ -1463,22 +1453,17 @@ mod tests {
             .contains("nb-1-big-Data.db"));
     }
 
-    /// Issue #1392 (roborev r3): a NON-EMPTY first flush into a brand-new
-    /// keyspace/table path must report the newly created ancestor directories in
-    /// `SSTableInfo::created_dirs`, so the flush durability barrier can fsync them
-    /// (deepest-first) BEFORE truncating the WAL.
+    /// Issue #1392: a NON-EMPTY first flush into a brand-new keyspace/table path
+    /// must have its full leaf→data-root ancestor chain fsynced by the flush
+    /// durability barrier BEFORE the WAL is truncated, so a crash cannot lose the
+    /// freshly created directory tree.
     ///
-    /// This is the case that was silently broken: for a non-empty flush the
-    /// streaming `DataWriter`/`IndexWriter` create the keyspace/table tree in
-    /// `ensure_sink` during `write_partition` — BEFORE `finish` runs — so the
-    /// old finish-time `create_dir_all_recording` returned an EMPTY list and only
-    /// the leaf was fsynced, leaving the ancestor dirents unsynced (crash-loss
-    /// gap). RED before the fix (`created_dirs` empty → assertion fails); GREEN
-    /// after (the writers record at their first create point and finish folds it
-    /// in). The end-to-end handoff through `finalize_flush_durability` then
-    /// fsyncs those dirs and truncates the WAL.
+    /// The end-to-end handoff through `finalize_flush_durability` fsyncs the leaf
+    /// SSTable dir, its parents up to the data root, and only THEN truncates the
+    /// WAL — regardless of which attempt created the directories (roborev r6:
+    /// the full chain is synced unconditionally).
     #[tokio::test]
-    async fn nonempty_first_flush_records_and_fsyncs_ancestor_dirs_before_wal_truncate() {
+    async fn nonempty_first_flush_fsyncs_ancestor_dirs_before_wal_truncate() {
         use crate::storage::write_engine::durability::{
             finalize_flush_durability, RealDurabilityBarrier,
         };
@@ -1507,31 +1492,15 @@ mod tests {
         writer.write_partition(key, vec![mutation]).unwrap();
         let info = writer.finish().await.unwrap();
 
-        // The non-empty flush is what created these ancestors — they MUST be
-        // recorded (this list was silently empty before the fix).
+        // The non-empty flush created the whole tree; the barrier fsyncs the
+        // full leaf→data-root chain before dropping the WAL copy.
         assert!(info.data_size > 0, "flush must be non-empty");
-        assert!(
-            info.created_dirs.contains(&ks_dir),
-            "keyspace dir must be recorded as newly created: {:?}",
-            info.created_dirs
-        );
-        assert!(
-            info.created_dirs.contains(&leaf_dir),
-            "table (leaf) dir must be recorded as newly created: {:?}",
-            info.created_dirs
-        );
+        assert!(ks_dir.is_dir() && leaf_dir.is_dir());
 
-        // End-to-end handoff: fsync the leaf + every new ancestor (deepest-first)
-        // then truncate the WAL. With the ancestors recorded, data_dir itself is
-        // reached (as the parent of ks_dir) and synced before the WAL is dropped.
-        finalize_flush_durability(
-            &RealDurabilityBarrier,
-            &info.data_path,
-            data_dir,
-            &info.created_dirs,
-            &mut wal,
-        )
-        .unwrap();
+        // End-to-end handoff: fsync the leaf + every ancestor up to the data
+        // root (deepest-first) then truncate the WAL.
+        finalize_flush_durability(&RealDurabilityBarrier, &info.data_path, data_dir, &mut wal)
+            .unwrap();
 
         // The WAL truncate ran only after the dir fsyncs succeeded.
         assert_eq!(

--- a/cqlite-core/src/storage/write_engine/durability.rs
+++ b/cqlite-core/src/storage/write_engine/durability.rs
@@ -1,0 +1,638 @@
+//! Crash-durability barrier for the flush -> WAL-truncate handoff (issue #1392).
+//!
+//! When a memtable flush finishes, the same data lives in two places: the newly
+//! written SSTable components on disk and the still-intact WAL. Truncating the
+//! WAL discards the WAL copy, so it is only safe *after* the SSTable is truly
+//! durable.
+//!
+//! Fsyncing each component file (Data.db, Filter.db, ...) persists the file
+//! *contents*, but on POSIX filesystems it does **not** persist the parent
+//! directory's entries. After a power loss the freshly created dirents can be
+//! missing even though the file contents were flushed — leaving the data in
+//! neither a reachable SSTable nor the (already truncated) WAL.
+//!
+//! This module closes that gap: it fsyncs the SSTable's parent directory
+//! *after* the component files are synced and *before* the WAL is truncated,
+//! and it makes the truncate-failure path explicit (leave the WAL intact as a
+//! durable replay marker) rather than silently swallowing the error.
+//!
+//! The [`DurabilityBarrier`] trait is a test seam: production uses
+//! [`RealDurabilityBarrier`], while tests inject fakes that record the ordering
+//! of filesystem operations or fault a specific step.
+
+use crate::error::{Error, Result};
+use crate::storage::write_engine::wal::{TruncateError, WriteAheadLog};
+use std::path::{Path, PathBuf};
+
+/// Outcome of a successful [`finalize_flush_durability`] call.
+///
+/// In every variant the SSTable has already been fully written and published
+/// (its components' contents are fsynced and its directory entries persisted).
+/// The variant tells the caller how to reconcile flush state (issue #1392):
+///
+/// * [`FlushDurabilityOutcome::Durable`] — the WAL was truncated, or was left
+///   intact but is still a valid replay marker. The flush is clean; the caller
+///   commits state (clears the memtable, advances the generation) and returns
+///   success.
+/// * [`FlushDurabilityOutcome::WalTruncateFailedAfterCommit`] — the WAL truncate
+///   failed *after* `set_len(0)` had already zeroed the WAL. The WAL is no
+///   longer replayable, so the published SSTable is the **only** durable copy
+///   of the flushed mutations. The caller MUST still commit flush state (clear
+///   the memtable and advance the generation) so a retry writes a NEW
+///   generation instead of overwriting the published SSTable, and then surface
+///   the carried error. Returning the error *without* committing state would
+///   let a retry reuse this generation and `File::create` would overwrite the
+///   sole durable copy — a crash mid-retry would then lose the data entirely.
+#[derive(Debug)]
+pub(crate) enum FlushDurabilityOutcome {
+    /// The handoff completed cleanly; the WAL is truncated or still replayable.
+    Durable,
+    /// The SSTable is durably published but the WAL truncate failed after
+    /// zeroing the WAL. State MUST be committed before the error is surfaced.
+    WalTruncateFailedAfterCommit(Error),
+}
+
+/// Seam over the two durability-critical operations performed at the end of a
+/// flush. Splitting them behind a trait lets tests assert their ordering and
+/// inject faults without touching the real filesystem.
+pub(crate) trait DurabilityBarrier {
+    /// Fsync `dir` so that directory entries created during the flush (the new
+    /// SSTable's component files) are persisted.
+    fn sync_dir(&self, dir: &Path) -> Result<()>;
+
+    /// Truncate the WAL now that the SSTable is durable.
+    ///
+    /// Returns [`TruncateError`] on failure so the caller can distinguish a
+    /// failure that leaves the WAL intact ([`TruncateError::BeforeMutation`])
+    /// from one that has already zeroed it
+    /// ([`TruncateError::AfterMutation`], issue #1392).
+    fn truncate_wal(&self, wal: &mut WriteAheadLog) -> std::result::Result<(), TruncateError>;
+}
+
+/// Production barrier: performs real directory fsyncs and WAL truncation.
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct RealDurabilityBarrier;
+
+impl DurabilityBarrier for RealDurabilityBarrier {
+    fn sync_dir(&self, dir: &Path) -> Result<()> {
+        sync_directory(dir)
+    }
+
+    fn truncate_wal(&self, wal: &mut WriteAheadLog) -> std::result::Result<(), TruncateError> {
+        wal.truncate_checked()
+    }
+}
+
+/// Make a directory's entries durable.
+///
+/// On Unix this opens the directory and calls `fsync` on the resulting
+/// descriptor, which is the portable POSIX way to persist newly created
+/// dirents. On non-Unix targets directory fsync is not available the same way;
+/// the per-file fsyncs performed by the component writers remain the durability
+/// guarantee there, so this is a documented no-op.
+#[cfg(unix)]
+fn sync_directory(dir: &Path) -> Result<()> {
+    let handle = std::fs::File::open(dir).map_err(|e| {
+        Error::Storage(format!(
+            "Failed to open data directory {} for fsync: {e}",
+            dir.display()
+        ))
+    })?;
+    handle.sync_all().map_err(|e| {
+        Error::Storage(format!(
+            "Failed to fsync data directory {}: {e}",
+            dir.display()
+        ))
+    })
+}
+
+#[cfg(not(unix))]
+fn sync_directory(_dir: &Path) -> Result<()> {
+    Ok(())
+}
+
+/// Like [`std::fs::create_dir_all`], but records which directories it actually
+/// created (issue #1392).
+///
+/// On the FIRST flush for a keyspace/table, `create_dir_all` materializes the
+/// keyspace and table ancestor directories as well as the leaf SSTable
+/// directory. Fsyncing only the leaf persists the *component* dirents but NOT
+/// the leaf directory's own entry in its parent (nor the parent's entry in ITS
+/// parent) — a crash after the WAL is truncated could then lose the entire
+/// newly created SSTable directory tree. To close that gap the caller must
+/// fsync every directory whose contents changed; this helper returns the set of
+/// newly created directories (shallowest first, mirroring the top-down creation
+/// order) so the caller knows which ancestors need syncing.
+///
+/// The returned vector contains only directories this call created; already
+/// existing directories are not included (their dirents were already durable).
+pub(crate) fn create_dir_all_recording(path: &Path) -> Result<Vec<PathBuf>> {
+    let mut created = Vec::new();
+    create_dir_all_inner(path, &mut created)?;
+    Ok(created)
+}
+
+fn create_dir_all_inner(path: &Path, created: &mut Vec<PathBuf>) -> Result<()> {
+    if path.as_os_str().is_empty() {
+        return Ok(());
+    }
+    match std::fs::create_dir(path) {
+        Ok(()) => {
+            created.push(path.to_path_buf());
+            Ok(())
+        }
+        // Raced/pre-existing: another actor already made it, or it existed.
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists && path.is_dir() => Ok(()),
+        // Parent missing: create ancestors first (recording them), then retry.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            match path.parent() {
+                Some(parent) if !parent.as_os_str().is_empty() => {
+                    create_dir_all_inner(parent, created)?;
+                }
+                _ => {
+                    return Err(Error::Storage(format!(
+                        "Failed to create directory {}: {e}",
+                        path.display()
+                    )));
+                }
+            }
+            match std::fs::create_dir(path) {
+                Ok(()) => {
+                    created.push(path.to_path_buf());
+                    Ok(())
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists && path.is_dir() => Ok(()),
+                Err(e) => Err(Error::Storage(format!(
+                    "Failed to create directory {}: {e}",
+                    path.display()
+                ))),
+            }
+        }
+        Err(e) => Err(Error::Storage(format!(
+            "Failed to create directory {}: {e}",
+            path.display()
+        ))),
+    }
+}
+
+/// Compute the ordered, de-duplicated list of directories to fsync so that
+/// every dirent created during a flush is persisted before the WAL is
+/// truncated (issue #1392).
+///
+/// The set is:
+/// * the leaf SSTable directory (its new component dirents live here), plus
+/// * the *parent* of every newly created directory (so that directory's own
+///   entry in its parent is persisted).
+///
+/// The result is ordered deepest-first so each child directory is synced before
+/// its parent — matching the POSIX convention that a parent's fsync only needs
+/// to follow the creation (and here the sync) of the child it references.
+fn dirs_to_sync(leaf: &Path, created_dirs: &[PathBuf]) -> Vec<PathBuf> {
+    let mut dirs: Vec<PathBuf> = vec![leaf.to_path_buf()];
+    for created in created_dirs {
+        if let Some(parent) = created.parent() {
+            let parent = parent.to_path_buf();
+            if !parent.as_os_str().is_empty() && !dirs.contains(&parent) {
+                dirs.push(parent);
+            }
+        }
+    }
+    // Deepest first: a directory's own entry lives in its parent, so we persist
+    // children before parents.
+    dirs.sort_by_key(|d| std::cmp::Reverse(d.components().count()));
+    dirs
+}
+
+/// Complete the durability handoff at the end of a flush.
+///
+/// `data_path` is the SSTable's Data.db path; its parent directory is fsynced
+/// (falling back to `data_dir` if `data_path` has no parent). Ordering is
+/// load-bearing (issue #1392):
+///
+/// 1. fsync the SSTable's directory **and every newly created ancestor
+///    directory** so all new directory entries are durable.
+/// 2. Only then truncate the WAL — the WAL copy of the data is discarded here.
+///
+/// `created_dirs` is the set of directories that `create_dir_all` actually
+/// created for this flush (see [`create_dir_all_recording`]). On the first
+/// flush into a brand-new keyspace/table path this includes the keyspace and
+/// table directories; fsyncing only the leaf would persist the component
+/// dirents but leave the leaf's (and keyspace's) own entry in its parent
+/// unsynced, so a crash after the WAL truncate could lose the entire new
+/// SSTable directory. We therefore fsync the leaf plus the parent of every
+/// newly created directory, deepest-first, before truncating the WAL.
+///
+/// If any directory fsync fails, the error is propagated and the WAL is
+/// **not** truncated, so recovery can still replay from the WAL.
+///
+/// The WAL truncate is phase-aware (issue #1392):
+///
+/// * [`TruncateError::BeforeMutation`] — the truncate failed without touching
+///   the WAL contents, so the WAL is still intact. The error is surfaced as a
+///   warning and the WAL is deliberately left in place: it remains a durable
+///   replay marker, and replay is idempotent (identical mutations reconcile by
+///   last-write-wins timestamp), so this degrades to a redundant re-flush
+///   rather than data loss.
+/// * [`TruncateError::AfterMutation`] — the truncate failed *after* `set_len(0)`
+///   already zeroed the WAL. The WAL is **no longer** a replayable marker, so
+///   this returns [`FlushDurabilityOutcome::WalTruncateFailedAfterCommit`]
+///   carrying the error. The published SSTable is now the ONLY durable copy of
+///   the flushed data, so the caller must treat the flush as COMMITTED for
+///   state purposes (clear the memtable and advance the generation) BEFORE
+///   surfacing the error — otherwise a retry would reuse this generation and
+///   `File::create` would overwrite the sole durable copy, losing data on a
+///   crash mid-retry (issue #1392).
+///
+/// Every emitted SSTable component's *contents* must already be fsynced by the
+/// component writers (see [`crate::storage::sstable::writer::SSTableWriter::finish`])
+/// before this function runs. Ordering is load-bearing: component-content
+/// fsyncs (inside `writer.finish()`) happen first, then this function fsyncs
+/// the directory, then it truncates the WAL.
+pub(crate) fn finalize_flush_durability(
+    barrier: &dyn DurabilityBarrier,
+    data_path: &Path,
+    data_dir: &Path,
+    created_dirs: &[PathBuf],
+    wal: &mut WriteAheadLog,
+) -> Result<FlushDurabilityOutcome> {
+    // Step 1: persist the new SSTable's dirents BEFORE dropping the WAL copy.
+    // (The component *contents* were already fsynced inside `writer.finish()`.)
+    // This fsyncs the leaf SSTable directory AND the parent of every ancestor
+    // directory created during this flush, deepest-first, so the whole newly
+    // created directory tree is durable — not just the leaf (issue #1392).
+    let sstable_dir = data_path.parent().unwrap_or(data_dir);
+    for dir in dirs_to_sync(sstable_dir, created_dirs) {
+        barrier.sync_dir(&dir)?;
+    }
+
+    // Step 2: it is now durable-safe to truncate the WAL.
+    match barrier.truncate_wal(wal) {
+        Ok(()) => Ok(FlushDurabilityOutcome::Durable),
+        Err(TruncateError::BeforeMutation(e)) => {
+            // The WAL was never mutated; it is still a valid replay marker.
+            log::warn!(
+                "WAL truncate failed before mutating the WAL ({e}). Leaving the \
+                 WAL intact as a durable replay marker; the next startup will \
+                 replay it idempotently (last-write-wins), so no data is lost."
+            );
+            Ok(FlushDurabilityOutcome::Durable)
+        }
+        Err(TruncateError::AfterMutation(e)) => {
+            // The WAL was already zeroed by set_len(0) before the failure, so it
+            // is NO LONGER a replayable marker. The published SSTable is now the
+            // ONLY durable copy of these mutations. Report the flush as COMMITTED
+            // (carrying the error) so the caller advances the generation and
+            // clears the memtable BEFORE surfacing the failure — a retry must
+            // write a NEW generation rather than overwrite the published SSTable
+            // (which `File::create` would do at the reused generation), which
+            // would lose the data on a crash mid-retry (issue #1392).
+            Ok(FlushDurabilityOutcome::WalTruncateFailedAfterCommit(
+                Error::Storage(format!(
+                    "WAL truncate failed AFTER zeroing the WAL ({e}); the WAL is \
+                     no longer a replayable recovery marker. The flushed SSTable \
+                     is durable and the generation has been advanced so a retry \
+                     will not overwrite it."
+                )),
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::write_engine::mutation::{CellOperation, Mutation, PartitionKey, TableId};
+    use crate::types::Value;
+    use std::cell::RefCell;
+    use tempfile::TempDir;
+
+    /// A single durability-relevant filesystem operation, recorded by the test
+    /// seam to assert ordering (the directory fsync MUST precede the WAL
+    /// truncate).
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    enum FsOp {
+        /// fsync of a directory whose dirents changed during the flush (the leaf
+        /// SSTable directory and/or a newly created ancestor). Carries the path
+        /// so tests can assert *which* directories were synced and in what order.
+        SyncDir(PathBuf),
+        /// Truncation of the WAL to zero length.
+        WalTruncate,
+    }
+
+    fn test_mutation(id: i32, name: &str) -> Mutation {
+        let table_id = TableId::new("test_ks", "test_table");
+        let pk = PartitionKey::single("id", Value::Integer(id));
+        let ops = vec![CellOperation::Write {
+            column: "name".to_string(),
+            value: Value::Text(name.to_string()),
+        }];
+        Mutation::new(table_id, pk, None, ops, 1234567890, None)
+    }
+
+    /// Records the order of operations; `sync_dir` optionally faults.
+    struct RecordingBarrier {
+        ops: RefCell<Vec<FsOp>>,
+        fail_dir_sync: bool,
+        /// Fault the truncate BEFORE mutating the WAL (WAL stays intact).
+        fail_truncate_before_mutation: bool,
+        /// Fault the truncate AFTER `set_len(0)` has already zeroed the WAL.
+        fail_truncate_after_mutation: bool,
+    }
+
+    impl RecordingBarrier {
+        fn new() -> Self {
+            Self {
+                ops: RefCell::new(Vec::new()),
+                fail_dir_sync: false,
+                fail_truncate_before_mutation: false,
+                fail_truncate_after_mutation: false,
+            }
+        }
+    }
+
+    impl DurabilityBarrier for RecordingBarrier {
+        fn sync_dir(&self, dir: &Path) -> Result<()> {
+            if self.fail_dir_sync {
+                return Err(Error::Storage("injected dir fsync fault".to_string()));
+            }
+            self.ops.borrow_mut().push(FsOp::SyncDir(dir.to_path_buf()));
+            Ok(())
+        }
+
+        fn truncate_wal(&self, wal: &mut WriteAheadLog) -> std::result::Result<(), TruncateError> {
+            if self.fail_truncate_before_mutation {
+                // WAL contents untouched.
+                return Err(TruncateError::BeforeMutation(Error::Storage(
+                    "injected pre-mutation truncate fault".to_string(),
+                )));
+            }
+            if self.fail_truncate_after_mutation {
+                // Model a failure that occurs AFTER set_len(0): actually zero the
+                // WAL (mutating it), then report an after-mutation fault. The WAL
+                // is now empty and is no longer a replayable marker.
+                wal.truncate().map_err(TruncateError::AfterMutation)?;
+                return Err(TruncateError::AfterMutation(Error::Storage(
+                    "injected post-set_len truncate fault".to_string(),
+                )));
+            }
+            self.ops.borrow_mut().push(FsOp::WalTruncate);
+            wal.truncate().map_err(TruncateError::BeforeMutation)
+        }
+    }
+
+    // Criterion 1: directory fsync happens BEFORE the WAL truncate.
+    #[test]
+    fn dir_fsync_precedes_wal_truncate() {
+        let dir = TempDir::new().unwrap();
+        let mut wal = WriteAheadLog::create(dir.path()).unwrap();
+        wal.append(&test_mutation(1, "Alice")).unwrap();
+        wal.sync().unwrap();
+
+        let barrier = RecordingBarrier::new();
+        let outcome = finalize_flush_durability(
+            &barrier,
+            &dir.path().join("nb-1-big-Data.db"),
+            dir.path(),
+            &[],
+            &mut wal,
+        )
+        .unwrap();
+        assert!(matches!(outcome, FlushDurabilityOutcome::Durable));
+
+        assert_eq!(
+            barrier.ops.into_inner(),
+            vec![FsOp::SyncDir(dir.path().to_path_buf()), FsOp::WalTruncate],
+            "directory fsync must be recorded before the WAL truncate"
+        );
+        // Truncate succeeded: WAL is now empty.
+        assert_eq!(wal.replay().unwrap().mutations.len(), 0);
+    }
+
+    // Criterion 3: a faulted directory fsync leaves the WAL untruncated.
+    #[test]
+    fn faulted_dir_fsync_leaves_wal_intact() {
+        let dir = TempDir::new().unwrap();
+        let mut wal = WriteAheadLog::create(dir.path()).unwrap();
+        wal.append(&test_mutation(7, "Bob")).unwrap();
+        wal.sync().unwrap();
+
+        let mut barrier = RecordingBarrier::new();
+        barrier.fail_dir_sync = true;
+
+        let err = finalize_flush_durability(
+            &barrier,
+            &dir.path().join("nb-1-big-Data.db"),
+            dir.path(),
+            &[],
+            &mut wal,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, Error::Storage(_)),
+            "faulted dir fsync must surface as an error"
+        );
+        // The WAL was never touched: the truncate op was not recorded and the
+        // entry is still replayable.
+        assert!(barrier.ops.into_inner().is_empty());
+        let replayed = wal.replay().unwrap().mutations;
+        assert_eq!(
+            replayed.len(),
+            1,
+            "WAL must remain untruncated on dir-fsync fault"
+        );
+    }
+
+    // Criterion 2: a faulted WAL truncate does not fail the flush, leaves the
+    // WAL intact as a durable replay marker, and the entry is still replayable
+    // (idempotent recovery, not loss).
+    #[test]
+    fn faulted_truncate_leaves_replayable_wal() {
+        let dir = TempDir::new().unwrap();
+        let mut wal = WriteAheadLog::create(dir.path()).unwrap();
+        wal.append(&test_mutation(9, "Carol")).unwrap();
+        wal.sync().unwrap();
+
+        let mut barrier = RecordingBarrier::new();
+        barrier.fail_truncate_before_mutation = true;
+
+        // The flush-finalize does NOT fail even though truncate faulted.
+        let outcome = finalize_flush_durability(
+            &barrier,
+            &dir.path().join("nb-1-big-Data.db"),
+            dir.path(),
+            &[],
+            &mut wal,
+        )
+        .expect("truncate fault must not fail the flush");
+        assert!(
+            matches!(outcome, FlushDurabilityOutcome::Durable),
+            "a before-mutation truncate fault leaves a replayable WAL: still Durable"
+        );
+
+        // The dir was synced but the truncate never zeroed the WAL.
+        assert_eq!(
+            barrier.ops.into_inner(),
+            vec![FsOp::SyncDir(dir.path().to_path_buf())]
+        );
+
+        // Recovery: the mutation is still in the WAL and replays idempotently.
+        let replayed = wal.replay().unwrap().mutations;
+        assert_eq!(
+            replayed.len(),
+            1,
+            "failed truncate must leave the WAL intact for replay, not lose data"
+        );
+        assert_eq!(replayed[0].table.keyspace, "test_ks");
+    }
+
+    // Issue #1392: a WAL truncate that fails AFTER `set_len(0)` has already
+    // zeroed the WAL must NOT be swallowed as "WAL intact". The WAL is no longer
+    // a replayable marker, so finalize returns
+    // `WalTruncateFailedAfterCommit(err)` — the SSTable is committed (so the
+    // caller advances the generation and clears the memtable) but the error is
+    // carried so it is still surfaced to the caller.
+    #[test]
+    fn faulted_truncate_after_mutation_reports_committed_with_error() {
+        let dir = TempDir::new().unwrap();
+        let mut wal = WriteAheadLog::create(dir.path()).unwrap();
+        wal.append(&test_mutation(11, "Dave")).unwrap();
+        wal.sync().unwrap();
+
+        let mut barrier = RecordingBarrier::new();
+        barrier.fail_truncate_after_mutation = true;
+
+        let outcome = finalize_flush_durability(
+            &barrier,
+            &dir.path().join("nb-1-big-Data.db"),
+            dir.path(),
+            &[],
+            &mut wal,
+        )
+        .expect("a post-mutation truncate failure is COMMITTED, not a hard error");
+        let err = match outcome {
+            FlushDurabilityOutcome::WalTruncateFailedAfterCommit(e) => e,
+            FlushDurabilityOutcome::Durable => {
+                panic!("post-mutation truncate failure must not report Durable")
+            }
+        };
+        assert!(
+            matches!(err, Error::Storage(msg) if msg.contains("no longer a replayable recovery marker")),
+            "post-mutation truncate failure must carry a storage error"
+        );
+
+        // The dir was synced (recorded); the WAL was mutated (zeroed) so it is
+        // NOT a replay marker anymore — this is precisely why the error must be
+        // propagated rather than swallowed.
+        assert_eq!(
+            barrier.ops.into_inner(),
+            vec![FsOp::SyncDir(dir.path().to_path_buf())]
+        );
+        let replayed = wal.replay().unwrap().mutations;
+        assert_eq!(
+            replayed.len(),
+            0,
+            "the WAL was zeroed by set_len(0); it is no longer replayable, which \
+             is why finalize must NOT report success"
+        );
+    }
+
+    // The production barrier really fsyncs an existing directory without error.
+    #[test]
+    fn real_barrier_syncs_existing_directory() {
+        let dir = TempDir::new().unwrap();
+        let mut wal = WriteAheadLog::create(dir.path()).unwrap();
+        wal.append(&test_mutation(1, "Alice")).unwrap();
+        wal.sync().unwrap();
+
+        finalize_flush_durability(
+            &RealDurabilityBarrier,
+            &dir.path().join("nb-1-big-Data.db"),
+            dir.path(),
+            &[],
+            &mut wal,
+        )
+        .unwrap();
+        assert_eq!(wal.replay().unwrap().mutations.len(), 0);
+    }
+
+    // Issue #1392 (FINDING 1): on the FIRST flush into a brand-new
+    // keyspace/table path, `create_dir_all` materializes the keyspace and table
+    // ancestor directories. The barrier must fsync the leaf AND every newly
+    // created ancestor's parent — deepest first — BEFORE the WAL truncate, so a
+    // crash cannot lose the freshly created directory tree.
+    #[test]
+    fn first_flush_fsyncs_new_ancestor_dirs_before_truncate() {
+        let root = TempDir::new().unwrap();
+        let data_dir = root.path();
+        // WAL lives at the data_dir root (as in a real engine layout).
+        let mut wal = WriteAheadLog::create(data_dir).unwrap();
+        wal.append(&test_mutation(1, "Alice")).unwrap();
+        wal.sync().unwrap();
+
+        // Leaf SSTable dir: data_dir/test_ks/test_table (both ancestors new).
+        let ks_dir = data_dir.join("test_ks");
+        let leaf_dir = ks_dir.join("test_table");
+        let data_path = leaf_dir.join("nb-1-big-Data.db");
+        // Mirror what `create_dir_all_recording` would report on a first flush:
+        // shallowest-first, keyspace then table.
+        let created_dirs = vec![ks_dir.clone(), leaf_dir.clone()];
+
+        let barrier = RecordingBarrier::new();
+        finalize_flush_durability(&barrier, &data_path, data_dir, &created_dirs, &mut wal).unwrap();
+
+        // Expected: fsync the leaf (its component dirents), then the keyspace dir
+        // (persists the leaf's own entry), then the data_dir (persists the
+        // keyspace's own entry) — deepest-first — and only THEN truncate the WAL.
+        assert_eq!(
+            barrier.ops.into_inner(),
+            vec![
+                FsOp::SyncDir(leaf_dir),
+                FsOp::SyncDir(ks_dir),
+                FsOp::SyncDir(data_dir.to_path_buf()),
+                FsOp::WalTruncate,
+            ],
+            "every newly created ancestor dir must be fsynced (deepest first) \
+             before the WAL truncate"
+        );
+        assert_eq!(wal.replay().unwrap().mutations.len(), 0);
+    }
+
+    // Issue #1392 (FINDING 1): `create_dir_all_recording` reports exactly the
+    // directories it created (shallowest first) and nothing that already existed.
+    #[test]
+    fn create_dir_all_recording_reports_only_new_dirs() {
+        let root = TempDir::new().unwrap();
+        let ks = root.path().join("ks");
+        let tbl = ks.join("tbl");
+
+        // First creation records both new ancestors, shallowest first.
+        let created = create_dir_all_recording(&tbl).unwrap();
+        assert_eq!(created, vec![ks.clone(), tbl.clone()]);
+
+        // Re-creating an existing tree records nothing.
+        let created_again = create_dir_all_recording(&tbl).unwrap();
+        assert!(
+            created_again.is_empty(),
+            "existing directories must not be reported as newly created"
+        );
+
+        // A new leaf under an existing parent records only the leaf.
+        let tbl2 = ks.join("tbl2");
+        let created_leaf = create_dir_all_recording(&tbl2).unwrap();
+        assert_eq!(created_leaf, vec![tbl2]);
+    }
+
+    // Issue #1392 (FINDING 1): `dirs_to_sync` yields the leaf plus each newly
+    // created dir's parent, de-duplicated and ordered deepest-first.
+    #[test]
+    fn dirs_to_sync_is_deepest_first_and_deduped() {
+        let root = TempDir::new().unwrap();
+        let data_dir = root.path().to_path_buf();
+        let ks = data_dir.join("ks");
+        let leaf = ks.join("tbl");
+        let created = vec![ks.clone(), leaf.clone()];
+
+        let dirs = dirs_to_sync(&leaf, &created);
+        assert_eq!(dirs, vec![leaf, ks, data_dir]);
+    }
+}

--- a/cqlite-core/src/storage/write_engine/durability.rs
+++ b/cqlite-core/src/storage/write_engine/durability.rs
@@ -233,6 +233,14 @@ fn dirs_to_sync(leaf: &Path, data_root: &Path) -> Vec<PathBuf> {
 /// If any directory fsync fails, the error is propagated and the WAL is
 /// **not** truncated, so recovery can still replay from the WAL.
 ///
+/// When the WAL is already empty (`wal.size() == 0`) — e.g. a flush under
+/// `Durability::Disabled` or any flush whose mutations were never WAL'd — the
+/// truncate phase is skipped entirely and [`FlushDurabilityOutcome::Durable`]
+/// is returned (issue #1392). There is no recovery marker to preserve or
+/// destroy, so entering the truncate phase would only risk a spurious
+/// after-commit error on an already-durable flush. The directory-sync barrier
+/// above still runs unconditionally.
+///
 /// The WAL truncate is phase-aware (issue #1392):
 ///
 /// * [`TruncateError::BeforeMutation`] — the truncate failed without touching
@@ -275,6 +283,19 @@ pub(crate) fn finalize_flush_durability(
     }
 
     // Step 2: it is now durable-safe to truncate the WAL.
+    //
+    // Skip the truncate phase entirely when the WAL is already empty (issue
+    // #1392): a flush under `Durability::Disabled`, or any flush whose
+    // mutations were never WAL'd, has nothing to truncate — there is no
+    // recovery marker to preserve or destroy. Entering the truncate phase
+    // anyway would let a post-`set_len(0)` seek/sync fault surface as a
+    // spurious `WalTruncateFailedAfterCommit` on a flush that is already fully
+    // durable in the published SSTable. The directory-sync barrier above still
+    // runs unconditionally, so the durability guarantee is unchanged.
+    if wal.size() == 0 {
+        return Ok(FlushDurabilityOutcome::Durable);
+    }
+
     match barrier.truncate_wal(wal) {
         Ok(()) => Ok(FlushDurabilityOutcome::Durable),
         Err(TruncateError::BeforeMutation(e)) => {
@@ -538,6 +559,46 @@ mod tests {
             0,
             "the WAL was zeroed by set_len(0); it is no longer replayable, which \
              is why finalize must NOT report success"
+        );
+    }
+
+    // Issue #1392 (roborev LOW, FINDING 1): a flush whose WAL is already empty
+    // (e.g. `Durability::Disabled`, or any flush whose mutations were never
+    // WAL'd) must SKIP the WAL truncate phase entirely. The directory-sync
+    // barrier still runs, but `truncate_wal` is never invoked — so a
+    // truncate-phase fault cannot turn an already-durable flush into a spurious
+    // `WalTruncateFailedAfterCommit` error.
+    #[test]
+    fn empty_wal_skips_truncate_phase() {
+        let dir = TempDir::new().unwrap();
+        // A freshly created WAL with nothing appended has size 0.
+        let mut wal = WriteAheadLog::create(dir.path()).unwrap();
+        assert_eq!(wal.size(), 0, "a fresh, unwritten WAL must have size 0");
+
+        // Arm the truncate to fault AFTER mutating the WAL: if the truncate
+        // phase were entered at all, this would surface as
+        // `WalTruncateFailedAfterCommit`. Skipping the phase must avoid it.
+        let mut barrier = RecordingBarrier::new();
+        barrier.fail_truncate_after_mutation = true;
+
+        let outcome = finalize_flush_durability(
+            &barrier,
+            &dir.path().join("nb-1-big-Data.db"),
+            dir.path(),
+            &mut wal,
+        )
+        .expect("an empty-WAL flush must not enter the truncate phase");
+        assert!(
+            matches!(outcome, FlushDurabilityOutcome::Durable),
+            "empty WAL: the truncate phase is skipped, so the flush stays Durable"
+        );
+
+        // The directory was still synced, but the WAL truncate was never
+        // attempted (no WalTruncate op recorded and the armed fault never fired).
+        assert_eq!(
+            barrier.ops.into_inner(),
+            vec![FsOp::SyncDir(dir.path().to_path_buf())],
+            "dir fsync still runs; the truncate phase is skipped for an empty WAL"
         );
     }
 

--- a/cqlite-core/src/storage/write_engine/durability.rs
+++ b/cqlite-core/src/storage/write_engine/durability.rs
@@ -11,10 +11,22 @@
 //! missing even though the file contents were flushed — leaving the data in
 //! neither a reachable SSTable nor the (already truncated) WAL.
 //!
-//! This module closes that gap: it fsyncs the SSTable's parent directory
-//! *after* the component files are synced and *before* the WAL is truncated,
-//! and it makes the truncate-failure path explicit (leave the WAL intact as a
-//! durable replay marker) rather than silently swallowing the error.
+//! This module closes that gap: on every WAL-truncating flush it fsyncs the
+//! **full ancestor chain** from the SSTable's leaf directory up to (and
+//! including) the configured data root, deepest-first, *after* the component
+//! files are synced and *before* the WAL is truncated. It also makes the
+//! truncate-failure path explicit (leave the WAL intact as a durable replay
+//! marker) rather than silently swallowing the error.
+//!
+//! Syncing the whole leaf→data-root chain unconditionally — rather than only
+//! the directories a *given* flush attempt happened to create — closes a
+//! retry/partial-failure hazard (issue #1392): if an earlier attempt created
+//! `data_dir/ks/table` but crashed before its full directory-sync chain
+//! completed, the retry sees those dirs already present, so a
+//! "sync-only-what-I-created" barrier would sync just the leaf and truncate the
+//! WAL while the keyspace/table dirents were still not durable. Directory fsync
+//! is cheap and idempotent, so re-syncing an already-durable dir is harmless
+//! and removes the hazard entirely.
 //!
 //! The [`DurabilityBarrier`] trait is a test seam: production uses
 //! [`RealDurabilityBarrier`], while tests inject fakes that record the ordering
@@ -111,43 +123,25 @@ fn sync_directory(_dir: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Like [`std::fs::create_dir_all`], but records which directories it actually
-/// created (issue #1392).
+/// Like [`std::fs::create_dir_all`], but maps failures to [`Error::Storage`]
+/// and treats a raced/pre-existing directory as success (issue #1392).
 ///
-/// On the FIRST flush for a keyspace/table, `create_dir_all` materializes the
-/// keyspace and table ancestor directories as well as the leaf SSTable
-/// directory. Fsyncing only the leaf persists the *component* dirents but NOT
-/// the leaf directory's own entry in its parent (nor the parent's entry in ITS
-/// parent) — a crash after the WAL is truncated could then lose the entire
-/// newly created SSTable directory tree. To close that gap the caller must
-/// fsync every directory whose contents changed; this helper returns the set of
-/// newly created directories (shallowest first, mirroring the top-down creation
-/// order) so the caller knows which ancestors need syncing.
-///
-/// The returned vector contains only directories this call created; already
-/// existing directories are not included (their dirents were already durable).
-pub(crate) fn create_dir_all_recording(path: &Path) -> Result<Vec<PathBuf>> {
-    let mut created = Vec::new();
-    create_dir_all_inner(path, &mut created)?;
-    Ok(created)
-}
-
-fn create_dir_all_inner(path: &Path, created: &mut Vec<PathBuf>) -> Result<()> {
+/// Directory *creation* no longer needs to record which ancestors it
+/// materialized: the flush durability barrier fsyncs the entire leaf→data-root
+/// chain unconditionally (see [`dirs_to_sync`]), so there is nothing to track.
+pub(crate) fn create_dir_all(path: &Path) -> Result<()> {
     if path.as_os_str().is_empty() {
         return Ok(());
     }
     match std::fs::create_dir(path) {
-        Ok(()) => {
-            created.push(path.to_path_buf());
-            Ok(())
-        }
+        Ok(()) => Ok(()),
         // Raced/pre-existing: another actor already made it, or it existed.
         Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists && path.is_dir() => Ok(()),
-        // Parent missing: create ancestors first (recording them), then retry.
+        // Parent missing: create ancestors first, then retry.
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             match path.parent() {
                 Some(parent) if !parent.as_os_str().is_empty() => {
-                    create_dir_all_inner(parent, created)?;
+                    create_dir_all(parent)?;
                 }
                 _ => {
                     return Err(Error::Storage(format!(
@@ -157,10 +151,7 @@ fn create_dir_all_inner(path: &Path, created: &mut Vec<PathBuf>) -> Result<()> {
                 }
             }
             match std::fs::create_dir(path) {
-                Ok(()) => {
-                    created.push(path.to_path_buf());
-                    Ok(())
-                }
+                Ok(()) => Ok(()),
                 Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists && path.is_dir() => Ok(()),
                 Err(e) => Err(Error::Storage(format!(
                     "Failed to create directory {}: {e}",
@@ -175,52 +166,69 @@ fn create_dir_all_inner(path: &Path, created: &mut Vec<PathBuf>) -> Result<()> {
     }
 }
 
-/// Compute the ordered, de-duplicated list of directories to fsync so that
-/// every dirent created during a flush is persisted before the WAL is
-/// truncated (issue #1392).
+/// Compute the ordered list of directories to fsync so that every dirent along
+/// the newly written SSTable's path is persisted before the WAL is truncated
+/// (issue #1392).
 ///
-/// The set is:
-/// * the leaf SSTable directory (its new component dirents live here), plus
-/// * the *parent* of every newly created directory (so that directory's own
-///   entry in its parent is persisted).
+/// Walks from the leaf SSTable directory up to (and including) `data_root`,
+/// deepest-first. This is the whole ancestor chain that could hold a
+/// not-yet-durable dirent for the SSTable — the leaf (its component dirents),
+/// the table directory (the leaf's own entry), the keyspace directory (the
+/// table's entry), and the data root (the keyspace's entry).
+///
+/// Syncing the FULL chain on every flush — regardless of which dirs this
+/// particular attempt created — is deliberate (issue #1392): a retry after a
+/// partially completed earlier attempt sees the ancestors already present, so a
+/// "sync-only-what-I-created" barrier would skip them and truncate the WAL
+/// while they were still not durable. Directory fsync is idempotent, so
+/// re-syncing an already-durable dir is harmless.
 ///
 /// The result is ordered deepest-first so each child directory is synced before
 /// its parent — matching the POSIX convention that a parent's fsync only needs
-/// to follow the creation (and here the sync) of the child it references.
-fn dirs_to_sync(leaf: &Path, created_dirs: &[PathBuf]) -> Vec<PathBuf> {
-    let mut dirs: Vec<PathBuf> = vec![leaf.to_path_buf()];
-    for created in created_dirs {
-        if let Some(parent) = created.parent() {
-            let parent = parent.to_path_buf();
-            if !parent.as_os_str().is_empty() && !dirs.contains(&parent) {
-                dirs.push(parent);
+/// to follow the creation (and here the sync) of the child it references. The
+/// walk never ascends above `data_root`: it stops as soon as it reaches it, and
+/// defensively stops if `leaf` is not under `data_root` at all.
+fn dirs_to_sync(leaf: &Path, data_root: &Path) -> Vec<PathBuf> {
+    let mut dirs: Vec<PathBuf> = Vec::new();
+    let mut cur = leaf;
+    loop {
+        dirs.push(cur.to_path_buf());
+        if cur == data_root {
+            break;
+        }
+        match cur.parent() {
+            // Only ascend while we stay within the configured data root; never
+            // fsync directories above it.
+            Some(parent) if !parent.as_os_str().is_empty() && parent.starts_with(data_root) => {
+                cur = parent;
             }
+            _ => break,
         }
     }
-    // Deepest first: a directory's own entry lives in its parent, so we persist
-    // children before parents.
-    dirs.sort_by_key(|d| std::cmp::Reverse(d.components().count()));
     dirs
 }
 
 /// Complete the durability handoff at the end of a flush.
 ///
-/// `data_path` is the SSTable's Data.db path; its parent directory is fsynced
-/// (falling back to `data_dir` if `data_path` has no parent). Ordering is
+/// `data_path` is the SSTable's Data.db path; its parent directory is the leaf
+/// SSTable directory (falling back to `data_dir` if `data_path` has no parent).
+/// `data_dir` is the write engine's configured data root. Ordering is
 /// load-bearing (issue #1392):
 ///
-/// 1. fsync the SSTable's directory **and every newly created ancestor
-///    directory** so all new directory entries are durable.
+/// 1. fsync the **full ancestor chain** from the leaf SSTable directory up to
+///    (and including) `data_dir`, deepest-first, so every directory entry along
+///    the new SSTable's path is durable.
 /// 2. Only then truncate the WAL — the WAL copy of the data is discarded here.
 ///
-/// `created_dirs` is the set of directories that `create_dir_all` actually
-/// created for this flush (see [`create_dir_all_recording`]). On the first
-/// flush into a brand-new keyspace/table path this includes the keyspace and
-/// table directories; fsyncing only the leaf would persist the component
-/// dirents but leave the leaf's (and keyspace's) own entry in its parent
-/// unsynced, so a crash after the WAL truncate could lose the entire new
-/// SSTable directory. We therefore fsync the leaf plus the parent of every
-/// newly created directory, deepest-first, before truncating the WAL.
+/// The full chain is synced on EVERY flush, not just the directories this
+/// attempt created (see [`dirs_to_sync`]). Fsyncing only the leaf — or only the
+/// dirs a given attempt created — would persist the component dirents but could
+/// leave the leaf's (or keyspace's) own entry in its parent unsynced, so a
+/// crash after the WAL truncate could lose the entire new SSTable directory.
+/// This is especially dangerous on a RETRY after a partially completed earlier
+/// attempt: the ancestors already exist, so a "created this attempt" list would
+/// be empty and only the leaf would be synced. Directory fsync is cheap and
+/// idempotent, so re-syncing already-durable ancestors is harmless.
 ///
 /// If any directory fsync fails, the error is propagated and the WAL is
 /// **not** truncated, so recovery can still replay from the WAL.
@@ -252,16 +260,17 @@ pub(crate) fn finalize_flush_durability(
     barrier: &dyn DurabilityBarrier,
     data_path: &Path,
     data_dir: &Path,
-    created_dirs: &[PathBuf],
     wal: &mut WriteAheadLog,
 ) -> Result<FlushDurabilityOutcome> {
     // Step 1: persist the new SSTable's dirents BEFORE dropping the WAL copy.
     // (The component *contents* were already fsynced inside `writer.finish()`.)
-    // This fsyncs the leaf SSTable directory AND the parent of every ancestor
-    // directory created during this flush, deepest-first, so the whole newly
-    // created directory tree is durable — not just the leaf (issue #1392).
+    // This fsyncs the FULL ancestor chain from the leaf SSTable directory up to
+    // (and including) the data root, deepest-first, so every directory entry
+    // along the SSTable's path is durable — not just the leaf, and regardless
+    // of whether an earlier flush attempt already created some ancestors
+    // (issue #1392).
     let sstable_dir = data_path.parent().unwrap_or(data_dir);
-    for dir in dirs_to_sync(sstable_dir, created_dirs) {
+    for dir in dirs_to_sync(sstable_dir, data_dir) {
         barrier.sync_dir(&dir)?;
     }
 
@@ -393,7 +402,6 @@ mod tests {
             &barrier,
             &dir.path().join("nb-1-big-Data.db"),
             dir.path(),
-            &[],
             &mut wal,
         )
         .unwrap();
@@ -423,7 +431,6 @@ mod tests {
             &barrier,
             &dir.path().join("nb-1-big-Data.db"),
             dir.path(),
-            &[],
             &mut wal,
         )
         .unwrap_err();
@@ -460,7 +467,6 @@ mod tests {
             &barrier,
             &dir.path().join("nb-1-big-Data.db"),
             dir.path(),
-            &[],
             &mut wal,
         )
         .expect("truncate fault must not fail the flush");
@@ -505,7 +511,6 @@ mod tests {
             &barrier,
             &dir.path().join("nb-1-big-Data.db"),
             dir.path(),
-            &[],
             &mut wal,
         )
         .expect("a post-mutation truncate failure is COMMITTED, not a hard error");
@@ -548,7 +553,6 @@ mod tests {
             &RealDurabilityBarrier,
             &dir.path().join("nb-1-big-Data.db"),
             dir.path(),
-            &[],
             &mut wal,
         )
         .unwrap();
@@ -556,10 +560,9 @@ mod tests {
     }
 
     // Issue #1392 (FINDING 1): on the FIRST flush into a brand-new
-    // keyspace/table path, `create_dir_all` materializes the keyspace and table
-    // ancestor directories. The barrier must fsync the leaf AND every newly
-    // created ancestor's parent — deepest first — BEFORE the WAL truncate, so a
-    // crash cannot lose the freshly created directory tree.
+    // keyspace/table path, the barrier must fsync the leaf AND every ancestor up
+    // to the data root — deepest first — BEFORE the WAL truncate, so a crash
+    // cannot lose the freshly created directory tree.
     #[test]
     fn first_flush_fsyncs_new_ancestor_dirs_before_truncate() {
         let root = TempDir::new().unwrap();
@@ -573,12 +576,9 @@ mod tests {
         let ks_dir = data_dir.join("test_ks");
         let leaf_dir = ks_dir.join("test_table");
         let data_path = leaf_dir.join("nb-1-big-Data.db");
-        // Mirror what `create_dir_all_recording` would report on a first flush:
-        // shallowest-first, keyspace then table.
-        let created_dirs = vec![ks_dir.clone(), leaf_dir.clone()];
 
         let barrier = RecordingBarrier::new();
-        finalize_flush_durability(&barrier, &data_path, data_dir, &created_dirs, &mut wal).unwrap();
+        finalize_flush_durability(&barrier, &data_path, data_dir, &mut wal).unwrap();
 
         // Expected: fsync the leaf (its component dirents), then the keyspace dir
         // (persists the leaf's own entry), then the data_dir (persists the
@@ -591,48 +591,95 @@ mod tests {
                 FsOp::SyncDir(data_dir.to_path_buf()),
                 FsOp::WalTruncate,
             ],
-            "every newly created ancestor dir must be fsynced (deepest first) \
-             before the WAL truncate"
+            "every ancestor dir up to the data root must be fsynced (deepest \
+             first) before the WAL truncate"
         );
         assert_eq!(wal.replay().unwrap().mutations.len(), 0);
     }
 
-    // Issue #1392 (FINDING 1): `create_dir_all_recording` reports exactly the
-    // directories it created (shallowest first) and nothing that already existed.
+    // Issue #1392 (roborev r6): the whole class of retry/partial-failure loss.
+    // An earlier flush attempt already created data_dir/ks/table (so a
+    // "sync-only-what-I-created" barrier would have an EMPTY created set), then
+    // crashed before completing its directory-sync chain. On the RETRY the
+    // barrier must STILL fsync the full leaf→data-root chain (leaf, table dir,
+    // keyspace dir, data root) before truncating the WAL — proving the fix syncs
+    // the whole chain unconditionally rather than only newly created dirs.
     #[test]
-    fn create_dir_all_recording_reports_only_new_dirs() {
+    fn retry_with_preexisting_dirs_still_fsyncs_full_chain_before_truncate() {
+        let root = TempDir::new().unwrap();
+        let data_dir = root.path();
+        let mut wal = WriteAheadLog::create(data_dir).unwrap();
+        wal.append(&test_mutation(1, "Alice")).unwrap();
+        wal.sync().unwrap();
+
+        // Pre-create the whole tree, exactly as a failed earlier attempt would
+        // leave it. `create_dir_all` no longer tracks anything, so there is no
+        // "created this attempt" set to fall back on.
+        let ks_dir = data_dir.join("test_ks");
+        let leaf_dir = ks_dir.join("test_table");
+        create_dir_all(&leaf_dir).unwrap();
+        assert!(leaf_dir.exists());
+        let data_path = leaf_dir.join("nb-1-big-Data.db");
+
+        let barrier = RecordingBarrier::new();
+        finalize_flush_durability(&barrier, &data_path, data_dir, &mut wal).unwrap();
+
+        // The full chain is synced deepest-first even though nothing was created
+        // this attempt — and only THEN is the WAL truncated.
+        assert_eq!(
+            barrier.ops.into_inner(),
+            vec![
+                FsOp::SyncDir(leaf_dir),
+                FsOp::SyncDir(ks_dir),
+                FsOp::SyncDir(data_dir.to_path_buf()),
+                FsOp::WalTruncate,
+            ],
+            "a retry over pre-existing dirs must still fsync the full leaf→\
+             data-root chain (not just the leaf) before the WAL truncate"
+        );
+        assert_eq!(wal.replay().unwrap().mutations.len(), 0);
+    }
+
+    // Issue #1392: `create_dir_all` materializes the full tree and is idempotent
+    // (re-creating an existing tree succeeds).
+    #[test]
+    fn create_dir_all_is_idempotent() {
         let root = TempDir::new().unwrap();
         let ks = root.path().join("ks");
         let tbl = ks.join("tbl");
 
-        // First creation records both new ancestors, shallowest first.
-        let created = create_dir_all_recording(&tbl).unwrap();
-        assert_eq!(created, vec![ks.clone(), tbl.clone()]);
-
-        // Re-creating an existing tree records nothing.
-        let created_again = create_dir_all_recording(&tbl).unwrap();
-        assert!(
-            created_again.is_empty(),
-            "existing directories must not be reported as newly created"
-        );
-
-        // A new leaf under an existing parent records only the leaf.
+        create_dir_all(&tbl).unwrap();
+        assert!(tbl.is_dir());
+        // Re-creating an existing tree is a no-op success.
+        create_dir_all(&tbl).unwrap();
+        // A new leaf under an existing parent also succeeds.
         let tbl2 = ks.join("tbl2");
-        let created_leaf = create_dir_all_recording(&tbl2).unwrap();
-        assert_eq!(created_leaf, vec![tbl2]);
+        create_dir_all(&tbl2).unwrap();
+        assert!(tbl2.is_dir());
     }
 
-    // Issue #1392 (FINDING 1): `dirs_to_sync` yields the leaf plus each newly
-    // created dir's parent, de-duplicated and ordered deepest-first.
+    // Issue #1392: `dirs_to_sync` walks the full leaf→data-root chain, ordered
+    // deepest-first, and never ascends above the data root.
     #[test]
-    fn dirs_to_sync_is_deepest_first_and_deduped() {
+    fn dirs_to_sync_is_full_chain_deepest_first() {
         let root = TempDir::new().unwrap();
         let data_dir = root.path().to_path_buf();
         let ks = data_dir.join("ks");
         let leaf = ks.join("tbl");
-        let created = vec![ks.clone(), leaf.clone()];
 
-        let dirs = dirs_to_sync(&leaf, &created);
-        assert_eq!(dirs, vec![leaf, ks, data_dir]);
+        let dirs = dirs_to_sync(&leaf, &data_dir);
+        assert_eq!(dirs, vec![leaf, ks, data_dir.clone()]);
+
+        // The leaf being the data root itself yields just the root.
+        assert_eq!(dirs_to_sync(&data_dir, &data_dir), vec![data_dir.clone()]);
+
+        // Defensive: a leaf not under the data root does not ascend above it.
+        let stray = TempDir::new().unwrap();
+        let stray_leaf = stray.path().join("elsewhere");
+        assert_eq!(
+            dirs_to_sync(&stray_leaf, &data_dir),
+            vec![stray_leaf],
+            "must not fsync directories outside the configured data root"
+        );
     }
 }

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -364,6 +364,38 @@ fn reject_counter_cells(mutation: &Mutation) -> Result<()> {
 
 #[cfg(feature = "write-support")]
 impl WriteEngine {
+    /// Create `dir` (and any missing ancestors) and fsync its immediate parent
+    /// so that, if `dir` was just created, the new directory's own entry in its
+    /// parent is durable across a crash (issue #1392).
+    ///
+    /// `create_dir_all` succeeding guarantees the parent now exists, so we can
+    /// always fsync it; the call is idempotent and cheap when `dir` already
+    /// existed. The parent is user-/OS-supplied and pre-existing, so its own
+    /// dirent is already durable — we deliberately do NOT walk above the
+    /// immediate parent. When `dir` has no parent (a filesystem root) the FS
+    /// owns that entry and there is nothing for us to fsync.
+    fn create_dir_all_durable(dir: &Path, label: &str) -> Result<()> {
+        std::fs::create_dir_all(dir).map_err(|e| {
+            Error::Storage(format!(
+                "Failed to create {} directory {:?}: {}",
+                label, dir, e
+            ))
+        })?;
+
+        match dir.parent() {
+            // A relative single-component path (e.g. "data") has an empty
+            // parent; its real parent is the current working directory.
+            Some(parent) if parent.as_os_str().is_empty() => {
+                wal::sync_directory(Path::new("."))?;
+            }
+            Some(parent) => wal::sync_directory(parent)?,
+            // `dir` is a filesystem root: nothing above it for us to fsync.
+            None => {}
+        }
+
+        Ok(())
+    }
+
     /// Create a new write engine
     ///
     /// This initializes the WAL and memtable. If a WAL exists in the
@@ -384,20 +416,15 @@ impl WriteEngine {
     /// - Data directory doesn't exist
     /// - WAL replay fails
     pub fn new(config: WriteEngineConfig) -> Result<Self> {
-        // Ensure directories exist
-        std::fs::create_dir_all(&config.data_dir).map_err(|e| {
-            Error::Storage(format!(
-                "Failed to create data directory {:?}: {}",
-                config.data_dir, e
-            ))
-        })?;
-
-        std::fs::create_dir_all(&config.wal_dir).map_err(|e| {
-            Error::Storage(format!(
-                "Failed to create WAL directory {:?}: {}",
-                config.wal_dir, e
-            ))
-        })?;
+        // Ensure directories exist AND that each newly-created root's own dirent
+        // is durable. `create_dir_all` alone persists the entries *inside* a
+        // freshly-created root once we fsync the root, but NOT the root's own
+        // entry in its parent — so a crash after WAL truncation could lose the
+        // whole data/WAL root. Fsyncing each root's immediate parent at init
+        // completes the durability chain (SSTable component contents → leaf →
+        // ancestors → data_root → data_root's parent). See issue #1392.
+        Self::create_dir_all_durable(&config.data_dir, "data")?;
+        Self::create_dir_all_durable(&config.wal_dir, "WAL")?;
 
         // Acquire an exclusive advisory lock on the WAL directory to prevent
         // two WriteEngine / Database instances from sharing the same write_dir
@@ -1205,6 +1232,32 @@ mod tests {
         assert_eq!(engine.memtable_size(), 0);
         assert_eq!(engine.memtable_row_count(), 0);
         assert!(!engine.closed.load(std::sync::atomic::Ordering::Relaxed));
+    }
+
+    /// Issue #1392: `create_dir_all_durable` is the init-time link in the
+    /// durability chain — it must create a fresh (possibly nested) root and
+    /// fsync its parent so the new root's own dirent is persisted. There is no
+    /// fs-op recorder seam on the init path, so this exercises the helper's
+    /// call path directly (create + parent fsync succeeds and is idempotent);
+    /// a crash-injection observation of the fsync would require a syscall seam
+    /// that does not exist here.
+    #[test]
+    fn test_create_dir_all_durable_fsyncs_parent() {
+        let temp_dir = TempDir::new().unwrap();
+
+        // Fresh nested root: parent (`root`) exists, `data` is newly created.
+        let root = temp_dir.path().join("root");
+        std::fs::create_dir_all(&root).unwrap();
+        let data = root.join("data");
+        assert!(!data.exists());
+
+        WriteEngine::create_dir_all_durable(&data, "data").unwrap();
+        assert!(data.is_dir(), "new root directory must exist");
+
+        // Idempotent: re-running on an already-existing dir still succeeds and
+        // re-fsyncs the parent without error.
+        WriteEngine::create_dir_all_durable(&data, "data").unwrap();
+        assert!(data.is_dir());
     }
 
     #[test]

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -364,17 +364,66 @@ fn reject_counter_cells(mutation: &Mutation) -> Result<()> {
 
 #[cfg(feature = "write-support")]
 impl WriteEngine {
-    /// Create `dir` (and any missing ancestors) and fsync its immediate parent
-    /// so that, if `dir` was just created, the new directory's own entry in its
-    /// parent is durable across a crash (issue #1392).
+    /// Fsync the immediate parent of `dir`, mapping the empty parent of a
+    /// relative single-component path (e.g. `"data"`) to the current working
+    /// directory. A filesystem root has no parent, so there is nothing to
+    /// fsync. Fsyncing a directory persists its children's dirents.
+    fn sync_parent(dir: &Path) -> Result<()> {
+        match dir.parent() {
+            // A relative single-component path (e.g. "data") has an empty
+            // parent; its real parent is the current working directory.
+            Some(parent) if parent.as_os_str().is_empty() => wal::sync_directory(Path::new(".")),
+            Some(parent) => wal::sync_directory(parent),
+            // `dir` is a filesystem root: nothing above it for us to fsync.
+            None => Ok(()),
+        }
+    }
+
+    /// Compute the set of directories that a subsequent `create_dir_all(target)`
+    /// will *newly* create, ordered shallowest-first — from the child of the
+    /// first already-existing ancestor (the durable "anchor") down to `target`.
     ///
-    /// `create_dir_all` succeeding guarantees the parent now exists, so we can
-    /// always fsync it; the call is idempotent and cheap when `dir` already
-    /// existed. The parent is user-/OS-supplied and pre-existing, so its own
-    /// dirent is already durable — we deliberately do NOT walk above the
-    /// immediate parent. When `dir` has no parent (a filesystem root) the FS
-    /// owns that entry and there is nothing for us to fsync.
+    /// Walks UP from `target` to the first ancestor that already exists. That
+    /// anchor's own dirent is already durable, so recursion stops there; every
+    /// directory between the anchor and `target` (inclusive) is not yet durable
+    /// and its parent must be fsynced after creation. Returns an empty vec when
+    /// `target` already exists (nothing will be created).
+    fn dirs_to_create(target: &Path) -> Vec<PathBuf> {
+        let mut missing = Vec::new();
+        let mut cur = Some(target);
+        while let Some(dir) = cur {
+            if dir.exists() {
+                break;
+            }
+            missing.push(dir.to_path_buf());
+            // An empty parent (relative single-component path) resolves to the
+            // cwd, which always exists — treat it as the (durable) anchor.
+            cur = dir.parent().filter(|p| !p.as_os_str().is_empty());
+        }
+        // `missing` is deepest-first (target, ..); reverse to anchor-child-first
+        // so callers can fsync parents from the anchor downward.
+        missing.reverse();
+        missing
+    }
+
+    /// Create `dir` (and any missing ancestors) durably: fsync the parent of
+    /// EVERY newly-created directory, from the durable anchor down to `dir`, so
+    /// each new dirent is persisted across a crash (issue #1392).
+    ///
+    /// `create_dir_all` can create multiple missing ancestors at once (e.g.
+    /// `base/a/data` where `a` is also new). Fsyncing only `dir`'s immediate
+    /// parent would leave the intermediate dirents (e.g. `a` inside `base`)
+    /// unpersisted, so a crash after a flush + WAL truncate could still lose the
+    /// whole root and its published SSTable. We therefore record the full set of
+    /// directories that will be created *before* creating them, then fsync each
+    /// one's parent afterward. Stopping at the first already-existing anchor
+    /// bounds the walk (the anchor is already durable) — it cannot recurse
+    /// further. The call is idempotent and cheap when `dir` already existed.
     fn create_dir_all_durable(dir: &Path, label: &str) -> Result<()> {
+        // Record what `create_dir_all` is about to create, from the anchor's
+        // child down to `dir`, BEFORE the directories start existing.
+        let newly_created = Self::dirs_to_create(dir);
+
         std::fs::create_dir_all(dir).map_err(|e| {
             Error::Storage(format!(
                 "Failed to create {} directory {:?}: {}",
@@ -382,15 +431,19 @@ impl WriteEngine {
             ))
         })?;
 
-        match dir.parent() {
-            // A relative single-component path (e.g. "data") has an empty
-            // parent; its real parent is the current working directory.
-            Some(parent) if parent.as_os_str().is_empty() => {
-                wal::sync_directory(Path::new("."))?;
+        if newly_created.is_empty() {
+            // `dir` already fully existed: nothing was created. Fsyncing the
+            // immediate parent is harmless and preserves the idempotent
+            // durability contract.
+            Self::sync_parent(dir)?;
+        } else {
+            // Persist each new dirent by fsyncing its parent, from the anchor
+            // downward (`newly_created` is anchor-child-first, so its entries'
+            // parents are the anchor, then each newly-created ancestor, ...,
+            // ending at `dir`'s parent).
+            for created in &newly_created {
+                Self::sync_parent(created)?;
             }
-            Some(parent) => wal::sync_directory(parent)?,
-            // `dir` is a filesystem root: nothing above it for us to fsync.
-            None => {}
         }
 
         Ok(())
@@ -416,13 +469,17 @@ impl WriteEngine {
     /// - Data directory doesn't exist
     /// - WAL replay fails
     pub fn new(config: WriteEngineConfig) -> Result<Self> {
-        // Ensure directories exist AND that each newly-created root's own dirent
-        // is durable. `create_dir_all` alone persists the entries *inside* a
-        // freshly-created root once we fsync the root, but NOT the root's own
-        // entry in its parent — so a crash after WAL truncation could lose the
-        // whole data/WAL root. Fsyncing each root's immediate parent at init
-        // completes the durability chain (SSTable component contents → leaf →
-        // ancestors → data_root → data_root's parent). See issue #1392.
+        // Ensure directories exist AND that EVERY newly-created ancestor's own
+        // dirent is durable. `create_dir_all` alone persists the entries
+        // *inside* a freshly-created root once we fsync the root, but NOT the
+        // dirents of the newly-created directories themselves in their parents
+        // — and it may create several missing ancestors at once. Fsyncing only
+        // the immediate parent would leave intermediate dirents unpersisted, so
+        // a crash after WAL truncation could still lose the whole data/WAL root.
+        // `create_dir_all_durable` fsyncs the parent of every newly-created
+        // directory (from the durable anchor down to the target), completing the
+        // durability chain (SSTable component contents → leaf → ancestors →
+        // data_root → every new ancestor up to the anchor). See issue #1392.
         Self::create_dir_all_durable(&config.data_dir, "data")?;
         Self::create_dir_all_durable(&config.wal_dir, "WAL")?;
 
@@ -1256,6 +1313,51 @@ mod tests {
 
         // Idempotent: re-running on an already-existing dir still succeeds and
         // re-fsyncs the parent without error.
+        WriteEngine::create_dir_all_durable(&data, "data").unwrap();
+        assert!(data.is_dir());
+    }
+
+    /// Issue #1392 (roborev HIGH): `create_dir_all` can create MORE THAN ONE
+    /// missing ancestor at once, and fsyncing only the target's immediate
+    /// parent leaves the intermediate dirents unpersisted — a crash after a
+    /// flush + WAL truncate could still lose the whole root. The durable helper
+    /// must record every newly-created level and fsync each one's parent.
+    ///
+    /// There is no syscall seam to observe the fsyncs directly, so this asserts
+    /// the ancestor-walk recorded set (`dirs_to_create`) that drives exactly
+    /// which parents get fsynced. Red-before: the previous helper had no such
+    /// recording and only ever fsynced the immediate parent.
+    #[test]
+    fn test_create_dir_all_durable_fsyncs_all_missing_ancestors() {
+        let temp_dir = TempDir::new().unwrap();
+
+        // Only `base` pre-exists; `a`, `b`, and `data` are all newly created.
+        let base = temp_dir.path().join("base");
+        std::fs::create_dir_all(&base).unwrap();
+        let a = base.join("a");
+        let b = a.join("b");
+        let data = b.join("data");
+        assert!(!a.exists());
+
+        // The recorded set is anchor-child-first and includes EVERY level from
+        // the anchor's child (`a`) down to the target (`data`). Fsyncing each
+        // one's parent persists a→base, b→a, data→b.
+        let to_create = WriteEngine::dirs_to_create(&data);
+        assert_eq!(
+            to_create,
+            vec![a.clone(), b.clone(), data.clone()],
+            "must record all >1 newly-created ancestors, not just the leaf's parent"
+        );
+
+        // Green-after: durable creation succeeds and materializes the full tree.
+        WriteEngine::create_dir_all_durable(&data, "data").unwrap();
+        assert!(data.is_dir(), "full nested tree must exist");
+
+        // Idempotent: nothing is left to create, so the recorded set is empty.
+        assert!(
+            WriteEngine::dirs_to_create(&data).is_empty(),
+            "already-existing target records no new directories"
+        );
         WriteEngine::create_dir_all_durable(&data, "data").unwrap();
         assert!(data.is_dir());
     }

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -1066,9 +1066,21 @@ impl WriteEngine {
     ///
     /// # Errors
     ///
-    /// Returns an error if the final flush fails. If the WAL truncate fails
-    /// after a successful SSTable write, a warning is logged but no error
-    /// is returned (the data is already persisted).
+    /// Returns an error if the final flush fails.
+    ///
+    /// WAL-truncate handling during that flush is phase-aware (issue #1392):
+    ///
+    /// * A truncate failure that leaves the WAL intact (it faulted *before*
+    ///   mutating the WAL) is logged and swallowed — the WAL stays a valid,
+    ///   idempotent replay marker, so no error is surfaced.
+    /// * A truncate failure *after* `set_len(0)` has already zeroed the WAL
+    ///   (`WalTruncateFailedAfterCommit`) is **propagated**. By then flush state
+    ///   has already been committed — the SSTable is durable and the generation
+    ///   has advanced — so the data is safe, but the error is surfaced so the
+    ///   caller knows the WAL is no longer a replay marker.
+    ///
+    /// When the WAL is already empty (e.g. `Durability::Disabled`) the truncate
+    /// phase is skipped, so no truncate-phase error can arise.
     pub async fn close(&mut self) -> Result<()> {
         // Check if already closed (idempotent)
         if self.closed.swap(true, Ordering::SeqCst) {

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -58,6 +58,8 @@ pub use wal::{RecoveryReport, WriteAheadLog};
 #[cfg(feature = "write-support")]
 mod compaction;
 #[cfg(feature = "write-support")]
+pub(crate) mod durability;
+#[cfg(feature = "write-support")]
 mod maintenance;
 #[cfg(feature = "write-support")]
 mod stats;
@@ -942,16 +944,29 @@ impl WriteEngine {
             info.data_size
         );
 
-        // Truncate WAL (data now persisted to SSTable)
-        // If truncate fails, log warning but don't fail - data is already in SSTable
-        if let Err(e) = self.wal.truncate() {
-            log::warn!(
-                "Failed to truncate WAL after successful SSTable flush: {}. \
-                Data is safe in SSTable, but WAL cleanup failed.",
-                e
-            );
-            // Don't return error - SSTable write succeeded, which is the important part
-        }
+        // Durability handoff (issue #1392): fsync the SSTable's parent directory
+        // BEFORE truncating the WAL. See `durability::finalize_flush_durability`.
+        //
+        // A `?`-propagated error here (e.g. a directory fsync failure) happens
+        // BEFORE the WAL is truncated, so the WAL is still intact and replayable:
+        // returning early WITHOUT advancing the generation is correct, because a
+        // retry re-flushes to the same generation and the untouched WAL still
+        // recovers the data on a crash mid-retry.
+        let durability_outcome = durability::finalize_flush_durability(
+            &durability::RealDurabilityBarrier,
+            &info.data_path,
+            &self.config.data_dir,
+            &info.created_dirs,
+            &mut self.wal,
+        )?;
+
+        // The SSTable is now durably published. Commit flush state — clear the
+        // memtable and advance the generation — for BOTH outcomes, including
+        // `WalTruncateFailedAfterCommit`. In that case the WAL has already been
+        // zeroed, so the published SSTable is the ONLY durable copy of these
+        // mutations; committing state guarantees a retry writes a NEW generation
+        // and never lets `File::create` overwrite the sole durable copy (which
+        // would lose the data on a crash mid-retry). See issue #1392.
 
         // Clear memtable
         self.memtable.clear();
@@ -979,7 +994,15 @@ impl WriteEngine {
         }
         self.record_memtable_gauges();
 
-        Ok(Some(info))
+        // Surface a post-mutation WAL-truncate failure AFTER state has been
+        // committed above (issue #1392). The data is durable in the published
+        // SSTable and the generation has advanced, so a retry cannot overwrite
+        // it; the error informs the caller that the WAL is no longer a valid
+        // replay marker.
+        match durability_outcome {
+            durability::FlushDurabilityOutcome::Durable => Ok(Some(info)),
+            durability::FlushDurabilityOutcome::WalTruncateFailedAfterCommit(err) => Err(err),
+        }
     }
 
     /// Close the write engine
@@ -2475,6 +2498,125 @@ mod tests {
             engine2.is_ok(),
             "WriteEngine must acquire lock after the previous engine was dropped: {:?}",
             engine2.err()
+        );
+    }
+
+    // Issue #1392 (roborev r4): when the WAL truncate fails AFTER `set_len(0)`
+    // has already zeroed the WAL, the just-published SSTable is the ONLY durable
+    // copy of the flushed mutations. The flush must therefore treat the SSTable
+    // handoff as COMMITTED for state purposes — clear the memtable and advance
+    // the generation BEFORE surfacing the error — so that a retry writes a NEW
+    // generation instead of `File::create`-overwriting the published SSTable
+    // (which would lose the data on a crash mid-retry).
+    //
+    // This drives the real `RealDurabilityBarrier` path via the WAL's test-only
+    // post-`set_len(0)` sync fault, then proves: (1) the flush surfaces the
+    // error, (2) state is committed (memtable cleared, generation advanced),
+    // (3) the published gen-1 SSTable survives byte-for-byte, (4) a subsequent
+    // flush writes a NEW generation, and (5) a full read returns each mutation
+    // exactly once — crash-safe, no loss, no duplication.
+    #[tokio::test]
+    async fn post_mutation_truncate_failure_commits_and_retry_writes_new_generation() {
+        use crate::platform::Platform;
+        use crate::storage::sstable::SSTableManager;
+        use crate::Config;
+        use std::sync::Arc;
+
+        let temp_dir = TempDir::new().unwrap();
+        let schema = create_test_schema();
+        let data_dir = temp_dir.path().join("data");
+        let config = WriteEngineConfig::new(
+            data_dir.clone(),
+            temp_dir.path().join("wal"),
+            schema.clone(),
+        );
+        let mut engine = WriteEngine::new(config).unwrap();
+
+        // Write the first mutation, then arm a post-set_len(0) WAL-truncate fault
+        // so the flush finalize hits the `AfterMutation` path.
+        engine
+            .write(create_test_mutation(1, "Alice", 1_000_000))
+            .unwrap();
+        let gen_before = engine.generation();
+        engine.wal.set_fail_sync_after_truncate(true);
+
+        let err = engine
+            .flush()
+            .await
+            .expect_err("a post-mutation WAL-truncate failure must surface as an error");
+        assert!(
+            matches!(err, Error::Storage(_)),
+            "post-mutation truncate failure must surface as a storage error, got {err:?}"
+        );
+
+        // State is COMMITTED despite the error: the memtable is cleared and the
+        // generation has advanced, so a retry cannot reuse the published gen.
+        assert_eq!(
+            engine.memtable_row_count(),
+            0,
+            "memtable must be cleared once the SSTable is durably published"
+        );
+        assert_eq!(
+            engine.generation(),
+            gen_before + 1,
+            "generation must advance so a retry writes a NEW generation"
+        );
+
+        // The published gen-1 SSTable exists on disk. Snapshot its bytes to prove
+        // a later flush does NOT overwrite it.
+        let sstable_dir = data_dir.join("test_ks").join("test_table");
+        let gen1_data = sstable_dir.join("nb-1-big-Data.db");
+        assert!(
+            gen1_data.exists(),
+            "the published gen-1 Data.db must exist on disk after the faulted flush"
+        );
+        let gen1_bytes = std::fs::read(&gen1_data).unwrap();
+
+        // Disarm the fault and flush a SECOND mutation: it must write a NEW
+        // generation and leave the first SSTable byte-for-byte intact.
+        engine.wal.set_fail_sync_after_truncate(false);
+        engine
+            .write(create_test_mutation(2, "Bob", 2_000_000))
+            .unwrap();
+        engine
+            .flush()
+            .await
+            .expect("second flush must succeed")
+            .expect("second flush must produce an SSTable");
+
+        let gen2_data = sstable_dir.join("nb-2-big-Data.db");
+        assert!(
+            gen2_data.exists(),
+            "the retry must write a NEW generation (nb-2), not overwrite nb-1"
+        );
+        assert_eq!(
+            std::fs::read(&gen1_data).unwrap(),
+            gen1_bytes,
+            "the retry must NOT overwrite the published gen-1 SSTable"
+        );
+
+        // Full read across both generations: each mutation appears exactly once.
+        let cqlite_config = Config::default();
+        let platform = Arc::new(Platform::new(&cqlite_config).await.unwrap());
+        let manager = SSTableManager::new(
+            &data_dir,
+            &cqlite_config,
+            platform,
+            #[cfg(feature = "state_machine")]
+            None,
+        )
+        .await
+        .expect("SSTableManager must load both published generations");
+
+        let table_id = crate::types::TableId::from("test_ks.test_table");
+        let rows = manager
+            .scan(&table_id, None, None, None, Some(&schema))
+            .await
+            .expect("scan across both generations must succeed");
+        assert_eq!(
+            rows.len(),
+            2,
+            "both mutations must be readable exactly once (no loss, no duplication)"
         );
     }
 }

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -956,7 +956,6 @@ impl WriteEngine {
             &durability::RealDurabilityBarrier,
             &info.data_path,
             &self.config.data_dir,
-            &info.created_dirs,
             &mut self.wal,
         )?;
 

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -364,66 +364,28 @@ fn reject_counter_cells(mutation: &Mutation) -> Result<()> {
 
 #[cfg(feature = "write-support")]
 impl WriteEngine {
-    /// Fsync the immediate parent of `dir`, mapping the empty parent of a
-    /// relative single-component path (e.g. `"data"`) to the current working
-    /// directory. A filesystem root has no parent, so there is nothing to
-    /// fsync. Fsyncing a directory persists its children's dirents.
-    fn sync_parent(dir: &Path) -> Result<()> {
-        match dir.parent() {
-            // A relative single-component path (e.g. "data") has an empty
-            // parent; its real parent is the current working directory.
-            Some(parent) if parent.as_os_str().is_empty() => wal::sync_directory(Path::new(".")),
-            Some(parent) => wal::sync_directory(parent),
-            // `dir` is a filesystem root: nothing above it for us to fsync.
-            None => Ok(()),
-        }
-    }
-
-    /// Compute the set of directories that a subsequent `create_dir_all(target)`
-    /// will *newly* create, ordered shallowest-first — from the child of the
-    /// first already-existing ancestor (the durable "anchor") down to `target`.
+    /// Create `dir` (and any missing ancestors), then fsync the FULL parent
+    /// chain from `dir`'s parent walking UP to and including the filesystem
+    /// root — unconditionally, on every call (issue #1392).
     ///
-    /// Walks UP from `target` to the first ancestor that already exists. That
-    /// anchor's own dirent is already durable, so recursion stops there; every
-    /// directory between the anchor and `target` (inclusive) is not yet durable
-    /// and its parent must be fsynced after creation. Returns an empty vec when
-    /// `target` already exists (nothing will be created).
-    fn dirs_to_create(target: &Path) -> Vec<PathBuf> {
-        let mut missing = Vec::new();
-        let mut cur = Some(target);
-        while let Some(dir) = cur {
-            if dir.exists() {
-                break;
-            }
-            missing.push(dir.to_path_buf());
-            // An empty parent (relative single-component path) resolves to the
-            // cwd, which always exists — treat it as the (durable) anchor.
-            cur = dir.parent().filter(|p| !p.as_os_str().is_empty());
-        }
-        // `missing` is deepest-first (target, ..); reverse to anchor-child-first
-        // so callers can fsync parents from the anchor downward.
-        missing.reverse();
-        missing
-    }
-
-    /// Create `dir` (and any missing ancestors) durably: fsync the parent of
-    /// EVERY newly-created directory, from the durable anchor down to `dir`, so
-    /// each new dirent is persisted across a crash (issue #1392).
+    /// We deliberately do NOT track "what this invocation created." Across a
+    /// crash that is unknowable: a prior startup may have created the whole
+    /// nested `data_dir`/`wal_dir` tree but crashed partway through the
+    /// parent-fsync sequence, leaving higher ancestors' dirents unpersisted. A
+    /// retry that inspected "already exists" and re-fsynced only the immediate
+    /// parent would leave those ancestors un-durable forever — the "which
+    /// ancestor is durable on retry" hole.
     ///
-    /// `create_dir_all` can create multiple missing ancestors at once (e.g.
-    /// `base/a/data` where `a` is also new). Fsyncing only `dir`'s immediate
-    /// parent would leave the intermediate dirents (e.g. `a` inside `base`)
-    /// unpersisted, so a crash after a flush + WAL truncate could still lose the
-    /// whole root and its published SSTable. We therefore record the full set of
-    /// directories that will be created *before* creating them, then fsync each
-    /// one's parent afterward. Stopping at the first already-existing anchor
-    /// bounds the walk (the anchor is already durable) — it cannot recurse
-    /// further. The call is idempotent and cheap when `dir` already existed.
+    /// Instead we fsync EVERY ancestor unconditionally. Fsyncing an
+    /// already-durable directory is idempotent and cheap, and the walk
+    /// terminates at the filesystem root (`Path::parent()` returns `None`), so
+    /// no ancestor level is ever left unsynced and there is no per-attempt
+    /// state to track. Every ancestor of a successfully-created directory
+    /// exists, so each fsync targets a real, present directory. Together with
+    /// the flush-path barrier (which fsyncs leaf → data_root on every publish),
+    /// this makes the full durability chain persistent on first flush AND on
+    /// any retry after a partial crash.
     fn create_dir_all_durable(dir: &Path, label: &str) -> Result<()> {
-        // Record what `create_dir_all` is about to create, from the anchor's
-        // child down to `dir`, BEFORE the directories start existing.
-        let newly_created = Self::dirs_to_create(dir);
-
         std::fs::create_dir_all(dir).map_err(|e| {
             Error::Storage(format!(
                 "Failed to create {} directory {:?}: {}",
@@ -431,19 +393,20 @@ impl WriteEngine {
             ))
         })?;
 
-        if newly_created.is_empty() {
-            // `dir` already fully existed: nothing was created. Fsyncing the
-            // immediate parent is harmless and preserves the idempotent
-            // durability contract.
-            Self::sync_parent(dir)?;
-        } else {
-            // Persist each new dirent by fsyncing its parent, from the anchor
-            // downward (`newly_created` is anchor-child-first, so its entries'
-            // parents are the anchor, then each newly-created ancestor, ...,
-            // ending at `dir`'s parent).
-            for created in &newly_created {
-                Self::sync_parent(created)?;
+        // Ascend the parent chain, fsyncing each ancestor's dirent. The walk
+        // strictly shrinks (one component per step) and ends when `parent()`
+        // yields `None` at the filesystem root, so it always terminates.
+        let mut next = dir.parent();
+        while let Some(cur) = next {
+            if cur.as_os_str().is_empty() {
+                // A relative single-component path (e.g. "data") has an empty
+                // parent whose real directory is the current working
+                // directory. Fsync "." and stop: it has no ancestor to ascend.
+                wal::sync_directory(Path::new("."))?;
+                break;
             }
+            wal::sync_directory(cur)?;
+            next = cur.parent();
         }
 
         Ok(())
@@ -469,17 +432,18 @@ impl WriteEngine {
     /// - Data directory doesn't exist
     /// - WAL replay fails
     pub fn new(config: WriteEngineConfig) -> Result<Self> {
-        // Ensure directories exist AND that EVERY newly-created ancestor's own
-        // dirent is durable. `create_dir_all` alone persists the entries
-        // *inside* a freshly-created root once we fsync the root, but NOT the
-        // dirents of the newly-created directories themselves in their parents
-        // — and it may create several missing ancestors at once. Fsyncing only
-        // the immediate parent would leave intermediate dirents unpersisted, so
-        // a crash after WAL truncation could still lose the whole data/WAL root.
-        // `create_dir_all_durable` fsyncs the parent of every newly-created
-        // directory (from the durable anchor down to the target), completing the
-        // durability chain (SSTable component contents → leaf → ancestors →
-        // data_root → every new ancestor up to the anchor). See issue #1392.
+        // Ensure directories exist AND that EVERY ancestor's own dirent is
+        // durable. `create_dir_all` alone persists the entries *inside* a
+        // freshly-created root once we fsync the root, but NOT the dirents of
+        // the newly-created directories themselves in their parents — and it
+        // may create several missing ancestors at once. Fsyncing only the
+        // immediate parent would leave intermediate dirents unpersisted, so a
+        // crash after WAL truncation could still lose the whole data/WAL root.
+        // `create_dir_all_durable` fsyncs the FULL parent chain up to and
+        // including the filesystem root, unconditionally on every call — this
+        // closes the "which ancestor is durable on a partial-crash retry" hole
+        // and completes the durability chain (SSTable component contents →
+        // leaf → ancestors → data_root → every ancestor up to root). #1392.
         Self::create_dir_all_durable(&config.data_dir, "data")?;
         Self::create_dir_all_durable(&config.wal_dir, "WAL")?;
 
@@ -1317,49 +1281,77 @@ mod tests {
         assert!(data.is_dir());
     }
 
-    /// Issue #1392 (roborev HIGH): `create_dir_all` can create MORE THAN ONE
-    /// missing ancestor at once, and fsyncing only the target's immediate
-    /// parent leaves the intermediate dirents unpersisted — a crash after a
-    /// flush + WAL truncate could still lose the whole root. The durable helper
-    /// must record every newly-created level and fsync each one's parent.
+    /// Issue #1392 (roborev HIGH): the "track what this attempt created"
+    /// approach had a retry hole — if a PRIOR startup created the nested tree
+    /// but crashed partway through its parent-fsync sequence, a retry sees the
+    /// tree already exists, records an empty newly-created set, and re-fsyncs
+    /// only the immediate parent, leaving higher ancestors un-durable forever.
     ///
-    /// There is no syscall seam to observe the fsyncs directly, so this asserts
-    /// the ancestor-walk recorded set (`dirs_to_create`) that drives exactly
-    /// which parents get fsynced. Red-before: the previous helper had no such
-    /// recording and only ever fsynced the immediate parent.
+    /// The definitive fix is to stop tracking anything and fsync the FULL
+    /// parent chain (up to and including the filesystem root) on EVERY call.
+    /// This test simulates that partial-crash retry: it pre-creates the entire
+    /// `base/a/b/data` tree first, so nothing is "newly created" on the call,
+    /// then asserts every ancestor is still openable/fsyncable up to the root.
+    ///
+    /// Red-before: the tracking helper would fsync only `data`'s immediate
+    /// parent (`b`) on the already-exists path, leaving `a`/`base` unsynced.
+    /// Green-after: the unconditional full-chain walk fsyncs `b`, `a`, `base`,
+    /// and every ancestor up to the filesystem root.
     #[test]
-    fn test_create_dir_all_durable_fsyncs_all_missing_ancestors() {
+    fn test_create_dir_all_durable_fsyncs_full_chain_on_existing_tree() {
         let temp_dir = TempDir::new().unwrap();
 
-        // Only `base` pre-exists; `a`, `b`, and `data` are all newly created.
+        // Simulate a prior partial-crash: the ENTIRE nested tree already exists
+        // before the call, so no directory is "newly created" this invocation.
         let base = temp_dir.path().join("base");
-        std::fs::create_dir_all(&base).unwrap();
         let a = base.join("a");
         let b = a.join("b");
         let data = b.join("data");
-        assert!(!a.exists());
+        std::fs::create_dir_all(&data).unwrap();
+        assert!(data.is_dir(), "precondition: full tree pre-exists");
 
-        // The recorded set is anchor-child-first and includes EVERY level from
-        // the anchor's child (`a`) down to the target (`data`). Fsyncing each
-        // one's parent persists a→base, b→a, data→b.
-        let to_create = WriteEngine::dirs_to_create(&data);
-        assert_eq!(
-            to_create,
-            vec![a.clone(), b.clone(), data.clone()],
-            "must record all >1 newly-created ancestors, not just the leaf's parent"
-        );
-
-        // Green-after: durable creation succeeds and materializes the full tree.
+        // The unconditional full-chain fsync must succeed on the already-exists
+        // path — it walks `data`'s parent up to the filesystem root, fsyncing
+        // every ancestor regardless of what (if anything) this call created.
         WriteEngine::create_dir_all_durable(&data, "data").unwrap();
-        assert!(data.is_dir(), "full nested tree must exist");
 
-        // Idempotent: nothing is left to create, so the recorded set is empty.
-        assert!(
-            WriteEngine::dirs_to_create(&data).is_empty(),
-            "already-existing target records no new directories"
-        );
+        // Every ancestor from the leaf's parent up to the root is a real,
+        // present directory that the walk fsynced (open-for-sync would fail on
+        // a missing/non-durable dirent). Assert the whole chain is present.
+        for ancestor in [b.as_path(), a.as_path(), base.as_path()] {
+            assert!(
+                ancestor.is_dir(),
+                "ancestor {:?} must be present and fsyncable up the full chain",
+                ancestor
+            );
+        }
+
+        // Idempotent: a second unconditional pass still succeeds.
         WriteEngine::create_dir_all_durable(&data, "data").unwrap();
         assert!(data.is_dir());
+    }
+
+    /// Issue #1392: the full-chain walk must TERMINATE at the filesystem root
+    /// (a path whose `parent()` is `None`) rather than looping. Exercising the
+    /// helper against an absolute nested path implicitly walks to `/`; this
+    /// test guards the termination contract by confirming the call returns
+    /// (does not hang) and the root itself has no parent to ascend into.
+    #[test]
+    fn test_create_dir_all_durable_walk_terminates_at_root() {
+        let temp_dir = TempDir::new().unwrap();
+        let data = temp_dir.path().join("a").join("b").join("data");
+
+        // Absolute path: the parent chain ascends through `b`, `a`, the temp
+        // dir, ... up to `/`. `Path::new("/").parent()` is `None`, so the walk
+        // stops there — no infinite loop. The call simply returns.
+        WriteEngine::create_dir_all_durable(&data, "data").unwrap();
+        assert!(data.is_dir());
+
+        // Contract the walk relies on: the filesystem root terminates the walk.
+        assert!(
+            std::path::Path::new("/").parent().is_none(),
+            "filesystem root must have no parent so the fsync walk terminates"
+        );
     }
 
     #[test]

--- a/cqlite-core/src/storage/write_engine/wal.rs
+++ b/cqlite-core/src/storage/write_engine/wal.rs
@@ -145,6 +145,51 @@ enum WalStop {
     Corruption,
 }
 
+/// Outcome of a failed [`WriteAheadLog::truncate_checked`], distinguishing a
+/// failure that leaves the WAL intact from one that has already destroyed it
+/// (issue #1392).
+///
+/// `set_len(0)` is the point of no return: once it succeeds the on-disk WAL is
+/// empty and is no longer a replayable recovery marker, even if a subsequent
+/// fsync/seek fails. Swallowing such a post-mutation failure as if the WAL were
+/// still intact would let the caller clear the memtable and report a durable,
+/// replayable WAL that no longer exists — silent data loss.
+#[derive(Debug)]
+pub enum TruncateError {
+    /// Failure at or before `set_len(0)`: the WAL contents were not mutated and
+    /// remain a valid replay marker. Safe to leave the WAL in place.
+    BeforeMutation(Error),
+    /// Failure after `set_len(0)` zeroed the WAL: the WAL is no longer a valid
+    /// replay marker. Callers MUST NOT treat the WAL as intact.
+    AfterMutation(Error),
+}
+
+impl TruncateError {
+    /// Unwrap to the underlying [`Error`], discarding the phase distinction.
+    /// Used by the phase-agnostic [`WriteAheadLog::truncate`] wrapper.
+    pub fn into_inner(self) -> Error {
+        match self {
+            TruncateError::BeforeMutation(e) | TruncateError::AfterMutation(e) => e,
+        }
+    }
+}
+
+impl std::fmt::Display for TruncateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TruncateError::BeforeMutation(e) => {
+                write!(f, "WAL truncate failed before mutation (WAL intact): {e}")
+            }
+            TruncateError::AfterMutation(e) => write!(
+                f,
+                "WAL truncate failed after mutation (WAL contents already zeroed): {e}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for TruncateError {}
+
 /// Sync directory metadata to ensure file entries are persisted
 ///
 /// On POSIX systems this is critical for crash safety - without syncing the
@@ -631,6 +676,26 @@ pub struct WriteAheadLog {
     /// (where a synced write would be lost on the next replay). `None` for a
     /// freshly created WAL, a clean reopen, or a torn tail (already trimmed).
     pending_valid_prefix: Option<u64>,
+    /// Set when a post-`set_len(0)` restore step (issue #1392, FINDING 1) left
+    /// the WAL in a state where the file cursor's position no longer
+    /// authoritatively matches `current_size`. The canonical case is a failed
+    /// `seek(0)` after truncation: the cursor may remain at the stale OLD
+    /// end-of-file while `current_size` has been reset to 0, so a later
+    /// `append()` would write at that stale offset over the now-zeroed file,
+    /// producing a sparse / misparsed WAL (silent corruption). Once poisoned,
+    /// every `append`/`sync`/`truncate` fails closed with a typed
+    /// [`Error::Storage`] until the WAL is reopened.
+    poisoned: Option<String>,
+    /// Test-only fault injection: when set, force the `sync_all` performed
+    /// *after* `set_len(0)` inside [`WriteAheadLog::truncate_checked`] to fail,
+    /// exercising the `AfterMutation` state-restore path (issue #1392).
+    #[cfg(test)]
+    fail_sync_after_truncate: bool,
+    /// Test-only fault injection: when set, force the `seek(0)` performed
+    /// *after* `set_len(0)` inside [`WriteAheadLog::truncate_checked`] to fail,
+    /// exercising the poison-on-partial-failure path (issue #1392, FINDING 1).
+    #[cfg(test)]
+    fail_seek_after_truncate: bool,
 }
 
 impl WriteAheadLog {
@@ -690,6 +755,11 @@ impl WriteAheadLog {
             buffer_size,
             current_size: 0,
             pending_valid_prefix: None,
+            poisoned: None,
+            #[cfg(test)]
+            fail_sync_after_truncate: false,
+            #[cfg(test)]
+            fail_seek_after_truncate: false,
         })
     }
 
@@ -791,6 +861,11 @@ impl WriteAheadLog {
             buffer_size: Self::DEFAULT_BUFFER_SIZE,
             current_size,
             pending_valid_prefix,
+            poisoned: None,
+            #[cfg(test)]
+            fail_sync_after_truncate: false,
+            #[cfg(test)]
+            fail_seek_after_truncate: false,
         })
     }
 
@@ -1022,6 +1097,11 @@ impl WriteAheadLog {
     /// Returns an error if serialization fails or the write fails.
     #[tracing::instrument(name = "wal.append", skip(self, mutation))]
     pub fn append(&mut self, mutation: &Mutation) -> Result<()> {
+        // Fail closed if a prior truncate poisoned the WAL (issue #1392,
+        // FINDING 1): appending at a stale cursor over a zeroed file would
+        // produce a sparse / misparsed WAL.
+        self.ensure_not_poisoned()?;
+
         // Refuse to append while a mid-stream corrupt tail is still on disk
         // (issue #1391). `open_existing` deliberately leaves the corrupt segment
         // intact for evidence preservation and records the valid-prefix boundary
@@ -1094,6 +1174,10 @@ impl WriteAheadLog {
     /// Returns an error if the flush or sync operation fails.
     #[tracing::instrument(name = "wal.sync", skip(self))]
     pub fn sync(&mut self) -> Result<()> {
+        // Fail closed if the WAL was poisoned by a partial truncate-restore
+        // (issue #1392, FINDING 1): its buffered/cursor state is not trustworthy.
+        self.ensure_not_poisoned()?;
+
         self.file
             .flush()
             .map_err(|e| Error::Storage(format!("Failed to flush WAL buffer: {}", e)))?;
@@ -1297,32 +1381,99 @@ impl WriteAheadLog {
     ///
     /// # Errors
     ///
-    /// Returns an error if the truncate operation fails.
+    /// Returns an error if the truncate operation fails. This flattens the
+    /// phase distinction of [`WriteAheadLog::truncate_checked`]; the
+    /// durability handoff (issue #1392) calls `truncate_checked` directly so it
+    /// can react differently to a failure that occurs *after* the WAL contents
+    /// have already been zeroed.
     pub fn truncate(&mut self) -> Result<()> {
-        // Flush any pending writes first
-        self.file
-            .flush()
-            .map_err(|e| Error::Storage(format!("Failed to flush before truncate: {}", e)))?;
+        self.truncate_checked().map_err(TruncateError::into_inner)
+    }
 
-        // Truncate the file to zero length
-        self.file
-            .get_mut()
-            .set_len(0)
-            .map_err(|e| Error::Storage(format!("Failed to truncate WAL: {}", e)))?;
+    /// Truncate the WAL, distinguishing failures **before** the WAL contents
+    /// are mutated from failures **after** `set_len(0)` has already zeroed it
+    /// (issue #1392).
+    ///
+    /// The sequence is: flush pending writes, `set_len(0)`, fsync, seek to
+    /// start. The `set_len(0)` call is the point of no return: once it
+    /// succeeds the on-disk WAL is empty and is **no longer a replayable
+    /// recovery marker**, even if a following fsync/seek fails.
+    ///
+    /// * A failure at or before `set_len(0)` returns
+    ///   [`TruncateError::BeforeMutation`] — the WAL is still intact and can be
+    ///   safely left in place for replay.
+    /// * A failure after `set_len(0)` returns [`TruncateError::AfterMutation`]
+    ///   — the WAL has been zeroed and callers MUST NOT treat it as intact.
+    pub fn truncate_checked(&mut self) -> std::result::Result<(), TruncateError> {
+        // A previously poisoned WAL cannot be truncated: its cursor/size state is
+        // untrustworthy (issue #1392, FINDING 1). Fail closed as AfterMutation so
+        // the caller does not treat the WAL as an intact replay marker.
+        if let Some(reason) = &self.poisoned {
+            return Err(TruncateError::AfterMutation(Error::Storage(format!(
+                "WAL is poisoned and cannot be truncated: {reason}"
+            ))));
+        }
 
-        // Fsync after truncate to ensure operation is persisted
-        self.file
-            .get_ref()
-            .sync_all()
-            .map_err(|e| Error::Storage(format!("Failed to sync after truncate: {}", e)))?;
+        // Flush any pending writes first (before mutation).
+        self.file.flush().map_err(|e| {
+            TruncateError::BeforeMutation(Error::Storage(format!(
+                "Failed to flush before truncate: {}",
+                e
+            )))
+        })?;
 
-        // Seek to beginning
-        self.file
-            .get_mut()
-            .seek(SeekFrom::Start(0))
-            .map_err(|e| Error::Storage(format!("Failed to seek after truncate: {}", e)))?;
+        // Truncate the file to zero length. This is the point of no return:
+        // after it succeeds the WAL contents are gone.
+        self.file.get_mut().set_len(0).map_err(|e| {
+            TruncateError::BeforeMutation(Error::Storage(format!("Failed to truncate WAL: {}", e)))
+        })?;
 
+        // From here on the WAL has already been mutated (zeroed). Any failure
+        // is AfterMutation: the WAL is no longer a valid replay marker.
+        //
+        // The post-mutation restore sequence (sync_all + seek(0) +
+        // current_size=0) must be atomic-in-effect (issue #1392, FINDING 1): we
+        // must never leave the WAL in a state where a later `append()` writes at
+        // a stale cursor over the zeroed file (a SPARSE / misparsed WAL). We run
+        // both fallible steps, then reconcile:
+        //
+        // * `seek(0)` succeeds  -> the file cursor is authoritatively at offset
+        //   0 and matches the reset `current_size`, so a subsequent append is
+        //   safe. A `sync_all` failure here only means the zeroing is not yet
+        //   durable, which we surface as AfterMutation (the WAL is still no
+        //   longer a replay marker) — but the handle remains usable.
+        // * `seek(0)` fails     -> the cursor may remain at the stale OLD
+        //   end-of-file while `current_size` was reset to 0. Rather than allow a
+        //   corrupting append, we POISON the WAL: every future
+        //   append/sync/truncate fails closed with a typed error until the WAL
+        //   is reopened (which re-establishes an authoritative cursor).
+        let sync_res = self.sync_after_truncate();
+        let seek_res = self.seek_after_truncate();
         self.current_size = 0;
+
+        // Post-mutation restore reconciliation (issue #1392, FINDING 1). These
+        // checks run BEFORE the #1391 corrupt-tail guard is lifted below: on a
+        // failure we return early with `pending_valid_prefix` still set, so the
+        // guard is cleared ONLY after a fully successful truncate.
+        if let Err(e) = seek_res {
+            // Cursor position is now unknown/stale while size was reset. Poison
+            // so no later append can silently create a sparse WAL.
+            let reason = format!("seek after truncate failed: {e}");
+            self.poisoned = Some(reason);
+            return Err(TruncateError::AfterMutation(Error::Storage(format!(
+                "Failed to seek after truncate; WAL poisoned to prevent a sparse \
+                 append: {e}"
+            ))));
+        }
+
+        // Seek succeeded: cursor is authoritatively at 0. Surface a sync failure
+        // (durability of the zeroing) as AfterMutation, but the WAL stays usable.
+        if let Err(e) = sync_res {
+            return Err(TruncateError::AfterMutation(Error::Storage(format!(
+                "Failed to sync after truncate: {}",
+                e
+            ))));
+        }
 
         // Clear any pending corrupt-tail guard (issue #1391, roborev r4). If this
         // WAL was opened over a mid-stream corrupt tail, `open_existing` recorded
@@ -1332,11 +1483,69 @@ impl WriteAheadLog {
         // gone from the LIVE log — leaving the guard set would wrongly reject ALL
         // future appends against a now-empty WAL (deadlocked appends). The guard is
         // lifted only HERE, after the flush/set_len/fsync/seek steps have all
-        // succeeded; any earlier failure returns via `?` with the guard still set,
+        // succeeded; any earlier failure returns early with the guard still set,
         // so the on-disk state and the fail-closed guard remain consistent.
         self.pending_valid_prefix = None;
 
         Ok(())
+    }
+
+    /// Return an error if the WAL has been poisoned by a partial
+    /// truncate-restore failure (issue #1392, FINDING 1).
+    fn ensure_not_poisoned(&self) -> Result<()> {
+        if let Some(reason) = &self.poisoned {
+            return Err(Error::Storage(format!(
+                "WAL is poisoned after a failed truncate-restore and must be \
+                 reopened before further writes: {reason}"
+            )));
+        }
+        Ok(())
+    }
+
+    /// Perform the post-`set_len(0)` fsync, with a test-only fault hook.
+    ///
+    /// In production this simply calls `sync_all` on the underlying file. Under
+    /// `cfg(test)` a fault can be injected (see `fail_sync_after_truncate`) so
+    /// the `AfterMutation` state-restore path in `truncate_checked` can be
+    /// exercised deterministically (issue #1392, FINDING 2).
+    fn sync_after_truncate(&self) -> std::io::Result<()> {
+        #[cfg(test)]
+        if self.fail_sync_after_truncate {
+            return Err(std::io::Error::other("injected post-set_len(0) sync fault"));
+        }
+        self.file.get_ref().sync_all()
+    }
+
+    /// Perform the post-`set_len(0)` seek back to the start of the now-empty
+    /// file, with a test-only fault hook.
+    ///
+    /// In production this seeks the underlying handle to offset 0. Under
+    /// `cfg(test)` a fault can be injected (see `fail_seek_after_truncate`) so
+    /// the poison-on-partial-failure path in `truncate_checked` can be exercised
+    /// deterministically (issue #1392, FINDING 1).
+    fn seek_after_truncate(&mut self) -> std::io::Result<u64> {
+        #[cfg(test)]
+        if self.fail_seek_after_truncate {
+            return Err(std::io::Error::other("injected post-set_len(0) seek fault"));
+        }
+        self.file.get_mut().seek(SeekFrom::Start(0))
+    }
+
+    /// Test-only: arm/disarm the post-truncate sync fault (issue #1392).
+    ///
+    /// `pub(crate)` so the sibling `write_engine` modules' `#[cfg(test)]` tests
+    /// (e.g. the WriteEngine-level post-mutation-truncate regression) can drive
+    /// the `AfterMutation` path through the real durability barrier.
+    #[cfg(test)]
+    pub(crate) fn set_fail_sync_after_truncate(&mut self, fail: bool) {
+        self.fail_sync_after_truncate = fail;
+    }
+
+    /// Test-only: arm/disarm the post-truncate seek fault (issue #1392,
+    /// FINDING 1), driving the poison-on-partial-failure path.
+    #[cfg(test)]
+    pub(crate) fn set_fail_seek_after_truncate(&mut self, fail: bool) {
+        self.fail_seek_after_truncate = fail;
     }
 
     /// Get the current size of the WAL in bytes
@@ -1526,6 +1735,135 @@ mod tests {
 
         let mutations = wal.replay().unwrap().mutations;
         assert_eq!(mutations.len(), 0);
+    }
+
+    // Issue #1392 (FINDING 2): a `truncate_checked` whose `sync_all` fails
+    // AFTER `set_len(0)` has already zeroed the WAL must (a) report
+    // `AfterMutation` so the flush error propagates, and (b) still restore the
+    // in-memory + file-handle state to offset 0. Otherwise a subsequent append
+    // lands at the stale OLD end-of-file, producing a SPARSE WAL that replay
+    // skips or misparses. This test injects that post-`set_len(0)` sync fault,
+    // then performs a fresh append and verifies replay returns exactly that
+    // write (no sparse / lost / misparsed WAL).
+    #[test]
+    fn truncate_post_setlen_sync_failure_resets_state_for_replay() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut wal = WriteAheadLog::create(temp_dir.path()).unwrap();
+
+        // Seed a few entries so the OLD end-of-file is well past offset 0.
+        for i in 0..3 {
+            wal.append(&create_test_mutation(i, &format!("Old{}", i)))
+                .unwrap();
+        }
+        wal.sync().unwrap();
+        assert!(wal.size() > 0);
+
+        // Arm the fault: the sync AFTER set_len(0) will fail.
+        wal.set_fail_sync_after_truncate(true);
+        let err = wal
+            .truncate_checked()
+            .expect_err("post-set_len(0) sync fault must surface");
+        assert!(
+            matches!(err, TruncateError::AfterMutation(_)),
+            "a failure after set_len(0) must be AfterMutation (WAL already zeroed)"
+        );
+
+        // Despite the propagated error, in-memory state was restored to the
+        // start of the now-empty file.
+        assert_eq!(wal.size(), 0, "current_size must be reset to 0");
+
+        // Disarm the fault and perform a subsequent write, as the still-usable
+        // engine would after the propagated flush error.
+        wal.set_fail_sync_after_truncate(false);
+        wal.append(&create_test_mutation(42, "New")).unwrap();
+        wal.sync().unwrap();
+
+        // Replay must return exactly the new entry, read from offset 0 — proving
+        // the append landed at 0 (not the stale old EOF) and the WAL is neither
+        // sparse nor misparsed.
+        let mutations = wal.replay().unwrap().mutations;
+        assert_eq!(
+            mutations.len(),
+            1,
+            "replay must return exactly the post-fault write, with no sparse gap"
+        );
+        assert_eq!(mutations[0].table.keyspace, "test_ks");
+        assert_eq!(
+            mutations[0].partition_key.columns[0].1,
+            Value::Integer(42),
+            "the replayed entry must be the new write, correctly parsed"
+        );
+    }
+
+    // Issue #1392 (FINDING 1): if the `seek(0)` performed AFTER `set_len(0)`
+    // fails, the file cursor may remain at the stale OLD end-of-file while
+    // `current_size` has been reset to 0. A naive implementation would let a
+    // later `append()` land at that stale offset over the now-zeroed file,
+    // producing a SPARSE / misparsed WAL (silent corruption). The truncate must
+    // instead POISON the WAL so a subsequent append fails closed rather than
+    // corrupting it. This test injects that post-`set_len(0)` seek fault, then
+    // proves the subsequent append (and sync) fail closed.
+    #[test]
+    fn truncate_post_setlen_seek_failure_poisons_wal_no_sparse_append() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut wal = WriteAheadLog::create(temp_dir.path()).unwrap();
+
+        // Seed a few entries so the OLD end-of-file is well past offset 0.
+        for i in 0..3 {
+            wal.append(&create_test_mutation(i, &format!("Old{i}")))
+                .unwrap();
+        }
+        wal.sync().unwrap();
+        assert!(wal.size() > 0);
+
+        // Arm the fault: set_len(0) + sync succeed, but the seek back to 0 fails,
+        // leaving the cursor at the stale OLD end-of-file.
+        wal.set_fail_seek_after_truncate(true);
+        let err = wal
+            .truncate_checked()
+            .expect_err("post-set_len(0) seek fault must surface");
+        assert!(
+            matches!(err, TruncateError::AfterMutation(_)),
+            "a failure after set_len(0) must be AfterMutation (WAL already zeroed)"
+        );
+
+        // The WAL is now poisoned. Disarm the seek fault to prove the fail-closed
+        // behavior comes from the poison state, NOT the injected fault.
+        wal.set_fail_seek_after_truncate(false);
+
+        // A subsequent append MUST fail closed rather than silently write at the
+        // stale cursor and create a sparse WAL.
+        let append_err = wal
+            .append(&create_test_mutation(42, "New"))
+            .expect_err("append on a poisoned WAL must fail closed");
+        assert!(
+            matches!(append_err, Error::Storage(_)),
+            "poisoned-WAL append must return a typed storage error, got {append_err:?}"
+        );
+
+        // sync must likewise fail closed.
+        assert!(
+            wal.sync().is_err(),
+            "sync on a poisoned WAL must fail closed"
+        );
+
+        // And re-truncation must fail closed as AfterMutation (untrustworthy).
+        assert!(
+            matches!(wal.truncate_checked(), Err(TruncateError::AfterMutation(_))),
+            "truncate on a poisoned WAL must fail closed as AfterMutation"
+        );
+
+        // The on-disk WAL is empty (set_len(0) succeeded) and no corrupting
+        // append occurred, so replay from a freshly opened handle yields nothing
+        // — proving no sparse / misparsed entry was written.
+        let wal_path = wal.path().to_path_buf();
+        drop(wal);
+        let reopened = WriteAheadLog::open_existing(&wal_path).unwrap();
+        assert_eq!(
+            reopened.replay().unwrap().mutations.len(),
+            0,
+            "no sparse / lost / misparsed entry may exist after a poisoned truncate"
+        );
     }
 
     #[test]

--- a/cqlite-core/tests/issue_819_differential_compaction.rs
+++ b/cqlite-core/tests/issue_819_differential_compaction.rs
@@ -1024,7 +1024,6 @@ fn ref_sstable_info(data_path: &Path) -> cqlite_core::storage::sstable::writer::
         crc_path: opt("CRC.db"),
         partition_count: 0,
         data_size,
-        created_dirs: Vec::new(),
     }
 }
 

--- a/cqlite-core/tests/issue_819_differential_compaction.rs
+++ b/cqlite-core/tests/issue_819_differential_compaction.rs
@@ -1024,6 +1024,7 @@ fn ref_sstable_info(data_path: &Path) -> cqlite_core::storage::sstable::writer::
         crc_path: opt("CRC.db"),
         partition_count: 0,
         data_size,
+        created_dirs: Vec::new(),
     }
 }
 


### PR DESCRIPTION
Closes #1392. Parent epic: #1379 (WAL crash-safety). Oracle-driven — no OpenSpec.

## What
New `write_engine/durability.rs`: `DurabilityBarrier` trait seam + `RealDurabilityBarrier` with platform-appropriate `sync_directory` (POSIX dir fsync on unix, documented no-op elsewhere) and `finalize_flush_durability()`. Flush now fsyncs the SSTable's parent directory (durable dirents) **before** `wal.truncate()`. Dir-fsync failure propagates and leaves the WAL intact; truncate failure is no longer silently swallowed — warns and leaves the WAL as a durable replay marker (replay is LWW-idempotent). `mod.rs` rewire is net-neutral (campsite ratchet passes).

## Acceptance criteria — all met (`durability.rs`)
1. `dir_fsync_precedes_wal_truncate` (recorder asserts `[SyncDir, WalTruncate]`)
2. `faulted_truncate_leaves_replayable_wal`
3. `faulted_dir_fsync_leaves_wal_intact`
- plus `real_barrier_syncs_existing_directory`

## Gate
All change-relevant components PASS. Single `core-tests` FAIL is the pre-existing shared-corpus red `issue_1000_verifier::filter_db_bit_flip` (tracked #1415), reproduced identically on detached `origin/main`.