### PR TITLE
ci(#1405): compaction byte-tier PR-gate visibility

### DIFF
--- a/.github/workflows/live-cell-compaction-parity.yml
+++ b/.github/workflows/live-cell-compaction-parity.yml
@@ -168,12 +168,41 @@ jobs:
               --test issue_1020_udt_frozen_compaction_byte_parity \
               -- --nocapture
 
-      # Issue #1027 convergence audit: this lane's live-cell/UDT compaction parity
-      # tests use plain assert!/assert_eq! terminals — they do NOT route through
-      # ParityFailure::panic and have no scenario-id-keyed bundle emitter — so a
-      # speculative `parity-failures-*` upload here would advertise a bundle that
-      # never appears (even with `if-no-files-found: ignore`, the artifact promise
-      # is false). The upload was removed rather than left misleading. FOLLOW-UP:
-      # to restore it, first route these tests' failure terminals through the
-      # shared ParityFailure/FailureBundle emitter (out of scope for #1027, which
-      # only standardises the artifact system, not each suite's assertion sites).
+      # Issue #1027 note (historical): this lane's tests use plain assert!/assert_eq!
+      # terminals — they do NOT route through the per-SCENARIO ParityFailure::panic
+      # bundle emitter, so a speculative scenario-id-keyed `parity-failures-*` bundle
+      # would advertise an artifact that never appears. That per-scenario bundle
+      # remains out of scope (tracked in #1345).
+      #
+      # Issue #1405: the parity-failure-issue automation only needs a LANE-SCOPED
+      # `parity-failures.json` (structured fields to fingerprint from), exactly as
+      # tombstone-ttl-parity.yml already emits. On a NIGHTLY failure this lets a real
+      # byte-parity regression file/update ONE deduped `parity-failure` issue rather
+      # than being discovered by manual log-reading. The scenario_id/test_target here
+      # are intentionally lane-scoped v1 placeholders (stable per lane so cross-run
+      # dedup works); per-scenario emission is the #1345 follow-up. This emits ONLY on
+      # failure, and the automation ignores pull_request-origin runs (it files for the
+      # scheduled/dispatch runs), so PRs still just surface the red check.
+      - name: Emit parity-failures.json (on failure)
+        if: failure()
+        run: |
+          set -euo pipefail
+          cat > parity-failures.json <<'JSON'
+          [
+            {
+              "scenario_id": "cass.compaction.byte_tier_pr_proxy.live_cell_udt_lane",
+              "workflow": "live-cell-compaction-parity.yml",
+              "test_target": "cqlite-core compaction byte-parity subset (issue_1017/1020/1240)",
+              "component_path": "test-data/datasets/sstables/test_compactionparity,test_compactionparityudt",
+              "failure_class": "ByteParityMismatch"
+            }
+          ]
+          JSON
+
+      - name: Upload parity-failures.json
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: parity-failures
+          path: parity-failures.json
+          if-no-files-found: warn

--- a/.github/workflows/parity-failure-issue.yml
+++ b/.github/workflows/parity-failure-issue.yml
@@ -32,6 +32,7 @@ on:
       - "CI: Compression / Corruption Parity (Nightly Docker, Epic #970)"
       - "CI: CQL Type & Schema-Evolution Parity (Nightly Docker, Epic #971)"
       - "CI: Tombstone / TTL Parity (Nightly Docker, Epic #972)"
+      - "CI: Live-Cell Compaction Byte Parity (issue #1017, #1020)"
       - "Exhaustive Regeneration (parity corpus)"
     types: [completed]
   workflow_dispatch:
@@ -134,13 +135,14 @@ jobs:
             R_EVENT="$(printf '%s' "${META}" | jq -r '.event // ""')"
             R_CONCLUSION="$(printf '%s' "${META}" | jq -r '.conclusion // ""')"
             R_URL="$(printf '%s' "${META}" | jq -r '.url // ""')"
-            # (a) tracked-workflow allowlist — the target run must belong to one of the 4
+            # (a) tracked-workflow allowlist — the target run must belong to one of the 5
             # tracked parity lanes (matched by workflow NAME, the same names the auto
             # workflow_run trigger allowlists above).
             case "${R_NAME}" in
               "CI: Compression / Corruption Parity (Nightly Docker, Epic #970)"|\
               "CI: CQL Type & Schema-Evolution Parity (Nightly Docker, Epic #971)"|\
               "CI: Tombstone / TTL Parity (Nightly Docker, Epic #972)"|\
+              "CI: Live-Cell Compaction Byte Parity (issue #1017, #1020)"|\
               "Exhaustive Regeneration (parity corpus)")
                 : ;;
               *)
@@ -236,7 +238,7 @@ jobs:
           # Fix A: map the completed run's identity to its workflow FILENAME so the
           # green-lane resolve is scoped to THAT lane only (never all open issues). Prefer
           # the payload `path` (`.github/workflows/<file>`); fall back to a name→filename
-          # lookup for the 4 tracked lanes. On a replay, WR_NAME/WR_PATH are empty — use
+          # lookup for the 5 tracked lanes. On a replay, WR_NAME/WR_PATH are empty — use
           # the validated target-run workflow name. WR_PATH/WR_NAME/VALIDATED_NAME are
           # untrusted -> quoted env.
           LANE_FILE=""
@@ -251,6 +253,8 @@ jobs:
                 LANE_FILE="cql-type-parity.yml" ;;
               "CI: Tombstone / TTL Parity (Nightly Docker, Epic #972)")
                 LANE_FILE="tombstone-ttl-parity.yml" ;;
+              "CI: Live-Cell Compaction Byte Parity (issue #1017, #1020)")
+                LANE_FILE="live-cell-compaction-parity.yml" ;;
               "Exhaustive Regeneration (parity corpus)")
                 LANE_FILE="exhaustive-regeneration.yml" ;;
               *)
@@ -268,7 +272,7 @@ jobs:
           case "${LANE_FILE}" in
             exhaustive-regeneration.yml)
               LANE_TIER="exhaustive_regeneration" ;;
-            compression-corruption-parity.yml|cql-type-parity.yml|tombstone-ttl-parity.yml)
+            compression-corruption-parity.yml|cql-type-parity.yml|tombstone-ttl-parity.yml|live-cell-compaction-parity.yml)
               LANE_TIER="nightly_docker" ;;
             *)
               : ;;

--- a/docs/development/parity-ci-tiers.md
+++ b/docs/development/parity-ci-tiers.md
@@ -174,6 +174,44 @@ P0 data-loss path without a recorded gap is a contract violation.
   `required_parity` scenario whose fixtures need a live Cassandra to regenerate
   is *attached* to the nightly so its goldens stay fresh.
 
+#### PR-visibility proxy for the compaction byte tier (issue #1405)
+
+The compaction byte-tier scenarios
+`cass.compaction.SSTableRewriterTest.output_component_integrity` and
+`cass.compaction.harness_byte_tier_artifacts` are `nightly_docker`: their real
+Cassandra-vs-CQLite byte comparison only runs under `gradle byteParity`
+(`compaction-parity.yml` / `nightly-docker-parity.yml`) on the nightly schedule
+and on `workflow_dispatch`. A PR that breaks compaction byte parity would
+otherwise merge green and be caught only by the next nightly. To give PRs
+*visibility* (not a heavyweight new required lane), a **PR proxy** runs a
+Rust-side re-compaction byte-parity subset:
+
+- **What runs.** The `compaction-byte-parity` component of
+  [`scripts/agent-gate.sh`](../../scripts/agent-gate.sh) executes the committed
+  Rust byte-parity tests (`issue_1017` live-cell, `issue_1020` frozen-UDT,
+  `issue_1240` nested frozen-collection-UDT — under `CQLITE_REQUIRE_FIXTURES=1`,
+  fail-closed on committed goldens; plus `issue_1019` static/dropped-column,
+  skip-aware over its fetched-only `test_tomb` fixtures). CQLite re-produces the
+  same inputs, runs its own compaction, and diffs the output components
+  byte-for-byte against committed Cassandra 5.0.2 compacted references. The same
+  tests also run on PRs via
+  [`live-cell-compaction-parity.yml`](../../.github/workflows/live-cell-compaction-parity.yml)
+  and [`tombstone-ttl-parity.yml`](../../.github/workflows/tombstone-ttl-parity.yml).
+- **What the PR proxy PROMISES.** For the committed live-cell / frozen-UDT /
+  nested-UDT scenarios, CQLite's compaction output is byte-identical to the
+  committed Cassandra golden on the diffed component set
+  (Data.db/Index.db/Summary.db/Digest.crc32/CRC.db). A regression there fails
+  the PR gate before merge.
+- **What it does NOT promise (why the nightly tier remains authoritative).** The
+  PR proxy is a *subset over committed goldens*, not the Java differential
+  harness. It does not rebuild Cassandra from source, does not exercise the full
+  scenario matrix, does not diff every component (Statistics.db/Filter.db are
+  present-not-diffed), and cannot catch drift induced by a transitive change
+  outside the covered write/merge/serializer paths. The `nightly_docker`
+  `gradle byteParity` run over a live Cassandra build is the authoritative
+  byte-tier backstop; the two manifest scenarios stay `nightly_docker` and
+  record this PR-proxy relationship in their `evidence` notes.
+
 ### `exhaustive_regeneration`
 
 - **Purpose.** The full, expensive regeneration of the entire fixture corpus

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -151,7 +151,7 @@ if ! command -v cargo >/dev/null 2>&1 && [ -d "$HOME/.cargo/bin" ]; then
 fi
 export CQLITE_DATASETS_ROOT="${CQLITE_DATASETS_ROOT:-$REPO_ROOT/test-data/datasets}"
 
-COMPONENTS=(file-size fmt clippy core-tests tombstones-scan scan-offload-guard integration-tests format-compat write-tests cli-tests python-bindings node-bindings delivery-telemetry parity-report tooling-tests minimal-build smoke)
+COMPONENTS=(file-size fmt clippy core-tests tombstones-scan scan-offload-guard integration-tests format-compat write-tests cli-tests compaction-byte-parity python-bindings node-bindings delivery-telemetry parity-report tooling-tests minimal-build smoke)
 ONLY=""
 SELFTEST=0
 case "${1:-}" in
@@ -516,6 +516,76 @@ run_delivery_telemetry() {
   echo ">>> [$name] $status ($((end - start))s)"
 }
 
+# compaction-byte-parity: the PR-VISIBLE proxy for the nightly-only Java
+# differential byte tier (issue #1405). The two manifest scenarios
+# cass.compaction.SSTableRewriterTest.output_component_integrity and
+# cass.compaction.harness_byte_tier_artifacts prove Cassandra-vs-CQLite
+# byte identity only under `gradle byteParity` (compaction-parity.yml /
+# nightly-docker-parity.yml), which fires nightly + on workflow_dispatch — never
+# on a PR. A PR could break compaction byte parity and merge green.
+#
+# This component runs the Rust re-compaction byte-parity SUBSET as the local PR
+# proxy: CQLite re-produces the same inputs, runs its own compaction, and diffs
+# the output components (Data.db/Index.db/Summary.db/Digest.crc32/CRC.db)
+# byte-for-byte against committed Cassandra 5.0.2 compacted references. It does
+# NOT replace the nightly Java tier (which diffs the FULL component set over the
+# whole scenario matrix from a live Cassandra build) — see
+# docs/development/parity-ci-tiers.md for the PR-proxy vs nightly tier contract.
+#
+# Fixture policy (fail-closed where fixtures are committed, SKIP-aware otherwise):
+#   * Group A (issue_1017/1020/1240): references are COMMITTED to git under
+#     test_compactionparity/** + test_compactionparityudt/**, so they run under
+#     CQLITE_REQUIRE_FIXTURES=1 — an absent/present-but-incomplete committed
+#     golden is a hard FAIL, never a silent skip.
+#   * Group B (issue_1019): its test_tomb references are fetched-only (not
+#     committed), so it runs WITHOUT CQLITE_REQUIRE_FIXTURES — it enforces the
+#     byte/header diff when the fixtures are present and cleanly self-skips when
+#     they are not (e.g. a checkout that has not fetched test_tomb).
+# The whole component SKIPs (loud, never silent PASS) when CQLITE_DATASETS_ROOT
+# is unset or the committed test_compactionparity keyspace is absent (a minimal
+# checkout). NOT in DATASET_COMPONENTS: it is self-guarding, so it must not trip
+# the hard dataset preflight.
+run_compaction_byte_parity() {
+  local name=compaction-byte-parity
+  if [ -n "$ONLY" ] && ! grep -qw "$name" <<<"${ONLY//,/ }"; then
+    return 0
+  fi
+  local log="$LOG_DIR/$name.log"
+  local start end status
+  start=$(date +%s)
+  local committed_ks="${CQLITE_DATASETS_ROOT:-}/sstables/test_compactionparity"
+  if [ -z "${CQLITE_DATASETS_ROOT:-}" ] || [ ! -d "$committed_ks" ]; then
+    status=SKIP
+    echo ">>> [$name] SKIP (CQLITE_DATASETS_ROOT unset or committed test_compactionparity fixtures absent)"
+    NAMES+=("$name"); STATUSES+=("$status"); TIMES+=("0s")
+    return 0
+  fi
+  echo ">>> [$name] Rust byte-parity PR proxy for the nightly Java byte tier (#1405)"
+  if CQLITE_DATASETS_ROOT="$CQLITE_DATASETS_ROOT" bash -c '
+      set -euo pipefail
+      # Group A — committed references, fail-closed (CQLITE_REQUIRE_FIXTURES=1).
+      env CQLITE_REQUIRE_FIXTURES=1 CQLITE_DATASETS_ROOT="'"$CQLITE_DATASETS_ROOT"'" \
+        cargo test -p cqlite-core --features write-support \
+          --test issue_1017_live_cell_compaction_byte_parity \
+          --test issue_1020_udt_frozen_compaction_byte_parity \
+          --test issue_1240_nested_frozen_collection_udt_parity
+      # Group B — fetched-only test_tomb references, skip-aware (no require-fixtures).
+      env CQLITE_DATASETS_ROOT="'"$CQLITE_DATASETS_ROOT"'" \
+        cargo test -p cqlite-core --features write-support \
+          --test issue_1019_static_dropped_collection_compaction_parity' >"$log" 2>&1; then
+    status=PASS
+  else
+    status=FAIL
+    OVERALL=FAIL
+    echo "--- [$name] FAILED; last 40 lines of $log ---"
+    tail -40 "$log"
+    echo "--- end of $name output ---"
+  fi
+  end=$(date +%s)
+  NAMES+=("$name"); STATUSES+=("$status"); TIMES+=("$((end - start))s")
+  echo ">>> [$name] $status ($((end - start))s)"
+}
+
 # parity-report: verify the committed derived parity report is not stale vs its
 # source manifest (issue #1338). Renders test-data/cassandra-parity-manifest.yml
 # with `cassandra-parity report --check`; PASS when the committed report matches a
@@ -858,6 +928,7 @@ run_component write-tests bash -c '
 run_component cli-tests bash -c '
   cargo test --package cqlite-cli --test unit_tests &&
   cargo test --package cqlite-cli --features write-support --test write_readback_content_tests'
+run_compaction_byte_parity
 run_python_bindings
 run_node_bindings
 run_delivery_telemetry

--- a/test-data/cassandra-parity-manifest.yml
+++ b/test-data/cassandra-parity-manifest.yml
@@ -5459,18 +5459,34 @@ scenarios:
       cassandra_version: "5.0.2"
       cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
       storage_format_version: [nb]
+      fixture_generation_command: >-
+        cd compaction-parity && bash scripts/bootstrap-cassandra.sh && gradle --no-daemon byteParity
+        # RUN-GENERATED: builds pinned cassandra-5.0.2 and emits the reference SSTable components
+        # into build/parity-artifacts-byteParity/<scenario>/cassandra-output/ (NOT committed to git)
       comparison_command: >-
         cd compaction-parity && gradle --no-daemon byteParity  # per-component cmp, no allowlist
       reference_paths:
+        # RUN-GENERATED placeholder (not committed): materialized only by fixture_generation_command
+        # above, inside a nightly/workflow_dispatch harness run. Empty on a fresh checkout.
         - compaction-parity/build/parity-artifacts-byteParity/<scenario>/cassandra-output/
       failure_artifacts:
         - artifact.nightly_docker.live_logs
       known_limitations: >-
-        The byte tier is implemented and runs in CI, but is non-blocking
-        (continue-on-error) and has no committed reference fixtures — the
-        reference output is regenerated in CI from the pinned Cassandra build, so
-        this scenario is `planned` (target named, not yet a gated claim). Promote
-        to a hard gate once compaction output is byte-stable.
+        CADENCE — the real Cassandra-vs-CQLite byte comparison for this claim runs
+        NIGHTLY-ONLY (schedule + workflow_dispatch via compaction-parity.yml /
+        nightly-docker-parity.yml `gradle byteParity`); it is NOT PR-gated, so a
+        byte_for_byte claim here must not be read as per-PR enforced. PR VISIBILITY
+        is provided by a Rust re-compaction byte-parity PROXY (issue #1405): the
+        `compaction-byte-parity` component of scripts/agent-gate.sh plus the
+        live-cell-compaction-parity.yml / tombstone-ttl-parity.yml PR lanes run
+        issue_1017/1019/1020/1240 (a committed-golden SUBSET, not the full Java
+        differential harness) — see docs/development/parity-ci-tiers.md
+        (PR-visibility proxy for the compaction byte tier). The byte tier is
+        implemented and runs in CI but is non-blocking (continue-on-error) and has
+        NO committed reference fixtures — the reference output is RUN-GENERATED in
+        CI from the pinned Cassandra build (see fixture_generation_command), so this
+        scenario is `planned` (target named, not yet a gated claim). Promote to a
+        hard gate once compaction output is byte-stable.
     ci:
       tier: nightly_docker
       workflow: .github/workflows/nightly-docker-parity.yml
@@ -5626,17 +5642,32 @@ scenarios:
       cassandra_version: "5.0.2"
       cassandra_git_sha: f278f6774fc76465c182041e081982105c3e7dbb
       storage_format_version: [nb]
+      fixture_generation_command: >-
+        cd compaction-parity && bash scripts/bootstrap-cassandra.sh && gradle --no-daemon byteParity
+        # RUN-GENERATED: builds pinned cassandra-5.0.2 and emits reference components +
+        # byte-diff/checksum artifacts into build/parity-artifacts-byteParity/ (NOT committed)
       comparison_command: >-
         cd compaction-parity && gradle --no-daemon byteParity
       reference_paths:
+        # RUN-GENERATED placeholder (not committed): materialized only by fixture_generation_command
+        # above, inside a nightly/workflow_dispatch harness run. Empty on a fresh checkout.
         - compaction-parity/build/parity-artifacts-byteParity/<scenario>/cassandra-output/
       failure_artifacts:
         - artifact.nightly_docker.live_logs
       known_limitations: >-
-        Byte tier is implemented and runs non-blocking in CI with full failure
-        artifacts, but has no committed reference fixtures (reference output is
-        regenerated in CI) and the writer is not yet byte-identical — hence
-        `planned`, not a gated byte-for-byte claim.
+        CADENCE — this harness byte-tier MECHANISM asserts (per-component cmp,
+        artifact preservation) run NIGHTLY-ONLY (schedule + workflow_dispatch via
+        compaction-parity.yml / nightly-docker-parity.yml `gradle byteParity`);
+        NOT PR-gated. PR VISIBILITY of the underlying byte claim is provided by the
+        Rust re-compaction byte-parity PROXY (issue #1405): the
+        `compaction-byte-parity` agent-gate component + live-cell-compaction-parity.yml
+        / tombstone-ttl-parity.yml PR lanes (issue_1017/1019/1020/1240, a
+        committed-golden SUBSET, not this Java harness) — see
+        docs/development/parity-ci-tiers.md (PR-visibility proxy for the compaction
+        byte tier). Byte tier is implemented and runs non-blocking in CI with full
+        failure artifacts, but has NO committed reference fixtures (reference output
+        is RUN-GENERATED in CI, see fixture_generation_command) and the writer is not
+        yet byte-identical — hence `planned`, not a gated byte-for-byte claim.
     ci:
       tier: nightly_docker
       workflow: .github/workflows/nightly-docker-parity.yml


### PR DESCRIPTION
Closes #1405. Surfaces the 2 compaction `byte_for_byte` scenarios' status on PRs (previously nightly-only via the Java differential harness).

## What changed
- **AC1 — PR-visible tier.** New SKIP-aware `compaction-byte-parity` component in `scripts/agent-gate.sh` runs the Rust re-compaction byte-parity SUBSET as the local PR proxy: `issue_1017`/`issue_1020`/`issue_1240` under `CQLITE_REQUIRE_FIXTURES=1` (fail-closed on committed goldens) + `issue_1019` skip-aware over its fetched-only `test_tomb` fixtures. Documented as a "PR-visibility proxy for the compaction byte tier" in `docs/development/parity-ci-tiers.md` (what the PR proxy promises vs the authoritative nightly `gradle byteParity` tier).
- **AC2 — manifest evidence.** `cass.compaction.SSTableRewriterTest.output_component_integrity` and `cass.compaction.harness_byte_tier_artifacts` now record the nightly-only CADENCE, the PR-proxy relationship (so `byte_for_byte` is not misread as PR-gated), and mark `reference_paths` RUN-GENERATED via a new `fixture_generation_command`. Report regenerated; lint/tier-contract-check green.
- **AC3 — nightly auto-file.** A nightly byte-parity regression now files/updates a deduped `parity-failure` issue: `live-cell-compaction-parity.yml` is added to the `parity-failure-issue.yml` tracked-lane allowlist (3 sites + tier map) and emits a lane-scoped `parity-failures.json` on failure only (mirrors `tombstone-ttl-parity.yml`; PR-origin runs are ignored by the automation, so PRs just show the red check).

## Validation
- `actionlint` clean on both edited workflows; YAML + `bash -n` valid; `cassandra-parity` lint + tier-contract-check + tests green.
- `compaction-byte-parity` verified PASS (fixtures present) and SKIP (fixtures absent) in isolation.

Note: the Java-harness byte tier itself stays `nightly_docker` + non-blocking (writer not yet byte-stable, #842); this change is visibility, not a new heavyweight required lane.

Gate: PASS

```
==== AGENT-GATE SUMMARY ====
commit: ebba0d55 branch: issue-1405-compaction-byte-tier-pr-gate dirty: no
datasets: 141 Data.db files under /Users/pmcfadin/projects/cqlite/test-data/datasets
file-size:         PASS (0s)
fmt:               PASS (3s)
clippy:            PASS (77s)
core-tests:        PASS (805s)
tombstones-scan:   PASS (56s)
scan-offload-guard: PASS (66s)
integration-tests: PASS (68s)
format-compat:     PASS (25s)
write-tests:       PASS (92s)
cli-tests:         PASS (145s)
compaction-byte-parity: PASS (1s)
python-bindings:   PASS (180s)
node-bindings:     PASS (177s)
delivery-telemetry: PASS (0s)
parity-report:     PASS (5s)
tooling-tests:     PASS (16s)
minimal-build:     PASS (43s)
smoke:             PASS (76s)
RESULT: PASS
==== END AGENT-GATE SUMMARY ====
```

Discovered follow-ups: none (the Rust byte-parity subset passes byte-for-byte on committed goldens; no new byte-parity failure surfaced).