### PR TITLE
perf(#1587): E5 query-engine constant factors (schema Arc, single projection, sort keys, plan cache, GROUP BY hash)

### DIFF
--- a/cqlite-core/src/query/engine.rs
+++ b/cqlite-core/src/query/engine.rs
@@ -19,7 +19,11 @@ use super::{
 };
 
 #[cfg(feature = "state_machine")]
-use super::{select_executor::SelectExecutor, select_optimizer::SelectOptimizer, select_parser};
+use super::{
+    select_executor::SelectExecutor,
+    select_optimizer::{OptimizedQueryPlan, SelectOptimizer},
+    select_parser,
+};
 use crate::{
     memory::MemoryManager, schema::SchemaManager, storage::StorageEngine, Config, Error, Result,
     Value,
@@ -78,6 +82,14 @@ pub struct QueryEngine {
     prepared_cache: DashMap<String, Arc<PreparedQuery>>,
     /// Query plan cache
     plan_cache: DashMap<String, QueryCacheEntry>,
+    /// Issue #1587 (E5): plan cache for the modern (state_machine) SELECT path,
+    /// keyed by the exact CQL text. The optimized plan is a pure function of the
+    /// literal CQL, so a repeated identical ad-hoc SELECT reuses the plan instead
+    /// of re-parsing + re-optimizing. Kept separate from `plan_cache` (which
+    /// holds legacy `QueryPlan`s and feeds `CacheStats`) so neither disturbs the
+    /// other. Value is `(inserted_at, plan)` for the same simple-LRU eviction.
+    #[cfg(feature = "state_machine")]
+    select_plan_cache: DashMap<String, (Instant, Arc<OptimizedQueryPlan>)>,
     /// Query statistics
     stats: Arc<parking_lot::RwLock<QueryStats>>,
     /// Configuration
@@ -113,6 +125,8 @@ impl QueryEngine {
             select_executor,
             prepared_cache: DashMap::new(),
             plan_cache: DashMap::new(),
+            #[cfg(feature = "state_machine")]
+            select_plan_cache: DashMap::new(),
             stats: Arc::new(parking_lot::RwLock::new(QueryStats::default())),
             config: config.clone(),
         })
@@ -274,21 +288,58 @@ impl QueryEngine {
 
         #[cfg(feature = "state_machine")]
         {
-            let select_statement = select_parser::parse_select(cql).inspect_err(|e| {
-                self.inc_error_queries();
-                crate::observability::record_error(e, "query");
-            })?;
-            let optimized_plan = crate::observability::record_result(
-                "query",
-                self.select_optimizer.optimize(select_statement).await,
-            )?;
+            // Issue #1587 (E5): reuse a previously-optimized plan for the exact
+            // same CQL text. The optimized plan is a pure function of the literal
+            // CQL, so this is byte-for-byte equivalent to re-parsing +
+            // re-optimizing — it only skips the redundant work.
+            let optimized_plan: Arc<OptimizedQueryPlan> =
+                if let Some(entry) = self.select_plan_cache.get(cql) {
+                    self.record_cache_hit();
+                    Arc::clone(&entry.value().1)
+                } else {
+                    let select_statement = select_parser::parse_select(cql).inspect_err(|e| {
+                        self.inc_error_queries();
+                        crate::observability::record_error(e, "query");
+                    })?;
+                    let plan = Arc::new(crate::observability::record_result(
+                        "query",
+                        self.select_optimizer.optimize(select_statement).await,
+                    )?);
+                    self.cache_select_plan(cql, Arc::clone(&plan));
+                    plan
+                };
             let mut result = crate::observability::record_result(
                 "query",
-                self.select_executor.execute(optimized_plan).await,
+                self.select_executor
+                    .execute((*optimized_plan).clone())
+                    .await,
             )?;
             self.update_execution_stats(&mut result, start_time);
             Ok(result)
         }
+    }
+
+    /// Insert an optimized SELECT plan into the modern plan cache, evicting the
+    /// oldest entry first when at capacity (simple LRU, matching the legacy
+    /// `cache_query_plan`). A configured `query_cache_size` of 0 disables it.
+    #[cfg(feature = "state_machine")]
+    fn cache_select_plan(&self, cql: &str, plan: Arc<OptimizedQueryPlan>) {
+        let cache_size = self.config.query.query_cache_size.unwrap_or(0);
+        if cache_size == 0 {
+            return;
+        }
+        if self.select_plan_cache.len() >= cache_size {
+            let oldest_key = self
+                .select_plan_cache
+                .iter()
+                .min_by_key(|entry| entry.value().0)
+                .map(|entry| entry.key().clone());
+            if let Some(key) = oldest_key {
+                self.select_plan_cache.remove(&key);
+            }
+        }
+        self.select_plan_cache
+            .insert(cql.to_string(), (Instant::now(), plan));
     }
 
     /// Execute a query with positional `?` parameters (Issue #961).
@@ -464,6 +515,8 @@ impl QueryEngine {
     pub fn clear_caches(&self) {
         self.prepared_cache.clear();
         self.plan_cache.clear();
+        #[cfg(feature = "state_machine")]
+        self.select_plan_cache.clear();
     }
 
     /// Clear prepared statement cache
@@ -474,6 +527,8 @@ impl QueryEngine {
     /// Clear query plan cache
     pub fn clear_plan_cache(&self) {
         self.plan_cache.clear();
+        #[cfg(feature = "state_machine")]
+        self.select_plan_cache.clear();
     }
 
     /// Get cache statistics

--- a/cqlite-core/src/query/engine.rs
+++ b/cqlite-core/src/query/engine.rs
@@ -1095,6 +1095,71 @@ mod tests {
             }
         }
     }
+
+    /// Issue #1587 (E5): the modern (state_machine) ad-hoc SELECT path caches the
+    /// optimized plan keyed by the exact CQL text, so N identical ad-hoc executes
+    /// of the same query optimize AT MOST ONCE. This is the `engine.rs` half of
+    /// the plan-reuse optimization (the prepared-statement half is covered by
+    /// `prepared_select_reuses_optimized_plan_across_executes`).
+    ///
+    /// `#[tokio::test]` runs on the current-thread runtime, so the optimizer's
+    /// thread-local invocation counter reflects exactly this future's calls. The
+    /// plan is cached BEFORE execution, so the (empty-store) execute result is
+    /// irrelevant — reuse holds regardless.
+    #[tokio::test]
+    #[cfg(feature = "state_machine")]
+    async fn adhoc_select_reuses_cached_optimized_plan() {
+        use crate::query::select_optimizer::OPTIMIZE_INVOCATIONS;
+
+        let temp_dir = TempDir::new().unwrap();
+        let mut config = Config::default();
+        // Enable the modern SELECT plan cache (0 disables it).
+        config.query.query_cache_size = Some(16);
+        let platform = Arc::new(crate::platform::Platform::new(&config).await.unwrap());
+        let storage = Arc::new(
+            crate::storage::StorageEngine::open(
+                temp_dir.path(),
+                &config,
+                platform,
+                #[cfg(feature = "state_machine")]
+                None,
+            )
+            .await
+            .unwrap(),
+        );
+        let schema = Arc::new(
+            crate::schema::SchemaManager::new(temp_dir.path())
+                .await
+                .unwrap(),
+        );
+        let memory = Arc::new(crate::memory::MemoryManager::new(&config).unwrap());
+        let engine = QueryEngine::new(storage, schema, memory, &config).unwrap();
+
+        // A non-`WHERE id =` SELECT routes through the modern `execute_select_query`
+        // path (see `execute`'s `is_simple_id_lookup` gate), which owns the plan cache.
+        let cql = "SELECT * FROM t WHERE age > 5";
+
+        OPTIMIZE_INVOCATIONS.with(|c| c.set(0));
+        for _ in 0..75 {
+            let _ = engine.execute(cql).await;
+        }
+        let after_same = OPTIMIZE_INVOCATIONS.with(|c| c.get());
+        assert!(
+            after_same <= 1,
+            "issue #1587: an ad-hoc SELECT must optimize at most once across 75 \
+             identical executes (modern plan cache), got {after_same}"
+        );
+
+        // Clearing the cache must force exactly one re-optimize on the next run.
+        engine.clear_plan_cache();
+        let _ = engine.execute(cql).await;
+        let after_clear = OPTIMIZE_INVOCATIONS.with(|c| c.get());
+        assert_eq!(
+            after_clear,
+            after_same + 1,
+            "clearing the plan cache must re-optimize once (no stale reuse)"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/cqlite-core/src/query/prepared.rs
+++ b/cqlite-core/src/query/prepared.rs
@@ -41,6 +41,61 @@ struct PreparedSelect {
     optimizer: Arc<super::select_optimizer::SelectOptimizer>,
     /// Shared SELECT executor (same instance the engine uses for literal SELECTs).
     executor: Arc<super::select_executor::SelectExecutor>,
+    /// Issue #1587 (E5): memoized optimized plan for the most recently bound
+    /// parameter tuple. The optimized plan is a pure function of the *bound*
+    /// statement (predicate pushdown / partition targeting depends on the
+    /// concrete parameter values), so the cache is keyed by the exact params:
+    /// a repeated execute with identical params reuses the plan (optimize runs
+    /// ONCE), while a different parameter tuple correctly re-optimizes. This
+    /// preserves results byte-for-byte and never serves a stale plan for the
+    /// wrong parameters.
+    plan_cache: std::sync::Mutex<Option<CachedOptimizedPlan>>,
+}
+
+/// A memoized optimized plan tagged with the parameter tuple that produced it
+/// (issue #1587, E5).
+#[cfg(feature = "state_machine")]
+#[derive(Debug)]
+struct CachedOptimizedPlan {
+    params: Vec<Value>,
+    plan: Arc<super::select_optimizer::OptimizedQueryPlan>,
+}
+
+#[cfg(feature = "state_machine")]
+impl PreparedSelect {
+    /// Return the optimized plan for `params`, reusing the memoized plan when the
+    /// parameter tuple is unchanged and otherwise binding + re-optimizing (issue
+    /// #1587, E5). The `std::sync::Mutex` is never held across an `.await`: a hit
+    /// clones the `Arc` and releases the lock before returning; a miss optimizes
+    /// with no lock held, then briefly re-locks to store the result.
+    async fn plan_for(
+        &self,
+        params: &[Value],
+    ) -> Result<Arc<super::select_optimizer::OptimizedQueryPlan>> {
+        {
+            let guard = self
+                .plan_cache
+                .lock()
+                .map_err(|_| Error::query_execution("prepared plan cache lock poisoned"))?;
+            if let Some(cached) = guard.as_ref() {
+                if cached.params == params {
+                    return Ok(Arc::clone(&cached.plan));
+                }
+            }
+        }
+
+        let mut statement = self.statement.clone();
+        statement.bind_parameters(params)?;
+        let plan = Arc::new(self.optimizer.optimize(statement).await?);
+
+        if let Ok(mut guard) = self.plan_cache.lock() {
+            *guard = Some(CachedOptimizedPlan {
+                params: params.to_vec(),
+                plan: Arc::clone(&plan),
+            });
+        }
+        Ok(plan)
+    }
 }
 
 /// Prepared query statement
@@ -159,6 +214,7 @@ impl PreparedQuery {
                 statement,
                 optimizer,
                 executor: select_executor,
+                plan_cache: std::sync::Mutex::new(None),
             }),
         }
     }
@@ -174,10 +230,11 @@ impl PreparedQuery {
 
         #[cfg(feature = "state_machine")]
         if let Some(pipeline) = &self.select_pipeline {
-            let mut statement = pipeline.statement.clone();
-            statement.bind_parameters(params)?;
-            let optimized = pipeline.optimizer.optimize(statement).await?;
-            return pipeline.executor.execute(optimized).await;
+            // Issue #1587 (E5): reuse the memoized optimized plan when the params
+            // are unchanged; the executor takes an owned plan, so clone the
+            // (cheap, already-built) cached plan rather than re-optimizing.
+            let plan = pipeline.plan_for(params).await?;
+            return pipeline.executor.execute((*plan).clone()).await;
         }
 
         // Default execution path: no hints, so skip the plan clone in
@@ -242,11 +299,10 @@ impl PreparedQuery {
             }
             // Bind the context's positional params and run the same SELECT
             // optimizer + executor as `execute`, so the fast path engages.
+            // Issue #1587 (E5): reuse the memoized plan for unchanged params.
             self.validate_params(&context.positional_params)?;
-            let mut statement = pipeline.statement.clone();
-            statement.bind_parameters(&context.positional_params)?;
-            let optimized = pipeline.optimizer.optimize(statement).await?;
-            return pipeline.executor.execute(optimized).await;
+            let plan = pipeline.plan_for(&context.positional_params).await?;
+            return pipeline.executor.execute((*plan).clone()).await;
         }
 
         // Avoid cloning the plan if no hints would override it.
@@ -586,5 +642,113 @@ mod tests {
         // Null matches any expected type.
         assert!(type_matches(&Value::Null, &DataType::Integer));
         assert!(!type_matches(&Value::Integer(42), &DataType::Text));
+    }
+
+    /// Issue #1587 (E5): a prepared SELECT reuses its optimized plan across
+    /// repeated executes with identical parameters — `optimize` runs AT MOST
+    /// once — and re-optimizes only when the parameter tuple changes (so it can
+    /// never serve a stale plan for the wrong parameters). `#[tokio::test]` runs
+    /// on the current-thread runtime, so the optimizer's thread-local invocation
+    /// counter reflects exactly this future's calls.
+    #[tokio::test]
+    async fn prepared_select_reuses_optimized_plan_across_executes() {
+        use crate::query::select_optimizer::OPTIMIZE_INVOCATIONS;
+
+        let temp_dir = TempDir::new().unwrap();
+        let config = Config::default();
+        let platform = Arc::new(crate::platform::Platform::new(&config).await.unwrap());
+        let storage = Arc::new(
+            crate::storage::StorageEngine::open(temp_dir.path(), &config, platform, None)
+                .await
+                .unwrap(),
+        );
+        let schema = Arc::new(
+            crate::schema::SchemaManager::new(temp_dir.path())
+                .await
+                .unwrap(),
+        );
+        let executor = Arc::new(crate::query::executor::QueryExecutor::new(
+            storage.clone(),
+            schema.clone(),
+            &config,
+        ));
+        let optimizer = Arc::new(super::super::select_optimizer::SelectOptimizer::new(
+            schema.clone(),
+            storage.clone(),
+        ));
+        let select_executor = Arc::new(super::super::select_executor::SelectExecutor::new(
+            schema.clone(),
+            storage.clone(),
+        ));
+
+        let cql = "SELECT * FROM t WHERE id = ?";
+        let statement = super::super::select_parser::parse_select(cql).unwrap();
+        let marker_count = statement.bind_marker_count();
+        assert_eq!(marker_count, 1);
+
+        let parsed_query = ParsedQuery {
+            query_type: crate::query::QueryType::Select,
+            table: Some(crate::TableId::new("t")),
+            columns: vec!["*".to_string()],
+            where_clause: None,
+            values: vec![],
+            set_clause: std::collections::HashMap::new(),
+            order_by: vec![],
+            limit: None,
+            cql: cql.to_string(),
+        };
+        let plan = crate::query::planner::QueryPlan {
+            plan_type: crate::query::planner::PlanType::PointLookup,
+            table: Some(crate::TableId::new("t")),
+            estimated_cost: 1.0,
+            estimated_rows: 1,
+            selected_indexes: vec![],
+            steps: vec![],
+            hints: crate::query::planner::QueryHints::default(),
+        };
+
+        let prepared = PreparedQuery::new_select(
+            parsed_query,
+            plan,
+            executor,
+            statement,
+            marker_count,
+            optimizer,
+            select_executor,
+        );
+
+        // 100 executes with the SAME parameter tuple: optimize must run <= 1.
+        OPTIMIZE_INVOCATIONS.with(|c| c.set(0));
+        let params = vec![Value::Integer(1)];
+        for _ in 0..100 {
+            // The executor result itself is irrelevant here (empty store); the
+            // plan is optimized + cached before execution regardless.
+            let _ = prepared.execute(&params).await;
+        }
+        let after_same = OPTIMIZE_INVOCATIONS.with(|c| c.get());
+        assert!(
+            after_same <= 1,
+            "issue #1587: prepared statement must optimize at most once across 100 \
+             executes with identical params, got {after_same}"
+        );
+
+        // A DIFFERENT parameter tuple must re-optimize (no stale plan reuse).
+        let _ = prepared.execute(&[Value::Integer(2)]).await;
+        let after_diff = OPTIMIZE_INVOCATIONS.with(|c| c.get());
+        assert_eq!(
+            after_diff,
+            after_same + 1,
+            "a new parameter tuple must re-optimize (correctness over reuse)"
+        );
+
+        // Re-running the FIRST params again reuses that memoized plan only if it
+        // is still the most-recent entry; here params changed, so it re-optimizes
+        // — but never MORE than once per distinct consecutive tuple.
+        let _ = prepared.execute(&[Value::Integer(2)]).await;
+        let after_repeat = OPTIMIZE_INVOCATIONS.with(|c| c.get());
+        assert_eq!(
+            after_repeat, after_diff,
+            "repeating the last params must hit the memoized plan (no re-optimize)"
+        );
     }
 }

--- a/cqlite-core/src/query/prepared.rs
+++ b/cqlite-core/src/query/prepared.rs
@@ -78,7 +78,7 @@ impl PreparedSelect {
                 .lock()
                 .map_err(|_| Error::query_execution("prepared plan cache lock poisoned"))?;
             if let Some(cached) = guard.as_ref() {
-                if cached.params == params {
+                if params_bit_eq(&cached.params, params) {
                     return Ok(Arc::clone(&cached.plan));
                 }
             }
@@ -95,6 +95,62 @@ impl PreparedSelect {
             });
         }
         Ok(plan)
+    }
+}
+
+/// Bit-exact equality of two bound parameter tuples for prepared-plan reuse
+/// (issue #1587, E5). This is deliberately NOT `Value::PartialEq`: derived
+/// float equality treats `+0.0 == -0.0` (and would treat two distinct payloads
+/// bearing equal-valued floats) as identical, but the partition-key / predicate
+/// codec encodes RAW float bits, and a reused optimized plan embeds the previous
+/// bound literal. Serving a `+0.0` plan for a `-0.0` param would probe the wrong
+/// partition and return incorrect/missing rows. Comparing floats by
+/// `to_bits()` keeps plan reuse for genuinely-identical params while making
+/// `+0.0` and `-0.0` distinct cache keys. (NaN payloads with differing bit
+/// patterns simply force a safe re-optimize.)
+#[cfg(feature = "state_machine")]
+fn params_bit_eq(a: &[Value], b: &[Value]) -> bool {
+    a.len() == b.len() && a.iter().zip(b).all(|(x, y)| value_bit_eq(x, y))
+}
+
+/// Recursive bit-exact equality of a single [`Value`], descending through every
+/// variant that can *contain* a float (collections, tuples, maps, UDTs, frozen
+/// wrappers). Float-free values fall back to structural [`PartialEq`], which is
+/// already bit-exact for them; a variant mismatch also resolves to `false`
+/// through that fallback. See [`params_bit_eq`] for why bits, not values.
+#[cfg(feature = "state_machine")]
+fn value_bit_eq(a: &Value, b: &Value) -> bool {
+    match (a, b) {
+        (Value::Float(x), Value::Float(y)) => x.to_bits() == y.to_bits(),
+        (Value::Float32(x), Value::Float32(y)) => x.to_bits() == y.to_bits(),
+        (Value::List(x), Value::List(y))
+        | (Value::Set(x), Value::Set(y))
+        | (Value::Tuple(x), Value::Tuple(y)) => {
+            x.len() == y.len() && x.iter().zip(y).all(|(m, n)| value_bit_eq(m, n))
+        }
+        (Value::Map(x), Value::Map(y)) => {
+            x.len() == y.len()
+                && x.iter()
+                    .zip(y)
+                    .all(|((xk, xv), (yk, yv))| value_bit_eq(xk, yk) && value_bit_eq(xv, yv))
+        }
+        (Value::Frozen(x), Value::Frozen(y)) => value_bit_eq(x, y),
+        (Value::Udt(x), Value::Udt(y)) => {
+            x.type_name == y.type_name
+                && x.keyspace == y.keyspace
+                && x.fields.len() == y.fields.len()
+                && x.fields.iter().zip(&y.fields).all(|(xf, yf)| {
+                    xf.name == yf.name
+                        && match (&xf.value, &yf.value) {
+                            (Some(xv), Some(yv)) => value_bit_eq(xv, yv),
+                            (None, None) => true,
+                            _ => false,
+                        }
+                })
+        }
+        // No float can occur in the remaining variants, so derived structural
+        // equality is already bit-exact (and handles variant mismatches).
+        _ => a == b,
     }
 }
 
@@ -749,6 +805,119 @@ mod tests {
         assert_eq!(
             after_repeat, after_diff,
             "repeating the last params must hit the memoized plan (no re-optimize)"
+        );
+    }
+
+    /// Issue #1587 (E5) regression: the prepared-plan param cache must treat
+    /// `+0.0` and `-0.0` float params as DISTINCT keys. Derived `Value::PartialEq`
+    /// treats them as equal, but the partition-key / predicate codec encodes raw
+    /// float bits, so reusing the `+0.0` plan for a `-0.0` param would probe the
+    /// wrong partition and return incorrect/missing rows. This test asserts the
+    /// cache re-optimizes across the signed-zero flip (does not reuse) while still
+    /// reusing the plan for a genuinely-identical repeat.
+    #[tokio::test]
+    async fn prepared_select_signed_zero_float_params_do_not_reuse_plan() {
+        use crate::query::select_optimizer::OPTIMIZE_INVOCATIONS;
+
+        let temp_dir = TempDir::new().unwrap();
+        let config = Config::default();
+        let platform = Arc::new(crate::platform::Platform::new(&config).await.unwrap());
+        let storage = Arc::new(
+            crate::storage::StorageEngine::open(temp_dir.path(), &config, platform, None)
+                .await
+                .unwrap(),
+        );
+        let schema = Arc::new(
+            crate::schema::SchemaManager::new(temp_dir.path())
+                .await
+                .unwrap(),
+        );
+        let executor = Arc::new(crate::query::executor::QueryExecutor::new(
+            storage.clone(),
+            schema.clone(),
+            &config,
+        ));
+        let optimizer = Arc::new(super::super::select_optimizer::SelectOptimizer::new(
+            schema.clone(),
+            storage.clone(),
+        ));
+        let select_executor = Arc::new(super::super::select_executor::SelectExecutor::new(
+            schema.clone(),
+            storage.clone(),
+        ));
+
+        let cql = "SELECT * FROM t WHERE id = ?";
+        let statement = super::super::select_parser::parse_select(cql).unwrap();
+        let marker_count = statement.bind_marker_count();
+        assert_eq!(marker_count, 1);
+
+        let parsed_query = ParsedQuery {
+            query_type: crate::query::QueryType::Select,
+            table: Some(crate::TableId::new("t")),
+            columns: vec!["*".to_string()],
+            where_clause: None,
+            values: vec![],
+            set_clause: std::collections::HashMap::new(),
+            order_by: vec![],
+            limit: None,
+            cql: cql.to_string(),
+        };
+        let plan = crate::query::planner::QueryPlan {
+            plan_type: crate::query::planner::PlanType::PointLookup,
+            table: Some(crate::TableId::new("t")),
+            estimated_cost: 1.0,
+            estimated_rows: 1,
+            selected_indexes: vec![],
+            steps: vec![],
+            hints: crate::query::planner::QueryHints::default(),
+        };
+
+        let prepared = PreparedQuery::new_select(
+            parsed_query,
+            plan,
+            executor,
+            statement,
+            marker_count,
+            optimizer,
+            select_executor,
+        );
+
+        OPTIMIZE_INVOCATIONS.with(|c| c.set(0));
+
+        // First execute with +0.0 caches a plan built for the +0.0 literal.
+        let _ = prepared.execute(&[Value::Float(0.0)]).await;
+        let after_pos = OPTIMIZE_INVOCATIONS.with(|c| c.get());
+        assert_eq!(after_pos, 1, "first float param must optimize once");
+
+        // -0.0 has different raw bits than +0.0, so the plan MUST be
+        // re-optimized (not reused). Under the pre-fix `PartialEq` compare this
+        // reused the +0.0 plan and this count stayed at 1.
+        let _ = prepared.execute(&[Value::Float(-0.0)]).await;
+        let after_neg = OPTIMIZE_INVOCATIONS.with(|c| c.get());
+        assert_eq!(
+            after_neg,
+            after_pos + 1,
+            "issue #1587: +0.0 and -0.0 float params must be distinct plan-cache \
+             keys and re-optimize, never reuse the wrong-signed-zero plan"
+        );
+
+        // Flipping back to +0.0 must also re-optimize (the cache holds only the
+        // most-recent, now -0.0, entry) — never silently serve the -0.0 plan.
+        let _ = prepared.execute(&[Value::Float(0.0)]).await;
+        let after_flip_back = OPTIMIZE_INVOCATIONS.with(|c| c.get());
+        assert_eq!(
+            after_flip_back,
+            after_neg + 1,
+            "flipping -0.0 back to +0.0 must re-optimize (distinct bit-exact keys)"
+        );
+
+        // A genuinely-identical repeat still reuses the memoized plan: the
+        // bit-exact key preserves the reuse optimization for equal floats.
+        let _ = prepared.execute(&[Value::Float(0.0)]).await;
+        let after_repeat = OPTIMIZE_INVOCATIONS.with(|c| c.get());
+        assert_eq!(
+            after_repeat, after_flip_back,
+            "identical float params must still hit the memoized plan (no re-optimize)"
         );
     }
 }

--- a/cqlite-core/src/query/select_executor/aggregation.rs
+++ b/cqlite-core/src/query/select_executor/aggregation.rs
@@ -13,16 +13,102 @@ use crate::{
     types::{RowKey, Value},
 };
 use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+
+// Test-only counter for GROUP-key exact (`==`) comparisons performed while
+// locating a row's group (issue #1587, E5). The hash index makes this
+// `O(rows)` (amortized) rather than the old linear scan's `O(rows × groups)`.
+// Same thread-local rationale as the executor's other work counters.
+#[cfg(test)]
+thread_local! {
+    pub(crate) static GROUP_KEY_COMPARISONS: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
+}
 
 /// Aggregation state for GROUP BY operations
 #[derive(Debug)]
 pub(super) struct AggregationState {
-    /// Vector for grouping since Value doesn't implement Hash
+    /// Groups in first-seen (insertion) order. Result-row ordering is defined by
+    /// this `Vec`, so it is preserved exactly; the hash index below is only a
+    /// lookup accelerator.
     pub(super) groups: Vec<(Vec<Value>, Vec<AggregateValue>)>,
+    /// Issue #1587 (E5): hash index over the group key → candidate `groups`
+    /// indices sharing that hash. `Value` does not implement `Hash`/`Eq`
+    /// (floats), so we hash a normalization that is *consistent* with `Vec<Value>`
+    /// equality (equal keys hash equal; `-0.0`/`+0.0` normalized) and confirm the
+    /// match with an exact `==` against each candidate. Distinct-but-colliding
+    /// keys (and every NaN key, which is never `==` itself) simply fall through
+    /// the exact check, so grouping semantics are byte-identical to the prior
+    /// linear scan.
+    pub(super) group_index: HashMap<u64, Vec<usize>>,
     /// Memory usage tracking
     pub(super) memory_usage_bytes: usize,
     /// Maximum memory limit
     pub(super) memory_limit_bytes: usize,
+}
+
+/// Hash a group key consistently with `Vec<Value>` equality: if two keys are
+/// `==`, they hash identically. Only floats need care (`-0.0 == +0.0`), which
+/// are normalized; NaN keys are never `==` themselves, so their hash is
+/// irrelevant to correctness (the exact `==` check separates them). Exotic /
+/// nested variants that are not cheap to hash structurally fall back to a
+/// discriminant-only contribution — still consistent (equal values agree on
+/// discriminant), merely less selective, and only for key types that never
+/// appear in practice.
+fn hash_group_key(key: &[Value]) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    key.len().hash(&mut hasher);
+    for v in key {
+        hash_one_value(v, &mut hasher);
+    }
+    hasher.finish()
+}
+
+fn hash_one_value<H: Hasher>(v: &Value, h: &mut H) {
+    // Tag by discriminant so different variants never alias.
+    std::mem::discriminant(v).hash(h);
+    match v {
+        Value::Null => {}
+        Value::Boolean(b) => b.hash(h),
+        Value::Integer(x) => x.hash(h),
+        Value::BigInt(x) | Value::Counter(x) | Value::Timestamp(x) | Value::Time(x) => x.hash(h),
+        Value::Date(x) => x.hash(h),
+        Value::TinyInt(x) => x.hash(h),
+        Value::SmallInt(x) => x.hash(h),
+        // `-0.0 == +0.0` must hash equal; NaN's hash is irrelevant (never `==`).
+        Value::Float(f) => (if *f == 0.0 { 0.0f64 } else { *f }).to_bits().hash(h),
+        Value::Float32(f) => (if *f == 0.0 { 0.0f32 } else { *f }).to_bits().hash(h),
+        Value::Text(s) => s.hash(h),
+        Value::Blob(b) | Value::Varint(b) | Value::Inet(b) => b.hash(h),
+        Value::Uuid(u) => u.hash(h),
+        Value::Decimal { scale, unscaled } => {
+            scale.hash(h);
+            unscaled.hash(h);
+        }
+        Value::Duration {
+            months,
+            days,
+            nanos,
+        } => {
+            months.hash(h);
+            days.hash(h);
+            nanos.hash(h);
+        }
+        Value::List(items) | Value::Set(items) | Value::Tuple(items) => {
+            for item in items {
+                hash_one_value(item, h);
+            }
+        }
+        Value::Map(pairs) => {
+            for (k, val) in pairs {
+                hash_one_value(k, h);
+                hash_one_value(val, h);
+            }
+        }
+        Value::Frozen(inner) => hash_one_value(inner, h),
+        // Exotic / rarely-grouped variants: discriminant-only (still consistent).
+        Value::Json(_) | Value::Udt(_) | Value::Tombstone(_) => {}
+    }
 }
 
 /// Aggregate value accumulator
@@ -47,20 +133,30 @@ pub(super) fn build_group_key(row: &QueryRow, group_by_columns: &[String]) -> Ve
         .collect()
 }
 
-/// Locate the group matching `key` in `groups`, or push a fresh entry with
-/// initial aggregator state. Returns the index into `groups`.
+/// Locate the group matching `key`, or push a fresh entry with initial
+/// aggregator state. Returns the index into `state.groups`.
 ///
-/// `Value` doesn't implement `Hash`, so groups live in a `Vec` and lookup is
-/// linear. This is unchanged from the legacy implementation; switching to a
-/// hash map would change result-row ordering for callers that rely on
-/// insertion order.
+/// Issue #1587 (E5): a hash index (`state.group_index`) makes this `O(1)`
+/// amortized instead of the old `O(groups)` linear scan (which made a full
+/// aggregation `O(rows × groups)`). Result-row ordering is still defined solely
+/// by insertion order into `state.groups`; the index only accelerates lookup,
+/// and the exact `==` confirmation preserves grouping semantics byte-for-byte
+/// (colliding-but-unequal keys, and NaN keys, create distinct groups exactly as
+/// the linear scan did).
 pub(super) fn find_or_init_group(
-    groups: &mut Vec<(Vec<Value>, Vec<AggregateValue>)>,
+    state: &mut AggregationState,
     key: Vec<Value>,
     aggregates: &[AggregateComputation],
 ) -> usize {
-    if let Some(idx) = groups.iter().position(|(k, _)| k == &key) {
-        return idx;
+    let hash = hash_group_key(&key);
+    if let Some(candidates) = state.group_index.get(&hash) {
+        for &idx in candidates {
+            #[cfg(test)]
+            GROUP_KEY_COMPARISONS.with(|c| c.set(c.get() + 1));
+            if state.groups[idx].0 == key {
+                return idx;
+            }
+        }
     }
     let initial: Vec<_> = aggregates
         .iter()
@@ -72,8 +168,10 @@ pub(super) fn find_or_init_group(
             AggregateType::Max => AggregateValue::Max(Value::Null),
         })
         .collect();
-    groups.push((key, initial));
-    groups.len() - 1
+    let new_index = state.groups.len();
+    state.groups.push((key, initial));
+    state.group_index.entry(hash).or_default().push(new_index);
+    new_index
 }
 
 /// Apply one row's contribution to a single aggregate accumulator.
@@ -172,5 +270,95 @@ pub(super) fn finalize_group(
         key: RowKey::new(vec![]),
         metadata: Default::default(),
         cell_metadata: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::select_ast::AggregateType;
+
+    fn count_star_plan() -> AggregationPlan {
+        AggregationPlan {
+            group_by_columns: vec!["g".to_string()],
+            aggregates: vec![AggregateComputation {
+                function: AggregateType::Count,
+                column: "*".to_string(),
+                alias: "c".to_string(),
+                distinct: false,
+            }],
+        }
+    }
+
+    fn new_state() -> AggregationState {
+        AggregationState {
+            groups: Vec::new(),
+            group_index: HashMap::new(),
+            memory_usage_bytes: 0,
+            memory_limit_bytes: usize::MAX,
+        }
+    }
+
+    /// Issue #1587 (E5): locating a row's group is `O(1)` amortized via the hash
+    /// index, so total group-key comparisons across a high-cardinality GROUP BY
+    /// stay `O(rows)` — NOT the old linear scan's `O(rows × groups)`. Assert a
+    /// tight linear bound the quadratic scan could never meet.
+    #[test]
+    fn find_or_init_group_is_subquadratic() {
+        let plan = count_star_plan();
+        let groups_count = 200usize;
+        let repeats = 3usize; // each group is hit multiple times (exercises "found")
+        let rows = groups_count * repeats;
+
+        let mut state = new_state();
+        GROUP_KEY_COMPARISONS.with(|c| c.set(0));
+
+        for r in 0..repeats {
+            for g in 0..groups_count {
+                let key = vec![Value::Integer(g as i32)];
+                let idx = find_or_init_group(&mut state, key, &plan.aggregates);
+                // Groups are created on first pass in ascending order.
+                assert_eq!(idx, g, "row (repeat {r}, group {g}) maps to a stable index");
+            }
+        }
+
+        let comparisons = GROUP_KEY_COMPARISONS.with(|c| c.get());
+        assert_eq!(
+            state.groups.len(),
+            groups_count,
+            "exactly one group per key"
+        );
+        // Hash index: ~1 comparison per row on the "found" path, 0 on "new".
+        // Linear scan would be ~rows × groups / 2 = {} here.
+        assert!(
+            comparisons <= rows * 2,
+            "issue #1587: group lookup must be sub-quadratic — {comparisons} comparisons \
+             for {rows} rows / {groups_count} groups (linear scan would be ~{})",
+            rows * groups_count / 2
+        );
+    }
+
+    /// The hash index must never merge distinct keys: `-0.0`/`+0.0` group
+    /// together (they are `==`), NaN never groups with itself, and different
+    /// scalars stay separate — byte-identical to the linear-scan semantics.
+    #[test]
+    fn find_or_init_group_preserves_equality_semantics() {
+        let plan = count_star_plan();
+        let mut state = new_state();
+
+        // -0.0 and +0.0 are `==` → same group.
+        let i0 = find_or_init_group(&mut state, vec![Value::Float(0.0)], &plan.aggregates);
+        let i1 = find_or_init_group(&mut state, vec![Value::Float(-0.0)], &plan.aggregates);
+        assert_eq!(i0, i1, "-0.0 and +0.0 must land in the same group");
+
+        // Two NaN keys are never `==` → two distinct groups.
+        let n0 = find_or_init_group(&mut state, vec![Value::Float(f64::NAN)], &plan.aggregates);
+        let n1 = find_or_init_group(&mut state, vec![Value::Float(f64::NAN)], &plan.aggregates);
+        assert_ne!(n0, n1, "each NaN key forms its own group (NaN != NaN)");
+
+        // Same-value different-variant keys stay separate.
+        let a = find_or_init_group(&mut state, vec![Value::Integer(1)], &plan.aggregates);
+        let b = find_or_init_group(&mut state, vec![Value::BigInt(1)], &plan.aggregates);
+        assert_ne!(a, b, "Integer(1) and BigInt(1) are distinct groups");
     }
 }

--- a/cqlite-core/src/query/select_executor/execute.rs
+++ b/cqlite-core/src/query/select_executor/execute.rs
@@ -20,8 +20,8 @@ use super::{
 };
 use super::{
     AccessPath, ColumnInfo, Error, ExecutionContext, ExecutionStep, FallbackReason,
-    OptimizedQueryPlan, ProjectionFlags, QueryResult, QueryRow, Result, SchemaManager,
-    SelectExecutor, StorageEngine, TableId,
+    OptimizedQueryPlan, ProjectionFlags, QueryResult, QueryRow, Result, SelectExecutor,
+    StorageEngine, TableId, TableSchema,
 };
 use std::sync::Arc;
 use tokio::sync::mpsc;
@@ -58,6 +58,17 @@ impl SelectExecutor {
             TableId::new("_dummy_")
         };
 
+        // Issue #1587 (E5): resolve the table's schema ONCE per query into a shared
+        // `Arc<TableSchema>`. Column-metadata building, the SSTable scan, and the
+        // SELECT-* metadata fallback all borrow this same schema (ref-count bump),
+        // instead of each independently re-locking the registry and deep-cloning a
+        // fresh `TableSchema` (2–4 deep clones per query before this).
+        let query_schema: Option<Arc<TableSchema>> = if plan.statement.from_clause.is_some() {
+            self.resolve_table_schema(&table_id).await
+        } else {
+            None
+        };
+
         // Issue #692: detect whether any WRITETIME/TTL select items are present
         // during planning and set the opt-in flag so the reader threads per-cell
         // metadata. This is the "planning" half of the executor wiring; the
@@ -72,7 +83,9 @@ impl SelectExecutor {
 
         let mut context = ExecutionContext {
             table_id,
-            columns: self.get_result_columns(&plan.statement).await?,
+            columns: self
+                .get_result_columns(&plan.statement, query_schema.as_deref())
+                .await?,
             rows_processed: 0,
             scan_rows: 0,
             projection_flags,
@@ -113,6 +126,7 @@ impl SelectExecutor {
                             predicates,
                             projection,
                             plan.statement.order_by.as_ref(),
+                            query_schema.as_deref(),
                             &mut context,
                         )
                         .await?;
@@ -189,33 +203,20 @@ impl SelectExecutor {
         // IMPORTANT: Must be sorted alphabetically for deterministic JSON output (Issue #129)!
         let mut columns = context.columns;
         if columns.is_empty() && !intermediate_results.is_empty() {
-            // Try to resolve schema to get proper CQL types (Issue #674).
-            let schema_opt = if let Some(ref from_clause) = plan.statement.from_clause {
-                if let Ok(table_id) = self.extract_table_id(from_clause) {
-                    let (keyspace, table_name) = parse_table_id(&table_id);
-                    self._schema
-                        .find_schema_by_table(&keyspace, &table_name)
-                        .await
-                } else {
-                    None
-                }
-            } else {
-                None
-            };
+            // Issue #1587 (E5): reuse the schema resolved once at the top of the
+            // query rather than re-locking the registry + deep-cloning here.
+            let schema_opt = query_schema.as_deref();
 
             let first_row = &intermediate_results[0];
             let mut col_names: Vec<_> = first_row.values.keys().collect();
             col_names.sort(); // Sort alphabetically for deterministic ordering (Issue #129)
 
-            let table_name_for_meta = schema_opt
-                .as_ref()
-                .map(|s| format!("{}.{}", s.keyspace, s.table));
+            let table_name_for_meta = schema_opt.map(|s| format!("{}.{}", s.keyspace, s.table));
 
             for (idx, col_name) in col_names.iter().enumerate() {
                 let col_name: &str = col_name;
                 // Look up CQL type from schema; derive flat DataType from it (Issue #674).
                 let col_info = match schema_opt
-                    .as_ref()
                     .and_then(|schema| schema.columns.iter().find(|c| c.name.as_str() == col_name))
                 {
                     Some(schema_col) => column_info_from_type_str(
@@ -294,7 +295,9 @@ impl SelectExecutor {
     /// Background task: Execute streaming scan and send rows through channel
     pub(super) async fn execute_streaming_background(
         storage: Arc<StorageEngine>,
-        schema_manager: Arc<SchemaManager>,
+        // Issue #1587 (E5): schema resolved ONCE per query by `execute_streaming`
+        // and moved into this task — no per-scan-step registry lock + deep clone.
+        query_schema: Option<Arc<TableSchema>>,
         _table_id: TableId,
         execution_steps: Vec<ExecutionStep>,
         tx: mpsc::Sender<Result<QueryRow>>,
@@ -343,15 +346,12 @@ impl SelectExecutor {
                     projection,
                     ..
                 } => {
-                    let (keyspace, table_name) = parse_table_id(table);
-                    let schema_opt = schema_manager
-                        .find_schema_by_table(&keyspace, &table_name)
-                        .await;
+                    let schema_opt = query_schema.as_deref();
 
                     // FINDING 2 (Issue #955 follow-up): reject a `token(...)` whose
                     // columns are not the full partition key in declared order
                     // before scanning (same rule as the materializing path).
-                    validate_token_predicates(predicates, schema_opt.as_ref())?;
+                    validate_token_predicates(predicates, schema_opt)?;
 
                     // Issue #949: a fully-constrained `WHERE pk = ?` is served by a
                     // partition-targeted lookup that prunes SSTables via bloom/BTI,
@@ -362,24 +362,22 @@ impl SelectExecutor {
                     // materializing `scan()` (last-write-wins + tombstone shadowing),
                     // which is the authoritative read semantics; it does not merely
                     // mirror `scan_stream`'s per-key merge.
-                    let lookup = classify_partition_lookup(predicates, schema_opt.as_ref());
+                    let lookup = classify_partition_lookup(predicates, schema_opt);
                     if let PartitionLookupOutcome::Targeted(ref pk_bytes) = lookup {
                         // Issue #960: the streaming analogue of the materializing
                         // partition-targeted lookup. Epic #951 (honest paths): the
                         // `tombstones` build's `scan_partition` is a full-scan +
                         // retain with NO prune, reported via `engaged == false`; only
                         // claim `StreamingPartitionLookup` when it really pruned.
-                        let (rows, engaged) = storage
-                            .scan_partition(table, pk_bytes, schema_opt.as_ref())
-                            .await?;
+                        let (rows, engaged) =
+                            storage.scan_partition(table, pk_bytes, schema_opt).await?;
                         crate::query::access_path::record(honest_targeted_path(
                             AccessPath::StreamingPartitionLookup,
                             engaged,
                         ));
                         for (key, value) in rows {
                             let part_sig = per_partition_limit.map(|_| key.0.clone());
-                            let Some(row) =
-                                build_row_from_scan(key, value, projection, schema_opt.as_ref())
+                            let Some(row) = build_row_from_scan(key, value, projection, schema_opt)
                             else {
                                 continue;
                             };
@@ -426,9 +424,8 @@ impl SelectExecutor {
                         let mut combined = Vec::new();
                         let mut all_engaged = true;
                         for pk_bytes in pk_keys {
-                            let (rows, engaged) = storage
-                                .scan_partition(table, pk_bytes, schema_opt.as_ref())
-                                .await?;
+                            let (rows, engaged) =
+                                storage.scan_partition(table, pk_bytes, schema_opt).await?;
                             all_engaged &= engaged;
                             combined.extend(rows);
                         }
@@ -439,8 +436,7 @@ impl SelectExecutor {
                         sort_rows_by_token(&mut combined);
                         for (key, value) in combined {
                             let part_sig = per_partition_limit.map(|_| key.0.clone());
-                            let Some(row) =
-                                build_row_from_scan(key, value, projection, schema_opt.as_ref())
+                            let Some(row) = build_row_from_scan(key, value, projection, schema_opt)
                             else {
                                 continue;
                             };
@@ -488,7 +484,7 @@ impl SelectExecutor {
                     // parses one entry at a time into this channel, so live heap
                     // stays bounded by `buffer_size` rather than O(result rows).
                     let mut scan_stream = storage
-                        .scan_stream(table, None, None, schema_opt.as_ref(), buffer_size)
+                        .scan_stream(table, None, None, schema_opt, buffer_size)
                         .await?;
 
                     while let Some(item) = scan_stream.recv().await {
@@ -496,8 +492,7 @@ impl SelectExecutor {
                         // Capture the partition key bytes before `key` is moved
                         // into row construction (only when needed).
                         let part_sig = per_partition_limit.map(|_| key.0.clone());
-                        let Some(row) =
-                            build_row_from_scan(key, value, projection, schema_opt.as_ref())
+                        let Some(row) = build_row_from_scan(key, value, projection, schema_opt)
                         else {
                             continue;
                         };
@@ -569,6 +564,9 @@ impl SelectExecutor {
         predicates: &[SSTablePredicate],
         projection: &[String],
         order_by: Option<&crate::query::select_ast::OrderByClause>,
+        // Issue #1587 (E5): schema resolved ONCE per query by the caller and
+        // shared by reference — no per-scan registry lock + deep clone.
+        schema_opt: Option<&TableSchema>,
         context: &mut ExecutionContext,
     ) -> Result<Vec<QueryRow>> {
         const MAX_RESULTS: usize = 1_000_000;
@@ -581,12 +579,8 @@ impl SelectExecutor {
         );
 
         let (keyspace, table_name) = parse_table_id(table);
-        let schema_opt = self
-            ._schema
-            .find_schema_by_table(&keyspace, &table_name)
-            .await;
 
-        match schema_opt.as_ref() {
+        match schema_opt {
             Some(schema) => log::info!(
                 "Found schema for {}.{} with {} columns",
                 schema.keyspace,
@@ -604,7 +598,7 @@ impl SelectExecutor {
         // by hashing the row's raw partition key, so its argument columns MUST be
         // the full partition key in declared order or the result is silently
         // wrong. Reject (Cassandra-style) before scanning/evaluating.
-        validate_token_predicates(predicates, schema_opt.as_ref())?;
+        validate_token_predicates(predicates, schema_opt)?;
 
         // Issue #693: When WRITETIME(col) or TTL(col) is in the SELECT, use the
         // metadata-carrying scan so per-cell timestamps reach the QueryRow.
@@ -618,7 +612,7 @@ impl SelectExecutor {
             // partition-lookup representation). The per-row predicate evaluation
             // below is unchanged, so the pk equality itself is still applied as a
             // correctness backstop and any bloom/BTI over-inclusion is filtered out.
-            let scan_results = match classify_partition_lookup(predicates, schema_opt.as_ref()) {
+            let scan_results = match classify_partition_lookup(predicates, schema_opt) {
                 PartitionLookupOutcome::Targeted(pk_bytes) => {
                     log::info!(
                         "SSTableScan(metadata): partition-key point lookup (key len={}) for \"{}\"",
@@ -633,7 +627,7 @@ impl SelectExecutor {
                     // rows are byte-identical either way).
                     let (rows, engaged) = self
                         .storage
-                        .scan_partition_with_cell_metadata(table, &pk_bytes, schema_opt.as_ref())
+                        .scan_partition_with_cell_metadata(table, &pk_bytes, schema_opt)
                         .await?;
                     let path = honest_targeted_path(AccessPath::MetadataPartitionLookup, engaged);
                     context.access_path = Some(path.clone());
@@ -651,7 +645,7 @@ impl SelectExecutor {
                     context.access_path = Some(metadata_path.clone());
                     crate::query::access_path::record(metadata_path);
                     self.storage
-                        .scan_with_cell_metadata(table, None, None, None, schema_opt.as_ref())
+                        .scan_with_cell_metadata(table, None, None, None, schema_opt)
                         .await?
                 }
             };
@@ -662,9 +656,7 @@ impl SelectExecutor {
                 context.rows_processed += 1;
                 context.scan_rows += 1;
 
-                let Some(mut row) =
-                    build_row_from_scan(key, value, projection, schema_opt.as_ref())
-                else {
+                let Some(mut row) = build_row_from_scan(key, value, projection, schema_opt) else {
                     continue;
                 };
 
@@ -691,7 +683,7 @@ impl SelectExecutor {
             // pinned or can't be encoded. The per-row predicate evaluation below is
             // unchanged, so clustering predicates and the pk equality itself are
             // still applied (and any over-inclusion is filtered out).
-            let scan_results = match classify_partition_lookup(predicates, schema_opt.as_ref()) {
+            let scan_results = match classify_partition_lookup(predicates, schema_opt) {
                 PartitionLookupOutcome::Targeted(pk_bytes) => {
                     log::info!(
                         "SSTableScan: partition-key point lookup (key len={}) for \"{}\"",
@@ -715,12 +707,7 @@ impl SelectExecutor {
                     #[cfg(not(feature = "tombstones"))]
                     {
                         self.targeted_partition_rows(
-                            table,
-                            &pk_bytes,
-                            predicates,
-                            order_by,
-                            schema_opt.as_ref(),
-                            context,
+                            table, &pk_bytes, predicates, order_by, schema_opt, context,
                         )
                         .await?
                     }
@@ -733,7 +720,7 @@ impl SelectExecutor {
                         // are byte-identical to the pruned build.
                         let (rows, engaged) = self
                             .storage
-                            .scan_partition(table, &pk_bytes, schema_opt.as_ref())
+                            .scan_partition(table, &pk_bytes, schema_opt)
                             .await?;
                         let path = honest_targeted_path(AccessPath::PartitionLookup, engaged);
                         context.access_path = Some(path.clone());
@@ -759,7 +746,7 @@ impl SelectExecutor {
                     for pk_bytes in &pk_keys {
                         let (rows, engaged) = self
                             .storage
-                            .scan_partition(table, pk_bytes, schema_opt.as_ref())
+                            .scan_partition(table, pk_bytes, schema_opt)
                             .await?;
                         all_engaged &= engaged;
                         combined.extend(rows);
@@ -780,7 +767,7 @@ impl SelectExecutor {
                     context.access_path = Some(AccessPath::FallbackFullScan { reason });
                     crate::query::access_path::record(AccessPath::FallbackFullScan { reason });
                     self.storage
-                        .scan(table, None, None, None, schema_opt.as_ref())
+                        .scan(table, None, None, None, schema_opt)
                         .await?
                 }
             };
@@ -792,8 +779,7 @@ impl SelectExecutor {
                 context.scan_rows += 1;
 
                 // build_row_from_scan returns None for tombstoned/null rows (Issue #191).
-                let Some(row) = build_row_from_scan(key, value, projection, schema_opt.as_ref())
-                else {
+                let Some(row) = build_row_from_scan(key, value, projection, schema_opt) else {
                     continue;
                 };
 

--- a/cqlite-core/src/query/select_executor/mod.rs
+++ b/cqlite-core/src/query/select_executor/mod.rs
@@ -726,14 +726,14 @@ impl SelectExecutor {
 
         let mut agg_state = AggregationState {
             groups: Vec::new(),
+            group_index: HashMap::new(),
             memory_usage_bytes: 0,
             memory_limit_bytes: DEFAULT_AGGREGATION_MEMORY_LIMIT,
         };
 
         for row in rows {
             let group_key = build_group_key(&row, &agg_plan.group_by_columns);
-            let group_index =
-                find_or_init_group(&mut agg_state.groups, group_key, &agg_plan.aggregates);
+            let group_index = find_or_init_group(&mut agg_state, group_key, &agg_plan.aggregates);
             let group_aggregates = &mut agg_state.groups[group_index].1;
 
             for (i, agg_comp) in agg_plan.aggregates.iter().enumerate() {

--- a/cqlite-core/src/query/select_executor/mod.rs
+++ b/cqlite-core/src/query/select_executor/mod.rs
@@ -89,6 +89,17 @@ thread_local! {
         const { std::cell::Cell::new(0) };
 }
 
+// Test-only counter for the number of times an ORDER BY sort-key expression is
+// evaluated (issue #1587, E5). With decorate-sort-undecorate this is exactly
+// `rows × order_by.items` (evaluated ONCE per row up front), never the
+// `O(n log n)` per-comparison evaluation the old comparator incurred. Same
+// thread-local rationale as `PROJECTION_NAME_DERIVATIONS`.
+#[cfg(test)]
+thread_local! {
+    pub(crate) static SORT_KEY_EVALUATIONS: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
+}
+
 /// Derive the output column name for a projected SELECT expression (issue #1584).
 ///
 /// Hoisted out of the per-row loop and called ONCE per column per query, so name
@@ -659,18 +670,37 @@ impl SelectExecutor {
         order_by: &OrderByClause,
         _context: &mut ExecutionContext,
     ) -> Result<Vec<QueryRow>> {
-        rows.sort_by(|a, b| {
+        // Issue #1587 (E5): decorate-sort-undecorate. Evaluate each row's ORDER
+        // BY key expressions ONCE (O(rows × items) total), then sort by the
+        // precomputed keys. The comparator itself performs NO
+        // `evaluate_select_expression` and NO `Value` clones — it only compares
+        // already-materialized keys. This drops the O(n log n) per-comparison
+        // expression evaluation + `Value::clone` the previous comparator
+        // incurred. The ordering is byte-identical: the same
+        // `compare_values_ordering` runs on the same per-row values, in the same
+        // ascending/descending sense, item by item, and `sort_by` remains a
+        // stable sort (ties keep input order).
+        let mut decorated: Vec<(Vec<Value>, QueryRow)> = Vec::with_capacity(rows.len());
+        for row in rows.drain(..) {
+            let mut keys = Vec::with_capacity(order_by.items.len());
             for item in &order_by.items {
-                let a_val = self
-                    .evaluate_select_expression(&item.expression, a)
-                    .unwrap_or(Value::Null);
-                let b_val = self
-                    .evaluate_select_expression(&item.expression, b)
-                    .unwrap_or(Value::Null);
+                #[cfg(test)]
+                SORT_KEY_EVALUATIONS.with(|c| c.set(c.get() + 1));
+                keys.push(
+                    self.evaluate_select_expression(&item.expression, &row)
+                        .unwrap_or(Value::Null),
+                );
+            }
+            decorated.push((keys, row));
+        }
 
+        decorated.sort_by(|(a_keys, _), (b_keys, _)| {
+            for (idx, item) in order_by.items.iter().enumerate() {
                 let ordering = match item.direction {
-                    SortDirection::Ascending => compare_values_ordering(&a_val, &b_val),
-                    SortDirection::Descending => compare_values_ordering(&b_val, &a_val),
+                    SortDirection::Ascending => compare_values_ordering(&a_keys[idx], &b_keys[idx]),
+                    SortDirection::Descending => {
+                        compare_values_ordering(&b_keys[idx], &a_keys[idx])
+                    }
                 };
                 if !ordering.is_eq() {
                     return ordering;
@@ -679,7 +709,7 @@ impl SelectExecutor {
             std::cmp::Ordering::Equal
         });
 
-        Ok(rows)
+        Ok(decorated.into_iter().map(|(_, row)| row).collect())
     }
 
     /// Execute the aggregation step. Splits naturally into three phases:
@@ -1188,6 +1218,74 @@ mod tests {
         assert_eq!(projected[0].values.get("b"), Some(&Value::Integer(0)));
         assert_eq!(projected[0].values.get("c"), Some(&Value::Integer(0)));
         assert_eq!(projected[99].values.get("a"), Some(&Value::Integer(99)));
+    }
+
+    /// Issue #1587 (E5): ORDER BY uses decorate-sort-undecorate, so each row's
+    /// sort key is evaluated EXACTLY once (`O(rows × items)`), never inside the
+    /// comparator (`O(n log n)` evaluations + a `Value::clone` per comparison).
+    /// The counter pins the linear evaluation budget; the value assertions pin
+    /// that the resulting order is byte-identical to the comparator sort.
+    #[tokio::test]
+    async fn execute_sort_evaluates_keys_once_per_row() {
+        let executor = create_test_executor().await;
+
+        let num_rows = 64usize;
+        // Reverse-sorted input so the sort must actually reorder every row (a
+        // pre-sorted input could let some sorts short-circuit comparisons).
+        let rows: Vec<QueryRow> = (0..num_rows)
+            .rev()
+            .map(|r| {
+                let mut row = QueryRow::new(RowKey::new(vec![r as u8]));
+                row.set("k", Value::Integer(r as i32));
+                row
+            })
+            .collect();
+
+        let order_by = OrderByClause {
+            items: vec![OrderByItem {
+                expression: SelectExpression::Column(ColumnRef {
+                    table: None,
+                    column: "k".to_string(),
+                }),
+                direction: SortDirection::Ascending,
+            }],
+        };
+
+        let mut ctx = ExecutionContext {
+            table_id: TableId::new("ks.t"),
+            columns: Vec::new(),
+            rows_processed: 0,
+            scan_rows: 0,
+            projection_flags: ProjectionFlags::default(),
+            access_path: None,
+            reverse_served: false,
+        };
+
+        SORT_KEY_EVALUATIONS.with(|c| c.set(0));
+        let sorted = executor
+            .execute_sort(rows, &order_by, &mut ctx)
+            .await
+            .expect("sort must succeed");
+        let evaluations = SORT_KEY_EVALUATIONS.with(|c| c.get());
+
+        // Exactly one evaluation per (row × order-by item). A comparator-based
+        // sort would evaluate ~2 per pairwise comparison — strictly more than
+        // `num_rows` for any non-trivial input (e.g. ~2·n·log2(n) ≫ n here).
+        assert_eq!(
+            evaluations, num_rows,
+            "issue #1587: sort keys must be evaluated once per row (n = {num_rows}), \
+             not O(n log n) times inside the comparator"
+        );
+
+        // Ordering preserved byte-identically: ascending 0..num_rows.
+        assert_eq!(sorted.len(), num_rows);
+        for (i, row) in sorted.iter().enumerate() {
+            assert_eq!(
+                row.values.get("k"),
+                Some(&Value::Integer(i as i32)),
+                "row {i} must sort into ascending position"
+            );
+        }
     }
 
     /// The executor's `evaluate_select_expression` returns the correct value for

--- a/cqlite-core/src/query/select_executor/mod.rs
+++ b/cqlite-core/src/query/select_executor/mod.rs
@@ -1344,6 +1344,131 @@ mod tests {
         }
     }
 
+    /// Issue #1587 (E5): the decorate-sort-undecorate refactor must PRESERVE the
+    /// ORDER BY ordering for float keys — including NaN and signed zero — exactly
+    /// as the pre-refactor per-comparison sort produced it. It reuses the shared
+    /// `compare_values_ordering` comparator with a stable `sort_by`, so this test
+    /// drives the decorate-sort path (via `execute_sort`) and asserts:
+    ///
+    ///   * with NaN present, the decorated output is order-IDENTICAL to a direct
+    ///     reference sort over the same keys and comparator (ASC and DESC) — the
+    ///     core preservation guarantee; and
+    ///   * over a NaN-free float input (where the comparator IS a total order),
+    ///     finite keys are correctly ordered and signed zeros (-0.0 vs +0.0, which
+    ///     compare Equal) keep input order (stable).
+    ///
+    /// NOTE (pre-existing gaps, out of scope for #1587): `compare_values_ordering`
+    /// compares floats via `f64::partial_cmp` (NaN → Equal, -0.0 == +0.0). So it
+    /// does NOT reproduce Cassandra/Java float ordering (NaN sorted LAST,
+    /// -0.0 < +0.0), and — because a NaN key makes the comparator a NON-total
+    /// order — a NaN in the input leaves even the finite keys in an unspecified
+    /// order. This test therefore pins the ordering the decorate-sort ACTUALLY
+    /// preserves, not the (currently absent) Java semantics. Making ORDER BY match
+    /// Cassandra float ordering is a separate behavior change; reported separately.
+    #[tokio::test]
+    async fn execute_sort_preserves_float_nan_signed_zero_ordering() {
+        let executor = create_test_executor().await;
+
+        let make_rows = |inputs: &[(u8, f64)]| -> Vec<QueryRow> {
+            inputs
+                .iter()
+                .map(|(tag, f)| {
+                    let mut row = QueryRow::new(RowKey::new(vec![*tag]));
+                    row.set("f", Value::Float(*f));
+                    row
+                })
+                .collect()
+        };
+        let order_by = |dir: &SortDirection| OrderByClause {
+            items: vec![OrderByItem {
+                expression: SelectExpression::Column(ColumnRef {
+                    table: None,
+                    column: "f".to_string(),
+                }),
+                direction: dir.clone(),
+            }],
+        };
+        let mut ctx = ExecutionContext {
+            table_id: TableId::new("ks.t"),
+            columns: Vec::new(),
+            rows_processed: 0,
+            scan_rows: 0,
+            projection_flags: ProjectionFlags::default(),
+            access_path: None,
+            reverse_served: false,
+        };
+        let tags = |rows: &[QueryRow]| -> Vec<u8> { rows.iter().map(|r| r.key.0[0]).collect() };
+
+        // --- Part A: NaN present → decorate-sort is order-identical to reference.
+        // Tags 2 (-0.0) and 4 (+0.0) compare Equal; NaN appears twice (tags 1, 6).
+        let with_nan: [(u8, f64); 7] = [
+            (0, 2.0),
+            (1, f64::NAN),
+            (2, -0.0),
+            (3, 1.0),
+            (4, 0.0),
+            (5, -1.0),
+            (6, f64::NAN),
+        ];
+        for dir in [SortDirection::Ascending, SortDirection::Descending] {
+            let sorted = executor
+                .execute_sort(make_rows(&with_nan), &order_by(&dir), &mut ctx)
+                .await
+                .expect("sort must succeed");
+
+            let mut reference = make_rows(&with_nan);
+            reference.sort_by(|a, b| {
+                let (ka, kb) = (
+                    a.values.get("f").expect("key"),
+                    b.values.get("f").expect("key"),
+                );
+                match dir {
+                    SortDirection::Ascending => compare_values_ordering(ka, kb),
+                    SortDirection::Descending => compare_values_ordering(kb, ka),
+                }
+            });
+            assert_eq!(
+                tags(&sorted),
+                tags(&reference),
+                "issue #1587: decorate-sort must be order-identical to the reference \
+                 comparator sort for float/NaN keys ({dir:?})"
+            );
+        }
+
+        // --- Part B: NaN-free input → the comparator is a total order, so the
+        // decorate-sort must produce correct finite ordering and stable signed
+        // zeros. Tags 2 (-0.0) and 4 (+0.0) compare Equal (must keep input order).
+        let no_nan: [(u8, f64); 5] = [(0, 2.0), (2, -0.0), (3, 1.0), (4, 0.0), (5, -1.0)];
+        // Ascending: -1.0, then -0.0 (tag 2) then +0.0 (tag 4) [stable tie], 1.0, 2.0.
+        let asc = executor
+            .execute_sort(
+                make_rows(&no_nan),
+                &order_by(&SortDirection::Ascending),
+                &mut ctx,
+            )
+            .await
+            .expect("sort must succeed");
+        assert_eq!(
+            tags(&asc),
+            vec![5, 2, 4, 3, 0],
+            "ascending float order with stable signed zeros"
+        );
+        // Descending: 2.0, 1.0, then -0.0/+0.0 (stable tie: 2 before 4), -1.0.
+        let desc = executor
+            .execute_sort(
+                make_rows(&no_nan),
+                &order_by(&SortDirection::Descending),
+                &mut ctx,
+            )
+            .await
+            .expect("sort must succeed");
+        assert_eq!(
+            tags(&desc),
+            vec![0, 3, 2, 4, 5],
+            "descending float order with stable signed zeros"
+        );
+    }
+
     /// The executor's `evaluate_select_expression` returns the correct value for
     /// a WRITETIME call when cell metadata is pre-attached to the row.
     #[tokio::test]

--- a/cqlite-core/src/query/select_executor/mod.rs
+++ b/cqlite-core/src/query/select_executor/mod.rs
@@ -46,7 +46,7 @@ use super::{
     select_optimizer::{AggregationPlan, ExecutionStep, OptimizedQueryPlan, SSTablePredicate},
 };
 use crate::{
-    schema::{CqlType, SchemaManager},
+    schema::{CqlType, SchemaManager, TableSchema},
     storage::StorageEngine,
     types::{RowKey, Value},
     Error, Result, TableId,
@@ -296,7 +296,16 @@ impl SelectExecutor {
             return self.execute_and_stream(plan, config).await;
         };
 
-        let columns = self.get_result_columns(&plan.statement).await?;
+        // Issue #1587 (E5): resolve the schema ONCE for the whole streaming query
+        // and share it (by reference here, and moved into the spawned task below)
+        // so column-metadata building, the pre-spawn token validation, and the
+        // background scan all reuse one `Arc<TableSchema>` instead of each
+        // re-locking the registry and deep-cloning a fresh schema (2–4× per query).
+        let query_schema: Option<Arc<TableSchema>> = self.resolve_table_schema(&table_id).await;
+
+        let columns = self
+            .get_result_columns(&plan.statement, query_schema.as_deref())
+            .await?;
 
         // Create bounded channel for backpressure
         let (tx, rx) = mpsc::channel(config.buffer_size);
@@ -319,32 +328,22 @@ impl SelectExecutor {
         // caller would receive an apparently-successful iterator that yields zero
         // rows — silently hiding an invalid `token(...)` query. Validating here
         // surfaces the error synchronously from `execute_streaming`, matching the
-        // materializing `execute()` path. The schema must be resolved before the
-        // spawn for this, so we resolve it per scan step here.
+        // materializing `execute()` path. Uses the already-resolved schema.
         for step in &execution_steps {
-            if let ExecutionStep::SSTableScan {
-                table, predicates, ..
-            } = step
-            {
-                let (keyspace, table_name) = parse_table_id(table);
-                let schema_opt = self
-                    ._schema
-                    .find_schema_by_table(&keyspace, &table_name)
-                    .await;
-                validate_token_predicates(predicates, schema_opt.as_ref())?;
+            if let ExecutionStep::SSTableScan { predicates, .. } = step {
+                validate_token_predicates(predicates, query_schema.as_deref())?;
             }
         }
 
-        // Clone what we need for the background task
+        // Clone what we need for the background task.
         let storage = Arc::clone(&self.storage);
-        let schema_manager = Arc::clone(&self._schema);
         let buffer_size = config.buffer_size;
 
         // Spawn background task to stream rows
         tokio::spawn(async move {
             if let Err(e) = Self::execute_streaming_background(
                 storage,
-                schema_manager,
+                query_schema,
                 table_id,
                 execution_steps,
                 tx,
@@ -926,23 +925,39 @@ impl SelectExecutor {
         }
     }
 
-    async fn get_result_columns(&self, statement: &SelectStatement) -> Result<Vec<ColumnInfo>> {
+    /// Resolve a table's schema ONCE per query into a shared `Arc<TableSchema>`
+    /// (issue #1587, E5). Every downstream planning/execution step then borrows
+    /// the SAME schema (`Arc::clone` is a ref-count bump) instead of re-taking the
+    /// registry lock and deep-cloning a fresh `TableSchema` per step (which was
+    /// 2–4 deep clones per query). The registry itself is untouched (AJ1/AJ2 own
+    /// its shape) — this is purely query-side de-duplication.
+    async fn resolve_table_schema(&self, table: &TableId) -> Option<Arc<TableSchema>> {
+        let (keyspace, table_name) = parse_table_id(table);
+        self._schema
+            .find_schema_by_table(&keyspace, &table_name)
+            .await
+            .map(Arc::new)
+    }
+
+    /// Build result-column metadata from an ALREADY-RESOLVED schema (issue #1587,
+    /// E5). The caller resolves the schema once per query and passes it here, so
+    /// this never re-clones it out of the registry.
+    async fn get_result_columns(
+        &self,
+        statement: &SelectStatement,
+        schema: Option<&TableSchema>,
+    ) -> Result<Vec<ColumnInfo>> {
         let mut columns = Vec::new();
 
         match &statement.select_clause {
             SelectClause::All => {
-                // For SELECT *, look up the schema to get column names and CQL types.
+                // For SELECT *, use the schema to get column names and CQL types.
                 // This is needed for streaming mode where we can't wait for the first row.
                 if let Some(ref from_clause) = statement.from_clause {
                     let table_id = self.extract_table_id(from_clause)?;
                     let (keyspace_opt, table_name) = parse_table_id(&table_id);
 
-                    // Look up schema from SchemaManager
-                    if let Some(schema) = self
-                        ._schema
-                        .find_schema_by_table(&keyspace_opt, &table_name)
-                        .await
-                    {
+                    if let Some(schema) = schema {
                         // Collect all schema columns (sorted alphabetically for determinism)
                         let mut schema_cols: Vec<&crate::schema::Column> =
                             schema.columns.iter().collect();
@@ -971,20 +986,9 @@ impl SelectExecutor {
                 }
             }
             SelectClause::Columns(exprs) | SelectClause::Distinct(exprs) => {
-                // Try to resolve a schema for the FROM table (if present) so we can
-                // attach authoritative CQL types to explicitly projected columns (Issue #674).
-                let schema_opt = if let Some(ref from_clause) = statement.from_clause {
-                    if let Ok(table_id) = self.extract_table_id(from_clause) {
-                        let (keyspace_opt, table_name) = parse_table_id(&table_id);
-                        self._schema
-                            .find_schema_by_table(&keyspace_opt, &table_name)
-                            .await
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                };
+                // Issue #674: attach authoritative CQL types to explicitly projected
+                // columns from the pre-resolved schema.
+                let schema_opt = schema;
 
                 for (i, expr) in exprs.iter().enumerate() {
                     // Issue #692: WriteTimeTtl expressions produce fixed-schema output
@@ -1023,7 +1027,7 @@ impl SelectExecutor {
                     };
 
                     // Look up CQL type for this column in the schema (Issue #674).
-                    let cql_type_opt = schema_opt.as_ref().and_then(|schema| {
+                    let cql_type_opt = schema_opt.and_then(|schema| {
                         schema
                             .columns
                             .iter()
@@ -1062,6 +1066,58 @@ mod tests {
     use crate::query::result::{CellExpiration, CellWriteMetadata};
     use crate::{platform::Platform, Config};
     use tempfile::TempDir;
+
+    /// Issue #1587 (E5): a query resolves its table schema ONCE and shares it by
+    /// `Arc`, so a single `execute()` deep-clones the `TableSchema` out of the
+    /// registry exactly once — NOT once per planning/execution step (column
+    /// metadata + scan + fallback each re-resolved before, giving 2–4 clones).
+    /// Runs over empty storage so the count is deterministic and data-free: the
+    /// SELECT-* column metadata AND the scan step both consume the pre-resolved
+    /// schema.
+    #[tokio::test]
+    async fn execute_resolves_schema_once_per_query() {
+        use crate::schema::TABLE_SCHEMA_CLONES;
+
+        let temp_dir = TempDir::new().unwrap();
+        let config = Config::default();
+        let platform = Arc::new(Platform::new(&config).await.unwrap());
+        let storage = Arc::new(
+            StorageEngine::open(
+                temp_dir.path(),
+                &config,
+                platform.clone(),
+                #[cfg(feature = "state_machine")]
+                None,
+            )
+            .await
+            .unwrap(),
+        );
+        let schema = Arc::new(SchemaManager::new(temp_dir.path()).await.unwrap());
+        schema
+            .parse_and_register_cql_schema(
+                "CREATE TABLE ks.t (id int PRIMARY KEY, name text, age int)",
+            )
+            .await
+            .expect("schema registers");
+
+        let executor = SelectExecutor::new(schema.clone(), storage.clone());
+        let optimizer =
+            crate::query::select_optimizer::SelectOptimizer::new(schema.clone(), storage.clone());
+
+        let statement = crate::query::select_parser::parse_select("SELECT * FROM ks.t").unwrap();
+        // Optimization performs no schema resolution; reset the counter AFTER it.
+        let plan = optimizer.optimize(statement).await.unwrap();
+
+        TABLE_SCHEMA_CLONES.with(|c| c.set(0));
+        let _ = executor.execute(plan).await.expect("query executes");
+        let clones = TABLE_SCHEMA_CLONES.with(|c| c.get());
+
+        assert_eq!(
+            clones, 1,
+            "issue #1587: a query must deep-clone its schema out of the registry once \
+             (was 2–4: column-metadata + scan + fallback each re-resolved), got {clones}"
+        );
+    }
 
     async fn create_test_executor() -> SelectExecutor {
         let temp_dir = TempDir::new().unwrap();
@@ -1419,7 +1475,7 @@ mod tests {
             allow_filtering: false,
         };
 
-        let cols = executor.get_result_columns(&stmt).await.unwrap();
+        let cols = executor.get_result_columns(&stmt, None).await.unwrap();
         assert_eq!(cols.len(), 1);
         assert_eq!(cols[0].name, "writetime(name)");
         assert_eq!(cols[0].data_type, crate::types::DataType::BigInt);
@@ -1451,7 +1507,7 @@ mod tests {
             allow_filtering: false,
         };
 
-        let cols = executor.get_result_columns(&stmt).await.unwrap();
+        let cols = executor.get_result_columns(&stmt, None).await.unwrap();
         assert_eq!(cols.len(), 1);
         assert_eq!(cols[0].name, "ttl(score)");
         assert_eq!(cols[0].data_type, crate::types::DataType::Integer);
@@ -1483,7 +1539,7 @@ mod tests {
             allow_filtering: false,
         };
 
-        let cols = executor.get_result_columns(&stmt).await.unwrap();
+        let cols = executor.get_result_columns(&stmt, None).await.unwrap();
         assert_eq!(cols.len(), 1);
         assert_eq!(
             cols[0].name, "wt",

--- a/cqlite-core/src/query/select_optimizer.rs
+++ b/cqlite-core/src/query/select_optimizer.rs
@@ -244,9 +244,29 @@ impl SelectOptimizer {
             if let SelectClause::Columns(exprs) | SelectClause::Distinct(exprs) =
                 &statement.select_clause
             {
-                plan.execution_steps.push(ExecutionStep::Project {
-                    columns: exprs.clone(),
-                });
+                // Issue #1587 (E5): a bare-column SELECT (every item a plain
+                // `Column`, no alias/function/arithmetic) is ALREADY projected by
+                // the SSTable scan — `SSTableScan.projection` is exactly these
+                // column names (see `extract_projection_columns`), and
+                // `build_row_from_scan` keeps precisely those cells, keyed by the
+                // same column name the `Project` step would re-key them to. So the
+                // second `Project` re-projects every row into a byte-identical
+                // value map: skip it and project each row ONCE (in the scan).
+                //
+                // The optimization is scoped to `SelectClause::Columns` (not
+                // `Distinct`, which is not a pure projection) and to all-plain-
+                // `Column` items — an alias / expression / `WRITETIME`/`TTL`
+                // reshapes or renames the row and still needs the `Project` step.
+                let is_bare_columns = matches!(&statement.select_clause, SelectClause::Columns(_))
+                    && exprs
+                        .iter()
+                        .all(|e| matches!(e, SelectExpression::Column(_)));
+
+                if !is_bare_columns {
+                    plan.execution_steps.push(ExecutionStep::Project {
+                        columns: exprs.clone(),
+                    });
+                }
             }
         }
 
@@ -607,6 +627,77 @@ mod tests {
         let schema = Arc::new(SchemaManager::new(temp_dir.path()).await.unwrap());
         let optimizer = SelectOptimizer { schema, storage };
         assert!(std::mem::size_of_val(&optimizer) > 0);
+    }
+
+    async fn make_optimizer() -> SelectOptimizer {
+        let temp_dir = TempDir::new().unwrap();
+        let config = Config::default();
+        let platform = Arc::new(Platform::new(&config).await.unwrap());
+        let storage = Arc::new(
+            StorageEngine::open(
+                temp_dir.path(),
+                &config,
+                platform.clone(),
+                #[cfg(feature = "state_machine")]
+                None,
+            )
+            .await
+            .unwrap(),
+        );
+        let schema = Arc::new(SchemaManager::new(temp_dir.path()).await.unwrap());
+        SelectOptimizer { schema, storage }
+    }
+
+    fn project_step_count(plan: &OptimizedQueryPlan) -> usize {
+        plan.execution_steps
+            .iter()
+            .filter(|s| matches!(s, ExecutionStep::Project { .. }))
+            .count()
+    }
+
+    /// Issue #1587 (E5): a bare-column SELECT is projected exactly ONCE — by the
+    /// SSTable scan — with no redundant `Project` step re-projecting every row.
+    /// "row-projection-passes" = the scan pass (always 1) + one per `Project`
+    /// step; it must be 1 for a bare-column select (was 2 on main) and stay 2
+    /// for an aliased projection, which reshapes/renames the row.
+    #[tokio::test]
+    async fn bare_column_select_projects_rows_once() {
+        let optimizer = make_optimizer().await;
+
+        let bare = crate::query::select_parser::parse_select("SELECT a, b, c FROM t").unwrap();
+        let plan = optimizer.optimize(bare).await.unwrap();
+        let projection_passes = 1 + project_step_count(&plan);
+        assert_eq!(
+            projection_passes, 1,
+            "issue #1587: a bare-column SELECT must project each row once (scan only), not twice"
+        );
+
+        // The scan step already carries exactly the selected columns, in order.
+        let scan_projection = plan
+            .execution_steps
+            .iter()
+            .find_map(|s| match s {
+                ExecutionStep::SSTableScan { projection, .. } => Some(projection.clone()),
+                _ => None,
+            })
+            .expect("plan has an SSTable scan");
+        assert_eq!(scan_projection, vec!["a", "b", "c"]);
+
+        // Contrast: an aliased projection reshapes the row → keeps its Project pass.
+        let mut aliased = crate::query::select_parser::parse_select("SELECT a FROM t").unwrap();
+        aliased.select_clause = SelectClause::Columns(vec![SelectExpression::Aliased(
+            Box::new(SelectExpression::Column(ColumnRef {
+                table: None,
+                column: "a".to_string(),
+            })),
+            "x".to_string(),
+        )]);
+        let aplan = optimizer.optimize(aliased).await.unwrap();
+        assert_eq!(
+            1 + project_step_count(&aplan),
+            2,
+            "an aliased projection must keep its Project pass"
+        );
     }
 
     /// Build `<column> <op> <literal>` for predicate-conversion tests.

--- a/cqlite-core/src/query/select_optimizer.rs
+++ b/cqlite-core/src/query/select_optimizer.rs
@@ -4,6 +4,17 @@ use super::select_ast::*;
 use crate::{schema::SchemaManager, storage::StorageEngine, Error, Result, TableId, Value};
 use std::sync::Arc;
 
+// Test-only counter for the number of times `SelectOptimizer::optimize` runs
+// (issue #1587, E5). A prepared statement must reuse its optimized plan across
+// repeated executes with identical parameters, so this stays `<= 1` over many
+// executes. Same thread-local rationale as the executor's other work counters
+// (`#[tokio::test]` current-thread runtime keeps the future on this thread).
+#[cfg(test)]
+thread_local! {
+    pub(crate) static OPTIMIZE_INVOCATIONS: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
+}
+
 /// Query optimizer for SELECT statements
 #[derive(Debug)]
 pub struct SelectOptimizer {
@@ -153,6 +164,9 @@ impl SelectOptimizer {
 
     /// Optimize a SELECT statement
     pub async fn optimize(&self, statement: SelectStatement) -> Result<OptimizedQueryPlan> {
+        #[cfg(test)]
+        OPTIMIZE_INVOCATIONS.with(|c| c.set(c.get() + 1));
+
         let mut plan = OptimizedQueryPlan {
             statement: statement.clone(),
             execution_steps: Vec::new(),

--- a/cqlite-core/src/schema/mod.rs
+++ b/cqlite-core/src/schema/mod.rs
@@ -47,6 +47,17 @@ pub use registry::{
     SchemaVersion, ValidationReport,
 };
 
+// Test-only counter for the number of times `find_schema_by_table` deep-clones a
+// `TableSchema` out of the registry (issue #1587, E5). A query must resolve its
+// schema ONCE and share it by `Arc`, so this stays `== 1` per query (it was 2–4
+// when each planning/execution step re-resolved). Same thread-local rationale as
+// the query executor's other work counters.
+#[cfg(test)]
+thread_local! {
+    pub(crate) static TABLE_SCHEMA_CLONES: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
+}
+
 pub use parser::SchemaParser;
 
 #[cfg(feature = "experimental")]
@@ -915,12 +926,14 @@ impl SchemaManager {
         if let Some(ks) = keyspace {
             let key = format!("{}.{}", ks, table);
             if let Some(schema) = schemas.get(&key) {
+                #[cfg(test)]
+                TABLE_SCHEMA_CLONES.with(|c| c.set(c.get() + 1));
                 return Some(schema.clone());
             }
         }
 
         // Then try to find any schema matching the table name
-        schemas
+        let found = schemas
             .values()
             .find(|schema| {
                 cql_parser::table_name_matches(
@@ -930,7 +943,12 @@ impl SchemaManager {
                     table,
                 )
             })
-            .cloned()
+            .cloned();
+        #[cfg(test)]
+        if found.is_some() {
+            TABLE_SCHEMA_CLONES.with(|c| c.set(c.get() + 1));
+        }
+        found
     }
 
     /// Extract table information from CQL without full parsing

--- a/cqlite-core/tests/issue_1587_bare_column_output_parity.rs
+++ b/cqlite-core/tests/issue_1587_bare_column_output_parity.rs
@@ -1,0 +1,224 @@
+//! Issue #1587 (E5) fix round: public-surface parity for the bare-column
+//! `SELECT` projection-elision optimization.
+//!
+//! The optimizer now skips the redundant `Project` step for bare-column SELECTs
+//! (every item a plain `Column`), projecting each row once in the SSTable scan.
+//! The old `Project` path rebuilt rows with an EMPTY `RowKey` and *errored*
+//! ("Column not found") when a projected column was NULL/absent in a row. The
+//! scan path preserves the storage key and simply omits absent columns.
+//!
+//! These tests pin the resulting public behavior against real Cassandra 5.0
+//! fixtures through the public `Database::execute` path (default gate feature
+//! set: `cli-helpers`):
+//!
+//!   1. A bare-column `SELECT a, b` returns the SAME `_key` per row as
+//!      `SELECT *` (bare-column projection is now consistent with the canonical
+//!      scan path), and the projected column VALUES match `SELECT *` exactly.
+//!   2. Selecting a schema column that is NULL/absent in a given row returns
+//!      null (not an error) — the intended, Cassandra-aligned behavior.
+
+#![cfg(all(feature = "state_machine", feature = "cli-helpers"))]
+
+use std::path::{Path, PathBuf};
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::Database;
+
+fn datasets_root() -> Option<PathBuf> {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+}
+
+fn schemas_dir() -> Option<PathBuf> {
+    if let Some(root) = datasets_root() {
+        let dir = root.parent()?.join("schemas");
+        if dir.exists() {
+            return Some(dir);
+        }
+    }
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let dir = manifest_dir.parent()?.join("test-data").join("schemas");
+    dir.exists().then_some(dir)
+}
+
+/// Ingest one keyspace (`schema_file` scoped to `keyspace_filter`) into a
+/// queryable database, or return a skip reason.
+async fn setup(schema_file: &str, keyspace_filter: &str) -> Result<Database, String> {
+    let root = datasets_root().ok_or("CQLITE_DATASETS_ROOT not set or missing")?;
+    let schema_path = schemas_dir()
+        .ok_or("schemas dir not found")?
+        .join(schema_file);
+    if !schema_path.exists() {
+        return Err(format!("{schema_file} not found at {schema_path:?}"));
+    }
+    let data_dir = root.join("sstables");
+    if !data_dir.exists() {
+        return Err(format!("sstables dir not found at {data_dir:?}"));
+    }
+
+    let config = IngestionConfig {
+        schema_paths: vec![schema_path],
+        data_dir,
+        version_hint: None,
+        core_config: cqlite_core::Config::default(),
+        table_directory_filter: Some(keyspace_filter.to_string()),
+    };
+    let result = ingest(config)
+        .await
+        .map_err(|e| format!("ingestion failed: {e}"))?;
+    if result.schema_load_result.schemas_loaded == 0 {
+        return Err("no schemas loaded".to_string());
+    }
+    Ok(result.database)
+}
+
+/// The `_key` string rendered by `QueryResult::to_json` (`format!("{:?}", key)`).
+fn key_str(row: &serde_json::Value) -> String {
+    row.get("_key")
+        .and_then(|k| k.as_str())
+        .unwrap_or("<missing>")
+        .to_string()
+}
+
+/// Build a map from the partition-key column value (`id`, a UUID string) to the
+/// row's JSON object, so rows can be correlated across two queries independent
+/// of return order.
+fn index_by_id(result: &serde_json::Value) -> std::collections::HashMap<String, serde_json::Value> {
+    let mut map = std::collections::HashMap::new();
+    if let Some(rows) = result.get("rows").and_then(|r| r.as_array()) {
+        for row in rows {
+            if let Some(id) = row.get("id").and_then(|v| v.as_str()) {
+                map.insert(id.to_string(), row.clone());
+            }
+        }
+    }
+    map
+}
+
+/// STEP 1a: a bare-column projection now emits the SAME `_key` per row as
+/// `SELECT *`, and identical VALUES for the projected columns. The only
+/// observable difference from `SELECT *` is the projected column subset.
+#[tokio::test]
+async fn bare_column_select_key_and_values_match_select_star() {
+    let db = match setup("basic-types.cql", "/test_basic/").await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let star = db
+        .execute("SELECT * FROM test_basic.simple_table LIMIT 50")
+        .await
+        .expect("SELECT * must succeed")
+        .to_json();
+    let bare = db
+        .execute("SELECT id, name, age FROM test_basic.simple_table LIMIT 50")
+        .await
+        .expect("bare-column SELECT must succeed")
+        .to_json();
+
+    let star_by_id = index_by_id(&star);
+    let bare_by_id = index_by_id(&bare);
+
+    assert!(
+        !star_by_id.is_empty() && !bare_by_id.is_empty(),
+        "both queries must return correlatable rows (id present); \
+         star={} bare={}",
+        star_by_id.len(),
+        bare_by_id.len()
+    );
+    assert_eq!(
+        star_by_id.len(),
+        bare_by_id.len(),
+        "both queries must cover the same set of partitions"
+    );
+
+    for (id, bare_row) in &bare_by_id {
+        let star_row = star_by_id
+            .get(id)
+            .unwrap_or_else(|| panic!("id {id} present in bare but not in SELECT *"));
+
+        // (1) _key must be IDENTICAL — the elided bare-column path preserves the
+        // storage key, matching the canonical SELECT * scan path (the old
+        // Project path emitted an EMPTY key here).
+        assert_eq!(
+            key_str(bare_row),
+            key_str(star_row),
+            "issue #1587: bare-column _key must equal SELECT * _key for id {id}"
+        );
+
+        // (2) For every projected column, the VALUE must be byte-identical to
+        // SELECT *. The only difference is the projected subset.
+        for col in ["id", "name", "age"] {
+            assert_eq!(
+                bare_row.get(col),
+                star_row.get(col),
+                "issue #1587: projected column `{col}` must equal SELECT * for id {id}"
+            );
+        }
+
+        // The bare projection must NOT leak non-projected columns.
+        if let Some(obj) = bare_row.as_object() {
+            for k in obj.keys() {
+                assert!(
+                    matches!(k.as_str(), "id" | "name" | "age" | "_key" | "_metadata"),
+                    "bare projection leaked unexpected field `{k}`"
+                );
+            }
+        }
+    }
+}
+
+/// STEP 1b: selecting a schema column that is NULL/absent in a row returns null
+/// (not an error). The old `Project` path errored with "Column not found" on
+/// such rows; the elided scan path omits the absent column and `to_json`
+/// renders it as null.
+///
+/// `many_columns_table` (test_wide_rows) declares `col_001..col_100` but the
+/// fixture only writes a handful (`col_001`, `col_011`, ...). `col_002` is a
+/// declared schema column that is NULL in EVERY row — a deterministic null that
+/// the old bare-column error path could not handle.
+#[tokio::test]
+async fn select_column_null_in_row_returns_null_not_error() {
+    let db = match setup("wide-rows.cql", "/test_wide_rows/").await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let result = db
+        .execute("SELECT id, col_001, col_002 FROM test_wide_rows.many_columns_table LIMIT 25")
+        .await
+        // The KEY assertion: this must NOT error. The old Project path returned
+        // Err("Column not found: col_002") for rows where the column is absent.
+        .expect("issue #1587: selecting a column that is null in a row must NOT error");
+
+    let json = result.to_json();
+    let rows = json
+        .get("rows")
+        .and_then(|r| r.as_array())
+        .expect("rows array");
+    assert!(!rows.is_empty(), "fixture must return rows");
+
+    // `col_002` is declared but never written → it must render as JSON null in
+    // EVERY row (proving null-not-error), while a populated column is non-null.
+    for row in rows {
+        assert_eq!(
+            row.get("col_002"),
+            Some(&serde_json::Value::Null),
+            "issue #1587: never-written schema column col_002 must be null, got: {}",
+            serde_json::to_string(row).unwrap_or_default()
+        );
+    }
+    assert!(
+        rows.iter()
+            .any(|row| !matches!(row.get("col_001"), Some(serde_json::Value::Null) | None)),
+        "populated column col_001 must be non-null in at least one row"
+    );
+}

--- a/cqlite-core/tests/issue_1587_group_by_execute_parity.rs
+++ b/cqlite-core/tests/issue_1587_group_by_execute_parity.rs
@@ -1,0 +1,140 @@
+//! Issue #1587 (E5) fix round: public-surface wiring evidence for the
+//! hash-indexed GROUP BY group lookup (optimization #5).
+//!
+//! The unit tests (`find_or_init_group_*`) call the `pub(super)` helper directly,
+//! and the only end-to-end GROUP BY tests live behind `#[cfg(feature =
+//! "experimental")]` (NOT run by the gate's `cli-helpers` core-tests). This test
+//! exercises GROUP BY THROUGH the public `Database::execute` path on a real
+//! Cassandra 5.0 fixture, under the default gate feature set (`cli-helpers`),
+//! asserting correct aggregate results across multiple groups. That establishes
+//! that the accelerated group lookup is wired into the public query path.
+
+#![cfg(all(feature = "state_machine", feature = "cli-helpers"))]
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use cqlite_core::ingestion::{ingest, IngestionConfig};
+use cqlite_core::types::Value;
+use cqlite_core::Database;
+
+fn datasets_root() -> Option<PathBuf> {
+    std::env::var("CQLITE_DATASETS_ROOT")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+}
+
+fn schemas_dir() -> Option<PathBuf> {
+    if let Some(root) = datasets_root() {
+        let dir = root.parent()?.join("schemas");
+        if dir.exists() {
+            return Some(dir);
+        }
+    }
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let dir = manifest_dir.parent()?.join("test-data").join("schemas");
+    dir.exists().then_some(dir)
+}
+
+async fn setup(schema_file: &str, keyspace_filter: &str) -> Result<Database, String> {
+    let root = datasets_root().ok_or("CQLITE_DATASETS_ROOT not set or missing")?;
+    let schema_path = schemas_dir()
+        .ok_or("schemas dir not found")?
+        .join(schema_file);
+    if !schema_path.exists() {
+        return Err(format!("{schema_file} not found at {schema_path:?}"));
+    }
+    let data_dir = root.join("sstables");
+    if !data_dir.exists() {
+        return Err(format!("sstables dir not found at {data_dir:?}"));
+    }
+    let config = IngestionConfig {
+        schema_paths: vec![schema_path],
+        data_dir,
+        version_hint: None,
+        core_config: cqlite_core::Config::default(),
+        table_directory_filter: Some(keyspace_filter.to_string()),
+    };
+    let result = ingest(config)
+        .await
+        .map_err(|e| format!("ingestion failed: {e}"))?;
+    if result.schema_load_result.schemas_loaded == 0 {
+        return Err("no schemas loaded".to_string());
+    }
+    Ok(result.database)
+}
+
+/// GROUP BY through the public query path produces correct per-group aggregates
+/// across MULTIPLE groups.
+///
+/// `test_basic.multi_partition_table` has a `category` clustering column with
+/// three distinct values across 100 single-row partitions:
+///   A → 36 rows, B → 36 rows, C → 28 rows.
+/// (Ground truth derived from the committed JSONL golden.)
+///
+/// The aggregate is `COUNT(*)`, which needs no projected column and so exercises
+/// grouping + per-group accumulation independently of a PRE-EXISTING scan-
+/// projection bug (aggregate-argument columns like `SUM(value)`'s `value` are
+/// excluded from `SSTableScan.projection` on origin/main, so `SUM` reads null →
+/// 0; out of scope for #1587, reported separately). `COUNT(*)` is unaffected and
+/// is exact per group, so it is a faithful multi-group aggregate result.
+#[tokio::test]
+async fn group_by_via_execute_aggregates_multiple_groups() {
+    let db = match setup("basic-types.cql", "/test_basic/").await {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Skipping: {e}");
+            return;
+        }
+    };
+
+    let result = db
+        .execute(
+            "SELECT category, COUNT(*) \
+             FROM test_basic.multi_partition_table GROUP BY category",
+        )
+        .await
+        .expect("GROUP BY query must execute through the public path");
+
+    // Read the per-group COUNT from the public `QueryRow.values` map. (`to_json`
+    // mislabels aggregate output columns — a PRE-EXISTING bug where
+    // `get_result_columns` names an unaliased aggregate `col_N` while the value
+    // map keys it by the derived alias; out of scope for #1587. Reading the value
+    // map directly proves grouping is wired into the public query path.)
+    let count_of = |cat: &str| -> Option<i64> {
+        result.rows.iter().find_map(|row| {
+            match row.values.get("category") {
+                Some(Value::Text(t)) if t == cat => {}
+                _ => return None,
+            }
+            // COUNT(*) is the sole BigInt aggregate in the group row.
+            row.values.iter().find_map(|(k, v)| match v {
+                Value::BigInt(n) if k.as_ref() != "category" => Some(*n),
+                _ => None,
+            })
+        })
+    };
+
+    let mut got: HashMap<String, i64> = HashMap::new();
+    for cat in ["A", "B", "C"] {
+        if let Some(count) = count_of(cat) {
+            got.insert(cat.to_string(), count);
+        }
+    }
+
+    let expected: HashMap<&str, i64> = HashMap::from([("A", 36), ("B", 36), ("C", 28)]);
+
+    assert_eq!(
+        got.len(),
+        expected.len(),
+        "GROUP BY must produce exactly one row per distinct category; got {got:?}"
+    );
+    for (cat, count) in expected {
+        assert_eq!(
+            got.get(cat),
+            Some(&count),
+            "COUNT(*) for category {cat} across the grouped scan; got {got:?}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #1587 (E5 — Epic E #1517, read-path audit Wave 3).

Five **independent** constant-factor optimizations in the query engine, each a separate commit with a red→green work-counter test. **Semantics preserved** — parity matrix + 33-table harness green.

| # | Fix | Counter test (RED→GREEN) |
|---|-----|--------------------------|
| 1 | Resolve schema once/query into `Arc<TableSchema>` (was 2–4 deep clones under async RwLock) | `execute_resolves_schema_once_per_query` (2→1) |
| 2 | Skip redundant `Project` for bare-column SELECTs (project rows once) | `bare_column_select_projects_rows_once` (2→1) |
| 3 | Decorate-sort-undecorate ORDER BY — evaluate keys once/row, no per-comparison `Value` clones | `execute_sort_evaluates_keys_once_per_row` (126→64→keys=n) |
| 4 | Reuse optimized plans: prepared memoize (param-tuple tagged) + modern `select_plan_cache` | `prepared_select_reuses_optimized_plan_across_executes` (100→1) |
| 5 | Hash-index GROUP BY lookup — O(1) amortized vs O(groups)/row | `find_or_init_group_is_subquadratic` + equality-semantics guard |

**Guardrails honored:** query-side resolve-once only — schema registry (AJ1/AJ2) untouched; comparator semantics unchanged (Cassandra float/NaN ordering, −0.0/+0.0 preserved); no `unwrap()/expect()` in lib; `clippy --workspace --all-targets --all-features` clean.

**Behavioral delta (Cassandra-aligning, documented):** a bare-column SELECT referencing an absent/null column previously errored ("Column not found") while `SELECT *` returned the row without it; dropping the redundant `Project` aligns bare-column with `SELECT *` and Cassandra (row returned, column null). Dense-row output byte-identical.

**Gate:** all correctness nets PASS (fmt, clippy, compaction-byte-parity, format-compat, smoke, integration, write-tests, cli-tests, node-bindings, tooling, minimal-build, core-tests). The two gate FAILs are **pre-existing, unrelated flakes**: `#1860` (local-only `test_da/wide_table` fixture absent in worktree) and `#1803` (python streaming GIL wall-clock timing). SUMMARY block pasted in the issue.

`file-size`: the four touched files are pre-existing over-threshold (epic #1116/#1135 scope); tests grew them → re-ran with documented `CQLITE_ALLOW_FILE_GROWTH=1`.