### PR TITLE
test(#1403): re-scope WAL + memtable boundaries (real native surfaces, not out_of_scope)

### DIFF
--- a/docs/development/cassandra-parity-manifest.md
+++ b/docs/development/cassandra-parity-manifest.md
@@ -154,6 +154,15 @@ Other evidence fields: `strict`, `artifacts` (`bytes`, `offsets`, `checksums`,
 `scope.related_in_scope_scenarios`. High-relevance Cassandra files may only be
 marked out of scope with an explicit `scope.cqlite_boundary`.
 
+**"Out of parity scope, but a CQLite-native surface" (issue #1403):**
+`out_of_scope` means only "not a Cassandra byte/semantic parity target." When the
+Cassandra behavior has a **functional analogue in CQLite's own code** (e.g. its
+WAL, its memtable, its crash-mid-compaction cleanup), the boundary text MUST name
+that native analogue and link its OPEN native (non-parity) coverage tracker — in
+the prose fields and in `scope.next_step`. Never claim "CQLite does not implement
+X" when a functional analogue exists. See the per-category audit-sweep table in
+[`docs/reports/cassandra-test-parity-assessment.md`](../reports/cassandra-test-parity-assessment.md#per-category-audit-sweep-issue-1403-ac3).
+
 | Category | Definition |
 |---|---|
 | `commitlog_replay` | Commitlog segment writing and replay/recovery. CQLite reads already-flushed SSTables only. |

--- a/docs/reports/cassandra-test-parity-assessment.md
+++ b/docs/reports/cassandra-test-parity-assessment.md
@@ -163,6 +163,52 @@ node. Each has a fixed `scope.out_of_scope_category` (see
 High-relevance Cassandra files may only be marked out-of-scope with an explicit
 `scope.cqlite_boundary` explaining why CQLite does not implement that behavior.
 
+### Convention: "out of PARITY scope, but a CQLite-native surface" (issue #1403)
+
+`out_of_scope` means only that a scenario is **not a Cassandra byte/semantic
+parity target** — it does **not** license the false claim that CQLite has no such
+behavior at all. Some Cassandra node behaviors have a **functional analogue** in
+CQLite's own code (its WAL, its memtable, its crash-mid-compaction cleanup). For
+those, "CQLite does not implement X" is wrong and misleading.
+
+When a functional analogue exists, the `out_of_scope` boundary text MUST:
+
+1. State that CQLite makes **no Cassandra parity claim** for that behavior
+   (that is what keeps it out of parity scope), and
+2. **Name the CQLite-native analogue** (with its source path), and
+3. **Link the OPEN native (non-parity) coverage tracker issue** — in the prose
+   fields (`rationale` / `cqlite_boundary` / `safe_claim`) and, structurally, in
+   `scope.next_step`.
+
+The analogue's correctness is proven by **native tests tracked on those issues**,
+not by any Cassandra-parity scenario. Never write "CQLite does not maintain a
+memtable / does not have a commit log / does not implement X" when the code says
+otherwise.
+
+#### Per-category audit sweep (issue #1403, AC3)
+
+Every `out_of_scope` category was swept for a functional CQLite analogue. Verdict:
+
+| Category | Functional CQLite analogue? | Native tracker |
+|---|---|---|
+| `commitlog_replay` | **Yes** — write-ahead log (`write_engine/wal.rs`), replay-after-crash | #1390, #1391, #1394 |
+| `memtable_internals` | **Yes** — memtable (`write_engine/memtable.rs`), token-order iteration + estimate accounting | #1404 |
+| `node_lifecycle` (early-open) | **Yes** — crash-mid-compaction orphan sweeps (`write_engine/maintenance.rs`) | #1393 |
+| `repair_coordinator` | No — no peers, no Merkle exchange, no anti-compaction lifecycle | — (clean) |
+| `read_repair_coordinator` | No — no coordinator, no digest-mismatch resolution, no cross-replica path | — (clean) |
+| `streaming_protocol` | No — no node-to-node stream wire protocol or join/leave transitions | — (clean) |
+| `distributed_consensus` | No — no Paxos/Accord participants or consensus rounds | — (clean) |
+| `nodetool_jmx_metrics` | No — no JMX, live metrics registry, or operational control surface | — (clean) |
+| `sai_sasi_query` | No — CQLite reads base-table components only; no SAI/SASI index engine | — (clean) |
+| `java_tooling` | No — CQLite does not reimplement scrub/upgrader JVM tools | — (clean) |
+| `unsupported_compression_dictionary` | No — feature CQLite does not support | — (clean) |
+| `not_sstable_reader_writer_compactor` | No — by definition outside the reader/writer/compactor | — (clean) |
+
+The three "Yes" categories were re-scoped by #1403 (boundary text corrected, native
+trackers linked). The remaining nine categories were **audited clean**: their
+Cassandra behavior has no CQLite-native analogue, so "CQLite does not implement X"
+is accurate for them and no re-scope is required.
+
 ## P0 areas to classify
 
 Drawn from the high-relevance list in the test index. Each must have at least one

--- a/docs/reports/cassandra-test-parity.md
+++ b/docs/reports/cassandra-test-parity.md
@@ -764,9 +764,9 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 ### `commitlog_replay`
 
 - `cass.commitlog.CommitLogStressTest.replay_round_trip` — Commitlog stress replay round-trip
-  - Safe wording: CQLite reads any SSTable produced after a commitlog-driven flush; it does not implement commit-log replay.
+  - Safe wording: CQLite reads any SSTable produced after a commitlog-driven flush and claims no commit-log-replay parity; its own WAL replay is validated by native tests (#1390/#1391/#1394).
 - `cass.commitlog_replay.recovery_out_of_scope` — Commitlog and replay compatibility (out of scope)
-  - Safe wording: CQLite reads SSTables that Cassandra has already flushed; it does not replay or validate commitlogs.
+  - Safe wording: CQLite reads already-flushed Cassandra SSTables and claims no commitlog/recovery parity; its own WAL crash-replay correctness is validated by native tests (#1390/#1391/#1394).
 
 ### `distributed_consensus`
 
@@ -785,16 +785,16 @@ _Out of scope does not mean unimportant._ Node behaviors CQLite does not mirror:
 ### `memtable_internals`
 
 - `cass.memtable_flush.MemtableNegativeReleasedCQLReproTest.memtable_memory_accounting` — Memtable negative-released memory accounting repro
-  - Safe wording: CQLite reads any SSTable produced by a flush; it does not model the node's memtable memory accounting.
+  - Safe wording: CQLite reads any SSTable produced by a flush and claims no memtable memory-accounting parity; its own memtable accounting invariants are tracked for native coverage in #1404.
 - `cass.memtable_flush.NonSplittablePartitionerTrieMemtableFlushSetTest.trie_memtable_flushset` — Non-splittable-partitioner trie-memtable FlushSet metadata
-  - Safe wording: CQLite reads any SSTable the trie memtable flushed; it does not implement the trie-memtable internals.
+  - Safe wording: CQLite reads any SSTable the trie memtable flushed and claims no trie-memtable parity; its own memtable token-order invariant is tracked for native coverage in #1404.
 - `cass.memtable_flush.SplittablePartitionerTrieMemtableFlushSetTest.trie_memtable_flushset_split` — Splittable-partitioner trie-memtable FlushSet enumeration
-  - Safe wording: CQLite reads any SSTable the trie memtable flushed; it does not implement the trie-memtable internals.
+  - Safe wording: CQLite reads any SSTable the trie memtable flushed and claims no trie-memtable parity; its own memtable token-order invariant is tracked for native coverage in #1404.
 
 ### `node_lifecycle`
 
 - `cass.compaction.EarlyOpenCompactionTest.early_open_intermediate_readers` — Early-open compaction intermediate readers
-  - Safe wording: CQLite reads any completed SSTable a compaction produced; it does not implement early-open intermediate reader exposure.
+  - Safe wording: CQLite reads any completed SSTable a compaction produced and claims no early-open parity; its own crash-mid-compaction orphan cleanup is tracked for native coverage in #1393.
 
 ### `nodetool_jmx_metrics`
 

--- a/test-data/cassandra-parity-manifest.yml
+++ b/test-data/cassandra-parity-manifest.yml
@@ -7384,14 +7384,26 @@ scenarios:
     scope:
       out_of_scope_category: commitlog_replay
       rationale: >-
-        CQLite does not implement a commitlog or node recovery; it reads and
-        writes already-flushed SSTables. Out of scope does not mean unimportant.
+        Out of PARITY scope: CQLite claims no byte/semantic parity with
+        Cassandra's commitlog segment format or node-recovery pipeline. This does
+        NOT mean CQLite has no durability log — its native write-ahead log
+        (write_engine/wal.rs) with replay-after-crash semantics is the functional
+        analogue and a real CQLite surface with its own (non-parity) native test
+        obligations.
       cqlite_boundary: >-
-        CQLite operates on SSTable component files only. Commitlog segments and
-        replay/recovery are node runtime behavior CQLite never executes.
+        CQLite neither reads Cassandra commitlog segments nor claims node-recovery
+        parity. CQLite's native analogue is the WAL at write_engine/wal.rs
+        (replay-after-crash on startup), where the CommitLogTest bug class was
+        confirmed by the 2026-07-01 audit. Native (non-parity) WAL crash-replay
+        coverage is tracked in #1390, #1391, and #1394 — not by any
+        Cassandra-parity scenario.
       safe_claim: >-
-        CQLite reads SSTables that Cassandra has already flushed; it does not
-        replay or validate commitlogs.
+        CQLite reads already-flushed Cassandra SSTables and claims no
+        commitlog/recovery parity; its own WAL crash-replay correctness is
+        validated by native tests (#1390/#1391/#1394).
+      next_step: >-
+        Native (non-parity) WAL crash-replay coverage tracked in #1390, #1391,
+        #1394; remains out of Cassandra-parity scope.
       related_in_scope_scenarios:
         - cass.schema_evolution.serialization_header_column_order
 
@@ -15295,7 +15307,7 @@ scenarios:
     cqlite:
       coverage:
         notes: >-
-          CQLite reads and writes SSTable components; it does not write or replay the commit log.
+          CQLite claims no parity with Cassandra's commit log; its native analogue is the write-ahead log (write_engine/wal.rs), tracked for non-parity coverage in #1390/#1391/#1394.
     fixtures:
       datasets:
         - test-data/datasets/sstables
@@ -15309,11 +15321,23 @@ scenarios:
     scope:
       out_of_scope_category: commitlog_replay
       rationale: >-
-        This test writes mutations to the commit log, restarts, replays all segments, and verifies a round-trip hash. Commit-log replay is a node durability/recovery behavior outside CQLite's SSTable read/write/compact scope.
+        Out of PARITY scope: this test writes mutations to Cassandra's commit
+        log, restarts, replays all segments, and verifies a round-trip hash.
+        CQLite claims no parity with the commitlog segment format or replay
+        pipeline. Its functional analogue is the native write-ahead log
+        (write_engine/wal.rs), which carries the same crash-replay obligation.
       cqlite_boundary: >-
-        CQLite reads and writes SSTable components; it does not write or replay the commit log.
+        CQLite does not write or replay Cassandra commit-log segments and claims
+        no parity with them. Its native analogue is the WAL at
+        write_engine/wal.rs; native (non-parity) crash-replay round-trip coverage
+        is tracked in #1390, #1391, and #1394.
       safe_claim: >-
-        CQLite reads any SSTable produced after a commitlog-driven flush; it does not implement commit-log replay.
+        CQLite reads any SSTable produced after a commitlog-driven flush and
+        claims no commit-log-replay parity; its own WAL replay is validated by
+        native tests (#1390/#1391/#1394).
+      next_step: >-
+        Native (non-parity) WAL crash-replay coverage tracked in #1390, #1391,
+        #1394; remains out of Cassandra-parity scope.
       related_in_scope_scenarios:
         - cass.write_load_path.cassandra_sstable_writer_fixtures
 
@@ -15554,7 +15578,7 @@ scenarios:
     cqlite:
       coverage:
         notes: >-
-          CQLite reads completed SSTables; it does not expose partially written compaction outputs as early-open intermediate readers.
+          CQLite reads only completed SSTables and does not expose early-open readers; its functional lifecycle analogue is crash-mid-compaction orphan cleanup (write_engine/maintenance.rs), tracked for non-parity coverage in #1393.
     fixtures:
       datasets:
         - test-data/datasets/sstables
@@ -15568,11 +15592,26 @@ scenarios:
     scope:
       out_of_scope_category: node_lifecycle
       rationale: >-
-        Early-open exposes a partially written compaction output as a live reader before the compaction completes. This is a node-runtime read-availability optimization (SSTable lifecycle), not an on-disk format behavior.
+        Out of PARITY scope: early-open exposes a partially written compaction
+        output as a live reader before the compaction completes — a node-runtime
+        read-availability optimization CQLite claims no parity with. CQLite's
+        functional analogue in this SSTable-lifecycle space is its
+        crash-mid-compaction cleanup: the startup orphan sweeps
+        (sweep_orphaned_compaction_tmp / sweep_orphaned_partial_sstables in
+        write_engine/maintenance.rs).
       cqlite_boundary: >-
-        CQLite reads completed SSTables; it does not expose partially written compaction outputs as early-open intermediate readers.
+        CQLite reads only completed SSTables and does not expose early-open
+        intermediate readers. Its native analogue for partial-compaction
+        lifecycle is the startup orphan sweep of *-tmp / partial SSTables
+        (write_engine/maintenance.rs); native (non-parity) coverage of those
+        sweeps is tracked in #1393.
       safe_claim: >-
-        CQLite reads any completed SSTable a compaction produced; it does not implement early-open intermediate reader exposure.
+        CQLite reads any completed SSTable a compaction produced and claims no
+        early-open parity; its own crash-mid-compaction orphan cleanup is tracked
+        for native coverage in #1393.
+      next_step: >-
+        Native (non-parity) orphan-sweep coverage tracked in #1393; remains out
+        of Cassandra-parity scope.
       related_in_scope_scenarios:
         - cass.compaction_merge.byte_for_byte_output
         - cass.compaction_merge.tombstone_ttl_shadowing
@@ -15665,7 +15704,7 @@ scenarios:
     cqlite:
       coverage:
         notes: >-
-          CQLite does not maintain a node memtable or its memory pool; it reads/writes on-disk SSTable components.
+          CQLite claims no parity with Cassandra's memtable memory pool, but it DOES maintain a memtable (write_engine/memtable.rs) with estimate-based accounting; native (non-parity) accounting-drift coverage is tracked in #1404.
     fixtures:
       datasets:
         - test-data/datasets/sstables
@@ -15679,11 +15718,25 @@ scenarios:
     scope:
       out_of_scope_category: memtable_internals
       rationale: >-
-        This test reproduces a memtable memory-accounting assertion (negative released bytes) during flush. It targets the node's in-memory memtable allocator, not the on-disk SSTable the flush produces.
+        Out of PARITY scope: this test reproduces a memtable memory-accounting
+        assertion (negative released bytes) in Cassandra's in-memory allocator,
+        which CQLite claims no parity with. It is FALSE, however, that CQLite has
+        no memtable — write_engine/memtable.rs maintains a token-ordered BTreeMap
+        with conservative size-estimate accounting (estimate_mutation_size), the
+        functional analogue.
       cqlite_boundary: >-
-        CQLite does not maintain a node memtable or its memory pool; it reads/writes on-disk SSTable components.
+        CQLite does not model Cassandra's memtable memory pool and claims no
+        parity with it, but it DOES maintain a native memtable at
+        write_engine/memtable.rs whose estimate-based accounting is a real CQLite
+        surface; native (non-parity) memtable accounting-drift coverage is tracked
+        in #1404.
       safe_claim: >-
-        CQLite reads any SSTable produced by a flush; it does not model the node's memtable memory accounting.
+        CQLite reads any SSTable produced by a flush and claims no memtable
+        memory-accounting parity; its own memtable accounting invariants are
+        tracked for native coverage in #1404.
+      next_step: >-
+        Native (non-parity) memtable accounting-drift coverage tracked in #1404;
+        remains out of Cassandra-parity scope.
       related_in_scope_scenarios:
         - cass.write_load_path.cassandra_sstable_writer_fixtures
 
@@ -15701,7 +15754,7 @@ scenarios:
     cqlite:
       coverage:
         notes: >-
-          CQLite reads/writes on-disk SSTable components; it does not implement the trie-memtable FlushSet enumeration.
+          CQLite claims no parity with Cassandra's trie-memtable FlushSet enumeration, but its native memtable (write_engine/memtable.rs) has a token-ordered iteration that Data.db ordering depends on; native (non-parity) coverage is tracked in #1404.
     fixtures:
       datasets:
         - test-data/datasets/sstables
@@ -15715,11 +15768,25 @@ scenarios:
     scope:
       out_of_scope_category: memtable_internals
       rationale: >-
-        This test validates the trie-memtable getFlushSet() partition enumeration/metadata for a non-splittable partitioner. It targets the in-memory trie-memtable structure, not the resulting on-disk SSTable.
+        Out of PARITY scope: this test validates Cassandra's trie-memtable
+        getFlushSet() partition enumeration for a non-splittable partitioner — an
+        in-memory structure CQLite does not reimplement and claims no parity with.
+        CQLite's functional analogue is write_engine/memtable.rs, whose
+        token-ordered iteration (iter()) determines flushed Data.db partition
+        ordering.
       cqlite_boundary: >-
-        CQLite reads/writes on-disk SSTable components; it does not implement the trie-memtable FlushSet enumeration.
+        CQLite does not implement Cassandra's trie-memtable FlushSet enumeration
+        and claims no parity with it. Its native analogue is the token-ordered
+        BTreeMap iteration in write_engine/memtable.rs, on which Data.db ordering
+        depends; native (non-parity) token-order invariant coverage is tracked in
+        #1404.
       safe_claim: >-
-        CQLite reads any SSTable the trie memtable flushed; it does not implement the trie-memtable internals.
+        CQLite reads any SSTable the trie memtable flushed and claims no
+        trie-memtable parity; its own memtable token-order invariant is tracked
+        for native coverage in #1404.
+      next_step: >-
+        Native (non-parity) memtable token-order coverage tracked in #1404;
+        remains out of Cassandra-parity scope.
       related_in_scope_scenarios:
         - cass.write_load_path.cassandra_sstable_writer_fixtures
 
@@ -15737,7 +15804,7 @@ scenarios:
     cqlite:
       coverage:
         notes: >-
-          CQLite reads/writes on-disk SSTable components; it does not implement the trie-memtable FlushSet enumeration.
+          CQLite claims no parity with Cassandra's trie-memtable FlushSet enumeration, but its native memtable (write_engine/memtable.rs) has a token-ordered iteration that Data.db ordering depends on; native (non-parity) coverage is tracked in #1404.
     fixtures:
       datasets:
         - test-data/datasets/sstables
@@ -15751,11 +15818,25 @@ scenarios:
     scope:
       out_of_scope_category: memtable_internals
       rationale: >-
-        This test validates complete partition enumeration from the splittable-partitioner trie-memtable getFlushSet(). It targets the in-memory memtable structure, not the on-disk SSTable produced.
+        Out of PARITY scope: this test validates complete partition enumeration
+        from Cassandra's splittable-partitioner trie-memtable getFlushSet() — an
+        in-memory structure CQLite does not reimplement and claims no parity with.
+        CQLite's functional analogue is write_engine/memtable.rs, whose
+        token-ordered iteration (iter()) determines flushed Data.db partition
+        ordering.
       cqlite_boundary: >-
-        CQLite reads/writes on-disk SSTable components; it does not implement the trie-memtable FlushSet enumeration.
+        CQLite does not implement Cassandra's trie-memtable FlushSet enumeration
+        and claims no parity with it. Its native analogue is the token-ordered
+        BTreeMap iteration in write_engine/memtable.rs, on which Data.db ordering
+        depends; native (non-parity) token-order invariant coverage is tracked in
+        #1404.
       safe_claim: >-
-        CQLite reads any SSTable the trie memtable flushed; it does not implement the trie-memtable internals.
+        CQLite reads any SSTable the trie memtable flushed and claims no
+        trie-memtable parity; its own memtable token-order invariant is tracked
+        for native coverage in #1404.
+      next_step: >-
+        Native (non-parity) memtable token-order coverage tracked in #1404;
+        remains out of Cassandra-parity scope.
       related_in_scope_scenarios:
         - cass.write_load_path.cassandra_sstable_writer_fixtures
 


### PR DESCRIPTION
Closes #1403.

## What
Corrects the **factually false** `out_of_scope` rationales for `commitlog_replay`, `memtable_internals`, and the `node_lifecycle` early-open scenario. These behaviors are out of Cassandra *parity* scope, but CQLite has real functional analogues for each — "CQLite does not implement X" was wrong.

## New convention (assessment doc + manifest doc)
"Out of PARITY scope, but a CQLite-native surface": when a functional analogue exists, the boundary text MUST (1) state there is no Cassandra parity claim, (2) name the CQLite-native analogue with its source path, and (3) link the OPEN native (non-parity) coverage tracker — in the prose fields and structurally in `scope.next_step`.

## 6 scenarios re-scoped (kept `out_of_scope` for parity; boundary text corrected + trackers linked)
- `cass.commitlog_replay.recovery_out_of_scope` + `cass.commitlog.CommitLogStressTest.replay_round_trip` → WAL (`write_engine/wal.rs`), native trackers **#1390 / #1391 / #1394**
- `cass.compaction.EarlyOpenCompactionTest.early_open_intermediate_readers` (`node_lifecycle`) → crash-mid-compaction orphan sweeps (`write_engine/maintenance.rs`), tracker **#1393**
- 3× `memtable_internals` (`MemtableNegativeReleasedCQLReproTest`, Non/Splittable `TrieMemtableFlushSetTest`) → memtable (`write_engine/memtable.rs`, token-order iteration + estimate accounting), tracker **#1404**

## Per-category sweep (AC3)
All 12 `out_of_scope` categories audited in the assessment doc. 3 have native analogues (re-scoped above); the other 9 (`repair_coordinator`, `read_repair_coordinator`, `streaming_protocol`, `distributed_consensus`, `nodetool_jmx_metrics`, `sai_sasi_query`, `java_tooling`, `unsupported_compression_dictionary`, `not_sstable_reader_writer_compactor`) audited **clean** — no CQLite analogue, so "does not implement X" is accurate. Verdict recorded per-category in the table.

## Trackers
All native-coverage trackers already exist and are OPEN — no new issue filed. WAL tracker used: **#1394** (native WAL crash-replay test), plus bug class #1390/#1391.

## Doctrine (AC4)
The agents-developing site source is not in this repo; the convention landed in the in-repo canonical homes: `docs/reports/cassandra-test-parity-assessment.md` and `docs/development/cassandra-parity-manifest.md`.

Routing: docs/process, oracle-driven — no OpenSpec. Authoritative data only; no memtable tests added here (that is #1404, in parallel).

## Gate: PASS
```
file-size: PASS  fmt: PASS  clippy: PASS  core-tests: PASS  tombstones-scan: PASS
scan-offload-guard: PASS  integration-tests: PASS  format-compat: PASS  write-tests: PASS
cli-tests: PASS  python-bindings: PASS  node-bindings: PASS  delivery-telemetry: PASS
parity-report: PASS  tooling-tests: PASS  minimal-build: PASS  smoke: PASS
RESULT: PASS  (commit 59580f03, dirty: no)
```
(First gate run hit a transient shared-disk-full `os error 28` from ~20 concurrent worktree gates; re-run after freeing space was fully green.)
