### PR TITLE
fix(#1572): BIG get() resolves via raw-key Index.db + seeks covering chunk (stop whole-file decompress per lookup)

### DIFF
--- a/cqlite-core/src/storage/sstable/index_reader.rs
+++ b/cqlite-core/src/storage/sstable/index_reader.rs
@@ -133,17 +133,6 @@ pub struct IndexReader {
     index_data: IndexData,
     /// Platform abstraction for file operations
     platform: Arc<Platform>,
-    /// Whether the partition map is KNOWN-COMPLETE (issue #1572 correctness).
-    ///
-    /// `true` only when entry parsing consumed every byte of the entry section
-    /// with no early `break` and no leftover `remaining` (see
-    /// [`parse_all_partition_keys_with_summary`], which `break`s on the first
-    /// unparseable entry and returns the parsed prefix). A truncated /
-    /// partially-corrupt / unexpectedly-encoded `Index.db` opens successfully
-    /// with a PARTIAL map — `false` — so point-lookup callers must fall back to
-    /// a whole-file scan rather than treat an index miss as a definitive absent.
-    /// Derived from authoritative parse-consumption (no heuristics, issue #28).
-    is_complete: bool,
 }
 
 impl IndexReader {
@@ -179,13 +168,21 @@ impl IndexReader {
         }
 
         // Parse the index data with optional Summary.db correlation.
-        // `remaining` is the leftover after entry parsing: empty ⇒ every entry
-        // byte was consumed with no early `break`, so the map is KNOWN-COMPLETE
-        // (issue #1572). Non-empty ⇒ the parser stopped early (truncated /
-        // corrupt / unexpectedly-encoded input) leaving a PARTIAL map.
-        let (index_data, is_complete) = match parse_index_data_with_summary(&buffer, summary_reader)
-        {
-            Ok((remaining, data)) => (data, remaining.is_empty()),
+        //
+        // NOTE (issue #1572): `parse_all_partition_keys_with_summary` `break`s on
+        // the first unparseable entry and returns the parsed prefix, so a
+        // truncated / partially-corrupt Index.db opens successfully with a PARTIAL
+        // map. The leftover `remaining` being empty ONLY proves the surviving
+        // bytes parsed cleanly to EOF — it CANNOT detect truncation aligned to an
+        // exact entry boundary (whole trailing entries dropped ⇒ the prefix parses
+        // cleanly, `remaining` is empty, yet partitions are missing). There is no
+        // cleanly-available authoritative partition count at this layer to close
+        // that gap, so completeness is NOT tracked here; instead the BIG
+        // point-lookup miss branch always falls back to a whole-file scan rather
+        // than treating an index miss as a definitive absent (see
+        // `big_get_with_resolution`). No heuristics (issue #28).
+        let index_data = match parse_index_data_with_summary(&buffer, summary_reader) {
+            Ok((_remaining, data)) => data,
             Err(e) => {
                 return Err(Error::corruption(format!(
                     "Failed to parse Index.db: {:?}",
@@ -198,19 +195,7 @@ impl IndexReader {
             file_path: path.to_path_buf(),
             index_data,
             platform,
-            is_complete,
         })
-    }
-
-    /// Whether this reader's partition map is KNOWN-COMPLETE (issue #1572).
-    ///
-    /// Returns `true` only when Index.db entry parsing consumed all entry bytes
-    /// with no early stop. When `false`, an index MISS is NOT authoritative: the
-    /// map may be a partial prefix of a truncated/corrupt Index.db, so callers
-    /// that treat a miss as a definitive absent must instead fall back to a
-    /// whole-file scan to preserve correctness on degraded inputs.
-    pub(crate) fn is_complete(&self) -> bool {
-        self.is_complete
     }
 
     /// Get all partition entries

--- a/cqlite-core/src/storage/sstable/index_reader.rs
+++ b/cqlite-core/src/storage/sstable/index_reader.rs
@@ -133,6 +133,17 @@ pub struct IndexReader {
     index_data: IndexData,
     /// Platform abstraction for file operations
     platform: Arc<Platform>,
+    /// Whether the partition map is KNOWN-COMPLETE (issue #1572 correctness).
+    ///
+    /// `true` only when entry parsing consumed every byte of the entry section
+    /// with no early `break` and no leftover `remaining` (see
+    /// [`parse_all_partition_keys_with_summary`], which `break`s on the first
+    /// unparseable entry and returns the parsed prefix). A truncated /
+    /// partially-corrupt / unexpectedly-encoded `Index.db` opens successfully
+    /// with a PARTIAL map — `false` — so point-lookup callers must fall back to
+    /// a whole-file scan rather than treat an index miss as a definitive absent.
+    /// Derived from authoritative parse-consumption (no heuristics, issue #28).
+    is_complete: bool,
 }
 
 impl IndexReader {
@@ -167,9 +178,14 @@ impl IndexReader {
             )));
         }
 
-        // Parse the index data with optional Summary.db correlation
-        let index_data = match parse_index_data_with_summary(&buffer, summary_reader) {
-            Ok((_, data)) => data,
+        // Parse the index data with optional Summary.db correlation.
+        // `remaining` is the leftover after entry parsing: empty ⇒ every entry
+        // byte was consumed with no early `break`, so the map is KNOWN-COMPLETE
+        // (issue #1572). Non-empty ⇒ the parser stopped early (truncated /
+        // corrupt / unexpectedly-encoded input) leaving a PARTIAL map.
+        let (index_data, is_complete) = match parse_index_data_with_summary(&buffer, summary_reader)
+        {
+            Ok((remaining, data)) => (data, remaining.is_empty()),
             Err(e) => {
                 return Err(Error::corruption(format!(
                     "Failed to parse Index.db: {:?}",
@@ -182,7 +198,19 @@ impl IndexReader {
             file_path: path.to_path_buf(),
             index_data,
             platform,
+            is_complete,
         })
+    }
+
+    /// Whether this reader's partition map is KNOWN-COMPLETE (issue #1572).
+    ///
+    /// Returns `true` only when Index.db entry parsing consumed all entry bytes
+    /// with no early stop. When `false`, an index MISS is NOT authoritative: the
+    /// map may be a partial prefix of a truncated/corrupt Index.db, so callers
+    /// that treat a miss as a definitive absent must instead fall back to a
+    /// whole-file scan to preserve correctness on degraded inputs.
+    pub(crate) fn is_complete(&self) -> bool {
+        self.is_complete
     }
 
     /// Get all partition entries

--- a/cqlite-core/src/storage/sstable/reader/data_access/big_point.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/big_point.rs
@@ -29,18 +29,28 @@ impl SSTableReader {
     ///
     /// Resolution order:
     /// 1. Bloom pre-check (unchanged) — a definite miss short-circuits to `None`.
+    ///    This is the fast definitive-absent path for the common case: the
+    ///    bloom filter answers "not present" for an absent key WITHOUT a scan.
     /// 2. Fast path: `index_reader` (raw-key `Index.db` map) resolves the
     ///    uncompressed partition offset; only the covering chunk(s) are read,
-    ///    CRC-checked, decompressed, and decoded. When the `Index.db` map is
-    ///    KNOWN-COMPLETE (`IndexReader::is_complete()`), a MISS is a definitive
-    ///    absent — no full scan.
-    /// 3. `scan_for_key` is kept for genuinely index-less readers (no
-    ///    `index_reader`); for the rare exact index hit that decodes to no
-    ///    matching row (schema-unavailable soft-miss or a benign per-row
-    ///    table-guard rejection); AND for an index MISS when the map is NOT
-    ///    known-complete (truncated/corrupt/partial `Index.db`, issue #1572) —
-    ///    in every case the whole-file oracle preserves the pre-#1572 result and
-    ///    keeps `get()`/`scan()` in agreement.
+    ///    CRC-checked, decompressed, and decoded.
+    /// 3. `scan_for_key` is the whole-file oracle. It is used for genuinely
+    ///    index-less readers (no `index_reader`); for the rare exact index hit
+    ///    that decodes to no matching row (schema-unavailable soft-miss or a
+    ///    benign per-row table-guard rejection); AND for EVERY `index_reader`
+    ///    MISS (issue #1572 correctness). An `Index.db` map miss is NOT treated
+    ///    as a definitive absent, because `IndexReader::open` opens a truncated /
+    ///    partially-corrupt Index.db with a PARTIAL prefix map and — critically —
+    ///    truncation aligned to an exact entry boundary (whole trailing entries
+    ///    dropped) leaves the prefix parsing cleanly to EOF, so it is
+    ///    indistinguishable from a complete map at parse time. There is no
+    ///    cleanly-available authoritative partition count at this layer to close
+    ///    that gap, so a miss conservatively falls back to the scan oracle,
+    ///    keeping `get()`/`scan()` in agreement on degraded inputs. The fast
+    ///    definitive-absent path for the common (non-degraded) case is the bloom
+    ///    pre-check in step 1, so this fallback fires only on a bloom
+    ///    false-positive — rare and acceptable. `SCAN_FOR_KEY_CALLS` stays
+    ///    observable on the fallback.
     ///
     /// `fully_qualified_match` is threaded through to the shared decode's per-row
     /// table-consistency guard exactly as the BTI path does (issue #1321 / #1284).
@@ -112,27 +122,21 @@ impl SSTableReader {
                     // safe scan_for_key oracle to preserve the pre-#1572 result.
                 }
                 None => {
-                    // Index.db map miss. Treat it as a definitive absent ONLY when
-                    // the map is KNOWN-COMPLETE (issue #1572 correctness): entry
-                    // parsing consumed every entry byte with no early stop. A
-                    // truncated / partially-corrupt / unexpectedly-encoded Index.db
-                    // opens successfully with a PARTIAL prefix map, and a partition
-                    // whose entry lies past the parse-stop point would then miss the
-                    // map yet still be present in Data.db — a silent get/scan
-                    // divergence. When the map is NOT known-complete, fall back to
-                    // the whole-file `scan_for_key` oracle (pre-#1572 behaviour),
-                    // keeping the SCAN_FOR_KEY_CALLS counter observable on that path.
-                    let index_complete = self
-                        .index_reader
-                        .as_ref()
-                        .map(|r| r.is_complete())
-                        .unwrap_or(false);
-                    if index_complete {
-                        // Complete Index.db map miss ⇒ definitively absent. No full
-                        // scan (guardrail: definitive negative without a whole-file
-                        // decompress).
-                        return Ok(None);
-                    }
+                    // Index.db map miss. An index miss is NOT treated as a
+                    // definitive absent (issue #1572 correctness): `IndexReader::open`
+                    // opens a truncated / partially-corrupt Index.db with a PARTIAL
+                    // prefix map, and truncation aligned to an EXACT entry boundary
+                    // (whole trailing entries dropped) leaves the surviving prefix
+                    // parsing cleanly to EOF — indistinguishable from a complete map
+                    // at parse time, with no cleanly-available authoritative partition
+                    // count at this layer to detect the loss. A partition whose entry
+                    // was dropped would then miss the map yet still be present in
+                    // Data.db — a silent get/scan divergence. So conservatively fall
+                    // back to the whole-file `scan_for_key` oracle, which keeps
+                    // `get()`/`scan()` in agreement and keeps the SCAN_FOR_KEY_CALLS
+                    // counter observable. The fast definitive-absent path for the
+                    // common (non-degraded) case is the bloom pre-check above; this
+                    // fallback fires only on a bloom false-positive (rare, acceptable).
                     return self.scan_for_key(table_id, key).await;
                 }
             }

--- a/cqlite-core/src/storage/sstable/reader/data_access/big_point.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/big_point.rs
@@ -1,0 +1,135 @@
+//! BIG ("nb" / uncompressed) partition point lookup (issue #1572).
+//!
+//! Before this module, `SSTableReader::get()` on a BIG SSTable read and
+//! decompressed the ENTIRE `Data.db` on every lookup: the legacy `SSTableIndex`
+//! (`self.index`) is keyed on key *digests*, so `find_entry()` called with the
+//! raw partition-key bytes always missed and the miss fell through to
+//! `scan_for_key` → whole-file stitch + decompress.
+//!
+//! The fix resolves the partition's uncompressed `Data.db` offset via the raw-key
+//! `index_reader` (the O(1) `Index.db` map, keyed on raw partition-key bytes since
+//! issue #552), then seeks and decompresses ONLY the chunk(s) covering that offset
+//! — reusing the exact chunk-targeted decode the BTI point lookup already proves
+//! correct ([`SSTableReader::bti_decompress_and_parse_target`], bti.rs). The
+//! `Index.db` data offset and the BTI trie offset share the same uncompressed
+//! `Data.db` offset domain (headerless NB starts the data section at file offset
+//! 0), so the same chunk-targeting arithmetic applies verbatim.
+//!
+//! No-heuristics (issue #28): the offset comes from `Index.db` and the covering
+//! chunk from `CompressionInfo` — chunk boundaries are never guessed. CRC / decode
+//! errors surface (the shared decode path runs the same per-chunk CRC as the scan),
+//! never swallowed (guardrail from #1411).
+
+use super::super::SSTableReader;
+use crate::types::{ScanRow, TableId};
+use crate::{Result, RowKey};
+
+impl SSTableReader {
+    /// Point-lookup entry for BIG ("nb"/uncompressed) readers (issue #1572).
+    ///
+    /// Resolution order:
+    /// 1. Bloom pre-check (unchanged) — a definite miss short-circuits to `None`.
+    /// 2. Fast path: `index_reader` (raw-key `Index.db` map) resolves the
+    ///    uncompressed partition offset; only the covering chunk(s) are read,
+    ///    CRC-checked, decompressed, and decoded. `index_reader` is the COMPLETE
+    ///    partition index for a BIG SSTable, so a MISS is a definitive absent —
+    ///    no full scan.
+    /// 3. `scan_for_key` is kept ONLY for genuinely index-less readers (no
+    ///    `index_reader`), and — conservatively — for the rare exact index hit
+    ///    that decodes to no matching row (schema-unavailable soft-miss or a
+    ///    benign per-row table-guard rejection), where the whole-file oracle
+    ///    preserves the pre-#1572 result.
+    ///
+    /// `fully_qualified_match` is threaded through to the shared decode's per-row
+    /// table-consistency guard exactly as the BTI path does (issue #1321 / #1284).
+    pub(super) async fn big_get_with_resolution(
+        &self,
+        table_id: &TableId,
+        key: &RowKey,
+        fully_qualified_match: bool,
+    ) -> Result<Option<ScanRow>> {
+        use crate::observability::{self as obs, catalog};
+
+        // 1. Bloom pre-check (unchanged behaviour): a definite miss short-circuits.
+        if let Some(bloom_filter) = &self.bloom_filter {
+            let present = bloom_filter.might_contain(key.as_bytes());
+            obs::add_counter(
+                catalog::READ_BLOOM_CHECKS,
+                1,
+                &[
+                    (
+                        catalog::attr::RESULT,
+                        if present { "hit" } else { "miss" }.into(),
+                    ),
+                    (
+                        catalog::attr::SSTABLE_FORMAT,
+                        self.sstable_format_label().into(),
+                    ),
+                ],
+            );
+            if !present {
+                return Ok(None);
+            }
+        }
+
+        // 2. Fast path: resolve the partition offset via the raw-key Index.db map
+        //    and decode ONLY the covering chunk(s). The Index.db map is the
+        //    complete, authoritative partition set for a BIG SSTable.
+        if self.index_reader.is_some() {
+            match self.lookup_partition_with_index(key.as_bytes()).await? {
+                Some((data_offset, _size)) => {
+                    // `_size` (Index.db does not store partition size) is unused:
+                    // the shared chunk-targeted decode parses forward from the
+                    // offset until the partition is complete, so no size is needed.
+                    let schema_opt = self.get_table_schema(None);
+                    let parser = self.build_v5_parser(true);
+                    let found = self
+                        .bti_decompress_and_parse_target(
+                            data_offset as usize,
+                            key,
+                            table_id,
+                            fully_qualified_match,
+                            schema_opt.as_ref(),
+                            &parser,
+                        )
+                        .await?;
+                    if let Some(value) = found {
+                        if !self.filter_tombstone(&value) {
+                            return Ok(None);
+                        }
+                        return Ok(Some(value));
+                    }
+                    // Exact index hit but no matching row decoded (schema-unavailable
+                    // soft-miss / benign table-guard rejection). Fall through to the
+                    // safe scan_for_key oracle to preserve the pre-#1572 result.
+                }
+                None => {
+                    // Complete Index.db map miss ⇒ partition is definitively absent
+                    // from this SSTable. No full scan (guardrail: definitive negative
+                    // without a whole-file decompress).
+                    return Ok(None);
+                }
+            }
+        }
+
+        // 3. Legacy fallbacks for index-less readers (or the rare hit-but-soft-miss).
+        //    NOTE: `self.index` (SSTableIndex) is keyed on key digests, so
+        //    `find_entry()` with raw key bytes misses; retained for the size==0
+        //    uncompressed handling and the writer-produced-index cases (issue #517).
+        if let Some(index) = &self.index {
+            if let Some(entry) = index.find_entry(table_id, key).await? {
+                if entry.size == 0 {
+                    log::debug!(
+                        "Index reports size=0 for key {:?}, using sequential scan fallback",
+                        key
+                    );
+                    return self.scan_for_key(table_id, key).await;
+                }
+                // Index offsets are relative to data section start - adjust for header.
+                let file_offset = entry.offset + self.actual_header_size as u64;
+                return self.read_value_at_offset(file_offset, entry.size).await;
+            }
+        }
+        self.scan_for_key(table_id, key).await
+    }
+}

--- a/cqlite-core/src/storage/sstable/reader/data_access/big_point.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/big_point.rs
@@ -31,14 +31,16 @@ impl SSTableReader {
     /// 1. Bloom pre-check (unchanged) — a definite miss short-circuits to `None`.
     /// 2. Fast path: `index_reader` (raw-key `Index.db` map) resolves the
     ///    uncompressed partition offset; only the covering chunk(s) are read,
-    ///    CRC-checked, decompressed, and decoded. `index_reader` is the COMPLETE
-    ///    partition index for a BIG SSTable, so a MISS is a definitive absent —
-    ///    no full scan.
-    /// 3. `scan_for_key` is kept ONLY for genuinely index-less readers (no
-    ///    `index_reader`), and — conservatively — for the rare exact index hit
-    ///    that decodes to no matching row (schema-unavailable soft-miss or a
-    ///    benign per-row table-guard rejection), where the whole-file oracle
-    ///    preserves the pre-#1572 result.
+    ///    CRC-checked, decompressed, and decoded. When the `Index.db` map is
+    ///    KNOWN-COMPLETE (`IndexReader::is_complete()`), a MISS is a definitive
+    ///    absent — no full scan.
+    /// 3. `scan_for_key` is kept for genuinely index-less readers (no
+    ///    `index_reader`); for the rare exact index hit that decodes to no
+    ///    matching row (schema-unavailable soft-miss or a benign per-row
+    ///    table-guard rejection); AND for an index MISS when the map is NOT
+    ///    known-complete (truncated/corrupt/partial `Index.db`, issue #1572) —
+    ///    in every case the whole-file oracle preserves the pre-#1572 result and
+    ///    keeps `get()`/`scan()` in agreement.
     ///
     /// `fully_qualified_match` is threaded through to the shared decode's per-row
     /// table-consistency guard exactly as the BTI path does (issue #1321 / #1284).
@@ -110,10 +112,28 @@ impl SSTableReader {
                     // safe scan_for_key oracle to preserve the pre-#1572 result.
                 }
                 None => {
-                    // Complete Index.db map miss ⇒ partition is definitively absent
-                    // from this SSTable. No full scan (guardrail: definitive negative
-                    // without a whole-file decompress).
-                    return Ok(None);
+                    // Index.db map miss. Treat it as a definitive absent ONLY when
+                    // the map is KNOWN-COMPLETE (issue #1572 correctness): entry
+                    // parsing consumed every entry byte with no early stop. A
+                    // truncated / partially-corrupt / unexpectedly-encoded Index.db
+                    // opens successfully with a PARTIAL prefix map, and a partition
+                    // whose entry lies past the parse-stop point would then miss the
+                    // map yet still be present in Data.db — a silent get/scan
+                    // divergence. When the map is NOT known-complete, fall back to
+                    // the whole-file `scan_for_key` oracle (pre-#1572 behaviour),
+                    // keeping the SCAN_FOR_KEY_CALLS counter observable on that path.
+                    let index_complete = self
+                        .index_reader
+                        .as_ref()
+                        .map(|r| r.is_complete())
+                        .unwrap_or(false);
+                    if index_complete {
+                        // Complete Index.db map miss ⇒ definitively absent. No full
+                        // scan (guardrail: definitive negative without a whole-file
+                        // decompress).
+                        return Ok(None);
+                    }
+                    return self.scan_for_key(table_id, key).await;
                 }
             }
         }

--- a/cqlite-core/src/storage/sstable/reader/data_access/big_point.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/big_point.rs
@@ -83,6 +83,12 @@ impl SSTableReader {
                     // offset until the partition is complete, so no size is needed.
                     let schema_opt = self.get_table_schema(None);
                     let parser = self.build_v5_parser(true);
+                    // Pass `data_offset` raw (NO `actual_header_size` add): the
+                    // chunk-targeted decode operates in the uncompressed data-section
+                    // domain that begins at offset 0 (and for `nb`
+                    // `actual_header_size == 0` anyway). The legacy whole-section
+                    // fallback below seeks the file past the header itself, so it must
+                    // add `actual_header_size`; this path must not.
                     let found = self
                         .bti_decompress_and_parse_target(
                             data_offset as usize,

--- a/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/bti.rs
@@ -555,7 +555,7 @@ impl SSTableReader {
     /// Uses its own per-scan [`ScanCursor`] (private file position + chunk
     /// index), so concurrent lookups run in parallel without serialization
     /// (issue #815).
-    async fn bti_decompress_and_parse_target(
+    pub(super) async fn bti_decompress_and_parse_target(
         &self,
         offset: usize,
         key: &RowKey,

--- a/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/data_access/mod.rs
@@ -33,6 +33,9 @@ mod big_promoted_crc_tests;
 // `tests/`.
 #[cfg(test)]
 mod chunk_cache_wiring_tests;
+// BIG ("nb"/uncompressed) point lookup: raw-key Index.db resolve + covering-chunk
+// seek (issue #1572), replacing the whole-file scan_for_key fallback.
+mod big_point;
 mod compaction;
 mod model;
 mod sequential;
@@ -198,8 +201,6 @@ impl SSTableReader {
         key: &RowKey,
         fully_qualified_match: bool,
     ) -> Result<Option<ScanRow>> {
-        use crate::observability::{self as obs, catalog};
-
         // Issue #831 / #909: BTI ("da") readers resolve partitions via the
         // Partitions.db trie (O(log n)), never via Index.db (absent for BTI) or
         // the sequential scan. The trie is the AUTHORITATIVE presence oracle for a
@@ -216,59 +217,14 @@ impl SSTableReader {
                 .await;
         }
 
-        // First check bloom filter if available
-        if let Some(bloom_filter) = &self.bloom_filter {
-            let present = bloom_filter.might_contain(key.as_bytes());
-            obs::add_counter(
-                catalog::READ_BLOOM_CHECKS,
-                1,
-                &[
-                    (
-                        catalog::attr::RESULT,
-                        if present { "hit" } else { "miss" }.into(),
-                    ),
-                    (
-                        catalog::attr::SSTABLE_FORMAT,
-                        self.sstable_format_label().into(),
-                    ),
-                ],
-            );
-            if !present {
-                return Ok(None);
-            }
-        }
-
-        // Use index for efficient lookup if available
-        if let Some(index) = &self.index {
-            if let Some(entry) = index.find_entry(table_id, key).await? {
-                // When Index.db reports size=0 (Cassandra 5.0), fall back to sequential scan
-                if entry.size == 0 {
-                    log::debug!(
-                        "Index reports size=0 for key {:?}, using sequential scan fallback",
-                        key
-                    );
-                    return self.scan_for_key(table_id, key).await;
-                }
-
-                // Index offsets are relative to data section start - adjust for header
-                let file_offset = entry.offset + self.actual_header_size as u64;
-                return self.read_value_at_offset(file_offset, entry.size).await;
-            }
-
-            // Issue #517: The SSTableIndex is built from Index.db key *digests* (16-byte
-            // Murmur3 hashes), not raw partition key bytes.  A raw-key lookup via
-            // find_entry() always misses.  Fall back to scan_for_key() so that get()
-            // and scan() agree on which partitions exist.
-            log::debug!(
-                "Index lookup returned no entry for key {:?} (possible digest/raw-key mismatch), \
-                 falling back to sequential scan",
-                key
-            );
-            return self.scan_for_key(table_id, key).await;
-        } else {
-            // No index at all — fall back to sequential scan
-            return self.scan_for_key(table_id, key).await;
-        }
+        // BIG ("nb"/uncompressed) readers: raw-key Index.db resolve + covering-chunk
+        // seek (issue #1572). The bloom pre-check, the fast Index.db-resolved
+        // chunk-targeted decode, and the index-less `scan_for_key` fallback all live
+        // in `big_point`. Before #1572 this path called `self.index.find_entry()`
+        // with raw key bytes against a *digest*-keyed map (always a miss, issue
+        // #517), so every lookup fell through to a whole-file `scan_for_key`.
+        self.big_get_with_resolution(table_id, key, fully_qualified_match)
+            .await
     }
 
     /// Stitch all compressed chunks and parse as a single buffer (V5CompressedLegacy)

--- a/cqlite-core/tests/issue_1572_big_get_chunk_seek.rs
+++ b/cqlite-core/tests/issue_1572_big_get_chunk_seek.rs
@@ -98,12 +98,13 @@ async fn scan_oracle(reader: &SSTableReader) -> HashMap<Vec<u8>, ScanRow> {
 }
 
 /// Return the fixture's chunk length when it is genuinely MULTI-CHUNK (so the
-/// chunk-targeting tests are meaningful), or `None` when the fixture is present
+/// chunk-targeting test is meaningful), or `None` when the fixture is present
 /// but single-chunk / uncompressed (no `CompressionInfo.db` or a single chunk).
 ///
-/// A present-but-not-multi-chunk fixture is treated as a SKIP by callers (same
-/// graceful skip as a fixture-absent run), NOT a hard failure — a legitimately
-/// single-chunk fixture must not fail the suite.
+/// Only `get_reads_bounded_chunks_not_whole_file` (the bytes-bounded micro-proof)
+/// consults this — a present-but-single-chunk fixture is a LOUD warn-skip there,
+/// NOT a hard failure. The scan-counter and oracle-parity proofs are decoupled
+/// from chunk count and run on any present fixture (roborev #1572 Medium).
 fn multi_chunk_len(reader: &SSTableReader) -> Option<u64> {
     let comp = reader.compression_info.as_ref()?;
     if comp.chunk_offsets.len() <= 1 {
@@ -123,11 +124,13 @@ async fn present_key_get_does_not_sequential_scan() {
         eprintln!("SKIP: {KEYSPACE}/{TABLE} BIG fixture not available");
         return;
     };
+    // This proof (SCAN_FOR_KEY delta == 0 on a present key) is valid on a
+    // single-chunk fixture too, so it must run whenever the fixture is PRESENT
+    // regardless of chunk count — it may only SKIP when Data.db is ABSENT
+    // (handled above). Decoupling the multi-chunk requirement from the core
+    // correctness proof means a fixture regression to single-chunk can never
+    // silently neuter the scan-counter guard (roborev #1572 Medium).
     let reader = open_reader(&dd).await;
-    if multi_chunk_len(&reader).is_none() {
-        eprintln!("SKIP: {KEYSPACE}/{TABLE} present but not multi-chunk");
-        return;
-    }
     let oracle = scan_oracle(&reader).await;
     let present_key = oracle.keys().next().expect("at least one key").clone();
 
@@ -182,8 +185,18 @@ async fn get_reads_bounded_chunks_not_whole_file() {
         return;
     };
     let reader = open_reader(&dd).await;
+    // This is the ONLY test that genuinely requires a MULTI-CHUNK fixture (it
+    // proves a get() decompresses a bounded number of chunks, not O(file)). If
+    // the fixture is PRESENT but single-chunk, the chunk-bound micro-proof cannot
+    // run — but that non-execution must be LOUD so a fixture regression to
+    // single-chunk can't quietly neuter the perf proof (roborev #1572 Medium).
+    // (A fixture-ABSENT run above is a quiet skip; this is a present-but-degraded
+    // warn-skip.)
     let Some(chunk_len) = multi_chunk_len(&reader) else {
-        eprintln!("SKIP: {KEYSPACE}/{TABLE} present but not multi-chunk");
+        eprintln!(
+            "WARNING: #1572 chunk-bound proof did not run — fixture present but single-chunk \
+             ({KEYSPACE}/{TABLE}); the bytes-bounded chunk-targeting proof was SKIPPED"
+        );
         return;
     };
     let n_chunks = reader
@@ -233,16 +246,16 @@ async fn get_reads_bounded_chunks_not_whole_file() {
     // Bounded: one covering chunk (up to 2 if the partition straddles a boundary),
     // NEVER O(file) = n_chunks. The `>= 1` lower bound is what fails on `main`
     // (the whole-file stitch never touches the wired decompress site).
+    // The `(1..=2).contains(&cost)` bound alone proves chunk-targeting for ANY
+    // `n_chunks >= 2` (a whole-file stitch would decompress `n_chunks`). We do NOT
+    // additionally assert `cost < n_chunks`: on an exactly-2-chunk fixture a
+    // partition straddling the boundary reads both chunks (`cost == 2`), a correct
+    // chunk-targeted read that `2 < 2` would false-fail (roborev #1572 Low).
     for (label, cost) in [("head", head_cost), ("tail", tail_cost)] {
         assert!(
             (1..=2).contains(&cost),
             "{label} get() must decompress a bounded 1..=2 chunks (chunk-targeted), \
              got {cost} on a {n_chunks}-chunk fixture"
-        );
-        assert!(
-            cost < n_chunks as u64,
-            "{label} get() decompressed {cost} chunks — must be far below the \
-             whole-file count {n_chunks}"
         );
     }
     // NOTE: we do NOT assert `head_cost == tail_cost`. Chunk-targeting is already
@@ -267,11 +280,10 @@ async fn absent_key_returns_none_without_scan() {
         eprintln!("SKIP: {KEYSPACE}/{TABLE} BIG fixture not available");
         return;
     };
+    // An Index.db-definitive absent (no sequential scan) holds on a single-chunk
+    // fixture too, so this runs whenever the fixture is PRESENT; it only SKIPs
+    // when Data.db is ABSENT (handled above) (roborev #1572 Medium).
     let reader = open_reader(&dd).await;
-    if multi_chunk_len(&reader).is_none() {
-        eprintln!("SKIP: {KEYSPACE}/{TABLE} present but not multi-chunk");
-        return;
-    }
     let oracle = scan_oracle(&reader).await;
 
     // Synthesize a 16-byte key that is definitely NOT in the fixture.
@@ -317,11 +329,12 @@ async fn get_value_matches_full_scan_oracle_for_all_keys() {
         eprintln!("SKIP: {KEYSPACE}/{TABLE} BIG fixture not available");
         return;
     };
+    // The correctness guard: get() byte-parity vs the whole-file scan oracle for
+    // EVERY key. Valid on a single-chunk fixture too, so it must run whenever the
+    // fixture is PRESENT — decoupling it from the multi-chunk requirement means a
+    // regression to a single-chunk fixture can never silently pass this proof
+    // (roborev #1572 Medium). It SKIPs only when Data.db is ABSENT (handled above).
     let reader = open_reader(&dd).await;
-    if multi_chunk_len(&reader).is_none() {
-        eprintln!("SKIP: {KEYSPACE}/{TABLE} present but not multi-chunk");
-        return;
-    }
     let oracle = scan_oracle(&reader).await;
 
     let mut checked = 0usize;

--- a/cqlite-core/tests/issue_1572_big_get_chunk_seek.rs
+++ b/cqlite-core/tests/issue_1572_big_get_chunk_seek.rs
@@ -316,8 +316,9 @@ async fn get_value_matches_full_scan_oracle_for_all_keys() {
             .get(&table_id(), &RowKey::new(raw_key.clone()))
             .await
             .unwrap_or_else(|e| panic!("get() errored for key {raw_key:02x?}: {e}"));
-        let got = got
-            .unwrap_or_else(|| panic!("get() returned None for a key the scan found: {raw_key:02x?}"));
+        let got = got.unwrap_or_else(|| {
+            panic!("get() returned None for a key the scan found: {raw_key:02x?}")
+        });
         assert_eq!(
             &got, expected,
             "fixed get() row differs from the whole-file scan oracle for key {raw_key:02x?}"

--- a/cqlite-core/tests/issue_1572_big_get_chunk_seek.rs
+++ b/cqlite-core/tests/issue_1572_big_get_chunk_seek.rs
@@ -333,3 +333,140 @@ async fn get_value_matches_full_scan_oracle_for_all_keys() {
     );
     eprintln!("get_value_matches_full_scan_oracle_for_all_keys PASSED ({checked} keys)");
 }
+
+// -------------------------------------------------------------------------
+// Test 5 (roborev correctness regression): a TRUNCATED / partial Index.db
+// must not turn an index MISS into a silent wrong-answer.
+//
+// `IndexReader::open` does NOT guarantee a complete partition map: entry
+// parsing `break`s on the first unparseable entry and the leftover bytes are
+// discarded, so a truncated Index.db opens successfully with a PARTIAL prefix
+// map. The #1572 fast path treated an index miss as a definitive absent →
+// a partition whose entry lies past the parse-stop point returned `None` from
+// `get()` even though `scan()` still finds it in Data.db (get/scan divergence).
+//
+// The fix only treats a miss as authoritative when the map is KNOWN-COMPLETE;
+// otherwise it falls back to the whole-file scan. This test builds a degraded
+// fixture by truncating a COPY of a real Index.db (never mutating the shared
+// dataset) and asserts every scan-visible key is still found by `get()`.
+// FAILS without the fix (get() returns None for the post-truncation key),
+// PASSES with it.
+// -------------------------------------------------------------------------
+
+/// Copy the full SSTable component set (every sibling of `data_db`, e.g.
+/// `nb-1-big-*`) into `dst_dir`, returning the copied Data.db path.
+fn copy_component_set(data_db: &Path, dst_dir: &Path) -> PathBuf {
+    let src_dir = data_db.parent().expect("Data.db has a parent dir");
+    let data_name = data_db
+        .file_name()
+        .expect("Data.db file name")
+        .to_string_lossy()
+        .to_string();
+    // Component stem is everything up to `-Data.db` (e.g. `nb-1-big`).
+    let stem = data_name
+        .strip_suffix("-Data.db")
+        .expect("Data.db name ends with -Data.db");
+    for entry in std::fs::read_dir(src_dir).expect("read source SSTable dir").flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        // Copy this generation's real components, but NOT the `.jsonl` golden.
+        if name.starts_with(&format!("{stem}-")) && !name.ends_with(".jsonl") {
+            std::fs::copy(entry.path(), dst_dir.join(&name))
+                .unwrap_or_else(|e| panic!("copy {name}: {e}"));
+        }
+    }
+    dst_dir.join(&data_name)
+}
+
+#[tokio::test]
+async fn truncated_index_get_falls_back_to_scan() {
+    let Some(dd) = big_data_db() else {
+        eprintln!("SKIP: {KEYSPACE}/{TABLE} BIG fixture not available");
+        return;
+    };
+
+    // 1. Copy the component set to a temp dir so we never mutate the shared dataset.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let copied_data = copy_component_set(&dd, tmp.path());
+    let index_copy = tmp.path().join(
+        copied_data
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .replace("-Data.db", "-Index.db"),
+    );
+
+    // 2. Truncate the Index.db copy MID-ENTRY: drop the tail so the final entry
+    //    fails to parse. The parser stops early (partial prefix map, leftover
+    //    remaining ⇒ NOT known-complete); the token-tail partition(s) are lost
+    //    from the map but still present in Data.db.
+    let orig_len = std::fs::metadata(&index_copy).expect("Index.db metadata").len();
+    assert!(orig_len > 32, "Index.db unexpectedly tiny ({orig_len} bytes)");
+    // Remove the last 8 bytes — cuts into the final entry's key so `take` fails,
+    // leaving a non-empty `remaining` (guaranteed is_complete == false), and
+    // only the final entry is affected (earlier entries parse intact).
+    let truncated_len = orig_len - 8;
+    let f = std::fs::OpenOptions::new()
+        .write(true)
+        .open(&index_copy)
+        .expect("open Index.db copy for truncation");
+    f.set_len(truncated_len).expect("truncate Index.db copy");
+    drop(f);
+
+    // 3. Open the reader over the DEGRADED copy and enumerate all keys via scan
+    //    (the whole-file oracle is unaffected by the Index.db truncation).
+    let reader = open_reader(&copied_data).await;
+    let oracle = scan_oracle(&reader).await;
+
+    // 4. Partition oracle keys by whether the truncated Index.db still resolves
+    //    them. A partial map means at least one scan-visible key now MISSES the
+    //    index — that is the key the #1572 regression would silently drop.
+    let mut missing: Vec<Vec<u8>> = Vec::new();
+    let mut resolvable = 0usize;
+    for k in oracle.keys() {
+        if reader
+            .lookup_partition_with_index(k)
+            .await
+            .expect("index lookup must not error")
+            .is_some()
+        {
+            resolvable += 1;
+        } else {
+            missing.push(k.clone());
+        }
+    }
+    assert!(
+        resolvable > 0,
+        "truncation should leave a parsed prefix (some keys still resolvable)"
+    );
+    assert!(
+        !missing.is_empty(),
+        "truncation must drop at least one scan-visible key from the Index.db map \
+         (else the degraded-input scenario is not exercised)"
+    );
+
+    // 5. Correctness: every scan-visible key whose Index.db entry was lost must
+    //    STILL be found by get() (via the scan fallback), byte-identical to scan.
+    //    Without the fix, get() returns None here → get/scan divergence.
+    for raw_key in &missing {
+        let got = reader
+            .get(&table_id(), &RowKey::new(raw_key.clone()))
+            .await
+            .unwrap_or_else(|e| panic!("get() errored for post-truncation key {raw_key:02x?}: {e}"));
+        let got = got.unwrap_or_else(|| {
+            panic!(
+                "REGRESSION: get() returned None for key {raw_key:02x?} that scan() finds \
+                 (partial Index.db miss treated as definitive absent)"
+            )
+        });
+        let expected = oracle.get(raw_key).expect("oracle has the key");
+        assert_eq!(
+            &got, expected,
+            "get() (scan fallback) row differs from the scan oracle for key {raw_key:02x?}"
+        );
+    }
+    eprintln!(
+        "truncated_index_get_falls_back_to_scan PASSED \
+         ({} dropped keys recovered via scan fallback, {resolvable} still indexed)",
+        missing.len()
+    );
+}

--- a/cqlite-core/tests/issue_1572_big_get_chunk_seek.rs
+++ b/cqlite-core/tests/issue_1572_big_get_chunk_seek.rs
@@ -1,0 +1,333 @@
+//! Issue #1572 (Epic C / C1): BIG ("nb") `get()` must resolve a partition via
+//! the raw-key `Index.db` map and seek ONLY the covering chunk(s) — it must NOT
+//! read + decompress the whole `Data.db` on every lookup via `scan_for_key`.
+//!
+//! # What these prove (red on `main`, green with the fix)
+//! 1. `present_key_get_does_not_sequential_scan` — a `get()` for a present key on
+//!    a MULTI-CHUNK BIG fixture leaves `SCAN_FOR_KEY_CALLS` unchanged (delta == 0).
+//!    On `main` every BIG `get()` falls through to `scan_for_key` (delta == 1).
+//! 2. `get_reads_bounded_chunks_not_whole_file` — a `get()` decompresses a BOUNDED
+//!    number of chunks (the covering chunk, 1..=2), NOT O(file). Identical bounded
+//!    work for a head-of-file and a deep (high-chunk) partition proves the read is
+//!    chunk-targeted, not a whole-file stitch. On `main` the wired decompress site
+//!    never runs (delta == 0), so the `>= 1` lower bound is red there too.
+//! 3. `absent_key_returns_none_without_scan` — a key absent from the complete
+//!    `Index.db` map returns `None` definitively, with no sequential scan.
+//! 4. `get_value_matches_full_scan_oracle_for_all_keys` — for EVERY key in the
+//!    fixture, the fixed `get()` returns byte-identical rows to the whole-file scan
+//!    (the slow-but-correct oracle). This is the correctness guard on the new path.
+//!
+//! The `SCAN_FOR_KEY_CALLS` / decompress counters are process-global, so every
+//! counter-observing test serializes on the `serial_test` mutex (the existing
+//! counter-test convention). Tests SKIP (never fail) when the binary fixture is
+//! absent; a present fixture that yields 0 rows stays a hard failure.
+//!
+//! ```bash
+//! CQLITE_DATASETS_ROOT=$PWD/test-data/datasets \
+//!   cargo test --test issue_1572_big_get_chunk_seek
+//! ```
+
+use cqlite_core::{
+    storage::sstable::reader::SSTableReader, types::TableId, Config, RowKey, ScanRow,
+};
+use serial_test::serial;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+const KEYSPACE: &str = "test_basic";
+const TABLE: &str = "simple_table";
+
+/// Locate the multi-chunk BIG `Data.db` for `test_basic/simple_table`, or `None`
+/// when the binary fixture is absent (skip, not fail).
+fn big_data_db() -> Option<PathBuf> {
+    let root = std::env::var("CQLITE_DATASETS_ROOT").ok()?;
+    let base = PathBuf::from(root).join("sstables").join(KEYSPACE);
+    let table_dir = std::fs::read_dir(&base)
+        .ok()?
+        .flatten()
+        .find(|e| {
+            e.file_name()
+                .to_string_lossy()
+                .starts_with(&format!("{TABLE}-"))
+        })
+        .map(|e| e.path())?;
+    std::fs::read_dir(&table_dir).ok()?.flatten().find_map(|e| {
+        let s = e.file_name().to_string_lossy().to_string();
+        // `-Data.db` (never the `-Data.db.jsonl` golden).
+        if s.ends_with("-Data.db") {
+            Some(e.path())
+        } else {
+            None
+        }
+    })
+}
+
+async fn open_reader(data_db: &Path) -> SSTableReader {
+    let config = Config::default();
+    let platform = Arc::new(
+        cqlite_core::platform::Platform::new(&config)
+            .await
+            .expect("Platform::new"),
+    );
+    SSTableReader::open(data_db, &config, platform)
+        .await
+        .expect("SSTableReader::open must succeed for the BIG fixture")
+}
+
+fn table_id() -> TableId {
+    TableId::from(format!("{KEYSPACE}.{TABLE}"))
+}
+
+/// Enumerate the fixture's partitions via a full scan (the slow-but-correct
+/// oracle) keyed by raw partition-key bytes → first row for that key.
+async fn scan_oracle(reader: &SSTableReader) -> HashMap<Vec<u8>, ScanRow> {
+    let rows = reader
+        .scan(&table_id(), None, None, None, None)
+        .await
+        .expect("full scan (oracle) must succeed");
+    assert!(
+        !rows.is_empty(),
+        "fixture is present but the full scan returned 0 rows"
+    );
+    let mut map: HashMap<Vec<u8>, ScanRow> = HashMap::new();
+    for (k, v) in rows {
+        map.entry(k.as_bytes().to_vec()).or_insert(v);
+    }
+    map
+}
+
+/// The fixture must be genuinely MULTI-CHUNK for these tests to be meaningful.
+fn assert_multi_chunk(reader: &SSTableReader) -> u64 {
+    let comp = reader
+        .compression_info
+        .as_ref()
+        .expect("BIG fixture is chunk-compressed (CompressionInfo.db present)");
+    let n = comp.chunk_offsets.len();
+    assert!(
+        n > 1,
+        "this test requires a multi-chunk fixture; {KEYSPACE}/{TABLE} has {n} chunk(s)"
+    );
+    comp.chunk_length as u64
+}
+
+// -------------------------------------------------------------------------
+// Test 1: present-key get() does not sequential scan
+// -------------------------------------------------------------------------
+
+#[tokio::test]
+#[serial]
+async fn present_key_get_does_not_sequential_scan() {
+    let Some(dd) = big_data_db() else {
+        eprintln!("SKIP: {KEYSPACE}/{TABLE} BIG fixture not available");
+        return;
+    };
+    let reader = open_reader(&dd).await;
+    assert_multi_chunk(&reader);
+    let oracle = scan_oracle(&reader).await;
+    let present_key = oracle.keys().next().expect("at least one key").clone();
+
+    // Sanity: the raw-key Index.db map resolves this present key (fast path arms).
+    assert!(
+        reader
+            .lookup_partition_with_index(&present_key)
+            .await
+            .expect("index lookup must not error")
+            .is_some(),
+        "index_reader must resolve a present key for the fast path"
+    );
+
+    let before = SSTableReader::scan_for_key_call_count();
+    let got = reader
+        .get(&table_id(), &RowKey::new(present_key.clone()))
+        .await
+        .expect("get() must not error");
+    let after = SSTableReader::scan_for_key_call_count();
+
+    assert!(got.is_some(), "get() for a present key must return a row");
+    assert_eq!(
+        before, after,
+        "BIG get() for a present key must NOT invoke scan_for_key \
+         (whole-file decompress); count went {before} -> {after}"
+    );
+    eprintln!("present_key_get_does_not_sequential_scan PASSED (scan_for_key delta 0)");
+}
+
+// -------------------------------------------------------------------------
+// Test 2: get() reads a bounded number of chunks, independent of file size
+// -------------------------------------------------------------------------
+
+/// Open a FRESH reader (cold chunk cache) and return the number of chunk
+/// decompressions a single `get()` for `key` performs.
+async fn decompress_cost_for(dd: &Path, key: &[u8]) -> u64 {
+    let reader = open_reader(dd).await;
+    SSTableReader::reset_decompress_calls();
+    let got = reader
+        .get(&table_id(), &RowKey::new(key.to_vec()))
+        .await
+        .expect("get() must not error");
+    assert!(got.is_some(), "get() for a present key must return a row");
+    SSTableReader::decompress_call_count()
+}
+
+#[tokio::test]
+#[serial]
+async fn get_reads_bounded_chunks_not_whole_file() {
+    let Some(dd) = big_data_db() else {
+        eprintln!("SKIP: {KEYSPACE}/{TABLE} BIG fixture not available");
+        return;
+    };
+    let reader = open_reader(&dd).await;
+    let chunk_len = assert_multi_chunk(&reader);
+    let n_chunks = reader
+        .compression_info
+        .as_ref()
+        .map(|c| c.chunk_offsets.len())
+        .unwrap_or(0);
+    let oracle = scan_oracle(&reader).await;
+
+    // Pick the partition with the SMALLEST and the LARGEST uncompressed offset so
+    // the two probes land in different (and, for the max, a deep) chunk.
+    let mut min_key: Option<(u64, Vec<u8>)> = None;
+    let mut max_key: Option<(u64, Vec<u8>)> = None;
+    for k in oracle.keys() {
+        if let Some((off, _)) = reader
+            .lookup_partition_with_index(k)
+            .await
+            .expect("index lookup must not error")
+        {
+            if min_key.as_ref().is_none_or(|(m, _)| off < *m) {
+                min_key = Some((off, k.clone()));
+            }
+            if max_key.as_ref().is_none_or(|(m, _)| off > *m) {
+                max_key = Some((off, k.clone()));
+            }
+        }
+    }
+    let (min_off, head_key) = min_key.expect("a min-offset key");
+    let (max_off, tail_key) = max_key.expect("a max-offset key");
+    let tail_chunk = max_off / chunk_len;
+    assert!(
+        tail_chunk >= 1,
+        "the deepest partition (offset {max_off}, chunk_len {chunk_len}) should be past chunk 0 \
+         on a {n_chunks}-chunk fixture"
+    );
+    // The two probes must land in DIFFERENT chunks so neither reuses the other's
+    // decompressed chunk (a same-chunk pair would just be a cache hit = 0).
+    assert_ne!(
+        min_off / chunk_len,
+        max_off / chunk_len,
+        "head/tail probes must be in different chunks"
+    );
+
+    let head_cost = decompress_cost_for(&dd, &head_key).await;
+    let tail_cost = decompress_cost_for(&dd, &tail_key).await;
+
+    // Bounded: one covering chunk (up to 2 if the partition straddles a boundary),
+    // NEVER O(file) = n_chunks. The `>= 1` lower bound is what fails on `main`
+    // (the whole-file stitch never touches the wired decompress site).
+    for (label, cost) in [("head", head_cost), ("tail", tail_cost)] {
+        assert!(
+            (1..=2).contains(&cost),
+            "{label} get() must decompress a bounded 1..=2 chunks (chunk-targeted), \
+             got {cost} on a {n_chunks}-chunk fixture"
+        );
+        assert!(
+            cost < n_chunks as u64,
+            "{label} get() decompressed {cost} chunks — must be far below the \
+             whole-file count {n_chunks}"
+        );
+    }
+    assert_eq!(
+        head_cost, tail_cost,
+        "chunk-targeted work must be independent of the partition's file position \
+         (head {head_cost} vs deep-tail {tail_cost})"
+    );
+    eprintln!(
+        "get_reads_bounded_chunks_not_whole_file PASSED \
+         (head={head_cost} tail={tail_cost} of {n_chunks} chunks)"
+    );
+}
+
+// -------------------------------------------------------------------------
+// Test 3: absent key returns None without a full scan
+// -------------------------------------------------------------------------
+
+#[tokio::test]
+#[serial]
+async fn absent_key_returns_none_without_scan() {
+    let Some(dd) = big_data_db() else {
+        eprintln!("SKIP: {KEYSPACE}/{TABLE} BIG fixture not available");
+        return;
+    };
+    let reader = open_reader(&dd).await;
+    assert_multi_chunk(&reader);
+    let oracle = scan_oracle(&reader).await;
+
+    // Synthesize a 16-byte key that is definitely NOT in the fixture.
+    let absent = RowKey::new(vec![0xEEu8; 16]);
+    assert!(
+        !oracle.contains_key(absent.as_bytes()),
+        "chosen absent key unexpectedly present"
+    );
+    // The complete Index.db map must not resolve it.
+    assert!(
+        reader
+            .lookup_partition_with_index(absent.as_bytes())
+            .await
+            .expect("index lookup must not error")
+            .is_none(),
+        "absent key must miss the complete Index.db map"
+    );
+
+    let before = SSTableReader::scan_for_key_call_count();
+    let got = reader
+        .get(&table_id(), &absent)
+        .await
+        .expect("get() for an absent key must not error");
+    let after = SSTableReader::scan_for_key_call_count();
+
+    assert!(got.is_none(), "get() for an absent key must return None");
+    assert_eq!(
+        before, after,
+        "an Index.db-definitive absent must not trigger a sequential scan; \
+         count went {before} -> {after}"
+    );
+    eprintln!("absent_key_returns_none_without_scan PASSED");
+}
+
+// -------------------------------------------------------------------------
+// Test 4: value parity vs the whole-file scan oracle for EVERY key
+// -------------------------------------------------------------------------
+
+#[tokio::test]
+async fn get_value_matches_full_scan_oracle_for_all_keys() {
+    let Some(dd) = big_data_db() else {
+        eprintln!("SKIP: {KEYSPACE}/{TABLE} BIG fixture not available");
+        return;
+    };
+    let reader = open_reader(&dd).await;
+    assert_multi_chunk(&reader);
+    let oracle = scan_oracle(&reader).await;
+
+    let mut checked = 0usize;
+    for (raw_key, expected) in &oracle {
+        let got = reader
+            .get(&table_id(), &RowKey::new(raw_key.clone()))
+            .await
+            .unwrap_or_else(|e| panic!("get() errored for key {raw_key:02x?}: {e}"));
+        let got = got
+            .unwrap_or_else(|| panic!("get() returned None for a key the scan found: {raw_key:02x?}"));
+        assert_eq!(
+            &got, expected,
+            "fixed get() row differs from the whole-file scan oracle for key {raw_key:02x?}"
+        );
+        checked += 1;
+    }
+    assert_eq!(
+        checked,
+        oracle.len(),
+        "must have checked every partition key"
+    );
+    eprintln!("get_value_matches_full_scan_oracle_for_all_keys PASSED ({checked} keys)");
+}

--- a/cqlite-core/tests/issue_1572_big_get_chunk_seek.rs
+++ b/cqlite-core/tests/issue_1572_big_get_chunk_seek.rs
@@ -301,6 +301,7 @@ async fn absent_key_returns_none_without_scan() {
 // -------------------------------------------------------------------------
 
 #[tokio::test]
+#[serial]
 async fn get_value_matches_full_scan_oracle_for_all_keys() {
     let Some(dd) = big_data_db() else {
         eprintln!("SKIP: {KEYSPACE}/{TABLE} BIG fixture not available");

--- a/cqlite-core/tests/issue_1572_big_get_chunk_seek.rs
+++ b/cqlite-core/tests/issue_1572_big_get_chunk_seek.rs
@@ -97,18 +97,19 @@ async fn scan_oracle(reader: &SSTableReader) -> HashMap<Vec<u8>, ScanRow> {
     map
 }
 
-/// The fixture must be genuinely MULTI-CHUNK for these tests to be meaningful.
-fn assert_multi_chunk(reader: &SSTableReader) -> u64 {
-    let comp = reader
-        .compression_info
-        .as_ref()
-        .expect("BIG fixture is chunk-compressed (CompressionInfo.db present)");
-    let n = comp.chunk_offsets.len();
-    assert!(
-        n > 1,
-        "this test requires a multi-chunk fixture; {KEYSPACE}/{TABLE} has {n} chunk(s)"
-    );
-    comp.chunk_length as u64
+/// Return the fixture's chunk length when it is genuinely MULTI-CHUNK (so the
+/// chunk-targeting tests are meaningful), or `None` when the fixture is present
+/// but single-chunk / uncompressed (no `CompressionInfo.db` or a single chunk).
+///
+/// A present-but-not-multi-chunk fixture is treated as a SKIP by callers (same
+/// graceful skip as a fixture-absent run), NOT a hard failure — a legitimately
+/// single-chunk fixture must not fail the suite.
+fn multi_chunk_len(reader: &SSTableReader) -> Option<u64> {
+    let comp = reader.compression_info.as_ref()?;
+    if comp.chunk_offsets.len() <= 1 {
+        return None;
+    }
+    Some(comp.chunk_length as u64)
 }
 
 // -------------------------------------------------------------------------
@@ -123,7 +124,10 @@ async fn present_key_get_does_not_sequential_scan() {
         return;
     };
     let reader = open_reader(&dd).await;
-    assert_multi_chunk(&reader);
+    if multi_chunk_len(&reader).is_none() {
+        eprintln!("SKIP: {KEYSPACE}/{TABLE} present but not multi-chunk");
+        return;
+    }
     let oracle = scan_oracle(&reader).await;
     let present_key = oracle.keys().next().expect("at least one key").clone();
 
@@ -178,7 +182,10 @@ async fn get_reads_bounded_chunks_not_whole_file() {
         return;
     };
     let reader = open_reader(&dd).await;
-    let chunk_len = assert_multi_chunk(&reader);
+    let Some(chunk_len) = multi_chunk_len(&reader) else {
+        eprintln!("SKIP: {KEYSPACE}/{TABLE} present but not multi-chunk");
+        return;
+    };
     let n_chunks = reader
         .compression_info
         .as_ref()
@@ -238,11 +245,11 @@ async fn get_reads_bounded_chunks_not_whole_file() {
              whole-file count {n_chunks}"
         );
     }
-    assert_eq!(
-        head_cost, tail_cost,
-        "chunk-targeted work must be independent of the partition's file position \
-         (head {head_cost} vs deep-tail {tail_cost})"
-    );
+    // NOTE: we do NOT assert `head_cost == tail_cost`. Chunk-targeting is already
+    // proven by the bounded `(1..=2).contains(&cost)` check above; a strict
+    // equality would flake if exactly one probed partition straddles a chunk
+    // boundary (cost 2) while the other does not (cost 1) — both are correct
+    // chunk-targeted reads, just off by one covering chunk.
     eprintln!(
         "get_reads_bounded_chunks_not_whole_file PASSED \
          (head={head_cost} tail={tail_cost} of {n_chunks} chunks)"
@@ -261,7 +268,10 @@ async fn absent_key_returns_none_without_scan() {
         return;
     };
     let reader = open_reader(&dd).await;
-    assert_multi_chunk(&reader);
+    if multi_chunk_len(&reader).is_none() {
+        eprintln!("SKIP: {KEYSPACE}/{TABLE} present but not multi-chunk");
+        return;
+    }
     let oracle = scan_oracle(&reader).await;
 
     // Synthesize a 16-byte key that is definitely NOT in the fixture.
@@ -308,7 +318,10 @@ async fn get_value_matches_full_scan_oracle_for_all_keys() {
         return;
     };
     let reader = open_reader(&dd).await;
-    assert_multi_chunk(&reader);
+    if multi_chunk_len(&reader).is_none() {
+        eprintln!("SKIP: {KEYSPACE}/{TABLE} present but not multi-chunk");
+        return;
+    }
     let oracle = scan_oracle(&reader).await;
 
     let mut checked = 0usize;
@@ -345,12 +358,13 @@ async fn get_value_matches_full_scan_oracle_for_all_keys() {
 // a partition whose entry lies past the parse-stop point returned `None` from
 // `get()` even though `scan()` still finds it in Data.db (get/scan divergence).
 //
-// The fix only treats a miss as authoritative when the map is KNOWN-COMPLETE;
-// otherwise it falls back to the whole-file scan. This test builds a degraded
+// The fix makes EVERY `index_reader` miss fall back to the whole-file scan
+// oracle (the bloom pre-check remains the fast definitive-absent path for the
+// common case). This test exercises the MID-ENTRY truncation case; the
+// boundary-aligned case (whole trailing entries dropped) is covered by
+// `boundary_truncated_index_get_falls_back_to_scan` below. Both build a degraded
 // fixture by truncating a COPY of a real Index.db (never mutating the shared
-// dataset) and asserts every scan-visible key is still found by `get()`.
-// FAILS without the fix (get() returns None for the post-truncation key),
-// PASSES with it.
+// dataset) and assert every scan-visible key is still found by `get()`.
 // -------------------------------------------------------------------------
 
 /// Copy the full SSTable component set (every sibling of `data_db`, e.g.
@@ -366,7 +380,10 @@ fn copy_component_set(data_db: &Path, dst_dir: &Path) -> PathBuf {
     let stem = data_name
         .strip_suffix("-Data.db")
         .expect("Data.db name ends with -Data.db");
-    for entry in std::fs::read_dir(src_dir).expect("read source SSTable dir").flatten() {
+    for entry in std::fs::read_dir(src_dir)
+        .expect("read source SSTable dir")
+        .flatten()
+    {
         let name = entry.file_name().to_string_lossy().to_string();
         // Copy this generation's real components, but NOT the `.jsonl` golden.
         if name.starts_with(&format!("{stem}-")) && !name.ends_with(".jsonl") {
@@ -397,13 +414,17 @@ async fn truncated_index_get_falls_back_to_scan() {
 
     // 2. Truncate the Index.db copy MID-ENTRY: drop the tail so the final entry
     //    fails to parse. The parser stops early (partial prefix map, leftover
-    //    remaining ⇒ NOT known-complete); the token-tail partition(s) are lost
-    //    from the map but still present in Data.db.
-    let orig_len = std::fs::metadata(&index_copy).expect("Index.db metadata").len();
-    assert!(orig_len > 32, "Index.db unexpectedly tiny ({orig_len} bytes)");
+    //    bytes discarded); the token-tail partition(s) are lost from the map but
+    //    still present in Data.db.
+    let orig_len = std::fs::metadata(&index_copy)
+        .expect("Index.db metadata")
+        .len();
+    assert!(
+        orig_len > 32,
+        "Index.db unexpectedly tiny ({orig_len} bytes)"
+    );
     // Remove the last 8 bytes — cuts into the final entry's key so `take` fails,
-    // leaving a non-empty `remaining` (guaranteed is_complete == false), and
-    // only the final entry is affected (earlier entries parse intact).
+    // and only the final entry is affected (earlier entries parse intact).
     let truncated_len = orig_len - 8;
     let f = std::fs::OpenOptions::new()
         .write(true)
@@ -451,7 +472,9 @@ async fn truncated_index_get_falls_back_to_scan() {
         let got = reader
             .get(&table_id(), &RowKey::new(raw_key.clone()))
             .await
-            .unwrap_or_else(|e| panic!("get() errored for post-truncation key {raw_key:02x?}: {e}"));
+            .unwrap_or_else(|e| {
+                panic!("get() errored for post-truncation key {raw_key:02x?}: {e}")
+            });
         let got = got.unwrap_or_else(|| {
             panic!(
                 "REGRESSION: get() returned None for key {raw_key:02x?} that scan() finds \
@@ -466,6 +489,203 @@ async fn truncated_index_get_falls_back_to_scan() {
     }
     eprintln!(
         "truncated_index_get_falls_back_to_scan PASSED \
+         ({} dropped keys recovered via scan fallback, {resolvable} still indexed)",
+        missing.len()
+    );
+}
+
+// -------------------------------------------------------------------------
+// Test 6 (roborev correctness regression, boundary-aligned): the specific case
+// the previous parse-consumption completeness signal could NOT detect.
+//
+// The pre-fix code marked the Index.db map "known-complete" whenever the entry
+// parser consumed all bytes to EOF (empty leftover). That detects MID-ENTRY
+// truncation (test 5) but NOT truncation aligned to an EXACT entry boundary:
+// dropping WHOLE trailing entries leaves the surviving prefix parsing cleanly
+// with NO leftover bytes, so the map looked "complete" while partitions were
+// silently missing → an index miss for a dropped-but-scan-visible key returned
+// `None` from `get()` (get/scan divergence).
+//
+// The fix removes the unreliable completeness signal entirely: EVERY index miss
+// falls back to the whole-file scan oracle. This test truncates a COPY of a real
+// Index.db at an EXACT entry boundary (drop the last whole entry, computed by
+// walking the on-disk entry layout) and asserts every dropped-but-scan-visible
+// key is still returned by `get()` byte-identical to `scan()`.
+// FAILS without the fix (get() returns None for the dropped key), PASSES with it.
+// -------------------------------------------------------------------------
+
+/// Decode a Cassandra unsigned vint at `buf[pos..]`, returning
+/// `(value, total_bytes_consumed)`, or `None` if the vint is truncated.
+///
+/// Encoding: the first byte's leading 1-bits give the number of EXTRA bytes;
+/// the remaining low bits of the first byte are the value's high bits, followed
+/// by the extra bytes big-endian (Cassandra `VIntCoding`).
+fn read_unsigned_vint(buf: &[u8], pos: usize) -> Option<(u64, usize)> {
+    let first = *buf.get(pos)?;
+    let extra = first.leading_ones() as usize;
+    if extra == 0 {
+        return Some((first as u64, 1));
+    }
+    if pos + 1 + extra > buf.len() {
+        return None;
+    }
+    // For extra >= 7 the first byte carries no value bits (all marker bits).
+    let mask = if extra >= 7 {
+        0u8
+    } else {
+        0xffu8 >> (extra + 1)
+    };
+    let mut val = (first & mask) as u64;
+    for i in 0..extra {
+        val = (val << 8) | buf[pos + 1 + i] as u64;
+    }
+    Some((val, 1 + extra))
+}
+
+/// Walk the headerless BIG Index.db entry layout from `start`, returning the byte
+/// offset AFTER each complete entry (i.e. every exact entry boundary). Each entry
+/// is `[key_len: u16 BE][key][data_offset: uvint][promoted_len: uvint][promoted]`.
+///
+/// Returns `None` when the bytes don't look like the expected headerless layout
+/// (implausible key length) so the caller can SKIP rather than truncate blindly.
+/// Real Cassandra 5.0 `nb` Index.db is headerless (starts with the u16 key_len).
+fn entry_end_offsets(buf: &[u8]) -> Option<Vec<usize>> {
+    let mut pos = 0usize;
+    let mut ends = Vec::new();
+    while pos + 2 <= buf.len() {
+        let key_len = u16::from_be_bytes([buf[pos], buf[pos + 1]]) as usize;
+        // Plausibility guard: a real partition key is 1..=4096 bytes. An
+        // implausible length means this isn't the headerless entry layout.
+        if key_len == 0 || key_len > 4096 {
+            return None;
+        }
+        let mut p = pos + 2;
+        if p + key_len > buf.len() {
+            break; // partial trailing entry (key truncated)
+        }
+        p += key_len;
+        // data_offset uvint
+        let (_data_off, n1) = read_unsigned_vint(buf, p)?;
+        p += n1;
+        // promoted_index_len uvint + promoted_index_data
+        let (promoted_len, n2) = read_unsigned_vint(buf, p)?;
+        p += n2;
+        let promoted_len = promoted_len as usize;
+        if p + promoted_len > buf.len() {
+            break; // partial trailing entry (promoted data truncated)
+        }
+        p += promoted_len;
+        ends.push(p);
+        pos = p;
+    }
+    Some(ends)
+}
+
+#[tokio::test]
+async fn boundary_truncated_index_get_falls_back_to_scan() {
+    let Some(dd) = big_data_db() else {
+        eprintln!("SKIP: {KEYSPACE}/{TABLE} BIG fixture not available");
+        return;
+    };
+
+    // 1. Copy the component set to a temp dir so we never mutate the shared dataset.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let copied_data = copy_component_set(&dd, tmp.path());
+    let index_copy = tmp.path().join(
+        copied_data
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .replace("-Data.db", "-Index.db"),
+    );
+
+    // 2. Compute the EXACT entry boundaries of the real Index.db, then truncate
+    //    at the boundary that drops the LAST WHOLE entry. The surviving prefix
+    //    parses cleanly with NO leftover bytes — the boundary-aligned case the
+    //    old parse-consumption signal could not detect.
+    let index_bytes = std::fs::read(&index_copy).expect("read Index.db copy");
+    let Some(ends) = entry_end_offsets(&index_bytes) else {
+        eprintln!("SKIP: {KEYSPACE}/{TABLE} Index.db is not the headerless BIG layout");
+        return;
+    };
+    if ends.len() < 2 {
+        eprintln!("SKIP: {KEYSPACE}/{TABLE} Index.db has <2 entries; cannot drop a whole entry");
+        return;
+    }
+    // Drop the last whole entry: truncate at the boundary after the penultimate
+    // entry. This is an EXACT boundary ⇒ the prefix parses cleanly to EOF.
+    let truncated_len = ends[ends.len() - 2] as u64;
+    let full_len = index_bytes.len() as u64;
+    assert!(
+        truncated_len < full_len,
+        "boundary truncation must actually shorten the file ({truncated_len} < {full_len})"
+    );
+    let f = std::fs::OpenOptions::new()
+        .write(true)
+        .open(&index_copy)
+        .expect("open Index.db copy for truncation");
+    f.set_len(truncated_len).expect("truncate Index.db copy");
+    drop(f);
+
+    // 3. Open the reader over the DEGRADED copy and enumerate all keys via scan
+    //    (the whole-file oracle is unaffected by the Index.db truncation).
+    let reader = open_reader(&copied_data).await;
+    let oracle = scan_oracle(&reader).await;
+
+    // 4. Partition oracle keys by whether the boundary-truncated Index.db still
+    //    resolves them. Dropping whole trailing entries must leave at least one
+    //    scan-visible key that now MISSES the index — the key the boundary-aligned
+    //    #1572 regression would silently drop.
+    let mut missing: Vec<Vec<u8>> = Vec::new();
+    let mut resolvable = 0usize;
+    for k in oracle.keys() {
+        if reader
+            .lookup_partition_with_index(k)
+            .await
+            .expect("index lookup must not error")
+            .is_some()
+        {
+            resolvable += 1;
+        } else {
+            missing.push(k.clone());
+        }
+    }
+    // Self-check that the boundary walk was correct: the surviving prefix must
+    // still resolve a non-empty set of keys (a bad walk / wrong header assumption
+    // would corrupt the prefix and resolve none).
+    assert!(
+        resolvable > 0,
+        "boundary truncation should leave a clean parsed prefix (some keys still resolvable)"
+    );
+    assert!(
+        !missing.is_empty(),
+        "dropping a whole trailing entry must remove at least one scan-visible key \
+         from the Index.db map (else the boundary-aligned scenario is not exercised)"
+    );
+
+    // 5. Correctness: every scan-visible key whose Index.db entry was dropped must
+    //    STILL be found by get() (via the scan fallback), byte-identical to scan.
+    //    Without the fix, the boundary-aligned truncation looked "complete" so the
+    //    index miss returned None here → get/scan divergence.
+    for raw_key in &missing {
+        let got = reader
+            .get(&table_id(), &RowKey::new(raw_key.clone()))
+            .await
+            .unwrap_or_else(|e| panic!("get() errored for dropped key {raw_key:02x?}: {e}"));
+        let got = got.unwrap_or_else(|| {
+            panic!(
+                "REGRESSION: get() returned None for key {raw_key:02x?} that scan() finds \
+                 (boundary-aligned Index.db miss treated as definitive absent)"
+            )
+        });
+        let expected = oracle.get(raw_key).expect("oracle has the key");
+        assert_eq!(
+            &got, expected,
+            "get() (scan fallback) row differs from the scan oracle for key {raw_key:02x?}"
+        );
+    }
+    eprintln!(
+        "boundary_truncated_index_get_falls_back_to_scan PASSED \
          ({} dropped keys recovered via scan fallback, {resolvable} still indexed)",
         missing.len()
     );


### PR DESCRIPTION
Closes #1572 (C1 — child of Epic C #1515, read-path audit block 1).

## Problem
On BIG (`nb`) SSTables, `SSTableManager::get()` read + decompressed the **entire Data.db on every lookup**: the BIG index HashMap is keyed by 16-byte Murmur3 digests but `find_entry()` was called with raw key bytes → always missed → fell back to `scan_for_key` → `stitch_and_parse_all_chunks` (whole-file read+decompress per lookup).

## Fix
- BIG `get_with_resolution()` resolves the partition's `Data.db` offset via the raw-key `index_reader` (the O(1) `Index.db` map), then decodes ONLY the covering chunk(s) by reusing the proven BTI chunk-targeted decode `bti_decompress_and_parse_target` (offset → `CompressionInfo` chunk → CRC-check → decompress → parse the single partition) — the same pattern the query-engine single-candidate path already uses.
- **Conservative on degraded inputs:** any `Index.db` miss falls back to `scan_for_key` (never claims definitive-absent from an index miss), so `get()` and `scan()` stay consistent on truncated / partial / boundary-truncated indexes. The bloom pre-check remains the fast definitive-absent path for the common case (satisfies the "absent key without full scan" criterion).
- No-heuristics (#28): offset from `Index.db`, covering chunk from `CompressionInfo` (no boundary guessing); CRC-before-decompress preserved (#1411). Works in default and `tombstones` builds.
- Extracted the BIG point-lookup into `big_point.rs` to keep `mod.rs` within the size ratchet.

## Tests (TDD, real 41-chunk `test_basic/simple_table` fixture)
- `present_key_get_does_not_sequential_scan` — `SCAN_FOR_KEY_CALLS` delta == 0 (RED on main).
- `get_reads_bounded_chunks_not_whole_file` — a `get()` decompresses 1..=2 chunks, not O(file) (RED on main); loud warn-skip if fixture present-but-single-chunk.
- `absent_key_returns_none_without_scan` — definitive None via bloom, no scan.
- `get_value_matches_full_scan_oracle_for_all_keys` — fixed `get()` byte-matches the whole-file scan oracle for all 1000 keys.
- `truncated_index_get_falls_back_to_scan` / `boundary_truncated_index_get_falls_back_to_scan` — partial/boundary-truncated `Index.db` → dropped keys still found via scan fallback (get/scan divergence regression guards).

## Quality bar
- **Full agent-gate.sh (gate of record) — all change-attributable components PASS**; roborev **clean ("No issues found")** after 3 convergence rounds (partial-index → boundary-truncation → test-neutering, all closed).
- The gate's overall `RESULT: FAIL` is caused **solely by two known, pre-existing, unrelated failures**, each the only failure in its component:
  1. `core-tests` → `issue_953_multichunk_cell_seek::multichunk_row_seek_returns_full_partition` panics "Data.db must be present" — **tracked #1856** (local-only `test_da/wide_table` Data.db absent; directory-keyed skip guard). This branch does not touch `issue_953`; fails identically on `origin/main`.
  2. `python-bindings` → `test_streaming.py::TestStreamingGilRelease::test_streaming_next_releases_gil` — load-sensitive GIL-release timing flake (measured under concurrent gate load).

<details><summary>Full AGENT-GATE SUMMARY (commit 1ee4069d)</summary>

```
==== AGENT-GATE SUMMARY ====
commit: 1ee4069d branch: issue-1572-big-get-chunk-seek dirty: no
file-size: PASS  fmt: PASS  clippy: PASS  core-tests: FAIL(#1856 only)
tombstones-scan: PASS  scan-offload-guard: PASS  memory-budget: PASS
integration-tests: PASS  format-compat: PASS  write-tests: PASS  cli-tests: PASS
compaction-byte-parity: PASS  python-bindings: FAIL(GIL flake only)  node-bindings: PASS
delivery-telemetry: PASS  parity-report: PASS  binding-unwind-profile: PASS
tooling-tests: PASS  minimal-build: PASS  smoke: PASS
==== END AGENT-GATE SUMMARY ====
```
</details>

Follow-up filed: **#1857** (sibling BIG `get_with_spec_readers`/`get_with_schema_context` still use whole-blob offset read).