### PR TITLE
fix(#1764): guard cqlite-core lib tests behind state_machine/write-support (red main)

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/crc.rs
+++ b/cqlite-core/src/storage/sstable/reader/crc.rs
@@ -256,14 +256,17 @@ impl CrcDb {
 
     /// Stored CRC32 for the chunk containing Data.db byte `offset`
     /// (`chunk_index = offset / chunk_size`).
-    #[cfg(test)]
+    // Only consumed by the write-support-gated test module below.
+    #[cfg(all(test, feature = "write-support"))]
     pub(crate) fn crc_for_offset(&self, offset: u64) -> Result<u32> {
         let chunk_index = (offset / self.chunk_size as u64) as usize;
         self.crc_for_chunk(chunk_index)
     }
 }
 
-#[cfg(test)]
+// This test module references `crate::storage::sstable::writer::crc_writer`, which
+// only exists under the `write-support` feature; gate the whole module accordingly.
+#[cfg(all(test, feature = "write-support"))]
 mod tests {
     use super::*;
     use crate::storage::sstable::writer::crc_writer::{write_crc_db, CrcTrailer, CRC_CHUNK_SIZE};

--- a/cqlite-core/src/storage/sstable/reader/parsing/block_entries.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/block_entries.rs
@@ -1085,6 +1085,9 @@ mod tests {
     /// `into_cells()` — so the column silently disappeared from SELECT/export.
     /// This drives the real conversion path and asserts the value surfaces; it
     /// would fail (build_row_from_scan → None → panic) under marker-suppression.
+    // Exercises `crate::query::build_row_from_scan`, which only exists under the
+    // `state_machine` feature.
+    #[cfg(feature = "state_machine")]
     #[tokio::test]
     async fn convert_parsed_row_live_value_surfaces_via_build_row_from_scan() {
         let reader = match create_test_reader("test_basic", "simple_table").await {
@@ -1153,6 +1156,9 @@ mod tests {
     /// `"data"` blob. Before the fix the site decoded then discarded the value and
     /// always emitted `ScanRow::RawRow`, so a schema-aware non-stitching scan lost
     /// the typed column value.
+    // Exercises `crate::query::build_row_from_scan`, which only exists under the
+    // `state_machine` feature.
+    #[cfg(feature = "state_machine")]
     #[test]
     fn fallback_decoded_value_with_name_surfaces_as_typed_row() {
         let decoded = Value::Integer(42);
@@ -1214,6 +1220,9 @@ mod tests {
     /// `"data"` column via the public `build_row_from_scan` — the exact pre-#1334
     /// bare-`Value::Blob` behavior — so the legacy blob can never silently
     /// disappear from SELECT/export.
+    // Exercises `crate::query::build_row_from_scan`, which only exists under the
+    // `state_machine` feature.
+    #[cfg(feature = "state_machine")]
     #[test]
     fn raw_fallback_surfaces_via_build_row_from_scan() {
         let key = RowKey::new(b"pk".to_vec());


### PR DESCRIPTION
Fixes #1764. **P0 red-main hotfix.**

## Problem
`cqlite-core` lib test failed to compile under any feature combo lacking `state_machine` and/or `write-support` (incl. default features, which omit `write-support`) — `E0433` ×4. This reddened **Minimal Features CI** and **All Compression Build & Test**, and since PR CI merge-tests against main's tip, it was failing that lane on every open PR (#1746/#1747/#1748/#1756).

## Root cause
Two `#[cfg(test)]` modules referenced feature-gated modules without matching guards (`query` → `state_machine` lib.rs:23-24; `sstable::writer` → `write-support` sstable/mod.rs:44-45). Predates #1749 — the offenders came from #1396 (crc.rs) and #1334 (block_entries.rs); main's CI runs were cancelled so it reached the tip un-caught.

## Fix (test-only; no product code, no Cargo feature changes)
- `crc.rs`: gate `mod tests` + its `crc_for_offset` helper behind `#[cfg(all(test, feature = "write-support"))]`.
- `block_entries.rs`: add `#[cfg(feature = "state_machine")]` to exactly the 3 test fns calling `crate::query::build_row_from_scan`.

## Verification (all `-D warnings`)
- `cargo test -p cqlite-core --no-default-features --features=all-compression --lib --no-run` — PASS
- `cargo test -p cqlite-core --no-default-features --features=lz4,snappy --lib --no-run` — PASS (Minimal Features lane)
- `cargo test -p cqlite-core --lib --no-run` (default) — PASS
- `cargo test -p cqlite-core --features write-support --lib --no-run` — PASS (guarded tests still run under their features)
- `scripts/agent-gate.sh` — **RESULT: PASS** (commit 20946662)
- roborev branch review (claude-code/opus, thorough) — **No issues found**

Unblocks #1746/#1747/#1748/#1756.