### PR TITLE
fix(#1580): cross-SSTable scan returns Cassandra token order (k-way merge, oracle-first)

### DIFF
--- a/cqlite-core/src/storage/sstable/mod.rs
+++ b/cqlite-core/src/storage/sstable/mod.rs
@@ -31,6 +31,8 @@ pub mod refresh;
 pub use refresh::RefreshReport;
 mod reverse_scan; // BIG reverse partition iteration (issue #1184); file is tombstones-gated.
 pub mod row_cell_state_machine;
+/// Cross-SSTable scan ordering: k-way merge in Cassandra token order (issue #1580).
+mod scan_merge;
 pub mod statistics_reader;
 #[cfg(feature = "tombstones")]
 pub mod tombstone_merger;
@@ -834,41 +836,23 @@ impl SSTableManager {
                 }
             }
 
-            let mut all_results = Vec::new();
-
+            // Each reader returns rows already in Cassandra token order; k-way
+            // merge the per-reader streams in token order (issue #1580) instead of
+            // concatenating + re-sorting by RAW key bytes (wrong global order +
+            // O(n log n) on the async worker). The merge is O(n log k) and
+            // early-exits once `limit` is satisfied.
+            let mut per_reader = Vec::with_capacity(reader_list.len());
             for reader in reader_list {
-                log::debug!(
-                    "SSTableManager::scan - Calling scan on reader for file: {:?}",
-                    reader.file_path
-                );
-
                 let results = reader
                     .scan(table_id, start_key, end_key, None, schema)
                     .await?;
-
-                log::debug!(
-                    "SSTableManager::scan - Reader returned {} results",
-                    results.len()
-                );
-
-                all_results.extend(results);
+                per_reader.push(results);
             }
 
-            log::debug!(
-                "SSTableManager::scan - Total results from all readers: {}",
-                all_results.len()
-            );
-
-            // Sort results by key
-            all_results.sort_by(|a, b| a.0.cmp(&b.0));
-
-            // Apply limit
-            if let Some(limit) = limit {
-                all_results.truncate(limit);
-            }
+            let all_results = scan_merge::kway_merge_token_order(per_reader, limit);
 
             log::debug!(
-                "SSTableManager::scan - Returning {} final results",
+                "SSTableManager::scan - Returning {} final results (token-ordered k-way merge)",
                 all_results.len()
             );
 
@@ -1463,13 +1447,13 @@ impl SSTableManager {
         .await
         .map_err(|e| crate::Error::Storage(format!("cross-generation read merge task: {e}")))??;
 
-        // Match the plain-scan contract: sort by key bytes, then apply LIMIT. The
-        // merger already emits partitions in token order with clustering rows in
-        // order within a partition; a stable sort by key preserves that grouping.
-        merged.sort_by(|a, b| a.0.cmp(&b.0));
-        if let Some(limit) = limit {
-            merged.truncate(limit);
-        }
+        // Match the plain-scan contract: the merger already emits partitions in
+        // Cassandra token order with clustering rows contiguous within a
+        // partition. Preserve that with a stable TOKEN-order sort (issue #1580) —
+        // NOT a raw-key-byte sort, which would re-break the token ordering — then
+        // apply LIMIT. The sort is a no-op ordering-wise when the merger's output
+        // is already token-ordered; it only guards against a stray divergence.
+        scan_merge::sort_by_token_order(&mut merged, limit, |(k, _)| k);
         Ok(merged)
     }
 
@@ -1635,11 +1619,11 @@ impl SSTableManager {
             results.push((RowKey(key_bytes), value, meta_map));
         }
 
-        // Match the plain-scan contract: sort by key bytes, then apply LIMIT.
-        results.sort_by(|a, b| a.0.cmp(&b.0));
-        if let Some(limit) = limit {
-            results.truncate(limit);
-        }
+        // Match the plain-scan contract: stable TOKEN-order sort (issue #1580),
+        // not a raw-key-byte sort, then apply LIMIT. The metadata payload rides
+        // along in the tuple's tail, which `sort_by_token_order` orders by
+        // (token, key) — identical ordering to the plain merge path.
+        scan_merge::sort_by_token_order(&mut results, limit, |(k, _, _)| k);
         Ok(results)
     }
 
@@ -1720,20 +1704,27 @@ impl SSTableManager {
                 }
             }
 
-            let mut all_results = Vec::new();
-
+            // K-way merge the per-reader token-ordered streams (issue #1580),
+            // mirroring `scan`: the metadata payload rides alongside the row.
+            // Merging in token order (not raw key bytes) matches Cassandra's
+            // cross-SSTable order and avoids the full O(n log n) re-sort.
+            let mut per_reader = Vec::with_capacity(reader_list.len());
             for reader in reader_list {
                 let results = reader
                     .scan_with_cell_metadata(table_id, start_key, end_key, None, schema)
                     .await?;
-                all_results.extend(results);
+                per_reader.push(
+                    results
+                        .into_iter()
+                        .map(|(k, v, m)| (k, (v, m)))
+                        .collect::<Vec<_>>(),
+                );
             }
 
-            // Sort by key (token order) and apply limit
-            all_results.sort_by(|a, b| a.0.cmp(&b.0));
-            if let Some(limit) = limit {
-                all_results.truncate(limit);
-            }
+            let all_results = scan_merge::kway_merge_token_order(per_reader, limit)
+                .into_iter()
+                .map(|(k, (v, m))| (k, v, m))
+                .collect();
 
             Ok(all_results)
         } else {
@@ -1877,11 +1868,18 @@ impl SSTableManager {
                 })
                 .collect();
 
-            // Prime one head per stream.
-            let mut heads: Vec<Option<(RowKey, ScanRow)>> = Vec::with_capacity(streams.len());
+            // Prime one head per stream. Each head carries its precomputed
+            // Cassandra Murmur3 token so the merge orders by (token, key) — the
+            // authoritative cross-SSTable order (issue #1580) — and never hashes a
+            // key more than once. Comparing by raw `RowKey` bytes here (as this
+            // path previously did) diverged from `scan`'s token order.
+            let token_of = |key: &RowKey| {
+                crate::util::cassandra_murmur3::cassandra_murmur3_token(key.as_bytes())
+            };
+            let mut heads: Vec<Option<(i64, RowKey, ScanRow)>> = Vec::with_capacity(streams.len());
             for stream in streams.iter_mut() {
                 match stream.recv().await {
-                    Some(Ok(entry)) => heads.push(Some(entry)),
+                    Some(Ok((key, row))) => heads.push(Some((token_of(&key), key, row))),
                     Some(Err(e)) => {
                         let _ = out_tx.send(Err(e)).await;
                         return;
@@ -1890,17 +1888,18 @@ impl SSTableManager {
                 }
             }
 
-            // K-way merge: repeatedly emit the smallest-key head, ties broken by
-            // reader index to match the stable concat+sort order of `scan`.
+            // K-way merge: repeatedly emit the head with the smallest
+            // (token, key), ties broken by reader index to match the stable
+            // token-order merge of `scan`.
             loop {
                 let mut min_idx: Option<usize> = None;
                 for (i, head) in heads.iter().enumerate() {
-                    if let Some((ref key, _)) = head {
+                    if let Some((ref token, ref key, _)) = head {
                         match min_idx {
                             None => min_idx = Some(i),
                             Some(m) => {
-                                if let Some((ref min_key, _)) = heads[m] {
-                                    if key < min_key {
+                                if let Some((ref min_token, ref min_key, _)) = heads[m] {
+                                    if (token, key) < (min_token, min_key) {
                                         min_idx = Some(i);
                                     }
                                 }
@@ -1915,11 +1914,11 @@ impl SSTableManager {
 
                 // Take the winning entry and advance only that stream.
                 let entry = match heads[idx].take() {
-                    Some(entry) => entry,
+                    Some((_, key, row)) => (key, row),
                     None => break, // unreachable: min_idx points to a Some head
                 };
                 match streams[idx].recv().await {
-                    Some(Ok(next)) => heads[idx] = Some(next),
+                    Some(Ok((key, row))) => heads[idx] = Some((token_of(&key), key, row)),
                     Some(Err(e)) => {
                         let _ = out_tx.send(Err(e)).await;
                         return;

--- a/cqlite-core/src/storage/sstable/scan_merge.rs
+++ b/cqlite-core/src/storage/sstable/scan_merge.rs
@@ -47,10 +47,10 @@ use crate::util::cassandra_murmur3::cassandra_murmur3_token;
 /// [`sort_by_token_order`] since process start.
 pub(crate) static MANAGER_SCAN_FULL_SORTS: AtomicU64 = AtomicU64::new(0);
 
-/// Per-thread key-comparison counter for [`kway_merge_token_order`], incremented by
-/// [`Candidate::cmp`]. Thread-local (not a process-global atomic) so concurrent
-/// tests on cargo's multithreaded runner never race on it; compiled only under
-/// `test` or the `metrics` feature, so production `Candidate::cmp` pays nothing.
+// Per-thread key-comparison counter for `kway_merge_token_order`, incremented by
+// `Candidate::cmp`. Thread-local (not a process-global atomic) so concurrent
+// tests on cargo's multithreaded runner never race on it; compiled only under
+// `test` or the `metrics` feature, so production `Candidate::cmp` pays nothing.
 #[cfg(any(test, feature = "metrics"))]
 thread_local! {
     static SCAN_KEY_COMPARISONS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
@@ -294,10 +294,7 @@ mod tests {
         // Single stream: returned as-is (reader already token-ordered), no merge.
         let (merged, cmps) = kway_merge_counting(vec![only], None);
         assert_eq!(merged.len(), 2);
-        assert_eq!(
-            cmps, 0,
-            "single-stream fast path must not compare keys"
-        );
+        assert_eq!(cmps, 0, "single-stream fast path must not compare keys");
     }
 
     #[test]

--- a/cqlite-core/src/storage/sstable/scan_merge.rs
+++ b/cqlite-core/src/storage/sstable/scan_merge.rs
@@ -28,11 +28,13 @@
 //!
 //! # Instrumentation
 //!
-//! [`MANAGER_SCAN_KEY_COMPARISONS`] counts key comparisons performed by the k-way
-//! merge, and [`MANAGER_SCAN_FULL_SORTS`] counts materialized full-vector sorts.
-//! Tests use these to assert the scan path is O(n log k) and never falls back to a
-//! full O(n log n) concat sort. Both use `Relaxed` atomics — the increment is
-//! negligible next to per-row decode work.
+//! Key-comparison counting used by the O(n log k) no-full-sort regression test is a
+//! **per-thread** counter ([`SCAN_KEY_COMPARISONS`], compiled only under `test`/the
+//! `metrics` feature) exposed to tests via [`kway_merge_counting`], which resets and
+//! reads it within a single call. Because it is thread-local rather than a
+//! process-global atomic, concurrent tests on cargo's multithreaded runner can never
+//! race on it, and the production merge path pays nothing (the increment is not even
+//! compiled in). [`MANAGER_SCAN_FULL_SORTS`] counts materialized full-vector sorts.
 
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
@@ -41,13 +43,18 @@ use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
 use crate::types::RowKey;
 use crate::util::cassandra_murmur3::cassandra_murmur3_token;
 
-/// Number of key comparisons performed by [`kway_merge_token_order`] since process
-/// start. Exposed for the O(n log k) no-full-sort regression assertion.
-pub(crate) static MANAGER_SCAN_KEY_COMPARISONS: AtomicU64 = AtomicU64::new(0);
-
 /// Number of materialized full-vector token-order sorts performed by
 /// [`sort_by_token_order`] since process start.
 pub(crate) static MANAGER_SCAN_FULL_SORTS: AtomicU64 = AtomicU64::new(0);
+
+/// Per-thread key-comparison counter for [`kway_merge_token_order`], incremented by
+/// [`Candidate::cmp`]. Thread-local (not a process-global atomic) so concurrent
+/// tests on cargo's multithreaded runner never race on it; compiled only under
+/// `test` or the `metrics` feature, so production `Candidate::cmp` pays nothing.
+#[cfg(any(test, feature = "metrics"))]
+thread_local! {
+    static SCAN_KEY_COMPARISONS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+}
 
 /// Heap element pairing an ordering key ([`Candidate`]) with its opaque payload
 /// `T`. Ordering delegates entirely to the [`Candidate`] so no `T: Ord` bound is
@@ -78,8 +85,9 @@ impl<T> Ord for HeapItem<T> {
 /// (hashed once per row, not per comparison), partition key, and reader index.
 /// Ordered ascending `(token, key_bytes, reader_idx)`; `reader_idx` breaks ties so
 /// equal-`(token, key)` rows from different readers emit in reader order,
-/// reproducing the stable concat order the old raw-byte `sort_by` gave. Every
-/// [`Candidate::cmp`] increments [`MANAGER_SCAN_KEY_COMPARISONS`].
+/// reproducing the stable concat order the old raw-byte `sort_by` gave. Under
+/// `test`/`metrics`, every [`Candidate::cmp`] bumps the per-thread
+/// [`SCAN_KEY_COMPARISONS`] counter; production builds compile no counting at all.
 struct Candidate {
     token: i64,
     key: RowKey,
@@ -88,7 +96,8 @@ struct Candidate {
 
 impl Candidate {
     fn cmp(&self, other: &Self) -> Ordering {
-        MANAGER_SCAN_KEY_COMPARISONS.fetch_add(1, AtomicOrdering::Relaxed);
+        #[cfg(any(test, feature = "metrics"))]
+        SCAN_KEY_COMPARISONS.with(|c| c.set(c.get().wrapping_add(1)));
         self.token
             .cmp(&other.token)
             .then_with(|| self.key.cmp(&other.key))
@@ -127,6 +136,12 @@ pub(crate) fn kway_merge_token_order<T>(
 
     let total: usize = per_reader.iter().map(|s| s.len()).sum();
     let cap = limit.map_or(total, |l| l.min(total));
+    if cap == 0 {
+        // `limit == Some(0)`: emit nothing. Guard here because the in-loop
+        // `out.len() == cap` early-exit is only checked *after* the first push, so
+        // it would never fire for cap == 0 and would leak the entire result set.
+        return Vec::new();
+    }
 
     // Convert each stream into a forward iterator so we can pull heads lazily.
     let mut iters: Vec<std::vec::IntoIter<(RowKey, T)>> =
@@ -210,6 +225,21 @@ pub(crate) fn sort_by_token_order<E>(
 mod tests {
     use super::*;
 
+    /// Runs [`kway_merge_token_order`] and returns the number of key comparisons it
+    /// performed on the current thread alongside the merged output. Resets and reads
+    /// the per-thread [`SCAN_KEY_COMPARISONS`] counter within this single call, so
+    /// the count is a purely local value — concurrent tests on other threads cannot
+    /// perturb it, eliminating the cross-test data race of a process-global counter.
+    fn kway_merge_counting<T>(
+        per_reader: Vec<Vec<(RowKey, T)>>,
+        limit: Option<usize>,
+    ) -> (Vec<(RowKey, T)>, u64) {
+        SCAN_KEY_COMPARISONS.with(|c| c.set(0));
+        let out = kway_merge_token_order(per_reader, limit);
+        let count = SCAN_KEY_COMPARISONS.with(|c| c.get());
+        (out, count)
+    }
+
     // UUID keys whose token order differs from raw-byte order (pinned in
     // `util::cassandra_murmur3` tests): token(0x22) < token(0x11) < token(0x33).
     fn uuid_key(b: u8) -> RowKey {
@@ -260,15 +290,30 @@ mod tests {
 
     #[test]
     fn single_reader_is_passthrough_no_comparisons() {
-        let before = MANAGER_SCAN_KEY_COMPARISONS.load(AtomicOrdering::Relaxed);
         let only = vec![(uuid_key(0x33), 1u32), (uuid_key(0x11), 2u32)];
         // Single stream: returned as-is (reader already token-ordered), no merge.
-        let merged = kway_merge_token_order(vec![only], None);
+        let (merged, cmps) = kway_merge_counting(vec![only], None);
         assert_eq!(merged.len(), 2);
-        let after = MANAGER_SCAN_KEY_COMPARISONS.load(AtomicOrdering::Relaxed);
         assert_eq!(
-            after, before,
+            cmps, 0,
             "single-stream fast path must not compare keys"
+        );
+    }
+
+    #[test]
+    fn limit_zero_returns_empty_with_multiple_readers() {
+        // ≥2 non-empty readers with limit=Some(0) must emit nothing, matching the
+        // single/zero-reader `truncate(0)` and `sort_by_token_order` behavior. The
+        // in-loop early-exit alone would leak everything (out.len() starts at 1 and
+        // never equals cap == 0), so the top-of-heap-path `cap == 0` guard is what
+        // makes this hold.
+        let reader_a = vec![(uuid_key(0x22), 1u32), (uuid_key(0x33), 3u32)];
+        let reader_b = vec![(uuid_key(0x11), 2u32)];
+        let merged = kway_merge_token_order(vec![reader_a, reader_b], Some(0));
+        assert!(
+            merged.is_empty(),
+            "limit=Some(0) with multiple non-empty readers must return no rows, got {}",
+            merged.len()
         );
     }
 
@@ -298,9 +343,7 @@ mod tests {
             per_reader.push(stream);
         }
 
-        MANAGER_SCAN_KEY_COMPARISONS.store(0, AtomicOrdering::Relaxed);
-        let merged = kway_merge_token_order(per_reader, None);
-        let cmps = MANAGER_SCAN_KEY_COMPARISONS.load(AtomicOrdering::Relaxed);
+        let (merged, cmps) = kway_merge_counting(per_reader, None);
 
         assert_eq!(merged.len(), n, "merge must emit every row");
 

--- a/cqlite-core/src/storage/sstable/scan_merge.rs
+++ b/cqlite-core/src/storage/sstable/scan_merge.rs
@@ -49,14 +49,6 @@ pub(crate) static MANAGER_SCAN_KEY_COMPARISONS: AtomicU64 = AtomicU64::new(0);
 /// [`sort_by_token_order`] since process start.
 pub(crate) static MANAGER_SCAN_FULL_SORTS: AtomicU64 = AtomicU64::new(0);
 
-/// A candidate head in the k-way merge: the current unemitted row of one reader
-/// stream, tagged with its precomputed token so the token is hashed once per row
-/// (not once per comparison).
-///
-/// Ordering is ascending `(token, key_bytes, reader_idx)`. `reader_idx` breaks
-/// ties so equal-`(token, key)` rows from different readers emit in reader order —
-/// reproducing the stable concat order the old `sort_by` gave. Every `cmp`
-/// increments [`MANAGER_SCAN_KEY_COMPARISONS`].
 /// Heap element pairing an ordering key ([`Candidate`]) with its opaque payload
 /// `T`. Ordering delegates entirely to the [`Candidate`] so no `T: Ord` bound is
 /// needed — the row value/metadata never participates in the merge order.
@@ -82,6 +74,12 @@ impl<T> Ord for HeapItem<T> {
     }
 }
 
+/// The ordering key for one reader stream's current head: its precomputed token
+/// (hashed once per row, not per comparison), partition key, and reader index.
+/// Ordered ascending `(token, key_bytes, reader_idx)`; `reader_idx` breaks ties so
+/// equal-`(token, key)` rows from different readers emit in reader order,
+/// reproducing the stable concat order the old raw-byte `sort_by` gave. Every
+/// [`Candidate::cmp`] increments [`MANAGER_SCAN_KEY_COMPARISONS`].
 struct Candidate {
     token: i64,
     key: RowKey,

--- a/cqlite-core/src/storage/sstable/scan_merge.rs
+++ b/cqlite-core/src/storage/sstable/scan_merge.rs
@@ -1,0 +1,330 @@
+//! Cross-SSTable scan ordering for [`SSTableManager`](super::SSTableManager)
+//! (issue #1580, Epic D4).
+//!
+//! # The ordering contract (the oracle)
+//!
+//! Cassandra's default `Murmur3Partitioner` orders partitions by their **token**
+//! — the Murmur3 hash of the partition-key bytes — with equal-token ties broken by
+//! raw key bytes. A full scan / `sstabledump` therefore emits partitions in
+//! ascending token order, which in general is **not** the lexicographic order of
+//! the raw partition-key bytes (e.g. UUID `0x22…` sorts *before* `0x11…` by token).
+//!
+//! Each per-reader scan already returns rows in this exact order (the reader's
+//! `sort_by_token_order`). The manager previously concatenated every reader's
+//! output and RE-SORTED the whole concatenation by raw `RowKey` bytes
+//! (`sort_by(|a, b| a.0.cmp(&b.0))`), which both produced the wrong global order
+//! and cost a full O(n log n) sort on the async worker.
+//!
+//! # What this module provides
+//!
+//! * [`kway_merge_token_order`] — a k-way merge over the per-reader token-ordered
+//!   streams that emits the merged stream in token order in **O(n log k)** key
+//!   comparisons (k = number of readers), with early-exit once a pushed-down
+//!   `limit` is satisfied. This replaces the concat + O(n log n) re-sort.
+//! * [`sort_by_token_order`] — a stable token-order sort for the few paths that
+//!   have already materialized a merged `Vec` (the multi-generation
+//!   `KWayMerger` paths); it corrects the old raw-byte sort while remaining a
+//!   no-op when the input is already token-ordered.
+//!
+//! # Instrumentation
+//!
+//! [`MANAGER_SCAN_KEY_COMPARISONS`] counts key comparisons performed by the k-way
+//! merge, and [`MANAGER_SCAN_FULL_SORTS`] counts materialized full-vector sorts.
+//! Tests use these to assert the scan path is O(n log k) and never falls back to a
+//! full O(n log n) concat sort. Both use `Relaxed` atomics — the increment is
+//! negligible next to per-row decode work.
+
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
+use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
+
+use crate::types::RowKey;
+use crate::util::cassandra_murmur3::cassandra_murmur3_token;
+
+/// Number of key comparisons performed by [`kway_merge_token_order`] since process
+/// start. Exposed for the O(n log k) no-full-sort regression assertion.
+pub(crate) static MANAGER_SCAN_KEY_COMPARISONS: AtomicU64 = AtomicU64::new(0);
+
+/// Number of materialized full-vector token-order sorts performed by
+/// [`sort_by_token_order`] since process start.
+pub(crate) static MANAGER_SCAN_FULL_SORTS: AtomicU64 = AtomicU64::new(0);
+
+/// A candidate head in the k-way merge: the current unemitted row of one reader
+/// stream, tagged with its precomputed token so the token is hashed once per row
+/// (not once per comparison).
+///
+/// Ordering is ascending `(token, key_bytes, reader_idx)`. `reader_idx` breaks
+/// ties so equal-`(token, key)` rows from different readers emit in reader order —
+/// reproducing the stable concat order the old `sort_by` gave. Every `cmp`
+/// increments [`MANAGER_SCAN_KEY_COMPARISONS`].
+/// Heap element pairing an ordering key ([`Candidate`]) with its opaque payload
+/// `T`. Ordering delegates entirely to the [`Candidate`] so no `T: Ord` bound is
+/// needed — the row value/metadata never participates in the merge order.
+struct HeapItem<T> {
+    cand: Candidate,
+    val: T,
+}
+
+impl<T> PartialEq for HeapItem<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.cand.cmp(&other.cand) == Ordering::Equal
+    }
+}
+impl<T> Eq for HeapItem<T> {}
+impl<T> PartialOrd for HeapItem<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl<T> Ord for HeapItem<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.cand.cmp(&other.cand)
+    }
+}
+
+struct Candidate {
+    token: i64,
+    key: RowKey,
+    reader_idx: usize,
+}
+
+impl Candidate {
+    fn cmp(&self, other: &Self) -> Ordering {
+        MANAGER_SCAN_KEY_COMPARISONS.fetch_add(1, AtomicOrdering::Relaxed);
+        self.token
+            .cmp(&other.token)
+            .then_with(|| self.key.cmp(&other.key))
+            .then_with(|| self.reader_idx.cmp(&other.reader_idx))
+    }
+}
+
+/// K-way merge over per-reader token-ordered streams.
+///
+/// `per_reader[i]` MUST already be sorted in ascending Cassandra token order (with
+/// equal-token ties by raw key bytes and clustering rows of one partition
+/// contiguous) — which every `SSTableReader` scan guarantees via
+/// `sort_by_token_order`. The output is the globally token-ordered concatenation.
+///
+/// Cost: **O(n log k)** key comparisons (k = number of non-empty streams), versus
+/// the O(n log n) full re-sort it replaces. When `limit` is `Some(n)`, the merge
+/// stops after emitting `n` rows (D1 pushed-down-limit early-exit).
+pub(crate) fn kway_merge_token_order<T>(
+    per_reader: Vec<Vec<(RowKey, T)>>,
+    limit: Option<usize>,
+) -> Vec<(RowKey, T)> {
+    // Fast paths avoid heap setup for the overwhelmingly common cases.
+    let non_empty = per_reader.iter().filter(|s| !s.is_empty()).count();
+    if non_empty <= 1 {
+        // Zero or one contributing stream: it is already in token order. Just
+        // take it (the reader emitted it sorted) and apply the limit.
+        let mut out: Vec<(RowKey, T)> = per_reader
+            .into_iter()
+            .find(|s| !s.is_empty())
+            .unwrap_or_default();
+        if let Some(lim) = limit {
+            out.truncate(lim);
+        }
+        return out;
+    }
+
+    let total: usize = per_reader.iter().map(|s| s.len()).sum();
+    let cap = limit.map_or(total, |l| l.min(total));
+
+    // Convert each stream into a forward iterator so we can pull heads lazily.
+    let mut iters: Vec<std::vec::IntoIter<(RowKey, T)>> =
+        per_reader.into_iter().map(|s| s.into_iter()).collect();
+
+    // Min-heap over the current head of each stream. `Reverse` turns the max-heap
+    // into a min-heap; the payload rides inside `HeapItem` so no `T: Ord` bound.
+    let mut heap: BinaryHeap<std::cmp::Reverse<HeapItem<T>>> =
+        BinaryHeap::with_capacity(iters.len());
+    for (idx, it) in iters.iter_mut().enumerate() {
+        if let Some((key, val)) = it.next() {
+            let token = cassandra_murmur3_token(key.as_bytes());
+            heap.push(std::cmp::Reverse(HeapItem {
+                cand: Candidate {
+                    token,
+                    key,
+                    reader_idx: idx,
+                },
+                val,
+            }));
+        }
+    }
+
+    let mut out: Vec<(RowKey, T)> = Vec::with_capacity(cap);
+    while let Some(std::cmp::Reverse(HeapItem { cand, val })) = heap.pop() {
+        let idx = cand.reader_idx;
+        out.push((cand.key, val));
+        if out.len() == cap {
+            break; // pushed-down limit satisfied — stop early
+        }
+        if let Some((key, val)) = iters[idx].next() {
+            let token = cassandra_murmur3_token(key.as_bytes());
+            heap.push(std::cmp::Reverse(HeapItem {
+                cand: Candidate {
+                    token,
+                    key,
+                    reader_idx: idx,
+                },
+                val,
+            }));
+        }
+    }
+    out
+}
+
+/// Stable in-place token-order sort of an already-materialized result vector, then
+/// truncate to `limit`.
+///
+/// `key_of` extracts each element's partition `RowKey` (the first tuple field for
+/// both the plain `(RowKey, ScanRow)` and the metadata `(RowKey, ScanRow, Meta)`
+/// paths). Elements are ordered by ascending `(token, key_bytes)`; the sort is
+/// stable, so equal-`(token, key)` rows (a partition's clustering rows) keep their
+/// input order.
+///
+/// Used by the multi-generation `KWayMerger` read paths, which hand back a single
+/// merged `Vec` (already token-ordered by the merger): this replaces their prior
+/// raw-byte `sort_by`, so a stray raw-byte ordering can never leak out, while the
+/// sort is effectively a no-op when the input is already ordered. Computes each
+/// key's token once to avoid recomputation inside the comparator.
+pub(crate) fn sort_by_token_order<E>(
+    results: &mut Vec<E>,
+    limit: Option<usize>,
+    key_of: impl Fn(&E) -> &RowKey,
+) {
+    MANAGER_SCAN_FULL_SORTS.fetch_add(1, AtomicOrdering::Relaxed);
+    let mut tagged: Vec<(i64, E)> = results
+        .drain(..)
+        .map(|e| {
+            let t = cassandra_murmur3_token(key_of(&e).as_bytes());
+            (t, e)
+        })
+        .collect();
+    tagged.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| key_of(&a.1).cmp(key_of(&b.1))));
+    results.extend(tagged.into_iter().map(|(_, e)| e));
+    if let Some(lim) = limit {
+        results.truncate(lim);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // UUID keys whose token order differs from raw-byte order (pinned in
+    // `util::cassandra_murmur3` tests): token(0x22) < token(0x11) < token(0x33).
+    fn uuid_key(b: u8) -> RowKey {
+        RowKey::new(vec![b; 16])
+    }
+
+    fn keys_in_order<T>(rows: &[(RowKey, T)]) -> Vec<u8> {
+        let mut out = Vec::new();
+        for (k, _) in rows {
+            let first = k.as_bytes()[0];
+            if out.last() != Some(&first) {
+                out.push(first);
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn merge_emits_token_order_across_readers() {
+        // Two readers, each internally token-ordered. Reader A: 0x22, 0x33.
+        // Reader B: 0x11. Global token order must be 0x22, 0x11, 0x33.
+        let reader_a = vec![(uuid_key(0x22), 1u32), (uuid_key(0x33), 3u32)];
+        let reader_b = vec![(uuid_key(0x11), 2u32)];
+        let merged = kway_merge_token_order(vec![reader_a, reader_b], None);
+        assert_eq!(keys_in_order(&merged), vec![0x22, 0x11, 0x33]);
+    }
+
+    #[test]
+    fn merge_preserves_clustering_rows_and_reader_tiebreak() {
+        // Same partition (0x11) present in two readers with multiple clustering
+        // rows each. They must stay grouped, reader 0's rows before reader 1's.
+        let reader0 = vec![(uuid_key(0x11), 0u32), (uuid_key(0x11), 1u32)];
+        let reader1 = vec![(uuid_key(0x11), 2u32), (uuid_key(0x33), 9u32)];
+        let merged = kway_merge_token_order(vec![reader0, reader1], None);
+        let payloads: Vec<u32> = merged.iter().map(|(_, v)| *v).collect();
+        // 0x11 rows first (0,1 from reader0 then 2 from reader1), then 0x33.
+        assert_eq!(payloads, vec![0, 1, 2, 9]);
+    }
+
+    #[test]
+    fn merge_early_exits_on_limit() {
+        let reader_a = vec![(uuid_key(0x22), 1u32), (uuid_key(0x33), 3u32)];
+        let reader_b = vec![(uuid_key(0x11), 2u32)];
+        let merged = kway_merge_token_order(vec![reader_a, reader_b], Some(2));
+        assert_eq!(merged.len(), 2);
+        assert_eq!(keys_in_order(&merged), vec![0x22, 0x11]);
+    }
+
+    #[test]
+    fn single_reader_is_passthrough_no_comparisons() {
+        let before = MANAGER_SCAN_KEY_COMPARISONS.load(AtomicOrdering::Relaxed);
+        let only = vec![(uuid_key(0x33), 1u32), (uuid_key(0x11), 2u32)];
+        // Single stream: returned as-is (reader already token-ordered), no merge.
+        let merged = kway_merge_token_order(vec![only], None);
+        assert_eq!(merged.len(), 2);
+        let after = MANAGER_SCAN_KEY_COMPARISONS.load(AtomicOrdering::Relaxed);
+        assert_eq!(
+            after, before,
+            "single-stream fast path must not compare keys"
+        );
+    }
+
+    /// The no-full-sort assertion (issue #1580): the k-way merge over k readers
+    /// must use O(n log k) key comparisons, NOT the O(n log n) of a full re-sort.
+    /// With k = 4 and n = 4000, n·log2(k) = 8000 while n·log2(n) ≈ 47726 — the
+    /// bound below (≈ 4·n·ceil(log2 k)) sits well under n·log2(n).
+    #[test]
+    fn merge_comparison_count_is_n_log_k_not_n_log_n() {
+        let k = 4usize;
+        let per_stream = 1000usize;
+        let n = k * per_stream;
+
+        // k readers, each with `per_stream` distinct token-ordered partitions.
+        // Distinct 4-byte big-endian int keys, then per-reader token-sorted so the
+        // merge input honours its precondition.
+        let mut per_reader: Vec<Vec<(RowKey, u32)>> = Vec::with_capacity(k);
+        let mut next: i32 = 0;
+        for _ in 0..k {
+            let mut stream: Vec<(RowKey, u32)> = Vec::with_capacity(per_stream);
+            for _ in 0..per_stream {
+                let key = RowKey::new(next.to_be_bytes().to_vec());
+                stream.push((key, next as u32));
+                next += 1;
+            }
+            stream.sort_by_key(|(k, _)| cassandra_murmur3_token(k.as_bytes()));
+            per_reader.push(stream);
+        }
+
+        MANAGER_SCAN_KEY_COMPARISONS.store(0, AtomicOrdering::Relaxed);
+        let merged = kway_merge_token_order(per_reader, None);
+        let cmps = MANAGER_SCAN_KEY_COMPARISONS.load(AtomicOrdering::Relaxed);
+
+        assert_eq!(merged.len(), n, "merge must emit every row");
+
+        // Output is globally token-ordered.
+        for w in merged.windows(2) {
+            let ta = cassandra_murmur3_token(w[0].0.as_bytes());
+            let tb = cassandra_murmur3_token(w[1].0.as_bytes());
+            assert!(ta <= tb, "merge output must be ascending token order");
+        }
+
+        let log2_k = (usize::BITS - (k - 1).leading_zeros()) as u64; // ceil(log2 k)
+        let n_log_k_bound = 4 * (n as u64) * (log2_k + 1);
+        let n_log_n = (n as f64 * (n as f64).log2()) as u64;
+        assert!(
+            cmps <= n_log_k_bound,
+            "k-way merge did {cmps} comparisons; expected O(n log k) ≤ {n_log_k_bound} \
+             (n={n}, k={k}); a full O(n log n) re-sort would be ≈ {n_log_n}"
+        );
+        assert!(
+            cmps < n_log_n,
+            "comparison count {cmps} must be strictly below the O(n log n)≈{n_log_n} \
+             full-sort cost the k-way merge replaces"
+        );
+    }
+}

--- a/cqlite-core/tests/issue_1580_scan_token_order_oracle.rs
+++ b/cqlite-core/tests/issue_1580_scan_token_order_oracle.rs
@@ -60,7 +60,9 @@ const TABLE: &str = "simple_table";
 /// binary fixtures are present. Returns `None` (skip) when they are not — the
 /// gitignored `.db` binaries are absent in a clean checkout.
 fn test_da_dir() -> Option<PathBuf> {
-    let root = std::env::var("CQLITE_DATASETS_ROOT").ok().map(PathBuf::from)?;
+    let root = std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)?;
     let dir = root.join("sstables").join(KEYSPACE);
     // Require an actual Data.db under the simple_table generation; a bare dir
     // (JSONL-only) must skip, not spuriously pass with zero rows.
@@ -73,9 +75,9 @@ fn test_da_dir() -> Option<PathBuf> {
             name.starts_with(&format!("{TABLE}-"))
                 && std::fs::read_dir(e.path())
                     .map(|inner| {
-                        inner.filter_map(|x| x.ok()).any(|x| {
-                            x.file_name().to_string_lossy().ends_with("-Data.db")
-                        })
+                        inner
+                            .filter_map(|x| x.ok())
+                            .any(|x| x.file_name().to_string_lossy().ends_with("-Data.db"))
                     })
                     .unwrap_or(false)
         });

--- a/cqlite-core/tests/issue_1580_scan_token_order_oracle.rs
+++ b/cqlite-core/tests/issue_1580_scan_token_order_oracle.rs
@@ -1,0 +1,186 @@
+//! Issue #1580 (Epic D4): `SSTableManager` cross-SSTable scan ordering must match
+//! Cassandra's authoritative order — ascending Murmur3 **token**, NOT raw
+//! partition-key byte order.
+//!
+//! ## Oracle (determined FIRST, before the fix — decision #10)
+//!
+//! Cassandra's default `Murmur3Partitioner` orders partitions by their token (the
+//! Murmur3 hash of the partition-key bytes). A full scan / `sstabledump` therefore
+//! emits partitions in **token order**, which in general is NOT the lexicographic
+//! order of the raw key bytes.
+//!
+//! The `test_da/simple_table` BTI fixture (authored by Cassandra 5.0.2) pins this
+//! divergence exactly. Its `da-2-bti-Data.db.jsonl` golden — the sstabledump
+//! reference, i.e. the on-disk physical order — lists the three UUID partitions in
+//! this order:
+//!
+//! ```text
+//!   22222222-…   (token 1213057064512856170)
+//!   11111111-…   (token 4360155383588533346)
+//!   33333333-…   (token 8780122315263850168)
+//! ```
+//!
+//! Ascending token → `[0x22, 0x11, 0x33]`. Ascending raw bytes → `[0x11, 0x22,
+//! 0x33]`. They disagree, so this fixture is a clean oracle. (The token values are
+//! independently pinned in `util::cassandra_murmur3` unit tests.)
+//!
+//! ## What this asserts
+//!
+//! `SSTableManager::scan` over the fixture returns the partitions in ascending
+//! Murmur3-token order — equivalently, exactly the physical/`sstabledump` order
+//! `[0x22, 0x11, 0x33]`. A guard confirms the fixture actually exercises the
+//! divergence (token order ≠ raw-byte order), so the test can never silently
+//! degenerate into asserting the wrong (raw-byte) order.
+//!
+//! ## Regression it guards
+//!
+//! Pre-fix, the manager concatenated each reader's (already token-ordered) rows
+//! and RE-SORTED the whole concatenation by raw `RowKey` bytes
+//! (`all_results.sort_by(|a, b| a.0.cmp(&b.0))`). That both (1) produced the wrong
+//! order `[0x11, 0x22, 0x33]` and (2) cost a full O(n log n) sort on the async
+//! worker. This test FAILS on that code and PASSES once the manager preserves
+//! token order via a k-way merge over the per-reader token-ordered streams.
+
+#![cfg(feature = "state_machine")]
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use cqlite_core::platform::Platform;
+use cqlite_core::schema::{parse_cql_schema, TableSchema};
+use cqlite_core::storage::sstable::SSTableManager;
+use cqlite_core::types::TableId as CqlTableId;
+use cqlite_core::util::cassandra_murmur3::cassandra_murmur3_token;
+use cqlite_core::{Config, RowKey};
+
+const KEYSPACE: &str = "test_da";
+const TABLE: &str = "simple_table";
+
+/// Locate the `test_da` keyspace directory under `CQLITE_DATASETS_ROOT`, if the
+/// binary fixtures are present. Returns `None` (skip) when they are not — the
+/// gitignored `.db` binaries are absent in a clean checkout.
+fn test_da_dir() -> Option<PathBuf> {
+    let root = std::env::var("CQLITE_DATASETS_ROOT").ok().map(PathBuf::from)?;
+    let dir = root.join("sstables").join(KEYSPACE);
+    // Require an actual Data.db under the simple_table generation; a bare dir
+    // (JSONL-only) must skip, not spuriously pass with zero rows.
+    let has_data = std::fs::read_dir(&dir)
+        .ok()?
+        .filter_map(|e| e.ok())
+        .any(|e| {
+            let name = e.file_name();
+            let name = name.to_string_lossy();
+            name.starts_with(&format!("{TABLE}-"))
+                && std::fs::read_dir(e.path())
+                    .map(|inner| {
+                        inner.filter_map(|x| x.ok()).any(|x| {
+                            x.file_name().to_string_lossy().ends_with("-Data.db")
+                        })
+                    })
+                    .unwrap_or(false)
+        });
+    has_data.then_some(dir)
+}
+
+/// Schema for `test_da.simple_table` (matches `test-data/schemas/da-test.cql`).
+fn simple_table_schema() -> TableSchema {
+    let cql = format!(
+        "CREATE TABLE {KEYSPACE}.{TABLE} (\
+             id UUID PRIMARY KEY, \
+             name TEXT, \
+             age INT, \
+             salary BIGINT, \
+             active BOOLEAN, \
+             created TIMESTAMP\
+         );"
+    );
+    parse_cql_schema(&cql).expect("parse simple_table schema")
+}
+
+/// Distinct partition keys in first-seen order (rows for one partition are
+/// contiguous; this collapses clustering duplicates while preserving order).
+fn distinct_keys_in_order(rows: &[(RowKey, impl Sized)]) -> Vec<Vec<u8>> {
+    let mut out: Vec<Vec<u8>> = Vec::new();
+    for (k, _) in rows {
+        let bytes = k.as_bytes().to_vec();
+        if out.last().map(|last| last != &bytes).unwrap_or(true) {
+            out.push(bytes);
+        }
+    }
+    out
+}
+
+#[tokio::test]
+async fn manager_scan_returns_cassandra_token_order_not_rawbyte_order() {
+    let Some(data_dir) = test_da_dir() else {
+        eprintln!(
+            "Skipping issue #1580 oracle test: test_da/simple_table Data.db not present \
+             (set CQLITE_DATASETS_ROOT and fetch datasets)"
+        );
+        return;
+    };
+
+    let config = Config::default();
+    let platform = Arc::new(Platform::new(&config).await.expect("platform"));
+    let manager = SSTableManager::new(
+        &data_dir,
+        &config,
+        platform,
+        #[cfg(feature = "state_machine")]
+        None,
+    )
+    .await
+    .expect("open SSTableManager over test_da");
+
+    let schema = simple_table_schema();
+    let table_id = CqlTableId::from(format!("{KEYSPACE}.{TABLE}").as_str());
+    let rows = manager
+        .scan(&table_id, None, None, None, Some(&schema))
+        .await
+        .expect("scan must not error");
+
+    assert!(
+        !rows.is_empty(),
+        "fixture present but scan returned 0 rows — fixture/registration problem"
+    );
+
+    let got = distinct_keys_in_order(&rows);
+    assert_eq!(
+        got.len(),
+        3,
+        "test_da/simple_table has exactly 3 partitions; got {} distinct keys",
+        got.len()
+    );
+
+    // The oracle order: sort the observed keys by ascending Murmur3 token.
+    let mut token_sorted = got.clone();
+    token_sorted.sort_by_key(|k| cassandra_murmur3_token(k));
+
+    // Guard: this fixture must actually exercise the token≠rawbyte divergence,
+    // otherwise the assertion below would be vacuous.
+    let mut rawbyte_sorted = got.clone();
+    rawbyte_sorted.sort();
+    assert_ne!(
+        token_sorted, rawbyte_sorted,
+        "fixture no longer exercises token≠raw-byte divergence — oracle is vacuous"
+    );
+
+    // THE oracle assertion: the manager's scan output is in ascending token order.
+    assert_eq!(
+        got, token_sorted,
+        "Issue #1580: SSTableManager::scan must return partitions in ascending \
+         Murmur3-token order (Cassandra's cross-SSTable scan order), not raw \
+         partition-key byte order.\n  got (first byte of each key): {:?}\n  token order:  {:?}\n  raw-byte order: {:?}",
+        got.iter().map(|k| k.first().copied()).collect::<Vec<_>>(),
+        token_sorted.iter().map(|k| k.first().copied()).collect::<Vec<_>>(),
+        rawbyte_sorted.iter().map(|k| k.first().copied()).collect::<Vec<_>>(),
+    );
+
+    // Pin the exact physical/sstabledump order for this fixture: 0x22, 0x11, 0x33.
+    let first_bytes: Vec<u8> = got.iter().filter_map(|k| k.first().copied()).collect();
+    assert_eq!(
+        first_bytes,
+        vec![0x22, 0x11, 0x33],
+        "Issue #1580: expected the Cassandra physical order [0x22, 0x11, 0x33]"
+    );
+}


### PR DESCRIPTION
Closes #1580 (D4, oracle-driven, P1).

## Oracle verdict (determined FIRST, decision #10)
Cassandra's `Murmur3Partitioner` orders partitions across SSTables by **ascending Murmur3 token** (ties by raw key bytes), NOT raw partition-key byte order. Confirmed against the real Cassandra 5.0.2 `test_da/simple_table` BTI golden: partitions `[0x22,0x11,0x33]` have strictly ascending tokens, while raw-byte order would be `[0x11,0x22,0x33]` — a clean divergence oracle. Reader/writer already agree (`sort_by_token_order`, memtable `DecoratedKey`); only the manager scan diverged.

## Regression proof (oracle test FAILED pre-fix)
```
manager_scan_returns_cassandra_token_order_not_rawbyte_order panicked:
  got:          [17, 34, 51]   // 0x11,0x22,0x33 raw-byte (WRONG)
  token order:  [34, 17, 51]   // 0x22,0x11,0x33 oracle
```
Committed as the failing-test commit before the fix (regression-test-verification doctrine).

## Fix
- New `cqlite-core/src/storage/sstable/scan_merge.rs`: `kway_merge_token_order` — O(n log k) `BinaryHeap` merge over per-reader token-ordered streams, ordered by `(token, key, reader_idx)` (stable reader tiebreak), early-exit on pushed-down limit; `sort_by_token_order` for already-materialized merge paths; thread-local, cfg-gated comparison counter (no production cost, no cross-test race).
- `mod.rs`: replaced raw-byte concat+re-sort in `scan` / `scan_with_cell_metadata`; token-order sorts in both `merge_generations_for_read*`; `scan_stream` inline k-way merge now orders heads by `(token, key)`.
- D3 coordination: the streaming `scan_stream` k-way path had already landed but compared **raw bytes** while claiming token order — same defect, fixed here (didn't reduce scope).

## Review + gate
- rust-reviewer review-first: core merge correctness confirmed; two edge findings fixed (global-counter cross-test race → thread-local cfg-gated; `limit=Some(0)` footgun → early return).
- FULL `agent-gate.sh`: `fmt`/`clippy` PASS; the SUMMARY's two reds are **pre-existing/unrelated** — `issue_953` missing-fixture skip-guard defect (filed #1859, not in this diff) and the known python GIL-throughput flaky. Exclusion run: **4060/4060** core tests pass incl. all `scan_merge` unit tests + the oracle test. 33-table parity green.
- No `unwrap()`/`expect()` in library code; `-D warnings` clean.

## Out of scope (filed)
- #1859 — `issue_953` test hard-asserts on missing local-only Data.db instead of skipping (pre-existing).
- Multi-gen write-support read paths still materialize+sort (correct order now) rather than streaming — noted #957 follow-up.