### PR TITLE
perf(#1661): streaming WAL replay (replay_each) — no whole-log Vec<Mutation>

### DIFF
--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -559,10 +559,32 @@ impl WriteEngine {
         // stays empty.
         let mut memtable = Memtable::new();
         let mut recovered = 0usize;
+        // DEFER the first memtable-application error instead of aborting the scan
+        // (issue #1661, roborev). The pre-streaming flow scanned the ENTIRE WAL
+        // first (`replay()`), ran the lossy-recovery preserve/reset, and only THEN
+        // applied mutations — so a schema/key-conversion or insert failure on an
+        // earlier valid mutation could never prevent a LATER corrupt tail from
+        // being detected, preserved aside, and reset. If the streaming callback
+        // returned that error via `?`, replay would stop early and skip
+        // preserve/reset, silently changing the #1390/#1391 recovery semantics
+        // this refactor must preserve. So we record the FIRST apply error, stop
+        // applying (the engine will not be constructed), but keep scanning for the
+        // full RecoveryReport; the error is surfaced only after preserve/reset
+        // below. The streaming memory win is unaffected — no whole-log Vec.
+        let mut apply_error: Option<Error> = None;
         let wal_recovery = wal.replay_each(|mutation| {
-            let decorated_key = mutation.decorated_key(&config.schema)?;
-            memtable.insert_with_key(decorated_key, mutation)?;
-            recovered += 1;
+            if apply_error.is_some() {
+                // An earlier mutation already failed; keep scanning to reach any
+                // later corruption but skip further application.
+                return Ok(());
+            }
+            match mutation.decorated_key(&config.schema) {
+                Ok(decorated_key) => match memtable.insert_with_key(decorated_key, mutation) {
+                    Ok(()) => recovered += 1,
+                    Err(e) => apply_error = Some(e),
+                },
+                Err(e) => apply_error = Some(e),
+            }
             Ok(())
         })?;
 
@@ -598,6 +620,15 @@ impl WriteEngine {
                 preserved,
                 reset_to,
             );
+        }
+
+        // Surface any deferred memtable-application error now — AFTER the
+        // lossy-recovery preserve/reset above has run (issue #1661, roborev).
+        // This restores the pre-streaming ordering: on-disk WAL corruption is
+        // preserved aside and the live WAL is reset to its valid prefix before
+        // engine construction fails on the apply error.
+        if let Some(e) = apply_error {
+            return Err(e);
         }
 
         if recovered > 0 {
@@ -1954,6 +1985,95 @@ mod tests {
             count_corrupt_aside(&config.wal_dir),
             1,
             "flush must NOT destroy the preserved corrupt WAL segment"
+        );
+    }
+
+    /// Issue #1661 (roborev): a memtable-application error on an EARLIER valid
+    /// mutation MUST NOT abort the WAL scan before a LATER corrupt tail can be
+    /// detected, preserved aside, and reset. The streaming refactor applies each
+    /// mutation as it is scanned; if that apply error propagated immediately, the
+    /// #1390/#1391 lossy-recovery preserve/reset would be skipped — a forbidden
+    /// behavior change. Build a WAL of [A(applies-fail), B(corrupt)]: A is a
+    /// CRC-valid, decodable mutation whose partition key value (`Text`) cannot be
+    /// encoded against the `int` schema, so `decorated_key` fails at apply time;
+    /// B is bit-flipped so replay reports the recovery as lossy. `WriteEngine::new`
+    /// must return the deferred apply error, but ONLY after the corrupt segment was
+    /// preserved aside and the live WAL reset to its valid prefix [A].
+    #[test]
+    fn test_write_engine_apply_error_still_preserves_and_resets_corrupt_tail() {
+        use crate::storage::write_engine::mutation::{CellOperation, PartitionKey, TableId};
+        use crate::types::Value;
+        use std::io::{Read, Seek, SeekFrom, Write};
+
+        let temp_dir = TempDir::new().unwrap();
+        let schema = create_test_schema(); // partition key `id` is `int`
+        let config = WriteEngineConfig::new(
+            temp_dir.path().join("data"),
+            temp_dir.path().join("wal"),
+            schema,
+        );
+
+        // Seed A = a mutation whose partition key is Text (mismatches the int
+        // schema) so it serializes/CRCs/deserializes fine but fails at apply
+        // (`decorated_key`); then B = a valid mutation we will corrupt.
+        std::fs::create_dir_all(&config.wal_dir).unwrap();
+        let end_a = {
+            let mut wal = WriteAheadLog::create(&config.wal_dir).unwrap();
+            let bad = Mutation::new(
+                TableId::new("test_ks", "test_table"),
+                PartitionKey::single("id", Value::Text("not-an-int".to_string())),
+                None,
+                vec![CellOperation::Write {
+                    column: "name".to_string(),
+                    value: Value::Text("A".to_string()),
+                }],
+                1_000_000,
+                None,
+            );
+            wal.append(&bad).unwrap();
+            wal.sync().unwrap();
+            let end_a = wal.size();
+            wal.append(&create_test_mutation(2, "B", 2_000_000)).unwrap();
+            wal.sync().unwrap();
+            end_a
+        };
+
+        // Bit-flip B's first payload byte (just past its 8-byte header) → CRC
+        // mismatch → mid-stream corruption.
+        let wal_file = config.wal_dir.join(WriteAheadLog::WAL_FILENAME);
+        {
+            let mut f = std::fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(&wal_file)
+                .unwrap();
+            f.seek(SeekFrom::Start(end_a + 8)).unwrap();
+            let mut byte = [0u8; 1];
+            f.read_exact(&mut byte).unwrap();
+            f.seek(SeekFrom::Start(end_a + 8)).unwrap();
+            f.write_all(&[byte[0] ^ 0x01]).unwrap();
+            f.sync_all().unwrap();
+        }
+
+        // Opening must FAIL on the deferred apply error...
+        let result = WriteEngine::new(config.clone());
+        assert!(
+            result.is_err(),
+            "engine open must surface the deferred memtable-application error"
+        );
+
+        // ...but ONLY after the lossy-recovery preserve/reset ran. Pre-fix, the
+        // apply error aborted the scan before B's corruption was seen, so neither
+        // of these held.
+        assert_eq!(
+            count_corrupt_aside(&config.wal_dir),
+            1,
+            "corrupt segment must be preserved aside even though an earlier apply failed"
+        );
+        assert_eq!(
+            std::fs::metadata(&wal_file).unwrap().len(),
+            end_a,
+            "live WAL must be reset to its valid prefix [A] before the apply error surfaces"
         );
     }
 

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -547,9 +547,24 @@ impl WriteEngine {
 
         // Replay WAL into memtable. The report distinguishes a clean recovery
         // from a lossy one (issue #1391); a bare Vec cannot.
+        //
+        // Stream each recovered mutation straight into the memtable via
+        // `replay_each` (issue #1661) instead of materialising a whole-log
+        // `Vec<Mutation>` and then copying it in: peak memory is bounded by the
+        // memtable itself, not ~2× it. `recovered` is an authoritative count of
+        // mutations actually recovered (used only for the lossy-recovery log,
+        // preserving its prior `mutations.len()` meaning); the completion log
+        // counts from the memtable. The report still carries all corruption
+        // metadata — mutations stream via the closure, so its `mutations` vec
+        // stays empty.
         let mut memtable = Memtable::new();
-        let mut wal_recovery = wal.replay()?;
-        let mutations = std::mem::take(&mut wal_recovery.mutations);
+        let mut recovered = 0usize;
+        let wal_recovery = wal.replay_each(|mutation| {
+            let decorated_key = mutation.decorated_key(&config.schema)?;
+            memtable.insert_with_key(decorated_key, mutation)?;
+            recovered += 1;
+            Ok(())
+        })?;
 
         if !wal_recovery.is_clean() {
             // Preserve the raw WAL segment aside BEFORE anything (a later flush,
@@ -576,7 +591,7 @@ impl WriteEngine {
                  {:?}; live WAL reset to valid prefix ({:?}). Investigate before relying on this \
                  data.",
                 wal_path,
-                mutations.len(),
+                recovered,
                 wal_recovery.corrupt_entries,
                 wal_recovery.stopped_early,
                 wal_recovery.bytes_skipped,
@@ -585,19 +600,10 @@ impl WriteEngine {
             );
         }
 
-        if !mutations.is_empty() {
-            log::info!("Replaying {} mutations from WAL", mutations.len());
-
-            for mutation in mutations {
-                // Compute decorated key
-                let decorated_key = mutation.decorated_key(&config.schema)?;
-
-                // Insert into memtable
-                memtable.insert_with_key(decorated_key, mutation)?;
-            }
-
+        if recovered > 0 {
             log::info!(
-                "WAL replay complete: {} rows in memtable, {} bytes",
+                "WAL replay complete: replayed {} mutation(s); {} rows in memtable, {} bytes",
+                recovered,
                 memtable.row_count(),
                 memtable.size_bytes()
             );

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -2033,7 +2033,8 @@ mod tests {
             wal.append(&bad).unwrap();
             wal.sync().unwrap();
             let end_a = wal.size();
-            wal.append(&create_test_mutation(2, "B", 2_000_000)).unwrap();
+            wal.append(&create_test_mutation(2, "B", 2_000_000))
+                .unwrap();
             wal.sync().unwrap();
             end_a
         };

--- a/cqlite-core/src/storage/write_engine/wal.rs
+++ b/cqlite-core/src/storage/write_engine/wal.rs
@@ -1237,6 +1237,52 @@ impl WriteAheadLog {
     /// Returns an error if the WAL file cannot be opened or read (an I/O fault
     /// distinct from in-band corruption, which is reported, not errored).
     pub fn replay(&self) -> Result<RecoveryReport> {
+        // Thin wrapper over `replay_each` (issue #1661): collect the streamed
+        // mutations into the report's Vec so existing callers/tests are
+        // unchanged. `replay_each` itself never materialises the whole log.
+        let mut out = Vec::new();
+        let mut report = self.replay_each(|m| {
+            out.push(m);
+            Ok(())
+        })?;
+        report.mutations = out;
+        Ok(report)
+    }
+
+    /// Streaming form of [`replay`](Self::replay): invoke `f` once per recovered
+    /// mutation instead of accumulating a whole-log `Vec<Mutation>` (issue #1661).
+    ///
+    /// Control flow — decode/skip/stop/error semantics and the on-disk framing —
+    /// is byte-for-byte identical to [`replay`](Self::replay); this is a pure
+    /// memory refactor. The two differences are internal:
+    ///
+    /// 1. A single payload buffer is reused across entries (its capacity grows to
+    ///    the largest entry seen and is retained), so the peak read buffer is
+    ///    bounded by the largest single entry rather than allocated fresh per
+    ///    entry.
+    /// 2. Each successfully decoded mutation is passed to `f` rather than pushed
+    ///    onto a `Vec`, so the caller (e.g. crash recovery) can insert it into the
+    ///    memtable immediately and never hold the whole log resident.
+    ///
+    /// The returned [`RecoveryReport`] carries the same corruption metadata
+    /// ([`corrupt_entries`](RecoveryReport::corrupt_entries),
+    /// [`stopped_early`](RecoveryReport::stopped_early),
+    /// [`bytes_skipped`](RecoveryReport::bytes_skipped)) as `replay`, but its
+    /// [`mutations`](RecoveryReport::mutations) vec is left empty — the mutations
+    /// were streamed to `f`. Callers MUST still consult
+    /// [`RecoveryReport::is_clean`].
+    ///
+    /// If `f` returns an error, replay stops and the error propagates unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the WAL file cannot be opened or read (an I/O fault
+    /// distinct from in-band corruption, which is reported, not errored), or if
+    /// `f` returns an error for a recovered mutation.
+    pub fn replay_each<F>(&self, mut f: F) -> Result<RecoveryReport>
+    where
+        F: FnMut(Mutation) -> Result<()>,
+    {
         let mut file = File::open(&self.path)
             .map_err(|e| Error::Storage(format!("Failed to open WAL for replay: {}", e)))?;
         let total_len = file
@@ -1246,6 +1292,10 @@ impl WriteAheadLog {
 
         let mut report = RecoveryReport::default();
         let mut offset = 0u64;
+        // Reuse ONE payload buffer across entries (issue #1661): `resize` retains
+        // the allocation's capacity, so the peak read buffer is bounded by the
+        // largest single entry rather than a fresh `vec![0u8; len]` per entry.
+        let mut mutation_bytes: Vec<u8> = Vec::new();
 
         loop {
             // Read entry header: [length][crc32]
@@ -1285,8 +1335,10 @@ impl WriteAheadLog {
                 break;
             }
 
-            // Read mutation bytes
-            let mut mutation_bytes = vec![0u8; entry_length as usize];
+            // Read mutation bytes into the reused buffer (issue #1661). `resize`
+            // grows/shrinks the length to exactly `entry_length` (reusing the
+            // retained capacity); `read_exact` then overwrites all of it.
+            mutation_bytes.resize(entry_length as usize, 0);
             match file.read_exact(&mut mutation_bytes) {
                 Ok(_) => {}
                 Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
@@ -1350,7 +1402,10 @@ impl WriteAheadLog {
             // is trustworthy we skip just this entry and continue.
             match decode_mutation(&mutation_bytes) {
                 Ok(mutation) => {
-                    report.mutations.push(mutation);
+                    // Stream the mutation to the caller instead of accumulating a
+                    // whole-log Vec (issue #1661). An `f` error propagates
+                    // unchanged.
+                    f(mutation)?;
                 }
                 Err(e) => {
                     log::error!(
@@ -3255,6 +3310,117 @@ mod tests {
             } => assert_eq!(name, "Alice", "the sole recovered entry must be A"),
             other => panic!("expected Write op, got {other:?}"),
         }
+    }
+
+    /// Issue #1661: `replay_each` must be semantically identical to `replay()` —
+    /// it must yield the SAME mutations in the SAME order and produce the SAME
+    /// corruption metadata for a mixed WAL (valid entries plus a CRC-corrupt
+    /// entry). This proves the streaming refactor changed only allocation
+    /// behavior, not decode/skip/stop semantics.
+    #[test]
+    fn test_replay_each_matches_replay_for_mixed_wal() {
+        let temp_dir = TempDir::new().unwrap();
+
+        // [A][B][C], all synced. Capture the end-of-A offset (start of B's frame).
+        let (path, end_of_a) = {
+            let mut wal = WriteAheadLog::create(temp_dir.path()).unwrap();
+            wal.append(&create_test_mutation(1, "Alice")).unwrap();
+            wal.sync().unwrap();
+            let end_of_a = wal.size();
+            wal.append(&create_test_mutation(2, "Bob")).unwrap();
+            wal.sync().unwrap();
+            wal.append(&create_test_mutation(3, "Carol")).unwrap();
+            wal.sync().unwrap();
+            let path = wal.path().to_path_buf();
+            drop(wal);
+            (path, end_of_a)
+        };
+
+        // Corrupt B's CRC (4 bytes at end_of_a + 4) via a bit flip; B stays
+        // structurally complete so this exercises the CRC-mismatch stop path.
+        let mut file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&path)
+            .unwrap();
+        file.seek(SeekFrom::Start(end_of_a + 4)).unwrap();
+        let mut crc = [0u8; 4];
+        file.read_exact(&mut crc).unwrap();
+        crc[0] ^= 0xFF;
+        file.seek(SeekFrom::Start(end_of_a + 4)).unwrap();
+        file.write_all(&crc).unwrap();
+        file.sync_all().unwrap();
+        drop(file);
+
+        let wal = WriteAheadLog::open_existing(&path).unwrap();
+
+        // Reference: the whole-log `replay()`.
+        let report = wal.replay().unwrap();
+
+        // Streaming: collect the callback-delivered mutations.
+        let mut streamed = Vec::new();
+        let stream_report = wal
+            .replay_each(|m| {
+                streamed.push(m);
+                Ok(())
+            })
+            .unwrap();
+
+        // Same mutations, same order (compare via bincode bytes — Mutation has no
+        // PartialEq).
+        let ser = |m: &Mutation| bincode::serialize(m).unwrap();
+        let expected: Vec<Vec<u8>> = report.mutations.iter().map(ser).collect();
+        let actual: Vec<Vec<u8>> = streamed.iter().map(ser).collect();
+        assert_eq!(
+            actual, expected,
+            "replay_each must yield the same mutations in the same order as replay()"
+        );
+        // Only the valid prefix A survives the mid-stream corruption.
+        assert_eq!(streamed.len(), 1, "only the valid prefix A is recovered");
+
+        // Same corruption metadata; `replay_each`'s report leaves mutations empty
+        // (they were streamed to the callback), while `replay()` populates them.
+        assert_eq!(stream_report.corrupt_entries, report.corrupt_entries);
+        assert_eq!(stream_report.stopped_early, report.stopped_early);
+        assert_eq!(stream_report.bytes_skipped, report.bytes_skipped);
+        assert!(
+            stream_report.stopped_early,
+            "must stop at the corrupt entry"
+        );
+        assert_eq!(stream_report.corrupt_entries, 1);
+        assert!(
+            stream_report.mutations.is_empty(),
+            "replay_each streams mutations to the callback, so its report Vec stays empty"
+        );
+    }
+
+    /// Issue #1661: a fully clean multi-entry WAL must stream every entry in
+    /// order and report clean, matching `replay()`.
+    #[test]
+    fn test_replay_each_clean_multi_entry() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut wal = WriteAheadLog::create(temp_dir.path()).unwrap();
+        wal.append(&create_test_mutation(1, "Alice")).unwrap();
+        wal.append(&create_test_mutation(2, "Bob")).unwrap();
+        wal.append(&create_test_mutation(3, "Carol")).unwrap();
+        wal.sync().unwrap();
+
+        let report = wal.replay().unwrap();
+        let mut streamed = Vec::new();
+        let stream_report = wal
+            .replay_each(|m| {
+                streamed.push(m);
+                Ok(())
+            })
+            .unwrap();
+
+        let ser = |m: &Mutation| bincode::serialize(m).unwrap();
+        let expected: Vec<Vec<u8>> = report.mutations.iter().map(ser).collect();
+        let actual: Vec<Vec<u8>> = streamed.iter().map(ser).collect();
+        assert_eq!(actual, expected);
+        assert_eq!(streamed.len(), 3);
+        assert!(stream_report.is_clean());
+        assert!(report.is_clean());
     }
 
     #[test]

--- a/cqlite-core/tests/test_issue_1661_wal_replay_streaming_memory.rs
+++ b/cqlite-core/tests/test_issue_1661_wal_replay_streaming_memory.rs
@@ -1,0 +1,180 @@
+//! Memory-bound regression test for Issue #1661 (dhat-gated) — THE deliverable.
+//!
+//! **Problem**: `WriteAheadLog::replay()` decoded EVERY WAL entry into a single
+//! `Vec<Mutation>` (the whole log) and returned it; crash recovery in
+//! `WriteEngine::new` then iterated that Vec to build the memtable. The memtable
+//! *moves* each mutation in (it does not copy the payload heap), so the resident
+//! payload is not literally doubled — but the whole-log Vec's M-slot backing
+//! buffer stays allocated for the entire drain loop *on top of* the growing
+//! memtable, so end-to-end reopen peak carries an extra `M × size_of::<Mutation>`
+//! allocation above the memtable's own resident size.
+//!
+//! **Fix**: `WriteAheadLog::replay_each` streams one decoded mutation at a time
+//! to a callback (reusing a single read buffer), and recovery inserts each
+//! straight into the memtable. No whole-log Vec is ever materialised, so reopen
+//! peak is bounded by the memtable itself plus a small constant.
+//!
+//! **Observed** (deterministic, dhat `testing()` mode; 60_000 × 256 B):
+//! pre-change reopen peak 114.66 MiB, post-change 98.16 MiB — a reproducible
+//! 16.5 MiB reduction (the eliminated whole-log Vec backing buffer). The budget
+//! below sits in that gap so the streaming path passes and the whole-log path
+//! fails.
+//!
+//! **This test** writes M mutations to a WAL (no flush, so they persist for
+//! replay), drops the engine, then reopens it under the dhat heap profiler so
+//! only the crash-recovery replay is attributed. It asserts the reopen peak
+//! heap stays within a budget that the streaming path meets but the old
+//! whole-log path exceeds.
+//!
+//! Gated on the `dhat-heap` feature; runs in the profiling job, not normal
+//! `cargo test`. Run via:
+//!
+//! ```text
+//! cargo test --package cqlite-core \
+//!   --features write-support,cli-helpers,dhat-heap \
+//!   --test test_issue_1661_wal_replay_streaming_memory --profile bench -- --nocapture
+//! ```
+
+#![cfg(all(
+    feature = "write-support",
+    feature = "cli-helpers",
+    feature = "dhat-heap"
+))]
+
+use std::collections::HashMap;
+
+use cqlite_core::schema::{Column, KeyColumn, TableSchema};
+use cqlite_core::storage::write_engine::{
+    CellOperation, Mutation, PartitionKey, TableId, WriteEngine, WriteEngineConfig,
+};
+use cqlite_core::types::Value;
+use tempfile::TempDir;
+
+// The dhat allocator must be the global allocator to observe every allocation.
+// This test binary is separate from all others, so installing it here does not
+// affect normal builds or other test binaries.
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+const KEYSPACE: &str = "issue1661_mem_ks";
+const TABLE: &str = "blobs";
+
+// Workload sizing. A large mutation count makes the eliminated whole-log Vec
+// backing buffer (`M × size_of::<Mutation>`) a clearly measurable slice of the
+// reopen peak, well above any constant overhead. The payload size is modest so
+// the memtable resident set stays bounded while the count drives the signal.
+const PAYLOAD_BYTES: usize = 256;
+const MUTATION_COUNT: i32 = 60_000;
+
+// Budget: sits in the deterministic gap between the streaming reopen peak
+// (~98.16 MiB, PASS) and the pre-fix whole-log peak (~114.66 MiB, FAIL). dhat's
+// `testing()` mode makes the measurement reproducible, so an ~8 MiB margin on
+// each side is safe.
+const HEAP_BUDGET_BYTES: usize = 106 * 1024 * 1024;
+
+fn make_schema() -> TableSchema {
+    TableSchema {
+        keyspace: KEYSPACE.to_string(),
+        table: TABLE.to_string(),
+        partition_keys: vec![KeyColumn {
+            name: "id".to_string(),
+            data_type: "int".to_string(),
+            position: 0,
+        }],
+        clustering_keys: vec![],
+        columns: vec![
+            Column {
+                name: "id".to_string(),
+                data_type: "int".to_string(),
+                nullable: false,
+                default: None,
+                is_static: false,
+            },
+            Column {
+                name: "payload".to_string(),
+                data_type: "text".to_string(),
+                nullable: true,
+                default: None,
+                is_static: false,
+            },
+        ],
+        comments: HashMap::new(),
+        dropped_columns: HashMap::new(),
+    }
+}
+
+fn payload_for(id: i32) -> String {
+    let mut s = format!("row-{id:08}-");
+    s.push_str(&"abcdefghij".repeat(PAYLOAD_BYTES / 10 + 1));
+    s.truncate(PAYLOAD_BYTES);
+    s
+}
+
+fn write_row(id: i32) -> Mutation {
+    let table_id = TableId::new(KEYSPACE, TABLE);
+    let pk = PartitionKey::single("id", Value::Integer(id));
+    let ops = vec![CellOperation::Write {
+        column: "payload".to_string(),
+        value: Value::Text(payload_for(id)),
+    }];
+    Mutation::new(table_id, pk, None, ops, 100 + id as i64, None)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_wal_replay_streaming_stays_within_heap_budget() {
+    let temp_dir = TempDir::new().unwrap();
+    let data_dir = temp_dir.path().join("data");
+    let wal_dir = temp_dir.path().join("wal");
+    std::fs::create_dir_all(&wal_dir).unwrap();
+    let schema = make_schema();
+
+    // ── Phase 1 (UNMEASURED): fill the WAL, do NOT flush ──────────────────────
+    // A high flush threshold + running inside the Tokio runtime guarantees
+    // `write()` never auto-flushes, so every mutation stays in the WAL for
+    // replay. Dropping the engine discards the memtable but leaves the WAL on
+    // disk as the recovery source.
+    {
+        let config = WriteEngineConfig::new(data_dir.clone(), wal_dir.clone(), schema.clone())
+            .with_flush_threshold(usize::MAX);
+        let mut engine = WriteEngine::new(config).expect("engine creation");
+        for id in 0..MUTATION_COUNT {
+            engine.write(write_row(id)).expect("write row");
+        }
+        // Drop without flush: the WAL retains all MUTATION_COUNT entries.
+        drop(engine);
+    }
+
+    // ── Phase 2 (MEASURED): reopen, which drives WAL crash-recovery replay ────
+    let _profiler = dhat::Profiler::builder().testing().build();
+
+    let config = WriteEngineConfig::new(data_dir.clone(), wal_dir.clone(), schema.clone())
+        .with_flush_threshold(usize::MAX);
+    let engine = WriteEngine::new(config).expect("engine reopen (drives WAL replay)");
+
+    let stats = dhat::HeapStats::get();
+    eprintln!(
+        "Issue #1661 WAL replay streaming: {MUTATION_COUNT} mutations × {PAYLOAD_BYTES} B payload, \
+         reopen peak heap {} bytes ({:.2} MiB) vs budget {} MiB",
+        stats.max_bytes,
+        stats.max_bytes as f64 / (1024.0 * 1024.0),
+        HEAP_BUDGET_BYTES / (1024 * 1024),
+    );
+
+    // Correctness guard: the reopened memtable must hold every replayed row.
+    assert_eq!(
+        engine.memtable_row_count(),
+        MUTATION_COUNT as usize,
+        "Issue #1661: replay must recover every WAL entry into the memtable"
+    );
+
+    assert!(
+        stats.max_bytes <= HEAP_BUDGET_BYTES,
+        "Issue #1661: WAL-replay reopen peak heap {} bytes ({:.2} MiB) exceeds the {} MiB budget — \
+         recovery regressed to materialising the whole log as a Vec<Mutation>",
+        stats.max_bytes,
+        stats.max_bytes as f64 / (1024.0 * 1024.0),
+        HEAP_BUDGET_BYTES / (1024 * 1024),
+    );
+
+    drop(temp_dir);
+}


### PR DESCRIPTION
Closes #1661.

## What
Pure memory refactor of WAL recovery: replace whole-log `Vec<Mutation>` materialization with a streaming `replay_each(FnMut(Mutation) -> Result<()>)`. Recovery now streams each entry straight into the memtable — no whole-log Vec resident during the recovery window.

Perf sibling of #1390/#1391 (both landed). Decode/skip/stop/CRC semantics are the ported landed shape, **unchanged**.

## Changes
- `wal.rs`: `replay_each` (one reused read buffer, no per-entry `vec![0u8; len]`); `replay()` retained as a thin wrapper over it.
- `mod.rs` (`WriteEngine::new`): recovery streams into the memtable via `replay_each`; log counts from the memtable + an authoritative `recovered` counter.
- Error-ordering (roborev): a mid-stream memtable-apply error is **recorded and deferred**, not early-returned, so the WAL scan completes and lossy-recovery preserve-aside + `reset_to_valid_prefix` run **before** the apply error surfaces — identical to the pre-refactor ordering.

## Tests
- `test_issue_1661_wal_replay_streaming_memory.rs` (dhat-heap gated): reopen peak heap **114.66 MiB → 98.16 MiB** (16.5 MiB whole-log Vec eliminated). FAILs on pre-change, passes after.
- `replay_each` vs `replay()` parity unit test over a mixed valid+CRC-corrupt WAL (same mutations/order/corruption metadata).
- `test_write_engine_apply_error_still_preserves_and_resets_corrupt_tail`: proves the restored preserve/reset ordering; FAILs pre-fix.

## Quality bar
- `scripts/agent-gate.sh`: **RESULT: PASS** (all components; `CQLITE_ALLOW_FILE_GROWTH=1` acked — `mod.rs`/`wal.rs` already over threshold, split out of scope per #1116/#1135).
- roborev (codex, `--base origin/main`): **No issues found** (initial Low ordering finding fixed).
- Rebased on origin/main (5 commits, no `write_engine/` overlap).