### PR TITLE
refactor(#1439): compiler-enforced writable_engine() accessor in bindings

### DIFF
--- a/bindings/node/src/database.rs
+++ b/bindings/node/src/database.rs
@@ -411,6 +411,21 @@ impl Database {
         }
     }
 
+    /// The write engine, or a typed error if the database is read-only.
+    /// Replaces the `ensure_writable()? … .expect(Some)` two-step so the `Some`
+    /// unwrap is compiler-enforced (no reachable panic in a write path).
+    #[cfg(feature = "write-support")]
+    fn writable_engine(
+        &self,
+    ) -> napi::Result<&Arc<Mutex<cqlite_core::storage::write_engine::WriteEngine>>> {
+        self.write_engine.as_ref().ok_or_else(|| {
+            simple_error(
+                "Write support not enabled. Open with { writable: true, writeDir: '<path>' } \
+                 to enable write operations.",
+            )
+        })
+    }
+
     /// Determine whether a CQL statement is a write operation.
     ///
     /// Deliberately NOT feature-gated: the read-path entry points must be able to
@@ -820,12 +835,7 @@ impl Database {
             // engine.execute() call does not stall the napi async executor thread.
             #[cfg(feature = "write-support")]
             if Self::is_dml_statement(&query) {
-                self.ensure_writable()?;
-                let we_clone = Arc::clone(
-                    self.write_engine
-                        .as_ref()
-                        .expect("ensure_writable verified write_engine is Some"),
-                );
+                let we_clone = Arc::clone(self.writable_engine()?);
                 let (elapsed_ms, applied) = tokio::task::spawn_blocking(move || {
                     let start = std::time::Instant::now();
                     let mut engine = we_clone
@@ -1224,12 +1234,7 @@ impl Database {
 
         #[cfg(feature = "write-support")]
         {
-            self.ensure_writable()?;
-
-            let we = self
-                .write_engine
-                .as_ref()
-                .expect("ensure_writable verified write_engine is Some");
+            let we = self.writable_engine()?;
 
             // `flush()` is async and takes &mut self on the engine.
             // We hold the Mutex lock and block_on inside a spawn_blocking to avoid
@@ -1290,15 +1295,9 @@ impl Database {
 
         #[cfg(feature = "write-support")]
         {
-            self.ensure_writable()?;
-
             let budget_ms = options.as_ref().and_then(|o| o.budget_ms).unwrap_or(100) as u64;
 
-            let we = self
-                .write_engine
-                .as_ref()
-                .expect("ensure_writable verified write_engine is Some");
-            let we_clone = Arc::clone(we);
+            let we_clone = Arc::clone(self.writable_engine()?);
 
             let report = tokio::task::spawn_blocking(move || {
                 let mut engine = we_clone
@@ -1354,12 +1353,7 @@ impl Database {
 
         #[cfg(feature = "write-support")]
         {
-            self.ensure_writable()?;
-
-            let we = self
-                .write_engine
-                .as_ref()
-                .expect("ensure_writable verified write_engine is Some");
+            let we = self.writable_engine()?;
             let engine = we
                 .lock()
                 .map_err(|_| simple_error("Write engine lock poisoned"))?;

--- a/bindings/python/src/database.rs
+++ b/bindings/python/src/database.rs
@@ -102,16 +102,15 @@ impl Database {
         per_call.or(self.default_traceparent.as_deref())
     }
 
-    /// Return a clear error when a write method is called on a read-only database.
-    fn require_writable(&self) -> PyResult<()> {
-        if self.write_engine.is_none() {
-            return Err(PyRuntimeError::new_err(
-                "Database is read-only. \
-                 Open with writable=True and write_dir=<path> to enable write operations. \
-                 Example: cqlite.open(path, schema=schema, writable=True, write_dir='/tmp/writes')",
-            ));
-        }
-        Ok(())
+    /// The write engine, or a typed error if the database is read-only.
+    /// Replaces the `require_writable()? … .expect(Some)` two-step.
+    fn writable_engine(&self) -> PyResult<&Mutex<PyWriteEngine>> {
+        self.write_engine.as_ref().ok_or_else(|| {
+            PyRuntimeError::new_err(
+                "Database is read-only. Open with writable=True and write_dir=<path> \
+                 to enable write operations.",
+            )
+        })
     }
 
     /// Detect DML statements (INSERT / UPDATE / DELETE / BEGIN BATCH).
@@ -593,12 +592,8 @@ impl Database {
     /// ```
     pub fn flush_run(&self) -> PyResult<String> {
         self.ensure_open()?;
-        self.require_writable()?;
 
-        let engine_mutex = self
-            .write_engine
-            .as_ref()
-            .expect("require_writable() guarantees write_engine is Some");
+        let engine_mutex = self.writable_engine()?;
 
         let mut engine = engine_mutex
             .lock()
@@ -641,12 +636,8 @@ impl Database {
     /// ```
     pub fn maintenance_step(&self, budget_ms: u64) -> PyResult<MaintenanceReport> {
         self.ensure_open()?;
-        self.require_writable()?;
 
-        let engine_mutex = self
-            .write_engine
-            .as_ref()
-            .expect("require_writable() guarantees write_engine is Some");
+        let engine_mutex = self.writable_engine()?;
 
         let mut engine = engine_mutex
             .lock()
@@ -684,12 +675,8 @@ impl Database {
     #[getter]
     pub fn write_stats(&self) -> PyResult<WriteStats> {
         self.ensure_open()?;
-        self.require_writable()?;
 
-        let engine_mutex = self
-            .write_engine
-            .as_ref()
-            .expect("require_writable() guarantees write_engine is Some");
+        let engine_mutex = self.writable_engine()?;
 
         let engine = engine_mutex
             .lock()
@@ -708,12 +695,7 @@ impl Database {
     fn execute_dml(&self, py: Python<'_>, query: &str) -> PyResult<QueryResult> {
         use std::time::Instant;
 
-        self.require_writable()?;
-
-        let engine_mutex = self
-            .write_engine
-            .as_ref()
-            .expect("require_writable() guarantees write_engine is Some");
+        let engine_mutex = self.writable_engine()?;
 
         let query_owned = query.to_string();
         let t0 = Instant::now();


### PR DESCRIPTION
Closes #1439.

## What
Collapses the `require_writable()?`/`ensure_writable()?` + `.expect("write_engine is Some")` two-step into a single `Result`-returning `writable_engine()` accessor in both bindings, so the `Some` unwrap is **compiler-enforced** — no reachable `.expect` panic in a write path (which under release `panic=abort` would abort the host process).

- **Python** (`bindings/python/src/database.rs`): added `writable_engine() -> PyResult<&Mutex<PyWriteEngine>>`; replaced 4 sites (flush_run, maintenance_step, write_stats, execute_dml); deleted now-dead `require_writable`.
- **Node** (`bindings/node/src/database.rs`): added `#[cfg(feature="write-support")]` `writable_engine() -> napi::Result<&Arc<Mutex<WriteEngine>>>`; replaced 4 `write_engine` sites; **kept** `ensure_writable` (still used standalone as the execute() DML pre-check); left `:536` `write_dir` expect untouched (out of scope).
- Node `database.rs`: 1821 → 1815 lines.

## Verification
- `rg '\.expect\("(require_writable|ensure_writable)' bindings/*/src/database.rs` → 0 hits.
- rust-reviewer: clean. roborev (claude-code/opus vs origin/main): No issues found.
- Full agent-gate: all diff-relevant components PASS. Two FAILs proven pre-existing/environmental (NOT this 2-file diff): `core-tests` `issue_953_multichunk_cell_seek` hard-panics on absent local-only fixture — reproduces byte-identically on clean origin/main, filed as #1856; `python-bindings` known load-sensitive GIL flake `test_streaming_next_releases_gil`.

_Delivered by flow-lead worker; seams pre-approved (owner AFK)._