### PR TITLE
fix(#1626): hard-fail open() on corrupt Statistics.db (no silent zero-base WRITETIME/TTL)

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/component_loading.rs
+++ b/cqlite-core/src/storage/sstable/reader/component_loading.rs
@@ -216,13 +216,31 @@ impl SSTableReader {
         }
     }
 
-    /// Load Statistics.db reader for min/max timestamps and metadata
+    /// Load Statistics.db reader for min/max timestamps and metadata.
+    ///
+    /// # Errors
+    ///
+    /// A *present but unparseable* Statistics.db is a HARD FAILURE (issue #1626):
+    /// proceeding with zero EncodingStats baselines and no SerializationHeader
+    /// columns would make every WRITETIME()/TTL/deletion-time from this SSTable
+    /// silently wrong (the "default-on-parse-failure" anti-pattern the
+    /// no-heuristics mandate forbids, issue #28). Corruption/UnsupportedVersion/IO
+    /// errors are propagated with the component file path named.
+    ///
+    /// Out of scope (returns `Ok(None)`, preserving prior behavior):
+    /// - a genuinely *missing* Statistics.db (`Error::NotFound`);
+    /// - a path from which the SSTable base name / parent dir cannot be derived.
     pub(super) async fn load_statistics_reader(
         path: &Path,
         platform: &Arc<Platform>,
-    ) -> Option<StatisticsReader> {
-        let base_name = extract_sstable_base_name(path)?;
-        let statistics_path = path.parent()?.join(format!("{}-Statistics.db", base_name));
+    ) -> Result<Option<StatisticsReader>> {
+        let Some(base_name) = extract_sstable_base_name(path) else {
+            return Ok(None);
+        };
+        let Some(parent) = path.parent() else {
+            return Ok(None);
+        };
+        let statistics_path = parent.join(format!("{}-Statistics.db", base_name));
 
         match StatisticsReader::open(&statistics_path, platform.clone()).await {
             Ok(reader) => {
@@ -230,16 +248,18 @@ impl SSTableReader {
                     "Loaded Statistics.db reader for {}",
                     statistics_path.display()
                 );
-                Some(reader)
+                Ok(Some(reader))
             }
-            Err(e) => {
-                log::warn!(
-                    "Failed to load Statistics.db from {}: {}. Timestamp delta decoding will use zero base values.",
-                    statistics_path.display(),
-                    e
-                );
-                None
-            }
+            // A missing Statistics.db keeps prior behavior: proceed without it.
+            Err(Error::NotFound(_)) => Ok(None),
+            // A present-but-unparseable Statistics.db (Corruption, UnsupportedVersion,
+            // IO, ...) must abort open() — name the component path AND include the
+            // underlying parse error.
+            Err(e) => Err(Error::corruption(format!(
+                "Failed to load Statistics.db from {}: {}",
+                statistics_path.display(),
+                e
+            ))),
         }
     }
 

--- a/cqlite-core/src/storage/sstable/reader/component_loading.rs
+++ b/cqlite-core/src/storage/sstable/reader/component_loading.rs
@@ -252,14 +252,20 @@ impl SSTableReader {
             }
             // A missing Statistics.db keeps prior behavior: proceed without it.
             Err(Error::NotFound(_)) => Ok(None),
-            // A present-but-unparseable Statistics.db (Corruption, UnsupportedVersion,
-            // IO, ...) must abort open() — name the component path AND include the
-            // underlying parse error.
-            Err(e) => Err(Error::corruption(format!(
+            // A genuine PARSE failure is data corruption: keep the `Corruption`
+            // kind but add the component path + underlying error for diagnosis.
+            Err(e @ Error::Corruption(_)) => Err(Error::corruption(format!(
                 "Failed to load Statistics.db from {}: {}",
                 statistics_path.display(),
                 e
             ))),
+            // Any other failure of a PRESENT Statistics.db (IO read error, a
+            // below-floor `UnsupportedVersion`, ...) must still abort open()
+            // (issue #1626), but propagate the ORIGINAL error unchanged so its
+            // category/source is preserved rather than mislabeled as data
+            // corruption. `UnsupportedVersion` already names version + floor; an
+            // IO error keeps its `System` category.
+            Err(e) => Err(e),
         }
     }
 

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -579,7 +579,7 @@ impl SSTableReader {
             .await;
         let statistics_reader = Self::load_statistics_reader(path, &platform)
             .instrument(tracing::debug_span!("sstable.reader.open.load_statistics"))
-            .await;
+            .await?;
 
         // Extract SerializationHeader columns from Statistics.db (Issue #163)
         // This enables schema extraction for V5CompressedLegacy format

--- a/cqlite-core/tests/statistics_corrupt_hardfail_test.rs
+++ b/cqlite-core/tests/statistics_corrupt_hardfail_test.rs
@@ -1,0 +1,173 @@
+//! Issue #1626: a *present but unparseable* Statistics.db must HARD-FAIL
+//! `SSTableReader::open` rather than being silently swallowed into zero
+//! EncodingStats baselines + no SerializationHeader columns (which would make
+//! every WRITETIME()/TTL/deletion-time from that SSTable silently wrong).
+//!
+//! This is the "default-on-parse-failure" anti-pattern the no-heuristics
+//! mandate (issue #28) forbids. A *missing* Statistics.db is out of scope and
+//! keeps its current (open-succeeds) behavior — this test only covers the
+//! corrupt/truncated case.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use cqlite_core::storage::sstable::reader::SSTableReader;
+use cqlite_core::{Config, Platform};
+
+/// Resolve the datasets root: prefer `CQLITE_DATASETS_ROOT`, else fall back to
+/// the in-repo `test-data/datasets` directory (relative to this crate).
+fn datasets_root() -> PathBuf {
+    if let Ok(root) = std::env::var("CQLITE_DATASETS_ROOT") {
+        return PathBuf::from(root);
+    }
+    // cqlite-core/tests/.. -> cqlite-core -> workspace root
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("test-data")
+        .join("datasets")
+}
+
+/// Recursively copy every file in `src` dir (flat SSTable dir) into `dst`.
+fn copy_sstable_dir(src: &Path, dst: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_file() {
+            if let Some(name) = path.file_name() {
+                std::fs::copy(&path, dst.join(name))?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn find_file_suffix(dir: &Path, suffix: &str) -> Option<PathBuf> {
+    std::fs::read_dir(dir)
+        .ok()?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .find(|p| {
+            p.is_file()
+                && p.file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|n| n.ends_with(suffix))
+                    .unwrap_or(false)
+        })
+}
+
+async fn platform() -> (Config, Arc<Platform>) {
+    let config = Config::default();
+    let platform = Arc::new(
+        Platform::new(&config)
+            .await
+            .expect("Failed to create platform"),
+    );
+    (config, platform)
+}
+
+const FIXTURE_REL: &str = "sstables/test_basic/simple_table-6aa08200a25111f0a3fef1a551383fb9";
+
+/// A present-but-truncated Statistics.db must make `open()` return `Err` whose
+/// message names the component file ("Statistics.db"). On current `main` this
+/// returns `Ok` (the parse error is swallowed into `None`) so this test FAILS
+/// before the fix.
+#[tokio::test]
+async fn corrupt_statistics_hard_fails_open() {
+    let fixture = datasets_root().join(FIXTURE_REL);
+    let src_data = match find_file_suffix(&fixture, "-Data.db") {
+        Some(p) if p.exists() => p,
+        _ => {
+            eprintln!(
+                "SKIP: fixture Data.db not present under {} (dataset not fetched)",
+                fixture.display()
+            );
+            return;
+        }
+    };
+    // Guard: the fixture ships a Statistics.db to corrupt.
+    if find_file_suffix(&fixture, "-Statistics.db").is_none() {
+        eprintln!(
+            "SKIP: fixture has no Statistics.db under {}",
+            fixture.display()
+        );
+        return;
+    }
+    let _ = src_data; // presence check only; we copy the whole dir below
+
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let dst = tmp.path().join("sstable");
+    copy_sstable_dir(&fixture, &dst).expect("copy sstable dir");
+
+    // Truncate the copied Statistics.db so the file is present but unparseable.
+    //
+    // NOTE (empirical, see #1626 report): truncating to len/2 does NOT make the
+    // minimal nb parser fail for this fixture — the SerializationHeader lives at
+    // a TOC offset near the END of the file, and `parse_minimal_encoding_stats`
+    // silently FALLS BACK to reading EncodingStats from the front when that
+    // offset is past EOF, so a back-truncated file still parses Ok. The only
+    // robust "present-but-unparseable" corruption is to truncate below the
+    // 32-byte fixed header so `parse_nb_format_header` itself fails. We truncate
+    // to `min(len/2, 16)` bytes (< 32, still > 0).
+    let stats = find_file_suffix(&dst, "-Statistics.db").expect("copied Statistics.db");
+    let len = std::fs::metadata(&stats).expect("stat Statistics.db").len();
+    let target = (len / 2).clamp(1, 16);
+    {
+        let f = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&stats)
+            .expect("open Statistics.db for truncation");
+        f.set_len(target).expect("truncate Statistics.db");
+    }
+
+    let copied_data = find_file_suffix(&dst, "-Data.db").expect("copied Data.db");
+    let (config, platform) = platform().await;
+
+    let result = SSTableReader::open(&copied_data, &config, platform).await;
+
+    let err = match result {
+        Ok(_) => panic!(
+            "expected SSTableReader::open to HARD-FAIL on a truncated Statistics.db, \
+             but it returned Ok (parse error was swallowed)"
+        ),
+        Err(e) => e,
+    };
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Statistics.db"),
+        "error message must name the component file 'Statistics.db', got: {msg}"
+    );
+}
+
+/// Acceptance guard: opening the UNMODIFIED copied SSTable still returns `Ok`.
+/// Proves the hard-fail is scoped strictly to corrupt Statistics.db and does
+/// not regress healthy files.
+#[tokio::test]
+async fn healthy_statistics_still_opens_ok() {
+    let fixture = datasets_root().join(FIXTURE_REL);
+    let src_data = match find_file_suffix(&fixture, "-Data.db") {
+        Some(p) if p.exists() => p,
+        _ => {
+            eprintln!(
+                "SKIP: fixture Data.db not present under {} (dataset not fetched)",
+                fixture.display()
+            );
+            return;
+        }
+    };
+    let _ = src_data;
+
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let dst = tmp.path().join("sstable");
+    copy_sstable_dir(&fixture, &dst).expect("copy sstable dir");
+
+    let copied_data = find_file_suffix(&dst, "-Data.db").expect("copied Data.db");
+    let (config, platform) = platform().await;
+
+    let result = SSTableReader::open(&copied_data, &config, platform).await;
+    assert!(
+        result.is_ok(),
+        "healthy copied SSTable must still open Ok, got: {:?}",
+        result.err()
+    );
+}

--- a/cqlite-core/tests/statistics_corrupt_hardfail_test.rs
+++ b/cqlite-core/tests/statistics_corrupt_hardfail_test.rs
@@ -56,6 +56,27 @@ fn find_file_suffix(dir: &Path, suffix: &str) -> Option<PathBuf> {
         })
 }
 
+/// `CQLITE_REQUIRE_FIXTURES=1` (the strict CI lanes) makes a missing fixture a
+/// HARD failure so a renamed/dropped fixture can never let this hard-fail guard
+/// false-pass. Without it, the test skips cleanly (fresh checkout, binaries
+/// absent). Mirrors the repo-wide convention (see `issue_1007_complex_type_parity`).
+fn require_fixtures_strict() -> bool {
+    std::env::var("CQLITE_REQUIRE_FIXTURES")
+        .map(|v| v == "1" || v == "true")
+        .unwrap_or(false)
+}
+
+/// Skip when the fixture is absent — unless strict mode is on, in which case
+/// fail loud so the scenario cannot false-pass as exercised. Returns `true` when
+/// the caller should skip.
+fn skip_or_fail(reason: &str) -> bool {
+    if require_fixtures_strict() {
+        panic!("CQLITE_REQUIRE_FIXTURES=1 but #1626 fixture unavailable: {reason}");
+    }
+    eprintln!("SKIP: {reason}");
+    true
+}
+
 async fn platform() -> (Config, Arc<Platform>) {
     let config = Config::default();
     let platform = Arc::new(
@@ -75,25 +96,26 @@ const FIXTURE_REL: &str = "sstables/test_basic/simple_table-6aa08200a25111f0a3fe
 #[tokio::test]
 async fn corrupt_statistics_hard_fails_open() {
     let fixture = datasets_root().join(FIXTURE_REL);
-    let src_data = match find_file_suffix(&fixture, "-Data.db") {
-        Some(p) if p.exists() => p,
+    match find_file_suffix(&fixture, "-Data.db") {
+        Some(p) if p.exists() => {}
         _ => {
-            eprintln!(
-                "SKIP: fixture Data.db not present under {} (dataset not fetched)",
+            if skip_or_fail(&format!(
+                "fixture Data.db not present under {} (dataset not fetched)",
                 fixture.display()
-            );
-            return;
+            )) {
+                return;
+            }
         }
     };
     // Guard: the fixture ships a Statistics.db to corrupt.
-    if find_file_suffix(&fixture, "-Statistics.db").is_none() {
-        eprintln!(
-            "SKIP: fixture has no Statistics.db under {}",
+    if find_file_suffix(&fixture, "-Statistics.db").is_none()
+        && skip_or_fail(&format!(
+            "fixture has no Statistics.db under {}",
             fixture.display()
-        );
+        ))
+    {
         return;
     }
-    let _ = src_data; // presence check only; we copy the whole dir below
 
     let tmp = tempfile::tempdir().expect("create tempdir");
     let dst = tmp.path().join("sstable");
@@ -145,17 +167,17 @@ async fn corrupt_statistics_hard_fails_open() {
 #[tokio::test]
 async fn healthy_statistics_still_opens_ok() {
     let fixture = datasets_root().join(FIXTURE_REL);
-    let src_data = match find_file_suffix(&fixture, "-Data.db") {
-        Some(p) if p.exists() => p,
+    match find_file_suffix(&fixture, "-Data.db") {
+        Some(p) if p.exists() => {}
         _ => {
-            eprintln!(
-                "SKIP: fixture Data.db not present under {} (dataset not fetched)",
+            if skip_or_fail(&format!(
+                "fixture Data.db not present under {} (dataset not fetched)",
                 fixture.display()
-            );
-            return;
+            )) {
+                return;
+            }
         }
     };
-    let _ = src_data;
 
     let tmp = tempfile::tempdir().expect("create tempdir");
     let dst = tmp.path().join("sstable");


### PR DESCRIPTION
Closes #1626 (I3 — corrupt Statistics.db must hard-fail open()). Oracle-driven parser bug (DECIDED by owner 2026-07-01: hard-fail, no degraded mode, no opt-in flag). Manager order `<!-- MGR:mbp-0702 -->` GO.

## Problem
`load_statistics_reader` swallowed a **parse failure** of a *present* `Statistics.db` into `None` (with only a warning). The reader then proceeded with zero EncodingStats baselines and no SerializationHeader columns, so every `WRITETIME()`/TTL/deletion-time decoded from that SSTable was silently wrong (deltas over a zero base) — the default-on-parse-failure anti-pattern the no-heuristics mandate (#28) forbids.

## Fix
- `load_statistics_reader` now returns `Result<Option<StatisticsReader>>`:
  - present-but-unparseable (`Corruption`) → `Err`, naming the component path + underlying parse error;
  - `NotFound` (missing file) → `Ok(None)` — **out of scope**, prior behavior preserved (per issue scope guard);
  - IO / below-floor `UnsupportedVersion` → propagated **unchanged** (original category/source preserved, not mislabeled as corruption);
  - unparseable base-name/parent → `Ok(None)` (out of scope).
- `SSTableReader::open` propagates the `Err` (`reader/mod.rs:580`).

## Tests
Pinned integration test `cqlite-core/tests/statistics_corrupt_hardfail_test.rs`:
- `corrupt_statistics_hard_fails_open` — truncated `Statistics.db` → `open()` returns `Err` whose message names `Statistics.db` (fails on current `main`, which returns `Ok`). Honors `CQLITE_REQUIRE_FIXTURES=1` (hard-fail on missing fixture in strict lanes).
- `healthy_statistics_still_opens_ok` — unmodified copy still opens `Ok` (no regression for healthy files).

## Wiring evidence
Exercised through the public `SSTableReader::open` surface end-to-end (not a helper-only unit test).

## Validation
- `scripts/agent-gate.sh`: **RESULT: PASS** (18/18 components; 33-table parity green via core-tests + smoke).
- roborev (`--base origin/main`, codex): **No issues found** (initial 2 findings — error-kind preservation + `CQLITE_REQUIRE_FIXTURES` — addressed).
- No `unwrap`/`expect` in library code; `RUSTFLAGS=-D warnings` clean.

## Note for triage (out of scope, not fixed here)
`parse_minimal_encoding_stats` silently falls back to reading EncodingStats from the front of the file when the TOC SerializationHeader offset is past EOF — so a *back-truncated* `Statistics.db` still parses `Ok`. That is an adjacent silent-degradation surface (missing SerializationHeader → empty columns without error); flagging for a possible follow-up under epic #1602.