### PR TITLE
perf(#1586): cache file size at open; drop 3–4 redundant seeks per chunk

### DIFF
--- a/cqlite-core/src/storage/sstable/chunk_decompressor.rs
+++ b/cqlite-core/src/storage/sstable/chunk_decompressor.rs
@@ -19,6 +19,21 @@ pub struct ChunkDecompressor {
     max_cached_chunks: usize,
     /// Data file path for error reporting
     data_file_path: Option<String>,
+    /// Cached Data.db length, captured on the first chunk read (issue #1586).
+    ///
+    /// The file is an immutable SSTable, so its size is derived exactly once
+    /// with a single seek probe and then reused for every subsequent chunk's
+    /// `compressed_chunk_size` bounds math — instead of re-seeking to `End(0)`
+    /// (and back) on every chunk read.
+    cached_data_file_size: Option<u64>,
+    /// The reader's logical position after the most recent chunk read within the
+    /// current `read_data` / `decompress_chunk_by_index` call (issue #1586).
+    ///
+    /// Sequential chunk reads leave the reader positioned exactly at the next
+    /// chunk's offset, so the explicit `seek(Start(offset))` can be skipped when
+    /// it would be a no-op. Reset to `None` at each public entry point so it is
+    /// only ever trusted within a single call against a single reader.
+    stream_pos: Option<u64>,
 }
 
 impl ChunkDecompressor {
@@ -38,6 +53,8 @@ impl ChunkDecompressor {
             chunk_cache: HashMap::new(),
             max_cached_chunks: 16, // Cache up to 16 chunks (16 * 16KB = 256KB max memory)
             data_file_path: None,
+            cached_data_file_size: None,
+            stream_pos: None,
         })
     }
 
@@ -56,6 +73,8 @@ impl ChunkDecompressor {
             chunk_cache: HashMap::new(),
             max_cached_chunks: 16,
             data_file_path: Some(data_file_path),
+            cached_data_file_size: None,
+            stream_pos: None,
         })
     }
 
@@ -69,6 +88,12 @@ impl ChunkDecompressor {
         let mut result = Vec::with_capacity(length);
         let mut remaining = length;
         let mut current_offset = offset;
+
+        // The reader's logical position is unknown at the start of a call (the
+        // caller may have passed a fresh reader), so the first chunk read always
+        // seeks; subsequent sequential reads within this call skip the redundant
+        // seek (issue #1586).
+        self.stream_pos = None;
 
         while remaining > 0 {
             // Determine which chunk contains this offset
@@ -152,7 +177,7 @@ impl ChunkDecompressor {
 
     /// Decompress a specific chunk from the compressed data file
     fn decompress_chunk<R: Read + Seek>(
-        &self,
+        &mut self,
         reader: &mut R,
         chunk_index: usize,
     ) -> Result<Vec<u8>> {
@@ -162,12 +187,23 @@ impl ChunkDecompressor {
             .compressed_chunk_offset(chunk_index)
             .ok_or_else(|| Error::InvalidFormat(format!("No offset for chunk {}", chunk_index)))?;
 
-        // Determine record size (compressed payload + 4-byte inline CRC) using file size
-        let current_pos = reader.stream_position().map_err(Error::Io)?;
-        let file_size = reader.seek(SeekFrom::End(0)).map_err(Error::Io)?;
-        reader
-            .seek(SeekFrom::Start(current_pos))
-            .map_err(Error::Io)?;
+        // Determine record size (compressed payload + 4-byte inline CRC) using the
+        // Data.db length. The SSTable is immutable, so its size is derived once
+        // with a single seek probe and cached — never re-probed per chunk (#1586).
+        let file_size = match self.cached_data_file_size {
+            Some(size) => size,
+            None => {
+                let current_pos = reader.stream_position().map_err(Error::Io)?;
+                let size = reader.seek(SeekFrom::End(0)).map_err(Error::Io)?;
+                reader
+                    .seek(SeekFrom::Start(current_pos))
+                    .map_err(Error::Io)?;
+                self.cached_data_file_size = Some(size);
+                // The probe restored the reader to `current_pos`.
+                self.stream_pos = Some(current_pos);
+                size
+            }
+        };
 
         // compressed_chunk_size returns the full record delta including the 4-byte inline CRC.
         // CompressedSequentialWriter.java:203: chunkOffset += compressedLength + 4
@@ -189,10 +225,16 @@ impl ChunkDecompressor {
         }
         let compressed_len = (record_size - 4) as usize;
 
-        // Seek to compressed chunk offset and read compressed payload only
-        reader
-            .seek(SeekFrom::Start(compressed_offset))
-            .map_err(Error::Io)?;
+        // Seek to compressed chunk offset and read compressed payload only.
+        // Skip the seek when the previous sequential chunk read already left the
+        // reader positioned exactly here (issue #1586 step 3).
+        if self.stream_pos != Some(compressed_offset) {
+            reader
+                .seek(SeekFrom::Start(compressed_offset))
+                .map_err(Error::Io)?;
+        }
+        // Position is unknown until the record's bytes are fully read.
+        self.stream_pos = None;
 
         let mut compressed_data = vec![0u8; compressed_len];
         reader.read_exact(&mut compressed_data).map_err(Error::Io)?;
@@ -201,6 +243,10 @@ impl ChunkDecompressor {
         // Authority: CompressedSequentialWriter.java:192 + read path lines 275-282.
         let mut crc_bytes = [0u8; 4];
         reader.read_exact(&mut crc_bytes).map_err(Error::Io)?;
+        // The record (payload + 4-byte CRC) has been consumed; the reader now sits
+        // at the next chunk's offset, so a subsequent sequential read can skip its
+        // seek (issue #1586).
+        self.stream_pos = Some(compressed_offset.saturating_add(record_size));
         let stored_crc = u32::from_be_bytes(crc_bytes);
         let computed_crc = crc32fast::hash(&compressed_data);
         if stored_crc != computed_crc {
@@ -540,6 +586,9 @@ impl ChunkDecompressor {
         reader: &mut R,
         chunk_index: usize,
     ) -> Result<Vec<u8>> {
+        // Single-chunk entry point: the reader position is unknown here too, so
+        // force the first (only) read to seek (issue #1586).
+        self.stream_pos = None;
         self.get_decompressed_chunk(reader, chunk_index)
     }
 
@@ -612,5 +661,97 @@ mod tests {
         decompressor.clear_cache();
         let (cached_after_clear, _) = decompressor.cache_stats();
         assert_eq!(cached_after_clear, 0);
+    }
+
+    /// A `Read + Seek` wrapper that counts every `seek()` call (which includes
+    /// `stream_position()`, since the default `Seek::stream_position` is
+    /// `seek(SeekFrom::Current(0))`). Used to prove the chunk read path does not
+    /// re-derive the immutable file size with a seek probe on every chunk
+    /// (issue #1586).
+    struct SeekCountingReader {
+        inner: std::io::Cursor<Vec<u8>>,
+        seeks: std::rc::Rc<std::cell::Cell<usize>>,
+    }
+
+    impl std::io::Read for SeekCountingReader {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            self.inner.read(buf)
+        }
+    }
+
+    impl Seek for SeekCountingReader {
+        fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+            self.seeks.set(self.seeks.get() + 1);
+            self.inner.seek(pos)
+        }
+    }
+
+    /// Build a synthetic `k`-chunk LZ4 Data.db body plus its `CompressionInfo`.
+    /// Each chunk record is `[LE u32 uncompressed_len][lz4 bytes][BE u32 CRC32]`
+    /// exactly as Cassandra's `CompressedSequentialWriter` lays them out.
+    #[cfg(feature = "lz4")]
+    fn build_multichunk_lz4(
+        k: usize,
+        chunk_len: usize,
+        last_len: usize,
+    ) -> (Vec<u8>, CompressionInfo) {
+        let mut data_db: Vec<u8> = Vec::new();
+        let mut offsets: Vec<u64> = Vec::new();
+        let mut data_length: u64 = 0;
+        for i in 0..k {
+            offsets.push(data_db.len() as u64);
+            let unclen = if i + 1 == k { last_len } else { chunk_len };
+            let uncompressed: Vec<u8> = (0..unclen).map(|j| ((i * 7 + j) % 251) as u8).collect();
+            data_length += unclen as u64;
+            let mut payload = (unclen as u32).to_le_bytes().to_vec();
+            payload.extend_from_slice(&lz4_flex::compress(&uncompressed));
+            let crc = crc32fast::hash(&payload);
+            data_db.extend_from_slice(&payload);
+            data_db.extend_from_slice(&crc.to_be_bytes());
+        }
+        let info = CompressionInfo {
+            algorithm: "LZ4Compressor".to_string(),
+            chunk_length: chunk_len as u32,
+            data_length,
+            chunk_offsets: offsets,
+            option_pairs: vec![],
+            max_compressed_length: i32::MAX as u32,
+        };
+        (data_db, info)
+    }
+
+    /// Issue #1586: reading every chunk of a K-chunk file must NOT re-probe the
+    /// immutable file size with a `seek(End)`/`seek(Start)` dance on each chunk.
+    /// A full `read_all_data` scan must issue `<= K + O(1)` seeks, not the ~4*K
+    /// seeks the per-chunk size probe produced. On unfixed code this asserts
+    /// ~4*K and FAILS; after threading the cached file size it passes.
+    #[cfg(feature = "lz4")]
+    #[test]
+    fn read_all_data_does_not_reprobe_file_size_per_chunk() {
+        let k = 8usize;
+        let (data_db, info) = build_multichunk_lz4(k, 200, 50);
+        let mut decompressor = ChunkDecompressor::new(info, CassandraVersion::V5_0Release).unwrap();
+
+        let seeks = std::rc::Rc::new(std::cell::Cell::new(0usize));
+        let mut reader = SeekCountingReader {
+            inner: std::io::Cursor::new(data_db),
+            seeks: seeks.clone(),
+        };
+
+        let out = decompressor
+            .read_all_data(&mut reader)
+            .expect("read_all_data");
+        assert_eq!(out.len(), 7 * 200 + 50, "all decompressed bytes returned");
+
+        // Budget: one initial size probe (a small constant) plus at most one
+        // positioning seek per chunk. The per-chunk file-size re-probe (3 extra
+        // seeks/chunk) must be gone.
+        let total = seeks.get();
+        let budget = k + 4;
+        assert!(
+            total <= budget,
+            "expected <= {budget} seeks for {k} chunks (K + O(1)), got {total} \
+             — per-chunk file-size re-probe not eliminated (issue #1586)"
+        );
     }
 }

--- a/cqlite-core/src/storage/sstable/reader/block_io.rs
+++ b/cqlite-core/src/storage/sstable/reader/block_io.rs
@@ -181,14 +181,12 @@ async fn read_next_block_impl(
     if cassandra_version.is_nb_format() || is_bti {
         log::debug!("block_io::read_next_block_impl: Using NB/BTI format chunk reader");
 
-        // Get file size for chunk size calculation
+        // File size for chunk-size calculation. The SSTable is immutable, so this
+        // reads the cached length instead of re-deriving it with a seek(End)/back
+        // probe on every chunk (issue #1586).
         let file_size = {
             let mut file_guard = file.lock().await;
-            let current = file_guard.stream_position().await?;
-            file_guard.seek(std::io::SeekFrom::End(0)).await?;
-            let size = file_guard.stream_position().await?;
-            file_guard.seek(std::io::SeekFrom::Start(current)).await?;
-            size
+            file_guard.len().await?
         };
 
         // Read chunk with CRC validation
@@ -692,33 +690,14 @@ async fn read_uncompressed_data_block(
             )))
         })?;
 
-        // Get file size
-        file_guard
-            .seek(std::io::SeekFrom::End(0))
-            .await
-            .map_err(|e| {
-                Error::Io(std::io::Error::other(format!(
-                    "Failed to seek to end: {}",
-                    e
-                )))
-            })?;
-        let size = file_guard.stream_position().await.map_err(|e| {
+        // File size from the cached immutable length — no seek(End)/back probe on
+        // every piece read (issue #1586).
+        let size = file_guard.len().await.map_err(|e| {
             Error::Io(std::io::Error::other(format!(
                 "Failed to get file size: {}",
                 e
             )))
         })?;
-
-        // Seek back to current position
-        file_guard
-            .seek(std::io::SeekFrom::Start(current))
-            .await
-            .map_err(|e| {
-                Error::Io(std::io::Error::other(format!(
-                    "Failed to seek back to position: {}",
-                    e
-                )))
-            })?;
 
         (current, size)
     };

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -736,10 +736,15 @@ impl SSTableReader {
 
     /// Open a buffered point-read source and its per-scan factory. Shared by the
     /// buffered backend and as the graceful fallback for mmap/direct.
-    async fn open_buffered_sources(path: &Path) -> Result<(BlockSource, ScanSource)> {
+    async fn open_buffered_sources(
+        path: &Path,
+        file_size: u64,
+    ) -> Result<(BlockSource, ScanSource)> {
         Ok((
-            BlockSource::buffered(File::open(path).await?),
-            ScanSource::Buffered,
+            BlockSource::buffered_sized(File::open(path).await?, file_size),
+            ScanSource::Buffered {
+                file_len: file_size,
+            },
         ))
     }
 
@@ -767,7 +772,7 @@ impl SSTableReader {
             prefetch_bytes
         };
         match mode {
-            DiskAccessMode::Buffered => Self::open_buffered_sources(path).await,
+            DiskAccessMode::Buffered => Self::open_buffered_sources(path, file_size).await,
             DiskAccessMode::Mmap => match Self::map_file(path) {
                 Ok(mmap) => {
                     log::debug!(
@@ -797,7 +802,7 @@ impl SSTableReader {
                         path.display(),
                         e
                     );
-                    Self::open_buffered_sources(path).await
+                    Self::open_buffered_sources(path, file_size).await
                 }
             },
             DiskAccessMode::Direct => {
@@ -815,6 +820,7 @@ impl SSTableReader {
                                 BlockSource::direct(cursor),
                                 ScanSource::Direct {
                                     window: direct_window,
+                                    file_len: file_size,
                                 },
                             ))
                         }
@@ -824,7 +830,7 @@ impl SSTableReader {
                                 path.display(),
                                 e
                             );
-                            Self::open_buffered_sources(path).await
+                            Self::open_buffered_sources(path, file_size).await
                         }
                     }
                 }
@@ -835,11 +841,11 @@ impl SSTableReader {
                         "Direct I/O is unavailable on this platform; using buffered I/O for {}",
                         path.display()
                     );
-                    Self::open_buffered_sources(path).await
+                    Self::open_buffered_sources(path, file_size).await
                 }
             }
             // `resolve_disk_access_mode` never yields `Auto`; handle defensively.
-            DiskAccessMode::Auto => Self::open_buffered_sources(path).await,
+            DiskAccessMode::Auto => Self::open_buffered_sources(path, file_size).await,
         }
     }
 

--- a/cqlite-core/src/storage/sstable/reader/source.rs
+++ b/cqlite-core/src/storage/sstable/reader/source.rs
@@ -40,8 +40,13 @@ use crate::Result;
 ///
 /// See the module documentation for the trade-offs between the two backends.
 pub(crate) enum BlockSource {
-    /// Buffered file I/O through the OS page cache.
-    Buffered(BufReader<File>),
+    /// Buffered file I/O through the OS page cache. `len` caches the immutable
+    /// file length so the block-I/O layer never re-probes it with `seek(End)`
+    /// per chunk (issue #1586).
+    Buffered {
+        reader: BufReader<File>,
+        len: Option<u64>,
+    },
     /// Memory-mapped file view served directly from the page cache.
     Mapped(MmapCursor),
     /// Direct I/O (`O_DIRECT` / `F_NOCACHE`) that bypasses the page cache.
@@ -50,9 +55,43 @@ pub(crate) enum BlockSource {
 }
 
 impl BlockSource {
-    /// Create a buffered (non-mmap) source from an open tokio file.
+    /// Create a buffered (non-mmap) source with the length resolved lazily on the
+    /// first [`Self::len`] call. Test-only: production paths know the length at
+    /// open and use [`Self::buffered_sized`] (issue #1586).
+    #[cfg(test)]
     pub(crate) fn buffered(file: File) -> Self {
-        BlockSource::Buffered(BufReader::new(file))
+        BlockSource::Buffered {
+            reader: BufReader::new(file),
+            len: None,
+        }
+    }
+
+    /// Create a buffered source with its (immutable) file length already known,
+    /// so the block-I/O layer never issues a size probe at all (issue #1586).
+    pub(crate) fn buffered_sized(file: File, len: u64) -> Self {
+        BlockSource::Buffered {
+            reader: BufReader::new(file),
+            len: Some(len),
+        }
+    }
+
+    /// The total byte length of the backing file. Resident for mmap/direct; for a
+    /// buffered source it is cached (derived once via `metadata`, SSTables being
+    /// immutable) rather than re-probed with `seek(End)` per chunk (issue #1586).
+    pub(crate) async fn len(&mut self) -> io::Result<u64> {
+        match self {
+            BlockSource::Buffered { reader, len } => match *len {
+                Some(l) => Ok(l),
+                None => {
+                    let l = reader.get_ref().metadata().await?.len();
+                    *len = Some(l);
+                    Ok(l)
+                }
+            },
+            BlockSource::Mapped(c) => Ok(c.mmap.len() as u64),
+            #[cfg(unix)]
+            BlockSource::Direct(c) => Ok(c.len),
+        }
     }
 
     /// Create a memory-mapped source from a previously mapped file.
@@ -90,7 +129,10 @@ impl BlockSource {
 pub(crate) enum ScanSource {
     /// Reopen the file for each scan, giving it its own OS file handle and seek
     /// position. The per-handle cost is a small buffered reader.
-    Buffered,
+    Buffered {
+        /// Immutable file length captured at reader open (issue #1586).
+        file_len: u64,
+    },
     /// Share the underlying read-only memory map; each scan gets its own cursor
     /// position over the same mapped bytes (just an `Arc` clone, no new mapping).
     Mapped(Arc<Mmap>),
@@ -100,6 +142,9 @@ pub(crate) enum ScanSource {
     Direct {
         /// Read-ahead window (bytes) for each scan's [`DirectCursor`].
         window: usize,
+        /// Immutable file length captured at reader open (issue #1586), used by
+        /// the buffered fallback when direct I/O is refused.
+        file_len: u64,
     },
 }
 
@@ -107,10 +152,12 @@ impl ScanSource {
     /// Mint a fresh, independent [`BlockSource`] for one scan.
     pub(crate) async fn open(&self, path: &Path) -> Result<BlockSource> {
         Ok(match self {
-            ScanSource::Buffered => BlockSource::buffered(File::open(path).await?),
+            ScanSource::Buffered { file_len } => {
+                BlockSource::buffered_sized(File::open(path).await?, *file_len)
+            }
             ScanSource::Mapped(mmap) => BlockSource::mapped(mmap.clone()),
             #[cfg(unix)]
-            ScanSource::Direct { window } => {
+            ScanSource::Direct { window, file_len } => {
                 // Reopen with O_DIRECT for this scan. If the platform/filesystem
                 // refuses direct I/O, degrade to buffered rather than failing the
                 // scan (mirrors the open()-time fallback).
@@ -122,7 +169,7 @@ impl ScanSource {
                             path.display(),
                             e
                         );
-                        BlockSource::buffered(File::open(path).await?)
+                        BlockSource::buffered_sized(File::open(path).await?, *file_len)
                     }
                 }
             }
@@ -159,7 +206,7 @@ impl AsyncRead for BlockSource {
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
         match self.get_mut() {
-            BlockSource::Buffered(r) => Pin::new(r).poll_read(cx, buf),
+            BlockSource::Buffered { reader, .. } => Pin::new(reader).poll_read(cx, buf),
             BlockSource::Mapped(c) => Pin::new(c).poll_read(cx, buf),
             #[cfg(unix)]
             BlockSource::Direct(c) => Pin::new(c).poll_read(cx, buf),
@@ -170,7 +217,7 @@ impl AsyncRead for BlockSource {
 impl AsyncSeek for BlockSource {
     fn start_seek(self: Pin<&mut Self>, position: SeekFrom) -> io::Result<()> {
         match self.get_mut() {
-            BlockSource::Buffered(r) => Pin::new(r).start_seek(position),
+            BlockSource::Buffered { reader, .. } => Pin::new(reader).start_seek(position),
             BlockSource::Mapped(c) => Pin::new(c).start_seek(position),
             #[cfg(unix)]
             BlockSource::Direct(c) => Pin::new(c).start_seek(position),
@@ -179,7 +226,7 @@ impl AsyncSeek for BlockSource {
 
     fn poll_complete(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<u64>> {
         match self.get_mut() {
-            BlockSource::Buffered(r) => Pin::new(r).poll_complete(cx),
+            BlockSource::Buffered { reader, .. } => Pin::new(reader).poll_complete(cx),
             BlockSource::Mapped(c) => Pin::new(c).poll_complete(cx),
             #[cfg(unix)]
             BlockSource::Direct(c) => Pin::new(c).poll_complete(cx),


### PR DESCRIPTION
Closes #1586. Epic E child E4 (read-path perf, #1517). Oracle-driven, **behavior-preserving** — same bytes read, same bounds/CRC errors; purely removes redundant seek syscalls.

## Problem
Every chunk read re-derived the immutable SSTable file size via 3–4 `seek` syscalls (while holding the cursor lock). A K-chunk scan paid ~5K seeks instead of ~K.

## Changes
- Cache the file length once at reader open (already computed at `reader/mod.rs`) and thread it into the block-I/O layer (`BlockSource::Buffered { len }`, `ScanSource` carries `file_len`).
- Delete the per-chunk `seek(End)` size probes at both anchor sites (`block_io.rs`, `chunk_decompressor.rs`); bounds-check against the cached length.
- Skip `seek(Start(pos))` when the cursor is already at `pos` (sequential chunk N+1), tracked locally; reset at each public entry point for reader-identity safety.
- Cached length is per-open of an immutable SSTable — never cached across reopen.

## Test (TDD — failed on main, passes after)
`chunk_decompressor::tests::read_all_data_does_not_reprobe_file_size_per_chunk` (seek-counting wrapper over an 8-chunk LZ4 file):
- Before: **32 seeks (4/chunk)** → FAILS
- After: **3 seeks total** → PASSES

33-table parity + smoke green; 2667 core lib tests pass.

## Gate
`scripts/agent-gate.sh` → **RESULT: PASS** (all components; `file-size` acked via `CQLITE_ALLOW_FILE_GROWTH=1` for +6-line `mod.rs` threading, epic #1116; `source.rs` trimmed back under threshold).