### PR TITLE
fix(#1620): route Node/Python binding writes through real async flush; rate-limit over-threshold warn (N2)

### DIFF
--- a/bindings/node/__test__/auto-flush-cliff.test.js
+++ b/bindings/node/__test__/auto-flush-cliff.test.js
@@ -1,0 +1,153 @@
+/**
+ * Auto-flush cliff wiring evidence (Issue #1620, N2).
+ *
+ * The Node binding routes DML through the write engine inside a `spawn_blocking`
+ * where a Tokio runtime handle IS present. On main the engine's sync auto-flush
+ * is intentionally skipped in that topology, so the memtable grew unbounded and
+ * NO SSTable was ever written until an explicit `flushRun()`. This test proves
+ * the fix end-to-end: with a tiny `flushThreshold`, a loop of `db.execute(...)`
+ * inserts triggers a REAL async flush on its own — with NO explicit flushRun —
+ * and on-disk `*-Data.db` generation files appear.
+ *
+ * Named-public-surface → call-chain → e2e evidence:
+ *   { flushThreshold } open option  →  Database.execute (DML)
+ *     →  WriteEngine::execute_flushing (async flush)  →  *-Data.db on disk
+ *
+ * On main this test is red: 0 Data.db files (auto-flush never fires).
+ *
+ * Generates its own SSTables in a tmp dir; no fixture-corpus dependency.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { Database } = require('../lib/index.js');
+
+const SCHEMA_TEXT = `
+CREATE KEYSPACE IF NOT EXISTS flush_test
+  WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};
+
+USE flush_test;
+
+CREATE TABLE IF NOT EXISTS items (
+    id    INT PRIMARY KEY,
+    name  TEXT,
+    value INT
+);
+`;
+
+function setup() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cqlite-autoflush-'));
+  const schema = path.join(dir, 'schema.cql');
+  fs.writeFileSync(schema, SCHEMA_TEXT);
+  const dataDir = path.join(dir, 'data_dir');
+  fs.mkdirSync(dataDir);
+  const writeDir = path.join(dir, 'write_dir');
+  return {
+    dir,
+    schema,
+    dataDir,
+    writeDir,
+    cleanup() {
+      try {
+        fs.rmSync(dir, { recursive: true, force: true });
+      } catch (_) {
+        /* ignore */
+      }
+    },
+  };
+}
+
+/** Recursively count `*-Data.db` files anywhere under `dir`. */
+function countDataDbUnder(dir) {
+  if (!fs.existsSync(dir)) return 0;
+  let count = 0;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      count += countDataDbUnder(full);
+    } else if (entry.name.endsWith('-Data.db')) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+/**
+ * Count `*-Data.db` files under the write dir's `data/` directory, recursively.
+ * Flushed SSTables land under data/<keyspace>/<table>/nb-*-big-Data.db, so a
+ * flat readdir of `data/` would miss them (issue #1620).
+ */
+function countDataDbFiles(writeDir) {
+  return countDataDbUnder(path.join(writeDir, 'data'));
+}
+
+describe('Auto-flush cliff wiring (Issue #1620)', () => {
+  test('tiny flushThreshold triggers a real flush during execute() (no manual flush)', async () => {
+    const env = setup();
+    try {
+      const db = await Database.open(env.dataDir, {
+        schema: env.schema,
+        writable: true,
+        writeDir: env.writeDir,
+        flushThreshold: 4096, // 4 KB — crossed after a handful of inserts
+      });
+
+      const TOTAL = 2000;
+      for (let i = 0; i < TOTAL; i++) {
+        const res = await db.execute(
+          `INSERT INTO flush_test.items (id, name, value) VALUES (${i}, 'user${i}', ${i})`
+        );
+        expect(res.rowsAffected).toBe(1);
+      }
+
+      // A real auto-flush must have fired: on-disk generation files exist.
+      // On main this is 0 because the runtime-present sync path never flushes.
+      const dataDbCount = countDataDbFiles(env.writeDir);
+      expect(dataDbCount).toBeGreaterThanOrEqual(1);
+
+      // The memtable was cleared by the flush(es), so its residual row count is
+      // far below the total inserted. `writeStats` is a synchronous getter.
+      const stats = db.writeStats;
+      expect(Number(stats.memtableRows)).toBeLessThan(TOTAL);
+
+      await db.close();
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test('flushThreshold below 1 byte is rejected', async () => {
+    const env = setup();
+    try {
+      await expect(
+        Database.open(env.dataDir, {
+          schema: env.schema,
+          writable: true,
+          writeDir: env.writeDir,
+          flushThreshold: 0,
+        })
+      ).rejects.toThrow(/flushThreshold/);
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test('flushThreshold above the memtable hard limit is rejected', async () => {
+    // A threshold above the 256 MB hard limit would never trigger an auto-flush
+    // (writes dead-end at the hard limit first) — issue #1620.
+    const env = setup();
+    try {
+      await expect(
+        Database.open(env.dataDir, {
+          schema: env.schema,
+          writable: true,
+          writeDir: env.writeDir,
+          flushThreshold: 300 * 1024 * 1024, // 300 MB > 256 MB hard limit
+        })
+      ).rejects.toThrow(/hard limit/);
+    } finally {
+      env.cleanup();
+    }
+  });
+});

--- a/bindings/node/lib/index.d.ts
+++ b/bindings/node/lib/index.d.ts
@@ -383,6 +383,14 @@ export interface DatabaseOptions {
   autoCompaction?: boolean;
 
   /**
+   * Memtable flush threshold in bytes for the write engine (issue #1620).
+   * When the in-memory memtable grows past this size, the write path
+   * (`execute`) awaits a real async flush to a new SSTable generation.
+   * Only meaningful when `writable` is true. Default: 64 MB (67108864 bytes).
+   */
+  flushThreshold?: number;
+
+  /**
    * OpenTelemetry export options (epic #1031, issue #1040).
    *
    * When omitted, the `CQLITE_OTEL_*` environment variables are consulted.

--- a/bindings/node/src/database.rs
+++ b/bindings/node/src/database.rs
@@ -185,6 +185,14 @@ pub struct DatabaseOptions {
     #[napi(js_name = "autoCompaction")]
     pub auto_compaction: Option<bool>,
 
+    /// Memtable flush threshold in bytes for the write engine (issue #1620).
+    /// When the in-memory memtable grows past this size, the binding write path
+    /// (`execute`) awaits a real async flush to a new SSTable generation.
+    /// Only meaningful when `writable` is true. Default: 64 MB (67108864 bytes).
+    /// JavaScript numbers safely represent up to 2^53 bytes.
+    #[napi(js_name = "flushThreshold")]
+    pub flush_threshold: Option<f64>,
+
     /// OpenTelemetry export options (epic #1031, issue #1040).
     ///
     /// When omitted, the `CQLITE_OTEL_*` environment variables are consulted;
@@ -378,12 +386,6 @@ pub struct Database {
     /// Wrapped in Arc so it can be shared with async tasks.
     #[cfg(feature = "write-support")]
     write_engine: Option<Arc<Mutex<cqlite_core::storage::write_engine::WriteEngine>>>,
-    /// Track total bytes written across all flushes (for writeStats.totalWritten).
-    #[cfg(feature = "write-support")]
-    total_written_bytes: Arc<Mutex<u64>>,
-    /// Track how many L0 SSTable files have been flushed.
-    #[cfg(feature = "write-support")]
-    l0_count: Arc<Mutex<u32>>,
 }
 
 impl Database {
@@ -466,7 +468,9 @@ impl Database {
             .filter(|t| !t.trim().is_empty());
 
         // Extract all options and build config
-        let (schema_path, core_config, writable, write_dir) = if let Some(opts) = options {
+        let (schema_path, core_config, writable, write_dir, flush_threshold) = if let Some(opts) =
+            options
+        {
             let mut config = cqlite_core::Config::default();
 
             if let Some(limit) = opts.memory_limit {
@@ -496,9 +500,54 @@ impl Database {
             let writable = opts.writable.unwrap_or(false);
             let write_dir = opts.write_dir.map(PathBuf::from);
 
-            (opts.schema.map(PathBuf::from), config, writable, write_dir)
+            // Validate the optional flush threshold (issue #1620). Bytes as an
+            // f64 (napi-idiomatic; matches `memoryLimit`). Must be finite, at
+            // least 1 byte, and no greater than the memtable hard limit;
+            // converted to `usize` at config-build time.
+            let flush_threshold = match opts.flush_threshold {
+                Some(v) => {
+                    if !v.is_finite() {
+                        return Err(napi::Error::from_reason(
+                            "flushThreshold must be a finite number",
+                        ));
+                    }
+                    if v < 1.0 {
+                        return Err(napi::Error::from_reason(
+                            "flushThreshold must be at least 1 byte",
+                        ));
+                    }
+                    // A threshold above the hard limit would never trigger an
+                    // auto-flush: the memtable hits the hard limit and rejects
+                    // writes first, dead-ending the binding write path
+                    // (roborev jobs 2885/2890, issue #1620). Gated on
+                    // `write-support`, matching every other `write_engine`
+                    // reference in this file — `WriteEngineConfig` is
+                    // `#[cfg(feature = "write-support")]` in core, and the
+                    // threshold is only meaningful when the write engine exists.
+                    #[cfg(feature = "write-support")]
+                    {
+                        let hard_limit =
+                            cqlite_core::storage::write_engine::WriteEngineConfig::DEFAULT_HARD_LIMIT;
+                        if v > hard_limit as f64 {
+                            return Err(napi::Error::from_reason(format!(
+                                "flushThreshold ({v} bytes) must not exceed the memtable hard limit ({hard_limit} bytes)"
+                            )));
+                        }
+                    }
+                    Some(v)
+                }
+                None => None,
+            };
+
+            (
+                opts.schema.map(PathBuf::from),
+                config,
+                writable,
+                write_dir,
+                flush_threshold,
+            )
         } else {
-            (None, cqlite_core::Config::default(), false, None)
+            (None, cqlite_core::Config::default(), false, None, None)
         };
 
         // Clone schema path before it is potentially consumed by db open, so the
@@ -660,12 +709,18 @@ impl Database {
                 ));
             };
 
-            let config = cqlite_core::storage::write_engine::WriteEngineConfig::new(
+            let mut config = cqlite_core::storage::write_engine::WriteEngineConfig::new(
                 wd.join("data"),
                 wd.join("wal"),
                 schema,
             )
             .with_compaction_config(&compaction_config);
+
+            // Apply the optional flush threshold (issue #1620); default is the
+            // engine's 64 MB when not provided.
+            if let Some(v) = flush_threshold {
+                config = config.with_flush_threshold(v as usize);
+            }
 
             let engine = cqlite_core::storage::write_engine::WriteEngine::new(config)
                 .map_err(to_napi_error)?;
@@ -675,7 +730,7 @@ impl Database {
         };
 
         #[cfg(not(feature = "write-support"))]
-        let _ = (writable, write_dir); // suppress unused warning when feature off
+        let _ = (writable, write_dir, flush_threshold); // suppress unused warning when feature off
 
         Ok(Database {
             inner: Arc::new(db),
@@ -683,10 +738,6 @@ impl Database {
             traceparent,
             #[cfg(feature = "write-support")]
             write_engine: write_engine_opt,
-            #[cfg(feature = "write-support")]
-            total_written_bytes: Arc::new(Mutex::new(0)),
-            #[cfg(feature = "write-support")]
-            l0_count: Arc::new(Mutex::new(0)),
         })
     }
 
@@ -733,13 +784,19 @@ impl Database {
                         .as_ref()
                         .expect("ensure_writable verified write_engine is Some"),
                 );
-                let elapsed_ms = tokio::task::spawn_blocking(move || {
+                let (elapsed_ms, applied) = tokio::task::spawn_blocking(move || {
                     let start = std::time::Instant::now();
                     let mut engine = we_clone
                         .lock()
                         .map_err(|_| simple_error("Write engine lock poisoned"))?;
-                    engine.execute(&query).map_err(to_napi_error)?;
-                    Ok::<u32, napi::Error>(start.elapsed().as_millis() as u32)
+                    // Drive the async-flushing write path to completion while the
+                    // engine Mutex is held (issue #1620). This restores auto-flush
+                    // in the runtime-present binding topology; the plain sync
+                    // `execute()` skips it and would grow the memtable to the hard
+                    // limit. Returns the number of mutations applied.
+                    let n = crate::runtime::block_on(engine.execute_flushing(&query))
+                        .map_err(to_napi_error)?;
+                    Ok::<(u32, u64), napi::Error>((start.elapsed().as_millis() as u32, n))
                 })
                 .await
                 .map_err(|e| simple_error(format!("execute DML task panicked: {e}")))??;
@@ -747,7 +804,7 @@ impl Database {
                 return Ok(QueryResult {
                     rows: vec![],
                     row_count: 0,
-                    rows_affected: 1,
+                    rows_affected: applied as u32,
                     execution_time_ms: elapsed_ms,
                     columns: vec![],
                 });
@@ -1119,8 +1176,6 @@ impl Database {
             // We hold the Mutex lock and block_on inside a spawn_blocking to avoid
             // blocking the napi async executor thread.
             let we_clone = Arc::clone(we);
-            let total_written_clone = Arc::clone(&self.total_written_bytes);
-            let l0_clone = Arc::clone(&self.l0_count);
 
             let result = tokio::task::spawn_blocking(move || {
                 let mut engine = we_clone
@@ -1131,17 +1186,11 @@ impl Database {
             .await
             .map_err(|e| simple_error(format!("flush_run task panicked: {e}")))??;
 
+            // Flush statistics (l0Count, totalWritten) are read straight from the
+            // engine's own counters in `writeStats` (issue #1620), so there are no
+            // Node-side counters to update here.
             match result {
-                Some(info) => {
-                    // Track flush statistics
-                    if let Ok(mut tw) = total_written_clone.lock() {
-                        *tw += info.data_size;
-                    }
-                    if let Ok(mut l0) = l0_clone.lock() {
-                        *l0 += 1;
-                    }
-                    Ok(info.data_path.to_string_lossy().into_owned())
-                }
+                Some(info) => Ok(info.data_path.to_string_lossy().into_owned()),
                 None => Ok(String::new()),
             }
         }
@@ -1254,15 +1303,17 @@ impl Database {
                 .lock()
                 .map_err(|_| simple_error("Write engine lock poisoned"))?;
 
-            let total_written = self.total_written_bytes.lock().map(|g| *g).unwrap_or(0);
-            let l0_count = self.l0_count.lock().map(|g| *g).unwrap_or(0);
-
+            // Read L0 count and cumulative flushed bytes from the engine's own
+            // authoritative counters (issue #1620). The engine increments these
+            // on EVERY flush — including the automatic flushes the `execute()`
+            // path now performs via `execute_flushing` — so the stats stay
+            // accurate for auto-flushes, not just explicit `flushRun()` calls.
             Ok(WriteStats {
                 memtable_size: engine.memtable_size() as f64,
                 memtable_rows: engine.memtable_row_count() as u32,
                 wal_size: engine.wal_size() as f64,
-                l0_count,
-                total_written: total_written as f64,
+                l0_count: engine.l0_count() as u32,
+                total_written: engine.total_flushed_bytes() as f64,
             })
         }
 

--- a/bindings/python/python/cqlite/__init__.pyi
+++ b/bindings/python/python/cqlite/__init__.pyi
@@ -388,6 +388,7 @@ def open(
     config: Config | None = None,
     writable: bool = False,
     write_dir: str | Path | None = None,
+    flush_threshold: int | None = None,
     otel_config: dict[str, object] | None = None,
     traceparent: str | None = None,
 ) -> Database:
@@ -403,6 +404,11 @@ def open(
                   When ``True``, both ``schema`` and ``write_dir`` must be provided.
         write_dir: Directory for WAL files and flushed SSTables.
                    Required when ``writable=True``; created automatically.
+        flush_threshold: Memtable flush threshold in bytes for the write engine
+                   (issue #1620).  When the in-memory memtable grows past this
+                   size, ``execute`` awaits a real async flush to a new SSTable
+                   generation.  Only meaningful when ``writable=True``.
+                   Default: 64 MB (67108864 bytes).
 
                    **Caveat**: Only one ``Database`` instance should hold a given
                    ``write_dir`` at a time.  Concurrent instances sharing the same

--- a/bindings/python/src/database.rs
+++ b/bindings/python/src/database.rs
@@ -704,16 +704,24 @@ impl Database {
             .as_ref()
             .expect("require_writable() guarantees write_engine is Some");
 
-        let mut engine = engine_mutex
-            .lock()
-            .map_err(|_| PyRuntimeError::new_err("Write engine lock poisoned"))?;
-
         let query_owned = query.to_string();
         let t0 = Instant::now();
 
-        // MutexGuard is not Send so we cannot release the GIL here.
-        // execute() is a fast synchronous in-memory operation (WAL write + memtable insert).
-        let rows_affected = engine.execute(&query_owned).map_err(to_py_err)?;
+        // Release the GIL for the write (issue #1620). `execute()` now routes
+        // through `WriteEngine::execute_flushing`, which performs a REAL async
+        // SSTable flush (disk I/O) when the memtable crosses the flush threshold
+        // — so holding the GIL for its duration would block every other Python
+        // thread. The `MutexGuard` is created and dropped entirely inside the
+        // closure, so it never crosses the GIL boundary; the closure captures
+        // only `Send` values (`&Mutex<PyWriteEngine>` + `String`).
+        let rows_affected = py
+            .allow_threads(|| {
+                let mut engine = engine_mutex.lock().map_err(|_| {
+                    cqlite_core::error::Error::Storage("Write engine lock poisoned".to_string())
+                })?;
+                engine.execute(&query_owned)
+            })
+            .map_err(to_py_err)?;
 
         let elapsed_ms = t0.elapsed().as_millis() as u64;
 
@@ -779,7 +787,7 @@ impl Database {
 ///     pass
 /// ```
 #[pyfunction]
-#[pyo3(signature = (path, *, schema=None, config=None, writable=false, write_dir=None, otel_config=None, traceparent=None))]
+#[pyo3(signature = (path, *, schema=None, config=None, writable=false, write_dir=None, flush_threshold=None, otel_config=None, traceparent=None))]
 pub fn open(
     py: Python<'_>,
     path: PathBuf,
@@ -787,6 +795,7 @@ pub fn open(
     config: Option<&Bound<'_, PyAny>>,
     writable: bool,
     write_dir: Option<PathBuf>,
+    flush_threshold: Option<u64>,
     otel_config: Option<&Bound<'_, PyAny>>,
     traceparent: Option<String>,
 ) -> PyResult<Database> {
@@ -797,6 +806,27 @@ pub fn open(
     // simply yields no telemetry.
     let obs_cfg = crate::observability::config_from_py(py, otel_config)?;
     crate::observability::ensure_initialized(obs_cfg);
+
+    // Validate the optional flush threshold upfront (issue #1620), regardless of
+    // `writable`, so Python matches the Node binding's validation. A `0` threshold
+    // would make `should_flush(0)` true after every write (pathological
+    // flush-per-write); a threshold above the memtable hard limit would never
+    // trigger an auto-flush (the memtable hits the hard limit and rejects writes
+    // first, dead-ending the write path — roborev job 2885).
+    if let Some(v) = flush_threshold {
+        if v < 1 {
+            return Err(PyValueError::new_err(
+                "flush_threshold must be at least 1 byte",
+            ));
+        }
+        let hard_limit =
+            cqlite_core::storage::write_engine::WriteEngineConfig::DEFAULT_HARD_LIMIT as u64;
+        if v > hard_limit {
+            return Err(PyValueError::new_err(format!(
+                "flush_threshold ({v} bytes) must not exceed the memtable hard limit ({hard_limit} bytes)"
+            )));
+        }
+    }
 
     // Validate writable-mode requirements upfront before any I/O.
     if writable {
@@ -894,12 +924,18 @@ pub fn open(
             })
             .map_err(to_py_err)?;
 
-        let engine_config = cqlite_core::storage::write_engine::WriteEngineConfig::new(
+        let mut engine_config = cqlite_core::storage::write_engine::WriteEngineConfig::new(
             wd.join("data"),
             wd.join("wal"),
             table_schema,
         )
         .with_compaction_config(&compaction_config);
+
+        // Apply the optional flush threshold in bytes (issue #1620); the engine
+        // default (64 MB) is used when not provided.
+        if let Some(v) = flush_threshold {
+            engine_config = engine_config.with_flush_threshold(v as usize);
+        }
 
         let engine = cqlite_core::storage::write_engine::WriteEngine::new(engine_config)
             .map_err(to_py_err)?;
@@ -907,7 +943,12 @@ pub fn open(
         Some(Mutex::new(PyWriteEngine::new(engine)))
     } else {
         // Silence unused-variable warning
-        let _ = (write_dir, schema_registry_opt, compaction_config);
+        let _ = (
+            write_dir,
+            schema_registry_opt,
+            compaction_config,
+            flush_threshold,
+        );
         None
     };
 

--- a/bindings/python/src/write.rs
+++ b/bindings/python/src/write.rs
@@ -184,9 +184,15 @@ impl PyWriteEngine {
     /// Execute a DML CQL statement (INSERT / UPDATE / DELETE / BEGIN BATCH).
     ///
     /// Returns the number of mutations applied (typically 1, or N for BATCH).
+    ///
+    /// Routes through the async-flushing write path (issue #1620): the Python
+    /// binding runs inside a Tokio runtime where the sync `execute()` auto-flush
+    /// is intentionally skipped, so it would otherwise grow the memtable to the
+    /// hard limit. `execute_flushing` awaits a real async flush once the flush
+    /// threshold is crossed.
     pub fn execute(&mut self, statement: &str) -> cqlite_core::error::Result<u64> {
-        self.inner.execute(statement)?;
-        Ok(1)
+        use crate::runtime::block_on;
+        block_on(self.inner.execute_flushing(statement))
     }
 
     /// Flush the memtable to a new SSTable generation.

--- a/bindings/python/tests/test_auto_flush_cliff.py
+++ b/bindings/python/tests/test_auto_flush_cliff.py
@@ -1,0 +1,111 @@
+"""Auto-flush cliff wiring evidence (Issue #1620, N2).
+
+The Python binding routes DML through the write engine inside a Tokio runtime
+(``block_on``), where the engine's sync auto-flush is intentionally skipped. On
+main that meant the memtable grew unbounded and NO SSTable was written until an
+explicit ``flush_run()``. This test proves the fix end-to-end: with a tiny
+``flush_threshold`` open option, a loop of ``db.execute(...)`` inserts triggers a
+REAL async flush on its own — with NO explicit ``flush_run`` — so on-disk
+``*-Data.db`` generation files appear.
+
+Named-public-surface → call-chain → e2e evidence:
+    flush_threshold open kwarg  →  Database.execute (DML)
+        →  PyWriteEngine.execute → WriteEngine::execute_flushing (async flush)
+        →  *-Data.db on disk
+
+On main this test is red: 0 Data.db files (auto-flush never fires).
+
+Generates its own SSTables in a tmp dir; no fixture-corpus dependency.
+"""
+
+from pathlib import Path
+
+import pytest
+
+import cqlite
+
+SCHEMA_TEXT = """\
+CREATE KEYSPACE IF NOT EXISTS flush_test
+  WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};
+
+USE flush_test;
+
+CREATE TABLE IF NOT EXISTS items (
+    id    INT PRIMARY KEY,
+    name  TEXT,
+    value INT
+);
+"""
+
+
+@pytest.fixture()
+def schema_file(tmp_path):
+    path = tmp_path / "schema.cql"
+    path.write_text(SCHEMA_TEXT)
+    return path
+
+
+def _count_data_db(write_dir):
+    # Flushed SSTables land under data/<keyspace>/<table>/nb-*-big-Data.db, so
+    # recurse rather than globbing the top level (issue #1620).
+    data_path = Path(write_dir) / "data"
+    if not data_path.exists():
+        return 0
+    return len(list(data_path.rglob("*-Data.db")))
+
+
+def test_tiny_flush_threshold_auto_flushes_during_execute(tmp_path, schema_file):
+    data_dir = tmp_path / "data_dir"
+    data_dir.mkdir(exist_ok=True)
+    write_dir = tmp_path / "write_dir"
+
+    db = cqlite.open(
+        str(data_dir),
+        schema=str(schema_file),
+        writable=True,
+        write_dir=str(write_dir),
+        flush_threshold=4096,  # 4 KB — crossed after a handful of inserts
+    )
+    try:
+        total = 2000
+        for i in range(total):
+            result = db.execute(
+                f"INSERT INTO flush_test.items (id, name, value) "
+                f"VALUES ({i}, 'user{i}', {i})"
+            )
+            assert result.rows_affected == 1
+
+        # A real auto-flush must have fired: on-disk generation files exist.
+        # On main this is 0 because the runtime-present sync path never flushes.
+        assert _count_data_db(write_dir) >= 1
+
+        # The memtable was cleared by the flush(es), so its residual row count is
+        # far below the total inserted.
+        assert db.write_stats.memtable_rows < total
+    finally:
+        db.close()
+
+
+def test_flush_threshold_zero_rejected(tmp_path, schema_file):
+    # 0 would make should_flush(0) true after every write (flush-per-write).
+    with pytest.raises(ValueError):
+        cqlite.open(
+            str(tmp_path / "data_dir"),
+            schema=str(schema_file),
+            writable=True,
+            write_dir=str(tmp_path / "write_dir"),
+            flush_threshold=0,
+        )
+
+
+def test_flush_threshold_above_hard_limit_rejected(tmp_path, schema_file):
+    # A threshold above the 256 MB memtable hard limit would never trigger an
+    # auto-flush (writes dead-end at the hard limit first) — issue #1620.
+    with pytest.raises(ValueError):
+        cqlite.open(
+            str(tmp_path / "data_dir"),
+            schema=str(schema_file),
+            writable=True,
+            write_dir=str(tmp_path / "write_dir"),
+            flush_threshold=300 * 1024 * 1024,  # 300 MB > 256 MB hard limit
+        )

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -358,6 +358,13 @@ pub struct WriteEngine {
     /// also be used for persistence, but the counter is more robust and avoids
     /// scanning the filesystem on every stats query).
     l0_count: u64,
+    /// Cumulative bytes written to flushed L0 SSTables (Data.db + all sibling
+    /// components) since the engine was opened (issue #1620). Incremented once
+    /// per successful `flush_internal_async()` by the flushed SSTable's
+    /// `data_size`. In-process only; reset to zero on re-open. Read via
+    /// [`WriteEngine::total_flushed_bytes`] so binding stats stay accurate for
+    /// automatic flushes (not just explicit `flush()` calls).
+    total_flushed_bytes: u64,
     /// Advisory exclusive lock on `write_dir` (`.lock` file).
     ///
     /// Held for the lifetime of the `WriteEngine`; released on `close()` or
@@ -369,6 +376,17 @@ pub struct WriteEngine {
     /// the same `write_dir`, which would corrupt WAL files and SSTables
     /// (Issue #485).
     dir_lock: std::fs::File,
+    /// Whether the "memtable over flush threshold" warning has already been
+    /// emitted for the current threshold crossing (issue #1620).
+    ///
+    /// The sync `write()` path does NOT auto-flush when a Tokio runtime is
+    /// present, so once the memtable crosses the flush threshold it stays over
+    /// it until an explicit (or async) flush. Without this guard the
+    /// over-threshold `log::warn!` fired on EVERY subsequent write (log spam).
+    /// It is set to `true` the first time the warning is emitted and reset to
+    /// `false` on the next successful flush, so the warning fires at most once
+    /// per threshold crossing.
+    warned_over_threshold: bool,
 }
 
 /// Reject any mutation that contains a counter cell write.
@@ -617,7 +635,9 @@ impl WriteEngine {
             cumulative_stats: CompactionStats::default(),
             rows_written: 0,
             l0_count: 0,
+            total_flushed_bytes: 0,
             dir_lock,
+            warned_over_threshold: false,
         })
     }
 
@@ -717,6 +737,48 @@ impl WriteEngine {
     }
 
     fn write_inner(&mut self, mutation: Mutation) -> Result<()> {
+        // Insert into WAL + memtable, then handle sync-context auto-flush.
+        self.write_into_memtable(mutation)?;
+
+        // Check if memtable should be flushed (sync callers only). The binding
+        // write path runs inside a Tokio runtime and does NOT reach here — it
+        // uses `execute_flushing`, which owns its own real async flush and
+        // deliberately skips the "call flush() manually" warning below.
+        if self
+            .memtable
+            .should_flush(self.config.memtable_flush_threshold)
+        {
+            // Rate-limit the over-threshold warning (issue #1620). A sync caller
+            // that lives inside a runtime never auto-flushes below, so the
+            // memtable stays over threshold across many writes; without this
+            // guard the warning fired on EVERY such write. Emit it at most once
+            // per crossing; it is reset on the next flush.
+            if !self.warned_over_threshold {
+                log::warn!(
+                    "Memtable size {} exceeds threshold {} - call flush() manually in async context",
+                    self.memtable.size_bytes(),
+                    self.config.memtable_flush_threshold
+                );
+                self.warned_over_threshold = true;
+            }
+
+            // Try to flush synchronously only if we're not in an async context.
+            if tokio::runtime::Handle::try_current().is_err() {
+                log::info!("Triggering automatic flush");
+                self.flush_internal()?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Insert a mutation into the WAL + memtable WITHOUT any auto-flush handling.
+    ///
+    /// Shared by the sync [`write_inner`] path (which then performs the
+    /// sync-context warn + flush) and the async [`execute_flushing`] path (which
+    /// owns its own real async flush and must NOT emit the sync "call flush()
+    /// manually in async context" warning) (issue #1620, roborev job 2879).
+    fn write_into_memtable(&mut self, mutation: Mutation) -> Result<()> {
         if self.closed.load(Ordering::SeqCst) {
             return Err(Error::InvalidInput(
                 "WriteEngine has been closed".to_string(),
@@ -751,24 +813,6 @@ impl WriteEngine {
         self.rows_written += 1;
         crate::observability::add_counter(crate::observability::catalog::WRITE_MUTATIONS, 1, &[]);
         self.record_memtable_gauges();
-
-        // 5. Check if memtable should be flushed (only in non-async context)
-        if self
-            .memtable
-            .should_flush(self.config.memtable_flush_threshold)
-        {
-            log::warn!(
-                "Memtable size {} exceeds threshold {} - call flush() manually in async context",
-                self.memtable.size_bytes(),
-                self.config.memtable_flush_threshold
-            );
-
-            // Try to flush synchronously only if we're not in an async context
-            if tokio::runtime::Handle::try_current().is_err() {
-                log::info!("Triggering automatic flush");
-                self.flush_internal()?;
-            }
-        }
 
         Ok(())
     }
@@ -899,31 +943,96 @@ impl WriteEngine {
     }
 
     fn execute_inner(&mut self, statement: &str) -> Result<()> {
+        // The public sync `execute` signature is unchanged: delegate to the
+        // counted implementation and discard the mutation count (issue #1620).
+        self.execute_inner_counted(statement).map(|_| ())
+    }
+
+    /// Parse + write a CQL statement into the memtable, returning the number of
+    /// mutations applied (N for a BATCH, else 1).
+    ///
+    /// This is the shared core of the sync `execute` path and the async
+    /// `execute_flushing` path (issue #1620). It is *unrecorded* (no
+    /// `record_result`); callers record at the public boundary.
+    fn execute_inner_counted(&mut self, statement: &str) -> Result<u64> {
         if self.closed.load(Ordering::SeqCst) {
             return Err(Error::InvalidInput(
                 "WriteEngine has been closed".to_string(),
             ));
         }
 
-        let trimmed = statement.trim();
-
-        // BATCH statements produce multiple mutations.
-        //
         // Single-boundary error recording (issue #1036): call the *unrecorded*
         // `write_inner` here rather than the public `write`. `execute` already
         // wraps this method in `record_result`, so the escaping error is counted
         // exactly once at the public boundary instead of twice.
-        if trimmed.len() >= 5 && trimmed.as_bytes()[..5].eq_ignore_ascii_case(b"BEGIN") {
-            let mutations =
-                cql_to_mutation::convert_cql_to_mutations(trimmed, &self.config.schema)?;
-            for mutation in mutations {
-                self.write_inner(mutation)?;
-            }
-            Ok(())
-        } else {
-            let mutation = self.parse_cql_to_mutation(statement)?;
-            self.write_inner(mutation)
+        let mutations = self.parse_statement_to_mutations(statement)?;
+        let n = mutations.len() as u64;
+        for mutation in mutations {
+            self.write_inner(mutation)?;
         }
+        Ok(n)
+    }
+
+    /// Parse a CQL DML statement into its mutation(s). A `BEGIN BATCH` yields one
+    /// mutation per statement in the batch; any other DML yields exactly one.
+    ///
+    /// Shared by the sync `execute` path ([`execute_inner_counted`]) and the
+    /// async [`execute_flushing`] path so both agree on batch semantics
+    /// (issue #1620).
+    fn parse_statement_to_mutations(&self, statement: &str) -> Result<Vec<Mutation>> {
+        let trimmed = statement.trim();
+        if trimmed.len() >= 5 && trimmed.as_bytes()[..5].eq_ignore_ascii_case(b"BEGIN") {
+            cql_to_mutation::convert_cql_to_mutations(trimmed, &self.config.schema)
+        } else {
+            Ok(vec![self.parse_cql_to_mutation(statement)?])
+        }
+    }
+
+    /// Execute a DML statement and, if the memtable has crossed the flush
+    /// threshold, await a REAL async flush (issue #1620, DECIDED: write_async).
+    ///
+    /// This is the entry point for the Node/Python binding write path, which runs
+    /// inside a Tokio runtime where the sync auto-flush in `write()` is
+    /// intentionally skipped. It restores auto-flush there WITHOUT the surprise
+    /// inline-flush latency the plain sync `write()`/`execute()` path avoids.
+    /// Returns the number of mutations applied (N for BATCH, else 1).
+    #[tracing::instrument(name = "write.cql_execute_flushing", skip(self, statement))]
+    pub async fn execute_flushing(&mut self, statement: &str) -> Result<u64> {
+        // Single-boundary error recording (issue #1036): `execute_flushing` is
+        // the public Node/Python DML entry point, so — like `execute`,
+        // `write_async`, and `flush` — it records the escaping result exactly
+        // once here. The inner helper and everything it calls (`write_inner`,
+        // `flush_internal_async`) are *unrecorded* to avoid double counting.
+        crate::observability::record_result("write", self.execute_flushing_inner(statement).await)
+    }
+
+    async fn execute_flushing_inner(&mut self, statement: &str) -> Result<u64> {
+        if self.closed.load(Ordering::SeqCst) {
+            return Err(Error::InvalidInput(
+                "WriteEngine has been closed".to_string(),
+            ));
+        }
+
+        // Parse first, then write each mutation and flush as soon as the memtable
+        // crosses the threshold. Checking after EVERY mutation (not just once at
+        // the end) means a large `BEGIN BATCH` cannot accumulate all the way to
+        // the hard limit before flushing and dead-ending (roborev job 2854,
+        // issue #1620).
+        let mutations = self.parse_statement_to_mutations(statement)?;
+        let n = mutations.len() as u64;
+        for mutation in mutations {
+            // Use the warn-free memtable insert: this path owns the real async
+            // flush below, so it must not emit the sync "call flush() manually"
+            // warning (roborev job 2879, issue #1620).
+            self.write_into_memtable(mutation)?;
+            if self
+                .memtable
+                .should_flush(self.config.memtable_flush_threshold)
+            {
+                self.flush_internal_async().await?;
+            }
+        }
+        Ok(n)
     }
 
     /// Force a flush of the memtable to SSTable
@@ -1068,8 +1177,17 @@ impl WriteEngine {
         // Clear memtable
         self.memtable.clear();
 
+        // Reset the over-threshold warn guard (issue #1620): the memtable is now
+        // empty, so the next threshold crossing is a fresh event that should warn
+        // again (at most once).
+        self.warned_over_threshold = false;
+
         // Increment the L0 SSTable counter (Issue #486).
         self.l0_count += 1;
+
+        // Accumulate cumulative flushed bytes (issue #1620) so binding write
+        // stats reflect automatic flushes, not only explicit `flush()` calls.
+        self.total_flushed_bytes = self.total_flushed_bytes.saturating_add(info.data_size);
 
         // Increment generation for next flush
         self.generation += 1;
@@ -2337,6 +2455,131 @@ mod tests {
         assert!(result.is_ok(), "Should accept writes after flush");
 
         assert_eq!(engine.memtable_row_count(), 1);
+    }
+
+    /// Issue #1620 (N2 — auto-flush cliff): the binding write path runs INSIDE a
+    /// Tokio runtime, where the sync `write()`/`execute()` auto-flush is
+    /// intentionally skipped (`Handle::try_current().is_err()` is false). On main
+    /// that meant the memtable grew unbounded until the hard limit, then every
+    /// write dead-ended. `execute_flushing` restores auto-flush via a REAL async
+    /// flush.
+    ///
+    /// Negative control: with the OLD sync `execute()` path in this same
+    /// runtime-present topology, no flush would ever fire, so `generation()`
+    /// would stay `1` and eventually a write would hit the hard limit. Here we
+    /// assert a real flush advanced the generation and no write dead-ended.
+    #[tokio::test]
+    async fn test_execute_flushing_auto_flushes_in_runtime() {
+        let temp_dir = TempDir::new().unwrap();
+        let schema = create_test_schema();
+
+        // Tiny flush threshold (4KB), default 256MB hard limit.
+        let config = WriteEngineConfig::new(
+            temp_dir.path().join("data"),
+            temp_dir.path().join("wal"),
+            schema,
+        )
+        .with_flush_threshold(4096)
+        .with_durability(Durability::Disabled);
+
+        let mut engine = WriteEngine::new(config).unwrap();
+        assert_eq!(engine.generation(), 1);
+
+        // We are inside a runtime (this is #[tokio::test]) — the exact topology
+        // the bindings hit. Drive enough inserts to cross the tiny threshold
+        // many times.
+        for i in 0..2000 {
+            let stmt = format!(
+                "INSERT INTO test_ks.test_table (id, name) VALUES ({}, 'User{}')",
+                i, i
+            );
+            let n = engine
+                .execute_flushing(&stmt)
+                .await
+                .expect("execute_flushing must not dead-end at the hard limit");
+            assert_eq!(n, 1, "single INSERT applies exactly one mutation");
+        }
+
+        // A real async flush happened: generation advanced past 1.
+        assert!(
+            engine.generation() > 1,
+            "expected auto-flush to advance generation, got {} (would stay 1 on the old sync path in a runtime)",
+            engine.generation()
+        );
+    }
+
+    /// Issue #1620: the over-threshold `log::warn!` must fire at most once per
+    /// threshold crossing. With a runtime present the sync `write()` path does
+    /// NOT auto-flush, so the memtable stays over threshold across many writes;
+    /// the `warned_over_threshold` guard prevents re-warning until the next
+    /// flush resets it. This asserts the private flag directly (same module) so
+    /// it is deterministic without capturing log output.
+    #[tokio::test]
+    async fn test_over_threshold_warn_fires_at_most_once_per_crossing() {
+        let temp_dir = TempDir::new().unwrap();
+        let schema = create_test_schema();
+
+        // Tiny flush threshold so a couple of writes cross it; generous hard
+        // limit so the sync path keeps accepting writes over threshold.
+        let config = WriteEngineConfig::new(
+            temp_dir.path().join("data"),
+            temp_dir.path().join("wal"),
+            schema,
+        )
+        .with_flush_threshold(256)
+        .with_hard_limit(64 * 1024)
+        .with_durability(Durability::Disabled);
+
+        let mut engine = WriteEngine::new(config).unwrap();
+        assert!(
+            !engine.warned_over_threshold,
+            "guard starts false before any crossing"
+        );
+
+        // Sync path inside a runtime: no auto-flush, so the memtable climbs and
+        // stays over threshold. First over-threshold write flips the guard.
+        let mut crossed = false;
+        for i in 0..500 {
+            engine
+                .write(create_test_mutation(
+                    i,
+                    &format!("User{}", i),
+                    1_000_000 + i as i64,
+                ))
+                .unwrap();
+            if engine.warned_over_threshold {
+                crossed = true;
+                break;
+            }
+        }
+        assert!(crossed, "memtable should have crossed the flush threshold");
+        assert!(
+            engine.warned_over_threshold,
+            "guard set after first crossing"
+        );
+
+        // Subsequent over-threshold writes must NOT re-arm/clear the guard.
+        for i in 500..600 {
+            engine
+                .write(create_test_mutation(
+                    i,
+                    &format!("User{}", i),
+                    1_000_000 + i as i64,
+                ))
+                .unwrap();
+            assert!(
+                engine.warned_over_threshold,
+                "guard must remain set across subsequent over-threshold writes"
+            );
+        }
+
+        // An explicit flush clears the memtable and resets the guard, so the
+        // next crossing warns again.
+        engine.flush().await.unwrap();
+        assert!(
+            !engine.warned_over_threshold,
+            "guard resets to false after a successful flush"
+        );
     }
 
     #[test]

--- a/cqlite-core/src/storage/write_engine/stats.rs
+++ b/cqlite-core/src/storage/write_engine/stats.rs
@@ -76,6 +76,17 @@ impl WriteEngine {
     pub fn l0_count(&self) -> u64 {
         self.l0_count
     }
+
+    /// Return the cumulative bytes written to flushed L0 SSTables (Data.db plus
+    /// all sibling components) since the engine was opened (issue #1620).
+    ///
+    /// Incremented on every successful flush — including the automatic flushes
+    /// the binding write path now performs via `execute_flushing` — so binding
+    /// write stats stay accurate for automatic flushes, not only explicit
+    /// `flush()` calls. In-process counter; resets to zero on re-open.
+    pub fn total_flushed_bytes(&self) -> u64 {
+        self.total_flushed_bytes
+    }
 }
 
 #[cfg(all(test, feature = "write-support"))]


### PR DESCRIPTION
Closes #1620 (N2 — auto-flush cliff). Part of epic #1607.

## Problem
The binding write path (Node/Python) routes DML through the sync `WriteEngine::execute()`/`write()` inside a `spawn_blocking` where a Tokio runtime handle IS present. The sync auto-flush is gated by `tokio::runtime::Handle::try_current().is_err()` (false in that topology), so the memtable grew to the 256MB hard limit and every subsequent write errored. The over-threshold `log::warn!` also fired on every write past threshold (log spam).

## Fix (DECIDED: write_async)
- New `WriteEngine::execute_flushing(&mut self, &str) -> Result<u64>`: parses DML into mutation(s), writes each, and awaits a REAL async flush (`flush_internal_async`) as soon as the memtable crosses the threshold — **checked after every mutation**, so a large `BEGIN BATCH` cannot accumulate to the hard limit before flushing (roborev job 2854). Shared parse helper `parse_statement_to_mutations` keeps sync/async batch semantics identical. The sync `write()`/`execute()` signatures and their `try_current().is_err()` behavior are unchanged (per the Do-NOT list; N5 hard-limit rejection untouched).
- Node `execute` (`bindings/node/src/database.rs`): drives `execute_flushing` to completion via `block_on` inside the existing `spawn_blocking`; returns the real mutation count as `rows_affected`.
- Python `execute` (`bindings/python/src/write.rs` + `execute_dml` in `database.rs`): routes through `execute_flushing` via `block_on`, and now releases the GIL with `py.allow_threads` (the write can perform real disk-flush I/O; the `MutexGuard` is created/dropped entirely inside the closure so it never crosses the GIL boundary — roborev job 2854).
- Over-threshold warn is rate-limited to once per crossing via a `warned_over_threshold` guard, reset on every successful flush.
- Added `flushThreshold` (Node) / `flush_threshold` (Python) open options (bytes, default 64MB unchanged) to make the flush path testable and tunable.

## Wiring evidence
Named public surface -> call chain -> e2e:
- Node: `Database.open({flushThreshold})` -> `db.execute(INSERT)` -> `execute_flushing` -> `*-Data.db` on disk. Jest e2e `bindings/node/__test__/auto-flush-cliff.test.js`.
- Python: `cqlite.open(flush_threshold=)` -> `db.execute(INSERT)` -> `PyWriteEngine.execute` -> `execute_flushing` -> `*-Data.db` on disk. pytest e2e `bindings/python/tests/test_auto_flush_cliff.py`.
- Engine `#[tokio::test]`s (runtime-present binding topology): `test_execute_flushing_auto_flushes_in_runtime` (generation advances; no hard-limit dead-end) + `test_over_threshold_warn_fires_at_most_once_per_crossing`.

## Gate
`scripts/agent-gate.sh` RESULT: PASS (all 19 stages, clean tree, commit 4d28ff15). `CQLITE_ALLOW_FILE_GROWTH=1` used: three touched files (`write_engine/mod.rs`, node/python `database.rs`) are pre-existing over-threshold; splitting them is epic #1116/#1135 territory, out of scope for this wiring fix.

roborev (codex) reviewed; both Medium findings (batch flush, GIL) addressed and re-reviewed.

## Oracle-driven wiring bug — issue + pinned regression tests, no OpenSpec.