### PR TITLE
perf(#1564): gate concurrent_scan (scaling floor) + read_while_write (median) benches

### DIFF
--- a/.github/workflows/perf-regression.yml
+++ b/.github/workflows/perf-regression.yml
@@ -109,7 +109,8 @@ jobs:
             read -r -a BENCH_ARGV <<< "$BENCH_ARGS"
           fi
           cargo bench -p cqlite-core --features "$BENCH_FEATURES" \
-            --bench read --bench write -- --save-baseline pr "${BENCH_ARGV[@]}"
+            --bench read --bench write --bench concurrent_scan --bench read_while_write \
+            -- --save-baseline pr "${BENCH_ARGV[@]}"
 
       - name: Benchmark main → baseline 'base'
         run: |
@@ -121,7 +122,8 @@ jobs:
           git checkout --force --detach origin/main
           git submodule update --init --recursive || true
           cargo bench -p cqlite-core --features "$BENCH_FEATURES" \
-            --bench read --bench write -- --save-baseline base "${BENCH_ARGV[@]}"
+            --bench read --bench write --bench concurrent_scan --bench read_while_write \
+            -- --save-baseline base "${BENCH_ARGV[@]}"
 
       - name: Restore PR ref (for the gate script + policy)
         run: git checkout --force --detach ${{ steps.refs.outputs.pr_ref }}

--- a/cqlite-core/Cargo.toml
+++ b/cqlite-core/Cargo.toml
@@ -188,10 +188,10 @@ harness = false
 name = "observability_overhead"
 harness = false
 
-# Read-while-write tail-latency guard (issue #1143). ADVISORY: deliberately
-# absent from benches/perf-gate.json — p99 tail statistics are runner-noisy, so
-# this is a local regression guard run under scripts/profile.sh, never a CI gate
-# (mirrors `concurrent_scan`).
+# Read-while-write reader-latency-under-write-load guard (issue #1143). GATED
+# (issue #1564): a strict median entry in benches/perf-gate.json
+# (read_while_write/readers6_writers2, 25% threshold). The p99 tail stays
+# stderr-only / runner-noisy and is owned by the A2 tail-latency harness (#1563).
 [[bench]]
 name = "read_while_write"
 harness = false

--- a/cqlite-core/benches/README.md
+++ b/cqlite-core/benches/README.md
@@ -204,14 +204,22 @@ speed cancels — this is exactly the property absolute-time gating lacks.
 The **floor is `1.8`**: below observed healthy (≈2.98/3.19) with ~40% headroom for
 CI-runner variance (fewer cores, shared scheduler; ubuntu-latest is ~4 vCPU),
 while still failing decisively against the ≈1.0 serialization signature. `n2`/`n8`
-are still measured for the local scaling curve but are not floored. A scaling
-entry whose `n1` or `n4` median is absent is reported `SKIP` and never fails.
+are still measured for the local scaling curve but are not floored. Because a
+scaling floor is **intra-run** (its data is always present on any run that benches
+`concurrent_scan`), a configured floor whose `n1`/`n4` median is **missing** is a
+gate **failure** (`MISSING DATA`), not a silent `SKIP` — so a typo'd id, an omitted
+`--bench`, or a no-data bench cannot quietly disable the gate. A floor may opt into
+skip-on-absent with `"optional": true` (for a genuinely optional fixture, like the
+`test_da` BTI corpus convention).
 
 `read_while_write` is gated as a standard **strict median** entry
 (`read_while_write/readers6_writers2`, 25% threshold) — the reader-side aggregate
 latency under write load, which is machine-readable and stable (tracks p50 ≈ 5 ms).
-Its p99 tail is not gated here (it is stderr-only and runner-noisy); the tail is
-owned by the A2 tail-latency harness (#1563).
+The bench uses a writer-readiness barrier so the readers' timed scans begin only
+once every writer is actively ingesting, guaranteeing the median reflects latency
+under live write contention (not an uncontended window). Its p99 tail is not gated
+here (it is stderr-only and runner-noisy); the tail is owned by the A2 tail-latency
+harness (#1563).
 
 ### Path-ignore behavior (Issue #572)
 

--- a/cqlite-core/benches/README.md
+++ b/cqlite-core/benches/README.md
@@ -94,6 +94,8 @@ env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets \
 | `read` | added (#538), point-read reworked (#1562) | Read suite (needs `--features cli-helpers`): `get_partition_big`, `get_partition_bti`, `clustering_slice`, `full_scan`, `type_heavy` over the fixtures via the public query API. `get_partition_*` are **real** partition-targeted point reads (`WHERE id = <unquoted-uuid>`, #949/#956), asserted at setup to report a targeted `AccessPath` (not the old `SELECT * … LIMIT 1` scan proxy). `_bti` skip-registers when the optional `test_da` corpus is absent. |
 | `write` | added (#539, #574) | Write suite (needs `--features write-support`): `ingest_wal_on`, `ingest_wal_off`, and `flush` — see below. |
 | `observability_overhead` | added (#1043) | Zero-overhead-when-disabled gate: `read_scan` (needs `cli-helpers`) and `write_merge` (needs `write-support`). The SAME bench source runs under the default build vs `--features observability` with export disabled; the two arms are compared by `scripts/ci/observability_overhead.sh` — see below. |
+| `concurrent_scan` | added (#917), **gated** (#1564) | Aggregate throughput of N ∈ {1,2,4,8} concurrent `get_all_entries()` scans against one shared `Arc<SSTableReader>`, for the buffered and mmap backends (needs `--features cli-helpers`). Gated via a **concurrency scaling floor** (not absolute time) — see below. |
+| `read_while_write` | added (#1143), **gated** (#1564) | Reader-side scan latency with ~6 full-scan readers running concurrently with ~2 sustained-ingest writers (needs `--features cli-helpers,write-support`). Gated on the Criterion **median** (strict, 25% threshold); the p99 tail is printed to stderr for local diagnosis and owned by the A2 tail-latency harness (#1563). |
 
 ### `observability_overhead` two-build comparison (Issue #1043)
 
@@ -168,6 +170,48 @@ To mark a bench advisory, add its ID to the `advisory_benches` list in
 `perf-gate.json`. The per-bench `threshold_pct` for advisory benches still
 controls what is highlighted in the output (the "elevated delta" warning level);
 it never triggers a failure.
+
+### Concurrency scaling floor (Issue #1564)
+
+`concurrent_scan` is gated by a **machine-independent scaling floor**, not an
+absolute time, because its absolute curve is runner-noisy but its *intra-run
+ratio* is not. The gate policy carries this in a `scaling_floors` array in
+`perf-gate.json` (evaluated by `check_perf_regression.py` after the median loop):
+
+```jsonc
+"scaling_floors": [
+  { "id": "concurrent_scan/buffered/n4", "baseline_id": "concurrent_scan/buffered/n1",
+    "degree_ratio": 4, "min_scaling": 1.8 },
+  { "id": "concurrent_scan/mmap/n4",     "baseline_id": "concurrent_scan/mmap/n1",
+    "degree_ratio": 4, "min_scaling": 1.8 }
+]
+```
+
+Each entry checks, **on the PR (`pr`) baseline alone** (no `main` comparison):
+
+```
+scaling = degree_ratio · median(n1) / median(n4)
+```
+
+Both medians come from the same run on the same runner, so the machine's absolute
+speed cancels — this is exactly the property absolute-time gating lacks.
+
+- **Healthy parallel scans:** `median(n4) ≈ median(n1)` → `scaling ≈ 4`
+  (measured ≈ **2.98** buffered, ≈ **3.19** mmap).
+- **Re-serialized read path** (e.g. a reintroduced shared `Mutex`, exactly what
+  #815 removed): `median(n4) ≈ 4·median(n1)` → `scaling ≈ 1.0`.
+
+The **floor is `1.8`**: below observed healthy (≈2.98/3.19) with ~40% headroom for
+CI-runner variance (fewer cores, shared scheduler; ubuntu-latest is ~4 vCPU),
+while still failing decisively against the ≈1.0 serialization signature. `n2`/`n8`
+are still measured for the local scaling curve but are not floored. A scaling
+entry whose `n1` or `n4` median is absent is reported `SKIP` and never fails.
+
+`read_while_write` is gated as a standard **strict median** entry
+(`read_while_write/readers6_writers2`, 25% threshold) — the reader-side aggregate
+latency under write load, which is machine-readable and stable (tracks p50 ≈ 5 ms).
+Its p99 tail is not gated here (it is stderr-only and runner-noisy); the tail is
+owned by the A2 tail-latency harness (#1563).
 
 ### Path-ignore behavior (Issue #572)
 

--- a/cqlite-core/benches/concurrent_scan.rs
+++ b/cqlite-core/benches/concurrent_scan.rs
@@ -16,17 +16,20 @@
 //! scans. Reading the rows/sec criterion prints for `n1` vs `n2/n4/n8` gives the
 //! scaling curve directly (n4 rows/sec ÷ n1 rows/sec = 4-way scaling factor).
 //!
-//! # Not a CI gate (by design)
+//! # CI gate: concurrency scaling floor (Issue #1564)
 //!
-//! Concurrent-scan scaling is sublinear and IO/scheduler-bound, so the absolute
-//! curve is machine-dependent and noisy on shared runners. Per the issue and the
-//! project's flaky-perf-gate history, this bench is **documentation + a local
-//! regression guard**, not a hard timing assertion: it is intentionally absent
-//! from `cqlite-core/benches/perf-gate.json`, so it runs under
-//! `./scripts/profile.sh` but never fails the perf-regression CI. The only
-//! hard assertion here is a *correctness* floor — every scan must return the same
-//! non-zero row count — which catches an accidental re-serialization or a broken
-//! scan far more reliably than a timing threshold would.
+//! The *absolute* scan curve is IO/scheduler-bound and runner-noisy, so this
+//! bench is NOT gated on absolute time. Instead the perf gate enforces a
+//! **machine-independent scaling floor** in `cqlite-core/benches/perf-gate.json`
+//! (`scaling_floors`): for each backend it checks the *intra-run* ratio
+//! `scaling = degree_ratio · median(n1) / median(n4)` on the PR baseline alone
+//! (both medians come from the same run, so machine speed cancels). Healthy
+//! parallel scans measure ≈2.98 (buffered) / ≈3.19 (mmap); a re-serialized read
+//! path (e.g. a reintroduced shared `Mutex`, exactly what #815 removed) collapses
+//! `median(n4)→≈4·median(n1)` so scaling→≈1.0 and the gate reds against the
+//! `1.8` floor. `n2`/`n8` are still measured for the local scaling curve but are
+//! not floored. The correctness floor below (every scan returns the same non-zero
+//! row count) still guards against a broken scan.
 //!
 //! Gated on `cli-helpers` only to share the profiling-harness feature set used by
 //! the other read benches (`scripts/profile.sh`); the scan path itself is core.

--- a/cqlite-core/benches/perf-gate.json
+++ b/cqlite-core/benches/perf-gate.json
@@ -37,6 +37,27 @@
     {
       "id": "write/flush",
       "threshold_pct": 10
+    },
+    {
+      "id": "read_while_write/readers6_writers2",
+      "threshold_pct": 25,
+      "_note": "reader-side median under concurrent write load; wide threshold (contention bench); p99 tail owned by A2 tail-latency harness #1563"
+    }
+  ],
+  "scaling_floors": [
+    {
+      "id": "concurrent_scan/buffered/n4",
+      "baseline_id": "concurrent_scan/buffered/n1",
+      "degree_ratio": 4,
+      "min_scaling": 1.8,
+      "_note": "throughput(n4)/throughput(n1)=degree_ratio*median(n1)/median(n4); healthy≈2.98, serialized≈1.0 → floor 1.8 leaves CI-runner headroom (issue #1564)"
+    },
+    {
+      "id": "concurrent_scan/mmap/n4",
+      "baseline_id": "concurrent_scan/mmap/n1",
+      "degree_ratio": 4,
+      "min_scaling": 1.8,
+      "_note": "throughput(n4)/throughput(n1)=degree_ratio*median(n1)/median(n4); healthy≈3.19, serialized≈1.0 → floor 1.8 leaves CI-runner headroom (issue #1564)"
     }
   ]
 }

--- a/cqlite-core/benches/read_while_write.rs
+++ b/cqlite-core/benches/read_while_write.rs
@@ -36,7 +36,9 @@
 //! `cqlite-core/benches/perf-gate.json` with a wide 25% threshold (contention
 //! bench). The *correctness* floors (every scan returns the same non-zero row
 //! count; writers actually ingested) still guard against a broken scan or a
-//! wedged writer.
+//! wedged writer. A writer-readiness barrier holds the readers' timed scans until
+//! every writer is actively ingesting, so the gated median always reflects latency
+//! under live write contention rather than an uncontended window.
 //!
 //! Gated on `cli-helpers` + `write-support` (the read fixture loader needs the
 //! former, the `WriteEngine` the latter). Under default features the bench
@@ -69,7 +71,7 @@ const SCANS_PER_READER: usize = 8;
 #[cfg(all(feature = "cli-helpers", feature = "write-support"))]
 fn bench_read_while_write(c: &mut Criterion) {
     use criterion::black_box;
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::Arc;
     use std::time::{Duration, Instant};
 
@@ -118,6 +120,13 @@ fn bench_read_while_write(c: &mut Criterion) {
                     // them once the readers finish so a slow writer cannot
                     // pin the iteration open.
                     let stop = Arc::new(AtomicBool::new(false));
+                    // Readiness barrier: each writer bumps this after its first
+                    // ingest; the driver waits for all WRITERS before starting the
+                    // readers' timed scans, so the measured window genuinely
+                    // overlaps sustained write load (issue #1564 roborev — a
+                    // no-overlap iteration would measure an artificially fast,
+                    // uncontended median and could mask a regression).
+                    let ready = Arc::new(AtomicUsize::new(0));
 
                     // Spawn sustained-ingest writers, each on its own engine
                     // + temp dir (WAL off → pure CPU/memtable allocation, the
@@ -125,6 +134,7 @@ fn bench_read_while_write(c: &mut Criterion) {
                     let mut writer_handles = Vec::with_capacity(WRITERS);
                     for _ in 0..WRITERS {
                         let stop = Arc::clone(&stop);
+                        let ready = Arc::clone(&ready);
                         writer_handles.push(tokio::task::spawn_blocking(move || {
                             use rand::Rng;
                             let tmp = tempfile::TempDir::new()
@@ -134,14 +144,13 @@ fn bench_read_while_write(c: &mut Criterion) {
                             let mut rng = fixtures::seeded_rng();
                             let mut written = 0u64;
                             // Do-while: ingest at least once before honoring
-                            // `stop`, so a writer scheduled only after the
-                            // readers finished (and set stop=true) still ingests
-                            // once. This guarantees total_written >= WRITERS,
-                            // removing the zero-ingest scheduling race that
-                            // panicked the correctness floor below. Measurement
-                            // semantics are unchanged: in the common case the
-                            // writer still sustain-ingests for the whole reader
-                            // window.
+                            // `stop`, then signal readiness. This guarantees
+                            // total_written >= WRITERS (removing the zero-ingest
+                            // race that panicked the correctness floor) and lets
+                            // the driver barrier below start reader timing only
+                            // once every writer is actively ingesting. Measurement
+                            // semantics are unchanged: the writer sustain-ingests
+                            // for the whole reader window.
                             loop {
                                 let id = uuid::Uuid::from_u128(rng.gen());
                                 let age: i32 = rng.gen_range(0..100);
@@ -152,12 +161,29 @@ fn bench_read_while_write(c: &mut Criterion) {
                                 );
                                 engine.execute(&stmt).expect("read_while_write ingest");
                                 written += 1;
+                                if written == 1 {
+                                    ready.fetch_add(1, Ordering::Relaxed);
+                                }
                                 if stop.load(Ordering::Relaxed) {
                                     break;
                                 }
                             }
                             written
                         }));
+                    }
+
+                    // Barrier: wait until every writer has performed its first
+                    // ingest before starting the readers, so their timed scans
+                    // overlap live write pressure. Each writer's guaranteed first
+                    // ingest makes this terminate; bounded so a wedged writer
+                    // surfaces as a panic rather than a hang.
+                    let barrier_deadline = Instant::now() + Duration::from_secs(30);
+                    while ready.load(Ordering::Relaxed) < WRITERS {
+                        assert!(
+                            Instant::now() < barrier_deadline,
+                            "read_while_write: writers did not start within 30s — wedged writer path"
+                        );
+                        tokio::time::sleep(Duration::from_micros(100)).await;
                     }
 
                     // Spawn the readers; each loops `SCANS_PER_READER` full

--- a/cqlite-core/benches/read_while_write.rs
+++ b/cqlite-core/benches/read_while_write.rs
@@ -23,17 +23,20 @@
 //! bandwidth / scheduler — exactly the contention surface #1143 is about — and
 //! never on the same files.
 //!
-//! # Not a CI gate (by design)
+//! # CI gate: strict median (Issue #1564)
 //!
 //! Tail (p99) statistics over a fixed sample are runner-noisy: p99 is dominated by
 //! the worst few samples, which on a shared CI runner are scheduler/allocator
-//! outliers unrelated to the code under test. So, exactly like `concurrent_scan`,
-//! this bench is **advisory** — it is deliberately ABSENT from
-//! `cqlite-core/benches/perf-gate.json`, so it runs under `./scripts/profile.sh`
-//! and as a local regression guard but never fails the perf-regression CI. The
-//! only hard assertions here are *correctness* floors (every scan returns the
-//! same non-zero row count; writers actually ingested), which catch a broken scan
-//! or a wedged writer far more reliably than a timing threshold would.
+//! outliers unrelated to the code under test — so the p99 is NOT gated here (it is
+//! still printed to stderr for local diagnosis, and the reader-side tail is owned
+//! by the A2 tail-latency harness, #1563). What IS gated is the machine-readable
+//! Criterion **median** for `read_while_write/readers6_writers2` — the
+//! per-iteration aggregate reader latency under write load, which is stable
+//! (tracks p50 ≈ 5 ms). It is a **strict** entry in
+//! `cqlite-core/benches/perf-gate.json` with a wide 25% threshold (contention
+//! bench). The *correctness* floors (every scan returns the same non-zero row
+//! count; writers actually ingested) still guard against a broken scan or a
+//! wedged writer.
 //!
 //! Gated on `cli-helpers` + `write-support` (the read fixture loader needs the
 //! former, the `WriteEngine` the latter). Under default features the bench
@@ -130,7 +133,16 @@ fn bench_read_while_write(c: &mut Criterion) {
                                 fixtures::open_write_engine_wal_off(tmp.path(), usize::MAX);
                             let mut rng = fixtures::seeded_rng();
                             let mut written = 0u64;
-                            while !stop.load(Ordering::Relaxed) {
+                            // Do-while: ingest at least once before honoring
+                            // `stop`, so a writer scheduled only after the
+                            // readers finished (and set stop=true) still ingests
+                            // once. This guarantees total_written >= WRITERS,
+                            // removing the zero-ingest scheduling race that
+                            // panicked the correctness floor below. Measurement
+                            // semantics are unchanged: in the common case the
+                            // writer still sustain-ingests for the whole reader
+                            // window.
+                            loop {
                                 let id = uuid::Uuid::from_u128(rng.gen());
                                 let age: i32 = rng.gen_range(0..100);
                                 let stmt = format!(
@@ -140,6 +152,9 @@ fn bench_read_while_write(c: &mut Criterion) {
                                 );
                                 engine.execute(&stmt).expect("read_while_write ingest");
                                 written += 1;
+                                if stop.load(Ordering::Relaxed) {
+                                    break;
+                                }
                             }
                             written
                         }));

--- a/openspec/changes/gate-scan-benches/design.md
+++ b/openspec/changes/gate-scan-benches/design.md
@@ -1,0 +1,121 @@
+# Design — gate-scan-benches
+
+## Context
+
+The perf gate (`scripts/ci/check_perf_regression.py`, policy `cqlite-core/benches/perf-gate.json`, driver
+`.github/workflows/perf-regression.yml`) compares each tracked bench's Criterion **median** between a PR
+baseline (`pr`) and a main baseline (`base`) measured **on the same runner**, and fails if a strict
+bench is more than `threshold_pct` slower on the PR. This "relative on one runner" model is immune to
+cross-machine variance and is why there are no committed absolute-time baselines.
+
+`concurrent_scan` and `read_while_write` were deliberately kept out of this gate because their *absolute*
+timings are runner-noisy. But that leaves concurrency-scaling and read-under-write regressions ungated.
+
+## Key decision — gate an intra-run ratio, not an absolute time
+
+The dominant `concurrent_scan` regression is **re-serialization** (a shared `Mutex` on the read path),
+which #815 explicitly removed. Its signature is unambiguous in a *ratio within a single run*:
+
+```
+scaling(n) = throughput(n) / throughput(1)
+           = (elements(n)/median(n)) / (elements(1)/median(1))
+           = (degree · rows_per_scan / median(n)) / (rows_per_scan / median(1))
+           = degree · median(1) / median(n)
+```
+
+- Healthy parallel scans: `median(n4) ≈ median(n1)` → `scaling ≈ 4` (observed: 2.98 buffered, 3.19 mmap).
+- Fully serialized (mutex): `median(n4) ≈ 4·median(n1)` → `scaling ≈ 1.0`.
+
+Because both medians come from the **same baseline on the same runner**, the machine's absolute speed
+cancels. This is exactly the property the bench doc said absolute-time gating lacked, so the "not a CI
+gate" objection does not apply to a scaling floor. The floor is evaluated on the PR (`new`) baseline
+alone — it needs no `main` baseline.
+
+### Floor value: 1.8
+
+Observed healthy scaling is ≈2.98 (buffered) / ≈3.19 (mmap); serialized collapses to ≈1.0. `1.8` sits
+below healthy with ~40% headroom for CI-runner variance (fewer cores, shared scheduler; ubuntu-latest is
+~4 vCPU) while still failing decisively against the ≈1.0 serialization signature. The floor and this
+derivation are recorded in `perf-gate.json` (`_note`) and README so a future editor understands the
+margin. The issue's specified ratio is `n4/n1`; `n2`/`n8` remain measured (for the local scaling curve)
+but are not floored.
+
+## perf-gate.json schema extension (additive)
+
+A new optional top-level array `scaling_floors`, evaluated independently of `benches`:
+
+```jsonc
+"scaling_floors": [
+  {
+    "id": "concurrent_scan/buffered/n4",       // the scaled bench (numerator degree)
+    "baseline_id": "concurrent_scan/buffered/n1", // the n=1 baseline
+    "degree_ratio": 4,                          // elements(id)/elements(baseline_id)
+    "min_scaling": 1.8,
+    "_note": "throughput(n4)/throughput(n1)=4·median(n1)/median(n4); healthy≈2.98, serialized≈1.0"
+  },
+  { "id": "concurrent_scan/mmap/n4", "baseline_id": "concurrent_scan/mmap/n1",
+    "degree_ratio": 4, "min_scaling": 1.8, "_note": "healthy≈3.19, serialized≈1.0" }
+]
+```
+
+Legacy configs without `scaling_floors` behave exactly as before (`cfg.get("scaling_floors", [])`).
+
+## check_perf_regression.py extension (additive)
+
+After the existing median-regression loop, evaluate each `scaling_floors` entry against the **`new`**
+baseline:
+
+- `m_base = _median_ns(dir, baseline_id, new)`, `m_scaled = _median_ns(dir, id, new)`.
+- If either is `None` → **SKIP** (report, never fail) — mirrors the missing-data rule so an absent
+  optional fixture (or a bench not yet on this branch) cannot fail the gate.
+- Else `scaling = degree_ratio · m_base / m_scaled`. If `scaling < min_scaling` → **FAIL** (append to
+  failures → non-zero exit). Else `ok`.
+- Print each in a clearly-labeled section (`baseline (ns)`, `scaled (ns)`, `scaling`, `floor`, status).
+- The "nothing was compared" guard is widened: it fails only when **no** median bench AND **no** scaling
+  floor could be evaluated, so a fixture that provides only scaling data still passes/fails correctly.
+
+No `unwrap`-equivalent silent paths; missing keys use `.get` with documented defaults. Pure Python,
+stdlib only (matches the existing script).
+
+## read_while_write bit-rot fix (bench code only)
+
+The writer loop `while !stop.load(...) { ingest }` lets a late-scheduled `spawn_blocking` writer observe
+`stop == true` on its first check and return `written = 0`; if both writers do, `total_written == 0`
+panics the correctness floor. Fix: make the loop do-while — **ingest once, then check `stop`** — so
+`total_written ≥ WRITERS` always. Measurement semantics are unchanged: writers still sustain-ingest for
+the whole reader window in the common case; the fix only removes the zero-ingest race. No library code
+changes.
+
+## read_while_write gated metric
+
+Criterion's median for `read_while_write/readers6_writers2` is the per-iteration aggregate reader latency
+under write load — machine-readable and stable (tracks p50 ≈ 5 ms). Gated as a standard strict median
+entry with a **wide 25% threshold** (contention bench) and a note that p99 tails belong to A2 (#1563).
+The bench keeps printing p50/p99 to stderr for local diagnosis.
+
+## Workflow wiring
+
+`.github/workflows/perf-regression.yml` currently runs `--bench read --bench write`. Add `--bench
+concurrent_scan --bench read_while_write` to **both** the PR and main invocations (features already
+include `cli-helpers,write-support`, which both benches need). concurrent_scan on `main` is unused by the
+scaling floor but is harmless and keeps the two invocations symmetric.
+
+## Alternatives considered
+
+- **Gate concurrent_scan absolute n4 time pr-vs-main** — rejected: reintroduces exactly the runner-noise
+  flakiness the bench doc (and the project's flaky-perf-gate history) warned against; a scaling ratio is
+  machine-independent.
+- **Gate read_while_write p99** — rejected: p99 is not a machine-readable Criterion metric here (stderr
+  only) and is runner-noisy; A2's harness (#1563) owns tails. Median is the honest, stable choice.
+- **Signal writer-readiness via a barrier instead of do-while** — rejected as heavier; do-while is the
+  minimal change that guarantees the correctness floor without altering measurement.
+
+## Test strategy (TDD)
+
+Extend `scripts/ci/tests/test_check_perf_regression.py` with fixture Criterion trees:
+1. **Scaling PASS**: `concurrent_scan/*/n1` & `/n4` medians giving scaling ≈3.0 → exit 0.
+2. **Scaling FAIL (red-run proof)**: `median(n4) ≈ 4·median(n1)` → scaling ≈1.0 < 1.8 → non-zero exit,
+   output names the floored bench. This is the committed, deterministic serialization-regression proof.
+3. **Scaling SKIP**: missing `n4` data → reported SKIP, never fails.
+Plus a real scratch-branch red-run (wrap the scan hot path in a `Mutex`, re-measure, show the gate reds)
+pasted in the PR for narrative.

--- a/openspec/changes/gate-scan-benches/proposal.md
+++ b/openspec/changes/gate-scan-benches/proposal.md
@@ -1,0 +1,63 @@
+## Why
+
+`cqlite-core/benches/concurrent_scan.rs` and `cqlite-core/benches/read_while_write.rs` already exist and
+measure exactly the read-path properties the July 2026 read-path audit (Epic A, #1513) cares about —
+concurrency scaling of a shared `SSTableReader` (#815/#917) and reader-side latency under concurrent
+write load (#1143) — but **neither is in `cqlite-core/benches/perf-gate.json`**. Both bench source files
+deliberately opted out with the rationale that *absolute-timing* gating is too noisy on shared CI
+runners. That rationale is correct for absolute times, but it leaves a real hole: today a concurrency
+regression (e.g. someone reintroduces a shared `Mutex` on the read path, re-serializing scans — exactly
+what #815 removed) or a reader-side regression under write contention **merges silently**.
+
+Epic A is "measurement first": no downstream optimization claim is trustworthy until the gate watches
+the path. This change closes the concurrency + read-under-write hole without reintroducing runner-noise
+flakiness, by gating a **machine-independent invariant** rather than an absolute time.
+
+Audit / measurement facts that constrain the design (baseline measured on this machine, `--sample-size
+20 --warm-up-time 1 --measurement-time 3`):
+- `concurrent_scan` throughput scaling `throughput(n4)/throughput(n1) = 4 · median(n1)/median(n4)`:
+  **buffered ≈ 2.98**, **mmap ≈ 3.19**. A shared-mutex re-serialization collapses `median(n4) → ~4·
+  median(n1)`, i.e. **scaling → ~1.0**. The *ratio within a single run* cancels machine speed, so it is
+  robust to the cross-machine variance the bench doc warned about — unlike an absolute-time comparison.
+- `read_while_write` exposes reader-side **p99 only via stderr `eprintln`** (not a machine-readable
+  Criterion metric); its Criterion **median** (per-iteration aggregate reader latency under write load)
+  is machine-readable and stable (p50 ≈ 5.0–5.4 ms across runs; p99 6–9 ms is the noisy tail).
+- `read_while_write` has a **pre-existing zero-ingest race**: readers finish and set `stop=true` before
+  both `spawn_blocking` writers are scheduled, so the `total_written > 0` correctness floor panics on
+  most runs. The bench cannot be gated until this bit-rot is fixed.
+
+## What Changes
+
+- **Add a new `scaling_floors` check to the perf gate** (`scripts/ci/check_perf_regression.py` +
+  `cqlite-core/benches/perf-gate.json`): an *intra-run* invariant `degree_ratio · median(baseline_id) /
+  median(scaled_id) ≥ min_scaling`, evaluated on the PR (`new`) baseline only. This is additive gate
+  wiring — a new check kind alongside the existing pr-vs-main median-regression check.
+- **Gate `concurrent_scan` n4/n1 scaling** for both backends: `concurrent_scan/buffered/n4` vs
+  `.../n1` and `concurrent_scan/mmap/n4` vs `.../n1`, `degree_ratio: 4`, **`min_scaling: 1.8`** —
+  set well below observed healthy (≈2.98/3.19) for CI-runner headroom, well above the serialized-
+  regression value (≈1.0) so it fails decisively. The floor and its derivation are documented in the
+  policy file and README.
+- **Gate `read_while_write` median** as a standard strict median-regression entry
+  (`read_while_write/readers6_writers2`, `threshold_pct: 25`) with a note that the **p99 tail is owned
+  by A2's tail-latency harness (#1563)**; the gate watches the stable median, not the noisy tail.
+- **Fix the `read_while_write` zero-ingest bit-rot** minimally: each writer ingests at least once before
+  honoring `stop` (a do-while), guaranteeing `total_written ≥ WRITERS`. This does not change what the
+  bench measures (reader-side latency under sustained write contention).
+- **Wire both benches into `.github/workflows/perf-regression.yml`**: add `--bench concurrent_scan
+  --bench read_while_write` to both the PR and main Criterion runs so the gate has data.
+- **Demonstrated red-run** (committed as a deterministic test + shown in the PR): synthetic serialized
+  medians (`median(n4) ≈ 4·median(n1)`) drive scaling to ~1.0 and the gate exits non-zero.
+- **Docs**: `cqlite-core/benches/README.md` gains a "concurrency scaling floor" subsection; the two
+  bench module docs are updated to reflect that they are now gated (scaling floor / strict median),
+  superseding the "Not a CI gate (by design)" note.
+
+## Non-goals
+
+- **No read-path / write-path production-code changes.** The only source edit is the `read_while_write`
+  bench's writer-loop robustness fix (bench code, not library code); everything else is gate wiring,
+  policy, tests, and docs.
+- **No p99/tail gating.** The reader-side p99 is A2's (#1563) harness responsibility; this gate uses the
+  machine-readable median with a documented note.
+- **No absolute-time gating of the concurrency benches** — the whole point is to gate a machine-
+  independent *ratio* (scaling floor), not committed absolute timings.
+- **No change to the existing read/write median-regression benches or their thresholds.**

--- a/openspec/changes/gate-scan-benches/specs/read-perf-gate/spec.md
+++ b/openspec/changes/gate-scan-benches/specs/read-perf-gate/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: The perf gate enforces a concurrent-scan scaling floor
+The performance regression gate SHALL enforce a machine-independent concurrency-scaling floor on the
+existing `concurrent_scan` benchmark for each backend (`buffered` and `mmap`): the ratio
+`throughput(n4)/throughput(n1)`, computed within a single benchmark run as `degree_ratio ·
+median(n1) / median(n4)`, SHALL be at least a configured `min_scaling`. The floor SHALL be evaluated on
+the PR (`new`) baseline alone (it does not compare against `main`), so it is immune to cross-machine
+timing variance. `cqlite-core/benches/perf-gate.json` SHALL carry the floor policy in a `scaling_floors`
+array, and the floor value and its derivation SHALL be documented.
+
+#### Scenario: A serialized read path reds the scaling floor
+- **WHEN** the `concurrent_scan` n4 median is approximately four times the n1 median (the signature of a
+  re-serialized scan path, e.g. a reintroduced shared `Mutex`), so scaling ≈ 1.0
+- **THEN** `scripts/ci/check_perf_regression.py` reports the `concurrent_scan/*/n4` scaling entry below
+  its floor and exits non-zero
+
+#### Scenario: A healthy parallel scan passes the floor
+- **WHEN** the `concurrent_scan` n4 and n1 medians yield scaling at or above `min_scaling` (healthy
+  parallel scans measure ≈ 3.0)
+- **THEN** the scaling entry is reported `ok` and does not fail the gate
+
+#### Scenario: Absent concurrent-scan data skips the floor without failing
+- **WHEN** the `concurrent_scan` n1 or n4 median is missing from the evaluated baseline
+- **THEN** that scaling entry is reported SKIP and does not fail the gate
+
+### Requirement: The perf gate tracks the read-while-write median under concurrent writes
+The performance regression gate SHALL track the existing `read_while_write/readers6_writers2` benchmark
+as a strict median-regression entry in `cqlite-core/benches/perf-gate.json` with a documented threshold,
+so a reader-side regression under concurrent write load can no longer merge silently. The gated metric
+SHALL be the Criterion median (reader-side aggregate latency under write load); the reader-side p99 tail
+is explicitly out of scope for this gate and owned by the A2 tail-latency harness (#1563), noted in the
+policy.
+
+#### Scenario: read_while_write is a strict gated bench
+- **WHEN** `cqlite-core/benches/perf-gate.json` is read
+- **THEN** it contains a `read_while_write/readers6_writers2` entry with a `threshold_pct`
+- **AND** the entry is not in `advisory_benches` (it is strict)
+
+#### Scenario: The gate has data for both concurrency benches
+- **WHEN** `.github/workflows/perf-regression.yml` runs the Criterion benchmarks
+- **THEN** both `concurrent_scan` and `read_while_write` are included in the PR and main `cargo bench`
+  invocations, so the gate script has medians to evaluate
+
+### Requirement: The read-while-write bench never spuriously reports zero writer ingest
+The `read_while_write` benchmark SHALL guarantee that each writer task performs at least one ingest
+before honoring the stop signal, so the bench's writers-ingested correctness floor cannot panic due to a
+scheduling race, without changing what the bench measures (reader-side latency under sustained write
+contention).
+
+#### Scenario: A late-scheduled writer still satisfies the correctness floor
+- **WHEN** a writer task is scheduled only after the readers finish and set the stop flag
+- **THEN** the writer still performs at least one ingest, so `total_written ≥ WRITERS` and the bench does
+  not panic

--- a/openspec/changes/gate-scan-benches/specs/read-perf-gate/spec.md
+++ b/openspec/changes/gate-scan-benches/specs/read-perf-gate/spec.md
@@ -7,7 +7,11 @@ existing `concurrent_scan` benchmark for each backend (`buffered` and `mmap`): t
 median(n1) / median(n4)`, SHALL be at least a configured `min_scaling`. The floor SHALL be evaluated on
 the PR (`new`) baseline alone (it does not compare against `main`), so it is immune to cross-machine
 timing variance. `cqlite-core/benches/perf-gate.json` SHALL carry the floor policy in a `scaling_floors`
-array, and the floor value and its derivation SHALL be documented.
+array, and the floor value and its derivation SHALL be documented. Because a scaling floor is intra-run
+(its data is always present on any run that benches the target), missing data for a configured floor
+SHALL fail the gate loudly rather than silently skip it — so a typo'd id, an omitted `--bench`, or a
+bench that produced no data cannot quietly disable the gate. A floor MAY opt into skip-on-absent with
+`"optional": true` for a genuinely optional fixture.
 
 #### Scenario: A serialized read path reds the scaling floor
 - **WHEN** the `concurrent_scan` n4 median is approximately four times the n1 median (the signature of a
@@ -20,9 +24,15 @@ array, and the floor value and its derivation SHALL be documented.
   parallel scans measure ≈ 3.0)
 - **THEN** the scaling entry is reported `ok` and does not fail the gate
 
-#### Scenario: Absent concurrent-scan data skips the floor without failing
-- **WHEN** the `concurrent_scan` n1 or n4 median is missing from the evaluated baseline
-- **THEN** that scaling entry is reported SKIP and does not fail the gate
+#### Scenario: Missing required scaling data fails the gate loudly
+- **WHEN** the n1 or n4 median for a configured (non-optional) scaling floor is missing from the
+  evaluated baseline
+- **THEN** `scripts/ci/check_perf_regression.py` reports the entry as MISSING DATA and exits non-zero
+  (it does not silently skip and pass)
+
+#### Scenario: An optional scaling floor skips when absent
+- **WHEN** a scaling floor marked `"optional": true` has no data in the evaluated baseline
+- **THEN** that entry is reported SKIP and does not fail the gate
 
 ### Requirement: The perf gate tracks the read-while-write median under concurrent writes
 The performance regression gate SHALL track the existing `read_while_write/readers6_writers2` benchmark
@@ -42,13 +52,19 @@ policy.
 - **THEN** both `concurrent_scan` and `read_while_write` are included in the PR and main `cargo bench`
   invocations, so the gate script has medians to evaluate
 
-### Requirement: The read-while-write bench never spuriously reports zero writer ingest
+### Requirement: The read-while-write bench guarantees write overlap and never reports zero writer ingest
 The `read_while_write` benchmark SHALL guarantee that each writer task performs at least one ingest
-before honoring the stop signal, so the bench's writers-ingested correctness floor cannot panic due to a
-scheduling race, without changing what the bench measures (reader-side latency under sustained write
-contention).
+before honoring the stop signal (so the writers-ingested correctness floor cannot panic on a scheduling
+race), AND SHALL not begin the readers' timed scans until every writer is actively ingesting (so the
+measured reader-side latency genuinely overlaps sustained write load rather than an artificially
+uncontended window), without changing what the bench measures.
 
 #### Scenario: A late-scheduled writer still satisfies the correctness floor
 - **WHEN** a writer task is scheduled only after the readers finish and set the stop flag
 - **THEN** the writer still performs at least one ingest, so `total_written ≥ WRITERS` and the bench does
   not panic
+
+#### Scenario: Reader timing overlaps live write pressure
+- **WHEN** the bench measures an iteration
+- **THEN** the readers' timed scans begin only after all `WRITERS` writers have performed their first
+  ingest (a readiness barrier), so the gated median reflects reader latency under active write contention

--- a/openspec/changes/gate-scan-benches/tasks.md
+++ b/openspec/changes/gate-scan-benches/tasks.md
@@ -1,0 +1,44 @@
+# Tasks — gate-scan-benches
+
+## 1. TDD tests first (must red before the code exists)
+- [ ] 1.1 Add fixture Criterion trees under `scripts/ci/tests/fixtures/`:
+      `scaling_floor_pass` (`concurrent_scan/{buffered,mmap}/{n1,n4}/pr/estimates.json` with
+      `median(n4)≈median(n1)` → scaling≈3.0) and `scaling_floor_fail` (`median(n4)≈4·median(n1)` →
+      scaling≈1.0). Only `pr` baseline needed (scaling is intra-run).
+- [ ] 1.2 Add tests to `scripts/ci/tests/test_check_perf_regression.py`: scaling PASS → exit 0;
+      scaling FAIL → non-zero exit AND output names `concurrent_scan/*/n4`; missing-`n4` → SKIP (exit 0).
+      These fail today (no `scaling_floors` support) — the red-run proof.
+
+## 2. Gate machinery (additive)
+- [ ] 2.1 `cqlite-core/benches/perf-gate.json`: add `scaling_floors` array (buffered + mmap n4/n1,
+      `degree_ratio:4`, `min_scaling:1.8`, `_note`s); add `read_while_write/readers6_writers2` to
+      `benches` with `threshold_pct:25` and a `_note` (p99 owned by A2 #1563).
+- [ ] 2.2 `scripts/ci/check_perf_regression.py`: evaluate `scaling_floors` on the `new` baseline
+      (`scaling = degree_ratio·median(baseline_id)/median(id)`); SKIP on missing data, FAIL when
+      `scaling < min_scaling`; print a labeled section; widen the "nothing compared" guard to count
+      scaling evaluations. `cfg.get("scaling_floors", [])` so legacy configs are unaffected.
+
+## 3. Bench bit-rot fix (bench code only, no library change)
+- [ ] 3.1 `cqlite-core/benches/read_while_write.rs`: make the writer loop do-while (ingest once before
+      honoring `stop`) so `total_written ≥ WRITERS`; keep the correctness-floor assert. Do not change
+      readers, sample count, or the measured metric.
+
+## 4. Workflow wiring
+- [ ] 4.1 `.github/workflows/perf-regression.yml`: add `--bench concurrent_scan --bench read_while_write`
+      to BOTH the PR and main `cargo bench` invocations.
+
+## 5. Docs
+- [ ] 5.1 `cqlite-core/benches/README.md`: add a "concurrency scaling floor" subsection (formula, the
+      1.8 floor + derivation, read_while_write median-gated with p99→A2 note); list both benches as gated.
+- [ ] 5.2 Update the module docs of `concurrent_scan.rs` and `read_while_write.rs`: replace the "Not a CI
+      gate (by design)" note with the scaling-floor / strict-median gating reality.
+
+## 6. Validation
+- [ ] 6.1 New Python tests green: `bindings/python/.venv/bin/pytest scripts/ci/tests/test_check_perf_regression.py -v`.
+- [ ] 6.2 Both benches compile + run against fetched datasets (`CQLITE_DATASETS_ROOT`); record the
+      current-main baseline scaling numbers in the PR.
+- [ ] 6.3 Real red-run: wrap the scan hot path in a `Mutex` on a scratch branch, re-measure, show the
+      scaling floor reds (non-zero exit). Paste in the PR. Discard the scratch change.
+- [ ] 6.4 `scripts/agent-gate.sh` PASS — paste the AGENT-GATE SUMMARY block verbatim.
+- [ ] 6.5 `RUSTFLAGS="-D warnings"` clean; no `unwrap()`/`expect()` in library code (bench code exempt but
+      keep the existing style).

--- a/scripts/ci/check_perf_regression.py
+++ b/scripts/ci/check_perf_regression.py
@@ -144,9 +144,21 @@ def main(argv):
     # (e.g. a reintroduced shared Mutex) collapses median(id)→≈degree_ratio*
     # median(baseline_id), driving scaling→≈1.0. A `scaling` below `min_scaling`
     # fails the gate. Legacy configs without `scaling_floors` are unaffected.
+    #
+    # Missing data for a configured floor is a FAILURE, not a SKIP (issue #1564
+    # roborev): the whole point of a scaling gate is to catch regressions, so a
+    # typo'd id, an omitted `--bench`, or a bench that produced no data must NOT
+    # silently disable the gate. Unlike the pr-vs-main median benches (which
+    # legitimately SKIP a bench absent from `main`), a scaling floor is intra-run,
+    # so its data is always present on any run that benches the target. An entry
+    # may opt into skip-on-absent with `"optional": true` (for a genuinely
+    # optional fixture, mirroring the read/get_partition_bti convention).
     # -----------------------------------------------------------------------
     scaling_floors = cfg.get("scaling_floors", [])
     scaling_evaluated = 0
+    # Reason text for each scaling-floor failure, keyed by bench id (the failures
+    # list carries only (id, None) for scaling entries).
+    scaling_fail_reason = {}
     if scaling_floors:
         print(
             f"Concurrency scaling floors (evaluated on '{new_baseline}' baseline):\n"
@@ -173,10 +185,24 @@ def main(argv):
                 missing.append(baseline_id)
             if m_scaled is None:
                 missing.append(bench_id)
-            print(
-                f"{bench_id:<{col_w}} {'-':>16} {'-':>16} {'-':>9}  "
-                f"{min_scaling:>7g}  SKIP (no data in '{new_baseline}': {', '.join(missing)})"
-            )
+            missing_txt = ", ".join(missing)
+            if entry.get("optional", False):
+                # Genuinely optional fixture — skip without failing.
+                print(
+                    f"{bench_id:<{col_w}} {'-':>16} {'-':>16} {'-':>9}  "
+                    f"{min_scaling:>7g}  SKIP (optional, no data in '{new_baseline}': {missing_txt})"
+                )
+            else:
+                # Required floor with no data — fail loudly rather than silently
+                # disabling the gate.
+                print(
+                    f"{bench_id:<{col_w}} {'-':>16} {'-':>16} {'-':>9}  "
+                    f"{min_scaling:>7g}  MISSING DATA (required; '{new_baseline}': {missing_txt})"
+                )
+                failures.append((bench_id, None))
+                scaling_fail_reason[bench_id] = (
+                    f"required scaling data missing in '{new_baseline}': {missing_txt}"
+                )
             continue
 
         scaling_evaluated += 1
@@ -184,6 +210,7 @@ def main(argv):
         if scaling < min_scaling:
             status = f"REGRESSION (scaling < {min_scaling:g})"
             failures.append((bench_id, None))
+            scaling_fail_reason[bench_id] = f"below scaling floor: {min_scaling:g}"
         else:
             status = "ok"
         print(
@@ -210,13 +237,10 @@ def main(argv):
         print(f"❌ {len(failures)} bench(es) regressed past their threshold:")
         for bench, ratio in failures:
             if ratio is None:
-                # Scaling-floor failure (ratio is not a pr-vs-main delta).
-                sf_entry = next(
-                    (s for s in scaling_floors if s.get("id") == bench), {}
-                )
-                floor = sf_entry.get("min_scaling")
-                floor_txt = f"scaling floor: {float(floor):g}" if floor is not None else "scaling floor"
-                print(f"   - {bench}: below scaling floor  ({floor_txt})")
+                # Scaling-floor failure (ratio is not a pr-vs-main delta): either
+                # below the floor or required data missing.
+                reason = scaling_fail_reason.get(bench, "scaling floor")
+                print(f"   - {bench}: {reason}")
             else:
                 bc_entry = next((b for b in bench_configs if b["id"] == bench), {})
                 tpct = bc_entry.get("threshold_pct", default_threshold_pct)

--- a/scripts/ci/check_perf_regression.py
+++ b/scripts/ci/check_perf_regression.py
@@ -221,9 +221,16 @@ def main(argv):
     if scaling_floors:
         print()
 
-    if compared == 0 and scaling_evaluated == 0:
-        # Nothing could be compared or evaluated (e.g. baselines never produced)
-        # — surface loudly rather than passing silently.
+    # Median-bench protection is INDEPENDENT of the scaling floors (issue #1564
+    # roborev): if median benches are configured but none could be compared, that
+    # is missing baseline data and must fail — a passing scaling floor must not
+    # mask it.
+    if bench_configs and compared == 0:
+        print("❌ No median benches could be compared (baseline data missing).")
+        return 1
+    # Nothing configured at all, or a scaling-only config whose floors all skipped
+    # — surface loudly rather than passing silently.
+    if not bench_configs and scaling_evaluated == 0:
         print("❌ No tracked benches could be compared (no baseline data found).")
         return 1
 

--- a/scripts/ci/check_perf_regression.py
+++ b/scripts/ci/check_perf_regression.py
@@ -131,9 +131,72 @@ def main(argv):
 
     print()
 
-    if compared == 0:
-        # No bench could be compared (e.g. baselines never produced) — surface
-        # loudly rather than passing silently.
+    # -----------------------------------------------------------------------
+    # Concurrency scaling floors (Issue #1564)
+    #
+    # A machine-independent intra-run invariant, evaluated on the `new` (PR)
+    # baseline alone (both medians come from the same run on the same runner, so
+    # the machine's absolute speed cancels):
+    #
+    #     scaling = degree_ratio * median(baseline_id) / median(id)
+    #
+    # Healthy parallel scans measure ≈degree_ratio; a re-serialized read path
+    # (e.g. a reintroduced shared Mutex) collapses median(id)→≈degree_ratio*
+    # median(baseline_id), driving scaling→≈1.0. A `scaling` below `min_scaling`
+    # fails the gate. Legacy configs without `scaling_floors` are unaffected.
+    # -----------------------------------------------------------------------
+    scaling_floors = cfg.get("scaling_floors", [])
+    scaling_evaluated = 0
+    if scaling_floors:
+        print(
+            f"Concurrency scaling floors (evaluated on '{new_baseline}' baseline):\n"
+            f"  scaling = degree_ratio * median(baseline) / median(scaled); "
+            f"fails below floor.\n"
+        )
+        sh = (
+            f"{'scaling entry':<{col_w}} {'baseline (ns)':>16} {'scaled (ns)':>16} "
+            f"{'scaling':>9}  {'floor':>7}  status"
+        )
+        print(sh)
+        print("-" * len(sh))
+
+    for entry in scaling_floors:
+        bench_id = entry.get("id", "")
+        baseline_id = entry.get("baseline_id", "")
+        m_base = _median_ns(criterion_dir, baseline_id, new_baseline)
+        m_scaled = _median_ns(criterion_dir, bench_id, new_baseline)
+        min_scaling = float(entry.get("min_scaling", 0.0))
+
+        if m_base is None or m_scaled is None:
+            missing = []
+            if m_base is None:
+                missing.append(baseline_id)
+            if m_scaled is None:
+                missing.append(bench_id)
+            print(
+                f"{bench_id:<{col_w}} {'-':>16} {'-':>16} {'-':>9}  "
+                f"{min_scaling:>7g}  SKIP (no data in '{new_baseline}': {', '.join(missing)})"
+            )
+            continue
+
+        scaling_evaluated += 1
+        scaling = float(entry.get("degree_ratio", 1)) * m_base / m_scaled
+        if scaling < min_scaling:
+            status = f"REGRESSION (scaling < {min_scaling:g})"
+            failures.append((bench_id, None))
+        else:
+            status = "ok"
+        print(
+            f"{bench_id:<{col_w}} {m_base:>16.0f} {m_scaled:>16.0f} "
+            f"{scaling:>9.2f}  {min_scaling:>7g}  {status}"
+        )
+
+    if scaling_floors:
+        print()
+
+    if compared == 0 and scaling_evaluated == 0:
+        # Nothing could be compared or evaluated (e.g. baselines never produced)
+        # — surface loudly rather than passing silently.
         print("❌ No tracked benches could be compared (no baseline data found).")
         return 1
 
@@ -146,9 +209,18 @@ def main(argv):
     if failures:
         print(f"❌ {len(failures)} bench(es) regressed past their threshold:")
         for bench, ratio in failures:
-            bc_entry = next((b for b in bench_configs if b["id"] == bench), {})
-            tpct = bc_entry.get("threshold_pct", default_threshold_pct)
-            print(f"   - {bench}: {ratio * 100:+.1f}%  (threshold: {tpct:g}%)")
+            if ratio is None:
+                # Scaling-floor failure (ratio is not a pr-vs-main delta).
+                sf_entry = next(
+                    (s for s in scaling_floors if s.get("id") == bench), {}
+                )
+                floor = sf_entry.get("min_scaling")
+                floor_txt = f"scaling floor: {float(floor):g}" if floor is not None else "scaling floor"
+                print(f"   - {bench}: below scaling floor  ({floor_txt})")
+            else:
+                bc_entry = next((b for b in bench_configs if b["id"] == bench), {})
+                tpct = bc_entry.get("threshold_pct", default_threshold_pct)
+                print(f"   - {bench}: {ratio * 100:+.1f}%  (threshold: {tpct:g}%)")
         print(
             "\nIf this slowdown is expected/intended, justify it in the PR. To change "
             "the threshold or tracked set, edit cqlite-core/benches/perf-gate.json."

--- a/scripts/ci/tests/fixtures/scaling_floor_fail/concurrent_scan/buffered/n1/pr/estimates.json
+++ b/scripts/ci/tests/fixtures/scaling_floor_fail/concurrent_scan/buffered/n1/pr/estimates.json
@@ -1,0 +1,1 @@
+{"median": {"point_estimate": 2400000.0}}

--- a/scripts/ci/tests/fixtures/scaling_floor_fail/concurrent_scan/buffered/n4/pr/estimates.json
+++ b/scripts/ci/tests/fixtures/scaling_floor_fail/concurrent_scan/buffered/n4/pr/estimates.json
@@ -1,0 +1,1 @@
+{"median": {"point_estimate": 9600000.0}}

--- a/scripts/ci/tests/fixtures/scaling_floor_fail/concurrent_scan/mmap/n1/pr/estimates.json
+++ b/scripts/ci/tests/fixtures/scaling_floor_fail/concurrent_scan/mmap/n1/pr/estimates.json
@@ -1,0 +1,1 @@
+{"median": {"point_estimate": 2400000.0}}

--- a/scripts/ci/tests/fixtures/scaling_floor_fail/concurrent_scan/mmap/n4/pr/estimates.json
+++ b/scripts/ci/tests/fixtures/scaling_floor_fail/concurrent_scan/mmap/n4/pr/estimates.json
@@ -1,0 +1,1 @@
+{"median": {"point_estimate": 3000000.0}}

--- a/scripts/ci/tests/fixtures/scaling_floor_pass/concurrent_scan/buffered/n1/pr/estimates.json
+++ b/scripts/ci/tests/fixtures/scaling_floor_pass/concurrent_scan/buffered/n1/pr/estimates.json
@@ -1,0 +1,1 @@
+{"median": {"point_estimate": 2400000.0}}

--- a/scripts/ci/tests/fixtures/scaling_floor_pass/concurrent_scan/buffered/n4/pr/estimates.json
+++ b/scripts/ci/tests/fixtures/scaling_floor_pass/concurrent_scan/buffered/n4/pr/estimates.json
@@ -1,0 +1,1 @@
+{"median": {"point_estimate": 3200000.0}}

--- a/scripts/ci/tests/fixtures/scaling_floor_pass/concurrent_scan/mmap/n1/pr/estimates.json
+++ b/scripts/ci/tests/fixtures/scaling_floor_pass/concurrent_scan/mmap/n1/pr/estimates.json
@@ -1,0 +1,1 @@
+{"median": {"point_estimate": 2400000.0}}

--- a/scripts/ci/tests/fixtures/scaling_floor_pass/concurrent_scan/mmap/n4/pr/estimates.json
+++ b/scripts/ci/tests/fixtures/scaling_floor_pass/concurrent_scan/mmap/n4/pr/estimates.json
@@ -1,0 +1,1 @@
+{"median": {"point_estimate": 3000000.0}}

--- a/scripts/ci/tests/fixtures/scaling_floor_skip/concurrent_scan/buffered/n1/pr/estimates.json
+++ b/scripts/ci/tests/fixtures/scaling_floor_skip/concurrent_scan/buffered/n1/pr/estimates.json
@@ -1,0 +1,1 @@
+{"median": {"point_estimate": 2400000.0}}

--- a/scripts/ci/tests/fixtures/scaling_floor_skip/concurrent_scan/mmap/n1/pr/estimates.json
+++ b/scripts/ci/tests/fixtures/scaling_floor_skip/concurrent_scan/mmap/n1/pr/estimates.json
@@ -1,0 +1,1 @@
+{"median": {"point_estimate": 2400000.0}}

--- a/scripts/ci/tests/fixtures/scaling_floor_skip/concurrent_scan/mmap/n4/pr/estimates.json
+++ b/scripts/ci/tests/fixtures/scaling_floor_skip/concurrent_scan/mmap/n4/pr/estimates.json
@@ -1,0 +1,1 @@
+{"median": {"point_estimate": 3000000.0}}

--- a/scripts/ci/tests/test_check_perf_regression.py
+++ b/scripts/ci/tests/test_check_perf_regression.py
@@ -251,7 +251,7 @@ class TestScalingFloor:
         Here the buffered n4 median is absent (required buffered floor → MISSING
         DATA → fail) while the mmap floor is present and healthy.
         """
-        exit_code = _run(_CRIT_SCALING_SKIP)
+        exit_code = _run_scaling_only(_CRIT_SCALING_SKIP)
         assert exit_code != 0, (
             "Expected non-zero exit when a required scaling floor's data is "
             f"missing (must not silently skip), but got exit code {exit_code}."

--- a/scripts/ci/tests/test_check_perf_regression.py
+++ b/scripts/ci/tests/test_check_perf_regression.py
@@ -48,6 +48,13 @@ _CRIT_CPU_REGRESSION = os.path.join(_FIXTURES, "cpu_regression")
 _CRIT_ADVISORY_ONLY = os.path.join(_FIXTURES, "criterion_advisory_only")
 _CRIT_WAL_OFF_REGRESSION = os.path.join(_FIXTURES, "criterion_wal_off_regression")
 
+# Concurrency scaling-floor scenarios (Issue #1564). These trees carry only the
+# `pr` baseline because the scaling floor is an *intra-run* ratio
+# (degree_ratio · median(n1)/median(n4)) evaluated on the PR baseline alone.
+_CRIT_SCALING_PASS = os.path.join(_FIXTURES, "scaling_floor_pass")
+_CRIT_SCALING_FAIL = os.path.join(_FIXTURES, "scaling_floor_fail")
+_CRIT_SCALING_SKIP = os.path.join(_FIXTURES, "scaling_floor_skip")
+
 
 # ---------------------------------------------------------------------------
 # Helper
@@ -153,3 +160,50 @@ class TestMissingDataSkipped:
         assert exit_code != 0, (
             "Expected non-zero exit when no baseline data exists (should surface loudly)."
         )
+
+
+class TestScalingFloor:
+    """Concurrency scaling floor (Issue #1564).
+
+    scaling = degree_ratio · median(n1) / median(n4), evaluated on the `pr`
+    baseline. Healthy parallel scans measure ≈3.0; a re-serialized read path
+    (shared Mutex) collapses median(n4)→≈4·median(n1) so scaling→≈1.0, below the
+    1.8 floor in perf-gate.json.
+    """
+
+    def test_healthy_scaling_passes(self, capsys):
+        """scaling ≈3.0 (buffered) / ≈3.2 (mmap) is above the floor → exit 0."""
+        exit_code = _run(_CRIT_SCALING_PASS)
+        assert exit_code == 0, (
+            "Expected zero exit when concurrent_scan scaling is healthy (≈3.0), "
+            f"but got exit code {exit_code}."
+        )
+
+    def test_serialized_scaling_fails(self, capsys):
+        """median(n4) ≈ 4·median(n1) → scaling ≈1.0 < 1.8 → non-zero exit."""
+        exit_code = _run(_CRIT_SCALING_FAIL)
+        assert exit_code != 0, (
+            "Expected non-zero exit when concurrent_scan n4 median is ~4x the n1 "
+            "median (re-serialized scan path, scaling ≈1.0), but got exit code 0."
+        )
+
+    def test_serialized_scaling_output_names_bench(self, capsys):
+        """The failure output must name the floored scaling entry."""
+        _run(_CRIT_SCALING_FAIL)
+        captured = capsys.readouterr()
+        assert "concurrent_scan/buffered/n4" in captured.out
+
+    def test_missing_n4_skips_without_failing(self, capsys):
+        """A scaling entry with a missing n4 median is SKIP, not a failure.
+
+        The buffered n4 median is absent here (buffered floor → SKIP) while the
+        mmap floor is present and healthy, so the gate still exits 0.
+        """
+        exit_code = _run(_CRIT_SCALING_SKIP)
+        assert exit_code == 0, (
+            "Expected zero exit when a scaling entry's n4 data is missing (SKIP), "
+            f"but got exit code {exit_code}."
+        )
+        captured = capsys.readouterr()
+        assert "concurrent_scan/buffered/n4" in captured.out
+        assert "SKIP" in captured.out

--- a/scripts/ci/tests/test_check_perf_regression.py
+++ b/scripts/ci/tests/test_check_perf_regression.py
@@ -60,18 +60,48 @@ _CRIT_SCALING_SKIP = os.path.join(_FIXTURES, "scaling_floor_skip")
 
 
 # ---------------------------------------------------------------------------
-# Helper
+# Helpers
+#
+# The real perf-gate.json now carries BOTH median `benches` and required
+# `scaling_floors`. Each test class exercises one concern in isolation by running
+# the real config with the other section stripped, so median fixtures need no
+# concurrent_scan data and scaling fixtures need no median data. A dedicated guard
+# test uses the FULL config to prove the two checks are independent.
 # ---------------------------------------------------------------------------
+import json  # noqa: E402
+import tempfile  # noqa: E402
+
+
+def _load_gate():
+    with open(_GATE_JSON) as fh:
+        return json.load(fh)
+
+
+def _run_with_config(criterion_dir, cfg, new_baseline="pr", base_baseline="base"):
+    fd, path = tempfile.mkstemp(suffix=".json")
+    try:
+        with os.fdopen(fd, "w") as fh:
+            json.dump(cfg, fh)
+        return main(
+            ["check_perf_regression.py", criterion_dir, new_baseline, base_baseline, path]
+        )
+    finally:
+        os.unlink(path)
+
+
 def _run(criterion_dir, new_baseline="pr", base_baseline="base"):
-    """Invoke main() with the real perf-gate.json and return the exit code."""
-    argv = [
-        "check_perf_regression.py",
-        criterion_dir,
-        new_baseline,
-        base_baseline,
-        _GATE_JSON,
-    ]
-    return main(argv)
+    """Median-bench view: real config with `scaling_floors` stripped."""
+    cfg = _load_gate()
+    cfg["scaling_floors"] = []
+    return _run_with_config(criterion_dir, cfg, new_baseline, base_baseline)
+
+
+def _run_scaling_only(criterion_dir, new_baseline="pr", base_baseline="base"):
+    """Scaling-floor view: real config with median `benches` stripped."""
+    cfg = _load_gate()
+    cfg["benches"] = []
+    cfg["advisory_benches"] = []
+    return _run_with_config(criterion_dir, cfg, new_baseline, base_baseline)
 
 
 # ---------------------------------------------------------------------------
@@ -176,7 +206,7 @@ class TestScalingFloor:
 
     def test_healthy_scaling_passes(self, capsys):
         """scaling ≈3.0 (buffered) / ≈3.2 (mmap) is above the floor → exit 0."""
-        exit_code = _run(_CRIT_SCALING_PASS)
+        exit_code = _run_scaling_only(_CRIT_SCALING_PASS)
         assert exit_code == 0, (
             "Expected zero exit when concurrent_scan scaling is healthy (≈3.0), "
             f"but got exit code {exit_code}."
@@ -184,7 +214,7 @@ class TestScalingFloor:
 
     def test_serialized_scaling_fails(self, capsys):
         """median(n4) ≈ 4·median(n1) → scaling ≈1.0 < 1.8 → non-zero exit."""
-        exit_code = _run(_CRIT_SCALING_FAIL)
+        exit_code = _run_scaling_only(_CRIT_SCALING_FAIL)
         assert exit_code != 0, (
             "Expected non-zero exit when concurrent_scan n4 median is ~4x the n1 "
             "median (re-serialized scan path, scaling ≈1.0), but got exit code 0."
@@ -192,9 +222,25 @@ class TestScalingFloor:
 
     def test_serialized_scaling_output_names_bench(self, capsys):
         """The failure output must name the floored scaling entry."""
-        _run(_CRIT_SCALING_FAIL)
+        _run_scaling_only(_CRIT_SCALING_FAIL)
         captured = capsys.readouterr()
         assert "concurrent_scan/buffered/n4" in captured.out
+
+    def test_passing_scaling_does_not_mask_missing_median(self, capsys):
+        """A passing scaling floor must NOT mask uncompared median benches.
+
+        Runs the FULL real config (median benches + scaling floors) against a
+        fixture that has only concurrent_scan data: the scaling floors pass, but
+        every configured median bench is uncompared → the gate must still fail
+        (issue #1564 roborev: the two checks are independent).
+        """
+        exit_code = main(
+            ["check_perf_regression.py", _CRIT_SCALING_PASS, "pr", "base", _GATE_JSON]
+        )
+        assert exit_code != 0, (
+            "Expected non-zero exit: median benches are configured but uncompared, "
+            "which a passing scaling floor must not mask."
+        )
 
     def test_missing_required_data_fails(self, capsys):
         """Missing data for a required scaling floor FAILS the gate (issue #1564).

--- a/scripts/ci/tests/test_check_perf_regression.py
+++ b/scripts/ci/tests/test_check_perf_regression.py
@@ -53,6 +53,9 @@ _CRIT_WAL_OFF_REGRESSION = os.path.join(_FIXTURES, "criterion_wal_off_regression
 # (degree_ratio · median(n1)/median(n4)) evaluated on the PR baseline alone.
 _CRIT_SCALING_PASS = os.path.join(_FIXTURES, "scaling_floor_pass")
 _CRIT_SCALING_FAIL = os.path.join(_FIXTURES, "scaling_floor_fail")
+# Missing-required-data tree: buffered n4 absent (required floor → MISSING DATA →
+# fail), mmap present + healthy. Required-floor data is never legitimately absent in
+# CI, so a missing median is a gate failure, not a silent skip (issue #1564).
 _CRIT_SCALING_SKIP = os.path.join(_FIXTURES, "scaling_floor_skip")
 
 
@@ -193,17 +196,71 @@ class TestScalingFloor:
         captured = capsys.readouterr()
         assert "concurrent_scan/buffered/n4" in captured.out
 
-    def test_missing_n4_skips_without_failing(self, capsys):
-        """A scaling entry with a missing n4 median is SKIP, not a failure.
+    def test_missing_required_data_fails(self, capsys):
+        """Missing data for a required scaling floor FAILS the gate (issue #1564).
 
-        The buffered n4 median is absent here (buffered floor → SKIP) while the
-        mmap floor is present and healthy, so the gate still exits 0.
+        A scaling floor is intra-run: its data is always present on any run that
+        benches the target, so a missing median means a typo'd id / omitted
+        `--bench` / no-data bench — which must red, not silently disable the gate.
+        Here the buffered n4 median is absent (required buffered floor → MISSING
+        DATA → fail) while the mmap floor is present and healthy.
         """
         exit_code = _run(_CRIT_SCALING_SKIP)
-        assert exit_code == 0, (
-            "Expected zero exit when a scaling entry's n4 data is missing (SKIP), "
-            f"but got exit code {exit_code}."
+        assert exit_code != 0, (
+            "Expected non-zero exit when a required scaling floor's data is "
+            f"missing (must not silently skip), but got exit code {exit_code}."
         )
         captured = capsys.readouterr()
         assert "concurrent_scan/buffered/n4" in captured.out
-        assert "SKIP" in captured.out
+        assert "MISSING DATA" in captured.out
+
+    def test_optional_floor_skips_when_absent(self, tmp_path, capsys):
+        """A scaling floor marked ``optional: true`` SKIPs (exit 0) when absent.
+
+        Uses a custom gate config: one present required floor (evaluated ok, so
+        the "nothing evaluated" guard does not fire) plus one optional floor whose
+        data is missing (→ SKIP, not a failure).
+        """
+        import json
+
+        # Present, healthy required floor: scaling = 4 * 2.4M / 3.2M = 3.0.
+        crit = tmp_path / "criterion"
+        for name, ns in (("n1", 2_400_000.0), ("n4", 3_200_000.0)):
+            d = crit / "concurrent_scan" / "buffered" / name / "pr"
+            d.mkdir(parents=True)
+            (d / "estimates.json").write_text(
+                json.dumps({"median": {"point_estimate": ns}})
+            )
+
+        cfg = {
+            "default_threshold_pct": 10,
+            "advisory_benches": [],
+            "benches": [],
+            "scaling_floors": [
+                {
+                    "id": "concurrent_scan/buffered/n4",
+                    "baseline_id": "concurrent_scan/buffered/n1",
+                    "degree_ratio": 4,
+                    "min_scaling": 1.8,
+                },
+                {
+                    "id": "concurrent_scan/absent/n4",
+                    "baseline_id": "concurrent_scan/absent/n1",
+                    "degree_ratio": 4,
+                    "min_scaling": 1.8,
+                    "optional": True,
+                },
+            ],
+        }
+        cfg_path = tmp_path / "gate.json"
+        cfg_path.write_text(json.dumps(cfg))
+
+        exit_code = main(
+            ["check_perf_regression.py", str(crit), "pr", "base", str(cfg_path)]
+        )
+        captured = capsys.readouterr()
+        assert exit_code == 0, (
+            "Expected zero exit: the required floor passes and the optional floor "
+            f"skips, but got exit code {exit_code}.\n{captured.out}"
+        )
+        assert "SKIP (optional" in captured.out

--- a/scripts/profile.sh
+++ b/scripts/profile.sh
@@ -28,7 +28,7 @@ FEATURES="cli-helpers,write-support"
 # The bench targets that make up the profiling surface. m1_performance and
 # fixtures_smoke exist but are not part of the gated loop; profile them
 # explicitly with `cargo bench` if needed.
-BENCH_TARGETS=(--bench read --bench write --bench partition_lookup --bench partition_lookup_scaling --bench concurrent_scan)
+BENCH_TARGETS=(--bench read --bench write --bench partition_lookup --bench partition_lookup_scaling --bench concurrent_scan --bench read_while_write)
 
 require_fixtures() {
     if ! compgen -G "$CQLITE_DATASETS_ROOT/sstables/test_basic/simple_table-*/nb-1-big-Data.db" > /dev/null; then


### PR DESCRIPTION
Closes #1564 (A3 — gate the existing `concurrent_scan` + `read_while_write` benches, Epic A #1513).

Design-driven; OpenSpec change `gate-scan-benches` (Seam-1 pre-approved for the measurement batch).

## What

Gates the two existing (previously ungated) read-path benches **without** reintroducing the runner-noise flakiness that kept them out:

1. **`concurrent_scan` → machine-independent scaling floor.** New `scaling_floors` check in `scripts/ci/check_perf_regression.py` + `cqlite-core/benches/perf-gate.json`: the *intra-run* ratio `scaling = degree_ratio · median(n1) / median(n4)` (buffered + mmap), floored at **1.8**. Both medians come from the same run, so machine speed cancels — unlike an absolute-time comparison. Healthy parallel scans measure **2.98 (buffered) / 3.19 (mmap)**; a re-serialized read path (reintroduced shared `Mutex`, exactly what #815 removed) collapses `median(n4) ≈ 4·median(n1)` → scaling ≈ **1.0**.
2. **`read_while_write` → strict median gate** (`read_while_write/readers6_writers2`, 25% threshold). The reader-side **p99** is stderr-only/runner-noisy and stays owned by the A2 tail-latency harness (#1563); the gate watches the stable machine-readable median.
3. Both benches wired into `.github/workflows/perf-regression.yml` (PR + main runs) and `scripts/profile.sh`.

## Fixes surfaced while gating (bench code only; no library change)
- **`read_while_write` zero-ingest race**: readers finished and set `stop` before both `spawn_blocking` writers were scheduled → `total_written == 0` panic on nearly every run. Fixed with a do-while (each writer ingests once before honoring `stop`) **plus a writer-readiness barrier** so reader timing begins only once all writers are actively ingesting — the gated median reflects latency under live write contention, not an uncontended window.

## Red-run proof (scaling floor catches serialization)
Committed deterministic proof: `scripts/ci/tests/fixtures/scaling_floor_fail` (`median(n4) ≈ 4·median(n1)`) → gate reports `concurrent_scan/buffered/n4 ... 1.00 ... REGRESSION (scaling < 1.8)`, exit 1.

Live end-to-end proof: wrapped the scan hot path in a `tokio::sync::Mutex` on a scratch branch, re-measured — scaling collapsed to **0.90 (buffered) / 1.02 (mmap)**, both RED, gate exit 1. Scratch reverted.

## Missing-data is a failure, not a silent skip (roborev)
A scaling floor is intra-run, so its data is always present on any run that benches the target — a missing median (typo'd id, omitted `--bench`, no-data bench) **fails** (`MISSING DATA`), never silently skips. Median-bench "nothing compared" protection is independent of the scaling floors, so a passing floor cannot mask uncompared median benches. `"optional": true` opts a floor into skip-on-absent.

## Tests
`scripts/ci/tests/test_check_perf_regression.py` (`TestScalingFloor`): healthy pass, serialized fail, missing-required fail, optional skip, and passing-scaling-does-not-mask-missing-median.

## Quality bar
- `scripts/agent-gate.sh`: **PASS** (all components; summary in a comment).
- spec-auditor (C intent audit): **PASS** on all three requirements.
- roborev (`--agent codex`): **clean** ("No issues found") after converging findings.
