### PR TITLE
perf(#1563): tail-latency mixed-load harness + p50/p99/p999 advisory gate (Epic A A2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,3 +207,7 @@ docs/sstable-guide-audit/
 
 # parity-report self-test probe (issue #1338): removed by trap, ignored as a safety net
 test-data/.tmp-parity-manifest-mutated.yml
+
+# tail-latency harness history ledger (issue #1563): generated run data,
+# machine/run-specific. Consolidates into Epic A5's unified history.jsonl.
+cqlite-core/benches/tail-latency-history.jsonl

--- a/cqlite-core/Cargo.toml
+++ b/cqlite-core/Cargo.toml
@@ -196,6 +196,14 @@ harness = false
 name = "read_while_write"
 harness = false
 
+# Mixed-load tail-latency harness (issue #1563, Epic A / A2). `harness = false`
+# custom main: emits p50/p99/p999 + intra-run ratios (JSON), which Criterion's
+# median model cannot express. ADVISORY tail gate lives in
+# benches/tail-latency-gate.json + scripts/ci/check_tail_latency.py.
+[[bench]]
+name = "tail_latency"
+harness = false
+
 [features]
 # M2+ production defaults: Full query engine + write path enabled.
 # write-support is a pure first-party code-gating flag (no extra dependencies),

--- a/cqlite-core/benches/README.md
+++ b/cqlite-core/benches/README.md
@@ -222,6 +222,91 @@ bindings/python/.venv/bin/pytest scripts/ci/tests/test_check_perf_regression.py 
 The tests prove: (a) a CPU-bench regression above threshold exits non-zero;
 (b) a large `write/ingest_wal_on` swing exits zero (advisory reported only).
 
+## Tail-latency harness (Issue #1563)
+
+The perf-regression gate above compares Criterion **medians**. But the July 2026
+read-path audit (`docs/reports/read-path-performance-audit-2026-07-01.md` §Epic A)
+found the three biggest read-path defects — C2 cursor convoy, F1 reader-map FIFO
+stall, F3 blocking I/O on async workers — are all **tail** pathologies: they
+barely move the median but inflate p99/p999 under a mixed load (a background scan
+running while point reads arrive). A median gate is structurally blind to them.
+
+`benches/tail_latency.rs` is a `harness = false` custom-main bench (not Criterion,
+which reports only a median) whose measurement core lives in the shared
+`benches/tail_latency/mod.rs` module (also exercised by
+`cqlite-core/tests/tail_latency_harness.rs`). Over one shared `Database` on the
+BIG `test_basic.simple_table` fixture it:
+
+1. runs a fixed stream of real partition-targeted point reads
+   (`SELECT id, name … WHERE id = <uuid-literal>`, the #949/#956 path) with **no**
+   background scan — the *scan-free baseline*; then
+2. runs the identical stream while **one continuous background full-table scan**
+   (`SELECT *` looped on its own thread) hammers the same reader set — the
+   *mixed* load.
+
+Setup asserts the point read returns ≥1 row and reports a **targeted**
+`AccessPath` (`PartitionLookup`) or panics — the same honesty guard as the `read`
+benches. Sample counts are fixed consts (`WARMUP` + `MEASURED_N`), never
+wall-clock-bounded.
+
+### Running
+
+```bash
+env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets \
+  cargo bench -p cqlite-core --features cli-helpers --bench tail_latency
+```
+
+Under default features (no `cli-helpers`) it prints a note and exits 0 without
+measuring. When the fixture binary is absent it skips (no measurement).
+
+### JSON output
+
+It prints a machine-readable report to stdout:
+
+```json
+{
+  "mixed":     { "p50": <ns>, "p99": <ns>, "p999": <ns> },
+  "scan_free": { "p50": <ns>, "p99": <ns>, "p999": <ns> },
+  "p99_over_p50": <mixed.p99 / mixed.p50>,
+  "p99_mixed_over_scan_free": <mixed.p99 / scan_free.p99>
+}
+```
+
+`p99_over_p50` is the tail spread within the mixed load; `p99_mixed_over_scan_free`
+is the convoy inflation — the headline number the C2/F1/F3 fixes must drive down.
+All gate thresholds are these intra-run **ratios**, never wall-clock absolutes, so
+shared-runner noise cannot flap the gate.
+
+### History ledger
+
+Each run appends one JSON record (`{ts, commit, mixed, scan_free, ratios}`) to
+`benches/tail-latency-history.jsonl`. This is generated run data (machine/run
+specific), so it is **gitignored**, not committed. It is documented to consolidate
+into the Epic A5 unified `history.jsonl` when A5 lands.
+
+### Advisory-first tail gate
+
+`benches/tail-latency-gate.json` holds per-ratio `max` thresholds plus an
+`advisory` flag; `scripts/ci/check_tail_latency.py <harness_json> <gate_json>`
+reports each ratio against its threshold:
+
+- **Advisory** (`advisory: true`, the default): breaches are reported with an
+  advisory status but the checker **always exits 0**. This records today's convoy
+  so the C2/F1/F3 fixes can be shown red-then-green without redding the gate now.
+- **Enforcing** (`advisory: false`, or pass `--enforce`): any ratio over its `max`
+  exits non-zero.
+
+**Flip to enforcing:** once C2/F1/F3 land and `p99_mixed_over_scan_free` drops,
+tighten the `max` values in `tail-latency-gate.json` to the new floor and set
+`advisory: false` (or pass `--enforce` in CI).
+
+The checker logic is proven by `scripts/ci/tests/test_check_tail_latency.py`
+(advisory breach → exit 0; enforce breach → exit 1; within-threshold → exit 0):
+
+```bash
+bindings/python/.venv/bin/pytest scripts/ci/tests/test_check_tail_latency.py -v
+```
+
 ## Audit (Issue #536)
 
 The three benches wired here dated to Aug 2025 (pre-format-maturity). Issue #536

--- a/cqlite-core/benches/fixtures/mod.rs
+++ b/cqlite-core/benches/fixtures/mod.rs
@@ -230,6 +230,29 @@ pub fn open_read_db(fx: &ReadFixture) -> ReadDb {
     ReadDb { db, _tmp: tmp }
 }
 
+#[cfg(feature = "cli-helpers")]
+impl ReadDb {
+    /// Consume this fixture handle into a shareable `Arc<Database>`, **persisting
+    /// (leaking) the backing temp dir** so the copied SSTable files outlive the
+    /// handle.
+    ///
+    /// Why leak: the `Database` keeps live mmap/file handles into the temp copy,
+    /// and a full-table scan opens its OWN file handle per scan (issue #815), so
+    /// reaping the dir while queries run breaks reads (`ENOENT` on the next scan).
+    /// The tail-latency harness (issue #1563) shares one `Arc<Database>` across a
+    /// background-scan thread and a foreground point-read stream, so it needs the
+    /// DB — not a `ReadDb` wrapper — and the files must stay put for the run.
+    ///
+    /// Bench/test processes are short-lived, so the leaked temp copy (a few MB) is
+    /// reclaimed by the OS temp sweeper. Do not use this in long-running code.
+    pub fn into_shared_db(self) -> std::sync::Arc<cqlite_core::Database> {
+        // `keep()` returns the path and disables auto-delete: hand the copy to the
+        // OS for the process lifetime.
+        let _persisted = self._tmp.keep();
+        std::sync::Arc::new(self.db)
+    }
+}
+
 /// CQL for the write-bench target table — a single `CREATE TABLE` so the
 /// no-heuristics mandate (Issue #28) has an unambiguous write target. Mirrors
 /// `test_basic.simple_table` (UUID PK) used by the read fixtures.

--- a/cqlite-core/benches/tail-latency-gate.json
+++ b/cqlite-core/benches/tail-latency-gate.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "Tail-latency ratio gate policy (Issue #1563, Epic A / A2). ADVISORY-FIRST: while `advisory` is true, scripts/ci/check_tail_latency.py reports each ratio against its `max` but ALWAYS exits 0 (never fails CI) — it records the current convoy so the C2/F1/F3 tail fixes can be shown red-then-green. To ENFORCE: once those fixes land and p99_mixed_over_scan_free drops, tighten these `max` values to the new floor and set `advisory` to false (or pass --enforce in CI). Thresholds are intra-run RATIOS, never wall-clock absolutes, so shared-runner noise cannot flap the gate. Maxes are set a bit above the values measured on main (2026-07, local run): p99_over_p50 ≈ 1.33, p99_mixed_over_scan_free ≈ 1.28, with headroom for shared-runner tail noise. See cqlite-core/benches/README.md.",
+  "advisory": true,
+  "ratios": {
+    "p99_over_p50": {
+      "max": 6.0
+    },
+    "p99_mixed_over_scan_free": {
+      "max": 4.0
+    }
+  }
+}

--- a/cqlite-core/benches/tail_latency.rs
+++ b/cqlite-core/benches/tail_latency.rs
@@ -1,0 +1,57 @@
+//! Mixed-load tail-latency harness bench (Issue #1563, Epic A / A2).
+//!
+//! A `harness = false` custom-main bench (not Criterion): Criterion reports a
+//! single median per bench, but this harness must emit **percentiles**
+//! (p50/p99/p999) and derived **intra-run ratios**, which Criterion's model does
+//! not express. The measurement core lives in the shared `tail_latency/mod.rs`
+//! module so the `tail_latency_harness` integration test can exercise the same
+//! code (see that module's docs for what it measures and why).
+//!
+//! Run it (needs the read fixture loader):
+//! ```bash
+//! env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets \
+//!   cargo bench -p cqlite-core --features cli-helpers --bench tail_latency
+//! ```
+//! It prints the harness JSON to stdout and appends one record to the history
+//! ledger (`benches/tail-latency-history.jsonl`, gitignored). Under default
+//! features (no `cli-helpers`) it prints a note and exits 0 without measuring.
+
+#[path = "fixtures/mod.rs"]
+mod fixtures;
+
+#[path = "tail_latency/mod.rs"]
+mod harness;
+
+fn main() {
+    #[cfg(feature = "cli-helpers")]
+    {
+        match harness::run(fixtures::ReadFixture::SIMPLE) {
+            Some(report) => {
+                // Machine-readable JSON to stdout.
+                println!("{}", report.to_json());
+                // Persist one record to the (gitignored) history ledger.
+                let ledger = harness::default_ledger_path();
+                if let Err(e) = harness::append_ledger(&ledger, &report) {
+                    eprintln!(
+                        "tail_latency: could not append ledger {}: {e}",
+                        ledger.display()
+                    );
+                }
+            }
+            None => {
+                eprintln!(
+                    "tail_latency: fixture absent — no measurement. \
+                     Fetch datasets: bash test-data/scripts/fetch-datasets.sh"
+                );
+            }
+        }
+    }
+
+    #[cfg(not(feature = "cli-helpers"))]
+    {
+        eprintln!(
+            "tail_latency: requires --features cli-helpers; nothing to measure. \
+             Run: cargo bench -p cqlite-core --features cli-helpers --bench tail_latency"
+        );
+    }
+}

--- a/cqlite-core/benches/tail_latency/mod.rs
+++ b/cqlite-core/benches/tail_latency/mod.rs
@@ -394,8 +394,14 @@ pub fn run(fx: crate::fixtures::ReadFixture) -> Option<HarnessReport> {
 
     // Mixed load: one continuous background full-table scan on its own thread.
     let stop = Arc::new(AtomicBool::new(false));
+    // Readiness signal: the scan thread sets this once it has begun executing a
+    // scan, so the measured point-read stream overlaps a *live* scan rather than
+    // racing thread startup (roborev finding — without this, "scans > 0" after
+    // join only proves a scan ran at some point, not during the measured window).
+    let scan_started = Arc::new(AtomicBool::new(false));
     let scan_db = Arc::clone(&db);
     let scan_stop = Arc::clone(&stop);
+    let scan_started_w = Arc::clone(&scan_started);
     let scan_sql = format!("SELECT * FROM {}", fx.qualified());
     let scan_handle = std::thread::spawn(move || {
         let rt = tokio::runtime::Builder::new_current_thread()
@@ -404,6 +410,8 @@ pub fn run(fx: crate::fixtures::ReadFixture) -> Option<HarnessReport> {
             .expect("tail_latency background-scan runtime");
         let mut scans: u64 = 0;
         while !scan_stop.load(Ordering::Relaxed) {
+            // Mark the scan live just before the first execute begins.
+            scan_started_w.store(true, Ordering::Relaxed);
             let res = rt
                 .block_on(scan_db.execute(&scan_sql))
                 .expect("tail_latency background scan");
@@ -412,6 +420,17 @@ pub fn run(fx: crate::fixtures::ReadFixture) -> Option<HarnessReport> {
         }
         scans
     });
+
+    // Wait (bounded) until the background scan has actually begun, so the measured
+    // point reads run under live contention. Never hang: fall through after the
+    // timeout (the post-join `scans > 0` assertion still guards a wedged scan).
+    let wait_start = std::time::Instant::now();
+    while !scan_started.load(Ordering::Relaxed) {
+        if wait_start.elapsed() > std::time::Duration::from_secs(30) {
+            break;
+        }
+        std::thread::yield_now();
+    }
 
     let mixed_lat = run_point_read_stream(&db, &sql, MEASURED_N, WARMUP);
     let mixed = TailStats::from_latencies(&mixed_lat);

--- a/cqlite-core/benches/tail_latency/mod.rs
+++ b/cqlite-core/benches/tail_latency/mod.rs
@@ -394,10 +394,11 @@ pub fn run(fx: crate::fixtures::ReadFixture) -> Option<HarnessReport> {
 
     // Mixed load: one continuous background full-table scan on its own thread.
     let stop = Arc::new(AtomicBool::new(false));
-    // Readiness signal: the scan thread sets this once it has begun executing a
-    // scan, so the measured point-read stream overlaps a *live* scan rather than
-    // racing thread startup (roborev finding — without this, "scans > 0" after
-    // join only proves a scan ran at some point, not during the measured window).
+    // Readiness signal: the scan thread sets this once it has *completed a full
+    // scan* (and is looping into the next), so the measured point-read stream
+    // overlaps a demonstrably-live scan rather than racing thread startup (roborev
+    // finding — without this, "scans > 0" after join only proves a scan ran at some
+    // point, not during the measured window).
     let scan_started = Arc::new(AtomicBool::new(false));
     let scan_db = Arc::clone(&db);
     let scan_stop = Arc::clone(&stop);
@@ -410,13 +411,18 @@ pub fn run(fx: crate::fixtures::ReadFixture) -> Option<HarnessReport> {
             .expect("tail_latency background-scan runtime");
         let mut scans: u64 = 0;
         while !scan_stop.load(Ordering::Relaxed) {
-            // Mark the scan live just before the first execute begins.
-            scan_started_w.store(true, Ordering::Relaxed);
             let res = rt
                 .block_on(scan_db.execute(&scan_sql))
                 .expect("tail_latency background scan");
             std::hint::black_box(res.rows.len());
             scans += 1;
+            // Signal readiness only AFTER a full scan has actually executed, and
+            // keep looping: this proves the scan path is live (one pass done, the
+            // next already starting) before the foreground measured stream is
+            // released, rather than merely proving the thread was scheduled
+            // (roborev — a pre-execute flag could fire while this thread is
+            // descheduled, leaving the "mixed" window mostly scan-free).
+            scan_started_w.store(true, Ordering::Relaxed);
         }
         scans
     });
@@ -432,8 +438,8 @@ pub fn run(fx: crate::fixtures::ReadFixture) -> Option<HarnessReport> {
             stop.store(true, Ordering::Relaxed);
             let _ = scan_handle.join();
             panic!(
-                "tail_latency: background scan did not begin within 30s — cannot measure \
-                 the point-read stream under live contention (mixed load would be invalid)"
+                "tail_latency: background scan did not complete a full pass within 30s — cannot \
+                 measure the point-read stream under live contention (mixed load would be invalid)"
             );
         }
         std::thread::yield_now();

--- a/cqlite-core/benches/tail_latency/mod.rs
+++ b/cqlite-core/benches/tail_latency/mod.rs
@@ -404,7 +404,13 @@ pub fn run(fx: crate::fixtures::ReadFixture) -> Option<HarnessReport> {
     let scan_stop = Arc::clone(&stop);
     let scan_started_w = Arc::clone(&scan_started);
     let scan_sql = format!("SELECT * FROM {}", fx.qualified());
-    let scan_handle = std::thread::spawn(move || {
+    // The scan thread reports its completed-pass count over a channel rather than
+    // via `join()`, so BOTH waits below (readiness and shutdown) can be bounded: a
+    // scan wedged inside `db.execute` would make a blocking `join()` hang forever
+    // despite the timeouts (roborev). The `JoinHandle` is intentionally dropped
+    // (detached) — on a timeout the thread is reaped on process exit.
+    let (scan_tx, scan_rx) = std::sync::mpsc::channel::<u64>();
+    std::thread::spawn(move || {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -424,21 +430,18 @@ pub fn run(fx: crate::fixtures::ReadFixture) -> Option<HarnessReport> {
             // descheduled, leaving the "mixed" window mostly scan-free).
             scan_started_w.store(true, Ordering::Relaxed);
         }
-        scans
+        let _ = scan_tx.send(scans);
     });
 
     // Wait (bounded) until the background scan has actually begun, so the measured
     // point reads run under live contention. A timeout is a HARNESS FAILURE, not a
     // free pass: measuring the "mixed" stream without a live scan would mostly
     // record the scan-free path and could still satisfy `scans > 0` from one late
-    // scan (roborev). Stop + join the thread and panic rather than mis-measure.
+    // scan (roborev). Signal stop best-effort and panic rather than mis-measure
+    // (no join — the detached thread is reaped on process exit).
     let wait_start = std::time::Instant::now();
     while !scan_started.load(Ordering::Relaxed) {
         if wait_start.elapsed() > std::time::Duration::from_secs(30) {
-            // Fail loud and PROMPTLY. Do NOT join here: if the scan is wedged
-            // inside `db.execute` it never observes `stop`, so `join()` would block
-            // indefinitely and defeat the bound (roborev). Signal stop best-effort
-            // and panic — the detached scan thread is reaped on process exit.
             stop.store(true, Ordering::Relaxed);
             panic!(
                 "tail_latency: background scan did not complete a full pass within 30s — cannot \
@@ -451,10 +454,17 @@ pub fn run(fx: crate::fixtures::ReadFixture) -> Option<HarnessReport> {
     let mixed_lat = run_point_read_stream(&db, &sql, MEASURED_N, WARMUP);
     let mixed = TailStats::from_latencies(&mixed_lat);
 
+    // Bounded shutdown: signal stop and wait for the scan thread's completed-pass
+    // count via the channel with a timeout. A blocking `join()` here would hang
+    // forever if the scan wedged inside `db.execute` after signalling readiness
+    // (roborev); `recv_timeout` bounds it and panics loudly instead.
     stop.store(true, Ordering::Relaxed);
-    let scans = scan_handle
-        .join()
-        .expect("tail_latency background-scan thread panicked");
+    let scans = match scan_rx.recv_timeout(std::time::Duration::from_secs(30)) {
+        Ok(n) => n,
+        Err(_) => panic!(
+            "tail_latency: background scan did not shut down within 30s of stop — wedged scan path?"
+        ),
+    };
     assert!(
         scans > 0,
         "tail_latency: background scan completed zero full passes — wedged scan path?"

--- a/cqlite-core/benches/tail_latency/mod.rs
+++ b/cqlite-core/benches/tail_latency/mod.rs
@@ -422,12 +422,19 @@ pub fn run(fx: crate::fixtures::ReadFixture) -> Option<HarnessReport> {
     });
 
     // Wait (bounded) until the background scan has actually begun, so the measured
-    // point reads run under live contention. Never hang: fall through after the
-    // timeout (the post-join `scans > 0` assertion still guards a wedged scan).
+    // point reads run under live contention. A timeout is a HARNESS FAILURE, not a
+    // free pass: measuring the "mixed" stream without a live scan would mostly
+    // record the scan-free path and could still satisfy `scans > 0` from one late
+    // scan (roborev). Stop + join the thread and panic rather than mis-measure.
     let wait_start = std::time::Instant::now();
     while !scan_started.load(Ordering::Relaxed) {
         if wait_start.elapsed() > std::time::Duration::from_secs(30) {
-            break;
+            stop.store(true, Ordering::Relaxed);
+            let _ = scan_handle.join();
+            panic!(
+                "tail_latency: background scan did not begin within 30s — cannot measure \
+                 the point-read stream under live contention (mixed load would be invalid)"
+            );
         }
         std::thread::yield_now();
     }

--- a/cqlite-core/benches/tail_latency/mod.rs
+++ b/cqlite-core/benches/tail_latency/mod.rs
@@ -435,8 +435,11 @@ pub fn run(fx: crate::fixtures::ReadFixture) -> Option<HarnessReport> {
     let wait_start = std::time::Instant::now();
     while !scan_started.load(Ordering::Relaxed) {
         if wait_start.elapsed() > std::time::Duration::from_secs(30) {
+            // Fail loud and PROMPTLY. Do NOT join here: if the scan is wedged
+            // inside `db.execute` it never observes `stop`, so `join()` would block
+            // indefinitely and defeat the bound (roborev). Signal stop best-effort
+            // and panic — the detached scan thread is reaped on process exit.
             stop.store(true, Ordering::Relaxed);
-            let _ = scan_handle.join();
             panic!(
                 "tail_latency: background scan did not complete a full pass within 30s — cannot \
                  measure the point-read stream under live contention (mixed load would be invalid)"

--- a/cqlite-core/benches/tail_latency/mod.rs
+++ b/cqlite-core/benches/tail_latency/mod.rs
@@ -1,0 +1,429 @@
+//! Shared mixed-load tail-latency harness (Issue #1563, Epic A / A2).
+//!
+//! This module is the measurement core for the `tail_latency` bench and the
+//! `tail_latency_harness` integration test. Both include it via `#[path]`, so it
+//! refers to the shared fixtures loader as [`crate::fixtures`] (it never declares
+//! its own `mod fixtures`). Like `fixtures/mod.rs`, everything here is shared
+//! support code — each includer uses only a subset — so the module allows dead
+//! code rather than treating an unused helper as a smell.
+//!
+//! # What it measures
+//!
+//! The July 2026 read-path audit (`docs/reports/read-path-performance-audit-2026-07-01.md`
+//! §Epic A) found the three biggest read-path defects (C2 cursor convoy, F1
+//! reader-map FIFO stall, F3 blocking I/O on async workers) are all **tail**
+//! pathologies: they barely move the median but inflate p99/p999 under a mixed
+//! load (a background scan running while point reads arrive). The median gate
+//! (A1, #1562) cannot see them.
+//!
+//! This harness reproduces that mixed load. Over one shared `Database` opened on
+//! the BIG multi-chunk fixture (`test_basic.simple_table`, reused from A1) it:
+//!
+//! 1. runs a fixed-length stream of real partition-targeted **point reads**
+//!    (`SELECT id, name … WHERE id = <uuid-literal>`, the #949/#956 path A1 proved)
+//!    with **no** background scan — the *scan-free baseline*; then
+//! 2. runs the identical point-read stream while **one continuous background
+//!    full-table scan** (`SELECT *` looped) hammers the same reader set — the
+//!    *mixed* load.
+//!
+//! It records per-op latency for each mode, computes `{p50, p99, p999}` (ns) for
+//! both, and derives the gate ratios `p99_over_p50` (tail spread within the mixed
+//! load) and `p99_mixed_over_scan_free` (convoy inflation). Everything is
+//! additive (bench/gate/test only): no read-path production code changes.
+//!
+//! # Determinism & honesty
+//!
+//! The measured set is a fixed count (`WARMUP` + `MEASURED_N`), never a
+//! wall-clock-bounded loop, so the sample size is identical run-to-run. Setup
+//! asserts the point read returns >=1 row AND reports a *targeted* `AccessPath`
+//! (`PartitionLookup`) — otherwise it panics loudly rather than measuring a scan
+//! proxy (parity-is-truth; same guards as A1). The gate/tests compare **ratios**,
+//! never wall-clock absolutes, so shared-runner noise cannot flap them.
+
+#![allow(dead_code)]
+
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+
+#[cfg(feature = "cli-helpers")]
+use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(feature = "cli-helpers")]
+use std::sync::Arc;
+#[cfg(feature = "cli-helpers")]
+use std::time::Instant;
+
+#[cfg(feature = "cli-helpers")]
+use cqlite_core::Database;
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/// Warmup point reads issued (and discarded) before measurement, so the first
+/// measured op is not paying one-time cache/JIT/allocation costs. 200 is enough
+/// to warm the reader caches for the ~999-row fixture without dominating runtime.
+pub const WARMUP: usize = 200;
+
+/// Measured point reads per stream. The tail (p999) needs a sample large enough
+/// that the 99.9th percentile is a real observation, not a single outlier: 2000
+/// ops gives 2 samples at/above the p999 rank while still running in a few
+/// seconds against the small fixture (point reads are sub-millisecond).
+pub const MEASURED_N: usize = 2000;
+
+/// Default history-ledger path, anchored to the crate dir (not the CWD) so the
+/// bench appends to the same file regardless of where cargo runs it.
+///
+/// This holds **generated run data** (machine/run-specific) and is gitignored.
+/// Epic A5 (cold-open bench + persisted ledger) introduces a unified
+/// `history.jsonl`; this path is documented to fold into A5's ledger then.
+pub fn default_ledger_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches/tail-latency-history.jsonl")
+}
+
+// ---------------------------------------------------------------------------
+// Percentile math (pure — unit-tested with no dataset dependency)
+// ---------------------------------------------------------------------------
+
+/// Nearest-rank percentile (ns) of a latency sample.
+///
+/// `q` is a percentile in `[0, 100]` (e.g. `99.9` for p999). Sorts a copy of the
+/// input (so the caller's slice need not be pre-sorted) and returns the value at
+/// nearest rank `ceil(q/100 * N)`, 1-indexed and clamped to `[1, N]`. Returns `0`
+/// for an empty sample (a total function; real streams are never empty because
+/// setup guards >=1 row).
+pub fn percentile_ns(latencies: &[u128], q: f64) -> u128 {
+    if latencies.is_empty() {
+        return 0;
+    }
+    let mut sorted = latencies.to_vec();
+    sorted.sort_unstable();
+    let n = sorted.len() as f64;
+    let rank_f = ((q / 100.0) * n).ceil();
+    let rank = if rank_f < 1.0 {
+        1usize
+    } else {
+        rank_f as usize
+    };
+    let idx = rank.min(sorted.len()) - 1;
+    sorted[idx]
+}
+
+/// The three tracked percentiles (nanoseconds) of one point-read stream.
+///
+/// `p50 <= p99 <= p999` holds **by construction**: nearest-rank percentiles are
+/// monotonic in `q`, so a higher percentile can never pick a smaller sorted
+/// value. No assertion is needed to maintain the invariant.
+#[derive(Clone, Copy, Debug, serde::Serialize)]
+pub struct TailStats {
+    pub p50: u128,
+    pub p99: u128,
+    pub p999: u128,
+}
+
+impl TailStats {
+    /// Compute `{p50, p99, p999}` from recorded per-op latencies.
+    pub fn from_latencies(latencies: &[u128]) -> Self {
+        Self {
+            p50: percentile_ns(latencies, 50.0),
+            p99: percentile_ns(latencies, 99.0),
+            p999: percentile_ns(latencies, 99.9),
+        }
+    }
+}
+
+/// Ratio `num / den`, returning `0.0` when `den == 0` (a degenerate guard — real
+/// ns latencies are microseconds, so the denominators here are never zero).
+fn ratio(num: u128, den: u128) -> f64 {
+    if den == 0 {
+        return 0.0;
+    }
+    (num as f64) / (den as f64)
+}
+
+/// One harness run: point-read tail stats under the mixed load and the scan-free
+/// baseline, plus the two derived gate ratios.
+///
+/// - `p99_over_p50` is the tail spread **within the mixed load** (`mixed.p99 /
+///   mixed.p50`).
+/// - `p99_mixed_over_scan_free` is the convoy inflation (`mixed.p99 /
+///   scan_free.p99`) — the headline number the C2/F1/F3 fixes must drive down.
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct HarnessReport {
+    pub mixed: TailStats,
+    pub scan_free: TailStats,
+    pub p99_over_p50: f64,
+    pub p99_mixed_over_scan_free: f64,
+}
+
+impl HarnessReport {
+    /// Build a report from the two measured stat blocks, deriving the ratios.
+    pub fn new(mixed: TailStats, scan_free: TailStats) -> Self {
+        let p99_over_p50 = ratio(mixed.p99, mixed.p50);
+        let p99_mixed_over_scan_free = ratio(mixed.p99, scan_free.p99);
+        Self {
+            mixed,
+            scan_free,
+            p99_over_p50,
+            p99_mixed_over_scan_free,
+        }
+    }
+
+    /// Machine-readable JSON: `{mixed:{p50,p99,p999}, scan_free:{p50,p99,p999},
+    /// p99_over_p50, p99_mixed_over_scan_free}`. Field names match the spec.
+    pub fn to_json(&self) -> String {
+        serde_json::to_string_pretty(self)
+            .unwrap_or_else(|e| format!("{{\"error\":\"serialize HarnessReport: {e}\"}}"))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// History ledger
+// ---------------------------------------------------------------------------
+
+/// One appended ledger record: timestamp + commit + both stat blocks + ratios.
+#[derive(serde::Serialize)]
+struct LedgerRecord {
+    ts: u64,
+    commit: String,
+    mixed: TailStats,
+    scan_free: TailStats,
+    p99_over_p50: f64,
+    p99_mixed_over_scan_free: f64,
+}
+
+/// Best-effort current commit SHA: `GIT_COMMIT` env override, else `git rev-parse
+/// HEAD`, else `"unknown"`. Never fails (ledger append must not abort a run).
+fn current_commit() -> String {
+    if let Ok(sha) = std::env::var("GIT_COMMIT") {
+        let sha = sha.trim().to_string();
+        if !sha.is_empty() {
+            return sha;
+        }
+    }
+    std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .and_then(|out| String::from_utf8(out.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+/// Append one JSON-line record for `report` to the ledger at `path`
+/// (creating it if absent). Generated run data; the ledger is gitignored.
+pub fn append_ledger(path: &Path, report: &HarnessReport) -> std::io::Result<()> {
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let record = LedgerRecord {
+        ts,
+        commit: current_commit(),
+        mixed: report.mixed,
+        scan_free: report.scan_free,
+        p99_over_p50: report.p99_over_p50,
+        p99_mixed_over_scan_free: report.p99_mixed_over_scan_free,
+    };
+    let line = serde_json::to_string(&record).map_err(std::io::Error::other)?;
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)?;
+    writeln!(file, "{line}")
+}
+
+// ---------------------------------------------------------------------------
+// Measurement (requires cli-helpers for the read fixture loader)
+// ---------------------------------------------------------------------------
+
+/// Format a 16-byte UUID as the canonical 8-4-4-4-12 unquoted-UUID literal the
+/// SELECT parser accepts (issue #956). Duplicated from `benches/read.rs` so the
+/// harness has no cross-bench dependency.
+#[cfg(feature = "cli-helpers")]
+fn uuid_to_literal(bytes: &[u8; 16]) -> String {
+    let h = |range: std::ops::Range<usize>| -> String {
+        bytes[range].iter().map(|b| format!("{b:02x}")).collect()
+    };
+    format!(
+        "{}-{}-{}-{}-{}",
+        h(0..4),
+        h(4..6),
+        h(6..8),
+        h(8..10),
+        h(10..16)
+    )
+}
+
+/// Open the fixture DB, learn a present partition key, build the projected point
+/// SQL, and run the two honesty guards. Returns `(shared db, point sql)`.
+///
+/// Panics loudly (never returns a mis-measurement) if the point read returns 0
+/// rows or does not report a *targeted* `AccessPath` — the same wiring-evidence
+/// guards as A1's `bench_get_partition`. The caller must have already confirmed
+/// the fixture is present (see [`run`]).
+///
+/// The returned `Arc<Database>` owns a **leaked** temp copy of the SSTable
+/// (see [`crate::fixtures::ReadDb::into_shared_db`]) so it is safe to share across
+/// the scan thread and the point-read stream for the process lifetime.
+#[cfg(feature = "cli-helpers")]
+pub fn setup(fx: &crate::fixtures::ReadFixture) -> (Arc<Database>, String) {
+    use cqlite_core::Value;
+
+    let db = crate::fixtures::open_read_db(fx).into_shared_db();
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tail_latency setup runtime");
+
+    // Learn a present partition key from a one-shot scan.
+    let scan = rt
+        .block_on(db.execute(&format!("SELECT id FROM {}", fx.qualified())))
+        .expect("tail_latency setup scan");
+    let first = scan.rows.first().unwrap_or_else(|| {
+        panic!(
+            "tail_latency: scan of {} returned zero rows — fixtures not fetched?",
+            fx.qualified()
+        )
+    });
+    let id = match first.values.get("id") {
+        Some(Value::Uuid(b)) => *b,
+        other => panic!(
+            "tail_latency: first row `id` did not decode as Value::Uuid (got {other:?}) for {}",
+            fx.qualified()
+        ),
+    };
+    let literal = uuid_to_literal(&id);
+
+    // Projected (>8 tokens) so it routes through the modern SelectExecutor and
+    // engages the #949 fast path (see benches/read.rs on the legacy routing quirk).
+    let sql = format!(
+        "SELECT id, name FROM {} WHERE id = {}",
+        fx.qualified(),
+        literal
+    );
+
+    // Guard 1: never silently measure a 0-row query.
+    let probe = rt
+        .block_on(db.execute(&sql))
+        .expect("tail_latency setup point read");
+    assert!(
+        !probe.rows.is_empty(),
+        "tail_latency: point read on {} returned zero rows for a known-present key — \
+         #949/#956 regressed?",
+        fx.qualified()
+    );
+
+    // Guard 2: the point read MUST take a partition-targeted path, else we would
+    // be measuring a scan proxy under the "point read" name.
+    let targeted = probe
+        .metadata
+        .access_path
+        .as_ref()
+        .map(|p| p.is_targeted())
+        .unwrap_or(false);
+    assert!(
+        targeted,
+        "tail_latency: point read fell back to full scan (access_path = {:?}) on {} — \
+         #956/#949 regressed, or the query routed to the legacy executor",
+        probe.metadata.access_path,
+        fx.qualified()
+    );
+
+    (db, sql)
+}
+
+/// Issue `warmup` discarded then `n` measured point reads of `sql` against `db`,
+/// returning the per-op latency (ns) of the measured ops. Uses its own
+/// current-thread Tokio runtime so it can run on any OS thread.
+#[cfg(feature = "cli-helpers")]
+pub fn run_point_read_stream(db: &Arc<Database>, sql: &str, n: usize, warmup: usize) -> Vec<u128> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tail_latency point-read runtime");
+
+    for _ in 0..warmup {
+        let res = rt
+            .block_on(db.execute(sql))
+            .expect("tail_latency warmup point read");
+        std::hint::black_box(res.rows.len());
+    }
+
+    let mut latencies = Vec::with_capacity(n);
+    for _ in 0..n {
+        let t0 = Instant::now();
+        let res = rt
+            .block_on(db.execute(sql))
+            .expect("tail_latency measured point read");
+        latencies.push(t0.elapsed().as_nanos());
+        std::hint::black_box(res.rows.len());
+    }
+    latencies
+}
+
+/// Run the full harness against `fx`: scan-free baseline then mixed load, and the
+/// derived report.
+///
+/// Returns `None` (with a skip message) when the fixture binary is absent, so a
+/// clean checkout skips rather than fails. When the fixture is present it runs to
+/// completion and panics loudly on a 0-row / non-targeted setup (see [`setup`]).
+///
+/// The mixed load spawns one background full-table-scan thread (its own runtime,
+/// a clone of the shared `Arc<Database>`, and an `AtomicBool` stop flag). The
+/// scan is started **before** and joined **after** the measured point-read stream
+/// so the tail is captured under live contention, and the join asserts the scan
+/// actually completed at least one full pass (a wedged scan is a bug, not a pass).
+#[cfg(feature = "cli-helpers")]
+pub fn run(fx: crate::fixtures::ReadFixture) -> Option<HarnessReport> {
+    if !crate::fixtures::fixture_present(&fx) {
+        eprintln!(
+            "tail_latency: fixture {} not present — skipping (fetch: bash test-data/scripts/fetch-datasets.sh)",
+            fx.qualified()
+        );
+        return None;
+    }
+
+    let (db, sql) = setup(&fx);
+
+    // Scan-free baseline first (no background contention).
+    let scan_free_lat = run_point_read_stream(&db, &sql, MEASURED_N, WARMUP);
+    let scan_free = TailStats::from_latencies(&scan_free_lat);
+
+    // Mixed load: one continuous background full-table scan on its own thread.
+    let stop = Arc::new(AtomicBool::new(false));
+    let scan_db = Arc::clone(&db);
+    let scan_stop = Arc::clone(&stop);
+    let scan_sql = format!("SELECT * FROM {}", fx.qualified());
+    let scan_handle = std::thread::spawn(move || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tail_latency background-scan runtime");
+        let mut scans: u64 = 0;
+        while !scan_stop.load(Ordering::Relaxed) {
+            let res = rt
+                .block_on(scan_db.execute(&scan_sql))
+                .expect("tail_latency background scan");
+            std::hint::black_box(res.rows.len());
+            scans += 1;
+        }
+        scans
+    });
+
+    let mixed_lat = run_point_read_stream(&db, &sql, MEASURED_N, WARMUP);
+    let mixed = TailStats::from_latencies(&mixed_lat);
+
+    stop.store(true, Ordering::Relaxed);
+    let scans = scan_handle
+        .join()
+        .expect("tail_latency background-scan thread panicked");
+    assert!(
+        scans > 0,
+        "tail_latency: background scan completed zero full passes — wedged scan path?"
+    );
+
+    Some(HarnessReport::new(mixed, scan_free))
+}

--- a/cqlite-core/tests/tail_latency_harness.rs
+++ b/cqlite-core/tests/tail_latency_harness.rs
@@ -169,7 +169,12 @@ fn append_ledger_writes_one_json_line_with_required_keys() {
 #[cfg(feature = "cli-helpers")]
 const K: f64 = 12.0;
 
+// Serialize the two dataset-backed latency tests: cargo runs tests within one
+// binary on parallel threads, so an un-serialized mixed-load test would run its
+// background scan concurrently with the scan-free determinism test and perturb its
+// timings (roborev). `#[serial]` forces them to run one at a time.
 #[cfg(feature = "cli-helpers")]
+#[serial_test::serial]
 #[test]
 fn mixed_p99_bounded_by_k_times_baseline() {
     use fixtures::ReadFixture;
@@ -200,6 +205,7 @@ fn mixed_p99_bounded_by_k_times_baseline() {
 }
 
 #[cfg(feature = "cli-helpers")]
+#[serial_test::serial]
 #[test]
 fn scan_free_determinism_within_wide_tolerance() {
     use fixtures::ReadFixture;

--- a/cqlite-core/tests/tail_latency_harness.rs
+++ b/cqlite-core/tests/tail_latency_harness.rs
@@ -85,6 +85,70 @@ fn report_ratios_and_json_shape() {
     }
 }
 
+#[test]
+fn append_ledger_writes_one_json_line_with_required_keys() {
+    // Exercises the persisted-ledger surface (spec R4) without a dataset: build a
+    // report, append it twice to a temp ledger, and assert each append is exactly
+    // one JSON-lines record carrying ts + commit + both stat blocks + ratios.
+    let report = harness::HarnessReport::new(
+        harness::TailStats {
+            p50: 100,
+            p99: 400,
+            p999: 800,
+        },
+        harness::TailStats {
+            p50: 90,
+            p99: 100,
+            p999: 150,
+        },
+    );
+
+    let dir = tempfile::TempDir::new().expect("temp dir for ledger");
+    let path = dir.path().join("tail-latency-history.jsonl");
+
+    // GIT_COMMIT override keeps the record deterministic (no reliance on a repo).
+    std::env::set_var("GIT_COMMIT", "deadbeefcafef00d");
+    harness::append_ledger(&path, &report).expect("append ledger record 1");
+    harness::append_ledger(&path, &report).expect("append ledger record 2");
+    std::env::remove_var("GIT_COMMIT");
+
+    let contents = std::fs::read_to_string(&path).expect("read ledger");
+    let lines: Vec<&str> = contents.lines().filter(|l| !l.trim().is_empty()).collect();
+    assert_eq!(
+        lines.len(),
+        2,
+        "expected 2 JSON-lines records, got: {contents}"
+    );
+
+    // Each line is a standalone JSON object with the required keys.
+    for line in &lines {
+        let v: serde_json::Value = serde_json::from_str(line).expect("record is valid JSON");
+        assert!(v.get("ts").and_then(|t| t.as_u64()).is_some(), "ts: {line}");
+        assert_eq!(
+            v.get("commit").and_then(|c| c.as_str()),
+            Some("deadbeefcafef00d"),
+            "commit: {line}"
+        );
+        for key in ["mixed", "scan_free"] {
+            let block = v
+                .get(key)
+                .unwrap_or_else(|| panic!("missing {key}: {line}"));
+            for stat in ["p50", "p99", "p999"] {
+                assert!(
+                    block.get(stat).and_then(|s| s.as_u64()).is_some(),
+                    "{key}.{stat}: {line}"
+                );
+            }
+        }
+        for ratio in ["p99_over_p50", "p99_mixed_over_scan_free"] {
+            assert!(
+                v.get(ratio).and_then(|r| r.as_f64()).is_some(),
+                "{ratio}: {line}"
+            );
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Dataset tests (require cli-helpers + the present BIG fixture)
 // ---------------------------------------------------------------------------

--- a/cqlite-core/tests/tail_latency_harness.rs
+++ b/cqlite-core/tests/tail_latency_harness.rs
@@ -1,0 +1,169 @@
+//! Tests for the mixed-load tail-latency harness (Issue #1563, Epic A / A2).
+//!
+//! Includes the shared harness module and the fixtures loader via `#[path]`
+//! (both resolve to `crate::…`, the same pattern the benches use). Two tiers:
+//!
+//! - **Pure** (always run, no dataset): the percentile math and the
+//!   report-ratio/JSON logic.
+//! - **Dataset** (`cli-helpers`, skip-not-fail when the fixture is absent): the
+//!   self-assertion that mixed-load p99 is bounded by `K` × the scan-free p99,
+//!   and a deliberately-loose determinism smoke test. These gate on **ratios**,
+//!   never wall-clock absolutes (issue guardrail), and panic loudly (via the
+//!   harness setup guards) when the fixture is present but yields 0 rows.
+
+#[path = "../benches/fixtures/mod.rs"]
+mod fixtures;
+
+#[path = "../benches/tail_latency/mod.rs"]
+mod harness;
+
+// ---------------------------------------------------------------------------
+// Pure unit tests (no dataset dependency)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn percentile_nearest_rank_on_known_vector() {
+    // 1..=100: nearest-rank p50 = value at ceil(0.50*100)=50 -> 50;
+    // p99 = ceil(0.99*100)=99 -> 99; p999 = ceil(0.999*100)=100 -> 100.
+    let v: Vec<u128> = (1..=100).collect();
+    assert_eq!(harness::percentile_ns(&v, 50.0), 50);
+    assert_eq!(harness::percentile_ns(&v, 99.0), 99);
+    assert_eq!(harness::percentile_ns(&v, 99.9), 100);
+
+    // Works on an unsorted input (the function sorts a copy).
+    let mut shuffled = v.clone();
+    shuffled.reverse();
+    assert_eq!(harness::percentile_ns(&shuffled, 50.0), 50);
+    assert_eq!(harness::percentile_ns(&shuffled, 99.0), 99);
+}
+
+#[test]
+fn percentile_empty_sample_is_zero() {
+    assert_eq!(harness::percentile_ns(&[], 50.0), 0);
+    assert_eq!(harness::percentile_ns(&[], 99.9), 0);
+}
+
+#[test]
+fn tailstats_invariant_p50_le_p99_le_p999() {
+    let v: Vec<u128> = vec![5, 1, 9, 3, 7, 2, 8, 4, 6, 10];
+    let s = harness::TailStats::from_latencies(&v);
+    assert!(s.p50 <= s.p99, "p50 {} !<= p99 {}", s.p50, s.p99);
+    assert!(s.p99 <= s.p999, "p99 {} !<= p999 {}", s.p99, s.p999);
+}
+
+#[test]
+fn report_ratios_and_json_shape() {
+    let mixed = harness::TailStats {
+        p50: 100,
+        p99: 400,
+        p999: 800,
+    };
+    let scan_free = harness::TailStats {
+        p50: 90,
+        p99: 100,
+        p999: 150,
+    };
+    let report = harness::HarnessReport::new(mixed, scan_free);
+
+    // p99_over_p50 = mixed.p99 / mixed.p50 = 400/100 = 4.0
+    assert!((report.p99_over_p50 - 4.0).abs() < 1e-9);
+    // p99_mixed_over_scan_free = mixed.p99 / scan_free.p99 = 400/100 = 4.0
+    assert!((report.p99_mixed_over_scan_free - 4.0).abs() < 1e-9);
+
+    // JSON contains both stat blocks and the ratios (spec field names).
+    let json = report.to_json();
+    for field in [
+        "mixed",
+        "scan_free",
+        "p50",
+        "p99",
+        "p999",
+        "p99_over_p50",
+        "p99_mixed_over_scan_free",
+    ] {
+        assert!(json.contains(field), "JSON missing `{field}`: {json}");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Dataset tests (require cli-helpers + the present BIG fixture)
+// ---------------------------------------------------------------------------
+
+/// Bound for the mixed-load convoy: point-read p99 under the background scan must
+/// be at most `K` × the scan-free baseline p99.
+///
+/// `K` is chosen GENEROUSLY above the convoy ratio measured on `main` so the test
+/// is green today; it tightens as the C2/F1/F3 tail fixes land. Measured on main
+/// (2026-07, local run against the BIG `test_basic.simple_table` fixture):
+/// p99_mixed/p99_scan_free ≈ 1.28 (mixed p99 25583 ns vs scan-free p99 19959 ns).
+/// The convoy is mild on fast local hardware with this small fixture; it is worse
+/// on slower/loaded shared runners and under the heavier loads the audit
+/// describes. `K = 12` (~9× the measured ratio) leaves ample headroom for
+/// shared-runner tail noise while still catching a gross convoy regression. This
+/// blocking test is intentionally the loosest safety net; the advisory
+/// `tail-latency-gate.json` `p99_mixed_over_scan_free` max is a tighter watch line.
+#[cfg(feature = "cli-helpers")]
+const K: f64 = 12.0;
+
+#[cfg(feature = "cli-helpers")]
+#[test]
+fn mixed_p99_bounded_by_k_times_baseline() {
+    use fixtures::ReadFixture;
+
+    if !fixtures::fixture_present(&ReadFixture::SIMPLE) {
+        eprintln!("tail_latency test: SIMPLE fixture absent — skipping (fetch datasets)");
+        return;
+    }
+
+    let report = harness::run(ReadFixture::SIMPLE).expect("harness run on present fixture");
+
+    // Structural invariants in both blocks (rows>0 is enforced via setup's no-panic).
+    assert!(report.mixed.p50 <= report.mixed.p99 && report.mixed.p99 <= report.mixed.p999);
+    assert!(
+        report.scan_free.p50 <= report.scan_free.p99
+            && report.scan_free.p99 <= report.scan_free.p999
+    );
+
+    let bound = K * (report.scan_free.p99 as f64);
+    assert!(
+        (report.mixed.p99 as f64) <= bound,
+        "mixed p99 {} exceeded K({K}) * scan_free p99 {} = {bound} \
+         (p99_mixed_over_scan_free = {:.2})",
+        report.mixed.p99,
+        report.scan_free.p99,
+        report.p99_mixed_over_scan_free
+    );
+}
+
+#[cfg(feature = "cli-helpers")]
+#[test]
+fn scan_free_determinism_within_wide_tolerance() {
+    use fixtures::ReadFixture;
+
+    if !fixtures::fixture_present(&ReadFixture::SIMPLE) {
+        eprintln!("tail_latency test: SIMPLE fixture absent — skipping (fetch datasets)");
+        return;
+    }
+
+    let (db, sql) = harness::setup(&ReadFixture::SIMPLE);
+    let a = harness::run_point_read_stream(&db, &sql, harness::MEASURED_N, harness::WARMUP);
+    let b = harness::run_point_read_stream(&db, &sql, harness::MEASURED_N, harness::WARMUP);
+
+    let sa = harness::TailStats::from_latencies(&a);
+    let sb = harness::TailStats::from_latencies(&b);
+
+    assert!(sa.p50 <= sa.p99 && sa.p99 <= sa.p999);
+    assert!(sb.p50 <= sb.p99 && sb.p99 <= sb.p999);
+
+    // Deliberately loose: two consecutive scan-free p50s agree within 4x either
+    // direction. This proves the harness is not wildly nondeterministic without
+    // gating on wall-clock noise (issue guardrail).
+    let lo = sa.p50.min(sb.p50) as f64;
+    let hi = sa.p50.max(sb.p50) as f64;
+    assert!(
+        hi <= 4.0 * lo.max(1.0),
+        "scan-free p50 drift too large across two runs: {} vs {} (>4x)",
+        sa.p50,
+        sb.p50
+    );
+}

--- a/openspec/changes/tail-latency-harness/design.md
+++ b/openspec/changes/tail-latency-harness/design.md
@@ -1,0 +1,95 @@
+# Design — tail-latency-harness
+
+## Context
+
+Source of truth: `docs/reports/read-path-performance-audit-2026-07-01.md` §Epic A (row A2); issue #1563
+(child of Epic A #1513). Builds on A1 (#1562, merged): the real point-read surface, the
+`benches/fixtures/mod.rs` loader, and the `perf-gate.json` + `scripts/ci/check_perf_regression.py`
+conventions. Guardrail: **no read-path production code changes** — additive harness/gate/test only.
+
+## Decision 1 — harness form: `harness = false` custom-main bench, not a Criterion bench
+
+Criterion reports a single **median** per bench and the A1 gate compares that median PR-vs-`main`. The
+tail harness must report **percentiles** (p50/p99/p999) and gate **intra-run ratios**, which Criterion's
+model does not express. Options considered:
+
+| Form | Verdict |
+|------|---------|
+| Criterion bench (`harness = true`) | **Rejected.** Emits a median, not percentiles; the gate mechanism is a PR-vs-main median compare, not an intra-run ratio. |
+| Plain `scripts/` binary invoking the CLI | **Rejected.** Would drive the process boundary, not the in-process reader set the audit convoy is about; can't share one `Database`/reader set between the scan and the point reads. |
+| `harness = false` bench under `benches/` with a custom `fn main()` | **Chosen.** Compiles against `cqlite-core` + the shared `fixtures` loader, drives one in-process shared `Database`, and is free to compute/emit percentiles + ratios as JSON and append the ledger. Lives with the other benches. |
+
+**Chosen: a `harness = false` bench** `cqlite-core/benches/tail_latency.rs` whose measurement logic
+lives in a shared module `cqlite-core/benches/tail_latency/mod.rs` so the TDD test can include and
+exercise it (see Decision 5).
+
+## Decision 2 — load model: background scan + foreground point-read stream, vs a scan-free baseline
+
+Per the issue step 1: start **one continuous background full-table scan** (`SELECT *` looped over the
+shared `Database`), then issue a fixed-length stream of foreground **point reads** against the *same*
+reader set, timing each point read. This is exactly the C2/F1/F3 tail pathology (a scan cursor + reader
+map held while point reads arrive). The **scan-free baseline** runs the identical point-read stream with
+no background scan. The gate compares the two.
+
+- **Point-read surface** = A1's proven real path: `SELECT id, name FROM test_basic.simple_table WHERE
+  id = <uuid-literal>` (projected → routes through `SelectExecutor`/#949, not the legacy scan). Setup
+  asserts `rows.len() ≥ 1` and `access_path.is_targeted()` (`PartitionLookup`) or panics — wiring-evidence.
+- **Sharing** = `Arc<Database>` (the read handle is `&self`/`Send + Sync`; concurrent execute is safe,
+  per #815). The background scan runs on a spawned thread (its own current-thread Tokio runtime) driven
+  by an `AtomicBool` stop flag; the foreground stream runs on the main thread. The scan thread is
+  started before and joined after the point-read stream so the tail is measured under live contention.
+- **Fixed iteration counts** (documented consts: warmup + measured N point reads, and the scan loops
+  until stopped) so the measured set is identical run-to-run; no wall-clock-bounded loops.
+
+## Decision 3 — gate: a self-contained intra-run ratio checker, ADVISORY first
+
+The A1 gate compares medians PR-vs-main on one runner. Tail ratios are computed **within a single run**,
+so a separate checker is cleaner than overloading `check_perf_regression.py`:
+
+- `cqlite-core/benches/tail-latency-gate.json` — policy: `advisory: true`, and per-ratio thresholds
+  `p99_over_p50` and `p99_mixed_over_scan_free` (`max`). Mirrors `perf-gate.json`'s "policy file is the
+  committed baseline" model.
+- `scripts/ci/check_tail_latency.py <harness_json> <gate_json>` — reads the harness JSON, prints each
+  ratio vs its threshold with a status, and **while `advisory` is true exits 0 regardless of any
+  breach** (reports only). A `--enforce` flag (or setting `advisory: false`) makes a breach exit
+  non-zero. `scripts/ci/tests/test_check_tail_latency.py` proves: advisory breach → exit 0 (reported);
+  enforce breach → exit 1; within-threshold → exit 0.
+
+**Flip-to-enforcing** (documented in the gate JSON `_comment`, the bench README, and the checker
+`--help`): once C2/F1/F3 land and the `p99_mixed_over_scan_free` ratio drops, tighten the thresholds to
+the new floor and set `advisory: false`.
+
+## Decision 4 — persisted ledger, pending A5 consolidation
+
+Each harness run appends one JSON record — `{ts, commit, mixed:{p50,p99,p999},
+scan_free:{p50,p99,p999}, ratios:{...}}` — to `cqlite-core/benches/tail-latency-history.jsonl`. This is
+**generated run data** (machine/run-specific), so it is **gitignored**, not committed. A5 (cold-open
+bench + persisted ledger) will introduce the unified `history.jsonl`; the harness ledger path is a
+single const documented to fold into A5's ledger then.
+
+## Decision 5 — TDD tests robust to shared-runner noise (ratios, wide tolerances)
+
+`cqlite-core/tests/tail_latency_harness.rs` includes the shared harness module and the fixtures loader
+via `#[path]` (both resolve to `crate::…`, the same pattern the benches use). Under the gate's
+`core-tests` (`--features cli-helpers`) component:
+
+- **Self-assertion (mixed vs baseline):** `p99_mixed ≤ k × p99_scan_free`, where `k` is chosen from the
+  first measured run on `main` (the convoy inflates the ratio) and documented as a const with the
+  measured "before" number. `k` is set generously above the observed convoy ratio so the test is green
+  on today's `main`; it tightens when the tail fixes land. Never asserts absolute times.
+- **Determinism (smoke):** two consecutive scan-free runs agree within a wide, documented tolerance
+  (structural invariants always: `p50 ≤ p99 ≤ p999`, counts match, JSON round-trips). Deliberately loose
+  — the issue guardrail forbids gating on wall-clock noise.
+- **Pure unit tests** (no datasets): percentile computation (nearest-rank on a known vector) and the
+  gate-ratio/advisory logic.
+- **Skip-not-fail** when the fixture binary is absent (reuse `fixtures::fixture_present`), and
+  **fail-loud** (panic) when the fixture is present but yields 0 rows or a non-targeted path — never a
+  0-row measurement (parity-is-truth doctrine).
+
+## Alternatives rejected
+
+- **Gating absolute p99 latency** — rejected; cross-runner variance makes any committed absolute time
+  unreliable (the same rationale A1/#572 give). Ratios only.
+- **Reusing Criterion's sample vector for percentiles** — rejected; Criterion owns its sampling/warmup
+  loop and reports a median, not the raw per-op latencies under a *concurrent background scan*, which is
+  the whole point.

--- a/openspec/changes/tail-latency-harness/proposal.md
+++ b/openspec/changes/tail-latency-harness/proposal.md
@@ -1,0 +1,64 @@
+## Why
+
+Every gated read-path perf number today is a Criterion **median** (issue #1562 landed the real
+point-read median gate). But the July 2026 read-path audit
+(`docs/reports/read-path-performance-audit-2026-07-01.md` §Epic A) found that its three biggest
+read-path defects are all **tail** pathologies, not median ones:
+
+- **C2 cursor convoy** — a background scan holds a cursor that serializes concurrent point reads;
+- **F1 reader-map FIFO stall** — `table_readers.read().await` held across I/O stalls other readers;
+- **F3 blocking I/O on async workers** — mmap page faults / `O_DIRECT` reads block a Tokio worker.
+
+Each barely moves the median but inflates p99/p999 badly under a mixed load (a scan running while
+point reads arrive). With no tail harness, none of those fixes can be shown red-then-green, and a
+tail regression merges silently because the median gate cannot see it.
+
+This is child **A2** of Epic A (#1513, "measurement first"; issue #1563). It is design-driven,
+additive **measurement-harness** work — Seam-1 pre-approved for the Epic A batch. It builds directly
+on A1 (#1562): the same real `WHERE pk = ?` partition-targeted point-read surface, the same
+`benches/fixtures/mod.rs` loader, and the same `perf-gate.json`/checker conventions.
+
+Guardrail (from the issue): **no production-code changes** — additive harness/gate/test only. Gate on
+**ratios**, never wall-clock absolutes, so shared-runner noise cannot flap the gate.
+
+## What Changes
+
+- **A mixed-load tail-latency harness** (`cqlite-core/benches/tail_latency.rs`, a `harness = false`
+  custom-main bench so it can emit percentiles instead of a single Criterion median). It:
+  1. opens one shared `Database` over the BIG multi-chunk fixture (`test_basic.simple_table`, reused
+     from A1) and starts **one continuous background full-table scan** (`SELECT *` in a loop);
+  2. issues a fixed-length stream of real partition-targeted **point reads**
+     (`SELECT id, name … WHERE id = <uuid-literal>`, the #949/#956 path A1 proved), recording per-op
+     latency; and
+  3. runs the identical point-read stream **with no background scan** as a **scan-free baseline**.
+- **Machine-readable JSON output**: `{p50, p99, p999}` (nanoseconds) for the point-read stream under
+  both the mixed load and the scan-free baseline, plus the derived gate ratios `p99_over_p50` and
+  `p99_mixed_over_scan_free`.
+- **Wiring-evidence**: the point-read stream drives the real public read path; setup asserts the query
+  returns ≥1 row and reports a **targeted** `AccessPath` (`PartitionLookup`), never a full-scan
+  fallback — otherwise the harness panics loudly (same honesty guards as A1).
+- **A self-contained ratio gate, ADVISORY first**: `cqlite-core/benches/tail-latency-gate.json`
+  (thresholds + an `advisory: true` flag) and `scripts/ci/check_tail_latency.py`, which reads the
+  harness JSON, reports both ratios against their thresholds, and — while `advisory` is true —
+  **always exits 0** (reports, never fails). A documented flip (`advisory: false`, or `--enforce`)
+  turns it enforcing once C2/F1/F3 land.
+- **Persisted ledger**: each harness run appends one JSON record (commit, timestamp, both stat blocks,
+  ratios) to a history ledger (`cqlite-core/benches/tail-latency-history.jsonl`, gitignored run data).
+  Documented to consolidate into A5's unified `history.jsonl` when A5 lands.
+- **TDD tests** (`cqlite-core/tests/tail_latency_harness.rs`, run by the gate's `core-tests`
+  `cli-helpers` component): (a) point-read p99 under mixed load ≤ `k` × the scan-free baseline p99,
+  with `k` chosen from the first measured run on `main` and documented (this records the convoy as the
+  "before" number); (b) determinism — two consecutive scan-free runs agree within a documented, wide
+  tolerance; plus pure unit tests for the percentile math and the gate-ratio/advisory logic.
+
+## Non-goals
+
+- **No read-path production code changes.** Additive harness/gate/test only (issue guardrail). The
+  actual C2/F1/F3 fixes are later Epic F children; this only makes them measurable.
+- **No enforcing tail gate yet.** The gate ships advisory; flipping to enforcing is documented and
+  deferred until the tail fixes land (so the recorded convoy ratio does not red the gate today).
+- **No write-load axis.** The audit's tail findings are scan-vs-point-read read contention; a background
+  write load is a documented future extension, out of scope here.
+- **No change to the existing A1 median gate** (`check_perf_regression.py`, `perf-regression.yml`,
+  `perf-gate.json`) — the tail gate is a separate, self-contained ratio checker.
+- **Not** a cross-machine absolute-latency SLO; the harness gates intra-run ratios only.

--- a/openspec/changes/tail-latency-harness/specs/tail-latency-harness/spec.md
+++ b/openspec/changes/tail-latency-harness/specs/tail-latency-harness/spec.md
@@ -1,0 +1,89 @@
+## ADDED Requirements
+
+### Requirement: A mixed-load tail-latency harness measures point-read percentiles under a background scan
+The project SHALL provide a tail-latency harness that opens one shared `Database` over a BIG multi-chunk
+fixture, starts one continuous background full-table scan, and issues a fixed-length stream of real
+partition-targeted point reads against the same reader set, recording per-op latency. It SHALL also run
+the identical point-read stream with no background scan as a scan-free baseline. The harness SHALL be
+additive (bench/gate/test only) and change no read-path production code.
+
+#### Scenario: The harness runs a point-read stream under a concurrent background scan
+- **WHEN** the harness runs against the present BIG fixture
+- **THEN** it drives one continuous background full-table scan concurrently with a fixed-length stream of point reads over the same shared `Database`
+- **AND** it also runs the identical point-read stream with the background scan absent (the scan-free baseline)
+- **AND** it records per-operation latency for the point-read stream in each mode
+
+#### Scenario: The point-read stream drives the real targeted access path
+- **WHEN** the harness sets up the point-read stream
+- **THEN** the point read returns at least one row and reports a targeted `AccessPath` (`PartitionLookup`), not a full-scan fallback
+- **AND** if the query returns zero rows or a non-targeted path the harness panics with an actionable message rather than measuring the wrong path
+
+### Requirement: The harness emits machine-readable p50/p99/p999 JSON for both modes
+The harness SHALL emit machine-readable JSON containing `p50`, `p99`, and `p999` (nanoseconds) for the
+point-read stream under both the mixed load and the scan-free baseline, plus the derived gate ratios
+`p99_over_p50` and `p99_mixed_over_scan_free`. Percentiles SHALL be computed from the recorded per-op
+latencies and SHALL satisfy `p50 <= p99 <= p999`.
+
+#### Scenario: JSON output contains both stat blocks and the gate ratios
+- **WHEN** the harness completes a run
+- **THEN** its JSON output contains a `mixed` block and a `scan_free` block, each with numeric `p50`, `p99`, `p999`
+- **AND** it contains numeric `p99_over_p50` and `p99_mixed_over_scan_free` ratios
+- **AND** within each block `p50 <= p99 <= p999`
+
+#### Scenario: Percentiles are computed correctly from recorded latencies
+- **WHEN** the percentile function is given a known vector of latencies
+- **THEN** the returned p50/p99/p999 match the nearest-rank percentiles of that vector (proven by a unit test with no dataset dependency)
+
+### Requirement: The tail gate is wired advisory-first with a documented flip to enforcing
+The project SHALL provide a self-contained ratio gate — a committed policy file with per-ratio
+thresholds and an `advisory` flag, and a checker script — that reads the harness JSON and reports each
+ratio against its threshold. While `advisory` is true the checker SHALL report breaches but always exit
+zero (never fail). Setting the policy to enforcing (or passing an enforce flag) SHALL make a threshold
+breach exit non-zero. The flip-to-enforcing procedure SHALL be documented.
+
+#### Scenario: Advisory mode reports a breach but does not fail
+- **WHEN** the checker runs on harness JSON whose ratio exceeds its threshold while the policy is advisory
+- **THEN** the checker prints the breach with an advisory status
+- **AND** it exits zero (does not fail the build)
+
+#### Scenario: Enforcing mode fails on a breach
+- **WHEN** the checker runs in enforcing mode (policy `advisory: false` or the enforce flag) on harness JSON whose ratio exceeds its threshold
+- **THEN** the checker exits non-zero
+
+#### Scenario: Within-threshold ratios pass in either mode
+- **WHEN** the checker runs on harness JSON whose ratios are within their thresholds
+- **THEN** the checker exits zero regardless of advisory/enforcing mode
+
+### Requirement: Harness output is persisted to a history ledger
+Each harness run SHALL append one JSON record — timestamp, commit, both stat blocks, and the ratios — to
+a history ledger, so tail latency over time is inspectable. The ledger holds generated run data and
+SHALL NOT be committed to the repository; it is documented to consolidate into the Epic A5 unified
+`history.jsonl` when A5 lands.
+
+#### Scenario: A run appends a ledger record
+- **WHEN** the harness completes a run
+- **THEN** it appends one JSON record containing a timestamp, the commit, the `mixed` and `scan_free` stat blocks, and the ratios to the history ledger
+- **AND** the ledger file is gitignored (not tracked in the repository)
+
+### Requirement: The harness self-asserts the tail bound and is deterministic within tolerance
+A committed test SHALL assert that the point-read p99 under mixed load is at most `k` times the scan-free
+baseline p99, where `k` is chosen from the first measured run on `main` and documented (recording the
+current convoy as the "before" number). A committed test SHALL assert that two consecutive scan-free
+runs agree within a documented tolerance. Tests SHALL gate on ratios, never wall-clock absolutes, and
+SHALL skip (not fail) when the fixture binary is absent while failing loudly when it is present but
+yields zero rows.
+
+#### Scenario: Mixed-load p99 is bounded by k times the baseline
+- **WHEN** the self-assertion test runs against the present fixture
+- **THEN** the point-read p99 under mixed load is at most `k` times the scan-free baseline p99, with `k` a documented const
+
+#### Scenario: Two scan-free runs agree within tolerance
+- **WHEN** the determinism test runs two consecutive scan-free point-read streams
+- **THEN** their p50 values agree within the documented tolerance
+- **AND** each stream satisfies `p50 <= p99 <= p999`
+
+#### Scenario: Absent fixture skips, present-but-empty fails loudly
+- **WHEN** the harness fixture binary is absent
+- **THEN** the harness self-assertion test skips without failing
+- **AND WHEN** the fixture is present but the point read returns zero rows
+- **THEN** the harness panics rather than recording a zero-row measurement

--- a/openspec/changes/tail-latency-harness/tasks.md
+++ b/openspec/changes/tail-latency-harness/tasks.md
@@ -1,0 +1,41 @@
+# Tasks — tail-latency-harness
+
+## 1. TDD tests first (must be green on current main, gate on ratios not absolutes)
+- [ ] 1.1 `cqlite-core/tests/tail_latency_harness.rs`: pure unit tests (no dataset) for the percentile
+      function (nearest-rank p50/p99/p999 on a known vector) and the gate-ratio/advisory logic.
+- [ ] 1.2 Same file: self-assertion test — `p99_mixed <= K * p99_scan_free` with `K` a documented const
+      chosen from the first measured run on `main` (record the measured convoy ratio in the PR).
+      Skip-not-fail when the fixture binary is absent; panic-loud when present-but-0-rows.
+- [ ] 1.3 Same file: determinism test — two consecutive scan-free runs' p50 agree within a documented
+      wide tolerance; each run satisfies `p50 <= p99 <= p999`.
+- [ ] 1.4 `scripts/ci/tests/test_check_tail_latency.py`: advisory breach → exit 0 (reported);
+      enforce breach → exit 1; within-threshold → exit 0.
+
+## 2. Harness implementation (additive; no read-path production changes)
+- [ ] 2.1 `cqlite-core/benches/tail_latency/mod.rs` (shared module, `crate::fixtures`): percentile math
+      (`TailStats { p50, p99, p999 }`), `HarnessReport` (mixed + scan_free + ratios), JSON serialize,
+      ledger append; `run_point_read_stream(db, sql, n)`, `run_mixed_load(...)`, `run_scan_free(...)`.
+      Background scan on a spawned thread with an `AtomicBool` stop flag over a shared `Arc<Database>`.
+- [ ] 2.2 Setup guards: point read returns ≥1 row AND `access_path.is_targeted()` (`PartitionLookup`),
+      else panic (wiring-evidence). Reuse A1's `uuid_to_literal` + the `SELECT id, name … WHERE id=<lit>`
+      projected shape. Fixed warmup + measured `N` consts (no wall-clock-bounded loops).
+- [ ] 2.3 `cqlite-core/benches/tail_latency.rs` (`harness = false` custom main): run mixed + scan-free,
+      print JSON to stdout, append the ledger record. Skip-register (no measurement, clear message) when
+      the fixture is absent. Register the bench in `cqlite-core/Cargo.toml` (`[[bench]] harness = false`).
+
+## 3. Gate config + checker (advisory first)
+- [ ] 3.1 `cqlite-core/benches/tail-latency-gate.json`: `advisory: true`, thresholds for
+      `p99_over_p50` and `p99_mixed_over_scan_free`, plus a `_comment` documenting the flip-to-enforcing.
+- [ ] 3.2 `scripts/ci/check_tail_latency.py <harness_json> <gate_json>`: report each ratio vs threshold;
+      exit 0 while advisory; `--enforce` (or `advisory: false`) → non-zero on breach. Document the flip.
+- [ ] 3.3 `.gitignore`: add `cqlite-core/benches/tail-latency-history.jsonl` (generated run data).
+
+## 4. Docs
+- [ ] 4.1 `cqlite-core/benches/README.md`: document the tail harness, its JSON/ledger, and the
+      advisory-first tail gate + flip-to-enforcing. Note A5 ledger consolidation.
+
+## 5. Validation
+- [ ] 5.1 Run the harness locally against the fetched BIG fixture; record the measured "before"
+      p99_mixed/p99_scan_free convoy ratio in the PR; set `K` and the gate thresholds from it.
+- [ ] 5.2 `scripts/agent-gate.sh` PASS — paste the AGENT-GATE SUMMARY block in the PR.
+- [ ] 5.3 `RUSTFLAGS="-D warnings"` clean; no `unwrap()`/`expect()` in library code.

--- a/scripts/ci/check_tail_latency.py
+++ b/scripts/ci/check_tail_latency.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Report mixed-load tail-latency ratios against thresholds; advisory-first (Issue #1563).
+
+Reads the tail-latency harness JSON (emitted by the `tail_latency` bench) and the
+gate policy JSON, prints each derived ratio against its `max` threshold with a
+status, and picks the exit code by the gate mode:
+
+  - ADVISORY (policy `advisory: true` and no `--enforce`): breaches are REPORTED
+    with an advisory status, but the checker ALWAYS exits 0 (never fails CI). This
+    records the current convoy so the C2/F1/F3 tail fixes can be shown red-then-green.
+  - ENFORCING (policy `advisory: false`, or the `--enforce` flag): any ratio that
+    exceeds its `max` exits non-zero; otherwise exit 0.
+
+Ratios checked (top-level keys of the harness JSON):
+  - p99_over_p50               — tail spread within the mixed load (mixed.p99/mixed.p50)
+  - p99_mixed_over_scan_free   — convoy inflation (mixed.p99 / scan_free.p99)
+
+All thresholds are intra-run RATIOS, never wall-clock absolutes, so shared-runner
+noise cannot flap the gate.
+
+Flip-to-enforcing: once the C2/F1/F3 tail fixes land and p99_mixed_over_scan_free
+drops, tighten the `max` values in cqlite-core/benches/tail-latency-gate.json to
+the new floor and set `advisory: false` (or pass --enforce in CI). See
+cqlite-core/benches/README.md.
+
+Usage:
+    check_tail_latency.py <harness_json> <gate_json> [--enforce]
+
+Example:
+    check_tail_latency.py /tmp/tail.json cqlite-core/benches/tail-latency-gate.json
+"""
+
+import json
+import sys
+
+# Ratios the gate knows about (top-level keys in the harness JSON).
+RATIO_KEYS = ("p99_over_p50", "p99_mixed_over_scan_free")
+
+
+def main(argv):
+    positional = [a for a in argv[1:] if not a.startswith("--")]
+    flags = {a for a in argv[1:] if a.startswith("--")}
+    if len(positional) != 2:
+        print(__doc__)
+        return 2
+
+    harness_path, gate_path = positional
+    enforce_flag = "--enforce" in flags
+
+    with open(harness_path) as fh:
+        harness = json.load(fh)
+    with open(gate_path) as fh:
+        gate = json.load(fh)
+
+    advisory = bool(gate.get("advisory", True))
+    enforcing = enforce_flag or not advisory
+    ratios_cfg = gate.get("ratios", {})
+
+    mode = "ENFORCING" if enforcing else "ADVISORY (reported only)"
+    print(f"Tail-latency ratio gate [{mode}]\n")
+    col = 30
+    header = f"{'ratio':<{col}} {'value':>12} {'max':>12}  status"
+    print(header)
+    print("-" * len(header))
+
+    breaches = []
+    for key in RATIO_KEYS:
+        value = harness.get(key)
+        cfg = ratios_cfg.get(key)
+
+        if value is None:
+            print(f"{key:<{col}} {'-':>12} {'-':>12}  SKIP (absent from harness JSON)")
+            continue
+        if cfg is None or cfg.get("max") is None:
+            print(f"{key:<{col}} {float(value):>12.3f} {'-':>12}  SKIP (no threshold)")
+            continue
+
+        value = float(value)
+        threshold = float(cfg["max"])
+        if value > threshold:
+            breaches.append((key, value, threshold))
+            status = "BREACH" if enforcing else "BREACH (advisory — reported only)"
+        else:
+            status = "ok"
+        print(f"{key:<{col}} {value:>12.3f} {threshold:>12.3f}  {status}")
+
+    print()
+    if breaches:
+        if enforcing:
+            print(f"❌ {len(breaches)} tail ratio(s) exceeded threshold:")
+            for key, value, threshold in breaches:
+                print(f"   - {key}: {value:.3f} > {threshold:.3f}")
+            return 1
+        print(f"⚠️  {len(breaches)} tail ratio(s) exceeded threshold (advisory — not failing CI):")
+        for key, value, threshold in breaches:
+            print(f"   - {key}: {value:.3f} > {threshold:.3f}")
+        print(
+            "\nAdvisory gate: reported only. Flip to enforcing by setting "
+            "advisory:false in tail-latency-gate.json or passing --enforce."
+        )
+        return 0
+
+    print("✅ All tail ratios within threshold.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/ci/check_tail_latency.py
+++ b/scripts/ci/check_tail_latency.py
@@ -41,6 +41,13 @@ RATIO_KEYS = ("p99_over_p50", "p99_mixed_over_scan_free")
 def main(argv):
     positional = [a for a in argv[1:] if not a.startswith("--")]
     flags = {a for a in argv[1:] if a.startswith("--")}
+    # Reject unknown flags fail-closed: a typo like `--enfore` must NOT silently
+    # leave the checker in advisory mode and exit 0 on a breach (roborev).
+    unknown = flags - {"--enforce"}
+    if unknown:
+        print(f"error: unknown flag(s): {', '.join(sorted(unknown))}\n")
+        print(__doc__)
+        return 2
     if len(positional) != 2:
         print(__doc__)
         return 2

--- a/scripts/ci/check_tail_latency.py
+++ b/scripts/ci/check_tail_latency.py
@@ -31,6 +31,7 @@ Example:
 """
 
 import json
+import math
 import sys
 
 # Ratios the gate knows about (top-level keys in the harness JSON).
@@ -64,21 +65,32 @@ def main(argv):
     print("-" * len(header))
 
     breaches = []
-    # A ratio the gate has a `max` for but that is absent from the harness JSON.
-    # In enforcing mode this is a fail-closed error (stale/malformed harness output
-    # must NOT bypass the gate); in advisory mode it is a reported SKIP.
+    # A ratio the gate has a `max` for but that is absent OR non-finite/malformed in
+    # the harness JSON. In enforcing mode this is a fail-closed error (stale/malformed
+    # harness output — including NaN, which makes `value > threshold` false — must NOT
+    # bypass the gate); in advisory mode it is a reported SKIP.
     missing_required = []
+
+    def _finite_number(v):
+        # Reject None, bool (a subclass of int), and non-finite floats (NaN/inf).
+        return (
+            isinstance(v, (int, float))
+            and not isinstance(v, bool)
+            and math.isfinite(float(v))
+        )
+
     for key in RATIO_KEYS:
         value = harness.get(key)
         cfg = ratios_cfg.get(key)
         has_threshold = cfg is not None and cfg.get("max") is not None
 
-        if value is None:
+        if not _finite_number(value):
+            reason = "absent from harness JSON" if value is None else f"malformed ({value!r})"
             if enforcing and has_threshold:
                 missing_required.append(key)
-                print(f"{key:<{col}} {'-':>12} {float(cfg['max']):>12.3f}  MISSING (required)")
+                print(f"{key:<{col}} {str(value):>12.12} {float(cfg['max']):>12.3f}  INVALID (required)")
             else:
-                print(f"{key:<{col}} {'-':>12} {'-':>12}  SKIP (absent from harness JSON)")
+                print(f"{key:<{col}} {'-':>12} {'-':>12}  SKIP ({reason})")
             continue
         if not has_threshold:
             print(f"{key:<{col}} {float(value):>12.3f} {'-':>12}  SKIP (no threshold)")
@@ -99,8 +111,8 @@ def main(argv):
     # output silently pass the gate.
     if missing_required:
         print(
-            f"❌ {len(missing_required)} required tail ratio(s) missing from harness JSON "
-            f"(enforcing): {', '.join(missing_required)}"
+            f"❌ {len(missing_required)} required tail ratio(s) missing or malformed in harness "
+            f"JSON (enforcing): {', '.join(missing_required)}"
         )
         print("   Regenerate the harness JSON (cargo bench --bench tail_latency) before gating.")
         return 1

--- a/scripts/ci/check_tail_latency.py
+++ b/scripts/ci/check_tail_latency.py
@@ -64,14 +64,23 @@ def main(argv):
     print("-" * len(header))
 
     breaches = []
+    # A ratio the gate has a `max` for but that is absent from the harness JSON.
+    # In enforcing mode this is a fail-closed error (stale/malformed harness output
+    # must NOT bypass the gate); in advisory mode it is a reported SKIP.
+    missing_required = []
     for key in RATIO_KEYS:
         value = harness.get(key)
         cfg = ratios_cfg.get(key)
+        has_threshold = cfg is not None and cfg.get("max") is not None
 
         if value is None:
-            print(f"{key:<{col}} {'-':>12} {'-':>12}  SKIP (absent from harness JSON)")
+            if enforcing and has_threshold:
+                missing_required.append(key)
+                print(f"{key:<{col}} {'-':>12} {float(cfg['max']):>12.3f}  MISSING (required)")
+            else:
+                print(f"{key:<{col}} {'-':>12} {'-':>12}  SKIP (absent from harness JSON)")
             continue
-        if cfg is None or cfg.get("max") is None:
+        if not has_threshold:
             print(f"{key:<{col}} {float(value):>12.3f} {'-':>12}  SKIP (no threshold)")
             continue
 
@@ -85,6 +94,17 @@ def main(argv):
         print(f"{key:<{col}} {value:>12.3f} {threshold:>12.3f}  {status}")
 
     print()
+    # Fail-closed: enforcing mode must not exit 0 when a required (thresholded)
+    # ratio is missing from the harness JSON — that would let stale/malformed
+    # output silently pass the gate.
+    if missing_required:
+        print(
+            f"❌ {len(missing_required)} required tail ratio(s) missing from harness JSON "
+            f"(enforcing): {', '.join(missing_required)}"
+        )
+        print("   Regenerate the harness JSON (cargo bench --bench tail_latency) before gating.")
+        return 1
+
     if breaches:
         if enforcing:
             print(f"❌ {len(breaches)} tail ratio(s) exceeded threshold:")

--- a/scripts/ci/tests/test_check_tail_latency.py
+++ b/scripts/ci/tests/test_check_tail_latency.py
@@ -117,6 +117,17 @@ class TestMissingRatioFailsClosedWhenEnforcing:
         rc = _run(tmp_path, harness, _gate(advisory=True))
         assert rc == 0, "advisory gate skips a missing ratio (reported, not failing)"
 
+    def test_enforcing_nan_ratio_exits_nonzero(self, tmp_path):
+        # A NaN ratio makes `value > threshold` false — it must NOT be reported ok.
+        # JSON has no NaN literal, so write it via the Python encoder's default.
+        h = tmp_path / "harness.json"
+        obj = _harness()
+        obj["p99_mixed_over_scan_free"] = float("nan")
+        h.write_text(json.dumps(obj))  # emits NaN (json.load reads it back as nan)
+        g = _write(tmp_path, "gate.json", _gate(advisory=False))
+        rc = main(["check_tail_latency.py", str(h), g])
+        assert rc != 0, "enforcing gate must fail on a non-finite (NaN) ratio"
+
 
 class TestWithinThresholdPasses:
     def test_within_threshold_advisory_exits_zero(self, tmp_path):

--- a/scripts/ci/tests/test_check_tail_latency.py
+++ b/scripts/ci/tests/test_check_tail_latency.py
@@ -1,0 +1,116 @@
+"""Tests for scripts/ci/check_tail_latency.py (Issue #1563).
+
+Validates the advisory-vs-enforcing exit-code model of the tail-latency ratio
+gate. Mirrors test_check_perf_regression.py: import the script as a module and
+drive main() with temp harness/gate JSON fixtures.
+
+Matrix:
+  A) Advisory breach          → exit 0 (breach reported, gate does not fail)
+  B) Enforce flag + breach     → exit 1
+  C) advisory:false + breach   → exit 1
+  D) Within threshold (either mode) → exit 0
+"""
+
+import importlib.util
+import json
+import os
+
+# ---------------------------------------------------------------------------
+# Import the script as a module (it is not a package, has no __init__)
+# ---------------------------------------------------------------------------
+_SCRIPT = os.path.join(os.path.dirname(__file__), "..", "check_tail_latency.py")
+_spec = importlib.util.spec_from_file_location("check_tail_latency", _SCRIPT)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+main = _mod.main
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _write(tmp_path, name, obj):
+    path = tmp_path / name
+    path.write_text(json.dumps(obj))
+    return str(path)
+
+
+def _harness(p99_over_p50=2.0, p99_mixed_over_scan_free=3.0):
+    return {
+        "mixed": {"p50": 100, "p99": 300, "p999": 500},
+        "scan_free": {"p50": 90, "p99": 100, "p999": 150},
+        "p99_over_p50": p99_over_p50,
+        "p99_mixed_over_scan_free": p99_mixed_over_scan_free,
+    }
+
+
+def _gate(advisory=True, p50_max=40.0, cross_max=12.0):
+    return {
+        "advisory": advisory,
+        "ratios": {
+            "p99_over_p50": {"max": p50_max},
+            "p99_mixed_over_scan_free": {"max": cross_max},
+        },
+    }
+
+
+def _run(tmp_path, harness, gate, *flags):
+    h = _write(tmp_path, "harness.json", harness)
+    g = _write(tmp_path, "gate.json", gate)
+    return main(["check_tail_latency.py", h, g, *flags])
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+class TestAdvisoryBreachReportsButPasses:
+    def test_advisory_breach_exits_zero(self, tmp_path):
+        rc = _run(
+            tmp_path,
+            _harness(p99_mixed_over_scan_free=99.0),
+            _gate(advisory=True, cross_max=12.0),
+        )
+        assert rc == 0, "advisory breach must exit 0 (reported, not failing)"
+
+    def test_advisory_breach_is_reported(self, tmp_path, capsys):
+        _run(
+            tmp_path,
+            _harness(p99_mixed_over_scan_free=99.0),
+            _gate(advisory=True, cross_max=12.0),
+        )
+        out = capsys.readouterr().out
+        assert "p99_mixed_over_scan_free" in out
+        assert "advisory" in out.lower()
+
+
+class TestEnforcingBreachFails:
+    def test_enforce_flag_breach_exits_nonzero(self, tmp_path):
+        rc = _run(
+            tmp_path,
+            _harness(p99_mixed_over_scan_free=99.0),
+            _gate(advisory=True, cross_max=12.0),
+            "--enforce",
+        )
+        assert rc != 0, "enforce flag on a breach must exit non-zero"
+
+    def test_advisory_false_breach_exits_nonzero(self, tmp_path):
+        rc = _run(
+            tmp_path,
+            _harness(p99_mixed_over_scan_free=99.0),
+            _gate(advisory=False, cross_max=12.0),
+        )
+        assert rc != 0, "advisory:false on a breach must exit non-zero"
+
+
+class TestWithinThresholdPasses:
+    def test_within_threshold_advisory_exits_zero(self, tmp_path):
+        rc = _run(tmp_path, _harness(), _gate(advisory=True))
+        assert rc == 0
+
+    def test_within_threshold_enforcing_exits_zero(self, tmp_path):
+        rc = _run(tmp_path, _harness(), _gate(advisory=False))
+        assert rc == 0
+
+    def test_within_threshold_success_message(self, tmp_path, capsys):
+        _run(tmp_path, _harness(), _gate(advisory=False))
+        out = capsys.readouterr().out
+        assert "✅" in out or "within threshold" in out.lower()

--- a/scripts/ci/tests/test_check_tail_latency.py
+++ b/scripts/ci/tests/test_check_tail_latency.py
@@ -101,6 +101,23 @@ class TestEnforcingBreachFails:
         assert rc != 0, "advisory:false on a breach must exit non-zero"
 
 
+class TestMissingRatioFailsClosedWhenEnforcing:
+    def test_enforcing_missing_required_ratio_exits_nonzero(self, tmp_path):
+        # A thresholded ratio absent from the harness JSON (stale/malformed output)
+        # must NOT silently pass the enforcing gate.
+        harness = _harness()
+        del harness["p99_mixed_over_scan_free"]
+        rc = _run(tmp_path, harness, _gate(advisory=False))
+        assert rc != 0, "enforcing gate must fail when a required ratio is missing"
+
+    def test_advisory_missing_ratio_still_exits_zero(self, tmp_path):
+        # Advisory mode reports a missing ratio as SKIP and still passes.
+        harness = _harness()
+        del harness["p99_mixed_over_scan_free"]
+        rc = _run(tmp_path, harness, _gate(advisory=True))
+        assert rc == 0, "advisory gate skips a missing ratio (reported, not failing)"
+
+
 class TestWithinThresholdPasses:
     def test_within_threshold_advisory_exits_zero(self, tmp_path):
         rc = _run(tmp_path, _harness(), _gate(advisory=True))

--- a/scripts/ci/tests/test_check_tail_latency.py
+++ b/scripts/ci/tests/test_check_tail_latency.py
@@ -129,6 +129,19 @@ class TestMissingRatioFailsClosedWhenEnforcing:
         assert rc != 0, "enforcing gate must fail on a non-finite (NaN) ratio"
 
 
+class TestUnknownFlagRejected:
+    def test_typo_enforce_flag_is_rejected(self, tmp_path):
+        # `--enfore` must not be silently ignored (which would leave advisory mode
+        # and exit 0 on a breach). Expect a usage error (exit 2).
+        rc = _run(
+            tmp_path,
+            _harness(p99_mixed_over_scan_free=99.0),
+            _gate(advisory=True, cross_max=12.0),
+            "--enfore",
+        )
+        assert rc == 2, "unknown flag must be rejected with a usage error"
+
+
 class TestWithinThresholdPasses:
     def test_within_threshold_advisory_exits_zero(self, tmp_path):
         rc = _run(tmp_path, _harness(), _gate(advisory=True))


### PR DESCRIPTION
Closes #1563 (Epic A #1513, child A2 — "measurement first"). Design-driven; OpenSpec change `tail-latency-harness`. **Additive bench/gate/test only — no read-path production code changes.**

## What
A mixed-load tail-latency harness that reproduces the audit's tail pathologies (C2 cursor convoy / F1 reader-map / F3 blocking-I/O) so the later Epic F fixes can be shown red-then-green:
- Opens one shared `Arc<Database>` over the BIG multi-chunk fixture (`test_basic.simple_table`, reused from A1/#1562), runs **one continuous background full-table scan** concurrently with a fixed-length stream of **real partition-targeted point reads** (`SELECT id, name … WHERE id = <uuid-literal>` — the #949/#956 path A1 proved; setup asserts rows≥1 + `access_path.is_targeted()` or panics = wiring-evidence).
- Emits machine-readable JSON `{p50,p99,p999}` (ns) for the point-read stream under the mixed load and a **scan-free baseline**, plus derived ratios `p99_over_p50` and `p99_mixed_over_scan_free`.
- **Advisory-first ratio gate**: `cqlite-core/benches/tail-latency-gate.json` (`advisory:true` + per-ratio `max`) + `scripts/ci/check_tail_latency.py` — reports each ratio; while advisory always exits 0; `--enforce`/`advisory:false` fails on breach (and fail-closed on missing/malformed/NaN ratios and unknown flags). Flip-to-enforcing documented for when C2/F1/F3 land.
- Appends each run to a gitignored history ledger (A5 will consolidate into the unified `history.jsonl`).

## "Before" numbers (current `main`, local hardware)
`p99_mixed_over_scan_free ≈ 1.28–1.37`, `p99_over_p50 ≈ 1.33–1.38` (mild convoy on fast local hw + small fixture; worse on loaded/shared runners and under the heavier loads the audit describes). The blocking self-assertion test uses `K=12` (~9× the measured convoy) for ample shared-runner headroom; the advisory gate maxes (`p99_over_p50` 6.0, `p99_mixed_over_scan_free` 4.0) are the tighter watch line.

## Tests (TDD)
`cqlite-core/tests/tail_latency_harness.rs` (run by the gate `core-tests`/`cli-helpers`): pure percentile (nearest-rank) + ratio/JSON unit tests; `append_ledger` record-shape test; dataset self-assertion (`p99_mixed ≤ K·p99_scan_free`) + wide-tolerance determinism (both `#[serial]`, skip-not-fail absent / panic present-but-0-rows). `scripts/ci/tests/test_check_tail_latency.py`: advisory/enforce/within/missing/NaN/unknown-flag matrix.

## Quality bar
- `scripts/agent-gate.sh`: **PASS** (commit 567a0bad, all components green incl. clippy `-D warnings` --all-features, python-/node-bindings).
- roborev (`--base origin/main --agent codex`): **clean / No issues found** (6 fix rounds — all real: harness contention-readiness + bounded startup/shutdown, gate fail-closed on missing/NaN/unknown-flag, test serialization).
- spec-auditor (C): **PASS** — every requirement satisfied with cited public-surface evidence (the one R4 ledger-coverage gap closed by the `append_ledger` test).

```
==== AGENT-GATE SUMMARY ====
commit: 567a0bad branch: issue-1563-tail-latency-harness dirty: no
file-size: PASS  fmt: PASS  clippy: PASS  core-tests: PASS  tombstones-scan: PASS
scan-offload-guard: PASS  integration-tests: PASS  format-compat: PASS  write-tests: PASS
cli-tests: PASS  compaction-byte-parity: PASS  python-bindings: PASS  node-bindings: PASS
delivery-telemetry: PASS  parity-report: PASS  binding-unwind-profile: PASS  tooling-tests: PASS
minimal-build: PASS  smoke: PASS
RESULT: PASS
==== END AGENT-GATE SUMMARY ====
```