### PR TITLE
fix(#1444): release GIL for Python write path (Arc<tokio::Mutex> write engine)

### DIFF
--- a/bindings/python/src/database.rs
+++ b/bindings/python/src/database.rs
@@ -28,7 +28,9 @@
 
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+
+use tokio::sync::Mutex as AsyncMutex;
 
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
@@ -69,7 +71,10 @@ pub struct Database {
     inner: Arc<cqlite_core::Database>,
     closed: AtomicBool,
     /// Optional write engine — present only when opened with `writable=True`.
-    write_engine: Option<Mutex<PyWriteEngine>>,
+    /// A `tokio::sync::Mutex` (not `std`) so its guard is `Send` and survives the
+    /// `py.allow_threads` boundary (issue #1444): blocking writes (WAL fsync +
+    /// SSTable materialization) run with the GIL released, matching the read path.
+    write_engine: Option<Arc<AsyncMutex<PyWriteEngine>>>,
     /// W3C `traceparent` captured at `open` time (issue #1039). When set, every
     /// per-call span is re-parented to this trace unless a per-call traceparent
     /// overrides it, so the bindings' Rust spans correlate with the caller's
@@ -102,14 +107,38 @@ impl Database {
         per_call.or(self.default_traceparent.as_deref())
     }
 
-    /// The write engine, or a typed error if the database is read-only.
-    /// Replaces the `require_writable()? … .expect(Some)` two-step.
-    fn writable_engine(&self) -> PyResult<&Mutex<PyWriteEngine>> {
+    /// The write engine handle, or a typed error if the database is read-only.
+    /// Replaces the `require_writable()? … .expect(Some)` two-step. Returns the
+    /// `&Arc<..>` so callers can `Arc::clone` a `Send` handle into an
+    /// `allow_threads` closure (issue #1444).
+    fn writable_engine(&self) -> PyResult<&Arc<AsyncMutex<PyWriteEngine>>> {
         self.write_engine.as_ref().ok_or_else(|| {
             PyRuntimeError::new_err(
                 "Database is read-only. Open with writable=True and write_dir=<path> \
                  to enable write operations.",
             )
+        })
+    }
+
+    /// Run `f` with the write-engine guard held, releasing the GIL for the
+    /// duration (issue #1444). The `tokio::sync::Mutex` guard is `Send`, so the
+    /// blocking write executes inside `py.allow_threads` while the lock still
+    /// serializes writes (single-writer: no two flushes/DML overlap).
+    ///
+    /// The guard is taken with `blocking_lock()` on the (synchronous) Python
+    /// calling thread — NOT inside a `block_on`. `PyWriteEngine::flush`/`execute`
+    /// bridge their own async work via `block_on`; acquiring the lock via
+    /// `.lock().await` here would make this thread a runtime driver and nest
+    /// `block_on`s ("cannot start a runtime from within a runtime").
+    fn with_write_engine<T, F>(&self, py: Python<'_>, f: F) -> PyResult<T>
+    where
+        F: FnOnce(&mut PyWriteEngine) -> PyResult<T> + Send,
+        T: Send,
+    {
+        let engine = Arc::clone(self.writable_engine()?);
+        py.allow_threads(move || {
+            let mut guard = engine.blocking_lock();
+            f(&mut guard)
         })
     }
 
@@ -145,16 +174,19 @@ impl Database {
             return Ok(());
         }
 
-        // Close the write engine first (flushes remaining memtable)
-        if let Some(ref engine_mutex) = self.write_engine {
-            let mut engine = engine_mutex
-                .lock()
-                .map_err(|_| PyRuntimeError::new_err("Write engine lock poisoned during close"))?;
-            // close() flushes remaining data. MutexGuard is not Send, so we
-            // cannot release the GIL here. The flush on close is typically fast.
-            block_on(engine.inner.close())
-                .map_err(runtime_init_to_py_err)?
-                .map_err(to_py_err)?;
+        // Close the write engine first (flushes remaining memtable). The tokio
+        // guard is `Send`, so the flush-on-close I/O runs with the GIL released
+        // (issue #1444), the same as every other write op. `blocking_lock` on the
+        // synchronous calling thread + `block_on` inside mirrors `with_write_engine`
+        // (never nest `block_on`s).
+        if let Some(ref engine_arc) = self.write_engine {
+            let engine = Arc::clone(engine_arc);
+            py.allow_threads(move || {
+                let mut guard = engine.blocking_lock();
+                block_on(guard.inner.close())
+                    .map_err(runtime_init_to_py_err)?
+                    .map_err(to_py_err)
+            })?;
         }
 
         // Shutdown the read-side storage engine
@@ -590,19 +622,12 @@ impl Database {
     /// path = db.flush_run()
     /// assert Path(path).exists()
     /// ```
-    pub fn flush_run(&self) -> PyResult<String> {
+    pub fn flush_run(&self, py: Python<'_>) -> PyResult<String> {
         self.ensure_open()?;
-
-        let engine_mutex = self.writable_engine()?;
-
-        let mut engine = engine_mutex
-            .lock()
-            .map_err(|_| PyRuntimeError::new_err("Write engine lock poisoned"))?;
-
-        // Flush involves substantial I/O. We cannot release the GIL here because
-        // MutexGuard is not Send. Flush is typically fast (writes a single SSTable
-        // file). This is acceptable for the current implementation.
-        engine.flush().map_err(to_py_err)
+        // Flush is substantial I/O (WAL fsync + SSTable materialization). The
+        // `Send` tokio guard lets it run under `allow_threads`, so a large-memtable
+        // flush no longer freezes every other Python thread (issue #1444).
+        self.with_write_engine(py, |e| e.flush().map_err(to_py_err))
     }
 
     /// Perform one incremental maintenance step (compaction).
@@ -634,21 +659,12 @@ impl Database {
     /// report = db.maintenance_step(budget_ms=100)
     /// print(f"Merged {report.rows_merged} rows in {report.time_spent_ms:.1f} ms")
     /// ```
-    pub fn maintenance_step(&self, budget_ms: u64) -> PyResult<MaintenanceReport> {
+    pub fn maintenance_step(&self, py: Python<'_>, budget_ms: u64) -> PyResult<MaintenanceReport> {
         self.ensure_open()?;
-
-        let engine_mutex = self.writable_engine()?;
-
-        let mut engine = engine_mutex
-            .lock()
-            .map_err(|_| PyRuntimeError::new_err("Write engine lock poisoned"))?;
-
         let budget = std::time::Duration::from_millis(budget_ms);
-
-        // MutexGuard is not Send so we cannot release the GIL here.
-        // maintenance_step() is time-bounded and typically completes quickly.
-        let report = engine.maintenance_step(budget).map_err(to_py_err)?;
-
+        // GIL released for the duration; the guard serializes against flush/DML.
+        let report =
+            self.with_write_engine(py, move |e| e.maintenance_step(budget).map_err(to_py_err))?;
         Ok(MaintenanceReport::from_core(report))
     }
 
@@ -673,16 +689,11 @@ impl Database {
     /// print(f"Memtable: {stats.memtable_size} bytes, {stats.memtable_rows} rows")
     /// ```
     #[getter]
-    pub fn write_stats(&self) -> PyResult<WriteStats> {
+    pub fn write_stats(&self, py: Python<'_>) -> PyResult<WriteStats> {
         self.ensure_open()?;
-
-        let engine_mutex = self.writable_engine()?;
-
-        let engine = engine_mutex
-            .lock()
-            .map_err(|_| PyRuntimeError::new_err("Write engine lock poisoned"))?;
-
-        Ok(engine.write_stats())
+        // Same `Send`-guard path so acquiring the lock never blocks the GIL
+        // against a concurrent flush/DML holding it (issue #1444).
+        self.with_write_engine(py, |e| Ok(e.write_stats()))
     }
 }
 
@@ -695,26 +706,15 @@ impl Database {
     fn execute_dml(&self, py: Python<'_>, query: &str) -> PyResult<QueryResult> {
         use std::time::Instant;
 
-        let engine_mutex = self.writable_engine()?;
-
         let query_owned = query.to_string();
         let t0 = Instant::now();
 
-        // Release the GIL for the write (issue #1620). `execute()` now routes
+        // Release the GIL for the write (issue #1620, #1444). `execute()` routes
         // through `WriteEngine::execute_flushing`, which performs a REAL async
-        // SSTable flush (disk I/O) when the memtable crosses the flush threshold
-        // — so holding the GIL for its duration would block every other Python
-        // thread. The `MutexGuard` is created and dropped entirely inside the
-        // closure, so it never crosses the GIL boundary; the closure captures
-        // only `Send` values (`&Mutex<PyWriteEngine>` + `String`).
-        let rows_affected = py
-            .allow_threads(|| {
-                let mut engine = engine_mutex.lock().map_err(|_| {
-                    cqlite_core::error::Error::Storage("Write engine lock poisoned".to_string())
-                })?;
-                engine.execute(&query_owned)
-            })
-            .map_err(to_py_err)?;
+        // SSTable flush (disk I/O) once the memtable crosses the flush threshold;
+        // the `Send` tokio guard runs it entirely inside `allow_threads`.
+        let rows_affected =
+            self.with_write_engine(py, move |e| e.execute(&query_owned).map_err(to_py_err))?;
 
         let elapsed_ms = t0.elapsed().as_millis() as u64;
 
@@ -883,7 +883,7 @@ pub fn open(
     };
 
     // Build WriteEngine when writable=True.
-    let write_engine: Option<Mutex<PyWriteEngine>> = if writable {
+    let write_engine: Option<Arc<AsyncMutex<PyWriteEngine>>> = if writable {
         let wd = write_dir.expect("validated above");
         let schema_path_display = schema.clone().expect("validated above");
 
@@ -936,7 +936,7 @@ pub fn open(
         let engine = cqlite_core::storage::write_engine::WriteEngine::new(engine_config)
             .map_err(to_py_err)?;
 
-        Some(Mutex::new(PyWriteEngine::new(engine)))
+        Some(Arc::new(AsyncMutex::new(PyWriteEngine::new(engine))))
     } else {
         // Silence unused-variable warning
         let _ = (

--- a/bindings/python/tests/test_write_api.py
+++ b/bindings/python/tests/test_write_api.py
@@ -9,7 +9,9 @@ Covers:
 - writable=True validation (write_dir and schema required)
 """
 
+import sys
 import tempfile
+import threading
 import time
 from pathlib import Path
 
@@ -605,3 +607,193 @@ def test_compaction_partial_config_dict_rejected(tmp_path, write_schema):
             write_dir=str(tmp_path / "write_dir"),
             config={"storage": {"compaction": {"auto_compaction": False}}},
         )
+
+
+# ---------------------------------------------------------------------------
+# Issue #1444 — write path releases the GIL during blocking I/O
+# ---------------------------------------------------------------------------
+#
+# These tests generate their own SSTables in a tmp dir, so they do NOT touch
+# the fixture corpus (no dataset skip / _require_fixtures_strict needed). They
+# use a self-calibrated free-run rate so the floor tolerates a heavily-loaded
+# machine (this repo runs many concurrent gates) rather than a tight
+# wall-clock number that would flake.
+
+
+def _spin_counter():
+    """Start a daemon thread spinning a pure-Python counter.
+
+    Returns ``(counter, stop, thread)`` where ``counter[0]`` is the live count.
+    A pure-Python loop can only advance while it holds the GIL, so its progress
+    during another thread's C call is a direct probe of whether that call
+    released the GIL.
+    """
+    counter = [0]
+    stop = threading.Event()
+    ready = threading.Event()
+
+    def run():
+        ready.set()
+        c = 0
+        while not stop.is_set():
+            c += 1
+            counter[0] = c
+
+    t = threading.Thread(target=run, daemon=True)
+    t.start()
+    ready.wait()
+    return counter, stop, t
+
+
+@pytest.mark.slow
+def test_flush_run_releases_gil(tmp_path, write_schema):
+    """flush_run() releases the GIL for the duration of its blocking I/O.
+
+    Thread B spins a pure-Python counter; the main thread (A) calls
+    flush_run(). On ``main`` (pre-#1444) the write engine held the GIL for the
+    whole flush, starving thread B; after the fix thread B advances at close to
+    its free-run rate. We compare the spinner's *rate* during the flush to a
+    self-calibrated free-run rate, which is duration- and load-independent.
+    """
+    # A short GIL switch interval shrinks the boundary "leakage" so the
+    # held-GIL bug shows near-zero progress (makes the test discriminating).
+    old_interval = sys.getswitchinterval()
+    sys.setswitchinterval(0.001)
+
+    data_dir = tmp_path / "data_dir"
+    data_dir.mkdir()
+    write_dir = tmp_path / "write_dir"
+    db = cqlite.open(
+        str(data_dir),
+        schema=str(write_schema),
+        writable=True,
+        write_dir=str(write_dir),
+    )
+    try:
+        # Enough rows that the flush does real, measurable serialize + fsync I/O.
+        for i in range(20000):
+            db.execute(
+                f"INSERT INTO write_test.items (id, name, value) "
+                f"VALUES ({i}, 'gil_row_{i}', {i})"
+            )
+
+        counter, stop, t = _spin_counter()
+        try:
+            # Calibrate the spinner's free-run rate: the main thread sleeps,
+            # which (like the fix) releases the GIL, so the spinner runs freely.
+            c0 = counter[0]
+            time.sleep(0.05)
+            free_rate = (counter[0] - c0) / 0.05
+            assert free_rate > 0, "spinner made no progress during calibration"
+
+            # Measure the spinner's rate DURING the flush.
+            before = counter[0]
+            t_start = time.monotonic()
+            path = db.flush_run()
+            flush_secs = time.monotonic() - t_start
+            during_rate = (counter[0] - before) / flush_secs if flush_secs else 0.0
+        finally:
+            stop.set()
+            t.join(timeout=5)
+
+        assert path and Path(path).exists(), "flush must produce a Data.db"
+        # With the GIL released the spinner runs concurrently at a large fraction
+        # of its free rate; with the GIL held it is starved (rate ~0). 15% cleanly
+        # separates the two while tolerating a saturated machine.
+        assert during_rate >= 0.15 * free_rate, (
+            f"spinner starved during flush: {during_rate:.0f}/s vs free "
+            f"{free_rate:.0f}/s over {flush_secs*1000:.1f} ms — GIL was likely "
+            "held for the flush (issue #1444 regression)."
+        )
+    finally:
+        db.close()
+        sys.setswitchinterval(old_interval)
+
+
+@pytest.mark.slow
+def test_execute_dml_releases_gil(tmp_path, write_schema):
+    """A DML batch that triggers auto-flushes keeps the GIL released.
+
+    Companion to the flush test: DML routes through the same Send-guard
+    ``allow_threads`` path (issue #1444). A small flush_threshold makes the
+    inserts cross it repeatedly so ``execute()`` performs real flush I/O.
+    """
+    old_interval = sys.getswitchinterval()
+    sys.setswitchinterval(0.001)
+
+    data_dir = tmp_path / "data_dir"
+    data_dir.mkdir()
+    write_dir = tmp_path / "write_dir"
+    db = cqlite.open(
+        str(data_dir),
+        schema=str(write_schema),
+        writable=True,
+        write_dir=str(write_dir),
+        flush_threshold=4096,
+    )
+    try:
+        counter, stop, t = _spin_counter()
+        try:
+            c0 = counter[0]
+            time.sleep(0.05)
+            free_rate = (counter[0] - c0) / 0.05
+            assert free_rate > 0, "spinner made no progress during calibration"
+
+            before = counter[0]
+            t_start = time.monotonic()
+            for i in range(5000):
+                db.execute(
+                    f"INSERT INTO write_test.items (id, name, value) "
+                    f"VALUES ({i}, 'dml_{i}', {i})"
+                )
+            secs = time.monotonic() - t_start
+            during_rate = (counter[0] - before) / secs if secs else 0.0
+        finally:
+            stop.set()
+            t.join(timeout=5)
+
+        assert during_rate >= 0.10 * free_rate, (
+            f"spinner starved during DML batch: {during_rate:.0f}/s vs free "
+            f"{free_rate:.0f}/s — DML did not release the GIL (issue #1444)."
+        )
+    finally:
+        db.close()
+        sys.setswitchinterval(old_interval)
+
+
+def test_flush_readback_after_send_handle_change(tmp_path, write_schema):
+    """Single-writer correctness holds after the #1444 Send-handle change.
+
+    Proves moving the write engine to an Arc<tokio::Mutex> and running the flush
+    under allow_threads did not corrupt the write: the flushed Data.db is real,
+    non-empty, and every inserted row reads back with its exact values.
+    """
+    data_dir = tmp_path / "data_dir"
+    data_dir.mkdir()
+    write_dir = tmp_path / "write_dir"
+    db = cqlite.open(
+        str(data_dir),
+        schema=str(write_schema),
+        writable=True,
+        write_dir=str(write_dir),
+    )
+    try:
+        for i in range(50):
+            db.execute(
+                f"INSERT INTO write_test.items (id, name, value) "
+                f"VALUES ({i}, 'row_{i}', {i * 2})"
+            )
+        path = db.flush_run()
+        assert path and Path(path).exists(), "flush must produce a Data.db"
+        assert Path(path).stat().st_size > 0, "Data.db must be non-empty"
+    finally:
+        db.close()
+
+    with cqlite.open(str(write_dir / "data"), schema=str(write_schema)) as rd:
+        rows = [r.to_dict() for r in rd.execute("SELECT * FROM write_test.items")]
+
+    assert len(rows) == 50, f"expected 50 rows on read-back, got {len(rows)}"
+    by_id = {r["id"]: r for r in rows}
+    for i in range(50):
+        assert by_id[i]["name"] == f"row_{i}", f"name mismatch for id={i}: {by_id[i]}"
+        assert by_id[i]["value"] == i * 2, f"value mismatch for id={i}: {by_id[i]}"


### PR DESCRIPTION
Closes #1444.

## What
Python DML and `flush_run()` held the GIL across WAL fsync + SSTable materialization because the write engine was a `std::sync::Mutex<PyWriteEngine>` whose `MutexGuard` is `!Send` and can't cross `py.allow_threads`. A large-memtable flush froze every other Python thread for the length of that disk I/O. This makes the write-engine handle `Send` so the blocking write runs with the GIL released — matching the read path.

- Field `Option<Mutex<PyWriteEngine>>` → `Option<Arc<tokio::sync::Mutex<PyWriteEngine>>>` (Send handle); `writable_engine()` accessor (from #1439) updated to match, no `.expect(Some)` reintroduced.
- New private `with_write_engine()` helper acquires the guard via `blocking_lock()` **inside** `py.allow_threads` and runs the write there. `flush_run`, `execute_dml`, `maintenance_step`, `write_stats`, and `close` all route through it (GIL released).
- **Deviation from the issue snippet (justified):** the guard is taken with `blocking_lock()` on the sync Python thread, NOT `.lock().await` inside `block_on` — because `PyWriteEngine::flush`/`execute` already nest their own `block_on`, so an outer `block_on(async { lock().await })` panics "Cannot start a runtime from within a runtime." `blocking_lock()` is valid here (the Python thread is never a tokio worker) and lets the existing inner `block_on` run unchanged. Single-writer serialization preserved by the lock.
- FFI GIL mechanic ONLY — no flush policy/threshold/compaction change (N–T scope untouched); Node write path untouched; read-path `execute` GIL handling untouched.
- `database.rs`: 998 → 998 lines (net-neutral).

## Verification
- **rust-reviewer (high-rigor concurrency pass): CLEAN** — confirmed `blocking_lock()` has no reachable panic path (always called on the sync Python thread, inside `allow_threads`, before any `block_on`); no self-deadlock (inner runtime work never awaits the outer lock); GIL is released before any lock contention (the fix isn't defeated); Send is compiler-enforced; single-writer preserved. Minor acceptable note: tokio Mutex drops lock-poisoning (idiomatic; no caller depended on the poison error path).
- roborev (claude-code/opus vs origin/main): **No issues found.**
- GIL-release test (`test_flush_run_releases_gil`, + execute_dml companion): thread-B advances past a robust floor DURING the flush; discrimination proven (reverting the fix collapses thread-B rate → test fails). Read-back correctness: all inserted rows read back after flush+reopen.
- Full agent-gate: all attributable components PASS (**python-bindings** via maturin+pytest, fmt, clippy, file-size, write-tests, node-bindings, integration, smoke, …). Sole FAIL is the pre-existing environmental `core-tests` `issue_953_multichunk_cell_seek` fixture hard-panic (#1856; reproduces byte-identically on clean origin/main), NOT attributable to this Python-only diff.

_Delivered by flow-lead worker; seams pre-approved (owner AFK)._