### PR TITLE
perf(#1589): window-drain cursor — stop Θ(P·W) memmove per window (scan + compaction)

### DIFF
--- a/cqlite-core/benches/read.rs
+++ b/cqlite-core/benches/read.rs
@@ -320,6 +320,57 @@ fn bench_type_heavy(c: &mut Criterion) {
     group.finish();
 }
 
+/// Bench: partition-dense STREAMING full scan of simple_table (issue #1589).
+///
+/// `test_basic.simple_table` is UUID-keyed with no clustering column, so every row
+/// is its OWN partition (~999 one-row partitions) — the Θ(P·W) pathological shape
+/// the window-drain cursor targets. Unlike `full_scan` (which uses `db.execute`),
+/// this drives `execute_streaming`, the sliding-`WindowCursor` path where confirmed
+/// partitions used to be removed with a per-partition `window.drain(0..consumed)`
+/// (memmoving the whole residual tail each time). It is the sensitive read bench for
+/// a regression in the window-consume cost. `Throughput::Elements(row_count)` so the
+/// report shows rows/sec.
+#[cfg(feature = "cli-helpers")]
+fn bench_scan_partition_dense_stream(c: &mut Criterion) {
+    use cqlite_core::query::result::StreamingConfig;
+
+    let fx = fixtures::ReadFixture::SIMPLE;
+    let loaded = fixtures::open_read_db(&fx);
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let sql = format!("SELECT * FROM {}", fx.qualified());
+
+    // Drain one streaming scan to completion, returning the row count.
+    let drain = |sql: &str| -> usize {
+        rt.block_on(async {
+            let mut iter = loaded
+                .db
+                .execute_streaming(sql, StreamingConfig::default())
+                .await
+                .expect("execute_streaming");
+            let mut n = 0usize;
+            while let Some(row) = iter.next_async().await {
+                black_box(row.expect("streamed row"));
+                n += 1;
+            }
+            n
+        })
+    };
+
+    let row_count = drain(&sql) as u64;
+    assert!(
+        row_count > 0,
+        "partition-dense stream scan of {} returned zero rows — fixtures not fetched?",
+        fx.qualified()
+    );
+
+    let mut group = c.benchmark_group("read");
+    group.throughput(Throughput::Elements(row_count));
+    group.bench_function("scan_partition_dense_stream", |bch| {
+        bch.iter(|| black_box(drain(black_box(&sql))));
+    });
+    group.finish();
+}
+
 // ---------------------------------------------------------------------------
 // criterion_group! / criterion_main! — feature-gated so the bench compiles
 // under default features (no cli-helpers) with an empty but valid group.
@@ -333,7 +384,8 @@ criterion_group!(
               bench_get_partition_bti,
               bench_clustering_slice,
               bench_full_scan,
-              bench_type_heavy
+              bench_type_heavy,
+              bench_scan_partition_dense_stream
 );
 
 #[cfg(not(feature = "cli-helpers"))]

--- a/cqlite-core/src/storage/sstable/reader/data_access/compaction.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/compaction.rs
@@ -617,6 +617,10 @@ impl SSTableReader {
             } else {
                 compressed_chunk
             };
+            // Issue #1589 red-measure: count bytes appended into the window so the
+            // byte-movement guard can compare against bytes memmoved.
+            #[cfg(feature = "scan-offload-probe")]
+            super::super::window_cursor::probe::note_bytes_appended(decompressed_chunk.len());
             window.extend_from_slice(&decompressed_chunk);
             chunk_count += 1;
 
@@ -696,6 +700,15 @@ impl SSTableReader {
             match step {
                 ParseStep::Emitted(consumed) => {
                     let take = if consumed == 0 { 1 } else { consumed };
+                    // Issue #1589 red-measure: the front-drain memmoves the entire
+                    // residual tail after every confirmed partition — Θ(P·W).
+                    #[cfg(feature = "scan-offload-probe")]
+                    {
+                        let capped = take.min(window.len());
+                        super::super::window_cursor::probe::note_bytes_memmoved(
+                            window.len() - capped,
+                        );
+                    }
                     window.drain(0..take.min(window.len()));
                     if local_break {
                         *broke = true;

--- a/cqlite-core/src/storage/sstable/reader/data_access/compaction.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/compaction.rs
@@ -7,6 +7,7 @@
 //! the k-way merger can apply tombstone-shadowing semantics (Issue #505).
 
 use super::super::source::ScanCursor;
+use super::super::window_cursor::WindowCursor;
 use super::super::SSTableReader;
 use crate::{Error, Result};
 use std::io::SeekFrom;
@@ -529,12 +530,14 @@ impl SSTableReader {
     ///
     /// ## Sliding-window driver
     ///
-    /// The V5CompressedLegacy chunk-stitching path keeps a `window: Vec<u8>` of
-    /// decompressed bytes. After appending each decompressed chunk it drains
-    /// confirmed partitions via `parse_one_partition_with_timestamps`,
-    /// `drain(0..consumed)`-ing the front of the window after every `Emitted`,
-    /// and stopping at `NeedMore` to await the next chunk (a partition can
-    /// straddle a chunk boundary). At EOF a final drain pass runs with
+    /// The V5CompressedLegacy chunk-stitching path keeps a sliding
+    /// [`WindowCursor`](super::super::window_cursor::WindowCursor) of decompressed
+    /// bytes. After refilling with each decompressed chunk it drains confirmed
+    /// partitions via `parse_one_partition_with_timestamps`, advancing the cursor
+    /// over the front after every `Emitted` (the reclaimed prefix is compacted once
+    /// per refill, not memmoved per partition — issue #1589), and stopping at
+    /// `NeedMore` to await the next chunk (a partition can straddle a chunk
+    /// boundary). At EOF a final drain pass runs with
     /// `at_final_chunk = true` so the trailing (possibly truncated) partition is
     /// terminal rather than requesting a refill that will never come.
     ///
@@ -577,7 +580,10 @@ impl SSTableReader {
         let owned_schema = schema.cloned().or_else(|| self.get_table_schema(None));
         let parser = self.build_v5_parser();
 
-        let mut window: Vec<u8> = Vec::new();
+        // Sliding window with a FRONT CURSOR (issue #1589): confirmed partitions are
+        // consumed by advancing the cursor, and the reclaimed prefix is compacted
+        // once per refill — not memmoved per partition as the old front-drain did.
+        let mut window = WindowCursor::new();
         let mut broke = false;
 
         use crate::storage::sstable::compression::Compression;
@@ -617,11 +623,9 @@ impl SSTableReader {
             } else {
                 compressed_chunk
             };
-            // Issue #1589 red-measure: count bytes appended into the window so the
-            // byte-movement guard can compare against bytes memmoved.
-            #[cfg(feature = "scan-offload-probe")]
-            super::super::window_cursor::probe::note_bytes_appended(decompressed_chunk.len());
-            window.extend_from_slice(&decompressed_chunk);
+            // Refill the window: compact the already-consumed prefix ONCE
+            // (issue #1589), then append the freshly decompressed chunk.
+            window.refill(&decompressed_chunk);
             chunk_count += 1;
 
             // Not the final chunk yet: NeedMore means "await more bytes". Drain
@@ -670,7 +674,7 @@ impl SSTableReader {
         &self,
         parser: &crate::storage::sstable::reader::parsing::V5CompressedLegacyParser,
         schema: Option<&crate::schema::TableSchema>,
-        window: &mut Vec<u8>,
+        window: &mut WindowCursor,
         at_final_chunk: bool,
         emit: &mut F,
         broke: &mut bool,
@@ -700,16 +704,11 @@ impl SSTableReader {
             match step {
                 ParseStep::Emitted(consumed) => {
                     let take = if consumed == 0 { 1 } else { consumed };
-                    // Issue #1589 red-measure: the front-drain memmoves the entire
-                    // residual tail after every confirmed partition — Θ(P·W).
-                    #[cfg(feature = "scan-offload-probe")]
-                    {
-                        let capped = take.min(window.len());
-                        super::super::window_cursor::probe::note_bytes_memmoved(
-                            window.len() - capped,
-                        );
-                    }
-                    window.drain(0..take.min(window.len()));
+                    // Advance the cursor over the confirmed partition (issue #1589):
+                    // NO memmove here — the reclaimed prefix is compacted once at the
+                    // next refill. `consume` clamps to the remaining length, matching
+                    // the prior `drain(0..take.min(window.len()))`.
+                    window.consume(take);
                     if local_break {
                         *broke = true;
                         return Ok(());

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -38,6 +38,13 @@ mod source;
 #[cfg(test)]
 mod tests;
 mod types;
+// Sliding-window byte cursor + its test-only byte-movement probe (issue #1589);
+// `pub` ONLY under the non-default `scan-offload-probe` feature so the guard test
+// reaches `window_cursor::probe`, else crate-private.
+#[cfg(not(feature = "scan-offload-probe"))]
+pub(crate) mod window_cursor;
+#[cfg(feature = "scan-offload-probe")]
+pub mod window_cursor;
 
 // Re-export public types
 pub use types::{

--- a/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
+++ b/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
@@ -125,6 +125,7 @@
 
 use super::data_access::table_ids_match;
 use super::source::ScanCursor;
+use super::window_cursor::WindowCursor;
 use super::SSTableReader;
 use crate::types::{ScanRow, TableId};
 use crate::{Error, Result, RowKey};
@@ -493,7 +494,7 @@ impl SSTableReader {
     /// Blocking parse half of the windowed streaming scan (issue #1143).
     ///
     /// Runs entirely on a `spawn_blocking` thread — NEVER on an async worker.
-    /// Owns the sliding `window: Vec<u8>`; for each raw chunk pulled from
+    /// Owns the sliding `window` (a [`WindowCursor`], issue #1589); for each raw chunk pulled from
     /// `raw_rx` it applies the incompressible-raw fallback or decompresses,
     /// appends to the window, and drains every confirmed partition via
     /// [`drain_scan_window`]. On a CLEAN `raw_rx` close (I/O EOF) it runs a final
@@ -521,7 +522,10 @@ impl SSTableReader {
         use crate::storage::sstable::compression::Compression;
 
         let parser = self.build_v5_parser();
-        let mut window: Vec<u8> = Vec::new();
+        // Sliding window with a FRONT CURSOR (issue #1589): confirmed partitions are
+        // consumed by advancing the cursor, and the reclaimed prefix is compacted
+        // once per refill — not memmoved per partition as the old front-drain did.
+        let mut window = WindowCursor::new();
         let mut broke = false;
         let mut chunk_count = 0usize;
         // Pending surviving rows not yet handed to the forwarder. Flushed as a
@@ -564,11 +568,9 @@ impl SSTableReader {
                 } else {
                     compressed_chunk
                 };
-                // Issue #1589 red-measure: count bytes appended into the window so
-                // the byte-movement guard can compare against bytes memmoved.
-                #[cfg(feature = "scan-offload-probe")]
-                super::window_cursor::probe::note_bytes_appended(decompressed_chunk.len());
-                window.extend_from_slice(&decompressed_chunk);
+                // Refill the window: compact the already-consumed prefix ONCE
+                // (issue #1589), then append the freshly decompressed chunk.
+                window.refill(&decompressed_chunk);
                 chunk_count += 1;
 
                 // Not the final chunk yet: drain confirmed partitions; NeedMore
@@ -681,7 +683,7 @@ impl SSTableReader {
         &self,
         parser: &crate::storage::sstable::reader::parsing::V5CompressedLegacyParser,
         ctx: &WindowParseCtx,
-        window: &mut Vec<u8>,
+        window: &mut WindowCursor,
         at_final_chunk: bool,
         tx: &mpsc::Sender<Result<Vec<(RowKey, ScanRow)>>>,
         batch: &mut Vec<(RowKey, ScanRow)>,
@@ -757,14 +759,11 @@ impl SSTableReader {
             match step {
                 ParseStep::Emitted(consumed) => {
                     let take = if consumed == 0 { 1 } else { consumed };
-                    // Issue #1589 red-measure: the front-drain memmoves the entire
-                    // residual tail after every confirmed partition — Θ(P·W).
-                    #[cfg(feature = "scan-offload-probe")]
-                    {
-                        let capped = take.min(window.len());
-                        super::window_cursor::probe::note_bytes_memmoved(window.len() - capped);
-                    }
-                    window.drain(0..take.min(window.len()));
+                    // Advance the cursor over the confirmed partition (issue #1589):
+                    // NO memmove here — the reclaimed prefix is compacted once at the
+                    // next refill. `consume` clamps to the remaining length, matching
+                    // the prior `drain(0..take.min(window.len()))`.
+                    window.consume(take);
                     // Accumulate this partition's surviving entries in scan order,
                     // flushing a full batch as ONE channel item whenever it
                     // reaches `BATCH_EMIT_ROWS`. `blocking_send` carries the same

--- a/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
+++ b/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
@@ -522,9 +522,7 @@ impl SSTableReader {
         use crate::storage::sstable::compression::Compression;
 
         let parser = self.build_v5_parser();
-        // Sliding window with a FRONT CURSOR (issue #1589): confirmed partitions are
-        // consumed by advancing the cursor, and the reclaimed prefix is compacted
-        // once per refill — not memmoved per partition as the old front-drain did.
+        // Sliding front-cursor window (issue #1589): compacts once per refill.
         let mut window = WindowCursor::new();
         let mut broke = false;
         let mut chunk_count = 0usize;
@@ -568,8 +566,6 @@ impl SSTableReader {
                 } else {
                     compressed_chunk
                 };
-                // Refill the window: compact the already-consumed prefix ONCE
-                // (issue #1589), then append the freshly decompressed chunk.
                 window.refill(&decompressed_chunk);
                 chunk_count += 1;
 
@@ -759,10 +755,7 @@ impl SSTableReader {
             match step {
                 ParseStep::Emitted(consumed) => {
                     let take = if consumed == 0 { 1 } else { consumed };
-                    // Advance the cursor over the confirmed partition (issue #1589):
-                    // NO memmove here — the reclaimed prefix is compacted once at the
-                    // next refill. `consume` clamps to the remaining length, matching
-                    // the prior `drain(0..take.min(window.len()))`.
+                    // Advance the cursor (no memmove); `consume` clamps to remaining.
                     window.consume(take);
                     // Accumulate this partition's surviving entries in scan order,
                     // flushing a full batch as ONE channel item whenever it

--- a/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
+++ b/cqlite-core/src/storage/sstable/reader/scan_stream_windowed.rs
@@ -564,6 +564,10 @@ impl SSTableReader {
                 } else {
                     compressed_chunk
                 };
+                // Issue #1589 red-measure: count bytes appended into the window so
+                // the byte-movement guard can compare against bytes memmoved.
+                #[cfg(feature = "scan-offload-probe")]
+                super::window_cursor::probe::note_bytes_appended(decompressed_chunk.len());
                 window.extend_from_slice(&decompressed_chunk);
                 chunk_count += 1;
 
@@ -753,6 +757,13 @@ impl SSTableReader {
             match step {
                 ParseStep::Emitted(consumed) => {
                     let take = if consumed == 0 { 1 } else { consumed };
+                    // Issue #1589 red-measure: the front-drain memmoves the entire
+                    // residual tail after every confirmed partition — Θ(P·W).
+                    #[cfg(feature = "scan-offload-probe")]
+                    {
+                        let capped = take.min(window.len());
+                        super::window_cursor::probe::note_bytes_memmoved(window.len() - capped);
+                    }
                     window.drain(0..take.min(window.len()));
                     // Accumulate this partition's surviving entries in scan order,
                     // flushing a full batch as ONE channel item whenever it

--- a/cqlite-core/src/storage/sstable/reader/window_cursor.rs
+++ b/cqlite-core/src/storage/sstable/reader/window_cursor.rs
@@ -9,8 +9,88 @@
 //! partition-dense table: thousands of one-row partitions packed into one window).
 //!
 //! This module hosts the test-only byte-movement [`probe`] that measures that cost
-//! (issue #1589), and — after the fix — the [`WindowCursor`] cursor that reduces it
-//! to Θ(W) per window.
+//! (issue #1589), and the [`WindowCursor`] cursor that reduces it to Θ(W) per
+//! window.
+
+/// A decompressed-byte window with a FRONT CURSOR (issue #1589).
+///
+/// Invariant: `start <= buf.len()`. The logical window (the bytes not yet consumed)
+/// is `buf[start..]`. [`consume`](Self::consume) advances `start` with NO memmove;
+/// [`refill`](Self::refill) reclaims the consumed prefix `buf[..start]` with a
+/// SINGLE compaction — once per refill, not once per confirmed partition — then
+/// appends the new chunk. So each byte is physically moved at most once per refill
+/// it survives (Θ(W) per window over the whole window lifetime), replacing the
+/// per-partition `window.drain(0..consumed)` that moved Θ(P·W).
+///
+/// Window sizing / backpressure semantics are unchanged: [`as_slice`](Self::as_slice)
+/// yields exactly the same unconsumed bytes the prior `Vec` did after each drain;
+/// only the physical byte movement differs.
+pub(crate) struct WindowCursor {
+    buf: Vec<u8>,
+    start: usize,
+}
+
+impl WindowCursor {
+    /// A new, empty window.
+    pub(crate) fn new() -> Self {
+        Self {
+            buf: Vec::new(),
+            start: 0,
+        }
+    }
+
+    /// The unconsumed bytes — the logical window the parser reads. Cursor-relative.
+    #[inline]
+    pub(crate) fn as_slice(&self) -> &[u8] {
+        &self.buf[self.start..]
+    }
+
+    /// Number of unconsumed bytes remaining in the logical window.
+    #[inline]
+    pub(crate) fn len(&self) -> usize {
+        self.buf.len() - self.start
+    }
+
+    /// Whether the logical window is empty (all appended bytes consumed).
+    #[inline]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.start >= self.buf.len()
+    }
+
+    /// Consume `n` bytes from the FRONT of the logical window by advancing the
+    /// cursor — NO memmove. `n` is clamped to the unconsumed length, exactly
+    /// matching the prior `drain(0..n.min(len))` semantics (a parser reporting
+    /// `consumed > remaining` cannot advance the cursor past the window end).
+    #[inline]
+    pub(crate) fn consume(&mut self, n: usize) {
+        // `capped <= self.len()` and `start + self.len() == buf.len()`, so the
+        // cursor never runs past the buffer; no overflow (capped <= buf.len()).
+        let capped = n.min(self.len());
+        self.start += capped;
+    }
+
+    /// Append a freshly decompressed `chunk`. First reclaims the already-consumed
+    /// prefix `buf[..start]` with a SINGLE compaction (one memmove of the residual
+    /// unconsumed tail), resetting the cursor to 0, THEN extends with `chunk`. The
+    /// residual tail is therefore moved at most once PER REFILL — never once per
+    /// confirmed partition (issue #1589).
+    pub(crate) fn refill(&mut self, chunk: &[u8]) {
+        if self.start > 0 {
+            // Residual (unconsumed) bytes this single compaction moves. `copy_within`
+            // + `truncate` moves exactly `residual` bytes — the same work a
+            // `drain(0..start)` would do, but done once per refill, not per partition.
+            let residual = self.len();
+            #[cfg(feature = "scan-offload-probe")]
+            probe::note_bytes_memmoved(residual);
+            self.buf.copy_within(self.start.., 0);
+            self.buf.truncate(residual);
+            self.start = 0;
+        }
+        #[cfg(feature = "scan-offload-probe")]
+        probe::note_bytes_appended(chunk.len());
+        self.buf.extend_from_slice(chunk);
+    }
+}
 
 /// Test-only probe (issue #1589) for the sliding window's byte-movement cost.
 ///
@@ -64,5 +144,65 @@ pub mod probe {
     /// Total decompressed bytes appended into the window during the armed run.
     pub fn recorded_bytes_appended() -> usize {
         BYTES_APPENDED.load(Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::WindowCursor;
+
+    #[test]
+    fn consume_advances_cursor_without_memmove() {
+        let mut w = WindowCursor::new();
+        w.refill(b"abcdefgh");
+        assert_eq!(w.as_slice(), b"abcdefgh");
+        assert_eq!(w.len(), 8);
+        assert!(!w.is_empty());
+        w.consume(3);
+        assert_eq!(w.as_slice(), b"defgh");
+        assert_eq!(w.len(), 5);
+        w.consume(5);
+        assert!(w.is_empty());
+        assert_eq!(w.len(), 0);
+        assert_eq!(w.as_slice(), b"");
+    }
+
+    #[test]
+    fn consume_clamps_to_remaining() {
+        let mut w = WindowCursor::new();
+        w.refill(b"xyz");
+        // A parser reporting more consumed than remaining must not run past the end
+        // (mirrors the prior `drain(0..take.min(window.len()))` clamp).
+        w.consume(100);
+        assert!(w.is_empty());
+        assert_eq!(w.len(), 0);
+    }
+
+    #[test]
+    fn refill_compacts_consumed_prefix_and_preserves_residual() {
+        let mut w = WindowCursor::new();
+        w.refill(b"aabbccdd");
+        w.consume(6); // consume "aabbcc", residual "dd"
+        assert_eq!(w.as_slice(), b"dd");
+        w.refill(b"eeff"); // compact residual "dd" once, then append "eeff"
+        assert_eq!(w.as_slice(), b"ddeeff");
+        assert_eq!(w.len(), 6);
+        // A second consume + refill continues from the compacted base.
+        w.consume(2); // "dd"
+        w.refill(b"gg");
+        assert_eq!(w.as_slice(), b"eeffgg");
+    }
+
+    #[test]
+    fn refill_from_empty_and_fully_consumed_windows() {
+        let mut w = WindowCursor::new();
+        // Refill into an empty window: no residual to compact.
+        w.refill(b"first");
+        w.consume(5); // fully consumed
+        assert!(w.is_empty());
+        // Refill after full consumption: compaction removes everything, then appends.
+        w.refill(b"second");
+        assert_eq!(w.as_slice(), b"second");
+        assert_eq!(w.len(), 6);
     }
 }

--- a/cqlite-core/src/storage/sstable/reader/window_cursor.rs
+++ b/cqlite-core/src/storage/sstable/reader/window_cursor.rs
@@ -1,0 +1,68 @@
+//! Sliding decompressed-byte window helpers (issue #1589).
+//!
+//! Both the user-facing windowed scan (`scan_stream_windowed`) and the streaming
+//! compaction driver (`data_access::compaction`) keep a `Vec<u8>` of decompressed
+//! bytes, parse CONFIRMED partitions from the FRONT, and refill from the tail as
+//! new chunks arrive. Consuming the front with `window.drain(0..consumed)` memmoves
+//! the ENTIRE residual tail on every confirmed partition — Θ(P·W) bytes moved per
+//! window for P tiny partitions over a W-byte residual (the pathological case is a
+//! partition-dense table: thousands of one-row partitions packed into one window).
+//!
+//! This module hosts the test-only byte-movement [`probe`] that measures that cost
+//! (issue #1589), and — after the fix — the [`WindowCursor`] cursor that reduces it
+//! to Θ(W) per window.
+
+/// Test-only probe (issue #1589) for the sliding window's byte-movement cost.
+///
+/// Records the total bytes physically memmoved by the window's consume/compact path
+/// and the total decompressed bytes appended, so a guard test can prove that a
+/// partition-dense scan moves O(appended) bytes total — each byte at most ~once per
+/// window — rather than the Θ(P·W) the per-partition front-drain moved. Compiled
+/// ONLY under the non-default `scan-offload-probe` feature, so it adds zero cost and
+/// no public surface in normal/release builds; both the windowed scan and the
+/// streaming compaction driver feed this one counter, so it covers both sites.
+#[cfg(feature = "scan-offload-probe")]
+#[doc(hidden)]
+pub mod probe {
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    static ARMED: AtomicBool = AtomicBool::new(false);
+    static BYTES_MEMMOVED: AtomicUsize = AtomicUsize::new(0);
+    static BYTES_APPENDED: AtomicUsize = AtomicUsize::new(0);
+
+    /// Arm the probe and reset the counters. Call before driving a scan/compaction.
+    pub fn arm() {
+        BYTES_MEMMOVED.store(0, Ordering::SeqCst);
+        BYTES_APPENDED.store(0, Ordering::SeqCst);
+        ARMED.store(true, Ordering::SeqCst);
+    }
+
+    /// Disarm the probe (restores the production no-op state).
+    pub fn disarm() {
+        ARMED.store(false, Ordering::SeqCst);
+    }
+
+    /// Record `n` bytes physically memmoved while consuming/compacting the window.
+    pub(crate) fn note_bytes_memmoved(n: usize) {
+        if ARMED.load(Ordering::Relaxed) {
+            BYTES_MEMMOVED.fetch_add(n, Ordering::Relaxed);
+        }
+    }
+
+    /// Record `n` bytes appended (decompressed) into the window, if armed.
+    pub(crate) fn note_bytes_appended(n: usize) {
+        if ARMED.load(Ordering::Relaxed) {
+            BYTES_APPENDED.fetch_add(n, Ordering::Relaxed);
+        }
+    }
+
+    /// Total bytes physically memmoved by the window during the armed run.
+    pub fn recorded_bytes_memmoved() -> usize {
+        BYTES_MEMMOVED.load(Ordering::Relaxed)
+    }
+
+    /// Total decompressed bytes appended into the window during the armed run.
+    pub fn recorded_bytes_appended() -> usize {
+        BYTES_APPENDED.load(Ordering::Relaxed)
+    }
+}

--- a/cqlite-core/tests/issue_1589_window_drain_bytes.rs
+++ b/cqlite-core/tests/issue_1589_window_drain_bytes.rs
@@ -1,0 +1,253 @@
+//! Issue #1589 (E7 — window-drain cursor): the sliding-window scan/compaction
+//! drivers must consume confirmed partitions with a FRONT CURSOR, not
+//! `window.drain(0..consumed)`.
+//!
+//! ## What this guards
+//!
+//! `drain_scan_window` (`scan_stream_windowed.rs`) and `drain_compaction_window`
+//! (`data_access/compaction.rs`) parse CONFIRMED partitions from the FRONT of a
+//! `window: Vec<u8>` and used to remove each one with `window.drain(0..consumed)`.
+//! `Vec::drain` at the front memmoves the ENTIRE residual tail — so a
+//! partition-dense window (thousands of one-row partitions packed into one window)
+//! moves Θ(P·W) bytes: for each of P partitions it shifts the ~W-byte remainder
+//! down. The fix advances a cursor instead and compacts the reclaimed prefix ONCE
+//! per refill, so each byte is physically moved at most ~once per window — Θ(W).
+//!
+//! ## The measured invariant (why it fails today, passes after the fix)
+//!
+//! The `scan-offload-probe` instrumentation counts total bytes physically memmoved
+//! by the window (`recorded_bytes_memmoved`) and total decompressed bytes appended
+//! (`recorded_bytes_appended`). On a partition-dense fixture:
+//!
+//! - **Before the fix (front-drain):** each confirmed partition memmoves the whole
+//!   residual tail, so bytes_memmoved grows ~quadratically in partitions-per-window
+//!   and is many times bytes_appended. `bytes_memmoved <= bytes_appended` FAILS.
+//! - **After the fix (cursor + compact-once-per-refill):** the window compacts only
+//!   the surviving straddle once per chunk refill, so bytes_memmoved is a small
+//!   fraction of bytes_appended (each byte moved at most ~once). The bound PASSES
+//!   with a large margin.
+//!
+//! `test_basic.simple_table` is UUID-keyed with no clustering column, so every row
+//! is its OWN partition (999 partitions on the pinned fixture) — the partition-dense
+//! shape this guard needs. Both the user-facing windowed scan and the streaming
+//! compaction driver refill the same window abstraction, so the guard exercises
+//! BOTH sites (issue #1589 touches both, kept aligned).
+//!
+//! Requirements:
+//! - `CQLITE_DATASETS_ROOT` pointing to `test-data/datasets`
+//! - real SSTable Data.db files (`bash test-data/scripts/fetch-datasets.sh`).
+//!   Dataset-dependent: skips when Data.db is absent, but a present fixture that
+//!   returns zero rows / does not route through the windowed path is a FAILURE.
+
+// Requires the non-default `scan-offload-probe` feature: it gates the
+// `window_cursor::probe` instrumentation this guard reads (issue #1589). The agent
+// gate runs this binary with the feature enabled.
+#![cfg(all(
+    feature = "state_machine",
+    feature = "cli-helpers",
+    feature = "scan-offload-probe"
+))]
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::platform::Platform;
+use cqlite_core::query::result::StreamingConfig;
+use cqlite_core::storage::sstable::reader::window_cursor::probe;
+use cqlite_core::storage::sstable::SSTableReader;
+use cqlite_core::{Config, Database};
+
+/// UUID-keyed, no-clustering table: one row per partition, so the fixture has as
+/// many partitions as rows (999 on the pinned dataset) — the partition-dense shape
+/// this guard needs.
+const KEYSPACE: &str = "test_basic";
+const TABLE: &str = "simple_table";
+const SCHEMA_FILE: &str = "basic-types.cql";
+
+fn get_datasets_root() -> Option<PathBuf> {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+}
+
+fn get_schemas_dir() -> Option<PathBuf> {
+    if let Some(datasets_root) = get_datasets_root() {
+        if let Some(parent) = datasets_root.parent() {
+            let schemas_dir = parent.join("schemas");
+            if schemas_dir.exists() {
+                return Some(schemas_dir);
+            }
+        }
+    }
+    let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let schemas_dir = manifest_dir.parent()?.join("test-data").join("schemas");
+    schemas_dir.exists().then_some(schemas_dir)
+}
+
+/// Directory holding the fixture's SSTable components, if a Data.db is present.
+fn fixture_dir() -> Option<PathBuf> {
+    let root = get_datasets_root()?;
+    let table_root = root.join("sstables").join(KEYSPACE);
+    for entry in std::fs::read_dir(&table_root).ok()?.flatten() {
+        let name = entry.file_name();
+        if name.to_string_lossy().starts_with(&format!("{TABLE}-"))
+            && entry.path().is_dir()
+            && std::fs::read_dir(entry.path()).ok()?.flatten().any(|f| {
+                f.file_name()
+                    .to_str()
+                    .is_some_and(|n| n.ends_with("-Data.db"))
+            })
+        {
+            return Some(entry.path());
+        }
+    }
+    None
+}
+
+/// Path to the fixture's Data.db, if present.
+fn fixture_data_db() -> Option<PathBuf> {
+    let dir = fixture_dir()?;
+    std::fs::read_dir(&dir).ok()?.flatten().find_map(|f| {
+        f.file_name()
+            .to_str()
+            .is_some_and(|n| n.ends_with("-Data.db"))
+            .then(|| f.path())
+    })
+}
+
+async fn setup_db() -> Database {
+    let datasets_root = get_datasets_root().expect("CQLITE_DATASETS_ROOT");
+    let schemas_dir = get_schemas_dir().expect("schemas dir");
+    let schema_path = schemas_dir.join(SCHEMA_FILE);
+    assert!(schema_path.exists(), "schema not found: {schema_path:?}");
+
+    let config = IngestionConfig {
+        schema_paths: vec![schema_path],
+        data_dir: datasets_root.join("sstables"),
+        version_hint: None,
+        core_config: Config::default(),
+        table_directory_filter: Some(format!("/{KEYSPACE}/")),
+    };
+    ingest(config).await.expect("ingest simple_table").database
+}
+
+async fn open_reader(data_db: &Path) -> SSTableReader {
+    let config = Config::default();
+    let platform = Arc::new(Platform::new(&config).await.expect("platform"));
+    SSTableReader::open(data_db, &config, platform)
+        .await
+        .expect("open reader")
+}
+
+/// Drain a single full streaming scan to completion, returning the row count.
+async fn drain_one_scan(db: &Database, sql: &str) -> usize {
+    let config = StreamingConfig {
+        buffer_size: 1,
+        ..StreamingConfig::default()
+    };
+    let mut iter = db
+        .execute_streaming(sql, config)
+        .await
+        .expect("execute_streaming should succeed");
+    let mut n = 0usize;
+    while let Some(row) = iter.next_async().await {
+        row.expect("streamed row should be Ok");
+        n += 1;
+    }
+    n
+}
+
+/// Assert the byte-movement bound, printing the observed figures. `context` names
+/// the driver (scan vs compaction) so a failure is unambiguous.
+fn assert_bytes_moved_bounded(context: &str, units: usize, appended: usize, memmoved: usize) {
+    // Non-vacuous: the fixture must have produced rows AND routed through the
+    // chunk-stitching window path (the only path that appends into the window /
+    // arms this probe). Zero appended bytes means a non-stitching fallback ran and
+    // the guard would be meaningless.
+    assert!(
+        units > 0,
+        "Issue #1589 [{context}]: fixture is present but produced 0 units — guard would be vacuous"
+    );
+    assert!(
+        appended > 0,
+        "Issue #1589 [{context}]: 0 bytes appended into the window — the chunk-stitching \
+         window path this guard instruments did not run (fixture may not be the `nb` \
+         chunk-compressed format)"
+    );
+
+    eprintln!(
+        "Issue #1589 [{context}] window byte-movement: units={units} \
+         bytes_appended={appended} bytes_memmoved={memmoved} \
+         (ratio memmoved/appended = {:.2})",
+        memmoved as f64 / appended as f64
+    );
+
+    // The load-bearing assertion. Front-drain moves the whole residual tail per
+    // partition (Θ(P·W)) and blows far past bytes_appended on a partition-dense
+    // fixture; the cursor + compact-once-per-refill moves each byte at most ~once,
+    // so total bytes memmoved stays at or below bytes appended (with large margin).
+    assert!(
+        memmoved <= appended,
+        "Issue #1589 REGRESSION [{context}]: the window memmoved {memmoved} bytes over a \
+         {units}-unit run while only {appended} bytes were appended — the front-drain \
+         (`window.drain(0..consumed)`) is moving the residual tail once PER PARTITION \
+         (Θ(P·W)). Replace it with a front cursor that advances on consume and compacts \
+         the reclaimed prefix ONCE per refill (see WindowCursor, issue #1589)."
+    );
+}
+
+/// Both the user-facing windowed scan AND the streaming compaction driver must
+/// move O(appended) bytes, not Θ(P·W) (issue #1589 touches both, kept aligned).
+///
+/// Combined into ONE test: the byte-movement probe is a process-global counter, so
+/// two probe tests in this single binary would race if run in parallel. Driving
+/// scan then compaction sequentially (arm/measure/disarm around each) keeps the
+/// counters isolated without depending on the harness thread count.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn scan_and_compaction_windows_move_bytes_bounded_by_appended() {
+    let Some(data_db) = fixture_data_db() else {
+        eprintln!(
+            "Skipping {KEYSPACE}.{TABLE}: no Data.db present (run fetch-datasets.sh). \
+             This guard is non-vacuous only with the real partition-dense fixture."
+        );
+        return;
+    };
+
+    // --- Scan path -------------------------------------------------------------
+    let db = setup_db().await;
+    let sql = format!("SELECT * FROM {KEYSPACE}.{TABLE}");
+
+    probe::arm();
+    let rows = drain_one_scan(&db, &sql).await;
+    // `drain_one_scan` returns only after the stream ends, which the consumer
+    // observes only once the blocking parse task dropped its sender — after its
+    // last window refill/consume. That channel-close happens-before ordering makes
+    // every recorded byte-move visible to this read without a settle sleep.
+    let scan_memmoved = probe::recorded_bytes_memmoved();
+    let scan_appended = probe::recorded_bytes_appended();
+    probe::disarm();
+
+    assert_bytes_moved_bounded("scan", rows, scan_appended, scan_memmoved);
+
+    // --- Streaming compaction path (production k-way-merge feed) ---------------
+    let reader = open_reader(&data_db).await;
+    let count: Arc<Mutex<usize>> = Arc::new(Mutex::new(0));
+    let sink = Arc::clone(&count);
+
+    probe::arm();
+    reader
+        .stream_all_partitions_for_compaction(None, move |_row| {
+            *sink.lock().expect("count lock") += 1;
+            Ok(std::ops::ControlFlow::Continue(()))
+        })
+        .await
+        .expect("stream_all_partitions_for_compaction");
+    let comp_memmoved = probe::recorded_bytes_memmoved();
+    let comp_appended = probe::recorded_bytes_appended();
+    probe::disarm();
+
+    let emitted = *count.lock().expect("count lock");
+    assert_bytes_moved_bounded("compaction", emitted, comp_appended, comp_memmoved);
+}

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -18,7 +18,10 @@
 #                      the default core-tests run can't execute it — issue #1143).
 #                      Also runs --test issue_1333_scan_scratch_reuse (the
 #                      windowed scan's per-partition scratch Vec is reused, not
-#                      reallocated per partition — issue #1333); same feature gate.
+#                      reallocated per partition — issue #1333) and
+#                      --test issue_1589_window_drain_bytes (the scan/compaction
+#                      windows advance a cursor + compact once per refill instead
+#                      of front-draining per partition — issue #1589); same gate.
 #   integration-tests  cargo test -p cqlite-integration-tests: compile ALL targets
 #                      (--no-run, whole package) then run the seven CI-enforced ones
 #   format-compat      cargo test -p format-compatibility-tests (the 'oa' format crate;
@@ -913,7 +916,8 @@ run_component tombstones-scan cargo test --package cqlite-core \
 run_component scan-offload-guard cargo test --package cqlite-core \
   --features cli-helpers,scan-offload-probe \
   --test issue_1143_scan_offload_thread \
-  --test issue_1333_scan_scratch_reuse
+  --test issue_1333_scan_scratch_reuse \
+  --test issue_1589_window_drain_bytes
 # Compile EVERY target in the package first (--no-run, whole package) so a
 # new/edited test file that doesn't compile can't hide behind the enumerated
 # run-list (issue #865); then execute the seven CI-enforced targets.


### PR DESCRIPTION
Closes #1589 (E7 — Epic E #1517 read-path audit).

## Problem
Windowed scan + streaming compaction consumed confirmed partitions with `window.drain(0..consumed)` (front-drain), memmoving the entire residual tail → **Θ(P·W)** bytes moved per window on partition-dense tables.

## Fix
Extracted a shared `WindowCursor` (front-cursor byte window) used by BOTH sites (`scan_stream_windowed.rs`, `data_access/compaction.rs`):
- `consume(n)` advances a cursor — **no memmove**.
- `refill(chunk)` compacts the reclaimed prefix **once** (single `copy_within` + `truncate` when `start>0`), then appends. Each byte moved at most once per refill it survives → **Θ(W)**.
- Every window index audited to be cursor-relative.

## Evidence (TDD, red→green)
- New byte-movement guard `issue_1589_window_drain_bytes.rs` over the 999-tiny-partition fixture asserts `bytes_memmoved ≤ bytes_appended`.
  - RED on main: scan **12.11x** (8.03M vs 663K). After scan fix: 0.02x. After compaction fix: **both 0.02x** (14.3K).
- `WindowCursor` unit tests (consume/clamp/refill/empty-window).
- New `scan_partition_dense_stream` bench.
- Guard added to the `scan-offload-guard` agent-gate component.

## Gate — PASS (all 20 components, incl. compaction-byte-parity, python/node bindings)
```
commit: 5d21f134 branch: issue-1589-window-drain-cursor dirty: no
compaction-byte-parity: PASS
scan-offload-guard: PASS
RESULT: PASS
```

## Notes
- `file-size`: `reader/mod.rs` (+7) and `scan_stream_windowed.rs` (+7) were already over the 800-line threshold; residual growth is irreducible (a `use` import + a module decl in the re-export hub). Splitting those is epic **#1116** scope, out of scope here → acknowledged via `CQLITE_ALLOW_FILE_GROWTH=1` (the documented mechanism).
- No window sizing/backpressure semantics changed.