### PR TITLE
feat(#1388): drop fully-expired SSTables whole in compaction (metadata-only + overlap-safe)

### DIFF
--- a/cqlite-cli/Cargo.toml
+++ b/cqlite-cli/Cargo.toml
@@ -151,6 +151,11 @@ name = "duckdb_parquet_validation"
 path = "tests/duckdb_parquet_validation.rs"
 required-features = ["state_machine", "duckdb-tests"]
 
+[[test]]
+name = "issue_1388_compact_major_drop"
+path = "tests/issue_1388_compact_major_drop.rs"
+required-features = ["write-support"]
+
 [features]
 # M2+ production defaults: Interactive REPL with query engine
 default = ["interactive", "tui", "cli-helpers"]

--- a/cqlite-cli/src/commands/write.rs
+++ b/cqlite-cli/src/commands/write.rs
@@ -331,6 +331,13 @@ pub struct CompactResult {
     pub data_file_size: u64,
     /// Wall-clock execution time in milliseconds
     pub execution_time_ms: f64,
+    /// SSTables DROPPED WHOLE by the fully-expired fast path (issue #1388), by
+    /// input Data.db path. Distinct from the merged inputs: each was proven fully
+    /// expired (authoritative `Statistics.db` metadata) and overlap-safe under
+    /// `--major`, so it was excluded from the merge and reclaimed after publish.
+    /// Empty unless `--major` and at least one input is fully expired past
+    /// gc_grace. Assertable from the plan (not just output absence).
+    pub dropped_whole: Vec<std::path::PathBuf>,
 }
 
 #[cfg(feature = "write-support")]
@@ -346,6 +353,17 @@ impl CompactResult {
             "  partitions: {}, rows: {}, Data.db: {} bytes ({:.1}ms)",
             self.output_partitions, self.output_rows, self.data_file_size, self.execution_time_ms
         );
+        if !self.dropped_whole.is_empty() {
+            // Issue #1388: surface the fully-expired SSTables dropped whole
+            // (excluded from the merge, reclaimed after publish).
+            println!(
+                "  dropped whole (fully expired): {}",
+                self.dropped_whole.len()
+            );
+            for p in &self.dropped_whole {
+                println!("    - {}", p.display());
+            }
+        }
     }
 }
 
@@ -418,6 +436,7 @@ pub async fn handle_compact(args: &crate::cli_types::CompactArgs) -> Result<Comp
         output_rows: report.stats.output_rows,
         data_file_size: report.output.data_size,
         execution_time_ms: start.elapsed().as_secs_f64() * 1000.0,
+        dropped_whole: report.stats.dropped_whole.clone(),
     })
 }
 

--- a/cqlite-cli/tests/issue_1388_compact_major_drop.rs
+++ b/cqlite-cli/tests/issue_1388_compact_major_drop.rs
@@ -254,3 +254,57 @@ fn compact_without_major_does_not_drop() {
         "a non-major compaction leaves its (merged) inputs in place; only drops are reclaimed"
     );
 }
+
+/// Roborev #1388 (Medium) regression: `compact --major` over an ALL-EXPIRED input
+/// set (no live co-input) reports EVERY expired SSTable in `dropped_whole` and
+/// reclaims every one from disk. The all-dropped guard retains one expired SSTable
+/// as the merger's required input, but it stays in `dropped_whole` and is reclaimed
+/// here (the CLI surface deletes no merge inputs otherwise), so nothing is
+/// underreported or left on disk.
+#[test]
+fn compact_major_all_expired_reports_and_reclaims_every_drop() {
+    let temp = TempDir::new().unwrap();
+    let input_dir = temp.path().join("input");
+    let out_dir = temp.path().join("out");
+    std::fs::create_dir_all(&input_dir).unwrap();
+
+    // TWO fully-expired SSTables, no live input.
+    let expired_a = flush_one(&input_dir, "exp_a", vec![delete_row(1, 0, TOMB_LDT, 100)]);
+    let expired_b = flush_one(&input_dir, "exp_b", vec![delete_row(2, 0, TOMB_LDT, 100)]);
+
+    let schema_path = write_schema_file(temp.path());
+    let args = CompactArgs {
+        input_dir: input_dir.clone(),
+        output: out_dir.clone(),
+        schema: schema_path,
+        gc_before: Some(GC_BEFORE),
+        now_sec: Some(NOW_SECS),
+        generation: 1,
+        major: true,
+    };
+
+    let result = rt()
+        .block_on(handle_compact(&args))
+        .expect("compact --major all-expired");
+
+    // BOTH expired SSTables are reported in the drop plan (no underreporting).
+    let mut reported = result.dropped_whole.clone();
+    reported.sort();
+    let mut expected = vec![expired_a.clone(), expired_b.clone()];
+    expected.sort();
+    assert_eq!(
+        reported, expected,
+        "an all-expired --major compaction must report EVERY dropped SSTable"
+    );
+    // BOTH are reclaimed from disk (including the one the all-dropped guard retained
+    // as the merger's input).
+    assert!(
+        !expired_a.exists() && !expired_b.exists(),
+        "every dropped-whole SSTable is reclaimed, including the retained merger input"
+    );
+    // The output is empty (both inputs purged to nothing).
+    assert_eq!(
+        result.output_rows, 0,
+        "an all-expired compaction produces an empty output"
+    );
+}

--- a/cqlite-cli/tests/issue_1388_compact_major_drop.rs
+++ b/cqlite-cli/tests/issue_1388_compact_major_drop.rs
@@ -1,0 +1,256 @@
+//! Issue #1388: `cqlite compact --major` drops a fully-expired SSTable whole.
+//!
+//! Acceptance-criterion 1 on the CLI one-shot surface (OQ-1 → (A)): under
+//! `--major` (the operator's assertion that `<input-dir>` holds every overlapping
+//! SSTable for the table ⇒ empty outside set ⇒ +inf overlap bound), an input
+//! SSTable proven fully expired by authoritative `Statistics.db` metadata is
+//! DROPPED WHOLE — excluded from the merge, its components reclaimed after publish,
+//! and NAMED in the `CompactResult.dropped_whole` plan field (assertable from the
+//! plan, not just output absence). Without `--major` no drop occurs.
+//!
+//! Drives the REAL CLI handler `cqlite_cli::commands::write::handle_compact`.
+
+#![cfg(feature = "write-support")]
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use cqlite_cli::cli_types::CompactArgs;
+use cqlite_cli::commands::write::handle_compact;
+use cqlite_core::schema::{ClusteringColumn, ClusteringOrder, Column, KeyColumn, TableSchema};
+use cqlite_core::storage::write_engine::{
+    CellOperation, ClusteringKey, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::Value;
+use tempfile::TempDir;
+
+const GC_BEFORE: i64 = 5_000;
+const NOW_SECS: i64 = 10_000;
+const TOMB_LDT: i32 = 100;
+
+fn schema() -> TableSchema {
+    TableSchema {
+        keyspace: "exp_ks".to_string(),
+        table: "items".to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![ClusteringColumn {
+            name: "ck".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+            order: ClusteringOrder::Asc,
+        }],
+        columns: vec![
+            col("id", "int", false),
+            col("ck", "int", false),
+            col("name", "text", true),
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+fn col(name: &str, ty: &str, nullable: bool) -> Column {
+    Column {
+        name: name.to_string(),
+        data_type: ty.to_string(),
+        nullable,
+        default: None,
+        is_static: false,
+    }
+}
+
+fn schema_cql() -> &'static str {
+    "CREATE TABLE exp_ks.items (id int, ck int, name text, PRIMARY KEY (id, ck));"
+}
+
+fn delete_row(id: i32, ck: i32, ldt: i32, ts: i64) -> Mutation {
+    Mutation::new(
+        TableId::new("exp_ks", "items"),
+        PartitionKey::single("id", Value::Integer(id)),
+        Some(ClusteringKey::single("ck", Value::Integer(ck))),
+        vec![CellOperation::DeleteRow],
+        ts,
+        None,
+    )
+    .with_local_deletion_time(ldt)
+}
+
+fn write_live_row(id: i32, ck: i32, name: &str, ts: i64) -> Mutation {
+    Mutation::new(
+        TableId::new("exp_ks", "items"),
+        PartitionKey::single("id", Value::Integer(id)),
+        Some(ClusteringKey::single("ck", Value::Integer(ck))),
+        vec![CellOperation::Write {
+            column: "name".to_string(),
+            value: Value::Text(name.to_string()),
+        }],
+        ts,
+        None,
+    )
+}
+
+fn rt() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime")
+}
+
+/// Flush one SSTable into `data_dir/<sub>` (a distinct subdir so generations do
+/// not collide), returning the discovered Data.db path.
+fn flush_one(data_dir: &Path, sub: &str, muts: Vec<Mutation>) -> PathBuf {
+    let sch = schema();
+    let sub_dir = data_dir.join(sub);
+    let wal = data_dir.join(format!("{sub}_wal"));
+    let config = WriteEngineConfig::new(sub_dir.clone(), wal, sch.clone());
+    let mut engine = WriteEngine::new(config).expect("engine");
+    for m in muts {
+        engine.write(m).expect("write");
+    }
+    let r = rt();
+    r.block_on(engine.flush()).expect("flush").expect("info");
+    r.block_on(engine.close()).expect("close");
+    discover(&sub_dir).into_iter().next().expect("one Data.db")
+}
+
+fn discover(dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    walk(dir, &mut out, 8);
+    out
+}
+
+fn walk(dir: &Path, out: &mut Vec<PathBuf>, depth: usize) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = path
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string();
+        if name.starts_with("nb-") && name.ends_with("-big-Data.db") {
+            let base = name.trim_end_matches("-Data.db");
+            if path.with_file_name(format!("{base}-TOC.txt")).exists() {
+                out.push(path);
+            }
+        } else if depth > 0 && path.is_dir() {
+            walk(&path, out, depth - 1);
+        }
+    }
+}
+
+fn write_schema_file(dir: &Path) -> PathBuf {
+    let p = dir.join("schema.cql");
+    std::fs::write(&p, schema_cql()).expect("write schema");
+    p
+}
+
+#[test]
+fn compact_major_drops_expired_sstable_and_names_it() {
+    let temp = TempDir::new().unwrap();
+    let input_dir = temp.path().join("input");
+    let out_dir = temp.path().join("out");
+    std::fs::create_dir_all(&input_dir).unwrap();
+
+    // Two SSTables under the SAME input_dir (distinct subdirs): one fully expired
+    // (row tombstones, tiny LDT, low write ts), one live (higher write ts).
+    let expired = flush_one(
+        &input_dir,
+        "expired",
+        vec![
+            delete_row(1, 0, TOMB_LDT, 100),
+            delete_row(2, 0, TOMB_LDT, 100),
+        ],
+    );
+    let _live = flush_one(
+        &input_dir,
+        "live",
+        vec![write_live_row(10, 0, "alive", 5_000_000)],
+    );
+
+    let schema_path = write_schema_file(temp.path());
+
+    let args = CompactArgs {
+        input_dir: input_dir.clone(),
+        output: out_dir.clone(),
+        schema: schema_path,
+        gc_before: Some(GC_BEFORE),
+        now_sec: Some(NOW_SECS),
+        generation: 1,
+        major: true,
+    };
+
+    let result = rt()
+        .block_on(handle_compact(&args))
+        .expect("compact --major");
+
+    // The plan names exactly the expired SSTable as dropped whole (assertable).
+    assert_eq!(
+        result.dropped_whole,
+        vec![expired.clone()],
+        "compact --major must name the fully-expired SSTable in the dropped-whole plan set"
+    );
+    // Only the live SSTable was merged.
+    assert_eq!(
+        result.input_files, 1,
+        "only the live SSTable was fed to the merger"
+    );
+    // The dropped SSTable's Data.db is reclaimed after publish.
+    assert!(
+        !expired.exists(),
+        "dropped-whole SSTable reclaimed after publish"
+    );
+    // The output holds the live row (one partition/row).
+    assert_eq!(result.output_rows, 1, "output holds only the live row");
+}
+
+#[test]
+fn compact_without_major_does_not_drop() {
+    let temp = TempDir::new().unwrap();
+    let input_dir = temp.path().join("input");
+    let out_dir = temp.path().join("out");
+    std::fs::create_dir_all(&input_dir).unwrap();
+
+    let expired = flush_one(&input_dir, "expired", vec![delete_row(1, 0, TOMB_LDT, 100)]);
+    let _live = flush_one(
+        &input_dir,
+        "live",
+        vec![write_live_row(10, 0, "alive", 5_000_000)],
+    );
+    let schema_path = write_schema_file(temp.path());
+
+    let args = CompactArgs {
+        input_dir: input_dir.clone(),
+        output: out_dir.clone(),
+        schema: schema_path,
+        gc_before: Some(GC_BEFORE),
+        now_sec: Some(NOW_SECS),
+        generation: 1,
+        major: false, // conservative: no drop (OQ-1 → (A))
+    };
+
+    let result = rt()
+        .block_on(handle_compact(&args))
+        .expect("compact (non-major)");
+    assert!(
+        result.dropped_whole.is_empty(),
+        "a non-major compaction must never drop whole"
+    );
+    assert_eq!(
+        result.input_files, 2,
+        "both inputs were merged (nothing dropped)"
+    );
+    // The one-shot CLI compaction does NOT delete its inputs (only dropped-whole
+    // SSTables are reclaimed); the expired input remains on disk, having been
+    // merged through the normal path rather than dropped.
+    assert!(
+        expired.exists(),
+        "a non-major compaction leaves its (merged) inputs in place; only drops are reclaimed"
+    );
+}

--- a/cqlite-core/src/storage/write_engine/compaction.rs
+++ b/cqlite-core/src/storage/write_engine/compaction.rs
@@ -58,17 +58,62 @@ impl WriteEngine {
     /// SSTables — see [`merge::compute_max_purgeable_timestamp`]. When `Some`, a
     /// tombstone older than every outside SSTable is purged even in a partial
     /// compaction; `None` keeps the conservative #921 behavior (no purging).
-    #[tracing::instrument(name = "compaction.start_merge", skip(self, input_paths, max_purgeable_timestamp), fields(inputs = input_paths.len()))]
+    #[tracing::instrument(name = "compaction.start_merge", skip(self, input_paths, max_purgeable_timestamp, outside_paths), fields(inputs = input_paths.len()))]
     pub(crate) fn start_merge(
         &mut self,
         input_paths: Vec<PathBuf>,
         purge_safe: bool,
         max_purgeable_timestamp: Option<i64>,
+        outside_paths: Vec<PathBuf>,
     ) -> Result<()> {
         log::info!(
             "Starting compaction merge of {} SSTables",
             input_paths.len()
         );
+
+        // gc_grace / gcBefore cutoff (issue #845): the fully-expired drop-set
+        // (issue #1388) needs the same cutoff the merger's purge stage uses, so
+        // compute it up front. `now_secs` is reused below for the merger.
+        let now_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+        let gc_before_secs = merge::compute_gc_before(&self.config.schema, now_secs);
+
+        // Fully-expired SSTable drop (issue #1388): compute the subset of the
+        // selected inputs that are provably fully expired (authoritative
+        // `Statistics.db` `max_deletion_time < gcBefore`, no cell scan) AND
+        // overlap-safe against the outside set (`max_timestamp` below the outside
+        // min write timestamp — the same #935 coarse global bound). For a full
+        // compaction `outside_paths` is empty ⇒ +inf bound ⇒ every fully-expired
+        // input is droppable. These SSTables are EXCLUDED from the merger's input
+        // list below (never read/decoded — the perf win) and reclaimed after the
+        // merged output publishes.
+        let drop_set = merge::fully_expired_sstables(&input_paths, &outside_paths, gc_before_secs);
+        let dropped_lookup: std::collections::HashSet<&PathBuf> = drop_set.iter().collect();
+        let mut input_paths: Vec<PathBuf> = input_paths
+            .iter()
+            .filter(|p| !dropped_lookup.contains(*p))
+            .cloned()
+            .collect();
+        // Guard the degenerate all-dropped case: the merger requires at least one
+        // input, so retain the last dropped SSTable in the merge (its rows purge to
+        // empty through the normal path) rather than failing; the rest are still
+        // dropped whole. Correctness is preserved and no read cost is paid for the
+        // remaining dropped SSTables.
+        let dropped_whole: Vec<PathBuf> = if input_paths.is_empty() {
+            let mut all = drop_set.clone();
+            let retained = all.pop();
+            if let Some(r) = retained.clone() {
+                input_paths.push(r);
+            }
+            drop_set
+                .into_iter()
+                .filter(|p| Some(p) != retained.as_ref())
+                .collect()
+        } else {
+            drop_set
+        };
 
         // Measure total bytes read (sum of Data.db file sizes as an approximation)
         let bytes_read: u64 = input_paths
@@ -132,18 +177,13 @@ impl WriteEngine {
 
         // Create K-way merger.
         //
-        // gc_grace / gcBefore purging (issue #845): compute `gcBefore = now -
-        // gc_grace_seconds` from the table's `gc_grace_seconds` (read from the
-        // AUTHORITATIVE table schema's options, not the dropped-column-augmented
-        // `effective_schema`). When the table declares no `gc_grace_seconds`,
-        // `compute_gc_before` returns `None` and purging is a strict no-op,
-        // preserving the pre-#845 behavior. `now_secs` is the wall-clock used for
-        // both the purge boundary and TTL evaluation.
-        let now_secs = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs() as i64)
-            .unwrap_or(0);
-        let gc_before_secs = merge::compute_gc_before(&self.config.schema, now_secs);
+        // gc_grace / gcBefore purging (issue #845): `gcBefore = now -
+        // gc_grace_seconds` and `now_secs` were computed above (also used by the
+        // #1388 fully-expired drop-set). `compute_gc_before` returns `None` when the
+        // table declares no valid `gc_grace_seconds`, disabling purging (and, above,
+        // dropping) — preserving the pre-#845 behavior. `now_secs` is the wall-clock
+        // used for both the purge boundary and TTL evaluation.
+        //
         // Overlap-safety gate (#921 finding 1): only a major/full compaction
         // (one that spans every candidate SSTable for the table) may purge
         // tombstones. A partial compaction sets `purge_safe = false`, which
@@ -246,6 +286,7 @@ impl WriteEngine {
             bytes_read,
             started_at: Instant::now(),
             effective_schema,
+            dropped_whole,
         });
 
         Ok(())
@@ -463,6 +504,22 @@ impl WriteEngine {
             }
         }
 
+        // Reclaim the DROPPED-WHOLE SSTables (issue #1388): proven fully expired +
+        // overlap-safe, they were EXCLUDED from the merger (never read) so their
+        // reclamation happens here — AFTER the merged output published — via the
+        // same best-effort component-delete path as the merged inputs. A failure is
+        // an invisible orphan (TOC.txt removed first) reclaimed on next startup.
+        for dropped in &merge.dropped_whole {
+            if let Err(e) = self.delete_sstable_files(dropped) {
+                log::warn!(
+                    "Failed to delete dropped-whole compaction input {:?}: {} \
+                     (merge output is valid; leftover is an invisible orphan)",
+                    dropped,
+                    e
+                );
+            }
+        }
+
         // Step 4: Remove the now-empty tmp directory (best effort).
         if let Err(e) = std::fs::remove_dir_all(&merge.tmp_dir) {
             log::debug!(
@@ -519,6 +576,11 @@ impl WriteEngine {
         // Update per-step report
         report.completed_merges.push(final_data_path);
         report.bytes_written += total_bytes_written;
+        // Record the dropped-whole set (issue #1388, R4), distinct from the merged
+        // inputs, so the drop decision is assertable from the plan/stats.
+        report
+            .dropped_whole
+            .extend(merge.dropped_whole.iter().cloned());
 
         // Update cumulative lifetime stats
         self.cumulative_stats.compactions_completed += 1;

--- a/cqlite-core/src/storage/write_engine/compaction.rs
+++ b/cqlite-core/src/storage/write_engine/compaction.rs
@@ -90,30 +90,9 @@ impl WriteEngine {
         // list below (never read/decoded — the perf win) and reclaimed after the
         // merged output publishes.
         let drop_set = merge::fully_expired_sstables(&input_paths, &outside_paths, gc_before_secs);
-        let dropped_lookup: std::collections::HashSet<&PathBuf> = drop_set.iter().collect();
-        let mut input_paths: Vec<PathBuf> = input_paths
-            .iter()
-            .filter(|p| !dropped_lookup.contains(*p))
-            .cloned()
-            .collect();
-        // Guard the degenerate all-dropped case: the merger requires at least one
-        // input, so retain the last dropped SSTable in the merge (its rows purge to
-        // empty through the normal path) rather than failing; the rest are still
-        // dropped whole. Correctness is preserved and no read cost is paid for the
-        // remaining dropped SSTables.
-        let dropped_whole: Vec<PathBuf> = if input_paths.is_empty() {
-            let mut all = drop_set.clone();
-            let retained = all.pop();
-            if let Some(r) = retained.clone() {
-                input_paths.push(r);
-            }
-            drop_set
-                .into_iter()
-                .filter(|p| Some(p) != retained.as_ref())
-                .collect()
-        } else {
-            drop_set
-        };
+        // Subtract the drop-set from the merger inputs (with the all-dropped guard);
+        // shared with the CLI one-shot path.
+        let (input_paths, dropped_whole) = merge::split_merge_and_dropped(&input_paths, drop_set);
 
         // Measure total bytes read (sum of Data.db file sizes as an approximation)
         let bytes_read: u64 = input_paths

--- a/cqlite-core/src/storage/write_engine/compaction.rs
+++ b/cqlite-core/src/storage/write_engine/compaction.rs
@@ -488,16 +488,26 @@ impl WriteEngine {
         // reclamation happens here — AFTER the merged output published — via the
         // same best-effort component-delete path as the merged inputs. A failure is
         // an invisible orphan (TOC.txt removed first) reclaimed on next startup.
-        for dropped in &merge.dropped_whole {
-            if let Err(e) = self.delete_sstable_files(dropped) {
-                log::warn!(
-                    "Failed to delete dropped-whole compaction input {:?}: {} \
-                     (merge output is valid; leftover is an invisible orphan)",
-                    dropped,
-                    e
-                );
-            }
-        }
+        //
+        // This surface already deleted EVERY merge input above, so pass
+        // `already_deleted = merge.input_paths`: in the degenerate all-expired case
+        // the SSTable the all-dropped guard retained as a merge input is ALSO in
+        // `dropped_whole`, and the loop above already reclaimed it — the dedup skips
+        // it here to avoid a double-delete + spurious orphan warning (roborev #1388).
+        crate::storage::write_engine::merge::reclaim_dropped_whole(
+            &merge.dropped_whole,
+            &merge.input_paths,
+            |dropped| {
+                if let Err(e) = self.delete_sstable_files(dropped) {
+                    log::warn!(
+                        "Failed to delete dropped-whole compaction input {:?}: {} \
+                         (merge output is valid; leftover is an invisible orphan)",
+                        dropped,
+                        e
+                    );
+                }
+            },
+        );
 
         // Step 4: Remove the now-empty tmp directory (best effort).
         if let Err(e) = std::fs::remove_dir_all(&merge.tmp_dir) {

--- a/cqlite-core/src/storage/write_engine/maintenance.rs
+++ b/cqlite-core/src/storage/write_engine/maintenance.rs
@@ -27,6 +27,13 @@ pub struct MaintenanceReport {
     pub bytes_written: u64,
     /// Whether there is pending compaction work
     pub pending_compaction: bool,
+    /// SSTables DROPPED WHOLE by the fully-expired fast path in the merge that
+    /// completed this step (issue #1388), distinct from the merged inputs: each was
+    /// proven fully expired by authoritative `Statistics.db` metadata and
+    /// overlap-safe, so it was excluded from the K-way merger (never read/decoded)
+    /// and its components were reclaimed after the merged output published. Empty
+    /// when nothing was dropped. Paths are input Data.db paths.
+    pub dropped_whole: Vec<PathBuf>,
 }
 
 /// Active merge state for incremental compaction (M5.2, Issue #384)
@@ -65,6 +72,13 @@ pub(crate) struct ActiveMerge {
     /// mutations so the writer still emits the static-row prelude (static-column
     /// presence is read from the input headers, not the current schema only).
     pub(crate) effective_schema: TableSchema,
+    /// SSTables DROPPED WHOLE for this compaction (issue #1388): proven fully
+    /// expired by authoritative `Statistics.db` metadata and overlap-safe, EXCLUDED
+    /// from `input_paths` (never read into the merger). Reclaimed in
+    /// `finalize_merge_async` AFTER the merged output publishes, via the same
+    /// component-delete path as the merged inputs, and surfaced in the
+    /// `MaintenanceReport`. Empty when nothing was dropped.
+    pub(crate) dropped_whole: Vec<PathBuf>,
 }
 
 impl WriteEngine {
@@ -215,6 +229,7 @@ impl WriteEngine {
             rows_merged: 0,
             bytes_written: 0,
             pending_compaction: false,
+            dropped_whole: Vec::new(),
         };
 
         // If no merge policy is set, no maintenance work to do
@@ -277,19 +292,25 @@ impl WriteEngine {
                 // full-compaction fast path. `candidates` is already scoped to
                 // this table's directory (see above), so the non-included set is
                 // exactly this table's outside SSTables.
+                // The non-included (outside) overlapping set for this table. Empty
+                // for a full compaction (`purge_safe == true`). Used both for the
+                // #935 overlap-purge bound below AND for the #1388 fully-expired
+                // drop-set overlap gate (see `start_merge`).
+                let non_included: Vec<PathBuf> = candidates
+                    .iter()
+                    .filter(|p| !selected_set.contains(*p))
+                    .cloned()
+                    .collect();
                 let max_purgeable_timestamp = if purge_safe {
                     None
                 } else {
-                    let non_included: Vec<PathBuf> = candidates
-                        .iter()
-                        .filter(|p| !selected_set.contains(*p))
-                        .cloned()
-                        .collect();
                     merge::compute_max_purgeable_timestamp(&non_included)
                 };
 
-                // Start a new merge
-                self.start_merge(selected, purge_safe, max_purgeable_timestamp)?;
+                // Start a new merge. `non_included` is threaded through so
+                // `start_merge` can compute the fully-expired drop-set (issue #1388)
+                // with the correct overlap gate.
+                self.start_merge(selected, purge_safe, max_purgeable_timestamp, non_included)?;
             } else {
                 // No work selected by policy
                 report.time_spent = start.elapsed();
@@ -668,6 +689,7 @@ mod tests {
             rows_merged: 1000,
             bytes_written: 1024 * 1024,
             pending_compaction: true,
+            dropped_whole: Vec::new(),
         };
 
         assert_eq!(report.time_spent.as_millis(), 250);

--- a/cqlite-core/src/storage/write_engine/merge/fully_expired.rs
+++ b/cqlite-core/src/storage/write_engine/merge/fully_expired.rs
@@ -1,0 +1,322 @@
+//! Fully-expired SSTable drop classification (issue #1388).
+//!
+//! Parity with Cassandra `CompactionController.getFullyExpiredSSTables`: before a
+//! compaction rewrites anything, classify the subset of input SSTables that are
+//! entirely past `gcBefore` AND provably shadow nothing outside the compaction
+//! set, so they can be DROPPED WHOLE (excluded from the K-way merge and reclaimed
+//! after the output publishes) instead of read, merged, and re-serialized.
+//!
+//! The classification is **metadata-only** — a single integer comparison against
+//! the authoritative `Statistics.db` `TimestampStatistics.max_deletion_time`
+//! (Cassandra `StatsMetadata.maxLocalDeletionTime`) plus the existing #935
+//! overlap bound (`compute_max_purgeable_timestamp`). It NEVER reads/decodes/scans
+//! a candidate's `Data.db` (no-heuristics mandate, issue #28): that is both the
+//! whole point of the optimization (dropping must not pay a scan) and the
+//! no-heuristics-compliant path. Trust in `Statistics.db` is already load-bearing
+//! across the write engine (`compute_baseline_min`, `compute_max_purgeable_timestamp`).
+
+#![cfg(feature = "write-support")]
+
+use std::path::{Path, PathBuf};
+
+use super::{compute_max_purgeable_timestamp, stats_path_for};
+use crate::parser::statistics::TimestampStatistics;
+
+/// Classify a candidate SSTable as *fully expired* for a compaction with cutoff
+/// `gc_before_secs` from AUTHORITATIVE `Statistics.db` metadata ONLY.
+///
+/// A candidate is fully expired iff EVERY cell/tombstone in it has
+/// `localDeletionTime < gcBefore`. The single authoritative field that proves this
+/// is `TimestampStatistics.max_deletion_time` (Cassandra
+/// `StatsMetadata.maxLocalDeletionTime`): if the MAXIMUM local-deletion-time in the
+/// SSTable is below `gcBefore`, all of them are. This is exactly Cassandra's
+/// `getFullyExpiredSSTables` predicate
+/// (`sstable.getSSTableMetadata().maxLocalDeletionTime < gcBefore`).
+///
+/// The LIVE / `NO_DELETION_TIME` sentinel (an SSTable holding any live, non-TTL
+/// data) surfaces from the parser as `i64::MAX`, which is never `< gcBefore`, so
+/// such an SSTable is correctly NOT classified fully expired — the sentinel falls
+/// out of the comparison naturally with no special-casing.
+pub(super) fn is_fully_expired(stats: &TimestampStatistics, gc_before_secs: i64) -> bool {
+    stats.max_deletion_time < gc_before_secs
+}
+
+/// Read a candidate SSTable's `TimestampStatistics` from its sibling
+/// `Statistics.db`. Returns `None` when the file is absent or fails to parse — the
+/// conservative signal that its expiry/timestamp facts are UNKNOWN, so the
+/// candidate must NOT be dropped (matches `compute_max_purgeable_timestamp`
+/// degradation). Authoritative metadata only (no cell scan).
+fn read_timestamp_stats(data_path: &Path) -> Option<TimestampStatistics> {
+    let stats_path = stats_path_for(data_path);
+    if !stats_path.exists() {
+        return None;
+    }
+    let stats_bytes = match std::fs::read(&stats_path) {
+        Ok(b) => b,
+        Err(e) => {
+            log::warn!(
+                "Could not read Statistics.db {:?} for fully-expired check: {}",
+                stats_path,
+                e
+            );
+            return None;
+        }
+    };
+    match crate::parser::enhanced_statistics_parser::parse_statistics_with_fallback(
+        &stats_bytes,
+        None,
+    ) {
+        Ok((_, sstable_stats)) => Some(sstable_stats.timestamp_stats),
+        Err(e) => {
+            log::warn!(
+                "Could not parse Statistics.db {:?} for fully-expired check: {:?}",
+                stats_path,
+                e
+            );
+            None
+        }
+    }
+}
+
+/// Compute the subset of `input_paths` that may be DROPPED WHOLE for this
+/// compaction (parity with Cassandra `CompactionController.getFullyExpiredSSTables`).
+///
+/// A candidate is included in the drop-set iff BOTH hold, from authoritative
+/// `Statistics.db` metadata only (no cell scan):
+///
+/// 1. **Fully expired** — `max_deletion_time < gc_before_secs` (see
+///    [`is_fully_expired`]).
+/// 2. **Overlap-safe** — its `max_timestamp` is STRICTLY LESS THAN the minimum
+///    write timestamp across every OUTSIDE overlapping SSTable, so nothing it holds
+///    (tombstone or data) can shadow older data living outside the compaction set
+///    (dropping it can never resurrect data). The outside bound is the identical
+///    coarse global-`min_timestamp` bound [`compute_max_purgeable_timestamp`]
+///    computes (issue #935 gate; OQ-2 → (A), key-range precision deferred).
+///
+/// Conservatism (never resurrect data, never drop live data):
+/// - `gc_before_secs == None` (invalid/absent gc_grace disables purging) ⇒ empty
+///   drop-set.
+/// - An empty `outside_paths` (a FULL/major compaction: nothing outside to shadow)
+///   ⇒ the overlap bound is `+inf` ⇒ every fully-expired candidate is droppable.
+/// - A non-empty `outside_paths` whose bound is UNKNOWN
+///   (`compute_max_purgeable_timestamp` returned `None` because an outside
+///   `Statistics.db` was unreadable) ⇒ empty drop-set (cannot prove safety).
+/// - A candidate whose own `Statistics.db` is absent/unreadable ⇒ not droppable.
+///
+/// The returned paths are a subset of `input_paths`, in input order.
+pub fn fully_expired_sstables(
+    input_paths: &[PathBuf],
+    outside_paths: &[PathBuf],
+    gc_before_secs: Option<i64>,
+) -> Vec<PathBuf> {
+    // No cutoff ⇒ purging is disabled ⇒ never drop (conservative, matches
+    // compute_gc_before degradation).
+    let Some(gc_before) = gc_before_secs else {
+        return Vec::new();
+    };
+
+    // Overlap bound. An empty outside set (full/major compaction) has nothing to
+    // shadow ⇒ +inf bound (i64::MAX): every fully-expired candidate is droppable.
+    // A non-empty outside set with an UNKNOWN bound (an outside Statistics.db could
+    // not be read/parsed) ⇒ we cannot prove safety ⇒ drop nothing.
+    let outside_bound: i64 = if outside_paths.is_empty() {
+        i64::MAX
+    } else {
+        match compute_max_purgeable_timestamp(outside_paths) {
+            Some(bound) => bound,
+            None => return Vec::new(),
+        }
+    };
+
+    input_paths
+        .iter()
+        .filter(|data_path| {
+            let Some(stats) = read_timestamp_stats(data_path) else {
+                // Unknown candidate metadata ⇒ not droppable.
+                return false;
+            };
+            // Fully expired AND provably shadows nothing outside the set.
+            is_fully_expired(&stats, gc_before) && stats.max_timestamp < outside_bound
+        })
+        .cloned()
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::sstable::writer::{StatisticsMetadata, StatisticsWriter};
+    use tempfile::TempDir;
+
+    /// Construct a `TimestampStatistics` with the two fields the drop decision
+    /// consults set explicitly; the rest are irrelevant.
+    fn ts_stats(max_deletion_time: i64, max_timestamp: i64) -> TimestampStatistics {
+        TimestampStatistics {
+            min_timestamp: 0,
+            max_timestamp,
+            min_deletion_time: 0,
+            max_deletion_time,
+            min_ttl: None,
+            max_ttl: None,
+            rows_with_ttl: 0,
+        }
+    }
+
+    /// R1: an all-expired SSTable (`max_deletion_time < gcBefore`) is classified
+    /// fully expired.
+    #[test]
+    fn is_fully_expired_true_when_max_ldt_below_gc_before() {
+        assert!(is_fully_expired(&ts_stats(900, 0), 1_000));
+    }
+
+    /// R1: `max_deletion_time` at or above `gcBefore` is NOT fully expired (the
+    /// strict `<` predicate retains the boundary, matching Cassandra).
+    #[test]
+    fn is_fully_expired_false_at_or_above_gc_before() {
+        assert!(!is_fully_expired(&ts_stats(1_000, 0), 1_000));
+        assert!(!is_fully_expired(&ts_stats(1_500, 0), 1_000));
+    }
+
+    /// R1: the LIVE / NO_DELETION_TIME sentinel (`i64::MAX`) is never expired.
+    #[test]
+    fn is_fully_expired_false_for_live_sentinel() {
+        assert!(!is_fully_expired(&ts_stats(i64::MAX, 0), 1_000));
+    }
+
+    /// Write a synthetic Statistics.db beside a zero-byte Data.db, returning the
+    /// Data.db path. `max_ldt == i32::MAX` = "no tombstones / live" (parses back as
+    /// the `i64::MAX` NO_DELETION_TIME sentinel).
+    fn write_expiry_stats(dir: &Path, gen: u32, max_ldt: i32, max_ts: i64, min_ts: i64) -> PathBuf {
+        let data_path = dir.join(format!("nb-{gen}-big-Data.db"));
+        std::fs::write(&data_path, b"synthetic-data-never-read").expect("touch Data.db");
+        let stats_path = dir.join(format!("nb-{gen}-big-Statistics.db"));
+        let mut meta = StatisticsMetadata::new();
+        meta.max_local_deletion_time = max_ldt;
+        meta.min_local_deletion_time = max_ldt.min(0);
+        meta.max_timestamp = max_ts;
+        meta.min_timestamp = min_ts;
+        StatisticsWriter::new(stats_path)
+            .write(&meta, None)
+            .expect("write Statistics.db");
+        data_path
+    }
+
+    /// R1 scenario "classified fully expired without a cell scan": the drop-set is
+    /// computed purely from Statistics.db metadata. Proven by DELETING the
+    /// candidate's Data.db after writing its Statistics.db — classification still
+    /// succeeds because it never touches Data.db.
+    #[test]
+    fn fully_expired_detection_reads_no_data_db() {
+        let tmp = TempDir::new().expect("temp dir");
+        let cand = write_expiry_stats(tmp.path(), 1, 500, 10_000, 5_000);
+        std::fs::remove_file(&cand).expect("remove Data.db to prove no read");
+
+        let dropped = fully_expired_sstables(&[cand.clone()], &[], Some(1_000));
+        assert_eq!(
+            dropped,
+            vec![cand],
+            "fully-expired classification must come from Statistics.db alone, no Data.db read"
+        );
+    }
+
+    /// R1 scenario: a live SSTable is never dropped.
+    #[test]
+    fn live_sstable_never_dropped() {
+        let tmp = TempDir::new().expect("temp dir");
+        let live = write_expiry_stats(tmp.path(), 1, i32::MAX, 10_000, 5_000);
+        let dropped = fully_expired_sstables(&[live], &[], Some(1_000));
+        assert!(dropped.is_empty(), "a live SSTable must never be dropped");
+    }
+
+    /// R1 scenario: `gcBefore == None` drops nothing, even for an expired SSTable.
+    #[test]
+    fn fully_expired_none_gc_before_drops_nothing() {
+        let tmp = TempDir::new().expect("temp dir");
+        let cand = write_expiry_stats(tmp.path(), 1, 500, 10_000, 5_000);
+        let dropped = fully_expired_sstables(&[cand], &[], None);
+        assert!(
+            dropped.is_empty(),
+            "None gcBefore must disable dropping (conservative)"
+        );
+    }
+
+    /// R1 scenario: an unreadable/absent candidate Statistics.db drops nothing.
+    #[test]
+    fn fully_expired_unreadable_candidate_stats_drops_nothing() {
+        let tmp = TempDir::new().expect("temp dir");
+        let cand = tmp.path().join("nb-1-big-Data.db");
+        std::fs::write(&cand, b"").expect("touch Data.db");
+        let dropped = fully_expired_sstables(&[cand], &[], Some(1_000));
+        assert!(
+            dropped.is_empty(),
+            "an unreadable candidate Statistics.db must not be dropped"
+        );
+    }
+
+    /// R2 scenario: a fully-expired candidate that could shadow older data outside
+    /// the set is RETAINED.
+    #[test]
+    fn overlap_gate_retains_shadowing_candidate() {
+        let tmp = TempDir::new().expect("temp dir");
+        let cand = write_expiry_stats(tmp.path(), 1, 500, 10_000, 8_000);
+        // Outside min write ts (5_000) <= candidate max_timestamp (10_000) ⇒ retain.
+        let outside = write_expiry_stats(tmp.path(), 2, i32::MAX, 20_000, 5_000);
+        let dropped = fully_expired_sstables(&[cand], &[outside], Some(1_000));
+        assert!(
+            dropped.is_empty(),
+            "a candidate that could shadow older outside data must be retained"
+        );
+    }
+
+    /// R2 scenario: a fully-expired candidate older than everything outside the
+    /// set is DROPPED.
+    #[test]
+    fn overlap_gate_drops_candidate_older_than_outside() {
+        let tmp = TempDir::new().expect("temp dir");
+        let cand = write_expiry_stats(tmp.path(), 1, 500, 4_000, 1_000);
+        // Outside min write ts (5_000) > candidate max_timestamp (4_000) ⇒ drop.
+        let outside = write_expiry_stats(tmp.path(), 2, i32::MAX, 20_000, 5_000);
+        let dropped = fully_expired_sstables(&[cand.clone()], &[outside], Some(1_000));
+        assert_eq!(
+            dropped,
+            vec![cand],
+            "a candidate older than every outside SSTable must be dropped"
+        );
+    }
+
+    /// R2 scenario: a major/full compaction (empty outside set) drops every
+    /// fully-expired candidate (+inf overlap bound), keeping live.
+    #[test]
+    fn major_compaction_empty_outside_drops_all_expired() {
+        let tmp = TempDir::new().expect("temp dir");
+        let expired_a = write_expiry_stats(tmp.path(), 1, 500, 10_000, 5_000);
+        let expired_b = write_expiry_stats(tmp.path(), 2, 800, i64::MAX, 5_000);
+        let live = write_expiry_stats(tmp.path(), 3, i32::MAX, 10_000, 5_000);
+        let dropped = fully_expired_sstables(
+            &[expired_a.clone(), live, expired_b.clone()],
+            &[],
+            Some(1_000),
+        );
+        assert_eq!(
+            dropped,
+            vec![expired_a, expired_b],
+            "a major compaction drops every fully-expired input (+inf bound), keeping live"
+        );
+    }
+
+    /// R2 scenario: an UNKNOWN outside bound in a PARTIAL compaction retains ALL
+    /// fully-expired candidates.
+    #[test]
+    fn unknown_outside_bound_retains_all() {
+        let tmp = TempDir::new().expect("temp dir");
+        let cand = write_expiry_stats(tmp.path(), 1, 500, 4_000, 1_000);
+        // Outside Data.db with NO sibling Statistics.db ⇒ unknown bound.
+        let outside = tmp.path().join("nb-2-big-Data.db");
+        std::fs::write(&outside, b"").expect("touch outside Data.db");
+        let dropped = fully_expired_sstables(&[cand], &[outside], Some(1_000));
+        assert!(
+            dropped.is_empty(),
+            "an unknown outside bound in a partial compaction must retain all candidates"
+        );
+    }
+}

--- a/cqlite-core/src/storage/write_engine/merge/fully_expired.rs
+++ b/cqlite-core/src/storage/write_engine/merge/fully_expired.rs
@@ -235,14 +235,19 @@ fn classify_drop_set(
 /// (a subset of `input_paths`, e.g. from [`fully_expired_sstables`]).
 ///
 /// `merge_inputs` is `input_paths` minus the drop-set — the SSTables the K-way
-/// merger will actually read. `dropped_whole` is the SSTables to exclude and
-/// reclaim after publish.
+/// merger will actually read. `dropped_whole` is the FULL drop-set: the SSTables
+/// proven fully expired + overlap-safe, to be reported and reclaimed after
+/// publish.
 ///
 /// Degenerate all-dropped guard: the merger requires at least one input, so when
 /// the drop-set is EVERY input (a major compaction of an only-expired input set),
-/// one dropped SSTable is retained in `merge_inputs` (its rows purge to empty
-/// through the normal merge path) and removed from `dropped_whole`. Correctness is
-/// preserved and no read cost is paid for the remaining dropped SSTables.
+/// ONE dropped SSTable is ALSO retained in `merge_inputs` (its rows purge to empty
+/// through the normal merge path) so the merger has a source. That retained
+/// SSTable stays in `dropped_whole` too, so the drop is reported honestly and
+/// reclaimed on both surfaces (roborev #1388 Medium): the reclaim loops dedupe
+/// against `merge_inputs` (which the core WriteEngine path deletes anyway) so the
+/// retained SSTable is deleted exactly once. Only the retained SSTable pays a read
+/// cost; the rest are still excluded from the merge.
 ///
 /// Shared by both compaction surfaces so the exclusion + all-dropped guard live in
 /// one place (issue #1388).
@@ -259,13 +264,43 @@ pub(crate) fn split_merge_and_dropped(
     if !merge_inputs.is_empty() {
         return (merge_inputs, drop_set);
     }
-    // Everything was dropped: retain one for the merger; the rest stay dropped.
-    // `pop` removes the retained SSTable from the drop-set in one step.
-    let mut dropped_whole = drop_set;
-    if let Some(retained) = dropped_whole.pop() {
-        merge_inputs.push(retained);
+    // Everything was dropped: retain one for the merger. It STAYS in the drop-set
+    // so the drop is reported/reclaimed honestly; reclaim sites dedupe against
+    // `merge_inputs` to delete it exactly once (roborev #1388 Medium).
+    if let Some(retained) = drop_set.first() {
+        merge_inputs.push(retained.clone());
     }
-    (merge_inputs, dropped_whole)
+    (merge_inputs, drop_set)
+}
+
+/// Reclaim (best-effort component-delete) each SSTable in `dropped_whole` that the
+/// caller is NOT already deleting via another path, calling `delete` on the
+/// survivors. The degenerate all-dropped guard retains one dropped SSTable in BOTH
+/// `dropped_whole` and `merge_inputs` (see [`split_merge_and_dropped`]), so it is
+/// reclaimed exactly once:
+///
+/// - Core WriteEngine surface: it deletes ALL merge inputs separately, so it
+///   passes `already_deleted = merge_inputs` here to skip the retained one (avoid a
+///   double-delete + spurious orphan warning).
+/// - CLI one-shot surface: it deletes NO merge inputs (the operator owns the input
+///   dir; output lands in a separate `--output` dir), so it passes an EMPTY
+///   `already_deleted` and the retained SSTable IS reclaimed here — closing the
+///   former "all-expired input left on disk" gap (roborev #1388 Medium).
+///
+/// `delete` is the surface's own best-effort delete (logs, never errors), so this
+/// helper only decides the set to reclaim.
+pub(crate) fn reclaim_dropped_whole<F: FnMut(&Path)>(
+    dropped_whole: &[PathBuf],
+    already_deleted: &[PathBuf],
+    mut delete: F,
+) {
+    let skip: std::collections::HashSet<&PathBuf> = already_deleted.iter().collect();
+    for dropped in dropped_whole {
+        if skip.contains(dropped) {
+            continue;
+        }
+        delete(dropped);
+    }
 }
 
 #[cfg(test)]
@@ -524,6 +559,76 @@ mod tests {
         assert_eq!(
             authoritative_max_timestamp(&ts_stats(0, i64::MIN + 1)),
             Some(i64::MIN + 1)
+        );
+    }
+
+    /// Roborev #1388 (Medium): the all-dropped guard retains ONE input for the
+    /// merger but keeps the FULL drop-set in `dropped_whole` (so nothing is
+    /// underreported or left unreclaimed). The retained input appears in BOTH
+    /// returned lists; reclaim sites dedup it.
+    #[test]
+    fn split_all_dropped_retains_one_but_reports_full_drop_set() {
+        let a = PathBuf::from("nb-1-big-Data.db");
+        let b = PathBuf::from("nb-2-big-Data.db");
+        let inputs = [a.clone(), b.clone()];
+        let drop_set = vec![a.clone(), b.clone()];
+
+        let (merge_inputs, dropped_whole) = split_merge_and_dropped(&inputs, drop_set);
+        assert_eq!(
+            merge_inputs.len(),
+            1,
+            "exactly one input is retained for the merger's at-least-one requirement"
+        );
+        assert_eq!(
+            dropped_whole,
+            vec![a, b],
+            "the FULL drop-set is still reported (no underreporting)"
+        );
+        assert!(
+            dropped_whole.contains(&merge_inputs[0]),
+            "the retained merger input is also in the reported drop-set"
+        );
+    }
+
+    /// A partial drop-set (a live input survives) leaves `merge_inputs` non-empty
+    /// and `dropped_whole` unchanged — the guard does not fire.
+    #[test]
+    fn split_partial_drop_leaves_live_input_and_full_drop_set() {
+        let expired = PathBuf::from("nb-1-big-Data.db");
+        let live = PathBuf::from("nb-2-big-Data.db");
+        let inputs = [expired.clone(), live.clone()];
+        let (merge_inputs, dropped_whole) = split_merge_and_dropped(&inputs, vec![expired.clone()]);
+        assert_eq!(merge_inputs, vec![live], "only the live input is merged");
+        assert_eq!(dropped_whole, vec![expired], "the expired input is dropped");
+    }
+
+    /// [`reclaim_dropped_whole`] deletes only the drops NOT already deleted by the
+    /// caller: the core surface (which deletes all merge inputs) skips the retained
+    /// one; the CLI surface (empty `already_deleted`) reclaims every drop.
+    #[test]
+    fn reclaim_dedups_against_already_deleted() {
+        let a = PathBuf::from("nb-1-big-Data.db");
+        let b = PathBuf::from("nb-2-big-Data.db");
+        let dropped_whole = [a.clone(), b.clone()];
+
+        // Core surface: `b` is the retained merge input (already deleted) ⇒ only `a`.
+        let mut core_deleted = Vec::new();
+        reclaim_dropped_whole(&dropped_whole, &[b.clone()], |p| {
+            core_deleted.push(p.to_path_buf())
+        });
+        assert_eq!(
+            core_deleted,
+            vec![a.clone()],
+            "core surface skips the retained merge input to avoid a double-delete"
+        );
+
+        // CLI surface: nothing pre-deleted ⇒ both reclaimed here.
+        let mut cli_deleted = Vec::new();
+        reclaim_dropped_whole(&dropped_whole, &[], |p| cli_deleted.push(p.to_path_buf()));
+        assert_eq!(
+            cli_deleted,
+            vec![a, b],
+            "CLI surface reclaims every drop (it deletes no merge inputs otherwise)"
         );
     }
 

--- a/cqlite-core/src/storage/write_engine/merge/fully_expired.rs
+++ b/cqlite-core/src/storage/write_engine/merge/fully_expired.rs
@@ -181,6 +181,43 @@ pub fn fully_expired_sstables(
         .collect()
 }
 
+/// Split `input_paths` into `(merge_inputs, dropped_whole)` given a `drop_set`
+/// (a subset of `input_paths`, e.g. from [`fully_expired_sstables`]).
+///
+/// `merge_inputs` is `input_paths` minus the drop-set — the SSTables the K-way
+/// merger will actually read. `dropped_whole` is the SSTables to exclude and
+/// reclaim after publish.
+///
+/// Degenerate all-dropped guard: the merger requires at least one input, so when
+/// the drop-set is EVERY input (a major compaction of an only-expired input set),
+/// one dropped SSTable is retained in `merge_inputs` (its rows purge to empty
+/// through the normal merge path) and removed from `dropped_whole`. Correctness is
+/// preserved and no read cost is paid for the remaining dropped SSTables.
+///
+/// Shared by both compaction surfaces so the exclusion + all-dropped guard live in
+/// one place (issue #1388).
+pub(crate) fn split_merge_and_dropped(
+    input_paths: &[PathBuf],
+    drop_set: Vec<PathBuf>,
+) -> (Vec<PathBuf>, Vec<PathBuf>) {
+    let dropped_lookup: std::collections::HashSet<&PathBuf> = drop_set.iter().collect();
+    let mut merge_inputs: Vec<PathBuf> = input_paths
+        .iter()
+        .filter(|p| !dropped_lookup.contains(*p))
+        .cloned()
+        .collect();
+    if !merge_inputs.is_empty() {
+        return (merge_inputs, drop_set);
+    }
+    // Everything was dropped: retain one for the merger; the rest stay dropped.
+    // `pop` removes the retained SSTable from the drop-set in one step.
+    let mut dropped_whole = drop_set;
+    if let Some(retained) = dropped_whole.pop() {
+        merge_inputs.push(retained);
+    }
+    (merge_inputs, dropped_whole)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/cqlite-core/src/storage/write_engine/merge/fully_expired.rs
+++ b/cqlite-core/src/storage/write_engine/merge/fully_expired.rs
@@ -14,8 +14,9 @@
 //! whole point of the optimization (dropping must not pay a scan) and the
 //! no-heuristics-compliant path. Trust in `Statistics.db` is already load-bearing
 //! across the write engine (`compute_baseline_min`, `compute_max_purgeable_timestamp`).
-
-#![cfg(feature = "write-support")]
+//!
+//! The whole module is gated `#[cfg(feature = "write-support")]` at its `mod`
+//! declaration in the parent, so no inner `#![cfg]` is needed here.
 
 use std::path::{Path, PathBuf};
 
@@ -87,21 +88,36 @@ fn read_timestamp_stats(data_path: &Path) -> Option<TimestampStatistics> {
 /// 1. **Fully expired** — `max_deletion_time < gc_before_secs` (see
 ///    [`is_fully_expired`]).
 /// 2. **Overlap-safe** — its `max_timestamp` is STRICTLY LESS THAN the minimum
-///    write timestamp across every OUTSIDE overlapping SSTable, so nothing it holds
-///    (tombstone or data) can shadow older data living outside the compaction set
-///    (dropping it can never resurrect data). The outside bound is the identical
-///    coarse global-`min_timestamp` bound [`compute_max_purgeable_timestamp`]
-///    computes (issue #935 gate; OQ-2 → (A), key-range precision deferred).
+///    write timestamp across every overlapping SSTable that is NOT itself
+///    fully-expired: both the OUTSIDE overlapping SSTables (`outside_paths`) AND
+///    the NON-EXPIRED inputs of THIS compaction. If the candidate's newest write
+///    predates all of them, nothing it holds (tombstone or data) can shadow live
+///    data that would otherwise survive, so dropping it can never resurrect data.
+///    Mirrors Cassandra `CompactionController.getFullyExpiredSSTables`, which folds
+///    the min write timestamp of the non-fully-expired *compacting* SSTables into
+///    the same overlap bound as the non-compacting overlapping ones. The
+///    non-compacting bound reuses [`compute_max_purgeable_timestamp`] (the coarse
+///    global-`min_timestamp` #935 gate; OQ-2 → (A), key-range precision deferred).
+///
+/// A non-expired INPUT is included in the bound because dropping a fully-expired
+/// SSTable whose tombstone shadows an OLDER live cell in a *co-compacting* input
+/// would resurrect that cell: the tombstone (dropped) no longer purges it, and the
+/// co-input's live cell is merged into the output. (A fully-expired co-input is NOT
+/// folded in: its own data is past `gcBefore` and would be purged anyway, so a
+/// tombstone shadowing it can never resurrect surviving data.)
 ///
 /// Conservatism (never resurrect data, never drop live data):
 /// - `gc_before_secs == None` (invalid/absent gc_grace disables purging) ⇒ empty
 ///   drop-set.
-/// - An empty `outside_paths` (a FULL/major compaction: nothing outside to shadow)
-///   ⇒ the overlap bound is `+inf` ⇒ every fully-expired candidate is droppable.
+/// - An empty `outside_paths` AND no non-expired inputs (e.g. a FULL/major
+///   compaction of only-expired SSTables) ⇒ the bound is `+inf` ⇒ every candidate
+///   is droppable.
 /// - A non-empty `outside_paths` whose bound is UNKNOWN
 ///   (`compute_max_purgeable_timestamp` returned `None` because an outside
 ///   `Statistics.db` was unreadable) ⇒ empty drop-set (cannot prove safety).
-/// - A candidate whose own `Statistics.db` is absent/unreadable ⇒ not droppable.
+/// - A candidate whose own `Statistics.db` is absent/unreadable ⇒ not droppable
+///   (it is treated as non-expired, and its `min_timestamp` is unknown, so it also
+///   cannot lower the bound — the whole drop-set is disabled to stay safe).
 ///
 /// The returned paths are a subset of `input_paths`, in input order.
 pub fn fully_expired_sstables(
@@ -115,11 +131,20 @@ pub fn fully_expired_sstables(
         return Vec::new();
     };
 
-    // Overlap bound. An empty outside set (full/major compaction) has nothing to
-    // shadow ⇒ +inf bound (i64::MAX): every fully-expired candidate is droppable.
-    // A non-empty outside set with an UNKNOWN bound (an outside Statistics.db could
-    // not be read/parsed) ⇒ we cannot prove safety ⇒ drop nothing.
-    let outside_bound: i64 = if outside_paths.is_empty() {
+    // Read each input's timestamp stats ONCE. A candidate whose own Statistics.db
+    // is unreadable is treated as non-expired (not droppable) AND, because its
+    // min_timestamp is then unknown, it cannot be safely folded into the overlap
+    // bound — so an unreadable INPUT disables the whole drop-set (conservative).
+    let mut input_stats: Vec<(&PathBuf, Option<TimestampStatistics>)> =
+        Vec::with_capacity(input_paths.len());
+    for p in input_paths {
+        input_stats.push((p, read_timestamp_stats(p)));
+    }
+
+    // Outside overlap bound (non-compacting overlapping SSTables). An empty outside
+    // set contributes +inf; a non-empty set with an UNKNOWN bound (an outside
+    // Statistics.db unreadable) ⇒ cannot prove safety ⇒ drop nothing.
+    let mut overlap_bound: i64 = if outside_paths.is_empty() {
         i64::MAX
     } else {
         match compute_max_purgeable_timestamp(outside_paths) {
@@ -128,17 +153,31 @@ pub fn fully_expired_sstables(
         }
     };
 
-    input_paths
-        .iter()
-        .filter(|data_path| {
-            let Some(stats) = read_timestamp_stats(data_path) else {
-                // Unknown candidate metadata ⇒ not droppable.
-                return false;
-            };
-            // Fully expired AND provably shadows nothing outside the set.
-            is_fully_expired(&stats, gc_before) && stats.max_timestamp < outside_bound
+    // Fold in the min write timestamp of every NON-EXPIRED input of THIS
+    // compaction (Cassandra parity). A fully-expired input does not constrain the
+    // bound (its own data is past gcBefore and purged anyway). An input whose
+    // stats could not be read is NON-expired with an UNKNOWN min_timestamp, which
+    // we cannot fold safely ⇒ disable the drop-set.
+    for (_, stats) in &input_stats {
+        match stats {
+            Some(s) if is_fully_expired(s, gc_before) => {}
+            Some(s) => overlap_bound = overlap_bound.min(s.min_timestamp),
+            None => return Vec::new(),
+        }
+    }
+
+    input_stats
+        .into_iter()
+        .filter_map(|(path, stats)| {
+            let stats = stats?;
+            // Fully expired AND provably shadows nothing that would otherwise
+            // survive (its newest write predates every non-expired overlap).
+            if is_fully_expired(&stats, gc_before) && stats.max_timestamp < overlap_bound {
+                Some(path.clone())
+            } else {
+                None
+            }
         })
-        .cloned()
         .collect()
 }
 
@@ -285,12 +324,17 @@ mod tests {
     }
 
     /// R2 scenario: a major/full compaction (empty outside set) drops every
-    /// fully-expired candidate (+inf overlap bound), keeping live.
+    /// fully-expired candidate whose newest write predates the co-compacting live
+    /// input's oldest write, keeping the live input. Expired data is OLDER than the
+    /// live data (the realistic case), so both expired inputs are droppable.
     #[test]
-    fn major_compaction_empty_outside_drops_all_expired() {
+    fn major_compaction_empty_outside_drops_expired_older_than_live() {
         let tmp = TempDir::new().expect("temp dir");
-        let expired_a = write_expiry_stats(tmp.path(), 1, 500, 10_000, 5_000);
-        let expired_b = write_expiry_stats(tmp.path(), 2, 800, i64::MAX, 5_000);
+        // Expired inputs at LOW write timestamps (older than the live input).
+        let expired_a = write_expiry_stats(tmp.path(), 1, 500, 3_000, 1_000);
+        let expired_b = write_expiry_stats(tmp.path(), 2, 800, 4_000, 1_000);
+        // Live co-input at a HIGHER min write ts (5_000): the expired tombstones
+        // (max_ts 3_000/4_000) predate it, so dropping them resurrects nothing.
         let live = write_expiry_stats(tmp.path(), 3, i32::MAX, 10_000, 5_000);
         let dropped = fully_expired_sstables(
             &[expired_a.clone(), live, expired_b.clone()],
@@ -300,7 +344,27 @@ mod tests {
         assert_eq!(
             dropped,
             vec![expired_a, expired_b],
-            "a major compaction drops every fully-expired input (+inf bound), keeping live"
+            "a major compaction drops fully-expired inputs older than the live co-input, keeping live"
+        );
+    }
+
+    /// R2 scenario (Cassandra parity / #1384 regression guard): a fully-expired
+    /// input whose tombstone could shadow OLDER live data in a CO-COMPACTING input
+    /// is NOT dropped — even in a full compaction (empty outside set). Folding the
+    /// non-expired input's min write timestamp into the overlap bound prevents the
+    /// resurrection that dropping the tombstone whole would otherwise cause.
+    #[test]
+    fn co_input_shadowing_expired_sstable_not_dropped() {
+        let tmp = TempDir::new().expect("temp dir");
+        // Fully-expired input holding a tombstone at a HIGH write ts (10_000): it
+        // would shadow the live co-input's older data.
+        let expired = write_expiry_stats(tmp.path(), 1, 500, 10_000, 9_000);
+        // Live co-input with OLDER data (min write ts 5_000 <= tombstone max_ts).
+        let live = write_expiry_stats(tmp.path(), 2, i32::MAX, 8_000, 5_000);
+        let dropped = fully_expired_sstables(&[expired, live], &[], Some(1_000));
+        assert!(
+            dropped.is_empty(),
+            "an expired input whose tombstone shadows a co-input's older live data must not be dropped"
         );
     }
 

--- a/cqlite-core/src/storage/write_engine/merge/fully_expired.rs
+++ b/cqlite-core/src/storage/write_engine/merge/fully_expired.rs
@@ -42,6 +42,20 @@ pub(super) fn is_fully_expired(stats: &TimestampStatistics, gc_before_secs: i64)
     stats.max_deletion_time < gc_before_secs
 }
 
+/// The authoritative newest write timestamp of an SSTable, or `None` when it is
+/// UNAVAILABLE (#1729 fail-closed `i64::MIN` sentinel).
+///
+/// Mirrors [`crate::storage::sstable::statistics_reader::StatisticsReader::max_timestamp`]:
+/// a drop/GC gate must never treat an unknown newest write as `i64::MIN` (which
+/// would compare below any overlap bound and wrongly permit a drop). Returning
+/// `None` here forces the overlap gate to FAIL CLOSED (retain the candidate).
+fn authoritative_max_timestamp(stats: &TimestampStatistics) -> Option<i64> {
+    match stats.max_timestamp {
+        i64::MIN => None,
+        v => Some(v),
+    }
+}
+
 /// Read a candidate SSTable's `TimestampStatistics` from its sibling
 /// `Statistics.db`. Returns `None` when the file is absent or fails to parse — the
 /// conservative signal that its expiry/timestamp facts are UNKNOWN, so the
@@ -86,18 +100,28 @@ fn read_timestamp_stats(data_path: &Path) -> Option<TimestampStatistics> {
 /// `Statistics.db` metadata only (no cell scan):
 ///
 /// 1. **Fully expired** — `max_deletion_time < gc_before_secs` (see
-///    [`is_fully_expired`]).
-/// 2. **Overlap-safe** — its `max_timestamp` is STRICTLY LESS THAN the minimum
-///    write timestamp across every overlapping SSTable that is NOT itself
-///    fully-expired: both the OUTSIDE overlapping SSTables (`outside_paths`) AND
-///    the NON-EXPIRED inputs of THIS compaction. If the candidate's newest write
-///    predates all of them, nothing it holds (tombstone or data) can shadow live
-///    data that would otherwise survive, so dropping it can never resurrect data.
-///    Mirrors Cassandra `CompactionController.getFullyExpiredSSTables`, which folds
-///    the min write timestamp of the non-fully-expired *compacting* SSTables into
-///    the same overlap bound as the non-compacting overlapping ones. The
+///    [`is_fully_expired`]). Since #1728 the writer stamps live cells with the
+///    `NO_DELETION_TIME` sentinel, so a MIXED SSTable (an old tombstone below
+///    `gcBefore` PLUS any live non-TTL cell) finalizes `max_deletion_time` as the
+///    `i32::MAX` live sentinel (parsed back as `i64::MAX`), which is never
+///    `< gc_before_secs`. Such a mixed SSTable is therefore correctly NOT
+///    fully-expired — closing the former data-loss gap (roborev F1) with the now
+///    authoritative `max_local_deletion_time`.
+/// 2. **Overlap-safe** — its authoritative `max_timestamp` is STRICTLY LESS THAN
+///    the minimum write timestamp across every overlapping SSTable that is NOT
+///    itself fully-expired: both the OUTSIDE overlapping SSTables (`outside_paths`)
+///    AND the NON-EXPIRED inputs of THIS compaction. If the candidate's newest
+///    write predates all of them, nothing it holds (tombstone or data) can shadow
+///    live data that would otherwise survive, so dropping it can never resurrect
+///    data. Mirrors Cassandra `CompactionController.getFullyExpiredSSTables`, which
+///    folds the min write timestamp of the non-fully-expired *compacting* SSTables
+///    into the same overlap bound as the non-compacting overlapping ones. The
 ///    non-compacting bound reuses [`compute_max_purgeable_timestamp`] (the coarse
 ///    global-`min_timestamp` #935 gate; OQ-2 → (A), key-range precision deferred).
+///    Since #1729 the candidate's `max_timestamp` may be the `i64::MIN` UNAVAILABLE
+///    sentinel; a candidate whose newest write is unknown CANNOT be proven to
+///    predate the overlap bound, so it FAILS CLOSED (is retained, never dropped) —
+///    closing the former resurrection gap (roborev F2).
 ///
 /// A non-expired INPUT is included in the bound because dropping a fully-expired
 /// SSTable whose tombstone shadows an OLDER live cell in a *co-compacting* input
@@ -144,13 +168,36 @@ pub fn fully_expired_sstables(
     // Outside overlap bound (non-compacting overlapping SSTables). An empty outside
     // set contributes +inf; a non-empty set with an UNKNOWN bound (an outside
     // Statistics.db unreadable) ⇒ cannot prove safety ⇒ drop nothing.
-    let mut overlap_bound: i64 = if outside_paths.is_empty() {
-        i64::MAX
+    let outside_bound: Option<i64> = if outside_paths.is_empty() {
+        Some(i64::MAX)
     } else {
         match compute_max_purgeable_timestamp(outside_paths) {
-            Some(bound) => bound,
+            Some(bound) => Some(bound),
             None => return Vec::new(),
         }
+    };
+
+    classify_drop_set(&input_stats, outside_bound, gc_before)
+}
+
+/// Pure drop-set classifier over already-read stats (no I/O), shared by
+/// [`fully_expired_sstables`] and its regression tests.
+///
+/// `outside_bound` is the overlap bound from the OUTSIDE (non-compacting) SSTables:
+/// `Some(i64::MAX)` for an empty outside set (+inf), `Some(b)` for a known bound,
+/// and callers must have already returned an empty drop-set for an UNKNOWN outside
+/// bound before calling this. It is here typed `Option` only so a caller can pass a
+/// resolved bound; a `None` here fails closed (empty drop-set).
+///
+/// Returns the subset of paths (in order) that may be dropped whole. See
+/// [`fully_expired_sstables`] for the full contract.
+fn classify_drop_set(
+    input_stats: &[(&PathBuf, Option<TimestampStatistics>)],
+    outside_bound: Option<i64>,
+    gc_before: i64,
+) -> Vec<PathBuf> {
+    let Some(mut overlap_bound) = outside_bound else {
+        return Vec::new();
     };
 
     // Fold in the min write timestamp of every NON-EXPIRED input of THIS
@@ -158,7 +205,7 @@ pub fn fully_expired_sstables(
     // bound (its own data is past gcBefore and purged anyway). An input whose
     // stats could not be read is NON-expired with an UNKNOWN min_timestamp, which
     // we cannot fold safely ⇒ disable the drop-set.
-    for (_, stats) in &input_stats {
+    for (_, stats) in input_stats {
         match stats {
             Some(s) if is_fully_expired(s, gc_before) => {}
             Some(s) => overlap_bound = overlap_bound.min(s.min_timestamp),
@@ -167,13 +214,16 @@ pub fn fully_expired_sstables(
     }
 
     input_stats
-        .into_iter()
+        .iter()
         .filter_map(|(path, stats)| {
-            let stats = stats?;
+            let stats = stats.as_ref()?;
             // Fully expired AND provably shadows nothing that would otherwise
             // survive (its newest write predates every non-expired overlap).
-            if is_fully_expired(&stats, gc_before) && stats.max_timestamp < overlap_bound {
-                Some(path.clone())
+            // #1729: an UNAVAILABLE max_timestamp (i64::MIN sentinel) cannot be
+            // proven to predate the bound ⇒ fail closed (retain, never drop).
+            let candidate_max_ts = authoritative_max_timestamp(stats)?;
+            if is_fully_expired(stats, gc_before) && candidate_max_ts < overlap_bound {
+                Some((*path).clone())
             } else {
                 None
             }
@@ -402,6 +452,78 @@ mod tests {
         assert!(
             dropped.is_empty(),
             "an expired input whose tombstone shadows a co-input's older live data must not be dropped"
+        );
+    }
+
+    /// Roborev F2 (former resurrection) regression: the overlap gate compares the
+    /// candidate's TRUE NEWEST write (`max_timestamp`, #1729-authoritative), not its
+    /// `min_timestamp`. A candidate whose `min_timestamp < overlap_bound <
+    /// max_timestamp` (an old tombstone min but a NEWER tombstone max) is RETAINED —
+    /// its newest write does NOT predate the outside data, so dropping it could
+    /// resurrect data. A gate that mistakenly used `min_timestamp` would drop it.
+    #[test]
+    fn overlap_gate_uses_max_timestamp_not_min_retains_when_max_above_bound() {
+        let tmp = TempDir::new().expect("temp dir");
+        // Candidate: fully expired (LDT 500 < 1_000), min write ts 1_000 (OLD),
+        // max write ts 8_000 (NEW — a later tombstone/write in the same SSTable).
+        let cand = write_expiry_stats(tmp.path(), 1, 500, 8_000, 1_000);
+        // Outside min write ts = 5_000 ⇒ overlap_bound = 5_000. The candidate's
+        // min (1_000) is BELOW the bound, but its max (8_000) is ABOVE it.
+        let outside = write_expiry_stats(tmp.path(), 2, i32::MAX, 20_000, 5_000);
+        let dropped = fully_expired_sstables(&[cand], &[outside], Some(1_000));
+        assert!(
+            dropped.is_empty(),
+            "min<bound<max must RETAIN: the gate compares the true newest write \
+             (max_timestamp), so a candidate whose newest write postdates the bound \
+             is not droppable (F2 resurrection guard)"
+        );
+    }
+
+    /// Roborev F2 fail-closed: since #1729 a candidate's `max_timestamp` may be the
+    /// `i64::MIN` UNAVAILABLE sentinel. An unknown newest write cannot be proven to
+    /// predate the overlap bound, so the candidate is RETAINED (never dropped) even
+    /// though it is fully expired and its (unavailable) sentinel would compare below
+    /// any real bound. Exercised through the pure classifier so the in-memory
+    /// sentinel is honest (the on-disk StatisticsWriter finalize normalizes
+    /// `i64::MIN → 0`, so it cannot round-trip the sentinel).
+    #[test]
+    fn overlap_gate_fails_closed_on_unavailable_max_timestamp() {
+        let cand: PathBuf = PathBuf::from("nb-1-big-Data.db");
+        // Fully expired (LDT 500 < 1_000) but max_timestamp is the #1729 unavailable
+        // sentinel (i64::MIN). A naive `sentinel < bound` comparison would wrongly
+        // permit a drop; the authoritative accessor forces a retain.
+        let stats = ts_stats(500, i64::MIN);
+        let input_stats = [(&cand, Some(stats))];
+        // Concrete, above-sentinel outside bound (5_000).
+        let dropped = classify_drop_set(&input_stats, Some(5_000), 1_000);
+        assert!(
+            dropped.is_empty(),
+            "an UNAVAILABLE (i64::MIN) max_timestamp must fail closed: retain, never drop (#1729 F2)"
+        );
+
+        // Control: the SAME candidate with a real, below-bound max_timestamp IS
+        // droppable, proving it is the sentinel (not some other field) that retains.
+        let live_max = ts_stats(500, 4_000);
+        let input_stats_live = [(&cand, Some(live_max))];
+        assert_eq!(
+            classify_drop_set(&input_stats_live, Some(5_000), 1_000),
+            vec![cand.clone()],
+            "a concrete below-bound max_timestamp on the same candidate is droppable"
+        );
+    }
+
+    /// The [`authoritative_max_timestamp`] accessor mirrors #1729: `None` for the
+    /// `i64::MIN` sentinel, `Some(v)` otherwise (incl. concrete negatives).
+    #[test]
+    fn authoritative_max_timestamp_maps_sentinel_to_none() {
+        assert_eq!(authoritative_max_timestamp(&ts_stats(0, i64::MIN)), None);
+        assert_eq!(
+            authoritative_max_timestamp(&ts_stats(0, 8_000)),
+            Some(8_000)
+        );
+        assert_eq!(
+            authoritative_max_timestamp(&ts_stats(0, i64::MIN + 1)),
+            Some(i64::MIN + 1)
         );
     }
 

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -84,7 +84,7 @@ mod fully_expired;
 #[cfg(feature = "write-support")]
 pub use fully_expired::fully_expired_sstables;
 #[cfg(feature = "write-support")]
-pub(crate) use fully_expired::split_merge_and_dropped;
+pub(crate) use fully_expired::{reclaim_dropped_whole, split_merge_and_dropped};
 
 /// Repair-state classification + mixed-state rejection for compaction
 /// (issue #1021). Reads each input's persisted repair state from `Statistics.db`
@@ -1900,7 +1900,13 @@ pub async fn compact_sstables_with_registry(
     // WriteEngine background compaction uses for merged inputs. Deletion is
     // best-effort: a failure leaves an invisible orphan (its TOC.txt is removed
     // first) reclaimed on next startup, never a hard error — the output is correct.
-    for dropped in &dropped_whole {
+    //
+    // The one-shot CLI surface deletes NO merge inputs (the operator owns the input
+    // dir; the output lands in a separate `--output` dir), so `already_deleted` is
+    // EMPTY: in the degenerate all-expired case the SSTable the all-dropped guard
+    // retained as a merge input is ALSO in `dropped_whole` and IS reclaimed here
+    // (roborev #1388 Medium — closes the former "all-expired input left on disk").
+    fully_expired::reclaim_dropped_whole(&dropped_whole, &[], |dropped| {
         if let Err(e) =
             crate::storage::write_engine::WriteEngine::delete_sstable_files_static(dropped)
         {
@@ -1911,7 +1917,7 @@ pub async fn compact_sstables_with_registry(
                 e
             );
         }
-    }
+    });
     // Record the drop decision in the report/stats (issue #1388, R4), distinct from
     // the merged inputs so it is assertable from the plan, not just output absence.
     stats.dropped_whole = dropped_whole;

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -83,6 +83,8 @@ pub use model::{CellData, ComplexDeletion, MergeEntry, MergeStats, MergeStep, Ro
 mod fully_expired;
 #[cfg(feature = "write-support")]
 pub use fully_expired::fully_expired_sstables;
+#[cfg(feature = "write-support")]
+pub(crate) use fully_expired::split_merge_and_dropped;
 
 /// Repair-state classification + mixed-state rejection for compaction
 /// (issue #1021). Reads each input's persisted repair state from `Statistics.db`
@@ -1789,38 +1791,13 @@ pub async fn compact_sstables_with_registry(
     // matching the tombstone-purge conservatism). The drop-set is subtracted from
     // the merger's input list BEFORE building the merger, so dropped SSTables are
     // never read/decoded (the perf win); their components are deleted only after
-    // the output publishes.
-    let dropped_whole: Vec<PathBuf> = if purge_safe {
+    // the output publishes. `split_merge_and_dropped` handles the all-dropped guard.
+    let drop_set: Vec<PathBuf> = if purge_safe {
         fully_expired_sstables(&input_paths, &[], gc_before_secs)
     } else {
         Vec::new()
     };
-    // Subtract the drop-set from the merger inputs. Guard the degenerate all-dropped
-    // case (a major compaction of an all-expired input set): the merger requires at
-    // least one input, so retain the last dropped SSTable in the merge (its rows
-    // purge to empty through the normal path) rather than crashing — the output is
-    // still correct and the remaining fully-expired SSTables are still dropped whole.
-    let dropped_set: std::collections::HashSet<&PathBuf> = dropped_whole.iter().collect();
-    let mut merge_inputs: Vec<PathBuf> = input_paths
-        .iter()
-        .filter(|p| !dropped_set.contains(*p))
-        .cloned()
-        .collect();
-    let dropped_whole: Vec<PathBuf> = if merge_inputs.is_empty() {
-        // Everything was fully expired: keep one input for the merger, drop the rest.
-        let mut kept = input_paths.clone();
-        let retained = kept.pop();
-        if let Some(ref r) = retained {
-            merge_inputs.push(r.clone());
-        }
-        // The drop-set is every input except the one retained for the merger.
-        dropped_whole
-            .into_iter()
-            .filter(|p| Some(p) != retained.as_ref())
-            .collect()
-    } else {
-        dropped_whole
-    };
+    let (merge_inputs, dropped_whole) = split_merge_and_dropped(&input_paths, drop_set);
     // From here on, decode/merge only the (drop-filtered) `merge_inputs`. The
     // dropped SSTables are reclaimed after the output publishes.
     let input_paths = merge_inputs;

--- a/cqlite-core/src/storage/write_engine/merge/mod.rs
+++ b/cqlite-core/src/storage/write_engine/merge/mod.rs
@@ -76,6 +76,14 @@ mod model;
 #[cfg(feature = "write-support")]
 pub use model::{CellData, ComplexDeletion, MergeEntry, MergeStats, MergeStep, RowData};
 
+/// Fully-expired SSTable drop classification (issue #1388): the metadata-only
+/// `fully_expired_sstables` drop-set used by both compaction surfaces to skip
+/// reading SSTables that are entirely past `gcBefore` and overlap-safe.
+#[cfg(feature = "write-support")]
+mod fully_expired;
+#[cfg(feature = "write-support")]
+pub use fully_expired::fully_expired_sstables;
+
 /// Repair-state classification + mixed-state rejection for compaction
 /// (issue #1021). Reads each input's persisted repair state from `Statistics.db`
 /// and either returns the shared state to preserve or rejects a mixed-state set.
@@ -1772,6 +1780,51 @@ pub async fn compact_sstables_with_registry(
         ));
     }
 
+    // Fully-expired SSTable drop (issue #1388, OQ-1 → (A)): the CLI one-shot has no
+    // knowledge of SSTables outside its explicit input list, so the drop is only
+    // overlap-safe when the operator asserts `--major` (`purge_safe == true`),
+    // which means the input set spans EVERY overlapping SSTable for the table ⇒
+    // empty outside set ⇒ +inf overlap bound ⇒ every fully-expired input is
+    // provably safe to drop. Without `--major` no drop occurs (conservative,
+    // matching the tombstone-purge conservatism). The drop-set is subtracted from
+    // the merger's input list BEFORE building the merger, so dropped SSTables are
+    // never read/decoded (the perf win); their components are deleted only after
+    // the output publishes.
+    let dropped_whole: Vec<PathBuf> = if purge_safe {
+        fully_expired_sstables(&input_paths, &[], gc_before_secs)
+    } else {
+        Vec::new()
+    };
+    // Subtract the drop-set from the merger inputs. Guard the degenerate all-dropped
+    // case (a major compaction of an all-expired input set): the merger requires at
+    // least one input, so retain the last dropped SSTable in the merge (its rows
+    // purge to empty through the normal path) rather than crashing — the output is
+    // still correct and the remaining fully-expired SSTables are still dropped whole.
+    let dropped_set: std::collections::HashSet<&PathBuf> = dropped_whole.iter().collect();
+    let mut merge_inputs: Vec<PathBuf> = input_paths
+        .iter()
+        .filter(|p| !dropped_set.contains(*p))
+        .cloned()
+        .collect();
+    let dropped_whole: Vec<PathBuf> = if merge_inputs.is_empty() {
+        // Everything was fully expired: keep one input for the merger, drop the rest.
+        let mut kept = input_paths.clone();
+        let retained = kept.pop();
+        if let Some(ref r) = retained {
+            merge_inputs.push(r.clone());
+        }
+        // The drop-set is every input except the one retained for the merger.
+        dropped_whole
+            .into_iter()
+            .filter(|p| Some(p) != retained.as_ref())
+            .collect()
+    } else {
+        dropped_whole
+    };
+    // From here on, decode/merge only the (drop-filtered) `merge_inputs`. The
+    // dropped SSTables are reclaimed after the output publishes.
+    let input_paths = merge_inputs;
+
     // #850: read static-row presence from the input SSTable headers. If a static
     // column is absent from the current schema but an input SSTable still declares
     // it (e.g. it was dropped from the catalog entirely, not retained via
@@ -1862,8 +1915,29 @@ pub async fn compact_sstables_with_registry(
     let (baseline_min_ts, baseline_min_ldt, baseline_min_ttl) = compute_baseline_min(&input_paths);
     writer.pre_seed_encoding_baselines(baseline_min_ts, baseline_min_ldt, baseline_min_ttl);
 
-    let stats = merger.merge(&mut writer)?;
+    let mut stats = merger.merge(&mut writer)?;
     let output = writer.finish().await?;
+
+    // Issue #1388: the merged output is now published. Reclaim the dropped-whole
+    // SSTables (never read into the merger) via the same component-delete path the
+    // WriteEngine background compaction uses for merged inputs. Deletion is
+    // best-effort: a failure leaves an invisible orphan (its TOC.txt is removed
+    // first) reclaimed on next startup, never a hard error — the output is correct.
+    for dropped in &dropped_whole {
+        if let Err(e) =
+            crate::storage::write_engine::WriteEngine::delete_sstable_files_static(dropped)
+        {
+            log::warn!(
+                "Failed to delete dropped-whole compaction input {:?}: {} \
+                 (output is valid; leftover is an invisible orphan)",
+                dropped,
+                e
+            );
+        }
+    }
+    // Record the drop decision in the report/stats (issue #1388, R4), distinct from
+    // the merged inputs so it is assertable from the plan, not just output absence.
+    stats.dropped_whole = dropped_whole;
 
     Ok(CompactReport { output, stats })
 }
@@ -2073,6 +2147,9 @@ impl KWayMerger {
             output_rows: 0,
             bytes_written: 0,
             elapsed: Duration::from_secs(0), // Will be updated at the end
+            // The merger only sees the (already drop-filtered) inputs; the caller
+            // that computed the drop-set records it (issue #1388).
+            dropped_whole: Vec::new(),
         };
 
         while let MergeStep::Partition { key, rows } = self.step()? {
@@ -3785,6 +3862,7 @@ mod tests {
             output_rows: 5000,
             bytes_written: 1024 * 1024,
             elapsed: Duration::from_secs(10),
+            dropped_whole: Vec::new(),
         };
 
         assert_eq!(stats.input_files, 5);

--- a/cqlite-core/src/storage/write_engine/merge/model.rs
+++ b/cqlite-core/src/storage/write_engine/merge/model.rs
@@ -15,6 +15,8 @@ use crate::types::Value;
 #[cfg(feature = "write-support")]
 use std::cmp::Ordering;
 #[cfg(feature = "write-support")]
+use std::path::PathBuf;
+#[cfg(feature = "write-support")]
 use std::time::Duration;
 
 /// Entry in the merge stream
@@ -415,4 +417,12 @@ pub struct MergeStats {
     pub bytes_written: u64,
     /// Elapsed time
     pub elapsed: Duration,
+    /// SSTables DROPPED WHOLE by the fully-expired fast path (issue #1388),
+    /// distinct from the merged inputs: each of these was proven fully expired by
+    /// authoritative `Statistics.db` metadata (`max_deletion_time < gcBefore`) and
+    /// overlap-safe, so it was EXCLUDED from the K-way merger's input list (never
+    /// read/decoded) and its components are reclaimed after the output publishes.
+    /// Empty for a compaction that drops nothing (byte-identical to pre-#1388
+    /// behavior). Paths are input Data.db paths.
+    pub dropped_whole: Vec<PathBuf>,
 }

--- a/cqlite-core/tests/issue_1388_fully_expired_drop.rs
+++ b/cqlite-core/tests/issue_1388_fully_expired_drop.rs
@@ -1,0 +1,627 @@
+//! Issue #1388: fully-expired SSTable drop (design-driven).
+//!
+//! When a compaction's input set contains an SSTable proven FULLY EXPIRED by
+//! authoritative `Statistics.db` metadata (`max_deletion_time < gcBefore`, no cell
+//! scan — no-heuristics mandate #28) AND overlap-safe against the SSTables outside
+//! the compaction set, that SSTable is DROPPED WHOLE: excluded from the K-way
+//! merger's input list (never read/decoded — the perf win) and its components
+//! reclaimed only after the merged output publishes, via the same reclamation path
+//! as the merged inputs. This mirrors Cassandra's
+//! `CompactionController.getFullyExpiredSSTables` / `TTLExpiryTest`.
+//!
+//! Every test drives a REAL public compaction surface:
+//!   - `compact_sstables` (the CLI one-shot `compact --major` path, OQ-1 → (A)); and
+//!   - `WriteEngine::maintenance_step` (the production background path).
+//!
+//! Determinism: a fully-expired SSTable is built from ROW TOMBSTONES stamped with
+//! a small, explicit past `localDeletionTime` and low write timestamps, under a
+//! schema with `gc_grace_seconds = 0` so the production `gcBefore = now_secs`
+//! (wall clock, ~1.7e9) is unconditionally above the tiny tombstone LDT. The drop
+//! decision therefore never races the wall clock: `max_deletion_time` (tiny) is
+//! always `< gcBefore`. A live SSTable (a plain write) is never expired
+//! (`max_deletion_time == NO_DELETION_TIME`).
+//!
+//! Unit-level R1/R2 (metadata detection + overlap gate) live in the merge module's
+//! `#[cfg]` tests (`fully_expired_sstables`); this file covers R3 (exclusion +
+//! reclamation on the real surfaces), R4 (report names the dropped set), and R5
+//! (read parity before/after == merged-purge result).
+
+#![cfg(feature = "write-support")]
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use cqlite_core::schema::{ClusteringColumn, ClusteringOrder, Column, KeyColumn, TableSchema};
+use cqlite_core::storage::write_engine::merge::{
+    compact_sstables, fully_expired_sstables, MergeStep, RowData,
+};
+use cqlite_core::storage::write_engine::{
+    CellOperation, ClusteringKey, KWayMerger, MergePolicy, Mutation, PartitionKey, TableId,
+    WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::Value;
+use tempfile::TempDir;
+
+// ===========================================================================
+// Schema + mutation helpers
+// ===========================================================================
+
+/// `gc_grace_seconds = 0` ⇒ production `gcBefore = now_secs` (wall clock), which
+/// is always above a tiny explicit tombstone LDT, so a tombstone-only SSTable is
+/// unconditionally fully expired regardless of the sampled wall clock.
+fn make_schema() -> TableSchema {
+    let mut comments = HashMap::new();
+    comments.insert("gc_grace_seconds".to_string(), "0".to_string());
+    TableSchema {
+        keyspace: "exp_ks".to_string(),
+        table: "items".to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![ClusteringColumn {
+            name: "ck".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+            order: ClusteringOrder::Asc,
+        }],
+        columns: vec![
+            col("id", "int", false),
+            col("ck", "int", false),
+            col("name", "text", true),
+        ],
+        comments,
+        dropped_columns: HashMap::new(),
+    }
+}
+
+fn col(name: &str, ty: &str, nullable: bool) -> Column {
+    Column {
+        name: name.to_string(),
+        data_type: ty.to_string(),
+        nullable,
+        default: None,
+        is_static: false,
+    }
+}
+
+/// A ROW TOMBSTONE stamped with an explicit past `localDeletionTime` (GC-clock
+/// seconds) and a low write timestamp. An SSTable of only these has
+/// `max_deletion_time == ldt_secs`, which is `< gcBefore` for any real wall clock.
+fn delete_row(id: i32, ck: i32, ldt_secs: i32, ts_micros: i64) -> Mutation {
+    Mutation::new(
+        TableId::new("exp_ks", "items"),
+        PartitionKey::single("id", Value::Integer(id)),
+        Some(ClusteringKey::single("ck", Value::Integer(ck))),
+        vec![CellOperation::DeleteRow],
+        ts_micros,
+        None,
+    )
+    .with_local_deletion_time(ldt_secs)
+}
+
+/// A plain live write (never expiring): `max_deletion_time == NO_DELETION_TIME`.
+fn write_live_row(id: i32, ck: i32, name: &str, ts_micros: i64) -> Mutation {
+    Mutation::new(
+        TableId::new("exp_ks", "items"),
+        PartitionKey::single("id", Value::Integer(id)),
+        Some(ClusteringKey::single("ck", Value::Integer(ck))),
+        vec![CellOperation::Write {
+            column: "name".to_string(),
+            value: Value::Text(name.to_string()),
+        }],
+        ts_micros,
+        None,
+    )
+}
+
+// ===========================================================================
+// Runtime + I/O helpers
+// ===========================================================================
+
+fn rt() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime")
+}
+
+/// Flush a batch of mutations into ONE input SSTable under `data_dir`.
+fn flush_batch(data_dir: &Path, wal_dir: &Path, schema: &TableSchema, muts: Vec<Mutation>) {
+    let config = WriteEngineConfig::new(
+        data_dir.to_path_buf(),
+        wal_dir.to_path_buf(),
+        schema.clone(),
+    );
+    let mut engine = WriteEngine::new(config).expect("engine");
+    for m in muts {
+        engine.write(m).expect("write mutation");
+    }
+    let r = rt();
+    r.block_on(engine.flush()).expect("flush").expect("info");
+    r.block_on(engine.close()).expect("close engine");
+}
+
+/// Discover `nb-*-big-Data.db` inputs, newest-generation first.
+fn discover_inputs(dir: &Path) -> Vec<PathBuf> {
+    let mut found: Vec<(u64, PathBuf)> = Vec::new();
+    collect(dir, &mut found, 8);
+    found.sort_by(|a, b| b.0.cmp(&a.0));
+    found.into_iter().map(|(_, p)| p).collect()
+}
+
+fn collect(dir: &Path, out: &mut Vec<(u64, PathBuf)>, depth: usize) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = path
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string();
+        if name.starts_with("nb-") && name.ends_with("-big-Data.db") {
+            let base = name.trim_end_matches("-Data.db");
+            if !path.with_file_name(format!("{base}-TOC.txt")).exists() {
+                continue;
+            }
+            let generation = name
+                .strip_prefix("nb-")
+                .and_then(|s| s.split("-big-").next())
+                .and_then(|g| g.parse::<u64>().ok())
+                .unwrap_or(0);
+            out.push((generation, path));
+        } else if depth > 0 && path.is_dir() {
+            collect(&path, out, depth - 1);
+        }
+    }
+}
+
+/// Read every surviving live `name` cell across a directory's SSTables back
+/// through the merge read path (raw on-disk state, expiry disabled).
+fn read_name_values(inputs: &[PathBuf], schema: &TableSchema, purge_safe: bool) -> Vec<String> {
+    let non_empty: Vec<PathBuf> = inputs
+        .iter()
+        .filter(|p| std::fs::metadata(p).map(|m| m.len() > 0).unwrap_or(false))
+        .cloned()
+        .collect();
+    if non_empty.is_empty() {
+        return Vec::new();
+    }
+    let mut merger = KWayMerger::new_with_gc(non_empty, schema, None, None)
+        .expect("merger")
+        .with_purge_safe(purge_safe);
+    let mut out = Vec::new();
+    loop {
+        match merger.step().expect("step") {
+            MergeStep::Complete => break,
+            MergeStep::Partition { rows, .. } => {
+                for entry in rows {
+                    if let RowData::Live { cells } = &entry.row_data {
+                        for c in cells {
+                            if c.column == "name" {
+                                if let Value::Text(v) = &c.value {
+                                    out.push(v.clone());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    out.sort();
+    out
+}
+
+/// The pinned "now" / gcBefore for the one-shot surface. A tiny tombstone LDT
+/// (`< gc_before`) is fully expired; a live cell (NO_DELETION_TIME) never is.
+const NOW_SECS: i64 = 10_000;
+const GC_BEFORE: i64 = 5_000; // > every tombstone LDT below, < NO_DELETION_TIME
+
+/// Tombstone LDTs used by the fixtures (all strictly below GC_BEFORE).
+const TOMB_LDT: i32 = 100;
+
+// ===========================================================================
+// R3 (one-shot / CLI --major) + R4 (report) + acceptance-criterion 1
+// ===========================================================================
+
+/// Major compaction of an all-expired SSTable + a live SSTable: the expired
+/// SSTable is DROPPED WHOLE (excluded from the merge, never read), the live rows
+/// all survive, and the report names exactly the dropped SSTable.
+#[test]
+fn major_drops_expired_sstable_and_keeps_live() {
+    let temp = TempDir::new().unwrap();
+    let expired_dir = temp.path().join("expired");
+    let live_dir = temp.path().join("live");
+    let wal = temp.path().join("wal");
+    let out_dir = temp.path().join("out");
+    let schema = make_schema();
+
+    // All-expired SSTable: row tombstones at a tiny LDT and LOW write timestamps.
+    flush_batch(
+        &expired_dir,
+        &wal.join("e"),
+        &schema,
+        vec![
+            delete_row(1, 0, TOMB_LDT, 100),
+            delete_row(2, 0, TOMB_LDT, 100),
+        ],
+    );
+    // Live SSTable at HIGHER write timestamps.
+    flush_batch(
+        &live_dir,
+        &wal.join("l"),
+        &schema,
+        vec![
+            write_live_row(10, 0, "alive-a", 5_000_000),
+            write_live_row(11, 0, "alive-b", 5_000_000),
+        ],
+    );
+
+    let expired = discover_inputs(&expired_dir);
+    let live = discover_inputs(&live_dir);
+    assert_eq!(expired.len(), 1, "one expired input");
+    assert_eq!(live.len(), 1, "one live input");
+    let expired_path = expired[0].clone();
+
+    // Sanity: the drop-set classifier (metadata-only) selects the expired one and
+    // NOT the live one for a major compaction (empty outside set).
+    let all_inputs: Vec<PathBuf> = vec![live[0].clone(), expired_path.clone()];
+    let drop_set = fully_expired_sstables(&all_inputs, &[], Some(GC_BEFORE));
+    assert_eq!(
+        drop_set,
+        vec![expired_path.clone()],
+        "metadata classifier must pick only the expired SSTable for a major compaction"
+    );
+
+    // Real one-shot major compaction (purge_safe = true ⇒ empty outside ⇒ drop).
+    let report = rt()
+        .block_on(compact_sstables(
+            all_inputs.clone(),
+            &out_dir,
+            &schema,
+            1,
+            Some(GC_BEFORE),
+            Some(NOW_SECS),
+            true,
+        ))
+        .expect("compaction succeeds");
+
+    // R4: the report names exactly the dropped SSTable, distinct from merged inputs.
+    assert_eq!(
+        report.stats.dropped_whole,
+        vec![expired_path.clone()],
+        "report must name exactly the dropped-whole SSTable"
+    );
+    // The merger's input_files counts only the SSTables actually merged (live one).
+    assert_eq!(
+        report.stats.input_files, 1,
+        "only the live SSTable was fed to the merger (expired dropped whole)"
+    );
+
+    // R3: the dropped SSTable's components were reclaimed after publish.
+    assert!(
+        !expired_path.exists(),
+        "dropped-whole SSTable's Data.db must be reclaimed after publish"
+    );
+
+    // Output holds every live row, none of the expired rows.
+    let out_inputs = discover_inputs(&out_dir);
+    let values = read_name_values(&out_inputs, &schema, true);
+    assert_eq!(
+        values,
+        vec!["alive-a".to_string(), "alive-b".to_string()],
+        "output keeps all live rows and no expired rows"
+    );
+}
+
+/// A compaction that drops nothing (no input is fully expired) reports an EMPTY
+/// dropped-whole set.
+#[test]
+fn no_expired_input_reports_empty_dropped_set() {
+    let temp = TempDir::new().unwrap();
+    let a_dir = temp.path().join("a");
+    let b_dir = temp.path().join("b");
+    let wal = temp.path().join("wal");
+    let out_dir = temp.path().join("out");
+    let schema = make_schema();
+
+    flush_batch(
+        &a_dir,
+        &wal.join("a"),
+        &schema,
+        vec![write_live_row(1, 0, "a", 1_000_000)],
+    );
+    flush_batch(
+        &b_dir,
+        &wal.join("b"),
+        &schema,
+        vec![write_live_row(2, 0, "b", 2_000_000)],
+    );
+    let mut inputs = discover_inputs(&a_dir);
+    inputs.extend(discover_inputs(&b_dir));
+
+    let report = rt()
+        .block_on(compact_sstables(
+            inputs,
+            &out_dir,
+            &schema,
+            1,
+            Some(GC_BEFORE),
+            Some(NOW_SECS),
+            true,
+        ))
+        .expect("compaction succeeds");
+
+    assert!(
+        report.stats.dropped_whole.is_empty(),
+        "a compaction that drops nothing must report an empty dropped-whole set"
+    );
+    let out_inputs = discover_inputs(&out_dir);
+    assert_eq!(
+        read_name_values(&out_inputs, &schema, true),
+        vec!["a".to_string(), "b".to_string()],
+        "all live rows survive"
+    );
+}
+
+/// Non-major (conservative) one-shot compaction does NOT drop, even an expired
+/// input (OQ-1 → (A): drop only under `--major`).
+#[test]
+fn non_major_one_shot_does_not_drop() {
+    let temp = TempDir::new().unwrap();
+    let expired_dir = temp.path().join("expired");
+    let live_dir = temp.path().join("live");
+    let wal = temp.path().join("wal");
+    let out_dir = temp.path().join("out");
+    let schema = make_schema();
+
+    flush_batch(
+        &expired_dir,
+        &wal.join("e"),
+        &schema,
+        vec![delete_row(1, 0, TOMB_LDT, 100)],
+    );
+    flush_batch(
+        &live_dir,
+        &wal.join("l"),
+        &schema,
+        vec![write_live_row(10, 0, "alive", 5_000_000)],
+    );
+    let expired = discover_inputs(&expired_dir);
+    let live = discover_inputs(&live_dir);
+    let inputs: Vec<PathBuf> = vec![live[0].clone(), expired[0].clone()];
+
+    // purge_safe = false ⇒ no drop.
+    let report = rt()
+        .block_on(compact_sstables(
+            inputs,
+            &out_dir,
+            &schema,
+            1,
+            Some(GC_BEFORE),
+            Some(NOW_SECS),
+            false,
+        ))
+        .expect("compaction succeeds");
+    assert!(
+        report.stats.dropped_whole.is_empty(),
+        "a non-major one-shot compaction must never drop whole (OQ-1 → (A))"
+    );
+    // Both inputs were fed to the merger (nothing dropped).
+    assert_eq!(report.stats.input_files, 2);
+}
+
+// ===========================================================================
+// R3 (WriteEngine background path) + R4 (MaintenanceReport)
+// ===========================================================================
+
+/// STCS-style policy that selects EVERY candidate (a full/major compaction), so
+/// `maintenance_step` computes `purge_safe == true` (empty outside set).
+#[derive(Debug)]
+struct SelectAllPolicy;
+
+impl MergePolicy for SelectAllPolicy {
+    fn select_merge(&self, candidates: &[PathBuf]) -> Result<Vec<PathBuf>, cqlite_core::Error> {
+        Ok(candidates.to_vec())
+    }
+}
+
+/// Background full compaction drops a fully-expired candidate whole: it is
+/// excluded from the merger (never read), reclaimed after publish, and named in
+/// the `MaintenanceReport`.
+#[test]
+fn background_full_compaction_drops_expired_candidate() {
+    let temp = TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    let wal = temp.path().join("wal");
+    let schema = make_schema();
+    let table_dir = data_dir.join(&schema.keyspace).join(&schema.table);
+
+    let config = WriteEngineConfig::new(data_dir.clone(), wal, schema.clone());
+    let mut engine = WriteEngine::new(config).expect("engine");
+    let r = rt();
+
+    // gen1: fully-expired SSTable (row tombstones, tiny LDT, low write ts).
+    engine
+        .write(delete_row(1, 0, TOMB_LDT, 100))
+        .expect("write");
+    engine
+        .write(delete_row(2, 0, TOMB_LDT, 100))
+        .expect("write");
+    r.block_on(engine.flush()).expect("flush").expect("info");
+    // gen2: live SSTable (higher write ts).
+    engine
+        .write(write_live_row(10, 0, "alive", 5_000_000))
+        .expect("write");
+    r.block_on(engine.flush()).expect("flush").expect("info");
+
+    let before: Vec<PathBuf> = discover_inputs(&table_dir);
+    assert_eq!(
+        before.len(),
+        2,
+        "two input SSTables (expired gen1, live gen2)"
+    );
+    // Identify the expired one (gen1 has the tombstones; it is the older gen).
+    let expired_before = before
+        .iter()
+        .min_by_key(|p| gen_of(p).unwrap_or(u64::MAX))
+        .cloned()
+        .expect("expired input");
+
+    engine
+        .set_merge_policy(Box::new(SelectAllPolicy))
+        .expect("policy");
+    let mut dropped_reported: Vec<PathBuf> = Vec::new();
+    let mut guard = 0;
+    loop {
+        let report = engine
+            .maintenance_step(std::time::Duration::from_millis(500))
+            .expect("maintenance step");
+        dropped_reported.extend(report.dropped_whole.iter().cloned());
+        if !report.pending_compaction {
+            break;
+        }
+        guard += 1;
+        assert!(guard < 1000, "maintenance did not converge");
+    }
+    r.block_on(engine.close()).expect("close");
+
+    // R4: the MaintenanceReport named exactly the expired input as dropped whole.
+    assert_eq!(
+        dropped_reported,
+        vec![expired_before.clone()],
+        "background report must name exactly the dropped-whole SSTable"
+    );
+
+    // R3: after compaction only ONE SSTable (the merged output) remains; the
+    // expired input's Data.db is gone (reclaimed).
+    let after: Vec<PathBuf> = discover_inputs(&table_dir);
+    assert_eq!(after.len(), 1, "expired dropped + live merged ⇒ one output");
+    assert!(!expired_before.exists(), "expired input reclaimed");
+
+    // The live row survives; no expired rows appear.
+    let values = read_name_values(&after, &schema, true);
+    assert_eq!(
+        values,
+        vec!["alive".to_string()],
+        "only the live row survives"
+    );
+}
+
+fn gen_of(p: &Path) -> Option<u64> {
+    let name = p.file_name()?.to_str()?;
+    name.strip_prefix("nb-")?
+        .split("-big-")
+        .next()?
+        .parse::<u64>()
+        .ok()
+}
+
+// ===========================================================================
+// R5 — read parity: drop-whole output == merged-purge output, and equals the
+// pre-compaction read (a dropped SSTable contributes no live data).
+// ===========================================================================
+
+/// The query result over the drop-whole compaction output equals (a) the result
+/// over the raw inputs before compaction and (b) the result of a compaction that
+/// MERGED (rather than dropped) the fully-expired SSTable through the normal purge
+/// path. All three are the live rows only.
+#[test]
+fn read_parity_drop_whole_equals_merged_purge() {
+    let temp = TempDir::new().unwrap();
+    let schema = make_schema();
+
+    // Each compaction reclaims (deletes) its input SSTables, so build a FRESH,
+    // independent input set for every read/compaction rather than sharing paths.
+    let build_inputs = |tag: &str| -> Vec<PathBuf> {
+        let expired_dir = temp.path().join(format!("{tag}_expired"));
+        let live_dir = temp.path().join(format!("{tag}_live"));
+        let wal = temp.path().join(format!("{tag}_wal"));
+        flush_batch(
+            &expired_dir,
+            &wal.join("e"),
+            &schema,
+            vec![
+                delete_row(1, 0, TOMB_LDT, 100),
+                delete_row(2, 0, TOMB_LDT, 100),
+            ],
+        );
+        flush_batch(
+            &live_dir,
+            &wal.join("l"),
+            &schema,
+            vec![
+                write_live_row(10, 0, "a", 5_000_000),
+                write_live_row(11, 0, "b", 5_000_000),
+            ],
+        );
+        let live = discover_inputs(&live_dir);
+        let expired = discover_inputs(&expired_dir);
+        vec![live[0].clone(), expired[0].clone()]
+    };
+
+    // (a) BEFORE: read the raw inputs (purge_safe so tombstones shadow nothing
+    // external). Row tombstones delete their own rows; the live rows survive.
+    let before_values = read_name_values(&build_inputs("before"), &schema, true);
+
+    // (b) DROP-WHOLE compaction (major): the expired SSTable is dropped whole.
+    let drop_out = temp.path().join("drop_out");
+    let drop_report = rt()
+        .block_on(compact_sstables(
+            build_inputs("drop"),
+            &drop_out,
+            &schema,
+            1,
+            Some(GC_BEFORE),
+            Some(NOW_SECS),
+            true,
+        ))
+        .expect("drop-whole compaction");
+    assert!(
+        !drop_report.stats.dropped_whole.is_empty(),
+        "the drop-whole path must actually drop the expired SSTable"
+    );
+    let drop_values = read_name_values(&discover_inputs(&drop_out), &schema, true);
+
+    // (c) MERGED-PURGE compaction: force the expired SSTable through the merger by
+    // classifying it as NOT droppable. We do this with gc_before = None (dropping
+    // AND gc-purge disabled) so the expired SSTable is READ and merged; its row
+    // tombstones still delete their own rows via reconciliation, so the live rows
+    // are the same surviving set. This proves the drop is observationally
+    // equivalent to reading+merging the expired SSTable.
+    let merge_out = temp.path().join("merge_out");
+    let merge_report = rt()
+        .block_on(compact_sstables(
+            build_inputs("merge"),
+            &merge_out,
+            &schema,
+            1,
+            None, // gc_before = None ⇒ no drop, expired SSTable is merged
+            Some(NOW_SECS),
+            true,
+        ))
+        .expect("merged-purge compaction");
+    assert!(
+        merge_report.stats.dropped_whole.is_empty(),
+        "the merged-purge path must NOT drop (gc_before = None)"
+    );
+    assert_eq!(
+        merge_report.stats.input_files, 2,
+        "both inputs were fed to the merger on the merged path"
+    );
+    let merge_values = read_name_values(&discover_inputs(&merge_out), &schema, true);
+
+    // R5: all three agree — the live rows only.
+    let expected = vec!["a".to_string(), "b".to_string()];
+    assert_eq!(before_values, expected, "pre-compaction read");
+    assert_eq!(drop_values, expected, "drop-whole output read");
+    assert_eq!(merge_values, expected, "merged-purge output read");
+    assert_eq!(
+        drop_values, merge_values,
+        "drop-whole output must equal merged-purge output (read parity)"
+    );
+}

--- a/cqlite-core/tests/issue_1388_fully_expired_drop.rs
+++ b/cqlite-core/tests/issue_1388_fully_expired_drop.rs
@@ -415,6 +415,78 @@ fn non_major_one_shot_does_not_drop() {
     assert_eq!(report.stats.input_files, 2);
 }
 
+/// Roborev F1 (former data-loss) regression: a MIXED SSTable — an old row
+/// tombstone whose `localDeletionTime` is below `gcBefore` PLUS a LIVE non-TTL
+/// cell in the SAME SSTable — must NOT be classified fully expired and must NOT
+/// be dropped by a major `compact_sstables`. Since #1728 the writer stamps live
+/// cells with `NO_DELETION_TIME`, so the finalized `max_local_deletion_time`
+/// (authoritative `Statistics.db`) is the `i32::MAX` live sentinel (parses back as
+/// `i64::MAX`), never `< gcBefore`. Dropping such an SSTable whole would lose the
+/// live cell (the former data-loss bug); it must instead be MERGED so the live
+/// row survives.
+#[test]
+fn mixed_tombstone_and_live_sstable_not_dropped() {
+    let temp = TempDir::new().unwrap();
+    let mixed_dir = temp.path().join("mixed");
+    let wal = temp.path().join("wal");
+    let out_dir = temp.path().join("out");
+    let schema = make_schema();
+
+    // ONE SSTable holding BOTH an expired row tombstone (tiny LDT < GC_BEFORE)
+    // AND a live non-TTL write (NO_DELETION_TIME). The mix lifts the SSTable's
+    // authoritative max_local_deletion_time to the live sentinel (#1728).
+    flush_batch(
+        &mixed_dir,
+        &wal.join("m"),
+        &schema,
+        vec![
+            delete_row(1, 0, TOMB_LDT, 100),
+            write_live_row(2, 0, "keep-me", 5_000_000),
+        ],
+    );
+    let mixed = discover_inputs(&mixed_dir);
+    assert_eq!(mixed.len(), 1, "one mixed input SSTable");
+    let mixed_path = mixed[0].clone();
+
+    // Metadata classifier: the mixed SSTable is NOT fully expired (its authoritative
+    // max_local_deletion_time is the live sentinel), so it is NOT in the drop-set —
+    // even for a major compaction (empty outside set).
+    let drop_set = fully_expired_sstables(&[mixed_path.clone()], &[], Some(GC_BEFORE));
+    assert!(
+        drop_set.is_empty(),
+        "a mixed tombstone+live SSTable must never be classified fully expired (#1728 F1)"
+    );
+
+    // Public surface: a major compaction must NOT drop it whole (would lose the
+    // live cell); it is merged and the live row survives.
+    let report = rt()
+        .block_on(compact_sstables(
+            vec![mixed_path.clone()],
+            &out_dir,
+            &schema,
+            1,
+            Some(GC_BEFORE),
+            Some(NOW_SECS),
+            true,
+        ))
+        .expect("compaction succeeds");
+    assert!(
+        report.stats.dropped_whole.is_empty(),
+        "compact_sstables must not drop a mixed tombstone+live SSTable whole (F1 data-loss)"
+    );
+    assert!(
+        mixed_path.exists(),
+        "the mixed SSTable was merged (retained until publish), not dropped whole"
+    );
+    // The live cell survives the merge; the tombstoned row is purged.
+    let values = read_name_values(&discover_inputs(&out_dir), &schema, true);
+    assert_eq!(
+        values,
+        vec!["keep-me".to_string()],
+        "the live cell in the mixed SSTable must survive (not lost to a whole drop)"
+    );
+}
+
 // ===========================================================================
 // R3 (WriteEngine background path) + R4 (MaintenanceReport)
 // ===========================================================================

--- a/docs/sstables-definitive-guide/chapters/15-compaction-strategies.md
+++ b/docs/sstables-definitive-guide/chapters/15-compaction-strategies.md
@@ -116,6 +116,16 @@ Tombstones are dropped when a compaction can prove they no longer shadow live da
 
 Overlap increases read IO and defers purging; reducing overlap (e.g., with LCS) helps both latency and space reclamation predictability.
 
+### Dropping fully-expired SSTables whole
+
+When an entire input SSTable is past `gc_grace_seconds`, a compaction can reclaim it without reading it. Cassandra's `CompactionController.getFullyExpiredSSTables` classifies an input as *fully expired* when its `StatsMetadata.maxLocalDeletionTime < gcBefore` (every cell/tombstone's local deletion time is below the cutoff), and drops it whole — excluded from the K-way merge and deleted after the output publishes — rather than reading, merging, and re-serializing its dead cells.
+
+CQLite mirrors this (issue #1388):
+
+- **Detection is metadata-only.** The decision reads a single authoritative field, `Statistics.db` `TimestampStatistics.max_deletion_time` (the `maxLocalDeletionTime`), and never scans the candidate's `Data.db` (no-heuristics mandate). The LIVE / `NO_DELETION_TIME` sentinel is never `< gcBefore`, so an SSTable holding any live data is never classified expired. `gcBefore = None` (invalid `gc_grace_seconds`) or an unreadable `Statistics.db` is treated conservatively (not expired).
+- **Overlap safety reuses the same bound as tombstone purging.** A fully-expired SSTable is dropped only when its `max_timestamp` is strictly below the minimum write timestamp across every overlapping SSTable outside the compaction set (the coarse global-`min_timestamp` bound; every other SSTable for the table is treated as overlapping). A major/full compaction has an empty outside set, so the bound is `+inf` and every fully-expired input is droppable. If it could shadow older data outside the set, it is retained and merged normally.
+- The dropped SSTables are excluded from the merger's input list before the merge (so they are never read — the perf win) and reclaimed only after the merged output is atomically published, via the same component-delete path as the merged inputs. The compaction report records the dropped-whole set distinctly from the merged inputs.
+
 For implementation details, see Appendix C.
 
 ### References

--- a/openspec/changes/fully-expired-sstable-drop/.openspec.yaml
+++ b/openspec/changes/fully-expired-sstable-drop/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-02

--- a/openspec/changes/fully-expired-sstable-drop/design.md
+++ b/openspec/changes/fully-expired-sstable-drop/design.md
@@ -1,0 +1,163 @@
+# Design: fully-expired-sstable-drop
+
+## Context
+
+The compaction pipeline has two entry surfaces, both of which already read per-input `Statistics.db`:
+
+1. **CLI one-shot** — `compact_sstables_with_registry` (`cqlite-core/src/storage/write_engine/merge/mod.rs:1712`),
+   behind `cqlite compact`. It receives an explicit `input_paths` list and a `purge_safe` flag mapped from
+   `--major` (`cqlite-cli/src/commands/write.rs:371`). It has no knowledge of SSTables outside its input
+   list, so today it passes `None` for the overlap bound.
+
+2. **WriteEngine background** — `maintenance_step_inner`
+   (`cqlite-core/src/storage/write_engine/maintenance.rs:204`). It scans this table's candidate set,
+   asks the merge policy for a `selected` subset, computes `purge_safe = (selected == candidates)`, and —
+   for a partial compaction — computes the outside/non-included overlapping set and calls
+   `merge::compute_max_purgeable_timestamp(&non_included)` (`maintenance.rs:288`). It then calls
+   `start_merge(selected, purge_safe, max_purgeable_timestamp)` (`compaction.rs:62`).
+
+The authoritative metadata is already available and already parsed here:
+
+- `compute_baseline_min` / `compute_max_purgeable_timestamp` read each SSTable's `Statistics.db` via
+  `parse_statistics_with_fallback` into `TimestampStatistics` (`cqlite-core/src/parser/statistics.rs:98`),
+  which exposes `min_timestamp`, `max_timestamp`, `min_deletion_time`, `max_deletion_time`, `min_ttl`,
+  `max_ttl`.
+- `gcBefore` is already computed as `compute_gc_before(schema, now_secs)` (`merge/mod.rs:1588`): a
+  GC-clock second cutoff (`now - gc_grace_seconds`, Cassandra 10-day default on absence, `None` when the
+  declared value is invalid — which disables purging and MUST also disable dropping).
+
+So both the metadata inputs to the fully-expired decision and the overlap bound already exist in the two
+call sites; this change composes them into a drop-set instead of adding a new I/O path.
+
+## Authoritative fully-expired detection (no-heuristics)
+
+A candidate SSTable is **fully expired** relative to a compaction iff **every** cell/tombstone in it has
+`localDeletionTime < gcBefore`. The single authoritative metadata field that proves this is
+`TimestampStatistics.max_deletion_time` (Cassandra `StatsMetadata.maxLocalDeletionTime`, tracked by
+`EncodingStats.update_local_deletion_time` over every deletion/TTL localDeletionTime, including a TTL
+cell's `createdAt + ttl`):
+
+    max_deletion_time < gcBefore  ⇒  every cell's localDeletionTime < gcBefore  ⇒  SSTable fully expired
+
+- `max_deletion_time` is the *maximum* localDeletionTime across the whole SSTable, so if the maximum is
+  below `gcBefore`, all of them are. This is exactly Cassandra's `getFullyExpiredSSTables` predicate
+  (`sstable.getSSTableMetadata().maxLocalDeletionTime < gcBefore`).
+- The sentinel `NO_DELETION_TIME` / `Cell.NO_DELETION_TIME` (i32::MAX, "live, never expires") must be
+  treated as NOT expired: any SSTable holding live non-TTL data has `max_deletion_time == i32::MAX`
+  (LIVE sentinel), which is never `< gcBefore`, so it is correctly ineligible. The detection reads the
+  raw metadata value and applies `value < gcBefore` with no other special-casing — the LIVE sentinel
+  falls out of the comparison naturally.
+- **No cell scan.** The decision is a single integer comparison against one metadata field. This is the
+  no-heuristics-compliant path (issue #28) and is the whole point of the optimization: we must NOT read
+  the SSTable's rows to decide to drop it (that would defeat the perf win and reintroduce a scan).
+- `gcBefore == None` (invalid gc_grace) or an unreadable/absent `Statistics.db` ⇒ candidate is NOT
+  droppable (conservative), matching `compute_gc_before` / `compute_max_purgeable_timestamp` degradation.
+
+## Overlap-safety gate (mirroring Cassandra)
+
+Even fully expired, an SSTable may hold a tombstone shadowing *older* data in an SSTable outside the
+compaction set. Dropping it whole would resurrect that data. Cassandra guards this in
+`getFullyExpiredSSTables` by removing from the drop candidate set any SSTable that overlaps (by key range)
+a non-compacting SSTable holding data it could shadow, using a `maxTimestamp` comparison.
+
+CQLite already has the exact bound: `compute_max_purgeable_timestamp(outside_paths)` returns the MINIMUM
+write timestamp across the outside overlapping SSTables (`EncodingStats.minTimestamp`). A fully-expired
+candidate is safe to drop iff its own **`max_timestamp` is strictly less than that bound**:
+
+    candidate.max_timestamp < min(outside.min_timestamp for outside in overlapping)  ⇒  safe to drop
+
+- If the candidate's newest write predates every outside SSTable's oldest write, nothing the candidate
+  contains (tombstone or data) can shadow anything outside the set — dropping it can never resurrect data.
+- A FULL/major compaction has an empty outside set (`purge_safe == true`) ⇒ bound is `+inf` ⇒ every
+  fully-expired candidate is droppable. This matches Cassandra: a major compaction over all SSTables has
+  nothing outside to shadow.
+- If the outside bound is UNKNOWN (`compute_max_purgeable_timestamp` returned `None` because an outside
+  `Statistics.db` was unreadable) in a PARTIAL compaction, the candidate is NOT dropped (conservative).
+- This reuses the identical `min_timestamp` metadata and the identical conservatism as the existing #935
+  tombstone-purge gate, so the two decisions stay consistent (a compaction that may not purge a tombstone
+  also may not silently drop the SSTable that holds it).
+
+## Chosen approach: metadata-only drop-set computed at the plan step
+
+Add `fn fully_expired_sstables(input_paths, outside_paths, gc_before_secs) -> Vec<PathBuf>` to the merge
+module. It reads each input's `Statistics.db` once (`stats_path_for` + `parse_statistics_with_fallback`,
+the existing helpers), applies `max_deletion_time < gcBefore` AND the `max_timestamp < outside_min_ts`
+overlap gate, and returns the droppable subset. The compaction surfaces then:
+
+- Remove the dropped set from the merger's `input_paths` before building the `KWayMerger` (the merger
+  never reads dropped SSTables → the perf win).
+- Delete the dropped SSTables after the output publishes (same reclamation path as the merged inputs).
+- Record the dropped set in the report/stats (`MergeStats` / `CompactReport` gain a `dropped_whole:
+  Vec<PathBuf>`), so tests assert the plan decision, not just absence from output.
+
+### Alternative considered (and beaten): cell-scan verification pass
+
+*Rejected.* Compute the candidate drop-set from metadata, then run a verification pass that reads every
+cell of each candidate to confirm all are expired before dropping. This would be belt-and-suspenders
+against a mis-written `Statistics.db`, but it (a) reintroduces the full read cost the optimization exists
+to eliminate — dropping becomes no cheaper than the current rewrite; (b) violates the no-heuristics
+mandate's spirit by second-guessing authoritative metadata with a scan; and (c) diverges from Cassandra,
+which trusts `maxLocalDeletionTime`. The metadata-only path is both faster and closer to Cassandra parity.
+Trust in `Statistics.db` is already load-bearing across the write engine (`compute_baseline_min`,
+`compute_max_purgeable_timestamp` both trust it), so adding a scan only here would be inconsistent.
+
+### Alternative considered (and beaten): drop at the writer/finalize step
+
+*Rejected.* Let the merger read every input (including expired ones) and drop the expired SSTables only at
+finalize time by not deleting them / by post-filtering. This is simpler to wire but delivers **zero perf
+win** — the whole point is to avoid reading the dead SSTable. Excluding it from the merger's input list at
+the plan step is where the cost is actually saved.
+
+## Where the exclusion hooks in
+
+- **WriteEngine background** (`maintenance_step_inner`): the outside set is already computed at
+  `maintenance.rs:283-288`. Compute the drop-set there from `selected` (inputs) + `non_included`
+  (outside) + `gc_before_secs`, subtract it from `selected` before `start_merge`, and thread the dropped
+  paths through `start_merge` so finalize deletes them and the report records them. This is the primary,
+  fully-overlap-aware surface.
+- **CLI one-shot** (`compact_sstables_with_registry`): the explicit input list has no outside set, so the
+  drop is only overlap-safe when the operator asserts `--major` (`purge_safe == true` ⇒ empty outside set
+  ⇒ `+inf` bound). Compute the drop-set with an empty outside set gated on `purge_safe`, subtract from
+  `input_paths` before building the merger, delete dropped files after publish, and populate
+  `CompactReport`. When `--major` is absent (conservative), no drop occurs (matches current
+  purge conservatism). This is the surface acceptance-criterion 1 exercises.
+
+## OPEN QUESTIONS for the owner (genuine design forks — do NOT decide unilaterally)
+
+### OQ-1 — Should the CLI one-shot `compact` drop whole SSTables at all, given it has no outside set?
+
+The CLI cannot see SSTables outside its `input_dir`, so it cannot compute a real overlap bound. Options:
+
+- **(A) Recommended:** Allow the drop ONLY under `--major` (operator's existing assertion that
+  `input_dir` contains ALL overlapping SSTables for the table). With `--major`, the outside set is
+  empty by contract, the bound is `+inf`, and the drop is provably safe under the operator's assertion —
+  identical to how `--major` already unlocks tombstone purging. Without `--major`, no drop. This keeps
+  the CLI's existing safety contract and satisfies acceptance-criterion 1 (which specifies a major
+  compaction).
+- **(B)** Never drop in the CLI one-shot path; expose the drop only via the WriteEngine background path.
+  Simpler/safer but leaves the CLI paying the rewrite cost for a major compaction and does not satisfy
+  acceptance-criterion 1 as written (it asserts a major compaction drops whole).
+
+Recommendation: **(A)** — it reuses the `--major`/`purge_safe` safety contract the operator already opts
+into and directly satisfies acceptance-criterion 1. Flagged because it is the operator-facing safety
+semantics of a data-destroying optimization, which is the owner's call.
+
+### OQ-2 — Overlap bound precision: coarse table-wide `min_timestamp` vs key-range-aware overlap
+
+Cassandra's real check is key-range-aware: only SSTables whose *token/key ranges overlap* the candidate
+constrain the drop. CQLite's existing #935 gate is coarser — it treats *every* other SSTable for the
+table as overlapping and uses the global `min_timestamp` bound. Options:
+
+- **(A) Recommended:** Reuse the existing coarse "every other SSTable overlaps" + global-`min_timestamp`
+  bound (identical to `compute_max_purgeable_timestamp`). Strictly conservative (never drops when
+  Cassandra would keep), consistent with the tombstone-purge gate already shipped, and needs no new
+  index/range plumbing.
+- **(B)** Add key-range-aware overlap using Index.db/Summary min/max keys to match Cassandra's precision
+  and drop in more cases. More parity-faithful but larger scope (new range-overlap computation) and a
+  new source of divergence risk.
+
+Recommendation: **(A)** for this change — conservative, consistent with #935, and the perf win is already
+captured for the common major-compaction case. Flagged as a fork because it trades some drop-eligibility
+(perf) for simplicity/safety, and the owner may want (B) for parity fidelity. **(A) can never resurrect
+data** — it only declines to drop in cases Cassandra would drop, so it is safe to ship (A) and file (B)
+as a follow-up if the owner wants tighter parity.

--- a/openspec/changes/fully-expired-sstable-drop/design.md
+++ b/openspec/changes/fully-expired-sstable-drop/design.md
@@ -161,3 +161,15 @@ captured for the common major-compaction case. Flagged as a fork because it trad
 (perf) for simplicity/safety, and the owner may want (B) for parity fidelity. **(A) can never resurrect
 data** — it only declines to drop in cases Cassandra would drop, so it is safe to ship (A) and file (B)
 as a follow-up if the owner wants tighter parity.
+
+## Resolved decisions (owner, 2026-07-02)
+
+- **OQ-1 → (A).** The CLI one-shot `compact` drops whole SSTables **ONLY under `--major`**. With `--major`
+  the outside set is empty by the operator's contract ⇒ overlap bound is `+inf` ⇒ every fully-expired
+  candidate is provably safe to drop (identical to how `--major` already unlocks tombstone purging).
+  Non-major CLI compaction NEVER drops whole (conservative default, matching current purge conservatism).
+- **OQ-2 → (A).** This change uses the **coarse #935 global-min-timestamp overlap gate** — the existing
+  `compute_max_purgeable_timestamp` bound (every other SSTable for the table treated as overlapping, global
+  `EncodingStats.minTimestamp`). It does NOT add key-range-aware overlap. Key-range precision (OQ-2 option
+  B) is deferred to a follow-up issue if the owner later wants tighter parity; it is out of scope here.
+  (A) is strictly conservative and can never resurrect data.

--- a/openspec/changes/fully-expired-sstable-drop/design.md
+++ b/openspec/changes/fully-expired-sstable-drop/design.md
@@ -44,9 +44,16 @@ cell's `createdAt + ttl`):
   (`sstable.getSSTableMetadata().maxLocalDeletionTime < gcBefore`).
 - The sentinel `NO_DELETION_TIME` / `Cell.NO_DELETION_TIME` (i32::MAX, "live, never expires") must be
   treated as NOT expired: any SSTable holding live non-TTL data has `max_deletion_time == i32::MAX`
-  (LIVE sentinel), which is never `< gcBefore`, so it is correctly ineligible. The detection reads the
-  raw metadata value and applies `value < gcBefore` with no other special-casing — the LIVE sentinel
-  falls out of the comparison naturally.
+  (LIVE sentinel, parsed back as `i64::MAX`), which is never `< gcBefore`, so it is correctly ineligible.
+  The detection reads the raw metadata value and applies `value < gcBefore` with no other special-casing
+  — the LIVE sentinel falls out of the comparison naturally.
+- **This metadata is now AUTHORITATIVE (prerequisites merged).** Issue #1728 makes the writer stamp
+  `NO_DELETION_TIME` on live cells, so a MIXED SSTable (an old tombstone whose localDeletionTime is below
+  `gcBefore` PLUS any live non-TTL cell) finalizes `max_local_deletion_time` as the `i32::MAX` live
+  sentinel — never `< gcBefore` — and is correctly NOT classified fully expired. This closes the former
+  data-loss gap (roborev High F1): before #1728 a mixed SSTable could under-report its
+  `max_local_deletion_time` and be wrongly dropped whole, losing its live cell. The classifier relies
+  directly on this now-authoritative value; no workaround is needed.
 - **No cell scan.** The decision is a single integer comparison against one metadata field. This is the
   no-heuristics-compliant path (issue #28) and is the whole point of the optimization: we must NOT read
   the SSTable's rows to decide to drop it (that would defeat the perf win and reintroduce a scan).
@@ -76,6 +83,15 @@ candidate is safe to drop iff its own **`max_timestamp` is strictly less than th
 - This reuses the identical `min_timestamp` metadata and the identical conservatism as the existing #935
   tombstone-purge gate, so the two decisions stay consistent (a compaction that may not purge a tombstone
   also may not silently drop the SSTable that holds it).
+- **The candidate `max_timestamp` is now AUTHORITATIVE (prerequisite merged).** Issue #1729 makes
+  `StatisticsReader::max_timestamp()` decode the true maxTimestamp from `Statistics.db`, returning `None`
+  (fail-closed) via the `i64::MIN` sentinel when it is unavailable. The overlap gate compares that
+  authoritative newest write against the bound and **fails closed** on `None`: a candidate whose newest
+  write is unknown cannot be proven to predate the outside data, so it is RETAINED (never dropped). This
+  closes the former resurrection gap (roborev High F2): before #1729 an unavailable max could compare as a
+  low placeholder and wrongly permit a drop, resurrecting shadowed data. The gate compares the true NEWEST
+  write (`max_timestamp`), never `min_timestamp`, so a candidate with `min_timestamp < bound <
+  max_timestamp` is correctly retained.
 
 ## Chosen approach: metadata-only drop-set computed at the plan step
 

--- a/openspec/changes/fully-expired-sstable-drop/proposal.md
+++ b/openspec/changes/fully-expired-sstable-drop/proposal.md
@@ -1,0 +1,78 @@
+# Proposal: fully-expired-sstable-drop
+
+> Milestone: Cassandra Byte-for-Byte Parity Program (parent epic #1378, from the 2026-07-01 parity audit).
+> Issue: #1388. Routing: **design-driven** (a new compaction-planning capability + public API surface,
+> not an oracle-driven decode/offset bug fix) → OpenSpec. Owner has already approved the product go/no-go
+> (feature is YES). Priority P2 (perf/space optimization). Builds on #1382 (expired data already purges
+> through the normal compaction path) — this change makes that purge *cheaper* by dropping whole SSTables
+> instead of rewriting them.
+
+## Why
+
+Cassandra's `CompactionController.getFullyExpiredSSTables` computes, before a compaction rewrites
+anything, the subset of input SSTables whose data is entirely past `gcBefore` (every cell's
+`localDeletionTime < gcBefore`). Those SSTables are **dropped whole** — excluded from the K-way merge and
+simply deleted after the output is published — instead of being read, merged, and re-serialized into the
+output. This mirrors `TTLExpiryTest`: a table written with only TTL'd data, once every TTL has expired and
+the grace period has elapsed, compacts to *nothing* without paying the rewrite cost.
+
+CQLite today has none of this. Grepping `fully_expired` in the write engine finds only a doc comment
+(`cqlite-core/src/storage/write_engine/merge/mod.rs:~1092`). After #1382 landed, an all-expired SSTable is
+still read and merged; its rows are correctly purged (so the *output* is right), but CQLite pays the full
+rewrite cost — reading and decoding every dead cell only to drop it. For a large all-expired SSTable next
+to a small live one, a major compaction rewrites the live rows and needlessly streams the entire dead
+SSTable through the merger. Dropping it whole is strictly faster and reclaims the space in one unlink.
+
+The correctness subtlety Cassandra guards is **overlap safety**: a fully-expired SSTable may still hold a
+*tombstone* (or a deletion) that shadows *older live data* living in an SSTable that is NOT part of this
+compaction. Dropping the expired SSTable whole in that case would resurrect the shadowed data on the next
+read. Cassandra gates the drop with a max-timestamp overlap check against the non-compacting overlapping
+SSTables; this change mirrors that gate using authoritative `Statistics.db` metadata.
+
+## What changes
+
+- Add a **metadata-only fully-expired detection** function to the merge module that, given a candidate
+  SSTable's `Statistics.db` and the compaction's `gcBefore` cutoff, decides whether the SSTable is fully
+  expired: `maxLocalDeletionTime < gcBefore` (read from `TimestampStatistics.max_deletion_time`). No cell
+  scan — authoritative metadata only (no-heuristics mandate).
+- Add an **overlap-safety gate** mirroring Cassandra: a candidate that passes the expiry test is only
+  eligible to be dropped when its `maxTimestamp` (`TimestampStatistics.max_timestamp`) is strictly less
+  than the minimum write timestamp across every *outside* overlapping SSTable (the same
+  `EncodingStats.minTimestamp` bound `compute_max_purgeable_timestamp` already reads). If it could shadow
+  older data outside the compaction set, it is NOT dropped.
+- Add a **drop-set computation** that composes the two: given the compaction input set and the outside
+  overlapping set, return the subset to drop whole. Excluded (dropped) SSTables are removed from the
+  merger's input list and deleted after the output publishes.
+- Wire the drop-set into the compaction surfaces so a dropped SSTable's rows are absent from output AND
+  the plan/stats record which SSTables were dropped whole (assertable, not just observable in output).
+- Extend the compaction report/stats to expose the dropped-whole set (paths + count) so tests and the CLI
+  can assert the plan decision.
+
+## Non-goals
+
+- **NOT changing single-SSTable / normal-path purge from #1382.** Expired cells still purge correctly
+  through the merge for any SSTable that is *not* dropped whole; this change only adds a whole-SSTable
+  fast path on top of that behavior. Read output for a non-dropped SSTable is unchanged.
+- **NOT partial drop.** An SSTable that is only *partially* expired is never dropped; it goes through the
+  normal merge exactly as today. Only an SSTable proven fully expired by metadata is eligible.
+- **NOT relaxing the overlap-safety contract.** The drop is gated at least as conservatively as
+  Cassandra's overlap check. When metadata cannot prove safety (unreadable/absent `Statistics.db` for the
+  candidate or any outside SSTable), the SSTable is NOT dropped (conservative default), exactly as
+  `compute_max_purgeable_timestamp` already degrades.
+- **NOT a new compaction strategy or policy.** This is a planning refinement inside existing major/full
+  compaction paths; it does not add STCS/LCS/TWCS selection logic.
+- **NOT changing how `gcBefore` is derived.** `gcBefore` continues to come from `compute_gc_before`
+  (schema `gc_grace_seconds`, Cassandra's 10-day default on absence) / the CLI `--gc-before` cutoff.
+- **NOT applied to purge-unsafe partial background compactions beyond what the max-timestamp gate
+  already proves.** A background partial compaction may still drop a fully-expired SSTable, but ONLY when
+  the overlap gate proves it shadows nothing outside the set (same conservatism as #935 purging).
+
+## Doctrine impact
+
+- No change to `CLAUDE.md` or the `agents-developing/` site is required: this is a scoped compaction
+  capability governed by the existing no-heuristics mandate and the existing supported-format floor. The
+  new detection reads only authoritative `Statistics.db` metadata, so it is squarely inside the
+  no-heuristics doctrine (cite it in code comments, do not amend it).
+- The definitive guide's compaction chapter (`docs/sstables-definitive-guide/chapters/15-compaction-strategies.md`)
+  MAY gain a short note that fully-expired SSTables are dropped whole; that documentation edit is in scope
+  for the implement phase but changes no doctrine.

--- a/openspec/changes/fully-expired-sstable-drop/specs/fully-expired-sstable-drop/spec.md
+++ b/openspec/changes/fully-expired-sstable-drop/specs/fully-expired-sstable-drop/spec.md
@@ -1,0 +1,109 @@
+## ADDED Requirements
+
+### Requirement: A fully-expired SSTable is detected from authoritative Statistics.db metadata only
+
+The compaction engine SHALL classify a candidate SSTable as *fully expired* for a compaction with cutoff
+`gcBefore` iff its `Statistics.db` `TimestampStatistics.max_deletion_time` (Cassandra
+`StatsMetadata.maxLocalDeletionTime`) is strictly less than `gcBefore`. The decision MUST be made from
+that single metadata field and MUST NOT read, decode, or scan any cell of the candidate SSTable
+(no-heuristics mandate, issue #28). When `gcBefore` is `None` (invalid/absent gc_grace disables purging)
+or the candidate's `Statistics.db` cannot be read or parsed, the candidate SHALL NOT be classified as
+fully expired.
+
+#### Scenario: An all-expired SSTable is classified fully expired without a cell scan
+- **GIVEN** a candidate SSTable whose `Statistics.db` reports `max_deletion_time` strictly less than the compaction's `gcBefore`
+- **WHEN** the engine computes the fully-expired classification
+- **THEN** the SSTable is classified fully expired
+- **AND** the classification consulted only the `max_deletion_time` metadata field and read no rows/cells from the candidate's Data.db
+
+#### Scenario: An SSTable holding live (non-expiring) data is never classified fully expired
+- **GIVEN** a candidate SSTable whose `max_deletion_time` equals the LIVE sentinel (i32::MAX / `NO_DELETION_TIME`) or is >= `gcBefore`
+- **WHEN** the engine computes the fully-expired classification
+- **THEN** the SSTable is NOT classified fully expired
+
+#### Scenario: Unknown gcBefore or unreadable Statistics.db is treated conservatively
+- **GIVEN** a candidate SSTable for a compaction whose `gcBefore` is `None`, OR whose sibling `Statistics.db` is absent or fails to parse
+- **WHEN** the engine computes the fully-expired classification
+- **THEN** the SSTable is NOT classified fully expired
+- **AND** the SSTable proceeds through the normal merge unchanged
+
+### Requirement: A fully-expired SSTable that could shadow data outside the compaction set is not dropped (overlap safety)
+
+The compaction engine SHALL drop a fully-expired SSTable whole ONLY when it is proven not to shadow data
+living in an overlapping SSTable outside the compaction set. The proof SHALL be that the candidate's
+`TimestampStatistics.max_timestamp` is strictly less than the minimum write timestamp
+(`EncodingStats.minTimestamp`) across every outside overlapping SSTable — the same bound
+`compute_max_purgeable_timestamp` computes. For a full/major compaction the outside set is empty and the
+bound is treated as `+inf` (every fully-expired SSTable is droppable). When the outside bound is UNKNOWN
+in a partial compaction (any outside `Statistics.db` unreadable), no fully-expired SSTable SHALL be
+dropped.
+
+#### Scenario: A fully-expired SSTable that shadows older data outside the set is retained
+- **GIVEN** a fully-expired candidate SSTable in a partial compaction
+- **AND** an EXCLUDED overlapping SSTable whose minimum write timestamp is <= the candidate's `max_timestamp`
+- **WHEN** the engine computes the drop-set
+- **THEN** the candidate is NOT dropped whole
+- **AND** the candidate proceeds through the normal merge so its tombstones/deletions still shadow the outside data on read
+
+#### Scenario: A fully-expired SSTable older than everything outside the set is dropped
+- **GIVEN** a fully-expired candidate SSTable in a partial compaction
+- **AND** every EXCLUDED overlapping SSTable has a minimum write timestamp strictly greater than the candidate's `max_timestamp`
+- **WHEN** the engine computes the drop-set
+- **THEN** the candidate is included in the drop-set
+
+#### Scenario: A major compaction drops every fully-expired SSTable (empty outside set)
+- **GIVEN** a full/major compaction whose input set spans every SSTable for the table (empty outside set)
+- **AND** a fully-expired candidate among the inputs
+- **WHEN** the engine computes the drop-set
+- **THEN** the candidate is included in the drop-set (the `+inf` overlap bound is always satisfied)
+
+#### Scenario: An unknown outside bound in a partial compaction retains all fully-expired SSTables
+- **GIVEN** a partial compaction with a fully-expired candidate
+- **AND** at least one EXCLUDED overlapping SSTable whose `Statistics.db` cannot be read or parsed
+- **WHEN** the engine computes the drop-set
+- **THEN** no SSTable is dropped whole
+- **AND** every candidate proceeds through the normal merge
+
+### Requirement: A dropped-whole SSTable is excluded from the merge output and its rows are absent
+
+The compaction engine SHALL exclude every drop-set SSTable from the K-way merger's input list before the
+merge runs, so its rows are never read, decoded, or written to the compaction output. The compaction
+SHALL delete the dropped SSTable's components only after the merged output is atomically published, using
+the same reclamation path as the merged inputs.
+
+#### Scenario: Major compaction of an all-expired SSTable plus a live SSTable omits the expired rows
+- **GIVEN** an SSTable containing only expired-past-grace TTL cells and a separate SSTable containing live rows
+- **WHEN** a major compaction runs over both
+- **THEN** none of the expired SSTable's rows appear in the compaction output
+- **AND** every live row from the live SSTable appears in the compaction output
+- **AND** the expired SSTable's rows were never read into the merger (it was excluded from the merger input list)
+
+### Requirement: The compaction plan/stats record which SSTables were dropped whole
+
+The compaction report SHALL expose the set of SSTables that were dropped whole (their paths and a count),
+distinct from the merged inputs, so the drop decision is assertable from the plan/stats and not only
+inferable from output absence.
+
+#### Scenario: The report names the dropped-whole SSTables
+- **GIVEN** a major compaction that drops one fully-expired SSTable and merges one live SSTable
+- **WHEN** the compaction completes
+- **THEN** the compaction report lists exactly the dropped SSTable in its dropped-whole set
+- **AND** the dropped SSTable does not appear in the report's merged-input accounting
+
+#### Scenario: A compaction that drops nothing reports an empty dropped-whole set
+- **GIVEN** a compaction where no input is fully expired (or the overlap gate retains all candidates)
+- **WHEN** the compaction completes
+- **THEN** the report's dropped-whole set is empty
+- **AND** the merge output is byte-for-byte identical to the pre-change behavior for that input set
+
+### Requirement: Read parity across generations is unchanged before and after compaction
+
+Dropping fully-expired SSTables whole SHALL NOT change the query result for any partition or generation
+compared with the pre-change compaction behavior. A dropped SSTable contributes no live data (it is fully
+expired), so its removal is observationally equivalent to purging its cells through the normal merge.
+
+#### Scenario: Query results are identical before and after a drop-whole compaction
+- **GIVEN** a set of SSTables containing live data plus one fully-expired SSTable
+- **WHEN** the same query is run against the SSTables before compaction and against the compaction output afterwards
+- **THEN** the two result sets are equal for every partition and clustering row
+- **AND** the result equals the result of a compaction that merged (rather than dropped) the fully-expired SSTable through the normal purge path

--- a/openspec/changes/fully-expired-sstable-drop/tasks.md
+++ b/openspec/changes/fully-expired-sstable-drop/tasks.md
@@ -7,7 +7,7 @@
 
 ## 1. Metadata-only fully-expired detection
 
-- [ ] 1.1 Add `fn is_fully_expired(stats: &TimestampStatistics, gc_before_secs: i64) -> bool` (or a
+- [x] 1.1 Add `fn is_fully_expired(stats: &TimestampStatistics, gc_before_secs: i64) -> bool` (or a
       per-path variant reading `Statistics.db` via `stats_path_for` + `parse_statistics_with_fallback`)
       to the merge module. Predicate: `max_deletion_time < gc_before_secs`. Surface:
       `cqlite_core::storage::write_engine::merge` public/pub(crate) fn + a unit test that passes for an
@@ -16,7 +16,7 @@
 
 ## 2. Overlap-safety gate + drop-set computation
 
-- [ ] 2.1 Add `fn fully_expired_sstables(input_paths, outside_paths, gc_before_secs: Option<i64>) ->
+- [x] 2.1 Add `fn fully_expired_sstables(input_paths, outside_paths, gc_before_secs: Option<i64>) ->
       Vec<PathBuf>` composing 1.1 with the overlap bound. Reuse `compute_max_purgeable_timestamp` for the
       outside `min_timestamp` bound; drop a candidate iff fully expired AND
       `candidate.max_timestamp < outside_bound` (with `+inf` for an empty outside set / full compaction,
@@ -26,7 +26,7 @@
 
 ## 3. Wire drop-set into the WriteEngine background path
 
-- [ ] 3.1 In `maintenance_step_inner` compute the drop-set from `selected` (inputs) + `non_included`
+- [x] 3.1 In `maintenance_step_inner` compute the drop-set from `selected` (inputs) + `non_included`
       (outside) + `gc_before_secs`, subtract it from `selected` before `start_merge`, and thread the
       dropped paths into `start_merge` so finalize deletes them after publish. Surface:
       `WriteEngine::maintenance_step` (via `start_merge`) + an integration test asserting a fully-expired
@@ -34,7 +34,7 @@
 
 ## 4. Wire drop-set into the CLI one-shot path (gated per OQ-1)
 
-- [ ] 4.1 Per OQ-1 resolution: in `compact_sstables_with_registry`, when `purge_safe == true` (`--major`),
+- [x] 4.1 Per OQ-1 resolution: in `compact_sstables_with_registry`, when `purge_safe == true` (`--major`),
       compute the drop-set with an empty outside set, subtract it from `input_paths` before building the
       `KWayMerger`, and delete the dropped files after `writer.finish()`. No drop when `purge_safe`
       is false. Surface: `merge::compact_sstables_with_registry` + `cqlite compact --major` integration
@@ -42,29 +42,29 @@
 
 ## 5. Report/stats surface for the drop decision
 
-- [ ] 5.1 Add `dropped_whole: Vec<PathBuf>` (and count) to `MergeStats` / `CompactReport` and populate it
+- [x] 5.1 Add `dropped_whole: Vec<PathBuf>` (and count) to `MergeStats` / `CompactReport` and populate it
       from the drop-set on both surfaces. Surface: `CompactReport.stats.dropped_whole` +
       `CompactResult` (CLI) fields + tests asserting the plan decision (acceptance-criterion 1's
       "assert via plan/stats, not just output") and an empty set when nothing is dropped.
 
 ## 6. Read-parity + regression tests
 
-- [ ] 6.1 Add an integration test: build live + fully-expired SSTables, run the query before and after a
+- [x] 6.1 Add an integration test: build live + fully-expired SSTables, run the query before and after a
       drop-whole compaction, assert identical result sets per partition/generation (acceptance-criterion
       3), and assert the drop-whole result equals a merged-purge result. Surface: query engine over the
       compaction output.
-- [ ] 6.2 Add an overlap-safety regression test: a fully-expired SSTable that shadows data in an EXCLUDED
+- [x] 6.2 Add an overlap-safety regression test: a fully-expired SSTable that shadows data in an EXCLUDED
       overlapping SSTable is NOT dropped and the shadowed data stays shadowed on read (acceptance-criterion
       2). Surface: `WriteEngine::maintenance_step` + query engine.
 
 ## 7. Documentation
 
-- [ ] 7.1 Add a short note to `docs/sstables-definitive-guide/chapters/15-compaction-strategies.md` that
+- [x] 7.1 Add a short note to `docs/sstables-definitive-guide/chapters/15-compaction-strategies.md` that
       fully-expired SSTables are dropped whole (metadata-only detection + overlap gate). No doctrine change.
 
 ## 8. Gate + audit + review (pipeline)
 
-- [ ] 8.1 Run `scripts/agent-gate.sh` (fmt, clippy `-D warnings`, core/integration/write-support/CLI
+- [x] 8.1 Run `scripts/agent-gate.sh` (fmt, clippy `-D warnings`, core/integration/write-support/CLI
       tests, minimal build, smoke) and paste the SUMMARY block. Run with `CQLITE_DATASETS_ROOT` pointed
       at the main repo's `test-data/datasets` (worktrees have no Data.db binaries).
 - [ ] 8.2 Spec-auditor (C) review anchored to `openspec/changes/fully-expired-sstable-drop/specs/**`:

--- a/openspec/changes/fully-expired-sstable-drop/tasks.md
+++ b/openspec/changes/fully-expired-sstable-drop/tasks.md
@@ -20,9 +20,11 @@
       Vec<PathBuf>` composing 1.1 with the overlap bound. Reuse `compute_max_purgeable_timestamp` for the
       outside `min_timestamp` bound; drop a candidate iff fully expired AND
       `candidate.max_timestamp < outside_bound` (with `+inf` for an empty outside set / full compaction,
-      and NO drop when `gc_before_secs == None` or the bound is UNKNOWN in a partial compaction). Surface:
-      `merge::fully_expired_sstables` + unit tests covering: shadowing-retained, older-than-outside-dropped,
-      major-empty-outside-dropped, unknown-bound-retained, invalid-gcBefore-retained.
+      and NO drop when `gc_before_secs == None` or the bound is UNKNOWN in a partial compaction). Uses the
+      authoritative #1729 `max_timestamp` and fails closed (retains) when it is unavailable (`i64::MIN`
+      sentinel). Surface: `merge::fully_expired_sstables` + unit tests covering: shadowing-retained,
+      older-than-outside-dropped, major-empty-outside-dropped, unknown-bound-retained,
+      invalid-gcBefore-retained, min<bound<max-retained, unavailable-max-fails-closed.
 
 ## 3. Wire drop-set into the WriteEngine background path
 
@@ -56,6 +58,15 @@
 - [x] 6.2 Add an overlap-safety regression test: a fully-expired SSTable that shadows data in an EXCLUDED
       overlapping SSTable is NOT dropped and the shadowed data stays shadowed on read (acceptance-criterion
       2). Surface: `WriteEngine::maintenance_step` + query engine.
+- [x] 6.3 Roborev High F1/F2 regression tests (prerequisites #1728/#1729 merged make the metadata
+      authoritative). F1 (data-loss): a MIXED SSTable (old tombstone LDT < gcBefore + a live non-TTL cell)
+      is NOT classified fully expired and is NOT dropped by `compact_sstables` — the live cell survives
+      (`mixed_tombstone_and_live_sstable_not_dropped`). F2 (resurrection): the overlap gate compares the
+      authoritative `max_timestamp` — a candidate with `min_timestamp < bound < max_timestamp` is RETAINED
+      (`overlap_gate_uses_max_timestamp_not_min_retains_when_max_above_bound`), and an UNAVAILABLE
+      (`i64::MIN`) max_timestamp fails closed / retains
+      (`overlap_gate_fails_closed_on_unavailable_max_timestamp`). Surface: `compact_sstables` + the
+      metadata classifier.
 
 ## 7. Documentation
 

--- a/openspec/changes/fully-expired-sstable-drop/tasks.md
+++ b/openspec/changes/fully-expired-sstable-drop/tasks.md
@@ -1,0 +1,73 @@
+# Tasks: fully-expired-sstable-drop
+
+> Implementation tasks for the LATER implement phase. Each task names the public surface it exercises.
+> Do NOT start these during the proposal/design phase. Owner OPEN QUESTIONS in `design.md` (OQ-1 CLI
+> drop under `--major`; OQ-2 coarse vs key-range overlap) MUST be resolved before tasks 3–4 are
+> finalized.
+
+## 1. Metadata-only fully-expired detection
+
+- [ ] 1.1 Add `fn is_fully_expired(stats: &TimestampStatistics, gc_before_secs: i64) -> bool` (or a
+      per-path variant reading `Statistics.db` via `stats_path_for` + `parse_statistics_with_fallback`)
+      to the merge module. Predicate: `max_deletion_time < gc_before_secs`. Surface:
+      `cqlite_core::storage::write_engine::merge` public/pub(crate) fn + a unit test that passes for an
+      all-expired stats block and fails for a LIVE-sentinel / >= gcBefore block, asserting NO Data.db
+      read occurs.
+
+## 2. Overlap-safety gate + drop-set computation
+
+- [ ] 2.1 Add `fn fully_expired_sstables(input_paths, outside_paths, gc_before_secs: Option<i64>) ->
+      Vec<PathBuf>` composing 1.1 with the overlap bound. Reuse `compute_max_purgeable_timestamp` for the
+      outside `min_timestamp` bound; drop a candidate iff fully expired AND
+      `candidate.max_timestamp < outside_bound` (with `+inf` for an empty outside set / full compaction,
+      and NO drop when `gc_before_secs == None` or the bound is UNKNOWN in a partial compaction). Surface:
+      `merge::fully_expired_sstables` + unit tests covering: shadowing-retained, older-than-outside-dropped,
+      major-empty-outside-dropped, unknown-bound-retained, invalid-gcBefore-retained.
+
+## 3. Wire drop-set into the WriteEngine background path
+
+- [ ] 3.1 In `maintenance_step_inner` compute the drop-set from `selected` (inputs) + `non_included`
+      (outside) + `gc_before_secs`, subtract it from `selected` before `start_merge`, and thread the
+      dropped paths into `start_merge` so finalize deletes them after publish. Surface:
+      `WriteEngine::maintenance_step` (via `start_merge`) + an integration test asserting a fully-expired
+      candidate is excluded and reclaimed.
+
+## 4. Wire drop-set into the CLI one-shot path (gated per OQ-1)
+
+- [ ] 4.1 Per OQ-1 resolution: in `compact_sstables_with_registry`, when `purge_safe == true` (`--major`),
+      compute the drop-set with an empty outside set, subtract it from `input_paths` before building the
+      `KWayMerger`, and delete the dropped files after `writer.finish()`. No drop when `purge_safe`
+      is false. Surface: `merge::compact_sstables_with_registry` + `cqlite compact --major` integration
+      test (acceptance-criterion 1).
+
+## 5. Report/stats surface for the drop decision
+
+- [ ] 5.1 Add `dropped_whole: Vec<PathBuf>` (and count) to `MergeStats` / `CompactReport` and populate it
+      from the drop-set on both surfaces. Surface: `CompactReport.stats.dropped_whole` +
+      `CompactResult` (CLI) fields + tests asserting the plan decision (acceptance-criterion 1's
+      "assert via plan/stats, not just output") and an empty set when nothing is dropped.
+
+## 6. Read-parity + regression tests
+
+- [ ] 6.1 Add an integration test: build live + fully-expired SSTables, run the query before and after a
+      drop-whole compaction, assert identical result sets per partition/generation (acceptance-criterion
+      3), and assert the drop-whole result equals a merged-purge result. Surface: query engine over the
+      compaction output.
+- [ ] 6.2 Add an overlap-safety regression test: a fully-expired SSTable that shadows data in an EXCLUDED
+      overlapping SSTable is NOT dropped and the shadowed data stays shadowed on read (acceptance-criterion
+      2). Surface: `WriteEngine::maintenance_step` + query engine.
+
+## 7. Documentation
+
+- [ ] 7.1 Add a short note to `docs/sstables-definitive-guide/chapters/15-compaction-strategies.md` that
+      fully-expired SSTables are dropped whole (metadata-only detection + overlap gate). No doctrine change.
+
+## 8. Gate + audit + review (pipeline)
+
+- [ ] 8.1 Run `scripts/agent-gate.sh` (fmt, clippy `-D warnings`, core/integration/write-support/CLI
+      tests, minimal build, smoke) and paste the SUMMARY block. Run with `CQLITE_DATASETS_ROOT` pointed
+      at the main repo's `test-data/datasets` (worktrees have no Data.db binaries).
+- [ ] 8.2 Spec-auditor (C) review anchored to `openspec/changes/fully-expired-sstable-drop/specs/**`:
+      every requirement `satisfied` with a public-surface test as evidence.
+- [ ] 8.3 roborev review (`--branch --base origin/main --agent codex --wait`); clear all findings.
+- [ ] 8.4 `openspec archive fully-expired-sstable-drop` after gate PASS + C PASS + roborev clean + merge.


### PR DESCRIPTION
Closes #1388. Epic #1378 (final child). OpenSpec change fully-expired-sstable-drop (owner-approved Seam 1). Prereqs #1728/#1729 merged.

Cassandra getFullyExpiredSSTables parity: an SSTable whose Statistics.db max_deletion_time < gcBefore is dropped WHOLE (excluded from the merge, reclaimed after publish) instead of rewritten. Metadata-only detection (no cell scan, no-heuristics); overlap-safety gate uses authoritative maxTimestamp (#1729) and fails closed; CLI drops only under --major (OQ-1); coarse #935 overlap bound (OQ-2). dropped_whole surfaced in MergeStats/MaintenanceReport/CLI.

Quality bar (all on final HEAD 3cd1f195): gate green (canonical RESULT: PASS on parent b9964e7c; the additive roborev fix verified component-isolated green — core-tests 3931/0, clippy -D warnings, fmt, integration, CLI, unit — a contiguous block blocked only by machine OOM under 17-20 concurrent gates); **C (spec-auditor) PASS** (R1-R5 satisfied w/ public-surface tests, no-heuristics confirmed, F1/F2 closed); **roborev CLEAN** (job 2748). Byte-parity fixtures (#1387/#1410) still byte-identical.