### PR TITLE
perf(#1590): E8 read-path idioms bundle (de-async, FxHash, OFFSET skip/take, per-partition digest, IN-expansion allocs)

### DIFF
--- a/cqlite-core/Cargo.toml
+++ b/cqlite-core/Cargo.toml
@@ -64,6 +64,10 @@ base64 = "0.21"
 # Hashing for Cassandra compatibility
 murmur3 = "0.5"
 
+# Fast non-cryptographic hasher (FxHashMap) for integer/digest-keyed hot-path
+# maps only — NOT for maps exposed to untrusted string keys (issue #1590, E8).
+rustc-hash = "1.1"
+
 # Arbitrary-precision integers for varint/decimal formatting (util::value_fmt)
 # and the Parquet export writer's Decimal128 rescaling
 num-bigint = "0.4"

--- a/cqlite-core/src/lib.rs
+++ b/cqlite-core/src/lib.rs
@@ -60,6 +60,70 @@ pub mod fuzz_support;
 // NOTE: memory_safety_runner moved to tools/memory-safety-runner (Issue #245)
 // NOTE: memory_safety_tests disabled - MemTable removed in Issue #175
 
+// Test-only heap-allocation probe (issue #1590, E8). Installed as the global
+// allocator for `cqlite-core`'s unit-test binary so a test can count the heap
+// allocations a specific code path performs (see the `cartesian_product`
+// allocation regression test in the SELECT executor's `lookup` module). It
+// delegates every operation to the system allocator and only bumps a per-thread
+// counter while a measurement is ACTIVE, so it is inert for every other test.
+#[cfg(test)]
+pub(crate) mod test_alloc_probe {
+    use std::alloc::{GlobalAlloc, Layout, System};
+    use std::cell::Cell;
+
+    thread_local! {
+        static COUNT: Cell<u64> = const { Cell::new(0) };
+        static ACTIVE: Cell<bool> = const { Cell::new(false) };
+    }
+
+    pub(crate) struct CountingAllocator;
+
+    // SAFETY: every storage operation is delegated verbatim to `System`; the only
+    // added work is bumping a `Copy` thread-local counter, which never allocates
+    // (the `thread_local!`s are `const`-initialized, so first access is
+    // alloc-free — no reentrancy into the allocator).
+    unsafe impl GlobalAlloc for CountingAllocator {
+        unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+            bump();
+            System.alloc(layout)
+        }
+        unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+            System.dealloc(ptr, layout)
+        }
+        // Counting `realloc` as an allocation is deliberate: it distinguishes a
+        // `Vec::clone()` + `push()` (a clone-alloc then a grow-realloc) from a
+        // single sized `Vec::with_capacity()` fill.
+        unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+            bump();
+            System.realloc(ptr, layout, new_size)
+        }
+    }
+
+    fn bump() {
+        let _ = ACTIVE.try_with(|a| {
+            if a.get() {
+                let _ = COUNT.try_with(|c| c.set(c.get() + 1));
+            }
+        });
+    }
+
+    /// Count the heap allocations `f` performs ON THE CURRENT THREAD (thread-local
+    /// counter, so concurrent tests do not pollute each other). Returns
+    /// `(allocations, f's result)`.
+    pub(crate) fn measure<R>(f: impl FnOnce() -> R) -> (u64, R) {
+        ACTIVE.with(|a| a.set(true));
+        COUNT.with(|c| c.set(0));
+        let r = f();
+        let n = COUNT.with(|c| c.get());
+        ACTIVE.with(|a| a.set(false));
+        (n, r)
+    }
+}
+
+#[cfg(test)]
+#[global_allocator]
+static TEST_ALLOC: test_alloc_probe::CountingAllocator = test_alloc_probe::CountingAllocator;
+
 // Re-export main types for convenience
 pub use crate::{
     config::Config,

--- a/cqlite-core/src/query/select_executor/aggregation.rs
+++ b/cqlite-core/src/query/select_executor/aggregation.rs
@@ -12,6 +12,7 @@ use crate::{
     query::result::QueryRow,
     types::{RowKey, Value},
 };
+use rustc_hash::FxHashMap;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 
@@ -40,7 +41,12 @@ pub(super) struct AggregationState {
     /// keys (and every NaN key, which is never `==` itself) simply fall through
     /// the exact check, so grouping semantics are byte-identical to the prior
     /// linear scan.
-    pub(super) group_index: HashMap<u64, Vec<usize>>,
+    ///
+    /// Issue #1590 (E8): `FxHashMap` rather than the default `HashMap`. The key
+    /// is already a well-mixed `u64` group-key hash, so SipHashing it again is
+    /// wasted work; Fx hashes the integer key directly. Collisions remain safe —
+    /// the `Vec<usize>` bucket + exact `==` confirmation above is unchanged.
+    pub(super) group_index: FxHashMap<u64, Vec<usize>>,
     /// Memory usage tracking
     pub(super) memory_usage_bytes: usize,
     /// Maximum memory limit
@@ -293,7 +299,7 @@ mod tests {
     fn new_state() -> AggregationState {
         AggregationState {
             groups: Vec::new(),
-            group_index: HashMap::new(),
+            group_index: FxHashMap::default(),
             memory_usage_bytes: 0,
             memory_limit_bytes: usize::MAX,
         }

--- a/cqlite-core/src/query/select_executor/execute.rs
+++ b/cqlite-core/src/query/select_executor/execute.rs
@@ -15,8 +15,8 @@
 
 use super::{
     build_row_from_scan, classify_partition_lookup, column_info_from_type_str, evaluate_predicates,
-    honest_targeted_path, parse_table_id, select_has_writetime_ttl, sort_rows_by_token,
-    validate_token_predicates, PartitionLookupOutcome, SSTablePredicate,
+    honest_targeted_path, parse_table_id, partition_key_digest, select_has_writetime_ttl,
+    sort_rows_by_token, validate_token_predicates, PartitionLookupOutcome, SSTablePredicate,
 };
 use super::{
     AccessPath, ColumnInfo, Error, ExecutionContext, ExecutionStep, FallbackReason,
@@ -320,13 +320,16 @@ impl SelectExecutor {
 
         // Issue #757: PER PARTITION LIMIT caps rows per partition before the
         // query-wide LIMIT/OFFSET. The scan yields rows grouped by partition
-        // key, so we track the current partition (by its raw key bytes) and
-        // reset the counter at each boundary.
+        // key, so we track the current partition and reset the counter at each
+        // boundary. Issue #1590 (E8): the boundary is compared on the partition
+        // key's 128-bit `partition_key_digest` (a heap-free hash of the key bytes
+        // we already hold) instead of cloning the raw key bytes into an owned
+        // `Vec<u8>` for every row (see the digest's collision note).
         let per_partition_limit = execution_steps.iter().find_map(|step| match step {
             ExecutionStep::PerPartitionLimit { count } => Some(*count),
             _ => None,
         });
-        let mut current_partition: Option<Vec<u8>> = None;
+        let mut current_partition: Option<u128> = None;
         let mut partition_count: u64 = 0;
 
         let mut sent: u64 = 0;
@@ -369,7 +372,8 @@ impl SelectExecutor {
                             engaged,
                         ));
                         for (key, value) in rows {
-                            let part_sig = per_partition_limit.map(|_| key.0.clone());
+                            let part_sig =
+                                per_partition_limit.map(|_| partition_key_digest(&key.0));
                             let Some(row) = build_row_from_scan(key, value, projection, schema_opt)
                             else {
                                 continue;
@@ -378,7 +382,7 @@ impl SelectExecutor {
                                 continue;
                             }
                             if let (Some(cap), Some(sig)) = (per_partition_limit, part_sig) {
-                                if current_partition.as_deref() != Some(sig.as_slice()) {
+                                if current_partition != Some(sig) {
                                     current_partition = Some(sig);
                                     partition_count = 0;
                                 }
@@ -428,7 +432,8 @@ impl SelectExecutor {
                         ));
                         sort_rows_by_token(&mut combined);
                         for (key, value) in combined {
-                            let part_sig = per_partition_limit.map(|_| key.0.clone());
+                            let part_sig =
+                                per_partition_limit.map(|_| partition_key_digest(&key.0));
                             let Some(row) = build_row_from_scan(key, value, projection, schema_opt)
                             else {
                                 continue;
@@ -437,7 +442,7 @@ impl SelectExecutor {
                                 continue;
                             }
                             if let (Some(cap), Some(sig)) = (per_partition_limit, part_sig) {
-                                if current_partition.as_deref() != Some(sig.as_slice()) {
+                                if current_partition != Some(sig) {
                                     current_partition = Some(sig);
                                     partition_count = 0;
                                 }
@@ -482,9 +487,9 @@ impl SelectExecutor {
 
                     while let Some(item) = scan_stream.recv().await {
                         let (key, value) = item?;
-                        // Capture the partition key bytes before `key` is moved
+                        // Capture the partition-key digest before `key` is moved
                         // into row construction (only when needed).
-                        let part_sig = per_partition_limit.map(|_| key.0.clone());
+                        let part_sig = per_partition_limit.map(|_| partition_key_digest(&key.0));
                         let Some(row) = build_row_from_scan(key, value, projection, schema_opt)
                         else {
                             continue;
@@ -497,7 +502,7 @@ impl SelectExecutor {
                         // Apply PER PARTITION LIMIT: cap matching rows per
                         // partition, before OFFSET/LIMIT (Cassandra semantics).
                         if let (Some(cap), Some(sig)) = (per_partition_limit, part_sig) {
-                            if current_partition.as_deref() != Some(sig.as_slice()) {
+                            if current_partition != Some(sig) {
                                 current_partition = Some(sig);
                                 partition_count = 0;
                             }

--- a/cqlite-core/src/query/select_executor/execute.rs
+++ b/cqlite-core/src/query/select_executor/execute.rs
@@ -323,13 +323,16 @@ impl SelectExecutor {
         // key, so we track the current partition and reset the counter at each
         // boundary. Issue #1590 (E8): the boundary is compared on the partition
         // key's 128-bit `partition_key_digest` (a heap-free hash of the key bytes
-        // we already hold) instead of cloning the raw key bytes into an owned
-        // `Vec<u8>` for every row (see the digest's collision note).
+        // we already hold) as a FAST pre-check, then confirmed by EXACT byte
+        // equality against the current partition's raw bytes — stored ONCE when
+        // the boundary advances, never cloned per row. This keeps correctness
+        // independent of digest collisions (a collision between two DISTINCT
+        // partitions never shares a counter).
         let per_partition_limit = execution_steps.iter().find_map(|step| match step {
             ExecutionStep::PerPartitionLimit { count } => Some(*count),
             _ => None,
         });
-        let mut current_partition: Option<u128> = None;
+        let mut current_partition: Option<(u128, Vec<u8>)> = None;
         let mut partition_count: u64 = 0;
 
         let mut sent: u64 = 0;
@@ -382,8 +385,17 @@ impl SelectExecutor {
                                 continue;
                             }
                             if let (Some(cap), Some(sig)) = (per_partition_limit, part_sig) {
-                                if current_partition != Some(sig) {
-                                    current_partition = Some(sig);
+                                // Fast digest pre-check, then EXACT byte confirm so a
+                                // digest collision between DISTINCT partitions never
+                                // shares a counter (issue #1590).
+                                let same = matches!(
+                                    &current_partition,
+                                    Some((d, bytes))
+                                        if *d == sig && bytes.as_slice() == row.key.0.as_slice()
+                                );
+                                if !same {
+                                    // Clone the key bytes ONCE per boundary, not per row.
+                                    current_partition = Some((sig, row.key.0.clone()));
                                     partition_count = 0;
                                 }
                                 if partition_count >= cap {
@@ -442,8 +454,17 @@ impl SelectExecutor {
                                 continue;
                             }
                             if let (Some(cap), Some(sig)) = (per_partition_limit, part_sig) {
-                                if current_partition != Some(sig) {
-                                    current_partition = Some(sig);
+                                // Fast digest pre-check, then EXACT byte confirm so a
+                                // digest collision between DISTINCT partitions never
+                                // shares a counter (issue #1590).
+                                let same = matches!(
+                                    &current_partition,
+                                    Some((d, bytes))
+                                        if *d == sig && bytes.as_slice() == row.key.0.as_slice()
+                                );
+                                if !same {
+                                    // Clone the key bytes ONCE per boundary, not per row.
+                                    current_partition = Some((sig, row.key.0.clone()));
                                     partition_count = 0;
                                 }
                                 if partition_count >= cap {
@@ -502,8 +523,17 @@ impl SelectExecutor {
                         // Apply PER PARTITION LIMIT: cap matching rows per
                         // partition, before OFFSET/LIMIT (Cassandra semantics).
                         if let (Some(cap), Some(sig)) = (per_partition_limit, part_sig) {
-                            if current_partition != Some(sig) {
-                                current_partition = Some(sig);
+                            // Fast digest pre-check, then EXACT byte confirm so a
+                            // digest collision between DISTINCT partitions never
+                            // shares a counter (issue #1590).
+                            let same = matches!(
+                                &current_partition,
+                                Some((d, bytes))
+                                    if *d == sig && bytes.as_slice() == row.key.0.as_slice()
+                            );
+                            if !same {
+                                // Clone the key bytes ONCE per boundary, not per row.
+                                current_partition = Some((sig, row.key.0.clone()));
                                 partition_count = 0;
                             }
                             if partition_count >= cap {

--- a/cqlite-core/src/query/select_executor/execute.rs
+++ b/cqlite-core/src/query/select_executor/execute.rs
@@ -83,9 +83,7 @@ impl SelectExecutor {
 
         let mut context = ExecutionContext {
             table_id,
-            columns: self
-                .get_result_columns(&plan.statement, query_schema.as_deref())
-                .await?,
+            columns: self.get_result_columns(&plan.statement, query_schema.as_deref())?,
             rows_processed: 0,
             scan_rows: 0,
             projection_flags,
@@ -95,7 +93,7 @@ impl SelectExecutor {
 
         // Handle queries without FROM clause (like SELECT 1)
         if plan.statement.from_clause.is_none() {
-            return self.execute_constant_query(&plan.statement, &context).await;
+            return self.execute_constant_query(&plan.statement, &context);
         }
 
         // Execute the plan step by step
@@ -133,18 +131,16 @@ impl SelectExecutor {
                     intermediate_results = rows;
                 }
                 ExecutionStep::Filter { expression, .. } => {
-                    intermediate_results = self
-                        .execute_filter(intermediate_results, expression, &mut context)
-                        .await?;
+                    intermediate_results =
+                        self.execute_filter(intermediate_results, expression, &mut context)?;
                 }
                 ExecutionStep::Sort { order_by, .. } => {
                     // Issue #1184: when the BIG reverse partition iterator already
                     // produced the rows in descending clustering order, skip the
                     // in-memory sort entirely (it remains the fallback otherwise).
                     if !context.reverse_served {
-                        intermediate_results = self
-                            .execute_sort(intermediate_results, order_by, &mut context)
-                            .await?;
+                        intermediate_results =
+                            self.execute_sort(intermediate_results, order_by, &mut context)?;
                     } else {
                         // Issue #1307 (hardening): skipping this Sort is sound ONLY
                         // because `reverse_served` is set exclusively by
@@ -174,23 +170,20 @@ impl SelectExecutor {
                     }
                 }
                 ExecutionStep::Aggregate { plan: agg_plan, .. } => {
-                    intermediate_results = self
-                        .execute_aggregation(intermediate_results, agg_plan, &mut context)
-                        .await?;
+                    intermediate_results =
+                        self.execute_aggregation(intermediate_results, agg_plan, &mut context)?;
                 }
                 ExecutionStep::PerPartitionLimit { count } => {
                     intermediate_results =
                         Self::execute_per_partition_limit(intermediate_results, *count);
                 }
                 ExecutionStep::Limit { count, offset } => {
-                    intermediate_results = self
-                        .execute_limit(intermediate_results, *count, *offset, &mut context)
-                        .await?;
+                    intermediate_results =
+                        self.execute_limit(intermediate_results, *count, *offset, &mut context)?;
                 }
                 ExecutionStep::Project { columns } => {
-                    intermediate_results = self
-                        .execute_projection(intermediate_results, columns, &mut context)
-                        .await?;
+                    intermediate_results =
+                        self.execute_projection(intermediate_results, columns, &mut context)?;
                 }
             }
         }

--- a/cqlite-core/src/query/select_executor/lookup.rs
+++ b/cqlite-core/src/query/select_executor/lookup.rs
@@ -466,19 +466,43 @@ impl super::SelectExecutor {
 }
 
 /// Cartesian product of per-column value sets, preserving column order and the
-/// input order within each column. Empty input yields a single empty tuple.
+/// input order within each column. Empty input yields a single empty tuple; any
+/// empty column set yields no tuples.
+///
+/// Issue #1590 (E8): builds each output combination into ONE sized allocation
+/// via a mixed-radix odometer over the per-column value indices, instead of the
+/// old level-by-level build that did `prefix.clone()` + `push()` per combo (a
+/// clone-alloc plus a grow-realloc). Enumeration order is identical — the
+/// rightmost (last) column advances fastest, exactly as the level-by-level build
+/// grew the last column innermost — so the produced key set is byte-identical.
+/// The caller (`classify_partition_lookup`) bounds the product by
+/// `MAX_IN_TARGETED_LOOKUPS` with checked arithmetic BEFORE calling, so `total`
+/// never overflows here.
 fn cartesian_product(per_column: &[Vec<Value>]) -> Vec<Vec<Value>> {
-    let mut out: Vec<Vec<Value>> = vec![Vec::new()];
-    for column_values in per_column {
-        let mut next = Vec::with_capacity(out.len() * column_values.len());
-        for prefix in &out {
-            for value in column_values {
-                let mut combo = prefix.clone();
-                combo.push(value.clone());
-                next.push(combo);
-            }
+    let total: usize = per_column.iter().map(Vec::len).product();
+    if total == 0 {
+        // An empty column set means no complete tuples (matches the old build,
+        // whose next-level capacity `out.len() * 0` produced an empty `out`).
+        return Vec::new();
+    }
+    let num_cols = per_column.len();
+    let mut out: Vec<Vec<Value>> = Vec::with_capacity(total);
+    // `idx[c]` = the current value index within column `c`.
+    let mut idx = vec![0usize; num_cols];
+    for _ in 0..total {
+        let mut combo = Vec::with_capacity(num_cols);
+        for (c, col) in per_column.iter().enumerate() {
+            combo.push(col[idx[c]].clone());
         }
-        out = next;
+        out.push(combo);
+        // Advance the odometer, rightmost column fastest.
+        for c in (0..num_cols).rev() {
+            idx[c] += 1;
+            if idx[c] < per_column[c].len() {
+                break;
+            }
+            idx[c] = 0;
+        }
     }
     out
 }
@@ -757,6 +781,61 @@ mod tests {
                 PartitionLookupOutcome::Fallback(FallbackReason::NoSchema)
             ),
             "no schema must report the NoSchema fallback reason",
+        );
+    }
+
+    /// Issue #1590 (E8): the `IN`-list / composite `IN` key expansion
+    /// (`cartesian_product`) builds each output combination into one sized
+    /// allocation instead of `prefix.clone()` + `push()` (a clone-alloc plus a
+    /// grow-realloc per combo). This pins two properties: (1) the output is
+    /// byte-identical to the old prefix-clone build (no behavior change), and
+    /// (2) the index-based build allocates strictly fewer times than that
+    /// reference — the regression that fails on the old impl (where the two
+    /// builds are the same code and allocate identically).
+    #[test]
+    fn cartesian_product_builds_each_combo_in_one_allocation() {
+        use crate::test_alloc_probe::measure;
+
+        // The OLD level-by-level build, kept verbatim as the allocation + output
+        // reference (`prefix.clone()` then `push()`).
+        fn reference(per_column: &[Vec<Value>]) -> Vec<Vec<Value>> {
+            let mut out: Vec<Vec<Value>> = vec![Vec::new()];
+            for column_values in per_column {
+                let mut next = Vec::with_capacity(out.len() * column_values.len());
+                for prefix in &out {
+                    for value in column_values {
+                        let mut combo = prefix.clone();
+                        combo.push(value.clone());
+                        next.push(combo);
+                    }
+                }
+                out = next;
+            }
+            out
+        }
+
+        // A composite `IN` over three columns (4×4×4 = 64 combos, the classifier
+        // cap): every combo has length 3, so the old prefix-clone path pays a
+        // clone + a grow-realloc per combo while the index-based build pays one
+        // sized allocation per combo.
+        let per_column: Vec<Vec<Value>> = vec![
+            (0..4).map(Value::Integer).collect(),
+            (0..4).map(|i| Value::Integer(i + 100)).collect(),
+            (0..4).map(|i| Value::Integer(i + 1000)).collect(),
+        ];
+
+        let (ref_allocs, ref_out) = measure(|| reference(&per_column));
+        let (new_allocs, new_out) = measure(|| cartesian_product(&per_column));
+
+        assert_eq!(
+            new_out, ref_out,
+            "cartesian product output must be byte-identical to the prefix-clone build"
+        );
+        assert_eq!(new_out.len(), 64, "4×4×4 composite IN expands to 64 keys");
+        assert!(
+            new_allocs < ref_allocs,
+            "index-based cartesian_product must allocate strictly fewer times than \
+             the prefix-clone reference: {new_allocs} vs {ref_allocs}"
         );
     }
 }

--- a/cqlite-core/src/query/select_executor/mod.rs
+++ b/cqlite-core/src/query/select_executor/mod.rs
@@ -753,7 +753,7 @@ impl SelectExecutor {
 
         let mut agg_state = AggregationState {
             groups: Vec::new(),
-            group_index: HashMap::new(),
+            group_index: rustc_hash::FxHashMap::default(),
             memory_usage_bytes: 0,
             memory_limit_bytes: DEFAULT_AGGREGATION_MEMORY_LIMIT,
         };

--- a/cqlite-core/src/query/select_executor/mod.rs
+++ b/cqlite-core/src/query/select_executor/mod.rs
@@ -795,12 +795,18 @@ impl SelectExecutor {
         _context: &mut ExecutionContext,
     ) -> Result<Vec<QueryRow>> {
         let start_index = offset.unwrap_or(0) as usize;
-        if start_index >= rows.len() {
-            return Ok(Vec::new());
+        let limit = count as usize;
+        // Issue #1590 (E8): with no OFFSET, truncate in place — no allocation and
+        // no element shift. With an OFFSET, apply it via `skip`/`take` instead of
+        // `drain(..offset)`: `drain` memmoves every surviving element left, while
+        // `skip` drops the prefix and yields the survivors without shifting. The
+        // resulting rows are identical (same slice, same order); `skip` past the
+        // end yields nothing, matching the old `start_index >= len` early return.
+        if start_index == 0 {
+            rows.truncate(limit);
+            return Ok(rows);
         }
-        rows.drain(..start_index);
-        rows.truncate(count as usize);
-        Ok(rows)
+        Ok(rows.into_iter().skip(start_index).take(limit).collect())
     }
 
     /// Execute projection step
@@ -1282,6 +1288,78 @@ mod tests {
         assert_eq!(projected[0].values.get("b"), Some(&Value::Integer(0)));
         assert_eq!(projected[0].values.get("c"), Some(&Value::Integer(0)));
         assert_eq!(projected[99].values.get("a"), Some(&Value::Integer(99)));
+    }
+
+    /// Issue #1590 (E8): `execute_limit` now applies OFFSET via `skip`/`take`
+    /// (was `drain(..offset)` + `truncate`). This pins that the new path yields
+    /// the SAME rows as the old drain/truncate reference across a matrix of
+    /// (len, offset, limit) — including offset past the end, zero offset, and
+    /// limit exceeding the remainder. No behavior change.
+    #[tokio::test]
+    async fn execute_limit_offset_matches_drain_truncate_reference() {
+        let executor = create_test_executor().await;
+        let mut ctx = ExecutionContext {
+            table_id: TableId::new("ks.t"),
+            columns: Vec::new(),
+            rows_processed: 0,
+            scan_rows: 0,
+            projection_flags: ProjectionFlags::default(),
+            access_path: None,
+            reverse_served: false,
+        };
+
+        let make = |len: usize| -> Vec<QueryRow> {
+            (0..len)
+                .map(|r| {
+                    let mut row = QueryRow::new(RowKey::new(vec![r as u8]));
+                    row.set("a", Value::Integer(r as i32));
+                    row
+                })
+                .collect()
+        };
+        // The old in-place algorithm, kept verbatim as the parity oracle.
+        let reference = |mut rows: Vec<QueryRow>, count: u64, offset: Option<u64>| {
+            let start_index = offset.unwrap_or(0) as usize;
+            if start_index >= rows.len() {
+                return Vec::new();
+            }
+            rows.drain(..start_index);
+            rows.truncate(count as usize);
+            rows
+        };
+        let tags = |rows: &[QueryRow]| -> Vec<i32> {
+            rows.iter()
+                .map(|r| match r.values.get("a") {
+                    Some(Value::Integer(v)) => *v,
+                    _ => -1,
+                })
+                .collect()
+        };
+
+        for len in [0usize, 1, 5, 10] {
+            for offset in [
+                None,
+                Some(0u64),
+                Some(1),
+                Some(3),
+                Some(9),
+                Some(10),
+                Some(50),
+            ] {
+                for count in [0u64, 1, 3, 10, 1000] {
+                    let got = executor
+                        .execute_limit(make(len), count, offset, &mut ctx)
+                        .expect("limit must succeed");
+                    let want = reference(make(len), count, offset);
+                    assert_eq!(
+                        tags(&got),
+                        tags(&want),
+                        "len={len} offset={offset:?} count={count}: skip/take must \
+                         equal drain/truncate"
+                    );
+                }
+            }
+        }
     }
 
     /// Issue #1587 (E5): ORDER BY uses decorate-sort-undecorate, so each row's

--- a/cqlite-core/src/query/select_executor/mod.rs
+++ b/cqlite-core/src/query/select_executor/mod.rs
@@ -24,6 +24,17 @@
 //!   continuation (issue #1174),
 //! - this `mod.rs` — the [`SelectExecutor`] orchestration and remaining
 //!   per-step helpers.
+//!
+//! ## Lint policy (issue #1590, E8)
+//!
+//! The read-path pipeline step helpers below are pure/synchronous — none awaits.
+//! Deny `clippy::unused_async` for this module (and its submodules) so a future
+//! edit cannot silently reintroduce the future/state-machine overhead of an
+//! `async fn` that never awaits (which also infects every caller with an
+//! `.await`). A crate-level deny is deliberately NOT used: `cqlite-core` still
+//! has many legitimately-flagged `async fn`s on its public surface (out of E8's
+//! scope), so the guard is scoped to the pipeline it protects.
+#![deny(clippy::unused_async)]
 
 mod aggregation;
 mod execute;
@@ -303,9 +314,7 @@ impl SelectExecutor {
         // re-locking the registry and deep-cloning a fresh schema (2–4× per query).
         let query_schema: Option<Arc<TableSchema>> = self.resolve_table_schema(&table_id).await;
 
-        let columns = self
-            .get_result_columns(&plan.statement, query_schema.as_deref())
-            .await?;
+        let columns = self.get_result_columns(&plan.statement, query_schema.as_deref())?;
 
         // Create bounded channel for backpressure
         let (tx, rx) = mpsc::channel(config.buffer_size);
@@ -427,7 +436,7 @@ impl SelectExecutor {
     // `execute` submodule alongside `execute` (issue #1174).
 
     /// Execute filtering step
-    async fn execute_filter(
+    fn execute_filter(
         &self,
         rows: Vec<QueryRow>,
         filter_expr: &WhereExpression,
@@ -663,7 +672,7 @@ impl SelectExecutor {
     }
 
     /// Execute sorting step
-    async fn execute_sort(
+    fn execute_sort(
         &self,
         mut rows: Vec<QueryRow>,
         order_by: &OrderByClause,
@@ -714,7 +723,7 @@ impl SelectExecutor {
     /// Execute the aggregation step. Splits naturally into three phases:
     /// build group key, accumulate per-aggregate state, then finalize each
     /// group into a result row.
-    async fn execute_aggregation(
+    fn execute_aggregation(
         &self,
         rows: Vec<QueryRow>,
         agg_plan: &AggregationPlan,
@@ -778,7 +787,7 @@ impl SelectExecutor {
     }
 
     /// Execute limit step (apply OFFSET then truncate to LIMIT).
-    async fn execute_limit(
+    fn execute_limit(
         &self,
         mut rows: Vec<QueryRow>,
         count: u64,
@@ -795,7 +804,7 @@ impl SelectExecutor {
     }
 
     /// Execute projection step
-    async fn execute_projection(
+    fn execute_projection(
         &self,
         rows: Vec<QueryRow>,
         columns: &[SelectExpression],
@@ -837,7 +846,7 @@ impl SelectExecutor {
     }
 
     /// Execute a query without FROM clause (constant expressions like SELECT 1)
-    async fn execute_constant_query(
+    fn execute_constant_query(
         &self,
         statement: &SelectStatement,
         _context: &ExecutionContext,
@@ -942,7 +951,7 @@ impl SelectExecutor {
     /// Build result-column metadata from an ALREADY-RESOLVED schema (issue #1587,
     /// E5). The caller resolves the schema once per query and passes it here, so
     /// this never re-clones it out of the registry.
-    async fn get_result_columns(
+    fn get_result_columns(
         &self,
         statement: &SelectStatement,
         schema: Option<&TableSchema>,
@@ -1257,7 +1266,6 @@ mod tests {
         PROJECTION_NAME_DERIVATIONS.with(|c| c.set(0));
         let projected = executor
             .execute_projection(rows, &columns, &mut ctx)
-            .await
             .expect("projection must succeed");
         let derivations = PROJECTION_NAME_DERIVATIONS.with(|c| c.get());
 
@@ -1320,7 +1328,6 @@ mod tests {
         SORT_KEY_EVALUATIONS.with(|c| c.set(0));
         let sorted = executor
             .execute_sort(rows, &order_by, &mut ctx)
-            .await
             .expect("sort must succeed");
         let evaluations = SORT_KEY_EVALUATIONS.with(|c| c.get());
 
@@ -1413,7 +1420,6 @@ mod tests {
         for dir in [SortDirection::Ascending, SortDirection::Descending] {
             let sorted = executor
                 .execute_sort(make_rows(&with_nan), &order_by(&dir), &mut ctx)
-                .await
                 .expect("sort must succeed");
 
             let mut reference = make_rows(&with_nan);
@@ -1446,7 +1452,6 @@ mod tests {
                 &order_by(&SortDirection::Ascending),
                 &mut ctx,
             )
-            .await
             .expect("sort must succeed");
         assert_eq!(
             tags(&asc),
@@ -1460,7 +1465,6 @@ mod tests {
                 &order_by(&SortDirection::Descending),
                 &mut ctx,
             )
-            .await
             .expect("sort must succeed");
         assert_eq!(
             tags(&desc),
@@ -1600,7 +1604,7 @@ mod tests {
             allow_filtering: false,
         };
 
-        let cols = executor.get_result_columns(&stmt, None).await.unwrap();
+        let cols = executor.get_result_columns(&stmt, None).unwrap();
         assert_eq!(cols.len(), 1);
         assert_eq!(cols[0].name, "writetime(name)");
         assert_eq!(cols[0].data_type, crate::types::DataType::BigInt);
@@ -1632,7 +1636,7 @@ mod tests {
             allow_filtering: false,
         };
 
-        let cols = executor.get_result_columns(&stmt, None).await.unwrap();
+        let cols = executor.get_result_columns(&stmt, None).unwrap();
         assert_eq!(cols.len(), 1);
         assert_eq!(cols[0].name, "ttl(score)");
         assert_eq!(cols[0].data_type, crate::types::DataType::Integer);
@@ -1664,7 +1668,7 @@ mod tests {
             allow_filtering: false,
         };
 
-        let cols = executor.get_result_columns(&stmt, None).await.unwrap();
+        let cols = executor.get_result_columns(&stmt, None).unwrap();
         assert_eq!(cols.len(), 1);
         assert_eq!(
             cols[0].name, "wt",

--- a/cqlite-core/src/query/select_executor/mod.rs
+++ b/cqlite-core/src/query/select_executor/mod.rs
@@ -111,6 +111,25 @@ thread_local! {
         const { std::cell::Cell::new(0) };
 }
 
+/// 128-bit digest of a partition key's raw bytes for PER PARTITION LIMIT
+/// bookkeeping (issue #1590, E8).
+///
+/// PER PARTITION LIMIT keys its per-partition counters on the partition. Keying
+/// a map (or an adjacent-boundary compare) on the raw `Vec<u8>` clones the key
+/// bytes for every row; keying on this fixed-size `u128` digest instead makes
+/// the per-row work a heap-free hash of the bytes we already hold. The digest is
+/// Cassandra's own `murmur3_x64_128` (already used for token routing), so it is
+/// stable and well-distributed. Collision safety: at 128 bits the birthday
+/// bound is ~2^64 distinct partitions before any collision is even probable —
+/// unreachable under the <128MB memory budget (and far beyond any real
+/// partition count) — so two distinct partitions never share a counter in
+/// practice. This is bookkeeping only (a query row-cap), never a security or
+/// correctness boundary.
+pub(super) fn partition_key_digest(key_bytes: &[u8]) -> u128 {
+    let (h1, h2) = crate::util::cassandra_murmur3::cassandra_murmur3_x64_128(key_bytes);
+    ((h1 as u64 as u128) << 64) | (h2 as u64 as u128)
+}
+
 /// Derive the output column name for a projected SELECT expression (issue #1584).
 ///
 /// Hoisted out of the per-row loop and called ONCE per column per query, so name
@@ -768,16 +787,20 @@ impl SelectExecutor {
     }
 
     /// Execute PER PARTITION LIMIT: keep at most `count` rows per partition,
-    /// preserving order (Issue #757). Counts are keyed on the partition (raw key
-    /// bytes) rather than tracking only the most recent partition, so the cap
-    /// holds even when a partition's rows are not contiguous — e.g. when an
-    /// upstream `ORDER BY` interleaves rows from different partitions (roborev
-    /// job 38).
+    /// preserving order (Issue #757). Counts are keyed on the partition rather
+    /// than tracking only the most recent partition, so the cap holds even when a
+    /// partition's rows are not contiguous — e.g. when an upstream `ORDER BY`
+    /// interleaves rows from different partitions (roborev job 38).
+    ///
+    /// Issue #1590 (E8): the counter map is keyed on the partition-key 128-bit
+    /// [`partition_key_digest`] instead of a cloned `Vec<u8>` of the raw key
+    /// bytes, so no key bytes are cloned per row (see the digest's collision
+    /// note).
     fn execute_per_partition_limit(rows: Vec<QueryRow>, count: u64) -> Vec<QueryRow> {
         let mut out = Vec::with_capacity(rows.len());
-        let mut counts: HashMap<Vec<u8>, u64> = HashMap::new();
+        let mut counts: HashMap<u128, u64> = HashMap::new();
         for row in rows {
-            let seen = counts.entry(row.key.0.clone()).or_insert(0);
+            let seen = counts.entry(partition_key_digest(&row.key.0)).or_insert(0);
             if *seen < count {
                 *seen += 1;
                 out.push(row);
@@ -1359,6 +1382,68 @@ mod tests {
                     );
                 }
             }
+        }
+    }
+
+    /// Issue #1590 (E8): PER PARTITION LIMIT now keys its per-partition counters
+    /// on the partition-key 128-bit digest instead of a cloned `Vec<u8>` of the
+    /// raw key bytes. Pin that the digest-keyed batch path yields the SAME rows
+    /// as the raw-bytes reference — including NON-contiguous (interleaved)
+    /// partitions, where the cap must still be enforced per distinct partition.
+    #[test]
+    fn per_partition_limit_digest_matches_raw_bytes_reference() {
+        // Partition key bytes → row tag. Interleave partitions so the counter
+        // cannot rely on contiguity (roborev job 38 invariant).
+        let spec: [(&[u8], i32); 9] = [
+            (b"pk-a", 0),
+            (b"pk-b", 1),
+            (b"pk-a", 2),
+            (b"pk-c", 3),
+            (b"pk-b", 4),
+            (b"pk-a", 5),
+            (b"pk-a", 6),
+            (b"pk-c", 7),
+            (b"pk-b", 8),
+        ];
+        let make = || -> Vec<QueryRow> {
+            spec.iter()
+                .map(|(pk, tag)| {
+                    let mut row = QueryRow::new(RowKey::new(pk.to_vec()));
+                    row.set("a", Value::Integer(*tag));
+                    row
+                })
+                .collect()
+        };
+        // Old raw-`Vec<u8>`-keyed algorithm, kept verbatim as the parity oracle.
+        let reference = |rows: Vec<QueryRow>, count: u64| -> Vec<QueryRow> {
+            let mut out = Vec::with_capacity(rows.len());
+            let mut counts: HashMap<Vec<u8>, u64> = HashMap::new();
+            for row in rows {
+                let seen = counts.entry(row.key.0.clone()).or_insert(0);
+                if *seen < count {
+                    *seen += 1;
+                    out.push(row);
+                }
+            }
+            out
+        };
+        let tags = |rows: &[QueryRow]| -> Vec<i32> {
+            rows.iter()
+                .map(|r| match r.values.get("a") {
+                    Some(Value::Integer(v)) => *v,
+                    _ => -1,
+                })
+                .collect()
+        };
+
+        for count in [0u64, 1, 2, 3, 100] {
+            let got = SelectExecutor::execute_per_partition_limit(make(), count);
+            let want = reference(make(), count);
+            assert_eq!(
+                tags(&got),
+                tags(&want),
+                "count={count}: digest-keyed per-partition-limit must equal raw-bytes reference"
+            );
         }
     }
 

--- a/cqlite-core/src/query/select_executor/mod.rs
+++ b/cqlite-core/src/query/select_executor/mod.rs
@@ -116,18 +116,63 @@ thread_local! {
 ///
 /// PER PARTITION LIMIT keys its per-partition counters on the partition. Keying
 /// a map (or an adjacent-boundary compare) on the raw `Vec<u8>` clones the key
-/// bytes for every row; keying on this fixed-size `u128` digest instead makes
-/// the per-row work a heap-free hash of the bytes we already hold. The digest is
-/// Cassandra's own `murmur3_x64_128` (already used for token routing), so it is
-/// stable and well-distributed. Collision safety: at 128 bits the birthday
-/// bound is ~2^64 distinct partitions before any collision is even probable —
-/// unreachable under the <128MB memory budget (and far beyond any real
-/// partition count) — so two distinct partitions never share a counter in
-/// practice. This is bookkeeping only (a query row-cap), never a security or
-/// correctness boundary.
+/// bytes for every row; using this fixed-size `u128` digest as the FAST outer
+/// lookup key makes the per-row work a heap-free hash of the bytes we already
+/// hold. The digest is Cassandra's own `murmur3_x64_128` (already used for token
+/// routing), so it is stable and well-distributed.
+///
+/// The digest is only a pre-check: both the batch counter map and the streaming
+/// boundary confirm an EXACT match on the raw partition-key bytes (stored ONCE
+/// per distinct partition, never cloned per row) before sharing a counter. So
+/// correctness does NOT depend on collision absence — two distinct partitions
+/// whose digests collide get separate counters and no valid row is dropped.
 pub(super) fn partition_key_digest(key_bytes: &[u8]) -> u128 {
     let (h1, h2) = crate::util::cassandra_murmur3::cassandra_murmur3_x64_128(key_bytes);
     ((h1 as u64 as u128) << 64) | (h2 as u64 as u128)
+}
+
+/// PER PARTITION LIMIT counter map for the batch path (issue #1590, E8).
+///
+/// The outer key is the fast 128-bit [`partition_key_digest`]; each bucket is a
+/// chain of `(raw_key_bytes, count)` entries disambiguated by EXACT byte
+/// equality. The chain is near-always length 1 — it grows only on a genuine
+/// digest collision between two DISTINCT partition keys — so the fast path is an
+/// `O(1)` digest hash plus a single byte compare, yet correctness never depends
+/// on collision absence.
+type PartitionCounts = HashMap<u128, Vec<(Vec<u8>, u64)>>;
+
+/// Admit one row under PER PARTITION LIMIT `count`, returning `true` when the
+/// row is within its partition's cap (and incrementing that partition's count).
+///
+/// `digest` is the fast outer lookup key; the raw `key_bytes` confirm the exact
+/// partition so a (vanishingly rare) digest collision between two distinct keys
+/// never shares a counter. The key's bytes are cloned at most ONCE — on the row
+/// that first opens the partition's counter — never per row.
+fn admit_partition_row(
+    counts: &mut PartitionCounts,
+    digest: u128,
+    key_bytes: &[u8],
+    count: u64,
+) -> bool {
+    let chain = counts.entry(digest).or_default();
+    let slot = match chain
+        .iter()
+        .position(|(bytes, _)| bytes.as_slice() == key_bytes)
+    {
+        Some(i) => &mut chain[i],
+        None => {
+            // The ONLY key-byte clone: once per distinct partition, not per row.
+            chain.push((key_bytes.to_vec(), 0));
+            let last = chain.len() - 1;
+            &mut chain[last]
+        }
+    };
+    if slot.1 < count {
+        slot.1 += 1;
+        true
+    } else {
+        false
+    }
 }
 
 /// Derive the output column name for a projected SELECT expression (issue #1584).
@@ -792,17 +837,18 @@ impl SelectExecutor {
     /// partition's rows are not contiguous — e.g. when an upstream `ORDER BY`
     /// interleaves rows from different partitions (roborev job 38).
     ///
-    /// Issue #1590 (E8): the counter map is keyed on the partition-key 128-bit
-    /// [`partition_key_digest`] instead of a cloned `Vec<u8>` of the raw key
-    /// bytes, so no key bytes are cloned per row (see the digest's collision
-    /// note).
+    /// Issue #1590 (E8): the counter map uses the partition-key 128-bit
+    /// [`partition_key_digest`] as a FAST outer lookup key, then confirms an
+    /// EXACT match on the raw key bytes (via [`admit_partition_row`]). No key
+    /// bytes are cloned per row — a partition's bytes are stored at most ONCE,
+    /// on the row that first opens its counter — and correctness stays
+    /// independent of digest collisions.
     fn execute_per_partition_limit(rows: Vec<QueryRow>, count: u64) -> Vec<QueryRow> {
         let mut out = Vec::with_capacity(rows.len());
-        let mut counts: HashMap<u128, u64> = HashMap::new();
+        let mut counts: PartitionCounts = HashMap::new();
         for row in rows {
-            let seen = counts.entry(partition_key_digest(&row.key.0)).or_insert(0);
-            if *seen < count {
-                *seen += 1;
+            let digest = partition_key_digest(&row.key.0);
+            if admit_partition_row(&mut counts, digest, &row.key.0, count) {
                 out.push(row);
             }
         }
@@ -1445,6 +1491,51 @@ mod tests {
                 "count={count}: digest-keyed per-partition-limit must equal raw-bytes reference"
             );
         }
+    }
+
+    /// Issue #1590 (E8, roborev fix #4 follow-up): PER PARTITION LIMIT uses the
+    /// 128-bit digest only as a FAST outer key; it confirms EXACT partition-key
+    /// bytes before sharing a counter. Correctness must NOT depend on
+    /// collision absence. Real 128-bit digest collisions can't be produced, so
+    /// drive [`admit_partition_row`] with a CONSTANT (forced-colliding) digest
+    /// for two DISTINCT keys and assert each key keeps its OWN counter — i.e. no
+    /// valid row is dropped when digests collide.
+    #[test]
+    fn per_partition_limit_exact_confirm_survives_digest_collision() {
+        let mut counts: PartitionCounts = HashMap::new();
+        // A single digest value shared by two genuinely distinct partitions.
+        const COLLIDING: u128 = 0xDEAD_BEEF;
+        let a = b"partition-a".as_slice();
+        let b = b"partition-b".as_slice();
+
+        // cap = 1 per partition. A's first row opens A's counter.
+        assert!(
+            admit_partition_row(&mut counts, COLLIDING, a, 1),
+            "A's first row is admitted"
+        );
+        // B collides on the digest but is a DISTINCT key: exact-byte confirm
+        // gives it its OWN counter, so its first row is admitted (NOT dropped by
+        // A's now-exhausted counter). This is the exact bug the finding flags.
+        assert!(
+            admit_partition_row(&mut counts, COLLIDING, b, 1),
+            "B's first row is admitted despite the colliding digest (separate counter)"
+        );
+        // Each partition's cap of 1 is now independently exhausted.
+        assert!(
+            !admit_partition_row(&mut counts, COLLIDING, a, 1),
+            "A's second row is capped"
+        );
+        assert!(
+            !admit_partition_row(&mut counts, COLLIDING, b, 1),
+            "B's second row is capped"
+        );
+        // Both distinct keys are chained under the one colliding digest bucket,
+        // proving the exact-confirm path (not the digest) disambiguates them.
+        assert_eq!(
+            counts.get(&COLLIDING).map(Vec::len),
+            Some(2),
+            "both distinct keys are chained under the colliding digest"
+        );
     }
 
     /// Issue #1587 (E5): ORDER BY uses decorate-sort-undecorate, so each row's

--- a/cqlite-core/src/storage/sstable/bti/nodes.rs
+++ b/cqlite-core/src/storage/sstable/bti/nodes.rs
@@ -9,7 +9,7 @@ use nom::{
     number::complete::{be_u16, be_u64, be_u8},
     IResult,
 };
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 /// BTI trie node types
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -212,7 +212,7 @@ pub struct NodeParser {
     position: u64,
     /// Page cache for efficient reading
     #[allow(dead_code)]
-    page_cache: HashMap<u64, Vec<u8>>,
+    page_cache: FxHashMap<u64, Vec<u8>>,
 }
 
 impl Default for NodeParser {
@@ -226,7 +226,7 @@ impl NodeParser {
     pub fn new() -> Self {
         Self {
             position: 0,
-            page_cache: HashMap::new(),
+            page_cache: FxHashMap::default(),
         }
     }
 

--- a/cqlite-core/src/storage/sstable/bti/parser/reader.rs
+++ b/cqlite-core/src/storage/sstable/bti/parser/reader.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     types::Value,
 };
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::io::{Read, Seek, SeekFrom};
 
 use super::encoding::{encode_clustering_bound_oss50, encode_clustering_bound_oss50_with_order};
@@ -140,7 +140,7 @@ pub struct PartitionsParser<R: Read + Seek> {
     /// Byte-comparable encoder for key encoding
     encoder: ByteComparableEncoder,
     /// Node cache for performance
-    node_cache: HashMap<u64, BtiNode>,
+    node_cache: FxHashMap<u64, BtiNode>,
 }
 
 impl<R: Read + Seek> PartitionsParser<R> {
@@ -157,7 +157,7 @@ impl<R: Read + Seek> PartitionsParser<R> {
             reader,
             header,
             encoder: ByteComparableEncoder::new(),
-            node_cache: HashMap::new(),
+            node_cache: FxHashMap::default(),
         })
     }
 
@@ -270,7 +270,7 @@ pub struct RowsParser<R: Read + Seek> {
     /// Byte-comparable encoder for key encoding
     encoder: ByteComparableEncoder,
     /// Node cache for performance
-    node_cache: HashMap<u64, BtiNode>,
+    node_cache: FxHashMap<u64, BtiNode>,
 }
 
 impl<R: Read + Seek> RowsParser<R> {
@@ -308,7 +308,7 @@ impl<R: Read + Seek> RowsParser<R> {
             reader,
             header,
             encoder: ByteComparableEncoder::new(),
-            node_cache: HashMap::new(),
+            node_cache: FxHashMap::default(),
         })
     }
 

--- a/cqlite-core/src/storage/sstable/chunk_decompressor.rs
+++ b/cqlite-core/src/storage/sstable/chunk_decompressor.rs
@@ -6,7 +6,7 @@
 use super::compression_info::CompressionInfo;
 use crate::parser::header::CassandraVersion;
 use crate::{Error, Result};
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::io::{Read, Seek, SeekFrom};
 
 /// Chunk-based decompressor for SSTable Data.db files
@@ -14,7 +14,7 @@ pub struct ChunkDecompressor {
     /// Compression metadata from CompressionInfo.db
     compression_info: CompressionInfo,
     /// Cache of decompressed chunks
-    chunk_cache: HashMap<usize, Vec<u8>>,
+    chunk_cache: FxHashMap<usize, Vec<u8>>,
     /// Maximum number of chunks to cache
     max_cached_chunks: usize,
     /// Data file path for error reporting
@@ -50,7 +50,7 @@ impl ChunkDecompressor {
 
         Ok(Self {
             compression_info,
-            chunk_cache: HashMap::new(),
+            chunk_cache: FxHashMap::default(),
             max_cached_chunks: 16, // Cache up to 16 chunks (16 * 16KB = 256KB max memory)
             data_file_path: None,
             cached_data_file_size: None,
@@ -70,7 +70,7 @@ impl ChunkDecompressor {
 
         Ok(Self {
             compression_info,
-            chunk_cache: HashMap::new(),
+            chunk_cache: FxHashMap::default(),
             max_cached_chunks: 16,
             data_file_path: Some(data_file_path),
             cached_data_file_size: None,

--- a/cqlite-core/src/storage/sstable/reader/mod.rs
+++ b/cqlite-core/src/storage/sstable/reader/mod.rs
@@ -74,7 +74,7 @@ use header::{
     calculate_actual_header_size, extract_generation_from_path, parse_header_with_version_detection,
 };
 
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::path::Path;
 use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use std::sync::Arc;
@@ -731,8 +731,8 @@ impl SSTableReader {
             index,
             bloom_filter,
             compression_reader,
-            block_meta_cache: HashMap::new(),
-            block_cache: HashMap::new(),
+            block_meta_cache: FxHashMap::default(),
+            block_cache: FxHashMap::default(),
             config: reader_config,
             open_config,
             platform,

--- a/cqlite-core/src/storage/sstable/reader/types.rs
+++ b/cqlite-core/src/storage/sstable/reader/types.rs
@@ -1,6 +1,6 @@
 //! Public types for SSTable reader
 
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
@@ -255,10 +255,10 @@ pub struct SSTableReader {
     pub(crate) bloom_filter: Option<BloomFilter>,
     /// Compression reader
     pub(crate) compression_reader: Option<CompressionReader>,
-    /// Block metadata cache
-    pub(crate) block_meta_cache: HashMap<u64, BlockMeta>,
-    /// Block data cache (LRU)
-    pub(crate) block_cache: HashMap<u64, CachedBlock>,
+    /// Block metadata cache (issue #1590, E8: `FxHashMap` — u64-offset key).
+    pub(crate) block_meta_cache: FxHashMap<u64, BlockMeta>,
+    /// Block data cache (LRU) (issue #1590, E8: `FxHashMap` — u64-offset key).
+    pub(crate) block_cache: FxHashMap<u64, CachedBlock>,
     /// Reader configuration
     pub(crate) config: SSTableReaderConfig,
     /// The full [`Config`] this reader was opened with.


### PR DESCRIPTION
Closes #1590 (E8 — Epic E #1517, read-path audit Wave 3). Pure-mechanics bundle, no behavior changes. 5 focused commits; fix #6 skipped per its own guardrail.

| # | Fix | Proof |
|---|-----|-------|
| 1 | De-async 7 private SELECT-pipeline step helpers; scoped `#![deny(clippy::unused_async)]` to `select_executor` | clippy lint (regression guard) |
| 2 | `FxHashMap` on 6 integer/digest-keyed hot maps (aggregation group_index, BTI page/node caches, chunk/block caches) | identical lib pass/fail before/after; row/string maps left alone (E2 scope) |
| 3 | SELECT OFFSET via `skip/take` (was `drain(..offset)` memmove) | `execute_limit_offset_matches_drain_truncate_reference` (len×offset×limit matrix) |
| 4 | Per-PARTITION-LIMIT keyed by 128-bit partition-key digest (was per-row byte clone) | `per_partition_limit_digest_matches_raw_bytes_reference` (interleaved partitions) |
| 5 | IN-key expansion: one sized alloc per combo (mixed-radix odometer, was clone+push) | dhat alloc counter RED→GREEN |
| 6 | `#[inline]` cross-crate accessors | **SKIPPED** — no measurable A-suite win (per guardrail: measure-first, else skip) |

**Honest scope notes:** (1) `unused_async` deny is module-scoped, not crate-level — current main has 100+ pre-existing sites across public APIs/benchmarks; a crate-level deny would force out-of-scope public-surface churn. (5) The anchor's "O(list²) growing-prefix" premise does NOT hold on current main (`cartesian_product` already builds level-by-level, capped at 64); the delivered+pinned win is eliminating the per-combo clone+realloc.

**Gate:** all correctness nets PASS (fmt, clippy `-D warnings`, compaction-byte-parity, format-compat, smoke, integration, write-tests, cli-tests, python-bindings, node-bindings, tooling, minimal-build). Sole FAIL is the pre-existing **#1860** (local-only `test_da/wide_table` fixture absent → `issue_953` skip-guard panics; not a parity assertion, unrelated to this change). `file-size`: pre-oversized `mod.rs`/`lookup.rs` grew from required tests → documented `CQLITE_ALLOW_FILE_GROWTH=1` (#1116 scope).

**Out-of-scope observed (filed/flagged):** pre-existing `cargo test -p cqlite-core --lib --all-features` fails 17 tests with "Write operations (flush) removed in Issue #175" (identical on origin/main; gate's feature-scoped lane doesn't hit them).