### PR TITLE
feat(#1450): exact Python duration/time types (lossless)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING (Python bindings):** CQL `duration` and `time` now decode to exact,
+  lossless Python types, matching the Node binding (#1450). The previous mapping
+  (M4 §5.2) was lossy and disagreed with Node, the CLI, and Cassandra:
+  - `time` → `int` (nanoseconds since midnight), was `datetime.time` (which
+    truncated sub-microsecond nanoseconds).
+  - `duration` → `cqlite.Duration(months, days, nanos)`, was `datetime.timedelta`
+    (which approximated months as 30 days and truncated nanoseconds to
+    microseconds).
+
+  Migration for code that relied on the old types:
+  ```python
+  # OLD: t was a datetime.time; d was a datetime.timedelta
+  # NEW: t is an int (nanoseconds); d is a cqlite.Duration
+  import datetime
+  t_ns = row["work_time"]                       # e.g. 3723123456789
+  t = datetime.time(                            # reconstruct a datetime.time (µs, lossy)
+      t_ns // 3_600_000_000_000,
+      (t_ns // 60_000_000_000) % 60,
+      (t_ns // 1_000_000_000) % 60,
+      (t_ns // 1000) % 1_000_000,
+  )
+  d = row["duration_val"]                        # cqlite.Duration
+  d.months, d.days, d.nanos                      # exact components
+  ```
+
 ### Removed
 
 - **BREAKING (CLI):** dropped YAML as a query output format. `--out yaml` and

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -164,8 +164,8 @@ CQL types are automatically converted to Python native types:
 | `blob` | `bytes` |
 | `timestamp` | `datetime.datetime` |
 | `date` | `datetime.date` |
-| `time` | `datetime.time` |
-| `duration` | `datetime.timedelta` |
+| `time` | `int` (nanoseconds since midnight, lossless) |
+| `duration` | `cqlite.Duration` (exact `months` / `days` / `nanos`) |
 | `uuid`, `timeuuid` | `uuid.UUID` |
 | `inet` | `ipaddress.IPv4Address` or `IPv6Address` |
 | `decimal` | `decimal.Decimal` |

--- a/bindings/python/python/cqlite/__init__.py
+++ b/bindings/python/python/cqlite/__init__.py
@@ -23,6 +23,8 @@ from cqlite._cqlite import (
     Row,
     ColumnInfo,
     StreamingIterator,
+    # Exact temporal types (issue #1450)
+    Duration,
     # Prepared statements
     PreparedStatement,
     # Statistics
@@ -57,6 +59,8 @@ __all__ = [
     "Row",
     "ColumnInfo",
     "StreamingIterator",
+    # Exact temporal types (issue #1450)
+    "Duration",
     # Prepared statements
     "PreparedStatement",
     # Statistics

--- a/bindings/python/python/cqlite/__init__.pyi
+++ b/bindings/python/python/cqlite/__init__.pyi
@@ -622,6 +622,46 @@ class ColumnInfo:
 
     def __repr__(self) -> str: ...
 
+class Duration:
+    """Exact CQL ``duration`` value (issue #1450).
+
+    A CQL ``duration`` has three independent components that cannot be collapsed
+    into a single scalar without loss (a month is not a fixed number of days, and
+    a day is not a fixed number of nanoseconds). All three are preserved exactly,
+    mirroring the Node binding's ``{ months, days, nanos }`` object.
+
+    Breaking change (v0.13): a ``duration`` column previously decoded to a
+    ``datetime.timedelta`` that approximated months as 30 days and truncated
+    nanoseconds to microseconds (the M4 §5.2 lossy mapping). It now decodes to
+    this exact type. CQL ``time`` columns, likewise, now decode to an ``int``
+    (nanoseconds since midnight) instead of a microsecond-capped ``datetime.time``.
+
+    Attributes:
+        months: Whole months (may be negative).
+        days: Whole days (may be negative).
+        nanos: Sub-day component in nanoseconds (may be negative).
+    """
+
+    def __init__(self, months: int, days: int, nanos: int) -> None: ...
+    @property
+    def months(self) -> int:
+        """Whole months (may be negative)."""
+        ...
+
+    @property
+    def days(self) -> int:
+        """Whole days (may be negative)."""
+        ...
+
+    @property
+    def nanos(self) -> int:
+        """Sub-day component in nanoseconds (may be negative)."""
+        ...
+
+    def __eq__(self, other: object) -> bool: ...
+    def __hash__(self) -> int: ...
+    def __repr__(self) -> str: ...
+
 class StreamingIterator:
     """Memory-efficient iterator for large result sets.
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -27,6 +27,7 @@ pub use refresh::RefreshReport;
 pub use result::{ColumnInfo, QueryResult, QueryResultIter, Row, StreamingIterator};
 pub use runtime::{block_on, try_get_runtime};
 pub use stats::DatabaseStats;
+pub use value::Duration;
 pub use write::{MaintenanceReport, WriteStats};
 
 /// CQLite version string.
@@ -78,6 +79,9 @@ fn _cqlite(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     // Register result types (QueryResult, Row, ColumnInfo)
     result::register_result(m)?;
+
+    // Register value-conversion types (exact `Duration`)
+    value::register_value(m)?;
 
     // Register prepared statement types
     prepared::register_prepared(m)?;

--- a/bindings/python/src/value.rs
+++ b/bindings/python/src/value.rs
@@ -14,7 +14,8 @@ use cqlite_core::Value;
 /// Handles all CQL types with proper Python type mapping:
 /// - Primitives: Null→None, Boolean→bool, Integer→int, Float→float, Text→str
 /// - Binary: Blob→bytes, Uuid→str (formatted), Inet→str (IP format)
-/// - Temporal: Timestamp→datetime, Date→date, Time→time, Duration→timedelta
+/// - Temporal: Timestamp→datetime, Date→date, Time→int (nanoseconds since
+///   midnight, lossless), Duration→[`Duration`] (exact months/days/nanos)
 /// - Collections: List→list, Set→frozenset, Map→dict, Tuple→tuple
 /// - Complex: Udt→dict, Varint→int, Decimal→decimal.Decimal
 /// - Special: Tombstone→None, Frozen→unwrap
@@ -33,7 +34,7 @@ pub fn value_to_py(py: Python<'_>, value: &Value) -> PyResult<PyObject> {
         Value::Blob(b) => Ok(PyBytes::new(py, b).into_any().unbind()),
         Value::Timestamp(ts) => timestamp_to_datetime(py, *ts),
         Value::Date(d) => date_to_pydate(py, *d),
-        Value::Time(t) => time_to_pytime(py, *t),
+        Value::Time(t) => Ok(t.into_pyobject(py)?.into_any().unbind()),
         Value::Uuid(u) => uuid_to_py(py, u),
         Value::Varint(v) => varint_to_pyint(py, v),
         Value::Decimal { scale, unscaled } => decimal_to_pydecimal(py, *scale, unscaled),
@@ -41,7 +42,15 @@ pub fn value_to_py(py: Python<'_>, value: &Value) -> PyResult<PyObject> {
             months,
             days,
             nanos,
-        } => duration_to_timedelta(py, *months, *days, *nanos),
+        } => Ok(Py::new(
+            py,
+            Duration {
+                months: *months,
+                days: *days,
+                nanos: *nanos,
+            },
+        )?
+        .into_any()),
         Value::Json(j) => json_to_py(py, j),
         Value::List(l) => list_to_py(py, l),
         Value::Set(s) => set_to_py(py, s),
@@ -183,22 +192,55 @@ fn date_to_pydate(py: Python<'_>, days: i32) -> PyResult<PyObject> {
     Ok(result.into_pyobject(py)?.into_any().unbind())
 }
 
-/// Convert nanoseconds since midnight to datetime.time.
-fn time_to_pytime(py: Python<'_>, nanos: i64) -> PyResult<PyObject> {
-    let datetime = py.import("datetime")?;
-    let time_class = datetime.getattr("time")?;
+/// Exact CQL `duration` value.
+///
+/// A CQL `duration` has three independent components — `months`, `days`, and
+/// `nanos` — that cannot be collapsed into a single scalar without loss (a
+/// month is not a fixed number of days, and a day is not a fixed number of
+/// nanoseconds). This type preserves all three exactly, mirroring the Node
+/// binding's `{ months, days, nanos }` object.
+///
+/// Before v0.13 the Python binding returned a `datetime.timedelta`, which
+/// approximated months as 30 days and truncated nanoseconds to microseconds
+/// (the M4 §5.2 lossy mapping). That approximation has been removed.
+#[pyclass(module = "cqlite", frozen, eq, hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct Duration {
+    /// Whole months (may be negative).
+    #[pyo3(get)]
+    pub months: i32,
+    /// Whole days (may be negative).
+    #[pyo3(get)]
+    pub days: i32,
+    /// Sub-day component in nanoseconds (may be negative).
+    #[pyo3(get)]
+    pub nanos: i64,
+}
 
-    // Convert nanoseconds to hours, minutes, seconds, microseconds
-    let total_micros = nanos / 1000;
-    let total_seconds = total_micros / 1_000_000;
-    let micros = (total_micros % 1_000_000) as i32;
-    let total_minutes = total_seconds / 60;
-    let seconds = (total_seconds % 60) as i32;
-    let hours = (total_minutes / 60) as i32;
-    let minutes = (total_minutes % 60) as i32;
+#[pymethods]
+impl Duration {
+    /// Construct a `Duration` from its exact components.
+    #[new]
+    fn new(months: i32, days: i32, nanos: i64) -> Self {
+        Duration {
+            months,
+            days,
+            nanos,
+        }
+    }
 
-    let time = time_class.call1((hours, minutes, seconds, micros))?;
-    Ok(time.into_pyobject(py)?.into_any().unbind())
+    fn __repr__(&self) -> String {
+        format!(
+            "Duration(months={}, days={}, nanos={})",
+            self.months, self.days, self.nanos
+        )
+    }
+}
+
+/// Register value-conversion types (the exact [`Duration`] class) on the module.
+pub fn register_value(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<Duration>()?;
+    Ok(())
 }
 
 /// Convert UUID bytes to Python uuid.UUID object.
@@ -305,48 +347,6 @@ fn decimal_to_pydecimal(py: Python<'_>, scale: i32, unscaled: &[u8]) -> PyResult
             .into_any()
             .unbind())
     }
-}
-
-/// Convert duration to datetime.timedelta.
-///
-/// IMPORTANT: Precision limitations:
-/// - Months are approximated as 30 days (1 month = 30 days)
-///   Example: 2 months, 5 days → 65 days
-/// - Nanoseconds are truncated to microseconds (Python timedelta precision)
-///   Example: 1,234,567,890 ns → 1,234,567 μs (890 ns lost)
-///
-/// This approximation is documented in M4 spec section 5.2.
-fn duration_to_timedelta(py: Python<'_>, months: i32, days: i32, nanos: i64) -> PyResult<PyObject> {
-    let datetime = py.import("datetime")?;
-    let timedelta = datetime.getattr("timedelta")?;
-
-    // Convert months to days (approximation: 1 month = 30 days)
-    // Use checked arithmetic to prevent overflow on extreme values
-    let total_days = (months as i64)
-        .checked_mul(30)
-        .and_then(|m| m.checked_add(days as i64))
-        .ok_or_else(|| {
-            pyo3::exceptions::PyOverflowError::new_err(
-                "Duration value too large to convert to timedelta",
-            )
-        })?;
-
-    // Convert nanoseconds to microseconds (truncate sub-microsecond precision)
-    // nanos = total nanoseconds in the duration
-    // 1 microsecond = 1000 nanoseconds
-    let total_micros = nanos.checked_div(1000).ok_or_else(|| {
-        pyo3::exceptions::PyOverflowError::new_err("Duration nanoseconds value invalid")
-    })?;
-
-    // timedelta(days=X, microseconds=Y)
-    // Note: timedelta normalizes large microseconds to seconds/days automatically
-    // Example: timedelta(days=0, microseconds=86400000000) → timedelta(days=1)
-    let kwargs = PyDict::new(py);
-    kwargs.set_item("days", total_days)?;
-    kwargs.set_item("microseconds", total_micros)?;
-
-    let result = timedelta.call((), Some(&kwargs))?;
-    Ok(result.into_pyobject(py)?.into_any().unbind())
 }
 
 /// Convert serde_json::Value to Python object.

--- a/bindings/python/tests/test_cli_parity.py
+++ b/bindings/python/tests/test_cli_parity.py
@@ -12,17 +12,20 @@ Key Differences Handled:
     - Python `bytes` → CLI `"0xhex"`
     - Python `datetime` → CLI `"YYYY-MM-DD HH:MM:SS.fff+0000"`
     - Python `date` → CLI `"YYYY-MM-DD"`
-    - Python `time` → CLI `"HH:MM:SS.nnnnnnnnn"`
+    - Python `time` → `int` nanoseconds (issue #1450); the CLI's
+      `"HH:MM:SS.nnnnnnnnn"` string is parsed back to nanoseconds so both
+      sides compare on the exact nanosecond value (no fake-zero padding)
     - Python `UUID` → CLI `"uuid-string"`
-    - Python `timedelta` → CLI `"XmoYdZns"` (lossy: months approximated as 30d)
+    - Python `cqlite.Duration` → CLI `"XmoYdZns"` (exact months/days/nanos, #1450)
     - Python `IPv4Address`/`IPv6Address` → CLI `"ip-string"`
     - Python `frozenset` → CLI JSON array
     - Python `dict` (for maps) → CLI array of `{"key": k, "value": v}`
 """
 
 import json
+import re
 import subprocess
-from datetime import date, datetime, time, timedelta, timezone
+from datetime import date, datetime, timezone
 from decimal import Decimal
 from ipaddress import IPv4Address, IPv6Address
 from pathlib import Path
@@ -34,6 +37,20 @@ import pytest
 import cqlite
 
 from conftest import DATASETS, SCHEMAS, PROJECT_ROOT
+
+
+# CLI renders CQL `time` as "HH:MM:SS.nnnnnnnnn" (9-digit nanoseconds). The
+# Python binding returns exact `int` nanoseconds since midnight (issue #1450),
+# so we parse the CLI string back to nanoseconds for an exact comparison rather
+# than padding the Python value with fake zeros.
+_CLI_TIME_RE = re.compile(r"^(\d{2}):(\d{2}):(\d{2})\.(\d{9})$")
+
+
+def _cli_time_to_nanos(value: str) -> int:
+    """Convert a CLI `HH:MM:SS.nnnnnnnnn` time string to nanoseconds since midnight."""
+    match = _CLI_TIME_RE.match(value)
+    hours, minutes, seconds, nanos = (int(g) for g in match.groups())
+    return (hours * 3600 + minutes * 60 + seconds) * 1_000_000_000 + nanos
 
 
 # =============================================================================
@@ -87,24 +104,21 @@ def normalize_python_value(value: Any, is_row_level: bool = True) -> Any:
         # CLI format: "YYYY-MM-DD"
         return value.strftime("%Y-%m-%d")
 
-    if isinstance(value, time):
-        # CLI format: "HH:MM:SS.nnnnnnnnn" (nanosecond precision)
-        # Python time only has microsecond precision, pad with zeros
-        return f"{value.hour:02d}:{value.minute:02d}:{value.second:02d}.{value.microsecond:06d}000"
+    # CQL `time` now decodes to exact `int` nanoseconds (issue #1450); it is
+    # handled by the int/float branch above and compared against the CLI time
+    # string parsed to nanoseconds in `normalize_cli_value`.
 
-    if isinstance(value, timedelta):
-        # CLI format: "XmoYdZns"
-        # Note: timedelta doesn't preserve months, so we lose that precision
-        # Convert to days and nanoseconds
-        total_days = value.days
-        total_nanos = (
-            value.seconds * 1_000_000_000 + value.microseconds * 1_000
-        )
+    if isinstance(value, cqlite.Duration):
+        # CLI format: "XmoYdZns" — matches cqlite ValueFormatter::format_duration.
+        # The exact months/days/nanos components are preserved (no 30-day
+        # collapse, no nanosecond truncation).
         parts = []
-        if total_days != 0:
-            parts.append(f"{total_days}d")
-        if total_nanos != 0:
-            parts.append(f"{total_nanos}ns")
+        if value.months != 0:
+            parts.append(f"{value.months}mo")
+        if value.days != 0:
+            parts.append(f"{value.days}d")
+        if value.nanos != 0:
+            parts.append(f"{value.nanos}ns")
         return "".join(parts) if parts else "0ns"
 
     if isinstance(value, Decimal):
@@ -184,6 +198,10 @@ def normalize_cli_value(value: Any) -> Any:
         return value
 
     if isinstance(value, str):
+        # CQL `time` renders as "HH:MM:SS.nnnnnnnnn"; parse to exact nanoseconds
+        # to match the Python binding's `int` nanoseconds (issue #1450).
+        if _CLI_TIME_RE.match(value):
+            return _cli_time_to_nanos(value)
         return value
 
     if isinstance(value, list):

--- a/bindings/python/tests/test_parity.py
+++ b/bindings/python/tests/test_parity.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import functools
 import json
 import re
-from datetime import date, datetime, time, timedelta
+from datetime import date, datetime
 from decimal import Decimal
 from ipaddress import IPv4Address, IPv6Address
 from pathlib import Path
@@ -275,28 +275,33 @@ def normalize_jsonl_value(value: Any, cell_name: str = "") -> Any:
         if re.match(r"^\d{4}-\d{2}-\d{2}$", value):
             return date.fromisoformat(value)
 
-        # Detect time pattern with nanoseconds: "01:12:05.394017000"
+        # Detect time pattern with nanoseconds: "01:12:05.394017000".
+        # CQL `time` decodes to exact int nanoseconds since midnight (#1450),
+        # so parse the full nanosecond fraction (no microsecond truncation).
         time_match = re.match(r"^(\d{2}):(\d{2}):(\d{2})\.(\d+)$", value)
         if time_match:
             h, m, s, frac = time_match.groups()
-            # Truncate to microseconds
-            micros = int(frac[:6].ljust(6, "0"))
-            return time(int(h), int(m), int(s), micros)
+            nanos = int(frac[:9].ljust(9, "0"))
+            return (int(h) * 3600 + int(m) * 60 + int(s)) * 1_000_000_000 + nanos
 
-        # Detect simple time: "01:12:05"
-        if re.match(r"^\d{2}:\d{2}:\d{2}$", value):
-            return time.fromisoformat(value)
+        # Detect simple time: "01:12:05" -> exact int nanoseconds (#1450).
+        simple_time = re.match(r"^(\d{2}):(\d{2}):(\d{2})$", value)
+        if simple_time:
+            h, m, s = simple_time.groups()
+            return (int(h) * 3600 + int(m) * 60 + int(s)) * 1_000_000_000
 
-        # Duration pattern: "12h58m22s" or with months/days
+        # Duration pattern: "12h58m22s" or with months/days.
+        # CQL `duration` decodes to an exact cqlite.Duration (#1450): months and
+        # days are kept independently (no 30-day collapse) and sub-day time is
+        # nanoseconds.
         duration_match = re.match(
             r"^(?:(\d+)mo)?(?:(\d+)d)?(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$",
             value,
         )
         if duration_match and any(duration_match.groups()):
             mo, d, h, m, s = [int(g) if g else 0 for g in duration_match.groups()]
-            # Convert months to days (approximation: 30 days/month)
-            total_days = mo * 30 + d
-            return timedelta(days=total_days, hours=h, minutes=m, seconds=s)
+            nanos = (h * 3600 + m * 60 + s) * 1_000_000_000
+            return cqlite.Duration(mo, d, nanos)
 
         # Plain string
         return value

--- a/bindings/python/tests/test_parity.py
+++ b/bindings/python/tests/test_parity.py
@@ -290,18 +290,29 @@ def normalize_jsonl_value(value: Any, cell_name: str = "") -> Any:
             h, m, s = simple_time.groups()
             return (int(h) * 3600 + int(m) * 60 + int(s)) * 1_000_000_000
 
-        # Duration pattern: "12h58m22s" or with months/days.
-        # CQL `duration` decodes to an exact cqlite.Duration (#1450): months and
-        # days are kept independently (no 30-day collapse) and sub-day time is
-        # nanoseconds.
-        duration_match = re.match(
-            r"^(?:(\d+)mo)?(?:(\d+)d)?(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$",
-            value,
-        )
-        if duration_match and any(duration_match.groups()):
-            mo, d, h, m, s = [int(g) if g else 0 for g in duration_match.groups()]
-            nanos = (h * 3600 + m * 60 + s) * 1_000_000_000
-            return cqlite.Duration(mo, d, nanos)
+        # Duration pattern: "12h58m22s", "1mo2d3h", "1s123ns", etc.
+        # CQL `duration` decodes to an exact cqlite.Duration (#1450). sstabledump
+        # renders Cassandra's stored (months, days, nanos) via the full grammar
+        # (y/mo/w/d/h/m/s/ms/us/ns); reconstruct the exact three components,
+        # inverting that rendering (no 30-day collapse, no truncation). The
+        # two-char units are matched before the single-char ones so `mo`/`ms`/`us`
+        # are not mis-read as `m`/`s`.
+        duration_tokens = re.findall(r"(\d+)(mo|ms|us|µs|ns|[ymwdhs])", value)
+        if duration_tokens and "".join(n + u for n, u in duration_tokens) == value:
+            units: dict[str, int] = {}
+            for num, unit in duration_tokens:
+                units[unit] = units.get(unit, 0) + int(num)
+            months = units.get("y", 0) * 12 + units.get("mo", 0)
+            days = units.get("w", 0) * 7 + units.get("d", 0)
+            nanos = (
+                units.get("h", 0) * 3_600_000_000_000
+                + units.get("m", 0) * 60_000_000_000
+                + units.get("s", 0) * 1_000_000_000
+                + units.get("ms", 0) * 1_000_000
+                + (units.get("us", 0) + units.get("µs", 0)) * 1_000
+                + units.get("ns", 0)
+            )
+            return cqlite.Duration(months, days, nanos)
 
         # Plain string
         return value

--- a/bindings/python/tests/test_types_temporal.py
+++ b/bindings/python/tests/test_types_temporal.py
@@ -1,25 +1,31 @@
-"""Tests for temporal CQL type to Python type conversions - Issue #299.
+"""Tests for temporal CQL type to Python type conversions - Issues #299, #1450.
 
-TDD tests verifying that temporal types convert correctly
-to Python native types according to M4 spec section 5.1.
+Verifies that temporal types convert to Python types exactly (no precision loss).
 
 Type Mapping (Temporal):
     CQL Type     | Rust Value         | Python Type
-    -------------|--------------------|-----------------
+    -------------|--------------------|--------------------------------------
     timestamp    | Value::Timestamp   | datetime.datetime (UTC)
     date         | Value::Date        | datetime.date
-    time         | Value::Time        | datetime.time
-    duration     | Value::Duration    | datetime.timedelta
+    time         | Value::Time        | int (nanoseconds since midnight)
+    duration     | Value::Duration    | cqlite.Duration(months, days, nanos)
 
-Precision Notes:
-    - Duration: Months approximated as 30 days, nanos truncated to microseconds
-    - Time: Nanoseconds truncated to microseconds
-    - Timestamp: Millisecond precision preserved
+Precision Notes (issue #1450 — the M4 §5.2 lossy mapping was removed):
+    - Time: exact nanoseconds since midnight as a Python ``int``. Previously a
+      microsecond-capped ``datetime.time`` (sub-µs nanos were truncated).
+    - Duration: exact ``months`` / ``days`` / ``nanos`` components, mirroring the
+      Node binding. Previously a ``datetime.timedelta`` that approximated months
+      as 30 days and truncated nanoseconds to microseconds.
+    - Timestamp: millisecond precision preserved.
 
-Tests use real SSTable data from test_basic keyspace.
+Tests use real SSTable data from test_basic keyspace, plus self-contained
+write→flush→read round-trips (independent of the fixture corpus) to prove
+exactness for values the OLD lossy path would have corrupted.
 """
 
 import datetime
+from pathlib import Path
+
 import pytest
 
 import cqlite
@@ -137,22 +143,27 @@ class TestDateConversion:
             assert not hasattr(value, "hour") or type(value) is datetime.date
 
 
-class TestTimeConversion:
-    """Test CQL TIME to Python datetime.time conversion."""
+# Nanoseconds in one 24-hour day (exclusive upper bound for CQL `time`).
+_NANOS_PER_DAY = 24 * 60 * 60 * 1_000_000_000
 
-    def test_time_returns_time(self, db):
-        """TIME should return Python datetime.time."""
+
+class TestTimeConversion:
+    """Test CQL TIME to Python int (nanoseconds since midnight) conversion (#1450)."""
+
+    def test_time_returns_int_nanos(self, db):
+        """TIME should return a Python int (nanoseconds), NOT datetime.time."""
         result = db.execute("SELECT work_time FROM test_basic.simple_table LIMIT 1")
-        if len(result.rows) == 0:
-            pytest.skip("No data available")
+        assert len(result.rows) > 0, "test_basic.simple_table returned no rows"
 
         value = result.rows[0]["work_time"]
         if value is not None:
-            assert isinstance(value, datetime.time)
-            assert type(value) is datetime.time
+            assert type(value) is int, f"Expected int nanos, got {type(value).__name__}"
+            # A bool is an int subclass; make sure we did not get one by accident.
+            assert not isinstance(value, bool)
+            assert not isinstance(value, datetime.time)
 
-    def test_time_components_valid_range(self, db):
-        """TIME components should be in valid ranges."""
+    def test_time_in_valid_day_range(self, db):
+        """TIME nanoseconds should fall within a single day [0, 86_400e9)."""
         result = db.execute("SELECT work_time FROM test_basic.simple_table LIMIT 10")
 
         found_time = False
@@ -160,89 +171,44 @@ class TestTimeConversion:
             value = row.get("work_time")
             if value is not None:
                 found_time = True
-                assert 0 <= value.hour <= 23, f"Hour out of range: {value.hour}"
-                assert 0 <= value.minute <= 59, f"Minute out of range: {value.minute}"
-                assert 0 <= value.second <= 59, f"Second out of range: {value.second}"
-                assert 0 <= value.microsecond <= 999999, (
-                    f"Microsecond out of range: {value.microsecond}"
-                )
+                assert isinstance(value, int) and not isinstance(value, bool)
+                assert 0 <= value < _NANOS_PER_DAY, f"nanos out of day range: {value}"
 
-        if not found_time:
-            pytest.skip("No time values found in test data")
-
-    def test_time_microsecond_precision(self, db):
-        """TIME should have microsecond precision (nanoseconds truncated)."""
-        result = db.execute("SELECT work_time FROM test_basic.simple_table LIMIT 1")
-        if len(result.rows) == 0:
-            pytest.skip("No data available")
-
-        value = result.rows[0]["work_time"]
-        if value is not None:
-            # microsecond attribute should exist and be an int
-            assert hasattr(value, "microsecond")
-            assert isinstance(value.microsecond, int)
+        assert found_time, "no non-null work_time values found in test data"
 
 
 class TestDurationConversion:
-    """Test CQL DURATION to Python datetime.timedelta conversion.
+    """Test CQL DURATION to cqlite.Duration conversion (exact, #1450).
 
-    IMPORTANT: Duration conversion has precision limitations:
-    - Months are approximated as 30 days each
-    - Nanoseconds are truncated to microseconds
-
-    These limitations are documented in M4 spec section 5.2.
+    A CQL duration is decoded to a ``cqlite.Duration`` exposing the exact
+    ``months`` / ``days`` / ``nanos`` components (mirroring the Node binding),
+    replacing the lossy ``datetime.timedelta`` mapping (M4 §5.2) that collapsed
+    months into 30 days and truncated nanoseconds to microseconds.
     """
 
-    def test_duration_returns_timedelta(self, db):
-        """DURATION should return Python datetime.timedelta."""
+    def test_duration_returns_cqlite_duration(self, db):
+        """DURATION should return cqlite.Duration, NOT datetime.timedelta."""
         result = db.execute("SELECT duration_val FROM test_basic.simple_table LIMIT 1")
-        if len(result.rows) == 0:
-            pytest.skip("No data available")
+        assert len(result.rows) > 0, "test_basic.simple_table returned no rows"
 
         value = result.rows[0]["duration_val"]
         if value is not None:
-            assert isinstance(value, datetime.timedelta), (
-                f"Expected datetime.timedelta, got {type(value).__name__}"
+            assert isinstance(value, cqlite.Duration), (
+                f"Expected cqlite.Duration, got {type(value).__name__}"
             )
-
-    def test_duration_exact_type(self, db):
-        """DURATION should return exactly datetime.timedelta."""
-        result = db.execute("SELECT duration_val FROM test_basic.simple_table LIMIT 1")
-        if len(result.rows) == 0:
-            pytest.skip("No data available")
-
-        value = result.rows[0]["duration_val"]
-        if value is not None:
-            assert type(value) is datetime.timedelta, (
-                f"Expected timedelta, got {type(value).__name__}"
-            )
+            assert not isinstance(value, datetime.timedelta)
 
     def test_duration_not_dict(self, db):
-        """DURATION should NOT return dict (old behavior)."""
+        """DURATION should NOT return a dict."""
         result = db.execute("SELECT duration_val FROM test_basic.simple_table LIMIT 1")
-        if len(result.rows) == 0:
-            pytest.skip("No data available")
+        assert len(result.rows) > 0, "test_basic.simple_table returned no rows"
 
         value = result.rows[0]["duration_val"]
         if value is not None:
-            assert not isinstance(value, dict), (
-                "DURATION should not return dict, should return timedelta"
-            )
+            assert not isinstance(value, dict)
 
-    def test_duration_has_total_seconds(self, db):
-        """DURATION timedelta should support total_seconds() method."""
-        result = db.execute("SELECT duration_val FROM test_basic.simple_table LIMIT 1")
-        if len(result.rows) == 0:
-            pytest.skip("No data available")
-
-        value = result.rows[0]["duration_val"]
-        if value is not None:
-            assert hasattr(value, "total_seconds")
-            total = value.total_seconds()
-            assert isinstance(total, float)
-
-    def test_duration_positive_values(self, db):
-        """DURATION with positive nanoseconds should convert correctly."""
+    def test_duration_components_are_ints(self, db):
+        """cqlite.Duration exposes months/days/nanos as ints."""
         result = db.execute("SELECT duration_val FROM test_basic.simple_table LIMIT 10")
 
         found_duration = False
@@ -250,31 +216,36 @@ class TestDurationConversion:
             value = row.get("duration_val")
             if value is not None:
                 found_duration = True
-                # Verify it's a valid timedelta
-                assert isinstance(value, datetime.timedelta)
-                # Test data has positive durations
-                assert value.total_seconds() >= 0, (
-                    f"Expected positive duration, got {value}"
+                assert isinstance(value.months, int)
+                assert isinstance(value.days, int)
+                assert isinstance(value.nanos, int)
+
+        assert found_duration, "no non-null duration_val values found in test data"
+
+    def test_duration_full_nanos_preserved_on_read(self, db):
+        """The full nanosecond component survives the real read path.
+
+        The test_basic corpus stores hour/minute/second durations (months=0,
+        days=0), so ``nanos`` is a large i64 (>= 1e9). Assert it is preserved
+        verbatim as ``nanos`` — the OLD path stuffed it through a
+        ``timedelta`` microseconds field (``nanos // 1000``), so a value with
+        sub-µs precision would have lost its trailing nanoseconds.
+        """
+        result = db.execute("SELECT duration_val FROM test_basic.simple_table LIMIT 50")
+
+        found = False
+        for row in result.rows:
+            value = row.get("duration_val")
+            if value is not None and value.nanos != 0:
+                found = True
+                # nanos is stored exactly (not divided by 1000, not folded into days)
+                assert value.nanos >= 1_000_000_000, (
+                    f"expected a sub-day nanos component, got {value.nanos}"
                 )
+                # Round-trip the components back into a Duration: exact identity.
+                assert value == cqlite.Duration(value.months, value.days, value.nanos)
 
-        if not found_duration:
-            pytest.skip("No duration values found in test data")
-
-    def test_duration_components_accessible(self, db):
-        """DURATION timedelta components should be accessible."""
-        result = db.execute("SELECT duration_val FROM test_basic.simple_table LIMIT 1")
-        if len(result.rows) == 0:
-            pytest.skip("No data available")
-
-        value = result.rows[0]["duration_val"]
-        if value is not None:
-            # timedelta has days, seconds, microseconds
-            assert hasattr(value, "days")
-            assert hasattr(value, "seconds")
-            assert hasattr(value, "microseconds")
-            assert isinstance(value.days, int)
-            assert isinstance(value.seconds, int)
-            assert isinstance(value.microseconds, int)
+        assert found, "no non-zero-nanos duration values found in test data"
 
 
 class TestTemporalNullHandling:
@@ -363,7 +334,7 @@ class TestTemporalTypeConsistency:
             assert datetime.date in types_seen
 
     def test_time_type_consistent(self, db):
-        """TIME should return same type across all rows."""
+        """TIME should return same type (int) across all rows."""
         result = db.execute("SELECT work_time FROM test_basic.simple_table LIMIT 20")
         if len(result.rows) == 0:
             pytest.skip("No data available")
@@ -376,7 +347,7 @@ class TestTemporalTypeConsistency:
 
         if types_seen:
             assert len(types_seen) == 1, f"Inconsistent types: {types_seen}"
-            assert datetime.time in types_seen
+            assert int in types_seen
 
     def test_duration_type_consistent(self, db):
         """DURATION should return same type across all rows."""
@@ -392,7 +363,7 @@ class TestTemporalTypeConsistency:
 
         if types_seen:
             assert len(types_seen) == 1, f"Inconsistent types: {types_seen}"
-            assert datetime.timedelta in types_seen
+            assert cqlite.Duration in types_seen
 
     def test_all_temporal_types_together(self, db):
         """All temporal types should convert correctly in same query."""
@@ -414,9 +385,9 @@ class TestTemporalTypeConsistency:
             if birth_date is not None:
                 assert type(birth_date) is datetime.date
             if work_time is not None:
-                assert type(work_time) is datetime.time
+                assert type(work_time) is int
             if duration_val is not None:
-                assert type(duration_val) is datetime.timedelta
+                assert isinstance(duration_val, cqlite.Duration)
 
 
 class TestTimestampEdgeCases:
@@ -453,3 +424,114 @@ class TestTimeSeriesData:
             if value is not None:
                 assert isinstance(value, datetime.datetime)
                 assert value.tzinfo == datetime.timezone.utc
+
+
+# =============================================================================
+# Exactness / losslessness proofs (issue #1450)
+# =============================================================================
+
+
+# A single-table schema keeps the write path's target unambiguous (no-heuristics
+# mandate). `wtime` exercises the sub-microsecond TIME round-trip.
+_TIME_SCHEMA = """\
+CREATE KEYSPACE IF NOT EXISTS temporal_exact
+  WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};
+
+USE temporal_exact;
+
+CREATE TABLE IF NOT EXISTS t (
+    id    INT PRIMARY KEY,
+    wtime TIME
+);
+"""
+
+
+class TestTemporalExactness:
+    """Prove values the OLD (M4 §5.2) lossy path corrupted are now preserved."""
+
+    def test_time_lossless_nanos(self, tmp_path):
+        """A sub-microsecond TIME survives a write→flush→read round-trip exactly.
+
+        Inserts 01:02:03.123456789 (nanos = 3_723_123_456_789). The old
+        ``datetime.time`` mapping truncated to microseconds, dropping the
+        trailing ``789`` ns (it would have read back 3_723_123_456_000). The new
+        ``int`` nanoseconds mapping preserves every digit.
+        """
+        schema = tmp_path / "schema.cql"
+        schema.write_text(_TIME_SCHEMA)
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        write_dir = tmp_path / "wd"
+
+        sub_us_nanos = 3_723_123_456_789  # 01:02:03.123456789
+        old_lossy_nanos = (sub_us_nanos // 1000) * 1000  # what µs-truncation gave
+
+        db = cqlite.open(
+            str(data_dir),
+            schema=str(schema),
+            writable=True,
+            write_dir=str(write_dir),
+        )
+        try:
+            db.execute(
+                f"INSERT INTO temporal_exact.t (id, wtime) VALUES (1, {sub_us_nanos})"
+            )
+            path = db.flush_run()
+            assert path and Path(path).exists(), "flush must produce a real Data.db"
+        finally:
+            db.close()
+
+        with cqlite.open(str(write_dir / "data"), schema=str(schema)) as rd:
+            rows = [row.to_dict() for row in rd.execute(
+                "SELECT wtime FROM temporal_exact.t"
+            )]
+
+        assert len(rows) == 1, f"exactly one row expected, got {rows}"
+        value = rows[0]["wtime"]
+        assert type(value) is int, f"TIME must decode to int nanos, got {type(value)}"
+        assert value == sub_us_nanos, f"expected exact {sub_us_nanos}, got {value}"
+        assert value != old_lossy_nanos, (
+            "sub-µs nanoseconds must NOT be truncated (regression to M4 §5.2)"
+        )
+
+    def test_duration_exact_months_days_nanos(self, db):
+        """DURATION exposes months/days/nanos exactly — no 30-day collapse, no
+        nanosecond truncation.
+
+        The real corpus is asserted first (structured type on the read path),
+        then a components round-trip pins the exact values the OLD
+        ``datetime.timedelta`` mapping would have destroyed: months folded into
+        ``months * 30`` days and nanos truncated via ``nanos // 1000``. The
+        read-path conversion is a verbatim 1:1 copy of the stored
+        ``months``/``days``/``nanos`` (see ``bindings/python/src/value.rs``),
+        so the constructed value is byte-identical to what a stored cell with
+        these components decodes to.
+        """
+        result = db.execute("SELECT duration_val FROM test_basic.simple_table LIMIT 1")
+        assert len(result.rows) > 0, "test_basic.simple_table returned no rows"
+        sample = result.rows[0]["duration_val"]
+        if sample is not None:
+            assert isinstance(sample, cqlite.Duration)
+            assert (sample.months, sample.days) == (0, 0)  # corpus stores h/m/s only
+
+        # A duration the OLD path could not represent without loss.
+        months, days, nanos = 14, 3, 123_456_789  # 14 months, 3 days, sub-µs nanos
+        dur = cqlite.Duration(months, days, nanos)
+
+        # Exact, independent components (no collapse into a single scalar).
+        assert dur.months == months
+        assert dur.days == days
+        assert dur.nanos == nanos
+
+        # Contrast with the removed lossy mapping, to make the regression guard
+        # explicit:
+        old_days = months * 30 + days      # timedelta collapsed months → 30 days
+        old_micros = nanos // 1000         # timedelta truncated nanos → micros
+        assert dur.months != 0, "months must be kept, not folded into days"
+        assert (old_days, old_micros) == (423, 123_456)  # what the OLD path yielded
+        assert dur.nanos != old_micros * 1000, "sub-µs nanos must be preserved"
+
+        # Value equality + hashability (usable as dict/set keys).
+        assert dur == cqlite.Duration(months, days, nanos)
+        assert hash(dur) == hash(cqlite.Duration(months, days, nanos))
+        assert dur != cqlite.Duration(months, days, nanos + 1)


### PR DESCRIPTION
Closes #1450. DECIDED 2026-07-01 (owner pre-approved: break the lossy M4 §5.2 mapping in the next minor).

## Premise verified (true)
`bindings/python/src/value.rs` on `main` decoded CQL `time` via `time_to_pytime` (`nanos / 1000` → sub-µs truncated, returned `datetime.time`) and CQL `duration` via `duration_to_timedelta` (`months * 30` days + `nanos / 1000` µs → returned `datetime.timedelta`). Node already decodes both exactly (`Value::Time(nanos)` → bigint; `duration_to_object` → `{months, days, nanos}`). Confirmed at runtime.

## What changed
- **`time` → `int`** (nanoseconds since midnight), lossless. Mirrors Node's bigint.
- **`duration` → `cqlite.Duration(months, days, nanos)`** — new `#[pyclass]` (`frozen, eq, hash`) with `months`/`days`/`nanos` getters; a verbatim 1:1 copy of the stored components (no `*30`, no `/1000`). Registered on the module; exported from `__init__` and typed in `__init__.pyi`.
- Type stub, `README.md` type table updated (drift-free).
- **CLI-parity normalizer** (`test_cli_parity.py`): removed the fake-zero µs→ns padding; the CLI's `HH:MM:SS.nnnnnnnnn` is parsed back to exact nanoseconds (`normalize_cli_value`) so it compares against Python's `int` nanos; `duration` normalizes to the CLI's `XmoYdZns` from exact components (months now preserved).
- `CHANGELOG.md`: breaking-change entry + migration snippet.

## Verified (local)
- `pytest bindings/python/tests/test_types_temporal.py` → **27 passed**, including:
  - `test_time_lossless_nanos` — sub-µs TIME (`01:02:03.123456789`) via **write→flush→read round-trip**, read back as exact `int` (old path would have dropped the trailing `789` ns).
  - `test_duration_exact_months_days_nanos` — exact `months`/`days`/`nanos`, contrasted against the old `months*30` + `nanos//1000` values; eq/hash.
- Real-data reads: `work_time` → `int`, `duration_val` → `cqlite.Duration(0,0,<full nanos>)`.
- Normalizer validated in isolation and against the real CLI output (`3033000000000ns`, `01:12:05.926782000`) — both sides canonicalize equal.
- Rust `cargo fmt --check` clean (cqlite-py). Local agent-gate not run (box OOM under concurrent compiles; targeted verification only).

## ⚠️ BLOCKED ON #1789 (pre-existing main-red, separate owner)
`origin/main` (8d8318f6) does **not compile** the Node/Python binding crates — `bindings/python/src/write.rs:195` is missing a `?` (a #1438×#1620 semantic merge race, tracked as **P1 #1789**). This blocks ALL bindings builds/CI regardless of this PR. This PR is deliberately scoped to #1450 and does **not** include the #1789 fix (owned by the active team). I verified #1450 locally by temporarily applying the one-line #1789 fix, then reverted it. **This PR's bindings CI will stay red until #1789 lands; rebase then to go green.**

Duration cells with `months != 0` and sub-µs nanos are not in the fixture corpus and cannot be written via Python (the CQL write path has no duration-literal parser), so months-preservation is proven at the type + structural-copy level; the sub-µs TIME round-trip is fully end-to-end.