### PR TITLE
fix(#1411): surface chunk-CRC corruption on point lookup (get no longer returns Ok(None) on corrupt chunk)

### DIFF
--- a/cqlite-core/src/storage/sstable/reader/data_access/sequential.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/sequential.rs
@@ -359,23 +359,31 @@ impl SSTableReader {
                 file_guard.seek(SeekFrom::Start(header_size as u64)).await?;
             }
 
+            // Issue #1411: separate the chunk-integrity stitch from the schema-aware
+            // parse so their failure classes are not conflated. `stitch_all_chunks`
+            // drives the authoritative per-chunk CRC32 check
+            // (`block_io::read_nb_format_chunk_data`) + decompression; a CRC mismatch,
+            // decompression failure, or corrupt offset is corruption and MUST surface
+            // (propagate via `?`, matching `scan`), never be masked as a missing key.
+            // Only the `parse_block` step below may soft-miss (schema unavailable /
+            // wrong table type) so the caller can try the next reader. Previously
+            // `stitch_and_parse_all_chunks` combined both under a blanket
+            // `Err(_) => Ok(None)` that swallowed CRC corruption on point lookups.
+            let stitched_buffer = self.stitch_all_chunks(&cursor).await?;
+
             // Pass the reader's own schema so that V5CompressedLegacy rows can be fully
             // parsed and their partition RowKeys emitted.  Without a schema, parse_row_v5
             // fails for all rows in a partition, causing no entries to be pushed and making
             // the key comparison always miss even when the key exists.
             let schema_opt = self.get_table_schema(None);
-            let all_entries = match self
-                .stitch_and_parse_all_chunks(&cursor, schema_opt.as_ref())
-                .await
+            let parser = self.build_v5_parser();
+            let all_entries = match parser.parse_block(&stitched_buffer, schema_opt.as_ref(), self)
             {
                 Ok(entries) => entries,
                 Err(e) => {
                     // Schema may not be available for this reader (e.g., wrong table type).
                     // Return None so the caller can try the next reader.
-                    log::debug!(
-                        "scan_for_key: stitch_and_parse_all_chunks failed (schema missing?): {}",
-                        e
-                    );
+                    log::debug!("scan_for_key: parse_block failed (schema missing?): {}", e);
                     return Ok(None);
                 }
             };

--- a/cqlite-core/src/storage/sstable/reader/data_access/sequential.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/sequential.rs
@@ -11,10 +11,36 @@ use super::model::{
     sort_by_token_order, sort_by_token_order_with_meta, table_ids_match, SCAN_FOR_KEY_CALLS,
 };
 use crate::types::{CellWriteMetadata, ScanRow, TableId};
-use crate::{Result, RowKey};
+use crate::{Error, Result, RowKey};
 use std::io::SeekFrom;
 use tokio::io::AsyncSeekExt;
 use tokio::sync::mpsc;
+
+/// Classify a `parse_block` failure on the compressed (`V5CompressedLegacy`)
+/// point-lookup path (`scan_for_key`) as a soft-miss vs. a fatal error.
+///
+/// Issue #1411: the scan path ([`SSTableReader::stitch_and_parse_all_chunks`])
+/// propagates every `parse_block` error via `?`. The point-lookup path mirrors
+/// that so `get()` and `scan()` agree on which failures are fatal — with ONE
+/// deliberate exception, the case the original blanket `Err(_) => Ok(None)`
+/// existed to protect: this reader has no schema for the table, so it cannot
+/// serve the key and the caller must fall through to the next SSTable reader.
+///
+/// Returns `true` (soft-miss → `Ok(None)`) ONLY when both hold:
+/// - `schema_present == false` — the reader supplied no schema, and
+/// - the parser reported [`Error::Schema`] — which `V5CompressedLegacy`'s
+///   `parse_block` raises ("requires schema for <ks>.<table>") *before* it
+///   inspects any bytes when no schema is available.
+///
+/// Every other failure is non-recoverable and must propagate: real data
+/// corruption / malformed blocks (`Corruption`, `InvalidFormat`, `Parse`, I/O,
+/// etc.), and — critically — a deep schema/type-resolution `Error::Schema`
+/// raised when a schema IS present (a UDT/type that cannot be resolved is a real
+/// error, not a missing key). Requiring `!schema_present` prevents that class
+/// from ever being masked as "not found".
+fn is_parse_soft_miss(schema_present: bool, err: &Error) -> bool {
+    !schema_present && matches!(err, Error::Schema(_))
+}
 
 impl SSTableReader {
     /// Scan a range of keys
@@ -380,12 +406,24 @@ impl SSTableReader {
             let all_entries = match parser.parse_block(&stitched_buffer, schema_opt.as_ref(), self)
             {
                 Ok(entries) => entries,
-                Err(e) => {
-                    // Schema may not be available for this reader (e.g., wrong table type).
-                    // Return None so the caller can try the next reader.
-                    log::debug!("scan_for_key: parse_block failed (schema missing?): {}", e);
+                // Issue #1411 (roborev): the scan path (`stitch_and_parse_all_chunks`)
+                // propagates EVERY `parse_block` error via `?`. Mirror that here so
+                // `get()` and `scan()` agree on which errors are fatal. The ONLY
+                // legitimate soft-miss — the case the original blanket
+                // `Err(_) => Ok(None)` existed to protect — is classified by
+                // `is_parse_soft_miss`: this reader has no schema for the table, so it
+                // cannot serve the key and the caller must try the next SSTable reader.
+                // Every other failure (real corruption / malformed block, or a deep
+                // schema/type-resolution error when a schema IS present) MUST surface.
+                Err(e) if is_parse_soft_miss(schema_opt.is_some(), &e) => {
+                    log::debug!(
+                        "scan_for_key: no schema for this reader ({}); soft-miss so the caller tries the next reader: {}",
+                        table_id,
+                        e
+                    );
                     return Ok(None);
                 }
+                Err(e) => return Err(e),
             };
 
             // NOTE: The SSTableIndex is built from 16-byte Murmur3 *digests*, not raw keys,
@@ -722,6 +760,57 @@ impl SSTableReader {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // =========================================================================
+    // Issue #1411: point-lookup parse-error classification (unit level)
+    //
+    // Proves `scan_for_key`'s parse-error handling matches the scan path
+    // (`stitch_and_parse_all_chunks`, which propagates EVERY `parse_block` error):
+    // only "this reader has no schema for the table" soft-misses to Ok(None) so a
+    // multi-reader `get()` can try the next reader; real corruption / malformed
+    // blocks (and a deep schema error when a schema IS present) stay fatal.
+    // =========================================================================
+
+    #[test]
+    fn soft_miss_only_when_schema_absent_and_schema_error() {
+        // The one legitimate soft-miss: no schema for this reader → the parser
+        // reports Error::Schema before touching bytes → caller tries next reader.
+        assert!(is_parse_soft_miss(
+            false,
+            &Error::schema("V5CompressedLegacy format requires schema for ks.tbl")
+        ));
+    }
+
+    #[test]
+    fn schema_error_with_schema_present_is_fatal() {
+        // A schema IS present but a deep type/UDT resolution failed → real error,
+        // NOT a missing key. Must propagate (matches the scan path).
+        assert!(!is_parse_soft_miss(
+            true,
+            &Error::schema("Not a UserType: frozen<...>")
+        ));
+    }
+
+    #[test]
+    fn corruption_classes_are_always_fatal() {
+        // Real data corruption / malformed block classes MUST propagate in BOTH
+        // schema-present and schema-absent modes — never masked as "not found".
+        // These are exactly the classes the scan path surfaces via `?`.
+        for schema_present in [true, false] {
+            assert!(!is_parse_soft_miss(
+                schema_present,
+                &Error::corruption("chunk 0 CRC mismatch at offset 0x0")
+            ));
+            assert!(!is_parse_soft_miss(
+                schema_present,
+                &Error::invalid_format("malformed row header in chunk 0 at offset 0x0")
+            ));
+            assert!(!is_parse_soft_miss(
+                schema_present,
+                &Error::Parse("bad VInt".to_string())
+            ));
+        }
+    }
 
     // =========================================================================
     // Integration tests with real SSTable data

--- a/cqlite-core/tests/issue_1397_corrupt_query_surface.rs
+++ b/cqlite-core/tests/issue_1397_corrupt_query_surface.rs
@@ -53,6 +53,13 @@ use std::sync::Arc;
 /// Relative path of the corrupt COMPRESSED Data.db under the datasets root.
 const CORRUPT_DATA_DB: &str = "corruption/test_comp_corrupt/data_db_bit_flip/nb-1-big-Data.db";
 
+/// Relative path of the CLEAN source Data.db the corrupt fixture was derived from
+/// (`test_comp/lz4_table`). Used to prove the #1411 fix keeps a healthy point
+/// lookup returning `Ok(Some(_))` — so the corrupt-fixture `Err` is genuinely the
+/// corruption surfacing, not a lookup that fails for every input.
+const CLEAN_DATA_DB: &str =
+    "sstables/test_comp/lz4_table-25801a0071a911f19b3225f9984c6a77/nb-1-big-Data.db";
+
 /// Fully-qualified table the corrupt fixture was derived from.
 const TABLE: &str = "test_comp.lz4_table";
 
@@ -219,15 +226,17 @@ async fn streaming_scan_terminates_with_error_not_silent_truncation() {
 /// EXPECTED behavior (issue #1397): a typed, non-recoverable corruption error naming
 /// the corrupt chunk index + offset — NOT `Ok(None)` and NOT garbage.
 ///
-/// This test asserts that correct behavior. It is `#[ignore]`d today because the
-/// point-lookup path (`get` → bloom(present) → `read_value_at_offset`/`get_cached_data`)
-/// reads raw bytes at an offset and LZ4-decodes them WITHOUT the inline per-chunk CRC
-/// check, so a bit-flipped chunk currently reads as "not found" (`Ok(None)`) instead
-/// of surfacing corruption. Fixing that bypass is tracked as #1411; un-ignore this
-/// test when #1411 lands. The identical `get([0,0,0,1])` returns `Ok(Some(_))` on the
-/// CLEAN fixture, so the divergence is a read-path defect, not a wrong key.
+/// Fixed by issue #1411. The point lookup for `lz4_table` (a compressed `nb` table)
+/// falls through the digest-index miss (issue #517) into `scan_for_key`, whose
+/// chunk-stitching branch used to swallow EVERY `Err` from
+/// `stitch_and_parse_all_chunks` as `Ok(None)` — including the authoritative
+/// per-chunk CRC32 mismatch raised by `block_io::read_nb_format_chunk_data`. #1411
+/// split the integrity stitch (`stitch_all_chunks`, whose errors now propagate) from
+/// the schema-aware parse (which alone may soft-miss), so the corruption surfaces as
+/// the SAME typed error the full-scan/stream paths return. The identical
+/// `get([0,0,0,1])` returns `Ok(Some(_))` on the CLEAN fixture, so the divergence was
+/// a read-path defect, not a wrong key.
 #[tokio::test]
-#[ignore = "expected behavior; blocked on #1411 (point-lookup bypasses inline chunk-CRC check). Un-ignore when #1411 lands."]
 async fn point_lookup_into_corrupt_chunk_should_error_see_1411() {
     let Some(path) = corrupt_data_db_or_gate() else {
         return;
@@ -248,6 +257,43 @@ async fn point_lookup_into_corrupt_chunk_should_error_see_1411() {
             "point lookup over the corrupt chunk returned Ok(Some({v:?})) — garbage \
              from a bit-flipped chunk; it must return a typed corruption error."
         ),
+    }
+}
+
+/// Issue #1411 CLEAN-fixture control — the SAME point lookup (`get([0,0,0,1])`) on
+/// the healthy source SSTable returns `Ok(Some(_))`. This proves the corrupt-fixture
+/// `Err` above is the CRC corruption surfacing, not a lookup that misses for every
+/// input (which would make the corrupt-fixture assertion vacuous). Skip-clean when
+/// the clean binary is absent; `CQLITE_REQUIRE_FIXTURES=1` makes absence a hard fail;
+/// a present fixture that returns `Ok(None)`/`Err` fails unconditionally.
+#[tokio::test]
+async fn point_lookup_on_clean_chunk_returns_some_1411() {
+    let path = datasets_root().map(|r| r.join(CLEAN_DATA_DB));
+    let path = match path {
+        Some(p) if p.is_file() => p,
+        _ => {
+            assert!(
+                !require_fixtures(),
+                "CQLITE_REQUIRE_FIXTURES=1 but the clean source fixture is absent: {CLEAN_DATA_DB}. \
+                 Fetch the corpus (test-data/scripts/fetch-datasets.sh)."
+            );
+            eprintln!("SKIP: clean source fixture absent ({CLEAN_DATA_DB}); set CQLITE_REQUIRE_FIXTURES=1 to enforce.");
+            return;
+        }
+    };
+    let reader = open_reader(&path).await;
+    let table_id = TableId::new(TABLE.to_string());
+    let key = RowKey::new(PK1_KEY_BYTES.to_vec());
+
+    match reader.get(&table_id, &key).await {
+        Ok(Some(_)) => {}
+        Ok(None) => panic!(
+            "point lookup for pk=1 on the CLEAN {TABLE} fixture returned Ok(None); the \
+             partition must be found (else the corrupt-fixture assertion is vacuous)."
+        ),
+        Err(e) => {
+            panic!("point lookup for pk=1 on the CLEAN {TABLE} fixture must succeed, got Err: {e}")
+        }
     }
 }
 


### PR DESCRIPTION
Closes #1411

## Problem
`SSTableReader::get(table_id, key)` bypassed the inline per-chunk CRC32 check that `scan`/`scan_stream` enforce, so on a corrupt **compressed** chunk it returned `Ok(None)` ("not found") instead of surfacing the corruption. On the `data_db_bit_flip` LZ4 fixture (`test_comp/lz4_table`, pk=1 in chunk 0), `scan` → `Err(InvalidFormat("CRC32 mismatch for chunk 0 …"))` but `get(pk1)` → `Ok(None)`.

## Root cause (differs from the issue's hypothesis)
The hypothesized `read_value_at_offset`/`get_cached_data` offset path is **never reached** for a compressed `nb` point lookup — `Index.db` is keyed by 16-byte Murmur3 digests so `find_entry(pk)` misses (#517) and `get` falls through to `scan_for_key`. The real bypass: `scan_for_key`'s chunk-stitching branch wrapped `stitch_and_parse_all_chunks` in a blanket `Err(_) => Ok(None)`, swallowing the typed CRC error that `block_io::read_nb_format_chunk_data` (the sole authoritative CRC check) raises.

## Fix (reuses the existing CRC path — no duplication)
Split the combined helper into its two phases in `data_access/sequential.rs`:
1. `stitch_all_chunks(&cursor).await?` — chunk-integrity (CRC32 / decompress / corrupt-offset) now **propagates** via `?`, surfacing the identical `Error::InvalidFormat` the scan path returns.
2. `parse_block(...)` — parse errors classified via `is_parse_soft_miss(schema_present, err)`: soft-miss `Ok(None)` **only** when schema is absent and the error is `Error::Schema` (the legitimate "this reader can't serve this key → try next reader" case); **all** non-recoverable errors (`Corruption`/`InvalidFormat`/`Parse`, and a deep `Error::Schema` when a schema IS present) propagate — at parity with the scan path.

No CRC logic duplicated; the check stays solely in `block_io`. Clean-fixture `get` → `Ok(Some)` unchanged; multi-reader fall-through unchanged.

## Tests (wiring-evidence)
- `issue_1397_corrupt_query_surface.rs`: un-ignored `point_lookup_into_corrupt_chunk_should_error_see_1411` (bit-flip → typed CRC `Err`, same `assert_typed_chunk_corruption` invariant as scan/stream) + added `point_lookup_on_clean_chunk_returns_some_1411` (clean → `Ok(Some)`). Fail-closed under `CQLITE_REQUIRE_FIXTURES=1`; FAILED before / PASS after against real fixture bytes.
- Unit tests for `is_parse_soft_miss`: schema-absent+`Schema` soft-misses; schema-present+`Schema` fatal; `Corruption`/`InvalidFormat`/`Parse` always fatal.

## Quality bar
- `scripts/agent-gate.sh` **PASS** — all 20 components (commit 48a06933; rebased onto current origin/main with zero conflicts and no overlap in `sequential.rs`/`error.rs`).
- Workspace clippy `--all-targets --all-features -D warnings` clean; no `unwrap()`/`expect()` added.
- roborev **clean** (codex, `--base origin/main`; converged after propagating parse-time corruption too).
- Builds verified under default, `all-compression`, and `tombstones`.

## Notes
- `sequential.rs` was already over the file-size threshold (1147L) before this change; the minimal fix pushed it ~+8L → acknowledged with `CQLITE_ALLOW_FILE_GROWTH=1` (a #1116-class split is out of scope for this focused fix).
- Filed **#1773** (P3): a latent identical CRC gap in the currently-unreachable `read_value_at_offset`/`get_cached_data` compressed offset path — defensive follow-up, out of scope here.
