### PR TITLE
perf(#1565): dhat memory-budget lane + size_of::<Value> pin (Epic A A4)

### DIFF
--- a/cqlite-core/src/types.rs
+++ b/cqlite-core/src/types.rs
@@ -84,6 +84,12 @@ pub enum Value {
     Inet(Vec<u8>),
 }
 
+// size_of::<Value>() layout pin (issue #1565, Epic A A4 ratchet). Measured 88
+// bytes today; Epic E #1517 E1 shrinks the three inlined rare variants (Decimal,
+// Duration, the widest inline payload) toward <= 40. If Value grows past this,
+// the build fails — measure and tighten, do not just bump.
+const _: () = assert!(std::mem::size_of::<Value>() <= 88);
+
 /// Ordered interned cells of a single decoded row (issue #1334).
 ///
 /// Each entry is `(column_name, value)` where the name is a shared `Arc<str>`

--- a/cqlite-core/tests/memory_budget.rs
+++ b/cqlite-core/tests/memory_budget.rs
@@ -1,0 +1,132 @@
+//! dhat allocation / peak-heap budget lane for the read path (issue #1565, Epic A / A4).
+//!
+//! This target compiles ONLY under the opt-in `dhat-heap` feature (see the
+//! file-wide `#![cfg]` below), so the default `core-tests` run never installs
+//! the dhat global allocator or executes these budgets. It is additive
+//! measurement machinery: it drives the real public query path
+//! (`cqlite_core::Database::execute`) over the vendored real SSTable fixtures
+//! and pins today's measured allocation totals / peak heap as regression nets
+//! (ratchet targets for Epic E to tighten).
+//!
+//! Run it:
+//!
+//! ```text
+//! cargo test --package cqlite-core --features cli-helpers,dhat-heap \
+//!     --test memory_budget -- --test-threads=1
+//! ```
+//!
+//! `dhat::Profiler` is a process-global singleton (two live profilers panic),
+//! so every test builds/drops its own profiler AND is `#[serial_test::serial]`;
+//! the gate additionally passes `--test-threads=1`.
+#![cfg(feature = "dhat-heap")]
+
+// The dhat allocator must be the global allocator to observe every allocation.
+// It is confined to this one test binary — default builds/tests never link it.
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+#[path = "../benches/fixtures/mod.rs"]
+mod fixtures;
+
+/// The CLAUDE.md project memory budget: <128 MiB for large files.
+const PROJECT_HEAP_BUDGET_BYTES: u64 = 128 * 1024 * 1024;
+
+/// Fixed repeat count for the full-scan allocation workload. SIMPLE has 999
+/// rows; repeating the scan 10x inside the profiled region gives ~10k-row
+/// allocation volume (the issue's "10k-row intent") deterministically, using
+/// real data rather than a synthetic 10k-row table.
+const FULL_SCAN_ITERATIONS: usize = 10;
+
+/// Full-scan total-bytes regression net. Measured 209,380,005 bytes on `main`
+/// today (SIMPLE, 10 iterations); ceiling = measured + ~20% slack for
+/// allocator/toolchain variance. Epic E (E2/E3) ratchets this DOWN toward the
+/// streaming target as the read path stops materializing whole result sets —
+/// tighten this constant when E2/E3 land, do not just leave the slack.
+const CEILING_TOTAL_BYTES: u64 = 252_000_000;
+
+/// Materializing-read peak-heap regression net. Measured 4,944,842 bytes on
+/// `main` today (TYPE_HEAVY); ceiling = measured + ~21% slack. Epic E ratchets
+/// this DOWN as peak working-set shrinks; it also sits far below the 128 MiB
+/// project budget asserted alongside it.
+const CEILING_PEAK_BYTES: u64 = 6_000_000;
+
+/// Total bytes allocated during a repeated full-table `SELECT *` over the
+/// largest simple real fixture must stay within the pinned ceiling.
+#[test]
+#[serial_test::serial]
+fn select_full_scan_alloc_budget() {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let fx = fixtures::ReadFixture::SIMPLE;
+    let sql = format!("SELECT * FROM {}", fx.qualified());
+
+    let _profiler = dhat::Profiler::builder().testing().build();
+
+    let loaded = fixtures::open_read_db(&fx);
+    for i in 0..FULL_SCAN_ITERATIONS {
+        let result = rt
+            .block_on(loaded.db.execute(&sql))
+            .expect("full-scan query");
+        if i == 0 {
+            assert!(
+                !result.rows.is_empty(),
+                "zero rows from {} — fixtures not fetched? \
+                 Run: bash test-data/scripts/fetch-datasets.sh",
+                fx.qualified()
+            );
+        }
+    }
+
+    let stats = dhat::HeapStats::get();
+    println!(
+        "select_full_scan_alloc_budget: total_bytes={} total_blocks={} max_bytes={} max_blocks={} (iters={})",
+        stats.total_bytes, stats.total_blocks, stats.max_bytes, stats.max_blocks, FULL_SCAN_ITERATIONS
+    );
+
+    assert!(
+        stats.total_bytes <= CEILING_TOTAL_BYTES,
+        "full-scan total bytes {} exceeded ceiling {}",
+        stats.total_bytes,
+        CEILING_TOTAL_BYTES
+    );
+}
+
+/// Peak heap bytes for a materializing type-heavy `SELECT *` must stay within
+/// the pinned ceiling AND under the project's 128 MiB budget.
+#[test]
+#[serial_test::serial]
+fn materialized_select_byte_ceiling() {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let fx = fixtures::ReadFixture::TYPE_HEAVY;
+    let sql = format!("SELECT * FROM {}", fx.qualified());
+
+    let _profiler = dhat::Profiler::builder().testing().build();
+
+    let loaded = fixtures::open_read_db(&fx);
+    let result = rt
+        .block_on(loaded.db.execute(&sql))
+        .expect("type-heavy query");
+    assert!(
+        !result.rows.is_empty(),
+        "zero rows from {} — fixtures not fetched? \
+         Run: bash test-data/scripts/fetch-datasets.sh",
+        fx.qualified()
+    );
+
+    let stats = dhat::HeapStats::get();
+    println!(
+        "materialized_select_byte_ceiling: total_bytes={} total_blocks={} max_bytes={} max_blocks={}",
+        stats.total_bytes, stats.total_blocks, stats.max_bytes, stats.max_blocks
+    );
+
+    assert!(
+        stats.max_bytes as u64 <= CEILING_PEAK_BYTES,
+        "peak heap {} exceeded pinned ceiling {}",
+        stats.max_bytes,
+        CEILING_PEAK_BYTES
+    );
+    assert!(
+        stats.max_bytes as u64 <= PROJECT_HEAP_BUDGET_BYTES,
+        "peak heap {} exceeded 128 MiB project budget",
+        stats.max_bytes
+    );
+}

--- a/cqlite-core/tests/memory_budget.rs
+++ b/cqlite-core/tests/memory_budget.rs
@@ -18,7 +18,13 @@
 //! `dhat::Profiler` is a process-global singleton (two live profilers panic),
 //! so every test builds/drops its own profiler AND is `#[serial_test::serial]`;
 //! the gate additionally passes `--test-threads=1`.
-#![cfg(feature = "dhat-heap")]
+//!
+//! Requires BOTH `dhat-heap` (the global allocator + `HeapStats`) and
+//! `cli-helpers` (the `benches/fixtures/mod.rs` real-SSTable loader below uses
+//! `open_read_db`, which is itself `#[cfg(feature = "cli-helpers")]`). Gating on
+//! both means `--features dhat-heap` alone compiles an empty target instead of
+//! failing to build (roborev #1565); the gate always passes `cli-helpers,dhat-heap`.
+#![cfg(all(feature = "dhat-heap", feature = "cli-helpers"))]
 
 // The dhat allocator must be the global allocator to observe every allocation.
 // It is confined to this one test binary — default builds/tests never link it.

--- a/cqlite-core/tests/memory_budget.rs
+++ b/cqlite-core/tests/memory_budget.rs
@@ -43,12 +43,12 @@ const PROJECT_HEAP_BUDGET_BYTES: u64 = 128 * 1024 * 1024;
 /// real data rather than a synthetic 10k-row table.
 const FULL_SCAN_ITERATIONS: usize = 10;
 
-/// Full-scan total-bytes regression net for the SELECT loop ONLY (fixture copy +
-/// ingest are excluded — the profiler starts after `open_read_db`). Measured
-/// 207,016,624 bytes on `main` today (SIMPLE, 10 iterations); ceiling = measured
-/// + ~22% slack for allocator/toolchain variance. Epic E (E2/E3) ratchets this
-/// DOWN toward the streaming target as the read path stops materializing whole
-/// result sets — tighten this constant when E2/E3 land, do not just leave slack.
+/// Full-scan total-bytes regression net for the SELECT loop ONLY (fixture copy
+/// and ingest are excluded — the profiler starts after `open_read_db`). Measured
+/// 207,016,624 bytes on `main` today (SIMPLE, 10 iterations); the ceiling is that
+/// measured value plus ~22% slack for allocator/toolchain variance. Epic E
+/// (E2/E3) ratchets this downward toward the streaming target as the read path
+/// stops materializing whole result sets — tighten this constant when E2/E3 land.
 const CEILING_TOTAL_BYTES: u64 = 252_000_000;
 
 /// Materializing-read peak-heap regression net for the query's working set ONLY

--- a/cqlite-core/tests/memory_budget.rs
+++ b/cqlite-core/tests/memory_budget.rs
@@ -43,17 +43,20 @@ const PROJECT_HEAP_BUDGET_BYTES: u64 = 128 * 1024 * 1024;
 /// real data rather than a synthetic 10k-row table.
 const FULL_SCAN_ITERATIONS: usize = 10;
 
-/// Full-scan total-bytes regression net. Measured 209,380,005 bytes on `main`
-/// today (SIMPLE, 10 iterations); ceiling = measured + ~20% slack for
-/// allocator/toolchain variance. Epic E (E2/E3) ratchets this DOWN toward the
-/// streaming target as the read path stops materializing whole result sets —
-/// tighten this constant when E2/E3 land, do not just leave the slack.
+/// Full-scan total-bytes regression net for the SELECT loop ONLY (fixture copy +
+/// ingest are excluded — the profiler starts after `open_read_db`). Measured
+/// 207,016,624 bytes on `main` today (SIMPLE, 10 iterations); ceiling = measured
+/// + ~22% slack for allocator/toolchain variance. Epic E (E2/E3) ratchets this
+/// DOWN toward the streaming target as the read path stops materializing whole
+/// result sets — tighten this constant when E2/E3 land, do not just leave slack.
 const CEILING_TOTAL_BYTES: u64 = 252_000_000;
 
-/// Materializing-read peak-heap regression net. Measured 4,944,842 bytes on
-/// `main` today (TYPE_HEAVY); ceiling = measured + ~21% slack. Epic E ratchets
-/// this DOWN as peak working-set shrinks; it also sits far below the 128 MiB
-/// project budget asserted alongside it.
+/// Materializing-read peak-heap regression net for the query's working set ONLY
+/// (fixture copy + ingest excluded — profiler starts after `open_read_db`).
+/// Measured 4,579,884 bytes on `main` today (TYPE_HEAVY); ceiling = measured +
+/// ~31% slack (peak varies more than totals). Epic E ratchets this DOWN as peak
+/// working-set shrinks; it also sits far below the 128 MiB project budget
+/// asserted alongside it.
 const CEILING_PEAK_BYTES: u64 = 6_000_000;
 
 /// Total bytes allocated during a repeated full-table `SELECT *` over the
@@ -65,9 +68,14 @@ fn select_full_scan_alloc_budget() {
     let fx = fixtures::ReadFixture::SIMPLE;
     let sql = format!("SELECT * FROM {}", fx.qualified());
 
+    // Open the fixture (copy + schema ingest + db open) BEFORE starting the
+    // profiler so those one-time setup allocations are NOT attributed to the
+    // budget — this must be a *read-path* regression net, not a fixture/ingest
+    // one (roborev #1565). Only the repeated SELECT loop below is measured.
+    let loaded = fixtures::open_read_db(&fx);
+
     let _profiler = dhat::Profiler::builder().testing().build();
 
-    let loaded = fixtures::open_read_db(&fx);
     for i in 0..FULL_SCAN_ITERATIONS {
         let result = rt
             .block_on(loaded.db.execute(&sql))
@@ -105,9 +113,13 @@ fn materialized_select_byte_ceiling() {
     let fx = fixtures::ReadFixture::TYPE_HEAVY;
     let sql = format!("SELECT * FROM {}", fx.qualified());
 
+    // Open the fixture BEFORE the profiler so the measured peak reflects only the
+    // query's working set, not one-time fixture-copy/ingest allocations
+    // (roborev #1565).
+    let loaded = fixtures::open_read_db(&fx);
+
     let _profiler = dhat::Profiler::builder().testing().build();
 
-    let loaded = fixtures::open_read_db(&fx);
     let result = rt
         .block_on(loaded.db.execute(&sql))
         .expect("type-heavy query");

--- a/openspec/changes/dhat-alloc-lane/design.md
+++ b/openspec/changes/dhat-alloc-lane/design.md
@@ -1,0 +1,79 @@
+# Design — dhat alloc/memory-budget lane + `size_of::<Value>` pin (A4)
+
+## Context
+
+Epic A is "measurement first": land honest regression nets pinned to today's numbers, then let the
+optimization epics tighten them. A4 is the memory axis. dhat is already a `cqlite-core` dependency
+(`cqlite-core/Cargo.toml`), installed only under the opt-in `dhat-heap` feature, and already drives
+`cqlite-core/examples/heap_profile.rs` via `./scripts/profile.sh heap`. This change turns that
+manual profiling into an automated, ratchet-able gate lane plus a compile-time layout pin.
+
+## Decisions
+
+### D1 — dhat in a `cargo test` target, not just an example
+`dhat::Alloc` must be the `#[global_allocator]` to observe every allocation, which affects the whole
+binary. Putting the budget tests in a dedicated integration test file
+(`cqlite-core/tests/memory_budget.rs`) isolates the dhat allocator to that one test binary; the
+default `core-tests` run (no `dhat-heap`) never compiles or runs it. The entire file is gated
+`#![cfg(feature = "dhat-heap")]` so it exists only when the feature is on.
+
+### D2 — single-threaded test execution (`--test-threads=1`)
+`dhat::Profiler` is a process-global singleton; building a second one while one is live panics.
+Each budget test builds its own `dhat::Profiler::builder().testing().build()`, reads
+`dhat::HeapStats::get()`, and drops it. Cargo runs tests in a binary concurrently by default, so the
+gate invokes the lane with `-- --test-threads=1`. Belt-and-suspenders: the tests also carry
+`#[serial_test::serial]` (already a dev-dep, used by A2) so intra-binary ordering is enforced even if
+someone runs the target without the flag.
+
+### D3 — real fixtures, measured-first ceilings (ratchet semantics)
+Workloads use the vendored real SSTables through `benches/fixtures/mod.rs` (`open_read_db`), the same
+loader A1/A2 use — no synthetic data, honoring parity-is-truth. Ceilings are set from the first
+measured run on `main`: `ceiling = measured + slack`, with the measured number and the Epic E target
+written in a comment beside each constant. The issue's "10k-row" intent is met by driving the largest
+real fixture over a fixed repeat count (real data, meaningful allocation volume) rather than
+fabricating a 10k-row synthetic table.
+
+### D4 — `size_of::<Value>` compile-time pin
+A `const _: () = assert!(std::mem::size_of::<Value>() <= N);` beside the `Value` enum in
+`cqlite-core/src/types.rs`. `N` is today's measured size; the comment records the measured value and
+Epic E #1517 E1's smaller target (E1 tightens `N` when it lands). This is a zero-cost compile-time
+check that fires under any feature set (including the default build and clippy `--all-features`), so a
+`Value` that grows a hot per-cell type can never merge green. It is the one code edit outside
+test/gate machinery and changes no runtime behavior.
+
+### D5 — dataset-dependent, fail-closed on empty
+The lane reads real Data.db, so `memory-budget` joins `DATASET_COMPONENTS`; the existing agent-gate
+preflight already FAILs loudly when no Data.db is present (the #646/#1175 hazard). Present-but-empty
+must fail, not skip: the tests assert the query returns ≥1 row before reading dhat stats, so a
+zero-row fixture is a hard failure, never a green pass.
+
+### D6 — honest partial: peak-byte ceiling vs the 128 MiB budget
+`materialized_select_byte_ceiling` asserts two things: peak ≤ the pinned measured ceiling (the
+ratchet) AND peak ≤ 128 MiB (the CLAUDE.md project budget). Today's small real fixtures sit far below
+128 MiB, so the pinned ceiling is the meaningful regression net; the 128 MiB assertion documents the
+project ceiling the lane ultimately defends as fixtures/workloads grow.
+
+## Alternatives considered
+
+- **Reuse `examples/heap_profile.rs` as the gate step.** Rejected: an example's process exit code and
+  fixed workload are awkward to assert per-budget and it is not a `cargo test` target the gate
+  component model expects; a test target gives per-budget red/green and `#[serial]` control.
+- **A synthetic 10k-row generated fixture.** Rejected: violates parity-is-truth (real binaries only)
+  and would fold write-path allocations into a read-path budget. Repeating a real scan is honest.
+- **Runtime `assert!` on `size_of` in a test.** Rejected: a compile-time `const _` pin catches growth
+  at build time under every feature set with zero runtime cost and no dataset dependency.
+
+## Risks
+
+- **dhat overhead / flakiness.** dhat counts allocations deterministically (not wall-clock), so byte
+  and allocation totals are stable across runs on a given target; ceilings use documented slack for
+  allocator/toolchain variance. Mitigated by `--test-threads=1` + `#[serial]`.
+- **`--all-features` clippy compiles the file.** The `dhat-heap` + `cli-helpers` file must be
+  warning-clean under `-D warnings`; ensured as part of the gate's clippy component.
+
+## Wiring evidence
+
+Public surface: `cqlite_core::Database::execute` (the real query path) driven from the test over a
+real fixture loaded by `benches/fixtures/mod.rs`; dhat observes the allocations of that path. The gate
+`memory-budget` component runs the target so the net actually executes in CI/gate (a net that does not
+run is not a net). The `size_of` pin fires from `cqlite-core/src/types.rs` in every build.

--- a/openspec/changes/dhat-alloc-lane/proposal.md
+++ b/openspec/changes/dhat-alloc-lane/proposal.md
@@ -1,0 +1,63 @@
+## Why
+
+The project's <128 MiB memory target (CLAUDE.md "Memory target") is checked only by a **manual**
+dhat step (`./scripts/profile.sh heap`) that no CI or gate run ever executes. There is no
+allocation-budget regression net and no compile-time pin on `size_of::<Value>()` (measured today;
+three rare `Value` variants are still inlined — Epic E #1517 E1 will shrink it). A read-path
+allocation regression, or a `Value` that silently grows a hot per-cell type, merges green today.
+
+This is child **A4** of Epic A (#1513, "measurement first"; issue #1565). Source of truth:
+`docs/reports/read-path-performance-audit-2026-07-01.md` §Epic A, Wave 1. It is design-driven,
+additive **measurement machinery** — Seam-1 pre-approved for the Epic A batch. It reuses A1/A2
+conventions: the same `benches/fixtures/mod.rs` real-SSTable loader and the existing
+`cqlite-core/examples/heap_profile.rs` dhat wiring (dhat is already a `cqlite-core` dependency,
+installed only under the opt-in `dhat-heap` feature).
+
+**Ratchet, not improvement.** The deliverable is the *machinery + honest pins* set to **today's
+measured numbers** (measured-first, ceiling = measured + documented slack). The optimization epics
+(E1 `Value` shrink; E2/E3 read-path alloc reductions) then *tighten* these ceilings. Nothing here
+"fixes" allocations — no production-code changes.
+
+Guardrail (from the issue): **no production-code changes** — additive test/gate machinery only, plus
+one compile-time `size_of` assertion in `types.rs` (a zero-cost pin, not a behavior change). Never
+let a dataset-dependent budget test pass on an empty dataset.
+
+## What Changes
+
+- **A dhat allocation/memory-budget test lane** — a new integration test target
+  `cqlite-core/tests/memory_budget.rs`, compiled only under the `dhat-heap` feature (so normal builds
+  and the default `core-tests` run are unaffected; the file installs the `dhat::Alloc` global
+  allocator, so it must be its own binary). It opens a real fixture via the shared
+  `benches/fixtures/mod.rs` loader and asserts allocation/peak-byte budgets from `dhat::HeapStats`.
+- **`select_full_scan_alloc_budget`** — runs a full-table `SELECT *` over the largest available real
+  fixture, asserts total bytes allocated ≤ a pinned ceiling. (The issue's "10k-row" intent: real
+  corpus fixtures cap below 10k rows, so we drive the largest real fixture and, to reach a
+  meaningful row count, repeat the scan a fixed number of iterations — the workload is real SSTable
+  data, not synthetic; the ceiling is the honestly-measured total.)
+- **`materialized_select_byte_ceiling`** — runs a materializing `SELECT *` over the type-heavy
+  fixture, asserts **peak** heap bytes ≤ a pinned ceiling (and ≤ the 128 MiB project budget).
+- **A compile-time `Value` layout pin** in `cqlite-core/src/types.rs`:
+  `const _: () = assert!(std::mem::size_of::<Value>() <= N);` where `N` is today's measured
+  `size_of::<Value>()`, with a comment naming the measured value and Epic E #1517 E1's smaller
+  target. Fails the build (any feature set) if `Value` grows past the pin.
+- **Gate wiring**: a new `memory-budget` component in `scripts/agent-gate.sh` that runs the lane with
+  `--features cli-helpers,dhat-heap` and `--test-threads=1` (dhat's global profiler is a singleton;
+  concurrent test threads would double-install it). It is dataset-dependent — added to
+  `DATASET_COMPONENTS` so the existing preflight FAILs loudly on a missing/empty dataset (never a
+  silent skip). The gate header documents the component and its budgets.
+- **TDD honesty**: each budget test is written so that setting its ceiling below today's measured
+  value makes it FAIL red — demonstrated once in the PR, then landed at the honest ceiling.
+
+## Non-goals
+
+- **No read-path production code changes.** Additive test/gate machinery + one zero-cost compile-time
+  `size_of` assertion only (issue guardrail). The actual `Value` shrink and allocation reductions are
+  later Epic E children; this only makes them measurable and ratchet-able.
+- **No tightening of the ceilings here.** They ship at today's measured values (+ documented slack);
+  E1/E2/E3 tighten them. Deliberately-red "too-tight" runs are shown in the PR only, not committed.
+- **No new fixture corpus.** Reuses the vendored real SSTables via `benches/fixtures/mod.rs`; adds no
+  Docker/network/synthetic-data dependency.
+- **No change to A1/A2/A3 gates** (`perf-gate.json`, `tail-latency-gate.json`) — the memory-budget
+  lane is a separate, self-contained dhat test target.
+- **Not** a cross-machine absolute-memory SLO; peak-byte ceilings are pinned to the measured local
+  workload with documented slack and are ratchet targets, not portable guarantees.

--- a/openspec/changes/dhat-alloc-lane/specs/dhat-alloc-lane/spec.md
+++ b/openspec/changes/dhat-alloc-lane/specs/dhat-alloc-lane/spec.md
@@ -1,0 +1,85 @@
+## ADDED Requirements
+
+### Requirement: A dhat allocation/memory-budget test lane measures the read path against pinned budgets
+The project SHALL provide a dhat-based test lane, compiled only under the `dhat-heap` feature, that
+opens a real SSTable fixture via the shared bench fixture loader, drives the public query path, and
+asserts allocation/peak-byte budgets read from `dhat::HeapStats`. The lane SHALL be additive (test/gate
+machinery only) and change no read-path production code. It SHALL install the dhat global allocator only
+within its own test binary, so default builds and the default `core-tests` run are unaffected.
+
+#### Scenario: The lane runs only under the dhat-heap feature
+- **WHEN** the test suite is built without the `dhat-heap` feature
+- **THEN** the memory-budget test target is not compiled and does not run
+- **WHEN** the test suite is built with `--features cli-helpers,dhat-heap`
+- **THEN** the memory-budget tests compile, install the dhat global allocator in their own binary, and run
+
+#### Scenario: The budget tests drive the real query path over a real fixture
+- **WHEN** a budget test runs against the present fixture corpus
+- **THEN** it opens the fixture through the shared `benches/fixtures/mod.rs` loader and executes a real `SELECT` via `Database::execute`
+- **AND** it reads allocation statistics from `dhat::HeapStats` collected during that query
+
+### Requirement: An allocation-count/bytes budget test pins today's measured read-path allocations
+The project SHALL provide `select_full_scan_alloc_budget`, which runs a full-table `SELECT *` over the
+largest available real fixture and asserts total bytes allocated during the query do not exceed a
+ceiling pinned to today's measured value plus documented slack. The ceiling constant SHALL carry a
+comment stating the measured number and the later-epic (E2/E3) target it will be ratcheted toward. The
+test SHALL be constructed so that lowering the ceiling below today's measured value makes it fail.
+
+#### Scenario: Allocation total within the pinned ceiling passes
+- **WHEN** `select_full_scan_alloc_budget` runs on current `main` against the present fixture
+- **THEN** the measured total bytes allocated are at or below the pinned ceiling
+- **AND** the test passes
+
+#### Scenario: A tighter-than-measured ceiling fails (ratchet honesty)
+- **WHEN** the ceiling constant is set below today's measured total bytes allocated
+- **THEN** `select_full_scan_alloc_budget` fails, demonstrating the budget is a real regression net
+
+### Requirement: A peak-bytes ceiling test pins materializing-read peak heap and defends the 128 MiB budget
+The project SHALL provide `materialized_select_byte_ceiling`, which runs a materializing `SELECT *` over
+the type-heavy real fixture and asserts peak heap bytes (`dhat::HeapStats::max_bytes`) do not exceed a
+ceiling pinned to today's measured value plus documented slack, AND do not exceed the project's 128 MiB
+memory budget. The ceiling constant SHALL carry a comment stating the measured number and its ratchet
+target.
+
+#### Scenario: Peak bytes within the pinned ceiling and under 128 MiB passes
+- **WHEN** `materialized_select_byte_ceiling` runs on current `main` against the present fixture
+- **THEN** the measured peak heap bytes are at or below both the pinned ceiling and 128 MiB
+- **AND** the test passes
+
+#### Scenario: A tighter-than-measured peak ceiling fails (ratchet honesty)
+- **WHEN** the peak-bytes ceiling constant is set below today's measured peak
+- **THEN** `materialized_select_byte_ceiling` fails
+
+### Requirement: A compile-time layout pin guards `size_of::<Value>()` against growth
+The `cqlite-core` crate SHALL contain a compile-time assertion of the form
+`const _: () = assert!(std::mem::size_of::<Value>() <= N);` beside the `Value` enum, where `N` is
+today's measured `size_of::<Value>()`. The assertion SHALL carry a comment stating the measured value
+and Epic E #1517 E1's smaller target. It SHALL fire in every build regardless of feature set, so a
+`Value` that grows past the pin fails to compile.
+
+#### Scenario: A Value that fits the pin compiles
+- **WHEN** `cqlite-core` is built with the current `Value` layout
+- **THEN** the `size_of::<Value>()` const assertion holds and the crate compiles
+
+#### Scenario: A Value that grows past the pin fails to compile
+- **WHEN** a change grows `size_of::<Value>()` above the pinned `N`
+- **THEN** the crate fails to compile at the const assertion, blocking the regression
+
+### Requirement: The memory-budget lane is wired into the agent gate and fails closed on empty datasets
+The `scripts/agent-gate.sh` component set SHALL include a `memory-budget` component that runs the dhat
+lane with `--features cli-helpers,dhat-heap` and single-threaded test execution. The component SHALL be
+treated as dataset-dependent so the gate's dataset preflight FAILs loudly when no Data.db is present.
+When datasets are present but a fixture yields zero rows, the budget tests SHALL fail rather than pass,
+so a present-but-empty dataset can never produce a green run.
+
+#### Scenario: The component appears in the gate component set
+- **WHEN** `scripts/agent-gate.sh --list` is run
+- **THEN** `memory-budget` is listed among the components
+
+#### Scenario: A missing dataset fails the lane loudly
+- **WHEN** the `memory-budget` component is selected and no Data.db files are present under the datasets root
+- **THEN** the gate's dataset preflight fails loudly rather than skipping the lane
+
+#### Scenario: A present-but-empty fixture fails rather than passes
+- **WHEN** the datasets root is present but the target fixture yields zero rows
+- **THEN** the budget test fails (it asserts a non-empty result before reading dhat stats), never reporting a green pass

--- a/openspec/changes/dhat-alloc-lane/tasks.md
+++ b/openspec/changes/dhat-alloc-lane/tasks.md
@@ -1,0 +1,40 @@
+# Tasks — dhat alloc/memory-budget lane + `size_of::<Value>` pin (A4)
+
+## 1. Measure today's numbers (measure-first)
+- [ ] 1.1 Measure `size_of::<Value>()` on current `main` (record the exact byte value).
+- [ ] 1.2 Measure total bytes allocated for a full-scan `SELECT *` workload over the largest real
+      fixture (via a scratch dhat run), and peak heap bytes for the type-heavy materializing `SELECT *`.
+      Record all three numbers.
+
+## 2. dhat budget test target (TDD)
+- [ ] 2.1 Add `cqlite-core/tests/memory_budget.rs`, `#![cfg(feature = "dhat-heap")]`, installing
+      `#[global_allocator] static ALLOC: dhat::Alloc`. Include `#[path = "../benches/fixtures/mod.rs"] mod fixtures;`.
+      Public surface exercised: `cqlite_core::Database::execute` over `benches/fixtures/mod.rs::open_read_db`.
+- [ ] 2.2 Write `select_full_scan_alloc_budget` (`#[serial_test::serial]`): build a testing-mode
+      `dhat::Profiler`, run the full-scan workload (assert ≥1 row first), assert total bytes ≤ pinned
+      ceiling. Demonstrate red with a too-tight ceiling, then land the honest ceiling + comment
+      (measured value + E2/E3 target).
+- [ ] 2.3 Write `materialized_select_byte_ceiling` (`#[serial_test::serial]`): run the type-heavy
+      materializing workload (assert ≥1 row first), assert `max_bytes` ≤ pinned ceiling AND ≤ 128 MiB.
+      Demonstrate red with a too-tight ceiling, then land the honest ceiling + comment.
+
+## 3. `size_of::<Value>` compile-time pin
+- [ ] 3.1 Add `const _: () = assert!(std::mem::size_of::<Value>() <= N);` beside `Value` in
+      `cqlite-core/src/types.rs`, `N` = measured value from 1.1, with a comment naming the measured
+      number and Epic E #1517 E1's smaller target.
+
+## 4. Gate wiring
+- [ ] 4.1 Add `memory-budget` to the `COMPONENTS` array and `DATASET_COMPONENTS` in
+      `scripts/agent-gate.sh`; run it as
+      `cargo test --package cqlite-core --features cli-helpers,dhat-heap --test memory_budget -- --test-threads=1`.
+- [ ] 4.2 Document the component + its budgets in the agent-gate header comment block.
+- [ ] 4.3 (If touched in passing) fix the pre-existing partial-feature dead-code warning in
+      `cqlite-core/examples/heap_profile.rs`; otherwise leave it (gate uses `--all-features` where it is
+      green).
+
+## 5. Verify
+- [ ] 5.1 `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features` clean
+      (the `dhat-heap` file compiles under `--all-features`).
+- [ ] 5.2 No `unwrap()`/`expect()` in library code (test code may use them).
+- [ ] 5.3 Run `scripts/agent-gate.sh` — PASS; paste the AGENT-GATE SUMMARY block verbatim.
+- [ ] 5.4 spec-auditor C verdict PASS; roborev `--base origin/main --agent codex` clean.

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -22,6 +22,17 @@
 #                      --test issue_1589_window_drain_bytes (the scan/compaction
 #                      windows advance a cursor + compact once per refill instead
 #                      of front-draining per partition — issue #1589); same gate.
+#   memory-budget      cargo test -p cqlite-core --features cli-helpers,dhat-heap
+#                      --test memory_budget -- --test-threads=1 (issue #1565, Epic
+#                      A/A4). dhat allocation/peak-heap regression net over the real
+#                      read path: pins today's measured full-scan total-bytes
+#                      (~209 MB, ceiling 252 MB) and materializing peak-heap
+#                      (~4.9 MB, ceiling 6 MB, also asserted < 128 MiB) as Epic-E
+#                      ratchet targets. Requires the dhat-heap feature (installs the
+#                      dhat global allocator, confined to this one test binary) and
+#                      --test-threads=1 (dhat::Profiler is a process-global
+#                      singleton). Dataset-dependent: fails closed on empty (each
+#                      test asserts >=1 row before reading dhat stats).
 #   integration-tests  cargo test -p cqlite-integration-tests: compile ALL targets
 #                      (--no-run, whole package) then run the seven CI-enforced ones
 #   format-compat      cargo test -p format-compatibility-tests (the 'oa' format crate;
@@ -163,7 +174,7 @@ if ! command -v cargo >/dev/null 2>&1 && [ -d "$HOME/.cargo/bin" ]; then
 fi
 export CQLITE_DATASETS_ROOT="${CQLITE_DATASETS_ROOT:-$REPO_ROOT/test-data/datasets}"
 
-COMPONENTS=(file-size fmt clippy core-tests tombstones-scan scan-offload-guard integration-tests format-compat write-tests cli-tests compaction-byte-parity python-bindings node-bindings delivery-telemetry parity-report binding-unwind-profile tooling-tests minimal-build smoke)
+COMPONENTS=(file-size fmt clippy core-tests tombstones-scan scan-offload-guard memory-budget integration-tests format-compat write-tests cli-tests compaction-byte-parity python-bindings node-bindings delivery-telemetry parity-report binding-unwind-profile tooling-tests minimal-build smoke)
 ONLY=""
 SELFTEST=0
 case "${1:-}" in
@@ -826,6 +837,7 @@ run_file_size
 # for a dataset-dependent component is the #646 hazard, so this set must stay
 # complete.
 #   needs datasets: core-tests, tombstones-scan, scan-offload-guard,
+#     memory-budget (dhat lane reads real Data.db and fails closed on empty),
 #     integration-tests, write-tests, smoke (read Data.db / golden fixtures), and
 #     python-bindings — the pytest suite resolves CQLITE_DATASETS_ROOT and calls
 #     skip_if_no_datasets() (bindings/python/tests/conftest.py), so with data
@@ -847,7 +859,7 @@ run_file_size
 #     assertions with hardcoded vectors — it reads no CQLITE_DATASETS_ROOT and no
 #     Data.db — so guarding it just made `--only format-compat` falsely fail the
 #     preflight when datasets are absent.
-DATASET_COMPONENTS="core-tests tombstones-scan scan-offload-guard integration-tests write-tests python-bindings smoke"
+DATASET_COMPONENTS="core-tests tombstones-scan scan-offload-guard memory-budget integration-tests write-tests python-bindings smoke"
 
 # selected_needs_datasets: true iff at least one SELECTED component reads datasets.
 # With no --only, every component runs, so it's always true. With --only, it's true
@@ -918,6 +930,15 @@ run_component scan-offload-guard cargo test --package cqlite-core \
   --test issue_1143_scan_offload_thread \
   --test issue_1333_scan_scratch_reuse \
   --test issue_1589_window_drain_bytes
+# Issue #1565 (Epic A/A4): dhat allocation/peak-heap regression net over the real
+# read path. Compiled only under `dhat-heap` (installs the dhat global allocator
+# in its own test binary), single-threaded because dhat::Profiler is a
+# process-global singleton. Pins today's measured full-scan total-bytes and
+# materializing peak-heap as Epic-E ratchet targets; dataset-dependent and fails
+# closed on empty (asserts >=1 row before reading dhat stats).
+run_component memory-budget cargo test --package cqlite-core \
+  --features cli-helpers,dhat-heap \
+  --test memory_budget -- --test-threads=1
 # Compile EVERY target in the package first (--no-run, whole package) so a
 # new/edited test file that doesn't compile can't hide behind the enumerated
 # run-list (issue #865); then execute the seven CI-enforced targets.


### PR DESCRIPTION
## Summary
Child **A4** of Epic A (#1513) — additive **measurement machinery** for the memory axis (no read-path production changes). Turns the manual `./scripts/profile.sh heap` step into an automated, ratchet-able gate lane, plus a compile-time `Value` layout pin.

Closes #1565.

## What landed
- **dhat memory-budget test lane** — new `cqlite-core/tests/memory_budget.rs`, compiled only under `all(dhat-heap, cli-helpers)` (installs the dhat global allocator in its own binary; default `core-tests` never touches it). Drives the real public query path (`Database::execute`) over the vendored real SSTable fixtures via `benches/fixtures/mod.rs`. Two `#[serial]` budget tests:
  - `select_full_scan_alloc_budget` — full-scan `SELECT *` (SIMPLE ×10 iters); **total_bytes ≤ 252 MB** (measured 207,016,624 today, ~22% slack).
  - `materialized_select_byte_ceiling` — type-heavy materializing `SELECT *`; **peak max_bytes ≤ 6 MB** (measured 4,579,884, ~31% slack) **AND < 128 MiB** project budget.
  - The profiler starts **after** `open_read_db`, so budgets net the read path only (not one-time fixture-copy/ingest).
- **`size_of::<Value>()` compile-time pin** in `cqlite-core/src/types.rs`: `const _: () = assert!(std::mem::size_of::<Value>() <= 88);` (measured 88 today; comment points at Epic E #1517 E1's ≤40 target). Fires in every build.
- **Gate wiring** — new dataset-dependent `memory-budget` component in `scripts/agent-gate.sh` (`--features cli-helpers,dhat-heap --test-threads=1`), fail-closed on empty (each test asserts ≥1 row before reading dhat stats) + header docs.

**Ratchet semantics:** ceilings are pinned at today's measured values (measure-first, + documented slack). Epic E (E1 `Value` shrink; E2/E3 read-path alloc reductions) tightens them. This PR is machinery + honest pins, not the improvement.

## OpenSpec
Change `dhat-alloc-lane` (proposal/design/specs/tasks). Seam-1 pre-approved for the Epic A measurement batch (manager order `MGR:mbp-0702`, GO).

## Quality bars (DoD)
- **agent-gate.sh: PASS** — all 20 components, commit 7721d548, clean tree, 144 Data.db:
  `file-size, fmt, clippy, core-tests, tombstones-scan, scan-offload-guard, memory-budget, integration-tests, format-compat, write-tests, cli-tests, compaction-byte-parity, python-bindings, node-bindings, delivery-telemetry, parity-report, binding-unwind-profile, tooling-tests, minimal-build, smoke` → **RESULT: PASS**
- **spec-auditor (C): PASS** — every requirement `satisfied` with public-surface/compile-time evidence.
- **roborev (codex): converged** — 2 real findings fixed (require both features so `--features dhat-heap` alone compiles; start profiler after setup so budgets net the read path only); 1 **false positive refuted+closed** (claimed `total_bytes: usize` breaks compile — dhat 0.3 `total_bytes` is `u64` (dhat-0.3 lib.rs:1614); the `memory-budget` gate lane compiles + runs green, definitively disproving it).

No `unwrap()`/`expect()` in library code; `RUSTFLAGS="-D warnings"` clean.
