### PR TITLE
test(#1437): abort-safety regression harness for corrupt SSTables via bindings

### DIFF
--- a/bindings/node/__test__/abort-safety.test.js
+++ b/bindings/node/__test__/abort-safety.test.js
@@ -54,39 +54,69 @@ const { MODES, sourceTableDir, makeCorruptFixture } = require('./corrupt-fixture
 
 const MODULE_PATH = path.resolve(__dirname, '..', 'lib', 'index.js');
 
-// Child driver. `require` sits OUTSIDE the try so a broken build crashes
-// non-zero (surfacing as a setup failure, not a false green). A hard abort
-// prints no terminal sentinel and exits with a signal.
+// Child driver. Setup (`require`, `Database.open`, and the entry-method lookup)
+// sits OUTSIDE the success `try`: a broken build, missing schema, failed
+// `open`, or a renamed/absent entry method is a HARD error (non-zero exit via
+// the outer `.catch`), never a false-green `RAISED`. Only a native/typed error
+// thrown FROM the entry-point call itself is caught as `RAISED`. The driver
+// emits `OPENED` then `CALLING <entry>` before any terminal sentinel so the
+// parent can prove corrupt input was actually driven through the entry point.
+// A hard abort prints no terminal sentinel and exits with a signal.
 const DRIVER = `
 const [root, schema, entry] = process.argv.slice(1);
 const { Database } = require(${JSON.stringify(MODULE_PATH)});
 const QUERY = 'SELECT * FROM test_basic.simple_table';
+
+// entry name -> underlying Database method that must exist on the instance.
+const METHOD = {
+  executeNative: 'executeNative',
+  streaming: 'executeStreaming',
+  parquet: 'exportParquet',
+};
+
 (async () => {
-  try {
-    const db = await Database.open(root, { schema });
-    console.log('OPENED');
+  // --- setup: NOT catchable as success ---
+  const db = await Database.open(root, { schema });
+  console.log('OPENED');
+
+  const methodName = METHOD[entry];
+  if (methodName === undefined || typeof db[methodName] !== 'function') {
+    console.log('BADENTRY ' + entry);
+    process.exit(3);
+  }
+
+  const call = async () => {
     if (entry === 'executeNative') {
       const r = await db.executeNative(QUERY);
-      console.log('RETURNED rows=' + r.rowCount);
+      return 'rows=' + r.rowCount;
     } else if (entry === 'streaming') {
       let n = 0;
       for await (const _ of db.executeStreaming(QUERY)) { n++; }
-      console.log('RETURNED rows=' + n);
-    } else if (entry === 'parquet') {
+      return 'rows=' + n;
+    } else {
       const fs = require('fs'); const os = require('os'); const path = require('path');
       const out = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'cq-pq-')), 'out.parquet');
       const rows = await db.exportParquet(QUERY, out);
-      console.log('RETURNED rows=' + rows);
-    } else {
-      console.log('BADENTRY ' + entry);
-      process.exit(3);
+      return 'rows=' + rows;
     }
-    await db.close();
+  };
+
+  console.log('CALLING ' + entry);
+  // --- ONLY the entry-point call is catchable as success ---
+  try {
+    const detail = await call();
+    console.log('RETURNED ' + detail);
   } catch (e) {
     const name = (e && e.constructor && e.constructor.name) || 'Error';
     console.log('RAISED ' + name);
   }
-})();
+
+  try { await db.close(); } catch (_) { /* best-effort */ }
+})().catch((e) => {
+  // Setup/lookup failure -> hard error (non-zero exit), NOT a passing RAISED.
+  console.error('SETUP_FAILED ' + ((e && e.stack) || e));
+  process.exit(4);
+});
 `;
 
 function requireSource() {
@@ -133,9 +163,20 @@ function runAndAssertSurvives(mode, entry, exposeUncompressed) {
           `stdout=${JSON.stringify(out)}\nstderr=${JSON.stringify(errOut)}`
       );
     }
+    // Prove the driver actually drove corrupt input THROUGH the entry point:
+    // it must have opened the DB and announced the call before any terminal
+    // sentinel. This defeats a false-green where a setup/open/lookup failure
+    // would otherwise surface as a passing RAISED.
+    const lines = stdout.split(/\r?\n/);
+    const openedIdx = lines.indexOf('OPENED');
+    const callingIdx = lines.indexOf('CALLING ' + entry);
+    const terminalIdx = lines.findIndex((l) => /^(RETURNED|RAISED)\b/.test(l));
+    expect(openedIdx).toBeGreaterThanOrEqual(0);
+    expect(callingIdx).toBeGreaterThan(openedIdx);
     // RAISED (incl. a napi-converted panic under panic=unwind) or RETURNED both
-    // prove the boundary held and the process lived on.
-    expect(stdout).toMatch(/RETURNED|RAISED/);
+    // prove the boundary held and the process lived on -- but only when reached
+    // AFTER CALLING (i.e. from the entry-point call itself).
+    expect(terminalIdx).toBeGreaterThan(callingIdx);
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true });
   }

--- a/bindings/node/__test__/abort-safety.test.js
+++ b/bindings/node/__test__/abort-safety.test.js
@@ -40,8 +40,15 @@
  * therefore be RED under the debug gate, so it is intentionally omitted and
  * reported as a follow-up rather than run as a known-red test.
  *
- * These tests actually run and assert (never silently skip) when the dataset
- * is present; a missing/empty source Data.db throws loudly per issue #1437.
+ * DATASET GATING (never false-green): when the source Data.db is present these
+ * tests actually run and assert. A BROKEN source (present but empty), or a
+ * genuinely absent source under strict fixture mode
+ * (CQLITE_REQUIRE_FIXTURES / CQLITE_PARITY_REQUIRE_DATASETS), is a HARD FAILURE
+ * asserted loudly in beforeAll. A genuinely absent source in non-strict local
+ * dev registers as a real Jest SKIP (via test.skip) — NOT an early `return`
+ * from the test body, which Jest would score as a PASS and false-green the
+ * whole abort-safety harness. This mirrors the Python side
+ * (test_abort_safety.py::_require_source_or_skip -> pytest.skip / pytest.fail).
  */
 'use strict';
 
@@ -119,21 +126,38 @@ const METHOD = {
 });
 `;
 
-function requireSource() {
+/**
+ * True when strict fixture mode is requested (mirrors the Python
+ * `_require_fixtures_strict` helper and the Rust `require_fixtures_strict`):
+ * either CQLITE_REQUIRE_FIXTURES or CQLITE_PARITY_REQUIRE_DATASETS set to a
+ * truthy value flips a missing dataset from a Jest SKIP to a HARD FAILURE, so
+ * a dropped table or a path regression reds CI rather than false-greening.
+ * @returns {boolean}
+ */
+function requireFixturesStrict() {
+  const truthy = (v) => v === '1' || v === 'true';
+  return truthy(process.env.CQLITE_REQUIRE_FIXTURES) || truthy(process.env.CQLITE_PARITY_REQUIRE_DATASETS);
+}
+
+/**
+ * Classify the source SSTable at collection time (never false-green):
+ *   - { status: 'ok' }     : a present, non-empty source Data.db -> run.
+ *   - { status: 'broken' } : present but empty -> HARD FAIL (loud in beforeAll).
+ *   - { status: 'absent' } : no source dir    -> Jest SKIP, or HARD FAIL under
+ *                            strict fixture mode.
+ * @returns {{status: 'ok'|'broken'|'absent', reason?: string}}
+ */
+function classifySource() {
   const sstables = global.testPaths.SSTABLES_DIR;
   const src = sourceTableDir(sstables);
   if (src === null) {
-    // Dataset genuinely absent: honor the suite-wide availability guard.
-    if (!global.DATASETS_AVAILABLE) {
-      return false;
-    }
-    throw new Error(`No test_basic.simple_table SSTable under ${sstables} (issue #1437)`);
+    return { status: 'absent', reason: `No test_basic.simple_table SSTable under ${sstables} (issue #1437)` };
   }
   const data = path.join(src, 'nb-1-big-Data.db');
   if (fs.statSync(data).size === 0) {
-    throw new Error(`Source ${data} present but empty (issue #1437)`);
+    return { status: 'broken', reason: `Source ${data} present but empty (issue #1437)` };
   }
-  return true;
+  return { status: 'ok' };
 }
 
 /**
@@ -182,21 +206,35 @@ function runAndAssertSurvives(mode, entry, exposeUncompressed) {
   }
 }
 
-describe('Abort safety: corrupt SSTable must not kill the host (issue #1437)', () => {
-  let haveSource = false;
+// Decide gating ONCE, at collection time, so absence becomes a real Jest SKIP
+// rather than an early `return` (which Jest scores as a PASS). A broken source,
+// or an absent source under strict fixture mode, is a HARD FAILURE asserted in
+// beforeAll; a genuinely absent source in non-strict dev uses `test.skip`.
+const SOURCE = classifySource();
+const STRICT = requireFixturesStrict();
+const HARD_FAIL = SOURCE.status === 'broken' || (SOURCE.status === 'absent' && STRICT);
+const CAN_RUN = SOURCE.status === 'ok';
+// Use a real `test.skip` (Jest reports SKIPPED) only for a genuine, non-strict
+// absence. When we must run OR must hard-fail, register a real `test` so the
+// beforeAll guard executes and can throw loudly.
+const testOrSkip = CAN_RUN || HARD_FAIL ? test : test.skip;
 
+describe('Abort safety: corrupt SSTable must not kill the host (issue #1437)', () => {
   beforeAll(() => {
-    haveSource = requireSource();
+    // Fail closed on a hard misconfiguration; never silently continue.
+    if (HARD_FAIL) {
+      const hint = SOURCE.status === 'absent'
+        ? ' (strict fixture mode: CQLITE_REQUIRE_FIXTURES/CQLITE_PARITY_REQUIRE_DATASETS set; ' +
+          'fetch with bash test-data/scripts/fetch-datasets.sh)'
+        : '';
+      throw new Error(`${SOURCE.reason}${hint}`);
+    }
   });
 
   describe('compressed Data.db (exact issue recipe; survives in debug + release)', () => {
     for (const mode of MODES) {
       for (const entry of ['executeNative', 'streaming', 'parquet']) {
-        test(`survives ${mode} via ${entry}`, () => {
-          if (!haveSource) {
-            console.warn(`SKIP ${mode}/${entry}: datasets not available`);
-            return;
-          }
+        testOrSkip(`survives ${mode} via ${entry}`, () => {
           runAndAssertSurvives(mode, entry, false);
         });
       }

--- a/bindings/node/__test__/abort-safety.test.js
+++ b/bindings/node/__test__/abort-safety.test.js
@@ -172,9 +172,16 @@ function runAndAssertSurvives(mode, entry, exposeUncompressed) {
     });
     let stdout = '';
     try {
+      // Child timeout is deliberately BELOW Jest's testTimeout (30s, see
+      // jest.config.js). execFileSync is synchronous and blocks the Jest
+      // worker, so a hung child must be killed by execFileSync's OWN timeout
+      // (surfacing here as a caught ETIMEDOUT -> rich "did not survive" failure)
+      // BEFORE Jest's worker timeout fires and kills the whole worker with a
+      // context-free error. Keeping it under 30s preserves meaningful abort/hang
+      // detection at the child boundary.
       stdout = execFileSync(process.execPath, ['-e', DRIVER, root, global.testPaths.SCHEMA_BASIC_TYPES, entry], {
         encoding: 'utf8',
-        timeout: 120000,
+        timeout: 20000,
         stdio: ['ignore', 'pipe', 'pipe'],
       });
     } catch (err) {

--- a/bindings/node/__test__/abort-safety.test.js
+++ b/bindings/node/__test__/abort-safety.test.js
@@ -1,0 +1,164 @@
+/**
+ * Abort-safety regression harness (issue #1437).
+ *
+ * Drives a corrupt/truncated SSTable through every Node entry point and proves
+ * the host process SURVIVES: each call must terminate in a catchable state (a
+ * normal return, or — under a panic=unwind build — a caught panic surfaced as
+ * a thrown JS Error) rather than aborting the process.
+ *
+ * Why a child process?  The workspace *release* profile is `panic = "abort"`
+ * (Cargo.toml), so a panic inside cqlite-core during a scan through napi-rs
+ * does not become a catchable JS Error — it kills the whole Node process with
+ * a signal.  The only way to observe that as a test FAILURE (rather than the
+ * Jest runner dying) is to spawn each driver in a child process and assert it
+ * exited 0 while emitting a terminal sentinel on stdout.
+ *
+ * This harness exercises the "compressed" fixture flavor — the exact issue
+ * recipe (mutate the Snappy-compressed Data.db). Snappy decompression contains
+ * the corruption, so all three entry points survive today in BOTH debug and
+ * release. Covers executeNative, streaming, and exportParquet over both
+ * truncate and bit-flip mutations.
+ *
+ * DEBUG vs RELEASE: `npm run build` builds the addon `--release`
+ * (`panic=abort`). These compressed tests survive on that release addon
+ * because the corruption never reaches a panic. The release-profile abort
+ * PROOF for issue #1437 is carried by the Python harness
+ * (`test_abort_safety.py::test_uncompressed_...`), which does reach the
+ * raw-parser panic through PyO3.
+ *
+ * WHY NO "uncompressed" (raw parse path) FLAVOR HERE (finding, verified
+ * 2026-07-02): dropping CompressionInfo.db to reach the raw VInt/row parser
+ * makes the Node process ABORT even under a DEBUG (`panic=unwind`) build with
+ *   thread '<unnamed>' panicked at bindings/node/src/value.rs:266
+ *   fatal runtime error: failed to initiate panic, error 5, aborting
+ * i.e. a panic in the Node binding's own decimal formatter (unbounded
+ * `format!` padding width from a corrupt DECIMAL scale) on the napi async
+ * worker thread, which cannot unwind across the FFI boundary. Because it
+ * aborts under unwind too, #1440's panic profile alone will NOT fix the Node
+ * path — it additionally needs `scale` bounded in value.rs and/or an explicit
+ * catch_unwind at the napi boundary. Asserting survival on that flavor would
+ * therefore be RED under the debug gate, so it is intentionally omitted and
+ * reported as a follow-up rather than run as a known-red test.
+ *
+ * These tests actually run and assert (never silently skip) when the dataset
+ * is present; a missing/empty source Data.db throws loudly per issue #1437.
+ */
+'use strict';
+
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { MODES, sourceTableDir, makeCorruptFixture } = require('./corrupt-fixture.js');
+
+const MODULE_PATH = path.resolve(__dirname, '..', 'lib', 'index.js');
+
+// Child driver. `require` sits OUTSIDE the try so a broken build crashes
+// non-zero (surfacing as a setup failure, not a false green). A hard abort
+// prints no terminal sentinel and exits with a signal.
+const DRIVER = `
+const [root, schema, entry] = process.argv.slice(1);
+const { Database } = require(${JSON.stringify(MODULE_PATH)});
+const QUERY = 'SELECT * FROM test_basic.simple_table';
+(async () => {
+  try {
+    const db = await Database.open(root, { schema });
+    console.log('OPENED');
+    if (entry === 'executeNative') {
+      const r = await db.executeNative(QUERY);
+      console.log('RETURNED rows=' + r.rowCount);
+    } else if (entry === 'streaming') {
+      let n = 0;
+      for await (const _ of db.executeStreaming(QUERY)) { n++; }
+      console.log('RETURNED rows=' + n);
+    } else if (entry === 'parquet') {
+      const fs = require('fs'); const os = require('os'); const path = require('path');
+      const out = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'cq-pq-')), 'out.parquet');
+      const rows = await db.exportParquet(QUERY, out);
+      console.log('RETURNED rows=' + rows);
+    } else {
+      console.log('BADENTRY ' + entry);
+      process.exit(3);
+    }
+    await db.close();
+  } catch (e) {
+    const name = (e && e.constructor && e.constructor.name) || 'Error';
+    console.log('RAISED ' + name);
+  }
+})();
+`;
+
+function requireSource() {
+  const sstables = global.testPaths.SSTABLES_DIR;
+  const src = sourceTableDir(sstables);
+  if (src === null) {
+    // Dataset genuinely absent: honor the suite-wide availability guard.
+    if (!global.DATASETS_AVAILABLE) {
+      return false;
+    }
+    throw new Error(`No test_basic.simple_table SSTable under ${sstables} (issue #1437)`);
+  }
+  const data = path.join(src, 'nb-1-big-Data.db');
+  if (fs.statSync(data).size === 0) {
+    throw new Error(`Source ${data} present but empty (issue #1437)`);
+  }
+  return true;
+}
+
+/**
+ * Spawn the child driver and assert the process survives (exit 0) and reaches
+ * a terminal sentinel. Throws with rich context on a signal/non-zero exit.
+ */
+function runAndAssertSurvives(mode, entry, exposeUncompressed) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cqlite-abort-'));
+  try {
+    const root = makeCorruptFixture(tmp, global.testPaths.SSTABLES_DIR, mode, {
+      exposeUncompressed,
+    });
+    let stdout = '';
+    try {
+      stdout = execFileSync(process.execPath, ['-e', DRIVER, root, global.testPaths.SCHEMA_BASIC_TYPES, entry], {
+        encoding: 'utf8',
+        timeout: 120000,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+    } catch (err) {
+      const exit = err.status != null ? err.status : err.signal || 1;
+      const out = (err.stdout && err.stdout.toString()) || '';
+      const errOut = (err.stderr && err.stderr.toString()) || '';
+      throw new Error(
+        `child did not survive corrupt input (mode=${mode} entry=${entry} ` +
+          `exposeUncompressed=${exposeUncompressed} exit=${exit})\n` +
+          `stdout=${JSON.stringify(out)}\nstderr=${JSON.stringify(errOut)}`
+      );
+    }
+    // RAISED (incl. a napi-converted panic under panic=unwind) or RETURNED both
+    // prove the boundary held and the process lived on.
+    expect(stdout).toMatch(/RETURNED|RAISED/);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+describe('Abort safety: corrupt SSTable must not kill the host (issue #1437)', () => {
+  let haveSource = false;
+
+  beforeAll(() => {
+    haveSource = requireSource();
+  });
+
+  describe('compressed Data.db (exact issue recipe; survives in debug + release)', () => {
+    for (const mode of MODES) {
+      for (const entry of ['executeNative', 'streaming', 'parquet']) {
+        test(`survives ${mode} via ${entry}`, () => {
+          if (!haveSource) {
+            console.warn(`SKIP ${mode}/${entry}: datasets not available`);
+            return;
+          }
+          runAndAssertSurvives(mode, entry, false);
+        });
+      }
+    }
+  });
+});

--- a/bindings/node/__test__/corrupt-fixture.js
+++ b/bindings/node/__test__/corrupt-fixture.js
@@ -1,0 +1,129 @@
+/**
+ * Runtime corrupt-SSTable fixture generation for the abort-safety harness.
+ *
+ * Issue #1437. No large binaries are committed. Given a temp dir this copies
+ * the real `test_basic.simple_table` SSTable directory and mutates
+ * `nb-1-big-Data.db` in one of two modes, both exercised by the harness:
+ *   - "truncate": copy the dir, then truncate Data.db to ~50% of its length.
+ *   - "bitflip":  copy the whole dir, then XOR 0x01 into a middle byte.
+ *
+ * Sibling components (-Statistics.db / -Index.db / -Summary.db /
+ * -CompressionInfo.db / -TOC.txt) are kept so Database.open() proceeds far
+ * enough to read the corrupt Data.db during a scan.
+ *
+ * Dataset rule (issue #1437): if the real source Data.db is missing or
+ * zero-length, THROW (never silently `return`); a broken source is a hard
+ * failure, not a skippable condition.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const KEYSPACE = 'test_basic';
+const TABLE = 'simple_table';
+const DATA_COMPONENT = 'nb-1-big-Data.db';
+const COMPRESSION_COMPONENT = 'nb-1-big-CompressionInfo.db';
+const TOC_COMPONENT = 'nb-1-big-TOC.txt';
+const MODES = ['truncate', 'bitflip'];
+
+/**
+ * Find the real `simple_table-<uuid>` dir under the sstables root, or null.
+ * @param {string} sstablesRoot
+ * @returns {string|null}
+ */
+function sourceTableDir(sstablesRoot) {
+  const ksDir = path.join(sstablesRoot, KEYSPACE);
+  if (!fs.existsSync(ksDir) || !fs.statSync(ksDir).isDirectory()) {
+    return null;
+  }
+  const matches = fs
+    .readdirSync(ksDir)
+    .filter((name) => name.startsWith(`${TABLE}-`))
+    .map((name) => path.join(ksDir, name))
+    .filter((dir) => fs.existsSync(path.join(dir, DATA_COMPONENT)))
+    .sort();
+  return matches.length > 0 ? matches[0] : null;
+}
+
+/**
+ * Force the reader down the uncompressed Data.db path by dropping the
+ * CompressionInfo sidecar (and its TOC line). The raw VInt/row parser is where
+ * the audited corrupt-input panics live; with compression present, Snappy
+ * decompression contains any corruption before the panics are reached. A
+ * missing CompressionInfo.db is itself a plausible real-world corruption.
+ * @param {string} destTable
+ */
+function dropCompressionInfo(destTable) {
+  const comp = path.join(destTable, COMPRESSION_COMPONENT);
+  if (fs.existsSync(comp)) {
+    fs.rmSync(comp);
+  }
+  const toc = path.join(destTable, TOC_COMPONENT);
+  if (fs.existsSync(toc)) {
+    const kept = fs
+      .readFileSync(toc, 'utf8')
+      .split('\n')
+      .filter((line) => !line.includes('CompressionInfo'));
+    fs.writeFileSync(toc, kept.join('\n') + '\n');
+  }
+}
+
+/**
+ * Build a corrupt copy under `destParent` and return the `sstables/` root to
+ * pass to Database.open. Throws when the source Data.db is missing/empty.
+ * @param {string} destParent
+ * @param {string} sstablesRoot
+ * @param {'truncate'|'bitflip'} mode
+ * @param {{exposeUncompressed?: boolean}} [opts] - when exposeUncompressed is
+ *   true, also drop CompressionInfo.db to read Data.db on the raw parse path.
+ * @returns {string}
+ */
+function makeCorruptFixture(destParent, sstablesRoot, mode, opts = {}) {
+  if (!MODES.includes(mode)) {
+    throw new Error(`unknown mode ${mode}; expected one of ${MODES.join(', ')}`);
+  }
+  const src = sourceTableDir(sstablesRoot);
+  if (src === null) {
+    throw new Error(
+      `No ${KEYSPACE}.${TABLE} SSTable with ${DATA_COMPONENT} under ${sstablesRoot}`
+    );
+  }
+  const srcData = path.join(src, DATA_COMPONENT);
+  if (fs.statSync(srcData).size === 0) {
+    throw new Error(`Source ${srcData} present but empty (issue #1437)`);
+  }
+
+  const destRoot = path.join(destParent, 'sstables');
+  const destTable = path.join(destRoot, KEYSPACE, path.basename(src));
+  fs.cpSync(src, destTable, {
+    recursive: true,
+    // Skip only the multi-megabyte JSONL golden; the small -TOC.txt MUST be
+    // kept (issue #1437). The reader consults only TOC-listed binary files.
+    filter: (s) => !s.endsWith('.jsonl'),
+  });
+
+  if (opts.exposeUncompressed) {
+    dropCompressionInfo(destTable);
+  }
+
+  const destData = path.join(destTable, DATA_COMPONENT);
+  const length = fs.statSync(destData).size;
+  if (mode === 'truncate') {
+    fs.truncateSync(destData, Math.floor(length / 2));
+  } else {
+    const offset = Math.floor(length / 2);
+    const fd = fs.openSync(destData, 'r+');
+    try {
+      const buf = Buffer.alloc(1);
+      fs.readSync(fd, buf, 0, 1, offset);
+      buf[0] ^= 0x01;
+      fs.writeSync(fd, buf, 0, 1, offset);
+    } finally {
+      fs.closeSync(fd);
+    }
+  }
+  return destRoot;
+}
+
+module.exports = { KEYSPACE, TABLE, DATA_COMPONENT, MODES, sourceTableDir, makeCorruptFixture };

--- a/bindings/python/python/cqlite/__init__.py
+++ b/bindings/python/python/cqlite/__init__.py
@@ -3,6 +3,8 @@
 from cqlite._cqlite import (
     __version__,
     version,
+    # Test-support introspection (issue #1437)
+    _built_with_panic_abort,
     # Exception types
     CqliteError,
     SchemaError,
@@ -33,6 +35,8 @@ from cqlite._cqlite import (
 __all__ = [
     "__version__",
     "version",
+    # Test-support introspection (issue #1437)
+    "_built_with_panic_abort",
     # Exception types
     "CqliteError",
     "SchemaError",

--- a/bindings/python/python/cqlite/__init__.pyi
+++ b/bindings/python/python/cqlite/__init__.pyi
@@ -16,6 +16,14 @@ def version() -> str:
     """Return the CQLite version string."""
     ...
 
+# Test-support introspection (issue #1437). Reports the ACTUAL compiled panic
+# strategy of the loaded wheel via ``cfg!(panic = "abort")``; used by the
+# abort-safety harness to key its conditional strict xfail. Not part of the
+# stable public API.
+def _built_with_panic_abort() -> bool:
+    """Whether this wheel was compiled with ``panic = "abort"``."""
+    ...
+
 # Exception hierarchy
 class CqliteError(Exception):
     """Base exception for all CQLite errors."""

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -34,12 +34,34 @@ fn version() -> &'static str {
     VERSION
 }
 
+/// Test-support introspection: reports whether this extension was compiled with
+/// the `panic = "abort"` strategy.
+///
+/// This is read-only and derived at compile time from `cfg!(panic = "abort")`,
+/// so it reflects the ACTUAL compiled panic strategy of the loaded wheel (which
+/// differs between the debug/test profile, `panic = "unwind"`, and the release
+/// profile). The abort-safety harness (`tests/test_abort_safety.py`, issue
+/// #1437) keys a conditional strict xfail on this value: under `panic = "unwind"`
+/// PyO3 contains a core panic as a catchable exception and the survival cases
+/// hard-assert; under `panic = "abort"` the same panic is a process abort until
+/// issue #1440 flips the release profile to `panic = "unwind"`.
+///
+/// Not part of the stable public API; the leading underscore marks it as
+/// internal test support.
+#[pyfunction]
+fn _built_with_panic_abort() -> bool {
+    cfg!(panic = "abort")
+}
+
 /// Python module for CQLite.
 #[pymodule]
 fn _cqlite(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Register version info
     m.add("__version__", VERSION)?;
     m.add_function(wrap_pyfunction!(version, m)?)?;
+
+    // Test-support introspection (issue #1437). See the fn doc comment.
+    m.add_function(wrap_pyfunction!(_built_with_panic_abort, m)?)?;
 
     // Register exception types
     error::register_exceptions(m)?;

--- a/bindings/python/tests/corrupt_fixture.py
+++ b/bindings/python/tests/corrupt_fixture.py
@@ -1,0 +1,137 @@
+"""Runtime corrupt-SSTable fixture generation for the abort-safety harness.
+
+Issue #1437. No large binaries are committed to the repo. Given a temp dir,
+this module copies the real ``test_basic.simple_table`` SSTable directory and
+mutates ``nb-1-big-Data.db`` in one of two modes, both of which the harness
+exercises:
+
+- ``truncate``: copy the SSTable dir, then truncate ``nb-1-big-Data.db`` to
+  roughly 50% of its byte length.
+- ``bitflip``: copy the whole SSTable dir, then XOR ``0x01`` into a byte in the
+  middle of ``nb-1-big-Data.db``.
+
+The sibling ``-Statistics.db`` / ``-Index.db`` / ``-Summary.db`` /
+``-CompressionInfo.db`` / ``-TOC.txt`` components are kept intact so that
+``cqlite.open()`` proceeds far enough to actually read the corrupt Data.db
+during a scan (that is where the corrupt-input panic paths live).
+
+Dataset rule (issue #1437): if the real source Data.db is present but empty or
+unreadable, callers must FAIL LOUDLY — never skip. ``ensure_source_readable``
+raises so the pytest layer can turn that into a hard failure.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+KEYSPACE = "test_basic"
+TABLE = "simple_table"
+DATA_COMPONENT = "nb-1-big-Data.db"
+COMPRESSION_COMPONENT = "nb-1-big-CompressionInfo.db"
+TOC_COMPONENT = "nb-1-big-TOC.txt"
+MODES = ("truncate", "bitflip")
+
+# Do not copy the multi-megabyte derived JSONL golden; the reader only consults
+# the TOC-listed binary components. The small ``-TOC.txt`` MUST be kept (the
+# issue requires it), so we scope the ignore to the JSONL only.
+_IGNORE = shutil.ignore_patterns("*.jsonl")
+
+
+def source_table_dir(datasets_root: Path) -> Path | None:
+    """Return the real ``simple_table-<uuid>`` dir under ``datasets_root``.
+
+    ``datasets_root`` is the ``sstables/`` directory (the conftest ``DATASETS``
+    constant). Returns ``None`` when no matching table dir with a Data.db is
+    present (dataset simply not fetched).
+    """
+    ks_dir = Path(datasets_root) / KEYSPACE
+    if not ks_dir.is_dir():
+        return None
+    for candidate in sorted(ks_dir.glob(f"{TABLE}-*")):
+        if (candidate / DATA_COMPONENT).is_file():
+            return candidate
+    return None
+
+
+def ensure_source_readable(datasets_root: Path) -> Path:
+    """Return the source table dir or raise loudly when it is broken.
+
+    Raises ``FileNotFoundError`` when the dataset is absent (caller decides
+    skip-vs-fail) and ``ValueError`` when the Data.db is present but empty —
+    which is a corrupt fixture source, never a skip (issue #1437).
+    """
+    src = source_table_dir(datasets_root)
+    if src is None:
+        raise FileNotFoundError(
+            f"No {KEYSPACE}.{TABLE} SSTable with {DATA_COMPONENT} under {datasets_root}"
+        )
+    data = src / DATA_COMPONENT
+    if data.stat().st_size == 0:
+        raise ValueError(f"Source {data} is present but empty (corrupt dataset)")
+    return src
+
+
+def _drop_compression_info(dest_table: Path) -> None:
+    """Remove ``CompressionInfo.db`` (and its TOC line) from a copied table.
+
+    This forces the reader down the *uncompressed* Data.db path, which parses
+    raw VInt/row lengths directly. That is where the corrupt-input panics live
+    (ZigZag lengths etc.); with the compression sidecar present, the Snappy
+    decompression layer contains any corruption and the panics are never
+    reached. A missing/absent CompressionInfo.db is itself a plausible
+    real-world corruption, so this is a valid abort-safety scenario — not a
+    contrivance.
+    """
+    comp = dest_table / COMPRESSION_COMPONENT
+    if comp.exists():
+        comp.unlink()
+    toc = dest_table / TOC_COMPONENT
+    if toc.exists():
+        kept = [
+            line
+            for line in toc.read_text().splitlines()
+            if "CompressionInfo" not in line
+        ]
+        toc.write_text("\n".join(kept) + "\n")
+
+
+def make_corrupt_fixture(
+    dest_parent: Path,
+    datasets_root: Path,
+    mode: str,
+    *,
+    expose_uncompressed: bool = False,
+) -> Path:
+    """Build a corrupt copy of the SSTable under ``dest_parent`` and return the
+    ``sstables/`` root to pass to :func:`cqlite.open`.
+
+    ``mode`` is one of :data:`MODES`. When ``expose_uncompressed`` is True the
+    copy also drops ``CompressionInfo.db`` so the corrupt Data.db is read on the
+    raw (uncompressed) parse path — see :func:`_drop_compression_info`.
+    """
+    if mode not in MODES:
+        raise ValueError(f"unknown mode {mode!r}; expected one of {MODES}")
+
+    src = ensure_source_readable(datasets_root)
+    dest_root = Path(dest_parent) / "sstables"
+    dest_table = dest_root / KEYSPACE / src.name
+    shutil.copytree(src, dest_table, ignore=_IGNORE)
+
+    if expose_uncompressed:
+        _drop_compression_info(dest_table)
+
+    data = dest_table / DATA_COMPONENT
+    length = data.stat().st_size
+    if mode == "truncate":
+        with open(data, "r+b") as fh:
+            fh.truncate(length // 2)
+    else:  # bitflip
+        offset = length // 2
+        with open(data, "r+b") as fh:
+            fh.seek(offset)
+            (byte,) = fh.read(1)
+            fh.seek(offset)
+            fh.write(bytes([byte ^ 0x01]))
+
+    return dest_root

--- a/bindings/python/tests/test_abort_safety.py
+++ b/bindings/python/tests/test_abort_safety.py
@@ -1,0 +1,184 @@
+"""Abort-safety regression harness (issue #1437).
+
+Drives a corrupt/truncated SSTable through every Python entry point and proves
+the host interpreter SURVIVES: each call must terminate in a catchable state
+(a normal return, a ``cqlite.CqliteError``, or — under a ``panic=unwind``
+build — a caught panic surfaced as a Python exception) rather than aborting
+the process.
+
+Why a subprocess?  The workspace *release* profile is ``panic = "abort"``
+(``Cargo.toml``), so a panic inside ``cqlite-core`` during a scan through PyO3
+does not become a catchable exception — it kills the whole interpreter with a
+signal.  The only way to observe that kill as a test FAILURE (instead of the
+pytest runner itself dying) is to run each driver in a child process and assert
+the child exited 0 while emitting a terminal sentinel on stdout.
+
+DEBUG vs RELEASE (important):
+  Under the normal debug/test profile used by the agent gate, ``[profile.dev]``
+  is ``panic = "unwind"``, so PyO3 converts any core panic into a catchable
+  Python exception and the child survives — these tests therefore PASS
+  trivially in debug and do NOT by themselves prove the release guarantee.
+  The release-profile proof (flipping the release panic strategy so the same
+  child survives a *release* wheel) lands with issue #1440.  This harness is
+  the machinery that #1440 turns green on a release build; it FAILS on an
+  unmodified ``main`` release wheel because the abort kills the child.
+
+Two fixture flavors are exercised (see ``corrupt_fixture``):
+  * ``compressed`` — the exact issue recipe (mutate the Snappy-compressed
+    Data.db). The decompression layer contains the corruption, so all three
+    entry points survive today in BOTH debug and release. This proves graceful
+    containment on the compressed path.
+  * ``uncompressed`` — additionally drops ``CompressionInfo.db`` so the corrupt
+    bytes reach the raw VInt/row parser, which is where the audited
+    corrupt-input panics live. ``execute``/``streaming`` panic here: caught by
+    PyO3 under debug (survives, green) but SIGABRT under an unmodified ``main``
+    RELEASE wheel (this is the DoD "fails on release" proof); #1440 turns it
+    green on release too. ``parquet`` is intentionally NOT run on this flavor:
+    it triggers a SEPARATE non-panic HANG (infinite loop / pathological
+    allocation) that ``panic=unwind`` does not fix — reported for follow-up,
+    out of scope for this harness.
+
+These tests actually run and assert (no silent skip) whenever the dataset is
+present; a present-but-empty source Data.db FAILs loudly per issue #1437.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+
+import pytest
+
+from conftest import (
+    SCHEMA_BASIC_TYPES,
+    DATASETS,
+    _require_fixtures_strict,
+    skip_if_no_schema,
+)
+from corrupt_fixture import MODES, make_corrupt_fixture, source_table_dir
+
+# Entry points exercised per fixture. Each name selects a branch in the driver.
+ENTRY_POINTS = ("execute", "streaming", "parquet")
+
+# The child driver. Runs one entry point against a corrupt fixture and prints a
+# terminal sentinel. ``import cqlite`` sits OUTSIDE the try so a broken build
+# (ImportError) crashes non-zero and surfaces as a setup failure, never a false
+# green. A hard abort prints no terminal sentinel and exits with a signal.
+_DRIVER = r"""
+import sys, os, tempfile
+import cqlite
+
+root, schema, entry = sys.argv[1], sys.argv[2], sys.argv[3]
+QUERY = "SELECT * FROM test_basic.simple_table"
+try:
+    db = cqlite.open(root, schema=schema)
+    print("OPENED", flush=True)
+    if entry == "execute":
+        n = sum(1 for _ in db.execute(QUERY))
+        print("RETURNED rows=%d" % n, flush=True)
+    elif entry == "streaming":
+        n = sum(1 for _ in db.execute_streaming(QUERY))
+        print("RETURNED rows=%d" % n, flush=True)
+    elif entry == "parquet":
+        out = os.path.join(tempfile.mkdtemp(), "out.parquet")
+        rows = db.export_parquet(QUERY, out)
+        print("RETURNED rows=%d" % rows, flush=True)
+    else:
+        print("BADENTRY %s" % entry, flush=True)
+        raise SystemExit(3)
+except cqlite.CqliteError as exc:
+    print("RAISED_CQLITE %s" % type(exc).__name__, flush=True)
+except SystemExit:
+    raise
+except BaseException as exc:  # includes PyO3 PanicException under panic=unwind
+    print("RAISED_OTHER %s" % type(exc).__name__, flush=True)
+"""
+
+
+def _require_source_or_skip():
+    """FAIL loudly on a broken source, skip only when the dataset is absent."""
+    skip_if_no_schema(SCHEMA_BASIC_TYPES)
+    src = source_table_dir(DATASETS)
+    if src is None:
+        msg = f"No test_basic.simple_table SSTable under {DATASETS}"
+        if _require_fixtures_strict():
+            pytest.fail(msg, pytrace=False)
+        pytest.skip(msg)
+    data = src / "nb-1-big-Data.db"
+    if data.stat().st_size == 0:
+        pytest.fail(f"Source {data} present but empty (issue #1437)", pytrace=False)
+
+
+def _run_driver(mode, entry, *, expose_uncompressed):
+    with tempfile.TemporaryDirectory(prefix="cqlite-abort-") as tmp:
+        root = str(
+            make_corrupt_fixture(
+                tmp, DATASETS, mode, expose_uncompressed=expose_uncompressed
+            )
+        )
+        return subprocess.run(
+            [sys.executable, "-c", _DRIVER, root, str(SCHEMA_BASIC_TYPES), entry],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+
+
+@pytest.mark.parametrize("mode", MODES)
+@pytest.mark.parametrize("entry", ENTRY_POINTS)
+def test_compressed_corrupt_sstable_survives(mode, entry):
+    """Exact issue recipe: a corrupt compressed Data.db must not kill the host.
+
+    Green in both debug and release today (Snappy decompression contains the
+    corruption). Covers all three entry points and both mutation modes.
+    """
+    _require_source_or_skip()
+    result = _run_driver(mode, entry, expose_uncompressed=False)
+    ctx = (
+        f"mode={mode} entry={entry} rc={result.returncode}\n"
+        f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+    )
+    # Liveness: an abort exits with a signal (negative rc) or non-zero code.
+    assert result.returncode == 0, f"child process did not survive corrupt input\n{ctx}"
+    # And it reached a catchable terminal state rather than hanging or aborting
+    # silently. RAISED_OTHER (e.g. a PanicException under panic=unwind) still
+    # proves the boundary contained the panic and the process lived on — which
+    # is exactly the guarantee #1440 extends to release builds.
+    terminal = ("RETURNED", "RAISED_CQLITE", "RAISED_OTHER")
+    assert any(tok in result.stdout for tok in terminal), (
+        f"no terminal sentinel on stdout (possible abort/hang)\n{ctx}"
+    )
+
+
+# The uncompressed flavor reaches the raw-parser panic. parquet is excluded
+# because it hangs there (a separate non-panic bug); see the module docstring.
+@pytest.mark.parametrize("mode", MODES)
+@pytest.mark.parametrize("entry", ("execute", "streaming"))
+def test_uncompressed_corrupt_sstable_panic_is_contained(mode, entry):
+    """The raw parse path panics on corrupt input; the boundary must contain it.
+
+    RELEASE-vs-DEBUG: this ASSERTS the interpreter survives (rc==0). Under the
+    debug/test profile (``panic=unwind``) PyO3 converts the core panic into a
+    catchable ``PanicException`` and the child exits 0 -> PASS. Under an
+    unmodified ``main`` RELEASE wheel (``panic=abort``) the same panic raises
+    SIGABRT, the child dies with a signal, ``returncode != 0`` -> this test
+    FAILS. That failure is the point (issue #1437 DoD): it proves the harness
+    exercises a real abort. Issue #1440 flips the release panic strategy so
+    this goes green on release too.
+    """
+    _require_source_or_skip()
+    result = _run_driver(mode, entry, expose_uncompressed=True)
+    ctx = (
+        f"mode={mode} entry={entry} rc={result.returncode}\n"
+        f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+    )
+    assert result.returncode == 0, (
+        "child process aborted on corrupt input (expected on unmodified `main` "
+        "release; #1440 fixes it). If this failed under a DEBUG build the "
+        f"boundary regressed.\n{ctx}"
+    )
+    terminal = ("RETURNED", "RAISED_CQLITE", "RAISED_OTHER")
+    assert any(tok in result.stdout for tok in terminal), (
+        f"no terminal sentinel on stdout (possible abort/hang)\n{ctx}"
+    )

--- a/bindings/python/tests/test_abort_safety.py
+++ b/bindings/python/tests/test_abort_safety.py
@@ -153,6 +153,24 @@ def _require_source_or_skip():
         pytest.fail(f"Source {data} present but empty (issue #1437)", pytrace=False)
 
 
+def _reached_entry_point_call(result, entry):
+    """Whether the child emitted ``OPENED`` then ``CALLING <entry>`` IN ORDER.
+
+    Uses the SAME ordering sentinels the survival path asserts, but WITHOUT
+    requiring a terminal sentinel (an abort prints none). Returns True only when
+    the child proved it opened the DB and then invoked the corrupt-input entry
+    point -- distinguishing a genuine post-call abort from a setup/open/lookup
+    failure that ALSO exits non-zero but never reaches the entry point.
+    """
+    lines = result.stdout.splitlines()
+    if "OPENED" not in lines:
+        return False
+    calling = "CALLING %s" % entry
+    if calling not in lines:
+        return False
+    return lines.index(calling) > lines.index("OPENED")
+
+
 def _assert_drove_entry_point(result, entry, ctx):
     """Prove corrupt input was driven THROUGH the entry point.
 
@@ -268,6 +286,20 @@ def test_uncompressed_corrupt_sstable_panic_is_contained(mode, entry):
     if _PANIC_ABORT:
         # release=abort, pre-#1440. Strict xfail scoped to the rc assertion only.
         if result.returncode != 0:
+            # A non-zero exit is the EXPECTED abort ONLY if it happened AFTER the
+            # child opened the DB and reached the entry-point call. A non-zero
+            # exit lacking the ``OPENED``/``CALLING <entry>`` ordering sentinels
+            # is a setup/import/open/API-lookup failure that never drove corrupt
+            # input through the boundary -- that must hard-FAIL, never masquerade
+            # as the expected abort (false-green on the release harness).
+            if not _reached_entry_point_call(result, entry):
+                pytest.fail(
+                    "child exited non-zero WITHOUT reaching the entry point "
+                    f"(missing OPENED/CALLING {entry}): a setup/open/lookup "
+                    "failure, not the expected post-call abort.\n"
+                    f"{ctx}",
+                    pytrace=False,
+                )
             pytest.xfail(
                 "corrupt uncompressed SSTable aborts the interpreter until "
                 f"#1440 lands panic=unwind (#1437)\n{ctx}"

--- a/bindings/python/tests/test_abort_safety.py
+++ b/bindings/python/tests/test_abort_safety.py
@@ -222,27 +222,27 @@ def test_compressed_corrupt_sstable_survives(mode, entry):
 # The uncompressed flavor reaches the raw-parser panic. parquet is excluded
 # because it hangs there (a separate non-panic bug); see the module docstring.
 #
-# CONDITIONAL STRICT XFAIL (issue #1437): the marker is keyed on the ACTUAL
-# compiled panic strategy of the loaded wheel.
-#   * condition False (debug/unwind, or a post-#1440 release=unwind wheel):
-#     marker inactive -> these cases hard-assert the interpreter SURVIVES
-#     (rc==0) and must PASS. This preserves the gate's teeth: a boundary
-#     regression under an unwind build is still a hard FAIL.
-#   * condition True (release=abort, pre-#1440): the corrupt uncompressed
-#     SSTable aborts the interpreter (SIGABRT, rc!=0). A `strict` xfail records
-#     that expected failure as green -- and would flip to a hard failure the
-#     moment the case unexpectedly starts surviving.
+# CONDITIONAL STRICT XFAIL, applied IMPERATIVELY (issue #1437, roborev fix): the
+# expected-abort logic is keyed on the ACTUAL compiled panic strategy of the
+# loaded wheel and scoped to JUST the child-survival (rc==0) assertion -- it is
+# deliberately NOT a function-level ``@pytest.mark.xfail`` decorator. A decorator
+# marker masks EVERY exception in the test's setup AND call phase (verified:
+# both a fixture failure and a call-phase ``pytest.fail`` are swallowed as
+# XFAIL), which would let a fail-closed dataset gate (missing datasets under
+# ``CQLITE_REQUIRE_FIXTURES=1``) be silently recorded as an expected xfail
+# instead of the hard failure it must be. By running ``_require_source_or_skip``
+# first (unmasked) and only then branching on the compiled panic strategy, a
+# strict fixture failure stays a real error/skip while the rc-survival keeps
+# strict xfail semantics:
+#   * debug/unwind, or a post-#1440 release=unwind wheel (`_PANIC_ABORT` False):
+#     no xfail branch -> hard-assert the interpreter SURVIVES (rc==0) and PASS.
+#     Preserves the gate's teeth: a boundary regression under unwind is a FAIL.
+#   * release=abort, pre-#1440 (`_PANIC_ABORT` True): a dead child (rc!=0) is the
+#     expected abort -> ``pytest.xfail`` (green); an unexpectedly SURVIVING child
+#     (rc==0) is a hard FAIL, mirroring ``strict=True`` XPASS.
 # Once #1440 flips the release profile to `panic = "unwind"`,
-# `_built_with_panic_abort()` goes False on every wheel, the marker deactivates,
-# and these cases hard-assert again -- self-cleaning, no follow-up edit needed.
-@pytest.mark.xfail(
-    _PANIC_ABORT,
-    strict=True,
-    reason=(
-        "corrupt uncompressed SSTable aborts the interpreter until #1440 lands "
-        "panic=unwind (#1437)"
-    ),
-)
+# `_built_with_panic_abort()` goes False on every wheel, the abort branch never
+# fires, and these cases hard-assert again -- self-cleaning, no follow-up edit.
 @pytest.mark.parametrize("mode", MODES)
 @pytest.mark.parametrize("entry", ("execute", "streaming"))
 def test_uncompressed_corrupt_sstable_panic_is_contained(mode, entry):
@@ -252,20 +252,36 @@ def test_uncompressed_corrupt_sstable_panic_is_contained(mode, entry):
     debug/test profile (``panic=unwind``) PyO3 converts the core panic into a
     catchable ``PanicException`` and the child exits 0 -> PASS. Under an
     unmodified ``main`` RELEASE wheel (``panic=abort``) the same panic raises
-    SIGABRT, the child dies with a signal, ``returncode != 0`` -> this test
-    FAILS. That failure is the point (issue #1437 DoD): it proves the harness
-    exercises a real abort. Issue #1440 flips the release panic strategy so
-    this goes green on release too.
+    SIGABRT, the child dies with a signal, ``returncode != 0`` -> this case is
+    an expected (strict) xfail. That expected abort is the point (issue #1437
+    DoD): it proves the harness exercises a real abort. Issue #1440 flips the
+    release panic strategy so this goes green on release too.
     """
+    # Dataset/schema gating runs FIRST and UNMASKED: a strict fail-closed
+    # dataset failure here is a hard error, never swallowed as an expected xfail.
     _require_source_or_skip()
     result = _run_driver(mode, entry, expose_uncompressed=True)
     ctx = (
         f"mode={mode} entry={entry} rc={result.returncode}\n"
         f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
     )
+    if _PANIC_ABORT:
+        # release=abort, pre-#1440. Strict xfail scoped to the rc assertion only.
+        if result.returncode != 0:
+            pytest.xfail(
+                "corrupt uncompressed SSTable aborts the interpreter until "
+                f"#1440 lands panic=unwind (#1437)\n{ctx}"
+            )
+        # Child unexpectedly survived on an abort wheel -> strict XPASS = FAIL.
+        pytest.fail(
+            "child survived corrupt input on a panic=abort wheel: the abort "
+            "boundary unexpectedly held. Remove the abort xfail branch (#1440 "
+            f"may have landed early).\n{ctx}",
+            pytrace=False,
+        )
+    # unwind build: the boundary MUST contain the panic and the child MUST live.
     assert result.returncode == 0, (
-        "child process aborted on corrupt input (expected on unmodified `main` "
-        "release; #1440 fixes it). If this failed under a DEBUG build the "
-        f"boundary regressed.\n{ctx}"
+        "child process aborted on corrupt input under a DEBUG/unwind build -- "
+        f"the boundary regressed.\n{ctx}"
     )
     _assert_drove_entry_point(result, entry, ctx)

--- a/bindings/python/tests/test_abort_safety.py
+++ b/bindings/python/tests/test_abort_safety.py
@@ -62,37 +62,59 @@ from corrupt_fixture import MODES, make_corrupt_fixture, source_table_dir
 ENTRY_POINTS = ("execute", "streaming", "parquet")
 
 # The child driver. Runs one entry point against a corrupt fixture and prints a
-# terminal sentinel. ``import cqlite`` sits OUTSIDE the try so a broken build
-# (ImportError) crashes non-zero and surfaces as a setup failure, never a false
-# green. A hard abort prints no terminal sentinel and exits with a signal.
+# terminal sentinel. Setup -- ``import cqlite``, ``cqlite.open``, and the
+# entry-method lookup -- sits OUTSIDE the success ``try``: a broken build
+# (ImportError), missing schema, failed ``open``, or a renamed/absent API method
+# crashes non-zero and surfaces as a setup failure, never a false-green
+# ``RAISED_*``. Only an EXPECTED native error thrown FROM the entry-point call
+# (``cqlite.CqliteError`` or a PyO3 ``PanicException`` under panic=unwind) is
+# accepted as a terminal ``RAISED_*``; any other exception re-raises and aborts
+# non-zero. The driver emits ``OPENED`` then ``CALLING <entry>`` before any
+# terminal sentinel so the parent can prove corrupt input was driven through the
+# entry point. A hard abort prints no terminal sentinel and exits with a signal.
 _DRIVER = r"""
 import sys, os, tempfile
 import cqlite
 
 root, schema, entry = sys.argv[1], sys.argv[2], sys.argv[3]
 QUERY = "SELECT * FROM test_basic.simple_table"
-try:
-    db = cqlite.open(root, schema=schema)
-    print("OPENED", flush=True)
+
+# entry name -> underlying Database method that must exist on the instance.
+METHODS = {"execute": "execute", "streaming": "execute_streaming", "parquet": "export_parquet"}
+
+# --- setup: NOT catchable as success ---
+db = cqlite.open(root, schema=schema)
+print("OPENED", flush=True)
+
+method_name = METHODS.get(entry)
+if method_name is None or not callable(getattr(db, method_name, None)):
+    print("BADENTRY %s" % entry, flush=True)
+    raise SystemExit(3)
+
+
+def _call():
     if entry == "execute":
-        n = sum(1 for _ in db.execute(QUERY))
-        print("RETURNED rows=%d" % n, flush=True)
-    elif entry == "streaming":
-        n = sum(1 for _ in db.execute_streaming(QUERY))
-        print("RETURNED rows=%d" % n, flush=True)
-    elif entry == "parquet":
-        out = os.path.join(tempfile.mkdtemp(), "out.parquet")
-        rows = db.export_parquet(QUERY, out)
-        print("RETURNED rows=%d" % rows, flush=True)
-    else:
-        print("BADENTRY %s" % entry, flush=True)
-        raise SystemExit(3)
+        return sum(1 for _ in db.execute(QUERY))
+    if entry == "streaming":
+        return sum(1 for _ in db.execute_streaming(QUERY))
+    out = os.path.join(tempfile.mkdtemp(), "out.parquet")
+    return db.export_parquet(QUERY, out)
+
+
+print("CALLING %s" % entry, flush=True)
+# --- ONLY the entry-point call is catchable as success ---
+try:
+    n = _call()
+    print("RETURNED rows=%d" % n, flush=True)
 except cqlite.CqliteError as exc:
     print("RAISED_CQLITE %s" % type(exc).__name__, flush=True)
-except SystemExit:
-    raise
-except BaseException as exc:  # includes PyO3 PanicException under panic=unwind
-    print("RAISED_OTHER %s" % type(exc).__name__, flush=True)
+except BaseException as exc:
+    # Accept ONLY a PyO3 PanicException (the panic=unwind containment path).
+    # Any other unexpected exception must NOT read as a passing terminal state.
+    if type(exc).__name__ == "PanicException":
+        print("RAISED_OTHER %s" % type(exc).__name__, flush=True)
+    else:
+        raise
 """
 
 
@@ -108,6 +130,33 @@ def _require_source_or_skip():
     data = src / "nb-1-big-Data.db"
     if data.stat().st_size == 0:
         pytest.fail(f"Source {data} present but empty (issue #1437)", pytrace=False)
+
+
+def _assert_drove_entry_point(result, entry, ctx):
+    """Prove corrupt input was driven THROUGH the entry point.
+
+    The driver must have emitted ``OPENED`` then ``CALLING <entry>`` before any
+    terminal sentinel. This defeats a false-green where a setup/open/lookup
+    failure would otherwise surface as a passing ``RAISED_*``.
+    """
+    lines = result.stdout.splitlines()
+    assert "OPENED" in lines, f"driver never opened the DB (setup failed?)\n{ctx}"
+    calling = "CALLING %s" % entry
+    assert calling in lines, f"driver never reached the {entry} entry point\n{ctx}"
+    opened_idx = lines.index("OPENED")
+    calling_idx = lines.index(calling)
+    assert calling_idx > opened_idx, f"CALLING before OPENED\n{ctx}"
+    terminal = ("RETURNED", "RAISED_CQLITE", "RAISED_OTHER")
+    term_idx = next(
+        (i for i, ln in enumerate(lines) if any(ln.startswith(t) for t in terminal)),
+        None,
+    )
+    assert term_idx is not None, (
+        f"no terminal sentinel on stdout (possible abort/hang)\n{ctx}"
+    )
+    assert term_idx > calling_idx, (
+        f"terminal sentinel appeared before the entry-point call\n{ctx}"
+    )
 
 
 def _run_driver(mode, entry, *, expose_uncompressed):
@@ -142,13 +191,11 @@ def test_compressed_corrupt_sstable_survives(mode, entry):
     # Liveness: an abort exits with a signal (negative rc) or non-zero code.
     assert result.returncode == 0, f"child process did not survive corrupt input\n{ctx}"
     # And it reached a catchable terminal state rather than hanging or aborting
-    # silently. RAISED_OTHER (e.g. a PanicException under panic=unwind) still
-    # proves the boundary contained the panic and the process lived on — which
-    # is exactly the guarantee #1440 extends to release builds.
-    terminal = ("RETURNED", "RAISED_CQLITE", "RAISED_OTHER")
-    assert any(tok in result.stdout for tok in terminal), (
-        f"no terminal sentinel on stdout (possible abort/hang)\n{ctx}"
-    )
+    # silently -- AFTER actually driving corrupt input through the entry point.
+    # RAISED_OTHER (e.g. a PanicException under panic=unwind) still proves the
+    # boundary contained the panic and the process lived on — which is exactly
+    # the guarantee #1440 extends to release builds.
+    _assert_drove_entry_point(result, entry, ctx)
 
 
 # The uncompressed flavor reaches the raw-parser panic. parquet is excluded
@@ -178,7 +225,4 @@ def test_uncompressed_corrupt_sstable_panic_is_contained(mode, entry):
         "release; #1440 fixes it). If this failed under a DEBUG build the "
         f"boundary regressed.\n{ctx}"
     )
-    terminal = ("RETURNED", "RAISED_CQLITE", "RAISED_OTHER")
-    assert any(tok in result.stdout for tok in terminal), (
-        f"no terminal sentinel on stdout (possible abort/hang)\n{ctx}"
-    )
+    _assert_drove_entry_point(result, entry, ctx)

--- a/bindings/python/tests/test_abort_safety.py
+++ b/bindings/python/tests/test_abort_safety.py
@@ -50,6 +50,8 @@ import tempfile
 
 import pytest
 
+import cqlite
+
 from conftest import (
     SCHEMA_BASIC_TYPES,
     DATASETS,
@@ -60,6 +62,25 @@ from corrupt_fixture import MODES, make_corrupt_fixture, source_table_dir
 
 # Entry points exercised per fixture. Each name selects a branch in the driver.
 ENTRY_POINTS = ("execute", "streaming", "parquet")
+
+
+def _built_with_panic_abort() -> bool:
+    """Whether the loaded wheel was compiled with ``panic = "abort"``.
+
+    Delegates to the ``cqlite._built_with_panic_abort`` introspection helper
+    (issue #1437), which reports the ACTUAL compiled panic strategy via
+    ``cfg!(panic = "abort")``. Guarded so this file still collects against an
+    older wheel that predates the symbol: a missing symbol is treated as "not
+    abort", i.e. the survival cases below hard-assert (preserving the gate's
+    teeth) rather than silently xfailing.
+    """
+    probe = getattr(cqlite, "_built_with_panic_abort", None)
+    return bool(probe()) if callable(probe) else False
+
+
+# True only on a `panic = "abort"` wheel (release, pre-#1440). See the marker
+# rationale on the uncompressed test below.
+_PANIC_ABORT = _built_with_panic_abort()
 
 # The child driver. Runs one entry point against a corrupt fixture and prints a
 # terminal sentinel. Setup -- ``import cqlite``, ``cqlite.open``, and the
@@ -200,6 +221,28 @@ def test_compressed_corrupt_sstable_survives(mode, entry):
 
 # The uncompressed flavor reaches the raw-parser panic. parquet is excluded
 # because it hangs there (a separate non-panic bug); see the module docstring.
+#
+# CONDITIONAL STRICT XFAIL (issue #1437): the marker is keyed on the ACTUAL
+# compiled panic strategy of the loaded wheel.
+#   * condition False (debug/unwind, or a post-#1440 release=unwind wheel):
+#     marker inactive -> these cases hard-assert the interpreter SURVIVES
+#     (rc==0) and must PASS. This preserves the gate's teeth: a boundary
+#     regression under an unwind build is still a hard FAIL.
+#   * condition True (release=abort, pre-#1440): the corrupt uncompressed
+#     SSTable aborts the interpreter (SIGABRT, rc!=0). A `strict` xfail records
+#     that expected failure as green -- and would flip to a hard failure the
+#     moment the case unexpectedly starts surviving.
+# Once #1440 flips the release profile to `panic = "unwind"`,
+# `_built_with_panic_abort()` goes False on every wheel, the marker deactivates,
+# and these cases hard-assert again -- self-cleaning, no follow-up edit needed.
+@pytest.mark.xfail(
+    _PANIC_ABORT,
+    strict=True,
+    reason=(
+        "corrupt uncompressed SSTable aborts the interpreter until #1440 lands "
+        "panic=unwind (#1437)"
+    ),
+)
 @pytest.mark.parametrize("mode", MODES)
 @pytest.mark.parametrize("entry", ("execute", "streaming"))
 def test_uncompressed_corrupt_sstable_panic_is_contained(mode, entry):


### PR DESCRIPTION
Closes #1437.

## What
Abort-safety regression harness: drives corrupt SSTables (truncate + bit-flip of `Data.db`) through both bindings across `execute`/streaming/parquet entry points, in a **subprocess** so a `panic=abort` kill is observed as a test failure (non-zero exit) rather than the runner dying.

**Harness only — no production code touched.** The panic profile firewall (`panic=unwind`) lands in #1440.

## Files
- `bindings/python/tests/corrupt_fixture.py`, `bindings/python/tests/test_abort_safety.py`
- `bindings/node/__test__/corrupt-fixture.js`, `bindings/node/__test__/abort-safety.test.js`

## Proof it does its job
- **Debug wheel/module** (gate profile, `panic=unwind`): all harness tests pass (panics caught, process survives).
- **Release wheel** (`panic=abort`): Python's 4 uncompressed-path cases fail with child SIGABRT — the DoD "fails on unmodified `main` release" proof. #1440 flips these green.

## Gate: PASS (all components; no flakes)

## HOLD
Per manager order (`MGR:mba-pmcfadin-pmcfad`, ORDER 12): **HOLD merge until #1440's `panic=unwind` profile lands.** Armed merge-on-green is gated behind #1440.

## Scope-adjacent findings (filed separately, NOT fixed here)
Uncovered while building the harness — these mean **#1440's profile alone will not fully close the guarantee**:
1. Node raw-parse path aborts even under an unwind build — `bindings/node/src/value.rs:266` uses an unbounded padding width from a corrupt DECIMAL `scale`, and the panic on the napi async-worker thread cannot unwind across the FFI boundary. Needs `scale` bounded + `catch_unwind` at the napi boundary.
2. `export_parquet`/`exportParquet` **hangs** (non-panic infinite loop / pathological alloc) on raw-path corruption — `panic=unwind` cannot fix a hang.
3. Premise correction: mutating the *compressed* `Data.db` never reaches the audited ZigZag/row panic paths (Snappy contains the corruption); reaching them requires the uncompressed read path (missing `CompressionInfo.db`), which the Python harness exercises via `expose_uncompressed`.
