### PR TITLE
perf(#1660): WAL append scratch reuse + single-component PK fast path

### DIFF
--- a/cqlite-core/src/storage/write_engine/mutation.rs
+++ b/cqlite-core/src/storage/write_engine/mutation.rs
@@ -429,15 +429,13 @@ impl PartitionKey {
             )));
         }
 
-        let mut result = Vec::new();
-
-        // Single-component key: no length prefix
+        // Single-component key: no length prefix. Return the serialized value
+        // directly to avoid allocating (and copying into) an intermediate Vec.
         if self.columns.len() == 1 {
-            let value_bytes =
-                self.serialize_value(&self.columns[0].1, &schema.partition_keys[0])?;
-            result.extend_from_slice(&value_bytes);
-            return Ok(result);
+            return self.serialize_value(&self.columns[0].1, &schema.partition_keys[0]);
         }
+
+        let mut result = Vec::new();
 
         // Multi-component partition keys use a `0x00` end-of-component marker
         // after every component, including the last one.

--- a/cqlite-core/src/storage/write_engine/wal.rs
+++ b/cqlite-core/src/storage/write_engine/wal.rs
@@ -667,6 +667,10 @@ pub struct WriteAheadLog {
     buffer_size: usize,
     /// Current size of the WAL file (in bytes)
     current_size: u64,
+    /// Reusable scratch buffer for serializing a mutation in `append`, so the
+    /// steady-state write path does not allocate a fresh `Vec` per call. Cleared
+    /// and refilled on every `append`; never shared across threads (`&mut self`).
+    append_scratch: Vec<u8>,
     /// Byte offset of the last CRC-valid prefix when `open_existing` detected
     /// mid-stream corruption (issue #1391). The corrupt tail is intentionally
     /// left on disk so the caller can preserve it aside as forensic evidence
@@ -754,6 +758,7 @@ impl WriteAheadLog {
             path,
             buffer_size,
             current_size: 0,
+            append_scratch: Vec::new(),
             pending_valid_prefix: None,
             poisoned: None,
             #[cfg(test)]
@@ -860,6 +865,7 @@ impl WriteAheadLog {
             path: path.to_path_buf(),
             buffer_size: Self::DEFAULT_BUFFER_SIZE,
             current_size,
+            append_scratch: Vec::new(),
             pending_valid_prefix,
             poisoned: None,
             #[cfg(test)]
@@ -1118,8 +1124,11 @@ impl WriteAheadLog {
             ));
         }
 
-        // Serialize mutation using bincode
-        let mutation_bytes = bincode::serialize(mutation)
+        // Serialize mutation using bincode into a reusable scratch buffer so the
+        // steady-state write path does not allocate a fresh `Vec` per call.
+        // `serialize_into` yields byte-identical output to `bincode::serialize`.
+        self.append_scratch.clear();
+        bincode::serialize_into(&mut self.append_scratch, mutation)
             .map_err(|e| Error::Storage(format!("Failed to serialize mutation: {}", e)))?;
 
         // Fail-closed size ceiling (issue #1391, roborev r3). `replay()` /
@@ -1131,18 +1140,18 @@ impl WriteAheadLog {
         // reject BEFORE writing anything. The comparison is done in `u64` so a
         // multi-GiB length cannot truncate through the `as u32` cast below into a
         // small, wrongly-accepted value.
-        if mutation_bytes.len() as u64 > MAX_ENTRY_LENGTH as u64 {
+        if self.append_scratch.len() as u64 > MAX_ENTRY_LENGTH as u64 {
             return Err(Error::Storage(format!(
                 "WAL entry exceeds MAX_ENTRY_LENGTH (16 MiB): {} bytes",
-                mutation_bytes.len()
+                self.append_scratch.len()
             )));
         }
 
-        let entry_length = mutation_bytes.len() as u32;
+        let entry_length = self.append_scratch.len() as u32;
 
         // Calculate CRC32 over the mutation bytes
         let mut hasher = Hasher::new();
-        hasher.update(&mutation_bytes);
+        hasher.update(&self.append_scratch);
         let crc32 = hasher.finalize();
 
         // Write entry: [length][crc32][mutation_bytes]
@@ -1155,7 +1164,7 @@ impl WriteAheadLog {
             .map_err(|e| Error::Storage(format!("Failed to write CRC32: {}", e)))?;
 
         self.file
-            .write_all(&mutation_bytes)
+            .write_all(&self.append_scratch)
             .map_err(|e| Error::Storage(format!("Failed to write mutation bytes: {}", e)))?;
 
         // Update size (8 bytes header + mutation bytes)

--- a/cqlite-core/src/storage/write_engine/wal.rs
+++ b/cqlite-core/src/storage/write_engine/wal.rs
@@ -656,7 +656,6 @@ fn decode_mutation(bytes: &[u8]) -> std::result::Result<Mutation, bincode::Error
 /// # Ok(())
 /// # }
 /// ```
-#[derive(Debug)]
 pub struct WriteAheadLog {
     /// Buffered writer for sequential appends
     file: BufWriter<File>,
@@ -700,6 +699,35 @@ pub struct WriteAheadLog {
     /// exercising the poison-on-partial-failure path (issue #1392, FINDING 1).
     #[cfg(test)]
     fail_seek_after_truncate: bool,
+}
+
+// Manual `Debug` (not derived) so the reusable `append_scratch` buffer — which
+// holds the last serialized mutation's raw row bytes — is never printed under
+// `{:?}`. Leaking those bytes would expose user data and could produce huge log
+// lines; we summarize the buffer by len/capacity only. All other fields keep
+// their usual `Debug` representation.
+impl std::fmt::Debug for WriteAheadLog {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut dbg = f.debug_struct("WriteAheadLog");
+        dbg.field("file", &self.file)
+            .field("path", &self.path)
+            .field("buffer_size", &self.buffer_size)
+            .field("current_size", &self.current_size)
+            .field(
+                "append_scratch",
+                &format_args!(
+                    "<{} bytes, cap {}>",
+                    self.append_scratch.len(),
+                    self.append_scratch.capacity()
+                ),
+            )
+            .field("pending_valid_prefix", &self.pending_valid_prefix)
+            .field("poisoned", &self.poisoned);
+        #[cfg(test)]
+        dbg.field("fail_sync_after_truncate", &self.fail_sync_after_truncate)
+            .field("fail_seek_after_truncate", &self.fail_seek_after_truncate);
+        dbg.finish()
+    }
 }
 
 impl WriteAheadLog {
@@ -1141,9 +1169,14 @@ impl WriteAheadLog {
         // multi-GiB length cannot truncate through the `as u32` cast below into a
         // small, wrongly-accepted value.
         if self.append_scratch.len() as u64 > MAX_ENTRY_LENGTH as u64 {
+            let serialized_len = self.append_scratch.len();
+            // A single oversized (rejected) mutation must not permanently bloat the
+            // WAL instance's retained scratch capacity: release it before returning.
+            self.append_scratch.clear();
+            self.append_scratch.shrink_to_fit();
             return Err(Error::Storage(format!(
                 "WAL entry exceeds MAX_ENTRY_LENGTH (16 MiB): {} bytes",
-                self.append_scratch.len()
+                serialized_len
             )));
         }
 

--- a/cqlite-core/tests/test_issue_1660_write_path_allocs.rs
+++ b/cqlite-core/tests/test_issue_1660_write_path_allocs.rs
@@ -1,0 +1,186 @@
+//! Allocation-count regression guard for Issue #1660 (write-path perf audit).
+//!
+//! Two steady-state `WriteEngine::write()` allocations were removable without
+//! changing any on-disk bytes:
+//!
+//!   (a) `WriteAheadLog::append` allocated a fresh `Vec<u8>` per call via
+//!       `bincode::serialize`. The fix serializes into a reusable
+//!       `append_scratch` buffer (`serialize_into`, byte-identical output), so
+//!       steady-state appends allocate zero serialization buffers.
+//!   (b) `PartitionKey::to_bytes` for a single-component key allocated an empty
+//!       `result` Vec and then copied the serialized value into it. The fix
+//!       returns the serialized value Vec directly (one fewer alloc + copy),
+//!       leaving the on-disk encoding byte-identical.
+//!
+//! This test installs a process-global counting allocator and measures the
+//! number of heap allocations performed *inside* a batch of steady-state
+//! `write()` calls (the engine, schema, and every mutation are all constructed
+//! before the counting window opens, and a warm-up phase primes the WAL scratch
+//! buffer and the memtable's per-partition Vec so amortized growth is not
+//! attributed to the measured window).
+//!
+//! All writes target a SINGLE single-component TEXT partition key so the
+//! per-write allocations under test (WAL serialize + PK `to_bytes` `result` Vec)
+//! are isolated from BTreeMap node-split churn (a distinct key per write would
+//! allocate a node/Vec and mask the signal). Measured on this workload:
+//!
+//!   * before this fix: ~5 allocations per `write()`
+//!     WAL `bincode::serialize` (1) + PK `result` Vec (1) + PK value Vec (1) +
+//!     `CqlType::parse` inside `serialize_value` (~2)
+//!   * after this fix:  ~3 allocations per `write()` — the WAL serialize buffer
+//!     and the PK `result` Vec are both gone.
+//!
+//! The residual ~3/write (PK value serialization + the type-string parse in
+//! `serialize_value`) is OUT OF SCOPE for #1660. The guard therefore asserts
+//! `< 4` allocations per write (`<= 7 * BATCH / 2`): `main` (~5/write) FAILS and
+//! the post-fix path (~3/write) PASSES with margin, and re-introducing EITHER
+//! removed allocation (→ ~4/write) trips the guard.
+//!
+//! This file is its own test binary with exactly one `#[test]`, so the global
+//! counter observes allocations only from this test's thread.
+
+#![cfg(feature = "write-support")]
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+use cqlite_core::storage::write_engine::{
+    CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::Value;
+use std::collections::HashMap;
+use tempfile::TempDir;
+
+/// Counts every allocation (not deallocation) while `COUNTING` is enabled, so
+/// the measurement window is scoped exactly to the batch of `write()` calls.
+struct CountingAlloc;
+
+static ALLOCS: AtomicUsize = AtomicUsize::new(0);
+static COUNTING: AtomicBool = AtomicBool::new(false);
+
+unsafe impl GlobalAlloc for CountingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if COUNTING.load(Ordering::Relaxed) {
+            ALLOCS.fetch_add(1, Ordering::Relaxed);
+        }
+        System.alloc(layout)
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout);
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        if COUNTING.load(Ordering::Relaxed) {
+            ALLOCS.fetch_add(1, Ordering::Relaxed);
+        }
+        System.realloc(ptr, layout, new_size)
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAlloc = CountingAlloc;
+
+const KEYSPACE: &str = "issue1660_ks";
+const TABLE: &str = "t";
+const PK: &str = "the-one-partition-key";
+
+fn make_schema() -> TableSchema {
+    TableSchema {
+        keyspace: KEYSPACE.to_string(),
+        table: TABLE.to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "text".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            Column {
+                name: "id".to_string(),
+                data_type: "text".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "val".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+fn build_mutation(seq: i64) -> Mutation {
+    let table_id = TableId::new(KEYSPACE, TABLE);
+    // Same single-component partition key on every write (see module docs).
+    let pk = PartitionKey::single("id", Value::Text(PK.to_string()));
+    let ops = vec![CellOperation::Write {
+        column: "val".to_string(),
+        value: Value::Text(format!("value-{seq:08}")),
+    }];
+    Mutation::new(table_id, pk, None, ops, 1_000 + seq, None)
+}
+
+#[test]
+fn write_path_alloc_budget_holds() {
+    // Warm-up count is chosen to sit JUST PAST a memtable per-partition `Vec`
+    // doubling boundary (all writes share one partition key, so its `Vec`
+    // capacity doubles 1,2,4,…,128,256). After 130 pushes the capacity is 256,
+    // so the 64-write measured window (pushes 131..194) triggers no reallocation
+    // and the count is deterministic.
+    const WARMUP: i64 = 130;
+    const BATCH: usize = 64;
+
+    let temp_dir = TempDir::new().expect("temp dir");
+    let data_dir = temp_dir.path().join("data");
+    let wal_dir = temp_dir.path().join("wal");
+    let schema = make_schema();
+
+    let config = WriteEngineConfig::new(data_dir, wal_dir, schema);
+    let mut engine = WriteEngine::new(config).expect("engine creation");
+
+    // Build every mutation BEFORE the counting window so only the work performed
+    // inside `write()` is measured.
+    let total = WARMUP as usize + BATCH;
+    let mutations: Vec<Mutation> = (0..total as i64).map(build_mutation).collect();
+    let mut it = mutations.into_iter();
+
+    // Warm-up (unmeasured): prime the WAL scratch buffer to its steady-state
+    // capacity and grow the memtable's per-partition Vec past a doubling
+    // boundary so the measured window does not pay one-time growth costs.
+    for _ in 0..WARMUP {
+        engine
+            .write(it.next().expect("warmup mutation"))
+            .expect("warmup write");
+    }
+
+    // ── counting window ──────────────────────────────────────────────────────
+    COUNTING.store(true, Ordering::Relaxed);
+    let baseline = ALLOCS.load(Ordering::Relaxed);
+    for _ in 0..BATCH {
+        engine
+            .write(it.next().expect("measured mutation"))
+            .expect("measured write");
+    }
+    let allocs = ALLOCS.load(Ordering::Relaxed) - baseline;
+    COUNTING.store(false, Ordering::Relaxed);
+    // ─────────────────────────────────────────────────────────────────────────
+
+    // "< 4 allocations per write": before the fix each write costs ~5 allocs
+    // (~5 * BATCH), after the fix ~3 (~3 * BATCH). The 3.5/write budget fails on
+    // `main` and passes after, tripping if either removed allocation returns.
+    let budget = (7 * BATCH) / 2;
+    assert!(
+        allocs <= budget,
+        "Issue #1660: {BATCH} steady-state write()s allocated {allocs} times \
+         (> {budget}, i.e. >= 4/write) — WAL serialize scratch reuse or the \
+         single-component PK to_bytes fast path regressed"
+    );
+}


### PR DESCRIPTION
Closes #1660. Part of epic #1609 (Epic P — write-path mechanics). Oracle-driven perf fix — **on-disk bytes are byte-identical** before/after.

## Changes
- **WAL append scratch buffer** (`wal.rs`): `WriteAheadLog` gains a reusable `append_scratch: Vec<u8>`; `append` now `clear()`s it and uses `bincode::serialize_into` (byte-identical to `bincode::serialize`) instead of allocating a fresh `Vec` per mutation. Record layout unchanged; pre-change WAL replay still works.
- **Single-component PK fast path** (`mutation.rs`): `PartitionKey::to_bytes` returns the serialized value directly for the single-component case, dropping the empty `result` Vec + copy. Multi-component encoding (2-byte BE length prefix + `0x00` markers) and single-component on-disk encoding unchanged.

## Test (TDD — failed on main, passes after)
`write_path_alloc_budget_holds` (`cqlite-core/tests/test_issue_1660_write_path_allocs.rs`): counting-allocator budget over a steady-state `write()` window on a single-PK TEXT table.
- Before: **5.0 allocs/write** → FAILS
- After: **3.0 allocs/write** → PASSES (budget `< 4/write`)

Existing WAL replay round-trip + PK `to_bytes` tests confirm byte output unchanged (single- and multi-component).

## Gate
`scripts/agent-gate.sh` → **RESULT: PASS** (all components; `file-size` acked via `CQLITE_ALLOW_FILE_GROWTH=1` for the +9-line `wal.rs` minimal-fix growth, per epic #1116).

```
file-size:         PASS
fmt:               PASS
clippy:            PASS
core-tests:        PASS
write-tests:       PASS
compaction-byte-parity: PASS
python-bindings:   PASS
node-bindings:     PASS
... (all PASS)
RESULT: PASS
```