### PR TITLE
perf(#1333): hoist per-partition scratch Vec in windowed scan driver

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
+++ b/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
@@ -73,7 +73,7 @@
 //!   `StreamingConfig::buffer_size`.
 //! - **`max_partition_size`** — INHERENT to any row-materializing partition scan and
 //!   PRE-DATES this change: `drain_scan_window` parses one CONFIRMED partition fully
-//!   into a `surviving: Vec<(RowKey, Value)>` before batching (the parser's `FnMut`
+//!   into a reused `scratch: Vec<(RowKey, Value)>` before batching (the parser's `FnMut`
 //!   emit is synchronous, so a partition's rows cannot stream out mid-parse), so if
 //!   `blocking_send` stalls mid-iteration the producer still owns that Vec's
 //!   not-yet-batched tail. This is the pre-existing #1156 windowed-scan heap term
@@ -172,7 +172,7 @@ const RAW_CHUNK_CHANNEL_CAP: usize = 8;
 /// ~`BATCH_EMIT_ROWS`× (one wake per batch instead of one per row) while keeping
 /// the bounded-heap and backpressure guarantees: a batch holds at most this many
 /// `(RowKey, Value)` already-owned entries (the same entries the prior code held
-/// transiently in `surviving`), and the batch channel is bounded
+/// transiently in `scratch`), and the batch channel is bounded
 /// ([`BATCH_CHANNEL_CAP`]) so a slow consumer still stops the parse loop, which
 /// still stops draining raw chunks, which still stops disk reads. Order is
 /// preserved (entries are pushed and drained FIFO, batches sent in order). A
@@ -200,7 +200,7 @@ const BATCH_CHANNEL_CAP: usize = 2;
 /// resident-row bound: the complete worst case (module doc) is
 /// `buffer_size + max_partition_size + MAX_INFLIGHT_BATCH_ROWS`, and this constant
 /// does NOT cover the inherent pre-existing-#1156 `max_partition_size` term (the one
-/// confirmed partition `drain_scan_window` materializes in `surviving` before
+/// confirmed partition `drain_scan_window` materializes in `scratch` before
 /// batching). It is named/tested so a future `BATCH_EMIT_ROWS`/`BATCH_CHANNEL_CAP`
 /// tweak cannot silently let batching run arbitrarily far ahead of a stalled consumer.
 ///
@@ -529,6 +529,17 @@ impl SSTableReader {
         // partition's worth of rows, so it stays within the sliding-window heap
         // bound.
         let mut batch: Vec<(RowKey, Value)> = Vec::with_capacity(BATCH_EMIT_ROWS);
+        // Reused scratch buffer for ONE confirmed partition's surviving
+        // `(RowKey, Value)` entries. Hoisted OUT of the per-partition loop in
+        // [`drain_scan_window`] (issue #1333, follow-up to #1046) and passed by
+        // `&mut` so it is allocated ONCE for the whole scan and `.clear()`-reused
+        // per partition. `clear()` drops the prior partition's entries but PRESERVES
+        // capacity, so a warmed buffer performs ZERO per-partition backing
+        // allocations — the #1046 "buffers should be reused, do not allocate as we
+        // iterate" mandate, extended to the per-partition scratch. Its peak size is
+        // still bounded by one partition's rows (`max_partition_size`), the same
+        // bound the transient per-partition `Vec::new()` had.
+        let mut scratch: Vec<(RowKey, Value)> = Vec::new();
 
         // The parse loop + terminal drain are fallible; on ANY `Err` we must
         // first deliver the rows already buffered in `batch` (confirmed rows
@@ -564,6 +575,7 @@ impl SSTableReader {
                     false,
                     &tx,
                     &mut batch,
+                    &mut scratch,
                     &mut broke,
                 )?;
                 if broke {
@@ -611,6 +623,7 @@ impl SSTableReader {
                     true,
                     &tx,
                     &mut batch,
+                    &mut scratch,
                     &mut broke,
                 )?;
             }
@@ -667,6 +680,7 @@ impl SSTableReader {
         at_final_chunk: bool,
         tx: &mpsc::Sender<Result<Vec<(RowKey, Value)>>>,
         batch: &mut Vec<(RowKey, Value)>,
+        scratch: &mut Vec<(RowKey, Value)>,
         broke: &mut bool,
     ) -> Result<()> {
         use crate::storage::sstable::reader::parsing::ParseStep;
@@ -676,12 +690,24 @@ impl SSTableReader {
                 return Ok(());
             }
 
-            // Buffer this partition's surviving entries, then forward them via
-            // `blocking_send` AFTER the parser returns.
-            // `parse_one_partition_with_timestamps` takes a synchronous `FnMut`
-            // emit, so we cannot send inside it; a partition's rows are bounded
-            // by `max_partition_size`, so this stays within the window bound.
-            let mut surviving: Vec<(RowKey, Value)> = Vec::new();
+            // Buffer this partition's surviving entries in the caller's REUSED
+            // `scratch` buffer, then forward them via `blocking_send` AFTER the
+            // parser returns. `parse_one_partition_with_timestamps` takes a
+            // synchronous `FnMut` emit, so we cannot send inside it; a partition's
+            // rows are bounded by `max_partition_size`, so this stays within the
+            // window bound. `clear()` drops the previous partition's entries but
+            // PRESERVES the backing capacity, so after warmup this loop performs
+            // NO per-partition allocation for `scratch` (issue #1333, follow-up to
+            // #1046). NeedMore/Done leave `scratch` empty (the parser only invokes
+            // the emit closure on a CONFIRMED `Emitted`), so nothing leaks across
+            // partitions.
+            scratch.clear();
+            // Snapshot the (retained) capacity BEFORE this partition's pushes so
+            // the offload probe can count how many times `scratch` actually grows
+            // its backing store across the whole scan — the direct signal that the
+            // buffer is reused, not reallocated per partition (issue #1333 guard).
+            #[cfg(feature = "scan-offload-probe")]
+            let scratch_cap_before = scratch.capacity();
             let step = parser.parse_one_partition_with_timestamps(
                 window.as_slice(),
                 ctx.schema.as_ref(),
@@ -709,10 +735,19 @@ impl SSTableReader {
                     if !self.filter_tombstone(&value) {
                         return Ok(std::ops::ControlFlow::Continue(()));
                     }
-                    surviving.push((key, value));
+                    scratch.push((key, value));
                     Ok(std::ops::ControlFlow::Continue(()))
                 },
             )?;
+
+            // Record whether this partition forced `scratch` to (re)allocate its
+            // backing store. With the hoist this happens only while the buffer
+            // grows to its high-water mark (a small bounded number of times per
+            // scan); if the buffer were freshly allocated per partition it would
+            // grow from empty EVERY partition, so the count would scale with
+            // partition count — exactly what the #1333 guard asserts it does not.
+            #[cfg(feature = "scan-offload-probe")]
+            probe::note_scratch_capacity(scratch_cap_before, scratch.capacity());
 
             match step {
                 ParseStep::Emitted(consumed) => {
@@ -724,7 +759,7 @@ impl SSTableReader {
                     // backpressure as the prior per-row send (this runs on a
                     // spawn_blocking thread) but wakes the async forwarder once per
                     // batch instead of once per row (issue #1143).
-                    for entry in surviving {
+                    for entry in scratch.drain(..) {
                         batch.push(entry);
                         if batch.len() >= BATCH_EMIT_ROWS {
                             let full =
@@ -739,7 +774,7 @@ impl SSTableReader {
                 // NeedMore: the partition straddles this chunk boundary. The
                 // per-partition parser buffers a partition's rows internally and
                 // only invokes our emit closure on a CONFIRMED `Emitted` return,
-                // so on `NeedMore` our `surviving` buffer is empty — nothing was
+                // so on `NeedMore` our `scratch` buffer is empty — nothing was
                 // forwarded and nothing is dropped. The caller appends the next
                 // chunk and we re-parse this partition from its start, so no row
                 // is duplicated or lost across the boundary. Record the straddle
@@ -760,54 +795,15 @@ impl SSTableReader {
     }
 }
 
-/// Test-only probe (issue #1143): records the [`std::thread::ThreadId`] on which
-/// the windowed scan's decompress+parse half actually ran, so a guard test can
-/// deterministically prove that work executed on a `spawn_blocking` thread and
-/// NOT on a tokio async worker.
-///
-/// Compiled ONLY under the non-default `scan-offload-probe` feature. In a
-/// normal/default/release build this module, its statics, and its call-site do
-/// not exist at all — the probe never enters the crate's public surface and adds
-/// zero cost (issue #1143 finding 1).
+/// Test-only probe (issues #1143, #1333) for the windowed scan — see
+/// `scan_stream_windowed_probe.rs`. Compiled ONLY under the non-default
+/// `scan-offload-probe` feature, so it adds zero cost and no public surface in
+/// normal/release builds (issue #1143 finding 1); kept in a sibling file so this
+/// source stays under the campsite-rule size limit (epic #1116).
 #[cfg(feature = "scan-offload-probe")]
 #[doc(hidden)]
-pub mod probe {
-    use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::Mutex;
-    use std::thread::ThreadId;
-
-    static ARMED: AtomicBool = AtomicBool::new(false);
-    static LAST_PARSE_THREAD: Mutex<Option<ThreadId>> = Mutex::new(None);
-
-    /// Arm the probe and clear any previously recorded thread. Call from a test
-    /// before driving a scan.
-    pub fn arm() {
-        if let Ok(mut g) = LAST_PARSE_THREAD.lock() {
-            *g = None;
-        }
-        ARMED.store(true, Ordering::SeqCst);
-    }
-
-    /// Disarm the probe (restores the production no-op state).
-    pub fn disarm() {
-        ARMED.store(false, Ordering::SeqCst);
-    }
-
-    /// Record the current thread as the parse thread, if armed. Called from the
-    /// blocking parse half after a scan's parse work completes.
-    pub(super) fn record_parse_thread() {
-        if ARMED.load(Ordering::Relaxed) {
-            if let Ok(mut g) = LAST_PARSE_THREAD.lock() {
-                *g = Some(std::thread::current().id());
-            }
-        }
-    }
-
-    /// The [`ThreadId`] recorded by the most recent parse, if any.
-    pub fn recorded_parse_thread() -> Option<ThreadId> {
-        LAST_PARSE_THREAD.lock().ok().and_then(|g| *g)
-    }
-}
+#[path = "scan_stream_windowed_probe.rs"]
+pub mod probe;
 
 // Unit + dataset-dependent guards live in a sibling file to keep this source
 // file under the campsite-rule size limit (issue #1143). `use super::*` in the

--- a/cqlite-core/src/storage/sstable/reader/scan_stream_windowed_probe.rs
+++ b/cqlite-core/src/storage/sstable/reader/scan_stream_windowed_probe.rs
@@ -1,0 +1,79 @@
+//! Test-only probe (issues #1143, #1333) for the windowed streaming scan.
+//!
+//! Records (a) the [`std::thread::ThreadId`] on which the windowed scan's
+//! decompress+parse half actually ran, so a guard test can deterministically
+//! prove that work executed on a `spawn_blocking` thread and NOT on a tokio async
+//! worker (#1143); and (b) how many times the per-partition scratch buffer GREW
+//! its backing store, so a guard test can prove the scratch is reused across
+//! partitions rather than reallocated per partition (#1333).
+//!
+//! Included via `#[cfg(feature = "scan-offload-probe")] #[path =
+//! "scan_stream_windowed_probe.rs"] pub mod probe;` in the parent module and
+//! compiled ONLY under the non-default `scan-offload-probe` feature. In a
+//! normal/default/release build this module, its statics, and its call-sites do
+//! not exist at all — the probe never enters the crate's public surface and adds
+//! zero cost (issue #1143 finding 1). Kept in a sibling file so the parent stays
+//! under the campsite-rule size limit (epic #1116).
+
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Mutex;
+use std::thread::ThreadId;
+
+static ARMED: AtomicBool = AtomicBool::new(false);
+static LAST_PARSE_THREAD: Mutex<Option<ThreadId>> = Mutex::new(None);
+/// Number of times the per-partition scratch buffer GREW its backing store
+/// during the armed scan (issue #1333). With the scratch hoisted out of the
+/// per-partition loop and `.clear()`-reused this is a small bounded count
+/// (the buffer grows only up to its high-water mark); if the buffer were
+/// reallocated per partition it would grow from empty every partition, so this
+/// count would scale with partition count.
+static SCRATCH_ALLOCS: AtomicUsize = AtomicUsize::new(0);
+
+/// Arm the probe and clear any previously recorded thread + scratch-growth
+/// count. Call from a test before driving a scan.
+pub fn arm() {
+    if let Ok(mut g) = LAST_PARSE_THREAD.lock() {
+        *g = None;
+    }
+    SCRATCH_ALLOCS.store(0, Ordering::SeqCst);
+    ARMED.store(true, Ordering::SeqCst);
+}
+
+/// Disarm the probe (restores the production no-op state).
+pub fn disarm() {
+    ARMED.store(false, Ordering::SeqCst);
+}
+
+/// Record the current thread as the parse thread, if armed. Called from the
+/// blocking parse half after a scan's parse work completes.
+pub(super) fn record_parse_thread() {
+    if ARMED.load(Ordering::Relaxed) {
+        if let Ok(mut g) = LAST_PARSE_THREAD.lock() {
+            *g = Some(std::thread::current().id());
+        }
+    }
+}
+
+/// The [`ThreadId`] recorded by the most recent parse, if any.
+pub fn recorded_parse_thread() -> Option<ThreadId> {
+    LAST_PARSE_THREAD.lock().ok().and_then(|g| *g)
+}
+
+/// Record that the per-partition scratch buffer's capacity changed from
+/// `before` to `after`. Counts one growth event whenever `after > before`
+/// (a Vec grows its backing store only by reallocating). Called once per
+/// partition from [`super::SSTableReader::drain_scan_window`]; a no-op unless
+/// armed. Issue #1333 scratch-reuse guard.
+pub(super) fn note_scratch_capacity(before: usize, after: usize) {
+    if ARMED.load(Ordering::Relaxed) && after > before {
+        SCRATCH_ALLOCS.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// The number of scratch-buffer growth events recorded during the armed scan.
+/// Bounded and independent of partition count when the scratch is reused
+/// (issue #1333); scales with partition count if it is reallocated per
+/// partition.
+pub fn recorded_scratch_allocs() -> usize {
+    SCRATCH_ALLOCS.load(Ordering::Relaxed)
+}

--- a/cqlite-core/src/storage/sstable/reader/scan_stream_windowed_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/scan_stream_windowed_tests.rs
@@ -486,7 +486,7 @@ mod fixture_drain {
     /// sized by the caller's channel, not that it is the whole pipeline's resident
     /// bound. The full resident-row worst case ALSO includes the inherent
     /// `max_partition_size` term (the one confirmed partition `drain_scan_window`
-    /// materializes in `surviving` before batching — pre-existing #1156 behavior);
+    /// materializes in `scratch` before batching — pre-existing #1156 behavior);
     /// that term is documented on the constant and NOT asserted here.
     ///
     /// Dataset-dependent: skips when the fixture is absent. The pure

--- a/cqlite-core/tests/issue_1333_scan_scratch_reuse.rs
+++ b/cqlite-core/tests/issue_1333_scan_scratch_reuse.rs
@@ -1,0 +1,228 @@
+//! Issue #1333 (follow-up to #1046): the windowed streaming scan's per-partition
+//! scratch buffer must be REUSED across partitions, not reallocated per
+//! partition.
+//!
+//! ## What this guards
+//!
+//! `drain_scan_window` (`scan_stream_windowed.rs`) parses ONE confirmed partition
+//! into a scratch `Vec<(RowKey, Value)>` before moving its entries into the
+//! outgoing batch. That scratch used to be a fresh `Vec::new()` allocated INSIDE
+//! the per-partition loop, so every non-empty partition allocated a new backing
+//! store. Issue #1333 hoists it OUT of the loop into `drain_scan_window_blocking`
+//! and `.clear()`-reuses it each partition; `clear()` preserves capacity, so a
+//! warmed buffer performs ZERO per-partition backing allocations. This is the
+//! #1046 mandate ("buffers should be reused, do not allocate as we iterate")
+//! applied to the per-partition scratch.
+//!
+//! ## Why a scratch-growth counter (not a global dhat delta)
+//!
+//! The hoist saves ONE backing allocation per non-empty partition. Against the
+//! full-scan allocation total (tens of allocations PER ROW for row
+//! materialization, per #1046) that single per-partition allocation is a fraction
+//! of a percent — far below the noise floor of a global `dhat` allocation-count
+//! delta, so a whole-scan dhat assertion could not distinguish the hoisted from
+//! the reallocating code without a flaky, razor-thin ceiling. Instead the
+//! `scan-offload-probe` instrumentation counts the SCRATCH BUFFER's OWN growth
+//! events directly (`recorded_scratch_allocs`): the Vec grows its backing store
+//! only by reallocating, so this is exactly "how many times was the scratch
+//! (re)allocated". This is the precise quantity the issue targets, measured
+//! without noise.
+//!
+//! ## Why it FAILS if the hoist is reverted
+//!
+//! `test_basic.simple_table` is UUID-keyed with no clustering column, so every
+//! row is its OWN partition (999 partitions on the pinned fixture). With the
+//! scratch reused, it grows only while climbing to its high-water mark — a small
+//! bounded count (`<= MAX_SCRATCH_GROWTHS`), INDEPENDENT of the 999 partitions.
+//! Revert the hoist (a fresh `Vec::new()` per partition) and the buffer grows
+//! from empty on EVERY non-empty partition, so the growth count jumps to ~999 —
+//! two orders of magnitude past the bound, failing this guard loudly. The
+//! assertion also requires the fixture to have produced far more partitions than
+//! the bound, so it can never pass vacuously.
+//!
+//! Requirements:
+//! - `CQLITE_DATASETS_ROOT` pointing to `test-data/datasets`
+//! - real SSTable Data.db files (`bash test-data/scripts/fetch-datasets.sh`).
+//!   Dataset-dependent: skips when Data.db is absent, but a present fixture that
+//!   returns zero rows / does not route through the windowed path is a FAILURE.
+
+// Requires the non-default `scan-offload-probe` feature: it gates the
+// `scan_stream_windowed::probe` instrumentation this guard reads (issue #1143
+// finding 1 / #1333). The agent gate runs this binary with the feature enabled.
+#![cfg(all(
+    feature = "state_machine",
+    feature = "cli-helpers",
+    feature = "scan-offload-probe"
+))]
+
+use std::path::PathBuf;
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::query::result::StreamingConfig;
+use cqlite_core::storage::sstable::reader::scan_stream_windowed::probe as scan_offload_probe;
+use cqlite_core::Database;
+
+/// UUID-keyed, no-clustering table: one row per partition, so the fixture has as
+/// many partitions as rows (999 on the pinned dataset) — the many-partition shape
+/// this guard needs.
+const KEYSPACE: &str = "test_basic";
+const TABLE: &str = "simple_table";
+const SCHEMA_FILE: &str = "basic-types.cql";
+
+/// Upper bound on scratch-buffer growth events for a full scan when the scratch is
+/// reused. The buffer grows only while climbing to its high-water mark: for this
+/// fixture's single-row partitions that is a 0 -> small-capacity step that happens
+/// essentially once, plus generous headroom for any legitimate high-water climb.
+/// It is a small CONSTANT — crucially NOT proportional to partition count — so a
+/// per-partition reallocation (the reverted code, ~999 growths) blows past it.
+const MAX_SCRATCH_GROWTHS: usize = 16;
+
+fn get_datasets_root() -> Option<PathBuf> {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+}
+
+fn get_schemas_dir() -> Option<PathBuf> {
+    if let Some(datasets_root) = get_datasets_root() {
+        if let Some(parent) = datasets_root.parent() {
+            let schemas_dir = parent.join("schemas");
+            if schemas_dir.exists() {
+                return Some(schemas_dir);
+            }
+        }
+    }
+    let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let schemas_dir = manifest_dir.parent()?.join("test-data").join("schemas");
+    schemas_dir.exists().then_some(schemas_dir)
+}
+
+/// Directory holding the fixture's SSTable components, if a Data.db is present.
+fn fixture_dir() -> Option<PathBuf> {
+    let root = get_datasets_root()?;
+    let table_root = root.join("sstables").join(KEYSPACE);
+    for entry in std::fs::read_dir(&table_root).ok()?.flatten() {
+        let name = entry.file_name();
+        if name.to_string_lossy().starts_with(&format!("{TABLE}-"))
+            && entry.path().is_dir()
+            && std::fs::read_dir(entry.path()).ok()?.flatten().any(|f| {
+                f.file_name()
+                    .to_str()
+                    .is_some_and(|n| n.ends_with("-Data.db"))
+            })
+        {
+            return Some(entry.path());
+        }
+    }
+    None
+}
+
+async fn setup_db() -> Database {
+    let datasets_root = get_datasets_root().expect("CQLITE_DATASETS_ROOT");
+    let schemas_dir = get_schemas_dir().expect("schemas dir");
+    let schema_path = schemas_dir.join(SCHEMA_FILE);
+    assert!(schema_path.exists(), "schema not found: {schema_path:?}");
+
+    let config = IngestionConfig {
+        schema_paths: vec![schema_path],
+        data_dir: datasets_root.join("sstables"),
+        version_hint: None,
+        core_config: cqlite_core::Config::default(),
+        table_directory_filter: Some(format!("/{KEYSPACE}/")),
+    };
+    ingest(config).await.expect("ingest simple_table").database
+}
+
+/// Drain a single full streaming scan to completion, returning the row count.
+/// `buffer_size = 1` maximizes per-partition backpressure so the parse loop runs
+/// in tight per-partition bursts — the exact shape that would reallocate a fresh
+/// scratch buffer every partition if it were not hoisted.
+async fn drain_one_scan(db: &Database, sql: &str) -> usize {
+    let config = StreamingConfig {
+        buffer_size: 1,
+        ..StreamingConfig::default()
+    };
+    let mut iter = db
+        .execute_streaming(sql, config)
+        .await
+        .expect("execute_streaming should succeed");
+    let mut n = 0usize;
+    while let Some(row) = iter.next_async().await {
+        row.expect("streamed row should be Ok");
+        n += 1;
+    }
+    n
+}
+
+/// The windowed streaming scan's per-partition scratch buffer must be reused, so
+/// its backing-store growth count stays a small constant regardless of how many
+/// partitions the scan drains.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn scratch_buffer_is_reused_across_partitions() {
+    let Some(_dir) = fixture_dir() else {
+        eprintln!(
+            "Skipping {KEYSPACE}.{TABLE}: no Data.db present (run fetch-datasets.sh). \
+             This guard is non-vacuous only with the real many-partition fixture."
+        );
+        return;
+    };
+
+    let db = setup_db().await;
+    let sql = format!("SELECT * FROM {KEYSPACE}.{TABLE}");
+
+    // Arm the probe, run a full streaming scan over the many-partition fixture,
+    // then read back how many times the scratch buffer grew.
+    scan_offload_probe::arm();
+    let rows = drain_one_scan(&db, &sql).await;
+    // `drain_one_scan` returns only after the stream ends, which the consumer
+    // observes only once the blocking parse task has dropped its sender — after
+    // its last `note_scratch_capacity`. That channel-close happens-before ordering
+    // makes every recorded growth visible to this read without a settle sleep.
+    let scratch_growths = scan_offload_probe::recorded_scratch_allocs();
+    scan_offload_probe::disarm();
+
+    // Non-vacuous: a present fixture must return rows AND must have routed through
+    // the windowed (chunk-stitching) parse path that arms the probe (a growth is
+    // recorded once per partition, so a windowed scan of a non-empty table records
+    // at least one).
+    assert!(
+        rows > 0,
+        "Issue #1333: {KEYSPACE}.{TABLE} is present but the streaming scan returned \
+         0 rows — guard would be vacuous"
+    );
+    assert!(
+        scratch_growths >= 1,
+        "Issue #1333: the scan returned {rows} rows but recorded 0 scratch-growth \
+         events — the windowed (chunk-stitching) scan path that this guard \
+         instruments did not run; fixture may not be the `nb` chunk-compressed \
+         format the probe instruments"
+    );
+
+    // Every row is its own partition (UUID PK, no clustering), so partitions ==
+    // rows. The bound must be far below the partition count or the guard is not
+    // meaningful: if it held, the "constant vs per-partition" distinction would be
+    // untestable on this fixture.
+    assert!(
+        rows > MAX_SCRATCH_GROWTHS * 4,
+        "Issue #1333: fixture has only {rows} partitions; need many more than the \
+         MAX_SCRATCH_GROWTHS={MAX_SCRATCH_GROWTHS} bound for the reuse assertion to \
+         be meaningful (a per-partition realloc must be able to overshoot it)"
+    );
+
+    eprintln!(
+        "Issue #1333 scratch-reuse guard: partitions(rows)={rows} \
+         scratch_growths={scratch_growths} (bound {MAX_SCRATCH_GROWTHS})"
+    );
+
+    assert!(
+        scratch_growths <= MAX_SCRATCH_GROWTHS,
+        "Issue #1333 REGRESSION: the per-partition scratch buffer grew its backing \
+         store {scratch_growths} times over a {rows}-partition scan (> \
+         {MAX_SCRATCH_GROWTHS}). A reused scratch grows only up to its high-water \
+         mark (a small constant); a count scaling with the {rows} partitions means \
+         the scratch is being reallocated per partition. Hoist the scratch `Vec` \
+         out of the per-partition loop in `drain_scan_window` and `.clear()`-reuse \
+         it (see `drain_scan_window_blocking`)."
+    );
+}

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -15,7 +15,10 @@
 #   scan-offload-guard cargo test -p cqlite-core --features cli-helpers,scan-offload-probe
 #                      --test issue_1143_scan_offload_thread (windowed-scan parse
 #                      runs off the async worker pool; probe is feature-gated so
-#                      the default core-tests run can't execute it — issue #1143)
+#                      the default core-tests run can't execute it — issue #1143).
+#                      Also runs --test issue_1333_scan_scratch_reuse (the
+#                      windowed scan's per-partition scratch Vec is reused, not
+#                      reallocated per partition — issue #1333); same feature gate.
 #   integration-tests  cargo test -p cqlite-integration-tests: compile ALL targets
 #                      (--no-run, whole package) then run the seven CI-enforced ones
 #   format-compat      cargo test -p format-compatibility-tests (the 'oa' format crate;
@@ -830,7 +833,8 @@ run_component tombstones-scan cargo test --package cqlite-core \
 # doesn't run in CI is not a guard.
 run_component scan-offload-guard cargo test --package cqlite-core \
   --features cli-helpers,scan-offload-probe \
-  --test issue_1143_scan_offload_thread
+  --test issue_1143_scan_offload_thread \
+  --test issue_1333_scan_scratch_reuse
 # Compile EVERY target in the package first (--no-run, whole package) so a
 # new/edited test file that doesn't compile can't hide behind the enumerated
 # run-list (issue #865); then execute the seven CI-enforced targets.


### PR DESCRIPTION
## What

Hoists the per-partition scratch `Vec` in the windowed scan driver (`drain_scan_window` / `scan_stream_windowed.rs`) so it is allocated **once** and `.clear()`/`.drain(..)`-reused across partitions instead of reallocated per partition. Internal-only, behavior-preserving — same row order/values/filters/bounds. Follow-up to #1046.

## Acceptance (manager-specified)
- ✅ Scratch Vec reused across partitions (allocated once, cleared per partition; capacity retained).
- ✅ Alloc guard test (`cqlite-core/tests/issue_1333_scan_scratch_reuse.rs`) proving per-partition allocations are bounded: full 1000-single-row-partition scan records **1** scratch growth (high-water once, then reused); guard asserts `<= 16` and is **non-vacuous** (asserts partition count >> bound). Verified fail-on-revert: reintroducing per-partition allocation drives the count to 1000 and the guard FAILS. Wired into the `scan-offload-guard` gate lane.

## Quality bar
- Gate: change's own lanes **PASS** (`file-size`, `fmt`, `clippy`, `scan-offload-guard` incl. the new guard, `integration-tests`, `write-tests`, `cli-tests`, `minimal-build`, `smoke`).
- Two aggregate gate FAILs verified **unrelated**: `core-tests` (`issue_1000_verifier` Filter.db false-negative) reproduces byte-identically on base `main` `cd9e324b` — pre-existing main-red, tracked in #1415/#1417/#1419; `node-bindings` was a transient build-kill that **PASSES** on clean isolated re-run.
- roborev (codex, `--base origin/main`): **clean** (no issues).

Closes #1333