### PR TITLE
H2(#1615): per-CQL-type decode benches + allocs/row-cell budget lane

### DIFF
--- a/.github/workflows/perf-regression.yml
+++ b/.github/workflows/perf-regression.yml
@@ -140,7 +140,16 @@ jobs:
           if [[ -f cqlite-core/benches/decode_bench.rs ]]; then
             BENCH_TARGETS+=(--bench decode)
           fi
-          cargo bench -p cqlite-core --features "$BENCH_FEATURES" \
+          # `bench-internals` (issue #1615) is defined by the PR but may not exist
+          # on `main` yet. Passing it to `cargo bench` on a checkout that does not
+          # define it fails feature resolution BEFORE the guarded --bench decode is
+          # skipped, so build a base-specific feature list that appends it only when
+          # the checked-out Cargo.toml declares it (mirrors the target guards above).
+          BASE_FEATURES="cli-helpers,write-support"
+          if grep -q '^bench-internals' cqlite-core/Cargo.toml; then
+            BASE_FEATURES="$BASE_FEATURES,bench-internals"
+          fi
+          cargo bench -p cqlite-core --features "$BASE_FEATURES" \
             "${BENCH_TARGETS[@]}" -- --save-baseline base "${BENCH_ARGV[@]}"
 
       - name: Restore PR ref (for the gate script + policy)

--- a/.github/workflows/perf-regression.yml
+++ b/.github/workflows/perf-regression.yml
@@ -39,7 +39,9 @@ env:
   CQLITE_DATASETS_ROOT: ${{ github.workspace }}/test-data/datasets
   # Features needed by the benches: cli-helpers for the read suite (queryable
   # Database), write-support for the write suite (WriteEngine).
-  BENCH_FEATURES: "cli-helpers,write-support"
+  # bench-internals adds the decode_value_for_bench shim the `decode` bench needs
+  # (issue #1615); it changes no other bench and no production default build.
+  BENCH_FEATURES: "cli-helpers,write-support,bench-internals"
   # Criterion run config — kept small for CI. Tune here if the gate is too noisy
   # (more samples → stabler medians, slower job).
   BENCH_ARGS: "--sample-size 20 --warm-up-time 1 --measurement-time 3"
@@ -109,7 +111,7 @@ jobs:
             read -r -a BENCH_ARGV <<< "$BENCH_ARGS"
           fi
           cargo bench -p cqlite-core --features "$BENCH_FEATURES" \
-            --bench read --bench write --bench concurrent_scan --bench read_while_write --bench compaction \
+            --bench read --bench write --bench concurrent_scan --bench read_while_write --bench compaction --bench decode \
             -- --save-baseline pr "${BENCH_ARGV[@]}"
 
       - name: Benchmark main → baseline 'base'
@@ -130,6 +132,13 @@ jobs:
           BENCH_TARGETS=(--bench read --bench write --bench concurrent_scan --bench read_while_write)
           if [[ -f cqlite-core/benches/compaction.rs ]]; then
             BENCH_TARGETS+=(--bench compaction)
+          fi
+          # The `decode` bench target (issue #1615) may not exist on `main` yet;
+          # include it only when present, mirroring the `compaction` guard. The
+          # compare script SKIPs any bench missing from the baseline, so a first-PR
+          # baseline with no decode data stays green.
+          if [[ -f cqlite-core/benches/decode_bench.rs ]]; then
+            BENCH_TARGETS+=(--bench decode)
           fi
           cargo bench -p cqlite-core --features "$BENCH_FEATURES" \
             "${BENCH_TARGETS[@]}" -- --save-baseline base "${BENCH_ARGV[@]}"

--- a/cqlite-core/Cargo.toml
+++ b/cqlite-core/Cargo.toml
@@ -184,6 +184,17 @@ harness = false
 name = "read"
 harness = false
 
+# Per-CQL-type + wide-row/text-heavy decode benches (issue #1615, Epic H).
+# `harness = false` criterion target. Needs `cli-helpers` (real fixture reader for
+# the `&self` decode context) AND `bench-internals` (the decode_value_for_bench
+# shim); without those it compiles to an empty criterion main. The two throughput
+# benches (decode/wide_row_primitives, decode/text_heavy) are STRICT perf-gate
+# entries; the many per-type benches are recorded/advisory.
+[[bench]]
+name = "decode"
+path = "benches/decode_bench.rs"
+harness = false
+
 [[bench]]
 name = "write"
 harness = false
@@ -293,6 +304,16 @@ wasm = ["wasm-bindgen", "js-sys", "web-sys"]
 # does not exist unless this feature is enabled, so every default build / gate /
 # CI run is byte-identical without it. NOT in defaults.
 fuzz = []
+
+# Bench-internals surface (issue #1615, Epic H) — gates a single
+# `#[doc(hidden)] #[cfg(feature = "bench-internals")] pub fn
+# SSTableReader::decode_value_for_bench` that forwards VERBATIM to the crate-private
+# block-path decode entry `parse_value_with_schema_type`, so the `decode` bench
+# (an external crate) can measure the REAL dispatch rather than a re-implemented
+# copy. Adds NO dependencies and NO real public API: without this feature the
+# symbol does not exist and every default build / gate / CI run is byte-identical.
+# NOT in defaults.
+bench-internals = []
 
 # Legacy heuristics support (backward compatibility for pre-5.0 formats)
 # NOT enabled in default CI configuration - opt-in only

--- a/cqlite-core/benches/decode_bench.rs
+++ b/cqlite-core/benches/decode_bench.rs
@@ -1,0 +1,570 @@
+//! Decode micro-benchmarks for cqlite-core (issue #1615, Epic H / H2).
+//!
+//! These benches pin the *decode-level* cost that nothing else measures: the
+//! existing `read/type_heavy` bench exercises the whole v5 read path (open →
+//! seek → chunk decompress → row/cell decode), so a pure decode regression can
+//! hide inside its I/O. This target isolates the block-path value decoder.
+//!
+//! Three criterion groups:
+//!
+//! - `decode/type_<name>` — for each CQL type (all scalars + `list`/`set`/`map`/
+//!   `tuple`/UDT/`frozen`), decode a FIXED representative byte buffer through the
+//!   **live** block-path entry `SSTableReader::parse_value_with_schema_type`,
+//!   reached via the opt-in `#[doc(hidden)]` `decode_value_for_bench` shim (never
+//!   a re-implemented copy). ns/op per type. Numerous + individually noisy, so
+//!   these are recorded/advisory, not STRICT perf-gate entries.
+//! - `decode/wide_row_primitives` — `Throughput::Elements(rows)` decoding a wide
+//!   all-primitive row (~20 primitive columns) repeated to a row volume; rows/sec.
+//! - `decode/text_heavy` — `Throughput::Elements(rows)` on a `text`/`blob`-dominated
+//!   column set (the K5/K6 measurement); rows/sec.
+//!
+//! # Why a real opened reader supplies `&self`
+//!
+//! The scalar decode arms are `self`-independent, but the collection/UDT/tuple/
+//! frozen arms recurse via `&self` and read `self.header.cassandra_version`. So the
+//! bench opens ONE real, CI-present V5 fixture reader (`SIMPLE`,
+//! `test_basic.simple_table`) once, outside every measured region, and reuses it as
+//! the decode context. The per-type byte buffers are fixed literals built here, so
+//! the measurement is deterministic and independent of any single fixture's columns
+//! while still routing every decode through the live entry.
+//!
+//! # UDT note
+//!
+//! `parse_value_with_schema_type` resolves its `data_type` string via
+//! `ComparatorType::from_data_type`, which does NOT consult a UDT registry, so it
+//! can never produce a `ComparatorType::Udt` from a type string — a UDT reference
+//! decodes through the `Custom` fallback. The UDT-class decode (multi-field, i32-BE
+//! field lengths) is therefore benched via its structural twin `tuple`: Cassandra's
+//! `UserType` extends `TupleType` and shares the identical wire format and decode
+//! logic (`parse_udt_value` vs `parse_tuple_value`). The `decode/type_udt` entry
+//! documents this and asserts `Value::Tuple`.
+//!
+//! # Gating
+//!
+//! Needs `cli-helpers` (the `open_read_db`/fixture loader + a queryable reader) AND
+//! `bench-internals` (the `decode_value_for_bench` shim). Without BOTH, the bench
+//! compiles to an empty-but-valid criterion main (mirrors `read.rs`).
+
+use criterion::{criterion_group, criterion_main};
+
+#[path = "fixtures/mod.rs"]
+mod fixtures;
+
+#[path = "bench_ledger/mod.rs"]
+mod bench_ledger;
+
+#[path = "profiling/mod.rs"]
+mod profiling;
+
+// ---------------------------------------------------------------------------
+// Real benches (need BOTH cli-helpers and bench-internals)
+// ---------------------------------------------------------------------------
+
+#[cfg(all(feature = "cli-helpers", feature = "bench-internals"))]
+mod decode_impl {
+    use super::{bench_ledger, fixtures};
+    use cqlite_core::storage::sstable::reader::SSTableReader;
+    use cqlite_core::{Config, Platform, Value};
+    use criterion::{black_box, Criterion, Throughput};
+    use std::sync::Arc;
+
+    /// Fixed number of "rows" decoded per throughput iteration (a stable row
+    /// volume for the rows/sec measurement; identical across runs and machines).
+    const ROWS: u64 = 1_000;
+
+    /// One per-type decode case: a fixed byte buffer, the type string the live
+    /// entry resolves, and a matcher proving the decode took the right arm.
+    struct TypeCase {
+        name: &'static str,
+        data_type: String,
+        buf: Vec<u8>,
+        /// Non-capturing (coerces to `fn`) matcher for the expected `Value`
+        /// variant — wiring evidence that the live entry ran, not a no-op.
+        matches: fn(&Value) -> bool,
+    }
+
+    /// Minimal Cassandra unsigned-VInt length prefix for small values (< 128 fit
+    /// in a single byte, which is all the fixed collection buffers here need).
+    fn vlen(n: u64) -> Vec<u8> {
+        assert!(n < 0x80, "vlen helper only encodes single-byte lengths");
+        vec![n as u8]
+    }
+
+    /// Assemble a `list`/`set` body: element count then per-element (vlen, bytes).
+    fn collection_of_ints(vals: &[i32]) -> Vec<u8> {
+        let mut buf = vlen(vals.len() as u64);
+        for v in vals {
+            buf.extend_from_slice(&vlen(4));
+            buf.extend_from_slice(&v.to_be_bytes());
+        }
+        buf
+    }
+
+    /// Assemble a `map<text,text>` body: entry count then per-entry
+    /// (vlen(key), key, vlen(val), val).
+    fn map_text_text(entries: &[(&str, &str)]) -> Vec<u8> {
+        let mut buf = vlen(entries.len() as u64);
+        for (k, v) in entries {
+            buf.extend_from_slice(&vlen(k.len() as u64));
+            buf.extend_from_slice(k.as_bytes());
+            buf.extend_from_slice(&vlen(v.len() as u64));
+            buf.extend_from_slice(v.as_bytes());
+        }
+        buf
+    }
+
+    /// Assemble a `tuple`/UDT body: per-field 4-byte BE i32 length then field bytes
+    /// (Cassandra `TupleType`/`UserType` wire format; -1 = null, unused here).
+    fn tuple_int_text(i: i32, s: &str) -> Vec<u8> {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&4i32.to_be_bytes());
+        buf.extend_from_slice(&i.to_be_bytes());
+        buf.extend_from_slice(&(s.len() as i32).to_be_bytes());
+        buf.extend_from_slice(s.as_bytes());
+        buf
+    }
+
+    /// Cassandra DATE wire form for `days` since epoch (offset by i32::MIN for
+    /// byte-order comparability); the decoder inverts with `wrapping_add`.
+    fn date_bytes(days: i32) -> Vec<u8> {
+        (days as u32)
+            .wrapping_sub(i32::MIN as u32)
+            .to_be_bytes()
+            .to_vec()
+    }
+
+    /// The full per-type case set routed through the live decode entry.
+    fn type_cases() -> Vec<TypeCase> {
+        vec![
+            TypeCase {
+                name: "boolean",
+                data_type: "boolean".into(),
+                buf: vec![1],
+                matches: |v| matches!(v, Value::Boolean(_)),
+            },
+            TypeCase {
+                name: "tinyint",
+                data_type: "tinyint".into(),
+                buf: vec![42],
+                matches: |v| matches!(v, Value::TinyInt(_)),
+            },
+            TypeCase {
+                name: "smallint",
+                data_type: "smallint".into(),
+                buf: 4200i16.to_be_bytes().to_vec(),
+                matches: |v| matches!(v, Value::SmallInt(_)),
+            },
+            TypeCase {
+                name: "int",
+                data_type: "int".into(),
+                buf: 42i32.to_be_bytes().to_vec(),
+                matches: |v| matches!(v, Value::Integer(_)),
+            },
+            TypeCase {
+                name: "bigint",
+                data_type: "bigint".into(),
+                buf: 42i64.to_be_bytes().to_vec(),
+                matches: |v| matches!(v, Value::BigInt(_)),
+            },
+            TypeCase {
+                name: "counter",
+                data_type: "counter".into(),
+                buf: 7i64.to_be_bytes().to_vec(),
+                matches: |v| matches!(v, Value::Counter(_)),
+            },
+            TypeCase {
+                name: "float",
+                data_type: "float".into(),
+                buf: 1.5f32.to_be_bytes().to_vec(),
+                matches: |v| matches!(v, Value::Float32(_)),
+            },
+            TypeCase {
+                name: "double",
+                data_type: "double".into(),
+                buf: 2.5f64.to_be_bytes().to_vec(),
+                matches: |v| matches!(v, Value::Float(_)),
+            },
+            TypeCase {
+                name: "text",
+                data_type: "text".into(),
+                buf: b"hello".to_vec(),
+                matches: |v| matches!(v, Value::Text(_)),
+            },
+            TypeCase {
+                name: "varchar",
+                data_type: "varchar".into(),
+                buf: b"hello".to_vec(),
+                matches: |v| matches!(v, Value::Text(_)),
+            },
+            TypeCase {
+                name: "ascii",
+                data_type: "ascii".into(),
+                buf: b"hello".to_vec(),
+                matches: |v| matches!(v, Value::Text(_)),
+            },
+            TypeCase {
+                name: "blob",
+                data_type: "blob".into(),
+                buf: vec![0xde, 0xad, 0xbe, 0xef],
+                matches: |v| matches!(v, Value::Blob(_)),
+            },
+            TypeCase {
+                name: "timestamp",
+                data_type: "timestamp".into(),
+                buf: 1_700_000_000_000i64.to_be_bytes().to_vec(),
+                matches: |v| matches!(v, Value::Timestamp(_)),
+            },
+            TypeCase {
+                name: "date",
+                data_type: "date".into(),
+                buf: date_bytes(19_500),
+                matches: |v| matches!(v, Value::Date(_)),
+            },
+            TypeCase {
+                name: "time",
+                data_type: "time".into(),
+                buf: 45_000_000_000i64.to_be_bytes().to_vec(),
+                matches: |v| matches!(v, Value::Time(_)),
+            },
+            TypeCase {
+                name: "uuid",
+                data_type: "uuid".into(),
+                buf: (0u8..16).collect(),
+                matches: |v| matches!(v, Value::Uuid(_)),
+            },
+            TypeCase {
+                name: "timeuuid",
+                data_type: "timeuuid".into(),
+                buf: (0u8..16).collect(),
+                matches: |v| matches!(v, Value::Uuid(_)),
+            },
+            TypeCase {
+                name: "inet",
+                data_type: "inet".into(),
+                buf: vec![10, 0, 0, 1],
+                matches: |v| matches!(v, Value::Inet(_)),
+            },
+            TypeCase {
+                name: "varint",
+                data_type: "varint".into(),
+                buf: vec![0x01, 0x02, 0x03],
+                matches: |v| matches!(v, Value::Varint(_)),
+            },
+            TypeCase {
+                name: "decimal",
+                // 4-byte scale (=2) + variable-length unscaled value.
+                data_type: "decimal".into(),
+                buf: {
+                    let mut b = 2i32.to_be_bytes().to_vec();
+                    b.extend_from_slice(&[0x30, 0x39]); // unscaled 12345
+                    b
+                },
+                matches: |v| matches!(v, Value::Decimal { .. }),
+            },
+            TypeCase {
+                name: "duration",
+                // Three ZigZag VInts (months, days, nanos); all zero => three 0x00.
+                data_type: "duration".into(),
+                buf: vec![0, 0, 0],
+                matches: |v| matches!(v, Value::Duration { .. }),
+            },
+            TypeCase {
+                name: "json",
+                data_type: "json".into(),
+                buf: b"[1,2,3]".to_vec(),
+                matches: |v| matches!(v, Value::Json(_)),
+            },
+            TypeCase {
+                name: "list",
+                data_type: "list<int>".into(),
+                buf: collection_of_ints(&[1, 2, 3]),
+                matches: |v| matches!(v, Value::List(_)),
+            },
+            TypeCase {
+                name: "set",
+                data_type: "set<int>".into(),
+                buf: collection_of_ints(&[10, 20]),
+                matches: |v| matches!(v, Value::Set(_)),
+            },
+            TypeCase {
+                name: "map",
+                data_type: "map<text,text>".into(),
+                buf: map_text_text(&[("k1", "v1"), ("k2", "v2")]),
+                matches: |v| matches!(v, Value::Map(_)),
+            },
+            TypeCase {
+                name: "tuple",
+                data_type: "tuple<int,text>".into(),
+                buf: tuple_int_text(42, "hi"),
+                matches: |v| matches!(v, Value::Tuple(_)),
+            },
+            TypeCase {
+                // UDT-class decode via its structural twin `tuple` — see module doc:
+                // the string entry cannot construct a `ComparatorType::Udt`.
+                name: "udt",
+                data_type: "tuple<int,text,int>".into(),
+                buf: {
+                    let mut b = tuple_int_text(1, "name");
+                    b.extend_from_slice(&4i32.to_be_bytes());
+                    b.extend_from_slice(&2i32.to_be_bytes());
+                    b
+                },
+                matches: |v| matches!(v, Value::Tuple(_)),
+            },
+            TypeCase {
+                name: "frozen",
+                data_type: "frozen<list<int>>".into(),
+                buf: collection_of_ints(&[1, 2, 3]),
+                matches: |v| matches!(v, Value::Frozen(_)),
+            },
+        ]
+    }
+
+    /// Locate the `-Data.db` component inside the SIMPLE fixture directory.
+    fn simple_data_db() -> std::path::PathBuf {
+        let dir = fixtures::table_dir(
+            fixtures::ReadFixture::SIMPLE.keyspace,
+            fixtures::ReadFixture::SIMPLE.table,
+        );
+        std::fs::read_dir(&dir)
+            .unwrap_or_else(|e| panic!("read fixture dir {}: {e}", dir.display()))
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .find(|p| {
+                p.file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|n| n.ends_with("-Data.db"))
+                    .unwrap_or(false)
+            })
+            .unwrap_or_else(|| {
+                panic!(
+                    "no -Data.db under {} — fetch fixtures: bash test-data/scripts/fetch-datasets.sh",
+                    dir.display()
+                )
+            })
+    }
+
+    /// Open one real SIMPLE reader as the `&self` decode context. Panics with an
+    /// actionable message if the fixture is absent (per-type benches require it).
+    fn open_simple_reader(rt: &tokio::runtime::Runtime) -> SSTableReader {
+        let path = simple_data_db();
+        let config = Config::default();
+        let platform = Arc::new(
+            rt.block_on(Platform::new(&config))
+                .expect("init platform for decode bench"),
+        );
+        rt.block_on(SSTableReader::open(&path, &config, platform))
+            .expect("open SIMPLE reader for decode bench")
+    }
+
+    /// `decode/type_<name>` — per-CQL-type decode through the live entry.
+    pub fn bench_types(c: &mut Criterion) {
+        if !fixtures::fixture_present(&fixtures::ReadFixture::SIMPLE) {
+            eprintln!("decode/type_*: SIMPLE fixture absent — skip-register (no group)");
+            return;
+        }
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        let reader = open_simple_reader(&rt);
+        let cases = type_cases();
+
+        // Wiring evidence: every case must decode through the live entry to the
+        // expected variant BEFORE we measure, so a no-op / wrong-path decode
+        // fails loudly rather than benching nothing.
+        for case in &cases {
+            let decoded = reader
+                .decode_value_for_bench(&case.buf, &case.data_type)
+                .unwrap_or_else(|e| panic!("decode/type_{}: live entry errored: {e}", case.name));
+            assert!(
+                (case.matches)(&decoded),
+                "decode/type_{}: unexpected Value variant {decoded:?} (wrong decode path?)",
+                case.name
+            );
+        }
+
+        let mut group = c.benchmark_group("decode");
+        for case in &cases {
+            let name = format!("type_{}", case.name);
+            group.bench_function(&name, |bch| {
+                bch.iter(|| {
+                    let v = reader
+                        .decode_value_for_bench(black_box(&case.buf), black_box(&case.data_type))
+                        .expect("decode value");
+                    black_box(v)
+                });
+            });
+        }
+        group.finish();
+    }
+
+    /// A fixed set of ~20 primitive typed columns (name is documentary only).
+    fn wide_primitive_columns() -> Vec<(String, Vec<u8>)> {
+        vec![
+            ("int".into(), 42i32.to_be_bytes().to_vec()),
+            ("int".into(), (-7i32).to_be_bytes().to_vec()),
+            ("bigint".into(), 42i64.to_be_bytes().to_vec()),
+            ("bigint".into(), 9_000_000_000i64.to_be_bytes().to_vec()),
+            ("smallint".into(), 300i16.to_be_bytes().to_vec()),
+            ("tinyint".into(), vec![9]),
+            ("boolean".into(), vec![1]),
+            ("boolean".into(), vec![0]),
+            ("float".into(), 1.5f32.to_be_bytes().to_vec()),
+            ("double".into(), 2.5f64.to_be_bytes().to_vec()),
+            ("uuid".into(), (0u8..16).collect()),
+            ("timeuuid".into(), (16u8..32).collect()),
+            (
+                "timestamp".into(),
+                1_700_000_000_000i64.to_be_bytes().to_vec(),
+            ),
+            ("date".into(), date_bytes(19_500)),
+            ("time".into(), 45_000_000_000i64.to_be_bytes().to_vec()),
+            ("counter".into(), 5i64.to_be_bytes().to_vec()),
+            ("int".into(), 12345i32.to_be_bytes().to_vec()),
+            ("bigint".into(), (-1i64).to_be_bytes().to_vec()),
+            ("smallint".into(), (-2i16).to_be_bytes().to_vec()),
+            ("boolean".into(), vec![1]),
+        ]
+    }
+
+    /// A `text`/`blob`-dominated column set (K5/K6 measurement).
+    fn text_heavy_columns() -> Vec<(String, Vec<u8>)> {
+        let text = |s: &str| ("text".to_string(), s.as_bytes().to_vec());
+        vec![
+            text("alpha"),
+            text("bravo"),
+            text("charlie the quick brown fox jumped"),
+            text("delta"),
+            text("echo foxtrot golf hotel"),
+            ("varchar".into(), b"india".to_vec()),
+            ("ascii".into(), b"juliet".to_vec()),
+            ("blob".into(), vec![0u8; 32]),
+            ("blob".into(), vec![0xab; 64]),
+            text("kilo lima mike november oscar papa"),
+        ]
+    }
+
+    /// Time `iters` decodes of the full `cols` set and record rows/sec + ns/row to
+    /// the unified ledger (best-effort — a ledger failure never aborts the bench).
+    fn record_throughput(
+        reader: &SSTableReader,
+        metric_prefix: &str,
+        cols: &[(String, Vec<u8>)],
+        iters: u64,
+    ) {
+        let start = std::time::Instant::now();
+        for _ in 0..iters {
+            for (dt, buf) in cols {
+                let v = reader
+                    .decode_value_for_bench(buf, dt)
+                    .expect("decode column");
+                black_box(v);
+            }
+        }
+        let elapsed = start.elapsed().as_secs_f64();
+        if elapsed <= 0.0 {
+            return;
+        }
+        let rows_per_sec = iters as f64 / elapsed;
+        let ns_per_row = elapsed * 1e9 / iters as f64;
+        let m_rps = format!("{metric_prefix}/rows_per_sec");
+        let m_nspr = format!("{metric_prefix}/ns_per_row");
+        if let Err(e) = bench_ledger::append_metrics(
+            "decode",
+            &[
+                (m_rps.as_str(), rows_per_sec, "rows_per_sec"),
+                (m_nspr.as_str(), ns_per_row, "ns"),
+            ],
+        ) {
+            eprintln!(
+                "decode: could not append unified ledger {}: {e}",
+                bench_ledger::ledger_path().display()
+            );
+        }
+    }
+
+    /// Decode all `cols` `ROWS` times per iteration; `Throughput::Elements(ROWS)`.
+    fn bench_row_set(
+        c: &mut Criterion,
+        reader: &SSTableReader,
+        bench: &str,
+        cols: &[(String, Vec<u8>)],
+    ) {
+        // Wiring evidence + one recorded ledger pass before measuring.
+        for (dt, buf) in cols {
+            reader
+                .decode_value_for_bench(buf, dt)
+                .unwrap_or_else(|e| panic!("decode/{bench}: column {dt} errored: {e}"));
+        }
+        record_throughput(reader, bench, cols, ROWS);
+
+        let mut group = c.benchmark_group("decode");
+        group.throughput(Throughput::Elements(ROWS));
+        group.bench_function(bench, |bch| {
+            bch.iter(|| {
+                for _ in 0..ROWS {
+                    for (dt, buf) in cols {
+                        let v = reader
+                            .decode_value_for_bench(black_box(buf), black_box(dt))
+                            .expect("decode column");
+                        black_box(v);
+                    }
+                }
+            });
+        });
+        group.finish();
+    }
+
+    /// `decode/wide_row_primitives` — rows/sec over a wide all-primitive row.
+    pub fn bench_wide_row_primitives(c: &mut Criterion) {
+        if !fixtures::fixture_present(&fixtures::ReadFixture::SIMPLE) {
+            eprintln!("decode/wide_row_primitives: SIMPLE fixture absent — skip-register");
+            return;
+        }
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        let reader = open_simple_reader(&rt);
+        bench_row_set(c, &reader, "wide_row_primitives", &wide_primitive_columns());
+    }
+
+    /// `decode/text_heavy` — rows/sec over a text/blob-dominated column set.
+    pub fn bench_text_heavy(c: &mut Criterion) {
+        if !fixtures::fixture_present(&fixtures::ReadFixture::SIMPLE) {
+            eprintln!("decode/text_heavy: SIMPLE fixture absent — skip-register");
+            return;
+        }
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        let reader = open_simple_reader(&rt);
+        bench_row_set(c, &reader, "text_heavy", &text_heavy_columns());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// criterion_group! / criterion_main! — gated so the target builds an empty but
+// valid main without BOTH cli-helpers and bench-internals (mirrors read.rs).
+// ---------------------------------------------------------------------------
+
+#[cfg(all(feature = "cli-helpers", feature = "bench-internals"))]
+criterion_group!(
+    name = benches;
+    config = profiling::configure();
+    targets = decode_impl::bench_types,
+              decode_impl::bench_wide_row_primitives,
+              decode_impl::bench_text_heavy
+);
+
+#[cfg(not(all(feature = "cli-helpers", feature = "bench-internals")))]
+fn bench_noop(_c: &mut criterion::Criterion) {
+    // Without both cli-helpers and bench-internals there is no reader/shim to
+    // drive; the target still compiles and runs, reporting no measurements.
+    eprintln!(
+        "decode: requires --features cli-helpers,bench-internals; nothing to measure. \
+         Run: cargo bench -p cqlite-core --features cli-helpers,bench-internals --bench decode"
+    );
+}
+
+#[cfg(not(all(feature = "cli-helpers", feature = "bench-internals")))]
+criterion_group!(
+    name = benches;
+    config = profiling::configure();
+    targets = bench_noop
+);
+
+criterion_main!(benches);

--- a/cqlite-core/benches/fixtures/mod.rs
+++ b/cqlite-core/benches/fixtures/mod.rs
@@ -173,6 +173,19 @@ impl ReadFixture {
         schema_file: "collections.cql",
     };
 
+    /// `test_wide_rows.many_columns_table` — one `UUID` PK + `col_001..col_100`
+    /// spanning every CQL primitive plus collections (text/int/bigint/float/double/
+    /// boolean/timestamp/uuid/blob/decimal/set/list/map/inet/date/time/duration/
+    /// timeuuid/varchar/ascii/tinyint/smallint). The widest real fixture; the
+    /// allocations-per-row / per-cell budget target (issue #1615). **Optional** —
+    /// not present in every checkout, so callers must guard on [`fixture_present`]
+    /// and fall back to [`Self::SIMPLE`] (or SKIP) when absent.
+    pub const MANY_COLUMNS: ReadFixture = ReadFixture {
+        keyspace: "test_wide_rows",
+        table: "many_columns_table",
+        schema_file: "wide-rows.cql",
+    };
+
     /// Fully-qualified `keyspace.table` for use in CQL queries.
     pub fn qualified(&self) -> String {
         format!("{}.{}", self.keyspace, self.table)

--- a/cqlite-core/benches/perf-gate.json
+++ b/cqlite-core/benches/perf-gate.json
@@ -32,6 +32,16 @@
       "threshold_pct": 10
     },
     {
+      "id": "decode/wide_row_primitives",
+      "threshold_pct": 10,
+      "_note": "issue #1615 (Epic H) — rows/sec decoding a wide all-primitive row through the live block-path entry"
+    },
+    {
+      "id": "decode/text_heavy",
+      "threshold_pct": 10,
+      "_note": "issue #1615 (Epic H) — rows/sec decoding a text/blob-dominated column set (K5/K6)"
+    },
+    {
       "id": "write/ingest_wal_off",
       "threshold_pct": 10
     },

--- a/cqlite-core/src/storage/sstable/reader/parsing/bench_shim.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/bench_shim.rs
@@ -1,0 +1,27 @@
+//! Bench-only decode shim (issue #1615, Epic H).
+//!
+//! `SSTableReader::parse_value_with_schema_type` — the live block-path value
+//! decode entry — is `pub(in crate::storage::sstable::reader)`, so the `decode`
+//! bench (`cqlite-core/benches/decode_bench.rs`, an external crate) cannot call it
+//! directly. This module adds ONE `#[doc(hidden)]`, `bench-internals`-gated public
+//! forwarder so the bench measures the REAL dispatch rather than a re-implemented
+//! copy that would drift from production.
+//!
+//! It is compiled only when the non-default `bench-internals` feature is on
+//! (`#[cfg(feature = "bench-internals")] mod bench_shim;` in the parent module), so
+//! every default build / gate / CI run is byte-identical and the public API is
+//! unchanged. It lives in its own tiny file so `value_parsing.rs` stays within the
+//! source file-size ratchet (campsite rule).
+
+use super::super::types::SSTableReader;
+use crate::{Result, Value};
+
+impl SSTableReader {
+    /// Bench-only forwarder to the crate-private block-path decode entry
+    /// [`parse_value_with_schema_type`](SSTableReader::parse_value_with_schema_type),
+    /// forwarding its arguments verbatim. Adds no behavior of its own.
+    #[doc(hidden)]
+    pub fn decode_value_for_bench(&self, value_data: &[u8], data_type: &str) -> Result<Value> {
+        self.parse_value_with_schema_type(value_data, data_type)
+    }
+}

--- a/cqlite-core/src/storage/sstable/reader/parsing/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/mod.rs
@@ -8,6 +8,13 @@
 //! - Collection types (list, set, map, tuple, UDT)
 
 // Sub-modules
+// Bench-only decode shim (issue #1615, Epic H). Compiled only under
+// `bench-internals`; adds one `#[doc(hidden)] pub fn decode_value_for_bench` on
+// `SSTableReader` so the external `decode` bench can measure the real block-path
+// decode dispatch without widening the default public API. Lives in its own tiny
+// module so value_parsing.rs stays within the source file-size ratchet.
+#[cfg(feature = "bench-internals")]
+mod bench_shim;
 mod block_entries;
 pub(crate) mod byte_comparable; // Needs to be accessible from row_cell_state_machine
 pub(crate) mod comparator_value_parsing; // Standalone comparator-based parsing for state machine

--- a/cqlite-core/src/storage/sstable/reader/parsing/value_parsing.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/value_parsing.rs
@@ -495,6 +495,21 @@ impl SSTableReader {
         }
     }
 
+    /// Bench-only forwarder to the crate-private block-path decode entry
+    /// [`parse_value_with_schema_type`](Self::parse_value_with_schema_type).
+    ///
+    /// `parse_value_with_schema_type` is `pub(in crate::storage::sstable::reader)`,
+    /// so the `decode` bench (issue #1615, Epic H) — an external crate — cannot call
+    /// it directly. This shim exposes the REAL dispatch (not a re-implemented copy)
+    /// through a single `#[doc(hidden)]`, non-default, `bench-internals`-gated symbol,
+    /// forwarding its arguments verbatim. It adds no behavior: with the feature off it
+    /// does not exist and the public API is unchanged.
+    #[cfg(feature = "bench-internals")]
+    #[doc(hidden)]
+    pub fn decode_value_for_bench(&self, value_data: &[u8], data_type: &str) -> Result<Value> {
+        self.parse_value_with_schema_type(value_data, data_type)
+    }
+
     /// Parse value directly using ComparatorType (helper method for nested collection elements)
     ///
     /// This function provides complete recursive type parsing for collection elements,

--- a/cqlite-core/src/storage/sstable/reader/parsing/value_parsing.rs
+++ b/cqlite-core/src/storage/sstable/reader/parsing/value_parsing.rs
@@ -495,21 +495,6 @@ impl SSTableReader {
         }
     }
 
-    /// Bench-only forwarder to the crate-private block-path decode entry
-    /// [`parse_value_with_schema_type`](Self::parse_value_with_schema_type).
-    ///
-    /// `parse_value_with_schema_type` is `pub(in crate::storage::sstable::reader)`,
-    /// so the `decode` bench (issue #1615, Epic H) — an external crate — cannot call
-    /// it directly. This shim exposes the REAL dispatch (not a re-implemented copy)
-    /// through a single `#[doc(hidden)]`, non-default, `bench-internals`-gated symbol,
-    /// forwarding its arguments verbatim. It adds no behavior: with the feature off it
-    /// does not exist and the public API is unchanged.
-    #[cfg(feature = "bench-internals")]
-    #[doc(hidden)]
-    pub fn decode_value_for_bench(&self, value_data: &[u8], data_type: &str) -> Result<Value> {
-        self.parse_value_with_schema_type(value_data, data_type)
-    }
-
     /// Parse value directly using ComparatorType (helper method for nested collection elements)
     ///
     /// This function provides complete recursive type parsing for collection elements,

--- a/cqlite-core/tests/memory_budget.rs
+++ b/cqlite-core/tests/memory_budget.rs
@@ -104,18 +104,29 @@ fn select_full_scan_alloc_budget() {
     );
 }
 
-/// allocations-per-row ceiling for a full `SELECT *` over the widest real fixture,
+/// Per-fixture allocations-per-row / per-cell ceilings for a full `SELECT *`,
 /// pinned at the current-main measured value plus variance slack (a ratchet Epic
 /// J/K children lower as the O(rows×cols) transient-string dispatch is fixed).
 ///
-/// MEASURED on `main` today (test_wide_rows.many_columns_table): total_blocks=2282,
-/// rows=50, cols=8 (populated columns in the first row) → allocs/row=45.6,
-/// allocs/cell=5.7. Ceiling = measured allocs/row + ~30% slack for
-/// allocator/toolchain/platform variance (block counts differ slightly by std/OS).
-const CEILING_ALLOCS_PER_ROW: f64 = 60.0;
-
-/// allocations-per-cell ceiling for the same full scan; measured 5.7 → +~35% slack.
-const CEILING_ALLOCS_PER_CELL: f64 = 8.0;
+/// Two fixtures are supported so the budget still runs when the optional wide
+/// fixture is absent, and each gets its OWN ceiling so neither ratchet is loosened
+/// by the other's very different shape (allocs/cell in particular scales inversely
+/// with column count):
+///
+/// - `many_columns_table` (preferred, wide): MEASURED total_blocks=2282, rows=50,
+///   cols=8 (populated columns in the first row) → allocs/row=45.6, allocs/cell=5.7.
+/// - `simple_table` (CI-guaranteed fallback): MEASURED total_blocks≈60337/scan,
+///   rows=999, cols=5 → allocs/row≈60.4, allocs/cell≈12.1.
+///
+/// Ceilings add ~25-35% slack for allocator/toolchain/platform variance (block
+/// counts differ slightly by std/OS). Returns `(per_row, per_cell)`.
+fn alloc_ceilings(fx: &fixtures::ReadFixture) -> (f64, f64) {
+    if fx.table == fixtures::ReadFixture::MANY_COLUMNS.table {
+        (60.0, 8.0) // measured 45.6 / 5.7
+    } else {
+        (78.0, 16.0) // SIMPLE fallback: measured 60.4 / 12.1
+    }
+}
 
 /// allocations-per-row and allocations-per-cell for a full-table `SELECT *` driven
 /// through the real public query path over the widest real fixture must stay within
@@ -139,6 +150,7 @@ fn select_full_scan_alloc_per_row_budget() {
         eprintln!("alloc_per_row_budget: no wide fixture present — skipping (skip-register)");
         return;
     };
+    let (ceiling_per_row, ceiling_per_cell) = alloc_ceilings(&fx);
     let sql = format!("SELECT * FROM {}", fx.qualified());
 
     // Open BEFORE the profiler so fixture-copy/ingest allocations are excluded and
@@ -184,19 +196,19 @@ fn select_full_scan_alloc_per_row_budget() {
     );
 
     assert!(
-        allocs_per_row <= CEILING_ALLOCS_PER_ROW,
+        allocs_per_row <= ceiling_per_row,
         "allocs/row {:.1} exceeded ceiling {:.1} (fixture {}, {} rows × {} cols)",
         allocs_per_row,
-        CEILING_ALLOCS_PER_ROW,
+        ceiling_per_row,
         fx.qualified(),
         rows,
         cols
     );
     assert!(
-        allocs_per_cell <= CEILING_ALLOCS_PER_CELL,
+        allocs_per_cell <= ceiling_per_cell,
         "allocs/cell {:.1} exceeded ceiling {:.1} (fixture {}, {} rows × {} cols)",
         allocs_per_cell,
-        CEILING_ALLOCS_PER_CELL,
+        ceiling_per_cell,
         fx.qualified(),
         rows,
         cols

--- a/cqlite-core/tests/memory_budget.rs
+++ b/cqlite-core/tests/memory_budget.rs
@@ -104,6 +104,105 @@ fn select_full_scan_alloc_budget() {
     );
 }
 
+/// allocations-per-row ceiling for a full `SELECT *` over the widest real fixture,
+/// pinned at the current-main measured value plus variance slack (a ratchet Epic
+/// J/K children lower as the O(rows×cols) transient-string dispatch is fixed).
+///
+/// MEASURED on `main` today (test_wide_rows.many_columns_table): total_blocks=2282,
+/// rows=50, cols=8 (populated columns in the first row) → allocs/row=45.6,
+/// allocs/cell=5.7. Ceiling = measured allocs/row + ~30% slack for
+/// allocator/toolchain/platform variance (block counts differ slightly by std/OS).
+const CEILING_ALLOCS_PER_ROW: f64 = 60.0;
+
+/// allocations-per-cell ceiling for the same full scan; measured 5.7 → +~35% slack.
+const CEILING_ALLOCS_PER_CELL: f64 = 8.0;
+
+/// allocations-per-row and allocations-per-cell for a full-table `SELECT *` driven
+/// through the real public query path over the widest real fixture must stay within
+/// their pinned ceilings (issue #1615, Epic H). Fails closed: a present-but-empty
+/// fixture panics; an entirely-absent optional fixture SKIPs.
+#[test]
+#[serial_test::serial]
+fn select_full_scan_alloc_per_row_budget() {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+
+    // Prefer the widest fixture (every CQL type, 100 columns); fall back to the
+    // CI-guaranteed SIMPLE fixture; SKIP only if neither is present.
+    let fx = if fixtures::fixture_present(&fixtures::ReadFixture::MANY_COLUMNS) {
+        fixtures::ReadFixture::MANY_COLUMNS
+    } else if fixtures::fixture_present(&fixtures::ReadFixture::SIMPLE) {
+        eprintln!(
+            "alloc_per_row_budget: many_columns_table absent — falling back to SIMPLE fixture"
+        );
+        fixtures::ReadFixture::SIMPLE
+    } else {
+        eprintln!("alloc_per_row_budget: no wide fixture present — skipping (skip-register)");
+        return;
+    };
+    let sql = format!("SELECT * FROM {}", fx.qualified());
+
+    // Open BEFORE the profiler so fixture-copy/ingest allocations are excluded and
+    // only the read path is attributed (mirrors the other budgets in this file).
+    let loaded = fixtures::open_read_db(&fx);
+
+    let _profiler = dhat::Profiler::builder().testing().build();
+
+    let result = rt
+        .block_on(loaded.db.execute(&sql))
+        .expect("wide full-scan query");
+
+    // Fail closed: a present fixture that yields no rows is a broken measurement,
+    // never a silent 0-row pass.
+    assert!(
+        !result.rows.is_empty(),
+        "zero rows from {} — fixtures not fetched or fixture broken? \
+         Run: bash test-data/scripts/fetch-datasets.sh",
+        fx.qualified()
+    );
+
+    let rows = result.rows.len();
+    // Column count is read from the data, never hardcoded (fixture-independent).
+    let cols = result.rows[0].values.len();
+    assert!(
+        cols > 0,
+        "first row of {} decoded zero columns",
+        fx.qualified()
+    );
+
+    let stats = dhat::HeapStats::get();
+    let allocs_per_row = stats.total_blocks as f64 / rows as f64;
+    let allocs_per_cell = stats.total_blocks as f64 / (rows as f64 * cols as f64);
+    println!(
+        "select_full_scan_alloc_per_row_budget: fixture={} total_blocks={} rows={} cols={} \
+         allocs_per_row={:.1} allocs_per_cell={:.1}",
+        fx.qualified(),
+        stats.total_blocks,
+        rows,
+        cols,
+        allocs_per_row,
+        allocs_per_cell
+    );
+
+    assert!(
+        allocs_per_row <= CEILING_ALLOCS_PER_ROW,
+        "allocs/row {:.1} exceeded ceiling {:.1} (fixture {}, {} rows × {} cols)",
+        allocs_per_row,
+        CEILING_ALLOCS_PER_ROW,
+        fx.qualified(),
+        rows,
+        cols
+    );
+    assert!(
+        allocs_per_cell <= CEILING_ALLOCS_PER_CELL,
+        "allocs/cell {:.1} exceeded ceiling {:.1} (fixture {}, {} rows × {} cols)",
+        allocs_per_cell,
+        CEILING_ALLOCS_PER_CELL,
+        fx.qualified(),
+        rows,
+        cols
+    );
+}
+
 /// Peak heap bytes for a materializing type-heavy `SELECT *` must stay within
 /// the pinned ceiling AND under the project's 128 MiB budget.
 #[test]

--- a/openspec/changes/decode-benches/design.md
+++ b/openspec/changes/decode-benches/design.md
@@ -1,0 +1,68 @@
+## Context
+
+Finding H2 wants decode cost pinned three ways: per-type ns/op, wide-row rows/sec, and
+allocations-per-row / per-cell. The two hard constraints are (1) benches must exercise the **real** live
+decode entry (`SSTableReader::parse_value_with_schema_type`), not a copy, and (2) the change must be
+green at landing (ratchet) while faithfully showing today's bad allocation number.
+
+## Key decisions
+
+### D1 — Reach the crate-private decode entry via an opt-in `#[doc(hidden)]` shim, not a copy
+`parse_value_with_schema_type` is `pub(in crate::storage::sstable::reader)`; a bench is an external
+crate. Options: (a) re-implement the dispatch in the bench — rejected, it measures a different code path
+and rots; (b) make the entry `pub` — rejected, it leaks parser internals into the stable API; (c) add an
+empty `bench-internals` feature guarding a `#[doc(hidden)] pub fn decode_value_for_bench` that forwards
+verbatim. **Chose (c)**: the real dispatch is measured, the surface is invisible (`#[doc(hidden)]`,
+non-default feature), and default builds are byte-identical.
+
+### D2 — Real opened reader supplies `&self`; per-type buffers are fixed literals
+The scalar arms are `self`-independent, but the collection/UDT/tuple/frozen arms recurse via `&self` and
+read `self.header.cassandra_version`. So the bench opens one real, CI-present V5 fixture reader (`SIMPLE`,
+`test_basic.simple_table`, already vendored + used by A4) once, outside the measured region, and reuses it
+as the decode context. The per-type byte buffers are fixed representative literals constructed in the
+bench (e.g. `42i32.to_be_bytes()`, a short UTF-8 text, a 16-byte UUID, an assembled `list<int>` /
+`map<text,text>` / tuple / frozen buffer). This keeps the per-type bench deterministic and independent of
+any single fixture's column set, while still routing every decode through the live entry.
+
+### D3 — Two throughput benches are the STRICT criterion gate; per-type entries are advisory
+`decode/wide_row_primitives` (assemble a fixed ~20-primitive-column row buffer set, decode all columns in
+a loop, `Throughput::Elements(rows)`) and `decode/text_heavy` (a text/blob-dominated block) are the two
+STRICT `perf-gate.json` entries (≥10% median-regression). The many per-type `decode/type_<name>` benches
+are numerous, tiny, and individually noisy — they are recorded (ledger) and left out of the STRICT set to
+avoid flaky gating; their value is longitudinal tracking, not per-PR gating. This mirrors the existing
+advisory/strict split.
+
+### D4 — allocs/row + allocs/cell live in the A4 dhat lane, over REAL data, as absolute ratchets
+The criterion gate is a *relative* PR-vs-base delta; an absolute allocation budget belongs in the dhat
+lane (`memory_budget.rs`, `#[cfg(all(feature = "dhat-heap", feature = "cli-helpers"))]`,
+`--test-threads=1`, `#[serial_test::serial]`). The budget drives the real public path
+(`Database::execute("SELECT * …")`) over a wide real fixture — consistent with CQLite's "integration
+tests use real SSTable data only" and A4's existing pattern — starts the profiler AFTER `open_read_db`
+(so fixture-copy/ingest allocations are excluded), and computes:
+- allocs/row  = `total_blocks / row_count`
+- allocs/cell = `total_blocks / (row_count * column_count)`
+It asserts each ≤ a pinned ceiling = **current-main measured value + variance slack**, and fails closed
+(panics) if the fixture is present but yields 0 rows. The wide real fixture is `many_columns_table`
+(`test_wide_rows`, 100 columns spanning every CQL type) when present, else the CI-guaranteed `SIMPLE`
+fixture — selected via the existing `fixtures::fixture_present` guard so an absent optional fixture SKIPs
+rather than fails, but a present-but-empty one panics.
+
+### D5 — perf-regression.yml: guard the new bench like `compaction`
+`--bench decode` is added to the PR bench run and, guarded by `[[ -f cqlite-core/benches/decode_bench.rs ]]`,
+to the base (main) run. `check_perf_regression.py` already SKIPs any gated id missing from the base
+baseline, so the first landing (no base data) stays green; subsequent PRs gate normally.
+
+## Red-run (honest failing evidence)
+
+The allocs/row budget is the honest part: today's dispatch allocates O(rows×cols) transient strings
+(finding J1). The PR records the measured allocs/row and demonstrates that setting the ceiling below the
+measured value makes the `memory-budget` lane RED (non-zero exit) — proving the budget catches a
+regression — then restores the ceiling to the ratchet value so the gate is green at landing.
+
+## Risks / mitigations
+
+- **Per-type bench needs a fixture reader** → use `SIMPLE` (CI-guaranteed, already used by A4); skip
+  gracefully only if entirely absent, panic if present-but-broken.
+- **dhat lane is process-global** → reuse A4's `#[serial_test::serial]` + `--test-threads=1` discipline.
+- **Ledger write failure** → best-effort; log to stderr, never fail the bench (existing `bench_ledger`
+  contract).

--- a/openspec/changes/decode-benches/proposal.md
+++ b/openspec/changes/decode-benches/proposal.md
@@ -1,0 +1,70 @@
+## Why
+
+Nothing pins decode-level cost. The existing `read/type_heavy` perf-gate entry exercises the real v5
+read path (good) but there is **no per-CQL-type decode bench, no rows/sec floor for wide all-primitive
+rows, and no allocations-per-row / allocations-per-cell budget**. The July 2026 parser audit
+(`docs/reports/parser-performance-audit-2026-07-01.md`, finding H2, audit block 2) calls this out:
+Epics J and K claim large decode/allocation wins, and without these benches those claims are
+unverifiable and their regressions invisible.
+
+This is Epic H (#1601) "measurement + safety net", Wave 1 (measurement train). Design-driven
+measurement-harness work — Seam-1 pre-approved for the batch. It coordinates with (and reuses) the
+already-landed Epic A machinery: the criterion perf-gate (`perf-gate.json` +
+`scripts/ci/check_perf_regression.py` + `.github/workflows/perf-regression.yml`), the unified append-only
+history ledger (`cqlite-core/benches/bench_ledger/mod.rs`, A5 #1566), and the dhat allocation lane
+(`cqlite-core/tests/memory_budget.rs` under the `dhat-heap` feature, run by the agent-gate
+`memory-budget` component, A4 #1565). Parser decode-bench territory — disjoint from the concurrently
+running read-cache work (B1 #1567).
+
+Facts that constrain the design:
+- The live block-path decode entry is `SSTableReader::parse_value_with_schema_type(&self, value_data,
+  data_type)` (`cqlite-core/src/storage/sstable/reader/parsing/value_parsing.rs`). It is
+  `pub(in crate::storage::sstable::reader)` — **not reachable from a bench crate**, so a bench must go
+  through a thin, opt-in, `#[doc(hidden)]` bench-only public shim rather than a re-implemented copy
+  (which would measure a different code path and violate the audit's intent).
+- The scalar arms delegate to the authoritative standalone decoders; the collection/UDT/tuple/frozen
+  arms recurse via `&self` and read `self.header.cassandra_version` — so the shim needs a real opened
+  reader as its `&self` context. A single real CI-present fixture reader (`SIMPLE`, already used by A4)
+  supplies that context; the per-type byte buffers themselves are fixed representative literals built in
+  the bench.
+- `dhat::HeapStats` exposes `total_blocks` (allocation count). allocs/row = `total_blocks / rows`;
+  allocs/cell = `total_blocks / (rows * cols)` over a real full-scan of a wide real fixture — the honest
+  measure of today's O(rows×cols) transient-string dispatch (finding J1).
+
+## What Changes
+
+- **Add an opt-in `bench-internals` feature** to `cqlite-core` (empty; enables a `#[doc(hidden)]
+  #[cfg(feature = "bench-internals")] pub fn decode_value_for_bench(&self, value_data, data_type)` on
+  `SSTableReader` that forwards verbatim to `parse_value_with_schema_type`). No default build, no real
+  public API, no production-path change.
+- **Add `cqlite-core/benches/decode_bench.rs`** (harness = false) with three criterion groups:
+  - **`decode/type_<name>`** — for each CQL type (all scalars + `list`/`set`/`map`/`tuple`/UDT/`frozen`),
+    decode a fixed representative byte buffer in a loop through the live entry (`decode_value_for_bench`
+    → `parse_value_with_schema_type`); ns/op per type.
+  - **`decode/wide_row_primitives`** — throughput (rows/sec) decoding a fixed in-memory block of a wide
+    all-primitive row (~20 primitive typed columns) repeated to a row volume.
+  - **`decode/text_heavy`** — throughput (rows/sec) on a block dominated by `text`/`blob` values (the
+    K5/K6 measurement).
+- **Reuse the unified history ledger**: the bench appends its metrics via `crate::bench_ledger`
+  (best-effort; a ledger write never fails the bench).
+- **Wire the criterion decode benches into the perf gate**: add `decode/wide_row_primitives` and
+  `decode/text_heavy` to `perf-gate.json` (STRICT, ≥10% threshold); add `--bench decode` to the
+  `perf-regression.yml` bench invocations (guarded by the existing "bench may not exist on base"
+  pattern so the first landing stays green). Per-type entries are recorded/advisory (many small ns/op
+  benches; the two throughput benches are the STRICT regression nets).
+- **Add allocs/row + allocs/cell dhat budgets** to the A4 lane (`memory_budget.rs`): drive the real
+  public `Database::execute` full scan over a wide real fixture, compute allocs/row and allocs/cell from
+  `dhat::HeapStats::total_blocks`, and assert ≤ **current-main measured** ceilings (ratchet pattern —
+  J1/K3 lower them later). Run by the agent-gate `memory-budget` component; fails closed on 0 rows.
+- **Record the measured baseline numbers** (per-type ns/op, wide-row & text-heavy rows/sec, allocs/row,
+  allocs/cell) on issue #1615 at landing.
+- **Demonstrated red-run** (in the PR): show the allocs/row budget REDs when the ceiling is set below the
+  measured value — the honest failing-on-regression evidence.
+
+## Non-goals
+
+- **No production decode-path change.** Additive bench/gate/test + one opt-in `#[doc(hidden)]` shim only.
+- **No aspirational budgets.** Ceilings are pinned at current-main measured values so the gate is green at
+  landing; J/K children tighten them as their fixes land.
+- **No benching of dead code** (`optimized_complex_types`, `zero_copy_parser` — being deleted in J3).
+- **No redefinition of the perf-gate mechanism** or the dhat lane beyond adding tracked entries/tests.

--- a/openspec/changes/decode-benches/specs/decode-benches/spec.md
+++ b/openspec/changes/decode-benches/specs/decode-benches/spec.md
@@ -7,10 +7,23 @@ block-path decode entry (`SSTableReader::parse_value_with_schema_type`), reached
 `#[doc(hidden)]` bench-only shim, never a re-implemented copy of the dispatch. The bench SHALL NOT bench
 dead decode paths (`optimized_complex_types`, `zero_copy_parser`).
 
+UDT wire-decode fidelity boundary: the live string entry resolves types via the registry-free
+`ComparatorType::from_data_type`, which maps a UDT reference to `Custom("udt:…")` and therefore can never
+yield a `ComparatorType::Udt` arm from a type string (a genuine UDT comparator only arises from the
+registry-aware entry, a different code path that is out of scope here). The UDT decode is therefore
+benched via its structural twin `tuple` — in Cassandra `UserType extends TupleType`, so the on-wire decode
+(i32-BE field lengths, per-field recursion) is identical — and this equivalence SHALL be documented at the
+bench.
+
 #### Scenario: Each CQL type is decoded through the real entry
 - **WHEN** the `decode/type_<name>` bench runs for a given CQL type
 - **THEN** the representative buffer is decoded by calling the crate's `parse_value_with_schema_type` (via the `bench-internals` shim), not a copy
 - **AND** the bench setup asserts the decode yields the expected `Value` variant, so a no-op or wrong-path decode fails loudly
+
+#### Scenario: UDT decode is covered via its structural-twin tuple wire format
+- **WHEN** the per-type group covers UDT
+- **THEN** it benches the UDT wire-decode via the `tuple` arm (identical i32-BE field-length wire format), because the registry-free live string entry cannot produce a `ComparatorType::Udt`
+- **AND** the equivalence and its reason are documented at the bench
 
 #### Scenario: The bench-internals shim is opt-in and invisible in default builds
 - **WHEN** `cqlite-core` is built without the `bench-internals` feature

--- a/openspec/changes/decode-benches/specs/decode-benches/spec.md
+++ b/openspec/changes/decode-benches/specs/decode-benches/spec.md
@@ -1,0 +1,73 @@
+## ADDED Requirements
+
+### Requirement: Per-CQL-type decode is benched through the live decode entry
+The measurement suite SHALL provide a criterion bench that decodes a fixed representative byte buffer for
+each CQL type — all scalars plus `list`, `set`, `map`, `tuple`, UDT, and `frozen` — through the **live**
+block-path decode entry (`SSTableReader::parse_value_with_schema_type`), reached via an opt-in
+`#[doc(hidden)]` bench-only shim, never a re-implemented copy of the dispatch. The bench SHALL NOT bench
+dead decode paths (`optimized_complex_types`, `zero_copy_parser`).
+
+#### Scenario: Each CQL type is decoded through the real entry
+- **WHEN** the `decode/type_<name>` bench runs for a given CQL type
+- **THEN** the representative buffer is decoded by calling the crate's `parse_value_with_schema_type` (via the `bench-internals` shim), not a copy
+- **AND** the bench setup asserts the decode yields the expected `Value` variant, so a no-op or wrong-path decode fails loudly
+
+#### Scenario: The bench-internals shim is opt-in and invisible in default builds
+- **WHEN** `cqlite-core` is built without the `bench-internals` feature
+- **THEN** no `decode_value_for_bench` symbol is compiled and the public API is unchanged
+
+### Requirement: Wide-row and text-heavy decode throughput are benched
+The suite SHALL provide a `decode/wide_row_primitives` bench reporting rows/sec for decoding a wide
+all-primitive row (about 20 primitive columns) and a `decode/text_heavy` bench reporting rows/sec for a
+block dominated by `text`/`blob` values (the K5/K6 measurement). Both SHALL report criterion throughput in
+elements (rows).
+
+#### Scenario: Throughput benches report rows/sec
+- **WHEN** the `decode/wide_row_primitives` and `decode/text_heavy` benches run
+- **THEN** each configures criterion `Throughput::Elements` over its decoded row count so the reported number is rows/sec
+
+### Requirement: Decode throughput benches are gated for regressions
+`cqlite-core/benches/perf-gate.json` SHALL track `decode/wide_row_primitives` and `decode/text_heavy` as
+STRICT benches with a median-regression failure threshold of at least 10%, and the perf-regression
+workflow SHALL run the `decode` bench on both the PR and the base checkout (guarded so a base checkout
+lacking the bench target does not break the run), so a decode-throughput regression fails the lane.
+
+#### Scenario: perf-gate.json tracks the decode throughput benches
+- **WHEN** `cqlite-core/benches/perf-gate.json` is read
+- **THEN** it contains `decode/wide_row_primitives` and `decode/text_heavy`, each with `threshold_pct >= 10`
+
+#### Scenario: A decode-throughput regression reds the gate
+- **WHEN** decode throughput regresses past its threshold versus the base baseline
+- **THEN** `scripts/ci/check_perf_regression.py` flags the bench as a REGRESSION and exits non-zero
+
+#### Scenario: First landing with no base data stays green
+- **WHEN** the base checkout does not yet contain `cqlite-core/benches/decode_bench.rs`
+- **THEN** the workflow omits `--bench decode` on the base run and `check_perf_regression.py` reports the decode benches as SKIP without failing the gate
+
+### Requirement: allocations-per-row and per-cell are measured and gated at current-main values
+The dhat allocation lane SHALL measure allocations-per-row and allocations-per-cell for a full-table
+`SELECT *` driven through the real public query path (`Database::execute`) over a real wide SSTable
+fixture, and SHALL assert each stays within a ceiling pinned at the current-main measured value (a ratchet
+that later Epic J/K children lower). The measurement SHALL start after fixture open/ingest so only the
+read path is attributed, using `dhat::HeapStats::total_blocks` for the allocation count.
+
+#### Scenario: allocs/row and allocs/cell are computed from real full-scan allocations
+- **WHEN** the dhat budget test full-scans the wide fixture through `Database::execute` with the profiler started after `open_read_db`
+- **THEN** allocs/row = `total_blocks / row_count` and allocs/cell = `total_blocks / (row_count * column_count)` are computed and each asserted `<=` its pinned current-main ceiling
+
+#### Scenario: The budget lane reds on an allocation regression
+- **WHEN** the allocs/row ceiling is set below the measured value (a stand-in for a regression)
+- **THEN** the `memory-budget` agent-gate lane fails (non-zero exit), demonstrating the budget catches regressions
+
+### Requirement: Decode measurement never silently passes on an empty or absent dataset
+A dataset-dependent decode measurement SHALL fail loudly (panic) when its fixture is present but yields
+zero rows, and SHALL be skipped (not registered / SKIP) only when its fixture directory is entirely
+absent — never recording a 0-row measurement as a pass.
+
+#### Scenario: Present-but-empty fixture panics
+- **WHEN** the wide fixture directory exists but the full scan returns zero rows
+- **THEN** the dhat budget test panics with an actionable message rather than dividing by zero or recording a 0-row pass
+
+#### Scenario: Absent optional fixture skips without failing
+- **WHEN** an optional wide fixture is entirely absent from the checkout
+- **THEN** the measurement is skipped and the lane does not fail on its absence

--- a/openspec/changes/decode-benches/tasks.md
+++ b/openspec/changes/decode-benches/tasks.md
@@ -1,0 +1,24 @@
+## 1. Bench-internals shim (production, additive, opt-in)
+- [ ] 1.1 Add empty `bench-internals` feature to `cqlite-core/Cargo.toml` `[features]`.
+- [ ] 1.2 Add `#[cfg(feature = "bench-internals")] #[doc(hidden)] pub fn decode_value_for_bench(&self, value_data: &[u8], data_type: &str) -> Result<Value>` on `SSTableReader`, forwarding verbatim to `parse_value_with_schema_type`. No `unwrap`/`expect`.
+
+## 2. Per-type + throughput criterion benches
+- [ ] 2.1 Add `cqlite-core/benches/decode_bench.rs` (`harness = false`) + `[[bench]] name = "decode"` in `Cargo.toml`.
+- [ ] 2.2 `decode/type_<name>` group: open one real `SIMPLE` fixture reader once (outside the loop); decode a fixed representative buffer for each CQL type (all scalars + list/set/map/tuple/UDT/frozen) through `decode_value_for_bench`. Assert each decode yields the expected `Value` variant at setup (wiring-evidence — proves the live entry ran, not a no-op).
+- [ ] 2.3 `decode/wide_row_primitives` group: assemble a fixed ~20-primitive-column row buffer set; decode all columns in a loop; `Throughput::Elements(rows)` → rows/sec.
+- [ ] 2.4 `decode/text_heavy` group: text/blob-dominated block; `Throughput::Elements(rows)` → rows/sec.
+- [ ] 2.5 Append per-run metrics via `crate::bench_ledger` (best-effort; ledger failure logs to stderr, never fails the bench).
+
+## 3. Perf-gate wiring
+- [ ] 3.1 Add `decode/wide_row_primitives` and `decode/text_heavy` to `cqlite-core/benches/perf-gate.json` `benches` (STRICT, `threshold_pct: 10`).
+- [ ] 3.2 Add `--bench decode` to `.github/workflows/perf-regression.yml`: unconditionally on the PR run; guarded by `[[ -f cqlite-core/benches/decode_bench.rs ]]` on the base (main) run (compaction pattern).
+
+## 4. allocs/row + allocs/cell dhat budget (A4 lane)
+- [ ] 4.1 Add allocs/row + allocs/cell budget tests to `cqlite-core/tests/memory_budget.rs` (or a sibling `#[cfg(all(feature = "dhat-heap", feature = "cli-helpers"))]` target): drive real `Database::execute("SELECT * …")` full scan over the wide real fixture; profiler starts AFTER `open_read_db`.
+- [ ] 4.2 Compute allocs/row = `total_blocks / rows`, allocs/cell = `total_blocks / (rows * cols)`; assert each ≤ pinned current-main ceiling; fail closed (panic) on 0 rows for a present fixture; SKIP only when the fixture is entirely absent.
+- [ ] 4.3 Pin ceilings to measured current-main values + documented variance slack; document the measured numbers in code comments.
+
+## 5. Baseline + red-run + validation
+- [ ] 5.1 Record measured baseline numbers (per-type ns/op, wide-row & text-heavy rows/sec, allocs/row, allocs/cell) as a comment on issue #1615.
+- [ ] 5.2 Demonstrate the allocs/row budget REDs when the ceiling is set below measured (paste the red output), then restore to the ratchet value.
+- [ ] 5.3 `scripts/agent-gate.sh` PASS — paste the AGENT-GATE SUMMARY block verbatim.

--- a/openspec/changes/decode-benches/tasks.md
+++ b/openspec/changes/decode-benches/tasks.md
@@ -1,24 +1,24 @@
 ## 1. Bench-internals shim (production, additive, opt-in)
-- [ ] 1.1 Add empty `bench-internals` feature to `cqlite-core/Cargo.toml` `[features]`.
-- [ ] 1.2 Add `#[cfg(feature = "bench-internals")] #[doc(hidden)] pub fn decode_value_for_bench(&self, value_data: &[u8], data_type: &str) -> Result<Value>` on `SSTableReader`, forwarding verbatim to `parse_value_with_schema_type`. No `unwrap`/`expect`.
+- [x] 1.1 Add empty `bench-internals` feature to `cqlite-core/Cargo.toml` `[features]`.
+- [x] 1.2 Add `#[cfg(feature = "bench-internals")] #[doc(hidden)] pub fn decode_value_for_bench(&self, value_data: &[u8], data_type: &str) -> Result<Value>` on `SSTableReader`, forwarding verbatim to `parse_value_with_schema_type`. No `unwrap`/`expect`.
 
 ## 2. Per-type + throughput criterion benches
-- [ ] 2.1 Add `cqlite-core/benches/decode_bench.rs` (`harness = false`) + `[[bench]] name = "decode"` in `Cargo.toml`.
-- [ ] 2.2 `decode/type_<name>` group: open one real `SIMPLE` fixture reader once (outside the loop); decode a fixed representative buffer for each CQL type (all scalars + list/set/map/tuple/UDT/frozen) through `decode_value_for_bench`. Assert each decode yields the expected `Value` variant at setup (wiring-evidence — proves the live entry ran, not a no-op).
-- [ ] 2.3 `decode/wide_row_primitives` group: assemble a fixed ~20-primitive-column row buffer set; decode all columns in a loop; `Throughput::Elements(rows)` → rows/sec.
-- [ ] 2.4 `decode/text_heavy` group: text/blob-dominated block; `Throughput::Elements(rows)` → rows/sec.
-- [ ] 2.5 Append per-run metrics via `crate::bench_ledger` (best-effort; ledger failure logs to stderr, never fails the bench).
+- [x] 2.1 Add `cqlite-core/benches/decode_bench.rs` (`harness = false`) + `[[bench]] name = "decode"` in `Cargo.toml`.
+- [x] 2.2 `decode/type_<name>` group: open one real `SIMPLE` fixture reader once (outside the loop); decode a fixed representative buffer for each CQL type (all scalars + list/set/map/tuple/UDT/frozen) through `decode_value_for_bench`. Assert each decode yields the expected `Value` variant at setup (wiring-evidence — proves the live entry ran, not a no-op).
+- [x] 2.3 `decode/wide_row_primitives` group: assemble a fixed ~20-primitive-column row buffer set; decode all columns in a loop; `Throughput::Elements(rows)` → rows/sec.
+- [x] 2.4 `decode/text_heavy` group: text/blob-dominated block; `Throughput::Elements(rows)` → rows/sec.
+- [x] 2.5 Append per-run metrics via `crate::bench_ledger` (best-effort; ledger failure logs to stderr, never fails the bench).
 
 ## 3. Perf-gate wiring
-- [ ] 3.1 Add `decode/wide_row_primitives` and `decode/text_heavy` to `cqlite-core/benches/perf-gate.json` `benches` (STRICT, `threshold_pct: 10`).
-- [ ] 3.2 Add `--bench decode` to `.github/workflows/perf-regression.yml`: unconditionally on the PR run; guarded by `[[ -f cqlite-core/benches/decode_bench.rs ]]` on the base (main) run (compaction pattern).
+- [x] 3.1 Add `decode/wide_row_primitives` and `decode/text_heavy` to `cqlite-core/benches/perf-gate.json` `benches` (STRICT, `threshold_pct: 10`).
+- [x] 3.2 Add `--bench decode` to `.github/workflows/perf-regression.yml`: unconditionally on the PR run; guarded by `[[ -f cqlite-core/benches/decode_bench.rs ]]` on the base (main) run (compaction pattern).
 
 ## 4. allocs/row + allocs/cell dhat budget (A4 lane)
-- [ ] 4.1 Add allocs/row + allocs/cell budget tests to `cqlite-core/tests/memory_budget.rs` (or a sibling `#[cfg(all(feature = "dhat-heap", feature = "cli-helpers"))]` target): drive real `Database::execute("SELECT * …")` full scan over the wide real fixture; profiler starts AFTER `open_read_db`.
-- [ ] 4.2 Compute allocs/row = `total_blocks / rows`, allocs/cell = `total_blocks / (rows * cols)`; assert each ≤ pinned current-main ceiling; fail closed (panic) on 0 rows for a present fixture; SKIP only when the fixture is entirely absent.
-- [ ] 4.3 Pin ceilings to measured current-main values + documented variance slack; document the measured numbers in code comments.
+- [x] 4.1 Add allocs/row + allocs/cell budget tests to `cqlite-core/tests/memory_budget.rs` (or a sibling `#[cfg(all(feature = "dhat-heap", feature = "cli-helpers"))]` target): drive real `Database::execute("SELECT * …")` full scan over the wide real fixture; profiler starts AFTER `open_read_db`.
+- [x] 4.2 Compute allocs/row = `total_blocks / rows`, allocs/cell = `total_blocks / (rows * cols)`; assert each ≤ pinned current-main ceiling; fail closed (panic) on 0 rows for a present fixture; SKIP only when the fixture is entirely absent.
+- [x] 4.3 Pin ceilings to measured current-main values + documented variance slack; document the measured numbers in code comments.
 
 ## 5. Baseline + red-run + validation
-- [ ] 5.1 Record measured baseline numbers (per-type ns/op, wide-row & text-heavy rows/sec, allocs/row, allocs/cell) as a comment on issue #1615.
-- [ ] 5.2 Demonstrate the allocs/row budget REDs when the ceiling is set below measured (paste the red output), then restore to the ratchet value.
-- [ ] 5.3 `scripts/agent-gate.sh` PASS — paste the AGENT-GATE SUMMARY block verbatim.
+- [x] 5.1 Record measured baseline numbers (per-type ns/op, wide-row & text-heavy rows/sec, allocs/row, allocs/cell) as a comment on issue #1615.
+- [x] 5.2 Demonstrate the allocs/row budget REDs when the ceiling is set below measured (paste the red output), then restore to the ratchet value.
+- [x] 5.3 `scripts/agent-gate.sh` PASS — paste the AGENT-GATE SUMMARY block verbatim.


### PR DESCRIPTION
Closes #1615 (Epic H, Wave 1 — parser measurement + safety net).

Design-driven measurement machinery. OpenSpec change `decode-benches` (Seam-1 pre-approved for the batch). **Additive only — no production decode-path change** (one opt-in `#[doc(hidden)]` shim).

## What
- **`bench-internals` feature** (empty, non-default) exposing `#[doc(hidden)] SSTableReader::decode_value_for_bench` forwarding verbatim to the live entry `parse_value_with_schema_type`, so benches exercise the real decode dispatch (not a copy). Default builds byte-identical.
- **`cqlite-core/benches/decode_bench.rs`** — three criterion groups:
  - `decode/type_<name>` — per-CQL-type ns/op (all scalars + list/set/map/tuple/UDT/frozen) through the live entry; UDT via its structural twin `tuple` (identical i32-BE field-length wire format — the registry-free string entry cannot yield a `Udt` comparator; documented).
  - `decode/wide_row_primitives` — rows/sec, 20 primitive columns.
  - `decode/text_heavy` — rows/sec, text/blob-dominated (K5/K6).
- **allocs/row + allocs/cell dhat budget** in `cqlite-core/tests/memory_budget.rs` — real `Database::execute` full scan, profiler after open, per-fixture ratchet ceilings, fail-closed on 0 rows (A4 lane, `memory-budget` gate component).
- **Perf-gate wiring** — `decode/wide_row_primitives` + `decode/text_heavy` STRICT (≥10%) in `perf-gate.json`; `--bench decode` added to `perf-regression.yml` (PR unconditional, base guarded).
- Reuses the unified history ledger (`bench_ledger`).

## Measured baseline (current-main ratchet)
| metric | value |
|---|---|
| `decode/wide_row_primitives` | ~1,118,800 rows/sec (893.8 µs/iter, 20 cols) |
| `decode/text_heavy` | ~1,685,700 rows/sec (593.2 µs/iter, 10 cols) |
| allocs/row (many_columns) | 45.6 (total_blocks=2282, 50 rows × 8 cols) |
| allocs/cell (many_columns) | 5.7 |
| allocs/row (SIMPLE fallback) | ~60.4 (999 rows × 5 cols) |
| per-type ns/op (sample) | int 35.7 / bigint 38.8 / boolean 40.1 / text 55.8 ns |

Pinned ceilings (ratchet, J1/K3 lower later): many_columns 60.0/8.0, simple 78.0/16.0.

## Red-run proof
Ceiling set to 10.0 → `memory-budget` lane exits 101: `allocs/row 45.6 exceeded ceiling 10.0 (fixture test_wide_rows.many_columns_table, 50 rows × 8 cols)`; restored to ratchet → green.

## Quality
- `scripts/agent-gate.sh` PASS (re-run on rebased tree).
- spec-auditor (C) verdict PASS — every requirement satisfied with wiring evidence.
- roborev clean (codex).
- No `unwrap`/`expect` in the shim; `RUSTFLAGS="-D warnings"` clippy clean; no-heuristics (shim forwards only).
