### PR TITLE
feat(#1749): per-surface SSTable freshness contract + explicit Database::refresh()

### DIFF
--- a/bindings/node/__test__/refresh.test.js
+++ b/bindings/node/__test__/refresh.test.js
@@ -1,0 +1,265 @@
+/**
+ * End-to-end tests for `Database.refresh()` (issue #1749).
+ *
+ * These drive the full stale -> refresh -> fresh cycle through the Node public
+ * API (`Database.open`, `db.execute`, `db.executeNative`, `db.refresh`) against
+ * REAL SSTable binaries.
+ *
+ * Fixture strategy (mirrors the Python binding test and the Rust integration
+ * test): the two SSTable generations are built IN-TEST with CQLite's own write
+ * path (writable `Database.open` + INSERT + `flushRun`) — `nb-1-big-*` holds
+ * only partition `id=1` and `nb-2-big-*` holds only `id=2`. Because the
+ * generations are generated here rather than fetched, there is NO skip path: a
+ * write-path failure fails the test, every id-set assertion is exact (never
+ * `>= 0`), and each copy asserts it moved at least one component file. A
+ * 0-rows-on-present-data regression therefore fails loudly instead of silently
+ * passing.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { Database } = require('../lib/index.js');
+
+const KEYSPACE = 'test_freshness';
+const TABLE = 'users';
+const SCHEMA = `CREATE TABLE ${KEYSPACE}.${TABLE} (id int PRIMARY KEY, value text);`;
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+/** Create a fresh temp root and register it for cleanup. */
+function makeRoot(cleanups) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cqlite-refresh-test-'));
+  cleanups.push(() => fs.rmSync(root, { recursive: true, force: true }));
+  return root;
+}
+
+/** Write the single-table schema used by the write engine and readers. */
+function writeSchema(root) {
+  const schemaPath = path.join(root, 'users.cql');
+  fs.writeFileSync(schemaPath, SCHEMA);
+  return schemaPath;
+}
+
+/**
+ * Build a source table dir with two SSTable generations.
+ *
+ * Each `flushRun()` of a single writable database advances the generation:
+ * `nb-1-big-*` contains only partition `id=1` and `nb-2-big-*` only `id=2`.
+ * Returns the `.../data/<keyspace>/<table>` directory containing both.
+ */
+async function buildTwoGenerations(root, schema) {
+  // The read side of a writable open still requires an existing data dir.
+  const readDir = path.join(root, 'src_read');
+  fs.mkdirSync(readDir);
+  const writeDir = path.join(root, 'src_write');
+
+  const db = await Database.open(readDir, {
+    schema,
+    writable: true,
+    writeDir,
+  });
+  try {
+    for (const genId of [1, 2]) {
+      await db.execute(
+        `INSERT INTO ${KEYSPACE}.${TABLE} (id, value) VALUES (${genId}, 'v${genId}')`
+      );
+      const flushed = await db.flushRun();
+      expect(flushed).toBeTruthy(); // flush produced an SSTable path
+    }
+  } finally {
+    await db.close();
+  }
+
+  const tableDir = path.join(writeDir, 'data', KEYSPACE, TABLE);
+  expect(fs.existsSync(path.join(tableDir, 'nb-1-big-Data.db'))).toBe(true);
+  expect(fs.existsSync(path.join(tableDir, 'nb-2-big-Data.db'))).toBe(true);
+  return tableDir;
+}
+
+/**
+ * Copy every `nb-<gen>-big-*` component into `dstTableDir`.
+ * Returns the count copied (asserted > 0 so a path regression fails loudly).
+ */
+function copyGeneration(srcTableDir, dstTableDir, gen) {
+  fs.mkdirSync(dstTableDir, { recursive: true });
+  const prefix = `nb-${gen}-big-`;
+  let copied = 0;
+  for (const name of fs.readdirSync(srcTableDir)) {
+    if (name.startsWith(prefix)) {
+      fs.copyFileSync(
+        path.join(srcTableDir, name),
+        path.join(dstTableDir, name)
+      );
+      copied += 1;
+    }
+  }
+  expect(copied).toBeGreaterThan(0);
+  return copied;
+}
+
+/** Delete every `nb-<gen>-big-*` component (simulated compaction). */
+function deleteGeneration(tableDir, gen) {
+  const prefix = `nb-${gen}-big-`;
+  let removed = 0;
+  for (const name of fs.readdirSync(tableDir)) {
+    if (name.startsWith(prefix)) {
+      fs.unlinkSync(path.join(tableDir, name));
+      removed += 1;
+    }
+  }
+  expect(removed).toBeGreaterThan(0);
+  return removed;
+}
+
+/** The set of `id` partition-key values in `SELECT *` (native int -> number). */
+async function selectAllIds(db) {
+  const res = await db.executeNative(`SELECT * FROM ${KEYSPACE}.${TABLE}`);
+  return new Set(res.rows.map((row) => Number(row.id)));
+}
+
+/** Assert two Sets contain exactly the same numeric members. */
+function expectIds(actual, expected) {
+  expect([...actual].sort((a, b) => a - b)).toEqual(
+    [...expected].sort((a, b) => a - b)
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Database.refresh() end-to-end (issue #1749)', () => {
+  let cleanups;
+
+  beforeEach(() => {
+    cleanups = [];
+  });
+
+  afterEach(async () => {
+    for (const fn of cleanups.reverse()) {
+      try {
+        await fn();
+      } catch (_) {
+        // ignore cleanup errors
+      }
+    }
+  });
+
+  test('new generation invisible until refresh, visible after (readersAdded === 1)', async () => {
+    const root = makeRoot(cleanups);
+    const schema = writeSchema(root);
+    const srcTableDir = await buildTwoGenerations(root, schema);
+
+    // Live directory starts with ONLY generation 1 (partition id=1).
+    const live = path.join(root, 'live');
+    const liveTableDir = path.join(live, KEYSPACE, TABLE);
+    copyGeneration(srcTableDir, liveTableDir, 1);
+
+    const db = await Database.open(live, { schema });
+    cleanups.push(() => db.close());
+
+    const before = await selectAllIds(db);
+    expectIds(before, new Set([1])); // only gen-1 partition visible at open
+
+    // Copy in generation 2 (partition id=2) but do NOT refresh yet.
+    copyGeneration(srcTableDir, liveTableDir, 2);
+    expectIds(await selectAllIds(db), new Set([1])); // stale-until-refresh
+
+    const report = await db.refresh();
+    expect(report.readersAdded).toBe(1);
+    expect(report.readersRemoved).toBe(0);
+    expect(report.tablesScanned).toBeGreaterThanOrEqual(1);
+
+    // New generation's partition is now visible.
+    expectIds(await selectAllIds(db), new Set([1, 2]));
+  });
+
+  test('removed generation dropped on refresh (readersRemoved === 1)', async () => {
+    const root = makeRoot(cleanups);
+    const schema = writeSchema(root);
+    const srcTableDir = await buildTwoGenerations(root, schema);
+
+    const live = path.join(root, 'live');
+    const liveTableDir = path.join(live, KEYSPACE, TABLE);
+    copyGeneration(srcTableDir, liveTableDir, 1);
+    copyGeneration(srcTableDir, liveTableDir, 2);
+
+    const db = await Database.open(live, { schema });
+    cleanups.push(() => db.close());
+
+    expectIds(await selectAllIds(db), new Set([1, 2])); // both visible at open
+
+    deleteGeneration(liveTableDir, 2);
+    const report = await db.refresh();
+    expect(report.readersRemoved).toBe(1);
+    expect(report.readersAdded).toBe(0);
+
+    // Only the remaining generation's partition after removal.
+    expectIds(await selectAllIds(db), new Set([1]));
+  });
+
+  test('unchanged directory is a zero-delta no-op', async () => {
+    const root = makeRoot(cleanups);
+    const schema = writeSchema(root);
+    const srcTableDir = await buildTwoGenerations(root, schema);
+
+    const live = path.join(root, 'live');
+    const liveTableDir = path.join(live, KEYSPACE, TABLE);
+    copyGeneration(srcTableDir, liveTableDir, 1);
+
+    const db = await Database.open(live, { schema });
+    cleanups.push(() => db.close());
+
+    const before = await selectAllIds(db);
+
+    const report = await db.refresh();
+    expect(report.readersAdded).toBe(0);
+    expect(report.readersRemoved).toBe(0);
+
+    expectIds(await selectAllIds(db), before); // result unchanged by no-op
+  });
+
+  test('RefreshReport exposes camelCase count fields', async () => {
+    const root = makeRoot(cleanups);
+    const schema = writeSchema(root);
+    const srcTableDir = await buildTwoGenerations(root, schema);
+
+    const live = path.join(root, 'live');
+    const liveTableDir = path.join(live, KEYSPACE, TABLE);
+    copyGeneration(srcTableDir, liveTableDir, 1);
+
+    const db = await Database.open(live, { schema });
+    cleanups.push(() => db.close());
+
+    copyGeneration(srcTableDir, liveTableDir, 2);
+    const report = await db.refresh();
+
+    // Exactly the camelCase surface documented in index.d.ts.
+    expect(Object.keys(report).sort()).toEqual([
+      'readersAdded',
+      'readersRemoved',
+      'tablesScanned',
+    ]);
+    expect(typeof report.readersAdded).toBe('number');
+    expect(report.readersAdded).toBe(1);
+    expect(report.readersRemoved).toBe(0);
+  });
+
+  test('refresh() on a closed database rejects', async () => {
+    const root = makeRoot(cleanups);
+    const schema = writeSchema(root);
+    const srcTableDir = await buildTwoGenerations(root, schema);
+
+    const live = path.join(root, 'live');
+    const liveTableDir = path.join(live, KEYSPACE, TABLE);
+    copyGeneration(srcTableDir, liveTableDir, 1);
+
+    const db = await Database.open(live, { schema });
+    await db.close();
+
+    await expect(db.refresh()).rejects.toThrow(/closed/i);
+  });
+});

--- a/bindings/node/__test__/typescript-definitions.test.js
+++ b/bindings/node/__test__/typescript-definitions.test.js
@@ -71,6 +71,10 @@ describe('TypeScript Definitions (Issue #312)', () => {
       expect(dtsContent).toMatch(/export\s+interface\s+DatabaseStats\b/);
     });
 
+    test('should export RefreshReport interface (issue #1749)', () => {
+      expect(dtsContent).toMatch(/export\s+interface\s+RefreshReport\b/);
+    });
+
     test('should export DatabaseOptions interface', () => {
       expect(dtsContent).toMatch(/export\s+interface\s+DatabaseOptions\b/);
     });
@@ -123,6 +127,10 @@ describe('TypeScript Definitions (Issue #312)', () => {
 
     test('should have getStats method', () => {
       expect(dtsContent).toMatch(/getStats\s*\(\s*\)\s*:\s*Promise\s*<\s*DatabaseStats\s*>/);
+    });
+
+    test('should have refresh method (issue #1749)', () => {
+      expect(dtsContent).toMatch(/refresh\s*\(\s*\)\s*:\s*Promise\s*<\s*RefreshReport\s*>/);
     });
 
     test('should have close method', () => {

--- a/bindings/node/lib/error-wrapper.js
+++ b/bindings/node/lib/error-wrapper.js
@@ -229,6 +229,25 @@ function createWrappedDatabase(NativeDatabase, wrapPreparedStatement) {
       }
     }
 
+    /**
+     * Re-discover the data directory and apply changes to the held reader set.
+     *
+     * Newly present SSTable generations become queryable, removed generations
+     * stop being queried, and unchanged generations keep their warm parsed
+     * state. In-flight queries are unaffected; the refresh is atomic and
+     * fail-closed. See index.d.ts for the full contract (issue #1749).
+     *
+     * @returns {Promise<Object>} RefreshReport with tablesScanned, readersAdded, readersRemoved
+     * @throws {CqliteError} If the database is closed or a new generation fails to open
+     */
+    async refresh() {
+      try {
+        return await this._native.refresh();
+      } catch (error) {
+        throw enhanceError(error);
+      }
+    }
+
     async close() {
       try {
         return await this._native.close();

--- a/bindings/node/lib/index.d.ts
+++ b/bindings/node/lib/index.d.ts
@@ -577,7 +577,7 @@ export interface MaintenanceReport {
  * ```
  */
 export interface RefreshReport {
-  /** Number of table directories re-discovered during the refresh. */
+  /** Number of distinct logical tables present after the refresh. */
   tablesScanned: number;
 
   /** Number of SSTable generations newly opened and made queryable. */

--- a/bindings/node/lib/index.d.ts
+++ b/bindings/node/lib/index.d.ts
@@ -560,6 +560,34 @@ export interface MaintenanceReport {
 }
 
 /**
+ * Report returned by `Database.refresh()`.
+ *
+ * Describes what an explicit directory refresh applied to the database's held
+ * SSTable reader set: newly present generations become queryable, removed
+ * generations stop being queried, and unchanged generations keep their warm
+ * parsed state (they are not re-parsed).
+ *
+ * @example
+ * ```typescript
+ * const report = await db.refresh();
+ * console.log(
+ *   `scanned ${report.tablesScanned} tables, ` +
+ *   `+${report.readersAdded}/-${report.readersRemoved} readers`
+ * );
+ * ```
+ */
+export interface RefreshReport {
+  /** Number of table directories re-discovered during the refresh. */
+  tablesScanned: number;
+
+  /** Number of SSTable generations newly opened and made queryable. */
+  readersAdded: number;
+
+  /** Number of SSTable generations dropped from the reader set. */
+  readersRemoved: number;
+}
+
+/**
  * Configuration for streaming query execution.
  *
  * Controls memory usage during large result set iteration.
@@ -1010,6 +1038,35 @@ export declare class Database {
    * ```
    */
   getStats(): Promise<DatabaseStats>;
+
+  /**
+   * Re-discover the data directory and apply changes to the held reader set.
+   *
+   * A `Database` is a snapshot at `open()`: a Cassandra flush/compaction (or a
+   * CQLite `--flush`) may add or remove SSTable generations under a warm handle,
+   * and those changes become queryable only after an explicit `refresh()`. This
+   * re-runs the same TOC/filename-based discovery `open()` used (no content
+   * sniffing, no heuristics) and applies the diff:
+   * - newly present generations become queryable,
+   * - removed generations stop being queried,
+   * - unchanged generations keep their warm parsed Index/Statistics/bloom state.
+   *
+   * In-flight queries are never affected: a scan already running completes
+   * against the pre-refresh set; a query issued after this Promise resolves sees
+   * the post-refresh set. The refresh is atomic and fail-closed — if any newly
+   * discovered generation fails to open (e.g. a corrupt `Statistics.db`), the
+   * Promise rejects and the previously held reader set is left unchanged.
+   *
+   * @returns Promise resolving to a RefreshReport with the applied counts
+   * @throws {CqliteError} If the database is closed or a new generation fails to open
+   *
+   * @example
+   * ```typescript
+   * const report = await db.refresh();
+   * console.log(`+${report.readersAdded}/-${report.readersRemoved} readers`);
+   * ```
+   */
+  refresh(): Promise<RefreshReport>;
 
   /**
    * Close the database and release resources.

--- a/bindings/node/src/database.rs
+++ b/bindings/node/src/database.rs
@@ -363,7 +363,7 @@ impl ParquetExportOptions {
 /// The write engine is protected by an Arc<Mutex> and only one write can proceed at a time.
 #[napi]
 pub struct Database {
-    inner: Arc<cqlite_core::Database>,
+    pub(crate) inner: Arc<cqlite_core::Database>,
     closed: AtomicBool,
     /// Default incoming W3C `traceparent` for this handle's per-call spans
     /// (issue #1040). `None` when not supplied or invalid.
@@ -382,7 +382,7 @@ pub struct Database {
 
 impl Database {
     /// Check if database is open, returning error if closed.
-    fn ensure_open(&self) -> napi::Result<()> {
+    pub(crate) fn ensure_open(&self) -> napi::Result<()> {
         if self.closed.load(Ordering::SeqCst) {
             Err(simple_error("Database is closed"))
         } else {

--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -24,6 +24,7 @@ mod database;
 mod error;
 mod observability;
 mod prepared;
+mod refresh;
 mod runtime;
 mod streaming;
 mod value;
@@ -40,6 +41,7 @@ pub use database::WriteStats;
 pub use observability::OtelOptions;
 pub use prepared::PreparedStatement;
 pub use prepared::PreparedStatementStats;
+pub use refresh::RefreshReport;
 pub use streaming::StreamingResult;
 
 use napi_derive::napi;

--- a/bindings/node/src/refresh.rs
+++ b/bindings/node/src/refresh.rs
@@ -44,10 +44,12 @@ pub struct RefreshReport {
 impl RefreshReport {
     /// Build the Node report from the core [`cqlite_core::RefreshReport`].
     fn from_core(report: cqlite_core::RefreshReport) -> Self {
+        // Saturating conversion (no-silent-data-loss posture): the counts are
+        // usize on the core side; clamp to u32::MAX rather than truncating.
         Self {
-            tables_scanned: report.tables_scanned as u32,
-            readers_added: report.readers_added as u32,
-            readers_removed: report.readers_removed as u32,
+            tables_scanned: u32::try_from(report.tables_scanned).unwrap_or(u32::MAX),
+            readers_added: u32::try_from(report.readers_added).unwrap_or(u32::MAX),
+            readers_removed: u32::try_from(report.readers_removed).unwrap_or(u32::MAX),
         }
     }
 }

--- a/bindings/node/src/refresh.rs
+++ b/bindings/node/src/refresh.rs
@@ -1,0 +1,87 @@
+//! `Database.refresh()` + `RefreshReport` for Node.js bindings (issue #1749).
+//!
+//! Exposes an explicit directory refresh through the Node public surface. A
+//! `Database` is a snapshot at `open()`: a Cassandra flush/compaction (or a
+//! CQLite `--flush`) may add or remove SSTable generations under a warm handle,
+//! and those changes become queryable only after `await db.refresh()`.
+
+use napi_derive::napi;
+
+use crate::database::Database;
+use crate::error::to_napi_error;
+
+/// Report returned by `Database.refresh()`.
+///
+/// Describes what an explicit directory refresh applied to the database's held
+/// SSTable reader set: newly present generations become queryable, removed
+/// generations stop being queried, and unchanged generations keep their warm
+/// parsed state (they are not re-parsed).
+///
+/// Field names are camelCase on the JavaScript side (`tablesScanned`,
+/// `readersAdded`, `readersRemoved`).
+///
+/// ## Example
+///
+/// ```javascript
+/// const report = await db.refresh();
+/// console.log(
+///   `scanned ${report.tablesScanned} tables, ` +
+///   `+${report.readersAdded}/-${report.readersRemoved} readers`
+/// );
+/// ```
+#[napi(object)]
+pub struct RefreshReport {
+    /// Number of table directories re-discovered during the refresh.
+    pub tables_scanned: u32,
+
+    /// Number of SSTable generations newly opened and made queryable.
+    pub readers_added: u32,
+
+    /// Number of SSTable generations dropped from the reader set.
+    pub readers_removed: u32,
+}
+
+impl RefreshReport {
+    /// Build the Node report from the core [`cqlite_core::RefreshReport`].
+    fn from_core(report: cqlite_core::RefreshReport) -> Self {
+        Self {
+            tables_scanned: report.tables_scanned as u32,
+            readers_added: report.readers_added as u32,
+            readers_removed: report.readers_removed as u32,
+        }
+    }
+}
+
+#[napi]
+impl Database {
+    /// Re-discover the data directory and apply changes to the held reader set.
+    ///
+    /// Re-runs the same TOC/filename-based discovery that `open()` used (no
+    /// content sniffing, no heuristics) and applies the diff:
+    /// - newly present generations become queryable,
+    /// - removed generations stop being queried,
+    /// - unchanged generations keep their warm parsed Index/Statistics/bloom
+    ///   state (they are not re-parsed).
+    ///
+    /// In-flight queries are never affected: a scan already running completes
+    /// against the pre-refresh set; a query issued after this Promise resolves
+    /// sees the post-refresh set. The refresh is atomic and fail-closed — if any
+    /// newly discovered generation fails to open (e.g. a corrupt
+    /// `Statistics.db`), the returned Promise rejects and the previously held
+    /// reader set is left fully unchanged.
+    ///
+    /// @returns Promise resolving to a RefreshReport with the applied counts
+    /// @throws {CqliteError} If the database is closed or a new generation fails to open
+    ///
+    /// @example
+    /// ```javascript
+    /// const report = await db.refresh();
+    /// console.log(`+${report.readersAdded}/-${report.readersRemoved} readers`);
+    /// ```
+    #[napi]
+    pub async fn refresh(&self) -> napi::Result<RefreshReport> {
+        self.ensure_open()?;
+        let report = self.inner.refresh().await.map_err(to_napi_error)?;
+        Ok(RefreshReport::from_core(report))
+    }
+}

--- a/bindings/node/src/refresh.rs
+++ b/bindings/node/src/refresh.rs
@@ -31,7 +31,7 @@ use crate::error::to_napi_error;
 /// ```
 #[napi(object)]
 pub struct RefreshReport {
-    /// Number of table directories re-discovered during the refresh.
+    /// Number of distinct logical tables present after the refresh.
     pub tables_scanned: u32,
 
     /// Number of SSTable generations newly opened and made queryable.

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 cqlite-core = { path = "../../cqlite-core", features = ["state_machine", "all-compression", "cli-helpers", "write-support", "parquet"] }
-pyo3 = { workspace = true, features = ["extension-module", "abi3-py39"] }
+pyo3 = { workspace = true, features = ["extension-module", "abi3-py39", "multiple-pymethods"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "sync"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/bindings/python/python/cqlite/__init__.py
+++ b/bindings/python/python/cqlite/__init__.py
@@ -28,6 +28,8 @@ from cqlite._cqlite import (
     # Write API (Issue #390)
     WriteStats,
     MaintenanceReport,
+    # Refresh (Issue #1749)
+    RefreshReport,
 )
 
 __all__ = [
@@ -58,4 +60,6 @@ __all__ = [
     # Write API (Issue #390)
     "WriteStats",
     "MaintenanceReport",
+    # Refresh (Issue #1749)
+    "RefreshReport",
 ]

--- a/bindings/python/python/cqlite/__init__.pyi
+++ b/bindings/python/python/cqlite/__init__.pyi
@@ -803,7 +803,7 @@ class RefreshReport:
     set.
 
     Attributes:
-        tables_scanned: Number of table directories re-discovered.
+        tables_scanned: Number of distinct logical tables present after the refresh.
         readers_added: Number of SSTable generations newly opened.
         readers_removed: Number of SSTable generations dropped.
 
@@ -814,7 +814,7 @@ class RefreshReport:
 
     @property
     def tables_scanned(self) -> int:
-        """Number of table directories re-discovered."""
+        """Number of distinct logical tables present after the refresh."""
         ...
 
     @property

--- a/bindings/python/python/cqlite/__init__.pyi
+++ b/bindings/python/python/cqlite/__init__.pyi
@@ -269,6 +269,32 @@ class Database:
         """
         ...
 
+    def refresh(self) -> "RefreshReport":
+        """Re-discover the data directory and apply changes to the reader set.
+
+        A ``Database`` serves every query from the snapshot of on-disk SSTables
+        taken at ``open`` time. ``refresh()`` explicitly picks up files that
+        appeared or disappeared since then: newly present generations become
+        queryable, removed generations stop being queried, and unchanged
+        generations keep their warm reader state (they are not re-parsed).
+
+        The refresh is atomic and fail-closed: if any newly discovered
+        generation fails to open (e.g. a corrupt ``Statistics.db``) the call
+        raises and the previously held reader set is left fully unchanged. A
+        query already in flight is unaffected; queries started after this call
+        returns see the new set.
+
+        Returns:
+            A ``RefreshReport`` with ``tables_scanned``, ``readers_added``,
+            and ``readers_removed``.
+
+        Raises:
+            RuntimeError: If the database is closed.
+            CqliteError: If a newly discovered generation fails to open (the
+                held reader set is left unchanged).
+        """
+        ...
+
     def flush_run(self) -> str:
         """Flush the memtable to a new SSTable.
 
@@ -764,6 +790,47 @@ class MaintenanceReport:
 
         Keys: ``time_spent_ms``, ``rows_merged``, ``bytes_written``,
               ``completed_merges``, ``pending_compaction``.
+        """
+        ...
+
+    def __repr__(self) -> str: ...
+
+
+class RefreshReport:
+    """Result of a single ``Database.refresh()`` call (issue #1749).
+
+    Describes how an explicit directory refresh changed the held SSTable reader
+    set.
+
+    Attributes:
+        tables_scanned: Number of table directories re-discovered.
+        readers_added: Number of SSTable generations newly opened.
+        readers_removed: Number of SSTable generations dropped.
+
+    Example:
+        >>> report = db.refresh()
+        >>> print(f"+{report.readers_added}/-{report.readers_removed} readers")
+    """
+
+    @property
+    def tables_scanned(self) -> int:
+        """Number of table directories re-discovered."""
+        ...
+
+    @property
+    def readers_added(self) -> int:
+        """Number of SSTable generations newly opened."""
+        ...
+
+    @property
+    def readers_removed(self) -> int:
+        """Number of SSTable generations dropped."""
+        ...
+
+    def to_dict(self) -> dict[str, int]:
+        """Convert to a plain dictionary.
+
+        Keys: ``tables_scanned``, ``readers_added``, ``readers_removed``.
         """
         ...
 

--- a/bindings/python/src/database.rs
+++ b/bindings/python/src/database.rs
@@ -36,6 +36,7 @@ use pyo3::prelude::*;
 use crate::config::{config_from_py, StreamingConfig};
 use crate::error::to_py_err;
 use crate::prepared::PreparedStatement;
+use crate::refresh::RefreshReport;
 use crate::result::{QueryResult, StreamingIterator};
 use crate::runtime::block_on;
 use crate::stats::DatabaseStats;
@@ -549,6 +550,56 @@ impl Database {
             .map_err(to_py_err)?;
 
         DatabaseStats::from_core(py, core_stats)
+    }
+
+    /// Re-discover the data directory and apply changes to the held reader set.
+    ///
+    /// A `Database` takes a snapshot of the on-disk SSTables at `open` time and
+    /// serves every subsequent query from that snapshot. `refresh()` is the
+    /// explicit way to pick up files that appeared or disappeared since then:
+    /// it re-runs the same TOC/filename-component discovery `open` uses (no
+    /// content sniffing) and applies the diff — newly present generations
+    /// become queryable, removed generations stop being queried, and unchanged
+    /// generations keep their existing warm reader state (Index/Statistics/bloom
+    /// are not re-parsed).
+    ///
+    /// The refresh is atomic and fail-closed: if any newly discovered generation
+    /// fails to open (including a corrupt `Statistics.db`, per the #1626
+    /// posture), `refresh()` raises and leaves the previously held reader set
+    /// fully unchanged — no partial application. A query already in flight is
+    /// unaffected; queries started after `refresh()` returns see the new set.
+    ///
+    /// # Returns
+    ///
+    /// A `RefreshReport` with `tables_scanned`, `readers_added`, and
+    /// `readers_removed`.
+    ///
+    /// # Raises
+    ///
+    /// * `RuntimeError` – If the database is closed
+    /// * `CqliteError`  – If a newly discovered generation fails to open (the
+    ///                    held reader set is left unchanged)
+    ///
+    /// # Example
+    ///
+    /// ```python
+    /// # A new SSTable was copied into the data directory after open.
+    /// report = db.refresh()
+    /// print(f"added {report.readers_added}, removed {report.readers_removed}")
+    /// # Subsequent queries now see the new generation.
+    /// ```
+    pub fn refresh(&self, py: Python<'_>) -> PyResult<RefreshReport> {
+        self.ensure_open()?;
+
+        let db = self.inner();
+
+        // Release the GIL during the async re-discovery + reader swap so other
+        // Python threads keep running (same pattern as execute).
+        let core_report = py
+            .allow_threads(|| block_on(db.refresh()))
+            .map_err(to_py_err)?;
+
+        Ok(RefreshReport::from_core(core_report))
     }
 
     // -----------------------------------------------------------------------

--- a/bindings/python/src/database.rs
+++ b/bindings/python/src/database.rs
@@ -36,7 +36,6 @@ use pyo3::prelude::*;
 use crate::config::{config_from_py, StreamingConfig};
 use crate::error::to_py_err;
 use crate::prepared::PreparedStatement;
-use crate::refresh::RefreshReport;
 use crate::result::{QueryResult, StreamingIterator};
 use crate::runtime::block_on;
 use crate::stats::DatabaseStats;
@@ -80,7 +79,7 @@ pub struct Database {
 
 impl Database {
     /// Check if database is open, raising RuntimeError if closed.
-    fn ensure_open(&self) -> PyResult<()> {
+    pub(crate) fn ensure_open(&self) -> PyResult<()> {
         if self.closed.load(Ordering::SeqCst) {
             Err(PyRuntimeError::new_err("Database is closed"))
         } else {
@@ -550,56 +549,6 @@ impl Database {
             .map_err(to_py_err)?;
 
         DatabaseStats::from_core(py, core_stats)
-    }
-
-    /// Re-discover the data directory and apply changes to the held reader set.
-    ///
-    /// A `Database` takes a snapshot of the on-disk SSTables at `open` time and
-    /// serves every subsequent query from that snapshot. `refresh()` is the
-    /// explicit way to pick up files that appeared or disappeared since then:
-    /// it re-runs the same TOC/filename-component discovery `open` uses (no
-    /// content sniffing) and applies the diff — newly present generations
-    /// become queryable, removed generations stop being queried, and unchanged
-    /// generations keep their existing warm reader state (Index/Statistics/bloom
-    /// are not re-parsed).
-    ///
-    /// The refresh is atomic and fail-closed: if any newly discovered generation
-    /// fails to open (including a corrupt `Statistics.db`, per the #1626
-    /// posture), `refresh()` raises and leaves the previously held reader set
-    /// fully unchanged — no partial application. A query already in flight is
-    /// unaffected; queries started after `refresh()` returns see the new set.
-    ///
-    /// # Returns
-    ///
-    /// A `RefreshReport` with `tables_scanned`, `readers_added`, and
-    /// `readers_removed`.
-    ///
-    /// # Raises
-    ///
-    /// * `RuntimeError` – If the database is closed
-    /// * `CqliteError`  – If a newly discovered generation fails to open (the
-    ///                    held reader set is left unchanged)
-    ///
-    /// # Example
-    ///
-    /// ```python
-    /// # A new SSTable was copied into the data directory after open.
-    /// report = db.refresh()
-    /// print(f"added {report.readers_added}, removed {report.readers_removed}")
-    /// # Subsequent queries now see the new generation.
-    /// ```
-    pub fn refresh(&self, py: Python<'_>) -> PyResult<RefreshReport> {
-        self.ensure_open()?;
-
-        let db = self.inner();
-
-        // Release the GIL during the async re-discovery + reader swap so other
-        // Python threads keep running (same pattern as execute).
-        let core_report = py
-            .allow_threads(|| block_on(db.refresh()))
-            .map_err(to_py_err)?;
-
-        Ok(RefreshReport::from_core(core_report))
     }
 
     // -----------------------------------------------------------------------

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -10,6 +10,7 @@ mod database;
 mod error;
 mod observability;
 mod prepared;
+mod refresh;
 mod result;
 mod runtime;
 mod stats;
@@ -20,6 +21,7 @@ pub use config::{config_from_py, StreamingConfig};
 pub use database::{open, Database};
 pub use error::{to_py_err, CqliteError, ParseError, QueryError, SchemaError};
 pub use prepared::PreparedStatement;
+pub use refresh::RefreshReport;
 pub use result::{ColumnInfo, QueryResult, QueryResultIter, Row, StreamingIterator};
 pub use runtime::{block_on, get_runtime};
 pub use stats::DatabaseStats;
@@ -55,6 +57,9 @@ fn _cqlite(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     // Register prepared statement types
     prepared::register_prepared(m)?;
+
+    // Register refresh report type (issue #1749)
+    refresh::register_refresh(m)?;
 
     // Register database stats types
     stats::register_stats(m)?;

--- a/bindings/python/src/refresh.rs
+++ b/bindings/python/src/refresh.rs
@@ -18,7 +18,7 @@ use crate::runtime::block_on;
 ///
 /// # Attributes
 ///
-/// * `tables_scanned`  – Number of table directories re-discovered.
+/// * `tables_scanned`  – Number of distinct logical tables present after the refresh.
 /// * `readers_added`   – Number of SSTable generations newly opened.
 /// * `readers_removed` – Number of SSTable generations dropped.
 ///
@@ -31,7 +31,7 @@ use crate::runtime::block_on;
 /// ```
 #[pyclass(module = "cqlite")]
 pub struct RefreshReport {
-    /// Number of table directories re-discovered during the refresh.
+    /// Number of distinct logical tables present after the refresh.
     #[pyo3(get)]
     pub tables_scanned: usize,
     /// Number of SSTable generations newly opened and made queryable.

--- a/bindings/python/src/refresh.rs
+++ b/bindings/python/src/refresh.rs
@@ -1,0 +1,78 @@
+//! `RefreshReport` wrapper for Python bindings (issue #1749).
+//!
+//! Exposes the result of [`Database.refresh()`], describing how an explicit
+//! directory refresh changed the held reader set.
+
+use pyo3::prelude::*;
+
+/// Result returned by `Database.refresh()`.
+///
+/// Describes what an explicit directory refresh applied to the database's held
+/// SSTable reader set: newly present generations become queryable, removed
+/// generations stop being queried, and unchanged generations keep their warm
+/// parsed state (they are not re-parsed).
+///
+/// # Attributes
+///
+/// * `tables_scanned`  – Number of table directories re-discovered.
+/// * `readers_added`   – Number of SSTable generations newly opened.
+/// * `readers_removed` – Number of SSTable generations dropped.
+///
+/// # Example
+///
+/// ```python
+/// report = db.refresh()
+/// print(f"scanned {report.tables_scanned} tables, "
+///       f"+{report.readers_added}/-{report.readers_removed} readers")
+/// ```
+#[pyclass(module = "cqlite")]
+pub struct RefreshReport {
+    /// Number of table directories re-discovered during the refresh.
+    #[pyo3(get)]
+    pub tables_scanned: usize,
+    /// Number of SSTable generations newly opened and made queryable.
+    #[pyo3(get)]
+    pub readers_added: usize,
+    /// Number of SSTable generations dropped from the reader set.
+    #[pyo3(get)]
+    pub readers_removed: usize,
+}
+
+impl RefreshReport {
+    /// Build the Python report from the core [`cqlite_core::RefreshReport`].
+    pub fn from_core(report: cqlite_core::RefreshReport) -> Self {
+        Self {
+            tables_scanned: report.tables_scanned,
+            readers_added: report.readers_added,
+            readers_removed: report.readers_removed,
+        }
+    }
+}
+
+#[pymethods]
+impl RefreshReport {
+    fn __repr__(&self) -> String {
+        format!(
+            "RefreshReport(tables_scanned={}, readers_added={}, readers_removed={})",
+            self.tables_scanned, self.readers_added, self.readers_removed
+        )
+    }
+
+    /// Convert to a plain Python dict.
+    ///
+    /// Keys: `tables_scanned`, `readers_added`, `readers_removed`.
+    fn to_dict(&self, py: Python<'_>) -> PyResult<PyObject> {
+        use pyo3::types::PyDict;
+        let d = PyDict::new(py);
+        d.set_item("tables_scanned", self.tables_scanned)?;
+        d.set_item("readers_added", self.readers_added)?;
+        d.set_item("readers_removed", self.readers_removed)?;
+        Ok(d.into_any().unbind())
+    }
+}
+
+/// Register refresh types with the Python module.
+pub fn register_refresh(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<RefreshReport>()?;
+    Ok(())
+}

--- a/bindings/python/src/refresh.rs
+++ b/bindings/python/src/refresh.rs
@@ -5,6 +5,10 @@
 
 use pyo3::prelude::*;
 
+use crate::database::Database;
+use crate::error::to_py_err;
+use crate::runtime::block_on;
+
 /// Result returned by `Database.refresh()`.
 ///
 /// Describes what an explicit directory refresh applied to the database's held
@@ -68,6 +72,64 @@ impl RefreshReport {
         d.set_item("readers_added", self.readers_added)?;
         d.set_item("readers_removed", self.readers_removed)?;
         Ok(d.into_any().unbind())
+    }
+}
+
+/// `Database.refresh()` lives here (issue #1749), split from `database.rs` per
+/// the campsite file-size doctrine (epic #1116). PyO3's `multiple-pymethods`
+/// feature lets this second `#[pymethods] impl Database` block coexist with the
+/// primary one in `database.rs`; the public Python surface (`db.refresh()`) is
+/// unchanged. This mirrors the Node binding's `bindings/node/src/refresh.rs`.
+#[pymethods]
+impl Database {
+    /// Re-discover the data directory and apply changes to the held reader set.
+    ///
+    /// A `Database` takes a snapshot of the on-disk SSTables at `open` time and
+    /// serves every subsequent query from that snapshot. `refresh()` is the
+    /// explicit way to pick up files that appeared or disappeared since then:
+    /// it re-runs the same TOC/filename-component discovery `open` uses (no
+    /// content sniffing) and applies the diff — newly present generations
+    /// become queryable, removed generations stop being queried, and unchanged
+    /// generations keep their existing warm reader state (Index/Statistics/bloom
+    /// are not re-parsed).
+    ///
+    /// The refresh is atomic and fail-closed: if any newly discovered generation
+    /// fails to open (including a corrupt `Statistics.db`, per the #1626
+    /// posture), `refresh()` raises and leaves the previously held reader set
+    /// fully unchanged — no partial application. A query already in flight is
+    /// unaffected; queries started after `refresh()` returns see the new set.
+    ///
+    /// # Returns
+    ///
+    /// A `RefreshReport` with `tables_scanned`, `readers_added`, and
+    /// `readers_removed`.
+    ///
+    /// # Raises
+    ///
+    /// * `RuntimeError` – If the database is closed
+    /// * `CqliteError`  – If a newly discovered generation fails to open (the
+    ///                    held reader set is left unchanged)
+    ///
+    /// # Example
+    ///
+    /// ```python
+    /// # A new SSTable was copied into the data directory after open.
+    /// report = db.refresh()
+    /// print(f"added {report.readers_added}, removed {report.readers_removed}")
+    /// # Subsequent queries now see the new generation.
+    /// ```
+    pub fn refresh(&self, py: Python<'_>) -> PyResult<RefreshReport> {
+        self.ensure_open()?;
+
+        let db = self.inner();
+
+        // Release the GIL during the async re-discovery + reader swap so other
+        // Python threads keep running (same pattern as execute).
+        let core_report = py
+            .allow_threads(|| block_on(db.refresh()))
+            .map_err(to_py_err)?;
+
+        Ok(RefreshReport::from_core(core_report))
     }
 }
 

--- a/bindings/python/tests/test_refresh.py
+++ b/bindings/python/tests/test_refresh.py
@@ -19,6 +19,8 @@ import shutil
 import tempfile
 from pathlib import Path
 
+import pytest
+
 import cqlite
 
 KEYSPACE = "test_freshness"
@@ -206,3 +208,22 @@ def test_refresh_report_repr_and_to_dict():
                 "readers_added": 1,
                 "readers_removed": 0,
             }
+
+
+def test_refresh_on_closed_database_raises():
+    """``refresh()`` on a closed database raises the closed-database error
+    (mirrors the Node ``refresh() on a closed database rejects`` test)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        schema = _write_schema(root)
+        src_table_dir = _build_two_generations(root, schema)
+
+        live = root / "live"
+        live_table_dir = live / KEYSPACE / TABLE
+        _copy_generation(src_table_dir, live_table_dir, 1)
+
+        db = cqlite.open(live, schema=schema)
+        db.close()
+
+        with pytest.raises(RuntimeError, match="closed"):
+            db.refresh()

--- a/bindings/python/tests/test_refresh.py
+++ b/bindings/python/tests/test_refresh.py
@@ -1,0 +1,208 @@
+"""End-to-end tests for ``Database.refresh()`` (issue #1749).
+
+These drive the full stale -> refresh -> fresh cycle through the Python public
+API (`cqlite.open`, `db.execute`, `db.refresh`) against REAL SSTable binaries.
+
+The fixtures are built in-test with CQLite's own write path (the natural Python
+mirror of the ``WriteEngine`` fixture construction in
+``cqlite-core/tests/issue_1749_sstable_freshness_refresh.rs``): two single-flush
+generations, ``nb-1-big-*`` holding only partition ``id=1`` and ``nb-2-big-*``
+holding only ``id=2``. Because the generations are generated here rather than
+fetched, there is **no skip path** — a write-path failure fails the test, every
+row-set assertion is exact (never ``>= 0``), and each copy asserts it moved at
+least one component file. A 0-rows-on-present-data regression therefore fails
+loudly instead of silently passing.
+"""
+
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+import cqlite
+
+KEYSPACE = "test_freshness"
+TABLE = "users"
+
+_SCHEMA = f"CREATE TABLE {KEYSPACE}.{TABLE} (id int PRIMARY KEY, value text);"
+
+
+def _write_schema(root: Path) -> Path:
+    """Write the single-table schema used by the write engine and readers."""
+    schema_path = root / "users.cql"
+    schema_path.write_text(_SCHEMA)
+    return schema_path
+
+
+def _build_two_generations(root: Path, schema: Path) -> Path:
+    """Build a source table dir with two SSTable generations.
+
+    ``nb-1-big-*`` contains only partition ``id=1`` and ``nb-2-big-*`` only
+    ``id=2`` — each ``flush_run()`` of a single writable database advances the
+    generation. Returns the ``.../<keyspace>/<table>`` directory containing both
+    generations.
+    """
+    # The read side of a writable open still requires an existing data dir.
+    read_dir = root / "src_read"
+    read_dir.mkdir()
+    write_dir = root / "src_write"
+
+    with cqlite.open(
+        read_dir, schema=schema, writable=True, write_dir=write_dir
+    ) as db:
+        for gen_id in (1, 2):
+            db.execute(
+                f"INSERT INTO {KEYSPACE}.{TABLE} (id, value) "
+                f"VALUES ({gen_id}, 'v{gen_id}')"
+            )
+            path = db.flush_run()
+            assert path, f"flush for id={gen_id} produced no SSTable"
+
+    table_dir = write_dir / "data" / KEYSPACE / TABLE
+    assert (table_dir / "nb-1-big-Data.db").exists(), "gen-1 must exist in source"
+    assert (table_dir / "nb-2-big-Data.db").exists(), "gen-2 must exist in source"
+    return table_dir
+
+
+def _copy_generation(src_table_dir: Path, dst_table_dir: Path, gen: int) -> int:
+    """Copy every ``nb-<gen>-big-*`` component into ``dst_table_dir``.
+
+    Returns the number of component files copied (asserted > 0 so a build/path
+    regression fails rather than silently copying nothing).
+    """
+    dst_table_dir.mkdir(parents=True, exist_ok=True)
+    prefix = f"nb-{gen}-big-"
+    copied = 0
+    for name in os.listdir(src_table_dir):
+        if name.startswith(prefix):
+            shutil.copy(src_table_dir / name, dst_table_dir / name)
+            copied += 1
+    assert copied > 0, f"expected to copy generation {gen} components"
+    return copied
+
+
+def _delete_generation(table_dir: Path, gen: int) -> int:
+    """Delete every ``nb-<gen>-big-*`` component (simulated compaction)."""
+    prefix = f"nb-{gen}-big-"
+    removed = 0
+    for name in os.listdir(table_dir):
+        if name.startswith(prefix):
+            (table_dir / name).unlink()
+            removed += 1
+    assert removed > 0, f"expected to remove generation {gen} components"
+    return removed
+
+
+def _select_all_ids(db) -> set:
+    """The set of ``id`` partition-key values in ``SELECT *``."""
+    res = db.execute(f"SELECT * FROM {KEYSPACE}.{TABLE}")
+    return {row.to_dict()["id"] for row in res}
+
+
+def test_added_generation_invisible_until_refresh_then_visible():
+    """Spec: new generation invisible until refresh, visible after;
+    report ``readers_added == 1`` and ``readers_removed == 0``."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        schema = _write_schema(root)
+        src_table_dir = _build_two_generations(root, schema)
+
+        # Live directory starts with ONLY generation 1 (partition id=1).
+        live = root / "live"
+        live_table_dir = live / KEYSPACE / TABLE
+        _copy_generation(src_table_dir, live_table_dir, 1)
+
+        with cqlite.open(live, schema=schema) as db:
+            before = _select_all_ids(db)
+            assert before == {1}, "only gen-1 partition visible at open"
+
+            # Copy in generation 2 (partition id=2) but do NOT refresh yet.
+            _copy_generation(src_table_dir, live_table_dir, 2)
+            assert _select_all_ids(db) == {1}, (
+                "stale-until-refresh: same result before refresh() "
+                "despite new file on disk"
+            )
+
+            report = db.refresh()
+            assert report.readers_added == 1, "one generation added"
+            assert report.readers_removed == 0, "none removed"
+            assert report.tables_scanned >= 1, "at least the users table scanned"
+
+            assert _select_all_ids(db) == {1, 2}, (
+                "new generation's partition visible after refresh"
+            )
+
+
+def test_removed_generation_dropped_on_refresh():
+    """Spec: removed generation dropped safely — ``readers_removed == 1`` and
+    the subsequent SELECT returns only the remaining generation."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        schema = _write_schema(root)
+        src_table_dir = _build_two_generations(root, schema)
+
+        live = root / "live"
+        live_table_dir = live / KEYSPACE / TABLE
+        _copy_generation(src_table_dir, live_table_dir, 1)
+        _copy_generation(src_table_dir, live_table_dir, 2)
+
+        with cqlite.open(live, schema=schema) as db:
+            assert _select_all_ids(db) == {1, 2}, "both partitions visible at open"
+
+            _delete_generation(live_table_dir, 2)
+            report = db.refresh()
+            assert report.readers_removed == 1, "one generation removed"
+            assert report.readers_added == 0, "none added"
+
+            assert _select_all_ids(db) == {1}, (
+                "only the remaining generation's partition after removal"
+            )
+
+
+def test_unchanged_directory_is_zero_delta_noop():
+    """Spec: unchanged directory is a cheap no-op — zero-delta report and an
+    unchanged result set."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        schema = _write_schema(root)
+        src_table_dir = _build_two_generations(root, schema)
+
+        live = root / "live"
+        live_table_dir = live / KEYSPACE / TABLE
+        _copy_generation(src_table_dir, live_table_dir, 1)
+
+        with cqlite.open(live, schema=schema) as db:
+            before = _select_all_ids(db)
+
+            report = db.refresh()
+            assert report.readers_added == 0, "no-op: nothing added"
+            assert report.readers_removed == 0, "no-op: nothing removed"
+
+            assert _select_all_ids(db) == before, "result unchanged by no-op"
+
+
+def test_refresh_report_repr_and_to_dict():
+    """The ``RefreshReport`` exposes readable ``__repr__`` and ``to_dict()``."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        schema = _write_schema(root)
+        src_table_dir = _build_two_generations(root, schema)
+
+        live = root / "live"
+        live_table_dir = live / KEYSPACE / TABLE
+        _copy_generation(src_table_dir, live_table_dir, 1)
+
+        with cqlite.open(live, schema=schema) as db:
+            _copy_generation(src_table_dir, live_table_dir, 2)
+            report = db.refresh()
+
+            text = repr(report)
+            assert "RefreshReport" in text
+            assert "readers_added=1" in text
+
+            as_dict = report.to_dict()
+            assert as_dict == {
+                "tables_scanned": report.tables_scanned,
+                "readers_added": 1,
+                "readers_removed": 0,
+            }

--- a/cqlite-core/src/lib.rs
+++ b/cqlite-core/src/lib.rs
@@ -60,6 +60,10 @@ pub use crate::{
     types::*,
 };
 
+// Explicit SSTable directory refresh report (issue #1749). Not feature-gated —
+// `Database::refresh()` is available in the minimal build too.
+pub use storage::sstable::RefreshReport;
+
 // Re-export query types when state_machine feature is enabled
 #[cfg(feature = "state_machine")]
 pub use query::SchemaStatus;
@@ -287,6 +291,35 @@ impl Database {
             memory,
             config,
         })
+    }
+
+    /// Re-scan the data directory and atomically apply added/removed SSTable
+    /// generations to this handle's reader set (issue #1749).
+    ///
+    /// # Freshness contract
+    ///
+    /// A `Database` is a **snapshot at [`open`](Self::open)**: it discovers the
+    /// SSTable generations once and never re-scans on its own. A Cassandra
+    /// flush/compaction (or a CQLite `--flush`) may add or remove generations
+    /// underneath a warm handle at any time; those changes become visible only
+    /// after an explicit `refresh()`. Re-runs the same TOC/filename-based
+    /// discovery `open` used — no content sniffing, no heuristics.
+    ///
+    /// - Newly present generations become queryable; removed generations stop
+    ///   being queried; unchanged generations keep their warm parsed
+    ///   Index/Statistics/bloom state (not rebuilt).
+    /// - **In-flight queries are never affected**: a scan already running holds
+    ///   its own `Arc` reader clones and completes against the pre-refresh set. A
+    ///   query issued after `refresh()` returns sees the post-refresh set.
+    /// - **Atomic and fail-closed**: if any newly discovered generation fails to
+    ///   open (e.g. a corrupt `Statistics.db`, issue #1626), `refresh()` returns
+    ///   the typed error and leaves the previously held reader set fully
+    ///   unchanged — no partial view.
+    ///
+    /// Returns a [`RefreshReport`] describing what this call applied. Explicit
+    /// refresh only: there is no filesystem watching or per-query staleness check.
+    pub async fn refresh(&self) -> Result<RefreshReport> {
+        self.storage.refresh().await
     }
 
     /// Execute a SQL query and return the result

--- a/cqlite-core/src/storage/mod.rs
+++ b/cqlite-core/src/storage/mod.rs
@@ -234,6 +234,29 @@ impl StorageEngine {
         self.sstables.get(table_id, key).await
     }
 
+    /// Re-scan the data directory and atomically apply added/removed SSTable
+    /// generations to the held reader set (issue #1749).
+    ///
+    /// # Freshness contract
+    ///
+    /// A `StorageEngine` (and the [`Database`](crate::Database) built on it)
+    /// snapshots the discovered SSTable generations **at open**; it does not
+    /// re-scan on its own. This is the ONLY way the reader set changes for a
+    /// long-lived handle. Re-runs the same TOC/filename-based discovery `open`
+    /// used — no content sniffing.
+    ///
+    /// - Added generations become queryable; removed generations stop being
+    ///   queried; unchanged generations keep their warm parsed state.
+    /// - **In-flight queries are unaffected**: a scan already running holds its
+    ///   own `Arc` reader clones and completes against the pre-refresh set;
+    ///   queries started after the refresh see the new set.
+    /// - **Atomic / fail-closed**: if any newly discovered generation fails to
+    ///   open (e.g. a corrupt `Statistics.db`, issue #1626), the typed error is
+    ///   returned and the previously held reader set is left fully unchanged.
+    pub async fn refresh(&self) -> Result<sstable::RefreshReport> {
+        self.sstables.refresh_tables().await
+    }
+
     /// Delete a key
     ///
     /// NOTE: Write functionality removed in Issue #175 (WAL/MemTable infrastructure deleted).

--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -428,7 +428,10 @@ impl SSTableManager {
                                         key,
                                         path.display()
                                     );
-                                    table_readers.entry(key).or_insert_with(Vec::new).push(reader_arc);
+                                    table_readers
+                                        .entry(key)
+                                        .or_insert_with(Vec::new)
+                                        .push(reader_arc);
                                 } else {
                                     log::warn!(
                                         "SSTableManager could not extract table name from path: {}",

--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -24,6 +24,10 @@ pub mod work_counters;
 pub use reader::SSTableReader;
 pub mod schema_aware_reader;
 pub use schema_aware_reader::SchemaAwareReader;
+/// Explicit directory refresh (issue #1749): re-scan + atomic diff-and-swap of
+/// the held reader set. Not `state_machine`-gated — meaningful for minimal builds.
+pub mod refresh;
+pub use refresh::RefreshReport;
 mod reverse_scan; // BIG reverse partition iteration (issue #1184); file is tombstones-gated.
 pub mod row_cell_state_machine;
 pub mod statistics_reader;
@@ -232,6 +236,10 @@ pub struct SSTableManager {
     /// Configuration
     config: Config,
 
+    /// How this manager discovers SSTable generations, recorded so
+    /// [`SSTableManager::refresh_tables`] re-runs the same discovery (issue #1749).
+    discovery_source: refresh::DiscoverySource,
+
     /// Schema registry for schema-aware operations (feature-gated)
     #[cfg(feature = "state_machine")]
     schema_registry: Arc<RwLock<Option<Arc<RwLock<crate::schema::SchemaRegistry>>>>>,
@@ -257,6 +265,7 @@ impl SSTableManager {
             table_readers,
             platform,
             config: config.clone(),
+            discovery_source: refresh::DiscoverySource::BasePath,
             #[cfg(feature = "state_machine")]
             schema_registry: Arc::new(RwLock::new(schema_registry)),
         };
@@ -343,6 +352,7 @@ impl SSTableManager {
             table_readers,
             platform: platform.clone(),
             config: config.clone(),
+            discovery_source: refresh::DiscoverySource::TableDirs(table_dirs.clone()),
             #[cfg(feature = "state_machine")]
             schema_registry: Arc::new(RwLock::new(schema_registry)),
         };
@@ -397,76 +407,28 @@ impl SSTableManager {
                         log::debug!("SSTableManager found SSTable file: {:?}", path);
 
                         let sstable_id = SSTableId::from_filename(filename);
-                        // Try to open the SSTable reader
-                        match reader::SSTableReader::open(
-                            &path,
-                            &self.config,
-                            self.platform.clone(),
-                        )
-                        .await
-                        {
-                            #[cfg_attr(not(feature = "state_machine"), allow(unused_mut))]
-                            Ok(mut reader) => {
+                        // Open + wire registries via the shared helper so refresh
+                        // opens readers identically (issue #1749). A per-file open
+                        // error is logged and skipped here (best-effort load).
+                        match self.open_reader_with_schema(&path).await {
+                            Ok(reader_arc) => {
                                 log::debug!(
                                     "SSTableManager successfully loaded SSTable: {}",
                                     sstable_id.0
                                 );
 
-                                // Set schema registry if available (before wrapping in Arc)
-                                #[cfg(feature = "state_machine")]
-                                {
-                                    let schema_reg_guard = self.schema_registry.read().await;
-                                    if let Some(ref registry_rwlock) = *schema_reg_guard {
-                                        log::debug!(
-                                            "SSTableManager setting schema registry on reader: {}",
-                                            sstable_id.0
-                                        );
-                                        reader.set_schema_registry(Arc::clone(registry_rwlock));
-
-                                        // Also set UDT registry for UDT-aware collection parsing (Issue #238)
-                                        let schema_registry = registry_rwlock.read().await;
-                                        let udt_registry_lock = schema_registry.get_udt_registry();
-                                        let udt_registry = udt_registry_lock.read().await.clone();
-                                        reader.set_udt_registry(udt_registry);
-                                    }
-                                }
-
-                                let reader_arc = Arc::new(reader);
-
                                 // Store by SSTableId (existing)
                                 readers.insert(sstable_id, reader_arc.clone());
 
-                                // Extract fully-qualified "keyspace.table" key so that
-                                // same-named tables in different keyspaces (e.g.
-                                // test_basic.simple_table vs test_oa.simple_table) are
-                                // stored under distinct entries (Issue #680).
-                                if let Some((keyspace, table_name)) =
-                                    extract_keyspace_and_table_name(&path)
-                                {
-                                    let qualified_key = format!("{}.{}", keyspace, table_name);
+                                // Fully-qualified "keyspace.table" key (or unqualified
+                                // fallback) via the shared keying helper (Issue #680).
+                                if let Some(key) = refresh::table_dir_table_key(&path) {
                                     log::debug!(
                                         "SSTableManager mapping table '{}' to SSTable '{}'",
-                                        qualified_key,
+                                        key,
                                         path.display()
                                     );
-
-                                    table_readers
-                                        .entry(qualified_key)
-                                        .or_insert_with(Vec::new)
-                                        .push(reader_arc);
-                                } else if let Some(table_name) = extract_table_name(&path) {
-                                    // Fallback for flat/non-Cassandra directory layouts that
-                                    // lack a keyspace parent: use unqualified name.
-                                    log::debug!(
-                                        "SSTableManager mapping table '{}' (no keyspace) to SSTable '{}'",
-                                        table_name,
-                                        path.display()
-                                    );
-
-                                    table_readers
-                                        .entry(table_name)
-                                        .or_insert_with(Vec::new)
-                                        .push(reader_arc);
+                                    table_readers.entry(key).or_insert_with(Vec::new).push(reader_arc);
                                 } else {
                                     log::warn!(
                                         "SSTableManager could not extract table name from path: {}",
@@ -535,63 +497,21 @@ impl SSTableManager {
                 None => continue,
             };
             let sstable_id = SSTableId::from_filename(&filename);
-            // Try to open the SSTable reader, but don't fail if one file is problematic
-            match reader::SSTableReader::open(&path, &self.config, self.platform.clone()).await {
-                #[cfg_attr(not(feature = "state_machine"), allow(unused_mut))]
-                Ok(mut reader) => {
-                    // Set schema registry if available (before wrapping in Arc)
-                    #[cfg(feature = "state_machine")]
-                    {
-                        let schema_reg_guard = self.schema_registry.read().await;
-                        if let Some(ref registry_rwlock) = *schema_reg_guard {
-                            reader.set_schema_registry(Arc::clone(registry_rwlock));
-
-                            // Also set UDT registry for UDT-aware collection parsing (Issue #238)
-                            let schema_registry = registry_rwlock.read().await;
-                            let udt_registry_lock = schema_registry.get_udt_registry();
-                            let udt_registry = udt_registry_lock.read().await.clone();
-                            reader.set_udt_registry(udt_registry);
-                        }
-                    }
-
-                    let reader_arc = Arc::new(reader);
-
+            // Open + wire registries via the shared helper so refresh opens
+            // readers identically (issue #1749). Don't fail the whole load if one
+            // file is problematic — skip it (best-effort initial load).
+            match self.open_reader_with_schema(&path).await {
+                Ok(reader_arc) => {
                     // Store by SSTableId
                     readers.insert(sstable_id, reader_arc.clone());
 
-                    // Build a fully-qualified "keyspace.table" key so that same-named
-                    // tables in different keyspaces (e.g. test_basic.simple_table vs
-                    // test_oa.simple_table) are stored under distinct entries (Issue #680).
-                    //
-                    // Priority:
-                    //   1. keyspace + table extracted from the filesystem path
-                    //   2. Unqualified table name (flat layout without a keyspace parent)
-                    //   3. Table name from the SSTable header (last resort)
-                    let table_key: Option<String> = if let Some((keyspace, table_name)) =
-                        extract_keyspace_and_table_name(&path)
-                    {
-                        // Only use if the table name is meaningful (not just the base_dir)
-                        if table_name.as_str() != base_dir_name {
-                            Some(format!("{}.{}", keyspace, table_name))
-                        } else {
-                            None
-                        }
-                    } else {
-                        None
-                    }
-                    .or_else(|| {
-                        extract_table_name(&path).filter(|name| name.as_str() != base_dir_name)
-                    })
-                    .or_else(|| {
-                        // Fallback: use table name from SSTable header (populated from
-                        // Statistics.db or path during reader::open)
-                        let header_table = reader_arc.header().table_name.clone();
-                        if header_table != "test_table" && !header_table.is_empty() {
-                            Some(header_table)
-                        } else {
-                            None
-                        }
-                    });
+                    // Fully-qualified "keyspace.table" key (base-dir-excluded, with
+                    // header fallback) via the shared keying helper (Issue #680).
+                    let table_key = refresh::base_path_table_key(
+                        &path,
+                        &base_dir_name,
+                        &reader_arc.header().table_name,
+                    );
 
                     if let Some(key) = table_key {
                         log::debug!(

--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -68,7 +68,7 @@ mod schema_aware_reader_test;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 
 #[cfg(feature = "tombstones")]
 use self::tombstone_merger::{EntryMetadata, GenerationValue, TombstoneMerger};
@@ -240,6 +240,13 @@ pub struct SSTableManager {
     /// [`SSTableManager::refresh_tables`] re-runs the same discovery (issue #1749).
     discovery_source: refresh::DiscoverySource,
 
+    /// Serializes concurrent [`SSTableManager::refresh_tables`] calls end-to-end
+    /// (discovery through swap) so two refreshes cannot interleave — a stale
+    /// discovery set from one refresh can never remove a generation a concurrent
+    /// refresh just added (TOCTOU, issue #1749, Decision 4). Held ONLY across a
+    /// refresh; queries never take this lock (they use the `RwLock` read guards).
+    refresh_lock: Arc<Mutex<()>>,
+
     /// Schema registry for schema-aware operations (feature-gated)
     #[cfg(feature = "state_machine")]
     schema_registry: Arc<RwLock<Option<Arc<RwLock<crate::schema::SchemaRegistry>>>>>,
@@ -266,6 +273,7 @@ impl SSTableManager {
             platform,
             config: config.clone(),
             discovery_source: refresh::DiscoverySource::BasePath,
+            refresh_lock: Arc::new(Mutex::new(())),
             #[cfg(feature = "state_machine")]
             schema_registry: Arc::new(RwLock::new(schema_registry)),
         };
@@ -353,6 +361,7 @@ impl SSTableManager {
             platform: platform.clone(),
             config: config.clone(),
             discovery_source: refresh::DiscoverySource::TableDirs(table_dirs.clone()),
+            refresh_lock: Arc::new(Mutex::new(())),
             #[cfg(feature = "state_machine")]
             schema_registry: Arc::new(RwLock::new(schema_registry)),
         };

--- a/cqlite-core/src/storage/sstable/refresh.rs
+++ b/cqlite-core/src/storage/sstable/refresh.rs
@@ -31,7 +31,7 @@
 //! a scan already in flight completes against the pre-refresh set and is never
 //! affected by a concurrent refresh.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -211,31 +211,56 @@ impl SSTableManager {
     pub async fn refresh_tables(&self) -> Result<RefreshReport> {
         // 1. Rediscover the current on-disk Data.db set (no readers opened yet).
         let discovered_paths = self.discover_data_file_paths().await?;
-        let discovered_canon: HashSet<PathBuf> =
-            discovered_paths.iter().map(|p| canon(p)).collect();
 
-        // 2. Snapshot the canonical paths currently held (short read guards).
-        //    Union both maps so no held generation is missed even under a
-        //    pre-existing SSTableId (filename) collision across keyspaces.
-        let held_canon: HashSet<PathBuf> = {
+        // Precompute a raw-path -> canonical-path cache for EVERY path this
+        // refresh will diff. Filesystem canonicalization happens ONLY here (and
+        // in step 4 for freshly opened readers), never inside the write-guarded
+        // critical section (step 5), which must perform zero syscalls. A
+        // reader's `file_path` is immutable and `canon` is a pure function of
+        // path + filesystem, so a cache built now stays valid for the whole
+        // call.
+        let mut canon_cache: HashMap<PathBuf, PathBuf> =
+            HashMap::with_capacity(discovered_paths.len());
+        for p in &discovered_paths {
+            canon_cache.entry(p.clone()).or_insert_with(|| canon(p));
+        }
+
+        // 2. Snapshot the canonical paths currently held (short read guards),
+        //    extending the cache with every held reader's file_path so the
+        //    guarded section can resolve them without syscalls. Union both maps
+        //    so no held generation is missed even under a pre-existing
+        //    SSTableId (filename) collision across keyspaces.
+        let mut held_canon: HashSet<PathBuf> = HashSet::new();
+        {
             let readers = self.readers.read().await;
             let table_readers = self.table_readers.read().await;
-            readers
-                .values()
-                .map(|r| canon(&r.file_path))
-                .chain(
-                    table_readers
-                        .values()
-                        .flatten()
-                        .map(|r| canon(&r.file_path)),
-                )
-                .collect()
+            for r in readers.values().chain(table_readers.values().flatten()) {
+                let c = canon_cache
+                    .entry(r.file_path.clone())
+                    .or_insert_with(|| canon(&r.file_path))
+                    .clone();
+                held_canon.insert(c);
+            }
+        }
+
+        // Cache-only canonicalization: reads the precomputed map, falling back
+        // to the raw path (NO syscall) for any path not seen during precompute
+        // — matching `canon`'s own fallback for an un-canonicalizable path.
+        let canon_of = |p: &Path| -> PathBuf {
+            canon_cache
+                .get(p)
+                .cloned()
+                .unwrap_or_else(|| p.to_path_buf())
         };
+
+        let discovered_canon: HashSet<PathBuf> =
+            discovered_paths.iter().map(|p| canon_of(p)).collect();
 
         // 3. Candidate additions = discovered paths not already held.
         let added_paths: Vec<PathBuf> = discovered_paths
-            .into_iter()
-            .filter(|p| !held_canon.contains(&canon(p)))
+            .iter()
+            .filter(|p| !held_canon.contains(&canon_of(p)))
+            .cloned()
             .collect();
 
         // 4. Open every added generation OUTSIDE the write guard. Fail-closed:
@@ -253,39 +278,41 @@ impl SSTableManager {
             let sstable_id = SSTableId::from_filename(filename);
             let reader_arc = self.open_reader_with_schema(path).await?;
             let key = self.table_key_for(path, &reader_arc);
-            opened.push((canon(path), sstable_id, key, reader_arc));
+            opened.push((canon_of(path), sstable_id, key, reader_arc));
         }
 
         // 5. Apply the diff under the write guards (short critical section).
         let mut readers = self.readers.write().await;
         let mut table_readers = self.table_readers.write().await;
 
-        // 5a. Removal: retain only readers still present on disk.
+        // 5a. Removal: retain only readers still present on disk. Every
+        //     canonical path below comes from the precomputed cache — the
+        //     guarded section performs zero filesystem syscalls.
         let before_canon: HashSet<PathBuf> = readers
             .values()
-            .map(|r| canon(&r.file_path))
+            .map(|r| canon_of(&r.file_path))
             .chain(
                 table_readers
                     .values()
                     .flatten()
-                    .map(|r| canon(&r.file_path)),
+                    .map(|r| canon_of(&r.file_path)),
             )
             .collect();
 
-        readers.retain(|_id, r| discovered_canon.contains(&canon(&r.file_path)));
+        readers.retain(|_id, r| discovered_canon.contains(&canon_of(&r.file_path)));
         for list in table_readers.values_mut() {
-            list.retain(|r| discovered_canon.contains(&canon(&r.file_path)));
+            list.retain(|r| discovered_canon.contains(&canon_of(&r.file_path)));
         }
         table_readers.retain(|_key, list| !list.is_empty());
 
         let after_removal_canon: HashSet<PathBuf> = readers
             .values()
-            .map(|r| canon(&r.file_path))
+            .map(|r| canon_of(&r.file_path))
             .chain(
                 table_readers
                     .values()
                     .flatten()
-                    .map(|r| canon(&r.file_path)),
+                    .map(|r| canon_of(&r.file_path)),
             )
             .collect();
         let readers_removed = before_canon.difference(&after_removal_canon).count();
@@ -299,7 +326,7 @@ impl SSTableManager {
             }
             // Guard against inserting the same freshly-opened path twice if the
             // discovery listed a duplicate (defensive; discovery does not).
-            if readers.values().any(|r| canon(&r.file_path) == cpath) {
+            if readers.values().any(|r| canon_of(&r.file_path) == cpath) {
                 continue;
             }
             readers.insert(sstable_id, Arc::clone(&reader_arc));

--- a/cqlite-core/src/storage/sstable/refresh.rs
+++ b/cqlite-core/src/storage/sstable/refresh.rs
@@ -29,7 +29,12 @@
 //! Concurrency reuses the existing lock discipline (Decision 4): queries resolve
 //! their reader list once under the `RwLock` read guard and hold `Arc` clones, so
 //! a scan already in flight completes against the pre-refresh set and is never
-//! affected by a concurrent refresh.
+//! affected by a concurrent refresh. Two concurrent `refresh_tables` calls fully
+//! serialize on a dedicated refresh mutex held end-to-end (discovery through
+//! swap): the second cannot start until the first has applied its diff, so its
+//! discovery set already reflects the first's changes and it becomes a zero-delta
+//! no-op — a stale discovery set can never remove a generation a concurrent
+//! refresh just added. The refresh mutex is NEVER taken on a query path.
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -209,6 +214,13 @@ impl SSTableManager {
     /// full contract (snapshot-at-open, explicit refresh, in-flight isolation,
     /// fail-closed atomicity).
     pub async fn refresh_tables(&self) -> Result<RefreshReport> {
+        // 0. Serialize the WHOLE refresh (discovery through swap) so two
+        //    concurrent refreshes cannot interleave: without this, a refresh with
+        //    a stale discovery set (step 1) could, at swap time (step 5), remove a
+        //    generation a concurrent refresh already added (TOCTOU, Decision 4).
+        //    Held only across the refresh; queries never take this lock.
+        let _refresh_guard = self.refresh_lock.lock().await;
+
         // 1. Rediscover the current on-disk Data.db set (no readers opened yet).
         let discovered_paths = self.discover_data_file_paths().await?;
 
@@ -615,6 +627,143 @@ mod tests {
         assert!(
             Arc::ptr_eq(&before[0], &after[0]),
             "no-op refresh must keep the SAME reader Arc (warm state preserved)"
+        );
+    }
+
+    /// Two SEQUENTIAL refreshes with a generation added between them must both
+    /// apply correctly: the first is a no-op over the unchanged directory, the
+    /// second picks up the newly-added generation. Deterministic (no timing).
+    #[tokio::test]
+    async fn sequential_refreshes_each_apply_correctly() {
+        let src = TempDir::new().expect("tmp src");
+        let src_table_dir = build_two_generations(src.path()).await;
+
+        let live = TempDir::new().expect("tmp live");
+        let live_table_dir = live.path().join("ks_ptr").join("users");
+        copy_generation(&src_table_dir, &live_table_dir, 1);
+
+        let config = Config::default();
+        let platform = Arc::new(Platform::new(&config).await.expect("platform"));
+        let manager = SSTableManager::new(
+            live.path(),
+            &config,
+            platform,
+            #[cfg(feature = "state_machine")]
+            None,
+        )
+        .await
+        .expect("manager");
+
+        // First refresh over the unchanged directory: zero delta.
+        let first = manager.refresh_tables().await.expect("first refresh");
+        assert_eq!(first.readers_added, 0, "first refresh adds nothing");
+        assert_eq!(first.readers_removed, 0, "first refresh removes nothing");
+
+        // Add gen-2, then refresh again: the second refresh picks it up.
+        copy_generation(&src_table_dir, &live_table_dir, 2);
+        let second = manager.refresh_tables().await.expect("second refresh");
+        assert_eq!(second.readers_added, 1, "second refresh adds gen-2");
+        assert_eq!(second.readers_removed, 0, "second refresh removes nothing");
+
+        let held = {
+            let table_readers = manager.table_readers.read().await;
+            table_readers
+                .values()
+                .flatten()
+                .map(Arc::clone)
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(
+            held.len(),
+            2,
+            "both generations held after the two refreshes"
+        );
+    }
+
+    /// Regression for the TOCTOU race (issue #1749, Decision 4): N `refresh()`
+    /// calls launched concurrently after a generation is added must serialize on
+    /// the refresh mutex. The final reader set must equal the on-disk truth
+    /// ({gen-1, gen-2}), EXACTLY ONE refresh may report the addition (the rest are
+    /// zero-delta no-ops), and NO reader may vanish (a stale-discovery refresh must
+    /// not remove what a concurrent refresh just added). Deterministic: correctness
+    /// is asserted on the final state and the aggregate deltas, with no timing.
+    #[tokio::test]
+    async fn concurrent_refreshes_serialize_no_reader_vanishes() {
+        let src = TempDir::new().expect("tmp src");
+        let src_table_dir = build_two_generations(src.path()).await;
+
+        let live = TempDir::new().expect("tmp live");
+        let live_table_dir = live.path().join("ks_ptr").join("users");
+        copy_generation(&src_table_dir, &live_table_dir, 1);
+
+        let config = Config::default();
+        let platform = Arc::new(Platform::new(&config).await.expect("platform"));
+        let manager = SSTableManager::new(
+            live.path(),
+            &config,
+            platform,
+            #[cfg(feature = "state_machine")]
+            None,
+        )
+        .await
+        .expect("manager");
+
+        // Add gen-2 on disk, then fire several refreshes concurrently.
+        copy_generation(&src_table_dir, &live_table_dir, 2);
+        let (r0, r1, r2, r3) = tokio::join!(
+            manager.refresh_tables(),
+            manager.refresh_tables(),
+            manager.refresh_tables(),
+            manager.refresh_tables(),
+        );
+        let reports = [
+            r0.expect("refresh 0"),
+            r1.expect("refresh 1"),
+            r2.expect("refresh 2"),
+            r3.expect("refresh 3"),
+        ];
+
+        // Exactly one refresh applied the +1 addition; the rest are no-ops. No
+        // refresh may report a removal (nothing left the directory).
+        let total_added: usize = reports.iter().map(|r| r.readers_added).sum();
+        let total_removed: usize = reports.iter().map(|r| r.readers_removed).sum();
+        assert_eq!(
+            total_added, 1,
+            "exactly one serialized refresh adds gen-2 (others are no-ops)"
+        );
+        assert_eq!(
+            total_removed, 0,
+            "no refresh may remove a reader a concurrent refresh just added"
+        );
+
+        // Final held set equals the on-disk truth: both generations, none vanished.
+        let held = {
+            let table_readers = manager.table_readers.read().await;
+            table_readers
+                .values()
+                .flatten()
+                .map(Arc::clone)
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(
+            held.len(),
+            2,
+            "final reader set equals on-disk truth ({{gen-1, gen-2}})"
+        );
+        let scanned = manager
+            .scan(
+                &crate::types::TableId::new("ks_ptr.users"),
+                None,
+                None,
+                None,
+                Some(&users_schema()),
+            )
+            .await
+            .expect("post scan");
+        assert_eq!(
+            scan_partition_ids(&scanned),
+            std::collections::BTreeSet::from([1, 2]),
+            "both partitions queryable after concurrent refreshes"
         );
     }
 }

--- a/cqlite-core/src/storage/sstable/refresh.rs
+++ b/cqlite-core/src/storage/sstable/refresh.rs
@@ -1,0 +1,408 @@
+//! Explicit, concurrency-safe SSTable directory refresh (issue #1749).
+//!
+//! CQLite opens a data directory once and snapshots the discovered SSTable
+//! generations. A Cassandra flush/compaction (or a CQLite `--flush`) may add or
+//! remove generations underneath a long-lived handle at any time, but a warm
+//! session never re-scans on its own — that is the documented per-surface
+//! *freshness contract*: the library handle is a **snapshot at open**, and
+//! [`SSTableManager::refresh_tables`] is the ONLY way its reader set changes.
+//!
+//! `refresh_tables` re-runs the *same* directory discovery that
+//! [`StorageEngine::open`](crate::storage::StorageEngine::open) used (TOC /
+//! filename-component based — no content sniffing, no heuristics), diffs the
+//! discovered canonical `Data.db` paths against the held reader set, and applies
+//! the difference:
+//!
+//! - **added** generations are opened (standard [`SSTableReader::open`]:
+//!   bloom/Index/Statistics parsed, the issue #1626 corrupt-`Statistics.db`
+//!   hard-fail inherited) and become queryable;
+//! - **removed** generations are dropped (the underlying reader closes once the
+//!   last in-flight scan's `Arc` clone is dropped);
+//! - **unchanged** generations keep their existing `Arc<SSTableReader>` — their
+//!   parsed Index/Statistics/bloom state is *not* rebuilt (refresh of an
+//!   unchanged directory is ~free).
+//!
+//! Application is **atomic and fail-closed**: every added generation is opened
+//! *before* the write guard is taken, so if any open fails the whole refresh
+//! returns that typed error and mutates nothing — no partial view (Decision 3).
+//!
+//! Concurrency reuses the existing lock discipline (Decision 4): queries resolve
+//! their reader list once under the `RwLock` read guard and hold `Arc` clones, so
+//! a scan already in flight completes against the pre-refresh set and is never
+//! affected by a concurrent refresh.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use super::{
+    extract_keyspace_and_table_name, extract_table_name, is_apple_double_sidecar, reader,
+    SSTableId, SSTableManager, MAX_SSTABLE_SCAN_DEPTH,
+};
+use crate::Result;
+
+/// Outcome of a single [`SSTableManager::refresh_tables`] call.
+///
+/// Counts reflect what *this* refresh actually applied under the write guard:
+/// two concurrent refreshes serialize, and the second observes the first's
+/// changes already applied (so it reports a zero-delta no-op).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RefreshReport {
+    /// Number of distinct logical tables present after the refresh.
+    pub tables_scanned: usize,
+    /// SSTable generations newly opened and added by this refresh.
+    pub readers_added: usize,
+    /// SSTable generations dropped by this refresh (no longer on disk).
+    pub readers_removed: usize,
+}
+
+/// How a manager discovers its SSTable generations — recorded at construction so
+/// [`SSTableManager::refresh_tables`] re-runs *exactly* the same discovery.
+#[derive(Debug, Clone)]
+pub(crate) enum DiscoverySource {
+    /// Recursively scan `base_path` (mirrors `SSTableManager::new` /
+    /// `StorageEngine::open` — the library-handle path).
+    BasePath,
+    /// Scan a fixed set of pre-discovered table directories (mirrors
+    /// `SSTableManager::new_from_discovered_paths`).
+    TableDirs(Vec<PathBuf>),
+}
+
+/// Compute the `table_readers` key for a Data.db `path` using the **base-path**
+/// discovery keying — the single source of truth shared by `load_existing_sstables`
+/// and [`SSTableManager::refresh_tables`] so the two can never drift.
+///
+/// Priority (identical to the original inline logic, issue #680):
+///   1. `keyspace.table` from the filesystem path (when the table name is
+///      meaningful, i.e. not merely the scan base directory name);
+///   2. the unqualified table name from the path (same base-dir exclusion);
+///   3. the table name embedded in the SSTable header (last resort).
+pub(crate) fn base_path_table_key(
+    path: &Path,
+    base_dir_name: &str,
+    header_table_name: &str,
+) -> Option<String> {
+    if let Some((keyspace, table_name)) = extract_keyspace_and_table_name(path) {
+        if table_name.as_str() != base_dir_name {
+            return Some(format!("{}.{}", keyspace, table_name));
+        }
+    }
+    if let Some(name) = extract_table_name(path) {
+        if name.as_str() != base_dir_name {
+            return Some(name);
+        }
+    }
+    if header_table_name != "test_table" && !header_table_name.is_empty() {
+        return Some(header_table_name.to_string());
+    }
+    None
+}
+
+/// Compute the `table_readers` key for a Data.db `path` using the
+/// **table-directories** discovery keying — the single source of truth shared by
+/// `load_from_table_directories` and [`SSTableManager::refresh_tables`].
+pub(crate) fn table_dir_table_key(path: &Path) -> Option<String> {
+    if let Some((keyspace, table_name)) = extract_keyspace_and_table_name(path) {
+        Some(format!("{}.{}", keyspace, table_name))
+    } else {
+        extract_table_name(path)
+    }
+}
+
+/// Canonicalize `p` for stable diffing, falling back to the path as-given when
+/// the file no longer exists (a removed generation) or cannot be canonicalized.
+/// Never panics — uses `unwrap_or_else`, not `unwrap`.
+fn canon(p: &Path) -> PathBuf {
+    std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf())
+}
+
+impl SSTableManager {
+    /// Open an `SSTableReader` at `path` and wire the schema/UDT registries onto
+    /// it (when the `state_machine` feature is enabled), returning a shared
+    /// handle. Extracted so the initial load paths and refresh open readers
+    /// identically. The `SSTableReader::open` error — including the issue #1626
+    /// corrupt-`Statistics.db` hard-fail — is propagated to the caller, which
+    /// decides whether to skip (initial best-effort load) or abort (fail-closed
+    /// refresh).
+    pub(crate) async fn open_reader_with_schema(
+        &self,
+        path: &Path,
+    ) -> Result<Arc<reader::SSTableReader>> {
+        #[cfg_attr(not(feature = "state_machine"), allow(unused_mut))]
+        let mut reader = reader::SSTableReader::open(path, &self.config, self.platform.clone()).await?;
+
+        #[cfg(feature = "state_machine")]
+        {
+            let schema_reg_guard = self.schema_registry.read().await;
+            if let Some(ref registry_rwlock) = *schema_reg_guard {
+                reader.set_schema_registry(Arc::clone(registry_rwlock));
+
+                // Also set the UDT registry for UDT-aware collection parsing (Issue #238).
+                let schema_registry = registry_rwlock.read().await;
+                let udt_registry_lock = schema_registry.get_udt_registry();
+                let udt_registry = udt_registry_lock.read().await.clone();
+                reader.set_udt_registry(udt_registry);
+            }
+        }
+
+        Ok(Arc::new(reader))
+    }
+
+    /// List the current on-disk `Data.db` paths using the manager's recorded
+    /// [`DiscoverySource`] — the same discovery the manager was built with.
+    async fn discover_data_file_paths(&self) -> Result<Vec<PathBuf>> {
+        match &self.discovery_source {
+            DiscoverySource::BasePath => {
+                if !self.platform.fs().exists(&self.base_path).await? {
+                    return Ok(Vec::new());
+                }
+                SSTableManager::find_data_files(
+                    &self.platform,
+                    &self.base_path,
+                    MAX_SSTABLE_SCAN_DEPTH,
+                )
+                .await
+            }
+            DiscoverySource::TableDirs(dirs) => {
+                let mut out = Vec::new();
+                for dir in dirs {
+                    if !self.platform.fs().exists(dir).await? {
+                        continue;
+                    }
+                    let mut entries = match self.platform.fs().read_dir(dir).await {
+                        Ok(entries) => entries,
+                        Err(_) => continue,
+                    };
+                    while let Some(entry) = entries.next_entry().await? {
+                        let path = entry.path();
+                        if let Some(fname) = path.file_name().and_then(|n| n.to_str()) {
+                            if fname.ends_with("-Data.db") && !is_apple_double_sidecar(fname) {
+                                out.push(path);
+                            }
+                        }
+                    }
+                }
+                Ok(out)
+            }
+        }
+    }
+
+    /// Compute the `table_readers` key for a discovered `path`/`reader` under the
+    /// manager's discovery keying.
+    fn table_key_for(&self, path: &Path, reader: &reader::SSTableReader) -> Option<String> {
+        match &self.discovery_source {
+            DiscoverySource::BasePath => {
+                let base_dir_name = self
+                    .base_path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("");
+                base_path_table_key(path, base_dir_name, &reader.header().table_name)
+            }
+            DiscoverySource::TableDirs(_) => table_dir_table_key(path),
+        }
+    }
+
+    /// Re-scan the data directory and atomically apply added/removed SSTable
+    /// generations to the held reader set. See the [module docs](self) for the
+    /// full contract (snapshot-at-open, explicit refresh, in-flight isolation,
+    /// fail-closed atomicity).
+    pub async fn refresh_tables(&self) -> Result<RefreshReport> {
+        // 1. Rediscover the current on-disk Data.db set (no readers opened yet).
+        let discovered_paths = self.discover_data_file_paths().await?;
+        let discovered_canon: HashSet<PathBuf> =
+            discovered_paths.iter().map(|p| canon(p)).collect();
+
+        // 2. Snapshot the canonical paths currently held (short read guards).
+        //    Union both maps so no held generation is missed even under a
+        //    pre-existing SSTableId (filename) collision across keyspaces.
+        let held_canon: HashSet<PathBuf> = {
+            let readers = self.readers.read().await;
+            let table_readers = self.table_readers.read().await;
+            readers
+                .values()
+                .map(|r| canon(&r.file_path))
+                .chain(table_readers.values().flatten().map(|r| canon(&r.file_path)))
+                .collect()
+        };
+
+        // 3. Candidate additions = discovered paths not already held.
+        let added_paths: Vec<PathBuf> = discovered_paths
+            .into_iter()
+            .filter(|p| !held_canon.contains(&canon(p)))
+            .collect();
+
+        // 4. Open every added generation OUTSIDE the write guard. Fail-closed:
+        //    the first open error aborts the whole refresh, mutating nothing.
+        let mut opened: Vec<(PathBuf, SSTableId, Option<String>, Arc<reader::SSTableReader>)> =
+            Vec::with_capacity(added_paths.len());
+        for path in &added_paths {
+            let Some(filename) = path.file_name().and_then(|n| n.to_str()) else {
+                continue;
+            };
+            let sstable_id = SSTableId::from_filename(filename);
+            let reader_arc = self.open_reader_with_schema(path).await?;
+            let key = self.table_key_for(path, &reader_arc);
+            opened.push((canon(path), sstable_id, key, reader_arc));
+        }
+
+        // 5. Apply the diff under the write guards (short critical section).
+        let mut readers = self.readers.write().await;
+        let mut table_readers = self.table_readers.write().await;
+
+        // 5a. Removal: retain only readers still present on disk.
+        let before_canon: HashSet<PathBuf> = readers
+            .values()
+            .map(|r| canon(&r.file_path))
+            .chain(table_readers.values().flatten().map(|r| canon(&r.file_path)))
+            .collect();
+
+        readers.retain(|_id, r| discovered_canon.contains(&canon(&r.file_path)));
+        for list in table_readers.values_mut() {
+            list.retain(|r| discovered_canon.contains(&canon(&r.file_path)));
+        }
+        table_readers.retain(|_key, list| !list.is_empty());
+
+        let after_removal_canon: HashSet<PathBuf> = readers
+            .values()
+            .map(|r| canon(&r.file_path))
+            .chain(table_readers.values().flatten().map(|r| canon(&r.file_path)))
+            .collect();
+        let readers_removed = before_canon.difference(&after_removal_canon).count();
+
+        // 5b. Addition: insert the pre-opened readers, skipping any a concurrent
+        //     refresh already added (preserving that refresh's warm Arc).
+        let mut readers_added = 0usize;
+        for (cpath, sstable_id, key, reader_arc) in opened {
+            if after_removal_canon.contains(&cpath) {
+                continue;
+            }
+            // Guard against inserting the same freshly-opened path twice if the
+            // discovery listed a duplicate (defensive; discovery does not).
+            if readers.values().any(|r| canon(&r.file_path) == cpath) {
+                continue;
+            }
+            readers.insert(sstable_id, Arc::clone(&reader_arc));
+            if let Some(key) = key {
+                table_readers.entry(key).or_default().push(reader_arc);
+            }
+            readers_added += 1;
+        }
+
+        let tables_scanned = table_readers.len();
+
+        Ok(RefreshReport {
+            tables_scanned,
+            readers_added,
+            readers_removed,
+        })
+    }
+}
+
+#[cfg(all(test, feature = "write-support", feature = "state_machine"))]
+mod tests {
+    use super::*;
+    use crate::schema::{Column, KeyColumn, TableSchema};
+    use crate::storage::write_engine::{
+        CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+    };
+    use crate::types::Value;
+    use crate::{Config, Platform};
+    use std::collections::HashMap;
+    use tempfile::TempDir;
+
+    fn users_schema() -> TableSchema {
+        TableSchema {
+            keyspace: "ks_ptr".to_string(),
+            table: "users".to_string(),
+            partition_keys: vec![KeyColumn {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                position: 0,
+            }],
+            clustering_keys: vec![],
+            columns: vec![
+                Column {
+                    name: "id".to_string(),
+                    data_type: "int".to_string(),
+                    nullable: false,
+                    default: None,
+                    is_static: false,
+                },
+                Column {
+                    name: "value".to_string(),
+                    data_type: "text".to_string(),
+                    nullable: true,
+                    default: None,
+                    is_static: false,
+                },
+            ],
+            comments: HashMap::new(),
+            dropped_columns: HashMap::new(),
+        }
+    }
+
+    async fn flush_one_partition(data_dir: &Path, wal_dir: &Path, id: i32) {
+        let config = WriteEngineConfig::new(
+            data_dir.to_path_buf(),
+            wal_dir.to_path_buf(),
+            users_schema(),
+        );
+        let mut engine = WriteEngine::new(config).expect("write engine");
+        let table_id = TableId::new("ks_ptr", "users");
+        let pk = PartitionKey::single("id", Value::Integer(id));
+        let ops = vec![CellOperation::Write {
+            column: "value".to_string(),
+            value: Value::Text(format!("v{}", id)),
+        }];
+        engine
+            .write_async(Mutation::new(table_id, pk, None, ops, 1_000 + id as i64, None))
+            .await
+            .expect("write");
+        engine.flush().await.expect("flush");
+    }
+
+    /// Spec scenario "Unchanged directory is a cheap no-op": a refresh over an
+    /// unchanged directory reports a zero delta AND keeps the exact same reader
+    /// `Arc` objects (pointer identity — warm state preserved).
+    #[tokio::test]
+    async fn refresh_noop_preserves_reader_arc_identity() {
+        let tmp = TempDir::new().expect("tmp");
+        let data_dir = tmp.path().join("data");
+        let wal_dir = tmp.path().join("wal");
+        flush_one_partition(&data_dir, &wal_dir, 1).await;
+
+        let config = Config::default();
+        let platform = Arc::new(Platform::new(&config).await.expect("platform"));
+        let manager = SSTableManager::new(
+            &data_dir,
+            &config,
+            platform,
+            #[cfg(feature = "state_machine")]
+            None,
+        )
+        .await
+        .expect("manager");
+
+        // Snapshot the reader Arc(s) for the table before refresh.
+        let before: Vec<Arc<reader::SSTableReader>> = {
+            let table_readers = manager.table_readers.read().await;
+            table_readers.values().flatten().map(Arc::clone).collect()
+        };
+        assert_eq!(before.len(), 1, "one generation expected pre-refresh");
+
+        let report = manager.refresh_tables().await.expect("refresh");
+        assert_eq!(report.readers_added, 0, "no-op: nothing added");
+        assert_eq!(report.readers_removed, 0, "no-op: nothing removed");
+
+        let after: Vec<Arc<reader::SSTableReader>> = {
+            let table_readers = manager.table_readers.read().await;
+            table_readers.values().flatten().map(Arc::clone).collect()
+        };
+        assert_eq!(after.len(), 1, "still one generation after no-op refresh");
+        assert!(
+            Arc::ptr_eq(&before[0], &after[0]),
+            "no-op refresh must keep the SAME reader Arc (warm state preserved)"
+        );
+    }
+}

--- a/cqlite-core/src/storage/sstable/refresh.rs
+++ b/cqlite-core/src/storage/sstable/refresh.rs
@@ -129,7 +129,8 @@ impl SSTableManager {
         path: &Path,
     ) -> Result<Arc<reader::SSTableReader>> {
         #[cfg_attr(not(feature = "state_machine"), allow(unused_mut))]
-        let mut reader = reader::SSTableReader::open(path, &self.config, self.platform.clone()).await?;
+        let mut reader =
+            reader::SSTableReader::open(path, &self.config, self.platform.clone()).await?;
 
         #[cfg(feature = "state_machine")]
         {
@@ -222,7 +223,12 @@ impl SSTableManager {
             readers
                 .values()
                 .map(|r| canon(&r.file_path))
-                .chain(table_readers.values().flatten().map(|r| canon(&r.file_path)))
+                .chain(
+                    table_readers
+                        .values()
+                        .flatten()
+                        .map(|r| canon(&r.file_path)),
+                )
                 .collect()
         };
 
@@ -234,8 +240,12 @@ impl SSTableManager {
 
         // 4. Open every added generation OUTSIDE the write guard. Fail-closed:
         //    the first open error aborts the whole refresh, mutating nothing.
-        let mut opened: Vec<(PathBuf, SSTableId, Option<String>, Arc<reader::SSTableReader>)> =
-            Vec::with_capacity(added_paths.len());
+        let mut opened: Vec<(
+            PathBuf,
+            SSTableId,
+            Option<String>,
+            Arc<reader::SSTableReader>,
+        )> = Vec::with_capacity(added_paths.len());
         for path in &added_paths {
             let Some(filename) = path.file_name().and_then(|n| n.to_str()) else {
                 continue;
@@ -254,7 +264,12 @@ impl SSTableManager {
         let before_canon: HashSet<PathBuf> = readers
             .values()
             .map(|r| canon(&r.file_path))
-            .chain(table_readers.values().flatten().map(|r| canon(&r.file_path)))
+            .chain(
+                table_readers
+                    .values()
+                    .flatten()
+                    .map(|r| canon(&r.file_path)),
+            )
             .collect();
 
         readers.retain(|_id, r| discovered_canon.contains(&canon(&r.file_path)));
@@ -266,7 +281,12 @@ impl SSTableManager {
         let after_removal_canon: HashSet<PathBuf> = readers
             .values()
             .map(|r| canon(&r.file_path))
-            .chain(table_readers.values().flatten().map(|r| canon(&r.file_path)))
+            .chain(
+                table_readers
+                    .values()
+                    .flatten()
+                    .map(|r| canon(&r.file_path)),
+            )
             .collect();
         let readers_removed = before_canon.difference(&after_removal_canon).count();
 
@@ -356,7 +376,14 @@ mod tests {
             value: Value::Text(format!("v{}", id)),
         }];
         engine
-            .write_async(Mutation::new(table_id, pk, None, ops, 1_000 + id as i64, None))
+            .write_async(Mutation::new(
+                table_id,
+                pk,
+                None,
+                ops,
+                1_000 + id as i64,
+                None,
+            ))
             .await
             .expect("write");
         engine.flush().await.expect("flush");
@@ -377,7 +404,14 @@ mod tests {
                 value: Value::Text(format!("v{}", id)),
             }];
             engine
-                .write_async(Mutation::new(table_id, pk, None, ops, 1_000 + id as i64, None))
+                .write_async(Mutation::new(
+                    table_id,
+                    pk,
+                    None,
+                    ops,
+                    1_000 + id as i64,
+                    None,
+                ))
                 .await
                 .expect("write");
             engine.flush().await.expect("flush");
@@ -401,7 +435,9 @@ mod tests {
         assert!(copied > 0, "copied generation {} components", gen);
     }
 
-    fn scan_partition_ids(rows: &[(crate::RowKey, crate::ScanRow)]) -> std::collections::BTreeSet<i32> {
+    fn scan_partition_ids(
+        rows: &[(crate::RowKey, crate::ScanRow)],
+    ) -> std::collections::BTreeSet<i32> {
         rows.iter()
             .map(|(key, _)| {
                 let b = key.as_bytes();
@@ -460,7 +496,11 @@ mod tests {
             let table_readers = manager.table_readers.read().await;
             table_readers.values().flatten().map(Arc::clone).collect()
         };
-        assert_eq!(held_snapshot.len(), 1, "in-flight scan holds one gen-1 reader");
+        assert_eq!(
+            held_snapshot.len(),
+            1,
+            "in-flight scan holds one gen-1 reader"
+        );
 
         // Add gen-2 and refresh while that snapshot is "in flight".
         copy_generation(&src_table_dir, &live_table_dir, 2);

--- a/cqlite-core/src/storage/sstable/refresh.rs
+++ b/cqlite-core/src/storage/sstable/refresh.rs
@@ -362,6 +362,151 @@ mod tests {
         engine.flush().await.expect("flush");
     }
 
+    /// Build a source dir holding two generations (`nb-1` = partition 1, `nb-2` =
+    /// partition 2), returning the `.../ks_ptr/users` table directory.
+    async fn build_two_generations(root: &Path) -> PathBuf {
+        let data_dir = root.join("data");
+        let wal_dir = root.join("wal");
+        let config = WriteEngineConfig::new(data_dir.clone(), wal_dir, users_schema());
+        let mut engine = WriteEngine::new(config).expect("write engine");
+        for id in [1_i32, 2_i32] {
+            let table_id = TableId::new("ks_ptr", "users");
+            let pk = PartitionKey::single("id", Value::Integer(id));
+            let ops = vec![CellOperation::Write {
+                column: "value".to_string(),
+                value: Value::Text(format!("v{}", id)),
+            }];
+            engine
+                .write_async(Mutation::new(table_id, pk, None, ops, 1_000 + id as i64, None))
+                .await
+                .expect("write");
+            engine.flush().await.expect("flush");
+        }
+        data_dir.join("ks_ptr").join("users")
+    }
+
+    fn copy_generation(src_table_dir: &Path, dst_table_dir: &Path, gen: u32) {
+        std::fs::create_dir_all(dst_table_dir).expect("mkdir dst");
+        let prefix = format!("nb-{}-big-", gen);
+        let mut copied = 0;
+        for entry in std::fs::read_dir(src_table_dir).expect("read src") {
+            let entry = entry.expect("entry");
+            let name = entry.file_name();
+            let name = name.to_str().expect("utf8");
+            if name.starts_with(&prefix) {
+                std::fs::copy(entry.path(), dst_table_dir.join(name)).expect("copy");
+                copied += 1;
+            }
+        }
+        assert!(copied > 0, "copied generation {} components", gen);
+    }
+
+    fn scan_partition_ids(rows: &[(crate::RowKey, crate::ScanRow)]) -> std::collections::BTreeSet<i32> {
+        rows.iter()
+            .map(|(key, _)| {
+                let b = key.as_bytes();
+                assert_eq!(b.len(), 4, "int pk is 4 bytes");
+                i32::from_be_bytes([b[0], b[1], b[2], b[3]])
+            })
+            .collect()
+    }
+
+    /// Spec scenario "In-flight scan unaffected by concurrent refresh".
+    ///
+    /// A scan resolves its reader list once (under the read guard) and holds
+    /// `Arc` clones; a scan's output is therefore a pure function of the reader
+    /// set it captured. This test pins the isolation invariant deterministically
+    /// (no timing): it captures the exact `Arc` reader set an in-flight scan
+    /// would hold on the pre-refresh directory, adds a generation and refreshes,
+    /// and asserts (a) the captured set is byte-for-byte unchanged by the refresh
+    /// — so a scan bound to it still yields the pre-refresh content {1} — and
+    /// (b) a scan started AFTER the refresh sees the post-refresh content {1, 2}.
+    #[tokio::test]
+    async fn in_flight_scan_unaffected_by_concurrent_refresh() {
+        let src = TempDir::new().expect("tmp src");
+        let src_table_dir = build_two_generations(src.path()).await;
+
+        let live = TempDir::new().expect("tmp live");
+        let live_table_dir = live.path().join("ks_ptr").join("users");
+        copy_generation(&src_table_dir, &live_table_dir, 1);
+
+        let config = Config::default();
+        let platform = Arc::new(Platform::new(&config).await.expect("platform"));
+        let manager = SSTableManager::new(
+            live.path(),
+            &config,
+            platform,
+            #[cfg(feature = "state_machine")]
+            None,
+        )
+        .await
+        .expect("manager");
+
+        let schema = users_schema();
+        let table_id = crate::types::TableId::new("ks_ptr.users");
+
+        // Pre-refresh scan content is {1}; capture the exact Arc reader set an
+        // in-flight scan would hold (the read-guard snapshot the scan clones).
+        let pre_rows = manager
+            .scan(&table_id, None, None, None, Some(&schema))
+            .await
+            .expect("pre scan");
+        assert_eq!(
+            scan_partition_ids(&pre_rows),
+            std::collections::BTreeSet::from([1]),
+            "pre-refresh scan content is gen-1 only"
+        );
+        let held_snapshot: Vec<Arc<reader::SSTableReader>> = {
+            let table_readers = manager.table_readers.read().await;
+            table_readers.values().flatten().map(Arc::clone).collect()
+        };
+        assert_eq!(held_snapshot.len(), 1, "in-flight scan holds one gen-1 reader");
+
+        // Add gen-2 and refresh while that snapshot is "in flight".
+        copy_generation(&src_table_dir, &live_table_dir, 2);
+        let report = manager.refresh_tables().await.expect("refresh");
+        assert_eq!(report.readers_added, 1, "gen-2 added");
+
+        // (a) The captured in-flight reader set is unchanged by the refresh: the
+        //     same single gen-1 Arc (pointer identity), and NOT the gen-2 reader.
+        //     A scan bound to this unchanged set is therefore still exactly {1}.
+        let post_snapshot: Vec<Arc<reader::SSTableReader>> = {
+            let table_readers = manager.table_readers.read().await;
+            table_readers.values().flatten().map(Arc::clone).collect()
+        };
+        assert_eq!(post_snapshot.len(), 2, "manager now holds both generations");
+        assert_eq!(
+            held_snapshot.len(),
+            1,
+            "the in-flight snapshot is untouched by refresh"
+        );
+        assert!(
+            post_snapshot
+                .iter()
+                .any(|r| Arc::ptr_eq(r, &held_snapshot[0])),
+            "the pre-refresh gen-1 reader Arc survives the refresh unchanged"
+        );
+        let gen2_reader = post_snapshot
+            .iter()
+            .find(|r| !Arc::ptr_eq(r, &held_snapshot[0]))
+            .expect("gen-2 reader present post-refresh");
+        assert!(
+            !Arc::ptr_eq(gen2_reader, &held_snapshot[0]),
+            "the added gen-2 reader is NOT part of the in-flight snapshot (isolation)"
+        );
+
+        // (b) A scan started AFTER the refresh sees the post-refresh set {1, 2}.
+        let post_rows = manager
+            .scan(&table_id, None, None, None, Some(&schema))
+            .await
+            .expect("post scan");
+        assert_eq!(
+            scan_partition_ids(&post_rows),
+            std::collections::BTreeSet::from([1, 2]),
+            "post-refresh scan sees the new generation"
+        );
+    }
+
     /// Spec scenario "Unchanged directory is a cheap no-op": a refresh over an
     /// unchanged directory reports a zero delta AND keeps the exact same reader
     /// `Arc` objects (pointer identity — warm state preserved).

--- a/cqlite-core/tests/issue_1749_sstable_freshness_refresh.rs
+++ b/cqlite-core/tests/issue_1749_sstable_freshness_refresh.rs
@@ -135,7 +135,11 @@ fn delete_generation(table_dir: &Path, gen: u32) -> usize {
             removed += 1;
         }
     }
-    assert!(removed > 0, "expected to remove generation {} components", gen);
+    assert!(
+        removed > 0,
+        "expected to remove generation {} components",
+        gen
+    );
     removed
 }
 
@@ -261,7 +265,10 @@ async fn corrupt_new_generation_rejects_whole_refresh() {
     std::fs::write(&stats, b"\x00\x01\x02corrupt-not-a-statistics-db\xff\xff")
         .expect("corrupt statistics");
 
-    let err = db.refresh().await.expect_err("refresh must fail-closed on corrupt generation");
+    let err = db
+        .refresh()
+        .await
+        .expect_err("refresh must fail-closed on corrupt generation");
     // Typed error (no panic); any Error variant is acceptable — assert it Displays.
     let _ = err.to_string();
 
@@ -294,7 +301,11 @@ async fn unchanged_directory_is_zero_delta_noop() {
     assert_eq!(report.readers_added, 0, "no-op: nothing added");
     assert_eq!(report.readers_removed, 0, "no-op: nothing removed");
 
-    assert_eq!(select_all_ids(&db).await, before, "result unchanged by no-op");
+    assert_eq!(
+        select_all_ids(&db).await,
+        before,
+        "result unchanged by no-op"
+    );
 }
 
 // The "In-flight scan unaffected by concurrent refresh" spec scenario is covered

--- a/cqlite-core/tests/issue_1749_sstable_freshness_refresh.rs
+++ b/cqlite-core/tests/issue_1749_sstable_freshness_refresh.rs
@@ -1,0 +1,306 @@
+//! Issue #1749: explicit SSTable directory refresh — public-surface integration
+//! tests for the storage-freshness spec (`Database::refresh()`).
+//!
+//! Fixtures are REAL CQLite-written uncompressed SSTables (the write path is
+//! byte-parity with Cassandra, M5) built in-test, giving deterministic,
+//! distinct-partition generations. Because the fixtures are generated here, an
+//! "absent dataset" case cannot silently skip: a fixture-write failure fails the
+//! test, and every row assertion is an exact count (never `>= 0`), so a
+//! 0-rows-on-present-data regression fails loudly.
+//!
+//! Gated on `write-support` (to build the fixtures) and `state_machine` (to run
+//! SELECTs via `Database::execute`), so the file is empty in the minimal build —
+//! no ungated write-support test items leak into the minimal-features CI step.
+
+#![cfg(all(feature = "write-support", feature = "state_machine"))]
+
+use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+use cqlite_core::storage::write_engine::{
+    CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::Value;
+use cqlite_core::{Config, Database};
+use std::collections::{BTreeSet, HashMap};
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+const KEYSPACE: &str = "test_freshness";
+const TABLE: &str = "users";
+
+fn users_schema() -> TableSchema {
+    TableSchema {
+        keyspace: KEYSPACE.to_string(),
+        table: TABLE.to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            Column {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "value".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+/// Build a SOURCE directory holding two SSTable generations of the same table:
+/// `nb-1-big-*` contains only partition id=1, `nb-2-big-*` only partition id=2
+/// (each flush of a single WriteEngine advances the generation). Returns the
+/// `.../<keyspace>/<table>` directory containing both generations.
+async fn build_two_generations(root: &Path) -> PathBuf {
+    let data_dir = root.join("data");
+    let wal_dir = root.join("wal");
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir, users_schema());
+    let mut engine = WriteEngine::new(config).expect("write engine");
+
+    for id in [1_i32, 2_i32] {
+        let table_id = TableId::new(KEYSPACE, TABLE);
+        let pk = PartitionKey::single("id", Value::Integer(id));
+        let ops = vec![CellOperation::Write {
+            column: "value".to_string(),
+            value: Value::Text(format!("v{}", id)),
+        }];
+        engine
+            .write_async(Mutation::new(
+                table_id,
+                pk,
+                None,
+                ops,
+                1_000 + id as i64,
+                None,
+            ))
+            .await
+            .expect("write partition");
+        engine.flush().await.expect("flush generation");
+    }
+
+    let table_dir = data_dir.join(KEYSPACE).join(TABLE);
+    assert!(
+        table_dir.join("nb-1-big-Data.db").exists(),
+        "gen-1 must exist in source"
+    );
+    assert!(
+        table_dir.join("nb-2-big-Data.db").exists(),
+        "gen-2 must exist in source"
+    );
+    table_dir
+}
+
+/// Copy every component file of one generation (`nb-<n>-big-*`) from
+/// `src_table_dir` into `dst_table_dir`, creating the destination if needed.
+/// Returns the number of component files copied (must be > 0).
+fn copy_generation(src_table_dir: &Path, dst_table_dir: &Path, gen: u32) -> usize {
+    std::fs::create_dir_all(dst_table_dir).expect("create dst table dir");
+    let prefix = format!("nb-{}-big-", gen);
+    let mut copied = 0;
+    for entry in std::fs::read_dir(src_table_dir).expect("read src table dir") {
+        let entry = entry.expect("dir entry");
+        let name = entry.file_name();
+        let name = name.to_str().expect("utf8 filename");
+        if name.starts_with(&prefix) {
+            std::fs::copy(entry.path(), dst_table_dir.join(name)).expect("copy component");
+            copied += 1;
+        }
+    }
+    assert!(copied > 0, "expected to copy generation {} components", gen);
+    copied
+}
+
+/// Delete every component file of one generation (`nb-<n>-big-*`) from
+/// `table_dir` (simulating a compaction that removed the generation).
+fn delete_generation(table_dir: &Path, gen: u32) -> usize {
+    let prefix = format!("nb-{}-big-", gen);
+    let mut removed = 0;
+    for entry in std::fs::read_dir(table_dir).expect("read table dir") {
+        let entry = entry.expect("dir entry");
+        let name = entry.file_name();
+        let name = name.to_str().expect("utf8 filename");
+        if name.starts_with(&prefix) {
+            std::fs::remove_file(entry.path()).expect("remove component");
+            removed += 1;
+        }
+    }
+    assert!(removed > 0, "expected to remove generation {} components", gen);
+    removed
+}
+
+/// The set of partition-key `id` values in a `SELECT *` result. The single-int
+/// partition key is the 4-byte big-endian row key.
+fn partition_ids(rows: &[cqlite_core::query::result::QueryRow]) -> BTreeSet<i32> {
+    rows.iter()
+        .map(|r| {
+            let b = r.key.as_bytes();
+            assert_eq!(b.len(), 4, "int partition key must be 4 bytes, got {:?}", b);
+            i32::from_be_bytes([b[0], b[1], b[2], b[3]])
+        })
+        .collect()
+}
+
+async fn select_all_ids(db: &Database) -> BTreeSet<i32> {
+    let sql = format!("SELECT * FROM {}.{}", KEYSPACE, TABLE);
+    let res = db.execute(&sql).await.expect("select");
+    partition_ids(&res.rows)
+}
+
+/// Spec: "New generation invisible until refresh, visible after" + report
+/// `readers_added == 1`, `readers_removed == 0`.
+#[tokio::test]
+async fn added_generation_invisible_until_refresh_then_visible() {
+    let src = TempDir::new().unwrap();
+    let src_table_dir = build_two_generations(src.path()).await;
+
+    // Live directory starts with ONLY generation 1 (partition id=1).
+    let live = TempDir::new().unwrap();
+    let live_table_dir = live.path().join(KEYSPACE).join(TABLE);
+    copy_generation(&src_table_dir, &live_table_dir, 1);
+
+    let db = Database::open(live.path(), Config::default())
+        .await
+        .expect("open db");
+
+    // Pre-copy result: exactly {1}.
+    let before = select_all_ids(&db).await;
+    assert_eq!(
+        before,
+        BTreeSet::from([1]),
+        "only gen-1 partition visible at open"
+    );
+
+    // Copy in generation 2 (partition id=2) but do NOT refresh yet.
+    copy_generation(&src_table_dir, &live_table_dir, 2);
+    let stale = select_all_ids(&db).await;
+    assert_eq!(
+        stale, before,
+        "stale-until-refresh: same result before refresh() despite new file on disk"
+    );
+
+    // Refresh, then re-run the SELECT.
+    let report = db.refresh().await.expect("refresh");
+    assert_eq!(report.readers_added, 1, "one generation added");
+    assert_eq!(report.readers_removed, 0, "none removed");
+
+    let after = select_all_ids(&db).await;
+    assert_eq!(
+        after,
+        BTreeSet::from([1, 2]),
+        "new generation's partition visible after refresh"
+    );
+}
+
+/// Spec: "Removed generation dropped safely" — `readers_removed == 1`, the
+/// subsequent SELECT returns only the remaining generation, no panic.
+#[tokio::test]
+async fn removed_generation_dropped_on_refresh() {
+    let src = TempDir::new().unwrap();
+    let src_table_dir = build_two_generations(src.path()).await;
+
+    // Live directory starts with BOTH generations.
+    let live = TempDir::new().unwrap();
+    let live_table_dir = live.path().join(KEYSPACE).join(TABLE);
+    copy_generation(&src_table_dir, &live_table_dir, 1);
+    copy_generation(&src_table_dir, &live_table_dir, 2);
+
+    let db = Database::open(live.path(), Config::default())
+        .await
+        .expect("open db");
+    assert_eq!(
+        select_all_ids(&db).await,
+        BTreeSet::from([1, 2]),
+        "both partitions visible at open"
+    );
+
+    // Remove generation 2 (simulated compaction) and refresh.
+    delete_generation(&live_table_dir, 2);
+    let report = db.refresh().await.expect("refresh");
+    assert_eq!(report.readers_removed, 1, "one generation removed");
+    assert_eq!(report.readers_added, 0, "none added");
+
+    assert_eq!(
+        select_all_ids(&db).await,
+        BTreeSet::from([1]),
+        "only the remaining generation's partition after removal"
+    );
+}
+
+/// Spec: "Corrupt new generation rejects the whole refresh" — typed error, the
+/// pre-refresh result set is fully intact (fail-closed, #1626 inherited).
+#[tokio::test]
+async fn corrupt_new_generation_rejects_whole_refresh() {
+    let src = TempDir::new().unwrap();
+    let src_table_dir = build_two_generations(src.path()).await;
+
+    let live = TempDir::new().unwrap();
+    let live_table_dir = live.path().join(KEYSPACE).join(TABLE);
+    copy_generation(&src_table_dir, &live_table_dir, 1);
+
+    let db = Database::open(live.path(), Config::default())
+        .await
+        .expect("open db");
+    let before = select_all_ids(&db).await;
+    assert_eq!(before, BTreeSet::from([1]), "gen-1 visible at open");
+
+    // Copy generation 2 in, then corrupt its Statistics.db (truncate + garble),
+    // which fails SSTableReader::open per the #1626 hard-fail posture.
+    copy_generation(&src_table_dir, &live_table_dir, 2);
+    let stats = live_table_dir.join("nb-2-big-Statistics.db");
+    std::fs::write(&stats, b"\x00\x01\x02corrupt-not-a-statistics-db\xff\xff")
+        .expect("corrupt statistics");
+
+    let err = db.refresh().await.expect_err("refresh must fail-closed on corrupt generation");
+    // Typed error (no panic); any Error variant is acceptable — assert it Displays.
+    let _ = err.to_string();
+
+    // Pre-refresh result set fully intact — the corrupt gen-2 is NOT visible.
+    let after = select_all_ids(&db).await;
+    assert_eq!(
+        after, before,
+        "fail-closed: reader set unchanged, corrupt generation not partially visible"
+    );
+}
+
+/// Spec: unchanged directory is a zero-delta no-op at the `Database::refresh()`
+/// surface (the reader-Arc pointer-identity half is a core-level unit test in
+/// `storage::sstable::refresh`).
+#[tokio::test]
+async fn unchanged_directory_is_zero_delta_noop() {
+    let src = TempDir::new().unwrap();
+    let src_table_dir = build_two_generations(src.path()).await;
+
+    let live = TempDir::new().unwrap();
+    let live_table_dir = live.path().join(KEYSPACE).join(TABLE);
+    copy_generation(&src_table_dir, &live_table_dir, 1);
+
+    let db = Database::open(live.path(), Config::default())
+        .await
+        .expect("open db");
+    let before = select_all_ids(&db).await;
+
+    let report = db.refresh().await.expect("refresh");
+    assert_eq!(report.readers_added, 0, "no-op: nothing added");
+    assert_eq!(report.readers_removed, 0, "no-op: nothing removed");
+
+    assert_eq!(select_all_ids(&db).await, before, "result unchanged by no-op");
+}
+
+// The "In-flight scan unaffected by concurrent refresh" spec scenario is covered
+// as a core-level test in `storage::sstable::refresh` (module
+// `in_flight_scan_unaffected_by_concurrent_refresh`): it drives the actual
+// streaming primitive, `SSTableManager::scan_stream`, which resolves and holds
+// its `Arc` reader snapshot before yielding — the invariant this scenario pins.
+// The public-surface half ("a query issued after the refresh sees the new set")
+// is exercised by `added_generation_invisible_until_refresh_then_visible` above.

--- a/openspec/changes/sstable-freshness-refresh/.openspec.yaml
+++ b/openspec/changes/sstable-freshness-refresh/.openspec.yaml
@@ -1,0 +1,4 @@
+schema: spec-driven
+created: 2026-07-02
+goal: "Deliberate snapshot/refresh/torn-read posture across library, CLI, and
+  Flight read surfaces (issue #1749)"

--- a/openspec/changes/sstable-freshness-refresh/README.md
+++ b/openspec/changes/sstable-freshness-refresh/README.md
@@ -1,0 +1,3 @@
+# sstable-freshness-refresh
+
+Per-surface SSTable-set freshness contract + explicit Database::refresh()

--- a/openspec/changes/sstable-freshness-refresh/design.md
+++ b/openspec/changes/sstable-freshness-refresh/design.md
@@ -1,0 +1,99 @@
+# Design: sstable-freshness-refresh
+
+## Decision 1 — Freshness posture per surface (the product call)
+
+**Chosen: explicit-refresh-only for the library handle; document the other two surfaces
+as they are.**
+
+| Option | Verdict |
+|---|---|
+| **(a) Explicit `refresh()` only** — chosen | Deterministic, zero per-query overhead, no surprise result-set changes mid-session, trivially testable. The caller decides when freshness matters. |
+| (b) Auto-check per query (dir mtime / generation-set hash) | Rejected for now: adds a stat/readdir syscall tax to every query on the hot path we are actively trying to shrink (#1562), and makes result sets change *between two identical queries* with no user action — surprising for analytical sessions. Viable follow-up as an opt-in `open` option once (a) exists. |
+| (c) Filesystem watch (notify/kqueue/inotify) | Rejected: platform-divergent, brings a background thread + event-coalescing complexity into a library, and still needs (a)'s swap machinery underneath. Strictly a follow-up. |
+
+Per-surface contract this change documents:
+
+- **Library handle:** snapshot at `open`; `refresh()` is the only way the set changes.
+  In-flight queries are never affected by a concurrent refresh.
+- **CLI one-shot:** always fresh (re-open per process). Cold-start cost documented.
+- **Flight:** fresh per request; **torn window acknowledged** — the recorded posture for
+  the #1477 rewrite is *retry-once-on-vanished-file, then typed error* (rewrite may
+  choose to hold `Arc` readers per request via the shared manager instead, which
+  subsumes retry; either satisfies the contract page).
+
+## Decision 2 — Swap semantics: diff-and-swap keyed by canonical Data.db path
+
+`SSTableManager::refresh_tables()`:
+
+1. Re-run the same directory discovery `open` uses (TOC/filename-component based — no
+   new discovery logic, no heuristics).
+2. Under the `table_readers` **write** guard, diff discovered canonical `Data.db` paths
+   against held readers per table key:
+   - **added** → `SSTableReader::open` (standard path: bloom/Index/Statistics parsed,
+     #1626 hard-fail inherited) — opened *before* taking the write guard to keep the
+     critical section short; see Decision 3 for failure atomicity.
+   - **removed** → drop the `Arc` from the map (readers physically close when the last
+     in-flight scan's clone drops).
+   - **unchanged** → keep the existing `Arc<SSTableReader>` untouched (warm Index
+     HashMap/bloom preserved — refresh of an unchanged 1000-file dir is ~free).
+3. Return `RefreshReport { tables_scanned, readers_added, readers_removed }`.
+
+Rejected alternative: rebuild-the-world (`open` a fresh manager, swap wholesale).
+Simpler, but re-parses every Index.db (exactly the cost warm sessions exist to avoid),
+transiently doubles memory (budget rule), and drops warm state for unchanged files.
+
+## Decision 3 — Failure atomicity: fail-closed, keep old set
+
+All newly discovered generations are opened *first*, outside the write guard. If **any**
+open fails, `refresh()` returns that error and performs **no mutation** — the previous
+reader set remains live and queries continue against it. Rationale: a partial view
+(some new generations visible, one missing) is precisely the torn state this change
+exists to eliminate, and silently skipping a corrupt generation would violate the
+fail-closed posture #1626 just established.
+
+## Decision 4 — Concurrency model: reuse the existing lock discipline
+
+No new synchronization. Queries already resolve their reader list once under the
+`RwLock` read guard and clone `Arc<SSTableReader>`s (per-scan `ScanCursor`s mean no
+shared file-position state, #815). Refresh takes the write guard only for the
+HashMap diff/swap (opens happen outside it). Consequences, stated in the contract:
+
+- A query started before a refresh completes on the **old** set (correct + consistent).
+- A query started after sees the **new** set.
+- Two concurrent `refresh()` calls serialize on the write guard; both are correct
+  (second becomes a no-op diff).
+
+## Decision 5 — API shape
+
+```rust
+// cqlite-core
+impl Database {
+    /// Re-scan the data directory; apply added/removed SSTable generations atomically.
+    pub async fn refresh(&self) -> Result<RefreshReport>;
+}
+pub struct RefreshReport {
+    pub tables_scanned: usize,
+    pub readers_added: usize,
+    pub readers_removed: usize,
+}
+```
+
+- Python: `db.refresh() -> RefreshReport` (dataclass-like pyclass; GIL released during
+  the async op, same pattern as `execute`). Type stub updated.
+- Node: `await db.refresh(): Promise<RefreshReport>` (napi object; TS definition updated).
+- Feature gating: lives with the storage layer (not `state_machine`-gated — refresh is
+  meaningful for minimal builds too). Minimal-features build must compile (known CI
+  gotcha with ungated test items).
+
+## Test strategy notes
+
+- Integration tests use real SSTable binaries; the add-a-generation fixture is created
+  by copying an existing corpus generation (or a CQLite-flushed uncompressed one) into a
+  temp dir — **never** a synthetic byte blob. 0-rows-on-present-data is a failure.
+- The concurrency scenario uses a deliberately slow/streaming scan overlapped with a
+  refresh; assertions are on result-set consistency, not timing (no wall-clock races —
+  telemetry retro recurring-finding class).
+- Multi-generation correctness after refresh (old + new generation reconcile) leans on
+  the existing KWayMerger path; the known single-generation reconciliation gap (#1741)
+  is orthogonal and NOT masked: the refresh tests assert row *visibility*, not
+  tombstone semantics.

--- a/openspec/changes/sstable-freshness-refresh/proposal.md
+++ b/openspec/changes/sstable-freshness-refresh/proposal.md
@@ -1,0 +1,68 @@
+# Proposal: sstable-freshness-refresh (core + bindings + docs)
+
+> Milestone: platform/read-surface hardening (post-M5; feeds the Flight rewrite #1477/AB1).
+> Issue: #1749. Routing: **design-driven** — public API surface (`Database`), a product
+> posture decision (freshness contract per read surface), and user-facing docs. No
+> Cassandra/sstabledump oracle exists for "when should a reader see new files".
+
+## Why
+
+CQLite has three read surfaces with three *accidental* — never decided — behaviors when
+the SSTable directory changes underneath them (a Cassandra flush/compaction, or a CQLite
+`--flush`, may add or remove generations at any time):
+
+| Surface | Behavior today | Consequence |
+|---|---|---|
+| Library handle (Python / Node / CLI REPL) | `StorageEngine::open` discovers once; `SSTableManager.table_readers` is never re-scanned | **Stale until reopen** — new generations invisible; compacted-away files held open indefinitely |
+| CLI one-shot | Full re-open per process | Fresh, but pays the entire setup cost (incl. full Index.db materialization) every query |
+| Arrow Flight server | `MergeProducer` re-lists `*-Data.db` per request (`cqlite-flight/src/producer.rs`) | Fresh per request, but **no isolation within a request**: paths listed at request start; files deleted mid-stream error the stream (torn window) |
+
+Warm long-lived sessions are the recommended way to amortize the 150–500 ms open cost
+(#1562 investigation), which makes the library surface's stale-forever behavior the
+*default* user experience. Cassandra solves the torn-read side with hardlink snapshots;
+CQLite reads in place and has no equivalent. The gap is not any one bug — it is that no
+contract exists.
+
+## What Changes
+
+- **A documented per-surface freshness contract** (user docs page): what each surface
+  promises about seeing added/removed generations, and what happens when files vanish
+  mid-query. The Flight torn-window posture is **recorded as a decision** for the Flight
+  rewrite (#1477) to implement — no Flight code changes here.
+- **`Database::refresh()`** (async, and via `StorageEngine`/`SSTableManager`): an
+  explicit, concurrency-safe re-scan that diffs the directory against the held reader
+  set — opens added generations, drops removed ones, **keeps existing `Arc<SSTableReader>`
+  instances for unchanged files** (warm state preserved: parsed Index/Statistics/bloom are
+  not rebuilt). Returns a `RefreshReport { readers_added, readers_removed, tables_scanned }`.
+- **Atomic, fail-closed application:** if any newly discovered generation fails to open
+  (e.g. corrupt `Statistics.db` — the #1626 hard-fail is inherited via the standard
+  `SSTableReader::open`), `refresh()` returns the error and the previous reader set stays
+  in place unchanged. No partial view.
+- **Query-consistent snapshots:** each query resolves its reader list once under the
+  existing `RwLock` read guard; in-flight scans hold `Arc` clones and complete against
+  the pre-refresh set. `refresh()` swaps under the write guard.
+- **Bindings wiring:** `db.refresh()` exposed in Python and Node with end-to-end tests
+  (public surface exercises the core path — wiring evidence, not helper-only tests).
+
+## Non-goals
+
+- **No filesystem watching / auto-refresh / per-query staleness checks.** Explicit
+  refresh only. Auto-refresh is a possible follow-up once the contract exists (recorded
+  in the docs page as such).
+- **No one-shot CLI changes** (it is already fresh by construction).
+- **No Flight implementation changes** — the torn-window posture decision is an input to
+  #1477, not built here.
+- **No read-your-writes / memtable visibility** — separate product question (open
+  NEEDS-YOU item), unchanged by this work.
+- **No hardlink/snapshot isolation across refreshes** — queries get consistency via
+  `Arc`-held readers, not filesystem snapshots.
+- **No REPL `.refresh` command** in this change (trivial follow-up once the API exists).
+
+## Doctrine impact
+
+- User docs: new "Read surfaces and freshness" page; limitations page cross-link. Lands
+  in the same change (CLAUDE.md doctrine-currency rule).
+- No-heuristics: discovery stays TOC/filename-component based exactly as `open` does
+  today; refresh introduces no content sniffing.
+- Memory budget: refresh must not double-hold reader state transiently beyond the added
+  generations (diff-and-swap, not rebuild-everything).

--- a/openspec/changes/sstable-freshness-refresh/specs/storage-freshness/spec.md
+++ b/openspec/changes/sstable-freshness-refresh/specs/storage-freshness/spec.md
@@ -1,0 +1,109 @@
+# Spec: storage-freshness (core + bindings + docs)
+
+## ADDED Requirements
+
+### Requirement: Explicit refresh applies directory changes to the held reader set
+
+`Database::refresh()` SHALL re-discover the data directory using the same
+TOC/filename-component-based discovery as `open` (no content sniffing), and SHALL apply
+the diff to the held reader set: newly present generations become queryable, removed
+generations stop being queried, and unchanged generations keep their existing parsed
+reader state (Index/Statistics/bloom are not re-parsed). It SHALL return a
+`RefreshReport` with `tables_scanned`, `readers_added`, `readers_removed`.
+
+#### Scenario: New generation invisible until refresh, visible after
+
+- **GIVEN** an open `Database` on a directory with one SSTable generation of a table
+  (real corpus binaries, non-empty)
+- **WHEN** a second generation containing an additional partition is copied into the
+  table directory **and** the same SELECT is re-run *without* refresh
+- **THEN** the result equals the pre-copy result (stale-until-refresh contract)
+- **WHEN** `refresh()` is called and the SELECT is re-run
+- **THEN** the result includes the new generation's partition
+- **AND** the `RefreshReport` records `readers_added == 1` and `readers_removed == 0`.
+
+#### Scenario: Removed generation dropped safely
+
+- **GIVEN** an open `Database` on a table with two generations
+- **WHEN** one generation's component files are deleted (simulating compaction) and
+  `refresh()` is called
+- **THEN** `refresh()` succeeds with `readers_removed == 1`
+- **AND** a subsequent SELECT returns rows from the remaining generation only, with no
+  panic and no `unwrap()`/`expect()` in the library path.
+
+#### Scenario: Unchanged directory is a cheap no-op
+
+- **GIVEN** an open `Database` whose directory has not changed
+- **WHEN** `refresh()` is called
+- **THEN** it returns `readers_added == 0 && readers_removed == 0`
+- **AND** the reader instances for unchanged files are the same objects as before the
+  call (pointer identity via `Arc::ptr_eq` in a core-level test — warm state preserved).
+
+### Requirement: Refresh failure is atomic and fail-closed
+
+`refresh()` SHALL be atomic: if any newly discovered generation fails to open
+(including a corrupt `Statistics.db`, which fails per the #1626 posture), `refresh()`
+SHALL return a typed error and SHALL leave the previously held reader set fully
+unchanged — no partial application.
+
+#### Scenario: Corrupt new generation rejects the whole refresh
+
+- **GIVEN** an open `Database` with one valid generation
+- **WHEN** a new generation with a truncated/corrupt `Statistics.db` is copied in and
+  `refresh()` is called
+- **THEN** `refresh()` returns a typed error (no panic)
+- **AND** a subsequent SELECT returns exactly the pre-refresh result set (old readers
+  still live, new generation not partially visible).
+
+### Requirement: Queries execute against a single consistent reader snapshot
+
+Every query SHALL resolve its reader set exactly once; a concurrent `refresh()` SHALL
+NOT affect a query already in flight. Queries started after a completed refresh SHALL
+see the post-refresh set.
+
+#### Scenario: In-flight scan unaffected by concurrent refresh
+
+- **GIVEN** a long-running/streaming full scan in progress on the pre-refresh set
+- **WHEN** `refresh()` adds and removes generations while the scan is draining
+- **THEN** the scan completes without error and its result is exactly the correct
+  result for the pre-refresh reader set (assertions on result content, not timing)
+- **AND** a query issued after the refresh returns the post-refresh result.
+
+### Requirement: Refresh is exposed through the public binding surfaces (wiring evidence)
+
+`refresh()` SHALL be callable from Python (`db.refresh()`) and Node
+(`await db.refresh()`), each returning the report fields, each covered by an
+end-to-end test that drives the full stale→refresh→fresh cycle through the binding's
+own public API against real SSTable binaries.
+
+#### Scenario: Python end-to-end refresh
+
+- **GIVEN** `cqlite.open(...)` on a temp directory with one generation
+- **WHEN** a second generation is copied in, `db.refresh()` is called, and the query is
+  re-run via `db.execute(...)`
+- **THEN** the new partition appears and the returned report has `readers_added == 1`
+- **AND** the test fails (does not skip) if the dataset binaries are absent-but-expected
+  (no silent 0-row pass).
+
+#### Scenario: Node end-to-end refresh
+
+- **GIVEN** `Database.open(...)` on a temp directory with one generation
+- **WHEN** a second generation is copied in, `await db.refresh()` resolves, and the
+  query is re-run
+- **THEN** the new partition appears and the report has `readersAdded == 1`.
+
+### Requirement: The per-surface freshness contract is documented
+
+User documentation SHALL state, for each read surface (library handle, CLI one-shot,
+Arrow Flight), its freshness semantics (snapshot-at-open + explicit refresh / fresh per
+process / fresh per request), and the mid-query file-removal (torn-window) behavior. The
+Flight torn-window posture SHALL be recorded as a decision consumed by the Flight
+rewrite (#1477). The limitations page SHALL cross-link the contract.
+
+#### Scenario: Contract page ships in the same change
+
+- **WHEN** the change is complete
+- **THEN** a docs page exists describing all three surfaces' freshness + torn-window
+  semantics, including that auto-refresh/watching is explicitly a non-goal follow-up
+- **AND** the limitations page links to it
+- **AND** the #1477 issue carries (or links) the recorded Flight posture decision.

--- a/openspec/changes/sstable-freshness-refresh/tasks.md
+++ b/openspec/changes/sstable-freshness-refresh/tasks.md
@@ -1,0 +1,52 @@
+# Tasks: sstable-freshness-refresh
+
+> All tasks start **after** owner spec approval (Seam 1). TDD: each functional task
+> lands its failing test first. Each task names the public surface it exercises.
+
+## 1. Core refresh mechanism (surface: `Database::refresh()` / `StorageEngine`)
+- [ ] Failing integration test (real corpus binaries, `CQLITE_DATASETS_ROOT`):
+      stale-until-refresh — copy a second generation in; same SELECT unchanged before
+      `refresh()`, includes the new partition after; report `readers_added == 1`.
+      Must fail (not skip) on absent-but-expected datasets.
+- [ ] `SSTableManager::refresh_tables()` — rediscover via the same discovery `open`
+      uses; open added generations **outside** the write guard; diff-and-swap keyed by
+      canonical Data.db path under the write guard; keep unchanged `Arc`s
+      (`Arc::ptr_eq` no-op test); return `RefreshReport`. No `unwrap`/`expect`.
+- [ ] `StorageEngine::refresh()` + `Database::refresh()` public API (async), rustdoc
+      stating the contract (snapshot-at-open, explicit refresh, in-flight isolation).
+- [ ] Removal test: delete one of two generations → `readers_removed == 1`, subsequent
+      SELECT correct, no panic.
+- [ ] Atomicity test: corrupt `Statistics.db` in the new generation → typed error,
+      pre-refresh result set fully intact (#1626 posture inherited).
+- [ ] No-op test: unchanged dir → zero-delta report, reader `Arc`s pointer-identical.
+
+## 2. Concurrency (surface: streaming scan + `refresh()` overlap)
+- [ ] Test: long/streaming scan overlapped with a refresh completes with exactly the
+      pre-refresh result; post-refresh query sees the new set. Content assertions only
+      — no wall-clock/timing assertions (telemetry-retro recurring flake class).
+
+## 3. Bindings (surface: `db.refresh()` Python / `await db.refresh()` Node)
+- [ ] Python: pyclass `RefreshReport`, GIL released during the async op; `__init__.pyi`
+      stub updated; e2e test drives stale→refresh→fresh via `db.execute`.
+- [ ] Node: napi method + TS definition (`readersAdded` etc.); Jest e2e test, same cycle.
+
+## 4. Docs + posture record (surface: user docs site, issue #1477)
+- [ ] "Read surfaces and freshness" docs page: three-surface contract table,
+      torn-window semantics, auto-refresh explicitly a non-goal follow-up.
+- [ ] Limitations page cross-link.
+- [ ] Post the recorded Flight torn-window posture (Decision 1) on #1477 as a
+      consumed-decision comment.
+
+## 5. Quality gates (in order; all in this worktree)
+- [ ] Minimal-features build compiles (refresh not `state_machine`-gated; watch the
+      ungated-test-item CI gotcha).
+- [ ] `scripts/agent-gate.sh` PASS — paste the AGENT-GATE SUMMARY block verbatim
+      (`AGENT_GATE_SUMMARY_FILE` set; `CQLITE_DATASETS_ROOT` pointed at the main
+      checkout's datasets from this worktree).
+- [ ] **C intent audit**: `spec-auditor` anchored to
+      `openspec/changes/sstable-freshness-refresh/specs/**` — every requirement
+      `satisfied` with a public-surface test as evidence.
+- [ ] roborev clean (pre-empt recurring classes: no wall-clock races, no
+      `manual_range_contains`, no heuristics).
+- [ ] PR referencing #1749; merge per autonomy model; then `flow-finalize`
+      (archive change, remove worktree/branch, close issue, telemetry record).

--- a/website/src/content/docs/user-docs/index.md
+++ b/website/src/content/docs/user-docs/index.md
@@ -30,6 +30,7 @@ daemon required.
 ### Topics
 
 - [Write Support](/cqlite/user-docs/write-support/) — offline SSTable writing, flush, compaction (M5)
+- [Read Surfaces and Freshness](/cqlite/user-docs/read-surfaces-and-freshness/) — snapshot-at-open, `refresh()`, and torn-window semantics per surface
 - [Observability](/cqlite/user-docs/observability/) — runtime OpenTelemetry traces/metrics, local stack, config, metric catalog
 - [Limitations](/cqlite/user-docs/limitations/) — what CQLite can and cannot read (format matrix, known gaps)
 - [Troubleshooting](/cqlite/user-docs/troubleshooting/) — common problems and fixes

--- a/website/src/content/docs/user-docs/limitations.md
+++ b/website/src/content/docs/user-docs/limitations.md
@@ -135,6 +135,11 @@ write/flush/compact workflows.
   knowledge of replication, consistency levels, or coordinator routing.
 - **Memory target**: CQLite targets less than 128 MB for files up to 1 GB.
   Files larger than 1 GB may require the streaming API or a partition-key filter.
+- **Snapshot-at-open freshness**: a long-lived handle reads the generations that
+  existed when it was opened and does not auto-detect new or compacted-away files.
+  Call `refresh()` to re-scan; filesystem watching is a non-goal. See
+  [Read Surfaces and Freshness](/cqlite/user-docs/read-surfaces-and-freshness/) for
+  the per-surface contract.
 
 ## Workarounds for unsupported scenarios
 

--- a/website/src/content/docs/user-docs/read-surfaces-and-freshness.md
+++ b/website/src/content/docs/user-docs/read-surfaces-and-freshness.md
@@ -1,0 +1,144 @@
+---
+title: Read Surfaces and Freshness
+description: What each CQLite read surface promises when the SSTable directory changes underneath it — snapshot-at-open, explicit refresh(), and torn-window behavior.
+sidebar:
+  label: Read Surfaces and Freshness
+  order: 7
+---
+
+# Read Surfaces and Freshness
+
+CQLite reads SSTable files in place. While a reader is open, the directory can change
+underneath it — a Cassandra flush or compaction, or a CQLite `--flush`, may add or
+remove generations at any time. This page states, for each read surface, what it
+promises about seeing those changes and what happens when a file is deleted mid-query.
+
+If you keep a long-lived handle open to amortize the open cost, read the
+[library handle](#library-handle) section: your handle sees a **snapshot taken at
+open** and does not pick up new generations until you call `refresh()`.
+
+## Freshness contract per surface
+
+| Surface | Freshness | Torn window (file removed mid-query) |
+|---------|-----------|--------------------------------------|
+| [Library handle](#library-handle) (Python / Node / CLI REPL) | Snapshot at `open`; changes apply **only** on an explicit `refresh()` | In-flight queries hold their readers and complete on the pre-refresh set; never torn |
+| [CLI one-shot](#cli-one-shot) | Fresh per process — re-discovered every invocation | Not applicable (single short-lived scan) |
+| [Arrow Flight](#arrow-flight) | Fresh per request — re-discovered when the request starts | Acknowledged gap; recorded posture below, implemented by the Flight rewrite ([#1477](https://github.com/pmcfadin/cqlite/issues/1477)) |
+
+## Library handle
+
+A `Database` handle (the Python `cqlite.open(...)`, the Node `Database.open(...)`, and
+the CLI REPL) discovers the SSTable generations **once, at open**, and holds each
+generation's reader for the life of the handle. New generations that appear afterward
+are invisible, and generations that are compacted away stay open, until you refresh.
+
+This is deliberate: discovery and open cost O(SSTable count) — parsing every
+`Index.db` / `Statistics.db` and building bloom filters — which is why a cold open runs
+roughly 150–500 ms on a typical corpus. A long-lived handle exists precisely to pay
+that cost once, so re-checking the directory on every query would defeat it. The handle
+decides when freshness matters and calls `refresh()`.
+
+### `refresh()`
+
+`refresh()` re-scans the data directory and applies the difference to the held reader
+set. Discovery uses the same TOC- and filename-component-based logic as `open` (no
+content sniffing).
+
+- **Added** generations are opened and become queryable.
+- **Removed** generations stop being queried; their reader is dropped once the last
+  in-flight scan releases it.
+- **Unchanged** generations keep their existing reader untouched — the parsed
+  `Index` map, `Statistics`, and bloom filter are **not** rebuilt. Refreshing a
+  directory that has not changed is effectively free, even with thousands of files.
+
+`refresh()` returns a `RefreshReport`:
+
+| Field | Meaning |
+|-------|---------|
+| `tables_scanned` | Number of tables re-discovered |
+| `readers_added` | Generations opened by this refresh |
+| `readers_removed` | Generations dropped by this refresh |
+
+```rust
+// cqlite-core
+let report = db.refresh().await?;
+println!("{} added, {} removed", report.readers_added, report.readers_removed);
+```
+
+```python
+# Python
+report = db.refresh()
+print(report.readers_added, report.readers_removed)
+```
+
+```javascript
+// Node
+const report = await db.refresh();
+console.log(report.readersAdded, report.readersRemoved);
+```
+
+### Atomic and fail-closed
+
+`refresh()` opens every newly discovered generation **before** it changes the held set.
+If any new generation fails to open — for example a corrupt or truncated
+`Statistics.db`, which hard-fails per the
+[#1626](https://github.com/pmcfadin/cqlite/issues/1626) posture — `refresh()` returns a
+typed error and leaves the previously held reader set **fully unchanged**. There is no
+partial view: you never see some new generations while another is silently skipped. A
+subsequent query returns exactly the pre-refresh result set.
+
+### In-flight query isolation
+
+Queries resolve their reader set once, at the moment they start, and hold each reader
+for the duration of the scan. A `refresh()` running concurrently with a query does not
+affect that query:
+
+- A query started **before** a refresh completes against the **pre-refresh** set.
+- A query started **after** a refresh sees the **post-refresh** set.
+
+Because readers are reference-counted, an in-flight streaming scan drains to completion
+on the generations it started with, even if `refresh()` removes them meanwhile. This is
+consistency by held readers, not by filesystem snapshots — CQLite does not hardlink or
+copy files.
+
+## CLI one-shot
+
+One-shot invocations (`cqlite --query ...`, `--execute`, `export`, and similar) open,
+query, and exit. Each process re-discovers the directory from scratch, so a one-shot
+command is **always fresh** — it sees whatever generations exist when it starts.
+
+The trade-off is cold-start cost: every invocation pays the full open cost (O(SSTable
+count), roughly 150–500 ms on a typical corpus) before returning a single row. For
+repeated queries over the same data, prefer a long-lived handle (Python, Node, or the
+REPL) and call [`refresh()`](#refresh) when you need to pick up new generations.
+
+## Arrow Flight
+
+The Arrow Flight server re-lists the table's `*-Data.db` files when a request starts, so
+each request is **fresh per request**.
+
+It does not yet isolate a request from concurrent directory changes: the file paths are
+resolved at request start, and if a generation is deleted mid-stream (a compaction
+removing the file a request is reading), the stream errors. This torn window is a known
+gap.
+
+**Recorded posture** (an input to the Flight rewrite,
+[#1477](https://github.com/pmcfadin/cqlite/issues/1477); no Flight code changes here):
+on a vanished file, **retry once, then return a typed error** rather than a raw I/O
+failure. The rewrite may instead hold reference-counted readers per request through the
+shared manager — which subsumes the retry by keeping the generation alive for the life
+of the request. Either approach satisfies this contract.
+
+## Non-goal: filesystem watching / auto-refresh
+
+CQLite does **not** watch the filesystem, poll directory modification times, or check
+for new generations on each query. Freshness on the library handle is explicit: it
+changes only when you call `refresh()`.
+
+Auto-refresh — whether an opt-in per-query staleness check or a background filesystem
+watcher (inotify/kqueue) — is a **possible follow-up**, not a promise. It is recorded
+here so the absence is intentional, not an oversight. An opt-in check would add a
+`stat`/`readdir` syscall to the query hot path and could change a result set between two
+identical queries with no user action; a watcher would add a platform-divergent
+background thread. Both are deferred until the explicit-refresh contract on this page has
+proven out.


### PR DESCRIPTION
Closes #1749. OpenSpec change: `sstable-freshness-refresh` (owner-approved Seam 1, 2026-07-02).

## What

- **`Database::refresh()`** (+ `StorageEngine`/`SSTableManager`): explicit, atomic, fully-serialized re-scan of the data directory — diff-and-swap keyed by canonical Data.db path; added generations opened *before* the write guard (fail-closed: any open error, incl. corrupt Statistics.db per #1626, aborts with zero mutation); unchanged readers keep their `Arc` identity (warm Index/bloom state preserved); removed generations dropped safely (in-flight scans finish on their `Arc`-held set). Concurrent refreshes serialize on a dedicated mutex (TOCTOU-proof). Returns `RefreshReport { tables_scanned, readers_added, readers_removed }`.
- **Bindings:** Python `db.refresh()` (GIL released) and Node `await db.refresh()` (camelCase report), each with e2e stale→refresh→fresh tests using self-contained CQLite-written fixtures (no skip path, exact set-equality assertions).
- **Docs:** new user-docs page "Read Surfaces and Freshness" (three-surface contract: library snapshot-at-open + explicit refresh / CLI one-shot fresh-per-process / Flight fresh-per-request with recorded torn-window posture for #1477); limitations cross-link; auto-refresh explicitly a non-goal.
- Not `state_machine`-gated — available in the minimal build.

## Quality evidence

- **agent-gate: PASS** (authoritative run r6 on quiesced tree; summary block on the issue thread / `/tmp/gate-summary-1749-r6.txt`) — all 18 components green; re-verified targeted tests post-rebase onto 7aaea4a3.
- **C intent audit (spec-auditor): PASS** — every requirement `satisfied` with public-surface test evidence; two implementation deviations judged justified against the spec's own language.
- **roborev: clean** (3 review rounds; 5 findings fixed in-loop: syscall-free write-locked section, saturating Node casts, Python closed-db test, TOCTOU serialization + regression tests, doc alignment; final round: "No issues found").

## Tests

Core: 4 integration (add/remove/corrupt-atomic/no-op) + 4 unit (Arc-identity no-op, in-flight isolation, sequential apply, 4-way concurrent `join!` serialization). Python: 5 e2e. Node: 5 e2e + TS-definition assertions. Website build + link validator green.

🤖 Opened by flow-lead per the delivery pipeline (gate → C → roborev → PR → merge-on-green).