### PR TITLE
test(#1397): corrupt-bytes tests drive the plain query surface (Database.execute / scan)

### DIFF
--- a/cqlite-core/tests/issue_1397_corrupt_query_surface.rs
+++ b/cqlite-core/tests/issue_1397_corrupt_query_surface.rs
@@ -1,0 +1,296 @@
+//! Issue #1397 (Epic #1380): the PLAIN user-facing query surface must surface a
+//! typed, non-recoverable corruption error when it reads a bit-flipped COMPRESSED
+//! chunk — it must NOT silently return garbage or truncate.
+//!
+//! ## Why this exists
+//!
+//! The production per-chunk CRC32 check (`reader/block_io.rs:412-440`) is real and
+//! unconditional, but before this suite its failure branch was only exercised
+//! *indirectly* (issue #998 drives `ChunkDecompressor`; verify Check 5/7 drive the
+//! verifier). Nothing asserted that a **user query** — `SSTableReader::scan`
+//! (full scan), `SSTableReader::get` (point lookup), or `scan_stream` (streaming) —
+//! returns the typed corruption error. A refactor that reroutes the query path
+//! around `read_next_block_impl` (exactly what the offset-based point-lookup path
+//! already does — see #1411) would pass every other test while silently returning
+//! garbage. These tests break on such a reroute.
+//!
+//! ## Fixture (real Cassandra 5.0.2 bytes, one deterministic bit flip)
+//!
+//! `corruption/test_comp_corrupt/data_db_bit_flip/nb-1-big-Data.db` — a single-bit
+//! flip (byte offset 64, `0x61`→`0x60`) inside the FIRST LZ4 compressed chunk of
+//! `test_comp/lz4_table`. That table is a single partition (`pk=1`) whose entire
+//! payload lives in chunk 0, so the corruption is unavoidable on any read of the
+//! data section. Apache Cassandra 5.0.2 `sstableverify -e` rejects this exact file
+//! ("Data.db digest integrity check failed -> Invalid SSTable"), per the corpus
+//! manifest (`corruption-manifest.yml`, fixture `data_db_bit_flip`).
+//!
+//! ## Error-variant note
+//!
+//! The scan/stream CRC-mismatch surfaces as `Error::InvalidFormat` (non-recoverable,
+//! message naming the chunk index + offset), NOT `Error::Corruption`. Both variants
+//! are non-recoverable (`error.rs`: `InvalidFormat => false`, `Corruption => false`),
+//! and #1397's substance is "typed non-recoverable error naming chunk + offset", so
+//! these tests assert those robust invariants rather than pinning the exact variant.
+//! Unifying the CRC-mismatch to `Error::Corruption` is tracked as a secondary note on
+//! #1411.
+//!
+//! ## Fixture-gating (issue #1094 doctrine, AC #5)
+//!
+//! Skip-clean when the corpus binary is absent; `CQLITE_REQUIRE_FIXTURES=1` turns
+//! that skip into a hard failure. A fixture that is *present but no longer corrupt*
+//! (regeneration rot) FAILS unconditionally — the scan/stream tests assert `Err`, so
+//! an `Ok` result on a present fixture fails the suite regardless of the env flag.
+
+use cqlite_core::storage::sstable::reader::SSTableReader;
+use cqlite_core::types::{RowKey, TableId};
+use cqlite_core::{Config, Error, Platform};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+/// Relative path of the corrupt COMPRESSED Data.db under the datasets root.
+const CORRUPT_DATA_DB: &str = "corruption/test_comp_corrupt/data_db_bit_flip/nb-1-big-Data.db";
+
+/// Fully-qualified table the corrupt fixture was derived from.
+const TABLE: &str = "test_comp.lz4_table";
+
+/// Partition key `pk = 1` serialized as a CQL `int` (4-byte big-endian). This is
+/// the ONLY partition in `lz4_table` and its row lives in the corrupt chunk 0.
+/// Verified against the CLEAN fixture: `get([0,0,0,1])` returns `Ok(Some(_))` there,
+/// so the bloom/key encoding is correct — the corrupt-fixture divergence is a
+/// read-path defect, not a wrong key.
+const PK1_KEY_BYTES: [u8; 4] = [0, 0, 0, 1];
+
+/// `true` when the full-dataset/nightly lanes demand the corpus be present.
+fn require_fixtures() -> bool {
+    matches!(
+        std::env::var("CQLITE_REQUIRE_FIXTURES").ok().as_deref(),
+        Some("1") | Some("true") | Some("TRUE")
+    )
+}
+
+/// Locate the datasets root, honoring `CQLITE_DATASETS_ROOT` with a worktree fallback.
+fn datasets_root() -> Option<PathBuf> {
+    if let Ok(root) = std::env::var("CQLITE_DATASETS_ROOT") {
+        let p = PathBuf::from(root);
+        if p.is_dir() {
+            return Some(p);
+        }
+    }
+    let fallback = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .map(|p| p.join("test-data/datasets"))?;
+    fallback.is_dir().then_some(fallback)
+}
+
+/// Resolve the corrupt Data.db path, applying the fail-closed gate (AC #5):
+/// - present  → `Some(path)`
+/// - absent + `CQLITE_REQUIRE_FIXTURES=1` → panic (hard failure)
+/// - absent otherwise → `None` (skip-clean)
+fn corrupt_data_db_or_gate() -> Option<PathBuf> {
+    let path = datasets_root().map(|r| r.join(CORRUPT_DATA_DB));
+    match path {
+        Some(p) if p.is_file() => Some(p),
+        _ => {
+            assert!(
+                !require_fixtures(),
+                "CQLITE_REQUIRE_FIXTURES=1 but the corruption fixture is absent: {CORRUPT_DATA_DB}. \
+                 Fetch the corpus (test-data/scripts/fetch-datasets.sh) / regenerate it \
+                 (test-data/scripts/generate-corruption-corpus.sh)."
+            );
+            eprintln!("SKIP: corruption fixture absent ({CORRUPT_DATA_DB}); set CQLITE_REQUIRE_FIXTURES=1 to enforce.");
+            None
+        }
+    }
+}
+
+async fn open_reader(path: &Path) -> SSTableReader {
+    let config = Config::default();
+    let platform = Arc::new(
+        Platform::new(&config)
+            .await
+            .expect("platform init should succeed"),
+    );
+    SSTableReader::open(path, &config, platform).await.expect(
+        "opening the (structurally valid) corrupt Data.db should succeed; \
+                 corruption is in a chunk payload, not the header",
+    )
+}
+
+/// Assert an error is the typed, non-recoverable corruption class that names the
+/// corrupt chunk index + on-disk offset. Shared by the full-scan and streaming
+/// tests so both prove the SAME invariant reached the user.
+fn assert_typed_chunk_corruption(err: &Error) {
+    // Non-recoverable class (error.rs) — a retry cannot help a bad chunk.
+    assert!(
+        !err.is_recoverable(),
+        "chunk CRC-mismatch must be a non-recoverable error, got recoverable: {err}"
+    );
+    let msg = err.to_string();
+    // Message must name the failing chunk index (chunk 0) AND its byte offset so an
+    // operator can locate the damage. Also confirms the error came from the inline
+    // per-chunk CRC path (`block_io.rs`), not a generic parse failure.
+    assert!(
+        msg.contains("chunk 0"),
+        "corruption error must name the chunk index ('chunk 0'), got: {msg}"
+    );
+    assert!(
+        msg.to_lowercase().contains("offset") && msg.contains("0x0"),
+        "corruption error must name the chunk offset (0x0), got: {msg}"
+    );
+    assert!(
+        msg.to_uppercase().contains("CRC"),
+        "corruption error should identify the CRC mismatch, got: {msg}"
+    );
+}
+
+/// AC #1 — full scan over the corrupt COMPRESSED fixture returns the typed,
+/// non-recoverable error naming chunk index + offset, and yields NO rows first.
+///
+/// Also serves AC #5's "present-but-clean fails" guard: this test only skips when
+/// the fixture is ABSENT; if it is present but no longer corrupt (regen rot),
+/// `scan` returns `Ok` and the assertion below fails.
+#[tokio::test]
+async fn full_scan_over_corrupt_chunk_errors_before_yielding_rows() {
+    let Some(path) = corrupt_data_db_or_gate() else {
+        return;
+    };
+    let reader = open_reader(&path).await;
+    let table_id = TableId::new(TABLE.to_string());
+
+    let result = reader.scan(&table_id, None, None, None, None).await;
+
+    match result {
+        Ok(rows) => panic!(
+            "FIXTURE ROT or read-path regression: full scan over the bit-flipped \
+             chunk returned Ok with {} rows; it must return a corruption error. \
+             (A refactor rerouting scan around read_next_block_impl would land here.)",
+            rows.len()
+        ),
+        Err(err) => {
+            assert_typed_chunk_corruption(&err);
+            // `scan` returns a materialized Vec, so the Err path inherently yielded
+            // zero rows for the corrupt chunk — there is no partial buffer to leak.
+        }
+    }
+}
+
+/// AC #3 — streaming/windowed scan (the stitch path, data_access/mod.rs:248-308)
+/// surfaces the same typed error MID-ITERATION: the iterator terminates with an
+/// `Err` item, not a silent truncation, and emits zero `Ok` rows beforehand.
+#[tokio::test]
+async fn streaming_scan_terminates_with_error_not_silent_truncation() {
+    let Some(path) = corrupt_data_db_or_gate() else {
+        return;
+    };
+    let reader = Arc::new(open_reader(&path).await);
+    let table_id = TableId::new(TABLE.to_string());
+
+    let mut rx = reader.scan_stream(table_id, None, None, None, 4);
+
+    let mut ok_rows = 0usize;
+    let mut terminal_err: Option<Error> = None;
+    while let Some(item) = rx.recv().await {
+        match item {
+            Ok(_) => ok_rows += 1,
+            Err(e) => {
+                terminal_err = Some(e);
+                break;
+            }
+        }
+    }
+
+    assert_eq!(
+        ok_rows, 0,
+        "the corrupt chunk holds the whole partition — no rows may be yielded before \
+         the error (silent truncation would show ok_rows>0 then a clean end-of-stream)"
+    );
+    let err = terminal_err.expect(
+        "streaming scan over the corrupt chunk must end with a terminal Err item, \
+         NOT a silent end-of-stream (which would be undetectable truncation)",
+    );
+    assert_typed_chunk_corruption(&err);
+}
+
+/// AC #2 — point lookup whose target row lives in the corrupt chunk.
+///
+/// EXPECTED behavior (issue #1397): a typed corruption error, NOT `Ok(None)`.
+///
+/// ACTUAL behavior (characterized): `Ok(None)`. The point-lookup path
+/// (`get` → bloom(present) → `read_value_at_offset`/`get_cached_data`) reads raw
+/// bytes at an offset and LZ4-decodes them WITHOUT the inline per-chunk CRC check,
+/// so a bit-flipped chunk reads as "not found" instead of surfacing corruption.
+/// The identical `get([0,0,0,1])` returns `Ok(Some(_))` on the CLEAN fixture, so
+/// this is a read-path defect, not a wrong key.
+///
+// KNOWN LIMITATION: see #1411 — point lookup bypasses the inline chunk-CRC check
+// and returns Ok(None) on a corrupt COMPRESSED chunk. This is a CHARACTERIZATION
+// test asserting today's (wrong) behavior so the suite stays green; when #1411 is
+// fixed this test must flip to assert `assert_typed_chunk_corruption(&err)`.
+#[tokio::test]
+async fn point_lookup_into_corrupt_chunk_currently_returns_ok_none_see_1411() {
+    let Some(path) = corrupt_data_db_or_gate() else {
+        return;
+    };
+    let reader = open_reader(&path).await;
+    let table_id = TableId::new(TABLE.to_string());
+    let key = RowKey::new(PK1_KEY_BYTES.to_vec());
+
+    let result = reader.get(&table_id, &key).await;
+
+    match result {
+        // Documented current defect (#1411).
+        Ok(None) => {
+            eprintln!(
+                "KNOWN LIMITATION #1411: point lookup for pk=1 over the corrupt chunk \
+                 returned Ok(None); expected a typed corruption error."
+            );
+        }
+        // If the read path ever starts surfacing the corruption here, #1411 is fixed
+        // — assert it is the correct typed error and update this test.
+        Err(err) => {
+            assert_typed_chunk_corruption(&err);
+            panic!(
+                "#1411 appears FIXED: point lookup now returns the typed corruption \
+                 error. Update this characterization test to assert Err unconditionally."
+            );
+        }
+        // Returning garbage from a corrupt chunk is never acceptable.
+        Ok(Some(v)) => panic!(
+            "point lookup over the corrupt chunk returned Ok(Some({v:?})) — garbage \
+             from a bit-flipped chunk. Neither the current (#1411) nor the correct \
+             behavior; hard failure."
+        ),
+    }
+}
+
+/// AC #5 (explicit) — the fail-closed gate itself: with `CQLITE_REQUIRE_FIXTURES=1`,
+/// an absent fixture MUST hard-fail rather than skip. Verifies the gate helper's
+/// contract without depending on the fixture being present in this process.
+#[test]
+fn require_fixtures_gate_hard_fails_on_absent_fixture() {
+    // Only meaningful when the fixture is genuinely absent; when present the gate
+    // returns the path (covered by the other tests). Probe presence directly so we
+    // don't trip the gate's own panic here.
+    let present = datasets_root()
+        .map(|r| r.join(CORRUPT_DATA_DB).is_file())
+        .unwrap_or(false);
+    if present {
+        eprintln!("fixture present — absent-path gate assertion is exercised elsewhere; skipping.");
+        return;
+    }
+
+    if require_fixtures() {
+        // In enforce mode, calling the gate on an absent fixture must panic.
+        let panicked = std::panic::catch_unwind(corrupt_data_db_or_gate).is_err();
+        assert!(
+            panicked,
+            "CQLITE_REQUIRE_FIXTURES=1 with an absent fixture must hard-fail (panic), not skip"
+        );
+    } else {
+        // Default mode: absent fixture skips cleanly (returns None).
+        assert!(
+            corrupt_data_db_or_gate().is_none(),
+            "absent fixture without enforce mode should skip (None)"
+        );
+    }
+}

--- a/cqlite-core/tests/issue_1397_corrupt_query_surface.rs
+++ b/cqlite-core/tests/issue_1397_corrupt_query_surface.rs
@@ -12,7 +12,10 @@
 //! returns the typed corruption error. A refactor that reroutes the query path
 //! around `read_next_block_impl` (exactly what the offset-based point-lookup path
 //! already does — see #1411) would pass every other test while silently returning
-//! garbage. These tests break on such a reroute.
+//! garbage. The scan/stream tests break on such a reroute. The point-lookup
+//! expectation is captured as an `#[ignore]`d expected-behavior regression test
+//! (asserting the typed corruption error) that is un-ignored when #1411 lands — we
+//! do NOT codify today's `Ok(None)` defect.
 //!
 //! ## Fixture (real Cassandra 5.0.2 bytes, one deterministic bit flip)
 //!
@@ -213,21 +216,19 @@ async fn streaming_scan_terminates_with_error_not_silent_truncation() {
 
 /// AC #2 — point lookup whose target row lives in the corrupt chunk.
 ///
-/// EXPECTED behavior (issue #1397): a typed corruption error, NOT `Ok(None)`.
+/// EXPECTED behavior (issue #1397): a typed, non-recoverable corruption error naming
+/// the corrupt chunk index + offset — NOT `Ok(None)` and NOT garbage.
 ///
-/// ACTUAL behavior (characterized): `Ok(None)`. The point-lookup path
-/// (`get` → bloom(present) → `read_value_at_offset`/`get_cached_data`) reads raw
-/// bytes at an offset and LZ4-decodes them WITHOUT the inline per-chunk CRC check,
-/// so a bit-flipped chunk reads as "not found" instead of surfacing corruption.
-/// The identical `get([0,0,0,1])` returns `Ok(Some(_))` on the CLEAN fixture, so
-/// this is a read-path defect, not a wrong key.
-///
-// KNOWN LIMITATION: see #1411 — point lookup bypasses the inline chunk-CRC check
-// and returns Ok(None) on a corrupt COMPRESSED chunk. This is a CHARACTERIZATION
-// test asserting today's (wrong) behavior so the suite stays green; when #1411 is
-// fixed this test must flip to assert `assert_typed_chunk_corruption(&err)`.
+/// This test asserts that correct behavior. It is `#[ignore]`d today because the
+/// point-lookup path (`get` → bloom(present) → `read_value_at_offset`/`get_cached_data`)
+/// reads raw bytes at an offset and LZ4-decodes them WITHOUT the inline per-chunk CRC
+/// check, so a bit-flipped chunk currently reads as "not found" (`Ok(None)`) instead
+/// of surfacing corruption. Fixing that bypass is tracked as #1411; un-ignore this
+/// test when #1411 lands. The identical `get([0,0,0,1])` returns `Ok(Some(_))` on the
+/// CLEAN fixture, so the divergence is a read-path defect, not a wrong key.
 #[tokio::test]
-async fn point_lookup_into_corrupt_chunk_currently_returns_ok_none_see_1411() {
+#[ignore = "expected behavior; blocked on #1411 (point-lookup bypasses inline chunk-CRC check). Un-ignore when #1411 lands."]
+async fn point_lookup_into_corrupt_chunk_should_error_see_1411() {
     let Some(path) = corrupt_data_db_or_gate() else {
         return;
     };
@@ -238,27 +239,14 @@ async fn point_lookup_into_corrupt_chunk_currently_returns_ok_none_see_1411() {
     let result = reader.get(&table_id, &key).await;
 
     match result {
-        // Documented current defect (#1411).
-        Ok(None) => {
-            eprintln!(
-                "KNOWN LIMITATION #1411: point lookup for pk=1 over the corrupt chunk \
-                 returned Ok(None); expected a typed corruption error."
-            );
-        }
-        // If the read path ever starts surfacing the corruption here, #1411 is fixed
-        // — assert it is the correct typed error and update this test.
-        Err(err) => {
-            assert_typed_chunk_corruption(&err);
-            panic!(
-                "#1411 appears FIXED: point lookup now returns the typed corruption \
-                 error. Update this characterization test to assert Err unconditionally."
-            );
-        }
-        // Returning garbage from a corrupt chunk is never acceptable.
+        Err(err) => assert_typed_chunk_corruption(&err),
+        Ok(None) => panic!(
+            "point lookup for pk=1 over the corrupt chunk returned Ok(None); it must \
+             return a typed corruption error (see #1411)."
+        ),
         Ok(Some(v)) => panic!(
             "point lookup over the corrupt chunk returned Ok(Some({v:?})) — garbage \
-             from a bit-flipped chunk. Neither the current (#1411) nor the correct \
-             behavior; hard failure."
+             from a bit-flipped chunk; it must return a typed corruption error."
         ),
     }
 }


### PR DESCRIPTION
Closes #1397. Part of epic #1380 (read-path integrity hardening).

## What
Adds fixture-gated corrupt-bytes tests on the compressed `data_db_bit_flip` corruption fixture that drive the **user-facing** query surface (not just `verify_sstable`), guarding the `block_io.rs:412-440` CRC-mismatch branch end-to-end:
- **full scan** — `SSTableReader::scan` errors with a typed, non-recoverable chunk corruption (names chunk index + offset); zero rows leaked before the error.
- **streaming/windowed scan** — the stitch path terminates with `Err` mid-iteration, not silent truncation.
- **point lookup** — `point_lookup_into_corrupt_chunk_should_error_see_1411`: `#[ignore]`d expected-behavior regression asserting the *correct* typed `Err` (panics on `Ok`); un-ignore when #1411 lands. (roborev-guided — does not codify the current defect.)
- **fail-closed gate** — `CQLITE_REQUIRE_FIXTURES=1` hard-fails on absent fixture; present-but-clean also fails (fixture-rot guard).

## Discovered (filed, not fixed inline — 1:1:1:1)
- **#1411** (P1) — point lookup bypasses the inline chunk-CRC check, returns `Ok(None)` on a corrupt compressed chunk. The exact "reroute around read_next_block_impl returns garbage" hazard this issue guards.
- **#1412** (P2) — bindings smoke follow-on (AC #4).

## Quality bar
- agent-gate.sh: **PASS** (all components).
- roborev (codex): **clean.**

Oracle-driven (no OpenSpec).