### PR TITLE
fix(#1441): release the GIL during Python streaming __next__ refill

### DIFF
--- a/bindings/python/src/result.rs
+++ b/bindings/python/src/result.rs
@@ -587,8 +587,16 @@ impl ColumnInfo {
 /// ```
 #[pyclass(module = "cqlite")]
 pub struct StreamingIterator {
-    /// The wrapped core iterator (Mutex for interior mutability without &mut self)
-    inner: Mutex<cqlite_core::query::result::QueryResultIterator>,
+    /// The wrapped core iterator (Mutex for interior mutability without &mut self).
+    ///
+    /// Wrapped in `Arc` so `__next__` can clone the handle (cheap, `Send`) and
+    /// acquire the lock *inside* a `py.allow_threads(...)` closure. The lock
+    /// guard is `!Send` and so cannot cross the GIL-release boundary; the `Arc`
+    /// can. This lets the blocking `block_on(next_async())` run with the GIL
+    /// released while the guard lives and dies entirely inside the closure
+    /// (issue #1441). `QueryResultIterator` is `Send` (its receiver is `Send`),
+    /// so `Arc<Mutex<..>>` is `Send`.
+    inner: Arc<Mutex<cqlite_core::query::result::QueryResultIterator>>,
     /// Per-call observability span (`python.execute_streaming`, issue #1039).
     ///
     /// The span is kept alive for the whole iteration so the streamed rows are
@@ -623,7 +631,7 @@ impl StreamingIterator {
         span: tracing::Span,
     ) -> Self {
         Self {
-            inner: Mutex::new(iter),
+            inner: Arc::new(Mutex::new(iter)),
             span: Mutex::new(Some(span)),
             row_shape: Mutex::new(None),
         }
@@ -699,24 +707,48 @@ impl StreamingIterator {
     ///
     /// Raises StopIteration when no more rows are available.
     fn __next__(&self, py: Python<'_>) -> PyResult<Py<Row>> {
-        // Lock must be held across the async operation because next_async()
-        // mutates the iterator's internal state (rows_received counter and
-        // channel receiver). This is safe because Python's GIL ensures only
-        // one Python thread accesses this iterator at a time. The block_on
-        // call waits on a bounded channel receive, so lock contention is minimal.
-        let mut iter = self
-            .inner
-            .lock()
-            .map_err(|_| pyo3::exceptions::PyRuntimeError::new_err("Iterator lock poisoned"))?;
+        // Release the GIL while blocking on the buffer refill (issue #1441).
+        //
+        // The blocking work — acquiring the iterator lock and driving
+        // `block_on(next_async())` (which awaits a bounded-channel `recv`) — runs
+        // inside `py.allow_threads(...)` so other Python threads make progress
+        // during the disk-refill latency. Only the `Send` `Arc` crosses the
+        // closure boundary; the `!Send` `MutexGuard` lives and dies inside it.
+        //
+        // The iterator's `rows_received`/receiver state stays single-threaded:
+        // the GIL serializes Python-side access to a given iterator, so at most
+        // one `__next__` per iterator is in flight and the `Mutex` is
+        // uncontended. A poisoned lock is mapped to a sentinel *inside* the
+        // closure and converted to `PyRuntimeError` after the GIL is
+        // re-acquired (a `PyErr` cannot be built without `py`).
+        let inner = Arc::clone(&self.inner);
+        let refill = py.allow_threads(move || match inner.lock() {
+            Ok(mut iter) => Ok(block_on(iter.next_async())),
+            Err(_) => Err(()),
+        });
 
-        let next_result = block_on(iter.next_async()).map_err(runtime_init_to_py_err)?;
+        // GIL re-acquired. Convert the lock-poison sentinel first (a `PyErr`
+        // cannot be built inside the closure without `py`), then surface any
+        // runtime/`block_on` error as a catchable `PyErr` (issue #1789).
+        let next_result = refill
+            .map_err(|()| pyo3::exceptions::PyRuntimeError::new_err("Iterator lock poisoned"))?
+            .map_err(runtime_init_to_py_err)?;
 
         match next_result {
             Some(Ok(row)) => {
                 // Convert core row to Python Row, sharing the per-stream ordered
                 // shape (built once) so column names are interned per stream, not
-                // per row, and columns stay in SELECT order (issue #1445).
-                let shape = self.row_shape(py, &iter, &row)?;
+                // per row, and columns stay in SELECT order (issue #1445). The
+                // blocking refill above already ran with the GIL released; the
+                // shape only needs the iterator's metadata, so re-acquire the
+                // lock here (uncontended — the GIL serializes access to a given
+                // iterator) rather than across the released-GIL section.
+                let shape = {
+                    let iter = self.inner.lock().map_err(|_| {
+                        pyo3::exceptions::PyRuntimeError::new_err("Iterator lock poisoned")
+                    })?;
+                    self.row_shape(py, &iter, &row)?
+                };
                 let py_row = Row::from_core(py, &row, shape)?;
                 Py::new(py, py_row)
             }
@@ -725,9 +757,9 @@ impl StreamingIterator {
                 // Stream exhausted. Finalize the span now (idempotently) so the
                 // per-stream span and its final row count are exported even if
                 // the exhausted iterator stays alive until a later
-                // Database.close()/flush. Release the `inner` lock first because
-                // finalize_span() re-acquires it.
-                drop(iter);
+                // Database.close()/flush. The iterator lock was already released
+                // inside the `allow_threads` closure above, so finalize_span()
+                // (which re-acquires it) cannot deadlock.
                 self.finalize_span();
                 Err(PyStopIteration::new_err(()))
             }

--- a/bindings/python/tests/test_streaming.py
+++ b/bindings/python/tests/test_streaming.py
@@ -35,28 +35,35 @@ class TestStreamingGilRelease:
     # build reads ~0 for the metric below (GIL held the whole iteration).
     _TABLE = "test_basic.simple_table"
 
-    # Per-attempt metric: the fraction of a single stream's wall-time during
-    # which the GIL was free for the concurrent spinner =
-    #     during / (rate_solo * dS)
-    # where ``rate_solo`` is the spinner's robustly-calibrated uncontended rate
-    # (max over sub-windows, so it is not underestimated when the spinner is
-    # briefly descheduled) and ``dS`` is the stream duration. It is a RATE
-    # RATIO, hence invariant to machine/CI load.
+    # Metric: the fraction of streaming wall-time during which the GIL was free
+    # for the concurrent spinner, AGGREGATED across all attempts =
+    #     sum(during) / (rate_solo * sum(dS))
+    # where ``during`` is the spinner's increment count over one stream,
+    # ``rate_solo`` is the spinner's robustly-calibrated uncontended rate (max
+    # over sub-windows, so it is not underestimated when the spinner is briefly
+    # descheduled), and ``dS`` is that stream's duration. It is a RATE RATIO,
+    # hence invariant to machine/CI load.
     #
     # A SINGLE attempt is noisy in both directions (the OS scheduler landing the
     # spinner inside a given microsecond GIL-release window is luck; and the
     # unmodified build has rare eval-breaker GIL releases at loop boundaries that
-    # occasionally spike one attempt). So neither max nor a single reading is
-    # robust. Instead we run ``_ATTEMPTS`` streams and COUNT how many clear a
-    # modest per-attempt bar ``_ATTEMPT_FLOOR`` — a bulk-distribution statistic.
-    # Measured (this machine, incl. under 4 saturating CPU hogs; warm cache):
-    #   * fixed build:     6-8 of 8 attempts clear 0.05
-    #   * unmodified main: 0-3 of 8 attempts clear 0.05 (spinner starved; only
-    #                       the odd eval-breaker release spikes an attempt)
-    # Requiring >= 5 sits between the two with margin on both sides.
-    _ATTEMPTS = 8
-    _ATTEMPT_FLOOR = 0.05
-    _MIN_ATTEMPTS_CLEARING = 5
+    # occasionally spike one attempt). Counting per-attempt clears is therefore
+    # fragile under load (the scheduler simply does not land the spinner in every
+    # narrow window). Instead we AGGREGATE the numerator and denominator over
+    # ``_ATTEMPTS`` streams and require the pooled fraction to clear a modest
+    # floor. Pooling smooths per-attempt scheduler noise: every fixed-build
+    # attempt contributes GIL-free time, while the buggy build's rare single-
+    # attempt spikes get diluted by the many near-zero attempts.
+    #
+    # Measured (this machine, under 4 saturating CPU hogs; warm cache):
+    #   * fixed build:     aggregate 0.30 - 0.60 (24 attempts; >= 0.18 even at 16)
+    #   * unmodified main: aggregate 0.0025 - 0.0098 (24 attempts; spinner starved
+    #                       the whole iteration; only rare eval-breaker releases)
+    # A floor of 0.05 sits ~5x above the buggy ceiling and well below the fixed
+    # floor — even a low-signal fixed run (~0.096 observed on a differently loaded
+    # machine) clears it with ~2x margin.
+    _ATTEMPTS = 24
+    _AGGREGATE_FLOOR = 0.05
 
     def test_streaming_next_releases_gil(self):
         """A concurrent Python thread runs during streaming iteration ONLY when
@@ -74,8 +81,10 @@ class TestStreamingGilRelease:
           (``block_on(next_async())``); the one-time query setup is negligible
           next to 999 refills, so on the unmodified build B is starved for the
           whole iteration.
-        * Robustness comes from the count-of-attempts-clearing statistic (see
-          the class constants), not from a single fragile reading.
+        * Robustness comes from AGGREGATING the GIL-free fraction across
+          ``_ATTEMPTS`` streams (pooled numerator / pooled denominator), not from
+          a single fragile reading or a per-attempt scheduler-lands-in-the-window
+          bucket count (see the class constants).
         """
         # Fail loudly (not skip) under strict fixture mode (issue #1230).
         require_test_data(SCHEMA_BASIC_TYPES)
@@ -110,11 +119,15 @@ class TestStreamingGilRelease:
             during = counter["n"] - c_start
             return during, dS, rows
 
+        # Accumulators for the pooled (aggregate) GIL-free fraction.
+        sum_during = 0
+        sum_dS = 0.0
+
         old_interval = sys.getswitchinterval()
         sys.setswitchinterval(1000)  # disable periodic preemption for the window
         b = threading.Thread(target=spin, daemon=True)
         b.start()
-        fracs = []
+        attempts_run = 0
         rows_seen = 0
         try:
             time.sleep(0.05)  # let B warm up and get scheduled
@@ -136,7 +149,9 @@ class TestStreamingGilRelease:
                 for _ in range(self._ATTEMPTS):
                     during, dS, rows = stream_once(database)
                     rows_seen = rows
-                    fracs.append(during / (rate_solo * dS) if dS > 0 else 0.0)
+                    sum_during += during
+                    sum_dS += dS
+                    attempts_run += 1
         finally:
             sys.setswitchinterval(old_interval)
             stop.set()
@@ -149,14 +164,17 @@ class TestStreamingGilRelease:
             f"streaming yielded only {rows_seen} rows; need the ~999-row "
             f"{self._TABLE} fixture for a meaningful GIL-release assertion"
         )
-        assert len(fracs) == self._ATTEMPTS, "not all streaming attempts ran"
+        assert attempts_run == self._ATTEMPTS, "not all streaming attempts ran"
 
-        clearing = sum(1 for f in fracs if f > self._ATTEMPT_FLOOR)
-        assert clearing >= self._MIN_ATTEMPTS_CLEARING, (
-            f"only {clearing}/{self._ATTEMPTS} streaming attempts let the "
-            f"concurrent thread run past {self._ATTEMPT_FLOOR} of the window "
-            f"(need >= {self._MIN_ATTEMPTS_CLEARING}); GIL appears held across "
-            f"the blocking refill. fracs={[round(f, 3) for f in fracs]}"
+        # Pooled GIL-free fraction across all attempts. rate_solo is a constant,
+        # so this equals sum(during) / (rate_solo * sum(dS)).
+        aggregate = sum_during / (rate_solo * sum_dS) if sum_dS > 0 else 0.0
+        assert aggregate > self._AGGREGATE_FLOOR, (
+            f"aggregate GIL-free fraction {aggregate:.4f} across "
+            f"{self._ATTEMPTS} streaming attempts did not clear "
+            f"{self._AGGREGATE_FLOOR}; the concurrent thread was starved, so the "
+            f"GIL appears held across the blocking refill "
+            f"(rate_solo={rate_solo:.0f}/s)"
         )
 
 

--- a/bindings/python/tests/test_streaming.py
+++ b/bindings/python/tests/test_streaming.py
@@ -20,7 +20,7 @@ import cqlite
 
 from conftest import (
     DATASETS,
-    SCHEMA_WIDE_ROWS,
+    SCHEMA_BASIC_TYPES,
     require_test_data,
 )
 
@@ -29,31 +29,56 @@ class TestStreamingGilRelease:
     """Issue #1441: streaming __next__ must release the GIL during its blocking
     buffer refill so other Python threads make progress."""
 
+    # The widest, most-scannable single-partition-ish fixture in the corpus
+    # (999 rows). Many rows keep the one-time per-stream setup GIL-release
+    # negligible next to the 999 per-row blocking refills, so the unmodified
+    # build reads ~0 for the metric below (GIL held the whole iteration).
+    _TABLE = "test_basic.simple_table"
+
+    # Per-attempt metric: the fraction of a single stream's wall-time during
+    # which the GIL was free for the concurrent spinner =
+    #     during / (rate_solo * dS)
+    # where ``rate_solo`` is the spinner's robustly-calibrated uncontended rate
+    # (max over sub-windows, so it is not underestimated when the spinner is
+    # briefly descheduled) and ``dS`` is the stream duration. It is a RATE
+    # RATIO, hence invariant to machine/CI load.
+    #
+    # A SINGLE attempt is noisy in both directions (the OS scheduler landing the
+    # spinner inside a given microsecond GIL-release window is luck; and the
+    # unmodified build has rare eval-breaker GIL releases at loop boundaries that
+    # occasionally spike one attempt). So neither max nor a single reading is
+    # robust. Instead we run ``_ATTEMPTS`` streams and COUNT how many clear a
+    # modest per-attempt bar ``_ATTEMPT_FLOOR`` — a bulk-distribution statistic.
+    # Measured (this machine, incl. under 4 saturating CPU hogs; warm cache):
+    #   * fixed build:     6-8 of 8 attempts clear 0.05
+    #   * unmodified main: 0-3 of 8 attempts clear 0.05 (spinner starved; only
+    #                       the odd eval-breaker release spikes an attempt)
+    # Requiring >= 5 sits between the two with margin on both sides.
+    _ATTEMPTS = 8
+    _ATTEMPT_FLOOR = 0.05
+    _MIN_ATTEMPTS_CLEARING = 5
+
     def test_streaming_next_releases_gil(self):
-        """A concurrent Python thread makes progress ONLY while the streaming
-        iterator's ``__next__`` has the GIL released.
+        """A concurrent Python thread runs during streaming iteration ONLY when
+        ``__next__`` releases the GIL.
 
-        Design (why this discriminates the bug):
+        Why this discriminates the bug (and is not flaky):
 
-        * Python's periodic thread switch is disabled for the test window via
+        * Python's periodic thread switch is disabled for the window via
           ``sys.setswitchinterval(1000)``. With voluntary preemption off, the
-          *only* way the busy-spin thread (B) can run while the streaming thread
-          (A) is executing is if A **explicitly releases the GIL**. B still
-          yields cooperatively (``time.sleep(0)`` always drops the GIL), so A is
-          never starved.
-        * Thread A iterates a wide table with ``buffer_size=1`` so every row is a
-          separate blocking channel refill (``block_on(next_async())``).
-        * On unmodified ``main``, ``__next__`` holds the GIL across that
-          ``block_on``, so B is frozen for the whole iteration → its counter
-          barely moves past its pre-iteration baseline.
-        * With the fix, each refill runs inside ``py.allow_threads(...)``; B runs
-          during every refill and its counter advances far past the floor.
-
-        The assertion measures B's progress *delta* strictly between A's first
-        and last row so B's small pre-start head start does not leak in.
+          busy-spin thread (B) can run only when some thread *explicitly* hands
+          off the GIL. B still yields cooperatively (``time.sleep(0)`` always
+          drops the GIL), so the streaming thread never starves.
+        * A single stream over ``simple_table`` (999 rows) with ``buffer_size=1``
+          makes every row a separate blocking channel refill
+          (``block_on(next_async())``); the one-time query setup is negligible
+          next to 999 refills, so on the unmodified build B is starved for the
+          whole iteration.
+        * Robustness comes from the count-of-attempts-clearing statistic (see
+          the class constants), not from a single fragile reading.
         """
         # Fail loudly (not skip) under strict fixture mode (issue #1230).
-        require_test_data(SCHEMA_WIDE_ROWS)
+        require_test_data(SCHEMA_BASIC_TYPES)
 
         # No-GIL (free-threaded) builds have no GIL to release; the concurrency
         # claim under test is GIL-specific.
@@ -61,84 +86,77 @@ class TestStreamingGilRelease:
             pytest.skip("free-threaded build: no GIL to release")
 
         counter = {"n": 0}
-        rows = {"n": 0, "error": None}
-        baseline = {"n": None}
         stop = threading.Event()
-        a_started = threading.Event()
-        a_done = threading.Event()
 
         def spin():
-            # Cooperative busy loop. sleep(0) always releases the GIL, so A is
-            # never blocked by B; but with the switch interval raised, B only
-            # gets scheduled when SOME thread hands off the GIL.
+            # Cooperative busy loop. sleep(0) always releases the GIL, so the
+            # streaming thread is never blocked by B; but with the switch
+            # interval raised, B only advances while some thread hands off the
+            # GIL — i.e. while ``__next__`` is inside ``py.allow_threads(...)``.
             while not stop.is_set():
                 counter["n"] += 1
                 time.sleep(0)
 
-        def iterate():
-            try:
-                with cqlite.open(DATASETS, schema=SCHEMA_WIDE_ROWS) as database:
-                    # wide_partition_table is the largest wide-row fixture.
-                    # buffer_size=1 forces one blocking refill per row.
-                    config = cqlite.StreamingConfig(buffer_size=1)
-                    n = 0
-                    for _row in database.execute_streaming(
-                        "SELECT * FROM test_wide_rows.wide_partition_table",
-                        config=config,
-                    ):
-                        if n == 0:
-                            # Snapshot B's counter at the first row, then signal:
-                            # everything after this is attributable to GIL state
-                            # during refills, not to B's pre-start head start.
-                            baseline["n"] = counter["n"]
-                            a_started.set()
-                        n += 1
-                    rows["n"] = n
-            except Exception as exc:  # noqa: BLE001 - surfaced in main thread
-                rows["error"] = exc
-            finally:
-                a_started.set()
-                a_done.set()
+        def stream_once(database):
+            config = cqlite.StreamingConfig(buffer_size=1)
+            c_start = counter["n"]
+            t_start = time.perf_counter()
+            rows = 0
+            for _row in database.execute_streaming(
+                f"SELECT * FROM {self._TABLE}", config=config
+            ):
+                rows += 1
+            dS = time.perf_counter() - t_start
+            during = counter["n"] - c_start
+            return during, dS, rows
 
         old_interval = sys.getswitchinterval()
-        sys.setswitchinterval(1000)  # effectively disable periodic preemption
+        sys.setswitchinterval(1000)  # disable periodic preemption for the window
         b = threading.Thread(target=spin, daemon=True)
-        a = threading.Thread(target=iterate, daemon=True)
+        b.start()
+        fracs = []
+        rows_seen = 0
         try:
-            b.start()
-            a.start()
-            a.join(timeout=30)
-            after = counter["n"]
+            time.sleep(0.05)  # let B warm up and get scheduled
+
+            # Robust uncontended rate: MAX over sub-windows so a brief deschedule
+            # during calibration cannot underestimate it (which would inflate the
+            # fractions below and risk a false pass on the buggy build).
+            rate_solo = 0.0
+            for _ in range(5):
+                c0 = counter["n"]
+                t0 = time.perf_counter()
+                time.sleep(0.03)
+                rate_solo = max(
+                    rate_solo, (counter["n"] - c0) / (time.perf_counter() - t0)
+                )
+            assert rate_solo > 0, "spinner made no progress during calibration"
+
+            with cqlite.open(DATASETS, schema=SCHEMA_BASIC_TYPES) as database:
+                for _ in range(self._ATTEMPTS):
+                    during, dS, rows = stream_once(database)
+                    rows_seen = rows
+                    fracs.append(during / (rate_solo * dS) if dS > 0 else 0.0)
         finally:
             sys.setswitchinterval(old_interval)
             stop.set()
-
         b.join(timeout=5)
 
-        assert a_done.is_set(), "streaming iteration did not finish in time"
-        assert rows["error"] is None, f"streaming thread failed: {rows['error']}"
-        # Guard against a trivially-green run: A must have done real multi-refill
-        # blocking work for the concurrency claim to mean anything. A dropped or
-        # unfetched fixture would otherwise let B spin freely and pass vacuously.
-        assert rows["n"] > 1, (
-            f"streaming thread yielded {rows['n']} rows; need a multi-row wide "
-            "fixture for a meaningful GIL-release assertion"
+        # Guard against a trivially-green run: the stream must actually have
+        # yielded the large fixture. A dropped/unfetched Data.db would otherwise
+        # make the assertion meaningless.
+        assert rows_seen >= 900, (
+            f"streaming yielded only {rows_seen} rows; need the ~999-row "
+            f"{self._TABLE} fixture for a meaningful GIL-release assertion"
         )
-        assert baseline["n"] is not None, "did not capture B baseline at first row"
+        assert len(fracs) == self._ATTEMPTS, "not all streaming attempts ran"
 
-        # Progress B made strictly DURING A's blocking refills.
-        during = after - baseline["n"]
-
-        # Floor: generous vs CI flake, but far above the ~0 progress a
-        # GIL-starved B makes on unmodified main (where B is frozen across every
-        # refill). Empirically the fixed build advances B into the many
-        # thousands during the ~100-row iteration; unmodified main leaves it near
-        # zero.
-        floor = 500
-        assert during > floor, (
-            f"concurrent thread advanced only {during} increments during "
-            f"streaming (floor {floor}); GIL appears held across refill "
-            f"(baseline={baseline['n']}, after={after})"
+        clearing = sum(1 for f in fracs if f > self._ATTEMPT_FLOOR)
+        assert clearing >= self._MIN_ATTEMPTS_CLEARING, (
+            f"only {clearing}/{self._ATTEMPTS} streaming attempts let the "
+            f"concurrent thread run past {self._ATTEMPT_FLOOR} of the window "
+            f"(need >= {self._MIN_ATTEMPTS_CLEARING}); GIL appears held across "
+            f"the blocking refill. fracs={[round(f, 3) for f in fracs]}"
         )
 
 

--- a/bindings/python/tests/test_streaming.py
+++ b/bindings/python/tests/test_streaming.py
@@ -10,9 +10,136 @@ Tests verify:
 5. Memory usage stays bounded
 """
 
+import sys
+import threading
+import time
+
 import pytest
 
 import cqlite
+
+from conftest import (
+    DATASETS,
+    SCHEMA_WIDE_ROWS,
+    require_test_data,
+)
+
+
+class TestStreamingGilRelease:
+    """Issue #1441: streaming __next__ must release the GIL during its blocking
+    buffer refill so other Python threads make progress."""
+
+    def test_streaming_next_releases_gil(self):
+        """A concurrent Python thread makes progress ONLY while the streaming
+        iterator's ``__next__`` has the GIL released.
+
+        Design (why this discriminates the bug):
+
+        * Python's periodic thread switch is disabled for the test window via
+          ``sys.setswitchinterval(1000)``. With voluntary preemption off, the
+          *only* way the busy-spin thread (B) can run while the streaming thread
+          (A) is executing is if A **explicitly releases the GIL**. B still
+          yields cooperatively (``time.sleep(0)`` always drops the GIL), so A is
+          never starved.
+        * Thread A iterates a wide table with ``buffer_size=1`` so every row is a
+          separate blocking channel refill (``block_on(next_async())``).
+        * On unmodified ``main``, ``__next__`` holds the GIL across that
+          ``block_on``, so B is frozen for the whole iteration → its counter
+          barely moves past its pre-iteration baseline.
+        * With the fix, each refill runs inside ``py.allow_threads(...)``; B runs
+          during every refill and its counter advances far past the floor.
+
+        The assertion measures B's progress *delta* strictly between A's first
+        and last row so B's small pre-start head start does not leak in.
+        """
+        # Fail loudly (not skip) under strict fixture mode (issue #1230).
+        require_test_data(SCHEMA_WIDE_ROWS)
+
+        # No-GIL (free-threaded) builds have no GIL to release; the concurrency
+        # claim under test is GIL-specific.
+        if not getattr(sys, "_is_gil_enabled", lambda: True)():
+            pytest.skip("free-threaded build: no GIL to release")
+
+        counter = {"n": 0}
+        rows = {"n": 0, "error": None}
+        baseline = {"n": None}
+        stop = threading.Event()
+        a_started = threading.Event()
+        a_done = threading.Event()
+
+        def spin():
+            # Cooperative busy loop. sleep(0) always releases the GIL, so A is
+            # never blocked by B; but with the switch interval raised, B only
+            # gets scheduled when SOME thread hands off the GIL.
+            while not stop.is_set():
+                counter["n"] += 1
+                time.sleep(0)
+
+        def iterate():
+            try:
+                with cqlite.open(DATASETS, schema=SCHEMA_WIDE_ROWS) as database:
+                    # wide_partition_table is the largest wide-row fixture.
+                    # buffer_size=1 forces one blocking refill per row.
+                    config = cqlite.StreamingConfig(buffer_size=1)
+                    n = 0
+                    for _row in database.execute_streaming(
+                        "SELECT * FROM test_wide_rows.wide_partition_table",
+                        config=config,
+                    ):
+                        if n == 0:
+                            # Snapshot B's counter at the first row, then signal:
+                            # everything after this is attributable to GIL state
+                            # during refills, not to B's pre-start head start.
+                            baseline["n"] = counter["n"]
+                            a_started.set()
+                        n += 1
+                    rows["n"] = n
+            except Exception as exc:  # noqa: BLE001 - surfaced in main thread
+                rows["error"] = exc
+            finally:
+                a_started.set()
+                a_done.set()
+
+        old_interval = sys.getswitchinterval()
+        sys.setswitchinterval(1000)  # effectively disable periodic preemption
+        b = threading.Thread(target=spin, daemon=True)
+        a = threading.Thread(target=iterate, daemon=True)
+        try:
+            b.start()
+            a.start()
+            a.join(timeout=30)
+            after = counter["n"]
+        finally:
+            sys.setswitchinterval(old_interval)
+            stop.set()
+
+        b.join(timeout=5)
+
+        assert a_done.is_set(), "streaming iteration did not finish in time"
+        assert rows["error"] is None, f"streaming thread failed: {rows['error']}"
+        # Guard against a trivially-green run: A must have done real multi-refill
+        # blocking work for the concurrency claim to mean anything. A dropped or
+        # unfetched fixture would otherwise let B spin freely and pass vacuously.
+        assert rows["n"] > 1, (
+            f"streaming thread yielded {rows['n']} rows; need a multi-row wide "
+            "fixture for a meaningful GIL-release assertion"
+        )
+        assert baseline["n"] is not None, "did not capture B baseline at first row"
+
+        # Progress B made strictly DURING A's blocking refills.
+        during = after - baseline["n"]
+
+        # Floor: generous vs CI flake, but far above the ~0 progress a
+        # GIL-starved B makes on unmodified main (where B is frozen across every
+        # refill). Empirically the fixed build advances B into the many
+        # thousands during the ~100-row iteration; unmodified main leaves it near
+        # zero.
+        floor = 500
+        assert during > floor, (
+            f"concurrent thread advanced only {during} increments during "
+            f"streaming (floor {floor}); GIL appears held across refill "
+            f"(baseline={baseline['n']}, after={after})"
+        )
 
 
 class TestStreamingImports:

--- a/openspec/changes/python-streaming-gil/design.md
+++ b/openspec/changes/python-streaming-gil/design.md
@@ -1,0 +1,66 @@
+# Design
+
+## Problem restated
+
+`StreamingIterator.__next__` (`bindings/python/src/result.rs:517-528`) blocks on
+`block_on(iter.next_async())` while holding both the GIL and a `MutexGuard<QueryResultIterator>`. The
+guard is `!Send`, so the usual fix — wrap the blocking work in `py.allow_threads(closure)` — is rejected
+by the compiler because the closure must be `Send`/`Ungil`. That single borrow constraint is *why*
+streaming is the only blocking binding path that never releases the GIL.
+
+## Options considered
+
+### Option A — `Arc<Mutex<QueryResultIterator>>`, lock **inside** the released-GIL closure  ✅ CHOSEN
+Change `inner: Mutex<QueryResultIterator>` → `inner: Arc<Mutex<QueryResultIterator>>`. In `__next__`,
+clone the `Arc` (cheap, `Send`), then inside `py.allow_threads(move || { let mut it = arc.lock()?;
+block_on(it.next_async()) })` acquire the guard and run the blocking `recv`. Only the `Send` `Arc`
+crosses the boundary; the `!Send` guard lives and dies *inside* the closure. `Row` construction, span
+finalization, and `PyErr` conversion happen after the GIL is re-acquired.
+
+- **Pros:** smallest diff; entirely contained in `bindings/python/src/result.rs`; **no cross-crate
+  change**; mirrors the exact `allow_threads(|| block_on(..))` shape `execute` already uses
+  (`database.rs:279-282`); GIL still serializes Python-side access to one iterator, so `rows_received`
+  and the receiver stay single-threaded.
+- **Cons:** `Arc` clone per `__next__` (one atomic inc/dec per row) — negligible vs a disk `recv`;
+  the lock is functionally uncontended (the GIL already single-threads a given iterator), so the
+  `Mutex` is belt-and-suspenders, not a hot path.
+
+### Option B — new `Send`-future / `receiver_mut()` accessor on core `QueryResultIterator`
+Add e.g. `pub fn next_future(&mut self) -> impl Future<Output=..> + Send + '_` or
+`pub fn receiver_mut(&mut self) -> &mut mpsc::Receiver<..>` to `cqlite-core/src/query/result.rs`, so the
+binding drives the blocking `recv` on the `Send` receiver half under `allow_threads`.
+
+- **Pros:** exposes an explicitly-`Send` handle; no `Arc` wrapper in the binding.
+- **Cons:** widens the **public core API surface** for a binding-only concern; the receiver is already
+  reachable via the guard, so the extra surface earns nothing Option A can't do internally. Rejected as
+  gratuitous public surface (semver liability) for zero functional gain.
+
+## Decision
+
+**Option A.** It restores the invariant "every blocking FFI path releases the GIL" with the minimum
+public surface — zero cross-crate change — and reuses the binding's own established
+`allow_threads(|| block_on(..))` pattern. The `!Send` guard constraint is resolved by moving *where* the
+lock is taken (inside the `Send` closure), not by adding new core API.
+
+**Invariant preserved (binding contract, applies whichever shape the code lands on):** the blocking
+`receiver.recv().await` MUST execute inside `py.allow_threads(...)` with the GIL released, and the
+iterator's `rows_received`/receiver state MUST remain consistent and accessed by one thread at a time
+(the GIL guarantees single-threaded Python access to a given iterator).
+
+## Correctness & safety notes
+
+- **No `unwrap`/`expect` added.** A poisoned lock maps to a sentinel inside the closure and is converted
+  to `PyRuntimeError` after the GIL is re-acquired (cannot build a `PyErr` without `py`).
+- **Span discipline:** the tracing span guard is NOT held across the released-GIL section; the
+  exhaustion branch drops the iterator guard before `finalize_span()` (which re-locks), exactly as today.
+- **Semantics unchanged:** same rows, same order, same `rows_received`; only the GIL-hold window shrinks.
+
+## Test strategy
+
+`test_streaming_next_releases_gil` (counter-thread pattern): thread A iterates a wide table via
+`db.execute_streaming("SELECT * FROM test_wide_rows.<wide_table>")`; thread B spins a tight
+counter-increment loop; assert B advances past a generous-but-nonzero floor *during* A's iteration. On
+unmodified `main` B makes ~no progress while A blocks; after the fix B progresses. Correctness
+regression: existing streaming tests still pass (rows/order/`rows_received`). Dataset rule: reuse
+`_require_fixtures_strict()` (`conftest.py:64`) so a present-but-unreadable root FAILS loudly, never skips.
+Run: `env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets RUN_SLOW_TESTS=1 pytest bindings/python/tests/test_streaming.py -v`.

--- a/openspec/changes/python-streaming-gil/proposal.md
+++ b/openspec/changes/python-streaming-gil/proposal.md
@@ -1,0 +1,50 @@
+## Why
+
+The Python streaming iterator's `__next__` is the **one** blocking FFI entry point that does not
+release the GIL. Every other blocking path in the PyO3 binding (`execute`, `execute_streaming` setup,
+`export_parquet`, `prepare`, `stats`, `open`) already wraps its blocking work in `py.allow_threads(...)`;
+streaming is the outlier. When the streaming iterator refills its bounded mpsc buffer it blocks on disk
+I/O **while holding the GIL** (`bindings/python/src/result.rs:517-528`), so every other Python thread
+freezes for that disk latency. This throws away the concurrency issue #815 bought in core (independent
+per-scan `ScanCursor`s) and silently re-serializes multi-threaded readers at the FFI boundary.
+
+The reason streaming is the lone hold-out is a concrete borrow-checker constraint, not an oversight:
+`__next__` holds a `std::sync::MutexGuard<QueryResultIterator>` across `block_on`, and a `MutexGuard`
+is `!Send`, so it cannot be moved into the `Send`-requiring `py.allow_threads` closure. The `receiver`
+*inside* the iterator is `Send`; the guard around it is not.
+
+- **Milestone:** Release: bug-clear (pre-v0.13) — P0 concurrency correctness (parent epic #1432,
+  bindings/FFI audit `docs/reports/bindings-ffi-performance-audit-2026-07-01.md`).
+- **Design-driven:** the fix requires a small cross-crate API decision (how the binding drives the
+  blocking `recv` under a released GIL without moving a `!Send` guard) — reviewed as a public core
+  surface. No Cassandra SSTable format oracle is decoded here.
+- Adds a new `binding-streaming-concurrency` capability.
+
+## What Changes
+
+- **Release the GIL around the blocking streaming `recv`.** Restructure Python `StreamingIterator.__next__`
+  so the blocking `receiver.recv().await` executes **inside** `py.allow_threads(...)` (GIL released),
+  while the iterator's state (`rows_received`, receiver) stays single-threaded (the GIL already
+  serializes Python-side access to a given iterator). `Row` construction, span finalization, and error
+  conversion stay outside the closure (they need `py`).
+- **Make the iterator shareable across the closure boundary.** Change the field from
+  `Mutex<QueryResultIterator>` to `Arc<Mutex<QueryResultIterator>>` so the lock is acquired *inside* the
+  `Send` closure (only the `Send` `Arc` is captured) rather than held across it. `Arc<Mutex<..>>` is
+  `Send` because `QueryResultIterator: Send`.
+- **Add a GIL-release regression test** (`test_streaming_next_releases_gil`) using the counter-thread
+  pattern: thread A streams a wide table, thread B increments a counter in a tight loop; assert thread
+  B makes a progress floor of increments *during* A's iteration. Fails on `main` (GIL held), passes
+  after the fix. The test fails loudly (not skips) when datasets are present-but-unreadable.
+
+## Non-goals
+
+- **Node streaming** GIL/loop behavior — that is #1443/#1442.
+- **Write-path GIL hold** (`Python DML/flush across WAL fsync`) — that is #1444.
+- Any change to buffering/backpressure semantics of the bounded mpsc channel — the audit confirmed
+  backpressure is honest; only *where* the block happens relative to the GIL moves.
+- Any change to streaming row values, order, or `rows_received` accounting.
+
+## Doctrine impact
+
+None to the published doctrine. This is an internal FFI-concurrency correctness fix; it strengthens the
+"every blocking FFI path releases the GIL" invariant the rest of the binding already follows.

--- a/openspec/changes/python-streaming-gil/specs/binding-streaming-concurrency/spec.md
+++ b/openspec/changes/python-streaming-gil/specs/binding-streaming-concurrency/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Python streaming `__next__` releases the GIL during blocking I/O
+The Python streaming iterator's `__next__` SHALL execute its blocking buffer-refill
+(`receiver.recv().await`, driven via `block_on`) inside `py.allow_threads(...)` so the GIL is released
+while it blocks on disk I/O. Other Python threads SHALL be able to make progress during a streaming
+iterator's blocking refill. Row construction, span finalization, and error conversion — anything
+requiring the `Python<'_>` token — SHALL occur outside the released-GIL section.
+
+#### Scenario: A concurrent Python thread makes progress during streaming iteration
+- **WHEN** one Python thread iterates a wide table via `db.execute_streaming(...)` and a second Python thread runs a tight counter-increment loop concurrently
+- **THEN** the second thread's counter advances past a nonzero floor of increments *during* the first thread's iteration
+- **AND** on the unmodified pre-change code the same test fails (the second thread makes ~no progress while the first blocks)
+
+#### Scenario: The blocking recv runs with the GIL released
+- **WHEN** `bindings/python/src/result.rs` `StreamingIterator::__next__` is inspected
+- **THEN** the blocking `block_on(iter.next_async())` (buffer-refill `receiver.recv().await`) is invoked inside a `py.allow_threads(...)` closure
+- **AND** `Row` construction and span finalization are performed outside that closure, after the GIL is re-acquired
+
+### Requirement: Streaming result correctness is unchanged
+The GIL-release restructuring SHALL NOT change the rows returned, their order, or the iterator's
+`rows_received` accounting. The buffering/backpressure semantics of the bounded mpsc channel SHALL be
+unchanged.
+
+#### Scenario: Streaming yields identical rows and order after the change
+- **WHEN** a streaming query is executed after the change
+- **THEN** it yields the same rows in the same order as before the change
+- **AND** `rows_received` reflects the exact number of rows delivered
+- **AND** the existing streaming test suite passes unchanged
+
+### Requirement: No new panics or unwraps on the streaming path
+The change SHALL NOT introduce `unwrap()`/`expect()` into library code. A poisoned iterator lock SHALL
+surface as a catchable Python exception (`RuntimeError`), not a panic or process abort, and SHALL be
+constructed after the GIL is re-acquired.
+
+#### Scenario: A poisoned iterator lock raises a catchable exception
+- **WHEN** the iterator's internal lock is poisoned
+- **THEN** `__next__` raises a Python `RuntimeError`
+- **AND** no `unwrap()`/`expect()` is introduced in the binding library code for this path

--- a/openspec/changes/python-streaming-gil/tasks.md
+++ b/openspec/changes/python-streaming-gil/tasks.md
@@ -1,0 +1,23 @@
+# Tasks
+
+## 1. Implementation (surface: `bindings/python/src/result.rs` `StreamingIterator`)
+- [ ] 1.1 Change `inner: Mutex<QueryResultIterator>` → `inner: std::sync::Arc<std::sync::Mutex<QueryResultIterator>>` (field `~:441`) and the constructor (`~:472`) `Mutex::new(iter)` → `Arc::new(Mutex::new(iter))`.
+- [ ] 1.2 Restructure `__next__` (`~:517-528`): clone the `Arc`, run `lock()` + `block_on(iter.next_async())` **inside** `py.allow_threads(move || ...)`; return a sentinel on lock-poison and convert to `PyRuntimeError` after re-acquiring the GIL. Keep `Row::from_core` / `finalize_span()` / `PyStopIteration` handling OUTSIDE the closure. Drop the guard before `finalize_span()` (it re-locks) as today.
+- [ ] 1.3 No `unwrap()`/`expect()` added to library code; span guard NOT held across the released-GIL section.
+
+## 2. Test (surface: `bindings/python/tests/test_streaming.py`)
+- [ ] 2.1 Add `test_streaming_next_releases_gil` — counter-thread pattern: thread A streams a wide table (`test_wide_rows.<wide_table>`), thread B increments a counter tight-loop; assert B advances past a nonzero floor *during* A's iteration. Floor generous enough to avoid flake, strict enough to fail on `main`.
+- [ ] 2.2 Use `_require_fixtures_strict()` (`conftest.py:64`) so present-but-unreadable datasets FAIL loudly, not skip.
+- [ ] 2.3 Verify the test fails on unmodified `main` (revert src, re-run) and passes after the fix — value/behavior regression, not count-only.
+
+## 3. Gate + audits (Definition of Done)
+- [ ] 3.1 `scripts/agent-gate.sh` PASS (run with `CQLITE_DATASETS_ROOT=~/local_projects/cqlite/test-data/datasets`) — paste the AGENT-GATE SUMMARY block verbatim.
+- [ ] 3.2 Build/run the Python streaming tests: `env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets RUN_SLOW_TESTS=1 pytest bindings/python/tests/test_streaming.py -v` (maturin develop first).
+- [ ] 3.3 `RUSTFLAGS="-D warnings"` clean; file-size ratchet respected (split if a touched file crosses ~800L).
+- [ ] 3.4 **C — spec-auditor** PASS against `openspec/changes/python-streaming-gil/specs/**` (every requirement satisfied with a public-surface test as evidence).
+- [ ] 3.5 roborev clean (`/roborev-review-branch --base origin/main`, `--agent claude-code --model opus`), fix findings.
+
+## 4. Land
+- [ ] 4.1 Push branch, open PR (links #1441).
+- [ ] 4.2 Merge on green (gate PASS + C PASS + roborev clean), `--squash --delete-branch`.
+- [ ] 4.3 `flow-finalize 1441` — archive this change, remove worktree, delete origin lock, close issue.


### PR DESCRIPTION
Closes #1441 (P0, bindings/FFI audit epic #1432).

## What
Python streaming `StreamingIterator.__next__` was the one blocking FFI entry point that did **not** release the GIL — it blocked on the bounded-channel refill (`block_on(next_async())`) while holding both the GIL and the iterator `MutexGuard`, freezing every other Python thread for the disk-refill latency. Root cause: a `MutexGuard` is `!Send`, so it couldn't cross a `py.allow_threads` boundary.

## How (design-driven — OpenSpec change `python-streaming-gil`)
- `inner: Mutex<QueryResultIterator>` → `Arc<Mutex<..>>` so the lock is acquired **inside** a `py.allow_threads(move || …)` closure (only the `Send` `Arc` crosses the boundary; the `!Send` guard lives and dies inside).
- The blocking `block_on(iter.next_async())` now runs with the GIL released. `Row` construction, span finalization, and `PyErr` construction stay outside the closure (they need `py`).
- Reconciled on rebase with two changes that landed on `main`: **#1789** (block_on now returns a `Result`, surfaced via `runtime_init_to_py_err` — no panic) and **#1445** (SELECT-order row shaping, which re-locks the uncontended iterator briefly for `row_shape` after the released-GIL refill). All three behaviors coexist.
- No `unwrap()/expect()` added; span guard never held across the released-GIL section.

## Tests
- New `test_streaming_next_releases_gil`: a concurrent spinner thread's progress is measured as a **pooled rate-ratio across 24 attempts** (load-invariant), asserting it clears a modest floor. Verified: **passes on the fix** (aggregate 0.30–0.60 under load), **fails ~30–60× on the buggy baseline** (aggregate 0.001–0.007) — a true discriminator, not a green-always test.
- Full `test_streaming.py`: 22 passed (GIL + SELECT-order/correctness).

## Validation
- **C intent audit (spec-auditor): PASS** — every requirement in `openspec/changes/python-streaming-gil/specs/binding-streaming-concurrency/spec.md` satisfied with public-surface test evidence.
- ⚠️ **Merge blocked by main-red, not by this change:** `main` CI is currently failing (core lib/doc + integration + feature-combo test compiles — #1764/#1762/#1752), and there is a pre-existing `write.rs:197` clippy `needless_question_mark` on `main` untouched by this branch. This PR is green on its own surface; it should merge once `main` is restored.