### PR TITLE
fix(#1789): unbreak Node+Python binding builds (block_on Result unwrap; #1438×#1620 race)

### DIFF
--- a/bindings/node/src/database.rs
+++ b/bindings/node/src/database.rs
@@ -827,7 +827,10 @@ impl Database {
                     // in the runtime-present binding topology; the plain sync
                     // `execute()` skips it and would grow the memtable to the hard
                     // limit. Returns the number of mutations applied.
+                    // Outer `?` folds a runtime-init `io::Error` into napi; inner
+                    // `?` propagates the core error (issue #1438).
                     let n = crate::runtime::block_on(engine.execute_flushing(&query))
+                        .map_err(runtime_init_error)?
                         .map_err(to_napi_error)?;
                     Ok::<(u32, u64), napi::Error>((start.elapsed().as_millis() as u32, n))
                 })

--- a/bindings/python/src/write.rs
+++ b/bindings/python/src/write.rs
@@ -192,7 +192,9 @@ impl PyWriteEngine {
     /// threshold is crossed.
     pub fn execute(&mut self, statement: &str) -> cqlite_core::error::Result<u64> {
         use crate::runtime::block_on;
-        block_on(self.inner.execute_flushing(statement))
+        // Outer `?` converts a runtime-init `io::Error` via `Error::Io` (#[from]);
+        // inner `?` propagates the core error (issue #1438).
+        Ok(block_on(self.inner.execute_flushing(statement))??)
     }
 
     /// Flush the memtable to a new SSTable generation.


### PR DESCRIPTION
Closes #1789. main-red: binding crates failed to compile after #1438 changed block_on to return Result<F::Output, io::Error> and #1620's call sites weren't updated to unwrap the nested Result.

Fixed call sites:
- bindings/python/src/write.rs:193 execute() — applied `??` (mirrors sibling flush())
- bindings/node/src/database.rs:830 execute DML path — split into .map_err(runtime_init_error)?.map_err(to_napi_error)? (mirrors sibling flush() at ~1231)

All other block_on sites were already correct (updated in #1438). No unrelated refactors; no new unwrap()/expect().

Verified: `cargo check -p cqlite-py` clean (cdylib link needs maturin/libpython, expected) and `cargo build -p cqlite-node` compiles clean. cargo fmt --check clean.