### PR TITLE
chore(#1822): wire sccache into agent-gate for shared compiler cache

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,57 @@ cat /tmp/gate-summary.txt   # complete SUMMARY, even if gate.log truncated
 # Fast self-test of the emission/recovery path:
 bash scripts/tests/test_agent_gate_summary.sh
 
+### Shared Compiler Cache (sccache)
+
+The gate uses **sccache** (Mozilla's shared compiler cache) to eliminate duplicated compilation across worktrees. Each worktree is **independent** (owns its `target/` dir, no lock contention), but reuses cached compilation artifacts from any prior worktree, giving **25.6% wall-clock speedup on fresh-worktree scenarios** (measured in issue #1822).
+
+**Setup** (one-time per machine):
+```bash
+# macOS:
+brew install sccache
+
+# Linux:
+cargo install sccache
+
+# Or download a release binary: https://github.com/mozilla/sccache/releases
+```
+
+**Configuration** (optional; auto-detects on first use):
+The gate auto-enables sccache if it's on `$PATH`. To customize:
+```bash
+# Set cache location (default: ~/.cache/sccache on Linux, ~/Library/Caches/Mozilla.sccache on macOS)
+export SCCACHE_DIR=/custom/cache/path
+
+# Set size limit (default 10 GiB; raise for multi-worktree teams)
+export SCCACHE_CACHE_SIZE=50G
+
+# Disable sccache for a single gate run (if needed for diagnostics)
+CQLITE_DISABLE_SCCACHE=1 bash scripts/agent-gate.sh
+
+# Disable sccache permanently (not recommended)
+export CQLITE_DISABLE_SCCACHE=1
+```
+
+**Rationale: sccache vs shared `CARGO_TARGET_DIR`** (issue #1822):
+- **sccache (chosen):** Each worktree has its own `target/` dir (parallel gates do not contend for the build lock); the shared object cache deduplicates `rustc` invocations. Empirically: 7 concurrent worktree gates run in parallel, all benefiting from the cache.
+- **Shared `CARGO_TARGET_DIR` (rejected):** `cargo` takes an exclusive build lock on the shared target dir, so concurrent gates serialize (throughput bottleneck), thrashing the cache with different feature sets (each gate component uses different flags / features).
+
+**Cache management**:
+```bash
+# View cache stats (shows hit rate, size, cache location)
+sccache --show-stats
+
+# Zero stats for measurement
+sccache --zero-stats
+
+# Stop the background server (if needed for diagnostics)
+sccache --stop-server
+
+# Start the server explicitly (normally auto-starts)
+sccache --start-server
+```
+
+
 # Build
 cargo build
 

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -172,6 +172,20 @@ REPO_ROOT="$PWD"
 if ! command -v cargo >/dev/null 2>&1 && [ -d "$HOME/.cargo/bin" ]; then
   export PATH="$HOME/.cargo/bin:$PATH"
 fi
+
+# sccache auto-detect (issue #1822): if sccache is available, use it as the
+# rustc wrapper for incremental compilation cache. Each worktree keeps its own
+# target/ dir (no lock contention); the shared object cache deduplicates
+# compilation across worktrees. Disabled via CQLITE_DISABLE_SCCACHE=1.
+# Cache location: $SCCACHE_DIR (default ~/.cache/sccache on Linux,
+# ~/Library/Caches/Mozilla.sccache on macOS). Cache size limit:
+# $SCCACHE_CACHE_SIZE (default 10 GiB; raise for multi-user builds).
+# Measurement (issue #1822): 25.6% speedup on fresh worktrees with warm cache.
+if [ "${CQLITE_DISABLE_SCCACHE:-0}" != 1 ] && command -v sccache >/dev/null 2>&1; then
+  export RUSTC_WRAPPER=sccache
+  export CARGO_INCREMENTAL=0
+  echo "agent-gate: sccache detected; using as RUSTC_WRAPPER with CARGO_INCREMENTAL=0 (#1822)"
+fi
 export CQLITE_DATASETS_ROOT="${CQLITE_DATASETS_ROOT:-$REPO_ROOT/test-data/datasets}"
 
 COMPONENTS=(file-size fmt clippy core-tests tombstones-scan scan-offload-guard memory-budget integration-tests format-compat write-tests cli-tests compaction-byte-parity python-bindings node-bindings delivery-telemetry parity-report binding-unwind-profile tooling-tests minimal-build smoke)


### PR DESCRIPTION
Closes #1822.

Auto-detects sccache on PATH in `scripts/agent-gate.sh` and sets `RUSTC_WRAPPER=sccache` + `CARGO_INCREMENTAL=0` (opt-out via `CQLITE_DISABLE_SCCACHE=1`; graceful no-op when absent). Per-worktree `target/` preserved — rejected shared `CARGO_TARGET_DIR` (build lock serializes parallel gates). CLAUDE.md documents setup + rationale.

## Measured (sccache 0.16.0)
| Scenario | Wall-clock | sccache hit rate |
|---|---|---|
| COLD (empty cache) | 36.6 min | 10% |
| **FRESH_WITH_CACHE** (new worktree, warm cache) | **27.3 min** | **100%** (1083/1091) |
| WARM (incremental target/) | 17.3 min | n/a |

**562s (25.6%) saved on the fresh-worktree case** — the cross-worktree scenario sccache targets. Compile-bound components 24–91% faster (format-compat 91%, smoke/minimal-build 76%, cli/write/integration 53–56%); test-execution-bound (core-tests) <5% as expected. ~1.1h saved per gate-run cycle across 7 active worktrees.

## Validation
- Final gate with wiring: **RESULT: PASS** (all 20 components; sccache auto-detected, 99.9% hit rate).
- roborev (codex, vs origin/main): No issues found.
- Docs-only + build-infra; no production code touched.