### PR TITLE
fix(#1728): stamp NO_DELETION_TIME on live cells so max_local_deletion_time is authoritative

### DIFF
--- a/cqlite-core/src/storage/sstable/writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/mod.rs
@@ -713,6 +713,7 @@ impl SSTableWriter {
                         timestamp_micros,
                         ttl_seconds,
                         local_deletion_time,
+                        is_deleted,
                         ..
                     } => {
                         self.stats.update_timestamp(*timestamp_micros);
@@ -721,6 +722,16 @@ impl SSTableWriter {
                         }
                         if let Some(ldt) = local_deletion_time {
                             self.stats.update_local_deletion_time(*ldt);
+                        }
+                        // Issue #1728 (roborev finding 2): a LIVE complex element
+                        // (not deleted, not expiring, no explicit LDT) carries
+                        // Cassandra's `NO_DELETION_TIME` sentinel just like a simple
+                        // live `Write`, so it must lift `maxLocalDeletionTime` to the
+                        // sentinel in a mixed SSTable. Authoritative liveness comes
+                        // from the verbatim `is_deleted` flag (never re-derived from
+                        // `value`, per the no-heuristics mandate / roborev #885).
+                        if !*is_deleted && ttl_seconds.is_none() && local_deletion_time.is_none() {
+                            self.stats.note_live_local_deletion_time();
                         }
                     }
                     // Issue #1728: a live, non-TTL `Write` cell carries Cassandra's
@@ -732,8 +743,23 @@ impl SSTableWriter {
                     // tombstones with a smaller real LDT. The dedicated chokepoint
                     // raises the max ALONE (never poisoning minLocalDeletionTime or
                     // the tombstone drop-time histogram, issue #851).
-                    crate::storage::write_engine::mutation::CellOperation::Write { .. } => {
-                        self.stats.note_live_local_deletion_time();
+                    //
+                    // Two cases must NOT fold the live sentinel (roborev #1728):
+                    //   * `mutation.ttl_seconds.is_some()` — a plain `Write` under a
+                    //     row-level TTL is emitted as an EXPIRING cell with a real
+                    //     `now + ttl` LDT (data_writer::rows), which the mutation-TTL
+                    //     block above (`if let Some(ttl) = mutation.ttl_seconds`)
+                    //     already folded; overwriting max with the sentinel would
+                    //     clobber that real expiring LDT.
+                    //   * `value == Null` — a null `Write` is skipped by
+                    //     `write_merged_cells` (no cell is emitted), so it confers no
+                    //     LDT at all.
+                    crate::storage::write_engine::mutation::CellOperation::Write { value, .. } => {
+                        if mutation.ttl_seconds.is_none()
+                            && !matches!(value, crate::types::Value::Null)
+                        {
+                            self.stats.note_live_local_deletion_time();
+                        }
                     }
                 }
             }
@@ -1875,6 +1901,64 @@ mod tests {
         let _info = writer.finish().await.unwrap();
     }
 
+    /// Issue #1728 (roborev finding 2): a LIVE complex element (`is_deleted:
+    /// false`, `ttl_seconds: None`, `local_deletion_time: None`) carries the
+    /// `NO_DELETION_TIME` sentinel just like a simple live `Write`. In a MIXED
+    /// row (a `ComplexDeletion` marker at a real LDT plus a live element) the
+    /// finalized `max_local_deletion_time` must be the live sentinel (`i32::MAX`),
+    /// while `min_local_deletion_time` stays at the real marker LDT (issue #851).
+    #[tokio::test]
+    async fn test_live_complex_element_plus_marker_max_ldt_is_live_sentinel() {
+        let temp_dir = TempDir::new().unwrap();
+        let schema = create_complex_schema();
+        let mut writer = SSTableWriter::new(temp_dir.path().to_path_buf(), 1, &schema).unwrap();
+
+        const MARKER_LDT: i32 = 1_500;
+        let table_id = TableId::new("test_ks", "test_complex");
+        let pk = PartitionKey::single("id", Value::Integer(3));
+        let ck = ClusteringKey::single("ck", Value::Integer(1));
+        let mutation = Mutation::new(
+            table_id,
+            pk,
+            Some(ck),
+            vec![
+                // Older complex-deletion marker at a real LDT.
+                CellOperation::ComplexDeletion {
+                    column: "tags".to_string(),
+                    marked_for_delete_at: 1_000_000,
+                    local_deletion_time: MARKER_LDT,
+                },
+                // A LIVE element (not deleted, not expiring, no explicit LDT).
+                CellOperation::WriteComplexElement {
+                    column: "tags".to_string(),
+                    cell_path: b"live".to_vec(),
+                    value: None,
+                    timestamp_micros: 5_000_000,
+                    ttl_seconds: None,
+                    local_deletion_time: None,
+                    is_deleted: false,
+                },
+            ],
+            5_000_000,
+            None,
+        );
+        let key = mutation.decorated_key(&schema).unwrap();
+        writer.write_partition(key, vec![mutation]).unwrap();
+
+        assert_eq!(
+            writer.stats.max_local_deletion_time,
+            i32::MAX,
+            "a live complex element must lift max_local_deletion_time to the \
+             NO_DELETION_TIME sentinel even alongside an older ComplexDeletion marker"
+        );
+        assert_eq!(
+            writer.stats.min_local_deletion_time, MARKER_LDT,
+            "the live sentinel must not poison min_local_deletion_time (issue #851)"
+        );
+
+        let _info = writer.finish().await.unwrap();
+    }
+
     /// Issue #887: the PRE-SEEDED baseline path (`compute_mutations_baseline_stats`,
     /// issue #729 two-pass flush) must fold the same marker/element timestamps the
     /// DataWriter delta-encodes. A marker LDT or element ts/ttl BELOW the mutation's
@@ -2140,6 +2224,50 @@ mod tests {
             writer.stats.tombstone_histogram.size(),
             1,
             "only the real tombstone enters the drop-time histogram, not the live cell"
+        );
+
+        let _info = writer.finish().await.unwrap();
+    }
+
+    /// Issue #1728 (roborev finding 1): a plain `Write` under a ROW-LEVEL TTL is
+    /// emitted as an EXPIRING cell with a real `now + ttl` local-deletion-time,
+    /// NOT a live cell. The mutation-TTL block folds that real expiring LDT into
+    /// `max_local_deletion_time`; the live-cell fold must NOT run and clobber it
+    /// with the `i32::MAX` sentinel. With ONLY a TTL'd write (no live non-TTL cell,
+    /// no tombstone), the finalized max must equal the real expiring LDT, which is
+    /// strictly below the sentinel.
+    #[tokio::test]
+    async fn test_ttl_row_write_does_not_fold_live_sentinel() {
+        let temp_dir = TempDir::new().unwrap();
+        let schema = create_two_regular_schema();
+        let mut writer = SSTableWriter::new(temp_dir.path().to_path_buf(), 1, &schema).unwrap();
+
+        let table_id = TableId::new("test_ks", "test_two_regular");
+        let pk = PartitionKey::single("id", Value::Integer(7));
+        // Row-level TTL: the plain `Write` becomes an expiring cell.
+        let mutation = Mutation::new(
+            table_id,
+            pk,
+            None,
+            vec![CellOperation::Write {
+                column: "age".to_string(),
+                value: Value::Integer(42),
+            }],
+            5_000_000,
+            Some(3600),
+        );
+        let key = mutation.decorated_key(&schema).unwrap();
+        writer.write_partition(key, vec![mutation]).unwrap();
+
+        assert!(
+            writer.stats.max_local_deletion_time < i32::MAX,
+            "a row-TTL Write is an expiring cell: its real LDT must NOT be clobbered \
+             by the live NO_DELETION_TIME sentinel (got {})",
+            writer.stats.max_local_deletion_time
+        );
+        assert!(
+            writer.stats.max_local_deletion_time > 0,
+            "the expiring cell's real (now+ttl) LDT must be recorded"
         );
 
         let _info = writer.finish().await.unwrap();

--- a/cqlite-core/src/storage/sstable/writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/mod.rs
@@ -723,7 +723,18 @@ impl SSTableWriter {
                             self.stats.update_local_deletion_time(*ldt);
                         }
                     }
-                    crate::storage::write_engine::mutation::CellOperation::Write { .. } => {}
+                    // Issue #1728: a live, non-TTL `Write` cell carries Cassandra's
+                    // `Cell.NO_DELETION_TIME` (`Integer.MAX_VALUE`) as its
+                    // localDeletionTime. Cassandra's MetadataCollector folds that
+                    // sentinel into `maxLocalDeletionTime`, so any SSTable holding a
+                    // live non-TTL cell finalizes `maxLocalDeletionTime` == the live
+                    // sentinel — including a MIXED SSTable that also carries older
+                    // tombstones with a smaller real LDT. The dedicated chokepoint
+                    // raises the max ALONE (never poisoning minLocalDeletionTime or
+                    // the tombstone drop-time histogram, issue #851).
+                    crate::storage::write_engine::mutation::CellOperation::Write { .. } => {
+                        self.stats.note_live_local_deletion_time();
+                    }
                 }
             }
             // Track stats for partition tombstones
@@ -2064,6 +2075,71 @@ mod tests {
         assert_eq!(
             writer.stats.max_local_deletion_time, HIGHER_LDT,
             "max_local_deletion_time must reflect the higher per-cell Delete LDT"
+        );
+
+        let _info = writer.finish().await.unwrap();
+    }
+
+    /// Issue #1728: a MIXED SSTable (an older cell tombstone at a real, smaller
+    /// local-deletion-time PLUS a live non-TTL `Write` cell) must finalize
+    /// `max_local_deletion_time` at Cassandra's live `NO_DELETION_TIME` sentinel
+    /// (`i32::MAX`), NOT the tombstone LDT. Cassandra stamps every live non-TTL
+    /// cell with `Cell.NO_DELETION_TIME` and its MetadataCollector folds that into
+    /// `maxLocalDeletionTime`, so any SSTable containing a live cell reports the
+    /// sentinel there. The tombstone chokepoint invariants (issue #851) must
+    /// still hold: `min_local_deletion_time` and the tombstone drop-time histogram
+    /// describe the REAL tombstone only, never the live sentinel.
+    /// RED before the fix: the live `Write` arm was a no-op, so a mixed SSTable
+    /// kept `max_local_deletion_time` at the tombstone LDT and diverged from
+    /// Cassandra.
+    #[tokio::test]
+    async fn test_live_write_plus_tombstone_max_ldt_is_live_sentinel() {
+        let temp_dir = TempDir::new().unwrap();
+        let schema = create_two_regular_schema();
+        let mut writer = SSTableWriter::new(temp_dir.path().to_path_buf(), 1, &schema).unwrap();
+
+        // A real (non-sentinel) tombstone LDT, well below i32::MAX.
+        const TOMBSTONE_LDT: i32 = 1_500_000_000;
+        const ROW_TS_MICROS: i64 = 5_000_000;
+
+        let table_id = TableId::new("test_ks", "test_two_regular");
+        let pk = PartitionKey::single("id", Value::Integer(7));
+        let mutation = Mutation::new(
+            table_id,
+            pk,
+            None,
+            vec![
+                // An older cell tombstone at a real LDT.
+                CellOperation::Delete {
+                    column: "name".to_string(),
+                    local_deletion_time: Some(TOMBSTONE_LDT),
+                },
+                // A live, non-TTL cell in the SAME (mixed) SSTable.
+                CellOperation::Write {
+                    column: "age".to_string(),
+                    value: Value::Integer(42),
+                },
+            ],
+            ROW_TS_MICROS,
+            None,
+        );
+        let key = mutation.decorated_key(&schema).unwrap();
+        writer.write_partition(key, vec![mutation]).unwrap();
+
+        assert_eq!(
+            writer.stats.max_local_deletion_time,
+            i32::MAX,
+            "a live non-TTL cell must lift max_local_deletion_time to the NO_DELETION_TIME \
+             sentinel even alongside an older tombstone with a smaller real LDT"
+        );
+        assert_eq!(
+            writer.stats.min_local_deletion_time, TOMBSTONE_LDT,
+            "the live sentinel must not poison min_local_deletion_time (issue #851 chokepoint)"
+        );
+        assert_eq!(
+            writer.stats.tombstone_histogram.size(),
+            1,
+            "only the real tombstone enters the drop-time histogram, not the live cell"
         );
 
         let _info = writer.finish().await.unwrap();

--- a/cqlite-core/src/storage/sstable/writer/stats_writer/metadata.rs
+++ b/cqlite-core/src/storage/sstable/writer/stats_writer/metadata.rs
@@ -263,6 +263,34 @@ impl StatisticsMetadata {
         self.tombstone_histogram.update(deletion_time);
     }
 
+    /// Fold a LIVE (non-TTL) cell's `NO_DELETION_TIME` sentinel into the
+    /// `maxLocalDeletionTime` aggregate ONLY.
+    ///
+    /// Cassandra stamps every live, non-expiring cell with
+    /// `Cell.NO_DELETION_TIME` (`Integer.MAX_VALUE`) as its `localDeletionTime`,
+    /// and `MetadataCollector.update(Cell)` folds that value into
+    /// `maxLocalDeletionTime`. So any SSTable that contains at least one live
+    /// non-TTL cell finalizes `maxLocalDeletionTime == Integer.MAX_VALUE`,
+    /// EVEN when the same SSTable also carries older tombstones with a smaller
+    /// real LDT (a mixed SSTable — e.g. after compaction). Without this fold a
+    /// mixed SSTable would keep `maxLocalDeletionTime` at the largest TOMBSTONE
+    /// LDT and diverge from Cassandra (issue #1728).
+    ///
+    /// Unlike [`Self::update_local_deletion_time`], the live sentinel must NOT
+    /// pull `minLocalDeletionTime` down nor enter the tombstone drop-time
+    /// histogram (those describe real tombstones only; issue #851). This method
+    /// therefore raises the max alone. A pure-live SSTable ends at
+    /// `max_local_deletion_time == i32::MAX`, which serialises to the same
+    /// `NO_DELETION_TIME` sentinel as the `== 0` "no deletions" case, so the
+    /// pure-live output byte-parity is unchanged.
+    pub fn note_live_local_deletion_time(&mut self) {
+        // `i32::MAX` is the largest possible local-deletion-time, so folding it
+        // into the running max is simply an assignment (a real tombstone LDT is
+        // always strictly smaller). Written directly to avoid the no-op
+        // `.max(i32::MAX)` clippy::unnecessary_min_or_max lint.
+        self.max_local_deletion_time = i32::MAX;
+    }
+
     /// True when `timestamp` is a LIVE / `NO_DELETION` marker rather than a real
     /// deletion timestamp. CQLite writes `DeletionTime.LIVE` as `Long.MIN_VALUE`
     /// (see `data_writer.rs`); Cassandra's `NO_DELETION` / `NO_TIMESTAMP` sentinel
@@ -458,6 +486,68 @@ mod tests {
             1,
             "LIVE marker must not be counted as a tombstone in the histogram"
         );
+    }
+
+    /// Issue #1728: a live non-TTL `Write` cell folds `NO_DELETION_TIME`
+    /// (`i32::MAX`) into `max_local_deletion_time`, matching Cassandra's
+    /// MetadataCollector. In a MIXED SSTable (an older tombstone at a smaller
+    /// real LDT plus a live cell) `max_local_deletion_time` must be the live
+    /// sentinel, NOT the tombstone LDT — while `min_local_deletion_time` and the
+    /// tombstone drop-time histogram continue to describe the real tombstone
+    /// only (issue #851 chokepoint invariants preserved).
+    #[test]
+    fn test_note_live_local_deletion_time_mixed_sstable() {
+        let mut meta = StatisticsMetadata::new();
+        // An older tombstone at a real, smaller LDT.
+        meta.update_local_deletion_time(1_500_000_000);
+        // A live non-TTL cell in the same (mixed) SSTable.
+        meta.note_live_local_deletion_time();
+
+        assert_eq!(
+            meta.max_local_deletion_time,
+            i32::MAX,
+            "a live cell must lift max_local_deletion_time to the NO_DELETION_TIME sentinel"
+        );
+        assert_eq!(
+            meta.min_local_deletion_time, 1_500_000_000,
+            "the live sentinel must not poison min_local_deletion_time"
+        );
+        assert_eq!(
+            meta.tombstone_histogram.size(),
+            1,
+            "the live cell must not be counted as a tombstone in the drop-time histogram"
+        );
+
+        // The sentinel survives finalize (only i32::MIN normalizes to 0), so the
+        // STATS component serialises the live NO_DELETION_TIME sentinel.
+        meta.finalize();
+        assert_eq!(meta.max_local_deletion_time, i32::MAX);
+    }
+
+    /// Issue #1728: a pure-live SSTable (only live `Write` cells, no tombstone)
+    /// ends with `max_local_deletion_time == i32::MAX`, which serialises to the
+    /// same `NO_DELETION_TIME` sentinel as the untouched `== 0` "no deletions"
+    /// case — so pure-live output byte-parity is unchanged.
+    #[test]
+    fn test_note_live_local_deletion_time_pure_live() {
+        let mut meta = StatisticsMetadata::new();
+        meta.note_live_local_deletion_time();
+
+        assert_eq!(meta.max_local_deletion_time, i32::MAX);
+        assert_eq!(
+            meta.min_local_deletion_time,
+            i32::MAX,
+            "no tombstone recorded: min stays at its unset sentinel"
+        );
+        assert!(
+            meta.tombstone_histogram.is_empty(),
+            "a live cell must not create a tombstone histogram bin"
+        );
+
+        meta.finalize();
+        // min unset -> normalized to 0; max holds the live sentinel.
+        assert_eq!(meta.min_local_deletion_time, 0);
+        assert_eq!(meta.max_local_deletion_time, i32::MAX);
     }
 
     /// With only LIVE markers, stats remain at sentinels and `finalize()`


### PR DESCRIPTION
Closes #1728. Prereq for #1388. A live Write/complex-element cell now folds the NO_DELETION_TIME (i32::MAX) live sentinel into max_local_deletion_time (metadata.rs note_live_local_deletion_time), gated on real-live only (ttl_seconds.is_none() && value != Null; is_deleted==false for complex). So a MIXED SSTable (tombstone + live non-TTL cell) finalizes max_deletion_time == live sentinel, not the tombstone LDT — matching Cassandra MetadataCollector. Pure-live output byte-identical (i32::MAX serializes to the same sentinel as the old ==0 path). min_local_deletion_time + tombstone-drop histogram untouched (#851 invariants).

Byte-parity fixtures re-verified byte-identical (Statistics.db is PRESENT_NOT_DIFFED): #1387 (shadow_row_delete + rt_cross_gen), #1190, #1017/1019/1020. Gate RESULT: PASS. 5 tests.

roborev: round-1 (2 findings) fixed; round-2 design call (fold over input stream vs post-reconciliation survivors) resolved by owner 2026-07-02 → **keep input-stream fold** (Cassandra-aligned; every other aggregate arm folds unreconciled ops; fail-safe for #1388 — a shadowed-live SSTable reports live so it is never mis-dropped). roborev suggestion declined with justification (would be less safe + a new Cassandra divergence; no byte-parity oracle either way).