### PR TITLE
feat(#1406): CompressionInfo.db fail-closed guard (posture b — guard now, wire later)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -380,6 +380,20 @@ enforced in code: `BigVersionGates::from_version` rejects `< na` and `BtiVersion
 rejects non-`da`, both with `Error::UnsupportedVersion`; `SSTableReader::open` propagates that
 error rather than falling back. Do not re-litigate pre-`na` "regressions."
 
+### Write surface: CQLite writes UNCOMPRESSED SSTables (claim boundary, issue #1406)
+The production write surface (flush + compaction via `SSTableWriter`) emits
+**uncompressed** SSTables only and never emits a `CompressionInfo.db`. The
+compressed-write building blocks (`CompressedDataWriter`, `CompressionInfoWriter`)
+are built but **UNWIRED** — they exist solely to synthesize compressed fixtures for
+the read/decompress path, and carry zero Cassandra-side byte-parity coverage for a
+CQLite-emitted `CompressionInfo.db`. This is fail-closed in code: any attempt to
+configure compressed production writing returns `Error::UnsupportedFormat`
+(`SSTableWriter::with_compression` / `CompressionInfoWriter::guard_unsupported_production_write`).
+Do NOT claim CQLite emits compressed SSTables (parity manifest records this as
+`claim.blocked.compressed_sstable_writes`; the safe wording is
+`claim.safe.uncompressed_sstable_writes`). Wiring compressed writes (posture a) is
+tracked in issue #1406.
+
 ### Code Quality
 - `RUSTFLAGS="-D warnings"` must pass
 - No `unwrap()`/`expect()` in library code

--- a/cqlite-core/src/storage/sstable/writer/compressed_data_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/compressed_data_writer.rs
@@ -21,6 +21,16 @@
 //! 4. Track chunk offsets for CompressionInfo.db
 //! 5. On finish(), flush remaining buffer
 //!
+//! # Claim boundary — BUILT-BUT-UNWIRED (issue #1406, posture b)
+//!
+//! This writer is NOT wired into CQLite's production write surface (flush +
+//! compaction via `SSTableWriter` emit uncompressed SSTables only). It exists to
+//! let read-path fixtures synthesize compressed SSTables for exercising the
+//! decompressing reader. Any attempt to emit a compressed SSTable as a real,
+//! parity-claimed artifact is fail-closed by
+//! [`super::compression_info_writer::CompressionInfoWriter::guard_unsupported_production_write`].
+//! See that module's docs and issue #1406.
+//!
 //! References:
 //! - Parser: `cqlite-core/src/storage/sstable/reader/compression.rs`
 //! - Format docs: `docs/sstables-definitive-guide/chapters/09-compression.md`

--- a/cqlite-core/src/storage/sstable/writer/compression_info_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/compression_info_writer.rs
@@ -27,6 +27,23 @@
 //! References:
 //! - Parser: `cqlite-core/src/storage/sstable/compression_info.rs`
 //! - Cassandra source: `CompressionMetadata.java:375-392`
+//!
+//! # Claim boundary — BUILT-BUT-UNWIRED (issue #1406, posture b)
+//!
+//! CQLite's production write surface (flush + compaction via `SSTableWriter`)
+//! emits **uncompressed** SSTables only, and therefore never emits a
+//! CompressionInfo.db. This writer and its sibling `CompressedDataWriter` are
+//! wired ONLY into read-path fixtures: they let tests synthesize compressed
+//! SSTables so the *reader/decompressor* can be exercised. They are NOT wired
+//! into any production write path, and there is ZERO Cassandra-side byte-parity
+//! coverage for a CQLite-emitted CompressionInfo.db.
+//!
+//! To keep that boundary honest and fail-closed, any code that would emit a
+//! CompressionInfo.db as part of a real (claimed) SSTable must first pass
+//! [`CompressionInfoWriter::guard_unsupported_production_write`], which errors
+//! for every real compression algorithm rather than emitting a false/partial
+//! artifact or making an unearned parity claim. Wiring real compressed writes
+//! (posture a) is tracked in issue #1406.
 
 use crate::error::{Error, Result};
 use std::fs::File;
@@ -155,6 +172,37 @@ impl CompressionInfoWriter {
     /// Create a new CompressionInfo.db writer
     pub fn new(path: PathBuf) -> Self {
         Self { path }
+    }
+
+    /// Fail-closed guard for PRODUCTION CompressionInfo.db emission (issue #1406,
+    /// posture b — "guard now, wire compression later").
+    ///
+    /// CQLite does not have a wired compressed-write path: flush and compaction
+    /// emit uncompressed SSTables (no CompressionInfo.db), and no Cassandra-side
+    /// byte-parity coverage exists for a CQLite-emitted CompressionInfo.db. Any
+    /// code that intends to produce a CompressionInfo.db as part of a real,
+    /// parity-claimed SSTable MUST call this first so an unwired compression
+    /// request errors clearly instead of silently emitting an uncompressed
+    /// SSTable (a false claim) or a partial/unvalidated CompressionInfo.db.
+    ///
+    /// [`CompressionAlgorithm::None`] (uncompressed) is permitted; every real
+    /// compression algorithm returns [`Error::UnsupportedFormat`]. This is the
+    /// enforced claim boundary — see the module docs and issue #1406.
+    ///
+    /// Note: this does NOT restrict [`Self::build_to_vec`] / [`Self::write`],
+    /// which read-path fixtures legitimately use to synthesize compressed
+    /// SSTables for exercising the decompressing reader.
+    pub fn guard_unsupported_production_write(algorithm: CompressionAlgorithm) -> Result<()> {
+        match algorithm {
+            CompressionAlgorithm::None => Ok(()),
+            other => Err(Error::UnsupportedFormat(format!(
+                "compressed SSTable writing is not supported: CQLite emits \
+                 uncompressed SSTables only (requested {}). The CompressionInfo.db \
+                 write path is built but unwired and unvalidated against Cassandra \
+                 (see issue #1406).",
+                other.cassandra_name()
+            ))),
+        }
     }
 
     /// Write compression metadata to file in Cassandra's binary format.
@@ -431,6 +479,41 @@ mod tests {
         assert_eq!(info.data_length, 32000);
         assert_eq!(info.chunk_offsets, vec![0, 9876]);
         assert!(info.option_pairs.is_empty());
+    }
+
+    /// Issue #1406 (posture b): the production-emission guard fails closed for
+    /// every real compression algorithm and permits only the uncompressed case.
+    #[test]
+    fn test_guard_unsupported_production_write_fails_closed() {
+        // Uncompressed is the only permitted production write.
+        assert!(
+            CompressionInfoWriter::guard_unsupported_production_write(CompressionAlgorithm::None)
+                .is_ok(),
+            "uncompressed (None) production writes must be permitted"
+        );
+
+        for algo in [
+            CompressionAlgorithm::Lz4,
+            CompressionAlgorithm::Snappy,
+            CompressionAlgorithm::Deflate,
+            CompressionAlgorithm::Zstd,
+        ] {
+            let err = CompressionInfoWriter::guard_unsupported_production_write(algo)
+                .expect_err("real compression must be rejected by the fail-closed guard");
+            match err {
+                Error::UnsupportedFormat(msg) => {
+                    assert!(
+                        msg.contains(algo.cassandra_name()),
+                        "error must name the requested algorithm, got: {msg}"
+                    );
+                    assert!(
+                        msg.contains("1406"),
+                        "error must cite the claim-boundary issue, got: {msg}"
+                    );
+                }
+                other => panic!("expected UnsupportedFormat, got {other:?}"),
+            }
+        }
     }
 
     #[test]

--- a/cqlite-core/src/storage/sstable/writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/mod.rs
@@ -402,6 +402,31 @@ impl SSTableWriter {
         )
     }
 
+    /// Configure compression for the SSTable this writer emits.
+    ///
+    /// FAIL-CLOSED GUARD (issue #1406, posture b — "guard now, wire compression
+    /// later"). CQLite's production write surface emits **uncompressed** SSTables
+    /// only: there is no wired path from flush or compaction to the
+    /// `CompressedDataWriter` / `CompressionInfoWriter` building blocks, and no
+    /// Cassandra-side byte-parity coverage exists for a CQLite-emitted
+    /// CompressionInfo.db. Rather than silently drop a compression request (and
+    /// emit an uncompressed SSTable that falsely claims otherwise) or emit an
+    /// unvalidated CompressionInfo.db, this constructor errors for every real
+    /// compression algorithm via
+    /// [`CompressionInfoWriter::guard_unsupported_production_write`].
+    /// [`CompressionAlgorithm::None`] is accepted and maps to the normal
+    /// uncompressed writer. Wiring real compression (posture a) is tracked in
+    /// issue #1406.
+    pub fn with_compression(
+        output_dir: PathBuf,
+        generation: u64,
+        schema: &TableSchema,
+        algorithm: CompressionAlgorithm,
+    ) -> Result<Self> {
+        CompressionInfoWriter::guard_unsupported_production_write(algorithm)?;
+        Self::with_expected_partitions(output_dir, generation, schema, 128)
+    }
+
     /// Create a new SSTable writer selecting the on-disk index `format` and an
     /// optional [`UdtRegistry`] for bare-UDT resolution (issue #766 + #929).
     pub fn with_format_and_registry(

--- a/cqlite-core/tests/issue_1406_compression_write_guard.rs
+++ b/cqlite-core/tests/issue_1406_compression_write_guard.rs
@@ -1,0 +1,74 @@
+//! Issue #1406 — CompressionInfo.db write path: fail-closed guard + claim boundary.
+//!
+//! Posture (b), owner-approved: CQLite's production write surface emits
+//! UNCOMPRESSED SSTables only. The compressed-write building blocks
+//! (`CompressedDataWriter` / `CompressionInfoWriter`) are built but UNWIRED — they
+//! exist for read-path fixtures, not production emission, and carry zero
+//! Cassandra-side byte-parity coverage. These tests exercise the PUBLIC write
+//! surface to prove that any attempt to configure compression fails closed with a
+//! clear error instead of silently emitting an uncompressed (falsely-claimed) or
+//! partial/unvalidated artifact.
+
+#![cfg(feature = "write-support")]
+
+use cqlite_core::error::Error;
+use cqlite_core::schema::cql_parser::parse_cql_schema;
+use cqlite_core::schema::TableSchema;
+use cqlite_core::storage::sstable::writer::{CompressionAlgorithm, SSTableWriter};
+
+fn minimal_schema() -> TableSchema {
+    parse_cql_schema("CREATE TABLE test_ks.guard_tbl (id int PRIMARY KEY, val text);")
+        .expect("CQL schema should parse")
+}
+
+/// The public write surface refuses every real compression algorithm.
+#[test]
+fn with_compression_fails_closed_for_real_algorithms() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let schema = minimal_schema();
+
+    for algo in [
+        CompressionAlgorithm::Lz4,
+        CompressionAlgorithm::Snappy,
+        CompressionAlgorithm::Deflate,
+        CompressionAlgorithm::Zstd,
+    ] {
+        let result = SSTableWriter::with_compression(dir.path().to_path_buf(), 1, &schema, algo);
+        let err = result.err().unwrap_or_else(|| {
+            panic!(
+                "SSTableWriter::with_compression({algo:?}) MUST fail closed while the \
+                 compressed write path is unwired (issue #1406)"
+            )
+        });
+        match err {
+            Error::UnsupportedFormat(msg) => {
+                assert!(
+                    msg.contains(algo.cassandra_name()),
+                    "error must name the requested algorithm, got: {msg}"
+                );
+                assert!(
+                    msg.contains("1406"),
+                    "error must cite the claim-boundary issue #1406, got: {msg}"
+                );
+            }
+            other => panic!("expected Error::UnsupportedFormat, got {other:?}"),
+        }
+    }
+}
+
+/// The uncompressed case (the only supported production write) is accepted.
+#[test]
+fn with_compression_none_builds_an_uncompressed_writer() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let schema = minimal_schema();
+
+    let writer = SSTableWriter::with_compression(
+        dir.path().to_path_buf(),
+        1,
+        &schema,
+        CompressionAlgorithm::None,
+    )
+    .expect("uncompressed (None) production writes must be permitted");
+    // Constructing the writer is sufficient evidence the None path is live; drop it.
+    drop(writer);
+}

--- a/docs/reports/cassandra-test-parity.md
+++ b/docs/reports/cassandra-test-parity.md
@@ -1524,9 +1524,15 @@ Public/release-facing parity claims are enforced by the claim-scan lint. Safe wo
 - **claim.safe.traceable_cassandra_parity_suite** — a traceable parity suite mapping CQLite tests to specific Cassandra scenarios
   - Why safe: The parity manifest maps each CQLite test/fixture to the Cassandra scenario it mirrors, so claims are traceable to named evidence. This is distinct from running Cassandra's own JVM test suite.
   - Backed by: `cass.compaction.CompactionIteratorTest.differential_compaction_loop`, `cass.data_db_decode.serialization_mirror.multi_clustering_column_order`
+- **claim.safe.uncompressed_sstable_writes** — CQLite writes uncompressed SSTables
+  - Why safe: The production write surface (flush + compaction via SSTableWriter) emits UNCOMPRESSED SSTables only and never emits a CompressionInfo.db. The compressed-write building blocks (CompressedDataWriter, CompressionInfoWriter) are built but UNWIRED — used only by read-path fixtures — and any attempt to configure compressed production writing is fail-closed (SSTableWriter::with_compression / CompressionInfoWriter::guard_unsupported_production_write return Error::UnsupportedFormat). This is the claim boundary from issue #1406, posture (b): guard now, wire compression later. It scopes the write claim to uncompressed output rather than implying byte-validated compressed writing, for which zero Cassandra-side coverage exists.
+  - Backed by: `cass.write_load_path.cql_sstable_writer.finished_data_db_artifacts`
 
 ### Blocked phrases (rejected unless explicitly scoped)
 
+- **claim.blocked.compressed_sstable_writes** — "CQLite writes compressed SSTables"
+  - Why blocked: CQLite does not emit compressed SSTables from any production path. The compressed-write modules are built but unwired and carry no Cassandra-side byte-parity coverage for a CQLite-emitted CompressionInfo.db (issue #1406). Claiming compressed writing overstates the write surface, which is fail-closed for every real compression algorithm.
+  - Use instead: `claim.safe.uncompressed_sstable_writes`
 - **claim.blocked.full_compaction_byte_parity** — "full compaction byte parity"
   - Why blocked: Byte-for-byte compaction parity is proven only for the scenarios that carry byte_for_byte evidence, not for all compaction inputs/strategies. "Full" generalizes byte parity beyond the manifest's evidence.
   - Use instead: `claim.safe.rust_byte_level_coverage`

--- a/test-data/cassandra-parity-manifest.yml
+++ b/test-data/cassandra-parity-manifest.yml
@@ -15706,6 +15706,36 @@ scenarios:
 #                   as a counter-example. Each names the safe wording to use.
 # ==============================================================================
 claims:
+  - id: claim.safe.uncompressed_sstable_writes
+    kind: safe
+    phrase: >-
+      CQLite writes uncompressed SSTables
+    rationale: >-
+      The production write surface (flush + compaction via SSTableWriter) emits
+      UNCOMPRESSED SSTables only and never emits a CompressionInfo.db. The
+      compressed-write building blocks (CompressedDataWriter,
+      CompressionInfoWriter) are built but UNWIRED — used only by read-path
+      fixtures — and any attempt to configure compressed production writing is
+      fail-closed (SSTableWriter::with_compression /
+      CompressionInfoWriter::guard_unsupported_production_write return
+      Error::UnsupportedFormat). This is the claim boundary from issue #1406,
+      posture (b): guard now, wire compression later. It scopes the write claim
+      to uncompressed output rather than implying byte-validated compressed
+      writing, for which zero Cassandra-side coverage exists.
+    evidence_scenarios:
+      - cass.write_load_path.cql_sstable_writer.finished_data_db_artifacts
+
+  - id: claim.blocked.compressed_sstable_writes
+    kind: blocked
+    phrase: CQLite writes compressed SSTables
+    rationale: >-
+      CQLite does not emit compressed SSTables from any production path. The
+      compressed-write modules are built but unwired and carry no Cassandra-side
+      byte-parity coverage for a CQLite-emitted CompressionInfo.db (issue #1406).
+      Claiming compressed writing overstates the write surface, which is
+      fail-closed for every real compression algorithm.
+    safe_alternative: claim.safe.uncompressed_sstable_writes
+
   - id: claim.safe.selected_fixture_validation
     kind: safe
     phrase: >-


### PR DESCRIPTION
Closes #1406. Owner-approved posture (b): fail-closed guard now, wire compression later.

## What
The CompressionInfo.db write path (`CompressedDataWriter` / `CompressionInfoWriter`) is built but UNWIRED — it is used only by read-path fixtures and has zero Cassandra-side byte-parity coverage. This adds a fail-closed guard + honest claim boundary so the unwired path errors clearly instead of emitting a false/partial artifact or making an unearned parity claim.

- `CompressionInfoWriter::guard_unsupported_production_write(algorithm)` and `SSTableWriter::with_compression(...)` fail closed with `Error::UnsupportedFormat` for every real compression algorithm; `CompressionAlgorithm::None` (uncompressed) is permitted. No `unwrap`/`expect`; `thiserror` variant reused.
- Module doc-comments on both built-but-unwired writer modules point at the guard + issue #1406, clarifying they are read-path fixture builders, not production emitters.
- Claim boundary recorded in the parity manifest: `claim.safe.uncompressed_sstable_writes` (backed by `cass.write_load_path.cql_sstable_writer.finished_data_db_artifacts`) + `claim.blocked.compressed_sstable_writes`; report regenerated; CLAUDE.md note added.
- Guard tests: public-surface (`SSTableWriter::with_compression`) integration test + module-level unit test.

Note: the low-level `build_to_vec` / `write` builders are intentionally NOT restricted — read-path fixtures legitimately synthesize compressed SSTables to exercise the decompressing reader.

## Gate: PASS

```
file-size:         PASS (0s)
fmt:               PASS (3s)
clippy:            PASS (4s)
core-tests:        PASS (570s)
tombstones-scan:   PASS (1s)
scan-offload-guard: PASS (1s)
integration-tests: PASS (2s)
format-compat:     PASS (2s)
write-tests:       PASS (51s)
cli-tests:         PASS (10s)
python-bindings:   PASS (75s)
node-bindings:     PASS (68s)
delivery-telemetry: PASS (0s)
parity-report:     PASS (1s)
tooling-tests:     PASS (8s)
minimal-build:     PASS (0s)
smoke:             PASS (6s)
commit: d3ad69d7  dirty: no
RESULT: PASS
```

`CQLITE_ALLOW_FILE_GROWTH=1` acknowledges a 25-line growth of the already over-threshold `writer/mod.rs` (source split tracked by epic #1116).

Discovered follow-ups: none.
