### PR TITLE
perf(#1584): row-assembly interim wins (capacity hints + hoisted projection names)

### DIFF
--- a/cqlite-core/src/query/select_executor/aggregation.rs
+++ b/cqlite-core/src/query/select_executor/aggregation.rs
@@ -139,7 +139,11 @@ pub(super) fn finalize_group(
     group_aggregates: Vec<AggregateValue>,
     agg_plan: &AggregationPlan,
 ) -> QueryRow {
-    let mut row_values: HashMap<std::sync::Arc<str>, Value> = HashMap::new();
+    // Issue #1584: one sized allocation per group — the row holds exactly the
+    // GROUP BY columns plus the aggregate results, so pre-size to that count and
+    // avoid rehash growth.
+    let mut row_values: HashMap<std::sync::Arc<str>, Value> =
+        HashMap::with_capacity(agg_plan.group_by_columns.len() + agg_plan.aggregates.len());
 
     for (i, col) in agg_plan.group_by_columns.iter().enumerate() {
         if let Some(v) = group_key.get(i) {

--- a/cqlite-core/src/query/select_executor/mod.rs
+++ b/cqlite-core/src/query/select_executor/mod.rs
@@ -79,6 +79,35 @@ pub use writetime_ttl::{FixedClock, NowSeconds};
 // `validate_token_predicates` is used by the executor's scan paths.
 use predicate::validate_token_predicates;
 
+// Test-only counter for the number of times a projected column NAME is derived
+// (issue #1584). A thread-local `Cell` (not a global atomic) so parallel test
+// binaries cannot pollute one another; `#[tokio::test]` uses the current-thread
+// runtime, so the future under test runs on the same thread that reads it.
+#[cfg(test)]
+thread_local! {
+    pub(crate) static PROJECTION_NAME_DERIVATIONS: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
+}
+
+/// Derive the output column name for a projected SELECT expression (issue #1584).
+///
+/// Hoisted out of the per-row loop and called ONCE per column per query, so name
+/// derivation is `O(columns)` rather than `O(rows × columns)`. The produced
+/// `Arc<str>` is `clone`d (a ref-count bump) into every row, preserving the exact
+/// output name — the materialized rows are byte-identical to the prior per-row
+/// `String` derivation.
+fn projected_column_name(expr: &SelectExpression, index: usize) -> std::sync::Arc<str> {
+    #[cfg(test)]
+    PROJECTION_NAME_DERIVATIONS.with(|c| c.set(c.get() + 1));
+    match expr {
+        // Issue #692: WriteTimeTtl expressions use Cassandra-convention names.
+        SelectExpression::Column(col_ref) => col_ref.column.as_str().into(),
+        SelectExpression::Aliased(_, alias) => alias.as_str().into(),
+        SelectExpression::WriteTimeTtl(call) => writetime_ttl_column_name(call).into(),
+        _ => format!("col_{index}").into(),
+    }
+}
+
 /// SELECT query executor for SSTable-based storage
 pub struct SelectExecutor {
     /// Schema manager for metadata
@@ -743,21 +772,28 @@ impl SelectExecutor {
         columns: &[SelectExpression],
         _context: &mut ExecutionContext,
     ) -> Result<Vec<QueryRow>> {
-        let mut projected_rows = Vec::new();
+        // Issue #1584: derive the projected output column names ONCE per query
+        // (`O(columns)`), then only `Arc`-clone them into each row's value map
+        // (a ref-count bump). Previously each name was re-derived — `String`
+        // clone / `format!` — for every row × column (`O(rows × columns)`).
+        // Cloning the hoisted `Arc<str>` preserves the exact output name, so the
+        // materialized rows are byte-identical to the prior per-row derivation.
+        let column_names: Vec<std::sync::Arc<str>> = columns
+            .iter()
+            .enumerate()
+            .map(|(i, expr)| projected_column_name(expr, i))
+            .collect();
+
+        let mut projected_rows = Vec::with_capacity(rows.len());
 
         for row in rows {
-            let mut projected_values: HashMap<std::sync::Arc<str>, Value> = HashMap::new();
+            // Issue #1584: one sized allocation per row — no rehash growth.
+            let mut projected_values: HashMap<std::sync::Arc<str>, Value> =
+                HashMap::with_capacity(columns.len());
 
             for (i, expr) in columns.iter().enumerate() {
                 let value = self.evaluate_select_expression(expr, &row)?;
-                // Issue #692: WriteTimeTtl expressions use Cassandra-convention column names.
-                let column_name = match expr {
-                    SelectExpression::Column(col_ref) => col_ref.column.clone(),
-                    SelectExpression::Aliased(_, alias) => alias.clone(),
-                    SelectExpression::WriteTimeTtl(call) => writetime_ttl_column_name(call),
-                    _ => format!("col_{i}"),
-                };
-                projected_values.insert(column_name.into(), value);
+                projected_values.insert(column_names[i].clone(), value);
             }
 
             projected_rows.push(QueryRow {
@@ -1083,6 +1119,75 @@ mod tests {
         );
         assert_eq!(count(b), 2, "partition B has 2 rows, all kept");
         assert_eq!(out.len(), 4);
+    }
+
+    /// Issue #1584: projected column NAMES are derived once per query
+    /// (`O(columns)`), never per row (`O(rows × columns)`). Cloning the hoisted
+    /// `Arc<str>` per row is permitted; re-deriving / formatting a name per row is
+    /// the regression this pins. `#[tokio::test]` runs on the current-thread
+    /// runtime and the derivation counter is thread-local, so this is immune to
+    /// pollution from other tests running in parallel.
+    #[tokio::test]
+    async fn execute_projection_derives_names_once_per_query() {
+        let executor = create_test_executor().await;
+
+        let columns = vec![
+            SelectExpression::Column(ColumnRef {
+                table: None,
+                column: "a".to_string(),
+            }),
+            SelectExpression::Column(ColumnRef {
+                table: None,
+                column: "b".to_string(),
+            }),
+            SelectExpression::Column(ColumnRef {
+                table: None,
+                column: "c".to_string(),
+            }),
+        ];
+        let num_cols = columns.len();
+        let num_rows = 100usize;
+
+        let rows: Vec<QueryRow> = (0..num_rows)
+            .map(|r| {
+                let mut row = QueryRow::new(RowKey::new(vec![r as u8]));
+                row.set("a", Value::Integer(r as i32));
+                row.set("b", Value::Integer(r as i32));
+                row.set("c", Value::Integer(r as i32));
+                row
+            })
+            .collect();
+
+        let mut ctx = ExecutionContext {
+            table_id: TableId::new("ks.t"),
+            columns: Vec::new(),
+            rows_processed: 0,
+            scan_rows: 0,
+            projection_flags: ProjectionFlags::default(),
+            access_path: None,
+            reverse_served: false,
+        };
+
+        PROJECTION_NAME_DERIVATIONS.with(|c| c.set(0));
+        let projected = executor
+            .execute_projection(rows, &columns, &mut ctx)
+            .await
+            .expect("projection must succeed");
+        let derivations = PROJECTION_NAME_DERIVATIONS.with(|c| c.get());
+
+        assert_eq!(projected.len(), num_rows, "one projected row per input row");
+        assert_eq!(
+            derivations,
+            num_cols,
+            "issue #1584: column names must be derived once per query \
+             (O(cols) = {num_cols}), not per row (would be {})",
+            num_rows * num_cols
+        );
+        // Output preserved byte-identically: names + values intact.
+        assert_eq!(projected[0].values.get("a"), Some(&Value::Integer(0)));
+        assert_eq!(projected[0].values.get("b"), Some(&Value::Integer(0)));
+        assert_eq!(projected[0].values.get("c"), Some(&Value::Integer(0)));
+        assert_eq!(projected[99].values.get("a"), Some(&Value::Integer(99)));
     }
 
     /// The executor's `evaluate_select_expression` returns the correct value for

--- a/cqlite-core/src/query/select_executor/row_build.rs
+++ b/cqlite-core/src/query/select_executor/row_build.rs
@@ -104,7 +104,12 @@ pub fn build_row_from_scan(
     // fall through to a non-row fallback (issue #1334 / roborev H2).
     let cells = row.into_cells()?;
 
-    let mut row_values: HashMap<Arc<str>, Value> = HashMap::new();
+    // Issue #1584: pre-size the value map to the upper bound of inserts — the
+    // decoded cell count plus the reconstructed partition-key columns. This is a
+    // single sized allocation with no rehash growth (for `SELECT *` it is exact;
+    // for a narrower projection it slightly over-reserves, still one alloc).
+    let pk_hint = schema.map(|s| s.partition_keys.len()).unwrap_or(0);
+    let mut row_values: HashMap<Arc<str>, Value> = HashMap::with_capacity(cells.len() + pk_hint);
     let project = |name: &str| projection.is_empty() || projection.iter().any(|p| p == name);
 
     // Issue #1334: the decoder carries interned `Arc<str>` column-name handles in
@@ -241,6 +246,31 @@ mod tests {
             row.values.len(),
             2,
             "exactly the two real columns, no extras"
+        );
+    }
+
+    /// Issue #1584: the row value map is pre-sized to the decoded cell count so a
+    /// single sized allocation covers the row (no rehash growth). Pinned via a
+    /// narrow projection: 8 cells are decoded but only ONE survives projection —
+    /// the map's capacity must still reflect the 8-cell hint (`>= 8`). With the
+    /// pre-fix `HashMap::new()` the map is grown from empty to the single inserted
+    /// entry (capacity 3), which fails this lower bound.
+    #[test]
+    fn build_row_from_scan_presizes_value_map() {
+        let cells: Vec<(Arc<str>, Value)> = (0..8)
+            .map(|i| (Arc::from(format!("c{i}").as_str()), Value::Integer(i)))
+            .collect();
+        let key = RowKey::new(b"k".to_vec());
+
+        let row = build_row_from_scan(key, ScanRow::Row(cells), &["c0".to_string()], None)
+            .expect("a live row must build");
+
+        assert_eq!(row.values.len(), 1, "projection keeps exactly one column");
+        assert!(
+            row.values.capacity() >= 8,
+            "issue #1584: value map must be pre-sized to the decoded cell count \
+             (>= 8), not grown from empty to the projected size; got capacity {}",
+            row.values.capacity()
         );
     }
 


### PR DESCRIPTION
Closes #1584. Epic E child E2 (read-path perf, #1517). Oracle-driven, **behavior-preserving** — row content/order/JSON output byte-identical (33-table parity + CLI smoke green).

## Scope: interim wins only (K3 owns positional-row redesign)
Delivered the cheap, mechanically-reviewable wins that don't change the row representation:
- **Step 1 — capacity hints:** per-row/per-group value maps pre-sized to the known insert count (`build_row_from_scan`, `execute_projection`, `finalize_group`) — one sized alloc, no rehash growth.
- **Step 3 — hoist name derivation:** `execute_projection` derives projected column names once per query into `Vec<Arc<str>>`, then Arc-clones per row (was re-deriving `String`/`format!` per row per column). Names byte-identical.
- **Step 4 — N/A:** the cited per-column linear projection scan no longer exists (already refactored to direct per-expression eval).

### Deferred (tracked in follow-up) — genuine scope/API entanglement
- **Step 2 (FxHashMap)** — `QueryRow.values` is a **public** `HashMap<Arc<str>, Value>`; swapping the hasher changes the public field type and ripples across bindings/CLI/serde — that is the "no representation redesign" STOP; belongs with K3.
- **Step 5 (partition-key hoist)** — requires cross-call memoization across the 5 `build_row_from_scan` scan sites + public API + Flight producer; not containable as a small interim.

## Tests (TDD — red→green)
- `build_row_from_scan_presizes_value_map`: map capacity 3 → 14 (≥ cells).
- `execute_projection_derives_names_once_per_query`: 100 rows × 3 cols → derivations **300 → 3**.

## Gate
`scripts/agent-gate.sh` → **RESULT: PASS** (all components; `file-size` acked via `CQLITE_ALLOW_FILE_GROWTH=1` for pre-existing over-threshold `mod.rs`, epic #1116).