### PR TITLE
fix(#1690): depth-guard schema type parsers (P0 safety — adversarial CREATE TABLE aborts the process)

### DIFF
--- a/cqlite-core/src/schema/cql_parser.rs
+++ b/cqlite-core/src/schema/cql_parser.rs
@@ -1521,8 +1521,7 @@ mod tests {
         );
 
         let bad_str = "frozen<".repeat(depth + 1) + "int" + &">".repeat(depth + 1);
-        let err = cql_type_to_type_id(&bad_str)
-            .expect_err("one level past the bound must error");
+        let err = cql_type_to_type_id(&bad_str).expect_err("one level past the bound must error");
         let msg = err.to_string();
         assert!(
             msg.contains("nesting") || msg.contains("deep"),

--- a/cqlite-core/src/schema/cql_parser.rs
+++ b/cqlite-core/src/schema/cql_parser.rs
@@ -933,6 +933,24 @@ pub fn parse_create_table(input: &str) -> IResult<&str, TableSchema> {
 
 /// Convert CQL type string to internal CqlTypeId
 pub fn cql_type_to_type_id(cql_type: &str) -> Result<CqlTypeId> {
+    cql_type_to_type_id_with_depth(cql_type, 0)
+}
+
+/// Recursive body of [`cql_type_to_type_id`], threading the current nesting
+/// `depth` so the `frozen<...>` unwrap is bounded at [`MAX_TYPE_NESTING_DEPTH`]
+/// (issue #1690). Without this bound a pathological `frozen<` × N string reaching
+/// this public conversion path (via `SchemaManager::cql_type_to_internal`) would
+/// recurse until the stack overflows and, under `panic = "abort"`, abort the
+/// whole process instead of returning an error. `depth` is 0 at the top level and
+/// increments by one per nesting level.
+fn cql_type_to_type_id_with_depth(cql_type: &str, depth: usize) -> Result<CqlTypeId> {
+    if depth > MAX_TYPE_NESTING_DEPTH {
+        return Err(Error::schema(format!(
+            "type nesting too deep (max {})",
+            MAX_TYPE_NESTING_DEPTH
+        )));
+    }
+
     let type_lower = cql_type.trim().to_lowercase();
 
     // Handle collection types
@@ -953,7 +971,7 @@ pub fn cql_type_to_type_id(cql_type: &str) -> Result<CqlTypeId> {
         if let Some(inner_start) = type_lower.find('<') {
             if let Some(inner_end) = type_lower.rfind('>') {
                 let inner_type = &type_lower[inner_start + 1..inner_end];
-                return cql_type_to_type_id(inner_type);
+                return cql_type_to_type_id_with_depth(inner_type, depth + 1);
             }
         }
     }
@@ -1476,6 +1494,39 @@ mod tests {
         assert!(
             cql_type(&bad_str).is_err(),
             "one level past the bound must return Err"
+        );
+    }
+
+    /// Issue #1690 (P0 safety): the public `cql_type_to_type_id` conversion path
+    /// (reached via `SchemaManager::cql_type_to_internal`) unwraps `frozen<...>`
+    /// recursively. Pathologically nested `frozen<` input must return `Err`, not
+    /// stack-overflow / abort. A leaf at the depth bound still resolves; one level
+    /// deeper errors.
+    #[test]
+    fn test_cql_type_to_type_id_deep_frozen_returns_err_not_abort() {
+        let s = "frozen<".repeat(50_000) + "int" + &">".repeat(50_000);
+        assert!(
+            cql_type_to_type_id(&s).is_err(),
+            "pathological frozen nesting must return Err, not abort"
+        );
+
+        let depth = MAX_TYPE_NESTING_DEPTH;
+        // frozen<...> unwrapping: `depth` frozen levels reach the leaf at `depth`,
+        // which is the last allowed level and must still resolve to the leaf id.
+        let ok_str = "frozen<".repeat(depth) + "int" + &">".repeat(depth);
+        assert_eq!(
+            cql_type_to_type_id(&ok_str).expect("frozen nesting at the bound must resolve"),
+            CqlTypeId::Int,
+            "the leaf type id must be unchanged"
+        );
+
+        let bad_str = "frozen<".repeat(depth + 1) + "int" + &">".repeat(depth + 1);
+        let err = cql_type_to_type_id(&bad_str)
+            .expect_err("one level past the bound must error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("nesting") || msg.contains("deep"),
+            "error message must mention nesting/depth, got: {msg}"
         );
     }
 

--- a/cqlite-core/src/schema/cql_parser.rs
+++ b/cqlite-core/src/schema/cql_parser.rs
@@ -58,17 +58,41 @@ fn qualified_table_name(input: &str) -> IResult<&str, (Option<String>, String)> 
     }
 }
 
+/// Maximum allowed CQL type nesting depth for the nom schema parser. Mirrors
+/// [`crate::parser::complex_types::ComplexTypeParser`] (`max_depth = 32`) and the
+/// [`crate::schema::CqlType`] string parser guard.
+///
+/// Without this bound, a hostile or malformed schema with pathological nesting
+/// (e.g. `frozen<` × 50_000) recurses in `parse_type_inner` until the thread
+/// stack overflows and, under `panic = "abort"`, aborts the whole process
+/// instead of returning an error (issue #1690). The guard is
+/// `depth > MAX_TYPE_NESTING_DEPTH`, where `depth` is 0 for the outermost type
+/// and increments once per nesting level, so a leaf reached at exactly depth 32
+/// (i.e. 32 levels of nesting) is the last allowed depth; a 33rd level returns a
+/// nom failure (surfaced as `Err`).
+const MAX_TYPE_NESTING_DEPTH: usize = 32;
+
 /// Parse CQL data type
 fn cql_type(input: &str) -> IResult<&str, String> {
-    // Handle complex types like list<text>, map<text, bigint>, frozen<set<uuid>>
-    fn parse_type_inner(input: &str) -> IResult<&str, String> {
+    // Handle complex types like list<text>, map<text, bigint>, frozen<set<uuid>>.
+    // `depth` bounds recursion so pathological nesting cannot overflow the stack.
+    fn parse_type_inner(input: &str, depth: usize) -> IResult<&str, String> {
+        if depth > MAX_TYPE_NESTING_DEPTH {
+            // Unrecoverable failure so the enclosing `alt` short-circuits instead
+            // of backtracking; surfaces to the caller as `Err` (never a panic).
+            return Err(nom::Err::Failure(nom::error::Error::new(
+                input,
+                nom::error::ErrorKind::TooLarge,
+            )));
+        }
+
         let (input, base) = alt((
             // Collection types
             map(
                 tuple((
                     alt((keyword("list"), keyword("set"))),
                     char('<'),
-                    parse_type_inner,
+                    |i| parse_type_inner(i, depth + 1),
                     char('>'),
                 )),
                 |(collection, _, inner, _)| format!("{}<{}>", collection, inner),
@@ -78,10 +102,10 @@ fn cql_type(input: &str) -> IResult<&str, String> {
                 tuple((
                     keyword("map"),
                     char('<'),
-                    parse_type_inner,
+                    |i| parse_type_inner(i, depth + 1),
                     char(','),
                     ws,
-                    parse_type_inner,
+                    |i| parse_type_inner(i, depth + 1),
                     char('>'),
                 )),
                 |(_, _, key_type, _, _, value_type, _)| {
@@ -93,14 +117,21 @@ fn cql_type(input: &str) -> IResult<&str, String> {
                 tuple((
                     keyword("tuple"),
                     char('<'),
-                    separated_list1(tuple((ws, char(','), ws)), parse_type_inner),
+                    separated_list1(tuple((ws, char(','), ws)), |i| {
+                        parse_type_inner(i, depth + 1)
+                    }),
                     char('>'),
                 )),
                 |(_, _, types, _)| format!("tuple<{}>", types.join(", ")),
             ),
             // Frozen type
             map(
-                tuple((keyword("frozen"), char('<'), parse_type_inner, char('>'))),
+                tuple((
+                    keyword("frozen"),
+                    char('<'),
+                    |i| parse_type_inner(i, depth + 1),
+                    char('>'),
+                )),
                 |(_, _, inner, _)| format!("frozen<{}>", inner),
             ),
             // Simple types and UDTs
@@ -111,7 +142,7 @@ fn cql_type(input: &str) -> IResult<&str, String> {
     }
 
     let (input, _) = ws(input)?;
-    let (input, type_name) = parse_type_inner(input)?;
+    let (input, type_name) = parse_type_inner(input, 0)?;
     let (input, _) = ws(input)?;
 
     Ok((input, type_name))
@@ -1410,6 +1441,42 @@ mod tests {
             .find(|c| c.name == "person_info")
             .unwrap();
         assert_eq!(person.data_type, "tuple<text, int, boolean>");
+    }
+
+    /// Issue #1690 (P0 safety): the nom `cql_type` parser must NOT stack-overflow
+    /// on pathologically nested type strings (which under `panic = "abort"` abort
+    /// the whole process). Recursion is bounded at [`MAX_TYPE_NESTING_DEPTH`], so
+    /// deep input returns `Err` long before the stack is exhausted.
+    #[test]
+    fn test_cql_type_adversarial_deep_nesting_returns_err_not_abort() {
+        let s = "frozen<".repeat(50_000) + "int" + &">".repeat(50_000);
+        assert!(
+            cql_type(&s).is_err(),
+            "pathological nesting must return Err, not abort"
+        );
+    }
+
+    /// The depth bound is exact and behavior-preserving: a leaf reached at depth
+    /// == [`MAX_TYPE_NESTING_DEPTH`] (i.e. that many `frozen<...>` levels) is the
+    /// last allowed depth and reconstructs to the identical type string it did
+    /// before the guard existed; one level deeper returns `Err`.
+    #[test]
+    fn test_cql_type_nesting_depth_boundary_is_exact() {
+        let depth = MAX_TYPE_NESTING_DEPTH; // 32 — the last allowed nesting level.
+
+        // At the bound: must parse and round-trip to the exact same string.
+        let ok_str = "frozen<".repeat(depth) + "int" + &">".repeat(depth);
+        let (rest, parsed) =
+            cql_type(&ok_str).expect("nesting at the depth bound must still parse");
+        assert!(rest.trim().is_empty(), "entire input must be consumed");
+        assert_eq!(parsed, ok_str, "type string must be preserved unchanged");
+
+        // One past the bound: must error (nom failure surfaced as Err), not abort.
+        let bad_str = "frozen<".repeat(depth + 1) + "int" + &">".repeat(depth + 1);
+        assert!(
+            cql_type(&bad_str).is_err(),
+            "one level past the bound must return Err"
+        );
     }
 
     #[test]

--- a/cqlite-core/src/schema/cql_type_parser.rs
+++ b/cqlite-core/src/schema/cql_type_parser.rs
@@ -7,6 +7,18 @@
 use super::CqlType;
 use crate::error::{Error, Result};
 
+/// Maximum allowed CQL type nesting depth. Mirrors
+/// [`crate::parser::complex_types::ComplexTypeParser`] (`max_depth = 32`).
+///
+/// Without this bound, a hostile or malformed schema with pathological nesting
+/// (e.g. `frozen<` × 50_000) recurses until the thread stack overflows and,
+/// under `panic = "abort"`, aborts the whole process instead of returning an
+/// error (issue #1690). The guard is `depth > MAX_NESTING_DEPTH`, where `depth`
+/// is 0 for the outermost type and increments once per nesting level. A leaf
+/// reached at exactly depth 32 (i.e. 32 levels of collection/frozen nesting) is
+/// therefore the last allowed depth; a 33rd level returns `Err`.
+const MAX_NESTING_DEPTH: usize = 32;
+
 impl CqlType {
     fn split_top_level_types(type_str: &str) -> Result<Vec<&str>> {
         let mut parts = Vec::new();
@@ -46,6 +58,20 @@ impl CqlType {
 
     /// Parse CQL type string into structured type
     pub fn parse(type_str: &str) -> Result<Self> {
+        Self::parse_with_depth(type_str, 0)
+    }
+
+    /// Recursive body of [`CqlType::parse`], threading the current nesting
+    /// `depth` so recursion is bounded at [`MAX_NESTING_DEPTH`] (issue #1690).
+    /// `depth` is 0 at the top level and increments by one for each nested type.
+    fn parse_with_depth(type_str: &str, depth: usize) -> Result<Self> {
+        if depth > MAX_NESTING_DEPTH {
+            return Err(Error::schema(format!(
+                "type nesting too deep (max {})",
+                MAX_NESTING_DEPTH
+            )));
+        }
+
         let type_str = type_str.trim();
 
         // CQL type keywords are case-insensitive (`SET<TEXT>` == `set<text>`),
@@ -62,20 +88,29 @@ impl CqlType {
         // Handle frozen types
         if let Some(inner) = strip_prefix_ci(type_str, "frozen<") {
             if let Some(inner) = inner.strip_suffix('>') {
-                return Ok(CqlType::Frozen(Box::new(Self::parse(inner)?)));
+                return Ok(CqlType::Frozen(Box::new(Self::parse_with_depth(
+                    inner,
+                    depth + 1,
+                )?)));
             }
         }
 
         // Handle collection types
         if let Some(inner) = strip_prefix_ci(type_str, "list<") {
             if let Some(inner) = inner.strip_suffix('>') {
-                return Ok(CqlType::List(Box::new(Self::parse(inner)?)));
+                return Ok(CqlType::List(Box::new(Self::parse_with_depth(
+                    inner,
+                    depth + 1,
+                )?)));
             }
         }
 
         if let Some(inner) = strip_prefix_ci(type_str, "set<") {
             if let Some(inner) = inner.strip_suffix('>') {
-                return Ok(CqlType::Set(Box::new(Self::parse(inner)?)));
+                return Ok(CqlType::Set(Box::new(Self::parse_with_depth(
+                    inner,
+                    depth + 1,
+                )?)));
             }
         }
 
@@ -86,8 +121,8 @@ impl CqlType {
                     return Err(Error::schema(format!("Invalid map type: {}", type_str)));
                 }
                 return Ok(CqlType::Map(
-                    Box::new(Self::parse(parts[0].trim())?),
-                    Box::new(Self::parse(parts[1].trim())?),
+                    Box::new(Self::parse_with_depth(parts[0].trim(), depth + 1)?),
+                    Box::new(Self::parse_with_depth(parts[1].trim(), depth + 1)?),
                 ));
             }
         }
@@ -98,7 +133,7 @@ impl CqlType {
                 let parts = Self::split_top_level_types(inner)?;
                 let mut types = Vec::new();
                 for part in parts {
-                    types.push(Self::parse(part.trim())?);
+                    types.push(Self::parse_with_depth(part.trim(), depth + 1)?);
                 }
                 return Ok(CqlType::Tuple(types));
             }
@@ -276,6 +311,50 @@ mod tests {
         assert_eq!(
             CqlType::parse("MyType").unwrap(),
             CqlType::Custom("udt:MyType".to_string())
+        );
+    }
+
+    /// Issue #1690 (P0 safety): a hostile/malformed schema with pathological
+    /// nesting must NOT stack-overflow (which under `panic = "abort"` aborts the
+    /// whole process). It must return `Err` instead. The recursion is bounded at
+    /// [`MAX_NESTING_DEPTH`], so this errors long before the stack is exhausted.
+    #[test]
+    fn test_adversarial_deep_nesting_returns_err_not_abort() {
+        let s = "frozen<".repeat(50_000) + "int" + &">".repeat(50_000);
+        assert!(
+            CqlType::parse(&s).is_err(),
+            "pathological nesting must return Err, not abort"
+        );
+    }
+
+    /// The depth bound is exact: a leaf reached at depth == [`MAX_NESTING_DEPTH`]
+    /// (i.e. `MAX_NESTING_DEPTH` levels of `frozen<...>` around a leaf) is the
+    /// last allowed depth and must still parse to the identical `CqlType` it did
+    /// before the guard existed; one level deeper must error.
+    #[test]
+    fn test_nesting_depth_boundary_is_exact() {
+        // 32 levels of frozen nesting: last allowed. Must parse and produce the
+        // unchanged nested structure (Frozen x32 around Int).
+        let depth = MAX_NESTING_DEPTH; // 32 — the last allowed nesting level.
+        let ok_str = "frozen<".repeat(depth) + "int" + &">".repeat(depth);
+        let mut parsed =
+            CqlType::parse(&ok_str).expect("nesting at the depth bound must still parse");
+
+        let mut frozen_levels = 0usize;
+        while let CqlType::Frozen(inner) = parsed {
+            parsed = *inner;
+            frozen_levels += 1;
+        }
+        assert_eq!(frozen_levels, depth, "all frozen levels must be preserved");
+        assert_eq!(parsed, CqlType::Int, "the leaf type must be unchanged");
+
+        // 33 levels: one past the bound. Must error with a clear message.
+        let bad_str = "frozen<".repeat(depth + 1) + "int" + &">".repeat(depth + 1);
+        let err = CqlType::parse(&bad_str).expect_err("one level past the bound must error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("nesting") || msg.contains("deep"),
+            "error message must mention nesting/depth, got: {msg}"
         );
     }
 }


### PR DESCRIPTION
Fixes #1690 (P0 safety, oracle-driven).

## Problem
The schema CQL type-string parsers recursed on nested types with **no depth guard**. A hostile or malformed schema with pathological nesting (e.g. `frozen<` × 50,000) stack-overflowed and, under the `panic=abort` profile, **aborted the whole process** instead of returning `Err`. Reachable from CLI `--schema` and from every embedder that passes a schema string.

## Fix
Bound recursion at depth **32** (matching the in-tree `ComplexTypeParser` `max_depth = 32`) in **all three** schema type-string entry points. `depth` is 0 at the outermost type and increments once per nesting level; a leaf reached at depth 32 is the last allowed level, a 33rd errors with `Error::schema("type nesting too deep (max 32)")` (nom parser returns `nom::Err::Failure` -> surfaces as `Err`, never a panic):

- `cqlite-core/src/schema/cql_type_parser.rs` — `CqlType::parse` -> `parse_with_depth`; all 6 recursive edges (frozen/list/set/map key+value/tuple) carry `depth+1`.
- `cqlite-core/src/schema/cql_parser.rs` — nom `parse_type_inner` gains a `depth` param; all 6 recursive edges carry `depth+1`.
- `cqlite-core/src/schema/cql_parser.rs` — `cql_type_to_type_id` -> `cql_type_to_type_id_with_depth` (the third recursive `frozen<...>` entry point, reachable via public `SchemaManager::cql_type_to_internal`; found by roborev codex job 2712, now clean job 2723).

Valid nested types (<= 32 deep) parse **unchanged** — existing schema tests pass.

## Wiring-evidence / tests
Pinned regression tests in both files: the adversarial `("frozen<"×50_000)+"int"+(">"×50_000)` input returns `Err` for **all three** parsers (aborts on pre-fix code — verified SIGABRT), a 32-deep valid type round-trips unchanged, a 33-deep one errors with a clear message.

## Fuzz target (#1614)
The schema-parse fuzz target belongs on the H1 #1614 parser fuzz crate (not yet landed); noted there to land with it, per the issue's acceptance criteria.

## Notes
- No `unwrap()`/`expect()` in library code; `RUSTFLAGS="-D warnings"` clippy passes.
- `cql_parser.rs` is over the file-size ratchet target (1943/800 lines); splitting it is **out of scope** for this P0 safety fix, so the gate ran with `CQLITE_ALLOW_FILE_GROWTH=1` (acknowledged per epic #1116 / #1135).

## Gate
`scripts/agent-gate.sh` RESULT: PASS (all components green, commit 80f01001). roborev codex job 2723: "No issues found."
