### PR TITLE
fix(#1794): drop needless Ok(..??) re-wrap in cqlite-py execute (main-red clippy)

### DIFF
--- a/bindings/python/src/write.rs
+++ b/bindings/python/src/write.rs
@@ -192,9 +192,10 @@ impl PyWriteEngine {
     /// threshold is crossed.
     pub fn execute(&mut self, statement: &str) -> cqlite_core::error::Result<u64> {
         use crate::runtime::block_on;
-        // Outer `?` converts a runtime-init `io::Error` via `Error::Io` (#[from]);
-        // inner `?` propagates the core error (issue #1438).
-        Ok(block_on(self.inner.execute_flushing(statement))??)
+        // `?` converts the runtime-init `io::Error` via `Error::Io` (#[from],
+        // issue #1438); the inner `Result<u64>` is this fn's return type and is
+        // returned as-is (no needless `Ok(..??)` re-wrap — clippy #1794).
+        block_on(self.inner.execute_flushing(statement))?
     }
 
     /// Flush the memtable to a new SSTable generation.


### PR DESCRIPTION
Fixes #1794.

Pre-existing **main-red**: `needless_question_mark` at `bindings/python/src/write.rs:197` (introduced by #1792) fails workspace clippy under `-D warnings`, blocking every worker's `scripts/agent-gate.sh` (main has no required clippy CI context, so it slipped in).

## Fix
```rust
- Ok(block_on(self.inner.execute_flushing(statement))??)
+ block_on(self.inner.execute_flushing(statement))?
```
`block_on(..)` returns `Result<Result<u64, CoreError>, io::Error>`. The outer `?` converts the `io::Error` via `Error::Io` (`#[from]`, #1438); the inner `Result<u64>` is this fn's return type, returned as-is. Behaviorally identical to the `Ok(..??)` form, clippy-clean.

Found while running the #1614 (parser fuzz crate) gate. Discovered/tracked in parallel by the session that filed #1794.