### PR TITLE
fix(#1588): deterministic raw-only Snappy decode (no format guessing) + transient-only retry

### DIFF
--- a/cqlite-core/src/storage/sstable/chunk_decompressor.rs
+++ b/cqlite-core/src/storage/sstable/chunk_decompressor.rs
@@ -429,8 +429,28 @@ impl ChunkDecompressor {
         #[cfg(feature = "snappy")]
         {
             use snap::raw::Decoder;
-            let mut decoder = Decoder::new();
 
+            // Decompression-bomb guard (issue #1588): a raw Snappy block advertises
+            // its decompressed length as a leading varint, and `decompress_vec`
+            // pre-allocates that size BEFORE decoding. Reject an over-limit advertised
+            // length up front — a chunk decodes to at most `chunk_length` bytes — so a
+            // crafted block cannot force a huge allocation (mirrors the Deflate/Zstd
+            // chunk guards, which bound by `chunk_size_guard()`).
+            let max_chunk = self.chunk_size_guard();
+            let advertised = snap::raw::decompress_len(compressed_data).map_err(|e| {
+                Error::InvalidFormat(format!(
+                    "Snappy length decode failed for chunk {}: {}",
+                    chunk_index, e
+                ))
+            })?;
+            if advertised as u64 > max_chunk {
+                return Err(Error::InvalidFormat(format!(
+                    "Snappy chunk {} advertises {} bytes, beyond chunk_length {} (decompression-bomb guard)",
+                    chunk_index, advertised, max_chunk
+                )));
+            }
+
+            let mut decoder = Decoder::new();
             match decoder.decompress_vec(compressed_data) {
                 Ok(decompressed) => Ok(decompressed),
                 Err(e) => Err(Error::InvalidFormat(format!(

--- a/cqlite-core/src/storage/sstable/chunk_decompressor.rs
+++ b/cqlite-core/src/storage/sstable/chunk_decompressor.rs
@@ -331,9 +331,9 @@ impl ChunkDecompressor {
     /// streaming Deflate/Zstd decoders against decompression bombs. Falls back to
     /// the 128MB global cap if chunk_length is unset/zero.
     ///
-    /// Only the streaming Deflate/Zstd paths consume this bound, so the method is
+    /// Only the Snappy/Deflate/Zstd paths consume this bound, so the method is
     /// gated to match its callers and stay dead-code-free under minimal builds.
-    #[cfg(any(feature = "deflate", feature = "zstd"))]
+    #[cfg(any(feature = "snappy", feature = "deflate", feature = "zstd"))]
     fn chunk_size_guard(&self) -> u64 {
         match self.compression_info.chunk_length {
             0 => 128 * 1024 * 1024,

--- a/cqlite-core/src/storage/sstable/compression.rs
+++ b/cqlite-core/src/storage/sstable/compression.rs
@@ -993,10 +993,14 @@ mod tests {
 
         let compression = Compression::new(CompressionAlgorithm::Snappy).unwrap();
         let got = compression.decompress(&adversarial).ok();
-        assert_ne!(
-            got,
-            Some(p_wrong),
-            "strict raw decode must not return the framed-guess bytes (no-heuristics, #1588)"
+        // Strict raw decode must not merely differ from the framed guess — it must
+        // FAIL (typed error) rather than silently produce any bytes: the leading
+        // 4-byte pseudo-header parses as a malformed raw Snappy stream (a
+        // zero-length literal with trailing data), which the raw decoder rejects.
+        assert!(
+            got.is_none(),
+            "strict raw decode must ERROR on the ambiguous chunk, not return bytes \
+             (no-heuristics, #1588); got {got:?}"
         );
     }
 

--- a/cqlite-core/src/storage/sstable/compression.rs
+++ b/cqlite-core/src/storage/sstable/compression.rs
@@ -588,44 +588,45 @@ impl StreamingDecompressor {
     ) -> Result<()> {
         #[cfg(feature = "snappy")]
         {
-            use snap::read::FrameDecoder;
             use std::io::BufReader;
 
-            let buf_reader = BufReader::new(reader);
-            let mut decoder = FrameDecoder::new(buf_reader);
-            let mut chunk_buffer = vec![0u8; self.config.chunk_size];
+            // Cassandra 5.0's `SnappyCompressor` emits a RAW Snappy block (no
+            // stream framing, no length prefix) — the SAME single authoritative
+            // format that `compress` and the chunk `decompress` path use
+            // (no-heuristics, issue #1588; this closes #1862). The previous
+            // `snap::read::FrameDecoder` decoded the DIFFERENT *framed* Snappy
+            // format, so the public streaming decompressor could not read bytes
+            // produced by `CompressionAlgorithm::Snappy`. Raw Snappy is not
+            // self-delimiting and carries no length prefix, so the whole
+            // compressed block must be read before it can be decoded — decode it
+            // through the same `snappy_decompress_raw` helper as the chunk path.
+            let mut buf_reader = BufReader::new(reader);
+            let mut compressed = Vec::new();
+            buf_reader.read_to_end(&mut compressed).map_err(|e| {
+                Error::storage(format!("Failed to read Snappy compressed data: {}", e))
+            })?;
+            self.bytes_processed += compressed.len();
 
-            loop {
-                let bytes_read = decoder.read(&mut chunk_buffer).map_err(|e| {
-                    Error::storage(format!("Snappy streaming decompression failed: {}", e))
-                })?;
+            let decompressed = snappy_decompress_raw(&compressed, &mut 0)?;
 
-                if bytes_read == 0 {
-                    break; // EOF
-                }
-
-                // Check memory limits
-                if output.len() + bytes_read > memory_limit {
-                    return Err(Error::storage(format!(
-                        "Memory limit exceeded during Snappy decompression: {} bytes (limit: {} bytes)",
-                        output.len() + bytes_read,
-                        memory_limit
-                    )));
-                }
-
-                output.extend_from_slice(&chunk_buffer[..bytes_read]);
-                self.bytes_processed += bytes_read;
-
-                // Yield control for large operations
-                if self.bytes_processed % (4 * 1024 * 1024) == 0 {
-                    tokio::task::yield_now().await;
-                }
+            if output.len() + decompressed.len() > memory_limit {
+                return Err(Error::storage(format!(
+                    "Memory limit exceeded during Snappy decompression: {} bytes (limit: {} bytes)",
+                    output.len() + decompressed.len(),
+                    memory_limit
+                )));
             }
+
+            output.extend_from_slice(&decompressed);
+            // Yield once after a potentially large decode so we do not starve the
+            // runtime (the read+decode above is a single bounded operation).
+            tokio::task::yield_now().await;
 
             Ok(())
         }
         #[cfg(not(feature = "snappy"))]
         {
+            let _ = (reader, output, memory_limit);
             Err(Error::storage(
                 "Snappy compression not available".to_string(),
             ))
@@ -1024,6 +1025,34 @@ mod tests {
 
         let decompressed = compression.decompress(&compressed).unwrap();
         assert_eq!(decompressed, data);
+    }
+
+    /// Finding 2 (issue #1588; closes #1862): the public streaming Snappy
+    /// decompressor must decode the SAME single authoritative raw Snappy format
+    /// that `compress` (and the chunk `decompress` path) use. Previously it used
+    /// `snap::read::FrameDecoder` (the DIFFERENT framed format), so bytes produced
+    /// by `CompressionAlgorithm::Snappy` were unreadable through streaming.
+    /// Round-trip: compress raw -> streaming-decompress -> byte-identical.
+    #[cfg(feature = "snappy")]
+    #[tokio::test]
+    async fn test_snappy_streaming_roundtrip_raw() {
+        use std::io::Cursor;
+        let compression = Compression::new(CompressionAlgorithm::Snappy).unwrap();
+        let data =
+            b"streaming raw snappy round-trip payload for issue 1862. ".repeat(64);
+
+        let compressed = compression.compress(&data).unwrap();
+
+        let mut decompressor =
+            compression.create_streaming_decompressor(ChunkedDecompressionConfig::default());
+        let out = decompressor
+            .decompress_streaming(Cursor::new(compressed), Some(data.len()))
+            .await
+            .expect("streaming decode of raw Snappy must succeed");
+        assert_eq!(
+            out, data,
+            "streaming Snappy must decode raw compress() output byte-for-byte"
+        );
     }
 
     /// A legitimate RAW Snappy chunk decodes to the known-good bytes in EXACTLY

--- a/cqlite-core/src/storage/sstable/compression.rs
+++ b/cqlite-core/src/storage/sstable/compression.rs
@@ -975,6 +975,37 @@ mod tests {
     // Note: Test methods temporarily disabled due to compilation issues
     // The functionality is tested via integration tests
 
+    /// Adversarial oracle (issue #1588, decision #14): a chunk whose leading 4
+    /// bytes ALSO parse as a plausible framed big-endian length header, followed
+    /// by a valid RAW-snappy body of exactly that many output bytes.
+    ///
+    /// Under the (deleted) framed-then-raw guessing, `decompress` read the 4-byte
+    /// BE prefix `S`, decoded `data[4..]` as raw snappy to `P_wrong` (whose length
+    /// equals `S`), and RETURNED those bytes — silently wrong. The authoritative
+    /// Cassandra 5.0 format for a `SnappyCompressor` chunk is RAW snappy with NO
+    /// length prefix, so strict raw decoding of the WHOLE chunk must NOT return
+    /// `P_wrong` (it rejects the malformed leading zero-varint stream). This is the
+    /// no-heuristics enforcement: decode exactly one format determined by metadata.
+    #[cfg(feature = "snappy")]
+    #[test]
+    fn test_snappy_decode_is_strict_raw_only_no_format_guessing() {
+        use snap::raw::Encoder;
+        let p_wrong = b"WRONG-framed-decode-abcdefghijklmnopqrstuvwxyz".to_vec();
+        let s = p_wrong.len() as u32;
+        let mut enc = Encoder::new();
+        let inner = enc.compress_vec(&p_wrong).unwrap(); // valid raw snappy -> p_wrong
+        let mut adversarial = s.to_be_bytes().to_vec(); // plausible framed BE header
+        adversarial.extend_from_slice(&inner);
+
+        let compression = Compression::new(CompressionAlgorithm::Snappy).unwrap();
+        let got = compression.decompress(&adversarial).ok();
+        assert_ne!(
+            got,
+            Some(p_wrong),
+            "strict raw decode must not return the framed-guess bytes (no-heuristics, #1588)"
+        );
+    }
+
     #[cfg(feature = "snappy")]
     #[test]
     fn test_snappy_compression_cassandra_format() {

--- a/cqlite-core/src/storage/sstable/compression.rs
+++ b/cqlite-core/src/storage/sstable/compression.rs
@@ -141,10 +141,28 @@ fn validate_decompression_size(uncompressed_size: usize) -> Result<()> {
 fn snappy_decompress_raw(data: &[u8], decode_attempts: &mut usize) -> Result<Vec<u8>> {
     use snap::raw::Decoder;
     *decode_attempts += 1;
+
+    // CENTRALIZED bomb guard (issue #1588): a raw Snappy block carries its
+    // decompressed length as a leading varint. Inspect it FIRST and reject an
+    // over-limit block WITHOUT calling `decompress_vec` — `decompress_vec`
+    // pre-allocates `decompress_len` bytes up front, so an adversarial block
+    // declaring a huge size would allocate before any post-decode guard runs.
+    // This single choke point protects EVERY caller (chunk decode + streaming).
+    let advertised = snap::raw::decompress_len(data)
+        .map_err(|e| Error::storage(format!("Snappy (raw) length decode failed: {}", e)))?;
+    if advertised > MAX_DECOMPRESSED_SIZE {
+        return Err(Error::storage(format!(
+            "Decompression bomb protection: advertised size {} exceeds limit {} (128MB)",
+            advertised, MAX_DECOMPRESSED_SIZE
+        )));
+    }
+
     let mut decoder = Decoder::new();
     let decompressed = decoder
         .decompress_vec(data)
         .map_err(|e| Error::storage(format!("Snappy (raw) decompression failed: {}", e)))?;
+    // Belt-and-suspenders: the advertised length is attacker-controlled, so
+    // re-check the ACTUAL decoded size against the hard cap.
     if decompressed.len() > MAX_DECOMPRESSED_SIZE {
         return Err(Error::storage(format!(
             "Decompression bomb protection: decompressed size {} exceeds limit {} (128MB)",
@@ -637,14 +655,20 @@ impl StreamingDecompressor {
             self.bytes_processed += compressed.len();
 
             // Pre-allocation bomb guard: reject before allocating the output buffer.
+            // Bound by the MINIMUM of every relevant limit — the streaming memory
+            // budget AND the configured output cap (issue #1588). A `max_memory_mb`
+            // set above `max_output_size` must not be allowed to allocate past the
+            // intended output cap. `snappy_decompress_raw` additionally enforces the
+            // hard `MAX_DECOMPRESSED_SIZE` ceiling at the shared choke point.
             let advertised = snap::raw::decompress_len(&compressed).map_err(|e| {
                 Error::storage(format!("Snappy (raw) length decode failed: {}", e))
             })?;
+            let effective_limit = memory_limit.min(self.config.max_output_size);
             let projected = output.len().checked_add(advertised);
-            if projected.is_none_or(|total| total > memory_limit) {
+            if projected.is_none_or(|total| total > effective_limit) {
                 return Err(Error::storage(format!(
                     "Decompression bomb protection: advertised Snappy size {} exceeds limit {} bytes",
-                    advertised, memory_limit
+                    advertised, effective_limit
                 )));
             }
 
@@ -1149,6 +1173,37 @@ mod tests {
         );
     }
 
+    /// SECURITY (issue #1588): when `max_memory_mb` is configured ABOVE
+    /// `max_output_size`, the advertised-size guard must still bound to the
+    /// MINIMUM of the two (the output cap), so a block that fits the memory
+    /// budget but exceeds the output cap is rejected before allocating.
+    #[cfg(feature = "snappy")]
+    #[tokio::test]
+    async fn test_snappy_streaming_output_cap_bounds_below_memory_limit() {
+        use std::io::Cursor;
+
+        // 100MB memory budget, but only a 1MB output cap. Advertise 50MB: within
+        // the memory budget yet over the output cap -> must be rejected.
+        let config = ChunkedDecompressionConfig {
+            max_memory_mb: 100,
+            chunk_size: 1024,
+            max_output_size: 1024 * 1024,
+        };
+        let mut input = snappy_len_prefix(50 * 1024 * 1024);
+        input.push(0x00); // stub tag byte; guard fires before any decode
+
+        let compression = Compression::new(CompressionAlgorithm::Snappy).unwrap();
+        let mut decompressor = compression.create_streaming_decompressor(config);
+        let err = decompressor
+            .decompress_streaming(Cursor::new(input), None)
+            .await
+            .expect_err("advertised size over output cap must be rejected");
+        assert!(
+            err.to_string().contains("Decompression bomb protection"),
+            "expected output-cap-bounded bomb error, got: {err}"
+        );
+    }
+
     /// SECURITY (issue #1588): a COMPRESSED input larger than the max Snappy
     /// encoding of the memory budget cannot legitimately decode in-budget, so the
     /// read is capped and the oversized input errors without buffering it all.
@@ -1196,6 +1251,35 @@ mod tests {
             attempts, 1,
             "exactly one decode attempt (no format guessing)"
         );
+    }
+
+    /// SECURITY (issue #1588): the SHARED `snappy_decompress_raw` helper — the
+    /// choke point used by the CHUNK (non-streaming) decode path — must reject a
+    /// block whose ADVERTISED decompressed length exceeds `MAX_DECOMPRESSED_SIZE`
+    /// WITHOUT allocating (i.e. before `decompress_vec` pre-allocates that size).
+    /// This proves the guard lives at the helper, not only in the streaming caller.
+    #[cfg(feature = "snappy")]
+    #[test]
+    fn test_snappy_raw_helper_advertised_len_bomb_rejected_no_alloc() {
+        // Craft a tiny raw block: a varint advertising 200MB (> 128MB cap) plus a
+        // stub tag byte. The length guard fires before any output allocation.
+        let mut chunk = snappy_len_prefix(200 * 1024 * 1024);
+        chunk.push(0x00);
+
+        let mut attempts = 0usize;
+        let err = super::snappy_decompress_raw(&chunk, &mut attempts)
+            .expect_err("over-limit advertised length must be rejected at the helper");
+        assert!(
+            err.to_string().contains("Decompression bomb protection"),
+            "expected typed decompression-bomb error, got: {err}"
+        );
+        assert!(
+            err.to_string().contains("advertised size"),
+            "guard must fire on the ADVERTISED length before decode/alloc, got: {err}"
+        );
+        // The decode attempt is counted, but the rejection happens before the
+        // `decompress_vec` allocation of the advertised 200MB.
+        assert_eq!(attempts, 1, "helper is entered exactly once");
     }
 
     #[cfg(feature = "deflate")]

--- a/cqlite-core/src/storage/sstable/compression.rs
+++ b/cqlite-core/src/storage/sstable/compression.rs
@@ -1037,8 +1037,14 @@ mod tests {
 
         let mut attempts = 0usize;
         let out = super::snappy_decompress_raw(&chunk, &mut attempts).unwrap();
-        assert_eq!(out, good, "raw decode is byte-identical to the known-good input");
-        assert_eq!(attempts, 1, "exactly one decode attempt (no format guessing)");
+        assert_eq!(
+            out, good,
+            "raw decode is byte-identical to the known-good input"
+        );
+        assert_eq!(
+            attempts, 1,
+            "exactly one decode attempt (no format guessing)"
+        );
     }
 
     #[cfg(feature = "deflate")]

--- a/cqlite-core/src/storage/sstable/compression.rs
+++ b/cqlite-core/src/storage/sstable/compression.rs
@@ -127,6 +127,34 @@ fn validate_decompression_size(uncompressed_size: usize) -> Result<()> {
     Ok(())
 }
 
+/// Decode a RAW Snappy block (Cassandra 5.0 `SnappyCompressor`: no length prefix)
+/// in EXACTLY one attempt.
+///
+/// The authoritative CompressionInfo.db algorithm determines the single format —
+/// no framed-then-raw guessing (no-heuristics mandate #28, issue #1588). A guess
+/// could silently mis-decode an adversarial chunk to wrong bytes; strict raw
+/// decoding surfaces a typed error instead.
+///
+/// `decode_attempts` is incremented once per decode call. Production passes a
+/// throwaway `&mut 0`; tests thread a real counter to assert a single attempt.
+#[cfg(feature = "snappy")]
+fn snappy_decompress_raw(data: &[u8], decode_attempts: &mut usize) -> Result<Vec<u8>> {
+    use snap::raw::Decoder;
+    *decode_attempts += 1;
+    let mut decoder = Decoder::new();
+    let decompressed = decoder
+        .decompress_vec(data)
+        .map_err(|e| Error::storage(format!("Snappy (raw) decompression failed: {}", e)))?;
+    if decompressed.len() > MAX_DECOMPRESSED_SIZE {
+        return Err(Error::storage(format!(
+            "Decompression bomb protection: decompressed size {} exceeds limit {} (128MB)",
+            decompressed.len(),
+            MAX_DECOMPRESSED_SIZE
+        )));
+    }
+    Ok(decompressed)
+}
+
 /// Compression handler
 pub struct Compression {
     algorithm: CompressionAlgorithm,
@@ -162,17 +190,15 @@ impl Compression {
                 {
                     use snap::raw::Encoder;
 
-                    // Use Cassandra-compatible Snappy parameters
+                    // Cassandra 5.0's SnappyCompressor writes a RAW Snappy block with NO
+                    // length prefix (see writer::compressed_data_writer::SnappyCompressor
+                    // and org.apache.cassandra.io.compress.SnappyCompressor). Emit raw so
+                    // it round-trips through the strict raw decode path below (#1588). A
+                    // 4-byte size prefix was NEVER a Cassandra-compatible format.
                     let mut encoder = Encoder::new();
-                    let compressed = encoder
+                    encoder
                         .compress_vec(data)
-                        .map_err(|e| Error::storage(format!("Snappy compression failed: {}", e)))?;
-
-                    // Prepend uncompressed size (4 bytes, big-endian) for Cassandra compatibility
-                    let mut result = Vec::with_capacity(4 + compressed.len());
-                    result.extend_from_slice(&(data.len() as u32).to_be_bytes());
-                    result.extend_from_slice(&compressed);
-                    Ok(result)
+                        .map_err(|e| Error::storage(format!("Snappy compression failed: {}", e)))
                 }
                 #[cfg(not(feature = "snappy"))]
                 {
@@ -279,45 +305,13 @@ impl Compression {
             CompressionAlgorithm::Snappy => {
                 #[cfg(feature = "snappy")]
                 {
-                    use snap::raw::Decoder;
-
-                    // Try two formats:
-                    // 1. With 4-byte size prefix (legacy Cassandra format)
-                    // 2. Raw Snappy without prefix (Cassandra 5.0 nb format)
-
-                    let mut decoder = Decoder::new();
-
-                    // First, try with 4-byte prefix if data is long enough
-                    if data.len() >= 4 {
-                        let uncompressed_size =
-                            u32::from_be_bytes([data[0], data[1], data[2], data[3]]) as usize;
-
-                        // Only try prefixed format if size is reasonable (not a decompression bomb)
-                        // If size is unreasonable, it's likely raw Snappy without a prefix
-                        if uncompressed_size > 0 && uncompressed_size <= MAX_DECOMPRESSED_SIZE {
-                            let compressed_data = &data[4..];
-                            if let Ok(decompressed) = decoder.decompress_vec(compressed_data) {
-                                if decompressed.len() == uncompressed_size {
-                                    return Ok(decompressed);
-                                }
-                            }
-                        }
-                    }
-
-                    // Fall back to raw Snappy (no prefix) - Cassandra 5.0 nb format
-                    let decompressed = decoder.decompress_vec(data).map_err(|e| {
-                        Error::storage(format!("Snappy decompression failed (both formats): {}", e))
-                    })?;
-
-                    // Validate decompressed size
-                    if decompressed.len() > MAX_DECOMPRESSED_SIZE {
-                        return Err(Error::storage(format!(
-                            "Decompression bomb protection: decompressed size {} exceeds limit {} (128MB)",
-                            decompressed.len(), MAX_DECOMPRESSED_SIZE
-                        )));
-                    }
-
-                    Ok(decompressed)
+                    // Decode EXACTLY one format (raw Snappy), determined by the
+                    // authoritative CompressionInfo.db algorithm — never by trying
+                    // framed-then-raw and keeping whichever "succeeds" (no-heuristics
+                    // mandate #28, issue #1588). The framed-guess could silently return
+                    // wrong bytes for an adversarial chunk; strict raw decoding rejects
+                    // it. `&mut 0` discards the (test-only) attempt counter.
+                    snappy_decompress_raw(data, &mut 0)
                 }
                 #[cfg(not(feature = "snappy"))]
                 {
@@ -1015,14 +1009,32 @@ mod tests {
 
         let compressed = compression.compress(&data).unwrap();
 
-        // Verify format: 4-byte size prefix + compressed data
-        assert!(compressed.len() >= 4);
-        let size_prefix =
-            u32::from_be_bytes([compressed[0], compressed[1], compressed[2], compressed[3]]);
-        assert_eq!(size_prefix, data.len() as u32);
+        // Cassandra 5.0 SnappyCompressor emits a RAW Snappy block with NO length
+        // prefix (#1588). The compressed bytes are exactly what a raw Snappy
+        // decoder consumes; there is no 4-byte big-endian size header.
+        let raw_roundtrip = {
+            use snap::raw::Decoder;
+            Decoder::new().decompress_vec(&compressed).unwrap()
+        };
+        assert_eq!(raw_roundtrip, data, "compress() output must be raw Snappy");
 
         let decompressed = compression.decompress(&compressed).unwrap();
         assert_eq!(decompressed, data);
+    }
+
+    /// A legitimate RAW Snappy chunk decodes to the known-good bytes in EXACTLY
+    /// one decode attempt (issue #1588 decision #14: single-attempt + byte-identity).
+    #[cfg(feature = "snappy")]
+    #[test]
+    fn test_snappy_decode_single_attempt_and_byte_identical() {
+        use snap::raw::Encoder;
+        let good = b"the quick brown fox jumps over the lazy dog. ".repeat(8);
+        let chunk = Encoder::new().compress_vec(&good).unwrap();
+
+        let mut attempts = 0usize;
+        let out = super::snappy_decompress_raw(&chunk, &mut attempts).unwrap();
+        assert_eq!(out, good, "raw decode is byte-identical to the known-good input");
+        assert_eq!(attempts, 1, "exactly one decode attempt (no format guessing)");
     }
 
     #[cfg(feature = "deflate")]

--- a/cqlite-core/src/storage/sstable/compression.rs
+++ b/cqlite-core/src/storage/sstable/compression.rs
@@ -600,13 +600,57 @@ impl StreamingDecompressor {
             // self-delimiting and carries no length prefix, so the whole
             // compressed block must be read before it can be decoded — decode it
             // through the same `snappy_decompress_raw` helper as the chunk path.
-            let mut buf_reader = BufReader::new(reader);
+            //
+            // SECURITY (issue #1588): bound BOTH allocations before they happen so
+            // a huge/malicious reader cannot exceed the streaming memory budget or
+            // OOM before the guards run:
+            //  1. Cap the COMPRESSED read. Any Snappy block that legitimately
+            //     decodes to <= `memory_limit` bytes cannot be larger than the
+            //     maximum Snappy encoding of `memory_limit` bytes
+            //     (`snap::raw::max_compress_len`). A larger input cannot produce
+            //     in-budget output, so we refuse to buffer it (read `cap + 1` via
+            //     `take` to detect overrun without reading unbounded input).
+            //  2. Reject a decompression bomb using the advertised uncompressed
+            //     length (`snap::raw::decompress_len`, the raw block's varint
+            //     prefix) BEFORE allocating the output buffer.
+            let max_compressed = snap::raw::max_compress_len(memory_limit);
+            if max_compressed == 0 {
+                return Err(Error::storage(format!(
+                    "Snappy streaming memory limit {} too large to bound compressed input",
+                    memory_limit
+                )));
+            }
+            let read_cap = max_compressed.checked_add(1).ok_or_else(|| {
+                Error::storage("Snappy compressed read cap overflow".to_string())
+            })?;
+            let mut buf_reader = BufReader::new(reader).take(read_cap as u64);
             let mut compressed = Vec::new();
             buf_reader.read_to_end(&mut compressed).map_err(|e| {
                 Error::storage(format!("Failed to read Snappy compressed data: {}", e))
             })?;
+            if compressed.len() > max_compressed {
+                return Err(Error::storage(format!(
+                    "Snappy compressed input exceeds bound {} bytes (memory limit: {} bytes)",
+                    max_compressed, memory_limit
+                )));
+            }
             self.bytes_processed += compressed.len();
 
+            // Pre-allocation bomb guard: reject before allocating the output buffer.
+            let advertised = snap::raw::decompress_len(&compressed).map_err(|e| {
+                Error::storage(format!("Snappy (raw) length decode failed: {}", e))
+            })?;
+            let projected = output.len().checked_add(advertised);
+            if projected.is_none_or(|total| total > memory_limit) {
+                return Err(Error::storage(format!(
+                    "Decompression bomb protection: advertised Snappy size {} exceeds limit {} bytes",
+                    advertised, memory_limit
+                )));
+            }
+
+            // Belt-and-suspenders: enforce against the ACTUAL decoded size (the
+            // advertised length is attacker-controlled); `snappy_decompress_raw`
+            // additionally caps at MAX_DECOMPRESSED_SIZE.
             let decompressed = snappy_decompress_raw(&compressed, &mut 0)?;
 
             if output.len() + decompressed.len() > memory_limit {
@@ -1052,6 +1096,84 @@ mod tests {
         assert_eq!(
             out, data,
             "streaming Snappy must decode raw compress() output byte-for-byte"
+        );
+    }
+
+    /// Encode a Snappy raw-block length prefix (LEB128 varint) for `n`.
+    #[cfg(feature = "snappy")]
+    fn snappy_len_prefix(mut n: u64) -> Vec<u8> {
+        let mut out = Vec::new();
+        loop {
+            let mut b = (n & 0x7f) as u8;
+            n >>= 7;
+            if n != 0 {
+                b |= 0x80;
+            }
+            out.push(b);
+            if n == 0 {
+                break;
+            }
+        }
+        out
+    }
+
+    /// SECURITY (issue #1588): a streaming Snappy block whose ADVERTISED
+    /// uncompressed length exceeds the memory budget is rejected BEFORE the
+    /// output buffer is allocated (no OOM). The crafted input is tiny (only a
+    /// length prefix + a stub), so it passes the compressed read cap and reaches
+    /// the pre-allocation length guard.
+    #[cfg(feature = "snappy")]
+    #[tokio::test]
+    async fn test_snappy_streaming_advertised_len_bomb_rejected() {
+        use std::io::Cursor;
+
+        // 1MB budget; advertise 100MB uncompressed.
+        let config = ChunkedDecompressionConfig {
+            max_memory_mb: 1,
+            chunk_size: 1024,
+            max_output_size: 128 * 1024 * 1024,
+        };
+        let mut input = snappy_len_prefix(100 * 1024 * 1024);
+        input.push(0x00); // stub tag byte; guard fires before any decode
+
+        let compression = Compression::new(CompressionAlgorithm::Snappy).unwrap();
+        let mut decompressor = compression.create_streaming_decompressor(config);
+        // `None` expected_size so the caller-side pre-check does not short-circuit.
+        let err = decompressor
+            .decompress_streaming(Cursor::new(input), None)
+            .await
+            .expect_err("advertised-size bomb must be rejected");
+        assert!(
+            err.to_string().contains("Decompression bomb protection"),
+            "expected pre-allocation bomb error, got: {err}"
+        );
+    }
+
+    /// SECURITY (issue #1588): a COMPRESSED input larger than the max Snappy
+    /// encoding of the memory budget cannot legitimately decode in-budget, so the
+    /// read is capped and the oversized input errors without buffering it all.
+    #[cfg(feature = "snappy")]
+    #[tokio::test]
+    async fn test_snappy_streaming_oversized_compressed_rejected() {
+        use std::io::Cursor;
+
+        let config = ChunkedDecompressionConfig {
+            max_memory_mb: 1,
+            chunk_size: 1024,
+            max_output_size: 128 * 1024 * 1024,
+        };
+        // 4MB of bytes, well past max_compress_len(1MB) (~1.2MB).
+        let oversized = vec![0u8; 4 * 1024 * 1024];
+
+        let compression = Compression::new(CompressionAlgorithm::Snappy).unwrap();
+        let mut decompressor = compression.create_streaming_decompressor(config);
+        let err = decompressor
+            .decompress_streaming(Cursor::new(oversized), None)
+            .await
+            .expect_err("over-cap compressed input must be rejected");
+        assert!(
+            err.to_string().contains("Snappy compressed input exceeds bound"),
+            "expected compressed read-cap error, got: {err}"
         );
     }
 

--- a/cqlite-core/src/storage/sstable/compression.rs
+++ b/cqlite-core/src/storage/sstable/compression.rs
@@ -638,9 +638,9 @@ impl StreamingDecompressor {
                     memory_limit
                 )));
             }
-            let read_cap = max_compressed.checked_add(1).ok_or_else(|| {
-                Error::storage("Snappy compressed read cap overflow".to_string())
-            })?;
+            let read_cap = max_compressed
+                .checked_add(1)
+                .ok_or_else(|| Error::storage("Snappy compressed read cap overflow".to_string()))?;
             let mut buf_reader = BufReader::new(reader).take(read_cap as u64);
             let mut compressed = Vec::new();
             buf_reader.read_to_end(&mut compressed).map_err(|e| {
@@ -660,9 +660,8 @@ impl StreamingDecompressor {
             // set above `max_output_size` must not be allowed to allocate past the
             // intended output cap. `snappy_decompress_raw` additionally enforces the
             // hard `MAX_DECOMPRESSED_SIZE` ceiling at the shared choke point.
-            let advertised = snap::raw::decompress_len(&compressed).map_err(|e| {
-                Error::storage(format!("Snappy (raw) length decode failed: {}", e))
-            })?;
+            let advertised = snap::raw::decompress_len(&compressed)
+                .map_err(|e| Error::storage(format!("Snappy (raw) length decode failed: {}", e)))?;
             let effective_limit = memory_limit.min(self.config.max_output_size);
             let projected = output.len().checked_add(advertised);
             if projected.is_none_or(|total| total > effective_limit) {
@@ -1106,8 +1105,7 @@ mod tests {
     async fn test_snappy_streaming_roundtrip_raw() {
         use std::io::Cursor;
         let compression = Compression::new(CompressionAlgorithm::Snappy).unwrap();
-        let data =
-            b"streaming raw snappy round-trip payload for issue 1862. ".repeat(64);
+        let data = b"streaming raw snappy round-trip payload for issue 1862. ".repeat(64);
 
         let compressed = compression.compress(&data).unwrap();
 
@@ -1227,7 +1225,8 @@ mod tests {
             .await
             .expect_err("over-cap compressed input must be rejected");
         assert!(
-            err.to_string().contains("Snappy compressed input exceeds bound"),
+            err.to_string()
+                .contains("Snappy compressed input exceeds bound"),
             "expected compressed read-cap error, got: {err}"
         );
     }

--- a/cqlite-core/src/storage/sstable/reader/block_io.rs
+++ b/cqlite-core/src/storage/sstable/reader/block_io.rs
@@ -1219,151 +1219,6 @@ mod tests {
         (dir, Arc::new(Mutex::new(BlockSource::buffered(file))))
     }
 
-    // ========================================================================
-    // Retry policy: transient-only, single retry, re-seek to original offset
-    // (issue #1588)
-    // ========================================================================
-
-    use std::sync::atomic::Ordering;
-
-    fn transient_io() -> Error {
-        Error::Io(std::io::Error::new(
-            std::io::ErrorKind::Interrupted,
-            "simulated EINTR",
-        ))
-    }
-
-    /// A transient (EINTR-class) fault triggers EXACTLY one retry, and that retry
-    /// re-reads the SAME (original) offset — proving the source is re-seeked back
-    /// after the first attempt advanced the position. This is the moved-position
-    /// bug: without the re-seek the second attempt would observe offset 8.
-    #[tokio::test]
-    async fn retry_transient_reseeks_to_original_offset() {
-        let (_dir, file) = blocksource_from(&[0u8; 16]).await;
-        let calls = Arc::new(AtomicUsize::new(0));
-        let seen = Arc::new(Mutex::new(Vec::<u64>::new()));
-
-        let f = file.clone();
-        let c = calls.clone();
-        let s = seen.clone();
-        let attempt = move || {
-            let f = f.clone();
-            let c = c.clone();
-            let s = s.clone();
-            async move {
-                let n = c.fetch_add(1, Ordering::Relaxed);
-                let pos = { f.lock().await.stream_position().await.unwrap() };
-                s.lock().await.push(pos);
-                if n == 0 {
-                    // Simulate a partial read that advanced the position, then a
-                    // transient fault mid-block.
-                    {
-                        let mut g = f.lock().await;
-                        g.seek(std::io::SeekFrom::Start(8)).await.unwrap();
-                    }
-                    Err(transient_io())
-                } else {
-                    Ok::<u32, Error>(99)
-                }
-            }
-        };
-
-        let out = retry_transient_once(&file, attempt).await.unwrap();
-        assert_eq!(out, 99);
-        assert_eq!(
-            calls.load(Ordering::Relaxed),
-            2,
-            "exactly one transient retry (two attempts total)"
-        );
-        assert_eq!(
-            seen.lock().await.clone(),
-            vec![0, 0],
-            "retry must re-read the SAME original offset, not the moved position"
-        );
-    }
-
-    /// A deterministic corruption error is NOT retried and does NOT sleep: exactly
-    /// one attempt, returns fast. The attempt counter is the robust proof (no
-    /// wall-clock race); the elapsed bound is a generous secondary guard.
-    #[tokio::test]
-    async fn retry_does_not_retry_or_sleep_on_deterministic_corruption() {
-        let (_dir, file) = blocksource_from(&[0u8; 16]).await;
-        let calls = Arc::new(AtomicUsize::new(0));
-
-        let c = calls.clone();
-        let attempt = move || {
-            let c = c.clone();
-            async move {
-                c.fetch_add(1, Ordering::Relaxed);
-                Err::<u32, Error>(Error::corruption("CRC32 mismatch"))
-            }
-        };
-
-        let start = std::time::Instant::now();
-        let err = retry_transient_once(&file, attempt).await.unwrap_err();
-        let elapsed = start.elapsed();
-
-        assert!(matches!(err, Error::Corruption(_)), "typed corruption: {err}");
-        assert_eq!(
-            calls.load(Ordering::Relaxed),
-            1,
-            "corruption is deterministic — never retried"
-        );
-        assert!(
-            elapsed < std::time::Duration::from_millis(500),
-            "no sleep on the deterministic-error path: {elapsed:?}"
-        );
-    }
-
-    /// A NON-transient I/O error (e.g. NotFound) is not retried either: only
-    /// EINTR-class transient faults qualify, unlike the broad `is_recoverable`
-    /// classification which treats every `Io` as retryable.
-    #[tokio::test]
-    async fn retry_does_not_retry_non_transient_io() {
-        let (_dir, file) = blocksource_from(&[0u8; 16]).await;
-        let calls = Arc::new(AtomicUsize::new(0));
-
-        let c = calls.clone();
-        let attempt = move || {
-            let c = c.clone();
-            async move {
-                c.fetch_add(1, Ordering::Relaxed);
-                Err::<u32, Error>(Error::Io(std::io::Error::new(
-                    std::io::ErrorKind::NotFound,
-                    "gone",
-                )))
-            }
-        };
-
-        let err = retry_transient_once(&file, attempt).await.unwrap_err();
-        assert!(matches!(err, Error::Io(_)));
-        assert_eq!(
-            calls.load(Ordering::Relaxed),
-            1,
-            "non-transient I/O (NotFound) is not retried"
-        );
-    }
-
-    #[test]
-    fn is_transient_io_classifies_only_eintr_class() {
-        assert!(is_transient_io(&transient_io()));
-        assert!(is_transient_io(&Error::Io(std::io::Error::new(
-            std::io::ErrorKind::WouldBlock,
-            "eagain"
-        ))));
-        assert!(is_transient_io(&Error::Io(std::io::Error::new(
-            std::io::ErrorKind::TimedOut,
-            "etimedout"
-        ))));
-        // Deterministic / non-transient are NOT transient.
-        assert!(!is_transient_io(&Error::corruption("crc")));
-        assert!(!is_transient_io(&Error::invalid_format("bad")));
-        assert!(!is_transient_io(&Error::Io(std::io::Error::new(
-            std::io::ErrorKind::NotFound,
-            "nf"
-        ))));
-    }
-
     #[tokio::test]
     async fn verify_uncompressed_chunks_clean_multichunk_passes() {
         // Chunk size must be >= MIN_CRC_CHUNK_SIZE (4096, issue #1396 floor) so
@@ -1981,3 +1836,11 @@ mod tests {
         }
     }
 }
+
+// Retry-policy guards (issue #1588) live in a sibling file to keep this source
+// file under the campsite-rule size limit (issue #1135). `use super::*` in the
+// included module resolves to this module's private items
+// (`retry_transient_once`, `is_transient_io`).
+#[cfg(test)]
+#[path = "block_io_retry_tests.rs"]
+mod retry_tests;

--- a/cqlite-core/src/storage/sstable/reader/block_io.rs
+++ b/cqlite-core/src/storage/sstable/reader/block_io.rs
@@ -52,35 +52,8 @@ pub(crate) async fn read_next_block(
     current_chunk_index: &std::sync::atomic::AtomicUsize,
     header_offset: u64,
 ) -> Result<Option<Vec<u8>>> {
-    read_next_block_with_retry(
-        file,
-        cassandra_version,
-        config,
-        compression_info,
-        crc_reader,
-        current_chunk_index,
-        header_offset,
-        3,
-    )
-    .await
-}
-
-/// Read block with retry logic for handling transient I/O errors
-#[allow(clippy::too_many_arguments)]
-async fn read_next_block_with_retry(
-    file: &Arc<Mutex<BlockSource>>,
-    cassandra_version: &crate::parser::header::CassandraVersion,
-    config: &SSTableReaderConfig,
-    compression_info: &Option<Arc<crate::storage::sstable::compression_info::CompressionInfo>>,
-    crc_reader: Option<&CrcDb>,
-    current_chunk_index: &std::sync::atomic::AtomicUsize,
-    header_offset: u64,
-    max_retries: usize,
-) -> Result<Option<Vec<u8>>> {
-    let mut retry_count = 0;
-
-    loop {
-        match read_next_block_impl(
+    retry_transient_once(file, || {
+        read_next_block_impl(
             file,
             cassandra_version,
             config,
@@ -89,38 +62,76 @@ async fn read_next_block_with_retry(
             current_chunk_index,
             header_offset,
         )
-        .await
-        {
-            Ok(result) => return Ok(result),
-            Err(e) => {
-                // Never retry a non-recoverable error (issue #1396). Retries exist
-                // for TRANSIENT I/O faults; a CRC/corruption error is deterministic
-                // and non-recoverable. Critically, the uncompressed piecewise read
-                // advances the stream position BEFORE verifying, so retrying a
-                // failed CRC would silently skip the corrupt piece and return the
-                // NEXT one — turning fail-fast corruption into a silent truncation.
-                // Surface it immediately instead.
-                if !e.is_recoverable() {
-                    return Err(e);
-                }
-                retry_count += 1;
-                if retry_count >= max_retries {
-                    log::error!("Failed to read block after {} retries: {}", max_retries, e);
-                    return Err(e);
-                }
+    })
+    .await
+}
 
-                log::warn!(
-                    "Block read failed (attempt {}/{}): {}, retrying...",
-                    retry_count,
-                    max_retries,
-                    e
-                );
+/// Classify an error as a TRANSIENT I/O fault (EINTR-class) that a single
+/// re-seek + re-read may clear.
+///
+/// Only genuinely-transient kernel faults qualify: `Interrupted` (EINTR),
+/// `WouldBlock` (EAGAIN) and `TimedOut`. Everything else — deterministic
+/// corruption/format errors (a CRC/format mismatch never heals on re-read), and
+/// non-transient I/O (`NotFound`, `PermissionDenied`, `UnexpectedEof`, …) — is
+/// NOT retried (issue #1588). This is intentionally stricter than
+/// [`Error::is_recoverable`], which classes ALL `Io` as recoverable; a
+/// deterministic re-read of the same bytes cannot fix a permanent failure and
+/// only wastes work.
+fn is_transient_io(e: &Error) -> bool {
+    match e {
+        Error::Io(io) => matches!(
+            io.kind(),
+            std::io::ErrorKind::Interrupted
+                | std::io::ErrorKind::WouldBlock
+                | std::io::ErrorKind::TimedOut
+        ),
+        _ => false,
+    }
+}
 
-                // Brief delay before retry
-                tokio::time::sleep(tokio::time::Duration::from_millis(10 * retry_count as u64))
-                    .await;
+/// Run `attempt`, retrying it EXACTLY once — and only on a transient I/O fault —
+/// after re-seeking the source back to the ORIGINAL offset (issue #1588).
+///
+/// Two defects this closes:
+/// 1. **Moved-position re-read.** A sequential read (e.g. the legacy block-header
+///    path, or the uncompressed piecewise read) advances the stream position past
+///    a partially-read block before a mid-read fault. Retrying WITHOUT re-seeking
+///    re-enters the reader at the MOVED position and reads DIFFERENT bytes (a
+///    silent wrong-block read). Capturing the position up front and seeking back
+///    makes the retry re-read the SAME bytes.
+/// 2. **Sleeping / retrying deterministic errors.** The old loop slept 10/20ms and
+///    re-read up to 3 times even for deterministic corruption (CRC/format), which
+///    can never heal. Deterministic errors now fail fast: no sleep, no retry, the
+///    typed error is returned immediately.
+async fn retry_transient_once<F, Fut, T>(file: &Arc<Mutex<BlockSource>>, attempt: F) -> Result<T>
+where
+    F: Fn() -> Fut,
+    Fut: std::future::Future<Output = Result<T>>,
+{
+    // Capture the original offset BEFORE the first attempt so a transient retry
+    // re-reads exactly the same bytes.
+    let original_pos = {
+        let mut guard = file.lock().await;
+        guard.stream_position().await.map_err(Error::Io)?
+    };
+
+    match attempt().await {
+        Ok(v) => Ok(v),
+        Err(e) if is_transient_io(&e) => {
+            log::warn!(
+                "transient I/O fault ({e}); re-seeking to offset {original_pos} and retrying once"
+            );
+            {
+                let mut guard = file.lock().await;
+                guard
+                    .seek(std::io::SeekFrom::Start(original_pos))
+                    .await
+                    .map_err(Error::Io)?;
             }
+            attempt().await
         }
+        // Deterministic corruption/format and non-transient I/O: fail fast, no sleep.
+        Err(e) => Err(e),
     }
 }
 
@@ -1206,6 +1217,151 @@ mod tests {
         tokio::fs::write(&path, bytes).await.expect("write data");
         let file = tokio::fs::File::open(&path).await.expect("open data");
         (dir, Arc::new(Mutex::new(BlockSource::buffered(file))))
+    }
+
+    // ========================================================================
+    // Retry policy: transient-only, single retry, re-seek to original offset
+    // (issue #1588)
+    // ========================================================================
+
+    use std::sync::atomic::Ordering;
+
+    fn transient_io() -> Error {
+        Error::Io(std::io::Error::new(
+            std::io::ErrorKind::Interrupted,
+            "simulated EINTR",
+        ))
+    }
+
+    /// A transient (EINTR-class) fault triggers EXACTLY one retry, and that retry
+    /// re-reads the SAME (original) offset — proving the source is re-seeked back
+    /// after the first attempt advanced the position. This is the moved-position
+    /// bug: without the re-seek the second attempt would observe offset 8.
+    #[tokio::test]
+    async fn retry_transient_reseeks_to_original_offset() {
+        let (_dir, file) = blocksource_from(&[0u8; 16]).await;
+        let calls = Arc::new(AtomicUsize::new(0));
+        let seen = Arc::new(Mutex::new(Vec::<u64>::new()));
+
+        let f = file.clone();
+        let c = calls.clone();
+        let s = seen.clone();
+        let attempt = move || {
+            let f = f.clone();
+            let c = c.clone();
+            let s = s.clone();
+            async move {
+                let n = c.fetch_add(1, Ordering::Relaxed);
+                let pos = { f.lock().await.stream_position().await.unwrap() };
+                s.lock().await.push(pos);
+                if n == 0 {
+                    // Simulate a partial read that advanced the position, then a
+                    // transient fault mid-block.
+                    {
+                        let mut g = f.lock().await;
+                        g.seek(std::io::SeekFrom::Start(8)).await.unwrap();
+                    }
+                    Err(transient_io())
+                } else {
+                    Ok::<u32, Error>(99)
+                }
+            }
+        };
+
+        let out = retry_transient_once(&file, attempt).await.unwrap();
+        assert_eq!(out, 99);
+        assert_eq!(
+            calls.load(Ordering::Relaxed),
+            2,
+            "exactly one transient retry (two attempts total)"
+        );
+        assert_eq!(
+            seen.lock().await.clone(),
+            vec![0, 0],
+            "retry must re-read the SAME original offset, not the moved position"
+        );
+    }
+
+    /// A deterministic corruption error is NOT retried and does NOT sleep: exactly
+    /// one attempt, returns fast. The attempt counter is the robust proof (no
+    /// wall-clock race); the elapsed bound is a generous secondary guard.
+    #[tokio::test]
+    async fn retry_does_not_retry_or_sleep_on_deterministic_corruption() {
+        let (_dir, file) = blocksource_from(&[0u8; 16]).await;
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        let c = calls.clone();
+        let attempt = move || {
+            let c = c.clone();
+            async move {
+                c.fetch_add(1, Ordering::Relaxed);
+                Err::<u32, Error>(Error::corruption("CRC32 mismatch"))
+            }
+        };
+
+        let start = std::time::Instant::now();
+        let err = retry_transient_once(&file, attempt).await.unwrap_err();
+        let elapsed = start.elapsed();
+
+        assert!(matches!(err, Error::Corruption(_)), "typed corruption: {err}");
+        assert_eq!(
+            calls.load(Ordering::Relaxed),
+            1,
+            "corruption is deterministic — never retried"
+        );
+        assert!(
+            elapsed < std::time::Duration::from_millis(500),
+            "no sleep on the deterministic-error path: {elapsed:?}"
+        );
+    }
+
+    /// A NON-transient I/O error (e.g. NotFound) is not retried either: only
+    /// EINTR-class transient faults qualify, unlike the broad `is_recoverable`
+    /// classification which treats every `Io` as retryable.
+    #[tokio::test]
+    async fn retry_does_not_retry_non_transient_io() {
+        let (_dir, file) = blocksource_from(&[0u8; 16]).await;
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        let c = calls.clone();
+        let attempt = move || {
+            let c = c.clone();
+            async move {
+                c.fetch_add(1, Ordering::Relaxed);
+                Err::<u32, Error>(Error::Io(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "gone",
+                )))
+            }
+        };
+
+        let err = retry_transient_once(&file, attempt).await.unwrap_err();
+        assert!(matches!(err, Error::Io(_)));
+        assert_eq!(
+            calls.load(Ordering::Relaxed),
+            1,
+            "non-transient I/O (NotFound) is not retried"
+        );
+    }
+
+    #[test]
+    fn is_transient_io_classifies_only_eintr_class() {
+        assert!(is_transient_io(&transient_io()));
+        assert!(is_transient_io(&Error::Io(std::io::Error::new(
+            std::io::ErrorKind::WouldBlock,
+            "eagain"
+        ))));
+        assert!(is_transient_io(&Error::Io(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "etimedout"
+        ))));
+        // Deterministic / non-transient are NOT transient.
+        assert!(!is_transient_io(&Error::corruption("crc")));
+        assert!(!is_transient_io(&Error::invalid_format("bad")));
+        assert!(!is_transient_io(&Error::Io(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "nf"
+        ))));
     }
 
     #[tokio::test]

--- a/cqlite-core/src/storage/sstable/reader/block_io.rs
+++ b/cqlite-core/src/storage/sstable/reader/block_io.rs
@@ -89,6 +89,24 @@ fn is_transient_io(e: &Error) -> bool {
     }
 }
 
+/// Wrap an underlying [`std::io::Error`] with human-readable `context` WITHOUT
+/// discarding its [`ErrorKind`](std::io::ErrorKind).
+///
+/// Preserving the source kind is load-bearing for [`is_transient_io`] (issue
+/// #1588). Every read/seek in this file is retried at most once through
+/// [`retry_transient_once`], and that retry fires ONLY when the classifier sees a
+/// truthful transient kind (EINTR / EAGAIN / timeout). The block-data and
+/// uncompressed-piece read paths used to wrap their source error with
+/// `std::io::Error::other(..)`, which relabels the kind as `Other` — so a REAL
+/// transient fault surfacing through those paths was silently NOT retried
+/// (dropping the transient-retry semantics this issue mandates). Constructing the
+/// wrapper with the SAME kind keeps the classifier honest, while corruption /
+/// format / `UnexpectedEof` kinds keep failing fast (they are not transient).
+fn io_error_with_context(context: impl std::fmt::Display, source: std::io::Error) -> Error {
+    let kind = source.kind();
+    Error::Io(std::io::Error::new(kind, format!("{context}: {source}")))
+}
+
 /// Run `attempt`, retrying it EXACTLY once — and only on a transient I/O fault —
 /// after re-seeking the source back to the ORIGINAL offset (issue #1588).
 ///
@@ -514,10 +532,7 @@ async fn read_bti_format_block_header(
                 return Ok(None);
             }
             Err(e) => {
-                return Err(Error::Io(std::io::Error::other(format!(
-                    "Failed to read BTI block header: {}",
-                    e
-                ))));
+                return Err(io_error_with_context("Failed to read BTI block header", e));
             }
         }
     };
@@ -561,10 +576,10 @@ async fn read_legacy_format_block_header(
                 return Ok(None);
             }
             Err(e) => {
-                return Err(Error::Io(std::io::Error::other(format!(
-                    "Failed to read legacy block header: {}",
-                    e
-                ))));
+                return Err(io_error_with_context(
+                    "Failed to read legacy block header",
+                    e,
+                ));
             }
         }
     };
@@ -591,10 +606,7 @@ async fn read_block_direct(file: &Arc<Mutex<BlockSource>>, size: usize) -> Resul
     {
         let mut file_guard = file.lock().await;
         file_guard.read_exact(&mut block_data).await.map_err(|e| {
-            Error::Io(std::io::Error::other(format!(
-                "Failed to read block data ({}): {}",
-                size, e
-            )))
+            io_error_with_context(format!("Failed to read block data ({size})"), e)
         })?;
     }
     Ok(block_data)
@@ -659,12 +671,7 @@ async fn read_large_block_streaming(
     let mut file_guard = file.lock().await;
     read_into_vec_capped(&mut *file_guard, size, config.read_buffer_size)
         .await
-        .map_err(|e| {
-            Error::Io(std::io::Error::other(format!(
-                "Failed to read block chunk: {}",
-                e
-            )))
-        })
+        .map_err(|e| io_error_with_context("Failed to read block chunk", e))
 }
 
 /// Read uncompressed data block (no compression, no block headers): the data
@@ -698,21 +705,17 @@ async fn read_uncompressed_data_block(
 ) -> Result<Option<Vec<u8>>> {
     let (current_pos, file_size) = {
         let mut file_guard = file.lock().await;
-        let current = file_guard.stream_position().await.map_err(|e| {
-            Error::Io(std::io::Error::other(format!(
-                "Failed to get stream position: {}",
-                e
-            )))
-        })?;
+        let current = file_guard
+            .stream_position()
+            .await
+            .map_err(|e| io_error_with_context("Failed to get stream position", e))?;
 
         // File size from the cached immutable length — no seek(End)/back probe on
         // every piece read (issue #1586).
-        let size = file_guard.len().await.map_err(|e| {
-            Error::Io(std::io::Error::other(format!(
-                "Failed to get file size: {}",
-                e
-            )))
-        })?;
+        let size = file_guard
+            .len()
+            .await
+            .map_err(|e| io_error_with_context("Failed to get file size", e))?;
 
         (current, size)
     };
@@ -778,10 +781,10 @@ async fn read_uncompressed_data_block(
         read_into_vec_capped(&mut *file_guard, to_read, config.read_buffer_size)
             .await
             .map_err(|e| {
-                Error::Io(std::io::Error::other(format!(
-                    "Failed to read uncompressed data block ({} bytes): {}",
-                    to_read, e
-                )))
+                io_error_with_context(
+                    format!("Failed to read uncompressed data block ({to_read} bytes)"),
+                    e,
+                )
             })?
     };
 
@@ -913,9 +916,7 @@ async fn verify_uncompressed_chunks(
             .seek(std::io::SeekFrom::Start(end))
             .await
             .map_err(|e| {
-                Error::Io(std::io::Error::other(format!(
-                    "failed to restore Data.db position after CRC verification: {e}"
-                )))
+                io_error_with_context("failed to restore Data.db position after CRC verification", e)
             })?;
     }
     Ok(())
@@ -938,9 +939,10 @@ async fn read_range_into(
         .seek(std::io::SeekFrom::Start(lo))
         .await
         .map_err(|e| {
-            Error::Io(std::io::Error::other(format!(
-                "failed to seek Data.db to 0x{lo:x} for CRC chunk completion: {e}"
-            )))
+            io_error_with_context(
+                format!("failed to seek Data.db to 0x{lo:x} for CRC chunk completion"),
+                e,
+            )
         })?;
     guard.read_exact(&mut buf).await.map_err(|e| {
         Error::corruption(format!(

--- a/cqlite-core/src/storage/sstable/reader/block_io.rs
+++ b/cqlite-core/src/storage/sstable/reader/block_io.rs
@@ -605,9 +605,10 @@ async fn read_block_direct(file: &Arc<Mutex<BlockSource>>, size: usize) -> Resul
     let mut block_data = vec![0u8; size];
     {
         let mut file_guard = file.lock().await;
-        file_guard.read_exact(&mut block_data).await.map_err(|e| {
-            io_error_with_context(format!("Failed to read block data ({size})"), e)
-        })?;
+        file_guard
+            .read_exact(&mut block_data)
+            .await
+            .map_err(|e| io_error_with_context(format!("Failed to read block data ({size})"), e))?;
     }
     Ok(block_data)
 }
@@ -916,7 +917,10 @@ async fn verify_uncompressed_chunks(
             .seek(std::io::SeekFrom::Start(end))
             .await
             .map_err(|e| {
-                io_error_with_context("failed to restore Data.db position after CRC verification", e)
+                io_error_with_context(
+                    "failed to restore Data.db position after CRC verification",
+                    e,
+                )
             })?;
     }
     Ok(())

--- a/cqlite-core/src/storage/sstable/reader/block_io_retry_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/block_io_retry_tests.rs
@@ -161,7 +161,8 @@ fn wrapped_read_error_preserves_kind_for_transient_classifier() {
         std::io::ErrorKind::TimedOut,
     ] {
         let src = std::io::Error::new(kind, "transient mid-read");
-        let wrapped = io_error_with_context("Failed to read uncompressed data block (64 bytes)", src);
+        let wrapped =
+            io_error_with_context("Failed to read uncompressed data block (64 bytes)", src);
         // Kind survives the context wrap...
         match &wrapped {
             Error::Io(io) => assert_eq!(io.kind(), kind, "kind must be preserved through wrap"),
@@ -181,7 +182,10 @@ fn wrapped_read_error_preserves_kind_for_transient_classifier() {
         std::io::ErrorKind::InvalidData,
         std::io::ErrorKind::NotFound,
     ] {
-        let wrapped = io_error_with_context("Failed to read block data (64)", std::io::Error::new(kind, "x"));
+        let wrapped = io_error_with_context(
+            "Failed to read block data (64)",
+            std::io::Error::new(kind, "x"),
+        );
         assert!(
             !is_transient_io(&wrapped),
             "non-transient kind {kind:?} must never be reclassified transient"

--- a/cqlite-core/src/storage/sstable/reader/block_io_retry_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/block_io_retry_tests.rs
@@ -1,0 +1,163 @@
+//! Retry-policy guards for the block I/O layer ([`super`] = `block_io`): a
+//! transient (EINTR-class) fault triggers EXACTLY one retry that re-seeks back
+//! to the original offset, while deterministic corruption and non-transient I/O
+//! are never retried (issue #1588).
+//!
+//! Split out of `block_io.rs` to keep that source file under the campsite-rule
+//! size limit (issue #1135). Included via
+//! `#[cfg(test)] #[path = "block_io_retry_tests.rs"] mod retry_tests;` in the
+//! parent, so `use super::*` resolves to `block_io`'s private items
+//! (`retry_transient_once`, `is_transient_io`, `BlockSource`, `Error`, …).
+
+use super::*;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use tempfile::TempDir;
+
+/// Build an `Arc<Mutex<BlockSource>>` over `bytes`. The returned `TempDir` MUST
+/// be held for the source's lifetime. (Local to this module so the retry guards
+/// are self-contained, mirroring the sibling-test-file pattern.)
+async fn blocksource_from(bytes: &[u8]) -> (TempDir, Arc<Mutex<BlockSource>>) {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().join("data.bin");
+    tokio::fs::write(&path, bytes).await.expect("write data");
+    let file = tokio::fs::File::open(&path).await.expect("open data");
+    (dir, Arc::new(Mutex::new(BlockSource::buffered(file))))
+}
+
+fn transient_io() -> Error {
+    Error::Io(std::io::Error::new(
+        std::io::ErrorKind::Interrupted,
+        "simulated EINTR",
+    ))
+}
+
+/// A transient (EINTR-class) fault triggers EXACTLY one retry, and that retry
+/// re-reads the SAME (original) offset — proving the source is re-seeked back
+/// after the first attempt advanced the position. This is the moved-position
+/// bug: without the re-seek the second attempt would observe offset 8.
+#[tokio::test]
+async fn retry_transient_reseeks_to_original_offset() {
+    let (_dir, file) = blocksource_from(&[0u8; 16]).await;
+    let calls = Arc::new(AtomicUsize::new(0));
+    let seen = Arc::new(Mutex::new(Vec::<u64>::new()));
+
+    let f = file.clone();
+    let c = calls.clone();
+    let s = seen.clone();
+    let attempt = move || {
+        let f = f.clone();
+        let c = c.clone();
+        let s = s.clone();
+        async move {
+            let n = c.fetch_add(1, Ordering::Relaxed);
+            let pos = { f.lock().await.stream_position().await.unwrap() };
+            s.lock().await.push(pos);
+            if n == 0 {
+                // Simulate a partial read that advanced the position, then a
+                // transient fault mid-block.
+                {
+                    let mut g = f.lock().await;
+                    g.seek(std::io::SeekFrom::Start(8)).await.unwrap();
+                }
+                Err(transient_io())
+            } else {
+                Ok::<u32, Error>(99)
+            }
+        }
+    };
+
+    let out = retry_transient_once(&file, attempt).await.unwrap();
+    assert_eq!(out, 99);
+    assert_eq!(
+        calls.load(Ordering::Relaxed),
+        2,
+        "exactly one transient retry (two attempts total)"
+    );
+    assert_eq!(
+        seen.lock().await.clone(),
+        vec![0, 0],
+        "retry must re-read the SAME original offset, not the moved position"
+    );
+}
+
+/// A deterministic corruption error is NOT retried and does NOT sleep: exactly
+/// one attempt, returns fast. The attempt counter is the robust proof (no
+/// wall-clock race); the elapsed bound is a generous secondary guard.
+#[tokio::test]
+async fn retry_does_not_retry_or_sleep_on_deterministic_corruption() {
+    let (_dir, file) = blocksource_from(&[0u8; 16]).await;
+    let calls = Arc::new(AtomicUsize::new(0));
+
+    let c = calls.clone();
+    let attempt = move || {
+        let c = c.clone();
+        async move {
+            c.fetch_add(1, Ordering::Relaxed);
+            Err::<u32, Error>(Error::corruption("CRC32 mismatch"))
+        }
+    };
+
+    let start = std::time::Instant::now();
+    let err = retry_transient_once(&file, attempt).await.unwrap_err();
+    let elapsed = start.elapsed();
+
+    assert!(matches!(err, Error::Corruption(_)), "typed corruption: {err}");
+    assert_eq!(
+        calls.load(Ordering::Relaxed),
+        1,
+        "corruption is deterministic — never retried"
+    );
+    assert!(
+        elapsed < std::time::Duration::from_millis(500),
+        "no sleep on the deterministic-error path: {elapsed:?}"
+    );
+}
+
+/// A NON-transient I/O error (e.g. NotFound) is not retried either: only
+/// EINTR-class transient faults qualify, unlike the broad `is_recoverable`
+/// classification which treats every `Io` as retryable.
+#[tokio::test]
+async fn retry_does_not_retry_non_transient_io() {
+    let (_dir, file) = blocksource_from(&[0u8; 16]).await;
+    let calls = Arc::new(AtomicUsize::new(0));
+
+    let c = calls.clone();
+    let attempt = move || {
+        let c = c.clone();
+        async move {
+            c.fetch_add(1, Ordering::Relaxed);
+            Err::<u32, Error>(Error::Io(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "gone",
+            )))
+        }
+    };
+
+    let err = retry_transient_once(&file, attempt).await.unwrap_err();
+    assert!(matches!(err, Error::Io(_)));
+    assert_eq!(
+        calls.load(Ordering::Relaxed),
+        1,
+        "non-transient I/O (NotFound) is not retried"
+    );
+}
+
+#[test]
+fn is_transient_io_classifies_only_eintr_class() {
+    assert!(is_transient_io(&transient_io()));
+    assert!(is_transient_io(&Error::Io(std::io::Error::new(
+        std::io::ErrorKind::WouldBlock,
+        "eagain"
+    ))));
+    assert!(is_transient_io(&Error::Io(std::io::Error::new(
+        std::io::ErrorKind::TimedOut,
+        "etimedout"
+    ))));
+    // Deterministic / non-transient are NOT transient.
+    assert!(!is_transient_io(&Error::corruption("crc")));
+    assert!(!is_transient_io(&Error::invalid_format("bad")));
+    assert!(!is_transient_io(&Error::Io(std::io::Error::new(
+        std::io::ErrorKind::NotFound,
+        "nf"
+    ))));
+}

--- a/cqlite-core/src/storage/sstable/reader/block_io_retry_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/block_io_retry_tests.rs
@@ -101,7 +101,10 @@ async fn retry_does_not_retry_or_sleep_on_deterministic_corruption() {
     let err = retry_transient_once(&file, attempt).await.unwrap_err();
     let elapsed = start.elapsed();
 
-    assert!(matches!(err, Error::Corruption(_)), "typed corruption: {err}");
+    assert!(
+        matches!(err, Error::Corruption(_)),
+        "typed corruption: {err}"
+    );
     assert_eq!(
         calls.load(Ordering::Relaxed),
         1,

--- a/cqlite-core/src/storage/sstable/reader/block_io_retry_tests.rs
+++ b/cqlite-core/src/storage/sstable/reader/block_io_retry_tests.rs
@@ -145,6 +145,87 @@ async fn retry_does_not_retry_non_transient_io() {
     );
 }
 
+/// Finding 1 (issue #1588): the block-data / uncompressed-piece read paths add
+/// human-readable context to their underlying `io::Error` via
+/// [`io_error_with_context`]. That wrapper MUST preserve the source
+/// [`std::io::ErrorKind`] so a REAL transient fault (EINTR/EAGAIN/timeout)
+/// surfacing THROUGH the wrap is still classified transient by
+/// [`is_transient_io`] and retried once. The old `io::Error::other(..)` wrap
+/// relabeled the kind to `Other`, silently defeating the retry. Corruption /
+/// format / `UnexpectedEof` kinds must still fail fast (never transient).
+#[test]
+fn wrapped_read_error_preserves_kind_for_transient_classifier() {
+    for kind in [
+        std::io::ErrorKind::Interrupted,
+        std::io::ErrorKind::WouldBlock,
+        std::io::ErrorKind::TimedOut,
+    ] {
+        let src = std::io::Error::new(kind, "transient mid-read");
+        let wrapped = io_error_with_context("Failed to read uncompressed data block (64 bytes)", src);
+        // Kind survives the context wrap...
+        match &wrapped {
+            Error::Io(io) => assert_eq!(io.kind(), kind, "kind must be preserved through wrap"),
+            other => panic!("expected Error::Io, got {other}"),
+        }
+        // ...and is therefore still classified transient and retried once.
+        assert!(
+            is_transient_io(&wrapped),
+            "wrapped transient read error must stay transient: {wrapped}"
+        );
+    }
+
+    // The corruption-fails-fast guarantee is NOT weakened: a wrapped
+    // non-transient kind stays non-transient.
+    for kind in [
+        std::io::ErrorKind::UnexpectedEof,
+        std::io::ErrorKind::InvalidData,
+        std::io::ErrorKind::NotFound,
+    ] {
+        let wrapped = io_error_with_context("Failed to read block data (64)", std::io::Error::new(kind, "x"));
+        assert!(
+            !is_transient_io(&wrapped),
+            "non-transient kind {kind:?} must never be reclassified transient"
+        );
+    }
+}
+
+/// End-to-end through [`retry_transient_once`]: an attempt whose FIRST failure is
+/// a transient fault produced by the read-path wrapper ([`io_error_with_context`],
+/// as the block-data / uncompressed-piece reads now build it) is retried EXACTLY
+/// once. This is the behaviour the old `io::Error::other(..)` wrap silently broke
+/// (issue #1588 finding 1): the wrapped error would have been classified `Other`
+/// and never retried.
+#[tokio::test]
+async fn wrapped_transient_read_error_is_retried_once() {
+    let (_dir, file) = blocksource_from(&[0u8; 16]).await;
+    let calls = Arc::new(AtomicUsize::new(0));
+
+    let c = calls.clone();
+    let attempt = move || {
+        let c = c.clone();
+        async move {
+            let n = c.fetch_add(1, Ordering::Relaxed);
+            if n == 0 {
+                // Exactly what a read path now yields for an EINTR mid-read.
+                Err(io_error_with_context(
+                    "Failed to read uncompressed data block (64 bytes)",
+                    std::io::Error::new(std::io::ErrorKind::Interrupted, "EINTR"),
+                ))
+            } else {
+                Ok::<u32, Error>(7)
+            }
+        }
+    };
+
+    let out = retry_transient_once(&file, attempt).await.unwrap();
+    assert_eq!(out, 7);
+    assert_eq!(
+        calls.load(Ordering::Relaxed),
+        2,
+        "a context-wrapped transient read fault is retried exactly once"
+    );
+}
+
 #[test]
 fn is_transient_io_classifies_only_eintr_class() {
     assert!(is_transient_io(&transient_io()));


### PR DESCRIPTION
Closes #1588 (E6, oracle-driven, P1, no-heuristics enforcement — decision #14).

## Two defects fixed
1. **Snappy format guessing (no-heuristics #28):** the chunk decompressor tried TWO formats per chunk (framed vs raw) and kept whichever succeeded — a silent-wrong-bytes hazard. Now decodes EXACTLY one format (raw), determined by authoritative `CompressionInfo.db` provenance (Cassandra 5.0 `SnappyCompressor` = raw blocks). Deleted the second attempt.
2. **Broken retry semantics:** the chunk-read loop slept 10/20ms and retried even deterministic corruption (CRC never heals), and the legacy path re-read from a MOVED position. Now: only EINTR-class transient I/O retries exactly once after re-seeking to the ORIGINAL offset; corruption/format fails fast with the typed error, no sleep.

## Oracle-first (decision #14, red→green proven)
Adversarial fixture: a valid RAW-snappy chunk whose leading 4 bytes also parse as a plausible framed BE-length header. Pre-fix, framed-then-raw guessing returned silently-wrong bytes (`[87,82,79,78,71,...]` = "WRONG..."); the test FAILED on main. Post-fix, strict raw decode rejects it (errors) with exactly ONE attempt. Retry tests likewise red-then-green (moved-position re-read; over-broad retry+sleeps).

## Review + gate
- rust-reviewer review-first: **no blocking issues.** Verified the Snappy `compress` raw alignment is safe (production writer already emits raw via `compressed_data_writer.rs`; `Compression::compress` is unwired — benchmarks/tests only; no fixture depends on the old 4-byte prefix). Retry classification, re-seek idempotency (chunk index advanced only post-success), and the dropped `max_retries` signature propagation all correct.
- Split the #1588 retry tests into sibling `block_io_retry_tests.rs` (epic #1135); residual `CQLITE_ALLOW_FILE_GROWTH=1` ack (base files already far over threshold on main; full mod-dir split out of scope for a bug fix).
- FULL `agent-gate.sh`: file-size/fmt/clippy PASS; exclusion run **4072/4072** core tests pass incl. the adversarial oracle + 4 retry tests + compression round-trip/parity suites; 33-table parity green. The two SUMMARY reds are pre-existing/unrelated — #1859 (issue_953 missing-fixture skip-guard defect) and the known python GIL-throughput flaky.
- No `unwrap()`/`expect()` in library code; `-D warnings` clean.

## Out of scope (filed)
- #1862 — `StreamingDecompressor::decompress_snappy_streaming` uses Snappy FRAME format (a third inconsistent path; currently unused). Follow-up.