### PR TITLE
fix(#1741): apply partition/range-tombstone + TTL shadowing on single-gen reads

### DIFF
--- a/bindings/python/python/cqlite/__init__.py
+++ b/bindings/python/python/cqlite/__init__.py
@@ -5,6 +5,8 @@ from cqlite._cqlite import (
     version,
     # Test-support introspection (issue #1437)
     _built_with_panic_abort,
+    # Test-support: direct DECIMAL rendering path (issue #1741)
+    _decimal_from_parts,
     # Exception types
     CqliteError,
     SchemaError,
@@ -41,6 +43,8 @@ __all__ = [
     "version",
     # Test-support introspection (issue #1437)
     "_built_with_panic_abort",
+    # Test-support: direct DECIMAL rendering path (issue #1741)
+    "_decimal_from_parts",
     # Exception types
     "CqliteError",
     "SchemaError",

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -58,6 +58,21 @@ fn _built_with_panic_abort() -> bool {
     cfg!(panic = "abort")
 }
 
+/// Test-support: render a CQL DECIMAL from its raw parts — `scale` and the
+/// big-endian two's-complement `unscaled` magnitude — through the exact
+/// production conversion (`value::decimal_to_pydecimal`).
+///
+/// Lets the pytest suite exercise the fail-closed corrupt-DECIMAL guard (issue
+/// #1741) directly: a large-but-REPRESENTABLE unscaled value must render as a
+/// `decimal.Decimal`, while a genuinely oversized one must raise a typed
+/// `CqliteError` (never abort the interpreter) — without needing a multi-kilobyte
+/// on-disk fixture. Not part of the stable public API; the leading underscore
+/// marks it internal test support.
+#[pyfunction]
+fn _decimal_from_parts(py: Python<'_>, scale: i32, unscaled: Vec<u8>) -> PyResult<PyObject> {
+    value::decimal_to_pydecimal(py, scale, &unscaled)
+}
+
 /// Python module for CQLite.
 #[pymodule]
 fn _cqlite(m: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -67,6 +82,10 @@ fn _cqlite(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     // Test-support introspection (issue #1437). See the fn doc comment.
     m.add_function(wrap_pyfunction!(_built_with_panic_abort, m)?)?;
+
+    // Test-support: direct DECIMAL rendering path for the corrupt-guard tests
+    // (issue #1741). See the fn doc comment.
+    m.add_function(wrap_pyfunction!(_decimal_from_parts, m)?)?;
 
     // Register exception types
     error::register_exceptions(m)?;

--- a/bindings/python/src/value.rs
+++ b/bindings/python/src/value.rs
@@ -7,6 +7,7 @@ use pyo3::exceptions::PyKeyError;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyFrozenSet, PyList, PyTuple};
 
+use crate::error::to_py_err;
 use cqlite_core::Value;
 
 /// Convert a CQL Value to a Python object.
@@ -283,7 +284,15 @@ fn varint_to_pyint(py: Python<'_>, bytes: &[u8]) -> PyResult<PyObject> {
 }
 
 /// Convert decimal to Python decimal.Decimal.
-fn decimal_to_pydecimal(py: Python<'_>, scale: i32, unscaled: &[u8]) -> PyResult<PyObject> {
+///
+/// `pub(crate)` so the internal `_decimal_from_parts` test helper (lib.rs) can
+/// drive this exact conversion path directly, exercising the fail-closed
+/// corrupt-DECIMAL guard (issue #1741) without a multi-kilobyte on-disk fixture.
+pub(crate) fn decimal_to_pydecimal(
+    py: Python<'_>,
+    scale: i32,
+    unscaled: &[u8],
+) -> PyResult<PyObject> {
     let decimal_mod = py.import("decimal")?;
     let decimal_class = decimal_mod.getattr("Decimal")?;
 
@@ -310,6 +319,65 @@ fn decimal_to_pydecimal(py: Python<'_>, scale: i32, unscaled: &[u8]) -> PyResult
             .into_any()
             .unbind())
     } else {
+        // Fail-closed guard (issue #1741, abort-safety regression). Real Cassandra
+        // DECIMAL values are tiny; a multi-thousand-digit unscaled value or an
+        // absurd scale only arises from a CORRUPT SSTable. The rendering below
+        // would otherwise (a) call Python `str()` on the unscaled int — which
+        // raises a bare `ValueError` once the digit count exceeds
+        // `sys.get_int_max_str_digits()` (py3.11+, default 4300) — or (b) use
+        // `scale` as a `format!` width, which panics with "Formatting argument
+        // out of range". Neither is a catchable driver error (the former escapes
+        // as an uncaught `ValueError`, aborting the caller), so we refuse to
+        // stringify an unbounded integer and instead surface a typed corruption
+        // error. This preserves the abort-safety guarantee (issue #1437/#1440):
+        // a corrupt SSTable raises `CqliteError`, it never crashes the driver.
+        //
+        // The read-side tombstone/TTL shadowing added for #1741 changed which
+        // corrupt row surfaces first on the truncated/bitflipped fixtures,
+        // exposing this pre-existing binding fragility (the unscaled-`str()`
+        // path) that the previous emit order happened to avoid.
+        const DECIMAL_HARD_DIGIT_CAP: usize = 1_000_000;
+        // Python's own configured int->str safety threshold (py3.11+, 0 ==
+        // unlimited). Absent on older interpreters, where there is no such limit;
+        // fall back to the hard cap so the `format!`-width panic is still avoided.
+        let py_int_limit: usize = py
+            .import("sys")
+            .and_then(|sys| sys.getattr("get_int_max_str_digits"))
+            .and_then(|f| f.call0())
+            .and_then(|v| v.extract::<i64>())
+            .map(|n| if n <= 0 { 0 } else { n as usize })
+            .unwrap_or(0);
+        let cap = match py_int_limit {
+            0 => DECIMAL_HARD_DIGIT_CAP,
+            n => n.min(DECIMAL_HARD_DIGIT_CAP),
+        };
+        // TIGHT upper bound on the decimal digit count of |unscaled|. For an
+        // N-byte SIGNED two's-complement integer one bit is the sign, so the
+        // MAGNITUDE is at most 2^(8N-1) — hence at most ceil((8N-1) * log10(2))
+        // decimal digits. That product is never an integer (log10(2) is
+        // irrational × an integer), so `ceil` equals `floor + 1`, which is the
+        // EXACT digit-count upper bound: no extra rounding margin is needed. The
+        // previous `ceil(N * log10(256)) + 1` added a spurious +1 and over-rejected
+        // a minimal value whose magnitude sits exactly at the cap (e.g. a 1785-byte
+        // integer fits in 4300 digits but the old formula computed 4301). Rejecting
+        // only when this tight bound STILL exceeds `cap` lets every representable
+        // value render while a truly unbounded/corrupt byte length is still refused
+        // (fail-closed) — the abort-safety guarantee is preserved. Compute the bit
+        // count in f64 so `8*len - 1` cannot underflow `usize` (len == 0 yields a
+        // negative product → 0 digits after the clamp); the float->int `as`
+        // saturates in Rust, so the guard never wraps or under-counts an oversized
+        // value.
+        let magnitude_bits = 8.0 * (unscaled.len() as f64) - 1.0;
+        let max_digits = (magnitude_bits * std::f64::consts::LOG10_2).ceil().max(0.0) as usize;
+        if max_digits > cap || (scale.unsigned_abs() as usize) > cap {
+            return Err(to_py_err(cqlite_core::Error::corruption(format!(
+                "DECIMAL cell not representable (scale={scale}, unscaled_len={} bytes, \
+                 cap={cap} digits): corrupt SSTable — refusing to stringify an unbounded \
+                 integer (issue #1741)",
+                unscaled.len()
+            ))));
+        }
+
         // Create string representation for exact decimal
         // Convert Python int to string by calling str()
         let builtins = py.import("builtins")?;

--- a/bindings/python/tests/test_decimal_guard.py
+++ b/bindings/python/tests/test_decimal_guard.py
@@ -1,0 +1,112 @@
+"""Corrupt-DECIMAL rendering guard (issue #1741).
+
+The Python binding renders a CQL DECIMAL by calling ``str()`` on the unscaled
+integer, which raises an *uncatchable* ``ValueError`` once the digit count
+exceeds ``sys.get_int_max_str_digits()`` (py3.11+, default 4300). To keep the
+interpreter abort-safe the binding refuses to stringify an unbounded/corrupt
+unscaled magnitude and surfaces a typed ``CqliteError`` instead.
+
+The guard must reject ONLY a genuinely unbounded/corrupt value, not a
+large-but-representable one. An ``N``-byte SIGNED two's-complement integer has
+one sign bit, so its MAGNITUDE is at most ``2^(8N-1)`` and has at most
+``ceil((8N-1) * log10(2))`` decimal digits. That product is never integral, so
+``ceil`` equals ``floor + 1`` — the EXACT digit-count upper bound, needing no
+rounding margin. Rejecting only when this bound exceeds the interpreter limit
+lets a value sitting exactly at the cap render while a truly unbounded/corrupt
+byte length is still refused (fail-closed). The previous
+``ceil(N * log10(256)) + 1`` added a spurious ``+1`` and over-rejected a minimal
+value at the boundary (e.g. a 1785-byte integer fits in 4300 digits but the old
+formula computed 4301).
+
+These drive :func:`cqlite._decimal_from_parts` — the internal test helper that
+runs the exact production conversion path (``value::decimal_to_pydecimal``) — so
+no multi-kilobyte on-disk fixture is required.
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+from decimal import Decimal
+
+import pytest
+
+import cqlite
+
+# log10(2): the guard bounds |unscaled| (magnitude 2^(8N-1)) digit count by
+# ceil((8N-1) * log10(2)).
+_LOG10_2 = 0.301_029_995_663_981_2
+
+
+def _positive_unscaled(num_bytes: int) -> bytes:
+    """A positive big-endian two's-complement magnitude of ``num_bytes`` bytes."""
+    return b"\x7f" + b"\xff" * (num_bytes - 1)
+
+
+def _max_digits(num_bytes: int) -> int:
+    """The guard's tight digit-count upper bound for an ``num_bytes``-byte value."""
+    return math.ceil((8 * num_bytes - 1) * _LOG10_2)
+
+
+class TestDecimalRenderingGuard:
+    def test_large_but_representable_decimal_renders(self):
+        """A ~1500-byte unscaled value (~3613 digits, under the 4300 default)
+        must render — the tight bound does not over-reject it."""
+        num_bytes = 1500
+        # Sanity: the tight bound stays under a default interpreter limit.
+        assert _max_digits(num_bytes) < 4300
+
+        value = cqlite._decimal_from_parts(2, _positive_unscaled(num_bytes))
+        assert isinstance(value, Decimal)
+        # Non-zero and scaled by 10^-2 (scale == 2); exact value is irrelevant.
+        assert value != 0
+
+    def test_oversized_decimal_raises_typed_error(self):
+        """A value whose TIGHT digit bound exceeds the interpreter limit must
+        surface a typed ``CqliteError`` (never abort), preserving the fail-closed
+        guard against a corrupt/unbounded unscaled magnitude."""
+        get_limit = getattr(sys, "get_int_max_str_digits", None)
+        limit = get_limit() if callable(get_limit) else 0
+        if limit == 0:
+            pytest.skip(
+                "interpreter exposes no int->str digit limit; guard uses the hard "
+                "cap (1_000_000) only, not exercisable with a small byte buffer"
+            )
+
+        # Pick a byte length whose tight bound exceeds `limit`.
+        num_bytes = int(limit / (8 * _LOG10_2)) + 64
+        assert _max_digits(num_bytes) > limit
+
+        with pytest.raises(cqlite.CqliteError):
+            cqlite._decimal_from_parts(1, _positive_unscaled(num_bytes))
+
+    def test_boundary_at_configured_digit_cap(self):
+        """At the configured cap the guard is EXACT: the largest byte length whose
+        magnitude bound is ``<= cap`` renders, and the next byte length (bound
+        ``> cap``) raises. This pins that a minimal value sitting right at the cap
+        is no longer over-rejected (the dropped spurious ``+1``)."""
+        get_limit = getattr(sys, "get_int_max_str_digits", None)
+        limit = get_limit() if callable(get_limit) else 0
+        if limit == 0:
+            pytest.skip("interpreter exposes no int->str digit limit; no cap boundary")
+
+        # Smallest byte length whose bound exceeds the cap, and the one below it.
+        n_over = next(n for n in range(1, limit) if _max_digits(n) > limit)
+        n_under = n_over - 1
+        # The boundary is genuine: under is <= cap, over is > cap.
+        assert _max_digits(n_under) <= limit < _max_digits(n_over)
+
+        # At/just under the cap: renders (its true digit count is <= the bound).
+        rendered = cqlite._decimal_from_parts(2, _positive_unscaled(n_under))
+        assert isinstance(rendered, Decimal)
+        assert rendered != 0
+
+        # Just over the cap: fail-closed typed error, never an interpreter abort.
+        with pytest.raises(cqlite.CqliteError):
+            cqlite._decimal_from_parts(2, _positive_unscaled(n_over))
+
+    def test_scale_zero_never_reaches_guard(self):
+        """scale == 0 short-circuits before the guard (no stringification of the
+        unscaled int), so even a large magnitude renders as an integer Decimal."""
+        value = cqlite._decimal_from_parts(0, _positive_unscaled(1500))
+        assert isinstance(value, Decimal)

--- a/bindings/python/tests/test_parity.py
+++ b/bindings/python/tests/test_parity.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import functools
 import json
 import re
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from decimal import Decimal
 from ipaddress import IPv4Address, IPv6Address
 from pathlib import Path
@@ -190,6 +190,125 @@ def count_rows_in_jsonl(jsonl_path: str | Path) -> int:
     """
     path = Path(jsonl_path) if isinstance(jsonl_path, str) else jsonl_path
     return _count_rows_in_jsonl_impl(path)
+
+
+def _parse_golden_expires_at(expires_at: str) -> datetime | None:
+    """Parse a golden ``liveness_info.expires_at`` ISO-8601 stamp to an aware UTC
+    ``datetime`` (e.g. ``"2025-10-07T01:12:06Z"``). Returns ``None`` if unparseable.
+    """
+    try:
+        return datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return None
+
+
+def count_live_rows_in_jsonl(jsonl_path: str | Path) -> int:
+    """Count golden rows that are LIVE under Cassandra ``SELECT`` semantics NOW.
+
+    Issue #1741 / #1742: the read path now applies partition/range-tombstone
+    shadowing and wall-clock TTL expiry (matching a Cassandra ``SELECT``), so an
+    expired-TTL row is correctly HIDDEN from query results. The physical
+    sstabledump golden does NOT apply wall-clock TTL — it lists every on-disk row
+    — so a raw physical count over-counts once TTLs elapse.
+
+    This helper derives the expected LIVE count from the same authoritative
+    metadata the reader uses, rather than hard-coding ``0`` (which would be
+    wall-clock-fragile if fixtures are ever regenerated with future TTLs):
+
+      * excludes range-tombstone markers (``type != "row"``) and row tombstones
+        (``deletion_info`` with no surviving cells) — exactly like
+        :func:`count_rows_in_jsonl`; and
+      * additionally excludes a row that is TTL-expired NOW. A row whose row-level
+        ``liveness_info`` carries a ``ttl`` whose ``expires_at`` is at/before now is
+        HIDDEN unless a surviving cell keeps it alive — mirroring EXACTLY the
+        reader's ``has_live_forever_data_cell`` aggregate (``row_data.rs``, issue
+        #1741). A non-deleted cell keeps the row visible when it is either:
+
+          - explicitly still-live: it carries its own ``expires_at`` in the future
+            (a per-cell TTL not yet elapsed); or
+          - live-forever: it carries NO ``expires_at`` at all AND is written by a
+            SEPARATE non-TTL mutation — which the golden marks by an own ``tstamp``
+            distinct from the row liveness (the reader's non-``USE_ROW_TTL``,
+            non-``IS_EXPIRING`` scalar path). A cell with no ``expires_at`` and no
+            own ``tstamp`` shares the row liveness (``USE_ROW_TTL``) and expires with
+            it — this is the crucial distinction Finding 2 adds: previously ANY
+            no-``expires_at`` cell was implicitly treated as inherited-and-expired,
+            so a genuinely live-forever non-TTL update would have been undercounted.
+
+        Why an own ``tstamp`` (not merely a collection ``path``) is the live-forever
+        signal: the golden does NOT expose a per-element TTL flag, so a collection
+        ELEMENT that INHERITS a table ``default_time_to_live`` looks identical to a
+        live-forever element (both show no ``expires_at``). The reader resolves this
+        from the on-disk ``IS_EXPIRING``/``USE_ROW_TTL`` flags; the golden cannot, so
+        keying live-forever off ``path`` would DISAGREE with the reader. Concretely
+        ``test_timeseries.app_metrics`` has ``default_time_to_live = 2592000`` (30d),
+        so every cell — including each ``tags`` map element — inherited that TTL and
+        expired ~2025-11; a Cassandra ``SELECT`` returns 0, which the reader returns.
+
+        Consequences that match the reader: every TTL-expired fixture whose cells all
+        inherit the elapsed row TTL collapses to 0 — ``test_basic.ttl_test_table``→0,
+        ``test_timeseries.log_entries``/``tick_data``/``app_metrics``→0,
+        ``test_oa.ttl_table``/``test_da.ttl_table``→0.
+
+    For a table with NO TTL metadata this is identical to
+    :func:`count_rows_in_jsonl` (nothing extra is excluded), so non-TTL tables
+    keep asserting exact physical parity. ``now`` is captured once per call; the
+    fixtures' expiries are far from the present, so no one-second-boundary race
+    is possible.
+    """
+    path = Path(jsonl_path) if isinstance(jsonl_path, str) else jsonl_path
+    now = datetime.now(timezone.utc)
+    total = 0
+    with open(path, "r") as f:
+        for line in f:
+            if not line.strip():
+                continue
+            partition = json.loads(line)
+            for row in partition.get("rows", []):
+                if row.get("type") != "row":
+                    continue
+                cells = row.get("cells") or []
+                if "deletion_info" in row and not cells:
+                    continue
+                liveness = row.get("liveness_info") or {}
+                expires_at = liveness.get("expires_at")
+                if liveness.get("ttl") and expires_at:
+                    exp = _parse_golden_expires_at(expires_at)
+                    if exp is not None and exp <= now:
+                        # Row-liveness TTL elapsed: the row survives only if some
+                        # non-deleted cell keeps it alive (mirrors the reader's
+                        # has_live_forever_data_cell / has_live_forever_element).
+                        cell_still_live = False
+                        for cell in cells:
+                            if "deletion_info" in cell:
+                                # A cell/collection tombstone is not live data.
+                                continue
+                            cell_exp = _parse_golden_expires_at(
+                                cell.get("expires_at")
+                            )
+                            if cell_exp is not None:
+                                # Explicit per-cell TTL: live iff still in the future.
+                                if cell_exp > now:
+                                    cell_still_live = True
+                                    break
+                                continue
+                            # No per-cell expiry -> live-forever ONLY if written by a
+                            # separate non-TTL mutation, which the golden marks with
+                            # an own ``tstamp`` distinct from the row liveness. A cell
+                            # with neither ``expires_at`` nor own ``tstamp`` inherits
+                            # the elapsed row TTL (USE_ROW_TTL) and does NOT keep the
+                            # row. A collection ``path`` alone is NOT a live-forever
+                            # signal: the golden cannot tell an inherited-TTL element
+                            # from a live-forever one, so keying off it would diverge
+                            # from the reader (see the docstring for app_metrics).
+                            if cell.get("tstamp") is not None:
+                                cell_still_live = True
+                                break
+                        if not cell_still_live:
+                            # Every cell shadowed/expired: a SELECT hides the row.
+                            continue
+                total += 1
+    return total
 
 
 def load_jsonl_partitions(jsonl_path: Path) -> list[dict]:
@@ -553,7 +672,12 @@ class TestRowCountParity:
         if jsonl_file is None:
             pytest.skip(f"JSONL reference not found for {keyspace}.{table}")
 
-        expected_count = count_rows_in_jsonl(jsonl_file)
+        # Issues #1741 (correct SELECT-side TTL/tombstone hiding) + #1742
+        # (query-semantics oracle): expected count is the golden's WALL-CLOCK-LIVE
+        # row count, not the raw physical count — TTL-expired rows are hidden by a
+        # Cassandra SELECT. For non-TTL tables this equals the physical count, so
+        # exact physical parity is unchanged.
+        expected_count = count_live_rows_in_jsonl(jsonl_file)
         result = database.execute(f"SELECT * FROM {keyspace}.{table}")
         actual_count = len(result.rows)
 
@@ -901,8 +1025,11 @@ class TestE2ESummary:
                 skipped.append((keyspace, table, "JSONL not found"))
                 continue
 
-            # Get expected row count
-            expected_count = count_rows_in_jsonl(jsonl_file)
+            # Get expected row count. Issues #1741/#1742: use the WALL-CLOCK-LIVE
+            # count so TTL-expired rows (correctly hidden by a Cassandra SELECT)
+            # are not over-counted; identical to the physical count for non-TTL
+            # tables, so exact physical parity is preserved there.
+            expected_count = count_live_rows_in_jsonl(jsonl_file)
 
             # Get schema file
             schema_file = get_schema_for_keyspace(keyspace)
@@ -1016,7 +1143,10 @@ class TestOaRowCountParity:
         if jsonl_file is None:
             pytest.skip(f"JSONL reference not found for test_oa.{table}")
 
-        expected_count = count_rows_in_jsonl(jsonl_file)
+        # Issues #1741/#1742: WALL-CLOCK-LIVE golden count (TTL-expired rows are
+        # hidden by a Cassandra SELECT). Equals the physical count for non-TTL
+        # oa tables, preserving exact physical parity there.
+        expected_count = count_live_rows_in_jsonl(jsonl_file)
         result = db_oa.execute(f"SELECT * FROM test_oa.{table}")
         actual_count = len(result.rows)
 

--- a/cqlite-core/src/storage/sstable/reader/data_access/big_promoted.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/big_promoted.rs
@@ -373,7 +373,7 @@ impl SSTableReader {
             return Ok(None);
         };
 
-        let parser = self.build_v5_parser();
+        let parser = self.build_v5_parser(true);
         let key = RowKey::from(partition_key.to_vec());
         let avail = window.len().saturating_sub(within);
         let mut out: Vec<(RowKey, ScanRow)> = Vec::new();
@@ -437,7 +437,7 @@ impl SSTableReader {
         else {
             return Ok(None);
         };
-        let parser = self.build_v5_parser();
+        let parser = self.build_v5_parser(true);
         let key = RowKey::from(partition_key.to_vec());
         let avail = window.len().saturating_sub(within);
         let clamped = row_body_window.map(|(s, e)| (s.min(avail), e.min(avail)));

--- a/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
@@ -198,7 +198,7 @@ impl SSTableReader {
         //    Issue #954: when `row_body_window` is set, the parse is bounded to the
         //    clustering slice's row-index block extent so only O(slice) rows are
         //    decoded (the post-scan backstop trims the block-granularity slack).
-        let parser = self.build_v5_parser();
+        let parser = self.build_v5_parser(true);
         let key = RowKey::from(partition_key.to_vec());
         let decoded_rows = match self
             .bti_decompress_and_parse_target_all(
@@ -490,7 +490,7 @@ impl SSTableReader {
         //    (`window_base = 0`). Either way the parse below uses the same
         //    `within = offset - window_base` index.
         let schema_opt = self.get_table_schema(None);
-        let parser = self.build_v5_parser();
+        let parser = self.build_v5_parser(true);
 
         let found = self
             .bti_decompress_and_parse_target(
@@ -1226,12 +1226,18 @@ impl SSTableReader {
     /// scans on this reader without serialization (issue #815).
     ///
     /// [`parse_block_with_cell_metadata`]: crate::storage::sstable::reader::parsing::V5CompressedLegacyParser::parse_block_with_cell_metadata
+    ///
+    /// `read_shadowing` (issue #1741): `true` for user-facing SELECT scans
+    /// (`scan`, `scan_with_cell_metadata`), `false` for the physical
+    /// `get_all_entries` (integrity verification / data-manager) which must count
+    /// every on-disk row.
     pub(super) async fn bti_scan_with_metadata(
         &self,
         start_key: Option<&RowKey>,
         end_key: Option<&RowKey>,
         limit: Option<usize>,
         schema: Option<&crate::schema::TableSchema>,
+        read_shadowing: bool,
     ) -> Result<
         Vec<(
             RowKey,
@@ -1256,7 +1262,7 @@ impl SSTableReader {
         // Resolve schema via the four-tier strategy (provided > header > registry).
         // V5CompressedLegacy partition decode requires a schema (cells lack names).
         let effective_schema = self.get_table_schema(schema);
-        let parser = self.build_v5_parser();
+        let parser = self.build_v5_parser(read_shadowing);
         let parsed =
             parser.parse_block_with_cell_metadata(&whole, effective_schema.as_ref(), self)?;
 

--- a/cqlite-core/src/storage/sstable/reader/data_access/compaction.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/compaction.rs
@@ -248,7 +248,7 @@ impl SSTableReader {
         let whole = self.stitch_all_chunks(&cursor).await?;
 
         let effective_schema = self.get_table_schema(None);
-        let parser = self.build_v5_parser();
+        let parser = self.build_v5_parser(false);
         let rows = parser.parse_block_for_compaction(&whole, effective_schema.as_ref(), self)?;
 
         let mut seen: HashSet<Vec<u8>> = HashSet::new();
@@ -291,7 +291,7 @@ impl SSTableReader {
         let whole = self.stitch_all_chunks(&cursor).await?;
 
         let effective_schema = self.get_table_schema(None);
-        let parser = self.build_v5_parser();
+        let parser = self.build_v5_parser(false);
 
         // `seen` dedups partition keys; the recorded position is the FIRST row's
         // offset for a partition (a partition spans contiguous rows, so the first
@@ -347,7 +347,7 @@ impl SSTableReader {
         let whole = self.stitch_all_chunks(&cursor).await?;
 
         let effective_schema = self.get_table_schema(None);
-        let parser = self.build_v5_parser();
+        let parser = self.build_v5_parser(false);
 
         // First pass: recover the distinct partition-start offsets in on-disk
         // order (a partition spans contiguous rows, so the first row's offset is
@@ -440,7 +440,7 @@ impl SSTableReader {
             return Ok(Vec::new());
         }
 
-        let parser = self.build_v5_parser();
+        let parser = self.build_v5_parser(false);
 
         // Group clustering tuples by partition-start offset (partitions appear in
         // ascending on-disk offset order; rows within a partition are emitted in
@@ -578,7 +578,7 @@ impl SSTableReader {
 
         // Resolve the schema the parser needs (cells lack column names on disk).
         let owned_schema = schema.cloned().or_else(|| self.get_table_schema(None));
-        let parser = self.build_v5_parser();
+        let parser = self.build_v5_parser(false);
 
         // Sliding window with a FRONT CURSOR (issue #1589): confirmed partitions are
         // consumed by advancing the cursor, and the reclaimed prefix is compacted

--- a/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
@@ -276,13 +276,19 @@ impl SSTableReader {
     /// This helper method extracts the stitching logic from get_all_entries so it can be
     /// reused by sequential_scan and other methods that need to handle V5CompressedLegacy
     /// format where partitions can span chunk boundaries.
+    ///
+    /// `read_shadowing` (issue #1741): `true` for user-facing SELECT scans
+    /// (`scan_for_key`, `sequential_scan`), `false` for the physical
+    /// `get_all_entries` (integrity verification / data-manager) so it counts every
+    /// on-disk row.
     pub(super) async fn stitch_and_parse_all_chunks(
         &self,
         cursor: &ScanCursor,
         schema: Option<&crate::schema::TableSchema>,
+        read_shadowing: bool,
     ) -> Result<Vec<(TableId, RowKey, ScanRow)>> {
         let stitched_buffer = self.stitch_all_chunks(cursor).await?;
-        let parser = self.build_v5_parser();
+        let parser = self.build_v5_parser(read_shadowing);
 
         // Get schema (use provided schema or reader's schema)
         let reader_schema;
@@ -321,7 +327,7 @@ impl SSTableReader {
         )>,
     > {
         let stitched_buffer = self.stitch_all_chunks(cursor).await?;
-        let parser = self.build_v5_parser();
+        let parser = self.build_v5_parser(true);
 
         let reader_schema;
         let table_schema = if let Some(s) = schema {
@@ -415,9 +421,17 @@ impl SSTableReader {
     /// Build a [`V5CompressedLegacyParser`] configured from this reader's header,
     /// statistics (EncodingStats), version gates, and UDT registry.
     ///
+    /// `read_shadowing` (issue #1741) MUST be `true` for user-facing query reads
+    /// (`scan`/`scan_stream`/`scan_with_cell_metadata`/point `get`) so the emit path
+    /// applies SELECT-semantic partition/range-tombstone shadowing and TTL expiry, and
+    /// `false` for PHYSICAL consumers that must see every on-disk row — integrity
+    /// verification via `get_all_entries`, `sstable_data_manager`, delta-scan, and the
+    /// compaction read path (which reconciles tombstones itself across generations).
+    ///
     /// [`V5CompressedLegacyParser`]: crate::storage::sstable::reader::parsing::V5CompressedLegacyParser
     pub(super) fn build_v5_parser(
         &self,
+        read_shadowing: bool,
     ) -> crate::storage::sstable::reader::parsing::V5CompressedLegacyParser {
         let keyspace = self.header.keyspace.clone();
         let table_name = self.header.table_name.clone();
@@ -444,7 +458,9 @@ impl SSTableReader {
         )
         // VG1: thread VersionGates from SSTableReader down to row parser so
         // that VG3 can flip gate-sensitive code paths without re-deriving gates.
-        .with_version_gates(self.version_gates.clone());
+        .with_version_gates(self.version_gates.clone())
+        // Issue #1741: SELECT-semantic read shadowing (see fn docs).
+        .with_read_shadowing(read_shadowing);
         // Add UDT registry if available for UDT-aware collection parsing (Issue #238)
         if let Some(ref registry) = self.udt_registry {
             parser.with_udt_registry(registry.clone())
@@ -814,7 +830,7 @@ impl SSTableReader {
 
         // Build a parser (re-using the existing builder so version-gates and
         // UDT registry are threaded through correctly).
-        let parser = self.build_v5_parser();
+        let parser = self.build_v5_parser(false);
 
         Ok((stitched, parser))
     }

--- a/cqlite-core/src/storage/sstable/reader/data_access/sequential.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/sequential.rs
@@ -80,7 +80,7 @@ impl SSTableReader {
         // correct, but emitting ALL partitions instead of stopping at the first.
         if self.bti_partitions_db.is_some() {
             let entries = self
-                .bti_scan_with_metadata(start_key, end_key, limit, schema)
+                .bti_scan_with_metadata(start_key, end_key, limit, schema, true)
                 .await?;
             return Ok(entries.into_iter().map(|(k, v, _meta)| (k, v)).collect());
         }
@@ -203,7 +203,9 @@ impl SSTableReader {
                 "{}.{}",
                 self.header.keyspace, self.header.table_name
             ));
-            let entries = self.bti_scan_with_metadata(None, None, None, None).await?;
+            let entries = self
+                .bti_scan_with_metadata(None, None, None, None, false)
+                .await?;
             return Ok(entries
                 .into_iter()
                 .map(|(k, v, _meta)| (table_id.clone(), k, v))
@@ -230,12 +232,14 @@ impl SSTableReader {
             );
 
             // Use shared stitching helper method
-            let entries = self.stitch_and_parse_all_chunks(&cursor, None).await?;
+            let entries = self
+                .stitch_and_parse_all_chunks(&cursor, None, false)
+                .await?;
             results.extend(entries);
         } else {
             // Other formats: Read and parse blocks individually
             while let Some(block) = self.read_next_block(&cursor).await? {
-                let entries = self.parse_block_entries(&block, None)?;
+                let entries = self.parse_block_entries(&block, None, false)?;
                 results.extend(entries);
             }
         }
@@ -326,7 +330,8 @@ impl SSTableReader {
             // Non-stitching formats already read block-by-block; emit per block so
             // only one block's entries are live at a time.
             while let Some(block) = self.read_next_block(&cursor).await? {
-                let entries = self.parse_block_entries_with_schema(&block, schema.as_ref())?;
+                let entries =
+                    self.parse_block_entries_with_schema(&block, schema.as_ref(), true)?;
                 for (entry_table_id, entry_key, entry_value) in entries {
                     if !table_ids_match(&entry_table_id, &table_id) {
                         continue;
@@ -402,7 +407,11 @@ impl SSTableReader {
             // fails for all rows in a partition, causing no entries to be pushed and making
             // the key comparison always miss even when the key exists.
             let schema_opt = self.get_table_schema(None);
-            let parser = self.build_v5_parser();
+            // Issue #1741: point lookups apply SELECT-semantic read shadowing, so
+            // build the parser with read_shadowing = true. The stitch/parse split
+            // (issue #1411) is preserved: CRC/decompress failures already surfaced
+            // via `stitch_all_chunks` above; only `parse_block` may soft-miss.
+            let parser = self.build_v5_parser(true);
             let all_entries = match parser.parse_block(&stitched_buffer, schema_opt.as_ref(), self)
             {
                 Ok(entries) => entries,
@@ -458,7 +467,7 @@ impl SSTableReader {
 
         // Sequential scan through blocks
         while let Some(block) = self.read_next_block(&cursor).await? {
-            let entries = self.parse_block_entries(&block, None)?;
+            let entries = self.parse_block_entries(&block, None, true)?;
 
             for (entry_table_id, entry_key, entry_value) in entries {
                 if table_ids_match(&entry_table_id, table_id) && entry_key == *key {
@@ -529,7 +538,9 @@ impl SSTableReader {
             );
 
             // Stitch all chunks together (reuse logic from get_all_entries)
-            let all_entries = self.stitch_and_parse_all_chunks(&cursor, schema).await?;
+            let all_entries = self
+                .stitch_and_parse_all_chunks(&cursor, schema, true)
+                .await?;
             log::debug!(
                 "SSTableReader::sequential_scan - Stitched parsing returned {} total entries",
                 all_entries.len()
@@ -588,7 +599,7 @@ impl SSTableReader {
                 block.len()
             );
 
-            let entries = self.parse_block_entries_with_schema(&block, schema)?;
+            let entries = self.parse_block_entries_with_schema(&block, schema, true)?;
             log::debug!(
                 "SSTableReader::sequential_scan - Block {} contains {} entries",
                 block_count,
@@ -696,7 +707,7 @@ impl SSTableReader {
         // plain BTI scan, but surfaces per-cell write metadata for WRITETIME/TTL.
         if self.bti_partitions_db.is_some() {
             return self
-                .bti_scan_with_metadata(start_key, end_key, limit, schema)
+                .bti_scan_with_metadata(start_key, end_key, limit, schema, true)
                 .await;
         }
 

--- a/cqlite-core/src/storage/sstable/reader/parsing/block_entries.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/block_entries.rs
@@ -67,21 +67,31 @@ impl SSTableReader {
     /// 1. SSTable header schema (V5.0+ formats)
     /// 2. Schema registry lookup (external schema files)
     /// 3. Header-constructed fallback schema
+    ///
+    /// `read_shadowing` (issue #1741): `true` for user-facing SELECT scans, `false`
+    /// for physical consumers (see [`SSTableReader::build_v5_parser`]).
     pub(in crate::storage::sstable::reader) fn parse_block_entries_with_schema(
         &self,
         block_data: &[u8],
         schema: Option<&crate::schema::TableSchema>,
+        read_shadowing: bool,
     ) -> Result<Vec<(TableId, RowKey, ScanRow)>> {
         // Pass the provided schema through to the parsing logic
         // This schema parameter flows through the call chain to get_table_schema()
-        self.parse_block_entries(block_data, schema)
+        self.parse_block_entries(block_data, schema, read_shadowing)
     }
 
-    /// Parse block entries from decompressed block data
+    /// Parse block entries from decompressed block data.
+    ///
+    /// `read_shadowing` (issue #1741): `true` for user-facing SELECT scans (applies
+    /// partition/range-tombstone shadowing + TTL expiry), `false` for physical
+    /// consumers that must see every on-disk row (see
+    /// [`SSTableReader::build_v5_parser`]).
     pub(in crate::storage::sstable::reader) fn parse_block_entries(
         &self,
         block_data: &[u8],
         schema: Option<&crate::schema::TableSchema>,
+        read_shadowing: bool,
     ) -> Result<Vec<(TableId, RowKey, ScanRow)>> {
         log::debug!(
             "parse_block_entries: Starting parse (data size: {} bytes, version: {:?})",
@@ -230,13 +240,26 @@ impl SSTableReader {
             let table_id_str = table_id.name();
             let (keyspace, table_name) = table_id_str.split_once('.').unwrap_or(("", table_id_str));
 
+            // NOTE: this site intentionally does NOT route through
+            // `self.build_v5_parser()`: that helper sources keyspace/table from
+            // `self.header`, which can be empty for V5CompressedLegacy `nb` files
+            // (see the non-empty validation above). This path uses the
+            // path-extracted keyspace/table as the reliable source. We still must
+            // thread the same VersionGates + read-shadowing + now_secs (captured in
+            // `new`) that `build_v5_parser` applies, so oa/da deletion-time layouts
+            // are gated correctly instead of falling back to DEFAULT gates.
             let parser = super::V5CompressedLegacyParser::new(
                 keyspace.to_string(),
                 table_name.to_string(),
                 min_timestamp,
                 min_local_deletion_time,
                 min_ttl,
-            );
+            )
+            // VG1: thread VersionGates from SSTableReader down to the row parser
+            // (mirrors `build_v5_parser`) so VG3 can flip gate-sensitive paths.
+            .with_version_gates(self.version_gates.clone());
+            // Issue #1741: apply SELECT-semantic read shadowing per the caller.
+            let parser = parser.with_read_shadowing(read_shadowing);
             // Add UDT registry if available for UDT-aware collection parsing (Issue #238)
             let parser = if let Some(ref registry) = self.udt_registry {
                 parser.with_udt_registry(registry.clone())
@@ -1270,7 +1293,7 @@ mod tests {
         block_data.extend_from_slice(&[0, 0, 0, 0, 0, 0, 0, 0]); // unknown 8-byte field
 
         // Try parsing - should route to V5CompressedLegacyParser
-        let result = reader.parse_block_entries(&block_data, None);
+        let result = reader.parse_block_entries(&block_data, None, false);
 
         // We expect either success or a specific parsing error (not a dispatch error)
         match result {
@@ -1338,7 +1361,7 @@ mod tests {
         // Pass invalid compressed data (should fall back to raw parsing)
         let invalid_compressed_data = vec![0xFF; 100];
 
-        let result = reader.parse_block_entries(&invalid_compressed_data, None);
+        let result = reader.parse_block_entries(&invalid_compressed_data, None, false);
 
         // Should attempt decompression, fail, then fall back to raw parsing
         // The raw parsing will likely fail too (invalid data), but we verify

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/block_emit.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/block_emit.rs
@@ -75,18 +75,35 @@ impl V5CompressedLegacyParser {
 
         let mut offset = 0;
         let mut partition_index = 0;
+        // Issue #1741 (F2): read-time TTL clock — captured ONCE per parser (== once per
+        // read/scan operation) in `V5CompressedLegacyParser::new`, reused for every
+        // block/partition here so a scan crossing an expiration-second boundary decides
+        // all rows with the SAME `now`.
+        let now_secs = self.now_secs;
+        // Issue #1741: authoritative per-clustering-column reversal flags (DESC),
+        // built ONCE per block so range-tombstone coverage compares clustering
+        // prefixes in physical storage order. Bounded by clustering arity.
+        let clustering_reversed = clustering_reversed_flags(schema);
 
         while offset < data.len() {
-            // Parse partition header: returns (RowKey, next_data_offset)
-            let (partition_key, next_data_offset) = match self.parse_partition_header(data, offset)
-            {
-                Ok(ph) => ph,
-                Err(_) => break,
-            };
+            // Parse partition header: returns (RowKey, next_data_offset, deletion)
+            let (partition_key, next_data_offset, partition_deletion) =
+                match self.parse_partition_header_full(data, offset) {
+                    Ok(ph) => ph,
+                    Err(_) => break,
+                };
 
             let table_id = TableId(format!("{}.{}", self.keyspace, self.table_name));
             offset = next_data_offset;
             partition_index += 1;
+
+            // Issue #1741: per-partition read-side shadowing (WRITETIME/TTL projection
+            // path), active ONLY for user-facing query reads (`self.read_shadowing`).
+            // Un-gated; hides partition/range-tombstone-shadowed and TTL-expired rows
+            // to match a Cassandra SELECT. `None` for physical consumers.
+            let mut shadow = self.read_shadowing.then(|| {
+                PartitionShadow::open(now_secs, partition_deletion, clustering_reversed.clone())
+            });
 
             let mut static_cells: HashMap<Arc<str>, Value> = HashMap::new();
             let mut static_cell_meta: HashMap<String, CellWriteMetadata> = HashMap::new();
@@ -99,6 +116,21 @@ impl V5CompressedLegacyParser {
                 }
 
                 if offset < data.len() && Self::is_range_tombstone_marker(data[offset]) {
+                    // Issue #1741: when shadowing is active, decode + feed the
+                    // range-tombstone FSM so covered rows are shadowed; otherwise
+                    // (physical read) only advance past the marker.
+                    if let Some(sh) = shadow.as_mut() {
+                        match self.parse_range_tombstone_marker_full(data, offset, schema) {
+                            Ok((bv, bk, dp, ds, next_offset)) => {
+                                if sh.feed_range_marker(bv, bk, dp, ds).is_err() {
+                                    break;
+                                }
+                                offset = next_offset;
+                                continue;
+                            }
+                            Err(_) => break,
+                        }
+                    }
                     match self.skip_range_tombstone_marker(data, offset, schema) {
                         Ok(next_offset) => {
                             offset = next_offset;
@@ -115,6 +147,7 @@ impl V5CompressedLegacyParser {
                     reader,
                     true,
                     &resolution,
+                    shadow.as_ref(),
                 ) {
                     Ok((
                         mut cells,
@@ -129,8 +162,24 @@ impl V5CompressedLegacyParser {
                         row_count += 1;
 
                         if is_static {
-                            static_cells = cells;
-                            static_cell_meta = row_cell_meta;
+                            // Issue #1741 (Finding 1): drop a static row's cells/metadata
+                            // when the static row is itself shadowed by the partition
+                            // tombstone or expired by its own TTL, so a surviving
+                            // clustering row does not resurface the stale static value.
+                            // Static rows have no clustering key (empty clustering); no-op
+                            // when shadowing is off.
+                            let static_hidden = shadow.as_ref().is_some_and(|sh| {
+                                row_header_opt
+                                    .as_ref()
+                                    .is_some_and(|h| sh.row_hidden(h, &[]))
+                            });
+                            if static_hidden {
+                                static_cells = HashMap::new();
+                                static_cell_meta = HashMap::new();
+                            } else {
+                                static_cells = cells;
+                                static_cell_meta = row_cell_meta;
+                            }
                         } else {
                             // Merge static cells / metadata into clustering row
                             for (k, v) in &static_cells {
@@ -140,43 +189,38 @@ impl V5CompressedLegacyParser {
                                 row_cell_meta.entry(k.clone()).or_insert_with(|| v.clone());
                             }
 
-                            let row_tombstone =
-                                row_header_opt.as_ref().filter(|h| h.is_row_tombstone());
+                            // Issue #1741: hide partition/range-tombstone-shadowed and
+                            // TTL-expired rows (matching a Cassandra SELECT). Active
+                            // only for query reads (shadow is `Some`). A row reduced to
+                            // only its primary key by per-cell filtering is hidden here
+                            // too: the dropped cells still fold into the row aggregate,
+                            // so `row_hidden` sees the whole row as shadowed/expired.
+                            let hidden = shadow.as_ref().is_some_and(|sh| {
+                                row_header_opt.as_ref().is_some_and(|h| {
+                                    let clustering = if sh.needs_clustering() {
+                                        extract_clustering_values(&cells, schema)
+                                    } else {
+                                        Vec::new()
+                                    };
+                                    sh.row_hidden(h, &clustering)
+                                })
+                            });
 
-                            // Issue #932: a HAS_DELETION row may ALSO carry surviving
-                            // cells (written strictly after the row deletion). For the
-                            // user-facing scan those cells — all newer than the
-                            // deletion — display as a live row; the deletion shadows
-                            // only already-absent older cells, so it has no display
-                            // effect here. Emit a pure `Tombstone` ONLY when no
-                            // non-primary-key cell survives.
-                            let has_data_cell = row_has_non_key_cell(&cells, schema);
-                            let row_value = if row_tombstone.is_some() && !has_data_cell {
-                                ScanRow::Marker(
-                                    row_tombstone
-                                        .map(|h| h.row_tombstone())
-                                        .unwrap_or(Value::Null),
-                                )
-                            } else if cells.is_empty() {
-                                ScanRow::Marker(Value::Null)
-                            } else {
-                                // Issue #1334: carry the interned `Arc<str>` name
-                                // handles straight into the row carrier (no
-                                // `Value::Text(String)` round-trip). Emit-time
-                                // alphabetical ordering preserved exactly.
-                                let mut row_cells: RowCells = cells.into_iter().collect();
-                                row_cells.sort_by(|a, b| a.0.as_ref().cmp(b.0.as_ref()));
-                                ScanRow::Row(row_cells)
-                            };
+                            // Issue #505/#932: row-tombstone display rule lives in the
+                            // shared `build_display_row` helper.
+                            let row_value =
+                                build_display_row(cells, row_header_opt.as_ref(), schema);
 
-                            match emit((
-                                table_id.clone(),
-                                partition_key.clone(),
-                                row_value,
-                                row_cell_meta,
-                            ))? {
-                                std::ops::ControlFlow::Continue(()) => {}
-                                std::ops::ControlFlow::Break(()) => return Ok(()),
+                            if !hidden {
+                                match emit((
+                                    table_id.clone(),
+                                    partition_key.clone(),
+                                    row_value,
+                                    row_cell_meta,
+                                ))? {
+                                    std::ops::ControlFlow::Continue(()) => {}
+                                    std::ops::ControlFlow::Break(()) => return Ok(()),
+                                }
                             }
                         }
 
@@ -502,6 +546,8 @@ impl V5CompressedLegacyParser {
                     reader,
                     true,
                     &resolution,
+                    // Delta-scan is a physical consumer: no read-side shadowing.
+                    None,
                 ) {
                     Ok((
                         cells,
@@ -528,7 +574,7 @@ impl V5CompressedLegacyParser {
                             // (Issue #702: delta-scan CellMeta.expires_at).
                             let liveness_exp = h
                                 .liveness_expires_at_seconds
-                                .map(|s| (s as i64).saturating_mul(1_000_000));
+                                .map(|s| s.saturating_mul(1_000_000));
                             (
                                 h.timestamp,
                                 h.is_row_tombstone(),

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/block_emit_windowed.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/block_emit_windowed.rs
@@ -83,6 +83,11 @@ impl V5CompressedLegacyParser {
 
         let mut emitted: usize = 0;
         let mut offset = 0;
+        // Issue #1741 (F2): read-time TTL clock — captured ONCE per parser (== once per
+        // read/scan operation) in `V5CompressedLegacyParser::new`. The windowed scan
+        // driver reuses this parser across every block; sampling `self.now_secs` here
+        // (not the wall clock per block) keeps a boundary-crossing scan consistent.
+        let now_secs = self.now_secs;
         let table_id = TableId::new(format!("{}.{}", self.keyspace, self.table_name));
 
         // Cassandra partition key size limits (used in header validation)
@@ -165,10 +170,25 @@ impl V5CompressedLegacyParser {
             }
 
             // Try to parse partition header
-            match self.parse_partition_header(data, offset) {
-                Ok((partition_key, new_offset)) => {
+            match self.parse_partition_header_full(data, offset) {
+                Ok((partition_key, new_offset, partition_deletion)) => {
                     let header_size = new_offset - offset;
                     offset = new_offset;
+
+                    // Issue #1741: per-partition read-side shadowing, active ONLY for
+                    // user-facing query reads (`self.read_shadowing`). Captures the
+                    // partition-level deletion and tracks the open range tombstone as
+                    // rows are walked, so partition/range-tombstone-shadowed and
+                    // TTL-expired rows are hidden (matching Cassandra SELECT). `None`
+                    // for physical consumers (verify / get_all_entries) which must see
+                    // every on-disk row. Un-gated (not behind write-support).
+                    let mut shadow = self.read_shadowing.then(|| {
+                        PartitionShadow::open(
+                            now_secs,
+                            partition_deletion,
+                            clustering_reversed_flags(schema),
+                        )
+                    });
 
                     // Issue #954: when a within-partition clustering-slice window is
                     // supplied, fast-forward the row cursor of the FIRST partition to
@@ -181,7 +201,47 @@ impl V5CompressedLegacyParser {
                     let row_body_end = match row_body_window {
                         Some((body_start, body_end)) if partition_index == 0 => {
                             if body_start > offset && body_start <= data.len() {
-                                offset = body_start;
+                                // Issue #1741 (Finding 1): a range tombstone that
+                                // OPENS before `body_start` can cover rows inside the
+                                // requested clustering slice. Fast-forwarding straight
+                                // to `body_start` would skip those markers, so the open
+                                // range would never be fed into `PartitionShadow` and a
+                                // slice read could return rows a full scan correctly
+                                // hides. When shadowing is active, replay the markers
+                                // from the partition body start up to `body_start` into
+                                // the shadow FSM first. If priming cannot faithfully
+                                // reconstruct the state (unrepresentable marker or an
+                                // undecodable row), fall back to a full-partition decode
+                                // from the body start rather than skip the markers: the
+                                // post-scan clustering backstop still trims the rows
+                                // before the slice, so correctness holds and only the
+                                // fast path is lost. When shadowing is off (physical
+                                // read) there is nothing to prime — keep the byte-for-
+                                // byte fast-forward (no-RT fast path unaffected).
+                                //
+                                // Issue #1741 (Finding 2): priming decodes the pre-window
+                                // prefix, regressing the row-index fast-forward from
+                                // O(slice) to O(prefix+slice) on a wide partition. Pay it
+                                // ONLY when a range tombstone can actually reach the slice.
+                                // Partition-deletion shadowing needs NO prefix decode (it is
+                                // captured from the header into `shadow`). Range tombstones:
+                                // when the SSTable's authoritative EncodingStats prove there
+                                // are no deletions (hence no range tombstones), keep the
+                                // O(slice) `offset = body_start` fast-forward and skip
+                                // priming. Priming itself is now marker-ONLY — it skips row
+                                // bodies via framing (no cell decode), feeding only the RT
+                                // markers into the FSM — so even when it runs it never
+                                // re-decodes the prefix cells.
+                                let primed = match shadow.as_mut() {
+                                    Some(_) if !self.sstable_may_have_range_tombstones() => true,
+                                    Some(sh) => self.prime_shadow_before_window(
+                                        data, offset, body_start, schema, sh,
+                                    ),
+                                    None => true,
+                                };
+                                if primed {
+                                    offset = body_start;
+                                }
                             }
                             Some(body_end)
                         }
@@ -270,19 +330,54 @@ impl V5CompressedLegacyParser {
                                 "V5CompressedLegacy: Range tombstone marker at offset {} (partition {}), skipping",
                                 offset, partition_index
                             );
-                            // Skip the marker - for now, just advance past it
-                            // A full implementation would parse ClusteringBoundOrBoundary and deletion times
+                            // Issue #1741: when read-side shadowing is active, decode
+                            // the marker (bounds + deletion time) and feed the
+                            // range-tombstone FSM so covered rows are shadowed;
+                            // otherwise (physical read) only advance past it.
+                            if let Some(sh) = shadow.as_mut() {
+                                match self.parse_range_tombstone_marker_full(data, offset, schema) {
+                                    Ok((
+                                        bound_values,
+                                        bound_kind,
+                                        del_primary,
+                                        del_secondary,
+                                        next_offset,
+                                    )) => {
+                                        if let Err(e) = sh.feed_range_marker(
+                                            bound_values,
+                                            bound_kind,
+                                            del_primary,
+                                            del_secondary,
+                                        ) {
+                                            log::debug!(
+                                                "V5CompressedLegacy: range tombstone FSM error at offset {}: {}",
+                                                offset, e
+                                            );
+                                            break; // Unrepresentable marker, end partition
+                                        }
+                                        offset = next_offset;
+                                        continue; // Continue to next row/marker
+                                    }
+                                    Err(e) => {
+                                        log::debug!(
+                                            "V5CompressedLegacy: Failed to parse range tombstone marker at offset {}: {}",
+                                            offset, e
+                                        );
+                                        break; // Can't parse marker, end partition
+                                    }
+                                }
+                            }
                             match self.skip_range_tombstone_marker(data, offset, schema) {
                                 Ok(next_offset) => {
                                     offset = next_offset;
-                                    continue; // Continue to next row/marker
+                                    continue;
                                 }
                                 Err(e) => {
                                     log::debug!(
                                         "V5CompressedLegacy: Failed to skip range tombstone marker at offset {}: {}",
                                         offset, e
                                     );
-                                    break; // Can't parse marker, end partition
+                                    break;
                                 }
                             }
                         }
@@ -294,6 +389,7 @@ impl V5CompressedLegacyParser {
                             reader,
                             false,
                             &resolution,
+                            shadow.as_ref(),
                         ) {
                             Ok((
                                 mut cells,
@@ -343,7 +439,21 @@ impl V5CompressedLegacyParser {
                                         partition_index,
                                         cells.len()
                                     );
-                                    static_cells = cells;
+                                    // Issue #1741 (Finding 1): a static row can itself be
+                                    // shadowed by the partition tombstone (static write ts
+                                    // <= markedForDeleteAt) or expired by its own TTL. If
+                                    // so its cells are STALE and must NOT be merged into a
+                                    // surviving clustering row, or a SELECT would resurface
+                                    // the deleted/expired static value. Static rows carry no
+                                    // clustering key, so an open range tombstone never covers
+                                    // them (empty clustering). No-op when shadowing is off.
+                                    let static_hidden = shadow.as_ref().is_some_and(|sh| {
+                                        row_header_opt
+                                            .as_ref()
+                                            .is_some_and(|h| sh.row_hidden(h, &[]))
+                                    });
+                                    static_cells =
+                                        if static_hidden { HashMap::new() } else { cells };
                                     // Do NOT push to results — static rows are not result rows
                                     // Continue to next row/marker in partition
                                 } else {
@@ -352,73 +462,28 @@ impl V5CompressedLegacyParser {
                                         cells.entry(k.clone()).or_insert_with(|| v.clone());
                                     }
 
-                                    // Convert cells HashMap to Value::Map (required by SelectExecutor)
-                                    //
-                                    // Issue #505: Row tombstones are detected via HAS_DELETION in the
-                                    // row header.  When present, emit a proper `Value::Tombstone`
-                                    // carrying the authoritative `markedForDeleteAt` (microseconds) so
-                                    // the compaction merger can apply tombstone-shadowing semantics
-                                    // rather than treating the absent cells as a live empty row.
-                                    let row_tombstone =
-                                        row_header_opt.as_ref().filter(|h| h.is_row_tombstone());
+                                    // Issue #1741: hide rows shadowed by a partition or
+                                    // range tombstone, or expired by TTL, matching a
+                                    // Cassandra SELECT. Active only for query reads
+                                    // (shadow is `Some`). A row reduced to only its
+                                    // primary key by per-cell filtering is hidden here
+                                    // too: the dropped cells still fold into the row
+                                    // aggregate, so `row_hidden` sees it shadowed/expired.
+                                    let hidden = shadow.as_ref().is_some_and(|sh| {
+                                        row_header_opt.as_ref().is_some_and(|h| {
+                                            let clustering = if sh.needs_clustering() {
+                                                extract_clustering_values(&cells, schema)
+                                            } else {
+                                                Vec::new()
+                                            };
+                                            sh.row_hidden(h, &clustering)
+                                        })
+                                    });
 
-                                    // Issue #932: a HAS_DELETION row carrying
-                                    // surviving (strictly-newer) cells displays as a
-                                    // live row for the user-facing scan — the
-                                    // deletion shadows only already-absent older
-                                    // cells. Emit a pure Tombstone only when no
-                                    // non-primary-key cell survives.
-                                    let has_data_cell = row_has_non_key_cell(&cells, schema);
-                                    let row_value = if row_tombstone.is_some() && !has_data_cell {
-                                        if let Some(h) = row_tombstone {
-                                            log::debug!(
-                                                "V5CompressedLegacy: Partition {} Row {} - emitting Tombstone(deletion_time={})",
-                                                partition_index, row_count, h.row_tombstone_deletion_time()
-                                            );
-                                            ScanRow::Marker(h.row_tombstone())
-                                        } else {
-                                            ScanRow::Marker(Value::Null)
-                                        }
-                                    } else if cells.is_empty() {
-                                        warn!(
-                                            "V5CompressedLegacy: No cells extracted for {}.{} partition {} row {} (partition key: {} bytes)",
-                                            self.keyspace,
-                                            self.table_name,
-                                            partition_index,
-                                            row_count,
-                                            partition_key.0.len()
-                                        );
-                                        ScanRow::Marker(Value::Null)
-                                    } else {
-                                        // Convert HashMap<String, Value> to Vec<(Value, Value)> for Value::Map.
-                                        //
-                                        // Sort alphabetically by column name to guarantee a deterministic
-                                        // ordering across independent parse calls.  HashMap iteration order
-                                        // is randomized per-instance in Rust, so two separate calls to
-                                        // stitch_and_parse_all_chunks (e.g. get() then scan()) would
-                                        // otherwise produce Vec orderings that compare as unequal even
-                                        // though they hold the same data.
-                                        //
-                                        // Alphabetical is not schema column order, but the query layer
-                                        // (executor.rs:storage_data_to_query_row) accesses columns by name
-                                        // (not position), so this ordering does not affect query correctness
-                                        // or sstabledump parity.
-                                        //
-                                        // NON-BLOCKING-3 (Issue #516/517): A future improvement could use
-                                        // serialization-header order (reader.header.columns) rather than
-                                        // alphabetical, matching Cassandra's on-disk column order exactly.
-                                        // That would require threading the column order through ParsedRow
-                                        // to this call site.
-                                        // Issue #1334: carry the interned `Arc<str>`
-                                        // column-name handles straight into the row
-                                        // carrier (no `Value::Text(String)` round-trip,
-                                        // no per-cell `.to_string()` re-allocation). The
-                                        // emit-time alphabetical ordering is preserved
-                                        // exactly (sort key is the name `str`).
-                                        let mut row_cells: RowCells = cells.into_iter().collect();
-                                        row_cells.sort_by(|a, b| a.0.as_ref().cmp(b.0.as_ref()));
-                                        ScanRow::Row(row_cells)
-                                    };
+                                    // Issue #505/#932: row-tombstone display rule now
+                                    // lives in the shared `build_display_row` helper.
+                                    let row_value =
+                                        build_display_row(cells, row_header_opt.as_ref(), schema);
 
                                     // Issue #954: count each clustering row actually
                                     // decoded out of Data.db so a slice query can be
@@ -430,14 +495,16 @@ impl V5CompressedLegacyParser {
                                     #[cfg(not(feature = "tombstones"))]
                                     crate::storage::sstable::work_counters::add_rows_decoded(1);
 
-                                    match emit((
-                                        table_id.clone(),
-                                        partition_key.clone(),
-                                        row_value,
-                                    ))? {
-                                        std::ops::ControlFlow::Continue(()) => emitted += 1,
-                                        // Consumer dropped (streaming receiver gone): stop parsing.
-                                        std::ops::ControlFlow::Break(()) => return Ok(()),
+                                    if !hidden {
+                                        match emit((
+                                            table_id.clone(),
+                                            partition_key.clone(),
+                                            row_value,
+                                        ))? {
+                                            std::ops::ControlFlow::Continue(()) => emitted += 1,
+                                            // Consumer dropped (streaming receiver gone): stop parsing.
+                                            std::ops::ControlFlow::Break(()) => return Ok(()),
+                                        }
                                     }
                                 }
 
@@ -526,6 +593,120 @@ impl V5CompressedLegacyParser {
         );
 
         Ok(())
+    }
+
+    /// Issue #1741 (Finding 1): replay the range-tombstone (and any other)
+    /// unfiltereds between the partition body start (`start`) and the
+    /// clustering-slice window start (`body_start`) into `shadow`, so an open
+    /// range tombstone that begins BEFORE the slice correctly shadows covered
+    /// rows inside it. Rows in this prefix are NOT emitted — only markers move
+    /// the FSM. `body_start` aligns to the start of an unfiltered (a BTI row-index
+    /// block boundary), so markers before it are fully contained in the prefix.
+    ///
+    /// Returns `true` when the prefix was replayed cleanly all the way to
+    /// `body_start` (the caller may then fast-forward). Returns `false` when the
+    /// state cannot be faithfully reconstructed (an unrepresentable marker, an
+    /// undecodable row framing, an early END_OF_PARTITION, or a non-advancing
+    /// parse); the caller then declines the fast-forward and decodes the full
+    /// partition, which is still correct because the post-scan backstop trims rows
+    /// before the slice.
+    ///
+    /// Issue #1741 (Finding 2): this is a MARKER-ONLY scan. Data rows in the prefix
+    /// are skipped via their framing (`skip_row_framing`) WITHOUT decoding any cell
+    /// values — only range-tombstone markers move the FSM. It therefore adds no
+    /// per-cell decode / allocation over the pre-window prefix; only the (cheap)
+    /// row framing (flags + clustering + row_size VInts) is parsed to advance. It
+    /// runs solely on the slice-read fast-forward branch when shadowing is active
+    /// AND the SSTable may contain range tombstones (see the call site gate).
+    fn prime_shadow_before_window(
+        &self,
+        data: &[u8],
+        start: usize,
+        body_start: usize,
+        schema: &TableSchema,
+        shadow: &mut PartitionShadow,
+    ) -> bool {
+        let mut offset = start;
+        while offset < body_start {
+            if offset >= data.len() {
+                return false;
+            }
+            let flags = data[offset];
+            // An END_OF_PARTITION before the window means the window is not in this
+            // partition — bail to the safe full-decode path.
+            if Self::is_end_of_partition(flags) {
+                return false;
+            }
+            if Self::is_range_tombstone_marker(flags) {
+                match self.parse_range_tombstone_marker_full(data, offset, schema) {
+                    Ok((bound_values, bound_kind, del_primary, del_secondary, next_offset)) => {
+                        if shadow
+                            .feed_range_marker(bound_values, bound_kind, del_primary, del_secondary)
+                            .is_err()
+                        {
+                            return false;
+                        }
+                        if next_offset <= offset {
+                            return false; // non-advancing parse guard
+                        }
+                        offset = next_offset;
+                        continue;
+                    }
+                    Err(_) => return false,
+                }
+            }
+            // A data row in the prefix: advance past it via framing ONLY (no cell
+            // decode), so the fast-forward stays O(prefix framing), not O(prefix
+            // cells). The prefix carries no static row (the caller only requests a
+            // start fast-forward when the schema has no static columns).
+            match self.skip_row_framing(data, offset, schema) {
+                Ok(next_offset) => {
+                    if next_offset <= offset {
+                        return false; // non-advancing parse guard
+                    }
+                    offset = next_offset;
+                }
+                Err(_) => return false,
+            }
+        }
+        true
+    }
+
+    /// Issue #1741 (Finding 2): compute the offset immediately after the row at
+    /// `offset` by parsing ONLY its framing — flags, clustering prefix, and the
+    /// `row_size` VInt — never decoding cell values. Mirrors the authoritative
+    /// offset arithmetic in `parse_row_data_with_offset`
+    /// (`next = row_metadata_offset + row_size_vint_len + row_size`) so a marker-only
+    /// prefix scan can skip data rows cheaply. Returns an error on truncation or an
+    /// out-of-range `row_size`, which the caller treats as "cannot prime".
+    pub(super) fn skip_row_framing(
+        &self,
+        data: &[u8],
+        offset: usize,
+        schema: &TableSchema,
+    ) -> Result<usize> {
+        let (row_flags, extended_flags, flags_size) = self.parse_row_flags(data, offset)?;
+        let after_flags = offset + flags_size;
+        let is_static = extended_flags
+            .map(|ef| (ef & EXTENDED_IS_STATIC) != 0)
+            .unwrap_or(false);
+        // Static rows carry no clustering prefix; regular rows do.
+        let row_metadata_offset = if is_static {
+            after_flags
+        } else {
+            let (_clustering, after_clustering) =
+                self.parse_clustering_prefix(data, after_flags, schema)?;
+            after_clustering
+        };
+        let (row_header, row_size) =
+            self.parse_row_metadata(data, row_metadata_offset, row_flags, extended_flags)?;
+        let next_offset = (row_metadata_offset + row_header.row_size_vint_len) + row_size as usize;
+        if next_offset > data.len() {
+            return Err(Error::corruption(
+                "prime_shadow: row framing extends past decompressed block".to_string(),
+            ));
+        }
+        Ok(next_offset)
     }
 
     /// Parse all partitions in a decompressed block, returning per-row timestamps.
@@ -620,6 +801,10 @@ impl V5CompressedLegacyParser {
                 // The whole block is present; never request a refill. A trailing
                 // parse failure is terminal here (matches the legacy
                 // `Err(_) => break` behaviour of the original loop).
+                //
+                // Compaction NEVER shadows: this parser is built without
+                // `read_shadowing`, so the merger sees the raw tombstones/expired
+                // cells it needs to reconcile across generations (#1741).
                 true,
                 &mut tracking_emit,
             )? {
@@ -677,6 +862,12 @@ impl V5CompressedLegacyParser {
     /// mid-stream would silently drop every partition after a chunk boundary, so
     /// we return `NeedMore` whenever the buffer may simply be truncated and we
     /// are not yet at the final chunk.
+    /// Read-side shadowing (issue #1741) is driven by `self.read_shadowing`: when the
+    /// parser was built for a user-facing query read, rows shadowed by a partition/
+    /// range tombstone or expired by TTL are dropped before they reach `emit`. The
+    /// compaction read path builds the parser WITHOUT shadowing (`read_shadowing ==
+    /// false`) — it needs the raw tombstones/expired cells preserved to reconcile
+    /// across generations. Un-gated: read correctness does not depend on `write-support`.
     pub fn parse_one_partition_with_timestamps<F>(
         &self,
         data: &[u8],
@@ -706,49 +897,68 @@ impl V5CompressedLegacyParser {
 
         let table_id = TableId::new(format!("{}.{}", self.keyspace, self.table_name));
 
-        const CASSANDRA_MAX_KEY_SIZE: usize = 65536;
-        const FORMAT_MAX_KEY_SIZE: usize = 255;
-
-        // A partition header is at least flags(1) + key_len(1). If we cannot even
-        // read those two bytes, we are truncated: request more unless final.
-        if data.len() < 2 {
-            return Ok(if at_final_chunk {
-                ParseStep::Done
-            } else {
-                ParseStep::NeedMore
-            });
+        // #1741 (roborev HIGH): size the header need-more decision correctly for
+        // the oa/da DeletionTime form. A DELETED oa/da partition carries the full
+        // 12-byte DeletionTime, not the 1-byte LIVE sentinel; peeking the
+        // discriminator (via `partition_header_readiness`) ensures a deleted header
+        // split across a NON-FINAL chunk returns `NeedMore` instead of being
+        // mis-parsed and emitted as `Emitted(1)` (which desynced the scan). The
+        // nb path is unchanged (fixed 12-byte signed form).
+        match self.partition_header_readiness(data) {
+            // Invalid header shape (zero/over-long key) → malformed; advance by
+            // one byte so the outer loop can resynchronise. Mirrors the legacy
+            // `offset += 1; continue` skip-a-byte recovery.
+            PartitionHeaderReadiness::Malformed => return Ok(ParseStep::Emitted(1)),
+            // Header (or its deleted-form DeletionTime) is split across the chunk
+            // boundary. On a non-final chunk request more bytes; on the final
+            // chunk no more will arrive, so the legacy loop treated this as the
+            // end of parseable partitions.
+            PartitionHeaderReadiness::Incomplete => {
+                return Ok(if at_final_chunk {
+                    ParseStep::Done
+                } else {
+                    ParseStep::NeedMore
+                });
+            }
+            // Every byte of the header (incl. its full DeletionTime) is present.
+            PartitionHeaderReadiness::Ready => {}
         }
 
-        let key_len = data[1] as usize;
-        let header_min_size = 1 + 1 + key_len + 4 + 8;
-
-        // Invalid header shape (zero/over-long key) → malformed; advance by one
-        // byte so the outer loop can resynchronise. Returning Emitted(1) here
-        // mirrors the legacy `offset += 1; continue` skip-a-byte recovery.
-        if key_len == 0 || key_len > FORMAT_MAX_KEY_SIZE.min(CASSANDRA_MAX_KEY_SIZE) {
-            return Ok(ParseStep::Emitted(1));
-        }
-
-        // Header declared but not fully present in `data` → truncated mid-header.
-        if header_min_size > data.len() {
-            return Ok(if at_final_chunk {
-                // No more bytes will ever arrive; the legacy loop treated this
-                // as the end of parseable partitions.
-                ParseStep::Done
-            } else {
-                ParseStep::NeedMore
-            });
-        }
-
-        let (partition_key, mut offset) = match self.parse_partition_header(data, 0) {
+        let (partition_key, mut offset, partition_deletion) = match self
+            .parse_partition_header_full(data, 0)
+        {
             Ok(v) => v,
+            // Defense-in-depth: `Ready` guarantees the DeletionTime is fully
+            // present, so a parse failure here cannot be truncation — it is a
+            // genuinely corrupt header (e.g. a non-0x80 byte with bit 7 set).
+            // On a non-final chunk, however, only re-request more bytes if the
+            // header is not yet complete; otherwise skip a byte to make forward
+            // progress (returning NeedMore on a complete buffer would loop
+            // forever). Since `Ready` holds, that reduces to the legacy
+            // skip-a-byte resync.
             Err(_) => {
-                // Fixed header bytes are present but did not parse: skip a byte
-                // to resynchronise — matching the legacy
-                // `Err(_) => { offset += 1; continue }` recovery.
+                if !at_final_chunk
+                    && self.partition_header_readiness(data) == PartitionHeaderReadiness::Incomplete
+                {
+                    return Ok(ParseStep::NeedMore);
+                }
                 return Ok(ParseStep::Emitted(1));
             }
         };
+
+        // Issue #1741: read-side shadowing is active ONLY when the parser was built
+        // for a user-facing query read (`self.read_shadowing`); the compaction caller
+        // builds the parser without it, leaving this `None`.
+        // F2: reuse the parser's once-per-read `now_secs` (see `new`), not a per-block
+        // wall-clock sample, so all blocks of one scan share a single `now`.
+        let now_secs = self.now_secs;
+        let mut shadow = self.read_shadowing.then(|| {
+            PartitionShadow::open(
+                now_secs,
+                partition_deletion,
+                clustering_reversed_flags(schema),
+            )
+        });
 
         let mut static_cells: HashMap<Arc<str>, Value> = HashMap::new();
 
@@ -801,6 +1011,29 @@ impl V5CompressedLegacyParser {
             }
 
             if Self::is_range_tombstone_marker(data[offset]) {
+                // Issue #1741: on the user-facing scan path decode the marker and
+                // feed the range-tombstone FSM so covered rows are shadowed; the
+                // compaction path (shadow == None) only advances past it.
+                if let Some(sh) = shadow.as_mut() {
+                    match self.parse_range_tombstone_marker_full(data, offset, schema) {
+                        Ok((bv, bk, dp, ds, next_offset)) => {
+                            if sh.feed_range_marker(bv, bk, dp, ds).is_err() {
+                                if at_final_chunk {
+                                    return flush_and_emitted!(offset, pending, emit);
+                                }
+                                return Ok(ParseStep::NeedMore);
+                            }
+                            offset = next_offset;
+                            continue;
+                        }
+                        Err(_) => {
+                            if at_final_chunk {
+                                return flush_and_emitted!(offset, pending, emit);
+                            }
+                            return Ok(ParseStep::NeedMore);
+                        }
+                    }
+                }
                 match self.skip_range_tombstone_marker(data, offset, schema) {
                     Ok(next_offset) => {
                         offset = next_offset;
@@ -823,6 +1056,7 @@ impl V5CompressedLegacyParser {
                 reader,
                 false,
                 &resolution,
+                shadow.as_ref(),
             ) {
                 Ok((
                     mut cells,
@@ -854,46 +1088,60 @@ impl V5CompressedLegacyParser {
                         .unwrap_or(0);
 
                     if is_static {
-                        static_cells = cells;
+                        // Issue #1741 (Finding 1): on the shadowing (user-facing) path,
+                        // drop a static row's cells when the static row is itself shadowed
+                        // by the partition tombstone or expired by its own TTL, so a
+                        // surviving clustering row does not resurface stale static data.
+                        // No-op on the compaction path (shadow == None), which must keep
+                        // the raw static cells for cross-generation reconcile.
+                        let static_hidden = shadow.as_ref().is_some_and(|sh| {
+                            row_header_opt
+                                .as_ref()
+                                .is_some_and(|h| sh.row_hidden(h, &[]))
+                        });
+                        static_cells = if static_hidden { HashMap::new() } else { cells };
                     } else {
                         for (k, v) in &static_cells {
                             cells.entry(k.clone()).or_insert_with(|| v.clone());
                         }
 
-                        // Row tombstone → Value::Tombstone(markedForDeleteAt).
-                        // Issue #932: unless the row ALSO carries surviving cells
-                        // (newer than the deletion), in which case it displays as a
-                        // live row — the deletion shadows only already-absent older
-                        // cells.
-                        let has_data_cell = row_has_non_key_cell(&cells, schema);
-                        let row_value = if row_tombstone.is_some() && !has_data_cell {
-                            ScanRow::Marker(
-                                row_tombstone
-                                    .map(|h| h.row_tombstone())
-                                    .unwrap_or(Value::Null),
-                            )
-                        } else if cells.is_empty() {
-                            ScanRow::Marker(Value::Null)
-                        } else {
-                            // Issue #1334: carry the interned `Arc<str>` name
-                            // handles straight into the row carrier (no
-                            // `Value::Text(String)` round-trip / per-cell
-                            // `.to_string()` re-allocation). This path drives BOTH
-                            // the user-facing streaming scan (`scan_stream_windowed`,
-                            // via `build_row_from_scan`) and the compaction read
-                            // (`from_legacy_value`); both consume the same `ScanRow`
-                            // carrier. Emit-time alphabetical ordering preserved exactly.
-                            let mut row_cells: RowCells = cells.into_iter().collect();
-                            row_cells.sort_by(|a, b| a.0.as_ref().cmp(b.0.as_ref()));
-                            ScanRow::Row(row_cells)
-                        };
+                        // Issue #1741: on the user-facing scan path, hide rows
+                        // shadowed by a partition/range tombstone or expired by TTL
+                        // (matching a Cassandra SELECT). No-op on the compaction path
+                        // (shadow == None), which must preserve the row for the merger.
+                        // A row reduced to only its primary key by per-cell filtering is
+                        // hidden here too: the dropped cells still fold into the row
+                        // aggregate, so `row_hidden` sees it shadowed/expired.
+                        let hidden = shadow.as_ref().is_some_and(|sh| {
+                            row_header_opt.as_ref().is_some_and(|h| {
+                                let clustering = if sh.needs_clustering() {
+                                    extract_clustering_values(&cells, schema)
+                                } else {
+                                    Vec::new()
+                                };
+                                sh.row_hidden(h, &clustering)
+                            })
+                        });
+
+                        // Issue #505/#932: row-tombstone display rule now lives in the
+                        // shared `build_display_row` helper. This `ScanRow` drives BOTH
+                        // the user-facing streaming scan and the compaction read; both
+                        // consume the same carrier.
+                        let row_value = build_display_row(cells, row_header_opt.as_ref(), schema);
 
                         // Finding 1: buffer the row instead of forwarding it now.
                         // It is flushed to `emit` only when the partition is
                         // confirmed complete (a `flush_and_emitted!` return). A
                         // mid-partition `NeedMore` discards `pending` and the
                         // caller re-parses from the partition start.
-                        pending.push((table_id.clone(), partition_key.clone(), row_value, row_ts));
+                        if !hidden {
+                            pending.push((
+                                table_id.clone(),
+                                partition_key.clone(),
+                                row_value,
+                                row_ts,
+                            ));
+                        }
                     }
 
                     if offset >= data.len() {

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/compaction.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/compaction.rs
@@ -348,37 +348,45 @@ impl V5CompressedLegacyParser {
         // with partition count, not row count.
         let resolution = RowColumnResolution::build(schema, reader);
 
-        const CASSANDRA_MAX_KEY_SIZE: usize = 65536;
-        const FORMAT_MAX_KEY_SIZE: usize = 255;
-
-        if data.len() < 2 {
-            return Ok(if at_final_chunk {
-                ParseStep::Done
-            } else {
-                ParseStep::NeedMore
-            });
+        // #1741 (roborev HIGH): size the header need-more decision correctly for
+        // the oa/da DeletionTime form. A DELETED oa/da partition carries the full
+        // 12-byte DeletionTime, not the 1-byte LIVE sentinel; a header split across
+        // a NON-FINAL chunk with only the first deletion byte present must return
+        // `NeedMore`, NOT be mis-parsed and skipped as `Emitted(1)` — on the
+        // compaction path that would DROP the partition tombstone and let older /
+        // deleted data survive or resurface. The nb path is unchanged (fixed
+        // 12-byte signed form). No heuristics: keyed off the authoritative
+        // `hasUIntDeletionTime` gate and the canonical DeletionTime sentinel.
+        match self.partition_header_readiness(data) {
+            PartitionHeaderReadiness::Malformed => return Ok(ParseStep::Emitted(1)),
+            PartitionHeaderReadiness::Incomplete => {
+                return Ok(if at_final_chunk {
+                    ParseStep::Done
+                } else {
+                    ParseStep::NeedMore
+                });
+            }
+            PartitionHeaderReadiness::Ready => {}
         }
 
-        let key_len = data[1] as usize;
-        let header_min_size = 1 + 1 + key_len + 4 + 8;
-
-        if key_len == 0 || key_len > FORMAT_MAX_KEY_SIZE.min(CASSANDRA_MAX_KEY_SIZE) {
-            return Ok(ParseStep::Emitted(1));
-        }
-
-        if header_min_size > data.len() {
-            return Ok(if at_final_chunk {
-                ParseStep::Done
-            } else {
-                ParseStep::NeedMore
-            });
-        }
-
-        let (partition_key, mut offset, partition_deletion) =
-            match self.parse_partition_header_full(data, 0) {
-                Ok(v) => v,
-                Err(_) => return Ok(ParseStep::Emitted(1)),
-            };
+        let (partition_key, mut offset, partition_deletion) = match self
+            .parse_partition_header_full(data, 0)
+        {
+            Ok(v) => v,
+            // Defense-in-depth: `Ready` guarantees the DeletionTime is fully
+            // present, so this cannot be a truncation. On a non-final chunk
+            // only re-request bytes if the header is still incomplete;
+            // otherwise skip a byte to resynchronise (NeedMore on a complete
+            // buffer would loop forever). Under `Ready` this stays a byte skip.
+            Err(_) => {
+                if !at_final_chunk
+                    && self.partition_header_readiness(data) == PartitionHeaderReadiness::Incomplete
+                {
+                    return Ok(ParseStep::NeedMore);
+                }
+                return Ok(ParseStep::Emitted(1));
+            }
+        };
 
         // Issue #1074: on the COMPACTION path the static row is emitted as its own
         // partition-level `CompactionRow` (Cassandra's `Row.staticRow`), NOT folded
@@ -570,6 +578,8 @@ impl V5CompressedLegacyParser {
                 true,
                 Some(&mut complex_capture),
                 &resolution,
+                // Compaction is a physical consumer: no read-side shadowing.
+                None,
             ) {
                 Ok((
                     cells,

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/complex_column.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/complex_column.rs
@@ -34,6 +34,10 @@ impl V5CompressedLegacyParser {
         complex_type: &str,
         has_complex_deletion: bool,
         _reader: &crate::storage::sstable::reader::types::SSTableReader,
+        // Issue #1741 (per-element filtering): read-side shadow/TTL context. `Some`
+        // only on the user-facing SELECT read path; `None` keeps physical consumers
+        // byte-unchanged.
+        element_filter: Option<ElementShadow>,
     ) -> Result<(Value, usize, ComplexColumnMeta)> {
         self.parse_complex_column_inner(
             data,
@@ -43,6 +47,7 @@ impl V5CompressedLegacyParser {
             has_complex_deletion,
             0,
             None,
+            element_filter,
         )
     }
 
@@ -77,6 +82,11 @@ impl V5CompressedLegacyParser {
         mut elements_out: Option<
             &mut Vec<crate::storage::sstable::reader::compaction_row::ComplexElement>,
         >,
+        // Issue #1741 (per-element filtering): read-side shadow/TTL context. `Some`
+        // ONLY on the user-facing SELECT read path (where `elements_out` is `None`);
+        // `None` on every physical consumer (compaction / delta-scan / unit tests),
+        // where no element is ever dropped so output is byte-unchanged.
+        element_filter: Option<ElementShadow>,
     ) -> Result<(Value, usize, ComplexColumnMeta)> {
         use crate::storage::sstable::reader::compaction_row::ComplexElement;
 
@@ -225,6 +235,19 @@ impl V5CompressedLegacyParser {
         let mut max_element_writetime: i64 = 0;
         let mut element_tombstone_count: u64 = 0;
 
+        // Issue #1741 (Finding 3): read-time TTL aggregate over LIVE elements.
+        // `has_live_forever_element` becomes true when a live element carries no
+        // TTL of any kind (never IS_EXPIRING); `max_element_expires_at` folds the
+        // explicit per-element expiries. Scalar-only, no per-cell allocation.
+        let mut has_live_forever_element = false;
+        let mut max_element_expires_at: Option<i64> = None;
+
+        // Issue #1741 (per-element filtering): count of LIVE elements dropped from
+        // the emitted container by the read-side shadow/TTL filter. Stays `0` when
+        // `element_filter` is `None` (physical consumers), so their output is
+        // byte-unchanged.
+        let mut shadow_filtered_element_count: usize = 0;
+
         /// Helper to update max_element_writetime from a parsed cell.
         #[inline]
         fn update_max_writetime(max: &mut i64, cell: &ComplexCellParse) {
@@ -232,6 +255,35 @@ impl V5CompressedLegacyParser {
                 if ts > *max {
                     *max = ts;
                 }
+            }
+        }
+
+        /// Issue #1741 (Finding 3): fold ONE live (non-deleted) element's TTL into
+        /// the collection aggregate. A non-expiring element is live-forever (keeps
+        /// the row visible) — but ONLY when it is not itself dropped by the read-side
+        /// shadow/TTL filter (`dropped`), so a wholly-shadowed collection never marks
+        /// live-forever. An expiring element with an EXPLICIT per-element expiry
+        /// contributes that expiry REGARDLESS of `dropped` (so an all-expired
+        /// collection still folds a past expiry that cannot keep the row alive, and
+        /// signals `has_ttl`); an expiring element inheriting the row TTL
+        /// (`USE_ROW_TTL`, no per-element `localDeletionTime`) is governed by the
+        /// row-liveness expiry, so it neither marks live-forever nor folds here.
+        /// Far-future `localDeletionTime` in `[2^31, 2^32)` is recovered via
+        /// `as u32 as i64`, matching the row-liveness expiry clock.
+        #[inline]
+        fn fold_element_expiry(
+            has_live_forever: &mut bool,
+            max_exp: &mut Option<i64>,
+            cell: &ComplexCellParse,
+            dropped: bool,
+        ) {
+            if !cell.is_expiring {
+                if !dropped {
+                    *has_live_forever = true;
+                }
+            } else if let Some(ldt) = cell.element_local_deletion_time {
+                let e = ldt as u32 as i64;
+                *max_exp = Some(max_exp.map_or(e, |m: i64| m.max(e)));
             }
         }
 
@@ -273,7 +325,26 @@ impl V5CompressedLegacyParser {
                 // DS4: Track element timestamp for live elements only (roborev Finding 2).
                 // Tombstoned elements are skipped above; their timestamps must not
                 // inflate the max_element_writetime reported for the collection.
+                // ALWAYS folded (even for a shadow-dropped element) so a wholly-
+                // shadowed collection still contributes its element ts to the row
+                // aggregate and is recognised as shadowed.
                 update_max_writetime(&mut max_element_writetime, &cell);
+                // Issue #1741 (per-element): is THIS element shadowed by the covering
+                // deletion or TTL-expired at the read clock? Always `false` when the
+                // filter is `None` (physical consumers) — byte-unchanged.
+                let dropped = Self::element_dropped(element_filter, &cell);
+                // Issue #1741 (Finding 3): fold the live element's TTL/expiry
+                // (live-forever only when NOT dropped).
+                fold_element_expiry(
+                    &mut has_live_forever_element,
+                    &mut max_element_expires_at,
+                    &cell,
+                    dropped,
+                );
+                if dropped {
+                    shadow_filtered_element_count += 1;
+                    continue;
+                }
 
                 // Epic #899: surface this live element to the compaction path.
                 record_element(
@@ -332,7 +403,23 @@ impl V5CompressedLegacyParser {
                 // DS4: Track element timestamp for live elements only (roborev Finding 2).
                 // Tombstoned elements are skipped above; their timestamps must not
                 // inflate the max_element_writetime reported for the collection.
+                // ALWAYS folded (even for a shadow-dropped element) so the row
+                // aggregate still sees a wholly-shadowed collection as shadowed.
                 update_max_writetime(&mut max_element_writetime, &cell);
+                // Issue #1741 (per-element): shadow/TTL filter for THIS set member.
+                let dropped = Self::element_dropped(element_filter, &cell);
+                // Issue #1741 (Finding 3): fold the live element's TTL/expiry
+                // (live-forever only when NOT dropped).
+                fold_element_expiry(
+                    &mut has_live_forever_element,
+                    &mut max_element_expires_at,
+                    &cell,
+                    dropped,
+                );
+                if dropped {
+                    shadow_filtered_element_count += 1;
+                    continue;
+                }
 
                 // For sets: the path bytes ARE the element value (cell value is always empty).
                 // If cell.value is Some (unusual case where a set cell has a non-empty value),
@@ -411,7 +498,26 @@ impl V5CompressedLegacyParser {
                     );
                 } else {
                     // DS4: Track element timestamp for live map entries only.
+                    // ALWAYS folded (even for a shadow-dropped entry) so the row
+                    // aggregate sees a wholly-shadowed map as shadowed.
                     update_max_writetime(&mut max_element_writetime, &cell);
+                    // Issue #1741 (per-element): shadow/TTL filter for THIS entry —
+                    // drop the WHOLE (key, value) entry when its own cell is shadowed
+                    // by the covering deletion or TTL-expired. `false` when the filter
+                    // is `None` (physical consumers), so maps stay byte-unchanged.
+                    let dropped = Self::element_dropped(element_filter, &cell);
+                    // Issue #1741 (Finding 3): fold the live entry's TTL/expiry
+                    // (live-forever only when NOT dropped).
+                    fold_element_expiry(
+                        &mut has_live_forever_element,
+                        &mut max_element_expires_at,
+                        &cell,
+                        dropped,
+                    );
+                    if dropped {
+                        shadow_filtered_element_count += 1;
+                        continue;
+                    }
                 }
 
                 // Decode the map key (from cell_path) up front so it can be both
@@ -502,6 +608,22 @@ impl V5CompressedLegacyParser {
                     continue;
                 }
                 update_max_writetime(&mut max_element_writetime, &cell);
+                // Issue #1741 (per-element): shadow/TTL filter for THIS UDT field —
+                // a shadowed/expired field is left absent (its `field_values` slot
+                // stays `None`). `false` when the filter is `None` (byte-unchanged).
+                let dropped = Self::element_dropped(element_filter, &cell);
+                // Issue #1741 (Finding 3): fold the live UDT field's TTL/expiry
+                // (live-forever only when NOT dropped).
+                fold_element_expiry(
+                    &mut has_live_forever_element,
+                    &mut max_element_expires_at,
+                    &cell,
+                    dropped,
+                );
+                if dropped {
+                    shadow_filtered_element_count += 1;
+                    continue;
+                }
 
                 // Decode the field value with its DECLARED type. `cell.value` is the
                 // raw bytes wrapped as Blob (BytesType) above; an empty-value cell
@@ -581,8 +703,69 @@ impl V5CompressedLegacyParser {
                 max_element_writetime,
                 element_tombstone_count,
                 complex_deletion,
+                has_live_forever_element,
+                max_element_expires_at,
+                shadow_filtered_element_count,
             },
         ))
+    }
+
+    /// Issue #1741 (per-element filtering): whether a LIVE collection element is
+    /// dropped by read-side shadow/TTL filtering. `None` filter (every physical
+    /// consumer — compaction / delta-scan / unit tests) NEVER drops, keeping their
+    /// output byte-unchanged. A covering deletion shadows an element whose effective
+    /// write ts (its own, or the inherited row ts for `USE_ROW_TIMESTAMP`) is
+    /// `<= cover`; an EXPIRING element with an explicit per-element `localDeletionTime
+    /// <= now` is TTL-expired. An element inheriting the row TTL (`USE_ROW_TTL`, no
+    /// per-element `localDeletionTime`) has `element_local_deletion_time == None` and
+    /// is TTL-checked against the row liveness expiry (`filter.row_expires_at`),
+    /// EXACTLY as the scalar `USE_ROW_TTL` cell path does — so an expired inherited-TTL
+    /// element is dropped even when another live cell keeps the row visible. An
+    /// element with no authoritative write ts is never shadowed
+    /// (no-heuristics, issue #28). Reuses the SAME decision as the simple-cell path
+    /// ([`PartitionShadow::cell_shadowed_or_expired`]) so both stay consistent.
+    #[inline]
+    fn element_dropped(filter: Option<ElementShadow>, cell: &ComplexCellParse) -> bool {
+        let Some(f) = filter else {
+            return false;
+        };
+        // Effective element write ts: its own, else the inherited row ts for a
+        // USE_ROW_TIMESTAMP element (`element_writetime == None`). The read path
+        // always sets `f.row_ts` from the row header, so this is authoritative. When
+        // neither is present the element has no authoritative ts (`eff_ts = None`),
+        // which `cell_shadowed_or_expired` never shadows (no-heuristics).
+        let eff_ts = cell.element_writetime.or(f.row_ts);
+        // An EXPIRING element's effective expiry mirrors the scalar USE_ROW_TTL cell
+        // path EXACTLY: an explicit per-element `localDeletionTime` wins (recovered
+        // from the far-future [2^31,2^32) encoding via `as u32 as i64`); an element
+        // that inherits the row TTL (`USE_ROW_TTL`, no per-element LDT) uses the row
+        // liveness expiry (`f.row_expires_at`). A non-expiring element is live-forever
+        // (no expiry). This makes scalar and collection-element USE_ROW_TTL semantics
+        // identical, so an inherited-TTL element that has expired is dropped even when
+        // another (live) cell keeps the row visible.
+        let eff_exp = if cell.is_expiring {
+            match cell.element_local_deletion_time {
+                Some(l) => Some(l as u32 as i64),
+                None => f.row_expires_at,
+            }
+        } else {
+            None
+        };
+        PartitionShadow::cell_shadowed_or_expired(f.cover, f.now, eff_ts, eff_exp)
+    }
+
+    /// Issue #1741 (per-element filtering): whether a parsed non-frozen collection
+    /// value emitted ZERO surviving elements (so the read path treats it as absent /
+    /// null). Only the collection variants are meaningful; any other value returns
+    /// `false` (never treated as an empty collection).
+    pub(super) fn complex_value_is_empty(value: &Value) -> bool {
+        match value {
+            Value::List(v) => v.is_empty(),
+            Value::Set(v) => v.is_empty(),
+            Value::Map(v) => v.is_empty(),
+            Value::Udt(u) => u.fields.iter().all(|f| f.value.is_none()),
+            _ => false,
+        }
     }
 
     /// Parse a single complex cell and extract its value.
@@ -825,6 +1008,7 @@ impl V5CompressedLegacyParser {
             element_writetime,
             element_ttl,
             element_local_deletion_time,
+            is_expiring,
         })
     }
 
@@ -1370,6 +1554,390 @@ mod tests {
         );
     }
 
+    /// Issue #1741 (Finding 3): a non-frozen collection's read-time TTL aggregate
+    /// must reflect its ELEMENTS, not blanket "live-forever". Build a `list<blob>`
+    /// with one EXPIRING element (explicit `localDeletionTime = 1000`) and one
+    /// LIVE-FOREVER element (no TTL), and assert the derived aggregate:
+    ///   * `has_live_forever_element == true` (the no-TTL element keeps the row visible)
+    ///   * `max_element_expires_at == Some(1000)` (the expiring element's expiry).
+    ///
+    /// Then a collection whose elements are ALL expiring must report
+    /// `has_live_forever_element == false` (so an otherwise-expired row is NOT kept
+    /// alive by the collection), and an all-deleted collection contributes neither.
+    #[test]
+    fn test_1741_collection_element_ttl_aggregate() {
+        use super::super::test_support::helpers::encode_unsigned;
+
+        // Deltas are absolute (min_timestamp / min_local_deletion_time / min_ttl = 0).
+        let parser = V5CompressedLegacyParser::new("k".to_string(), "t".to_string(), 0, 0, Some(0));
+        let column = crate::schema::Column {
+            name: "c".to_string(),
+            data_type: "list<blob>".to_string(),
+            nullable: true,
+            default: None,
+            is_static: false,
+        };
+
+        // One expiring element (flags IS_EXPIRING 0x02): ts, ldt, ttl, path, value.
+        // All deltas are < 128 so each VUInt is a single byte (unambiguous layout).
+        let expiring = |ldt: u64, val: u8| {
+            let mut b = vec![0x02u8];
+            encode_unsigned(1, &mut b); // timestamp delta
+            encode_unsigned(ldt, &mut b); // localDeletionTime delta == absolute expiry
+            encode_unsigned(1, &mut b); // ttl delta
+            encode_unsigned(0, &mut b); // path_len
+            encode_unsigned(1, &mut b); // value_len
+            b.push(val);
+            b
+        };
+        // One live-forever element (flags 0x08 USE_ROW_TIMESTAMP, no TTL fields).
+        let live_forever = |val: u8| {
+            let mut b = vec![0x08u8];
+            encode_unsigned(0, &mut b); // path_len
+            encode_unsigned(1, &mut b); // value_len
+            b.push(val);
+            b
+        };
+        // A deleted element (flags IS_DELETED 0x01): timestamp, ldt (deleted), path,
+        // no ttl (not expiring), no value (deleted).
+        let deleted = |ldt: u64| {
+            let mut b = vec![0x01u8];
+            encode_unsigned(1, &mut b); // timestamp delta (not USE_ROW_TIMESTAMP)
+            encode_unsigned(ldt, &mut b); // localDeletionTime delta
+            encode_unsigned(0, &mut b); // path_len
+            b
+        };
+
+        // Case A: expiring + live-forever.
+        let mut data = Vec::new();
+        encode_unsigned(2, &mut data); // cell_count
+        data.extend_from_slice(&expiring(100, 0xAA));
+        data.extend_from_slice(&live_forever(0xBB));
+        let (_v, _off, meta) = parser
+            .parse_complex_column_inner(&data, 0, &column, "list<blob>", false, 0, None, None)
+            .expect("parse list<blob>");
+        assert!(
+            meta.has_live_forever_element,
+            "a live-forever element must keep the row visible"
+        );
+        assert_eq!(
+            meta.max_element_expires_at,
+            Some(100),
+            "the expiring element's explicit expiry must fold into the aggregate"
+        );
+        assert_eq!(meta.element_tombstone_count, 0);
+
+        // Case B: all elements expiring — NO live-forever, max is the larger expiry.
+        let mut data = Vec::new();
+        encode_unsigned(2, &mut data);
+        data.extend_from_slice(&expiring(100, 0xAA));
+        data.extend_from_slice(&expiring(120, 0xBB));
+        let (_v, _off, meta) = parser
+            .parse_complex_column_inner(&data, 0, &column, "list<blob>", false, 0, None, None)
+            .expect("parse list<blob>");
+        assert!(
+            !meta.has_live_forever_element,
+            "an all-expiring collection must NOT keep an otherwise-expired row alive"
+        );
+        assert_eq!(meta.max_element_expires_at, Some(120));
+
+        // Case C: all elements deleted — neither live-forever nor an expiry.
+        let mut data = Vec::new();
+        encode_unsigned(2, &mut data);
+        data.extend_from_slice(&deleted(100));
+        data.extend_from_slice(&deleted(120));
+        let (_v, _off, meta) = parser
+            .parse_complex_column_inner(&data, 0, &column, "list<blob>", false, 0, None, None)
+            .expect("parse list<blob>");
+        assert!(!meta.has_live_forever_element);
+        assert_eq!(meta.max_element_expires_at, None);
+        assert_eq!(meta.element_tombstone_count, 2);
+    }
+
+    /// Issue #1741 (per-element filtering, test 2 — expired vs live): a non-frozen
+    /// collection with ONE expired element (explicit per-element
+    /// `localDeletionTime <= now`) and ONE live-forever element must emit ONLY the
+    /// live element when the read-side [`ElementShadow`] filter is active. The
+    /// dropped element folds its (past) expiry into the aggregate but never marks
+    /// `live-forever`.
+    ///
+    /// Pinned as a UNIT test (not end-to-end) because the writer stamps an expiring
+    /// cell's `localDeletionTime` as `now + ttl`, so a PAST-expired per-element TTL
+    /// is not synthesizable via a fresh writer flush — the same rationale as the
+    /// existing `per_cell_shadow_and_ttl_drop_decision` pin. This drives the exact
+    /// element loop the read path calls (`element_filter = Some`).
+    ///
+    /// Revert-verify: with the filter `None` (the physical-consumer path) the list
+    /// keeps BOTH elements and `shadow_filtered_element_count == 0` — proving the
+    /// differential is the filter, not the parse.
+    #[test]
+    fn test_1741_per_element_ttl_filter_keeps_only_live() {
+        use super::super::test_support::helpers::encode_unsigned;
+
+        let parser = V5CompressedLegacyParser::new("k".to_string(), "t".to_string(), 0, 0, Some(0));
+        let column = crate::schema::Column {
+            name: "c".to_string(),
+            data_type: "list<blob>".to_string(),
+            nullable: true,
+            default: None,
+            is_static: false,
+        };
+        // Expiring element (IS_EXPIRING 0x02): own ts, ldt (absolute expiry), ttl,
+        // empty path, one value byte.
+        let expiring = |ldt: u64, val: u8| {
+            let mut b = vec![0x02u8];
+            encode_unsigned(1, &mut b); // timestamp delta
+            encode_unsigned(ldt, &mut b); // localDeletionTime delta == absolute expiry
+            encode_unsigned(1, &mut b); // ttl delta
+            encode_unsigned(0, &mut b); // path_len
+            encode_unsigned(1, &mut b); // value_len
+            b.push(val);
+            b
+        };
+        // Live-forever element (USE_ROW_TIMESTAMP 0x08, no TTL fields).
+        let live_forever = |val: u8| {
+            let mut b = vec![0x08u8];
+            encode_unsigned(0, &mut b); // path_len
+            encode_unsigned(1, &mut b); // value_len
+            b.push(val);
+            b
+        };
+
+        let mut data = Vec::new();
+        encode_unsigned(2, &mut data); // cell_count
+        data.extend_from_slice(&expiring(100, 0xAA)); // expires at 100
+        data.extend_from_slice(&live_forever(0xBB));
+
+        // now = 200 (> 100) so the expiring element is TTL-expired; no covering
+        // deletion. row_ts feeds the USE_ROW_TIMESTAMP element's inherited ts.
+        let filter = ElementShadow {
+            cover: None,
+            now: 200,
+            row_ts: Some(5),
+            row_expires_at: None,
+        };
+        let (value, _off, meta) = parser
+            .parse_complex_column_inner(
+                &data,
+                0,
+                &column,
+                "list<blob>",
+                false,
+                0,
+                None,
+                Some(filter),
+            )
+            .expect("parse list<blob>");
+        assert_eq!(
+            value,
+            Value::List(vec![Value::Blob(vec![0xBB])]),
+            "only the live-forever element survives; the expired element is dropped"
+        );
+        assert_eq!(meta.shadow_filtered_element_count, 1);
+        assert!(
+            meta.has_live_forever_element,
+            "the surviving live-forever element keeps the row visible"
+        );
+        assert_eq!(meta.max_element_expires_at, Some(100));
+
+        // Revert-verify: with NO filter the parse keeps both elements.
+        let (value_unfiltered, _off, meta_unfiltered) = parser
+            .parse_complex_column_inner(&data, 0, &column, "list<blob>", false, 0, None, None)
+            .expect("parse list<blob>");
+        assert_eq!(
+            value_unfiltered,
+            Value::List(vec![Value::Blob(vec![0xAA]), Value::Blob(vec![0xBB])]),
+            "the physical (no-filter) parse must keep BOTH elements (byte-unchanged)"
+        );
+        assert_eq!(meta_unfiltered.shadow_filtered_element_count, 0);
+    }
+
+    /// Issue #1741 (per-element filtering, test 3 — all shadowed/expired): a
+    /// collection whose every element is shadowed by the covering deletion OR
+    /// TTL-expired emits an EMPTY container, reports `shadow_filtered_element_count
+    /// == cell_count`, and never marks live-forever. The read call site turns that
+    /// (empty container + filtered count > 0) into an ABSENT column so it cannot by
+    /// itself keep an otherwise-dead row alive.
+    ///
+    /// Revert-verify: with the filter `None` the container keeps every element and
+    /// `shadow_filtered_element_count == 0`.
+    #[test]
+    fn test_1741_per_element_all_shadowed_collection_is_empty() {
+        use super::super::test_support::helpers::encode_unsigned;
+
+        let parser = V5CompressedLegacyParser::new("k".to_string(), "t".to_string(), 0, 0, Some(0));
+        let column = crate::schema::Column {
+            name: "c".to_string(),
+            data_type: "list<blob>".to_string(),
+            nullable: true,
+            default: None,
+            is_static: false,
+        };
+        // Two plain (non-expiring) elements each carrying its OWN write ts (delta),
+        // both OLDER than the covering deletion below.
+        let plain = |ts_delta: u64, val: u8| {
+            let mut b = vec![0x00u8];
+            encode_unsigned(ts_delta, &mut b); // timestamp delta == absolute ts
+            encode_unsigned(0, &mut b); // path_len
+            encode_unsigned(1, &mut b); // value_len
+            b.push(val);
+            b
+        };
+        let mut data = Vec::new();
+        encode_unsigned(2, &mut data);
+        data.extend_from_slice(&plain(10, 0xAA)); // ts = 10
+        data.extend_from_slice(&plain(20, 0xBB)); // ts = 20
+
+        // Covering deletion at 100 (µs) shadows both elements (10, 20 <= 100).
+        let filter = ElementShadow {
+            cover: Some(100),
+            now: 0,
+            row_ts: None,
+            row_expires_at: None,
+        };
+        let (value, _off, meta) = parser
+            .parse_complex_column_inner(
+                &data,
+                0,
+                &column,
+                "list<blob>",
+                false,
+                0,
+                None,
+                Some(filter),
+            )
+            .expect("parse list<blob>");
+        assert!(
+            V5CompressedLegacyParser::complex_value_is_empty(&value),
+            "every element is shadowed by the covering deletion, so the container is empty"
+        );
+        assert_eq!(meta.shadow_filtered_element_count, 2);
+        assert!(
+            !meta.has_live_forever_element,
+            "a wholly-shadowed collection must NOT keep an otherwise-dead row alive"
+        );
+        // The shadowed elements STILL fold their write ts into the aggregate so the
+        // row is recognised as shadowed (max 20 <= covering 100).
+        assert_eq!(meta.max_element_writetime, 20);
+
+        // Revert-verify: with NO filter the container keeps both elements.
+        let (value_unfiltered, _off, meta_unfiltered) = parser
+            .parse_complex_column_inner(&data, 0, &column, "list<blob>", false, 0, None, None)
+            .expect("parse list<blob>");
+        assert_eq!(
+            value_unfiltered,
+            Value::List(vec![Value::Blob(vec![0xAA]), Value::Blob(vec![0xBB])])
+        );
+        assert_eq!(meta_unfiltered.shadow_filtered_element_count, 0);
+    }
+
+    /// Issue #1741 (roborev Medium — inherited-row-TTL collection elements): an
+    /// expiring collection element that INHERITS the row TTL (`USE_ROW_TTL` 0x10,
+    /// `is_expiring` true, NO explicit per-element `localDeletionTime`) must be
+    /// dropped when the inherited row liveness expiry is past `now`, EXACTLY as the
+    /// scalar `USE_ROW_TTL` cell path does — even though the row itself survives
+    /// (another live element keeps it visible). Before the fix such an element had
+    /// `element_local_deletion_time == None`, so its computed `eff_exp` was `None`
+    /// and it was KEPT (the expired inherited-TTL element leaked into the result).
+    ///
+    /// Scenario: a `list<blob>` with (1) a USE_ROW_TTL element inheriting an EXPIRED
+    /// row TTL and (2) a live-forever element that keeps the collection non-empty →
+    /// only the live-forever element survives.
+    ///
+    /// Pinned as a UNIT test (not end-to-end) for the same reason as
+    /// `test_1741_per_element_ttl_filter_keeps_only_live`: the writer stamps an
+    /// expiring row's `liveness_expires_at_seconds` as `now + ttl`, so a PAST-expired
+    /// inherited TTL is not synthesizable via a fresh writer flush. This drives the
+    /// exact element loop the read path calls (`element_filter = Some`) with the row
+    /// liveness expiry threaded into `ElementShadow::row_expires_at`.
+    ///
+    /// Revert-verify: with the filter `None` (physical-consumer path) BOTH elements
+    /// survive and `shadow_filtered_element_count == 0` — proving the differential is
+    /// the filter, not the parse.
+    #[test]
+    fn test_1741_per_element_inherited_row_ttl_expired_is_dropped() {
+        use super::super::test_support::helpers::encode_unsigned;
+
+        let parser = V5CompressedLegacyParser::new("k".to_string(), "t".to_string(), 0, 0, Some(0));
+        let column = crate::schema::Column {
+            name: "c".to_string(),
+            data_type: "list<blob>".to_string(),
+            nullable: true,
+            default: None,
+            is_static: false,
+        };
+        // USE_ROW_TTL element (flags 0x12 = IS_EXPIRING 0x02 | USE_ROW_TTL 0x10):
+        // it carries its OWN timestamp (USE_ROW_TIMESTAMP not set) but NO per-element
+        // localDeletionTime / TTL (both omitted under USE_ROW_TTL). Its expiry is
+        // inherited from the row liveness expiry.
+        let use_row_ttl = |val: u8| {
+            let mut b = vec![0x12u8];
+            encode_unsigned(1, &mut b); // timestamp delta
+            encode_unsigned(0, &mut b); // path_len
+            encode_unsigned(1, &mut b); // value_len
+            b.push(val);
+            b
+        };
+        // Live-forever element (USE_ROW_TIMESTAMP 0x08, no TTL fields).
+        let live_forever = |val: u8| {
+            let mut b = vec![0x08u8];
+            encode_unsigned(0, &mut b); // path_len
+            encode_unsigned(1, &mut b); // value_len
+            b.push(val);
+            b
+        };
+        let mut data = Vec::new();
+        encode_unsigned(2, &mut data); // cell_count
+        data.extend_from_slice(&use_row_ttl(0xAA)); // inherits (expired) row TTL
+        data.extend_from_slice(&live_forever(0xBB)); // keeps the collection non-empty
+
+        // Row liveness expiry = 100 (epoch s), now = 200 (> 100) → the inherited-TTL
+        // element is EXPIRED. No covering deletion. row_ts feeds the inherited write ts.
+        let filter = ElementShadow {
+            cover: None,
+            now: 200,
+            row_ts: Some(5),
+            row_expires_at: Some(100),
+        };
+        let (value, _off, meta) = parser
+            .parse_complex_column_inner(
+                &data,
+                0,
+                &column,
+                "list<blob>",
+                false,
+                0,
+                None,
+                Some(filter),
+            )
+            .expect("parse list<blob>");
+        assert_eq!(
+            value,
+            Value::List(vec![Value::Blob(vec![0xBB])]),
+            "the inherited-row-TTL element is expired and must be dropped; only the \
+             live-forever element survives (pre-fix: BOTH leaked)"
+        );
+        assert_eq!(
+            meta.shadow_filtered_element_count, 1,
+            "exactly the expired inherited-TTL element was filtered"
+        );
+        assert!(
+            meta.has_live_forever_element,
+            "the surviving live-forever element keeps the row visible"
+        );
+
+        // Revert-verify: with NO filter (physical consumer) BOTH elements survive.
+        let (value_unfiltered, _off, meta_unfiltered) = parser
+            .parse_complex_column_inner(&data, 0, &column, "list<blob>", false, 0, None, None)
+            .expect("parse list<blob>");
+        assert_eq!(
+            value_unfiltered,
+            Value::List(vec![Value::Blob(vec![0xAA]), Value::Blob(vec![0xBB])]),
+            "the physical (no-filter) parse keeps BOTH elements (byte-unchanged)"
+        );
+        assert_eq!(meta_unfiltered.shadow_filtered_element_count, 0);
+    }
+
     /// Regression test for Issue #481 regression: `list<frozen<udt>>` elements
     /// were being returned as `Value::Blob` instead of `Value::Udt`.
     ///
@@ -1456,7 +2024,7 @@ mod tests {
         blob.extend_from_slice(&udt_bytes);
 
         let (value, consumed, _meta) = parser
-            .parse_complex_column_inner(&blob, 0, &column, &column.data_type, false, 0, None)
+            .parse_complex_column_inner(&blob, 0, &column, &column.data_type, false, 0, None, None)
             .expect("parse_complex_column_inner must succeed for list<frozen<address_type>>");
         assert_eq!(consumed, blob.len(), "all bytes must be consumed");
 
@@ -1710,7 +2278,7 @@ mod tests {
         blob.extend(build_set_cell_bytes(world));
 
         let (value, consumed, _meta) = parser
-            .parse_complex_column_inner(&blob, 0, &column, &column.data_type, false, 0, None)
+            .parse_complex_column_inner(&blob, 0, &column, &column.data_type, false, 0, None, None)
             .expect("parse_complex_column_inner should succeed");
 
         assert_eq!(consumed, blob.len());
@@ -1763,7 +2331,7 @@ mod tests {
         blob.extend(build_set_tombstone_cell_bytes(dead));
 
         let (value, consumed, meta) = parser
-            .parse_complex_column_inner(&blob, 0, &column, &column.data_type, false, 0, None)
+            .parse_complex_column_inner(&blob, 0, &column, &column.data_type, false, 0, None, None)
             .expect("parse_complex_column_inner should succeed");
 
         assert_eq!(consumed, blob.len(), "parser must consume the entire blob");
@@ -1834,6 +2402,7 @@ mod tests {
                 &column.data_type,
                 true, /* has_complex_deletion */
                 0,
+                None,
                 None,
             )
             .expect("parse_complex_column_inner must succeed for collection tombstone");
@@ -1950,6 +2519,7 @@ mod tests {
                 true, // has_complex_deletion
                 min_timestamp,
                 Some(&mut elements),
+                None,
             )
             .expect("parse must succeed");
 

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/mod.rs
@@ -334,11 +334,13 @@ struct RowHeader {
     /// This is the `expires_at` for the row liveness — distinct from
     /// `local_deletion_time` which is the GC-grace clock for row tombstones.
     /// `None` when `HAS_TTL` was not set.
-    /// Only read by the delta-scan emit path (`parse_block_emit_delta`); allow it
-    /// to be unused when that feature is off so non-delta builds compile under
-    /// `-D warnings`.
-    #[cfg_attr(not(feature = "delta-scan"), allow(dead_code))]
-    liveness_expires_at_seconds: Option<i32>,
+    ///
+    /// Stored as `i64` (not `i32`): on oa/da (`hasUIntDeletionTime`) a post-2038 expiry
+    /// is decoded as an UNSIGNED 32-bit value in `[2^31, 2^32)`; keeping it `i64`
+    /// preserves the large positive second count so the read-time TTL filter does not
+    /// wrap it negative and hide a still-live row (#1741 F1). See the decode site in
+    /// `row_framing.rs` for the reinterpretation.
+    liveness_expires_at_seconds: Option<i64>,
     /// Row-level local deletion time in SECONDS (after delta decoding from
     /// min_local_deletion_time). This is the GC-grace clock, NOT the reconciliation
     /// timestamp; do not use it for last-write-wins comparisons.
@@ -358,6 +360,22 @@ struct RowHeader {
     /// bit=1 means column missing, bit=0 means column present.
     /// None when HAS_ALL_COLUMNS flag is set.
     missing_columns_bitmap: Option<u64>,
+    /// Issue #1741 read-side shadowing aggregate: max write timestamp (µs) across
+    /// this row's decoded DATA cells (excludes partition/clustering pseudo-cells;
+    /// a cell inheriting the row timestamp contributes the row liveness timestamp,
+    /// and a non-frozen collection contributes its newest element ts). Includes
+    /// shadow/TTL-dropped cells so a fully-reduced row is still recognised as
+    /// shadowed. `None` when the row decoded no data cell (e.g. a truncated parse).
+    /// Combined with `timestamp` to decide whether a tombstone shadows the WHOLE row.
+    max_data_cell_timestamp: Option<i64>,
+    /// Issue #1741: max effective expiry (epoch seconds) across this row's expiring
+    /// DATA cells (explicit per-cell TTL or a `USE_ROW_TTL` cell inheriting the
+    /// row's expiry; includes expired cells). `None` when none is expiring.
+    max_data_cell_expires_at: Option<i64>,
+    /// Issue #1741: `true` when at least one decoded DATA cell is LIVE (not
+    /// shadowed, not expired) and live-forever (no TTL). Keeps the row visible
+    /// regardless of liveness expiry. A shadowed/expired cell never sets this.
+    has_live_forever_data_cell: bool,
 }
 
 impl RowHeader {
@@ -408,6 +426,61 @@ impl RowHeader {
                 .unwrap_or(0),
         }
     }
+
+    /// Issue #1741: the row's maximum write timestamp (µs) across its liveness and
+    /// decoded data cells. Used for partition/range-tombstone shadowing.
+    fn max_write_timestamp(&self) -> i64 {
+        let mut m = self.timestamp.unwrap_or(i64::MIN);
+        if let Some(c) = self.max_data_cell_timestamp {
+            if c > m {
+                m = c;
+            }
+        }
+        m
+    }
+
+    /// Issue #1741: `true` when a deletion at `deleted_at_micros` shadows the WHOLE
+    /// row — i.e. every piece of the row's data is older than (or equal to) the
+    /// deletion. Follows Cassandra `DeletionTime.deletes(ts) = ts <= markedForDeleteAt`.
+    ///
+    /// Fail-safe: a row with NO authoritative timestamp (the `i64::MIN` sentinel —
+    /// no liveness and no decodable data cell, e.g. an empty/undecodable row) is
+    /// NOT shadowed. We only hide a row when authoritative metadata proves it
+    /// predates the deletion, never by guessing (no-heuristics mandate, issue #28).
+    fn shadowed_by_deletion_at(&self, deleted_at_micros: i64) -> bool {
+        let max_ts = self.max_write_timestamp();
+        max_ts != i64::MIN && max_ts <= deleted_at_micros
+    }
+
+    /// Issue #1741: read-time TTL expiry. `true` iff the row carries a TTL somewhere
+    /// AND every piece of its data (primary-key liveness + cells) has expired at
+    /// `now_secs`, matching what a Cassandra `SELECT` hides. Returns `false` for any
+    /// row with no TTL at all (never touches the tombstone-free common case).
+    fn row_liveness_expired(&self, now_secs: i64) -> bool {
+        let has_ttl =
+            self.liveness_expires_at_seconds.is_some() || self.max_data_cell_expires_at.is_some();
+        if !has_ttl {
+            return false;
+        }
+        // A live-forever data cell (written with no TTL) keeps the row visible.
+        if self.has_live_forever_data_cell {
+            return false;
+        }
+        // Primary-key liveness still live? Present iff HAS_TIMESTAMP; live-forever
+        // when it carries no TTL expiry, otherwise live until its expiry passes.
+        let liveness_live = self.timestamp.is_some()
+            && self
+                .liveness_expires_at_seconds
+                .is_none_or(|s| s > now_secs);
+        if liveness_live {
+            return false;
+        }
+        // Any expiring data cell still live keeps the row visible.
+        if self.max_data_cell_expires_at.is_some_and(|e| e > now_secs) {
+            return false;
+        }
+        true
+    }
 }
 
 /// Result of parsing a single complex cell (an element of a list/set, or a
@@ -448,6 +521,42 @@ struct ComplexCellParse {
     /// `as u32 as i32` representation (epic #899 invariant). `None` when the
     /// element carries no local deletion time.
     element_local_deletion_time: Option<i32>,
+    /// Issue #1741 (Finding 3): whether the element carries the IS_EXPIRING
+    /// (0x02) flag, i.e. it has a TTL (either an explicit per-element TTL, or an
+    /// inherited row TTL via `USE_ROW_TTL`). Needed for read-time collection-TTL
+    /// expiry: an expiring element is NOT live-forever, so an otherwise-expired
+    /// row must not be kept alive merely because it carries such an element.
+    is_expiring: bool,
+}
+
+/// Issue #1741 (per-element filtering): read-side per-element shadow/TTL filter
+/// context threaded into the complex-column element loop. `Some` ONLY on the
+/// user-facing SELECT read path (a covering partition/range deletion and/or the
+/// read clock is active); `None` for every physical consumer (compaction /
+/// delta-scan / unit tests), which stay byte-unchanged (the filter never drops an
+/// element when it is `None`).
+#[derive(Clone, Copy)]
+pub(crate) struct ElementShadow {
+    /// Covering deletion `markedForDeleteAt` (µs) for the row this collection
+    /// belongs to (the partition tombstone folded with the open range tombstone
+    /// when the row falls inside it), or `None` when nothing covers the row.
+    pub cover: Option<i64>,
+    /// Read clock (epoch seconds) for per-element TTL expiry.
+    pub now: i64,
+    /// Row-liveness write timestamp (µs) inherited by `USE_ROW_TIMESTAMP` elements
+    /// (flag 0x08 — the element carries no own timestamp); `None` when the row
+    /// carries no liveness marker, in which case such an element has no
+    /// authoritative write ts and is NEVER shadowed (no-heuristics, issue #28).
+    pub row_ts: Option<i64>,
+    /// Row-liveness expiry (epoch seconds) inherited by `USE_ROW_TTL` elements
+    /// (flag 0x10 — an expiring element that carries NO explicit per-element
+    /// `localDeletionTime`). This is the SAME effective row expiry the scalar
+    /// `USE_ROW_TTL` cell path computes (`liveness_expires_at_seconds`, falling
+    /// back to the row `local_deletion_time`), so scalar and collection-element
+    /// inherited-TTL semantics stay identical (issue #1741). `None` when the row
+    /// carries no liveness expiry, in which case such an element has no
+    /// authoritative expiry and is never TTL-expired here (no-heuristics, issue #28).
+    pub row_expires_at: Option<i64>,
 }
 
 /// Extra metadata produced by `parse_complex_column_inner` for delta-scan callers
@@ -478,6 +587,28 @@ pub(crate) struct ComplexColumnMeta {
     /// compaction read path to populate `ComplexColumn.complex_deletion`.
     /// Always `None` on the user-facing read path (where the field is unused).
     pub complex_deletion: Option<(i64, i32)>,
+    /// Issue #1741 (Finding 3): read-time TTL aggregate over this collection's
+    /// LIVE (non-deleted) elements. `true` when at least one live element carries
+    /// no TTL of any kind (genuinely live-forever) — such an element keeps the
+    /// row visible regardless of the row-liveness TTL. Computed from authoritative
+    /// per-element cell flags (no heuristics), scalar-only (no extra allocation).
+    pub has_live_forever_element: bool,
+    /// Issue #1741 (Finding 3): max effective expiry (epoch seconds) across this
+    /// collection's live elements that carry an EXPLICIT per-element TTL. `None`
+    /// when no live element has an explicit expiry (elements that inherit the row
+    /// TTL via `USE_ROW_TTL` are governed by the row-liveness expiry instead).
+    /// Folded into the row's `max_data_cell_expires_at` so a collection whose
+    /// elements are all expired does not keep an otherwise-expired row alive.
+    pub max_element_expires_at: Option<i64>,
+    /// Issue #1741 (per-element filtering): number of LIVE (non-tombstone)
+    /// elements DROPPED from the emitted container by the read-side per-element
+    /// shadow/TTL filter — i.e. elements shadowed by the covering deletion (own
+    /// write ts `<= cover`) or TTL-expired at the read clock. Always `0` for every
+    /// physical consumer (the filter is `None`), so their output is byte-unchanged.
+    /// The read call site uses `> 0` (together with an emptied container) to tell a
+    /// collection that the filter reduced to nothing (read as absent/null) apart
+    /// from one that was genuinely empty / all element-tombstones (kept as-is).
+    pub shadow_filtered_element_count: usize,
 }
 
 // Row header flag constants
@@ -501,6 +632,59 @@ fn row_has_non_key_cell(cells: &HashMap<Arc<str>, Value>, schema: &TableSchema) 
         !schema.partition_keys.iter().any(|k| k.name == name)
             && !schema.clustering_keys.iter().any(|c| c.name == name)
     })
+}
+
+/// Issue #932/#1741: build the user-facing `ScanRow` display value for a parsed
+/// clustering row from its decoded `cells` and row header. Shared by every
+/// user-facing emit path so the row-tombstone display rule lives in ONE place:
+/// a `HAS_DELETION` row that carries NO surviving non-key cell displays as a pure
+/// `Tombstone` marker (suppressed downstream by `filter_tombstone`); a row that
+/// still carries surviving cells displays as a live `Row` (the deletion shadows
+/// only already-absent older cells). An empty cell set becomes a null marker.
+fn build_display_row(
+    cells: HashMap<Arc<str>, Value>,
+    row_header_opt: Option<&RowHeader>,
+    schema: &TableSchema,
+) -> ScanRow {
+    let row_tombstone = row_header_opt.filter(|h| h.is_row_tombstone());
+    let has_data_cell = row_has_non_key_cell(&cells, schema);
+    if row_tombstone.is_some() && !has_data_cell {
+        ScanRow::Marker(
+            row_tombstone
+                .map(|h| h.row_tombstone())
+                .unwrap_or(Value::Null),
+        )
+    } else if cells.is_empty() {
+        ScanRow::Marker(Value::Null)
+    } else {
+        // Issue #1334: carry the interned `Arc<str>` name handles straight into
+        // the row carrier; emit-time alphabetical ordering preserved exactly.
+        let mut row_cells: RowCells = cells.into_iter().collect();
+        row_cells.sort_by(|a, b| a.0.as_ref().cmp(b.0.as_ref()));
+        ScanRow::Row(row_cells)
+    }
+}
+
+/// Issue #1741: extract a clustering row's clustering-key values (in schema
+/// clustering order) from its decoded cell map. Only called when a range
+/// tombstone is currently OPEN in the partition, so the per-row clone is off the
+/// tombstone-free hot path. Returns fewer values than the clustering arity only
+/// for a malformed/partial row (missing clustering pseudo-cells).
+fn extract_clustering_values(cells: &HashMap<Arc<str>, Value>, schema: &TableSchema) -> Vec<Value> {
+    schema
+        .clustering_keys
+        .iter()
+        .filter_map(|ck| cells.get(ck.name.as_str()).cloned())
+        .collect()
+}
+
+/// Issue #1741: current wall-clock as epoch seconds, for read-time TTL expiry.
+/// Falls back to `0` (nothing appears expired) if the clock is before the epoch.
+fn now_epoch_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
 }
 
 // Unfiltered marker constants (from Cassandra UnfilteredSerializer.java lines 102-109)
@@ -536,6 +720,24 @@ pub struct V5CompressedLegacyParser {
     /// identical to the existing `nb`-compatible path regardless of the gate
     /// values stored here.
     version_gates: std::sync::Arc<VersionGates>,
+    /// Issue #1741: apply read-side SELECT-semantic shadowing (hide partition/
+    /// range-tombstone-shadowed and TTL-expired rows) in the emit paths. `true`
+    /// ONLY for user-facing query reads (`scan`/`scan_stream`/`scan_with_cell_metadata`/
+    /// point `get`). `false` (the default) for PHYSICAL consumers that must see every
+    /// on-disk row — integrity verification (`get_all_entries` → `verify_sstable`),
+    /// `sstable_data_manager`, delta-scan, and the compaction read path (which
+    /// reconciles tombstones itself across generations). Un-gated: read correctness
+    /// does not depend on the `write-support` feature (AC2).
+    read_shadowing: bool,
+    /// Issue #1741 (F2): the read-time TTL "now" clock (epoch seconds), captured ONCE
+    /// when this parser (the user-facing scan/read context) is constructed and reused
+    /// for EVERY shadowing decision across all blocks/partitions of the read. A single
+    /// scan builds this parser once and drives many blocks through it, so sampling the
+    /// clock here — rather than per block in the emit loop — gives one consistent `now`
+    /// for the whole operation (a row exactly at an expiration-second boundary is then
+    /// decided uniformly regardless of which block parsed it). Only consulted when
+    /// `read_shadowing` is `true`; physical consumers ignore it and stay byte-unchanged.
+    now_secs: i64,
 }
 
 mod block_emit;
@@ -544,14 +746,32 @@ mod cell_value;
 mod compaction;
 mod complex_column;
 mod frozen;
+mod partition_shadow;
 mod raw_type_value;
 mod raw_value;
 mod row_data;
 mod row_framing;
 mod udt;
 
+use partition_shadow::{clustering_reversed_flags, PartitionShadow};
+// #1741: shared partition-header need-more classifier used by both sliding
+// parsers (`block_emit_windowed` + `compaction`) via their `use super::*` glob.
+use row_framing::PartitionHeaderReadiness;
+
 #[cfg(test)]
 mod test_support;
+
+#[cfg(test)]
+mod regression_1741c_tests;
+
+#[cfg(test)]
+mod regression_1741d_tests;
+
+#[cfg(test)]
+mod regression_1741h_tests;
+
+#[cfg(test)]
+mod regression_1741k_tests;
 
 impl V5CompressedLegacyParser {
     /// Create a new V5CompressedLegacy parser
@@ -580,7 +800,19 @@ impl V5CompressedLegacyParser {
             min_ttl,
             udt_registry: None,
             version_gates,
+            read_shadowing: false,
+            // Issue #1741 (F2): sample the read clock ONCE per parser (== once per
+            // read/scan operation); every block/partition below reuses this value.
+            now_secs: now_epoch_secs(),
         }
+    }
+
+    /// Issue #1741: enable read-side SELECT-semantic shadowing on this parser. Call
+    /// with `true` ONLY when building the parser for a user-facing query read; leave
+    /// the default (`false`) for physical/verification/compaction/delta reads.
+    pub fn with_read_shadowing(mut self, on: bool) -> Self {
+        self.read_shadowing = on;
+        self
     }
 
     /// Set the version gates for version-sensitive parsing decisions (VG1 plumbing).
@@ -608,6 +840,28 @@ impl V5CompressedLegacyParser {
             VersionGates::Big(g) => g.has_uint_deletion_time,
             VersionGates::Bti(g) => g.has_uint_deletion_time,
         }
+    }
+
+    /// Issue #1741 (Finding 2): `true` when this SSTable's authoritative
+    /// EncodingStats prove it carries NO deletions of any kind — hence NO range
+    /// tombstones. A clustering-slice read can then keep the O(slice) row-index
+    /// fast-forward and skip prefix priming entirely (a range tombstone opening
+    /// before the slice is impossible).
+    ///
+    /// `min_local_deletion_time` is `EncodingStats.minLocalDeletionTime`, the MIN
+    /// of every cell's `localDeletionTime`. A live cell contributes the LIVE
+    /// sentinel `Cell.NO_DELETION_TIME == Integer.MAX_VALUE`; a partition/row/
+    /// range/cell tombstone OR an expiring cell contributes a smaller value. So
+    /// the min equals `Integer.MAX_VALUE` iff the SSTable has no deletion and no
+    /// TTL. This OVER-approximates range-tombstone presence (a cell tombstone or
+    /// TTL also trips it), which is safe: priming then runs and stays correct. No
+    /// stats (`min == 0` from the `build_v5_parser` fallback) conservatively primes.
+    /// No heuristics — authoritative metadata only (issue #28).
+    #[inline]
+    fn sstable_may_have_range_tombstones(&self) -> bool {
+        // Integer.MAX_VALUE — Cassandra `Cell.NO_DELETION_TIME` LIVE sentinel.
+        const NO_DELETION_TIME: i64 = i32::MAX as i64;
+        self.min_local_deletion_time != NO_DELETION_TIME
     }
 
     /// Try to parse partition header at offset WITHOUT consuming it.

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/partition_shadow.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/partition_shadow.rs
@@ -1,0 +1,505 @@
+//! Read-side tombstone/TTL shadowing for a single partition (issue #1741).
+//!
+//! Single-generation / full-scan reads historically bypassed reconciliation and
+//! returned partition-deleted, range-tombstoned, or TTL-expired data as live. This
+//! helper restores Cassandra `SELECT` semantics on the READ path without routing
+//! through the write-support `ReconcileState`: it captures the partition-level
+//! deletion, tracks the currently-open range tombstone as the row stream is walked
+//! in clustering order, and decides per row whether a user-facing scan must hide it.
+//!
+//! It is **un-gated** — NOT behind the `write-support` feature — because read
+//! correctness must not depend on a write feature (AC2). It is shared by every
+//! user-facing emit path so there is ONE read-side shadowing implementation.
+//!
+//! Timestamp comparisons follow Cassandra `DeletionTime.deletes(ts) = ts <=
+//! markedForDeleteAt`: a deletion at `d` shadows the whole row iff every piece of
+//! the row's data is older than (or equal to) `d`. A row that still carries a cell
+//! strictly newer than the deletion survives (the deletion shadows only the
+//! already-absent older cells), matching the row-tombstone coexistence rule (#932).
+
+use super::*;
+
+/// Authoritative per-clustering-column reversal flags for `schema`, in schema
+/// clustering-key order: `true` for a column declared `CLUSTERING ORDER BY
+/// (... DESC)`, `false` for ASC (issue #1741). Threaded into [`PartitionShadow`]
+/// so range-tombstone coverage compares clustering prefixes in physical storage
+/// order. Same `is_reversed` derivation the BTI reader uses
+/// (`data_access/bti.rs`). No-heuristics: schema clustering order only.
+pub(super) fn clustering_reversed_flags(schema: &crate::schema::TableSchema) -> Vec<bool> {
+    schema
+        .clustering_keys
+        .iter()
+        .map(|c| matches!(c.order, crate::schema::ClusteringOrder::Desc))
+        .collect()
+}
+
+/// Per-partition read-side shadowing state (issue #1741).
+pub(super) struct PartitionShadow {
+    /// Partition-level `markedForDeleteAt` (µs), or `None` when the partition is live.
+    partition_deletion: Option<i64>,
+    /// The currently-open range tombstone: `(start_bound_values, start_inclusive,
+    /// deleted_at_µs)`. Cassandra writes non-overlapping range tombstones in
+    /// clustering order — a start marker opens a range, an end marker closes it, and
+    /// a boundary marker closes one and opens the next — so at most ONE range is open
+    /// at a time. Every row physically between the open start marker and its
+    /// (not-yet-seen) end marker falls inside the range, so a row is covered while
+    /// the range is open iff it is at/after the start bound.
+    open_range: Option<(Vec<Value>, bool, i64)>,
+    /// Current wall-clock, epoch seconds, for read-time TTL expiry.
+    now_secs: i64,
+    /// Per-clustering-column reversal flags in schema order: `true` for a column
+    /// declared `CLUSTERING ORDER BY (... DESC)`. Range-tombstone coverage must
+    /// compare a row's clustering prefix against the range bounds in PHYSICAL
+    /// storage order, which for a DESC column is the reverse of value order — so
+    /// this carries the authoritative schema clustering order into the coverage
+    /// FSM. A missing/short entry is treated as ASC (`false`), matching the
+    /// `is_reversed` idiom used by the sibling reader code (`data_access/bti.rs`).
+    /// No-heuristics: sourced only from `TableSchema::clustering_keys`.
+    clustering_reversed: Vec<bool>,
+}
+
+impl PartitionShadow {
+    /// Open shadowing for a partition given its decoded partition-level deletion
+    /// (`Some((markedForDeleteAt_µs, localDeletionTime_s))` when the partition
+    /// carries a tombstone, `None` when live), the current epoch-seconds clock, and
+    /// the per-clustering-column reversal flags (`true` = DESC) in schema order.
+    pub(super) fn open(
+        now_secs: i64,
+        partition_deletion: Option<(i64, i32)>,
+        clustering_reversed: Vec<bool>,
+    ) -> Self {
+        Self {
+            partition_deletion: partition_deletion.map(|(mfda, _ldt)| mfda),
+            open_range: None,
+            now_secs,
+            clustering_reversed,
+        }
+    }
+
+    /// Feed one decoded range-tombstone bound marker, running the same start/end/
+    /// boundary FSM the delta-scan path uses. `bound_kind` is the raw Cassandra
+    /// `ClusteringPrefix.Kind` ordinal; `deleted_at_secondary` is present only for
+    /// boundary markers (kind 2/5) and carries the new range's deletion time.
+    pub(super) fn feed_range_marker(
+        &mut self,
+        bound_values: Vec<Value>,
+        bound_kind: u8,
+        deleted_at_primary: i64,
+        deleted_at_secondary: Option<i64>,
+    ) -> Result<()> {
+        match bound_kind {
+            // Simple start bound: open a range (INCL_START=1, EXCL_START=7).
+            1 | 7 => {
+                self.open_range = Some((bound_values, bound_kind == 1, deleted_at_primary));
+            }
+            // Simple end bound: close the open range (EXCL_END=0, INCL_END=6).
+            0 | 6 => {
+                self.open_range = None;
+            }
+            // EXCL_END_INCL_START_BOUNDARY: close prev, open new range (inclusive start).
+            2 => {
+                let d = deleted_at_secondary.unwrap_or(deleted_at_primary);
+                self.open_range = Some((bound_values, true, d));
+            }
+            // INCL_END_EXCL_START_BOUNDARY: close prev, open new range (exclusive start).
+            5 => {
+                let d = deleted_at_secondary.unwrap_or(deleted_at_primary);
+                self.open_range = Some((bound_values, false, d));
+            }
+            unknown => {
+                return Err(Error::corruption(format!(
+                    "read-shadow: unknown range tombstone bound kind {unknown} — cannot represent \
+                     faithfully (no-heuristics mandate, issue #28)"
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// `true` when the row's clustering values must be extracted for a coverage
+    /// check — i.e. a range tombstone is currently open. The tombstone-free common
+    /// case returns `false`, so the caller skips the per-row clustering clone.
+    pub(super) fn needs_clustering(&self) -> bool {
+        self.open_range.is_some()
+    }
+
+    /// `true` when a user-facing `SELECT` must HIDE this row: it is shadowed by the
+    /// partition tombstone or the open range tombstone (all of the row's data is
+    /// older than the deletion), or it is TTL-expired. `clustering` is the row's
+    /// clustering-key values (needed only for range coverage; pass an empty slice
+    /// when [`Self::needs_clustering`] is `false`).
+    pub(super) fn row_hidden(&self, header: &RowHeader, clustering: &[Value]) -> bool {
+        // Partition-level deletion shadows every row whose data predates it.
+        if let Some(d) = self.partition_deletion {
+            if header.shadowed_by_deletion_at(d) {
+                return true;
+            }
+        }
+        // Open range tombstone shadows covered rows whose data predates it.
+        if let Some((start, inclusive, d)) = &self.open_range {
+            if self.at_or_after_start(clustering, start, *inclusive)
+                && header.shadowed_by_deletion_at(*d)
+            {
+                return true;
+            }
+        }
+        // Read-time TTL expiry.
+        header.row_liveness_expired(self.now_secs)
+    }
+
+    /// Whether `row_ck` lies at/after the range's start bound in PHYSICAL storage
+    /// order. While a range is open its end has not yet been seen, so a covered row
+    /// need only satisfy the start bound. Comparison honours the per-column
+    /// clustering order: for a DESC column the physical order is the reverse of
+    /// value order, so we reverse that component's comparison — the same rule
+    /// [`crate::storage::write_engine::mutation::ClusteringKey::compare`] applies
+    /// (`ordering.reverse()` when the column is `ClusteringOrder::Desc`). Using the
+    /// threaded `clustering_reversed` flags keeps this schema-authoritative with no
+    /// per-row allocation (we compare the borrowed `Value` slices in place rather
+    /// than materialising `ClusteringKey`/`TableSchema` per row). A prefix start
+    /// bound (fewer components than the clustering arity) treats its missing
+    /// components as −∞, per Cassandra clustering-bound semantics.
+    fn at_or_after_start(&self, row_ck: &[Value], start: &[Value], inclusive: bool) -> bool {
+        // Unbounded (open) start covers everything.
+        if start.is_empty() {
+            return true;
+        }
+        for (i, (a, b)) in row_ck.iter().zip(start.iter()).enumerate() {
+            // Clustering-key values share a type per component, so `partial_cmp`
+            // yields a total order here; fall back to Equal defensively.
+            let mut ord = a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal);
+            // DESC column: physical order is the reverse of value order.
+            if self.clustering_reversed.get(i).copied().unwrap_or(false) {
+                ord = ord.reverse();
+            }
+            match ord {
+                std::cmp::Ordering::Less => return false,
+                std::cmp::Ordering::Greater => return true,
+                std::cmp::Ordering::Equal => {}
+            }
+        }
+        // All compared components equal.
+        match row_ck.len().cmp(&start.len()) {
+            // Row extends a shorter (prefix) start bound: its missing components are
+            // −∞, so the row is strictly after the start ⇒ covered.
+            std::cmp::Ordering::Greater => true,
+            // Row is a prefix of a longer start bound (fewer clustering components
+            // than the bound) — not a well-formed data row; treat as before start.
+            std::cmp::Ordering::Less => false,
+            // Exact boundary point: covered only when the start bound is inclusive.
+            std::cmp::Ordering::Equal => inclusive,
+        }
+    }
+
+    /// The effective covering deletion timestamp (µs) for a row with clustering prefix
+    /// `clustering`: the partition tombstone `markedForDeleteAt`, folded with the open
+    /// range tombstone's `deleted_at` when the row falls inside the range. `None` when
+    /// nothing covers the row. Shared by per-cell shadow filtering (issue #1741,
+    /// Finding 1) and the primary-key-liveness decision below.
+    pub(super) fn covering_deleted_at(&self, clustering: &[Value]) -> Option<i64> {
+        let mut cover = self.partition_deletion;
+        if let Some((start, inclusive, d)) = &self.open_range {
+            if self.at_or_after_start(clustering, start, *inclusive) {
+                cover = Some(cover.map_or(*d, |c| c.max(*d)));
+            }
+        }
+        cover
+    }
+
+    /// Per-cell shadow context for the row-data cell loop (issue #1741, Finding 1):
+    /// `(covering_deleted_at, now_secs)`. A data cell is dropped when its effective
+    /// write ts <= `covering_deleted_at`, or it is TTL-expired at `now_secs`.
+    pub(super) fn cell_context(&self, clustering: &[Value]) -> (Option<i64>, i64) {
+        (self.covering_deleted_at(clustering), self.now_secs)
+    }
+
+    /// Whether a data cell is dropped by read-side shadow/TTL filtering (issue #1741,
+    /// Finding 1): its effective write ts is shadowed by the covering deletion
+    /// (`eff_ts <= cover`, matching `DeletionTime.deletes`), OR it is TTL-expired at
+    /// `now` (`eff_exp <= now`). A cell with no authoritative write ts is NEVER
+    /// shadowed (no-heuristics: we hide only what authoritative metadata proves
+    /// stale). Associated function so both the row-data cell loop and its unit pins
+    /// share one decision.
+    pub(super) fn cell_shadowed_or_expired(
+        cover: Option<i64>,
+        now: i64,
+        eff_ts: Option<i64>,
+        eff_exp: Option<i64>,
+    ) -> bool {
+        let shadowed = matches!((cover, eff_ts), (Some(d), Some(t)) if t <= d);
+        let expired = eff_exp.is_some_and(|e| e <= now);
+        shadowed || expired
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Issue #1741: deterministic pins for the read-side shadowing primitives.
+    //! These exercise the exact partition-deletion, range-tombstone-FSM, and TTL
+    //! decision logic the emit paths call, independent of on-disk fixtures.
+    use super::*;
+
+    /// Build a `RowHeader` describing a live row whose max data timestamp is
+    /// `write_ts_micros` and (optionally) whose row-liveness TTL expires at
+    /// `liveness_expiry_secs`. `has_live_forever` marks a no-TTL data cell.
+    fn row(
+        write_ts_micros: i64,
+        liveness_expiry_secs: Option<i64>,
+        max_cell_expires_at_secs: Option<i64>,
+        has_live_forever: bool,
+    ) -> RowHeader {
+        RowHeader {
+            timestamp: Some(write_ts_micros),
+            ttl: None,
+            liveness_expires_at_seconds: liveness_expiry_secs,
+            local_deletion_time: None,
+            marked_for_delete_at: None,
+            header_size: 0,
+            row_size_vint_len: 0,
+            missing_columns_bitmap: None,
+            max_data_cell_timestamp: Some(write_ts_micros),
+            max_data_cell_expires_at: max_cell_expires_at_secs,
+            has_live_forever_data_cell: has_live_forever,
+        }
+    }
+
+    #[test]
+    fn partition_deletion_shadows_only_older_or_equal_rows() {
+        // Partition tombstone at markedForDeleteAt = 2000µs.
+        let shadow = PartitionShadow::open(0, Some((2000, 12345)), vec![]);
+        // Row older than the deletion → hidden.
+        assert!(shadow.row_hidden(&row(1000, None, None, false), &[]));
+        // Row exactly at the deletion → hidden (deletes: ts <= markedForDeleteAt).
+        assert!(shadow.row_hidden(&row(2000, None, None, false), &[]));
+        // Row strictly newer than the deletion → survives.
+        assert!(!shadow.row_hidden(&row(3000, None, None, false), &[]));
+    }
+
+    #[test]
+    fn row_with_no_authoritative_timestamp_is_not_shadowed() {
+        // A row with no liveness and no decodable data cell (max_ts = i64::MIN, e.g.
+        // an empty/undecodable row) must NOT be hidden — we only shadow when
+        // authoritative metadata proves the row predates the deletion (no guessing).
+        let mut h = row(0, None, None, false);
+        h.timestamp = None;
+        h.max_data_cell_timestamp = None;
+        let shadow = PartitionShadow::open(0, Some((8_000_000_000_000_000_000, 12345)), vec![]);
+        assert!(!shadow.row_hidden(&h, &[]));
+    }
+
+    #[test]
+    fn live_partition_hides_nothing() {
+        let shadow = PartitionShadow::open(0, None, vec![]);
+        assert!(!shadow.row_hidden(&row(1000, None, None, false), &[]));
+    }
+
+    #[test]
+    fn range_tombstone_fsm_shadows_covered_older_rows() {
+        // ASC single clustering column (no reversal). INCL_START at ck=[10],
+        // INCL_END at ck=[20], deleted_at = 5000µs.
+        let mut shadow = PartitionShadow::open(0, None, vec![false]);
+        shadow
+            .feed_range_marker(vec![Value::Integer(10)], 1, 5000, None)
+            .unwrap();
+        assert!(shadow.needs_clustering());
+        // Covered older row (ck=15, ts < deleted_at) → hidden.
+        assert!(shadow.row_hidden(&row(1000, None, None, false), &[Value::Integer(15)]));
+        // Covered but strictly-newer row (ts > deleted_at) → survives.
+        assert!(!shadow.row_hidden(&row(9000, None, None, false), &[Value::Integer(15)]));
+        // Row before the open start bound (ck=5) → not covered → survives.
+        assert!(!shadow.row_hidden(&row(1000, None, None, false), &[Value::Integer(5)]));
+        // Close the range; subsequent rows are no longer covered.
+        shadow
+            .feed_range_marker(vec![Value::Integer(20)], 6, 5000, None)
+            .unwrap();
+        assert!(!shadow.needs_clustering());
+        assert!(!shadow.row_hidden(&row(1000, None, None, false), &[Value::Integer(15)]));
+    }
+
+    #[test]
+    fn range_tombstone_coverage_honors_desc_clustering_order() {
+        // Table with `CLUSTERING ORDER BY (ck DESC)`: physical storage order is the
+        // REVERSE of value order, so an INCL_START marker at ck=[10] opens a range
+        // that physically covers rows with ck < 10 (which come AFTER [10] on disk),
+        // NOT rows with ck > 10. deleted_at = 5000µs; rows below are older (ts=1000).
+        //
+        // Revert-verify: with the pre-fix raw `partial_cmp` (ignoring DESC), the
+        // coverage sides invert — ck=15 is wrongly hidden and ck=5 wrongly kept.
+        let mut shadow = PartitionShadow::open(0, None, vec![true]);
+        shadow
+            .feed_range_marker(vec![Value::Integer(10)], 1, 5000, None)
+            .unwrap();
+        assert!(shadow.needs_clustering());
+        // ck=5 is physically AFTER the DESC start [10] → covered → hidden.
+        assert!(shadow.row_hidden(&row(1000, None, None, false), &[Value::Integer(5)]));
+        // ck=15 is physically BEFORE the DESC start [10] → not covered → survives.
+        assert!(!shadow.row_hidden(&row(1000, None, None, false), &[Value::Integer(15)]));
+        // Exact inclusive boundary ck=10 → covered → hidden.
+        assert!(shadow.row_hidden(&row(1000, None, None, false), &[Value::Integer(10)]));
+        // A covered DESC row that is strictly newer than the deletion still survives.
+        assert!(!shadow.row_hidden(&row(9000, None, None, false), &[Value::Integer(5)]));
+    }
+
+    #[test]
+    fn range_tombstone_boundary_reopens_new_range() {
+        // EXCL_END_INCL_START_BOUNDARY (kind 2) closes the prev range and opens a new
+        // one (inclusive start) using the secondary deletion time.
+        let mut shadow = PartitionShadow::open(0, None, vec![false]);
+        shadow
+            .feed_range_marker(vec![Value::Integer(10)], 2, 5000, Some(6000))
+            .unwrap();
+        // New range starts inclusive at ck=10 with deleted_at=6000.
+        assert!(shadow.row_hidden(&row(5500, None, None, false), &[Value::Integer(12)]));
+        assert!(!shadow.row_hidden(&row(7000, None, None, false), &[Value::Integer(12)]));
+    }
+
+    #[test]
+    fn unknown_bound_kind_is_rejected() {
+        let mut shadow = PartitionShadow::open(0, None, vec![false]);
+        assert!(shadow
+            .feed_range_marker(vec![Value::Integer(1)], 9, 1, None)
+            .is_err());
+    }
+
+    #[test]
+    fn ttl_expired_row_is_hidden_and_live_ttl_is_kept() {
+        // now = 1_000_000 epoch-seconds.
+        let now = 1_000_000i64;
+        let shadow = PartitionShadow::open(now, None, vec![]);
+        // Row-liveness TTL already expired, no live-forever cell → hidden.
+        assert!(shadow.row_hidden(&row(10, Some(500_000), None, false), &[]));
+        // Row-liveness TTL still in the future → visible.
+        assert!(!shadow.row_hidden(&row(10, Some(2_000_000), None, false), &[]));
+        // Expired liveness but a live-forever data cell (later UPDATE) → visible.
+        assert!(!shadow.row_hidden(&row(10, Some(500_000), None, true), &[]));
+        // Expired liveness, only expiring cells whose max expiry is still future → visible.
+        assert!(!shadow.row_hidden(&row(10, Some(500_000), Some(2_000_000), false), &[]));
+        // Row with NO TTL anywhere is never TTL-hidden.
+        assert!(!shadow.row_hidden(&row(10, None, None, false), &[]));
+    }
+
+    /// Issue #1741 (Finding 1, test 2 / per-cell drop decision): a data cell is
+    /// dropped when its effective write ts is shadowed by the covering deletion OR it
+    /// is TTL-expired at `now`; a cell without an authoritative write ts is never
+    /// shadowed. The per-cell TTL branch is pinned here (not end-to-end) because the
+    /// writer stamps an expiring cell's `localDeletionTime` as `now + ttl`, so a
+    /// PAST-expired per-cell TTL is not synthesizable via a fresh writer flush; the
+    /// row-data cell loop calls exactly this function.
+    ///
+    /// Revert-verify: dropping the `expired` term makes the TTL assertions FALSE;
+    /// dropping the `shadowed` term makes the shadow assertions FALSE.
+    #[test]
+    fn per_cell_shadow_and_ttl_drop_decision() {
+        use super::PartitionShadow as PS;
+        let now = 1_000_000i64;
+        // Shadow: cell older/equal to the covering deletion (2000µs) → dropped.
+        assert!(PS::cell_shadowed_or_expired(
+            Some(2000),
+            now,
+            Some(1000),
+            None
+        ));
+        assert!(PS::cell_shadowed_or_expired(
+            Some(2000),
+            now,
+            Some(2000),
+            None
+        ));
+        // Shadow: cell strictly newer than the deletion → kept.
+        assert!(!PS::cell_shadowed_or_expired(
+            Some(2000),
+            now,
+            Some(3000),
+            None
+        ));
+        // No covering deletion → never shadowed.
+        assert!(!PS::cell_shadowed_or_expired(None, now, Some(1), None));
+        // No authoritative write ts → never shadowed (no-heuristics).
+        assert!(!PS::cell_shadowed_or_expired(Some(2000), now, None, None));
+        // TTL: expiry at/BEFORE now → expired → dropped (regardless of covering).
+        assert!(PS::cell_shadowed_or_expired(
+            None,
+            now,
+            Some(9999),
+            Some(now)
+        ));
+        assert!(PS::cell_shadowed_or_expired(
+            None,
+            now,
+            Some(9999),
+            Some(now - 1)
+        ));
+        // TTL: expiry in the future → kept.
+        assert!(!PS::cell_shadowed_or_expired(
+            None,
+            now,
+            Some(9999),
+            Some(now + 1)
+        ));
+    }
+
+    /// Issue #1741 (Finding 1, test 3): a row whose non-key data cells are ALL
+    /// shadowed/expired and which has no live pk-liveness marker must be hidden. The
+    /// row-data cell loop drops the stale cells from the emitted map BUT still folds
+    /// their write ts / expiry into the row aggregate, so `row_hidden` recognises the
+    /// reduced row as fully shadowed/expired. A single decoded-then-dropped cell
+    /// leaves `max_data_cell_timestamp = Some(<= covering)` (NOT the `i64::MIN`
+    /// sentinel a truncated no-cell parse leaves), which is exactly the signal that
+    /// distinguishes a genuinely reduced row (hidden) from a truncated parse (kept).
+    ///
+    /// Revert-verify: if a shadowed/expired cell were EXCLUDED from the aggregate
+    /// (leaving `None`), `max_write_timestamp` would be the `i64::MIN` sentinel and
+    /// the first two assertions (hidden) would become FALSE.
+    #[test]
+    fn reduced_to_primary_key_row_is_hidden() {
+        // (a) All non-key cells shadowed by a partition tombstone (2000µs), no live
+        //     marker: the dropped cells' ts folds to max_data_cell_timestamp <= 2000,
+        //     so row_hidden shadows the whole row.
+        let shadow = PartitionShadow::open(0, Some((2000, 12345)), vec![]);
+        let mut h = row(0, None, None, false);
+        h.timestamp = None; // UPDATE-only row (no pk-liveness marker)
+        h.max_data_cell_timestamp = Some(1500); // newest shadowed cell, <= 2000
+        assert!(shadow.row_hidden(&h, &[]));
+
+        // (b) All non-key cells TTL-expired (no covering deletion), no live marker:
+        //     the dropped cells fold an expiry in the past and are NOT live-forever.
+        let now = 1_000_000i64;
+        let shadow_ttl = PartitionShadow::open(now, None, vec![]);
+        let mut h2 = row(0, None, Some(now - 1), false);
+        h2.timestamp = None;
+        assert!(shadow_ttl.row_hidden(&h2, &[]));
+
+        // (c) A truncated / marker-only parse (NO decoded cells → sentinel) is NOT
+        //     hidden — it is a partial read, not a genuinely reduced row.
+        let mut h3 = row(0, None, None, false);
+        h3.timestamp = None;
+        h3.max_data_cell_timestamp = None;
+        assert!(!shadow.row_hidden(&h3, &[]));
+
+        // (d) A surviving non-key cell newer than the deletion keeps the row visible.
+        let mut h4 = row(0, None, None, false);
+        h4.timestamp = None;
+        h4.max_data_cell_timestamp = Some(3000); // > 2000
+        assert!(!shadow.row_hidden(&h4, &[]));
+    }
+
+    /// Issue #1741 (Finding 2, header-level consequence): a row whose aggregated
+    /// max data-cell timestamp (which now folds in a non-frozen collection's newest
+    /// `max_element_writetime`) exceeds the covering deletion survives, even when
+    /// the row-liveness `timestamp` predates the deletion. The end-to-end fold is
+    /// pinned by `collection_element_newer_than_partition_tombstone_survives`; this
+    /// pins the decision the fold feeds.
+    #[test]
+    fn newer_collection_element_ts_keeps_row_visible() {
+        let shadow = PartitionShadow::open(0, Some((2000, 12345)), vec![]);
+        // Row marker older than the deletion (1000 <= 2000) but a folded element ts
+        // (3000) newer than it → NOT shadowed → visible.
+        let mut h = row(1000, None, None, false);
+        h.max_data_cell_timestamp = Some(3000);
+        assert!(!shadow.row_hidden(&h, &[]));
+        // Without the fold (max cell ts == row ts == 1000 <= 2000) → shadowed.
+        let mut h_prefold = row(1000, None, None, false);
+        h_prefold.max_data_cell_timestamp = Some(1000);
+        assert!(shadow.row_hidden(&h_prefold, &[]));
+    }
+}

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/regression_1741c_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/regression_1741c_tests.rs
@@ -1,0 +1,396 @@
+//! Issue #1741 (roborev pass C): regression pins for two correctness holes found
+//! in the initial single-gen shadowing change.
+//!
+//! Finding 1 (HIGH) — the clustering-slice fast-forward in
+//! [`super::V5CompressedLegacyParser::parse_block_emit_windowed`] jumped straight
+//! to `body_start`, skipping any range-tombstone marker that OPENS before the
+//! slice. Such a marker can cover rows inside the slice, so a targeted slice read
+//! could return rows a full scan correctly hides. The fix replays the pre-window
+//! markers into `PartitionShadow` before fast-forwarding.
+//!
+//! Finding 2 (MEDIUM) — the two sliding parsers
+//! (`parse_one_partition_with_timestamps`, `parse_one_partition_for_compaction`)
+//! required the 12-byte `nb` deletion-time header minimum, so a small valid oa/da
+//! (`hasUIntDeletionTime`, 1-byte LIVE) partition whose total bytes were below the
+//! `nb` minimum was treated as truncated-at-EOF and DROPPED. The fix branches the
+//! deletion-time minimum on `has_uint_deletion_time()`.
+
+use super::V5CompressedLegacyParser as V5;
+use crate::error::Result;
+
+// ---------------------------------------------------------------------------
+// Finding 1: range-tombstone shadowing must survive the clustering-slice
+// fast-forward.
+// ---------------------------------------------------------------------------
+
+/// Locate the first `test_deltas/range_tombstones-*` fixture Data.db (nb-BIG).
+fn range_tombstones_data_db() -> Option<std::path::PathBuf> {
+    let root = std::env::var("CQLITE_DATASETS_ROOT").ok()?;
+    let ks = std::path::PathBuf::from(root)
+        .join("sstables")
+        .join("test_deltas");
+    if !ks.is_dir() {
+        return None;
+    }
+    for entry in std::fs::read_dir(&ks).ok()?.flatten() {
+        let p = entry.path();
+        let is_rt = p.is_dir()
+            && p.file_name()
+                .and_then(|n| n.to_str())
+                .map(|n| n.starts_with("range_tombstones-"))
+                .unwrap_or(false);
+        if is_rt {
+            let data = p.join("nb-1-big-Data.db");
+            if data.exists() {
+                return Some(data);
+            }
+        }
+    }
+    None
+}
+
+/// Count rows a windowed parse emits over `block`.
+fn count_emitted(
+    parser: &V5,
+    block: &[u8],
+    schema: &crate::schema::TableSchema,
+    reader: &crate::storage::sstable::reader::SSTableReader,
+    window: Option<(usize, usize)>,
+) -> Result<usize> {
+    let mut n = 0usize;
+    parser.parse_block_emit_windowed(block, Some(schema), reader, window, |_entry| {
+        n += 1;
+        Ok(std::ops::ControlFlow::Continue(()))
+    })?;
+    Ok(n)
+}
+
+/// A range tombstone that OPENS before a targeted clustering slice must hide the
+/// older rows inside that slice on a WINDOWED (slice) read exactly as it does on a
+/// full scan (issue #1741, Finding 1).
+///
+/// A real single-gen fixture cannot carry rows physically covered by a range
+/// tombstone (Cassandra purges them at flush), so we reassemble one from real
+/// range_tombstones bytes: keep the partition header + the first range-tombstone
+/// START marker, DROP the matching END marker, and append the rows that followed
+/// it. Dropping the END keeps the range open over those (older) rows, making them
+/// covered — the exact "covered rows inside the slice" shape Finding 1 is about.
+///
+/// Revert-verify: with the `block_emit_windowed.rs` fast-forward priming removed,
+/// the slice read returns the covered rows (`n_slice == n_physical > 0`) while the
+/// full scan returns 0 — the two disagree and this test FAILS. With the fix both
+/// return 0.
+#[tokio::test]
+async fn range_tombstone_before_slice_is_shadowed_on_windowed_read() {
+    let Some(data_db) = range_tombstones_data_db() else {
+        eprintln!("SKIP range_tombstone_before_slice_is_shadowed_on_windowed_read: fixture absent");
+        return;
+    };
+
+    let config = crate::Config::default();
+    let platform = match crate::platform::Platform::new(&config).await {
+        Ok(p) => std::sync::Arc::new(p),
+        Err(e) => {
+            eprintln!("SKIP: platform init failed: {e}");
+            return;
+        }
+    };
+    let reader =
+        match crate::storage::sstable::reader::SSTableReader::open(&data_db, &config, platform)
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!("SKIP: reader open failed: {e}");
+                return;
+            }
+        };
+
+    let Some(schema) = reader.get_table_schema(None) else {
+        eprintln!("SKIP: no schema derivable from range_tombstones header");
+        return;
+    };
+
+    // Whole (decompressed) data section — range_tombstones is a handful of tiny
+    // partitions, so this is a few hundred bytes.
+    let cursor = reader.new_scan_cursor().await.expect("scan cursor");
+    let buf = reader.stitch_all_chunks(&cursor).await.expect("stitch");
+    assert!(!buf.is_empty(), "fixture Data.db must decompress to bytes");
+
+    // Physical parser (no shadowing) is used both to WALK the real bytes and to
+    // prove the reassembled covered rows are physically present.
+    let p_phys = reader.build_v5_parser(false);
+    let p_shadow = reader.build_v5_parser(true);
+    let resolution = super::RowColumnResolution::build(&schema, &reader);
+
+    // Walk partition-by-partition; select the first partition whose reassembly
+    // yields a genuinely COVERING range (full-scan shadow hides every collected
+    // row) so the differential is meaningful regardless of which fixture UUID/dir
+    // resolved.
+    let mut poff = 0usize;
+    let mut asserted = false;
+    while poff < buf.len() {
+        let (_pk, mut off, _del) = match p_phys.parse_partition_header_full(&buf, poff) {
+            Ok(v) => v,
+            Err(_) => break,
+        };
+        let header = buf[poff..off].to_vec();
+        let mut rt_start: Vec<u8> = Vec::new();
+        let mut covered: Vec<u8> = Vec::new();
+        let mut seen_rt = false;
+
+        loop {
+            if off >= buf.len() {
+                break;
+            }
+            let flags = buf[off];
+            if V5::is_end_of_partition(flags) {
+                off += 1;
+                break;
+            }
+            if off != poff && p_phys.peek_is_partition_header(&buf, off) {
+                break; // next partition starts here
+            }
+            if V5::is_range_tombstone_marker(flags) {
+                let next = match p_phys.skip_range_tombstone_marker(&buf, off, &schema) {
+                    Ok(n) => n,
+                    Err(_) => break,
+                };
+                // Keep the FIRST marker (a range START) as the pre-window opener;
+                // drop every later marker so the range stays open over the rows.
+                if !seen_rt {
+                    rt_start = buf[off..next].to_vec();
+                    seen_rt = true;
+                }
+                off = next;
+                continue;
+            }
+            let next = match p_phys.parse_row_data_with_offset(
+                &buf,
+                off,
+                Some(&schema),
+                &reader,
+                false,
+                &resolution,
+                None,
+            ) {
+                Ok((.., n, _is_static, _complex)) => n,
+                Err(_) => break,
+            };
+            if seen_rt {
+                covered.extend_from_slice(&buf[off..next]);
+            }
+            off = next;
+        }
+
+        let next_partition = off;
+
+        if !rt_start.is_empty() && !covered.is_empty() {
+            // Reassemble: header + range-START + covered rows + END_OF_PARTITION.
+            let mut synth = header.clone();
+            synth.extend_from_slice(&rt_start);
+            let body_start = synth.len();
+            synth.extend_from_slice(&covered);
+            let body_end = synth.len();
+            synth.push(0x01); // END_OF_PARTITION
+
+            // Rows are physically present (no shadow → emitted).
+            let n_physical = count_emitted(&p_phys, &synth, &schema, &reader, None).unwrap();
+            // Full scan WITH shadowing hides them (open range covers older rows).
+            let n_full = count_emitted(&p_shadow, &synth, &schema, &reader, None).unwrap();
+
+            if n_physical == 0 || n_full != 0 {
+                // Not a covering range for this partition — try the next one.
+                if next_partition <= poff {
+                    break;
+                }
+                poff = next_partition;
+                continue;
+            }
+
+            // Slice (windowed) read must hide EXACTLY what the full scan hides.
+            // Pre-fix this returns `n_physical` (> 0) because the fast-forward
+            // skipped the pre-window range-START marker.
+            let n_slice = count_emitted(
+                &p_shadow,
+                &synth,
+                &schema,
+                &reader,
+                Some((body_start, body_end)),
+            )
+            .unwrap();
+
+            assert_eq!(
+                n_slice, 0,
+                "Finding 1: a range tombstone opening before the slice must hide the covered \
+                 rows on a windowed slice read (physical rows = {n_physical}), matching the full \
+                 scan (= {n_full})"
+            );
+            assert_eq!(n_slice, n_full, "slice read must match the full scan");
+            asserted = true;
+            break;
+        }
+
+        if next_partition <= poff {
+            break;
+        }
+        poff = next_partition;
+    }
+
+    assert!(
+        asserted,
+        "range_tombstones fixture present but no covering-range partition was found to exercise \
+         Finding 1 — fixture structure changed (not an empty pass)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Finding 2: sliding parsers must accept a small oa/da live partition.
+// ---------------------------------------------------------------------------
+
+/// pk-only schema (`tiny(pk int, v text)`) — no clustering — so a single-row
+/// partition is as small as possible.
+#[cfg(feature = "write-support")]
+fn tiny_schema() -> crate::schema::TableSchema {
+    use crate::schema::{Column, KeyColumn};
+    crate::schema::TableSchema {
+        keyspace: "test_ks".to_string(),
+        table: "tiny".to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "pk".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            Column {
+                name: "pk".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "v".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: std::collections::HashMap::new(),
+        dropped_columns: std::collections::HashMap::new(),
+    }
+}
+
+/// A small BTI (`da`) LIVE partition — whose total bytes fall below the legacy
+/// `nb` 12-byte deletion-time header minimum — must be read back by BOTH sliding
+/// parsers (streaming scan + compaction), not dropped as truncated-at-EOF
+/// (issue #1741, Finding 2).
+///
+/// Revert-verify: with the sliding parsers' `header_min_size` pinned to the `nb`
+/// `1 + 1 + key_len + 12`, both parsers return `ParseStep::Done` and emit ZERO
+/// rows for this partition, so the row-count asserts FAIL. With the fix (branch on
+/// `has_uint_deletion_time()` → 1 byte for oa/da) they emit the row.
+#[cfg(feature = "write-support")]
+#[tokio::test]
+async fn small_oa_live_partition_survives_sliding_parsers() {
+    use crate::storage::sstable::writer::{SSTableFormat, SSTableWriter};
+    use crate::storage::write_engine::mutation::{CellOperation, Mutation, PartitionKey, TableId};
+    use crate::types::Value;
+
+    let schema = tiny_schema();
+    let dir = tempfile::TempDir::new().unwrap();
+
+    let mut writer =
+        SSTableWriter::with_format(dir.path().to_path_buf(), 1, &schema, 16, SSTableFormat::Bti)
+            .unwrap();
+
+    // One tiny live row: pk=42, v="x". ts chosen equal to the SSTable min so the
+    // row's timestamp delta is 0 (1 byte), keeping the partition minimal.
+    let mutation = Mutation::new(
+        TableId::new("test_ks", "tiny"),
+        PartitionKey::single("pk", Value::Integer(42)),
+        None,
+        vec![CellOperation::Write {
+            column: "v".to_string(),
+            value: Value::Text("x".to_string()),
+        }],
+        1_000_000,
+        None,
+    );
+    let key = mutation.decorated_key(&schema).unwrap();
+    writer.write_partition(key, vec![mutation]).unwrap();
+    let info = writer.finish().await.unwrap();
+
+    // Open the produced da SSTable and read its decompressed data section.
+    let config = crate::Config::default();
+    let platform = std::sync::Arc::new(crate::platform::Platform::new(&config).await.unwrap());
+    let reader =
+        crate::storage::sstable::reader::SSTableReader::open(&info.data_path, &config, platform)
+            .await
+            .unwrap();
+
+    let cursor = reader.new_scan_cursor().await.unwrap();
+    let buf = reader.stitch_all_chunks(&cursor).await.unwrap();
+    assert!(
+        buf.len() >= 2,
+        "partition must have at least flags + key_len"
+    );
+
+    // The reader must be on the oa/da (hasUIntDeletionTime) path.
+    let parser = reader.build_v5_parser(false);
+
+    // Precondition that makes this a genuine Finding-2 differential: the whole
+    // (single) partition is smaller than the legacy nb 12-byte-deletion minimum,
+    // so the pre-fix sliding parsers would DROP it at the header_min_size gate.
+    let key_len = buf[1] as usize;
+    let nb_min = 1 + 1 + key_len + 12;
+    let oa_min = 1 + 1 + key_len + 1;
+    assert!(
+        buf.len() >= oa_min,
+        "sanity: partition ({} bytes) is below even the oa minimum ({oa_min})",
+        buf.len()
+    );
+    assert!(
+        buf.len() < nb_min,
+        "Finding 2 precondition: the tiny da partition ({} bytes, key_len={key_len}) must be \
+         smaller than the nb 12-byte-deletion minimum ({nb_min}) so the pre-fix sliding parsers \
+         drop it; shrink the fixture if this trips",
+        buf.len()
+    );
+
+    // Streaming-scan sliding parser: must EMIT the row, not return Done.
+    let mut ts_rows = 0usize;
+    let step = parser
+        .parse_one_partition_with_timestamps(&buf, Some(&schema), &reader, true, &mut |_e| {
+            ts_rows += 1;
+            Ok(std::ops::ControlFlow::Continue(()))
+        })
+        .unwrap();
+    assert!(
+        matches!(step, super::ParseStep::Emitted(_)),
+        "Finding 2: streaming-scan sliding parser must EMIT the small oa partition, got {step:?}"
+    );
+    assert!(
+        ts_rows >= 1,
+        "the small oa live partition's row must be read back by the streaming scan sliding parser"
+    );
+
+    // Compaction sliding parser: must also EMIT the row.
+    let mut comp_rows = 0usize;
+    let cstep = parser
+        .parse_one_partition_for_compaction(&buf, Some(&schema), &reader, true, &mut |_r| {
+            comp_rows += 1;
+            Ok(std::ops::ControlFlow::Continue(()))
+        })
+        .unwrap();
+    assert!(
+        matches!(cstep, super::ParseStep::Emitted(_)),
+        "Finding 2: compaction sliding parser must EMIT the small oa partition, got {cstep:?}"
+    );
+    assert!(
+        comp_rows >= 1,
+        "the small oa live partition's row must survive a compaction read pass"
+    );
+}

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/regression_1741d_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/regression_1741d_tests.rs
@@ -1,0 +1,854 @@
+//! Issue #1741 (roborev pass D): regression pins for three correctness/perf holes.
+//!
+//! Finding 1 (CORRECTNESS) — a STATIC row was stored and later merged into every
+//! surviving clustering row WITHOUT applying partition-tombstone / TTL shadowing to
+//! the static row itself. A partition tombstone (or static-row TTL) that shadows the
+//! static data while a newer clustering row survives therefore leaked the stale
+//! static value into `SELECT` output. The fix evaluates the static row header with
+//! `PartitionShadow` before saving `static_cells`.
+//!
+//! Finding 2 (PERF) — the slice-read fast-forward primed the pre-window prefix on
+//! EVERY user-facing windowed read, regressing O(slice) to O(prefix+slice). Priming
+//! is now (a) gated on authoritative EncodingStats evidence that the SSTable carries
+//! deletions (hence possibly range tombstones), and (b) marker-only (no cell decode).
+//! `sstable_may_have_range_tombstones()` is pinned here; the round-C
+//! `range_tombstone_before_slice_is_shadowed_on_windowed_read` still pins that RT
+//! shadowing survives the (now cheaper) priming.
+//!
+//! Finding 3's collection-element TTL aggregate is pinned in `complex_column.rs`.
+
+use super::V5CompressedLegacyParser as V5;
+
+// ---------------------------------------------------------------------------
+// Finding 2: the no-range-tombstone fast path is preserved authoritatively.
+// ---------------------------------------------------------------------------
+
+/// The priming gate is driven ONLY by authoritative `EncodingStats`
+/// (`minLocalDeletionTime`): the LIVE sentinel `Integer.MAX_VALUE` proves the
+/// SSTable has NO deletions (hence no range tombstones), so the slice read keeps
+/// the O(slice) fast-forward and skips prefix priming. Any smaller min means a
+/// tombstone/TTL exists, so priming runs (correctly, over-approximating RTs).
+#[test]
+fn range_tombstone_gate_follows_min_local_deletion_time() {
+    // No deletions: minLocalDeletionTime == Integer.MAX_VALUE LIVE sentinel.
+    let live = V5::new("k".into(), "t".into(), 0, i32::MAX as i64, None);
+    assert!(
+        !live.sstable_may_have_range_tombstones(),
+        "an SSTable whose EncodingStats minLocalDeletionTime is the LIVE sentinel \
+         (Integer.MAX_VALUE) has no deletions — the slice read must keep the O(slice) \
+         fast path and NOT prime the prefix"
+    );
+
+    // A real (smaller) minLocalDeletionTime means at least one deletion/TTL — prime.
+    let has_del = V5::new("k".into(), "t".into(), 0, 1_700_000_000, None);
+    assert!(
+        has_del.sstable_may_have_range_tombstones(),
+        "a real (< Integer.MAX_VALUE) minLocalDeletionTime means the SSTable carries a \
+         deletion/TTL, so priming must run to catch a range tombstone before the slice"
+    );
+
+    // The no-stats fallback (min == 0) conservatively primes (never skips wrongly).
+    let no_stats = V5::new("k".into(), "t".into(), 0, 0, None);
+    assert!(
+        no_stats.sstable_may_have_range_tombstones(),
+        "with no Statistics.db (min == 0) the gate must conservatively prime"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Finding 1: a static row shadowed by the partition tombstone must NOT leak its
+// stale value into a surviving (newer) clustering row.
+// ---------------------------------------------------------------------------
+
+/// `t(pk int, ck int, s text STATIC, v text)`, PRIMARY KEY ((pk), ck).
+#[cfg(feature = "write-support")]
+fn static_schema() -> crate::schema::TableSchema {
+    use crate::schema::{ClusteringColumn, ClusteringOrder, Column, KeyColumn};
+    crate::schema::TableSchema {
+        keyspace: "ks".to_string(),
+        table: "t".to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "pk".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![ClusteringColumn {
+            name: "ck".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+            order: ClusteringOrder::Asc,
+        }],
+        columns: vec![
+            Column {
+                name: "pk".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "ck".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "s".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: true,
+            },
+            Column {
+                name: "v".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: std::collections::HashMap::new(),
+        dropped_columns: std::collections::HashMap::new(),
+    }
+}
+
+/// Collect every emitted live-row's cells over `block` (markers dropped).
+#[cfg(feature = "write-support")]
+fn emit_rows(
+    parser: &V5,
+    block: &[u8],
+    schema: &crate::schema::TableSchema,
+    reader: &crate::storage::sstable::reader::SSTableReader,
+) -> Vec<crate::types::RowCells> {
+    let mut out = Vec::new();
+    parser
+        .parse_block_emit(block, Some(schema), reader, |(_t, _k, row)| {
+            if let crate::types::ScanRow::Row(cells) = row {
+                out.push(cells);
+            }
+            Ok(std::ops::ControlFlow::Continue(()))
+        })
+        .unwrap();
+    out
+}
+
+/// A static row shadowed by the partition tombstone must be dropped from the merge
+/// so a surviving NEWER clustering row does NOT carry the stale static value —
+/// matching a Cassandra `SELECT` (issue #1741, Finding 1).
+///
+/// A single flushed generation cannot naturally hold a partition tombstone that
+/// coexists with older-but-unpurged static data (the writer purges at flush), so we
+/// construct the repro deterministically: write ONE partition with a static cell
+/// `s='OLD'` at ts=1_000_000 and a clustering row `ck=1, v='new'` at ts=3_000_000
+/// (both LIVE), then patch the flushed nb partition header to carry a
+/// `markedForDeleteAt = 2_000_000` — between the two write timestamps. That shadows
+/// the static row (deletes: 1e6 <= 2e6) while the newer clustering row (3e6 > 2e6)
+/// survives.
+///
+/// Revert-verify: with the static-shadow check removed the shadowed static value is
+/// still merged into the surviving row, so `s` reappears and the final assertion
+/// FAILS. With the fix the surviving row carries no `s`, while the physical
+/// (no-shadow) parse still shows the leak — proving the differential is real.
+#[cfg(feature = "write-support")]
+#[tokio::test]
+async fn shadowed_static_row_is_not_merged_into_surviving_rows() {
+    use crate::storage::sstable::writer::{SSTableFormat, SSTableWriter};
+    use crate::storage::write_engine::mutation::{
+        CellOperation, ClusteringKey, Mutation, PartitionKey, TableId,
+    };
+    use crate::types::Value;
+
+    let schema = static_schema();
+    let dir = tempfile::TempDir::new().unwrap();
+    let mut writer =
+        SSTableWriter::with_format(dir.path().to_path_buf(), 1, &schema, 16, SSTableFormat::Big)
+            .unwrap();
+
+    // Static cell s='OLD' at the OLDER timestamp.
+    let static_mut = Mutation::new(
+        TableId::new("ks", "t"),
+        PartitionKey::single("pk", Value::Integer(1)),
+        None,
+        vec![CellOperation::Write {
+            column: "s".to_string(),
+            value: Value::Text("OLD".to_string()),
+        }],
+        1_000_000,
+        None,
+    );
+    // Clustering row ck=1, v='new' at the NEWER timestamp (survives the tombstone).
+    let row_mut = Mutation::new(
+        TableId::new("ks", "t"),
+        PartitionKey::single("pk", Value::Integer(1)),
+        Some(ClusteringKey::single("ck", Value::Integer(1))),
+        vec![CellOperation::Write {
+            column: "v".to_string(),
+            value: Value::Text("new".to_string()),
+        }],
+        3_000_000,
+        None,
+    );
+    let key = static_mut.decorated_key(&schema).unwrap();
+    writer
+        .write_partition(key, vec![static_mut, row_mut])
+        .unwrap();
+    let info = writer.finish().await.unwrap();
+
+    let config = crate::Config::default();
+    let platform = std::sync::Arc::new(crate::platform::Platform::new(&config).await.unwrap());
+    let reader =
+        crate::storage::sstable::reader::SSTableReader::open(&info.data_path, &config, platform)
+            .await
+            .unwrap();
+
+    let cursor = reader.new_scan_cursor().await.unwrap();
+    let mut buf = reader.stitch_all_chunks(&cursor).await.unwrap();
+    assert!(buf.len() >= 2, "decompressed partition must exist");
+
+    // Patch the single partition header (offset 0) to carry a partition tombstone.
+    // nb layout: flags(1) | key_len(1) | key | localDeletionTime(i32 BE) |
+    // markedForDeleteAt(i64 BE). The Big writer emits `nb` (12-byte deletion), so
+    // this is a same-size in-place patch.
+    let key_len = buf[1] as usize;
+    let del_off = 2 + key_len;
+    assert!(
+        buf.len() >= del_off + 12,
+        "nb partition header must carry a 12-byte deletion field"
+    );
+    let local_deletion_time: i32 = 1_700_000_000; // real (not the i32::MAX LIVE sentinel)
+    buf[del_off..del_off + 4].copy_from_slice(&local_deletion_time.to_be_bytes());
+    let marked_for_delete_at: i64 = 2_000_000; // between static ts (1e6) and row ts (3e6)
+    buf[del_off + 4..del_off + 12].copy_from_slice(&marked_for_delete_at.to_be_bytes());
+
+    let p_phys = reader.build_v5_parser(false);
+    let p_shadow = reader.build_v5_parser(true);
+
+    let phys = emit_rows(&p_phys, &buf, &schema, &reader);
+    let shadow = emit_rows(&p_shadow, &buf, &schema, &reader);
+
+    // Physical parse: the clustering row carries the (older) static value 's'.
+    assert_eq!(
+        phys.len(),
+        1,
+        "physical parse must emit the one clustering row"
+    );
+    assert!(
+        phys[0].iter().any(|(n, _)| &**n == "s"),
+        "physical (no-shadow) parse must leak the static value 's' into the clustering row \
+         (anti-empty-pass: proves the merge happens)"
+    );
+
+    // Shadow parse: the NEWER clustering row survives the partition tombstone...
+    assert_eq!(
+        shadow.len(),
+        1,
+        "the newer clustering row (ts=3e6 > markedForDeleteAt=2e6) must survive the tombstone"
+    );
+    // ...but the shadowed static value must NOT be merged into it.
+    assert!(
+        !shadow[0].iter().any(|(n, _)| &**n == "s"),
+        "Finding 1: the partition-tombstone-shadowed static row must NOT be merged into the \
+         surviving clustering row (its 's' cell is stale and a SELECT must hide it)"
+    );
+    // Sanity: the surviving row keeps its own live cell.
+    assert!(
+        shadow[0].iter().any(|(n, _)| &**n == "v"),
+        "the surviving clustering row must keep its own live 'v' cell"
+    );
+}
+
+/// Issue #1741 (Finding 2): the marker-only prefix skip (`skip_row_framing`) must
+/// advance over a data row to EXACTLY the same offset the full cell-decode
+/// (`parse_row_data_with_offset`) reaches — otherwise a primed prefix would
+/// desynchronise and either miss or double-feed a range-tombstone marker. This pins
+/// the framing-only fast path (flags + clustering + row_size) against the
+/// authoritative decode for both the static row and the clustering rows of a real
+/// writer-produced partition.
+#[cfg(feature = "write-support")]
+#[tokio::test]
+async fn skip_row_framing_matches_full_decode_offset() {
+    use crate::storage::sstable::writer::{SSTableFormat, SSTableWriter};
+    use crate::storage::write_engine::mutation::{
+        CellOperation, ClusteringKey, Mutation, PartitionKey, TableId,
+    };
+    use crate::types::Value;
+
+    let schema = static_schema();
+    let dir = tempfile::TempDir::new().unwrap();
+    let mut writer =
+        SSTableWriter::with_format(dir.path().to_path_buf(), 1, &schema, 16, SSTableFormat::Big)
+            .unwrap();
+
+    let static_mut = Mutation::new(
+        TableId::new("ks", "t"),
+        PartitionKey::single("pk", Value::Integer(7)),
+        None,
+        vec![CellOperation::Write {
+            column: "s".to_string(),
+            value: Value::Text("stat".to_string()),
+        }],
+        1_000_000,
+        None,
+    );
+    let mut muts = vec![static_mut];
+    for ck in 1..=3 {
+        muts.push(Mutation::new(
+            TableId::new("ks", "t"),
+            PartitionKey::single("pk", Value::Integer(7)),
+            Some(ClusteringKey::single("ck", Value::Integer(ck))),
+            vec![CellOperation::Write {
+                column: "v".to_string(),
+                value: Value::Text(format!("v{ck}")),
+            }],
+            2_000_000 + ck as i64,
+            None,
+        ));
+    }
+    let key = muts[0].decorated_key(&schema).unwrap();
+    writer.write_partition(key, muts).unwrap();
+    let info = writer.finish().await.unwrap();
+
+    let config = crate::Config::default();
+    let platform = std::sync::Arc::new(crate::platform::Platform::new(&config).await.unwrap());
+    let reader =
+        crate::storage::sstable::reader::SSTableReader::open(&info.data_path, &config, platform)
+            .await
+            .unwrap();
+    let cursor = reader.new_scan_cursor().await.unwrap();
+    let buf = reader.stitch_all_chunks(&cursor).await.unwrap();
+
+    let parser = reader.build_v5_parser(false);
+    let resolution = super::RowColumnResolution::build(&schema, &reader);
+
+    // Walk the single partition; for each row compare the framing-only skip offset
+    // to the full-decode next offset.
+    let (_pk, mut off, _del) = parser.parse_partition_header_full(&buf, 0).unwrap();
+    let mut rows_checked = 0usize;
+    loop {
+        if off >= buf.len() || V5::is_end_of_partition(buf[off]) {
+            break;
+        }
+        // Only peek AFTER at least one row has been consumed — the first row's bytes
+        // can look like a partition header to the peek probe (mirrors the real loop).
+        if rows_checked > 0 && parser.peek_is_partition_header(&buf, off) {
+            break;
+        }
+        let full_next = match parser.parse_row_data_with_offset(
+            &buf,
+            off,
+            Some(&schema),
+            &reader,
+            false,
+            &resolution,
+            None,
+        ) {
+            Ok((.., n, _is_static, _c)) => n,
+            Err(_) => break,
+        };
+        let framed_next = parser
+            .skip_row_framing(&buf, off, &schema)
+            .expect("skip_row_framing must succeed on a valid row");
+        assert_eq!(
+            framed_next, full_next,
+            "skip_row_framing offset must equal the full-decode next offset (row at {off})"
+        );
+        rows_checked += 1;
+        off = full_next;
+    }
+    assert!(
+        rows_checked >= 4,
+        "expected the static row + 3 clustering rows to be framing-checked, got {rows_checked}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// roborev pass F: per-CELL tombstone/TTL shadowing (Findings 1 & 2). The
+// shadowing is now applied PER CELL (and per whole collection), not just per
+// row, matching Cassandra which shadows individual cells written at or before a
+// covering deletion or expired by TTL.
+// ---------------------------------------------------------------------------
+
+/// `t(pk int, ck int, a text, b text)`, PRIMARY KEY ((pk), ck) — two regular
+/// (non-static) columns so a single row can carry two cells at DIFFERENT write
+/// timestamps (via `Mutation::cell_write_timestamps`).
+#[cfg(feature = "write-support")]
+fn two_col_schema() -> crate::schema::TableSchema {
+    use crate::schema::{ClusteringColumn, ClusteringOrder, Column, KeyColumn};
+    let col = |name: &str, ty: &str, is_static: bool| Column {
+        name: name.to_string(),
+        data_type: ty.to_string(),
+        nullable: true,
+        default: None,
+        is_static,
+    };
+    crate::schema::TableSchema {
+        keyspace: "ks".to_string(),
+        table: "t".to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "pk".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![ClusteringColumn {
+            name: "ck".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+            order: ClusteringOrder::Asc,
+        }],
+        columns: vec![
+            col("pk", "int", false),
+            col("ck", "int", false),
+            col("a", "text", false),
+            col("b", "text", false),
+        ],
+        comments: std::collections::HashMap::new(),
+        dropped_columns: std::collections::HashMap::new(),
+    }
+}
+
+/// Patch the single (offset-0) `nb` partition header in-place to carry a
+/// partition tombstone with `markedForDeleteAt = mfda` (µs). Layout: flags(1) |
+/// key_len(1) | key | localDeletionTime(i32 BE) | markedForDeleteAt(i64 BE).
+#[cfg(feature = "write-support")]
+fn patch_partition_tombstone(buf: &mut [u8], mfda: i64) {
+    let key_len = buf[1] as usize;
+    let del_off = 2 + key_len;
+    assert!(
+        buf.len() >= del_off + 12,
+        "nb partition header must carry a 12-byte deletion field"
+    );
+    let local_deletion_time: i32 = 1_700_000_000; // real (not the i32::MAX LIVE sentinel)
+    buf[del_off..del_off + 4].copy_from_slice(&local_deletion_time.to_be_bytes());
+    buf[del_off + 4..del_off + 12].copy_from_slice(&mfda.to_be_bytes());
+}
+
+/// Finding 1 (partial-row survival): a row under a partition tombstone at
+/// `markedForDeleteAt = 2e6` where cell `a` was written at ts=1e6 (<= 2e6, so
+/// shadowed) and cell `b` at ts=3e6 (> 2e6, survives). A Cassandra `SELECT`
+/// returns the row with ONLY `b` populated — `a` is stale and must be absent.
+///
+/// Revert-verify: with per-cell filtering removed the whole row is decided at
+/// once, so the stale `a` cell reappears and the `!contains("a")` assertion
+/// FAILS; the physical (no-shadow) parse still shows both cells (anti-empty-pass).
+#[cfg(feature = "write-support")]
+#[tokio::test]
+async fn partial_row_survival_drops_shadowed_cell() {
+    use crate::storage::sstable::writer::{SSTableFormat, SSTableWriter};
+    use crate::storage::write_engine::mutation::{
+        CellOperation, ClusteringKey, Mutation, PartitionKey, TableId,
+    };
+    use crate::types::Value;
+
+    let schema = two_col_schema();
+    let dir = tempfile::TempDir::new().unwrap();
+    let mut writer =
+        SSTableWriter::with_format(dir.path().to_path_buf(), 1, &schema, 16, SSTableFormat::Big)
+            .unwrap();
+
+    // One row, two cells: a@1e6 (via per-cell override), b@3e6 (row ts). Row
+    // liveness marker is at 3e6, so the marker survives the tombstone too.
+    let mut m = Mutation::new(
+        TableId::new("ks", "t"),
+        PartitionKey::single("pk", Value::Integer(1)),
+        Some(ClusteringKey::single("ck", Value::Integer(1))),
+        vec![
+            CellOperation::Write {
+                column: "a".to_string(),
+                value: Value::Text("AAA".to_string()),
+            },
+            CellOperation::Write {
+                column: "b".to_string(),
+                value: Value::Text("BBB".to_string()),
+            },
+        ],
+        3_000_000,
+        None,
+    );
+    m.cell_write_timestamps = Some(std::collections::HashMap::from([(
+        "a".to_string(),
+        1_000_000i64,
+    )]));
+    let key = m.decorated_key(&schema).unwrap();
+    writer.write_partition(key, vec![m]).unwrap();
+    let info = writer.finish().await.unwrap();
+
+    let config = crate::Config::default();
+    let platform = std::sync::Arc::new(crate::platform::Platform::new(&config).await.unwrap());
+    let reader =
+        crate::storage::sstable::reader::SSTableReader::open(&info.data_path, &config, platform)
+            .await
+            .unwrap();
+    let cursor = reader.new_scan_cursor().await.unwrap();
+    let mut buf = reader.stitch_all_chunks(&cursor).await.unwrap();
+    patch_partition_tombstone(&mut buf, 2_000_000);
+
+    let phys = emit_rows(&reader.build_v5_parser(false), &buf, &schema, &reader);
+    let shadow = emit_rows(&reader.build_v5_parser(true), &buf, &schema, &reader);
+
+    assert_eq!(phys.len(), 1, "physical parse emits the row");
+    assert!(
+        phys[0].iter().any(|(n, _)| &**n == "a") && phys[0].iter().any(|(n, _)| &**n == "b"),
+        "physical (no-shadow) parse must carry BOTH cells (anti-empty-pass)"
+    );
+
+    assert_eq!(
+        shadow.len(),
+        1,
+        "the row survives (cell b @3e6 and the marker @3e6 are newer than the tombstone @2e6)"
+    );
+    assert!(
+        shadow[0].iter().any(|(n, _)| &**n == "b"),
+        "the surviving cell b (ts 3e6 > 2e6) must be present"
+    );
+    assert!(
+        !shadow[0].iter().any(|(n, _)| &**n == "a"),
+        "Finding 1: the shadowed cell a (ts 1e6 <= 2e6) must be dropped per-cell, not returned stale"
+    );
+}
+
+/// `t(pk int, ck int, tags set<int>)`, PRIMARY KEY ((pk), ck) — a non-frozen
+/// set column so an ELEMENT can carry its OWN write timestamp distinct from the
+/// row liveness (via `CellOperation::WriteComplexElement`).
+#[cfg(feature = "write-support")]
+fn set_schema() -> crate::schema::TableSchema {
+    use crate::schema::{ClusteringColumn, ClusteringOrder, Column, KeyColumn};
+    let col = |name: &str, ty: &str| Column {
+        name: name.to_string(),
+        data_type: ty.to_string(),
+        nullable: true,
+        default: None,
+        is_static: false,
+    };
+    crate::schema::TableSchema {
+        keyspace: "ks".to_string(),
+        table: "t".to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "pk".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![ClusteringColumn {
+            name: "ck".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+            order: ClusteringOrder::Asc,
+        }],
+        columns: vec![col("pk", "int"), col("ck", "int"), col("tags", "set<int>")],
+        comments: std::collections::HashMap::new(),
+        dropped_columns: std::collections::HashMap::new(),
+    }
+}
+
+/// Finding 2 (collection element newer than a partition tombstone): a non-frozen
+/// `set<int>` element written at ts=3e6 while the row liveness marker is at ts=1e6
+/// and a partition tombstone is patched at markedForDeleteAt=2e6. Because the
+/// element (3e6) is newer than the tombstone (2e6), the element AND the row must
+/// survive — even though the row marker (1e6) predates the tombstone.
+///
+/// Revert-verify: with only `row_header.timestamp` folded into the row's
+/// max-cell timestamp (the pre-fix behavior), the row's max ts is 1e6 <= 2e6, so
+/// the whole row is wrongly shadowed and the shadow parse returns 0 rows; the
+/// physical parse still returns 1 (anti-empty-pass). With `max_element_writetime`
+/// folded in, the row survives.
+#[cfg(feature = "write-support")]
+#[tokio::test]
+async fn collection_element_newer_than_partition_tombstone_survives() {
+    use crate::storage::sstable::writer::{SSTableFormat, SSTableWriter};
+    use crate::storage::write_engine::mutation::{
+        CellOperation, ClusteringKey, Mutation, PartitionKey, TableId,
+    };
+    use crate::types::Value;
+
+    let schema = set_schema();
+    let dir = tempfile::TempDir::new().unwrap();
+    let mut writer =
+        SSTableWriter::with_format(dir.path().to_path_buf(), 1, &schema, 16, SSTableFormat::Big)
+            .unwrap();
+
+    // Row marker at 1e6; one set element `7` written at its OWN ts=3e6.
+    let m = Mutation::new(
+        TableId::new("ks", "t"),
+        PartitionKey::single("pk", Value::Integer(1)),
+        Some(ClusteringKey::single("ck", Value::Integer(1))),
+        vec![CellOperation::WriteComplexElement {
+            column: "tags".to_string(),
+            cell_path: 7i32.to_be_bytes().to_vec(),
+            value: None, // set members store the element in the cell path
+            timestamp_micros: 3_000_000,
+            ttl_seconds: None,
+            local_deletion_time: None,
+            is_deleted: false,
+        }],
+        1_000_000,
+        None,
+    );
+    let key = m.decorated_key(&schema).unwrap();
+    writer.write_partition(key, vec![m]).unwrap();
+    let info = writer.finish().await.unwrap();
+
+    let config = crate::Config::default();
+    let platform = std::sync::Arc::new(crate::platform::Platform::new(&config).await.unwrap());
+    let reader =
+        crate::storage::sstable::reader::SSTableReader::open(&info.data_path, &config, platform)
+            .await
+            .unwrap();
+    let cursor = reader.new_scan_cursor().await.unwrap();
+    let mut buf = reader.stitch_all_chunks(&cursor).await.unwrap();
+    patch_partition_tombstone(&mut buf, 2_000_000);
+
+    let phys = emit_rows(&reader.build_v5_parser(false), &buf, &schema, &reader);
+    let shadow = emit_rows(&reader.build_v5_parser(true), &buf, &schema, &reader);
+
+    assert_eq!(
+        phys.len(),
+        1,
+        "physical parse emits the row with the set element (anti-empty-pass)"
+    );
+    assert_eq!(
+        shadow.len(),
+        1,
+        "Finding 2: the row must survive because its set element (ts 3e6) is newer than the \
+         partition tombstone (2e6), even though the row marker (1e6) predates it"
+    );
+    assert!(
+        shadow[0].iter().any(|(n, _)| &**n == "tags"),
+        "the surviving set column must be present"
+    );
+}
+
+/// `t(pk int, ck int, tags set<int>, note text)`, PRIMARY KEY ((pk), ck) — a
+/// non-frozen set PLUS a scalar column, so the row can survive a tombstone via a
+/// live scalar cell while its collection is entirely shadowed (test 3).
+#[cfg(feature = "write-support")]
+fn set_scalar_schema() -> crate::schema::TableSchema {
+    use crate::schema::{ClusteringColumn, ClusteringOrder, Column, KeyColumn};
+    let col = |name: &str, ty: &str| Column {
+        name: name.to_string(),
+        data_type: ty.to_string(),
+        nullable: true,
+        default: None,
+        is_static: false,
+    };
+    crate::schema::TableSchema {
+        keyspace: "ks".to_string(),
+        table: "t".to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "pk".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![ClusteringColumn {
+            name: "ck".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+            order: ClusteringOrder::Asc,
+        }],
+        columns: vec![
+            col("pk", "int"),
+            col("ck", "int"),
+            col("tags", "set<int>"),
+            col("note", "text"),
+        ],
+        comments: std::collections::HashMap::new(),
+        dropped_columns: std::collections::HashMap::new(),
+    }
+}
+
+/// Extract the `tags` set column from an emitted row as a sorted `Vec<i32>` of its
+/// integer members (empty when the column is absent).
+#[cfg(feature = "write-support")]
+fn tag_ints(row: &crate::types::RowCells) -> Vec<i32> {
+    let mut out = Vec::new();
+    for (n, v) in row.iter() {
+        if &**n == "tags" {
+            if let crate::types::Value::Set(members) = v {
+                for m in members {
+                    if let crate::types::Value::Integer(i) = m {
+                        out.push(*i);
+                    }
+                }
+            }
+        }
+    }
+    out.sort_unstable();
+    out
+}
+
+/// Issue #1741 (per-element filtering, test 1 — mixed old/new): a SURVIVING
+/// non-frozen `set<int>` must return ONLY the elements newer than the covering
+/// tombstone. Element `1` is written at ts=1e6 (<= tombstone 2e6, shadowed) and
+/// element `2` at ts=3e6 (> 2e6, survives); the row marker is at 1e6. A Cassandra
+/// `SELECT` returns the row with `tags = {2}` — element `1` is stale and must be
+/// dropped from WITHIN the surviving collection, and the row survives because its
+/// newer element (3e6) outlives the tombstone.
+///
+/// Revert-verify: with per-ELEMENT filtering removed the whole collection is kept
+/// or dropped together, so the stale element `1` reappears in the returned set and
+/// the `== [2]` assertion FAILS; the physical (no-shadow) parse still shows both
+/// elements (anti-empty-pass).
+#[cfg(feature = "write-support")]
+#[tokio::test]
+async fn surviving_collection_drops_shadowed_elements() {
+    use crate::storage::sstable::writer::{SSTableFormat, SSTableWriter};
+    use crate::storage::write_engine::mutation::{
+        CellOperation, ClusteringKey, Mutation, PartitionKey, TableId,
+    };
+    use crate::types::Value;
+
+    let schema = set_schema();
+    let dir = tempfile::TempDir::new().unwrap();
+    let mut writer =
+        SSTableWriter::with_format(dir.path().to_path_buf(), 1, &schema, 16, SSTableFormat::Big)
+            .unwrap();
+
+    // Row marker at 1e6; element `1` at its OWN ts=1e6 (shadowed), element `2` at
+    // ts=3e6 (survives). Set members store the element in the cell path.
+    let elem = |v: i32, ts: i64| CellOperation::WriteComplexElement {
+        column: "tags".to_string(),
+        cell_path: v.to_be_bytes().to_vec(),
+        value: None,
+        timestamp_micros: ts,
+        ttl_seconds: None,
+        local_deletion_time: None,
+        is_deleted: false,
+    };
+    let m = Mutation::new(
+        TableId::new("ks", "t"),
+        PartitionKey::single("pk", Value::Integer(1)),
+        Some(ClusteringKey::single("ck", Value::Integer(1))),
+        vec![elem(1, 1_000_000), elem(2, 3_000_000)],
+        1_000_000,
+        None,
+    );
+    let key = m.decorated_key(&schema).unwrap();
+    writer.write_partition(key, vec![m]).unwrap();
+    let info = writer.finish().await.unwrap();
+
+    let config = crate::Config::default();
+    let platform = std::sync::Arc::new(crate::platform::Platform::new(&config).await.unwrap());
+    let reader =
+        crate::storage::sstable::reader::SSTableReader::open(&info.data_path, &config, platform)
+            .await
+            .unwrap();
+    let cursor = reader.new_scan_cursor().await.unwrap();
+    let mut buf = reader.stitch_all_chunks(&cursor).await.unwrap();
+    patch_partition_tombstone(&mut buf, 2_000_000);
+
+    let phys = emit_rows(&reader.build_v5_parser(false), &buf, &schema, &reader);
+    let shadow = emit_rows(&reader.build_v5_parser(true), &buf, &schema, &reader);
+
+    assert_eq!(phys.len(), 1, "physical parse emits the row");
+    assert_eq!(
+        tag_ints(&phys[0]),
+        vec![1, 2],
+        "physical (no-shadow) parse must carry BOTH set elements (anti-empty-pass)"
+    );
+
+    assert_eq!(
+        shadow.len(),
+        1,
+        "the row survives because its element 2 (ts 3e6) is newer than the tombstone (2e6)"
+    );
+    assert_eq!(
+        tag_ints(&shadow[0]),
+        vec![2],
+        "per-element filtering: only element 2 (ts 3e6 > 2e6) survives; the shadowed \
+         element 1 (ts 1e6 <= 2e6) must be dropped from WITHIN the surviving set"
+    );
+}
+
+/// Issue #1741 (per-element filtering, test 3 — all elements shadowed): a
+/// non-frozen `set<int>` whose EVERY element predates the covering tombstone must
+/// read as ABSENT (no `tags` column), even when the ROW itself survives via a
+/// DIFFERENT live cell. Set elements `1` and `2` are both at ts=1e6 (<= tombstone
+/// 2e6, shadowed) while a scalar `note='keep'` cell (and the row marker) is at
+/// ts=3e6 (> 2e6, survives). A Cassandra `SELECT` returns the row with `note` but
+/// NO `tags` — an all-shadowed non-frozen collection is null and must not keep the
+/// column present.
+///
+/// Revert-verify: with per-element filtering removed the whole collection is kept
+/// (its effective max ts folds the surviving row ts 3e6 > 2e6, so the old
+/// whole-collection drop does NOT fire), so both stale elements reappear and the
+/// `tags`-absent assertion FAILS; the physical parse still shows them
+/// (anti-empty-pass).
+#[cfg(feature = "write-support")]
+#[tokio::test]
+async fn all_shadowed_collection_reads_as_absent() {
+    use crate::storage::sstable::writer::{SSTableFormat, SSTableWriter};
+    use crate::storage::write_engine::mutation::{
+        CellOperation, ClusteringKey, Mutation, PartitionKey, TableId,
+    };
+    use crate::types::Value;
+
+    let schema = set_scalar_schema();
+    let dir = tempfile::TempDir::new().unwrap();
+    let mut writer =
+        SSTableWriter::with_format(dir.path().to_path_buf(), 1, &schema, 16, SSTableFormat::Big)
+            .unwrap();
+
+    let elem = |v: i32, ts: i64| CellOperation::WriteComplexElement {
+        column: "tags".to_string(),
+        cell_path: v.to_be_bytes().to_vec(),
+        value: None,
+        timestamp_micros: ts,
+        ttl_seconds: None,
+        local_deletion_time: None,
+        is_deleted: false,
+    };
+    // Scalar `note` + row marker at 3e6 (survives the tombstone); both set elements
+    // at 1e6 (shadowed).
+    let m = Mutation::new(
+        TableId::new("ks", "t"),
+        PartitionKey::single("pk", Value::Integer(1)),
+        Some(ClusteringKey::single("ck", Value::Integer(1))),
+        vec![
+            CellOperation::Write {
+                column: "note".to_string(),
+                value: Value::Text("keep".to_string()),
+            },
+            elem(1, 1_000_000),
+            elem(2, 1_000_000),
+        ],
+        3_000_000,
+        None,
+    );
+    let key = m.decorated_key(&schema).unwrap();
+    writer.write_partition(key, vec![m]).unwrap();
+    let info = writer.finish().await.unwrap();
+
+    let config = crate::Config::default();
+    let platform = std::sync::Arc::new(crate::platform::Platform::new(&config).await.unwrap());
+    let reader =
+        crate::storage::sstable::reader::SSTableReader::open(&info.data_path, &config, platform)
+            .await
+            .unwrap();
+    let cursor = reader.new_scan_cursor().await.unwrap();
+    let mut buf = reader.stitch_all_chunks(&cursor).await.unwrap();
+    patch_partition_tombstone(&mut buf, 2_000_000);
+
+    let phys = emit_rows(&reader.build_v5_parser(false), &buf, &schema, &reader);
+    let shadow = emit_rows(&reader.build_v5_parser(true), &buf, &schema, &reader);
+
+    assert_eq!(phys.len(), 1, "physical parse emits the row");
+    assert_eq!(
+        tag_ints(&phys[0]),
+        vec![1, 2],
+        "physical (no-shadow) parse must carry BOTH shadowed elements (anti-empty-pass)"
+    );
+
+    assert_eq!(
+        shadow.len(),
+        1,
+        "the row survives via its live scalar cell (note @3e6 > tombstone 2e6)"
+    );
+    assert!(
+        shadow[0].iter().any(|(n, _)| &**n == "note"),
+        "the surviving row must keep its live scalar 'note' cell"
+    );
+    assert!(
+        !shadow[0].iter().any(|(n, _)| &**n == "tags"),
+        "per-element filtering: every set element (ts 1e6 <= 2e6) is shadowed, so the \
+         collection reads as ABSENT and must NOT resurface the stale elements"
+    );
+}

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/regression_1741h_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/regression_1741h_tests.rs
@@ -1,0 +1,191 @@
+//! Issue #1741 (roborev pass H): regression pins for two holes in the read-time
+//! TTL/shadowing path.
+//!
+//! Finding 1 (MEDIUM, CORRECTNESS) — the row-liveness `localExpirationTime`
+//! (`liveness_expires_at_seconds`, from `HAS_TTL`) was decoded/stored as `i32`.
+//! On oa/da (`hasUIntDeletionTime`) a TTL expiry after 2038 occupies the UNSIGNED
+//! 32-bit range `[2^31, 2^32)`; casting it to `i32` wrapped it NEGATIVE, so the
+//! read-time TTL filter saw a long-past expiry and HID a still-live row. The fix
+//! decodes it as an UNSIGNED `u32`→`i64` (mirroring the row/complex deletion LDT
+//! reader) and stores it as `i64`.
+//!
+//! Finding 2 (LOW, CONSISTENCY) — the read clock (`now_secs`) was sampled per
+//! block via `now_epoch_secs()`, so a scan crossing an expiration-second boundary
+//! could decide two rows with the same TTL differently. The fix captures `now_secs`
+//! ONCE in `V5CompressedLegacyParser::new` (the per-read/scan context) and reuses it
+//! for every block/partition, so the boundary decision is a pure function of one
+//! fixed `now`.
+
+use super::{RowHeader, V5CompressedLegacyParser};
+use crate::storage::sstable::version_gate::{BigVersionGates, VersionGates};
+use std::sync::Arc;
+
+/// A post-2038 epoch-second expiry that does NOT fit in `i32` (> `i32::MAX`,
+/// < `u32::MAX`). `4_000_000_000` s ≈ year 2096.
+const POST_2038_EXPIRY_SECS: i64 = 4_000_000_000;
+
+/// A "now" well BEFORE `POST_2038_EXPIRY_SECS` (year 2023) so the row is still live.
+const NOW_2023_SECS: i64 = 1_700_000_000;
+
+/// Build a parser on the oa (BIG, `hasUIntDeletionTime`) path.
+fn oa_parser() -> V5CompressedLegacyParser {
+    let gates = VersionGates::Big(BigVersionGates::from_version("oa").expect("oa gates"));
+    V5CompressedLegacyParser::new("ks".to_string(), "tbl".to_string(), 0, 0, Some(0))
+        .with_version_gates(Arc::new(gates))
+}
+
+/// Build a parser on the nb (BIG, signed deletion time) path.
+fn nb_parser() -> V5CompressedLegacyParser {
+    // `new` defaults to the nb-compatible gates (`has_uint_deletion_time == false`).
+    V5CompressedLegacyParser::new("ks".to_string(), "tbl".to_string(), 0, 0, Some(0))
+}
+
+/// Serialize a `HAS_TTL | HAS_ALL_COLUMNS` row header carrying `ttl_delta` and
+/// `ldt_delta` (both unsigned VInt deltas). No HAS_TIMESTAMP / HAS_DELETION.
+/// Layout consumed by `parse_row_metadata` (which starts AFTER the flags byte):
+///   [flags=0x28][row_size=0][prev_size=0][ttl_delta][ldt_delta]
+fn has_ttl_row_bytes(ttl_delta: u64, ldt_delta: u64) -> Vec<u8> {
+    use crate::storage::serialization::vint::encode_unsigned;
+    let mut data = vec![0x28u8, 0x00, 0x00]; // flags, row_size=0, prev_size=0
+    encode_unsigned(ttl_delta, &mut data);
+    encode_unsigned(ldt_delta, &mut data);
+    data
+}
+
+/// Decode a `HAS_TTL` row header and return its `liveness_expires_at_seconds`.
+fn decode_liveness_expiry(parser: &V5CompressedLegacyParser, data: &[u8]) -> Option<i64> {
+    let (row_flags, ext_flags, flags_size) =
+        parser.parse_row_flags(data, 0).expect("parse_row_flags");
+    let (header, _row_size) = parser
+        .parse_row_metadata(data, flags_size, row_flags, ext_flags)
+        .expect("parse_row_metadata");
+    header.liveness_expires_at_seconds
+}
+
+/// A minimal live `RowHeader` carrying only a pk-liveness timestamp + TTL expiry.
+fn liveness_row(timestamp_micros: Option<i64>, liveness_expiry_secs: Option<i64>) -> RowHeader {
+    RowHeader {
+        timestamp: timestamp_micros,
+        ttl: None,
+        liveness_expires_at_seconds: liveness_expiry_secs,
+        local_deletion_time: None,
+        marked_for_delete_at: None,
+        header_size: 0,
+        row_size_vint_len: 0,
+        missing_columns_bitmap: None,
+        max_data_cell_timestamp: None,
+        max_data_cell_expires_at: None,
+        has_live_forever_data_cell: false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Finding 1: post-2038 oa/da liveness expiry must NOT wrap negative and must
+// keep a still-live row visible.
+// ---------------------------------------------------------------------------
+
+/// Decode + decision end-to-end. On the oa (`hasUIntDeletionTime`) path a liveness
+/// TTL expiry after 2038 must decode to a LARGE POSITIVE second count and the row
+/// must be treated as LIVE at a "now" before the expiry.
+///
+/// Revert-verify: reverting the decode to `... as i32 as i64` (dropping the
+/// `has_uint_deletion_time()` branch in `row_framing.rs`) makes the decoded value
+/// wrap NEGATIVE (`4_000_000_000 as i32 == -294_967_296`); the positive-value
+/// assertion FAILS and `row_liveness_expired` then hides the still-live row, so the
+/// `!expired` assertion FAILS too.
+#[test]
+fn oa_post_2038_liveness_expiry_is_positive_and_row_stays_live() {
+    let parser = oa_parser();
+    let data = has_ttl_row_bytes(0, POST_2038_EXPIRY_SECS as u64);
+
+    let decoded = decode_liveness_expiry(&parser, &data).expect("HAS_TTL sets liveness expiry");
+    assert_eq!(
+        decoded, POST_2038_EXPIRY_SECS,
+        "oa post-2038 liveness expiry must decode as UNSIGNED (u32→i64), not wrap negative; \
+         got {decoded}"
+    );
+    assert!(
+        decoded > i32::MAX as i64,
+        "sanity: the fixture expiry must exceed i32::MAX to exercise the wrap path"
+    );
+
+    // Downstream shadow decision: a TTL INSERT row (pk-liveness timestamp present)
+    // whose expiry is in 2096 must be LIVE at a 2023 read clock.
+    let mut header = liveness_row(Some(1_000), Some(decoded));
+    header.timestamp = Some(1_000);
+    assert!(
+        !header.row_liveness_expired(NOW_2023_SECS),
+        "a row whose post-2038 TTL expiry is still in the future must NOT be hidden"
+    );
+}
+
+/// The nb (signed) path is unchanged: a normal in-range liveness expiry decodes to
+/// exactly its value (sign-extension is a no-op for positive < i32::MAX values).
+#[test]
+fn nb_liveness_expiry_decode_unchanged() {
+    let parser = nb_parser();
+    let in_range = 1_700_000_000i64; // year 2023, fits i32
+    let data = has_ttl_row_bytes(0, in_range as u64);
+
+    let decoded = decode_liveness_expiry(&parser, &data).expect("HAS_TTL sets liveness expiry");
+    assert_eq!(
+        decoded, in_range,
+        "nb liveness expiry (in i32 range) must decode to its plain value"
+    );
+    // And an nb expiry already in the past hides the row (TTL semantics preserved).
+    let mut header = liveness_row(Some(1_000), Some(decoded));
+    header.timestamp = Some(1_000);
+    assert!(
+        header.row_liveness_expired(in_range + 1),
+        "nb row past its liveness expiry must be hidden"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Finding 2: one `now_secs` per read/scan, captured at parser construction; the
+// expiration-boundary decision is a pure function of that single fixed value.
+// ---------------------------------------------------------------------------
+
+/// The parser captures a single `now_secs` at construction and reuses it. With that
+/// ONE fixed clock, a row whose liveness expiry equals `now` is decided uniformly
+/// (hidden — Cassandra hides at `now >= localExpirationTime`), and `now + 1` is
+/// uniformly visible. Because the block-emit paths read `self.now_secs` (not a
+/// per-block wall-clock sample), every block of a scan crossing the second boundary
+/// applies the same `now`.
+#[test]
+fn single_now_secs_decides_boundary_uniformly() {
+    let parser = nb_parser();
+    let now = parser.now_secs;
+    assert!(
+        now > 0,
+        "now_secs must be sampled from the read clock at construction"
+    );
+    // Re-reading the field yields the SAME value: it is captured once, not resampled.
+    assert_eq!(
+        parser.now_secs, now,
+        "now_secs must be a single fixed per-read value"
+    );
+
+    // Two rows parsed in different "blocks" of the same scan share this one `now`.
+    let mut at_boundary = liveness_row(Some(1_000), Some(now));
+    at_boundary.timestamp = Some(1_000);
+    let mut past_boundary = liveness_row(Some(1_000), Some(now - 1));
+    past_boundary.timestamp = Some(1_000);
+    let mut future = liveness_row(Some(1_000), Some(now + 1));
+    future.timestamp = Some(1_000);
+
+    // expiry == now  → expired (hidden), decided identically for every block.
+    assert!(
+        at_boundary.row_liveness_expired(now),
+        "a row whose TTL expiry equals now must be hidden (now >= localExpirationTime)"
+    );
+    assert!(
+        past_boundary.row_liveness_expired(now),
+        "a row whose TTL expiry is before now must be hidden"
+    );
+    // expiry == now + 1 → still live (visible).
+    assert!(
+        !future.row_liveness_expired(now),
+        "a row whose TTL expiry is after now must stay visible"
+    );
+}

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/regression_1741k_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/regression_1741k_tests.rs
@@ -1,0 +1,366 @@
+//! Issue #1741 (roborev pass K): regression pin for a chunk-boundary desync
+//! introduced by the earlier oa/da deletion-time header-min-size fix.
+//!
+//! Finding (HIGH): the two sliding parsers
+//! (`parse_one_partition_with_timestamps`, `parse_one_partition_for_compaction`)
+//! sized the oa/da (`hasUIntDeletionTime`) partition header minimum at a flat
+//! 1 byte. But only the LIVE sentinel (`0x80`) is 1 byte; a DELETED oa/da
+//! partition carries the full 12-byte DeletionTime (8-byte `markedForDeleteAt`
+//! plus 4-byte unsigned `localDeletionTime`). If a deleted partition header was
+//! split across a NON-FINAL chunk with only the first deletion byte present, the
+//! guard wrongly allowed parsing: `parse_partition_header_full` failed mid-buffer
+//! and the sliding parser returned `Emitted(1)` (a byte skip) instead of
+//! `NeedMore`, desyncing the scan. On the COMPACTION path that dropped the
+//! partition tombstone, letting older/deleted data survive or resurface.
+//!
+//! The fix routes both parsers' need-more decision through
+//! [`super::V5CompressedLegacyParser::partition_header_readiness`], which peeks the
+//! DeletionTime discriminator to size the header correctly and returns `Incomplete`
+//! (mapped to `NeedMore` on a non-final chunk) when the full deleted DeletionTime
+//! is not yet present.
+//!
+//! Test shape (two layers):
+//!
+//! - Deterministic unit tests on `partition_header_readiness` itself. Both sliding
+//!   parsers route their emit/need-more decision through this one classifier, so a
+//!   unit test on it deterministically pins both. No reader/schema/feature needed.
+//! - End-to-end tests (write-support gated) that drive the ACTUAL sliding parsers
+//!   over a hand-constructed split buffer, using a real `da` reader for the schema
+//!   resolution. A real chunked fixture is not synthesizable here: Cassandra purges
+//!   rows covered by a partition tombstone at flush and compression chunk
+//!   boundaries are not byte-addressable, so a real SSTable cannot place a deleted
+//!   partition's 12-byte DeletionTime exactly astride a chunk boundary. The
+//!   hand-built split buffer reproduces that exact shape directly.
+
+use super::V5CompressedLegacyParser;
+use crate::storage::sstable::version_gate::{BigVersionGates, BtiVersionGates, VersionGates};
+use std::sync::Arc;
+
+use super::PartitionHeaderReadiness;
+
+/// Build a parser on the oa (BIG, `hasUIntDeletionTime`) path.
+fn oa_parser() -> V5CompressedLegacyParser {
+    let gates = VersionGates::Big(BigVersionGates::from_version("oa").expect("oa gates"));
+    V5CompressedLegacyParser::new("ks".to_string(), "tbl".to_string(), 0, 0, Some(0))
+        .with_version_gates(Arc::new(gates))
+}
+
+/// Build a parser on the da (BTI, `hasUIntDeletionTime`) path.
+fn da_parser() -> V5CompressedLegacyParser {
+    let gates = VersionGates::Bti(BtiVersionGates::from_version("da").expect("da gates"));
+    V5CompressedLegacyParser::new("ks".to_string(), "tbl".to_string(), 0, 0, Some(0))
+        .with_version_gates(Arc::new(gates))
+}
+
+/// Build a parser on the nb (BIG, signed 12-byte deletion time) path.
+fn nb_parser() -> V5CompressedLegacyParser {
+    // `new` defaults to the nb-compatible gates (`has_uint_deletion_time == false`).
+    V5CompressedLegacyParser::new("ks".to_string(), "tbl".to_string(), 0, 0, Some(0))
+}
+
+/// Bytes of a DELETED oa/da partition header for a 4-byte (int) partition key.
+///
+/// Layout: `flags(1) | key_len(1) | key(4) | markedForDeleteAt(i64 BE, 8) |
+/// localDeletionTime(u32 BE, 4)`. The first `markedForDeleteAt` byte is `0x00`
+/// (bit 7 clear) so the discriminator is NOT the `0x80` LIVE sentinel — i.e. this
+/// is unambiguously the 12-byte DELETED form.
+fn deleted_oa_partition_header() -> Vec<u8> {
+    let mut buf = Vec::new();
+    buf.push(0x00); // partition flags
+    buf.push(0x04); // key length (int pk = 4 bytes)
+    buf.extend_from_slice(&42i32.to_be_bytes()); // partition key
+                                                 // markedForDeleteAt = 1_000_000 µs → high byte 0x00 (bit 7 clear).
+    buf.extend_from_slice(&1_000_000i64.to_be_bytes());
+    // localDeletionTime = 1_600_000_000 s (~year 2020), a real tombstone LDT.
+    buf.extend_from_slice(&1_600_000_000u32.to_be_bytes());
+    buf
+}
+
+/// The offset of the DeletionTime discriminator byte in the header above.
+const DELETION_DISCRIMINATOR_OFFSET: usize = 2 + 4; // flags + key_len + key
+
+// ---------------------------------------------------------------------------
+// Layer 1: deterministic unit tests on the shared need-more classifier.
+// ---------------------------------------------------------------------------
+
+/// A DELETED oa/da partition header split so a NON-FINAL chunk holds only the
+/// partition key + the FIRST deletion byte (not the full 12-byte DeletionTime)
+/// must be classified `Incomplete` (→ `NeedMore`), never `Ready`.
+///
+/// Revert-verify: with the classifier sizing the oa/da header minimum at a flat
+/// 1 byte (`deletion_time_min = 1`), this split buffer is `Ready` (the pre-fix
+/// bug), so the `Incomplete` assertion FAILS.
+#[test]
+fn deleted_oa_header_split_at_first_deletion_byte_needs_more() {
+    let full = deleted_oa_partition_header();
+    // Keep only up to and including the first deletion byte.
+    let split = &full[..=DELETION_DISCRIMINATOR_OFFSET];
+    assert_eq!(
+        split.len(),
+        DELETION_DISCRIMINATOR_OFFSET + 1,
+        "sanity: split holds key + exactly one deletion byte"
+    );
+
+    for parser in [oa_parser(), da_parser()] {
+        assert_eq!(
+            parser.partition_header_readiness(split),
+            PartitionHeaderReadiness::Incomplete,
+            "a deleted oa/da header with only the first deletion byte present must be Incomplete"
+        );
+        // Once the full 12-byte DeletionTime is present, it becomes Ready.
+        assert_eq!(
+            parser.partition_header_readiness(&full),
+            PartitionHeaderReadiness::Ready,
+            "the complete deleted oa/da header must be Ready"
+        );
+    }
+}
+
+/// The discriminator byte itself not yet present (chunk ends right after the key)
+/// is also `Incomplete` — we must not guess the deletion form.
+#[test]
+fn oa_header_without_discriminator_byte_needs_more() {
+    let full = deleted_oa_partition_header();
+    let no_disc = &full[..DELETION_DISCRIMINATOR_OFFSET]; // flags + key_len + key only
+    assert_eq!(
+        oa_parser().partition_header_readiness(no_disc),
+        PartitionHeaderReadiness::Incomplete
+    );
+}
+
+/// A LIVE oa/da partition (1-byte `0x80` sentinel) is `Ready` with just that one
+/// byte present — the fix must not over-require bytes for the live form.
+#[test]
+fn live_oa_header_is_ready_with_one_deletion_byte() {
+    let mut buf = vec![0x00u8, 0x04];
+    buf.extend_from_slice(&42i32.to_be_bytes());
+    buf.push(super::row_framing::OA_IS_LIVE_DELETION); // 0x80 LIVE sentinel
+    for parser in [oa_parser(), da_parser()] {
+        assert_eq!(
+            parser.partition_header_readiness(&buf),
+            PartitionHeaderReadiness::Ready,
+            "a live oa/da partition needs only its single 0x80 sentinel byte"
+        );
+    }
+}
+
+/// The nb (signed) path is unchanged: it always requires the fixed 12-byte
+/// DeletionTime regardless of the deletion state.
+#[test]
+fn nb_header_always_requires_full_twelve_bytes() {
+    let parser = nb_parser();
+    let mut buf = vec![0x00u8, 0x04];
+    buf.extend_from_slice(&42i32.to_be_bytes());
+    // Only 1 of the 12 deletion bytes present → Incomplete for nb.
+    buf.push(0x00);
+    assert_eq!(
+        parser.partition_header_readiness(&buf),
+        PartitionHeaderReadiness::Incomplete
+    );
+    // Fill out the remaining 11 bytes → Ready.
+    buf.extend_from_slice(&[0u8; 11]);
+    assert_eq!(
+        parser.partition_header_readiness(&buf),
+        PartitionHeaderReadiness::Ready
+    );
+}
+
+/// An invalid header shape (zero key length) is `Malformed` (→ skip a byte),
+/// distinct from `Incomplete`.
+#[test]
+fn zero_key_length_is_malformed() {
+    assert_eq!(
+        oa_parser().partition_header_readiness(&[0x00, 0x00]),
+        PartitionHeaderReadiness::Malformed
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Layer 2: end-to-end over the ACTUAL sliding parsers with a real da reader.
+// ---------------------------------------------------------------------------
+
+/// pk-only `tiny(pk int, v text)` schema used to mint a real `da` reader.
+#[cfg(feature = "write-support")]
+fn tiny_schema() -> crate::schema::TableSchema {
+    use crate::schema::{Column, KeyColumn};
+    crate::schema::TableSchema {
+        keyspace: "test_ks".to_string(),
+        table: "tiny".to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "pk".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            Column {
+                name: "pk".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "v".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: std::collections::HashMap::new(),
+        dropped_columns: std::collections::HashMap::new(),
+    }
+}
+
+/// Open a freshly written tiny `da` SSTable, returning `(reader, schema)`. The
+/// reader is only needed for the sliding parsers' schema→column resolution and to
+/// put the parser on the oa/da (`hasUIntDeletionTime`) path; the hand-built buffers
+/// we feed carry their own bytes.
+#[cfg(feature = "write-support")]
+async fn da_reader() -> (
+    crate::storage::sstable::reader::SSTableReader,
+    crate::schema::TableSchema,
+) {
+    use crate::storage::sstable::writer::{SSTableFormat, SSTableWriter};
+    use crate::storage::write_engine::mutation::{CellOperation, Mutation, PartitionKey, TableId};
+    use crate::types::Value;
+
+    let schema = tiny_schema();
+    let dir = Box::leak(Box::new(tempfile::TempDir::new().unwrap()));
+    let mut writer =
+        SSTableWriter::with_format(dir.path().to_path_buf(), 1, &schema, 16, SSTableFormat::Bti)
+            .unwrap();
+    let mutation = Mutation::new(
+        TableId::new("test_ks", "tiny"),
+        PartitionKey::single("pk", Value::Integer(7)),
+        None,
+        vec![CellOperation::Write {
+            column: "v".to_string(),
+            value: Value::Text("x".to_string()),
+        }],
+        1_000_000,
+        None,
+    );
+    let key = mutation.decorated_key(&schema).unwrap();
+    writer.write_partition(key, vec![mutation]).unwrap();
+    let info = writer.finish().await.unwrap();
+
+    let config = crate::Config::default();
+    let platform = std::sync::Arc::new(crate::platform::Platform::new(&config).await.unwrap());
+    let reader =
+        crate::storage::sstable::reader::SSTableReader::open(&info.data_path, &config, platform)
+            .await
+            .unwrap();
+    assert!(
+        reader.has_uint_deletion_time(),
+        "sanity: the da reader must be on the hasUIntDeletionTime path"
+    );
+    (reader, schema)
+}
+
+/// A full DELETED-partition buffer that parses cleanly: the deleted header
+/// followed by an END_OF_PARTITION marker (0x01) so the row loop terminates with
+/// zero rows.
+fn deleted_partition_full_buffer() -> Vec<u8> {
+    let mut buf = deleted_oa_partition_header();
+    buf.push(0x01); // END_OF_PARTITION
+    buf
+}
+
+/// Windowed streaming sliding parser: a deleted oa/da header split so the
+/// non-final chunk holds only key + the first deletion byte must return
+/// `NeedMore`, then parse cleanly once the rest of the DeletionTime arrives.
+///
+/// Revert-verify: with the flat 1-byte oa minimum, the split chunk passes the
+/// header guard, `parse_partition_header_full` fails on the truncated 12-byte
+/// DeletionTime and the parser returns `Emitted(1)` — the desync. The `NeedMore`
+/// assertion FAILS.
+#[cfg(feature = "write-support")]
+#[tokio::test]
+async fn windowed_parser_needs_more_on_split_deleted_header() {
+    let (reader, schema) = da_reader().await;
+    let parser = reader.build_v5_parser(false);
+
+    let full = deleted_partition_full_buffer();
+    let split = &full[..=DELETION_DISCRIMINATOR_OFFSET];
+
+    // Non-final chunk with only the first deletion byte → NeedMore, emit nothing.
+    let mut emitted = 0usize;
+    let step = parser
+        .parse_one_partition_with_timestamps(split, Some(&schema), &reader, false, &mut |_e| {
+            emitted += 1;
+            Ok(std::ops::ControlFlow::Continue(()))
+        })
+        .unwrap();
+    assert!(
+        matches!(step, super::ParseStep::NeedMore),
+        "split deleted header on a non-final chunk must return NeedMore, got {step:?}"
+    );
+    assert_eq!(emitted, 0, "no row may be emitted from the truncated chunk");
+
+    // Once the full buffer is available, the partition parses cleanly.
+    let step = parser
+        .parse_one_partition_with_timestamps(&full, Some(&schema), &reader, true, &mut |_e| {
+            Ok(std::ops::ControlFlow::Continue(()))
+        })
+        .unwrap();
+    assert!(
+        matches!(step, super::ParseStep::Emitted(_)),
+        "the complete deleted partition must parse as Emitted, got {step:?}"
+    );
+}
+
+/// Compaction sliding parser: the same split must return `NeedMore` (not skip a
+/// byte), and once complete it must surface the partition tombstone as a
+/// `PartitionDelete` `CompactionRow` — i.e. the tombstone is NOT dropped.
+///
+/// Revert-verify: with the flat 1-byte oa minimum, the split chunk returns
+/// `Emitted(1)` and NO `PartitionDelete` row is produced — the partition tombstone
+/// is dropped (the resurrection risk). Both assertions FAIL.
+#[cfg(feature = "write-support")]
+#[tokio::test]
+async fn compaction_parser_preserves_tombstone_across_split() {
+    use crate::storage::sstable::reader::compaction_row::CompactionRowData;
+
+    let (reader, schema) = da_reader().await;
+    let parser = reader.build_v5_parser(false);
+
+    let full = deleted_partition_full_buffer();
+    let split = &full[..=DELETION_DISCRIMINATOR_OFFSET];
+
+    // Non-final split chunk → NeedMore, no CompactionRow.
+    let mut rows: Vec<crate::storage::sstable::reader::compaction_row::CompactionRow> = Vec::new();
+    let step = parser
+        .parse_one_partition_for_compaction(split, Some(&schema), &reader, false, &mut |r| {
+            rows.push(r);
+            Ok(std::ops::ControlFlow::Continue(()))
+        })
+        .unwrap();
+    assert!(
+        matches!(step, super::ParseStep::NeedMore),
+        "split deleted header on a non-final chunk must return NeedMore, got {step:?}"
+    );
+    assert!(
+        rows.is_empty(),
+        "nothing may be emitted from the truncated chunk"
+    );
+
+    // Full buffer (final) → the partition tombstone survives as a PartitionDelete.
+    let step = parser
+        .parse_one_partition_for_compaction(&full, Some(&schema), &reader, true, &mut |r| {
+            rows.push(r);
+            Ok(std::ops::ControlFlow::Continue(()))
+        })
+        .unwrap();
+    assert!(
+        matches!(step, super::ParseStep::Emitted(_)),
+        "the complete deleted partition must parse as Emitted, got {step:?}"
+    );
+    assert!(
+        rows.iter()
+            .any(|r| matches!(r.row_data, CompactionRowData::PartitionDelete { .. })),
+        "the partition tombstone must survive compaction parsing as a PartitionDelete row \
+         (dropping it would resurrect older data); got {rows:?}"
+    );
+}

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/row_data.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/row_data.rs
@@ -18,6 +18,11 @@ impl V5CompressedLegacyParser {
         reader: &crate::storage::sstable::reader::types::SSTableReader,
         want_cell_metadata: bool,
         resolution: &RowColumnResolution,
+        // Issue #1741 (Finding 1): read-side shadow for per-cell tombstone/TTL
+        // filtering. `Some` only on user-facing SELECT reads (`read_shadowing`);
+        // `None` for every physical consumer (compaction / delta-scan / tests), which
+        // stay byte-unchanged.
+        shadow: Option<&PartitionShadow>,
     ) -> Result<ParsedRow> {
         self.parse_row_data_with_offset_impl(
             data,
@@ -27,6 +32,7 @@ impl V5CompressedLegacyParser {
             want_cell_metadata,
             None,
             resolution,
+            shadow,
         )
     }
 
@@ -46,6 +52,7 @@ impl V5CompressedLegacyParser {
         want_cell_metadata: bool,
         mut compaction_complex_out: Option<&mut CompactionComplexColumns>,
         resolution: &RowColumnResolution,
+        shadow: Option<&PartitionShadow>,
     ) -> Result<ParsedRow> {
         // Cells map keyed by the interned column-name handle (issue #1334): the
         // name is a schema-owned `Arc<str>` shared across every cell/row, so
@@ -145,6 +152,16 @@ impl V5CompressedLegacyParser {
             }
         }
 
+        // Issue #1741 (Finding 1): per-cell shadow context for this row. `Some` only
+        // on the user-facing SELECT path. `covering` is the deletion (µs) that shadows
+        // any data older than it (partition tombstone folded with the open range
+        // tombstone when this row's clustering falls inside it); `now` is the read
+        // clock for per-cell TTL expiry. A data cell / whole collection whose
+        // effective write ts <= `covering`, or which is TTL-expired at `now`, is
+        // dropped below (no new per-cell allocation — the insert is made conditional).
+        let cell_ctx: Option<(Option<i64>, i64)> =
+            shadow.map(|sh| sh.cell_context(&clustering_values));
+
         // Step 3: Parse row metadata (row_size, prev_size, timestamps, etc.)
         //
         // CRITICAL (Issue #237): Save offset where row_size VInt STARTS.
@@ -152,7 +169,7 @@ impl V5CompressedLegacyParser {
         // Formula: next_offset = (row_metadata_offset + row_size_vint_len) + row_size
         // This offset is right after the clustering prefix (which was already parsed).
         let row_metadata_offset = offset;
-        let (row_header, row_size) =
+        let (mut row_header, row_size) =
             self.parse_row_metadata(data, offset, row_flags, extended_flags)?;
 
         // CRITICAL VALIDATION: row_size must be reasonable
@@ -329,6 +346,16 @@ impl V5CompressedLegacyParser {
             log::debug!("V5CompressedLegacy: Row has HAS_COMPLEX_DELETION flag (0x40) set");
         }
 
+        // Issue #1741 read-side shadowing aggregate. Computed from scalars the cell
+        // parser already returns (no new allocation, no extra HashMap): the max data
+        // cell write timestamp, the max expiring-cell expiry, and whether any data
+        // cell is live-forever. Stashed on `row_header` after the loop and consulted
+        // by the read emit paths to hide partition/range-tombstone-shadowed and
+        // TTL-expired rows. Kept off the write/compaction reconciliation path.
+        let mut agg_max_cell_ts: Option<i64> = None;
+        let mut agg_max_expires_at: Option<i64> = None;
+        let mut agg_has_live_forever = false;
+
         for (col_idx, ctp) in columns_in_order.iter().enumerate() {
             // Skip columns marked MISSING by the row's bitmap (inline, no per-row
             // allocation). `col_idx` is the ON-DISK column index — exactly what the
@@ -410,6 +437,9 @@ impl V5CompressedLegacyParser {
                         has_complex_deletion,
                         row_ts,
                         Some(&mut element_buf),
+                        // Compaction / delta read path: NO per-element filtering (it
+                        // needs every element for reconciliation) — byte-unchanged.
+                        None,
                     )
                     .map(|(value, new_offset, col_meta)| {
                         if emit {
@@ -425,6 +455,33 @@ impl V5CompressedLegacyParser {
                         (value, new_offset, col_meta)
                     })
                 } else {
+                    // Issue #1741 (per-element filtering): on the user-facing SELECT
+                    // read path (`cell_ctx.is_some()`), thread the covering deletion +
+                    // read clock + row-liveness ts into the element loop so shadowed /
+                    // TTL-expired elements are skipped from the emitted container.
+                    // `None` when no shadow context is active (tombstone-free reads and
+                    // physical consumers) — byte-unchanged.
+                    let element_filter = cell_ctx.map(|(cover, now)| ElementShadow {
+                        cover,
+                        now,
+                        row_ts: row_header.timestamp,
+                        // Issue #1741: the effective row expiry a USE_ROW_TTL
+                        // collection element inherits — computed EXACTLY like the
+                        // scalar USE_ROW_TTL cell path (see the `None if use_row_ttl`
+                        // arm below): the pk-liveness localExpirationTime
+                        // (`liveness_expires_at_seconds`, year-2106-safe i64 from
+                        // HAS_TTL), falling back to the row `local_deletion_time`
+                        // re-read UNSIGNED on oa/da when the GC clock is post-2038.
+                        row_expires_at: row_header.liveness_expires_at_seconds.or_else(|| {
+                            row_header.local_deletion_time.map(|s| {
+                                if self.has_uint_deletion_time() {
+                                    (s as u32) as i64
+                                } else {
+                                    s as i64
+                                }
+                            })
+                        }),
+                    });
                     self.parse_complex_column(
                         data,
                         offset,
@@ -432,6 +489,7 @@ impl V5CompressedLegacyParser {
                         complex_type,
                         has_complex_deletion,
                         reader,
+                        element_filter,
                     )
                 };
                 match parse_result {
@@ -449,22 +507,68 @@ impl V5CompressedLegacyParser {
                         // here — that would silently change WRITETIME(col) on the ordinary path
                         // (roborev Finding 1).
                         if emit {
-                            if let Some(ref mut meta_map) = cell_meta {
-                                let row_ts = row_header.timestamp.unwrap_or(0);
-                                meta_map.insert(
-                                    column.name.clone(),
-                                    CellWriteMetadata {
-                                        write_timestamp_micros: row_ts,
-                                        expiration: None,
-                                    },
+                            // Issue #1741 (Finding 2): the collection's effective max
+                            // write ts is the newest of its element-level timestamps and
+                            // the row liveness ts inherited by USE_ROW_TIMESTAMP elements.
+                            // Folding `max_element_writetime` (not just the row ts) means a
+                            // collection element NEWER than a partition/range tombstone
+                            // keeps the row visible even when the row ts predates the
+                            // tombstone. `max_element_writetime` folds ALL live elements
+                            // (including shadow-dropped ones), so a wholly-shadowed
+                            // collection still contributes its element ts here.
+                            let coll_eff_ts = col_meta
+                                .max_element_writetime
+                                .max(row_header.timestamp.unwrap_or(i64::MIN));
+                            // Issue #1741 (per-element filtering): the shadowed/expired
+                            // elements have ALREADY been skipped from `value` inside
+                            // `parse_complex_column_inner`. The collection now reads as
+                            // ABSENT (null) iff the read-side filter EMPTIED it (every
+                            // element was shadowed/expired: `shadow_filtered_element_count
+                            // > 0` AND the container is empty). A collection empty for any
+                            // OTHER reason (genuinely empty / all element-tombstones, where
+                            // `shadow_filtered_element_count == 0`) keeps its prior
+                            // behavior, so tombstone-free reads and physical consumers are
+                            // byte-unchanged. `cover == None` never filters an element, so
+                            // a non-shadowing read never treats a collection as absent.
+                            let collection_absent = col_meta.shadow_filtered_element_count > 0
+                                && Self::complex_value_is_empty(&value);
+                            // Fold the collection into the ROW aggregate REGARDLESS of
+                            // absence (so a wholly-shadowed collection is still recognised
+                            // as shadowed by `row_hidden`, and Finding 2's newest-element ts
+                            // keeps a surviving row visible). Its expiring elements
+                            // contribute their expiry; `has_live_forever_element` is already
+                            // computed POST-filter, so a wholly-shadowed collection never
+                            // sets live-forever.
+                            if coll_eff_ts != i64::MIN {
+                                agg_max_cell_ts = Some(
+                                    agg_max_cell_ts.map_or(coll_eff_ts, |m| m.max(coll_eff_ts)),
                                 );
                             }
-                            // DS4 (Issue #700): Store ComplexColumnMeta for delta-scan callers.
-                            if let Some(ref mut ccm_map) = complex_col_meta {
-                                ccm_map.insert(column.name.clone(), col_meta);
+                            if let Some(e) = col_meta.max_element_expires_at {
+                                agg_max_expires_at =
+                                    Some(agg_max_expires_at.map_or(e, |m| m.max(e)));
                             }
-                            // Issue #1334: interned name handle (Arc::clone), no String alloc.
-                            cells.insert(Arc::clone(&ctp.name), value);
+                            if col_meta.has_live_forever_element {
+                                agg_has_live_forever = true;
+                            }
+                            if !collection_absent {
+                                if let Some(ref mut meta_map) = cell_meta {
+                                    let row_ts = row_header.timestamp.unwrap_or(0);
+                                    meta_map.insert(
+                                        column.name.clone(),
+                                        CellWriteMetadata {
+                                            write_timestamp_micros: row_ts,
+                                            expiration: None,
+                                        },
+                                    );
+                                }
+                                // DS4 (Issue #700): Store ComplexColumnMeta for delta-scan.
+                                if let Some(ref mut ccm_map) = complex_col_meta {
+                                    ccm_map.insert(column.name.clone(), col_meta);
+                                }
+                                // Issue #1334: interned name handle (Arc::clone), no alloc.
+                                cells.insert(Arc::clone(&ctp.name), value);
+                            }
                         }
                         offset = new_offset;
                     }
@@ -477,6 +581,10 @@ impl V5CompressedLegacyParser {
                     }
                 }
             } else {
+                // Issue #1741: peek the cell flags (offset points at the flags byte)
+                // to detect USE_ROW_TTL (0x10), which makes a cell with no explicit
+                // expiry inherit the ROW's expiry rather than being live-forever.
+                let cell_flags = data.get(offset).copied().unwrap_or(0);
                 match self.parse_cell_value_schema_order(data, offset, column, header_type, reader)
                 {
                     Ok((value, cell_own_ts, cell_exp, new_offset)) => {
@@ -494,6 +602,82 @@ impl V5CompressedLegacyParser {
                         // `emit` is false for a DROPPED column (issue #1080 Part 2): we still
                         // advanced `offset` to consume its bytes, but emit no cell/metadata.
                         if emit {
+                            // Issue #1741 read-side shadowing aggregate (scalars only,
+                            // no allocation). A cell tombstone is not live data. A live
+                            // cell contributes its effective write timestamp and, if
+                            // expiring (explicit per-cell TTL, or USE_ROW_TTL inheriting
+                            // the row's expiry), its expiry; otherwise it is live-forever.
+                            // Computed BEFORE the metadata block, which moves `cell_exp`.
+                            let mut dropped = false;
+                            if !matches!(value, Value::Tombstone(_)) {
+                                let eff_ts = cell_own_ts.or(row_header.timestamp);
+                                // A USE_ROW_TTL cell inherits the ROW's expiry. For a
+                                // TTL-bearing INSERT that expiry is the pk-liveness
+                                // localExpirationTime (`liveness_expires_at_seconds`,
+                                // from HAS_TTL); `local_deletion_time` is set only by
+                                // HAS_DELETION (row tombstone), so it is the fallback.
+                                let use_row_ttl = (cell_flags & 0x10) != 0;
+                                let eff_exp: Option<i64> = match cell_exp.as_ref() {
+                                    Some(e) => Some(e.expires_at_seconds),
+                                    None if use_row_ttl => {
+                                        // Liveness expiry is already the year-2106-safe
+                                        // i64 (unsigned-reinterpreted at decode, #1741 F1).
+                                        // The `local_deletion_time` fallback is stored as
+                                        // the `(u32) as i32` on-disk representation, so on
+                                        // oa/da a post-2038 GC clock must be re-read UNSIGNED
+                                        // here too rather than sign-extended negative.
+                                        row_header.liveness_expires_at_seconds.or_else(|| {
+                                            row_header.local_deletion_time.map(|s| {
+                                                if self.has_uint_deletion_time() {
+                                                    (s as u32) as i64
+                                                } else {
+                                                    s as i64
+                                                }
+                                            })
+                                        })
+                                    }
+                                    None => None,
+                                };
+                                // Issue #1741 (Finding 1): per-cell shadow/TTL filter.
+                                // Drop this data cell from the EMITTED map when its
+                                // effective write ts is shadowed by the covering deletion
+                                // (`eff_ts <= cover`) or it is TTL-expired at `now`.
+                                // `cell_ctx` is `None` for physical reads → never drops →
+                                // byte-unchanged.
+                                if let Some((cover, now)) = cell_ctx {
+                                    dropped = PartitionShadow::cell_shadowed_or_expired(
+                                        cover, now, eff_ts, eff_exp,
+                                    );
+                                }
+                                // Fold this cell into the ROW aggregate that drives the
+                                // row-level `row_hidden` decision. A dropped (shadowed/
+                                // expired) cell STILL contributes its ts + expiry — so a
+                                // row reduced to nothing is recognised as shadowed/expired
+                                // (its max ts stays `<= covering` / its expiry stays past)
+                                // rather than looking like an empty/truncated parse — but
+                                // it is NEVER counted live-forever (it is not live).
+                                if let Some(t) = eff_ts {
+                                    agg_max_cell_ts = Some(agg_max_cell_ts.map_or(t, |m| m.max(t)));
+                                }
+                                match eff_exp {
+                                    Some(e) => {
+                                        agg_max_expires_at =
+                                            Some(agg_max_expires_at.map_or(e, |m| m.max(e)));
+                                    }
+                                    None => {
+                                        if !dropped {
+                                            agg_has_live_forever = true;
+                                        }
+                                    }
+                                }
+                            }
+                            if dropped {
+                                offset = new_offset;
+                                continue;
+                            }
+                            // Only compute and store per-cell metadata when the caller requested it.
+                            // On the normal read hot-path (want_cell_metadata == false), cell_meta is
+                            // None and this entire block is skipped — zero allocations per cell.
                             if let Some(ref mut meta_map) = cell_meta {
                                 // Resolve effective write timestamp:
                                 // use cell's own timestamp when present, else row-level liveness timestamp.
@@ -542,6 +726,11 @@ impl V5CompressedLegacyParser {
                 }
             }
         }
+
+        // Issue #1741: stash the read-side shadowing aggregate onto the header.
+        row_header.max_data_cell_timestamp = agg_max_cell_ts;
+        row_header.max_data_cell_expires_at = agg_max_expires_at;
+        row_header.has_live_forever_data_cell = agg_has_live_forever;
 
         log::debug!(
             "V5CompressedLegacy: Parsed {}/{} on-disk columns (missing columns are NULL)",

--- a/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/row_framing.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/v5_compressed_legacy/row_framing.rs
@@ -1,6 +1,90 @@
 use super::*;
 
+/// `DeletionTime.Serializer` LIVE sentinel for oa/da (`hasUIntDeletionTime`)
+/// partitions: a single byte `0x80` (`IS_LIVE_DELETION = 0b1000_0000`) encodes a
+/// live partition; any other leading byte introduces the full 12-byte deleted
+/// form (8-byte `markedForDeleteAt` + 4-byte unsigned `localDeletionTime`).
+/// Authority: `DeletionTime.java:208` (`Serializer.serialize`).
+pub(super) const OA_IS_LIVE_DELETION: u8 = 0x80;
+
+/// Whether the leading partition header in a sliding-window chunk buffer can be
+/// safely parsed yet. Computed WITHOUT consuming bytes so the two sliding
+/// parsers ([`V5CompressedLegacyParser::parse_one_partition_with_timestamps`] and
+/// [`V5CompressedLegacyParser::parse_one_partition_for_compaction`]) agree on the
+/// need-more decision for both the nb (fixed 12-byte) and oa/da (1-byte LIVE /
+/// 12-byte DELETED) `DeletionTime` forms.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum PartitionHeaderReadiness {
+    /// Enough bytes are present to parse the full header, INCLUDING the complete
+    /// partition `DeletionTime` for its live/deleted form. Parsing cannot fail
+    /// due to truncation.
+    Ready,
+    /// The header — or, for an oa/da deleted partition, its 12-byte
+    /// `DeletionTime` — is split across the chunk boundary. More bytes must be
+    /// appended before it can be parsed (non-final chunk → `NeedMore`).
+    Incomplete,
+    /// The header shape is invalid (zero or over-long key length): the caller
+    /// should skip one byte to resynchronise.
+    Malformed,
+}
+
 impl V5CompressedLegacyParser {
+    /// Decide whether the leading partition header in `data` is fully present.
+    ///
+    /// Issue #1741 (roborev HIGH): the oa/da (`hasUIntDeletionTime`) partition
+    /// `DeletionTime` is 1 byte only when LIVE (the [`OA_IS_LIVE_DELETION`]
+    /// sentinel); a DELETED partition carries the full 12-byte form. Sizing the
+    /// header minimum at a flat 1 byte let a deleted partition header that was
+    /// split across a NON-FINAL chunk (partition key + only the first deletion
+    /// byte present) pass the guard, so `parse_partition_header_full` failed
+    /// mid-buffer and the sliding parser returned `Emitted(1)` instead of
+    /// `NeedMore` — desyncing the scan and, on the compaction path, dropping the
+    /// partition tombstone (data-resurrection risk).
+    ///
+    /// This peeks the deletion-time discriminator to size the header correctly
+    /// and, when a `Ready` verdict is returned, guarantees the subsequent
+    /// `parse_partition_header_full` has every byte it needs — so a truncated
+    /// deletion-time can never be mis-parsed as a complete partition. No
+    /// heuristics: the branch keys off the authoritative `hasUIntDeletionTime`
+    /// version-gate flag and the canonical `DeletionTime` sentinel.
+    pub(super) fn partition_header_readiness(&self, data: &[u8]) -> PartitionHeaderReadiness {
+        // Cassandra partition key size limits (see the block loop guards).
+        const CASSANDRA_MAX_KEY_SIZE: usize = 65536; // 64KB per Cassandra spec
+        const FORMAT_MAX_KEY_SIZE: usize = 255; // u8 length field limit
+
+        // flags(1) + key_len(1) must both be present before anything else.
+        if data.len() < 2 {
+            return PartitionHeaderReadiness::Incomplete;
+        }
+        let key_len = data[1] as usize;
+        if key_len == 0 || key_len > FORMAT_MAX_KEY_SIZE.min(CASSANDRA_MAX_KEY_SIZE) {
+            return PartitionHeaderReadiness::Malformed;
+        }
+
+        // Offset of the DeletionTime, immediately after flags + key_len + key.
+        let deletion_offset = 2 + key_len;
+        let deletion_time_min = if self.has_uint_deletion_time() {
+            // oa/da: peek the DeletionTime discriminator to size the header.
+            match data.get(deletion_offset) {
+                // Discriminator byte itself is not present yet — split header.
+                None => return PartitionHeaderReadiness::Incomplete,
+                // LIVE sentinel (0x80): exactly 1 byte.
+                Some(&b) if (b & OA_IS_LIVE_DELETION) != 0 => 1,
+                // Any other leading byte introduces the full 12-byte deleted form.
+                Some(_) => 12,
+            }
+        } else {
+            // nb: fixed 12-byte signed DeletionTime (4-byte LDT + 8-byte MFDA).
+            12
+        };
+
+        if deletion_offset + deletion_time_min > data.len() {
+            PartitionHeaderReadiness::Incomplete
+        } else {
+            PartitionHeaderReadiness::Ready
+        }
+    }
+
     /// Parse row flags only (Issue #213 fix: split from parse_row_header)
     ///
     /// # Format
@@ -384,7 +468,20 @@ impl V5CompressedLegacyParser {
             let ldt_bytes_consumed = data[pos..].len() - remaining.len();
             pos += ldt_bytes_consumed;
 
-            let absolute_ldt = self.min_local_deletion_time.wrapping_add(ldt_delta as i64) as i32;
+            // Liveness localExpirationTime (SECONDS). Same VG3 unsigned-deletion-time
+            // reinterpretation as the row/complex-cell deletion LDT reader below
+            // (BigFormat.java:409, hasUIntDeletionTime): on oa/da a post-2038 expiry
+            // occupies [2^31, 2^32) and must be read as UNSIGNED (year-2106-safe) so
+            // it stays a large POSITIVE second count. Storing it as `i64` here (vs the
+            // old `as i32`) prevents the wrap-to-negative that would make the read-time
+            // TTL filter treat a still-live row as long-expired and hide it (#1741 F1).
+            // nb (signed) values are capped at ~2038 so sign-extension is a no-op.
+            let raw_liveness_ldt = self.min_local_deletion_time.wrapping_add(ldt_delta as i64);
+            let absolute_ldt: i64 = if self.has_uint_deletion_time() {
+                (raw_liveness_ldt as u32) as i64
+            } else {
+                raw_liveness_ldt as i32 as i64
+            };
 
             debug!(
                 "V5CompressedLegacy: Row TTL: ttl_delta={}, min={:?}, ttl={}, ldt_delta={}, ldt={}",
@@ -539,6 +636,12 @@ impl V5CompressedLegacyParser {
                 header_size,
                 row_size_vint_len,
                 missing_columns_bitmap,
+                // Issue #1741: populated after the cell loop in
+                // `parse_row_data_with_offset_impl`; defaults describe a row with no
+                // decoded data cells.
+                max_data_cell_timestamp: None,
+                max_data_cell_expires_at: None,
+                has_live_forever_data_cell: false,
             },
             row_size,
         ))
@@ -651,10 +754,9 @@ impl V5CompressedLegacyParser {
                 ));
             }
             let del_flags = data[offset];
-            const IS_LIVE_DELETION: u8 = 0x80; // DeletionTime.java:208
-            if (del_flags & IS_LIVE_DELETION) != 0 {
+            if (del_flags & OA_IS_LIVE_DELETION) != 0 {
                 // LIVE partition: exactly 1 byte — no tombstone.
-                if del_flags != IS_LIVE_DELETION {
+                if del_flags != OA_IS_LIVE_DELETION {
                     return Err(Error::corruption(format!(
                         "V5CompressedLegacy: Invalid IS_LIVE_DELETION byte 0x{:02x} at offset {} \
                          (only 0x80 is valid for oa-format LIVE partitions, per DeletionTime.java:227-229)",

--- a/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
+++ b/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
@@ -521,7 +521,10 @@ impl SSTableReader {
     ) -> Result<()> {
         use crate::storage::sstable::compression::Compression;
 
-        let parser = self.build_v5_parser();
+        // Issue #1741: single-gen full-scan read path applies SELECT-semantic
+        // read shadowing (partition/range tombstone + TTL), so build the parser
+        // with read_shadowing = true.
+        let parser = self.build_v5_parser(true);
         // Sliding front-cursor window (issue #1589): compacts once per refill.
         let mut window = WindowCursor::new();
         let mut broke = false;

--- a/cqlite-core/src/storage/sstable/writer/data_writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/mod.rs
@@ -193,6 +193,16 @@ pub struct DataWriter {
     crc: StreamingCrc,
     /// Encoding baselines used for delta encoding.
     stats: EncodingStatsBaselines,
+    /// Issue #1741: emit the partition-level `DeletionTime` in the oa/`da`
+    /// serialization (1-byte `0x80` LIVE sentinel; `markedForDeleteAt`(i64) +
+    /// `localDeletionTime`(u32) when deleted) rather than the legacy na/`nb`
+    /// layout (`localDeletionTime`(i32) + `markedForDeleteAt`(i64), LIVE encoded as
+    /// `i32::MAX`+`i64::MIN`). `true` ONLY for `da` (BTI) SSTables, whose reader
+    /// applies `hasUIntDeletionTime` (oa) decoding; a `da` file written with the
+    /// legacy layout has its live-partition sentinel misread as a tombstone (which
+    /// the read-side shadowing then treats as a partition delete). Default `false`
+    /// preserves byte-identical `nb` output.
+    oa_partition_deletion: bool,
 }
 
 mod cells;
@@ -282,7 +292,16 @@ impl DataWriter {
             position: 0,
             crc: StreamingCrc::new(),
             stats: EncodingStatsBaselines::from(&stats),
+            oa_partition_deletion: false,
         }
+    }
+
+    /// Issue #1741: select the oa/`da` partition-level `DeletionTime` serialization.
+    /// Call with `true` when producing a `da` (BTI) SSTable; the default (`false`)
+    /// keeps the legacy `nb` layout byte-identical.
+    pub fn with_oa_partition_deletion(mut self, on: bool) -> Self {
+        self.oa_partition_deletion = on;
+        self
     }
 
     /// Create a streaming Data.db writer that flushes each partition to `data_path`.
@@ -303,6 +322,7 @@ impl DataWriter {
             position: 0,
             crc: StreamingCrc::new(),
             stats: EncodingStatsBaselines::from(&stats),
+            oa_partition_deletion: false,
         }
     }
 

--- a/cqlite-core/src/storage/sstable/writer/data_writer/partition.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/partition.rs
@@ -757,17 +757,42 @@ impl DataWriter {
         // Partition key bytes
         self.buffer.extend_from_slice(&key.key);
 
-        // Partition deletion info
-        if let Some(ts) = tombstone {
-            // Local deletion time (i32 BE, in seconds)
-            self.buffer
-                .write_all(&ts.local_deletion_time.to_be_bytes())?;
-            // Deletion timestamp (i64 BE, in microseconds)
-            self.buffer.write_all(&ts.deletion_time.to_be_bytes())?;
-        } else {
-            // DeletionTime.LIVE: Cassandra uses (Integer.MAX_VALUE, Long.MIN_VALUE)
-            self.buffer.write_all(&i32::MAX.to_be_bytes())?;
-            self.buffer.write_all(&i64::MIN.to_be_bytes())?;
+        // Partition deletion info.
+        //
+        // Issue #1741: the on-disk `DeletionTime` layout is format-specific. `da`
+        // (BTI, oa `hasUIntDeletionTime`) uses `DeletionTime.Serializer`:
+        //   LIVE    = 1 byte `0x80` (IS_LIVE_DELETION);
+        //   DELETED = markedForDeleteAt (i64 BE) + localDeletionTime (u32 BE) = 12 bytes.
+        // The legacy na/`nb` layout (`legacySerializer`) is always 12 bytes:
+        //   localDeletionTime (i32 BE) + markedForDeleteAt (i64 BE), LIVE encoded as
+        //   (Integer.MAX_VALUE, Long.MIN_VALUE). Writing the `nb` layout into a `da`
+        //   file makes the reader's oa branch misread the LIVE sentinel as a
+        //   tombstone (its first byte `0x7F` != `0x80`), which the read-side
+        //   shadowing then treats as a partition delete — so `da` MUST use the oa
+        //   layout. Authority: DeletionTime.java (Serializer / legacySerializer),
+        //   BigFormat.java:409 (`hasUIntDeletionTime`).
+        match (self.oa_partition_deletion, tombstone) {
+            (true, Some(ts)) => {
+                // oa DELETED: markedForDeleteAt (i64) then localDeletionTime (u32).
+                self.buffer.write_all(&ts.deletion_time.to_be_bytes())?;
+                self.buffer
+                    .write_all(&(ts.local_deletion_time as u32).to_be_bytes())?;
+            }
+            (true, None) => {
+                // oa LIVE: single IS_LIVE_DELETION byte.
+                self.buffer.write_all(&[0x80])?;
+            }
+            (false, Some(ts)) => {
+                // nb DELETED: localDeletionTime (i32) then markedForDeleteAt (i64).
+                self.buffer
+                    .write_all(&ts.local_deletion_time.to_be_bytes())?;
+                self.buffer.write_all(&ts.deletion_time.to_be_bytes())?;
+            }
+            (false, None) => {
+                // nb LIVE: DeletionTime.LIVE sentinel (Integer.MAX_VALUE, Long.MIN_VALUE).
+                self.buffer.write_all(&i32::MAX.to_be_bytes())?;
+                self.buffer.write_all(&i64::MIN.to_be_bytes())?;
+            }
         }
 
         Ok(())

--- a/cqlite-core/src/storage/sstable/writer/data_writer/tests/scenarios_5.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/tests/scenarios_5.rs
@@ -1291,7 +1291,7 @@ fn udt_whole_write_roundtrips_sparse_out_of_order() {
     // True round-trip through the reader.
     let parser = person_reader();
     let (value, _off, _meta) = parser
-        .parse_complex_column_inner(&buf, 0, &col, &col.data_type, true, row_ts, None)
+        .parse_complex_column_inner(&buf, 0, &col, &col.data_type, true, row_ts, None, None)
         .expect("reader must parse the UDT complex column");
 
     match value {

--- a/cqlite-core/src/storage/sstable/writer/data_writer/tests/scenarios_6.rs
+++ b/cqlite-core/src/storage/sstable/writer/data_writer/tests/scenarios_6.rs
@@ -1448,7 +1448,7 @@ fn bare_udt_with_registry_roundtrips_sparse_out_of_order() {
 
     let parser = person_reader();
     let (value, _off, _meta) = parser
-        .parse_complex_column_inner(&buf, 0, &col, &col.data_type, true, row_ts, None)
+        .parse_complex_column_inner(&buf, 0, &col, &col.data_type, true, row_ts, None, None)
         .expect("reader must parse the UDT complex column");
 
     match value {

--- a/cqlite-core/src/storage/sstable/writer/mod.rs
+++ b/cqlite-core/src/storage/sstable/writer/mod.rs
@@ -465,7 +465,13 @@ impl SSTableWriter {
         // single partition instead of buffering the whole component. The file is
         // opened lazily on the first partition (creating sstable_dir as needed).
         let data_path = Self::component_path_for(&sstable_dir, generation, format, "Data.db");
-        let data_writer = DataWriter::with_sink(stats.clone(), data_path);
+        // Issue #1741: `da` (BTI) SSTables must serialize the partition-level
+        // `DeletionTime` in the oa layout so the reader's `hasUIntDeletionTime`
+        // branch reads the LIVE sentinel correctly (a legacy `nb` layout in a `da`
+        // file is misread as a partition tombstone). `nb` (BIG) keeps the legacy
+        // layout, byte-identical to before.
+        let data_writer = DataWriter::with_sink(stats.clone(), data_path)
+            .with_oa_partition_deletion(matches!(format, SSTableFormat::Bti));
 
         // Index.db writer.
         //

--- a/cqlite-core/tests/issue_1741_singlegen_tombstone_ttl_shadow.rs
+++ b/cqlite-core/tests/issue_1741_singlegen_tombstone_ttl_shadow.rs
@@ -1,0 +1,255 @@
+//! Issue #1741 (P0): single-generation / full-scan reads must apply partition
+//! deletions, range tombstones, and read-time TTL expiry — matching a Cassandra
+//! `SELECT`, which hides deleted/expired data. Historically the single-gen emit
+//! path bypassed reconciliation and returned that data as live.
+//!
+//! These are END-TO-END regression tests driving the same `Database::execute`
+//! query path the CLI/bindings use, so they exercise the shared v5 emit path below
+//! the query engine (independent of compression and feature flags).
+//!
+//! Revert-verify (AC3): on pre-fix `main` each `assert_eq!` below fails —
+//!   * `ttl_expired_rows_are_hidden`: current main returns all 100 rows; the fix
+//!     returns 0 (every row's `default_time_to_live = 86400` expired in Oct 2025).
+//!   * `partition_deletion_hides_covered_rows`: a real uncompressed single-gen
+//!     table is copied to a tempdir and its FIRST partition header is patched to
+//!     carry a `markedForDeleteAt` newer than that partition's row — the issue's
+//!     own validated repro method (writer-flush reconciliation makes an unpatched
+//!     coexisting partition-delete+rows fixture unsynthesizable). Current main
+//!     returns all N rows; the fix returns N-1.
+//!
+//! Fixtures resolve via `CQLITE_DATASETS_ROOT`; when the dataset (or its gitignored
+//! `*.db` binaries) is absent the tests SKIP cleanly. When the fixture IS present,
+//! a zero-row or mismatched result FAILS loudly (never an empty-pass).
+//!
+//! Range-tombstone coverage is pinned by the deterministic unit tests in
+//! `partition_shadow.rs` (`range_tombstone_fsm_shadows_covered_older_rows`,
+//! `range_tombstone_boundary_reopens_new_range`): no empirical single-gen RT
+//! fixture with COVERED rows is synthesizable (issue #1741 note (a)) because the
+//! writer purges covered rows at flush, so the read-side FSM + coverage logic is
+//! pinned directly rather than via an on-disk golden.
+#![cfg(all(feature = "state_machine", feature = "cli-helpers"))]
+
+use std::path::{Path, PathBuf};
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::Database;
+
+fn datasets_root() -> Option<PathBuf> {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+}
+
+fn schema_path(file: &str) -> Option<PathBuf> {
+    if let Some(root) = datasets_root() {
+        let p = root.parent()?.join("schemas").join(file);
+        if p.exists() {
+            return Some(p);
+        }
+    }
+    let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let p = manifest
+        .parent()?
+        .join("test-data")
+        .join("schemas")
+        .join(file);
+    p.exists().then_some(p)
+}
+
+fn fixture_dir(keyspace: &str, table: &str) -> Option<PathBuf> {
+    let root = datasets_root()?;
+    let ks_dir = root.join("sstables").join(keyspace);
+    if !ks_dir.is_dir() {
+        return None;
+    }
+    let prefix = format!("{table}-");
+    std::fs::read_dir(&ks_dir)
+        .ok()?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .find(|p| {
+            p.is_dir()
+                && p.file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|n| n.starts_with(&prefix))
+                    .unwrap_or(false)
+        })
+}
+
+/// Count `type == "row"` entries in the committed sstabledump JSONL golden.
+fn golden_row_count(dir: &Path) -> Option<usize> {
+    let jsonl = dir.join("nb-1-big-Data.db.jsonl");
+    let text = std::fs::read_to_string(&jsonl).ok()?;
+    let mut total = 0usize;
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let v: serde_json::Value = serde_json::from_str(line).ok()?;
+        if let Some(rows) = v.get("rows").and_then(|r| r.as_array()) {
+            total += rows
+                .iter()
+                .filter(|r| r.get("type").and_then(|t| t.as_str()) == Some("row"))
+                .count();
+        }
+    }
+    Some(total)
+}
+
+/// Ingest a `sstables` dir (real dataset root or a patched tempdir) filtered to one
+/// keyspace and return a queryable `Database`.
+async fn open_db(sstables_dir: &Path, schema: &Path, keyspace: &str) -> Result<Database, String> {
+    let cfg = IngestionConfig {
+        schema_paths: vec![schema.to_path_buf()],
+        data_dir: sstables_dir.to_path_buf(),
+        version_hint: None,
+        core_config: cqlite_core::Config::default(),
+        table_directory_filter: Some(format!("/{keyspace}/")),
+    };
+    let result = ingest(cfg).await.map_err(|e| format!("ingestion: {e}"))?;
+    if result.schema_load_result.schemas_loaded == 0 {
+        return Err("no schemas loaded".into());
+    }
+    Ok(result.database)
+}
+
+/// TTL expiry (issue #1741 repro (c)): every row of `test_basic.ttl_test_table`
+/// carries `default_time_to_live = 86400` and expired in Oct 2025, so a Cassandra
+/// `SELECT *` returns 0 rows. The committed golden proves 100 rows are physically
+/// on disk (anti-empty-pass), so a return of 100 (pre-fix) or any non-zero count is
+/// a hard failure.
+#[tokio::test]
+async fn ttl_expired_rows_are_hidden() {
+    let Some(dir) = fixture_dir("test_basic", "ttl_test_table") else {
+        eprintln!("SKIP ttl_expired_rows_are_hidden: fixture dir absent");
+        return;
+    };
+    if !dir.join("nb-1-big-Data.db").exists() {
+        eprintln!("SKIP ttl_expired_rows_are_hidden: Data.db not fetched");
+        return;
+    }
+    let Some(schema) = schema_path("basic-types.cql") else {
+        eprintln!("SKIP ttl_expired_rows_are_hidden: schema absent");
+        return;
+    };
+    let root = datasets_root().unwrap();
+
+    // Anti-empty-pass: the physical rows really exist on disk.
+    let golden = golden_row_count(&dir).expect("ttl_test_table golden JSONL missing/unreadable");
+    assert_eq!(
+        golden, 100,
+        "fixture sanity: ttl_test_table should have 100 physical rows, got {golden}"
+    );
+
+    let db = match open_db(&root.join("sstables"), &schema, "test_basic").await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("SKIP ttl_expired_rows_are_hidden: {e}");
+            return;
+        }
+    };
+
+    let result = db
+        .execute("SELECT id, expiring_value, session_info FROM test_basic.ttl_test_table")
+        .await
+        .expect("SELECT over ttl_test_table must succeed");
+
+    assert_eq!(
+        result.rows.len(),
+        0,
+        "issue #1741: every ttl_test_table row expired (TTL 86400, Oct 2025) — a \
+         Cassandra SELECT returns 0 rows, but the read path returned {} live rows",
+        result.rows.len()
+    );
+}
+
+/// Partition deletion (issue #1741 repro (b)): copy the real uncompressed single-gen
+/// `test_basic.uncompressed_table` to a tempdir, patch its FIRST partition header to
+/// carry a `markedForDeleteAt` newer than that partition's row, and assert a
+/// `SELECT *` returns exactly one fewer row (the deleted partition's row is hidden).
+#[tokio::test]
+async fn partition_deletion_hides_covered_rows() {
+    let Some(src) = fixture_dir("test_basic", "uncompressed_table") else {
+        eprintln!("SKIP partition_deletion_hides_covered_rows: fixture dir absent");
+        return;
+    };
+    if !src.join("nb-1-big-Data.db").exists() {
+        eprintln!("SKIP partition_deletion_hides_covered_rows: Data.db not fetched");
+        return;
+    }
+    let Some(schema) = schema_path("basic-types.cql") else {
+        eprintln!("SKIP partition_deletion_hides_covered_rows: schema absent");
+        return;
+    };
+
+    let golden = golden_row_count(&src).expect("uncompressed_table golden JSONL missing");
+    assert!(
+        golden >= 2,
+        "fixture sanity: need >= 2 physical rows to observe one hidden, got {golden}"
+    );
+
+    // Build a patched copy: <tmp>/sstables/test_basic/<same-dir-name>/, dropping the
+    // Digest.crc32 + CRC.db integrity sidecars (the reader warn-and-proceeds without
+    // them, decision D4) so the in-place partition-header patch is accepted.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir_name = src.file_name().unwrap();
+    let dst = tmp
+        .path()
+        .join("sstables")
+        .join("test_basic")
+        .join(dir_name);
+    std::fs::create_dir_all(&dst).expect("mkdir dst");
+    for entry in std::fs::read_dir(&src).expect("read src dir").flatten() {
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        if name_str.ends_with("-Digest.crc32") || name_str.ends_with("-CRC.db") {
+            continue; // drop integrity sidecars — we mutate Data.db below
+        }
+        std::fs::copy(entry.path(), dst.join(&name)).expect("copy component");
+    }
+
+    // Patch the FIRST partition header (Data.db byte 0). Layout (nb, no
+    // hasUIntDeletionTime): flags(1) | key_len(u8) | key | localDeletionTime(i32 BE)
+    // | markedForDeleteAt(i64 BE). Set a real localDeletionTime (!= i32::MAX LIVE
+    // sentinel) and a markedForDeleteAt newer than any row timestamp in the file.
+    let data_path = dst.join("nb-1-big-Data.db");
+    let mut bytes = std::fs::read(&data_path).expect("read Data.db");
+    let key_len = bytes[1] as usize;
+    let del_off = 2 + key_len;
+    assert!(
+        bytes.len() >= del_off + 12,
+        "Data.db too small to hold a partition-deletion field"
+    );
+    // localDeletionTime = 2025-10-09 (real epoch-seconds, not the LIVE sentinel).
+    let local_deletion_time: i32 = 1_760_000_000;
+    bytes[del_off..del_off + 4].copy_from_slice(&local_deletion_time.to_be_bytes());
+    // markedForDeleteAt ≈ year 2030 in µs — strictly newer than every row's write
+    // timestamp (~1.759e15 µs, Oct 2025), so the whole partition is shadowed.
+    let marked_for_delete_at: i64 = 1_900_000_000_000_000;
+    bytes[del_off + 4..del_off + 12].copy_from_slice(&marked_for_delete_at.to_be_bytes());
+    std::fs::write(&data_path, &bytes).expect("write patched Data.db");
+
+    let db = match open_db(&tmp.path().join("sstables"), &schema, "test_basic").await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("SKIP partition_deletion_hides_covered_rows: {e}");
+            return;
+        }
+    };
+
+    let result = db
+        .execute("SELECT * FROM test_basic.uncompressed_table")
+        .await
+        .expect("SELECT over patched uncompressed_table must succeed");
+
+    assert_eq!(
+        result.rows.len(),
+        golden - 1,
+        "issue #1741: the patched partition's row must be hidden by its \
+         partition-level deletion — expected {} rows, got {}",
+        golden - 1,
+        result.rows.len()
+    );
+}

--- a/cqlite-core/tests/issue_660_bti_end_to_end_read.rs
+++ b/cqlite-core/tests/issue_660_bti_end_to_end_read.rs
@@ -189,9 +189,19 @@ async fn bti_collection_table_select_star_returns_all_rows() {
     }
 }
 
-/// A `SELECT *` over the da/BTI `ttl_table` must return both partitions.
+/// A `SELECT *` over the da/BTI `ttl_table` returns ZERO rows because every row's
+/// TTL (`ttl=86400`, `expires_at = 2026-06-11T16:17:37Z`, baked into the fixture)
+/// has elapsed — a Cassandra `SELECT` hides expired rows.
+///
+/// This ORIGINALLY asserted "returns all rows": before issue #1741 the read path
+/// ignored TTL and served the expired rows as live (the P0 bug). The fix now applies
+/// read-time TTL expiry on the BTI read path too, so the correct result is 0 rows.
+/// The expiry is a FIXED past timestamp in the SSTable, so this is stable going
+/// forward in wall-clock time (the rows only get "more expired"). The BTI read-path's
+/// ability to decode live rows is covered by the sibling `simple_table` /
+/// `collection_table` cases above; this case now pins TTL shadowing on that path.
 #[tokio::test]
-async fn bti_ttl_table_select_star_returns_all_rows() {
+async fn bti_ttl_table_select_star_hides_expired_rows() {
     let db = match setup_test_database().await {
         Ok(db) => db,
         Err(e) => {
@@ -207,24 +217,9 @@ async fn bti_ttl_table_select_star_returns_all_rows() {
 
     assert_eq!(
         result.rows.len(),
-        2,
-        "Issue #660: da/BTI ttl_table has 2 partitions in the golden"
-    );
-
-    let values: Vec<String> = result
-        .rows
-        .iter()
-        .filter_map(|r| r.values.get("data").map(|v| format!("{:?}", v)))
-        .collect();
-    let joined = values.join(",");
-    assert!(
-        joined.contains("BTI TTL row 1"),
-        "missing TTL row 1: {}",
-        joined
-    );
-    assert!(
-        joined.contains("BTI TTL row 2"),
-        "missing TTL row 2: {}",
-        joined
+        0,
+        "Issue #1741: da/BTI ttl_table rows all expired (TTL 86400, expires 2026-06-11) \
+         — a Cassandra SELECT hides them, but the read path returned {} live rows",
+        result.rows.len()
     );
 }


### PR DESCRIPTION
Closes #1741.

## What
**P0 read-path correctness:** single-generation / full-scan reads bypassed reconciliation and returned deleted/expired data as live. This applies **partition-deletion shadowing, range-tombstone shadowing, and read-time TTL expiry** to single-gen reads, matching Cassandra `SELECT` semantics.

Empirically confirmed before/after: `test_basic.ttl_test_table` (100 rows, all TTL-expired ~2025-10-07) → Cassandra `0`, CQLite was `100`, now `0`.

## Approach (design note — deviates from AC1's literal wording; owner please confirm)
AC1 said "preferably route through the write-support-gated `ReconcileState`." Investigation showed that path is a **large/risky refactor** (`ReconcileState` is `write-support`-gated + a different `CellData` data model). Per the escape hatch, I instead implemented AC1's **intent** with a single **un-gated** read-side helper `PartitionShadow` called from all ~5 emit paths — satisfying AC2 (read correctness NOT gated on `write-support`) without pulling write-support into the read path. No-heuristics: authoritative header/RT/`Statistics.db` fields only. Hot path stays zero-per-cell-alloc (per-row temporal aggregate computed in the existing cell loop; `Statistics.db`-gated skip when an SSTable has no tombstones/TTL).

## Emit paths covered (all 5)
streaming `SELECT *`, BTI/big-promoted single-partition + point reads, WRITETIME/TTL projections, `parse_block`, and `bti_scan_with_metadata` + index/sequential/point-get. Physical consumers (integrity verify, delta-scan, compaction) pass `read_shadowing=false` and are byte-unchanged.

## Coupled writer fix (required — surfaced by the read fix)
CQLite's `da`/BTI `DataWriter` wrote the partition-level `DeletionTime` in **nb** layout even for `da` files, whose reader correctly applies **oa** (`hasUIntDeletionTime`) decoding → it misread the live-partition sentinel as a tombstone (harmless before, since deletion was discarded; now shadows every row). Fixed to emit oa layout for `da` (guarded, **nb byte-identical**). Real Cassandra `da` fixtures unaffected; only CQLite-written `da` files (which would otherwise return 0 rows on any SELECT). Validated green vs `issue_909`/`issue_908`/`issue_821`/`issue_1190` byte-parity + compaction-byte-parity.

## Robustness fix (regression I introduced, caught by the #1437 harness)
The new shadowing path changed which corrupt row surfaces first on truncated/bitflipped input, exposing an **unbounded DECIMAL stringify** in the Python binding (`decimal_to_pydecimal`) → python3.14 4300-digit `ValueError` crashing the driver (A/B proven: main 10/10, pre-fix branch 7/10). Guarded fail-closed: bound against `sys.get_int_max_str_digits()`, return a typed `CqliteError` instead of stringifying an unbounded int. abort-safety back to 10/10. (Related pre-existing class: #1754.)

## Tests (AC3) — pinned, revert-verified, not empty-passing
- `cqlite-core/tests/issue_1741_singlegen_tombstone_ttl_shadow.rs`: TTL 100→0 (asserts golden==100 first, anti-empty-pass) + partition-delete on a patched real fixture; both fail on pre-fix code. `partition_shadow.rs` unit tests (partition `<=`/`>`, RT FSM/coverage/boundary, TTL live/expired/live-forever, no-timestamp fail-safe).
- `test_parity.py` reconciled to SELECT semantics via a **wall-clock-aware live-count helper** (excludes tombstoned + TTL-expired golden rows; no hardcoded 0; non-TTL tables assert exact physical parity unchanged). This is the #1742 (query-semantics oracle) territory — done minimally here to keep the gate honest.

## Gate: PASS (all components; `python-bindings` PASS)
`CQLITE_ALLOW_FILE_GROWTH=1` acknowledged — the shadowing implementation grew 6 already-over-threshold parser/writer files; splitting them is tracked under epic #1116, out of scope for this P0.

## Routing: oracle-driven (Cassandra SELECT semantics + pinned parity tests). No OpenSpec change.
