### PR TITLE
A5 (#1566): cold-open bench, unified history ledger, test-only read-work counters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,6 +208,10 @@ docs/sstable-guide-audit/
 # parity-report self-test probe (issue #1338): removed by trap, ignored as a safety net
 test-data/.tmp-parity-manifest-mutated.yml
 
-# tail-latency harness history ledger (issue #1563): generated run data,
-# machine/run-specific. Consolidates into Epic A5's unified history.jsonl.
-cqlite-core/benches/tail-latency-history.jsonl
+# Unified perf history ledger (issue #1566, Epic A / A5): the A-series benches and
+# scripts/profile_report.py append per-metric run records to
+# target/profiling/history.jsonl. This is machine/run-specific generated run data —
+# it lives under /target (already ignored) so needs no rule of its own, and CI may
+# upload it as an artifact; we never commit it (a per-machine churning ledger would
+# be noise and a merge-race magnet). The A2 bespoke tail-latency ledger it replaced
+# was removed here when A5 landed.

--- a/cqlite-core/Cargo.toml
+++ b/cqlite-core/Cargo.toml
@@ -156,6 +156,14 @@ crc32fast = { workspace = true }
 [target.'cfg(unix)'.dev-dependencies]
 pprof = { version = "0.14", features = ["flamegraph", "criterion"] }
 
+# Current-RSS sampling for the open/mem bench (benches/open.rs, Issue #1566 A5):
+# mach `task_info(MACH_TASK_BASIC_INFO).resident_size` is the live resident size
+# (getrusage.ru_maxrss is PEAK, not current — Finding 3). libc's mach_task_self is
+# deprecated in favor of mach2, so use mach2 for the non-deprecated task port.
+# macOS-only, dev-only: never ships in the library.
+[target.'cfg(target_os = "macos")'.dev-dependencies]
+mach2 = "0.4"
+
 [[bench]]
 name = "partition_lookup"
 harness = false

--- a/cqlite-core/Cargo.toml
+++ b/cqlite-core/Cargo.toml
@@ -334,6 +334,16 @@ delta-scan = []
 # adds overhead). See docs/profiling.md.
 dhat-heap = []
 
+# Read-work counters (issue #1566, Epic A / A5). TEST/BENCH-ONLY, NOT in defaults:
+# enables the getters/`reset` and the counter bodies in
+# `storage::sstable::read_work_counters` so benches and integration tests can read
+# the trie-walk / decompress / seek / file-open gauges. The `record_*()` call sites
+# are unconditional but compile to no-ops without this feature (and without
+# `cfg(test)`), so a default/release build links no counter atomics and pays
+# nothing — verify with `cargo build -p cqlite-core` that no counter static is
+# referenced. Consumed by epics B–G's TDD work-guard tests.
+work-counters = []
+
 # Scan-offload thread-identity probe (issue #1143 regression guard). TEST-ONLY,
 # NOT in defaults: gates the `scan_stream_windowed::probe` module, the pub
 # visibility of `scan_stream_windowed`, and the single `record_parse_thread()`

--- a/cqlite-core/Cargo.toml
+++ b/cqlite-core/Cargo.toml
@@ -208,6 +208,15 @@ harness = false
 name = "tail_latency"
 harness = false
 
+# Cold-open + per-reader-memory bench (issue #1566, Epic A / A5). `harness = false`
+# criterion target: `open/cold_big`, `open/cold_bti` (skip-register when absent),
+# and `mem/open_n_readers` (records the per-reader RSS gauge the ledger can express
+# but criterion cannot). Appends its measured medians + memory metric to the unified
+# target/profiling/history.jsonl via the shared bench_ledger module.
+[[bench]]
+name = "open"
+harness = false
+
 [features]
 # M2+ production defaults: Full query engine + write path enabled.
 # write-support is a pure first-party code-gating flag (no extra dependencies),

--- a/cqlite-core/benches/README.md
+++ b/cqlite-core/benches/README.md
@@ -97,6 +97,8 @@ env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets \
 | `observability_overhead` | added (#1043) | Zero-overhead-when-disabled gate: `read_scan` (needs `cli-helpers`) and `write_merge` (needs `write-support`). The SAME bench source runs under the default build vs `--features observability` with export disabled; the two arms are compared by `scripts/ci/observability_overhead.sh` — see below. |
 | `concurrent_scan` | added (#917), **gated** (#1564) | Aggregate throughput of N ∈ {1,2,4,8} concurrent `get_all_entries()` scans against one shared `Arc<SSTableReader>`, for the buffered and mmap backends (needs `--features cli-helpers`). Gated via a **concurrency scaling floor** (not absolute time) — see below. |
 | `read_while_write` | added (#1143), **gated** (#1564) | Reader-side scan latency with ~6 full-scan readers running concurrently with ~2 sustained-ingest writers (needs `--features cli-helpers,write-support`). Gated on the Criterion **median** (strict, 25% threshold); the p99 tail is printed to stderr for local diagnosis and owned by the A2 tail-latency harness (#1563). |
+| `tail_latency` | added (#1563) | `harness = false` mixed-load tail harness (needs `--features cli-helpers`): p50/p99/p999 + intra-run ratios for point reads under a background scan — see below. Appends per-metric rows to the unified ledger. |
+| `open` | added (#1566) | `harness = false` cold-open + memory bench (needs `--features cli-helpers`): `open/cold_big` and `open/cold_bti` (fresh `SSTableReader::open` component-load cost; `_bti` skip-registers when `test_da` is absent) and `mem/open_n_readers` (per-reader RSS gauge). Skip-on-absent, panic-on-present-but-broken; appends its medians + the memory metric to the unified ledger — see below. |
 
 ### `observability_overhead` two-build comparison (Issue #1043)
 
@@ -344,12 +346,34 @@ is the convoy inflation — the headline number the C2/F1/F3 fixes must drive do
 All gate thresholds are these intra-run **ratios**, never wall-clock absolutes, so
 shared-runner noise cannot flap the gate.
 
-### History ledger
+### Unified history ledger (Issue #1566, Epic A / A5)
 
-Each run appends one JSON record (`{ts, commit, mixed, scan_free, ratios}`) to
-`benches/tail-latency-history.jsonl`. This is generated run data (machine/run
-specific), so it is **gitignored**, not committed. It is documented to consolidate
-into the Epic A5 unified `history.jsonl` when A5 lands.
+All harness benches persist their metrics to **one** append-only ledger,
+`target/profiling/history.jsonl`, written through the shared Rust module
+`benches/bench_ledger`. Every line is one JSON object **per metric** in the schema:
+
+```json
+{"ts": 1783103681, "commit": "<full-sha|unknown>", "bench": "tail_latency", "metric": "p99_over_p50", "value": 2.31, "unit": "ratio"}
+```
+
+- The `tail_latency` bench writes `mixed_p50/p99/p999` + `scan_free_p50/p99/p999`
+  (`ns`) and the two derived ratios (`ratio`), one line each.
+- The `open` bench writes `cold_big_median_ns` / `cold_bti_median_ns` (`ns`) and the
+  per-reader memory gauges `rss_after_n_readers_bytes` / `rss_per_reader_bytes`
+  (`bytes`).
+- `scripts/profile_report.py` writes each criterion bench's `median_ns` (`ns`) and
+  `peak_heap_bytes` (`bytes`) in the same schema.
+
+`./scripts/profile.sh report` reads the whole ledger back into a longitudinal
+per-metric table (latest value + delta vs the previous distinct commit). The ledger
+is generated run data (machine/run-specific): it lives under `target/` (gitignored)
+and is **never committed**; CI may upload it as an artifact. Override the path for a
+bench with the `CQLITE_BENCH_LEDGER` env var (else
+`<crate>/../target/profiling/history.jsonl`). Append is best-effort — a ledger write
+failure logs to stderr and never fails a measurement run.
+
+This replaced the A2 bespoke `benches/tail-latency-history.jsonl` (retired when A5
+landed). See `docs/profiling.md` for the full ledger contract.
 
 ### Advisory-first tail gate
 

--- a/cqlite-core/benches/bench_ledger/mod.rs
+++ b/cqlite-core/benches/bench_ledger/mod.rs
@@ -113,7 +113,11 @@ fn now_secs() -> u64 {
 pub fn append_metrics(bench: &str, metrics: &[(&str, f64, &str)]) -> std::io::Result<()> {
     let path = ledger_path();
     if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
+        // A bare filename (e.g. `CQLITE_BENCH_LEDGER=history.jsonl`) yields an empty
+        // parent; `create_dir_all("")` errors, so only create a real parent dir.
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
     }
     let ts = now_secs();
     let commit = current_commit();

--- a/cqlite-core/benches/bench_ledger/mod.rs
+++ b/cqlite-core/benches/bench_ledger/mod.rs
@@ -1,0 +1,144 @@
+//! Unified append-only perf history ledger (Issue #1566, Epic A / A5).
+//!
+//! This is the single append path every A-series harness bench uses to persist its
+//! run metrics, replacing the fragmented pair of ledgers A5 was chartered to unify
+//! (the A2 `tail_latency` bench's bespoke `tail-latency-history.jsonl` and
+//! `profile_report.py`'s run-summary line). Each bench includes it via `#[path]`
+//! (the same pattern `tail_latency/mod.rs` and `fixtures/mod.rs` use), so every
+//! bench compiles its own copy and refers to it as `crate::bench_ledger`. Like the
+//! other shared bench-support modules, each includer uses only a subset, hence the
+//! module-wide `dead_code` allowance.
+//!
+//! # Schema (one JSON object per line, one record PER metric)
+//!
+//! ```text
+//! {"ts": <unix_secs>, "commit": "<sha|unknown>", "bench": "<id>",
+//!  "metric": "<name>", "value": <number>, "unit": "<str>"}
+//! ```
+//!
+//! A single harness run emits several lines — e.g. the `tail_latency` bench writes
+//! `tail_latency`/`mixed_p99` (`ns`), `tail_latency`/`p99_over_p50` (`ratio`), … as
+//! separate records. `profile_report.py` writes the SAME schema for its criterion
+//! medians (`<group>/<bench>`/`median_ns`) and peak heap, and
+//! `./scripts/profile.sh report` reads the whole ledger back into a longitudinal
+//! per-metric table.
+//!
+//! # Path
+//!
+//! `target/profiling/history.jsonl` — the path `profile_report.py` and
+//! `docs/profiling.md` already document — resolvable from a bench via the
+//! `CQLITE_BENCH_LEDGER` env override, else `<CARGO_MANIFEST_DIR>/../target/
+//! profiling/history.jsonl`. It is machine-specific generated run data: gitignored
+//! (it lives under `target/`, which is ignored), and CI may upload it as an
+//! artifact — we do not commit it (a committed, per-machine, churning ledger would
+//! be noise and a merge-race magnet).
+//!
+//! # Best-effort
+//!
+//! [`append_metrics`] returns `io::Result` so a test can assert success, but a
+//! ledger write must NEVER abort a measurement run: bench mains log the error to
+//! stderr and continue (see `tail_latency.rs` / `open.rs`). The spec's "a ledger
+//! write failure does not fail the bench" guarantee lives at those call sites.
+
+#![allow(dead_code)]
+
+use std::io::Write as _;
+use std::path::PathBuf;
+
+/// One appended ledger record: a single metric of a single bench run.
+///
+/// Serialized as one JSON line. `commit` is owned (stamped per call);
+/// `bench`/`metric`/`unit` borrow the caller's strings to avoid per-metric
+/// allocation across a batch.
+#[derive(serde::Serialize)]
+struct LedgerRecord<'a> {
+    ts: u64,
+    commit: String,
+    bench: &'a str,
+    metric: &'a str,
+    value: f64,
+    unit: &'a str,
+}
+
+/// Resolve the ledger path: the `CQLITE_BENCH_LEDGER` env override if set and
+/// non-empty, else `<CARGO_MANIFEST_DIR>/../target/profiling/history.jsonl`
+/// (anchored to the crate dir, not the CWD, so the same file is appended
+/// regardless of where cargo runs the bench).
+pub fn ledger_path() -> PathBuf {
+    if let Ok(p) = std::env::var("CQLITE_BENCH_LEDGER") {
+        let p = p.trim();
+        if !p.is_empty() {
+            return PathBuf::from(p);
+        }
+    }
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../target/profiling/history.jsonl")
+}
+
+/// Best-effort current commit SHA: `GIT_COMMIT` env override, else `git rev-parse
+/// HEAD`, else `"unknown"`. Never fails (ledger append must not abort a run).
+/// Reused from the A2 `tail_latency` harness, now homed in the single writer.
+fn current_commit() -> String {
+    if let Ok(sha) = std::env::var("GIT_COMMIT") {
+        let sha = sha.trim().to_string();
+        if !sha.is_empty() {
+            return sha;
+        }
+    }
+    std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .and_then(|out| String::from_utf8(out.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+/// Unix-seconds timestamp (0 if the clock is before the epoch — never panics).
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Append one JSON-line record PER metric for `bench` to the unified ledger
+/// (creating the file and its parent dirs if absent). All records in one call
+/// share the same `ts` and `commit`. Generated run data; the ledger is gitignored.
+///
+/// Returns `io::Result` so a test can assert the write; bench mains treat a failure
+/// as best-effort (log to stderr, continue) — a ledger write must not fail a run.
+pub fn append_metrics(bench: &str, metrics: &[(&str, f64, &str)]) -> std::io::Result<()> {
+    let path = ledger_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let ts = now_secs();
+    let commit = current_commit();
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)?;
+    for (metric, value, unit) in metrics {
+        let record = LedgerRecord {
+            ts,
+            commit: commit.clone(),
+            bench,
+            metric,
+            value: *value,
+            unit,
+        };
+        let line = serde_json::to_string(&record).map_err(std::io::Error::other)?;
+        writeln!(file, "{line}")?;
+    }
+    Ok(())
+}
+
+// Tests live in `tests/bench_ledger.rs` (an integration test harness), not inline:
+// Cargo compiles bench targets with `cfg(test)` set, so an inline `#[cfg(test)] mod
+// tests` would be pulled into every harness bench binary (where `#[test]` fns are
+// dead and their imports flagged under `-D warnings`). The integration crate that
+// includes this module via `#[path]` is a real test harness and runs them cleanly —
+// the same convention `tail_latency/mod.rs` follows.

--- a/cqlite-core/benches/open.rs
+++ b/cqlite-core/benches/open.rs
@@ -110,9 +110,16 @@ fn open_reader_blocking(
     })
 }
 
-/// Sample the process RSS in bytes: `/proc/self/statm` (current RSS, Linux) or
-/// `getrusage` `ru_maxrss` (peak RSS in bytes, macOS). `None` elsewhere so the
-/// caller records nothing rather than a bogus value. Best-effort.
+/// Sample the process's CURRENT resident set size in bytes: `/proc/self/statm`
+/// (Linux) or the mach `task_info(MACH_TASK_BASIC_INFO).resident_size` (macOS).
+/// `None` elsewhere so the caller records nothing rather than a bogus value.
+/// Best-effort.
+///
+/// macOS note (Finding 3, roborev): `getrusage.ru_maxrss` is PEAK RSS, not current,
+/// so a per-reader delta computed from two peak samples can be 0/stale when an
+/// earlier peak already exceeded the post-open footprint. mach `task_info` with
+/// `MACH_TASK_BASIC_INFO` reports the live `resident_size`, so the delta honestly
+/// reflects the readers just opened.
 #[cfg(feature = "cli-helpers")]
 fn rss_bytes() -> Option<u64> {
     #[cfg(target_os = "linux")]
@@ -128,14 +135,27 @@ fn rss_bytes() -> Option<u64> {
     }
     #[cfg(target_os = "macos")]
     {
-        // SAFETY: getrusage writes a fully-initialized rusage into the zeroed struct.
-        let mut usage: libc::rusage = unsafe { std::mem::zeroed() };
-        let rc = unsafe { libc::getrusage(libc::RUSAGE_SELF, &mut usage) };
-        if rc != 0 {
+        // Current resident size via mach task_info(MACH_TASK_BASIC_INFO). Unlike
+        // getrusage.ru_maxrss (peak), resident_size is the live RSS. The task port
+        // comes from mach2 (libc's mach_task_self is deprecated); the info struct,
+        // flavor, count, and task_info entry point are the non-deprecated libc ones.
+        let mut info: libc::mach_task_basic_info = unsafe { std::mem::zeroed() };
+        let mut count: libc::mach_msg_type_number_t = libc::MACH_TASK_BASIC_INFO_COUNT;
+        // SAFETY: mach_task_self() returns this process's task port; task_info writes
+        // `count` integers into `info` (zeroed, correctly sized via
+        // MACH_TASK_BASIC_INFO_COUNT). We check the kern_return_t before reading it.
+        let rc = unsafe {
+            libc::task_info(
+                mach2::traps::mach_task_self(),
+                libc::MACH_TASK_BASIC_INFO,
+                &mut info as *mut _ as libc::task_info_t,
+                &mut count,
+            )
+        };
+        if rc != libc::KERN_SUCCESS {
             return None;
         }
-        // On macOS ru_maxrss is bytes (Linux would be KiB, handled above).
-        Some(usage.ru_maxrss.max(0) as u64)
+        Some(info.resident_size)
     }
     #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     {

--- a/cqlite-core/benches/open.rs
+++ b/cqlite-core/benches/open.rs
@@ -1,0 +1,340 @@
+//! Cold-open + per-reader-memory benchmarks for cqlite-core (Issue #1566, Epic A / A5).
+//!
+//! The read audit (`docs/reports/read-path-performance-audit-2026-07-01.md` §Epic A)
+//! has no gauge for `SSTableReader::open` cost (loading Statistics / Summary /
+//! CompressionInfo and, for BTI, the `Partitions.db` trie root) nor for the
+//! per-reader memory footprint. Epic G3's bounded-`Index.db` mode needs the RSS
+//! baseline; this bench establishes both.
+//!
+//! # Benches
+//!
+//! - `open/cold_big` — a fresh `SSTableReader::open` on the BIG multi-chunk
+//!   `test_basic.simple_table` (`nb`) fixture: a genuine COLD open (component load),
+//!   not a warm reuse — every iteration opens the file afresh.
+//! - `open/cold_bti` — the same over the BTI `test_da.simple_table` (`da`) fixture,
+//!   which additionally loads the trie root. **Optional**: skip-registers (no group)
+//!   when the `test_da` corpus is absent.
+//! - `mem/open_n_readers` — opens `N` readers over the BIG fixture and records the
+//!   process RSS after, so G3 has a before/after per-reader memory gauge.
+//!
+//! # Honesty (parity-is-truth)
+//!
+//! A fixture that is entirely absent is skip-registered (no group, gate reports
+//! SKIP). A fixture that is PRESENT but yields an unusable open panics at setup
+//! rather than recording a misleading measurement (same guard family as A1/A2).
+//!
+//! # Ledger
+//!
+//! Beyond the criterion medians (which `scripts/profile_report.py` folds into the
+//! unified `target/profiling/history.jsonl`), this bench appends its own measured
+//! cold-open medians and the per-reader memory metric — which criterion's timing
+//! model cannot express — directly through the shared `bench_ledger` module. The
+//! append is best-effort: a ledger failure logs and never fails the bench.
+//!
+//! Gated on `cli-helpers` only to keep parity with the other read benches' feature
+//! surface (the open path itself needs no query engine); under default features the
+//! bench compiles to an empty-but-valid criterion group.
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+#[path = "bench_ledger/mod.rs"]
+mod bench_ledger;
+
+#[path = "fixtures/mod.rs"]
+mod fixtures;
+
+#[path = "profiling/mod.rs"]
+mod profiling;
+
+// ---------------------------------------------------------------------------
+// cli-helpers benches
+// ---------------------------------------------------------------------------
+
+/// Readers opened for the memory footprint gauge. Enough that per-reader
+/// component memory (Summary/Statistics/CompressionInfo/BTI root) dominates
+/// fixed process overhead, without a long bench.
+#[cfg(feature = "cli-helpers")]
+const N_READERS: usize = 16;
+
+/// Cold-open samples for the manual median appended to the ledger. Small — one
+/// open is milliseconds — so the ledger append stays cheap alongside criterion.
+#[cfg(feature = "cli-helpers")]
+const MEDIAN_SAMPLES: usize = 30;
+
+/// Locate the `*-Data.db` file inside a present fixture's table directory.
+/// Returns `None` when absent (caller skip-registers) and panics only on a
+/// genuinely broken directory it could not read.
+#[cfg(feature = "cli-helpers")]
+fn data_db_path(fx: &fixtures::ReadFixture) -> Option<std::path::PathBuf> {
+    if !fixtures::fixture_present(fx) {
+        return None;
+    }
+    let dir = fixtures::table_dir(fx.keyspace, fx.table);
+    let entry = std::fs::read_dir(&dir)
+        .unwrap_or_else(|e| panic!("cannot read fixture dir {}: {e}", dir.display()))
+        .filter_map(|e| e.ok())
+        .find(|e| e.file_name().to_string_lossy().ends_with("-Data.db"));
+    entry.map(|e| e.path())
+}
+
+/// Median of a sample (nearest-rank p50 by sort; 0 for empty). Local to avoid a
+/// cross-bench dependency on the tail harness's percentile helper.
+#[cfg(feature = "cli-helpers")]
+fn median_ns(mut samples: Vec<u128>) -> f64 {
+    if samples.is_empty() {
+        return 0.0;
+    }
+    samples.sort_unstable();
+    samples[samples.len() / 2] as f64
+}
+
+/// Open one reader from `path`, panicking on error (present-but-broken guard).
+#[cfg(feature = "cli-helpers")]
+fn open_reader_blocking(
+    rt: &tokio::runtime::Runtime,
+    path: &std::path::Path,
+    config: &cqlite_core::Config,
+    platform: &std::sync::Arc<cqlite_core::Platform>,
+) -> cqlite_core::storage::sstable::reader::SSTableReader {
+    rt.block_on(cqlite_core::storage::sstable::reader::SSTableReader::open(
+        path,
+        config,
+        platform.clone(),
+    ))
+    .unwrap_or_else(|e| {
+        panic!(
+            "open: fixture {} present but a fresh SSTableReader::open failed: {e} — \
+             a broken/mismatched component would make this a misleading measurement",
+            path.display()
+        )
+    })
+}
+
+/// Sample the process RSS in bytes: `/proc/self/statm` (current RSS, Linux) or
+/// `getrusage` `ru_maxrss` (peak RSS in bytes, macOS). `None` elsewhere so the
+/// caller records nothing rather than a bogus value. Best-effort.
+#[cfg(feature = "cli-helpers")]
+fn rss_bytes() -> Option<u64> {
+    #[cfg(target_os = "linux")]
+    {
+        let statm = std::fs::read_to_string("/proc/self/statm").ok()?;
+        let resident_pages: u64 = statm.split_whitespace().nth(1)?.parse().ok()?;
+        // SAFETY: `sysconf(_SC_PAGESIZE)` is a pure read of a system constant.
+        let page = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+        if page <= 0 {
+            return None;
+        }
+        Some(resident_pages.saturating_mul(page as u64))
+    }
+    #[cfg(target_os = "macos")]
+    {
+        // SAFETY: getrusage writes a fully-initialized rusage into the zeroed struct.
+        let mut usage: libc::rusage = unsafe { std::mem::zeroed() };
+        let rc = unsafe { libc::getrusage(libc::RUSAGE_SELF, &mut usage) };
+        if rc != 0 {
+            return None;
+        }
+        // On macOS ru_maxrss is bytes (Linux would be KiB, handled above).
+        Some(usage.ru_maxrss.max(0) as u64)
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        None
+    }
+}
+
+/// Bench a genuine COLD open of `fx`'s `Data.db` and append its measured median to
+/// the ledger. Skip-registers (no group) when the fixture is absent; panics at
+/// setup when present-but-broken.
+#[cfg(feature = "cli-helpers")]
+fn bench_cold_open(
+    c: &mut Criterion,
+    fx: fixtures::ReadFixture,
+    bench_name: &str,
+    ledger_metric: &str,
+    ledger: &mut Vec<(String, f64, String)>,
+) {
+    let Some(path) = data_db_path(&fx) else {
+        eprintln!(
+            "open/{bench_name}: fixture {} not present — skipping (skip-register)",
+            fx.qualified()
+        );
+        return;
+    };
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let config = cqlite_core::Config::default();
+    let platform = std::sync::Arc::new(
+        rt.block_on(cqlite_core::Platform::new(&config))
+            .expect("platform init"),
+    );
+
+    // Setup guard: one fresh open must succeed (present-but-broken → panic).
+    let reader = open_reader_blocking(&rt, &path, &config, &platform);
+    std::hint::black_box(reader.header().generation);
+    drop(reader);
+
+    // Manual median (appended to the ledger — criterion's estimates are folded in
+    // separately by profile_report.py).
+    let mut samples = Vec::with_capacity(MEDIAN_SAMPLES);
+    for _ in 0..MEDIAN_SAMPLES {
+        let t0 = std::time::Instant::now();
+        let reader = open_reader_blocking(&rt, &path, &config, &platform);
+        samples.push(t0.elapsed().as_nanos());
+        std::hint::black_box(reader.header().generation);
+    }
+    ledger.push((
+        ledger_metric.to_string(),
+        median_ns(samples),
+        "ns".to_string(),
+    ));
+
+    let mut group = c.benchmark_group("open");
+    group.bench_function(bench_name, |bch| {
+        bch.iter(|| {
+            let reader = open_reader_blocking(&rt, &path, &config, &platform);
+            std::hint::black_box(reader.header().generation)
+        });
+    });
+    group.finish();
+}
+
+/// `open/cold_big` over the always-present BIG (`nb`) fixture.
+#[cfg(feature = "cli-helpers")]
+fn bench_cold_big(c: &mut Criterion) {
+    let mut ledger = Vec::new();
+    bench_cold_open(
+        c,
+        fixtures::ReadFixture::SIMPLE,
+        "cold_big",
+        "cold_big_median_ns",
+        &mut ledger,
+    );
+    append_ledger(&ledger);
+}
+
+/// `open/cold_bti` over the optional BTI (`da`) fixture (skip-register if absent).
+#[cfg(feature = "cli-helpers")]
+fn bench_cold_bti(c: &mut Criterion) {
+    let mut ledger = Vec::new();
+    bench_cold_open(
+        c,
+        fixtures::ReadFixture::SIMPLE_BTI,
+        "cold_bti",
+        "cold_bti_median_ns",
+        &mut ledger,
+    );
+    append_ledger(&ledger);
+}
+
+/// `mem/open_n_readers`: open `N` readers, record the process RSS after (per-reader
+/// and total), append that memory metric to the ledger, and time the batch open.
+#[cfg(feature = "cli-helpers")]
+fn bench_mem_open_n_readers(c: &mut Criterion) {
+    let fx = fixtures::ReadFixture::SIMPLE;
+    let Some(path) = data_db_path(&fx) else {
+        eprintln!(
+            "mem/open_n_readers: fixture {} not present — skipping (skip-register)",
+            fx.qualified()
+        );
+        return;
+    };
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let config = cqlite_core::Config::default();
+    let platform = std::sync::Arc::new(
+        rt.block_on(cqlite_core::Platform::new(&config))
+            .expect("platform init"),
+    );
+
+    // Hold N readers open, then sample RSS with them all resident.
+    let baseline = rss_bytes();
+    let readers: Vec<_> = (0..N_READERS)
+        .map(|_| open_reader_blocking(&rt, &path, &config, &platform))
+        .collect();
+    let after = rss_bytes();
+
+    let mut ledger: Vec<(String, f64, String)> = Vec::new();
+    if let Some(after) = after {
+        ledger.push((
+            "rss_after_n_readers_bytes".to_string(),
+            after as f64,
+            "bytes".to_string(),
+        ));
+        // Per-reader delta over the baseline (never negative; a best-effort gauge).
+        if let Some(base) = baseline {
+            let delta = after.saturating_sub(base);
+            ledger.push((
+                "rss_per_reader_bytes".to_string(),
+                delta as f64 / N_READERS as f64,
+                "bytes".to_string(),
+            ));
+        }
+        ledger.push((
+            "n_readers".to_string(),
+            N_READERS as f64,
+            "count".to_string(),
+        ));
+    } else {
+        eprintln!(
+            "mem/open_n_readers: RSS sampling unsupported on this platform — \
+             recording no memory metric (skip, not fail)"
+        );
+    }
+    drop(readers);
+    append_ledger(&ledger);
+
+    // Criterion timing of the N-reader batch open (drops the readers each iter).
+    let mut group = c.benchmark_group("mem");
+    group.bench_function("open_n_readers", |bch| {
+        bch.iter(|| {
+            let readers: Vec<_> = (0..N_READERS)
+                .map(|_| open_reader_blocking(&rt, &path, &config, &platform))
+                .collect();
+            std::hint::black_box(readers.len())
+        });
+    });
+    group.finish();
+}
+
+/// Append `metrics` under the `open` bench id, best-effort (log, never fail).
+#[cfg(feature = "cli-helpers")]
+fn append_ledger(metrics: &[(String, f64, String)]) {
+    if metrics.is_empty() {
+        return;
+    }
+    let rows: Vec<(&str, f64, &str)> = metrics
+        .iter()
+        .map(|(m, v, u)| (m.as_str(), *v, u.as_str()))
+        .collect();
+    if let Err(e) = bench_ledger::append_metrics("open", &rows) {
+        eprintln!(
+            "open: could not append unified ledger {}: {e}",
+            bench_ledger::ledger_path().display()
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// criterion_group! / criterion_main! — feature-gated so the bench compiles under
+// default features (no cli-helpers) with an empty but valid group.
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "cli-helpers")]
+criterion_group!(
+    name = benches;
+    config = profiling::configure();
+    targets = bench_cold_big, bench_cold_bti, bench_mem_open_n_readers
+);
+
+#[cfg(not(feature = "cli-helpers"))]
+fn bench_noop(_c: &mut Criterion) {
+    // Nothing to bench without cli-helpers. The binary still compiles and runs.
+}
+
+#[cfg(not(feature = "cli-helpers"))]
+criterion_group!(
+    name = benches;
+    config = profiling::configure();
+    targets = bench_noop
+);
+
+criterion_main!(benches);

--- a/cqlite-core/benches/tail_latency.rs
+++ b/cqlite-core/benches/tail_latency.rs
@@ -12,9 +12,13 @@
 //! env CQLITE_DATASETS_ROOT=$PWD/test-data/datasets \
 //!   cargo bench -p cqlite-core --features cli-helpers --bench tail_latency
 //! ```
-//! It prints the harness JSON to stdout and appends one record to the history
-//! ledger (`benches/tail-latency-history.jsonl`, gitignored). Under default
-//! features (no `cli-helpers`) it prints a note and exits 0 without measuring.
+//! It prints the harness JSON to stdout and appends one record PER metric to the
+//! unified history ledger (`target/profiling/history.jsonl`, gitignored) via the
+//! shared `bench_ledger` module (Issue #1566, Epic A / A5). Under default features
+//! (no `cli-helpers`) it prints a note and exits 0 without measuring.
+
+#[path = "bench_ledger/mod.rs"]
+mod bench_ledger;
 
 #[path = "fixtures/mod.rs"]
 mod fixtures;
@@ -29,12 +33,14 @@ fn main() {
             Some(report) => {
                 // Machine-readable JSON to stdout.
                 println!("{}", report.to_json());
-                // Persist one record to the (gitignored) history ledger.
-                let ledger = harness::default_ledger_path();
-                if let Err(e) = harness::append_ledger(&ledger, &report) {
+                // Persist one record PER metric to the unified (gitignored) ledger.
+                // Best-effort: a ledger write must never fail a measurement run.
+                if let Err(e) =
+                    bench_ledger::append_metrics("tail_latency", &report.ledger_metrics())
+                {
                     eprintln!(
-                        "tail_latency: could not append ledger {}: {e}",
-                        ledger.display()
+                        "tail_latency: could not append unified ledger {}: {e}",
+                        bench_ledger::ledger_path().display()
                     );
                 }
             }

--- a/cqlite-core/benches/tail_latency/mod.rs
+++ b/cqlite-core/benches/tail_latency/mod.rs
@@ -42,9 +42,6 @@
 
 #![allow(dead_code)]
 
-use std::io::Write as _;
-use std::path::{Path, PathBuf};
-
 #[cfg(feature = "cli-helpers")]
 use std::sync::atomic::{AtomicBool, Ordering};
 #[cfg(feature = "cli-helpers")]
@@ -69,16 +66,6 @@ pub const WARMUP: usize = 200;
 /// ops gives 2 samples at/above the p999 rank while still running in a few
 /// seconds against the small fixture (point reads are sub-millisecond).
 pub const MEASURED_N: usize = 2000;
-
-/// Default history-ledger path, anchored to the crate dir (not the CWD) so the
-/// bench appends to the same file regardless of where cargo runs it.
-///
-/// This holds **generated run data** (machine/run-specific) and is gitignored.
-/// Epic A5 (cold-open bench + persisted ledger) introduces a unified
-/// `history.jsonl`; this path is documented to fold into A5's ledger then.
-pub fn default_ledger_path() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches/tail-latency-history.jsonl")
-}
 
 // ---------------------------------------------------------------------------
 // Percentile math (pure — unit-tested with no dataset dependency)
@@ -174,65 +161,28 @@ impl HarnessReport {
         serde_json::to_string_pretty(self)
             .unwrap_or_else(|e| format!("{{\"error\":\"serialize HarnessReport: {e}\"}}"))
     }
-}
 
-// ---------------------------------------------------------------------------
-// History ledger
-// ---------------------------------------------------------------------------
-
-/// One appended ledger record: timestamp + commit + both stat blocks + ratios.
-#[derive(serde::Serialize)]
-struct LedgerRecord {
-    ts: u64,
-    commit: String,
-    mixed: TailStats,
-    scan_free: TailStats,
-    p99_over_p50: f64,
-    p99_mixed_over_scan_free: f64,
-}
-
-/// Best-effort current commit SHA: `GIT_COMMIT` env override, else `git rev-parse
-/// HEAD`, else `"unknown"`. Never fails (ledger append must not abort a run).
-fn current_commit() -> String {
-    if let Ok(sha) = std::env::var("GIT_COMMIT") {
-        let sha = sha.trim().to_string();
-        if !sha.is_empty() {
-            return sha;
-        }
+    /// Flatten this report into the unified history-ledger metric rows
+    /// (`(metric, value, unit)`) the shared `bench_ledger::append_metrics` consumes
+    /// (Issue #1566, Epic A / A5). One row per percentile (`ns`) and per derived
+    /// ratio (`ratio`), so the ledger holds one line per metric under the
+    /// `tail_latency` bench id.
+    pub fn ledger_metrics(&self) -> Vec<(&'static str, f64, &'static str)> {
+        vec![
+            ("mixed_p50", self.mixed.p50 as f64, "ns"),
+            ("mixed_p99", self.mixed.p99 as f64, "ns"),
+            ("mixed_p999", self.mixed.p999 as f64, "ns"),
+            ("scan_free_p50", self.scan_free.p50 as f64, "ns"),
+            ("scan_free_p99", self.scan_free.p99 as f64, "ns"),
+            ("scan_free_p999", self.scan_free.p999 as f64, "ns"),
+            ("p99_over_p50", self.p99_over_p50, "ratio"),
+            (
+                "p99_mixed_over_scan_free",
+                self.p99_mixed_over_scan_free,
+                "ratio",
+            ),
+        ]
     }
-    std::process::Command::new("git")
-        .args(["rev-parse", "HEAD"])
-        .current_dir(env!("CARGO_MANIFEST_DIR"))
-        .output()
-        .ok()
-        .filter(|out| out.status.success())
-        .and_then(|out| String::from_utf8(out.stdout).ok())
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| "unknown".to_string())
-}
-
-/// Append one JSON-line record for `report` to the ledger at `path`
-/// (creating it if absent). Generated run data; the ledger is gitignored.
-pub fn append_ledger(path: &Path, report: &HarnessReport) -> std::io::Result<()> {
-    let ts = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
-    let record = LedgerRecord {
-        ts,
-        commit: current_commit(),
-        mixed: report.mixed,
-        scan_free: report.scan_free,
-        p99_over_p50: report.p99_over_p50,
-        p99_mixed_over_scan_free: report.p99_mixed_over_scan_free,
-    };
-    let line = serde_json::to_string(&record).map_err(std::io::Error::other)?;
-    let mut file = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)?;
-    writeln!(file, "{line}")
 }
 
 // ---------------------------------------------------------------------------

--- a/cqlite-core/examples/heap_profile.rs
+++ b/cqlite-core/examples/heap_profile.rs
@@ -56,7 +56,11 @@ fn main() {
 fn main() {
     use std::path::PathBuf;
 
-    /// Memory budget from CLAUDE.md: <128 MiB for large files.
+    /// Memory budget from CLAUDE.md: <128 MiB for large files. Only referenced in
+    /// the `dhat-heap` summary block below, so gate it to that feature — otherwise a
+    /// non-`dhat-heap` build of this example (e.g. `--features cli-helpers` or
+    /// `work-counters`) trips `dead_code` under `-D warnings`.
+    #[cfg(feature = "dhat-heap")]
     const HEAP_BUDGET_BYTES: u64 = 128 * 1024 * 1024;
 
     let out_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../target/profiling");

--- a/cqlite-core/src/storage/sstable/compression.rs
+++ b/cqlite-core/src/storage/sstable/compression.rs
@@ -241,6 +241,10 @@ impl Compression {
 
     /// Decompress data using traditional method (for small blocks)
     pub fn decompress(&self, data: &[u8]) -> Result<Vec<u8>> {
+        // A5 read-work counter (DECOMPRESS_CALLS; consumers B1/E3): one per chunk
+        // decompress. This is the single choke point every compressed-chunk read
+        // path funnels through. No-op in release (design.md Decision 1/2).
+        crate::storage::sstable::read_work_counters::record_decompress();
         match self.algorithm {
             CompressionAlgorithm::None => Ok(data.to_vec()),
             CompressionAlgorithm::Lz4 => {

--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -17,6 +17,7 @@ pub mod index_reader;
 pub mod key_digest;
 pub mod performance_benchmarks;
 pub mod promoted_index_reader;
+pub mod read_work_counters;
 pub mod reader;
 pub mod summary_reader;
 pub mod version_gate;

--- a/cqlite-core/src/storage/sstable/read_work_counters.rs
+++ b/cqlite-core/src/storage/sstable/read_work_counters.rs
@@ -1,0 +1,325 @@
+//! Cfg-gated read-work counters for the read-path optimization program
+//! (Issue #1566, Epic A / A5).
+//!
+//! # Why this exists
+//!
+//! The July 2026 read-path audit (`docs/reports/read-path-performance-audit-2026-07-01.md`
+//! §Epic A) is measurement-first: land the gauges before the optimizations so every
+//! later claim (epics B–G) is pinned. Correct result rows never prove *how much
+//! work* a read did — a regression can return the right answer while decompressing
+//! the whole file, walking the trie twice, or reopening `Data.db` per lookup. These
+//! counters make that work observable so a later epic can assert on it the
+//! no-heuristics way: observe the *work*, not just the result.
+//!
+//! # Why cfg-gated (unlike [`work_counters`](super::work_counters))
+//!
+//! The existing [`work_counters`](super::work_counters) sit on *cold per-lookup
+//! boundaries* (once per candidate SSTable / once per returned partition) and are
+//! therefore always-on. A5's counters sit on *per-chunk / per-seek / per-open*
+//! paths that are much hotter, and the issue's DoD demands "zero overhead in
+//! release builds". So the pattern here (design.md Decision 1) is:
+//!
+//! - The `record_*()` functions are **unconditional public functions** — the read
+//!   path calls e.g. [`record_decompress`] with no `#[cfg]` at the call site, so
+//!   production code reads identically in every build.
+//! - Their **body** is `#[cfg(any(test, feature = "work-counters"))]`. In a
+//!   default/release build (no `work-counters`, no `cfg(test)`) the body is empty
+//!   and the `#[inline(always)]` no-op is optimized away → **zero overhead**. No
+//!   atomic is even linked (the static and its module are compiled only under the
+//!   same cfg), so the release read path pays literally nothing.
+//! - The **getters + [`reset`]** are `#[cfg(any(test, feature = "work-counters"))]`:
+//!   only test/feature builds read the values. In-crate unit tests get them via the
+//!   `test` cfg; integration tests in `tests/` and benches enable the
+//!   `work-counters` feature (they compile the lib WITHOUT its `test` cfg — the same
+//!   reason the `SCAN_FOR_KEY_CALLS` probe exists).
+//!
+//! A local-[`Counters`]-instance unit test (per issue #1071) gives deterministic
+//! absolute-value assertions immune to parallel tests mutating the process-global.
+//!
+//! # Counters and their consuming epic-children
+//!
+//! Grep a counter name to find its consumer, the same discoverability
+//! [`work_counters`](super::work_counters) provides:
+//!
+//! - [`record_trie_walk`] / [`trie_walks`] — **`TRIE_WALKS`**: one per BTI trie
+//!   descent (`lookup_partition_via_bti_trie`). Consumers **C3** (single-walk point
+//!   lookup) and **C4** (hoist the trie rehash out of the loop): both must prove a
+//!   point lookup descends the trie exactly once.
+//! - [`record_decompress`] / [`decompress_calls`] — **`DECOMPRESS_CALLS`**: one per
+//!   compression-chunk decompress (`Compressor::decompress`). Consumers **B1**
+//!   (chunk cache — a cache hit must skip the decompress) and **E3** (copy-chain —
+//!   count the decompress invocations a read triggers).
+//! - [`record_seek`] / [`seek_calls`] — **`SEEK_CALLS`**: one per block-read seek in
+//!   the chunk read path (`reader/block_io.rs`). Consumer **E4** (drop redundant
+//!   seeks): a sequential chunk walk must not re-seek to the position it is already
+//!   at.
+//! - [`record_file_open`] / [`file_opens`] — **`FILE_OPENS`**: one per `open(2)` that
+//!   mints a reader `BlockSource` file descriptor (`reader/source.rs` scan opens +
+//!   the reader's cold-open sites). Consumer **C2** (pread / kill the per-lookup
+//!   open): a point lookup must not `open(2)` `Data.db` on every call.
+//! - [`fd_high_water`] — the **fd high-water helper**: samples the process's current
+//!   open-fd count (`/dev/fd` on macOS, `/proc/self/fd` on Linux, `None` elsewhere).
+//!   Consumer **C2** (fd-exhaustion guard): a test brackets an operation with this
+//!   to bound fd growth. It is a *sample*, not an atomic — wrapping every
+//!   `open`/`close` to keep a live count is invasive and racy; sampling at a test
+//!   checkpoint is what the guard actually needs.
+
+// The atomics, the process-global, the struct methods, the getters, and `reset`
+// exist ONLY in test/feature builds — a release build links none of them, which is
+// what makes the counters zero-overhead there.
+#[cfg(any(test, feature = "work-counters"))]
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// The four read-work counters as one value (test/feature builds only).
+///
+/// Production code shares a single process-global instance ([`COUNTERS`]) reached
+/// through the unconditional `record_*` free functions; the increment sites and the
+/// integration probes all operate on that instance. Bundling the atomics in a
+/// struct also lets a unit test exercise the add/get/reset contract against a
+/// *local* instance, immune to other tests concurrently mutating the global
+/// (issue #1071) — the global is shared with read-path code that any parallel test
+/// can drive.
+#[cfg(any(test, feature = "work-counters"))]
+struct Counters {
+    /// BTI trie descents (`TRIE_WALKS`) — consumers C3/C4.
+    trie_walks: AtomicU64,
+    /// Compression-chunk decompress invocations (`DECOMPRESS_CALLS`) — consumers B1/E3.
+    decompress_calls: AtomicU64,
+    /// Block-read seeks in the chunk read path (`SEEK_CALLS`) — consumer E4.
+    seek_calls: AtomicU64,
+    /// `open(2)` calls minting a reader `BlockSource` fd (`FILE_OPENS`) — consumer C2.
+    file_opens: AtomicU64,
+}
+
+#[cfg(any(test, feature = "work-counters"))]
+impl Counters {
+    const fn new() -> Self {
+        Self {
+            trie_walks: AtomicU64::new(0),
+            decompress_calls: AtomicU64::new(0),
+            seek_calls: AtomicU64::new(0),
+            file_opens: AtomicU64::new(0),
+        }
+    }
+
+    fn record_trie_walk(&self) {
+        self.trie_walks.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_decompress(&self) {
+        self.decompress_calls.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_seek(&self) {
+        self.seek_calls.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_file_open(&self) {
+        self.file_opens.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn trie_walks(&self) -> u64 {
+        self.trie_walks.load(Ordering::Relaxed)
+    }
+
+    fn decompress_calls(&self) -> u64 {
+        self.decompress_calls.load(Ordering::Relaxed)
+    }
+
+    fn seek_calls(&self) -> u64 {
+        self.seek_calls.load(Ordering::Relaxed)
+    }
+
+    fn file_opens(&self) -> u64 {
+        self.file_opens.load(Ordering::Relaxed)
+    }
+
+    fn reset(&self) {
+        self.trie_walks.store(0, Ordering::Relaxed);
+        self.decompress_calls.store(0, Ordering::Relaxed);
+        self.seek_calls.store(0, Ordering::Relaxed);
+        self.file_opens.store(0, Ordering::Relaxed);
+    }
+}
+
+/// The process-global counters every read-path increment site and integration
+/// probe shares (test/feature builds only). Unit tests that assert absolute values
+/// use a local [`Counters`] instead (issue #1071).
+#[cfg(any(test, feature = "work-counters"))]
+static COUNTERS: Counters = Counters::new();
+
+/// Record one BTI trie descent (`TRIE_WALKS`; consumers C3/C4).
+///
+/// Called unconditionally at the single trie-descent entry
+/// ([`lookup_partition_via_bti_trie`](super::reader)); the body compiles to a no-op
+/// in a release build (design.md Decision 1).
+#[inline(always)]
+pub fn record_trie_walk() {
+    #[cfg(any(test, feature = "work-counters"))]
+    COUNTERS.record_trie_walk();
+}
+
+/// Record one compression-chunk decompress (`DECOMPRESS_CALLS`; consumers B1/E3).
+///
+/// Called unconditionally at the single decompress entry
+/// ([`Compressor::decompress`](super::compression)); the body compiles to a no-op
+/// in a release build (design.md Decision 1).
+#[inline(always)]
+pub fn record_decompress() {
+    #[cfg(any(test, feature = "work-counters"))]
+    COUNTERS.record_decompress();
+}
+
+/// Record one block-read seek in the chunk read path (`SEEK_CALLS`; consumer E4).
+///
+/// Called unconditionally at the chunk-read seek (`reader/block_io.rs`); the body
+/// compiles to a no-op in a release build (design.md Decision 1).
+#[inline(always)]
+pub fn record_seek() {
+    #[cfg(any(test, feature = "work-counters"))]
+    COUNTERS.record_seek();
+}
+
+/// Record one `open(2)` that mints a reader `BlockSource` fd (`FILE_OPENS`;
+/// consumer C2).
+///
+/// Called unconditionally at each `BlockSource` fd-mint (the reader's cold-open
+/// sites and the per-scan opens in `reader/source.rs`); the body compiles to a
+/// no-op in a release build (design.md Decision 1).
+#[inline(always)]
+pub fn record_file_open() {
+    #[cfg(any(test, feature = "work-counters"))]
+    COUNTERS.record_file_open();
+}
+
+/// Number of BTI trie descents since the last [`reset`] (`TRIE_WALKS`).
+#[cfg(any(test, feature = "work-counters"))]
+pub fn trie_walks() -> u64 {
+    COUNTERS.trie_walks()
+}
+
+/// Number of compression-chunk decompress invocations since the last [`reset`]
+/// (`DECOMPRESS_CALLS`).
+#[cfg(any(test, feature = "work-counters"))]
+pub fn decompress_calls() -> u64 {
+    COUNTERS.decompress_calls()
+}
+
+/// Number of block-read seeks since the last [`reset`] (`SEEK_CALLS`).
+#[cfg(any(test, feature = "work-counters"))]
+pub fn seek_calls() -> u64 {
+    COUNTERS.seek_calls()
+}
+
+/// Number of `open(2)` reader-fd mints since the last [`reset`] (`FILE_OPENS`).
+#[cfg(any(test, feature = "work-counters"))]
+pub fn file_opens() -> u64 {
+    COUNTERS.file_opens()
+}
+
+/// Clear all four process-global counters. Integration tests call this before a
+/// measured operation so a stale value cannot satisfy a later assertion. Because
+/// the global is shared, callers serialize on the shared test mutex (per the
+/// existing counter-test convention); the in-crate unit test sidesteps this by
+/// asserting against a local [`Counters`] instance (issue #1071).
+#[cfg(any(test, feature = "work-counters"))]
+pub fn reset() {
+    COUNTERS.reset();
+}
+
+/// Sample the process's current open file-descriptor count (the fd high-water
+/// helper; consumer C2).
+///
+/// Returns `Some(count)` by counting entries in `/dev/fd` (macOS) or
+/// `/proc/self/fd` (Linux), and `None` on any other platform so a test can `skip`
+/// rather than fail. This is a point-in-time sample, not a running maximum: a test
+/// captures it before/after an operation to bound fd growth (C2's fd-exhaustion
+/// guard). Best-effort — an unreadable fd directory yields `None`.
+#[cfg(any(test, feature = "work-counters"))]
+pub fn fd_high_water() -> Option<u64> {
+    #[cfg(target_os = "macos")]
+    {
+        count_fd_dir("/dev/fd")
+    }
+    #[cfg(target_os = "linux")]
+    {
+        count_fd_dir("/proc/self/fd")
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        None
+    }
+}
+
+/// Count the directory entries under an fd directory (`/dev/fd` | `/proc/self/fd`).
+/// Returns `None` if the directory cannot be read.
+#[cfg(all(
+    any(test, feature = "work-counters"),
+    any(target_os = "macos", target_os = "linux")
+))]
+fn count_fd_dir(path: &str) -> Option<u64> {
+    std::fs::read_dir(path)
+        .ok()
+        .map(|rd| rd.filter_map(|e| e.ok()).count() as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    // Exercises the add/get/reset contract against a *local* [`Counters`] rather
+    // than the process-global reached through the free functions. The global is
+    // shared with read-path increment sites any concurrent test in this binary can
+    // drive, so absolute-value assertions on it race nondeterministically
+    // (issue #1071). A local instance is owned by this test alone, so the
+    // exact-equality checks below are deterministic. Serialized so the local test
+    // never overlaps a wiring test that mutates the global (shared-mutex convention).
+    #[test]
+    #[serial]
+    fn counters_round_trip_and_reset() {
+        let c = Counters::new();
+        c.reset();
+        assert_eq!(c.trie_walks(), 0);
+        assert_eq!(c.decompress_calls(), 0);
+        assert_eq!(c.seek_calls(), 0);
+        assert_eq!(c.file_opens(), 0);
+
+        c.record_trie_walk();
+        c.record_decompress();
+        c.record_decompress();
+        c.record_seek();
+        c.record_seek();
+        c.record_seek();
+        c.record_file_open();
+        c.record_file_open();
+        c.record_file_open();
+        c.record_file_open();
+
+        assert_eq!(c.trie_walks(), 1);
+        assert_eq!(c.decompress_calls(), 2);
+        assert_eq!(c.seek_calls(), 3);
+        assert_eq!(c.file_opens(), 4);
+
+        c.reset();
+        assert_eq!(c.trie_walks(), 0);
+        assert_eq!(c.decompress_calls(), 0);
+        assert_eq!(c.seek_calls(), 0);
+        assert_eq!(c.file_opens(), 0);
+    }
+
+    // The fd high-water helper returns a positive count on the supported platforms
+    // (the process always holds stdin/stdout/stderr) and `None` elsewhere — a
+    // skip, never a failure.
+    #[test]
+    #[serial]
+    fn fd_high_water_is_positive_or_unsupported() {
+        match fd_high_water() {
+            Some(n) => assert!(
+                n > 0,
+                "a running process holds at least stdio fds, so the sample must be > 0"
+            ),
+            None => { /* unsupported platform: skip, not fail */ }
+        }
+    }
+}

--- a/cqlite-core/src/storage/sstable/read_work_counters.rs
+++ b/cqlite-core/src/storage/sstable/read_work_counters.rs
@@ -49,10 +49,14 @@
 //!   compression-chunk decompress (`Compressor::decompress`). Consumers **B1**
 //!   (chunk cache — a cache hit must skip the decompress) and **E3** (copy-chain —
 //!   count the decompress invocations a read triggers).
-//! - [`record_seek`] / [`seek_calls`] — **`SEEK_CALLS`**: one per block-read seek in
-//!   the chunk read path (`reader/block_io.rs`). Consumer **E4** (drop redundant
-//!   seeks): a sequential chunk walk must not re-seek to the position it is already
-//!   at.
+//! - [`record_seek`] / [`seek_calls`] — **`SEEK_CALLS`**: one per production
+//!   read-path seek. Wired across every read-path seek site: the compressed
+//!   chunk-read seek in `reader/block_io.rs` and the point-lookup / single-partition
+//!   / whole-section / scan seeks in the `reader/data_access` modules
+//!   (`bti.rs` BTI target-chunk + fallback + scan, `big_promoted.rs` BIG
+//!   reverse-block target-chunk + last-partition seek-to-end). Consumer **E4** (drop
+//!   redundant seeks): a sequential chunk walk must not re-seek to the position it is
+//!   already at.
 //! - [`record_file_open`] / [`file_opens`] — **`FILE_OPENS`**: one per `open(2)` that
 //!   mints a reader `BlockSource` file descriptor (`reader/source.rs` scan opens +
 //!   the reader's cold-open sites). Consumer **C2** (pread / kill the per-lookup
@@ -170,9 +174,11 @@ pub fn record_decompress() {
     COUNTERS.record_decompress();
 }
 
-/// Record one block-read seek in the chunk read path (`SEEK_CALLS`; consumer E4).
+/// Record one production read-path seek (`SEEK_CALLS`; consumer E4).
 ///
-/// Called unconditionally at the chunk-read seek (`reader/block_io.rs`); the body
+/// Called unconditionally at every production read-path seek site
+/// (`reader/block_io.rs` chunk-read seek plus the `reader/data_access` BTI/BIG
+/// point-lookup, single-partition, whole-section, and scan seeks); the body
 /// compiles to a no-op in a release build (design.md Decision 1).
 #[inline(always)]
 pub fn record_seek() {

--- a/cqlite-core/src/storage/sstable/reader/block_io.rs
+++ b/cqlite-core/src/storage/sstable/reader/block_io.rs
@@ -412,6 +412,10 @@ async fn read_nb_format_chunk_data(
         // Seek to chunk offset (adjusted by header_offset for files with embedded headers)
         // CompressionInfo chunk offsets are relative to start of compressed data
         let absolute_offset = chunk_offset + header_offset;
+        // A5 read-work counter (SEEK_CALLS; consumer E4): one per block-read seek in
+        // the production compressed-chunk read path. No-op in release (design.md
+        // Decision 1/2).
+        crate::storage::sstable::read_work_counters::record_seek();
         file_guard
             .seek(std::io::SeekFrom::Start(absolute_offset))
             .await

--- a/cqlite-core/src/storage/sstable/reader/data_access/big_promoted.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/big_promoted.rs
@@ -498,6 +498,10 @@ impl SSTableReader {
                     })?;
                 {
                     let mut file_guard = cursor.file.lock().await;
+                    // A5 read-work counter (SEEK_CALLS; consumer E4): the BIG
+                    // promoted-index reverse-block target-chunk seek on the point-read
+                    // path. No-op in release (design.md Decision 1/2).
+                    crate::storage::sstable::read_work_counters::record_seek();
                     file_guard.seek(SeekFrom::Start(chunk_start)).await?;
                 }
                 cursor
@@ -522,6 +526,10 @@ impl SSTableReader {
                     // Last partition: extends to the end of the Data.db data section.
                     None => {
                         let mut file_guard = cursor.file.lock().await;
+                        // A5 read-work counter (SEEK_CALLS; consumer E4): last-partition
+                        // seek-to-end bounding the uncompressed reverse-block window.
+                        // No-op in release (design.md Decision 1/2).
+                        crate::storage::sstable::read_work_counters::record_seek();
                         file_guard.seek(SeekFrom::End(0)).await?
                     }
                 };

--- a/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
@@ -603,6 +603,10 @@ impl SSTableReader {
                     })?;
                 {
                     let mut file_guard = cursor.file.lock().await;
+                    // A5 read-work counter (SEEK_CALLS; consumer E4): BTI point-lookup
+                    // target-chunk seek on the production read path. No-op in release
+                    // (design.md Decision 1/2).
+                    crate::storage::sstable::read_work_counters::record_seek();
                     file_guard.seek(SeekFrom::Start(chunk_start)).await?;
                 }
                 cursor
@@ -615,6 +619,10 @@ impl SSTableReader {
                 let header_size = self.calculate_header_size();
                 {
                     let mut file_guard = cursor.file.lock().await;
+                    // A5 read-work counter (SEEK_CALLS; consumer E4): whole-section
+                    // fallback seek-to-data-start. No-op in release (design.md
+                    // Decision 1/2).
+                    crate::storage::sstable::read_work_counters::record_seek();
                     file_guard.seek(SeekFrom::Start(header_size as u64)).await?;
                 }
                 let whole = self.stitch_all_chunks(&cursor).await?;
@@ -863,6 +871,10 @@ impl SSTableReader {
                     })?;
                 {
                     let mut file_guard = cursor.file.lock().await;
+                    // A5 read-work counter (SEEK_CALLS; consumer E4): BTI
+                    // single-partition target-chunk seek on the production read path.
+                    // No-op in release (design.md Decision 1/2).
+                    crate::storage::sstable::read_work_counters::record_seek();
                     file_guard.seek(SeekFrom::Start(chunk_start)).await?;
                 }
                 cursor
@@ -875,6 +887,10 @@ impl SSTableReader {
                 let header_size = self.calculate_header_size();
                 {
                     let mut file_guard = cursor.file.lock().await;
+                    // A5 read-work counter (SEEK_CALLS; consumer E4): whole-section
+                    // fallback seek-to-data-start. No-op in release (design.md
+                    // Decision 1/2).
+                    crate::storage::sstable::read_work_counters::record_seek();
                     file_guard.seek(SeekFrom::Start(header_size as u64)).await?;
                 }
                 let whole = self.stitch_all_chunks(&cursor).await?;
@@ -1216,6 +1232,9 @@ impl SSTableReader {
         let header_size = self.calculate_header_size();
         {
             let mut file_guard = cursor.file.lock().await;
+            // A5 read-work counter (SEEK_CALLS; consumer E4): scan seek-to-data-start
+            // before stitching the section. No-op in release (design.md Decision 1/2).
+            crate::storage::sstable::read_work_counters::record_seek();
             file_guard.seek(SeekFrom::Start(header_size as u64)).await?;
         }
         let whole = self.stitch_all_chunks(&cursor).await?;

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -745,6 +745,10 @@ impl SSTableReader {
         path: &Path,
         file_size: u64,
     ) -> Result<(BlockSource, ScanSource)> {
+        // A5 read-work counter (FILE_OPENS; consumer C2): one per open(2) that mints
+        // a reader fd — here the buffered cold-open / graceful-fallback site. No-op
+        // in release (design.md Decision 1/2).
+        crate::storage::sstable::read_work_counters::record_file_open();
         Ok((
             BlockSource::buffered_sized(File::open(path).await?, file_size),
             ScanSource::Buffered {
@@ -870,6 +874,10 @@ impl SSTableReader {
     /// `io::Error`. This is why mmap is opt-in and gated on immutable local
     /// files; see [`Config`]'s `storage.use_mmap` for the full constraints.
     fn map_file(path: &Path) -> Result<memmap2::Mmap> {
+        // A5 read-work counter (FILE_OPENS; consumer C2): one per open(2) that mints
+        // a reader fd — here the mmap cold-open site. No-op in release (design.md
+        // Decision 1/2).
+        crate::storage::sstable::read_work_counters::record_file_open();
         let std_file = std::fs::File::open(path)?;
         // SAFETY: read-only mapping of a file assumed immutable for the
         // reader's lifetime; see the function-level note above.

--- a/cqlite-core/src/storage/sstable/reader/partition_lookup.rs
+++ b/cqlite-core/src/storage/sstable/reader/partition_lookup.rs
@@ -113,9 +113,15 @@ impl SSTableReader {
         let _entered = span.enter();
 
         let Some(partitions_db) = &self.bti_partitions_db else {
-            // Not a BTI reader — no trie to consult.
+            // Not a BTI reader — no trie to consult (no descent, no count).
             return Ok(None);
         };
+
+        // A5 read-work counter (TRIE_WALKS; consumers C3/C4): one per real trie
+        // descent — counted only once we have a `Partitions.db` to descend, so a
+        // non-BTI reader that returned above never bumps it. No-op in release
+        // (design.md Decision 1/2).
+        crate::storage::sstable::read_work_counters::record_trie_walk();
 
         let lookup = lookup_raw_key_in_bti_partitions_db(
             &mut std::io::Cursor::new(partitions_db.as_slice()),

--- a/cqlite-core/src/storage/sstable/reader/source.rs
+++ b/cqlite-core/src/storage/sstable/reader/source.rs
@@ -151,8 +151,16 @@ pub(crate) enum ScanSource {
 impl ScanSource {
     /// Mint a fresh, independent [`BlockSource`] for one scan.
     pub(crate) async fn open(&self, path: &Path) -> Result<BlockSource> {
+        // A5 read-work counters (FILE_OPENS; consumer C2): each arm below counts the
+        // exact number of open(2)s it performs — the Buffered arm and the Direct
+        // buffered-fallback each do one File::open, and the Direct cursor open(2) is
+        // counted inside `DirectCursor::open_direct`. The Mapped arm reuses the
+        // shared `Arc<Mmap>` (no open(2)), so it records nothing. No-op in release
+        // (design.md Decision 1/2). This is the per-scan open site C2 targets.
+        use crate::storage::sstable::read_work_counters::record_file_open;
         Ok(match self {
             ScanSource::Buffered { file_len } => {
+                record_file_open();
                 BlockSource::buffered_sized(File::open(path).await?, *file_len)
             }
             ScanSource::Mapped(mmap) => BlockSource::mapped(mmap.clone()),
@@ -169,6 +177,7 @@ impl ScanSource {
                             path.display(),
                             e
                         );
+                        record_file_open();
                         BlockSource::buffered_sized(File::open(path).await?, *file_len)
                     }
                 }
@@ -373,6 +382,12 @@ impl DirectCursor {
     /// support direct I/O, so callers can fall back to buffered reads.
     pub(crate) fn open(path: &Path, window: usize) -> io::Result<Self> {
         let file = Self::open_direct(path)?;
+        // A5 read-work counter (FILE_OPENS; consumer C2): one per SUCCESSFUL
+        // direct-I/O open(2) (used by both the reader's cold-open direct path and
+        // per-scan direct reopens). Counted after `open_direct` succeeds so a failed
+        // direct open that falls back to a buffered open (which counts its own
+        // open(2)) is not double-counted. No-op in release (design.md Decision 1/2).
+        crate::storage::sstable::read_work_counters::record_file_open();
         let len = file.metadata()?.len();
         let align = DIRECT_IO_ALIGN;
         // Round the window up to the alignment, but saturate instead of

--- a/cqlite-core/tests/bench_ledger.rs
+++ b/cqlite-core/tests/bench_ledger.rs
@@ -104,6 +104,36 @@ fn append_metrics_writes_one_json_line_per_metric() {
     );
 }
 
+/// A bare relative filename (no directory component) must not fail the append: its
+/// `path.parent()` is `Some("")`, and `create_dir_all("")` errors — so the empty
+/// parent must be skipped (Finding 2). We chdir into a tempdir so the bare filename
+/// resolves there, then restore the CWD and env regardless of outcome.
+#[test]
+#[serial]
+fn append_metrics_ok_for_bare_relative_filename_empty_parent() {
+    let dir = tempfile::TempDir::new().expect("temp dir for ledger");
+    let prev_cwd = std::env::current_dir().expect("cwd");
+    std::env::set_current_dir(dir.path()).expect("chdir into tempdir");
+
+    // Bare filename → PathBuf::parent() == Some(""), the create_dir_all("") case.
+    std::env::set_var("CQLITE_BENCH_LEDGER", "history.jsonl");
+    let result = bench_ledger::append_metrics("unit_bench", &[("p50", 100.0, "ns")]);
+    let file_exists = dir.path().join("history.jsonl").is_file();
+
+    // Restore process-global state before asserting so a failure cannot leak it.
+    std::env::remove_var("CQLITE_BENCH_LEDGER");
+    std::env::set_current_dir(&prev_cwd).expect("restore cwd");
+
+    assert!(
+        result.is_ok(),
+        "bare-filename ledger path (empty parent) must append Ok, got {result:?}"
+    );
+    assert!(
+        file_exists,
+        "append to a bare-filename ledger path must create the file in the CWD"
+    );
+}
+
 /// Best-effort contract (spec R3 "a ledger write failure does not fail the bench"):
 /// when the ledger path is unwritable, `append_metrics` returns `Err` rather than
 /// panicking, so the bench `main` can log-and-continue instead of aborting the run.

--- a/cqlite-core/tests/bench_ledger.rs
+++ b/cqlite-core/tests/bench_ledger.rs
@@ -1,0 +1,105 @@
+//! Pure unit tests for the shared `bench_ledger` module (Issue #1566, Epic A / A5):
+//! record serialization + ledger-path resolution. The module lives under `benches/`
+//! (a bench-support module included by the harness benches via `#[path]`) and is not
+//! compiled by `cargo test` on its own; including it here — the same `#[path]`
+//! pattern the benches use — compiles it into this integration crate so its surface
+//! can be tested with a real test harness (Cargo builds bench targets with
+//! `cfg(test)` set, so inline `#[cfg(test)]` tests cannot live in the module itself).
+
+#[path = "../benches/bench_ledger/mod.rs"]
+mod bench_ledger;
+
+use serial_test::serial;
+use std::path::PathBuf;
+
+/// Path resolution: the `CQLITE_BENCH_LEDGER` env override wins when set/non-empty;
+/// otherwise the default is anchored under the crate's `../target/profiling/`.
+/// Serialized because it mutates the process-global `CQLITE_BENCH_LEDGER` env var.
+#[test]
+#[serial]
+fn ledger_path_prefers_env_then_default() {
+    std::env::remove_var("CQLITE_BENCH_LEDGER");
+    let default = bench_ledger::ledger_path();
+    assert!(
+        default.ends_with("target/profiling/history.jsonl"),
+        "default must be <manifest>/../target/profiling/history.jsonl, got {default:?}"
+    );
+
+    std::env::set_var("CQLITE_BENCH_LEDGER", "/tmp/cqlite-a5-ledger-test.jsonl");
+    assert_eq!(
+        bench_ledger::ledger_path(),
+        PathBuf::from("/tmp/cqlite-a5-ledger-test.jsonl")
+    );
+
+    // Empty/whitespace env falls back to the default.
+    std::env::set_var("CQLITE_BENCH_LEDGER", "   ");
+    assert_eq!(bench_ledger::ledger_path(), default);
+    std::env::remove_var("CQLITE_BENCH_LEDGER");
+}
+
+/// Record serialization + append: each metric becomes exactly one standalone JSON
+/// line with the six unified-schema fields, a batch shares one ts/commit, and a
+/// second call appends (never truncates).
+#[test]
+#[serial]
+fn append_metrics_writes_one_json_line_per_metric() {
+    let dir = tempfile::TempDir::new().expect("temp dir for ledger");
+    let path = dir.path().join("history.jsonl");
+
+    std::env::set_var("CQLITE_BENCH_LEDGER", &path);
+    std::env::set_var("GIT_COMMIT", "deadbeefcafef00d");
+    bench_ledger::append_metrics(
+        "unit_bench",
+        &[
+            ("p50", 100.0, "ns"),
+            ("p99", 400.0, "ns"),
+            ("ratio", 4.0, "ratio"),
+        ],
+    )
+    .expect("append batch 1");
+    // A second call appends (never truncates).
+    bench_ledger::append_metrics("unit_bench", &[("p50", 110.0, "ns")]).expect("append batch 2");
+    std::env::remove_var("GIT_COMMIT");
+    std::env::remove_var("CQLITE_BENCH_LEDGER");
+
+    let contents = std::fs::read_to_string(&path).expect("read ledger");
+    let lines: Vec<&str> = contents.lines().filter(|l| !l.trim().is_empty()).collect();
+    assert_eq!(lines.len(), 4, "3 + 1 metric records, got: {contents}");
+
+    for line in &lines {
+        let v: serde_json::Value = serde_json::from_str(line).expect("valid JSON");
+        assert!(v.get("ts").and_then(|t| t.as_u64()).is_some(), "ts: {line}");
+        assert_eq!(v.get("bench").and_then(|b| b.as_str()), Some("unit_bench"));
+        assert_eq!(
+            v.get("commit").and_then(|c| c.as_str()),
+            Some("deadbeefcafef00d"),
+            "commit: {line}"
+        );
+        assert!(
+            v.get("metric").and_then(|m| m.as_str()).is_some(),
+            "metric: {line}"
+        );
+        assert!(
+            v.get("value").and_then(|x| x.as_f64()).is_some(),
+            "value: {line}"
+        );
+        assert!(
+            v.get("unit").and_then(|u| u.as_str()).is_some(),
+            "unit: {line}"
+        );
+    }
+
+    // The first three records (one append_metrics call) share a single ts.
+    let b1: Vec<u64> = lines[..3]
+        .iter()
+        .map(|l| {
+            serde_json::from_str::<serde_json::Value>(l).unwrap()["ts"]
+                .as_u64()
+                .unwrap()
+        })
+        .collect();
+    assert!(
+        b1.windows(2).all(|w| w[0] == w[1]),
+        "one append_metrics call must stamp a single ts across its batch"
+    );
+}

--- a/cqlite-core/tests/bench_ledger.rs
+++ b/cqlite-core/tests/bench_ledger.rs
@@ -103,3 +103,29 @@ fn append_metrics_writes_one_json_line_per_metric() {
         "one append_metrics call must stamp a single ts across its batch"
     );
 }
+
+/// Best-effort contract (spec R3 "a ledger write failure does not fail the bench"):
+/// when the ledger path is unwritable, `append_metrics` returns `Err` rather than
+/// panicking, so the bench `main` can log-and-continue instead of aborting the run.
+/// The path is made unwritable by rooting it under a regular FILE, so both
+/// `create_dir_all` of the parent and the open fail deterministically and portably
+/// (no reliance on filesystem permissions).
+#[test]
+#[serial]
+fn append_metrics_returns_err_on_unwritable_path_without_panicking() {
+    let dir = tempfile::TempDir::new().expect("temp dir for ledger");
+    // A regular file; using it as a *directory* component below is always invalid.
+    let blocker = dir.path().join("not-a-dir");
+    std::fs::write(&blocker, b"x").expect("create blocker file");
+    // Parent (`.../not-a-dir`) is a file → create_dir_all + open both fail.
+    let unwritable = blocker.join("history.jsonl");
+
+    std::env::set_var("CQLITE_BENCH_LEDGER", &unwritable);
+    let result = bench_ledger::append_metrics("unit_bench", &[("p50", 100.0, "ns")]);
+    std::env::remove_var("CQLITE_BENCH_LEDGER");
+
+    assert!(
+        result.is_err(),
+        "append to an unwritable ledger path must return Err (best-effort), not Ok or panic"
+    );
+}

--- a/cqlite-core/tests/issue_1566_read_work_counters.rs
+++ b/cqlite-core/tests/issue_1566_read_work_counters.rs
@@ -1,0 +1,277 @@
+//! Issue #1566 (Epic A / A5): wiring-evidence for the cfg-gated read-work
+//! counters. Proves each counter increments on the REAL public read path — not
+//! only through the in-crate local-instance round-trip — by driving a cold open
+//! and a point read through the public `Database` API with the counters reset.
+//!
+//! Compiled only with `--features work-counters` (the getters/`reset` and the
+//! counter bodies live behind that feature; see `read_work_counters`). Requires
+//! `CQLITE_DATASETS_ROOT` + fetched binaries; skips (never fails) when the fixture
+//! is absent. Excluded under `tombstones` (that build serves point reads by a
+//! full-scan filter rather than the targeted seek this evidences).
+//!
+//! The counters are a shared process-global, so every test here serializes on the
+//! `serial_test` mutex (the existing counter-test convention) — a stale value from
+//! a parallel test can never satisfy an assertion after a `reset`.
+
+#![cfg(all(
+    feature = "state_machine",
+    feature = "cli-helpers",
+    feature = "work-counters",
+    not(feature = "tombstones")
+))]
+
+use std::path::{Path, PathBuf};
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::storage::sstable::read_work_counters as rwc;
+use cqlite_core::{Database, Value};
+use serial_test::serial;
+
+fn datasets_root() -> Option<PathBuf> {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+}
+
+fn schemas_dir() -> Option<PathBuf> {
+    if let Some(root) = datasets_root() {
+        if let Some(dir) = root.parent().and_then(|p| {
+            let d = p.join("schemas");
+            d.exists().then_some(d)
+        }) {
+            return Some(dir);
+        }
+    }
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let dir = manifest_dir.parent()?.join("test-data").join("schemas");
+    dir.exists().then_some(dir)
+}
+
+/// True if `<datasets>/sstables/<keyspace>/<table>-*/` holds a `*-Data.db` file.
+/// Skip keys off fixture presence (not a 0-row result), so a present fixture that
+/// yields 0 rows stays a hard failure.
+fn fixture_data_present(keyspace: &str, table: &str) -> bool {
+    let Some(root) = datasets_root() else {
+        return false;
+    };
+    let Ok(entries) = std::fs::read_dir(root.join("sstables").join(keyspace)) else {
+        return false;
+    };
+    let prefix = format!("{table}-");
+    for e in entries.flatten() {
+        if !e.file_name().to_string_lossy().starts_with(&prefix) {
+            continue;
+        }
+        if let Ok(files) = std::fs::read_dir(e.path()) {
+            for f in files.flatten() {
+                if f.file_name().to_string_lossy().ends_with("-Data.db") {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Ingest a single fixture table and return a fresh `Database` (its reader pool is
+/// empty — no `Data.db` `BlockSource` is open yet, so the first query is a genuine
+/// cold open). Returns `None` when the fixture / schema is absent.
+async fn setup(keyspace: &str, schema_file: &str) -> Option<Database> {
+    let root = datasets_root()?;
+    let schema_path = schemas_dir()?.join(schema_file);
+    if !schema_path.exists() {
+        return None;
+    }
+    let data_dir = root.join("sstables");
+    if !data_dir.exists() {
+        return None;
+    }
+    let config = IngestionConfig {
+        schema_paths: vec![schema_path],
+        data_dir,
+        version_hint: Some("5.0".to_string()),
+        core_config: cqlite_core::Config::default(),
+        table_directory_filter: Some(format!("/{keyspace}/")),
+    };
+    let result = ingest(config).await.ok()?;
+    if result.schema_load_result.schemas_loaded == 0 {
+        return None;
+    }
+    Some(result.database)
+}
+
+/// Format a 16-byte UUID as the canonical unquoted 8-4-4-4-12 literal the SELECT
+/// parser accepts (issue #956).
+fn uuid_to_literal(bytes: &[u8; 16]) -> String {
+    let h = |range: std::ops::Range<usize>| -> String {
+        bytes[range].iter().map(|b| format!("{b:02x}")).collect()
+    };
+    format!(
+        "{}-{}-{}-{}-{}",
+        h(0..4),
+        h(4..6),
+        h(6..8),
+        h(8..10),
+        h(10..16)
+    )
+}
+
+/// Scan for one present `id` UUID and build the projected point-read SQL for it.
+async fn learn_point_sql(db: &Database, table: &str) -> Option<String> {
+    let scan = db.execute(&format!("SELECT id FROM {table}")).await.ok()?;
+    let first = scan.rows.first()?;
+    let id = match first.values.get("id") {
+        Some(Value::Uuid(b)) => *b,
+        _ => return None,
+    };
+    // Projected (>8 tokens) so it routes through the modern SelectExecutor and the
+    // #949/#956 partition-targeted fast path (see benches/tail_latency).
+    Some(format!(
+        "SELECT id, name FROM {table} WHERE id = {}",
+        uuid_to_literal(&id)
+    ))
+}
+
+/// Scenario: a cold open increments the file-open counter, and the read that
+/// forces it decompresses at least one chunk. The reset happens BEFORE ingest, so
+/// the ENTIRE cold path (the reader pool is empty; ingest/discovery and the first
+/// query mint the `Data.db` `BlockSource` fd) is measured — readers are pooled, so
+/// once opened a later query reuses the handle and would not re-`open(2)`.
+#[tokio::test]
+#[serial]
+async fn cold_open_increments_file_opens_and_decompress() {
+    if !fixture_data_present("test_basic", "simple_table") {
+        eprintln!("Skipping (A5 wiring): test_basic/simple_table Data.db not present");
+        return;
+    }
+
+    // Counters read zero immediately after reset (reset scenario, cold state) —
+    // asserted before any open happens.
+    rwc::reset();
+    assert_eq!(rwc::file_opens(), 0, "reset must zero FILE_OPENS");
+    assert_eq!(
+        rwc::decompress_calls(),
+        0,
+        "reset must zero DECOMPRESS_CALLS"
+    );
+
+    // Cold path: ingest opens the reader pool, and the first query reads it.
+    let Some(db) = setup("test_basic", "basic-types.cql").await else {
+        eprintln!("Skipping (A5 wiring): could not ingest test_basic");
+        return;
+    };
+    let scan = db
+        .execute("SELECT id FROM test_basic.simple_table")
+        .await
+        .expect("cold scan of test_basic.simple_table");
+    assert!(
+        !scan.rows.is_empty(),
+        "present fixture must return rows (0 rows = read regression, not a skip)"
+    );
+
+    assert!(
+        rwc::file_opens() >= 1,
+        "A5: a cold open must record at least one open(2) at the BlockSource open \
+         sites; got {}",
+        rwc::file_opens()
+    );
+    assert!(
+        rwc::decompress_calls() >= 1,
+        "A5: reading a compressed SSTable must record at least one chunk decompress; \
+         got {}",
+        rwc::decompress_calls()
+    );
+}
+
+/// Scenario: a known single-chunk point read increments the decompress counter.
+/// The reader is opened first (learning a present key), then counters are reset so
+/// only the point read's work is measured.
+#[tokio::test]
+#[serial]
+async fn point_read_increments_decompress() {
+    if !fixture_data_present("test_basic", "simple_table") {
+        eprintln!("Skipping (A5 wiring): test_basic/simple_table Data.db not present");
+        return;
+    }
+    let Some(db) = setup("test_basic", "basic-types.cql").await else {
+        eprintln!("Skipping (A5 wiring): could not ingest test_basic");
+        return;
+    };
+    let Some(point_sql) = learn_point_sql(&db, "test_basic.simple_table").await else {
+        panic!("A5: could not learn a present UUID key from test_basic.simple_table");
+    };
+
+    // Reader is now open (from the learning scan); reset so we measure only the
+    // point read's decompression work.
+    rwc::reset();
+    assert_eq!(
+        rwc::decompress_calls(),
+        0,
+        "reset must zero DECOMPRESS_CALLS"
+    );
+
+    let res = db.execute(&point_sql).await.expect("point read");
+    assert!(
+        !res.rows.is_empty(),
+        "A5: point read on a known-present key returned zero rows — #949/#956 regressed?"
+    );
+    assert!(
+        rwc::decompress_calls() >= 1,
+        "A5: a point read that decodes one compression chunk must record >= 1 \
+         decompress; got {}",
+        rwc::decompress_calls()
+    );
+}
+
+/// Scenario: a BTI point read increments the trie-walk counter. Uses the optional
+/// `test_da` BTI corpus; skips (never fails) when it is absent.
+#[tokio::test]
+#[serial]
+async fn bti_point_read_increments_trie_walks() {
+    if !fixture_data_present("test_da", "simple_table") {
+        eprintln!("Skipping (A5 wiring): optional BTI test_da/simple_table not present");
+        return;
+    }
+    let Some(db) = setup("test_da", "da-test.cql").await else {
+        eprintln!("Skipping (A5 wiring): could not ingest test_da");
+        return;
+    };
+    let Some(point_sql) = learn_point_sql(&db, "test_da.simple_table").await else {
+        panic!("A5: could not learn a present UUID key from test_da.simple_table");
+    };
+
+    rwc::reset();
+    assert_eq!(rwc::trie_walks(), 0, "reset must zero TRIE_WALKS");
+
+    let res = db.execute(&point_sql).await.expect("BTI point read");
+    assert!(
+        !res.rows.is_empty(),
+        "A5: BTI point read on a known-present key returned zero rows"
+    );
+    assert!(
+        rwc::trie_walks() >= 1,
+        "A5: a BTI point read must descend the Partitions.db trie at least once; \
+         got {}",
+        rwc::trie_walks()
+    );
+}
+
+/// Scenario: counters reset between operations — each reads zero immediately after
+/// `reset` and reflects only the subsequent work. A pure-API check that does not
+/// require a fixture.
+#[tokio::test]
+#[serial]
+async fn reset_zeroes_all_counters() {
+    // Drive some work if the fixture is present, else just prove reset zeroes.
+    if let Some(db) = setup("test_basic", "basic-types.cql").await {
+        if fixture_data_present("test_basic", "simple_table") {
+            let _ = db.execute("SELECT id FROM test_basic.simple_table").await;
+        }
+    }
+    rwc::reset();
+    assert_eq!(rwc::trie_walks(), 0);
+    assert_eq!(rwc::decompress_calls(), 0);
+    assert_eq!(rwc::seek_calls(), 0);
+    assert_eq!(rwc::file_opens(), 0);
+}

--- a/cqlite-core/tests/issue_1566_read_work_counters.rs
+++ b/cqlite-core/tests/issue_1566_read_work_counters.rs
@@ -257,6 +257,62 @@ async fn bti_point_read_increments_trie_walks() {
     );
 }
 
+/// Scenario: a real read-path operation increments the seek counter. `SEEK_CALLS`
+/// is wired across every production read-path seek site (the `block_io` compressed
+/// chunk-read seek plus the `data_access` BTI/BIG point-lookup + scan seeks), so a
+/// real scan and a real point read through the public `Database` API on the BIG
+/// multi-chunk fixture must each bump it (consumer E4). This is the wiring evidence
+/// the finding requires: without instrumenting the `data_access` seeks the counter
+/// could stay 0 while real seeks happen, making the E4 guard unreliable.
+#[tokio::test]
+#[serial]
+async fn read_path_increments_seek_calls() {
+    if !fixture_data_present("test_basic", "simple_table") {
+        eprintln!("Skipping (A5 wiring): test_basic/simple_table Data.db not present");
+        return;
+    }
+    let Some(db) = setup("test_basic", "basic-types.cql").await else {
+        eprintln!("Skipping (A5 wiring): could not ingest test_basic");
+        return;
+    };
+
+    // Reset, then a full scan (which reads the compressed chunks through the
+    // production seek sites) must record at least one seek.
+    rwc::reset();
+    assert_eq!(rwc::seek_calls(), 0, "reset must zero SEEK_CALLS");
+    let scan = db
+        .execute("SELECT id FROM test_basic.simple_table")
+        .await
+        .expect("scan of test_basic.simple_table");
+    assert!(
+        !scan.rows.is_empty(),
+        "present fixture must return rows (0 rows = read regression, not a skip)"
+    );
+    assert!(
+        rwc::seek_calls() >= 1,
+        "A5: a real scan must record at least one production read-path seek; got {}",
+        rwc::seek_calls()
+    );
+
+    // A targeted point read also traverses a production seek site.
+    let Some(point_sql) = learn_point_sql(&db, "test_basic.simple_table").await else {
+        panic!("A5: could not learn a present UUID key from test_basic.simple_table");
+    };
+    rwc::reset();
+    assert_eq!(rwc::seek_calls(), 0, "reset must zero SEEK_CALLS");
+    let res = db.execute(&point_sql).await.expect("point read");
+    assert!(
+        !res.rows.is_empty(),
+        "A5: point read on a known-present key returned zero rows — #949/#956 regressed?"
+    );
+    assert!(
+        rwc::seek_calls() >= 1,
+        "A5: a real point read must record at least one production read-path seek; \
+         got {}",
+        rwc::seek_calls()
+    );
+}
+
 /// Scenario: counters reset between operations — each reads zero immediately after
 /// `reset` and reflects only the subsequent work. A pure-API check that does not
 /// require a fixture.

--- a/cqlite-core/tests/tail_latency_harness.rs
+++ b/cqlite-core/tests/tail_latency_harness.rs
@@ -86,10 +86,12 @@ fn report_ratios_and_json_shape() {
 }
 
 #[test]
-fn append_ledger_writes_one_json_line_with_required_keys() {
-    // Exercises the persisted-ledger surface (spec R4) without a dataset: build a
-    // report, append it twice to a temp ledger, and assert each append is exactly
-    // one JSON-lines record carrying ts + commit + both stat blocks + ratios.
+fn ledger_metrics_flatten_to_unified_per_metric_rows() {
+    // After the A5 migration (Issue #1566) the harness no longer owns a bespoke
+    // ledger; it exposes `ledger_metrics()`, and the shared `bench_ledger` module
+    // (unit-tested separately) does the append. Assert the flattening surface: one
+    // row per percentile (`ns`) and per derived ratio (`ratio`), covering every
+    // stat and both ratios, so a future edit to the metric set is caught here.
     let report = harness::HarnessReport::new(
         harness::TailStats {
             p50: 100,
@@ -103,50 +105,40 @@ fn append_ledger_writes_one_json_line_with_required_keys() {
         },
     );
 
-    let dir = tempfile::TempDir::new().expect("temp dir for ledger");
-    let path = dir.path().join("tail-latency-history.jsonl");
+    let rows = report.ledger_metrics();
+    assert_eq!(rows.len(), 8, "6 percentiles + 2 ratios");
 
-    // GIT_COMMIT override keeps the record deterministic (no reliance on a repo).
-    std::env::set_var("GIT_COMMIT", "deadbeefcafef00d");
-    harness::append_ledger(&path, &report).expect("append ledger record 1");
-    harness::append_ledger(&path, &report).expect("append ledger record 2");
-    std::env::remove_var("GIT_COMMIT");
-
-    let contents = std::fs::read_to_string(&path).expect("read ledger");
-    let lines: Vec<&str> = contents.lines().filter(|l| !l.trim().is_empty()).collect();
-    assert_eq!(
-        lines.len(),
-        2,
-        "expected 2 JSON-lines records, got: {contents}"
-    );
-
-    // Each line is a standalone JSON object with the required keys.
-    for line in &lines {
-        let v: serde_json::Value = serde_json::from_str(line).expect("record is valid JSON");
-        assert!(v.get("ts").and_then(|t| t.as_u64()).is_some(), "ts: {line}");
-        assert_eq!(
-            v.get("commit").and_then(|c| c.as_str()),
-            Some("deadbeefcafef00d"),
-            "commit: {line}"
-        );
-        for key in ["mixed", "scan_free"] {
-            let block = v
-                .get(key)
-                .unwrap_or_else(|| panic!("missing {key}: {line}"));
-            for stat in ["p50", "p99", "p999"] {
-                assert!(
-                    block.get(stat).and_then(|s| s.as_u64()).is_some(),
-                    "{key}.{stat}: {line}"
-                );
-            }
-        }
-        for ratio in ["p99_over_p50", "p99_mixed_over_scan_free"] {
-            assert!(
-                v.get(ratio).and_then(|r| r.as_f64()).is_some(),
-                "{ratio}: {line}"
-            );
-        }
+    // Percentile rows carry `ns`; the two ratio rows carry `ratio`.
+    let ns_rows: Vec<&str> = rows
+        .iter()
+        .filter(|(_, _, unit)| *unit == "ns")
+        .map(|(m, _, _)| *m)
+        .collect();
+    assert_eq!(ns_rows.len(), 6, "6 percentile rows in ns: {ns_rows:?}");
+    for expected in [
+        "mixed_p50",
+        "mixed_p99",
+        "mixed_p999",
+        "scan_free_p50",
+        "scan_free_p99",
+        "scan_free_p999",
+    ] {
+        assert!(ns_rows.contains(&expected), "missing ns metric {expected}");
     }
+
+    // Ratio values match the derived report ratios.
+    let get = |name: &str| {
+        rows.iter()
+            .find(|(m, _, _)| *m == name)
+            .map(|(_, v, u)| (*v, *u))
+    };
+    assert_eq!(get("p99_over_p50"), Some((report.p99_over_p50, "ratio")));
+    assert_eq!(
+        get("p99_mixed_over_scan_free"),
+        Some((report.p99_mixed_over_scan_free, "ratio"))
+    );
+    // mixed_p99 value round-trips as f64 ns.
+    assert_eq!(get("mixed_p99"), Some((400.0, "ns")));
 }
 
 // ---------------------------------------------------------------------------

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -183,12 +183,42 @@ so each round starts from the previous round's output instead of folklore.
 | `target/profiling/dhat-heap.json` | full allocation profile (open in the [dhat viewer](https://nnethercote.github.io/dh_view/dh_view.html)) |
 | `target/profiling/heap-summary.json` | peak heap + budget verdict, machine-readable |
 | `target/profiling/report.json` | ranked bench table with deltas — input for the *next* iteration (or an agent driving it) |
-| `target/profiling/report.md` | the same, human-readable |
-| `target/profiling/history.jsonl` | append-only ledger: one line per iteration with git rev, medians, peak heap |
+| `target/profiling/report.md` | the same, human-readable, plus a longitudinal per-metric History table |
+| `target/profiling/history.jsonl` | the **unified** append-only ledger — one JSON object **per metric** per run (see below) |
+
+#### The unified history ledger (Issue #1566, Epic A / A5)
+
+`target/profiling/history.jsonl` is the single perf ledger for the whole repo.
+Every record is one JSON object on its own line with the schema:
+
+```json
+{"ts": 1783103681, "commit": "<full-sha|unknown>", "bench": "read/full_scan", "metric": "median_ns", "value": 5000, "unit": "ns"}
+```
+
+One record **per metric**, so a single run emits many lines:
+
+- `scripts/profile_report.py` writes one `median_ns` (`ns`) record per criterion
+  bench and one `peak_heap_bytes` (`bytes`) record when dhat heap data exists;
+- the A-series harness benches append to the **same file and schema** through the
+  shared Rust module `cqlite-core/benches/bench_ledger` — the `tail_latency` bench
+  writes `mixed_p99` (`ns`), `p99_over_p50` (`ratio`), … and the `open` bench writes
+  `cold_big_median_ns` (`ns`), `rss_per_reader_bytes` (`bytes`), … — metrics
+  criterion's median-only model cannot express.
+
+`./scripts/profile.sh report` reads the whole ledger back and renders the **History
+(latest value + delta vs previous distinct commit)** table into `report.md`; the
+delta is computed against the most recent record from a *different* commit, so
+re-running the same commit never shows a spurious 0%.
+
+The ledger is **generated run data** (machine/run-specific): it lives under
+`target/` (already gitignored) and is **never committed** — a per-machine churning
+ledger would be noise and a merge-race magnet. CI may upload it as an artifact. Its
+path is overridable for benches via the `CQLITE_BENCH_LEDGER` env var (else
+`<crate>/../target/profiling/history.jsonl`).
 
 `history.jsonl` is what makes the loop *recursive* rather than one-shot: it
 survives baseline overwrites, so you can always answer "did the last five
-changes actually compound?" with `git rev` precision.
+changes actually compound?" with `commit` precision.
 
 ### Exit criteria for a round of optimization
 

--- a/openspec/changes/cold-open-ledger/design.md
+++ b/openspec/changes/cold-open-ledger/design.md
@@ -1,0 +1,118 @@
+# Design: cold-open-ledger (A5)
+
+## Context
+
+Measurement infrastructure only. A1–A4 established the conventions this change
+reuses (do not duplicate their benches): fixture-present skip / present-but-broken
+panic; ratios/counters over wall-clock absolutes; `cli-helpers` gates read benches;
+`perf-gate.json` is intra-run. A5 adds the three remaining gauges.
+
+## Decision 1 — Counter gating: unconditional call, cfg-gated body
+
+The existing `work_counters` sit on *cold per-lookup boundaries* and are therefore
+always-on. A5's counters (`DECOMPRESS_CALLS`, `SEEK_CALLS`) sit on *per-chunk /
+per-seek* paths that are much hotter, and the issue's DoD demands "zero overhead in
+release builds (cfg-gated)". Pattern:
+
+```rust
+#[inline(always)]
+pub fn record_decompress() {
+    #[cfg(any(test, feature = "work-counters"))]
+    DECOMPRESS_CALLS.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+}
+```
+
+- **Call sites are unconditional** (`read_work_counters::record_decompress();`) —
+  no `#[cfg]` scattered through production code, so the read path reads identically
+  in every build. In release (no `work-counters`, no `test`) the body is empty and
+  the `#[inline(always)]` no-op is optimized away → **zero overhead**, satisfying
+  the guardrail without touching behavior.
+- **Getters + `reset()` are cfg-gated** (`#[cfg(any(test, feature = "work-counters"))]`)
+  — only test/feature builds read the values. In-crate unit tests get them via the
+  `test` cfg; integration tests in `tests/` and benches enable the `work-counters`
+  feature (they compile the lib without its `test` cfg, same reason
+  `SCAN_FOR_KEY_CALLS` exists — see its doc). A local-`Counters`-instance unit test
+  (per issue #1071) gives deterministic absolute-value assertions immune to
+  parallel tests mutating the process-global.
+
+New Cargo feature `work-counters` (off by default, not in any default set):
+enables the getters/`reset` and the counter bodies for benches/integration tests.
+
+## Decision 2 — Counter choke points (minimal, unambiguous, documented)
+
+Instrument the single well-defined choke point for each counter rather than every
+scattered `.seek`/`open` (which would be fragile and risk behavioral edits):
+
+| Counter | Choke point (increment site) | Consumer epic-child |
+|---------|------------------------------|---------------------|
+| `TRIE_WALKS` | BTI trie descent entry (`data_access/bti.rs` walk fn) — one per descent | C3 (single-walk), C4 (hoist rehash) |
+| `DECOMPRESS_CALLS` | `Compressor::decompress` entry (`compression.rs`) — one per chunk decompress | B1 (chunk cache), E3 (copy-chain) |
+| `SEEK_CALLS` | the block-read seek in the chunk read path (`reader/block_io.rs`) | E4 (drop redundant seeks) |
+| `FILE_OPENS` | `BlockSource` file-open site(s) (`reader/source.rs`) — one per `open(2)` | C2 (pread / kill per-lookup open) |
+| fd high-water helper | `read_work_counters::fd_high_water()` — reads `/dev/fd` (macOS) or `/proc/self/fd` (Linux), returns count | C2 (fd-exhaustion guard) |
+
+The fd high-water mark is a **helper**, not an atomic: it samples the process's
+open-fd count at call time (platform-gated; returns `None` on unsupported OS so a
+test can `skip`). Tests capture it before/after to bound fd growth.
+
+Each counter's module doc names its consumer (above), so a future epic finds its
+gauge by grepping the counter name — the same discoverability the existing
+`work_counters` doc provides.
+
+## Decision 3 — One ledger schema, one file, one writer module
+
+**Schema:** one JSON object per line —
+`{"ts": <unix_secs>, "commit": "<sha|unknown>", "bench": "<id>", "metric": "<name>", "value": <number>, "unit": "<str>"}`.
+One record **per metric** (issue step 3), so a run of the tail harness emits e.g.
+`tail_latency`/`mixed_p99`, `tail_latency`/`p99_over_p50`, … as separate lines, and
+a `read` criterion group emits `read/get_partition_big`/`median_ns`, etc.
+
+**Path:** `target/profiling/history.jsonl` (the path `profile_report.py` +
+`docs/profiling.md` already document), resolvable from a Rust bench via env
+`CQLITE_BENCH_LEDGER` else `<CARGO_MANIFEST_DIR>/../target/profiling/history.jsonl`.
+Gitignored (machine-specific run data); the old
+`benches/tail-latency-history.jsonl` ignore line is removed with its producer.
+CI may upload it as an artifact (documented) — we do not commit it (a committed,
+per-machine, churning ledger would be noise and a merge-race magnet).
+
+**Single writer module** `benches/bench_ledger/mod.rs` (Rust, shared via `#[path]`
+by each harness bench, like `tail_latency/mod.rs` today):
+`append_metrics(bench: &str, metrics: &[(&str, f64, &str)]) -> io::Result<()>`
+resolves the path, stamps `ts` + `commit` (`GIT_COMMIT` env override else
+`git rev-parse HEAD` else `"unknown"`, reusing A2's `current_commit`), and appends
+one line per metric. Append is best-effort: a failure logs to stderr and never
+aborts the bench (a ledger write must not fail a measurement run).
+
+`profile_report.py` writes the **same** schema for its criterion medians + peak
+heap (replacing its old bespoke `{ts,rev,benches{},peak_heap}` summary line), and
+`./scripts/profile.sh report` reads the whole ledger back into a longitudinal
+per-metric table (latest value + delta vs the previous distinct commit). A
+round-trip test proves write→read.
+
+### Alternatives considered
+- *Keep two ledgers, teach `report` to read both.* Rejected: two schemas is exactly
+  the fragmentation A5 is chartered to remove.
+- *Commit the ledger.* Rejected: per-machine timing data churns every run and would
+  collide on `main` (the delivery-telemetry merge-race lesson); artifact/gitignore
+  is the honest choice for generated run data.
+- *Atomic fd counter instead of a sampling helper.* Rejected: wrapping every
+  `open`/`close` to keep a live fd count is invasive and racy; sampling
+  `/dev/fd`|`/proc/self/fd` at test checkpoints is what C2's guard actually needs.
+
+## Risks / Trade-offs
+
+- **Bench compile cost / feature matrix.** The `work-counters` feature adds one
+  build config; the agent gate already builds several. Mitigated by keeping the
+  feature tiny (getters+reset only) and off by default.
+- **fd helper portability.** `/dev/fd` (macOS) and `/proc/self/fd` (Linux) only;
+  returns `None` elsewhere so the test skips rather than fails — no false red on an
+  unsupported CI OS.
+- **Ledger path under `target/`.** Wiped by `cargo clean`; acceptable — it is a
+  run ledger, not a source artifact, and CI captures it as an artifact when needed.
+
+## Migration
+
+`tail_latency/mod.rs` drops its private `LedgerRecord`/`append_ledger`/
+`default_ledger_path` and calls `bench_ledger::append_metrics("tail_latency", …)`;
+the `tail_latency_harness` integration test is unaffected (it does not assert on the
+ledger file). The `.gitignore` line for the old file is removed.

--- a/openspec/changes/cold-open-ledger/proposal.md
+++ b/openspec/changes/cold-open-ledger/proposal.md
@@ -1,0 +1,66 @@
+# Change: cold-open-ledger (Epic A / A5)
+
+## Why
+
+The July 2026 read-path audit (`docs/reports/read-path-performance-audit-2026-07-01.md`
+§Epic A) is measurement-first: land the gauges before the optimizations so every
+later claim (epics B–G) is pinned. A1–A4 landed the point-read gate, the tail
+harness, the concurrency scaling floor, and the memory/layout lane. Three gaps
+remain — this change (A5) is the capstone:
+
+1. **No cold-open gauge.** Nothing benches `SSTableReader::open`/`Database` open
+   cost (component loading: Statistics/Summary/CompressionInfo/BTI root) or the
+   per-reader memory footprint. Epic G3 (bounded `Index.db` mode) needs the RSS
+   baseline; there is none.
+2. **The perf ledger is fragmented.** `scripts/profile_report.py` writes a
+   run-summary `target/profiling/history.jsonl` from criterion medians, while the
+   A2 tail harness writes a *separate* bespoke `benches/tail-latency-history.jsonl`.
+   Two schemas, two files, neither read back for a longitudinal view. The audit
+   calls for one persisted `history.jsonl`; A2's ledger is documented to
+   "consolidate into Epic A5's unified `history.jsonl` when A5 lands."
+3. **The work counters epics B–G need to write their TDD tests do not exist.**
+   B1/C1/C3/C4/E3/E4/C2 each assert on trie-walk counts, decompress-call counts,
+   seek counts, `open(2)` counts, and fd high-water marks — none of which is
+   instrumented today. Without these gauges those epics cannot prove their wins
+   the no-heuristics way (observe the *work*, not just the result).
+
+## What Changes
+
+- **Cold-open benchmarks** (`benches/open.rs`, additive; `harness = false`):
+  - `open/cold` — time a fresh `Database` open (component loading from cold) on
+    the BIG multi-chunk fixture and the BTI (`test_da`) fixture; skips when the
+    fixture is absent, panics on present-but-broken (parity-is-truth).
+  - `mem/open_n_readers` — open N readers and record heap/RSS after, so G3's
+    bounded-Index.db mode has a before/after RSS gauge.
+- **Unified append-only history ledger.** One schema — one JSON object per line,
+  `{ts, commit, bench, metric, value, unit}` — written to a single
+  `target/profiling/history.jsonl`. A shared Rust bench-support module
+  (`benches/bench_ledger/mod.rs`) is the single append path for every A-series
+  harness bench; `profile_report.py` writes criterion medians + peak heap in the
+  same schema; `./scripts/profile.sh report` reads the ledger back and renders a
+  longitudinal per-metric table (latest value + delta vs the previous commit).
+  A2's `tail_latency` bench migrates onto it (its bespoke ledger is retired). The
+  ledger is machine-specific generated run data: gitignored, uploadable as a CI
+  artifact; documented in `docs/profiling.md` + `benches/README.md`.
+- **Test-only read-work counters** in a new `read_work_counters` module, modeled
+  on the existing `work_counters`/`SCAN_FOR_KEY_CALLS` pattern but **cfg-gated**
+  (`#[cfg(any(test, feature = "work-counters"))]`) so release hot paths pay
+  nothing: `TRIE_WALKS`, `DECOMPRESS_CALLS`, `SEEK_CALLS`, `FILE_OPENS`, plus an
+  fd high-water-mark helper (platform-gated). Each has a reset + read API and a
+  module-doc note naming the epic-child that consumes it. Increment calls are
+  unconditional at their choke points but compile to a no-op in release.
+
+## Impact
+
+- Affected specs: **new** capability `read-perf-observability`.
+- Affected code (all additive / measurement-only; **no behavioral production
+  change**): `cqlite-core/benches/open.rs` (new), `benches/bench_ledger/mod.rs`
+  (new), `benches/tail_latency/mod.rs` (migrate onto shared ledger),
+  `cqlite-core/src/storage/sstable/read_work_counters.rs` (new) + a handful of
+  cfg-gated increment call sites (decompress entry, BTI trie descent, block seek,
+  BlockSource open), `cqlite-core/Cargo.toml` (new `work-counters` feature + bench
+  entries), `scripts/profile_report.py`, `scripts/profile.sh`, `docs/profiling.md`,
+  `cqlite-core/benches/README.md`, `.gitignore`.
+- Risk: low. Counters are zero-overhead in release (cfg-gated no-ops); benches and
+  ledger are dev-only; the only production-file edits are unconditional counter
+  calls that vanish in release builds.

--- a/openspec/changes/cold-open-ledger/specs/read-perf-observability/spec.md
+++ b/openspec/changes/cold-open-ledger/specs/read-perf-observability/spec.md
@@ -1,0 +1,132 @@
+# read-perf-observability Specification
+
+## Purpose
+
+Measurement infrastructure for the read-path optimization program (audit §Epic A):
+a cold-open cost gauge, a per-reader memory gauge, one unified longitudinal perf
+ledger, and the cfg-gated read-work counters the later epics use to write their TDD
+tests. All additive and measurement-only — no behavioral production change.
+
+## ADDED Requirements
+
+### Requirement: A cold-open benchmark measures reader open cost
+
+The bench suite SHALL include a benchmark that times a fresh open of a
+`Database`/`SSTableReader` from cold — including component loading
+(Statistics/Summary/CompressionInfo and, for BTI, the trie root) — on a BIG
+multi-chunk fixture and on a BTI (`test_da`) fixture. The bench SHALL be a
+custom-harness (`harness = false`) Criterion target. When a fixture table directory
+is entirely absent the corresponding variant SHALL be skipped (not registered), and
+when a fixture is present but yields an unusable open it SHALL panic at setup rather
+than record a misleading measurement (parity-is-truth).
+
+#### Scenario: Cold-open bench times a real open on a present fixture
+- **WHEN** the `open/cold` bench runs against a present BIG multi-chunk fixture
+- **THEN** it measures a fresh open that loads the SSTable components (not a cached/warm reuse)
+- **AND** it produces an `open/cold_big` measurement
+
+#### Scenario: Absent fixture skips without failing
+- **WHEN** the BTI `test_da` fixture directory is not present in the checkout
+- **THEN** the `open/cold_bti` variant is not registered and the bench run does not fail on its account
+
+#### Scenario: Present-but-broken fixture panics rather than mis-measures
+- **WHEN** a fixture directory exists but a fresh open cannot be established (e.g. components missing)
+- **THEN** the bench setup panics with an actionable message and records no `open/cold` measurement
+
+### Requirement: A per-reader memory benchmark records footprint after opening N readers
+
+The bench suite SHALL include a benchmark (`mem/open_n_readers`) that opens N
+readers over a fixture and records the process heap/RSS after, so a later change
+(bounded `Index.db` mode) has a before/after per-reader memory gauge. The recorded
+memory value SHALL be appended to the unified history ledger as a metric.
+
+#### Scenario: The memory bench records a footprint metric
+- **WHEN** `mem/open_n_readers` opens N readers over a present fixture
+- **THEN** it records a per-reader memory metric (heap or RSS bytes) for N readers
+- **AND** that metric is appended to the unified history ledger
+
+### Requirement: A single unified append-only history ledger persists per-metric run records
+
+Perf run history SHALL be persisted to one append-only ledger at
+`target/profiling/history.jsonl`, one JSON object per line, with the schema
+`{ts, commit, bench, metric, value, unit}` — one record per metric. A single shared
+Rust bench-support module SHALL be the append path for the harness benches, and
+`scripts/profile_report.py` SHALL write its criterion medians and peak heap in the
+same schema. The ledger SHALL be gitignored generated run data (documented as
+CI-artifact-uploadable), and the previous bespoke `benches/tail-latency-history.jsonl`
+ledger SHALL be retired onto this unified ledger. Ledger append SHALL be
+best-effort: a write failure SHALL log and SHALL NOT abort or fail a bench run.
+
+#### Scenario: A harness bench appends one line per metric in the unified schema
+- **WHEN** an A-series harness bench emits metrics through the shared ledger module
+- **THEN** each metric is appended to `target/profiling/history.jsonl` as one JSON line
+- **AND** each line has fields `ts`, `commit`, `bench`, `metric`, `value`, and `unit`
+
+#### Scenario: The tail harness writes to the unified ledger, not a bespoke file
+- **WHEN** the `tail_latency` bench runs
+- **THEN** its metrics are appended to the unified `target/profiling/history.jsonl`
+- **AND** no `benches/tail-latency-history.jsonl` file is produced or referenced
+
+#### Scenario: A ledger write failure does not fail the bench
+- **WHEN** the ledger path cannot be written (e.g. an unwritable directory)
+- **THEN** the bench logs the failure to stderr and completes its measurement normally
+
+### Requirement: `profile.sh report` reads the unified ledger back
+
+`scripts/profile_report.py` (invoked by `./scripts/profile.sh report`) SHALL read
+the unified `history.jsonl` back and render a longitudinal per-metric view (the
+latest recorded value per metric and its delta versus the previous distinct commit).
+A round-trip SHALL be covered by a test: metrics written to a ledger are read back
+and rendered by the report.
+
+#### Scenario: Written metrics round-trip through the report
+- **WHEN** metric records are appended to a `history.jsonl` and `profile_report.py` reads that ledger
+- **THEN** the report includes those metrics with their latest values
+- **AND** the round-trip is asserted by a committed test
+
+### Requirement: Cfg-gated test-only read-work counters exist with reset/read APIs and zero release overhead
+
+A read-work counters module SHALL provide, modeled on the existing
+`work_counters`/`SCAN_FOR_KEY_CALLS` convention: `TRIE_WALKS` (BTI descent count),
+`DECOMPRESS_CALLS` (per-chunk decompress invocations), `SEEK_CALLS` (block-read seek
+count), `FILE_OPENS` (`open(2)` count at the `BlockSource` open sites), and an fd
+high-water-mark helper (platform-gated: `/dev/fd` on macOS, `/proc/self/fd` on
+Linux, `None` elsewhere). Each counter SHALL have a `reset` and a read accessor. The
+counters SHALL be gated behind `#[cfg(any(test, feature = "work-counters"))]` so
+that a default/release build pays nothing (the increment call sites SHALL be
+unconditional but compile to a no-op in release). Each counter SHALL be documented
+in the module with the epic-child that consumes it.
+
+#### Scenario: A default release build pays nothing for the counters
+- **WHEN** the crate is built without the `work-counters` feature and without `cfg(test)`
+- **THEN** the counter increment call sites compile to no-ops (no atomic operations in the release read path)
+
+#### Scenario: Every counter has a reset and read API under test/feature builds
+- **WHEN** the crate is built with `cfg(test)` or the `work-counters` feature
+- **THEN** each of `TRIE_WALKS`, `DECOMPRESS_CALLS`, `SEEK_CALLS`, `FILE_OPENS` exposes a reset and a read accessor
+- **AND** an fd high-water-mark helper returns the current open-fd count on macOS/Linux (and `None` on unsupported platforms)
+
+#### Scenario: Each counter documents its consumer
+- **WHEN** the read-work-counters module is read
+- **THEN** each counter's doc names the epic-child (e.g. B1, C1, C2, C3, C4, E3, E4) that consumes it
+
+### Requirement: The counters are exercised via the public/bench surface (wiring evidence)
+
+The counters SHALL be proven to increment on the real read path — not only through a
+local instance round-trip — by a self-test that drives a real public operation (a
+cold open and/or a point read through the public API) and asserts the corresponding
+counter moved by the expected amount. Counter tests SHALL serialize on the shared
+test mutex (per the existing counter-test convention) so a stale value cannot
+satisfy a later assertion.
+
+#### Scenario: A known single-chunk point read increments the decompress counter
+- **WHEN** a point read that decodes one compression chunk runs through the public query API with counters reset
+- **THEN** `DECOMPRESS_CALLS` increases by the expected per-chunk amount for that read
+
+#### Scenario: A cold open increments the file-open counter
+- **WHEN** a fresh `Database`/reader open runs with counters reset
+- **THEN** `FILE_OPENS` increases (the open touched `open(2)` at the `BlockSource` open sites)
+
+#### Scenario: Counters reset between tests
+- **WHEN** `reset` is called before a measured operation
+- **THEN** each counter reads zero immediately after reset and reflects only the subsequent operation's work

--- a/openspec/changes/cold-open-ledger/tasks.md
+++ b/openspec/changes/cold-open-ledger/tasks.md
@@ -1,0 +1,55 @@
+# Tasks: cold-open-ledger (A5)
+
+## 1. Read-work counters (TDD: tests first)
+- [ ] 1.1 Add `cqlite-core/src/storage/sstable/read_work_counters.rs`: `TRIE_WALKS`,
+      `DECOMPRESS_CALLS`, `SEEK_CALLS`, `FILE_OPENS` atomics; unconditional
+      `record_*()` fns with `#[cfg(any(test, feature = "work-counters"))]` bodies;
+      `#[cfg(any(test, feature = "work-counters"))]` getters + `reset()`; fd
+      high-water helper (`/dev/fd` macOS, `/proc/self/fd` Linux, `None` else).
+      Module doc names each counter's consumer epic-child. `pub mod` it.
+- [ ] 1.2 Add Cargo feature `work-counters` (off by default) to `cqlite-core/Cargo.toml`.
+- [ ] 1.3 Unit test (serialized on the shared test mutex): local-instance
+      round-trip + `reset()` → 0 (deterministic, per #1071).
+- [ ] 1.4 Wire increment call sites (unconditional): decompress entry
+      (`compression.rs`), BTI trie descent (`data_access/bti.rs`), block-read seek
+      (`reader/block_io.rs`), `BlockSource` open (`reader/source.rs`).
+- [ ] 1.5 Wiring-evidence integration test (`work-counters` feature): reset →
+      cold open + single-chunk point read via the public API → assert
+      `DECOMPRESS_CALLS`/`FILE_OPENS`/`TRIE_WALKS` moved as expected.
+
+## 2. Unified history ledger
+- [ ] 2.1 Add `cqlite-core/benches/bench_ledger/mod.rs`: `LedgerRecord
+      {ts,commit,bench,metric,value,unit}`; `append_metrics(bench, &[(name,value,unit)])`;
+      path via `CQLITE_BENCH_LEDGER` env else `<MANIFEST>/../target/profiling/history.jsonl`;
+      reuse A2 `current_commit`; best-effort append (log, never abort).
+- [ ] 2.2 Pure unit test for record serialization / path resolution.
+- [ ] 2.3 Migrate `benches/tail_latency/mod.rs` onto `bench_ledger` (drop its
+      `LedgerRecord`/`append_ledger`/`default_ledger_path`); emit per-metric lines.
+- [ ] 2.4 `scripts/profile_report.py`: write criterion medians + peak heap in the
+      unified `{ts,commit,bench,metric,value,unit}` schema to
+      `target/profiling/history.jsonl`; add a longitudinal per-metric reader
+      (latest value + delta vs previous distinct commit) rendered in report.md.
+- [ ] 2.5 Round-trip test for the report reader (write ledger → read back → assert).
+- [ ] 2.6 `.gitignore`: add `target/profiling/history.jsonl` intent (already under
+      `/target`); remove the `cqlite-core/benches/tail-latency-history.jsonl` line.
+
+## 3. Cold-open + memory benches
+- [ ] 3.1 Add `cqlite-core/benches/open.rs` (`harness = false`): `open/cold_big`,
+      `open/cold_bti` (skip-on-absent, panic-on-broken); appends medians via
+      `bench_ledger`.
+- [ ] 3.2 Add `mem/open_n_readers` (RSS/heap after N opens) → appends a memory
+      metric via `bench_ledger`.
+- [ ] 3.3 Register `[[bench]] open` in `Cargo.toml`; enable `work-counters` in the
+      bench's required-features where it reads counters.
+
+## 4. Docs
+- [ ] 4.1 `docs/profiling.md`: document the unified ledger schema + path + CI-artifact
+      choice; update the history.jsonl table row.
+- [ ] 4.2 `cqlite-core/benches/README.md`: replace the "History ledger" section with
+      the unified schema; document `open`/`mem` benches.
+
+## 5. Gate + review
+- [ ] 5.1 `scripts/agent-gate.sh` PASS (paste SUMMARY verbatim); `RUSTFLAGS="-D warnings"`
+      clean; no `unwrap()`/`expect()` in library code.
+- [ ] 5.2 spec-auditor (C) PASS anchored to `openspec/changes/cold-open-ledger/specs/**`.
+- [ ] 5.3 roborev `--base origin/main --agent codex` clean.

--- a/openspec/changes/cold-open-ledger/tasks.md
+++ b/openspec/changes/cold-open-ledger/tasks.md
@@ -1,51 +1,55 @@
 # Tasks: cold-open-ledger (A5)
 
 ## 1. Read-work counters (TDD: tests first)
-- [ ] 1.1 Add `cqlite-core/src/storage/sstable/read_work_counters.rs`: `TRIE_WALKS`,
+- [x] 1.1 Add `cqlite-core/src/storage/sstable/read_work_counters.rs`: `TRIE_WALKS`,
       `DECOMPRESS_CALLS`, `SEEK_CALLS`, `FILE_OPENS` atomics; unconditional
       `record_*()` fns with `#[cfg(any(test, feature = "work-counters"))]` bodies;
       `#[cfg(any(test, feature = "work-counters"))]` getters + `reset()`; fd
       high-water helper (`/dev/fd` macOS, `/proc/self/fd` Linux, `None` else).
       Module doc names each counter's consumer epic-child. `pub mod` it.
-- [ ] 1.2 Add Cargo feature `work-counters` (off by default) to `cqlite-core/Cargo.toml`.
-- [ ] 1.3 Unit test (serialized on the shared test mutex): local-instance
+- [x] 1.2 Add Cargo feature `work-counters` (off by default) to `cqlite-core/Cargo.toml`.
+- [x] 1.3 Unit test (serialized on the shared test mutex): local-instance
       round-trip + `reset()` → 0 (deterministic, per #1071).
-- [ ] 1.4 Wire increment call sites (unconditional): decompress entry
-      (`compression.rs`), BTI trie descent (`data_access/bti.rs`), block-read seek
-      (`reader/block_io.rs`), `BlockSource` open (`reader/source.rs`).
-- [ ] 1.5 Wiring-evidence integration test (`work-counters` feature): reset →
+- [x] 1.4 Wire increment call sites (unconditional): decompress entry
+      (`compression.rs`), BTI trie descent (`reader/partition_lookup.rs`
+      `lookup_partition_via_bti_trie`), block-read seek (`reader/block_io.rs`),
+      `BlockSource` open (`reader/source.rs` + reader cold-open sites in `reader/mod.rs`).
+- [x] 1.5 Wiring-evidence integration test (`work-counters` feature): reset →
       cold open + single-chunk point read via the public API → assert
       `DECOMPRESS_CALLS`/`FILE_OPENS`/`TRIE_WALKS` moved as expected.
 
 ## 2. Unified history ledger
-- [ ] 2.1 Add `cqlite-core/benches/bench_ledger/mod.rs`: `LedgerRecord
+- [x] 2.1 Add `cqlite-core/benches/bench_ledger/mod.rs`: `LedgerRecord
       {ts,commit,bench,metric,value,unit}`; `append_metrics(bench, &[(name,value,unit)])`;
       path via `CQLITE_BENCH_LEDGER` env else `<MANIFEST>/../target/profiling/history.jsonl`;
       reuse A2 `current_commit`; best-effort append (log, never abort).
-- [ ] 2.2 Pure unit test for record serialization / path resolution.
-- [ ] 2.3 Migrate `benches/tail_latency/mod.rs` onto `bench_ledger` (drop its
+- [x] 2.2 Pure unit test for record serialization / path resolution
+      (`tests/bench_ledger.rs`).
+- [x] 2.3 Migrate `benches/tail_latency/mod.rs` onto `bench_ledger` (drop its
       `LedgerRecord`/`append_ledger`/`default_ledger_path`); emit per-metric lines.
-- [ ] 2.4 `scripts/profile_report.py`: write criterion medians + peak heap in the
+- [x] 2.4 `scripts/profile_report.py`: write criterion medians + peak heap in the
       unified `{ts,commit,bench,metric,value,unit}` schema to
       `target/profiling/history.jsonl`; add a longitudinal per-metric reader
       (latest value + delta vs previous distinct commit) rendered in report.md.
-- [ ] 2.5 Round-trip test for the report reader (write ledger → read back → assert).
-- [ ] 2.6 `.gitignore`: add `target/profiling/history.jsonl` intent (already under
+- [x] 2.5 Round-trip test for the report reader (write ledger → read back → assert)
+      (`scripts/ci/tests/test_profile_report_ledger.py`).
+- [x] 2.6 `.gitignore`: add `target/profiling/history.jsonl` intent (already under
       `/target`); remove the `cqlite-core/benches/tail-latency-history.jsonl` line.
 
 ## 3. Cold-open + memory benches
-- [ ] 3.1 Add `cqlite-core/benches/open.rs` (`harness = false`): `open/cold_big`,
+- [x] 3.1 Add `cqlite-core/benches/open.rs` (`harness = false`): `open/cold_big`,
       `open/cold_bti` (skip-on-absent, panic-on-broken); appends medians via
       `bench_ledger`.
-- [ ] 3.2 Add `mem/open_n_readers` (RSS/heap after N opens) → appends a memory
+- [x] 3.2 Add `mem/open_n_readers` (RSS/heap after N opens) → appends a memory
       metric via `bench_ledger`.
-- [ ] 3.3 Register `[[bench]] open` in `Cargo.toml`; enable `work-counters` in the
-      bench's required-features where it reads counters.
+- [x] 3.3 Register `[[bench]] open` in `Cargo.toml`. (Bench stays a pure timing +
+      RSS bench; the counter assertions live in the `work-counters` integration
+      test, so the bench needs no `required-features`.)
 
 ## 4. Docs
-- [ ] 4.1 `docs/profiling.md`: document the unified ledger schema + path + CI-artifact
+- [x] 4.1 `docs/profiling.md`: document the unified ledger schema + path + CI-artifact
       choice; update the history.jsonl table row.
-- [ ] 4.2 `cqlite-core/benches/README.md`: replace the "History ledger" section with
+- [x] 4.2 `cqlite-core/benches/README.md`: replace the "History ledger" section with
       the unified schema; document `open`/`mem` benches.
 
 ## 5. Gate + review

--- a/scripts/ci/tests/test_profile_report_ledger.py
+++ b/scripts/ci/tests/test_profile_report_ledger.py
@@ -1,0 +1,199 @@
+"""Tests for the unified history ledger in scripts/profile_report.py (Issue #1566,
+Epic A / A5).
+
+Validates that criterion medians + peak heap are written to
+`target/profiling/history.jsonl` in the unified `{ts, commit, bench, metric, value,
+unit}` schema (one record per metric), that the ledger reads back, and that the
+longitudinal per-metric view (latest value + delta vs the previous distinct commit)
+round-trips into report.md. Mirrors test_check_perf_regression.py: import the script
+as a module and drive its functions with temp fixtures.
+"""
+
+import importlib.util
+import json
+import os
+import sys
+
+# ---------------------------------------------------------------------------
+# Import scripts/profile_report.py as a module (not a package, no __init__)
+# ---------------------------------------------------------------------------
+_SCRIPT = os.path.join(
+    os.path.dirname(__file__), "..", "..", "profile_report.py"
+)
+_spec = importlib.util.spec_from_file_location("profile_report", _SCRIPT)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _write_estimate(criterion_dir, bench_id, median_ns):
+    """Write a criterion `new/estimates.json` under <criterion_dir>/<bench_id>/."""
+    d = os.path.join(criterion_dir, *bench_id.split("/"), "new")
+    os.makedirs(d, exist_ok=True)
+    with open(os.path.join(d, "estimates.json"), "w") as fh:
+        json.dump(
+            {
+                "median": {"point_estimate": float(median_ns)},
+                "mean": {"point_estimate": float(median_ns) * 1.1},
+                "std_dev": {"point_estimate": float(median_ns) * 0.05},
+            },
+            fh,
+        )
+
+
+def _read_ledger_lines(path):
+    with open(path) as fh:
+        return [json.loads(l) for l in fh if l.strip()]
+
+
+# ---------------------------------------------------------------------------
+# Unit: ledger record build / append / read round-trip
+# ---------------------------------------------------------------------------
+class TestLedgerRoundTrip:
+    def test_build_records_emit_unified_per_metric_schema(self):
+        report = {
+            "benches": [
+                {"id": "read/get_partition_big", "median_ns": 1234.5},
+                {"id": "read/full_scan", "median_ns": 9999.0},
+            ],
+            "heap": {"peak_bytes": 1048576},
+        }
+        recs = _mod.build_ledger_records(report)
+        # 2 bench median_ns records + 1 peak_heap_bytes record.
+        assert len(recs) == 3
+        for rec in recs:
+            assert set(rec.keys()) == set(_mod.LEDGER_FIELDS)
+        medians = {r["bench"]: r for r in recs if r["metric"] == "median_ns"}
+        assert medians["read/get_partition_big"]["value"] == 1234  # rounded
+        assert medians["read/get_partition_big"]["unit"] == "ns"
+        heap = [r for r in recs if r["metric"] == "peak_heap_bytes"]
+        assert len(heap) == 1
+        assert heap[0]["bench"] == "heap"
+        assert heap[0]["value"] == 1048576
+        assert heap[0]["unit"] == "bytes"
+        # A run shares one ts + commit across all its records.
+        assert len({r["ts"] for r in recs}) == 1
+        assert len({r["commit"] for r in recs}) == 1
+
+    def test_append_then_read_round_trips(self, tmp_path):
+        path = str(tmp_path / "history.jsonl")
+        records = [
+            {"ts": 10, "commit": "aaa", "bench": "read/x", "metric": "median_ns",
+             "value": 100, "unit": "ns"},
+            {"ts": 10, "commit": "aaa", "bench": "heap", "metric": "peak_heap_bytes",
+             "value": 2048, "unit": "bytes"},
+        ]
+        _mod.append_ledger(path, records)
+        # A second append never truncates.
+        _mod.append_ledger(path, [
+            {"ts": 20, "commit": "bbb", "bench": "read/x", "metric": "median_ns",
+             "value": 90, "unit": "ns"},
+        ])
+        back = _mod.read_ledger(path)
+        assert len(back) == 3
+        assert back[0]["bench"] == "read/x" and back[0]["value"] == 100
+
+    def test_read_skips_legacy_and_malformed_lines(self, tmp_path):
+        path = str(tmp_path / "history.jsonl")
+        with open(path, "w") as fh:
+            # legacy pre-A5 run-summary line (no `metric` field) — must be skipped
+            fh.write(json.dumps({"ts": "iso", "rev": "abc", "benches": {"a": 1}}) + "\n")
+            fh.write("not json at all\n")
+            fh.write(json.dumps(
+                {"ts": 1, "commit": "c", "bench": "b", "metric": "median_ns",
+                 "value": 5, "unit": "ns"}) + "\n")
+        back = _mod.read_ledger(path)
+        assert len(back) == 1
+        assert back[0]["metric"] == "median_ns"
+
+
+# ---------------------------------------------------------------------------
+# Unit: longitudinal summary (latest + delta vs previous distinct commit)
+# ---------------------------------------------------------------------------
+class TestSummarizeHistory:
+    def test_delta_is_vs_previous_distinct_commit(self):
+        records = [
+            {"ts": 1, "commit": "old", "bench": "read/x", "metric": "median_ns",
+             "value": 100, "unit": "ns"},
+            {"ts": 2, "commit": "new", "bench": "read/x", "metric": "median_ns",
+             "value": 150, "unit": "ns"},
+            # Re-run of the SAME (latest) commit must not become the delta baseline.
+            {"ts": 3, "commit": "new", "bench": "read/x", "metric": "median_ns",
+             "value": 150, "unit": "ns"},
+        ]
+        rows = _mod.summarize_history(records)
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["value"] == 150
+        assert row["prev_value"] == 100
+        # +50% vs the previous DISTINCT commit ("old"), not 0% vs the re-run.
+        assert abs(row["delta_pct"] - 50.0) < 1e-9
+
+    def test_single_commit_has_no_delta(self):
+        records = [
+            {"ts": 1, "commit": "only", "bench": "b", "metric": "median_ns",
+             "value": 42, "unit": "ns"},
+        ]
+        rows = _mod.summarize_history(records)
+        assert rows[0]["value"] == 42
+        assert "delta_pct" not in rows[0]
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: main() writes the unified ledger and renders the history table
+# ---------------------------------------------------------------------------
+class TestMainEndToEnd:
+    def test_main_writes_unified_ledger_and_history_table(self, tmp_path, monkeypatch):
+        criterion_dir = str(tmp_path / "criterion")
+        out_dir = str(tmp_path / "profiling")
+        _write_estimate(criterion_dir, "read/get_partition_big", 1000)
+        _write_estimate(criterion_dir, "read/full_scan", 5000)
+
+        monkeypatch.setattr(
+            sys, "argv",
+            ["profile_report.py", "--criterion-dir", criterion_dir, "--out-dir", out_dir],
+        )
+        rc = _mod.main()
+        assert rc == 0
+
+        # The ledger holds unified per-metric records for both benches.
+        ledger = os.path.join(out_dir, "history.jsonl")
+        lines = _read_ledger_lines(ledger)
+        by_bench = {r["bench"]: r for r in lines if r["metric"] == "median_ns"}
+        assert by_bench["read/get_partition_big"]["value"] == 1000
+        assert by_bench["read/full_scan"]["value"] == 5000
+        for r in lines:
+            assert set(r.keys()) == set(_mod.LEDGER_FIELDS)
+
+        # report.md contains the History section and the metrics round-trip into it.
+        with open(os.path.join(out_dir, "report.md")) as fh:
+            md = fh.read()
+        assert "## History (latest value + delta vs previous commit)" in md
+        assert "read/get_partition_big" in md
+        assert "median_ns" in md
+
+    def test_second_run_records_delta_vs_prior_commit(self, tmp_path, monkeypatch):
+        criterion_dir = str(tmp_path / "criterion")
+        out_dir = str(tmp_path / "profiling")
+        _write_estimate(criterion_dir, "read/x", 1000)
+
+        # Run 1 at commit "c1".
+        monkeypatch.setattr(_mod, "_git_commit", lambda: "c1")
+        monkeypatch.setattr(
+            sys, "argv",
+            ["profile_report.py", "--criterion-dir", criterion_dir, "--out-dir", out_dir],
+        )
+        assert _mod.main() == 0
+
+        # Run 2 at commit "c2" with a slower median.
+        _write_estimate(criterion_dir, "read/x", 1200)
+        monkeypatch.setattr(_mod, "_git_commit", lambda: "c2")
+        assert _mod.main() == 0
+
+        rows = _mod.summarize_history(_mod.read_ledger(os.path.join(out_dir, "history.jsonl")))
+        row = next(r for r in rows if r["bench"] == "read/x")
+        assert row["value"] == 1200
+        assert row["prev_value"] == 1000
+        assert abs(row["delta_pct"] - 20.0) < 1e-9

--- a/scripts/ci/tests/test_profile_report_ledger.py
+++ b/scripts/ci/tests/test_profile_report_ledger.py
@@ -142,6 +142,42 @@ class TestSummarizeHistory:
 
 
 # ---------------------------------------------------------------------------
+# Unit: commit resolver honors GIT_COMMIT (mirrors the Rust bench_ledger writer)
+# ---------------------------------------------------------------------------
+class TestCommitResolver:
+    def test_git_commit_env_override_wins(self, monkeypatch):
+        # A non-empty GIT_COMMIT wins over `git rev-parse HEAD` so a CI run that
+        # sets it does not split its records across two `commit` values.
+        monkeypatch.setenv("GIT_COMMIT", "envsha1234")
+        assert _mod._git_commit() == "envsha1234"
+
+    def test_git_commit_blank_env_falls_back_to_git(self, monkeypatch):
+        # A blank/whitespace override is ignored (matches the Rust `.trim()` guard);
+        # falls back to `git rev-parse HEAD` (stubbed) or "unknown".
+        monkeypatch.setenv("GIT_COMMIT", "   ")
+        monkeypatch.setattr(
+            _mod.subprocess, "run",
+            lambda *a, **k: type("R", (), {"stdout": "fallbackhead\n"})(),
+        )
+        assert _mod._git_commit() == "fallbackhead"
+
+    def test_ledger_commit_field_uses_git_commit_env(self, tmp_path, monkeypatch):
+        # End-to-end: the ledger `commit` field reflects GIT_COMMIT when set.
+        monkeypatch.setenv("GIT_COMMIT", "ledgerenvsha")
+        criterion_dir = str(tmp_path / "criterion")
+        out_dir = str(tmp_path / "profiling")
+        _write_estimate(criterion_dir, "read/x", 1000)
+        monkeypatch.setattr(
+            sys, "argv",
+            ["profile_report.py", "--criterion-dir", criterion_dir, "--out-dir", out_dir],
+        )
+        assert _mod.main() == 0
+        lines = _read_ledger_lines(os.path.join(out_dir, "history.jsonl"))
+        assert lines, "ledger must have records"
+        assert all(r["commit"] == "ledgerenvsha" for r in lines)
+
+
+# ---------------------------------------------------------------------------
 # End-to-end: main() writes the unified ledger and renders the history table
 # ---------------------------------------------------------------------------
 class TestMainEndToEnd:

--- a/scripts/profile_report.py
+++ b/scripts/profile_report.py
@@ -12,10 +12,15 @@ artifacts that drive the recursive-improvement loop:
 
   outputs:
     target/profiling/report.json     machine-readable, for tooling/agents
-    target/profiling/report.md       human-readable ranked bottleneck table
-    target/profiling/history.jsonl   append-only ledger (one line per run, with
-                                     git revision) so improvement across
-                                     iterations is auditable
+    target/profiling/report.md       human-readable ranked bottleneck table +
+                                     a longitudinal per-metric history view
+    target/profiling/history.jsonl   the unified append-only ledger (Issue #1566,
+                                     Epic A / A5): one JSON object PER METRIC per
+                                     run, schema {ts, commit, bench, metric, value,
+                                     unit}. The A-series harness benches append to
+                                     this same file/schema via benches/bench_ledger,
+                                     so criterion medians, bench percentiles, and the
+                                     cold-open/memory gauges all live in one ledger.
 
 Usage:
     scripts/profile_report.py [--criterion-dir target/criterion]
@@ -48,6 +53,138 @@ def _git_rev():
         return out.stdout.strip()
     except Exception:
         return "unknown"
+
+
+def _git_commit():
+    """Full HEAD SHA for the ledger `commit` field, matching the Rust bench_ledger
+    writer (which uses `git rev-parse HEAD`) so the two sources group together."""
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True, text=True, check=True,
+        )
+        return out.stdout.strip() or "unknown"
+    except Exception:
+        return "unknown"
+
+
+# Unified ledger schema (Issue #1566): one JSON object per line, one record per
+# metric. Shared with the Rust `benches/bench_ledger` module.
+LEDGER_FIELDS = ("ts", "commit", "bench", "metric", "value", "unit")
+
+
+def build_ledger_records(report):
+    """Flatten a report into unified per-metric ledger records: one `median_ns`
+    record per criterion bench and one `peak_heap_bytes` record when heap data
+    exists. All records in a run share the run's `ts` + `commit`."""
+    ts = int(
+        datetime.datetime.now(datetime.timezone.utc).timestamp()
+    )
+    commit = _git_commit()
+    records = []
+    for b in report["benches"]:
+        records.append(
+            {
+                "ts": ts,
+                "commit": commit,
+                "bench": b["id"],
+                "metric": "median_ns",
+                "value": round(b["median_ns"]),
+                "unit": "ns",
+            }
+        )
+    heap = report.get("heap")
+    if heap and heap.get("peak_bytes") is not None:
+        records.append(
+            {
+                "ts": ts,
+                "commit": commit,
+                "bench": "heap",
+                "metric": "peak_heap_bytes",
+                "value": heap["peak_bytes"],
+                "unit": "bytes",
+            }
+        )
+    return records
+
+
+def append_ledger(path, records):
+    """Append one JSON line per record to the unified ledger (best-effort: a write
+    failure is logged and does not abort the report)."""
+    try:
+        with open(path, "a") as fh:
+            for rec in records:
+                fh.write(json.dumps(rec) + "\n")
+    except OSError as e:
+        print(f"warning: could not append ledger {path}: {e}", file=sys.stderr)
+
+
+def read_ledger(path):
+    """Read the unified ledger back, returning the valid unified records (schema
+    {ts,commit,bench,metric,value,unit}). Malformed and legacy-schema lines (the
+    pre-A5 run-summary `{ts,rev,benches,...}` lines) are skipped, so a report over a
+    ledger that predates the migration still renders."""
+    records = []
+    try:
+        with open(path) as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except ValueError:
+                    continue
+                if not isinstance(obj, dict):
+                    continue
+                if all(k in obj for k in LEDGER_FIELDS):
+                    records.append(obj)
+    except OSError:
+        return []
+    return records
+
+
+def _latest_and_prev(group):
+    """Given a metric's records sorted ascending by ts, return (latest_record,
+    prev_record) where prev is the most recent record from a DIFFERENT commit than
+    the latest (or None). Grouping the delta by *distinct commit* (not by row) means
+    re-running the same commit does not show a spurious 0% delta against itself."""
+    if not group:
+        return None, None
+    latest = group[-1]
+    latest_commit = latest.get("commit")
+    for rec in reversed(group[:-1]):
+        if rec.get("commit") != latest_commit:
+            return latest, rec
+    return latest, None
+
+
+def summarize_history(records):
+    """Group ledger records by (bench, metric); for each, the latest value and the
+    delta vs the previous distinct commit. Returns a list of dicts sorted by id."""
+    groups = {}
+    for rec in records:
+        key = (rec["bench"], rec["metric"])
+        groups.setdefault(key, []).append(rec)
+    rows = []
+    for (bench, metric), recs in groups.items():
+        recs.sort(key=lambda r: r.get("ts", 0))
+        latest, prev = _latest_and_prev(recs)
+        row = {
+            "bench": bench,
+            "metric": metric,
+            "unit": latest.get("unit", ""),
+            "value": latest.get("value"),
+            "commit": latest.get("commit", "unknown"),
+            "prev_value": prev.get("value") if prev else None,
+        }
+        pv = row["prev_value"]
+        cv = row["value"]
+        if pv not in (None, 0) and isinstance(cv, (int, float)):
+            row["delta_pct"] = (cv / pv - 1.0) * 100.0
+        rows.append(row)
+    rows.sort(key=lambda r: (r["bench"], r["metric"]))
+    return rows
 
 
 def _throughput_elements(benchmark_json):
@@ -118,7 +255,50 @@ def fmt_ns(ns):
     return f"{ns:.0f} ns"
 
 
-def render_markdown(report):
+def _fmt_history_value(value, unit):
+    """Human-readable value for the history table, unit-aware."""
+    if not isinstance(value, (int, float)):
+        return "—"
+    if unit == "ns":
+        return fmt_ns(value)
+    if unit == "bytes":
+        return f"{value / 2**20:.1f} MiB"
+    if unit == "ratio":
+        return f"{value:.3f}"
+    return f"{value:g}"
+
+
+def render_history(history_rows):
+    """Render the longitudinal per-metric view: latest value + delta vs the previous
+    distinct commit (Issue #1566). Reads the whole unified ledger back."""
+    lines = [
+        "## History (latest value + delta vs previous commit)",
+        "",
+    ]
+    if not history_rows:
+        lines += [
+            "- no history yet — the unified ledger "
+            "(`target/profiling/history.jsonl`) is empty.",
+            "",
+        ]
+        return lines
+    lines += [
+        "| bench | metric | latest | Δ vs prev commit | unit | commit |",
+        "|-------|--------|--------|------------------|------|--------|",
+    ]
+    for r in history_rows:
+        delta = f"{r['delta_pct']:+.1f}%" if "delta_pct" in r else "—"
+        commit = (r.get("commit") or "unknown")[:12]
+        lines.append(
+            f"| {r['bench']} | {r['metric']} | "
+            f"{_fmt_history_value(r['value'], r['unit'])} | {delta} | "
+            f"{r['unit']} | `{commit}` |"
+        )
+    lines.append("")
+    return lines
+
+
+def render_markdown(report, history_rows=None):
     lines = [
         "# CQLite profiling report",
         "",
@@ -154,6 +334,9 @@ def render_markdown(report):
         ]
     else:
         lines.append("- no heap data — run `./scripts/profile.sh heap` first")
+
+    lines.append("")
+    lines += render_history(history_rows or [])
 
     lines += [
         "",
@@ -199,29 +382,28 @@ def main():
     os.makedirs(args.out_dir, exist_ok=True)
     json_path = os.path.join(args.out_dir, "report.json")
     md_path = os.path.join(args.out_dir, "report.md")
+    ledger_path = os.path.join(args.out_dir, "history.jsonl")
+
     with open(json_path, "w") as fh:
         json.dump(report, fh, indent=2)
-    with open(md_path, "w") as fh:
-        fh.write(render_markdown(report))
 
-    # Append-only ledger: one compact line per run so successive iterations of
-    # the improvement loop stay comparable even after baselines are overwritten.
-    history_line = {
-        "ts": report["generated_at"],
-        "rev": report["git_rev"],
-        "benches": {
-            b["id"]: round(b["median_ns"]) for b in benches
-        },
-        "peak_heap_bytes": heap.get("peak_bytes") if heap else None,
-    }
-    with open(os.path.join(args.out_dir, "history.jsonl"), "a") as fh:
-        fh.write(json.dumps(history_line) + "\n")
+    # Unified append-only ledger (Issue #1566): one JSON object PER METRIC in the
+    # {ts, commit, bench, metric, value, unit} schema, the same file+schema the
+    # A-series harness benches append to via benches/bench_ledger. Append first,
+    # then read the whole ledger back so the report's longitudinal view includes
+    # this run.
+    append_ledger(ledger_path, build_ledger_records(report))
+    history_rows = summarize_history(read_ledger(ledger_path))
+
+    md = render_markdown(report, history_rows)
+    with open(md_path, "w") as fh:
+        fh.write(md)
 
     print(f"wrote {json_path}")
     print(f"wrote {md_path}")
-    print(f"appended {os.path.join(args.out_dir, 'history.jsonl')}")
+    print(f"appended {ledger_path}")
     print()
-    print(render_markdown(report))
+    print(md)
     return 0
 
 

--- a/scripts/profile_report.py
+++ b/scripts/profile_report.py
@@ -56,8 +56,14 @@ def _git_rev():
 
 
 def _git_commit():
-    """Full HEAD SHA for the ledger `commit` field, matching the Rust bench_ledger
-    writer (which uses `git rev-parse HEAD`) so the two sources group together."""
+    """Commit id for the ledger `commit` field, mirroring the Rust bench_ledger
+    writer's `current_commit()`: a non-empty `GIT_COMMIT` env override wins, else
+    `git rev-parse HEAD`, else "unknown". Honoring the same override keeps a CI run
+    that sets `GIT_COMMIT` from splitting one run's records across two `commit`
+    values (Finding 4, roborev)."""
+    env_commit = os.environ.get("GIT_COMMIT", "").strip()
+    if env_commit:
+        return env_commit
     try:
         out = subprocess.run(
             ["git", "rev-parse", "HEAD"],


### PR DESCRIPTION
Closes #1566. Epic A (read-path measurement) capstone. **Measurement infrastructure only — no behavioral production change.**

## What
- **Cfg-gated read-work counters** (`read_work_counters.rs`): `TRIE_WALKS`, `DECOMPRESS_CALLS`, `SEEK_CALLS`, `FILE_OPENS` + fd high-water helper. Unconditional `record_*()` calls with `#[cfg(any(test, feature = "work-counters"))]` bodies → **zero overhead in release**. Reset/read APIs; each counter's doc names its consumer epic-child (B1/C1/C2/C3/C4/E3/E4). Wired at the production read-path choke points (decompress entry, BTI trie descent, block + data_access seek sites, BlockSource open) with real-path wiring-evidence tests through the public `Database` API.
- **Unified append-only history ledger** (`benches/bench_ledger/`): one schema `{ts,commit,bench,metric,value,unit}`, one line per metric, single writer module. `tail_latency` migrated off its bespoke ledger; `profile_report.py` writes + reads the same schema; `./scripts/profile.sh report` renders a longitudinal per-metric table. Gitignored generated run data.
- **Cold-open + memory benches** (`benches/open.rs`): `open/cold_big`, `open/cold_bti` (skip-on-absent, panic-on-broken), `mem/open_n_readers` (current RSS on macOS via mach `task_info`; `/proc/self/statm` on Linux). Metrics appended to the unified ledger.
- Docs: `docs/profiling.md`, `benches/README.md`.

## Quality
- OpenSpec change `cold-open-ledger` (new `read-perf-observability` capability).
- `scripts/agent-gate.sh`: PASS (v3 full-green; re-gated v4 after rebase+fixes).
- spec-auditor (C): PASS (all requirements satisfied with public-surface evidence).
- roborev (`--agent codex`): 4 findings, all fixed (SEEK_CALLS completeness + real-path test; ledger empty-parent; macOS current-RSS; python `GIT_COMMIT` honoring).