### PR TITLE
perf(#1844): scope gate clippy off --workspace --all-features (skip DuckDB/otel; nightly full-matrix backstop)

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -217,6 +217,14 @@ jobs:
           CQLITE_DATASETS_ROOT: ${{ github.workspace }}/test-data/datasets
           CQLITE_REQUIRE_FIXTURES: '1'
           AGENT_GATE_SUMMARY_FILE: ${{ github.workspace }}/agent-gate-summary.txt
+          # Full-matrix clippy backstop (issue #1844). The routine local gate runs a
+          # SCOPED per-package clippy that skips the source-built DuckDB C++
+          # amalgamation (cqlite-cli `duckdb-tests`) and the OpenTelemetry/OTLP stack
+          # (`observability`/`observability-testing`) — pure per-gate tax locally. This
+          # nightly deep-check restores the historical
+          # `cargo clippy --workspace --all-targets --all-features -D warnings` pass so
+          # any lint behind those excluded features is still caught within 24h.
+          CQLITE_CLIPPY_FULL: '1'
         run: bash scripts/agent-gate.sh
 
       # Legibility (issue #1269) — resource state after the gate, on success or

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,10 +68,19 @@ Subagents in `.claude/agents/` for specialized tasks:
 # write-support tests, CLI tests, minimal-features build, and smoke, then
 # emits a machine-checkable summary block. Paste that block verbatim when
 # reporting validation; ad-hoc cargo runs do not count as "the gate passed".
+#
+# clippy is SCOPED per-package (issue #1844): it lints the whole workspace with
+# -D warnings but does NOT compile the source-built DuckDB C++ amalgamation
+# (cqlite-cli `duckdb-tests`) or the OpenTelemetry/OTLP stack
+# (`observability`/`observability-testing`) — both were pure per-gate tax.
+# parquet/arrow stay linted. Coverage of the excluded features moves to nightly:
+# CQLITE_CLIPPY_FULL=1 runs the full `--workspace --all-targets --all-features`
+# matrix, which .github/workflows/gate.yml (nightly deep-check) sets.
 scripts/agent-gate.sh
 
 # FAST ITERATION gate (issue #1821) - NOT the gate of record.
-# Runs ONLY file-size + fmt + FULL-workspace clippy (-D warnings) +
+# Runs ONLY file-size + fmt + scoped workspace clippy (-D warnings, same #1844
+# duckdb/otel-excluded scoping as the full gate) +
 # blast-radius-scoped tests (the touched package's --lib + the diff's new --test
 # targets, mapped from `git diff --name-only origin/main...HEAD`; defaults to
 # `cqlite-core --lib` when no rust package is in the diff). ~1-5 min vs 12-25 min.

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -10,7 +10,17 @@
 # Components mirror the enforced CI gates (.github/workflows/ci.yml,
 # ci-minimal-features.yml, python-ci.yml) plus the local smoke suite:
 #   fmt                cargo fmt --all --check
-#   clippy             RUSTFLAGS="-D warnings" clippy --workspace --all-targets --all-features
+#   clippy             RUSTFLAGS="-D warnings" clippy, SCOPED per-package (issue
+#                      #1844): whole-workspace lint that deliberately does NOT
+#                      compile the source-built DuckDB C++ amalgamation
+#                      (cqlite-cli `duckdb-tests`) or the OpenTelemetry/OTLP stack
+#                      (`observability`/`observability-testing`) — both are pure
+#                      per-gate tax (-D warnings gives clippy a distinct fingerprint,
+#                      so no other component reuses them). parquet/arrow stay linted.
+#                      Set CQLITE_CLIPPY_FULL=1 to run the historical
+#                      `--workspace --all-targets --all-features` matrix instead; the
+#                      nightly gate.yml deep-check sets it so the otel/duckdb-inclusive
+#                      lint still runs within 24h (coverage moved, not deleted).
 #   core-tests         cargo test -p cqlite-core --features cli-helpers (CI skip-list applied)
 #   scan-offload-guard cargo test -p cqlite-core --features cli-helpers,scan-offload-probe
 #                      --test issue_1143_scan_offload_thread (windowed-scan parse
@@ -112,8 +122,9 @@
 # Usage:
 #   scripts/agent-gate.sh             # full gate (the only run that counts)
 #   scripts/agent-gate.sh --lite      # FAST ITERATION gate (issue #1821): runs
-#                                     # ONLY file-size + fmt + FULL-workspace clippy
-#                                     # (-D warnings) + BLAST-RADIUS-SCOPED tests
+#                                     # ONLY file-size + fmt + scoped workspace clippy
+#                                     # (-D warnings; same #1844 duckdb/otel-excluded
+#                                     # scoping as the full gate) + BLAST-RADIUS-SCOPED tests
 #                                     # (the touched package's --lib + the diff's
 #                                     # new --test targets; NOT core-tests/write/
 #                                     # cli/bindings/parity/smoke). ~1-5 min vs
@@ -685,6 +696,63 @@ fi
 # drains. This keeps the SUMMARY block deterministic regardless of finish order.
 record_result() { # <name> <status> <seconds>
   printf '%s %s\n' "$2" "$3" > "$LOG_DIR/$1.result"
+}
+
+# run_clippy: the `clippy` component's command (issue #1844). By default it runs a
+# SCOPED per-package clippy that lints the whole workspace with -D warnings WITHOUT
+# compiling two costly, gate-irrelevant artifacts on every run/worktree:
+#   * the source-built DuckDB C++ amalgamation (cqlite-cli `duckdb-tests` feature),
+#   * the full OpenTelemetry/OTLP stack (`observability`/`observability-testing` on
+#     cqlite-core/cli/flight/bindings — both the tonic AND reqwest transports).
+# `--workspace --all-features` would enable EVERY feature on EVERY package and pull
+# in both. `-D warnings` alone already gives clippy a distinct compile fingerprint,
+# so those artifacts are never reused by any other component — pure per-gate tax.
+#
+# parquet/arrow are NOT excluded: they are reachable in normal builds (cqlite-cli's
+# cli-helpers→state_machine→cqlite-core/parquet chain), so they stay linted here.
+# ONLY duckdb + otel move to the nightly backstop.
+#
+# Coverage of the excluded features is NOT deleted — it moves to a nightly full
+# matrix: set CQLITE_CLIPPY_FULL=1 to run the historical
+# `--workspace --all-targets --all-features` pass instead. `.github/workflows/gate.yml`
+# (the nightly deep-check) sets it, so the full otel/duckdb-inclusive lint still runs
+# within 24h. The explicit per-package feature lists below can drift as features are
+# added; that nightly `--all-features` pass is the backstop that catches any omission.
+run_clippy() {
+  if [ "${CQLITE_CLIPPY_FULL:-0}" = 1 ]; then
+    env RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features
+    return
+  fi
+
+  # (1) Whole workspace at all-features, EXCLUDING the five packages that carry the
+  #     duckdb/otel optional features. --all-features only turns on features of the
+  #     SELECTED packages, so with these excluded no `duckdb-tests`/`observability`
+  #     feature is ever activated — and cqlite-core, built here only as a transitive
+  #     dependency of the remaining crates, never gets its `observability` feature.
+  env RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features \
+    --exclude cqlite-core --exclude cqlite-cli --exclude cqlite-flight \
+    --exclude cqlite-py --exclude cqlite-node || return 1
+
+  # (2) cqlite-core: every feature EXCEPT observability/observability-testing/metrics
+  #     (the OpenTelemetry stack). Keep this in sync with cqlite-core/Cargo.toml when
+  #     features are added; the nightly CQLITE_CLIPPY_FULL=1 pass is the drift guard.
+  env RUSTFLAGS="-D warnings" cargo clippy -p cqlite-core --all-targets --features \
+"all-compression,antlr,arrow,bench-internals,benchmarks,ci_zero_tolerance,cli-helpers,deflate,delta-scan,dhat-heap,docker-integration,enhanced-index-validation,events,experimental,extended-index-validation,fuzz,legacy-heuristics,lz4,parquet,pest,scan-offload-probe,snappy,state_machine,test-coverage-tracking,test-infrastructure,test-property-testing,test-quality-gates,test-schema-validation,tombstones,unit-tests-only,wasm,work-counters,write-support,zstd" \
+    || return 1
+
+  # (3) cqlite-cli: every feature EXCEPT duckdb-tests + observability. Pulls in
+  #     parquet/arrow via state_machine and delta-scan via delta-export, so the
+  #     normal-build reachable surface stays linted.
+  env RUSTFLAGS="-D warnings" cargo clippy -p cqlite-cli --all-targets --features \
+"benchmarks,ci_zero_tolerance,cli-helpers,delta-export,experimental,integration-tests,interactive,state_machine,tui,write-support" \
+    || return 1
+
+  # (4) cqlite-flight + the Python/Node bindings at their DEFAULT features (none of
+  #     which enable observability), plus cqlite-node's write-support code path. This
+  #     lints their real binding/connector surface without linking the otel shim.
+  env RUSTFLAGS="-D warnings" cargo clippy --all-targets \
+    -p cqlite-flight -p cqlite-py -p cqlite-node --features cqlite-node/write-support \
+    || return 1
 }
 
 run_component() { # run_component <name> <cmd...>
@@ -1311,7 +1379,7 @@ run_lite() {
   echo
   echo "==================================================================="
   echo "  AGENT-GATE --lite  :  FAST ITERATION GATE — *NOT* THE GATE OF RECORD"
-  echo "  Runs: file-size + fmt + workspace clippy + blast-radius-scoped tests."
+  echo "  Runs: file-size + fmt + scoped workspace clippy + blast-radius-scoped tests."
   echo "  It SKIPS core-tests, write/cli, bindings, parity, smoke, etc."
   echo "  Before merge you MUST run the full  scripts/agent-gate.sh  and it must"
   echo "  PASS — its ==== AGENT-GATE SUMMARY ==== block is the ONLY run that counts."
@@ -1320,7 +1388,7 @@ run_lite() {
 
   run_file_size
   run_component fmt cargo fmt --all --check
-  run_component clippy env RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features
+  run_component clippy run_clippy
   run_scoped_tests
 
   declare -a SUMMARY_META=()
@@ -1604,7 +1672,7 @@ _pool_selected() {
 dispatch_component() {
   case "$1" in
     fmt) run_component fmt cargo fmt --all --check ;;
-    clippy) run_component clippy env RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features ;;
+    clippy) run_component clippy run_clippy ;;
     core-tests) run_core_tests ;;
     tombstones-scan) run_component tombstones-scan cargo test --package cqlite-core \
       --features write-support,cli-helpers,tombstones \

--- a/website/src/content/docs/agents-developing/gate-contract.md
+++ b/website/src/content/docs/agents-developing/gate-contract.md
@@ -31,7 +31,7 @@ The gate mirrors the enforced CI gates (`.github/workflows/ci.yml`,
 | Component | Command |
 |-----------|---------|
 | `fmt` | `cargo fmt --all --check` |
-| `clippy` | `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features` |
+| `clippy` | `RUSTFLAGS="-D warnings"` clippy, **scoped per-package** (issue #1844 — see below) |
 | `core-tests` | `cargo test -p cqlite-core --features cli-helpers` (one test skipped — see script) |
 | `integration-tests` | seven named `--test` targets in `cqlite-integration-tests` |
 | `write-tests` | `cargo test -p cqlite-core --features write-support` (lib + roundtrip + compaction) |
@@ -41,6 +41,30 @@ The gate mirrors the enforced CI gates (`.github/workflows/ci.yml`,
 | `smoke` | `bash test-data/scripts/smoke-test-all-tables.sh` (against a freshly built debug binary) |
 
 All components run even after a failure so one run reports everything.
+
+### Scoped clippy (issue #1844)
+
+`--workspace --all-features` enables *every* feature on *every* package, which pulls
+in two costly artifacts on **every** gate run in **every** worktree:
+
+- the **source-built DuckDB C++ amalgamation** (cqlite-cli `duckdb-tests` feature), and
+- the full **OpenTelemetry/OTLP** stack — both the tonic and reqwest transports
+  (`observability`/`observability-testing` on core/cli/flight/bindings).
+
+Neither is reusable by any other gate component (`-D warnings` gives clippy a distinct
+compile fingerprint), so they were pure per-gate tax. The `clippy` component therefore
+runs a **scoped per-package** lint that still covers the whole workspace with
+`-D warnings` but excludes only those two feature families. **parquet/arrow are NOT
+excluded** — they are reachable in normal builds (the
+cli-helpers→state_machine→`cqlite-core/parquet` chain) and stay linted. Both the full
+gate and `--lite` use the same scoping. See `run_clippy()` in `scripts/agent-gate.sh`.
+
+Coverage of the excluded features is **moved, not deleted**: set `CQLITE_CLIPPY_FULL=1`
+to run the historical `cargo clippy --workspace --all-targets --all-features -D warnings`
+matrix. `.github/workflows/gate.yml` (the nightly deep-check) sets it, so a lint that
+only fires behind `duckdb-tests` or `observability*` is still caught within 24h. The
+per-package feature lists in `run_clippy()` can drift as features are added; that
+nightly full pass is the drift backstop.
 
 ## Pre-condition: test data must be present
 


### PR DESCRIPTION
Closes #1844 (agent-throughput audit Tier 1.3).

The gate's clippy component ran `--workspace --all-features`, compiling the bundled DuckDB C++ amalgamation (`duckdb-tests`) and the full OpenTelemetry/OTLP stack (both tonic and reqwest) on every gate run in every worktree — pure per-gate tax, unusable by any other component.

## What
- `run_clippy()` in `scripts/agent-gate.sh`: scoped mode = workspace-minus-heavy-packages + explicit per-package near-all-features lists excluding ONLY `duckdb-tests` and `observability`/`observability-testing` (parquet/arrow still linted). Wired through full, `--lite`, and `--only` dispatch paths.
- `CQLITE_CLIPPY_FULL=1` restores the historical full `--workspace --all-features` pass; the nightly deep-check (`.github/workflows/gate.yml`) sets it — any lint behind the excluded features is still caught within 24h.
- CLAUDE.md + agents-developing gate-contract page updated in-change.

## Verification
- Gate clippy log: **0 occurrences** of `libduckdb`/`opentelemetry` — the C++ amalgamation is no longer compiled locally (measured clippy component: 8s warm).
- roborev job 1433 (claude-code/opus): **No issues found** — notes correct `|| return 1` propagation and consistent wiring across paths.

## Gate of record (full, verbatim)
```
==== AGENT-GATE SUMMARY ====
run-id: /var/folders/2c/tfxwt1g91x729x38m63d81540000gn/T//agent-gate.I9YzyI
commit: 69655457 branch: issue-1844-gate-clippy-scoping dirty: no
datasets: 144 Data.db files under /Users/patrickmcfadin/local_projects/cqlite/test-data/datasets
ci-pins: DATASET_TAG: datasets-v3 DATASET_ASSET: cassandra5-small-full-v3.4.tar.gz DATASET_SHA256: 3cae644360e0142a6bb5e96ddab445ff18e3478e7058104842ce1a455fba8a33 
file-size:         PASS (0s)
fmt:               PASS (18s)
clippy:            PASS (8s)
core-tests:        PASS (155s)
tombstones-scan:   PASS (1s)
scan-offload-guard: PASS (2s)
memory-budget:     PASS (47s)
integration-tests: PASS (3s)
format-compat:     PASS (2s)
write-tests:       PASS (31s)
cli-tests:         PASS (7s)
compaction-byte-parity: PASS (5s)
python-bindings:   PASS (259s)
node-bindings:     PASS (652s)
delivery-telemetry: PASS (1s)
parity-report:     PASS (5s)
binding-unwind-profile: PASS (2s)
tooling-tests:     PASS (36s)
minimal-build:     PASS (2s)
smoke:             PASS (235s)
logs: /var/folders/2c/tfxwt1g91x729x38m63d81540000gn/T//agent-gate.I9YzyI
summary-file: /tmp/gate-1844-summary.txt
RESULT: PASS
==== END AGENT-GATE SUMMARY ====
```

Known drift risk (accepted): the per-package feature lists can go stale as features are added — the nightly full-matrix pass is the safety net. Oracle-driven gate change, no OpenSpec.