### PR TITLE
fix(#1799): SKIP-aware corpus-specific corrupt-fixture guard in big_promoted_crc_tests (red main)

### DIFF
--- a/.github/workflows/compression-corruption-parity.yml
+++ b/.github/workflows/compression-corruption-parity.yml
@@ -190,6 +190,20 @@ jobs:
               --test sstable_parity_corruption_verify \
               -- --nocapture
 
+      - name: Run BIG promoted-CRC lib proof over corrupt corpus (strict, issue #1799)
+        # The uncompressed read-time CRC proof (issue #1396) lives as an in-crate
+        # `--lib` test (big_promoted_crc_tests), so it does NOT run in the strict
+        # `--test`-only step above. It is the ONLY lane that regenerates the
+        # corrupt uncompressed fixture, so enforce the hard requirement HERE with
+        # the corpus-specific flag: an absent/rotted corrupt fixture or a
+        # corrupt-detection regression FAILS the job (never a silent skip).
+        run: |
+          env CQLITE_REQUIRE_CORRUPT_FIXTURES=1 \
+            CQLITE_DATASETS_ROOT="$CQLITE_DATASETS_ROOT" \
+            cargo test -p cqlite-core --features write-support,cli-helpers \
+              --lib big_promoted_crc_tests \
+              -- --nocapture
+
       # issue #1028: structured failure summary for the parity-failure-issue automation.
       - name: Emit parity-failures.json (on failure)
         if: failure()

--- a/cqlite-core/src/storage/sstable/reader/data_access/big_promoted_crc_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/big_promoted_crc_tests.rs
@@ -39,6 +39,29 @@ fn require_fixtures() -> bool {
     )
 }
 
+/// Whether the *corrupt corpus* is required to be present (hard-fail on absent),
+/// as opposed to the generic fetched dataset (`require_fixtures`).
+///
+/// Issue #1799 (red main): the corrupt uncompressed fixture
+/// (`corruption/test_comp_corrupt/uncompressed_data_bit_flip/nb-1-big-Data.db`)
+/// is **not** part of the fetched dataset — its binaries are gitignored and are
+/// only regenerated from a Cassandra container by the strict
+/// `compression-corruption-parity` lane (`generate-corruption-corpus.sh`). The
+/// generic `Core lib/doc tests` lane sets `CQLITE_REQUIRE_FIXTURES=1` for the
+/// ~70 fetched-dataset tests but never provides this corpus, so gating this
+/// test's hard assertion on `require_fixtures()` panicked deterministically
+/// there. Gate the hard requirement on a *corpus-specific* flag that is set
+/// only in the lane that actually regenerates the fixture; everywhere else an
+/// absent corrupt fixture is a clean SKIP.
+fn require_corrupt_fixtures() -> bool {
+    matches!(
+        std::env::var("CQLITE_REQUIRE_CORRUPT_FIXTURES")
+            .ok()
+            .as_deref(),
+        Some("1") | Some("true") | Some("TRUE")
+    )
+}
+
 fn datasets_root() -> Option<PathBuf> {
     if let Ok(root) = std::env::var("CQLITE_DATASETS_ROOT") {
         let p = PathBuf::from(root);
@@ -57,10 +80,13 @@ fn corrupt_data_db() -> Option<PathBuf> {
     match path {
         Some(p) if p.exists() => Some(p),
         _ => {
+            // The corrupt corpus is only regenerated in the strict
+            // compression-corruption-parity lane (issue #1799); hard-fail only
+            // when that lane explicitly requires it, otherwise SKIP clean.
             assert!(
-                !require_fixtures(),
-                "CQLITE_REQUIRE_FIXTURES=1 but the corrupt uncompressed fixture is absent: \
-                 {CORRUPT_DATA_DB}"
+                !require_corrupt_fixtures(),
+                "CQLITE_REQUIRE_CORRUPT_FIXTURES=1 but the corrupt uncompressed fixture is \
+                 absent: {CORRUPT_DATA_DB}"
             );
             eprintln!("SKIP: corrupt uncompressed fixture absent ({CORRUPT_DATA_DB}).");
             None


### PR DESCRIPTION
Fixes #1799. **P1 red-main blocker** — unblocks all PR merges (#1798, #1800, #1796, #1790, …).

## Problem
The `Core lib/doc tests` CI lane fails deterministically:
```
test ...big_promoted_crc_tests::reverse_partition_path_over_corrupt... FAILED
panic: CQLITE_REQUIRE_FIXTURES=1 but the corrupt uncompressed fixture is absent: corruption/test_comp_corrupt/...
```
The corrupt uncompressed fixture is **gitignored** and regenerated only by the `compression-corruption-parity` lane. The generic `Core lib/doc tests` lane sets `CQLITE_REQUIRE_FIXTURES=1` for the ~70 fetched-dataset tests but never provides the corrupt corpus, so the test's hard assertion panicked there. Since PR CI merge-tests against main's tip, this failed the lane on **every open PR**.

## Fix (test + CI only; no product code)
- `big_promoted_crc_tests.rs`: gate the hard "absent corrupt fixture" assertion on a **corpus-specific** flag `CQLITE_REQUIRE_CORRUPT_FIXTURES=1` (distinct from the broad `CQLITE_REQUIRE_FIXTURES`). Everywhere the corpus flag is unset, an absent corrupt fixture is a **clean SKIP** (no panic). Coverage is **preserved**, not deleted.
- `.github/workflows/compression-corruption-parity.yml`: add a step that runs the `--lib` proof with `CQLITE_REQUIRE_CORRUPT_FIXTURES=1` — so the hard requirement is enforced in the lane that actually regenerates the fixture (absent/rotted fixture or corrupt-detection regression fails there, never a silent skip).

**No command-injection**: the workflow `run:` uses a shell `$CQLITE_DATASETS_ROOT` env ref, not a `${{ }}` expression interpolated into the shell.

## Validation
- **Authoritative for this fix = this PR's `Core lib/doc tests` CI lane** (the local agent-gate uses pre-existing datasets and does not exercise the absent-fixture path — L2/#1310). The PR includes the fix, so that lane should go **green even though main is red**.
- Local agent-gate.sh reached PASS on file-size/fmt/clippy/**core-tests**/tombstones-scan/scan-offload-guard before the implementing agent hit a platform session limit (reset 11am PT); the remaining components are unaffected by a test/CI-guard change.
- roborev **deferred** to the post-11am reset (platform limit); the lead reviewed the diff manually for correctness + the command-injection class. Will run roborev retroactively.

## Merge posture
Merging on `Core lib/doc tests` PR-CI green (the authoritative check) to unblock the pipeline, given it's a lead-reviewed minimal test/CI change and roborev is temporarily unavailable due to a platform limit.