### PR TITLE
test(#1399): fail-closed rejection of zstd-dictionary SSTables + parity boundary evidence

### DIFF
--- a/cqlite-core/Cargo.toml
+++ b/cqlite-core/Cargo.toml
@@ -144,7 +144,7 @@ sha2 = "0.10"
 # rejection characterization test (issue #1399). Dev-only: proves CQLite's
 # decompression path rejects (never garbles) genuinely dictionary-compressed
 # zstd frames. `zdict_builder` (default) provides the trained-dictionary API.
-zstd = "0.13"
+zstd = { version = "0.13", features = ["zdict_builder"] }
 # Inline-CRC32 framing for the hand-built Cassandra chunk image in that same
 # test (integration tests don't inherit the library's normal dependencies).
 crc32fast = { workspace = true }

--- a/cqlite-core/Cargo.toml
+++ b/cqlite-core/Cargo.toml
@@ -140,6 +140,14 @@ libc = { workspace = true }
 num-traits = "0.2"  # Required for BigInt conversion methods
 # Full-fixture-dir hashing for the corruption-verify parity test (issue #1294).
 sha2 = "0.10"
+# Real zstd dictionary-frame generation for the zstd-dictionary fail-closed
+# rejection characterization test (issue #1399). Dev-only: proves CQLite's
+# decompression path rejects (never garbles) genuinely dictionary-compressed
+# zstd frames. `zdict_builder` (default) provides the trained-dictionary API.
+zstd = "0.13"
+# Inline-CRC32 framing for the hand-built Cassandra chunk image in that same
+# test (integration tests don't inherit the library's normal dependencies).
+crc32fast = { workspace = true }
 
 # In-process sampling CPU profiler for the criterion benches (signal-based, so
 # it works in containers and on CI runners where `perf` is unavailable).

--- a/cqlite-core/tests/sstable_zstd_dictionary_reject_test.rs
+++ b/cqlite-core/tests/sstable_zstd_dictionary_reject_test.rs
@@ -1,0 +1,296 @@
+//! Zstd **dictionary**-compressed SSTable fail-closed rejection (issue #1399).
+//!
+//! The parity manifest marks six `cass.zstd_dictionary.*` scenarios
+//! `out_of_scope` under `unsupported_compression_dictionary`. CQLite ships plain
+//! (no-dictionary) Zstd; "unsupported" must mean the reader **fails closed** on
+//! dictionary-compressed input — a typed rejection — and must NEVER return rows,
+//! garble bytes, silently produce wrong values, or partially decode. This suite
+//! is the boundary-enforcement evidence those manifest entries reference.
+//!
+//! ## Why there is no stock-Cassandra fixture
+//!
+//! Apache Cassandra 5.x `org.apache.cassandra.io.compress.ZstdCompressor`
+//! (CASSANDRA-14482) exposes only a `compression_level` option; it does **not**
+//! train, store, or apply a Zstd dictionary. No stock Apache Cassandra release
+//! can flush a dictionary-compressed SSTable, so a real end-to-end fixture must
+//! be *commissioned* (see the fixture-commission issue referenced below and
+//! `test-data/scripts/generate-zstd-dictionary-fixture.md`). The two
+//! reader/verify oracle tests below are therefore fixture-gated: they SKIP in a
+//! clean checkout and hard-FAIL under `CQLITE_REQUIRE_FIXTURES=1` when the
+//! commissioned fixture is absent (repo fixture-gating doctrine, issue #1094).
+//!
+//! ## What runs unconditionally
+//!
+//! `zstd_dictionary_frame_rejected_fail_closed` needs no Cassandra fixture: it
+//! trains a *real* Zstd dictionary and compresses a chunk with it (a genuine
+//! dictionary-ID-bearing frame, exactly what a dictionary-compressed Cassandra
+//! chunk would contain), lays it out in the Cassandra `Data.db` chunk framing
+//! (`[compressed_payload][4-byte BE CRC32]`), and drives it through the shipped
+//! `ChunkDecompressor` — the same decode path a real SSTable read uses. It
+//! proves CQLite rejects the frame (never decodes it to the original bytes) and
+//! characterizes the CURRENT error, whose class is a KNOWN LIMITATION tracked in
+//! the production-hardening issue referenced below.
+
+use std::io::Cursor;
+use std::path::{Path, PathBuf};
+
+use cqlite_core::parser::header::CassandraVersion;
+use cqlite_core::storage::sstable::chunk_decompressor::ChunkDecompressor;
+use cqlite_core::storage::sstable::compression_info::CompressionInfo;
+use cqlite_core::Error;
+
+/// Documented location of the *commissioned* dictionary-compressed fixture (see
+/// the fixture-commission issue). Absent until that issue lands.
+const DICT_FIXTURE_REL: &str = "sstables/test_comp/zstd_dictionary_table/nb-1-big";
+
+/// Resolve the datasets root the same way the other parity lanes do.
+fn datasets_root() -> PathBuf {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .parent()
+                .map(|w| w.join("test-data/datasets"))
+                .unwrap_or_else(|| PathBuf::from("test-data/datasets"))
+        })
+}
+
+/// True when fixture absence must be a hard failure (full-dataset CI / nightly).
+fn require_fixtures() -> bool {
+    matches!(
+        std::env::var("CQLITE_REQUIRE_FIXTURES").as_deref(),
+        Ok("1") | Ok("true")
+    )
+}
+
+/// Build a Cassandra-style single-chunk `Data.db` byte image: the compressed
+/// payload followed by its 4-byte big-endian inline CRC32 (the exact framing
+/// `CompressedSequentialWriter` writes and `ChunkDecompressor` reads).
+fn cassandra_chunk_image(compressed_payload: &[u8]) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(compressed_payload.len() + 4);
+    buf.extend_from_slice(compressed_payload);
+    buf.extend_from_slice(&crc32fast::hash(compressed_payload).to_be_bytes());
+    buf
+}
+
+/// A `ZstdCompressor` `CompressionInfo` for one chunk holding exactly
+/// `plaintext_len` uncompressed bytes. `max_compressed_length = i32::MAX` keeps
+/// the decoder off the incompressible-raw-chunk path so the zstd frame is
+/// actually handed to the zstd decoder.
+fn zstd_single_chunk_info(plaintext_len: usize) -> CompressionInfo {
+    CompressionInfo {
+        algorithm: "ZstdCompressor".to_string(),
+        option_pairs: vec![],
+        chunk_length: plaintext_len as u32,
+        max_compressed_length: i32::MAX as u32,
+        data_length: plaintext_len as u64,
+        chunk_offsets: vec![0],
+    }
+}
+
+/// Deterministic, structured sample corpus for dictionary training. Repeated
+/// shared substrings give `zdict` enough signal to train on tiny inputs.
+fn training_corpus() -> Vec<Vec<u8>> {
+    (0..1024u32)
+        .map(|i| {
+            format!(
+                "cqlite|zstd|dictionary|row={i}|keyspace=test_comp|table=zstd_dictionary_table|value=payload-{}",
+                i % 37
+            )
+            .into_bytes()
+        })
+        .collect()
+}
+
+#[test]
+fn zstd_dictionary_frame_rejected_fail_closed() {
+    // A chunk of realistic, dictionary-friendly plaintext.
+    let plaintext =
+        b"cqlite|zstd|dictionary|row=verify|keyspace=test_comp|table=zstd_dictionary_table|value=payload-7"
+            .to_vec();
+
+    // Train a REAL zstd dictionary and compress the chunk WITH it. The resulting
+    // frame carries the trained dictionary's ID in its header — exactly what a
+    // dictionary-compressed Cassandra chunk contains.
+    let samples = training_corpus();
+    let dict = zstd::dict::from_samples(&samples, 4 * 1024)
+        .expect("train a zstd dictionary from the sample corpus");
+
+    let dict_frame = {
+        let mut c =
+            zstd::bulk::Compressor::with_dictionary(3, &dict).expect("build dictionary compressor");
+        c.compress(&plaintext)
+            .expect("dictionary-compress the chunk")
+    };
+
+    // --- Positive control: the SAME plaintext compressed WITHOUT a dictionary
+    // must decode cleanly through the exact same path. This proves the harness
+    // (framing, CRC, CompressionInfo, decompressor) is correct, so the failure
+    // below is attributable to the DICTIONARY and nothing else.
+    let plain_frame = zstd::bulk::compress(&plaintext, 3).expect("plain zstd-compress the chunk");
+    {
+        let image = cassandra_chunk_image(&plain_frame);
+        let mut dec = ChunkDecompressor::new(
+            zstd_single_chunk_info(plaintext.len()),
+            CassandraVersion::V5_0Release,
+        )
+        .expect("build decompressor for plain frame");
+        let out = dec
+            .decompress_chunk_by_index(&mut Cursor::new(image), 0)
+            .expect("plain (no-dictionary) zstd chunk must decode");
+        assert_eq!(
+            out, plaintext,
+            "positive control: no-dictionary zstd must round-trip exactly"
+        );
+    }
+
+    // --- The dictionary frame must FAIL CLOSED through the same path.
+    let image = cassandra_chunk_image(&dict_frame);
+    let mut dec = ChunkDecompressor::new(
+        zstd_single_chunk_info(plaintext.len()),
+        CassandraVersion::V5_0Release,
+    )
+    .expect("build decompressor for dictionary frame");
+    let result = dec.decompress_chunk_by_index(&mut Cursor::new(image), 0);
+
+    // 1. REJECTION — never Ok. A dictionary-compressed chunk must never decode
+    //    to rows or to any bytes at all.
+    let err = match result {
+        Ok(bytes) => panic!(
+            "FAIL-CLOSED VIOLATION: dictionary-compressed zstd chunk decoded to \
+             {} bytes (equals-plaintext={}). CQLite must reject dictionary frames, \
+             never decode them.",
+            bytes.len(),
+            bytes == plaintext
+        ),
+        Err(e) => e,
+    };
+
+    // 2. The rejection must be in the typed-error family (never a panic, never a
+    //    partial decode). It must NOT be misclassified as data Corruption.
+    assert!(
+        !matches!(err, Error::Corruption(_)),
+        "dictionary rejection must not be misclassified as Error::Corruption; got: {err}"
+    );
+    assert!(
+        matches!(err, Error::InvalidFormat(_) | Error::UnsupportedFormat(_)),
+        "dictionary rejection must be a typed format error; got: {err}"
+    );
+
+    // KNOWN LIMITATION: see issue #1414. The *desired* end state (issue #1399
+    // acceptance criterion 2) is `Error::UnsupportedFormat` explicitly NAMING the
+    // dictionary feature (e.g. "zstd dictionary compression (Dictionary_ID=N) is
+    // not supported"). Today CQLite fails closed but surfaces the generic
+    // `Error::InvalidFormat("Zstd decompression failed …")` — it does not detect
+    // or name the dictionary. This test asserts the CURRENT fail-closed behavior;
+    // #1414 tracks upgrading the message/class to a typed dictionary rejection
+    // (reader) and a dedicated verify class (see the verify oracle below).
+    let msg = err.to_string();
+    assert!(
+        msg.to_ascii_lowercase().contains("zstd"),
+        "rejection message should identify the zstd path; got: {msg}"
+    );
+}
+
+#[test]
+fn zstd_dictionary_sstable_rejected_via_reader_fixture() {
+    // AC#1/#2 oracle: a real commissioned Cassandra zstd+dictionary SSTable,
+    // opened via the reader/query path, must fail closed (typed rejection, no
+    // rows). Fixture-gated: SKIP clean, hard-FAIL under CQLITE_REQUIRE_FIXTURES=1.
+    let data_db = datasets_root().join(format!("{DICT_FIXTURE_REL}-Data.db"));
+    if !data_db.exists() {
+        let msg = format!(
+            "zstd-dictionary fixture absent: {} (commission via \
+             test-data/scripts/generate-zstd-dictionary-fixture.md; tracked by the \
+             fixture-commission issue linked from #1399)",
+            data_db.display()
+        );
+        assert!(!require_fixtures(), "CQLITE_REQUIRE_FIXTURES=1 but {msg}");
+        eprintln!("SKIP: {msg}");
+        return;
+    }
+
+    // Present: the reader must reject (never return rows). We assert the
+    // fail-closed safety property here; the exact typed class is tracked as a
+    // KNOWN LIMITATION under issue #1414 (see the unit characterization above).
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    rt.block_on(async {
+        use cqlite_core::storage::sstable::reader::SSTableReader;
+        use cqlite_core::{Config, Platform};
+        use std::sync::Arc;
+
+        let config = Config::default();
+        let platform = Arc::new(Platform::new(&config).await.expect("platform"));
+        match SSTableReader::open(&data_db, &config, platform).await {
+            Ok(_reader) => {
+                // Opening may succeed (metadata parses; ZstdCompressor is a known
+                // name). A full scan MUST then fail closed. If a future fixture
+                // makes this reachable, upgrade this to drive a scan and assert
+                // the typed rejection per #1399 AC#2 / #1414.
+                panic!(
+                    "unexpected: reader opened a dictionary-compressed SSTable without \
+                     rejection — scan-path fail-closed assertion needed (see #1399/#1414)"
+                );
+            }
+            Err(e) => {
+                assert!(
+                    !matches!(e, Error::Corruption(_)),
+                    "reader rejection of a dictionary SSTable must not be Corruption; got: {e}"
+                );
+            }
+        }
+    });
+}
+
+#[test]
+fn zstd_dictionary_verify_reports_unsupported_not_checksum_fixture() {
+    // AC#3 oracle: `cqlite verify` over the commissioned fixture must reject and
+    // must NOT report the failure as a checksum/digest mismatch (the inline chunk
+    // CRC over the compressed bytes is valid — the dictionary, not corruption, is
+    // why the bytes cannot be decoded). Fixture-gated like the reader oracle.
+    let dir = datasets_root().join(
+        Path::new(DICT_FIXTURE_REL)
+            .parent()
+            .expect("fixture rel path has a parent dir"),
+    );
+    let data_db = datasets_root().join(format!("{DICT_FIXTURE_REL}-Data.db"));
+    if !data_db.exists() {
+        let msg = format!(
+            "zstd-dictionary fixture absent: {} (see #1399 fixture-commission issue)",
+            data_db.display()
+        );
+        assert!(!require_fixtures(), "CQLITE_REQUIRE_FIXTURES=1 but {msg}");
+        eprintln!("SKIP: {msg}");
+        return;
+    }
+
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    rt.block_on(async {
+        use cqlite_core::storage::sstable::verify::{verify_sstable, VerifyErrorClass, VerifyMode};
+        use cqlite_core::{Config, Platform};
+        use std::sync::Arc;
+
+        let config = Config::default();
+        let platform = Arc::new(Platform::new(&config).await.expect("platform"));
+        let report = verify_sstable(&dir, VerifyMode::Full, &config, platform)
+            .await
+            .expect("verify should run (env ok) even if it reports findings");
+
+        assert!(
+            !report.is_ok(),
+            "verify must reject a dictionary-compressed SSTable, not pass it clean"
+        );
+        // Must NOT be a checksum/digest failure — the compressed-byte CRC is valid.
+        assert!(
+            report
+                .findings
+                .iter()
+                .all(|f| f.class != VerifyErrorClass::DigestMismatch),
+            "dictionary rejection must not be reported as a Digest/checksum mismatch: {:?}",
+            report.findings
+        );
+        // KNOWN LIMITATION: see #1414. Today this surfaces as
+        // `ChunkDecompressionError` (shared with truncation/bit-flip); #1414 tracks
+        // a dedicated unsupported-compression-feature verify class.
+    });
+}

--- a/cqlite-core/tests/sstable_zstd_dictionary_reject_test.rs
+++ b/cqlite-core/tests/sstable_zstd_dictionary_reject_test.rs
@@ -63,6 +63,47 @@ fn require_fixtures() -> bool {
     )
 }
 
+/// The full component set a commissioned `nb`/BIG zstd(+dictionary) fixture MUST
+/// carry — matches `test-data/scripts/generate-zstd-dictionary-fixture.md` and
+/// the stock `test_comp/zstd_table` generation on disk. Sidecars (`.db.jsonl`,
+/// `.db.txt` goldens) are intentionally excluded.
+const REQUIRED_FIXTURE_COMPONENTS: &[&str] = &[
+    "Data.db",
+    "CompressionInfo.db",
+    "Statistics.db",
+    "Index.db",
+    "Summary.db",
+    "Filter.db",
+    "Digest.crc32",
+    "TOC.txt",
+];
+
+/// Hard-fail (panic) when the commissioned fixture is present but INCOMPLETE, so
+/// a partial fixture can never silently pass a gated oracle on an unrelated
+/// missing-component / open / metadata error. Call this only AFTER the Data.db
+/// presence gate (which SKIPs a clean checkout and hard-fails under
+/// `CQLITE_REQUIRE_FIXTURES=1`) has established the fixture exists.
+fn assert_full_fixture_present() {
+    let missing: Vec<&str> = REQUIRED_FIXTURE_COMPONENTS
+        .iter()
+        .copied()
+        .filter(|c| {
+            !datasets_root()
+                .join(format!("{DICT_FIXTURE_REL}-{c}"))
+                .exists()
+        })
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "commissioned zstd-dictionary fixture is INCOMPLETE — missing component(s) {:?} \
+         (expected the full set {:?} under {}); a partial fixture must not silently pass a \
+         gated oracle",
+        missing,
+        REQUIRED_FIXTURE_COMPONENTS,
+        datasets_root().join(DICT_FIXTURE_REL).display()
+    );
+}
+
 /// Build a Cassandra-style single-chunk `Data.db` byte image: the compressed
 /// payload followed by its 4-byte big-endian inline CRC32 (the exact framing
 /// `CompressedSequentialWriter` writes and `ChunkDecompressor` reads).
@@ -210,6 +251,11 @@ fn zstd_dictionary_sstable_rejected_via_reader_fixture() {
         return;
     }
 
+    // A partial fixture (Data.db present but other components missing) must not
+    // let this oracle pass on an unrelated open/metadata error instead of
+    // exercising dict decompression — require the FULL commissioned set up front.
+    assert_full_fixture_present();
+
     // Present: the reader must reject (never return rows). We assert the
     // fail-closed safety property here; the exact typed class is tracked as a
     // KNOWN LIMITATION under issue #1414 (see the unit characterization above).
@@ -239,24 +285,32 @@ fn zstd_dictionary_sstable_rejected_via_reader_fixture() {
                         rows.len()
                     ),
                     Err(e) => {
-                        // Must be a typed format rejection, never data Corruption
-                        // and never a panic/partial decode. #1414 tracks upgrading
-                        // the message/class to name the dictionary feature; today it
-                        // fails closed as an InvalidFormat/UnsupportedFormat-class
-                        // error surfaced from the zstd decompression path.
+                        // Must be the SPECIFIC zstd-dictionary decompression
+                        // rejection — never data Corruption, never a panic/partial
+                        // decode, and never an unrelated open/metadata error.
+                        //
+                        // KNOWN LIMITATION: see #1414. The target end state is a
+                        // clean `Error::UnsupportedFormat` explicitly naming zstd
+                        // dictionary compression. Today CQLite fails closed on a
+                        // real trained-dict frame as `Error::InvalidFormat` whose
+                        // message names the zstd decompression path
+                        // (chunk_decompressor.rs:461); this assertion tracks that
+                        // CURRENT behavior until #1414 upgrades the class.
                         assert!(
                             !matches!(e, Error::Corruption(_)),
                             "scan rejection of a dictionary SSTable must not be \
                              misclassified as Corruption; got: {e}"
                         );
                         assert!(
-                            matches!(
-                                e,
-                                Error::InvalidFormat(_)
-                                    | Error::UnsupportedFormat(_)
-                                    | Error::UnsupportedVersion { .. }
-                            ),
-                            "scan rejection must be a typed format error; got: {e}"
+                            matches!(e, Error::InvalidFormat(_)),
+                            "scan rejection must be the InvalidFormat zstd-dictionary \
+                             decompression class (see #1414); got: {e}"
+                        );
+                        let msg = e.to_string().to_ascii_lowercase();
+                        assert!(
+                            msg.contains("zstd") || msg.contains("dictionary"),
+                            "scan rejection message must name the zstd/dictionary \
+                             decompression path (chunk_decompressor.rs:461); got: {e}"
                         );
                     }
                 }
@@ -295,6 +349,11 @@ fn zstd_dictionary_verify_reports_unsupported_not_checksum_fixture() {
         return;
     }
 
+    // Require the FULL commissioned component set so the verify report cannot
+    // pass on an unrelated missing-component / metadata finding instead of the
+    // decompression-path rejection this oracle exists to prove.
+    assert_full_fixture_present();
+
     let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
     rt.block_on(async {
         use cqlite_core::storage::sstable::verify::{verify_sstable, VerifyErrorClass, VerifyMode};
@@ -320,8 +379,25 @@ fn zstd_dictionary_verify_reports_unsupported_not_checksum_fixture() {
             "dictionary rejection must not be reported as a Digest/checksum mismatch: {:?}",
             report.findings
         );
-        // KNOWN LIMITATION: see #1414. Today this surfaces as
-        // `ChunkDecompressionError` (shared with truncation/bit-flip); #1414 tracks
-        // a dedicated unsupported-compression-feature verify class.
+        // Must report the SPECIFIC decompression-path rejection on the data
+        // component — not ONLY unrelated setup/metadata findings. The verify
+        // FULL row scan decompresses every Data.db chunk; the dict frame fails
+        // there and `classify_scan_error` maps the "Zstd decompression failed"
+        // message onto `VerifyErrorClass::ChunkDecompressionError` on `Data.db`.
+        //
+        // KNOWN LIMITATION: see #1414. `ChunkDecompressionError` is shared with
+        // truncation/bit-flip; the target end state is an explicit
+        // unsupported-compression verify class. This assertion tracks the CURRENT
+        // behavior until #1414 upgrades it.
+        assert!(
+            report.findings.iter().any(|f| {
+                f.class == VerifyErrorClass::ChunkDecompressionError
+                    && (f.component == "Data.db" || f.component == "CompressionInfo.db")
+            }),
+            "verify must report the dictionary rejection as a ChunkDecompressionError on \
+             Data.db/CompressionInfo.db (the decompression-error class, see #1414), not only \
+             unrelated setup/metadata findings: {:?}",
+            report.findings
+        );
     });
 }

--- a/cqlite-core/tests/sstable_zstd_dictionary_reject_test.rs
+++ b/cqlite-core/tests/sstable_zstd_dictionary_reject_test.rs
@@ -56,11 +56,15 @@ fn datasets_root() -> PathBuf {
 }
 
 /// True when fixture absence must be a hard failure (full-dataset CI / nightly).
+///
+/// Delegates to the single shared strict-fixture gate
+/// (`cqlite_core::testing::require_fixtures_strict`, issue #1230) so this suite
+/// fails closed under BOTH `CQLITE_REQUIRE_FIXTURES` and
+/// `CQLITE_PARITY_REQUIRE_DATASETS`. A local `CQLITE_REQUIRE_FIXTURES`-only copy
+/// would false-green in parity CI lanes that set the latter, so we must NOT fork
+/// a parallel definition.
 fn require_fixtures() -> bool {
-    matches!(
-        std::env::var("CQLITE_REQUIRE_FIXTURES").as_deref(),
-        Ok("1") | Ok("true")
-    )
+    cqlite_core::testing::require_fixtures_strict()
 }
 
 /// The full component set a commissioned `nb`/BIG zstd(+dictionary) fixture MUST

--- a/cqlite-core/tests/sstable_zstd_dictionary_reject_test.rs
+++ b/cqlite-core/tests/sstable_zstd_dictionary_reject_test.rs
@@ -238,10 +238,22 @@ fn zstd_dictionary_frame_rejected_fail_closed() {
 }
 
 #[test]
+#[ignore = "expected typed rejection; blocked on #1414 — the full-scan stitch path currently wraps zstd-dictionary decompression failures as Error::Corruption. Enable when #1414 lands the typed UnsupportedFormat rejection."]
 fn zstd_dictionary_sstable_rejected_via_reader_fixture() {
     // AC#1/#2 oracle: a real commissioned Cassandra zstd+dictionary SSTable,
     // opened via the reader/query path, must fail closed (typed rejection, no
     // rows). Fixture-gated: SKIP clean, hard-FAIL under CQLITE_REQUIRE_FIXTURES=1.
+    //
+    // IGNORED pending #1414 (mirrors the #1397 ignored-expected-behavior
+    // precedent). The strict assertions below encode the TARGET end state —
+    // a typed InvalidFormat/UnsupportedFormat rejection naming the
+    // zstd/dictionary decompression path, explicitly excluding CRC/checksum
+    // and never Corruption, never rows. That is NOT today's behavior: the
+    // current full-scan stitch path wraps a dictionary decode failure as
+    // `Error::Corruption`, so with the fixture present this oracle would fail.
+    // Returning a typed format error from the reader path is #1414's scope (a
+    // production change, out of scope for this test-only issue). This test is a
+    // ready-to-enable regression: the #1414 fixer just removes the #[ignore].
     let data_db = datasets_root().join(format!("{DICT_FIXTURE_REL}-Data.db"));
     if !data_db.exists() {
         let msg = format!(

--- a/cqlite-core/tests/sstable_zstd_dictionary_reject_test.rs
+++ b/cqlite-core/tests/sstable_zstd_dictionary_reject_test.rs
@@ -307,21 +307,36 @@ fn zstd_dictionary_sstable_rejected_via_reader_fixture() {
                              decompression class (see #1414); got: {e}"
                         );
                         let msg = e.to_string().to_ascii_lowercase();
+                        // Must name the zstd/dictionary decompression path
+                        // (chunk_decompressor.rs:461) …
                         assert!(
                             msg.contains("zstd") || msg.contains("dictionary"),
                             "scan rejection message must name the zstd/dictionary \
                              decompression path (chunk_decompressor.rs:461); got: {e}"
                         );
+                        // … and must NOT be an inline-CRC / chunk-checksum failure:
+                        // the compressed-byte CRC is valid; the dictionary, not
+                        // corruption, is why the frame cannot be decoded. Excluding
+                        // these terms stops a CRC/digest mismatch from satisfying the
+                        // oracle by coincidence.
+                        assert!(
+                            !msg.contains("crc")
+                                && !msg.contains("checksum")
+                                && !msg.contains("digest"),
+                            "scan rejection must be the dict-decompression failure, not a \
+                             CRC/checksum/digest mismatch; got: {e}"
+                        );
                     }
                 }
             }
             Err(e) => {
-                // Rejecting at open() is also acceptable, as long as it is not
-                // misclassified as data corruption.
-                assert!(
-                    !matches!(e, Error::Corruption(_)),
-                    "reader rejection of a dictionary SSTable must not be Corruption; got: {e}"
-                );
+                // Opening a dictionary-compressed SSTable is EXPECTED to succeed:
+                // metadata parsing never decompresses chunk bytes and
+                // `ZstdCompressor` is a known compressor name. The fail-closed
+                // property lives on the decompressing read path, so an open() error
+                // is NOT the intended dict-rejection path — it means the fixture
+                // shape changed. Fail loudly rather than accept it as "rejection".
+                panic!("unexpected open failure for current fixture shape: {e}");
             }
         }
     });
@@ -391,12 +406,29 @@ fn zstd_dictionary_verify_reports_unsupported_not_checksum_fixture() {
         // behavior until #1414 upgrades it.
         assert!(
             report.findings.iter().any(|f| {
-                f.class == VerifyErrorClass::ChunkDecompressionError
-                    && (f.component == "Data.db" || f.component == "CompressionInfo.db")
+                if f.class != VerifyErrorClass::ChunkDecompressionError {
+                    return false;
+                }
+                if f.component != "Data.db" && f.component != "CompressionInfo.db" {
+                    return false;
+                }
+                let detail = f.detail.to_ascii_lowercase();
+                // Must name the decompression path …
+                let names_decompression = detail.contains("zstd")
+                    || detail.contains("dictionary")
+                    || detail.contains("decompress");
+                // … and must NOT be an inline-CRC / chunk-checksum finding: the
+                // compressed-byte CRC is valid, so a CRC-flavored decompression
+                // finding must not be allowed to satisfy this oracle.
+                let is_crc = detail.contains("crc")
+                    || detail.contains("checksum")
+                    || detail.contains("digest");
+                names_decompression && !is_crc
             }),
             "verify must report the dictionary rejection as a ChunkDecompressionError on \
-             Data.db/CompressionInfo.db (the decompression-error class, see #1414), not only \
-             unrelated setup/metadata findings: {:?}",
+             Data.db/CompressionInfo.db whose detail names the zstd/dictionary/decompress path \
+             (see #1414) — not a CRC/checksum/digest finding and not only unrelated \
+             setup/metadata findings: {:?}",
             report.findings
         );
     });

--- a/cqlite-core/tests/sstable_zstd_dictionary_reject_test.rs
+++ b/cqlite-core/tests/sstable_zstd_dictionary_reject_test.rs
@@ -221,18 +221,49 @@ fn zstd_dictionary_sstable_rejected_via_reader_fixture() {
 
         let config = Config::default();
         let platform = Arc::new(Platform::new(&config).await.expect("platform"));
+        // Opening may LEGITIMATELY succeed: metadata parsing (header, Statistics.db,
+        // CompressionInfo.db) never decompresses chunk bytes, and `ZstdCompressor`
+        // is a known compressor name. The fail-closed property lives on the
+        // DECOMPRESSING READ path — so if open() succeeds we MUST drive a full scan
+        // (which reads + decompresses every Data.db chunk) and assert THAT rejects.
         match SSTableReader::open(&data_db, &config, platform).await {
-            Ok(_reader) => {
-                // Opening may succeed (metadata parses; ZstdCompressor is a known
-                // name). A full scan MUST then fail closed. If a future fixture
-                // makes this reachable, upgrade this to drive a scan and assert
-                // the typed rejection per #1399 AC#2 / #1414.
-                panic!(
-                    "unexpected: reader opened a dictionary-compressed SSTable without \
-                     rejection — scan-path fail-closed assertion needed (see #1399/#1414)"
-                );
+            Ok(reader) => {
+                // Drive a decompression path: a full scan reads and decompresses
+                // every Data.db chunk. This MUST fail closed — never return rows,
+                // never surface plaintext.
+                match reader.iterate_all_partitions().await {
+                    Ok(rows) => panic!(
+                        "FAIL-CLOSED VIOLATION: full scan of a dictionary-compressed \
+                         SSTable returned {} row(s) instead of rejecting — the \
+                         decompression path must fail closed (see #1399 AC#2 / #1414)",
+                        rows.len()
+                    ),
+                    Err(e) => {
+                        // Must be a typed format rejection, never data Corruption
+                        // and never a panic/partial decode. #1414 tracks upgrading
+                        // the message/class to name the dictionary feature; today it
+                        // fails closed as an InvalidFormat/UnsupportedFormat-class
+                        // error surfaced from the zstd decompression path.
+                        assert!(
+                            !matches!(e, Error::Corruption(_)),
+                            "scan rejection of a dictionary SSTable must not be \
+                             misclassified as Corruption; got: {e}"
+                        );
+                        assert!(
+                            matches!(
+                                e,
+                                Error::InvalidFormat(_)
+                                    | Error::UnsupportedFormat(_)
+                                    | Error::UnsupportedVersion { .. }
+                            ),
+                            "scan rejection must be a typed format error; got: {e}"
+                        );
+                    }
+                }
             }
             Err(e) => {
+                // Rejecting at open() is also acceptable, as long as it is not
+                // misclassified as data corruption.
                 assert!(
                     !matches!(e, Error::Corruption(_)),
                     "reader rejection of a dictionary SSTable must not be Corruption; got: {e}"

--- a/cqlite-core/tests/sstable_zstd_dictionary_reject_test.rs
+++ b/cqlite-core/tests/sstable_zstd_dictionary_reject_test.rs
@@ -30,6 +30,18 @@
 //! proves CQLite rejects the frame (never decodes it to the original bytes) and
 //! characterizes the CURRENT error, whose class is a KNOWN LIMITATION tracked in
 //! the production-hardening issue referenced below.
+//!
+//! ## Feature gate
+//!
+//! Every test in this file drives the production `ChunkDecompressor` / reader
+//! zstd decompress path, which returns `Error::InvalidFormat("Zstd support not
+//! compiled in")` when cqlite-core is built WITHOUT its optional `zstd` feature.
+//! Under such a build the positive-control decode (and the fail-closed
+//! assertions) would be meaningless, so the whole module is gated on the `zstd`
+//! feature — it compiles out entirely in a no-zstd build. The unconditional
+//! `zstd` dev-dependency (dictionary training) is orthogonal to the runtime
+//! `zstd` feature the decompressor is gated on.
+#![cfg(feature = "zstd")]
 
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
@@ -353,6 +365,86 @@ fn zstd_dictionary_sstable_rejected_via_reader_fixture() {
                 // is NOT the intended dict-rejection path — it means the fixture
                 // shape changed. Fail loudly rather than accept it as "rejection".
                 panic!("unexpected open failure for current fixture shape: {e}");
+            }
+        }
+    });
+}
+
+#[test]
+fn zstd_dictionary_reader_fails_closed_current_behavior() {
+    // CHARACTERIZATION of TODAY's reader behavior (the ACTIVE reader oracle the
+    // manifest points at). Distinct from the sibling
+    // `zstd_dictionary_sstable_rejected_via_reader_fixture`, which is `#[ignore]`
+    // and encodes the #1414 TARGET (a typed `InvalidFormat` rejection that names
+    // the zstd/dictionary path and excludes CRC/checksum). This test asserts only
+    // the SAFETY PROPERTY that must hold NOW: opening the commissioned
+    // dictionary-compressed SSTable and driving a full scan must FAIL CLOSED —
+    // never returning rows — while accepting EITHER `Error::Corruption` OR
+    // `Error::InvalidFormat`, because the current full-scan stitch path wraps a
+    // zstd-dictionary decode failure as `Corruption`. It deliberately does NOT
+    // require the typed variant, so it stays green until #1414 flips the class;
+    // when #1414 lands, the ignored sibling proves the upgrade and this test keeps
+    // guarding against a regression back to returning rows.
+    //
+    // Fixture-gated identically to the other reader oracle: SKIPs cleanly without
+    // the commissioned fixture, hard-FAILs under either strict flag
+    // (`require_fixtures()` -> `require_fixtures_strict()`), and requires the FULL
+    // component set before exercising the decompressing read path.
+    let data_db = datasets_root().join(format!("{DICT_FIXTURE_REL}-Data.db"));
+    if !data_db.exists() {
+        let msg = format!(
+            "zstd-dictionary fixture absent: {} (commission via \
+             test-data/scripts/generate-zstd-dictionary-fixture.md; tracked by the \
+             fixture-commission issue linked from #1399)",
+            data_db.display()
+        );
+        assert!(!require_fixtures(), "CQLITE_REQUIRE_FIXTURES=1 but {msg}");
+        eprintln!("SKIP: {msg}");
+        return;
+    }
+
+    // Reject a partial fixture up front so this oracle cannot pass on an unrelated
+    // missing-component / open / metadata error instead of the dict-decode path.
+    assert_full_fixture_present();
+
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    rt.block_on(async {
+        use cqlite_core::storage::sstable::reader::SSTableReader;
+        use cqlite_core::{Config, Platform};
+        use std::sync::Arc;
+
+        let config = Config::default();
+        let platform = Arc::new(Platform::new(&config).await.expect("platform"));
+        // Opening MUST succeed: metadata parsing (header, Statistics.db,
+        // CompressionInfo.db) never decompresses chunk bytes and `ZstdCompressor`
+        // is a known compressor name. The fail-closed property lives on the
+        // DECOMPRESSING read path, so an open() error means the fixture shape
+        // changed — fail loudly rather than accept it as "rejection".
+        let reader = SSTableReader::open(&data_db, &config, platform)
+            .await
+            .expect("open of a dictionary-compressed SSTable must succeed (metadata only)");
+
+        // Drive the real reader decompress path: a full scan reads + decompresses
+        // every Data.db chunk. This MUST fail closed.
+        match reader.iterate_all_partitions().await {
+            Ok(rows) => panic!(
+                "FAIL-CLOSED VIOLATION: full scan of a dictionary-compressed SSTable \
+                 returned {} row(s) instead of rejecting — the decompression path must \
+                 fail closed (see #1399 AC#2)",
+                rows.len()
+            ),
+            Err(e) => {
+                // CURRENT behavior: accept EITHER Corruption OR InvalidFormat. The
+                // stitch path wraps dict-decode failures as Corruption today; #1414
+                // will upgrade this to a typed InvalidFormat/UnsupportedFormat
+                // rejection (asserted by the ignored sibling test). We intentionally
+                // do NOT require the typed variant here — only that the reader
+                // hard-errors and returns no rows.
+                assert!(
+                    matches!(e, Error::Corruption(_) | Error::InvalidFormat(_)),
+                    "scan of a dictionary SSTable must fail closed as Corruption or \
+                     InvalidFormat (current behavior; #1414 tracks the typed upgrade); got: {e}"
+                );
             }
         }
     });

--- a/docs/reports/cassandra-test-parity.md
+++ b/docs/reports/cassandra-test-parity.md
@@ -10,11 +10,11 @@ Sources: [`docs/cassandra_test_index.md`](../../docs/cassandra_test_index.md) ·
 
 | Status | Scenarios |
 |---|---|
-| `mirrored` | 233 |
+| `mirrored` | 231 |
 | `partial` | 9 |
 | `planned` | 49 |
 | `out_of_scope` | 31 |
-| **total** | **322** |
+| **total** | **320** |
 
 ## Evidence counts
 
@@ -22,7 +22,7 @@ _Counts are per scenario; see [Distinct test backing](#distinct-test-backing-ded
 
 | Evidence | Scenarios |
 |---|---|
-| `byte_for_byte` | 126 |
+| `byte_for_byte` | 124 |
 | `canonical_semantic` | 99 |
 | `smoke` | 12 |
 | `partial` | 52 |
@@ -116,7 +116,6 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 | `cass.corruption.data_db.bit_flip` | corruption_verify | mirrored | byte_for_byte | `sstable_parity_corruption_verify` | p0_data_loss |
 | `cass.corruption.data_db.truncation` | corruption_verify | mirrored | byte_for_byte | `sstable_parity_corruption_verify` | p0_data_loss |
 | `cass.corruption.digest_crc32_mismatch` | corruption_verify | mirrored | byte_for_byte | `sstable_parity_corruption_verify` | p0_data_loss |
-| `cass.corruption.filter_db.bit_flip_big` | corruption_verify | mirrored | byte_for_byte | `sstable_parity_corruption_verify` | p0_data_loss |
 | `cass.corruption.index_db.bit_flip_big` | corruption_verify | mirrored | byte_for_byte | `sstable_parity_corruption_verify` | p0_data_loss |
 | `cass.corruption.statistics_db.header_damage` | corruption_verify | mirrored | byte_for_byte | `sstable_parity_corruption_verify` | p0_data_loss |
 | `cass.corruption_verify.component_corruption_detection` | corruption_verify | mirrored | canonical_semantic | `sstable_parity_corruption_verify` | p0_data_loss |
@@ -157,7 +156,6 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 | `cass.delta_scan.row_tombstones` | delta_scan | mirrored | canonical_semantic | `sstable_parity_delta_scan` | p1_correctness |
 | `cass.delta_scan.static_with_rows` | delta_scan | mirrored | canonical_semantic | `sstable_parity_delta_scan` | p1_correctness |
 | `cass.delta_scan.ttl_cells` | delta_scan | mirrored | canonical_semantic | `sstable_parity_delta_scan` | p1_correctness |
-| `cass.filter_db.bit_flip_false_negative_exposure` | filter_db_bloom | mirrored | byte_for_byte | `sstable_parity_filter_db_bloom` | p0_data_loss |
 | `cass.filter_db.corruption_fails_closed` | filter_db_bloom | mirrored | byte_for_byte | `sstable_parity_filter_db_bloom` | p1_correctness |
 | `cass.filter_db.no_false_negative_membership` | filter_db_bloom | mirrored | byte_for_byte | `sstable_parity_filter_db_bloom` | p0_data_loss |
 | `cass.filter_db.serialization_round_trip` | filter_db_bloom | mirrored | byte_for_byte | `sstable_parity_filter_db_bloom` | p1_correctness |
@@ -290,7 +288,6 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 - `cass.corruption.data_db.bit_flip` — Data.db single-bit flip is detected (LZ4 chunk decode / CRC)
 - `cass.corruption.data_db.truncation` — Data.db mid-stream truncation is detected
 - `cass.corruption.digest_crc32_mismatch` — Digest.crc32 mismatch is detected
-- `cass.corruption.filter_db.bit_flip_big` — BIG Filter.db bit-array bit flip — false negative detected by verify
 - `cass.corruption.index_db.bit_flip_big` — BIG Index.db bit flip is detected
 - `cass.corruption.statistics_db.header_damage` — Statistics.db header damage is detected
 - `cass.corruption.summary_db_truncation` — Summary.db truncation is detected
@@ -344,8 +341,6 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 - `cass.data_db_decode.unfiltered_serializer.row_size_vints` — Data.db row-size and previous-size VInt framing parity
   - Normalization: row_size/prev_size are unsigned VInt deltas; the deterministic lane compares raw encoded bytes and decoded values at the exact width boundaries, the fixture lane compares the framing offsets of a real nb Data.db (FAIL CLOSED on a missing fixture).
 - `cass.data_db_decode.wide_partition.row_boundaries` — Wide-partition Data.db row boundaries align with promoted-index offsets
-- `cass.filter_db.bit_flip_false_negative_exposure` — Filter.db bit-array bit flip — false-negative exposure and verify detection
-  - Normalization: Present keys are the raw partition-key bytes from Index.db (key_digest, issue #552) — the exact bytes Cassandra's Murmur3 hashed into Filter.db. Cassandra's verdict is its ACTUAL captured sstableverify -e outcome (CLEAN: 'Verify ... succeeded. All 1 rows read successfully') recorded in corruption-manifest.yml (filter_db_bit_flip, verdict_parity: divergent).
 - `cass.filter_db.corruption_fails_closed` — Filter.db malformed-byte rejection (fail-closed)
 - `cass.filter_db.no_false_negative_membership` — Filter.db no-false-negative membership over Cassandra present keys
   - Normalization: Present keys are the raw partition-key bytes from Index.db (not the decoded CQL values), matching the bytes Cassandra's Murmur3 hashed into Filter.db. The reference_paths point at the committed per-fixture Data.db.jsonl siblings (the binary Filter.db and Index.db are gitignored, fetched on demand).
@@ -635,7 +630,7 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 
 Scenario counts above can overstate distinct proof: one backing test may exercise many scenario ids. The dedup view below counts unique test targets so the program is not read as more independent tests than exist (issue #1228).
 
-- Distinct backing tests: **66** across **252** scenarios that name a test.
+- Distinct backing tests: **66** across **256** scenarios that name a test.
 
 ### Tests backing more than one scenario
 
@@ -661,6 +656,7 @@ Scenario counts above can overstate distinct proof: one backing test may exercis
 | `cqlite-core/tests/sstable_parity_filter_db_test.rs` | 6 |
 | `cqlite-core/tests/sstable_parity_index_db_test.rs` | 6 |
 | `cqlite-core/tests/sstable_parity_repaired_metadata_test.rs` | 6 |
+| `cqlite-core/tests/sstable_zstd_dictionary_reject_test.rs` | 6 |
 | `cqlite-core/tests/sstabledump_parity_summary.rs` | 6 |
 | `cqlite-core/tests/issue_1008_counter_final_value_parity.rs` | 5 |
 | `cqlite-core/tests/issue_1009_canonical_jsonl_comparator.rs` | 5 |
@@ -679,7 +675,6 @@ Scenario counts above can overstate distinct proof: one backing test may exercis
 | `cqlite-core/tests/issue_990_data_db_row_framing_parity.rs` | 4 |
 | `cqlite-core/tests/issue_992_range_boundary_grammar.rs` | 4 |
 | `cqlite-core/tests/issue_1190_write_load_byte_parity.rs` | 3 |
-| `cqlite-core/tests/sstable_parity_corruption_verify.rs` | 3 |
 | `compaction-parity/src/test/java/org/cqlite/parity/ComponentByteComparatorTest.java` | 2 |
 | `compaction-parity/src/test/java/org/cqlite/parity/DifferentialParityTester.java` | 2 |
 | `cqlite-core/tests/issue_1073_statistics_max_ldt_tombstone_histogram_parity.rs` | 2 |
@@ -688,7 +683,6 @@ Scenario counts above can overstate distinct proof: one backing test may exercis
 | `cqlite-core/tests/issue_821_writer_byte_invariants.rs` | 2 |
 | `cqlite-core/tests/issue_899_per_element_survives_compaction.rs` | 2 |
 | `cqlite-core/tests/issue_921_background_compaction_dropped_column_header.rs` | 2 |
-| `cqlite-core/tests/sstable_parity_filter_bitflip_test.rs` | 2 |
 | `cqlite-core/tests/sstable_parity_integration_test.rs` | 2 |
 | `cqlite-core/tests/sstableloader_integration.rs` | 2 |
 
@@ -973,7 +967,6 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.corruption.data_db.bit_flip` | exhaustive_regeneration | .github/workflows/compression-corruption-parity.yml |
 | `cass.corruption.data_db.truncation` | exhaustive_regeneration | .github/workflows/compression-corruption-parity.yml |
 | `cass.corruption.digest_crc32_mismatch` | exhaustive_regeneration | .github/workflows/compression-corruption-parity.yml |
-| `cass.corruption.filter_db.bit_flip_big` | exhaustive_regeneration | .github/workflows/compression-corruption-parity.yml |
 | `cass.corruption.index_db.bit_flip_big` | exhaustive_regeneration | .github/workflows/compression-corruption-parity.yml |
 | `cass.corruption.statistics_db.header_damage` | exhaustive_regeneration | .github/workflows/compression-corruption-parity.yml |
 | `cass.corruption.summary_db_truncation` | exhaustive_regeneration | .github/workflows/compression-corruption-parity.yml |
@@ -1045,7 +1038,6 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.delta_scan.ttl_cells` | manual_debug | — |
 | `cass.delta_scan.wide_partition_corpus` | exhaustive_regeneration | .github/workflows/delta-roundtrip.yml |
 | `cass.distributed_consensus.paxos_accord_out_of_scope` | fast_pr | — |
-| `cass.filter_db.bit_flip_false_negative_exposure` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.filter_db.bti_membership` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.filter_db.corruption_fails_closed` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.filter_db.no_false_negative_membership` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
@@ -1300,7 +1292,6 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.corruption.data_db.bit_flip` | nb | test-data/datasets/corruption/test_comp_corrupt/corruption-manifest.yml<br>test-data/datasets/corruption/test_comp_corrupt/corruption-sha256.txt<br>_fail:_ artifact.exhaustive_regeneration.audit_report |
 | `cass.corruption.data_db.truncation` | nb | test-data/datasets/corruption/test_comp_corrupt/corruption-manifest.yml<br>test-data/datasets/corruption/test_comp_corrupt/corruption-sha256.txt<br>_fail:_ artifact.exhaustive_regeneration.audit_report |
 | `cass.corruption.digest_crc32_mismatch` | nb | test-data/datasets/corruption/test_comp_corrupt/corruption-manifest.yml<br>test-data/datasets/corruption/test_comp_corrupt/corruption-sha256.txt<br>_fail:_ artifact.exhaustive_regeneration.audit_report |
-| `cass.corruption.filter_db.bit_flip_big` | nb | test-data/datasets/corruption/test_comp_corrupt/corruption-manifest.yml<br>test-data/datasets/corruption/test_comp_corrupt/corruption-sha256.txt<br>_fail:_ artifact.exhaustive_regeneration.audit_report |
 | `cass.corruption.index_db.bit_flip_big` | nb | test-data/datasets/corruption/test_comp_corrupt/corruption-manifest.yml<br>test-data/datasets/corruption/test_comp_corrupt/corruption-sha256.txt<br>_fail:_ artifact.exhaustive_regeneration.audit_report |
 | `cass.corruption.statistics_db.header_damage` | nb | test-data/datasets/corruption/test_comp_corrupt/corruption-manifest.yml<br>test-data/datasets/corruption/test_comp_corrupt/corruption-sha256.txt<br>_fail:_ artifact.exhaustive_regeneration.audit_report |
 | `cass.corruption.summary_db_truncation` | nb | test-data/datasets/corruption/test_comp_corrupt/corruption-manifest.yml<br>test-data/datasets/corruption/test_comp_corrupt/corruption-sha256.txt<br>_fail:_ artifact.exhaustive_regeneration.audit_report |
@@ -1372,7 +1363,6 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.delta_scan.ttl_cells` | nb | test-data/datasets/sstables/test_deltas/ttl_cells-299c9220701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl |
 | `cass.delta_scan.wide_partition_corpus` | nb | — |
 | `cass.distributed_consensus.paxos_accord_out_of_scope` | — | — |
-| `cass.filter_db.bit_flip_false_negative_exposure` | nb | test-data/datasets/corruption/test_comp_corrupt/corruption-manifest.yml<br>test-data/datasets/corruption/test_comp_corrupt/corruption-sha256.txt<br>_fail:_ artifact.required_parity.byte_diff |
 | `cass.filter_db.bti_membership` | da | — |
 | `cass.filter_db.corruption_fails_closed` | nb, oa, da | test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>_fail:_ artifact.required_parity.byte_diff |
 | `cass.filter_db.no_false_negative_membership` | nb, oa, da | test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>test-data/datasets/sstables/test_basic/composite_key_table-6ab56990a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>_fail:_ artifact.required_parity.byte_diff |

--- a/docs/reports/cassandra-test-parity.md
+++ b/docs/reports/cassandra-test-parity.md
@@ -10,11 +10,11 @@ Sources: [`docs/cassandra_test_index.md`](../../docs/cassandra_test_index.md) ·
 
 | Status | Scenarios |
 |---|---|
-| `mirrored` | 231 |
+| `mirrored` | 233 |
 | `partial` | 9 |
 | `planned` | 49 |
 | `out_of_scope` | 31 |
-| **total** | **320** |
+| **total** | **322** |
 
 ## Evidence counts
 
@@ -22,7 +22,7 @@ _Counts are per scenario; see [Distinct test backing](#distinct-test-backing-ded
 
 | Evidence | Scenarios |
 |---|---|
-| `byte_for_byte` | 124 |
+| `byte_for_byte` | 126 |
 | `canonical_semantic` | 99 |
 | `smoke` | 12 |
 | `partial` | 52 |
@@ -116,6 +116,7 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 | `cass.corruption.data_db.bit_flip` | corruption_verify | mirrored | byte_for_byte | `sstable_parity_corruption_verify` | p0_data_loss |
 | `cass.corruption.data_db.truncation` | corruption_verify | mirrored | byte_for_byte | `sstable_parity_corruption_verify` | p0_data_loss |
 | `cass.corruption.digest_crc32_mismatch` | corruption_verify | mirrored | byte_for_byte | `sstable_parity_corruption_verify` | p0_data_loss |
+| `cass.corruption.filter_db.bit_flip_big` | corruption_verify | mirrored | byte_for_byte | `sstable_parity_corruption_verify` | p0_data_loss |
 | `cass.corruption.index_db.bit_flip_big` | corruption_verify | mirrored | byte_for_byte | `sstable_parity_corruption_verify` | p0_data_loss |
 | `cass.corruption.statistics_db.header_damage` | corruption_verify | mirrored | byte_for_byte | `sstable_parity_corruption_verify` | p0_data_loss |
 | `cass.corruption_verify.component_corruption_detection` | corruption_verify | mirrored | canonical_semantic | `sstable_parity_corruption_verify` | p0_data_loss |
@@ -156,6 +157,7 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 | `cass.delta_scan.row_tombstones` | delta_scan | mirrored | canonical_semantic | `sstable_parity_delta_scan` | p1_correctness |
 | `cass.delta_scan.static_with_rows` | delta_scan | mirrored | canonical_semantic | `sstable_parity_delta_scan` | p1_correctness |
 | `cass.delta_scan.ttl_cells` | delta_scan | mirrored | canonical_semantic | `sstable_parity_delta_scan` | p1_correctness |
+| `cass.filter_db.bit_flip_false_negative_exposure` | filter_db_bloom | mirrored | byte_for_byte | `sstable_parity_filter_db_bloom` | p0_data_loss |
 | `cass.filter_db.corruption_fails_closed` | filter_db_bloom | mirrored | byte_for_byte | `sstable_parity_filter_db_bloom` | p1_correctness |
 | `cass.filter_db.no_false_negative_membership` | filter_db_bloom | mirrored | byte_for_byte | `sstable_parity_filter_db_bloom` | p0_data_loss |
 | `cass.filter_db.serialization_round_trip` | filter_db_bloom | mirrored | byte_for_byte | `sstable_parity_filter_db_bloom` | p1_correctness |
@@ -288,6 +290,7 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 - `cass.corruption.data_db.bit_flip` — Data.db single-bit flip is detected (LZ4 chunk decode / CRC)
 - `cass.corruption.data_db.truncation` — Data.db mid-stream truncation is detected
 - `cass.corruption.digest_crc32_mismatch` — Digest.crc32 mismatch is detected
+- `cass.corruption.filter_db.bit_flip_big` — BIG Filter.db bit-array bit flip — false negative detected by verify
 - `cass.corruption.index_db.bit_flip_big` — BIG Index.db bit flip is detected
 - `cass.corruption.statistics_db.header_damage` — Statistics.db header damage is detected
 - `cass.corruption.summary_db_truncation` — Summary.db truncation is detected
@@ -341,6 +344,8 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 - `cass.data_db_decode.unfiltered_serializer.row_size_vints` — Data.db row-size and previous-size VInt framing parity
   - Normalization: row_size/prev_size are unsigned VInt deltas; the deterministic lane compares raw encoded bytes and decoded values at the exact width boundaries, the fixture lane compares the framing offsets of a real nb Data.db (FAIL CLOSED on a missing fixture).
 - `cass.data_db_decode.wide_partition.row_boundaries` — Wide-partition Data.db row boundaries align with promoted-index offsets
+- `cass.filter_db.bit_flip_false_negative_exposure` — Filter.db bit-array bit flip — false-negative exposure and verify detection
+  - Normalization: Present keys are the raw partition-key bytes from Index.db (key_digest, issue #552) — the exact bytes Cassandra's Murmur3 hashed into Filter.db. Cassandra's verdict is its ACTUAL captured sstableverify -e outcome (CLEAN: 'Verify ... succeeded. All 1 rows read successfully') recorded in corruption-manifest.yml (filter_db_bit_flip, verdict_parity: divergent).
 - `cass.filter_db.corruption_fails_closed` — Filter.db malformed-byte rejection (fail-closed)
 - `cass.filter_db.no_false_negative_membership` — Filter.db no-false-negative membership over Cassandra present keys
   - Normalization: Present keys are the raw partition-key bytes from Index.db (not the decoded CQL values), matching the bytes Cassandra's Murmur3 hashed into Filter.db. The reference_paths point at the committed per-fixture Data.db.jsonl siblings (the binary Filter.db and Index.db are gitignored, fetched on demand).
@@ -630,7 +635,7 @@ These P0 scenarios are backed only by `smoke` or `partial` evidence and must not
 
 Scenario counts above can overstate distinct proof: one backing test may exercise many scenario ids. The dedup view below counts unique test targets so the program is not read as more independent tests than exist (issue #1228).
 
-- Distinct backing tests: **66** across **256** scenarios that name a test.
+- Distinct backing tests: **67** across **258** scenarios that name a test.
 
 ### Tests backing more than one scenario
 
@@ -675,6 +680,7 @@ Scenario counts above can overstate distinct proof: one backing test may exercis
 | `cqlite-core/tests/issue_990_data_db_row_framing_parity.rs` | 4 |
 | `cqlite-core/tests/issue_992_range_boundary_grammar.rs` | 4 |
 | `cqlite-core/tests/issue_1190_write_load_byte_parity.rs` | 3 |
+| `cqlite-core/tests/sstable_parity_corruption_verify.rs` | 3 |
 | `compaction-parity/src/test/java/org/cqlite/parity/ComponentByteComparatorTest.java` | 2 |
 | `compaction-parity/src/test/java/org/cqlite/parity/DifferentialParityTester.java` | 2 |
 | `cqlite-core/tests/issue_1073_statistics_max_ldt_tombstone_histogram_parity.rs` | 2 |
@@ -683,6 +689,7 @@ Scenario counts above can overstate distinct proof: one backing test may exercis
 | `cqlite-core/tests/issue_821_writer_byte_invariants.rs` | 2 |
 | `cqlite-core/tests/issue_899_per_element_survives_compaction.rs` | 2 |
 | `cqlite-core/tests/issue_921_background_compaction_dropped_column_header.rs` | 2 |
+| `cqlite-core/tests/sstable_parity_filter_bitflip_test.rs` | 2 |
 | `cqlite-core/tests/sstable_parity_integration_test.rs` | 2 |
 | `cqlite-core/tests/sstableloader_integration.rs` | 2 |
 
@@ -967,6 +974,7 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.corruption.data_db.bit_flip` | exhaustive_regeneration | .github/workflows/compression-corruption-parity.yml |
 | `cass.corruption.data_db.truncation` | exhaustive_regeneration | .github/workflows/compression-corruption-parity.yml |
 | `cass.corruption.digest_crc32_mismatch` | exhaustive_regeneration | .github/workflows/compression-corruption-parity.yml |
+| `cass.corruption.filter_db.bit_flip_big` | exhaustive_regeneration | .github/workflows/compression-corruption-parity.yml |
 | `cass.corruption.index_db.bit_flip_big` | exhaustive_regeneration | .github/workflows/compression-corruption-parity.yml |
 | `cass.corruption.statistics_db.header_damage` | exhaustive_regeneration | .github/workflows/compression-corruption-parity.yml |
 | `cass.corruption.summary_db_truncation` | exhaustive_regeneration | .github/workflows/compression-corruption-parity.yml |
@@ -1038,6 +1046,7 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.delta_scan.ttl_cells` | manual_debug | — |
 | `cass.delta_scan.wide_partition_corpus` | exhaustive_regeneration | .github/workflows/delta-roundtrip.yml |
 | `cass.distributed_consensus.paxos_accord_out_of_scope` | fast_pr | — |
+| `cass.filter_db.bit_flip_false_negative_exposure` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.filter_db.bti_membership` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.filter_db.corruption_fails_closed` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
 | `cass.filter_db.no_false_negative_membership` | required_parity | .github/workflows/sstabledump-parity-gate.yml |
@@ -1292,6 +1301,7 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.corruption.data_db.bit_flip` | nb | test-data/datasets/corruption/test_comp_corrupt/corruption-manifest.yml<br>test-data/datasets/corruption/test_comp_corrupt/corruption-sha256.txt<br>_fail:_ artifact.exhaustive_regeneration.audit_report |
 | `cass.corruption.data_db.truncation` | nb | test-data/datasets/corruption/test_comp_corrupt/corruption-manifest.yml<br>test-data/datasets/corruption/test_comp_corrupt/corruption-sha256.txt<br>_fail:_ artifact.exhaustive_regeneration.audit_report |
 | `cass.corruption.digest_crc32_mismatch` | nb | test-data/datasets/corruption/test_comp_corrupt/corruption-manifest.yml<br>test-data/datasets/corruption/test_comp_corrupt/corruption-sha256.txt<br>_fail:_ artifact.exhaustive_regeneration.audit_report |
+| `cass.corruption.filter_db.bit_flip_big` | nb | test-data/datasets/corruption/test_comp_corrupt/corruption-manifest.yml<br>test-data/datasets/corruption/test_comp_corrupt/corruption-sha256.txt<br>_fail:_ artifact.exhaustive_regeneration.audit_report |
 | `cass.corruption.index_db.bit_flip_big` | nb | test-data/datasets/corruption/test_comp_corrupt/corruption-manifest.yml<br>test-data/datasets/corruption/test_comp_corrupt/corruption-sha256.txt<br>_fail:_ artifact.exhaustive_regeneration.audit_report |
 | `cass.corruption.statistics_db.header_damage` | nb | test-data/datasets/corruption/test_comp_corrupt/corruption-manifest.yml<br>test-data/datasets/corruption/test_comp_corrupt/corruption-sha256.txt<br>_fail:_ artifact.exhaustive_regeneration.audit_report |
 | `cass.corruption.summary_db_truncation` | nb | test-data/datasets/corruption/test_comp_corrupt/corruption-manifest.yml<br>test-data/datasets/corruption/test_comp_corrupt/corruption-sha256.txt<br>_fail:_ artifact.exhaustive_regeneration.audit_report |
@@ -1363,6 +1373,7 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 | `cass.delta_scan.ttl_cells` | nb | test-data/datasets/sstables/test_deltas/ttl_cells-299c9220701f11f1b5d1d98b0640ec05/nb-1-big-Data.db.jsonl |
 | `cass.delta_scan.wide_partition_corpus` | nb | — |
 | `cass.distributed_consensus.paxos_accord_out_of_scope` | — | — |
+| `cass.filter_db.bit_flip_false_negative_exposure` | nb | test-data/datasets/corruption/test_comp_corrupt/corruption-manifest.yml<br>test-data/datasets/corruption/test_comp_corrupt/corruption-sha256.txt<br>_fail:_ artifact.required_parity.byte_diff |
 | `cass.filter_db.bti_membership` | da | — |
 | `cass.filter_db.corruption_fails_closed` | nb, oa, da | test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>_fail:_ artifact.required_parity.byte_diff |
 | `cass.filter_db.no_false_negative_membership` | nb, oa, da | test-data/datasets/sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>test-data/datasets/sstables/test_basic/composite_key_table-6ab56990a25111f0a3fef1a551383fb9/nb-1-big-Data.db.jsonl<br>_fail:_ artifact.required_parity.byte_diff |

--- a/test-data/cassandra-parity-manifest.yml
+++ b/test-data/cassandra-parity-manifest.yml
@@ -12829,6 +12829,18 @@ scenarios:
     cqlite:
       coverage:
         suite: sstable_parity_compression_info_chunks
+        tests:
+          - cqlite-core/tests/sstable_zstd_dictionary_reject_test.rs
+        notes: >-
+          Boundary-enforcement evidence for issue #1399: CQLite fails closed
+          on zstd dictionary-compressed input rather than decoding it. The
+          always-run characterization test drives a real trained-dictionary
+          zstd frame through the shipped ChunkDecompressor and proves it is
+          rejected (never decoded to the original bytes); two fixture-gated
+          reader/verify oracle tests assert the same over a commissioned
+          Cassandra dictionary SSTable (fixture: #1413). Upgrading the generic
+          rejection to a typed dictionary-naming error / dedicated verify
+          class is tracked by #1414.
     fixtures: {}
     evidence:
       type: out_of_scope
@@ -12870,6 +12882,18 @@ scenarios:
     cqlite:
       coverage:
         suite: sstable_parity_compression_info_chunks
+        tests:
+          - cqlite-core/tests/sstable_zstd_dictionary_reject_test.rs
+        notes: >-
+          Boundary-enforcement evidence for issue #1399: CQLite fails closed
+          on zstd dictionary-compressed input rather than decoding it. The
+          always-run characterization test drives a real trained-dictionary
+          zstd frame through the shipped ChunkDecompressor and proves it is
+          rejected (never decoded to the original bytes); two fixture-gated
+          reader/verify oracle tests assert the same over a commissioned
+          Cassandra dictionary SSTable (fixture: #1413). Upgrading the generic
+          rejection to a typed dictionary-naming error / dedicated verify
+          class is tracked by #1414.
     fixtures: {}
     evidence:
       type: out_of_scope
@@ -12908,6 +12932,18 @@ scenarios:
     cqlite:
       coverage:
         suite: sstable_parity_compression_info_chunks
+        tests:
+          - cqlite-core/tests/sstable_zstd_dictionary_reject_test.rs
+        notes: >-
+          Boundary-enforcement evidence for issue #1399: CQLite fails closed
+          on zstd dictionary-compressed input rather than decoding it. The
+          always-run characterization test drives a real trained-dictionary
+          zstd frame through the shipped ChunkDecompressor and proves it is
+          rejected (never decoded to the original bytes); two fixture-gated
+          reader/verify oracle tests assert the same over a commissioned
+          Cassandra dictionary SSTable (fixture: #1413). Upgrading the generic
+          rejection to a typed dictionary-naming error / dedicated verify
+          class is tracked by #1414.
     fixtures: {}
     evidence:
       type: out_of_scope
@@ -12945,6 +12981,18 @@ scenarios:
     cqlite:
       coverage:
         suite: sstable_parity_compression_info_chunks
+        tests:
+          - cqlite-core/tests/sstable_zstd_dictionary_reject_test.rs
+        notes: >-
+          Boundary-enforcement evidence for issue #1399: CQLite fails closed
+          on zstd dictionary-compressed input rather than decoding it. The
+          always-run characterization test drives a real trained-dictionary
+          zstd frame through the shipped ChunkDecompressor and proves it is
+          rejected (never decoded to the original bytes); two fixture-gated
+          reader/verify oracle tests assert the same over a commissioned
+          Cassandra dictionary SSTable (fixture: #1413). Upgrading the generic
+          rejection to a typed dictionary-naming error / dedicated verify
+          class is tracked by #1414.
     fixtures: {}
     evidence:
       type: out_of_scope
@@ -12982,6 +13030,18 @@ scenarios:
     cqlite:
       coverage:
         suite: sstable_parity_compression_info_chunks
+        tests:
+          - cqlite-core/tests/sstable_zstd_dictionary_reject_test.rs
+        notes: >-
+          Boundary-enforcement evidence for issue #1399: CQLite fails closed
+          on zstd dictionary-compressed input rather than decoding it. The
+          always-run characterization test drives a real trained-dictionary
+          zstd frame through the shipped ChunkDecompressor and proves it is
+          rejected (never decoded to the original bytes); two fixture-gated
+          reader/verify oracle tests assert the same over a commissioned
+          Cassandra dictionary SSTable (fixture: #1413). Upgrading the generic
+          rejection to a typed dictionary-naming error / dedicated verify
+          class is tracked by #1414.
     fixtures: {}
     evidence:
       type: out_of_scope
@@ -13023,6 +13083,18 @@ scenarios:
     cqlite:
       coverage:
         suite: sstable_parity_compression_info_chunks
+        tests:
+          - cqlite-core/tests/sstable_zstd_dictionary_reject_test.rs
+        notes: >-
+          Boundary-enforcement evidence for issue #1399: CQLite fails closed
+          on zstd dictionary-compressed input rather than decoding it. The
+          always-run characterization test drives a real trained-dictionary
+          zstd frame through the shipped ChunkDecompressor and proves it is
+          rejected (never decoded to the original bytes); two fixture-gated
+          reader/verify oracle tests assert the same over a commissioned
+          Cassandra dictionary SSTable (fixture: #1413). Upgrading the generic
+          rejection to a typed dictionary-naming error / dedicated verify
+          class is tracked by #1414.
     fixtures: {}
     evidence:
       type: out_of_scope

--- a/test-data/scripts/generate-zstd-dictionary-fixture.md
+++ b/test-data/scripts/generate-zstd-dictionary-fixture.md
@@ -1,0 +1,86 @@
+# Generating the zstd-dictionary negative SSTable fixture (issue #1399 / #1413)
+
+This documents how to produce the **commissioned** dictionary-compressed SSTable
+that `cqlite-core/tests/sstable_zstd_dictionary_reject_test.rs` gates on. It is a
+*negative* fixture: CQLite must **fail closed** on it (typed rejection, never
+rows, never a partial/garbled decode).
+
+## Why this cannot be a plain `nodetool flush`
+
+Apache Cassandra 5.x `org.apache.cassandra.io.compress.ZstdCompressor`
+(CASSANDRA-14482) exposes only a `compression_level` option. It does **not**
+train, store, reference, or apply a Zstd **dictionary**. There is no
+`WITH compression = {'class': 'ZstdCompressor', 'dictionary': ...}` option, and
+Cassandra records no separate dictionary compressor class in `CompressionInfo.db`
+(the compressor simple-name stays `ZstdCompressor`). **No stock Apache Cassandra
+release can flush a dictionary-compressed SSTable.** ScyllaDB's SSTable format is
+out of CQLite's scope, so it is not an acceptable source either.
+
+The fixture must therefore be produced by **post-processing** a genuine
+Cassandra-written Zstd SSTable, not by a vanilla flush.
+
+## Target layout (what the tests expect)
+
+```
+test-data/datasets/sstables/test_comp/zstd_dictionary_table/
+  nb-1-big-Data.db              # chunks re-compressed with a trained dictionary
+  nb-1-big-CompressionInfo.db   # ZstdCompressor, offsets updated for new chunks
+  nb-1-big-Statistics.db
+  nb-1-big-Index.db
+  nb-1-big-Summary.db
+  nb-1-big-Filter.db
+  nb-1-big-Digest.crc32         # recomputed over the rewritten Data.db
+  nb-1-big-TOC.txt
+```
+
+## Generation procedure (record full provenance for every step)
+
+1. **Base SSTable.** Flush a real `ZstdCompressor` table with Apache Cassandra
+   5.0.2 (record the exact image digest + `cassandra_git_sha`). Reuse the
+   existing corpus generator:
+   `bash test-data/scripts/regenerate-datasets.sh` (cassandra:5.0.2 → flush).
+   Start from `test_comp/zstd_table-*` (plain Zstd) as the source of truth for
+   the row data, Index/Summary/Statistics/Filter/TOC components.
+
+2. **Train a dictionary.** Train a zstd dictionary over the *uncompressed* chunk
+   payloads of the base Data.db (or a representative row corpus). Record the
+   `zstd`/`zdict` library version and the exact training corpus. The trained
+   dictionary embeds a Dictionary_ID in the frame header — this is the property
+   that makes the frames un-decodable without the dictionary.
+
+3. **Re-compress each chunk.** For every chunk in the base Data.db, decompress it
+   (plain zstd), then re-compress it **with the trained dictionary**
+   (`ZSTD_compress_usingDict`, dictID flag left enabled so the ID lands in the
+   header). Re-append the 4-byte big-endian inline CRC32 of the *new* compressed
+   bytes (`CompressedSequentialWriter.java:192`).
+
+4. **Rewrite `CompressionInfo.db`.** Keep the compressor simple-name
+   `ZstdCompressor`, keep `chunk_length`, recompute the chunk offset table for
+   the new compressed sizes (`chunkOffset += compressedLength + 4`), and update
+   `data_length`/`chunk_count` if the chunking changed (prefer keeping identical
+   chunk boundaries so only the compressed bytes differ).
+
+5. **Recompute `Digest.crc32`.** Recompute the whole-Data.db CRC32 to match the
+   rewritten file (`DigestWriter`), so the digest is *valid* — the fixture must
+   fail on the dictionary, not on a checksum mismatch (issue #1399 AC#3).
+
+6. **Provenance + integrity.** Record: base Cassandra version + git sha, zstd/
+   zdict version, the training corpus, and a sha-256 of every committed
+   component. The `.db` binaries are gitignored — force-add the tiny reference
+   files (`git add -f`) and verify the tests against a fresh detached worktree
+   (`git worktree add --detach HEAD`), not the dirty tree.
+
+## Validation once committed
+
+```bash
+env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets CQLITE_REQUIRE_FIXTURES=1 \
+  cargo test --package cqlite-core --test sstable_zstd_dictionary_reject_test
+```
+
+The two fixture-gated oracle tests
+(`zstd_dictionary_sstable_rejected_via_reader_fixture`,
+`zstd_dictionary_verify_reports_unsupported_not_checksum_fixture`) must run (not
+skip) and prove the reader/verify surfaces fail closed. If they instead reveal
+that CQLite does not yet return a *typed* dictionary rejection, that is the
+production gap tracked by **#1414** — update those tests to the
+characterization/`#[ignore = "blocked on #1414"]` form so the suite stays green.


### PR DESCRIPTION
Closes #1399. Part of epic #1380 (read-path integrity hardening).

## What
Proves CQLite fails closed (never garbles / partial-decodes / silently returns wrong values) on zstd **dictionary**-compressed input, and wires the 6 `unsupported_compression_dictionary` parity scenarios to real test evidence.
- **Always-run** `zstd_dictionary_frame_rejected_fail_closed` (`#![cfg(feature="zstd")]`): trains a real zstd dictionary, dict-compresses a Cassandra-framed chunk, drives the shipped `ChunkDecompressor` → asserts rejection (never Ok, never plaintext, never partial), typed `InvalidFormat`/`UnsupportedFormat`, never `Corruption`; plaintext positive control round-trips.
- **Fixture-gated reader** — active characterization (`..._current_behavior`: fail-closed today, accepts `Corruption`|`InvalidFormat`) + an `#[ignore]`d typed-target test enabled when #1414 lands.
- **Fixture-gated verify** — asserts `VerifyErrorClass::ChunkDecompressionError` on Data.db/CompressionInfo.db with zstd/dictionary detail, excludes CRC/checksum/digest.
- Fail-closed gating via shared `require_fixtures_strict()` (honors `CQLITE_REQUIRE_FIXTURES` + `CQLITE_PARITY_REQUIRE_DATASETS`) + `assert_full_fixture_present()` (rejects partial fixtures).
- Parity manifest: 6 `zstd_dictionary` scenarios reference this test; report regenerated.

## Discovered (filed, not fixed inline — 1:1:1:1)
- **#1413** (P2) — commission the zstd+trained-dictionary fixture (no stock Cassandra release can flush one; generation procedure documented).
- **#1414** (P2) — CQLite misclassifies a dict frame as `InvalidFormat`/"Dictionary mismatch" (verify → `ChunkDecompressionError`) instead of a typed `UnsupportedFormat`; the ignored reader oracle is its ready-to-enable regression.

## Quality bar
- agent-gate.sh: **PASS** (all components; no-zstd build compiles the module out).
- roborev (codex): **clean** (converged after a thorough 7-round hardening of the fixture oracles).

Oracle-driven (no OpenSpec).