### PR TITLE
fix(#1460): guard Node write-support flag (no silent read-path fallthrough) + release write smoke

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -70,7 +70,13 @@ jobs:
 
       - name: Run smoke Jest subset
         working-directory: bindings/node
-        run: npx jest __test__/loader.test.js __test__/publish.test.js __test__/smoke.test.js --runInBand
+        # write-smoke.test.js (issue #1460) runs against the release-built
+        # (`npm run build` = --features write-support) `.node` artifact and
+        # asserts a DML INSERT is routed to the write engine and persists a
+        # non-empty *-Data.db. It reds if the write-support flag is ever dropped
+        # (the fix makes a stripped build fail closed on DML). Kept in the always
+        # -required smoke subset so it guards every PR, not just ci:bindings-full.
+        run: npx jest __test__/loader.test.js __test__/publish.test.js __test__/smoke.test.js __test__/write-smoke.test.js --runInBand
 
   build:
     name: Build (${{ matrix.target }})

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -88,6 +88,17 @@ jobs:
             npm run build
           fi
 
+      # Issue #1460: prove the release artifact we are about to ship can actually
+      # write. If `--features write-support` were ever dropped from the build,
+      # the fix makes DML fail closed, so this smoke reds instead of silently
+      # publishing a binary that no-ops INSERTs. Skipped only for the
+      # aarch64-linux CROSS build, which cannot be executed on the x86_64 host.
+      - name: Verify release artifact can write (write-smoke)
+        if: matrix.target != 'aarch64-unknown-linux-gnu'
+        working-directory: bindings/node
+        shell: bash
+        run: npx jest __test__/write-smoke.test.js --runInBand
+
       - name: Upload artifact
         uses: actions/upload-artifact@v6
         with:

--- a/bindings/node/__test__/write-smoke.test.js
+++ b/bindings/node/__test__/write-smoke.test.js
@@ -1,0 +1,117 @@
+/**
+ * Release-artifact write smoke test (Issue #1460).
+ *
+ * The Node binding's entire write capability hangs on one build flag:
+ * `--features write-support` (bindings/node/package.json build script). If that
+ * flag is ever dropped from the release build, the DML routing is `#[cfg]`ed out
+ * and an INSERT does not error — historically it *silently* fell through to the
+ * read path, returned a read-shaped empty result, and never persisted the row.
+ *
+ * This test exercises a DML write end-to-end through the BUILT `lib/index.js` →
+ * `.node` artifact (the same module CI ships) and proves:
+ *   1. the INSERT is routed to the write engine (result is NOT read-shaped), and
+ *   2. `flushRun()` produces a non-empty `*-Data.db` on disk, and
+ *   3. `writeStats` advanced.
+ *
+ * If `--features write-support` is stripped from the build, the fix in
+ * database.rs makes the DML fail closed (an explicit error is thrown), so this
+ * test STILL reds — it can never pass against a write-support-stripped build.
+ * (TDD proof: `napi build --platform --release` without the flag → this test
+ * throws on the INSERT; rebuild with the flag → passes.)
+ *
+ * This test does NOT depend on the external SSTable datasets — it writes into a
+ * fresh tmp dir and needs only a single-table schema file. It must FAIL LOUDLY
+ * (throw) if the write engine cannot open; it must never skip.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { Database } = require('../lib/index.js');
+
+// Single-table schema (no-heuristics mandate, Issue #28): unambiguous write target.
+const SCHEMA_PATH = path.join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'test-data',
+  'schemas',
+  'write-test.cql'
+);
+
+/** Recursively find the first file whose name ends with `-Data.db`. */
+function findDataDb(root) {
+  const stack = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(full);
+      } else if (entry.isFile() && entry.name.endsWith('-Data.db')) {
+        return full;
+      }
+    }
+  }
+  return null;
+}
+
+describe('release-artifact write smoke (Issue #1460)', () => {
+  beforeAll(() => {
+    if (!fs.existsSync(SCHEMA_PATH)) {
+      throw new Error(
+        `Schema file not found at ${SCHEMA_PATH}. Cannot run write smoke.`
+      );
+    }
+  });
+
+  test('test_release_artifact_can_write', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cqlite-write-smoke-'));
+    let db;
+    try {
+      // Open the built artifact writable against a fresh, empty tmp dir.
+      db = await Database.open(tmp, {
+        schema: SCHEMA_PATH,
+        writable: true,
+        writeDir: tmp,
+      });
+
+      // Execute a DML write through the released artifact's native path.
+      // A literal UUID is used (not uuid()) so the assertion is deterministic and
+      // does not depend on server-side function support in the write parser.
+      const wr = await db.executeNative(
+        "INSERT INTO test_basic.simple_table (id, name) VALUES (550e8400-e29b-41d4-a716-446655441460, 'Smoke')"
+      );
+
+      // Negative assertion: the write branch returns rows:[], rowCount:0,
+      // rowsAffected:1 (bindings/node/src/database.rs). A read fall-through
+      // (feature stripped, pre-fix) would instead have returned a SELECT-shaped
+      // result where rowsAffected === rowCount and the write dir stayed empty.
+      // Post-fix, a stripped build throws before reaching here.
+      expect(wr.rowCount).toBe(0);
+      expect(wr.rowsAffected).toBeGreaterThanOrEqual(1);
+      expect(wr.rowsAffected).not.toBe(wr.rowCount);
+
+      // Flush the memtable to an SSTable on disk.
+      const flushedPath = await db.flushRun();
+      expect(typeof flushedPath).toBe('string');
+      expect(flushedPath.length).toBeGreaterThan(0);
+
+      // writeStats must show the write + flush advanced counters.
+      const stats = db.writeStats;
+      expect(stats.l0Count).toBeGreaterThan(0);
+      expect(stats.totalWritten).toBeGreaterThan(0);
+
+      // A non-empty *-Data.db must now exist somewhere under the write dir.
+      const dataDb = findDataDb(tmp);
+      expect(dataDb).not.toBeNull();
+      expect(fs.statSync(dataDb).size).toBeGreaterThan(0);
+    } finally {
+      if (db) {
+        await db.close();
+      }
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/bindings/node/src/database.rs
+++ b/bindings/node/src/database.rs
@@ -410,13 +410,32 @@ impl Database {
     }
 
     /// Determine whether a CQL statement is a write operation.
-    #[cfg(feature = "write-support")]
+    ///
+    /// Deliberately NOT feature-gated: the read-path entry points must be able to
+    /// detect DML even when the `write-support` feature is compiled out, so they
+    /// can fail closed (return an explicit error) instead of silently handing an
+    /// `INSERT`/`UPDATE`/`DELETE` to the read engine — which would return a
+    /// read-shaped, empty result and never persist the row (issue #1460).
     fn is_dml_statement(query: &str) -> bool {
         let upper = query.trim_start().to_uppercase();
         upper.starts_with("INSERT")
             || upper.starts_with("UPDATE")
             || upper.starts_with("DELETE")
             || upper.starts_with("BEGIN")
+    }
+
+    /// Error returned when a DML statement is issued against a binary that was
+    /// built WITHOUT the `write-support` feature. Failing closed here is the
+    /// whole point of issue #1460: without this guard the DML string falls
+    /// through to the read engine and silently no-ops (no write, no error).
+    #[cfg(not(feature = "write-support"))]
+    fn dml_unsupported_error() -> napi::Error {
+        simple_error(
+            "Write support is not compiled into this build of @cqlite/node. \
+             DML statements (INSERT/UPDATE/DELETE) cannot be executed and will \
+             NOT be silently ignored. Rebuild the native module with \
+             `--features write-support`.",
+        )
     }
 }
 
@@ -753,6 +772,13 @@ impl Database {
                 });
             }
 
+            // Fail closed: without the write-support feature, a DML statement must
+            // NOT fall through to the read engine (issue #1460).
+            #[cfg(not(feature = "write-support"))]
+            if Self::is_dml_statement(&query) {
+                return Err(Self::dml_unsupported_error());
+            }
+
             let core_result = self.inner.execute(&query).await.map_err(|e| {
                 // Boundary error: record once here (subsystem = "node"), not in
                 // nested helpers, to avoid double counting with core.
@@ -1065,6 +1091,13 @@ impl Database {
             self.ensure_writable()?;
         }
 
+        // Fail closed: without the write-support feature, a DML statement must
+        // NOT fall through to the read engine (issue #1460).
+        #[cfg(not(feature = "write-support"))]
+        if Self::is_dml_statement(&query) {
+            return Err(Self::dml_unsupported_error());
+        }
+
         Ok(napi::bindgen_prelude::AsyncTask::new(ExecuteNativeTask {
             inner: self.inner.clone(),
             query,
@@ -1323,6 +1356,15 @@ impl napi::Task for ExecuteNativeTask {
                     rows_affected: 1,
                 });
             }
+        }
+
+        // Fail closed: without the write-support feature, a DML statement must
+        // NOT fall through to the read engine (issue #1460). The public
+        // `execute_native` entry point already rejects this before creating the
+        // task; this is defense-in-depth so the task can never silently no-op.
+        #[cfg(not(feature = "write-support"))]
+        if Database::is_dml_statement(&self.query) {
+            return Err(Database::dml_unsupported_error());
         }
 
         // Use global runtime for async execution. The future is `.instrument`-ed


### PR DESCRIPTION
Closes #1460.

## Root cause
The Node binding's DML routing was entirely feature-gated behind `write-support`
(`bindings/node/src/database.rs`). With the feature stripped from the build,
`is_dml_statement` and the DML branch in `execute`/`executeNative`/`ExecuteNativeTask::compute`
vanished, so an `INSERT` was handed to the read engine and silently returned a
read-shaped empty result — no write, no error.

## Fix (fail closed)
- `is_dml_statement` is no longer feature-gated (it is a pure string check).
- Added `#[cfg(not(feature = "write-support"))]` guards in `execute`, the
  `executeNative` pre-check, and `ExecuteNativeTask::compute` that return an
  explicit error when a DML statement is issued against a write-support-stripped
  build — never a silent read-path fallthrough. New `Database::dml_unsupported_error()`
  carries the message. No new `unwrap()`/`expect()`.

## Release-artifact write smoke
- `bindings/node/__test__/write-smoke.test.js::test_release_artifact_can_write`
  runs against the BUILT `lib/index.js` -> `.node` artifact: opens writable in a
  fresh tmp dir, `executeNative` INSERT, asserts the result is NOT read-shaped
  (`rowCount===0`, `rowsAffected>=1`), `flushRun()`, asserts `writeStats`
  advanced (`l0Count`/`totalWritten` > 0), and recursively finds a non-empty
  `*-Data.db`. Needs only a schema file (no external datasets).
- Wired into CI where the release-built `.node` is exercised: added to the
  always-required `node-ci.yml` PR smoke Jest subset (built via `npm run build`
  = `--features write-support`), and a post-build verification step in
  `node-release.yml` (skipped only for the non-runnable aarch64-linux cross build).

## Verified
- `npm run build && npx jest write-smoke` -> PASS.
- TDD proof: rebuilt WITHOUT the flag (`napi build --platform --profile release-unwind`)
  -> write-smoke REDS with the explicit fail-closed error (confirms both the fix
  and that the smoke catches a dropped flag); rebuilt WITH the flag -> PASS.
- Full `write.test.js` (41 tests) + write-smoke -> PASS.

Local `scripts/agent-gate.sh` / `cargo clippy --workspace` are un-runnable on this
box (OOM under concurrent heavy compiles) — relying on CI lanes as the gate.