### PR TITLE
docs: fix storage engine architecture diagram

### DIFF
--- a/website/scripts/validate-proposals-research.mjs
+++ b/website/scripts/validate-proposals-research.mjs
@@ -41,6 +41,30 @@ const checks = [
     file: 'src/assets/storage-engine-parallel-planes.png',
     binary: true,
   },
+  {
+    name: 'architecture diagram separates OLTP writes from OLAP read path',
+    file: 'src/assets/storage-engine-architecture.svg',
+    includes: [
+      'Apps use Cassandra for reads and writes.',
+      'Apps query analytical services backed by SSTables.',
+      'Application analytical reads',
+      'Trino + Arrow Flight',
+      'Iceberg materializer',
+      'CQLite SSTable reader',
+      'snapshot read',
+      'optional fresh tail export',
+    ],
+    ordered: [
+      'Application analytical reads',
+      'Trino + Arrow Flight',
+      'Iceberg materializer',
+      'CQLite SSTable reader',
+    ],
+    excludes: [
+      'Operational writes, reads, repair, and lifecycle stay in Cassandra.',
+      'CQLite reads Cassandra files for analytics without owning OLTP.',
+    ],
+  },
 ];
 
 let failed = false;
@@ -68,6 +92,35 @@ for (const check of checks) {
       );
       failed = true;
       checkFailed = true;
+    }
+  }
+
+  if (check.excludes) {
+    for (const unexpected of check.excludes) {
+      if (contents.includes(unexpected)) {
+        console.error(
+          `FAIL ${check.name}: ${check.file} still includes ${JSON.stringify(unexpected)}`
+        );
+        failed = true;
+        checkFailed = true;
+      }
+    }
+  }
+
+  if (check.ordered) {
+    let cursor = -1;
+
+    for (const expected of check.ordered) {
+      const nextIndex = contents.indexOf(expected, cursor + 1);
+      if (nextIndex === -1) {
+        console.error(
+          `FAIL ${check.name}: ${check.file} does not include ${JSON.stringify(expected)} after the previous ordered label`
+        );
+        failed = true;
+        checkFailed = true;
+        break;
+      }
+      cursor = nextIndex;
     }
   }
 

--- a/website/src/assets/storage-engine-architecture.svg
+++ b/website/src/assets/storage-engine-architecture.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1180 620" role="img" aria-labelledby="title desc">
   <title id="title">CQLite storage engine direction architecture</title>
-  <desc id="desc">Cassandra OLTP plane and CQLite OLAP plane sit above a shared SSTable foundation.</desc>
+  <desc id="desc">Cassandra OLTP creates SSTables while OLAP applications query analytical services backed by CQLite SSTable reads.</desc>
   <defs>
     <marker id="arrow-blue" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
       <path d="M0,0 L10,5 L0,10 Z" fill="#2f6fed"/>
@@ -17,7 +17,7 @@
 
   <rect x="58" y="58" width="390" height="336" rx="18" fill="#ffffff" stroke="#ccd6e6" stroke-width="2"/>
   <text x="84" y="98" font-family="Inter, Arial, sans-serif" font-size="28" font-weight="700" fill="#162033">Cassandra OLTP Plane</text>
-  <text x="84" y="127" font-family="Inter, Arial, sans-serif" font-size="15" fill="#59677e">Operational writes, reads, repair, and lifecycle stay in Cassandra.</text>
+  <text x="84" y="127" font-family="Inter, Arial, sans-serif" font-size="15" fill="#59677e">Apps use Cassandra for reads and writes.</text>
 
   <rect x="92" y="166" width="322" height="52" rx="10" fill="#eef5ff" stroke="#c8d9fa"/>
   <text x="116" y="198" font-family="Inter, Arial, sans-serif" font-size="17" font-weight="650" fill="#23304a">Application reads and writes</text>
@@ -28,18 +28,20 @@
 
   <rect x="732" y="58" width="390" height="336" rx="18" fill="#ffffff" stroke="#ccd6e6" stroke-width="2"/>
   <text x="758" y="98" font-family="Inter, Arial, sans-serif" font-size="28" font-weight="700" fill="#162033">OLAP Plane</text>
-  <text x="758" y="127" font-family="Inter, Arial, sans-serif" font-size="15" fill="#59677e">CQLite reads Cassandra files for analytics without owning OLTP.</text>
+  <text x="758" y="127" font-family="Inter, Arial, sans-serif" font-size="15" fill="#59677e">Apps query analytical services backed by SSTables.</text>
 
-  <rect x="766" y="166" width="322" height="52" rx="10" fill="#eef5ff" stroke="#c8d9fa"/>
-  <text x="790" y="198" font-family="Inter, Arial, sans-serif" font-size="17" font-weight="650" fill="#23304a">CQLite SSTable reader</text>
-  <rect x="766" y="238" width="322" height="52" rx="10" fill="#eefaf7" stroke="#bfebe0"/>
-  <text x="790" y="270" font-family="Inter, Arial, sans-serif" font-size="17" font-weight="650" fill="#23304a">Arrow Flight + Trino</text>
-  <rect x="766" y="310" width="322" height="52" rx="10" fill="#fff8ec" stroke="#f0d3a9"/>
-  <text x="790" y="342" font-family="Inter, Arial, sans-serif" font-size="17" font-weight="650" fill="#23304a">Iceberg materializer</text>
+  <rect x="766" y="154" width="322" height="44" rx="10" fill="#eef5ff" stroke="#c8d9fa"/>
+  <text x="790" y="181" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="650" fill="#23304a">Application analytical reads</text>
+  <rect x="766" y="214" width="322" height="44" rx="10" fill="#eefaf7" stroke="#bfebe0"/>
+  <text x="790" y="241" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="650" fill="#23304a">Trino + Arrow Flight</text>
+  <rect x="766" y="274" width="322" height="44" rx="10" fill="#fff8ec" stroke="#f0d3a9"/>
+  <text x="790" y="301" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="650" fill="#23304a">Iceberg materializer</text>
+  <rect x="766" y="334" width="322" height="44" rx="10" fill="#f6f1ff" stroke="#d6c7fa"/>
+  <text x="790" y="361" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="650" fill="#23304a">CQLite SSTable reader</text>
 
   <rect x="118" y="454" width="944" height="108" rx="18" fill="#ffffff" stroke="#ccd6e6" stroke-width="2"/>
   <text x="148" y="492" font-family="Inter, Arial, sans-serif" font-size="25" font-weight="750" fill="#162033">SSTable Foundation</text>
-  <text x="148" y="522" font-family="Inter, Arial, sans-serif" font-size="15" fill="#59677e">Durable Cassandra components are the common substrate CQLite understands.</text>
+  <text x="148" y="522" font-family="Inter, Arial, sans-serif" font-size="15" fill="#59677e">Shared Cassandra SSTable files.</text>
 
   <g font-family="Inter, Arial, sans-serif" font-size="15" font-weight="700" fill="#2d3950">
     <rect x="430" y="480" width="96" height="44" rx="9" fill="#f4f7fb" stroke="#d7e0ee"/>

--- a/website/src/content/docs/proposals-research/storage-engine.mdx
+++ b/website/src/content/docs/proposals-research/storage-engine.mdx
@@ -75,10 +75,10 @@ flowchart TB
   end
 
   subgraph OLAP["OLAP Plane"]
-    CQLite["CQLite SSTable reader"]
-    Flight["Arrow Flight"]
-    Trino["Trino"]
+    ReadApp["Application analytical reads"]
+    Query["Trino + Arrow Flight"]
     Iceberg["Iceberg materializer"]
+    CQLite["CQLite SSTable reader"]
   end
 
   subgraph SSTables["SSTable Foundation"]
@@ -92,9 +92,9 @@ flowchart TB
   App --> CommitLog --> Lifecycle
   Lifecycle --> SSTables
   SSTables --> CQLite
-  CQLite --> Flight
-  Flight --> Trino
-  CQLite --> Iceberg
+  ReadApp --> Query
+  Query --> Iceberg
+  Iceberg --> CQLite
   CommitLog -. fresh tail export .-> Tail
 ```
 


### PR DESCRIPTION
Summary:
- Reorders the OLAP side to start with application analytical reads and end at the CQLite SSTable reader.
- Moves the snapshot-read arrow to the CQLite reader and rewrites plane subtitles to avoid OLTP/OLAP wording bleed.
- Adds validator coverage for the corrected label order and rejected old copy.

Verification:
- npm run validate-proposals-research
- npm run build