### PR TITLE
fix(#1619): install default STCSPolicy; wire real auto_compaction off-switch (N1)

### DIFF
--- a/bindings/node/__test__/write.test.js
+++ b/bindings/node/__test__/write.test.js
@@ -702,3 +702,75 @@ describe('Write error paths (Issue #391)', () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// auto_compaction off-switch (Issue #1619)
+// ---------------------------------------------------------------------------
+
+describe('autoCompaction off-switch (Issue #1619)', () => {
+  beforeAll(requireSchemaFile);
+
+  /**
+   * Open a writable DB with an explicit autoCompaction setting, insert `n`
+   * distinct rows flushing after each so that `n` separate L0 SSTables land on
+   * disk (>= STCS min_threshold = 4 triggers a merge), then run one
+   * maintenanceStep with a generous budget. Returns the report + l0 counts.
+   */
+  async function flushNAndMaintain(autoCompaction, n) {
+    const { dir, cleanup } = tmpWriteDir();
+    const opts = {
+      schema: SCHEMA_PATH,
+      writable: true,
+      writeDir: dir,
+    };
+    if (autoCompaction !== undefined) opts.autoCompaction = autoCompaction;
+    const db = await Database.open(dir, opts);
+    try {
+      for (let i = 0; i < n; i++) {
+        // Distinct partition key per flush → one L0 SSTable each.
+        const id = `550e8400-e29b-41d4-a716-4466554500${(80 + i)
+          .toString()
+          .padStart(2, '0')}`;
+        await db.execute(
+          `INSERT INTO test_basic.simple_table (id, name) VALUES (${id}, 'Row${i}')`
+        );
+        await db.flushRun();
+      }
+      // Note: writeStats.l0Count is a per-binding flush counter (incremented on
+      // every flushRun), NOT the live on-disk SSTable count — it is not
+      // decremented by a merge. Merge evidence therefore comes from the
+      // MaintenanceReport (rowsMerged / completedMerges), which is the
+      // authoritative signal for whether STCS ran.
+      const l0Flushes = db.writeStats.l0Count;
+      const report = await db.maintenanceStep({ budgetMs: 60000 });
+      return { report, l0Flushes };
+    } finally {
+      await db.close();
+      cleanup();
+    }
+  }
+
+  test('autoCompaction:false makes maintenanceStep a no-op with >=4 SSTables', async () => {
+    const { report, l0Flushes } = await flushNAndMaintain(false, 4);
+    expect(l0Flushes).toBe(4);
+    // Off-switch: no merge policy installed → nothing merges.
+    expect(report.rowsMerged).toBe(0);
+    expect(report.pendingCompaction).toBe(false);
+    expect(report.completedMerges.length).toBe(0);
+  });
+
+  test('default (autoCompaction omitted) merges with >=4 SSTables', async () => {
+    const { report, l0Flushes } = await flushNAndMaintain(undefined, 4);
+    expect(l0Flushes).toBe(4);
+    // Default STCS policy must merge rows and complete at least one merge.
+    expect(report.rowsMerged).toBeGreaterThan(0);
+    expect(report.completedMerges.length).toBeGreaterThan(0);
+  });
+
+  test('autoCompaction:true explicitly enables merges with >=4 SSTables', async () => {
+    const { report, l0Flushes } = await flushNAndMaintain(true, 4);
+    expect(l0Flushes).toBe(4);
+    expect(report.rowsMerged).toBeGreaterThan(0);
+    expect(report.completedMerges.length).toBeGreaterThan(0);
+  });
+});

--- a/bindings/node/lib/index.d.ts
+++ b/bindings/node/lib/index.d.ts
@@ -376,6 +376,13 @@ export interface DatabaseOptions {
   writeDir?: string;
 
   /**
+   * Enable automatic (STCS) size-tiered compaction for the write engine.
+   * Default: true. Set false to disable compaction — `maintenanceStep`
+   * then performs no merges (issue #1619).
+   */
+  autoCompaction?: boolean;
+
+  /**
    * OpenTelemetry export options (epic #1031, issue #1040).
    *
    * When omitted, the `CQLITE_OTEL_*` environment variables are consulted.

--- a/bindings/node/src/database.rs
+++ b/bindings/node/src/database.rs
@@ -179,6 +179,12 @@ pub struct DatabaseOptions {
     #[napi(js_name = "writeDir")]
     pub write_dir: Option<String>,
 
+    /// Enable automatic (STCS) size-tiered compaction for the write engine.
+    /// Default: true. Set false to disable compaction — `maintenanceStep`
+    /// then performs no merges (issue #1619).
+    #[napi(js_name = "autoCompaction")]
+    pub auto_compaction: Option<bool>,
+
     /// OpenTelemetry export options (epic #1031, issue #1040).
     ///
     /// When omitted, the `CQLITE_OTEL_*` environment variables are consulted;
@@ -481,6 +487,10 @@ impl Database {
                 config.memory.block_cache.enabled = enabled;
                 config.memory.row_cache.enabled = enabled;
                 config.memory.query_cache.enabled = enabled;
+            }
+
+            if let Some(ac) = opts.auto_compaction {
+                config.storage.compaction.auto_compaction = ac;
             }
 
             let writable = opts.writable.unwrap_or(false);

--- a/bindings/node/src/database.rs
+++ b/bindings/node/src/database.rs
@@ -496,6 +496,12 @@ impl Database {
         #[cfg(feature = "write-support")]
         let schema_path_for_write: Option<PathBuf> = schema_path.clone();
 
+        // Capture the compaction settings before `core_config` is moved into
+        // ingestion / Database::open, so `Config.storage.compaction` is
+        // authoritative for the write path (issue #1619) rather than decorative.
+        #[cfg(feature = "write-support")]
+        let compaction_config = core_config.storage.compaction.clone();
+
         // Validate write options
         #[cfg(feature = "write-support")]
         if writable && write_dir.is_none() {
@@ -648,7 +654,8 @@ impl Database {
                 wd.join("data"),
                 wd.join("wal"),
                 schema,
-            );
+            )
+            .with_compaction_config(&compaction_config);
 
             let engine = cqlite_core::storage::write_engine::WriteEngine::new(config)
                 .map_err(to_napi_error)?;

--- a/bindings/python/src/database.rs
+++ b/bindings/python/src/database.rs
@@ -816,6 +816,13 @@ pub fn open(
 
     let core_config = config_from_py(py, config)?;
 
+    // Capture the compaction settings before `core_config` is moved into
+    // ingestion / Database::open, so the write engine can honor
+    // `config={"storage": {"compaction": {"auto_compaction": false}}}` (issue
+    // #1619). This makes `Config.storage.compaction` authoritative for the
+    // Python write path rather than decorative.
+    let compaction_config = core_config.storage.compaction.clone();
+
     // Open the read-side database and capture the schema registry when present.
     // We always use ingestion when a schema file is provided because that path
     // performs the SSTable discovery and populates the schema registry.
@@ -884,7 +891,8 @@ pub fn open(
             wd.join("data"),
             wd.join("wal"),
             table_schema,
-        );
+        )
+        .with_compaction_config(&compaction_config);
 
         let engine = cqlite_core::storage::write_engine::WriteEngine::new(engine_config)
             .map_err(to_py_err)?;
@@ -892,7 +900,7 @@ pub fn open(
         Some(Mutex::new(PyWriteEngine::new(engine)))
     } else {
         // Silence unused-variable warning
-        let _ = (write_dir, schema_registry_opt);
+        let _ = (write_dir, schema_registry_opt, compaction_config);
         None
     };
 

--- a/bindings/python/src/database.rs
+++ b/bindings/python/src/database.rs
@@ -817,10 +817,17 @@ pub fn open(
     let core_config = config_from_py(py, config)?;
 
     // Capture the compaction settings before `core_config` is moved into
-    // ingestion / Database::open, so the write engine can honor
-    // `config={"storage": {"compaction": {"auto_compaction": false}}}` (issue
-    // #1619). This makes `Config.storage.compaction` authoritative for the
-    // Python write path rather than decorative.
+    // ingestion / Database::open, so `Config.storage.compaction` is
+    // authoritative for the Python write path rather than decorative (issue
+    // #1619). Setting `auto_compaction = false` disables STCS, making
+    // `maintenance_step` a no-op. NOTE: the config bridge (`config_from_dict`)
+    // deserializes into the full `cqlite_core::Config`, which is NOT
+    // `#[serde(default)]`, so `config` must be a COMPLETE config — a full dict,
+    // a full JSON string, or a preset. A partial dict such as
+    // `{"storage": {"compaction": {"auto_compaction": false}}}` is rejected
+    // with missing-field errors. To flip only this switch, obtain a full config
+    // dict from a preset (e.g. `cqlite.performance_optimized()`), set
+    // `["storage"]["compaction"]["auto_compaction"] = False`, then pass it.
     let compaction_config = core_config.storage.compaction.clone();
 
     // Open the read-side database and capture the schema registry when present.

--- a/bindings/python/tests/test_write_api.py
+++ b/bindings/python/tests/test_write_api.py
@@ -496,3 +496,112 @@ def test_total_written_accumulates_across_flushes(writable_db):
     assert stats_final.l0_count >= 2, (
         f"l0_count must be >= 2 after two flushes, got {stats_final.l0_count}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Issue #1619 — auto_compaction off-switch via the public config surface
+# ---------------------------------------------------------------------------
+#
+# The config bridge (`config_from_dict`) deserializes into the FULL
+# `cqlite_core::Config`, which is not `#[serde(default)]`, so a partial dict
+# like ``{"storage": {"compaction": {"auto_compaction": False}}}`` is rejected.
+# The supported way to flip just this switch is to obtain a COMPLETE config
+# dict from a preset (``cqlite.performance_optimized()`` returns a full
+# round-tripped config dict), toggle
+# ``["storage"]["compaction"]["auto_compaction"]``, then pass it to
+# ``cqlite.open(config=...)``. These tests exercise that public path
+# end-to-end (open -> write -> flush x4 -> maintenance_step).
+
+
+def _full_config_dict(auto_compaction: bool) -> dict:
+    """Return a COMPLETE config dict with the compaction switch flipped.
+
+    Starts from the ``performance_optimized`` preset (a full config dict) so
+    the config bridge accepts it, then sets the one field under test.
+    """
+    cfg = cqlite.performance_optimized()
+    assert "storage" in cfg and "compaction" in cfg["storage"], (
+        "preset config dict must expose storage.compaction"
+    )
+    cfg["storage"]["compaction"]["auto_compaction"] = auto_compaction
+    return cfg
+
+
+def _open_flush_n_maintain(tmp_path, write_schema, config, n=4):
+    """Open writable with `config`, flush `n` distinct L0 SSTables, then run
+    one maintenance_step with a generous budget.
+
+    Returns ``(report, l0_flushes)`` where ``l0_flushes`` is the per-engine
+    flush counter (``write_stats.l0_count``). Note that ``l0_count`` is a
+    monotonic count of successful flushes — it is NOT decremented by a merge —
+    so merge evidence comes from the MaintenanceReport (``rows_merged`` /
+    ``completed_merges``), the authoritative STCS-ran signal.
+    """
+    data_dir = tmp_path / "data_dir"
+    data_dir.mkdir()
+    write_dir = tmp_path / "write_dir"
+
+    with cqlite.open(
+        str(data_dir),
+        schema=str(write_schema),
+        writable=True,
+        write_dir=str(write_dir),
+        config=config,
+    ) as db:
+        for i in range(n):
+            # Distinct partition key per flush -> one L0 SSTable each.
+            db.execute(
+                f"INSERT INTO write_test.items (id, name, value) "
+                f"VALUES ({1900 + i}, 'compact{i}', {i})"
+            )
+            db.flush_run()
+        l0_flushes = db.write_stats.l0_count
+        report = db.maintenance_step(budget_ms=60000)
+        return report, l0_flushes
+
+
+def test_compaction_off_switch_disables_merges(tmp_path, write_schema):
+    """A full config with auto_compaction=False makes maintenance_step a no-op.
+
+    Proves the off-switch is reachable through the public
+    ``open(config=...)`` surface (issue #1619).
+    """
+    config = _full_config_dict(auto_compaction=False)
+    report, l0_flushes = _open_flush_n_maintain(
+        tmp_path, write_schema, config, n=4
+    )
+    assert l0_flushes == 4, f"expected 4 flushed SSTables, got {l0_flushes}"
+    assert report.rows_merged == 0, "off-switch: no rows may be merged"
+    assert not report.pending_compaction, "off-switch: no pending compaction"
+    assert report.completed_merges == [], "off-switch: no merges completed"
+
+
+def test_compaction_default_config_enables_merges(tmp_path, write_schema):
+    """A full config with auto_compaction=True (default) merges >=4 SSTables.
+
+    Companion to the off-switch test: proves the default STCS policy is
+    genuinely active through the same public config surface.
+    """
+    config = _full_config_dict(auto_compaction=True)
+    report, l0_flushes = _open_flush_n_maintain(
+        tmp_path, write_schema, config, n=4
+    )
+    assert l0_flushes == 4, f"expected 4 flushed SSTables, got {l0_flushes}"
+    assert report.rows_merged > 0, "default STCS policy must merge rows"
+    assert len(report.completed_merges) > 0, "at least one merge must complete"
+
+
+def test_compaction_partial_config_dict_rejected(tmp_path, write_schema):
+    """A PARTIAL config dict is rejected (documents the full-config
+    requirement). This guards against the doc ever again implying partial
+    dicts work (issue #1619)."""
+    data_dir = tmp_path / "data_dir"
+    data_dir.mkdir()
+    with pytest.raises(ValueError):
+        cqlite.open(
+            str(data_dir),
+            schema=str(write_schema),
+            writable=True,
+            write_dir=str(tmp_path / "write_dir"),
+            config={"storage": {"compaction": {"auto_compaction": False}}},
+        )

--- a/cqlite-core/src/config.rs
+++ b/cqlite-core/src/config.rs
@@ -243,36 +243,25 @@ impl Default for StorageConfig {
     }
 }
 
-/// Compaction strategy configuration
+/// Compaction strategy configuration.
+///
+/// The write engine implements Size-Tiered Compaction Strategy (STCS) and
+/// installs it by default (issue #1619). `auto_compaction` is the authoritative
+/// on/off switch consumed by the write path via
+/// `WriteEngineConfig::with_compaction_config`. Previously this struct also
+/// carried `strategy`/`max_sstables`/`size_ratio`/`max_threads`/
+/// `background_interval` fields that were never read by any behavior; they were
+/// removed (issue #1619) rather than left decorative.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CompactionConfig {
-    /// Compaction strategy to use
-    pub strategy: CompactionStrategy,
-
-    /// Maximum number of SSTables before triggering compaction
-    pub max_sstables: usize,
-
-    /// Size ratio for triggering compaction
-    pub size_ratio: f64,
-
-    /// Maximum compaction threads
-    pub max_threads: usize,
-
-    /// Compaction interval for background compaction
-    pub background_interval: Duration,
-
-    /// Enable automatic background compaction
+    /// Enable automatic (STCS) compaction. When `false`, the write engine
+    /// installs no merge policy and `maintenance_step` is a no-op.
     pub auto_compaction: bool,
 }
 
 impl Default for CompactionConfig {
     fn default() -> Self {
         Self {
-            strategy: CompactionStrategy::Leveled,
-            max_sstables: 10,
-            size_ratio: 2.0,
-            max_threads: 2,
-            background_interval: Duration::from_secs(300), // 5 minutes
             auto_compaction: true,
         }
     }
@@ -565,17 +554,6 @@ impl Default for CompressionConfig {
     }
 }
 
-/// Compaction strategies
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum CompactionStrategy {
-    /// Simple size-based compaction
-    Size,
-    /// Leveled compaction (like LevelDB)
-    Leveled,
-    /// Universal compaction
-    Universal,
-}
-
 /// Durability sync modes
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum SyncMode {
@@ -666,7 +644,6 @@ impl Config {
 
         // Reduce timeouts for faster test execution
         config.query.max_execution_time = std::time::Duration::from_secs(1);
-        config.storage.compaction.background_interval = std::time::Duration::from_secs(10);
 
         // Smaller memory usage for tests
         config.memory.max_memory = 64 * 1024 * 1024; // 64MB

--- a/cqlite-core/src/storage/write_engine/maintenance.rs
+++ b/cqlite-core/src/storage/write_engine/maintenance.rs
@@ -628,15 +628,18 @@ mod tests {
 
     #[test]
     fn test_maintenance_step_no_policy() {
-        // Without a merge policy, maintenance_step should do nothing
+        // Without a merge policy, maintenance_step should do nothing.
+        // Since #1619 makes STCS the default, disable auto_compaction so this
+        // test still validates the None branch (no-policy -> no work).
         let temp_dir = TempDir::new().unwrap();
         let schema = create_test_schema();
 
-        let config = WriteEngineConfig::new(
+        let mut config = WriteEngineConfig::new(
             temp_dir.path().join("data"),
             temp_dir.path().join("wal"),
             schema,
         );
+        config.auto_compaction = false;
 
         let mut engine = WriteEngine::new(config).unwrap();
 
@@ -1352,6 +1355,128 @@ mod tests {
              found: {:?}",
             leftover_tmp.iter().map(|e| e.path()).collect::<Vec<_>>()
         );
+    }
+
+    /// Issue #1619 WIRING EVIDENCE: `WriteEngine::new` must install a default
+    /// STCS policy so `maintenance_step` compacts WITHOUT any `set_merge_policy`
+    /// call. This test uses ONLY the public constructor — that is the whole
+    /// point of the fix (STCS on by default). Before the fix `merge_policy` was
+    /// hard-coded to `None`, so `rows_merged == 0` and no L0 reduction occurred.
+    #[test]
+    fn test_maintenance_step_default_policy_compacts_via_public_ctor() {
+        let temp_dir = TempDir::new().unwrap();
+        let schema = create_test_schema();
+
+        // Default config: auto_compaction = true (no set_merge_policy call).
+        let config = WriteEngineConfig::new(
+            temp_dir.path().join("data"),
+            temp_dir.path().join("wal"),
+            schema,
+        );
+
+        let mut engine = WriteEngine::new(config).unwrap();
+
+        // Flush 4 distinct L0 SSTables (>= min_threshold = 4). The tiny test
+        // files are all below DEFAULT_MIN_SSTABLE_SIZE, so STCS groups them via
+        // the "both small" rule into one eligible bucket.
+        let input_paths = flush_n_sstables_sync(&mut engine, 4);
+        assert_eq!(input_paths.len(), 4, "Expected 4 flushed SSTables");
+
+        let before = engine.scan_sstable_candidates().unwrap().len();
+        assert_eq!(before, 4, "Expected 4 L0 SSTables before compaction");
+
+        // NO set_merge_policy call — the public ctor must have wired STCS.
+        let report = engine.maintenance_step(Duration::from_secs(60)).unwrap();
+
+        assert!(
+            report.rows_merged > 0,
+            "default STCS policy must merge rows via the public ctor (rows_merged = {})",
+            report.rows_merged
+        );
+
+        let after = engine.scan_sstable_candidates().unwrap().len();
+        assert!(
+            after < before,
+            "on-disk L0 SSTable count must drop after compaction (before = {}, after = {})",
+            before,
+            after
+        );
+    }
+
+    /// Issue #1619 OFF-SWITCH: with `auto_compaction = false`, `WriteEngine::new`
+    /// installs NO policy, so `maintenance_step` is a no-op even with enough L0
+    /// SSTables to trigger a compaction. Proves the documented off-switch works.
+    #[test]
+    fn test_maintenance_step_auto_compaction_disabled_is_noop() {
+        let temp_dir = TempDir::new().unwrap();
+        let schema = create_test_schema();
+
+        let mut config = WriteEngineConfig::new(
+            temp_dir.path().join("data"),
+            temp_dir.path().join("wal"),
+            schema,
+        );
+        config.auto_compaction = false;
+
+        let mut engine = WriteEngine::new(config).unwrap();
+
+        let input_paths = flush_n_sstables_sync(&mut engine, 4);
+        assert_eq!(input_paths.len(), 4, "Expected 4 flushed SSTables");
+
+        let before = engine.scan_sstable_candidates().unwrap().len();
+        assert_eq!(before, 4, "Expected 4 L0 SSTables before compaction");
+
+        let report = engine.maintenance_step(Duration::from_secs(60)).unwrap();
+
+        assert_eq!(
+            report.rows_merged, 0,
+            "off-switch: no policy means no rows merged"
+        );
+        assert!(
+            !report.pending_compaction,
+            "off-switch: no policy means no pending compaction"
+        );
+
+        let after = engine.scan_sstable_candidates().unwrap().len();
+        assert_eq!(
+            after, before,
+            "off-switch: L0 SSTable count must be unchanged (before = {}, after = {})",
+            before, after
+        );
+    }
+
+    /// Issue #1619 AH1: `Config.storage.compaction` must be non-decorative.
+    /// A `CompactionConfig` with `auto_compaction = false` mapped onto the
+    /// WriteEngineConfig must disable the default policy end-to-end (no rows
+    /// merged, no L0 reduction) — proving the config wiring reaches behavior.
+    #[test]
+    fn test_compaction_config_disables_default_policy() {
+        let temp_dir = TempDir::new().unwrap();
+        let schema = create_test_schema();
+
+        let compaction = crate::config::CompactionConfig {
+            auto_compaction: false,
+        };
+        let config = WriteEngineConfig::new(
+            temp_dir.path().join("data"),
+            temp_dir.path().join("wal"),
+            schema,
+        )
+        .with_compaction_config(&compaction);
+        assert!(
+            !config.auto_compaction,
+            "config mapping must disable compaction"
+        );
+
+        let mut engine = WriteEngine::new(config).unwrap();
+        flush_n_sstables_sync(&mut engine, 4);
+        let before = engine.scan_sstable_candidates().unwrap().len();
+
+        let report = engine.maintenance_step(Duration::from_secs(60)).unwrap();
+        assert_eq!(report.rows_merged, 0, "disabled config: no rows merged");
+
+        let after = engine.scan_sstable_candidates().unwrap().len();
+        assert_eq!(after, before, "disabled config: L0 count unchanged");
     }
 
     // Startup orphan-sweep coverage lives in `write_engine::sweep` (issue #1393),

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -183,6 +183,19 @@ pub struct WriteEngineConfig {
     /// (the default), a column whose `data_type` is a bare UDT name is written
     /// as a single simple cell (documented fallback).
     pub udt_registry: Option<UdtRegistry>,
+    /// Whether the engine installs a default STCS compaction policy so that
+    /// [`WriteEngine::maintenance_step`] performs size-tiered compaction
+    /// (issue #1619). Defaults to `true` (compaction on). Set to `false` to
+    /// disable compaction entirely — `maintenance_step` then becomes a no-op.
+    pub auto_compaction: bool,
+    /// Minimum number of SSTables in a size bucket required to trigger a
+    /// compaction (STCS `min_threshold`). Defaults to `4`. Ignored when
+    /// [`WriteEngineConfig::auto_compaction`] is `false`.
+    pub compaction_min_threshold: usize,
+    /// Maximum number of SSTables compacted together in one step (STCS
+    /// `max_threshold`). Defaults to `32`. Ignored when
+    /// [`WriteEngineConfig::auto_compaction`] is `false`.
+    pub compaction_max_threshold: usize,
 }
 
 #[cfg(feature = "write-support")]
@@ -191,6 +204,10 @@ impl WriteEngineConfig {
     pub const DEFAULT_FLUSH_THRESHOLD: usize = 64 * 1024 * 1024;
     /// Default hard limit (256 MB)
     pub const DEFAULT_HARD_LIMIT: usize = 256 * 1024 * 1024;
+    /// Default STCS `min_threshold` (issue #1619)
+    pub const DEFAULT_COMPACTION_MIN_THRESHOLD: usize = 4;
+    /// Default STCS `max_threshold` (issue #1619)
+    pub const DEFAULT_COMPACTION_MAX_THRESHOLD: usize = 32;
 
     /// Create a new configuration with default flush threshold
     pub fn new(data_dir: PathBuf, wal_dir: PathBuf, schema: TableSchema) -> Self {
@@ -202,6 +219,9 @@ impl WriteEngineConfig {
             schema,
             durability: Durability::default(),
             udt_registry: None,
+            auto_compaction: true,
+            compaction_min_threshold: Self::DEFAULT_COMPACTION_MIN_THRESHOLD,
+            compaction_max_threshold: Self::DEFAULT_COMPACTION_MAX_THRESHOLD,
         }
     }
 
@@ -240,6 +260,19 @@ impl WriteEngineConfig {
     /// ```
     pub fn with_durability(mut self, durability: Durability) -> Self {
         self.durability = durability;
+        self
+    }
+
+    /// Apply a [`crate::config::CompactionConfig`] onto this write-engine
+    /// configuration (issue #1619). This makes `Config.storage.compaction`
+    /// authoritative for the write path: `auto_compaction = false` disables the
+    /// default STCS policy so [`WriteEngine::maintenance_step`] becomes a no-op.
+    ///
+    /// The compaction thresholds (`compaction_min_threshold` /
+    /// `compaction_max_threshold`) keep their defaults; only the on/off switch
+    /// is surfaced through the public `Config` today.
+    pub fn with_compaction_config(mut self, compaction: &crate::config::CompactionConfig) -> Self {
+        self.auto_compaction = compaction.auto_compaction;
         self
     }
 }
@@ -555,6 +588,23 @@ impl WriteEngine {
         // Determine next generation number by scanning data directory
         let generation = Self::determine_next_generation(&config.data_dir)?;
 
+        // Install the default STCS compaction policy so `maintenance_step`
+        // performs size-tiered compaction out of the box (issue #1619). The
+        // off-switch is `WriteEngineConfig::auto_compaction = false`, which
+        // leaves the policy unset and makes `maintenance_step` a no-op. Read the
+        // config values into locals BEFORE the struct-init moves `config`.
+        let merge_policy: Option<Box<dyn MergePolicy>> = if config.auto_compaction {
+            Some(Box::new(STCSPolicy::new(
+                config.compaction_min_threshold,
+                config.compaction_max_threshold,
+                0.5,
+                1.5,
+                STCSPolicy::DEFAULT_MIN_SSTABLE_SIZE,
+            )?))
+        } else {
+            None
+        };
+
         Ok(Self {
             config,
             wal,
@@ -563,7 +613,7 @@ impl WriteEngine {
             generation,
             closed: AtomicBool::new(false),
             active_merge: None,
-            merge_policy: None,
+            merge_policy,
             cumulative_stats: CompactionStats::default(),
             rows_written: 0,
             l0_count: 0,


### PR DESCRIPTION
## What & why

Fixes #1619 (N1, epic #1607 — wiring landmines). CQLite documented STCS compaction (`maintenance --budget-ms` CLI, Python `maintenance_step`, Node `maintenanceStep`) but it was a **silent no-op**: `WriteEngine::new` hard-coded `merge_policy: None` and `set_merge_policy` had zero non-test callers, so L0 SSTables accumulated without bound and the documented capability merged nothing — forever. `cqlite_core::Config.storage.compaction` was entirely decorative.

DECIDED (report §"Product decisions" #1; capstone §3 N1⇄AH1): default-on STCS with a real off-switch.

## Changes

- **Install a default `STCSPolicy` in `WriteEngine::new`** built from config (`STCSPolicy::new(...)?`, no `unwrap`). Compaction now runs by default via the public constructor — no manual `set_merge_policy` needed.
- **Real off-switch:** `WriteEngineConfig` gains `auto_compaction` (default `true`), `compaction_min_threshold` (4), `compaction_max_threshold` (32). `auto_compaction = false` installs no policy → `maintenance_step` is a genuine no-op. `WriteEngineConfig::new` fills all three so existing callers keep compiling.
- **AH1 — make `Config.storage.compaction` authoritative:** `WriteEngineConfig::with_compaction_config(&CompactionConfig)` threads the switch. Python `open(config=...)` and Node `Database.open` now honor it. Node gains a public `autoCompaction` option on `DatabaseOptions` so the off-switch is reachable from JS.
- **Deleted decorative `CompactionConfig` fields/variants:** `strategy` + the `CompactionStrategy` enum (Size/Leveled/Universal), `max_sstables`, `size_ratio`, `max_threads`, `background_interval` — none were read by any behavior. Kept `auto_compaction` (now authoritative). Verified no serialized golden / public example pinned them.

## Wiring-evidence (public surface exercises the policy end-to-end)

- Core: `test_maintenance_step_default_policy_compacts_via_public_ctor` builds via `WriteEngine::new(WriteEngineConfig)` **only** (no `set_merge_policy`), produces ≥4 L0 SSTables, calls `maintenance_step`, asserts `rows_merged > 0`. Companion `auto_compaction=false` test asserts a no-op. `with_compaction_config` mapping test proves `Config` → engine.
- Node: 3 jest cases in `write.test.js` via the public `Database.open` + `maintenanceStep` API (off + default-on).
- Python: 3 tests in `test_write_api.py` via public `open(config=...)` + `maintenance_step`, using a complete config from `performance_optimized()` with the switch flipped; plus a test locking in that partial config dicts are rejected.

## Not changed
Compaction byte output, the read path, and the merge kernel are untouched — #1666 (deterministic STCS bucket selection) governs *which* SSTables merge; this PR only *installs* that policy by default. Compaction byte-parity harness green; 33-table JSONL goldens unchanged.

## Validation
`scripts/agent-gate.sh` PASS (all components). Clippy `-D warnings` clean workspace-wide. No new `unwrap`/`expect` in library code. roborev (codex) findings addressed.
