### PR TITLE
docs(#1457): deprecate Node execute() (lossy legacy encodings); steer to executeNative()

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,7 +166,7 @@ const { Database } = require('@cqlite/node');
   const db = await Database.open('test-data/datasets/sstables', {
     schema: 'test-data/schemas/basic-types.cql'
   });
-  const result = await db.execute('SELECT * FROM test_basic.simple_table LIMIT 5');
+  const result = await db.executeNative('SELECT * FROM test_basic.simple_table LIMIT 5');
   console.log('Rows:', result.rowCount);
   for (const row of result.rows) {
     console.log(row.name);
@@ -344,7 +344,7 @@ bindings/node/
 
 **Status**: Phase 3 (Streaming) complete (Issue #305). Key APIs:
 - `Database.open(dataDir, options?)` — open with optional schema
-- `Database.execute(query)` — deprecated; use `executeNative()` for human-readable types
+- `Database.execute(query)` — **deprecated** (removed next major; emits a `DeprecationWarning`); lossy legacy JSON (blob→base64 string, timestamp→ISO string, varint/decimal→bespoke strings) and slower. Use `executeNative()`
 - `Database.executeNative(query)` — native JS types (BigInt, Date, Buffer, Set, Map)
 - `Database.executeStreaming(query, config?)` — async iteration for large result sets
 - `Database.getStats()` / `Database.close()`

--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -16,14 +16,28 @@ import { Database } from '@cqlite/node';
 // Open a database with schema
 const db = await Database.open('path/to/sstables', { schema: 'schema.cql' });
 
-// Execute queries
-const result = await db.execute('SELECT * FROM keyspace.table LIMIT 10');
+// Execute queries (executeNative() returns native JS types with full precision)
+const result = await db.executeNative('SELECT * FROM keyspace.table LIMIT 10');
 for (const row of result.rows) {
   console.log(row.name);
 }
 
 await db.close();
 ```
+
+> **⚠️ Warning: `execute()` is deprecated and will be removed in the next major.**
+> Prefer `executeNative()`. `execute()` returns **lossy** legacy JSON encodings:
+> - `blob` → base64 **string** (not a `Buffer`)
+> - `timestamp` → ISO-8601 **string** (not a `Date`)
+> - `varint` → `"0x{hex}"` **string**
+> - `decimal` → `"decimal:{scale}:0x{hex}"` **string**
+> - `date`/`time` → **number** (days-since-epoch / nanoseconds-since-midnight)
+>
+> It is also slower (JSON off-loop, then JS on-loop — a double conversion).
+> Calling `execute()` emits a one-time `DeprecationWarning`. Use `executeNative()`
+> for native types (`BigInt`, `Buffer`, `Date`, `Set`, `Map`) with full fidelity.
+> (`bigint`/`counter` currently come back as an exact `BigInt` on this napi build,
+> so they are not presently rounded — but `execute()` is unsupported regardless.)
 
 ## Features
 
@@ -70,20 +84,23 @@ The `close()` method is idempotent - safe to call multiple times.
 ### Executing Queries
 
 ```typescript
-// Simple query - returns JSON-serializable values
-const result = await db.execute('SELECT * FROM keyspace.table');
+// Simple query - executeNative() returns native JS types with full precision
+const result = await db.executeNative('SELECT * FROM keyspace.table');
 for (const row of result.rows) {
   console.log(row);
 }
 
 // With LIMIT
-const limited = await db.execute('SELECT name, age FROM users LIMIT 100');
+const limited = await db.executeNative('SELECT name, age FROM users LIMIT 100');
 
 // Access query metadata
 console.log(`Rows returned: ${result.rowCount}`);
 console.log(`Execution time: ${result.executionTimeMs}ms`);
 console.log(`Columns: ${result.columns.map(c => c.name).join(', ')}`);
 ```
+
+> Prefer `executeNative()` over the deprecated `execute()` — see the warning at
+> the top of this README for the precision/encoding hazards of `execute()`.
 
 ### Native Types with executeNative()
 
@@ -109,7 +126,13 @@ for (const row of result.rows) {
 }
 ```
 
-### JSON Encoding (execute method)
+### JSON Encoding (deprecated `execute()` method)
+
+> **⚠️ Deprecated — removed in the next major.** `execute()` returns lossy legacy
+> JSON encodings and is slower than `executeNative()`. In particular blob comes
+> back as a base64 string, timestamp as an ISO-8601 string, and varint/decimal
+> as bespoke non-round-trippable strings. This section documents the encoding for
+> the few callers that still depend on it; new code should use `executeNative()`.
 
 The `execute()` method returns JSON-serializable values. For most types this works intuitively,
 but `varint` and `decimal` types use a hex-based encoding to preserve arbitrary precision:
@@ -132,15 +155,16 @@ console.log(native.rows[0].amount);
 - `varint`: `"0x{hex}"` - Two's complement big-endian hex encoding
 - `decimal`: `"decimal:{scale}:0x{hex}"` - Scale (decimal places) + hex-encoded unscaled value
 
-**Recommendation:** Use `executeNative()` for most applications. The `execute()` method is
-primarily for JSON serialization scenarios where you need raw, reversible encoding.
+**Recommendation:** Use `executeNative()`. The `execute()` method is deprecated
+(removed in the next major); its JSON encoding is lossy (blob/timestamp/varint/
+decimal come back as bespoke strings) and it is slower than `executeNative()`.
 
 ### Column Metadata
 
 Each query result includes column information:
 
 ```typescript
-const result = await db.execute('SELECT * FROM keyspace.table');
+const result = await db.executeNative('SELECT * FROM keyspace.table');
 
 for (const col of result.columns) {
   console.log(`${col.name}: ${col.dataType}`);
@@ -167,7 +191,7 @@ import { Database } from '@cqlite/node';
 
 try {
   const db = await Database.open('/path/to/data');
-  const result = await db.execute('SELECT * FROM keyspace.table');
+  const result = await db.executeNative('SELECT * FROM keyspace.table');
 } catch (e) {
   // Error code for programmatic handling
   console.log(`Code: ${e.code}`);        // 'IO', 'SCHEMA', 'QUERY', 'PARSE', etc.
@@ -240,11 +264,11 @@ const db = await Database.open('path/to/sstables', {
 });
 
 // Write rows via CQL INSERT, UPDATE, or DELETE
-await db.execute(
+await db.executeNative(
   "INSERT INTO test_basic.simple_table (id, name, age) " +
   "VALUES (22222222-2222-2222-2222-222222222222, 'Bob', 25)"
 );
-await db.execute(
+await db.executeNative(
   "UPDATE test_basic.simple_table SET age = 26 " +
   "WHERE id = 22222222-2222-2222-2222-222222222222"
 );
@@ -273,7 +297,8 @@ await db.close();
 
 | Method / Property | Description |
 |-------------------|-------------|
-| `db.execute(cql)` | Execute a CQL INSERT, UPDATE, or DELETE statement |
+| `db.executeNative(cql)` | Execute a CQL INSERT, UPDATE, or DELETE statement (recommended) |
+| `db.execute(cql)` | **Deprecated** (removed next major; emits a `DeprecationWarning`). Same DML behavior as `executeNative()`, but lossy for SELECT — use `executeNative()` |
 | `db.flushRun()` | Flush memtable to SSTable; returns the Data.db path or `""` if memtable was empty |
 | `db.maintenanceStep(options?)` | Run STCS compaction for up to `options.budgetMs` ms (default: 100); returns `MaintenanceReport` |
 | `db.writeStats` | Synchronous getter: `memtableSizeBytes`, `memtableRowCount`, `totalWrittenBytes`, `l0SstableCount` |

--- a/bindings/node/__test__/execute-deprecation.test.js
+++ b/bindings/node/__test__/execute-deprecation.test.js
@@ -1,0 +1,129 @@
+/**
+ * Deprecation + precision-loss pinning tests for the legacy `execute()` method
+ * (Issue #1457).
+ *
+ * These tests pin two properties of the DEPRECATED `execute()` path so a future
+ * change cannot silently alter them:
+ *   1. Calling `execute()` emits a one-time Node `DeprecationWarning`
+ *      (code `CQLITE_DEP0001`) steering callers to `executeNative()`.
+ *   2. `execute()` loses precision for `bigint` above 2^53 and returns `blob`
+ *      as a base64 string, whereas `executeNative()` is the precision-safe path
+ *      (exact `BigInt`, `Buffer` for blob).
+ *
+ * The DB is generated in a tmp dir (write-support), so these tests do NOT depend
+ * on the fixture corpus. Setup writes use `executeNative()` so they do not
+ * consume the one-time deprecation warning before the warning test runs.
+ *
+ * NOTE (issue #1457 finding): the issue was filed on the premise that `execute()`
+ * silently rounds `bigint` above 2^53. That was NOT reproducible on the current
+ * napi build — napi's serde-json conversion returns the i64 as an exact JS
+ * `BigInt`, so `execute()` currently preserves the value. These tests therefore
+ * pin the OBSERVED behavior (exact BigInt via both paths) so a future napi/serde
+ * change that reintroduces f64 rounding turns them red, and pin the genuinely
+ * lossy behavior (blob → base64 string vs Buffer).
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { Database } = require('../lib/index.js');
+
+// 2^53 + 1 — the smallest integer NOT exactly representable as a JS `number`
+// (f64). If `execute()` ever downcast bigint to a JS number, this value would
+// round to 2^53 (= 9007199254740992) and the pinning test below would catch it.
+const BIG_UNSAFE = 9007199254740993n;
+
+const SCHEMA_TEXT = `
+CREATE KEYSPACE IF NOT EXISTS dep_test
+  WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};
+
+USE dep_test;
+
+CREATE TABLE IF NOT EXISTS items (
+    id   INT PRIMARY KEY,
+    big  BIGINT,
+    data BLOB
+);
+`;
+
+describe('execute() deprecation + precision loss (Issue #1457)', () => {
+  let dir;
+  let readDb;
+
+  beforeAll(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cqlite-exec-dep-'));
+    const schema = path.join(dir, 'schema.cql');
+    fs.writeFileSync(schema, SCHEMA_TEXT);
+    const dataDir = path.join(dir, 'data_dir');
+    fs.mkdirSync(dataDir);
+    const writeDir = path.join(dir, 'write_dir');
+
+    // Write via executeNative() so the one-time deprecation warning is NOT
+    // consumed before the warning test below.
+    const wdb = await Database.open(dataDir, { schema, writable: true, writeDir });
+    await wdb.executeNative(
+      `INSERT INTO dep_test.items (id, big, data) VALUES (1, ${BIG_UNSAFE.toString()}, 0xdeadbeef)`
+    );
+    await wdb.flushRun();
+    await wdb.close();
+
+    // Reopen the flushed SSTable directory read-only for the assertions.
+    readDb = await Database.open(path.join(writeDir, 'data'), { schema });
+  });
+
+  afterAll(async () => {
+    if (readDb) {
+      await readDb.close();
+      readDb = null;
+    }
+    if (dir) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('execute() emits a one-time DeprecationWarning steering to executeNative()', async () => {
+    const spy = jest.spyOn(process, 'emitWarning').mockImplementation(() => {});
+    try {
+      // Two calls: the warning must fire at most once for the whole process.
+      await readDb.execute('SELECT * FROM dep_test.items');
+      await readDb.execute('SELECT * FROM dep_test.items');
+
+      const depCalls = spy.mock.calls.filter(
+        (c) => c[1] && typeof c[1] === 'object' && c[1].code === 'CQLITE_DEP0001'
+      );
+      expect(depCalls).toHaveLength(1);
+      expect(depCalls[0][1].type).toBe('DeprecationWarning');
+      expect(depCalls[0][0]).toMatch(/deprecated/i);
+      expect(depCalls[0][0]).toMatch(/executeNative/);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test('bigint > 2^53 is exact via executeNative() AND (currently) via execute()', async () => {
+    const nativeRows = (await readDb.executeNative('SELECT big FROM dep_test.items')).rows;
+    expect(nativeRows).toHaveLength(1);
+    // Supported path: exact BigInt.
+    expect(typeof nativeRows[0].big).toBe('bigint');
+    expect(nativeRows[0].big).toBe(BIG_UNSAFE);
+
+    // Issue #1457 finding: contrary to the issue's premise, the current napi
+    // build returns the i64 as an exact JS BigInt from execute() too — it is
+    // NOT rounded to an f64. Pin that so a regression to f64 rounding reds here.
+    const jsonRows = (await readDb.execute('SELECT big FROM dep_test.items')).rows;
+    expect(jsonRows).toHaveLength(1);
+    expect(typeof jsonRows[0].big).toBe('bigint');
+    expect(jsonRows[0].big).toBe(BIG_UNSAFE);
+  });
+
+  test('execute() returns blob as base64 string while executeNative() returns a Buffer', async () => {
+    const nativeRows = (await readDb.executeNative('SELECT data FROM dep_test.items')).rows;
+    expect(Buffer.isBuffer(nativeRows[0].data)).toBe(true);
+    expect(nativeRows[0].data.equals(Buffer.from('deadbeef', 'hex'))).toBe(true);
+
+    const jsonRows = (await readDb.execute('SELECT data FROM dep_test.items')).rows;
+    expect(typeof jsonRows[0].data).toBe('string');
+    // Base64 of 0xdeadbeef.
+    expect(jsonRows[0].data).toBe(Buffer.from('deadbeef', 'hex').toString('base64'));
+  });
+});

--- a/bindings/node/lib/error-wrapper.js
+++ b/bindings/node/lib/error-wrapper.js
@@ -164,6 +164,41 @@ function createAsyncIterator(nativeStream) {
 }
 
 /**
+ * Emit a one-time deprecation warning for the legacy `execute()` method.
+ *
+ * `execute()` returns lossy legacy JSON encodings — blob comes back as a base64
+ * string (not a Buffer), timestamp as an ISO-8601 string (not a Date), and
+ * varint/decimal in bespoke `"0x…"` / `"decimal:…"` strings no caller can
+ * round-trip (see index.d.ts). It also double-converts (JSON off-loop, then JS
+ * on-loop) so it is slower than `executeNative()`. It is deprecated and will be
+ * removed in the next major; `executeNative()` returns native types with full
+ * fidelity. We emit via `process.emitWarning(..., 'DeprecationWarning')` guarded
+ * by a module-level flag so it fires at most once per process, matching Node's
+ * own deprecation convention (issue #1457).
+ *
+ * @private
+ */
+let executeDeprecationWarned = false;
+function warnExecuteDeprecated() {
+  if (executeDeprecationWarned) {
+    return;
+  }
+  executeDeprecationWarned = true;
+  process.emitWarning(
+    "Database.execute() is deprecated and will be removed in the next major. " +
+      "It returns lossy legacy JSON encodings: blob becomes a base64 string " +
+      "(not a Buffer), timestamp an ISO-8601 string (not a Date), and " +
+      "varint/decimal bespoke non-round-trippable strings; it is also slower " +
+      "(double conversion). Use executeNative() for native types with full " +
+      "fidelity (BigInt, Buffer, Date, Set, Map).",
+    {
+      type: "DeprecationWarning",
+      code: "CQLITE_DEP0001",
+    }
+  );
+}
+
+/**
  * Create a wrapped Database class with enhanced error handling.
  *
  * @param {Function} NativeDatabase - The native Database class
@@ -187,6 +222,7 @@ function createWrappedDatabase(NativeDatabase, wrapPreparedStatement) {
     }
 
     async execute(query) {
+      warnExecuteDeprecated();
       try {
         const result = await this._native.execute(query);
         // For SELECT: rowsAffected = rowCount (alias, Issue #348).

--- a/bindings/node/lib/index.d.ts
+++ b/bindings/node/lib/index.d.ts
@@ -200,19 +200,24 @@ export interface ColumnInfo {
  */
 export interface QueryResult {
   /**
-   * Result rows as JSON-serializable objects.
+   * Result rows as legacy JSON-serialized objects (returned by `execute()`).
    *
-   * Values are JSON-serialized versions of CQL types:
-   * - BigInt/Counter: number (may lose precision for values > 2^53)
-   * - Blob: base64 string
-   * - Timestamp: ISO 8601 string
-   * - Set/Map: Array representations
-   * - Varint: Hex string `"0x{hex}"` (e.g., `"0x7f"` for 127)
-   * - Decimal: String `"decimal:{scale}:0x{hex}"` (e.g., `"decimal:2:0x7b"` for 1.23)
+   * ⚠️ These values are lossy legacy JSON encodings of CQL types — see the
+   * hazards on {@link Database.execute}:
+   * - **Blob → base64 `string`** (not a `Buffer`).
+   * - **Timestamp → ISO-8601 `string`** (not a `Date`).
+   * - **Varint → hex `string` `"0x{hex}"`** (e.g., `"0x7f"` for 127).
+   * - **Decimal → `string` `"decimal:{scale}:0x{hex}"`** (e.g., `"decimal:2:0x7b"`).
+   * - **Date/Time → `number`** (days-since-epoch / nanoseconds-since-midnight).
+   * - Set/Map → Array representations.
    *
-   * For native types with full precision, use `executeNative()`.
+   * (BigInt/Counter are currently returned as an exact `BigInt` on this napi
+   * build, but `execute()` is deprecated and unsupported regardless.)
    *
-   * @deprecated The execute() method uses legacy JSON encoding. Use executeNative() for proper type fidelity.
+   * For native types with full fidelity, use `executeNative()`.
+   *
+   * @deprecated The execute() method uses lossy legacy JSON encoding and is
+   *   removed in the next major. Use executeNative() for proper type fidelity.
    */
   rows: Record<string, unknown>[];
 
@@ -968,24 +973,45 @@ export declare class Database {
   static open(dataDir: string, options?: DatabaseOptions): Promise<Database>;
 
   /**
-   * Execute a CQL query and return results as JSON-serializable values.
+   * Execute a CQL query and return results as legacy JSON-serialized values.
    *
-   * Use this method when you need JSON-compatible output or don't need
-   * native JavaScript types. For native types with full precision,
-   * use `executeNative()` instead.
+   * **DEPRECATED — removed in the next major. Use {@link Database.executeNative} instead.**
    *
-   * ## Varint and Decimal Encoding
+   * ## ⚠️ Lossy legacy encodings and correctness hazards
    *
-   * This method uses hex-based encoding for arbitrary precision numbers:
-   * - **Varint**: `"0x{hex}"` - Two's complement big-endian hex encoding
-   *   - Example: 127 -> `"0x7f"`, -1 -> `"0xff"`, 256 -> `"0x0100"`
-   * - **Decimal**: `"decimal:{scale}:0x{hex}"` - Scale + hex-encoded unscaled value
-   *   - Example: 1.23 (scale=2, unscaled=123) -> `"decimal:2:0x7b"`
+   * `execute()` routes every value through a legacy JSON encoder. Several CQL
+   * types come back in a lossy or bespoke encoding that no caller can round-trip
+   * and that differs from the native type `executeNative()` returns:
+   *
+   * - **`blob` → base64 `string`** (not a `Buffer`).
+   * - **`timestamp` → ISO-8601 `string`** (not a `Date`).
+   * - **`varint` → `"0x{hex}"` string.** Two's-complement big-endian hex.
+   *   Example: 127 -> `"0x7f"`, -1 -> `"0xff"`, 256 -> `"0x0100"`.
+   * - **`decimal` → `"decimal:{scale}:0x{hex}"` string.** Example: 1.23
+   *   (scale=2, unscaled=123) -> `"decimal:2:0x7b"`.
+   * - **`date` → `number`** (days since epoch); **`time` → `number`**
+   *   (nanoseconds since midnight).
+   *
+   * It is also **slower** than `executeNative()`: it converts each value to JSON
+   * off the JS main thread, then converts that JSON to JS values on-loop — a
+   * double conversion `executeNative()` avoids.
+   *
+   * NOTE on precision: with this napi build (BigInt support), `bigint`/`counter`
+   * are currently returned as an exact JS `BigInt`, so a value above 2^53 is
+   * **not** presently rounded. Do not rely on this — the encoding is legacy and
+   * unsupported; `executeNative()` is the contract. (Older docs claimed a >2^53
+   * rounding loss; that is not observed on the current binding — issue #1457.)
+   *
+   * `executeNative()` returns native types with full fidelity (`BigInt`,
+   * `Buffer`, `Date`, `Set`, `Map`) and is the supported path.
    *
    * @param query - CQL SELECT statement to execute
    * @returns Promise resolving to QueryResult with rows and metadata
    * @throws {CqliteError} If the query fails
-   * @deprecated Since 0.4.0. Use `executeNative()` for proper type fidelity.
+   * @deprecated Since 0.4.0; removed in the next major. Use `executeNative()`
+   *   for proper type fidelity — `execute()` returns blob/decimal/varint/
+   *   timestamp/date/time in lossy legacy encodings and is slower. Calling it
+   *   emits a one-time `DeprecationWarning`.
    *
    * @example
    * ```typescript

--- a/bindings/node/src/database.rs
+++ b/bindings/node/src/database.rs
@@ -776,7 +776,16 @@ impl Database {
 
     /// Execute a CQL query or write statement and return results.
     ///
-    /// For SELECT queries, returns matching rows.
+    /// **DEPRECATED — removed in the next major. Use `executeNative()` instead.**
+    ///
+    /// For SELECT queries, returns matching rows as lossy legacy JSON encodings:
+    /// blob → base64 string, timestamp → ISO-8601 string, varint → `"0x{hex}"`,
+    /// decimal → `"decimal:{scale}:0x{hex}"`, date/time → number. It also
+    /// double-converts (JSON off-loop, then JS on-loop) so it is slower than
+    /// `executeNative()`. The JS wrapper (`lib/error-wrapper.js`) emits a
+    /// one-time `DeprecationWarning` on first call. (BigInt/Counter are
+    /// currently returned as an exact JS `BigInt` on this napi build.)
+    ///
     /// For INSERT/UPDATE/DELETE, executes the write and returns `rowsAffected`.
     /// For large result sets, consider using streaming via `executeStreaming()`.
     ///
@@ -785,12 +794,12 @@ impl Database {
     ///
     /// @example
     /// ```javascript
-    /// // Read
-    /// const result = await db.execute('SELECT * FROM users LIMIT 10');
+    /// // Read (recommended: executeNative() for native types with full precision)
+    /// const result = await db.executeNative('SELECT * FROM users LIMIT 10');
     /// console.log(`Got ${result.rowCount} rows in ${result.executionTimeMs}ms`);
     ///
     /// // Write (requires writable: true in open options)
-    /// const wr = await db.execute("INSERT INTO users (id, name) VALUES (uuid(), 'Alice')");
+    /// const wr = await db.executeNative("INSERT INTO users (id, name) VALUES (uuid(), 'Alice')");
     /// console.log(`Rows affected: ${wr.rowsAffected}`);
     /// ```
     #[napi]
@@ -1522,6 +1531,16 @@ impl napi::Task for ExecuteNativeTask {
 ///
 /// This provides basic type conversion for Phase 2.
 /// For native JavaScript types, use `executeNative()` instead.
+///
+/// ⚠️ Lossy legacy encoding — see `execute()` in `lib/index.d.ts` for the full
+/// hazard list. blob → base64 string; timestamp → ISO-8601 string; varint →
+/// `"0x{hex}"`; decimal → `"decimal:{scale}:0x{hex}"`; date/time → number.
+/// (BigInt/Counter serde numbers are converted by napi to an exact JS `BigInt`
+/// on this build, so they are not presently rounded.)
+///
+/// TODO(next-major): remove `execute()` + `value_to_json` (breaking change;
+/// deprecated since 0.4.0, callers must migrate to `executeNative()`). See
+/// issue #1457. Do NOT remove before the next major bump.
 #[deprecated(
     since = "0.4.0",
     note = "Use executeNative() for native JavaScript types"


### PR DESCRIPTION
Closes #1457. DECIDED 2026-07-01 (owner pre-approved): document the `execute()` hazards now + add a deprecation signal; removal is next-major (out of scope here).

## ⚠️ NEEDS-YOU: the issue's headline premise is FALSE on the current build
The issue asserts `execute()` **silently rounds bigint/counter above 2^53**. I could not reproduce this. Runtime + code verification on the current napi build (napi 2.16.17, `napi9`/BigInt support):
- `value_to_json` maps `BigInt(i)` to a `serde_json` number, and napi's serde-json conversion returns the i64 as an **exact JS `BigInt`** — not an f64. `9007199254740993` (2^53+1) comes back exactly, via **both** `execute()` and `executeNative()`.
- The old `.d.ts` already carried this same (incorrect) ">2^53 rounding" claim; it was a code-reading assumption, not observed behavior.

The **genuinely** lossy/non-round-trippable `execute()` behaviors are real and are what I documented: blob → base64 string (not Buffer), timestamp → ISO-8601 string (not Date), varint → `"0x{hex}"`, decimal → `"decimal:{scale}:0x{hex}"`, date/time → number; plus it double-converts (JSON off-loop then JS on-loop) so it is slower. The deprecation is still justified on these grounds.

Because this contradicts the owner's DECIDED documentation wording, **holding merge for owner confirmation** of the reframing (document real hazards, drop the false 2^53 claim). Removal-next-major stays scheduled.

## What changed
- `lib/error-wrapper.js`: one-time `process.emitWarning(..., 'DeprecationWarning')` (code `CQLITE_DEP0001`) on first `execute()`, steering to `executeNative()`. Guarded by a module flag → fires at most once/process.
- `lib/index.d.ts`: `@deprecated` `execute()` + `QueryResult.rows` jsdoc updated to the verified lossy encodings (removed the false >2^53 rounding claim).
- `bindings/node/README.md`: prominent warning block above the first example; examples switched to `executeNative()`; API table marks `db.execute()` deprecated.
- `CLAUDE.md`: Node usage example switched to `executeNative()`; API note corrected.
- `src/database.rs`: `execute()` + `value_to_json` rustdoc updated; `TODO(next-major)` to remove `execute()`+`value_to_json` left in place (NOT removed now).
- `__test__/execute-deprecation.test.js` (new): pins (1) the one-time DeprecationWarning; (2) bigint 2^53+1 exact via both paths (reds if f64 rounding is ever reintroduced); (3) blob → base64 string vs `Buffer`.

## Verified
`cd bindings/node && npm run build` OK; `npx jest execute-deprecation` → **3 passed**. `cargo fmt -p cqlite-node --check` clean. Full local agent-gate not run (box OOMs under concurrent heavy compiles) — CI is the gate.

## Not done (out of scope, per issue)
- `execute()` / `value_to_json` NOT removed (next-major).
- `executeNative()` behavior unchanged.