### PR TITLE
perf(#1646): compaction/merge criterion bench (narrow + wide + tombstone-heavy) + perf-CI wiring

### DIFF
--- a/.github/workflows/perf-regression.yml
+++ b/.github/workflows/perf-regression.yml
@@ -109,7 +109,7 @@ jobs:
             read -r -a BENCH_ARGV <<< "$BENCH_ARGS"
           fi
           cargo bench -p cqlite-core --features "$BENCH_FEATURES" \
-            --bench read --bench write --bench concurrent_scan --bench read_while_write \
+            --bench read --bench write --bench concurrent_scan --bench read_while_write --bench compaction \
             -- --save-baseline pr "${BENCH_ARGV[@]}"
 
       - name: Benchmark main → baseline 'base'
@@ -122,7 +122,7 @@ jobs:
           git checkout --force --detach origin/main
           git submodule update --init --recursive || true
           cargo bench -p cqlite-core --features "$BENCH_FEATURES" \
-            --bench read --bench write --bench concurrent_scan --bench read_while_write \
+            --bench read --bench write --bench concurrent_scan --bench read_while_write --bench compaction \
             -- --save-baseline base "${BENCH_ARGV[@]}"
 
       - name: Restore PR ref (for the gate script + policy)

--- a/.github/workflows/perf-regression.yml
+++ b/.github/workflows/perf-regression.yml
@@ -121,9 +121,18 @@ jobs:
           fi
           git checkout --force --detach origin/main
           git submodule update --init --recursive || true
+          # The `compaction` bench target may not exist on `main` yet (it is
+          # introduced by the PR that adds this bench). Include --bench compaction
+          # only when the target is present on the checked-out tree; otherwise
+          # cargo bench would fail before the comparison script runs. The compare
+          # script SKIPs any bench missing from the baseline, so a first-PR
+          # baseline with no compaction data stays green.
+          BENCH_TARGETS=(--bench read --bench write --bench concurrent_scan --bench read_while_write)
+          if [[ -f cqlite-core/benches/compaction.rs ]]; then
+            BENCH_TARGETS+=(--bench compaction)
+          fi
           cargo bench -p cqlite-core --features "$BENCH_FEATURES" \
-            --bench read --bench write --bench concurrent_scan --bench read_while_write --bench compaction \
-            -- --save-baseline base "${BENCH_ARGV[@]}"
+            "${BENCH_TARGETS[@]}" -- --save-baseline base "${BENCH_ARGV[@]}"
 
       - name: Restore PR ref (for the gate script + policy)
         run: git checkout --force --detach ${{ steps.refs.outputs.pr_ref }}

--- a/cqlite-core/Cargo.toml
+++ b/cqlite-core/Cargo.toml
@@ -181,6 +181,10 @@ name = "write"
 harness = false
 
 [[bench]]
+name = "compaction"
+harness = false
+
+[[bench]]
 name = "concurrent_scan"
 harness = false
 

--- a/cqlite-core/benches/README.md
+++ b/cqlite-core/benches/README.md
@@ -93,6 +93,7 @@ env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets \
 | `fixtures_smoke` | added (#537) | Smoke/acceptance bench proving the fixture loaders are deterministic (seeded RNG + stable scan row count). Read/write portions activate under `cli-helpers` / `write-support`. |
 | `read` | added (#538), point-read reworked (#1562) | Read suite (needs `--features cli-helpers`): `get_partition_big`, `get_partition_bti`, `clustering_slice`, `full_scan`, `type_heavy` over the fixtures via the public query API. `get_partition_*` are **real** partition-targeted point reads (`WHERE id = <unquoted-uuid>`, #949/#956), asserted at setup to report a targeted `AccessPath` (not the old `SELECT * … LIMIT 1` scan proxy). `_bti` skip-registers when the optional `test_da` corpus is absent. |
 | `write` | added (#539, #574) | Write suite (needs `--features write-support`): `ingest_wal_on`, `ingest_wal_off`, and `flush` — see below. |
+| `compaction` | added (#1646) | Compaction / k-way-merge suite (needs `--features write-support`): `narrow`, `wide`, `tombstone_heavy` — full multi-generation STCS compaction over flushed L0 SSTables — see below. |
 | `observability_overhead` | added (#1043) | Zero-overhead-when-disabled gate: `read_scan` (needs `cli-helpers`) and `write_merge` (needs `write-support`). The SAME bench source runs under the default build vs `--features observability` with export disabled; the two arms are compared by `scripts/ci/observability_overhead.sh` — see below. |
 | `concurrent_scan` | added (#917), **gated** (#1564) | Aggregate throughput of N ∈ {1,2,4,8} concurrent `get_all_entries()` scans against one shared `Arc<SSTableReader>`, for the buffered and mmap backends (needs `--features cli-helpers`). Gated via a **concurrency scaling floor** (not absolute time) — see below. |
 | `read_while_write` | added (#1143), **gated** (#1564) | Reader-side scan latency with ~6 full-scan readers running concurrently with ~2 sustained-ingest writers (needs `--features cli-helpers,write-support`). Gated on the Criterion **median** (strict, 25% threshold); the p99 tail is printed to stderr for local diagnosis and owned by the A2 tail-latency harness (#1563). |
@@ -135,6 +136,20 @@ in-memory-OTLP correctness/sampling tests.
 | `write/ingest_wal_on` | **Advisory** — reported, never fails CI | Identical 256-row ingest with `Durability::SyncEachWrite` (default): every row calls `wal.append()` + `wal.sync()` (fsync). I/O-dominated; fsync latency on shared CI runners makes this too noisy for strict gating, but it documents durability cost. |
 | `write/flush` | **Strictly gated** — strict pass/fail | Pre-filled memtable flushed once per iteration. Throughput reported in MB/s. |
 
+### `compaction` bench breakdown (Issue #1646, Epic O finding O1)
+
+Each iteration flushes `min_threshold` (4) L0 SSTables in the **untimed** setup,
+installs an `STCSPolicy` explicitly via `set_merge_policy` (so O1 measures
+compaction regardless of whether the default-on STCS wiring, N1, has landed),
+then drives `WriteEngine::maintenance_step` to completion in the **timed**
+routine. Throughput is reported as compacted rows/second (`Throughput::Elements`).
+
+| Bench name | Gate policy | What it measures |
+|------------|-------------|------------------|
+| `compaction/narrow` | **Strictly gated** — strict pass/fail | Many small single-row partitions (`UUID` PK, no clustering) across the L0 SSTables. The CPU-bound merge-core probe; stable enough for strict regression detection. |
+| `compaction/wide` | **Advisory** — reported, never fails CI | A few fat partitions, each SSTable contributing a disjoint clustering slice so the merged partition is the union of all of them. Memory/data-shaped by design — **O2's dhat budget is its guard, not this wall clock** — so it is advisory. |
+| `compaction/tombstone_heavy` | **Strictly gated** — strict pass/fail | Live rows shadowed by row/range/cell tombstones in a later generation, exercising the reconcile + range-shadowing path. CPU-bound; strictly gated. |
+
 ## Performance regression gate (Issues #540, #572)
 
 CI runs the `read` + `write` benches on **both the PR and `main`, on the same
@@ -163,8 +178,8 @@ The gate distinguishes two classes of benches (configured via `perf-gate.json`):
 
 | Class | Behavior | When to use |
 |-------|----------|-------------|
-| **Strict** | Non-zero exit if delta > `threshold_pct`. Blocks merging. | CPU-bound, stable timings: `read/*`, `write/ingest_wal_off`, `write/flush`. |
-| **Advisory** | Delta reported in CI output, but **never causes a non-zero exit**, regardless of size. | I/O-dominated by fsync: `write/ingest_wal_on`. Variance on shared runners exceeds any useful threshold. |
+| **Strict** | Non-zero exit if delta > `threshold_pct`. Blocks merging. | CPU-bound, stable timings: `read/*`, `write/ingest_wal_off`, `write/flush`, `compaction/narrow`, `compaction/tombstone_heavy`. |
+| **Advisory** | Delta reported in CI output, but **never causes a non-zero exit**, regardless of size. | I/O-dominated by fsync (`write/ingest_wal_on`) or memory/data-shaped (`compaction/wide`, whose dhat budget is owned by O2, not this wall clock). Variance on shared runners exceeds any useful threshold. |
 
 To mark a bench advisory, add its ID to the `advisory_benches` list in
 `perf-gate.json`. The per-bench `threshold_pct` for advisory benches still

--- a/cqlite-core/benches/compaction.rs
+++ b/cqlite-core/benches/compaction.rs
@@ -1,0 +1,469 @@
+//! Compaction / k-way-merge micro-benchmarks for cqlite-core (Issue #1646,
+//! Epic O — write measurement, finding O1).
+//!
+//! The k-way merge (`storage::write_engine::merge`) is the heaviest CPU in the
+//! write path and drives every compaction, yet it had zero bench coverage.
+//! These benches measure a full multi-generation STCS compaction — flush
+//! `min_threshold` L0 SSTables (untimed setup) then drive
+//! `WriteEngine::maintenance_step` to completion (timed) — across three shapes:
+//!
+//! - `compaction/narrow` — many small partitions, few rows each. The CPU-bound
+//!   merge-core probe (one row per partition, `UUID` PK, no clustering).
+//!   **Strictly gated** in `perf-gate.json`.
+//!
+//! - `compaction/wide` — a few fat partitions with many clustering rows,
+//!   contributed disjointly by each input SSTable so the merged partition is the
+//!   union of all of them (exercises the wide-partition merge path). It is
+//!   memory/data-dependent, so it is tracked **advisory** — O2 owns its dhat
+//!   budget, not a wall-clock gate.
+//!
+//! - `compaction/tombstone_heavy` — live rows shadowed by row/range/cell
+//!   tombstones in a later generation, so the reconcile + range-shadowing path
+//!   is exercised. **Strictly gated** in `perf-gate.json`.
+//!
+//! The merge policy is installed **explicitly** in the bench via
+//! `set_merge_policy(STCSPolicy::default())`, so O1 measures compaction
+//! regardless of whether the default-on STCS wiring (N1) has landed.
+//!
+//! All input is generated from [`fixtures::seeded_rng`] so the compacted data is
+//! byte-for-byte identical across runs and machines, and each iteration uses a
+//! fresh [`tempfile::TempDir`] so iterations never share state.
+//!
+//! ## Running
+//!
+//! ```text
+//! # default features (compiles as a no-op group):
+//! cargo bench -p cqlite-core --bench compaction -- --test
+//!
+//! # with write-support:
+//! cargo bench -p cqlite-core --features write-support --bench compaction -- --test
+//! cargo bench -p cqlite-core --features write-support --bench compaction
+//! ```
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+#[cfg(feature = "write-support")]
+use criterion::{black_box, Throughput};
+
+#[path = "fixtures/mod.rs"]
+mod fixtures;
+
+#[path = "profiling/mod.rs"]
+mod profiling;
+
+// ── Shape sizing (feature-gated so the no-op build stays clean) ──────────────
+
+/// Number of L0 SSTables flushed before each compaction. `>=` the STCS default
+/// `min_threshold` (4) so the policy selects a bucket. The tiny bench SSTables
+/// are all below `min_sstable_size` (50 MB), so STCS groups them into a single
+/// eligible bucket — a full compaction of every input.
+#[cfg(feature = "write-support")]
+const L0_SSTABLES: usize = 4;
+
+/// `compaction/narrow`: partitions per flushed SSTable (one row each). Disjoint
+/// keys across SSTables, so the merge output is the sum of all inputs.
+#[cfg(feature = "write-support")]
+const NARROW_ROWS_PER_TABLE: usize = 200;
+
+/// `compaction/wide`: number of fat partitions.
+#[cfg(feature = "write-support")]
+const WIDE_PARTITIONS: usize = 2;
+
+/// `compaction/wide`: clustering rows each SSTable contributes to every
+/// partition (disjoint clustering ranges per SSTable so the merged partition is
+/// the union of all `L0_SSTABLES` slices — a genuinely fat merged partition).
+#[cfg(feature = "write-support")]
+const WIDE_CK_PER_TABLE: usize = 150;
+
+/// `compaction/tombstone_heavy`: number of partitions carrying live+shadowed rows.
+#[cfg(feature = "write-support")]
+const TOMB_PARTITIONS: usize = 2;
+
+/// `compaction/tombstone_heavy`: clustering rows per partition (the SAME keys in
+/// every live SSTable so the reconcile path runs), of which the lower half is
+/// shadowed by a range/row/cell tombstone in the final generation.
+#[cfg(feature = "write-support")]
+const TOMB_CK: usize = 150;
+
+/// CQL for the wide / tombstone bench target: a `(pk, ck)` composite primary key
+/// so a single partition holds many clustering rows. Single `CREATE TABLE` so
+/// the no-heuristics mandate (Issue #28) has an unambiguous write target.
+#[cfg(feature = "write-support")]
+const WIDE_TABLE_CQL: &str = "\
+CREATE TABLE test_bench.wide_table (
+    pk INT,
+    ck INT,
+    val TEXT,
+    PRIMARY KEY (pk, ck)
+);";
+
+// ── Shared helpers ──────────────────────────────────────────────────────────
+
+/// Build a `WriteEngine` over `cql` whose data/WAL dirs live under `dir`, with a
+/// huge flush threshold so no auto-flush fires mid-batch (the bench flushes
+/// explicitly to control the number of L0 SSTables).
+#[cfg(feature = "write-support")]
+fn open_engine(
+    dir: &std::path::Path,
+    cql: &str,
+    flush_threshold: usize,
+) -> cqlite_core::storage::write_engine::WriteEngine {
+    use cqlite_core::schema::parse_cql_schema;
+    use cqlite_core::storage::write_engine::{WriteEngine, WriteEngineConfig};
+
+    let schema = parse_cql_schema(cql).expect("parse compaction-bench schema");
+    let cfg = WriteEngineConfig::new(dir.join("data"), dir.join("wal"), schema)
+        .with_flush_threshold(flush_threshold);
+    WriteEngine::new(cfg).expect("build compaction-bench write engine")
+}
+
+/// Install the default STCS policy (`min_threshold = 4`) explicitly, so the
+/// bench measures compaction independent of N1's default-on wiring.
+#[cfg(feature = "write-support")]
+fn install_stcs(engine: &mut cqlite_core::storage::write_engine::WriteEngine) {
+    use cqlite_core::storage::write_engine::STCSPolicy;
+    engine
+        .set_merge_policy(Box::new(STCSPolicy::default()))
+        .expect("install STCS merge policy");
+}
+
+/// Drive `maintenance_step` until no compaction work remains, returning the
+/// total rows merged (output rows). Returns `> 0` iff a real compaction ran.
+#[cfg(feature = "write-support")]
+fn drive_compaction_to_completion(
+    engine: &mut cqlite_core::storage::write_engine::WriteEngine,
+) -> u64 {
+    use std::time::Duration;
+    // A near-unbounded budget so each step completes its active merge in one
+    // call. NOT `Duration::MAX`: `maintenance_step` computes `budget * 1.1` for
+    // its tolerance window, and `Duration::MAX * 1.1` overflows and panics. One
+    // day is unbounded for a bench-sized merge while leaving headroom for ×1.1.
+    let budget = Duration::from_secs(86_400);
+    let mut total = 0u64;
+    loop {
+        let report = engine
+            .maintenance_step(budget)
+            .expect("compaction maintenance step");
+        total += report.rows_merged;
+        // Terminate once the policy selects nothing more AND no merge is active:
+        // a finished merge reports `rows_merged > 0` with `pending == false`, so
+        // we loop once more to let the policy re-check the (now fewer) SSTables.
+        if !report.pending_compaction && report.rows_merged == 0 {
+            break;
+        }
+    }
+    total
+}
+
+// ── compaction/narrow ────────────────────────────────────────────────────────
+
+/// Build `L0_SSTABLES` SSTables of `NARROW_ROWS_PER_TABLE` single-row partitions
+/// (disjoint `UUID` keys), then install STCS. Returns the primed engine.
+#[cfg(feature = "write-support")]
+fn build_narrow(
+    rt: &tokio::runtime::Runtime,
+    dir: &std::path::Path,
+) -> cqlite_core::storage::write_engine::WriteEngine {
+    use rand::Rng;
+
+    let mut engine = fixtures::open_write_engine(dir, usize::MAX);
+    let mut rng = fixtures::seeded_rng();
+    for _ in 0..L0_SSTABLES {
+        for _ in 0..NARROW_ROWS_PER_TABLE {
+            let id = uuid::Uuid::from_u128(rng.gen());
+            let age: i32 = rng.gen_range(0..100);
+            let stmt = format!(
+                "INSERT INTO test_basic.simple_table \
+                 (id, name, age, active) \
+                 VALUES ({id}, 'narrow-row', {age}, true)"
+            );
+            engine.execute(&stmt).expect("narrow ingest row");
+        }
+        let flushed = rt
+            .block_on(engine.flush())
+            .expect("narrow flush must not error");
+        assert!(flushed.is_some(), "narrow flush produced no SSTable");
+    }
+    install_stcs(&mut engine);
+    engine
+}
+
+/// `compaction/narrow` — CPU-bound merge core over many small partitions.
+#[cfg(feature = "write-support")]
+fn bench_narrow(c: &mut Criterion) {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime for narrow setup");
+    let input_rows = (L0_SSTABLES * NARROW_ROWS_PER_TABLE) as u64;
+
+    let mut group = c.benchmark_group("compaction");
+    group.throughput(Throughput::Elements(input_rows));
+    group.bench_function("narrow", |b| {
+        b.iter_batched(
+            // SETUP (untimed): flush L0 SSTables + install STCS.
+            || {
+                let tmp = tempfile::TempDir::new().expect("temp dir for narrow bench");
+                let engine = build_narrow(&rt, tmp.path());
+                (tmp, engine)
+            },
+            // ROUTINE (timed): compact all L0 SSTables to completion.
+            |(_tmp, mut engine)| {
+                let merged = drive_compaction_to_completion(&mut engine);
+                assert!(
+                    merged > 0,
+                    "narrow: compaction merged 0 rows — no real work ran"
+                );
+                black_box(merged)
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+    group.finish();
+}
+
+// ── compaction/wide ───────────────────────────────────────────────────────────
+
+/// Build `L0_SSTABLES` SSTables that each contribute a DISJOINT clustering slice
+/// to the same `WIDE_PARTITIONS` partitions, so the merged partitions are fat
+/// (the union of every slice). Returns the primed engine.
+#[cfg(feature = "write-support")]
+fn build_wide(
+    rt: &tokio::runtime::Runtime,
+    dir: &std::path::Path,
+) -> cqlite_core::storage::write_engine::WriteEngine {
+    use cqlite_core::storage::write_engine::{
+        CellOperation, ClusteringKey, Mutation, PartitionKey, TableId,
+    };
+    use cqlite_core::types::Value;
+    use rand::Rng;
+
+    let mut engine = open_engine(dir, WIDE_TABLE_CQL, usize::MAX);
+    let mut rng = fixtures::seeded_rng();
+    let tid = TableId::new("test_bench", "wide_table");
+    for t in 0..L0_SSTABLES {
+        for pk in 0..WIDE_PARTITIONS {
+            for c in 0..WIDE_CK_PER_TABLE {
+                // Disjoint clustering key per SSTable → fat merged partition.
+                let ck = (t * WIDE_CK_PER_TABLE + c) as i32;
+                let val: u32 = rng.gen();
+                let m = Mutation::new(
+                    tid.clone(),
+                    PartitionKey::single("pk", Value::Integer(pk as i32)),
+                    Some(ClusteringKey::single("ck", Value::Integer(ck))),
+                    vec![CellOperation::Write {
+                        column: "val".to_string(),
+                        value: Value::Text(format!("wide-{val}")),
+                    }],
+                    1_000_000 + ck as i64,
+                    None,
+                );
+                engine.write(m).expect("wide write row");
+            }
+        }
+        let flushed = rt
+            .block_on(engine.flush())
+            .expect("wide flush must not error");
+        assert!(flushed.is_some(), "wide flush produced no SSTable");
+    }
+    install_stcs(&mut engine);
+    engine
+}
+
+/// `compaction/wide` — advisory (memory/data-shaped): fat-partition merge.
+#[cfg(feature = "write-support")]
+fn bench_wide(c: &mut Criterion) {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime for wide setup");
+    let input_rows = (L0_SSTABLES * WIDE_PARTITIONS * WIDE_CK_PER_TABLE) as u64;
+
+    let mut group = c.benchmark_group("compaction");
+    group.throughput(Throughput::Elements(input_rows));
+    group.bench_function("wide", |b| {
+        b.iter_batched(
+            || {
+                let tmp = tempfile::TempDir::new().expect("temp dir for wide bench");
+                let engine = build_wide(&rt, tmp.path());
+                (tmp, engine)
+            },
+            |(_tmp, mut engine)| {
+                let merged = drive_compaction_to_completion(&mut engine);
+                assert!(
+                    merged > 0,
+                    "wide: compaction merged 0 rows — no real work ran"
+                );
+                black_box(merged)
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+    group.finish();
+}
+
+// ── compaction/tombstone_heavy ─────────────────────────────────────────────────
+
+/// Build live rows in the first `L0_SSTABLES - 1` SSTables (same clustering keys
+/// so the reconcile path runs), then a final SSTable of row/range/cell
+/// tombstones shadowing the LOWER half of the clustering range. The upper half
+/// survives, so the merge does real reconcile + range-shadowing work and still
+/// emits output. Returns the primed engine.
+#[cfg(feature = "write-support")]
+fn build_tombstone_heavy(
+    rt: &tokio::runtime::Runtime,
+    dir: &std::path::Path,
+) -> cqlite_core::storage::write_engine::WriteEngine {
+    use cqlite_core::storage::write_engine::{
+        CellOperation, ClusteringBound, ClusteringKey, Mutation, PartitionKey, RangeTombstone,
+        TableId,
+    };
+    use cqlite_core::types::Value;
+    use rand::Rng;
+
+    let mut engine = open_engine(dir, WIDE_TABLE_CQL, usize::MAX);
+    let mut rng = fixtures::seeded_rng();
+    let tid = TableId::new("test_bench", "wide_table");
+    let half = (TOMB_CK / 2) as i32;
+
+    // Live generations: the same (pk, ck) keys in every SSTable so compaction
+    // reconciles overlapping cells across generations.
+    for gen in 0..(L0_SSTABLES - 1) {
+        for pk in 0..TOMB_PARTITIONS {
+            for ck in 0..TOMB_CK {
+                let val: u32 = rng.gen();
+                let m = Mutation::new(
+                    tid.clone(),
+                    PartitionKey::single("pk", Value::Integer(pk as i32)),
+                    Some(ClusteringKey::single("ck", Value::Integer(ck as i32))),
+                    vec![CellOperation::Write {
+                        column: "val".to_string(),
+                        value: Value::Text(format!("live-{gen}-{val}")),
+                    }],
+                    1_000_000 + (gen * TOMB_CK + ck) as i64,
+                    None,
+                );
+                engine.write(m).expect("tombstone-heavy live write");
+            }
+        }
+        let flushed = rt
+            .block_on(engine.flush())
+            .expect("tombstone-heavy live flush must not error");
+        assert!(
+            flushed.is_some(),
+            "tombstone-heavy live flush produced no SSTable"
+        );
+    }
+
+    // Tombstone generation: a higher timestamp so it shadows the live rows.
+    // Covers the lower clustering half via a range tombstone, plus a row
+    // tombstone and a cell tombstone inside that range (the reconcile path must
+    // resolve all three against the live cells).
+    let tomb_ts = 1_000_000 + (L0_SSTABLES * TOMB_CK) as i64;
+    let tomb_ldt = (tomb_ts / 1_000_000) as i32;
+    for pk in 0..TOMB_PARTITIONS {
+        let pk_val = Value::Integer(pk as i32);
+
+        // Range tombstone: [Bottom, ck = half) shadows the lower half.
+        let mut range_mut = Mutation::new(
+            tid.clone(),
+            PartitionKey::single("pk", pk_val.clone()),
+            None,
+            vec![],
+            tomb_ts,
+            None,
+        );
+        range_mut.range_tombstones.push(RangeTombstone {
+            start: ClusteringBound::Bottom,
+            end: ClusteringBound::Exclusive(ClusteringKey::single("ck", Value::Integer(half))),
+            deletion_time: tomb_ts,
+            local_deletion_time: tomb_ldt,
+        });
+        engine.write(range_mut).expect("range tombstone write");
+
+        // Row tombstone on a single clustering key inside the shadowed range.
+        let row_mut = Mutation::new(
+            tid.clone(),
+            PartitionKey::single("pk", pk_val.clone()),
+            Some(ClusteringKey::single("ck", Value::Integer(0))),
+            vec![CellOperation::DeleteRow],
+            tomb_ts,
+            None,
+        );
+        engine.write(row_mut).expect("row tombstone write");
+
+        // Cell tombstone on the `val` column of another key inside the range.
+        let cell_mut = Mutation::new(
+            tid.clone(),
+            PartitionKey::single("pk", pk_val),
+            Some(ClusteringKey::single("ck", Value::Integer(1))),
+            vec![CellOperation::Delete {
+                column: "val".to_string(),
+                local_deletion_time: None,
+            }],
+            tomb_ts,
+            None,
+        );
+        engine.write(cell_mut).expect("cell tombstone write");
+    }
+    let flushed = rt
+        .block_on(engine.flush())
+        .expect("tombstone flush must not error");
+    assert!(flushed.is_some(), "tombstone flush produced no SSTable");
+
+    install_stcs(&mut engine);
+    engine
+}
+
+/// `compaction/tombstone_heavy` — CPU-bound reconcile + range-shadowing path.
+#[cfg(feature = "write-support")]
+fn bench_tombstone_heavy(c: &mut Criterion) {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime for tombstone setup");
+    // Denominator = total LIVE input rows fed into the merge (the reconcile work).
+    let input_rows = ((L0_SSTABLES - 1) * TOMB_PARTITIONS * TOMB_CK) as u64;
+
+    let mut group = c.benchmark_group("compaction");
+    group.throughput(Throughput::Elements(input_rows));
+    group.bench_function("tombstone_heavy", |b| {
+        b.iter_batched(
+            || {
+                let tmp = tempfile::TempDir::new().expect("temp dir for tombstone bench");
+                let engine = build_tombstone_heavy(&rt, tmp.path());
+                (tmp, engine)
+            },
+            |(_tmp, mut engine)| {
+                let merged = drive_compaction_to_completion(&mut engine);
+                assert!(
+                    merged > 0,
+                    "tombstone_heavy: compaction merged 0 surviving rows — \
+                     tombstones shadowed everything (or no work ran)"
+                );
+                black_box(merged)
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+    group.finish();
+}
+
+// ── criterion_group! / criterion_main! ──────────────────────────────────────
+//
+// Two variants mirror write.rs so the file compiles under every feature
+// combination without dead-code noise: real benches with `write-support`, a
+// single no-op group without it.
+
+#[cfg(feature = "write-support")]
+criterion_group!(
+    name = benches;
+    config = profiling::configure();
+    targets = bench_narrow, bench_wide, bench_tombstone_heavy
+);
+
+#[cfg(not(feature = "write-support"))]
+fn bench_noop(_c: &mut Criterion) {
+    // write-support is disabled; these benches are no-ops.
+    // Enable with: --features write-support
+}
+
+#[cfg(not(feature = "write-support"))]
+criterion_group!(
+    name = benches;
+    config = profiling::configure();
+    targets = bench_noop
+);
+
+criterion_main!(benches);

--- a/cqlite-core/benches/perf-gate.json
+++ b/cqlite-core/benches/perf-gate.json
@@ -2,7 +2,8 @@
   "_comment": "Performance regression gate policy (Issue #572). The CI workflow .github/workflows/perf-regression.yml runs these benches on both the PR and main on the SAME runner and fails if any STRICT bench's Criterion median regresses by more than its threshold_pct. ADVISORY benches are always reported but never cause a non-zero exit, regardless of delta — they exist to document cost, not to block merges. To adjust, edit bench entries here; see cqlite-core/benches/README.md.",
   "default_threshold_pct": 10,
   "advisory_benches": [
-    "write/ingest_wal_on"
+    "write/ingest_wal_on",
+    "compaction/wide"
   ],
   "benches": [
     {
@@ -42,6 +43,19 @@
       "id": "read_while_write/readers6_writers2",
       "threshold_pct": 25,
       "_note": "reader-side median under concurrent write load; wide threshold (contention bench); p99 tail owned by A2 tail-latency harness #1563"
+    },
+    {
+      "id": "compaction/narrow",
+      "threshold_pct": 10
+    },
+    {
+      "id": "compaction/wide",
+      "threshold_pct": 10,
+      "_note": "advisory — memory/data-shaped fat-partition merge; O2's dhat budget is its guard, not this wall clock"
+    },
+    {
+      "id": "compaction/tombstone_heavy",
+      "threshold_pct": 10
     }
   ],
   "scaling_floors": [

--- a/scripts/ci/tests/test_check_perf_regression.py
+++ b/scripts/ci/tests/test_check_perf_regression.py
@@ -17,6 +17,7 @@ Test matrix:
 """
 
 import importlib.util
+import json
 import os
 import sys
 import types
@@ -182,6 +183,37 @@ class TestAllWithinThresholdPasses:
         _run(_CRIT_ADVISORY_ONLY)
         captured = capsys.readouterr()
         assert "✅" in captured.out or "All" in captured.out
+
+
+class TestCompactionGateEntries:
+    """Issue #1646 (Epic O, O1): the compaction CPU shapes must be STRICTLY
+    gated in the real perf-gate.json (present, not advisory), and the
+    memory-shaped `compaction/wide` must be advisory. This assertion FAILS on
+    `main`, where no `compaction/*` id exists in perf-gate.json."""
+
+    @staticmethod
+    def _cfg():
+        with open(_GATE_JSON, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+
+    def test_strict_compaction_ids_present_and_not_advisory(self):
+        cfg = self._cfg()
+        ids = {b["id"] for b in cfg["benches"]}
+        advisory = set(cfg.get("advisory_benches", []))
+        for strict_id in ("compaction/narrow", "compaction/tombstone_heavy"):
+            assert strict_id in ids, (
+                f"{strict_id} must be a tracked bench in perf-gate.json"
+            )
+            assert strict_id not in advisory, (
+                f"{strict_id} is a CPU-bound shape and must be STRICT, not advisory"
+            )
+
+    def test_compaction_wide_is_advisory(self):
+        cfg = self._cfg()
+        assert "compaction/wide" in set(cfg.get("advisory_benches", [])), (
+            "compaction/wide is memory/data-shaped (O2 owns its dhat budget) and "
+            "must be advisory, not a strict wall-clock gate"
+        )
 
 
 class TestMissingDataSkipped:


### PR DESCRIPTION
Closes #1646. Epic O / O1.

## What
Adds `cqlite-core/benches/compaction.rs` — the first bench coverage for the k-way merge that drives compaction (narrow / wide / tombstone_heavy shapes, compaction rows/sec). Unblocks O2 (#1648).

## Changes
- `benches/compaction.rs` (new): criterion bench (`harness=false`, `#[cfg(feature="write-support")]` + `bench_noop` fallback), mirrors `write.rs`; `seeded_rng()`, fresh TempDir/iter, untimed setup (flush ≥min_threshold L0), timed `maintenance_step` with an explicit `STCSPolicy` (independent of N1).
- `Cargo.toml`: register `[[bench]] name="compaction"`.
- `perf-gate.json`: strict `compaction/narrow`+`compaction/tombstone_heavy` (10%); `compaction/wide` advisory (memory-shaped).
- `perf-regression.yml`: `--bench compaction` on PR step (literal) + main-baseline step guarded behind `[[ -f benches/compaction.rs ]]` (bench absent on main until this lands — roborev High fix; no `${{ }}` in run:).
- `benches/README.md`, `scripts/ci/tests/test_check_perf_regression.py` (`TestCompactionGateEntries`).

## Quality bar
- `scripts/agent-gate.sh`: RESULT: PASS (rebased on origin/main, unioned with #1564's bench entries; core-tests 4023 passed).
- roborev (codex, `--base origin/main`): No issues found (initial High CI-baseline finding fixed + re-reviewed clean).
- Observed throughput (fast run): narrow ~14.7 Kelem/s, wide ~20.9 Kelem/s, tombstone_heavy ~15.8 Kelem/s — real compaction ran.

Out-of-scope robustness edge filed as #1815 (maintenance_step Duration::MAX overflow).