### PR TITLE
docs: design drafts, presentation, CI plan, 0.1.0 report

### DIFF
--- a/docs/942-point-read-fast-path-design.md
+++ b/docs/942-point-read-fast-path-design.md
@@ -1,0 +1,414 @@
+# Design Doc: Route Single-Partition Reads to a Point-Read Fast Path
+
+**Feeds:** GitHub issue [#942](https://github.com/pmcfadin/cqlite/issues/942) — "Use the read path for partition reads" (P2, enhancement, filed by @rustyrazorblade)
+**Intended use:** Input to OpenSpec workflow (`flow-groom` → proposal/design/tasks → epics + issues)
+**Suggested OpenSpec change name:** `point-read-fast-path`
+**Status of this doc:** Draft for grooming. Contains `VERIFY:` items that MUST be resolved against the code before spec approval (Seam 1). Authored from external inspection of the docs site, CLAUDE.md, and the SSTable format guide — not from reading `cqlite-core` source.
+
+---
+
+## 1. Problem Statement
+
+Every `SELECT` currently executes via the "compact to memory" path: all SSTable
+generations for the table are merged (compaction-style) into memory, and the query is
+evaluated against the merged result.
+
+This is the right semantics for full scans and exports. For a single-partition query —
+`SELECT ... WHERE <full partition key bound by equality>` — it is strictly wasteful:
+
+- **Latency:** cost is O(table size), not O(partition size). The project's stated
+  target of sub-millisecond partition lookups is unreachable through this path on
+  non-trivial tables.
+- **Memory:** the <128 MB budget for large files is spent materializing data the query
+  never touches.
+- **Scaling with M5:** now that flush + STCS compaction produce multiple SSTable
+  generations per table, the compact-to-memory cost grows with generation count even
+  when the target partition lives in one file.
+
+Issue #942 asks the engine to *intelligently route* single-partition queries to a
+normal read path: index lookup → seek → decompress only what's needed → stream one
+partition — i.e., what Cassandra itself does, and what the repo's own format guide
+documents in Ch.10 (Point Reads and Slices) and Ch.21 (flow card).
+
+`VERIFY:` locate the actual compact-to-memory entry point before speccing.
+Start: `rg -n "compact" cqlite-core/src/query/` and trace how
+`cqlite-core/src/query/` obtains rows from `storage/`. Confirm whether it invokes
+`storage/write_engine/merge.rs` machinery or a separate scan/merge in the reader.
+
+## 2. Goals
+
+- G1: Queries that fully bind the partition key by equality (or `IN`) execute without
+  materializing the whole table.
+- G2: Results are **bit-identical** to the compact-to-memory path for every query, on
+  every table in the corpus. Routing is a pure performance optimization; it must never
+  change semantics.
+- G3: The two paths share one merge/reconciliation implementation (no forked
+  tombstone/timestamp logic).
+- G4: Routing decisions come only from authoritative metadata (schema partition-key
+  definition, TOC component presence, Statistics.db) — no byte sniffing
+  (no-heuristics mandate).
+- G5: The chosen path is observable (EXPLAIN-style output and/or `metrics` feature
+  counters) and forcible (env/config override) for testing and support.
+- G6: Demonstrated wins: point-read latency and peak RSS benchmarks, fast path vs
+  compact path, captured with the existing `scripts/profile.sh` harness.
+
+## 3. Non-Goals (this change)
+
+- NG1: BTI (`da`) fast path. Ships as a follow-up epic; BTI tables fall back to the
+  compact path in this change. (See Open Question OQ-2.)
+- NG2: Secondary index (2i) or SAI acceleration.
+- NG3: Token-range routing, partition-range scans, or general predicate pushdown
+  beyond clustering bounds within the located partition.
+- NG4: Bloom-filter (Filter.db) parsing, **if** it does not already exist (OQ-1).
+  Designed-for but delivered as its own issue.
+- NG5: Any change to write/compaction output. This is read-side only.
+
+## 4. Current State (with verification checklist)
+
+Believed true from external inspection; each item needs code confirmation:
+
+| # | Claim | Basis | VERIFY command / question |
+|---|-------|-------|---------------------------|
+| C1 | Summary→Index partition lookup exists and is CI-tested | `golden_path_partition_lookup_tests.rs`, `golden_path_summary_index_integration_tests.rs`, `golden_path_get_operations_tests.rs` in `cqlite-integration-tests/tests/` | Which library API do these tests exercise? Is it callable from `query/`? |
+| C2 | K-way merge with byte-for-byte Cassandra compaction parity exists | `storage/write_engine/merge.rs` (M5.2), v0.12.0 release notes | Is `merge.rs` input an iterator abstraction or whole-SSTable readers? Refactor cost? |
+| C3 | Main V5 parser is `storage/sstable/reader/parsing/v5_compressed_legacy.rs` (~2000 lines) | source-map page | Does it expose (or can it expose) a "parse one partition starting at offset X" entry, or only whole-file iteration? |
+| C4 | BTI reader is incomplete; `da` excluded from default smoke | source-map page (may be stale vs v0.12.0 "canonical BTI read/write") | Actual state of `storage/sstable/bti/` read path: exact-key `Partitions.db` lookup usable? |
+| C5 | Filter.db (bloom) parsing status unknown | format guide Ch.7 exists; no source-map entry | `rg -ni "filter.db|bloom" cqlite-core/src/` |
+| C6 | CQLite-written SSTables are uncompressed, never emit CompressionInfo.db | CLAUDE.md issue #1406 claim boundary | Confirm reader handles absent CompressionInfo.db via direct offsets today |
+| C7 | Writable mode has a memtable that reads must consult | M5 write support | Does the current read path merge memtable contents? Where? |
+| C8 | Query classification data available: schema gives partition/clustering columns; `cql/` gives AST | source-map | Confirm AST shape for WHERE conjuncts; existing predicate model in `query/` |
+
+## 5. Proposed Design
+
+### 5.1 Plan layer (new: `cqlite-core/src/query/plan.rs`)
+
+Introduce a small physical-plan enum between CQL AST resolution and execution:
+
+```rust
+pub enum ReadPlan {
+    /// All partition key columns bound by `=` (or expanded from `IN`).
+    PointRead {
+        keys: Vec<DecoratedKey>,          // one per IN element; deduplicated
+        clustering: ClusteringBounds,      // full/prefix equality + range on clustering cols
+        residual: Option<Predicate>,       // non-key predicates, applied as post-filter
+        limit: Option<u64>,
+        reversed: bool,                    // ORDER BY ... DESC
+    },
+    /// Everything else — existing compact-to-memory execution, unchanged.
+    FullScan {
+        predicate: Option<Predicate>,
+        limit: Option<u64>,
+    },
+}
+```
+
+Classification rules (routing MUST be decidable from schema + AST alone — G4):
+
+- R1: `PointRead` iff every partition key column appears in exactly-one equality
+  conjunct (or one `IN` list). Any partition key column unbound, bound by range, or
+  bound through `OR` → `FullScan`.
+- R2: `IN (k1..kn)` → `PointRead` with n keys, executed as sequential lookups,
+  results concatenated in key order consistent with the compact path's ordering.
+  `VERIFY:` what ordering does the compact path produce for multi-partition results?
+  Match it exactly (G2).
+- R3: Clustering column predicates with a full partition key stay on the fast path:
+  equality/range prefixes become `ClusteringBounds` (seek/stop conditions); anything
+  not expressible as bounds goes to `residual` post-filter.
+- R4: Predicates on regular columns → `residual` post-filter (fast path still valid).
+- R5: Aggregations/`COUNT(*)`/`WRITETIME`/`TTL` projections do not affect routing —
+  they consume the row stream identically on either path. `VERIFY:` confirm
+  projection layer is path-agnostic.
+- R6: Any feature the fast path does not support (discovered at plan or exec time) →
+  fall back to `FullScan`. Fallback is silent for the user, but counted (5.5).
+
+### 5.2 Per-SSTable partition locator (new: `storage/sstable/reader/point_read.rs`)
+
+For each live SSTable generation of the table, locate the partition (or prove
+absence) using TOC component presence to dispatch (G4):
+
+**BIG family (`nb`/`oa`; has `Index.db` + `Summary.db`)** — per format guide Ch.21:
+1. *(Phase: bloom issue)* If `Filter.db` parsed and negative → absent; skip file.
+2. `Summary.db` binary search over decorated keys → `index_offset`.
+3. Sequential `Index.db` entry scan from `index_offset` (u16 key length + raw key +
+   vint data_offset + vint promoted_index_len); compare raw key bytes; skip on
+   mismatch; not found within window → absent (bloom false positive path).
+4. Map `data_offset` to the data stream:
+   - `CompressionInfo.db` present → chunk lookup, decompress only covering chunk(s).
+   - Absent (CQLite-flushed, C6) → direct seek.
+5. Parse exactly one partition via `SerializationHeader`, yielding a
+   **`PartitionRowIterator`** honoring `ClusteringBounds` and `reversed`.
+
+**BTI family (`da`; has `Partitions.db`)** — out of scope here (NG1); locator returns
+`Unsupported` → whole-query fallback to `FullScan` (R6). Follow-up epic implements
+trie `exactCandidate`, sign-bit routing to `Rows.db` vs direct `Data.db`, per Ch.21.
+
+Promoted index / `Rows.db` intra-partition seeking for wide partitions is an
+optimization issue, not required for correctness: v1 may scan the partition from its
+start applying bounds.
+
+### 5.3 Partition-scoped merge (refactor: `storage/write_engine/merge.rs`)
+
+- Extract the reconciliation core (timestamp resolution; partition/row/range
+  tombstone shadowing) so it operates over **N ordered row iterators** rather than
+  whole-SSTable inputs. Compaction becomes "merge over full-table iterators"; point
+  read becomes "merge over per-partition iterators (+ memtable iterator when
+  writable, C7)". One implementation, two callers (G3).
+- Byte-for-byte compaction parity tests MUST still pass after the refactor — this is
+  the highest-risk step and should be its own issue with the parity suite as its
+  gate.
+- Range tombstones spanning clustering bounds are the known bug farm: opening
+  markers before the seek point must still shadow rows inside the bound window.
+  `VERIFY:` how does current merge represent RT bounds? Property tests required
+  (7.3).
+
+### 5.4 Fallback + forcing
+
+- Config/env `CQLITE_READ_PATH=auto|point|compact` (default `auto`).
+  `point` = error if a query can't take the fast path (test mode);
+  `compact` = force legacy path (support/diagnosis mode);
+  `auto` = route per §5.1 with silent fallback.
+- Fast-path execution errors that indicate *unsupported*, not *corrupt* (missing
+  component, unexpected format feature) → transparent per-query fallback to compact.
+  Corruption errors surface as errors on both paths identically.
+
+### 5.5 Observability
+
+- `metrics` feature counters: `read_path.point`, `read_path.full_scan`,
+  `read_path.fallback{reason}`, per-generation `bloom_skip` (later).
+- CLI: `EXPLAIN SELECT ...` (or minimal: `--explain` flag) printing chosen plan,
+  per-SSTable locator outcome, and fallback reason. Even a debug-log line is
+  acceptable for v1; the requirement is that routing is observable (G5).
+
+### 5.6 Latency budget investigation (EXPLORE — feeds A1)
+
+**Observed problem (motivating data point):** single-partition point lookups are
+measured at **150–500 ms per read**. This design assumes the dominant term is
+compact-to-memory scan/merge cost, but that MUST be verified — if a large share is
+per-query setup or bindings overhead, routing alone will not reach the sub-ms target.
+
+A1 SHALL produce an end-to-end latency budget for one representative point read,
+decomposed into at least:
+
+1. **Session/setup:** file open, TOC/Statistics.db/Summary parse, schema resolution,
+   reader-state construction. Is any of this repeated per `execute()` within an open
+   Database/REPL session? (CLI one-shot mode pays full process + setup cost every
+   invocation and must be excluded from — or reported separately in — the budget.)
+2. **Scan/merge:** decompression + partition iteration + k-way merge (the cost this
+   design eliminates for point reads).
+3. **Projection/conversion:** row materialization, value formatting, and (when
+   measured through bindings) CQL→Python/JS conversion.
+
+Diagnostics (record method + numbers in the A1 findings on #942):
+
+- **Size-scaling check:** identical point lookup against a small table vs a large
+  one. Latency proportional to table size ⇒ scan-dominated ⇒ this design is the fix.
+  Flat-but-slow ⇒ setup-dominated ⇒ see contingency below.
+- **Flamegraph:** `./scripts/profile.sh flame` under a repeated single-partition
+  query; attribute samples to the three buckets above (expect
+  `v5_compressed_legacy.rs` iteration + merge frames if scan-dominated).
+- **Generation sensitivity:** same lookup at 1 vs N SSTable generations.
+
+**Contingency (in scope to spec, out of scope to build until data says so):** if
+setup dominates, add an issue for cached reader/index state across queries within an
+open session (Summary/index metadata, open file handles, decompression scratch) —
+complementary to routing, and likely required to hit sub-ms even with the fast path.
+Benchmarks in D2 SHALL report warm-session latency (excluding one-time open cost)
+as the primary metric, with cold/one-shot reported separately.
+
+## 6. Requirements (OpenSpec spec-delta form)
+
+### Requirement: Single-partition query routing
+The query engine SHALL classify each SELECT into `PointRead` or `FullScan` using only
+the resolved schema and query AST, per rules R1–R6.
+
+#### Scenario: Full partition key equality
+- **WHEN** a SELECT binds every partition key column with `=`
+- **THEN** the engine executes it via the point-read path
+- **AND** the result is byte-identical to the compact-to-memory path's result
+
+#### Scenario: Partial partition key
+- **WHEN** a SELECT binds only a proper subset of partition key columns
+- **THEN** the engine executes it via the compact-to-memory path unchanged
+
+#### Scenario: IN on partition key
+- **WHEN** a SELECT binds the partition key via `IN` with n values
+- **THEN** the engine executes n point lookups and returns results in the same order
+  the compact path would produce
+
+### Requirement: Result equivalence
+For every query in the validation corpus, output via the point-read path SHALL be
+identical to output via the compact path (rows, values, order, WRITETIME/TTL).
+
+#### Scenario: Differential corpus run
+- **WHEN** the full 33-table corpus query suite runs under `CQLITE_READ_PATH=point`
+  and `CQLITE_READ_PATH=compact`
+- **THEN** normalized outputs are equal for every table and query
+
+### Requirement: Multi-generation reconciliation
+A point read over a table with multiple SSTable generations (and a memtable when
+writable) SHALL reconcile rows and tombstones through the same merge implementation
+used by compaction.
+
+#### Scenario: Shadowed row across generations
+- **WHEN** generation 2 contains a row tombstone shadowing a row in generation 1 for
+  the queried partition
+- **THEN** the point read returns no such row, matching the compact path
+
+#### Scenario: Range tombstone spanning clustering bounds
+- **WHEN** a range tombstone opens before the queried clustering bound and closes
+  inside it
+- **THEN** rows within the shadowed range are absent from point-read results
+
+### Requirement: Authoritative-metadata routing (no heuristics)
+Index-family dispatch SHALL be driven by TOC component presence and version gates
+(`BigVersionGates`/`BtiVersionGates`); the engine SHALL NOT infer format or routing
+from data-byte patterns.
+
+#### Scenario: BTI table encountered (this change)
+- **WHEN** a point-read-eligible query targets a `da` (BTI) table
+- **THEN** the engine falls back to the compact path and increments
+  `read_path.fallback{reason="bti_unsupported"}`
+
+### Requirement: Uncompressed-generation support
+The point-read path SHALL read partitions from generations lacking
+`CompressionInfo.db` (CQLite-flushed) and generations with it (Cassandra-written)
+within the same query.
+
+#### Scenario: Mixed generations
+- **WHEN** a queried partition has fragments in one compressed and one uncompressed
+  generation
+- **THEN** the point read merges both fragments correctly
+
+### Requirement: Fallback safety
+Unsupported constructs discovered at plan or execution time SHALL cause transparent
+fallback to the compact path with an observable reason; correctness SHALL never
+depend on the fast path.
+
+### Requirement: Observability and forcing
+The engine SHALL expose the chosen path (metrics and/or EXPLAIN output) and honor
+`CQLITE_READ_PATH=auto|point|compact`.
+
+### Requirement: Performance evidence
+The change SHALL include criterion benchmarks demonstrating, on a large corpus table:
+point-read latency reduction and peak-RSS reduction vs the compact path, recorded via
+`scripts/profile.sh` baseline/compare.
+
+## 7. Validation Plan
+
+1. **Differential corpus test (primary gate):** run the corpus (per
+   `CQLITE_DATASETS_ROOT`) through both forced paths; assert normalized equality.
+   Wire as an integration test target alongside the golden-path suites; agent-gate
+   must include it.
+2. **Golden-path extension:** new `golden_path_point_read_tests.rs` covering: found /
+   not-found / bloom-false-positive-analog (key between index entries), first/last
+   partition in file, single-row and wide partitions, reversed reads, LIMIT.
+3. **Merge property tests:** randomized generations (timestamps, row/range
+   tombstones, static rows, clustering orders); invariant: partition-scoped merge
+   result == compact-path result for that partition. This is the guard for the §5.3
+   refactor.
+4. **Compaction parity regression:** the existing byte-for-byte compaction parity
+   suite must pass unchanged after the merge refactor (proves G3 didn't break the
+   writer side).
+5. **Bindings parity:** existing Python/CLI parity tests rerun with
+   `CQLITE_READ_PATH=point` in a slow-test lane (`RUN_SLOW_TESTS=1`).
+6. **Benchmarks:** criterion point-read benches (small partition, wide partition,
+   multi-generation) + dhat heap check vs the <128 MB budget; store baseline via
+   `./scripts/profile.sh baseline`.
+
+## 8. Epic / Issue Breakdown
+
+Sized for the repo's 1:1:1:1 model (one issue ↔ one branch ↔ one OpenSpec change ↔
+one PR). Suggested labels: `enhancement`, inherit P2; epics ordered by dependency.
+
+### Epic A — Verification & plan layer (unblocks everything)
+- **A1. Code archaeology spike (timeboxed):** resolve C1–C8 in §4 **and produce the
+  §5.6 latency budget for the observed 150–500 ms point reads**; post findings on
+  #942; amend this design. *Deliverable: updated design doc + measured latency
+  decomposition; no production code.*
+- **A2. `ReadPlan` classification:** implement §5.1 with exhaustive unit tests over
+  AST shapes (R1–R6). No execution changes; `PointRead` temporarily executes by
+  delegating to compact path (wiring proof).
+- **A3. Path forcing + observability:** `CQLITE_READ_PATH`, metrics counters,
+  minimal EXPLAIN/debug output. *Depends: A2.*
+
+### Epic B — BIG point-read execution
+- **B1. Partition locator API:** wrap/extract existing Summary→Index lookup (C1)
+  behind `locate_partition(&self, key) -> Located | Absent | Unsupported` in new
+  `point_read.rs`. *Depends: A1.*
+- **B2. Single-partition iterator:** "parse one partition at offset" entry into the
+  V5 parser as a new module (respect file-size ratchet on
+  `v5_compressed_legacy.rs`), honoring clustering bounds + reversed; handles
+  compressed and uncompressed generations (C6). *Depends: B1. Likely the largest
+  issue — split bounds/reversed into B2b if needed.*
+- **B3. Wire `PointRead` single-generation:** planner → locator → iterator →
+  projection for tables with exactly one generation and no memtable; differential
+  test on corpus (most corpus tables are single-generation). *Depends: A2, A3, B2.*
+
+### Epic C — Multi-source reconciliation
+- **C1. Merge refactor to iterator inputs:** §5.3; compaction parity suite is the
+  gate; zero behavior change intended. *Depends: A1. Can proceed parallel to Epic B.*
+- **C2. Partition-scoped merge in point path:** N generations + memtable (C7);
+  property tests §7.3; tombstone scenarios §6. *Depends: B3, C1.*
+- **C3. LIMIT early termination + IN execution order parity.** *Depends: C2.*
+
+### Epic D — Proof & release
+- **D1. Differential corpus test in agent-gate + CI.** *Depends: B3 (runs single-gen
+  subset), extended after C2.*
+- **D2. Benchmarks + profile baselines + report** (numbers for the PR/release
+  notes). *Depends: C2.*
+- **D3. Docs:** user-docs page on read paths + EXPLAIN; format-guide cross-links;
+  limitations page updated (BTI fallback). *Depends: C2.*
+
+### Epic E — Follow-ups (separate from #942 closure)
+- **E1. BTI (`da`) fast path** per Ch.21 (trie exactCandidate, Rows.db routing) —
+  gated on C4 findings.
+- **E2. Filter.db bloom check** with per-generation skip metrics — gated on C5.
+- **E3. Promoted-index / intra-partition seek for wide partitions.**
+- **E4. Retire compact-to-memory for point reads entirely?** Only after E1/E2 mature
+  (keep as forced fallback regardless).
+
+**Definition of done for #942:** Epics A–D merged; differential corpus green in CI;
+benchmarks show latency and RSS wins; BTI + bloom follow-ups filed under Epic E.
+
+## 9. Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Merge refactor (C1) breaks byte-for-byte compaction parity | Release-blocking regression | Parity suite as the issue's gate; zero-behavior-change PR isolated from feature PRs |
+| V5 parser not factorable for single-partition entry without large diff | Schedule; file-size ratchet friction | A1 spike answers early; new module + minimal seams into existing parser |
+| Range-tombstone edge cases under clustering bounds | Silent wrong results | Property tests before wiring bounds; residual-filter-only v1 if bounds seek slips |
+| Ordering mismatch on IN / multi-key results | Differential test failures late | Pin compact-path ordering in A1; encode in R2 test first |
+| Source-map staleness (BTI actually complete?) | Wasted fallback work or wrong scoping | A1 resolves C4 before Epic E scoping |
+
+## 10. Open Questions (resolve during A1 / grooming)
+
+- **OQ-1:** Does Filter.db parsing exist anywhere in `cqlite-core`? (C5)
+- **OQ-2:** True state of BTI read path in v0.12.0 — is E1 small or large? (C4)
+- **OQ-3:** Where exactly does compact-to-memory live, and is it also the path the
+  bindings use? (Bindings must route identically.)
+- **OQ-4:** Memtable read semantics in `--writable` mode today. (C7)
+- **OQ-5:** Should EXPLAIN be real CQL-surface syntax (design-driven → its own
+  OpenSpec change?) or a CLI flag for now? Recommend CLI flag in A3, EXPLAIN as
+  possible E-epic.
+- **OQ-6:** Does the `state_machine` feature gate the query engine such that the
+  plan layer must live behind it? (Feature-flag placement for minimal builds.)
+- **OQ-7:** What fraction of the observed 150–500 ms point-read latency is per-query
+  setup vs scan/merge vs conversion (§5.6)? If setup-dominated, does a
+  session-cached reader-state issue need to join Epic B as a peer deliverable for
+  the sub-ms target?
+
+## 11. References
+
+- Issue #942; issue #1406 (uncompressed write claim boundary); epic #1116 (file-split
+  doctrine)
+- Format guide: Ch.6 (Index/Summary), Ch.7 (Filter.db), Ch.9 (CompressionInfo),
+  Ch.10 (Point Reads and Slices), Ch.11 (Merging/Tombstones/Shadowing), Ch.17 (BTI),
+  Ch.21 (row-by-key flow card), Appendix F (known limitations)
+- Source map: `cqlite-core/src/query/`, `storage/sstable/reader/parsing/
+  v5_compressed_legacy.rs`, `storage/sstable/bti/`, `storage/write_engine/merge.rs`
+- Existing tests: `cqlite-integration-tests/tests/golden_path_*.rs`
+- Cassandra 5.0 source: `BigTableReader.java` (#L298–325 index entry scan),
+  `IndexSummary.java` (#L127–152 binary search), `BtiTableReader.java`,
+  `TrieIndexEntry.java`, `UnfilteredSerializer.java`
+- Doctrine: no-heuristics mandate, gate contract, file-size ratchet, validation
+  playbook (agents-developing site)

--- a/docs/compaction-manager-design.md
+++ b/docs/compaction-manager-design.md
@@ -1,0 +1,283 @@
+# Design: Standalone Compaction Manager for CQLite
+
+**Issue:** [#905](https://github.com/pmcfadin/cqlite/issues/905)
+**Status:** Draft for discussion
+**Depends on:** M5 (SSTable write support) for the executor; the planner and simulator have no write dependency.
+
+## 1. Summary
+
+This document proposes a compaction subsystem for CQLite built as three layers: a **planner** (a pure-function implementation of compaction strategies, starting with UCS), an **executor** (a k-way merge engine that reads N sstables and writes their merged replacement via the M5 writer), and a **manager** (a long-running process that schedules and throttles compaction work over one or more table directories). Each layer is independently useful and ships in that order.
+
+The design deliberately inverts a Cassandra assumption: compaction here is an *offline, standalone* operation over files on disk, with no live node, no memtables, and no cluster membership. That constraint is what makes the tool simple, but it also changes the correctness rules — particularly around tombstone garbage collection — and those changes are treated as first-class design decisions rather than caveats.
+
+## 2. Motivation and use cases
+
+CQLite's current design philosophy is "single sstable per table, no compaction complexity." Two forces make that untenable to hold forever. First, M5 introduces write support: once CQLite can create sstables, any workload with ongoing writes produces many of them, and read performance degrades linearly with sstable count until something merges them. Second — and independently — there is a standing operational gap in the Cassandra ecosystem that a standalone compactor fills:
+
+**Snapshot and backup hygiene.** A node's snapshot contains hundreds of sstables accumulated across compaction generations, full of shadowed data and expired tombstones. Compacting a snapshot offline before archiving or restoring it can shrink it dramatically and speeds up every downstream consumer.
+
+**Analytics pre-merge.** CQLite's export path (Parquet, CSV, CQL) currently reads sstables as-is. Merging to a canonical view first — one pass that resolves timestamps and tombstones — makes exports both smaller and semantically correct without every export format reimplementing reconciliation.
+
+**Compaction offload (future).** Compaction inside a Cassandra node competes with reads for CPU, page cache, and disk bandwidth. A standalone compactor with its own resource envelope (its own cgroup, its own machine, its own throttle) is the building block for offloading that work entirely — ship sstables out, compact on cheap hardware, ship results back. This design does not implement offload, but takes care not to foreclose it.
+
+**Strategy research and tuning.** Because the planner is a pure function over sstable metadata, it doubles as a simulator: replay a strategy against a real directory or a synthetic workload and measure write amplification, space amplification, and sstable count over time — without touching any data. No standalone tool like this exists today.
+
+**CQLite-native tables.** Post-M5, CQLite's own write path needs background compaction. The manager is that component.
+
+## 3. Goals and non-goals
+
+Goals:
+
+- Implement UCS (Unified Compaction Strategy) as the first and default strategy, behind a strategy trait that third parties can implement.
+- Merge semantics that are bit-for-bit faithful to Cassandra 5 reconciliation: last-write-wins by timestamp, row and range tombstone shadowing, TTL expiry, static rows.
+- Output sstables in valid Cassandra 5 'oa' format, so compacted data can be handed back to a cluster (`nodetool import` / sstableloader workflows).
+- Crash safety: an interrupted compaction never leaves a table directory in an ambiguous or data-losing state.
+- Explicit, user-controlled tombstone GC with safe defaults.
+- Deterministic, offline operation: given the same files and config, a run is reproducible; no network access in the compaction path.
+
+Non-goals (v1):
+
+- Compacting files under a **live Cassandra node's data directory**. Cassandra owns those files through its own lifecycle transaction machinery; external modification corrupts node state. The tool operates on snapshots, backups, offline data directories, and CQLite-native tables only, and should refuse or loudly warn when it detects a live node (e.g. presence of `*.log` lifecycle transaction files with recent mtimes).
+- Distributed coordination between multiple compactor instances.
+- Strategies other than UCS (the trait allows them; we do not commit to shipping them).
+- Anti-compaction, repair awareness, or pending-repair sstable handling.
+
+## 4. Background (short version)
+
+Readers familiar with LSM compaction and UCS can skip to §5. A fuller UCS primer is in Appendix A.
+
+Cassandra tables are log-structured: writes accumulate in immutable sstables, and a row's current value is the timestamp-wise merge of its fragments across all sstables that contain it. Deletes are writes too — tombstones — which must persist long enough to propagate to all replicas before they can be purged. Compaction is the background process that merges sstables, discarding shadowed data and expired tombstones, trading **write amplification** (rewriting data repeatedly) against **read amplification** (consulting many sstables per read) and **space amplification** (retaining dead data).
+
+Classic Cassandra strategies pick different points on that triangle. STCS (size-tiered) merges similarly-sized sstables — cheap writes, poor reads and space. LCS (leveled) maintains non-overlapping runs per level — great reads, expensive writes. TWCS specializes for time-series. **UCS**, introduced in Cassandra 5, unifies tiered and leveled behavior under one algorithm with a per-level scaling parameter, so a single implementation can express the whole spectrum (T4 ≈ STCS, L10 ≈ LCS) and even mix regimes across levels. Implementing UCS once gives us the practical coverage of implementing all three classic strategies, which is why it goes first.
+
+The one Cassandra concept UCS adds that matters to our data model: sstables are bucketed by **density** (data size divided by the fraction of the token space the sstable spans), not raw size, so the planner needs each sstable's token range — which CQLite already parses from `Statistics.db`.
+
+## 5. Architecture overview
+
+```
+┌───────────────────────────────────────────────────────┐
+│ Layer 3 · cqlite-compactd (manager)                   │
+│ discovery · scheduler · throttle · control API        │
+└──────────────────────────┬────────────────────────────┘
+┌──────────────────────────┴────────────────────────────┐
+│ Layer 2 · cqlite-compaction (library)                 │
+│ planner (strategy trait, UCS) · executor · simulator  │
+└───────────┬──────────────────────────────┬────────────┘
+┌───────────┴───────────┐      ┌───────────┴────────────┐
+│ Layer 1 · reader      │      │ Layer 1 · writer (M5)  │
+│ cqlite-core, shipped  │      │ hard dependency        │
+└───────────────────────┘      └────────────────────────┘
+```
+
+The library layer is the product; the CLI (`cqlite compact`, `cqlite simulate`) and the daemon are thin shells over it. The planner never performs I/O. The executor performs all I/O but makes no decisions about *what* to compact. This separation is the "more modular" answer to Cassandra, where strategy logic is entangled with `ColumnFamilyStore`, disk boundaries, and the live tracker, and cannot be exercised without most of a node running.
+
+## 6. The planner
+
+### 6.1 Strategy as a pure function
+
+A strategy consumes an immutable snapshot of table state and returns proposed jobs. It performs no I/O, holds no locks, and has no side effects. This is the load-bearing decision in the whole design: it makes strategies unit-testable with fabricated metadata, makes third-party strategies possible without exposing internals, and makes the simulator (§12) nearly free.
+
+```rust
+pub trait CompactionStrategy: Send + Sync {
+    /// Propose zero or more compaction jobs for the current state.
+    /// Must be deterministic for a given (state, config) pair.
+    fn plan(&self, state: &TableState) -> Vec<CompactionJob>;
+
+    /// Human-readable explanation of why each job was (or wasn't) proposed.
+    /// Powers `--dry-run --explain` and the simulator's reporting.
+    fn explain(&self, state: &TableState) -> PlanReport;
+}
+
+pub struct TableState {
+    pub sstables: Vec<SSTableMeta>,
+    pub schema: TableSchema,          // parsed from schema.cql
+    pub now: Timestamp,               // injected, never read from the clock
+}
+
+pub struct SSTableMeta {
+    pub id: SSTableId,
+    pub data_size: u64,
+    pub first_token: Token,
+    pub last_token: Token,            // density = size / token span covered
+    pub min_timestamp: Timestamp,
+    pub max_timestamp: Timestamp,
+    pub estimated_droppable_tombstones: f64,
+    pub level_hint: Option<u32>,      // from Statistics.db when present
+}
+
+pub struct CompactionJob {
+    pub inputs: Vec<SSTableId>,
+    pub kind: JobKind,                // Merge | SplitShard | TombstoneOnly
+    pub priority: Priority,
+    pub estimated_output_size: u64,
+    pub output_shards: u32,           // UCS sharding, 1 = single output
+}
+```
+
+`now` being injected rather than read from the clock is deliberate: it keeps runs reproducible and lets the simulator fast-forward time.
+
+### 6.2 UCS specifics
+
+The UCS implementation follows Cassandra 5's model: sstables are grouped into levels by density, each level has a scaling parameter (`T*` tiered-leaning, `L*` leveled-leaning, `N` neutral), and a level triggers a merge when its bucket exceeds the parameter's threshold. Configuration mirrors Cassandra's so that settings can be copied verbatim from `system_schema.tables`:
+
+```toml
+[table."ks.events".compaction]
+strategy            = "ucs"
+scaling_parameters  = ["T4", "T4", "L8"]  # per level; last value repeats
+target_sstable_size = "1GiB"
+base_shard_count    = 4
+```
+
+One scenario Cassandra never faces but we hit on day one: the input directory was usually produced by **some other strategy** — years of STCS output in a snapshot, say. Convergence from an arbitrary legacy layout to the target UCS shape is therefore a first-class planner mode, not an edge case. A one-shot `cqlite compact` run plans the full convergence (possibly as a sequence of jobs to bound peak disk usage); the long-running manager then does incremental maintenance. The simulator can cost a convergence before you commit to it.
+
+### 6.3 Major compaction
+
+`JobKind::Merge` over all live sstables, sharded per UCS output rules. This is also the degenerate strategy used by the phase-1 CLI before the UCS planner lands: "merge everything into one (or N sharded) sstables" requires the executor only.
+
+## 7. The executor
+
+### 7.1 Merge
+
+The executor opens the job's input sstables and drives a k-way merge iterator in (partition key, clustering key) order — the same shape as CQLite's existing multi-sstable read path, if one exists post-M3 tombstone work, and shared with it where possible. Reconciliation follows Cassandra semantics exactly: cell-level last-write-wins by timestamp (ties broken by value, matching Cassandra), row tombstones and range tombstones shadow older data, TTL'd cells convert to tombstones at expiry, static rows merge per-partition. Output rows stream directly into the M5 writer; memory stays bounded by the merge heap plus writer buffers regardless of input size, consistent with the project's <128MB target.
+
+### 7.2 Tombstone purge and the overlap invariant
+
+Whether a tombstone can be *dropped* (rather than carried forward) is governed by two independent checks, and conflating them is the classic way to resurrect deleted data:
+
+1. **Age:** the tombstone's local deletion time is older than `gc_grace_seconds` (see §8 for where that value comes from).
+2. **Overlap:** no sstable *outside the job's input set* contains data for the same partition older than the tombstone. Dropping a tombstone while an excluded sstable still holds the data it shadows resurrects that data on the next read.
+
+Check 2 is a hard invariant in **every** GC mode, including `authoritative`. The modes in §8 control check 1's policy; nothing controls check 2 — it is always enforced, using min/max token ranges and, where necessary, partition-level bloom/index probes against the excluded set. Standalone usage makes this more important than in Cassandra, not less, because users will naturally run partial compactions ("just merge these three files").
+
+### 7.3 Atomicity and crash safety
+
+A compaction transaction proceeds as: write outputs to a `tmp-<uuid>/` directory inside the table dir → fsync all components → append a commit record to a small transaction log (`compaction-<uuid>.txn`) naming inputs and outputs → atomically rename outputs into place → delete inputs → delete the log. On startup (or `cqlite compact --repair-log`), an incomplete log is rolled back (delete temps, keep inputs) if no commit record exists, or rolled forward (finish renames/deletions) if one does. This is a simplified version of Cassandra's lifecycle transaction log, and it is the reason the tool must never run against a live node's directory — two writers of this protocol cannot coexist.
+
+### 7.4 Resource isolation
+
+"Isolated" in the issue is read as *resource* isolation. The executor exposes a bytes-per-second throttle and a concurrency limit as library-level knobs; everything stronger comes free from being a separate OS process — cgroups, `nice`/`ionice`, or simply running on a different machine against a snapshot. The design assumes nothing about locality beyond "inputs are readable, output dir is writable," which is what keeps the future offload scenario open.
+
+## 8. Tombstone GC modes and gc_grace resolution
+
+Standalone compaction cannot know whether a tombstone has propagated to all replicas, so the user must choose a policy. Three modes:
+
+- **`off`** (default): never drop tombstones; pure merge. Always safe, still removes shadowed data, which is usually most of the win.
+- **`grace`**: drop tombstones older than `gc_grace_seconds`, subject to the overlap invariant. Matches a node's local behavior and inherits the same repair-related risks — the doc for this flag says so.
+- **`authoritative`**: the user asserts this dataset is the complete truth (a full-cluster export, or a CQLite-native table with no replicas). Grace is ignored; the overlap invariant is not.
+
+`gc_grace_seconds` resolves with the following precedence (highest wins):
+
+1. CLI flag (`--gc-grace 864000`)
+2. Config file (`[table."ks.events".gc] gc_grace_seconds = ...`)
+3. `schema.cql` table property (`WITH gc_grace_seconds = N`) — the free win, since CQLite already parses this file
+4. Cassandra's default (864000, 10 days) with a warning that no explicit value was found
+
+To keep the compaction path offline and deterministic, fetching values from a live cluster is a **separate command**, not part of compaction:
+
+```
+cqlite schema pull --contact-points node1:9042 --keyspace ks --table events
+```
+
+This connects over the native protocol, reads `system_schema.tables` (which carries `gc_grace_seconds` *and* the live compaction params), and writes/updates the local `schema.cql` and config — meaning "match what the cluster does" is one command away, after which every run is reproducible from files on disk. The CQL driver dependency lives behind a `cluster-sync` feature flag so the core library stays dependency-lean.
+
+## 9. Configuration
+
+One TOML file, per-table sections, everything overridable per-invocation. Complete example:
+
+```toml
+# cqlite-compaction.toml
+
+[defaults]
+throughput_limit = "64MiB/s"
+concurrent_jobs  = 2
+
+[table."ks.events"]
+schema   = "schemas/events.cql"
+data_dir = "data/ks/events"
+
+[table."ks.events".compaction]
+strategy            = "ucs"
+scaling_parameters  = ["T4", "T4", "L8"]
+target_sstable_size = "1GiB"
+base_shard_count    = 4
+
+[table."ks.events".gc]
+mode             = "grace"        # off | grace | authoritative
+gc_grace_seconds = 864000         # optional; overrides schema.cql
+```
+
+## 10. CLI surface
+
+```
+cqlite compact <table-dir> [--config f] [--strategy ucs|major]
+               [--gc-mode off|grace|authoritative] [--gc-grace SECS]
+               [--dry-run [--explain]] [--throughput 64MiB/s] [--jobs N]
+
+cqlite simulate <table-dir | --synthetic workload.toml>
+               [--strategy-config f] [--steps N] [--report json|table]
+
+cqlite schema pull --contact-points h:9042 --keyspace ks --table t [--out dir]
+
+cqlite compact --repair-log <table-dir>     # recover interrupted transaction
+```
+
+`--dry-run` runs the planner only and prints the jobs it would execute; `--explain` adds the strategy's reasoning per bucket (from `PlanReport`). These two flags are cheap because of the pure-planner design and are expected to be the most-used flags in practice.
+
+## 11. The manager (`cqlite-compactd`)
+
+A long-running process wrapping the library: it discovers table directories (explicit config list first; filesystem watching later), runs a plan/execute loop per table, and enforces global limits — max concurrent jobs, aggregate throughput, and a disk-headroom guard that refuses jobs whose estimated output would drop free space below a threshold. A small HTTP endpoint serves status (per-table pending/running jobs, progress, bytes compacted), Prometheus-format metrics, and pause/resume. Deliberately boring: all interesting logic lives in the library, and the daemon must stay simple enough to reason about in a crash loop.
+
+## 12. The simulator
+
+`plan()` being pure over `TableState` means simulation is a loop, not a subsystem: synthesize or ingest a starting state, apply the planner, apply each job's *predicted* effect to the metadata (no data touched), inject new "flushed" sstables per a workload model, advance `now`, repeat. Reported per run: cumulative write amplification, space amplification over time, sstable count over time, and largest transient disk requirement. Primary uses: costing a legacy-layout convergence before running it (§6.2), and comparing scaling parameters against a real directory's shape. This is the piece with no existing standalone equivalent in the ecosystem and is a strong candidate for the first public demo.
+
+## 13. Safety invariants (normative)
+
+1. Never modify a directory that shows signs of a live Cassandra node; refuse by default, proceed only with `--force-unsafe`.
+2. Inputs are never deleted before outputs are durably committed (fsync + txn log commit record).
+3. The tombstone overlap check (§7.2) is enforced in every GC mode without exception.
+4. In `off` mode, the merged output is read-equivalent to the input set: any query returns identical results before and after.
+5. A killed process leaves the directory recoverable by `--repair-log` to a state equivalent to either "job never ran" or "job completed" — never in between.
+6. The compaction path performs no network I/O.
+
+Invariant 4 is testable property-based: generate random sstable sets with the existing test-data tooling, compact, and diff full-table reads. This should be the backbone of the executor's test suite.
+
+## 14. Phasing
+
+**Phase A — executor + major compaction** (needs M5 writer): `cqlite compact --strategy major`, GC modes, txn log, throttle. Immediately useful for snapshot hygiene and pre-export merge. Forces the tombstone-semantics work early, where it belongs.
+
+**Phase B — UCS planner + simulator** (no writer dependency; can proceed in parallel with M5): strategy trait, UCS with density bucketing and legacy-layout convergence, `--dry-run/--explain`, `cqlite simulate`.
+
+**Phase C — manager daemon**: scheduling loop, global limits, status/metrics API, pause/resume.
+
+**Phase D (exploratory) — cluster sync & offload groundwork**: `schema pull`, and validation that round-tripped sstables import cleanly into a live Cassandra 5 cluster.
+
+## 15. Open questions
+
+- Should `schema pull` seed the UCS config from the cluster's live compaction params by default (making "match the cluster" the zero-config behavior), or stay copy-only?
+- Sharding fidelity: do we replicate UCS's shard-boundary computation exactly (bit-compatible output layout with what a node would produce), or is "valid oa format, sensible shards" sufficient for v1?
+- How much of the tombstone-merge machinery currently behind the `tombstones` feature flag is reusable as the executor's reconciliation core, versus needing a rewrite for streaming writes?
+- Does `estimated_droppable_tombstones` from Statistics.db carry enough signal to justify `JobKind::TombstoneOnly` (single-sstable rewrite) in v1, or defer?
+- Minimum viable overlap check: token-range intersection only (coarse, may retain some droppable tombstones) vs. per-partition index probes (precise, slower). Propose coarse for v1 with the precise path behind a flag.
+
+## Appendix A — UCS primer
+
+*Background for readers who have not worked with Cassandra 5's Unified Compaction Strategy. Nothing here is normative.*
+
+**The problem UCS solves.** Cassandra historically shipped separate strategies occupying fixed points on the write/read/space-amplification triangle, and switching between them was disruptive (a full rewrite of the table's layout). UCS's insight is that tiered and leveled compaction are the same algorithm with one parameter flipped — how many sstables (or "runs") you tolerate per size class before merging.
+
+**Density, not size.** UCS classifies sstables into levels by *density*: data size divided by the fraction of the token space the sstable covers. A 1 GiB sstable spanning the whole ring and a 256 MiB sstable spanning a quarter of it have the same density and belong to the same level. This matters because UCS also *shards* output: big compactions split their output at token boundaries into multiple sstables, which caps individual file size and increases parallelism. Raw size would misclassify those shards; density classifies them correctly. Consequence for any implementation: the planner must know each sstable's first/last token, not just its byte size.
+
+**Scaling parameters.** Each level gets a parameter from an integer `w`, written in operator-friendly form:
+
+| Notation | Meaning | Behaves like |
+|---|---|---|
+| `T4`, `T10`, … | tiered with fan-out F = value; merge when F sstables accumulate in a level | STCS (T4 ≈ classic STCS) |
+| `N` | neutral, F = 2 | middle ground |
+| `L4`, `L10`, … | leveled with fan-out F = value; merge as soon as 2 runs exist in a level | LCS (L10 ≈ classic LCS) |
+
+Higher `T` values favor cheap writes and tolerate more sstables per read (bounded read amplification per level ≈ F−1 for tiered, 1 for leveled). A common production pattern is tiered at low levels (absorb flush churn cheaply) and leveled at high levels (where data is cold and read amplification hurts most) — e.g. `["T4","T4","L8"]`. The parameter list applies per level, with the last value repeating for all deeper levels.
+
+**Why UCS first for CQLite.** One implementation covers the practical behavior space of STCS, LCS, and much of what people use TWCS for; its configuration is directly copyable from a Cassandra 5 cluster's schema; and it is the strategy the Cassandra project itself is converging on, which matters for a project intended for eventual donation. The costs are the density/sharding machinery (modest, since CQLite already parses the needed metadata) and slightly harder mental model for contributors, which this appendix exists to offset.
+
+**Further reading.** CEP-26 (Unified Compaction Strategy), the Cassandra 5 documentation on UCS, and `UnifiedCompactionStrategy.java` in the Cassandra source tree are the authoritative references for the bucketing and shard-boundary math; this design intentionally defers bit-level fidelity questions to §15.

--- a/docs/presentations/cqlite-parquet-arrow-flight.md
+++ b/docs/presentations/cqlite-parquet-arrow-flight.md
@@ -1,0 +1,246 @@
+# CQLite: Parquet & Arrow Support
+
+### Reading Cassandra SSTables directly into the analytics stack — Parquet files, Arrow over gRPC, and Arrow Flight → Trino
+
+> Speaker deck. Each slide has **talking points** plus a **Graphic** block describing the visual to build in PowerPoint/Keynote/Google Slides. Code/paths are real and current as of June 2026.
+
+---
+
+## Slide 1 — Title / The Problem
+
+**Title:** Querying Cassandra without querying Cassandra
+
+**Talking points**
+- Cassandra is built for OLTP: low-latency point reads/writes. Analytics scans steal that capacity — coordinator hops, read repair, GC pressure on production nodes.
+- The data already lives on disk as immutable **SSTables**. What if analytics tools read those files directly, off the hot path?
+- CQLite reads Cassandra 5.0 SSTables with **no cluster dependency**. New work (Epic #682 + the Flight/Trino effort) turns that reader into two analytics on-ramps:
+  1. **Parquet/Arrow export** — materialize SSTable data as columnar files.
+  2. **Arrow Flight sidecar** — stream SSTable data live to Trino over gRPC.
+
+**Graphic**
+- Split-screen contrast. Left half labeled "Today": a Trino/Spark icon arrow piercing a Cassandra cluster, red "OLTP contention" warning badge on the nodes. Right half labeled "With CQLite": the same analytics engines reading from a stack of SSTable file icons (Data.db / Index.db / Statistics.db), Cassandra nodes shown calm/green and untouched.
+- Bottom ribbon with the CQLite wordmark and the two on-ramps as pills: `Parquet/Arrow files` and `Arrow Flight → Trino`.
+
+---
+
+## Slide 2 — Layered Architecture Overview
+
+**Title:** One reader, two output paths
+
+**Talking points**
+- Everything sits on the **CQLite core reader** (`cqlite-core`): parses Data.db rows, decodes CQL types with authoritative schema metadata (no type guessing).
+- One shared conversion layer — **CQL → Arrow** (`cqlite-core/src/export/arrow_convert.rs`) — feeds both outputs. Write the type mapping once, reuse everywhere.
+- Path A (batch): Arrow RecordBatch → **Parquet file** (`export/parquet.rs`), exposed via CLI, Python, Node.
+- Path B (live): Arrow RecordBatch → **Arrow Flight gRPC stream** (`cqlite-flight` crate) → **Trino connector** (Java).
+- Feature-gated: `arrow` and `parquet` are off by default, so the base library's dependency surface is unchanged.
+
+**Graphic**
+- Horizontal layer cake, bottom to top:
+  1. **SSTables** (file icons).
+  2. **CQLite core reader** — "row reconstruction + CQL type decode".
+  3. **CQL → Arrow conversion** (`arrow_convert.rs`) — highlight this as the shared hinge, centered, with two arrows fanning upward.
+  4. Branch left: **Parquet writer** → `.parquet` file icon → consumers (DuckDB, Spark, pandas).
+  5. Branch right: **Arrow Flight server** → gRPC cloud → **Trino connector** → Trino SQL.
+- Color the shared `arrow_convert.rs` block distinctly (e.g., gold) to emphasize reuse. Annotate feature flags `arrow` / `parquet` as small toggle chips on the relevant blocks.
+
+---
+
+## Slide 3 — Reading the SSTable → Arrow
+
+**Title:** From bytes to columns
+
+**Talking points**
+- A query result is **row-oriented** (`QueryRow` objects with decoded partition key, clustering, regular columns). Arrow/Parquet are **column-oriented**. The conversion transposes.
+- Two-step public API in `arrow_convert.rs`:
+  - `build_arrow_schema(columns)` → derives the Arrow `Schema` from CQL column metadata.
+  - `rows_to_record_batch(columns, rows)` → builds one `RecordBatch` (column arrays).
+- **High-fidelity mapping**: when a column carries its CQL type, we map to the precise Arrow type, not a generic blob. Recursive — handles nested collections, tuples, UDTs. `Frozen<T>` unwraps transparently.
+- No-heuristics mandate honored: types come from schema, never inferred from byte patterns.
+
+**Graphic**
+- Left: a small grid of 3 logical rows (row-major) with cells colored by column.
+- Center: a rotating/transpose arrow labeled "transpose: row → column".
+- Right: the same data as Arrow columnar arrays (each column a vertical contiguous buffer), stacked into a labeled `RecordBatch`.
+- Callout box listing the two functions `build_arrow_schema()` and `rows_to_record_batch()` with their crate path `cqlite-core/src/export/arrow_convert.rs`.
+
+---
+
+## Slide 4 — CQL → Arrow Type Mapping
+
+**Title:** Type fidelity, not lossy blobs
+
+**Talking points**
+- The mapping is the heart of correctness. A few highlights:
+  - Scalars: `int→Int32`, `bigint→Int64`, `boolean→Boolean`, `text→Utf8`, `blob→Binary`.
+  - Temporal: `timestamp→Timestamp(ms, UTC)`, `date→Date32`, `time→Time64(ns)`.
+  - Numeric edge: `decimal→Decimal128(38,9)` (rescaled via `num_bigint`, errors on >38 digits — never silent truncation); `varint→Decimal128(38,0)`.
+  - Identity: `uuid/timeuuid→FixedSizeBinary(16)` carrying the **Arrow UUID extension** metadata so Parquet records the logical type.
+  - Nested: `list/set→List<T>`, `map→Map<Struct<key,value>>`, `tuple→Struct(field_0..)`, `udt→Struct(named fields)`.
+- Design choice: fixed decimal scale of 9 across columns so files interoperate without per-column negotiation.
+
+**Graphic**
+- A clean two-column reference table (CQL type | Arrow type) grouped into bands: Scalars, Temporal, Numeric, Identity, Nested. Use the rows above.
+- Right margin: three "gotcha" callout bubbles — (1) "decimal rescaled to fixed scale 9, overflow = error", (2) "UUID extension → Parquet logical type", (3) "set has no Arrow equivalent → List".
+- Keep it visually a "cheat sheet" — monospace type names, subtle zebra striping.
+
+---
+
+## Slide 5 — Parquet Export (Path A)
+
+**Title:** Materializing files — batch and streaming
+
+**Talking points**
+- Two writers in `export/parquet.rs`:
+  - `ParquetWriter` — loads all rows, one RecordBatch, returns the full file bytes. Good for small results.
+  - `StreamingParquetWriter<W>` — buffers up to `row_group_size` (default 10,000) rows, flushes **one Parquet row group per chunk**, bounded memory for arbitrarily large exports.
+- Critical detail: we call `WriterProperties::set_max_row_group_size()` so the Arrow writer doesn't silently coalesce into ~1M-row groups (which would blow the memory budget).
+- Options: compression `Snappy` (default, matches Cassandra), `Zstd` (smaller), or `Uncompressed`; configurable row-group size.
+- Exposed everywhere:
+  - CLI: `--out parquet`.
+  - Python: `db.export_parquet(query, path, row_group_size=, compression=)` (releases the GIL for the whole export).
+  - Node: `await db.exportParquet(query, path, { rowGroupSize, compression })`.
+
+**Graphic**
+- A pipeline diagram: streaming row source → a buffer box labeled "row_group_size (10k)" → "flush → Parquet row group" repeating into a `.parquet` file made of stacked row-group blocks (footer at bottom).
+- Side-by-side mini panels for the two writers ("Batch: all-in-memory, returns Vec<u8>" vs "Streaming: bounded memory, W: Write+Send").
+- Three small SDK badges (CLI / Python / Node) each with their one-line call signature.
+
+---
+
+## Slide 6 — The Sidecar: `cqlite-flight` (Path B)
+
+**Title:** A read-only Arrow Flight server, co-located on every node
+
+**Talking points**
+- `cqlite-flight` is a Rust binary that runs **on each Cassandra node**, reading that node's local SSTables (`/var/lib/cassandra/data`). Originals are never modified.
+- Built on `tonic` (gRPC) + `arrow-flight` 53. Implements the Arrow Flight `FlightService` — read-only subset:
+  - `GetFlightInfo` / `GetSchema` — return the Arrow schema for a request.
+  - `DoGet` — stream the table as Arrow record batches.
+  - `Handshake/DoPut/DoExchange/...` deliberately unimplemented.
+- On each `DoGet`, the server does real work before streaming:
+  1. **k-way compaction merge** of the node's SSTables on the fly (`KWayMerger`) — reconciles tombstones/updates, originals untouched.
+  2. **Token-range filter** — half-open `(start, end]`, wraparound aware.
+  3. **Predicate pushdown** — `=, IN, >, >=, <, <=, prefix` via the shared `evaluate_predicates`.
+  4. **Column projection** — only requested columns.
+  5. Reconstruct rows → `rows_to_record_batch` → encode as Arrow IPC `FlightData`.
+
+**Graphic**
+- A single Cassandra node box. Inside it, side by side: the Cassandra process (greyed, "untouched") and the `cqlite-flight` process. Show `cqlite-flight` with a read-only arrow into the shared SSTable volume.
+- Inside `cqlite-flight`, a vertical pipeline of 5 labeled stages: `k-way merge → token filter → predicate pushdown → projection → Arrow encode`.
+- Out the top: a gRPC stream pipe labeled "Arrow Flight DoGet → FlightData (IPC batches)".
+- Small RPC legend in corner: ✅ GetFlightInfo, ✅ GetSchema, ✅ DoGet, ✗ DoPut/DoExchange/Handshake.
+
+---
+
+## Slide 7 — The Flight Ticket Contract
+
+**Title:** One JSON ticket describes the whole scan
+
+**Talking points**
+- The client (Trino connector) and server agree on a versioned JSON **ticket** (`cqlite-flight/src/ticket.rs`). It's the contract that makes pushdown and parallelism work.
+- Fields: `keyspace`, `table`, full `ddl` (so the server builds the exact Arrow schema), optional `snapshot` (null = live dir), token bounds (`token_start` exclusive, `token_end` inclusive, `wraparound`), optional `columns` projection, optional `predicates`.
+- The Java side (`FlightTicketJson.java`) mirrors the Rust serde contract field-for-field — one source of truth, two languages.
+
+**Graphic**
+- A literal "ticket stub" graphic (like an event ticket / boarding pass) rendered with the JSON:
+  ```json
+  {
+    "version": 1,
+    "keyspace": "analytics",
+    "table": "events",
+    "ddl": "CREATE TABLE analytics.events (...)",
+    "snapshot": null,
+    "token_start": -3074457345618258602,
+    "token_end":   3074457345618258602,
+    "wraparound": false,
+    "columns": ["name"],
+    "predicates": [{ "column": "score", "op": "Gt", "value": 25 }]
+  }
+  ```
+- Annotate each field group with a small icon: identity (keyspace/table/ddl), placement (token range + wraparound), pushdown (columns + predicates).
+- Show two endpoints — Rust `ticket.rs` and Java `FlightTicketJson.java` — with a "⇄ same contract" connector between them.
+
+---
+
+## Slide 8 — Trino Connector & Parallelism
+
+**Title:** Trino splits the ring, reads every node in parallel
+
+**Talking points**
+- Java connector (Trino SPI 481, `trino-connector/`). Two discovery channels:
+  - **HTTP to Cassandra Sidecar** for topology: `/cassandra/ring`, `/token-range-replicas`, `/keyspaces/{ks}/schema`.
+  - **Arrow Flight** to `cqlite-flight` for schema (`GetSchema`) and data (`DoGet`).
+- **Split strategy** (`CqliteFlightSplitManager`): one split per token range, pinned to exactly one replica (prefer local DC). Guarantees each row is read **once** despite replication — no dedup needed downstream.
+- **Page source**: streams Arrow batches, converts `VectorSchemaRoot` → Trino `Page` via `ArrowToTrino` (Arrow vector → Trino BlockBuilder). UUID extension → formatted VARCHAR; Timestamp → TIMESTAMP_TZ_MILLIS.
+- Status today: projection pushdown ✅; predicate pushdown deferred (server supports it, Trino post-filters for now); complex CQL types rejected **at planning time**, not mid-scan.
+
+**Graphic**
+- Top: Trino coordinator receiving `SELECT name FROM cqlite.analytics.events WHERE score > 25`.
+- Coordinator has two dashed arrows to the **Sidecar** (HTTP, "ring + token ranges + schema").
+- Coordinator fans out N solid arrows to **Trino workers**; each worker has a Flight `DoGet` arrow to a different Cassandra node's `cqlite-flight` (8815). Label "1 split = 1 token range = 1 replica".
+- Bottom of each worker: a small "Arrow → Page" converter box. Converged result flows back up to the coordinator.
+- Status legend chips: `projection ✅ | predicate ⏳ post-filter | complex types ✗ at-plan`.
+
+---
+
+## Slide 9 — End-to-End Data Flow
+
+**Title:** SQL in, columns out — the full round trip
+
+**Talking points**
+- Walk the lifecycle of one query end to end:
+  1. Trino parses SQL, asks Sidecar for the ring + token ranges + schema.
+  2. Connector builds one ticket per token range with projection + (eventually) predicates.
+  3. Each Trino worker issues `DoGet` to the co-located `cqlite-flight` on the owning replica.
+  4. `cqlite-flight` merges that node's SSTables, filters by token/predicate, projects columns, encodes Arrow.
+  5. Arrow IPC batches stream back over gRPC; connector converts to Trino Pages.
+  6. Trino applies residual filters/aggregates and returns the result.
+- **SSTable semantics matter**: only flushed data is visible. The E2E test proves an un-flushed row is invisible until `nodetool flush`. This is a feature — you're reading the on-disk truth.
+
+**Graphic**
+- A single left-to-right swimlane diagram with numbered stages (1–6) across lanes: **Trino Coordinator → Sidecar → Trino Worker → cqlite-flight → (SSTables) → back to Trino**.
+- Use distinct line styles: HTTP (dashed) for Sidecar discovery, gRPC/Arrow (solid bold) for data.
+- Inset callout near the SSTable stage: "flushed SSTables only — memtable rows invisible (verified by E2E)".
+- Keep the numbers visible so the presenter can narrate stage by stage.
+
+---
+
+## Slide 10 — Status, Trade-offs & Roadmap
+
+**Title:** Where it stands and what's next
+
+**Talking points**
+- **Done & tested**
+  - CQL→Arrow conversion with high-fidelity types (scalars, temporal, decimal/varint, UUID extension, collections, tuples, UDTs).
+  - Parquet export: batch + streaming, Snappy/Zstd, CLI + Python + Node.
+  - `cqlite-flight` Arrow Flight server: merge, token filter, predicate + projection pushdown, `GetFlightInfo/GetSchema/DoGet`.
+  - Trino connector: discovery, split-per-range, Arrow→Page, projection pushdown, docker-compose E2E passing.
+- **Trade-offs / current limits**
+  - Flight server buffers batches in memory (streaming backpressure is future work).
+  - Trino predicate pushdown not yet wired (post-filtered); complex CQL types rejected at planning.
+  - Counters not yet supported in the Flight path.
+- **Roadmap**: streaming backpressure, wire predicate pushdown into Trino, broaden type coverage, snapshot lifecycle automation, lakehouse commit (Iceberg/Delta) handled by external committers — out of CQLite's scope by design.
+
+**Graphic**
+- Three-column board: **✅ Done** | **⚠️ Trade-offs** | **🛣️ Roadmap**, each with the bullets above as cards.
+- Top banner: a maturity bar showing Parquet path (solid/GA-ish) vs Flight/Trino path (labeled "Phase 1, E2E green").
+- Footer with reference paths for the curious: `cqlite-core/src/export/`, `cqlite-flight/`, `trino-connector/`, `docs/flight-trino/PLAN.md`.
+
+---
+
+## Appendix — Key file references (speaker backup, not a slide)
+
+| Area | Path |
+|------|------|
+| CQL→Arrow conversion | `cqlite-core/src/export/arrow_convert.rs` |
+| Parquet writers | `cqlite-core/src/export/parquet.rs` |
+| Export module gating | `cqlite-core/src/export/mod.rs` |
+| Python binding | `bindings/python/src/database.rs` (`export_parquet`) |
+| Node binding | `bindings/node/src/database.rs` (`exportParquet`) |
+| Flight server | `cqlite-flight/src/{main,service,producer,ticket}.rs` |
+| Merge engine | `cqlite-core/src/storage/write_engine.rs` (`KWayMerger`) |
+| Trino connector | `trino-connector/src/main/java/com/rustyrazorblade/cqlite/flight/` |
+| Design docs | `docs/flight-trino/PLAN.md`, `cqlite-flight/README.md`, `trino-connector/README.md` |
+| E2E harness | `trino-connector/docker/{docker-compose.yml,e2e-test.sh}` |
+
+**Feature flags:** `arrow` (pulls `arrow` 53), `parquet` (pulls `parquet` 53 with `arrow,snap,zstd`). Both off by default.

--- a/docs/storage engine/design.md
+++ b/docs/storage engine/design.md
@@ -1,0 +1,89 @@
+# Design: add-iceberg-materializer
+
+## Context
+
+Epic #696 gives us `DeltaRecord` streaming (`scan_delta`) and a
+`DeltaParquetWriter` with an envelope schema (`__op`, `__ts`, configurable
+prefix). The byte-parity compaction work (#842/#921/#938) gives us a
+machine-verified reconcile rule set. This change composes the two: reconcile
+semantics applied to delta envelopes, committed as Iceberg v2 snapshots.
+
+## Decisions
+
+### D1. Consume envelopes, not raw SSTables
+
+The materializer's input is the delta-envelope stream/files, not Data.db.
+Rationale: one authoritative extraction path (delta-scan) with existing
+tombstone-fidelity tests; the materializer stays format-agnostic and its
+oracle (DuckDB reference merge) consumes the identical input.
+
+### D2. Deletes: equality deletes on identifier fields, resolved per shape
+
+- **Row tombstone** → one equality-delete row on (partition key +
+  clustering key) identifier fields. Direct mapping.
+- **Partition tombstone** → one equality-delete row on partition-key fields
+  only (Iceberg equality deletes match on the declared subset).
+- **Range tombstone** → no direct Iceberg analogue. Resolved at fold time:
+  the materializer scans the affected partition in current table state,
+  enumerates shadowed rows, and emits equality deletes for each. This is a
+  read-before-delete, bounded by one partition per range tombstone. The
+  behavioral requirement (spec) is shape-independent; this is the mechanism.
+- Timestamps: `__ts` ordering decides fold outcome *before* delete-file
+  emission, so Iceberg sequence numbers are not asked to encode Cassandra
+  LWW — the fold layer owns reconcile, Iceberg owns visibility.
+
+### D3. Commit protocol and exactly-once
+
+One materialize invocation = at most one Iceberg snapshot commit. Snapshot
+summary properties record:
+
+- `cqlite.generations` — sorted list of consumed generation identities
+  (keyspace/table UUID + generation + Data.db content digest).
+- `cqlite.delta-horizon-micros` — authoritative watermark (spec req).
+- `cqlite.lineage` — for compaction outputs, the input generation set.
+
+Idempotency check = set membership against the union of `cqlite.generations`
+across current-branch snapshot history. Crash safety comes from Iceberg's
+atomic metadata swap: orphaned data files from a pre-commit crash are
+invisible and reclaimable by standard Iceberg maintenance.
+
+### D4. Lineage source
+
+Compaction runs performed by CQLite record input→output lineage in a
+sidecar manifest written atomically with the output TOC (same
+publication-barrier pattern as #591's TOC-first delete). Generations without
+a lineage record are treated as flush-origin; `--require-lineage` makes
+unknown lineage fail closed (spec req) for directories where Cassandra — not
+CQLite — performed compaction and lineage is genuinely unknowable.
+
+### D5. Catalog: filesystem first
+
+`iceberg-rust` filesystem catalog only. REST catalog (credentials, retries,
+multi-writer commit conflicts) is its own change. **Open question OQ1**
+covers iceberg-rust v2-delete write maturity; fallback is emitting the
+Iceberg metadata/manifests directly (we already own a Parquet writer), which
+is more code but zero new semantics.
+
+### D6. Feature isolation
+
+`iceberg` feature on `cqlite-core`, additive only, mirroring the `parquet`
+feature precedent (Epic #682): default dependency surface unchanged, CLI
+subcommand compiled out without the flag. Campsite rule: new module tree
+`export/iceberg/{mod.rs, fold.rs, deletes.rs, commit.rs, lineage.rs,
+schema.rs}` — no file grows past target.
+
+## Open questions (NEEDS YOU)
+
+- **OQ1**: iceberg-rust write-path maturity for v2 equality deletes at our
+  pin date — spike task 1.1 answers build-vs-adopt before implementation.
+- **OQ2**: identifier fields for tables where clustering columns include
+  types Iceberg disallows in identifier fields — degrade to
+  position deletes for those tables, or block with a named error?
+- **OQ3**: static columns — materialize as denormalized per-row values
+  (simple, redundant) or as a companion table (normalized, two commits)?
+
+## Non-goals restated
+
+Continuous watching, RF/primary-range dedup, repaired-status gating, REST
+catalogs, and delete-compaction maintenance are follow-up changes listed in
+the proposal; nothing in this design forecloses them.

--- a/docs/storage engine/epic-draft.md
+++ b/docs/storage engine/epic-draft.md
@@ -1,0 +1,64 @@
+# [EPIC] Lakehouse materialization: Cassandra tables as Iceberg tables
+
+*Draft GitHub epic body — label `epic`, children follow 1:1:1:1
+(one issue ↔ one OpenSpec change ↔ one PR).*
+
+## Goal
+
+Complete the OLAP path opened by delta-export (Epic #696): fold delta
+envelopes into queryable Apache Iceberg v2 tables so every Cassandra table
+is readable by Spark/Trino/DuckDB/Snowflake with zero ETL and zero consumer
+merge logic. Complements — does not replace — the Flight/Trino hot path
+(Epics #874/#918): Flight serves fresh per-node reads, Iceberg serves
+complete history at lakehouse scale.
+
+## Why now
+
+- Byte-parity compaction (#842/#921/#938) makes our reconcile semantics
+  machine-verified — the trust prerequisite for owning the fold.
+- Delta-export already emits tombstone-faithful envelopes; the DuckDB
+  reference-merge guide (#878) proves the remaining consumer burden and
+  doubles as the parity oracle.
+- Statistics.db authoritativeness work (#1728/#1729 → #1388) is landing the
+  watermark foundation this epic requires.
+
+## Child issues / changes (in order)
+
+1. **add-iceberg-materializer** — single-invocation materializer, filesystem
+   catalog, exactly-once commits, lineage-safe, reference-merge parity.
+   (OpenSpec change drafted; ready for flow-groom.)
+2. **add-materializer-daemon** — continuous data-directory watcher;
+   generation lifecycle; backoff/retry; sidecar-deployable.
+3. **add-materializer-primary-range-dedup** — cluster mode: per-node
+   materialization restricted to primary token ranges (reuse Flight
+   token-range pruning); RF-safe lakehouse writes.
+4. **add-materializer-repaired-gating** — consistency contract: only
+   repaired SSTables materialize; snapshot watermark = repair horizon.
+5. **add-iceberg-rest-catalog** — REST catalog backend, auth, commit-conflict
+   handling.
+6. **add-iceberg-maintenance** — equality-delete compaction, snapshot
+   rewrite/expiry, orphan-file cleanup.
+
+## Dependencies
+
+- #1729 / #1728 (authoritative Statistics.db) — blocks child 1's watermark
+  requirement (fail-closed until landed).
+- Epic #696 envelope schema — stable input contract.
+- OQ1 (iceberg-rust write maturity) — spike task inside child 1.
+
+## Exit criteria (epic)
+
+- A three-node cluster continuously materializes a keyspace to one Iceberg
+  catalog with no duplicate rows across replicas.
+- Trino query over the Iceberg table matches a quorum CQL read as of the
+  published repair-horizon watermark, verified by an automated harness.
+- Demo: `SELECT` in DuckDB against the catalog, sub-second, zero pipeline
+  code.
+
+## NEEDS YOU (product decisions before child 1 activates)
+
+- OQ2: tables whose clustering columns can't be Iceberg identifier fields —
+  degrade to position deletes or fail closed?
+- OQ3: static-column materialization shape (denormalize vs companion table).
+- Catalog naming convention: `catalog.<keyspace>.<table>` vs configurable
+  namespace mapping.

--- a/docs/storage engine/proposal.md
+++ b/docs/storage engine/proposal.md
@@ -1,0 +1,70 @@
+# Change: add-iceberg-materializer
+
+## Why
+
+Epic #696 (delta-scan / delta-export) projects an SSTable generation into a
+delta-envelope Parquet file with full tombstone fidelity. That output is a
+**CDC log, not a table**: today the consumer must fold upserts and tombstones
+into current state themselves — the shipped DuckDB reference-merge
+reconciliation guide (#878) is the proof that this burden currently sits on
+the user.
+
+This change moves the fold to our side of the boundary. A materializer
+consumes delta envelopes and maintains an **Apache Iceberg v2 table**, so any
+Iceberg-aware engine (Spark, Trino, DuckDB, Snowflake external tables) can
+`SELECT * FROM catalog.ks.table` with zero merge knowledge. It is the missing
+link between "delta-export exists" and "every Cassandra table is a lakehouse
+table", and it is the OLAP half of the parallel OLTP/OLAP path strategy.
+
+The DuckDB reference-merge guide is promoted from user documentation to the
+**parity oracle** for the materializer: for the same envelope set, materialized
+Iceberg state must equal the reference merge.
+
+## What Changes
+
+- New capability spec `iceberg-materializer`.
+- New cargo feature `iceberg` on `cqlite-core` (NOT in defaults), gating an
+  `export/iceberg/` module: `IcebergMaterializer` public API that consumes
+  delta envelopes (or a `scan_delta` stream) and commits Iceberg v2 snapshots.
+- New CLI subcommand `cqlite materialize` behind `--features iceberg`
+  (single invocation, single table, one-or-more input generations →
+  one Iceberg snapshot commit).
+- Catalog support: filesystem/Hadoop-style catalog only in this change.
+- Snapshot commits carry consumed-generation identities and an authoritative
+  delta-horizon watermark in snapshot properties.
+
+## Impact
+
+- Affected specs: `iceberg-materializer` (new).
+- Affected code: `cqlite-core/src/export/iceberg/` (new, feature-gated),
+  `cqlite-cli` `materialize` subcommand, `Cargo.toml` (iceberg-rust + arrow
+  deps behind the `iceberg` feature only — default dependency surface
+  unchanged, matching the #558 precedent).
+- Parity manifest: adds `claim.safe.iceberg_materialize_filesystem_catalog`;
+  records `claim.blocked.iceberg_rest_catalog` and
+  `claim.blocked.continuous_materialization` until follow-ups land.
+- Note on #1406: this change neither depends on nor alters the
+  uncompressed-SSTable-writes claim boundary. Parquet data files written by
+  the materializer carry Parquet-level compression; SSTable write claims are
+  untouched.
+
+## Dependencies
+
+- **Hard**: authoritative `maxTimestamp` decoding in Statistics.db (#1729)
+  and live-cell `maxLocalDeletionTime` fidelity (#1728) — the watermark
+  requirement fails closed without them (consistent with #1388's blockers).
+- **Hard**: Epic #696 delta-envelope schema (`__op`/`__ts`, `--envelope-prefix`).
+- **Soft**: Epic #673 Arrow type mapping (reused for Iceberg schema derivation).
+
+## Out of scope (follow-up changes under the same epic)
+
+1. `add-materializer-daemon` — continuous sidecar-style watcher with
+   generation-lineage tracking against the live data directory.
+2. `add-materializer-primary-range-dedup` — cluster mode: each node
+   materializes only its primary token ranges (RF dedup), reusing the Flight
+   connector's token-range pruning.
+3. `add-materializer-repaired-gating` — consistency watermark = incremental
+   repair horizon; only repaired SSTables feed the lakehouse.
+4. `add-iceberg-rest-catalog` — REST catalog backend + credential handling.
+5. `add-iceberg-maintenance` — equality-delete compaction / snapshot rewrite
+   and expiry.

--- a/docs/storage engine/spec.md
+++ b/docs/storage engine/spec.md
@@ -1,0 +1,162 @@
+# Capability: iceberg-materializer
+
+## ADDED Requirements
+
+### Requirement: Delta folding into an Iceberg v2 table
+
+The materializer SHALL fold delta-envelope records into an Apache Iceberg v2
+table such that upserts become data-file rows and row/range/partition
+tombstones remove the rows they shadow, with last-write-wins resolution by
+mutation timestamp matching Cassandra reconcile semantics (the compaction
+byte-parity rule set, `docs/compaction/byte-parity-rules.md`).
+
+#### Scenario: Upsert becomes a queryable row
+
+- **GIVEN** a delta envelope containing an upsert for partition key `id=1`
+  with `name='Alice'`
+- **WHEN** `cqlite materialize` commits it to an empty Iceberg table
+- **THEN** an Iceberg scan of the table returns exactly one row
+  `id=1, name='Alice'`
+
+#### Scenario: Row tombstone removes a materialized row
+
+- **GIVEN** a materialized table containing `id=1` and a subsequent envelope
+  containing a row tombstone for `id=1` with a higher timestamp
+- **WHEN** the envelope is materialized
+- **THEN** an Iceberg scan returns zero rows for `id=1` and the commit
+  contains a v2 delete file covering that key
+
+#### Scenario: Range tombstone removes only the shadowed clustering range
+
+- **GIVEN** a materialized partition with clustering rows `c=1..10` and an
+  envelope carrying a range tombstone covering `c >= 3 AND c <= 7` at a
+  higher timestamp
+- **WHEN** the envelope is materialized
+- **THEN** an Iceberg scan returns rows `c=1,2,8,9,10` only
+
+#### Scenario: Equal-timestamp Delete-vs-Live resolves to the tombstone
+
+- **GIVEN** an upsert and a tombstone for the same row carrying the same
+  mutation timestamp
+- **WHEN** both are materialized (in either envelope order)
+- **THEN** the row is absent from an Iceberg scan (Cassandra
+  `Cells#reconcile` tie-break, matching #498)
+
+### Requirement: Exactly-once generation consumption
+
+The materializer SHALL record the identities of consumed source generations
+in Iceberg snapshot metadata and SHALL treat a re-submission of an
+already-consumed generation as a no-op that performs no commit.
+
+#### Scenario: Re-running the same input is a no-op
+
+- **GIVEN** a generation already materialized into snapshot S
+- **WHEN** `cqlite materialize` is invoked again with the same generation
+- **THEN** the command exits success, reports the generation as already
+  consumed, and the table's current snapshot remains S
+
+#### Scenario: Crash before commit leaves no partial state
+
+- **GIVEN** a materialize run interrupted after writing data files but
+  before the snapshot commit
+- **WHEN** the same invocation is re-run
+- **THEN** the table's readable state reflects the generation exactly once
+
+### Requirement: Compaction supersession safety
+
+The materializer SHALL NOT double-count data when offered a
+compaction-output generation whose logical content was already materialized
+from its input generations, and SHALL fail closed with a descriptive error
+when generation lineage cannot be established from authoritative metadata.
+
+#### Scenario: Compacted rewrite of consumed inputs does not duplicate rows
+
+- **GIVEN** generations G1 and G2 already materialized, and G3 produced by
+  compacting G1+G2 with declared lineage
+- **WHEN** G3 is submitted for materialization
+- **THEN** an Iceberg scan returns the same row set as before the submission
+
+#### Scenario: Unknown lineage fails closed
+
+- **GIVEN** a generation with no establishable lineage record
+- **WHEN** it is submitted alongside `--require-lineage`
+- **THEN** the command exits non-zero naming the generation and no snapshot
+  is committed
+
+### Requirement: Authoritative delta-horizon watermark
+
+Each committed snapshot SHALL carry a `cqlite.delta-horizon-micros` property
+equal to the maximum mutation timestamp fully reflected by the snapshot,
+sourced only from authoritative Statistics.db metadata; when the source
+metadata is a placeholder (pre-#1729 writer output), the materializer SHALL
+fail closed rather than emit a fabricated watermark (no-heuristics mandate).
+
+#### Scenario: Watermark matches authoritative max timestamp
+
+- **GIVEN** input generations whose Statistics.db carries authoritative
+  `maxTimestamp` values T1 < T2
+- **WHEN** both are materialized in one commit
+- **THEN** the snapshot property `cqlite.delta-horizon-micros` equals T2
+
+#### Scenario: Placeholder statistics fail closed
+
+- **GIVEN** an input generation whose Statistics.db `maxTimestamp` is the
+  known `max=min` placeholder (#1729)
+- **WHEN** materialization is attempted
+- **THEN** the command exits non-zero citing non-authoritative statistics
+  and commits nothing
+
+### Requirement: Reference-merge parity
+
+For any envelope set, the materialized Iceberg table state SHALL be
+row-for-row equal to the DuckDB reference-merge reconciliation (#878) of the
+same envelopes, and this parity SHALL be enforced by an automated oracle
+test over the pinned test corpus.
+
+#### Scenario: Parity over the mixed-tombstone corpus table
+
+- **GIVEN** the pinned delta-envelope fixtures for a corpus table containing
+  upserts, row, range, and partition tombstones across generations
+- **WHEN** the fixtures are materialized and independently reference-merged
+  in DuckDB
+- **THEN** the two result sets are equal under the parity harness comparator
+
+### Requirement: Schema and type mapping fidelity
+
+The materializer SHALL derive the Iceberg schema from the provided CQL
+schema using the established Arrow mapping (Epic #673), declare the CQL
+primary-key columns as Iceberg identifier fields, and SHALL fail closed
+naming the column when a CQL type has no supported Iceberg mapping.
+
+#### Scenario: Collections map to nested Iceberg types
+
+- **GIVEN** a table with `list<int>`, `set<text>`, and `map<text,int>`
+  columns
+- **WHEN** the table is materialized
+- **THEN** the Iceberg schema declares list/list/map nested types and values
+  round-trip through an Iceberg scan
+
+#### Scenario: Unsupported type fails closed
+
+- **GIVEN** a schema containing a column type outside the supported mapping
+- **WHEN** materialization is attempted
+- **THEN** the command exits non-zero naming the column and type, and
+  commits nothing
+
+### Requirement: Feature-flag claim boundary
+
+Iceberg support SHALL be gated behind a non-default `iceberg` cargo feature:
+default builds SHALL contain no Iceberg dependencies and SHALL NOT expose
+the `materialize` subcommand or the `IcebergMaterializer` API.
+
+#### Scenario: Default build has no materialize surface
+
+- **GIVEN** a default-features build of the CLI
+- **WHEN** `cqlite materialize --help` is invoked
+- **THEN** the CLI reports the subcommand as unavailable/unknown
+
+#### Scenario: Feature build exposes the surface
+
+- **GIVEN** a `--features iceberg` build
+- **WHEN** `cqlite materialize --help` is invoked
+- **THEN** usage for the subcommand is printed

--- a/docs/storage engine/tasks.md
+++ b/docs/storage engine/tasks.md
@@ -1,0 +1,79 @@
+# Tasks: add-iceberg-materializer
+
+Each task lands with the public-surface test that becomes C-audit evidence
+for its requirement. Gate (`scripts/agent-gate.sh`) must pass per task; the
+change archives only after C reports every requirement `satisfied`.
+
+## 1. Spike & scaffolding
+
+- [ ] 1.1 Spike: iceberg-rust v2 equality-delete write support at current
+      pin; record build-vs-adopt decision in design.md (resolves OQ1)
+- [ ] 1.2 Add `iceberg` feature (core + CLI), empty `export/iceberg/`
+      module tree, feature-gated `materialize` subcommand stub
+      — evidence: default-build CLI test (subcommand absent) +
+      feature-build CLI test (help prints) → **Requirement:
+      Feature-flag claim boundary**
+
+## 2. Schema derivation
+
+- [ ] 2.1 CQL schema → Iceberg schema via the #673 Arrow mapping;
+      PK columns → identifier fields; unsupported types fail closed
+      naming the column
+      — evidence: collections round-trip test + unsupported-type
+      exit-code test → **Requirement: Schema and type mapping fidelity**
+- [ ] 2.2 Resolve OQ2 (identifier-field-ineligible clustering types) with
+      owner; encode the decision as a test
+
+## 3. Fold engine
+
+- [ ] 3.1 Envelope reader (delta Parquet + `scan_delta` stream) honoring
+      `--envelope-prefix`
+- [ ] 3.2 LWW fold keyed on identifier fields with byte-parity reconcile
+      rules (equal-timestamp tombstone-wins per #498)
+      — evidence: upsert scenario test + equal-timestamp scenario test
+      → **Requirement: Delta folding** (partial)
+- [ ] 3.3 Delete emission: row/partition tombstones → equality-delete
+      files; range tombstones → partition-scoped resolution (design D2)
+      — evidence: row-tombstone and range-tombstone scenario tests
+      → **Requirement: Delta folding** (complete)
+
+## 4. Commit protocol
+
+- [ ] 4.1 Snapshot commit with `cqlite.generations` +
+      `cqlite.delta-horizon-micros` properties; idempotent re-submission
+      — evidence: no-op re-run test + interrupted-run/re-run test
+      → **Requirement: Exactly-once generation consumption**
+- [ ] 4.2 Watermark sourced from authoritative Statistics.db
+      `maxTimestamp`; placeholder stats fail closed (dep #1729)
+      — evidence: watermark-equality test + placeholder fail-closed test
+      → **Requirement: Authoritative delta-horizon watermark**
+
+## 5. Lineage
+
+- [ ] 5.1 Compaction lineage sidecar manifest (written under the TOC-first
+      publication barrier); reader in materializer
+- [ ] 5.2 Supersession skip for consumed-input compaction outputs;
+      `--require-lineage` fail-closed path
+      — evidence: no-duplicate-rows test + unknown-lineage exit-code test
+      → **Requirement: Compaction supersession safety**
+
+## 6. Parity oracle & wiring
+
+- [ ] 6.1 DuckDB reference-merge parity harness over the pinned
+      mixed-tombstone corpus fixtures; comparator reused from the #881
+      delta parity harness
+      — evidence: corpus parity test → **Requirement: Reference-merge
+      parity**
+- [ ] 6.2 Wire an `iceberg` component into `agent-gate.sh` (SKIP-aware,
+      like `delivery-telemetry`) and the parity CI tier that fits
+      (`canonical-semantic`)
+- [ ] 6.3 Parity manifest claims: add
+      `claim.safe.iceberg_materialize_filesystem_catalog`; record blocked
+      claims (REST catalog, continuous materialization); regenerate
+      `docs/reports/cassandra-test-parity.md`
+
+## 7. Docs & finalize
+
+- [ ] 7.1 User doc page (site) + CLI examples in CLAUDE.md command block
+- [ ] 7.2 CHANGELOG entry; file follow-up issues for the five out-of-scope
+      changes named in proposal.md; `openspec archive`

--- a/docs/superpowers/plans/2026-07-01-ci-runtime-overhaul.md
+++ b/docs/superpowers/plans/2026-07-01-ci-runtime-overhaul.md
@@ -1,0 +1,332 @@
+# CI Runtime Overhaul Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce PR CI from broad, expensive validation to a small enforceable gate backed by local pre-merge validation, nightly deep checks, and release gates.
+
+**Architecture:** CI becomes a tiered system: local pre-merge validation is the primary engineering signal, one light always-running GitHub PR gate is the required branch-protection signal, heavy parity/matrix/performance validation moves to targeted PR labels, nightly, or release workflows. Shared composite actions and policy validation prevent the workflow sprawl from recurring.
+
+**Tech Stack:** GitHub Actions, Rust/Cargo/Clippy, optional cargo-nextest, shell scripts, GitHub branch-protection config, CQLite dataset fetch/provenance scripts.
+
+---
+
+## Target Model
+
+### Required PR Gate
+
+One stable always-running workflow should be the only global branch-protection requirement. It should run:
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --package cqlite-core --all-targets --all-features -- -D warnings`
+- `cargo build --package cqlite-core --all-features`
+- fast representative `cqlite-core` tests
+- workflow YAML/policy validation
+- a minimal smoke/parity slice only if it can run quickly and deterministically
+
+### Local Pre-Merge Validation
+
+Before merge approval, engineers run a maintained local script that covers the expensive checks appropriate to the change. This must be documented and executable without relying on GitHub runner state.
+
+### Targeted PR Checks
+
+Path-specific and label/manual checks may run on relevant PRs, but should not be global required checks:
+
+- minimal feature matrix
+- binding smoke tests
+- docs build
+- workflow policy validation
+- focused parity smoke for storage/write changes
+
+### Nightly Deep Checks
+
+Nightly `main` workflows run:
+
+- full SSTableDump parity
+- CQL type, tombstone/TTL, compression/corruption, live-cell compaction regeneration parity
+- Cassandra ingest paths
+- full all-table smoke
+- Node/Python/Flight/Trino full matrices
+- coverage, performance, observability overhead
+
+### Release Gate
+
+Release/tag workflows run the full validation matrix and publish dry-runs before any package/image publishing.
+
+---
+
+## Files and Ownership Boundaries
+
+### Governance and Documentation
+
+- Modify `.github/branch-protection.json`: required check list.
+- Modify `.github/setup-branch-protection.js`: keep required contexts in sync.
+- Modify `.github/QUALITY_GATES_ENFORCEMENT.md`: document tiered policy.
+- Modify `.github/workflows/workflow-config.yml`: enforce workflow policy.
+- Create `docs/ci/ci-tier-policy.md`: human-readable source of truth.
+- Create or modify `scripts/local/pre-merge.sh`: local validation entrypoint.
+
+### Shared CI Primitives
+
+- Create `.github/actions/setup-rust-ci/action.yml`: Rust setup/cache/sccache policy.
+- Create `.github/actions/restore-canonical-datasets/action.yml`: dataset cache/fetch/provenance policy.
+- Create `.github/actions/setup-sstabledump/action.yml`: Java/sstabledump setup.
+- Modify `test-data/scripts/fetch-datasets.sh`: keep as canonical dataset fetcher.
+- Modify `scripts/ci/ensure_real_dataset.sh`: update stale remediation text and consume canonical dataset metadata.
+
+### Core PR Gate and Rust Workflows
+
+- Create or modify `.github/workflows/pr-gate.yml`: light required PR workflow.
+- Modify `.github/workflows/ci.yml`: remove duplicate required work and move deep jobs to targeted/nightly/manual tiers.
+- Modify `.github/workflows/m1-ci.yml`: demote legacy heavy lanes or retire if superseded.
+- Modify `.github/workflows/ci-minimal-features.yml`: consolidate feature checks.
+- Modify `scripts/ci/run-core-test-group.sh`: keep or replace with nextest path.
+
+### Heavy Validation Workflows
+
+- Modify `.github/workflows/sstabledump-parity-gate.yml`.
+- Modify `.github/workflows/cassandra-validation.yml`.
+- Modify `.github/workflows/e2e-readback.yml`.
+- Modify `.github/workflows/smoke-tests.yml`.
+- Modify `.github/workflows/perf-regression.yml`.
+- Modify `.github/workflows/observability-gate.yml`.
+- Modify `.github/workflows/cql-type-parity.yml`.
+- Modify `.github/workflows/tombstone-ttl-parity.yml`.
+- Modify `.github/workflows/compression-corruption-parity.yml`.
+- Modify `.github/workflows/live-cell-compaction-parity.yml`.
+- Modify `.github/workflows/compaction-parity.yml`.
+
+### Polyglot, Docs, Flight, and Trino
+
+- Modify `.github/workflows/node-ci.yml`.
+- Modify `.github/workflows/python-ci.yml`.
+- Modify `.github/workflows/flight-ci.yml`.
+- Modify `.github/workflows/flight-image.yml`.
+- Modify `.github/workflows/flight-trino-e2e.yml`.
+- Modify `.github/workflows/trino-connector-ci.yml`.
+- Modify `.github/workflows/docs-site.yml`.
+- Modify release/publish workflows only where cache/concurrency policy changes are needed.
+
+---
+
+## Issue Breakdown
+
+### Task 1: Define CI Tier Policy and Required-Check Source of Truth
+
+**Files:**
+- Create: `docs/ci/ci-tier-policy.md`
+- Modify: `.github/branch-protection.json`
+- Modify: `.github/setup-branch-protection.js`
+- Modify: `.github/QUALITY_GATES_ENFORCEMENT.md`
+- Modify: `.github/workflows/quality-gates.yml`
+
+- [ ] Document the four tiers: local pre-merge, required PR, targeted/nightly, release.
+- [ ] Define which workflows are allowed to be globally required.
+- [ ] Remove stale references to missing workflows such as `multi-arch.yml` and `benchmark.yml`.
+- [ ] Keep required status names stable during migration or document any deliberate rename.
+- [ ] Verification: `ruby -e 'require "json"; JSON.parse(File.read(".github/branch-protection.json")); puts "branch protection JSON ok"'`
+- [ ] Verification: `gh workflow list` after push confirms referenced workflows exist.
+
+### Task 2: Add Local Pre-Merge Validation Entrypoint
+
+**Files:**
+- Create: `scripts/local/pre-merge.sh`
+- Modify: `scripts/local/test-m1-ci-locally.sh`
+- Modify: `scripts/local/test-all-ci-locally.sh`
+- Modify: `docs/ci/ci-tier-policy.md`
+
+- [ ] Add `scripts/local/pre-merge.sh` with modes: `fast`, `core`, `storage`, `bindings`, `full`.
+- [ ] `fast` must run formatting, `cqlite-core` Clippy with `-D warnings`, all-feature core build, and fast core tests.
+- [ ] `storage` must add dataset fetch/provenance checks and focused SSTable parity smoke.
+- [ ] `bindings` must add Linux-only Python and Node smoke where local toolchains are present.
+- [ ] `full` may call existing broader local scripts but must clearly print skipped external prerequisites.
+- [ ] Verification: `bash scripts/local/pre-merge.sh fast`.
+- [ ] Verification: `shellcheck scripts/local/pre-merge.sh scripts/local/test-m1-ci-locally.sh scripts/local/test-all-ci-locally.sh` if `shellcheck` is installed.
+
+### Task 3: Create Shared GitHub Actions Primitives
+
+**Files:**
+- Create: `.github/actions/setup-rust-ci/action.yml`
+- Create: `.github/actions/restore-canonical-datasets/action.yml`
+- Create: `.github/actions/setup-sstabledump/action.yml`
+- Modify: `test-data/scripts/fetch-datasets.sh`
+- Modify: `scripts/ci/ensure_real_dataset.sh`
+
+- [ ] `setup-rust-ci` installs the pinned/stable Rust toolchain, optional components, and one cache strategy.
+- [ ] `restore-canonical-datasets` restores the canonical dataset cache and always runs `test-data/scripts/fetch-datasets.sh` to guard partial caches.
+- [ ] `setup-sstabledump` installs Java and `sstabledump` consistently.
+- [ ] Remove direct dataset download snippets from workflows as each workflow migrates.
+- [ ] Update stale v2 dataset remediation text in `ensure_real_dataset.sh`.
+- [ ] Verification: migrate one non-required workflow first and run `gh workflow view <workflow>` after push.
+
+### Task 4: Build the Light Required PR Gate
+
+**Files:**
+- Create: `.github/workflows/pr-gate.yml`
+- Modify: `.github/branch-protection.json`
+- Modify: `.github/setup-branch-protection.js`
+- Modify: `.github/workflows/workflow-config.yml`
+
+- [ ] Add an always-running `pull_request` workflow with no path filters.
+- [ ] Include workflow config validation, Rust fmt, `cqlite-core` Clippy, core all-feature build, and fast tests.
+- [ ] Use a stable aggregate job name such as `Required PR Gate / required`.
+- [ ] Do not run Docker, full datasets, release builds, or platform matrices here.
+- [ ] Update branch protection to require the new aggregate check once the workflow is live.
+- [ ] Verification: a docs-only PR still produces the required check and completes quickly.
+
+### Task 5: Collapse `ci.yml` and `m1-ci.yml` Overlap
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+- Modify: `.github/workflows/m1-ci.yml`
+- Modify: `.github/branch-protection.json`
+- Modify: `scripts/ci/run-core-test-group.sh`
+
+- [ ] Decide whether `m1-ci.yml` remains as legacy/manual or is absorbed into `pr-gate.yml`.
+- [ ] Remove duplicate fmt/clippy/build/test lanes once `pr-gate.yml` owns them.
+- [ ] Move publish dry-run, flow tooling, CLI deep smoke, and broad dataset tests out of the required path.
+- [ ] Preserve required-check continuity until branch protection is updated.
+- [ ] Verification: `gh run list --limit 20` on a test PR shows fewer workflows triggered at PR creation.
+
+### Task 6: Introduce `cargo-nextest` Build-Once/Test-Many for Core Tests
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+- Modify: `.github/workflows/pr-gate.yml`
+- Modify: `scripts/ci/run-core-test-group.sh`
+- Create: `.config/nextest.toml` if no existing nextest config is present and project-specific configuration is needed.
+
+- [ ] Add `cargo-nextest` installation through `taiki-e/install-action` or an existing repo-approved tool installer.
+- [ ] Replace hand-rolled integration shard compilation with `cargo nextest archive`.
+- [ ] Run partitions from the archive using `nextest run --archive-file ... --partition count:N/M`.
+- [ ] Keep doc tests and example build checks separate because nextest does not replace all Cargo test modes.
+- [ ] Verification: nextest archive job succeeds and each partition reports tests run.
+
+### Task 7: Split Full SSTableDump Parity into PR Smoke and Nightly Full Gate
+
+**Files:**
+- Modify: `.github/workflows/sstabledump-parity-gate.yml`
+- Modify: `.github/workflows/cassandra-parity.yml`
+- Modify: `scripts/ci/ensure_real_dataset.sh`
+
+- [ ] Create a small PR smoke path covering representative Data.db, Index.db, Summary.db, Statistics.db, compression, and tombstone/TTL signals.
+- [ ] Move the current full parity matrix to nightly/manual/release trigger.
+- [ ] Remove informational `continue-on-error` PR work that does not affect merge.
+- [ ] Add explicit `timeout-minutes`.
+- [ ] Keep failure artifacts on all full parity runs.
+- [ ] Verification: ordinary core PR no longer runs the full parity suite by default.
+
+### Task 8: Tier Cassandra Ingest, Smoke, Performance, and Observability Workflows
+
+**Files:**
+- Modify: `.github/workflows/cassandra-validation.yml`
+- Modify: `.github/workflows/e2e-readback.yml`
+- Modify: `.github/workflows/smoke-tests.yml`
+- Modify: `.github/workflows/perf-regression.yml`
+- Modify: `.github/workflows/observability-gate.yml`
+
+- [ ] Keep at most one Cassandra ingest smoke path on default writer-path PRs.
+- [ ] Move the second ingest path to label/manual/nightly/release.
+- [ ] Move all-table smoke to nightly/manual unless a change explicitly touches all-table smoke logic.
+- [ ] Keep observability correctness on relevant PRs; move overhead benchmarks to nightly/manual.
+- [ ] Move perf regression to nightly/manual or label-gated PRs.
+- [ ] Verification: a storage PR does not enqueue two 30-minute Cassandra jobs by default.
+
+### Task 9: Split Node, Python, Flight, Trino, and Docs Matrices by Tier
+
+**Files:**
+- Modify: `.github/workflows/node-ci.yml`
+- Modify: `.github/workflows/python-ci.yml`
+- Modify: `.github/workflows/flight-ci.yml`
+- Modify: `.github/workflows/flight-image.yml`
+- Modify: `.github/workflows/flight-trino-e2e.yml`
+- Modify: `.github/workflows/trino-connector-ci.yml`
+- Modify: `.github/workflows/docs-site.yml`
+- Modify: `.github/workflows/node-release.yml`
+- Modify: `.github/workflows/python-release.yml`
+- Modify: `.github/workflows/release.yml`
+
+- [ ] PR binding smoke: Linux x64 only for ordinary core changes.
+- [ ] Full OS/arch native binding matrices: nightly/manual/release.
+- [ ] Flight CI: validate on PR, publish images only from release/image workflow.
+- [ ] Flight-Trino E2E: nightly/manual/full-label by default, with a minimal PR smoke for direct connector/Flight changes.
+- [ ] Docs: build/link check on docs PRs; dataset recipe smoke nightly/manual or when examples/scripts change.
+- [ ] Verification: core-only PR does not run full Node/Python native matrices.
+
+### Task 10: Add Nightly Deep Validation Orchestrator and Release Gate Policy
+
+**Files:**
+- Modify: `.github/workflows/quality-gates.yml`
+- Modify: `.github/workflows/coverage.yml`
+- Modify: `.github/workflows/coverage-baseline.yml`
+- Modify: `.github/workflows/exhaustive-regeneration.yml`
+- Modify: release workflows as needed.
+
+- [ ] Define nightly deep validation as the backstop for reduced PR CI.
+- [ ] Standardize nightly schedule offsets to avoid top-of-hour queue bursts.
+- [ ] Ensure nightly failure artifacts and summaries are retained long enough for triage.
+- [ ] Define release gate checklist that runs full parity, full matrices, coverage, perf, and publish dry-runs.
+- [ ] Verification: all nightly/full workflows can be triggered with `workflow_dispatch`.
+
+### Task 11: Enforce Workflow Policy Automatically
+
+**Files:**
+- Modify: `.github/workflows/workflow-config.yml`
+- Create: `scripts/ci/validate-workflows.rb` or keep inline Ruby if the repo prefers single-file workflow validation.
+
+- [ ] Fail on PR workflows missing `concurrency`.
+- [ ] Fail on jobs missing `timeout-minutes`, except documented tiny aggregate jobs.
+- [ ] Fail on workflows missing least-privilege `permissions`.
+- [ ] Warn or fail on direct dataset download snippets outside the shared action/script.
+- [ ] Warn or fail on broad PR matrices in binding workflows.
+- [ ] Verification: `ruby scripts/ci/validate-workflows.rb` or the inline workflow validation step passes locally.
+
+### Task 12: Add CI Runtime Metrics and Migration Success Criteria
+
+**Files:**
+- Modify: `.github/workflows/pr-gate.yml`
+- Modify: `.github/workflows/ci.yml`
+- Modify: `.github/workflows/sstabledump-parity-gate.yml`
+- Create: `scripts/ci/ci-timing-summary.sh`
+- Create: `docs/ci/ci-runtime-dashboard.md`
+
+- [ ] Add timing summaries for dataset fetch, cargo build/test groups, parity groups, and matrix jobs.
+- [ ] Document baseline and target metrics: required PR queue-to-green, workflow count per PR, cache hit rates, and p95 job runtime.
+- [ ] Add a short runbook for handling nightly failures.
+- [ ] Verification: a PR run emits `GITHUB_STEP_SUMMARY` timing data for the required gate.
+
+---
+
+## Suggested Dependency Order
+
+1. Task 1: policy and required-check source of truth.
+2. Task 2: local pre-merge script.
+3. Task 3: shared setup/dataset primitives.
+4. Task 4: new light required PR gate.
+5. Task 5: collapse `ci.yml`/`m1-ci.yml`.
+6. Task 6: nextest optimization.
+7. Task 7 and Task 8: heavy validation tiering.
+8. Task 9: polyglot matrix tiering.
+9. Task 10: nightly/release orchestration.
+10. Task 11: workflow policy enforcement.
+11. Task 12: runtime metrics.
+
+---
+
+## Acceptance Criteria for the Epic
+
+- A docs-only PR runs one required GitHub Actions check and does not leave required path-filtered checks pending.
+- A typical Rust core PR runs the required gate plus only relevant targeted checks.
+- Full SSTableDump parity, full Cassandra ingest, full binding matrices, coverage, perf, and observability overhead do not run by default on ordinary PRs.
+- Nightly `main` validation runs the deep checks and produces actionable artifacts.
+- `scripts/local/pre-merge.sh fast` passes locally before PRs.
+- `cargo clippy --package cqlite-core --all-targets --all-features -- -D warnings` remains a hard gate.
+- Branch protection references only stable aggregate check names.
+- Workflow policy validation prevents reintroducing unbounded PR fan-out.
+
+---
+
+## Self-Review
+
+- Spec coverage: The plan covers local-first validation, light PR CI, nightly deep checks, release gates, branch protection, Rust efficiency, parity tiering, binding matrices, shared CI primitives, and metrics.
+- Placeholder scan: No task contains TBD/TODO/fill-in placeholders.
+- Type consistency: Workflow names, scripts, and paths match existing repo structure or are explicitly listed as new files.

--- a/reports/2026-06-29-0.1.0/SUMMARY.md
+++ b/reports/2026-06-29-0.1.0/SUMMARY.md
@@ -1,0 +1,9 @@
+# cqlite-perf — run summary
+
+- **cqlite:** unknown
+- **results:** 0 run(s)
+
+## Throughput by concurrency
+
+| Workload | Codec | Conc | Cache | ops/sec | rows/sec | p50 µs | p99 µs | p99.9 µs | CV |
+|---|---|---:|---|---:|---:|---:|---:|---:|---:|


### PR DESCRIPTION
Docs-only. Adds new documentation authored 2026-07-02 at the owner's request:

- `docs/942-point-read-fast-path-design.md`
- `docs/compaction-manager-design.md`
- `docs/presentations/cqlite-parquet-arrow-flight.md`
- `docs/storage engine/` (proposal/design/spec/tasks/epic-draft)
- `docs/superpowers/plans/2026-07-01-ci-runtime-overhaul.md`
- `reports/2026-06-29-0.1.0/SUMMARY.md`

No code changes; no gate/roborev required (docs-only).