### PR TITLE
fix(#1762): feature-gate cqlite-core lib tests for --no-default-features --features all-compression

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/crc.rs
+++ b/cqlite-core/src/storage/sstable/reader/crc.rs
@@ -266,6 +266,8 @@ impl CrcDb {
 #[cfg(test)]
 mod tests {
     use super::*;
+    // Writer round-trip helpers live in the write-support-gated `writer` module.
+    #[cfg(feature = "write-support")]
     use crate::storage::sstable::writer::crc_writer::{write_crc_db, CrcTrailer, CRC_CHUNK_SIZE};
 
     fn synth_crc_db(chunk_size: u32, crcs: &[u32]) -> Vec<u8> {
@@ -490,6 +492,7 @@ mod tests {
 
     /// Round-trip: the #1197 writer output parses back to identical values, and
     /// each recovered CRC32 equals `crc32fast` over the corresponding raw chunk.
+    #[cfg(feature = "write-support")]
     #[tokio::test]
     async fn round_trips_the_writer_output_multi_chunk() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -613,6 +616,7 @@ mod tests {
 
     /// Compaction trailer (issue #1222) appends one trailing `0` entry; the reader
     /// exposes it as an extra entry that a real read never dereferences.
+    #[cfg(feature = "write-support")]
     #[tokio::test]
     async fn compaction_trailer_is_extra_harmless_entry() {
         let dir = tempfile::tempdir().expect("tempdir");

--- a/cqlite-core/src/storage/sstable/reader/parsing/block_entries.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/block_entries.rs
@@ -1085,6 +1085,7 @@ mod tests {
     /// `into_cells()` — so the column silently disappeared from SELECT/export.
     /// This drives the real conversion path and asserts the value surfaces; it
     /// would fail (build_row_from_scan → None → panic) under marker-suppression.
+    #[cfg(feature = "state_machine")]
     #[tokio::test]
     async fn convert_parsed_row_live_value_surfaces_via_build_row_from_scan() {
         let reader = match create_test_reader("test_basic", "simple_table").await {
@@ -1153,6 +1154,7 @@ mod tests {
     /// `"data"` blob. Before the fix the site decoded then discarded the value and
     /// always emitted `ScanRow::RawRow`, so a schema-aware non-stitching scan lost
     /// the typed column value.
+    #[cfg(feature = "state_machine")]
     #[test]
     fn fallback_decoded_value_with_name_surfaces_as_typed_row() {
         let decoded = Value::Integer(42);
@@ -1214,6 +1216,7 @@ mod tests {
     /// `"data"` column via the public `build_row_from_scan` — the exact pre-#1334
     /// bare-`Value::Blob` behavior — so the legacy blob can never silently
     /// disappear from SELECT/export.
+    #[cfg(feature = "state_machine")]
     #[test]
     fn raw_fallback_surfaces_via_build_row_from_scan() {
         let key = RowKey::new(b"pk".to_vec());


### PR DESCRIPTION
Closes #1762.

## What
Main-red fix: `cqlite-core` lib tests failed to **compile** under `--no-default-features --features all-compression` (4× E0433) because `#[cfg(test)]` items referenced default-gated symbols. Test-only feature-gating; **no production code behavior change** (diff is `+7 -0`, all inside `#[cfg(test)]`).

## E0433s fixed
| file:line | missing symbol | gate applied |
|---|---|---|
| `reader/crc.rs:269` | `sstable::writer::crc_writer::*` | `#[cfg(feature = "write-support")]` on the import + the 2 tests that use it |
| `reader/parsing/block_entries.rs:1115/1177/1229` | `crate::query::build_row_from_scan` | `#[cfg(feature = "state_machine")]` on the 3 tests that call it |

Gated the minimal specific tests, not whole modules — the other 12 crc tests / all other block_entries tests are untouched.

## Verification (acceptance criteria)
- `cargo test -p cqlite-core --lib --no-default-features --features all-compression` → **compiles, 1335 passed** (was E0433).
- `cargo test -p cqlite-core --lib` (default) → **compiles, 2645 passed**; the 5 gated tests confirmed still running under default (none silently gated out).
- `agent-gate.sh`: **PASS** (all components; `file-size` used the intended `CQLITE_ALLOW_FILE_GROWTH=1` ack for +3 lines on an already-over-threshold test file — a split is out of scope for a test-only main-red fix).
