### PR TITLE
fix(#1440): ship binding cdylibs panic=unwind (release-unwind profile) + fail-closed guard

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -93,7 +93,9 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist
+          # release-unwind: inherits release but panic = "unwind" so the PyO3
+          # catch_unwind firewall is active in the shipped wheel (issue #1440).
+          args: --profile release-unwind --out dist
           working-directory: bindings/python
           manylinux: ${{ matrix.manylinux || 'auto' }}
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,8 +121,8 @@ cargo run --package cqlite-cli -- \
   --out json
 
 # Python bindings build and test
-cd bindings/python && maturin develop  # Development build
-cd bindings/python && maturin build --release  # Release wheel
+cd bindings/python && maturin develop --profile dev  # Development build (debug; overrides the release-unwind firewall pin for a fast dev loop)
+cd bindings/python && maturin build --profile release-unwind  # Release wheel (panic-unwind firewall, issue #1440 — NOT --release, which is panic=abort)
 
 # Run Python tests - fast tests only (default, Issue #331)
 env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets pytest bindings/python/tests -v
@@ -503,7 +503,7 @@ rustup update
 **Python import errors**: Verify Python 3.9+ and rebuild bindings:
 ```bash
 python3 --version  # Must be 3.9+
-cd bindings/python && maturin develop
+cd bindings/python && maturin develop --profile dev
 ```
 
 **Python tests skip or fail**: Ensure test data is available:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,6 +159,14 @@ lto = true
 panic = "abort"
 strip = true
 
+# Binding cdylibs (Python wheel, Node npm prebuild) ship with this profile so the
+# PyO3 / napi-rs catch_unwind->exception firewall at the FFI boundary is active
+# (issue #1440). Inherits release (lto, codegen-units, strip) and flips only the
+# panic strategy to unwind. CLI/core keep [profile.release] (panic = "abort").
+[profile.release-unwind]
+inherits = "release"
+panic = "unwind"
+
 [profile.bench]
 debug = true
 # bench inherits from release, which sets `strip = true` — that would discard

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -26,7 +26,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "napi build --platform --release --features write-support",
+    "build": "napi build --platform --profile release-unwind --features write-support",
     "postbuild": "node scripts/generate-loader.mjs",
     "build:debug": "napi build --platform --features write-support",
     "pretest": "node scripts/generate-loader.mjs",

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -36,6 +36,17 @@ dev = ["pytest>=7.0", "mypy>=1.0"]
 features = ["pyo3/extension-module"]
 python-source = "python"
 module-name = "cqlite._cqlite"
+# Panic-unwind firewall (issue #1440). maturin honors this `profile` key on ALL
+# build paths, including the PEP 517 backend that `pip install .` / sdist builds
+# invoke (`maturin pep517 build-wheel`), whose DEFAULT profile is `release`
+# (panic = "abort"). Without this pin a source-installed wheel would ship WITHOUT
+# the PyO3 catch_unwind->exception firewall. `release-unwind` inherits from
+# `[profile.release]` but keeps `panic = "unwind"` so a core panic surfaces as a
+# catchable CqliteError instead of aborting the host process.
+# NOTE: this pin is global to maturin, so it also flips `maturin develop`'s
+# default from debug to release-unwind. For a fast debug dev loop, override it:
+#   maturin develop --profile dev   (CLI --profile wins over this pin).
+profile = "release-unwind"
 
 [tool.pytest.ini_options]
 markers = [

--- a/openspec/changes/panic-unwind-profile/design.md
+++ b/openspec/changes/panic-unwind-profile/design.md
@@ -1,0 +1,55 @@
+## Context
+
+`panic` is a Cargo *profile* setting, not a per-package one: `std` is monomorphized per panic strategy,
+so an entire final artifact and its whole dependency graph must be compiled with one strategy. You
+cannot mix abort and unwind in one binary. Today the workspace `[profile.release]` sets
+`panic = "abort"` and the two binding cdylibs inherit it, which makes PyO3's/napi-rs's built-in
+`catch_unwind`→exception firewall dead code.
+
+## Decisions
+
+### D1 — Mechanism: a named `release-unwind` profile (chosen)
+Add `[profile.release-unwind] inherits = "release"; panic = "unwind"` and build the two binding
+artifacts with it; CLI/core keep plain `--release`.
+
+- **Beat: edit `[profile.release]` to unwind.** Rejected — would flip CLI/core to unwind too, contrary
+  to the owner decision and the DoD ("`[profile.release]` still `panic="abort"`").
+- **Beat: a per-target/per-package panic override.** Impossible — Cargo has no per-package `panic`; it
+  is profile-scoped.
+- **Beat: an env/`RUSTFLAGS=-Cpanic=unwind` override at build time.** Rejected as the primary mechanism
+  — brittle, invisible in the build definition, and easy to lose; `RUSTFLAGS` is the documented
+  *fallback* (see D3) only if a toolchain rejects `--profile`.
+
+`inherits = "release"` preserves `lto`, `codegen-units = 1`, `strip`; only `panic` changes. This is the
+Cargo-supported, minimal-surface mechanism the issue prescribes.
+
+### D2 — Guard: a hermetic build-definition assertion runnable in the gate (chosen)
+Add a fail-closed check that reads the binding build definitions (`python-release.yml` maturin args,
+`bindings/python/pyproject.toml` `[tool.maturin]`, `bindings/node/package.json` build script,
+`node-release.yml`) and fails if any binding build uses `--release` or omits `--profile
+release-unwind`. It fails closed when a definition is missing/unparseable.
+
+- **Beat: a workflow-only step.** Rejected as the sole guard — it wouldn't fire until CI on a release
+  workflow, long after the regression merged; a locally-runnable guard catches the revert pre-push.
+- **Beat: a runtime abort-safety test in this change.** Rejected — that is #1437's harness (explicit
+  non-goal here). The end-to-end runtime proof lands when #1437 (HELD behind this) runs against a
+  `release-unwind`-built artifact.
+
+Implementation note (for the implementer, not a spec constraint): the guard can be a small script under
+`scripts/tests/` invoked by the gate, or a Rust test that reads the definition files — whichever
+integrates cleanly with `scripts/agent-gate.sh`. It must be deterministic and offline (no build).
+
+### D3 — napi-rs `--profile` plumbing, with a preserved-invariant fallback
+napi-rs v3 (`@napi-rs/cli ^3.5.1`) supports `--profile`. If a given toolchain/version rejects
+`--profile release-unwind` for one binding, the invariant to preserve is: **the shipped wheel and npm
+prebuild are compiled `panic = "unwind"` while CLI/core stay abort.** Any equivalent mechanism
+(`CARGO_PROFILE`, `--cargo-flags "--profile release-unwind"`, or `RUSTFLAGS=-Cpanic=unwind`) that
+achieves that — and that the guard in D2 can still verify — is acceptable.
+
+## Risks / tradeoffs
+
+- **Binary size / perf:** unwind adds landing-pad tables → modest size increase and near-zero
+  steady-state perf cost. Quantified as a deliverable (recorded in the PR), not assumed.
+- **Guard brittleness vs build-file churn:** the guard asserts on build-definition text, so it must
+  match the real flag the tool consumes (maturin `--profile`, napi cargo profile). Anchored to the
+  specific keys/args, not a broad grep, to avoid false negatives.

--- a/openspec/changes/panic-unwind-profile/proposal.md
+++ b/openspec/changes/panic-unwind-profile/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+The bindings (`bindings/python` PyO3, `bindings/node` napi-rs) are the surface most users touch, and
+both are shipped built with the **workspace release profile, which sets `panic = "abort"`**
+(`Cargo.toml:156-160`). PyO3 and napi-rs each ship a `catch_unwind`→exception firewall at the FFI
+boundary that turns a Rust panic into a catchable `CqliteError` — but that firewall is **dead code under
+abort**: unwinding never happens, so the firewall never runs. A panic raised inside `cqlite-core` while
+a scan runs through a binding's `block_on(...)` therefore **aborts the whole host process** (kills the
+Python interpreter / Node process) instead of raising an exception. The parser audit
+(`docs/reports/bindings-ffi-performance-audit-2026-07-01.md`) confirmed core has real corrupt-input
+panic paths (ZigZag lengths, BTI byte-depth cap), so a user pointing either binding at a
+corrupt/truncated SSTable can have their process killed outright today.
+
+`[profile.dev]` (`Cargo.toml:169-179`, `panic = "unwind"` at `:177`) is why debug builds don't
+reproduce the abort — but wheels and npm prebuilds are built `--release`
+(`.github/workflows/python-release.yml:96`; `bindings/node/package.json:29`), so the shipped artifacts
+abort. There is **no binding-level profile override**: the cdylibs inherit `panic = "abort"` from the
+workspace release profile.
+
+**Decision (DECIDED 2026-07-01, owner-approved):** ship the two binding cdylib artifacts (wheels + npm
+prebuilds) built `panic = "unwind"` so the PyO3/napi `catch_unwind` firewall re-activates and a core
+panic becomes a catchable `CqliteError`. `panic = "abort"` stays for the CLI/core.
+
+- **Milestone:** Release: bug-clear (pre-v0.13) — P0 abort-safety. **Design-driven** (build-profile
+  architecture + a fail-closed CI-artifact guard; touches release workflows and build config — latitude
+  in the profile mechanism and where the guard lives). No Cassandra SSTable format oracle is decoded here.
+- Adds a new `binding-panic-firewall` capability.
+
+## What Changes
+
+- **New `release-unwind` Cargo profile.** Add a workspace profile that `inherits = "release"` and flips
+  only `panic = "unwind"` (keeping `lto`, `codegen-units = 1`, `strip`). `panic` is a *profile* setting
+  — the whole artifact + its dependency graph must compile with one strategy, so a per-package override
+  is impossible; a named profile is the supported mechanism.
+- **Repoint the two binding builds to `release-unwind`.** Python wheels: maturin `--profile
+  release-unwind` (replacing `--release`) in `.github/workflows/python-release.yml`. Node prebuilds:
+  the cargo `release-unwind` profile in `bindings/node/package.json` build script (and
+  `.github/workflows/node-release.yml` if it invokes the build differently).
+- **Fail-closed CI-artifact guard.** Add a check that FAILS if a shipped binding artifact would be
+  built with abort — i.e. asserts the binding build definitions carry `--profile release-unwind` and do
+  NOT use `--release`. This guard runs locally (agent-gate reachable) so a regression to abort is caught
+  before shipping, not in production.
+- **Recorded size/perf delta.** Build each binding artifact both ways and record (a) cdylib byte size
+  and (b) a representative scan micro-benchmark (abort vs unwind) in the PR description.
+
+## Non-goals
+
+- **Does NOT build the abort-safety harness.** `bindings/python/tests/test_abort_safety.py` and
+  `bindings/node/__test__/abort-safety.test.js` are owned by **#1437** (HELD behind this issue). This
+  change makes that harness pass; it does not create it.
+- **Does NOT change `[profile.release]`.** CLI and core stay `panic = "abort"`.
+- **Does NOT eliminate the underlying core panic paths.** Parser panic elimination (epic H,
+  `#1438`/`#1439` and the parser audit) is complementary and out of scope here — the firewall converts
+  panics to exceptions; it does not remove them.
+- **No WASM binding profile** (M6, not yet shipped).
+
+## Doctrine impact
+
+None required in CLAUDE.md prose; the invariant "binding cdylibs ship `panic = "unwind"`; CLI/core ship
+`panic = "abort"`" is enforced by the fail-closed guard (the guard IS the doctrine, in executable form).

--- a/openspec/changes/panic-unwind-profile/specs/binding-panic-firewall/spec.md
+++ b/openspec/changes/panic-unwind-profile/specs/binding-panic-firewall/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: Binding cdylib artifacts are compiled with `panic = "unwind"`
+The shipped Python wheel and Node.js npm prebuild SHALL be compiled with `panic = "unwind"` so the
+PyO3/napi-rs `catch_unwind` firewall at the FFI boundary is active. A dedicated named Cargo profile
+SHALL provide this by inheriting the release profile and overriding only the panic strategy; the two
+binding build definitions SHALL select that profile.
+
+#### Scenario: A `release-unwind` profile inherits release and flips only panic
+- **WHEN** the workspace `Cargo.toml` is inspected
+- **THEN** it defines a `[profile.release-unwind]` with `inherits = "release"` and `panic = "unwind"`
+- **AND** that profile does not restate `lto`, `codegen-units`, or `strip` (they are inherited from release)
+
+#### Scenario: The Python wheel build selects the unwind profile
+- **WHEN** the Python wheel build definition (`.github/workflows/python-release.yml` maturin args, and any `[tool.maturin]` pin in `bindings/python/pyproject.toml`) is inspected
+- **THEN** the maturin build selects `--profile release-unwind`
+- **AND** it does NOT pass `--release` for the shipped wheel
+
+#### Scenario: The Node prebuild selects the unwind profile
+- **WHEN** the Node prebuild build definition (`bindings/node/package.json` `build` script, and `.github/workflows/node-release.yml` if it drives the build differently) is inspected
+- **THEN** the napi/cargo build selects the `release-unwind` profile
+- **AND** it does NOT pass `--release` for the shipped prebuild
+
+### Requirement: The CLI and core continue to use `panic = "abort"`
+The change SHALL NOT alter the abort strategy of the workspace release profile; only the two binding
+cdylib artifacts use the unwind profile.
+
+#### Scenario: `[profile.release]` still aborts
+- **WHEN** the workspace `Cargo.toml` `[profile.release]` block is inspected
+- **THEN** it still sets `panic = "abort"`
+- **AND** the CLI/core release build (plain `--release`) is unchanged
+
+### Requirement: A fail-closed guard rejects an abort-built binding artifact
+There SHALL be an automated guard, runnable locally (reachable from the agent gate), that FAILS if
+either binding build definition would produce an abort-compiled artifact — i.e. if a binding build uses
+`--release` (or otherwise omits `--profile release-unwind`). The guard SHALL be fail-closed: if the
+build definition it inspects is missing or unparseable, the guard SHALL fail rather than pass silently.
+
+#### Scenario: Guard fails when a binding build reverts to abort
+- **WHEN** a binding build definition is edited to use `--release` (or to drop `--profile release-unwind`)
+- **THEN** the guard fails and names the offending build definition
+
+#### Scenario: Guard passes when both binding builds use the unwind profile
+- **WHEN** both the Python wheel and Node prebuild definitions select `--profile release-unwind`
+- **THEN** the guard passes
+
+#### Scenario: Guard fails closed on a missing/unparseable build definition
+- **WHEN** a build definition the guard inspects is absent or cannot be parsed
+- **THEN** the guard fails (it does not treat "not found" as "compliant")
+
+### Requirement: The binary-size and perf delta of the profile switch is recorded
+The change SHALL record the observed delta of switching the binding artifacts from abort to unwind:
+the cdylib byte size (each artifact, both ways) and a representative scan micro-benchmark (abort vs
+unwind), captured in the PR description.
+
+#### Scenario: The PR documents the measured delta
+- **WHEN** the PR for this change is reviewed
+- **THEN** it contains, for each binding artifact, the abort-vs-unwind cdylib byte size and a scan micro-benchmark comparison

--- a/openspec/changes/panic-unwind-profile/tasks.md
+++ b/openspec/changes/panic-unwind-profile/tasks.md
@@ -1,0 +1,41 @@
+# Tasks
+
+## 1. Add the `release-unwind` profile
+- [ ] 1.1 In workspace `Cargo.toml`, after `[profile.release]`, add `[profile.release-unwind]` with
+      `inherits = "release"` and `panic = "unwind"` (no other keys). Surface exercised: `Cargo.toml`
+      profile table. Leave `[profile.release]` `panic = "abort"` untouched.
+
+## 2. Repoint the binding builds
+- [ ] 2.1 Python wheels: change `.github/workflows/python-release.yml` maturin-action `args` from
+      `--release --out dist` to `--profile release-unwind --out dist`. Verify
+      `bindings/python/pyproject.toml` `[tool.maturin]` does not re-pin `--release`.
+- [ ] 2.2 Node prebuilds: change `bindings/node/package.json` `build` script to build with the
+      `release-unwind` cargo profile (napi `--profile release-unwind`, or the version-appropriate
+      `--cargo-flags`/`CARGO_PROFILE` mechanism per design D3). Update
+      `.github/workflows/node-release.yml` if it drives the build differently.
+
+## 3. Fail-closed guard (binding-panic-firewall)
+- [ ] 3.1 Add a deterministic, offline guard (script under `scripts/tests/` invoked by the gate, or a
+      Rust test) that FAILS if either binding build definition uses `--release` / omits
+      `--profile release-unwind`, and fails closed on a missing/unparseable definition. Surface
+      exercised: the guard invocation + the four build definitions it reads.
+- [ ] 3.2 Wire the guard so `scripts/agent-gate.sh` runs it (a gate component or an existing test target).
+
+## 4. Measure + record the delta
+- [ ] 4.1 Build each binding artifact both ways (`--release` vs `--profile release-unwind`); record
+      cdylib byte size for each. Surface: `ls -l` the `.so`/`.node`/wheel.
+- [ ] 4.2 Run a representative scan micro-benchmark abort vs unwind (reuse an existing bindings perf
+      test). Record both numbers in the PR description.
+
+## 5. Quality gates (definition of done)
+- [ ] 5.1 `scripts/agent-gate.sh` PASS — paste the AGENT-GATE SUMMARY block verbatim.
+- [ ] 5.2 `RUSTFLAGS="-D warnings"` clean; no new `unwrap()`/`expect()` in library code.
+- [ ] 5.3 Spec-auditor (C) PASS against `openspec/changes/panic-unwind-profile/specs/**` — every
+      requirement satisfied with a public-surface/guard test as evidence.
+- [ ] 5.4 roborev clean (`--base origin/main --agent codex`).
+- [ ] 5.5 File-size ratchet respected (no touched file grows past threshold without ack).
+
+## Notes
+- Do NOT build the abort-safety harness (`test_abort_safety.py` / `abort-safety.test.js`) — owned by
+  #1437, HELD behind this issue. This change makes that harness pass; it does not create it.
+- Merge is HELD only in the reverse direction (#1437 waits on this); this change (#1440) merges on green.

--- a/openspec/changes/panic-unwind-profile/tasks.md
+++ b/openspec/changes/panic-unwind-profile/tasks.md
@@ -1,39 +1,44 @@
 # Tasks
 
 ## 1. Add the `release-unwind` profile
-- [ ] 1.1 In workspace `Cargo.toml`, after `[profile.release]`, add `[profile.release-unwind]` with
+- [x] 1.1 In workspace `Cargo.toml`, after `[profile.release]`, add `[profile.release-unwind]` with
       `inherits = "release"` and `panic = "unwind"` (no other keys). Surface exercised: `Cargo.toml`
       profile table. Leave `[profile.release]` `panic = "abort"` untouched.
 
 ## 2. Repoint the binding builds
-- [ ] 2.1 Python wheels: change `.github/workflows/python-release.yml` maturin-action `args` from
+- [x] 2.1 Python wheels: change `.github/workflows/python-release.yml` maturin-action `args` from
       `--release --out dist` to `--profile release-unwind --out dist`. Verify
       `bindings/python/pyproject.toml` `[tool.maturin]` does not re-pin `--release`.
-- [ ] 2.2 Node prebuilds: change `bindings/node/package.json` `build` script to build with the
-      `release-unwind` cargo profile (napi `--profile release-unwind`, or the version-appropriate
-      `--cargo-flags`/`CARGO_PROFILE` mechanism per design D3). Update
-      `.github/workflows/node-release.yml` if it drives the build differently.
+- [x] 2.2 Node prebuilds: change `bindings/node/package.json` `build` script to build with the
+      `release-unwind` cargo profile (napi `--profile release-unwind` — confirmed working via the gate's
+      node-bindings component, which runs `napi build --platform --profile release-unwind` and PASSED).
+      `.github/workflows/node-release.yml` drives the build via `npm run build` (the package.json
+      script), so no separate change was needed there.
 
 ## 3. Fail-closed guard (binding-panic-firewall)
-- [ ] 3.1 Add a deterministic, offline guard (script under `scripts/tests/` invoked by the gate, or a
-      Rust test) that FAILS if either binding build definition uses `--release` / omits
-      `--profile release-unwind`, and fails closed on a missing/unparseable definition. Surface
-      exercised: the guard invocation + the four build definitions it reads.
-- [ ] 3.2 Wire the guard so `scripts/agent-gate.sh` runs it (a gate component or an existing test target).
+- [x] 3.1 Add a deterministic, offline guard (`scripts/tests/test_binding_unwind_profile.sh`) that FAILS
+      if any binding build definition uses `--release` / omits `--profile release-unwind`, and fails
+      closed on a missing/unparseable definition. Includes an inline negative-path self-check
+      (compliant/missing/abort/empty fixtures). Surface exercised: the guard invocation + the four
+      build definitions it reads.
+- [x] 3.2 Wire the guard so `scripts/agent-gate.sh` runs it — added the `binding-unwind-profile`
+      component (hard FAIL, offline).
 
 ## 4. Measure + record the delta
-- [ ] 4.1 Build each binding artifact both ways (`--release` vs `--profile release-unwind`); record
-      cdylib byte size for each. Surface: `ls -l` the `.so`/`.node`/wheel.
-- [ ] 4.2 Run a representative scan micro-benchmark abort vs unwind (reuse an existing bindings perf
-      test). Record both numbers in the PR description.
+- [x] 4.1 Built each binding cdylib both ways (`--release` vs `--profile release-unwind`); recorded
+      byte size for each (see PR notes). macOS arm64: Node 9,197,504 -> 11,413,120 (+24.1%);
+      Python 9,233,808 -> 11,433,040 (+23.8%).
+- [ ] 4.2 Run a representative scan micro-benchmark abort vs unwind — NOT measured in the impl
+      environment (maturin/napi runtimes unavailable offline; the freshly-built cdylibs are not
+      loadable as installed modules). Lead to capture the scan micro-benchmark for the PR body.
 
 ## 5. Quality gates (definition of done)
-- [ ] 5.1 `scripts/agent-gate.sh` PASS — paste the AGENT-GATE SUMMARY block verbatim.
-- [ ] 5.2 `RUSTFLAGS="-D warnings"` clean; no new `unwrap()`/`expect()` in library code.
-- [ ] 5.3 Spec-auditor (C) PASS against `openspec/changes/panic-unwind-profile/specs/**` — every
-      requirement satisfied with a public-surface/guard test as evidence.
-- [ ] 5.4 roborev clean (`--base origin/main --agent codex`).
-- [ ] 5.5 File-size ratchet respected (no touched file grows past threshold without ack).
+- [x] 5.1 `scripts/agent-gate.sh` PASS — AGENT-GATE SUMMARY block pasted in the handoff.
+- [x] 5.2 `RUSTFLAGS="-D warnings"` clean (gate clippy PASS); no new `unwrap()`/`expect()` in library
+      code (no library code changed — profile/config/guard only).
+- [ ] 5.3 Spec-auditor (C) PASS against `openspec/changes/panic-unwind-profile/specs/**` — run by lead.
+- [ ] 5.4 roborev clean (`--base origin/main --agent codex`) — run by lead.
+- [x] 5.5 File-size ratchet respected (gate file-size PASS).
 
 ## Notes
 - Do NOT build the abort-safety harness (`test_abort_safety.py` / `abort-safety.test.js`) — owned by

--- a/openspec/changes/panic-unwind-profile/tasks.md
+++ b/openspec/changes/panic-unwind-profile/tasks.md
@@ -28,16 +28,16 @@
 - [x] 4.1 Built each binding cdylib both ways (`--release` vs `--profile release-unwind`); recorded
       byte size for each (see PR notes). macOS arm64: Node 9,197,504 -> 11,413,120 (+24.1%);
       Python 9,233,808 -> 11,433,040 (+23.8%).
-- [ ] 4.2 Run a representative scan micro-benchmark abort vs unwind — NOT measured in the impl
-      environment (maturin/napi runtimes unavailable offline; the freshly-built cdylibs are not
-      loadable as installed modules). Lead to capture the scan micro-benchmark for the PR body.
+- [x] 4.2 Scan micro-benchmark abort vs unwind captured in PR #1751 body: Node 10.71->10.76ms
+      (+0.46%, within jitter), Python 9.997->10.379ms (+3.8%, shown to be run-to-run noise). No
+      measurable steady-state scan overhead.
 
 ## 5. Quality gates (definition of done)
 - [x] 5.1 `scripts/agent-gate.sh` PASS — AGENT-GATE SUMMARY block pasted in the handoff.
 - [x] 5.2 `RUSTFLAGS="-D warnings"` clean (gate clippy PASS); no new `unwrap()`/`expect()` in library
       code (no library code changed — profile/config/guard only).
-- [ ] 5.3 Spec-auditor (C) PASS against `openspec/changes/panic-unwind-profile/specs/**` — run by lead.
-- [ ] 5.4 roborev clean (`--base origin/main --agent codex`) — run by lead.
+- [x] 5.3 Spec-auditor (C) PASS against `openspec/changes/panic-unwind-profile/specs/**` — all R1-R4 satisfied.
+- [x] 5.4 roborev clean (`--base origin/main --agent codex`) — converged, no issues found.
 - [x] 5.5 File-size ratchet respected (gate file-size PASS).
 
 ## Notes

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -52,6 +52,15 @@
 #                      (two manifest-changing PRs), which no per-PR/local check can
 #                      see; that path self-heals via the push-to-main job in
 #                      .github/workflows/cassandra-parity.yml (issue #1338).
+#   binding-unwind-profile
+#                      fail-closed guard (#1440): the shipped Python wheel and
+#                      Node prebuild build definitions must select
+#                      `--profile release-unwind` (PyO3/napi catch_unwind firewall
+#                      active) and never `--release` (abort). Reads the four build
+#                      definitions (python-release.yml, pyproject.toml [tool.maturin],
+#                      package.json build script, node-release.yml); hard-FAILs on
+#                      any abort-built or missing/unparseable definition. Pure
+#                      bash/grep/awk — offline, deterministic, no datasets/network.
 #   tooling-tests      shell-tooling regression tests (fast, no datasets/network):
 #                      scripts/tests/test_agent_gate_summary.sh — proves the
 #                      SUMMARY block survives non-foreground capture (#1175). It
@@ -151,7 +160,7 @@ if ! command -v cargo >/dev/null 2>&1 && [ -d "$HOME/.cargo/bin" ]; then
 fi
 export CQLITE_DATASETS_ROOT="${CQLITE_DATASETS_ROOT:-$REPO_ROOT/test-data/datasets}"
 
-COMPONENTS=(file-size fmt clippy core-tests tombstones-scan scan-offload-guard integration-tests format-compat write-tests cli-tests compaction-byte-parity python-bindings node-bindings delivery-telemetry parity-report tooling-tests minimal-build smoke)
+COMPONENTS=(file-size fmt clippy core-tests tombstones-scan scan-offload-guard integration-tests format-compat write-tests cli-tests compaction-byte-parity python-bindings node-bindings delivery-telemetry parity-report binding-unwind-profile tooling-tests minimal-build smoke)
 ONLY=""
 SELFTEST=0
 case "${1:-}" in
@@ -933,6 +942,12 @@ run_python_bindings
 run_node_bindings
 run_delivery_telemetry
 run_parity_report
+# binding-unwind-profile (#1440): fail-closed guard that the shipped Python wheel
+# and Node prebuild build definitions select `--profile release-unwind` (so the
+# PyO3/napi catch_unwind firewall is active) and never `--release` (abort). Pure
+# bash/grep/awk — offline, deterministic, no datasets; a hard FAIL on any
+# abort-built or missing/unparseable definition.
+run_component binding-unwind-profile bash "$REPO_ROOT/scripts/tests/test_binding_unwind_profile.sh"
 run_tooling_tests
 run_component minimal-build cargo build --package cqlite-core --no-default-features --features all-compression
 # Pin smoke to a binary built from THIS tree. Left to its own devices the

--- a/scripts/tests/test_binding_unwind_profile.sh
+++ b/scripts/tests/test_binding_unwind_profile.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+# Fail-closed guard for issue #1440 (OpenSpec change `panic-unwind-profile`,
+# capability `binding-panic-firewall`).
+#
+# The shipped Python wheel and Node.js npm prebuild MUST be compiled
+# `panic = "unwind"` so the PyO3 / napi-rs `catch_unwind`->exception firewall at
+# the FFI boundary is active; a core panic must become a catchable CqliteError,
+# not an abort that kills the host process. CLI/core stay `panic = "abort"`.
+#
+# This guard is deterministic and OFFLINE (no build, no network, no datasets).
+# It reads the four binding build DEFINITIONS and FAILS if any of them would
+# produce an abort-compiled artifact — i.e. uses `--release` or omits
+# `--profile release-unwind`. It fails CLOSED: a definition that is missing or
+# unparseable is treated as non-compliant ("not found" != "compliant").
+#
+# Definitions inspected (relative to the repo root):
+#   1. .github/workflows/python-release.yml   (maturin wheel-build args)
+#   2. bindings/python/pyproject.toml         ([tool.maturin] must not re-pin --release)
+#   3. bindings/node/package.json             ("build" script)
+#   4. .github/workflows/node-release.yml     (must not drive an abort build)
+#
+# Run standalone:   bash scripts/tests/test_binding_unwind_profile.sh
+# Or via the gate:  scripts/agent-gate.sh runs it as the `binding-unwind-profile`
+#                   component. The default invocation runs the negative-path
+#                   self-check (fail-closed proof) AND the real-tree check; both
+#                   must pass for exit 0.
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+
+UNWIND_PROFILE="release-unwind"
+UNWIND_FLAG="--profile ${UNWIND_PROFILE}"
+
+# ---------------------------------------------------------------------------
+# check_definitions <root> : inspect the four binding build definitions rooted
+# at <root>. Prints a "FAIL - <reason>" line for every violation and returns the
+# number of violations (0 == compliant). Fail-closed: a missing/unparseable
+# definition is a violation.
+# ---------------------------------------------------------------------------
+check_definitions() {
+  local root="$1"
+  local fails=0
+  local py_wf="$root/.github/workflows/python-release.yml"
+  local pyproject="$root/bindings/python/pyproject.toml"
+  local pkg="$root/bindings/node/package.json"
+  local node_wf="$root/.github/workflows/node-release.yml"
+
+  # --- 1. Python wheel workflow -------------------------------------------
+  if [ ! -f "$py_wf" ]; then
+    echo "FAIL - python-release.yml missing (fail-closed): $py_wf"
+    fails=$((fails + 1))
+  else
+    # The wheel build must select the unwind profile ...
+    if ! grep -qF -- "$UNWIND_FLAG" "$py_wf"; then
+      echo "FAIL - python-release.yml does not select '${UNWIND_FLAG}' for the wheel build"
+      fails=$((fails + 1))
+    fi
+    # ... and must never pass --release (abort). `--profile release-unwind`
+    # does not contain the substring `--release`, so this match is exact.
+    if grep -qE -- '--release([[:space:]]|$)' "$py_wf"; then
+      echo "FAIL - python-release.yml still passes '--release' (abort) to the wheel build"
+      fails=$((fails + 1))
+    fi
+  fi
+
+  # --- 2. Python pyproject [tool.maturin] ---------------------------------
+  if [ ! -f "$pyproject" ]; then
+    echo "FAIL - pyproject.toml missing (fail-closed): $pyproject"
+    fails=$((fails + 1))
+  else
+    # Extract the [tool.maturin] table (until the next top-level table header).
+    local maturin_section
+    maturin_section=$(awk '
+      /^\[tool\.maturin\]/ { in_sec = 1; next }
+      /^\[/               { in_sec = 0 }
+      in_sec              { print }
+    ' "$pyproject")
+    if ! grep -qF '[tool.maturin]' "$pyproject"; then
+      echo "FAIL - pyproject.toml has no [tool.maturin] table (fail-closed)"
+      fails=$((fails + 1))
+    elif printf '%s\n' "$maturin_section" | grep -qE -- '--release([[:space:]"'\'']|$)'; then
+      echo "FAIL - pyproject.toml [tool.maturin] re-pins '--release' (abort)"
+      fails=$((fails + 1))
+    fi
+  fi
+
+  # --- 3. Node package.json build script ----------------------------------
+  if [ ! -f "$pkg" ]; then
+    echo "FAIL - package.json missing (fail-closed): $pkg"
+    fails=$((fails + 1))
+  else
+    # Isolate the "build": "..." script line (not build:debug / postbuild).
+    local build_line
+    build_line=$(grep -E '"build"[[:space:]]*:' "$pkg")
+    if [ -z "$build_line" ]; then
+      echo "FAIL - package.json has no \"build\" script (fail-closed)"
+      fails=$((fails + 1))
+    else
+      if ! printf '%s\n' "$build_line" | grep -qF -- "$UNWIND_FLAG"; then
+        echo "FAIL - package.json \"build\" script does not select '${UNWIND_FLAG}'"
+        fails=$((fails + 1))
+      fi
+      if printf '%s\n' "$build_line" | grep -qE -- '--release([[:space:]"'\'']|$)'; then
+        echo "FAIL - package.json \"build\" script still passes '--release' (abort)"
+        fails=$((fails + 1))
+      fi
+    fi
+  fi
+
+  # --- 4. Node release workflow -------------------------------------------
+  # This workflow drives the build via `npm run build` (which uses the
+  # package.json build script checked above). It must NOT drive a separate
+  # abort build; fail if it introduces a bare `--release`.
+  if [ ! -f "$node_wf" ]; then
+    echo "FAIL - node-release.yml missing (fail-closed): $node_wf"
+    fails=$((fails + 1))
+  else
+    if grep -qE -- '--release([[:space:]]|$)' "$node_wf"; then
+      echo "FAIL - node-release.yml drives an abort build with '--release'"
+      fails=$((fails + 1))
+    fi
+  fi
+
+  return "$fails"
+}
+
+# ---------------------------------------------------------------------------
+# Negative-path self-check: prove the guard fails CLOSED on a missing definition
+# and on an abort definition, and PASSES on a compliant fixture set. Uses
+# throwaway fixtures under a temp dir, never the real tree.
+# ---------------------------------------------------------------------------
+SELF_PASS=0
+SELF_FAIL=0
+sok()  { printf 'ok   - selftest: %s\n' "$1"; SELF_PASS=$((SELF_PASS + 1)); }
+sbad() { printf 'FAIL - selftest: %s\n' "$1"; SELF_FAIL=$((SELF_FAIL + 1)); }
+
+# Write a COMPLIANT fixture tree at $1.
+write_compliant_fixture() {
+  local d="$1"
+  mkdir -p "$d/.github/workflows" "$d/bindings/python" "$d/bindings/node"
+  cat >"$d/.github/workflows/python-release.yml" <<'EOF'
+      - name: Build wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          args: --profile release-unwind --out dist
+EOF
+  cat >"$d/bindings/python/pyproject.toml" <<'EOF'
+[tool.maturin]
+features = ["pyo3/extension-module"]
+EOF
+  cat >"$d/bindings/node/package.json" <<'EOF'
+{
+  "scripts": {
+    "build": "napi build --platform --profile release-unwind --features write-support"
+  }
+}
+EOF
+  cat >"$d/.github/workflows/node-release.yml" <<'EOF'
+      - name: Build native module
+        run: npm run build
+EOF
+}
+
+run_selftest() {
+  local tmp
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/binding-unwind-selftest.XXXXXX")
+
+  # (a) Compliant fixture -> guard PASSES (0 violations).
+  local good="$tmp/good"
+  write_compliant_fixture "$good"
+  if check_definitions "$good" >/dev/null; then
+    sok "compliant fixture passes"
+  else
+    sbad "compliant fixture should pass but did not"
+    check_definitions "$good"
+  fi
+
+  # (b) Missing definition -> guard FAILS closed. Remove the python workflow.
+  local missing="$tmp/missing"
+  write_compliant_fixture "$missing"
+  rm -f "$missing/.github/workflows/python-release.yml"
+  if check_definitions "$missing" >/dev/null; then
+    sbad "missing python-release.yml should FAIL closed but passed"
+  else
+    sok "missing definition fails closed"
+  fi
+
+  # (c) Abort re-pin -> guard FAILS. Flip the node build script back to --release.
+  local abort="$tmp/abort"
+  write_compliant_fixture "$abort"
+  cat >"$abort/bindings/node/package.json" <<'EOF'
+{
+  "scripts": {
+    "build": "napi build --platform --release --features write-support"
+  }
+}
+EOF
+  if check_definitions "$abort" >/dev/null; then
+    sbad "abort (--release) build script should FAIL but passed"
+  else
+    sok "abort (--release) build script fails"
+  fi
+
+  # (d) Empty tree -> every definition missing -> FAILS closed.
+  local empty="$tmp/empty"
+  mkdir -p "$empty"
+  if check_definitions "$empty" >/dev/null; then
+    sbad "empty tree should FAIL closed but passed"
+  else
+    sok "empty tree fails closed"
+  fi
+
+  # Best-effort cleanup; the guard is offline so nothing else touches this dir.
+  rm -rf "$tmp"
+
+  echo "---- selftest: passed: $SELF_PASS  failed: $SELF_FAIL"
+  [ "$SELF_FAIL" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+main() {
+  local rc=0
+
+  echo ">>> binding-unwind-profile: negative-path self-check (fail-closed proof)"
+  if ! run_selftest; then
+    echo "FAIL - self-check did not hold; guard logic is unsound"
+    rc=1
+  fi
+
+  echo ">>> binding-unwind-profile: checking real build definitions under $REPO_ROOT"
+  local findings
+  findings=$(check_definitions "$REPO_ROOT")
+  local real_fails=$?
+  if [ "$real_fails" -eq 0 ]; then
+    echo "ok   - all four binding build definitions select '${UNWIND_FLAG}' (no --release)"
+  else
+    printf '%s\n' "$findings"
+    echo "FAIL - $real_fails binding build definition(s) would ship an abort-compiled artifact"
+    rc=1
+  fi
+
+  return "$rc"
+}
+
+main "$@"

--- a/scripts/tests/test_binding_unwind_profile.sh
+++ b/scripts/tests/test_binding_unwind_profile.sh
@@ -15,7 +15,9 @@
 #
 # Definitions inspected (relative to the repo root):
 #   1. .github/workflows/python-release.yml   (maturin wheel-build args)
-#   2. bindings/python/pyproject.toml         ([tool.maturin] must not re-pin --release)
+#   2. bindings/python/pyproject.toml         ([tool.maturin] must PIN
+#                                              profile = "release-unwind" and not
+#                                              re-pin --release)
 #   3. bindings/node/package.json             ("build" script)
 #   4. .github/workflows/node-release.yml     (must not drive an abort build)
 #   5. Cargo.toml                             ([profile.release-unwind] must set panic = "unwind")
@@ -37,6 +39,15 @@ REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
 
 UNWIND_PROFILE="release-unwind"
 UNWIND_FLAG="--profile ${UNWIND_PROFILE}"
+
+# A `[tool.maturin] profile = "release-unwind"` pin. maturin honors this key on
+# ALL build paths, crucially the PEP 517 backend (`maturin pep517 build-wheel`,
+# invoked by `pip install .` / sdist builds) whose DEFAULT profile is `release`
+# (panic = "abort"). The CI workflow `--profile release-unwind` override alone
+# does NOT cover source builds, so the pin is what makes the pyproject check
+# non-vacuous. Matches e.g. `profile = "release-unwind"` (optional surrounding
+# whitespace); requires the exact profile name.
+PROFILE_PIN_RE="^[[:space:]]*profile[[:space:]]*=[[:space:]]*\"${UNWIND_PROFILE}\"[[:space:]]*\$"
 
 # A `--release` token: bounded by start-of-value / EOL or a whitespace, quote
 # (" or '), or `=` delimiter. Matches `--release`, `"--release"`, `--release'`,
@@ -111,9 +122,20 @@ check_definitions() {
     if ! grep -qF '[tool.maturin]' "$pyproject"; then
       echo "FAIL - pyproject.toml has no [tool.maturin] table (fail-closed)"
       fails=$((fails + 1))
-    elif printf '%s\n' "$maturin_section" | grep -qE -- "$RELEASE_TOKEN_RE"; then
-      echo "FAIL - pyproject.toml [tool.maturin] re-pins '--release' (abort)"
-      fails=$((fails + 1))
+    else
+      # Positively require the profile pin. Without it, the PEP 517 backend that
+      # `pip install .` / sdist builds use defaults to profile `release`
+      # (panic = "abort") and a source-installed wheel would ship WITHOUT the FFI
+      # firewall while every other check still passed. Fail CLOSED if absent.
+      if ! printf '%s\n' "$maturin_section" | grep -qE -- "$PROFILE_PIN_RE"; then
+        echo "FAIL - pyproject.toml [tool.maturin] does not pin profile = \"${UNWIND_PROFILE}\" (source/PEP517 builds would default to release=abort)"
+        fails=$((fails + 1))
+      fi
+      # And it may not re-pin --release (abort) anywhere in the table.
+      if printf '%s\n' "$maturin_section" | grep -qE -- "$RELEASE_TOKEN_RE"; then
+        echo "FAIL - pyproject.toml [tool.maturin] re-pins '--release' (abort)"
+        fails=$((fails + 1))
+      fi
     fi
   fi
 
@@ -210,6 +232,7 @@ EOF
   cat >"$d/bindings/python/pyproject.toml" <<'EOF'
 [tool.maturin]
 features = ["pyo3/extension-module"]
+profile = "release-unwind"
 EOF
   cat >"$d/bindings/node/package.json" <<'EOF'
 {
@@ -367,6 +390,37 @@ EOF
     sok "python-release.yml comment-only profile w/ --release args fails closed"
   fi
 
+  # (j) pyproject [tool.maturin] WITHOUT the profile pin -> must FAIL closed.
+  #     This is the exact loophole the pin closes: the workflow override protects
+  #     only CI wheels, but a source/PEP517 build (`pip install .`) would default
+  #     to release=abort. A vacuous pyproject check (present before the pin
+  #     requirement) would wrongly PASS here.
+  local py_nopin="$tmp/py_nopin"
+  write_compliant_fixture "$py_nopin"
+  cat >"$py_nopin/bindings/python/pyproject.toml" <<'EOF'
+[tool.maturin]
+features = ["pyo3/extension-module"]
+EOF
+  if check_definitions "$py_nopin" >/dev/null; then
+    sbad "pyproject without profile = \"release-unwind\" pin should FAIL closed but passed"
+  else
+    sok "pyproject missing profile pin fails closed"
+  fi
+
+  # (k) pyproject pinning the WRONG profile (e.g. plain release=abort) -> FAIL.
+  local py_wrongpin="$tmp/py_wrongpin"
+  write_compliant_fixture "$py_wrongpin"
+  cat >"$py_wrongpin/bindings/python/pyproject.toml" <<'EOF'
+[tool.maturin]
+features = ["pyo3/extension-module"]
+profile = "release"
+EOF
+  if check_definitions "$py_wrongpin" >/dev/null; then
+    sbad "pyproject pinning profile = \"release\" (abort) should FAIL but passed"
+  else
+    sok "pyproject pinning wrong (abort) profile fails closed"
+  fi
+
   # Best-effort cleanup; the guard is offline so nothing else touches this dir.
   rm -rf "$tmp"
 
@@ -389,7 +443,7 @@ main() {
   findings=$(check_definitions "$REPO_ROOT")
   local real_fails=$?
   if [ "$real_fails" -eq 0 ]; then
-    echo "ok   - all binding build definitions select '${UNWIND_FLAG}' (no --release) and Cargo.toml [profile.release-unwind] pins panic = \"unwind\""
+    echo "ok   - all binding build definitions select '${UNWIND_FLAG}' (no --release), pyproject [tool.maturin] pins profile = \"${UNWIND_PROFILE}\" (source/PEP517 builds), and Cargo.toml [profile.release-unwind] pins panic = \"unwind\""
   else
     printf '%s\n' "$findings"
     echo "FAIL - $real_fails binding build definition(s) would ship an abort-compiled artifact"

--- a/scripts/tests/test_binding_unwind_profile.sh
+++ b/scripts/tests/test_binding_unwind_profile.sh
@@ -18,6 +18,12 @@
 #   2. bindings/python/pyproject.toml         ([tool.maturin] must not re-pin --release)
 #   3. bindings/node/package.json             ("build" script)
 #   4. .github/workflows/node-release.yml     (must not drive an abort build)
+#   5. Cargo.toml                             ([profile.release-unwind] must set panic = "unwind")
+#
+# Check 5 closes the loophole where the build commands correctly select
+# `--profile release-unwind` but the profile itself is deleted or flipped to
+# `panic = "abort"` — which would silently strip the panic firewall from the
+# shipped bindings while every build-command check still passed.
 #
 # Run standalone:   bash scripts/tests/test_binding_unwind_profile.sh
 # Or via the gate:  scripts/agent-gate.sh runs it as the `binding-unwind-profile`
@@ -45,6 +51,7 @@ check_definitions() {
   local pyproject="$root/bindings/python/pyproject.toml"
   local pkg="$root/bindings/node/package.json"
   local node_wf="$root/.github/workflows/node-release.yml"
+  local cargo_toml="$root/Cargo.toml"
 
   # --- 1. Python wheel workflow -------------------------------------------
   if [ ! -f "$py_wf" ]; then
@@ -122,6 +129,36 @@ check_definitions() {
     fi
   fi
 
+  # --- 5. Workspace Cargo.toml [profile.release-unwind] -------------------
+  # The build commands above select `--profile release-unwind`; that profile
+  # is only a firewall if it actually exists and pins `panic = "unwind"`.
+  # Fail CLOSED: a missing Cargo.toml, an absent section, an unset panic, or
+  # any panic value other than "unwind" (e.g. "abort") is a violation.
+  if [ ! -f "$cargo_toml" ]; then
+    echo "FAIL - Cargo.toml missing (fail-closed): $cargo_toml"
+    fails=$((fails + 1))
+  elif ! grep -qE '^\[profile\.release-unwind\]' "$cargo_toml"; then
+    echo "FAIL - Cargo.toml has no [profile.release-unwind] section (fail-closed)"
+    fails=$((fails + 1))
+  else
+    # Extract the [profile.release-unwind] table (until the next table header).
+    local profile_section
+    profile_section=$(awk '
+      /^\[profile\.release-unwind\]/ { in_sec = 1; next }
+      /^\[/                          { in_sec = 0 }
+      in_sec                         { print }
+    ' "$cargo_toml")
+    local panic_line
+    panic_line=$(printf '%s\n' "$profile_section" | grep -E '^[[:space:]]*panic[[:space:]]*=')
+    if [ -z "$panic_line" ]; then
+      echo "FAIL - [profile.release-unwind] does not set panic (fail-closed; must be \"unwind\")"
+      fails=$((fails + 1))
+    elif ! printf '%s\n' "$panic_line" | grep -qE '^[[:space:]]*panic[[:space:]]*=[[:space:]]*"unwind"[[:space:]]*$'; then
+      echo "FAIL - [profile.release-unwind] panic is not \"unwind\" (abort/other strips the FFI firewall)"
+      fails=$((fails + 1))
+    fi
+  fi
+
   return "$fails"
 }
 
@@ -159,6 +196,17 @@ EOF
   cat >"$d/.github/workflows/node-release.yml" <<'EOF'
       - name: Build native module
         run: npm run build
+EOF
+  cat >"$d/Cargo.toml" <<'EOF'
+[profile.release]
+panic = "abort"
+
+[profile.release-unwind]
+inherits = "release"
+panic = "unwind"
+
+[profile.bench]
+debug = true
 EOF
 }
 
@@ -211,6 +259,53 @@ EOF
     sok "empty tree fails closed"
   fi
 
+  # (e) Profile pinned panic = "unwind" -> guard PASSES.
+  #     (The compliant fixture already ships this Cargo.toml; assert explicitly.)
+  local prof_ok="$tmp/prof_ok"
+  write_compliant_fixture "$prof_ok"
+  if check_definitions "$prof_ok" >/dev/null; then
+    sok "Cargo.toml [profile.release-unwind] panic=unwind passes"
+  else
+    sbad "Cargo.toml panic=unwind should pass but did not"
+    check_definitions "$prof_ok"
+  fi
+
+  # (f) Profile flipped to panic = "abort" -> guard FAILS closed.
+  local prof_abort="$tmp/prof_abort"
+  write_compliant_fixture "$prof_abort"
+  cat >"$prof_abort/Cargo.toml" <<'EOF'
+[profile.release]
+panic = "abort"
+
+[profile.release-unwind]
+inherits = "release"
+panic = "abort"
+
+[profile.bench]
+debug = true
+EOF
+  if check_definitions "$prof_abort" >/dev/null; then
+    sbad "[profile.release-unwind] panic=abort should FAIL but passed"
+  else
+    sok "[profile.release-unwind] panic=abort fails closed"
+  fi
+
+  # (g) Profile section deleted entirely -> guard FAILS closed.
+  local prof_missing="$tmp/prof_missing"
+  write_compliant_fixture "$prof_missing"
+  cat >"$prof_missing/Cargo.toml" <<'EOF'
+[profile.release]
+panic = "abort"
+
+[profile.bench]
+debug = true
+EOF
+  if check_definitions "$prof_missing" >/dev/null; then
+    sbad "missing [profile.release-unwind] section should FAIL but passed"
+  else
+    sok "missing [profile.release-unwind] section fails closed"
+  fi
+
   # Best-effort cleanup; the guard is offline so nothing else touches this dir.
   rm -rf "$tmp"
 
@@ -233,7 +328,7 @@ main() {
   findings=$(check_definitions "$REPO_ROOT")
   local real_fails=$?
   if [ "$real_fails" -eq 0 ]; then
-    echo "ok   - all four binding build definitions select '${UNWIND_FLAG}' (no --release)"
+    echo "ok   - all binding build definitions select '${UNWIND_FLAG}' (no --release) and Cargo.toml [profile.release-unwind] pins panic = \"unwind\""
   else
     printf '%s\n' "$findings"
     echo "FAIL - $real_fails binding build definition(s) would ship an abort-compiled artifact"

--- a/scripts/tests/test_binding_unwind_profile.sh
+++ b/scripts/tests/test_binding_unwind_profile.sh
@@ -38,6 +38,16 @@ REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
 UNWIND_PROFILE="release-unwind"
 UNWIND_FLAG="--profile ${UNWIND_PROFILE}"
 
+# A `--release` token: bounded by start-of-value / EOL or a whitespace, quote
+# (" or '), or `=` delimiter. Matches `--release`, `"--release"`, `--release'`,
+# `x=--release`. Does NOT match `--profile release-unwind` (no `--` before
+# `release`) nor `--release-unwind` (trailing `-` is not a delimiter). Using an
+# explicit delimiter class instead of `[[:space:]]|$` closes the loophole where
+# a quoted or `=`-delimited `--release` slipped past the abort-build negative
+# check. (In the double-quoted string \" is a literal ", ' is literal, and \$ is
+# the ERE end-of-line anchor.)
+RELEASE_TOKEN_RE="(^|[[:space:]\"'=])--release([[:space:]\"'=]|\$)"
+
 # ---------------------------------------------------------------------------
 # check_definitions <root> : inspect the four binding build definitions rooted
 # at <root>. Prints a "FAIL - <reason>" line for every violation and returns the
@@ -58,16 +68,31 @@ check_definitions() {
     echo "FAIL - python-release.yml missing (fail-closed): $py_wf"
     fails=$((fails + 1))
   else
-    # The wheel build must select the unwind profile ...
-    if ! grep -qF -- "$UNWIND_FLAG" "$py_wf"; then
-      echo "FAIL - python-release.yml does not select '${UNWIND_FLAG}' for the wheel build"
+    # Inspect ONLY the maturin-action `args:` value(s) that drive the build, not
+    # the whole file. A `#`-comment line (first non-space char is `#`) never
+    # begins with `args:` so it is excluded by the anchored match; a trailing
+    # ` #...` inline comment is stripped. This closes two false-negative gaps:
+    #   - a commented / unrelated `--profile release-unwind` mention elsewhere in
+    #     the YAML can no longer satisfy the positive (present) check, and
+    #   - a quoted / `=`-delimited `--release` can no longer slip past the
+    #     negative (absent) check.
+    # Fail CLOSED: if no `args:` line is found, treat it as non-compliant.
+    local py_args
+    py_args=$(grep -E '^[[:space:]]*args[[:space:]]*:' "$py_wf" | sed -E 's/[[:space:]]+#.*$//')
+    if [ -z "$py_args" ]; then
+      echo "FAIL - python-release.yml has no maturin-action 'args:' line (fail-closed)"
       fails=$((fails + 1))
-    fi
-    # ... and must never pass --release (abort). `--profile release-unwind`
-    # does not contain the substring `--release`, so this match is exact.
-    if grep -qE -- '--release([[:space:]]|$)' "$py_wf"; then
-      echo "FAIL - python-release.yml still passes '--release' (abort) to the wheel build"
-      fails=$((fails + 1))
+    else
+      # At least one args value must select the unwind profile (the wheel build).
+      if ! printf '%s\n' "$py_args" | grep -qF -- "$UNWIND_FLAG"; then
+        echo "FAIL - python-release.yml 'args:' does not select '${UNWIND_FLAG}' for the wheel build"
+        fails=$((fails + 1))
+      fi
+      # No args value may pass --release (abort).
+      if printf '%s\n' "$py_args" | grep -qE -- "$RELEASE_TOKEN_RE"; then
+        echo "FAIL - python-release.yml 'args:' still passes '--release' (abort) to the wheel build"
+        fails=$((fails + 1))
+      fi
     fi
   fi
 
@@ -86,7 +111,7 @@ check_definitions() {
     if ! grep -qF '[tool.maturin]' "$pyproject"; then
       echo "FAIL - pyproject.toml has no [tool.maturin] table (fail-closed)"
       fails=$((fails + 1))
-    elif printf '%s\n' "$maturin_section" | grep -qE -- '--release([[:space:]"'\'']|$)'; then
+    elif printf '%s\n' "$maturin_section" | grep -qE -- "$RELEASE_TOKEN_RE"; then
       echo "FAIL - pyproject.toml [tool.maturin] re-pins '--release' (abort)"
       fails=$((fails + 1))
     fi
@@ -108,7 +133,7 @@ check_definitions() {
         echo "FAIL - package.json \"build\" script does not select '${UNWIND_FLAG}'"
         fails=$((fails + 1))
       fi
-      if printf '%s\n' "$build_line" | grep -qE -- '--release([[:space:]"'\'']|$)'; then
+      if printf '%s\n' "$build_line" | grep -qE -- "$RELEASE_TOKEN_RE"; then
         echo "FAIL - package.json \"build\" script still passes '--release' (abort)"
         fails=$((fails + 1))
       fi
@@ -123,7 +148,7 @@ check_definitions() {
     echo "FAIL - node-release.yml missing (fail-closed): $node_wf"
     fails=$((fails + 1))
   else
-    if grep -qE -- '--release([[:space:]]|$)' "$node_wf"; then
+    if grep -qE -- "$RELEASE_TOKEN_RE" "$node_wf"; then
       echo "FAIL - node-release.yml drives an abort build with '--release'"
       fails=$((fails + 1))
     fi
@@ -304,6 +329,42 @@ EOF
     sbad "missing [profile.release-unwind] section should FAIL but passed"
   else
     sok "missing [profile.release-unwind] section fails closed"
+  fi
+
+  # (h) Python workflow whose wheel-build `args` uses a QUOTED "--release" ->
+  #     the quote is the token delimiter, so this must FAIL closed. The old
+  #     `--release([[:space:]]|$)` matcher missed it (quote != whitespace/EOL).
+  local py_quoted="$tmp/py_quoted"
+  write_compliant_fixture "$py_quoted"
+  cat >"$py_quoted/.github/workflows/python-release.yml" <<'EOF'
+      - name: Build wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          args: "--release --out dist"
+EOF
+  if check_definitions "$py_quoted" >/dev/null; then
+    sbad "python-release.yml quoted \"--release\" args should FAIL closed but passed"
+  else
+    sok "python-release.yml quoted \"--release\" args fails closed"
+  fi
+
+  # (i) Python workflow that mentions `--profile release-unwind` ONLY in a
+  #     COMMENT while the real `args` build with `--release` -> must FAIL closed.
+  #     The old whole-file positive match was satisfied by the comment and the
+  #     abort build slipped through.
+  local py_comment="$tmp/py_comment"
+  write_compliant_fixture "$py_comment"
+  cat >"$py_comment/.github/workflows/python-release.yml" <<'EOF'
+      - name: Build wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          # TODO: switch to --profile release-unwind (issue #1440)
+          args: --release --out dist
+EOF
+  if check_definitions "$py_comment" >/dev/null; then
+    sbad "python-release.yml comment-only profile w/ --release args should FAIL closed but passed"
+  else
+    sok "python-release.yml comment-only profile w/ --release args fails closed"
   fi
 
   # Best-effort cleanup; the guard is offline so nothing else touches this dir.


### PR DESCRIPTION
Closes #1440

## What & why
Ship the two binding cdylibs (Python wheel, Node npm prebuild) compiled `panic = "unwind"` so the PyO3/napi-rs `catch_unwind`→exception firewall re-activates: a `cqlite-core` panic on corrupt/truncated input becomes a catchable `CqliteError` instead of aborting the host process. `panic = "abort"` stays for the CLI/core. Owner-DECIDED 2026-07-01. Design-driven; OpenSpec change `panic-unwind-profile` (capability `binding-panic-firewall`).

This flips #1437's abort-safety harness (HELD behind this) from red to green.

## Changes
- **`Cargo.toml`** — new `[profile.release-unwind]` (`inherits = "release"`, only `panic = "unwind"`); `[profile.release]` `panic = "abort"` untouched.
- **`.github/workflows/python-release.yml`** — wheel build maturin args `--release` → `--profile release-unwind`.
- **`bindings/python/pyproject.toml`** — `[tool.maturin] profile = "release-unwind"` so **source / PEP 517 builds** (`pip install .`) also get the firewall, not just the CI-prebuilt wheels.
- **`bindings/node/package.json`** — `build` → `napi build --platform --profile release-unwind --features write-support`.
- **`scripts/tests/test_binding_unwind_profile.sh`** (new) — fail-closed guard: asserts every binding build definition selects `--profile release-unwind` (quote/comment/`=`-delimiter robust, no `--release`), that pyproject pins the profile, and that `Cargo.toml [profile.release-unwind]` pins `panic = "unwind"`; fails closed on any missing/unparseable definition. 11 inline selftests. Wired as the `binding-unwind-profile` agent-gate component.
- **`CLAUDE.md`** — dev-loop doc: `maturin develop --profile dev` (see DX note below).

## Measured delta (R4)
| Binding cdylib | release (abort) | release-unwind | Δ size |
|---|---|---|---|
| Node `.node` | 8.77 MiB | 10.88 MiB | +24.1% |
| Python `.so` | 8.81 MiB | 10.90 MiB | +23.8% |

Scan micro-benchmark (test_basic.simple_table, 1000 rows, N=200, both toolchains real):
| Binding | abort (median ms) | unwind (median ms) | Δ |
|---|---|---|---|
| Node | 10.71 | 10.76 | +0.46% (within jitter) |
| Python | 9.997 | 10.379 | +3.8% — shown to be noise (overlapping run-to-run bands) |

**Conclusion:** unwind adds no measurable steady-state scan cost; the price is the expected ~24% cdylib size increase (landing-pad tables).

## DX note (reviewer heads-up)
maturin has no build/PEP517-*scoped* profile pin — pinning the profile in pyproject to protect source builds also flips `maturin develop`'s default from debug to `release-unwind` (optimized/slower). Mitigated in-scope: `maturin develop --profile dev` (CLI override wins) is now the documented dev command. Chosen deliberately — leaving source builds on `abort` would reopen the P0 firewall hole. Flagging in case a different tradeoff is preferred.

## Quality bar
- `scripts/agent-gate.sh` **PASS** — all 20 components (commit ab180eb3, clean tree); `python-bindings` + `binding-unwind-profile` both PASS with the pyproject pin.
- roborev **clean** (codex, `--base origin/main`) — converged after strengthening the guard (profile-definition check, quote/comment parsing, source-wheel hole).
- No `[profile.release]` change; no library `unwrap()`/`expect()` added.

## Out of scope
- The abort-safety harness (`test_abort_safety.py` / `abort-safety.test.js`) is **#1437** (HELD behind this).
- Core panic-path elimination (parser epic H).
