### PR TITLE
perf(#1663): incremental Data.db checksums at finish() (no double re-read)

### DIFF
--- a/cqlite-core/src/storage/sstable/work_counters.rs
+++ b/cqlite-core/src/storage/sstable/work_counters.rs
@@ -106,6 +106,14 @@ struct Counters {
     /// A regression that materialises the whole partition before reversing pushes
     /// this to the partition's full row count instead of one block's worth.
     reverse_peak_block_rows: AtomicU64,
+    /// Full re-reads of a finished `Data.db` performed to compute checksums
+    /// (Issue #1663). Bumped once each time the re-read CRC oracle
+    /// (`crc_writer::build_crc_bytes`) or the digest re-read
+    /// (`SSTableWriter::compute_crc32`) OPENS `Data.db`. The streaming write path
+    /// accumulates both checksums as it writes, so a non-empty
+    /// `SSTableWriter::finish()` must leave this at 0; a regression that
+    /// reintroduces the finish-time double re-read bumps it (2 on the old path).
+    data_db_checksum_full_reads: AtomicU64,
 }
 
 impl Counters {
@@ -118,6 +126,7 @@ impl Counters {
             rows_decoded: AtomicU64::new(0),
             reverse_blocks_decoded: AtomicU64::new(0),
             reverse_peak_block_rows: AtomicU64::new(0),
+            data_db_checksum_full_reads: AtomicU64::new(0),
         }
     }
 
@@ -157,6 +166,16 @@ impl Counters {
             .fetch_max(rows, Ordering::Relaxed);
     }
 
+    #[cfg(feature = "write-support")]
+    fn add_data_db_checksum_full_read(&self) {
+        self.data_db_checksum_full_reads
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn data_db_checksum_full_reads(&self) -> u64 {
+        self.data_db_checksum_full_reads.load(Ordering::Relaxed)
+    }
+
     fn reverse_blocks_decoded(&self) -> u64 {
         self.reverse_blocks_decoded.load(Ordering::Relaxed)
     }
@@ -193,6 +212,7 @@ impl Counters {
         self.rows_decoded.store(0, Ordering::Relaxed);
         self.reverse_blocks_decoded.store(0, Ordering::Relaxed);
         self.reverse_peak_block_rows.store(0, Ordering::Relaxed);
+        self.data_db_checksum_full_reads.store(0, Ordering::Relaxed);
     }
 }
 
@@ -284,6 +304,31 @@ pub(crate) fn add_reverse_block_decoded() {
 #[cfg(not(feature = "tombstones"))]
 pub(crate) fn observe_reverse_block_rows(rows: u64) {
     COUNTERS.observe_reverse_block_rows(rows);
+}
+
+/// Record one full re-read of a finished `Data.db` performed to compute
+/// checksums (Issue #1663). Called once at each site that OPENS `Data.db` to
+/// checksum it: the re-read CRC oracle (`crc_writer::build_crc_bytes`) and the
+/// digest re-read (`SSTableWriter::compute_crc32`).
+///
+/// Gated on `write-support` because both increment sites live in the writer,
+/// which is only compiled with that feature; the getter and [`reset`] are
+/// available in every build for the test API.
+#[cfg(feature = "write-support")]
+pub fn add_data_db_checksum_full_read() {
+    COUNTERS.add_data_db_checksum_full_read();
+}
+
+/// Number of full `Data.db` re-reads performed for checksum computation since
+/// the last [`reset`] (Issue #1663).
+///
+/// The streaming write path accumulates the whole-file digest and the per-chunk
+/// `CRC.db` values as it writes, so a non-empty `SSTableWriter::finish()` must
+/// leave this at 0. A regression that reintroduces the finish-time double
+/// re-read (one for `Digest.crc32`, one for `CRC.db`) bumps it to 2, failing the
+/// issue-#1663 work guard.
+pub fn data_db_checksum_full_reads() -> u64 {
+    COUNTERS.data_db_checksum_full_reads()
 }
 
 /// Number of candidate SSTables parsed by partition-targeted lookups since the

--- a/cqlite-core/src/storage/sstable/writer/crc_writer.rs
+++ b/cqlite-core/src/storage/sstable/writer/crc_writer.rs
@@ -51,9 +51,13 @@
 //! `crc_file_pos = (offset / chunk_size) * 4 + 4`
 //! (`DataIntegrityMetadata.ChecksumValidator`).
 
-use std::path::{Path, PathBuf};
-
+// `Path`/`PathBuf`/`Result` are used only by the re-read oracle helpers
+// (`build_crc_bytes`/`write_crc_db`), which are test-only since the production
+// write path assembles `CRC.db` from streaming-accumulated chunk CRCs (#1663).
+#[cfg(test)]
 use crate::error::Result;
+#[cfg(test)]
+use std::path::{Path, PathBuf};
 
 /// Default uncompressed CRC chunk size, matching Cassandra's
 /// `SequentialWriterOption.Builder` default `bufferSize` of `64 * 1024`.
@@ -81,41 +85,129 @@ pub(crate) enum CrcTrailer {
     EmptyFinalChunk,
 }
 
-/// Compute the `CRC.db` bytes for an uncompressed `Data.db`.
+/// Assemble the on-disk `CRC.db` bytes from a slice of per-chunk CRC32 values.
+///
+/// This is the single source of truth for the `CRC.db` byte layout (issue
+/// #1663): a big-endian `i32` chunk-size header followed by one big-endian `u32`
+/// CRC32 per chunk, plus the issue-#1222 compaction trailer rule. Both the
+/// streaming write path (checksums accumulated during the write — see
+/// [`StreamingCrc`]) and the re-read [`build_crc_bytes`] oracle route their
+/// chunk CRCs through here, so the two paths are provably byte-identical.
+///
+/// Trailer rule (issue #1222):
+/// - [`CrcTrailer::None`] (flush path) appends nothing after the last chunk CRC.
+/// - [`CrcTrailer::EmptyFinalChunk`] (compaction path) appends ONE trailing
+///   `CRC32 = 0` (`00000000`) — Cassandra's compaction close-time zero-length
+///   buffer flush — but ONLY when at least one real chunk CRC was produced
+///   (non-empty `Data.db`). An empty `Data.db` stays header-only for BOTH
+///   trailers (there is no Cassandra golden for the empty-compaction case).
+pub(crate) fn assemble_crc_bytes(chunk_crcs: &[u32], trailer: CrcTrailer) -> Vec<u8> {
+    // header (4) + one u32 per chunk + optional trailing empty-chunk CRC (4).
+    let mut out = Vec::with_capacity(4 + chunk_crcs.len() * 4 + 4);
+    // Header: chunk size as a big-endian signed 32-bit int (DataOutput.writeInt).
+    out.extend_from_slice(&(CRC_CHUNK_SIZE as i32).to_be_bytes());
+    for crc in chunk_crcs {
+        out.extend_from_slice(&crc.to_be_bytes());
+    }
+    // Compaction-only trailing empty-final-chunk CRC32 (issue #1222): CRC32 of a
+    // zero-length buffer is 0. Gated on a real chunk having been produced so an
+    // empty Data.db keeps the documented header-only output for both trailers.
+    if matches!(trailer, CrcTrailer::EmptyFinalChunk) && !chunk_crcs.is_empty() {
+        out.extend_from_slice(&0u32.to_be_bytes());
+    }
+    out
+}
+
+/// Incremental `CRC.db` + `Digest.crc32` accumulator for the streaming write
+/// path (issue #1663).
+///
+/// The streaming Data.db writer feeds every byte it writes to disk through
+/// [`update`](Self::update) exactly once, in write order. This computes the
+/// whole-file CRC32 (the `Digest.crc32` value) and the per-chunk CRC32s
+/// (`CRC.db`) as the data streams by, so `finish()` never has to re-read the
+/// finished `Data.db` to checksum it. The chunk boundaries are fixed
+/// `CRC_CHUNK_SIZE` blocks of the RAW Data.db bytes and span partition
+/// boundaries — identical to what the re-read [`build_crc_bytes`] oracle
+/// produces — because `update` carries `chunk_filled` across calls.
+#[derive(Debug, Default)]
+pub(crate) struct StreamingCrc {
+    /// Whole-file CRC32 hasher (the `Digest.crc32` value).
+    whole: crc32fast::Hasher,
+    /// CRC32 hasher for the chunk currently being filled.
+    chunk: crc32fast::Hasher,
+    /// Bytes already fed into `chunk` toward the current `CRC_CHUNK_SIZE` block.
+    chunk_filled: usize,
+    /// Finalized per-chunk CRC32s, in order.
+    chunk_crcs: Vec<u32>,
+}
+
+impl StreamingCrc {
+    /// Create an empty accumulator.
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Feed the next run of just-written Data.db bytes, in write order.
+    ///
+    /// Updates the whole-file hasher and slices `bytes` into the fixed
+    /// `CRC_CHUNK_SIZE` chunk grid, finalizing a chunk CRC every time a full
+    /// block is completed. `chunk_filled` carries across calls so a chunk that
+    /// straddles two `update` calls (i.e. two partition flushes) is checksummed
+    /// as one block — matching `build_crc_bytes`'s chunk boundaries exactly.
+    pub(crate) fn update(&mut self, bytes: &[u8]) {
+        self.whole.update(bytes);
+        let mut remaining = bytes;
+        while !remaining.is_empty() {
+            let take = (CRC_CHUNK_SIZE - self.chunk_filled).min(remaining.len());
+            self.chunk.update(&remaining[..take]);
+            self.chunk_filled += take;
+            remaining = &remaining[take..];
+            if self.chunk_filled == CRC_CHUNK_SIZE {
+                let done = std::mem::replace(&mut self.chunk, crc32fast::Hasher::new());
+                self.chunk_crcs.push(done.finalize());
+                self.chunk_filled = 0;
+            }
+        }
+    }
+
+    /// Finalize the accumulator, returning `(digest_crc32, chunk_crcs)`.
+    ///
+    /// `digest_crc32` is the whole-file CRC32 over every fed byte (the
+    /// `Digest.crc32` value). `chunk_crcs` is one CRC32 per `CRC_CHUNK_SIZE`
+    /// block, including a final short chunk if `chunk_filled > 0`. Pass
+    /// `chunk_crcs` to [`assemble_crc_bytes`] to obtain the `CRC.db` bytes.
+    pub(crate) fn finalize(mut self) -> (u32, Vec<u32>) {
+        if self.chunk_filled > 0 {
+            self.chunk_crcs.push(self.chunk.finalize());
+        }
+        (self.whole.finalize(), self.chunk_crcs)
+    }
+}
+
+/// Compute the `CRC.db` bytes for an uncompressed `Data.db` by RE-READING it.
 ///
 /// Streams `data_path` in `CRC_CHUNK_SIZE` blocks (bounded memory, independent
-/// of the total Data.db size — see the digest-streaming rationale in
-/// `finish.rs`) and emits the Cassandra `CRC.db` layout: a big-endian `i32`
-/// chunk-size header followed by one big-endian `u32` CRC32 per chunk.
+/// of the total Data.db size) to build the per-chunk CRC32s, then delegates the
+/// byte layout to [`assemble_crc_bytes`] so this re-read oracle and the
+/// streaming [`StreamingCrc`] path are provably byte-identical.
 ///
-/// When `trailer` is [`CrcTrailer::EmptyFinalChunk`] (the compaction path,
-/// issue #1222), one extra big-endian `u32` `CRC32 = 0` is appended after the
-/// last real chunk, matching Cassandra's compaction close-time empty-buffer
-/// flush. [`CrcTrailer::None`] (the flush path) appends nothing.
+/// Retained (issue #1663) as the golden oracle for the incremental path's
+/// byte-parity tests and to build a `CRC.db` for the reader-side tests; the
+/// production write path no longer re-reads Data.db and does NOT call this.
+/// Each invocation bumps the [`data_db_checksum_full_reads`] work counter so a
+/// regression that reintroduces the full-file re-read is caught.
 ///
-/// An empty `Data.db` yields just the 4-byte header (zero chunks), matching
-/// Cassandra's behaviour when no data buffer is ever flushed. This empty-file
-/// behaviour is preserved for BOTH trailers: the compaction trailing
-/// empty-final-chunk `CRC32 = 0` is appended only when at least one real data
-/// chunk was checksummed (non-empty `Data.db`). A compaction that purges all
-/// partitions and finalizes an empty BIG SSTable therefore still gets the
-/// documented header-only `CRC.db`, never a lone trailing `00000000` after the
-/// header — the trailing zero only makes sense after a real chunk, and we have
-/// no Cassandra golden for the empty-compaction case (issue #1222 roborev).
+/// [`data_db_checksum_full_reads`]: crate::storage::sstable::work_counters::data_db_checksum_full_reads
+#[cfg(test)]
 pub(super) async fn build_crc_bytes(data_path: &Path, trailer: CrcTrailer) -> Result<Vec<u8>> {
     use tokio::io::AsyncReadExt;
 
-    let mut out = Vec::new();
-    // Header: chunk size as a big-endian signed 32-bit int (DataOutput.writeInt).
-    out.extend_from_slice(&(CRC_CHUNK_SIZE as i32).to_be_bytes());
-
     let mut file = tokio::fs::File::open(data_path).await?;
+    // Full re-read of Data.db for checksums — count it (issue #1663).
+    crate::storage::sstable::work_counters::add_data_db_checksum_full_read();
+    let mut chunk_crcs = Vec::new();
     let mut buffer = vec![0u8; CRC_CHUNK_SIZE];
     let mut filled = 0usize;
-    // Track whether any real data-chunk CRC was emitted (non-empty Data.db). The
-    // compaction trailer is gated on this so an empty Data.db keeps the
-    // documented header-only output for both trailers (issue #1222).
-    let mut emitted_real_chunk = false;
     loop {
         // Fill up to a full chunk before checksumming so each CRC covers a
         // complete CRC_CHUNK_SIZE block (except the final, short chunk), exactly
@@ -126,8 +218,7 @@ pub(super) async fn build_crc_bytes(data_path: &Path, trailer: CrcTrailer) -> Re
             if filled > 0 {
                 let mut hasher = crc32fast::Hasher::new();
                 hasher.update(&buffer[..filled]);
-                out.extend_from_slice(&hasher.finalize().to_be_bytes());
-                emitted_real_chunk = true;
+                chunk_crcs.push(hasher.finalize());
             }
             break;
         }
@@ -135,37 +226,25 @@ pub(super) async fn build_crc_bytes(data_path: &Path, trailer: CrcTrailer) -> Re
         if filled == CRC_CHUNK_SIZE {
             let mut hasher = crc32fast::Hasher::new();
             hasher.update(&buffer[..filled]);
-            out.extend_from_slice(&hasher.finalize().to_be_bytes());
-            emitted_real_chunk = true;
+            chunk_crcs.push(hasher.finalize());
             filled = 0;
         }
     }
 
-    // Compaction-only trailing empty-final-chunk CRC32 (issue #1222). Cassandra's
-    // compaction close flushes the data writer once more over a zero-length
-    // buffer; CRC32 of zero bytes is 0, so emit one trailing `00000000`. The
-    // flush path (CrcTrailer::None) never reaches this. Gated on a real chunk
-    // having been emitted: an empty Data.db keeps the documented header-only
-    // output even on the compaction path (the trailing zero only makes sense
-    // after at least one real data chunk, and there is no empty-compaction
-    // golden to match).
-    if matches!(trailer, CrcTrailer::EmptyFinalChunk) && emitted_real_chunk {
-        let empty_crc = crc32fast::Hasher::new().finalize();
-        out.extend_from_slice(&empty_crc.to_be_bytes());
-    }
-
-    Ok(out)
+    Ok(assemble_crc_bytes(&chunk_crcs, trailer))
 }
 
-/// Write the `CRC.db` component for an uncompressed `Data.db`, returning the
-/// component path.
+/// Write a `CRC.db` component by re-reading `data_path` (test-only oracle,
+/// issue #1663).
 ///
-/// Computes the per-chunk CRC bytes (see [`build_crc_bytes`]) and writes them to
-/// `crc_path`. Callers add the returned path to `TOC.txt` and `SSTableInfo`.
+/// The production write path assembles `CRC.db` from streaming-accumulated chunk
+/// CRCs (see [`assemble_crc_bytes`] / [`StreamingCrc`]) and no longer calls this;
+/// it is retained to build `CRC.db` fixtures for the reader-side tests.
 ///
 /// `trailer` selects the flush vs compaction tail (issue #1222): flush callers
 /// pass [`CrcTrailer::None`]; compaction callers pass
 /// [`CrcTrailer::EmptyFinalChunk`].
+#[cfg(test)]
 pub(crate) async fn write_crc_db(
     data_path: &Path,
     crc_path: PathBuf,
@@ -306,5 +385,85 @@ mod tests {
             assert_eq!(stored, hasher.finalize());
             pos += 4;
         }
+    }
+
+    // ---------------------------------------------------------------------
+    // Issue #1663: the incremental (streaming-accumulated) checksums must be
+    // byte-identical to the re-read oracle for BOTH the flush (`CrcTrailer::None`)
+    // and compaction (`CrcTrailer::EmptyFinalChunk`) tails, across single-chunk,
+    // multi-chunk, and short-final-chunk sizes — regardless of how the byte
+    // stream is split across `update` calls (partition-flush boundaries), which
+    // proves chunks straddle partition boundaries exactly like `build_crc_bytes`.
+    // ---------------------------------------------------------------------
+
+    /// Feed `payload` through a `StreamingCrc` in `split`-sized runs (simulating
+    /// per-partition flushes), then assert the assembled `CRC.db` bytes and the
+    /// whole-file digest equal the re-read oracle (`build_crc_bytes` /
+    /// `SSTableWriter::compute_crc32`) over a file holding the same bytes.
+    async fn assert_incremental_matches_reread(payload: &[u8], trailer: CrcTrailer, split: usize) {
+        use crate::storage::sstable::writer::SSTableWriter;
+
+        // Incremental path: accumulate as the bytes "stream" by in `split` runs.
+        let mut acc = StreamingCrc::new();
+        for run in payload.chunks(split.max(1)) {
+            acc.update(run);
+        }
+        let (inc_digest, inc_chunk_crcs) = acc.finalize();
+        let inc_crc_db = assemble_crc_bytes(&inc_chunk_crcs, trailer);
+
+        // Re-read oracle over a file holding the identical bytes.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let data = dir.path().join("Data.db");
+        tokio::fs::write(&data, payload).await.expect("write data");
+        let reread_crc_db = build_crc_bytes(&data, trailer)
+            .await
+            .expect("build_crc_bytes");
+        let reread_digest = SSTableWriter::compute_crc32(&data)
+            .await
+            .expect("compute_crc32");
+
+        assert_eq!(
+            inc_crc_db, reread_crc_db,
+            "incremental CRC.db must equal re-read oracle (len={}, trailer={trailer:?}, split={split})",
+            payload.len()
+        );
+        assert_eq!(
+            inc_digest,
+            reread_digest,
+            "incremental Digest.crc32 must equal re-read oracle (len={}, split={split})",
+            payload.len()
+        );
+    }
+
+    #[tokio::test]
+    async fn incremental_checksums_match_reread_oracle_all_sizes() {
+        // single-chunk short, exactly one full chunk, multi + short final,
+        // exactly two full chunks, multi + short final again.
+        let sizes = [
+            100usize,
+            CRC_CHUNK_SIZE,
+            CRC_CHUNK_SIZE + 100,
+            CRC_CHUNK_SIZE * 2,
+            CRC_CHUNK_SIZE * 2 + 100,
+        ];
+        // A split that is NOT a multiple of CRC_CHUNK_SIZE forces chunks to
+        // straddle `update` (partition-flush) boundaries.
+        let splits = [1usize, 7_000, CRC_CHUNK_SIZE, usize::MAX];
+        for &len in &sizes {
+            let payload: Vec<u8> = (0..len).map(|i| (i % 251) as u8).collect();
+            for &trailer in &[CrcTrailer::None, CrcTrailer::EmptyFinalChunk] {
+                for &split in &splits {
+                    assert_incremental_matches_reread(&payload, trailer, split).await;
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn incremental_empty_matches_reread_oracle() {
+        // Empty Data.db: header-only for both trailers, digest = CRC32 of zero
+        // bytes = 0 — must match the re-read oracle.
+        assert_incremental_matches_reread(&[], CrcTrailer::None, 1).await;
+        assert_incremental_matches_reread(&[], CrcTrailer::EmptyFinalChunk, 1).await;
     }
 }

--- a/cqlite-core/src/storage/sstable/writer/data_writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/mod.rs
@@ -65,6 +65,7 @@ pub(crate) use crate::storage::serialization::types::TypeSerializer;
 pub(crate) use crate::storage::serialization::vint::{
     encode_signed, encode_unsigned, unsigned_len,
 };
+pub(crate) use crate::storage::sstable::writer::crc_writer::StreamingCrc;
 pub(crate) use crate::storage::sstable::writer::index_writer::{
     PromotedIndexBlock, COLUMN_INDEX_SIZE_BYTES,
 };
@@ -182,6 +183,14 @@ pub struct DataWriter {
     data_path: Option<PathBuf>,
     /// Bytes already flushed to `sink`. Always 0 in in-memory mode.
     position: u64,
+    /// Incremental whole-file (`Digest.crc32`) + per-chunk (`CRC.db`) checksum
+    /// accumulator, fed every flushed byte in write order (issue #1663).
+    ///
+    /// Streaming mode only: [`flush_partition`](Self::flush_partition) feeds each
+    /// flushed scratch buffer through it, so [`finish_streaming`](Self::finish_streaming)
+    /// can return both checksums without re-reading the finished `Data.db`. Left
+    /// untouched (empty) in in-memory mode, which never calls `finish_streaming`.
+    crc: StreamingCrc,
     /// Encoding baselines used for delta encoding.
     stats: EncodingStatsBaselines,
 }
@@ -241,6 +250,22 @@ impl From<&StatisticsMetadata> for EncodingStatsBaselines {
     }
 }
 
+/// Result of finishing a streaming [`DataWriter`] (issue #1663).
+///
+/// Carries the total Data.db byte size and the checksums accumulated during the
+/// streaming write, so `SSTableWriter::finish` writes `Digest.crc32` and
+/// `CRC.db` without re-reading the finished `Data.db`.
+#[derive(Debug)]
+pub struct StreamFinish {
+    /// Total number of Data.db bytes written (the `data_size`).
+    pub data_size: u64,
+    /// Whole-file CRC32 over the raw Data.db bytes — the `Digest.crc32` value.
+    pub digest_crc32: u32,
+    /// One CRC32 per `CRC_CHUNK_SIZE` chunk of the raw Data.db bytes, in order —
+    /// the `CRC.db` chunk values (pass to `crc_writer::assemble_crc_bytes`).
+    pub chunk_crcs: Vec<u32>,
+}
+
 impl DataWriter {
     /// Create a new in-memory Data.db writer.
     ///
@@ -255,6 +280,7 @@ impl DataWriter {
             sink: None,
             data_path: None,
             position: 0,
+            crc: StreamingCrc::new(),
             stats: EncodingStatsBaselines::from(&stats),
         }
     }
@@ -275,6 +301,7 @@ impl DataWriter {
             sink: None,
             data_path: Some(data_path),
             position: 0,
+            crc: StreamingCrc::new(),
             stats: EncodingStatsBaselines::from(&stats),
         }
     }
@@ -318,6 +345,12 @@ impl DataWriter {
         if let Some(sink) = self.sink.as_mut() {
             sink.write_all(&self.buffer)?;
         }
+        // Feed the just-written bytes through the incremental checksum accumulator
+        // (issue #1663) so `finish_streaming` never re-reads the finished Data.db.
+        // Done here (after the sink write, before the clear) so every byte written
+        // to disk is checksummed exactly once, in write order — chunks straddle
+        // partition boundaries just as the re-read oracle chunks the raw file.
+        self.crc.update(&self.buffer);
         self.position += self.buffer.len() as u64;
         self.buffer.clear();
         Ok(())
@@ -358,12 +391,17 @@ impl DataWriter {
     }
 
     /// Finish a streaming writer: flush the sink to disk and return the total
-    /// number of Data.db bytes written (i.e. `data_size`).
+    /// byte size plus the checksums accumulated during the write (issue #1663).
     ///
     /// Any residual scratch (there is none in normal operation, since
     /// `write_partition` flushes per partition) is flushed first. Returns an
     /// error if the writer was created in in-memory mode.
-    pub fn finish_streaming(mut self) -> Result<u64> {
+    ///
+    /// The returned [`StreamFinish`] carries the whole-file `Digest.crc32` value
+    /// and the per-chunk `CRC.db` values that were accumulated as the data
+    /// streamed to disk, so `SSTableWriter::finish` computes neither by
+    /// re-reading the finished `Data.db`.
+    pub fn finish_streaming(mut self) -> Result<StreamFinish> {
         if self.data_path.is_none() {
             return Err(Error::InvalidInput(
                 "finish_streaming() called on an in-memory DataWriter".to_string(),
@@ -384,7 +422,15 @@ impl DataWriter {
                 .sync_all()
                 .map_err(|e| Error::Storage(format!("Failed to fsync Data.db contents: {e}")))?;
         }
-        Ok(self.position)
+        // Finalize the incremental checksums accumulated in `flush_partition`
+        // (issue #1663). `finalize` closes any trailing short chunk.
+        let data_size = self.position;
+        let (digest_crc32, chunk_crcs) = self.crc.finalize();
+        Ok(StreamFinish {
+            data_size,
+            digest_crc32,
+            chunk_crcs,
+        })
     }
 
     /// Get current file position (for Index.db offset tracking).

--- a/cqlite-core/src/storage/sstable/writer/data_writer/tests/scenarios_5.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/tests/scenarios_5.rs
@@ -332,7 +332,7 @@ fn test_streaming_writer_byte_identical_to_in_memory() {
                 .unwrap(),
         );
     }
-    let data_size = stream_writer.finish_streaming().unwrap();
+    let data_size = stream_writer.finish_streaming().unwrap().data_size;
 
     // Offsets returned to the caller (fed to Index.db) must be identical.
     assert_eq!(
@@ -409,7 +409,7 @@ fn test_streaming_writer_bounds_memory_to_one_partition() {
         prev_flushed = flushed_after;
     }
 
-    let total = writer.finish_streaming().unwrap();
+    let total = writer.finish_streaming().unwrap().data_size;
     assert_eq!(
         total, prev_flushed,
         "total size must equal last flushed pos"
@@ -443,7 +443,7 @@ fn finish_streaming_persists_data_db_contents() {
             .write_partition(key, mutations, &schema, None, &[])
             .unwrap();
     }
-    let data_size = writer.finish_streaming().unwrap();
+    let data_size = writer.finish_streaming().unwrap().data_size;
 
     // The file length on disk equals the reported size (all bytes durable).
     let meta = std::fs::metadata(&data_path).unwrap();

--- a/cqlite-core/src/storage/sstable/writer/finish.rs
+++ b/cqlite-core/src/storage/sstable/writer/finish.rs
@@ -95,7 +95,12 @@ impl SSTableWriter {
         // The streamed Data.db is fsynced inside `finish_streaming` (issue
         // #1392). The empty-Data fallback below is written via tokio::fs::write
         // (no fsync), so it is fsynced explicitly.
-        let data_size = self.data_writer.finish_streaming()?;
+        // `finish_streaming` returns the byte size plus the whole-file
+        // (`Digest.crc32`) and per-chunk (`CRC.db`) checksums accumulated during
+        // the streaming write, so finalization needs no full re-read of Data.db
+        // (issue #1663).
+        let stream = self.data_writer.finish_streaming()?;
+        let data_size = stream.data_size;
         if data_size == 0 && !data_path.exists() {
             tokio::fs::write(&data_path, b"").await?;
             Self::fsync_component(&data_path).await?;
@@ -169,10 +174,19 @@ impl SSTableWriter {
         // data is uncompressed. The compression_info_writer module is retained
         // for future compressed SSTable support.
 
-        // 6. Write Digest.crc32 (compute CRC32 of Data.db)
+        // 6. Write Digest.crc32 (whole-file CRC32 of Data.db).
+        // The streaming DataWriter accumulated this CRC as it wrote, so the
+        // finished Data.db is NOT re-read here (issue #1663). The empty-Data.db
+        // lazy path (no partitions streamed, an empty file written above) has no
+        // accumulated bytes; it recomputes over the just-written empty file via
+        // `compute_crc32` so the value stays correct (CRC32 of zero bytes = 0).
         let digest_path = cpath("Digest.crc32");
         let digest_writer = DigestWriter::new(digest_path.clone());
-        let crc32_value = Self::compute_crc32(&data_path).await?;
+        let crc32_value = if data_size == 0 {
+            Self::compute_crc32(&data_path).await?
+        } else {
+            stream.digest_crc32
+        };
         digest_writer.write(crc32_value)?;
 
         // 6.5. Write CRC.db — per-chunk CRC32 for uncompressed BIG (issue #1197).
@@ -197,9 +211,14 @@ impl SSTableWriter {
             } else {
                 CrcTrailer::None
             };
-            let crc_path = crc_writer::write_crc_db(&data_path, cpath("CRC.db"), trailer).await?;
-            // fsync CRC.db contents (issue #1392): write_crc_db uses
-            // tokio::fs::write, which does not fsync.
+            // Assemble CRC.db from the per-chunk CRCs accumulated during the
+            // streaming write — no re-read of the finished Data.db (issue #1663).
+            // The trailer selection (flush vs compaction, issue #1222) and the
+            // is_bti gate are unchanged; only the checksum INPUT SOURCE differs.
+            let crc_path = cpath("CRC.db");
+            let bytes = crc_writer::assemble_crc_bytes(&stream.chunk_crcs, trailer);
+            tokio::fs::write(&crc_path, bytes).await?;
+            // fsync CRC.db contents (issue #1392): tokio::fs::write does not fsync.
             Self::fsync_component(&crc_path).await?;
             Some(crc_path)
         };
@@ -365,6 +384,10 @@ impl SSTableWriter {
         const DIGEST_READ_BUFFER_BYTES: usize = 64 * 1024;
 
         let mut file = tokio::fs::File::open(file_path).await?;
+        // Full re-read of a finished component for checksums — count it so the
+        // issue-#1663 work guard catches a regression that reintroduces the
+        // finish-time Data.db re-read on the non-empty path.
+        crate::storage::sstable::work_counters::add_data_db_checksum_full_read();
         let mut hasher = crc32fast::Hasher::new();
         let mut buffer = vec![0u8; DIGEST_READ_BUFFER_BYTES];
         loop {

--- a/cqlite-core/src/storage/sstable/writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/mod.rs
@@ -70,7 +70,7 @@ pub use compression_info_writer::{
     CompressionAlgorithm, CompressionInfoWriter, CompressionMetadata,
 };
 #[cfg(feature = "write-support")]
-pub use data_writer::DataWriter;
+pub use data_writer::{DataWriter, StreamFinish};
 #[cfg(feature = "write-support")]
 pub use digest_writer::DigestWriter;
 #[cfg(feature = "write-support")]

--- a/cqlite-core/tests/issue_1663_incremental_checksums.rs
+++ b/cqlite-core/tests/issue_1663_incremental_checksums.rs
@@ -1,0 +1,166 @@
+//! Issue #1663: `SSTableWriter::finish()` must compute `Digest.crc32` and
+//! `CRC.db` from checksums accumulated during the streaming write — NOT by
+//! re-reading the finished `Data.db`.
+//!
+//! WORK GUARD: this test drives a full non-empty flush through the public
+//! `SSTableWriter::finish()` and asserts the process-global
+//! `data_db_checksum_full_reads` work counter stays at 0. On the pre-#1663 path
+//! `finish()` re-read the whole `Data.db` twice (once for `Digest.crc32`, once
+//! for `CRC.db`), so the counter would read 2. Accumulating both checksums as
+//! the data streams makes finalization perform ZERO extra full-file reads.
+//!
+//! This lives in its own integration test binary so the global counter it
+//! asserts on has a FRESH per-process instance — no in-crate `crc_writer` /
+//! reader test (which exercise the re-read oracle and DO bump the counter) can
+//! race it. Byte-parity of the incrementally-produced checksums is covered by
+//! the in-crate `crc_writer` golden tests; here we additionally reconcile the
+//! written components against the on-disk `Data.db` as a sanity check.
+
+#![cfg(feature = "write-support")]
+
+use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+use cqlite_core::storage::sstable::work_counters;
+use cqlite_core::storage::sstable::writer::{SSTableFormat, SSTableWriter};
+use cqlite_core::storage::write_engine::mutation::{
+    CellOperation, DecoratedKey, Mutation, PartitionKey, TableId,
+};
+use cqlite_core::types::Value;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+const KEYSPACE: &str = "test_incr_checksum";
+const TABLE: &str = "rows";
+const T_WRITE: i64 = 1_700_000_000_000_000;
+
+/// Cassandra's default uncompressed CRC chunk size.
+const CRC_CHUNK_SIZE: usize = 64 * 1024;
+
+fn schema() -> TableSchema {
+    TableSchema {
+        keyspace: KEYSPACE.into(),
+        table: TABLE.into(),
+        partition_keys: vec![KeyColumn {
+            name: "id".into(),
+            data_type: "int".into(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            Column {
+                name: "id".into(),
+                data_type: "int".into(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "name".into(),
+                data_type: "text".into(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+fn mutations(schema: &TableSchema) -> Vec<(DecoratedKey, Vec<Mutation>)> {
+    let mut keyed: Vec<(DecoratedKey, Mutation)> = (0..12)
+        .map(|i| {
+            let m = Mutation::new(
+                TableId::new(KEYSPACE, TABLE),
+                PartitionKey::single("id", Value::Integer(i)),
+                None,
+                vec![CellOperation::Write {
+                    column: "name".into(),
+                    value: Value::Text(format!("name{i}")),
+                }],
+                T_WRITE,
+                None,
+            );
+            (m.decorated_key(schema).expect("decorated key"), m)
+        })
+        .collect();
+    keyed.sort_by_key(|(k, _)| k.token);
+
+    let mut grouped: Vec<(DecoratedKey, Vec<Mutation>)> = Vec::new();
+    for (k, m) in keyed {
+        match grouped.last_mut() {
+            Some((lk, ms)) if lk.token == k.token && lk.key == k.key => ms.push(m),
+            _ => grouped.push((k, vec![m])),
+        }
+    }
+    grouped
+}
+
+async fn flush() -> (TempDir, PathBuf) {
+    let dir = TempDir::new().expect("tempdir");
+    let s = schema();
+    let mut writer =
+        SSTableWriter::with_format(dir.path().to_path_buf(), 1, &s, 16, SSTableFormat::Big)
+            .expect("writer");
+    for (k, ms) in mutations(&s) {
+        writer.write_partition(k, ms).expect("write_partition");
+    }
+    let info = writer.finish().await.expect("finish");
+    let table_dir = info.data_path.parent().expect("data parent").to_path_buf();
+    (dir, table_dir)
+}
+
+/// The whole-file CRC32 of a raw `Data.db` payload (the `Digest.crc32` value).
+fn crc32(bytes: &[u8]) -> u32 {
+    let mut h = crc32fast::Hasher::new();
+    h.update(bytes);
+    h.finalize()
+}
+
+/// Expected `CRC.db` for a raw `Data.db` payload on the flush path (no trailer):
+/// big-endian i32 chunk-size header + one big-endian u32 CRC32 per chunk.
+fn expected_flush_crc_db(data: &[u8]) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(&(CRC_CHUNK_SIZE as i32).to_be_bytes());
+    for chunk in data.chunks(CRC_CHUNK_SIZE) {
+        out.extend_from_slice(&crc32(chunk).to_be_bytes());
+    }
+    out
+}
+
+/// WORK GUARD (issue #1663): a non-empty `finish()` performs ZERO full re-reads
+/// of `Data.db` for checksums. On the pre-#1663 double-re-read path this counter
+/// would read 2.
+#[tokio::test]
+async fn finish_does_not_reread_data_db_for_checksums() {
+    work_counters::reset();
+    let (_guard, out_dir) = flush().await;
+
+    assert_eq!(
+        work_counters::data_db_checksum_full_reads(),
+        0,
+        "finish() must not re-read Data.db for checksums (pre-#1663 path re-read it twice)"
+    );
+
+    // Sanity: the components written from the accumulated checksums reconcile
+    // against the on-disk Data.db (byte-parity is proven in the crc_writer
+    // golden tests; this guards the end-to-end wiring).
+    let data = std::fs::read(out_dir.join("nb-1-big-Data.db")).expect("Data.db");
+    assert!(!data.is_empty(), "flush must be non-empty for this guard");
+
+    let digest_text =
+        std::fs::read_to_string(out_dir.join("nb-1-big-Digest.crc32")).expect("Digest.crc32");
+    let digest: u32 = digest_text.trim().parse().expect("digest u32");
+    assert_eq!(
+        digest,
+        crc32(&data),
+        "Digest.crc32 must equal CRC32(Data.db)"
+    );
+
+    let crc_db = std::fs::read(out_dir.join("nb-1-big-CRC.db")).expect("CRC.db");
+    assert_eq!(
+        crc_db,
+        expected_flush_crc_db(&data),
+        "CRC.db must reconcile against the on-disk Data.db (flush path, no trailer)"
+    );
+}


### PR DESCRIPTION
Closes #1663 (P5, epic #1609).

## What
`SSTableWriter::finish()` re-read the entire finished Data.db from disk TWICE (whole-file Digest.crc32 + per-chunk CRC.db). Both are now accumulated incrementally during the streaming write; `finish()` performs **0** extra full-file reads on a non-empty flush.

- **`crc_writer.rs`**: new `assemble_crc_bytes(chunk_crcs, trailer)` = single source of truth for CRC.db byte layout (header + per-chunk CRCs + #1222 trailer rule gated on `!chunk_crcs.is_empty()`). New `StreamingCrc` accumulator carries `chunk_filled` across `update()` calls so 64 KiB chunks straddle partition-flush boundaries exactly like the re-read path. `build_crc_bytes`/`write_crc_db` now DELEGATE to `assemble_crc_bytes` and are `#[cfg(test)]` (test-only oracle); `compute_crc32` retained live for the empty-Data.db path.
- **`data_writer/mod.rs`**: `DataWriter` holds a `StreamingCrc`; `flush_partition` feeds each written buffer through it; `finish_streaming` returns `StreamFinish { data_size, digest_crc32, chunk_crcs }`.
- **`finish.rs`**: Digest uses `stream.digest_crc32` (empty path → `compute_crc32`); CRC.db uses `assemble_crc_bytes(&stream.chunk_crcs, trailer)` + `tokio::fs::write`. Trailer selection + `is_bti` gate UNCHANGED — only the checksum input source changed.
- **`work_counters.rs`**: process-global `data_db_checksum_full_reads` counter.

## Tests (TDD — red on main)
1. Work counter (`tests/issue_1663_incremental_checksums.rs`): asserts `data_db_checksum_full_reads() == 0` after non-empty `finish()`. Verified RED on main (== 2).
2. Golden byte-equality (`crc_writer.rs`): incremental `assemble_crc_bytes` == re-read `build_crc_bytes` and `digest` == `compute_crc32`, for BOTH `None`/`EmptyFinalChunk` trailers across single-chunk / exact-chunk / multi + short-final / empty, at multiple update-split sizes. Verified teeth by breaking cross-update carry → divergence.

BTI still emits no CRC.db; Digest value unchanged; on-disk layout byte-identical to #1190/#1017/#1222 goldens (proven by test #2's oracle comparison).

## Gate
```
==== AGENT-GATE SUMMARY ====
RESULT: PASS  (all 18 components green; rebased clean onto origin/main)
==== END AGENT-GATE SUMMARY ====
```