### PR TITLE
fix(#1446): emit Node row objects in SELECT order; intern column-name JsStrings once per result

### DIFF
--- a/bindings/node/__test__/result.test.js
+++ b/bindings/node/__test__/result.test.js
@@ -282,11 +282,9 @@ describe('Row property order matches SELECT order (Issue #1446)', () => {
     }
   });
 
-  test('executeNative: every selected column is present on every row (null-filled, never undefined)', async () => {
-    // Locks the null-fill branch: a selected column absent from a row's values
-    // must still appear as a key (emitted as null), so row shape is stable and
-    // Object.keys never diverges from the projection. Missing cells are null,
-    // never undefined/omitted.
+  test('executeNative: every selected column is present on every row (never undefined)', async () => {
+    // For normal projections core populates every selected column, so the row
+    // shape is stable: Object.keys equals the projection and no cell is omitted.
     const cols = ['id', 'name', 'age', 'salary', 'active'];
     const result = await db.executeNative(
       `SELECT ${cols.join(', ')} FROM test_basic.simple_table LIMIT 10`
@@ -295,8 +293,28 @@ describe('Row property order matches SELECT order (Issue #1446)', () => {
     for (const row of result.rows) {
       expect(Object.keys(row)).toEqual(cols);
       for (const k of cols) {
-        expect(row[k]).not.toBeUndefined(); // present as a value or explicit null
+        expect(row[k]).not.toBeUndefined();
       }
+    }
+  });
+
+  test('executeNative: aggregate projection emits no phantom metadata column', async () => {
+    // Regression (#1446 roborev job 2736): aggregate result metadata uses a
+    // fallback name (col_0) while the row value is keyed by the expression name
+    // (Count(*)). A metadata column absent from values must be skipped, not
+    // null-filled — otherwise the row gains a phantom `col_0: null`.
+    const result = await db.executeNative(
+      'SELECT COUNT(*) FROM test_basic.simple_table'
+    );
+    expect(result.rowCount).toBe(1);
+    const row = result.rows[0];
+    const keys = Object.keys(row);
+    // The real aggregate cell is present with a non-null value...
+    expect(keys.length).toBe(1);
+    expect(row[keys[0]]).not.toBeNull();
+    // ...and no phantom null-filled metadata column leaks through.
+    for (const [k, v] of Object.entries(row)) {
+      expect(v === null).toBe(false);
     }
   });
 

--- a/bindings/node/__test__/result.test.js
+++ b/bindings/node/__test__/result.test.js
@@ -241,3 +241,57 @@ describe('QueryResult and ColumnInfo Tests (Issue #303)', () => {
     });
   });
 });
+
+describe('Row property order matches SELECT order (Issue #1446)', () => {
+  let db = null;
+
+  beforeAll(async () => {
+    skipIfNoDatasets();
+    db = await Database.open(global.testPaths.SSTABLES_DIR, {
+      schema: global.testPaths.SCHEMA_BASIC_TYPES,
+    });
+  });
+
+  afterAll(async () => {
+    if (db) {
+      await db.close();
+      db = null;
+    }
+  });
+
+  test('executeNative: Object.keys(row) matches SELECT column order (SELECT *)', async () => {
+    const result = await db.executeNative(
+      'SELECT * FROM test_basic.simple_table LIMIT 5'
+    );
+    // Dataset rule: present-but-empty fixtures FAIL loudly, never skip.
+    expect(result.rowCount).toBeGreaterThan(0);
+    const expected = result.columns.map((c) => c.name);
+    for (const row of result.rows) {
+      expect(Object.keys(row)).toEqual(expected);
+    }
+  });
+
+  test('executeNative: Object.keys(row) honors an explicit reordered projection', async () => {
+    const result = await db.executeNative(
+      'SELECT name, id, age FROM test_basic.simple_table LIMIT 5'
+    );
+    expect(result.rowCount).toBeGreaterThan(0);
+    expect(result.columns.map((c) => c.name)).toEqual(['name', 'id', 'age']);
+    for (const row of result.rows) {
+      expect(Object.keys(row)).toEqual(['name', 'id', 'age']);
+    }
+  });
+
+  test('executeStreaming: Object.keys(row) matches SELECT column order', async () => {
+    const stream = db.executeStreaming(
+      'SELECT name, id, age FROM test_basic.simple_table LIMIT 5'
+    );
+    let seen = 0;
+    for await (const row of stream) {
+      expect(Object.keys(row)).toEqual(['name', 'id', 'age']);
+      seen += 1;
+    }
+    // Present-but-empty fixtures FAIL loudly, never skip.
+    expect(seen).toBeGreaterThan(0);
+  });
+});

--- a/bindings/node/__test__/result.test.js
+++ b/bindings/node/__test__/result.test.js
@@ -282,6 +282,24 @@ describe('Row property order matches SELECT order (Issue #1446)', () => {
     }
   });
 
+  test('executeNative: every selected column is present on every row (null-filled, never undefined)', async () => {
+    // Locks the null-fill branch: a selected column absent from a row's values
+    // must still appear as a key (emitted as null), so row shape is stable and
+    // Object.keys never diverges from the projection. Missing cells are null,
+    // never undefined/omitted.
+    const cols = ['id', 'name', 'age', 'salary', 'active'];
+    const result = await db.executeNative(
+      `SELECT ${cols.join(', ')} FROM test_basic.simple_table LIMIT 10`
+    );
+    expect(result.rowCount).toBeGreaterThan(0);
+    for (const row of result.rows) {
+      expect(Object.keys(row)).toEqual(cols);
+      for (const k of cols) {
+        expect(row[k]).not.toBeUndefined(); // present as a value or explicit null
+      }
+    }
+  });
+
   test('executeStreaming: Object.keys(row) matches SELECT column order', async () => {
     const stream = db.executeStreaming(
       'SELECT name, id, age FROM test_basic.simple_table LIMIT 5'

--- a/bindings/node/src/database.rs
+++ b/bindings/node/src/database.rs
@@ -1347,8 +1347,13 @@ impl napi::Task for ExecuteNativeTask {
 
         // Create rows array with native types
         let mut rows_arr = env.create_array_with_length(output.rows.len())?;
+        // Issue #1446: intern SELECT-order column-name keys ONCE per result (not
+        // per row) and reuse them so every row's properties are emitted in
+        // authoritative column order rather than HashMap hash order.
+        let col_names: Vec<String> = output.columns.iter().map(|c| c.name.clone()).collect();
+        let col_keys = crate::value::intern_column_keys(&env, &col_names)?;
         for (i, row_values) in output.rows.iter().enumerate() {
-            let row_obj = crate::value::row_to_object(&env, row_values)?;
+            let row_obj = crate::value::row_to_object(&env, &col_keys, row_values)?;
             rows_arr.set_element(i as u32, row_obj)?;
         }
 

--- a/bindings/node/src/streaming.rs
+++ b/bindings/node/src/streaming.rs
@@ -200,6 +200,12 @@ impl napi::Task for NextTask {
 
         match output {
             NextResult::Value(values) => {
+                // Streaming yields one row per `next()` AsyncTask, and napi value
+                // handles are scoped to this `resolve` callback's `Env`, so the
+                // key handles cannot be cached across rows the way the batch
+                // `executeNative` path does — interning here is necessarily once
+                // per yielded row. The streaming win from #1446 is SELECT-order
+                // output (from `self.column_names`), not per-result interning.
                 let col_keys = intern_column_keys(&env, &self.column_names)?;
                 let row_obj = row_to_object(&env, &col_keys, &values)?;
                 result.set_named_property("value", row_obj)?;

--- a/bindings/node/src/streaming.rs
+++ b/bindings/node/src/streaming.rs
@@ -41,7 +41,7 @@ use napi_derive::napi;
 
 use crate::database::ColumnInfo;
 use crate::error::to_napi_error;
-use crate::value::row_to_object;
+use crate::value::{intern_column_keys, row_to_object};
 
 /// Streaming query result iterator.
 ///
@@ -71,6 +71,9 @@ pub struct StreamingResult {
     inner: Arc<Mutex<Option<cqlite_core::query::result::QueryResultIterator>>>,
     /// Cached column metadata for the result set.
     columns: Vec<ColumnInfo>,
+    /// Authoritative SELECT-order column names, shared with each `next()` task so
+    /// rows are emitted in column order rather than HashMap hash order (#1446).
+    column_names: Arc<Vec<String>>,
     /// Per-stream span (issue #1040). Shared with each `next()` task so rows
     /// yielded across iterations accumulate, and finalised on
     /// exhaustion/close. `Span` is cheap to clone and is a no-op when telemetry
@@ -100,9 +103,12 @@ impl StreamingResult {
             })
             .collect();
 
+        let column_names = Arc::new(columns.iter().map(|c| c.name.clone()).collect::<Vec<_>>());
+
         Ok(Self {
             inner: Arc::new(Mutex::new(Some(iter))),
             columns,
+            column_names,
             span,
         })
     }
@@ -126,6 +132,9 @@ pub enum NextResult {
 /// Async task for fetching the next row.
 pub struct NextTask {
     inner: Arc<Mutex<Option<cqlite_core::query::result::QueryResultIterator>>>,
+    /// SELECT-order column names for this stream, used to emit the yielded row's
+    /// properties in column order rather than HashMap hash order (#1446).
+    column_names: Arc<Vec<String>>,
     /// Stream span, finalised with the row count when the stream ends or errors
     /// (issue #1040).
     span: tracing::Span,
@@ -191,7 +200,8 @@ impl napi::Task for NextTask {
 
         match output {
             NextResult::Value(values) => {
-                let row_obj = row_to_object(&env, &values)?;
+                let col_keys = intern_column_keys(&env, &self.column_names)?;
+                let row_obj = row_to_object(&env, &col_keys, &values)?;
                 result.set_named_property("value", row_obj)?;
                 result.set_named_property("done", env.get_boolean(false)?)?;
             }
@@ -222,6 +232,7 @@ impl StreamingResult {
         // Clone the Arc reference + span to share with the task
         AsyncTask::new(NextTask {
             inner: self.inner.clone(),
+            column_names: self.column_names.clone(),
             span: self.span.clone(),
         })
     }

--- a/bindings/node/src/value.rs
+++ b/bindings/node/src/value.rs
@@ -457,10 +457,32 @@ pub fn row_to_object(
     values: &std::collections::HashMap<String, Value>,
 ) -> Result<JsObject> {
     let mut obj = env.create_object()?;
+    let mut emitted = 0usize;
     for (col_name, js_key) in keys {
         if let Some(value) = values.get(col_name) {
             let js_value = value_to_napi(env, value)?;
             obj.set_property(*js_key, js_value)?;
+            emitted += 1;
+        }
+    }
+    // Never drop cells (#1446 roborev): if the result carried values that the
+    // authoritative column list does not cover — e.g. a streaming `SELECT *`
+    // whose schema lookup failed leaves `metadata.columns` empty while rows are
+    // still yielded — emit the remainder in a deterministic (name-sorted) order
+    // rather than returning `{}` or falling back to nondeterministic hash order.
+    if emitted < values.len() {
+        let known: std::collections::HashSet<&str> =
+            keys.iter().map(|(name, _)| name.as_str()).collect();
+        let mut extra: Vec<&String> = values
+            .keys()
+            .filter(|name| !known.contains(name.as_str()))
+            .collect();
+        extra.sort();
+        for name in extra {
+            if let Some(value) = values.get(name) {
+                let js_value = value_to_napi(env, value)?;
+                obj.set_named_property(name, js_value)?;
+            }
         }
     }
     Ok(obj)

--- a/bindings/node/src/value.rs
+++ b/bindings/node/src/value.rs
@@ -431,18 +431,31 @@ fn udt_to_object(env: &Env, udt: &cqlite_core::UdtValue) -> Result<JsUnknown> {
     Ok(obj.into_unknown())
 }
 
-/// Intern the SELECT-order column names into reusable JS key handles.
+/// Reusable, once-per-result column-key structure for row construction.
 ///
-/// Issue #1446: build each column-name `JsString` **once per result set** so a
-/// wide-table scan does not re-intern `O(rows × columns)` identical strings at
-/// the FFI boundary. The returned pairs are `(lookup_name, js_key)`, kept in
-/// authoritative SELECT order; `row_to_object` consumes a borrow of this slice
-/// for every row. `JsString` is a `Copy` handle valid for the enclosing scope.
-pub fn intern_column_keys(env: &Env, names: &[String]) -> Result<Vec<(String, JsString)>> {
-    names
+/// Issue #1446: both the interned `JsString` handles and the membership set are
+/// built a single time per result set (they depend only on the column list,
+/// which is constant across every row) so a wide-table scan pays neither the
+/// `O(rows × columns)` string re-interning nor a per-row `HashSet` rebuild.
+pub struct ColumnKeys {
+    /// `(lookup_name, pre-interned JS key)` in authoritative SELECT order.
+    /// `JsString` is a `Copy` handle valid for the enclosing `Env` scope.
+    ordered: Vec<(String, JsString)>,
+    /// Membership set of the ordered names, for O(1) "is this value covered by
+    /// the authoritative column list?" checks in [`row_to_object`].
+    known: std::collections::HashSet<String>,
+}
+
+/// Intern the SELECT-order column names into a reusable [`ColumnKeys`].
+///
+/// Called once per result set; the returned structure is borrowed for every row.
+pub fn intern_column_keys(env: &Env, names: &[String]) -> Result<ColumnKeys> {
+    let ordered = names
         .iter()
         .map(|name| Ok((name.clone(), env.create_string(name)?)))
-        .collect()
+        .collect::<Result<Vec<_>>>()?;
+    let known = names.iter().cloned().collect();
+    Ok(ColumnKeys { ordered, known })
 }
 
 /// Convert row values to a JavaScript object in authoritative SELECT order.
@@ -450,10 +463,10 @@ pub fn intern_column_keys(env: &Env, names: &[String]) -> Result<Vec<(String, Js
 /// Issue #1446: property insertion order equals `columns` order (V8 preserves
 /// string-key insertion order), so `Object.keys(row)` matches
 /// `columns.map(c => c.name)` — not `HashMap` hash order. `keys` are the
-/// pre-interned handles from [`intern_column_keys`], reused across every row.
+/// once-per-result handles from [`intern_column_keys`], reused across every row.
 pub fn row_to_object(
     env: &Env,
-    keys: &[(String, JsString)],
+    keys: &ColumnKeys,
     values: &std::collections::HashMap<String, Value>,
 ) -> Result<JsObject> {
     let mut obj = env.create_object()?;
@@ -461,7 +474,7 @@ pub fn row_to_object(
     // from this row's values (a sparse row) is emitted as `null` so that
     // `Object.keys(row)` always equals `columns.map(c => c.name)` and positional
     // access stays stable (#1446 roborev).
-    for (col_name, js_key) in keys {
+    for (col_name, js_key) in &keys.ordered {
         let js_value = match values.get(col_name) {
             Some(value) => value_to_napi(env, value)?,
             None => env.get_null()?.into_unknown(),
@@ -472,15 +485,12 @@ pub fn row_to_object(
     // list does not cover — e.g. a streaming `SELECT *` whose schema lookup
     // failed leaves `metadata.columns` empty while rows are still yielded — in a
     // deterministic (name-sorted) order rather than returning `{}` or falling
-    // back to nondeterministic hash order. Extras are detected by membership,
-    // not a length comparison, so a sparse row that also carries an unmapped
-    // value (fewer present selected columns than metadata entries, plus one
-    // extra) is still emitted in full.
-    let known: std::collections::HashSet<&str> =
-        keys.iter().map(|(name, _)| name.as_str()).collect();
+    // back to nondeterministic hash order. Extras are detected by membership
+    // against the precomputed `known` set (built once per result), so the common
+    // path where metadata covers every cell allocates no set and does no sort.
     let mut extra: Vec<&String> = values
         .keys()
-        .filter(|name| !known.contains(name.as_str()))
+        .filter(|name| !keys.known.contains(name.as_str()))
         .collect();
     if !extra.is_empty() {
         extra.sort();

--- a/bindings/node/src/value.rs
+++ b/bindings/node/src/value.rs
@@ -457,20 +457,23 @@ pub fn row_to_object(
     values: &std::collections::HashMap<String, Value>,
 ) -> Result<JsObject> {
     let mut obj = env.create_object()?;
-    let mut emitted = 0usize;
+    // Emit every selected column, in authoritative SELECT order. A column absent
+    // from this row's values (a sparse row) is emitted as `null` so that
+    // `Object.keys(row)` always equals `columns.map(c => c.name)` and positional
+    // access stays stable (#1446 roborev).
     for (col_name, js_key) in keys {
-        if let Some(value) = values.get(col_name) {
-            let js_value = value_to_napi(env, value)?;
-            obj.set_property(*js_key, js_value)?;
-            emitted += 1;
-        }
+        let js_value = match values.get(col_name) {
+            Some(value) => value_to_napi(env, value)?,
+            None => env.get_null()?.into_unknown(),
+        };
+        obj.set_property(*js_key, js_value)?;
     }
     // Never drop cells (#1446 roborev): if the result carried values that the
     // authoritative column list does not cover — e.g. a streaming `SELECT *`
     // whose schema lookup failed leaves `metadata.columns` empty while rows are
     // still yielded — emit the remainder in a deterministic (name-sorted) order
     // rather than returning `{}` or falling back to nondeterministic hash order.
-    if emitted < values.len() {
+    if values.len() > keys.len() {
         let known: std::collections::HashSet<&str> =
             keys.iter().map(|(name, _)| name.as_str()).collect();
         let mut extra: Vec<&String> = values

--- a/bindings/node/src/value.rs
+++ b/bindings/node/src/value.rs
@@ -468,18 +468,21 @@ pub fn row_to_object(
         };
         obj.set_property(*js_key, js_value)?;
     }
-    // Never drop cells (#1446 roborev): if the result carried values that the
-    // authoritative column list does not cover — e.g. a streaming `SELECT *`
-    // whose schema lookup failed leaves `metadata.columns` empty while rows are
-    // still yielded — emit the remainder in a deterministic (name-sorted) order
-    // rather than returning `{}` or falling back to nondeterministic hash order.
-    if values.len() > keys.len() {
-        let known: std::collections::HashSet<&str> =
-            keys.iter().map(|(name, _)| name.as_str()).collect();
-        let mut extra: Vec<&String> = values
-            .keys()
-            .filter(|name| !known.contains(name.as_str()))
-            .collect();
+    // Never drop cells (#1446 roborev): emit any values the authoritative column
+    // list does not cover — e.g. a streaming `SELECT *` whose schema lookup
+    // failed leaves `metadata.columns` empty while rows are still yielded — in a
+    // deterministic (name-sorted) order rather than returning `{}` or falling
+    // back to nondeterministic hash order. Extras are detected by membership,
+    // not a length comparison, so a sparse row that also carries an unmapped
+    // value (fewer present selected columns than metadata entries, plus one
+    // extra) is still emitted in full.
+    let known: std::collections::HashSet<&str> =
+        keys.iter().map(|(name, _)| name.as_str()).collect();
+    let mut extra: Vec<&String> = values
+        .keys()
+        .filter(|name| !known.contains(name.as_str()))
+        .collect();
+    if !extra.is_empty() {
         extra.sort();
         for name in extra {
             if let Some(value) = values.get(name) {

--- a/bindings/node/src/value.rs
+++ b/bindings/node/src/value.rs
@@ -470,24 +470,28 @@ pub fn row_to_object(
     values: &std::collections::HashMap<String, Value>,
 ) -> Result<JsObject> {
     let mut obj = env.create_object()?;
-    // Emit every selected column, in authoritative SELECT order. A column absent
-    // from this row's values (a sparse row) is emitted as `null` so that
-    // `Object.keys(row)` always equals `columns.map(c => c.name)` and positional
-    // access stays stable (#1446 roborev).
+    // Emit the selected columns that are present in this row's values, in
+    // authoritative SELECT order (#1446). For the normal case where metadata
+    // names match the value keys, this is every column, so `Object.keys(row)`
+    // equals `columns.map(c => c.name)`. A metadata column with no matching value
+    // is skipped (not null-filled): for aggregate queries core's metadata uses a
+    // fallback name like `col_0` while the value is keyed by the expression name
+    // like `Count(*)`, and null-filling would emit a phantom `col_0: null`
+    // alongside the real cell.
     for (col_name, js_key) in &keys.ordered {
-        let js_value = match values.get(col_name) {
-            Some(value) => value_to_napi(env, value)?,
-            None => env.get_null()?.into_unknown(),
-        };
-        obj.set_property(*js_key, js_value)?;
+        if let Some(value) = values.get(col_name) {
+            let js_value = value_to_napi(env, value)?;
+            obj.set_property(*js_key, js_value)?;
+        }
     }
     // Never drop cells (#1446 roborev): emit any values the authoritative column
-    // list does not cover — e.g. a streaming `SELECT *` whose schema lookup
-    // failed leaves `metadata.columns` empty while rows are still yielded — in a
-    // deterministic (name-sorted) order rather than returning `{}` or falling
-    // back to nondeterministic hash order. Extras are detected by membership
-    // against the precomputed `known` set (built once per result), so the common
-    // path where metadata covers every cell allocates no set and does no sort.
+    // list does not cover — an aggregate value keyed differently from its
+    // metadata name, or a streaming `SELECT *` whose schema lookup failed leaves
+    // `metadata.columns` empty while rows are still yielded — in a deterministic
+    // (name-sorted) order rather than dropping them or using nondeterministic
+    // hash order. Extras are detected by membership against the precomputed
+    // `known` set (built once per result), so the common path where metadata
+    // covers every cell allocates no set and does no sort.
     let mut extra: Vec<&String> = values
         .keys()
         .filter(|name| !keys.known.contains(name.as_str()))

--- a/bindings/node/src/value.rs
+++ b/bindings/node/src/value.rs
@@ -29,7 +29,7 @@
 //! | Udt | `object` with `_type`, `_keyspace`, and field properties |
 
 use cqlite_core::types::Value;
-use napi::{Env, JsFunction, JsObject, JsUnknown, Result};
+use napi::{Env, JsFunction, JsObject, JsString, JsUnknown, Result};
 
 /// Convert a CQL Value to a JavaScript value with native types.
 ///
@@ -431,17 +431,37 @@ fn udt_to_object(env: &Env, udt: &cqlite_core::UdtValue) -> Result<JsUnknown> {
     Ok(obj.into_unknown())
 }
 
-/// Convert row values to a JavaScript object.
+/// Intern the SELECT-order column names into reusable JS key handles.
 ///
-/// This is a convenience function for converting query result rows.
+/// Issue #1446: build each column-name `JsString` **once per result set** so a
+/// wide-table scan does not re-intern `O(rows × columns)` identical strings at
+/// the FFI boundary. The returned pairs are `(lookup_name, js_key)`, kept in
+/// authoritative SELECT order; `row_to_object` consumes a borrow of this slice
+/// for every row. `JsString` is a `Copy` handle valid for the enclosing scope.
+pub fn intern_column_keys(env: &Env, names: &[String]) -> Result<Vec<(String, JsString)>> {
+    names
+        .iter()
+        .map(|name| Ok((name.clone(), env.create_string(name)?)))
+        .collect()
+}
+
+/// Convert row values to a JavaScript object in authoritative SELECT order.
+///
+/// Issue #1446: property insertion order equals `columns` order (V8 preserves
+/// string-key insertion order), so `Object.keys(row)` matches
+/// `columns.map(c => c.name)` — not `HashMap` hash order. `keys` are the
+/// pre-interned handles from [`intern_column_keys`], reused across every row.
 pub fn row_to_object(
     env: &Env,
+    keys: &[(String, JsString)],
     values: &std::collections::HashMap<String, Value>,
 ) -> Result<JsObject> {
     let mut obj = env.create_object()?;
-    for (col_name, value) in values {
-        let js_value = value_to_napi(env, value)?;
-        obj.set_named_property(col_name, js_value)?;
+    for (col_name, js_key) in keys {
+        if let Some(value) = values.get(col_name) {
+            let js_value = value_to_napi(env, value)?;
+            obj.set_property(*js_key, js_value)?;
+        }
     }
     Ok(obj)
 }


### PR DESCRIPTION
Closes #1446.

## Problem
`executeNative()`/`executeStreaming()` built Node row objects by iterating a `HashMap`, so `Object.keys(row)` came back in hash order (disagreeing with the `columns` array, the CLI, and Python), and every row re-interned each column-name `JsString` at the FFI boundary (O(rows × columns) redundant string creation).

## Fix (bindings/node only — no cqlite-core public-surface change)
- `value.rs`: new `intern_column_keys()` builds each SELECT-order column-name `JsString` **once per result set**; `row_to_object()` takes those pre-interned key handles and emits properties in authoritative column order (V8 preserves string-key insertion order). Includes a deterministic name-sorted fallback so no cell is ever dropped when column metadata is empty (roborev job 2721).
- `database.rs`: precompute the ordered key handles once before the row loop (not per row).
- `streaming.rs`: thread ordered column names through `StreamingResult`/`NextTask` so streamed rows are emitted in SELECT order too.

## Tests (wiring evidence, real Jest against public API)
`__test__/result.test.js`: `Object.keys(row)` deep-equals `columns.map(c=>c.name)` for `SELECT *`, an explicit reordered projection (`SELECT name, id, age`), and the streaming path. Fail-loud on present-but-empty datasets.

## Notes
- Oracle-driven bug → GitHub issue + pinned parity test; no OpenSpec change.
- `database.rs` is over the campsite file-size threshold (#1116); split out of scope for this focused fix → `CQLITE_ALLOW_FILE_GROWTH=1` ack for +5 lines.

🤖 flow-lead worker