### PR TITLE
docs: stack storage mermaid diagrams

### DIFF
--- a/website/scripts/validate-proposals-research.mjs
+++ b/website/scripts/validate-proposals-research.mjs
@@ -67,6 +67,22 @@ const checks = [
     ],
   },
   {
+    name: 'storage-engine Mermaid diagrams use stacked layouts',
+    file: 'src/content/docs/proposals-research/storage-engine.mdx',
+    includes: [
+      'export const architectureMermaid = `flowchart TB',
+      'export const dataPathsMermaid = `flowchart TB',
+      'Cold ~~~ Fresh',
+      'Fresh ~~~ Research',
+    ],
+    excludes: [
+      'export const architectureMermaid = `flowchart LR',
+      '  subgraph Cold["Cold path"]\n    direction LR',
+      '  subgraph Fresh["Fresh tail path"]\n    direction LR',
+      '  subgraph Research["Research path"]\n    direction LR',
+    ],
+  },
+  {
     name: 'Mermaid diagram component renders and preserves source',
     file: 'src/components/MermaidDiagram.astro',
     includes: [

--- a/website/src/content/docs/proposals-research/storage-engine.mdx
+++ b/website/src/content/docs/proposals-research/storage-engine.mdx
@@ -11,21 +11,22 @@ import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
 import MermaidDiagram from '../../../components/MermaidDiagram.astro';
 import storageEngineConcept from '../../../assets/storage-engine-parallel-planes.png';
 
-export const architectureMermaid = `flowchart LR
+export const architectureMermaid = `flowchart TB
   subgraph OLTP["Cassandra OLTP Plane"]
     direction TB
-    OApp["Application reads/writes"] --> OStore["CommitLog + Memtable"] --> Lifecycle["Flush, compaction, repair"]
+    OApp["Application reads/writes"] --> OStore["CommitLog +<br/>Memtable"] --> Lifecycle["Flush, compaction, repair"]
   end
 
   subgraph Foundation["SSTable Foundation"]
     direction TB
-    SSTables["Data.db / Index.db / Summary.db / Statistics.db"]
-    Tail["Optional fresh tail gen-*"]
+    SSTables["Data.db / Index.db<br/>Summary.db / Statistics.db"]
+    Tail["Optional fresh<br/>tail gen-*"]
+    SSTables ~~~ Tail
   end
 
   subgraph OLAP["Trino / Iceberg OLAP Plane"]
     direction TB
-    AApp["Application analytical reads"] --> Services["Trino / Arrow Flight / Iceberg materializer"] --> CQLite["CQLite SSTable reader"]
+    AApp["Application analytical reads"] --> Services["Trino / Arrow Flight<br/>Iceberg materializer"] --> CQLite["CQLite SSTable reader"]
   end
 
   Lifecycle -->|flush creates durable SSTables| SSTables
@@ -35,28 +36,31 @@ export const architectureMermaid = `flowchart LR
 
 export const dataPathsMermaid = `flowchart TB
   subgraph Cold["Cold path"]
-    direction LR
-    SSTables["Flushed SSTables"] --> ColdCQLite["CQLite reader"]
+    direction TB
+    SSTables["Flushed<br/>SSTables"] --> ColdCQLite["CQLite reader"]
     ColdCQLite --> Flight["Arrow Flight"]
     Flight --> Trino["Trino"]
-    ColdCQLite --> Iceberg["Iceberg materializer"]
+    ColdCQLite --> Iceberg["Iceberg<br/>materializer"]
   end
 
   subgraph Fresh["Fresh tail path"]
-    direction LR
+    direction TB
     Write["Cassandra write"] --> Memtable["CqliteMemtable"]
-    Memtable --> TailGen["Tail gen-* SSTable"]
-    TailGen --> Merge["CQLite k-way LWW merge"]
+    Memtable --> TailGen["Tail gen-*<br/>SSTable"]
+    TailGen --> Merge["CQLite k-way<br/>LWW merge"]
     Merge --> Query["Flight / Trino query"]
   end
 
   subgraph Research["Research path"]
-    direction LR
-    Notes["Raw research notes"] --> Synthesis["Synthesis report"]
+    direction TB
+    Notes["Raw research<br/>notes"] --> Synthesis["Synthesis report"]
     Synthesis --> Proposal["Official proposal"]
-    Proposal --> Tasks["Implementation tasks"]
+    Proposal --> Tasks["Implementation<br/>tasks"]
     Tasks --> Roadmap["Roadmap"]
-  end`;
+  end
+
+  Cold ~~~ Fresh
+  Fresh ~~~ Research`;
 
 # Storage Engine Direction
 


### PR DESCRIPTION
## Summary
- switch the storage architecture Mermaid graph from left-to-right to top-to-bottom
- stack the data-path Mermaid subgraphs vertically instead of laying them out as tiny horizontal lanes
- add a proposals-research validator check to keep these diagrams from regressing to horizontal layouts

## Verification
- npm run validate-proposals-research
- npm run build
- node scripts/validate-agent-plumbing.mjs
- built HTML inspection confirmed two Mermaid diagrams, stacked data-path markers, and no static storage SVG refs