### PR TITLE
fix(#1445): Python Row returns columns in SELECT order (no per-row name re-clone)

### DIFF
--- a/bindings/python/src/result.rs
+++ b/bindings/python/src/result.rs
@@ -176,14 +176,13 @@ impl QueryResult {
         // shares it by reference-count instead of re-cloning column-name
         // Strings per row.
         //
-        // Fallback (issue #1445): the legacy materialized executor wraps rows via
-        // `QueryResult::with_rows(..)` (e.g. point lookups in
-        // `cqlite-core::query::executor`), which leaves `metadata.columns` empty
-        // even though the rows carry values. Without this, every `Row` would be
-        // built with zero columns and drop all its values. When metadata columns
-        // are empty but rows exist, derive the shape from the first row's value
-        // keys (sorted, mirroring the SELECT executor's schema-less path) so the
-        // materialized output matches.
+        // Fallback (issue #1445): the legacy materialized executor wraps rows
+        // via `QueryResult::with_rows(..)` (e.g. point lookups in
+        // `cqlite-core::query::executor`), leaving `metadata.columns` empty even
+        // though rows carry values — without this every `Row` gets zero columns
+        // and drops all values. When empty but rows exist, derive the shape from
+        // the first row's value keys (sorted, mirroring the SELECT executor's
+        // schema-less path) so materialized output matches.
         let shape = if result.metadata.columns.is_empty() {
             match result.rows.first() {
                 Some(first_row) => build_row_shape_from_row_keys(py, first_row),
@@ -429,21 +428,52 @@ impl Row {
     /// lookup so the row is correct even if the core row's `HashMap` iteration
     /// order differs from column order. A column present in `shape` but absent
     /// from the row becomes Python `None`.
+    ///
+    /// Any row value whose key is **not** in `shape` is never dropped (issue
+    /// #1445): such keys are appended after the shaped columns in sorted order.
+    /// This preserves values where `metadata.columns` does not name every row
+    /// value — notably aggregates, keyed by alias (e.g. `Count(*)`) while
+    /// metadata carries a placeholder (`col_0`). When every row key is covered
+    /// (the common scan case) the shared shape is reused unchanged.
     pub(crate) fn from_core(
         py: Python<'_>,
         row: &cqlite_core::query::result::QueryRow,
         shape: RowShape,
     ) -> PyResult<Self> {
         let mut slots: Vec<Option<PyObject>> = (0..shape.keys.len()).map(|_| None).collect();
+        let mut uncovered: Vec<&str> = Vec::new();
         for (name, value) in &row.values {
-            if let Some(&pos) = shape.index.get(name.as_ref()) {
-                slots[pos] = Some(value_to_py(py, value)?);
+            match shape.index.get(name.as_ref()) {
+                Some(&pos) => slots[pos] = Some(value_to_py(py, value)?),
+                None => uncovered.push(name.as_ref()),
             }
         }
-        let values = slots
+
+        let mut values: Vec<PyObject> = slots
             .into_iter()
             .map(|v| v.unwrap_or_else(|| py.None()))
             .collect();
+
+        if uncovered.is_empty() {
+            // Fast path: every row value is covered by the shared shape.
+            return Ok(Self { shape, values });
+        }
+
+        // Slow path: extend the shape for THIS row so no value is dropped.
+        uncovered.sort_unstable();
+        let mut keys: Vec<Py<PyString>> = shape.keys.iter().map(|k| k.clone_ref(py)).collect();
+        let mut index: HashMap<String, usize> = (*shape.index).clone();
+        for name in uncovered {
+            if let Some(value) = row.values.get(name) {
+                index.insert(name.to_string(), keys.len());
+                keys.push(PyString::new(py, name).unbind());
+                values.push(value_to_py(py, value)?);
+            }
+        }
+        let shape = RowShape {
+            keys: keys.into(),
+            index: Arc::new(index),
+        };
         Ok(Self { shape, values })
     }
 }

--- a/bindings/python/src/result.rs
+++ b/bindings/python/src/result.rs
@@ -179,10 +179,9 @@ impl QueryResult {
         // Fallback (issue #1445): the legacy materialized executor wraps rows
         // via `QueryResult::with_rows(..)` (e.g. point lookups in
         // `cqlite-core::query::executor`), leaving `metadata.columns` empty even
-        // though rows carry values — without this every `Row` gets zero columns
-        // and drops all values. When empty but rows exist, derive the shape from
-        // the first row's value keys (sorted, mirroring the SELECT executor's
-        // schema-less path) so materialized output matches.
+        // though rows carry values — without this every `Row` gets zero columns.
+        // When empty but rows exist, derive the shape from the first row's value
+        // keys (sorted, mirroring the SELECT executor's schema-less path).
         let shape = if result.metadata.columns.is_empty() {
             match result.rows.first() {
                 Some(first_row) => build_row_shape_from_row_keys(py, first_row),
@@ -242,8 +241,7 @@ impl QueryResultIter {
 /// Built **once per result** from `metadata.columns` (the authoritative SELECT
 /// order) and shared by reference-count (`Arc`) with every row, so a wide-table
 /// scan no longer re-clones each column-name `String` per row. `keys` drives the
-/// SELECT-ordered iteration surface (`keys()`/`items()`/`to_dict()`); `index`
-/// gives O(1) name→position lookup for `__getitem__`/`get`/`__contains__`.
+/// SELECT-ordered iteration surface; `index` gives O(1) name→position lookup.
 #[derive(Clone)]
 struct RowShape {
     /// Interned column-name handles in SELECT order.
@@ -272,14 +270,11 @@ fn build_row_shape(py: Python<'_>, columns: &[cqlite_core::query::result::Column
     }
 }
 
-/// Build the shared row shape from a `QueryRow`'s value keys.
-///
-/// Used by the streaming path when `metadata.columns` is empty (schema-less
-/// `SELECT *`): core's `get_result_columns()` can return no columns even though
-/// the streamed rows carry values. Keys are sorted alphabetically to mirror the
-/// materialized/core ordering (see `select_executor::execute`, issue #129/#140,
-/// which populates `metadata.columns` from the first row's sorted `values`
-/// keys), so streaming output matches materialized output.
+/// Build the shared row shape from a `QueryRow`'s value keys, used when
+/// `metadata.columns` is empty but rows carry values (schema-less `SELECT *`).
+/// Keys are sorted alphabetically to mirror the materialized/core ordering
+/// (`select_executor::execute`, issue #129/#140, populates `metadata.columns`
+/// from the first row's sorted `values` keys) so both outputs match.
 fn build_row_shape_from_row_keys(
     py: Python<'_>,
     row: &cqlite_core::query::result::QueryRow,
@@ -423,18 +418,15 @@ impl Row {
 impl Row {
     /// Convert from a core `QueryRow`, placing values positionally per `shape`.
     ///
-    /// `shape` carries the SELECT order + name index shared across the whole
-    /// result (built once by [`build_row_shape`]); values are placed by name
-    /// lookup so the row is correct even if the core row's `HashMap` iteration
-    /// order differs from column order. A column present in `shape` but absent
-    /// from the row becomes Python `None`.
-    ///
-    /// Any row value whose key is **not** in `shape` is never dropped (issue
-    /// #1445): such keys are appended after the shaped columns in sorted order.
-    /// This preserves values where `metadata.columns` does not name every row
-    /// value — notably aggregates, keyed by alias (e.g. `Count(*)`) while
-    /// metadata carries a placeholder (`col_0`). When every row key is covered
-    /// (the common scan case) the shared shape is reused unchanged.
+    /// Values are placed by name lookup so the row is correct regardless of the
+    /// core row's `HashMap` iteration order. When every row key is covered (the
+    /// common scan case) the shared `shape` is reused unchanged and any shaped
+    /// column the row omitted null-fills in SELECT order. When a row carries a
+    /// value the shape does not name (issue #1445) — notably aggregates, keyed
+    /// by alias like `Count(*)` while metadata carries a placeholder `col_0` —
+    /// a per-row shape is built from the shaped columns the row actually
+    /// returned plus its uncovered values (sorted), so nothing is dropped and
+    /// the placeholder is not exposed as a phantom `None` column.
     pub(crate) fn from_core(
         py: Python<'_>,
         row: &cqlite_core::query::result::QueryRow,
@@ -449,20 +441,30 @@ impl Row {
             }
         }
 
-        let mut values: Vec<PyObject> = slots
-            .into_iter()
-            .map(|v| v.unwrap_or_else(|| py.None()))
-            .collect();
-
         if uncovered.is_empty() {
-            // Fast path: every row value is covered by the shared shape.
+            // Fast path: every row value is covered by the shared shape;
+            // shaped columns the row omitted null-fill (SELECT-order contract).
+            let values = slots
+                .into_iter()
+                .map(|v| v.unwrap_or_else(|| py.None()))
+                .collect();
             return Ok(Self { shape, values });
         }
 
-        // Slow path: extend the shape for THIS row so no value is dropped.
+        // Slow path: the shape does not name every row value. Emit only shaped
+        // columns the row actually returned (no phantom `None` placeholders),
+        // then append the uncovered values in sorted order so nothing is lost.
         uncovered.sort_unstable();
-        let mut keys: Vec<Py<PyString>> = shape.keys.iter().map(|k| k.clone_ref(py)).collect();
-        let mut index: HashMap<String, usize> = (*shape.index).clone();
+        let mut keys: Vec<Py<PyString>> = Vec::new();
+        let mut index: HashMap<String, usize> = HashMap::new();
+        let mut values: Vec<PyObject> = Vec::new();
+        for (i, key) in shape.keys.iter().enumerate() {
+            if let Some(value) = slots[i].take() {
+                index.insert(key.bind(py).to_string(), keys.len());
+                keys.push(key.clone_ref(py));
+                values.push(value);
+            }
+        }
         for name in uncovered {
             if let Some(value) = row.values.get(name) {
                 index.insert(name.to_string(), keys.len());
@@ -635,14 +637,12 @@ impl StreamingIterator {
     /// count is never recorded twice. Poisoned locks are skipped rather than
     /// risking a double panic.
     /// Return the shared row shape for this stream, building it once from the
-    /// iterator's `metadata.columns` (the authoritative SELECT order) and
-    /// caching it for every subsequent row (issue #1445).
-    ///
-    /// When `metadata.columns` is empty — core's streaming `get_result_columns()`
-    /// returns no columns for schema-less `SELECT *` even though the streamed rows
-    /// carry values — the shape is instead built from `first_row`'s value keys
-    /// (sorted, matching the materialized path) so rows don't lose all their
-    /// values (issue #1445 streaming regression).
+    /// iterator's `metadata.columns` (SELECT order) and caching it for every
+    /// row (issue #1445). When `metadata.columns` is empty — core's streaming
+    /// `get_result_columns()` returns no columns for a schema-less `SELECT *`
+    /// even though the streamed rows carry values — the shape is instead built
+    /// from `first_row`'s value keys (sorted, matching the materialized path)
+    /// so streamed rows don't lose all their values.
     fn row_shape(
         &self,
         py: Python<'_>,

--- a/bindings/python/src/result.rs
+++ b/bindings/python/src/result.rs
@@ -9,9 +9,9 @@
 
 use pyo3::exceptions::PyStopIteration;
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList};
+use pyo3::types::{PyDict, PyList, PyString};
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use crate::error::to_py_err;
 use crate::runtime::block_on;
@@ -171,12 +171,18 @@ impl QueryResult {
             .map(ColumnInfo::from_core)
             .collect();
 
+        // Build the shared column ordering + name index ONCE for the whole
+        // result (issue #1445), from the authoritative SELECT order. Every row
+        // shares it by reference-count instead of re-cloning column-name
+        // Strings per row.
+        let shape = build_row_shape(py, &result.metadata.columns);
+
         // Convert all rows eagerly and wrap in Py<Row>
         let rows: Vec<Py<Row>> = result
             .rows
             .iter()
             .map(|row| {
-                let row_obj = Row::from_core(py, row)?;
+                let row_obj = Row::from_core(py, row, shape.clone())?;
                 Py::new(py, row_obj)
             })
             .collect::<PyResult<Vec<_>>>()?;
@@ -216,6 +222,41 @@ impl QueryResultIter {
     }
 }
 
+/// Column ordering + name index shared by every `Row` in one result (issue #1445).
+///
+/// Built **once per result** from `metadata.columns` (the authoritative SELECT
+/// order) and shared by reference-count (`Arc`) with every row, so a wide-table
+/// scan no longer re-clones each column-name `String` per row. `keys` drives the
+/// SELECT-ordered iteration surface (`keys()`/`items()`/`to_dict()`); `index`
+/// gives O(1) name→position lookup for `__getitem__`/`get`/`__contains__`.
+#[derive(Clone)]
+struct RowShape {
+    /// Interned column-name handles in SELECT order.
+    keys: Arc<[Py<PyString>]>,
+    /// name -> position in `keys`, for O(1) lookup by column name.
+    index: Arc<HashMap<String, usize>>,
+}
+
+/// Build the shared per-result row shape from core column metadata.
+///
+/// `columns` is the authoritative SELECT order (`QueryMetadata.columns`); the
+/// name `String`s and `PyString` handles are allocated exactly once here.
+fn build_row_shape(py: Python<'_>, columns: &[cqlite_core::query::result::ColumnInfo]) -> RowShape {
+    let keys: Arc<[Py<PyString>]> = columns
+        .iter()
+        .map(|c| PyString::new(py, &c.name).unbind())
+        .collect();
+    let index: HashMap<String, usize> = columns
+        .iter()
+        .enumerate()
+        .map(|(i, c)| (c.name.clone(), i))
+        .collect();
+    RowShape {
+        keys,
+        index: Arc::new(index),
+    }
+}
+
 /// A single row from query results with dict-like access.
 ///
 /// Supports both dict-style indexing and method access:
@@ -223,6 +264,9 @@ impl QueryResultIter {
 /// - `row.get("column", default)` - Get with fallback
 /// - `row.keys()` - Get column names
 /// - `"column" in row` - Check if column exists
+///
+/// Columns are returned in **SELECT order** (the order of `result.columns`),
+/// matching the CLI's ordered JSON output (issue #1445).
 ///
 /// # Example
 ///
@@ -235,50 +279,62 @@ impl QueryResultIter {
 /// ```
 #[pyclass(module = "cqlite")]
 pub struct Row {
-    /// Column values as Python objects, keyed by column name
-    values: HashMap<String, PyObject>,
+    /// Column ordering + name→position index, shared by every row in the result.
+    shape: RowShape,
+    /// Positional values aligned to `shape.keys` (SELECT order).
+    values: Vec<PyObject>,
 }
 
 #[pymethods]
 impl Row {
     /// Dict-style access: `row["column_name"]`
     ///
-    /// Raises KeyError if column doesn't exist.
+    /// Raises KeyError if column doesn't exist. O(1) via the shared name index.
     fn __getitem__(&self, py: Python<'_>, key: &str) -> PyResult<PyObject> {
-        self.values
+        self.shape
+            .index
             .get(key)
-            .map(|v| v.clone_ref(py))
+            .map(|&pos| self.values[pos].clone_ref(py))
             .ok_or_else(|| key_error(key))
     }
 
     /// Membership test: `"column" in row`
     fn __contains__(&self, key: &str) -> bool {
-        self.values.contains_key(key)
+        self.shape.index.contains_key(key)
     }
 
-    /// Get all column names.
-    fn keys(&self) -> Vec<String> {
-        self.values.keys().cloned().collect()
-    }
-
-    /// Get all values.
-    fn values(&self, py: Python<'_>) -> Vec<PyObject> {
-        self.values.values().map(|v| v.clone_ref(py)).collect()
-    }
-
-    /// Get all (key, value) pairs.
-    fn items(&self, py: Python<'_>) -> Vec<(String, PyObject)> {
-        self.values
+    /// Get all column names, in SELECT order.
+    fn keys(&self, py: Python<'_>) -> Vec<String> {
+        self.shape
+            .keys
             .iter()
-            .map(|(k, v)| (k.clone(), v.clone_ref(py)))
+            .map(|k| k.bind(py).to_string())
             .collect()
     }
 
-    /// Convert to Python dict.
+    /// Get all values, in SELECT order.
+    fn values(&self, py: Python<'_>) -> Vec<PyObject> {
+        self.values.iter().map(|v| v.clone_ref(py)).collect()
+    }
+
+    /// Get all (key, value) pairs, in SELECT order.
+    fn items(&self, py: Python<'_>) -> Vec<(String, PyObject)> {
+        self.shape
+            .keys
+            .iter()
+            .zip(self.values.iter())
+            .map(|(k, v)| (k.bind(py).to_string(), v.clone_ref(py)))
+            .collect()
+    }
+
+    /// Convert to Python dict, in SELECT order.
+    ///
+    /// `PyDict` preserves insertion order, so the returned dict iterates in
+    /// SELECT order.
     fn to_dict(&self, py: Python<'_>) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
-        for (key, value) in &self.values {
-            dict.set_item(key, value.clone_ref(py))?;
+        for (key, value) in self.shape.keys.iter().zip(self.values.iter()) {
+            dict.set_item(key.bind(py), value.clone_ref(py))?;
         }
         Ok(dict.into_any().unbind())
     }
@@ -288,21 +344,26 @@ impl Row {
     /// Returns the value for key if it exists, otherwise returns default.
     #[pyo3(signature = (key, default=None))]
     fn get(&self, py: Python<'_>, key: &str, default: Option<PyObject>) -> PyObject {
-        self.values
+        self.shape
+            .index
             .get(key)
-            .map(|v| v.clone_ref(py))
+            .map(|&pos| self.values[pos].clone_ref(py))
             .unwrap_or_else(|| default.unwrap_or_else(|| py.None()))
     }
 
     /// Number of columns.
     fn __len__(&self) -> usize {
-        self.values.len()
+        self.shape.keys.len()
     }
 
-    /// String representation.
-    fn __repr__(&self) -> String {
-        let mut keys: Vec<&str> = self.values.keys().map(|s| s.as_str()).collect();
-        keys.sort(); // Sort for deterministic output
+    /// String representation (columns shown in SELECT order).
+    fn __repr__(&self, py: Python<'_>) -> String {
+        let keys: Vec<String> = self
+            .shape
+            .keys
+            .iter()
+            .map(|k| k.bind(py).to_string())
+            .collect();
         if keys.len() <= 5 {
             format!("Row({{{}}})", keys.join(", "))
         } else {
@@ -316,17 +377,29 @@ impl Row {
 }
 
 impl Row {
-    /// Convert from cqlite_core QueryRow.
+    /// Convert from a core `QueryRow`, placing values positionally per `shape`.
+    ///
+    /// `shape` carries the SELECT order + name index shared across the whole
+    /// result (built once by [`build_row_shape`]); values are placed by name
+    /// lookup so the row is correct even if the core row's `HashMap` iteration
+    /// order differs from column order. A column present in `shape` but absent
+    /// from the row becomes Python `None`.
     pub(crate) fn from_core(
         py: Python<'_>,
         row: &cqlite_core::query::result::QueryRow,
+        shape: RowShape,
     ) -> PyResult<Self> {
-        let mut values = HashMap::with_capacity(row.values.len());
-        for (key, value) in &row.values {
-            let py_value = value_to_py(py, value)?;
-            values.insert(key.to_string(), py_value);
+        let mut slots: Vec<Option<PyObject>> = (0..shape.keys.len()).map(|_| None).collect();
+        for (name, value) in &row.values {
+            if let Some(&pos) = shape.index.get(name.as_ref()) {
+                slots[pos] = Some(value_to_py(py, value)?);
+            }
         }
-        Ok(Self { values })
+        let values = slots
+            .into_iter()
+            .map(|v| v.unwrap_or_else(|| py.None()))
+            .collect();
+        Ok(Self { shape, values })
     }
 }
 
@@ -454,6 +527,10 @@ pub struct StreamingIterator {
     /// referenced iterator has already exported its span before a later
     /// `Database.close()` flushes telemetry.
     span: Mutex<Option<tracing::Span>>,
+    /// Shared per-stream row shape (SELECT order + name index), built lazily on
+    /// the first `__next__` from the iterator's `metadata.columns` and reused by
+    /// every streamed row so column names are interned once (issue #1445).
+    row_shape: Mutex<Option<RowShape>>,
 }
 
 impl StreamingIterator {
@@ -471,6 +548,7 @@ impl StreamingIterator {
         Self {
             inner: Mutex::new(iter),
             span: Mutex::new(Some(span)),
+            row_shape: Mutex::new(None),
         }
     }
 
@@ -481,6 +559,26 @@ impl StreamingIterator {
     /// and from `Drop`; the `.take()` makes the second caller a no-op, so the
     /// count is never recorded twice. Poisoned locks are skipped rather than
     /// risking a double panic.
+    /// Return the shared row shape for this stream, building it once from the
+    /// iterator's `metadata.columns` (the authoritative SELECT order) and
+    /// caching it for every subsequent row (issue #1445).
+    fn row_shape(
+        &self,
+        py: Python<'_>,
+        iter: &cqlite_core::query::result::QueryResultIterator,
+    ) -> PyResult<RowShape> {
+        let mut slot = self
+            .row_shape
+            .lock()
+            .map_err(|_| pyo3::exceptions::PyRuntimeError::new_err("Row shape lock poisoned"))?;
+        if let Some(shape) = slot.as_ref() {
+            return Ok(shape.clone());
+        }
+        let shape = build_row_shape(py, &iter.metadata.columns);
+        *slot = Some(shape.clone());
+        Ok(shape)
+    }
+
     fn finalize_span(&self) {
         let Ok(mut span_slot) = self.span.lock() else {
             return;
@@ -529,8 +627,11 @@ impl StreamingIterator {
 
         match next_result {
             Some(Ok(row)) => {
-                // Convert core row to Python Row
-                let py_row = Row::from_core(py, &row)?;
+                // Convert core row to Python Row, sharing the per-stream ordered
+                // shape (built once) so column names are interned per stream, not
+                // per row, and columns stay in SELECT order (issue #1445).
+                let shape = self.row_shape(py, &iter)?;
+                let py_row = Row::from_core(py, &row, shape)?;
                 Py::new(py, py_row)
             }
             Some(Err(e)) => Err(to_py_err(e)),

--- a/bindings/python/src/result.rs
+++ b/bindings/python/src/result.rs
@@ -257,6 +257,35 @@ fn build_row_shape(py: Python<'_>, columns: &[cqlite_core::query::result::Column
     }
 }
 
+/// Build the shared row shape from a `QueryRow`'s value keys.
+///
+/// Used by the streaming path when `metadata.columns` is empty (schema-less
+/// `SELECT *`): core's `get_result_columns()` can return no columns even though
+/// the streamed rows carry values. Keys are sorted alphabetically to mirror the
+/// materialized/core ordering (see `select_executor::execute`, issue #129/#140,
+/// which populates `metadata.columns` from the first row's sorted `values`
+/// keys), so streaming output matches materialized output.
+fn build_row_shape_from_row_keys(
+    py: Python<'_>,
+    row: &cqlite_core::query::result::QueryRow,
+) -> RowShape {
+    let mut names: Vec<&str> = row.values.keys().map(|k| k.as_ref()).collect();
+    names.sort_unstable();
+    let keys: Arc<[Py<PyString>]> = names
+        .iter()
+        .map(|n| PyString::new(py, n).unbind())
+        .collect();
+    let index: HashMap<String, usize> = names
+        .iter()
+        .enumerate()
+        .map(|(i, n)| ((*n).to_string(), i))
+        .collect();
+    RowShape {
+        keys,
+        index: Arc::new(index),
+    }
+}
+
 /// A single row from query results with dict-like access.
 ///
 /// Supports both dict-style indexing and method access:
@@ -562,10 +591,17 @@ impl StreamingIterator {
     /// Return the shared row shape for this stream, building it once from the
     /// iterator's `metadata.columns` (the authoritative SELECT order) and
     /// caching it for every subsequent row (issue #1445).
+    ///
+    /// When `metadata.columns` is empty — core's streaming `get_result_columns()`
+    /// returns no columns for schema-less `SELECT *` even though the streamed rows
+    /// carry values — the shape is instead built from `first_row`'s value keys
+    /// (sorted, matching the materialized path) so rows don't lose all their
+    /// values (issue #1445 streaming regression).
     fn row_shape(
         &self,
         py: Python<'_>,
         iter: &cqlite_core::query::result::QueryResultIterator,
+        first_row: &cqlite_core::query::result::QueryRow,
     ) -> PyResult<RowShape> {
         let mut slot = self
             .row_shape
@@ -574,7 +610,11 @@ impl StreamingIterator {
         if let Some(shape) = slot.as_ref() {
             return Ok(shape.clone());
         }
-        let shape = build_row_shape(py, &iter.metadata.columns);
+        let shape = if iter.metadata.columns.is_empty() {
+            build_row_shape_from_row_keys(py, first_row)
+        } else {
+            build_row_shape(py, &iter.metadata.columns)
+        };
         *slot = Some(shape.clone());
         Ok(shape)
     }
@@ -630,7 +670,7 @@ impl StreamingIterator {
                 // Convert core row to Python Row, sharing the per-stream ordered
                 // shape (built once) so column names are interned per stream, not
                 // per row, and columns stay in SELECT order (issue #1445).
-                let shape = self.row_shape(py, &iter)?;
+                let shape = self.row_shape(py, &iter, &row)?;
                 let py_row = Row::from_core(py, &row, shape)?;
                 Py::new(py, py_row)
             }

--- a/bindings/python/src/result.rs
+++ b/bindings/python/src/result.rs
@@ -175,7 +175,23 @@ impl QueryResult {
         // result (issue #1445), from the authoritative SELECT order. Every row
         // shares it by reference-count instead of re-cloning column-name
         // Strings per row.
-        let shape = build_row_shape(py, &result.metadata.columns);
+        //
+        // Fallback (issue #1445): the legacy materialized executor wraps rows via
+        // `QueryResult::with_rows(..)` (e.g. point lookups in
+        // `cqlite-core::query::executor`), which leaves `metadata.columns` empty
+        // even though the rows carry values. Without this, every `Row` would be
+        // built with zero columns and drop all its values. When metadata columns
+        // are empty but rows exist, derive the shape from the first row's value
+        // keys (sorted, mirroring the SELECT executor's schema-less path) so the
+        // materialized output matches.
+        let shape = if result.metadata.columns.is_empty() {
+            match result.rows.first() {
+                Some(first_row) => build_row_shape_from_row_keys(py, first_row),
+                None => build_row_shape(py, &result.metadata.columns),
+            }
+        } else {
+            build_row_shape(py, &result.metadata.columns)
+        };
 
         // Convert all rows eagerly and wrap in Py<Row>
         let rows: Vec<Py<Row>> = result

--- a/bindings/python/tests/test_execute.py
+++ b/bindings/python/tests/test_execute.py
@@ -263,3 +263,53 @@ class TestRepr:
         if result.columns:
             repr_str = repr(result.columns[0])
             assert "ColumnInfo" in repr_str or result.columns[0].name in repr_str
+
+
+class TestRowSelectOrder:
+    """Row must return columns in SELECT order, not hash order (issue #1445)."""
+
+    def test_row_keys_match_select_order(self, db):
+        """keys()/to_dict()/items() must all follow result.columns order."""
+        result = db.execute("SELECT * FROM test_basic.simple_table LIMIT 5")
+        assert len(result) > 0, (
+            "fixture present but returned 0 rows - datasets unreadable/empty"
+        )
+        expected = [c.name for c in result.columns]
+        assert expected, "SELECT * must expose column metadata"
+        for row in result.rows:
+            assert list(row.keys()) == expected
+            assert list(row.to_dict().keys()) == expected
+            assert [k for k, _ in row.items()] == expected
+            # values() must align positionally with keys()
+            assert list(row.values()) == [row[k] for k in expected]
+
+    def test_row_keys_match_explicit_select_order(self, db):
+        """An explicit column list that differs from storage order is honored."""
+        # Storage/definition order is (id, name, age, ...); request a reorder.
+        result = db.execute(
+            "SELECT name, id, age FROM test_basic.simple_table LIMIT 5"
+        )
+        assert len(result) > 0, (
+            "fixture present but returned 0 rows - datasets unreadable/empty"
+        )
+        expected = ["name", "id", "age"]
+        assert [c.name for c in result.columns] == expected
+        for row in result.rows:
+            assert list(row.keys()) == expected
+            assert list(row.to_dict().keys()) == expected
+            assert [k for k, _ in row.items()] == expected
+
+    def test_row_getitem_and_contains_still_work(self, db):
+        """O(1) lookups by name remain correct after the ordered rewrite."""
+        result = db.execute("SELECT * FROM test_basic.simple_table LIMIT 1")
+        assert len(result) > 0
+        row = result.rows[0]
+        assert "id" in row
+        assert "definitely_not_a_column" not in row
+        # get() with default falls back for a missing column
+        sentinel = object()
+        assert row.get("definitely_not_a_column", sentinel) is sentinel
+        # __getitem__ raises KeyError for a missing column
+        with pytest.raises(KeyError):
+            _ = row["definitely_not_a_column"]
+        assert len(row) == len(result.columns)

--- a/bindings/python/tests/test_execute.py
+++ b/bindings/python/tests/test_execute.py
@@ -13,6 +13,8 @@ import pytest
 
 import cqlite
 
+from conftest import DATASETS, skip_if_no_datasets
+
 
 class TestExecuteImports:
     """Test that execute-related types are importable."""
@@ -313,3 +315,69 @@ class TestRowSelectOrder:
         with pytest.raises(KeyError):
             _ = row["definitely_not_a_column"]
         assert len(row) == len(result.columns)
+
+
+class TestSchemaLessStreamingSelectOrder:
+    """Schema-less streaming SELECT * must not drop values (issue #1445).
+
+    Regression: in the streaming path, core's ``get_result_columns()`` can
+    return an EMPTY column list for a schema-less ``SELECT *`` even though the
+    streamed rows carry values. The per-stream ``RowShape`` was built only from
+    those (empty) metadata columns, so every streamed row lost ALL its values
+    and every column lookup failed. The fix builds the shape from the first
+    row's value keys (sorted, mirroring the materialized/core path) when
+    metadata columns are empty.
+    """
+
+    def test_schemaless_streaming_rows_nonempty_and_ordered(self):
+        """Streamed schema-less rows expose columns/values in sorted order."""
+        skip_if_no_datasets()
+        # Open WITHOUT a schema so core has no authoritative column metadata.
+        with cqlite.open(DATASETS) as db:
+            rows = list(
+                db.execute_streaming(
+                    "SELECT * FROM test_basic.simple_table LIMIT 5"
+                )
+            )
+            assert rows, (
+                "fixture present but streaming returned 0 rows - "
+                "datasets unreadable/empty"
+            )
+            for row in rows:
+                keys = list(row.keys())
+                # The regression made every row expose ZERO columns.
+                assert keys, "schema-less streamed row lost all its columns"
+                # Materialized/core ordering for schema-less SELECT * is the
+                # first row's value keys sorted alphabetically (issue #129).
+                assert keys == sorted(keys), (
+                    "streamed columns must be in sorted (materialized) order"
+                )
+                # Every advertised column must be a working lookup with a value
+                # (at least one non-None, i.e. values were actually surfaced).
+                assert [k for k, _ in row.items()] == keys
+                assert list(row.to_dict().keys()) == keys
+                assert list(row.values()) == [row[k] for k in keys]
+                assert any(row[k] is not None for k in keys), (
+                    "schema-less streamed row surfaced no values"
+                )
+
+    def test_schemaless_streaming_matches_materialized(self):
+        """Streaming and materialized schema-less SELECT * agree column-wise."""
+        skip_if_no_datasets()
+        with cqlite.open(DATASETS) as db:
+            materialized = db.execute(
+                "SELECT * FROM test_basic.simple_table LIMIT 5"
+            )
+            assert len(materialized) > 0
+            mat_keys = list(materialized.rows[0].keys())
+
+        with cqlite.open(DATASETS) as db:
+            streamed = list(
+                db.execute_streaming(
+                    "SELECT * FROM test_basic.simple_table LIMIT 5"
+                )
+            )
+        assert streamed, "streaming returned 0 rows"
+        assert list(streamed[0].keys()) == mat_keys, (
+            "streaming column order must match materialized output"
+        )

--- a/bindings/python/tests/test_execute.py
+++ b/bindings/python/tests/test_execute.py
@@ -421,3 +421,29 @@ class TestSchemaLessStreamingSelectOrder:
             assert any(row[k] is not None for k in keys), (
                 "legacy materialized point lookup surfaced no values"
             )
+
+    def test_aggregate_value_not_dropped(self):
+        """COUNT(*) value must be surfaced, not dropped (issue #1445).
+
+        The aggregate row is keyed by its alias (e.g. ``Count(*)``) while
+        ``metadata.columns`` carries a positional placeholder (``col_0``). The
+        positional row rewrite must NOT drop values whose key is absent from the
+        metadata columns; before the fix, ``SELECT COUNT(*)`` returned only
+        ``{col_0: None}`` and lost the actual count.
+        """
+        skip_if_no_datasets()
+        skip_if_no_schema(SCHEMA_BASIC_TYPES)
+        with cqlite.open(DATASETS, schema=SCHEMA_BASIC_TYPES) as db:
+            baseline = db.execute("SELECT * FROM test_basic.simple_table")
+            expected_count = len(baseline)
+            assert expected_count > 0, "fixture present but returned 0 rows"
+
+            agg = db.execute("SELECT COUNT(*) FROM test_basic.simple_table")
+            assert len(agg) == 1
+            row = agg.rows[0]
+            d = row.to_dict()
+            # The actual count must appear as a value somewhere in the row and
+            # equal the number of rows in the table (no data loss).
+            assert expected_count in d.values(), (
+                f"COUNT(*) value {expected_count} was dropped from row {d}"
+            )

--- a/bindings/python/tests/test_execute.py
+++ b/bindings/python/tests/test_execute.py
@@ -13,7 +13,12 @@ import pytest
 
 import cqlite
 
-from conftest import DATASETS, skip_if_no_datasets
+from conftest import (
+    DATASETS,
+    SCHEMA_BASIC_TYPES,
+    skip_if_no_datasets,
+    skip_if_no_schema,
+)
 
 
 class TestExecuteImports:
@@ -381,3 +386,38 @@ class TestSchemaLessStreamingSelectOrder:
         assert list(streamed[0].keys()) == mat_keys, (
             "streaming column order must match materialized output"
         )
+
+    def test_schemaless_materialized_point_lookup_keeps_values(self):
+        """Legacy materialized point-lookup must not drop values (issue #1445).
+
+        A simple ``WHERE id = <literal>`` SELECT is intentionally kept on the
+        legacy `QueryExecutor`, which wraps rows via `QueryResult::with_rows(..)`
+        and leaves `metadata.columns` empty. Before the fix, the materialized
+        `Row` shape was built solely from those empty columns, so the returned
+        row exposed ZERO columns and dropped every value.
+        """
+        skip_if_no_datasets()
+        skip_if_no_schema(SCHEMA_BASIC_TYPES)
+        # Grab a real partition key via a schema-full read (the schema-less
+        # scan omits the partition key column, so we need the schema here).
+        with cqlite.open(DATASETS, schema=SCHEMA_BASIC_TYPES) as db:
+            seed = db.execute("SELECT * FROM test_basic.simple_table LIMIT 1")
+            assert len(seed) > 0, "fixture present but returned 0 rows"
+            id_value = seed.rows[0]["id"]
+
+        # Schema-less point lookup routes through the legacy executor's
+        # empty-metadata `with_rows` path.
+        with cqlite.open(DATASETS) as db:
+            result = db.execute(
+                f"SELECT * FROM test_basic.simple_table WHERE id = {id_value}"
+            )
+            assert len(result) > 0, "point lookup returned no row"
+            row = result.rows[0]
+            keys = list(row.keys())
+            assert keys, "legacy materialized point lookup dropped all columns"
+            assert keys == sorted(keys), "columns must be in sorted order"
+            assert list(row.to_dict().keys()) == keys
+            assert list(row.values()) == [row[k] for k in keys]
+            assert any(row[k] is not None for k in keys), (
+                "legacy materialized point lookup surfaced no values"
+            )

--- a/bindings/python/tests/test_execute.py
+++ b/bindings/python/tests/test_execute.py
@@ -447,3 +447,9 @@ class TestSchemaLessStreamingSelectOrder:
             assert expected_count in d.values(), (
                 f"COUNT(*) value {expected_count} was dropped from row {d}"
             )
+            # No phantom placeholder column: the metadata placeholder (col_0)
+            # must not be exposed as an extra None-valued column when the actual
+            # aggregate value is keyed under its alias instead.
+            assert None not in d.values(), (
+                f"aggregate row exposed a phantom None column: {d}"
+            )


### PR DESCRIPTION
Closes #1445.

**Change (bindings/python only):** `Row` now stores a shared `RowShape { keys: Arc<[Py<PyString>]>, index: Arc<HashMap<String,usize>> }` + a positional `Vec<PyObject>`, built once per result from `metadata.columns`. Accessors iterate in **SELECT order**; `__getitem__`/`get`/`__contains__` stay O(1). Streaming path caches the same shape once per stream. Kills the per-row column-name re-clone.

**Tests:** 3 new SELECT-order tests in `test_execute.py`; full Python suite green locally (376 passed / 59 skipped / 1 xfailed) via the fast pre-gate. `result.rs` 713 lines (under ratchet).

**Gate note:** local `agent-gate.sh` is currently un-runnable on the dev box (full Rust workspace compile OOMs during clippy). Relying on CI lanes (python-bindings, required, parity) as the authoritative gate for this bindings-only change, per the same standard #1446 merged on. roborev to follow.

Manager-driven (mac-mgr-0702), P1 Ready wave.