### PR TITLE
fix(#1438): Runtime::new Result→exception in Python + Node bindings (no panic across FFI)

### DIFF
--- a/bindings/node/src/database.rs
+++ b/bindings/node/src/database.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use napi_derive::napi;
 
-use crate::error::{simple_error, to_napi_error};
+use crate::error::{runtime_init_error, simple_error, to_napi_error};
 
 #[cfg(feature = "write-support")]
 use std::sync::Mutex;
@@ -478,6 +478,13 @@ impl Database {
         // off (issue #1040).
         crate::observability::init_once(options.as_ref().and_then(|o| o.otel.as_ref()));
 
+        // Eagerly build the shared tokio runtime so a resource-starved host
+        // (out of threads/FDs/memory) surfaces a catchable error AT open()
+        // rather than only later on the first executeNative/streaming next/flush
+        // block_on (issue #1438). On success the runtime is memoized and reused;
+        // this call is a cheap OnceLock fast-path on every subsequent open.
+        crate::runtime::try_get_runtime().map_err(runtime_init_error)?;
+
         // Per-handle default traceparent for this database's per-call spans.
         let traceparent = options
             .as_ref()
@@ -695,6 +702,13 @@ impl Database {
 
         #[cfg(not(feature = "write-support"))]
         let _ = (writable, write_dir); // suppress unused warning when feature off
+
+        // Eagerly build (and memoize) the shared async runtime so a resource-
+        // starved host surfaces the failure HERE at open() time as a catchable
+        // napi::Error, rather than deferring it to the first executeNative() /
+        // flushRun() / stream iteration that reaches `block_on` (issue #1438).
+        // Idempotent — later calls reuse the memoized runtime.
+        crate::runtime::try_get_runtime().map_err(runtime_init_error)?;
 
         Ok(Database {
             inner: Arc::new(db),
@@ -1159,7 +1173,9 @@ impl Database {
                 let mut engine = we_clone
                     .lock()
                     .map_err(|_| simple_error("Write engine lock poisoned"))?;
-                crate::runtime::block_on(engine.flush()).map_err(to_napi_error)
+                crate::runtime::block_on(engine.flush())
+                    .map_err(runtime_init_error)?
+                    .map_err(to_napi_error)
             })
             .await
             .map_err(|e| simple_error(format!("flush_run task panicked: {e}")))??;
@@ -1380,7 +1396,8 @@ impl napi::Task for ExecuteNativeTask {
                 })
             }
             .instrument(span),
-        )?;
+        )
+        .map_err(runtime_init_error)??;
 
         let row_count = result.rows.len() as u32;
         crate::observability::record_rows(&span_for_record, row_count as u64);

--- a/bindings/node/src/error.rs
+++ b/bindings/node/src/error.rs
@@ -160,6 +160,17 @@ pub fn to_napi_error(err: Error) -> napi::Error {
     napi::Error::new(napi::Status::GenericFailure, formatted_message)
 }
 
+/// Map a tokio runtime-initialization failure to a `napi::Error`.
+///
+/// The shared async runtime is built lazily (see `runtime::try_get_runtime`).
+/// If the host is out of threads/file descriptors/memory the build fails with an
+/// [`std::io::Error`]; surfacing it here as a `napi::Error` (via the same
+/// `Io` → System/`IO` mapping as any other I/O failure) lets `open()` reject/throw
+/// instead of the process aborting under `panic = "abort"` (issue #1438).
+pub fn runtime_init_error(err: std::io::Error) -> napi::Error {
+    to_napi_error(Error::Io(err))
+}
+
 /// Create a napi::Error with a simple message (no metadata).
 ///
 /// Use this for errors that don't originate from cqlite_core::Error,
@@ -355,6 +366,19 @@ mod tests {
         // Corruption has Data category, which maps to ParseError
         assert!(napi_err.reason.contains("data corrupted"));
         assert!(napi_err.reason.contains("code=PARSE"));
+    }
+
+    #[test]
+    fn test_runtime_init_error_maps_to_napi_error() {
+        // A runtime-init failure must surface as a catchable napi::Error
+        // (System/IO), never a process abort (issue #1438).
+        let io_err =
+            std::io::Error::other("cannot spawn worker threads: resource temporarily unavailable");
+        let napi_err = runtime_init_error(io_err);
+
+        assert!(napi_err.reason.contains("cannot spawn worker threads"));
+        assert!(napi_err.reason.contains("code=IO"));
+        assert!(napi_err.reason.contains("category=System"));
     }
 
     #[test]

--- a/bindings/node/src/runtime.rs
+++ b/bindings/node/src/runtime.rs
@@ -201,7 +201,11 @@ mod tests {
         let addresses: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
 
         // Exactly one build ran despite N concurrent first callers.
-        assert_eq!(BUILDS.load(Ordering::SeqCst), 1, "build must run exactly once");
+        assert_eq!(
+            BUILDS.load(Ordering::SeqCst),
+            1,
+            "build must run exactly once"
+        );
         // Every caller observed the same &'static value.
         assert!(
             addresses.windows(2).all(|w| w[0] == w[1]),

--- a/bindings/node/src/runtime.rs
+++ b/bindings/node/src/runtime.rs
@@ -7,55 +7,102 @@
 //! consistency across language bindings per M4 spec Section 2.1.
 
 use std::future::Future;
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
 use tokio::runtime::Runtime;
 
 /// Global tokio runtime instance.
 static RUNTIME: OnceLock<Runtime> = OnceLock::new();
 
-/// Returns a reference to the global tokio runtime.
+/// Serializes the fallible slow-path build so at most one runtime is ever
+/// constructed, even under concurrent first use.
+static INIT_LOCK: Mutex<()> = Mutex::new(());
+
+/// Returns a reference to the global tokio runtime, building it on first use.
 ///
 /// The runtime is lazily initialized on first access using a multi-threaded
-/// executor with all features enabled.
+/// executor with all features enabled. On success the runtime is memoized in a
+/// process-global `OnceLock` and reused by every subsequent call.
 ///
-/// # Panics
+/// # Errors
 ///
-/// Panics if the runtime cannot be created (e.g., system resource exhaustion).
-/// This use of `expect()` is acceptable because:
-///
-/// 1. **Module initialization context**: Failure occurs once at module load time,
-///    not during normal operations
-/// 2. **Fatal condition**: Runtime creation only fails under extreme resource
-///    exhaustion (no memory, file descriptors, or thread capacity)
-/// 3. **No recovery path**: All CQLite Node.js operations require an async runtime;
-///    there is no meaningful fallback
-/// 4. **Clear error message**: Users see the panic message as a module load failure
-///
-/// In Node.js, this manifests as a thrown error during `require('@cqlite/node')`,
-/// which is the appropriate failure mode for an unrecoverable initialization error.
-pub fn get_runtime() -> &'static Runtime {
-    RUNTIME.get_or_init(|| {
+/// Returns the underlying [`std::io::Error`] if the runtime cannot be created
+/// (e.g., the host is out of threads, file descriptors, or memory). Unlike a
+/// panicking initializer, a failed build does **not** poison the cell: a later
+/// call can retry once resources are available, and the error is surfaced to the
+/// caller (mapped to a `napi::Error` at the binding boundary so it rejects/throws)
+/// rather than aborting the host process under `panic = "abort"`.
+pub fn try_get_runtime() -> Result<&'static Runtime, std::io::Error> {
+    get_or_try_init(&RUNTIME, &INIT_LOCK, || {
         tokio::runtime::Builder::new_multi_thread()
             .thread_name("cqlite-node-worker")
             .enable_all()
             .build()
-            .expect("Failed to create tokio runtime - system may be out of resources")
     })
+}
+
+/// Serialized get-or-build for a process-global [`OnceLock`].
+///
+/// Preserves `OnceLock::get_or_init`'s single-initializer guarantee while
+/// allowing the initializer to be fallible: at most one `build` ever runs, even
+/// under concurrent first callers, and a build failure leaves the cell empty
+/// (no poisoning) so a later call can retry.
+///
+/// Shape: fast-path `get()`, then take `lock` (serializing the slow path),
+/// re-check `get()` under the lock (a thread that lost the race returns the
+/// already-built value instead of building a second one), then build + `set`.
+fn get_or_try_init<T, F>(
+    cell: &'static OnceLock<T>,
+    lock: &'static Mutex<()>,
+    build: F,
+) -> Result<&'static T, std::io::Error>
+where
+    F: FnOnce() -> Result<T, std::io::Error>,
+{
+    // Fast path: already built and memoized.
+    if let Some(v) = cell.get() {
+        return Ok(v);
+    }
+
+    // Slow path: serialize construction so concurrent first callers do not each
+    // run a competing `build` (which, under the very resource pressure this
+    // change handles, could make one caller spuriously fail while another
+    // succeeds). Recover from a poisoned lock instead of panicking — the guard
+    // protects no data, so the lock is still usable.
+    let _guard = lock.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    // Re-check under the lock: another thread may have installed the value while
+    // we waited on the lock.
+    if let Some(v) = cell.get() {
+        return Ok(v);
+    }
+
+    // Build fallibly. A failed build leaves the cell empty (no poisoning), so a
+    // later call can retry once resources are available.
+    let v = build()?;
+    // We hold the lock and confirmed the cell was empty, so this always installs.
+    let _ = cell.set(v);
+    match cell.get() {
+        Some(v) => Ok(v),
+        // Unreachable: we just set the cell while holding the init lock. Surface
+        // a plain error rather than panic to keep this function total (no
+        // unwrap/expect in library code).
+        None => Err(std::io::Error::other(
+            "OnceLock unexpectedly empty after serialized initialization",
+        )),
+    }
 }
 
 /// Executes an async future on the global runtime, blocking until completion.
 ///
 /// This is the primary bridge between napi-rs sync tasks and async Rust operations.
 ///
-/// # Arguments
+/// # Errors
 ///
-/// * `future` - The async operation to execute
-///
-/// # Returns
-///
-/// The result of the future
-pub fn block_on<F: Future>(future: F) -> F::Output {
-    get_runtime().block_on(future)
+/// Returns the [`std::io::Error`] from [`try_get_runtime`] if the shared runtime
+/// could not be created. On the success path this is identical to the previous
+/// behavior: the runtime is built once and reused.
+pub fn block_on<F: Future>(future: F) -> Result<F::Output, std::io::Error> {
+    Ok(try_get_runtime()?.block_on(future))
 }
 
 #[cfg(test)]
@@ -63,15 +110,26 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_runtime_initializes_once() {
-        let rt1 = get_runtime();
-        let rt2 = get_runtime();
+    fn test_try_get_runtime_ok_and_memoized() {
+        // Success path returns a usable runtime and memoizes it: the second call
+        // yields the very same instance (issue #1438).
+        let rt1 = try_get_runtime().expect("runtime should build in tests");
+        let rt2 = try_get_runtime().expect("runtime should build in tests");
         assert!(std::ptr::eq(rt1, rt2));
     }
 
     #[test]
+    fn test_try_get_runtime_returns_result() {
+        // The contract that replaces the old panicking `.expect()`: init is
+        // fallible and returns a `Result`, so a resource-starved host surfaces a
+        // catchable error at the binding boundary instead of aborting the process.
+        let rt: Result<&'static Runtime, std::io::Error> = try_get_runtime();
+        assert!(rt.is_ok());
+    }
+
+    #[test]
     fn test_block_on_executes_async() {
-        let result = block_on(async { 42 });
+        let result = block_on(async { 42 }).expect("runtime available");
         assert_eq!(result, 42);
     }
 
@@ -81,7 +139,8 @@ mod tests {
             let a = 10;
             let b = 20;
             a + b
-        });
+        })
+        .expect("runtime available");
         assert_eq!(result, 30);
     }
 
@@ -92,7 +151,7 @@ mod tests {
         let handles: Vec<_> = (0..4)
             .map(|_| {
                 thread::spawn(|| {
-                    let rt = get_runtime();
+                    let rt = try_get_runtime().expect("runtime should build in tests");
                     std::ptr::addr_of!(*rt) as usize
                 })
             })
@@ -102,5 +161,51 @@ mod tests {
 
         // All threads should get the same runtime instance
         assert!(addresses.windows(2).all(|w| w[0] == w[1]));
+    }
+
+    #[test]
+    fn test_serialized_slow_path_builds_at_most_once() {
+        // Prove the fallible slow path retains `OnceLock::get_or_init`'s
+        // single-initializer guarantee: N threads all hit the cold cell together
+        // yet exactly ONE `build` runs, and every caller observes the SAME
+        // `&'static T` (pointer identity). This is the fix for issue #1438's
+        // Finding 1 — the earlier get()-then-build()?-then-set() shape could
+        // build a separate runtime per racing first caller.
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::{Arc, Barrier};
+        use std::thread;
+
+        static CELL: OnceLock<usize> = OnceLock::new();
+        static LOCK: Mutex<()> = Mutex::new(());
+        static BUILDS: AtomicUsize = AtomicUsize::new(0);
+
+        const N: usize = 8;
+        let barrier = Arc::new(Barrier::new(N));
+        let handles: Vec<_> = (0..N)
+            .map(|_| {
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    // Release all threads simultaneously so they contend on the
+                    // cold cell / init lock at once.
+                    barrier.wait();
+                    let v = get_or_try_init(&CELL, &LOCK, || {
+                        BUILDS.fetch_add(1, Ordering::SeqCst);
+                        Ok(0xC0FFEE_usize)
+                    })
+                    .expect("serialized init should succeed");
+                    std::ptr::addr_of!(*v) as usize
+                })
+            })
+            .collect();
+
+        let addresses: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+
+        // Exactly one build ran despite N concurrent first callers.
+        assert_eq!(BUILDS.load(Ordering::SeqCst), 1, "build must run exactly once");
+        // Every caller observed the same &'static value.
+        assert!(
+            addresses.windows(2).all(|w| w[0] == w[1]),
+            "all callers must observe the same instance"
+        );
     }
 }

--- a/bindings/node/src/streaming.rs
+++ b/bindings/node/src/streaming.rs
@@ -40,7 +40,7 @@ use napi::{Env, JsObject};
 use napi_derive::napi;
 
 use crate::database::ColumnInfo;
-use crate::error::to_napi_error;
+use crate::error::{runtime_init_error, to_napi_error};
 use crate::value::{intern_column_keys, row_to_object};
 
 /// Streaming query result iterator.
@@ -164,7 +164,8 @@ impl napi::Task for NextTask {
 
         // Get next row from core iterator using the global runtime. The fetch is
         // `.instrument`-ed by the stream span (no guard across the runtime).
-        let next = crate::runtime::block_on(iter.next_async().instrument(self.span.clone()));
+        let next = crate::runtime::block_on(iter.next_async().instrument(self.span.clone()))
+            .map_err(runtime_init_error)?;
         match next {
             Some(Ok(row)) => {
                 // Materialise the interned `Arc<str>` name handles into `String`

--- a/bindings/python/src/database.rs
+++ b/bindings/python/src/database.rs
@@ -34,7 +34,7 @@ use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 
 use crate::config::{config_from_py, StreamingConfig};
-use crate::error::to_py_err;
+use crate::error::{runtime_init_to_py_err, to_py_err};
 use crate::prepared::PreparedStatement;
 use crate::result::{QueryResult, StreamingIterator};
 use crate::runtime::block_on;
@@ -153,11 +153,14 @@ impl Database {
                 .map_err(|_| PyRuntimeError::new_err("Write engine lock poisoned during close"))?;
             // close() flushes remaining data. MutexGuard is not Send, so we
             // cannot release the GIL here. The flush on close is typically fast.
-            block_on(engine.inner.close()).map_err(to_py_err)?;
+            block_on(engine.inner.close())
+                .map_err(runtime_init_to_py_err)?
+                .map_err(to_py_err)?;
         }
 
         // Shutdown the read-side storage engine
         py.allow_threads(|| block_on(self.inner.shutdown()))
+            .map_err(runtime_init_to_py_err)?
             .map_err(to_py_err)?;
 
         // Flush buffered telemetry (issue #1039) so a short-lived script that
@@ -279,6 +282,7 @@ impl Database {
         // Release GIL during async execution to allow other Python threads to run
         let core_result = py
             .allow_threads(|| block_on(db.execute(&query_owned)))
+            .map_err(runtime_init_to_py_err)?
             .map_err(to_py_err)?;
 
         let result = QueryResult::from_core(py, core_result)?;
@@ -349,6 +353,7 @@ impl Database {
         // Release GIL during async execution
         let core_iter = py
             .allow_threads(|| block_on(db.execute_streaming(&query_owned, core_config)))
+            .map_err(runtime_init_to_py_err)?
             .map_err(to_py_err)?;
 
         Ok(StreamingIterator::with_span(core_iter, span.clone()))
@@ -478,6 +483,10 @@ impl Database {
 
                 Ok(writer.rows_written())
             })
+            // Fold a runtime-init failure into the same PyErr channel as the
+            // export body so the caller sees a catchable exception (issue #1438).
+            .map_err(runtime_init_to_py_err)
+            .and_then(|inner| inner)
         });
 
         result
@@ -515,6 +524,7 @@ impl Database {
 
         let prepared = py
             .allow_threads(|| block_on(db.prepare(&query_owned)))
+            .map_err(runtime_init_to_py_err)?
             .map_err(to_py_err)?;
 
         Ok(PreparedStatement::new(prepared))
@@ -546,6 +556,7 @@ impl Database {
 
         let core_stats = py
             .allow_threads(|| block_on(db.stats()))
+            .map_err(runtime_init_to_py_err)?
             .map_err(to_py_err)?;
 
         DatabaseStats::from_core(py, core_stats)
@@ -849,10 +860,12 @@ pub fn open(
                 Ok::<_, cqlite_core::Error>((result.database, Some(registry)))
             })
         })
+        .map_err(runtime_init_to_py_err)?
         .map_err(to_py_err)?
     } else {
         let db = py
             .allow_threads(|| block_on(cqlite_core::Database::open(&path, core_config)))
+            .map_err(runtime_init_to_py_err)?
             .map_err(to_py_err)?;
         (db, None)
     };
@@ -892,6 +905,7 @@ pub fn open(
                     })
                 })
             })
+            .map_err(runtime_init_to_py_err)?
             .map_err(to_py_err)?;
 
         let engine_config = cqlite_core::storage::write_engine::WriteEngineConfig::new(

--- a/bindings/python/src/error.rs
+++ b/bindings/python/src/error.rs
@@ -107,6 +107,17 @@ pub fn to_py_err(err: cqlite_core::Error) -> PyErr {
     }
 }
 
+/// Map a tokio runtime-initialization failure to a Python exception.
+///
+/// The shared async runtime is built lazily (see `runtime::try_get_runtime`).
+/// If the host is out of threads/file descriptors/memory the build fails with an
+/// [`std::io::Error`]; surfacing it here as a catchable Python exception (via the
+/// same `Io` → `IOError` mapping as any other I/O failure) lets `open()` raise
+/// instead of the process aborting under `panic = "abort"` (issue #1438).
+pub fn runtime_init_to_py_err(err: std::io::Error) -> PyErr {
+    to_py_err(cqlite_core::Error::Io(err))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -418,6 +429,21 @@ mod tests {
             let _py_err = to_py_err(err);
             // If we got here, the mapping didn't panic
         }
+    }
+
+    #[test]
+    fn test_runtime_init_error_maps_to_catchable_exception() {
+        // A runtime-init failure must surface as a catchable Python exception
+        // (IOError), never a process abort (issue #1438).
+        let io_err =
+            std::io::Error::other("cannot spawn worker threads: resource temporarily unavailable");
+        let py_err = runtime_init_to_py_err(io_err);
+
+        Python::with_gil(|py| {
+            assert!(py_err.is_instance_of::<PyIOError>(py));
+            let msg = get_error_message(py, py_err);
+            assert!(msg.contains("cannot spawn worker threads"));
+        });
     }
 
     #[test]

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -19,11 +19,13 @@ mod write;
 
 pub use config::{config_from_py, StreamingConfig};
 pub use database::{open, Database};
-pub use error::{to_py_err, CqliteError, ParseError, QueryError, SchemaError};
+pub use error::{
+    runtime_init_to_py_err, to_py_err, CqliteError, ParseError, QueryError, SchemaError,
+};
 pub use prepared::PreparedStatement;
 pub use refresh::RefreshReport;
 pub use result::{ColumnInfo, QueryResult, QueryResultIter, Row, StreamingIterator};
-pub use runtime::{block_on, get_runtime};
+pub use runtime::{block_on, try_get_runtime};
 pub use stats::DatabaseStats;
 pub use write::{MaintenanceReport, WriteStats};
 

--- a/bindings/python/src/refresh.rs
+++ b/bindings/python/src/refresh.rs
@@ -6,7 +6,7 @@
 use pyo3::prelude::*;
 
 use crate::database::Database;
-use crate::error::to_py_err;
+use crate::error::{runtime_init_to_py_err, to_py_err};
 use crate::runtime::block_on;
 
 /// Result returned by `Database.refresh()`.
@@ -127,6 +127,7 @@ impl Database {
         // Python threads keep running (same pattern as execute).
         let core_report = py
             .allow_threads(|| block_on(db.refresh()))
+            .map_err(runtime_init_to_py_err)?
             .map_err(to_py_err)?;
 
         Ok(RefreshReport::from_core(core_report))

--- a/bindings/python/src/result.rs
+++ b/bindings/python/src/result.rs
@@ -13,7 +13,7 @@ use pyo3::types::{PyDict, PyList, PyString};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-use crate::error::to_py_err;
+use crate::error::{runtime_init_to_py_err, to_py_err};
 use crate::runtime::block_on;
 use crate::value::{key_error, value_to_py};
 
@@ -709,7 +709,7 @@ impl StreamingIterator {
             .lock()
             .map_err(|_| pyo3::exceptions::PyRuntimeError::new_err("Iterator lock poisoned"))?;
 
-        let next_result = block_on(iter.next_async());
+        let next_result = block_on(iter.next_async()).map_err(runtime_init_to_py_err)?;
 
         match next_result {
             Some(Ok(row)) => {

--- a/bindings/python/src/runtime.rs
+++ b/bindings/python/src/runtime.rs
@@ -198,7 +198,11 @@ mod tests {
         let addresses: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
 
         // Exactly one build ran despite N concurrent first callers.
-        assert_eq!(BUILDS.load(Ordering::SeqCst), 1, "build must run exactly once");
+        assert_eq!(
+            BUILDS.load(Ordering::SeqCst),
+            1,
+            "build must run exactly once"
+        );
         // Every caller observed the same &'static value.
         assert!(
             addresses.windows(2).all(|w| w[0] == w[1]),

--- a/bindings/python/src/runtime.rs
+++ b/bindings/python/src/runtime.rs
@@ -4,56 +4,102 @@
 //! operations to synchronous Python calls.
 
 use std::future::Future;
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
 use tokio::runtime::Runtime;
 
 /// Global tokio runtime instance.
 static RUNTIME: OnceLock<Runtime> = OnceLock::new();
 
-/// Returns a reference to the global tokio runtime.
+/// Serializes the fallible slow-path build so at most one runtime is ever
+/// constructed, even under concurrent first use.
+static INIT_LOCK: Mutex<()> = Mutex::new(());
+
+/// Returns a reference to the global tokio runtime, building it on first use.
 ///
 /// The runtime is lazily initialized on first access using a multi-threaded
-/// executor with all features enabled.
+/// executor with all features enabled. On success the runtime is memoized in a
+/// process-global `OnceLock` and reused by every subsequent call.
 ///
-/// # Panics
+/// # Errors
 ///
-/// Panics if the runtime cannot be created (e.g., system resource exhaustion).
-/// This use of `expect()` is acceptable because:
-///
-/// 1. **Module initialization context**: Failure occurs once at module load time,
-///    not during normal operations
-/// 2. **Fatal condition**: Runtime creation only fails under extreme resource
-///    exhaustion (no memory, file descriptors, or thread capacity)
-/// 3. **No recovery path**: All CQLite Python operations require an async runtime;
-///    there is no meaningful fallback
-/// 4. **Clear error message**: Users see the panic message rather than silent
-///    failure or downstream errors
-///
-/// In Python, this manifests as an `ImportError` during `import cqlite`, which
-/// is the appropriate failure mode for an unrecoverable initialization error.
-pub fn get_runtime() -> &'static Runtime {
-    RUNTIME.get_or_init(|| {
+/// Returns the underlying [`std::io::Error`] if the runtime cannot be created
+/// (e.g., the host is out of threads, file descriptors, or memory). Unlike a
+/// panicking initializer, a failed build does **not** poison the cell: a later
+/// call can retry once resources are available, and the error is surfaced to the
+/// caller (mapped to a catchable Python exception at the binding boundary) rather
+/// than aborting the host process under `panic = "abort"`.
+pub fn try_get_runtime() -> Result<&'static Runtime, std::io::Error> {
+    get_or_try_init(&RUNTIME, &INIT_LOCK, || {
         tokio::runtime::Builder::new_multi_thread()
             .thread_name("cqlite-py-worker")
             .enable_all()
             .build()
-            .expect("Failed to create tokio runtime - system may be out of resources")
     })
+}
+
+/// Serialized get-or-build for a process-global [`OnceLock`].
+///
+/// Preserves `OnceLock::get_or_init`'s single-initializer guarantee while
+/// allowing the initializer to be fallible: at most one `build` ever runs, even
+/// under concurrent first callers, and a build failure leaves the cell empty
+/// (no poisoning) so a later call can retry.
+///
+/// Shape: fast-path `get()`, then take `lock` (serializing the slow path),
+/// re-check `get()` under the lock (a thread that lost the race returns the
+/// already-built value instead of building a second one), then build + `set`.
+fn get_or_try_init<T, F>(
+    cell: &'static OnceLock<T>,
+    lock: &'static Mutex<()>,
+    build: F,
+) -> Result<&'static T, std::io::Error>
+where
+    F: FnOnce() -> Result<T, std::io::Error>,
+{
+    // Fast path: already built and memoized.
+    if let Some(v) = cell.get() {
+        return Ok(v);
+    }
+
+    // Slow path: serialize construction so concurrent first callers do not each
+    // run a competing `build` (which, under the very resource pressure this
+    // change handles, could make one caller spuriously fail while another
+    // succeeds). Recover from a poisoned lock instead of panicking — the guard
+    // protects no data, so the lock is still usable.
+    let _guard = lock.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    // Re-check under the lock: another thread may have installed the value while
+    // we waited on the lock.
+    if let Some(v) = cell.get() {
+        return Ok(v);
+    }
+
+    // Build fallibly. A failed build leaves the cell empty (no poisoning), so a
+    // later call can retry once resources are available.
+    let v = build()?;
+    // We hold the lock and confirmed the cell was empty, so this always installs.
+    let _ = cell.set(v);
+    match cell.get() {
+        Some(v) => Ok(v),
+        // Unreachable: we just set the cell while holding the init lock. Surface
+        // a plain error rather than panic to keep this function total (no
+        // unwrap/expect in library code).
+        None => Err(std::io::Error::other(
+            "OnceLock unexpectedly empty after serialized initialization",
+        )),
+    }
 }
 
 /// Executes an async future on the global runtime, blocking until completion.
 ///
 /// This is the primary bridge between sync Python calls and async Rust operations.
 ///
-/// # Arguments
+/// # Errors
 ///
-/// * `future` - The async operation to execute
-///
-/// # Returns
-///
-/// The result of the future
-pub fn block_on<F: Future>(future: F) -> F::Output {
-    get_runtime().block_on(future)
+/// Returns the [`std::io::Error`] from [`try_get_runtime`] if the shared runtime
+/// could not be created. On the success path this is identical to the previous
+/// behavior: the runtime is built once and reused.
+pub fn block_on<F: Future>(future: F) -> Result<F::Output, std::io::Error> {
+    Ok(try_get_runtime()?.block_on(future))
 }
 
 #[cfg(test)]
@@ -61,15 +107,26 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_runtime_initializes_once() {
-        let rt1 = get_runtime();
-        let rt2 = get_runtime();
+    fn test_try_get_runtime_ok_and_memoized() {
+        // Success path returns a usable runtime and memoizes it: the second call
+        // yields the very same instance (issue #1438).
+        let rt1 = try_get_runtime().expect("runtime should build in tests");
+        let rt2 = try_get_runtime().expect("runtime should build in tests");
         assert!(std::ptr::eq(rt1, rt2));
     }
 
     #[test]
+    fn test_try_get_runtime_returns_result() {
+        // The contract that replaces the old panicking `.expect()`: init is
+        // fallible and returns a `Result`, so a resource-starved host surfaces a
+        // catchable error at the binding boundary instead of aborting the process.
+        let rt: Result<&'static Runtime, std::io::Error> = try_get_runtime();
+        assert!(rt.is_ok());
+    }
+
+    #[test]
     fn test_block_on_executes_async() {
-        let result = block_on(async { 42 });
+        let result = block_on(async { 42 }).expect("runtime available");
         assert_eq!(result, 42);
     }
 
@@ -79,7 +136,8 @@ mod tests {
             let a = 10;
             let b = 20;
             a + b
-        });
+        })
+        .expect("runtime available");
         assert_eq!(result, 30);
     }
 
@@ -90,7 +148,7 @@ mod tests {
         let handles: Vec<_> = (0..4)
             .map(|_| {
                 thread::spawn(|| {
-                    let rt = get_runtime();
+                    let rt = try_get_runtime().expect("runtime should build in tests");
                     std::ptr::addr_of!(*rt) as usize
                 })
             })
@@ -100,5 +158,51 @@ mod tests {
 
         // All threads should get the same runtime instance
         assert!(addresses.windows(2).all(|w| w[0] == w[1]));
+    }
+
+    #[test]
+    fn test_serialized_slow_path_builds_at_most_once() {
+        // Prove the fallible slow path retains `OnceLock::get_or_init`'s
+        // single-initializer guarantee: N threads all hit the cold cell together
+        // yet exactly ONE `build` runs, and every caller observes the SAME
+        // `&'static T` (pointer identity). This is the fix for issue #1438's
+        // Finding 1 — the earlier get()-then-build()?-then-set() shape could
+        // build a separate runtime per racing first caller.
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::{Arc, Barrier};
+        use std::thread;
+
+        static CELL: OnceLock<usize> = OnceLock::new();
+        static LOCK: Mutex<()> = Mutex::new(());
+        static BUILDS: AtomicUsize = AtomicUsize::new(0);
+
+        const N: usize = 8;
+        let barrier = Arc::new(Barrier::new(N));
+        let handles: Vec<_> = (0..N)
+            .map(|_| {
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    // Release all threads simultaneously so they contend on the
+                    // cold cell / init lock at once.
+                    barrier.wait();
+                    let v = get_or_try_init(&CELL, &LOCK, || {
+                        BUILDS.fetch_add(1, Ordering::SeqCst);
+                        Ok(0xC0FFEE_usize)
+                    })
+                    .expect("serialized init should succeed");
+                    std::ptr::addr_of!(*v) as usize
+                })
+            })
+            .collect();
+
+        let addresses: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+
+        // Exactly one build ran despite N concurrent first callers.
+        assert_eq!(BUILDS.load(Ordering::SeqCst), 1, "build must run exactly once");
+        // Every caller observed the same &'static value.
+        assert!(
+            addresses.windows(2).all(|w| w[0] == w[1]),
+            "all callers must observe the same instance"
+        );
     }
 }

--- a/bindings/python/src/write.rs
+++ b/bindings/python/src/write.rs
@@ -194,7 +194,9 @@ impl PyWriteEngine {
     /// Returns the Data.db path, or an empty string if the memtable was empty.
     pub fn flush(&mut self) -> cqlite_core::error::Result<String> {
         use crate::runtime::block_on;
-        let info = block_on(self.inner.flush())?;
+        // Outer `?` converts a runtime-init `io::Error` via `Error::Io` (#[from]);
+        // inner `?` propagates the flush error (issue #1438).
+        let info = block_on(self.inner.flush())??;
         Ok(info
             .map(|i| i.data_path.to_string_lossy().into_owned())
             .unwrap_or_default())


### PR DESCRIPTION
Closes #1438.

## What changed
Both bindings built the shared tokio runtime lazily with `.expect()` on `Builder::build()`. Under the release `panic="abort"` profile that panic aborts the host process instead of raising a catchable exception. This makes runtime init fallible and surfaces the failure at the binding boundary.

### `runtime.rs` (both crates)
- Replaced panicking `get_runtime()` with `try_get_runtime() -> Result<&'static Runtime, std::io::Error>`. No reachable `expect()` on `Builder::build()`. A failed build does **not** poison the cell — a later call can retry.
- The fallible slow path is serialized by a dedicated `INIT_LOCK: Mutex<()>` with a re-check under the lock, so concurrent first callers build at most one runtime and none spuriously fails while another succeeds (roborev round 1). Poisoned-lock recovery via `into_inner()` (no panic).
- `block_on<F>` now returns `Result<F::Output, std::io::Error>`.

### Python boundary
- `error.rs`: new `runtime_init_to_py_err(std::io::Error) -> PyErr` (maps via `Error::Io` → catchable `IOError`).
- All `block_on` sites in `database.rs`, `result.rs`, `refresh.rs`, `write.rs` propagate the init error. `open()` funnels through `block_on`, so it already surfaces the failure at open() time.

### Node boundary
- `error.rs`: new `runtime_init_error(std::io::Error) -> napi::Error` (maps via `Error::Io` → System/IO).
- `database.rs`, `streaming.rs` `block_on` sites propagate the init error.
- `Database.open()` (a napi `async fn` that runs on napi's own executor and would otherwise never touch the binding runtime) now eagerly calls `try_get_runtime().map_err(runtime_init_error)?` before returning the handle, so a resource-starved host fails at open() rather than on the first executeNative()/flush()/stream call (roborev round 2).

## Tests
- Rust unit tests in each `runtime.rs`: `try_get_runtime` returns `Result` + memoizes; concurrent multi-thread access converges on one instance; `block_on` returns `Result`.
- Error-mapping unit tests in each `error.rs`: a synthetic runtime-init `io::Error` maps to a catchable `IOError`/`napi::Error` (not a panic). (A real `Builder::build()` failure is not cleanly injectable — tokio panics on `worker_threads(0)` at the setter — so the mapping is asserted directly.)

## Verification
- Node: `npm run build` (release-unwind) OK; `jest -t runtime` + `database.test.js` (23 tests) pass; module loads and `open()` success path works. Rebased on latest main (after #1460) and re-verified.
- All binding source compiles (`cargo build -p cqlite-node` clean; `cqlite-py` compiles — the final extension link needs maturin's `-undefined dynamic_lookup`, not plain `cargo build`).
- Python: maturin not installed locally + host python is 3.14; the full pytest run is left to CI. Machine load was ~44 during work, so `scripts/agent-gate.sh` was intentionally not run locally (OOM risk). **CI is the gate.**
- roborev (codex, branch): clean — "No issues found" after 2 fix rounds.

## Scope
Only the runtime-init `expect()` sites. Does NOT touch the write-path `ensure_writable`/`expect(Some)` sites (#1439) or the panic profile (#1440).