### PR TITLE
fix(#1430): validate Flight ticket path fields — block path traversal / arbitrary Data.db disclosure (P0 security)

### DIFF
--- a/cqlite-flight/src/lib.rs
+++ b/cqlite-flight/src/lib.rs
@@ -11,6 +11,7 @@
 pub mod agg;
 pub mod filter;
 pub mod obs;
+pub mod pathsafe;
 pub mod producer;
 pub mod service;
 pub mod stats;

--- a/cqlite-flight/src/pathsafe.rs
+++ b/cqlite-flight/src/pathsafe.rs
@@ -1,0 +1,195 @@
+//! Path-safety guards for attacker-controlled Flight ticket fields (issue #1430).
+//!
+//! A Flight ticket (or a `table_stats` request) carries `keyspace`, `table`, and
+//! an optional `snapshot` name that the server resolves into filesystem paths
+//! under its `data_dir`. Without validation an attacker can supply `../` or an
+//! absolute component and escape the data directory — `Path::join` with an
+//! absolute component silently replaces the whole path — to read arbitrary
+//! `*-Data.db` files. These helpers are the shared, dependency-free guards that
+//! reject such inputs at parse time and, as defense in depth, verify a resolved
+//! path stays within the (canonicalized) data directory.
+use std::path::{Path, PathBuf};
+
+/// A rejected attacker-controlled path component.
+#[derive(Debug, thiserror::Error)]
+pub enum PathSafetyError {
+    /// A field failed charset/emptiness validation.
+    #[error("invalid {field}: {reason}")]
+    InvalidField {
+        /// Which ticket field was rejected (`keyspace`, `table`, `snapshot`, …).
+        field: &'static str,
+        /// Why it was rejected.
+        reason: &'static str,
+    },
+    /// A resolved path escaped the data directory (e.g. via a symlink).
+    #[error("resolved path for {field} escapes the data directory")]
+    Escapes {
+        /// Which ticket field produced the escaping path.
+        field: &'static str,
+    },
+}
+
+/// Validate a Cassandra unquoted identifier used as a path component.
+///
+/// Accepts a non-empty string whose every character is ASCII alphanumeric or
+/// `_` — exactly the grammar of a Cassandra unquoted identifier. This inherently
+/// rejects `.`, `/`, `\`, NUL, `-`, whitespace, and any absolute or relative
+/// path syntax, so the value can never traverse out of or replace the data
+/// directory when joined as a path component.
+pub fn validate_identifier(field: &'static str, name: &str) -> Result<(), PathSafetyError> {
+    if name.is_empty() {
+        return Err(PathSafetyError::InvalidField {
+            field,
+            reason: "must not be empty",
+        });
+    }
+    if !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+        return Err(PathSafetyError::InvalidField {
+            field,
+            reason: "only ASCII letters, digits, and '_' are allowed",
+        });
+    }
+    Ok(())
+}
+
+/// Validate a snapshot name used as a path component.
+///
+/// Like [`validate_identifier`] but also allows `-`, since Cassandra/cqlite
+/// snapshot names contain hyphens (e.g. `cqlite-abc`). Still rejects `.`, `/`,
+/// `\`, NUL, whitespace, and any absolute or relative path syntax.
+pub fn validate_snapshot(name: &str) -> Result<(), PathSafetyError> {
+    if name.is_empty() {
+        return Err(PathSafetyError::InvalidField {
+            field: "snapshot",
+            reason: "must not be empty",
+        });
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    {
+        return Err(PathSafetyError::InvalidField {
+            field: "snapshot",
+            reason: "only ASCII letters, digits, '_', and '-' are allowed",
+        });
+    }
+    Ok(())
+}
+
+/// Defense-in-depth check that `target` stays within `root` after resolving
+/// symlinks.
+///
+/// Charset validation ([`validate_identifier`]/[`validate_snapshot`]) already
+/// prevents `../` and absolute components in ticket fields; this guards the
+/// residual case where a symlink *inside* the data directory points outside it.
+///
+/// `target` need not exist yet — a legitimately-absent table directory must not
+/// error here. We canonicalize the nearest existing ancestor of `target` (the
+/// data directory itself always exists, so the walk terminates) and require it
+/// to start with the canonicalized `root`.
+pub fn assert_within(
+    field: &'static str,
+    root: &Path,
+    target: &Path,
+) -> Result<(), PathSafetyError> {
+    let canon_root = root
+        .canonicalize()
+        .map_err(|_| PathSafetyError::InvalidField {
+            field: "data_dir",
+            reason: "data directory is not accessible",
+        })?;
+
+    // Walk up from `target` to the deepest ancestor that exists on disk and can
+    // be canonicalized. `data_dir` always exists, so this cannot loop forever;
+    // if we exhaust all components the path is unrelated to the data dir.
+    let mut probe: PathBuf = target.to_path_buf();
+    let canon_target = loop {
+        match probe.canonicalize() {
+            Ok(resolved) => break resolved,
+            Err(_) => {
+                if !probe.pop() {
+                    return Err(PathSafetyError::Escapes { field });
+                }
+            }
+        }
+    };
+
+    if canon_target.starts_with(&canon_root) {
+        Ok(())
+    } else {
+        Err(PathSafetyError::Escapes { field })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identifier_accepts_cassandra_names() {
+        for ok in ["test_basic", "simple_table", "a", "A1", "x_9_Y", "items"] {
+            assert!(
+                validate_identifier("keyspace", ok).is_ok(),
+                "{ok} should pass"
+            );
+        }
+    }
+
+    #[test]
+    fn identifier_rejects_traversal_and_absolute_and_special() {
+        for bad in [
+            "", "a/b", "..", "../x", "a/../b", "/abs", "abs/", ".", "a.b", "a-b", "a b", "a\\b",
+            "a\0b", "café",
+        ] {
+            assert!(
+                validate_identifier("keyspace", bad).is_err(),
+                "{bad:?} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn snapshot_allows_hyphen_but_not_traversal() {
+        for ok in ["cqlite-abc", "snap1", "2026-06-30", "a_b-c"] {
+            assert!(validate_snapshot(ok).is_ok(), "{ok} should pass");
+        }
+        for bad in ["", "..", "../x", "a/b", "/abs", ".", "a.b", "a b", "a\0b"] {
+            assert!(validate_snapshot(bad).is_err(), "{bad:?} must be rejected");
+        }
+    }
+
+    #[test]
+    fn within_allows_nonexistent_leaf_under_root() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = tmp.path();
+        // Non-existent table dir under a real root must be allowed (resolved
+        // to its nearest existing ancestor = root itself).
+        let target = root.join("realks").join("tbl");
+        assert!(assert_within("keyspace", root, &target).is_ok());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn within_rejects_symlink_escape() {
+        use std::os::unix::fs::symlink;
+        let root_tmp = tempfile::TempDir::new().unwrap();
+        let outside_tmp = tempfile::TempDir::new().unwrap();
+        let root = root_tmp.path();
+        // root/evil -> <outside dir>
+        symlink(outside_tmp.path(), root.join("evil")).unwrap();
+        // A file under the outside dir, reachable via the symlink.
+        std::fs::write(outside_tmp.path().join("secret"), b"x").unwrap();
+
+        let escaping = root.join("evil").join("secret");
+        let err = assert_within("keyspace", root, &escaping)
+            .expect_err("symlink escape must be rejected");
+        assert!(matches!(
+            err,
+            PathSafetyError::Escapes { field: "keyspace" }
+        ));
+
+        // A legitimate (non-existent) leaf under the real root still passes.
+        let ok = root.join("realks").join("tbl");
+        assert!(assert_within("keyspace", root, &ok).is_ok());
+    }
+}

--- a/cqlite-flight/src/producer.rs
+++ b/cqlite-flight/src/producer.rs
@@ -62,6 +62,14 @@ pub enum ProducerError {
     /// The aggregation spec was invalid (bad column, Sum on non-numeric, …).
     #[error("invalid aggregation: {0}")]
     Aggregation(#[from] AggError),
+    /// The resolved SSTable directory escaped the data directory — e.g. via a
+    /// symlink inside the data dir (issue #1430). Charset validation already
+    /// blocks `../`/absolute fields; this is the canonicalization backstop.
+    #[error("unsafe path for {field}: escapes the data directory")]
+    UnsafePath {
+        /// Which ticket field produced the escaping path (`table`/`snapshot`).
+        field: &'static str,
+    },
 }
 
 /// Source of the SSTable `Data.db` files to merge for one table.
@@ -103,13 +111,30 @@ impl DirSource {
     /// `<table-dir>/snapshots/<name>/` hardlink set (Phase 3). When nothing
     /// matches, the exact (non-existent) path is returned so `data_paths`
     /// surfaces a clean `NotFound`.
-    pub fn resolve(data_dir: &Path, keyspace: &str, table: &str, snapshot: Option<&str>) -> Self {
+    ///
+    /// As defense in depth (issue #1430) the resolved directory is verified to
+    /// stay within `data_dir` after resolving symlinks; an escape yields
+    /// [`ProducerError::UnsafePath`]. Callers should still validate the ticket
+    /// fields with [`crate::pathsafe`] at parse time — that is the primary guard.
+    pub fn resolve(
+        data_dir: &Path,
+        keyspace: &str,
+        table: &str,
+        snapshot: Option<&str>,
+    ) -> Result<Self, ProducerError> {
         let table_dir = Self::table_base_dir(data_dir, keyspace, table);
         let dir = match snapshot {
             Some(name) if !name.is_empty() => table_dir.join("snapshots").join(name),
             _ => table_dir,
         };
-        Self::new(dir)
+        let field = if matches!(snapshot, Some(name) if !name.is_empty()) {
+            "snapshot"
+        } else {
+            "table"
+        };
+        crate::pathsafe::assert_within(field, data_dir, &dir)
+            .map_err(|_| ProducerError::UnsafePath { field })?;
+        Ok(Self::new(dir))
     }
 
     /// Resolve the on-disk directory for a table (live data dir, no snapshot).
@@ -151,6 +176,26 @@ impl SstableSource for DirSource {
                     .and_then(|n| n.to_str())
                     .is_some_and(|n| n.ends_with("-Data.db"))
             })
+            // Per-file containment (issue #1430): legit SSTable components live
+            // DIRECTLY in the resolved dir (Cassandra snapshots are hardlinks,
+            // which canonicalize under the dir). The directory-level guard in
+            // `resolve` only vets the enumeration dir; a SYMLINK inside an
+            // otherwise-valid dir can still resolve outside `data_dir`. Exclude
+            // (fail-closed) any entry whose canonicalized target escapes the dir
+            // so it is never opened/merged.
+            .filter(
+                |p| match crate::pathsafe::assert_within("sstable", &self.dir, p) {
+                    Ok(()) => true,
+                    Err(reason) => {
+                        tracing::debug!(
+                            path = %p.display(),
+                            %reason,
+                            "excluding SSTable whose resolved path escapes the data directory"
+                        );
+                        false
+                    }
+                },
+            )
             .collect();
         // Newest generation first. The merger reconciles by per-row timestamp;
         // generation order only breaks exact-timestamp ties, but a deterministic
@@ -1164,14 +1209,14 @@ mod tests {
     fn resolve_builds_snapshot_path() {
         let tmp = tempfile::TempDir::new().unwrap();
         std::fs::create_dir_all(tmp.path().join("ks").join("tbl")).unwrap();
-        let src = DirSource::resolve(tmp.path(), "ks", "tbl", Some("snap1"));
+        let src = DirSource::resolve(tmp.path(), "ks", "tbl", Some("snap1")).expect("resolve");
         assert!(
             src.dir.ends_with("ks/tbl/snapshots/snap1"),
             "got {:?}",
             src.dir
         );
         // Empty/None snapshot resolves to the live table dir.
-        let live = DirSource::resolve(tmp.path(), "ks", "tbl", None);
+        let live = DirSource::resolve(tmp.path(), "ks", "tbl", None).expect("resolve");
         assert!(live.dir.ends_with("ks/tbl"));
     }
 
@@ -1185,13 +1230,57 @@ mod tests {
         make_snapshot(&table_dir, "snap1");
 
         let producer = MergeProducer::new(schema, 1024).unwrap();
-        let src = DirSource::resolve(&data_dir, KS, TBL, Some("snap1"));
+        let src = DirSource::resolve(&data_dir, KS, TBL, Some("snap1")).expect("resolve");
         let batches = producer.produce(&src).unwrap();
         assert_eq!(
             total_rows(&batches),
             3,
             "reads the frozen snapshot SSTables"
         );
+    }
+
+    /// Issue #1430 (roborev per-file follow-up): `data_paths` enumerates files
+    /// DIRECTLY in the resolved dir, but a SYMLINK inside an otherwise-valid dir
+    /// can resolve OUTSIDE `data_dir`. Such an entry must be excluded (fail-closed)
+    /// and never returned for merging. A hardlink-style legit component (a real
+    /// file in the dir, which canonicalizes under the dir) must still be served.
+    #[test]
+    #[cfg(unix)]
+    fn data_paths_excludes_symlink_escaping_the_dir() {
+        use std::os::unix::fs::symlink;
+        let dir_tmp = tempfile::TempDir::new().unwrap();
+        let outside_tmp = tempfile::TempDir::new().unwrap();
+        let dir = dir_tmp.path();
+
+        // A legit Data.db living directly in the table dir.
+        let legit = dir.join("nb-1-big-Data.db");
+        std::fs::write(&legit, b"legit").unwrap();
+
+        // A secret file OUTSIDE the tree, reachable only via a symlink placed
+        // inside the (valid) table dir with a legit-looking Data.db name.
+        let secret = outside_tmp.path().join("secret-Data.db");
+        std::fs::write(&secret, b"secret").unwrap();
+        let escaping = dir.join("nb-99-big-Data.db");
+        symlink(&secret, &escaping).unwrap();
+
+        let paths = DirSource::new(dir).data_paths().unwrap();
+
+        // Only the legit component survives; the escaping symlink is excluded.
+        let canon_legit = legit.canonicalize().unwrap();
+        let canon_secret = secret.canonicalize().unwrap();
+        let canon_paths: Vec<PathBuf> = paths
+            .iter()
+            .map(|p| p.canonicalize().unwrap_or_else(|_| p.clone()))
+            .collect();
+        assert!(
+            canon_paths.contains(&canon_legit),
+            "legit component must be served, got {paths:?}"
+        );
+        assert!(
+            !canon_paths.contains(&canon_secret),
+            "symlink escaping the data dir must NOT be returned, got {paths:?}"
+        );
+        assert_eq!(paths.len(), 1, "only the legit component survives");
     }
 
     #[test]

--- a/cqlite-flight/src/service.rs
+++ b/cqlite-flight/src/service.rs
@@ -65,6 +65,9 @@ impl From<ProducerError> for Status {
             {
                 Status::not_found(msg)
             }
+            // A canonicalization escape (issue #1430) is treated as a missing
+            // resource so the server never confirms a path outside the data dir.
+            ProducerError::UnsafePath { .. } => Status::not_found(msg),
             ProducerError::Discovery { .. }
             | ProducerError::Merge(_)
             | ProducerError::Convert(_)
@@ -374,7 +377,7 @@ impl CqliteFlightService {
             &ticket.keyspace,
             &ticket.table,
             ticket.snapshot.as_deref(),
-        );
+        )?;
 
         // The merge drains SSTables into memory and is CPU-bound — run it off the
         // async runtime so it cannot stall the gRPC reactor. A missing table
@@ -427,12 +430,22 @@ impl CqliteFlightService {
 
         let req = TableStatsRequest::from_bytes(&action.body)
             .map_err(|e| Status::invalid_argument(format!("invalid table_stats request: {e}")))?;
+        // Validate the path-bearing fields (issue #1430): a `table_stats` body is
+        // the same class of attacker-controlled input as a Flight ticket.
+        crate::pathsafe::validate_identifier("keyspace", &req.keyspace)
+            .map_err(|e| Status::invalid_argument(e.to_string()))?;
+        crate::pathsafe::validate_identifier("table", &req.table)
+            .map_err(|e| Status::invalid_argument(e.to_string()))?;
+        if let Some(snapshot) = &req.snapshot {
+            crate::pathsafe::validate_snapshot(snapshot)
+                .map_err(|e| Status::invalid_argument(e.to_string()))?;
+        }
         let dir = DirSource::resolve(
             &self.data_dir,
             &req.keyspace,
             &req.table,
             req.snapshot.as_deref(),
-        )
+        )?
         .into_dir();
 
         // `gather_table_stats` is synchronous blocking fs I/O (read_dir + read of
@@ -589,6 +602,65 @@ mod tests {
             Err(e) => e,
         };
         assert_eq!(err.code(), tonic::Code::NotFound, "got: {err:?}");
+    }
+
+    // ---- Issue #1430: end-to-end path-traversal rejection (wiring evidence) ----
+
+    #[test]
+    fn do_get_rejects_absolute_snapshot_traversal() {
+        // A legit data dir that a valid `do_get` would serve from.
+        let schema = simple_schema();
+        let (_temp, data_dir, _dir) =
+            build_sstables(&schema, vec![vec![write_row(1, "x", 1, 100)]]);
+
+        // A "secret" directory OUTSIDE data_dir holding a Data.db an attacker
+        // wants to disclose.
+        let secret = tempfile::TempDir::new().unwrap();
+        std::fs::write(secret.path().join("nb-1-big-Data.db"), b"top secret").unwrap();
+
+        let svc = CqliteFlightService::new(data_dir, 1024);
+        let rt = tokio::runtime::Runtime::new().unwrap();
+
+        // snapshot = absolute path to the secret dir. Without the guard,
+        // `Path::join` with an absolute component would escape data_dir entirely.
+        let mut t = ticket(KS, TBL);
+        t.snapshot = Some(secret.path().to_string_lossy().into_owned());
+
+        let result = rt.block_on(async {
+            let bytes = t.to_bytes().unwrap();
+            svc.do_get(Request::new(Ticket::new(bytes))).await
+        });
+        let err = match result {
+            Ok(_) => panic!("path-traversal ticket must be rejected, not served"),
+            Err(e) => e,
+        };
+        // Parse-time charset validation rejects the absolute snapshot path.
+        assert_eq!(
+            err.code(),
+            tonic::Code::InvalidArgument,
+            "absolute snapshot must be rejected as invalid argument, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn do_get_rejects_parent_traversal_keyspace() {
+        let schema = simple_schema();
+        let (_temp, data_dir, _dir) =
+            build_sstables(&schema, vec![vec![write_row(1, "x", 1, 100)]]);
+        let svc = CqliteFlightService::new(data_dir, 1024);
+        let rt = tokio::runtime::Runtime::new().unwrap();
+
+        // keyspace with `../` must be rejected before any filesystem access.
+        let t = ticket("../secret", TBL);
+        let result = rt.block_on(async {
+            let bytes = t.to_bytes().unwrap();
+            svc.do_get(Request::new(Ticket::new(bytes))).await
+        });
+        let err = match result {
+            Ok(_) => panic!("`../` keyspace must be rejected"),
+            Err(e) => e,
+        };
+        assert_eq!(err.code(), tonic::Code::InvalidArgument, "got: {err:?}");
     }
 
     #[test]

--- a/cqlite-flight/src/stats.rs
+++ b/cqlite-flight/src/stats.rs
@@ -225,6 +225,20 @@ pub fn gather_table_stats(dir: &Path) -> Result<TableStatsResponse, StatsError> 
     let data_paths = collect_data_paths(entries, &mut response);
 
     for data_path in data_paths {
+        // Per-file containment (issue #1430): the enumerated Data.db must resolve
+        // to a target INSIDE `dir`. A symlinked Data.db inside an otherwise-valid
+        // dir can point outside `data_dir`; treat an escaping entry exactly like a
+        // missing/undecodable Statistics.db (taint completeness) and never read it.
+        if let Err(reason) = crate::pathsafe::assert_within("sstable", dir, &data_path) {
+            response.complete = false;
+            response.skipped_sstables = response.skipped_sstables.saturating_add(1);
+            tracing::debug!(
+                path = %data_path.display(),
+                %reason,
+                "table_stats: Data.db resolves outside the data directory (marking incomplete)"
+            );
+            continue;
+        }
         // Derive the sibling Statistics.db (same generation prefix). The lookup
         // itself can fail (no recognisable Data.db suffix) — that taints too.
         let stats_path = match sibling_statistics_path(&data_path) {
@@ -239,6 +253,19 @@ pub fn gather_table_stats(dir: &Path) -> Result<TableStatsResponse, StatsError> 
                 continue;
             }
         };
+        // The derived Statistics.db must ALSO resolve inside `dir` (a symlinked
+        // sibling can escape even when the Data.db does not). Fail-closed the same
+        // way and never read a file whose resolved target leaves the directory.
+        if let Err(reason) = crate::pathsafe::assert_within("sstable", dir, &stats_path) {
+            response.complete = false;
+            response.skipped_sstables = response.skipped_sstables.saturating_add(1);
+            tracing::debug!(
+                path = %stats_path.display(),
+                %reason,
+                "table_stats: Statistics.db resolves outside the data directory (marking incomplete)"
+            );
+            continue;
+        }
         match read_one_sstable_counts(&stats_path) {
             Ok(counts) => fold_counts(&mut response, &stats_path, counts),
             Err(e) => {
@@ -467,7 +494,9 @@ mod tests {
             ],
         );
         // Resolve the SSTable dir exactly as the service does, then gather.
-        let dir = DirSource::resolve(&data_dir, KS, TBL, None).into_dir();
+        let dir = DirSource::resolve(&data_dir, KS, TBL, None)
+            .expect("resolve")
+            .into_dir();
 
         let stats = gather_table_stats(&dir).expect("gather");
 
@@ -558,7 +587,9 @@ mod tests {
             &schema,
             vec![vec![write_row(1, "a", 1, 100), write_row(2, "b", 2, 100)]],
         );
-        let dir = DirSource::resolve(&data_dir, KS, TBL, None).into_dir();
+        let dir = DirSource::resolve(&data_dir, KS, TBL, None)
+            .expect("resolve")
+            .into_dir();
 
         let stats = gather_table_stats(&dir).expect("gather");
 
@@ -770,6 +801,115 @@ mod tests {
         assert_eq!(stats.live_rows, 2000, "sensor_data has 2000 rows (wide)");
         assert!(stats.complete, "real fixture decoded fully → complete");
         assert_eq!(stats.skipped_sstables, 0);
+    }
+
+    /// Build one real, fully-decodable SSTable and return `(temp, dir, data, stats)`
+    /// where `data`/`stats` are its `*-Data.db`/`*-Statistics.db` paths. Used by the
+    /// #1430 symlink-escape tests so the OUTSIDE target is a VALID statistics file
+    /// that WOULD contribute counts if it were (wrongly) read — the fail-before /
+    /// pass-after signal. `temp` keeps the backing dir alive.
+    #[cfg(unix)]
+    fn build_one_valid_sstable() -> (tempfile::TempDir, std::path::PathBuf, std::path::PathBuf) {
+        let schema = simple_schema();
+        let (temp, data_dir, _table) =
+            build_sstables(&schema, vec![vec![write_row(1, "a", 1, 100)]]);
+        let dir = DirSource::resolve(&data_dir, KS, TBL, None)
+            .expect("resolve")
+            .into_dir();
+        let data = std::fs::read_dir(&dir)
+            .unwrap()
+            .flatten()
+            .map(|e| e.path())
+            .find(|p| {
+                p.file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.ends_with("-Data.db"))
+            })
+            .expect("a Data.db was produced");
+        let stats = sibling_statistics_path(&data).expect("sibling stats path");
+        assert!(stats.exists(), "the SSTable produced a Statistics.db");
+        (temp, data, stats)
+    }
+
+    /// Issue #1430 (roborev per-file follow-up): a SYMLINKED `*-Statistics.db`
+    /// inside an otherwise-valid dir can resolve OUTSIDE the data directory. The
+    /// SSTable must be SKIPPED (taint completeness) and its outside target must NOT
+    /// be read/contribute counts. The outside file is a REAL decodable Statistics.db
+    /// so that, before the fix, it WOULD be read and contribute — proving the guard.
+    #[test]
+    #[cfg(unix)]
+    fn gather_skips_sstable_with_statistics_escaping_the_dir() {
+        use std::os::unix::fs::symlink;
+        // A valid SSTable whose Statistics.db we relocate outside the served dir.
+        let (_src_temp, _src_data, valid_stats) = build_one_valid_sstable();
+
+        let dir_tmp = tempfile::TempDir::new().unwrap();
+        let outside_tmp = tempfile::TempDir::new().unwrap();
+        let dir = dir_tmp.path();
+
+        // A real Data.db enumerates the SSTable...
+        std::fs::write(dir.join("nb-1-big-Data.db"), b"data").unwrap();
+        // ...but its sibling Statistics.db is a SYMLINK to a VALID, decodable stats
+        // file OUTSIDE the tree. Before the fix this decodes and contributes counts;
+        // the guard must skip it unread.
+        let outside_stats = outside_tmp.path().join("secret-Statistics.db");
+        std::fs::copy(&valid_stats, &outside_stats).unwrap();
+        symlink(&outside_stats, dir.join("nb-1-big-Statistics.db")).unwrap();
+
+        let stats = gather_table_stats(dir).expect("gather");
+
+        assert!(
+            !stats.complete,
+            "an SSTable whose Statistics.db escapes the dir must mark the response incomplete"
+        );
+        assert_eq!(
+            stats.skipped_sstables, 1,
+            "the escaping SSTable is counted as skipped"
+        );
+        assert_eq!(
+            stats.sstable_count, 0,
+            "the escaping SSTable did not contribute (was not read)"
+        );
+        assert_eq!(
+            stats.live_rows, 0,
+            "the outside stats file's counts must not leak in"
+        );
+    }
+
+    /// Companion: a SYMLINKED `*-Data.db` that itself resolves outside the dir is
+    /// skipped at enumeration time and its (valid, in-dir) sibling is never read.
+    /// The in-dir sibling is a REAL decodable stats file, so before the fix the
+    /// SSTable would be enumerated and its sibling would contribute counts.
+    #[test]
+    #[cfg(unix)]
+    fn gather_skips_sstable_with_data_db_escaping_the_dir() {
+        use std::os::unix::fs::symlink;
+        let (_src_temp, _src_data, valid_stats) = build_one_valid_sstable();
+
+        let dir_tmp = tempfile::TempDir::new().unwrap();
+        let outside_tmp = tempfile::TempDir::new().unwrap();
+        let dir = dir_tmp.path();
+
+        // A Data.db that is a symlink to a file OUTSIDE the tree.
+        let outside_data = outside_tmp.path().join("secret-Data.db");
+        std::fs::write(&outside_data, b"data").unwrap();
+        symlink(&outside_data, dir.join("nb-1-big-Data.db")).unwrap();
+        // A VALID in-dir sibling Statistics.db that must NOT rescue the escaping
+        // Data.db: the SSTable is skipped before the sibling is ever considered.
+        std::fs::copy(&valid_stats, dir.join("nb-1-big-Statistics.db")).unwrap();
+
+        let stats = gather_table_stats(dir).expect("gather");
+
+        assert!(
+            !stats.complete,
+            "an SSTable whose Data.db escapes the dir must mark the response incomplete"
+        );
+        assert_eq!(stats.skipped_sstables, 1, "the escaping SSTable is skipped");
+        assert_eq!(
+            stats.sstable_count, 0,
+            "it did not contribute (the valid sibling was never read)"
+        );
+        assert_eq!(stats.live_rows, 0);
     }
 
     #[test]

--- a/cqlite-flight/src/ticket.rs
+++ b/cqlite-flight/src/ticket.rs
@@ -19,6 +19,10 @@ pub enum TicketError {
     /// The ticket bytes were not valid UTF-8 JSON or did not match the schema.
     #[error("invalid flight ticket: {0}")]
     Decode(#[from] serde_json::Error),
+    /// A path-bearing field (`keyspace`/`table`/`snapshot`) failed path-safety
+    /// validation (issue #1430) — e.g. `../` traversal or an absolute component.
+    #[error("invalid flight ticket field: {0}")]
+    InvalidField(#[from] crate::pathsafe::PathSafetyError),
 }
 
 /// Current ticket wire-format version. Bump when the JSON contract changes in a
@@ -281,8 +285,30 @@ impl Default for FlightTicket {
 
 impl FlightTicket {
     /// Parse a ticket from its on-the-wire JSON bytes.
+    ///
+    /// Rejects tickets whose path-bearing fields (`keyspace`/`table`/`snapshot`)
+    /// would traverse out of or replace the server's data directory (issue #1430)
+    /// — this is the PRIMARY guard against path-traversal / arbitrary-file
+    /// disclosure.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, TicketError> {
-        Ok(serde_json::from_slice(bytes)?)
+        let ticket: Self = serde_json::from_slice(bytes)?;
+        ticket.validate()?;
+        Ok(ticket)
+    }
+
+    /// Validate the path-bearing fields against the path-safety grammar.
+    ///
+    /// `keyspace`/`table` must be Cassandra unquoted identifiers
+    /// (`[A-Za-z0-9_]+`); `snapshot`, when present, additionally allows `-`. This
+    /// inherently rejects `.`, `/`, `\`, NUL, and absolute paths, so no field can
+    /// escape the data directory when joined as a path component.
+    pub fn validate(&self) -> Result<(), TicketError> {
+        crate::pathsafe::validate_identifier("keyspace", &self.keyspace)?;
+        crate::pathsafe::validate_identifier("table", &self.table)?;
+        if let Some(snapshot) = &self.snapshot {
+            crate::pathsafe::validate_snapshot(snapshot)?;
+        }
+        Ok(())
     }
 
     /// Serialize this ticket to its on-the-wire JSON bytes.
@@ -436,6 +462,44 @@ mod tests {
         // Missing required field `ddl`.
         let missing = json!({"keyspace": "k", "table": "t"}).to_string();
         assert!(FlightTicket::from_bytes(missing.as_bytes()).is_err());
+    }
+
+    // ---- Issue #1430: path-traversal / absolute-path field rejection ----
+
+    #[test]
+    fn rejects_path_traversal_and_absolute_fields() {
+        // Each malicious ticket must be rejected at parse time.
+        let cases: Vec<serde_json::Value> = vec![
+            json!({"keyspace": "a/../b", "table": "t", "ddl": "d"}),
+            json!({"keyspace": "", "table": "t", "ddl": "d"}),
+            json!({"keyspace": "/abs", "table": "t", "ddl": "d"}),
+            json!({"keyspace": "k", "table": "../x", "ddl": "d"}),
+            json!({"keyspace": "k", "table": "t", "ddl": "d", "snapshot": "../y"}),
+            json!({"keyspace": "k", "table": "t", "ddl": "d", "snapshot": "/etc/passwd"}),
+            json!({"keyspace": "k\u{0000}b", "table": "t", "ddl": "d"}),
+            json!({"keyspace": "a.b", "table": "t", "ddl": "d"}),
+        ];
+        for c in cases {
+            let raw = c.to_string();
+            assert!(
+                FlightTicket::from_bytes(raw.as_bytes()).is_err(),
+                "malicious ticket must be rejected: {raw}"
+            );
+        }
+
+        // A fully-valid ticket (identifier keyspace/table + hyphenated snapshot)
+        // must still parse successfully.
+        let ok = json!({
+            "keyspace": "test_basic",
+            "table": "simple_table",
+            "ddl": "CREATE TABLE test_basic.simple_table (id uuid PRIMARY KEY, name text)",
+            "snapshot": "cqlite-abc"
+        })
+        .to_string();
+        assert!(
+            FlightTicket::from_bytes(ok.as_bytes()).is_ok(),
+            "valid ticket must still parse"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #1430. Oracle-driven P0 security fix (no OpenSpec). Honors manager order `<!-- MGR:mbp-0702 -->` (GO).

## Vulnerability
The Arrow Flight connector (`cqlite-flight`) resolved attacker-controlled ticket fields (`keyspace`/`table`/`snapshot`) directly into filesystem paths with **zero validation** — allowing path traversal / arbitrary local `*-Data.db` disclosure. `Path::join` with an **absolute** component replaces the whole path (`snapshot="/etc/..."` escapes entirely); `../` traverses out. Both `do_get` and `do_action` (table_stats) were affected.

## Fix (fail-closed, defense in depth)
- **New `cqlite-flight/src/pathsafe.rs`**: `validate_identifier` (`[A-Za-z0-9_]+`), `validate_snapshot` (`[A-Za-z0-9_-]+`), and `assert_within` (canonicalize nearest existing ancestor, reject symlink escapes out of the containment root).
- **Parse-time validation (primary guard)**: `FlightTicket::from_bytes` now validates `keyspace`/`table`/`snapshot` → `Status::invalid_argument`. `table_stats` (`do_action`) validates the same fields.
- **Directory canonicalization (backstop)**: `DirSource::resolve` is now fallible and asserts the resolved dir stays under `data_dir` → `ProducerError::UnsafePath` → `Status::not_found`.
- **Per-file containment (roborev follow-up)**: `data_paths()` and `gather_table_stats()` canonicalize each discovered `*-Data.db` / `*-Statistics.db` and exclude/skip any symlink resolving outside the enumeration dir (never opened). Legit Cassandra snapshots (hardlinks) stay under the dir and are unaffected.

## Tests (TDD — fail on pre-fix code, pass after)
- `ticket`: parse-time rejection of `../`/absolute/NUL/`.`-containing fields.
- `pathsafe`: identifier/snapshot charset + `assert_within` symlink-escape (`#[cfg(unix)]`).
- `service` (wiring evidence, e2e): `do_get` with an absolute `snapshot` and a `../` `keyspace` pointed at a `*-Data.db` **outside** `data_dir` returns `InvalidArgument` — no outside file opened. (Pre-fix: the absolute-snapshot case was *served*, confirming the disclosure vuln.)
- `producer`/`stats`: symlinked `*-Data.db`/`*-Statistics.db` inside a valid dir is excluded/skipped and never read.

## Validation
- `scripts/agent-gate.sh` → **RESULT: PASS** (all components) on `1250d24a`.
- roborev (codex, `--base origin/main`): symlink-containment finding fixed; a second finding (strict `[A-Za-z0-9_]+` allowlist could reject exotic *quoted* table names) was **refuted + closed** — see below.

## Intentional limitation (owner visibility)
The `[A-Za-z0-9_]+` identifier charset is exactly what issue #1430 prescribes. Consequence: a table whose name is a *quoted* Cassandra identifier containing characters outside the word class (e.g. `"My-Table"`) would be rejected. This is intentional for a P0 security guard (allowlist > denylist), Cassandra already constrains **keyspace** names to `[a-zA-Z_0-9]` even when quoted, and no table in the corpus uses special chars. Broadening to support quoted-special-char table names is a separate feature decision (would also collide with the on-disk `<table>-<uuid>` separator) — out of scope here.

## Notes
- No `unwrap`/`expect` in library code; passes `RUSTFLAGS="-D warnings"`.
- Grows four already-large `cqlite-flight` files (`producer`/`service`/`stats`/`ticket`.rs); splitting them is out of scope for this P0 hotfix (see #1116/#1135) → gate run with `CQLITE_ALLOW_FILE_GROWTH=1`.