### PR TITLE
fix(#1729): decode authoritative maxTimestamp in enhanced statistics parser + fail-closed

### DIFF
--- a/cqlite-core/src/parser/enhanced_statistics_parser/mod.rs
+++ b/cqlite-core/src/parser/enhanced_statistics_parser/mod.rs
@@ -224,7 +224,16 @@ pub fn parse_nb_format_statistics_data(
 
             let timestamp_stats = TimestampStatistics {
                 min_timestamp,
-                max_timestamp: min_timestamp, // Not parsed, use min as placeholder
+                // Fail-closed placeholder. The authoritative `maxTimestamp` is
+                // recovered from STATS field 4 by the best-effort post-pass in
+                // `parse_enhanced_statistics_file` (issue #1729). The inner
+                // EncodingStats parser does not reach field 4, so until the
+                // post-pass runs we use `i64::MIN` — Cassandra's "no max write
+                // timestamp recorded" sentinel — NOT the old `min_timestamp`
+                // placeholder (which silently reported the MIN as the max).
+                // A consumer that sees `i64::MIN` must treat the max as
+                // unavailable (do not proceed as if a real max were known).
+                max_timestamp: i64::MIN,
                 min_deletion_time,
                 max_deletion_time: min_deletion_time,
                 min_ttl,
@@ -337,16 +346,25 @@ pub fn parse_enhanced_statistics_file<'a>(
 
             // Best-effort STATS-extras decode over the FULL buffer (with TOC):
             // recover the authoritative maxLocalDeletionTime (the inner parser
-            // leaves it as a placeholder equal to min_deletion_time) and the
-            // estimated tombstone-drop-times histogram (Issue #1073). This is
-            // strictly additive — a Statistics.db that parses today must keep
-            // parsing, so an Err here is logged and the placeholders are kept.
+            // leaves it as a placeholder equal to min_deletion_time), the
+            // authoritative maxTimestamp (issue #1729 — the inner parser leaves
+            // it as the `i64::MIN` "unavailable" sentinel), and the estimated
+            // tombstone-drop-times histogram (Issue #1073). This is strictly
+            // additive — a Statistics.db that parses today must keep parsing, so
+            // an Err here is logged and the placeholders are kept. When
+            // maxTimestamp is unavailable (extras.max_timestamp == None, i.e.
+            // Cassandra's Long.MIN_VALUE sentinel) we deliberately leave the
+            // `i64::MIN` fail-closed sentinel in place rather than substituting
+            // the min — consumers requiring a real max must not proceed.
             let tombstone_drop_times =
                 match crate::parser::repair_metadata::parse_stats_extras(input, gates) {
                     Ok(extras) => {
                         // Only set max_deletion_time. Do NOT touch min_deletion_time
                         // (the EncodingStats min baseline consumed elsewhere).
                         timestamp_stats.max_deletion_time = extras.max_local_deletion_time;
+                        if let Some(max_ts) = extras.max_timestamp {
+                            timestamp_stats.max_timestamp = max_ts;
+                        }
                         extras.tombstone_drop_times
                     }
                     Err(e) => {

--- a/cqlite-core/src/parser/repair_metadata.rs
+++ b/cqlite-core/src/parser/repair_metadata.rs
@@ -946,15 +946,29 @@ pub struct StatsExtras {
     /// when the histogram carries no bins (the common case for SSTables with no
     /// tombstones).
     pub tombstone_drop_times: Vec<(i64, u64)>,
+    /// Authoritative SSTable `maxTimestamp` (write timestamp, microseconds)
+    /// decoded from STATS field 4 (issue #1729). `None` when the SSTable
+    /// carries no live timestamp — Cassandra's `MetadataCollector` seeds the
+    /// tracker with `Long.MIN_VALUE`, so an on-disk value of [`i64::MIN`] is the
+    /// "no timestamps recorded" sentinel and is surfaced fail-closed as `None`
+    /// (consumers that require a real max — e.g. the #1388 drop gate — must NOT
+    /// proceed as if a max were known). Any other value is the true maximum.
+    ///
+    /// This intentionally replaces the historical `max_timestamp = min_timestamp`
+    /// placeholder in [`crate::parser::enhanced_statistics_parser`], which
+    /// silently reported the MIN write timestamp as the max.
+    pub max_timestamp: Option<i64>,
 }
 
 impl Default for StatsExtras {
     /// The default reported when no STATS component is locatable: "no
-    /// tombstones" max-LDT ([`NO_DELETION_TIME`]) and an empty histogram.
+    /// tombstones" max-LDT ([`NO_DELETION_TIME`]), an empty histogram, and no
+    /// authoritative `maxTimestamp` (fail-closed `None`).
     fn default() -> Self {
         StatsExtras {
             max_local_deletion_time: NO_DELETION_TIME,
             tombstone_drop_times: Vec::new(),
+            max_timestamp: None,
         }
     }
 }
@@ -1004,8 +1018,13 @@ pub fn parse_stats_extras(input: &[u8], gates: Option<&VersionGates>) -> Result<
     // 3. commitLogUpperBound: i64 segmentId + i32 position.
     c.skip(8 + 4)?;
 
-    // 4. minTimestamp, maxTimestamp.
-    c.skip(8 + 8)?;
+    // 4. minTimestamp, maxTimestamp (both i64 BE microseconds). Read (rather
+    //    than skip) maxTimestamp: it is the authoritative SSTable max write
+    //    timestamp (issue #1729). Both encodings (nb / oa / da) lay these out
+    //    identically here, so no version gating is needed for this field.
+    c.skip(8)?; // minTimestamp
+    let raw_max_timestamp = c.read_i64()?;
+    let max_timestamp = decode_max_timestamp(raw_max_timestamp);
 
     // 5. min/maxLocalDeletionTime. Width is 4 bytes each in both encodings; the
     //    signedness/sentinel differs by version (handled below).
@@ -1025,6 +1044,7 @@ pub fn parse_stats_extras(input: &[u8], gates: Option<&VersionGates>) -> Result<
     Ok(StatsExtras {
         max_local_deletion_time,
         tombstone_drop_times,
+        max_timestamp,
     })
 }
 
@@ -1037,6 +1057,26 @@ pub fn parse_stats_extras(input: &[u8], gates: Option<&VersionGates>) -> Result<
 /// The version sentinel maps to [`NO_DELETION_TIME`] (`i64::MAX`); any real
 /// deletion time (always `< 2^31` seconds-since-epoch) is returned as its
 /// integer value.
+/// Cassandra's `MetadataCollector` seeds its timestamp `MinMaxLongTracker` with
+/// `Long.MIN_VALUE` for the max; an SSTable that recorded no live write
+/// timestamp serializes that sentinel verbatim to STATS field 4. We treat it as
+/// "no authoritative maxTimestamp" rather than a real (nonsensical) maximum.
+const NO_MAX_TIMESTAMP_SENTINEL: i64 = i64::MIN;
+
+/// Normalize a raw STATS `maxTimestamp` (i64 BE microseconds) into an
+/// authoritative value, or `None` when the SSTable recorded no write timestamp.
+///
+/// The `Long.MIN_VALUE` sentinel maps to `None` (fail-closed: consumers that
+/// require a real max must not proceed as if one were known). Every other value
+/// — including a valid large or negative real timestamp — is returned verbatim.
+fn decode_max_timestamp(raw: i64) -> Option<i64> {
+    if raw == NO_MAX_TIMESTAMP_SENTINEL {
+        None
+    } else {
+        Some(raw)
+    }
+}
+
 fn decode_max_local_deletion_time(raw: u32, modern: bool) -> i64 {
     if modern {
         if raw == u32::MAX {
@@ -1165,6 +1205,19 @@ mod tests {
     /// are written using the legacy (16-byte: `f64 point + i64 value`) or
     /// modern (12-byte: `i64 point + i32 value`) layout per `modern`.
     fn synthetic_statistics_extras(modern: bool, raw_max_ldt: u32, bins: &[(i64, u64)]) -> Vec<u8> {
+        // Default fixture: minTimestamp=100, maxTimestamp=200.
+        synthetic_statistics_extras_ts(modern, raw_max_ldt, bins, 100, 200)
+    }
+
+    /// Same as [`synthetic_statistics_extras`] but with explicit min/max write
+    /// timestamps (STATS field 4), for exercising `decode_max_timestamp` (#1729).
+    fn synthetic_statistics_extras_ts(
+        modern: bool,
+        raw_max_ldt: u32,
+        bins: &[(i64, u64)],
+        min_timestamp: i64,
+        max_timestamp: i64,
+    ) -> Vec<u8> {
         let mut stats = Vec::new();
         // estimatedPartitionSize + estimatedCellPerPartitionCount (empty).
         stats.extend_from_slice(&0i32.to_be_bytes());
@@ -1173,8 +1226,8 @@ mod tests {
         stats.extend_from_slice(&(-1i64).to_be_bytes());
         stats.extend_from_slice(&0i32.to_be_bytes());
         // minTimestamp, maxTimestamp.
-        stats.extend_from_slice(&100i64.to_be_bytes());
-        stats.extend_from_slice(&200i64.to_be_bytes());
+        stats.extend_from_slice(&min_timestamp.to_be_bytes());
+        stats.extend_from_slice(&max_timestamp.to_be_bytes());
         // minLocalDeletionTime (any), maxLocalDeletionTime (verbatim raw u32).
         stats.extend_from_slice(&0u32.to_be_bytes());
         stats.extend_from_slice(&raw_max_ldt.to_be_bytes());
@@ -1445,6 +1498,45 @@ mod tests {
         let extras = parse_stats_extras(&bytes, Some(&nb_gates())).expect("decode");
         assert_eq!(extras.max_local_deletion_time, 1_700_000_000);
         assert!(extras.tombstone_drop_times.is_empty());
+        // Default fixture: maxTimestamp=200 (NOT the min=100 placeholder). #1729.
+        assert_eq!(extras.max_timestamp, Some(200));
+    }
+
+    #[test]
+    fn stats_extras_decodes_authoritative_max_timestamp_not_min() {
+        // Acceptance criterion #3: min < X < max, parsed max must equal the
+        // true max (not the min placeholder the enhanced parser used to emit).
+        let min_ts = 1_000_000i64;
+        let max_ts = 5_000_000i64;
+        let bytes = synthetic_statistics_extras_ts(false, i32::MAX as u32, &[], min_ts, max_ts);
+        let extras = parse_stats_extras(&bytes, Some(&nb_gates())).expect("decode");
+        assert_eq!(
+            extras.max_timestamp,
+            Some(max_ts),
+            "parsed max_timestamp must be the true max, not the min"
+        );
+        assert_ne!(
+            extras.max_timestamp,
+            Some(min_ts),
+            "max_timestamp must NOT equal the min placeholder"
+        );
+    }
+
+    #[test]
+    fn stats_extras_max_timestamp_long_min_sentinel_is_none() {
+        // Fail-closed (#1729): Cassandra seeds the max tracker with
+        // Long.MIN_VALUE; an SSTable with no recorded write timestamp
+        // serializes that sentinel → surfaced as None, never a bogus max.
+        let bytes = synthetic_statistics_extras_ts(false, i32::MAX as u32, &[], i64::MAX, i64::MIN);
+        let extras = parse_stats_extras(&bytes, Some(&nb_gates())).expect("decode");
+        assert_eq!(extras.max_timestamp, None);
+    }
+
+    #[test]
+    fn stats_extras_default_max_timestamp_is_none() {
+        // No STATS component → fail-closed None (no authoritative max).
+        let extras = StatsExtras::default();
+        assert_eq!(extras.max_timestamp, None);
     }
 
     #[test]

--- a/cqlite-core/src/parser/statistics.rs
+++ b/cqlite-core/src/parser/statistics.rs
@@ -790,8 +790,19 @@ impl StatisticsAnalyzer {
     }
 
     fn calculate_timestamp_range_days(stats: &SSTableStatistics) -> f64 {
-        let range_micros =
-            stats.timestamp_stats.max_timestamp - stats.timestamp_stats.min_timestamp;
+        // Fail-closed (#1729): the enhanced parser marks an unavailable
+        // authoritative maxTimestamp with the `i64::MIN` sentinel. When the max
+        // is unavailable — or is somehow below the min — we cannot compute a
+        // real range, so report 0.0 rather than an underflowing/garbage span.
+        let max = stats.timestamp_stats.max_timestamp;
+        let min = stats.timestamp_stats.min_timestamp;
+        if max == i64::MIN || max < min {
+            return 0.0;
+        }
+        // `max >= min` here, so the difference is non-negative and cannot
+        // overflow i64 for realistic timestamps; use a checked subtraction to
+        // stay defensive against pathological inputs.
+        let range_micros = max.saturating_sub(min);
         range_micros as f64 / (1_000_000.0 * 60.0 * 60.0 * 24.0)
     }
 }

--- a/cqlite-core/src/storage/sstable/statistics_reader.rs
+++ b/cqlite-core/src/storage/sstable/statistics_reader.rs
@@ -190,12 +190,29 @@ impl StatisticsReader {
         self.statistics.row_stats.live_rows
     }
 
-    /// Get timestamp range in microseconds
+    /// Get timestamp range in microseconds as `(min, max)`.
+    ///
+    /// Note (#1729): the returned `max` may be the `i64::MIN` "unavailable"
+    /// sentinel when the enhanced (nb) parser could not authoritatively decode
+    /// `maxTimestamp` from STATS. Callers that need a guaranteed-real maximum
+    /// should use [`Self::max_timestamp`], which returns `None` for that case.
     pub fn timestamp_range(&self) -> (i64, i64) {
         (
             self.statistics.timestamp_stats.min_timestamp,
             self.statistics.timestamp_stats.max_timestamp,
         )
+    }
+
+    /// Get the authoritative SSTable `maxTimestamp` (microseconds), or `None`
+    /// when it is not available (#1729 fail-closed sentinel `i64::MIN`).
+    ///
+    /// Consumers that must not proceed without a real maximum (e.g. a
+    /// compaction drop/GC gate, #1388) should gate on this returning `Some`.
+    pub fn max_timestamp(&self) -> Option<i64> {
+        match self.statistics.timestamp_stats.max_timestamp {
+            i64::MIN => None,
+            v => Some(v),
+        }
     }
 
     /// Get compression information
@@ -342,6 +359,10 @@ impl StatisticsReader {
             );
 
             report.push_str("## Timestamp Range\n");
+            // #1729: `max_timestamp()` returns None for the `i64::MIN`
+            // "unavailable" sentinel — render it honestly rather than printing a
+            // bogus epoch derived from i64::MIN.
+            let max_available = self.max_timestamp().is_some();
             if let (Some(min), Some(max)) = (min_time, max_time) {
                 report.push_str(&format!(
                     "- From: {}\n",
@@ -353,10 +374,14 @@ impl StatisticsReader {
                     "- Min timestamp: {}\n",
                     self.statistics.timestamp_stats.min_timestamp
                 ));
-                report.push_str(&format!(
-                    "- Max timestamp: {}\n",
-                    self.statistics.timestamp_stats.max_timestamp
-                ));
+                if max_available {
+                    report.push_str(&format!(
+                        "- Max timestamp: {}\n",
+                        self.statistics.timestamp_stats.max_timestamp
+                    ));
+                } else {
+                    report.push_str("- Max timestamp: unavailable\n");
+                }
             }
 
             if self.has_ttl_data() {
@@ -712,6 +737,64 @@ mod tests {
         }
     }
 
+    /// #1729 end-to-end: opening a REAL nb `Statistics.db` must decode the
+    /// authoritative `maxTimestamp` from STATS field 4 (via the enhanced-parser
+    /// post-pass), NOT leave the old `max == min` placeholder or the `i64::MIN`
+    /// "unavailable" sentinel. Skips when the dataset binaries are absent.
+    #[tokio::test]
+    async fn test_open_real_nb_decodes_authoritative_max_timestamp() {
+        use std::path::PathBuf;
+        use std::sync::Arc;
+
+        let Ok(root) = std::env::var("CQLITE_DATASETS_ROOT") else {
+            eprintln!("CQLITE_DATASETS_ROOT not set, skipping");
+            return;
+        };
+        let path = PathBuf::from(root).join(
+            "sstables/test_timeseries/sensor_data-6c698230a25111f0a3fef1a551383fb9/\
+             nb-1-big-Statistics.db",
+        );
+        if !path.exists() {
+            eprintln!("dataset Statistics.db absent, skipping: {path:?}");
+            return;
+        }
+
+        let config = crate::Config::default();
+        let platform = Arc::new(
+            crate::Platform::new(&config)
+                .await
+                .expect("create platform"),
+        );
+        let reader = super::StatisticsReader::open(&path, platform)
+            .await
+            .expect("open real nb Statistics.db");
+
+        let (min, max) = reader.timestamp_range();
+        // A real time-series SSTable records write timestamps, so the
+        // authoritative max must be available (fail-closed None only when
+        // truly absent) and must be a real max >= min — never the i64::MIN
+        // sentinel.
+        let decoded_max = reader.max_timestamp();
+        assert!(
+            decoded_max.is_some(),
+            "a real time-series nb SSTable must expose an authoritative maxTimestamp"
+        );
+        let decoded_max = decoded_max.unwrap_or(i64::MIN);
+        assert_ne!(
+            decoded_max,
+            i64::MIN,
+            "max_timestamp must not be the unavailable sentinel for real data"
+        );
+        assert!(
+            decoded_max >= min,
+            "authoritative max ({decoded_max}) must be >= min ({min})"
+        );
+        assert_eq!(
+            max, decoded_max,
+            "timestamp_range max must match the authoritative decode"
+        );
+    }
+
     /// Minimal in-memory statistics for report-rendering tests. `total_rows`,
     /// `live_rows`, and `avg_rows_per_partition` are the #1325 sentinel-carrying
     /// fields the caller sets per-scenario; everything else is a benign default.
@@ -843,6 +926,63 @@ mod tests {
         assert!(
             compact.contains("Rows: 1000"),
             "compact summary must render the real total_rows: {compact}"
+        );
+    }
+
+    /// Build `stats_with` and override the timestamp range (#1729).
+    #[cfg(test)]
+    fn stats_with_timestamps(
+        min_timestamp: i64,
+        max_timestamp: i64,
+    ) -> crate::parser::statistics::SSTableStatistics {
+        let mut s = stats_with(1, 1, 1.0);
+        s.timestamp_stats.min_timestamp = min_timestamp;
+        s.timestamp_stats.max_timestamp = max_timestamp;
+        s
+    }
+
+    /// #1729: when the authoritative maxTimestamp is present it must be exposed
+    /// as `Some(max)` — and it is the TRUE max (min < X < max), not the min.
+    #[tokio::test]
+    async fn test_max_timestamp_authoritative_is_some_and_true_max() {
+        let min = 1_000_000i64;
+        let max = 5_000_000i64;
+        let reader =
+            super::StatisticsReader::from_statistics_for_test(stats_with_timestamps(min, max))
+                .await;
+        assert_eq!(reader.max_timestamp(), Some(max));
+        assert_ne!(
+            reader.max_timestamp(),
+            Some(min),
+            "max_timestamp must be the true max, never the min placeholder"
+        );
+        // The range accessor still returns both endpoints.
+        assert_eq!(reader.timestamp_range(), (min, max));
+    }
+
+    /// #1729 fail-closed: the `i64::MIN` sentinel (Cassandra's "no max recorded"
+    /// / enhanced-parser "unavailable") surfaces as `None`, and the report
+    /// renders "unavailable" rather than a bogus epoch derived from i64::MIN.
+    #[tokio::test]
+    async fn test_max_timestamp_sentinel_is_none_and_report_unavailable() {
+        let min = 1_000_000i64;
+        let reader =
+            super::StatisticsReader::from_statistics_for_test(stats_with_timestamps(min, i64::MIN))
+                .await;
+        assert_eq!(
+            reader.max_timestamp(),
+            None,
+            "the i64::MIN unavailable sentinel must surface as None (fail-closed)"
+        );
+
+        let report = reader.generate_report(false);
+        assert!(
+            report.contains("Max timestamp: unavailable"),
+            "report must render an unavailable max honestly, not a bogus epoch:\n{report}"
+        );
+        assert!(
+            !report.contains("-9223372036854775808"),
+            "report must NOT leak the raw i64::MIN sentinel:\n{report}"
         );
     }
 


### PR DESCRIPTION
Closes #1729. Prereq for #1388. enhanced_statistics_parser set max_timestamp=min_timestamp placeholder; now parse_stats_extras reads the real maxTimestamp (STATS field 4: skip minTimestamp i64, read maxTimestamp i64 — identical nb/oa/da layout) onto StatsExtras.max_timestamp: Option. Fail-closed: i64::MIN sentinel → None; new StatisticsReader::max_timestamp()->Option lets consumers (the #1388 drop gate) gate on Some. Also fixed latent bug: calculate_timestamp_range_days returned 0 days for every nb SSTable under the placeholder (same root cause, fixed fail-closed). 7 tests incl. real-nb end-to-end. Gate RESULT: PASS. roborev clean (codex, no issues).