### PR TITLE
fix(#1693): graceful shutdown — SIGINT→close() in writable session, warn on unflushed drop (AG4)

### DIFF
--- a/cqlite-cli/Cargo.toml
+++ b/cqlite-cli/Cargo.toml
@@ -116,6 +116,8 @@ serial_test = "3.0"
 # Test infrastructure dependencies
 test-log = "0.2"
 wait-timeout = "0.2"
+# Send SIGINT to a spawned CLI child in the graceful-shutdown test (issue #1693).
+libc = { workspace = true }
 rustc_version = "0.4"
 
 # Enhanced testing framework dependencies

--- a/cqlite-cli/Cargo.toml
+++ b/cqlite-cli/Cargo.toml
@@ -25,7 +25,9 @@ cqlite-core = { path = "../cqlite-core", version = "0.12.0" }
 clap = { workspace = true }
 
 # Async runtime
-tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "signal"] }
+# `io-std` + `io-util` back the async stdin loop in the interactive writable
+# session (issue #1693); `signal` backs its Ctrl-C graceful-shutdown handler.
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "signal", "io-std", "io-util"] }
 
 # Error handling
 thiserror = { workspace = true }

--- a/cqlite-cli/src/main.rs
+++ b/cqlite-cli/src/main.rs
@@ -476,6 +476,15 @@ async fn run_main() -> Result<()> {
             write_dir.join("wal"),
             schema.clone(),
         );
+        // Issue #1693: allow a low flush threshold via env so an interactive
+        // writable session's mid-session auto-flush is observable in tests
+        // WITHOUT writing the 64MB default threshold worth of data over stdin.
+        // Production leaves this unset and keeps the 64MB default.
+        if let Ok(raw) = std::env::var("CQLITE_MEMTABLE_FLUSH_THRESHOLD") {
+            if let Ok(bytes) = raw.trim().parse::<usize>() {
+                config = config.with_flush_threshold(bytes);
+            }
+        }
         // #929: supply a UDT registry built from the schema file's CREATE TYPE
         // statements so a bare-name non-frozen UDT column flushes as complex
         // per-field cells instead of the single-cell fallback (roborev #1029).
@@ -1113,8 +1122,16 @@ async fn run_writable_interactive(engine: &mut WriteEngine) -> Result<()> {
                         if stmt.is_empty() {
                             continue;
                         }
-                        match engine.execute(stmt) {
-                            Ok(()) => {
+                        // Use the async, threshold-flushing path (NOT the sync
+                        // `execute`, which intentionally skips auto-flush in an
+                        // async context). Otherwise a long interactive session
+                        // grows the memtable past the flush threshold up to the
+                        // hard limit, after which writes fail until exit — see
+                        // roborev finding, issue #1693. `execute_flushing` awaits a
+                        // real async flush (no block_on) so mid-session data lands
+                        // durably in Data.db.
+                        match engine.execute_flushing(stmt).await {
+                            Ok(_) => {
                                 // stdout is block-buffered when piped; flush so a
                                 // driving parent (or test) observes the ack promptly.
                                 println!("OK");

--- a/cqlite-cli/src/main.rs
+++ b/cqlite-cli/src/main.rs
@@ -1049,12 +1049,128 @@ async fn run_main() -> Result<()> {
             unreachable!("Commands::Verify is dispatched before database initialization")
         }
         None => {
+            // Issue #1693 (AG4): with `--writable` and no one-shot operation
+            // requested, drop into an interactive writable session that flushes
+            // (via `engine.close()`) on SIGINT / EOF instead of just printing
+            // help and dropping the engine unflushed.
+            #[cfg(feature = "write-support")]
+            if cli.execute.is_none()
+                && cli.file.is_none()
+                && cli.mutation.is_empty()
+                && cli.mutations_file.is_none()
+                && !cli.flush
+            {
+                if let Some(engine) = write_engine.as_mut() {
+                    return run_writable_interactive(engine).await;
+                }
+            }
             // Default to help message for now
             println!("CQLite CLI v{}", env!("CARGO_PKG_VERSION"));
             println!("Use --help for available commands");
             Ok(())
         }
     }
+}
+
+/// Issue #1693 (AG4): interactive writable session with graceful shutdown.
+///
+/// Reads CQL DML statements (INSERT/UPDATE/DELETE), one per line, from stdin and
+/// applies each to the write engine, printing `OK` on success. The loop races
+/// input against `SIGINT` (Ctrl-C): on the first Ctrl-C — or on stdin EOF
+/// (Ctrl-D) — it calls [`WriteEngine::close`], which flushes the memtable to a
+/// durable SSTable before returning. Without this, an interrupted writable
+/// session would drop the engine unflushed and leave the last rows recoverable
+/// only via WAL replay.
+///
+/// A SECOND Ctrl-C received *while the shutdown flush is in progress* aborts the
+/// flush and exits immediately (exit code 130); any not-yet-flushed rows then
+/// remain only in the WAL. This escape hatch keeps a stuck flush from wedging
+/// the process.
+#[cfg(feature = "write-support")]
+async fn run_writable_interactive(engine: &mut WriteEngine) -> Result<()> {
+    use tokio::io::{AsyncBufReadExt, BufReader};
+
+    eprintln!(
+        "cqlite writable session: enter CQL DML (INSERT/UPDATE/DELETE), one per line. \
+         Ctrl-D or Ctrl-C flushes and exits; a second Ctrl-C during shutdown exits \
+         immediately (unflushed rows remain only in the WAL)."
+    );
+
+    let mut lines = BufReader::new(tokio::io::stdin()).lines();
+    loop {
+        tokio::select! {
+            // `biased`: check for Ctrl-C before draining more input so a pending
+            // interrupt wins deterministically instead of racing the reader.
+            biased;
+            _ = tokio::signal::ctrl_c() => {
+                eprintln!("\nReceived Ctrl-C — flushing memtable before exit...");
+                return shutdown_flush_and_exit(engine).await;
+            }
+            next = lines.next_line() => {
+                match next {
+                    Ok(Some(line)) => {
+                        let stmt = line.trim();
+                        if stmt.is_empty() {
+                            continue;
+                        }
+                        match engine.execute(stmt) {
+                            Ok(()) => {
+                                // stdout is block-buffered when piped; flush so a
+                                // driving parent (or test) observes the ack promptly.
+                                println!("OK");
+                                let _ = std::io::Write::flush(&mut std::io::stdout());
+                            }
+                            Err(e) => eprintln!("Error: {e}"),
+                        }
+                    }
+                    // stdin EOF (Ctrl-D): flush + finalize for durability.
+                    Ok(None) => {
+                        engine
+                            .close()
+                            .await
+                            .map_err(|e| anyhow::anyhow!("graceful close failed: {e}"))?;
+                        return Ok(());
+                    }
+                    Err(e) => return Err(anyhow::anyhow!("stdin read error: {e}")),
+                }
+            }
+        }
+    }
+}
+
+/// Flush + finalize the engine on Ctrl-C, then terminate the process.
+///
+/// A SECOND Ctrl-C received while the flush is in progress wins the race and
+/// exits immediately (code 130) so a wedged flush cannot hang shutdown; any
+/// not-yet-flushed rows then remain only in the WAL (issue #1693).
+///
+/// This deliberately calls [`std::process::exit`] rather than returning: the
+/// interactive loop leaves an async-stdin read parked on Tokio's blocking pool,
+/// and returning would wedge runtime shutdown waiting for that blocking read to
+/// finish (it never will). Because `close()` has already run, no in-flight write
+/// state is lost by skipping destructors here.
+#[cfg(feature = "write-support")]
+async fn shutdown_flush_and_exit(engine: &mut WriteEngine) -> Result<()> {
+    let code = tokio::select! {
+        biased;
+        _ = tokio::signal::ctrl_c() => {
+            eprintln!(
+                "Second Ctrl-C — exiting immediately; unflushed rows remain only in the WAL."
+            );
+            130
+        }
+        res = engine.close() => {
+            match res {
+                Ok(()) => 0,
+                Err(e) => {
+                    eprintln!("graceful close failed: {e}");
+                    1
+                }
+            }
+        }
+    };
+    let _ = std::io::Write::flush(&mut std::io::stdout());
+    std::process::exit(code);
 }
 
 /// Install the unified `tracing_subscriber` registry (Issue #1033, Epic #1031).

--- a/cqlite-cli/tests/graceful_shutdown_tests.rs
+++ b/cqlite-cli/tests/graceful_shutdown_tests.rs
@@ -1,0 +1,207 @@
+//! Issue #1693 (AG4) — graceful shutdown integration test.
+//!
+//! Drives the `cqlite` binary as a REAL child process in interactive
+//! `--writable` mode, performs a write over stdin, sends it `SIGINT`, and
+//! verifies the process:
+//!   1. exits cleanly (success), and
+//!   2. flushed the memtable to a durable SSTable before exiting — the written
+//!      row is present when the write directory is reopened read-only.
+//!
+//! This is IMPOSSIBLE on the pre-fix code: there is no interactive writable
+//! session and no SIGINT handler, so the process either exits immediately
+//! (never reading the write) or, on Ctrl-C, dies without flushing — leaving the
+//! row only in the WAL. The test is therefore RED before the CLI handler lands.
+//!
+//! Unix-only: it sends a real `SIGINT` via `libc::kill`.
+
+#![cfg(all(feature = "write-support", unix))]
+
+use serde_json::Value as Json;
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
+use std::thread;
+use std::time::{Duration, Instant};
+use tempfile::TempDir;
+use wait_timeout::ChildExt;
+
+/// The `cqlite` binary this test crate built with `--features write-support`.
+fn cqlite_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_cqlite")
+}
+
+/// Write the single-table schema used by the round-trip.
+fn write_schema(dir: &Path) -> PathBuf {
+    let path = dir.join("schema.cql");
+    std::fs::write(
+        &path,
+        r#"
+CREATE KEYSPACE IF NOT EXISTS test_write WITH replication = {
+  'class': 'SimpleStrategy',
+  'replication_factor': 1
+};
+
+USE test_write;
+
+CREATE TABLE IF NOT EXISTS users (
+    id INT PRIMARY KEY,
+    name TEXT,
+    age INT,
+    active BOOLEAN
+);
+"#,
+    )
+    .expect("write schema file");
+    path
+}
+
+/// Spawn a background reader that forwards each stdout line to a channel.
+fn spawn_line_reader<R: std::io::Read + Send + 'static>(reader: R) -> Receiver<String> {
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let buf = BufReader::new(reader);
+        for line in buf.lines() {
+            match line {
+                Ok(l) => {
+                    if tx.send(l).is_err() {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    });
+    rx
+}
+
+/// Block until a forwarded line satisfies `pred`, or `timeout` elapses.
+fn wait_for_line<F: Fn(&str) -> bool>(
+    rx: &Receiver<String>,
+    pred: F,
+    timeout: Duration,
+) -> Option<String> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return None;
+        }
+        match rx.recv_timeout(remaining.min(Duration::from_millis(250))) {
+            Ok(line) if pred(&line) => return Some(line),
+            Ok(_) => continue,
+            Err(RecvTimeoutError::Timeout) => {
+                if Instant::now() >= deadline {
+                    return None;
+                }
+            }
+            Err(RecvTimeoutError::Disconnected) => return None,
+        }
+    }
+}
+
+/// Reopen an SSTable directory read-only and SELECT, returning rows as JSON.
+fn select_rows(data_dir: &Path, schema: &Path, query: &str) -> Vec<Json> {
+    let out: Output = Command::new(cqlite_bin())
+        .args([
+            "--data-dir",
+            data_dir.to_str().unwrap(),
+            "--schema",
+            schema.to_str().unwrap(),
+            "--execute",
+            query,
+            "--out",
+            "json",
+        ])
+        .output()
+        .expect("spawn read-side cqlite");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "SELECT failed: `{query}`\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    match serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("SELECT did not emit JSON: {e}\nstdout: {stdout}"))
+    {
+        Json::Array(rows) => rows,
+        other => panic!("expected a JSON array of rows, got: {other}"),
+    }
+}
+
+/// AC (issue #1693): an interactive `--writable` session that receives SIGINT
+/// after a write exits cleanly AND has flushed the row to a durable SSTable.
+#[test]
+fn sigint_in_writable_session_flushes_before_exit() {
+    let tmp = TempDir::new().unwrap();
+    let schema = write_schema(tmp.path());
+    let wd = tmp.path().join("wd");
+
+    let mut child = Command::new(cqlite_bin())
+        .args([
+            "--writable",
+            "--write-dir",
+            wd.to_str().unwrap(),
+            "--schema",
+            schema.to_str().unwrap(),
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn cqlite interactive writable session");
+
+    // Keep the stdin handle alive for the whole test so the child exits via
+    // SIGINT, NOT via stdin EOF (an EOF would also flush and mask the bug).
+    let mut stdin = child.stdin.take().expect("child stdin");
+    let stdout_rx = spawn_line_reader(child.stdout.take().expect("child stdout"));
+
+    // Perform a write and wait for the "OK" acknowledgement so we KNOW the row
+    // is buffered in the memtable before we interrupt the process.
+    writeln!(
+        stdin,
+        "INSERT INTO test_write.users (id, name, age, active) VALUES (7, 'Grace', 30, true);"
+    )
+    .expect("write INSERT to child stdin");
+    stdin.flush().expect("flush child stdin");
+
+    let ack = wait_for_line(&stdout_rx, |l| l.trim() == "OK", Duration::from_secs(60));
+    assert!(
+        ack.is_some(),
+        "child never acknowledged the write with `OK` — no interactive writable session"
+    );
+
+    // Send a real SIGINT to the child.
+    let pid = child.id() as libc::pid_t;
+    let rc = unsafe { libc::kill(pid, libc::SIGINT) };
+    assert_eq!(rc, 0, "failed to deliver SIGINT to child pid {pid}");
+
+    // The child must exit cleanly within a generous window (saturated machine).
+    let status = child
+        .wait_timeout(Duration::from_secs(60))
+        .expect("wait_timeout on child")
+        .unwrap_or_else(|| {
+            let _ = child.kill();
+            panic!("child did not exit after SIGINT (no graceful shutdown handler)");
+        });
+    // Release stdin only after the process has exited.
+    drop(stdin);
+    assert!(
+        status.success(),
+        "child exited uncleanly after SIGINT: {status:?}"
+    );
+
+    // Durability: the SIGINT handler must have flushed the memtable to a real
+    // SSTable — the row is present on an independent read-only reopen.
+    let data_dir = wd.join("data");
+    let rows = select_rows(&data_dir, &schema, "SELECT * FROM test_write.users");
+    let grace = rows
+        .iter()
+        .find(|r| r.get("id").and_then(|v| v.as_i64()) == Some(7))
+        .unwrap_or_else(|| panic!("row id=7 not durable after SIGINT; rows: {rows:?}"));
+    assert_eq!(
+        grace["name"].as_str(),
+        Some("Grace"),
+        "durable row has wrong name: {grace}"
+    );
+}

--- a/cqlite-cli/tests/graceful_shutdown_tests.rs
+++ b/cqlite-cli/tests/graceful_shutdown_tests.rs
@@ -205,3 +205,130 @@ fn sigint_in_writable_session_flushes_before_exit() {
         "durable row has wrong name: {grace}"
     );
 }
+
+/// Count Data.db SSTable components under a write engine's data directory.
+fn count_data_db(data_dir: &Path) -> usize {
+    fn walk(dir: &Path, acc: &mut usize) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                walk(&path, acc);
+            } else if path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.ends_with("-Data.db"))
+            {
+                *acc += 1;
+            }
+        }
+    }
+    let mut n = 0;
+    walk(data_dir, &mut n);
+    n
+}
+
+/// Poll until `pred(count_data_db(..))` holds or `timeout` elapses.
+fn wait_for_sstable<F: Fn(usize) -> bool>(data_dir: &Path, pred: F, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if pred(count_data_db(data_dir)) {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+}
+
+/// Issue #1693 (roborev): the interactive writable loop must use the async,
+/// threshold-flushing path (`execute_flushing`) rather than the sync `execute`
+/// (which intentionally skips auto-flush in an async context). Otherwise a long
+/// session grows the memtable past the flush threshold up to the hard limit and
+/// then FAILS every write until exit.
+///
+/// This drives a real interactive session with a tiny flush threshold (env
+/// override), writes several rows to cross it, and asserts a durable SSTable
+/// appears MID-SESSION — before any Ctrl-D/Ctrl-C — and that writes keep being
+/// accepted afterwards. On the pre-fix code (sync `execute`) no SSTable is
+/// produced until `close()`, so this test is RED before the fix.
+#[test]
+fn writable_session_auto_flushes_mid_session_across_threshold() {
+    let tmp = TempDir::new().unwrap();
+    let schema = write_schema(tmp.path());
+    let wd = tmp.path().join("wd");
+    let data_dir = wd.join("data");
+
+    let mut child = Command::new(cqlite_bin())
+        .args([
+            "--writable",
+            "--write-dir",
+            wd.to_str().unwrap(),
+            "--schema",
+            schema.to_str().unwrap(),
+        ])
+        // Tiny threshold so a handful of small rows crosses it and forces a
+        // mid-session flush without writing 64MB over stdin.
+        .env("CQLITE_MEMTABLE_FLUSH_THRESHOLD", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn cqlite interactive writable session");
+
+    let mut stdin = child.stdin.take().expect("child stdin");
+    let stdout_rx = spawn_line_reader(child.stdout.take().expect("child stdout"));
+
+    // Write several rows; each write should trigger an auto-flush because the
+    // threshold is effectively zero. Wait for each OK so the session is making
+    // progress (and not dead-ending at the hard limit).
+    for id in 0..5 {
+        writeln!(
+            stdin,
+            "INSERT INTO test_write.users (id, name, age, active) VALUES ({id}, 'row{id}', {id}, true);"
+        )
+        .expect("write INSERT to child stdin");
+        stdin.flush().expect("flush child stdin");
+        let ack = wait_for_line(&stdout_rx, |l| l.trim() == "OK", Duration::from_secs(60));
+        assert!(
+            ack.is_some(),
+            "write id={id} was not acknowledged — session dead-ended (no mid-session flush?)"
+        );
+    }
+
+    // A durable SSTable must exist BEFORE we close the session. On the sync
+    // `execute` path this stays 0 until close(); the flushing path produces one.
+    let flushed = wait_for_sstable(&data_dir, |n| n >= 1, Duration::from_secs(60));
+    assert!(
+        flushed,
+        "no Data.db SSTable appeared mid-session — interactive loop did not use the \
+         threshold-flushing path (issue #1693)"
+    );
+
+    // Cleanly end via EOF and confirm the process exits successfully.
+    drop(stdin);
+    let status = child
+        .wait_timeout(Duration::from_secs(60))
+        .expect("wait_timeout on child")
+        .unwrap_or_else(|| {
+            let _ = child.kill();
+            panic!("child did not exit on stdin EOF");
+        });
+    assert!(
+        status.success(),
+        "child exited uncleanly on EOF: {status:?}"
+    );
+
+    // All rows are durable on an independent read-only reopen.
+    let rows = select_rows(&data_dir, &schema, "SELECT * FROM test_write.users");
+    for id in 0..5 {
+        assert!(
+            rows.iter()
+                .any(|r| r.get("id").and_then(|v| v.as_i64()) == Some(id)),
+            "row id={id} not durable after mid-session flush; rows: {rows:?}"
+        );
+    }
+}

--- a/cqlite-core/src/lib.rs
+++ b/cqlite-core/src/lib.rs
@@ -562,6 +562,15 @@ impl Database {
     ///
     /// This method ensures all pending operations are completed and
     /// all resources are properly cleaned up.
+    ///
+    /// ## Durability contract
+    ///
+    /// Embedders MUST call `close().await` for a graceful shutdown. `Drop` is
+    /// NOT a flush — Tokio has no async drop, so dropping a handle cannot await
+    /// a flush and any un-flushed writer state is left to recovery (WAL replay)
+    /// rather than being persisted here. For the write path this maps onto
+    /// [`storage::write_engine::WriteEngine::close`], which is the actual
+    /// memtable-to-SSTable durability boundary (issue #1693).
     pub async fn close(self) -> Result<()> {
         // Stop background tasks
         self.storage.shutdown().await?;

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -1435,12 +1435,25 @@ impl Drop for WriteEngine {
         // arguments (a single `usize`) allocate only when a warn-level logger is
         // actually enabled.
         if !self.memtable.is_empty() {
-            log::warn!(
-                "WriteEngine dropped without close(): {} row(s) in the memtable were NOT \
-                 flushed to an SSTable and remain only in the WAL (durability now relies on \
-                 WAL replay at next startup). Call `close().await` for a graceful shutdown.",
-                self.memtable.row_count()
-            );
+            // The recovery guidance depends on the durability mode: with WAL
+            // durability the rows survive in the WAL and replay on next open,
+            // but with `Durability::Disabled` the WAL was skipped entirely, so
+            // an ungraceful drop loses the un-flushed rows permanently.
+            match self.config.durability {
+                Durability::SyncEachWrite => log::warn!(
+                    "WriteEngine dropped without close(): {} row(s) in the memtable were NOT \
+                     flushed to an SSTable and remain only in the WAL (durability now relies on \
+                     WAL replay at next startup). Call `close().await` for a graceful shutdown.",
+                    self.memtable.row_count()
+                ),
+                Durability::Disabled => log::warn!(
+                    "WriteEngine dropped without close(): {} row(s) in the memtable were NOT \
+                     flushed to an SSTable and are LOST — durability is Disabled so these rows \
+                     were never written to the WAL and cannot be recovered (they existed in \
+                     memory only). Call `close().await` for a graceful shutdown.",
+                    self.memtable.row_count()
+                ),
+            }
         }
 
         // If close() was already called the lock was already released; a second
@@ -3323,6 +3336,59 @@ mod tests {
                 .iter()
                 .any(|m| m.contains("dropped") && m.contains("without close")),
             "expected an unflushed-drop warning, captured warnings: {warnings:?}"
+        );
+        // WAL-durable engine: the guidance must point at WAL recovery, NOT loss.
+        assert!(
+            warnings.iter().any(|m| m.contains("WAL replay")),
+            "WAL-durable drop warning must mention WAL replay recovery, captured: {warnings:?}"
+        );
+        assert!(
+            !warnings.iter().any(|m| m.contains("LOST")),
+            "WAL-durable drop warning must NOT claim data loss, captured: {warnings:?}"
+        );
+    }
+
+    /// Issue #1693 (roborev): with `Durability::Disabled` the WAL is skipped, so
+    /// an ungraceful drop loses the un-flushed rows. The warning must say the
+    /// rows are LOST rather than giving false "recoverable from the WAL" guidance.
+    #[test]
+    fn test_drop_without_close_warns_data_loss_when_durability_disabled() {
+        drop_warn_capture::start();
+
+        let temp_dir = TempDir::new().unwrap();
+        let schema = create_test_schema();
+        let config = WriteEngineConfig::new(
+            temp_dir.path().join("data"),
+            temp_dir.path().join("wal"),
+            schema,
+        )
+        .with_durability(Durability::Disabled);
+        let mut engine = WriteEngine::new(config).unwrap();
+        engine
+            .write(create_test_mutation(1, "Alice", 1_000_000))
+            .unwrap();
+        assert!(
+            engine.memtable_row_count() > 0,
+            "precondition: memtable must be non-empty before drop"
+        );
+
+        drop(engine);
+
+        let warnings = drop_warn_capture::take_warnings();
+        assert!(
+            warnings
+                .iter()
+                .any(|m| m.contains("dropped") && m.contains("without close")),
+            "expected an unflushed-drop warning, captured warnings: {warnings:?}"
+        );
+        // No-WAL engine: the warning must signal data loss, NOT WAL recovery.
+        assert!(
+            warnings.iter().any(|m| m.contains("LOST")),
+            "Durability::Disabled drop warning must signal data loss, captured: {warnings:?}"
+        );
+        assert!(
+            !warnings.iter().any(|m| m.contains("WAL replay")),
+            "Durability::Disabled drop warning must NOT promise WAL recovery, captured: {warnings:?}"
         );
     }
 

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -282,6 +282,22 @@ impl WriteEngineConfig {
 /// Orchestrates WAL, memtable, and SSTable flushing for write operations.
 /// This is the primary public API for all write operations in CQLite.
 ///
+/// ## Durability contract: you MUST call [`close`](WriteEngine::close)
+///
+/// **`Drop` is not a flush.** Rows written with [`write`](WriteEngine::write) /
+/// [`execute`](WriteEngine::execute) live in the in-memory memtable (and the
+/// WAL) until a flush turns them into an SSTable. Only
+/// [`close`](WriteEngine::close) (or an explicit flush) guarantees the memtable
+/// is persisted to a Data.db. Because Tokio has no async drop, `Drop` CANNOT
+/// flush — doing so would require a `block_on` inside `drop`, which is
+/// forbidden (issue #1693/AG3). An engine dropped with a non-empty memtable
+/// logs a `warn!` and leaves those rows recoverable only via WAL replay on the
+/// next startup.
+///
+/// Embedders (and every long-lived writer) MUST therefore call
+/// `engine.close().await` for a graceful shutdown — e.g. from a `SIGINT`
+/// handler — before the process exits.
+///
 /// ## Thread Safety
 ///
 /// WriteEngine follows a single-writer model. It is NOT thread-safe and
@@ -1263,6 +1279,11 @@ impl WriteEngine {
     /// syncs the WAL, then marks the engine as closed. After calling close(),
     /// the engine cannot be used for further writes.
     ///
+    /// **This is the durability boundary.** `Drop` does not (and cannot — no
+    /// async drop in Tokio) flush; callers MUST `close().await` before exit to
+    /// guarantee written rows reach an SSTable rather than relying on WAL replay
+    /// (issue #1693). See the type-level docs on [`WriteEngine`].
+    ///
     /// This method is idempotent - calling it multiple times is safe.
     ///
     /// # Returns
@@ -1406,6 +1427,22 @@ impl WriteEngine {
 #[cfg(feature = "write-support")]
 impl Drop for WriteEngine {
     fn drop(&mut self) {
+        // Issue #1693 (AG4): `Drop` is NOT a flush — there is no async drop in
+        // Tokio, and re-introducing a `block_on` here is the AG3 defect. So the
+        // best we can do on an ungraceful drop is make the silent data-loss mode
+        // visible: if the memtable still holds rows that `close()` never flushed,
+        // warn. The `is_empty()` guard is a cheap length check; the format
+        // arguments (a single `usize`) allocate only when a warn-level logger is
+        // actually enabled.
+        if !self.memtable.is_empty() {
+            log::warn!(
+                "WriteEngine dropped without close(): {} row(s) in the memtable were NOT \
+                 flushed to an SSTable and remain only in the WAL (durability now relies on \
+                 WAL replay at next startup). Call `close().await` for a graceful shutdown.",
+                self.memtable.row_count()
+            );
+        }
+
         // If close() was already called the lock was already released; a second
         // unlock is a no-op on most platforms (Linux returns ENOLCK which we
         // ignore here).  The important invariant is that the lock is always

--- a/cqlite-core/src/storage/write_engine/mod.rs
+++ b/cqlite-core/src/storage/write_engine/mod.rs
@@ -3197,4 +3197,125 @@ mod tests {
             "both mutations must be readable exactly once (no loss, no duplication)"
         );
     }
+
+    /// Minimal thread-local log capturer for the Drop-warn tests (issue #1693).
+    ///
+    /// A `log` logger can only be installed process-wide once and is shared by
+    /// every test in this binary, so it records into a *thread-local* buffer.
+    /// cargo runs each test on its own thread, so a thread-local buffer isolates
+    /// concurrent tests from one another. No external crate is pulled in.
+    mod drop_warn_capture {
+        use log::{Level, LevelFilter, Log, Metadata, Record};
+        use std::cell::RefCell;
+        use std::sync::Once;
+
+        thread_local! {
+            static BUFFER: RefCell<Option<Vec<String>>> = const { RefCell::new(None) };
+        }
+
+        struct ThreadLocalCapture;
+
+        impl Log for ThreadLocalCapture {
+            fn enabled(&self, _metadata: &Metadata) -> bool {
+                true
+            }
+
+            fn log(&self, record: &Record) {
+                if record.level() == Level::Warn {
+                    BUFFER.with(|b| {
+                        if let Some(buf) = b.borrow_mut().as_mut() {
+                            buf.push(record.args().to_string());
+                        }
+                    });
+                }
+            }
+
+            fn flush(&self) {}
+        }
+
+        static INSTALL: Once = Once::new();
+
+        /// Install the capturing logger process-wide (idempotent) and begin
+        /// capturing warnings on the current thread. If another logger was
+        /// already installed the buffer stays available on this thread but no
+        /// records arrive, which fails the assertions loudly rather than
+        /// silently passing.
+        pub(super) fn start() {
+            INSTALL.call_once(|| {
+                let _ = log::set_boxed_logger(Box::new(ThreadLocalCapture));
+                log::set_max_level(LevelFilter::Trace);
+            });
+            BUFFER.with(|b| *b.borrow_mut() = Some(Vec::new()));
+        }
+
+        /// Take the warnings captured on the current thread since `start()`.
+        pub(super) fn take_warnings() -> Vec<String> {
+            BUFFER.with(|b| b.borrow_mut().take().unwrap_or_default())
+        }
+    }
+
+    /// Issue #1693 (AG4): dropping a `WriteEngine` whose memtable still holds
+    /// un-flushed rows (i.e. `close()` was never called) must emit a `warn!` so
+    /// the silent data-loss mode is visible in logs.
+    #[test]
+    fn test_drop_without_close_warns_on_nonempty_memtable() {
+        drop_warn_capture::start();
+
+        let temp_dir = TempDir::new().unwrap();
+        let schema = create_test_schema();
+        let config = WriteEngineConfig::new(
+            temp_dir.path().join("data"),
+            temp_dir.path().join("wal"),
+            schema,
+        );
+        let mut engine = WriteEngine::new(config).unwrap();
+        engine
+            .write(create_test_mutation(1, "Alice", 1_000_000))
+            .unwrap();
+        assert!(
+            engine.memtable_row_count() > 0,
+            "precondition: memtable must be non-empty before drop"
+        );
+
+        // Drop WITHOUT close() — the durability-loss path.
+        drop(engine);
+
+        let warnings = drop_warn_capture::take_warnings();
+        assert!(
+            warnings
+                .iter()
+                .any(|m| m.contains("dropped") && m.contains("without close")),
+            "expected an unflushed-drop warning, captured warnings: {warnings:?}"
+        );
+    }
+
+    /// Control for issue #1693: after a graceful `close()` the memtable is empty,
+    /// so `Drop` must NOT emit the unflushed-drop warning.
+    #[tokio::test]
+    async fn test_drop_after_close_does_not_warn() {
+        drop_warn_capture::start();
+
+        let temp_dir = TempDir::new().unwrap();
+        let schema = create_test_schema();
+        let config = WriteEngineConfig::new(
+            temp_dir.path().join("data"),
+            temp_dir.path().join("wal"),
+            schema,
+        );
+        let mut engine = WriteEngine::new(config).unwrap();
+        engine
+            .write(create_test_mutation(1, "Alice", 1_000_000))
+            .unwrap();
+        engine.close().await.unwrap();
+
+        drop(engine);
+
+        let warnings = drop_warn_capture::take_warnings();
+        assert!(
+            !warnings
+                .iter()
+                .any(|m| m.contains("dropped") && m.contains("without close")),
+            "close() flushed the memtable; Drop must not warn, captured: {warnings:?}"
+        );
+    }
 }

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -38,7 +38,8 @@
 #   format-compat      cargo test -p format-compatibility-tests (the 'oa' format crate;
 #                      issue #865 folded it into the workspace so fmt/clippy reach it)
 #   write-tests        cargo test -p cqlite-core --features write-support (lib + roundtrip + compaction)
-#   cli-tests          cargo test -p cqlite-cli --test unit_tests + (write-support)
+#   cli-tests          cargo test -p cqlite-cli --test unit_tests + (write-support:
+#                      write_readback_content_tests + graceful_shutdown_tests)
 #                      write_readback_content_tests (CQL write→read content parity, #1231)
 #   python-bindings    maturin develop + pytest bindings/python/tests in a throwaway
 #                      venv; SKIPs (never silently PASSes) if python3 is unavailable.
@@ -961,7 +962,8 @@ run_component write-tests bash -c '
   cargo test --package cqlite-core --features write-support --test compaction_integration'
 run_component cli-tests bash -c '
   cargo test --package cqlite-cli --test unit_tests &&
-  cargo test --package cqlite-cli --features write-support --test write_readback_content_tests'
+  cargo test --package cqlite-cli --features write-support --test write_readback_content_tests &&
+  cargo test --package cqlite-cli --features write-support --test graceful_shutdown_tests'
 run_compaction_byte_parity
 run_python_bindings
 run_node_bindings


### PR DESCRIPTION
Closes #1693 (AG4 — epic #1684 platform landmines). Deps #1390/#1391 (WAL P0s) landed 2026-07-02.

## Bug
No graceful shutdown: `WriteEngine::Drop` released only the dir lock (no flush); the CLI had no SIGINT handler. Ctrl-C in `--writable` mode lost unflushed rows (durability rested entirely on WAL replay).

## Fix (3 parts)
1. **CLI SIGINT handler** — a new interactive `--writable` session (`run_writable_interactive`, command `None` + no one-shot flag): `tokio::select!` over `ctrl_c()` vs stdin lines; first Ctrl-C (or EOF) → `engine.close().await` (flush memtable→SSTable + finalize). **Second Ctrl-C during shutdown → immediate `exit(130)`** (documented; unflushed rows then remain in WAL only). Exits via `std::process::exit` because tokio's async stdin leaves a parked blocking read that would otherwise wedge runtime shutdown.
2. **Library docs** — close-for-durability contract on `Database::close` + `WriteEngine`: embedders MUST call `close()`; `Drop` is not a flush.
3. **Debug-warn on unflushed drop** — `WriteEngine::Drop` `warn!`s if the memtable is non-empty (makes silent loss visible).

## Evidence (TDD red→green)
- `sigint_in_writable_session_flushes_before_exit` (cqlite-cli): drives the real binary as a child, writes over stdin, `libc::kill(SIGINT)`, asserts clean exit AND the row present on independent reopen. RED (`no interactive writable session`) → GREEN (1.58s).
- `test_drop_without_close_warns_on_nonempty_memtable` (cqlite-core, thread-local log capture): RED (no warning) → GREEN; + `test_drop_after_close_does_not_warn` control.

## Gate — PASS (all components)
```
commit: fac99588  RESULT: PASS
```
Did NOT reintroduce `block_on` in Drop (that's the AG3 defect just fixed in #1692). Did not touch WAL replay (#1390/#1391 own it).

## Notes for reviewer
- `file-size`: grows `main.rs` (1283→1399) + `write_engine/mod.rs` (3200→3358), both already far over threshold; splitting is epic #1116 → `CQLITE_ALLOW_FILE_GROWTH=1` acknowledged.
- **AC scope note:** the issue named "writable AND REPL modes," but the REPL's write subcommands are placeholder stubs and REPL DML is NOT routed to a `WriteEngine` (pre-existing since #392) — so a REPL session holds no live engine to lose data from. The handler lives in the writable session, which is the real durability-loss path. Wiring REPL writes to an engine is a separate feature (flagged for follow-up), not #1693.