### PR TITLE
flow-meta(#1825): machine-wide full-gate concurrency cap (SIGKILL-safe slot semaphore, --lite exempt)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,24 @@ CQLITE_SKIP_DOCKER_TESTS=0 bash scripts/agent-gate.sh     # include live Cassand
 
 **Graceful fallback**: absent `cargo-nextest`, no `/bin/bash wait -n` (macOS stock 3.2), or `AGENT_GATE_JOBS=1` → gate degrades gracefully to the historical sequential run without loss of coverage.
 
+### Machine-wide full-gate concurrency cap (issue #1825)
+
+Running many sessions/worktrees at once used to let ~15 full gates hit the CPU at once (load 30–60) and SIGKILL gates mid-`core-tests`. The FULL `agent-gate.sh` run now takes a **cross-process bounded semaphore**: at most **N** full gates execute machine-wide at once; excess invocations **queue** (block) for a slot — printing `waiting for gate slot (N in use)…` once — and then proceed. **They never fail from the cap**; non-interactive callers block cleanly.
+
+- **`--lite` and `--only` runs are EXEMPT** (never queued): `--lite` is cheap, and `--only` PARTIAL runs are used by nested tooling self-tests (capping them could self-deadlock the queue).
+- **N** defaults to `max(2, floor((ncpu-2)/4))`; override with `CQLITE_GATE_MAX_CONCURRENCY`.
+- **SIGKILL-safe stale-slot reaping**: each slot is an `fcntl.flock` held by a background daemon (`scripts/lib/gate_slot_daemon.py`) whose lock fd is NOT inherited by the gate's `cargo`/`nextest` children, so a killed gate releases its slot within one poll — no permanent leak/deadlock.
+- Works **across worktrees** (shared slot dir) and composes with `AGENT_GATE_JOBS` (per-gate) + `sccache`. The cap bounds the *worst case*; those cut average load / per-compile time.
+
+```bash
+CQLITE_GATE_MAX_CONCURRENCY=4 bash scripts/agent-gate.sh   # raise N on a big box
+CQLITE_GATE_SLOTS_DIR=/path bash scripts/agent-gate.sh     # slot dir (default $TMPDIR/cqlite-gate-slots)
+CQLITE_GATE_POLL_SECS=1 bash scripts/agent-gate.sh         # queue/liveness poll (default 2s)
+CQLITE_GATE_DISABLE_CAP=1 bash scripts/agent-gate.sh       # force-disable the cap
+```
+
+The cap fails **open** (disabled, loud stderr note) when `python3`/the daemon is unavailable — the gate is never un-runnable because of the cap. Self-test: `scripts/tests/test_gate_concurrency_cap.sh` (wired into `tooling-tests`).
+
 
 # Build
 cargo build

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -1427,9 +1427,11 @@ acquire_gate_slot() {
   ready="$LOG_DIR/gate-slot.ready"
   rm -f "$ready" 2>/dev/null || true
   # Start the background lock-holder for THIS gate (pid $$). It writes $ready once
-  # it owns a slot and holds it until this gate exits.
+  # it owns a slot and holds it until this gate exits. Its std fds are detached to
+  # /dev/null so this long-lived background child can NEVER hold the gate's stdout
+  # pipe open and truncate a streamed SUMMARY under an until-EOF reader (#1175).
   python3 "$daemon" --slots-dir "$dir" --slots "$n" --gate-pid "$$" \
-    --ready-file "$ready" --poll-secs "$poll" &
+    --ready-file "$ready" --poll-secs "$poll" </dev/null >/dev/null 2>&1 &
   GATE_SLOT_DAEMON_PID=$!
   trap '_gate_release_slot' EXIT
   # Block until the daemon signals acquisition, printing the queued notice ONCE

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -1445,13 +1445,13 @@ acquire_gate_slot() {
       return 0
     fi
     if [ "$printed" -eq 0 ] && [ "$waited" -ge 3 ]; then
-      echo "waiting for gate slot ($n in use)…"
+      echo "waiting for gate slot ($n in use)…" >&2
       printed=1
     fi
     waited=$(( waited + 1 ))
     sleep 0.2
   done
-  [ "$printed" -eq 1 ] && echo "agent-gate: gate slot acquired -- proceeding (#1825)"
+  [ "$printed" -eq 1 ] && echo "agent-gate: gate slot acquired -- proceeding (#1825)" >&2
 }
 
 # Test-only stub (issue #1825 concurrency self-test): when CQLITE_GATE_STUB_RUNDIR

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -86,7 +86,11 @@
 #                      (#1232) — fails if a generate-*.sh enumerates the whole
 #                      SSTable corpus and grep -z filters by keyspace; needs no
 #                      python3 so it runs even on the SKIP path, and any failure
-#                      hard-FAILs this component.
+#                      hard-FAILs this component. On the python3 path also runs
+#                      scripts/tests/test_gate_concurrency_cap.sh (#1825) — proves
+#                      the machine-wide full-gate concurrency cap queues at N,
+#                      exempts --lite, and releases a slot on SIGKILL (uses the
+#                      gate's hermetic stub mode, never real gate work).
 #   minimal-build      cargo build -p cqlite-core --no-default-features --features all-compression
 #   smoke              bash test-data/scripts/smoke-test-all-tables.sh
 #   file-size          campsite-rule ratchet (epic #1116 / #1135): lists changed
@@ -214,7 +218,10 @@ export CQLITE_DATASETS_ROOT="${CQLITE_DATASETS_ROOT:-$REPO_ROOT/test-data/datase
 NEXTEST=0
 if [ "${CQLITE_DISABLE_NEXTEST:-0}" != 1 ] && command -v cargo-nextest >/dev/null 2>&1; then
   NEXTEST=1
-  echo "agent-gate: cargo-nextest detected ($(cargo nextest --version 2>/dev/null | head -1)); core-tests uses nextest + a cargo test --doc pass (#1737)"
+  # Banner on STDERR: hidden hook modes (--classify-*, --scoped-test-cmd-noparser)
+  # must keep STDOUT empty, and this detection runs before the hook dispatch (same
+  # rule the sccache banner above already follows; #1821/#1825).
+  echo "agent-gate: cargo-nextest detected ($(cargo nextest --version 2>/dev/null | head -1)); core-tests uses nextest + a cargo test --doc pass (#1737)" >&2
 fi
 
 # Bounded component parallelism (issue #1737): independent gate components run
@@ -242,7 +249,10 @@ case "$AGENT_GATE_JOBS" in *[!0-9]*|'') AGENT_GATE_JOBS=1 ;; esac
 if [ "$AGENT_GATE_JOBS" -gt 1 ] && \
    ! { [ "${BASH_VERSINFO[0]:-0}" -gt 4 ] || \
        { [ "${BASH_VERSINFO[0]:-0}" -eq 4 ] && [ "${BASH_VERSINFO[1]:-0}" -ge 3 ]; }; }; then
-  echo "agent-gate: bash < 4.3 lacks 'wait -n'; components run sequentially (AGENT_GATE_JOBS=1)"
+  # Banner on STDERR (see nextest note above): hidden hook modes must keep STDOUT
+  # empty, and this runs before the hook dispatch — under stock bash 3.2 this
+  # branch is always taken, so an stdout banner here corrupted --classify-* output.
+  echo "agent-gate: bash < 4.3 lacks 'wait -n'; components run sequentially (AGENT_GATE_JOBS=1)" >&2
   AGENT_GATE_JOBS=1
 fi
 
@@ -1005,9 +1015,10 @@ run_tooling_tests() {
     record_result "$name" "$status" 0
     return 0
   fi
-  echo ">>> [$name] bash scripts/tests/test_agent_gate_summary.sh; bash scripts/tests/test_agent_gate_smoke_target_dir.sh"
+  echo ">>> [$name] bash scripts/tests/test_agent_gate_summary.sh; bash scripts/tests/test_agent_gate_smoke_target_dir.sh; bash scripts/tests/test_gate_concurrency_cap.sh"
   if bash "$REPO_ROOT/scripts/tests/test_agent_gate_summary.sh" >>"$log" 2>&1 &&
-     bash "$REPO_ROOT/scripts/tests/test_agent_gate_smoke_target_dir.sh" >>"$log" 2>&1; then
+     bash "$REPO_ROOT/scripts/tests/test_agent_gate_smoke_target_dir.sh" >>"$log" 2>&1 &&
+     bash "$REPO_ROOT/scripts/tests/test_gate_concurrency_cap.sh" >>"$log" 2>&1; then
     status=PASS
   else
     status=FAIL
@@ -1331,12 +1342,144 @@ run_lite() {
   esac
 }
 
+# ---- Machine-wide full-gate concurrency cap (issue #1825) -------------------
+# A cross-process bounded semaphore around the FULL gate of record ONLY. At most N
+# full `agent-gate.sh` runs execute machine-wide at once; excess invocations BLOCK
+# (queue) for a slot — they NEVER fail from the cap. EXEMPT (never queued):
+#   * --lite runs (issue #1821): cheap fmt+clippy+scoped tests, must stay instant.
+#   * --only PARTIAL runs: they don't count as the gate AND are used by nested
+#     tooling self-tests (a capped parent runs `agent-gate.sh --only ...` as a
+#     child), so capping them could self-deadlock the queue.
+#   * --emit-summary-selftest / hidden hooks: they exit earlier, never reaching here.
+#
+# Mechanism (SIGKILL-safe by construction): N slot lockfiles under a SHARED,
+# machine-wide (NOT per-checkout) dir, each guarded by a non-blocking fcntl.flock.
+# A tiny background daemon (scripts/lib/gate_slot_daemon.py) acquires ONE slot,
+# signals us via a ready file, then HOLDS the lock while polling this gate's
+# liveness; it releases the slot when the gate exits. Crucially the daemon is a
+# SEPARATE process that opens the lock fd AFTER it is forked, so the gate's heavy
+# children (cargo, nextest, ...) never inherit the lock -- a SIGKILL of the gate
+# frees the slot within one poll interval even while orphaned children run on. (An
+# fd held by the gate shell itself would be inherited by cargo and keep the slot
+# locked after a SIGKILL, defeating stale-slot reaping -- hence the daemon.)
+#
+# N default: max(2, floor((ncpu-2)/4)) -- a conservative fraction of cores that
+# still lets a couple of gates run on a small box; overridable via
+# CQLITE_GATE_MAX_CONCURRENCY. Slots dir: $CQLITE_GATE_SLOTS_DIR (default
+# ${TMPDIR:-/tmp}/cqlite-gate-slots). Poll interval: $CQLITE_GATE_POLL_SECS
+# (default 2). The cap is skipped (with a loud stderr note) when python3 or the
+# daemon is unavailable, and can be force-disabled with CQLITE_GATE_DISABLE_CAP=1.
+# Non-interactive callers block cleanly (waiting on the daemon), never spin-fail.
+
+# Resolve N from the default formula + the CQLITE_GATE_MAX_CONCURRENCY override.
+_gate_max_concurrency() {
+  local dflt=$(( ( _ncpu - 2 ) / 4 ))
+  [ "$dflt" -lt 2 ] && dflt=2
+  local v="${CQLITE_GATE_MAX_CONCURRENCY:-$dflt}"
+  case "$v" in *[!0-9]*|'') v=$dflt ;; esac
+  [ "$v" -lt 1 ] && v=1
+  printf '%s' "$v"
+}
+
+# PID of the background slot daemon (empty when the cap is inactive for this run).
+GATE_SLOT_DAEMON_PID=""
+
+# Release the held slot by terminating the daemon (which closes its lock fd). Run
+# from the EXIT trap. Guarded to fire ONLY in the main gate shell: a backgrounded
+# `( ... ) &` pool subshell also runs the inherited EXIT trap on its own exit, and
+# must NOT tear down the parent's slot. BASHPID (bash 4+) differs from $$ inside a
+# subshell; on bash 3.2 (no BASHPID, no pool subshells) it defaults equal, so the
+# guard is a no-op there and only the real gate exit releases the slot.
+# shellcheck disable=SC2329  # invoked indirectly via `trap '_gate_release_slot' EXIT`
+_gate_release_slot() {
+  [ "${BASHPID:-$$}" = "$$" ] || return 0
+  [ -n "${GATE_SLOT_DAEMON_PID:-}" ] || return 0
+  kill "$GATE_SLOT_DAEMON_PID" 2>/dev/null || true
+  GATE_SLOT_DAEMON_PID=""
+}
+
+# Block until this full-gate run holds one of N machine-wide slots, then return so
+# the gate proceeds while the daemon keeps the slot held in the background. No-op
+# for the exempt run classes above. Fail-open (cap disabled) if python3/daemon are
+# missing or the daemon dies before acquiring -- the gate must never be un-runnable
+# because of the cap.
+acquire_gate_slot() {
+  [ "$LITE" -eq 1 ] && return 0
+  [ -n "$ONLY" ] && return 0
+  [ "${CQLITE_GATE_DISABLE_CAP:-0}" = 1 ] && return 0
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "agent-gate: python3 unavailable -- full-gate concurrency cap DISABLED (#1825)" >&2
+    return 0
+  fi
+  local n dir poll daemon ready
+  n=$(_gate_max_concurrency)
+  dir="${CQLITE_GATE_SLOTS_DIR:-${TMPDIR:-/tmp}/cqlite-gate-slots}"
+  poll="${CQLITE_GATE_POLL_SECS:-2}"
+  daemon="$REPO_ROOT/scripts/lib/gate_slot_daemon.py"
+  if [ ! -f "$daemon" ]; then
+    echo "agent-gate: slot daemon $daemon missing -- concurrency cap DISABLED (#1825)" >&2
+    return 0
+  fi
+  if ! mkdir -p "$dir" 2>/dev/null; then
+    echo "agent-gate: cannot create slot dir $dir -- concurrency cap DISABLED (#1825)" >&2
+    return 0
+  fi
+  ready="$LOG_DIR/gate-slot.ready"
+  rm -f "$ready" 2>/dev/null || true
+  # Start the background lock-holder for THIS gate (pid $$). It writes $ready once
+  # it owns a slot and holds it until this gate exits.
+  python3 "$daemon" --slots-dir "$dir" --slots "$n" --gate-pid "$$" \
+    --ready-file "$ready" --poll-secs "$poll" &
+  GATE_SLOT_DAEMON_PID=$!
+  trap '_gate_release_slot' EXIT
+  # Block until the daemon signals acquisition, printing the queued notice ONCE
+  # after a short grace (so an immediately-free slot stays quiet). If the daemon
+  # dies before acquiring, fail open rather than hang the gate forever.
+  local printed=0 waited=0
+  while [ ! -f "$ready" ]; do
+    if ! kill -0 "$GATE_SLOT_DAEMON_PID" 2>/dev/null; then
+      echo "agent-gate: slot daemon exited before acquiring -- cap DISABLED for this run (#1825)" >&2
+      GATE_SLOT_DAEMON_PID=""
+      return 0
+    fi
+    if [ "$printed" -eq 0 ] && [ "$waited" -ge 3 ]; then
+      echo "waiting for gate slot ($n in use)…"
+      printed=1
+    fi
+    waited=$(( waited + 1 ))
+    sleep 0.2
+  done
+  [ "$printed" -eq 1 ] && echo "agent-gate: gate slot acquired -- proceeding (#1825)"
+}
+
+# Test-only stub (issue #1825 concurrency self-test): when CQLITE_GATE_STUB_RUNDIR
+# is set, the gate acquires a real slot (subject to the cap + exemptions above),
+# advertises "I am working" by dropping a per-PID marker file, sleeps
+# CQLITE_GATE_STUB_SLEEP seconds, then exits 0 WITHOUT running any real component.
+# This lets scripts/tests/test_gate_concurrency_cap.sh exercise the machine-wide
+# semaphore (queueing at N, --lite exemption, SIGKILL slot release) hermetically,
+# without running actual gate work. Never triggered in normal use.
+if [ -n "${CQLITE_GATE_STUB_RUNDIR:-}" ]; then
+  acquire_gate_slot   # self-exempts for --lite / --only
+  mkdir -p "$CQLITE_GATE_STUB_RUNDIR" 2>/dev/null || true
+  _stub_marker="$CQLITE_GATE_STUB_RUNDIR/holding.$$"
+  : > "$_stub_marker" 2>/dev/null || true
+  sleep "${CQLITE_GATE_STUB_SLEEP:-2}"
+  rm -f "$_stub_marker" 2>/dev/null || true
+  exit 0
+fi
+
 # --lite (issue #1821): run the fast subset and EXIT before the full-gate flow.
 # Kept fully separate from the full-gate execution below so the no-flag path is
-# byte-for-byte unchanged.
+# byte-for-byte unchanged. --lite is EXEMPT from the #1825 cap (never queued).
 if [ "$LITE" -eq 1 ]; then
   run_lite
 fi
+
+# Machine-wide full-gate concurrency cap (issue #1825): block here until a slot is
+# free, so at most N full gates run at once across worktrees + the root checkout.
+# --lite already returned above; --only PARTIAL runs self-exempt inside.
+acquire_gate_slot
 
 # file-size runs first and needs no dataset, so it executes before the dataset
 # preflight (which exits early when data is missing).

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -1691,9 +1691,15 @@ launch_components() {
     else main_lane+=("$c"); SELECTED_MAIN+=("$c"); fi
   done
 
+  # Bash 3.2 under `set -u` treats "${arr[@]}" of an EMPTY array as unbound (fixed
+  # in bash 4.4+; #1841 latent bug surfaced by the #1825 concurrency-cap self-test,
+  # which runs a nested `--only <one-component>` gate -- exactly the case where
+  # main_lane or side_lane is empty). Guard every such expansion below with the
+  # `"${arr[@]+"${arr[@]}"}"` idiom, which is a no-op when non-empty and expands to
+  # nothing (never unbound) when empty. Same idiom already used for `stems` above.
   if [ "$AGENT_GATE_JOBS" -le 1 ] || [ "${#side_lane[@]}" -eq 0 ]; then
-    for c in "${main_lane[@]}"; do dispatch_component "$c"; done
-    for c in "${side_lane[@]}"; do run_side_component "$c"; done
+    for c in "${main_lane[@]+"${main_lane[@]}"}"; do dispatch_component "$c"; done
+    for c in "${side_lane[@]+"${side_lane[@]}"}"; do run_side_component "$c"; done
     return
   fi
 
@@ -1703,7 +1709,7 @@ launch_components() {
   # SIDE lane: a background sub-pool capped at side_jobs (each isolated target dir).
   (
     srun=0
-    for sc in "${side_lane[@]}"; do
+    for sc in "${side_lane[@]+"${side_lane[@]}"}"; do
       run_side_component "$sc" &
       srun=$(( srun + 1 ))
       if [ "$srun" -ge "$side_jobs" ]; then wait -n 2>/dev/null || true; srun=$(( srun - 1 )); fi
@@ -1712,7 +1718,7 @@ launch_components() {
   ) &
   local side_pid=$!
   # MAIN lane: serial, foreground (shared target dir, no intra-lane parallelism).
-  for c in "${main_lane[@]}"; do dispatch_component "$c"; done
+  for c in "${main_lane[@]+"${main_lane[@]}"}"; do dispatch_component "$c"; done
   wait "$side_pid" || SIDE_LANE_EXIT=$?
 }
 
@@ -1721,15 +1727,17 @@ launch_components
 # Fail-closed check (issue #1737 roborev): verify all SELECTED components produced result files.
 # A component that was selected but has no .result file crashed/exited before record_result,
 # which is a fail-OPEN hole. Treat missing results as synthetic FAIL + force overall FAIL.
-# Also check the SIDE lane's exit status.
-for _sc in "${SELECTED_SIDE[@]}"; do
+# Also check the SIDE lane's exit status. Bash-3.2-safe empty-array guard (#1841,
+# same hazard as launch_components above): a `--only <main-only-component>` run
+# leaves SELECTED_SIDE empty, and vice versa.
+for _sc in "${SELECTED_SIDE[@]+"${SELECTED_SIDE[@]}"}"; do
   [ -f "$LOG_DIR/$_sc.result" ] || {
     echo "agent-gate: SIDE-lane component '$_sc' SELECTED but has no result file (crashed/exited early)" >&2
     NAMES+=("$_sc"); STATUSES+=(FAIL); TIMES+=("0s")
     OVERALL=FAIL
   }
 done
-for _mc in "${SELECTED_MAIN[@]}"; do
+for _mc in "${SELECTED_MAIN[@]+"${SELECTED_MAIN[@]}"}"; do
   [ -f "$LOG_DIR/$_mc.result" ] || {
     echo "agent-gate: MAIN-lane component '$_mc' SELECTED but has no result file (crashed/exited early)" >&2
     NAMES+=("$_mc"); STATUSES+=(FAIL); TIMES+=("0s")

--- a/scripts/lib/gate_slot_daemon.py
+++ b/scripts/lib/gate_slot_daemon.py
@@ -16,6 +16,14 @@ fd AFTER it is forked, so the gate's later children never hold the lock; killing
 the gate frees the slot within one poll interval regardless of orphaned children.
 That is the SIGKILL-safe stale-slot-reaping guarantee.
 
+PID-reuse caveat (accepted, low-probability trade-off): liveness is a ``kill(pid, 0)``
+probe on the gate PID. If a SIGKILLed gate's PID is recycled by an UNRELATED process
+before the daemon's next poll, ``_gate_alive`` returns True and the slot stays held
+until that unrelated PID also exits. This only delays a slot release (never leaks one
+permanently, never over-admits gates), the window is a single poll interval, and PID
+reuse landing on exactly the gate PID in that window is rare -- so we accept it rather
+than complicating the probe (e.g. with start-time / pidfd matching).
+
 Contract:
   * Blocks (queues) when all N slots are busy; never fails from contention.
   * Exits 0 after a clean release; exits non-zero only on a usage/IO error before

--- a/scripts/lib/gate_slot_daemon.py
+++ b/scripts/lib/gate_slot_daemon.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Machine-wide full-gate concurrency-cap slot daemon (issue #1825).
+
+A tiny lock-holder process started in the background by scripts/agent-gate.sh. It
+acquires ONE of N machine-wide slot lockfiles via a non-blocking ``fcntl.flock``
+(macOS ships no ``flock(1)`` CLI, so the semaphore is implemented in Python, which
+is already a gate dependency), signals the gate on success by creating a ready
+file, then HOLDS the lock while polling the gate process's liveness. When the gate
+exits -- normally OR via SIGKILL -- the daemon releases the slot and exits.
+
+Why a separate process (not an inherited fd in the gate shell): the gate runs its
+heavy children (cargo, nextest, ...) after acquiring, and any fd the gate shell
+held would be INHERITED by those children, so a SIGKILL of the gate would leave
+the slot locked by an orphaned cargo until it finished. This daemon opens the lock
+fd AFTER it is forked, so the gate's later children never hold the lock; killing
+the gate frees the slot within one poll interval regardless of orphaned children.
+That is the SIGKILL-safe stale-slot-reaping guarantee.
+
+Contract:
+  * Blocks (queues) when all N slots are busy; never fails from contention.
+  * Exits 0 after a clean release; exits non-zero only on a usage/IO error before
+    acquisition (the gate then disables the cap for that run, fail-open).
+"""
+from __future__ import annotations
+
+import argparse
+import fcntl
+import os
+import sys
+import time
+
+
+def _gate_alive(pid: int) -> bool:
+    """True while the gate process is still running (signal 0 probe)."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Exists but owned by another user: still alive for our purposes.
+        return True
+    return True
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="agent-gate concurrency-cap slot daemon")
+    ap.add_argument("--slots-dir", required=True)
+    ap.add_argument("--slots", type=int, required=True)
+    ap.add_argument("--gate-pid", type=int, required=True)
+    ap.add_argument("--ready-file", required=True)
+    ap.add_argument("--poll-secs", type=float, default=2.0)
+    args = ap.parse_args()
+
+    n = args.slots if args.slots >= 1 else 1
+    poll = args.poll_secs if args.poll_secs > 0 else 2.0
+    os.makedirs(args.slots_dir, exist_ok=True)
+
+    held_fd = None
+    try:
+        # Acquire: sweep the N slots non-blocking until one is free, re-sweeping
+        # after a short wait. Give up (without acquiring) if the gate dies while we
+        # are still queued -- there is nothing left to protect.
+        while held_fd is None:
+            for i in range(n):
+                path = os.path.join(args.slots_dir, "slot.%d" % i)
+                fd = os.open(path, os.O_RDWR | os.O_CREAT, 0o644)
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except OSError:
+                    os.close(fd)
+                    continue
+                held_fd = fd
+                break
+            if held_fd is not None:
+                break
+            if not _gate_alive(args.gate_pid):
+                # Gate vanished while we were queued; exit cleanly, nothing held.
+                return 0
+            time.sleep(poll)
+
+        # Signal acquisition atomically (write-then-rename) so the gate never reads
+        # a half-written ready file.
+        tmp = args.ready_file + ".tmp.%d" % os.getpid()
+        with open(tmp, "w") as fh:
+            fh.write("ok\n")
+        os.replace(tmp, args.ready_file)
+
+        # Hold the slot until the gate exits (normal exit OR SIGKILL). The kernel
+        # releases the flock automatically when this process exits and closes the fd.
+        while _gate_alive(args.gate_pid):
+            time.sleep(poll)
+        return 0
+    finally:
+        if held_fd is not None:
+            try:
+                os.close(held_fd)
+            except OSError:
+                pass
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_gate_concurrency_cap.sh
+++ b/scripts/tests/test_gate_concurrency_cap.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# Regression test for issue #1825: the machine-wide FULL-gate concurrency cap.
+#
+# A cross-process bounded semaphore wraps the FULL `agent-gate.sh` run: at most N
+# full gates execute machine-wide at once, excess invocations QUEUE (block) for a
+# slot and never fail, and a SIGKILLed slot-holder releases its slot so a queued
+# gate proceeds. --lite runs are EXEMPT (never queued).
+#
+# This test exercises the semaphore HERMETICALLY via the gate's test-only stub
+# mode (CQLITE_GATE_STUB_RUNDIR): a stub run acquires a REAL slot, drops a per-PID
+# marker while "working", sleeps, then exits 0 without running any real gate work.
+# Every run here pins a PRIVATE CQLITE_GATE_SLOTS_DIR so it can never interfere
+# with (or be perturbed by) a real gate running on the same machine.
+#
+# Run standalone:   bash scripts/tests/test_gate_concurrency_cap.sh
+# Or via the gate:  scripts/agent-gate.sh runs it inside the `tooling-tests` component.
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+GATE="$SCRIPT_DIR/../agent-gate.sh"
+
+PASS=0
+FAIL=0
+ok()  { printf 'ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
+bad() { printf 'FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "SKIP - no python3 on PATH (the #1825 cap needs python3 for fcntl.flock)"
+  exit 0
+fi
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/gate-cap-test.XXXXXX")
+trap 'rm -rf "$tmp"; kill $(jobs -p) 2>/dev/null' EXIT
+
+# marker_count <rundir>: how many stub runs currently hold a slot (marker files).
+# Always prints an integer (0 when none), never empty — callers use it in `[ ]`.
+marker_count() {
+  local d="$1" c=0 f
+  for f in "$d"/holding.*; do
+    [ -e "$f" ] && c=$(( c + 1 ))
+  done
+  printf '%s' "$c"
+}
+
+# wait_until <timeout_s> <cmd...>: poll cmd (exit 0 == satisfied) up to timeout.
+wait_until() {
+  local timeout="$1"; shift
+  local deadline=$(( $(date +%s) + timeout ))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    if "$@"; then return 0; fi
+    sleep 0.2
+  done
+  return 1
+}
+
+# wait_for_markers <rundir> <target> <timeout_s>: re-poll the live marker count
+# until it reaches <target> (or timeout). Unlike passing `$(marker_count ...)` to
+# wait_until, this re-reads the count each iteration instead of a stale snapshot.
+wait_for_markers() {
+  local d="$1" target="$2" timeout="$3"
+  local deadline=$(( $(date +%s) + timeout ))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    [ "$(marker_count "$d")" -ge "$target" ] && return 0
+    sleep 0.2
+  done
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Case (a): M > N full gates concurrently -> at most N run at once; rest queue
+# then run; none fail from the cap.
+# ---------------------------------------------------------------------------
+a_slots="$tmp/a-slots"; a_run="$tmp/a-run"
+mkdir -p "$a_run"
+N=2; M=5
+declare -a a_pids=()
+for _ in $(seq 1 "$M"); do
+  CQLITE_GATE_SLOTS_DIR="$a_slots" CQLITE_GATE_MAX_CONCURRENCY="$N" \
+    CQLITE_GATE_STUB_RUNDIR="$a_run" CQLITE_GATE_STUB_SLEEP=2 CQLITE_GATE_POLL_SECS=0.3 \
+    bash "$GATE" >/dev/null 2>&1 &
+  a_pids+=("$!")
+done
+
+# Sample concurrency while the batch drains; track the max observed holders.
+a_max=0
+a_deadline=$(( $(date +%s) + 30 ))
+while [ "$(date +%s)" -lt "$a_deadline" ]; do
+  c=$(marker_count "$a_run")
+  [ "$c" -gt "$a_max" ] && a_max="$c"
+  # Stop sampling once every launched run has exited.
+  running=0
+  for p in "${a_pids[@]}"; do kill -0 "$p" 2>/dev/null && running=$((running + 1)); done
+  [ "$running" -eq 0 ] && break
+  sleep 0.15
+done
+
+a_fail=0
+for p in "${a_pids[@]}"; do wait "$p" || a_fail=$((a_fail + 1)); done
+
+if [ "$a_max" -le "$N" ]; then
+  ok "cap: at most N=$N stub gates ran at once (observed max=$a_max of M=$M)"
+else
+  bad "cap: observed max=$a_max EXCEEDS N=$N (semaphore leaked a slot)"
+fi
+if [ "$a_max" -ge "$N" ]; then
+  ok "cap: parallelism reached N=$N (observed max=$a_max) — slots are actually used"
+else
+  bad "cap: never reached N=$N concurrency (observed max=$a_max) — over-serialized"
+fi
+if [ "$a_fail" -eq 0 ]; then
+  ok "cap: all M=$M queued runs completed (exit 0) — none failed from the cap"
+else
+  bad "cap: $a_fail of M=$M runs exited non-zero (the cap must queue, not fail)"
+fi
+
+# ---------------------------------------------------------------------------
+# Case (b): --lite is NOT blocked when the cap is saturated.
+# ---------------------------------------------------------------------------
+b_slots="$tmp/b-slots"; b_run="$tmp/b-run"
+mkdir -p "$b_run"
+BN=2
+declare -a b_fillers=()
+for _ in $(seq 1 "$BN"); do
+  CQLITE_GATE_SLOTS_DIR="$b_slots" CQLITE_GATE_MAX_CONCURRENCY="$BN" \
+    CQLITE_GATE_STUB_RUNDIR="$b_run" CQLITE_GATE_STUB_SLEEP=15 CQLITE_GATE_POLL_SECS=0.3 \
+    bash "$GATE" >/dev/null 2>&1 &
+  b_fillers+=("$!")
+done
+# Wait until both slots are saturated (re-polls the live marker count).
+wait_for_markers "$b_run" "$BN" 10
+saturated=$(marker_count "$b_run")
+
+# Launch a --lite run against the SATURATED cap; it must finish fast (exempt), not
+# wait ~15s for a slot. Use its own rundir marker to confirm it actually ran.
+b_lite_run="$tmp/b-lite-run"; mkdir -p "$b_lite_run"
+lite_start=$(date +%s)
+CQLITE_GATE_SLOTS_DIR="$b_slots" CQLITE_GATE_MAX_CONCURRENCY="$BN" \
+  CQLITE_GATE_STUB_RUNDIR="$b_lite_run" CQLITE_GATE_STUB_SLEEP=0 CQLITE_GATE_POLL_SECS=0.3 \
+  bash "$GATE" --lite >/dev/null 2>&1
+lite_rc=$?
+lite_elapsed=$(( $(date +%s) - lite_start ))
+
+# Tear down the long-sleeping fillers immediately (don't wait 15s).
+for p in "${b_fillers[@]}"; do kill "$p" 2>/dev/null; done
+for p in "${b_fillers[@]}"; do wait "$p" 2>/dev/null; done
+
+if [ "$saturated" = "$BN" ]; then
+  ok "lite-exempt: cap saturated at N=$BN before the --lite run"
+else
+  bad "lite-exempt: cap did not saturate ($saturated of $BN) — test setup weak"
+fi
+if [ "$lite_rc" -eq 0 ] && [ "$lite_elapsed" -lt 8 ]; then
+  ok "lite-exempt: --lite completed in ${lite_elapsed}s despite a saturated cap (not queued)"
+else
+  bad "lite-exempt: --lite blocked or failed (rc=$lite_rc, ${lite_elapsed}s) — must be exempt"
+fi
+
+# ---------------------------------------------------------------------------
+# Case (c): SIGKILL a slot-holder -> its slot is released and a queued gate proceeds.
+# ---------------------------------------------------------------------------
+c_slots="$tmp/c-slots"; c_run="$tmp/c-run"
+mkdir -p "$c_run"
+# N=1: exactly one slot, so holder A blocks the queue until it dies. A sleeps long
+# enough to still be alive (holding the slot) when we SIGKILL it below.
+CQLITE_GATE_SLOTS_DIR="$c_slots" CQLITE_GATE_MAX_CONCURRENCY=1 \
+  CQLITE_GATE_STUB_RUNDIR="$c_run" CQLITE_GATE_STUB_SLEEP=30 CQLITE_GATE_POLL_SECS=0.3 \
+  bash "$GATE" >/dev/null 2>&1 &
+c_a=$!
+# Wait for A to hold the only slot.
+if wait_until 10 test -e "$c_run/holding.$c_a"; then
+  ok "sigkill: holder A acquired the only slot (N=1)"
+else
+  bad "sigkill: holder A never acquired the slot"
+fi
+
+# B queues behind A (short sleep once it gets in).
+CQLITE_GATE_SLOTS_DIR="$c_slots" CQLITE_GATE_MAX_CONCURRENCY=1 \
+  CQLITE_GATE_STUB_RUNDIR="$c_run" CQLITE_GATE_STUB_SLEEP=1 CQLITE_GATE_POLL_SECS=0.3 \
+  bash "$GATE" >/dev/null 2>&1 &
+c_b=$!
+sleep 1
+# B must NOT be holding yet (A owns the sole slot).
+if [ -e "$c_run/holding.$c_b" ]; then
+  bad "sigkill: B acquired a slot while A still held the only one (cap leaked)"
+else
+  ok "sigkill: B correctly queued while A held the only slot"
+fi
+
+# SIGKILL A: its fd 9 closes, the kernel releases the flock, B's next sweep gets it.
+kill -9 "$c_a" 2>/dev/null
+wait "$c_a" 2>/dev/null
+if wait_until 15 test -e "$c_run/holding.$c_b"; then
+  ok "sigkill: after A was SIGKILLed, queued B acquired the freed slot"
+else
+  bad "sigkill: B never acquired the slot after A died (stale-slot leak / deadlock)"
+fi
+if wait "$c_b"; then
+  ok "sigkill: B completed (exit 0) after inheriting the released slot"
+else
+  bad "sigkill: B did not exit 0 after acquiring the freed slot"
+fi
+
+# ---------------------------------------------------------------------------
+# Case (d): the default N formula = max(2, floor((ncpu-2)/4)) and the override.
+# ---------------------------------------------------------------------------
+# The override is honored (verified indirectly above via N=1/N=2 behavior). Here
+# assert the documented default floor of 2 by driving the exact formula in shell.
+ncpu_probe=$( { command -v nproc >/dev/null 2>&1 && nproc; } || sysctl -n hw.ncpu 2>/dev/null || echo 4 )
+case "$ncpu_probe" in *[!0-9]*|'') ncpu_probe=4 ;; esac
+formula=$(( ( ncpu_probe - 2 ) / 4 ))
+[ "$formula" -lt 2 ] && formula=2
+if [ "$formula" -ge 2 ]; then
+  ok "default-N: formula max(2, floor((ncpu-2)/4)) = $formula (>= floor of 2) for ncpu=$ncpu_probe"
+else
+  bad "default-N: formula produced $formula (< 2 floor) for ncpu=$ncpu_probe"
+fi
+
+echo "----"
+echo "passed: $PASS  failed: $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/scripts/tests/test_gate_concurrency_cap.sh
+++ b/scripts/tests/test_gate_concurrency_cap.sh
@@ -75,8 +75,12 @@ mkdir -p "$a_run"
 N=2; M=5
 declare -a a_pids=()
 for _ in $(seq 1 "$M"); do
+  # STUB_SLEEP is deliberately generous (4s): case (a)'s lower-bound assertion
+  # (a_max >= N) needs the N concurrent holders to overlap in time long enough that
+  # a loaded machine's sampler is guaranteed to observe them together. A short sleep
+  # could let holders come and go between polls and spuriously miss the overlap.
   CQLITE_GATE_SLOTS_DIR="$a_slots" CQLITE_GATE_MAX_CONCURRENCY="$N" \
-    CQLITE_GATE_STUB_RUNDIR="$a_run" CQLITE_GATE_STUB_SLEEP=2 CQLITE_GATE_POLL_SECS=0.3 \
+    CQLITE_GATE_STUB_RUNDIR="$a_run" CQLITE_GATE_STUB_SLEEP=4 CQLITE_GATE_POLL_SECS=0.3 \
     bash "$GATE" >/dev/null 2>&1 &
   a_pids+=("$!")
 done
@@ -91,7 +95,7 @@ while [ "$(date +%s)" -lt "$a_deadline" ]; do
   running=0
   for p in "${a_pids[@]}"; do kill -0 "$p" 2>/dev/null && running=$((running + 1)); done
   [ "$running" -eq 0 ] && break
-  sleep 0.15
+  sleep 0.05
 done
 
 a_fail=0

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -69,6 +69,48 @@ scripts/agent-gate.sh --list
 
 Exit codes: `0` = PASS, `1` = FAIL, `3` = PARTIAL (--only mode).
 
+## Machine-wide concurrency cap (issue #1825)
+
+Running many sessions/worktrees at once used to let ~15 full gates hit the CPU
+simultaneously (load 30–60), which SIGKILLed gates mid-`core-tests`. The full gate
+now takes a **cross-process bounded semaphore**: at most **N** full
+`agent-gate.sh` runs execute machine-wide at once. Excess invocations **queue**
+(block) for a slot and print one line — `waiting for gate slot (N in use)…` — then
+proceed when a slot frees. **They never fail from the cap**, and a non-interactive
+caller blocks cleanly rather than spin-failing.
+
+- **`--lite` and `--only` runs are EXEMPT** — never queued. `--lite` is cheap by
+  design; `--only` is a PARTIAL run (and is used by nested tooling self-tests, so
+  capping it could self-deadlock the queue).
+- **N** defaults to `max(2, floor((ncpu-2)/4))` — a conservative fraction of cores
+  that still lets a couple of gates run on a small box. Override with
+  `CQLITE_GATE_MAX_CONCURRENCY`.
+- **SIGKILL-safe stale-slot reaping:** each slot is an `fcntl.flock` held by a
+  small background daemon (`scripts/lib/gate_slot_daemon.py`) that the gate starts
+  and monitors. Because the daemon opens the lock fd *after* it is forked, the
+  gate's heavy children (`cargo`/`nextest`) never inherit the lock — a SIGKILLed
+  gate frees its slot within one poll interval even while orphaned children run on.
+  A crashed gate can never permanently leak a slot.
+- Works **across worktrees** (shared slot dir, not per-checkout) and composes with
+  the per-gate component parallelism (`AGENT_GATE_JOBS`) and `sccache`: the cap
+  bounds the *worst case* (several sessions hitting their one full gate at once),
+  the others cut average load and per-compile time.
+
+**Environment knobs** (all optional):
+
+```bash
+CQLITE_GATE_MAX_CONCURRENCY=4 bash scripts/agent-gate.sh   # raise N on a big box
+CQLITE_GATE_SLOTS_DIR=/path bash scripts/agent-gate.sh     # slot dir (default $TMPDIR/cqlite-gate-slots)
+CQLITE_GATE_POLL_SECS=1 bash scripts/agent-gate.sh         # queue/liveness poll (default 2s)
+CQLITE_GATE_DISABLE_CAP=1 bash scripts/agent-gate.sh       # force-disable the cap
+```
+
+The cap fails **open** (disabled, with a loud stderr note) when `python3` or the
+daemon is unavailable — the gate must never be un-runnable because of the cap. A
+hermetic self-test proving queueing at N, `--lite` exemption, and SIGKILL slot
+release lives at `scripts/tests/test_gate_concurrency_cap.sh` and runs inside the
+`tooling-tests` component.
+
 ## Capturing the gate robustly (issue #1175)
 
 The SUMMARY block is the only artifact that counts, so it must survive however


### PR DESCRIPTION
Closes #1825. Third lever of the gate-perf trio (#1821 --lite, #1822 sccache): bounds how many FULL gates run machine-wide at once, enabling higher session concurrency without the observed load-30–60 / SIGKILLed-gates / 1h22m-stall thrash.

## What
- `scripts/lib/gate_slot_daemon.py` — python3 fcntl.flock slot daemon (macOS has no flock(1)). Runs as a SEPARATE process so the gate's cargo children never inherit the lock fd: SIGKILL of the gate frees the slot within one poll interval even while orphaned children run. PID-reuse caveat documented.
- `scripts/agent-gate.sh` — `acquire_gate_slot` around the full gate only. EXEMPT: `--lite` (must stay instant) and `--only` (nested tooling self-tests would self-deadlock). Fail-open when python3/daemon/slots-dir unavailable. Queue notice on stderr. N = `max(2, floor((ncpu-2)/4))`, override `CQLITE_GATE_MAX_CONCURRENCY`; slots dir `CQLITE_GATE_SLOTS_DIR`; kill-switch `CQLITE_GATE_DISABLE_CAP=1`.
- `scripts/tests/test_gate_concurrency_cap.sh` — hermetic stub-mode self-test wired into the `tooling-tests` component: proves ≤N concurrency with M>N queued runs (none fail), --lite exemption under a saturated cap, and SIGKILL slot release. 10/10.
- Also fixes a latent #1841 bug this work surfaced: `${side_lane[@]}` unbound-variable crash under stock bash 3.2 + `set -u` on any `--only` run.
- Doctrine updated in-change: CLAUDE.md + agents-developing gate-contract page.

## Self-test (10/10)
```
ok - cap: at most N=2 stub gates ran at once (observed max=2 of M=5)
ok - cap: all M=5 queued runs completed (exit 0) — none failed from the cap
ok - lite-exempt: --lite completed in 1s despite a saturated cap (not queued)
ok - sigkill: after A was SIGKILLed, queued B acquired the freed slot
(+6 more)
```

## Gate of record (full, verbatim)
```
==== AGENT-GATE SUMMARY ====
run-id: /var/folders/2c/tfxwt1g91x729x38m63d81540000gn/T//agent-gate.EUcOjG
commit: bb551515 branch: issue-1825-gate-concurrency-cap dirty: no
datasets: 144 Data.db files under /Users/patrickmcfadin/local_projects/cqlite/test-data/datasets
ci-pins: DATASET_TAG: datasets-v3 DATASET_ASSET: cassandra5-small-full-v3.4.tar.gz DATASET_SHA256: 3cae644360e0142a6bb5e96ddab445ff18e3478e7058104842ce1a455fba8a33 
file-size:         PASS (0s)
fmt:               PASS (18s)
clippy:            PASS (5s)
core-tests:        PASS (159s)
tombstones-scan:   PASS (1s)
scan-offload-guard: PASS (1s)
memory-budget:     PASS (50s)
integration-tests: PASS (3s)
format-compat:     PASS (1s)
write-tests:       PASS (26s)
cli-tests:         PASS (7s)
compaction-byte-parity: PASS (3s)
python-bindings:   PASS (198s)
node-bindings:     PASS (519s)
delivery-telemetry: PASS (0s)
parity-report:     PASS (3s)
binding-unwind-profile: PASS (3s)
tooling-tests:     PASS (32s)
minimal-build:     PASS (1s)
smoke:             PASS (11s)
logs: /var/folders/2c/tfxwt1g91x729x38m63d81540000gn/T//agent-gate.EUcOjG
summary-file: /tmp/gate-1825-final3-summary.txt
RESULT: PASS
==== END AGENT-GATE SUMMARY ====
```

roborev job 1432: 3 Low findings, all addressed in `bb551515` (PID-reuse caveat doc, self-test timing margin, notices to stderr). Oracle-driven infra change (gate as oracle), no OpenSpec.